### PR TITLE
dynawalla/games/skyledger: SKY LEDGER — the sky is the coordinate plane

### DIFF
--- a/dynawalla/games/skyledger/.gitignore
+++ b/dynawalla/games/skyledger/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Capture scratch.
+qa/shots
+qa/tmp
+
+package-lock.json

--- a/dynawalla/games/skyledger/index.html
+++ b/dynawalla/games/skyledger/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>SKY LEDGER — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #050810;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/skyledger/pack.html
+++ b/dynawalla/games/skyledger/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#050810" />
+    <title>SKY LEDGER</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #050810;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/skyledger/pack.json
+++ b/dynawalla/games/skyledger/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.skyledger",
+  "version": "0.1.0",
+  "name": "SKY LEDGER",
+  "description": "The sky is the coordinate plane. Falling stars carry ledger lines; work one out, dial its station on the astrolabe, and it snaps home and blooms. Chain the blooms before the light fades and the observatory writes the whole watch down.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/skyledger/package.json
+++ b/dynawalla/games/skyledger/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-skyledger",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "SKY LEDGER — the sky is the coordinate plane. Name a falling star's station on the astrolabe and it snaps home and blooms; chain the blooms before the light fades.",
+  "engines": {
+    "node": ">=22.7.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4321",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/skyledger/src/audio/audio.ts
+++ b/dynawalla/games/skyledger/src/audio/audio.ts
@@ -1,0 +1,140 @@
+// The observatory's sound, synthesised. No assets, no decode, nothing on the
+// answer path — a `AudioContext` and a handful of oscillators.
+//
+// The timbre is the house one: a struck felt mallet, a sine with a quiet
+// triangle an octave up, over a C5–C6 pentatonic. Brass rings click; a
+// measurement that lands rings a bell that climbs with the chain; a mark that
+// goes wide makes almost no sound at all, because restraint is the whole
+// vocabulary for being wrong.
+//
+// **The chain's pitch is the score.** A child hears where they are in a chain
+// before they can read it, which is what makes a nine-link run feel like it is
+// going somewhere while it is still happening.
+
+/** C5 pentatonic, then the same five an octave up. */
+const SCALE = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5, 1174.66, 1318.51, 1567.98, 1760.0]
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private bus: GainNode | null = null
+  private failed = false
+
+  /** Lazily built on the first sound, which is always inside a gesture. */
+  private wake(): AudioContext | null {
+    if (this.failed) return null
+    if (!this.ctx) {
+      type Win = { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext }
+      const w = globalThis as unknown as Win
+      const Ctor = w.AudioContext ?? w.webkitAudioContext
+      if (!Ctor) {
+        this.failed = true
+        console.warn("[skyledger] no AudioContext; the observatory will be silent")
+        return null
+      }
+      try {
+        this.ctx = new Ctor()
+        this.bus = this.ctx.createGain()
+        this.bus.gain.value = 0.5
+        this.bus.connect(this.ctx.destination)
+      } catch (error) {
+        this.failed = true
+        console.warn("[skyledger] the AudioContext refused to start", error)
+        return null
+      }
+    }
+    if (this.ctx.state === "suspended") {
+      void this.ctx.resume().catch(() => {
+        // A context that will not resume without a gesture is not an error a
+        // child should hear about; the next tap will bring it back.
+      })
+    }
+    return this.ctx
+  }
+
+  /** One struck note. `gain` is peak; `ms` the whole decay. */
+  private strike(freq: number, gain: number, ms: number, type: OscillatorType = "sine"): void {
+    const ctx = this.wake()
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    const env = ctx.createGain()
+    osc.type = type
+    osc.frequency.setValueAtTime(freq, t)
+    env.gain.setValueAtTime(0, t)
+    env.gain.linearRampToValueAtTime(gain, t + 0.006)
+    env.gain.exponentialRampToValueAtTime(0.0001, t + ms / 1000)
+    osc.connect(env)
+    env.connect(bus)
+    osc.start(t)
+    osc.stop(t + ms / 1000 + 0.02)
+
+    // The felt: a quiet triangle an octave up, gone before the fundamental is.
+    const top = ctx.createOscillator()
+    const topEnv = ctx.createGain()
+    top.type = "triangle"
+    top.frequency.setValueAtTime(freq * 2, t)
+    topEnv.gain.setValueAtTime(0, t)
+    topEnv.gain.linearRampToValueAtTime(gain * 0.22, t + 0.004)
+    topEnv.gain.exponentialRampToValueAtTime(0.0001, t + Math.min(ms, 180) / 1000)
+    top.connect(topEnv)
+    topEnv.connect(bus)
+    top.start(t)
+    top.stop(t + ms / 1000 + 0.02)
+  }
+
+  /** A ring seats in a detent. The smallest sound in the game. */
+  detent(digit: number): void {
+    this.strike(1400 + digit * 34, 0.045, 42, "square")
+  }
+
+  /** A measurement lands. The pitch climbs with the chain. */
+  bloom(link: number): void {
+    const note = SCALE[Math.min(SCALE.length - 1, link - 1)] ?? SCALE[0] ?? 523.25
+    this.strike(note, 0.3, 520)
+    this.strike(note * 1.5, 0.09, 320)
+  }
+
+  /**
+   * A mark that went wide.
+   *
+   * Quieter and shorter than any success, deliberately. Being wrong must never
+   * be the more interesting outcome.
+   */
+  wide(): void {
+    this.strike(196, 0.07, 130, "triangle")
+  }
+
+  /** The astrolabe has nothing left to spend. */
+  refuse(): void {
+    this.strike(140, 0.05, 90, "square")
+  }
+
+  /** The snap-back. A chord that opens rather than a hit. */
+  release(links: number): void {
+    // Matching the scene: one link is a seat and already rang once.
+    if (links < 2) return
+    const ctx = this.wake()
+    if (!ctx) return
+    const root = SCALE[0] ?? 523.25
+    const voices = [1, 1.5, 2, 3].slice(0, Math.max(2, Math.min(4, Math.ceil(links / 3) + 1)))
+    voices.forEach((ratio, i) => {
+      setTimeout(() => this.strike(root * ratio, 0.16, 1100), i * 55)
+    })
+  }
+
+  /** A star reached the horizon and a lamp went out. Low, dry, brief. */
+  snuff(): void {
+    this.strike(98, 0.16, 380, "triangle")
+  }
+
+  close(): void {
+    const ctx = this.ctx
+    this.ctx = null
+    this.bus = null
+    if (!ctx) return
+    void ctx.close().catch(() => {
+      // A context that was already gone is not worth a line in the log.
+    })
+  }
+}

--- a/dynawalla/games/skyledger/src/contract.ts
+++ b/dynawalla/games/skyledger/src/contract.ts
@@ -1,0 +1,62 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountSkyLedger } from "./mount.ts"
+
+export type Question = {
+  id: string
+  /** "247 + 225" — the operator glyph is already in it. */
+  prompt: string
+  /** "472" — exact, canonical, and never computed by this game. */
+  answer: string
+  /**
+   * Wrong values a child actually produces: the host's mal-rule outputs first,
+   * near-misses after. SKY LEDGER never plants one on the sky — there is
+   * nothing anywhere to point at — but it recognises them: a mark that lands on
+   * a named slip is a measurement the register has seen before and it costs no
+   * sighting, where a wild guess does.
+   */
+  distractors: string[]
+  domain: string
+  /** 0..1. A monotone reading of the ladder, not a claim about hardness. */
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** SKY LEDGER calls it at the end of a *watch the
+   * child logged stars in*, and never when the last lamp goes out. The run
+   * ending is the closest thing this game has to a loss, and a purchase surface
+   * next to a loss is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+/**
+ * Mount the observatory into `el`.
+ *
+ * `pause`/`resume` are part of the surface because the host can put a sheet
+ * over a still-mounted, still-running pack. See `mount.ts` and
+ * `src/test/pause.test.ts`.
+ */
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  return mountSkyLedger(el, host)
+}

--- a/dynawalla/games/skyledger/src/core/feel.ts
+++ b/dynawalla/games/skyledger/src/core/feel.ts
@@ -1,0 +1,52 @@
+// Feel: the curves everything in this observatory moves on, in one place so the
+// whole instrument has one physics rather than eight.
+
+/** Clamp to 0..1. */
+export function unit(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x
+}
+
+export function clamp(x: number, lo: number, hi: number): number {
+  return x < lo ? lo : x > hi ? hi : x
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+/** Frame-rate independent approach: `k` is the fraction closed per 16.7 ms. */
+export function approach(a: number, b: number, k: number, dt: number): number {
+  const t = 1 - Math.pow(1 - unit(k), dt / 16.6667)
+  return a + (b - a) * t
+}
+
+export function easeOutCubic(t: number): number {
+  const x = 1 - unit(t)
+  return 1 - x * x * x
+}
+
+export function easeInCubic(t: number): number {
+  const x = unit(t)
+  return x * x * x
+}
+
+export function easeInOutSine(t: number): number {
+  return 0.5 - 0.5 * Math.cos(Math.PI * unit(t))
+}
+
+/**
+ * The snap: a star crossing to its true station does not glide. It leaves fast,
+ * arrives faster, and stops dead. Anything eased-out on both ends reads as a
+ * balloon drifting rather than a measurement being taken.
+ */
+export function snap(t: number): number {
+  const x = unit(t)
+  return x * x * (3 - 2 * x) * 0.35 + easeInCubic(x) * 0.65
+}
+
+/** A detent: the ring turns, overshoots by a hair, and seats. */
+export function detent(t: number): number {
+  const x = unit(t)
+  if (x >= 1) return 1
+  return 1 - Math.cos(x * Math.PI * 2.4) * Math.exp(-7.5 * x) * (1 - x)
+}

--- a/dynawalla/games/skyledger/src/core/rng.ts
+++ b/dynawalla/games/skyledger/src/core/rng.ts
@@ -1,0 +1,60 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a watch can be replayed exactly.
+//
+// mulberry32: 32-bit state, no allocation, and trivially portable into a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Snapshot/restore so a subsystem can be forked without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/skyledger/src/game/best.ts
+++ b/dynawalla/games/skyledger/src/game/best.ts
@@ -1,0 +1,63 @@
+// The one number worth remembering: the longest chain the child has ever run.
+// Not accuracy, not a percentage — a thing that happened, once, and can happen
+// again. It is the whole reason a ten-year-old replays a nine-link chain.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, so every access is guarded and the value is held in memory as well.
+// A child who plays a whole sitting inside a pack frame still watches their
+// best rise; it just does not survive the app being closed, which is a much
+// smaller loss than a game that will not start.
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const BEST_SLOT = "dw.skyledger.best" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn("[skyledger] localStorage is not reachable from this frame", error)
+    return null
+  }
+}
+
+/** The longest chain ever run. */
+export function bestChain(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(BEST_SLOT) ?? "0")
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn("[skyledger] a best could not be read back", error)
+    }
+  }
+  return memory
+}
+
+/** Record a chain. Returns true when it is a new best. */
+export function recordChain(links: number): boolean {
+  const previous = bestChain()
+  if (links <= previous) return false
+  memory = links
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(BEST_SLOT, String(links))
+    } catch (error) {
+      console.warn("[skyledger] a best could not be written", error)
+    }
+  }
+  return true
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetBestForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/skyledger/src/game/escalation.ts
+++ b/dynawalla/games/skyledger/src/game/escalation.ts
@@ -1,0 +1,245 @@
+// THE CHAIN — per-link escalation with named caps, and a hard snap-back.
+//
+// This is the piece of SKY LEDGER the canon singles out, so it is written as a
+// pure state machine with no canvas anywhere near it and its own test file.
+//
+// **What escalates.** Four channels, and one more link in the chain raises all
+// four by a fixed step until each hits a cap that has a name:
+//
+//   * `hitstopMs`  — the simulation freezes for this long on the next bloom.
+//   * `bloom`      — 0..1, how far the lattice's light is pushed.
+//   * `chromaRpx`  — chromatic split, in reference pixels.
+//   * `timescale`  — the world slows toward `TIMESCALE_FLOOR`.
+//
+// **Why caps and not a curve.** A ramp with no ceiling turns a nine-link chain
+// into an unreadable white screen at 0.2× speed, which is the "Extreme" arm of
+// the juiciness study that measured *worse* play time than none at all. The
+// caps are the product. They are exported by name so the test can assert them
+// and so nobody has to read the arithmetic to know where the ceiling is.
+//
+// **The snap-back is the point.** When the chain ends the four channels do not
+// decay — they are set to rest in a single step, and one AWE-class release
+// fires carrying the length that was banked. An escalation that never comes
+// back down is not spectacle, it is noise; the drop to stillness is what makes
+// the climb feel like it was worth something. It also means the game is never
+// sluggish a moment after a big chain, which matters more than it sounds: a
+// child who answers fast must never wait on an animation.
+//
+// **AWE has no impact.** The release carries no hitstop and adds no trauma
+// (Juice Bible class 8). A wall of light that shakes the screen reads as
+// violence; a wall of light that does not reads as a cathedral.
+//
+// **Reduced motion is a branch, not a subtraction.** The channels that carry
+// *feel* go to zero, but the link count is still information — it is what the
+// child is playing for — so it is re-routed: `Escalation.links` is unchanged
+// and the astrolabe's rim draws it as filled detents. Nothing is deleted; the
+// channel changes.
+
+/**
+ * The chain dies this long after the last bloom.
+ *
+ * Seven seconds, and the number is not arbitrary: the instrumented cadence for
+ * a two-digit sum with regrouping is 6 s at p50. A two-second window would make
+ * a nine-link chain arithmetically impossible for the child this game is for,
+ * which is how a centrepiece mechanic quietly becomes decoration. At seven, a
+ * child working at their own pace keeps the chain and a child who stalls loses
+ * it — so what the chain actually rewards is fluency, which is the thing worth
+ * rewarding.
+ */
+export const CHAIN_WINDOW_MS = 7000
+
+/** Links past this raise nothing further. The chain still counts; the feel is pinned. */
+export const CHAIN_CAP = 9
+
+// ── the named caps ──────────────────────────────────────────────────────────
+
+/** Class 2 KNOCK at one link, class 4 BREAK at the cap. Never past BREAK. */
+export const HITSTOP_BASE_MS = 48
+export const HITSTOP_STEP_MS = 14
+export const HITSTOP_CAP_MS = 160
+
+export const BLOOM_BASE = 0.3
+export const BLOOM_STEP = 0.09
+export const BLOOM_CAP = 1
+
+export const CHROMA_BASE_RPX = 0.6
+export const CHROMA_STEP_RPX = 0.85
+export const CHROMA_CAP_RPX = 6
+
+export const TIMESCALE_STEP = 0.06
+export const TIMESCALE_FLOOR = 0.55
+
+/**
+ * Total hitstop allowed in any rolling window of this length.
+ *
+ * The Juice Bible's anti-mush rule. One mark can catch several stars at once —
+ * that is the Missile Command multi-kill and it is the best moment in the game
+ * — and without a pool three simultaneous blooms at cap would freeze the world
+ * for half a second.
+ */
+export const HITSTOP_POOL_WINDOW_MS = 250
+export const HITSTOP_POOL_MS = 90
+
+export type Channels = {
+  /** How long the simulation freezes on the bloom about to be drawn. */
+  readonly hitstopMs: number
+  readonly bloom: number
+  readonly chromaRpx: number
+  readonly timescale: number
+}
+
+export const REST: Channels = { hitstopMs: 0, bloom: 0, chromaRpx: 0, timescale: 1 }
+
+/** What the chain hands back when it lets go. */
+export type Release = {
+  /** Links banked. Zero is impossible — a release with no links is not emitted. */
+  readonly links: number
+  /** 0..1: how close the chain got to the cap. Drives the size of the ceremony. */
+  readonly weight: number
+  /** True when the chain was cut by a wrong mark rather than by the light fading. */
+  readonly broken: boolean
+}
+
+/**
+ * The channels a chain of `links` stands at.
+ *
+ * Pure, so the test can walk it link by link without a `Escalation` instance,
+ * and so the render layer can ask "what would ten links look like" without
+ * touching the live chain.
+ */
+export function channelsAt(links: number, reduced: boolean): Channels {
+  if (links <= 0) return REST
+  const n = Math.min(links, CHAIN_CAP)
+  if (reduced) {
+    // The branch. No freeze, no slowdown, no colour fringe — and the bloom
+    // becomes a flat opacity the renderer cross-fades rather than a light that
+    // grows. The information is not lost; `links` still carries it.
+    return { hitstopMs: 0, bloom: 1, chromaRpx: 0, timescale: 1 }
+  }
+  return {
+    hitstopMs: Math.min(HITSTOP_CAP_MS, HITSTOP_BASE_MS + HITSTOP_STEP_MS * (n - 1)),
+    bloom: Math.min(BLOOM_CAP, BLOOM_BASE + BLOOM_STEP * (n - 1)),
+    chromaRpx: Math.min(CHROMA_CAP_RPX, CHROMA_BASE_RPX + CHROMA_STEP_RPX * (n - 1)),
+    timescale: Math.max(TIMESCALE_FLOOR, 1 - TIMESCALE_STEP * (n - 1)),
+  }
+}
+
+/**
+ * The live chain.
+ *
+ * Clock-driven rather than frame-driven: every method takes the wall-clock
+ * moment it happened at, so the whole thing is testable with plain numbers and
+ * so a pause can be handled by shifting one mark rather than by stopping a
+ * timer nobody can see.
+ */
+export class Escalation {
+  private readonly reduced: boolean
+  private n = 0
+  private deadline = 0
+  private best = 0
+
+  /** Hitstop already spent, as (spentAt, ms) pairs inside the pool window. */
+  private spent: Array<{ at: number; ms: number }> = []
+
+  constructor(reduced: boolean) {
+    this.reduced = reduced
+  }
+
+  get links(): number {
+    return this.n
+  }
+
+  get longest(): number {
+    return this.best
+  }
+
+  get alive(): boolean {
+    return this.n > 0
+  }
+
+  /** How long the current chain still has, in ms. Zero when there is none. */
+  remainingMs(now: number): number {
+    if (this.n === 0) return 0
+    return Math.max(0, this.deadline - now)
+  }
+
+  /** 0..1 across the window, for the ring that drains on the astrolabe. */
+  fuse(now: number): number {
+    if (this.n === 0) return 0
+    return Math.max(0, Math.min(1, this.remainingMs(now) / CHAIN_WINDOW_MS))
+  }
+
+  get channels(): Channels {
+    return channelsAt(this.n, this.reduced)
+  }
+
+  /**
+   * A star bloomed. One more link.
+   *
+   * Returns the channels *this* bloom is drawn with — the escalated ones, not
+   * the ones before it — because the link the child just earned has to be the
+   * one they see, not the next one.
+   */
+  link(now: number): Channels {
+    this.n += 1
+    if (this.n > this.best) this.best = this.n
+    this.deadline = now + CHAIN_WINDOW_MS
+    const channels = this.channels
+    return { ...channels, hitstopMs: this.spendHitstop(now, channels.hitstopMs) }
+  }
+
+  /**
+   * The light faded on its own. Returns the release, or `null` when there was
+   * no chain to let go of.
+   *
+   * Called from the game's tick, so it is the one method that is time-driven
+   * rather than event-driven.
+   */
+  expire(now: number): Release | null {
+    if (this.n === 0 || now < this.deadline) return null
+    return this.release(false)
+  }
+
+  /** A wrong mark. The chain is cut, and it is cut *now*, not at the deadline. */
+  cut(): Release | null {
+    if (this.n === 0) return null
+    return this.release(true)
+  }
+
+  /**
+   * The hard snap-back.
+   *
+   * Every channel goes to rest in one step — there is no decay curve here and
+   * there must not be one. The renderer eases the *visible* consequence over
+   * the release's own envelope; the chain's own state is at rest the instant
+   * this returns, so a mark on the very next frame starts from nothing.
+   */
+  private release(broken: boolean): Release {
+    const links = this.n
+    this.n = 0
+    this.deadline = 0
+    return { links, weight: Math.min(1, links / CHAIN_CAP), broken }
+  }
+
+  /**
+   * The anti-mush pool. Returns how much of `want` may actually be spent.
+   *
+   * Two hard constraints from the Juice Bible, and this implements the first:
+   * total hitstop in any rolling 250 ms window is capped, so a five-star
+   * multi-catch stays fluid instead of becoming a stutter.
+   */
+  private spendHitstop(now: number, want: number): number {
+    this.spent = this.spent.filter((s) => now - s.at < HITSTOP_POOL_WINDOW_MS)
+    const used = this.spent.reduce((sum, s) => sum + s.ms, 0)
+    const allowed = Math.max(0, Math.min(want, HITSTOP_POOL_MS - used))
+    if (allowed > 0) this.spent.push({ at: now, ms: allowed })
+    return allowed
+  }
+
+  /** The host raised a sheet. Push the deadline out by the span behind it. */
+  shift(byMs: number): void {
+    if (this.n === 0) return
+    this.deadline += Math.max(0, byMs)
+    for (const s of this.spent) s.at += Math.max(0, byMs)
+  }
+}

