### PR TITLE
fix(dynawalla/games/horde): three of DEEPSWARM's readouts were under the host's buttons, and the CORE was never explained

### DIFF
--- a/dynawalla/games/horde/package.json
+++ b/dynawalla/games/horde/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "preview": "vite preview --port 4179 --strictPort",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/**/*.test.ts",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
     "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -13,6 +13,7 @@
  * And underneath all of it, every upgrade card states its own arithmetic, so
  * choosing well is comparing products under pressure.
  */
+import { createInstructions, type Instructions } from "../../../../packs/shared/game-chrome/index.ts"
 import type { Host, Question } from "../contract.ts"
 import { Audio } from "../core/audio.ts"
 import { Input } from "../core/input.ts"
@@ -43,6 +44,7 @@ export class Game {
   private audio = new Audio()
   private feel = new Feel()
   private ui: Overlay
+  private guide: Instructions
   private gov: TierGovernor
   private T: Tier
 
@@ -153,6 +155,65 @@ export class Game {
     this.input = new Input(this.canvas)
     this.ui = new Overlay(root)
     this.wireUi()
+
+    // How to play. The title card carries three lines of hint and then it is
+    // gone for the rest of the run — which is exactly the wrong moment, because
+    // the CORE, the sealed CACHE and the RIFT all arrive minutes later and none
+    // of them were ever named. The manual stays behind the how-to-play button
+    // for the whole session, and the swarm holds still while it is open.
+    this.guide = createInstructions(root, {
+      title: "DEEPSWARM",
+      summary: [
+        "You are one small light in the deep. The swarm comes for you and never stops.",
+        "Your weapons fire on their own. Your only job is to move.",
+      ],
+      sections: [
+        {
+          heading: "Moving",
+          lines: [
+            "Put a finger anywhere on the screen and drag. Your light swims that way.",
+            "On a keyboard, use the arrow keys or W, A, S and D.",
+            "You never aim and you never shoot. Steering is the whole game.",
+          ],
+        },
+        {
+          heading: "Getting stronger",
+          lines: [
+            "Beaten enemies drop bright gems. Swim over them to fill the bar at the top.",
+            "When the bar fills, the game stops and shows you cards. Pick one to take it.",
+            "Each card shows what it changes, like 12 damage becoming 17 damage.",
+            "Read both numbers and take the bigger jump. That is the real choice.",
+          ],
+        },
+        {
+          heading: "The CORE",
+          lines: [
+            "Every so often a gold CORE appears. Swim into it.",
+            "Time slows down and three numbered balls circle you. One holds the answer.",
+            "Swim out and touch the right one. For nine seconds nothing can stand near you.",
+            "Touch a wrong one and a ring of enemies drops on top of you. The gold ball then lights up so you can see which it was.",
+          ],
+        },
+        {
+          heading: "The CACHE",
+          lines: [
+            "Sometimes a fourth card is sealed shut with a question on it.",
+            "Answer it and you get a stronger card than any of the other three.",
+            "You never have to open it. Take a plain card instead and nothing is lost.",
+          ],
+        },
+        {
+          heading: "The RIFT",
+          lines: [
+            "When your life runs out you do not lose straight away. A RIFT opens.",
+            "Answer questions to fill the round lamps. Fill them all and you come back with full life.",
+            "A wrong answer never takes a lamp away. It takes time off the clock.",
+            "If the clock empties before the lamps fill, the run is over.",
+          ],
+        },
+      ],
+      reducedMotion: this.reduced,
+    })
 
     let seed = (Date.now() ^ 0x9e3779b9) >>> 0
     this.rng = () => {
@@ -291,6 +352,7 @@ export class Game {
     cancelAnimationFrame(this.raf)
     this.ro?.disconnect()
     window.removeEventListener("resize", this.onWinResize)
+    this.guide.destroy()
     this.input.destroy()
     this.audio.destroy()
     this.r.destroy()
@@ -332,13 +394,19 @@ export class Game {
     this.audio.frame()
     this.input.update(frame)
     this.feel.update(frame)
-    this.keyboard()
+
+    // Reading the rules is not playing. With the manual open the swarm holds
+    // its shape, the rift clock stops, and the finger resting on the panel is
+    // not a steer — a child who looks something up must not be eaten for it.
+    // The renderer keeps drawing, so the world is still there behind the sheet.
+    const reading = this.guide.isOpen
+    if (!reading) this.keyboard()
 
     // Hitstop freezes the simulation, never the renderer.
     if (this.feel.hitstopMs > 0) {
       this.feel.hitstopMs -= frameMs
     } else {
-      const simming = this.mode === "play" || this.mode === "core"
+      const simming = !reading && (this.mode === "play" || this.mode === "core")
       if (simming) {
         this.timeScale += (this.timeScaleTarget - this.timeScale) * Math.min(1, frame * 9)
         this.acc += frame
@@ -354,7 +422,7 @@ export class Game {
       }
     }
 
-    if (this.mode === "rift") this.riftTick(frame)
+    if (this.mode === "rift" && !reading) this.riftTick(frame)
     this.desat += ((this.mode === "rift" ? 0.85 : 0) - this.desat) * Math.min(1, frame * 6)
 
     this.draw(frame)

--- a/dynawalla/games/horde/src/style.css
+++ b/dynawalla/games/horde/src/style.css
@@ -2,7 +2,19 @@
    Near-black indigo, luminous edges, heavy geometric numerals. No serif on
    anything a child has to read in under half a second. */
 
+/* The host's chrome floats over this game: a back chevron top-LEFT, a
+   how-to-play button top-RIGHT, 44px each. `ui/layout.ts` owns these numbers
+   and writes them onto the root at mount; the values here are the fallbacks,
+   and they are the same numbers. Nothing a child reads or touches may land in
+   those two squares — the swarm and the light still bleed to every edge. */
 .hz-root {
+  --hz-chrome-top: 63px;
+  --hz-xp-top: 3px;
+  --hz-icon: 40px;
+  --hz-icon-gap: 6px;
+  --hz-icon-edge: 10px;
+  --hz-icon-bottom: 40px;
+  --hz-fps-edge: 10px;
   position: relative;
   width: 100%;
   height: 100%;
@@ -44,9 +56,15 @@
   padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right)) max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
 }
 
+/* The XP bar had no `env()` at all: flush to y=0 and edge to edge, so on a
+   notched phone held sideways the first forty-seven pixels of fill — the part
+   that tells a child a level is coming — were behind the sensor housing. It
+   now starts under the host's own 3px hairline rather than beneath it. */
 .hz-xpbar {
   position: absolute;
-  top: 0; left: 0; right: 0;
+  top: calc(env(safe-area-inset-top) + var(--hz-xp-top));
+  left: env(safe-area-inset-left);
+  right: env(safe-area-inset-right);
   height: 7px;
   background: rgba(120, 190, 255, 0.10);
 }
@@ -58,10 +76,15 @@
   transition: width 90ms linear;
 }
 
+/* The clock, the level and the kill count. A centred row spanning the full
+   width, so on a 320px phone its two ends reached into both host corners — and
+   it only ever grows, because "0:00" becomes "12:04" and "0 SLAIN" becomes
+   "1,204 SLAIN". It drops below the corners instead of being squeezed between
+   them. */
 .hz-top {
   position: absolute;
-  top: calc(14px + env(safe-area-inset-top));
-  left: 0; right: 0;
+  top: calc(env(safe-area-inset-top) + var(--hz-chrome-top));
+  left: env(safe-area-inset-left); right: env(safe-area-inset-right);
   display: flex;
   justify-content: center;
   gap: clamp(10px, 3vw, 26px);
@@ -187,7 +210,15 @@
   align-items: center;
   justify-content: center;
   pointer-events: auto;
-  padding: max(12px, env(safe-area-inset-top)) 12px max(12px, env(safe-area-inset-bottom));
+  /* All four edges. The top and bottom were padded and the SIDES were a bare
+     12px, so in landscape on a notched phone the outermost rift answer and the
+     outermost upgrade card — both things a child taps — ran under the sensor
+     housing and the rounded corner. */
+  padding:
+    max(12px, env(safe-area-inset-top))
+    max(12px, env(safe-area-inset-right))
+    max(12px, env(safe-area-inset-bottom))
+    max(12px, env(safe-area-inset-left));
   background:
     radial-gradient(120% 90% at 50% 40%, rgba(8, 14, 34, 0.62), rgba(2, 4, 12, 0.93));
   backdrop-filter: blur(9px) saturate(0.85);
@@ -519,17 +550,21 @@
 }
 .hz-hint b { color: #a9d8f4; }
 
-/* corner buttons */
+/* Sound and pause. These were top-right, in the 44px square the host paints
+   its how-to-play button into — two buttons and a third button stacked on the
+   same pixels. Bottom-right is the one corner of this HUD that holds nothing:
+   the weapon list is bottom-left, the life bar is bottom-centre and 12px tall,
+   and the host paints nothing down there. */
 .hz-corner {
   position: absolute;
-  top: calc(10px + env(safe-area-inset-top));
-  right: calc(10px + env(safe-area-inset-right));
+  bottom: calc(var(--hz-icon-bottom) + env(safe-area-inset-bottom));
+  right: calc(var(--hz-icon-edge) + env(safe-area-inset-right));
   display: flex;
-  gap: 6px;
+  gap: var(--hz-icon-gap);
   pointer-events: auto;
 }
 .hz-icon {
-  width: 40px; height: 40px;
+  width: var(--hz-icon); height: var(--hz-icon);
   display: grid; place-items: center;
   background: rgba(10, 20, 40, 0.55);
   border: 1px solid rgba(140, 200, 255, 0.22);
@@ -544,10 +579,11 @@
 .hz-icon:hover { background: rgba(30, 60, 110, 0.7); color: #fff; }
 .hz-icon[aria-pressed="false"] { opacity: 0.42; }
 
+/* Behind `?debug`, but it sat under the back chevron too. */
 .hz-fps {
   position: absolute;
-  left: calc(10px + env(safe-area-inset-left));
-  top: calc(12px + env(safe-area-inset-top));
+  left: calc(var(--hz-fps-edge) + env(safe-area-inset-left));
+  top: calc(env(safe-area-inset-top) + var(--hz-chrome-top));
   font-size: 10px;
   letter-spacing: 0.1em;
   color: #4f7ea0;

--- a/dynawalla/games/horde/src/ui/layout.test.ts
+++ b/dynawalla/games/horde/src/ui/layout.test.ts
@@ -1,0 +1,116 @@
+// THE TWO CORNERS.
+//
+// The host floats a 44px back chevron over the top-LEFT of every game and the
+// how-to-play button over the top-RIGHT. It reserves no band — reserving one
+// costs a twelfth of a 568px phone to hold two buttons — so the promise a game
+// makes instead is narrow and testable: nothing a child must READ or TOUCH
+// lands in those two squares.
+//
+// DEEPSWARM broke it in three places at once. The sound and pause buttons were
+// at top:10, right:10 — the host's how-to-play square exactly, a third button
+// on the same pixels. The clock/level/kills row spanned the full width at
+// top:14 and its two ends reached into both corners on a small phone. The
+// debug fps readout was under the chevron.
+//
+// And the XP bar had no `env()` at all: `top:0; left:0; right:0`, so on a
+// notched phone held sideways the first forty-seven pixels of fill were behind
+// the sensor housing.
+//
+// The rects come from `hudRects`, and the same constants are written onto the
+// root as custom properties at mount, so this cannot pass while the stylesheet
+// says something else.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import { CHROME_TOP, ICON, hudRects } from "./layout.ts"
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+const NOTCH_PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+const NOTCH_LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["the smallest phone we support", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const [insetName, insets] of [
+    ["no insets", NONE],
+    ["a notch", w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT],
+  ] as const) {
+    test(`the HUD clears the host's corners at ${name} (${w}×${h}, ${insetName})`, () => {
+      const r = hudRects(w, h, insets)
+
+      assert.equal(
+        hitsHostChrome(r.top, w, insets),
+        false,
+        `${w}×${h}: the clock and the kill count are under host chrome`,
+      )
+      assert.equal(
+        hitsHostChrome(r.corner, w, insets),
+        false,
+        `${w}×${h}: the sound and pause buttons are under the host's how-to-play button`,
+      )
+      assert.equal(
+        hitsHostChrome(r.fps, w, insets),
+        false,
+        `${w}×${h}: the fps readout is under the host's back chevron`,
+      )
+      // The XP bar is a 7px hairline flush under the host's own 3px hairline.
+      // It is allowed to share the top edge with decoration; it is not allowed
+      // to reach the 44px squares, which begin 13px down.
+      assert.equal(
+        hitsHostChrome(r.xpbar, w, insets),
+        false,
+        `${w}×${h}: the XP bar reaches into a host corner`,
+      )
+    })
+  }
+}
+
+test("every HUD box stays inside the safe area on the edges it touches", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const insets = w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT
+    const r = hudRects(w, h, insets)
+
+    for (const [what, box] of [
+      ["the XP bar", r.xpbar],
+      ["the clock row", r.top],
+      ["the sound and pause buttons", r.corner],
+      ["the fps readout", r.fps],
+    ] as const) {
+      assert.ok(box.x >= insets.left, `${name}: ${what} runs into the left inset`)
+      assert.ok(
+        box.x + box.w <= w - insets.right + 0.5,
+        `${name}: ${what} runs into the right inset`,
+      )
+      assert.ok(box.y >= insets.top, `${name}: ${what} runs under the notch`)
+      assert.ok(
+        box.y + box.h <= h - insets.bottom + 0.5,
+        `${name}: ${what} runs under the home indicator`,
+      )
+    }
+  }
+})
+
+test("the two buttons are still reachable, not merely legal", () => {
+  // Clearing the corners by leaving the screen would satisfy every assert
+  // above. They have to be somewhere a thumb goes.
+  for (const [name, w, h] of VIEWPORTS) {
+    const r = hudRects(w, h, NONE)
+    assert.ok(r.corner.x > w * 0.5, `${name}: the buttons drifted off the right side`)
+    assert.ok(r.corner.y > h * 0.5, `${name}: the buttons drifted off the bottom`)
+    assert.equal(r.corner.h, ICON)
+  }
+})
+
+test("the offset is the host's own number, not one somebody typed", () => {
+  // 57 is the bottom of the host's corner squares: a 3px hairline, a 10px
+  // margin and a 44px control. This is the inequality the file exists to hold.
+  assert.ok(CHROME_TOP >= 57, `CHROME_TOP is ${CHROME_TOP} — the host's corners end at 57`)
+})

--- a/dynawalla/games/horde/src/ui/layout.ts
+++ b/dynawalla/games/horde/src/ui/layout.ts
@@ -1,0 +1,111 @@
+/**
+ * Where the HUD sits, in numbers, and how the stylesheet learns them.
+ *
+ * **Why this file exists.** The host does not hand a pack the whole frame. It
+ * floats a 44px back chevron over the top-LEFT corner and the how-to-play
+ * button over the top-RIGHT, both painted by something that is not this game
+ * and both *inside* the safe area — which is exactly where a careful HUD puts
+ * things. DEEPSWARM's sound and pause buttons were at `top:10, right:10`,
+ * directly under the question mark; the clock, the level and the kill count
+ * were a centred row at `top:14`, straddling both corners on a 320px phone.
+ *
+ * Nothing reserves a band for the chrome. Reserving one costs 67px, a twelfth
+ * of a 568px phone, to hold two buttons, and it broke SKY LEDGER's lattice
+ * outright. The promise a game makes instead is narrow: nothing a child must
+ * READ or TOUCH lands in those two squares. The swarm, the light and the
+ * background still bleed to every edge, which is the whole point of
+ * `viewport-fit=cover`.
+ *
+ * **Why the numbers live in TypeScript.** `style.css` cannot be asserted about.
+ * These constants are written onto the root as custom properties at mount, the
+ * stylesheet reads them through `var()`, and `hudRects` reports the same
+ * geometry to the tests. One source; the CSS and the test cannot drift apart.
+ */
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+
+/**
+ * How far below the safe top edge the readouts start.
+ *
+ * Derived from the host's own published constants rather than typed here, so
+ * if the host moves its chrome this game follows on the next build.
+ */
+export const CHROME_TOP = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + 6
+
+/** The XP hairline: under the host's own hairline, never on top of it. */
+export const XP_TOP = HOST_PROGRESS_H
+export const XP_H = 7
+
+/** The clock/level/kills row. Tallest at the largest step of its clamp. */
+export const TOP_H = 44
+
+/** Sound and pause: the game's own two buttons. */
+export const ICON = 40
+export const ICON_GAP = 6
+export const ICON_EDGE = 10
+
+/**
+ * How far above the bottom edge the two buttons sit.
+ *
+ * They used to be top-right, in the host's how-to-play square. Bottom-right is
+ * the one corner of this HUD that holds nothing: the weapon list is
+ * bottom-left, the life bar is bottom-centre and is only 12px tall, and the
+ * host paints nothing down there at all. 40 clears the life bar.
+ */
+export const ICON_BOTTOM = 40
+
+/** The debug fps readout. Behind `?debug`, but it was under the chevron too. */
+export const FPS_EDGE = 10
+
+/**
+ * The boxes the HUD actually occupies, so a test can assert they clear the
+ * host's corners at every viewport instead of a device finding out.
+ */
+export function hudRects(
+  w: number,
+  h: number,
+  insets: Insets,
+): { xpbar: Rect; top: Rect; corner: Rect; fps: Rect } {
+  const left = insets.left
+  const right = insets.right
+  const iconsW = ICON * 2 + ICON_GAP
+  return {
+    xpbar: { x: left, y: insets.top + XP_TOP, w: Math.max(0, w - left - right), h: XP_H },
+    top: {
+      x: left,
+      y: insets.top + CHROME_TOP,
+      w: Math.max(0, w - left - right),
+      h: TOP_H,
+    },
+    corner: {
+      x: Math.max(0, w - right - ICON_EDGE - iconsW),
+      y: Math.max(0, h - insets.bottom - ICON_BOTTOM - ICON),
+      w: iconsW,
+      h: ICON,
+    },
+    fps: { x: left + FPS_EDGE, y: insets.top + CHROME_TOP, w: 170, h: 46 },
+  }
+}
+
+/**
+ * Hand the stylesheet the numbers above.
+ *
+ * `style.css` carries the same values as fallbacks so a stylesheet loaded
+ * without a mounted root still looks right; these overwrite them, and these are
+ * what the tests see.
+ */
+export function applyChromeVars(root: HTMLElement): void {
+  root.style.setProperty("--hz-chrome-top", `${CHROME_TOP}px`)
+  root.style.setProperty("--hz-xp-top", `${XP_TOP}px`)
+  root.style.setProperty("--hz-icon", `${ICON}px`)
+  root.style.setProperty("--hz-icon-gap", `${ICON_GAP}px`)
+  root.style.setProperty("--hz-icon-edge", `${ICON_EDGE}px`)
+  root.style.setProperty("--hz-icon-bottom", `${ICON_BOTTOM}px`)
+  root.style.setProperty("--hz-fps-edge", `${FPS_EDGE}px`)
+}

--- a/dynawalla/games/horde/src/ui/overlay.ts
+++ b/dynawalla/games/horde/src/ui/overlay.ts
@@ -4,6 +4,7 @@
  */
 import type { Card } from "../game/loadout.ts"
 import type { Question } from "../contract.ts"
+import { applyChromeVars } from "./layout.ts"
 
 const h = <K extends keyof HTMLElementTagNameMap>(
   tag: K, cls?: string, text?: string,
@@ -62,6 +63,12 @@ export class Overlay {
 
   constructor(root: HTMLElement) {
     this.root = root
+
+    // The stylesheet is a static file and cannot be asserted about, so the
+    // numbers that keep this HUD out of the host's two corners live in
+    // `layout.ts` and are handed to the CSS here. One source, and the tests
+    // read the same one.
+    applyChromeVars(root)
 
     const hud = h("div", "hz-hud")
     const xp = h("div", "hz-xpbar")


### PR DESCRIPTION
## What

Adopt the shared game chrome in DEEPSWARM: finish the safe-area coverage on the
two elements that were missing it, move three readouts out of the host's 44px
corners, add a `createInstructions` manual that actually explains the CORE, the
CACHE and the RIFT — and fix a quoting bug that was about to stop the arithmetic
test from running.

## Why

**The safe area was nearly complete.** Most of this HUD was careful: the modal
padded top and bottom, the weapon list left and bottom, the life bar bottom,
the clock top, the fps readout top and left. Two elements were not.

- `.hz-xpbar` had **no `env()` at all** — `top:0; left:0; right:0`. On a
  notched phone held sideways the first 47px of fill, the part that tells a
  child a level-up is coming, sat behind the sensor housing.
- `.hz-modal` padded `top` and `bottom` and left the **sides** a bare `12px`.
  In landscape the outermost RIFT answer and the outermost upgrade card — both
  things a child taps — ran under the housing and the rounded corner.

**The two corners, which `env()` cannot help with.** The host floats a 44px
back chevron top-LEFT and the how-to-play button top-RIGHT, both *inside* the
safe area, which is exactly where a careful HUD puts things.

- Sound and pause were at `top:10, right:10` — the host's how-to-play square,
  exactly. Three buttons on the same pixels. They move to the bottom-right,
  the one corner of this HUD that holds nothing: the weapon list is
  bottom-left, the life bar is bottom-centre and 12px tall, and the host
  paints nothing down there.
- The clock/level/kills row spanned the full width at `top:14`, and its
  centred contents reached into both corners on a 320px phone. It only grows
  from there — "0:00" becomes "12:04", "0 SLAIN" becomes "1,204 SLAIN". It
  drops below the corners instead of being squeezed between them.
- The `?debug` fps readout was under the chevron. Same drop.

No band is reserved. 67px is a twelfth of a 568px phone spent on two buttons,
and it broke SKY LEDGER's lattice outright. The swarm and the light still bleed
to every edge, which is what `viewport-fit=cover` is for.

**The test script was silently running one file.** `--test src/**/*.test.ts`
was unquoted. `sh` has no `**`, so it expanded the pattern itself; with only
`src/stubHost.test.ts` present nothing matched, the pattern survived to node,
and node's own globber found it. Adding a second test file under `src/ui/`
made the shell match exactly that one — and `stubHost.test.ts`, the file that
proves no child is told correct work is wrong, would have stopped running with
nothing failing. Quoted, so node globs: **7 tests became 20, not 13.**

**Nobody was ever told what a CORE is.** The title card carries three lines of
hint and then it is gone for the run. The CORE, the sealed CACHE and the RIFT
all arrive minutes later and none of them was named anywhere. A child whose
life runs out meets a screen of round lamps and a draining clock with no idea
that answering fills them. The manual sits behind the how-to-play button for
the whole session and the swarm holds still while it is open.

## Blast radius

**Areas touched:** dynawalla (`dynawalla/games/horde/` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no
      `voiceId` renamed; no catalog entry dropped. `pack.json` untouched.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifests.
- [x] **Strings.** N/A — pack-local copy, not `corpan-app` locales.
- [x] **Curriculum.** N/A — no skill, generator, schema or renderer touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

Behaviour that changed for a player: sound and pause move from the top-right
to the bottom-right; the clock row and the fps readout sit ~49px lower; the XP
bar starts under the safe top edge instead of at y=0; modals pad all four
sides; a `?` button appears top-right; the simulation and the rift clock freeze
while the manual is open.

## Proof

```
$ npm test    # five runs — one green run is not proof
--- run 1 ---
# tests 20
# pass 20
# fail 0
--- run 2 ---
# tests 20
# pass 20
# fail 0
--- run 3 ---
# tests 20
# pass 20
# fail 0
--- run 4 ---
# tests 20
# pass 20
# fail 0
--- run 5 ---
# tests 20
# pass 20
# fail 0

$ npm run tsc
> @dynawalla/game-horde@0.1.0 tsc
> tsc --noEmit
(0 errors)

$ npm run build
dist/horde.js  138.00 kB | gzip: 40.23 kB
✓ built in 431ms

$ cd dynawalla/packs && node build.mjs horde
dynawalla.horde@0.1.0 — DEEPSWARM
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       9 skills, grades 1–5
  on disk      3 files, 120151 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF no leaks found

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty — nothing deleted)

$ git diff --name-only origin/main..HEAD
dynawalla/games/horde/package.json
dynawalla/games/horde/src/game/game.ts
dynawalla/games/horde/src/style.css
dynawalla/games/horde/src/ui/layout.test.ts
dynawalla/games/horde/src/ui/layout.ts
dynawalla/games/horde/src/ui/overlay.ts
```

**The clearance test fails when the fix is removed.** `CHROME_TOP` back to 14,
`XP_TOP` back to 0, `ICON_BOTTOM` to a value that puts the buttons back near
the top edge, and the two full-width rects back to `x: 0`:

```
$ node --test src/ui/layout.test.ts     # with the fix reverted
not ok 1 - the HUD clears the host's corners at the smallest phone we support (320×568, no insets)
not ok 2 - the HUD clears the host's corners at the smallest phone we support (320×568, a notch)
not ok 3 - the HUD clears the host's corners at phone portrait (390×844, no insets)
not ok 4 - the HUD clears the host's corners at phone portrait (390×844, a notch)
not ok 5 - the HUD clears the host's corners at tablet portrait (768×1024, no insets)
not ok 6 - the HUD clears the host's corners at tablet portrait (768×1024, a notch)
not ok 7 - the HUD clears the host's corners at tablet landscape (1024×768, no insets)
not ok 8 - the HUD clears the host's corners at tablet landscape (1024×768, a notch)
not ok 9 - the HUD clears the host's corners at phone landscape (844×390, no insets)
not ok 10 - the HUD clears the host's corners at phone landscape (844×390, a notch)
not ok 11 - every HUD box stays inside the safe area on the edges it touches
not ok 13 - the offset is the host's own number, not one somebody typed
# tests 13
# pass 1
# fail 12

$ node --test src/ui/layout.test.ts     # restored
# tests 13
# pass 13
# fail 0
```

The rects the test asserts come from `hudRects()` in `src/ui/layout.ts`, and
the same constants are written onto `.hz-root` as custom properties at mount
and read back by `style.css` through `var()`. The test cannot pass while the
stylesheet says something different.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
