### PR TITLE
dynawalla/games/runner: the lane numbers are the answers, so keep them out from under the notch

### DIFF
--- a/dynawalla/games/runner/README.md
+++ b/dynawalla/games/runner/README.md
@@ -257,4 +257,22 @@ usable distractors it nudges the answer's own trailing number with exact decimal
 arithmetic: `42` gives `43` and `41`, `3/4` gives `3/5` and `3/3`. Never a float,
 never a `NaN`, never the same value in two lanes.
 
-Nothing is imported from `dynawalla/packs/shared`.
+The only thing imported from `dynawalla/packs/shared` is `game-chrome`, and the
+reason is in `src/game/chrome.ts`. `pack.html` declares `viewport-fit=cover`,
+which opts the document *into* the display cutout and the home indicator; a DOM
+rule can claw that back with `env(safe-area-inset-*)`, but the candidates are
+drawn by a shader in NDC and a shader has never heard of `env()`. Held sideways
+a phone's cutout is about 47 CSS pixels of an 844-wide viewport — five and a
+half per cent — against a page margin of three, so the outer candidate reached
+underneath it, and in this game the outer candidate is an answer. The host also
+paints an exit control in the top-left 44px corner and a how-to-play control in
+the top-right one, over the pack: the score used to sit under the first and the
+surge meter under the second.
+
+So `ndcFrame(w, h, insets)` builds the read band's frame from the measured safe
+area — a *required* argument to `readBand`, because a default is a game that
+forgets the insets, compiles clean, and is found out on a device — and the two
+corner readouts drop clear of the controls. Nothing else moves: the causeway,
+the sky and the ocean still bleed to all four edges, which is the entire point
+of `cover`. `chrome.test.ts` asserts both at five viewports in both rotations,
+and how to remove each fix and watch it fail is written at the top of that file.

