### PR TITLE
fix(dynawalla-app): exit is a top-left chevron, and stop the double-tap leak

### DIFF
--- a/dynawalla/dynawalla-app/index.html
+++ b/dynawalla/dynawalla-app/index.html
@@ -4,7 +4,16 @@
     <meta charset="UTF-8" />
     <!-- viewport-fit=cover is what makes env(safe-area-inset-*) report real
          values on notched iPhones; the --safe-* tokens are dead without it. -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <!-- user-scalable=no and maximum-scale=1 are what actually stop iOS
+         double-tap-to-zoom. Without them a double tap inside a game scales and
+         pans the HOST document, and the catalog behind the pack slides into
+         view at the top. Every pack entry already sets both; the frame around
+         them did not. `touch-action: manipulation` does NOT cover this — it
+         removes the click delay and still permits pinch and double-tap. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+    />
     <!-- Tells the WebView to paint its own chrome (scrollbars, form controls)
          in whichever scheme is active, so a dark app has no white flash. -->
     <meta name="color-scheme" content="light dark" />

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -20,6 +20,10 @@
     /* Keeps the WebView's own chrome — overscroll glow, form controls,
        scrollbars — in the theme the app is actually painting. */
     color-scheme: light;
+    /* On iOS the rubber-band belongs to the scrolling VIEWPORT, not to body.
+       Set on body alone the document still bounces, which is how the catalog
+       slides into view above a running game. */
+    overscroll-behavior: none;
   }
 
   html.dw-dark {

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -215,9 +215,23 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
         <button
           type="button"
           onClick={onLeave}
-          className="border-line-cut bg-ground/85 text-ink rounded-cut-sm absolute top-[max(var(--safe-top),0.5rem)] right-[max(var(--safe-right),0.5rem)] min-h-11 min-w-11 border px-4 text-sm backdrop-blur"
+          aria-label={strings.packs.leave}
+          className="border-line-cut bg-ground/85 text-ink absolute top-[calc(max(var(--safe-top),0px)+13px)] left-[calc(max(var(--safe-left),0px)+10px)] flex h-11 w-11 items-center justify-center rounded-full border text-lg backdrop-blur"
         >
-          {strings.packs.leave}
+          {/* A chevron, not a word. Top-left back is what a child has already
+              learned from every other app on the device, and an icon has no
+              translated width — so a game can reserve one 44px square and know
+              it is right in every language. The label lives in aria-label so
+              the control is still announced. */}
+          <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none">
+            <path
+              d="M15 4 L7 12 L15 20"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
         </button>
       )}
 

--- a/dynawalla/dynawalla-app/src/packs/packs.css
+++ b/dynawalla/dynawalla-app/src/packs/packs.css
@@ -16,6 +16,12 @@
      a pack could overflow. */
   min-inline-size: 0;
   overflow: hidden;
+  /* While a pack is up, nothing here pans, pinches or double-tap-zooms. This is
+     deliberately NOT on `body`: the catalog has to scroll, and `touch-action:
+     none` there would freeze it. The stage exists only while a game is running,
+     which is exactly the scope that wants it. */
+  touch-action: none;
+  overscroll-behavior: none;
 }
 
 .pack-frame {


### PR DESCRIPTION
fix(dynawalla-app): exit is a top-left chevron, and stop the double-tap leak

TWO CHANGES, both about the frame the games run inside.

EXIT. The leave control was a translated word in a pill, top-right. Two
problems: its width changes per language so no game could reserve space for it,
and it covered real UI in several games. It is now a 44px chevron at top-LEFT,
which is what a child has already learned from every other app on the device —
top-right is where "close" lives, a different promise, and where the shared
how-to-play control now sits. The word survives as aria-label, so the control is
still announced.

44px, not smaller: the platform minimum touch target, and about the smallest
square a seven-year-old hits reliably. Both corners are published as constants
in packs/shared/game-chrome, so a game reserves exactly this and the two cannot
drift.

DOUBLE TAP. A double tap inside a game scaled and panned the HOST document and
slid the catalog into view above the pack. The games were not at fault: 26 of
the 27 already set touch-action:none, overscroll-behavior:none, user-scalable=no
and maximum-scale=1 in their own pack entry. The frame around them set none of
it.

  - The viewport meta had no user-scalable=no and no maximum-scale=1, which are
    what actually stop iOS double-tap-to-zoom. `touch-action: manipulation` does
    NOT: it removes the click delay and still permits pinch and double tap. The
    comment above it said "nothing should double-tap-zoom", so the intent was
    right and the value never delivered it.
  - overscroll-behavior was on body only. On iOS the rubber-band belongs to the
    scrolling viewport, so html needs it too.
  - touch-action:none now sits on .pack-frame-host rather than on body, because
    the catalog has to scroll and locking body would freeze it. The stage exists
    only while a game is running, which is exactly the scope that wants it.

Left alone deliberately: dynawalla/games/siege is the one pack still missing
touch-action and maximum-scale in its own entry. That belongs in siege's PR.
