### PR TITLE
fix(dynawalla/games/arena): the depth readout was under the back button, and nobody was ever told the rule

### DIFF
--- a/dynawalla/games/arena/src/mount.ts
+++ b/dynawalla/games/arena/src/mount.ts
@@ -1,3 +1,4 @@
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 import type { Host, MountOptions } from "./contract.ts"
 import { Gfx } from "./render/gfx.ts"
 import { Hud } from "./ui/hud.ts"
@@ -68,6 +69,60 @@ export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { 
     return on
   })
   const input = new Input(container)
+
+  // How to play. The arena states its rule with a picture and most children do
+  // read it in three seconds — but "most" is not "all", and a child who reads
+  // it wrong learns it by being stung, which is the one way we do not want to
+  // teach it. The manual is a button, never a wall: it opens nothing on its own
+  // and it stays reachable during play, because the moment a child needs the
+  // rules is never the title.
+  const guide = createInstructions(el, {
+    title: "ARENA",
+    summary: [
+      "You are a number swimming in dark water. Eat every number smaller than you and you grow.",
+      "Numbers bigger than you sting. Stay away from those.",
+    ],
+    sections: [
+      {
+        heading: "How to swim",
+        lines: [
+          "Put a finger on the screen and drag. You swim the way you drag.",
+          "Hold a second finger down to surge. You go fast, but you shrink while you do it.",
+          "The bits you drop while surging turn into food. Other numbers will eat them.",
+          "On a computer: point with the mouse to swim, and hold the space bar to surge.",
+        ],
+      },
+      {
+        heading: "What to eat",
+        lines: [
+          "A smooth filled circle is smaller than you. Swim into it and you eat it.",
+          "A spiky hollow ring is bigger than you. It stings and takes some of your size.",
+          "A red circle marked with a minus sign always hurts, however small it looks.",
+          "Some numbers are close, like 3,418 and 3,481. Read the digits before you swim in.",
+        ],
+      },
+      {
+        heading: "The dark moment",
+        lines: [
+          "Every so often the water goes dark and a math question appears above you.",
+          "Four glass balls float around you. Each ball holds a different answer.",
+          "Swim into the ball with the right answer and you grow a lot.",
+          "Pick the wrong ball and you lose some size. The right ball lights up so you can see it.",
+        ],
+      },
+      {
+        heading: "Going deeper",
+        lines: [
+          "The deeper you go, the more the water changes colour and the more there is to dodge.",
+          "The small marks under the depth name fill in as you go down. They never empty.",
+          "If something much bigger hits you, you burst and scatter, then come straight back.",
+          "There is no ending and no way to lose the run. You play until you want to stop.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
+
   const audio = new Audio()
   const cam = new Camera()
   cam.reduced = reduced
@@ -377,6 +432,15 @@ export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { 
     gov.sample(dtReal * 1000)
     dtReal = Math.min(dtReal, 0.1)
 
+    // Reading the rules is not playing. With the manual open the water holds
+    // its shape and nothing eats the child while they are looking something up
+    // — the picture keeps being drawn, the simulation does not advance, and the
+    // finger they are holding on the panel is not a steer.
+    if (guide.isOpen) {
+      gfx.draw(world, cam, time, reduced, floaters)
+      return
+    }
+
     const st = input.sample()
     if (st.hasAbsolute) {
       screenToWorld(st.absX, st.absY, aim)
@@ -447,6 +511,7 @@ export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { 
       container.removeEventListener("pointerdown", unlock)
       window.removeEventListener("keydown", unlock)
       input.dispose()
+      guide.destroy()
       hud.dispose()
       audio.dispose()
       gfx.dispose()

--- a/dynawalla/games/arena/src/ui/hud.ts
+++ b/dynawalla/games/arena/src/ui/hud.ts
@@ -1,3 +1,10 @@
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
 import { RIVAL_NAMES, type World } from "../sim/world.ts"
 import { DEPTHS } from "../sim/depths.ts"
 
@@ -13,21 +20,79 @@ const DEPTH_COUNT = DEPTHS.length
  *
  * Nothing here reflows per frame. Text nodes are written only when the value
  * they show actually changes.
+ *
+ * **The host draws over this.** A back chevron floats in the top-LEFT corner
+ * and the how-to-play button in the top-RIGHT, both 44px, both painted by
+ * something that is not this game. The depth readout used to start at 14,14 and
+ * the ladder at 14 from the right, so the chevron sat on the depth name and the
+ * question mark sat on the top of the ladder. Nothing reserves a band — that
+ * costs a twelfth of a small phone to hold two buttons — so the readouts drop
+ * below the two corners instead and the water still fills the glass.
  */
+
+/**
+ * How far below the safe top edge the readouts start.
+ *
+ * Derived from the host's own numbers rather than typed, so if the host moves
+ * its chrome this game follows on the next build instead of drifting.
+ */
+export const HUD_TOP = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + 6
+
+/** Gap from the safe left/right edge, for the two readouts. */
+export const HUD_EDGE = 14
+
+/** Widest the ladder gets, and the tallest six rows plus their gaps come to. */
+export const BOARD_W = 112
+export const BOARD_H = 138
+
+/** The depth block: name, RANK line, nine pips. Measured at the largest step. */
+export const DEPTH_W = 220
+export const DEPTH_H = 62
+
+/** Gap from the safe left/right edge for the Resonance question. */
+export const Q_EDGE = 12
+
+/**
+ * Where the readouts land, in numbers, so a test can assert they clear the
+ * host's two corners at every viewport instead of a device finding out.
+ *
+ * These mirror the CSS below them exactly, because the CSS is built from the
+ * same constants. Change one and the other moves with it.
+ *
+ * The ladder is anchored by its RIGHT edge and shrink-to-fit, so a long rival
+ * name grows it leftwards, away from the corner it has to clear. `BOARD_W` is
+ * therefore a floor and the rect is still the truthful one to test.
+ */
+export function hudRects(
+  w: number,
+  insets: Insets = { top: 0, right: 0, bottom: 0, left: 0 },
+): { depth: Rect; board: Rect; question: Rect } {
+  const top = insets.top + HUD_TOP
+  const left = Math.max(HUD_EDGE, insets.left)
+  const right = Math.max(HUD_EDGE, insets.right)
+  const qLeft = Math.max(Q_EDGE, insets.left)
+  const qRight = Math.max(Q_EDGE, insets.right)
+  return {
+    depth: { x: left, y: top, w: Math.min(DEPTH_W, w - left - right), h: DEPTH_H },
+    board: { x: Math.max(0, w - right - BOARD_W), y: top, w: BOARD_W, h: BOARD_H },
+    question: { x: qLeft, y: top, w: Math.max(0, w - qLeft - qRight), h: 96 },
+  }
+}
 
 const CSS = `
 .arena-hud{position:absolute;inset:0;pointer-events:none;font-family:ui-rounded,"SF Pro Rounded",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;color:#cfefff;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;overflow:hidden}
 .arena-hud *{box-sizing:border-box}
-.arena-depth{position:absolute;top:max(14px,env(safe-area-inset-top));left:max(14px,env(safe-area-inset-left));
+.arena-depth{position:absolute;top:calc(env(safe-area-inset-top) + ${HUD_TOP}px);left:max(${HUD_EDGE}px,env(safe-area-inset-left));
+  max-width:${DEPTH_W}px;
   font-size:clamp(11px,2.4vw,15px);letter-spacing:.30em;font-weight:800;opacity:.82;
   text-shadow:0 0 18px rgba(80,220,255,.55),0 2px 6px rgba(0,0,0,.9)}
 .arena-depth b{display:block;font-size:clamp(9px,1.7vw,11px);letter-spacing:.22em;opacity:.55;font-weight:700;margin-top:3px}
 .arena-pips{display:flex;gap:3px;margin-top:6px}
 .arena-pip{width:9px;height:3px;border-radius:2px;background:rgba(160,225,255,.20);transition:background .5s,box-shadow .5s}
 .arena-pip.on{background:#ffd479;box-shadow:0 0 9px rgba(255,200,110,.85)}
-.arena-board{position:absolute;top:max(14px,env(safe-area-inset-top));right:max(14px,env(safe-area-inset-right));
-  min-width:112px;display:flex;flex-direction:column;gap:2px;align-items:stretch}
+.arena-board{position:absolute;top:calc(env(safe-area-inset-top) + ${HUD_TOP}px);right:max(${HUD_EDGE}px,env(safe-area-inset-right));
+  min-width:${BOARD_W}px;display:flex;flex-direction:column;gap:2px;align-items:stretch}
 .arena-row{display:flex;justify-content:space-between;gap:10px;font-size:clamp(10px,2.1vw,13px);
   letter-spacing:.12em;font-weight:700;opacity:.5;font-variant-numeric:tabular-nums;
   padding:2px 7px;border-radius:3px;transition:opacity .25s}
@@ -39,10 +104,16 @@ const CSS = `
   font-size:clamp(14px,4vw,26px);font-weight:900;letter-spacing:.10em;opacity:0;transition:opacity .18s;
   text-shadow:0 0 26px rgba(120,255,220,.7),0 2px 8px rgba(0,0,0,.9);font-variant-numeric:tabular-nums}
 .arena-combo.on{opacity:.95}
-.arena-q{position:absolute;left:50%;top:max(52px,calc(env(safe-area-inset-top) + 42px));transform:translate(-50%,-14px);
+/* The one frame in the game that asks a direct question, so it is the one that
+   may least afford to sit under a notch or under a button. It is pinned to the
+   SAFE left and right edges and centred inside them — 94vw was centred on the
+   glass, which in landscape put a sixty-pixel numeral half under the sensor
+   housing on the notched side. */
+.arena-q{position:absolute;left:max(${Q_EDGE}px,env(safe-area-inset-left));right:max(${Q_EDGE}px,env(safe-area-inset-right));
+  top:calc(env(safe-area-inset-top) + ${HUD_TOP}px);max-width:760px;margin-inline:auto;transform:translateY(-14px);
   opacity:0;transition:opacity .22s cubic-bezier(.2,.9,.2,1),transform .34s cubic-bezier(.2,.9,.2,1);
-  text-align:center;width:min(94vw,760px);text-wrap:balance}
-.arena-q.on{opacity:1;transform:translate(-50%,0)}
+  text-align:center;text-wrap:balance}
+.arena-q.on{opacity:1;transform:none}
 .arena-q .p{font-size:clamp(26px,7.4vw,60px);font-weight:900;letter-spacing:.01em;color:#fff;line-height:1.05;
   text-shadow:0 0 40px rgba(150,235,255,.85),0 0 90px rgba(90,180,255,.45),0 3px 12px rgba(0,0,0,.95)}
 /* During a Resonance the question owns the screen. The ladder used to sit

--- a/dynawalla/games/arena/src/ui/layout.test.ts
+++ b/dynawalla/games/arena/src/ui/layout.test.ts
@@ -1,0 +1,94 @@
+// THE TWO CORNERS.
+//
+// The host paints a back chevron over the top-LEFT of every game and the
+// how-to-play button over the top-RIGHT, 44px each. It does not reserve a band
+// — reserving one costs a twelfth of a 568px phone to hold two buttons — so the
+// promise a game makes instead is narrow and testable: nothing a child must
+// READ or TOUCH lands in those two squares.
+//
+// ARENA broke that promise twice. The depth readout started at 14,14, directly
+// under the chevron; the ladder was 14 from the right, directly under the
+// question mark. Both are things a child reads. Neither was visible to any test
+// in this suite, because every other test here is about the water.
+//
+// The rects come from `hudRects`, which is built from the same constants the
+// stylesheet is built from, so this cannot pass while the CSS says otherwise.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import { BOARD_W, DEPTH_W, HUD_EDGE, HUD_TOP, hudRects } from "./hud.ts"
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+
+/** A notched phone held tall, and the same phone turned on its side. */
+const NOTCH_PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+const NOTCH_LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["the smallest phone we support", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const [insetName, insets] of [
+    ["no insets", NONE],
+    ["a notch", w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT],
+  ] as const) {
+    test(`the readouts clear the host's corners at ${name} (${w}×${h}, ${insetName})`, () => {
+      const r = hudRects(w, insets)
+
+      assert.equal(
+        hitsHostChrome(r.depth, w, insets),
+        false,
+        `${w}×${h}: the depth readout is under the host's back chevron`,
+      )
+      assert.equal(
+        hitsHostChrome(r.board, w, insets),
+        false,
+        `${w}×${h}: the ladder is under the host's how-to-play button`,
+      )
+      // The Resonance question is the one frame in the game that asks a direct
+      // question. It is the least affordable thing to put under a button.
+      assert.equal(
+        hitsHostChrome(r.question, w, insets),
+        false,
+        `${w}×${h}: the Resonance question is under host chrome`,
+      )
+    })
+  }
+}
+
+test("the readouts stay inside the safe area on every edge they touch", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const insets = w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT
+    const r = hudRects(w, insets)
+
+    // Left, right and top. A HUD that pads only the top is correct in portrait
+    // on one device and wrong the moment the child turns the tablet.
+    assert.ok(r.depth.x >= insets.left, `${name}: the depth readout runs into the left inset`)
+    assert.ok(r.depth.y >= insets.top, `${name}: the depth readout runs under the notch`)
+    assert.ok(
+      r.board.x + r.board.w <= w - insets.right,
+      `${name}: the ladder runs into the right inset`,
+    )
+    assert.ok(r.board.y >= insets.top, `${name}: the ladder runs under the notch`)
+    assert.ok(r.question.x >= insets.left, `${name}: the question runs into the left inset`)
+    assert.ok(
+      r.question.x + r.question.w <= w - insets.right,
+      `${name}: the question runs into the right inset`,
+    )
+  }
+})
+
+test("the constants are the ones the host publishes, not numbers somebody typed", () => {
+  // 57 is the bottom of the host's corner squares: 3px hairline + 10px margin
+  // + a 44px control. Anything smaller and the readouts are under a button
+  // again; this is the inequality the whole file exists to hold.
+  assert.ok(HUD_TOP >= 57, `HUD_TOP is ${HUD_TOP} — the host's corners end at 57`)
+  assert.ok(HUD_EDGE > 0 && BOARD_W > 0 && DEPTH_W > 0)
+})


### PR DESCRIPTION
## What

Adopt the shared game chrome in ARENA: pin the Resonance question to the safe
area rather than to the glass, drop the depth readout and the ladder clear of
the host's two 44px corners, and add a `createInstructions` manual.

## Why

Two defects, one of which `env()` cannot fix.

**The safe area was almost complete.** ARENA is one of the seven games that
already reads `env(safe-area-inset-*)`, and its DOM HUD was careful: the depth
readout padded top+left, the ladder top+right, the sound button left+bottom,
the perf readout right+bottom. Every element covered every edge it touched —
except the Resonance question, which was `left:50%` with
`width:min(94vw,760px)`. That is centred on the **glass**, not on the safe
area. Landscape insets are not symmetric, so on a notched phone held sideways
a sixty-pixel numeral — the one frame in this game that asks a child a direct
question — sat partly under the sensor housing.

**The corners were not.** The host floats a 44px back chevron over the
top-LEFT and the how-to-play button over the top-RIGHT, both *inside* the safe
area, which is exactly where a careful HUD puts things. The depth readout
started at 14,14 — under the chevron. The ladder was 14 from the right — under
the question mark. Both are things a child reads.

Nothing reserves a band: reserving 67px costs a twelfth of a 568px phone to
hold two buttons and it broke SKY LEDGER's lattice outright. The two readouts
drop below the corners instead, by `HOST_PROGRESS_H + HOST_MARGIN +
HOST_CONTROL + 6`, computed from the host's published constants rather than
typed, so if the host moves its chrome this game follows on the next build.
The water still bleeds to every edge.

**And nobody was ever taught the game.** ARENA argued it needed no
instructions: the radius law is one picture and a child reads it in three
seconds. Most do. The ones who do not learn it by being stung, which is the
worst available way to teach it, and nothing anywhere named the second verb,
the void motes, or what the four glass spheres during a Resonance are for.
The manual sits behind the how-to-play button, stays reachable during play,
and the simulation holds still while it is open — reading the rules is not
playing, and a child should not be eaten while looking something up.

## Blast radius

**Areas touched:** dynawalla (`dynawalla/games/arena/` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no
      `voiceId` renamed; no catalog entry dropped. `pack.json` untouched.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifests.
- [x] **Strings.** N/A — pack-local copy, not `corpan-app` locales.
- [x] **Curriculum.** N/A — no skill, generator, schema or renderer touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

Behaviour that changed for a player: the depth readout and the ladder sit
~49px lower; the Resonance question is centred in the safe area instead of on
the glass; a `?` button appears top-right; the simulation freezes while the
manual is open.

## Proof

```
$ npm test    # five runs — one green run is not proof
--- run 1 ---
# tests 36
# pass 36
# fail 0
--- run 2 ---
# tests 36
# pass 36
# fail 0
--- run 3 ---
# tests 36
# pass 36
# fail 0
--- run 4 ---
# tests 36
# pass 36
# fail 0
--- run 5 ---
# tests 36
# pass 36
# fail 0

$ npm run tsc
> @dynawalla/game-arena@0.1.0 tsc
> tsc --noEmit
(0 errors)

$ npm run build
dist/assets/index-BwgG43Zb.js  628.41 kB | gzip: 166.34 kB
✓ built in 124ms

$ cd dynawalla/packs && node build.mjs arena
dynawalla.arena@0.1.0 — ARENA
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       1 skills, grades 1–4
  on disk      3 files, 633891 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
(no leaks)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty — nothing deleted)

$ git diff --name-only origin/main..HEAD
dynawalla/games/arena/src/mount.ts
dynawalla/games/arena/src/ui/hud.ts
dynawalla/games/arena/src/ui/layout.test.ts
```

**The clearance test fails when the fix is removed.** A test that passes either
way is worthless, so this one was mutated: `HUD_TOP` back to `14` and `qLeft`/
`qRight` back to ignoring the side insets.

```
$ node --test src/ui/layout.test.ts     # with the fix reverted
not ok 1 - the readouts clear the host's corners at the smallest phone we support (320×568, no insets)
not ok 2 - the readouts clear the host's corners at the smallest phone we support (320×568, a notch)
not ok 3 - the readouts clear the host's corners at phone portrait (390×844, no insets)
not ok 4 - the readouts clear the host's corners at phone portrait (390×844, a notch)
not ok 5 - the readouts clear the host's corners at tablet portrait (768×1024, no insets)
not ok 6 - the readouts clear the host's corners at tablet portrait (768×1024, a notch)
not ok 7 - the readouts clear the host's corners at tablet landscape (1024×768, no insets)
not ok 8 - the readouts clear the host's corners at tablet landscape (1024×768, a notch)
not ok 9 - the readouts clear the host's corners at phone landscape (844×390, no insets)
not ok 10 - the readouts clear the host's corners at phone landscape (844×390, a notch)
not ok 11 - the readouts stay inside the safe area on every edge they touch
not ok 12 - the constants are the ones the host publishes, not numbers somebody typed
# tests 12
# pass 0
# fail 12

$ node --test src/ui/layout.test.ts     # restored
# tests 12
# pass 12
# fail 0
```

The rects the test asserts come from `hudRects()`, which is the same function
the stylesheet template is built from — the test cannot pass while the CSS
says something different.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
