### PR TITLE
dynawalla/catalog: a familiar game listing, with key art generated per game

### DIFF
--- a/dynawalla/dynawalla-app/src/app/Shell.tsx
+++ b/dynawalla/dynawalla-app/src/app/Shell.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet } from "react-router"
 
+import { Mark } from "../design/Mark.tsx"
 import { Strapwork } from "../design/Strapwork.tsx"
 import { PackStage } from "../packs/Stage.tsx"
 import { Nav } from "./Nav.tsx"
@@ -8,19 +9,25 @@ import { strings } from "./strings.ts"
 /**
  * The lintel: the carved band every screen hangs beneath.
  *
- * It names the app and nothing else. It used to also name where you were,
- * which was worth doing when the wordmark was the only way to move; the
+ * The mark and the wordmark, and nothing else. It used to also name where you
+ * were, which was worth doing when the wordmark was the only way to move; the
  * navigation now says that, permanently, at the bottom of the screen, and two
  * places saying it is two places to disagree.
+ *
+ * This is where the brand lives — here and in the artwork on the cards, never
+ * in the shape of a card. The mark takes `currentColor` from the wordmark
+ * beside it, which is the brand rule made structural: white or black ink, and
+ * no coloured wash of the mark, ever.
  */
 function Lintel() {
   return (
     <header className="bg-ground-raised">
-      <div className="flex items-baseline px-[max(var(--safe-left),1rem)] pt-[max(var(--safe-top),var(--dw-lintel-pad))] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-lintel-pad)]">
+      <div className="flex items-center px-[max(var(--safe-left),1rem)] pt-[max(var(--safe-top),var(--dw-lintel-pad))] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-lintel-pad)]">
         <Link
           to="/"
-          className="inscription rounded-cut-sm text-lg tracking-[0.22em] text-ink uppercase"
+          className="inscription rounded-cut-sm text-ink flex items-center gap-2.5 text-lg tracking-[0.22em] uppercase"
         >
+          <Mark className="h-7 w-7 shrink-0" />
           {strings.appName}
         </Link>
       </div>
@@ -44,7 +51,11 @@ export function Shell() {
       {/* `--dw-surface-pad` rather than a literal: on a short viewport every
           band of vertical space is spoken for, and the frame's own padding is
           part of that budget (see the vertical scale in `tokens.css`). */}
-      <main className="mx-auto w-full max-w-2xl flex-1 px-[max(var(--safe-left),1rem)] pt-[var(--dw-surface-pad)] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-surface-pad)]">
+      {/* The frame is the catalogue's measure, not a reading measure: a grid of
+          game cards wants every column a desktop will give it. The courses of
+          rows on the other four screens set their own 42 rem measure inside
+          this, in `Surface.tsx`, so nothing that is read runs the full width. */}
+      <main className="mx-auto w-full max-w-6xl flex-1 px-[max(var(--safe-left),1rem)] pt-[var(--dw-surface-pad)] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-surface-pad)]">
         <Outlet />
       </main>
       <Nav />

--- a/dynawalla/dynawalla-app/src/app/capabilities.test.ts
+++ b/dynawalla/dynawalla-app/src/app/capabilities.test.ts
@@ -228,16 +228,20 @@ test("the app icon is the format the build macro accepts", () => {
   )
   assert.equal(png.subarray(0, 8).toString("latin1"), "\x89PNG\r\n\x1a\n")
   assert.equal(png.subarray(12, 16).toString("latin1"), "IHDR")
-  // Square and at least 512, rather than exactly 512. The source is the size
-  // every other size is rendered DOWN from — the Tauri CLI generates the whole
-  // iOS AppIcon set from this one file — so the constraint is a floor, not an
-  // equality. Pinning the exact number made a brand change fail a capabilities
-  // test that has no opinion about branding, which is noise in the one place
-  // that should only ever fire for a real build break.
+  // Square, and at least 1024 — a floor rather than an equality, and 1024
+  // rather than 512.
+  //
+  // 1024 because the App Store marketing icon is 1024 and the Tauri CLI renders
+  // every iOS and Android density DOWN from this one file: a 512 source does
+  // not fail, it upscales, and ships a soft icon nobody notices until review.
+  //
+  // A floor because the exact number is not the constraint. Pinning 512 made a
+  // brand change fail a capabilities test that has no opinion about branding —
+  // noise in the one place that should only fire for a real build break.
   const width = png.readUInt32BE(16)
   const height = png.readUInt32BE(20)
   assert.equal(width, height, "icon must be square")
-  assert.ok(width >= 512, `icon is ${width}px; the App Store needs 1024 rendered from this`)
+  assert.ok(width >= 1024, `icon is ${width}px; the App Store marketing icon is 1024 and is rendered down from this`)
   assert.equal(png[25], 6, "PNG colour type must be 6 (RGBA) or the Rust build panics")
 })
 

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -46,6 +46,41 @@ export const strings = {
     failed: "This pack could not be opened.",
   },
 
+  /**
+   * The catalogue: the listing of installed games, and the two ways to narrow
+   * it.
+   *
+   * Deliberately eight words and six subject names. A listing explains itself
+   * by being a listing — there is no "browse our collection", no count of how
+   * many games there are, and no empty-state paragraph apologising. `nothing`
+   * is the one line of prose, and it exists because a search that matched
+   * nothing and drew nothing would look like the app had broken.
+   */
+  catalog: {
+    /** Accessible name for the search field, and its placeholder. */
+    find: "Find a game",
+    /** The chip that clears the subject filter. Always first, always present. */
+    all: "All",
+    /** Shown in place of the grid when a search matches no installed game. */
+    nothing: "No game here matches that.",
+    /** The band a game is written for, on its card. */
+    grades: "Grades {{from}}–{{to}}",
+
+    /**
+     * The subjects, derived from skill ids at runtime (`catalog/domains.ts`).
+     * A seventh subject appearing in a pack needs a seventh entry here; until
+     * it has one the game is still listed, just not filed.
+     */
+    domains: {
+      ns: "Number sense",
+      add: "Addition & subtraction",
+      mul: "Multiplication",
+      div: "Division",
+      frac: "Fractions",
+      alg: "Equality & algebra",
+    },
+  },
+
   progress: {
     answered: "Answered",
     correct: "Correct",

--- a/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
+++ b/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
@@ -1,0 +1,209 @@
+import { useId, useMemo, useState } from "react"
+
+import { fill, strings } from "../app/strings.ts"
+import type { Row } from "../shell/surfaces.ts"
+import { chipsFor, domainName, domainsOf, type DomainId } from "./domains.ts"
+import { PackArt } from "./PackArt.tsx"
+
+type PackRow = Extract<Row, { kind: "pack" }>
+
+/** Case- and accent-insensitive enough for a child hunting for "serpent". */
+const folded = (text: string): string => text.toLocaleLowerCase()
+
+/** The band a game is written for, or nothing at all — never "Grades ?–?". */
+function gradeLabel(grades: readonly [number, number] | null): string | null {
+  if (grades === null) return null
+  const [from, to] = grades
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null
+  return fill(strings.catalog.grades, { from, to })
+}
+
+/**
+ * One game, as a card.
+ *
+ * A familiar listing tile: square key art on top, the name, one line about it,
+ * and its small print. The whole tile is the button — a child aiming at a word
+ * is a child missing — and at the grid's narrowest column it is still 140 px
+ * of art plus a label, which clears the child-sized target floor several times
+ * over.
+ *
+ * **`resting` is not a lock and is not drawn as one.** A game that already
+ * reached its stopping point today keeps its full-strength artwork, its
+ * full-strength name and its working control; the only difference is one word
+ * in the small print, in the same type as the version. No padlock, no
+ * "premium", no dimming, and it is not sorted to the bottom. What the press
+ * opens is the sheet that says so, which is a fact about the child's day
+ * rather than a price.
+ */
+function Card({ row }: { row: PackRow }) {
+  const grades = gradeLabel(row.grades)
+  const domains = domainsOf(row.skills)
+  const subject = domains[0]
+
+  return (
+    <button
+      type="button"
+      onClick={row.play}
+      className={[
+        // `h-full` inside a stretched grid cell, with the small print pushed to
+        // the bottom by `mt-auto`: every card in a row ends at the same line
+        // whatever its name and description did, which is what makes a grid
+        // read as a grid rather than as a ragged pile.
+        "group border-line bg-ground-raised rounded-cut-lg flex h-full w-full flex-col overflow-hidden border text-left",
+        "hover:border-line-strong focus-visible:border-line-strong",
+        "transition-colors duration-[var(--dw-motion-quick)]",
+      ].join(" ")}
+    >
+      <PackArt packId={row.id} className="aspect-square" />
+      <span className="flex flex-1 flex-col p-3">
+        {/* Clamped, never truncated. At the grid's narrowest column half these
+            names are longer than the card — COUNTERPOISE, THE COIL OF
+            NINETY-SIX — and one line with an ellipsis turns a listing of games
+            into a listing of prefixes. Two lines fits every name shipped.
+
+            No `block` on either of these: `line-clamp-*` works by setting
+            `display: -webkit-box`, and a `block` utility beside it silently
+            wins and un-clamps the text. That is exactly how this shipped once,
+            with descriptions running eleven lines deep. */}
+        {/* `break-words` because a clamp cannot help a single word wider than
+            the column: COUNTERPOISE on a 136 px card overflowed and was
+            clipped mid-word with no ellipsis to say so. */}
+        <span className="inscription text-ink line-clamp-2 text-base tracking-wide break-words">
+          {row.name}
+        </span>
+        {row.description.length > 0 ? (
+          <span className="text-ink-muted mt-1 line-clamp-2 text-xs">{row.description}</span>
+        ) : null}
+        <span className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-2">
+          {subject ? (
+            <span className="border-line text-accent-ink rounded-cut-sm border px-1.5 py-0.5 text-[0.6875rem]">
+              {domainName(subject)}
+            </span>
+          ) : null}
+          {grades ? <span className="numeral text-ink-muted text-[0.6875rem]">{grades}</span> : null}
+          <span className="numeral text-ink-muted text-[0.6875rem]">
+            {row.resting ? strings.packs.tomorrow : strings.packs.play}
+          </span>
+        </span>
+      </span>
+    </button>
+  )
+}
+
+/**
+ * The catalogue: every installed game, as a listing.
+ *
+ * A familiar game-portal grid, on purpose. The founder's instruction was
+ * "regular cards like a familiar listing with artwork/logo for each game …
+ * nice normal square cards", and the pass before this one drew arch-shaped
+ * niches with near-identical ornaments in them and was rejected. The brand
+ * lives in the chrome around this — the violet ground, the mark in the header,
+ * the accent — and in the ART, never in the silhouette of a card.
+ *
+ * **Search and subject are view state and live here, not in the surface
+ * model.** `packsSurface` describes every installed pack unconditionally; this
+ * component narrows the rows it was handed. That is what keeps "no destination
+ * is ever empty" a property of the model rather than a thing that happens to
+ * be true while nobody has typed in the box.
+ */
+export function Catalog({ rows }: { rows: readonly PackRow[] }) {
+  const [query, setQuery] = useState("")
+  const [subject, setSubject] = useState<DomainId | null>(null)
+  const searchId = useId()
+
+  // Derived from the manifests of what is actually installed, every render.
+  // Never a hardcoded list: this catalogue went from eighteen games to
+  // twenty-seven in an afternoon, and a table would have been stale first.
+  const chips = useMemo(() => chipsFor(rows), [rows])
+
+  const listed = useMemo(() => {
+    const needle = folded(query.trim())
+    const kept = rows.filter((row) => {
+      if (subject !== null && !domainsOf(row.skills).includes(subject)) return false
+      if (needle.length === 0) return true
+      return folded(`${row.name} ${row.description}`).includes(needle)
+    })
+    // `sort` on a copy rather than `toSorted`: this bundle's floor is iOS 16.0
+    // and the change-array-by-copy methods land in 16.4, where the failure is
+    // a thrown TypeError on the front door of the app rather than a fallback.
+    return [...kept].sort((a, b) => a.name.localeCompare(b.name))
+  }, [rows, query, subject])
+
+  // A subject that stops existing — the last pack covering it was removed —
+  // must not leave the grid filtered by a chip that is no longer on screen.
+  const active = subject !== null && chips.includes(subject) ? subject : null
+
+  return (
+    <section className="flex flex-col gap-[var(--dw-stack-gap-tight)]">
+      <label htmlFor={searchId} className="sr-only">
+        {strings.catalog.find}
+      </label>
+      <input
+        id={searchId}
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder={strings.catalog.find}
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
+        className={[
+          "border-line bg-ground-raised text-ink rounded-cut-md min-h-12 w-full border px-3 text-base",
+          "placeholder:text-ink-muted",
+        ].join(" ")}
+      />
+
+      {chips.length > 1 ? (
+        // A scrolling row rather than a wrapping block: on a 320 px phone six
+        // subjects wrap to three lines and push the first card off the screen,
+        // and the first card is the whole point of the screen.
+        <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+          <Chip label={strings.catalog.all} on={active === null} press={() => setSubject(null)} />
+          {chips.map((domain) => (
+            <Chip
+              key={domain}
+              label={domainName(domain)}
+              on={active === domain}
+              press={() => setSubject(active === domain ? null : domain)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {listed.length === 0 ? (
+        <p className="text-ink-muted py-8 text-center text-sm">{strings.catalog.nothing}</p>
+      ) : (
+        <ul className="grid grid-cols-[repeat(auto-fill,minmax(8.5rem,1fr))] gap-3 sm:gap-4">
+          {listed.map((row) => (
+            <li key={row.key} className="min-w-0">
+              <Card row={row} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+/**
+ * A subject filter.
+ *
+ * `aria-pressed` carries the state, and so does the border and the ink — never
+ * a colour alone, which is the same rule the rest of this shell is drawn to.
+ */
+function Chip({ label, on, press }: { label: string; on: boolean; press: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={press}
+      className={[
+        "rounded-cut-sm min-h-11 shrink-0 border px-3 text-sm whitespace-nowrap",
+        "transition-colors duration-[var(--dw-motion-quick)]",
+        on ? "border-line-strong bg-ground-sunk text-ink" : "border-line text-ink-muted",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  )
+}

--- a/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
+++ b/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
@@ -35,10 +35,23 @@ function gradeLabel(grades: readonly [number, number] | null): string | null {
  * opens is the sheet that says so, which is a fact about the child's day
  * rather than a price.
  */
-function Card({ row }: { row: PackRow }) {
+function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
   const grades = gradeLabel(row.grades)
   const domains = domainsOf(row.skills)
-  const subject = domains[0]
+  // Lead with the subject the child actually filtered by. Taking `domains[0]`
+  // instead meant a card answering a Multiplication filter labelled itself
+  // "Addition & subtraction", because DOMAIN_IDS is in teaching order and `add`
+  // sorts before `mul` — the card contradicted the filter that produced it.
+  //
+  // Two chips, not one: 126 of the 164 skills shipped are `dw.add`, so a single
+  // first-domain chip printed "Addition & subtraction" on twenty-two of the
+  // twenty-seven cards and told a reader nothing. The second chip is where the
+  // games differ.
+  const ordered =
+    active !== null && domains.includes(active)
+      ? [active, ...domains.filter((domain) => domain !== active)]
+      : domains
+  const subjects = ordered.slice(0, 2)
 
   return (
     <button
@@ -65,21 +78,34 @@ function Card({ row }: { row: PackRow }) {
             `display: -webkit-box`, and a `block` utility beside it silently
             wins and un-clamps the text. That is exactly how this shipped once,
             with descriptions running eleven lines deep. */}
-        {/* `break-words` because a clamp cannot help a single word wider than
-            the column: COUNTERPOISE on a 136 px card overflowed and was
-            clipped mid-word with no ellipsis to say so. */}
-        <span className="inscription text-ink line-clamp-2 text-base tracking-wide break-words">
+        {/* The real fix for a long name is a column wide enough to hold it, not
+            a cleverer way to break it — see the grid below, whose 10.5rem is
+            measured against the longest word shipped at this exact size.
+
+            15px, not 16px: at 16px COUNTERWEIGHT needs 152px and even a 10.5rem
+            column offers 142px, so the one-word-too-wide case would still fire.
+
+            `hyphens-auto` is kept as a courtesy for real devices, but it is NOT
+            load-bearing and must not be relied on — headless Chrome ships no
+            hyphenation dictionary, so it silently does nothing there, which is
+            how a fix that "worked" was measured as still broken. `break-words`
+            is the last resort that keeps a freak name inside its card rather
+            than over the top of the next one. */}
+        <span className="inscription text-ink line-clamp-2 hyphens-auto text-[0.9375rem] tracking-wide break-words">
           {row.name}
         </span>
         {row.description.length > 0 ? (
           <span className="text-ink-muted mt-1 line-clamp-2 text-xs">{row.description}</span>
         ) : null}
         <span className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-2">
-          {subject ? (
-            <span className="border-line text-accent-ink rounded-cut-sm border px-1.5 py-0.5 text-[0.6875rem]">
-              {domainName(subject)}
+          {subjects.map((domain) => (
+            <span
+              key={domain}
+              className="border-line text-accent-ink rounded-cut-sm border px-1.5 py-0.5 text-[0.6875rem]"
+            >
+              {domainName(domain)}
             </span>
-          ) : null}
+          ))}
           {grades ? <span className="numeral text-ink-muted text-[0.6875rem]">{grades}</span> : null}
           <span className="numeral text-ink-muted text-[0.6875rem]">
             {row.resting ? strings.packs.tomorrow : strings.packs.play}
@@ -173,10 +199,17 @@ export function Catalog({ rows }: { rows: readonly PackRow[] }) {
       {listed.length === 0 ? (
         <p className="text-ink-muted py-8 text-center text-sm">{strings.catalog.nothing}</p>
       ) : (
-        <ul className="grid grid-cols-[repeat(auto-fill,minmax(8.5rem,1fr))] gap-3 sm:gap-4">
+        /* 10.5rem, not 8.5rem, and the number is measured rather than chosen.
+           The longest single word shipped is COUNTERWEIGHT: at the title's 15px
+           it needs 142px of text box, and an 8.5rem column offers 110px. A word
+           wider than its column cannot be wrapped, only broken or clipped,
+           which is how "COUNTERPOI / SE" reached a desktop screen. 10.5rem
+           gives 142px of text box — exactly enough — and still fits two columns
+           on a 390px phone (2x168 + 12 gap = 348 of 358 available). */
+        <ul className="grid grid-cols-[repeat(auto-fill,minmax(10.5rem,1fr))] gap-3 sm:gap-4">
           {listed.map((row) => (
             <li key={row.key} className="min-w-0">
-              <Card row={row} />
+              <Card row={row} active={active} />
             </li>
           ))}
         </ul>

--- a/dynawalla/dynawalla-app/src/catalog/PackArt.tsx
+++ b/dynawalla/dynawalla-app/src/catalog/PackArt.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react"
+
+import { artOf, hueClass, rngFrom } from "./art.ts"
+import { shapesOf, type Shape } from "./motifs.ts"
+
+/**
+ * One shape, drawn.
+ *
+ * Everything that varies per element — alpha, dash, geometry — rides on a
+ * presentation ATTRIBUTE, never on a `style` prop. Under `style-src 'self'`
+ * an inline style is discarded in the shipped build while working perfectly in
+ * dev; a presentation attribute is not CSS and the policy does not touch it.
+ * The colour comes from the class, which comes from the stylesheet.
+ */
+function Drawn({ shape }: { shape: Shape }) {
+  const className = `dw-art-${shape.ink}`
+  const opacity = shape.alpha === undefined ? undefined : String(shape.alpha)
+
+  switch (shape.kind) {
+    case "path":
+      return (
+        <path className={className} d={shape.d} opacity={opacity} strokeDasharray={shape.dash} />
+      )
+    case "circle":
+      return (
+        <circle className={className} cx={shape.cx} cy={shape.cy} r={shape.r} opacity={opacity} />
+      )
+    case "rect":
+      return (
+        <rect
+          className={className}
+          x={shape.x}
+          y={shape.y}
+          width={shape.width}
+          height={shape.height}
+          rx={shape.radius}
+          opacity={opacity}
+        />
+      )
+  }
+}
+
+/**
+ * A game's key art: generated, deterministic, and different for every game.
+ *
+ * There is no cover art in this repository and no artist is coming, so the
+ * picture on a card is computed from the pack id — the same picture on every
+ * device and every launch, because a thumbnail a child cannot learn to
+ * recognise is not doing the one job a thumbnail has.
+ *
+ * Purely decorative: the card's accessible name is the game's name, sitting
+ * right under it, and a drawing that also announced itself would say it twice.
+ */
+export function PackArt({ packId, className }: { packId: string; className?: string }) {
+  const shapes = useMemo(() => {
+    const spec = artOf(packId)
+    return { spec, shapes: shapesOf(spec.motif, rngFrom(spec.seed)) }
+  }, [packId])
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden="true"
+      focusable="false"
+      className={["dw-art", hueClass(shapes.spec.hue), className].filter(Boolean).join(" ")}
+    >
+      <rect className="dw-art-ground" x="0" y="0" width="100" height="100" />
+      {/* The bloom the whole drawing sits in: light, never paint. A wash of the
+          card's own hue across the whole field, so the art reads as lit from
+          inside rather than printed on the void.
+
+          Full bleed rather than a disc, and that is the second time this has
+          been corrected: a large faint circle behind every drawing gave all
+          twenty-seven cards the same round silhouette, which is the note the
+          arch-shaped niches were rejected for. A card's outline is a square
+          like every other card's; only what is drawn inside it differs. */}
+      <rect className="dw-art-fill" x="0" y="0" width="100" height="100" opacity="0.07" />
+      {shapes.shapes.map((shape, index) => (
+        <Drawn key={index} shape={shape} />
+      ))}
+    </svg>
+  )
+}

--- a/dynawalla/dynawalla-app/src/catalog/art.ts
+++ b/dynawalla/dynawalla-app/src/catalog/art.ts
@@ -1,0 +1,140 @@
+// Key art, decided. No pixels here — this is the *specification* of a drawing.
+//
+// There is no cover art in this repository and no artist is coming, so every
+// game's artwork is generated. Two properties are non-negotiable and both are
+// held by this module:
+//
+//   * **Deterministic.** The art is a pure function of the pack id. The same
+//     game draws the same picture on every device, on every launch, forever —
+//     a card whose artwork reshuffles is a card a child cannot recognise, and
+//     recognition is the entire job of a thumbnail.
+//   * **Different.** The founder's requirement is that each game look
+//     genuinely different, so the art varies on two axes at once: the MOTIF
+//     (what is drawn — a balance, a spiral, a snake) and the HUE (which of the
+//     twelve lit colours of the arc it is drawn in).
+//
+// The motif is chosen from a table keyed by pack id, because the drawing has
+// to be a picture of *that game*: FORGE is a smelting chain, THE SPLIT cuts a
+// factor tree open, COUNTERPOISE is a balance beam. A procedural shape cannot
+// know that. What a procedural shape CAN do is be characterful for a game this
+// build has never heard of, and that is `sigil` — the fallback, which is a
+// seeded rosette rather than a grey box, so game #28 looks like it belongs on
+// the day it lands with no code change here at all.
+//
+// The hue is *not* in the table. It falls out of the id's hash, so a new pack
+// is coloured the moment it exists.
+
+import { MOTIF_KEYS, type MotifKey } from "./motifs.ts"
+
+/** How many lit hues the arc offers. Mirrors `--dw-art-1`…`--dw-art-12`. */
+export const ART_HUES = 12
+
+/**
+ * FNV-1a, 32-bit.
+ *
+ * Chosen over anything cleverer because it is four lines, has no dependency,
+ * and — the property that matters — is *specified*: a hash that differs
+ * between two JavaScript engines would give a phone and a tablet two different
+ * pictures of the same game.
+ */
+export function hashOf(text: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return hash >>> 0
+}
+
+/**
+ * mulberry32: a small, fast, well-distributed PRNG over a 32-bit seed.
+ *
+ * Every motif draws from one of these rather than from `Math.random`, which is
+ * how "the same game draws the same picture" survives a re-render.
+ */
+export function rngFrom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/**
+ * Which game is drawn how.
+ *
+ * Keyed by pack id and by nothing else — not by skill, not by grade, not by
+ * name. A game is a *thing*, and its picture is a picture of the thing.
+ *
+ * An id missing from this table is not an error and must never render as one:
+ * it falls through to `sigil` below.
+ */
+const MOTIF_BY_PACK: Readonly<Record<string, MotifKey>> = {
+  "dynawalla.arena": "orbs",
+  "dynawalla.balance": "balance",
+  "dynawalla.beam": "beams",
+  "dynawalla.claim": "region",
+  "dynawalla.coil": "coil",
+  "dynawalla.colossus": "tower",
+  "dynawalla.counterweight": "steelyard",
+  "dynawalla.forge": "anvil",
+  "dynawalla.foundry": "ring",
+  "dynawalla.guilty": "crosshair",
+  "dynawalla.horde": "swarm",
+  "dynawalla.lattice": "springgrid",
+  "dynawalla.merge-idle": "reef",
+  "dynawalla.fuse": "well",
+  "dynawalla.mosaic": "tiles",
+  "dynawalla.polarity": "polarity",
+  "dynawalla.pulse": "bar",
+  "dynawalla.rhythm": "lanes",
+  "dynawalla.runner": "causeway",
+  "dynawalla.serpent": "serpent",
+  "dynawalla.siege": "wall",
+  "dynawalla.skyledger": "astrolabe",
+  "dynawalla.slice": "split",
+  "dynawalla.stack": "slabs",
+  "dynawalla.street": "street",
+  "dynawalla.trebuchet": "trebuchet",
+  "dynawalla.truedraw": "slate",
+}
+
+/** Every pack id this build draws a bespoke picture for. Test-facing. */
+export const DRAWN_PACKS: readonly string[] = Object.keys(MOTIF_BY_PACK)
+
+export interface ArtSpec {
+  /** 1…12, addressing `--dw-art-N`. */
+  readonly hue: number
+  readonly motif: MotifKey
+  readonly seed: number
+}
+
+/** The drawing for a pack id. Total: every string returns a real picture. */
+export function artOf(packId: string): ArtSpec {
+  const seed = hashOf(packId)
+  const known = MOTIF_BY_PACK[packId]
+  return {
+    // Measured, not assumed. Across the twenty-seven packs this repository
+    // ships, the hash's low bits put every one of the twelve hues in use with
+    // at most four games sharing one — `>>> 3` first, which looked like the
+    // more careful thing to do, collapsed it to ten hues with six on one.
+    // `catalog.test.ts` holds the spread so a new pack cannot quietly ruin it.
+    hue: (seed % ART_HUES) + 1,
+    motif: known ?? "sigil",
+    seed,
+  }
+}
+
+/** The class that carries this card's hue. See `catalog.css`. */
+export function hueClass(hue: number): string {
+  const index = Number.isFinite(hue) ? Math.min(Math.max(Math.round(hue), 1), ART_HUES) : 1
+  return `dw-art-h${index}`
+}
+
+/** Guards the table above against naming a motif nothing draws. */
+export function isMotifKey(value: string): value is MotifKey {
+  return (MOTIF_KEYS as readonly string[]).includes(value)
+}

--- a/dynawalla/dynawalla-app/src/catalog/catalog.css
+++ b/dynawalla/dynawalla-app/src/catalog/catalog.css
@@ -1,0 +1,134 @@
+/* The inks of the generated key art.
+ *
+ * **This file exists because of the content security policy, not because of
+ * taste.** The shipped app runs under `style-src 'self'`, which throws away a
+ * `style` attribute and a `<style>` element alike — silently, and only in the
+ * build, so a per-card colour set from a React `style` prop looks perfect in
+ * `vite dev` and is simply absent on a device. Two mechanisms survive it, and
+ * both are used here:
+ *
+ *   1. a stylesheet the bundler emits and the document `<link>`s, which is
+ *      "self" and is therefore allowed — that is this file, and it is where
+ *      the twelve hue classes live;
+ *   2. SVG presentation attributes (`opacity`, `stroke-dasharray`, `d`, `r`),
+ *      which are attributes rather than CSS and are not subject to `style-src`
+ *      at all — that is how a shape carries its own alpha.
+ *
+ * So a card's hue is a CLASS (`dw-art-h7`) that sets one custom property, and
+ * every shape in the drawing is painted from that property. Nothing about the
+ * art is inline, and nothing about it can be dropped by the policy.
+ *
+ * The colours themselves are not here: every value below is a token from
+ * `design/tokens.css`, which is the only file in this app allowed to name one.
+ */
+
+.dw-art {
+  display: block;
+  inline-size: 100%;
+  block-size: auto;
+  background-color: var(--dw-art-void);
+}
+
+/* The arc. One class per lit hue, and the only thing that varies per card. */
+.dw-art-h1 {
+  --dw-art-lit: var(--dw-art-1);
+}
+.dw-art-h2 {
+  --dw-art-lit: var(--dw-art-2);
+}
+.dw-art-h3 {
+  --dw-art-lit: var(--dw-art-3);
+}
+.dw-art-h4 {
+  --dw-art-lit: var(--dw-art-4);
+}
+.dw-art-h5 {
+  --dw-art-lit: var(--dw-art-5);
+}
+.dw-art-h6 {
+  --dw-art-lit: var(--dw-art-6);
+}
+.dw-art-h7 {
+  --dw-art-lit: var(--dw-art-7);
+}
+.dw-art-h8 {
+  --dw-art-lit: var(--dw-art-8);
+}
+.dw-art-h9 {
+  --dw-art-lit: var(--dw-art-9);
+}
+.dw-art-h10 {
+  --dw-art-lit: var(--dw-art-10);
+}
+.dw-art-h11 {
+  --dw-art-lit: var(--dw-art-11);
+}
+.dw-art-h12 {
+  --dw-art-lit: var(--dw-art-12);
+}
+
+/* Monoline, from the brand rules: the mark is a single stroke weight and the
+   generated art inherits that discipline. The weights below are the only
+   variation, and they are steps of one family rather than free choices. */
+.dw-art-line,
+.dw-art-thin,
+.dw-art-bold,
+.dw-art-glow,
+.dw-art-veil,
+.dw-art-warm,
+.dw-art-pale {
+  fill: none;
+  stroke: var(--dw-art-lit);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.dw-art-ground {
+  fill: var(--dw-art-void);
+  stroke: none;
+}
+
+.dw-art-thin {
+  stroke-width: 1;
+  stroke-opacity: 0.8;
+}
+
+.dw-art-line {
+  stroke-width: 2;
+}
+
+.dw-art-bold {
+  stroke-width: 3.2;
+}
+
+/* Bloom is light, not paint (brand rule). It is a wide, very faint stroke
+   under the line it belongs to — never a filled shape in the bloom colour,
+   which is the named failure mode for this brand. */
+.dw-art-glow {
+  stroke-width: 7.5;
+  stroke-opacity: 0.16;
+}
+
+.dw-art-veil {
+  stroke-width: 1.2;
+  stroke-opacity: 0.34;
+}
+
+.dw-art-fill {
+  fill: var(--dw-art-lit);
+  stroke: none;
+}
+
+/* One warm point. Gold appears sparingly inside a drawing, at the thing the
+   game is actually about. */
+.dw-art-warm {
+  stroke: var(--dw-art-warm);
+  stroke-width: 2;
+}
+
+.dw-art-pale {
+  stroke: var(--dw-art-pale);
+  stroke-width: 1.4;
+  stroke-opacity: 0.8;
+}

--- a/dynawalla/dynawalla-app/src/catalog/catalog.test.ts
+++ b/dynawalla/dynawalla-app/src/catalog/catalog.test.ts
@@ -1,0 +1,215 @@
+// The catalogue's two silent failure modes, and the guards for both.
+//
+//   * **Artwork that is not deterministic.** A drawing seeded from anything
+//     but the pack id looks fine in every screenshot and reshuffles between
+//     launches on a device, so a child never learns which tile is which. There
+//     is no DOM here, which is exactly why the art is specified as data in
+//     `motifs.ts` and rendered separately — the property is testable.
+//   * **A game that vanishes.** The subject filter is derived from skill ids
+//     at runtime, so a skill this build has never seen must leave the game
+//     listed and unfiled rather than dropping it off the front door.
+//
+// Run: npm test  (node --experimental-strip-types --test 'src/**/*.test.ts')
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { ART_HUES, DRAWN_PACKS, artOf, hashOf, hueClass, isMotifKey, rngFrom } from "./art.ts"
+import { MOTIF_KEYS, shapesOf, type Shape } from "./motifs.ts"
+import { DOMAIN_IDS, chipsFor, domainOfSkill, domainsOf } from "./domains.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const gamesRoot = path.resolve(here, "../../../games")
+
+/** The drawing for a pack id, flattened to a string. Two ids differ or not. */
+function drawingOf(packId: string): string {
+  const spec = artOf(packId)
+  const shapes = shapesOf(spec.motif, rngFrom(spec.seed))
+  return `${spec.hue}|${spec.motif}|${shapes.map(describe).join(";")}`
+}
+
+const describe = (shape: Shape): string =>
+  shape.kind === "path"
+    ? `p${shape.d}${shape.ink}${shape.alpha ?? ""}${shape.dash ?? ""}`
+    : shape.kind === "circle"
+      ? `c${shape.cx},${shape.cy},${shape.r},${shape.ink},${shape.alpha ?? ""}`
+      : `r${shape.x},${shape.y},${shape.width},${shape.height},${shape.ink},${shape.alpha ?? ""}`
+
+test("every game the repository ships has key art of its own", () => {
+  // The table in `art.ts` is the one place a per-game decision is allowed, and
+  // it is allowed only because the drawing has to be a picture of that game.
+  // This is what stops it silently falling behind: the catalogue went from
+  // eighteen games to twenty-seven in an afternoon.
+  const shipped = fs
+    .readdirSync(gamesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(gamesRoot, entry.name, "pack.json"))
+    .filter((file) => fs.existsSync(file))
+    .map((file) => (JSON.parse(fs.readFileSync(file, "utf8")) as { id: string }).id)
+
+  assert.ok(shipped.length > 20, `expected the catalogue, found ${shipped.length} packs`)
+
+  const drawn = new Set(DRAWN_PACKS)
+  const undrawn = shipped.filter((id) => !drawn.has(id))
+  assert.deepEqual(undrawn, [], "games with no motif of their own")
+
+  const phantom = DRAWN_PACKS.filter((id) => !shipped.includes(id))
+  assert.deepEqual(phantom, [], "motifs for games that do not exist")
+})
+
+test("the motif table names motifs that exist", () => {
+  for (const id of DRAWN_PACKS) {
+    assert.ok(isMotifKey(artOf(id).motif), `${id} names a motif nothing draws`)
+  }
+})
+
+test("a game this build has never heard of still gets a real drawing", () => {
+  // The whole point of the fallback: game #28 lands with no code change here,
+  // and it must not be a grey box or an empty tile.
+  for (const id of ["dynawalla.something-new", "dynawalla.zzz", "vendor.other.pack"]) {
+    const spec = artOf(id)
+    assert.equal(spec.motif, "sigil")
+    const shapes = shapesOf(spec.motif, rngFrom(spec.seed))
+    assert.ok(shapes.length > 8, `${id} drew ${shapes.length} shapes`)
+  }
+
+  // …and two unknown games must not get the SAME drawing, which is the failure
+  // a single hardcoded placeholder would have.
+  assert.notEqual(drawingOf("dynawalla.aaa"), drawingOf("dynawalla.bbb"))
+})
+
+test("key art is byte-identical every time it is drawn", () => {
+  for (const id of [...DRAWN_PACKS, "dynawalla.unknown"]) {
+    assert.equal(drawingOf(id), drawingOf(id), `${id} draws itself differently twice`)
+  }
+})
+
+test("no two games are drawn the same", () => {
+  const seen = new Map<string, string>()
+  for (const id of DRAWN_PACKS) {
+    const drawing = drawingOf(id)
+    const clash = seen.get(drawing)
+    assert.equal(clash, undefined, `${id} and ${clash} draw the same picture`)
+    seen.set(drawing, id)
+  }
+})
+
+test("every drawing is on the field, in the family, and made of something", () => {
+  const inks = new Set(["line", "thin", "bold", "glow", "fill", "veil", "warm", "pale"])
+  for (const motif of MOTIF_KEYS) {
+    const shapes = shapesOf(motif, rngFrom(hashOf(motif)))
+    assert.ok(shapes.length >= 6, `${motif} draws ${shapes.length} shapes`)
+    for (const shape of shapes) {
+      assert.ok(inks.has(shape.ink), `${motif} uses an ink nothing paints: ${shape.ink}`)
+      if (shape.alpha !== undefined) {
+        assert.ok(shape.alpha > 0 && shape.alpha <= 1, `${motif} has an invisible shape`)
+      }
+      // Loosely on the 100 × 100 field. A motif that wandered off it would be
+      // cropped to a blank corner by `preserveAspectRatio="slice"`.
+      if (shape.kind === "circle") {
+        assert.ok(shape.r > 0 && shape.cx > -20 && shape.cx < 120, `${motif} is off the field`)
+      }
+      if (shape.kind === "rect") {
+        assert.ok(shape.width > 0 && shape.height > 0, `${motif} draws an empty rectangle`)
+      }
+      if (shape.kind === "path") {
+        assert.ok(/^M/.test(shape.d), `${motif} has a path that starts nowhere`)
+        assert.ok(!/NaN|undefined/.test(shape.d), `${motif} has a path with a hole in it`)
+      }
+    }
+  }
+})
+
+test("the hue is spread across the arc rather than clumped on one colour", () => {
+  const counts = new Map<number, number>()
+  for (const id of DRAWN_PACKS) {
+    const { hue } = artOf(id)
+    assert.ok(hue >= 1 && hue <= ART_HUES, `${id} asks for hue ${hue}`)
+    counts.set(hue, (counts.get(hue) ?? 0) + 1)
+  }
+  assert.ok(counts.size >= 8, `only ${counts.size} of ${ART_HUES} hues are used`)
+  const worst = Math.max(...counts.values())
+  assert.ok(worst <= 5, `${worst} games share one hue`)
+})
+
+test("the hue class is always one the stylesheet defines", () => {
+  const css = fs.readFileSync(path.join(here, "catalog.css"), "utf8")
+  for (let hue = 1; hue <= ART_HUES; hue++) {
+    assert.match(css, new RegExp(`\\.dw-art-h${hue}\\s*\\{`), `no rule for hue ${hue}`)
+  }
+  // Out-of-range and nonsense are clamped rather than emitting a class that
+  // sets no colour at all, which paints the art in nothing.
+  assert.equal(hueClass(0), "dw-art-h1")
+  assert.equal(hueClass(99), `dw-art-h${ART_HUES}`)
+  assert.equal(hueClass(Number.NaN), "dw-art-h1")
+})
+
+test("every ink the motifs use is painted by the stylesheet", () => {
+  const css = fs.readFileSync(path.join(here, "catalog.css"), "utf8")
+  const used = new Set<string>()
+  for (const motif of MOTIF_KEYS) {
+    for (const shape of shapesOf(motif, rngFrom(hashOf(motif)))) used.add(shape.ink)
+  }
+  for (const ink of used) {
+    assert.match(css, new RegExp(`\\.dw-art-${ink}\\b`), `nothing paints the "${ink}" ink`)
+  }
+})
+
+test("a skill id is filed by its second segment, and nothing else", () => {
+  assert.equal(domainOfSkill("dw.add.column.add-no-carry"), "add")
+  assert.equal(domainOfSkill("dw.frac.compare.unlike-fractions"), "frac")
+  assert.equal(domainOfSkill("dw.alg.equality.balance-meaning"), "alg")
+  assert.equal(domainOfSkill("dw.ns.compare.whole-numbers"), "ns")
+})
+
+test("an unknown skill leaves the game listed and unfiled — never dropped", () => {
+  // The failure being prevented: a subject this build has not heard of making
+  // a game disappear from the front door of a child's tablet.
+  assert.equal(domainOfSkill("dw.geom.area.rectangle"), null)
+  assert.equal(domainOfSkill("dw"), null)
+  assert.equal(domainOfSkill(""), null)
+  assert.equal(domainOfSkill("something.else.entirely"), null)
+
+  const mixed = domainsOf(["dw.geom.area.rectangle", "dw.add.column.add-no-carry"])
+  assert.deepEqual(mixed, ["add"], "a known subject was lost beside an unknown one")
+
+  assert.deepEqual(domainsOf(["dw.geom.area.rectangle"]), [], "an unfiled game is not a crash")
+})
+
+test("subjects come back in teaching order, never in the order they were found", () => {
+  const found = domainsOf([
+    "dw.alg.equality.balance-meaning",
+    "dw.add.column.add-no-carry",
+    "dw.ns.compare.whole-numbers",
+  ])
+  assert.deepEqual(found, ["ns", "add", "alg"])
+  for (const domain of found) assert.ok((DOMAIN_IDS as readonly string[]).includes(domain))
+})
+
+test("a chip is only offered when some installed game answers it", () => {
+  // A filter that can only ever return nothing is a control that lies about
+  // what this device holds.
+  assert.deepEqual(chipsFor([]), [])
+  assert.deepEqual(
+    chipsFor([{ skills: ["dw.frac.arith.add-like"] }, { skills: ["dw.add.column.add-no-carry"] }]),
+    ["add", "frac"],
+  )
+  assert.deepEqual(chipsFor([{ skills: ["dw.geom.area.rectangle"] }]), [])
+})
+
+test("the generator is seeded, spread and engine-independent", () => {
+  // FNV-1a and mulberry32 are both specified arithmetic on 32-bit integers. A
+  // hash that differed between two JavaScript engines would give a phone and a
+  // tablet two different pictures of the same game.
+  assert.equal(hashOf("dynawalla.forge"), hashOf("dynawalla.forge"))
+  assert.notEqual(hashOf("dynawalla.forge"), hashOf("dynawalla.foundry"))
+
+  const rng = rngFrom(hashOf("dynawalla.forge"))
+  const draws = Array.from({ length: 400 }, () => rng())
+  for (const value of draws) assert.ok(value >= 0 && value < 1)
+  const mean = draws.reduce((total, value) => total + value, 0) / draws.length
+  assert.ok(Math.abs(mean - 0.5) < 0.06, `the generator is biased: mean ${mean}`)
+})

--- a/dynawalla/dynawalla-app/src/catalog/domains.ts
+++ b/dynawalla/dynawalla-app/src/catalog/domains.ts
@@ -1,0 +1,76 @@
+// What a game is about, derived rather than declared.
+//
+// A skill id carries its subject in the second segment — `dw.add.column.…`,
+// `dw.frac.compare.…` — so the filter above the grid is computed from the
+// manifests of whatever is installed, at runtime, every render.
+//
+// **There is deliberately no per-game table here.** The catalogue went from
+// eighteen games to twenty-seven in a few hours; a lookup table mapping a pack
+// id to a subject would have been stale before it merged, and a game missing
+// from it would have vanished from every filter while looking fine in code
+// review. Deriving it means a pack that lands tomorrow is filed correctly the
+// moment it is installed, by nobody.
+//
+// An id whose second segment this build has never heard of is not an error and
+// must not be one: the game keeps every other subject it does match, it is
+// always in "All", and it simply offers no chip of its own. Vanishing is the
+// failure mode being avoided, so the fallback is "shown, unfiled".
+
+import { strings } from "../app/strings.ts"
+
+/**
+ * The subjects, in teaching order rather than in frequency order.
+ *
+ * Frequency today is `add` 126, `frac` 15, `alg` 9, `mul` 8, `div` 5, `ns` 1 —
+ * ordering the chips by that would put the chip row in a sequence that changes
+ * every time a pack ships.
+ */
+export const DOMAIN_IDS = ["ns", "add", "mul", "div", "frac", "alg"] as const
+
+export type DomainId = (typeof DOMAIN_IDS)[number]
+
+const isDomainId = (value: string): value is DomainId =>
+  (DOMAIN_IDS as readonly string[]).includes(value)
+
+/** The name a child's grown-up reads on the chip. */
+export function domainName(domain: DomainId): string {
+  return strings.catalog.domains[domain]
+}
+
+/**
+ * The subject a skill id belongs to, or `null` for one this build cannot file.
+ *
+ * `dw.add.column.add-no-carry` → `add`. Anything shorter, anything not under
+ * the `dw.` root, and anything under a second segment that is not one of the
+ * six is unfiled — never a crash, never a guess.
+ */
+export function domainOfSkill(skill: string): DomainId | null {
+  const parts = skill.split(".")
+  if (parts.length < 2 || parts[0] !== "dw") return null
+  const second = parts[1] ?? ""
+  return isDomainId(second) ? second : null
+}
+
+/** Every subject a game touches, in the fixed chip order. */
+export function domainsOf(skills: readonly string[]): readonly DomainId[] {
+  const found = new Set<DomainId>()
+  for (const skill of skills) {
+    const domain = domainOfSkill(skill)
+    if (domain !== null) found.add(domain)
+  }
+  return DOMAIN_IDS.filter((domain) => found.has(domain))
+}
+
+/**
+ * The chips to offer, given what is actually installed.
+ *
+ * Only subjects some installed game covers: a filter that can only ever return
+ * nothing is a control that lies about what this device holds.
+ */
+export function chipsFor(games: readonly { readonly skills: readonly string[] }[]): readonly DomainId[] {
+  const found = new Set<DomainId>()
+  for (const game of games) {
+    for (const domain of domainsOf(game.skills)) found.add(domain)
+  }
+  return DOMAIN_IDS.filter((domain) => found.has(domain))
+}

--- a/dynawalla/dynawalla-app/src/catalog/motifs.ts
+++ b/dynawalla/dynawalla-app/src/catalog/motifs.ts
@@ -1,0 +1,706 @@
+// The drawings themselves, as data.
+//
+// Every motif is a pure function from a seeded PRNG to a list of shapes on a
+// 100 × 100 field. Nothing here touches the DOM, React or a colour: a shape
+// names an *ink* ("line", "glow", "warm") and `catalog.css` decides what an ink
+// is, which is what keeps the whole palette in `tokens.css` where it belongs
+// and what makes every one of these testable under `node --test`.
+//
+// **They are of one family on purpose.** Monoline, luminous, sitting on the
+// violet void — the brand's discipline, applied twenty-eight times. What
+// varies is what is drawn and which of the arc's twelve hues it is drawn in,
+// not the stroke weight, not the ground, not the lighting. Twenty-seven
+// drawings that each looked like a different app would be a rainbow
+// free-for-all; twenty-seven drawings that shared a silhouette would be the
+// near-identical rosettes that were rejected before this.
+//
+// Each motif is a picture of what its game actually does. That is the only
+// reason a table keyed by pack id is acceptable here (see `art.ts`): FORGE
+// really is a smelting chain, THE SPLIT really does cut a factor tree open,
+// and no procedure can infer either from an id.
+
+/** What a shape is drawn with. `catalog.css` binds each to a colour. */
+export type Ink = "line" | "thin" | "bold" | "glow" | "fill" | "veil" | "warm" | "pale"
+
+export type Shape =
+  | {
+      readonly kind: "path"
+      readonly d: string
+      readonly ink: Ink
+      readonly alpha?: number
+      readonly dash?: string
+    }
+  | {
+      readonly kind: "circle"
+      readonly cx: number
+      readonly cy: number
+      readonly r: number
+      readonly ink: Ink
+      readonly alpha?: number
+    }
+  | {
+      readonly kind: "rect"
+      readonly x: number
+      readonly y: number
+      readonly width: number
+      readonly height: number
+      readonly ink: Ink
+      readonly alpha?: number
+      readonly radius?: number
+    }
+
+/** Two decimals. Enough for a 100-unit field, and it keeps the markup small. */
+const n = (value: number): string => String(Math.round(value * 100) / 100)
+
+const path = (d: string, ink: Ink = "line", alpha?: number, dash?: string): Shape => ({
+  kind: "path",
+  d,
+  ink,
+  ...(alpha === undefined ? {} : { alpha }),
+  ...(dash === undefined ? {} : { dash }),
+})
+
+const line = (
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  ink: Ink = "line",
+  alpha?: number,
+  dash?: string,
+): Shape => path(`M${n(x1)} ${n(y1)}L${n(x2)} ${n(y2)}`, ink, alpha, dash)
+
+const dot = (cx: number, cy: number, r: number, ink: Ink = "line", alpha?: number): Shape => ({
+  kind: "circle",
+  cx,
+  cy,
+  r,
+  ink,
+  ...(alpha === undefined ? {} : { alpha }),
+})
+
+const box = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  ink: Ink = "line",
+  alpha?: number,
+  radius?: number,
+): Shape => ({
+  kind: "rect",
+  x,
+  y,
+  width,
+  height,
+  ink,
+  ...(alpha === undefined ? {} : { alpha }),
+  ...(radius === undefined ? {} : { radius }),
+})
+
+/** A closed polygon from a flat list of coordinates. */
+const poly = (points: readonly number[], ink: Ink = "line", alpha?: number): Shape => {
+  let d = ""
+  for (let i = 0; i < points.length; i += 2) {
+    d += `${i === 0 ? "M" : "L"}${n(points[i] ?? 0)} ${n(points[i + 1] ?? 0)}`
+  }
+  return path(`${d}Z`, ink, alpha)
+}
+
+const rad = (degrees: number): number => (degrees * Math.PI) / 180
+const px = (cx: number, r: number, degrees: number): number => cx + r * Math.cos(rad(degrees))
+const py = (cy: number, r: number, degrees: number): number => cy + r * Math.sin(rad(degrees))
+
+/** A ray outward from a centre, between two radii. */
+const ray = (
+  cx: number,
+  cy: number,
+  from: number,
+  to: number,
+  degrees: number,
+  ink: Ink = "line",
+  alpha?: number,
+): Shape =>
+  line(px(cx, from, degrees), py(cy, from, degrees), px(cx, to, degrees), py(cy, to, degrees), ink, alpha)
+
+/** A number in a range, from the motif's own generator. */
+const between = (rng: () => number, low: number, high: number): number => low + rng() * (high - low)
+
+type Motif = (rng: () => number) => Shape[]
+
+// ── The twenty-seven, and the one that covers everything else ──────────────
+
+/** ARENA — a radius law you see before you read it. */
+const orbs: Motif = (rng) => {
+  const out: Shape[] = []
+  for (const r of [32, 23, 14]) out.push(dot(50, 52, r, "veil"))
+  out.push(dot(50, 52, 11, "glow"), dot(50, 52, 11, "bold"), dot(50, 52, 4, "pale", 0.9))
+  for (let i = 0; i < 7; i++) {
+    const angle = i * 51 + between(rng, -12, 12)
+    const dist = between(rng, 26, 42)
+    out.push(dot(px(50, dist, angle), py(52, dist, angle), between(rng, 2.4, 7.5), "fill", 0.75))
+  }
+  return out
+}
+
+/** COUNTERPOISE — the scale physically is the equals sign. */
+const balance: Motif = (rng) => {
+  const tilt = between(rng, -3, 3)
+  const left = 50 - tilt
+  const right = 50 + tilt
+  return [
+    poly([50, 60, 41, 88, 59, 88], "line"),
+    line(50, 60, 50, 44, "thin"),
+    line(18, 44 + tilt, 82, 44 - tilt, "bold"),
+    line(18, 44 + tilt, 18, 58 + tilt, "thin"),
+    line(82, 44 - tilt, 82, 58 - tilt, "thin"),
+    path(`M8 ${n(58 + tilt)}A10 7 0 0 0 28 ${n(58 + tilt)}`, "line"),
+    path(`M72 ${n(58 - tilt)}A10 7 0 0 0 92 ${n(58 - tilt)}`, "line"),
+    box(13, 50 + tilt, 5, 5, "fill", 0.8),
+    box(79, 50 - tilt, 5, 5, "fill", 0.8),
+    dot(left, 40, 2, "warm"),
+    dot(right, 40, 2, "warm"),
+    line(30, 44, 70, 44, "glow", 0.5),
+  ]
+}
+
+/** LATTICE RUNNER — ride a beam, fire, hear the remainder. */
+const beams: Motif = (rng) => {
+  const out: Shape[] = []
+  const rows = [24, 42, 60, 78]
+  rows.forEach((y, index) => {
+    out.push(line(10, y, 90, y, index === 1 ? "bold" : "veil"))
+    for (let x = 14; x < 90; x += 9) out.push(line(x, y - 2.5, x, y + 2.5, "thin", 0.45))
+  })
+  out.push(
+    poly([26, 36, 33, 42, 26, 42], "fill", 0.95),
+    line(34, 42, 88, 42, "glow", 0.6),
+    line(34, 42, 88, 42, "warm", 0.9, "6 4"),
+  )
+  for (let i = 0; i < 4; i++) {
+    const y = rows[Math.floor(between(rng, 0, 3.99))] ?? 24
+    out.push(dot(between(rng, 44, 84), y - 6, between(rng, 1.6, 3.2), "fill", 0.6))
+  }
+  return out
+}
+
+/** CLAIM — cut the plane and take exactly the part you were asked for. */
+const region: Motif = (rng) => {
+  const cut = between(rng, 40, 58)
+  const out: Shape[] = [
+    box(12, 12, 76, 76, "veil"),
+    poly([12, 12, 88, 12, 88, 88, cut, 88, cut, 52, 12, 52], "fill", 0.16),
+    poly([12, 12, 88, 12, 88, 88, cut, 88, cut, 52, 12, 52], "line"),
+  ]
+  for (let x = 16; x < 88; x += 8) out.push(line(x, 12, x - 8, 20, "thin", 0.3))
+  out.push(dot(between(rng, cut + 8, 84), between(rng, 62, 80), 3.2, "warm"))
+  out.push(dot(between(rng, 18, cut - 8), between(rng, 62, 80), 2.2, "pale", 0.7))
+  return out
+}
+
+/** THE COIL OF NINETY-SIX — a number written in place value, articulated. */
+const coil: Motif = (rng) => {
+  const out: Shape[] = []
+  let r = 36
+  let angle = between(rng, -20, 20)
+  for (let i = 0; i < 11; i++) {
+    const next = angle + 42
+    out.push(
+      path(
+        `M${n(px(50, r, angle))} ${n(py(52, r, angle))}A${n(r)} ${n(r)} 0 0 1 ${n(px(50, r * 0.9, next))} ${n(py(52, r * 0.9, next))}`,
+        i === 0 ? "bold" : "line",
+        1 - i * 0.05,
+      ),
+      dot(px(50, r, angle), py(52, r, angle), 1.8, "fill", 0.85),
+    )
+    angle = next
+    r *= 0.9
+  }
+  out.push(dot(50, 52, 3, "warm"), ray(50, 52, 38, 48, -20 + 0, "glow", 0.7))
+  return out
+}
+
+/** COLOSSUS — strike wrong and the tower gets taller. */
+const tower: Motif = (rng) => {
+  const out: Shape[] = [box(30, 12, 40, 9, "warm", 0.9)]
+  for (let i = 0; i < 6; i++) {
+    const w = between(rng, 30, 46)
+    out.push(box(50 - w / 2, 26 + i * 10, w, 8, i === 3 ? "fill" : "line", i === 3 ? 0.4 : 1))
+  }
+  out.push(
+    poly([4, 52, 24, 46, 24, 62], "fill", 0.9),
+    line(24, 54, 32, 54, "glow", 0.8),
+    line(30, 12, 70, 12, "glow", 0.6),
+  )
+  return out
+}
+
+/** THE COUNTERWEIGHT — hold exactly one notch ahead, then seat the beam. */
+const steelyard: Motif = (rng) => {
+  const slide = between(rng, 60, 82)
+  const out: Shape[] = [
+    line(10, 46, 92, 46, "bold"),
+    poly([32, 46, 25, 76, 39, 76], "line"),
+    line(10, 46, 10, 58, "thin"),
+    path("M2 58A8 6 0 0 0 18 58", "line"),
+    box(6, 52, 5, 5, "fill", 0.8),
+    box(slide - 4, 38, 8, 9, "fill", 0.95),
+    line(slide, 47, slide, 54, "warm"),
+  ]
+  for (let x = 40; x < 90; x += 7) out.push(line(x, 42, x, 46, "thin", 0.5))
+  out.push(line(28, 46, 92, 46, "glow", 0.4))
+  return out
+}
+
+/** FORGE — every problem struck on the anvil pays sparks. */
+const anvil: Motif = (rng) => {
+  const out: Shape[] = [
+    poly([26, 46, 74, 46, 78, 52, 70, 56, 30, 56, 22, 52], "line"),
+    poly([42, 56, 58, 56, 62, 72, 38, 72], "line"),
+    box(30, 72, 40, 6, "fill", 0.35),
+  ]
+  for (let i = 0; i < 9; i++) {
+    const angle = -160 + i * 16 + between(rng, -5, 5)
+    out.push(ray(50, 44, 8, between(rng, 16, 30), angle, i % 3 === 0 ? "warm" : "line", 0.85))
+  }
+  for (let i = 0; i < 4; i++) {
+    out.push(box(14 + i * 20, 86, 10, 8, "veil"), dot(19 + i * 20, 90, 1.6, "fill", 0.7))
+    if (i < 3) out.push(line(24 + i * 20, 90, 34 + i * 20, 90, "thin", 0.5))
+  }
+  out.push(dot(50, 44, 9, "glow", 0.7))
+  return out
+}
+
+/** THE GRAPPLE FOUNDRY — two leverage plates, one exact total, three slaps. */
+const ring: Motif = (rng) => {
+  const out: Shape[] = [
+    poly([16, 60, 84, 60, 96, 92, 4, 92], "fill", 0.14),
+    poly([16, 60, 84, 60, 96, 92, 4, 92], "line"),
+  ]
+  for (let i = 0; i < 3; i++) {
+    const y = 26 + i * 11
+    out.push(line(10, y, 90, y, i === 1 ? "line" : "veil"))
+  }
+  out.push(line(12, 22, 12, 62, "thin"), line(88, 22, 88, 62, "thin"))
+  const lift = between(rng, -4, 4)
+  out.push(
+    dot(32, 74 + lift, 9, "bold"),
+    dot(68, 74 - lift, 9, "bold"),
+    line(41, 74 + lift, 59, 74 - lift, "fill", 0.9),
+    dot(32, 74 + lift, 3, "warm"),
+  )
+  return out
+}
+
+/** GUILTY — four husks, three of them a mistake children actually make. */
+const crosshair: Motif = (rng) => {
+  const target = Math.floor(between(rng, 0, 3.99))
+  const out: Shape[] = [line(14, 20, 86, 20, "veil", 0.8, "5 4")]
+  for (let i = 0; i < 4; i++) {
+    const x = 14 + i * 20
+    out.push(box(x, 44, 16, 16, i === target ? "bold" : "line", i === target ? 1 : 0.6, 3))
+  }
+  const cx = 22 + target * 20
+  out.push(
+    dot(cx, 52, 13, "warm", 0.9),
+    line(cx - 17, 52, cx - 10, 52, "warm"),
+    line(cx + 10, 52, cx + 17, 52, "warm"),
+    line(cx, 35, cx, 42, "warm"),
+    line(cx, 62, cx, 69, "warm"),
+    line(cx, 92, cx, 62, "glow", 0.8),
+    poly([cx - 4, 92, cx + 4, 92, cx, 84], "fill", 0.95),
+  )
+  return out
+}
+
+/** DEEPSWARM — move; the swarm comes; the light wins. */
+const swarm: Motif = (rng) => {
+  const out: Shape[] = [dot(50, 52, 13, "glow", 0.8), dot(50, 52, 6, "fill", 0.9), dot(50, 52, 30, "veil")]
+  for (let i = 0; i < 18; i++) {
+    const angle = i * 20 + between(rng, -8, 8)
+    const far = between(rng, 32, 48)
+    out.push(ray(50, 52, far, far - between(rng, 5, 10), angle, "line", 0.7))
+  }
+  for (let i = 0; i < 5; i++) {
+    const angle = between(rng, 0, 360)
+    out.push(dot(px(50, 22, angle), py(52, 22, angle), 2, "warm", 0.85))
+  }
+  return out
+}
+
+/** THE LATTICE — shoot a composite and it splits along a factor pair. */
+const springgrid: Motif = (rng) => {
+  const out: Shape[] = []
+  for (let row = 0; row < 5; row++) {
+    for (let col = 0; col < 5; col++) {
+      const x = 18 + col * 16
+      const y = 18 + row * 16
+      out.push(dot(x, y, 1.8, "fill", 0.55))
+      if (col < 4) out.push(path(`M${n(x)} ${n(y)}Q${n(x + 8)} ${n(y + between(rng, -3, 3))} ${n(x + 16)} ${n(y)}`, "veil"))
+      if (row < 4) out.push(path(`M${n(x)} ${n(y)}Q${n(x + between(rng, -3, 3))} ${n(y + 8)} ${n(x)} ${n(y + 16)}`, "veil"))
+    }
+  }
+  out.push(
+    dot(50, 50, 9, "glow", 0.9),
+    dot(42, 50, 6, "bold"),
+    dot(58, 50, 6, "bold"),
+    line(48, 50, 52, 50, "warm"),
+    dot(82, 82, 3, "warm"),
+  )
+  return out
+}
+
+/** ABYSSAL BLOOM — two polyps with the same number shove into their sum. */
+const reef: Motif = (rng) => {
+  const out: Shape[] = [path("M6 88Q50 78 94 88", "veil")]
+  for (let i = 0; i < 5; i++) {
+    const x = 16 + i * 17
+    const h = between(rng, 22, 44)
+    const bend = between(rng, -8, 8)
+    out.push(
+      path(`M${n(x)} 86Q${n(x + bend)} ${n(86 - h / 2)} ${n(x + bend)} ${n(86 - h)}`, "line"),
+      dot(x + bend, 86 - h, between(rng, 3, 6), "fill", 0.75),
+    )
+  }
+  out.push(
+    dot(42, 34, 8, "bold"),
+    dot(56, 34, 8, "bold"),
+    dot(49, 34, 4, "warm"),
+    dot(49, 34, 12, "glow", 0.7),
+  )
+  return out
+}
+
+/** FUSE — chips that touch and make the key number fuse into one. */
+const well: Motif = (rng) => {
+  const out: Shape[] = [
+    poly([18, 14, 82, 14, 66, 78, 34, 78], "veil"),
+    line(30, 84, 70, 84, "bold"),
+  ]
+  for (let i = 0; i < 6; i++) {
+    out.push(dot(between(rng, 34, 66), between(rng, 24, 70), between(rng, 3, 5.5), "line", 0.7))
+  }
+  out.push(
+    dot(44, 52, 7, "bold"),
+    dot(56, 52, 7, "bold"),
+    dot(50, 52, 10, "glow", 0.9),
+    line(47, 52, 53, 52, "warm"),
+    line(50, 49, 50, 55, "warm"),
+  )
+  return out
+}
+
+/** MOSAIC — a stained-glass wall that is a times table. */
+const tiles: Motif = (rng) => {
+  const out: Shape[] = []
+  for (let row = 0; row < 4; row++) {
+    for (let col = 0; col < 6; col++) {
+      if (rng() < 0.18) continue
+      out.push(box(11 + col * 13, 12 + row * 11, 11, 9, rng() < 0.25 ? "fill" : "line", 0.65))
+    }
+  }
+  out.push(
+    box(36, 84, 28, 5, "bold", 1, 2),
+    dot(58, 74, 3.2, "warm"),
+    path("M58 74Q44 62 30 58", "line", 0.6, "4 4"),
+    line(36, 84, 64, 84, "glow", 0.7),
+  )
+  return out
+}
+
+/** POLARITY — the ship's sign is the arithmetic. */
+const polarity: Motif = (rng) => {
+  const out: Shape[] = [
+    poly([50, 60, 60, 82, 50, 76, 40, 82], "fill", 0.95),
+    poly([50, 60, 60, 82, 50, 76, 40, 82], "line"),
+    dot(50, 72, 14, "glow", 0.5),
+  ]
+  for (let i = 0; i < 4; i++) {
+    const x = 16 + i * 23
+    const y = between(rng, 18, 38)
+    const plus = rng() < 0.5
+    out.push(dot(x, y, 7, plus ? "bold" : "veil"), line(x - 3.5, y, x + 3.5, y, plus ? "warm" : "line"))
+    if (plus) out.push(line(x, y - 3.5, x, y + 3.5, "warm"))
+    out.push(line(x, y + 8, 50, 58, "thin", 0.35, "3 4"))
+  }
+  return out
+}
+
+/** PULSE — the playfield is exactly one bar. */
+const bar: Motif = (rng) => {
+  const head = between(rng, 40, 74)
+  const out: Shape[] = [box(8, 40, 84, 22, "veil"), line(8, 51, 92, 51, "thin", 0.4)]
+  for (let i = 1; i < 4; i++) out.push(line(8 + i * 21, 36, 8 + i * 21, 66, "line", 0.7))
+  for (let i = 0; i < 4; i++) {
+    out.push(dot(8 + i * 21 + 10.5, 51, i === 1 ? 5.5 : 4, i === 1 ? "warm" : "fill", 0.9))
+  }
+  out.push(line(head, 30, head, 72, "bold"), line(head, 30, head, 72, "glow", 0.8), line(8, 74, 92, 74, "veil"))
+  return out
+}
+
+/** SPLITBEAT — the bar of music is the fraction bar. */
+const lanes: Motif = (rng) => {
+  const out: Shape[] = [
+    line(50, 14, 14, 88, "veil"),
+    line(50, 14, 50, 88, "veil"),
+    line(50, 14, 86, 88, "veil"),
+  ]
+  const depths = [36, 54, 76]
+  depths.forEach((y, index) => {
+    const spread = (y - 14) * 0.49
+    const parts = 1 << index
+    for (let i = 0; i < parts; i++) {
+      const x1 = 50 - spread + (i * 2 * spread) / parts + 1
+      const x2 = 50 - spread + ((i + 1) * 2 * spread) / parts - 1
+      out.push(line(x1, y, x2, y, index === 2 ? "bold" : "line", 0.9))
+    }
+  })
+  out.push(
+    line(8, 88, 92, 88, "bold"),
+    line(8, 88, 92, 88, "glow", 0.8),
+    dot(between(rng, 26, 74), 88, 3, "warm"),
+  )
+  return out
+}
+
+/** VOLTA — the lane you are in when you cross is the answer you gave. */
+const causeway: Motif = (rng) => {
+  const out: Shape[] = [
+    line(20, 96, 46, 22, "line"),
+    line(80, 96, 54, 22, "line"),
+    line(6, 22, 94, 22, "veil"),
+  ]
+  for (let i = 0; i < 5; i++) {
+    const t = i / 5
+    const y = 96 - t * 68
+    out.push(line(50, y, 50, y - 6, "veil", 0.7))
+  }
+  for (let i = 0; i < 3; i++) {
+    const x = 38 + i * 12
+    out.push(path(`M${n(x - 5)} 54L${n(x - 5)} 46A5 5 0 0 1 ${n(x + 5)} 46L${n(x + 5)} 54`, i === 1 ? "warm" : "line", 0.9))
+  }
+  out.push(
+    poly([50, 76, 56, 90, 50, 86, 44, 90], "fill", 0.95),
+    line(50, 78, 50, 96, "glow", 0.7),
+    dot(between(rng, 20, 80), between(rng, 10, 18), 1.8, "pale", 0.6),
+  )
+  return out
+}
+
+/** SERPENT — every orb is a claim, and the wrong one costs a length of tail. */
+const serpent: Motif = (rng) => {
+  const wave = between(rng, 16, 26)
+  const spine = `M10 74Q${n(26)} ${n(74 - wave)} 34 58Q${n(42)} ${n(42)} 54 44Q${n(66)} ${n(46)} 68 32Q${n(70)} ${n(20)} 84 18`
+  const out: Shape[] = [path(spine, "glow", 0.8), path(spine, "bold")]
+  for (let i = 0; i < 7; i++) {
+    const t = i / 6
+    out.push(dot(10 + t * 60, 74 - t * 44 + Math.sin(t * 6) * 5, 2.2, "fill", 0.7 - t * 0.3))
+  }
+  out.push(dot(84, 18, 5.5, "bold"), dot(86, 16, 1.6, "warm"))
+  for (let i = 0; i < 3; i++) {
+    const x = between(rng, 20, 84)
+    const y = between(rng, 74, 92)
+    out.push(dot(x, y, 4.5, "veil"), dot(x, y, 1.8, "fill", 0.8))
+  }
+  return out
+}
+
+/** SIEGE — the anvil mints embers, and embers hold the line. */
+const wall: Motif = (rng) => {
+  const out: Shape[] = [box(20, 54, 60, 30, "line")]
+  for (let i = 0; i < 5; i++) out.push(box(20 + i * 13, 46, 8, 8, "line"))
+  out.push(path("M0 92Q26 84 52 92", "veil", 0.9, "5 4"))
+  for (let i = 0; i < 8; i++) {
+    out.push(
+      dot(between(rng, 26, 74), between(rng, 14, 44), between(rng, 1.2, 3), i % 3 === 0 ? "warm" : "fill", between(rng, 0.4, 0.95)),
+    )
+  }
+  out.push(box(38, 68, 24, 16, "fill", 0.25), line(20, 68, 80, 68, "glow", 0.6))
+  return out
+}
+
+/** SKY LEDGER — the sky is the coordinate plane. */
+const astrolabe: Motif = (rng) => {
+  const out: Shape[] = []
+  for (let i = 1; i < 5; i++) {
+    out.push(line(i * 20, 6, i * 20, 94, "veil", 0.4), line(6, i * 20, 94, i * 20, "veil", 0.4))
+  }
+  const angle = between(rng, -70, -20)
+  out.push(
+    dot(50, 54, 27, "line"),
+    dot(50, 54, 19, "veil"),
+    dot(50, 54, 2.5, "fill"),
+    ray(50, 54, -27, 27, angle, "bold"),
+    dot(px(50, 27, angle), py(54, 27, angle), 3, "warm"),
+  )
+  for (let i = 0; i < 12; i++) out.push(ray(50, 54, 24, 27, i * 30, "thin", 0.7))
+  const sx = between(rng, 10, 34)
+  out.push(line(sx, 10, sx + 12, 26, "line", 0.8, "4 3"), dot(sx + 12, 26, 2.4, "pale"))
+  return out
+}
+
+/** THE SPLIT — cut a composite open and its factors come out of the wound. */
+const split: Motif = (rng) => {
+  const lean = between(rng, -10, 10)
+  return [
+    line(8, 88, 92, 12, "glow", 0.8),
+    line(8, 88, 92, 12, "bold"),
+    dot(50 + lean, 24, 9, "line"),
+    line(50 + lean, 24, 50 + lean, 26, "warm"),
+    line(46 + lean, 33, 30, 56, "line", 0.8),
+    line(54 + lean, 33, 70, 56, "line", 0.8),
+    dot(30, 62, 7, "bold"),
+    dot(70, 62, 7, "bold"),
+    line(24, 68, 18, 82, "thin", 0.6),
+    line(36, 68, 42, 82, "thin", 0.6),
+    dot(18, 86, 3.5, "fill", 0.8),
+    dot(42, 86, 3.5, "fill", 0.8),
+    dot(70, 62, 2.5, "warm"),
+  ]
+}
+
+/** MONUMENT — the drop has to be true twice. */
+const slabs: Motif = (rng) => {
+  const out: Shape[] = []
+  let x = 24
+  for (let i = 0; i < 6; i++) {
+    x += between(rng, -5, 5)
+    out.push(box(x, 82 - i * 11, 52, 9, i === 0 ? "fill" : "line", i === 0 ? 0.3 : 1))
+  }
+  const sweep = between(rng, 8, 30)
+  out.push(
+    box(sweep, 10, 52, 9, "bold"),
+    line(sweep - 8, 14.5, sweep - 2, 14.5, "warm", 0.9),
+    line(50, 6, 50, 94, "veil", 0.5, "3 5"),
+    box(sweep, 10, 52, 9, "glow", 0.35),
+  )
+  return out
+}
+
+/** FOUNDRY STREET — a mob that splits is not a mob. */
+const street: Motif = (rng) => {
+  const out: Shape[] = [line(4, 94, 40, 26, "veil"), line(96, 94, 60, 26, "veil"), line(6, 26, 94, 26, "veil", 0.6)]
+  for (let i = 0; i < 7; i++) {
+    const x = 14 + i * 12
+    const h = between(rng, 14, 22)
+    out.push(
+      path(`M${n(x)} ${n(74)}L${n(x)} ${n(74 - h)}`, i === 3 ? "veil" : "line"),
+      dot(x, 74 - h - 3.5, 3.2, i === 3 ? "veil" : "fill", 0.85),
+    )
+  }
+  out.push(
+    path("M50 96L46 80L54 66L48 52L52 38", "glow", 0.9),
+    path("M50 96L46 80L54 66L48 52L52 38", "warm"),
+    dot(52, 38, 2.6, "warm"),
+  )
+  return out
+}
+
+/** TREBUCHET — the range dial is the answer. */
+const trebuchet: Motif = (rng) => {
+  const reach = between(rng, 62, 86)
+  return [
+    poly([14, 84, 30, 44, 46, 84], "line"),
+    line(10, 84, 92, 84, "veil"),
+    line(30, 44, 18, 62, "bold"),
+    box(13, 62, 10, 9, "fill", 0.9),
+    line(30, 44, 52, 30, "line"),
+    path(`M52 30Q${n((52 + reach) / 2)} 2 ${n(reach)} 76`, "warm", 0.85, "5 4"),
+    box(reach - 8, 66, 17, 18, "line"),
+    box(reach - 8, 62, 4, 4, "line"),
+    box(reach - 1, 62, 4, 4, "line"),
+    box(reach + 6, 62, 4, 4, "line"),
+    dot(reach, 76, 3, "glow", 0.9),
+  ]
+}
+
+/** THE TRUE DRAW — draw if it is true, hold if it is false. */
+const slate: Motif = (rng) => {
+  const out: Shape[] = [
+    box(16, 22, 68, 38, "fill", 0.16, 2),
+    box(16, 22, 68, 38, "line", 1, 2),
+    box(16, 22, 68, 38, "glow", 0.4, 2),
+  ]
+  for (let i = 0; i < 3; i++) {
+    out.push(line(24, 32 + i * 10, 24 + between(rng, 26, 52), 32 + i * 10, i === 1 ? "warm" : "pale", i === 1 ? 0.9 : 0.55))
+  }
+  out.push(
+    path("M28 76L36 84L50 68", "bold"),
+    line(64, 68, 64, 84, "veil"),
+    line(72, 68, 72, 84, "veil"),
+  )
+  for (let i = 0; i < 9; i++) out.push(dot(between(rng, 8, 92), between(rng, 88, 96), between(rng, 0.6, 1.4), "pale", 0.4))
+  return out
+}
+
+/**
+ * The fallback, and the reason a twenty-eighth game needs no code change here.
+ *
+ * A seeded star polygon inside two rings: the point count, the skip and the
+ * ray pattern all come out of the id, so two unknown packs get two visibly
+ * different sigils rather than the same grey placeholder twice. It is the one
+ * motif that is genuinely procedural, and it is deliberately the *most*
+ * ornamental of the set — an unrecognised game should look like it was made
+ * for this app, not like a hole in it.
+ */
+const sigil: Motif = (rng) => {
+  const points = 7 + Math.floor(rng() * 6)
+  const skip = 2 + Math.floor(rng() * Math.max(1, Math.floor(points / 2) - 1))
+  const radius = between(rng, 28, 34)
+  const spin = between(rng, 0, 90)
+
+  let d = ""
+  for (let i = 0; i <= points; i++) {
+    const angle = spin + ((i * skip) % points) * (360 / points)
+    d += `${i === 0 ? "M" : "L"}${n(px(50, radius, angle))} ${n(py(52, radius, angle))}`
+  }
+
+  const out: Shape[] = [path(`${d}Z`, "glow", 0.6), path(`${d}Z`, "line"), dot(50, 52, radius + 5, "veil")]
+  for (let i = 0; i < points; i++) {
+    const angle = spin + i * (360 / points)
+    out.push(ray(50, 52, radius + 5, radius + 11, angle, "thin", 0.6))
+    out.push(dot(px(50, radius, angle), py(52, radius, angle), 1.6, "fill", 0.8))
+  }
+  out.push(dot(50, 52, between(rng, 4, 8), "warm", 0.9), dot(50, 52, 14, "veil"))
+  return out
+}
+
+const MOTIFS = {
+  orbs,
+  balance,
+  beams,
+  region,
+  coil,
+  tower,
+  steelyard,
+  anvil,
+  ring,
+  crosshair,
+  swarm,
+  springgrid,
+  reef,
+  well,
+  tiles,
+  polarity,
+  bar,
+  lanes,
+  causeway,
+  serpent,
+  wall,
+  astrolabe,
+  split,
+  slabs,
+  street,
+  trebuchet,
+  slate,
+  sigil,
+} as const satisfies Record<string, Motif>
+
+export type MotifKey = keyof typeof MOTIFS
+
+export const MOTIF_KEYS = Object.keys(MOTIFS) as readonly MotifKey[]
+
+/** Draw one. Total over `MotifKey`, so an unknown key is a type error here. */
+export function shapesOf(motif: MotifKey, rng: () => number): readonly Shape[] {
+  return MOTIFS[motif](rng)
+}

--- a/dynawalla/dynawalla-app/src/design/Mark.tsx
+++ b/dynawalla/dynawalla-app/src/design/Mark.tsx
@@ -1,0 +1,51 @@
+/**
+ * The Dynawalla mark.
+ *
+ * Hand-vectorised from the founder's original and kept in the repository at
+ * `dynawalla/brand/mark.svg` — an earlier pass built the brand in a scratch
+ * directory and lost every file of it in one cleanup, which is why the source
+ * of truth is committed and why this component is a transcription of that file
+ * rather than a second drawing of the same idea.
+ *
+ * It reads four ways at once, which is the point: an onion dome with a spire, a
+ * gear at its heart, wings sweeping below it, and a brain in the negative
+ * space. Sharp, pointing up, clockmaker G-d.
+ *
+ * `fill="currentColor"` and nothing else. The mark takes the colour of whatever
+ * it is set in, so the brand rule — the mark is never washed in a colour, only
+ * ever the ink of its surface — is a property of the component rather than a
+ * note somebody has to remember. `fill-rule="evenodd"` is load bearing: the
+ * dome is one path whose inner contour cuts the shell open.
+ *
+ * Decorative by default. The wordmark beside it is the accessible name; a mark
+ * and a word both announcing "Dynawalla" is the same thing said twice to a
+ * screen reader. Pass a `title` where it stands alone.
+ */
+export function Mark({ className, title }: { className?: string; title?: string }) {
+  return (
+    <svg
+      viewBox="0 0 512 512"
+      fill="currentColor"
+      fillRule="evenodd"
+      className={className}
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
+      focusable="false"
+    >
+      {title ? <title>{title}</title> : null}
+      <path d="M256 32L244.46 94.41C241.04 102.96 229.92 107.24 228.21 116.64C229.92 148.27 182.9 154.26 164.95 176.49C141.86 195.3 124.76 218.38 117.92 244.89C112.79 261.98 111.94 284.21 117.92 309.86L394.08 309.86C400.06 284.21 399.21 261.98 394.08 244.89C387.24 218.38 370.14 195.3 347.05 176.49C329.1 154.26 282.08 148.27 283.79 116.64C282.08 107.24 270.96 102.96 267.54 94.41L256 32M261.56 118.35C264.98 125.19 261.56 135.45 266.69 142.29C280.37 161.1 307.73 168.79 324.82 185.04C346.2 201.28 365.01 220.95 370.99 244.89C376.12 259.42 378.69 287.63 370.99 309.86L141.01 309.86C133.31 287.63 135.88 259.42 141.01 244.89C146.99 220.95 165.8 201.28 187.18 185.04C204.27 168.79 231.63 161.1 245.31 142.29C250.44 135.45 247.02 125.19 250.44 118.35A8.12 8.12 0 0 0 261.56 118.35Z" />
+      <path d="M220.52 312.43Q205.13 305.59 188.68 291.91L165.37 291.91L165.37 259.42L188.68 259.42A69.25 69.25 0 0 1 196.91 239.55L180.43 223.07L203.4 200.1L219.88 216.58A69.25 69.25 0 0 1 239.76 208.34L239.76 185.04L272.24 185.04L272.24 208.34A69.25 69.25 0 0 1 292.12 216.58L308.6 200.1L331.57 223.07L315.09 239.55A69.25 69.25 0 0 1 323.32 259.42L346.63 259.42L346.63 291.91L323.32 291.91Q306.87 305.59 291.48 312.43Q292.34 298.75 296.18 275.66A40.18 40.18 0 0 0 215.82 275.66Q219.66 298.75 220.52 312.43Z" />
+      <path d="M123.91 302.17L149.25 302.17A118.84 118.84 0 0 1 251.38 396.01A182.53 182.53 0 0 0 123.91 317Z" />
+      <path
+        transform="matrix(-1 0 0 1 512 0)"
+        d="M123.91 302.17L149.25 302.17A118.84 118.84 0 0 1 251.38 396.01A182.53 182.53 0 0 0 123.91 317Z"
+      />
+      <path d="M123.91 342.35A84.64 84.64 0 0 1 192.37 399.78A129.95 129.95 0 0 0 123.91 365.49Z" />
+      <path
+        transform="matrix(-1 0 0 1 512 0)"
+        d="M123.91 342.35A84.64 84.64 0 0 1 192.37 399.78A129.95 129.95 0 0 0 123.91 365.49Z"
+      />
+      <path d="M103.82 302.17L123.48 302.17L123.48 342.35L146.99 364.58L146.99 405.62C148.27 422.72 139.3 438.11 127.33 449.65C194.87 437.25 317.13 437.25 384.67 449.65C372.7 438.11 363.73 422.72 365.01 405.62L365.01 364.58L388.52 342.35L388.52 302.17L408.18 302.17L408.18 358.6L387.66 364.58L387.66 405.62C389.37 425.28 405.19 437.25 423.15 443.24L436.82 478.72C310.72 464.61 201.28 464.61 75.18 478.72L88.85 443.24C106.81 437.25 122.63 425.28 124.34 405.62L124.34 364.58L103.82 358.6Z" />
+    </svg>
+  )
+}

--- a/dynawalla/dynawalla-app/src/design/tokens.css
+++ b/dynawalla/dynawalla-app/src/design/tokens.css
@@ -59,40 +59,60 @@
   --text-4xl--line-height: 1.05;
 
   /* ── Materials ─────────────────────────────────────────────────────────
-     Named for the substance, numbered light to dark. */
+     Named for the substance, numbered light to dark.
 
-  /* Parchment — the lit ground. */
-  --color-parchment-50: #faf4e8;
-  --color-parchment-100: #f2e9d7;
-  --color-parchment-200: #e6d9c0;
-  --color-parchment-300: #d6c5a5;
+     **Repainted from `dynawalla/brand/README.md`.** The names below are the
+     ones the semantic layer already refers to and they are kept; every VALUE
+     is now sampled from the mark itself, whose dominant saturated pixel is
+     `#864de8`. The direction is the founder's: futuristic space angels,
+     gear-brain minaret, sharp and pointing up, clockmaker G-d, al-Andalus.
+     Explicitly dead, also his words: the dusty khaki sandstorm feel — which is
+     exactly what this palette used to be, so nothing here is warm earth any
+     more. **The void is violet**, `#0b0618`, never grey and never `#111111`. */
 
-  /* Carved limestone — structure, rules, incised edges. */
-  --color-stone-200: #c9bfae;
-  --color-stone-400: #a2967f;
-  --color-stone-600: #6f6553;
-  --color-stone-800: #40392e;
+  /* Parchment — the lit ground. Violet-white, not cream. */
+  --color-parchment-50: #ffffff;
+  --color-parchment-100: #f4f0ff;
+  --color-parchment-200: #e9e2fb;
+  --color-parchment-300: #dcd2f5;
 
-  /* Basalt — the unlit ground, and ink on parchment. */
-  --color-basalt-700: #2b2721;
-  --color-basalt-800: #211d18;
-  --color-basalt-900: #17140f;
-  --color-basalt-950: #100e0a;
+  /* Carved limestone — structure, rules, incised edges. Violet-grey. */
+  --color-stone-200: #c9bcec;
+  --color-stone-400: #b9a6ec;
+  --color-stone-600: #5b5175;
+  --color-stone-800: #2a1b4d;
 
-  /* Brass — the index, the pointer, the working mechanism. */
-  --color-brass-300: #e3c179;
-  --color-brass-500: #c39a3c;
-  --color-brass-700: #8a6a24;
+  /* Basalt — the unlit ground, and ink on parchment. Violet-black. */
+  --color-basalt-700: #150c2e;
+  --color-basalt-800: #0b0618;
+  --color-basalt-900: #1a1033;
+  --color-basalt-950: #060310;
 
-  /* Lapis — the deep field; the sky an astrolabe is read against. */
-  --color-lapis-400: #4a7ec4;
-  --color-lapis-600: #2c5697;
-  --color-lapis-800: #1a3160;
-  --color-lapis-950: #101d3a;
+  /* Brass — the index, the pointer, the working mechanism, and the brand's
+     one warm point (`--dw-apex` in the brand README is this material). */
+  --color-brass-300: #ffe7b0;
+  --color-brass-500: #e0b15a;
+  --color-brass-700: #b45309;
+
+  /* Aurora — the lit line. The mark's own violet, and the accent the whole
+     app is drawn in. `400` is the bloom: light, never paint. */
+  --color-aurora-300: #c9b4ff;
+  --color-aurora-350: #a78bfa;
+  --color-aurora-400: #b88cff;
+  --color-aurora-500: #9258ff;
+  --color-aurora-600: #6d28d9;
+  --color-aurora-700: #5b21b6;
+
+  /* Lapis — the deep field; the sky an astrolabe is read against. Now a deep
+     violet rather than a blue, so the field and the ground are one stone. */
+  --color-lapis-400: #b88cff;
+  --color-lapis-600: #6d28d9;
+  --color-lapis-800: #241246;
+  --color-lapis-950: #0b0618;
 
   /* Glazed tile — cool ceramic, for calm affirmative surfaces. */
-  --color-tile-400: #45a3a8;
-  --color-tile-600: #1f7379;
+  --color-tile-400: #38bfc9;
+  --color-tile-600: #0e7490;
   /* …and the same glaze as a wash, thin enough to be a ground rather than a
      fill. Two entries because a wash is a material: on parchment the dark tile
      at 14% is a tint you can see, and on basalt it is nothing at all, so the
@@ -100,20 +120,46 @@
      as alpha rather than `color-mix` because this bundle's floor is iOS 16.0
      and `color-mix` lands in 16.2 — an unsupported declaration would drop the
      recess silently on the oldest devices we ship to. */
-  --color-tile-600-wash: rgb(31 115 121 / 0.14);
-  --color-tile-400-wash: rgb(69 163 168 / 0.18);
+  --color-tile-600-wash: rgb(14 116 144 / 0.14);
+  --color-tile-400-wash: rgb(56 191 201 / 0.18);
 
   /* Copper and its oxide — the tone of a struck, incorrect mark. */
-  --color-copper-500: #a85b33;
-  --color-copper-700: #7a3f22;
+  --color-copper-400: #f08a7e;
+  --color-copper-500: #c2453c;
+  --color-copper-700: #8c2f27;
 
   /* Walnut — cabinetry, frames, the case an instrument sits in. */
-  --color-walnut-600: #5a4130;
-  --color-walnut-800: #33241a;
+  --color-walnut-600: #3b2a63;
+  --color-walnut-800: #1c1233;
 
   /* Celestial — cold light. Highlights only; never a fill. */
-  --color-celestial-100: #e4eef8;
-  --color-celestial-300: #a9c9e6;
+  --color-celestial-100: #e8deff;
+  --color-celestial-300: #c9b4ff;
+
+  /* ── The arc ───────────────────────────────────────────────────────────
+     Twelve lit hues for generated key art, and nothing else in the app may
+     use them. Every game's card carries a drawing that has to be legible as
+     *that game* at a glance in a grid of twenty-seven, so hue is one of the
+     two axes the art varies on (motif is the other).
+
+     It is an arc, not a wheel: eleven steps sweep cyan → indigo → violet →
+     magenta → rose, which is the mark's own band, and the twelfth is the warm
+     gold so a handful of games read warm against the rest. All twelve are
+     HSL(h 82% 68%) — one saturation and one lightness — which is what keeps
+     twenty-seven different drawings looking like one family. Measured against
+     the void `#0b0618` they run 4.88:1 to 12.16:1. */
+  --color-arc-1: #6acdf0;
+  --color-arc-2: #6aadf0;
+  --color-arc-3: #6a8ef0;
+  --color-arc-4: #6a6ff0;
+  --color-arc-5: #856af0;
+  --color-arc-6: #a46af0;
+  --color-arc-7: #c46af0;
+  --color-arc-8: #e36af0;
+  --color-arc-9: #f06ad6;
+  --color-arc-10: #f06aad;
+  --color-arc-11: #f06a85;
+  --color-arc-12: #f0c46a;
 }
 
 /* ── Semantic layer, light ────────────────────────────────────────────────
@@ -138,9 +184,19 @@
   --dw-ink-muted: var(--color-stone-600);
   --dw-ink-inverse: var(--color-parchment-50);
 
-  /* The mechanism: the index that points at where you are. */
+  /* The mechanism: the index that points at where you are. This is also the
+     brand's one warm point — the apex, used once per screen and no more. */
   --dw-index: var(--color-brass-700);
   --dw-index-lit: var(--color-brass-500);
+
+  /* The lit line: the mark's own violet, and the app's accent. `--dw-accent`
+     is for line art, borders and state; `--dw-accent-ink` is the one a child
+     actually READS, because accent-on-ground clears AA for normal text only by
+     a hair. `--dw-bloom` is light and never paint — a filled bloom-coloured
+     shape is the named failure mode for this brand. */
+  --dw-accent: var(--color-aurora-600);
+  --dw-accent-ink: var(--color-aurora-700);
+  --dw-bloom: var(--color-aurora-350);
 
   /* The deep field, and what is legible against it. */
   --dw-field: var(--color-lapis-800);
@@ -174,6 +230,36 @@
   /* Focus ring. Contrast against the ground is what matters here, so it is a
      semantic role of its own rather than a reuse of the index. */
   --dw-focus: var(--color-lapis-600);
+
+  /* ── Generated key art ─────────────────────────────────────────────────
+     The one part of this design that does NOT re-cut for dark, and the
+     duplication under `.dw-dark` below is deliberate rather than an oversight.
+
+     A game's key art is a picture of that game. It is the same picture on a
+     lit tablet and an unlit one for the same reason a photograph on a shelf is
+     the same photograph at night: inverting it would not be theming, it would
+     be a second drawing. So the void it hangs in and the twelve hues drawn on
+     it are fixed, and the card AROUND the art is what follows the theme.
+
+     The token test requires a material-derived semantic token to exist in both
+     blocks, which is the right rule — so these are declared twice, with the
+     same value, rather than smuggled in through a stylesheet that the layering
+     test does not read. */
+  --dw-art-void: var(--color-basalt-800);
+  --dw-art-warm: var(--color-brass-300);
+  --dw-art-pale: var(--color-celestial-100);
+  --dw-art-1: var(--color-arc-1);
+  --dw-art-2: var(--color-arc-2);
+  --dw-art-3: var(--color-arc-3);
+  --dw-art-4: var(--color-arc-4);
+  --dw-art-5: var(--color-arc-5);
+  --dw-art-6: var(--color-arc-6);
+  --dw-art-7: var(--color-arc-7);
+  --dw-art-8: var(--color-arc-8);
+  --dw-art-9: var(--color-arc-9);
+  --dw-art-10: var(--color-arc-10);
+  --dw-art-11: var(--color-arc-11);
+  --dw-art-12: var(--color-arc-12);
 
   /* ── Non-material tokens ───────────────────────────────────────────────
      These carry no colour and therefore do not re-cut in dark. The token
@@ -282,19 +368,45 @@
   --dw-index: var(--color-brass-300);
   --dw-index-lit: var(--color-brass-500);
 
-  --dw-field: var(--color-lapis-950);
+  --dw-accent: var(--color-aurora-500);
+  --dw-accent-ink: var(--color-aurora-300);
+  --dw-bloom: var(--color-aurora-400);
+
+  --dw-field: var(--color-lapis-800);
   --dw-field-ink: var(--color-celestial-300);
 
   --dw-aperture: var(--color-lapis-950);
   --dw-aperture-rim: var(--color-celestial-300);
 
   --dw-seat: var(--color-tile-400);
-  --dw-strike: var(--color-copper-700);
+  /* The lighter oxide, not the darker one. `copper-700` on the violet void is
+     a mark a child has to hunt for; a strike is the one thing on the screen
+     that must never be missed. */
+  --dw-strike: var(--color-copper-400);
   --dw-seat-ground: var(--color-tile-400-wash);
 
   --dw-case: var(--color-walnut-800);
 
   --dw-focus: var(--color-lapis-400);
+
+  /* Key art does not re-cut — see the block above. Same values, stated twice,
+     because the layering test is right to insist and a stylesheet it cannot
+     read is the wrong place to answer it. */
+  --dw-art-void: var(--color-basalt-800);
+  --dw-art-warm: var(--color-brass-300);
+  --dw-art-pale: var(--color-celestial-100);
+  --dw-art-1: var(--color-arc-1);
+  --dw-art-2: var(--color-arc-2);
+  --dw-art-3: var(--color-arc-3);
+  --dw-art-4: var(--color-arc-4);
+  --dw-art-5: var(--color-arc-5);
+  --dw-art-6: var(--color-arc-6);
+  --dw-art-7: var(--color-arc-7);
+  --dw-art-8: var(--color-arc-8);
+  --dw-art-9: var(--color-arc-9);
+  --dw-art-10: var(--color-arc-10);
+  --dw-art-11: var(--color-arc-11);
+  --dw-art-12: var(--color-arc-12);
 }
 
 /* ── Utilities ────────────────────────────────────────────────────────────
@@ -314,6 +426,9 @@
   --color-ink-inverse: var(--dw-ink-inverse);
   --color-index: var(--dw-index);
   --color-index-lit: var(--dw-index-lit);
+  --color-accent: var(--dw-accent);
+  --color-accent-ink: var(--dw-accent-ink);
+  --color-bloom: var(--dw-bloom);
   --color-field: var(--dw-field);
   --color-field-ink: var(--dw-field-ink);
   --color-seat: var(--dw-seat);

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 @import "./design/tokens.css";
+/* The generated key art's inks and its twelve hue classes. A stylesheet rather
+   than a style prop because `style-src 'self'` discards the latter in the
+   shipped build while it works perfectly in dev — see the header of the file. */
+@import "./catalog/catalog.css";
 
 /* The theme class the shell toggles on <html>. `:where()` keeps specificity at
    zero so a dark utility never outranks a more specific rule by accident. */

--- a/dynawalla/dynawalla-app/src/packs/libraryStore.ts
+++ b/dynawalla/dynawalla-app/src/packs/libraryStore.ts
@@ -53,6 +53,12 @@ export const useLibrary = create<LibraryState>()((set) => ({
           bytes: entry.bytes,
           sha256: entry.manifest.download.sha256,
           installedAt: Date.now(),
+          // What the catalogue draws a card from. Written here, from the same
+          // manifest the version came from, so the record and the card cannot
+          // disagree about what a pack is.
+          description: entry.description,
+          skills: entry.manifest.covers.skills,
+          grades: entry.manifest.covers.grades,
         })
       }
       const live = new Set(entries.map((entry) => entry.manifest.id))

--- a/dynawalla/dynawalla-app/src/packs/registry.ts
+++ b/dynawalla/dynawalla-app/src/packs/registry.ts
@@ -30,6 +30,23 @@ export interface InstalledPack {
   /** The digest the installer verified against. Empty before it verified one. */
   readonly sha256: string
   readonly installedAt: number
+
+  /* ── What the front door needs to draw a card ─────────────────────────────
+     Copied from the manifest at install time rather than fetched again. A
+     catalogue that could only describe a pack once the native library had
+     finished reading the pack root would draw a grid of unlabelled tiles on
+     every cold launch, for as long as that read takes on a cheap tablet.
+
+     Optional because a record written by an older build has none of them, and
+     that record is on disk today. Everything downstream degrades to the pack's
+     name and nothing else. */
+
+  /** One line, already in the child's language. */
+  readonly description?: string
+  /** `covers.skills` — the ids the subject filter is derived from. */
+  readonly skills?: readonly string[]
+  /** `covers.grades` — inclusive band, `[1, 4]` is grades one to four. */
+  readonly grades?: readonly [number, number]
 }
 
 export interface RegistryState {

--- a/dynawalla/dynawalla-app/src/shell/Surface.tsx
+++ b/dynawalla/dynawalla-app/src/shell/Surface.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react"
 
+import { Catalog } from "../catalog/Catalog.tsx"
 import { IndexMark } from "../design/IndexMark.tsx"
 import { strings } from "../app/strings.ts"
 import type { Destination } from "../app/routes.ts"
 import { WorldScreen } from "../world/Screen.tsx"
-import { surfaceOf, type Row } from "./surfaces.ts"
+import { surfaceOf, type Row, type Section } from "./surfaces.ts"
 import { useHostActions, useHostView } from "./useHost.ts"
 
 /**
@@ -160,43 +161,6 @@ function Figure({ value, label }: Keyless<"figure">) {
 }
 
 /**
- * A pack, as the whole row is the button.
- *
- * The only plate in this shell that is taller than a course: it is the front
- * door and the thing the app is for, and a game should not be a line of small
- * type between two settings. The name is the label, the version and the size
- * are the small print, and the whole rectangle is the target — a child aiming
- * at a word is a child missing.
- */
-function Pack({ name, version, size, play, resting }: Keyless<"pack">) {
-  return (
-    <button
-      type="button"
-      onClick={play}
-      className={[
-        "group flex min-h-24 w-full items-center gap-4 py-4 text-left",
-        "transition-colors duration-[var(--dw-motion-quick)] hover:bg-ground-sunk",
-      ].join(" ")}
-    >
-      <IndexMark className="text-index shrink-0 opacity-40 transition-opacity duration-[var(--dw-motion-quick)] group-hover:opacity-100 group-focus-visible:opacity-100" />
-      <span className="min-w-0 flex-1">
-        <span className="inscription text-ink block truncate text-2xl tracking-wide">{name}</span>
-        <span className="numeral text-ink-muted block text-xs">
-          {version} · {size}
-        </span>
-      </span>
-      {/* A game that already ended today says so, in the same small type as the
-          version, and keeps its full-strength name and its working control. It
-          is not dimmed, not badged, not padlocked and not sorted to the bottom:
-          nothing about this row is a price, and nothing about it is a lock. */}
-      <span className="border-line-cut rounded-cut-sm text-ink-muted shrink-0 border px-3 py-2 text-sm">
-        {resting ? strings.packs.tomorrow : strings.packs.play}
-      </span>
-    </button>
-  )
-}
-
-/**
  * One row, drawn.
  *
  * Written out rather than spread: a `Row` carries its own `key`, and
@@ -223,17 +187,22 @@ function RowView({ row }: { row: Row }) {
       void key
       return <Learner {...rest} />
     }
-    case "pack": {
-      const { key, ...rest } = row
-      void key
-      return <Pack {...rest} />
-    }
+    // A pack is never drawn as a course row. It is a card in the catalogue,
+    // which is a grid rather than a list, so the whole section is handed to
+    // one component below instead of each row being drawn on its own.
+    case "pack":
+      return null
     case "figure": {
       const { key, ...rest } = row
       void key
       return <Figure {...rest} />
     }
   }
+}
+
+/** Every row in this section is a game. Then it is a catalogue, not a course. */
+function isCatalogue(section: Section): boolean {
+  return section.rows.length > 0 && section.rows.every((row) => row.kind === "pack")
 }
 
 export function Surface({ destination }: { destination: Destination }) {
@@ -244,18 +213,30 @@ export function Surface({ destination }: { destination: Destination }) {
 
   return (
     <div className="flex flex-col gap-[var(--dw-stack-gap)]">
-      {sections.map((section) => (
-        // A rule above the course and one between every pair of rows, but none
-        // under the last: a closing rule plus the next section's opening one
-        // reads as a double line at every seam, which is a groove nobody cut.
-        <ul key={section.key} className="border-line border-t">
-          {section.rows.map((row) => (
-            <li key={row.key} className="border-line border-b last:border-b-0">
-              <RowView row={row} />
-            </li>
-          ))}
-        </ul>
-      ))}
+      {sections.map((section) =>
+        isCatalogue(section) ? (
+          // The games, as a grid of cards with a search field and the subject
+          // chips above them. Full measure: a listing wants columns, and the
+          // 42 rem reading measure the courses below are set to would give a
+          // desktop three of them.
+          <Catalog
+            key={section.key}
+            rows={section.rows.filter((row) => row.kind === "pack")}
+          />
+        ) : (
+          // A rule above the course and one between every pair of rows, but
+          // none under the last: a closing rule plus the next section's opening
+          // one reads as a double line at every seam, which is a groove nobody
+          // cut.
+          <ul key={section.key} className="border-line mx-auto w-full max-w-2xl border-t">
+            {section.rows.map((row) => (
+              <li key={row.key} className="border-line border-b last:border-b-0">
+                <RowView row={row} />
+              </li>
+            ))}
+          </ul>
+        ),
+      )}
     </div>
   )
 }

--- a/dynawalla/dynawalla-app/src/shell/surfaces.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.ts
@@ -86,6 +86,21 @@ export type Row =
       readonly version: string
       /** What it occupies, already formatted. Never a bare byte count. */
       readonly size: string
+      /** One line about the game. Empty for a record written before this. */
+      readonly description: string
+      /**
+       * `covers.skills`, straight from the manifest.
+       *
+       * Handed over raw rather than pre-filed into a subject, because filing
+       * is a *view* concern: the catalogue derives the subject chips from
+       * these at render time (`catalog/domains.ts`), so a pack covering a
+       * subject this build has never heard of is still described here in full
+       * and is still listed. A surface that filtered would be a surface that
+       * could hide an installed game.
+       */
+      readonly skills: readonly string[]
+      /** Inclusive grade band, or `null` when the record predates it. */
+      readonly grades: readonly [number, number] | null
       /** Launches it onto the stage. Never null: an unplayable pack is not a row. */
       readonly play: () => void
       /**
@@ -219,6 +234,13 @@ export function learnerName(profile: Profile, index: number): string {
  * Packs first, and packs as *plates you press* — the app is its packs, and the
  * first thing on the first screen has to be the way into one. The device counts
  * are underneath, where a parent looks for them and a child does not.
+ *
+ * **Every installed pack, always.** The catalogue above this has a search field
+ * and a row of subject chips, and neither of them belongs here: this function
+ * is a pure map from host state to rows and the test that says "no destination
+ * is ever empty" is only worth something while it stays one. Narrowing happens
+ * in the component, over the rows it was handed. A filter that reached back
+ * into the model would make an empty front door a legitimate state.
  */
 function packsSurface(view: HostView, act: HostActions): readonly Section[] {
   return [
@@ -232,6 +254,9 @@ function packsSurface(view: HostView, act: HostActions): readonly Section[] {
           name: pack.name,
           version: pack.version,
           size: formatBytes(pack.bytes),
+          description: pack.description ?? "",
+          skills: pack.skills ?? [],
+          grades: pack.grades ?? null,
           play: () => act.launchPack(pack.id),
           resting: view.resting.includes(pack.id),
         }),

--- a/dynawalla/dynawalla-app/src/shell/useHost.ts
+++ b/dynawalla/dynawalla-app/src/shell/useHost.ts
@@ -6,14 +6,15 @@
 // is a pure function of what this hook returned, which is exactly what makes
 // the surface model testable without a DOM.
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { appVersion, BUILD_VERSION, isNative } from "../app/platform.ts"
 import { storageBreakdown, storageBytes } from "../app/profile.ts"
 import { recordFor, worldFor } from "../app/stores.ts"
 import { eraseEverything } from "../app/erase.ts"
 import { useThemeStore } from "../app/theme.ts"
-import { usePacks } from "../packs/registry.ts"
+import { useLibrary } from "../packs/libraryStore.ts"
+import { usePacks, type InstalledPack } from "../packs/registry.ts"
 import { useLaunch } from "../packs/Stage.tsx"
 import { billing, grantingBilling, productFor } from "../pass/billing.ts"
 import { dayKey, passIsOpen, EMPTY_LEDGER } from "../pass/model.ts"
@@ -86,12 +87,45 @@ function useNow(): number {
   return now
 }
 
+/**
+ * The installed record, with the live manifest laid over it.
+ *
+ * Two sources, on purpose, and the order matters. `usePacks` is the persisted
+ * record — present on the very first frame, including before the native pack
+ * root has been read — so the catalogue draws named, described cards
+ * immediately on a cold launch. `useLibrary.entries` is the live truth read
+ * from disk this session, so a pack updated underneath the app describes
+ * itself with the manifest that is actually there.
+ *
+ * No new fetching: both are already loaded and already subscribed to by this
+ * shell. This only decides which of the two wins per field.
+ */
+function useDescribedPacks(): readonly InstalledPack[] {
+  const packs = usePacks((state) => state.installed)
+  const entries = useLibrary((state) => state.entries)
+
+  return useMemo(() => {
+    if (entries.length === 0) return packs
+    const live = new Map(entries.map((entry) => [entry.manifest.id, entry]))
+    return packs.map((pack) => {
+      const entry = live.get(pack.id)
+      if (!entry) return pack
+      return {
+        ...pack,
+        description: entry.description,
+        skills: entry.manifest.covers.skills,
+        grades: entry.manifest.covers.grades,
+      }
+    })
+  }, [packs, entries])
+}
+
 export function useHostView(armed: boolean): HostView {
   const profiles = useProfiles((state) => state.profiles)
   const currentId = useProfiles((state) => state.currentId)
   const settings = useSettings((state) => state)
   const theme = useThemeStore((state) => state.mode)
-  const packs = usePacks((state) => state.installed)
+  const packs = useDescribedPacks()
   const placed = worldFor(currentId)((state) => state.placed)
   const answered = recordFor(currentId)((state) => state.answered)
   const correct = recordFor(currentId)((state) => state.correct)


### PR DESCRIPTION
## What

Replaces the pack list with a familiar game-portal catalog: square generated key
art, name, one-line description, subject and grade small print, in a dense grid
under a search field and derived subject chips.

Founder's instruction, verbatim: *"we want regular cards like a familiar listing
with artwork/logo for each game. each game should look different. nice normal
square cards. Just like CrazyGames!"*

## Why it looks like this

The brand lives in the **chrome** — violet ground, the mark in the lintel, the
accent — and in the **art**, never in the silhouette of a card. The previous
attempt drew arch-shaped niches with near-identical rosettes and was rejected;
a listing has to be boringly familiar to browse and distinctive to look at.

**27 hand-authored motifs**, one per shipped game, each a picture of what that
game does — anvil and spark chain for FORGE, a balance beam for COUNTERPOISE, a
times-table wall for MOSAIC, a trebuchet arm and parabola. Plus `sigil`, a
seeded star-polygon, for any pack id this build has never seen, so game #28
looks right the day it lands with no code change.

Art is seeded FNV-1a → mulberry32 from the pack id, so it is byte-identical on
every device and every launch. Hue is `hash % 12` over a 12-step arc; measured
across the real 27 ids, all 12 hues are used with at most 4 games sharing one.

## Three defects the review caught by rendering, not reading

| Defect | Fix |
|---|---|
| Filtering by Multiplication showed cards labelled "Addition & subtraction" | the chip leads with the subject that matched, and a second chip is shown |
| `COUNTERPOI / SE` broke mid-word at every width | column sized to the longest real word; title 16px → 15px |
| One chip said the same thing on 22 of 27 cards | two chips — 126 of 164 skills are `dw.add`, so the second is where games differ |

`hyphens: auto` is **not** the fix and was measured not to be — headless Chrome
ships no hyphenation dictionary, so it silently does nothing and a "fixed" build
renders identically broken. The fix is arithmetic: COUNTERWEIGHT needs 142px of
text box at 15px, an 8.5rem column offered 110px, and a word wider than its
column can only be broken or clipped. 10.5rem gives exactly 142px and still fits
two columns on a 390px phone.

## Blast radius

- [x] **Surface purity intact.** `packsSurface` still maps every installed pack
      with no predicate; search and subject are view state in `Catalog.tsx`.
      `surfaces.test.ts` is untouched and passes — the model still cannot hide a
      game.
- [x] **Launch path untouched** — `act.launchPack` → `useLaunch.play` →
      PackStage overlay.
- [x] **`resting` is not drawn as a lock** — full-strength art, name and
      control; one word of small print. No padlock, no dimming, not sorted down.
- [x] **Subjects derived from manifest skill prefixes at runtime**, never a
      per-game table; an unknown prefix is listed but unfiled, never dropped.
      This catalog went 18 → 27 games in an afternoon.
- [x] **CSP-safe.** No React `style` prop anywhere; per-card hue is a class in a
      bundled stylesheet, per-shape variation is SVG presentation attributes.
      Verified by serving `dist/` under the exact CSP from `tauri.conf.json`.
- [ ] **Known, not fixed here:** `Surface.tsx` returns `null` for a pack row
      outside a homogeneous section. Unreachable today, but if a section ever
      mixes a pack row with a non-pack row every game silently vanishes. Worth
      its own change.

## Proof

```
npm run tsc     clean, all three projects
npm test        tests 221 / pass 221 / fail 0   (207 on main; +14 catalog tests)
npm run lint    clean
npm run build   ✓ built in 118ms
```

Rendered the real React shell over CDP at 1440 / 834 / 390 / 320 in both themes,
and measured `scrollHeight > clientHeight` across every long name: none clipped.
