### PR TITLE
release(dynawalla): 0.1.1 — twenty-six games

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
## What

Version bump only: `0.1.0` → `0.1.1` in `tauri.conf.json`. One line.

## Why

0.1.0 reached TestFlight with **5** packaged games. Thirty-eight commits later
`main` has **26**, every one of them installable — and none of them have shipped
to a device yet.

```
arena balance beam claim coil colossus counterweight forge foundry guilty
horde lattice merge merge-idle mosaic polarity pulse rhythm runner serpent
siege slice stack street trebuchet truedraw
```

The pack pipeline needed no change to carry them. `packs/build.mjs` says it
outright — *"Discovery is a glob, not a list… written for a thousand packs
rather than for two"* — so the twenty-sixth pack costs exactly what the sixth
did.

## Blast radius

- [x] One line in one file. No code, no workflow, no build config.
- [x] Corpán untouched.
- [x] Build numbers unchanged — still minutes-since-epoch, monotonic by
      construction.
- [x] The release fires on the `dynawalla-v0.1.1` tag, and the gate hard-fails
      if the tag does not match this file. Merging this alone ships nothing;
      the tag does.
- [ ] **Android will still fail**, and not because of this PR: the Play service
      account has no per-app grant (403, while a nonexistent package returns
      404 — so the app record exists and only the permission is missing). It
      fails in ~60s at the preflight rather than 35 minutes into a build.

## Proof

```
$ git ls-tree -r --name-only HEAD dynawalla/games/ | grep -c '/pack.json$'
26
$ grep '"version"' dynawalla/dynawalla-app/src-tauri/tauri.conf.json
  "version": "0.1.1",
```

CI's `dynawalla-packs · games + pack build` job builds every pack on this PR,
which is the real check that 26 packs still assemble.
