### PR TITLE
fix(dynawalla/games/coil): lay the alley out inside the safe area and keep the host's corners clear

### DIFF
--- a/dynawalla/games/coil/src/mount.ts
+++ b/dynawalla/games/coil/src/mount.ts
@@ -25,6 +25,7 @@
 // cut smashes two lumps on its way to the wall. The board you have to play on
 // is the board you made.
 
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 import type { Host } from "./contract.ts"
 import { Audio } from "./audio/audio.ts"
 import { SLAG_CELLS, buried as buriedCount } from "./game/board.ts"
@@ -45,6 +46,60 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
   const scene = new Scene(container)
   const audio = new Audio()
   let reduced = host.prefersReducedMotion()
+
+  // How to play. The wall says SHEAR OFF THE LIT NUMBER and nothing anywhere
+  // said that a second tap opens a drum into ten beads — which is the borrow,
+  // and the only way to cut 25 off a coil whose tail is two beads. A child who
+  // has not been told that decides the game is broken and leaves. The manual
+  // stays reachable during play, because the moment the rules are needed is
+  // never the title.
+  const guide = createInstructions(el, {
+    title: "THE COIL OF NINETY-SIX",
+    summary: [
+      "A brass chain crawls down the alley. The wall lights up one number.",
+      "Cut that exact number off the end of the chain.",
+    ],
+    sections: [
+      {
+        heading: "How to cut",
+        lines: [
+          "Tap a link. The jaws move there. That is where the cut will happen.",
+          "Pull the SHEAR lever. Everything after the jaws comes off.",
+          "Take as long as you like. There is no timer and nothing is rushing you.",
+        ],
+      },
+      {
+        heading: "What the links are worth",
+        lines: [
+          "A small bead is 1.",
+          "A ribbed drum is 10.",
+          "A ring with a hole in it is 100.",
+          "A tall tower is 1000.",
+          "The chain reads biggest first, the same way you write a number.",
+        ],
+      },
+      {
+        heading: "Making change",
+        lines: [
+          "Say the chain is 72 and the wall wants 25.",
+          "The end of the chain has only 2 beads. You cannot cut 25 off there.",
+          "Tap a link twice to open it. One drum opens into ten beads.",
+          "Now count back through those beads to find the right place to cut.",
+          "Opening links is free. Open as many as you want.",
+        ],
+      },
+      {
+        heading: "If you cut in the wrong place",
+        lines: [
+          "The piece does not fit the wall. It drops in the alley as a lump.",
+          "Lumps take up room. With less room, the front of your chain gets buried.",
+          "A cut that is exactly right smashes two lumps on its way to the wall.",
+          "Tap the FURNACE to melt every lump. It eats the chain you are holding.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
 
   const session = createSession({
     nextQuestion: () => {
@@ -416,6 +471,7 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
       observer?.disconnect()
       media?.removeEventListener("change", onMedia)
       audio.dispose()
+      guide.destroy()
       scene.destroy()
       container.remove()
     },

--- a/dynawalla/games/coil/src/render/chrome.test.ts
+++ b/dynawalla/games/coil/src/render/chrome.test.ts
@@ -1,0 +1,106 @@
+// THE TWO CORNERS AND THE NOTCH.
+//
+// This game declares `viewport-fit=cover`, so its canvas reaches under the
+// notch, the home indicator and the rounded corners, and the host floats an
+// exit control over the top-left and a how-to-play control over the top-right.
+// A canvas cannot read `env()`, so none of that is visible to `fillText`: the
+// carved problem was drawn at `wall.y + wall.h * 0.12`, about 27px down, which
+// is underneath the exit control on every phone that has one, and underneath
+// the notch as well on the ones with a notch.
+//
+// The gate is deliberately built around `viewLayout` — the exact function
+// `Scene.resize` calls — rather than around `layout`, because a test that hands
+// the layout an area it invented itself passes whether or not the renderer ever
+// asks for one. Here, if the safe area stops being plumbed through, the notched
+// profiles fail; if the corner inset on the recess goes, the flat profiles fail
+// too.
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  type Insets,
+  NO_INSETS,
+  type Rect,
+  hitsHostChrome,
+  safeRect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { cellAt, viewLayout } from "./layout.ts"
+
+const PORTRAIT_NOTCH: Insets = { top: 59, right: 0, bottom: 34, left: 0 }
+const LANDSCAPE_NOTCH: Insets = { top: 0, right: 59, bottom: 21, left: 59 }
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+/** A flat profile always, and the notch the device of that shape actually has. */
+function profiles(w: number, h: number): Array<[string, Insets]> {
+  return [
+    ["no insets", NO_INSETS],
+    w >= h
+      ? ["landscape notch", LANDSCAPE_NOTCH]
+      : ["portrait notch", PORTRAIT_NOTCH],
+  ]
+}
+
+const contains = (outer: Rect, inner: Rect): boolean =>
+  inner.x >= outer.x - 0.5 &&
+  inner.y >= outer.y - 0.5 &&
+  inner.x + inner.w <= outer.x + outer.w + 0.5 &&
+  inner.y + inner.h <= outer.y + outer.h + 0.5
+
+for (const [shape, w, h] of VIEWPORTS) {
+  for (const [profile, insets] of profiles(w, h)) {
+    const where = `${shape} ${String(w)}×${String(h)}, ${profile}`
+
+    test(`nothing a child reads or touches is under the host's chrome — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      const area = safeRect(w, h, insets)
+
+      // The carved problem with the lit demand. It IS the instruction of the
+      // game: a child who cannot read it cannot play, so it is first.
+      const critical: Array<[string, Rect]> = [
+        ["the recess", l.recess],
+        ["the brick courses", l.courses],
+        ["the lane", l.lane],
+        ["the SHEAR lever", l.shear],
+        ["the FURNACE lever", l.furnace],
+      ]
+
+      for (const [name, rect] of critical) {
+        assert.equal(
+          hitsHostChrome(rect, w, insets),
+          false,
+          `${name} is under the host's chrome at ${where}`,
+        )
+        assert.ok(
+          contains(area, rect),
+          `${name} leaves the safe area at ${where} — ${JSON.stringify(rect)} vs ${JSON.stringify(area)}`,
+        )
+      }
+    })
+
+    test(`every link in the lane is tappable — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      const area = safeRect(w, h, insets)
+      const r = l.lane.unit
+      for (let i = 0; i < l.lane.capacity; i++) {
+        const c = cellAt(l.lane, i)
+        const box: Rect = { x: c.x - r, y: c.y - r, w: r * 2, h: r * 2 }
+        assert.equal(hitsHostChrome(box, w, insets), false, `link ${String(i)} at ${where}`)
+        assert.ok(contains(area, box), `link ${String(i)} leaves the safe area at ${where}`)
+      }
+    })
+
+    test(`the recess is wide enough to carve a problem into — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      assert.ok(l.recess.w >= 90, `the recess is ${l.recess.w.toFixed(1)}px at ${where}`)
+      assert.ok(l.recess.h >= 55, `the recess is ${l.recess.h.toFixed(1)}px tall at ${where}`)
+    })
+  }
+}

--- a/dynawalla/games/coil/src/render/layout.test.ts
+++ b/dynawalla/games/coil/src/render/layout.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import test from "node:test"
 
 import { Rng } from "../core/rng.ts"
-import { LANE_CELLS, cellAt, cellNear, inside, layout } from "./layout.ts"
+import { LANE_CELLS, cellAt, cellNear, inside, viewLayout } from "./layout.ts"
 
 const SEED = 0x0c011960
 
@@ -19,7 +19,7 @@ const VIEWPORTS: [number, number][] = [
 
 test("the lane never claims more than ninety-six cells", () => {
   for (const [w, h] of VIEWPORTS) {
-    const l = layout(w, h)
+    const l = viewLayout(w, h)
     assert.ok(l.lane.capacity <= LANE_CELLS, `${String(w)}×${String(h)}`)
     assert.ok(l.lane.capacity >= 12, `${String(w)}×${String(h)} is playable`)
   }
@@ -27,7 +27,7 @@ test("the lane never claims more than ninety-six cells", () => {
 
 test("nothing overlaps and nothing leaves the viewport", () => {
   for (const [w, h] of VIEWPORTS) {
-    const l = layout(w, h)
+    const l = viewLayout(w, h)
     assert.ok(l.wall.y >= 0)
     assert.ok(l.wall.x >= 0)
     assert.ok(l.wall.x + l.wall.w <= w + 0.5)
@@ -41,7 +41,7 @@ test("nothing overlaps and nothing leaves the viewport", () => {
 
 test("every lever is at least a finger across", () => {
   for (const [w, h] of VIEWPORTS) {
-    const l = layout(w, h)
+    const l = viewLayout(w, h)
     assert.ok(l.shear.w >= 44 && l.shear.h >= 44, `shear at ${String(w)}×${String(h)}`)
     assert.ok(l.furnace.w >= 44 && l.furnace.h >= 44, `furnace at ${String(w)}×${String(h)}`)
   }
@@ -49,7 +49,7 @@ test("every lever is at least a finger across", () => {
 
 test("consecutive lane cells are adjacent — the chain never jumps", () => {
   for (const [w, h] of VIEWPORTS) {
-    const l = layout(w, h)
+    const l = viewLayout(w, h)
     for (let i = 1; i < l.lane.capacity; i++) {
       const a = cellAt(l.lane, i - 1)
       const b = cellAt(l.lane, i)
@@ -60,7 +60,7 @@ test("consecutive lane cells are adjacent — the chain never jumps", () => {
 })
 
 test("the serpentine turns at the end of every row and never crosses itself", () => {
-  const l = layout(1024, 768)
+  const l = viewLayout(1024, 768)
   const seen = new Set<string>()
   for (let i = 0; i < l.lane.capacity; i++) {
     const c = cellAt(l.lane, i)
@@ -73,7 +73,7 @@ test("the serpentine turns at the end of every row and never crosses itself", ()
 })
 
 test("cellNear finds the cell under a point and refuses one that is not", () => {
-  const l = layout(768, 1024)
+  const l = viewLayout(768, 1024)
   const rng = new Rng(SEED ^ 0xdd)
   for (let k = 0; k < 200; k++) {
     const i = rng.int(0, l.lane.capacity - 1)
@@ -86,7 +86,7 @@ test("cellNear finds the cell under a point and refuses one that is not", () => 
 })
 
 test("a point inside a rect is inside it", () => {
-  const l = layout(1024, 768)
+  const l = viewLayout(1024, 768)
   assert.equal(inside(l.shear, l.shear.x + 1, l.shear.y + 1), true)
   assert.equal(inside(l.shear, l.shear.x - 1, l.shear.y + 1), false)
   assert.equal(inside(l.furnace, l.shear.x + 1, l.shear.y + 1), false)
@@ -94,6 +94,6 @@ test("a point inside a rect is inside it", () => {
 
 test("the layout is a pure function of the viewport", () => {
   for (const [w, h] of VIEWPORTS) {
-    assert.deepEqual(layout(w, h), layout(w, h))
+    assert.deepEqual(viewLayout(w, h), viewLayout(w, h))
   }
 })

--- a/dynawalla/games/coil/src/render/layout.ts
+++ b/dynawalla/games/coil/src/render/layout.ts
@@ -9,6 +9,22 @@
 // **The lane holds ninety-six cells.** That is the coil the game is named for:
 // a full lane is nine tens and six ones of brass, and every lump of slag takes
 // two of them away for good until an exact cut smashes it.
+//
+// **The room is not the viewport.** Every game here declares `viewport-fit=cover`,
+// so the canvas reaches under the notch and the home indicator, and the host
+// floats two 44px controls over the top corners — exit on the left, how-to-play
+// on the right. The alley's stone may bleed anywhere it likes; the carved
+// problem, the levers and the links a child taps may not. Both facts arrive
+// here as geometry: the safe rect as `area`, the two corners as an inset on the
+// recess.
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  type Insets,
+  safeInsets,
+  safeRect,
+} from "../../../../packs/shared/game-chrome/index.ts"
 
 /** The lane's ceiling, whatever the viewport offers. The title, literally. */
 export const LANE_CELLS = 96
@@ -34,7 +50,16 @@ export type Layout = {
   h: number
   /** Small screens get a tighter wall and one fewer lane row. */
   compact: boolean
+  /** The stone plate. Decorative, and free to run under the host's corners. */
   wall: Rect
+  /**
+   * The carved problem, with the lit demand. This is the whole instruction of
+   * the game, so it is the one rect that is inset away from the host's two
+   * corners — see `CORNER`.
+   */
+  recess: Rect
+  /** The brick courses along the foot of the wall. */
+  courses: Rect
   lane: Lane
   levers: Rect
   shear: Rect
@@ -45,19 +70,71 @@ function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v))
 }
 
-export function layout(w: number, h: number): Layout {
-  const compact = Math.min(w, h) < 560
-  const pad = clamp(Math.min(w, h) * 0.035, 10, 26)
+/**
+ * How far in from either edge of the safe area the host's corner controls
+ * reach, plus two pixels so nothing is decided on a knife edge.
+ *
+ * Insetting horizontally rather than reserving a band is deliberate: a 67px
+ * strip off the top is a twelfth of a 568px phone, and reserving one broke SKY
+ * LEDGER's own layout outright. Between the two corners a 320px phone still
+ * leaves 212px of centre strip, which costs the recess a little type size and
+ * costs the alley no height at all.
+ */
+const CORNER = HOST_MARGIN + HOST_CONTROL + 2
 
-  const wallH = clamp(h * (compact ? 0.26 : 0.28), 118, 240)
-  const leverH = clamp(h * 0.13, 70, 118)
+/**
+ * Where everything is, inside `area`.
+ *
+ * `area` is the safe rectangle — `safeRect` from `packs/shared/game-chrome` —
+ * and it is REQUIRED, deliberately. Made optional, a caller that forgets it
+ * still compiles and quietly carves the problem under the notch, discoverable
+ * only on a device with one. Required, forgetting it does not build.
+ *
+ * The full-bleed stone behind all of this is drawn straight onto the canvas by
+ * the scene and is not laid out here; it is what a child must read or touch
+ * that lives inside `area`.
+ */
+export function layout(w: number, h: number, area: Rect): Layout {
+  const compact = Math.min(area.w, area.h) < 560
+  const pad = clamp(Math.min(area.w, area.h) * 0.035, 10, 26)
 
-  const wall: Rect = { x: pad, y: pad, w: w - pad * 2, h: wallH }
-  const levers: Rect = { x: pad, y: h - leverH - pad, w: w - pad * 2, h: leverH }
+  const wallH = clamp(area.h * (compact ? 0.26 : 0.28), 118, 240)
+  const leverH = clamp(area.h * 0.13, 70, 118)
+
+  const wall: Rect = { x: area.x + pad, y: area.y + pad, w: area.w - pad * 2, h: wallH }
+  const levers: Rect = {
+    x: area.x + pad,
+    y: area.y + area.h - leverH - pad,
+    w: area.w - pad * 2,
+    h: leverH,
+  }
+
+  // The recess sits high in the wall, which is exactly where the host's exit
+  // and how-to-play controls are, so it is squeezed between them. Nothing else
+  // in the alley reaches that high.
+  const clearL = area.x + CORNER
+  const clearR = area.x + area.w - CORNER
+  const recessL = Math.max(wall.x + wall.w * 0.045, clearL)
+  const recessR = Math.min(wall.x + wall.w * 0.955, clearR)
+  const recess: Rect = {
+    x: recessL,
+    y: wall.y + wall.h * 0.12,
+    w: Math.max(60, recessR - recessL),
+    h: wall.h * 0.52,
+  }
+
+  // The courses are low enough in the wall to clear the corners on their own —
+  // the test says so at every viewport rather than this comment.
+  const courses: Rect = {
+    x: wall.x + wall.w * 0.045,
+    y: wall.y + wall.h * 0.72,
+    w: wall.w * 0.91,
+    h: wall.h * 0.2,
+  }
 
   const laneY = wall.y + wall.h + pad * 0.9
   const laneH = Math.max(80, levers.y - pad * 0.9 - laneY)
-  const laneW = w - pad * 2
+  const laneW = area.w - pad * 2
 
   // Sixteen cells to a row, six rows: ninety-six, which is the coil the game is
   // named for and exactly the lane it gets. Capping the columns rather than
@@ -69,7 +146,7 @@ export function layout(w: number, h: number): Layout {
   const rows = Math.max(2, Math.min(7, Math.floor(laneH / rowPitch)))
 
   const lane: Lane = {
-    x: pad,
+    x: area.x + pad,
     y: laneY,
     w: laneW,
     h: laneH,
@@ -95,7 +172,19 @@ export function layout(w: number, h: number): Layout {
     h: levers.h,
   }
 
-  return { w, h, compact, wall, lane, levers, shear, furnace }
+  return { w, h, compact, wall, recess, courses, lane, levers, shear, furnace }
+}
+
+/**
+ * The layout the RENDERER uses, and the only one it may use.
+ *
+ * The insets are read here, once, rather than by every caller — which is what
+ * makes the clearance test worth having: it exercises this function, the same
+ * path `Scene.resize` takes, so it fails both when the corner inset goes and
+ * when the safe area stops being plumbed through.
+ */
+export function viewLayout(w: number, h: number, insets: Insets = safeInsets()): Layout {
+  return layout(w, h, safeRect(w, h, insets))
 }
 
 /**

--- a/dynawalla/games/coil/src/render/scene.ts
+++ b/dynawalla/games/coil/src/render/scene.ts
@@ -14,7 +14,7 @@ import type { Round } from "../game/round.ts"
 import { coilOf, linkValue } from "../game/place.ts"
 import { COURSE } from "../game/session.ts"
 import { SLAG_CELLS } from "../game/board.ts"
-import { type Layout, type Lane, cellAt, layout as computeLayout } from "./layout.ts"
+import { type Layout, type Lane, cellAt, viewLayout } from "./layout.ts"
 import { KIND_DUST, KIND_FILING, KIND_SPARK, Particles } from "./particles.ts"
 import {
   BONE,
@@ -212,7 +212,7 @@ export class Scene {
     if (!ctx) throw new Error("coil: no 2d context")
     this.canvas = canvas
     this.ctx = ctx
-    this.layout = computeLayout(Math.max(1, host.clientWidth), Math.max(1, host.clientHeight))
+    this.layout = viewLayout(Math.max(1, host.clientWidth), Math.max(1, host.clientHeight))
     this.resize(host.clientWidth, host.clientHeight)
   }
 
@@ -229,7 +229,7 @@ export class Scene {
     this.sized = { w: width, h: height }
     this.canvas.width = Math.round(width * dpr)
     this.canvas.height = Math.round(height * dpr)
-    this.layout = computeLayout(width, height)
+    this.layout = viewLayout(width, height)
     this.lattice = this.buildLattice(width, height)
     return this.layout
   }
@@ -327,22 +327,28 @@ export class Scene {
 
     // The recess: the one cold light. It brightens as the pending cut
     // approaches the demand, which is the only continuous feedback in the game.
+    //
+    // Its rectangle comes from the layout, not from the wall, because it is the
+    // one thing here that has to dodge the host's two corner controls — the
+    // stone plate above may run under them, the carved problem may not. The
+    // cradle still narrows it rightward to make room for the ingot, and the
+    // ingot now sits INSIDE the recess rather than beside it, so it is clear of
+    // the how-to-play control too.
     const cradle = s.round?.mode === "fill" && s.round.ingot > 0
-    const recessH = r.h * 0.52
-    const recessW = r.w * (cradle ? 0.6 : 0.91)
-    const rx = r.x + r.w * 0.045
-    const ry = r.y + r.h * 0.12
+    const rec = this.layout.recess
+    const recessW = rec.w * (cradle ? 0.62 : 1)
     const glow = 0.24 + s.seatPulse * 0.5
     ctx.fillStyle = withAlpha(CELESTIAL_DIM, 0.12 + glow * 0.2)
-    roundRect(ctx, rx, ry, recessW, recessH, 8)
+    roundRect(ctx, rec.x, rec.y, recessW, rec.h, 8)
     ctx.fill()
     ctx.strokeStyle = withAlpha(CELESTIAL, 0.32 + s.seatPulse * 0.5)
     ctx.lineWidth = 1.5
     ctx.stroke()
 
-    this.drawPrompt(s, rx, ry, recessW, recessH)
-    if (cradle) this.drawIngot(s, r.x + r.w * 0.815, ry + recessH * 0.5, r.w * 0.3)
-    this.drawCourses(s, r.x + r.w * 0.045, r.y + r.h * 0.72, r.w * 0.91, r.h * 0.2)
+    this.drawPrompt(s, rec.x, rec.y, recessW, rec.h)
+    if (cradle) this.drawIngot(s, rec.x + rec.w * 0.82, rec.y + rec.h * 0.5, rec.w * 0.33)
+    const cs = this.layout.courses
+    this.drawCourses(s, cs.x, cs.y, cs.w, cs.h)
     ctx.restore()
   }
 


### PR DESCRIPTION
## What

Lay THE COIL OF NINETY-SIX out inside the safe area, keep the host's two top corners clear of anything a child must read or touch, and give the game the how-to-play surface it never had.

## Why

Two real defects, both invisible to every test that is about rules.

**The safe area.** `pack.html` declares `viewport-fit=cover`, which opts the document *into* the notch, the home indicator and the rounded corners. A DOM HUD can claw that back with `env()`; a canvas cannot. `layout(w, h)` laid the wall, the lane and the levers out from `(0, 0, w, h)` and never read an inset, so on a notched phone the whole alley was shifted up under the hardware.

**Host chrome.** The host floats a 44px exit control over the top-LEFT and a 44px how-to-play control over the top-RIGHT of every pack. `scene.ts:drawWall` carved the recess — the problem with the lit demand, which is the *entire* instruction of the game — at `rx = wall.x + wall.w * 0.045`, `ry = wall.y + wall.h * 0.12`. On a 320×568 phone that is x ≈ 24, y ≈ 27: squarely under the exit control. A child who cannot read the demand cannot play.

**No instructions.** The wall says SHEAR OFF THE LIT NUMBER and nothing anywhere said that a second tap opens a drum into ten beads — which is the borrow, and the only way to cut 25 off a coil whose tail is two beads.

### What changed

- `layout(w, h, area: Rect)` — `area` is **required**, not optional. Optional, a caller that forgets it still compiles and quietly carves the problem under the notch, discoverable only on a device with one.
- `viewLayout(w, h, insets = safeInsets())` reads the insets once and is the **only** thing `Scene.resize` calls. The clearance test exercises that exact function, so it cannot pass by being handed an area it invented for itself.
- `recess` and `courses` move out of `drawWall`'s inline arithmetic and into the layout as rects, because they are pure geometry.
- The recess is inset **horizontally** between the two corners, not pushed below them. Reserving a 67px band costs a twelfth of a 568px phone to hold two buttons, and broke SKY LEDGER's own layout invariants when it was tried. Between the corners a 320px phone still leaves 212px.
- The `cradle` variant still narrows the recess panel rightward (0.62 of the recess), and the **ingot now sits inside the recess** — at `rec.x + rec.w * 0.82`, width `rec.w * 0.33` — instead of beside it at `wall.x + wall.w * 0.815`, where it collided with the how-to-play control on a phone.
- The stone plate, the girih lattice and the gradient sky still bleed to the glass edges. That is what `cover` is for. It is only what a child reads or touches that is fenced in.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/coil/`)

- [x] Every touched path is covered by a `ci.yml` area filter — everything is under `dynawalla/games/coil/`.
- [x] **Pack back-compat.** No published zip changed in place; no `voiceId` renamed; no catalog entry dropped or narrowed. `pack.json` untouched — same id, version, capabilities and skill coverage; `node build.mjs coil` re-stages the same manifest.
- [x] **Native integrity.** N/A — no Rust, no manifest, no `links =`.
- [x] **Strings.** N/A for `corpan-app` locales. The instruction copy is pack-local English, in the same place every other adopted game's copy lives.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema touched. The game's `pack.json` coverage (7 skills, grades 1–4) is unchanged.
- [x] **Secrets.** None. `gitleaks` output below.

**What a reviewer cannot reconstruct from the diff:** the layout signature change is a breaking one *inside this pack only* — `layout` is not exported past `src/render/`, and the two callers (`Scene` constructor and `Scene.resize`) both go through `viewLayout`. `session.resize(l.lane.capacity)` still receives a capacity from the same code path; the lane's cell count is unchanged at every viewport that has no insets, so no shipped behaviour moves on a device without a notch except the recess sliding inboard.

## Proof

`npm test`, five separate runs — one green run is not proof:

```
$ for i in 1 2 3 4 5; do echo "=== run $i ==="; npm test 2>&1 | grep -E "^# (tests|pass|fail)"; done
=== run 1 ===
# tests 109
# pass 109
# fail 0
=== run 2 ===
# tests 109
# pass 109
# fail 0
=== run 3 ===
# tests 109
# pass 109
# fail 0
=== run 4 ===
# tests 109
# pass 109
# fail 0
=== run 5 ===
# tests 109
# pass 109
# fail 0
```

### The test fails if either half of the fix is removed

A clearance test that passes either way is worse than none. Both halves were reverted in turn and the suite re-run.

**1. Remove the corner inset** (`recessL = wall.x + wall.w * 0.045` instead of `Math.max(..., clearL)`):

```
not ok 63 - nothing a child reads or touches is under the host's chrome — phone portrait, small 320×568, no insets
  error: |-
    the recess is under the host's chrome at phone portrait, small 320×568, no insets

    true !== false
  code: 'ERR_ASSERTION'
not ok 66 - ... 320×568, portrait notch
not ok 69 - ... 390×844, no insets
not ok 72 - ... 390×844, portrait notch
not ok 87 - ... 844×390, no insets
not ok 90 - ... 844×390, landscape notch
# pass 103
# fail 6
```

**2. Make `viewLayout` ignore the insets** (`layout(w, h, { x: 0, y: 0, w, h })`):

```
not ok 66 - nothing a child reads or touches is under the host's chrome — phone portrait, small 320×568, portrait notch
  error: 'the recess leaves the safe area at phone portrait, small 320×568, portrait notch — {"x":56,"y":28.921599999999998,"w":208,"h":76.79360000000001} vs {"x":0,"y":59,"w":320,"h":475}'
  code: 'ERR_ASSERTION'
not ok 72 - ... 390×844, portrait notch
not ok 78 - ... 768×1024, portrait notch
not ok 84 - ... 1024×768, landscape notch
not ok 90 - ... 844×390, landscape notch
# pass 104
# fail 5
```

Both were restored; the 109/109 above is the restored tree.

### Types and build

```
$ npm run tsc
> @dynawalla/game-coil@0.1.0 tsc
> tsc --noEmit

TSC_EXIT=0

$ npm run build
> @dynawalla/game-coil@0.1.0 build
> vite build

vite v8.1.5 building client environment for production...
transforming...✓ 18 modules transformed.
rendering chunks...
computing gzip size...
dist/coil.js  43.40 kB │ gzip: 14.54 kB

✓ built in 18ms
```

### Pack

```
$ node build.mjs coil
dynawalla.coil@0.1.0 — THE COIL OF NINETY-SIX
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 43552 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

### Secrets and scope

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~11811 bytes (11.81 KB) in 36.3ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/coil/src/mount.ts
dynawalla/games/coil/src/render/chrome.test.ts
dynawalla/games/coil/src/render/layout.test.ts
dynawalla/games/coil/src/render/layout.ts
dynawalla/games/coil/src/render/scene.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
