### PR TITLE
fix(dynawalla/games/counterweight): stand the yard inside the safe area and clear the host's corners

### DIFF
--- a/dynawalla/games/counterweight/src/mount.ts
+++ b/dynawalla/games/counterweight/src/mount.ts
@@ -6,6 +6,7 @@
 // because a clock that runs behind a sheet costs the child a round they never
 // saw.
 
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 import type { Handle, Host } from "./contract.ts"
 import { Audio } from "./audio.ts"
 import { Bout, type BoutEvent, TIMING, TIMING_REDUCED } from "./game/bout.ts"
@@ -49,6 +50,52 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
   const audio = new Audio()
   const beam = new Beam(reduced ? TUNING_REDUCED : TUNING)
   const bout = new Bout(() => host.next({ domain: "add" }), reduced ? TIMING_REDUCED : TIMING)
+
+  const guide = createInstructions(el, {
+    title: "THE COUNTERWEIGHT",
+    summary: [
+      "The Iron Turk's pan holds a sum. Work out its answer yourself — it is never shown.",
+      "Load your pan to exactly one more than his answer, then press SEAT.",
+    ],
+    sections: [
+      {
+        heading: "Loading your pan",
+        lines: [
+          "There are four pillars: thousands, hundreds, tens and ones.",
+          "The top face of a pillar adds one of that size. The bottom face takes one off.",
+          "Your load stays where you left it. Each round you only change the difference.",
+        ],
+      },
+      {
+        heading: "One more. Exactly one.",
+        lines: [
+          "Not two more. Not nearly. One.",
+          "That is what winning an arm-wrestle looks like: just in front.",
+          "Press SEAT and the beam is judged.",
+          "One ahead and he gives ground. Five lengths of ground and the Turk goes over.",
+          "Anything else and he takes one length back. Nothing else is lost.",
+        ],
+      },
+      {
+        heading: "A short cut",
+        lines: [
+          "To add 8, hit the tens face once and take the ones off twice.",
+          "Ten less two is eight, and that is three taps instead of eight.",
+        ],
+      },
+      {
+        heading: "Do not hammer the plates",
+        lines: [
+          "The beam is a bar of steel. Hit it again while it is still ringing and the ring grows.",
+          "Ring it too hard and the beam shears, and the round is over.",
+          "Leave a beat between blows and that never happens.",
+          "The window closes on its own. Whatever is on your pan then is your answer.",
+          "If you stop touching the rack your pan slowly settles. Any strike puts it back.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
 
   let tally = loadTally()
   let running = true
@@ -331,6 +378,7 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
       globalThis.removeEventListener("resize", resize)
       globalThis.document?.removeEventListener("visibilitychange", visibility)
       observer?.disconnect()
+      guide.destroy()
       audio.dispose()
       canvas.remove()
     },

--- a/dynawalla/games/counterweight/src/render/layout.ts
+++ b/dynawalla/games/counterweight/src/render/layout.ts
@@ -4,8 +4,45 @@
 // stack is the same everywhere and only the proportions move. Nothing is
 // measured from text — numerals live on a tabular grid, so a four-digit load
 // does not push the beam down after a two-digit one.
+//
+// **Two things constrain the yard beyond the glass it is drawn on.**
+//
+// The first is the safe area. This pack declares `viewport-fit=cover`, which
+// opts the document *into* the notch, the home indicator and the rounded
+// corners. A canvas cannot read `env()`, so `layoutFor` takes the safe
+// rectangle as an argument and every readable, touchable part of the yard is
+// measured from it rather than from `(0, 0, w, h)`. The backdrop still bleeds
+// to the full canvas — that is what `cover` is for.
+//
+// The second is the host's chrome. The host floats an exit control over the
+// top-LEFT corner and the how-to-play control over the top-RIGHT, 44px each.
+// They overlay; the yard does not get to reserve a band under them, because
+// giving up 67px of a 568px phone is worse than the problem it solves. So the
+// HUD row — `TURK n` at one end, the tally at the other, the arm bar between
+// them — is inset HORIZONTALLY, into the strip between the two corners. That
+// costs no height at all, and on the narrowest phone we support the strip is
+// still a little over 200px wide.
 
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  safeInsets,
+  safeRect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import type { Insets } from "../../../../packs/shared/game-chrome/index.ts"
 import { PLACES, type Place } from "../game/places.ts"
+import { MAX_TILT } from "../sim/beam.ts"
+
+/**
+ * The platform's minimum touch target, and this game's floor for both of them.
+ *
+ * The rack and the seat are the whole input vocabulary — eight faces and one
+ * lever. A face a child misses is a blow they meant to land, and on this beam a
+ * blow they did not mean to land is a shear. So these two get the floor and the
+ * rest of the stack takes what is left, not the other way round.
+ */
+export const TOUCH_FLOOR = 44
 
 export type Rect = { x: number; y: number; w: number; h: number }
 
@@ -38,48 +75,102 @@ export type Layout = {
   readonly seat: Rect
 }
 
-export function layoutFor(w: number, h: number): Layout {
-  const compact = Math.min(w, h) < 420
-  const unit = Math.max(11, Math.min(w, h) * (compact ? 0.038 : 0.03))
+/**
+ * The yard, laid out inside `area`.
+ *
+ * `area` is REQUIRED, and deliberately so. An optional safe rectangle is a
+ * rectangle a caller forgets, and forgetting it compiles, passes every test and
+ * then draws the seat lever under the home indicator on a device nobody in the
+ * room is holding. Callers who just want "the current screen" want
+ * `viewLayout` below, which is the one the renderer uses.
+ */
+export function layoutFor(w: number, h: number, area: Rect): Layout {
+  const short = Math.max(1, Math.min(area.w, area.h))
+  const compact = short < 420
+  const unit = Math.max(11, short * (compact ? 0.038 : 0.03))
 
   const pad = Math.round(unit * 0.9)
+  const gap = Math.round(unit * 0.5)
   const hudH = Math.round(unit * 3.1)
   // The rack is the thing a thumb has to reach, so it is sized from the shorter
-  // edge and given the floor rather than the leftovers.
-  const rackH = Math.round(Math.min(h * 0.34, unit * 12.4))
-  const seatH = Math.round(Math.min(h * 0.1, unit * 3.4))
+  // edge and given the floor rather than the leftovers — literally the floor:
+  // two faces of at least 44px, whatever that costs the stage above it.
+  const rackH = Math.round(
+    Math.max(TOUCH_FLOOR * 2 + gap, Math.min(area.h * 0.34, unit * 12.4)),
+  )
+  // The seat commits the answer. It was sized at a tenth of the height, which
+  // on a phone held sideways is 39px — under the touch floor, for the one
+  // control the whole round ends on.
+  const seatH = Math.round(Math.max(TOUCH_FLOOR, Math.min(area.h * 0.1, unit * 3.4)))
   const gaugeH = Math.round(unit * 1.5)
 
-  const hud: Rect = { x: pad, y: pad, w: w - pad * 2, h: hudH }
-  const seat: Rect = { x: pad, y: h - pad - seatH, w: w - pad * 2, h: seatH }
-  const rack: Rect = { x: pad, y: seat.y - pad * 0.6 - rackH, w: w - pad * 2, h: rackH }
+  const innerX = area.x + pad
+  const innerW = area.w - pad * 2
+
+  // The HUD, and only the HUD, steps in past the host's two corners. Nothing
+  // else up here is read or touched, and nothing below the corners needs it.
+  const corner = HOST_MARGIN + HOST_CONTROL + Math.round(unit * 0.4)
+  const hudX = area.x + corner
+  const hudW = Math.max(unit * 4, area.w - corner * 2)
+
+  // Four faces at the touch floor is the requirement. The margin beside the
+  // rack and the gaps between its pillars are not: on a narrow safe area they
+  // give way first, because a 41px plate is a plate a child misses.
+  const rackNeeds = TOUCH_FLOOR * PLACES.length
+  const rackPad = Math.min(pad, Math.max(0, (area.w - rackNeeds) / 2))
+  const rackX = area.x + rackPad
+  const rackW = area.w - rackPad * 2
+  const faceGap = Math.max(0, Math.min(gap, (rackW - rackNeeds) / (PLACES.length - 1)))
+
+  const hud: Rect = { x: hudX, y: area.y + pad, w: hudW, h: hudH }
+  const seat: Rect = { x: innerX, y: area.y + area.h - pad - seatH, w: innerW, h: seatH }
+  const rack: Rect = { x: rackX, y: seat.y - pad * 0.6 - rackH, w: rackW, h: rackH }
   const gauge: Rect = {
-    x: pad,
+    x: innerX,
     y: rack.y - pad * 0.5 - gaugeH,
-    w: w - pad * 2,
+    w: innerW,
     h: gaugeH,
   }
-  const stageTop = hud.y + hud.h + pad * 0.4
-  const stage: Rect = { x: pad, y: stageTop, w: w - pad * 2, h: Math.max(unit * 6, gauge.y - pad * 0.5 - stageTop) }
-
-  const arm = Math.min(stage.w * 0.4, stage.h * 0.78)
-  const panW = Math.min(arm * 0.92, stage.w * 0.42)
-  const panH = Math.min(stage.h * 0.46, unit * 6.2)
-  const panDrop = Math.min(stage.h * 0.3, unit * 3.2)
-  const fulcrum = {
-    x: stage.x + stage.w / 2,
-    y: stage.y + Math.min(stage.h * 0.34, unit * 4.4),
+  // The stage carries the two numbers of the round — his column and your load —
+  // so it starts below the host's corners as well as below the HUD. On a phone
+  // that is a few pixels; the HUD is already almost past them.
+  const stageTop = Math.max(
+    hud.y + hud.h + pad * 0.4,
+    area.y + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL,
+  )
+  const stage: Rect = {
+    x: innerX,
+    y: stageTop,
+    w: innerW,
+    h: Math.max(0, gauge.y - pad * 0.5 - stageTop),
   }
 
-  const gap = Math.round(unit * 0.5)
-  const pillarW = (rack.w - gap * (PLACES.length - 1)) / PLACES.length
-  const faceH = (rack.h - gap) / 2
+  const arm = Math.min(stage.w * 0.36, stage.h * 0.78)
+  // A pan hangs centred on the end of the beam, so half of it sticks out past
+  // the hook. `stage.w - 2 * arm` is the width that leaves it exactly inside
+  // the stage when the beam is level, which is the widest the beam ever
+  // reaches; every tilt is narrower.
+  const panW = Math.max(unit * 3, Math.min(arm * 0.92, stage.w * 0.42, stage.w - arm * 2))
+  const fulcrumDrop = Math.min(stage.h * 0.34, unit * 4.4)
+  // The room below the *lowest* the far hook ever swings. Chain and pan have to
+  // fit in that, or a tilted beam posts the number a child is reading off the
+  // bottom of the stage and into the gauge.
+  const room = Math.max(0, stage.h - fulcrumDrop - Math.sin(MAX_TILT) * arm)
+  const panDrop = Math.min(stage.h * 0.3, unit * 3.2, room * 0.3)
+  const panH = Math.min(stage.h * 0.46, unit * 6.2, room - panDrop)
+  const fulcrum = {
+    x: stage.x + stage.w / 2,
+    y: stage.y + fulcrumDrop,
+  }
+
+  const pillarW = (rack.w - faceGap * (PLACES.length - 1)) / PLACES.length
+  const faceH = (rack.h - faceGap) / 2
   const pillars: PillarRects[] = PLACES.map((place, i) => {
-    const x = rack.x + i * (pillarW + gap)
+    const x = rack.x + i * (pillarW + faceGap)
     return {
       place,
       up: { x, y: rack.y, w: pillarW, h: faceH },
-      down: { x, y: rack.y + faceH + gap, w: pillarW, h: faceH },
+      down: { x, y: rack.y + faceH + faceGap, w: pillarW, h: faceH },
       cx: x + pillarW / 2,
     }
   })
@@ -101,6 +192,64 @@ export function layoutFor(w: number, h: number): Layout {
     pillars,
     seat,
   }
+}
+
+/**
+ * The layout for the screen as it actually is.
+ *
+ * **This is the only entry point the renderer uses**, and that is the point of
+ * it existing. If the test called `layoutFor` with a safe rectangle it made up
+ * itself, it would pass whether or not the renderer ever asked for one — the
+ * clearance would be a property of the test, not of the game. Going through
+ * here means the test walks the same path the frame does.
+ */
+export function viewLayout(w: number, h: number, insets: Insets = safeInsets()): Layout {
+  return layoutFor(w, h, safeRect(w, h, insets))
+}
+
+/** Where the two hooks are, at a given tilt. The beam is drawn between them. */
+export function beamEnds(
+  l: Layout,
+  tilt: number,
+): { lx: number; ly: number; rx: number; ry: number } {
+  const dx = Math.cos(tilt) * l.arm
+  const dy = Math.sin(tilt) * l.arm
+  return {
+    lx: l.fulcrum.x - dx,
+    ly: l.fulcrum.y - dy,
+    rx: l.fulcrum.x + dx,
+    ry: l.fulcrum.y + dy,
+  }
+}
+
+/** The pan hanging from a hook: centred on it, one chain-drop below. */
+export function panRect(l: Layout, hookX: number, hookY: number): Rect {
+  return { x: hookX - l.panW / 2, y: hookY + l.panDrop, w: l.panW, h: l.panH }
+}
+
+/**
+ * The box both pans stay inside across every tilt the beam is read at.
+ *
+ * The load and the column are the two numbers of the round, so this is the rect
+ * the tests hold to the safe area. A shear *slams* past this — that is a
+ * transient with nothing readable in it, and it is meant to look like the beam
+ * lost the argument.
+ */
+export function panExtent(l: Layout): Rect {
+  let x0 = Infinity
+  let y0 = Infinity
+  let x1 = -Infinity
+  let y1 = -Infinity
+  for (const tilt of [-MAX_TILT, 0, MAX_TILT]) {
+    const ends = beamEnds(l, tilt)
+    for (const r of [panRect(l, ends.lx, ends.ly), panRect(l, ends.rx, ends.ry)]) {
+      x0 = Math.min(x0, r.x)
+      y0 = Math.min(y0, r.y)
+      x1 = Math.max(x1, r.x + r.w)
+      y1 = Math.max(y1, r.y + r.h)
+    }
+  }
+  return { x: x0, y: y0, w: x1 - x0, h: y1 - y0 }
 }
 
 export function hit(rect: Rect, x: number, y: number, slack = 0): boolean {

--- a/dynawalla/games/counterweight/src/render/scene.ts
+++ b/dynawalla/games/counterweight/src/render/scene.ts
@@ -14,7 +14,7 @@ import { GROUND, type Bout, type Seat, type Verdict } from "../game/bout.ts"
 import type { Column } from "../game/column.ts"
 import type { Place } from "../game/places.ts"
 import type { Beam } from "../sim/beam.ts"
-import { hit, layoutFor, type Layout, type Rect } from "./layout.ts"
+import { beamEnds, hit, panRect, viewLayout, type Layout, type Rect } from "./layout.ts"
 import { alpha, FACE_NUM, FACE_TEXT, font, mix, PALETTE } from "./palette.ts"
 import { Sparks } from "./particles.ts"
 
@@ -88,7 +88,7 @@ export class Scene {
     const ctx = canvas.getContext("2d")
     if (!ctx) throw new Error("counterweight: no 2d context")
     this.ctx = ctx
-    this.box = layoutFor(1, 1)
+    this.box = viewLayout(1, 1)
     this.resize()
   }
 
@@ -103,7 +103,9 @@ export class Scene {
     this.dpr = Math.min(3, Math.max(1, globalThis.devicePixelRatio || 1))
     this.canvas.width = Math.round(w * this.dpr)
     this.canvas.height = Math.round(h * this.dpr)
-    this.box = layoutFor(w, h)
+    // Read fresh each resize, not once at mount: a rotation swaps top/bottom
+    // with left/right, and Split View changes them without a rotation.
+    this.box = viewLayout(w, h)
   }
 
   /** Which face, if any, is under this point. */
@@ -236,7 +238,7 @@ export class Scene {
 
   private drawBeam(state: SceneState): void {
     const ctx = this.ctx
-    const { fulcrum, arm, unit } = this.box
+    const { fulcrum, unit } = this.box
     const angle = state.beam.angle
     // Positive margin is your side *down*: an arm-wrestle pushes the loser's
     // hand toward the table, and your side is the left one.
@@ -250,10 +252,9 @@ export class Scene {
     ctx.lineTo(fulcrum.x, this.box.stage.y + this.box.stage.h)
     ctx.stroke()
 
-    const lx = fulcrum.x - Math.cos(tilt) * arm
-    const ly = fulcrum.y - Math.sin(tilt) * arm
-    const rx = fulcrum.x + Math.cos(tilt) * arm
-    const ry = fulcrum.y + Math.sin(tilt) * arm
+    // Shared with `layout.panExtent`, so the test that holds the pans inside the
+    // safe area is measuring the geometry this frame actually draws.
+    const { lx, ly, rx, ry } = beamEnds(this.box, tilt)
 
     // The beam. Ring shows as a hot rim along the steel.
     const ring = state.beam.ring
@@ -290,8 +291,8 @@ export class Scene {
 
     this.drawChain(lx, ly, this.box.panDrop)
     this.drawChain(rx, ry, this.box.panDrop)
-    this.drawYourPan(state, lx, ly + this.box.panDrop)
-    this.drawHisPan(state, rx, ry + this.box.panDrop)
+    this.drawYourPan(state, panRect(this.box, lx, ly))
+    this.drawHisPan(state, panRect(this.box, rx, ry))
   }
 
   private drawChain(x: number, y: number, drop: number): void {
@@ -304,10 +305,10 @@ export class Scene {
     ctx.stroke()
   }
 
-  private drawYourPan(state: SceneState, cx: number, cy: number): void {
+  private drawYourPan(state: SceneState, r: Rect): void {
     const ctx = this.ctx
     const { panW, panH, unit } = this.box
-    const r: Rect = { x: cx - panW / 2, y: cy, w: panW, h: panH }
+    const cx = r.x + r.w / 2
     ctx.fillStyle = alpha(PALETTE.stone, 0.94)
     roundRect(ctx, r, unit * 0.5)
     ctx.fill()
@@ -326,10 +327,10 @@ export class Scene {
     ctx.fillText(grouped(state.bout.load), cx, r.y + panH * 0.62)
   }
 
-  private drawHisPan(state: SceneState, cx: number, cy: number): void {
+  private drawHisPan(state: SceneState, r: Rect): void {
     const ctx = this.ctx
     const { panW, panH, unit } = this.box
-    const r: Rect = { x: cx - panW / 2, y: cy, w: panW, h: panH }
+    const cx = r.x + r.w / 2
     ctx.fillStyle = alpha(PALETTE.stone, 0.94)
     roundRect(ctx, r, unit * 0.5)
     ctx.fill()

--- a/dynawalla/games/counterweight/src/test/layout.test.ts
+++ b/dynawalla/games/counterweight/src/test/layout.test.ts
@@ -1,0 +1,146 @@
+// THE YARD, ON A REAL DEVICE.
+//
+// Two things were wrong with this game's layout and neither could be seen from
+// a desk. The pack declares `viewport-fit=cover`, so the canvas runs under the
+// notch and the home indicator, and the seat lever — the one control the round
+// ends on — was pinned to `h - pad` and therefore underneath the home
+// indicator. And the host floats an exit control over the top-left corner and a
+// how-to-play control over the top-right, so `TURK 4` at one end of the HUD and
+// the tally at the other were both sitting under a button.
+//
+// This file is the gate. It runs the layout at the shapes the fleet has, CROSSED
+// with the inset profiles the fleet has, and asserts what a photograph of a
+// device would have shown.
+//
+// **Why it goes through `viewLayout`.** A test that calls `layoutFor(w, h,
+// safeRect(w, h))` proves nothing: it supplies the safe rectangle itself, so it
+// passes whether or not the renderer ever asks for one. `viewLayout` is the
+// single entry point `Scene.resize` uses, so exercising it here is exercising
+// the frame.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  hitsHostChrome,
+  NO_INSETS,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { panExtent, TOUCH_FLOOR, viewLayout } from "../render/layout.ts"
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+/** Real device shapes: a notched phone held tall, and the same one held wide. */
+const INSETS: Array<[string, Insets]> = [
+  ["no insets", NO_INSETS],
+  ["portrait notch", { top: 59, right: 0, bottom: 34, left: 0 }],
+  ["landscape notch", { top: 0, right: 59, bottom: 21, left: 59 }],
+]
+
+const inside = (r: Rect, area: Rect): boolean =>
+  r.x >= area.x - 0.5 &&
+  r.y >= area.y - 0.5 &&
+  r.x + r.w <= area.x + area.w + 0.5 &&
+  r.y + r.h <= area.y + area.h + 0.5
+
+const show = (r: Rect): string =>
+  `[${r.x.toFixed(1)}, ${r.y.toFixed(1)} ${r.w.toFixed(1)}×${r.h.toFixed(1)}]`
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    test(`the yard stands inside the safe area at ${vname} (${w}×${h}), ${iname}`, () => {
+      const l = viewLayout(w, h, insets)
+      const area = safeRect(w, h, insets)
+
+      // Everything a child reads or touches. The backdrop is deliberately not
+      // in this list — it bleeds to the full canvas, which is the entire point
+      // of `cover`.
+      const critical: Array<[string, Rect]> = [
+        ["the HUD row", l.hud],
+        ["the stage", l.stage],
+        ["the pans", panExtent(l)],
+        ["the gauge", l.gauge],
+        ["the rack", l.rack],
+        ["the seat lever", l.seat],
+        ...l.pillars.flatMap(
+          (p): Array<[string, Rect]> => [
+            [`the ${p.place} ADD face`, p.up],
+            [`the ${p.place} TAKE face`, p.down],
+          ],
+        ),
+      ]
+
+      for (const [what, rect] of critical) {
+        assert.ok(
+          inside(rect, area),
+          `${what} ${show(rect)} runs outside the safe area ${show(area)}`,
+        )
+        assert.equal(
+          hitsHostChrome(rect, w, insets),
+          false,
+          `${what} ${show(rect)} is under the host's chrome`,
+        )
+      }
+    })
+
+    test(`every touch target is still hittable at ${vname} (${w}×${h}), ${iname}`, () => {
+      const l = viewLayout(w, h, insets)
+      // The rack and the seat are the whole input vocabulary. A face under the
+      // touch floor is a blow the child meant to land and did not, and on this
+      // beam an unintended second blow is how you shear it.
+      const targets: Array<[string, Rect]> = [
+        ["the seat lever", l.seat],
+        ...l.pillars.flatMap(
+          (p): Array<[string, Rect]> => [
+            [`the ${p.place} ADD face`, p.up],
+            [`the ${p.place} TAKE face`, p.down],
+          ],
+        ),
+      ]
+      for (const [what, r] of targets) {
+        assert.ok(
+          r.w >= TOUCH_FLOOR,
+          `${what} is ${r.w.toFixed(1)}px wide — under the ${TOUCH_FLOOR}px touch floor`,
+        )
+        assert.ok(
+          r.h >= TOUCH_FLOOR,
+          `${what} is ${r.h.toFixed(1)}px tall — under the ${TOUCH_FLOOR}px touch floor`,
+        )
+      }
+    })
+  }
+}
+
+test("the HUD steps in past the host's corners rather than reserving a band", () => {
+  // The fix is horizontal, not vertical: reserving a 67px top band costs 12% of
+  // a small phone and would push the rack off the bottom. Both ends of the HUD
+  // give way instead, and the top of the HUD stays where it was.
+  const l = viewLayout(320, 568)
+  assert.ok(l.hud.x >= 54, `the HUD starts at ${l.hud.x.toFixed(1)} — inside the exit corner`)
+  assert.ok(
+    l.hud.x + l.hud.w <= 320 - 54,
+    `the HUD ends at ${(l.hud.x + l.hud.w).toFixed(1)} — inside the help corner`,
+  )
+  assert.ok(l.hud.y <= 20, `the HUD was pushed down to y=${l.hud.y.toFixed(1)}`)
+  assert.ok(l.hud.w >= 190, `only ${l.hud.w.toFixed(1)}px left between the corners`)
+})
+
+test("the safe area moves the yard, it does not merely shrink it", () => {
+  // If the insets were ignored, these two would be identical. They are the
+  // same screen, notched and not.
+  const bare = viewLayout(390, 844)
+  const notched = viewLayout(390, 844, { top: 59, right: 0, bottom: 34, left: 0 })
+  assert.ok(notched.hud.y > bare.hud.y, "the HUD did not move down for the notch")
+  assert.ok(
+    notched.seat.y + notched.seat.h < bare.seat.y + bare.seat.h,
+    "the seat lever did not lift off the home indicator",
+  )
+})

--- a/dynawalla/games/counterweight/src/test/mount.test.ts
+++ b/dynawalla/games/counterweight/src/test/mount.test.ts
@@ -21,7 +21,7 @@ import { mount } from "../contract.ts"
 import type { Host, Question } from "../contract.ts"
 import { openingLoad } from "../game/bout.ts"
 import { PLACES, planStrikes } from "../game/places.ts"
-import { layoutFor } from "../render/layout.ts"
+import { viewLayout } from "../render/layout.ts"
 import { createStubHost } from "../stubHost.ts"
 
 type Listener = (event: unknown) => void
@@ -53,11 +53,15 @@ function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderin
 }
 
 type FakeElement = {
-  style: { cssText: string }
+  id: string
+  style: Record<string, string>
   width: number
   height: number
   listeners: Map<string, Listener[]>
   appendChild(child: unknown): void
+  append(...children: unknown[]): void
+  setAttribute(name: string, value: string): void
+  focus(): void
   remove(): void
   addEventListener(type: string, fn: Listener): void
   removeEventListener(type: string, fn: Listener): void
@@ -70,11 +74,15 @@ function harness(size: { w: number; h: number }, counter: { calls: number; text:
   const make = (): FakeElement => {
     const listeners = new Map<string, Listener[]>()
     return {
+      id: "",
       style: { cssText: "" },
       width: 0,
       height: 0,
       listeners,
       appendChild() {},
+      append() {},
+      setAttribute() {},
+      focus() {},
       remove() {},
       addEventListener(type, fn) {
         const list = listeners.get(type) ?? []
@@ -89,13 +97,23 @@ function harness(size: { w: number; h: number }, counter: { calls: number; text:
     }
   }
   const created: FakeElement[] = []
+  // The shared chrome adds two things this stub has to answer for: the
+  // safe-area probe, which looks itself up by id before making a second one,
+  // and the how-to-play panel, which builds a small tree of buttons and lists.
+  // Both are DOM the game now really does create, so the fake DOM grows to meet
+  // them rather than the game being asked to skip them under test.
   const doc = {
     visibilityState: "visible",
     listeners: new Map<string, Listener[]>(),
+    body: { appendChild() {} },
+    activeElement: null,
     createElement() {
       const el = make()
       created.push(el)
       return el
+    },
+    getElementById(id: string): FakeElement | null {
+      return created.find((el) => el.id === id) ?? null
     },
     addEventListener(type: string, fn: Listener) {
       const list = doc.listeners.get(type) ?? []
@@ -194,7 +212,7 @@ function pump(
  * game renders while nobody is playing it.
  */
 function facePoints(w: number, h: number): Array<{ x: number; y: number }> {
-  const box = layoutFor(w, h)
+  const box = viewLayout(w, h)
   return box.pillars.flatMap((pillar) =>
     [pillar.up, pillar.down].map((r) => ({ x: r.x + r.w / 2, y: r.y + r.h / 2 })),
   )
@@ -202,7 +220,7 @@ function facePoints(w: number, h: number): Array<{ x: number; y: number }> {
 
 /** The seat lever, likewise. */
 function seatPoint(w: number, h: number): { x: number; y: number } {
-  const { seat } = layoutFor(w, h)
+  const { seat } = viewLayout(w, h)
   return { x: seat.x + seat.w / 2, y: seat.y + seat.h / 2 }
 }
 


### PR DESCRIPTION
## What

Stand THE COUNTERWEIGHT's yard inside the safe area, keep the host's two 44px
corners clear of anything a child reads or touches, and give the game the shared
how-to-play panel.

## Why

Two defects, neither visible from a desk.

**The safe area.** The pack declares `viewport-fit=cover`, which opts the canvas
*into* the notch, the home indicator and the rounded corners. A canvas cannot
read `env()`, and nothing here ever read the insets back. `layoutFor(w, h)`
measured everything from `(0, 0, w, h)` — so the **seat lever**, the single
control a round ends on, sat at `h - pad - seatH`, underneath the home indicator
on every phone that has one.

**The host's chrome.** The host floats an exit control over the top-LEFT corner
and the how-to-play control over the top-RIGHT. `hud` was `{x: pad, w: w -
pad*2}` — the full width at the very top — and `scene.ts` draws `TURK n`
left-aligned at `hud.x` and the won/held tally right-aligned at `hud.x + hud.w`.
Both ends were under a button.

### What was judged critical, and why

- **The HUD row** — the bout number, the tally and the arm bar between them.
  Fixed horizontally: `hud.x = area.x + HOST_MARGIN + HOST_CONTROL + gap`, and
  the same off the right. That costs **no height**, which matters, because
  reserving a 67px band is 12% of a 568px phone and broke SKY LEDGER's own
  layout when it was tried. On the narrowest viewport the strip between the
  corners is still 202px.
- **The seat lever** — the one button that commits the answer. Inside `area`
  (clear of the home indicator) and clear of both corners.
- **The eight rack faces** — the entire input vocabulary. Inside `area`, clear
  of both corners, and hittable.
- **The stage and the two pans** — his column and your load are the numbers of
  the round. The stage also starts below the corner band; on a phone that is a
  few pixels, because the HUD is already nearly past them.

Two floors were already being violated and are now enforced at 44px: the seat
was a tenth of the height, i.e. **39px** on a phone held sideways, and the rack
faces came out at **41px** on a narrow safe area. On this beam an unintended
second blow is how you shear, so a plate a child misses is not cosmetic.

### The test is not a tautology

A test that calls `layoutFor(w, h, safeRect(w, h))` proves nothing: it supplies
the safe rectangle itself, so it passes whether or not the renderer ever asks
for one. So `layout.ts` exports `viewLayout(w, h, insets = safeInsets())`, which
is the **single entry point `Scene.resize` uses**, and the test drives that —
5 viewports × 3 inset profiles. Beam-end and pan geometry moved out of
`scene.ts` into `layout.ts` (`beamEnds`, `panRect`, `panExtent`) so the test
measures the rects the frame actually draws rather than a copy of them.

Both halves were verified by removal:

- Reverting the corner inset (`const corner = pad`) → **16 of 32 fail**:
  `the HUD row [11.0, 11.0 298.0×38.0] is under the host's chrome`
- Making `viewLayout` ignore insets (`layoutFor(w, h, {x:0,y:0,w,h})`) →
  **11 of 32 fail**:
  `the HUD row [59.0, 11.0 202.0×38.0] runs outside the safe area [0.0, 59.0 320.0×475.0]`

`mount.test.ts`'s fake DOM grew a `getElementById`, a `body` and a few element
methods, because the safe-area probe and the how-to-play panel are DOM the game
now really does create. The game was not asked to skip them under test.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/counterweight/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no `voiceId`
      renamed; no catalog entry dropped or moved its version/platform gates.
      `dynawalla.counterweight@0.1.0` builds and stages with the same entry,
      host range, SDK version and capabilities as before.
- [x] **Native integrity.** N/A — no Rust, no manifest, no `links =` touched.
- [x] **Strings.** N/A — no `corpan-app` locale strings. The how-to-play copy is
      pack-local, matching the shared-chrome adoption pattern.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema
      touched. The pack still declares the same 7 skills, grades 1–4.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

## Proof

```
$ cd dynawalla/games/counterweight && for i in 1 2 3 4 5; do npm test; done
--- run 1 ---
# tests 111
# pass 111
# fail 0
--- run 2 ---
# tests 111
# pass 111
# fail 0
--- run 3 ---
# tests 111
# pass 111
# fail 0
--- run 4 ---
# tests 111
# pass 111
# fail 0
--- run 5 ---
# tests 111
# pass 111
# fail 0

$ npm run tsc
> @dynawalla/game-counterweight@0.1.0 tsc
> tsc --noEmit
(0 errors)

$ npm run build
vite v8.1.5 building client environment for production...
transforming...
✓ 21 modules transformed.
rendering chunks...
computing gzip size...
dist/counterweight.js  45.97 kB │ gzip: 14.87 kB
✓ built in 16ms

$ cd ../../packs && node build.mjs counterweight
dist-pack/pack.html                 1.27 kB │ gzip:  0.66 kB
dist-pack/assets/pack-mJQjRz4R.js  40.50 kB │ gzip: 14.84 kB
✓ built in 25ms
dynawalla.counterweight@0.1.0 — THE COUNTERWEIGHT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 42909 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~17159 bytes (17.16 KB) in 40.3ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/counterweight/src/mount.ts
dynawalla/games/counterweight/src/render/layout.ts
dynawalla/games/counterweight/src/render/scene.ts
dynawalla/games/counterweight/src/test/layout.test.ts
dynawalla/games/counterweight/src/test/mount.test.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

### The removal check, in full

```
# corner inset reverted:  const corner = pad
$ node --test src/test/layout.test.ts
ℹ pass 16
ℹ fail 16
  AssertionError: the HUD row [11.0, 11.0 298.0×38.0] is under the host's chrome
  AssertionError: the HUD row [11.0, 70.0 298.0×38.0] is under the host's chrome
  AssertionError: the HUD row [69.0, 10.0 182.0×34.0] is under the host's chrome
  AssertionError: the HUD row [13.0, 13.0 364.0×46.0] is under the host's chrome

# viewLayout ignoring insets:  layoutFor(w, h, { x: 0, y: 0, w, h })
$ node --test src/test/layout.test.ts
ℹ pass 21
ℹ fail 11
  AssertionError: the HUD row [59.0, 11.0 202.0×38.0] runs outside the safe area [0.0, 59.0 320.0×475.0]
  AssertionError: the HUD row [60.0, 13.0 270.0×46.0] runs outside the safe area [0.0, 59.0 390.0×751.0]
  AssertionError: the HUD row [63.0, 21.0 642.0×71.0] runs outside the safe area [0.0, 59.0 768.0×931.0]
  AssertionError: the HUD row [63.0, 21.0 898.0×71.0] runs outside the safe area [0.0, 59.0 1024.0×675.0]
```

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
