### PR TITLE
fix(dynawalla/games/foundry): the sum was under the notch and under both host buttons

### DIFF
--- a/dynawalla/games/foundry/src/mount.ts
+++ b/dynawalla/games/foundry/src/mount.ts
@@ -22,6 +22,11 @@
 // every rule lives in `game/bout.ts` and every piece of arithmetic in
 // `game/plates.ts`.
 
+import {
+  createInstructions,
+  onInsetsChange,
+  safeRect,
+} from "../../../packs/shared/game-chrome/index.ts"
 import type { Host } from "./contract.ts"
 import { Audio } from "./audio.ts"
 import { Feel } from "./core/feel.ts"
@@ -81,7 +86,7 @@ export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
   // every cast. The value is not drawn: see the note in `draw()`.
   loadBelt()
 
-  let layout: Layout = computeLayout(320, 568)
+  let layout: Layout = computeLayout(320, 568, safeRect(320, 568))
   const crowdSeed = 0x1b0c
 
   const bout = new Bout({ host, seed: 0x9a11ed, onEvent: handle })
@@ -322,10 +327,17 @@ export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
     canvas.width = Math.round(w * dpr)
     canvas.height = Math.round(h * dpr)
     g.setTransform(dpr, 0, 0, dpr, 0, 0)
-    layout = computeLayout(w, h)
+    layout = computeLayout(w, h, safeRect(w, h))
     crowd.layout(w, layout.horizon, gov.quality.crowd, crowdSeed)
     parts.setLimit(gov.quality.particles)
   }
+
+  // Rotation swaps the insets, and iPadOS changes them when the pack is resized
+  // in Split View. A layout read once at mount is right until the first turn of
+  // the tablet and wrong for the rest of the session.
+  const stopInsets = onInsetsChange(() => {
+    resize()
+  })
 
   const ro =
     typeof ResizeObserver === "function"
@@ -388,13 +400,85 @@ export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
   globalThis.addEventListener("keydown", onKeyDown)
   document.addEventListener("visibilitychange", onVisibility)
 
+  // ── how to play ──────────────────────────────────────────────────────────
+  //
+  // This game shipped with nothing at all telling a child what the pedals were
+  // for, and the one rule that decides every fall — that going over loses on
+  // the spot — was discoverable only by losing to it. So it is stated first,
+  // plainly, in the summary a child sees before their first tap.
+  //
+  // Opening the manual stops the count: a child who went to read the rules must
+  // not come back to a fall they lost while reading them.
+  const guide = createInstructions(root, {
+    title: "THE GRAPPLE FOUNDRY",
+    summary: [
+      "Someone has you pinned. The board above the ring shows a sum.",
+      "Work out the answer, then tap the two pedals until the bar holds exactly that number. Go one over and you lose.",
+    ],
+    sections: [
+      {
+        heading: "How to get free",
+        lines: [
+          "Read the board. It shows a sum, like 45 + 28.",
+          "Work out the answer in your head. The game never shows it to you.",
+          "The two pedals at the bottom each have a number stamped on them. Tapping a pedal adds that number to the bar.",
+          "Tap until the number on the bar is exactly your answer. Then the bar tips and you kick out.",
+        ],
+      },
+      {
+        heading: "Going over loses at once",
+        lines: [
+          "One over the answer and the fall is lost. Not close. Over.",
+          "So tapping fast never works. Work out the taps first, then tap.",
+          "Say the answer is 25 and your pedals are 7 and 4. Three taps of 7 makes 21, then one tap of 4 makes 25. That is the escape.",
+        ],
+      },
+      {
+        heading: "When there is no way out",
+        lines: [
+          "Sometimes the number you have left cannot be made from your two pedals.",
+          "If you need 3 more and the pedals are 4 and 7, nothing makes 3. The game stops the fall and tells you.",
+          "So think about what you will have left, not just about the next tap.",
+        ],
+      },
+      {
+        heading: "The count",
+        lines: [
+          "The referee slaps the mat three times. When the third slap lands, the fall is over.",
+          "A longer sum and a longer escape both give you more time.",
+          "Winning lots of falls never takes time away. The clock is set by the work, not by how well you are doing.",
+        ],
+      },
+      {
+        heading: "The finish that gets waved off",
+        lines: [
+          "Some totals are the answer you get when you do the sum a common wrong way.",
+          "Land on one of those and the crowd roars, and then the referee waves it off.",
+          "It costs you count. It never costs you the fall. Keep going.",
+        ],
+      },
+      {
+        heading: "Controls",
+        lines: [
+          "Tap the left half of the screen for the LIGHT pedal, the right half for the HEAVY one.",
+          "On a keyboard, A and D work, and so do the left and right arrows.",
+          "Press M to turn the sound off.",
+        ],
+      },
+    ],
+    onClose: (): void => {
+      last = 0
+    },
+    reducedMotion: reduced,
+  })
+
   // ── loop ─────────────────────────────────────────────────────────────────
   function frame(now: number): void {
     raf = requestAnimationFrame(frame)
     if (last === 0) last = now
     const rawMs = Math.min(64, now - last)
     last = now
-    if (paused) return
+    if (paused || guide.isOpen) return
 
     // A downgrade has to move the levers that actually cost fill rate. `maxDpr`
     // and the lantern count are only read in `resize()`, and a pack frame at a
@@ -511,7 +595,7 @@ export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
     g.textAlign = "left"
     g.textBaseline = "alphabetic"
     g.fillStyle = withAlpha(CHALK, 0.34)
-    g.fillText(`${bout.challenger} · ${bout.toBeat} TO GO`, 10, l.padTop - 8)
+    g.fillText(`${bout.challenger} · ${bout.toBeat} TO GO`, l.safe.x + 10, l.padTop - 8)
     g.restore()
   }
 
