### PR TITLE
fix(dynawalla/games/colossus): put the tower's numbers where a notch cannot eat them

### DIFF
--- a/dynawalla/games/colossus/src/mount.ts
+++ b/dynawalla/games/colossus/src/mount.ts
@@ -24,6 +24,7 @@ import { bestStreak, recordStreak } from "./game/best.ts"
 import { Game, type GameEvent } from "./game/game.ts"
 import { Scene, type Banner } from "./render/scene.ts"
 import { STRIKE_ON } from "./render/palette.ts"
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 
 /**
  * The largest step the clock may take in one frame.
@@ -51,6 +52,47 @@ export function mountColossus(
   const scene = new Scene(canvas, reduced, seed)
   const audio = new Audio()
   const game = new Game(host, new Rng(seed), now())
+
+  // How to play. The growth penalty is the whole design of this game and it is
+  // the one thing a child cannot deduce from the screen before it happens to
+  // them, so it gets a heading of its own and is stated plainly: nothing is
+  // taken away, you just get more building.
+  const guide = createInstructions(el, {
+    title: "COLOSSUS",
+    summary: [
+      "A stone tower stands in front of the giant. Every floor has a number on it.",
+      "Work out the sum on the keystone. Then punch out the floors that multiply to that answer.",
+    ],
+    sections: [
+      {
+        heading: "Taking a swing",
+        lines: [
+          "Tap a floor to grab it. Tap it again to let go. Grabbing costs you nothing.",
+          "The fist shows what you are holding, like 8 x 9. It never shows the total.",
+          "Multiplying it out is your job.",
+          "Tap STRIKE when you think you have it.",
+        ],
+      },
+      {
+        heading: "A wrong strike makes the tower taller",
+        lines: [
+          "If your floors do not multiply to the keystone, two new floors thud down on top.",
+          "Nothing is taken away from you. No buzzer, no lost life, no red cross.",
+          "You just get more building to knock down. So it pays to be sure first.",
+        ],
+      },
+      {
+        heading: "Bringing it down",
+        lines: [
+          "A right strike blows those floors out, and everything above falls into the hole.",
+          "Clear every keystone and the whole tower comes down.",
+          "Some floors carry numbers that look close but are wrong. Do the sum before you swing.",
+          "Sometimes one floor on its own is the whole answer.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
 
   let best = bestStreak()
   let streak = 0
@@ -218,6 +260,7 @@ export function mountColossus(
       globalThis.removeEventListener("resize", resize)
       observer?.disconnect()
       audio.dispose()
+      guide.destroy()
       canvas.remove()
     },
   }

--- a/dynawalla/games/colossus/src/render/layout.ts
+++ b/dynawalla/games/colossus/src/render/layout.ts
@@ -1,0 +1,267 @@
+// Where the tower's numbers are allowed to be.
+//
+// COLOSSUS shipped with its geometry scattered through the renderer as
+// literals: `fillText("TOWER 3", 18, 30)`, a pip strip anchored to `w - 18`, a
+// camera band that began at a hardcoded `74`. Every one of those numbers is
+// measured from the edge of the CANVAS, and the canvas is not the screen. The
+// pack declares `viewport-fit=cover`, so on a notched phone the first 59 rows of
+// that canvas are under the notch, and the host paints an exit control over the
+// top-left corner and a how-to-play control over the top-right one. `TOWER 3`
+// and `BEST 12` were under the exit control; the progress pips were under the
+// help control. On a device, not in a test.
+//
+// So the geometry lives here instead, as one pure function of the viewport and
+// the safe rectangle, and the test asserts it at every shape the fleet has.
+//
+// **`area` is required, not optional.** A game that forgets to pass it would
+// otherwise compile and quietly draw under the notch, discoverable only by
+// holding the device.
+//
+// **The corners are cleared horizontally, not by reserving a band.** Reserving
+// the 67px top strip costs 12% of a 568px phone and broke a sibling game's own
+// layout outright. Insetting between the two 44px corners costs no height at
+// all: the HUD labels start inboard of the exit control and the pips end
+// inboard of the help control, and the ~200px between them on the narrowest
+// phone is more than both need.
+//
+// What still bleeds to the full canvas: the sky, the sun, the skyline, the
+// ground, the dust. That is what `cover` is FOR. It is only what a child must
+// read or touch that belongs inside `area`.
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  safeInsets,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { MAX_KEYSTONES } from "../game/tower.ts"
+
+/** World units. One floor of the colossus. */
+export const FLOOR_H = 56
+export const FLOOR_W = 300
+export const KEY_H = 92
+export const KEY_GAP = 22
+
+/** Clear air between a host control and anything of ours standing beside it. */
+const CORNER_GAP = 8
+
+const HUD_FONT = 13
+const PIP_W = 10
+const PIP_H = 10
+const PIP_GAP = 6
+
+/** Enough for `TOWER 3` at 13px. Below this the pips stack instead. */
+const MIN_LABEL_W = 58
+/** Air between the ground line and the strike bar. */
+const GROUND_GAP = 26
+/** The bar gives height back to the world before it goes below this. */
+const MIN_BAR_H = 64
+/** What the building is owed before the strike bar may take its full height. */
+const MIN_BAND = 150
+
+export type { Rect }
+
+export type Layout = {
+  readonly w: number
+  readonly h: number
+  /** The rectangle the notch and the home indicator leave us. */
+  readonly area: Rect
+  /** Centre of the safe area — the building stands here, not at `w / 2`. */
+  readonly cx: number
+  readonly hudFont: number
+  /** Left edge of `TOWER n` / `BEST n`, inboard of the host's exit control. */
+  readonly hudX: number
+  readonly towerY: number
+  readonly bestY: number
+  /** What those two labels occupy, at their widest. Asserted, not guessed. */
+  readonly towerBox: Rect
+  readonly bestBox: Rect
+  readonly pipW: number
+  readonly pipH: number
+  readonly pipGap: number
+  /** Right edge the pip strip hangs from, inboard of the help control. */
+  readonly pipRight: number
+  readonly pipY: number
+  /** The whole strip at its widest — every shorter tower fits inside it. */
+  readonly pips: Rect
+  readonly strikeBarH: number
+  readonly strike: Rect
+  /** The camera band: world is fitted between these two, never above `hudTop`. */
+  readonly hudTop: number
+  readonly hudBottom: number
+  readonly usableH: number
+  readonly groundY: number
+}
+
+/**
+ * The geometry of one frame.
+ *
+ * `area` is the safe rectangle. Pass `safeRect(w, h)` — or, in a test, the same
+ * thing computed from a made-up inset profile.
+ */
+export function layout(w: number, h: number, area: Rect): Layout {
+  const cornerTop = area.y + HOST_PROGRESS_H + HOST_MARGIN
+  const cornerBottom = cornerTop + HOST_CONTROL
+
+  // The centre strip: everything the host does not own.
+  const left = area.x + HOST_MARGIN + HOST_CONTROL + CORNER_GAP
+  const right = Math.max(left, area.x + area.w - HOST_MARGIN - HOST_CONTROL - CORNER_GAP)
+
+  // Two lines of small caps, sitting level with the host's controls rather than
+  // pushed below them. Nothing is lost to the notch that the notch did not take.
+  const labelH = Math.ceil(HUD_FONT * 1.3)
+  const towerY = cornerTop + 17
+  const bestY = cornerTop + 37
+
+  const pipStripW = MAX_KEYSTONES * (PIP_W + PIP_GAP) - PIP_GAP
+
+  // The centre strip is everything the host's two corners leave. On a 320px
+  // phone that is ~196px, and `TOWER 999` plus five pips needs about 160 — so
+  // the two normally sit on one line, label left, pips right.
+  const centreW = right - left
+  const wantLabelW = HUD_FONT * 0.62 * 10
+  const abreast = centreW >= MIN_LABEL_W + pipStripW + CORNER_GAP
+
+  // When they will not fit abreast, the pips drop to their own line UNDER the
+  // labels rather than either of them backing into a corner. That line is below
+  // the 44px control squares, so it is clear of the chrome twice over.
+  const labelW = Math.max(
+    0,
+    Math.min(wantLabelW, abreast ? centreW - pipStripW - CORNER_GAP : centreW),
+  )
+  const towerBox: Rect = { x: left, y: towerY - labelH / 2, w: labelW, h: labelH }
+  const bestBox: Rect = { x: left, y: bestY - labelH / 2, w: labelW, h: labelH }
+
+  const pipY = abreast ? cornerTop + 12 : bestBox.y + bestBox.h + 6
+  const pips: Rect = { x: right - pipStripW, y: pipY, w: pipStripW, h: PIP_H }
+
+  // The camera band begins below everything the top of the frame is spending:
+  // the host's controls, our own labels, and the pips when they had to stack.
+  const hudTop = Math.max(cornerBottom, bestBox.y + bestBox.h, pips.y + pips.h) + CORNER_GAP
+
+  // The strike bar hangs off the bottom of the SAFE area, not the canvas: on a
+  // 390px-tall landscape phone the home indicator eats 21px, and a pill anchored
+  // to `h` puts the only button in the game under it.
+  //
+  // It also gives height back when there is not enough left for the building. A
+  // fixed 96px bar under a 59px notch on a landscape phone left the world 108px
+  // and the keystone climbed out of the frame; the bar yields first, because a
+  // shorter bar is still a 58px button and a clipped keystone is unreadable.
+  const bottom = area.y + area.h
+  const headroom = bottom - hudTop - GROUND_GAP
+  const wantBarH = Math.max(96, Math.min(132, area.h * 0.14))
+  const strikeBarH = Math.max(MIN_BAR_H, Math.min(wantBarH, headroom - MIN_BAND))
+  const pillH = Math.max(58, Math.min(78, strikeBarH * 0.62))
+  const pillW = Math.max(0, Math.min(area.w - 40, 520))
+  const strike: Rect = {
+    x: area.x + (area.w - pillW) / 2,
+    y: bottom - strikeBarH + (strikeBarH - pillH) / 2,
+    w: pillW,
+    h: pillH,
+  }
+
+  const groundY = bottom - strikeBarH - GROUND_GAP
+  // No floor under this. A band that claims to be 120px when only 108 exist is
+  // how the keystone ended up over the notch in the first place.
+  const usableH = Math.max(24, groundY - hudTop)
+
+  return {
+    w,
+    h,
+    area,
+    cx: area.x + area.w / 2,
+    hudFont: HUD_FONT,
+    hudX: left,
+    towerY,
+    bestY,
+    towerBox,
+    bestBox,
+    pipW: PIP_W,
+    pipH: PIP_H,
+    pipGap: PIP_GAP,
+    pipRight: right,
+    pipY,
+    pips,
+    strikeBarH,
+    strike,
+    hudTop,
+    hudBottom: h - groundY,
+    usableH,
+    groundY,
+  }
+}
+
+/**
+ * The one entry point the renderer uses.
+ *
+ * `Scene` obtains geometry through this and nothing else, which is what makes
+ * the layout test worth having: it exercises the exact path a frame takes,
+ * insets included, instead of a rectangle the test supplied itself.
+ */
+export function viewLayout(w: number, h: number, insets: Insets = safeInsets()): Layout {
+  return layout(w, h, safeRect(w, h, insets))
+}
+
+/** Screen x of pip `i` of `total`, hung from the right of the strip. */
+export function pipX(l: Layout, i: number, total: number): number {
+  return l.pipRight - (total - i) * (l.pipW + l.pipGap) + l.pipGap
+}
+
+/**
+ * The camera, for a tower `floors` high.
+ *
+ * One scale fits tower plus keystone into `usableH`, and everything is drawn
+ * through it — which is the whole trick of this game: a tower that grew makes
+ * the giant smaller, and nobody has to be told.
+ *
+ * `cap` is the safety half. The keystone carries the sum the child has to read;
+ * capping the scale so its top edge — float included — can never rise past
+ * `hudTop` means the notch and the host's corners cannot eat it, whatever a
+ * wrong strike does to the height of the building. `cap` is separate from
+ * `scale` because the renderer eases toward `scale` and would otherwise pass
+ * through a too-large value on the way down after the tower grows.
+ */
+export function cameraFor(l: Layout, floors: number): {
+  scale: number
+  cap: number
+  cx: number
+  groundY: number
+} {
+  const n = Math.max(0, floors)
+  const worldH = n * FLOOR_H + KEY_GAP + KEY_H + FLOOR_H * 0.6
+  const byHeight = l.usableH / Math.max(worldH, FLOOR_H * 6)
+  // A narrow frame gives the building less of the width, not more: the colossus
+  // has to have somewhere to stand, and a phone in portrait is the only case
+  // where the two are fighting over the same pixels.
+  const byWidth = (l.area.w * (l.area.w < 640 ? 0.68 : 0.82)) / (FLOOR_W * 1.18)
+  const byKeystone = l.usableH / (n * FLOOR_H + KEY_GAP + KEY_H + KEY_H * 0.06)
+  const cap = Math.min(1.05, byWidth, byKeystone)
+  return { scale: Math.min(cap, byHeight), cap, cx: l.cx, groundY: l.groundY }
+}
+
+/** Where the keystone plate lands on screen, float included. */
+export function keystoneBox(l: Layout, floors: number, scale = cameraFor(l, floors).scale): Rect {
+  const w = FLOOR_W * 1.16 * scale
+  const h = KEY_H * scale
+  const float = h * 0.05
+  return {
+    x: l.cx - w / 2,
+    y: l.groundY - (floors * FLOOR_H + KEY_GAP + KEY_H) * scale - float,
+    w,
+    h: h + float * 2,
+  }
+}
+
+/** Where floor `index` (0 = ground floor) lands on screen when it is at rest. */
+export function floorBox(l: Layout, floors: number, index: number, scale = cameraFor(l, floors).scale): Rect {
+  const w = FLOOR_W * scale
+  return {
+    x: l.cx - w / 2,
+    y: l.groundY - (index + 1) * FLOOR_H * scale,
+    w,
+    h: FLOOR_H * scale,
+  }
+}