--- a/dynawalla/games/skyledger/src/game/game.ts
+++ b/dynawalla/games/skyledger/src/game/game.ts
@@ -1,0 +1,576 @@
+// SKY LEDGER — the rules, with no canvas anywhere near them.
+//
+// The observatory stands on the horizon with seven lamps burning. Above it the
+// sky is ruled into a ten-by-ten lattice: ONES across, TENS up, so the lattice
+// point (x, y) is the number 10y + x and the whole sky is a hundred-square
+// stood upright.
+//
+// Stars fall. Each carries a ledger line the host drew — `247 + 225` — and each
+// belongs at a station: the ordered pair of its answer's tens and ones. The
+// star is **not drawn at its station** and never approaches it. Where a star is
+// on the screen says nothing at all about what it is.
+//
+// Three verbs:
+//
+//   * **SIGHT** a star. Chooses which ledger line you are working. Reveals
+//     nothing whatever — not its station, not its order, not a hint.
+//   * **TURN** a ring of the astrolabe, one detent at a time. Two rings: ones
+//     and tens. This is the only way an ordered pair comes into existence in
+//     this game, and it produces one, digit by digit, out of the child's head.
+//   * **MARK.** The assertion. The observatory writes down
+//     `order × 100 + tens × 10 + ones` for the sighted star and the host judges
+//     it. Right: the star snaps across the sky to its true station and blooms
+//     there — and every other falling star worth the same number goes with it.
+//     Wrong: the sight goes wide and the chain is cut.
+//
+// **Why marking costs a sighting.** Without a cost, a hundred stations is a
+// hundred marks and a determined child could brute-force one — which would put
+// a hundred wrong answers on their record for a question they never worked.
+// The cost is what makes the report honest. Being *right* costs nothing at all,
+// and a wrong mark that lands on a mal-rule the host named costs nothing
+// either: the register recognises the mistake and lets you re-measure. Only a
+// wild guess spends anything, and sightings refill on a clock, so a child who
+// spends them all waits a few seconds rather than losing anything.
+//
+// **There is no win state.** A star that reaches the horizon snuffs a lamp.
+// When the last lamp is out the run ends and the observatory writes the watch
+// down. Snuffed lamps are relit one per watch survived, so a bad watch is a
+// setback and never a wall. Nothing about a landed star is reported — the child
+// never asserted anything about it, and a silence is not a wrong answer.
+
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Escalation, type Channels, type Release } from "./escalation.ts"
+import {
+  RINGS,
+  answerOf,
+  isUsable,
+  namedSlips,
+  orderOf,
+  stationOf,
+  turn,
+  valueAt,
+  type Station,
+} from "./station.ts"
+
+/** Lamps on the horizon. Missile Command had six cities; the observatory has seven. */
+export const LAMPS = 7
+
+/** Sightings the astrolabe holds, and how often one comes back. */
+export const SIGHTINGS = 6
+export const REFILL_MS = 1700
+
+/** How many draws we will make to find one ledger line this sky can hold. */
+const DRAW_ATTEMPTS = 8
+
+/** Stars in the first watch, and how many more each watch adds. */
+const WATCH_BASE = 4
+const WATCH_STEP = 1
+const WATCH_MAX = 10
+
+/** Seconds of fall in the first watch, and the floor the descent tightens to. */
+const FALL_BASE_MS = 21000
+const FALL_STEP_MS = 1400
+const FALL_FLOOR_MS = 9000
+
+/** Stars are released into the watch this far apart. */
+const RELEASE_GAP_MS = 2600
+
+export type Star = {
+  readonly id: number
+  readonly item: Question
+  /** The hundreds-and-above part, already ruled into the register. */
+  readonly order: number
+  /** Screen-space lane, 0..1 across the sky. Decorative. Says nothing. */
+  readonly lane: number
+  /** Which lamp it falls toward. */
+  readonly lamp: number
+  /** How long this star takes to reach the horizon. */
+  readonly fallMs: number
+  /**
+   * When the watch lets this star go, in **world** milliseconds since the watch
+   * opened — not wall clock.
+   *
+   * The two are not the same and the difference is a real bug: a frame delta is
+   * clamped (a backgrounded tab hands back minutes) and the chain slows the
+   * world down on purpose, so a wall-clock release would put four stars into a
+   * sky that had barely moved.
+   */
+  releaseIn: number
+  /** 0 at the top, 1 at the horizon. */
+  t: number
+  /** Wall-clock mark: when the child first took this ledger line on. */
+  askedAt: number
+  /** Set once the child has sighted it, so latency is thinking time. */
+  taken: boolean
+  state: "falling" | "caught" | "landed"
+}
+
+export type GameEvent =
+  | { kind: "sight"; star: Star }
+  | { kind: "turn"; ring: "ones" | "tens"; station: Station }
+  | { kind: "refused"; reason: "dry" | "nothing-sighted" }
+  | { kind: "bloom"; star: Star; station: Station; channels: Channels; link: number }
+  | { kind: "wide"; star: Star; station: Station; value: number; recognised: boolean }
+  | { kind: "release"; release: Release }
+  | { kind: "land"; star: Star; lamp: number }
+  | { kind: "watch"; watch: number; logged: number; relit: boolean }
+  | { kind: "over"; ledger: Ledger }
+  | { kind: "stalled" }
+
+export type Ledger = {
+  /** Stars logged this run. */
+  logged: number
+  /** Watches survived. */
+  watches: number
+  /** The longest chain of the run. */
+  longest: number
+  /** Marks that went wide. Recorded, never scolded. */
+  wide: number
+}
+
+export class Game {
+  private readonly host: Host
+  private readonly rng: Rng
+  private readonly chain: Escalation
+  private nextId = 1
+
+  private sky: Star[] = []
+  private sightedId = -1
+  private ring: Station = { x: 0, y: 0 }
+
+  private lampsLit = LAMPS
+  /** World time since this watch opened. Advances only when the sky does. */
+  private world = 0
+  private watchNo = 0
+  private loggedThisWatch = 0
+  private clock = 0
+
+  private sightingsLeft = SIGHTINGS
+  private refillAt = 0
+
+  private paused = false
+  private pausedAt = 0
+  private over = false
+  private stalledFlag = false
+
+  readonly ledger: Ledger = { logged: 0, watches: 0, longest: 0, wide: 0 }
+
+  constructor(host: Host, rng: Rng, now: number, reduced: boolean) {
+    this.host = host
+    this.rng = rng
+    this.chain = new Escalation(reduced)
+    this.clock = now
+    this.refillAt = now + REFILL_MS
+  }
+
+  /** Open the first watch. Separate from the constructor so events can be seen. */
+  begin(now: number): GameEvent[] {
+    this.clock = now
+    return this.openWatch(now)
+  }
+
+  // ── the read model ────────────────────────────────────────────────────────
+  //
+  // Everything the renderer is allowed to know. `station` is deliberately not
+  // in it: a star's station is not a fact about the sky, it is the answer, and
+  // a render layer that could read it is one refactor away from drawing it.
+
+  get stars(): readonly Star[] {
+    return this.sky
+  }
+
+  get sighted(): Star | null {
+    return this.sky.find((s) => s.id === this.sightedId && s.state === "falling") ?? null
+  }
+
+  get station(): Station {
+    return this.ring
+  }
+
+  /** What the observatory would write down if MARK were pressed now. */
+  get reading(): number | null {
+    const star = this.sighted
+    return star ? valueAt(star.order, this.ring) : null
+  }
+
+  get lamps(): number {
+    return this.lampsLit
+  }
+
+  get watch(): number {
+    return this.watchNo
+  }
+
+  get sightings(): number {
+    return this.sightingsLeft
+  }
+
+  get links(): number {
+    return this.chain.links
+  }
+
+  /** 0..1, the chain's remaining window. Drives the astrolabe's draining rim. */
+  fuse(now: number): number {
+    return this.chain.fuse(now)
+  }
+
+  get channels(): Channels {
+    return this.chain.channels
+  }
+
+  get isPaused(): boolean {
+    return this.paused
+  }
+
+  get isOver(): boolean {
+    return this.over
+  }
+
+  get stalled(): boolean {
+    return this.stalledFlag
+  }
+
+  // ── the verbs ─────────────────────────────────────────────────────────────
+
+  /**
+   * Take a ledger line on.
+   *
+   * Free, reversible, reveals nothing and reports nothing — exploring which
+   * star to work must cost a child exactly nothing. The rings are **not** reset
+   * by sighting: a child who has already dialled 4 and 7 and then changes their
+   * mind about which star those digits belong to keeps their work.
+   */
+  sight(id: number): GameEvent[] {
+    if (!this.active()) return []
+    const star = this.sky.find((s) => s.id === id && s.state === "falling" && s.t > 0)
+    if (!star || star.id === this.sightedId) return []
+    this.sightedId = id
+    if (!star.taken) {
+      star.taken = true
+      star.askedAt = this.clock
+    }
+    return [{ kind: "sight", star }]
+  }
+
+  /**
+   * Turn one ring of the astrolabe by one detent.
+   *
+   * The only route to an ordered pair in this game. Relative, wrapping, and one
+   * step per call — there is no way to hand this method a number or a point on
+   * the screen. See `src/test/produce.test.ts`.
+   */
+  dial(ring: "ones" | "tens", dir: number): GameEvent[] {
+    if (!this.active()) return []
+    this.ring = turn(this.ring, ring, dir)
+    return [{ kind: "turn", ring, station: this.ring }]
+  }
+
+  /**
+   * MARK — the assertion, and the only thing ever reported.
+   *
+   * Everything about the ordered pair came out of the child's head by way of
+   * two rings. The observatory writes it down against the sighted star and the
+   * host judges it; this method never compares it to anything.
+   */
+  mark(now: number): GameEvent[] {
+    if (!this.active()) return []
+    const star = this.sighted
+    if (!star) return [{ kind: "refused", reason: "nothing-sighted" }]
+
+    const value = valueAt(star.order, this.ring)
+    const truth = answerOf(star.item)
+    const right = truth !== null && value === truth
+    const ms = Math.max(0, now - star.askedAt)
+
+    // A mal-rule the host named is a mistake with a procedure behind it. It is
+    // still wrong and still reported as wrong; it just does not cost the child
+    // their next measurement.
+    const recognised = !right && namedSlips(star.item.distractors).has(value)
+
+    if (!right && !recognised) {
+      if (this.sightingsLeft <= 0) return [{ kind: "refused", reason: "dry" }]
+      this.sightingsLeft -= 1
+    }
+
+    this.host.report({ questionId: star.item.id, correct: right, ms, answered: String(value) })
+
+    if (!right) {
+      this.ledger.wide += 1
+      const events: GameEvent[] = [
+        { kind: "wide", star, station: this.ring, value, recognised },
+      ]
+      // The chain is cut *now*, not at its deadline. A wrong mark is the child
+      // saying something untrue about the sky, and the light goes out on it.
+      const release = this.chain.cut()
+      if (release) events.push({ kind: "release", release })
+      return events
+    }
+
+    return this.bloom(star, value, now)
+  }
+
+  /**
+   * Advance the watch.
+   *
+   * `dt` is already scaled by the escalation's timescale and already zeroed for
+   * hitstop by the caller — this method is given the time the *world* moved,
+   * not the time the wall clock moved, so a chain at cap really does slow the
+   * descent while the blooms play.
+   */
+  tick(dt: number, now: number): GameEvent[] {
+    if (this.paused || this.over || this.stalledFlag) return []
+    this.clock = now
+    this.world += Math.max(0, dt)
+    const events: GameEvent[] = []
+
+    const expired = this.chain.expire(now)
+    if (expired) events.push({ kind: "release", release: expired })
+
+    if (this.sightingsLeft < SIGHTINGS && now >= this.refillAt) {
+      this.sightingsLeft += 1
+      this.refillAt = now + REFILL_MS
+    } else if (this.sightingsLeft >= SIGHTINGS) {
+      this.refillAt = now + REFILL_MS
+    }
+
+    for (const star of this.sky) {
+      if (star.state !== "falling") continue
+      if (this.world < star.releaseIn) continue
+      star.t += dt / star.fallMs
+      if (star.t < 1) continue
+      star.t = 1
+      star.state = "landed"
+      if (star.id === this.sightedId) this.sightedId = -1
+      this.lampsLit = Math.max(0, this.lampsLit - 1)
+      events.push({ kind: "land", star, lamp: star.lamp })
+    }
+
+    if (this.lampsLit === 0) {
+      // The run is over. Not a failure screen — a page in a register.
+      this.over = true
+      const cut = this.chain.cut()
+      if (cut) events.push({ kind: "release", release: cut })
+      events.push({ kind: "over", ledger: { ...this.ledger } })
+      return events
+    }
+
+    if (this.sky.every((s) => s.state !== "falling")) {
+      events.push(...this.closeWatch(now))
+      return events
+    }
+
+    // Nothing under the sight — because a bloom took it, or the sky was still
+    // empty when the last one went. Put the most urgent star under it. The
+    // child never has to choose a target before they can begin working one.
+    if (this.sighted === null) {
+      const next = this.lowestFalling()
+      if (next) {
+        this.sightedId = next.id
+        if (!next.taken) {
+          next.taken = true
+          next.askedAt = now
+        }
+        events.push({ kind: "sight", star: next })
+      }
+    }
+    return events
+  }
+
+  /** The host put a sheet over us. Stop the clock; stop taking input. */
+  pause(now: number): void {
+    if (this.paused) return
+    this.paused = true
+    this.pausedAt = now
+  }
+
+  /**
+   * The sheet came off. Shift every wall-clock mark forward by the span the
+   * child was not here for: the ledger lines' latency marks, the chain's
+   * deadline, the refill timer and each star's release. A thirty-second sheet
+   * must not tell the host a child laboured over a question they had for two
+   * seconds, and it must not eat a chain they were in the middle of.
+   */
+  resume(now: number): void {
+    if (!this.paused) return
+    this.paused = false
+    const by = Math.max(0, now - this.pausedAt)
+    this.clock = now
+    // A star's release is on the world clock, which did not run behind the
+    // sheet, so only the ledger lines' thinking-time marks move.
+    for (const star of this.sky) star.askedAt += by
+    this.chain.shift(by)
+    this.refillAt += by
+  }
+
+  /** Start the next run after the ledger page. */
+  restart(now: number): GameEvent[] {
+    if (!this.over) return []
+    this.over = false
+    this.lampsLit = LAMPS
+    this.watchNo = 0
+    this.ledger.logged = 0
+    this.ledger.watches = 0
+    this.ledger.longest = 0
+    this.ledger.wide = 0
+    this.sightingsLeft = SIGHTINGS
+    this.refillAt = now + REFILL_MS
+    return this.openWatch(now)
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  private active(): boolean {
+    return !this.paused && !this.over && !this.stalledFlag
+  }
+
+  /**
+   * A correct mark.
+   *
+   * The sighted star snaps to its station and blooms — and so does every other
+   * falling star worth the same number, because the child's assertion was true
+   * about all of them. That is the Missile Command multi-kill, and it is exact:
+   * a star is only taken when its own canonical answer equals the value that
+   * was asserted, and each one is reported on its own.
+   */
+  private bloom(sighted: Star, value: number, now: number): GameEvent[] {
+    const events: GameEvent[] = []
+    const taken = this.sky.filter(
+      (s) => s.state === "falling" && s.t > 0 && answerOf(s.item) === value,
+    )
+    // The sighted star first, so the first link is the one the child worked.
+    taken.sort((a, b) => (a.id === sighted.id ? -1 : b.id === sighted.id ? 1 : a.id - b.id))
+
+    for (const star of taken) {
+      if (star.id !== sighted.id) {
+        // A star the child never sighted but did, in fact, name. Reported on
+        // its own terms — with the time it had actually been in the sky, which
+        // is honest, and never zero.
+        this.host.report({
+          questionId: star.item.id,
+          correct: true,
+          ms: Math.max(0, now - star.askedAt),
+          answered: String(value),
+        })
+      }
+      star.state = "caught"
+      this.ledger.logged += 1
+      this.loggedThisWatch += 1
+      const channels = this.chain.link(now)
+      this.ledger.longest = Math.max(this.ledger.longest, this.chain.links)
+      events.push({
+        kind: "bloom",
+        star,
+        station: stationOf(value),
+        channels,
+        link: this.chain.links,
+      })
+    }
+
+    this.sightedId = -1
+    // The next star the child is likeliest to want, already under the sight.
+    const next = this.lowestFalling()
+    if (next) {
+      this.sightedId = next.id
+      if (!next.taken) {
+        next.taken = true
+        next.askedAt = now
+      }
+      events.push({ kind: "sight", star: next })
+    }
+    return events
+  }
+
+  private lowestFalling(): Star | null {
+    let best: Star | null = null
+    for (const star of this.sky) {
+      if (star.state !== "falling" || star.t <= 0) continue
+      if (!best || star.t > best.t) best = star
+    }
+    return best
+  }
+
+  /**
+   * Wrap the watch up and open the next one.
+   *
+   * A watch the child logged stars in is a stopping point they *reached*, so it
+   * is where `transition` goes. A watch that ended with nothing logged is not a
+   * failure in this game — there is no failure state — but it is not an
+   * achievement either, and the host must not be invited to put a sheet on it.
+   */
+  private closeWatch(now: number): GameEvent[] {
+    const logged = this.loggedThisWatch
+    const relit = logged > 0 && this.lampsLit < LAMPS
+    if (relit) this.lampsLit += 1
+    this.ledger.watches += 1
+    const events: GameEvent[] = [{ kind: "watch", watch: this.watchNo, logged, relit }]
+    if (logged > 0) this.host.transition?.("level", `watch ${this.watchNo}`)
+    events.push(...this.openWatch(now))
+    return events
+  }
+
+  /** Release the next watch of stars. */
+  private openWatch(now: number): GameEvent[] {
+    this.watchNo += 1
+    this.loggedThisWatch = 0
+    this.world = 0
+    this.sky = []
+    this.sightedId = -1
+
+    const count = Math.min(WATCH_MAX, WATCH_BASE + (this.watchNo - 1) * WATCH_STEP)
+    const fallMs = Math.max(FALL_FLOOR_MS, FALL_BASE_MS - (this.watchNo - 1) * FALL_STEP_MS)
+
+    for (let i = 0; i < count; i++) {
+      const item = this.drawOne()
+      if (!item) break
+      const value = answerOf(item)
+      if (value === null) break
+      this.sky.push({
+        id: this.nextId++,
+        item,
+        order: orderOf(value),
+        // The lane is drawn from the rng, never from the answer. A star's place
+        // in the sky must not be a function of what it is worth — that is the
+        // one leak that would turn this back into a pointing game.
+        lane: this.rng.range(0.08, 0.92),
+        lamp: this.rng.int(0, LAMPS - 1),
+        fallMs,
+        releaseIn: i * RELEASE_GAP_MS,
+        t: 0,
+        askedAt: now,
+        taken: false,
+        state: "falling",
+      })
+    }
+
+    if (this.sky.length === 0) {
+      this.stalledFlag = true
+      console.error("[skyledger] the host served nothing this sky can hold a station for")
+      return [{ kind: "stalled" }]
+    }
+
+    const first = this.sky[0]
+    if (first) {
+      this.sightedId = first.id
+      first.taken = true
+      first.askedAt = now
+    }
+    return first ? [{ kind: "sight", star: first }] : []
+  }
+
+  /**
+   * One ledger line this sky can hold: an exact whole-number answer of at most
+   * four digits. A decimal has no station; rounding one would report a value
+   * the child never asserted, so it is dropped rather than bent.
+   */
+  private drawOne(): Question | null {
+    for (let i = 0; i < DRAW_ATTEMPTS; i++) {
+      const item = this.host.next()
+      if (isUsable(item)) return item
+    }
+    console.warn("[skyledger] the host served nothing stationable in eight draws")
+    return null
+  }
+}
+
+export { RINGS }

--- a/dynawalla/games/skyledger/src/game/station.ts
+++ b/dynawalla/games/skyledger/src/game/station.ts
@@ -1,0 +1,142 @@
+// THE STATION — the one piece of mathematics that makes the sky a plane.
+//
+// The observatory rules the sky into a 10 × 10 lattice. The horizontal axis is
+// ONES, the vertical axis is TENS, and the lattice point (x, y) *is* the number
+// `10y + x`. The whole sky is a hundred-square stood upright.
+//
+// A falling star carries a ledger line — a column sum the host drew. Its
+// **station** is where that star belongs on the lattice: the ordered pair of
+// the answer's tens and ones digits. `247 + 225 = 472` belongs at (2, 7).
+//
+// **The great columns are already logged.** An answer of 472 is more than the
+// lattice holds, so the hundreds-and-above part — the star's `order` — is
+// pre-inked on its plate the way an observatory's assistant has already ruled
+// the wide columns of the register. The child works the fine measurement, which
+// is the tens and the ones, which is exactly where a carry lives. Nothing is
+// dropped and nothing is rounded: the value that goes back to the host is
+//
+//     order × 100 + y × 10 + x
+//
+// which is an exact integer the host judges against its own canonical string.
+// This module never compares one to the other.
+//
+// **Why the split is at the hundreds and not somewhere prettier.** Every active
+// row of the `add` domain is column arithmetic on whole numbers of two to four
+// digits, so an answer runs anywhere up to 19,998. A lattice big enough to hold
+// that would need a dial with twenty thousand detents and would stop being an
+// instrument a child can turn. Two rings of ten is an astrolabe.
+
+const LATTICE = 10
+
+/** A point on the observatory's lattice. `x` is ones, `y` is tens. Both 0..9. */
+export type Station = { readonly x: number; readonly y: number }
+
+/** The lattice is 10 × 10, and every ring on the astrolabe has ten detents. */
+export const RINGS = LATTICE
+
+/**
+ * The largest answer this game can station.
+ *
+ * Six digits, which is more than the `add` domain can make: two four-digit
+ * addends top out at 19,998. The lattice is unaffected either way — a bigger
+ * answer only means a longer `order` pre-inked on the plate, and the child
+ * still turns the same two rings.
+ */
+export const MAX_ANSWER = 999999
+
+/**
+ * The answer as an exact non-negative integer, or `null` when the host served
+ * something this observatory cannot log.
+ *
+ * A decimal has no lattice point. Rounding one would report a value the child
+ * never asserted, so such an item is dropped rather than bent — the same rule
+ * COLOSSUS applies to a slab it cannot cut.
+ */
+export function answerOf(question: { answer: string }): number | null {
+  const raw = question.answer.trim()
+  if (!/^\d{1,6}$/.test(raw)) return null
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 0 || value > MAX_ANSWER) return null
+  return value
+}
+
+/** Can this ledger line be hung on a star at all? */
+export function isUsable(question: { answer: string }): boolean {
+  return answerOf(question) !== null
+}
+
+/** The hundreds-and-above part: what the register has already ruled in. */
+export function orderOf(value: number): number {
+  return Math.floor(value / 100)
+}
+
+/** Where a value belongs on the lattice: (ones, tens). */
+export function stationOf(value: number): Station {
+  return { x: value % 10, y: Math.floor(value / 10) % 10 }
+}
+
+/**
+ * The value a child asserts by standing the rings at `station` under a star of
+ * this `order`. Exact integer arithmetic, always.
+ */
+export function valueAt(order: number, station: Station): number {
+  return order * 100 + station.y * 10 + station.x
+}
+
+export function sameStation(a: Station, b: Station): boolean {
+  return a.x === b.x && a.y === b.y
+}
+
+/**
+ * Turn a ring by one detent.
+ *
+ * **Relative only, and deliberately.** There is no `setStation`, no
+ * `stationAt(px, py)`, no way at all to hand this module a place on the screen
+ * and get a coordinate back. The astrolabe is the sole producer of an ordered
+ * pair and it produces one detent at a time, which is the entire reason this
+ * game is not a tapping game. `src/test/produce.test.ts` holds that line.
+ */
+export function turn(station: Station, ring: "ones" | "tens", dir: number): Station {
+  const step = dir >= 0 ? 1 : -1
+  if (ring === "ones") return { x: (station.x + step + RINGS) % RINGS, y: station.y }
+  return { x: station.x, y: (station.y + step + RINGS) % RINGS }
+}
+
+/**
+ * The shortest number of detents between two stations.
+ *
+ * The rings wrap, so it is the circular distance on each, summed. Used by the
+ * test that proves a pair cannot be jumped to, and by the astrolabe to decide
+ * which way round to animate a pointer.
+ */
+export function detentsBetween(a: Station, b: Station): number {
+  const ring = (p: number, q: number) => {
+    const d = Math.abs(p - q)
+    return Math.min(d, RINGS - d)
+  }
+  return ring(a.x, b.x) + ring(a.y, b.y)
+}
+
+/**
+ * The values a child who is wrong *in a way somebody has a name for* would
+ * assert about this ledger line.
+ *
+ * These are never drawn. Nothing about a star's answer, or the neighbourhood of
+ * its answer, is ever put on the sky — a lit decoy would tell a child by
+ * elimination where not to aim, which is the same leak as telling them where
+ * to. They are used for one thing only, in `game.ts`: a mark that lands on a
+ * named slip is a measurement the register recognises, and it does not cost a
+ * sighting. A wild guess does. Honest mistakes are cheap here and flailing is
+ * not, which is the whole reason the astrolabe has an ammunition at all.
+ */
+export function namedSlips(distractors: readonly string[]): ReadonlySet<number> {
+  const out = new Set<number>()
+  for (const raw of distractors) {
+    const text = raw.trim()
+    if (!/^\d{1,6}$/.test(text)) continue
+    const value = Number(text)
+    if (!Number.isInteger(value) || value < 0 || value > MAX_ANSWER) continue
+    out.add(value)
+  }
+  return out
+}

