### PR TITLE
fix(release): a version bump no longer races its own tag

### DIFF
--- a/.github/workflows/release-dynawalla.yml
+++ b/.github/workflows/release-dynawalla.yml
@@ -135,11 +135,30 @@ jobs:
                 REASON="manual dispatch"
               elif [ -n "${BEFORE}" ] && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ] \
                    && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+                # A VERSION CHANGE ON main NO LONGER RELEASES BY ITSELF, and the
+                # reason is that it used to release TWICE.
+                #
+                # Merging a version bump pushes main (this path) and is then
+                # followed by the `dynawalla-v*` tag (the path above). Both set
+                # RELEASE=true, so 0.1.1 and 0.2.0 each started two full runs.
+                # The concurrency group serialises them rather than deduping
+                # them, so the cost is a second ~60-minute macOS job, and the
+                # hazard is worse than the cost: the build number is
+                # minutes-since-epoch, so two runs a minute apart upload two
+                # different builds of the SAME version to TestFlight.
+                #
+                # Tag-triggered is also what RELEASE_ENGINEERING.md already
+                # prescribes ("Move both apps to tag-triggered release ... plus
+                # workflow_dispatch"). This makes the file agree with the doc.
+                #
+                # The bump is still DETECTED — it just announces the tag to push
+                # instead of racing it. Silence here would turn "I bumped the
+                # version and nothing shipped" into a mystery.
                 PREV=$(git show "${BEFORE}:${APP_DIR}/src-tauri/tauri.conf.json" 2>/dev/null \
                         | node -p "JSON.parse(require('fs').readFileSync(0)).version" 2>/dev/null || echo "")
                 if [ "$PREV" != "$VERSION" ]; then
-                  RELEASE=true
-                  REASON="version ${PREV:-<absent>} -> $VERSION"
+                  echo "::notice::version ${PREV:-<absent>} -> $VERSION on main, and this push does NOT release. Push the tag: git tag -a dynawalla-v$VERSION -m 'Dynawalla $VERSION' && git push origin dynawalla-v$VERSION"
+                  REASON="version bump seen; waiting for tag dynawalla-v$VERSION"
                 fi
               else
                 echo "::notice::no usable before-SHA; not releasing. Use the dynawalla-v* tag or a manual dispatch."


### PR DESCRIPTION
## What

A version change on `main` no longer sets `RELEASE=true`. Releases fire on the
`dynawalla-v*` tag or `workflow_dispatch`.

## Why

**Every release so far has started twice.** Merging the bump pushes `main` (one
trigger); pushing the tag seconds later is another. Both 0.1.1 and 0.2.0 did it,
and both needed a run cancelled by hand.

`concurrency` serialises the two runs, it does not deduplicate them. So the
visible cost is a wasted ~60-minute macOS job at a 10x minute multiplier. The
quieter hazard matters more: build numbers are minutes-since-epoch, so two runs
a minute apart upload **two different builds of the same marketing version** to
TestFlight.

This is also what `RELEASE_ENGINEERING.md` already prescribes — *"Move both apps
to tag-triggered release (`corpan-v*`, `dynawalla-v*`) plus
`workflow_dispatch`"*. The workflow had not caught up with the doc.

## Blast radius

- [x] One branch of one `case` in the gate job. No build, signing, upload or
      verification step touched.
- [x] Corpán's `release-mobile.yml` untouched.
- [x] `workflow_dispatch` still releases, so recovery is unchanged.
- [x] **The bump is still detected.** It now prints the exact tag command as a
      `::notice::` rather than racing it — a version bump that silently ships
      nothing is a worse failure than one that shipped twice.
- [ ] Behaviour change worth knowing: merging a version bump alone will no
      longer release. The tag does. That is the documented design, and the
      notice makes it self-explaining in the run log.

## Proof

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-dynawalla.yml'))"
YAML OK
```

Observed on 0.2.0 (runs `30387201062` and `30387229321`, the latter cancelled by
hand) and on 0.1.1 before it.