--- a/dynawalla/games/colossus/src/render/scene.ts
+++ b/dynawalla/games/colossus/src/render/scene.ts
@@ -24,13 +24,19 @@ import { approach, easeOutCubic, unit } from "../core/feel.ts"
 import { Rng } from "../core/rng.ts"
 import type { Floor } from "../game/tower.ts"
 import { Dust } from "./dust.ts"
+import {
+  cameraFor,
+  pipX,
+  viewLayout,
+  FLOOR_H,
+  FLOOR_W,
+  KEY_GAP,
+  KEY_H,
+  type Layout,
+} from "./layout.ts"
 import * as C from "./palette.ts"
 
-/** World units. One floor of the colossus. */
-const FLOOR_H = 56
-const FLOOR_W = 300
-const KEY_H = 92
-const KEY_GAP = 22
+/** World units. The colossus itself; the building's are in `layout.ts`. */
 const GIANT_H = 306
 
 /** Gravity, world units per millisecond squared. Stone, not feathers. */
@@ -91,6 +97,15 @@ export class Scene {
   private h = 0
   private dpr = 1
 
+  /**
+   * Every measurement in the frame, safe area and host chrome accounted for.
+   *
+   * This is the ONLY source of geometry in the renderer. Nothing below reaches
+   * for `this.w`/`this.h` to decide where a number goes — those two are the
+   * canvas, and the canvas runs under the notch on purpose.
+   */
+  private lay: Layout = viewLayout(1, 1)
+
   private slabs = new Map<number, Slab>()
   private debris: Debris[] = []
 
@@ -125,6 +140,9 @@ export class Scene {
     this.h = Math.max(1, Math.round(rect.height))
     this.canvas.width = Math.round(this.w * this.dpr)
     this.canvas.height = Math.round(this.h * this.dpr)
+    // Re-read the insets here rather than at mount: a rotation swaps top and
+    // bottom for left and right, and iPadOS changes them again in Split View.
+    this.lay = viewLayout(this.w, this.h)
   }
 
   get view(): Metrics {
@@ -176,25 +194,21 @@ export class Scene {
     this.time += dt
     const n = state.floors.length
 
-    // The camera. Fit tower plus keystone plus a little sky.
-    const hudTop = 74
-    const hudBottom = this.strikeBarHeight() + 26
-    const usableH = Math.max(120, this.h - hudTop - hudBottom)
-    const worldH = n * FLOOR_H + KEY_GAP + KEY_H + FLOOR_H * 0.6
-    const byHeight = usableH / Math.max(worldH, FLOOR_H * 6)
-    // A narrow frame gives the building less of the width, not more: the
-    // colossus has to have somewhere to stand, and a phone in portrait is the
-    // only case where the two are fighting over the same pixels.
-    const byWidth = (this.w * (this.w < 640 ? 0.68 : 0.82)) / (FLOOR_W * 1.18)
-    const want = Math.min(1.05, byHeight, byWidth)
-    this.scale = this.reduced ? want : approach(this.scale, want, 0.06, dt)
+    // The camera. Fit tower plus keystone plus a little sky — inside the band
+    // `layout.ts` cleared for it, which begins below the notch and below the
+    // host's two corners rather than at a hardcoded 74.
+    const l = this.lay
+    const cam = cameraFor(l, n)
+    this.scale = this.reduced
+      ? cam.scale
+      : Math.min(cam.cap, approach(this.scale, cam.scale, 0.06, dt))
 
-    const groundY = this.h - hudBottom
+    const groundY = cam.groundY
     this.metrics = {
       groundY,
-      cx: this.w * 0.5,
+      cx: cam.cx,
       scale: this.scale,
-      strike: this.strikeRect(),
+      strike: l.strike,
     }
 
     // Slab physics. Anything above its resting height is falling.
@@ -562,42 +576,32 @@ export class Scene {
 
   // ── the chrome ────────────────────────────────────────────────────────────
 
-  private strikeBarHeight(): number {
-    return Math.max(96, Math.min(132, this.h * 0.14))
-  }
-
-  private strikeRect(): { x: number; y: number; w: number; h: number } {
-    const barH = this.strikeBarHeight()
-    const h = Math.max(58, Math.min(78, barH * 0.62))
-    const w = Math.min(this.w - 40, 520)
-    return { x: (this.w - w) / 2, y: this.h - barH + (barH - h) / 2, w, h }
-  }
-
   private hud(state: SceneState): void {
     const ctx = this.ctx
+    const l = this.lay
 
-    // Top left: which tower this is. Top right: how many keystones are left in
-    // it, as stones. No sentences: the pips are the progress.
-    ctx.font = `700 13px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    // Left: which tower this is. Right: how many keystones are left in it, as
+    // stones. No sentences: the pips are the progress.
+    //
+    // Both are pulled INBOARD of the host's two 44px corners rather than pushed
+    // below them — the exit control sits top-left and the how-to-play control
+    // top-right, and `TOWER 3` used to be underneath the first of them.
+    ctx.font = `700 ${l.hudFont}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
     ctx.textAlign = "left"
     ctx.textBaseline = "middle"
     ctx.fillStyle = C.HUD_DIM
-    ctx.fillText(`TOWER ${state.level}`, 18, 30)
+    ctx.fillText(`TOWER ${state.level}`, l.hudX, l.towerY)
 
     const total = Math.max(1, state.progress.total)
-    const pipW = 10
-    const gap = 6
-    const right = this.w - 18
     for (let i = 0; i < total; i++) {
-      const x = right - (total - i) * (pipW + gap) + gap
       ctx.fillStyle = i < state.progress.done ? C.HUD_DIM : C.HUD_INK
-      ctx.fillRect(x, 25, pipW, 10)
+      ctx.fillRect(pipX(l, i, total), l.pipY, l.pipW, l.pipH)
     }
 
     if (state.best > 0) {
       ctx.textAlign = "left"
       ctx.fillStyle = C.HUD_DIM
-      ctx.fillText(`BEST ${state.best}`, 18, 50)
+      ctx.fillText(`BEST ${state.best}`, l.hudX, l.bestY)
     }
 
     // The fist. It reads back the expression the child is holding — and never
@@ -648,13 +652,14 @@ export class Scene {
     ctx.globalAlpha = t > 0.75 ? (1 - t) * 4 : 1
     ctx.textAlign = "center"
     ctx.textBaseline = "middle"
-    const size = fit(b.title, this.w * 0.82, 56)
+    const { area } = this.lay
+    const size = fit(b.title, area.w * 0.82, 56)
     ctx.font = `900 ${size}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
     ctx.fillStyle = b.tint
     ctx.shadowColor = "rgba(0,0,0,0.6)"
     ctx.shadowBlur = 18
-    const y = this.h * 0.34 + (1 - rise) * (this.reduced ? 0 : 28)
-    ctx.fillText(b.title, this.w / 2, y)
+    const y = area.y + area.h * 0.34 + (1 - rise) * (this.reduced ? 0 : 28)
+    ctx.fillText(b.title, this.lay.cx, y)
     ctx.restore()
   }
 
@@ -666,7 +671,8 @@ export class Scene {
     ctx.textBaseline = "middle"
     ctx.fillStyle = C.HUD_INK
     ctx.font = `600 17px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
-    ctx.fillText("Nothing to build with.", this.w / 2, this.h / 2)
+    const { area } = this.lay
+    ctx.fillText("Nothing to build with.", this.lay.cx, area.y + area.h / 2)
   }
 
   // ── hit testing ───────────────────────────────────────────────────────────

--- a/dynawalla/games/colossus/src/test/layout.test.ts
+++ b/dynawalla/games/colossus/src/test/layout.test.ts
@@ -1,0 +1,198 @@
+// THE FRAME.
+//
+// COLOSSUS shipped drawing `TOWER 3` at (18, 30) and its progress pips at
+// `w - 18`. On every phone the host ships to, those are respectively under the
+// exit control and under the how-to-play control, and on a notched phone the
+// first of them is under the notch as well. Nothing in the rules tests could
+// ever have noticed: a layout bug is invisible to a test about factors.
+//
+// This is that gate, and it is built so it cannot pass by accident.
+//
+//   * It calls `viewLayout`, the SAME entry point `Scene.resize` calls, rather
+//     than the inner `layout(w, h, area)` with an area the test made up. Take
+//     the `area` plumbing out of `viewLayout` and the notch cases fail here.
+//   * It runs every viewport against three inset profiles, including none. Take
+//     the horizontal corner inset out of `layout` and the zero-inset cases fail.
+//
+// Both halves are guarded, so neither can be removed quietly.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  hitsHostChrome,
+  safeRect,
+  NO_INSETS,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { MAX_FLOORS } from "../game/game.ts"
+import { MAX_KEYSTONES } from "../game/tower.ts"
+import { cameraFor, floorBox, keystoneBox, pipX, viewLayout } from "../render/layout.ts"
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+const INSETS: Array<[string, Insets]> = [
+  ["no insets", NO_INSETS],
+  ["portrait notch", { top: 59, right: 0, bottom: 34, left: 0 }],
+  ["landscape notch", { top: 0, right: 59, bottom: 21, left: 59 }],
+]
+
+const inside = (r: Rect, area: Rect): boolean =>
+  r.x >= area.x - 0.5 &&
+  r.y >= area.y - 0.5 &&
+  r.x + r.w <= area.x + area.w + 0.5 &&
+  r.y + r.h <= area.y + area.h + 0.5
+
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+const box = (r: Rect): string =>
+  `[${r.x.toFixed(1)}, ${r.y.toFixed(1)} ${r.w.toFixed(1)}×${r.h.toFixed(1)}]`
+
+// Tower heights worth checking: an almost-empty building, a fresh one, and the
+// tallest a run of wrong strikes can ever make it.
+const HEIGHTS = [1, 2, 5, 9, 14, MAX_FLOORS]
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    const where = `${vname} (${w}×${h}), ${iname}`
+
+    test(`nothing a child reads or touches is under the chrome — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      const area = safeRect(w, h, insets)
+
+      // Everything critical, named. If a rect is added to the HUD it belongs in
+      // this list or it is not being checked.
+      const critical: Array<[string, Rect]> = [
+        ["the TOWER label", l.towerBox],
+        ["the BEST label", l.bestBox],
+        ["the progress pips", l.pips],
+        ["the STRIKE pill", l.strike],
+      ]
+
+      for (const [name, rect] of critical) {
+        assert.equal(
+          hitsHostChrome(rect, w, insets),
+          false,
+          `${name} ${box(rect)} is under the host's chrome`,
+        )
+        assert.ok(inside(rect, area), `${name} ${box(rect)} is outside the safe area ${box(area)}`)
+      }
+
+      // The keystone carries the sum. The floors are the tap targets. Both are
+      // centred, so the corners are not the likely failure — the notch is.
+      for (const n of HEIGHTS) {
+        const key = keystoneBox(l, n)
+        assert.equal(
+          hitsHostChrome(key, w, insets),
+          false,
+          `${n} floors: the keystone ${box(key)} is under the host's chrome`,
+        )
+        assert.ok(
+          inside(key, area),
+          `${n} floors: the keystone ${box(key)} is outside the safe area ${box(area)}`,
+        )
+
+        const top = floorBox(l, n, n - 1)
+        assert.equal(
+          hitsHostChrome(top, w, insets),
+          false,
+          `${n} floors: the top floor ${box(top)} is under the host's chrome`,
+        )
+        assert.ok(
+          inside(top, area),
+          `${n} floors: the top floor ${box(top)} is outside the safe area ${box(area)}`,
+        )
+
+        // And the building never stands on its own button.
+        assert.ok(
+          l.groundY <= l.strike.y + 0.5,
+          `${n} floors: the ground line ${l.groundY.toFixed(1)} is inside the strike bar`,
+        )
+      }
+    })
+
+    test(`the label and the pips do not collide — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      // Abreast where there is room, stacked where there is not — but never
+      // overlapping, and never solved by letting one of them into a corner.
+      for (const label of [l.towerBox, l.bestBox]) {
+        assert.equal(
+          overlaps(label, l.pips),
+          false,
+          `the HUD label ${box(label)} runs into the pips ${box(l.pips)}`,
+        )
+      }
+      assert.ok(
+        l.towerBox.w >= 40,
+        `the HUD label has ${l.towerBox.w.toFixed(1)}px — "TOWER 3" does not fit`,
+      )
+      // Every shorter run of pips hangs inside the widest one.
+      for (let total = 1; total <= MAX_KEYSTONES; total++) {
+        assert.ok(
+          pipX(l, 0, total) >= l.pips.x - 0.5,
+          `a run of ${total} pips starts left of the strip`,
+        )
+        assert.ok(
+          pipX(l, total - 1, total) + l.pipW <= l.pips.x + l.pips.w + 0.5,
+          `a run of ${total} pips runs off the right of the strip`,
+        )
+      }
+    })
+
+    test(`the camera keeps the building in the room — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      assert.ok(l.usableH >= 120, `the camera band is ${l.usableH.toFixed(1)}px`)
+      assert.ok(l.hudTop >= l.area.y, "the camera band starts above the safe area")
+      for (const n of HEIGHTS) {
+        const cam = cameraFor(l, n)
+        assert.ok(cam.scale > 0, `${n} floors: the camera scale collapsed`)
+        assert.ok(cam.scale <= cam.cap + 1e-9, `${n} floors: the camera exceeds its own cap`)
+        assert.ok(
+          keystoneBox(l, n).y >= l.hudTop - 0.5,
+          `${n} floors: the keystone climbs above the camera band`,
+        )
+      }
+      // The eased camera can pass through a larger scale on its way down after
+      // the tower grows. The cap is what stops that frame from being wrong.
+      const grown = cameraFor(l, 3)
+      assert.ok(
+        keystoneBox(l, 3, grown.cap).y >= l.hudTop - 0.5,
+        "at the camera's cap the keystone still climbs above the band",
+      )
+    })
+  }
+}
+
+test("the safe area is what moves the HUD, not a constant", () => {
+  // The plumbing itself: with a notch, everything critical moves down and in by
+  // exactly the inset. This is the assertion that fails if `viewLayout` stops
+  // threading insets through `safeRect`.
+  const plain = viewLayout(390, 844, NO_INSETS)
+  const notched = viewLayout(390, 844, { top: 59, right: 0, bottom: 34, left: 0 })
+  assert.equal(notched.towerBox.y - plain.towerBox.y, 59, "the HUD did not move below the notch")
+  assert.ok(
+    notched.strike.y + notched.strike.h < plain.strike.y + plain.strike.h,
+    "the strike pill did not move above the home indicator",
+  )
+
+  const shifted = viewLayout(844, 390, { top: 0, right: 59, bottom: 21, left: 59 })
+  assert.equal(shifted.towerBox.x - viewLayout(844, 390, NO_INSETS).towerBox.x, 59)
+})
+
+test("the corners are cleared sideways, not by reserving a band", () => {
+  // A reserved 67px top strip costs 12% of a 568px phone. The promise here is
+  // narrower and cheaper: the HUD sits level with the host's controls, and the
+  // clearance is horizontal.
+  const l = viewLayout(320, 568, NO_INSETS)
+  assert.ok(l.towerBox.y < 44, "the HUD was pushed below the host's controls instead of beside them")
+  assert.ok(l.hudX >= 54, `the HUD starts at ${l.hudX}, inside the exit control`)
+  assert.ok(l.pips.x + l.pips.w <= 266, "the pips reach into the help control")
+})


