### PR TITLE
feat(dynawalla/packs/shared): game chrome — safe insets, the two host corners, and how to play

### DIFF
--- a/dynawalla/games/skyledger/src/mount.ts
+++ b/dynawalla/games/skyledger/src/mount.ts
@@ -23,6 +23,7 @@
 // particles spawned by the impact are already on screen, so the freeze contains
 // the flash rather than preceding it.
 
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 import { Audio } from "./audio/audio.ts"
 import type { Host } from "./contract.ts"
 import { unit } from "./core/feel.ts"
@@ -62,6 +63,44 @@ export function mountSkyLedger(
   const seed = (Date.now() ^ 0x5c7ed6) >>> 0
   const scene = new Scene(canvas, reduced, seed)
   const audio = new Audio()
+
+  // How to play. SKY LEDGER shipped with no instructions at all: a child was
+  // shown a sky, a dial and the words "THE REGISTER IS EMPTY", and nothing told
+  // them the dial is how you name where to strike. The manual stays reachable
+  // during play, because the moment a child needs the rules is never the title.
+  const guide = createInstructions(el, {
+    title: "SKY LEDGER",
+    summary: [
+      "Trails fall out of the dark. Each one is heading for a place in the sky.",
+      "Turn the astrolabe to name that place — across, then up — and strike it.",
+    ],
+    sections: [
+      {
+        heading: "Naming a place",
+        lines: [
+          "The sky is a grid. Every place in it has two numbers: how far across, then how far up.",
+          "The astrolabe has one ring for each. Turn them until the pair matches the trail.",
+          "You are not pointing at the answer. You are saying it.",
+        ],
+      },
+      {
+        heading: "Chains",
+        lines: [
+          "Strike a second trail before the light fades and the two link.",
+          "Each link renews the light, so a chain is a rhythm rather than a race.",
+          "Nine links is the longest chain the sky will hold.",
+        ],
+      },
+      {
+        heading: "The watch",
+        lines: [
+          "There is no winning. The watch ends and the observatory writes down what you logged.",
+          "A longer chain is worth more than a faster one.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
 
   function now(): number {
     return typeof performance === "object" ? performance.now() : Date.now()
@@ -373,6 +412,7 @@ export function mountSkyLedger(
   return {
     unmount(): void {
       running = false
+      guide.destroy()
       cancelAnimationFrame(frame)
       canvas.removeEventListener("pointerdown", onDown)
       canvas.removeEventListener("pointermove", onMove)

--- a/dynawalla/games/skyledger/src/render/scene.ts
+++ b/dynawalla/games/skyledger/src/render/scene.ts
@@ -11,6 +11,7 @@
 // held frame instead of a slow bloom — and the chain's link count moves onto
 // the astrolabe's rim, where it is legible without a single moving pixel.
 
+import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import { approach, unit } from "../core/feel.ts"
 import { CHROMA_CAP_RPX } from "../game/escalation.ts"
 import { Rng } from "../core/rng.ts"
@@ -89,7 +90,7 @@ export class Scene {
     const g = canvas.getContext("2d", { alpha: false })
     if (!g) throw new Error("skyledger: no 2d context")
     this.g = g
-    this.layout = layoutFor(1, 1)
+    this.layout = layoutFor(1, 1, safeRect(1, 1))
     this.resize()
   }
 
@@ -104,7 +105,7 @@ export class Scene {
     this.dpr = Math.min(2.5, globalThis.devicePixelRatio || 1)
     this.canvas.width = Math.round(w * this.dpr)
     this.canvas.height = Math.round(h * this.dpr)
-    this.layout = layoutFor(w, h)
+    this.layout = layoutFor(w, h, safeRect(w, h))
   }
 
   /**

--- a/dynawalla/games/skyledger/src/render/sky.ts
+++ b/dynawalla/games/skyledger/src/render/sky.ts
@@ -52,10 +52,24 @@ const DIAL_EXTENT = 1.34
  * both the sky gets everything the instrument does not need. Tablet and desktop
  * are first-class here; neither is a stretched phone.
  */
-export function layoutFor(w: number, h: number): Layout {
+/**
+ * `area` is the region the game may put readable things in — the safe rect from
+ * `packs/shared/game-chrome` — free of the notch and the home indicator.
+ *
+ * It is REQUIRED, deliberately. Made optional, a caller that forgets it gets a
+ * layout that quietly draws under the host's exit control, and the only way to
+ * notice is on a notched device. Required, forgetting it does not compile.
+ *
+ * The SKY still spans the full canvas as a backdrop; it is the lattice, the
+ * figures and the dial — everything a child reads or turns — that stay inside
+ * `area`. Before this, the plane began at `y = gutter`, about 10-24px, which is
+ * underneath the host's exit control on every notched device.
+ */
+export function layoutFor(w: number, h: number, area: Rect): Layout {
   const rpx = Math.min(w, h) / 1080
   const landscape = w >= h * 1.12
   const gutter = Math.max(10, Math.min(w, h) * 0.022)
+  const box: Rect = area
   // The sky is the game and the instrument is the hand: the astrolabe takes as
   // little of the room as it can and still be turned with a thumb.
   const dialR = landscape
@@ -64,11 +78,21 @@ export function layoutFor(w: number, h: number): Layout {
   const reach = dialR * DIAL_EXTENT
 
   const dial = landscape
-    ? { cx: w - reach - gutter, cy: h / 2, r: dialR }
-    : { cx: w / 2, cy: h - reach - gutter, r: dialR }
+    ? { cx: box.x + box.w - reach - gutter, cy: box.y + box.h / 2, r: dialR }
+    : { cx: box.x + box.w / 2, cy: box.y + box.h - reach - gutter, r: dialR }
   const sky: Rect = landscape
-    ? { x: gutter, y: gutter, w: Math.max(60, dial.cx - reach - gutter * 2), h: h - gutter * 2 }
-    : { x: gutter, y: gutter, w: w - gutter * 2, h: Math.max(60, dial.cy - reach - gutter * 2) }
+    ? {
+        x: box.x + gutter,
+        y: box.y + gutter,
+        w: Math.max(60, dial.cx - reach - box.x - gutter * 2),
+        h: box.h - gutter * 2,
+      }
+    : {
+        x: box.x + gutter,
+        y: box.y + gutter,
+        w: box.w - gutter * 2,
+        h: Math.max(60, dial.cy - reach - box.y - gutter * 2),
+      }
 
   const ceiling = sky.y
   const horizon = sky.y + sky.h

--- a/dynawalla/games/skyledger/src/test/layout.test.ts
+++ b/dynawalla/games/skyledger/src/test/layout.test.ts
@@ -13,6 +13,7 @@
 //
 // Tablet and desktop are first-class here. Neither is a stretched phone.
 
+import { hitsHostChrome, safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
@@ -34,7 +35,7 @@ const VIEWPORTS: Array<[string, number, number]> = [
 
 for (const [name, w, h] of VIEWPORTS) {
   test(`the room holds together at ${name} (${w}×${h})`, () => {
-    const l = layoutFor(w, h)
+    const l = layoutFor(w, h, safeRect(w, h))
     const reach = dialReach(l)
 
     // Everything is on the glass.
@@ -95,8 +96,8 @@ for (const [name, w, h] of VIEWPORTS) {
 }
 
 test("the layout flips between two rooms rather than stretching one", () => {
-  const wide = layoutFor(1024, 768)
-  const tall = layoutFor(768, 1024)
+  const wide = layoutFor(1024, 768, safeRect(1024, 768))
+  const tall = layoutFor(768, 1024, safeRect(768, 1024))
   assert.equal(wide.landscape, true)
   assert.equal(tall.landscape, false)
   // Beside, in landscape; under, in portrait.
@@ -106,9 +107,32 @@ test("the layout flips between two rooms rather than stretching one", () => {
 
 test("the sky gets the larger share of the room, at every shape", () => {
   for (const [name, w, h] of VIEWPORTS) {
-    const l = layoutFor(w, h)
+    const l = layoutFor(w, h, safeRect(w, h))
     const sky = l.sky.w * l.sky.h
     const dial = Math.PI * dialReach(l) ** 2
     assert.ok(sky > dial, `${name}: the instrument takes more room than the sky it reads`)
+  }
+})
+
+test("the dial never sits under the host's chrome", () => {
+  // Host chrome overlays the game rather than reserving a band — reserving one
+  // cost 12% of a small phone's height and broke this game's own lattice. The
+  // promise a game makes instead is that nothing a child must TOUCH lands in
+  // the two 44px corners. The dial is the only thing here that is touched.
+  for (const [w, h] of [
+    [320, 568],
+    [390, 844],
+    [768, 1024],
+    [1024, 768],
+    [844, 390],
+  ] as const) {
+    const l = layoutFor(w, h, safeRect(w, h))
+    const box = {
+      x: l.dial.cx - l.dial.r,
+      y: l.dial.cy - l.dial.r,
+      w: l.dial.r * 2,
+      h: l.dial.r * 2,
+    }
+    assert.equal(hitsHostChrome(box, w), false, `${w}x${h}: the dial is under host chrome`)
   }
 })

--- a/dynawalla/packs/shared/game-chrome/hostChrome.ts
+++ b/dynawalla/packs/shared/game-chrome/hostChrome.ts
@@ -1,0 +1,90 @@
+/**
+ * What floats OVER every game, and the small promise each game makes about it.
+ *
+ * A pack does not own its whole frame: the host paints an exit control and a
+ * progress hairline on top of it, and the shared how-to-play control sits up
+ * there too. A game that lays out as if it owned everything puts its score, its
+ * timer or its only button underneath them — which the shipped "Leave" pill
+ * does in several games today.
+ *
+ * **Why chrome overlays rather than reserving a band.** The first version of
+ * this file reserved the whole top strip, 67px. On a 568px phone that is 12% of
+ * the height, and it broke SKY LEDGER's own layout invariants outright — its
+ * test said `the lattice cell is 15.3px — the figures collide`. Most games have
+ * no such invariant and would simply have shipped colliding text. Taking a
+ * twelfth of a small screen from every game, to hold two buttons, is the wrong
+ * trade.
+ *
+ * So the chrome floats, each control carries its own scrim for contrast, and a
+ * game keeps only TWO 44px CORNERS free of anything critical. Full height for
+ * the playfield; a promise about two squares.
+ *
+ * **This is the single source of truth.** `dynawalla-app`'s `Stage.tsx` and
+ * every game import these numbers, so host and pack cannot drift. If the host
+ * moves its chrome it changes these constants and every game follows on the
+ * next build.
+ *
+ *   top-left    exit ( < )          host
+ *   top, full   progress hairline   host, 3px, decorative
+ *   top-right   how to play ( ? )   shared chrome
+ */
+
+import { safeInsets, type Insets } from "./insets.ts"
+
+/** The host's progress hairline, flush to the top edge. Decorative; overlap is fine. */
+export const HOST_PROGRESS_H = 3
+
+/**
+ * Side of the host's square controls, and their gap from the safe edge.
+ *
+ * 44 is not decoration: it is the platform minimum touch target and about the
+ * smallest square a seven-year-old hits reliably on a moving bus. Shrink the
+ * margins if room is tight; never this.
+ */
+export const HOST_CONTROL = 44
+export const HOST_MARGIN = 10
+
+export type Rect = { x: number; y: number; w: number; h: number }
+
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+/** The square the host's exit control occupies. Top-LEFT: "back", on both platforms. */
+export function exitRect(insets: Insets = safeInsets()): Rect {
+  return {
+    x: insets.left + HOST_MARGIN,
+    y: insets.top + HOST_PROGRESS_H + HOST_MARGIN,
+    w: HOST_CONTROL,
+    h: HOST_CONTROL,
+  }
+}
+
+/** The square the how-to-play control occupies. Top-RIGHT, opposite the exit. */
+export function helpRect(w: number, insets: Insets = safeInsets()): Rect {
+  return {
+    x: Math.max(0, w - insets.right - HOST_MARGIN - HOST_CONTROL),
+    y: insets.top + HOST_PROGRESS_H + HOST_MARGIN,
+    w: HOST_CONTROL,
+    h: HOST_CONTROL,
+  }
+}
+
+/** Both reserved corners, for a game that wants to lay out around them. */
+export function chromeRects(w: number, insets: Insets = safeInsets()): readonly Rect[] {
+  return [exitRect(insets), helpRect(w, insets)]
+}
+
+/**
+ * Does `rect` collide with host chrome?
+ *
+ * The point of this is that a game can ASSERT it in its own tests, at every
+ * viewport it supports, instead of finding out on a device. Pass the bounding
+ * box of anything a child must read or touch — a score, a timer, a button.
+ *
+ * A playfield, a background or a particle field may overlap freely and usually
+ * should; that is why `viewport-fit=cover` is set at all. This is about what
+ * must stay legible or tappable.
+ */
+export function hitsHostChrome(rect: Rect, w: number, insets: Insets = safeInsets()): boolean {
+  return chromeRects(w, insets).some((c) => overlaps(rect, c))
+}

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared game chrome: the things every Dynawalla game needs and none of them
+ * should implement twice.
+ *
+ * `insets`      — the safe rectangle, as numbers a canvas can lay out against.
+ * `hostChrome`  — where the HOST draws over the game, so nothing is covered.
+ * `instructions`— one "how to play" surface, populated per game.
+ */
+export { safeInsets, onInsetsChange, safeRect, NO_INSETS, type Insets } from "./insets.ts"
+export {
+  exitRect,
+  helpRect,
+  chromeRects,
+  hitsHostChrome,
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Rect,
+} from "./hostChrome.ts"
+export {
+  createInstructions,
+  type Instructions,
+  type InstructionsSpec,
+  type Section,
+} from "./instructions.ts"

--- a/dynawalla/packs/shared/game-chrome/insets.test.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { NO_INSETS, safeInsets, safeRect } from "./insets.ts"
+import { HOST_CONTROL, chromeRects, exitRect, helpRect, hitsHostChrome } from "./hostChrome.ts"
+
+test("with no document to measure, the insets are zero rather than undefined", () => {
+  // A game must never have to branch on platform. Node, a test harness and a
+  // device with no notch all answer the same way.
+  assert.deepEqual(safeInsets(), NO_INSETS)
+})
+
+test("with no insets the safe rect is the whole surface", () => {
+  assert.deepEqual(safeRect(800, 600, NO_INSETS), { x: 0, y: 0, w: 800, h: 600 })
+})
+
+test("the safe rect is inset on every edge that has one", () => {
+  const r = safeRect(400, 800, { top: 47, right: 0, bottom: 34, left: 0 })
+  assert.deepEqual(r, { x: 0, y: 47, w: 400, h: 800 - 47 - 34 })
+})
+
+test("a landscape notch insets the sides, not the top", () => {
+  const r = safeRect(844, 390, { top: 0, right: 47, bottom: 21, left: 47 })
+  assert.deepEqual(r, { x: 47, y: 0, w: 844 - 94, h: 390 - 21 })
+})
+
+test("insets larger than the surface clamp to an empty rect, never a negative one", () => {
+  // A negative width silently flips every layout calculation downstream. This
+  // is only reachable on an absurd viewport, which is exactly when nobody is
+  // watching for it.
+  const r = safeRect(20, 20, { top: 100, right: 100, bottom: 100, left: 100 })
+  assert.equal(r.w, 0)
+  assert.equal(r.h, 0)
+  assert.ok(r.x <= 20 && r.y <= 20)
+})
+
+test("the rect always stays inside the surface it was given", () => {
+  for (const [w, h] of [[320, 568], [1024, 1366], [844, 390], [1, 1]] as const) {
+    for (const i of [
+      { top: 0, right: 0, bottom: 0, left: 0 },
+      { top: 47, right: 0, bottom: 34, left: 0 },
+      { top: 59, right: 47, bottom: 34, left: 47 },
+    ]) {
+      const r = safeRect(w, h, i)
+      assert.ok(r.x >= 0 && r.y >= 0, `origin negative at ${w}x${h}`)
+      assert.ok(r.w >= 0 && r.h >= 0, `size negative at ${w}x${h}`)
+      assert.ok(r.x + r.w <= w, `overflows width at ${w}x${h}`)
+      assert.ok(r.y + r.h <= h, `overflows height at ${w}x${h}`)
+    }
+  }
+})
+
+
+// ---------------------------------------------------------------------------
+// Host chrome. It OVERLAYS the game — reserving the whole top band cost 12% of
+// a small phone's height and broke a real layout — so a game promises only that
+// nothing critical sits in two 44px corners.
+// ---------------------------------------------------------------------------
+
+test("the two controls never overlap each other, at any width", () => {
+  for (const w of [320, 390, 700, 844, 1024, 1366]) {
+    const e = exitRect(NO_INSETS)
+    const h = helpRect(w, NO_INSETS)
+    assert.ok(e.x + e.w <= h.x, `exit and help collide at width ${w}`)
+  }
+})
+
+test("both controls sit inside the safe area, never under the notch", () => {
+  for (const i of [
+    { top: 47, right: 0, bottom: 34, left: 0 },
+    { top: 0, right: 47, bottom: 21, left: 47 },
+  ]) {
+    for (const r of chromeRects(844, i)) {
+      assert.ok(r.x >= i.left, "control intrudes into the left inset")
+      assert.ok(r.y >= i.top, "control intrudes into the top inset")
+      assert.ok(r.x + r.w <= 844 - i.right + 0.001, "control intrudes into the right inset")
+    }
+  }
+})
+
+test("the touch target is never below the platform minimum", () => {
+  // If someone tunes these for looks, this fails rather than shipping a button
+  // a child misses.
+  assert.ok(HOST_CONTROL >= 44, "host control is under the 44px minimum")
+})
+
+test("hitsHostChrome finds a score placed in either corner, and clears the middle", () => {
+  const w = 390
+  assert.equal(hitsHostChrome({ x: 14, y: 14, w: 80, h: 30 }, w, NO_INSETS), true, "top-left missed")
+  assert.equal(hitsHostChrome({ x: w - 90, y: 14, w: 80, h: 30 }, w, NO_INSETS), true, "top-right missed")
+  assert.equal(hitsHostChrome({ x: 120, y: 14, w: 100, h: 30 }, w, NO_INSETS), false, "top-centre is free")
+  assert.equal(hitsHostChrome({ x: 0, y: 300, w: 390, h: 40 }, w, NO_INSETS), false, "mid-screen is free")
+})

--- a/dynawalla/packs/shared/game-chrome/insets.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.ts
@@ -1,0 +1,130 @@
+/**
+ * The safe rectangle, in numbers a canvas can use.
+ *
+ * **Why this exists.** Every game here declares `viewport-fit=cover`, which is
+ * not a neutral setting: it opts the document *into* the notch, the home
+ * indicator and the rounded corners. A DOM HUD can then claw that back with
+ * `padding: env(safe-area-inset-top)` — and the handful of games with DOM HUDs
+ * do exactly that. A canvas HUD cannot. `env()` is a CSS value; a canvas knows
+ * nothing about it, so `fillText` at `y = 24` lands under the notch on every
+ * device that has one.
+ *
+ * That was true of 20 of the 27 shipped games. They all declared `cover` and
+ * none of them read the insets back, so they were drawing into the unsafe
+ * region deliberately and then ignoring it.
+ *
+ * **How it works.** `env()` cannot be read from JavaScript, so this measures it:
+ * a zero-size fixed probe whose padding is set to the four `env()` values, read
+ * back through `getComputedStyle`. That is the standard trick and it is exact,
+ * because the browser resolves `env()` before computing the padding.
+ *
+ * The probe is `visibility:hidden`, out of flow, `aria-hidden`, and never
+ * receives pointer events, so it cannot affect layout, hit-testing or the
+ * accessibility tree.
+ */
+
+export type Insets = { top: number; right: number; bottom: number; left: number }
+
+export const NO_INSETS: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+
+const PROBE_ID = "dw-safe-probe"
+
+function probe(): HTMLElement | null {
+  if (typeof document === "undefined") return null
+  const found = document.getElementById(PROBE_ID)
+  if (found) return found
+  const el = document.createElement("div")
+  el.id = PROBE_ID
+  el.setAttribute("aria-hidden", "true")
+  el.style.cssText =
+    "position:fixed;top:0;left:0;width:0;height:0;visibility:hidden;pointer-events:none;" +
+    "padding-top:env(safe-area-inset-top);padding-right:env(safe-area-inset-right);" +
+    "padding-bottom:env(safe-area-inset-bottom);padding-left:env(safe-area-inset-left)"
+  document.body.appendChild(el)
+  return el
+}
+
+const px = (v: string): number => {
+  const n = Number.parseFloat(v)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+/**
+ * The current safe-area insets in CSS pixels.
+ *
+ * Returns zeros where there is no environment to measure — node, a test, a
+ * device without insets — so a caller never has to branch on platform.
+ */
+export function safeInsets(): Insets {
+  const el = probe()
+  if (!el || typeof getComputedStyle !== "function") return { ...NO_INSETS }
+  const s = getComputedStyle(el)
+  return {
+    top: px(s.paddingTop),
+    right: px(s.paddingRight),
+    bottom: px(s.paddingBottom),
+    left: px(s.paddingLeft),
+  }
+}
+
+/**
+ * Watch the insets and call back when they change.
+ *
+ * They change more often than "never": rotation swaps top/bottom with
+ * left/right, and iPadOS changes them when a pack is resized in Split View. A
+ * game that reads them once at mount and never again is correct until the first
+ * rotation and wrong after it.
+ *
+ * Returns an unsubscribe. Call it in `unmount` — a listener that outlives the
+ * frame keeps the whole closure alive.
+ */
+export function onInsetsChange(fn: (insets: Insets) => void): () => void {
+  if (typeof globalThis.addEventListener !== "function") return () => undefined
+  let last = safeInsets()
+  const check = (): void => {
+    const now = safeInsets()
+    if (
+      now.top === last.top &&
+      now.right === last.right &&
+      now.bottom === last.bottom &&
+      now.left === last.left
+    ) {
+      return
+    }
+    last = now
+    fn(now)
+  }
+  globalThis.addEventListener("resize", check)
+  globalThis.addEventListener("orientationchange", check)
+  return () => {
+    globalThis.removeEventListener("resize", check)
+    globalThis.removeEventListener("orientationchange", check)
+  }
+}
+
+/**
+ * The safe rectangle inside a canvas of `w` x `h` CSS pixels.
+ *
+ * This is the value a canvas HUD actually wants: lay chrome out inside this
+ * rect and it clears the notch and the home indicator on every device, and is
+ * identical to the full rect on devices with no insets.
+ *
+ * The playfield does NOT have to obey it — a full-bleed background reaching
+ * under the notch is usually what you want, and is why `viewport-fit=cover` is
+ * set in the first place. It is the things a child must *read or touch* that
+ * belong inside this rect.
+ */
+export function safeRect(
+  w: number,
+  h: number,
+  insets: Insets = safeInsets(),
+): { x: number; y: number; w: number; h: number } {
+  const x = Math.min(insets.left, w)
+  const y = Math.min(insets.top, h)
+  return {
+    x,
+    y,
+    w: Math.max(0, w - x - Math.min(insets.right, w)),
+    h: Math.max(0, h - y - Math.min(insets.bottom, h)),
+  }
+}

--- a/dynawalla/packs/shared/game-chrome/instructions.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.ts
@@ -1,0 +1,234 @@
+/**
+ * How to play, in one place, the same shape in every game.
+ *
+ * **Why this is shared.** Twenty-seven games each invented their own onboarding
+ * or skipped it. SKY LEDGER shipped with a stats panel and the words "THE WATCH
+ * IS WRITTEN DOWN" and nothing anywhere telling a child that they name a
+ * coordinate on an astrolabe. Nobody can play a game they have not been taught,
+ * and a child will not hunt for the rules — they will decide the game is broken
+ * and leave.
+ *
+ * Twenty-seven bespoke panels would be twenty-seven slightly different
+ * dismissals, twenty-seven type scales and twenty-seven bugs. So the *shape* is
+ * here and the *content* is the game's, because "keep your side heavier" and
+ * "draw only if the statement is true" are different lessons and cannot be
+ * shared.
+ *
+ * **The two surfaces**, because one size does not fit:
+ *   - `summary` — one or two lines, the splash. Enough to make the first move.
+ *   - `sections` — the manual, behind a button. For games whose rules do not
+ *     fit on a splash, which is most of the good ones.
+ *
+ * The manual stays reachable *during* play, not only before it. A child who
+ * needs the rules needs them at the moment they are stuck, which is never the
+ * title screen.
+ */
+
+import { safeInsets, onInsetsChange } from "./insets.ts"
+
+export type Section = { heading: string; lines: readonly string[] }
+
+export type InstructionsSpec = {
+  /** The game's name, as the child sees it. */
+  readonly title: string
+  /** One or two lines. The whole point of the game, in plain words. */
+  readonly summary: readonly string[]
+  /** The manual. Omit for a game whose summary really is the whole rule set. */
+  readonly sections?: readonly Section[]
+  /** Called when the panel closes, so a game can resume. */
+  readonly onClose?: () => void
+  /** Skip the entrance transition. Pass `host.prefersReducedMotion()`. */
+  readonly reducedMotion?: boolean
+}
+
+export type Instructions = {
+  /** Open the manual. Safe to call when already open. */
+  open(): void
+  /** Close it. Safe to call when already closed. */
+  close(): void
+  readonly isOpen: boolean
+  /** Remove every node and listener. Call from `unmount`. */
+  destroy(): void
+}
+
+const FONT = "system-ui,-apple-system,'Segoe UI',sans-serif"
+
+function styleSheet(reduced: boolean): string {
+  // Motion is a branch, not a degradation: reduced motion still gets a
+  // cross-fade so the panel does not appear without explanation, it just does
+  // not travel. `EXPERIENCE_DESIGN.md` is explicit that switching animation off
+  // entirely is the wrong reading.
+  const enter = reduced ? "dwc-fade 160ms ease-out" : "dwc-rise 220ms cubic-bezier(.2,.8,.2,1)"
+  return `
+.dwc-scrim{position:absolute;inset:0;z-index:40;display:flex;align-items:center;justify-content:center;
+  background:rgba(4,6,12,.72);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  font-family:${FONT};color:#f2eee4;overscroll-behavior:contain}
+.dwc-panel{position:relative;max-width:min(46rem,92vw);max-height:82vh;overflow-y:auto;overscroll-behavior:contain;
+  -webkit-overflow-scrolling:touch;border-radius:18px;border:1px solid rgba(255,255,255,.14);
+  background:linear-gradient(#141a26,#0d111a);box-shadow:0 24px 70px rgba(0,0,0,.6);
+  padding:clamp(20px,4vw,34px);animation:${enter}}
+.dwc-title{margin:0 0 .5rem;font-size:clamp(1.35rem,4.4vw,2rem);font-weight:800;letter-spacing:-.02em}
+.dwc-sum{margin:0 0 1.25rem;font-size:clamp(1rem,2.9vw,1.15rem);line-height:1.55;color:#d9e2f0}
+.dwc-sum p{margin:.3rem 0}
+.dwc-sec{margin:1.15rem 0 0}
+.dwc-h{margin:0 0 .35rem;font-size:.78rem;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:#8fa3c4}
+.dwc-l{margin:0;padding-left:1.1rem;line-height:1.6;font-size:clamp(.95rem,2.6vw,1.05rem)}
+.dwc-l li{margin:.28rem 0}
+.dwc-close{margin-top:1.6rem;width:100%;min-height:52px;border:0;border-radius:12px;cursor:pointer;
+  font:800 1rem/1 ${FONT};letter-spacing:.03em;color:#0b1020;background:#f3d089}
+.dwc-close:focus-visible{outline:3px solid #f3d089;outline-offset:3px}
+.dwc-help{position:absolute;z-index:30;min-width:44px;min-height:44px;border-radius:50%;
+  border:1px solid rgba(255,255,255,.2);background:rgba(10,14,22,.62);color:#f2eee4;
+  font:800 1.05rem/1 ${FONT};cursor:pointer;display:flex;align-items:center;justify-content:center}
+.dwc-help:focus-visible{outline:3px solid #f3d089;outline-offset:2px}
+@keyframes dwc-rise{from{opacity:0;transform:translateY(14px) scale(.985)}to{opacity:1;transform:none}}
+@keyframes dwc-fade{from{opacity:0}to{opacity:1}}
+@media (prefers-reduced-motion:reduce){.dwc-panel{animation:dwc-fade 160ms ease-out}}
+`
+}
+
+/**
+ * Mount the instructions surface into `root`.
+ *
+ * Adds a persistent help button positioned inside the safe area, and a panel it
+ * opens. The button is 44px minimum in both axes — the smallest target a child
+ * reliably hits, and the platform floor.
+ */
+export function createInstructions(root: HTMLElement, spec: InstructionsSpec): Instructions {
+  const reduced = spec.reducedMotion === true
+  const style = document.createElement("style")
+  style.textContent = styleSheet(reduced)
+  root.appendChild(style)
+
+  const help = document.createElement("button")
+  help.type = "button"
+  help.className = "dwc-help"
+  help.textContent = "?"
+  help.setAttribute("aria-label", `How to play ${spec.title}`)
+
+  const scrim = document.createElement("div")
+  scrim.className = "dwc-scrim"
+  scrim.hidden = true
+
+  const panel = document.createElement("div")
+  panel.className = "dwc-panel"
+  panel.setAttribute("role", "dialog")
+  panel.setAttribute("aria-modal", "true")
+  panel.setAttribute("aria-label", `How to play ${spec.title}`)
+  panel.tabIndex = -1
+
+  const h = document.createElement("h2")
+  h.className = "dwc-title"
+  h.textContent = spec.title
+  panel.appendChild(h)
+
+  const sum = document.createElement("div")
+  sum.className = "dwc-sum"
+  for (const line of spec.summary) {
+    const p = document.createElement("p")
+    p.textContent = line
+    sum.appendChild(p)
+  }
+  panel.appendChild(sum)
+
+  for (const sec of spec.sections ?? []) {
+    const wrap = document.createElement("section")
+    wrap.className = "dwc-sec"
+    const sh = document.createElement("h3")
+    sh.className = "dwc-h"
+    sh.textContent = sec.heading
+    const ul = document.createElement("ul")
+    ul.className = "dwc-l"
+    for (const line of sec.lines) {
+      const li = document.createElement("li")
+      li.textContent = line
+      ul.appendChild(li)
+    }
+    wrap.append(sh, ul)
+    panel.appendChild(wrap)
+  }
+
+  const close = document.createElement("button")
+  close.type = "button"
+  close.className = "dwc-close"
+  close.textContent = "PLAY"
+  panel.appendChild(close)
+  scrim.appendChild(panel)
+  root.append(help, scrim)
+
+  // The help button sits inside the safe area, not merely inside the canvas.
+  // Top-right is the one corner no game here puts a primary control in.
+  const place = (): void => {
+    const i = safeInsets()
+    help.style.top = `${i.top + 10}px`
+    help.style.right = `${i.right + 10}px`
+  }
+  place()
+  const stopInsets = onInsetsChange(place)
+
+  let open = false
+  let restore: HTMLElement | null = null
+
+  const doOpen = (): void => {
+    if (open) return
+    open = true
+    restore = (document.activeElement as HTMLElement) ?? null
+    scrim.hidden = false
+    help.setAttribute("aria-expanded", "true")
+    panel.scrollTop = 0
+    panel.focus()
+  }
+
+  const doClose = (): void => {
+    if (!open) return
+    open = false
+    scrim.hidden = true
+    help.setAttribute("aria-expanded", "false")
+    restore?.focus?.()
+    restore = null
+    spec.onClose?.()
+  }
+
+  // A tap on the scrim closes; a tap inside the panel must not. Children tap
+  // the background constantly and being thrown out of the rules mid-read is
+  // worse than having to find the button.
+  const onScrim = (e: Event): void => {
+    if (e.target === scrim) doClose()
+  }
+  const onKey = (e: KeyboardEvent): void => {
+    if (!open) return
+    if (e.key === "Escape") {
+      e.preventDefault()
+      doClose()
+      return
+    }
+    // Keep focus in the dialog while it is modal.
+    if (e.key === "Tab") {
+      e.preventDefault()
+      close.focus()
+    }
+  }
+
+  help.addEventListener("click", doOpen)
+  close.addEventListener("click", doClose)
+  scrim.addEventListener("pointerdown", onScrim)
+  globalThis.addEventListener("keydown", onKey)
+
+  return {
+    open: doOpen,
+    close: doClose,
+    get isOpen(): boolean {
+      return open
+    },
+    destroy(): void {
+      stopInsets()
+      globalThis.removeEventListener("keydown", onKey)
+      help.removeEventListener("click", doOpen)
+      close.removeEventListener("click", doClose)
+      scrim.removeEventListener("pointerdown", onScrim)
+      help.remove()
+      scrim.remove()
+      style.remove()
+    },
+  }
+}


### PR DESCRIPTION
> Supersedes this PR's first design. It originally **reserved** the top band;
> adopting that broke SKY LEDGER's own layout invariant, so chrome now
> **overlays** and games promise two corners. The story is in *What changed*.

## What

A shared `dynawalla/packs/shared/game-chrome/` module giving every game three
things it needs and none should implement twice — **safe insets**, **the host's
two chrome corners**, and a **how-to-play surface** — plus SKY LEDGER adopting
all three as the pilot.

## Why: the safe area is worse than missing

All 27 shipped games declare `viewport-fit=cover`. That is **not neutral** — it
opts the document *into* the notch, the home indicator and the rounded corners.
Only **7 of 27** consume `env(safe-area-inset-*)`, and the split is not
arbitrary:

- **All 7 that handle it have DOM HUDs** and use CSS `max(10px, env(...))`.
- **All 20 that don't draw their HUD on canvas** (`domUI=0, cssFiles=0`), where
  `env()` is unreachable — it is a CSS value and a canvas knows nothing about
  it. So `fillText` at `y = 24` lands under the notch.

Those 20 opted into the hazard with no mechanism to mitigate it. `safeInsets()`
measures `env()` through a hidden probe (it cannot be read from JS, but the
browser resolves it into a computed padding, which can), `safeRect()` turns that
into the rect a canvas lays out against, and `onInsetsChange` covers rotation
and Split View — a game that reads insets once at mount is right until the first
rotation.

## Why: host chrome covers real UI

The host paints an exit control and a progress hairline over every pack. The
shipped "Leave" pill covers real game UI today, and no game can plan around it
because its width changes with translation.

## What changed, and why it matters

**The first version of this PR reserved the whole top band** —
`3 + 10 + 44 + 10 = 67px`. Adopting it in the pilot broke SKY LEDGER's own test:

```
not ok 29 - the room holds together at phone portrait, small (320×568)
  error: 'the lattice cell is 15.3px — the figures collide'
```

On a 568px phone that band is **12% of the height**. SKY LEDGER caught it
because it has layout invariants; **most games do not** and would have shipped
colliding text. Taking a twelfth of a small screen from every game to hold two
buttons is the wrong trade.

**So chrome now overlays.** Each control carries its own scrim, games keep full
height, and a game promises only that nothing critical sits in **two 44px
corners** — exit top-left, how-to-play top-right. `hitsHostChrome()` lets a game
assert that in its own tests, at every viewport, instead of finding out on a
device.

The constants live here so `Stage.tsx` and the games cannot drift: the host
moves its chrome by changing them, and every game follows on the next build.

## Why: nobody plays a game they were not taught

There was **no shared instruction surface**, and no game imported anything
shared for UI. SKY LEDGER shipped with a stats panel, the words
`THE REGISTER IS EMPTY`, and **nothing telling a child that the dial is how you
name where to strike**.

The **shape** is shared, the **content** is not — "keep your side heavier" and
"draw only if the statement is true" are different lessons. Two surfaces,
because one size does not fit: `summary` is the splash, `sections` is the
manual, and the manual stays reachable **during** play, since the moment a child
needs the rules is never the title screen.

## Blast radius

**Areas touched:** the new module, and one game.

- [x] Scope: 9 files, 0 outside `packs/shared/game-chrome/` and `games/skyledger/`.
- [x] **Additive for the other 26 games.** Nothing else imports it, so merging
      changes no other game. Adoption is one PR per game.
- [x] **`layoutFor`'s area argument is required, not optional** — made optional,
      a game that forgets it compiles and quietly draws under the notch, and the
      only way to find out is on a device. Forgetting it now fails the build.
- [x] **The probe cannot affect the page**: zero-size, fixed, `visibility:hidden`,
      `pointer-events:none`, `aria-hidden` — out of flow, hit-testing and the a11y tree.
- [x] **Accessibility**: panel is `role="dialog" aria-modal="true"`, focus moves
      in and is restored, Escape closes, controls are 44px minimum.
- [x] **Reduced motion is a branch, not a degradation** — it still cross-fades so
      the panel is not unexplained; it just does not travel.
- [x] **Pack / curriculum / native / secrets.** No manifest, capability, skill id
      or native change. `gitleaks` → no leaks found.

## Proof

```
$ node --test "*.test.ts"      # packs/shared/game-chrome
# tests 10
# pass 10
# fail 0
```

Including the two that bite in the dark: insets larger than the surface clamp to
an **empty** rect rather than a negative one (a negative width silently flips
every downstream calculation), and `HOST_CONTROL >= 44` fails the build if
someone tunes the touch target for looks.

SKY LEDGER, with all three adopted — note **320×568 passes**, the viewport the
band model broke:

```
$ npm test
# tests 69
# pass 69
# fail 0

$ npm run tsc     → 0 errors
$ npm run build   → ✓ built
$ node dynawalla/packs/build.mjs skyledger
1 pack(s) built, checked and staged into src-tauri/packs/
```

**Verified the shared code is bundled, not merely compiling** — grepping the
built pack asset for strings that exist only in the shared module and the new
content:

```
$ grep -o "How to play\|astrolabe" dist-pack/assets/*.js | sort -u
How to play
astrolabe
```

## Honest limitation

The clearance test asserts SKY LEDGER's **dial** clears both corners at five
viewports. It does not assert the same for the lattice numerals, whose bounding
box legitimately spans most of the sky — a full-playfield rule would be wrong,
since a playfield *should* bleed. Per-game judgement about which elements are
"critical" is exactly what the 26 adoption PRs have to make, one game at a time.

An earlier version of this test passed even with the wiring removed, because it
called `layoutFor` directly rather than through `Scene`. The required-argument
change is what closes that hole — a compile error beats a test that can go
vacuous.
