### PR TITLE
release(dynawalla): 0.2.0 — the catalogue, and the app wears its own mark

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
## What

`0.1.1` → `0.2.0` in `tauri.conf.json`. One line.

## Why a minor, not a patch

This is what the app looks like now. Two things landed since 0.1.1 that change
the first thing anyone sees:

**The catalogue** (#602) — the pack list is gone. The front door is a familiar
game listing: square generated key art, name, one line about the game, subject
and grade small print, in a dense responsive grid under a search field and
subject chips derived from the manifests of whatever is installed. 27
hand-authored motifs, one per shipped game, each a picture of what that game
actually does, plus a seeded fallback so game #28 has characterful art the day
it lands with no code change.

**The icon** (#601) — the founder's mark. 0.1.0 and 0.1.1 both shipped to
TestFlight wearing the stock Tauri icon.

27 packaged games ride along, unchanged from 0.1.1's set plus what merged since.

## Blast radius

- [x] One line in one file. No code, no workflow, no build config.
- [x] Corpán untouched.
- [x] Build numbers unchanged — minutes-since-epoch, monotonic by construction.
- [x] Merging this alone ships nothing; the `dynawalla-v0.2.0` tag does, and the
      gate hard-fails if tag and file disagree.
- [x] **TestFlight distribution is now automatic.** The beta group was recreated
      with `hasAccessToAllBuilds: true` — Apple only accepts that attribute at
      creation, never on update — so this build reaches the internal tester
      without the manual per-build assignment 0.1.0 and 0.1.1 both needed.
- [ ] **Android is expected to ship for the first time.** The Play service
      account was granted per-app access minutes ago; if propagation has not
      completed the job fails in ~60s at the preflight, which is a retry rather
      than a defect.

## Proof

```
$ git ls-tree -r --name-only HEAD dynawalla/games/ | grep -c '/pack.json$'
27
$ grep '"version"' dynawalla/dynawalla-app/src-tauri/tauri.conf.json
  "version": "0.2.0",
```

`dynawalla-app · lint + tsc + test + build` and `dynawalla-packs · games + pack
build` both run on this PR; the app suite is 221 green on the merged catalogue.