### PR DESCRIPTION
## What

Move COLOSSUS's geometry into a pure `render/layout.ts` that is a function of the viewport **and the safe rectangle**, so the HUD, the progress pips, the STRIKE pill and the keystone all clear the notch, the home indicator and the host's two 44px corner controls. Adds a how-to-play sheet.

## Why

COLOSSUS drew `TOWER n` and `BEST n` at `x = 18`, `y = 30/50` — underneath the host's exit control — and right-anchored its progress pips to `w - 18`, `y 25..35` — underneath the how-to-play control. The camera band began at a hardcoded `hudTop = 74` measured from the top of the *canvas*, and the pack declares `viewport-fit=cover`, so on a notched phone those first 59 rows are under the notch. A child on an iPhone could not read which tower they were on, could not see how many keystones were left, and on a landscape phone the home indicator sat on the only button in the game.

Two further bugs the new test found, which had nothing to do with the reported ones:

- **The STRIKE pill was anchored to the canvas bottom.** At 844×390 with a 21px bottom inset the pill's bottom edge landed at 371.75 against a safe edge of 369. It is now anchored to the bottom of the safe area.
- **The camera band claimed a floor it did not have.** `usableH = Math.max(120, ...)` returned 120 where only 108.5px existed (844×390 under a 59px top notch), and the keystone — the sum the child has to read — climbed out of the frame. The band is now honest, and the strike bar yields height before the world does: a shorter bar is still a 58px button, a clipped keystone is unreadable.

