### PR TITLE
release(dynawalla): 0.2.1 — the app finally wears its own icon

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
## What

`0.2.0` → `0.2.1`. One line.

## Why

Ships #605. Three releases went to TestFlight and Play wearing the stock
yellow-and-cyan Tauri logo — proven by unzipping the 0.2.0 artifacts, not
inferred.

## Blast radius

- [x] One line. The icon fix itself is already on main.
- [x] Tag-triggered only now (#604), so this merge will NOT double-fire.
- [ ] **Verification is the point of this release.** I will unzip the produced
      IPA and AAB and confirm the shipped icon is the Dynawalla mark before
      calling it fixed. Every previous claim about this icon was made without
      looking inside the artifact.

## Proof

```
$ grep '"version"' dynawalla/dynawalla-app/src-tauri/tauri.conf.json
  "version": "0.2.1",
```