### PR TITLE
dynawalla/games/street: lay the street out inside the safe rect and off the host's two corners

### DIFF
--- a/dynawalla/games/street/src/mount.ts
+++ b/dynawalla/games/street/src/mount.ts
@@ -29,6 +29,7 @@ import { pressure } from "./game/push.ts"
 import { Street, type StreetEvent } from "./game/street.ts"
 import { WAVES_PER_BLOCK } from "./game/wave.ts"
 import { Scene, hit, type Frame } from "./render/scene.ts"
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 
 export function mountStreet(
   el: HTMLElement,
@@ -43,6 +44,57 @@ export function mountStreet(
   const scene = new Scene(canvas)
   const audio = new StreetAudio()
   const rng = new Rng((Date.now() ^ 0x57ee7) >>> 0)
+
+  // How to play. Nothing on the street says what a stud is, and nothing is
+  // going to: primeness here is a wall you walk into, not a fact you are given.
+  // But the two verbs are not discoverable — a child who does not know that a
+  // stud is a claim about the number is tapping brass at random. The manual
+  // stays reachable during play, because the moment a child needs the rules is
+  // never the title.
+  const guide = createInstructions(el, {
+    title: "FOUNDRY STREET",
+    summary: [
+      "A crowd blocks the street. Break it into equal rows, then knock the rows down.",
+      "Some crowds cannot be broken into rows at all. Those are the ones you punch.",
+    ],
+    sections: [
+      {
+        heading: "Breaking a crowd",
+        lines: [
+          "The crowd is a number. Say there are twelve of them.",
+          "There is a bar of small numbers. Tap one of them to try it.",
+          "Tap 3 and the twelve split into 4 rows of 3, made of the same people.",
+          "That only works if the number goes in evenly. If it does not, nothing breaks and the crowd closes back up.",
+        ],
+      },
+      {
+        heading: "Crowds you cannot break",
+        lines: [
+          "Some crowds will not split into equal rows however hard you try. Thirteen is one.",
+          "So are 2, 3, 5, 7 and 11.",
+          "If every number on the bar bounces off, that is your answer: this crowd cannot be broken.",
+          "Then you swing. One punch and the whole row goes down.",
+        ],
+      },
+      {
+        heading: "Swinging",
+        lines: [
+          "Your fists only work on a row that cannot be broken into smaller rows.",
+          "Swing at a row that could still be split and your fists bounce off it.",
+          "So the fast way through is to break the crowd down first, then punch the rows one at a time.",
+        ],
+      },
+      {
+        heading: "Getting it wrong",
+        lines: [
+          "There is no clock. Standing still and looking at the crowd costs you nothing.",
+          "A wrong tap makes the crowd lean on you. Enough of them in a row and it shoves you back a block.",
+          "Even then you keep everything you already built.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
 
   const street = new Street({
     rng,
@@ -226,6 +278,7 @@ export function mountStreet(
     },
     unmount(): void {
       running = false
+      guide.destroy()
       cancelAnimationFrame(frameId)
       canvas.removeEventListener("pointerdown", press)
       globalThis.removeEventListener("resize", resize)

--- a/dynawalla/games/street/src/render/scene.test.ts
+++ b/dynawalla/games/street/src/render/scene.test.ts
@@ -9,13 +9,18 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts"
 import { newCrowd, strike } from "../game/crowd.ts"
 import { bar } from "../game/factor.ts"
 import { newShutter } from "../game/shutter.ts"
 import type { Phase } from "../game/street.ts"
 import { Rng } from "../core/rng.ts"
 import { fakeCanvas } from "./fakeCanvas.ts"
-import { Scene, hit, type Frame } from "./scene.ts"
+import { Scene, hit, layoutFor, type Frame, type Layout } from "./scene.ts"
 
 const PHASES: readonly Phase[] = [
   "shutter-down",
@@ -263,6 +268,99 @@ test("a resize does not strand the layout input reads", () => {
   rec.reset()
   const layout = scene.draw(frame())
   assert.equal(scene.lastLayout, layout)
+})
+
+// --------------------------------------------------------- host chrome --
+
+/** The shapes the fleet actually has, small phone first. */
+const CHROME_SIZES: ReadonlyArray<readonly [number, number]> = [
+  [320, 568],
+  [390, 844],
+  [768, 1024],
+  [1024, 768],
+  [844, 390],
+] as const
+
+/**
+ * Everything on this frame a child must READ or TOUCH.
+ *
+ * The street, the furnace glow, the cobbles and the bodies are all deliberately
+ * left out: they bleed to the edges and under the host's controls, which is
+ * what `viewport-fit=cover` is for. What is listed here is the HUD band, the
+ * stud bar, the plate — drawn clipped to `mob` — and its rivets, plus `mob`
+ * itself, because a tap anywhere in `mob` swings.
+ */
+function critical(layout: Layout): Array<{ name: string; rect: ReturnType<typeof box> }> {
+  return [
+    { name: "the readouts", rect: box(layout.hud) },
+    { name: "the mob (a tap here swings)", rect: box(layout.mob) },
+    ...layout.studs.map((s) => ({ name: `stud ${s.k}`, rect: box(s.rect) })),
+    ...layout.rivets.map((r) => ({ name: `rivet ${r.index}`, rect: box(r.rect) })),
+  ]
+}
+
+const box = (r: { x: number; y: number; w: number; h: number }) => ({
+  x: r.x,
+  y: r.y,
+  w: r.w,
+  h: r.h,
+})
+
+test("nothing a child reads or touches lands under the host's chrome", () => {
+  // The host paints an exit control in the top-LEFT corner and a how-to-play
+  // control in the top-RIGHT, 44px each, floating OVER the game. It does not
+  // reserve a band — reserving one costs a twelfth of a small phone's height.
+  // The whole promise a game makes in exchange is these two squares.
+  //
+  // Run through `scene.draw`, which is the path the game itself takes at every
+  // frame, so a layout that only clears the corners when called by hand cannot
+  // pass this.
+  for (const [w, h] of CHROME_SIZES) {
+    const { scene } = sceneAt(w, h)
+    for (const crowd of [newCrowd(4), newCrowd(12), newCrowd(13), newCrowd(24)]) {
+      for (const phase of ["melee", "shutter", "crack", "shove"] as const) {
+        const layout = scene.draw(frame({ crowd, phase, progress: 1 }))
+        for (const { name, rect } of critical(layout)) {
+          assert.equal(
+            hitsHostChrome(rect, w),
+            false,
+            `${w}×${h}, ${phase}, mob of ${crowd.ranks}×${crowd.size}: ${name} is under the host's chrome`,
+          )
+        }
+      }
+    }
+  }
+})
+
+test("the safe rect is what the layout is built on, not the raw frame", () => {
+  // A notched phone held upright, and the same phone on its side. The street
+  // still fills the glass; the studs, the readouts and the plate do not.
+  const NOTCH: Insets = { top: 59, right: 0, bottom: 34, left: 0 }
+  const SIDEWAYS: Insets = { top: 0, right: 59, bottom: 21, left: 59 }
+  for (const [w, h, insets] of [
+    [390, 844, NOTCH],
+    [844, 390, SIDEWAYS],
+  ] as const) {
+    const area = safeRect(w, h, insets)
+    const layout = layoutFor(w, h, area, frame({ phase: "shutter", progress: 1 }))
+    for (const { name, rect } of critical(layout)) {
+      assert.ok(rect.x >= area.x - 0.5, `${name} runs out the left of the safe rect at ${w}×${h}`)
+      assert.ok(
+        rect.x + rect.w <= area.x + area.w + 0.5,
+        `${name} runs out the right of the safe rect at ${w}×${h}`,
+      )
+      assert.ok(rect.y >= area.y - 0.5, `${name} runs under the notch at ${w}×${h}`)
+      assert.ok(
+        rect.y + rect.h <= area.y + area.h + 0.5,
+        `${name} runs under the home indicator at ${w}×${h}`,
+      )
+      assert.equal(
+        hitsHostChrome(rect, w, insets),
+        false,
+        `${name} is under the host's chrome at ${w}×${h}`,
+      )
+    }
+  }
 })
 
 test("the hint is drawn as a lit stud rather than as a sentence", () => {

--- a/dynawalla/games/street/src/render/scene.ts
+++ b/dynawalla/games/street/src/render/scene.ts
@@ -23,12 +23,20 @@ import type { Shutter } from "../game/shutter.ts"
 import { PALETTE, alpha, face, label } from "./palette.ts"
 import { bar, isPrime } from "../game/factor.ts"
 import { PUSH_MAX } from "../game/push.ts"
+import {
+  exitRect,
+  helpRect,
+  safeRect,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts"
 
 export type Rect = { x: number; y: number; w: number; h: number }
 
 export type Layout = {
   readonly width: number
   readonly height: number
+  /** The band the readouts live in: the tally, the blocks and the push notches. */
+  readonly hud: Rect
   /** Tapping anywhere in here swings. */
   readonly mob: Rect
   /** One per stud on the bar, in the order `bar(size)` returns them. */
@@ -63,12 +71,136 @@ const MIN_TOUCH = 44
 /** Rank-to-rank spacing, as a multiple of the body cell. A body is 1.5 cells tall. */
 const ROW_PITCH = 1.55
 
+/** How far anything readable or touchable stands off the host's two corners. */
+const CHROME_GAP = 8
+
+/**
+ * The insets that produced `area`, recovered.
+ *
+ * `exitRect` and `helpRect` are written in terms of insets, and reading them
+ * back out of the area keeps the layout a pure function of its arguments: the
+ * chrome the layout dodges is the chrome belonging to the exact safe rect it was
+ * handed, never whatever the device happens to report mid-computation.
+ */
+function insetsOf(w: number, h: number, area: Rect): Insets {
+  return {
+    top: area.y,
+    left: area.x,
+    right: Math.max(0, w - area.x - area.w),
+    bottom: Math.max(0, h - area.y - area.h),
+  }
+}
+
+/**
+ * The rectangles the frame will be drawn into, and the ones input reads.
+ *
+ * `area` is the region the game may put readable or touchable things in — the
+ * safe rect from `packs/shared/game-chrome`, clear of the notch and the home
+ * indicator. It is **REQUIRED**, deliberately. Made optional, a caller that
+ * forgets it gets a bar of studs sitting under the home indicator and a tally
+ * lamp under the notch, and the only way to find out is on a device. Required,
+ * forgetting it does not compile.
+ *
+ * The street itself — the cobbles, the furnace glow, the bodies, the crack —
+ * still bleeds to all four edges. That is what `viewport-fit=cover` is for. It
+ * is the four things a child READS OR TOUCHES that stay inside `area` and out
+ * of the host's two 44px corners:
+ *
+ *   * the **stud bar**, the primary input;
+ *   * the **tally and blocks readouts** and the **push notches**, all in `hud`;
+ *   * the **shutter plate**, drawn clipped to `mob`, with the problem on it;
+ *   * the **rivets**, laid out inside `mob`.
+ *
+ * `mob` is itself a tap target — a tap anywhere in it swings — so its top edge
+ * is held below the host's controls too. A child reaching for the crowd and
+ * leaving the game instead is the worse of the two collisions, and it costs
+ * almost nothing: the HUD band is already taller than the chrome everywhere
+ * except a short landscape window.
+ */
+export function layoutFor(w: number, h: number, area: Rect, frame: Frame): Layout {
+  const pad = Math.round(Math.min(20, w * 0.045))
+  const insets = insetsOf(w, h, area)
+  const exit = exitRect(insets)
+  const help = helpRect(w, insets)
+
+  // The bar sits on the bottom of the SAFE rect. It grows rows until every stud
+  // clears a 44 px target — a smaller stud on a phone is a stud a child misses,
+  // and a missed stud reads as "that number did not work".
+  const studs = bar(frame.crowd.size)
+  const cols = Math.max(1, Math.min(6, Math.floor((area.w - pad * 2 + 8) / (MIN_TOUCH + 8))))
+  const rows = Math.max(1, Math.ceil(studs.length / cols))
+  const cellW = (area.w - pad * 2 - (cols - 1) * 8) / cols
+  const cellH = Math.max(MIN_TOUCH, Math.min(64, (area.h * 0.24 - (rows - 1) * 8) / rows))
+  const barH = rows * cellH + (rows - 1) * 8
+  const barTop = area.y + area.h - pad - barH
+
+  const placed: Array<{ k: number; rect: Rect }> = []
+  for (let i = 0; i < studs.length; i++) {
+    const r = Math.floor(i / cols)
+    const c = i % cols
+    // The last row is centred, so a bar of eight does not read as a bar of
+    // six with two stragglers.
+    const inRow = Math.min(cols, studs.length - r * cols)
+    const rowW = inRow * cellW + (inRow - 1) * 8
+    const x0 = area.x + (area.w - rowW) / 2
+    placed.push({
+      k: studs[i] as number,
+      rect: { x: x0 + c * (cellW + 8), y: barTop + r * (cellH + 8), w: cellW, h: cellH },
+    })
+  }
+
+  // The HUD band never dodges the chrome by moving down — that would spend a
+  // twelfth of a small phone on two buttons. It dodges sideways: the readouts
+  // start where the exit control ends and stop where the help control begins,
+  // and the band as a whole is a strip BETWEEN them.
+  const hudLeft = Math.max(area.x + pad, exit.x + exit.w + CHROME_GAP)
+  const hudRight = Math.min(area.x + area.w - pad, help.x - CHROME_GAP)
+  // Deep enough to clear the controls, so whatever begins under the band — the
+  // mob, and the plate drawn into it — begins below them.
+  const hudH = Math.max(
+    Math.round(Math.min(96, h * 0.14)),
+    exit.y + exit.h + CHROME_GAP - area.y,
+  )
+  const hud: Rect = { x: hudLeft, y: area.y, w: Math.max(1, hudRight - hudLeft), h: hudH }
+
+  const streetTop = area.y + hudH
+  const streetH = Math.max(80, barTop - pad - streetTop)
+  const mob: Rect = { x: area.x + pad, y: streetTop, w: area.w - pad * 2, h: streetH }
+
+  const rivets: Array<{ index: number; rect: Rect }> = []
+  const plate = frame.shutter
+  if (plate) {
+    const n = plate.rivets.length
+    const rcols = n <= 2 ? n : 2
+    const rrows = Math.ceil(n / rcols)
+    const gap = 12
+    const rw = Math.min(180, (mob.w - (rcols - 1) * gap) / rcols)
+    const rh = Math.max(MIN_TOUCH, Math.min(78, (mob.h * 0.46 - (rrows - 1) * gap) / rrows))
+    const gridW = rcols * rw + (rcols - 1) * gap
+    const x0 = mob.x + (mob.w - gridW) / 2
+    const y0 = mob.y + mob.h * 0.44
+    const floor = area.y + area.h - rh - 4
+    for (let i = 0; i < n; i++) {
+      const r = Math.floor(i / rcols)
+      const c = i % rcols
+      rivets.push({
+        index: i,
+        rect: { x: x0 + c * (rw + gap), y: Math.min(y0 + r * (rh + gap), floor), w: rw, h: rh },
+      })
+    }
+  }
+
+  return { width: w, height: h, hud, mob, studs: placed, rivets }
+}
+
 export class Scene {
   private readonly canvas: HTMLCanvasElement
   private readonly ctx: CanvasRenderingContext2D
   private dpr = 1
   private w = 0
   private h = 0
+  /** The safe rect, re-derived on every resize. Rotation and Split View move it. */
+  private area: Rect = { x: 0, y: 0, w: 0, h: 0 }
   private layoutCache: Layout | null = null
 
   constructor(canvas: HTMLCanvasElement) {
@@ -87,6 +219,9 @@ export class Scene {
     this.dpr = dpr
     this.canvas.width = Math.round(this.w * dpr)
     this.canvas.height = Math.round(this.h * dpr)
+    // Re-derived here rather than at mount: a rotation swaps top with left, and
+    // iPadOS moves the insets when a pack is resized in Split View.
+    this.area = safeRect(this.w, this.h)
     this.layoutCache = null
   }
 
@@ -99,67 +234,10 @@ export class Scene {
    *
    * Recomputed whenever the rank size or the plate changes, because the bar
    * narrows to `bar(size)`: a rank of five never shows a nine, so the studs
-   * move.
+   * move. Laid out against the safe rect this scene last measured.
    */
   layout(frame: Frame): Layout {
-    const w = this.w
-    const h = this.h
-    const pad = Math.round(Math.min(20, w * 0.045))
-
-    // The bar sits on the bottom. It grows rows until every stud clears a 44 px
-    // target — a smaller stud on a phone is a stud a child misses, and a missed
-    // stud reads as "that number did not work".
-    const studs = bar(frame.crowd.size)
-    const cols = Math.max(1, Math.min(6, Math.floor((w - pad * 2 + 8) / (MIN_TOUCH + 8))))
-    const rows = Math.max(1, Math.ceil(studs.length / cols))
-    const cellW = (w - pad * 2 - (cols - 1) * 8) / cols
-    const cellH = Math.max(MIN_TOUCH, Math.min(64, (h * 0.24 - (rows - 1) * 8) / rows))
-    const barH = rows * cellH + (rows - 1) * 8
-    const barTop = h - pad - barH
-
-    const placed: Array<{ k: number; rect: Rect }> = []
-    for (let i = 0; i < studs.length; i++) {
-      const r = Math.floor(i / cols)
-      const c = i % cols
-      // The last row is centred, so a bar of eight does not read as a bar of
-      // six with two stragglers.
-      const inRow = Math.min(cols, studs.length - r * cols)
-      const rowW = inRow * cellW + (inRow - 1) * 8
-      const x0 = (w - rowW) / 2
-      placed.push({
-        k: studs[i] as number,
-        rect: { x: x0 + c * (cellW + 8), y: barTop + r * (cellH + 8), w: cellW, h: cellH },
-      })
-    }
-
-    const hudH = Math.round(Math.min(96, h * 0.14))
-    const streetTop = hudH
-    const streetH = Math.max(80, barTop - pad - streetTop)
-    const mob: Rect = { x: pad, y: streetTop, w: w - pad * 2, h: streetH }
-
-    const rivets: Array<{ index: number; rect: Rect }> = []
-    const plate = frame.shutter
-    if (plate) {
-      const n = plate.rivets.length
-      const rcols = n <= 2 ? n : 2
-      const rrows = Math.ceil(n / rcols)
-      const gap = 12
-      const rw = Math.min(180, (mob.w - (rcols - 1) * gap) / rcols)
-      const rh = Math.max(MIN_TOUCH, Math.min(78, (mob.h * 0.46 - (rrows - 1) * gap) / rrows))
-      const gridW = rcols * rw + (rcols - 1) * gap
-      const x0 = mob.x + (mob.w - gridW) / 2
-      const y0 = mob.y + mob.h * 0.44
-      for (let i = 0; i < n; i++) {
-        const r = Math.floor(i / rcols)
-        const c = i % rcols
-        rivets.push({
-          index: i,
-          rect: { x: x0 + c * (rw + gap), y: Math.min(y0 + r * (rh + gap), h - rh - 4), w: rw, h: rh },
-        })
-      }
-    }
-
-    const out: Layout = { width: w, height: h, mob, studs: placed, rivets }
+    const out = layoutFor(this.w, this.h, this.area, frame)
     this.layoutCache = out
     return out
   }
@@ -230,8 +308,13 @@ export class Scene {
 
   private drawHud(frame: Frame, layout: Layout): void {
     const ctx = this.ctx
-    const pad = layout.mob.x
-    const top = Math.round(Math.min(96, this.h * 0.14))
+    // Everything up here is read, so everything up here lives in `hud` — a band
+    // that begins after the host's exit control and ends before its help
+    // control, and never runs under either.
+    const { hud } = layout
+    const left = hud.x
+    const right = hud.x + hud.w
+    const top = hud.h
 
     // The tally lamp: how many are still standing, and how wide a rank is. The
     // two numbers the whole game is about, and the only numerals up here.
@@ -240,7 +323,7 @@ export class Scene {
     ctx.textAlign = "left"
     ctx.fillStyle = PALETTE.chalk
     ctx.font = face(Math.round(top * 0.42))
-    ctx.fillText(String(standing), pad, top * 0.44)
+    ctx.fillText(String(standing), left, hud.y + top * 0.44)
 
     ctx.font = label(Math.round(top * 0.17))
     ctx.fillStyle = PALETTE.chalkDim
@@ -249,8 +332,8 @@ export class Scene {
     void w
     ctx.fillText(
       frame.crowd.ranks > 1 ? `${frame.crowd.ranks} × ${frame.crowd.size}` : "IN THE STREET",
-      pad,
-      top * 0.72,
+      left,
+      hud.y + top * 0.72,
     )
     ctx.globalAlpha = 1
 
@@ -258,17 +341,21 @@ export class Scene {
     ctx.textAlign = "right"
     ctx.fillStyle = PALETTE.brass
     ctx.font = face(Math.round(top * 0.3))
-    ctx.fillText(String(frame.blocks), this.w - pad, top * 0.42)
+    ctx.fillText(String(frame.blocks), right, hud.y + top * 0.42)
     ctx.font = label(Math.round(top * 0.15))
     ctx.fillStyle = PALETTE.chalkDim
     ctx.globalAlpha = 0.7
-    ctx.fillText(frame.best > frame.blocks ? `BLOCKS · BEST ${frame.best}` : "BLOCKS", this.w - pad, top * 0.68)
+    ctx.fillText(
+      frame.best > frame.blocks ? `BLOCKS · BEST ${frame.best}` : "BLOCKS",
+      right,
+      hud.y + top * 0.68,
+    )
     ctx.globalAlpha = 1
 
     // The push, as notches between the far end and you.
-    const nx = pad
-    const ny = top * 0.92
-    const nw = (this.w - pad * 2) / PUSH_MAX
+    const nx = left
+    const ny = hud.y + top * 0.92
+    const nw = hud.w / PUSH_MAX
     for (let i = 0; i < PUSH_MAX; i++) {
       const lit = i < frame.pushMarks
       ctx.fillStyle = lit ? PALETTE.ember : PALETTE.ironDark


### PR DESCRIPTION
## What

Adopt the shared game chrome in FOUNDRY STREET: derive the layout from
`safeRect()`, hold everything a child reads or touches out of the host's two
44px corners, and add the shared how-to-play surface.

## Why

Two defects, both invisible to a test suite that is about rules.

**1. Safe area.** `street` declares `viewport-fit=cover` — which opts the
document *into* the notch, the home indicator and the rounded corners — and
then draws its entire HUD on canvas, where `env()` cannot be reached. So the
tally lamp was drawn at `y ≈ 35` on a 390pt phone (under the notch) and the
stud bar at `h - pad` (under the home indicator). The layout is now
`layoutFor(w, h, area, frame)` with `area` **required**: made optional, a
caller that forgets it compiles and silently draws under the notch, and the
only way to find out is on a device. `Scene.resize()` re-derives it, which is
also when a rotation or an iPadOS Split View resize moves it.

**2. Host chrome.** The host paints an exit control top-LEFT and a
how-to-play control top-RIGHT, 44px each, plus a 3px hairline. They
**overlay**; they do not reserve a band, because reserving one costs a twelfth
of a small phone's height. The promise a game makes in exchange is that
nothing critical lands in those two squares.

What I judged critical for `street`, and why:

- **the HUD band** (`hud`) — the standing count, the `ranks × size` readout,
  the blocks count and the push notches. All read, all previously drawn from
  `x = pad` and `x = w - pad` at `y ≈ 0.14h`, i.e. straight through both
  corners. It now dodges **sideways**: the readouts begin where the exit
  control ends and stop where the help control begins. Sideways rather than
  down, because down is the trade that broke SKY LEDGER's lattice.
- **the stud bar** — the primary input, and a missed stud reads to a child as
  "that number did not work". Now laid out against the bottom of the safe rect.
- **the shutter plate and its four rivets** — the problem is read and the
  rivets are struck. Both are drawn clipped to `mob`, so clearing `mob` clears
  them.
- **`mob` itself** — a tap anywhere in it swings, so it is a touch target, and
  it legitimately spans the full width. I chose to clear it. Both collisions
  are real: a stray swing when a child aimed at the exit costs a push mark, and
  a child aiming at the crowd who leaves the game instead loses the session.
  The second is the worse one. It also costs almost nothing — the HUD band is
  already deeper than the chrome everywhere except a short landscape window
  (55px natural against the chrome's 57), so `mob.y` moves at all only there.

Deliberately left bleeding to all four edges: the street gradient, the furnace
glow, the cobble courses, the bodies, the crack. That is what `cover` is for.

**3. Instructions.** Nothing on screen said that a stud is a claim about the
number. Primeness being undiscoverable is the design — "a wall you walk into,
not a fact you are given" — but the two *verbs* being undiscoverable is not.

## Blast radius

**Areas touched:** dynawalla (one game pack only).

- [x] Every touched path is covered by a `ci.yml` area filter — only
      `dynawalla/games/street/` changed.
- [x] **Pack back-compat.** No published pack zip changed in place, no
      `voiceId` renamed, no catalog entry dropped. `node build.mjs street`
      re-builds and re-stages the pack; capabilities and `covers` are unchanged.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The instruction copy is
      English-only, as it is for every game pack today.
- [x] **Curriculum.** N/A — no skill id, grade, generator or renderer touched.
      `covers.skills` is unchanged.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

## Proof

```
$ cd dynawalla/games/street && for i in 1 2 3 4 5; do npm test; done
--- run 1 ---            --- run 2 ---            --- run 3 ---
# tests 99               # tests 99               # tests 99
# pass 99                # pass 99                # pass 99
# fail 0                 # fail 0                 # fail 0
--- run 4 ---            --- run 5 ---
# tests 99               # tests 99
# pass 99                # pass 99
# fail 0                 # fail 0

$ npm run tsc
> tsc --noEmit
(0 errors)

$ npm run build
vite v8.1.5 building client environment for production...
✓ 23 modules transformed.
dist/street.js  41.99 kB │ gzip: 13.49 kB
✓ built in 15ms

$ cd dynawalla/packs && node build.mjs street
dynawalla.street@0.1.0 — FOUNDRY STREET
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 40326 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~12951 bytes (12.95 KB) in 39.5ms
INF no leaks found

$ git diff origin/main..HEAD --diff-filter=D --name-only
(empty)

$ git diff origin/main..HEAD --name-only
dynawalla/games/street/src/mount.ts
dynawalla/games/street/src/render/scene.test.ts
dynawalla/games/street/src/render/scene.ts
```

### The clearance test fails without the fix

Both halves were reverted independently and the suite confirmed RED, then
restored. The test runs through `scene.draw()` — the path the game itself
takes every frame — not through a hand-built rect, so a layout that only
clears the corners when called directly cannot pass it.

```
# hud dodge removed (hudLeft/hudRight back to area.x + pad):
not ok 89 - nothing a child reads or touches lands under the host's chrome
    320×568, melee, mob of 1×4: the readouts is under the host's chrome
not ok 90 - the safe rect is what the layout is built on, not the raw frame
    the readouts is under the host's chrome at 390×844
# tests 99 / # pass 97 / # fail 2

# hud dodge restored, mob clearance removed (hudH back to round(min(96, h*0.14))):
not ok 89 - nothing a child reads or touches lands under the host's chrome
    844×390, melee, mob of 1×4: the mob (a tap here swings) is under the host's chrome
# tests 99 / # pass 97 / # fail 2
```

### One note on the instruction copy

The copy is used verbatim, and every claim in it checks out against the code —
`bar()` for the stud bar, `strike(12, 3) → 4 ranks of 3` for the split,
`isSeam` for "goes in evenly", `punch()` felling exactly one rank for "one
punch and the whole row goes down", `canPunch = isPrime` for the bounce, and
`PUSH_MAX = 6` with `push.ts`'s "restarts the wave, never touches the blocks
you have already cleared" for the last section. Two gaps worth a second pair of
eyes, neither reworded here:

1. **Swinging never says how.** The input is `hit(layout.mob, x, y) → swing()`
   — you tap the crowd. The copy says what a swing does but not that tapping
   the crowd is what does it, and the crowd is the one control with no label on
   it.
2. **The shutter is not mentioned.** Between waves the game drops a steel plate
   with an addition problem and four rivets on it, and that is the only surface
   the host actually judges. A child meeting it after the summary meets it
   cold.
