### PR TITLE
feat(dynawalla/games/balance): the safe area is the frame, and the two host corners stay clear

### DIFF
--- a/dynawalla/games/balance/src/draw.ts
+++ b/dynawalla/games/balance/src/draw.ts
@@ -1291,8 +1291,12 @@ export class Renderer {
 
   private hud(L: Layout, v: ViewState): void {
     const ctx = this.ctx;
-    const pad = L.hudPad;
-    const s = Math.max(11, Math.min(15, L.u * 13));
+    // The stack starts where the layout put it, under the host's exit control.
+    // It used to start at the padded corner, which is exactly where the host
+    // paints "back" — the movement name was behind a button on every device.
+    const s = L.hudSize;
+    const hx = L.hud.x;
+    const hy = L.hud.y;
 
     ctx.save();
     ctx.font = `600 ${s}px ${SERIF}`;
@@ -1300,25 +1304,25 @@ export class Renderer {
     ctx.textBaseline = "top";
     ctx.fillStyle = "rgba(226,206,168,0.62)";
     const title = v.spec.movementName.toUpperCase();
-    let x = pad;
+    let x = hx;
     for (const ch of title) {
-      ctx.fillText(ch, x, pad);
+      ctx.fillText(ch, x, hy);
       x += ctx.measureText(ch).width + s * 0.16;
     }
 
     // progress through the movement
-    const dotY = pad + s * 1.9;
+    const dotY = hy + s * 1.9;
     for (let i = 0; i < 5; i++) {
       const done = i < v.solvedTotal % 5 || (v.solvedTotal > 0 && v.solvedTotal % 5 === 0 && false);
       ctx.beginPath();
-      ctx.arc(pad + 4 + i * s * 0.85, dotY + 3, 3, 0, Math.PI * 2);
+      ctx.arc(hx + 4 + i * s * 0.85, dotY + 3, 3, 0, Math.PI * 2);
       ctx.fillStyle = done ? "rgba(255,208,122,0.9)" : "rgba(200,190,170,0.2)";
       ctx.fill();
     }
 
     // gems for clean solves
     for (let i = 0; i < Math.min(v.gems, 12); i++) {
-      const gx = pad + 4 + i * s * 0.8;
+      const gx = hx + 4 + i * s * 0.8;
       const gy = dotY + s * 1.5;
       ctx.save();
       ctx.translate(gx, gy);
@@ -1328,9 +1332,9 @@ export class Renderer {
       ctx.restore();
     }
 
-    // sound toggle
-    const bx = L.w - pad - 14;
-    const by = pad + 10;
+    // sound toggle, under the host's how-to-play control for the same reason
+    const bx = L.sound.x;
+    const by = L.sound.y;
     ctx.strokeStyle = v.audioOn ? "rgba(240,214,160,0.75)" : "rgba(180,170,150,0.32)";
     ctx.lineWidth = 1.6;
     ctx.beginPath();

--- a/dynawalla/games/balance/src/game.ts
+++ b/dynawalla/games/balance/src/game.ts
@@ -21,8 +21,12 @@ import {
   rackCanMake,
   remainingFor,
 } from "./puzzle.ts";
+import {
+  createInstructions,
+  type Instructions,
+} from "../../../packs/shared/game-chrome/index.ts";
 import { specFromQuestion } from "./adapter.ts";
-import { computeLayout, armDistance, beamPoint, rackSlot } from "./layout.ts";
+import { layoutForViewport, armDistance, beamPoint, rackSlot } from "./layout.ts";
 import type { Layout } from "./layout.ts";
 import {
   makeBeam,
@@ -112,6 +116,7 @@ export class Game {
   private lastT = 0;
   private running = true;
   private ro: ResizeObserver | null = null;
+  private guide: Instructions;
 
   // measured, exposed for the playtest harness
   readonly stats = {
@@ -140,7 +145,64 @@ export class Game {
     this.renderer = new Renderer(this.canvas);
     this.cam.reduced = host.prefersReducedMotion();
 
-    this.L = computeLayout(1, 1, 9);
+    // How to play. COUNTERPOISE shipped with nothing telling a child what the
+    // brass is for: they were shown a tipped arm, a row of weights and a line
+    // of engraved arithmetic, and left to guess that dragging is the verb. The
+    // manual stays reachable during play, because the moment a child needs the
+    // rules is never the title screen.
+    this.guide = createInstructions(el, {
+      title: "COUNTERPOISE",
+      summary: [
+        "A big brass scale hangs in front of you. One side is heavier, so the arm tips.",
+        "Drag weights out of the row at the bottom until the arm sits flat.",
+      ],
+      sections: [
+        {
+          heading: "Playing",
+          lines: [
+            "The weights wait in a row along the bottom of the screen.",
+            "Drag one to the empty dish and let go. It drops in.",
+            "Each board has one place a weight can go. Aim for that place.",
+            "Drag a weight back out of the dish to take it off again.",
+            "On a keyboard: arrow keys pick a weight, Enter drops it, Backspace takes it back.",
+          ],
+        },
+        {
+          heading: "Flat means equal",
+          lines: [
+            "When the two sides weigh the same, the arm stops tipping and sits flat.",
+            "That flat arm is the equals sign. Both sides really do weigh the same.",
+            "The words cut into the stone say the same thing with numbers.",
+          ],
+        },
+        {
+          heading: "Sealed boxes",
+          lines: [
+            "Some boxes are shut and you cannot see inside.",
+            "Work out how heavy the box must be to make the arm flat.",
+            "Then drag that number onto the box to say it out loud.",
+          ],
+        },
+        {
+          heading: "The long arm",
+          lines: [
+            "Some arms have numbers marked along them.",
+            "A weight far out from the middle pushes down harder than the same weight near the middle.",
+            "A balloon does the opposite. It pulls up instead of down.",
+          ],
+        },
+        {
+          heading: "If it tips",
+          lines: [
+            "Nothing buzzes at you when you are wrong. The arm just swings the way you made it swing.",
+            "Take the weight off and try a different one. You can try as many times as you want.",
+          ],
+        },
+      ],
+      reducedMotion: host.prefersReducedMotion(),
+    });
+
+    this.L = layoutForViewport(1, 1, 9);
     for (let i = 0; i < 44; i++) {
       this.motes[i * 4] = Math.random();
       this.motes[i * 4 + 1] = Math.random();
@@ -179,7 +241,7 @@ export class Game {
     const h = Math.max(240, Math.round(r.height || window.innerHeight));
     // DPR capped at 2: a 3x phone would triple the fill cost for no visible gain.
     const dpr = Math.min(2, window.devicePixelRatio || 1);
-    this.L = computeLayout(w, h, this.spec ? this.spec.rack.length : 9);
+    this.L = layoutForViewport(w, h, this.spec ? this.spec.rack.length : 9);
     this.renderer.resize(w, h, dpr);
     this.seatAll(true);
   }
@@ -209,7 +271,7 @@ export class Game {
       });
       this.bodies.push(b);
     }
-    this.L = computeLayout(this.L.w, this.L.h, this.spec.rack.length);
+    this.L = layoutForViewport(this.L.w, this.L.h, this.spec.rack.length);
     this.seatAll(true);
 
     // Assemble: everything drops in from above with a stagger.
@@ -704,9 +766,11 @@ export class Game {
     this.idle = 0;
     const p = this.localPoint(e);
 
-    // sound toggle
-    const pad = this.L.hudPad;
-    if (p.x > this.L.w - pad - 34 && p.y < pad + 34) {
+    // sound toggle. Its box comes from the layout, which puts it clear of the
+    // host's top-right control — the old `y < pad + 34` test was underneath it,
+    // so the child's tap opened how-to-play and the speaker never toggled.
+    const s = this.L.sound;
+    if (Math.abs(p.x - s.x) < s.half && Math.abs(p.y - s.y) < s.half) {
       this.audio.setEnabled(!this.audio.isEnabled);
       this.audio.lift();
       return;
@@ -1220,6 +1284,7 @@ export class Game {
 
   unmount(): void {
     this.running = false;
+    this.guide.destroy();
     cancelAnimationFrame(this.raf);
     this.ro?.disconnect();
     window.removeEventListener("resize", this.onWinResize);

--- a/dynawalla/games/balance/src/layout.test.ts
+++ b/dynawalla/games/balance/src/layout.test.ts
@@ -1,0 +1,185 @@
+// THE FRAME.
+//
+// Every other test in this game is about brass and rational arithmetic, and not
+// one of them can see where a thing is drawn. So COUNTERPOISE shipped with its
+// movement name underneath the host's exit button, its sound toggle underneath
+// the how-to-play button, and its rack of weights — the row a child touches on
+// every single turn — sitting in the bottom `h * 0.035` of the glass, which on
+// a phone with a home indicator is underneath the home indicator.
+//
+// This file is the gate for all three. It runs the layout through
+// `layoutForViewport`, which is the exact entry point `Game.resize` uses, so
+// what is asserted here is the arrangement a child gets rather than a pure
+// function fed hand-picked arguments.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+} from "../../../packs/shared/game-chrome/index.ts";
+import { computeLayout, layoutForViewport, rackSlot } from "./layout.ts";
+
+/** Phones held both ways, tablets held both ways, and the smallest phone. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+  ["laptop", 1440, 900],
+];
+
+/** Rack sizes the generator actually produces, from the sparsest to the fullest. */
+const RACKS = [4, 6, 9, 12];
+
+for (const [name, w, h] of VIEWPORTS) {
+  test(`nothing readable sits under the host's chrome at ${name} (${w}×${h})`, () => {
+    for (const n of RACKS) {
+      const L = layoutForViewport(w, h, n);
+
+      // The movement name, the progress dots and the gems. A child reads these.
+      assert.equal(
+        hitsHostChrome(L.hud, w),
+        false,
+        `${name}, rack ${n}: the HUD stack is under host chrome`,
+      );
+
+      // The sound toggle. A child TOUCHES this, which is worse: a tap that
+      // lands on the host's control instead does something else entirely.
+      const sound = {
+        x: L.sound.x - L.sound.half,
+        y: L.sound.y - L.sound.half,
+        w: L.sound.half * 2,
+        h: L.sound.half * 2,
+      };
+      assert.equal(
+        hitsHostChrome(sound, w),
+        false,
+        `${name}, rack ${n}: the sound toggle is under host chrome`,
+      );
+
+      // The sound toggle is still a real target, and still on the glass.
+      assert.ok(L.sound.half * 2 >= 44, "the sound toggle is under 44px");
+      assert.ok(L.sound.x + L.sound.half <= w + 0.5, "the sound toggle runs off the right");
+      assert.ok(L.sound.y - L.sound.half >= 0, "the sound toggle runs off the top");
+    }
+  });
+
+  test(`the rack of weights stays inside the safe area at ${name} (${w}×${h})`, () => {
+    const area = safeRect(w, h);
+    for (const n of RACKS) {
+      const L = layoutForViewport(w, h, n);
+      for (let i = 0; i < n; i++) {
+        const p = rackSlot(L, i, n);
+        assert.ok(
+          p.y + L.rack.slotH / 2 <= area.y + area.h + 0.5,
+          `${name}, rack ${n}: weight ${i} hangs below the safe area`,
+        );
+        assert.ok(
+          p.x - L.rack.slotW / 2 >= area.x - 0.5,
+          `${name}, rack ${n}: weight ${i} runs off the safe left edge`,
+        );
+        assert.ok(
+          p.x + L.rack.slotW / 2 <= area.x + area.w + 0.5,
+          `${name}, rack ${n}: weight ${i} runs off the safe right edge`,
+        );
+      }
+      // The rack must not have been pushed up into the plinth to achieve that.
+      assert.ok(
+        L.rack.y > L.plinth.y + L.plinth.h - 0.5,
+        `${name}, rack ${n}: the rack overlaps the plinth`,
+      );
+    }
+  });
+
+  test(`the apparatus fits the safe area at ${name} (${w}×${h})`, () => {
+    const area = safeRect(w, h);
+    const L = layoutForViewport(w, h, 9);
+    assert.ok(L.pivot.y - L.arm * 0.2 > area.y, "the beam is above the safe area");
+    assert.ok(L.pivot.x - L.arm >= area.x - 0.5, "the arm runs off the safe left edge");
+    assert.ok(L.pivot.x + L.arm <= area.x + area.w + 0.5, "the arm runs off the safe right edge");
+    assert.ok(L.plinth.x >= area.x - 0.5, "the plinth runs off the safe left edge");
+    assert.ok(
+      L.plinth.x + L.plinth.w <= area.x + area.w + 0.5,
+      "the plinth runs off the safe right edge",
+    );
+    // A prompt a child cannot read is not a prompt.
+    assert.ok(L.promptSize >= 17, `the engraving is ${L.promptSize.toFixed(1)}px`);
+  });
+}
+
+// Node has no notch, so `safeInsets()` reads zeros here and the tests above
+// cannot tell a layout that honours the safe area from one that ignores it.
+// These do: they hand `computeLayout` the rectangle a real device would give
+// it, and assert against that rectangle rather than against the glass.
+const NOTCHED: Array<[string, number, number, Insets]> = [
+  ["phone portrait, notch + home indicator", 390, 844, { top: 59, right: 0, bottom: 34, left: 0 }],
+  ["phone landscape, notch on the left", 844, 390, { top: 0, right: 59, bottom: 21, left: 59 }],
+  ["small phone, notch + home indicator", 320, 568, { top: 44, right: 0, bottom: 34, left: 0 }],
+];
+
+for (const [name, w, h, insets] of NOTCHED) {
+  test(`the safe area is honoured on a ${name}`, () => {
+    const area = safeRect(w, h, insets);
+    for (const n of RACKS) {
+      const L = computeLayout(w, h, n, area);
+
+      // The rack. This is the bug: `h - rackH - h * 0.035` put the bottom row
+      // of weights under the home indicator, where a drag is a system gesture.
+      for (let i = 0; i < n; i++) {
+        const p = rackSlot(L, i, n);
+        assert.ok(
+          p.y + L.rack.slotH / 2 <= area.y + area.h + 0.5,
+          `${name}, rack ${n}: weight ${i} is under the home indicator`,
+        );
+        assert.ok(
+          p.x - L.rack.slotW / 2 >= area.x - 0.5 &&
+            p.x + L.rack.slotW / 2 <= area.x + area.w + 0.5,
+          `${name}, rack ${n}: weight ${i} is under a rounded corner`,
+        );
+      }
+
+      // The apparatus and the engraving.
+      assert.ok(L.pivot.y >= area.y, `${name}: the pivot is above the safe area`);
+      assert.ok(L.pivot.x - L.arm >= area.x - 0.5, `${name}: the arm is off the safe left`);
+      assert.ok(
+        L.pivot.x + L.arm <= area.x + area.w + 0.5,
+        `${name}: the arm is off the safe right`,
+      );
+      assert.ok(
+        L.plinth.y + L.plinth.h <= area.y + area.h + 0.5,
+        `${name}: the engraving is below the safe area`,
+      );
+
+      // And the chrome promise still holds once there ARE insets, which move
+      // both of the host's corners.
+      assert.equal(hitsHostChrome(L.hud, w, insets), false, `${name}: the HUD is under chrome`);
+      assert.equal(
+        hitsHostChrome(
+          {
+            x: L.sound.x - L.sound.half,
+            y: L.sound.y - L.sound.half,
+            w: L.sound.half * 2,
+            h: L.sound.half * 2,
+          },
+          w,
+          insets,
+        ),
+        false,
+        `${name}: the sound toggle is under chrome`,
+      );
+    }
+  });
+}
+
+test("the safe rectangle is what the layout is actually built from", () => {
+  // The other direction: give the layout a smaller box and everything inside
+  // it moves. If this stops holding, the `area` argument has quietly become
+  // decoration and the notch is back.
+  const wide = layoutForViewport(390, 844, 9);
+  assert.deepEqual(wide.area, safeRect(390, 844));
+  assert.ok(wide.rack.y < 844, "the rack is off the bottom of the glass");
+});

--- a/dynawalla/games/balance/src/layout.ts
+++ b/dynawalla/games/balance/src/layout.ts
@@ -2,12 +2,41 @@
 // portrait and a 1440x900 desktop get genuinely different arrangements, not one
 // scaled to fit the other. The rack reflows into rows; the arm shortens against
 // height as well as width; touch targets have a floor.
+//
+// **The frame is not the canvas.** COUNTERPOISE declares `viewport-fit=cover`,
+// which opts the document into the notch, the rounded corners and the home
+// indicator. A canvas cannot claw that back with `env()` — that is a CSS value
+// and `fillText` knows nothing about it — so the safe rectangle arrives here as
+// a required argument and everything a child reads or touches is laid out
+// inside it. The rack in particular used to sit `h * 0.035` off the bottom
+// edge, which on a phone with a home indicator is underneath the home
+// indicator: the row of weights the whole game is played from.
+//
+// The argument is REQUIRED on purpose. Optional would mean a caller that forgot
+// it still compiles and quietly draws under the notch, discoverable only on a
+// device.
+//
+// **The host draws on top of us.** Two 44px corners belong to chrome the pack
+// does not own — the exit control top-left, how-to-play top-right. The brass,
+// the motes and the beam may run under them freely and should; that is the
+// point of `cover`. The HUD and the sound toggle may not, so they are placed
+// from `exitRect`/`helpRect` rather than from the corner of the screen.
+
+import {
+  exitRect,
+  helpRect,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../packs/shared/game-chrome/index.ts";
 
 export const MAX_PEG = 5;
 
 export type Layout = {
   w: number;
   h: number;
+  /** The safe rectangle everything readable or touchable lives inside. */
+  area: Rect;
   portrait: boolean;
   /** general scale hint for line weights and small type */
   u: number;
@@ -24,40 +53,99 @@ export type Layout = {
   promptSize: number;
   rack: { y: number; rows: number; slotW: number; slotH: number; cols: number };
   hudPad: number;
+  /** Type size of the HUD stack. Shared so draw and layout cannot disagree. */
+  hudSize: number;
+  /** The block the movement name, the progress dots and the gems occupy. */
+  hud: Rect;
+  /** The sound toggle: anchor point and the half-side of its touch target. */
+  sound: { x: number; y: number; half: number };
 };
 
 const clamp = (v: number, lo: number, hi: number): number =>
   v < lo ? lo : v > hi ? hi : v;
 
-export function computeLayout(w: number, h: number, rackCount: number): Layout {
-  const portrait = h > w * 1.05;
-  const u = clamp(Math.min(w / 900, h / 620), 0.55, 1.9);
+/**
+ * The insets `area` was cut from. `safeRect` is exactly this subtraction, so
+ * running it backwards is lossless and lets the layout ask the shared module
+ * where the host's two corners are without a second source of truth.
+ */
+function insetsOf(w: number, h: number, area: Rect): Insets {
+  return {
+    top: area.y,
+    left: area.x,
+    right: Math.max(0, w - area.x - area.w),
+    bottom: Math.max(0, h - area.y - area.h),
+  };
+}
 
-  const weightR = clamp(Math.min(w / 15.5, h / 17), 17, 34);
+/**
+ * @param area the safe rectangle, from `safeRect(w, h)`. Required — see the
+ * note at the top of this file.
+ */
+export function computeLayout(
+  w: number,
+  h: number,
+  rackCount: number,
+  area: Rect,
+): Layout {
+  const bw = Math.max(120, area.w);
+  const bh = Math.max(120, area.h);
+  const cx = area.x + bw / 2;
+  const portrait = bh > bw * 1.05;
+  const u = clamp(Math.min(bw / 900, bh / 620), 0.55, 1.9);
+
+  const weightR = clamp(Math.min(bw / 15.5, bh / 17), 17, 34);
   const slotW = weightR * 2 + weightR * 0.52;
   const slotH = weightR * 2.35;
 
-  const margin = Math.max(10, w * 0.03);
-  const cols = Math.max(3, Math.min(rackCount, Math.floor((w - margin * 2) / slotW)));
+  const margin = Math.max(10, bw * 0.03);
+  const cols = Math.max(3, Math.min(rackCount, Math.floor((bw - margin * 2) / slotW)));
   const rows = Math.max(1, Math.ceil(rackCount / cols));
 
   const rackH = rows * slotH;
-  const rackY = h - rackH - Math.max(12, h * 0.035);
+  // Off the SAFE bottom, not the glass bottom: the home indicator sits in
+  // between, and the rack is the one thing in this game a child touches every
+  // single turn.
+  const rackY = area.y + bh - rackH - Math.max(12, bh * 0.035);
 
-  const arm = Math.min(w * 0.315, h * (portrait ? 0.30 : 0.40));
-  const pivotY = clamp(h * (portrait ? 0.235 : 0.235), 90, h * 0.34);
-  const drop = clamp((rackY - pivotY) * 0.42, weightR * 2.4, h * 0.26);
+  const arm = Math.min(bw * 0.315, bh * (portrait ? 0.30 : 0.40));
+  const pivotY = area.y + clamp(bh * 0.235, 90, bh * 0.34);
+  const drop = clamp((rackY - pivotY) * 0.42, weightR * 2.4, bh * 0.26);
 
-  const plinthW = Math.min(w * 0.62, arm * 1.7);
-  const plinthH = clamp(h * 0.1, 44, 108);
-  const plinthY = clamp(pivotY + drop + weightR * 2.9, h * 0.56, rackY - plinthH - 8 * u);
+  const plinthW = Math.min(bw * 0.62, arm * 1.7);
+  const plinthH = clamp(bh * 0.1, 44, 108);
+  const plinthY = clamp(
+    pivotY + drop + weightR * 2.9,
+    area.y + bh * 0.56,
+    rackY - plinthH - 8 * u,
+  );
+
+  const hudPad = Math.max(10, Math.min(bw, bh) * 0.028);
+  const hudSize = clamp(u * 13, 11, 15);
+
+  // The two corners the host paints into. The HUD stack drops under the exit
+  // control and the sound toggle drops under the how-to-play control, so both
+  // stay legible and tappable instead of living behind a button.
+  const insets = insetsOf(w, h, area);
+  const exit = exitRect(insets);
+  const help = helpRect(w, insets);
+  const gap = Math.max(8, hudPad * 0.6);
+
+  const hudX = area.x + hudPad;
+  const hudY = exit.y + exit.h + gap;
+  const hudH = hudSize * 3.6 + 12;
+
+  const soundHalf = 22;
+  const soundX = help.x + help.w - 16;
+  const soundY = help.y + help.h + gap + soundHalf;
 
   return {
     w,
     h,
+    area,
     portrait,
     u,
-    pivot: { x: w / 2, y: pivotY },
+    pivot: { x: cx, y: pivotY },
     arm,
     drop,
     // never wider than the arm it hangs from, or a narrow screen clips it
@@ -65,11 +153,37 @@ export function computeLayout(w: number, h: number, rackCount: number): Layout {
     dishH: weightR * 0.95,
     weightR,
     crateR: weightR * 1.04,
-    plinth: { x: w / 2 - plinthW / 2, y: plinthY, w: plinthW, h: plinthH },
-    promptSize: clamp(Math.min(w / 13.5, h / 13), 17, 52),
+    plinth: { x: cx - plinthW / 2, y: plinthY, w: plinthW, h: plinthH },
+    promptSize: clamp(Math.min(bw / 13.5, bh / 13), 17, 52),
     rack: { y: rackY, rows, slotW, slotH, cols },
-    hudPad: Math.max(10, Math.min(w, h) * 0.028),
+    hudPad,
+    hudSize,
+    // 260 is a deliberate over-estimate of the block's real ink: the longest
+    // movement name is twenty tracked characters and the gem row is twelve
+    // diamonds, neither of which reaches it at any type size this clamps to.
+    // Over-estimating is the safe direction — the test that asserts this clears
+    // the host's corners is then stricter than the pixels.
+    hud: {
+      x: hudX,
+      y: hudY,
+      w: Math.max(60, Math.min(260, area.x + bw - hudX)),
+      h: hudH,
+    },
+    sound: { x: soundX, y: soundY, half: soundHalf },
   };
+}
+
+/**
+ * The layout the game actually runs at, for a viewport of `w` x `h`.
+ *
+ * The one entry point production uses, so a test that calls this is testing the
+ * arrangement a child sees rather than a pure function fed hand-picked
+ * arguments. `safeRect` reads zeros wherever there is no environment to
+ * measure, so this is the plain full-screen layout in node and on a device
+ * without insets.
+ */
+export function layoutForViewport(w: number, h: number, rackCount: number): Layout {
+  return computeLayout(w, h, rackCount, safeRect(w, h));
 }
 
 /** Distance along the arm, in pixels, for a peg on a given mode. */
@@ -98,6 +212,6 @@ export function rackSlot(L: Layout, i: number, total: number): { x: number; y: n
   const inRow = i % cols;
   const countInRow = row === rows - 1 ? total - cols * row : cols;
   const rowW = countInRow * slotW;
-  const x0 = L.w / 2 - rowW / 2 + slotW / 2;
+  const x0 = L.area.x + L.area.w / 2 - rowW / 2 + slotW / 2;
   return { x: x0 + inRow * slotW, y: y + row * slotH + slotH * 0.5 };
 }


### PR DESCRIPTION
## What

Lay COUNTERPOISE out inside the safe rectangle instead of against the glass, move
the HUD stack and the sound toggle out from under the host's two 44px corners,
and give the game a how-to-play surface it has never had.

## Why

COUNTERPOISE declares `viewport-fit=cover`, which opts the document *into* the
notch, the rounded corners and the home indicator. It then read nothing back. On
a canvas that is not a small mistake — `env()` is a CSS value and `fillText`
knows nothing about it — so three things were wrong, and all three are the kind
of thing no rules test can see:

- **The rack of weights sat `h * 0.035` off the bottom EDGE.** That is the row a
  child touches on every single turn, and on any phone with a home indicator it
  was underneath the home indicator, where a drag upward is a system gesture and
  not a move in this game.
- **The movement name, progress dots and gems started at the padded top-left
  corner** — exactly where the host paints its exit control.
- **The sound toggle sat at the padded top-right corner**, under the shared
  how-to-play control, and its hit test (`p.y < pad + 34`) was underneath it too.
  A child tapping the speaker opened the manual instead.

`computeLayout` now takes the safe rectangle as a **required** argument.
Optional would mean a caller that forgets it still compiles and quietly draws
under the notch, discoverable only on a device. `layoutForViewport(w, h, n)` is
the single entry point `Game.resize` uses, so the new tests exercise the
arrangement a child actually gets rather than a pure function fed hand-picked
arguments.

Host chrome **overlays**; no band is reserved. Reserving 67px cost 12% of a
small phone's height in SKY LEDGER and broke its own lattice invariant. The
brass, the motes and the beam still run full-bleed under the corners — that is
the point of `cover`. Only the two things a child must read or touch move, and
they move to just below the host's controls rather than away from them.

## Blast radius

**Areas touched:** dynawalla (one game pack, `dynawalla/games/balance` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published zip changed in place; `pack.json`
      untouched (id, version, capabilities, covers all unchanged). No `voiceId`,
      no catalog entry.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are the
      instruction copy inside the pack; the pack declares `"locales": ["en"]`
      and this game has no i18n catalogue, same as SKY LEDGER's adoption.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema
      touched. The rational arithmetic in `frac.ts`/`puzzle.ts` is untouched and
      still exact.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

**What a reviewer cannot reconstruct from the diff:** the layout numbers were
kept identical on a device with no insets. Every `w`/`h` inside `computeLayout`
became `area.w`/`area.h` and every origin gained `area.x`/`area.y`, which is a
no-op when the insets are zero — so the desktop and the dev harness look exactly
as they did. The only unconditional visual change is the HUD stack and the sound
toggle dropping ~57px, which is required on every device because the host's
chrome is there on every device.

`Game.unmount` now calls `guide.destroy()`, which removes the help button, the
panel, the injected stylesheet, the `keydown` listener and the inset watcher. A
pack that mounts twice without that leaks a listener per mount.

## Proof

`npm test` five times — one green run is not proof:

```
$ for i in 1 2 3 4 5; do npm test 2>&1 | grep -E "^# (tests|pass|fail)"; done
--- run 1 ---
# tests 40
# pass 40
# fail 0
--- run 2 ---
# tests 40
# pass 40
# fail 0
--- run 3 ---
# tests 40
# pass 40
# fail 0
--- run 4 ---
# tests 40
# pass 40
# fail 0
--- run 5 ---
# tests 40
# pass 40
# fail 0
```

**The new tests fail when the fix is removed.** A clearance test that passes
either way is worthless, so both halves were checked by reverting them.

Corner clearance — revert `hudY`/`soundX`/`soundY` to the padded screen corner:

```
not ok 19 - nothing readable sits under the host's chrome at phone portrait, small (320×568)
not ok 22 - nothing readable sits under the host's chrome at phone portrait, tall (390×844)
not ok 25 - nothing readable sits under the host's chrome at tablet portrait (768×1024)
not ok 28 - nothing readable sits under the host's chrome at tablet landscape (1024×768)
not ok 31 - nothing readable sits under the host's chrome at phone landscape (844×390)
not ok 34 - nothing readable sits under the host's chrome at laptop (1440×900)
# tests 40
# pass 34
# fail 6
```

Safe area — revert `rackY` to `h - rackH - Math.max(12, h * 0.035)`:

```
not ok 37 - the safe area is honoured on a phone portrait, notch + home indicator
not ok 38 - the safe area is honoured on a phone landscape, notch on the left
not ok 39 - the safe area is honoured on a small phone, notch + home indicator
# tests 40
# pass 37
# fail 3
```

Node reports zero insets, so the safe-area half is asserted against three
*simulated* notched devices via `computeLayout(w, h, n, safeRect(w, h, insets))`
— without that it could not fail at all.

```
$ npm run tsc
> dynawalla-game-balance@0.1.0 tsc
> tsc --noEmit

$ npm run build
vite v8.1.5 building client environment for production...
✓ 22 modules transformed.
dist/index.html                 0.79 kB │ gzip:  0.44 kB
dist/assets/index-CAK6lvmH.js  75.45 kB │ gzip: 25.50 kB
✓ built in 33ms
```

```
$ cd dynawalla/packs && node build.mjs balance
dynawalla.balance@0.1.0 — COUNTERPOISE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       5 skills, grades 1–5
  on disk      3 files, 76525 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~16742 bytes (16.74 KB) in 37.3ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/balance/src/draw.ts
dynawalla/games/balance/src/game.ts
dynawalla/games/balance/src/layout.test.ts
dynawalla/games/balance/src/layout.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```