**Corner clearance is horizontal, not a reserved band.** Reserving the 67px top strip costs 12% of a 568px phone and broke SKY LEDGER's own layout invariant outright. Here the labels start at `area.x + HOST_MARGIN + HOST_CONTROL + 8` and the pips end at `helpRect.x - 8`; the ~196px between them on a 320px phone holds `TOWER 999` plus five 16px pips with room to spare. Where they cannot fit abreast (a 320px viewport with 59px side insets — the test matrix produces it) the pips drop to their own line *under* the labels, below the control squares, rather than either backing into a corner.

The sky, the sun, the minarets, the ground and the dust still bleed to the full canvas. That is what `cover` is for.

## Blast radius

**Areas touched:** dynawalla (one game pack only)

- [x] Every touched path is covered by a `ci.yml` area filter. All four files are under `dynawalla/games/colossus/`.
- [x] **Pack back-compat.** No published pack zip changed in place; `pack.json` untouched (still `dynawalla.colossus@0.1.0`, same `capabilities`, same `covers`); no `voiceId` renamed; no catalog entry dropped.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** The how-to-play copy is inside the pack (`src/mount.ts`), not `corpan-app/public/locales/`. The pack declares `"locales": ["en"]` and is English-only today, as before this PR.
- [x] **Curriculum.** N/A — no skill id, grade, generator, schema or renderer touched. `pack.json` `covers` is byte-identical.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD` (output below).

## Proof

### The test fails if either half of the fix is removed

This is the point of the design. `Scene.resize` obtains geometry through `viewLayout(w, h)` and nothing else, and the test calls that same entry point — not the inner `layout(w, h, area)` with an area the test supplied itself. The matrix is 5 viewports × 3 inset profiles.

**1. Corner inset removed** (`left`/`right` reverted to `area.x ± 18`) — 16 failures, including every zero-inset case:

```
not ok 10 - nothing a child reads or touches is under the chrome — phone portrait, small (320×568), no insets
  error: |-
    the TOWER label [18.0, 21.5 80.6×17.0] is under the host's chrome
