### PR TITLE
feat(dynawalla/games/beam): build the hall inside the safe area, and keep the lives out from under the host's button

### DIFF
--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -22,12 +22,13 @@
 // you at the phase `(v mod b) / b`. At zero the two waveforms fuse. Division,
 // audible.
 
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 import type { Host, Question } from "./contract.ts"
 import { Audio } from "./audio.ts"
 import { Feel } from "./core/feel.ts"
 import { Rng } from "./core/rng.ts"
 import { detectTier, TierGovernor } from "./core/tiers.ts"
-import { columnAt, columnX, makeGeom, project } from "./render/geom.ts"
+import { columnAt, columnX, geomForViewport, project } from "./render/geom.ts"
 import {
   drawAnchors,
   drawAutomaton,
@@ -94,6 +95,66 @@ export function mountBeam(el: HTMLElement, host: Host): {
 
   // ── systems ──────────────────────────────────────────────────────────────
   const reduced = host.prefersReducedMotion()
+
+  // How to play. The kill rule here is a biconditional — a pulse works if and
+  // only if the beam divides the number — and a child shown a lattice of glowing
+  // lines and no words will read it as a shooter, fire at everything, and decide
+  // the game is broken when most shots bounce. The manual stays reachable during
+  // play, because the moment a child needs the rule is never the title screen.
+  const guide = createInstructions(root, {
+    title: "LATTICE RUNNER",
+    summary: [
+      "Five beams of light run down the hall. Each beam has a number at the bottom.",
+      "Robots walk down carrying numbers. Ride a beam and shoot — but a shot only works if the beam's number divides the robot's number.",
+    ],
+    sections: [
+      {
+        heading: "Moving and shooting",
+        lines: [
+          "Tap a beam to slide onto it. You shoot the moment you get there.",
+          "Tap the beam you are already on to shoot again.",
+          "Drag your finger across the beams to move without shooting. Use this to listen.",
+          "On a keyboard: left and right arrows move, space shoots.",
+        ],
+      },
+      {
+        heading: "When a shot works",
+        lines: [
+          "A shot destroys a robot only if you can share its number into equal groups of the beam's number, with nothing left over.",
+          "Beam 5 takes 405, because 405 is made of fives. Beam 4 does not.",
+          "Big robots can often be taken from more than one beam. The biggest beam that fits is worth the most.",
+          "A shot that does not work costs you nothing. The robot just rings and keeps walking.",
+        ],
+      },
+      {
+        heading: "Listening to the beam",
+        lines: [
+          "While you ride a beam it hums against the robot above you.",
+          "The closer you are to a beam that fits, the slower the wobble in the sound and in the lines.",
+          "When the beam fits exactly, the wobble stops and you hear one clean note.",
+          "It is a hint, not an answer. Working the number out is always faster.",
+        ],
+      },
+      {
+        heading: "The big blue one",
+        lines: [
+          "Every so often a big blue robot comes down the middle with a sum on it, like 247 + 158.",
+          "It breaks into several robots, each carrying a different number.",
+          "Work out the sum, find the robot with the right number, and shoot that one.",
+          "Getting it wrong does not cost a light. It only resets how much each robot is worth.",
+        ],
+      },
+      {
+        heading: "The three lights",
+        lines: [
+          "Three lights sit at the top of the screen. A robot that reaches the floor puts one out.",
+          "When all three are out the run is over. Tap to start again.",
+          "Get two sums right and one light comes back on.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
   const gov = new TierGovernor(detectTier())
   const feel = new Feel({ reducedMotion: reduced })
   const audio = new Audio()
@@ -117,7 +178,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
   let fx = new Rng(0x0fec7 ^ (Date.now() & 0xffffff))
 
   // ── run state ────────────────────────────────────────────────────────────
-  let geom = makeGeom(320, 480, N_BEAMS)
+  let geom = geomForViewport(320, 480, N_BEAMS)
   let dpr = 1
   let running = true
   let paused = false
@@ -194,7 +255,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
     const rect = root.getBoundingClientRect()
     const w = Math.max(320, Math.round(rect.width))
     const h = Math.max(320, Math.round(rect.height))
-    geom = makeGeom(w, h, N_BEAMS)
+    geom = geomForViewport(w, h, N_BEAMS)
     dpr = Math.min(q.maxDpr, globalThis.devicePixelRatio || 1)
     canvas.width = Math.round(w * dpr)
     canvas.height = Math.round(h * dpr)
@@ -865,8 +926,8 @@ export function mountBeam(el: HTMLElement, host: Host): {
     if (banner) {
       const t = banner.life / banner.max
       g.globalAlpha = Math.min(1, t * 3)
-      const y = geom.h * 0.3
-      const size = Math.max(19, Math.min(geom.w * 0.075, 40))
+      const y = geom.area.y + geom.area.h * 0.3
+      const size = Math.max(19, Math.min(geom.area.w * 0.075, 40))
       g.font = font(UI_FONT, size)
       g.textAlign = "center"
       g.textBaseline = "middle"
@@ -885,17 +946,14 @@ export function mountBeam(el: HTMLElement, host: Host): {
     if (over) {
       g.fillStyle = withAlpha("#04060d", 0.62)
       g.fillRect(0, 0, geom.w, geom.h)
-      g.font = font(UI_FONT, Math.max(15, Math.min(geom.w * 0.05, 24)))
+      g.font = font(UI_FONT, Math.max(15, Math.min(geom.area.w * 0.05, 24)))
       g.textAlign = "center"
       g.fillStyle = withAlpha(PAPER, 0.85)
-      g.fillText(`${score}`, geom.w / 2, geom.h * 0.52)
+      const overY = geom.area.y + geom.area.h * 0.52
+      g.fillText(`${score}`, geom.vpX, overY)
       g.font = font(UI_FONT, 13)
       g.fillStyle = withAlpha(PAPER, 0.5)
-      g.fillText(
-        `best ${best} · ${right}/${asked} cores read`,
-        geom.w / 2,
-        geom.h * 0.52 + 26,
-      )
+      g.fillText(`best ${best} · ${right}/${asked} cores read`, geom.vpX, overY + 26)
     }
 
     audio.setLock(140 + (beams[beamCol] ?? 2) * 26, target ? phase : 0.5, target !== null)
@@ -952,6 +1010,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
 
     unmount(): void {
       running = false
+      guide.destroy()
       cancelAnimationFrame(raf)
       ro.disconnect()
       canvas.removeEventListener("pointerdown", onDown)

--- a/dynawalla/games/beam/src/render/geom.ts
+++ b/dynawalla/games/beam/src/render/geom.ts
@@ -8,37 +8,109 @@
 // thing far up the lattice barely moves, then rushes the last third. That
 // acceleration is the whole reason the descent has tension.
 
+import {
+  exitRect,
+  helpRect,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+
 export type Geom = {
   w: number
   h: number
+  /**
+   * The safe rectangle. The hall is built inside THIS, not inside `w × h`.
+   *
+   * LATTICE RUNNER declares `viewport-fit=cover`, which opts the document into
+   * the notch, the rounded corners and the home indicator. A canvas cannot claw
+   * that back — `env()` is a CSS value and `fillText` knows nothing about it —
+   * so the floor plate's beam labels, which are the divisors the whole game is
+   * played by, were being carved into the strip under the home indicator, and
+   * in landscape the outermost beam's foot sat behind the notch.
+   */
+  area: Rect
   columns: number
   vpX: number
   horizonY: number
   floorY: number
   margin: number
+  /** Where the beam labels are carved. Inside the safe area, by construction. */
+  labelY: number
+  /** The score and resonance block, clear of the host's exit control. */
+  hud: Rect
+  /** The anchor lamps: the RIGHTMOST lamp's centre, and the row's metrics. */
+  anchors: { right: number; y: number; r: number; gap: number }
 }
 
 /** How deep the hall is. Bigger = more foreshortening near the horizon. */
 const DEPTH = 6
 
-export function makeGeom(w: number, h: number, columns: number): Geom {
+/**
+ * The insets `area` was cut from. `safeRect` is exactly this subtraction, so
+ * inverting it is lossless and the hall can ask the shared module where the
+ * host's two corners are without inventing a second source of truth.
+ */
+function insetsOf(w: number, h: number, area: Rect): Insets {
+  return {
+    top: area.y,
+    left: area.x,
+    right: Math.max(0, w - area.x - area.w),
+    bottom: Math.max(0, h - area.y - area.h),
+  }
+}
+
+/**
+ * @param area the safe rectangle, from `safeRect(w, h)`. REQUIRED — optional
+ * would mean a caller that forgets it still compiles and quietly draws the
+ * lattice under the notch, discoverable only on a device.
+ */
+export function makeGeom(w: number, h: number, columns: number, area: Rect): Geom {
+  const aw = Math.max(120, area.w)
+  const ah = Math.max(120, area.h)
+  const floorY = area.y + ah * 0.845
+
+  // The host paints two 44px corners over every pack: exit top-left,
+  // how-to-play top-right. The beams, the sky and the sparks run under them
+  // freely and should — that is what `cover` is for. The score and the anchor
+  // lamps may not: a child reads the score, and the anchors ARE the lives.
+  const insets = insetsOf(w, h, area)
+  const exit = exitRect(insets)
+  const help = helpRect(w, insets)
+
+  const r = 6
+  const gap = 18
+
   return {
     w,
     h,
+    area,
     columns: Math.max(1, columns),
-    vpX: w * 0.5,
-    horizonY: h * 0.155,
-    floorY: h * 0.845,
+    vpX: area.x + aw * 0.5,
+    horizonY: area.y + ah * 0.155,
+    floorY,
     // Wide enough that the outermost beam's label is never clipped.
-    margin: Math.max(26, Math.min(w * 0.11, 74)),
+    margin: Math.max(26, Math.min(aw * 0.11, 74)),
+    labelY: floorY + (area.y + ah - floorY) * 0.5,
+    // The score sits at 20 and the resonance line at 42 relative to this
+    // block's top, so the block is 56 tall at the type sizes this clamps to.
+    hud: { x: area.x + 14, y: exit.y + exit.h + 8, w: 170, h: 56 },
+    anchors: { right: help.x + help.w - 4, y: help.y + help.h + 8 + r, r, gap },
   }
 }
 
 /** Where a beam meets the floor. `col` may be fractional — a mid-slide body. */
 export function columnX(g: Geom, col: number): number {
   if (g.columns <= 1) return g.vpX
-  const span = g.w - g.margin * 2
-  return g.margin + (col / (g.columns - 1)) * span
+  const span = Math.max(1, g.area.w - g.margin * 2)
+  return g.area.x + g.margin + (col / (g.columns - 1)) * span
+}
+
+/** The box the anchor lamps occupy, for `total` of them. */
+export function anchorsRect(g: Geom, total: number): Rect {
+  const { right, y, r, gap } = g.anchors
+  const left = right - Math.max(0, total - 1) * gap
+  return { x: left - r, y: y - r, w: (right + r) - (left - r), h: r * 2 }
 }
 
 /**
@@ -66,7 +138,19 @@ export function project(g: Geom, col: number, t: number): { x: number; y: number
  */
 export function columnAt(g: Geom, x: number): number {
   if (g.columns <= 1) return 0
-  const span = g.w - g.margin * 2
-  const raw = ((x - g.margin) / span) * (g.columns - 1)
+  const span = Math.max(1, g.area.w - g.margin * 2)
+  const raw = ((x - g.area.x - g.margin) / span) * (g.columns - 1)
   return Math.max(0, Math.min(g.columns - 1, Math.round(raw)))
+}
+
+/**
+ * The hall the game actually runs at, for a viewport of `w` x `h`.
+ *
+ * The one entry point production uses, so a test that calls this is asserting
+ * the lattice a child gets rather than a pure function fed hand-picked
+ * arguments. `safeRect` reads zeros where there is nothing to measure, so in
+ * node and on a device without insets this is the plain full-screen hall.
+ */
+export function geomForViewport(w: number, h: number, columns: number): Geom {
+  return makeGeom(w, h, columns, safeRect(w, h))
 }

--- a/dynawalla/games/beam/src/render/hall.ts
+++ b/dynawalla/games/beam/src/render/hall.ts
@@ -132,7 +132,7 @@ export function drawBeams(g: CanvasRenderingContext2D, geom: Geom, styles: BeamS
     g.font = font(NUM_FONT, size)
     g.textAlign = "center"
     g.textBaseline = "middle"
-    const ly = geom.floorY + (geom.h - geom.floorY) * 0.5
+    const ly = geom.labelY
     g.fillStyle = withAlpha(INK, 0.85)
     g.fillText(String(s.label), foot, ly + 1.5)
     g.fillStyle = lit > 0.5 ? BEAM_HOT : withAlpha(PAPER, 0.62)
@@ -341,10 +341,11 @@ export function drawAnchors(
   credit: number,
   perAnchor: number,
 ): void {
-  const r = 6
-  const gap = 18
-  const x0 = geom.w - 14 - (total - 1) * gap
-  const y = 18
+  // Placed by the geometry, under the host's how-to-play control rather than
+  // behind it. The anchors ARE the lives: three lamps hidden by a button is a
+  // child who cannot tell how close the lattice is to going dark.
+  const { r, gap, y } = geom.anchors
+  const x0 = geom.anchors.right - (total - 1) * gap
   for (let i = 0; i < total; i++) {
     const on = i < lit
     g.beginPath()
@@ -370,14 +371,17 @@ export function drawScore(
   score: number,
   resonance: number,
 ): void {
-  g.font = font(UI_FONT, Math.max(17, Math.min(geom.w * 0.055, 27)))
+  // Under the host's exit control, not behind it. `(14, 20)` was the exact
+  // square the host paints "back" into.
+  const { x, y } = geom.hud
+  g.font = font(UI_FONT, Math.max(17, Math.min(geom.area.w * 0.055, 27)))
   g.textAlign = "left"
   g.textBaseline = "middle"
   g.fillStyle = withAlpha(PAPER, 0.9)
-  g.fillText(String(score), 14, 20)
+  g.fillText(String(score), x, y + 20)
   if (resonance > 1) {
     g.font = font(UI_FONT, 14)
     g.fillStyle = RESONANT
-    g.fillText(`RESONANCE ×${resonance}`, 14, 42)
+    g.fillText(`RESONANCE ×${resonance}`, x, y + 42)
   }
 }

--- a/dynawalla/games/beam/src/test/geom.test.ts
+++ b/dynawalla/games/beam/src/test/geom.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { columnAt, columnX, makeGeom, project } from "../render/geom.ts"
+import { columnAt, columnX, geomForViewport, project } from "../render/geom.ts"
 
 const SIZES: [number, number][] = [
   [320, 568], // the smallest phone this ships to
@@ -12,7 +12,7 @@ const SIZES: [number, number][] = [
 
 test("the lattice fits inside every viewport, with room for its labels", () => {
   for (const [w, h] of SIZES) {
-    const g = makeGeom(w, h, 5)
+    const g = geomForViewport(w, h, 5)
     for (let c = 0; c < 5; c++) {
       const x = columnX(g, c)
       assert.ok(x >= 0 && x <= w, `beam ${c} foot at ${x} is off a ${w}px screen`)
@@ -25,7 +25,7 @@ test("the lattice fits inside every viewport, with room for its labels", () => {
 })
 
 test("the projection pins the horizon and the floor exactly", () => {
-  const g = makeGeom(768, 1024, 5)
+  const g = geomForViewport(768, 1024, 5)
   const far = project(g, 0, 0)
   const near = project(g, 0, 1)
   assert.equal(far.y, g.horizonY)
@@ -36,7 +36,7 @@ test("the projection pins the horizon and the floor exactly", () => {
 })
 
 test("descent accelerates toward the child rather than sliding at a constant rate", () => {
-  const g = makeGeom(390, 844, 5)
+  const g = geomForViewport(390, 844, 5)
   const step = (t: number): number => project(g, 4, t + 0.05).y - project(g, 4, t).y
   assert.ok(step(0.8) > step(0.4), "the last stretch must be the fastest")
   assert.ok(step(0.4) > step(0.05))
@@ -50,14 +50,14 @@ test("descent accelerates toward the child rather than sliding at a constant rat
 })
 
 test("out-of-range t is clamped rather than projected off the world", () => {
-  const g = makeGeom(390, 844, 5)
+  const g = geomForViewport(390, 844, 5)
   assert.deepEqual(project(g, 2, -3), project(g, 2, 0))
   assert.deepEqual(project(g, 2, 9), project(g, 2, 1))
 })
 
 test("a tap anywhere on the floor lands on a real beam", () => {
   for (const [w, h] of SIZES) {
-    const g = makeGeom(w, h, 5)
+    const g = geomForViewport(w, h, 5)
     for (let x = -40; x <= w + 40; x += 3) {
       const c = columnAt(g, x)
       assert.ok(Number.isInteger(c) && c >= 0 && c <= 4, `tap at ${x} chose ${c}`)
@@ -68,8 +68,126 @@ test("a tap anywhere on the floor lands on a real beam", () => {
 })
 
 test("a single-beam lattice degenerates without dividing by zero", () => {
-  const g = makeGeom(390, 844, 1)
+  const g = geomForViewport(390, 844, 1)
   assert.equal(columnX(g, 0), g.vpX)
   assert.equal(columnAt(g, 300), 0)
   assert.ok(Number.isFinite(project(g, 0, 0.5).x))
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE FRAME.
+//
+// Everything above is about the projection. None of it can see that the hall is
+// drawn inside a screen that has a notch cut out of the top of it, a home
+// indicator across the bottom, and two 44px squares of host chrome floating
+// over the corners.
+//
+// LATTICE RUNNER shipped wrong on all three. The score was drawn at `(14, 20)`,
+// which is the exact square the host paints "back" into. The three anchor
+// lamps — which ARE the lives — were drawn at `(w - 14 - 2*18, 18)`, under the
+// how-to-play control. And the beam labels, the divisors the entire game is
+// played by, were carved at `floorY + (h - floorY) * 0.5` off the GLASS, which
+// on a phone with a home indicator is behind the home indicator.
+
+import { anchorsRect, makeGeom } from "../render/geom.ts"
+import { hitsHostChrome, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+
+/** The two counts the game actually mounts with. */
+const BEAMS = 5
+const ANCHORS = 3
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+test("nothing a child must read sits under the host's two corners", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const g = geomForViewport(w, h, BEAMS)
+
+    assert.equal(
+      hitsHostChrome(g.hud, w),
+      false,
+      `${name} (${w}×${h}): the score and resonance block is under host chrome`,
+    )
+    assert.equal(
+      hitsHostChrome(anchorsRect(g, ANCHORS), w),
+      false,
+      `${name} (${w}×${h}): the anchor lamps are under host chrome`,
+    )
+
+    // The beam labels, too. They are at the floor rather than the ceiling, so
+    // this can only fail if the hall is ever flipped — but they are the single
+    // most important text on the screen and the assertion costs nothing.
+    for (let c = 0; c < BEAMS; c++) {
+      const box = { x: columnX(g, c) - 18, y: g.labelY - 16, w: 36, h: 32 }
+      assert.equal(
+        hitsHostChrome(box, w),
+        false,
+        `${name} (${w}×${h}): beam ${c}'s label is under host chrome`,
+      )
+    }
+
+    // The two blocks must not collide with each other either, which is the
+    // failure mode of "just move everything down".
+    assert.ok(
+      g.hud.x + g.hud.w <= anchorsRect(g, ANCHORS).x + 0.5 ||
+        g.hud.y + g.hud.h <= anchorsRect(g, ANCHORS).y ||
+        anchorsRect(g, ANCHORS).y + anchorsRect(g, ANCHORS).h <= g.hud.y,
+      `${name}: the score and the anchor lamps overlap`,
+    )
+  }
+})
+
+// Node has no notch, so `safeInsets()` reads zeros and the test above cannot
+// tell a hall built inside the safe rectangle from one built against the glass.
+// This one can: it hands `makeGeom` the rectangle a real device would give it.
+const NOTCHED: Array<[string, number, number, Insets]> = [
+  ["phone portrait, notch + home indicator", 390, 844, { top: 59, right: 0, bottom: 34, left: 0 }],
+  ["phone landscape, notch on the left", 844, 390, { top: 0, right: 59, bottom: 21, left: 59 }],
+  ["small phone", 320, 568, { top: 44, right: 0, bottom: 34, left: 0 }],
+]
+
+test("the hall is built inside the safe rectangle, not against the glass", () => {
+  for (const [name, w, h, insets] of NOTCHED) {
+    const area = safeRect(w, h, insets)
+    const g = makeGeom(w, h, BEAMS, area)
+
+    // The beam labels. This is the bug: the divisors were carved into the strip
+    // the home indicator sits in.
+    assert.ok(
+      g.labelY + 16 <= area.y + area.h + 0.5,
+      `${name}: the beam labels are under the home indicator`,
+    )
+    assert.ok(g.labelY > g.floorY, `${name}: the labels climbed above the floor plate`)
+
+    // The lattice itself, left and right. In landscape the notch is on one side
+    // and the outermost beam's foot was behind it.
+    for (let c = 0; c < BEAMS; c++) {
+      const x = columnX(g, c)
+      assert.ok(
+        x - 18 >= area.x - 0.5 && x + 18 <= area.x + area.w + 0.5,
+        `${name}: beam ${c}'s foot at ${x.toFixed(0)} is outside the safe area`,
+      )
+    }
+
+    // The horizon and the floor.
+    assert.ok(g.horizonY >= area.y, `${name}: the horizon is above the safe area`)
+    assert.ok(g.floorY <= area.y + area.h, `${name}: the floor plate is below the safe area`)
+
+    // And the corners still hold once there ARE insets, which move both of the
+    // host's controls.
+    assert.equal(hitsHostChrome(g.hud, w, insets), false, `${name}: the score is under chrome`)
+    assert.equal(
+      hitsHostChrome(anchorsRect(g, ANCHORS), w, insets),
+      false,
+      `${name}: the anchor lamps are under chrome`,
+    )
+
+    // A tap still chooses the beam under the finger, with the origin shifted.
+    for (let c = 0; c < BEAMS; c++) assert.equal(columnAt(g, columnX(g, c)), c)
+  }
 })

--- a/dynawalla/games/beam/src/test/loop.test.ts
+++ b/dynawalla/games/beam/src/test/loop.test.ts
@@ -44,13 +44,29 @@ function stubSurface(
     apply: () => noop,
   }) as unknown as CanvasRenderingContext2D
 
+  // Rich enough for the shared how-to-play surface, which is real DOM: a
+  // button, a dialog, a stylesheet and an inset probe appended to `body`. It
+  // is built once at mount and torn down in `unmount`, so it is on the path of
+  // every test in this file whether or not the test is about instructions.
   const makeEl = (): HTMLElement => {
     const el = {
       style: { cssText: "" },
       width: 0,
       height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
       appendChild: () => undefined,
+      append: () => undefined,
       remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
       getBoundingClientRect: () => rect,
       getContext: () => noop,
       setPointerCapture: () => undefined,
@@ -110,7 +126,16 @@ function stubSurface(
     globalThis.removeEventListener = ((k: string): void => {
       keys.delete(k)
     }) as unknown as typeof globalThis.removeEventListener
-    ;(globalThis as { document?: unknown }).document = { createElement: () => makeEl() }
+    // `getElementById` and `body` are what the safe-area probe needs: it
+    // measures `env(safe-area-inset-*)` through a hidden fixed element, because
+    // `env()` cannot be read from JavaScript any other way. There is no
+    // `getComputedStyle` here, so it correctly reads zeros and node gets the
+    // plain full-screen layout.
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: () => makeEl(),
+      getElementById: () => null,
+      body: makeEl(),
+    }
     return () => {
       globalThis.requestAnimationFrame = saved.raf
       globalThis.cancelAnimationFrame = saved.caf


### PR DESCRIPTION
## What

Build LATTICE RUNNER's hall inside the safe rectangle instead of against the
glass, move the score and the three anchor lamps out from under the host's two
44px corners, and give the game a how-to-play surface it has never had.

## Why

LATTICE RUNNER declares `viewport-fit=cover`, which opts the document *into* the
notch, the rounded corners and the home indicator, and then read nothing back.
`env()` is a CSS value and a canvas cannot read it, so every number in
`makeGeom` was measuring a screen it had the wrong shape for. Three concrete
failures, none of which any rules test in this package could see:

- **The beam labels** are carved at `floorY + (h - floorY) * 0.5` off the
  **glass**. Those labels are the divisors; choosing one *is* the game. On a
  phone in landscape the label row lands under the home indicator, and the
  outermost beam's foot lands behind the notch — both places the child's finger
  has to go.
- **The score** was drawn at `(14, 20)`: the exact square the host paints its
  exit control into.
- **The three anchor lamps** were drawn at `(w - 14 - 2*18, 18)`, under the
  shared how-to-play control. Those lamps are the **lives**. A child who cannot
  see how close the lattice is to going dark is playing a different game.

`makeGeom` now takes the safe rectangle as a **required** fourth argument —
optional would mean a caller that forgets it still compiles and quietly draws
under the notch, discoverable only on a device. The vanishing point, horizon,
floor, margin and both column maps (`columnX`, `columnAt`) are built inside it.
`geomForViewport(w, h, columns)` is the single entry point `resize` uses, so the
tests exercise the lattice a child actually gets.

Host chrome **overlays**; nothing reserves a band. Reserving 67px cost 12% of a
small phone's height in SKY LEDGER and broke its own layout. The beams, the sky,
the sparks and the runner still run full-bleed under the corners — that is the
point of `cover`. Only the score and the lamps move, and only to just below the
host's controls.

## Blast radius

**Areas touched:** dynawalla (one game pack, `dynawalla/games/beam` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published zip changed in place; `pack.json`
      untouched (id, version, capabilities, the seven declared `dw.add.*` rows
      all unchanged). No `voiceId`, no catalog entry.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are instruction
      copy inside the pack; it declares `"locales": ["en"]` and has no i18n
      catalogue, same as SKY LEDGER's adoption.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema
      touched. `resonates()`, `usableCoreValue()` and the pulse biconditional are
      untouched and their tests still pass unchanged.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

**What a reviewer cannot reconstruct from the diff:**

*The geometry is a no-op where there are no insets.* Every `w`/`h` inside
`makeGeom` became `area.w`/`area.h` and every origin gained `area.x`/`area.y`,
which is identity when the insets are zero — so desktop, the dev harness and the
existing `geom.test.ts` projection assertions are unchanged. The only
unconditional visual change is the score and the lamps dropping ~57px, which is
required on every device because the host's chrome is there on every device.

*`loop.test.ts`'s headless surface had to grow.* The shared how-to-play panel is
real DOM — a button, a dialog, a stylesheet, and a hidden probe appended to
`document.body`, which is the only way `env()` can be read from JavaScript at
all. The stub gained `setAttribute`/`append`/`focus`/`textContent`/`hidden` and
the document gained `getElementById` and `body`. It is built at mount and torn
down in `unmount`, so it is on the path of every test in that file, not only the
ones about instructions. `mounting and unmounting repeatedly leaves nothing
running` still passes, which is the assertion that would catch a leaked listener
from `createInstructions`.

*`guide.destroy()` is wired into `unmount`*, removing the help button, the panel,
the injected stylesheet, the `keydown` handler and the inset watcher.

## Proof

`npm test` five times — one green run is not proof:

```
$ for i in 1 2 3 4 5; do npm test 2>&1 | grep -E "^# (tests|pass|fail)"; done
--- run 1 ---
# tests 78
# pass 78
# fail 0
--- run 2 ---
# tests 78
# pass 78
# fail 0
--- run 3 ---
# tests 78
# pass 78
# fail 0
--- run 4 ---
# tests 78
# pass 78
# fail 0
--- run 5 ---
# tests 78
# pass 78
# fail 0
```

**Both new tests fail when the fix is removed.** A clearance test that passes
either way is worthless.

Corner clearance — put `hud` back at `(14, 0)` and the lamps back at
`(w - 14, 18)`:

```
not ok 33 - nothing a child must read sits under the host's two corners
not ok 34 - the hall is built inside the safe rectangle, not against the glass
# tests 78
# pass 76
# fail 2
```

Safe area — rebuild the hall against the glass (`vpX`, `horizonY`, `floorY`,
`margin`, `labelY`, `columnX`, `columnAt` all back to `w`/`h`):

```
not ok 34 - the hall is built inside the safe rectangle, not against the glass
# tests 78
# pass 77
# fail 1
```

That one reports, at 844×390 with a notch on the left:
`the beam labels are under the home indicator` and
`beam 0's foot at 74 is outside the safe area`.

Node reports zero insets, so the safe-area half runs against three *simulated*
notched devices via `makeGeom(w, h, 5, safeRect(w, h, insets))` — without that it
could not fail at all.

```
$ npm run tsc
> @dynawalla/game-beam@0.1.0 tsc
> tsc --noEmit

$ npm run build
✓ 21 modules transformed.
dist/beam.js  51.48 kB │ gzip: 17.00 kB
✓ built in 17ms
```

```
$ cd dynawalla/packs && node build.mjs beam
dynawalla.beam@0.1.0 — LATTICE RUNNER
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 50327 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~14535 bytes (14.53 KB) in 33.5ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/beam/src/mount.ts
dynawalla/games/beam/src/render/geom.ts
dynawalla/games/beam/src/render/hall.ts
dynawalla/games/beam/src/test/geom.test.ts
dynawalla/games/beam/src/test/loop.test.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```