--- a/dynawalla/games/runner/src/game/chrome.test.ts
+++ b/dynawalla/games/runner/src/game/chrome.test.ts
@@ -1,0 +1,237 @@
+/**
+ * The two things a phone does to this game that a browser window never does.
+ *
+ * 1. It puts a cutout and a home indicator over the glass, and `pack.html` opts
+ *    in to that with `viewport-fit=cover`. In landscape the cutout is about 47
+ *    CSS pixels of an 844-wide viewport, and the read band's page margin was a
+ *    flat 0.94 NDC — three per cent. The outer candidate, which in this game IS
+ *    an answer, therefore reached about twenty pixels underneath it.
+ * 2. The host paints an exit control top-left and a how-to-play control
+ *    top-right, over the pack. VOLTA's score was in the first corner and its
+ *    surge meter in the second.
+ *
+ * Neither is visible in `npm run dev`, both are certain on a device, and both
+ * are pure arithmetic — so they belong in a test rather than in a bug report.
+ *
+ * Removing either fix fails this file: point `ndcFrame` back at `BAND.edge` and
+ * the landscape cases below blow up, and set `READOUT_CLEAR` back to a ten-pixel
+ * margin and every `hitsHostChrome` assertion trips.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  HOST_CONTROL,
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { hudEdge, ndcFrame, readoutRect, READOUT_CLEAR } from "./chrome.ts";
+import { BAND, FULL_FRAME, payoffEdge, popupEdge, readBand } from "./readband.ts";
+import { INK, TRACK } from "./glyphs.ts";
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+/** A tall phone: cutout at the top, home indicator at the bottom. */
+const PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+/** The same phone on its side: the cutout becomes a side inset, on both sides. */
+const LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+/**
+ * The viewports the fleet actually has, smallest first.
+ *
+ * 320x568 is here because it is where reserving a band instead of overlaying one
+ * broke a sibling game outright, and because it is the shape everything else is
+ * tuned away from.
+ */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+/**
+ * The insets a given viewport can actually have.
+ *
+ * Paired with the orientation rather than crossed with it: a 320-wide portrait
+ * phone never has 47 pixels of cutout down each side, and asserting against
+ * shapes no device produces only tempts the fix into clamping the safe area
+ * away to make an imaginary case pass.
+ */
+function insetsFor(w: number, h: number): Array<[string, Insets]> {
+  return [
+    ["no insets", NONE],
+    w > h ? ["cutout at the side", LANDSCAPE] : ["cutout at the top", PORTRAIT],
+  ];
+}
+
+
+
+/* -------------------------------------------------------------------------- */
+/* The host's two corners.                                                    */
+/* -------------------------------------------------------------------------- */
+
+test("the score and the surge meter are clear of the host's controls", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      for (const side of ["left", "right"] as const) {
+        const r = readoutRect(side, w, insets);
+        assert.equal(
+          hitsHostChrome(r, w, insets),
+          false,
+          `${name} (${w}x${h}), ${label}: the ${side} readout is under the host's chrome`,
+        );
+        assert.ok(r.y + r.h <= h, `${name}: the ${side} readout runs off the bottom`);
+      }
+    }
+  }
+});
+
+test("the readouts stay inside the safe area they were given", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const safe = safeRect(w, h, insets);
+      const left = readoutRect("left", w, insets);
+      const right = readoutRect("right", w, insets);
+      assert.ok(left.x >= safe.x, `${name}, ${label}: the score is inside the left inset`);
+      assert.ok(
+        right.x + right.w <= safe.x + safe.w + 1e-9,
+        `${name}, ${label}: the surge meter is inside the right inset`,
+      );
+      assert.ok(left.y >= safe.y, `${name}, ${label}: the score is under the top inset`);
+    }
+  }
+});
+
+test("dropping the readouts clears the control and no more", () => {
+  // A promise about two 44px squares, not a reserved band. If this number ever
+  // grows into a real strip, that is the trade the sibling game's lattice
+  // already showed to be wrong, and it should fail here first.
+  assert.ok(READOUT_CLEAR >= HOST_CONTROL, "the readouts do not clear the control at all");
+  assert.ok(READOUT_CLEAR <= HOST_CONTROL + 24, `READOUT_CLEAR is ${READOUT_CLEAR}px — that is a band`);
+});
+
+test("the HUD margin matches the clamp the stylesheet resolves to", () => {
+  assert.equal(hudEdge(320), 10);
+  assert.equal(hudEdge(2000), 26);
+  assert.ok(Math.abs(hudEdge(800) - 800 * 0.022) < 1e-9);
+});
+
+/* -------------------------------------------------------------------------- */
+/* The safe area, in NDC, where the answers are drawn.                        */
+/* -------------------------------------------------------------------------- */
+
+/** NDC x -> CSS pixels from the left edge. */
+const ndcToPx = (x: number, w: number): number => ((x + 1) / 2) * w;
+/** NDC y (up) -> CSS pixels from the top edge. */
+const ndcYToPx = (y: number, h: number): number => ((1 - y) / 2) * h;
+
+test("with no insets the frame is exactly the margins the game always had", () => {
+  const f = ndcFrame(390, 844, NONE);
+  assert.equal(f.edge, BAND.edge);
+  assert.equal(f.top, BAND.top);
+  assert.equal(f.bottom, BAND.bottom);
+  assert.deepEqual(f, FULL_FRAME);
+});
+
+test("a side cutout pulls the page margin in, so the outer answer stays visible", () => {
+  const f = ndcFrame(844, 390, LANDSCAPE);
+  assert.ok(f.edge < BAND.edge, "the frame ignored a 47px side cutout");
+  // The margin lands exactly on the safe edge, not somewhere near it.
+  assert.ok(Math.abs(ndcToPx(f.edge, 844) - (844 - 47)) < 1e-9);
+});
+
+/* The camera, mirrored from `mount.ts` so the numbers are the real ones. */
+const CAM_Z = 11.4;
+function scales(w: number, h: number, fovDeg: number, dist: number): { kx: number; ky: number } {
+  const ky = 1 / Math.tan((fovDeg * Math.PI) / 360) / (dist + CAM_Z);
+  return { kx: ky / (w / h), ky };
+}
+/** World width of a numeral at ink height 1, for `digits` digits. */
+const unit = (digits: number, advance: number): number => digits * advance * (1 / INK) * TRACK;
+
+test("no answer is ever drawn under the cutout, at any viewport or rotation", () => {
+  // This is the assertion the whole file exists for. The three candidates are
+  // the answer UI — there is no keypad and no button — so a numeral the cutout
+  // eats is not a cosmetic problem, it is a question with a missing option.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const frame = ndcFrame(w, h, insets);
+      const safe = safeRect(w, h, insets);
+      for (const fov of [58, 74, 104]) {
+        for (const dist of [4, 30, 90, 240]) {
+          const { kx, ky } = scales(w, h, fov, dist);
+          for (const adv of [0.36, 0.43, 0.5]) {
+            for (const n of [1, 2, 3, 4]) {
+              const u = unit(n, adv);
+              for (const approach of [0, 0.5, 1]) {
+                for (const archTop of [-0.4, 0.2, 1.4]) {
+                  const band = readBand([u, u, u], kx, ky, approach, archTop, frame);
+                  const ctx = `${name} ${label} fov${fov} d${dist} adv${adv} n${n} a${approach}`;
+
+                  const leftPx = ndcToPx(band.x[0] - band.wNdc / 2, w);
+                  const rightPx = ndcToPx(band.x[2] + band.wNdc / 2, w);
+                  assert.ok(leftPx >= safe.x - 1e-6, `${ctx}: left answer is ${leftPx.toFixed(1)}px, inside the left inset`);
+                  assert.ok(
+                    rightPx <= safe.x + safe.w + 1e-6,
+                    `${ctx}: right answer reaches ${rightPx.toFixed(1)}px of a safe area ending at ${(safe.x + safe.w).toFixed(1)}px`,
+                  );
+
+                  const topPx = ndcYToPx(band.y + band.hNdc / 2, h);
+                  const botPx = ndcYToPx(band.y - band.hNdc / 2, h);
+                  assert.ok(topPx >= safe.y - 1e-6, `${ctx}: the row rises into the top inset`);
+                  assert.ok(botPx <= safe.y + safe.h + 1e-6, `${ctx}: the row sinks into the bottom inset`);
+
+                  // And the row is never under a host control either.
+                  assert.equal(
+                    hitsHostChrome(
+                      { x: leftPx, y: topPx, w: rightPx - leftPx, h: botPx - topPx },
+                      w,
+                      insets,
+                    ),
+                    false,
+                    `${ctx}: the answer row is under the host's chrome`,
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+});
+
+test("the answers are still large enough to read once the cutout is respected", () => {
+  // Pulling the margin in costs width, and width is what a three-digit answer on
+  // a small screen is made of. If honouring the safe area ever shrinks a numeral
+  // below what a child can read at speed, the fix has broken the game it was
+  // protecting, and that is worse than the bug.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const frame = ndcFrame(w, h, insets);
+      const { kx, ky } = scales(w, h, 74, 90);
+      const u = unit(3, 0.5);
+      const band = readBand([u, u, u], kx, ky, 0, 0.1, frame);
+      const capPx = (band.hNdc / 2) * h;
+      const gutterPx = ((band.pitch - band.wNdc) / 2) * w;
+      assert.ok(capPx >= 24, `${name}, ${label}: three digits render at ${capPx.toFixed(1)}px cap height`);
+      assert.ok(gutterPx >= 12, `${name}, ${label}: only ${gutterPx.toFixed(1)}px of clear air between answers`);
+    }
+  }
+});
+
+test("the payoff and the score popups honour the same frame", () => {
+  for (const [, w, h] of VIEWPORTS) {
+    for (const [, insets] of insetsFor(w, h)) {
+      const f = ndcFrame(w, h, insets);
+      assert.ok(payoffEdge(f.edge) < f.edge, "the payoff margin is not inside the frame");
+      assert.ok(popupEdge(f.edge) < f.edge, "the popup margin is not inside the frame");
+      assert.ok(ndcToPx(payoffEdge(f.edge), w) <= w - insets.right, "the payoff can reach the cutout");
+      assert.ok(ndcToPx(popupEdge(f.edge), w) <= w - insets.right, "a popup can reach the cutout");
+      assert.ok(h > 0);
+    }
+  }
+});

--- a/dynawalla/games/runner/src/game/chrome.ts
+++ b/dynawalla/games/runner/src/game/chrome.ts
@@ -1,0 +1,106 @@
+/**
+ * Where VOLTA is allowed to put things a child has to read or touch.
+ *
+ * Two separate encroachments, both invisible in a browser window and both
+ * certain on a device:
+ *
+ * **The safe area.** `pack.html` declares `viewport-fit=cover`, which is not a
+ * neutral setting — it opts the document *into* the display cutout, the home
+ * indicator and the rounded corners. A DOM rule can claw that back with
+ * `env(safe-area-inset-*)`; the causeway cannot, because the numerals are drawn
+ * by a shader in NDC and a shader has never heard of `env()`. Held sideways, a
+ * phone's cutout is about 47 CSS pixels of an 844-wide viewport — five and a
+ * half per cent — while the read band's page margin was a flat three per cent.
+ * The outer candidate therefore reached roughly twenty pixels into the cutout.
+ * In this game the outer candidate is an answer.
+ *
+ * **The host's chrome.** The app paints an exit control top-left, a how-to-play
+ * control top-right, and a progress hairline across the top, over the pack.
+ * VOLTA put its score in one of those corners and its surge meter in the other,
+ * so both readouts shipped underneath a button.
+ *
+ * The chrome *overlays* — it does not reserve a band, and this file must not
+ * pretend it does. The causeway, the sky and the ocean still bleed to all four
+ * edges; that is the entire point of `cover`. Only the readouts move.
+ */
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { BAND, type Frame } from "./readband.ts";
+
+/** Clear air between the bottom of a host control and the readout under it. */
+const GAP = 6;
+
+/**
+ * How far below the top safe edge a corner readout starts.
+ *
+ * The hairline, the control's own margin, the control, and a gap. Derived from
+ * the shared constants rather than typed out, so if the host moves its chrome
+ * VOLTA follows on the next build instead of drifting.
+ */
+export const READOUT_CLEAR = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + GAP;
+
+/** The HUD's own side margin, mirroring `clamp(10px, 2.2vw, 26px)` in the CSS. */
+export function hudEdge(w: number): number {
+  return Math.min(26, Math.max(10, w * 0.022));
+}
+
+/**
+ * The widest and tallest a corner readout gets.
+ *
+ * Generous on purpose: the score stack is a label, a number at up to
+ * `clamp(24px, 5.4vw, 48px)` and a distance line, and the surge stack is a
+ * label, a multiplier and three pips. Nothing here has to be exact, because the
+ * readout hugs its own side of the screen and so does the control above it —
+ * what the clearance turns on is entirely the vertical offset.
+ */
+const READOUT_W = 150;
+const READOUT_H = 110;
+
+/**
+ * The box a top-corner readout occupies: `left` is the score, `right` the surge.
+ *
+ * This is what the CSS in `hud.ts` resolves to, expressed as arithmetic so a
+ * test can assert it against `hitsHostChrome` at every viewport instead of
+ * finding out on a device.
+ */
+export function readoutRect(side: "left" | "right", w: number, insets: Insets): Rect {
+  const m = hudEdge(w);
+  const x =
+    side === "left"
+      ? insets.left + m
+      : Math.max(0, w - insets.right - m - READOUT_W);
+  return { x, y: insets.top + READOUT_CLEAR, w: READOUT_W, h: READOUT_H };
+}
+
+/**
+ * The NDC rectangle the numeral row may occupy on a `w`x`h` surface.
+ *
+ * NDC runs -1..+1 with y up, so a CSS-pixel inset of `i` on a surface of size
+ * `s` is `2i/s` of NDC. The sides take the larger of the two insets because the
+ * row is symmetric about the centre — three candidates at `-pitch, 0, +pitch`
+ * cannot be lopsided without the middle one ceasing to be the middle one.
+ */
+export function ndcFrame(w: number, h: number, insets: Insets): Frame {
+  const vw = Math.max(1, w);
+  const vh = Math.max(1, h);
+  const side = Math.max(insets.left, insets.right);
+
+  const edge = Math.max(0.2, Math.min(BAND.edge, 1 - (2 * side) / vw));
+  const bottom = Math.max(BAND.bottom, -1 + (2 * insets.bottom) / vh);
+  // The top is bounded by the prompt, by the safe area, and by the host's two
+  // controls. The controls only bite on a surface short enough that a twelfth
+  // of it reaches down past the prompt line — but that is exactly the surface
+  // nobody tests on.
+  const top = Math.max(
+    bottom + 0.02,
+    Math.min(BAND.top, 1 - (2 * (insets.top + READOUT_CLEAR)) / vh),
+  );
+
+  return { edge, top, bottom };
+}

--- a/dynawalla/games/runner/src/game/entities.ts
+++ b/dynawalla/games/runner/src/game/entities.ts
@@ -4,7 +4,7 @@ import type { DigitField } from "./digits.ts";
 import type { Rng } from "./rng.ts";
 import type { Projector } from "./project.ts";
 import { LANE_W, DECK_HALF } from "./world.ts";
-import { readBand, payoffHeight, keepInside } from "./readband.ts";
+import { readBand, payoffHeight, keepInside, payoffEdge, popupEdge, type Frame } from "./readband.ts";
 import { laneOptions } from "./options.ts";
 import { clamp01, easeOutBack, easeOutCubic, easeOutQuint } from "./juice.ts";
 
@@ -241,6 +241,7 @@ export class Entities {
     ink: readonly [number, number, number],
     time: number,
     revealed: boolean,
+    frame: Frame,
   ): void {
     for (const g of this.gates) {
       if (!g.active) continue;
@@ -289,8 +290,8 @@ export class Entities {
       // The numerals. See `readband.ts` — they are laid out in screen units and
       // converted back to world space, because perspective is the wrong tool for
       // typesetting three values a child has half a second to compare.
-      if (resolving) this.drawPayoff(g, digits, glow, proj, good, bad, hot, bt);
-      else this.drawCandidates(g, digits, glow, proj, ink, ac, H);
+      if (resolving) this.drawPayoff(g, digits, glow, proj, good, bad, hot, bt, frame);
+      else this.drawCandidates(g, digits, glow, proj, ink, ac, H, frame);
 
       // The overhead beam that says "this is the answer line".
       const beamA = resolving ? Math.max(0, 1 - bt * 2) : intro * 0.85;
@@ -315,6 +316,7 @@ export class Entities {
     ink: readonly [number, number, number],
     ac: readonly [number, number, number],
     H: number,
+    frame: Frame,
   ): void {
     const dist = Math.max(0, -g.z);
     const approach = clamp01(1 - dist / Math.max(1, g.spawn));
@@ -324,9 +326,9 @@ export class Entities {
     const archTop = proj.ndcY(H);
     for (let i = 0; i < 3; i++) u[i] = Math.max(1e-4, digits.measure(g.values[i], 1));
 
-    let band = readBand(u, proj.kx, proj.ky, approach, archTop);
+    let band = readBand(u, proj.kx, proj.ky, approach, archTop, frame);
     proj.at(g.z, proj.worldY(band.y));
-    band = readBand(u, proj.kx, proj.ky, approach, archTop);
+    band = readBand(u, proj.kx, proj.ky, approach, archTop, frame);
 
     // The row is dealt outward from the vanishing point as the gate resolves out
     // of the fog. Overshoot is deliberate — `readBand` keeps a 30% gutter, so a
@@ -387,6 +389,7 @@ export class Entities {
     bad: readonly [number, number, number],
     hot: readonly [number, number, number],
     bt: number,
+    frame: Frame,
   ): void {
     const CZ = -14;
     proj.at(CZ, 3);
@@ -419,7 +422,7 @@ export class Entities {
       // How big the winning numeral is allowed to get. See `payoffHeight` —
       // like the candidate row, it is decided in screen units and converted back.
       const wPerH = digits.measure(g.values[right], 1) * (Math.abs(proj.kx) / Math.abs(proj.ky));
-      const hn = payoffHeight(wPerH, g.ndcH, swell);
+      const hn = payoffHeight(wPerH, g.ndcH, swell, payoffEdge(frame.edge));
       const x = proj.worldX(g.ndcX[right] * (1 - rush));
       const y = proj.worldY(g.ndcY + (0.02 - g.ndcY) * rush);
       digits.addNumber(
@@ -491,7 +494,7 @@ export class Entities {
    * back inside the frame in screen units — it keeps its lane as long as the
    * lane fits, and gives that up rather than be unreadable.
    */
-  drawPopups(digits: DigitField, proj: Projector): void {
+  drawPopups(digits: DigitField, proj: Projector, frame: Frame): void {
     for (const p of this.popups) {
       if (!p.active) continue;
       const t = p.t / p.life;
@@ -504,7 +507,7 @@ export class Entities {
       proj.at(p.z, y);
       const halfW = (digits.measure(p.text, size) * Math.abs(proj.kx)) / 2;
       const nx = proj.x0 + proj.kx * p.x;
-      const inside = keepInside(nx, halfW);
+      const inside = keepInside(nx, halfW, popupEdge(frame.edge));
       const x = inside === nx ? p.x : proj.worldX(inside);
 
       digits.addNumber(p.text, x, y, p.z, size, p.r, p.g, p.b, a, 1.6);

--- a/dynawalla/games/runner/src/game/hud.ts
+++ b/dynawalla/games/runner/src/game/hud.ts
@@ -13,6 +13,25 @@
  * reads as a worksheet or a settings app.
  */
 
+import { READOUT_CLEAR } from "./chrome.ts";
+
+/**
+ * The safe-area insets, as CSS values.
+ *
+ * `viewport-fit=cover` puts this document under the cutout and the home
+ * indicator on purpose — the causeway and the ocean should reach the physical
+ * edge of the glass. The HUD should not: a voltage bar under the home indicator
+ * is a voltage bar with a white pill through it, and a score under the cutout is
+ * a score nobody can read.
+ */
+const SA_T = "env(safe-area-inset-top, 0px)";
+const SA_R = "env(safe-area-inset-right, 0px)";
+const SA_B = "env(safe-area-inset-bottom, 0px)";
+const SA_L = "env(safe-area-inset-left, 0px)";
+
+/** The HUD's own margin from the safe edge. */
+const M = "clamp(10px,2.2vw,26px)";
+
 const CSS = `
 .vt-root { position:absolute; inset:0; pointer-events:none; overflow:hidden;
   font-family:"Archivo Black","Helvetica Neue","Arial Black","Segoe UI",system-ui,sans-serif;
@@ -22,7 +41,7 @@ const CSS = `
 .vt-num { font-variant-numeric:tabular-nums; letter-spacing:0.01em; }
 
 /* ---- prompt ---- */
-.vt-prompt { position:absolute; left:50%; top:15%; transform:translate(-50%,0);
+.vt-prompt { position:absolute; left:50%; top:max(15%, calc(${SA_T} + 8px)); transform:translate(-50%,0);
   display:flex; align-items:center; gap:clamp(8px,2.2vw,18px); white-space:nowrap; }
 .vt-prompt-bar { width:clamp(10px,3vw,26px); height:clamp(3px,0.7vw,5px); background:currentColor;
   opacity:0.55; }
@@ -33,8 +52,12 @@ const CSS = `
 @keyframes vt-punch { 0%{transform:scale(1.55);opacity:0.25;} 45%{transform:scale(0.94);opacity:1;} 100%{transform:scale(1);} }
 
 /* ---- corners ---- */
-.vt-tl { position:absolute; left:clamp(10px,2.2vw,26px); top:clamp(10px,2.2vw,24px); }
-.vt-tr { position:absolute; right:clamp(10px,2.2vw,26px); top:clamp(10px,2.2vw,24px); text-align:right; }
+/* The host paints an exit control in the top-LEFT 44px corner and a
+   how-to-play control in the top-RIGHT one, over this pack. The score used
+   to sit under the first and the surge meter under the second. They drop
+   clear of both — the readouts move, the world behind them does not. */
+.vt-tl { position:absolute; left:calc(${SA_L} + ${M}); top:calc(${SA_T} + ${READOUT_CLEAR}px); }
+.vt-tr { position:absolute; right:calc(${SA_R} + ${M}); top:calc(${SA_T} + ${READOUT_CLEAR}px); text-align:right; }
 .vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; opacity:0.5; }
 /* Tracking adds a trailing space after the last letter, which right-aligned
    text pushes off a narrow screen. Pull it back. */
@@ -58,8 +81,8 @@ const CSS = `
 @keyframes vt-clean { 0%{transform:scaleY(3.4); opacity:1;} 100%{transform:scaleY(1);} }
 
 /* ---- voltage ---- */
-.vt-volt { position:absolute; left:clamp(10px,2.2vw,26px); right:clamp(10px,2.2vw,26px);
-  bottom:clamp(12px,2.6vw,28px); height:clamp(9px,1.8vw,15px);
+.vt-volt { position:absolute; left:calc(${SA_L} + ${M}); right:calc(${SA_R} + ${M});
+  bottom:calc(${SA_B} + clamp(12px,2.6vw,28px)); height:clamp(9px,1.8vw,15px);
   border:2px solid rgba(255,255,255,0.30); display:flex; align-items:stretch; padding:2px; }
 .vt-volt-fill { height:100%; width:100%; transform-origin:0 50%; transition:none;
   box-shadow:0 0 18px currentColor; background:currentColor; }
@@ -87,7 +110,9 @@ const CSS = `
 
 /* ---- overlays ---- */
 .vt-veil { position:absolute; inset:0; display:none; flex-direction:column; align-items:center;
-  justify-content:center; pointer-events:auto; padding:clamp(14px,4vw,40px);
+  justify-content:center; pointer-events:auto;
+  padding:calc(${SA_T} + clamp(14px,4vw,40px)) calc(${SA_R} + clamp(14px,4vw,40px))
+          calc(${SA_B} + clamp(14px,4vw,40px)) calc(${SA_L} + clamp(14px,4vw,40px));
   background:radial-gradient(ellipse at 50% 45%, rgba(2,4,12,0.55) 0%, rgba(2,4,12,0.93) 72%); }
 .vt-veil.vt-on { display:flex; }
 .vt-title { font-size:clamp(38px,12vw,110px); line-height:0.86; letter-spacing:0.04em;
@@ -116,7 +141,7 @@ const CSS = `
     linear-gradient(180deg, rgba(3,7,18,0.82) 0%, rgba(3,7,18,0.16) 26%,
                             rgba(3,7,18,0.16) 52%, rgba(3,7,18,0.88) 82%),
     radial-gradient(ellipse at 50% 42%, rgba(0,0,0,0) 40%, rgba(2,5,14,0.55) 100%);
-  justify-content:flex-end; padding-bottom:clamp(20px,5vh,54px); }
+  justify-content:flex-end; padding-bottom:calc(${SA_B} + clamp(20px,5vh,54px)); }
 /* A charge front sweeping up the screen. Slow, wide, low-contrast: energy, not
    a strobe — 4.2s per pass is far under any flash threshold. */
 .vt-veil[data-v="revive"]::before { content:""; position:absolute; left:0; right:0; height:36%;
@@ -166,7 +191,7 @@ const CSS = `
 .vt-stat i { display:block; font-style:normal; font-size:clamp(8px,1.6vw,11px); letter-spacing:0.26em; opacity:0.5; margin-top:5px; }
 
 /* ---- settings ---- */
-.vt-tools { position:absolute; right:clamp(10px,2.2vw,26px); bottom:clamp(34px,6vw,58px);
+.vt-tools { position:absolute; right:calc(${SA_R} + ${M}); bottom:calc(${SA_B} + clamp(34px,6vw,58px));
   display:flex; gap:6px; pointer-events:auto; }
 .vt-tool { width:clamp(30px,6vw,40px); height:clamp(30px,6vw,40px); border:2px solid rgba(255,255,255,0.28);
   background:rgba(2,5,14,0.55); color:inherit; font:inherit; font-size:clamp(11px,2.2vw,14px);
@@ -174,7 +199,7 @@ const CSS = `
 .vt-tool[aria-pressed="true"] { background:currentColor; }
 .vt-tool[aria-pressed="true"] span { color:#04060f; }
 .vt-tool:focus-visible { outline:3px solid #fff; outline-offset:2px; }
-.vt-perf { position:absolute; left:clamp(10px,2.2vw,26px); bottom:clamp(58px,10vw,96px);
+.vt-perf { position:absolute; left:calc(${SA_L} + ${M}); bottom:calc(${SA_B} + clamp(58px,10vw,96px));
   font-size:11px; letter-spacing:0.1em; opacity:0.6; white-space:pre; display:none;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-weight:400; text-transform:none; }
 .vt-perf.vt-on { display:block; }

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -18,6 +18,13 @@ import { Rng } from "./rng.ts";
 import { biomeAt, biomeLength } from "./biomes.ts";
 import { detectTier, TierController, type TierName } from "./tiers.ts";
 import { buildHud, groupDigits, ringCircumference } from "./hud.ts";
+import { ndcFrame } from "./chrome.ts";
+import type { Frame } from "./readband.ts";
+import {
+  createInstructions,
+  onInsetsChange,
+  safeInsets,
+} from "../../../../packs/shared/game-chrome/index.ts";
 import { Shake, HitStop, FlashBus, Springy, clamp, clamp01, lerp, approach, easeOutCubic } from "./juice.ts";
 
 import {
@@ -252,10 +259,20 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
   /* -------------------------------- sizing ------------------------------ */
 
   let vw = 1, vh = 1;
+  /**
+   * The NDC box the numeral row, the payoff and the score popups live inside.
+   *
+   * Recomputed on every resize, and on every inset change, because the insets
+   * are not a launch-time constant: a rotation swaps the top inset for two side
+   * ones, and iPadOS changes them when the pack is resized in Split View. A
+   * game that reads them once at mount is correct until the first rotation.
+   */
+  let frameNdc: Frame = ndcFrame(1, 1, safeInsets());
   function resize(): void {
     const r = el.getBoundingClientRect();
     vw = Math.max(1, Math.round(r.width));
     vh = Math.max(1, Math.round(r.height));
+    frameNdc = ndcFrame(vw, vh, safeInsets());
     const dpr = Math.min(window.devicePixelRatio || 1, tiers.settings.dprCap) * tiers.renderScale;
     renderer.setPixelRatio(1);
     const bw = Math.max(2, Math.round(vw * dpr));
@@ -290,6 +307,71 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
   resize();
   applyTier();
   applyBiomeUniforms();
+
+  // A rotation does not always change the element's box — a square-ish split
+  // view can rotate and keep its size — but it always changes the insets.
+  const stopInsets = onInsetsChange(() => resize());
+
+  /* ----------------------------- how to play ---------------------------- */
+
+  // VOLTA's start card says "pick the lane that is right" and lists the swipes,
+  // and then it is gone. A child who works out on the fourth gate that the
+  // numbers ARE the answers had nowhere to go back to, and no way at all to
+  // find out what the voltage bar is or why a wrong lane costs so much. The
+  // manual stays reachable during the run, because the moment a child needs the
+  // rules is never the title screen.
+  const guide = createInstructions(el, {
+    title: "VOLTA",
+    summary: [
+      "You are running down a road with three lanes.",
+      "A sum is at the top. Each lane has a number. Move to the lane with the right answer.",
+    ],
+    sections: [
+      {
+        heading: "Moving",
+        lines: [
+          "Swipe left or right to change lane. You can also tap the left or right side of the screen.",
+          "Swipe up to jump over a hole.",
+          "Swipe down to slide under a bar.",
+          "On a keyboard, use the arrow keys.",
+        ],
+      },
+      {
+        heading: "Answering",
+        lines: [
+          "Read the sum at the top of the screen.",
+          "Three numbers float above the road. Only one is the answer.",
+          "Get into that lane before you reach the gate. The lane you are in is your answer.",
+          "You do not press anything. Driving through is answering.",
+        ],
+      },
+      {
+        heading: "The blue bar",
+        lines: [
+          "The bar along the bottom is your power.",
+          "A right answer adds power. A wrong answer takes a lot away, and you stumble.",
+          "Hitting a wall or a bar also takes power away.",
+        ],
+      },
+      {
+        heading: "When the power runs out",
+        lines: [
+          "The run stops and you get one more sum, with three big buttons.",
+          "Get it right and you carry on with full power.",
+          "Get it wrong and the run is over. Then you can start again.",
+        ],
+      },
+      {
+        heading: "Going faster",
+        lines: [
+          "Three right answers in a row make your score count for more.",
+          "One wrong answer sets that back to normal.",
+          "The road never ends. See how far you can get.",
+        ],
+      },
+    ],
+    reducedMotion: reduced(),
+  });
 
   /* --------------------------------- HUD -------------------------------- */
 
@@ -1034,7 +1116,7 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     proj.update(camera, shared.uBend.value.x, shared.uBend.value.y);
 
     scenery.draw(shardField, boxField, biome, shared.uShift.value);
-    ents.drawGates(boxField, glow, digits, proj, ac, hot, bad, good, numeralInk, shared.uTime.value, false);
+    ents.drawGates(boxField, glow, digits, proj, ac, hot, bad, good, numeralInk, shared.uTime.value, false, frameNdc);
     ents.drawHazards(boxField, glow, warn, ac, shared.uTime.value);
     ents.drawPits(glow, warn);
     ents.drawSparks(glow, ac2, shared.uTime.value);
@@ -1057,7 +1139,7 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
 
     parts.draw(glow, rm ? 0.75 : 1);
     player.draw(skiffField, boxField, glow, ac[0], ac[1], ac[2], ac2[0], ac2[1], ac2[2], rm);
-    ents.drawPopups(digits, proj);
+    ents.drawPopups(digits, proj, frameNdc);
 
     shardField.end();
     boxField.end();
@@ -1161,6 +1243,8 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
       disposed = true;
       cancelAnimationFrame(raf);
       if (reviveVerdict) window.clearTimeout(reviveVerdict);
+      guide.destroy();
+      stopInsets();
       ro.disconnect();
       window.removeEventListener("keydown", onKey);
       document.removeEventListener("visibilitychange", onVisibility);

--- a/dynawalla/games/runner/src/game/readband.test.ts
+++ b/dynawalla/games/runner/src/game/readband.test.ts
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { BAND, readBand, payoffHeight, keepInside, PAYOFF_EDGE, PAYOFF_MAX_H, POPUP_EDGE } from "./readband.ts";
+import {
+  BAND, FULL_FRAME, readBand, payoffHeight, keepInside,
+  PAYOFF_EDGE, PAYOFF_MAX_H, POPUP_EDGE,
+} from "./readband.ts";
 import { INK, TRACK } from "./glyphs.ts";
 
 /**
@@ -70,7 +73,7 @@ function forEachCase(fn: (b: ReturnType<typeof readBand>, ctx: string, w: number
             const u = unit(n, adv);
             for (const a of APPROACHES) {
               for (const archTop of [-0.4, 0, 0.2, 0.6, 1.4]) {
-                const band = readBand([u, u, u], kx, ky, a, archTop);
+                const band = readBand([u, u, u], kx, ky, a, archTop, FULL_FRAME);
                 fn(band, `${label} fov${fov} d${dist} adv${adv} n${n} a${a} arch${archTop}`, vw, vh);
               }
             }
@@ -111,7 +114,7 @@ test("numerals stay big enough to read on the smallest supported screen", () => 
   // the most digits an answer realistically has.
   const { kx, ky } = scales(320, 568, 74, 90);
   const u = unit(3, 0.5);
-  const band = readBand([u, u, u], kx, ky, 0, 0.1);
+  const band = readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME);
   const capPx = (band.hNdc / 2) * 568;
   assert.ok(capPx >= 24, `three digits at 320px render at ${capPx.toFixed(1)}px cap height`);
 });
@@ -119,7 +122,7 @@ test("numerals stay big enough to read on the smallest supported screen", () => 
 test("two digits on a 390px phone are unmistakable", () => {
   const { kx, ky } = scales(390, 844, 74, 90);
   const u = unit(2, 0.43);
-  const band = readBand([u, u, u], kx, ky, 0, 0.1);
+  const band = readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME);
   const capPx = (band.hNdc / 2) * 844;
   const gapPx = ((band.pitch - band.wNdc) / 2) * 390;
   assert.ok(capPx >= 44, `two digits at 390px render at ${capPx.toFixed(1)}px cap height`);
@@ -132,7 +135,7 @@ test("apparent size does not depend on how far away the gate is", () => {
   const u = unit(2, 0.43);
   const sizes = DISTANCES.map((d) => {
     const { kx, ky } = scales(1280, 800, 74, d);
-    return readBand([u, u, u], kx, ky, 0, 0.1).hNdc;
+    return readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME).hNdc;
   });
   for (const s of sizes) assert.ok(Math.abs(s - sizes[0]) < 1e-6, `sizes drift with distance: ${sizes.join(", ")}`);
 });
@@ -141,16 +144,16 @@ test("a mixed-width gate sizes every candidate to the widest", () => {
   const { kx, ky } = scales(1280, 800, 74, 60);
   const wide = unit(3, 0.43);
   const narrow = unit(1, 0.43);
-  const mixed = readBand([narrow, wide, narrow], kx, ky, 0.3, 0.1);
-  const allWide = readBand([wide, wide, wide], kx, ky, 0.3, 0.1);
+  const mixed = readBand([narrow, wide, narrow], kx, ky, 0.3, 0.1, FULL_FRAME);
+  const allWide = readBand([wide, wide, wide], kx, ky, 0.3, 0.1, FULL_FRAME);
   assert.equal(mixed.hNdc, allWide.hNdc);
 });
 
 test("the row opens outward as the gate arrives", () => {
   const u = unit(2, 0.43);
   const { kx, ky } = scales(1280, 800, 74, 60);
-  const far = readBand([u, u, u], kx, ky, 0, 0.1);
-  const near = readBand([u, u, u], kx, ky, 1, 0.1);
+  const far = readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME);
+  const near = readBand([u, u, u], kx, ky, 1, 0.1, FULL_FRAME);
   assert.ok(near.pitch > far.pitch, "candidates should spread as the gate closes");
 });
 
@@ -174,7 +177,7 @@ test("the winning numeral never rushes past the edge of the screen", () => {
         for (const n of DIGIT_COUNTS) {
           const wPerH = widthPerHeight(n, adv, vw, vh, fov);
           for (const swell of [0, 0.25, 0.5, 0.75, 1]) {
-            const h = payoffHeight(wPerH, 0.2, swell);
+            const h = payoffHeight(wPerH, 0.2, swell, PAYOFF_EDGE);
             const ctx = `${label} fov${fov} adv${adv} n${n} swell${swell}`;
             assert.ok(h * wPerH <= 2 * PAYOFF_EDGE + 1e-9, `${ctx}: payoff is ${(h * wPerH).toFixed(2)} NDC wide`);
             assert.ok(h <= PAYOFF_MAX_H + 1e-9, `${ctx}: payoff is ${h.toFixed(2)} NDC tall`);
@@ -189,11 +192,11 @@ test("the payoff grows out of the row and never shrinks back", () => {
   const wPerH = widthPerHeight(2, 0.43, 1280, 800, 74);
   let prev = -Infinity;
   for (let s = 0; s <= 1.0001; s += 0.05) {
-    const h = payoffHeight(wPerH, 0.2, s);
+    const h = payoffHeight(wPerH, 0.2, s, PAYOFF_EDGE);
     assert.ok(h >= prev - 1e-12, `payoff shrank at swell ${s.toFixed(2)}`);
     prev = h;
   }
-  assert.equal(payoffHeight(wPerH, 0.2, 0), 0.2, "the payoff must start exactly where the row left off");
+  assert.equal(payoffHeight(wPerH, 0.2, 0, PAYOFF_EDGE), 0.2, "the payoff must start exactly where the row left off");
 });
 
 test("the swell is one-way even for a row the layout cannot currently produce", () => {
@@ -204,7 +207,7 @@ test("the swell is one-way even for a row the layout cannot currently produce", 
   const wPerH = widthPerHeight(4, 0.5, 320, 568, FOV_MAX);
   const from = 1.4;
   for (const s of [0, 0.5, 1]) {
-    assert.ok(payoffHeight(wPerH, from, s) >= from, `payoff dipped below ${from} at swell ${s}`);
+    assert.ok(payoffHeight(wPerH, from, s, PAYOFF_EDGE) >= from, `payoff dipped below ${from} at swell ${s}`);
   }
 });
 
@@ -222,7 +225,7 @@ test("a score popup gives up its lane rather than hang off the edge", () => {
   // "+100" over the outer lane used to hang half off a 390px screen as "00".
   for (const halfW of [0, 0.1, 0.4, 0.9, 1.4]) {
     for (const nx of [-3, -0.9, -0.2, 0, 0.2, 0.9, 3]) {
-      const x = keepInside(nx, halfW);
+      const x = keepInside(nx, halfW, POPUP_EDGE);
       assert.ok(Math.abs(x) + halfW <= POPUP_EDGE + 1e-9 || halfW >= POPUP_EDGE,
         `half-width ${halfW} at ${nx} landed at ${x.toFixed(2)}`);
       assert.ok(Math.abs(x) <= Math.abs(nx) + 1e-9, "clamping moved the popup outward");
@@ -231,5 +234,5 @@ test("a score popup gives up its lane rather than hang off the edge", () => {
   }
   // Something already inside is left exactly alone, so the common case is a
   // no-op and the popup keeps its lane.
-  assert.equal(keepInside(0.3, 0.2), 0.3);
+  assert.equal(keepInside(0.3, 0.2, POPUP_EDGE), 0.3);
 });

--- a/dynawalla/games/runner/src/game/readband.ts
+++ b/dynawalla/games/runner/src/game/readband.ts
@@ -32,7 +32,7 @@ export const BAND = {
   fill: 0.7,
   /** Ceiling on apparent size, in NDC y. A single digit would otherwise fill the screen. */
   maxH: 0.3,
-  /** Hard page margin: no ink past |x| = this. */
+  /** Hard page margin on a device with no insets: no ink past |x| = this. */
   edge: 0.94,
   /** The row never rises past here — above it lives the prompt. */
   top: 0.56,
@@ -41,6 +41,33 @@ export const BAND = {
   /** Clear air between the numeral row and the top of its own gate arch. */
   lift: 0.07,
 } as const;
+
+/**
+ * The rectangle the numeral row is allowed to occupy, in NDC.
+ *
+ * **Why this is an argument and not a constant.** `BAND.edge` used to be the
+ * page margin, full stop: 0.94, three per cent of half the screen. On a phone
+ * held sideways the display cutout and the rounded corners eat far more than
+ * that — 47 CSS pixels of an 844-wide viewport is five and a half per cent, so
+ * the outer candidate reached about twenty pixels *into* the cutout. In this
+ * game the outer candidate is an answer. A digit the child cannot read is a
+ * wrong answer they did not choose.
+ *
+ * It is required rather than defaulted for the same reason. A default is a
+ * game that forgets the insets, compiles clean, and is discovered on a device.
+ * `chrome.ts` builds one of these from the measured safe area.
+ */
+export type Frame = {
+  /** No ink past |x| = this. */
+  edge: number;
+  /** The row's top edge never rises above this NDC y. */
+  top: number;
+  /** The row's bottom edge never sinks below this NDC y. */
+  bottom: number;
+};
+
+/** The frame on a surface with no insets at all: the old constants, exactly. */
+export const FULL_FRAME: Frame = { edge: BAND.edge, top: BAND.top, bottom: BAND.bottom };
 
 export type Band = {
   /** Ink height, in NDC y. Multiply by `1/|ky|` for world units. */
@@ -61,6 +88,7 @@ export type Band = {
  * @param ky       NDC y per world unit at the gate's depth (magnitude)
  * @param approach 0 when the gate spawns, 1 when it reaches the answer plane
  * @param archTop  NDC y of the top of the gate's arch
+ * @param frame    the NDC rectangle the row may occupy — see `Frame`
  */
 export function readBand(
   units: readonly [number, number, number],
@@ -68,6 +96,7 @@ export function readBand(
   ky: number,
   approach: number,
   archTop: number,
+  frame: Frame,
 ): Band {
   const ax = Math.max(1e-6, Math.abs(kx));
   const ay = Math.max(1e-6, Math.abs(ky));
@@ -79,7 +108,7 @@ export function readBand(
 
   // The widest a numeral can ever be: the point where the gutter rule
   // (w <= fill * pitch) and the page margin (pitch + w/2 <= edge) meet.
-  const wCeil = (BAND.fill * BAND.edge) / (1 + BAND.fill / 2);
+  const wCeil = (BAND.fill * frame.edge) / (1 + BAND.fill / 2);
   // The width at which the apparent-size cap bites. On a narrow phone this is
   // enormous, which is exactly why the pitch has to be free to open up: a
   // three-digit answer on a 320px screen needs most of the width or it lands at
@@ -89,7 +118,7 @@ export function readBand(
   let wNdc = Math.min(wCeil, wWanted);
   // The row spreads as the gate closes, but never tighter than the gutter needs.
   let pitch = Math.max(lerp(BAND.pitchFar, BAND.pitchNear, t), wNdc / BAND.fill);
-  const pitchCeil = BAND.edge - wNdc / 2;
+  const pitchCeil = frame.edge - wNdc / 2;
   if (pitch > pitchCeil) pitch = pitchCeil;
   wNdc = Math.min(wNdc, BAND.fill * pitch);
 
@@ -99,8 +128,8 @@ export function readBand(
   // Sit just clear of the arch, but never behind the prompt and never under the
   // deck. When the two limits collide the top wins: off the bottom is invisible,
   // slightly tight against the prompt is merely close.
-  const lo = BAND.bottom + half;
-  const hi = BAND.top - half;
+  const lo = frame.bottom + half;
+  const hi = frame.top - half;
   let y = archTop + half + BAND.lift;
   if (y < lo) y = lo;
   if (y > hi) y = hi;
@@ -122,6 +151,9 @@ export function readBand(
  */
 export const PAYOFF_EDGE = 0.92;
 
+/** The payoff's margin inside a frame: a shade tighter than the row's own. */
+export const payoffEdge = (frameEdge: number): number => Math.min(PAYOFF_EDGE, frameEdge - 0.02);
+
 /** Ceiling on the payoff numeral's NDC height, whatever the aspect ratio. */
 export const PAYOFF_MAX_H = 1.55;
 
@@ -138,9 +170,11 @@ export const PAYOFF_MAX_H = 1.55;
  * @param wPerH NDC width the text occupies per NDC of height (aspect-corrected)
  * @param from  the numeral's NDC height when it left the row
  * @param swell 0 at the moment of crossing, 1 when fully arrived
+ * @param edge  the page margin — `payoffEdge(frame.edge)`, never a constant,
+ *              because in landscape the cutout sits inside the old constant
  */
-export function payoffHeight(wPerH: number, from: number, swell: number): number {
-  const ceil = Math.min(PAYOFF_MAX_H, (2 * PAYOFF_EDGE) / Math.max(1e-4, wPerH));
+export function payoffHeight(wPerH: number, from: number, swell: number, edge: number): number {
+  const ceil = Math.min(PAYOFF_MAX_H, (2 * edge) / Math.max(1e-4, wPerH));
   // Belt and braces: the swell only ever runs upward. `readBand` already keeps
   // every candidate under 0.54 NDC wide, well inside this ceiling, so `from` is
   // never the larger of the two in practice — but a numeral that *shrank* on a
@@ -153,6 +187,9 @@ export function payoffHeight(wPerH: number, from: number, swell: number): number
 /** The margin a score popup is kept inside. Tighter than the payoff: it is chrome. */
 export const POPUP_EDGE = 0.93;
 
+/** The popup's margin inside a frame. */
+export const popupEdge = (frameEdge: number): number => Math.min(POPUP_EDGE, frameEdge - 0.01);
+
 /**
  * Nudge a centre back inside the frame, in NDC.
  *
@@ -163,9 +200,10 @@ export const POPUP_EDGE = 0.93;
  *
  * @param ndcX  where the text wants to be centred
  * @param halfW half the text's NDC width
- * @param edge  the hard page margin
+ * @param edge  the hard page margin — `popupEdge(frame.edge)`, required for the
+ *              same reason `readBand` requires a frame
  */
-export function keepInside(ndcX: number, halfW: number, edge = POPUP_EDGE): number {
+export function keepInside(ndcX: number, halfW: number, edge: number): number {
   const lim = Math.max(0, edge - Math.max(0, halfW));
   return ndcX < -lim ? -lim : ndcX > lim ? lim : ndcX;
 }


### PR DESCRIPTION
## What

Adopt the shared game chrome in **VOLTA** (`dynawalla/games/runner`): honour the
safe area where the answers are drawn, move the two corner readouts out from
under the host's controls, and give the game a how-to-play manual that stays
reachable mid-run.

## Why

VOLTA had both defects the shared `game-chrome` module exists for, and the first
one costs more here than anywhere else — **the lane you pick is the answer you
give**, so the three numerals floating over the causeway *are* the answer UI.

**Safe area.** `pack.html` declares `viewport-fit=cover`, which is not neutral:
it opts the document *into* the display cutout, the home indicator and the
rounded corners. A DOM rule can claw that back with `env(safe-area-inset-*)`;
the candidates cannot, because they are drawn by a shader in NDC and a shader
has never heard of `env()`. Held sideways, a phone's cutout is about 47 CSS
pixels of an 844-wide viewport — five and a half per cent — against a read-band
page margin of a flat three per cent (`BAND.edge = 0.94`). The outer candidate
reached roughly twenty pixels underneath it. A digit a child cannot read is a
wrong answer they did not choose.

`readBand` now takes a `Frame`, and it is **required rather than defaulted**: an
optional safe area is a game that forgets it, compiles clean, and is discovered
on a device. `payoffHeight` and `keepInside` take the same margin for the same
reason. `chrome.ts` builds the frame from the measured insets and `mount`
recomputes it on resize *and* on `onInsetsChange`, because a rotation swaps one
top inset for two side ones and iPadOS changes them in Split View.

**The host's two corners.** The app paints an exit control top-left and a
how-to-play control top-right, over the pack. VOLTA's score was under the first
and its surge meter under the second. Both drop by `READOUT_CLEAR`, derived from
the shared `HOST_*` constants so the pack follows if the host moves its chrome.
The chrome **overlays** — no band is reserved; the causeway, sky and ocean still
bleed to all four edges, which is the entire point of `cover`. The rest of the
DOM HUD (voltage bar, toggles, veils, recharge gate) picks up `env()` on the
edges it touches.

**How to play.** The start card said "pick the lane that is right", listed the
swipes, and then it was gone. A child who worked out on the fourth gate that the
numbers *are* the answers had nowhere to go back to, and no way at all to learn
what the voltage bar is or why a wrong lane costs so much.

## Blast radius

**Areas touched:** dynawalla (one game pack)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched: same id, same version, same
      capabilities (`items`, `items.reveal`, `haptics`), same `covers.skills`.
      No catalog entry changed, no published zip changed in place.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifests.
- [x] **Strings.** N/A — no `corpan-app` locale keys. The new strings are the
      pack's own instruction copy, written for a 7–11 year old.
- [x] **Curriculum.** N/A — no skill ids, generators or schemas touched.
- [x] **Secrets.** None. `gitleaks` output below.

## Proof

```
$ cd dynawalla/games/runner && for i in 1 2 3 4 5; do npm test; done
run 1: # pass 66 # fail 0
run 2: # pass 66 # fail 0
run 3: # pass 66 # fail 0
run 4: # pass 66 # fail 0
run 5: # pass 66 # fail 0

$ npm run tsc
> tsc --noEmit
(no output — 0 errors)

$ npm run build
✓ 35 modules transformed.
dist/index.html                  0.82 kB │ gzip:   0.44 kB
dist/assets/index-D7by79rd.js  619.91 kB │ gzip: 167.83 kB
✓ built in 621ms

$ cd ../../packs && node build.mjs runner
dynawalla.runner@0.1.0 — VOLTA
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 624995 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~26125 bytes (26.12 KB) in 35.4ms
INF no leaks found

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)

$ git diff --name-only origin/main...HEAD
dynawalla/games/runner/README.md
dynawalla/games/runner/src/game/chrome.test.ts
dynawalla/games/runner/src/game/chrome.ts
dynawalla/games/runner/src/game/entities.ts
dynawalla/games/runner/src/game/hud.ts
dynawalla/games/runner/src/game/mount.ts
dynawalla/games/runner/src/game/readband.test.ts
dynawalla/games/runner/src/game/readband.ts
```

### The clearance test fails without the fix

A clearance test that passes either way is worthless, so each fix was removed on
its own and the suite re-run:

```
### FIX 1 REMOVED (ndcFrame pinned back to the flat BAND.edge) ###
not ok 6 - a side cutout pulls the page margin in, so the outer answer stays visible
not ok 7 - no answer is ever drawn under the cutout, at any viewport or rotation
not ok 9 - the payoff and the score popups honour the same frame
# pass 63
# fail 3

### FIX 2 REMOVED (READOUT_CLEAR back to a 10px margin) ###
not ok 1 - the score and the surge meter are clear of the host's controls
not ok 3 - dropping the readouts clears the control and no more
# pass 64
# fail 2

### RESTORED ###
# pass 66
# fail 0
```

Viewports swept: 320×568, 390×844, 768×1024, 1024×768, 844×390 — each with no
insets and with the insets its own orientation actually produces (portrait
`top:47, bottom:34`; landscape `left/right:47, bottom:21`). Crossing insets with
orientation instead of pairing them was tried first and asserted a 320-wide
portrait phone with 94px of side cutout, which no device has and which only
tempts the fix into clamping the safe area away.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