not ok 19 - nothing a child reads or touches is under the chrome — phone portrait, tall (390×844), no insets
not ok 28 - nothing a child reads or touches is under the chrome — tablet portrait (768×1024), no insets
...
not ok 81 - the corners are cleared sideways, not by reserving a band
  error: 'the HUD starts at 18, inside the exit control'
# tests 81
# pass 65
# fail 16
```

**2. `viewLayout` made to ignore insets** (`layout(w, h, {x:0, y:0, w, h})`) — 11 failures, every notch case:

```
not ok 13 - nothing a child reads or touches is under the chrome — phone portrait, small (320×568), portrait notch
  error: 'the TOWER label [62.0, 21.5 80.6×17.0] is outside the safe area [0.0, 59.0 320.0×475.0]'
not ok 49 - nothing a child reads or touches is under the chrome — phone landscape (844×390), portrait notch
  error: 'the TOWER label [62.0, 21.5 80.6×17.0] is outside the safe area [0.0, 59.0 844.0×297.0]'
not ok 55 - the safe area is what moves the HUD, not a constant
  error: |-
    the HUD did not move below the notch
# tests 81
# pass 70
# fail 11
```

Both restored; the diff on this branch contains neither revert.

### `npm test`, five separate runs

```
$ for i in 1 2 3 4 5; do echo "=== run $i ==="; npm test 2>&1 | grep -E "^# (tests|pass|fail)"; done
=== run 1 ===
# tests 81
# pass 81
# fail 0
=== run 2 ===
# tests 81
# pass 81
# fail 0
=== run 3 ===
# tests 81
# pass 81
# fail 0
=== run 4 ===
# tests 81
# pass 81
# fail 0
=== run 5 ===
# tests 81
# pass 81
# fail 0
```

The pre-existing suites — `tower.test.ts`, `factor.test.ts`, `antimash.test.ts`, `pause.test.ts`, `stubHost.test.ts` — are unchanged and green in all five.

### `npm run tsc`

```
$ npm run tsc

