### PR TITLE
feat(dynawalla/games/merge-idle): the reef HUD clears the notch and the two host corners, and there are instructions

### DIFF
--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -17,6 +17,13 @@
  *   is a real cost with no red X and no lecture anywhere in the file.
  */
 
+import {
+  createInstructions,
+  onInsetsChange,
+  safeRect,
+  type Instructions,
+  type InstructionsSpec,
+} from '../../../packs/shared/game-chrome/index.ts'
 import type { Host, Question } from './contract.ts'
 import {
   at,
@@ -71,6 +78,7 @@ import { Particles, Shockwaves } from './fx/particles.ts'
 import { approach, ease, Punch } from './fx/shake.ts'
 import { CHALK, DANGER, hex, lift, rampAt, TIDE } from './render/palette.ts'
 import { cellAtPoint, cellCentre, Renderer } from './render/renderer.ts'
+import { chromeLayout, stageAreaFor } from './ui/chrome.ts'
 import { Hud, type Action } from './ui/hud.ts'
 
 const MAX_ROWS = 9
@@ -78,6 +86,81 @@ const START_COLS = 5
 const START_ROWS = 6
 
 type Cascade = { cell: number; value: number; at: number; chain: number }
+
+/**
+ * How to play, in a child's words.
+ *
+ * An idle game is the one genre that CANNOT be figured out by watching, because
+ * the half of it that matters happens while nobody is looking. A child who is
+ * not told that the reef keeps earning after they close it will read the away
+ * time as the game doing nothing, and the tide gate on their return as a quiz
+ * that came out of nowhere. So the manual says the quiet parts out loud: the
+ * reef earns while you are gone, it saves itself, and coming back is a move.
+ */
+const INSTRUCTIONS = (reducedMotion: boolean): InstructionsSpec => ({
+  title: 'ABYSSAL BLOOM',
+  summary: [
+    'Two polyps with the same number join into one polyp worth double. Drag one onto the other.',
+    'The tall vents hold up a sum. Build the answer out of polyps and drop it in the vent’s mouth.',
+  ],
+  sections: [
+    {
+      heading: 'Joining polyps',
+      lines: [
+        'The glowing creatures on the reef are polyps. Each one has a number.',
+        'Drag a polyp on top of another polyp with the same number.',
+        'They join into one polyp. Its number is the two numbers added together, so it is double.',
+        '3 and 3 make 6. 6 and 6 make 12. 96 and 96 make 192.',
+        'Tap a polyp once and every polyp with that same number lights up. That is how you find its partner.',
+        'Drag a polyp onto an empty space to move it there.',
+      ],
+    },
+    {
+      heading: 'Feeding a vent',
+      lines: [
+        'The tall towers are vents. Each vent holds up a sum, like 96 + 96.',
+        'Work out the answer. Then join polyps until you have a polyp with that number.',
+        'Drag that polyp into the round mouth at the bottom of the vent.',
+        'If it is right the vent erupts. It pays you essence, gets stronger, and asks a harder sum.',
+        'If it is wrong the vent goes cold for about three seconds. Wait for it to warm up, then try again.',
+        'Get several right in a row and your FLOW goes up, and every vent pays more.',
+        'Some answers are not numbers a polyp can have. Then four tiles appear above the vent. Drag the right tile into the mouth instead.',
+      ],
+    },
+    {
+      heading: 'Essence and the buttons',
+      lines: [
+        'Essence is the big number at the top. Vents make essence every second, all on their own.',
+        'Spend it on the buttons along the bottom.',
+        'UPWELL buys a handful of new polyps right now.',
+        'AWAKEN wakes up one more vent, so there are more sums and more essence.',
+        'DEEPEN makes the reef bigger, so you have more room.',
+        'OVERCHARGE makes every vent stronger at the same time.',
+      ],
+    },
+    {
+      heading: 'When the reef is full',
+      lines: [
+        'If every space is full and no two numbers match, a red bar says SHELF CROWDED.',
+        'Press DISSOLVE. It is free.',
+        'It clears away all the smallest polyps and pays you their numbers.',
+        'You can never get stuck. DISSOLVE always works.',
+      ],
+    },
+    {
+      heading: 'Going away and coming back',
+      lines: [
+        'This game keeps going when you are not here. That is not a bug, it is the point.',
+        'Leave, do something else, come back. The reef made essence the whole time you were gone, for up to eight hours.',
+        'When you come back a tide is waiting, with one question. Answer it and the tide is yours.',
+        'Get it right on the first try and you keep three times as much.',
+        'While you play, a glowing ball marked TIDE floats up now and then. Tap it for another one.',
+        'Your reef saves itself. It will be exactly where you left it.',
+      ],
+    },
+  ],
+  reducedMotion,
+})
 
 export function mountGame(el: HTMLElement, host: Host): { unmount(): void } {
   return new Game(el, host).handle()
@@ -89,6 +172,7 @@ class Game {
   private rnd: () => number
   private renderer: Renderer
   private hud: Hud
+  private guide: Instructions | null = null
   private audio = new Audio()
   private punch = new Punch()
   private particles: Particles
@@ -175,6 +259,8 @@ class Game {
     if (this.s.vents.length === 0) this.addVent()
     if (polyps(this.s.board).length === 0) this.seedShelf()
 
+    this.guide = createInstructions(el, INSTRUCTIONS(this.s.reduceMotion))
+
     this.bindInput()
     this.observeSize()
     this.layout()
@@ -190,6 +276,8 @@ class Game {
 
   private unmount(): void {
     this.running = false
+    this.guide?.destroy()
+    this.guide = null
     cancelAnimationFrame(this.raf)
     for (const off of this.detach) off()
     this.detach = []
@@ -201,6 +289,11 @@ class Game {
   }
 
   private observeSize(): void {
+    // Insets change more often than "never": a rotation swaps top and bottom
+    // with left and right, and iPadOS changes them when a pack is resized in
+    // Split View. A game that measures them once at mount is correct until the
+    // first rotation and wrong after it.
+    this.detach.push(onInsetsChange(() => this.layout()))
     if (typeof ResizeObserver === 'undefined') {
       const onResize = (): void => this.layout()
       window.addEventListener('resize', onResize)
@@ -211,11 +304,24 @@ class Game {
     this.ro.observe(this.hud.stage)
   }
 
+  /**
+   * One pass: the DOM chrome first, because the band's height decides where the
+   * stage starts, then the canvas inside whatever the stage turned out to be.
+   *
+   * The stage is measured rather than predicted — the rail grows a row when
+   * DISSOLVE appears — but its safe area comes from the same `chromeLayout`
+   * the band used, so the two can never disagree about where the notch is.
+   */
   private layout(): void {
-    const w = this.hud.stage.clientWidth || this.el.clientWidth || 360
-    const h = this.hud.stage.clientHeight || 480
+    const rw = this.el.clientWidth || 360
+    const rh = this.el.clientHeight || 640
+    const chrome = chromeLayout(rw, rh, safeRect(rw, rh))
+    this.hud.applyChrome(chrome)
+
+    const w = this.hud.stage.clientWidth || rw
+    const h = this.hud.stage.clientHeight || chrome.stage.h
     const dpr = Math.min(3, window.devicePixelRatio || 1)
-    this.renderer.resize(w, h, dpr, this.s.board, this.s.tier)
+    this.renderer.resize(w, h, dpr, this.s.board, this.s.tier, stageAreaFor(chrome, w, h))
     this.layoutVents()
     this.snowSeeded = false
   }

--- a/dynawalla/games/merge-idle/src/render/renderer.ts
+++ b/dynawalla/games/merge-idle/src/render/renderer.ts
@@ -58,20 +58,34 @@ export type Layout = {
  * them into a column down the right, which is the only way a tablet or a
  * desktop stops looking like a phone screenshot with grey bars beside it — and
  * it hands the whole reclaimed width back to the shelf.
+ *
+ * `area` is the region of the stage the game may put readable things in — see
+ * `ui/chrome.ts`, `stageAreaFor`. It is REQUIRED, deliberately, and not
+ * optional: a caller that forgets it gets a shelf and a column of vents laid
+ * out to the raw canvas edges, which on a phone held wide puts the vent that
+ * holds the question under the sensor housing. The only way to notice that is
+ * on a device. Required, forgetting it does not compile.
+ *
+ * The WATER is not laid out against `area` and must not be. The gradient, the
+ * light shafts and every particle run to the glass edges and under the rounded
+ * corners, which is the whole reason the document asks for `viewport-fit=cover`
+ * in the first place.
  */
-export function computeLayout(w: number, h: number, dpr: number, b: Board): Layout {
+export function computeLayout(w: number, h: number, dpr: number, b: Board, area: Rect): Layout {
   const pad = Math.max(8, Math.min(22, w * 0.03))
   const ventColumn = w / Math.max(1, h) > 1.15
+  const right = area.x + area.w
+  const bottom = area.y + area.h
   let board: Rect
   let ventStrip: Rect
   if (ventColumn) {
-    const cw = Math.max(190, Math.min(300, w * 0.26))
-    board = { x: pad, y: pad, w: w - cw - pad * 2.5, h: h - pad * 2 }
-    ventStrip = { x: w - cw - pad * 0.5, y: pad, w: cw, h: h - pad * 2 }
+    const cw = Math.max(190, Math.min(300, area.w * 0.26))
+    board = { x: area.x + pad, y: area.y + pad, w: area.w - cw - pad * 2.5, h: area.h - pad * 2 }
+    ventStrip = { x: right - cw - pad * 0.5, y: area.y + pad, w: cw, h: area.h - pad * 2 }
   } else {
-    const ventH = Math.max(104, Math.min(180, h * 0.21))
-    board = { x: pad, y: pad * 0.6, w: w - pad * 2, h: h - ventH - pad * 1.6 }
-    ventStrip = { x: pad, y: h - ventH, w: w - pad * 2, h: ventH - pad * 0.5 }
+    const ventH = Math.max(104, Math.min(180, area.h * 0.21))
+    board = { x: area.x + pad, y: area.y + pad * 0.6, w: area.w - pad * 2, h: area.h - ventH - pad * 1.6 }
+    ventStrip = { x: area.x + pad, y: bottom - ventH, w: area.w - pad * 2, h: ventH - pad * 0.5 }
   }
   const gap = Math.max(3, Math.min(9, Math.min(board.w, board.h) * 0.018))
   const cell = Math.max(
@@ -139,6 +153,8 @@ export class Renderer {
   private sg: CanvasRenderingContext2D
   private book = new SpriteBook()
   layout: Layout
+  /** The stage's safe rectangle, kept so `relayout` does not have to be told twice. */
+  private area: Rect = { x: 0, y: 0, w: 1, h: 1 }
   private glowScale = 0.5
   private waterGrad: CanvasGradient | null = null
   private gradKey = ''
@@ -162,7 +178,7 @@ export class Renderer {
     this.book.clear()
   }
 
-  resize(w: number, h: number, dpr: number, b: Board, tier: State['tier']): void {
+  resize(w: number, h: number, dpr: number, b: Board, tier: State['tier'], area: Rect): void {
     const budget = BUDGET[tier]
     this.glowScale = budget.glowScale
     this.book.setDpr(dpr)
@@ -185,14 +201,15 @@ export class Renderer {
     this.wg.setTransform(dpr, 0, 0, dpr, 0, 0)
     this.gg.setTransform(dpr * this.glowScale, 0, 0, dpr * this.glowScale, 0, 0)
     this.sg.setTransform(dpr, 0, 0, dpr, 0, 0)
-    this.layout = computeLayout(w, h, dpr, b)
+    this.area = area
+    this.layout = computeLayout(w, h, dpr, b, area)
     this.waterGrad = null
     this.gradKey = ''
   }
 
   relayout(b: Board): void {
     const l = this.layout
-    this.layout = computeLayout(l.w, l.h, l.dpr, b)
+    this.layout = computeLayout(l.w, l.h, l.dpr, b, this.area)
     this.book.clear()
   }
 

--- a/dynawalla/games/merge-idle/src/ui/chrome.test.ts
+++ b/dynawalla/games/merge-idle/src/ui/chrome.test.ts
@@ -1,0 +1,174 @@
+// THE FRAME.
+//
+// A layout bug is invisible to every test that is about rules, so all 54 of
+// this game's other tests passed while the essence odometer sat underneath the
+// notch and underneath the host's exit chevron, and the magnitude pips sat
+// underneath the how-to-play control. This file is that gate.
+//
+// It runs the real layout — the same `chromeLayout` the HUD applies and the
+// same `computeLayout` the renderer resizes with — at the shapes the fleet
+// actually has, with and without a notch, and asserts the two things a
+// screenshot would have shown:
+//
+//   1. Nothing a child must READ or TOUCH is inside the safe area's edges.
+//   2. Nothing a child must READ or TOUCH lands in either of the host's two
+//      44px corners.
+//
+// The water, the light shafts and the particles are deliberately NOT checked.
+// They run to the glass edge and under the rounded corners on purpose; that is
+// the whole reason the document asks for `viewport-fit=cover`.
+//
+// Tablet and desktop are first-class here. Neither is a stretched phone.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from '../../../../packs/shared/game-chrome/index.ts'
+import { makeBoard } from '../core/board.ts'
+import { computeLayout } from '../render/renderer.ts'
+import { chromeLayout, stageAreaFor } from './chrome.ts'
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ['phone portrait, small', 320, 568],
+  ['phone portrait, tall', 390, 844],
+  ['phone landscape', 844, 390],
+  ['tablet portrait', 768, 1024],
+  ['tablet landscape', 1024, 768],
+  ['laptop', 1440, 900],
+]
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+/** A notched phone held tall: the sensor housing above, the home indicator below. */
+const TALL: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+/** The same phone turned sideways: the housing moves to one edge, and swaps. */
+const WIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+const insetCases = (w: number, h: number): Array<[string, Insets]> => [
+  ['no insets', NONE],
+  ['notched', w > h ? WIDE : TALL],
+]
+
+/** Move a stage-local rect into viewport coordinates. */
+const onGlass = (r: Rect, stage: Rect): Rect => ({
+  x: r.x + stage.x,
+  y: r.y + stage.y,
+  w: r.w,
+  h: r.h,
+})
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const [label, ins] of insetCases(w, h)) {
+    test(`the frame holds together at ${name} (${w}×${h}, ${label})`, () => {
+      const area = safeRect(w, h, ins)
+      const c = chromeLayout(w, h, area)
+
+      // The band's readout is inside the safe area, in all four directions.
+      assert.ok(c.readout.y >= area.y, 'the readout starts above the safe area')
+      assert.ok(c.readout.x >= area.x, 'the readout starts left of the safe area')
+      assert.ok(
+        c.readout.x + c.readout.w <= area.x + area.w + 0.5,
+        'the readout runs past the right of the safe area',
+      )
+      assert.ok(c.readout.w >= 120, `the readout is ${c.readout.w.toFixed(0)}px wide — nothing fits`)
+
+      // The rail keeps its buttons off the home indicator.
+      assert.ok(
+        c.railPad.bottom >= ins.bottom,
+        'the action rail sits on top of the home indicator',
+      )
+
+      // The stage begins below the band and ends above the rail.
+      assert.equal(c.stage.y, c.band.h)
+      assert.ok(c.stage.h > 120, `the stage is ${c.stage.h.toFixed(0)}px tall — no room to play`)
+
+      // The canvas, through the renderer's own layout function.
+      const board = makeBoard(5, 6)
+      const sa = stageAreaFor(c, c.stage.w, c.stage.h)
+      const l = computeLayout(c.stage.w, c.stage.h, 2, board, sa)
+
+      // The shelf and the vents stay inside the safe area; the water does not,
+      // and is not asked to.
+      assert.ok(l.board.x >= ins.left, 'the shelf runs under the left edge')
+      assert.ok(
+        l.board.x + l.board.w <= w - ins.right + 0.5,
+        'the shelf runs under the right edge',
+      )
+      assert.ok(l.ventStrip.x >= ins.left, 'the vents run under the left edge')
+      assert.ok(
+        l.ventStrip.x + l.ventStrip.w <= w - ins.right + 0.5,
+        'the vents run under the right edge',
+      )
+      assert.ok(l.cell >= 18, `the shelf cell is ${l.cell.toFixed(1)}px — the numerals collide`)
+      assert.ok(l.ventStrip.w > 60 && l.ventStrip.h > 60, 'the vents have collapsed')
+    })
+  }
+}
+
+test('nothing a child reads or touches sits under the host chrome', () => {
+  // The host paints an exit chevron top-LEFT and a how-to-play control
+  // top-RIGHT, floating over the pack rather than reserving a band — reserving
+  // one cost 12% of a small phone's height. The promise a game makes in return
+  // is exactly this: those two 44px squares hold nothing critical.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const where = `${name} (${w}×${h}, ${label})`
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+
+      assert.equal(
+        hitsHostChrome(c.readout, w, ins),
+        false,
+        `${where}: the essence readout is under host chrome`,
+      )
+      assert.equal(
+        hitsHostChrome(c.mute, w, ins),
+        false,
+        `${where}: the mute button is under host chrome`,
+      )
+      assert.equal(
+        hitsHostChrome(c.rail, w, ins),
+        false,
+        `${where}: the action rail is under host chrome`,
+      )
+
+      // The canvas too: the shelf a child drags on, and the vent that holds the
+      // question. Both are in stage coordinates, so they move onto the glass by
+      // the height of the band above them.
+      const board = makeBoard(5, 6)
+      const sa = stageAreaFor(c, c.stage.w, c.stage.h)
+      const l = computeLayout(c.stage.w, c.stage.h, 2, board, sa)
+      assert.equal(
+        hitsHostChrome(onGlass(l.board, c.stage), w, ins),
+        false,
+        `${where}: the shelf is under host chrome`,
+      )
+      assert.equal(
+        hitsHostChrome(onGlass(l.ventStrip, c.stage), w, ins),
+        false,
+        `${where}: the vents are under host chrome`,
+      )
+    }
+  }
+})
+
+test('the band is tall enough that the whole canvas clears the corners', () => {
+  // This is the invariant that makes the canvas safe without the canvas having
+  // to know anything: the stage starts below the host's two squares, so every
+  // polyp, vent and floater is clear of them by construction. It holds because
+  // the odometer's floor height is larger than the gap it has to cover, and it
+  // is asserted here so that shrinking the odometer cannot silently break it.
+  for (const [, w, h] of VIEWPORTS) {
+    for (const [, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      const cornerBottom = ins.top + 3 + 10 + 44
+      assert.ok(
+        c.stage.y >= cornerBottom,
+        `${w}×${h}: the stage starts at ${c.stage.y} — above the corners' ${cornerBottom}`,
+      )
+    }
+  }
+})

--- a/dynawalla/games/merge-idle/src/ui/chrome.ts
+++ b/dynawalla/games/merge-idle/src/ui/chrome.ts
@@ -1,0 +1,176 @@
+/**
+ * Where ABYSSAL BLOOM's chrome goes — as numbers, so a test can check it.
+ *
+ * **Why this file exists.** The reef declares `viewport-fit=cover`, which is not
+ * a neutral setting: it opts the document *into* the notch, the home indicator
+ * and the rounded corners. Until now the essence odometer sat at `top: 8px`,
+ * `left: 12px` of the glass, which on a notched phone is underneath the notch
+ * and underneath the host's exit chevron — and the pips sat at the far right,
+ * underneath the how-to-play control. The two things a child reads constantly
+ * were the two things covered up.
+ *
+ * The host does NOT reserve a band for its chrome; it floats over the game and
+ * asks each game for one promise instead: nothing a child must READ or TOUCH
+ * lands in the two 44px corners. (Reserving a band was tried and cost 12% of a
+ * small phone's height — see `packs/shared/game-chrome/hostChrome.ts`.) So the
+ * band still spans the full width and its gradient still bleeds to both edges;
+ * it is the readout INSIDE it that is pushed past both corners.
+ *
+ * Everything here is pure arithmetic: no DOM, no `env()`, no measuring. The
+ * safe rectangle arrives as an argument, which is what makes the whole layout
+ * testable at 320x568 in node.
+ */
+
+import { exitRect, helpRect, type Rect } from '../../../../packs/shared/game-chrome/index.ts'
+
+export type Insets = { top: number; right: number; bottom: number; left: number }
+
+/** Breathing room between the host's controls and anything of ours. */
+const GAP = 8
+
+/** The band's own padding, above and below the readout. */
+const BAND_TOP = 8
+const BAND_BOTTOM = 6
+
+/**
+ * The two fixed lines of the readout, in px, locked by `line-height` in the
+ * HUD's stylesheet. Fixed on purpose: the band's height is the stage's origin,
+ * and a stage origin that depends on a font metric is a stage origin that moves
+ * when the platform font does.
+ */
+const CAP_H = 11
+const RATE_H = 14
+/** `.ab-essence` is a 1px-gap column of three rows. */
+const ROW_GAP = 1
+
+/** The mute button, and its gap from the stage's top-right corner. */
+const MUTE = 30
+const MUTE_GAP = 8
+
+/** The action rail: one row of buttons, its gaps and its padding. */
+const RAIL_BTN = 46
+const RAIL_GAP = 6
+const RAIL_TOP = 6
+const RAIL_BOTTOM = 10
+/** Above this width the rail is four across instead of two; matches the CSS. */
+const RAIL_WIDE = 620
+
+export type Chrome = {
+  w: number
+  h: number
+  inset: Insets
+  /** The whole top band. Its gradient bleeds edge to edge, and should. */
+  band: Rect
+  /**
+   * What the child READS up there: the essence odometer, the rate, the flow
+   * pill and the magnitude pips. Clear of both host corners at every viewport,
+   * which is the assertion in `chrome.test.ts`.
+   */
+  readout: Rect
+  /** Digit height of the odometer, px. */
+  odoPx: number
+  /** The mute button, in viewport coordinates. */
+  mute: Rect
+  /** The canvas stage, between the band and the rail. */
+  stage: Rect
+  /**
+   * The action rail, at the height it takes with the four standing buttons.
+   * DISSOLVE appears only on a crowded shelf and adds a row; the DOM measures
+   * that for itself, and only this nominal height is ever laid out against.
+   */
+  rail: Rect
+  /** The band's padding, for the DOM to apply verbatim. */
+  bandPad: { top: number; right: number; bottom: number; left: number }
+  /** The rail's padding — this is where the home indicator is kept out. */
+  railPad: { top: number; right: number; bottom: number; left: number }
+}
+
+/**
+ * Recover the insets from a safe rectangle.
+ *
+ * The rest of the game only ever holds the safe rect, and `exitRect`/`helpRect`
+ * want insets. Deriving them here means one measurement, taken once per layout,
+ * flows through everything — instead of a second `safeInsets()` call that could
+ * disagree with the first across a rotation.
+ */
+export function insetsOf(w: number, h: number, area: Rect): Insets {
+  return {
+    top: Math.max(0, area.y),
+    left: Math.max(0, area.x),
+    right: Math.max(0, w - area.x - area.w),
+    bottom: Math.max(0, h - area.y - area.h),
+  }
+}
+
+const clamp = (lo: number, hi: number, v: number): number => Math.max(lo, Math.min(hi, v))
+
+/**
+ * The whole frame, from the glass size and the safe rectangle.
+ *
+ * `area` is REQUIRED, deliberately — the same call the pilot game makes. Made
+ * optional, a caller that forgets it gets a HUD that quietly draws under the
+ * notch and under the host's exit control, and the only way to find out is on a
+ * notched device. Required, forgetting it does not compile.
+ */
+export function chromeLayout(w: number, h: number, area: Rect): Chrome {
+  const inset = insetsOf(w, h, area)
+  const exit = exitRect(inset)
+  const help = helpRect(w, inset)
+
+  // Past the chevron on the left, past the ? on the right. The band itself
+  // still starts at x=0 so its gradient covers the whole top edge.
+  const padLeft = exit.x + exit.w + GAP
+  const padRight = Math.max(0, w - help.x) + GAP
+  const padTop = inset.top + BAND_TOP
+  const readoutW = Math.max(1, w - padLeft - padRight)
+
+  const odoPx = Math.round(clamp(26, 48, readoutW * 0.14))
+  const readoutH = CAP_H + ROW_GAP + odoPx + ROW_GAP + RATE_H
+  const bandH = padTop + readoutH + BAND_BOTTOM
+
+  const rows = w >= RAIL_WIDE ? 1 : 2
+  const railH = RAIL_TOP + rows * RAIL_BTN + (rows - 1) * RAIL_GAP + RAIL_BOTTOM + inset.bottom
+  const stageH = Math.max(1, h - bandH - railH)
+
+  return {
+    w,
+    h,
+    inset,
+    band: { x: 0, y: 0, w, h: bandH },
+    readout: { x: padLeft, y: padTop, w: readoutW, h: readoutH },
+    odoPx,
+    mute: { x: w - inset.right - MUTE_GAP - MUTE, y: bandH + MUTE_GAP, w: MUTE, h: MUTE },
+    stage: { x: 0, y: bandH, w, h: stageH },
+    rail: { x: 0, y: bandH + stageH, w, h: railH },
+    bandPad: { top: padTop, right: padRight, bottom: BAND_BOTTOM, left: padLeft },
+    railPad: {
+      top: RAIL_TOP,
+      right: RAIL_BOTTOM + inset.right,
+      bottom: RAIL_BOTTOM + inset.bottom,
+      left: RAIL_BOTTOM + inset.left,
+    },
+  }
+}
+
+/**
+ * The safe rectangle *inside the canvas stage*, in the stage's own coordinates.
+ *
+ * The stage is full-bleed on purpose — the water, the light shafts and every
+ * particle should run under the rounded corners, which is the entire reason
+ * `cover` is set. What must stay inside this rect is the shelf and the vents:
+ * the numerals a child reads and the mouths they drop into.
+ *
+ * There is no top or bottom inset left to pay: the band above already carries
+ * the notch and the rail below already carries the home indicator. Only the
+ * left and right ones survive, and in landscape they are the whole problem —
+ * the vent column sits hard against the right edge, which on a phone held wide
+ * is exactly where the sensor housing is.
+ */
+export function stageAreaFor(c: Chrome, stageW: number, stageH: number): Rect {
+  return {
+    x: c.inset.left,
+    y: 0,
+    w: Math.max(1, stageW - c.inset.left - c.inset.right),
+    h: Math.max(1, stageH),
+  }
+}

--- a/dynawalla/games/merge-idle/src/ui/hud.ts
+++ b/dynawalla/games/merge-idle/src/ui/hud.ts
@@ -10,6 +10,7 @@
  */
 
 import { fmtCompact } from '../core/ladder.ts'
+import type { Chrome } from './chrome.ts'
 
 export type Action = {
   id: string
@@ -30,19 +31,23 @@ const CSS = `
 .ab-stage{position:relative;flex:1 1 auto;min-height:0}
 .ab-stage canvas{position:absolute;inset:0;display:block}
 
+/* The band bleeds edge to edge; its PADDING is written by chrome.ts so the
+   readout clears the notch and both of the host's 44px corners. */
 .ab-top{position:relative;z-index:3;display:flex;align-items:flex-end;gap:10px;
   padding:8px 12px 6px;flex:0 0 auto;
   background:linear-gradient(180deg,rgba(4,7,18,.94),rgba(4,7,18,.45) 70%,rgba(4,7,18,0));}
 .ab-essence{display:flex;flex-direction:column;gap:1px;min-width:0;flex:1 1 auto}
-.ab-cap{font-size:9px;letter-spacing:.24em;font-weight:800;opacity:.5;text-transform:uppercase}
-.ab-odo{display:flex;align-items:baseline;font-weight:900;line-height:1;
+/* Fixed line boxes: the band's height is the canvas stage's origin, and an
+   origin that drifts with a platform font metric is an origin that is wrong. */
+.ab-cap{font-size:9px;line-height:11px;height:11px;flex:0 0 auto;letter-spacing:.24em;font-weight:800;opacity:.5;text-transform:uppercase}
+.ab-odo{display:flex;align-items:baseline;flex:0 0 auto;font-weight:900;line-height:1;
   font-variant-numeric:tabular-nums;letter-spacing:-.02em;
   filter:drop-shadow(0 0 12px var(--ab-odo-glow,rgba(120,232,255,.5)));}
 .ab-dig{position:relative;overflow:hidden;display:inline-block}
 .ab-dig>span{display:block;text-align:center}
 .ab-sep{display:inline-block;opacity:.55}
-.ab-rate{font-size:11px;font-weight:800;opacity:.72;letter-spacing:.04em;display:flex;gap:8px;align-items:center}
-.ab-flow{font-weight:900;font-size:11px;padding:2px 7px;border-radius:999px;
+.ab-rate{font-size:11px;line-height:14px;height:14px;flex:0 0 auto;font-weight:800;opacity:.72;letter-spacing:.04em;display:flex;gap:8px;align-items:center}
+.ab-flow{font-weight:900;font-size:10px;line-height:12px;padding:1px 7px;border-radius:999px;
   background:rgba(255,209,46,.16);color:#ffd12e;border:1px solid rgba(255,209,46,.34)}
 .ab-pips{display:flex;gap:3px;align-items:center;flex:0 0 auto;max-width:44%;flex-wrap:wrap;justify-content:flex-end}
 .ab-pip{width:7px;height:7px;border-radius:2px;background:rgba(238,246,255,.14);transition:background .3s,box-shadow .3s}
@@ -120,7 +125,8 @@ class Odometer {
   readonly el = document.createElement('div')
   private cols: HTMLElement[] = []
   private chars = ''
-  private sizePx = 40
+  /** Zero until the frame is laid out, so the first `setSize` always applies. */
+  private sizePx = 0
 
   constructor() {
     this.el.className = 'ab-odo'
@@ -130,6 +136,10 @@ class Odometer {
     if (px === this.sizePx) return
     this.sizePx = px
     this.el.style.fontSize = `${px}px`
+    // Explicit, because the row is baseline-aligned: a comma's descender would
+    // otherwise stretch the flex line past the digits and push the band taller
+    // than `chrome.ts` computed — and the band's height is the stage's origin.
+    this.el.style.height = `${px}px`
     for (const c of this.cols) {
       if (c.classList.contains('ab-dig')) {
         c.style.height = `${px}px`
@@ -199,6 +209,7 @@ export type HudCallbacks = {
 export class Hud {
   readonly root = document.createElement('div')
   readonly stage = document.createElement('div')
+  private top = document.createElement('div')
   private odo = new Odometer()
   private rateEl = document.createElement('span')
   private flowEl = document.createElement('span')
@@ -225,7 +236,7 @@ export class Hud {
     installStyle()
     this.root.className = 'ab-root'
 
-    const top = document.createElement('div')
+    const top = this.top
     top.className = 'ab-top'
     const ess = document.createElement('div')
     ess.className = 'ab-essence'
@@ -299,13 +310,39 @@ export class Hud {
     this.root.remove()
   }
 
+  /**
+   * Put the DOM where `chrome.ts` says it goes.
+   *
+   * This is the only place the band's padding, the band's height and the mute
+   * button's corner are decided, and every number comes from `chromeLayout`.
+   * The stylesheet deliberately holds no safe-area rule of its own: two sources
+   * of truth for "where the notch is" is how a HUD ends up half-corrected.
+   */
+  applyChrome(c: Chrome): void {
+    const t = this.top.style
+    t.paddingTop = `${c.bandPad.top}px`
+    t.paddingRight = `${c.bandPad.right}px`
+    t.paddingBottom = `${c.bandPad.bottom}px`
+    t.paddingLeft = `${c.bandPad.left}px`
+    t.height = `${c.band.h}px`
+    this.odo.setSize(c.odoPx)
+
+    const r = this.railEl.style
+    r.paddingTop = `${c.railPad.top}px`
+    r.paddingRight = `${c.railPad.right}px`
+    r.paddingBottom = `${c.railPad.bottom}px`
+    r.paddingLeft = `${c.railPad.left}px`
+
+    // The mute button lives in the stage, so its top is measured from the band's
+    // underside — which is already below the host's corners.
+    this.muteBtn.style.top = `${c.mute.y - c.stage.y}px`
+    this.muteBtn.style.right = `${c.w - c.mute.x - c.mute.w}px`
+  }
+
   /* ------------------------------------------------------------------ state */
 
   setEssence(shown: number, glowColour: string): void {
-    const text = fmtCompact(shown)
-    const w = this.root.clientWidth || 360
-    this.odo.setSize(Math.round(Math.max(26, Math.min(52, w * 0.108))))
-    this.odo.set(text)
+    this.odo.set(fmtCompact(shown))
     this.odo.el.style.setProperty('--ab-odo-glow', glowColour)
   }
 


### PR DESCRIPTION
## What

Adopt `packs/shared/game-chrome` in **ABYSSAL BLOOM** (`dynawalla/games/merge-idle`): lay the HUD out inside the safe rectangle, keep the host's two 44px corners free of anything a child reads or touches, and add a how-to-play manual.

## Why

Two real defects, both invisible to the 54 tests this game already had, because a layout bug is invisible to every test that is about rules.

**1. The safe area.** The game declares `viewport-fit=cover`, which is not a neutral setting — it opts the document *into* the notch, the home indicator and the rounded corners — and then read nothing back. The essence odometer sat at `top: 8px, left: 12px` of the glass. The magnitude pips sat hard against the right edge. The action rail sat on the home indicator. Held wide, the vent column ran under the sensor housing, taking the question with it.

**2. Host chrome.** The host paints an exit chevron top-LEFT and the shared how-to-play `?` top-RIGHT, floating over every pack. The odometer was under the chevron; the pips were under the `?`. The two numbers a child watches most were the two the host covered up.

**3. No instructions.** ABYSSAL BLOOM shipped with none, and it is the one genre that cannot be figured out by watching — half of it happens while nobody is looking. A child who is not told the reef earns while the app is closed reads the away time as the game doing nothing and the tide gate on their return as a quiz out of nowhere.

### How

`src/ui/chrome.ts` is the whole frame as arithmetic — no DOM, no `env()`, no measuring — computed from the glass size and the safe rectangle. `area` is **required**, on the same terms as SKY LEDGER's `layoutFor`: optional means a caller that forgets it compiles and quietly draws under the notch, discoverable only on a device. `computeLayout` in the renderer takes the stage's safe rect on the same terms.

Host chrome **overlays**; nothing here reserves a top band (reserving one cost 12% of a small phone's height and broke SKY LEDGER's own lattice). The band still spans the full width and its gradient still bleeds to both edges — its **padding** moves the readout past both corners. The water, the light shafts and every particle still run to the glass edge; that is the point of `cover`. Only the shelf and the vents are held inside the safe area.

The band's height then puts the canvas stage below both corners **by construction**, so every polyp, vent, floater and toast clears them without the canvas knowing anything about it. That is asserted, so shrinking the odometer cannot silently break it.

`SAVE_SLOT` and its `gitleaks:allow` comment are untouched.

## Blast radius

**Areas touched:** dynawalla (one game pack, `dynawalla/games/merge-idle/` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; `pack.json` untouched (id, version, capabilities, covers all unchanged); no `voiceId` renamed; no catalog entry dropped or narrowed.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are the game's own manual, English-only, in the same shape as SKY LEDGER's; this pack declares `"locales": ["en"]`.
- [x] **Curriculum.** N/A — no skill id, grade, generator, schema or renderer touched. The question path (`host.next`, `host.report`, `items.answer` as judge) is unchanged.
- [x] **Secrets.** None. `gitleaks` clean over the branch (below).

Behavioural notes a reviewer cannot reconstruct from the diff:

- `Renderer.resize` gained a required `area` parameter and `computeLayout` gained a required 5th parameter. Both have exactly one caller each, in this game.
- The stylesheet deliberately holds **no** safe-area rule. Every inset number is applied from `chromeLayout` in `Hud.applyChrome`, because two sources of truth for "where the notch is" is how a HUD ends up half-corrected. `.ab-cap` and `.ab-rate` gained fixed `line-height`/`height` so the band's height — which is the stage's origin — cannot drift with a platform font metric.
- The game now relayouts on `onInsetsChange` as well as `ResizeObserver`, because a rotation swaps the insets and Split View changes them. The unsubscribe goes through the existing `detach` list.
- The odometer is a little smaller than before at every width (its size now comes from the readout width, not the glass width), since the readout is 124px narrower than the glass.
- Instructions auto-open is **not** added; the `?` opens the manual, exactly as in the SKY LEDGER pilot. `guide.destroy()` is the first thing `unmount` does.

## Proof

Everything below is real output.

### Tests, five separate runs

```
$ cd dynawalla/games/merge-idle
$ for i in 1 2 3 4 5; do echo "=== run $i ==="; npm test 2>&1 | grep -E "^# (tests|pass|fail|duration_ms)"; done
=== run 1 ===
# tests 68
# pass 68
# fail 0
# duration_ms 180.337459
=== run 2 ===
# tests 68
# pass 68
# fail 0
# duration_ms 179.388625
=== run 3 ===
# tests 68
# pass 68
# fail 0
# duration_ms 185.482833
=== run 4 ===
# tests 68
# pass 68
# fail 0
# duration_ms 179.756709
=== run 5 ===
# tests 68
# pass 68
# fail 0
# duration_ms 227.274708
```

54 before, 68 after. The 14 new ones — the layout is exercised at every viewport with and without a notch, and the RNG in this suite is `makeRng(seed)` throughout, so nothing here can flap:

```
ok 55 - the frame holds together at phone portrait, small (320×568, no insets)
ok 56 - the frame holds together at phone portrait, small (320×568, notched)
ok 57 - the frame holds together at phone portrait, tall (390×844, no insets)
ok 58 - the frame holds together at phone portrait, tall (390×844, notched)
ok 59 - the frame holds together at phone landscape (844×390, no insets)
ok 60 - the frame holds together at phone landscape (844×390, notched)
ok 61 - the frame holds together at tablet portrait (768×1024, no insets)
ok 62 - the frame holds together at tablet portrait (768×1024, notched)
ok 63 - the frame holds together at tablet landscape (1024×768, no insets)
ok 64 - the frame holds together at tablet landscape (1024×768, notched)
ok 65 - the frame holds together at laptop (1440×900, no insets)
ok 66 - the frame holds together at laptop (1440×900, notched)
ok 67 - nothing a child reads or touches sits under the host chrome
ok 68 - the band is tall enough that the whole canvas clears the corners
```

### The clearance test is RED without the fix

A clearance test that passes either way is worthless, so both halves of the fix were reverted in turn and the suite re-run.

**(a) Revert the band's padding** — `padLeft`/`padRight`/`padTop` back to the shipped `12 / 12 / 8`:

```
not ok 56 - the frame holds together at phone portrait, small (320×568, notched)
  error: 'the readout starts above the safe area'
not ok 58 - the frame holds together at phone portrait, tall (390×844, notched)
  error: 'the readout starts above the safe area'
not ok 60 - the frame holds together at phone landscape (844×390, notched)
  error: 'the readout starts left of the safe area'
not ok 62 - the frame holds together at tablet portrait (768×1024, notched)
  error: 'the readout starts above the safe area'
not ok 64 - the frame holds together at tablet landscape (1024×768, notched)
  error: 'the readout starts left of the safe area'
not ok 66 - the frame holds together at laptop (1440×900, notched)
  error: 'the readout starts left of the safe area'
not ok 67 - nothing a child reads or touches sits under the host chrome
    phone portrait, small (320×568, no insets): the essence readout is under host chrome
not ok 68 - the band is tall enough that the whole canvas clears the corners
# tests 68
# pass 60
# fail 8
```

The corner assertion in full — note it fails at **no insets** too, so this is the host-chrome promise failing on its own, not a notch artefact:

```
not ok 67 - nothing a child reads or touches sits under the host chrome
  ---
  location: 'src/ui/chrome.test.ts:112:1'
  failureType: 'testCodeFailure'
  error: |-
    phone portrait, small (320×568, no insets): the essence readout is under host chrome

    true !== false

  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: false
  actual: true
  operator: 'strictEqual'
  stack: |-
    TestContext.<anonymous> (src/ui/chrome.test.ts:122:14)
  ...
```

**(b) Revert the canvas half** — `computeLayout` back to laying the shelf and the vent column out against the raw canvas edges:

```
not ok 60 - the frame holds together at phone landscape (844×390, notched)
  error: 'the shelf runs under the left edge'
not ok 64 - the frame holds together at tablet landscape (1024×768, notched)
  error: 'the shelf runs under the left edge'
not ok 66 - the frame holds together at laptop (1440×900, notched)
  error: 'the shelf runs under the left edge'
# tests 68
# pass 65
# fail 3
```

Both reverts were then undone and the suite returned to 68/68 (above). The test reaches the layout through the same two functions the game itself calls — `chromeLayout`, which `Hud.applyChrome` turns directly into the band's padding and height, and `computeLayout`, which is `Renderer.resize`'s only layout path.

### Types and builds

```
$ npm run tsc
> tsc --noEmit
$ npm run build
vite v8.1.5 building client environment for production...
✓ 24 modules transformed.
dist/merge-idle.js  97.96 kB │ gzip: 30.65 kB
✓ built in 25ms
```

```
$ cd dynawalla/packs && node build.mjs merge-idle
✓ 32 modules transformed.
dist-pack/pack.html                 1.26 kB │ gzip:  0.67 kB
dist-pack/assets/pack-BVl-IEbu.js  82.39 kB │ gzip: 29.53 kB
dynawalla.merge-idle@0.1.0 — ABYSSAL BLOOM
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics, storage
  covers       8 skills, grades 1–5
  on disk      3 files, 84858 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

### Secrets and scope

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~22845 bytes (22.84 KB) in 35.7ms
INF no leaks found

$ git diff --diff-filter=D --name-only origin/main..HEAD
                     (empty — nothing deleted)

$ git diff --stat origin/main..HEAD
 dynawalla/games/merge-idle/src/game.ts            | 112 +++++++++++++-
 dynawalla/games/merge-idle/src/render/renderer.ts |  37 +++--
 dynawalla/games/merge-idle/src/ui/chrome.test.ts  | 174 +++++++++++++++++++++
 dynawalla/games/merge-idle/src/ui/chrome.ts       | 176 ++++++++++++++++++++++
 dynawalla/games/merge-idle/src/ui/hud.ts          |  57 +++++--
 5 files changed, 533 insertions(+), 23 deletions(-)
```

### The manual

Written for a 7–11 year old from the source, not from a README — this game has none. Everything in it was read out of `core/board.ts`, `core/ladder.ts`, `core/economy.ts`, `core/save.ts` and `game.ts`: the merge is the sum of two equal values, a choke is 3.2s cold, the away haul caps at 8 hours, the first-try tide multiplier is ×3, DISSOLVE is free and pays out, and the save is written on `visibilitychange` and on unmount.

> **ABYSSAL BLOOM**
>
> Two polyps with the same number join into one polyp worth double. Drag one onto the other.
> The tall vents hold up a sum. Build the answer out of polyps and drop it in the vent's mouth.
>
> **Joining polyps** — The glowing creatures on the reef are polyps. Each one has a number. · Drag a polyp on top of another polyp with the same number. · They join into one polyp. Its number is the two numbers added together, so it is double. · 3 and 3 make 6. 6 and 6 make 12. 96 and 96 make 192. · Tap a polyp once and every polyp with that same number lights up. That is how you find its partner. · Drag a polyp onto an empty space to move it there.
>
> **Feeding a vent** — The tall towers are vents. Each vent holds up a sum, like 96 + 96. · Work out the answer. Then join polyps until you have a polyp with that number. · Drag that polyp into the round mouth at the bottom of the vent. · If it is right the vent erupts. It pays you essence, gets stronger, and asks a harder sum. · If it is wrong the vent goes cold for about three seconds. Wait for it to warm up, then try again. · Get several right in a row and your FLOW goes up, and every vent pays more. · Some answers are not numbers a polyp can have. Then four tiles appear above the vent. Drag the right tile into the mouth instead.
>
> **Essence and the buttons** — Essence is the big number at the top. Vents make essence every second, all on their own. · Spend it on the buttons along the bottom. · UPWELL buys a handful of new polyps right now. · AWAKEN wakes up one more vent, so there are more sums and more essence. · DEEPEN makes the reef bigger, so you have more room. · OVERCHARGE makes every vent stronger at the same time.
>
> **When the reef is full** — If every space is full and no two numbers match, a red bar says SHELF CROWDED. · Press DISSOLVE. It is free. · It clears away all the smallest polyps and pays you their numbers. · You can never get stuck. DISSOLVE always works.
>
> **Going away and coming back** — This game keeps going when you are not here. That is not a bug, it is the point. · Leave, do something else, come back. The reef made essence the whole time you were gone, for up to eight hours. · When you come back a tide is waiting, with one question. Answer it and the tide is yours. · Get it right on the first try and you keep three times as much. · While you play, a glowing ball marked TIDE floats up now and then. Tap it for another one. · Your reef saves itself. It will be exactly where you left it.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