@@ -520,6 +604,8 @@ export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
   return {
     unmount(): void {
       cancelAnimationFrame(raf)
+      guide.destroy()
+      stopInsets()
       canvas.removeEventListener("pointerdown", onPointerDown)
       globalThis.removeEventListener("keydown", onKeyDown)
       document.removeEventListener("visibilitychange", onVisibility)

--- a/dynawalla/games/foundry/src/render/hud.ts
+++ b/dynawalla/games/foundry/src/render/hud.ts
@@ -155,9 +155,11 @@ export function drawPedals(
     const y = l.padTop + drop
     const h = l.padH - drop
 
-    // The socket the pedal sits in.
+    // The socket the pedal sits in. It fills to the bottom of the GLASS, not to
+    // the bottom of the safe area, so there is no black seam under the home
+    // indicator — the pedal plate above it is what stays inside the safe band.
     g.fillStyle = IRON_DARK
-    g.fillRect(x, l.padTop, w, l.padH)
+    g.fillRect(x, l.padTop, w, l.h - l.padTop)
 
     const grad = g.createLinearGradient(0, y, 0, y + h)
     grad.addColorStop(0, live ? IRON_EDGE : "#26262e")
@@ -206,10 +208,14 @@ export function drawBelt(
 ): void {
   const h = l.beltH
   const y = l.beltY
-  const shown = Math.min(plates, Math.max(6, Math.floor(l.w / (h * 0.72))))
   const pw = h * 0.5
+  // The belt lives in the channel between the host's two corner controls, and
+  // the two counters printed either side of the strap have to fit in there with
+  // it — 40px a side is enough for four figures and a star at this type size.
+  const budget = Math.max(pw + 3, l.topBar.w - 80)
+  const shown = Math.min(plates, Math.max(3, Math.floor(budget / (pw + 3))))
   const total = shown * (pw + 3)
-  const x0 = l.cx - total / 2
+  const x0 = l.topBar.x + l.topBar.w / 2 - total / 2
 
   g.save()
   // The strap.

--- a/dynawalla/games/foundry/src/render/layout.ts
+++ b/dynawalla/games/foundry/src/render/layout.ts
@@ -9,10 +9,50 @@
 // Tablet and desktop are first-class targets, not a phone layout stretched: the
 // ring is allowed to become wide and shallow, and the pedal band stops growing
 // once it is comfortably bigger than a hand.
+//
+// **The frame is not the screen.** `computeLayout` takes the safe rectangle and
+// takes it as a REQUIRED argument, because this game declares
+// `viewport-fit=cover` and draws its whole HUD on a canvas. `env()` is a CSS
+// value a canvas cannot see, so before this the board carrying the sum was laid
+// out from `h` alone and its top edge went under the notch. Making the argument
+// optional would mean a future caller that forgets it still compiles and only
+// fails on a device, which is the bug this signature exists to prevent.
+//
+// **Two corners stay clear.** The host floats an exit control over the top-left
+// and the how-to-play control over the top-right, 44px each. It does not
+// reserve a band and this layout must not pretend it did — reserving one costs
+// a twelfth of a small phone. Instead the belt and the board are confined to
+// the horizontal channel BETWEEN the two corners, `topBar`. At 320×568 that is
+// 196px of the 320, and the board narrows into it rather than moving down, so
+// the ring keeps every pixel of its height.
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+
+/** Breathing room between a HUD edge and a host control. */
+const CHROME_GAP = 8
+
+/**
+ * The narrowest channel the board is still worth squeezing into.
+ *
+ * Above this, the belt and the board narrow and the ring keeps its full height.
+ * Below it — an iPad in a narrow Split View, a phone on its side with insets on
+ * both long edges — there is not enough room left between the two corners to
+ * set a four-digit sum, so the whole top band drops beneath them instead and
+ * takes the width back. Narrowing is the default because dropping costs the
+ * ring 65px, and 65px of a 568px phone is a twelfth of the game.
+ */
+const MIN_CHANNEL = 180
 
 export type Layout = {
   w: number
   h: number
+  /** The safe rectangle this layout was built from. Kept for stray labels. */
+  safe: Rect
   /** Bottom of the crowd, top of the ring structure. */
   horizon: number
   /** The mat, in screen space. Corners are the four ring posts. */
@@ -36,30 +76,55 @@ export type Layout = {
   /** The belt strip along the top. */
   beltY: number
   beltH: number
+  /**
+   * The horizontal channel at the top that no host control covers.
+   *
+   * The belt is laid out inside this and the board never grows past its width.
+   * Everything else — the crowd, the ring, the pedals — bleeds to the screen
+   * edge, which is the whole reason `viewport-fit=cover` is set.
+   */
+  topBar: Rect
   /** Base size for stamped numerals. */
   unit: number
 }
 
-export function computeLayout(w: number, h: number): Layout {
-  const short = Math.min(w, h)
-  const wide = w / h > 1.35
+export function computeLayout(w: number, h: number, area: Rect): Layout {
+  const short = Math.min(area.w, area.h)
+  const wide = area.w / area.h > 1.35
 
   const beltH = Math.max(24, Math.min(44, short * 0.075))
-  const beltY = beltH * 0.28
 
-  const boardH = Math.max(56, Math.min(140, h * (wide ? 0.19 : 0.145)))
-  const boardW = Math.min(w * 0.86, Math.max(220, short * 1.15))
-  const boardY = beltY + beltH + Math.max(6, h * 0.018)
-  const boardX = (w - boardW) / 2
+  // The channel between the host's two 44px corners. Anything a child has to
+  // READ at the top of this game lives in here.
+  const rail = HOST_MARGIN + HOST_CONTROL + CHROME_GAP
+  const channelW = area.w - rail * 2
+  const narrow = channelW < MIN_CHANNEL
+  const topY = narrow
+    ? area.y + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + CHROME_GAP
+    : area.y
+
+  const beltY = topY + beltH * 0.28
+  const topBar: Rect = narrow
+    ? { x: area.x, y: beltY, w: area.w, h: beltH }
+    : { x: area.x + rail, y: beltY, w: channelW, h: beltH }
+
+  const boardH = Math.max(56, Math.min(140, area.h * (wide ? 0.19 : 0.145)))
+  const boardW = Math.min(area.w * 0.86, Math.max(220, short * 1.15), topBar.w)
+  const boardY = beltY + beltH + Math.max(6, area.h * 0.018)
+  // Centred in the safe area. The channel is symmetric about that centre, so a
+  // board that fits the channel is centred in it too.
+  const boardX = area.x + (area.w - boardW) / 2
 
   // The pedals get the bottom of the screen and a floor of 150px, because a
   // four-second escape is lost on a thumb that missed, not on the arithmetic.
-  const padH = Math.max(150, Math.min(300, h * (wide ? 0.34 : 0.29)))
-  const padTop = h - padH
+  // The band is measured inside the safe area so the stamped numeral clears the
+  // home indicator; the socket behind it still fills to the glass, in `hud.ts`.
+  const padH = Math.max(150, Math.min(300, area.h * (wide ? 0.34 : 0.29)))
+  const padTop = area.y + area.h - padH
 
-  const horizon = boardY + boardH + Math.max(8, h * 0.02)
-  const matTop = horizon + Math.max(18, h * 0.045)
-  const matBottom = padTop - Math.max(12, h * 0.03)
+  const horizon = boardY + boardH + Math.max(8, area.h * 0.02)
+  const matTop = horizon + Math.max(18, area.h * 0.045)
+  const matBottom = padTop - Math.max(12, area.h * 0.03)
 
   // The ring is drawn in a shallow one-point perspective: the far edge is
   // narrower than the near one. Just enough to sit the figures *in* something.
@@ -72,6 +137,7 @@ export function computeLayout(w: number, h: number): Layout {
   return {
     w,
     h,
+    safe: area,
     horizon,
     matTop,
     matBottom,
@@ -89,6 +155,7 @@ export function computeLayout(w: number, h: number): Layout {
     padH,
     beltY,
     beltH,
+    topBar,
     unit: Math.max(12, short * 0.052),
   }
 }

--- a/dynawalla/games/foundry/src/test/chrome.test.ts
+++ b/dynawalla/games/foundry/src/test/chrome.test.ts
@@ -1,0 +1,132 @@
+// THE TWO CORNERS AND THE NOTCH.
+//
+// This game paints its whole readable surface on a canvas: the board with the
+// sum, the running total on the bar, the belt, the two stamped pedals. A canvas
+// cannot see `env(safe-area-inset-*)` — it is a CSS value — so nothing about
+// `viewport-fit=cover` was ever compensated for here, and the board's top edge
+// sat under the notch on every phone that has one.
+//
+// On top of that the host floats two 44px controls over the pack, exit at the
+// top-left and how-to-play at the top-right. The board is 275px wide on a 320px
+// phone and centred, so it ran *under both of them*: the sum a child has to
+// read was covered at both ends.
+//
+// What is "critical" here is small and specific. The board and the belt carry
+// figures a child must read. The crowd, the ring frame, the mat, the particles
+// and the pedal sockets are background and are SUPPOSED to bleed to the glass —
+// that is the point of `cover`. So this file asserts two things and nothing
+// more: readable HUD stays inside the safe rectangle, and readable HUD stays
+// out of the two corners.
+//
+// The insets are passed explicitly rather than measured, because node has no
+// notch and a test that measures zero insets proves nothing about a device.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { computeLayout } from "../render/layout.ts"
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+/** No insets — a laptop, an old tablet, a desktop browser. */
+const FLAT: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+/** A notched phone held upright: status bar above, home indicator below. */
+const NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+/** The same phone on its side. Both long edges lose room to the notch. */
+const NOTCH_SIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+const INSETS: Array<[string, Insets]> = [
+  ["flat", FLAT],
+  ["notched", NOTCH],
+  ["notched, on its side", NOTCH_SIDE],
+]
+
+const inside = (r: Rect, a: Rect): boolean =>
+  r.x >= a.x - 0.5 &&
+  r.y >= a.y - 0.5 &&
+  r.x + r.w <= a.x + a.w + 0.5 &&
+  r.y + r.h <= a.y + a.h + 0.5
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    test(`the figures clear the notch and the host's corners — ${vname} (${w}×${h}), ${iname}`, () => {
+      const area = safeRect(w, h, insets)
+      const l = computeLayout(w, h, area)
+
+      const board: Rect = { x: l.boardX, y: l.boardY, w: l.boardW, h: l.boardH }
+
+      // 1. The safe rectangle. If `computeLayout` ignored `area` these fail on
+      //    the notched cases and pass on the flat one, which is exactly the
+      //    device-only bug this is here to catch.
+      assert.ok(inside(board, area), `the board leaves the safe area (${JSON.stringify(board)})`)
+      assert.ok(
+        inside(l.topBar, area),
+        `the belt channel leaves the safe area (${JSON.stringify(l.topBar)})`,
+      )
+      assert.ok(l.padTop >= area.y, "the pedal band starts above the safe area")
+      assert.ok(
+        l.padTop + l.padH <= area.y + area.h + 0.5,
+        "the pedal band runs under the home indicator",
+      )
+
+      // 2. The two host corners. These hold at zero insets too — the exit and
+      //    help squares exist on every device — so removing the channel makes
+      //    every case fail, not only the notched ones.
+      assert.equal(
+        hitsHostChrome(board, w, insets),
+        false,
+        `the sum is under a host control (${JSON.stringify(board)})`,
+      )
+      assert.equal(
+        hitsHostChrome(l.topBar, w, insets),
+        false,
+        `the belt is under a host control (${JSON.stringify(l.topBar)})`,
+      )
+
+      // The pedals are what a child touches. They are the bottom of the screen
+      // and must never reach the corners.
+      const pedals: Rect = { x: 0, y: l.padTop, w, h: l.padH }
+      assert.equal(hitsHostChrome(pedals, w, insets), false, "a pedal is under a host control")
+    })
+  }
+}
+
+test("the board stays big enough to read after it narrows into the channel", () => {
+  // Narrowing the board is only acceptable while the sum stays legible. The
+  // type size is `min(boardH * 0.62, boardW * 1.55 / chars)`, and the longest
+  // prompt the `add` domain serves is about eleven characters ("4,003 − 87").
+  for (const [name, w, h] of VIEWPORTS) {
+    const l = computeLayout(w, h, safeRect(w, h, NOTCH))
+    const px = Math.min(l.boardH * 0.62, (l.boardW * 1.55) / 11)
+    assert.ok(px >= 22, `${name}: the sum would be set at ${px.toFixed(1)}px`)
+  }
+})
+
+test("the ring itself is not letterboxed by the insets", () => {
+  // The counterpart assertion, and the reason `safeRect` is not simply applied
+  // to everything. A game that solved the notch by shrinking its whole world
+  // into the safe rectangle would have letterboxed itself and `cover` would be
+  // pointless. The ring is built from the full width on purpose, so it is
+  // pixel-identical with and without insets.
+  const flat = computeLayout(390, 844, safeRect(390, 844, FLAT))
+  const notched = computeLayout(390, 844, safeRect(390, 844, NOTCH))
+  for (const k of ["matLeftTop", "matRightTop", "matLeftBottom", "matRightBottom"] as const) {
+    assert.equal(notched[k], flat[k], `the ring moved when a notch appeared (${k})`)
+  }
+  assert.equal(notched.w, 390)
+  assert.equal(notched.h, 844)
+  // And the sum did move, because that is the half that has to.
+  assert.ok(notched.boardY > flat.boardY, "the board ignored the notch")
+})

--- a/dynawalla/games/foundry/src/test/feel.test.ts
+++ b/dynawalla/games/foundry/src/test/feel.test.ts
@@ -10,6 +10,7 @@ import { test } from "node:test"
 
 import { Feel } from "../core/feel.ts"
 import { Rng } from "../core/rng.ts"
+import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import { computeLayout, matHalfWidth } from "../render/layout.ts"
 
 test("reduced motion zeroes every motion channel", () => {
@@ -83,7 +84,7 @@ test("the layout keeps the pedals enormous at every size the app runs at", () =>
     [1024, 768],
     [1366, 1024],
   ] as const) {
-    const l = computeLayout(w, h)
+    const l = computeLayout(w, h, safeRect(w, h))
     assert.ok(l.padH >= 150, `${w}×${h} gave a ${l.padH}px pedal band`)
     assert.ok(l.padTop > l.matTop, `${w}×${h} put the pedals above the mat`)
     assert.ok(l.matBottom > l.matTop, `${w}×${h} inverted the mat`)
@@ -94,7 +95,7 @@ test("the layout keeps the pedals enormous at every size the app runs at", () =>
 })
 
 test("the mat narrows towards the far ropes and never inverts", () => {
-  const l = computeLayout(768, 1024)
+  const l = computeLayout(768, 1024, safeRect(768, 1024))
   const far = matHalfWidth(l, l.matTop)
   const near = matHalfWidth(l, l.matBottom)
   assert.ok(near > far, "the near edge of a ring is the wider one")

--- a/dynawalla/games/foundry/src/test/mount.test.ts
+++ b/dynawalla/games/foundry/src/test/mount.test.ts
@@ -46,12 +46,18 @@ function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderin
 }
 
 type FakeElement = {
-  style: { cssText: string }
+  style: { cssText: string; top: string; right: string }
   width: number
   height: number
+  id: string
   listeners: Map<string, Listener[]>
+  children: unknown[]
+  attrs: Map<string, string>
   appendChild(child: unknown): void
+  append(...children: unknown[]): void
+  setAttribute(name: string, value: string): void
   remove(): void
+  focus(): void
   addEventListener(type: string, fn: Listener): void
   removeEventListener(type: string, fn: Listener): void
   getBoundingClientRect(): { width: number; height: number; left: number; top: number }
@@ -62,13 +68,26 @@ function harness(size: { w: number; h: number }, counter: { calls: number; text:
   const ctx = fakeContext(counter)
   const make = (): FakeElement => {
     const listeners = new Map<string, Listener[]>()
+    const children: unknown[] = []
     return {
-      style: { cssText: "" },
+      style: { cssText: "", top: "", right: "" },
       width: 0,
       height: 0,
+      id: "",
       listeners,
-      appendChild() {},
+      children,
+      attrs: new Map<string, string>(),
+      appendChild(child) {
+        children.push(child)
+      },
+      append(...kids) {
+        children.push(...kids)
+      },
+      setAttribute(name, value) {
+        this.attrs.set(name, value)
+      },
       remove() {},
+      focus() {},
       addEventListener(type, fn) {
         const list = listeners.get(type) ?? []
         list.push(fn)
@@ -82,13 +101,29 @@ function harness(size: { w: number; h: number }, counter: { calls: number; text:
     }
   }
   const created: FakeElement[] = []
+  // The shared chrome measures `env(safe-area-inset-*)` through a hidden probe
+  // element and mounts a how-to-play button, so this document has to answer
+  // `getElementById`, own a `body`, and hand back elements that can take
+  // attributes. A partial document is worse than none: it type-checks, it looks
+  // like a browser, and it throws on the first real call.
+  const byId = new Map<string, FakeElement>()
+  const body = make()
+  body.appendChild = (child: unknown): void => {
+    const el = child as FakeElement
+    if (el?.id) byId.set(el.id, el)
+  }
   const doc = {
     visibilityState: "visible",
+    body,
+    activeElement: null,
     listeners: new Map<string, Listener[]>(),
     createElement() {
       const el = make()
       created.push(el)
       return el
+    },
+    getElementById(id: string) {
+      return byId.get(id) ?? null
     },
     addEventListener(type: string, fn: Listener) {
       const list = doc.listeners.get(type) ?? []
@@ -129,6 +164,14 @@ function withBrowser(
     return frames.length
   })
   set("cancelAnimationFrame", () => {})
+  // No notch off a real device. Zeros are the honest answer, and are what the
+  // safe-area probe resolves to on a laptop too.
+  set("getComputedStyle", () => ({
+    paddingTop: "0px",
+    paddingRight: "0px",
+    paddingBottom: "0px",
+    paddingLeft: "0px",
+  }))
   if (typeof g.addEventListener !== "function") set("addEventListener", () => {})
   if (typeof g.removeEventListener !== "function") set("removeEventListener", () => {})
 


### PR DESCRIPTION
## What

Make THE GRAPPLE FOUNDRY respect the safe area, keep the host's two 44px corners
free of anything a child must read or touch, and add a how-to-play manual.

## Why

Two real defects, both invisible to every existing test because they are layout.

**1 · The notch.** This game declares `viewport-fit=cover`, which opts the
document *into* the notch, the home indicator and the rounded corners. Every
readable thing it has is drawn on a canvas — the board with the sum, the running
total on the bar, the belt, the two stamped pedals — and a canvas cannot read
`env(safe-area-inset-*)`, because that is a CSS value. `computeLayout` took
`(w, h)` and anchored the belt at `beltH * 0.28` from the top of the *glass*, so
on any phone with a status-bar inset the belt and the top of the board sat under
it. The pedal numerals sat on the home indicator.

**2 · Host chrome.** The host floats a 44px exit control over the top-left and
the how-to-play control over the top-right. The board is centred and 275px wide
on a 320px phone, so it ran under **both** of them — the one number a child has
to read was clipped at each end by a button.

**3 · No instructions.** Nothing anywhere told a child what the pedals were for,
and the rule that decides every fall — one over the target and you lose on the
spot — was discoverable only by losing to it.

### What was judged critical for corner clearance

Critical: **the board** (carries the sum), **the belt** (carries the plate
count), **the pedals** (the only touch targets in the game).

Not critical, and deliberately still full-bleed: the crowd, the ring frame, the
mat, the ropes, the particles, the pedal socket. Those are supposed to reach the
glass — it is the entire reason `cover` is set. `render/layout.ts` builds the
ring from the full `w`, and a test asserts the four mat corners are *identical*
with and without insets, so a future change cannot quietly letterbox the game.

The chrome **overlays**, so no band is reserved. The belt and the board are
confined to a `topBar` channel between the two corners and the board narrows
into it rather than moving down — reserving a 65px band would cost the ring an
eighth of its height on a 568px phone, which is the trade that broke SKY
LEDGER's own lattice. Below 180px of channel (a narrow iPad Split View, a phone
on its side with insets on both long edges) narrowing would leave the sum
unreadable, so the top band drops beneath the corners instead and takes the full
width back.

`computeLayout(w, h, area)` takes the safe rect as a **required** argument.
Optional would mean a caller that forgets it still compiles and fails only on a
device.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/foundry/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched — same id, version, sdk, host
      range, capabilities and covers. No published zip changed in place, no
      catalog entry dropped. `node build.mjs foundry` rebuilds and re-stages it.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app/public/locales/`. The new strings are the
      how-to-play copy inside this pack; `pack.json` declares `"locales": ["en"]`
      and is unchanged.
- [x] **Curriculum.** N/A — no skill id, grade, generator or schema touched. The
      game consumes items through the host seam exactly as before.
- [x] **Secrets.** None. `gitleaks` output below.

Behavioural risk: this is a layout change, so it moves pixels. The board is
narrower on a 320–390px phone (275→196px at 320) and the sum's type size drops
with it; a test asserts the type stays at or above 22px even for the longest
prompt the `add` domain serves. Opening the manual now pauses the three-count,
which is new behaviour and the correct one — a child who left to read the rules
must not come back to a fall they lost while reading them.

## Proof

Everything below is real output from `dynawalla/games/foundry/` unless stated.

**`npm test`, five times** — one green run is not proof.

```
--- run 1
# tests 92
# pass 92
# fail 0
--- run 2
# tests 92
# pass 92
# fail 0
--- run 3
# tests 92
# pass 92
# fail 0
--- run 4
# tests 92
# pass 92
# fail 0
--- run 5
# tests 92
# pass 92
# fail 0
```

**The clearance test fails when the fix is removed.** A clearance test that
passes either way is worthless, so this was checked rather than assumed. With
`computeLayout` reverted to ignoring `area` and to giving the belt and board the
full width again:

```
# tests 92
# pass 76
# fail 16
not ok 23 - the figures clear the notch and the host's corners — phone portrait, small (320×568), flat
not ok 24 - the figures clear the notch and the host's corners — phone portrait, small (320×568), notched
not ok 25 - the figures clear the notch and the host's corners — phone portrait, small (320×568), notched, on its side
not ok 26 - the figures clear the notch and the host's corners — phone portrait (390×844), flat
not ok 27 - the figures clear the notch and the host's corners — phone portrait (390×844), notched
not ok 28 - the figures clear the notch and the host's corners — phone portrait (390×844), notched, on its side
not ok 29 - the figures clear the notch and the host's corners — tablet portrait (768×1024), flat
not ok 30 - the figures clear the notch and the host's corners — tablet portrait (768×1024), notched
not ok 31 - the figures clear the notch and the host's corners — tablet portrait (768×1024), notched, on its side
not ok 32 - the figures clear the notch and the host's corners — tablet landscape (1024×768), flat
not ok 33 - the figures clear the notch and the host's corners — tablet landscape (1024×768), notched
not ok 34 - the figures clear the notch and the host's corners — tablet landscape (1024×768), notched, on its side
```

Note the corner cases fail at **flat** insets too. The exit and help squares
exist on every device, so this gate holds on a laptop as well as on a phone — it
cannot pass by accident the way a zero-inset-only test would.

**`npm run tsc`** — 0 errors.

```
> @dynawalla/game-foundry@0.1.0 tsc
> tsc --noEmit

```

**`npm run build`**

```
> @dynawalla/game-foundry@0.1.0 build
> vite build

vite v8.1.5 building client environment for production...
transforming...✓ 24 modules transformed.
rendering chunks...
computing gzip size...
dist/foundry.js  59.63 kB │ gzip: 19.49 kB

✓ built in 18ms
```

**`node build.mjs foundry`**, from `dynawalla/packs/`

```
vite v8.1.5 building client environment for production...
transforming...✓ 33 modules transformed.
rendering chunks...
dist-pack/pack.html                 1.28 kB │ gzip:  0.67 kB
dist-pack/assets/pack-wmIspQbF.js  51.35 kB │ gzip: 19.20 kB

✓ built in 27ms
dynawalla.foundry@0.1.0 — THE GRAPPLE FOUNDRY
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 53759 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`**

```
INF 1 commits scanned.
INF scanned ~16023 bytes (16.02 KB) in 33.3ms
INF no leaks found
```

**Scope** — one game directory, nothing deleted.

```
$ git diff --stat origin/main..HEAD
 dynawalla/games/foundry/src/mount.ts            |  94 ++++++++++++++++-
 dynawalla/games/foundry/src/render/hud.ts       |  14 ++-
 dynawalla/games/foundry/src/render/layout.ts    |  93 ++++++++++++++---
 dynawalla/games/foundry/src/test/chrome.test.ts | 132 ++++++++++++++++++++++++
 dynawalla/games/foundry/src/test/feel.test.ts   |   5 +-
 dynawalla/games/foundry/src/test/mount.test.ts  |  49 ++++++++-
 6 files changed, 361 insertions(+), 26 deletions(-)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty)
```