> @dynawalla/game-colossus@0.1.0 tsc
> tsc --noEmit

```

Zero errors.

### `npm run build`

```
$ npm run build

> @dynawalla/game-colossus@0.1.0 build
> vite build

vite v8.1.5 building client environment for production...
transforming...✓ 20 modules transformed.
rendering chunks...
computing gzip size...
dist/colossus.js  41.36 kB │ gzip: 13.73 kB

✓ built in 16ms
```

### `node build.mjs colossus`

```
$ cd dynawalla/packs && node build.mjs colossus

> @dynawalla/game-colossus@0.1.0 build:pack
> vite build --config vite.pack.config.ts

vite v8.1.5 building client environment for production...
transforming...✓ 29 modules transformed.
rendering chunks...
computing gzip size...
dist-pack/pack.html                 1.26 kB │ gzip:  0.66 kB
dist-pack/assets/pack-D-5CiZAF.js  38.05 kB │ gzip: 14.34 kB

✓ built in 31ms
dynawalla.colossus@0.1.0 — COLOSSUS
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 40398 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

### `gitleaks`

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~22420 bytes (22.42 KB) in 88.5ms
INF no leaks found
```

### Scope

```
$ git diff --name-only origin/main...HEAD
dynawalla/games/colossus/src/mount.ts
dynawalla/games/colossus/src/render/layout.ts
dynawalla/games/colossus/src/render/scene.ts
dynawalla/games/colossus/src/test/layout.test.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