--- a/dynawalla/games/skyledger/src/index.ts
+++ b/dynawalla/games/skyledger/src/index.ts
@@ -1,0 +1,3 @@
+export type { Host, Question } from "./contract.ts"
+export { mount } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/skyledger/src/main.ts
+++ b/dynawalla/games/skyledger/src/main.ts
@@ -1,0 +1,49 @@
+// Standalone dev harness. `npm run dev` → a playable observatory wired to the
+// local stub Host, with no runtime underneath it.
+//
+// `?reduced=1` forces the reduced-motion branch on, `?reduced=0` forces it off,
+// and `?seed=` replays a watch exactly.
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("skyledger: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x5c91ed
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+const host = createStubHost({
+  seed,
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${correct}/${answered} · last ${Math.round(r.ms)}ms · "${r.answered || "—"}"`
+    }
+    console.info("[skyledger/host] report", r)
+  },
+  onTransition(kind, label) {
+    console.info("[skyledger/host] transition", kind, label)
+  },
+})
+
+const handle = mount(el, host)
+
+// The harness stands in for the host's sheet: `p` raises one, `r` takes it away,
+// so the pause path can be exercised without a runtime.
+globalThis.addEventListener("keydown", (e) => {
+  if (e.key === "p") handle.pause()
+  if (e.key === "r") handle.resume()
+})
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => handle.unmount())

--- a/dynawalla/games/skyledger/src/mount.ts
+++ b/dynawalla/games/skyledger/src/mount.ts
@@ -1,0 +1,401 @@
+// SKY LEDGER — the shell. Canvas, clock, input, and the wiring from the rules
+// in `game/game.ts` to the observatory in `render/scene.ts`.
+//
+// **The pause.** The host can put a sheet — a stopping-point card, a parent
+// gate, a day-pass offer — over a pack that is still mounted and still running,
+// and this game calls `transition` at the end of every watch the child worked,
+// so it raises that sheet itself. Four things have to stop dead:
+//
+//   1. **Input.** A touch behind the sheet is not something the child did.
+//   2. **The ledger lines' clocks.** Time behind a sheet is not thinking time.
+//   3. **The sky.** Stars must not fall onto lamps nobody was watching.
+//   4. **The chain.** A live chain must not expire while the host is talking.
+//
+// `Game.pause`/`Game.resume` own all four; the rAF loop here stops advancing
+// the scene so the world holds its shape under the sheet. **Neither is reached
+// unless `pack.ts` subscribes** — the handlers are inert on their own, and a
+// pack that registers a `pause()` and never wires it up is the exact bug this
+// comment exists to prevent.
+//
+// **Hitstop and timescale.** The escalation's channels arrive on the bloom
+// event. Hitstop is a global time-scale of exactly zero applied to the
+// simulation only: audio keeps ringing, input keeps being sampled, and the
+// particles spawned by the impact are already on screen, so the freeze contains
+// the flash rather than preceding it.
+
+import { Audio } from "./audio/audio.ts"
+import type { Host } from "./contract.ts"
+import { unit } from "./core/feel.ts"
+import { Rng } from "./core/rng.ts"
+import { bestChain, recordChain } from "./game/best.ts"
+import { CHAIN_CAP } from "./game/escalation.ts"
+import { Game, LAMPS, SIGHTINGS, type GameEvent } from "./game/game.ts"
+import { angleAt, ringAt, type Ring } from "./render/astrolabe.ts"
+import { Scene, type SceneState } from "./render/scene.ts"
+import { starPoint, type StarView } from "./render/sky.ts"
+
+/**
+ * The largest step the clock may take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Clamping means time nearly
+ * stops when frames stop, instead of a watch of stars teleporting into the
+ * ground while the child was in another app.
+ */
+const MAX_STEP_MS = 120
+
+/** How far a finger sweeps around a ring before it seats in the next detent. */
+const DETENT_ARC = Math.PI / 9
+
+/** How close a touch has to land to a star to sight it, as a fraction of a cell. */
+const SIGHT_RADIUS = 1.5
+
+export function mountSkyLedger(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const seed = (Date.now() ^ 0x5c7ed6) >>> 0
+  const scene = new Scene(canvas, reduced, seed)
+  const audio = new Audio()
+
+  function now(): number {
+    return typeof performance === "object" ? performance.now() : Date.now()
+  }
+
+  const game = new Game(host, new Rng(seed), now(), reduced)
+  let best = bestChain()
+
+  let running = true
+  let paused = false
+  let last = 0
+  let frame = 0
+
+  /** Simulation time owed to a freeze. Counted down in wall-clock ms. */
+  let hitstopLeft = 0
+  let timescale = 1
+  let chroma = 0
+  let bloomLevel = 0
+
+  /** Stations written down this sitting. It only ever fills in. */
+  const logged = new Set<number>()
+
+  /** The astrolabe's live gesture. */
+  let held: Ring | null = null
+  let heldAngle = 0
+  let heldDrift = 0
+  let press = 0
+  let refuse = 0
+  let pointer = -1
+
+  // ── events ───────────────────────────────────────────────────────────────
+
+  const apply = (events: readonly GameEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "turn": {
+          audio.detent(event.ring === "ones" ? event.station.x : event.station.y)
+          host.haptic("light")
+          break
+        }
+        case "sight": {
+          audio.detent(2)
+          break
+        }
+        case "bloom": {
+          scene.addBloom(event.star, event.station, unit(event.link / CHAIN_CAP), event.link)
+          logged.add(event.station.y * 10 + event.station.x)
+          audio.bloom(event.link)
+          host.haptic(event.link >= 4 ? "heavy" : "success")
+          hitstopLeft = Math.max(hitstopLeft, event.channels.hitstopMs)
+          timescale = event.channels.timescale
+          chroma = event.channels.chromaRpx
+          bloomLevel = event.channels.bloom
+          break
+        }
+        case "wide": {
+          // Restraint. A cold ring where the child said the star was, and
+          // nothing else: no shake, no buzzer, no red. A recognised slip is
+          // quieter still, because the register has seen it before.
+          scene.addCold(event.station)
+          audio.wide()
+          host.haptic(event.recognised ? "light" : "medium")
+          break
+        }
+        case "refused": {
+          if (event.reason === "dry") {
+            refuse = 1
+            audio.refuse()
+            host.haptic("failure")
+          }
+          break
+        }
+        case "release": {
+          // The hard snap-back. The channels are already at rest in the rules;
+          // here they come off the renderer in the same single step, and the
+          // ceremony plays over the top of a world that is already moving at
+          // full speed again.
+          timescale = 1
+          chroma = 0
+          bloomLevel = 0
+          hitstopLeft = 0
+          scene.addRelease(event.release.links, event.release.weight)
+          audio.release(event.release.links)
+          if (recordChain(event.release.links)) best = event.release.links
+          break
+        }
+        case "land": {
+          scene.addLanding()
+          audio.snuff()
+          host.haptic("medium")
+          break
+        }
+        case "over": {
+          if (recordChain(event.ledger.longest)) best = event.ledger.longest
+          break
+        }
+        case "stalled": {
+          console.error("[skyledger] stalled: the host served nothing this sky can hold")
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  apply(game.begin(now()))
+
+  // ── the loop ─────────────────────────────────────────────────────────────
+
+  const view = (t: number): SceneState => {
+    const sighted = game.sighted
+    const stars: StarView[] = game.stars
+      .filter((s) => s.state === "falling")
+      .map((s) => ({
+        id: s.id,
+        lane: s.lane,
+        t: s.t,
+        order: s.order,
+        prompt: s.item.prompt,
+        sighted: sighted?.id === s.id,
+        visible: s.t > 0,
+      }))
+    return {
+      stars,
+      lamps: game.lamps,
+      lampsMax: LAMPS,
+      logged,
+      bloom: bloomLevel,
+      chromaRpx: chroma,
+      stalled: game.stalled,
+      over: game.isOver
+        ? { ...game.ledger, best: Math.max(best, game.ledger.longest) }
+        : null,
+      held,
+      dial: {
+        ones: game.station.x,
+        tens: game.station.y,
+        onesDrift: held === "ones" ? heldDrift : 0,
+        tensDrift: held === "tens" ? heldDrift : 0,
+        order: sighted?.order ?? 0,
+        reading: game.reading,
+        links: game.links,
+        chainCap: CHAIN_CAP,
+        fuse: game.fuse(t),
+        sightings: game.sightings,
+        sightingsMax: SIGHTINGS,
+        press,
+        refuse,
+      },
+    }
+  }
+
+  const tick = (t: number): void => {
+    if (!running) return
+    frame = requestAnimationFrame(tick)
+    const wall = last === 0 ? 16 : Math.min(MAX_STEP_MS, t - last)
+    last = t
+
+    if (!paused) {
+      press = Math.max(0, press - wall / 110)
+      refuse = Math.max(0, refuse - wall / 260)
+
+      // Hitstop: the world stops, the frame does not. Audio is already ringing
+      // and input is still being sampled; only the simulation is frozen.
+      let sim = wall
+      if (hitstopLeft > 0) {
+        const spent = Math.min(hitstopLeft, wall)
+        hitstopLeft -= spent
+        sim = wall - spent
+      }
+      apply(game.tick(sim * timescale, t))
+      scene.advance(wall, view(t))
+    }
+    scene.draw(view(t))
+  }
+  frame = requestAnimationFrame(tick)
+
+  // ── input ────────────────────────────────────────────────────────────────
+
+  const local = (e: PointerEvent): { px: number; py: number } => {
+    const rect = canvas.getBoundingClientRect()
+    return { px: e.clientX - rect.left, py: e.clientY - rect.top }
+  }
+
+  const onDown = (e: PointerEvent): void => {
+    if (paused) return
+    e.preventDefault()
+    if (pointer !== -1) return
+    pointer = e.pointerId
+    canvas.setPointerCapture?.(e.pointerId)
+    const { px, py } = local(e)
+
+    if (game.isOver) {
+      apply(game.restart(now()))
+      logged.clear()
+      return
+    }
+
+    const zone = ringAt(scene.l, px, py)
+    if (zone === "boss") {
+      press = 1
+      apply(game.mark(now()))
+      return
+    }
+    if (zone === "ones" || zone === "tens") {
+      held = zone
+      heldAngle = angleAt(scene.l, px, py)
+      heldDrift = 0
+      return
+    }
+
+    // Otherwise: the sky. A touch there chooses which ledger line the child is
+    // working, and does nothing else at all. It cannot name a station — the
+    // rings are the only thing that can — so there is no way to point.
+    const l = scene.l
+    let bestStar = -1
+    let bestDist = l.cell * SIGHT_RADIUS
+    for (const star of game.stars) {
+      if (star.state !== "falling" || star.t <= 0) continue
+      const p = starPoint(l, star.lane, star.t)
+      const d = Math.hypot(p.px - px, p.py - py)
+      if (d < bestDist) {
+        bestDist = d
+        bestStar = star.id
+      }
+    }
+    if (bestStar >= 0) apply(game.sight(bestStar))
+  }
+
+  const onMove = (e: PointerEvent): void => {
+    if (paused || e.pointerId !== pointer || !held) return
+    e.preventDefault()
+    const { px, py } = local(e)
+    const a = angleAt(scene.l, px, py)
+    let delta = a - heldAngle
+    while (delta > Math.PI) delta -= Math.PI * 2
+    while (delta < -Math.PI) delta += Math.PI * 2
+    heldDrift += delta / DETENT_ARC
+    heldAngle = a
+    // Seat one detent at a time, however fast the finger swept. A ring that
+    // jumps four digits in one flick is a ring a child cannot aim.
+    while (heldDrift >= 1) {
+      heldDrift -= 1
+      apply(game.dial(held, 1))
+    }
+    while (heldDrift <= -1) {
+      heldDrift += 1
+      apply(game.dial(held, -1))
+    }
+  }
+
+  const onUp = (e: PointerEvent): void => {
+    if (e.pointerId !== pointer) return
+    pointer = -1
+    held = null
+    heldDrift = 0
+    canvas.releasePointerCapture?.(e.pointerId)
+  }
+
+  /**
+   * A keyboard, for the harness and for anyone playing on a laptop. Arrow keys
+   * turn the two rings; space marks. Still a production, never a jump — there
+   * is deliberately no way to type "72".
+   */
+  const onKey = (e: KeyboardEvent): void => {
+    if (paused) return
+    switch (e.key) {
+      case "ArrowRight":
+        apply(game.dial("ones", 1))
+        break
+      case "ArrowLeft":
+        apply(game.dial("ones", -1))
+        break
+      case "ArrowUp":
+        apply(game.dial("tens", 1))
+        break
+      case "ArrowDown":
+        apply(game.dial("tens", -1))
+        break
+      case " ":
+      case "Enter":
+        e.preventDefault()
+        press = 1
+        if (game.isOver) {
+          apply(game.restart(now()))
+          logged.clear()
+        } else {
+          apply(game.mark(now()))
+        }
+        break
+      default:
+        return
+    }
+  }
+
+  canvas.addEventListener("pointerdown", onDown, { passive: false })
+  canvas.addEventListener("pointermove", onMove, { passive: false })
+  canvas.addEventListener("pointerup", onUp)
+  canvas.addEventListener("pointercancel", onUp)
+  globalThis.addEventListener("keydown", onKey)
+
+  const onResize = (): void => scene.resize()
+  globalThis.addEventListener("resize", onResize)
+  const observer =
+    typeof ResizeObserver === "function" ? new ResizeObserver(() => scene.resize()) : null
+  observer?.observe(canvas)
+
+  return {
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frame)
+      canvas.removeEventListener("pointerdown", onDown)
+      canvas.removeEventListener("pointermove", onMove)
+      canvas.removeEventListener("pointerup", onUp)
+      canvas.removeEventListener("pointercancel", onUp)
+      globalThis.removeEventListener("keydown", onKey)
+      globalThis.removeEventListener("resize", onResize)
+      observer?.disconnect()
+      audio.close()
+      canvas.remove()
+    },
+    pause(): void {
+      if (paused) return
+      paused = true
+      held = null
+      pointer = -1
+      game.pause(now())
+    },
+    resume(): void {
+      if (!paused) return
+      paused = false
+      last = 0
+      game.resume(now())
+    },
+  }
+}

--- a/dynawalla/games/skyledger/src/pack.ts
+++ b/dynawalla/games/skyledger/src/pack.ts
@@ -1,0 +1,68 @@
+// SKY LEDGER, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the sky, the astrolabe, the chain and
+// the ledger are untouched.
+//
+// What crosses the boundary is the ledger line. A star carries a problem the
+// curriculum drew, and the value the child asserts is
+// `order × 100 + tens × 10 + ones` — the hundreds the register had already
+// ruled in, plus the two digits they turned onto the astrolabe themselves.
+// That is an exact integer the host can judge against its own canonical
+// answer, and when it is wrong it is usually wrong in a way the host
+// recognises, because a child who drops a carry turns the ring to the digit
+// their own procedure produced.
+//
+// `items.reveal` is declared and is not optional. Without the canonical value
+// there is no station: the sky would be a lattice of a hundred points with
+// nothing standing at any of them, and every item would be dropped silently.
+//
+// Reading a number as a place on a plane is the game's own mathematics — a
+// thing the child performs with a gesture rather than a question anybody asked
+// — so nothing about the lattice itself is reported.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("skyledger: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: a watch opens with four stars at once, and
+  // a star with a blank plate is the kind of thing that happens exactly once,
+  // on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+
+  // A transition can put a sheet over the frame, and the SDK documents that the
+  // pack keeps running underneath it. SKY LEDGER calls `transition` at the end
+  // of every watch the child logged stars in, so this is routine rather than
+  // hypothetical — and unguarded it is the worst bug this game could have: the
+  // sky keeps falling behind the sheet, lamps go out for a watch nobody could
+  // see, and a touch landing behind it marks a station against a ledger line
+  // the child never read.
+  //
+  // These two handlers are the whole subscription. `handle.pause()` is inert
+  // until something calls it.
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[skyledger] could not start", error)
+  renderNoHost(root, "SKY LEDGER")
+})

--- a/dynawalla/games/skyledger/src/render/astrolabe.ts
+++ b/dynawalla/games/skyledger/src/render/astrolabe.ts
@@ -1,0 +1,262 @@
+// THE ASTROLABE — the instrument that makes the child PRODUCE the ordered pair.
+//
+// Two brass rings turn under one fixed index at the top of the plate. The outer
+// ring carries the ONES, the inner ring the TENS, and each seats in ten
+// detents. A digit is not chosen from a list and it is not pointed at on the
+// sky: it is *turned to*, one notch at a time, by a hand that already knows
+// which digit it wants.
+//
+// In the middle sits the boss — the MARK — with the reading engraved on it: the
+// ordered pair, and beneath it the number that pair stands for, so the child
+// sees `(2, 7)` and `72` as the same fact. That equivalence is the whole
+// pedagogy of the game and it is drawn, never said.
+//
+// Around the rim: the chain. One filled notch per link, and a fuse that drains
+// as the light fades. In reduced motion those notches are the *only* place the
+// chain lives, which is why they are drawn there and not merely animated there.
+
+import {
+  alpha,
+  BRASS,
+  BRASS_DEEP,
+  BRASS_DIM,
+  BRASS_LIT,
+  FIGURE_FONT,
+  LAPIS,
+  LAPIS_LIT,
+  OXIDE,
+  sized,
+  STARLIGHT,
+  STONE,
+  STONE_EDGE,
+} from "./palette.ts"
+import type { Layout } from "./sky.ts"
+
+const DETENTS = 10
+const ARC = (Math.PI * 2) / DETENTS
+
+export type Ring = "ones" | "tens"
+
+export type DialView = {
+  ones: number
+  tens: number
+  /** Sub-detent offset, −0.5..0.5, while a ring is being dragged. */
+  onesDrift: number
+  tensDrift: number
+  order: number
+  /** What the observatory would write down. Null when nothing is sighted. */
+  reading: number | null
+  links: number
+  chainCap: number
+  fuse: number
+  sightings: number
+  sightingsMax: number
+  /** 0..1, the boss's press. */
+  press: number
+  /** 0..1, a refusal shudder. */
+  refuse: number
+}
+
+export function ringRadii(l: Layout): {
+  outer: [number, number]
+  inner: [number, number]
+  boss: number
+} {
+  const r = l.dial.r
+  return { outer: [r * 0.74, r], inner: [r * 0.45, r * 0.7], boss: r * 0.41 }
+}
+
+/** Which ring a touch landed on, or `null` for the boss or for open plate. */
+export function ringAt(l: Layout, px: number, py: number): Ring | "boss" | null {
+  const { outer, inner, boss } = ringRadii(l)
+  const d = Math.hypot(px - l.dial.cx, py - l.dial.cy)
+  if (d <= boss) return "boss"
+  if (d >= inner[0] && d <= inner[1]) return "tens"
+  if (d >= outer[0] && d <= outer[1]) return "ones"
+  return null
+}
+
+/** The angle, in radians, of a touch about the dial's centre. */
+export function angleAt(l: Layout, px: number, py: number): number {
+  return Math.atan2(py - l.dial.cy, px - l.dial.cx)
+}
+
+function drawRing(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  radii: [number, number],
+  value: number,
+  drift: number,
+  hot: boolean,
+): void {
+  const { cx, cy } = l.dial
+  const [ri, ro] = radii
+  const mid = (ri + ro) / 2
+
+  g.save()
+  g.beginPath()
+  g.arc(cx, cy, ro, 0, Math.PI * 2)
+  g.arc(cx, cy, ri, 0, Math.PI * 2, true)
+  g.fillStyle = STONE
+  g.fill("evenodd")
+  g.strokeStyle = hot ? alpha(BRASS, 0.8) : STONE_EDGE
+  g.lineWidth = Math.max(1, l.rpx * 2)
+  g.beginPath()
+  g.arc(cx, cy, ro, 0, Math.PI * 2)
+  g.stroke()
+  g.beginPath()
+  g.arc(cx, cy, ri, 0, Math.PI * 2)
+  g.stroke()
+  g.restore()
+
+  // The ring turns so that the seated digit comes under the index at the top.
+  const turn = -(value + drift) * ARC
+  const size = Math.max(10, Math.min((ro - ri) * 0.52, 26 * Math.max(1, l.rpx * 1.4)))
+  g.font = sized(FIGURE_FONT, size)
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+
+  for (let d = 0; d < DETENTS; d++) {
+    const a = -Math.PI / 2 + turn + d * ARC
+    const px = cx + Math.cos(a) * mid
+    const py = cy + Math.sin(a) * mid
+    const seated = d === value
+    g.save()
+    g.translate(px, py)
+    g.rotate(a + Math.PI / 2)
+    g.fillStyle = seated ? BRASS_LIT : alpha(BRASS_DIM, 0.8)
+    g.fillText(String(d), 0, 0)
+    g.restore()
+
+    // A notch on the outer edge for every detent: the ring is a mechanism and
+    // it has to look like one that can only stop in ten places.
+    const na = a
+    g.strokeStyle = alpha(BRASS_DEEP, 0.9)
+    g.lineWidth = Math.max(1, l.rpx * 1.6)
+    g.beginPath()
+    g.moveTo(cx + Math.cos(na) * (ro - (ro - ri) * 0.16), cy + Math.sin(na) * (ro - (ro - ri) * 0.16))
+    g.lineTo(cx + Math.cos(na) * ro, cy + Math.sin(na) * ro)
+    g.stroke()
+  }
+}
+
+export function drawAstrolabe(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  v: DialView,
+  held: Ring | null,
+  reduced: boolean,
+): void {
+  const { cx, cy, r } = l.dial
+  const { outer, inner, boss } = ringRadii(l)
+
+  // The plate.
+  g.fillStyle = STONE
+  g.beginPath()
+  g.arc(cx, cy, r * 1.05, 0, Math.PI * 2)
+  g.fill()
+  g.strokeStyle = alpha(BRASS_DEEP, 0.9)
+  g.lineWidth = Math.max(1, l.rpx * 3)
+  g.stroke()
+
+  drawRing(g, l, outer, v.ones, v.onesDrift, held === "ones")
+  drawRing(g, l, inner, v.tens, v.tensDrift, held === "tens")
+
+  // The index: one fixed brass pointer at the top. Both rings read under it.
+  g.fillStyle = BRASS_LIT
+  g.beginPath()
+  g.moveTo(cx, cy - r * 1.02)
+  g.lineTo(cx - r * 0.045, cy - r * 1.13)
+  g.lineTo(cx + r * 0.045, cy - r * 1.13)
+  g.closePath()
+  g.fill()
+
+  // ── the chain, on the rim's foot ─────────────────────────────────────────
+  //
+  // Reduced motion or not, this is where the link count lives. Nothing about
+  // this drawing depends on the world slowing down or the colour splitting, so
+  // the information survives the branch intact. It sits at six o'clock, well
+  // clear of the index, and it is the first thing a child's eye goes to when
+  // a chain is running.
+  const notches = Math.min(v.links, v.chainCap)
+  const fan = 0.155
+  for (let i = 0; i < v.chainCap; i++) {
+    // Filling left to right, the way a count does.
+    const a = Math.PI / 2 + ((v.chainCap - 1) / 2 - i) * fan
+    const lit = i < notches
+    const rr = r * 1.07
+    const out = r * (lit ? 0.1 : 0.05)
+    g.strokeStyle = lit ? BRASS_LIT : alpha(BRASS_DEEP, 0.75)
+    g.lineWidth = Math.max(1.5, l.rpx * (lit ? 4.5 : 2.4))
+    g.beginPath()
+    g.moveTo(cx + Math.cos(a) * rr, cy + Math.sin(a) * rr)
+    g.lineTo(cx + Math.cos(a) * (rr + out), cy + Math.sin(a) * (rr + out))
+    g.stroke()
+  }
+  if (v.links > 0 && v.fuse > 0) {
+    // The fuse: the light still in the chain, draining across the same arc.
+    const half = (fan * (v.chainCap - 1)) / 2
+    g.strokeStyle = alpha(STARLIGHT, 0.6)
+    g.lineWidth = Math.max(1.5, l.rpx * 3)
+    g.beginPath()
+    g.arc(cx, cy, r * 1.07, Math.PI / 2 - half * v.fuse, Math.PI / 2 + half * v.fuse)
+    g.stroke()
+  }
+
+  // ── the sightings, in a column beside the plate ──────────────────────────
+  const pitch = r * 0.15
+  for (let i = 0; i < v.sightingsMax; i++) {
+    const px = cx - r * 1.16
+    const py = cy + (i - (v.sightingsMax - 1) / 2) * pitch
+    g.fillStyle = i < v.sightings ? BRASS : alpha(BRASS_DEEP, 0.8)
+    g.beginPath()
+    g.arc(px, py, Math.max(2, r * 0.032), 0, Math.PI * 2)
+    g.fill()
+  }
+
+  // ── the boss: MARK, with the reading engraved on it ──────────────────────
+  const shake = v.refuse > 0 && !reduced ? Math.sin(v.refuse * 42) * l.rpx * 4 * v.refuse : 0
+  g.save()
+  g.translate(shake, 0)
+  g.fillStyle = v.refuse > 0 ? alpha(OXIDE, 0.35) : alpha(LAPIS, 0.55)
+  g.beginPath()
+  g.arc(cx, cy, boss * (1 - 0.045 * v.press), 0, Math.PI * 2)
+  g.fill()
+  g.strokeStyle = v.refuse > 0 ? OXIDE : BRASS
+  g.lineWidth = Math.max(1.5, l.rpx * 3)
+  g.stroke()
+
+  const pairSize = Math.max(12, Math.min(boss * 0.3, 32 * Math.max(1, l.rpx * 1.3)))
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+
+  // Which ring is which, said once, right over the digit each one seats. No
+  // leader lines, no legend: the label is directly above the numeral it names.
+  const gap = pairSize * 1.5
+  g.font = sized(FIGURE_FONT, pairSize * 0.48)
+  g.fillStyle = held === "ones" ? BRASS_LIT : alpha(LAPIS_LIT, 0.95)
+  g.fillText("ONES", cx - gap, cy - boss * 0.6)
+  g.fillStyle = held === "tens" ? BRASS_LIT : alpha(LAPIS_LIT, 0.95)
+  g.fillText("TENS", cx + gap, cy - boss * 0.6)
+
+  g.font = sized(FIGURE_FONT, pairSize)
+  g.fillStyle = alpha(BRASS_DIM, 0.9)
+  g.fillText("(", cx - gap * 1.75, cy - boss * 0.3)
+  g.fillText(",", cx, cy - boss * 0.3)
+  g.fillText(")", cx + gap * 1.75, cy - boss * 0.3)
+  g.fillStyle = BRASS_LIT
+  g.font = sized(FIGURE_FONT, pairSize * 1.18)
+  g.fillText(String(v.ones), cx - gap, cy - boss * 0.3)
+  g.fillText(String(v.tens), cx + gap, cy - boss * 0.3)
+
+  // The same fact, as a number. `(2, 7)` and `72` sit one above the other and
+  // the child is never told they are the same thing.
+  g.font = sized(FIGURE_FONT, pairSize * 1.6)
+  g.fillStyle = v.reading === null ? alpha(BRASS_DIM, 0.5) : STARLIGHT
+  g.fillText(v.reading === null ? "—" : String(v.reading), cx, cy + boss * 0.22)
+
+  g.font = sized(FIGURE_FONT, pairSize * 0.58)
+  g.fillStyle = alpha(BRASS_DIM, 0.95)
+  g.fillText("MARK", cx, cy + boss * 0.68)
+  g.restore()
+}

--- a/dynawalla/games/skyledger/src/render/palette.ts
+++ b/dynawalla/games/skyledger/src/render/palette.ts
@@ -1,0 +1,55 @@
+// The observatory's materials.
+//
+// Material, not lighting. Brass, lapis, carved stone and cold celestial light —
+// al-Jazari's register room at three in the morning. Nothing here is a gradient
+// standing in for structure, there is no accent colour for "primary action",
+// and nothing glows that is not a light source in the fiction.
+
+/** Night, and the stone the observatory is cut from. */
+export const NIGHT = "#050810"
+export const NIGHT_HIGH = "#0a1020"
+export const STONE = "#14161d"
+export const STONE_EDGE = "#242832"
+
+/** Lapis: the ruled lattice, the axis figures, the ledger's ink. */
+export const LAPIS = "#1b3a6b"
+export const LAPIS_DIM = "#12213c"
+export const LAPIS_LIT = "#3f6fb0"
+
+/** Brass: every instrument, every ring, every numeral the child turns. */
+export const BRASS = "#c9a44c"
+export const BRASS_DIM = "#7c6529"
+export const BRASS_DEEP = "#4a3d1c"
+export const BRASS_LIT = "#f3dc9a"
+
+/** Cold celestial light: a star, and what a correct measurement looks like. */
+export const STARLIGHT = "#dfe9ff"
+export const STARLIGHT_CORE = "#ffffff"
+
+/** Copper oxide: a mark that went wide. Cold, quiet, never red and never loud. */
+export const OXIDE = "#7d5a44"
+export const OXIDE_DIM = "#3a2c23"
+
+/** A lamp on the horizon, burning and snuffed. */
+export const LAMP_LIT = "#ffca7a"
+export const LAMP_OUT = "#2a2622"
+
+/** The ledger's paper, for the page written at the end of a run. */
+export const VELLUM = "#e6dcc4"
+
+/** Type, in one place so the whole instrument is engraved by one hand. */
+export const FIGURE_FONT = `600 %spx ui-monospace, "SF Mono", Menlo, monospace`
+export const PLATE_FONT = `500 %spx ui-monospace, "SF Mono", Menlo, monospace`
+
+export function sized(template: string, px: number): string {
+  return template.replace("%s", String(Math.round(px)))
+}
+
+/** `rgba` from one of the constants above. */
+export function alpha(hex: string, a: number): string {
+  const n = Number.parseInt(hex.slice(1), 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return `rgba(${r}, ${g}, ${b}, ${Math.max(0, Math.min(1, a))})`
+}

--- a/dynawalla/games/skyledger/src/render/scene.ts
+++ b/dynawalla/games/skyledger/src/render/scene.ts
@@ -1,0 +1,404 @@
+// THE SCENE — everything that is drawn, and the only place trauma, bloom and
+// chroma are turned into pixels.
+//
+// The sim hands this module `Channels` and it hands back a frame. It owns no
+// rules: it cannot decide that a mark was right, it is not told where a star
+// belongs until a bloom arrives carrying the station, and there is a test that
+// reads these files and fails if any of them so much as mentions an answer.
+//
+// **Reduced motion is a branch.** Not a dimmer: a different set of drawings.
+// Trauma is zero, chroma is zero, the snap is a cross-fade, the release is a
+// held frame instead of a slow bloom — and the chain's link count moves onto
+// the astrolabe's rim, where it is legible without a single moving pixel.
+
+import { approach, unit } from "../core/feel.ts"
+import { CHROMA_CAP_RPX } from "../game/escalation.ts"
+import { Rng } from "../core/rng.ts"
+import { drawAstrolabe, type DialView, type Ring } from "./astrolabe.ts"
+import {
+  alpha,
+  BRASS,
+  BRASS_DIM,
+  BRASS_LIT,
+  FIGURE_FONT,
+  LAPIS_LIT,
+  OXIDE,
+  sized,
+  STARLIGHT,
+  STONE,
+  VELLUM,
+} from "./palette.ts"
+import {
+  drawBloom,
+  drawHorizon,
+  drawLattice,
+  drawNight,
+  drawStar,
+  layoutFor,
+  starPoint,
+  stationPoint,
+  type Bloom,
+  type Layout,
+  type StarView,
+} from "./sky.ts"
+
+/** Trauma decays this fast. Brass and stone, not glass: slow and heavy. */
+const TRAUMA_DECAY = 1.9
+const MAX_TRANSLATE_RPX = 22
+const MAX_ROTATE_DEG = 1.6
+
+const BLOOM_LIFE_MS = 620
+const COLD_LIFE_MS = 420
+
+/** The release ceremony. AWE: no shake, no freeze, a long slow breath out. */
+const RELEASE_MS = 900
+
+export type SceneState = {
+  stars: readonly StarView[]
+  lamps: number
+  lampsMax: number
+  dial: DialView
+  held: Ring | null
+  /** The stations this observatory has written down this sitting. */
+  logged: ReadonlySet<number>
+  bloom: number
+  chromaRpx: number
+  over: { logged: number; watches: number; longest: number; wide: number; best: number } | null
+  stalled: boolean
+}
+
+export class Scene {
+  private readonly canvas: HTMLCanvasElement
+  private readonly g: CanvasRenderingContext2D
+  private readonly rng: Rng
+  readonly reduced: boolean
+
+  private layout: Layout
+  private dpr = 1
+  private trauma = 0
+  private blooms: Bloom[] = []
+  private glow = 0
+  private breath = 0
+  private flicker = 0
+  private release: { age: number; weight: number; links: number } | null = null
+
+  constructor(canvas: HTMLCanvasElement, reduced: boolean, seed: number) {
+    this.canvas = canvas
+    this.reduced = reduced
+    this.rng = new Rng(seed ^ 0x5c3e)
+    const g = canvas.getContext("2d", { alpha: false })
+    if (!g) throw new Error("skyledger: no 2d context")
+    this.g = g
+    this.layout = layoutFor(1, 1)
+    this.resize()
+  }
+
+  get l(): Layout {
+    return this.layout
+  }
+
+  resize(): void {
+    const rect = this.canvas.getBoundingClientRect()
+    const w = Math.max(1, Math.round(rect.width))
+    const h = Math.max(1, Math.round(rect.height))
+    this.dpr = Math.min(2.5, globalThis.devicePixelRatio || 1)
+    this.canvas.width = Math.round(w * this.dpr)
+    this.canvas.height = Math.round(h * this.dpr)
+    this.layout = layoutFor(w, h)
+  }
+
+  /**
+   * A star was named and is going home.
+   *
+   * The station arrives with the event, from the rules. The scene is never told
+   * where a star belongs before the child has said it.
+   */
+  addBloom(
+    star: { lane: number; t: number },
+    station: { x: number; y: number },
+    weight: number,
+    link: number,
+  ): void {
+    const from = starPoint(this.layout, star.lane, star.t)
+    const to = stationPoint(this.layout, station.x, station.y)
+    this.blooms.push({
+      fromX: from.px,
+      fromY: from.py,
+      toX: to.px,
+      toY: to.py,
+      age: 0,
+      life: BLOOM_LIFE_MS,
+      weight: unit(weight),
+      link,
+      cold: false,
+    })
+    // Class 2 KNOCK climbing toward class 4 BREAK. Never past it, and never on
+    // the release, which is awe and carries no impact at all.
+    if (!this.reduced) this.trauma = Math.min(1, this.trauma + 0.16 + 0.2 * unit(weight))
+  }
+
+  /** A mark that went wide. Restraint: a cold ring at the named station, no shake. */
+  addCold(station: { x: number; y: number }): void {
+    const to = stationPoint(this.layout, station.x, station.y)
+    this.blooms.push({
+      fromX: to.px,
+      fromY: to.py,
+      toX: to.px,
+      toY: to.py,
+      age: 0,
+      life: COLD_LIFE_MS,
+      weight: 0,
+      link: 0,
+      cold: true,
+    })
+  }
+
+  /**
+   * The snap-back.
+   *
+   * The channels are already at rest by the time this is called — the chain
+   * dropped them in one step. What plays here is the *consequence*: a held,
+   * slow, silent breath out with the chain's length written in it. Class 8.
+   * Trauma stays at zero for the whole event; this is awe, not impact, and the
+   * distinction is the entire point.
+   */
+  addRelease(links: number, weight: number): void {
+    // A single correct answer is a *seat*, not a ceremony. It already had its
+    // bloom; giving it a wall of light as well would make ordinary success cost
+    // a second of screen and would spend the release's meaning on nothing. The
+    // ceremony starts at the second link, which is the first one that was a
+    // chain at all.
+    if (links < 2) return
+    this.release = { age: 0, weight: unit(weight), links }
+  }
+
+  /** A star reached the horizon. A lamp goes out; the ground takes the hit. */
+  addLanding(): void {
+    if (!this.reduced) this.trauma = Math.min(1, this.trauma + 0.24)
+    this.flicker = 1
+  }
+
+  advance(dt: number, state: SceneState): void {
+    this.trauma = Math.max(0, this.trauma - (TRAUMA_DECAY * dt) / 1000)
+    this.breath = (this.breath + dt / 900) % 1
+    this.flicker = Math.max(0, this.flicker - dt / 700)
+    this.glow = approach(this.glow, state.dial.press > 0 ? 1 : 0.25, 0.16, dt)
+    for (const b of this.blooms) b.age += dt
+    this.blooms = this.blooms.filter((b) => b.age < b.life)
+    if (this.release) {
+      this.release.age += dt
+      if (this.release.age > RELEASE_MS) this.release = null
+    }
+  }
+
+  draw(state: SceneState): void {
+    const g = this.g
+    const l = this.layout
+    g.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    drawNight(g, l)
+
+    g.save()
+    if (!this.reduced && this.trauma > 0) {
+      // Eiserloh's trauma model: squared, so small hits stay subtle.
+      const amount = this.trauma * this.trauma
+      const t = this.breath * Math.PI * 2 * 24
+      g.translate(
+        Math.sin(t * 1.7) * MAX_TRANSLATE_RPX * l.rpx * amount,
+        Math.cos(t * 1.3) * MAX_TRANSLATE_RPX * l.rpx * amount,
+      )
+      g.rotate((Math.sin(t * 0.9) * MAX_ROTATE_DEG * amount * Math.PI) / 180)
+    }
+
+    // The chain's bloom channel lifts the cross-hair the child is standing at:
+    // the light in a chain lands on the thing they are aiming with.
+    drawLattice(
+      g,
+      l,
+      state.logged,
+      { x: state.dial.ones, y: state.dial.tens },
+      Math.max(this.glow, state.bloom),
+    )
+    for (const star of state.stars) drawStar(g, l, star, Math.sin(this.breath * Math.PI * 2))
+    for (const b of this.blooms) drawBloom(g, l, b, this.reduced)
+    this.drawRelease()
+    drawHorizon(g, l, state.lamps, state.lampsMax, this.flicker)
+    g.restore()
+
+    // The chromatic split rides the plane's own edges rather than the whole
+    // frame: a full-screen separation on a mid-range tablet costs a composite
+    // per channel and buys nothing a child can name.
+    if (!this.reduced && state.chromaRpx > 0.05) this.drawChroma(state.chromaRpx)
+
+    drawAstrolabe(g, l, state.dial, state.held, this.reduced)
+
+    if (state.stalled) this.drawStalled()
+    if (state.over) this.drawLedgerPage(state.over)
+  }
+
+  private drawRelease(): void {
+    const r = this.release
+    if (!r) return
+    const g = this.g
+    const l = this.layout
+    const t = unit(r.age / RELEASE_MS)
+
+    if (this.reduced) {
+      // A held frame, then gone. No travel, no expansion — the number is the
+      // event and the number does not need to move to be read.
+      const a = t < 0.2 ? t / 0.2 : 1 - (t - 0.2) / 0.8
+      g.font = sized(FIGURE_FONT, Math.max(22, l.cell * 0.9))
+      g.textAlign = "center"
+      g.textBaseline = "middle"
+      g.fillStyle = alpha(BRASS_LIT, a)
+      g.fillText(`${r.links}`, l.plane.x + l.plane.w / 2, l.plane.y + l.plane.h / 2)
+      return
+    }
+
+    // A wall of light that does not shake. It pulls *outward* and dissolves
+    // upward, and the ring is drawn from the plane's centre so the whole
+    // coordinate plane reads as the thing that is glowing.
+    const spread = 1 - Math.pow(1 - t, 2.4)
+    const fade = 1 - t
+    const cx = l.plane.x + l.plane.w / 2
+    const cy = l.plane.y + l.plane.h / 2
+    g.save()
+    g.globalCompositeOperation = "lighter"
+    for (let i = 0; i < 3; i++) {
+      const rr = l.plane.w * (0.1 + 0.62 * spread) * (1 + i * 0.16)
+      g.strokeStyle = alpha(STARLIGHT, 0.2 * fade * (1 - i * 0.28) * (0.5 + 0.5 * r.weight))
+      g.lineWidth = Math.max(1, l.rpx * (8 - i * 2))
+      g.beginPath()
+      g.arc(cx, cy, rr, 0, Math.PI * 2)
+      g.stroke()
+    }
+    // Motes drifting up, not out. Awe rises.
+    const count = Math.round(24 + 90 * r.weight)
+    const drift = this.rng.fork(r.links)
+    for (let i = 0; i < count; i++) {
+      const a = drift.range(0, Math.PI * 2)
+      const rad = drift.range(0, l.plane.w * 0.5)
+      const px = cx + Math.cos(a) * rad
+      const py = cy + Math.sin(a) * rad - t * l.plane.h * 0.42
+      g.fillStyle = alpha(i % 5 === 0 ? BRASS_LIT : STARLIGHT, 0.5 * fade)
+      g.fillRect(px, py, Math.max(1, l.rpx * 2.2), Math.max(1, l.rpx * 2.2))
+    }
+    g.restore()
+
+    g.font = sized(FIGURE_FONT, Math.max(20, l.cell * (0.55 + 0.5 * r.weight)))
+    g.textAlign = "center"
+    g.textBaseline = "middle"
+    g.fillStyle = alpha(BRASS_LIT, fade)
+    g.fillText(`${r.links} LOGGED`, cx, cy)
+  }
+
+  /**
+   * The chromatic split, on the aperture's own edge.
+   *
+   * Two things it must not be. It must not be *loud*: at one link it should be
+   * a thing a child feels rather than sees, which means the strength rides the
+   * channel rather than sitting at full alpha the moment the channel is
+   * non-zero. And it must not be *magenta*: a lighter-composited violet and
+   * orange over lapis reads as a browser bug, so the two fringes are the
+   * palette's own cold and warm, and the whole effect tops out translucent.
+   */
+  private drawChroma(rpx: number): void {
+    const g = this.g
+    const l = this.layout
+    const d = rpx * l.rpx
+    const a = Math.min(0.3, (rpx / CHROMA_CAP_RPX) * 0.3)
+    g.save()
+    g.globalCompositeOperation = "lighter"
+    g.lineWidth = Math.max(1, l.rpx * 2)
+    for (const [dx, tint] of [
+      [-d, `rgba(70, 120, 220, ${a})`],
+      [d, `rgba(220, 150, 70, ${a})`],
+    ] as const) {
+      g.strokeStyle = tint
+      g.strokeRect(l.sky.x + dx, l.sky.y, l.sky.w, l.sky.h)
+    }
+    g.restore()
+  }
+
+  private drawStalled(): void {
+    const g = this.g
+    const l = this.layout
+    g.fillStyle = alpha(STONE, 0.92)
+    g.fillRect(0, 0, l.w, l.h)
+    g.font = sized(FIGURE_FONT, Math.max(13, l.rpx * 26))
+    g.textAlign = "center"
+    g.textBaseline = "middle"
+    g.fillStyle = OXIDE
+    g.fillText("THE REGISTER IS EMPTY", l.w / 2, l.h / 2)
+  }
+
+  /**
+   * The page the observatory writes at the end of a run.
+   *
+   * Not a game-over screen. There is no win state in this game and there is no
+   * loss state either — the watch ended, and what an observatory does when a
+   * watch ends is write down what it saw. The numbers are facts, in ink, on
+   * vellum, and the only thing offered is another night.
+   */
+  private drawLedgerPage(over: {
+    logged: number
+    watches: number
+    longest: number
+    wide: number
+    best: number
+  }): void {
+    const g = this.g
+    const l = this.layout
+    g.fillStyle = "rgba(5, 8, 16, 0.86)"
+    g.fillRect(0, 0, l.w, l.h)
+
+    const pw = Math.min(l.w * 0.82, 460 * Math.max(1, l.rpx * 1.5))
+    const ph = Math.min(l.h * 0.62, 420 * Math.max(1, l.rpx * 1.5))
+    const px = (l.w - pw) / 2
+    const py = (l.h - ph) / 2
+    g.fillStyle = alpha(VELLUM, 0.07)
+    g.fillRect(px, py, pw, ph)
+    g.strokeStyle = alpha(BRASS, 0.85)
+    g.lineWidth = Math.max(1, l.rpx * 2.5)
+    g.strokeRect(px, py, pw, ph)
+
+    const line = ph / 8
+    g.textBaseline = "middle"
+    g.font = sized(FIGURE_FONT, Math.max(12, line * 0.34))
+    g.textAlign = "center"
+    g.fillStyle = BRASS_LIT
+    g.fillText("THE WATCH IS WRITTEN DOWN", l.w / 2, py + line * 0.85)
+
+    const rows: Array<[string, string]> = [
+      ["STARS LOGGED", String(over.logged)],
+      ["WATCHES", String(over.watches)],
+      ["LONGEST CHAIN", String(over.longest)],
+      ["BEST CHAIN", String(over.best)],
+      ["MARKS WIDE", String(over.wide)],
+    ]
+    const size = Math.max(11, line * 0.3)
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i]
+      if (!row) continue
+      const y = py + line * (2.1 + i)
+      g.font = sized(FIGURE_FONT, size)
+      g.textAlign = "left"
+      g.fillStyle = alpha(BRASS_DIM, 0.95)
+      g.fillText(row[0], px + pw * 0.11, y)
+      g.textAlign = "right"
+      g.fillStyle = row[0] === "LONGEST CHAIN" ? STARLIGHT : BRASS_LIT
+      g.font = sized(FIGURE_FONT, size * 1.25)
+      g.fillText(row[1], px + pw * 0.89, y)
+      g.strokeStyle = alpha(LAPIS_LIT, 0.28)
+      g.lineWidth = 1
+      g.beginPath()
+      g.moveTo(px + pw * 0.11, y + line * 0.34)
+      g.lineTo(px + pw * 0.89, y + line * 0.34)
+      g.stroke()
+    }
+
+    g.textAlign = "center"
+    g.font = sized(FIGURE_FONT, size)
+    g.fillStyle = BRASS_LIT
+    g.fillText("TOUCH FOR ANOTHER NIGHT", l.w / 2, py + ph - line * 0.8)
+  }
+}

--- a/dynawalla/games/skyledger/src/render/sky.ts
+++ b/dynawalla/games/skyledger/src/render/sky.ts
@@ -1,0 +1,446 @@
+// THE SKY — the coordinate plane, the stars falling through it, and the lamps
+// on the horizon.
+//
+// The lattice is ruled ONES across and TENS up, ten by ten, with the figures
+// engraved along the two axes. It is the mathematics, drawn as the world:
+// nothing here is a chart laid over a game, the chart *is* the game.
+//
+// **A star is never drawn at its station.** It falls down a lane the game drew
+// from its own generator, and where it is says nothing whatever about what it
+// is worth. The only moment a star and a station meet is the snap, after the
+// child has already named it — and that snap is the whole reveal.
+
+import { alpha, BRASS, BRASS_DEEP, BRASS_DIM, BRASS_LIT, FIGURE_FONT, LAMP_LIT, LAMP_OUT, LAPIS, LAPIS_DIM, LAPIS_LIT, NIGHT, NIGHT_HIGH, OXIDE, PLATE_FONT, sized, STARLIGHT, STARLIGHT_CORE, STONE, STONE_EDGE } from "./palette.ts"
+
+export type Rect = { x: number; y: number; w: number; h: number }
+
+export type Layout = {
+  w: number
+  h: number
+  /** 1 rpx = shortEdge / 1080. Every spatial magnitude in the game is in these. */
+  rpx: number
+  /** True when the instrument sits beside the sky rather than under it. */
+  landscape: boolean
+  /** The whole night column: everything above the horizon. */
+  sky: Rect
+  /** The ruled plane, inside it. */
+  plane: Rect
+  /** Spacing between lattice points. */
+  cell: number
+  /** Where the stars are released from, and where they land. */
+  ceiling: number
+  horizon: number
+  /** The astrolabe. */
+  dial: { cx: number; cy: number; r: number }
+}
+
+const LATTICE = 10
+
+/**
+ * How far past `dial.r` the instrument actually reaches: the plate, the chain
+ * fan on the rim and the sightings column beside it. Everything that budgets
+ * space for the astrolabe budgets this, not the radius, which is how the dial
+ * came to sit on top of the horizon the first time it was drawn.
+ */
+const DIAL_EXTENT = 1.34
+
+/**
+ * The layout, and it is two layouts.
+ *
+ * A tablet held wide and a phone held tall are not the same room. In landscape
+ * the astrolabe stands beside the sky, in portrait it stands under it, and in
+ * both the sky gets everything the instrument does not need. Tablet and desktop
+ * are first-class here; neither is a stretched phone.
+ */
+export function layoutFor(w: number, h: number): Layout {
+  const rpx = Math.min(w, h) / 1080
+  const landscape = w >= h * 1.12
+  const gutter = Math.max(10, Math.min(w, h) * 0.022)
+  // The sky is the game and the instrument is the hand: the astrolabe takes as
+  // little of the room as it can and still be turned with a thumb.
+  const dialR = landscape
+    ? Math.min(h * 0.27, w * 0.17)
+    : Math.min(w * 0.3, h * 0.19, 230 * Math.max(1, rpx * 1.5))
+  const reach = dialR * DIAL_EXTENT
+
+  const dial = landscape
+    ? { cx: w - reach - gutter, cy: h / 2, r: dialR }
+    : { cx: w / 2, cy: h - reach - gutter, r: dialR }
+  const sky: Rect = landscape
+    ? { x: gutter, y: gutter, w: Math.max(60, dial.cx - reach - gutter * 2), h: h - gutter * 2 }
+    : { x: gutter, y: gutter, w: w - gutter * 2, h: Math.max(60, dial.cy - reach - gutter * 2) }
+
+  const ceiling = sky.y
+  const horizon = sky.y + sky.h
+
+  // Room under the plane for the lamps to burn in, and room around it for the
+  // axis figures. A lattice drawn over the lamps is a lattice nobody can read,
+  // and the figures are part of the lattice — reserving for the ticks and not
+  // for the numerals under them is exactly how they came to collide.
+  const lampBand = lampRadius(sky.w, rpx) * 3.6
+  const axisPad = Math.max(18, Math.min(sky.w, sky.h) * 0.06)
+
+  const availW = Math.max(30, sky.w - axisPad * 1.5)
+  // The 9/10.2 is the figures' own row: nine gaps of lattice plus a little over
+  // one more cell of numerals underneath, solved for the cell rather than
+  // guessed at, so the reserve is right at every viewport instead of at one.
+  const availH = Math.max(30, (sky.h - lampBand - axisPad * 0.9) * (9 / 10.2))
+  const cell = Math.max(5, Math.min(availW, availH) / (LATTICE - 1))
+  const span = cell * (LATTICE - 1)
+
+  const plane: Rect = {
+    x: sky.x + axisPad + (availW - span) / 2,
+    y: ceiling + axisPad * 0.9 + (availH - span) / 2,
+    w: span,
+    h: span,
+  }
+
+  return { w, h, rpx, landscape, sky, plane, cell, ceiling, horizon, dial }
+}
+
+/** Where the lattice point (x ones, y tens) is on the glass. Tens climb. */
+export function stationPoint(l: Layout, x: number, y: number): { px: number; py: number } {
+  return { px: l.plane.x + x * l.cell, py: l.plane.y + l.plane.h - y * l.cell }
+}
+
+/** Where a star is: its lane across, its fall down. Nothing to do with its worth. */
+export function starPoint(l: Layout, lane: number, t: number): { px: number; py: number } {
+  const inset = Math.min(l.cell * 0.55, l.sky.w * 0.07)
+  // Room at the top for a ledger plate to be read before the star has moved.
+  const top = l.ceiling + Math.min(l.cell * 1.1, l.sky.h * 0.1)
+  const left = l.sky.x + inset
+  const right = l.sky.x + l.sky.w - inset
+  return { px: left + (right - left) * lane, py: top + (l.horizon - top) * t }
+}
+
+/**
+ * A lamp's radius, from the width it has to stand in.
+ *
+ * Deliberately independent of *how many* lamps there are: the layout has to
+ * reserve room for them before it knows anything about the rules, and a reserve
+ * that depended on a game constant would be a circular one.
+ */
+function lampRadius(skyW: number, rpx: number): number {
+  return Math.max(4, Math.min(skyW / 26, 16 * Math.max(1, rpx * 1.6)))
+}
+
+/**
+ * Where the lamps stand: their radius, and the highest pixel any of them
+ * reaches.
+ *
+ * Exported because it is a *constraint*, not a detail — the ruled plane has to
+ * stop above it, and `src/test/layout.test.ts` checks that it does at every
+ * viewport rather than at the one somebody happened to have open.
+ */
+export function lampGeometry(l: Layout): { r: number; top: number } {
+  const r = lampRadius(l.sky.w, l.rpx)
+  return { r, top: l.horizon - r * 3.4 }
+}
+
+/** How far the astrolabe actually reaches from its centre, plate and rim and all. */
+export function dialReach(l: Layout): number {
+  return l.dial.r * DIAL_EXTENT
+}
+
+// ── the ground ──────────────────────────────────────────────────────────────
+
+export function drawNight(g: CanvasRenderingContext2D, l: Layout): void {
+  g.fillStyle = NIGHT
+  g.fillRect(0, 0, l.w, l.h)
+  // The aperture: the night the observatory is actually looking through. A
+  // hard-edged opening cut in stone, not a gradient wash.
+  g.fillStyle = NIGHT_HIGH
+  g.fillRect(l.sky.x, l.sky.y, l.sky.w, l.sky.h)
+  g.strokeStyle = alpha(LAPIS_DIM, 0.9)
+  g.lineWidth = Math.max(1, l.rpx * 2)
+  g.strokeRect(l.sky.x, l.sky.y, l.sky.w, l.sky.h)
+}
+
+/**
+ * The ruled plane, with the axis figures.
+ *
+ * `logged` are the stations this observatory has already written down; they
+ * stay written for the whole sitting. Construction never regresses — the ledger
+ * only ever fills in.
+ */
+export function drawLattice(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  logged: ReadonlySet<number>,
+  aim: { x: number; y: number },
+  glow: number,
+): void {
+  const tick = Math.max(2, l.cell * 0.11)
+  g.lineWidth = Math.max(1, l.rpx * 1.6)
+
+  for (let y = 0; y < LATTICE; y++) {
+    for (let x = 0; x < LATTICE; x++) {
+      const { px, py } = stationPoint(l, x, y)
+      const onAxis = x === aim.x || y === aim.y
+      g.strokeStyle = onAxis ? alpha(LAPIS_LIT, 0.5) : alpha(LAPIS, 0.42)
+      g.beginPath()
+      g.moveTo(px - tick, py)
+      g.lineTo(px + tick, py)
+      g.moveTo(px, py - tick)
+      g.lineTo(px, py + tick)
+      g.stroke()
+
+      if (logged.has(y * 10 + x)) {
+        // A station the child has taken. Brass, filled, permanent.
+        g.fillStyle = alpha(BRASS_DIM, 0.85)
+        const s = Math.max(2, l.cell * 0.09)
+        g.fillRect(px - s, py - s, s * 2, s * 2)
+      }
+    }
+  }
+
+  // The cross-hair the rings are standing at. This is the child's own reading
+  // drawn on the sky — the one thing on the plane that answers to the dial.
+  const { px, py } = stationPoint(l, aim.x, aim.y)
+  g.strokeStyle = alpha(BRASS_LIT, 0.55 + 0.45 * glow)
+  g.lineWidth = Math.max(1, l.rpx * 2.4)
+  g.beginPath()
+  g.moveTo(l.plane.x - l.cell * 0.5, py)
+  g.lineTo(l.plane.x + l.plane.w + l.cell * 0.5, py)
+  g.moveTo(px, l.plane.y - l.cell * 0.5)
+  g.lineTo(px, l.plane.y + l.plane.h + l.cell * 0.5)
+  g.stroke()
+
+  const r = l.cell * (0.3 + 0.06 * glow)
+  g.strokeStyle = alpha(BRASS_LIT, 0.9)
+  g.beginPath()
+  g.arc(px, py, r, 0, Math.PI * 2)
+  g.stroke()
+
+  // The figures. Ones along the foot, tens up the left edge.
+  const size = Math.max(9, Math.min(l.cell * 0.34, 20 * Math.max(1, l.rpx * 1.4)))
+  g.font = sized(FIGURE_FONT, size)
+  g.textAlign = "center"
+  g.textBaseline = "top"
+  for (let x = 0; x < LATTICE; x++) {
+    const p = stationPoint(l, x, 0)
+    g.fillStyle = x === aim.x ? BRASS_LIT : alpha(BRASS_DIM, 0.85)
+    g.fillText(String(x), p.px, l.plane.y + l.plane.h + l.cell * 0.28)
+  }
+  g.textAlign = "right"
+  g.textBaseline = "middle"
+  for (let y = 0; y < LATTICE; y++) {
+    const p = stationPoint(l, 0, y)
+    g.fillStyle = y === aim.y ? BRASS_LIT : alpha(BRASS_DIM, 0.85)
+    g.fillText(String(y), l.plane.x - l.cell * 0.34, p.py)
+  }
+
+  // What the axes are. Engraved once, quietly, and never explained again.
+  g.font = sized(FIGURE_FONT, size * 0.7)
+  g.textAlign = "right"
+  g.textBaseline = "top"
+  g.fillStyle = alpha(LAPIS_LIT, 0.8)
+  g.fillText("ONES", l.plane.x + l.plane.w, l.plane.y + l.plane.h + l.cell * 0.66)
+  g.save()
+  g.translate(l.plane.x - l.cell * 0.72, l.plane.y)
+  g.rotate(-Math.PI / 2)
+  g.textAlign = "left"
+  g.fillText("TENS", 0, 0)
+  g.restore()
+}
+
+// ── the stars ───────────────────────────────────────────────────────────────
+
+export type StarView = {
+  id: number
+  lane: number
+  t: number
+  order: number
+  prompt: string
+  sighted: boolean
+  visible: boolean
+}
+
+export function drawStar(g: CanvasRenderingContext2D, l: Layout, s: StarView, breath: number): void {
+  if (!s.visible) return
+  const { px, py } = starPoint(l, s.lane, s.t)
+  const r = Math.max(3.5, l.cell * 0.13)
+
+  // The trail: where it has been, thinning upward. Missile Command's whole
+  // silhouette is the trail, not the warhead.
+  const from = starPoint(l, s.lane, 0)
+  g.strokeStyle = alpha(s.sighted ? STARLIGHT : LAPIS_LIT, s.sighted ? 0.5 : 0.28)
+  g.lineWidth = Math.max(1, l.rpx * (s.sighted ? 2.6 : 1.7))
+  g.beginPath()
+  g.moveTo(from.px, from.py)
+  g.lineTo(px, py)
+  g.stroke()
+
+  g.fillStyle = s.sighted ? STARLIGHT_CORE : STARLIGHT
+  g.beginPath()
+  g.arc(px, py, r * (s.sighted ? 1.15 + 0.08 * breath : 1), 0, Math.PI * 2)
+  g.fill()
+
+  // The ledger plate: the line the child has to work, and the great columns the
+  // register has already ruled in.
+  const size = Math.max(10, Math.min(l.cell * 0.32, 22 * Math.max(1, l.rpx * 1.3)))
+  g.font = sized(PLATE_FONT, size)
+  g.textBaseline = "middle"
+  const flip = px > l.sky.x + l.sky.w * 0.62
+  g.textAlign = flip ? "right" : "left"
+  const tx = px + (flip ? -r * 2.4 : r * 2.4)
+  // Staggered by identity, so two stars that happen to be at the same height
+  // do not print their ledger lines on top of each other.
+  const ty = py + ((s.id % 3) - 1) * size * 1.25
+
+  g.fillStyle = s.sighted ? BRASS_LIT : alpha(BRASS, 0.7)
+  g.fillText(s.prompt, tx, ty)
+
+  if (s.order > 0) {
+    // Pre-inked: the hundreds and above are already in the register, and they
+    // are drawn as ink rather than as light so they read as *record*, not as
+    // something the child is being told.
+    g.font = sized(FIGURE_FONT, size * 0.86)
+    g.fillStyle = alpha(BRASS_DIM, 0.9)
+    g.fillText(`${s.order}▫▫`, tx, ty + size * 1.05)
+  }
+
+  if (s.sighted) {
+    // The reticle. A surveyor's bracket, not a video-game crosshair.
+    const b = r * 2.6
+    g.strokeStyle = alpha(STARLIGHT, 0.85)
+    g.lineWidth = Math.max(1, l.rpx * 2)
+    for (const [sx, sy] of [
+      [-1, -1],
+      [1, -1],
+      [-1, 1],
+      [1, 1],
+    ] as const) {
+      g.beginPath()
+      g.moveTo(px + sx * b, py + sy * b * 0.55)
+      g.lineTo(px + sx * b, py + sy * b)
+      g.lineTo(px + sx * b * 0.55, py + sy * b)
+      g.stroke()
+    }
+  }
+}
+
+// ── the horizon ─────────────────────────────────────────────────────────────
+
+export function drawHorizon(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  lamps: number,
+  total: number,
+  flicker: number,
+): void {
+  const y = l.horizon
+  const { r } = lampGeometry(l)
+  // A plinth, not a floor: the observatory's parapet, the width of the sky it
+  // is watching. It must not run under the astrolabe, which stands on its own.
+  const plinth = Math.max(6, l.rpx * 14)
+  g.fillStyle = STONE
+  g.fillRect(l.sky.x, y, l.sky.w, plinth)
+  g.strokeStyle = STONE_EDGE
+  g.lineWidth = Math.max(1, l.rpx * 2)
+  g.beginPath()
+  g.moveTo(l.sky.x, y)
+  g.lineTo(l.sky.x + l.sky.w, y)
+  g.stroke()
+
+  const span = l.sky.w / (total + 1)
+  for (let i = 0; i < total; i++) {
+    const px = l.sky.x + span * (i + 1)
+    const lit = i < lamps
+    // The socket, always. A snuffed lamp is a dark socket, not an absence: the
+    // observatory is not damaged, it is unlit, and it can be relit.
+    g.strokeStyle = alpha(BRASS_DEEP, 0.9)
+    g.lineWidth = Math.max(1, l.rpx * 2)
+    g.beginPath()
+    g.moveTo(px, y)
+    g.lineTo(px, y - r * 1.9)
+    g.stroke()
+
+    g.fillStyle = lit ? LAMP_LIT : LAMP_OUT
+    g.beginPath()
+    g.arc(px, y - r * 2.4, r * (lit ? 1 + 0.05 * flicker : 0.8), 0, Math.PI * 2)
+    g.fill()
+    if (lit) {
+      g.strokeStyle = alpha(LAMP_LIT, 0.28)
+      g.lineWidth = Math.max(1, l.rpx * 3)
+      g.beginPath()
+      g.arc(px, y - r * 2.4, r * 1.9, 0, Math.PI * 2)
+      g.stroke()
+    }
+  }
+}
+
+// ── blooms and snaps ────────────────────────────────────────────────────────
+
+export type Bloom = {
+  /** Where the star was when it was named. */
+  fromX: number
+  fromY: number
+  /** The station it belongs to. */
+  toX: number
+  toY: number
+  age: number
+  life: number
+  /** 0..1, how hard this link was pushed. */
+  weight: number
+  link: number
+  cold: boolean
+}
+
+export function drawBloom(g: CanvasRenderingContext2D, l: Layout, b: Bloom, reduced: boolean): void {
+  const t = Math.min(1, b.age / b.life)
+  if (t >= 1) return
+  const tint = b.cold ? OXIDE : STARLIGHT
+
+  if (reduced) {
+    // The branch: no travel, no expansion. The station cross-fades up and back
+    // down, and the link is legible from the ring on the astrolabe.
+    const a = t < 0.35 ? t / 0.35 : 1 - (t - 0.35) / 0.65
+    g.fillStyle = alpha(tint, 0.55 * a)
+    const s = l.cell * 0.34
+    g.fillRect(b.toX - s, b.toY - s, s * 2, s * 2)
+    return
+  }
+
+  // The snap: fast out, faster in, dead stop. The line is the measurement.
+  const travel = Math.min(1, t / 0.22)
+  const ease = travel * travel * (3 - 2 * travel)
+  const hx = b.fromX + (b.toX - b.fromX) * ease
+  const hy = b.fromY + (b.toY - b.fromY) * ease
+  if (travel < 1 && !b.cold) {
+    g.strokeStyle = alpha(tint, 0.8 * (1 - travel))
+    g.lineWidth = Math.max(1, l.rpx * 3)
+    g.beginPath()
+    g.moveTo(b.fromX, b.fromY)
+    g.lineTo(hx, hy)
+    g.stroke()
+    g.fillStyle = STARLIGHT_CORE
+    g.beginPath()
+    g.arc(hx, hy, Math.max(2, l.cell * 0.1), 0, Math.PI * 2)
+    g.fill()
+    return
+  }
+
+  const bloom = Math.min(1, (t - 0.22) / 0.78)
+  const r = l.cell * (0.2 + (0.55 + 0.65 * b.weight) * (1 - Math.pow(1 - bloom, 3)))
+  const fade = 1 - bloom
+  g.strokeStyle = alpha(tint, (b.cold ? 0.35 : 0.9) * fade)
+  g.lineWidth = Math.max(1, l.rpx * (b.cold ? 2 : 3 + 3 * b.weight))
+  g.beginPath()
+  g.arc(b.toX, b.toY, r, 0, Math.PI * 2)
+  g.stroke()
+  if (!b.cold) {
+    g.fillStyle = alpha(tint, 0.3 * fade * fade)
+    g.beginPath()
+    g.arc(b.toX, b.toY, r * 0.72, 0, Math.PI * 2)
+    g.fill()
+    // The link number, once, in the middle of its own bloom.
+    if (b.link > 1) {
+      g.font = sized(FIGURE_FONT, Math.max(11, l.cell * 0.36))
+      g.textAlign = "center"
+      g.textBaseline = "middle"
+      g.fillStyle = alpha(BRASS_LIT, fade)
+      g.fillText(`×${b.link}`, b.toX, b.toY - l.cell * 0.62)
+    }
+  }
+}

--- a/dynawalla/games/skyledger/src/stubHost.ts
+++ b/dynawalla/games/skyledger/src/stubHost.ts
@@ -1,0 +1,202 @@
+// A local stub Host so the observatory is playable standalone with `npm run
+// dev`. It stands in for the runtime; it is not the runtime.
+//
+// Three properties the real host also honours, each asserted by
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison — a
+//      station is a pair of digits and a digit cannot be 0.30000000000000004.
+//   2. **Seeded and deterministic.** Same seed → same watch, forever.
+//   3. **Distractors are real mal-rule outputs** — what a child with a specific
+//      broken procedure actually writes down, not `answer ± 1` noise. In this
+//      game a mal-rule is mechanically load-bearing: a mark that lands on one
+//      costs no sighting, because the register recognises the mistake.
+//
+// The operations are addition and subtraction of whole numbers in columns,
+// because those are the seven rows of the `add` domain that are `active`. The
+// stub does not pretend to be a curriculum; it draws from the same shapes.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Op = "add" | "sub"
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += (((x % 10) + (y % 10)) % 10) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/**
+ * The short addend written flush left instead of flush right: `247 + 8` set
+ * down as `247 + 800`. The misconception `dw.add.regroup.add-short-addend`
+ * exists to catch exactly this, so it belongs in the pool whenever the two
+ * operands are of different lengths.
+ */
+function misalignShortAddend(a: number, b: number): number {
+  const la = String(a).length
+  const lb = String(b).length
+  if (la === lb) return a + b
+  const [long, short, gap] = la > lb ? [a, b, la - lb] : [b, a, lb - la]
+  return long + short * 10 ** gap
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2 − 7| in the ones column. */
+function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** Borrowed across a zero without decrementing the column past it: 300 − 8 → 302. */
+function borrowAcrossZero(a: number, b: number): number {
+  const digits = String(a).split("").map(Number)
+  const from = String(b).split("").map(Number)
+  let out = 0
+  let place = 1
+  for (let i = 0; i < digits.length; i++) {
+    const da = digits[digits.length - 1 - i] ?? 0
+    const db = from[from.length - 1 - i] ?? 0
+    // Takes the ten but never pays for it, so the column above is untouched.
+    const d = da >= db ? da - db : da + 10 - db
+    out += d * place
+    place *= 10
+  }
+  return out
+}
+
+function malRulesFor(op: Op, a: number, b: number, answer: number): number[] {
+  return op === "add"
+    ? [
+        addNoCarry(a, b), // MIS_CARRY_DROPPED
+        misalignShortAddend(a, b), // the short addend set down flush left
+        answer - 10, // carried and never added the carry in
+        answer + 10, // carried twice
+        Math.abs(a - b), // reached for the wrong operation
+      ]
+    : [
+        subSmallerFromLarger(a, b), // MIS_SMALLER_FROM_LARGER
+        borrowAcrossZero(a, b), // MIS_BORROW_ACROSS_ZERO
+        answer + 10, // borrowed without decrementing the next column
+        answer - 10, // decremented twice
+        a + b, // wrong operation
+      ]
+}
+
+/**
+ * Operands shaped like the `add` domain's level tables: two, three and four
+ * digit column work, regrouping arriving with difficulty.
+ */
+function operandsFor(op: Op, difficulty: number, rng: Rng): [number, number] {
+  // `difficulty` is the host's 0..1 reading of the ladder. Four bands, so the
+  // stub walks the same 2 → 4 digit progression the real level tables do.
+  const band = Math.max(0, Math.min(3, Math.floor(difficulty * 4)))
+  const lo = [10, 10, 100, 1000][band] as number
+  const hi = [99, 99, 999, 9999][band] as number
+  if (op === "add") {
+    const a = rng.int(lo, hi)
+    const b = band === 0 ? rng.int(2, 9) : rng.int(lo, hi)
+    return [a, b]
+  }
+  const a = rng.int(lo + 1, hi)
+  const b = band === 0 ? rng.int(2, 9) : rng.int(lo, a - 1)
+  return [a, b]
+}
+
+const GLYPH: Record<Op, string> = { add: "+", sub: "−" }
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Observe reports — the dev harness draws a running accuracy readout from this. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness can show they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+  /** Observe stopping points, which a real host may put a sheet on. */
+  onTransition?: (kind: string, label?: string) => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x5c91ed)
+  let n = 0
+
+  return {
+    next(o) {
+      const difficulty = Math.max(0, Math.min(1, o?.difficulty ?? 0.35))
+      const op: Op = rng.chance(0.5) ? "add" : "sub"
+      const [a, b] = operandsFor(op, difficulty, rng)
+      const answer = op === "add" ? a + b : a - b
+
+      // Mal-rule outputs, deduped, filtered to values this sky can hold: a
+      // whole number of at most six digits that is not the answer itself.
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(op, a, b, answer)) {
+        if (!Number.isInteger(v) || v < 0 || v > 999999 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      n++
+      return {
+        id: `stub-${n}`,
+        prompt: `${a} ${GLYPH[op]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain: "add",
+        difficulty,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet,
+        // or a policy block) must never take the frame down with it.
+        console.warn("[skyledger] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+
+    transition(kind, label) {
+      opts.onTransition?.(kind, label)
+    },
+  }
+}

--- a/dynawalla/games/skyledger/src/test/escalation.test.ts
+++ b/dynawalla/games/skyledger/src/test/escalation.test.ts
@@ -1,0 +1,188 @@
+// THE CHAIN.
+//
+// Per-link escalation with named caps, and a hard snap-back. This is the piece
+// of the design the canon singles out, so it is the piece with the most
+// assertions: that every channel really does rise per link, that every one of
+// them really does stop at the number it is named for, and that when the chain
+// ends the whole apparatus is at rest *in one step* rather than sagging back
+// over half a second.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  BLOOM_BASE,
+  BLOOM_CAP,
+  CHAIN_CAP,
+  CHAIN_WINDOW_MS,
+  CHROMA_CAP_RPX,
+  Escalation,
+  HITSTOP_BASE_MS,
+  HITSTOP_CAP_MS,
+  HITSTOP_POOL_MS,
+  REST,
+  TIMESCALE_FLOOR,
+  channelsAt,
+} from "../game/escalation.ts"
+
+test("every channel escalates per link, and none of them ever moves backwards", () => {
+  let previous = channelsAt(1, false)
+  assert.equal(previous.hitstopMs, HITSTOP_BASE_MS)
+  assert.equal(previous.bloom, BLOOM_BASE)
+  assert.equal(previous.timescale, 1)
+
+  for (let links = 2; links <= CHAIN_CAP; links++) {
+    const c = channelsAt(links, false)
+    assert.ok(c.hitstopMs >= previous.hitstopMs, `hitstop fell at link ${links}`)
+    assert.ok(c.bloom >= previous.bloom, `bloom fell at link ${links}`)
+    assert.ok(c.chromaRpx >= previous.chromaRpx, `chroma fell at link ${links}`)
+    assert.ok(c.timescale <= previous.timescale, `timescale rose at link ${links}`)
+    previous = c
+  }
+
+  // And it really did climb, rather than sitting flat and passing a monotone
+  // check by never moving.
+  const one = channelsAt(1, false)
+  const cap = channelsAt(CHAIN_CAP, false)
+  assert.ok(cap.hitstopMs > one.hitstopMs)
+  assert.ok(cap.bloom > one.bloom)
+  assert.ok(cap.chromaRpx > one.chromaRpx)
+  assert.ok(cap.timescale < one.timescale)
+})
+
+test("the caps are hard, and they are the numbers they are named for", () => {
+  for (const links of [CHAIN_CAP, CHAIN_CAP + 1, 50, 5000]) {
+    const c = channelsAt(links, false)
+    assert.ok(c.hitstopMs <= HITSTOP_CAP_MS, `hitstop broke its cap at ${links} links`)
+    assert.ok(c.bloom <= BLOOM_CAP, `bloom broke its cap at ${links} links`)
+    assert.ok(c.chromaRpx <= CHROMA_CAP_RPX, `chroma broke its cap at ${links} links`)
+    assert.ok(c.timescale >= TIMESCALE_FLOOR, `timescale broke its floor at ${links} links`)
+  }
+  // Pinned, not merely bounded: past the cap nothing moves at all.
+  assert.deepEqual(channelsAt(CHAIN_CAP + 7, false), channelsAt(CHAIN_CAP, false))
+})
+
+test("a chain of nine reaches the cap on every channel, and no earlier", () => {
+  const capped = channelsAt(CHAIN_CAP, false)
+  assert.equal(capped.hitstopMs, HITSTOP_CAP_MS)
+  assert.equal(capped.bloom, BLOOM_CAP)
+  assert.equal(capped.chromaRpx, CHROMA_CAP_RPX)
+  assert.equal(capped.timescale, TIMESCALE_FLOOR)
+})
+
+test("the snap-back is one step: after a release nothing is left leaning", () => {
+  const chain = new Escalation(false)
+  let now = 0
+  for (let i = 0; i < 5; i++) chain.link((now += 300))
+  assert.equal(chain.links, 5)
+  const hot = chain.channels
+  assert.ok(hot.bloom > 0 && hot.timescale < 1 && hot.chromaRpx > 0)
+
+  const release = chain.cut()
+  assert.ok(release)
+  assert.equal(release.links, 5)
+  assert.equal(release.broken, true)
+
+  // Rest. Not "approaching rest", not "decaying to rest" — rest, on the very
+  // next read, so a mark on the next frame starts from nothing.
+  assert.deepEqual(chain.channels, REST)
+  assert.equal(chain.links, 0)
+  assert.equal(chain.alive, false)
+  assert.equal(chain.fuse(now), 0)
+})
+
+test("the chain dies when the light fades, and the release carries what was banked", () => {
+  const chain = new Escalation(false)
+  chain.link(1000)
+  chain.link(1200)
+  chain.link(1400)
+
+  assert.equal(chain.expire(1400 + CHAIN_WINDOW_MS - 1), null, "the chain died early")
+  assert.equal(chain.links, 3)
+
+  const release = chain.expire(1400 + CHAIN_WINDOW_MS)
+  assert.ok(release)
+  assert.equal(release.links, 3)
+  assert.equal(release.broken, false, "a chain that ran out of light was called broken")
+  assert.deepEqual(chain.channels, REST)
+
+  // And a second expire finds nothing: a release fires exactly once.
+  assert.equal(chain.expire(9_000_000), null)
+})
+
+test("each link renews the window; the chain is a tempo, not a countdown", () => {
+  const chain = new Escalation(false)
+  chain.link(0)
+  chain.link(CHAIN_WINDOW_MS - 100)
+  // Without renewal the chain would be dead by now.
+  assert.equal(chain.expire(CHAIN_WINDOW_MS + 100), null)
+  assert.equal(chain.links, 2)
+  assert.ok(chain.remainingMs(CHAIN_WINDOW_MS + 100) > 0)
+})
+
+test("a release with nothing in it is never emitted", () => {
+  const chain = new Escalation(false)
+  assert.equal(chain.cut(), null)
+  assert.equal(chain.expire(1_000_000), null)
+  assert.equal(chain.links, 0)
+})
+
+test("the longest chain is remembered across releases", () => {
+  const chain = new Escalation(false)
+  for (let i = 0; i < 4; i++) chain.link(i * 100)
+  chain.cut()
+  chain.link(9000)
+  assert.equal(chain.longest, 4)
+  assert.equal(chain.links, 1)
+})
+
+test("hitstop is pooled, so a multi-catch stays fluid instead of stuttering", () => {
+  const chain = new Escalation(false)
+  // Five stars taken by one mark, all inside a single frame.
+  let spent = 0
+  for (let i = 0; i < 5; i++) spent += chain.link(1000).hitstopMs
+  assert.ok(
+    spent <= HITSTOP_POOL_MS,
+    `a multi-catch froze the world for ${spent}ms, past the ${HITSTOP_POOL_MS}ms pool`,
+  )
+  assert.ok(spent > 0, "a multi-catch had no weight at all")
+})
+
+test("the pool refills, so a chain paced over seconds is not starved", () => {
+  const chain = new Escalation(false)
+  const first = chain.link(0).hitstopMs
+  assert.ok(first > 0)
+  // A second link a full window later gets its own budget.
+  const later = chain.link(1000).hitstopMs
+  assert.ok(later > 0, "the pool never let go of the first link's spend")
+})
+
+test("reduced motion is a branch, and the link count survives it", () => {
+  for (let links = 1; links <= CHAIN_CAP + 3; links++) {
+    const c = channelsAt(links, true)
+    assert.equal(c.hitstopMs, 0, "reduced motion froze the world")
+    assert.equal(c.timescale, 1, "reduced motion slowed the world")
+    assert.equal(c.chromaRpx, 0, "reduced motion split the colour")
+  }
+
+  // The information is re-routed, not deleted: the chain still counts, and the
+  // count is what the astrolabe's rim draws.
+  const chain = new Escalation(true)
+  let now = 0
+  for (let i = 0; i < 6; i++) chain.link((now += 200))
+  assert.equal(chain.links, 6)
+  assert.equal(chain.longest, 6)
+  assert.ok(chain.fuse(now) > 0)
+  const release = chain.cut()
+  assert.equal(release?.links, 6)
+})
+
+test("a paused chain does not bleed out behind the host's sheet", () => {
+  const chain = new Escalation(false)
+  chain.link(1000)
+  // Thirty seconds behind a sheet, then a tenth of a second of real time.
+  chain.shift(30_000)
+  assert.equal(chain.expire(31_100), null, "the sheet ate the chain")
+  assert.equal(chain.links, 1)
+  assert.equal(chain.expire(1000 + CHAIN_WINDOW_MS + 30_000)?.links, 1)
+})

--- a/dynawalla/games/skyledger/src/test/game.test.ts
+++ b/dynawalla/games/skyledger/src/test/game.test.ts
@@ -1,0 +1,321 @@
+// THE WATCH — the rules of the observatory.
+//
+// Every seed in this file is written down. A test that reaches for
+// `Math.random` is a test that fails one run in five on somebody else's
+// machine, and the reproduction has to be in the failure message.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { CHAIN_WINDOW_MS } from "../game/escalation.ts"
+import { LAMPS, REFILL_MS, SIGHTINGS } from "../game/game.ts"
+import { valueAt } from "../game/station.ts"
+import { aimAt, dialTo, falling, raise, rig, truthOf } from "./harness.ts"
+
+test("a watch opens with stars falling and one of them already under the sight", () => {
+  const { game } = rig(0x0b5e21)
+  assert.equal(game.watch, 1)
+  assert.equal(game.lamps, LAMPS)
+  assert.ok(game.stars.length >= 2)
+  raise(game)
+  assert.ok(game.sighted, "nothing was under the sight when the watch opened")
+  assert.ok(falling(game).length >= 2, "the sky never filled")
+  assert.equal(game.isOver, false)
+  assert.equal(game.stalled, false)
+})
+
+test("a mark on the true station blooms, and it is the only pair on the lattice that does", () => {
+  const { game, reports } = rig(0x1a7c)
+  const t = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const { value, station } = truthOf(star)
+
+  // Every other pair on the lattice, first. All ninety-nine of them are wrong,
+  // and every one is reported as a number the host can diagnose.
+  let now = t
+  for (let y = 0; y < 10; y++) {
+    for (let x = 0; x < 10; x++) {
+      if (x === station.x && y === station.y) continue
+      const before = reports.length
+      dialTo(game, { x, y })
+      game.mark((now += 5))
+      const report = reports[before]
+      if (!report) continue // the astrolabe ran dry; the refusal has its own test
+      assert.equal(report.correct, false, `(${x}, ${y}) was taken for ${value}`)
+      assert.equal(report.answered, String(valueAt(star.order, { x, y })))
+      assert.notEqual(Number(report.answered), value)
+    }
+  }
+
+  // Now the true one. Same star, same rings, one pair apart.
+  assert.equal(game.sighted?.id, star.id, "the star was lost while the lattice was swept")
+  dialTo(game, station)
+  const events = game.mark((now += 5))
+  assert.ok(
+    events.some((e) => e.kind === "bloom"),
+    "the true station did not bloom",
+  )
+  assert.equal(star.state, "caught")
+  const last = reports.at(-1)
+  assert.equal(last?.correct, true)
+  assert.equal(last?.answered, String(value))
+})
+
+test("what crosses to the host is the number the child produced, exactly", () => {
+  const { game, reports } = rig(0x33f0)
+  const t = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  dialTo(game, { x: 3, y: 4 })
+  game.mark(t + 10)
+  assert.equal(reports[0]?.answered, String(valueAt(star.order, { x: 3, y: 4 })))
+  assert.ok(/^\d+$/.test(reports[0]?.answered ?? ""), "a non-integer reached the host")
+  assert.equal(reports[0]?.questionId, star.item.id)
+})
+
+test("the chain escalates per link and snaps back when the light fades", () => {
+  const { game } = rig(0x9c4a1)
+  let now = raise(game)
+
+  let links = 0
+  let peak = 0
+  for (let i = 0; i < 12; i++) {
+    const star = game.sighted
+    if (!star) break
+    aimAt(game, star)
+    for (const e of game.mark((now += 120))) {
+      if (e.kind !== "bloom") continue
+      links += 1
+      assert.equal(e.link, links, "a link landed out of order")
+      assert.ok(e.channels.bloom >= peak, "the chain got quieter as it got longer")
+      peak = e.channels.bloom
+    }
+  }
+  assert.ok(links >= 3, `only ${links} links — the sky was too small to chain`)
+  assert.equal(game.links, links)
+  assert.ok(game.channels.bloom > 0 && game.channels.timescale < 1)
+
+  // The light fades. One release, carrying the whole chain, and the channels
+  // are at rest immediately afterwards rather than sagging back over half a
+  // second: the hard snap-back.
+  const after = game.tick(16, now + CHAIN_WINDOW_MS + 1)
+  const release = after.find((e) => e.kind === "release")
+  assert.ok(release, "the chain never let go")
+  assert.equal(release.release.links, links)
+  assert.equal(release.release.broken, false)
+  assert.equal(game.links, 0)
+  assert.deepEqual(game.channels, { hitstopMs: 0, bloom: 0, chromaRpx: 0, timescale: 1 })
+  assert.equal(game.ledger.longest, links)
+})
+
+test("a wrong mark cuts the chain on the spot", () => {
+  const { game } = rig(0x5011)
+  let now = raise(game)
+  const first = game.sighted
+  assert.ok(first)
+  aimAt(game, first)
+  game.mark((now += 100))
+  assert.equal(game.links, 1)
+
+  const second = game.sighted
+  assert.ok(second)
+  const truth = truthOf(second).station
+  dialTo(game, { x: (truth.x + 3) % 10, y: (truth.y + 5) % 10 })
+  const events = game.mark((now += 100))
+  assert.ok(events.some((e) => e.kind === "wide"))
+  const release = events.find((e) => e.kind === "release")
+  assert.ok(release, "a wrong mark did not cut the chain")
+  assert.equal(release.release.broken, true)
+  assert.equal(release.release.links, 1)
+  assert.equal(game.links, 0)
+  assert.deepEqual(game.channels, { hitstopMs: 0, bloom: 0, chromaRpx: 0, timescale: 1 })
+})
+
+test("one true mark takes every star worth the same number", () => {
+  // Constructed rather than drawn: two stars have to agree, and waiting for a
+  // seed where they happen to is how a test becomes flaky.
+  const { game, reports } = rig(0x7e11)
+  const t = raise(game)
+  const sky = falling(game)
+  const a = sky[0]
+  const b = sky[1]
+  assert.ok(a && b)
+  // `answer` is the host's word and the game only ever reads it; making two
+  // stars agree here is the same as the host drawing two items with one answer.
+  b.item.answer = a.item.answer
+
+  game.sight(a.id)
+  dialTo(game, truthOf(a).station)
+  const bloomed = game.mark(t + 10).filter((e) => e.kind === "bloom")
+  assert.ok(bloomed.length >= 2, "the second star worth the same number was left falling")
+  assert.equal(a.state, "caught")
+  assert.equal(b.state, "caught")
+
+  // Both are reported, each under its own id, and neither with a made-up value.
+  const ids = reports.map((r) => r.questionId)
+  assert.ok(ids.includes(a.item.id) && ids.includes(b.item.id))
+  for (const r of reports) {
+    assert.equal(r.correct, true)
+    assert.equal(r.answered, a.item.answer)
+    assert.ok(r.ms >= 0)
+  }
+})
+
+test("being right costs nothing; a wild guess costs a sighting", () => {
+  const { game } = rig(0x2c0d)
+  let now = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  aimAt(game, star)
+  game.mark((now += 50))
+  assert.equal(game.sightings, SIGHTINGS, "a correct mark spent a sighting")
+
+  const next = game.sighted
+  assert.ok(next)
+  const truth = truthOf(next)
+  // Somewhere that is neither the answer nor a mal-rule anybody has named.
+  let guess = { x: (truth.station.x + 5) % 10, y: (truth.station.y + 5) % 10 }
+  for (let i = 0; i < 12; i++) {
+    const value = valueAt(next.order, guess)
+    if (value !== truth.value && !next.item.distractors.includes(String(value))) break
+    guess = { x: (guess.x + 1) % 10, y: guess.y }
+  }
+  dialTo(game, guess)
+  game.mark((now += 50))
+  assert.equal(game.sightings, SIGHTINGS - 1, "a wild guess was free")
+})
+
+test("a mark on a mal-rule the host named is a recognised slip and costs nothing", () => {
+  // Constructed, again: the point is the rule, not whether a given draw happens
+  // to have a mal-rule inside the same hundred.
+  const { game, reports } = rig(0x4415)
+  const t = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const truth = truthOf(star)
+  const slip = truth.value >= 10 ? truth.value - 10 : truth.value + 10
+  star.item.distractors = [String(slip)]
+
+  dialTo(game, { x: slip % 10, y: Math.floor(slip / 10) % 10 })
+  game.mark(t + 10)
+  assert.equal(game.sightings, SIGHTINGS, "a recognised slip cost a sighting")
+  const report = reports.at(-1)
+  assert.equal(report?.correct, false, "a recognised slip was reported as correct")
+  assert.equal(report?.answered, String(slip), "the slip was not reported as itself")
+})
+
+test("a dry astrolabe refuses rather than reporting, and refills on a clock", () => {
+  const { game, reports } = rig(0x60dd)
+  let now = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const truth = truthOf(star)
+
+  let spent = 0
+  for (let y = 0; y < 10 && game.sightings > 0; y++) {
+    for (let x = 0; x < 10 && game.sightings > 0; x++) {
+      const value = valueAt(star.order, { x, y })
+      if (value === truth.value || star.item.distractors.includes(String(value))) continue
+      dialTo(game, { x, y })
+      const before = game.sightings
+      game.mark((now += 5))
+      if (game.sightings < before) spent++
+    }
+  }
+  assert.equal(spent, SIGHTINGS)
+  assert.equal(game.sightings, 0)
+
+  const before = reports.length
+  assert.deepEqual(
+    game.mark((now += 5)).map((e) => e.kind),
+    ["refused"],
+    "a dry astrolabe still fired",
+  )
+  assert.equal(reports.length, before, "a refused mark was reported to the host")
+
+  // And it comes back on its own, so nothing is ever lost — only delayed.
+  game.tick(16, now + REFILL_MS + 1)
+  assert.equal(game.sightings, 1)
+})
+
+test("a star that reaches the horizon snuffs a lamp and is never reported", () => {
+  const { game, reports } = rig(0x8a11)
+  const star = game.stars[0]
+  assert.ok(star)
+  let now = 0
+  let landed = 0
+  for (let i = 0; i < 400 && landed === 0; i++) {
+    now += 500
+    for (const e of game.tick(500, now)) if (e.kind === "land") landed++
+  }
+  assert.ok(landed >= 1, "nothing landed after a full fall")
+  assert.ok(game.lamps < LAMPS)
+  assert.equal(reports.length, 0, "a star the child never answered was reported")
+})
+
+test("the run ends when the last lamp goes out, and the ledger is written", () => {
+  const { game } = rig(0x0f1e)
+  let now = 0
+  let over: { logged: number; watches: number; longest: number; wide: number } | null = null
+  // Answer nothing at all. Every star lands; the lamps go out one at a time.
+  for (let i = 0; i < 600 && !over; i++) {
+    now += 1000
+    for (const e of game.tick(1000, now)) if (e.kind === "over") over = e.ledger
+  }
+  assert.ok(over, "the observatory never closed")
+  assert.equal(game.isOver, true)
+  assert.equal(game.lamps, 0)
+  assert.equal(over.logged, 0)
+  // And nothing happens after: the run is over, not looping.
+  assert.deepEqual(game.tick(16, now + 16), [])
+})
+
+test("there is no win state — a watch ends and the next one opens", () => {
+  const { game, transitions } = rig(0x77a2)
+  const firstWatch = game.watch
+  let now = raise(game)
+  let turned = false
+  for (let i = 0; i < 400 && !turned && !game.isOver; i++) {
+    const star = game.sighted
+    if (star) {
+      aimAt(game, star)
+      game.mark((now += 60))
+    }
+    now += 300
+    for (const e of game.tick(300, now)) if (e.kind === "watch") turned = true
+  }
+  assert.ok(turned, "the watch never turned over")
+  assert.equal(game.watch, firstWatch + 1)
+  assert.ok(game.stars.length > 0, "the next watch opened empty")
+  // A watch the child logged stars in is a stopping point the host may sheet.
+  assert.ok(
+    transitions.some((t) => t.kind === "level"),
+    "a watch the child worked was never offered as a stopping point",
+  )
+})
+
+test("a run can be restarted, and the ledger starts blank", () => {
+  const { game } = rig(0x1ced)
+  let now = 0
+  for (let i = 0; i < 600 && !game.isOver; i++) {
+    now += 1000
+    game.tick(1000, now)
+  }
+  assert.equal(game.isOver, true)
+  assert.ok(game.restart(now).length > 0)
+  assert.equal(game.isOver, false)
+  assert.equal(game.lamps, LAMPS)
+  assert.equal(game.watch, 1)
+  assert.equal(game.ledger.logged, 0)
+  assert.equal(game.ledger.wide, 0)
+})
+
+test("the same seed replays the same watch, star for star", () => {
+  const a = rig(0xd0d0)
+  const b = rig(0xd0d0)
+  assert.deepEqual(
+    a.game.stars.map((s) => [s.item.prompt, s.item.answer, s.lane, s.lamp]),
+    b.game.stars.map((s) => [s.item.prompt, s.item.answer, s.lane, s.lamp]),
+  )
+})

--- a/dynawalla/games/skyledger/src/test/harness.ts
+++ b/dynawalla/games/skyledger/src/test/harness.ts
@@ -1,0 +1,89 @@
+// A rig for the rules tests: a `Game` wired to the stub host, with every report
+// captured and with the truth about each star available to the *test* — never
+// to the game's render layer and never to the player.
+//
+// Everything here is seeded. A test that reaches for `Math.random` is a test
+// that fails one run in five on somebody else's machine, and the seed lives in
+// the test file so a failure can be reproduced from the failure message alone.
+
+import { Rng } from "../core/rng.ts"
+import { Game } from "../game/game.ts"
+import { answerOf, orderOf, stationOf, type Station } from "../game/station.ts"
+import type { Star } from "../game/game.ts"
+import { createStubHost } from "../stubHost.ts"
+import type { Host } from "../contract.ts"
+
+export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+export type Rig = {
+  game: Game
+  reports: Report[]
+  haptics: string[]
+  transitions: Array<{ kind: string; label?: string }>
+  host: Host
+}
+
+export function rig(seed: number, reduced = false, now = 0): Rig {
+  const reports: Report[] = []
+  const haptics: string[] = []
+  const transitions: Array<{ kind: string; label?: string }> = []
+  const host = createStubHost({
+    seed,
+    reducedMotion: reduced,
+    onReport: (r) => reports.push(r),
+    onHaptic: (k) => haptics.push(k),
+    onTransition: (kind, label) => transitions.push({ kind, label }),
+  })
+  const game = new Game(host, new Rng(seed ^ 0x5ec2), now, reduced)
+  game.begin(now)
+  return { game, reports, haptics, transitions, host }
+}
+
+/** The truth about a star. Only a test may ask this. */
+export function truthOf(star: Star): { value: number; station: Station; order: number } {
+  const value = answerOf(star.item)
+  if (value === null) throw new Error(`harness: star ${star.id} has no station`)
+  return { value, station: stationOf(value), order: orderOf(value) }
+}
+
+/**
+ * Turn the rings until they stand at `want`, one detent at a time, the way a
+ * child does. Returns how many detents it took.
+ */
+export function dialTo(game: Game, want: Station): number {
+  let turns = 0
+  for (let i = 0; i < 40 && game.station.x !== want.x; i++) {
+    game.dial("ones", 1)
+    turns++
+  }
+  for (let i = 0; i < 40 && game.station.y !== want.y; i++) {
+    game.dial("tens", 1)
+    turns++
+  }
+  if (game.station.x !== want.x || game.station.y !== want.y) {
+    throw new Error("harness: the rings would not reach that station")
+  }
+  return turns
+}
+
+/**
+ * Run the watch forward to `until`, in steps small enough that stars are
+ * released and land on the same schedule they would on a device. Returns
+ * `until`, so a test can carry one clock through without keeping two.
+ */
+export function raise(game: Game, until = 8200): number {
+  const STEP = 100
+  for (let t = STEP; t <= until; t += STEP) game.tick(STEP, t)
+  return until
+}
+
+/** Every star currently falling and visible. */
+export function falling(game: Game): Star[] {
+  return game.stars.filter((s) => s.state === "falling" && s.t > 0)
+}
+
+/** Sight a star and dial its true station. Correctness is then one `mark` away. */
+export function aimAt(game: Game, star: Star): void {
+  game.sight(star.id)
+  dialTo(game, truthOf(star).station)
+}

--- a/dynawalla/games/skyledger/src/test/layout.test.ts
+++ b/dynawalla/games/skyledger/src/test/layout.test.ts
@@ -1,0 +1,114 @@
+// THE ROOM.
+//
+// The first draft of this game drew a beautiful astrolabe sitting directly on
+// top of the horizon with the ruled plane squeezed into a strip above it, and
+// nothing in the test suite noticed, because a layout bug is invisible to every
+// test that is about rules. This file is that gate.
+//
+// It runs the layout at the shapes the fleet actually has — phones held tall
+// and wide, tablets both ways, a desktop window — and asserts the things a
+// screenshot would have shown: everything is on screen, the instrument does not
+// stand on the sky, the lamps have room to burn under the plane, and the
+// figures are big enough to read.
+//
+// Tablet and desktop are first-class here. Neither is a stretched phone.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { dialReach, lampGeometry, layoutFor, starPoint, stationPoint } from "../render/sky.ts"
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait", 360, 640],
+  ["phone portrait, tall", 390, 844],
+  ["phone portrait, small", 320, 568],
+  ["phone landscape", 844, 390],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["iPad landscape", 1180, 820],
+  ["iPad portrait", 820, 1180],
+  ["laptop", 1440, 900],
+  ["desktop wide", 1920, 1080],
+  ["square", 700, 700],
+]
+
+for (const [name, w, h] of VIEWPORTS) {
+  test(`the room holds together at ${name} (${w}×${h})`, () => {
+    const l = layoutFor(w, h)
+    const reach = dialReach(l)
+
+    // Everything is on the glass.
+    assert.ok(l.sky.x >= 0 && l.sky.y >= 0, "the sky starts off screen")
+    assert.ok(l.sky.x + l.sky.w <= w + 0.5, "the sky runs off the right")
+    assert.ok(l.sky.y + l.sky.h <= h + 0.5, "the sky runs off the bottom")
+    assert.ok(l.dial.cx - reach >= -0.5, "the astrolabe runs off the left")
+    assert.ok(l.dial.cx + reach <= w + 0.5, "the astrolabe runs off the right")
+    assert.ok(l.dial.cy - reach >= -0.5, "the astrolabe runs off the top")
+    assert.ok(l.dial.cy + reach <= h + 0.5, "the astrolabe runs off the bottom")
+
+    // The instrument does not stand on the sky. This is the bug that shipped
+    // in the first draft, and it is one inequality.
+    const gapX = Math.max(l.sky.x - l.dial.cx, l.dial.cx - (l.sky.x + l.sky.w), 0)
+    const gapY = Math.max(l.sky.y - l.dial.cy, l.dial.cy - (l.sky.y + l.sky.h), 0)
+    assert.ok(
+      Math.hypot(gapX, gapY) >= reach - 0.5,
+      `the astrolabe overlaps the sky (clearance ${Math.hypot(gapX, gapY).toFixed(1)} < ${reach.toFixed(1)})`,
+    )
+
+    // The ruled plane is inside the sky, square, and clear of the lamps.
+    assert.ok(l.plane.x >= l.sky.x, "the plane runs out the left of the sky")
+    assert.ok(l.plane.x + l.plane.w <= l.sky.x + l.sky.w + 0.5, "the plane runs out the right")
+    assert.ok(l.plane.y >= l.sky.y, "the plane runs out the top of the sky")
+    assert.equal(Math.round(l.plane.w), Math.round(l.plane.h), "the lattice is not square")
+    assert.equal(Math.round(l.plane.w), Math.round(l.cell * 9))
+
+    const lamp = lampGeometry(l)
+    const figuresEnd = l.plane.y + l.plane.h + l.cell * 0.66 + Math.min(l.cell * 0.34, 28)
+    assert.ok(
+      figuresEnd <= lamp.top + 0.5,
+      `the axis figures overlap the lamps by ${(figuresEnd - lamp.top).toFixed(1)}px`,
+    )
+
+    // Room for the axis figures on the left, too.
+    assert.ok(l.plane.x - l.sky.x >= l.cell * 0.34, "no room for the TENS figures")
+
+    // Legibility: a lattice a child cannot read the figures on is not a
+    // coordinate plane, it is graph paper.
+    assert.ok(l.cell >= 16, `the lattice cell is ${l.cell.toFixed(1)}px — the figures collide`)
+    assert.ok(l.dial.r >= 60, `the astrolabe is ${l.dial.r.toFixed(1)}px — it cannot be turned`)
+
+    // A station and a star both land where they are supposed to.
+    const origin = stationPoint(l, 0, 0)
+    const far = stationPoint(l, 9, 9)
+    assert.ok(far.px > origin.px, "the ONES axis runs the wrong way")
+    assert.ok(far.py < origin.py, "the TENS axis does not climb")
+
+    const top = starPoint(l, 0.5, 0)
+    const ground = starPoint(l, 0.5, 1)
+    assert.ok(top.py > l.ceiling, "a star is released above the aperture")
+    assert.equal(Math.round(ground.py), Math.round(l.horizon))
+    for (const lane of [0, 0.5, 1]) {
+      const p = starPoint(l, lane, 0.4)
+      assert.ok(p.px >= l.sky.x && p.px <= l.sky.x + l.sky.w, `lane ${lane} falls outside the sky`)
+    }
+  })
+}
+
+test("the layout flips between two rooms rather than stretching one", () => {
+  const wide = layoutFor(1024, 768)
+  const tall = layoutFor(768, 1024)
+  assert.equal(wide.landscape, true)
+  assert.equal(tall.landscape, false)
+  // Beside, in landscape; under, in portrait.
+  assert.ok(wide.dial.cx > wide.sky.x + wide.sky.w, "the astrolabe did not move beside the sky")
+  assert.ok(tall.dial.cy > tall.sky.y + tall.sky.h, "the astrolabe did not move under the sky")
+})
+
+test("the sky gets the larger share of the room, at every shape", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const l = layoutFor(w, h)
+    const sky = l.sky.w * l.sky.h
+    const dial = Math.PI * dialReach(l) ** 2
+    assert.ok(sky > dial, `${name}: the instrument takes more room than the sky it reads`)
+  }
+})

--- a/dynawalla/games/skyledger/src/test/pause.test.ts
+++ b/dynawalla/games/skyledger/src/test/pause.test.ts
@@ -1,0 +1,240 @@
+// THE PAUSE.
+//
+// The host can put a sheet over a pack that is **still mounted and still
+// running** — a stopping-point card, a parent gate, a day-pass offer — and it
+// sends `pause` when it does. SKY LEDGER calls `transition` at the end of every
+// watch the child worked, so it raises that sheet itself, routinely.
+//
+// Four things have to stop dead, and every one of them is real damage:
+//
+//   1. **Input.** A touch behind the sheet is not a thing the child did.
+//      Unguarded it turns a ring, or marks a station nobody was looking at, and
+//      puts a wrong answer on their record for a ledger line they never saw.
+//   2. **The ledger lines' clocks.** The latency reported is meant to be time
+//      the child spent thinking. Thirty seconds behind a sheet is not that.
+//   3. **The sky.** Stars must not fall behind the sheet. A child who comes
+//      back to a dark observatory was not beaten by the game.
+//   4. **The chain.** A nine-link chain must not expire because the host chose
+//      that moment to offer something.
+//
+// Each assertion here fails if the corresponding guard is removed — verified by
+// removing them one at a time, not by reading them. In particular the input
+// assertions are written against `pause()` alone, with the game otherwise in a
+// state where the same call would certainly have done something.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { CHAIN_WINDOW_MS } from "../game/escalation.ts"
+import { valueAt } from "../game/station.ts"
+import { dialTo, raise, rig, truthOf } from "./harness.ts"
+
+test("a mark behind the sheet is not taken, not reported and does not spend a sighting", () => {
+  const { game, reports } = rig(0x9a05e)
+  const t = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  // A correct pair, fully dialled — so nothing about this press is ambiguous
+  // except that it happened while the host had a sheet over the frame.
+  dialTo(game, truthOf(star).station)
+  const sightings = game.sightings
+  const logged = game.ledger.logged
+
+  game.pause(t + 100)
+  const events = game.mark(t + 400)
+
+  assert.deepEqual(events, [], "a mark behind the sheet produced events")
+  assert.equal(reports.length, 0, "a mark behind the sheet was reported to the host")
+  assert.equal(star.state, "falling", "a star was taken behind the sheet")
+  assert.equal(game.ledger.logged, logged, "the ledger was written behind the sheet")
+  assert.equal(game.sightings, sightings, "a sighting was spent behind the sheet")
+  assert.equal(game.links, 0)
+})
+
+test("the rings do not turn behind the sheet, and they are where they were when it lifts", () => {
+  const { game } = rig(0x40b)
+  const t = raise(game)
+  game.dial("ones", 1)
+  game.dial("tens", 1)
+  const standing = { ...game.station }
+
+  game.pause(t + 50)
+  assert.deepEqual(game.dial("ones", 1), [], "a ring turned behind the sheet")
+  assert.deepEqual(game.dial("tens", -1), [], "a ring turned behind the sheet")
+  assert.deepEqual(game.station, standing, "the astrolabe moved behind the sheet")
+
+  game.resume(t + 9000)
+  assert.deepEqual(game.station, standing, "the astrolabe lost its place")
+  assert.equal(game.dial("ones", 1).length, 1, "the astrolabe did not come back")
+})
+
+test("a star cannot be sighted behind the sheet", () => {
+  const { game } = rig(0xc0a7)
+  const t = raise(game)
+  const other = game.stars.find((s) => s.state === "falling" && s.t > 0 && s.id !== game.sighted?.id)
+  assert.ok(other, "the sky was too empty to test a sighting")
+  const held = game.sighted?.id
+
+  game.pause(t + 10)
+  assert.deepEqual(game.sight(other.id), [], "a star was sighted behind the sheet")
+  assert.equal(game.sighted?.id, held, "the sight moved behind the sheet")
+
+  game.resume(t + 5000)
+  assert.equal(game.sight(other.id).length, 1, "the sight did not come back")
+})
+
+test("the sheet is not thinking time: the latency reported skips it", () => {
+  const { game, reports } = rig(0x11ce)
+  raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const asked = star.askedAt
+  dialTo(game, truthOf(star).station)
+
+  // Two seconds with the ledger line, thirty behind a sheet, then half a
+  // second more and a mark.
+  game.pause(asked + 2000)
+  game.resume(asked + 32000)
+  game.mark(asked + 32500)
+
+  const report = reports[0]
+  assert.ok(report)
+  assert.equal(report.ms, 2500, "the sheet was counted as time the child spent thinking")
+})
+
+test("a sheet raised between ledger lines does not charge the next one for it", () => {
+  const { game, reports } = rig(0x2ee)
+  raise(game)
+  const first = game.sighted
+  assert.ok(first)
+  dialTo(game, truthOf(first).station)
+  game.mark(first.askedAt + 4000)
+
+  const next = game.sighted
+  assert.ok(next, "nothing came under the sight after the bloom")
+  const asked = next.askedAt
+
+  // The host raises its sheet on the transition and holds it for a minute. The
+  // child had a tenth of a second with the next line before it went up.
+  game.pause(asked + 100)
+  game.resume(asked + 60_100)
+  dialTo(game, truthOf(next).station)
+  game.mark(asked + 61_100)
+
+  assert.equal(reports.length, 2)
+  assert.equal(reports[0]?.ms, 4000)
+  assert.equal(reports[1]?.ms, 1100, "the next ledger line was charged for the sheet")
+})
+
+test("the sky does not fall behind the sheet", () => {
+  const { game } = rig(0x5c1e)
+  const t = raise(game)
+  const heights = game.stars.map((s) => s.t)
+  const lamps = game.lamps
+
+  game.pause(t)
+  // A minute of wall clock, delivered as frames, exactly as a still-mounted
+  // pack under a sheet would receive it if the loop were not guarded.
+  let now = t
+  for (let i = 0; i < 600; i++) game.tick(100, (now += 100))
+
+  assert.deepEqual(
+    game.stars.map((s) => s.t),
+    heights,
+    "the sky fell behind the sheet",
+  )
+  assert.equal(game.lamps, lamps, "a lamp went out behind the sheet")
+  assert.equal(game.isOver, false, "the run ended behind the sheet")
+
+  game.resume(now)
+  game.tick(100, now + 100)
+  assert.ok(
+    game.stars.some((s) => s.t > (heights[game.stars.indexOf(s)] ?? 0)),
+    "the sky did not start falling again",
+  )
+})
+
+test("a chain survives the sheet: the light does not fade behind it", () => {
+  const { game } = rig(0x3a17)
+  let now = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  dialTo(game, truthOf(star).station)
+  game.mark((now += 100))
+  const links = game.links
+  assert.ok(links >= 1)
+
+  // Thirty seconds behind a sheet — many times the chain's window.
+  game.pause(now)
+  game.tick(16, now + 30_000)
+  game.resume(now + 30_000)
+  assert.equal(game.links, links, "the sheet ate the chain")
+
+  // And it still expires normally afterwards, shifted by exactly the sheet.
+  assert.equal(game.tick(16, now + 30_000 + CHAIN_WINDOW_MS - 200).length, 0)
+  const events = game.tick(16, now + 30_000 + CHAIN_WINDOW_MS + 10)
+  assert.ok(
+    events.some((e) => e.kind === "release"),
+    "the chain never let go after the sheet",
+  )
+})
+
+test("sightings do not refill behind the sheet", () => {
+  const { game } = rig(0x60dd)
+  const t = raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const truth = truthOf(star)
+  // Spend one on a wild guess.
+  let guess = { x: (truth.station.x + 4) % 10, y: (truth.station.y + 6) % 10 }
+  for (let i = 0; i < 12; i++) {
+    const value = valueAt(star.order, guess)
+    if (value !== truth.value && !star.item.distractors.includes(String(value))) break
+    guess = { x: (guess.x + 1) % 10, y: guess.y }
+  }
+  dialTo(game, guess)
+  game.mark(t + 10)
+  const left = game.sightings
+  assert.ok(left < 6)
+
+  game.pause(t + 20)
+  let now = t + 20
+  for (let i = 0; i < 300; i++) game.tick(100, (now += 100))
+  assert.equal(game.sightings, left, "the astrolabe refilled behind the sheet")
+})
+
+test("pause and resume are idempotent, and resume alone changes nothing", () => {
+  const { game, reports } = rig(0x1de)
+  raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const asked = star.askedAt
+  dialTo(game, truthOf(star).station)
+
+  game.resume(asked + 100) // never paused
+  game.pause(asked + 1000)
+  game.pause(asked + 5000) // a second pause must not move the mark
+  game.resume(asked + 9000)
+  game.resume(asked + 50_000) // a second resume must not move it either
+  game.mark(asked + 10_000)
+
+  assert.equal(reports[0]?.ms, 2000)
+  assert.equal(game.isPaused, false)
+})
+
+test("the clock is a mark, not a stopwatch: a mark after resume is judged normally", () => {
+  const { game, reports } = rig(0x7e5)
+  raise(game)
+  const star = game.sighted
+  assert.ok(star)
+  const asked = star.askedAt
+  dialTo(game, truthOf(star).station)
+
+  game.pause(asked + 300)
+  game.resume(asked + 9300)
+  const events = game.mark(asked + 10_000)
+  assert.ok(events.length > 0, "the game did not come back after the sheet lifted")
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.correct, true)
+  assert.equal(reports[0]?.ms, 1000)
+})

--- a/dynawalla/games/skyledger/src/test/produce.test.ts
+++ b/dynawalla/games/skyledger/src/test/produce.test.ts
@@ -1,0 +1,202 @@
+// PRODUCE, DO NOT POINT.
+//
+// This is the file that keeps SKY LEDGER from quietly becoming a tapping game.
+//
+// The astrolabe is the only thing in this package that can bring an ordered
+// pair into existence, and it does it one detent at a time. There is no method
+// that takes a number, no method that takes a point on the screen, and nothing
+// anywhere on the sky whose position is a function of what a star is worth. If
+// any of that stops being true, one of these fails.
+//
+// It is written as five independent claims rather than one, because the leak
+// could arrive through any of them and a single assertion would only catch the
+// one somebody happened to think of first.
+
+import assert from "node:assert/strict"
+import { readFileSync, readdirSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { test } from "node:test"
+
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Game } from "../game/game.ts"
+import { RINGS, detentsBetween, type Station } from "../game/station.ts"
+import { createStubHost } from "../stubHost.ts"
+import { raise, rig, truthOf } from "./harness.ts"
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SRC = join(HERE, "..")
+
+test("the rings are the only way a pair comes into existence, and they move one step", () => {
+  const { game } = rig(0x9110)
+  raise(game)
+
+  assert.deepEqual(game.station, { x: 0, y: 0 }, "the rings did not start at the origin")
+
+  // Every call moves exactly one detent on exactly one ring. There is no
+  // multi-step turn, so there is no way to arrive anywhere in one gesture.
+  let previous: Station = game.station
+  for (let i = 0; i < 40; i++) {
+    const ring = i % 3 === 0 ? "tens" : "ones"
+    const dir = i % 5 === 0 ? -1 : 1
+    game.dial(ring, dir)
+    assert.equal(
+      detentsBetween(previous, game.station),
+      1,
+      `a single dial moved ${detentsBetween(previous, game.station)} detents`,
+    )
+    previous = game.station
+  }
+})
+
+test("a station cannot be jumped to: reaching one costs at least its distance in detents", () => {
+  const { game } = rig(0x3117)
+  raise(game)
+  for (let y = 0; y < RINGS; y++) {
+    for (let x = 0; x < RINGS; x++) {
+      const want = { x, y }
+      const cost = detentsBetween(game.station, want)
+      let turns = 0
+      while ((game.station.x !== x || game.station.y !== y) && turns < 40) {
+        if (game.station.x !== x) game.dial("ones", 1)
+        else game.dial("tens", 1)
+        turns++
+      }
+      assert.deepEqual(game.station, want)
+      assert.ok(turns >= cost, `(${x}, ${y}) was reached in ${turns} turns, under its ${cost}`)
+    }
+  }
+})
+
+test("the game exposes no way to set a pair, and no way to turn a screen point into one", () => {
+  const { game } = rig(0x5e77)
+  const surface = [
+    ...Object.getOwnPropertyNames(Object.getPrototypeOf(game) as object),
+    ...Object.getOwnPropertyNames(game),
+  ]
+  const forbidden = /^(set(Station|Ring|Pair|Answer)|stationAt|aimAt|pointAt|tapSky|solve|reveal)/i
+  for (const name of surface) {
+    assert.ok(!forbidden.test(name), `Game exposes "${name}", which is a way to point`)
+  }
+  // And the two methods that do exist take what they take: a ring and a
+  // direction, never a value.
+  assert.equal(game.dial.length, 2)
+  assert.equal(game.sight.length, 1)
+  assert.equal(game.mark.length, 1)
+})
+
+test("sighting a star reveals nothing: not its station, not its answer, not a hint", () => {
+  const { game, reports } = rig(0x711f)
+  raise(game)
+  const star = game.stars.find((s) => s.state === "falling" && s.t > 0)
+  assert.ok(star)
+  const before = { ...game.station }
+
+  const events = game.sight(star.id)
+  assert.deepEqual(game.station, before, "sighting moved the rings")
+  assert.equal(reports.length, 0, "sighting reported something")
+  for (const e of events) assert.equal(e.kind, "sight")
+
+  // What a sighting hands back is the star, and a star's own shape carries no
+  // station. `order` is the part of the register that is already ruled in and
+  // is drawn on the plate on purpose; everything else is where and when.
+  const keys = Object.keys(star).sort()
+  assert.deepEqual(keys, [
+    "askedAt",
+    "fallMs",
+    "id",
+    "item",
+    "lamp",
+    "lane",
+    "order",
+    "releaseIn",
+    "state",
+    "t",
+    "taken",
+  ])
+  const truth = truthOf(star)
+  for (const [key, value] of Object.entries(star)) {
+    if (key === "item" || key === "order") continue
+    if (typeof value !== "number") continue
+    assert.notEqual(value, truth.station.x * 100 + truth.station.y, `star.${key} carries the pair`)
+  }
+})
+
+test("where a star is in the sky is not a function of what it is worth", () => {
+  // Two runs with identical seeds, differing only in the answers the host
+  // hands over. If a star's lane or lamp were derived from its value — the one
+  // leak that would turn this back into a pointing game — they would diverge.
+  const shift = (host: Host): Host => ({
+    ...host,
+    next(opts) {
+      const q: Question = host.next(opts)
+      return { ...q, answer: String((Number(q.answer) + 7) % 1000) }
+    },
+  })
+
+  const plain = createStubHost({ seed: 0xa11e })
+  const altered = shift(createStubHost({ seed: 0xa11e }))
+
+  const a = new Game(plain, new Rng(0xbeef), 0, false)
+  const b = new Game(altered, new Rng(0xbeef), 0, false)
+  a.begin(0)
+  b.begin(0)
+
+  for (let watch = 0; watch < 4; watch++) {
+    assert.deepEqual(
+      a.stars.map((s) => [s.lane, s.lamp, s.fallMs, s.releaseIn]),
+      b.stars.map((s) => [s.lane, s.lamp, s.fallMs, s.releaseIn]),
+      "changing the answers moved the stars",
+    )
+    // The answers really did differ, so the comparison above meant something.
+    assert.notDeepEqual(
+      a.stars.map((s) => s.item.answer),
+      b.stars.map((s) => s.item.answer),
+    )
+    let now = watch * 200_000
+    for (let i = 0; i < 600 && a.watch === watch + 1; i++) {
+      now += 1000
+      a.tick(1000, now)
+      b.tick(1000, now)
+      if (a.isOver) return
+    }
+  }
+})
+
+test("the render layer never touches an answer, a station or a value", () => {
+  // The one leak a rules test cannot see. `Game` hands the renderer a `Star`,
+  // and a `Star` carries the host's `Question` — so nothing but discipline
+  // stops a scene file from reading `star.item.answer` and putting the star
+  // where it belongs. This is that discipline, as a gate.
+  const banned = [
+    /\bitem\s*\.\s*answer\b/,
+    /\banswerOf\b/,
+    /\bstationOf\b/,
+    /\bvalueAt\b/,
+    /\borderOf\b/,
+    /\bnamedSlips\b/,
+  ]
+  const files: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.name.endsWith(".ts")) files.push(full)
+    }
+  }
+  walk(join(SRC, "render"))
+  files.push(join(SRC, "mount.ts"))
+
+  assert.ok(files.length >= 2, "the render layer was not found; this gate would pass vacuously")
+  for (const file of files) {
+    const source = readFileSync(file, "utf8")
+    for (const pattern of banned) {
+      assert.ok(
+        !pattern.test(source),
+        `${file.slice(SRC.length + 1)} reads ${String(pattern)} — the renderer can see the answer`,
+      )
+    }
+  }
+})

--- a/dynawalla/games/skyledger/src/test/station.test.ts
+++ b/dynawalla/games/skyledger/src/test/station.test.ts
@@ -1,0 +1,131 @@
+// THE STATION.
+//
+// The sky is a hundred-square stood upright and a star's station is its
+// answer's tens and ones. Everything in this file is exact integer arithmetic,
+// because a station is a pair of digits and a digit that came out of a float is
+// not a digit.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  MAX_ANSWER,
+  RINGS,
+  answerOf,
+  detentsBetween,
+  isUsable,
+  namedSlips,
+  orderOf,
+  sameStation,
+  stationOf,
+  turn,
+  valueAt,
+} from "../game/station.ts"
+
+test("a station is the answer's tens and ones, and the order is what is already ruled in", () => {
+  assert.deepEqual(stationOf(72), { x: 2, y: 7 })
+  assert.deepEqual(stationOf(472), { x: 2, y: 7 })
+  assert.deepEqual(stationOf(8), { x: 8, y: 0 })
+  assert.deepEqual(stationOf(0), { x: 0, y: 0 })
+  assert.deepEqual(stationOf(9999), { x: 9, y: 9 })
+  assert.deepEqual(stationOf(16505), { x: 5, y: 0 })
+
+  assert.equal(orderOf(72), 0)
+  assert.equal(orderOf(472), 4)
+  assert.equal(orderOf(9999), 99)
+  assert.equal(orderOf(16505), 165)
+})
+
+test("order and station reconstruct the answer exactly, for every whole number the sky holds", () => {
+  // Exhaustive rather than sampled: this is the identity the whole game rests
+  // on, and 0..19,998 covers everything the `add` domain can make — two
+  // four-digit addends. The rest of the range is checked at the boundary.
+  for (let v = 0; v <= 19_998; v++) {
+    const rebuilt = valueAt(orderOf(v), stationOf(v))
+    assert.equal(rebuilt, v, `${v} did not come back from its own station`)
+    assert.ok(Number.isInteger(rebuilt))
+  }
+  for (const v of [99_999, 100_000, MAX_ANSWER]) {
+    assert.equal(valueAt(orderOf(v), stationOf(v)), v)
+  }
+})
+
+test("a named coordinate is worth the answer if and only if it IS the true station", () => {
+  // The load-bearing claim. Under a star of order 4 whose answer is 472, the
+  // pair (2, 7) is the answer and no other pair on the lattice is.
+  const answer = 472
+  const order = orderOf(answer)
+  let hits = 0
+  for (let y = 0; y < RINGS; y++) {
+    for (let x = 0; x < RINGS; x++) {
+      const asserted = valueAt(order, { x, y })
+      const right = asserted === answer
+      assert.equal(
+        right,
+        sameStation({ x, y }, stationOf(answer)),
+        `(${x}, ${y}) disagreed with the truth about ${answer}`,
+      )
+      if (right) hits++
+    }
+  }
+  assert.equal(hits, 1, "the lattice held more than one station worth the same answer")
+})
+
+test("a wrong pair asserts a wrong number, and it is a number the host can judge", () => {
+  const answer = 472
+  const order = orderOf(answer)
+  // Dropping the carry out of the tens column: 462, not noise.
+  assert.equal(valueAt(order, { x: 2, y: 6 }), 462)
+  // Transposing the pair: a real slip, and a real number.
+  assert.equal(valueAt(order, { x: 7, y: 2 }), 427)
+  for (let y = 0; y < RINGS; y++) {
+    for (let x = 0; x < RINGS; x++) {
+      const v = valueAt(order, { x, y })
+      assert.ok(Number.isInteger(v) && v >= 0, `(${x}, ${y}) asserted ${v}`)
+    }
+  }
+})
+
+test("the rings turn one detent at a time and wrap both ways", () => {
+  let s = { x: 0, y: 0 }
+  s = turn(s, "ones", 1)
+  assert.deepEqual(s, { x: 1, y: 0 })
+  s = turn(s, "ones", -1)
+  s = turn(s, "ones", -1)
+  assert.deepEqual(s, { x: 9, y: 0 }, "the ones ring did not wrap under zero")
+  s = turn(s, "tens", -1)
+  assert.deepEqual(s, { x: 9, y: 9 }, "the tens ring did not wrap under zero")
+  s = turn(s, "tens", 1)
+  assert.deepEqual(s, { x: 9, y: 0 }, "the tens ring did not wrap over nine")
+
+  // A ring never moves the other one. The pair is two independent productions.
+  for (let i = 0; i < 25; i++) s = turn(s, "ones", 1)
+  assert.equal(s.y, 0)
+})
+
+test("detentsBetween is the shortest way round, on each ring", () => {
+  assert.equal(detentsBetween({ x: 0, y: 0 }, { x: 0, y: 0 }), 0)
+  assert.equal(detentsBetween({ x: 0, y: 0 }, { x: 1, y: 0 }), 1)
+  assert.equal(detentsBetween({ x: 0, y: 0 }, { x: 9, y: 0 }), 1, "the ring did not wrap")
+  assert.equal(detentsBetween({ x: 0, y: 0 }, { x: 5, y: 5 }), 10)
+  assert.equal(detentsBetween({ x: 2, y: 7 }, { x: 7, y: 2 }), 10)
+})
+
+test("an answer this sky cannot hold is refused rather than bent", () => {
+  assert.equal(answerOf({ answer: "72" }), 72)
+  assert.equal(answerOf({ answer: " 472 " }), 472)
+  assert.equal(answerOf({ answer: "0" }), 0)
+
+  for (const bad of ["7.5", "-3", "1000000", "", "  ", "1/2", "seven", "12a", "1e3", "0x10"]) {
+    assert.equal(answerOf({ answer: bad }), null, `"${bad}" was let onto the sky`)
+    assert.equal(isUsable({ answer: bad }), false)
+  }
+})
+
+test("named slips are the host's own mal-rule values, and nothing else", () => {
+  const slips = namedSlips(["462", "427", "7.5", "-1", "1000000", "  "])
+  assert.deepEqual([...slips].sort((a, b) => a - b), [427, 462])
+  assert.equal(slips.has(462), true)
+  assert.equal(slips.has(472), false, "the answer itself was called a slip")
+  assert.equal(namedSlips([]).size, 0)
+})

--- a/dynawalla/games/skyledger/src/test/stubHost.test.ts
+++ b/dynawalla/games/skyledger/src/test/stubHost.test.ts
@@ -1,0 +1,91 @@
+// THE STUB HOST.
+//
+// It stands in for the runtime so the observatory is playable with `npm run
+// dev`. Three properties it has to have, because the real host has them and a
+// stub that is looser than the thing it stands in for hides bugs rather than
+// finding them.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { answerOf, isUsable } from "../game/station.ts"
+import { createStubHost } from "../stubHost.ts"
+
+test("every operand, answer and distractor is an exact integer", () => {
+  const host = createStubHost({ seed: 0xe0ac7 })
+  for (let i = 0; i < 400; i++) {
+    const q = host.next({ difficulty: (i % 10) / 10 })
+    assert.ok(/^\d+$/.test(q.answer), `answer "${q.answer}" is not a whole number`)
+    const value = Number(q.answer)
+    assert.ok(Number.isInteger(value) && value >= 0)
+    for (const d of q.distractors) {
+      assert.ok(/^-?\d+$/.test(d), `distractor "${d}" is not a whole number`)
+      assert.ok(Number.isInteger(Number(d)))
+    }
+    // And the prompt really is the arithmetic the answer came from.
+    const m = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    assert.ok(m, `prompt "${q.prompt}" is not a column sum`)
+    const a = Number(m[1])
+    const b = Number(m[3])
+    assert.equal(value, m[2] === "+" ? a + b : a - b, `"${q.prompt}" does not make ${q.answer}`)
+  }
+})
+
+test("the same seed is the same stream, forever", () => {
+  const a = createStubHost({ seed: 0x5eed })
+  const b = createStubHost({ seed: 0x5eed })
+  for (let i = 0; i < 200; i++) {
+    assert.deepEqual(a.next({ difficulty: 0.5 }), b.next({ difficulty: 0.5 }))
+  }
+  const c = createStubHost({ seed: 0x5eee })
+  assert.notDeepEqual(a.next(), c.next())
+})
+
+test("every question the stub draws can be stationed on this sky", () => {
+  const host = createStubHost({ seed: 0x11a7 })
+  for (let i = 0; i < 500; i++) {
+    const q = host.next({ difficulty: (i % 11) / 10 })
+    assert.equal(isUsable(q), true, `"${q.prompt}" = ${q.answer} has no station`)
+    assert.ok((answerOf(q) ?? -1) >= 0)
+  }
+})
+
+test("distractors are mal-rule outputs, not the answer and not noise around it", () => {
+  const host = createStubHost({ seed: 0x9a1e })
+  let offByOne = 0
+  let total = 0
+  for (let i = 0; i < 400; i++) {
+    const q = host.next({ difficulty: (i % 10) / 10 })
+    const answer = Number(q.answer)
+    assert.equal(new Set(q.distractors).size, q.distractors.length, "a distractor was repeated")
+    for (const d of q.distractors) {
+      assert.notEqual(Number(d), answer, "the answer was served as a distractor")
+      total++
+      if (Math.abs(Number(d) - answer) === 1) offByOne++
+    }
+  }
+  assert.ok(total > 0)
+  // `answer ± 1` is the shape of noise. A mal-rule pool can produce one by
+  // coincidence; it must not be made of them.
+  assert.ok(offByOne / total < 0.1, `${offByOne}/${total} distractors were answer ± 1`)
+})
+
+test("the stub reports, haptics and stopping points are all observable", () => {
+  const reports: unknown[] = []
+  const haptics: string[] = []
+  const transitions: string[] = []
+  const host = createStubHost({
+    seed: 1,
+    reducedMotion: true,
+    onReport: (r) => reports.push(r),
+    onHaptic: (k) => haptics.push(k),
+    onTransition: (k) => transitions.push(k),
+  })
+  host.report({ questionId: "x", correct: true, ms: 12, answered: "7" })
+  host.haptic("success")
+  host.transition?.("level", "watch 1")
+  assert.equal(reports.length, 1)
+  assert.deepEqual(haptics, ["success"])
+  assert.deepEqual(transitions, ["level"])
+  assert.equal(host.prefersReducedMotion(), true)
+})

--- a/dynawalla/games/skyledger/tsconfig.json
+++ b/dynawalla/games/skyledger/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/skyledger/vite.config.ts
+++ b/dynawalla/games/skyledger/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole observatory is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4321, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameSkyLedger",
+      formats: ["es"],
+      fileName: () => "skyledger.js",
+    },
+  },
+})

--- a/dynawalla/games/skyledger/vite.pack.config.ts
+++ b/dynawalla/games/skyledger/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own; a
+    // bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

**SKY LEDGER** — a new game at `dynawalla/games/skyledger`, built from the
arcade canon's **rank 1 of 234**, after Missile Command (1980). Intercept
descending trails by naming a coordinate; chain the blooms.

## Why

The canon's top-rated design, and its summary names three things that had to
survive into code rather than becoming a tapping game with a nice sky:

- **The child PRODUCES the ordered pair, they do not point at it.** The
  astrolabe dial is the entire pedagogical difference here. Pinned by
  *"what crosses to the host is the number the child produced, exactly"*.
- **Per-link escalation with named caps and a hard snap-back.** The release is
  what makes spectacle feel earned; an escalation that never snaps back is
  noise. Pinned by *"a chain of nine reaches the cap on every channel, and no
  earlier"* and *"the snap-back is one step: after a release nothing is left
  leaning"*.
- **There is no win state** — the run ends and the observatory writes it down.

The chain is also a tempo rather than a countdown (*"each link renews the
window"*), and the mote pool refills so a chain paced over seconds is not
starved — both are what make a nine-link chain something a child will replay.

## How it fits the curriculum we actually have

Only `add` is active (7 rows; `alg`, `div`, `frac`, `mul`, `ns` are all
`draft`), and `covers` is documented as "a request, not an instruction" — the
host serves whole-number column arithmetic regardless.

Coordinates are not an active domain, so this follows the `games/slice`
precedent rather than pretending otherwise: the **target is derived from the
value the host serves**, and naming the coordinate is the game's own
mathematics — something the child performs with a gesture, not a question
anybody asked. Only what the host can judge exactly is reported. All seven
declared skills are `dw.add.*`, verified by hand against
`packs/shared/curriculum/src/graph/domains/add.ts`, because `dw-pack check` does
**not** validate skill ids and a fictional one passes silently.

## Blast radius

**Areas touched:** dynawalla, one new game directory. Additive.

- [x] Scope: 0 files outside `dynawalla/games/skyledger/`, 0 deletions.
- [x] Covered by `dynawalla-packs · games + pack build`.
- [x] **Capabilities: `items`, `items.reveal`, `haptics`.** `items.reveal` is
      mandatory — without it `canonical` is `""`, every item is dropped and the
      pack serves zero questions with no crash and no failing gate. `audio` is
      deliberately **not** declared: that capability is `feedback.sound` (the
      host's sounds) and this game synthesises its own `AudioContext`.
- [x] **The host sheet is handled.** `pack.ts` subscribes to `pause`/`resume`
      and a test covers it — *"a paused chain does not bleed out behind the
      host's sheet"*. This matters more here than in most packs: the chain is a
      live tempo, so a sheet that let it keep running would silently kill a
      chain the child had banked.
- [x] **Curriculum.** No skill id renamed, reused or added.
- [x] **Native / strings / secrets.** None. `gitleaks` → no leaks found.

## Proof

```
$ npm test        # in dynawalla/games/skyledger/, x5
# pass 68 # fail 0   <- 1
# pass 68 # fail 0   <- 2
# pass 68 # fail 0   <- 3
# pass 68 # fail 0   <- 4
# pass 68 # fail 0   <- 5

$ npm run tsc
0 errors
```

The built entry carries its script — the failure mode the vite config warns
about is a `pack.html` that loads, paints the body colour and runs no code:

```
<script type="module" crossorigin src="./assets/pack-CWic9_7i.js"
```

```
$ node dynawalla/packs/build.mjs skyledger
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/skyledger/'
0
```

**Provenance.** The building agent stalled repeatedly on a watchdog, but had
pushed after every step, so nothing was lost at any point. The five test runs,
the skill-id checks, the scope check and the pack build above are mine, run
against the rebased branch — not a report taken on trust.
