### PR TITLE
fix(release): give App Store Connect long enough, and stop the log lying about it

### DIFF
--- a/.github/workflows/release-dynawalla.yml
+++ b/.github/workflows/release-dynawalla.yml
@@ -699,6 +699,18 @@ jobs:
           ASC_BUNDLE_ID: ${{ env.BUNDLE_ID }}
           ASC_BUILD_VERSION: ${{ steps.ipa.outputs.cfbundleversion }}
           ASC_MIN_UPLOADED_DATE: ${{ needs.gate.outputs.run_started }}
+          # 15 minutes was not enough for a 27-game bundle. On 0.2.1 the
+          # verifier polled the full default deadline, failed the job, and the
+          # build appeared on App Store Connect minutes later — a red X on a
+          # release that had in fact shipped. Apple's processing time scales
+          # with package size and this app is still growing.
+          ASC_TIMEOUT_SECONDS: "2700"
+          # Python buffers stdout when it is not a TTY, so all thirty poll lines
+          # were held and flushed at once on exit. They appeared in the log with
+          # timestamps inside the same 13 milliseconds, which reads exactly like
+          # a retry loop that never sleeps — it cost a wrong diagnosis. Unbuffer
+          # it so the log tells the truth about when each attempt happened.
+          PYTHONUNBUFFERED: "1"
         run: |
           set -euo pipefail
           python3 -m pip install --quiet --disable-pip-version-check 'pyjwt[crypto]'


### PR DESCRIPTION
## What

Two env vars on the iOS verification step: `ASC_TIMEOUT_SECONDS: 2700` (was a
900s default) and `PYTHONUNBUFFERED: 1`.

## Why

**0.2.1 shipped and the job reported failure.** The upload succeeded, the
verifier polled the full 15-minute deadline, and the build appeared on App Store
Connect minutes after it gave up. Apple's processing scales with package size
and this bundle now carries 27 games.

**The buffering fix is why the timeout fix nearly wasn't made.** Python buffers
stdout off a TTY, so all thirty poll lines flushed together at exit and landed
in the log stamped within the same 13 milliseconds:

```
23:29:38.577  attempt 21
23:29:38.590  attempt 30
```

That reads as a retry loop whose `sleep` does nothing, and it was diagnosed as
exactly that before the arithmetic corrected it: 30 attempts x 30s poll = 900s =
precisely the deadline. The loop was fine; the log was lying. `PYTHONUNBUFFERED`
makes the timestamps mean what they appear to mean, so the next person reading
this log is not sent the same wrong way.

## Blast radius

- [x] Two environment variables. No logic change, no weaker assertion.
- [x] The check still requires `uploadedDate >= run_started`. CFBundleVersion is
      minutes-since-epoch, so a presence-only test would pass on the very
      duplicate this exists to catch.
- [x] A longer deadline cannot mask a genuine failure — an INVALID build still
      fails immediately, and a stale build still fails as stale.
- [ ] Costs up to 45 min of ubuntu runner time in the worst case, on a step that
      normally returns in seconds. Cheap next to a red X on a shipped release.

## Proof

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-dynawalla.yml'))"
YAML OK
```

Observed on run 30406939738: `Build 0.2.1.29754667 never appeared ... within the
timeout`, while the API now reports that same build present and processing.