### PR TITLE
feat(dynawalla/games/lattice): the HUD clears the notch and the two host corners, and there are instructions

### DIFF
--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -103,6 +103,26 @@ targets.
 
 ---
 
+## The frame this game does not own
+
+The host paints an exit control in the top-LEFT corner and the shared
+how-to-play button in the top-RIGHT, over every pack, and the pack declares
+`viewport-fit=cover`, which opts the canvas into the notch and the home
+indicator. A canvas cannot read `env()`.
+
+So the world — the sheet, the husks, the motes, the ship, the resonator — still
+uses every pixel, and the **chrome** is laid out by `render/hud.ts` inside the
+safe rectangle from `packs/shared/game-chrome`, starting below the two 44px
+corners. Chrome overlays rather than reserving a band: reserving one costs 67px,
+which is 12% of a 568px phone.
+
+How to play comes from the same shared module, so it looks and dismisses the
+same way in every game. It is reachable **during** play, because the moment a
+child needs the rules is never the title screen — and opening it holds the
+world, on the same guards the host's sheet uses.
+
+---
+
 ## Reduced motion is a branch, not a switch
 
 Turning the sheet off would delete the only cue that says *where a number came
@@ -136,14 +156,15 @@ src/
   game/best.ts       the longest chain, guarded for a pack frame
   sim/grid.ts     the mass-spring sheet that tears and re-knits
   render/         palette, scene, sparks
+  render/hud.ts   where the chrome may be drawn: the safe area, minus two corners
   audio/audio.ts  asset-free Web Audio, C5–C6 pentatonic
-  test/           71 tests: rules, not rendering
+  test/           94 tests: rules, wiring, and where the chrome lands
 ```
 
 ## Tests
 
 ```
-npm test        71 tests
+npm test        94 tests
 npm run tsc     0 errors
 npm run build   the library build
 npm run build:pack   the pack build → dist-pack/
@@ -171,3 +192,16 @@ The ones that matter:
   game where nothing throws and nothing can be beaten.
 * `grid.test.ts` — no NaN, always returns to rest, always knits back, and the
   reduced-motion branch is a branch.
+* `chrome.test.ts` — drives the real `Scene.draw` against a recording context at
+  five viewports, with and without a notch, and asserts that every word the
+  child reads is inside the safe area and clear of the host's two 44px corners,
+  and that the tile bar — which is a touch target, because tapping it drops the
+  hold — is reachable. **Verified to fail with the layout reverted**, not by
+  reading it.
+* `mount.test.ts` — the shell, including the one that got away: flying into the
+  resonator asserts the hold. `Arena.enter` was covered exhaustively by the
+  rules tests and **never called by the shell**, so the entire reasoning layer
+  was unreachable in the shipped game while every test was green. It also
+  asserts that reading the manual holds the world and that closing it lets go,
+  because a manual that leaves a twin-stick arena running is a manual a child
+  cannot afford to open.

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -26,10 +26,11 @@
 // the mouse as an alternative aim and its button as the trigger. Tablet and
 // desktop are first-class targets here, not a phone game stretched.
 
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
 import { Audio } from "./audio/audio.ts"
 import type { Host } from "./contract.ts"
 import { Rng } from "./core/rng.ts"
-import { Arena, type ArenaEvent } from "./game/arena.ts"
+import { Arena, RESONATOR_R, SHIP_R, type ArenaEvent } from "./game/arena.ts"
 import { bestChain, recordChain } from "./game/best.ts"
 import { Scene } from "./render/scene.ts"
 import { BRASS_LIGHT, CELESTIAL, OXIDE } from "./render/palette.ts"
@@ -75,6 +76,79 @@ export function mountLattice(
     width: scene.cssWidth,
     height: scene.cssHeight,
     reduced,
+  })
+
+  // How to play. Nothing on this screen says that the ring wants the ANSWER to
+  // the sum on its face, built out of numbers that multiply — and a child who
+  // does not know that plays the passive layer forever, shooting husks apart
+  // and sweeping them up, and never once does the thinking the game is for. The
+  // manual stays reachable during play, because the moment a child needs the
+  // rules is never the title screen.
+  const guide = createInstructions(el, {
+    title: "THE LATTICE",
+    summary: [
+      "A ring floats in the middle with a sum on it. Work out the answer.",
+      "Then collect glowing numbers that multiply to that answer, and fly into the ring.",
+    ],
+    sections: [
+      {
+        heading: "Flying and shooting",
+        lines: [
+          "Put a thumb on the left half of the screen and slide it. Your ship flies that way.",
+          "Put a thumb on the right half and slide it. Your ship aims that way and shoots.",
+          "On a keyboard: W A S D to fly, arrow keys to shoot, space to shoot straight ahead.",
+        ],
+      },
+      {
+        heading: "Breaking numbers open",
+        lines: [
+          "The stone squares hold big numbers. Shoot one and it breaks into two numbers that multiply back to it. Shoot 72 and you get 8 and 9.",
+          "Keep shooting the pieces. The 8 breaks into 2 and 4. The 4 breaks into 2 and 2.",
+          "Some numbers glow instead. Shooting one only shoves it, because nothing multiplies to make it. Those are called prime numbers, and they are the pieces you collect.",
+        ],
+      },
+      {
+        heading: "Your hold",
+        lines: [
+          "Fly into a glowing number to pick it up. It goes in the bar along the bottom.",
+          "The bar shows what you are carrying, like 2 · 2 · 3, and the number those pieces multiply to: 12.",
+          "Do not fly into a stone square. It knocks your biggest piece loose and drops it back on the field.",
+          "You can carry twelve pieces at once.",
+        ],
+      },
+      {
+        heading: "Opening the ring",
+        lines: [
+          "The ring shows a sum, like 47 + 25. Work it out: 72.",
+          "Now find pieces that multiply to 72. That is 2 · 2 · 2 · 3 · 3.",
+          "Carry exactly those and fly into the ring. It opens, and a new sum arrives.",
+        ],
+      },
+      {
+        heading: "If the ring says NOT YET",
+        lines: [
+          "Your pieces multiply to the wrong number. One extra 5 turns 72 into 360.",
+          "Nothing is lost. Your pieces drop back on the field and you can pick them up again.",
+          "To empty the bar yourself, tap the bar. On a keyboard, press Escape.",
+        ],
+      },
+      {
+        heading: "When the answer is a glowing number",
+        lines: [
+          "Sometimes the answer is a number that cannot be broken, like 41.",
+          "Then no pile of smaller pieces will ever reach it. Look for the single 41 drifting on the field and carry that in on its own.",
+        ],
+      },
+      {
+        heading: "The counters at the top",
+        lines: [
+          "OPENED is how many rings you have opened.",
+          "CHAIN is how many you opened in a row without a wrong one.",
+          "BEST is your longest chain ever.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
   })
 
   let best = bestChain()
@@ -191,19 +265,52 @@ export function mountLattice(
     firing = aimStick !== null || mouseDown || keys.has(" ") || ax !== 0 || ay !== 0
   }
 
+  /** Whatever the thumbs were doing, they are not doing it any more. */
+  const dropSticks = (): void => {
+    moveStick = null
+    aimStick = null
+    firing = false
+    mouseDown = false
+    keys.clear()
+  }
+
   const tick = (t: number): void => {
     if (!running) return
     frame = requestAnimationFrame(tick)
     const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, t - last)
     last = t
 
+    // The world is held for two reasons, and the second one is easy to miss:
+    // the host's sheet, and the child reading the rules. A manual that leaves
+    // the arena running is a manual a child cannot afford to open — they come
+    // back to a ship that drifted into a husk, or through the resonator, and
+    // asserted a hold they were not there for. That is the same damage the
+    // host's sheet does unguarded, from a button this pack owns.
+    const held = paused || guide.isOpen
+    if (held && !arena.isPaused) {
+      arena.pause(now())
+      dropSticks()
+    } else if (!held && arena.isPaused) {
+      arena.resume(now())
+    }
+
     // Behind a sheet the arena holds its shape. The frame is still drawn — a
     // frozen pack under a translucent host sheet is what a paused game looks
     // like — but nothing moves and nothing is decided.
-    if (!paused) {
+    if (!held) {
       readKeys()
       if (firing) apply(arena.fire())
       apply(arena.step(dt))
+      // Flying into the resonator is what asserts the hold, and it is the only
+      // act in this game the host ever hears about. `Arena.step` resolves every
+      // other collision itself, but not this one: the assertion is timed
+      // against the wall clock the report carries, and the wall clock belongs
+      // to the shell. Missing, the whole reasoning layer is unreachable — the
+      // ship flies through the ring and nothing at all happens.
+      const res = arena.resonator
+      if (res && Math.hypot(arena.ship.x - res.x, arena.ship.y - res.y) < RESONATOR_R + SHIP_R) {
+        apply(arena.enter(now()))
+      }
       grid.step(dt)
       scene.advance(dt)
     }
@@ -219,7 +326,7 @@ export function mountLattice(
 
   const down = (event: PointerEvent): void => {
     event.preventDefault()
-    if (paused) return
+    if (paused || guide.isOpen) return
     audio.resume()
     const p = at(event)
 
@@ -252,7 +359,7 @@ export function mountLattice(
   }
 
   const move = (event: PointerEvent): void => {
-    if (paused) return
+    if (paused || guide.isOpen) return
     const p = at(event)
     if (moveStick && moveStick.id === event.pointerId) {
       moveStick.x = p.x
@@ -288,8 +395,11 @@ export function mountLattice(
     }
   }
 
+  // While the manual is up, the keyboard belongs to the manual: Escape closes
+  // it rather than dumping the hold, and nothing lands in `keys` to be found
+  // still held down when the child comes back.
   const keyDown = (event: KeyboardEvent): void => {
-    if (paused || event.repeat) return
+    if (paused || guide.isOpen || event.repeat) return
     keys.add(event.key)
     if (event.key === " ") {
       event.preventDefault()
@@ -331,14 +441,9 @@ export function mountLattice(
       if (paused) return
       paused = true
       arena.pause(now())
-      // Whatever the thumbs were doing, they are not doing it any more. Left
-      // set, a resting thumb would fly the ship through the resonator behind
-      // the sheet and assert a product nobody assembled.
-      moveStick = null
-      aimStick = null
-      firing = false
-      mouseDown = false
-      keys.clear()
+      // Left set, a resting thumb would fly the ship through the resonator
+      // behind the sheet and assert a product nobody assembled.
+      dropSticks()
       scene.say("PAUSED", BRASS_LIGHT)
     },
     resume(): void {
@@ -352,6 +457,7 @@ export function mountLattice(
     },
     unmount(): void {
       running = false
+      guide.destroy()
       cancelAnimationFrame(frame)
       canvas.removeEventListener("pointerdown", down)
       canvas.removeEventListener("pointermove", move)

--- a/dynawalla/games/lattice/src/render/hud.ts
+++ b/dynawalla/games/lattice/src/render/hud.ts
@@ -1,0 +1,107 @@
+// Where the chrome goes: the counters at the top, the banner in the middle, and
+// the factor tile bar along the bottom.
+//
+// **Why this is a file and not four numbers inside `scene.ts`.** Two things
+// float over every Dynawalla pack that the pack does not own — the host's exit
+// control in the top-LEFT corner and the shared how-to-play control in the
+// top-RIGHT — and this game drew `OPENED` at `x = 14, y = 12` and `BEST` at
+// `w - 14, 12`, which is underneath both of them. It drew them at `y = 12` on a
+// phone whose notch is 47px deep as well, so the counters were under the notch
+// and under a button at the same time. A canvas cannot read `env()`; the only
+// way to clear either is to be handed the numbers.
+//
+// **The playfield is not moved.** The sheet, the husks, the motes, the ship and
+// the resonator still use the whole canvas, edge to edge and under the notch —
+// that is what `viewport-fit=cover` is for, and it is why this reads as an arena
+// rather than as a form. It is the counters, the banner and the tile bar — the
+// things a child must READ or TOUCH — that live inside `area`.
+//
+// **Chrome overlays; it does not reserve a band.** Reserving the top strip
+// costs 67px, which is 12% of a 568px phone. The counters simply begin below
+// the two corners, and the arena carries on behind them.
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+
+export type { Rect }
+
+/** Breathing room between the bottom of the host's corner controls and the counters. */
+const CORNER_GAP = 8
+
+/** The counters' inset from the safe edge, left and right. */
+const SIDE = 14
+
+export type HudLayout = {
+  /** `OPENED` / `CHAIN` on the left, `BEST` on the right, the stall notice centred. */
+  readonly status: {
+    readonly size: number
+    /** Top edge of the first row. Below both host corners, always. */
+    readonly top: number
+    readonly lineH: number
+    readonly left: number
+    readonly right: number
+    readonly cx: number
+  }
+  /** The factor tile bar. Tapping it drops the hold, so it is a touch target. */
+  readonly bar: {
+    readonly size: number
+    readonly gap: number
+    readonly dotW: number
+    /** Middle of the tile row. */
+    readonly y: number
+    readonly cx: number
+  }
+  /** `RESONANCE`, `NOT YET`, `PAUSED` — centred in the safe area, not the canvas. */
+  readonly banner: { readonly cx: number; readonly cy: number }
+  /** The word under the host's sheet. */
+  readonly sheet: { readonly cx: number; readonly cy: number }
+}
+
+/**
+ * Lay the chrome out inside `area`.
+ *
+ * `area` is the safe rectangle from `packs/shared/game-chrome` — the canvas
+ * minus the notch, the home indicator and the rounded corners.
+ *
+ * It is REQUIRED, deliberately, and that is the point of this signature. Made
+ * optional, a caller that forgets it still compiles and quietly draws the score
+ * under the notch, and the only way anybody finds out is by holding a notched
+ * phone. Required, forgetting it does not build.
+ *
+ * `w` is the full canvas width and is used for one thing only — the type scale,
+ * which should not shrink just because a phone is held sideways and has an
+ * inset down each edge.
+ */
+export function hudLayout(w: number, area: Rect): HudLayout {
+  // The host's two 44px corners hang from the top of the safe area. Everything
+  // the child reads starts underneath them.
+  const cornerBottom = area.y + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + CORNER_GAP
+  const size = Math.max(12, Math.min(17, w / 46))
+  const barSize = Math.max(26, Math.min(40, area.w / 16))
+
+  return {
+    status: {
+      size,
+      top: cornerBottom,
+      lineH: size * 1.5,
+      left: area.x + SIDE,
+      right: area.x + area.w - SIDE,
+      cx: area.x + area.w / 2,
+    },
+    bar: {
+      size: barSize,
+      gap: barSize * 0.22,
+      dotW: barSize * 0.5,
+      // Standing on the floor of the safe area rather than the floor of the
+      // canvas: on a phone the floor of the canvas is the home indicator.
+      y: area.y + area.h - barSize * 1.5,
+      cx: area.x + area.w / 2,
+    },
+    banner: { cx: area.x + area.w / 2, cy: area.y + area.h * 0.46 },
+    sheet: { cx: area.x + area.w / 2, cy: area.y + area.h / 2 },
+  }
+}

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -9,10 +9,16 @@
 // shots, the ship, the sparks, and then the chrome — the factor tile bar, which
 // is the whole passive layer made legible and is never allowed to be covered by
 // anything.
+//
+// The world uses the whole canvas. The chrome uses `hudLayout`, which keeps it
+// inside the safe area and clear of the host's two corner controls — see
+// `hud.ts` for why those are different rectangles.
 
+import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import type { Arena, Body, Resonator } from "../game/arena.ts"
 import { HUSK_R, MOTE_R, RESONATOR_R, SHIP_R, SHOT_R } from "../game/arena.ts"
 import type { Grid } from "../sim/grid.ts"
+import { hudLayout, type HudLayout } from "./hud.ts"
 import { Sparks } from "./particles.ts"
 import {
   BRASS,
@@ -56,6 +62,12 @@ export class Scene {
    * knows where it ended up.
    */
   private barRect = { x: 0, y: 0, w: 0, h: 0 }
+  /**
+   * Where the chrome may be drawn: inside the safe area and below the host's
+   * two corner controls. Recomputed on every resize, because a rotation swaps
+   * the insets over and Split View changes them without one.
+   */
+  private hud: HudLayout
 
   private readonly canvas: HTMLCanvasElement
   private reduced: boolean
@@ -67,6 +79,7 @@ export class Scene {
     if (!ctx) throw new Error("lattice: no 2d context")
     this.ctx = ctx
     this.sparks = new Sparks(reduced)
+    this.hud = hudLayout(320, { x: 0, y: 0, w: 320, h: 320 })
     this.resize()
   }
 
@@ -84,6 +97,8 @@ export class Scene {
     this.canvas.width = Math.round(this.cssWidth * this.dpr)
     this.canvas.height = Math.round(this.cssHeight * this.dpr)
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    // The world gets the whole canvas; the chrome gets the safe rectangle.
+    this.hud = hudLayout(this.cssWidth, safeRect(this.cssWidth, this.cssHeight))
     return { width: this.cssWidth, height: this.cssHeight }
   }
 
@@ -353,18 +368,13 @@ export class Scene {
   private drawTileBar(arena: Arena): void {
     const ctx = this.ctx
     const tiles = arena.bank.tiles
-    const h = this.cssHeight
-    const w = this.cssWidth
-    const size = Math.max(26, Math.min(40, w / 16))
-    const gap = size * 0.22
-    const dotW = size * 0.5
-    const y = h - size * 1.5
+    const { size, gap, dotW, y, cx } = this.hud.bar
 
     const total = tiles.length * size + Math.max(0, tiles.length - 1) * dotW
     const valueText = tiles.length === 0 ? "" : `= ${arena.bank.value}`
     ctx.font = chromeFont(size * 0.8, 600)
     const valueW = valueText === "" ? 0 : ctx.measureText(valueText).width + gap * 2
-    const left = (w - (total + valueW)) / 2
+    const left = cx - (total + valueW) / 2
     let x = left
     // A 44px minimum hit zone around the bar, per the touch-target rule — the
     // bar is small type and the tap that drops a hold must not be fiddly.
@@ -414,7 +424,7 @@ export class Scene {
         ctx.fillStyle = INK_DIM
         ctx.font = chromeFont(size * 0.52, 500)
         ctx.textAlign = "center"
-        ctx.fillText("SWEEP THE LIT ONES", w / 2, y)
+        ctx.fillText("SWEEP THE LIT ONES", cx, y)
       }
     }
   }
@@ -424,22 +434,24 @@ export class Scene {
     state: { best: number; paused: boolean; stalled: boolean },
   ): void {
     const ctx = this.ctx
-    const size = Math.max(12, Math.min(17, this.cssWidth / 46))
+    const { size, top, lineH, left, right, cx } = this.hud.status
     ctx.font = chromeFont(size, 600)
     ctx.textAlign = "left"
     ctx.textBaseline = "top"
     ctx.fillStyle = INK_DIM
-    ctx.fillText(`OPENED ${arena.opened}`, 14, 12)
+    ctx.fillText(`OPENED ${arena.opened}`, left, top)
     ctx.fillStyle = arena.chain > 0 ? BRASS_LIGHT : INK_DIM
-    ctx.fillText(`CHAIN ${arena.chain}`, 14, 12 + size * 1.5)
+    ctx.fillText(`CHAIN ${arena.chain}`, left, top + lineH)
     ctx.textAlign = "right"
     ctx.fillStyle = INK_DIM
-    ctx.fillText(`BEST ${state.best}`, this.cssWidth - 14, 12)
+    ctx.fillText(`BEST ${state.best}`, right, top)
 
     if (state.stalled) {
+      // On its own row. Centred at the counters' height it would be shouldered
+      // by BEST on a phone, and one row lower it would sit on CHAIN.
       ctx.textAlign = "center"
       ctx.fillStyle = OXIDE
-      ctx.fillText("NO RESONATOR — SWEEP ON", this.cssWidth / 2, 12)
+      ctx.fillText("NO RESONATOR — SWEEP ON", cx, top + lineH * 2)
     }
 
     if (this.banner) {
@@ -449,7 +461,7 @@ export class Scene {
       ctx.textBaseline = "middle"
       ctx.fillStyle = this.banner.tint
       ctx.font = chromeFont(Math.max(20, Math.min(38, this.cssWidth / 20)), 700)
-      ctx.fillText(this.banner.text, this.cssWidth / 2, this.cssHeight * 0.46)
+      ctx.fillText(this.banner.text, this.hud.banner.cx, this.hud.banner.cy)
       ctx.globalAlpha = 1
     }
   }
@@ -463,7 +475,7 @@ export class Scene {
     ctx.font = chromeFont(Math.max(14, Math.min(20, this.cssWidth / 40)), 600)
     ctx.textAlign = "center"
     ctx.textBaseline = "middle"
-    ctx.fillText("PAUSED", this.cssWidth / 2, this.cssHeight / 2)
+    ctx.fillText("PAUSED", this.hud.sheet.cx, this.hud.sheet.cy)
   }
 
   /** Did a press land on the tile bar? That gesture drops the hold. */

--- a/dynawalla/games/lattice/src/test/chrome.test.ts
+++ b/dynawalla/games/lattice/src/test/chrome.test.ts
@@ -1,0 +1,308 @@
+// THE TWO CORNERS, AND THE NOTCH.
+//
+// This game declares `viewport-fit=cover`, which is not a neutral setting: it
+// opts the canvas *into* the notch, the home indicator and the rounded corners.
+// And the host paints two 44px controls over every pack it runs — an exit
+// chevron top-LEFT and the how-to-play button top-RIGHT. Neither is something a
+// canvas can see. The shipped chrome drew `OPENED` at `(14, 12)` and `BEST` at
+// `(w - 14, 12)`, which is underneath both of them and underneath a 47px notch
+// as well, and nothing in this suite noticed, because every other test here is
+// about mathematics.
+//
+// So this drives the REAL renderer — `Scene.draw`, through the same code path a
+// frame takes — against a context that records instead of paints, and asserts
+// what a screenshot on a notched phone would have shown: every word the child
+// reads is inside the safe area and clear of both corners, and the tile bar,
+// which is TAPPABLE (a tap on it drops the hold), is a target they can actually
+// reach.
+//
+// Asserting the layout function on its own would not have caught the shipped
+// bug: the bug was that the renderer did not consult one.
+//
+// Everything here is seeded. Reduced motion is on, which also means the screen
+// shake — the one `Math.random` in the draw path — is exactly zero.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { Rng } from "../core/rng.ts"
+import { Arena } from "../game/arena.ts"
+import { hudLayout } from "../render/hud.ts"
+import { Scene } from "../render/scene.ts"
+import { Grid } from "../sim/grid.ts"
+import { createStubHost } from "../stubHost.ts"
+import { grindToPrimes } from "./harness.ts"
+
+/** Every shape the fleet actually has, including the smallest phone. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+const NO_INSETS: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+/** A notched phone held upright: the sensor housing, and the home indicator. */
+const PORTRAIT_NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+/** The same phone on its side: the housing moves to one edge, the bar shortens. */
+const LANDSCAPE_NOTCH: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+type Drawn = { text: string; box: Rect }
+
+/**
+ * One glyph is about 0.58em wide in the faces this game uses. The exact figure
+ * does not matter as long as the recorder and `measureText` agree, which is
+ * what makes the centred strings land where the renderer thinks they did.
+ */
+const advance = (text: string, px: number): number => text.length * px * 0.58
+
+function fontSize(font: string): number {
+  const m = /(\d+(?:\.\d+)?)px/.exec(font)
+  return m ? Number(m[1]) : 16
+}
+
+/**
+ * A 2D context that answers everything and writes down what it was told to
+ * draw, in order — including the state (`font`, `textAlign`, `textBaseline`)
+ * that was live at the moment of each `fillText`.
+ */
+function recorder(): { ctx: CanvasRenderingContext2D; log: Drawn[]; restores: number[] } {
+  const log: Drawn[] = []
+  const restores: number[] = []
+  const state: Record<string, unknown> = {
+    font: "16px sans-serif",
+    textAlign: "start",
+    textBaseline: "alphabetic",
+  }
+  const api: Record<string, unknown> = {
+    measureText: (text: string) => ({ width: advance(text, fontSize(String(state.font))) }),
+    createRadialGradient: () => ({ addColorStop() {} }),
+    restore: () => {
+      restores.push(log.length)
+    },
+    fillText: (text: string, x: number, y: number) => {
+      const px = fontSize(String(state.font))
+      const w = advance(text, px)
+      const align = String(state.textAlign)
+      const baseline = String(state.textBaseline)
+      const x0 = align === "left" || align === "start" ? x : align === "right" ? x - w : x - w / 2
+      const y0 = baseline === "top" ? y : baseline === "middle" ? y - px / 2 : y - px
+      log.push({ text, box: { x: x0, y: y0, w, h: px } })
+    },
+  }
+
+  const ctx = new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (prop in api) return api[prop]
+        if (prop in state) return state[prop]
+        return () => undefined
+      },
+      set(_t, prop: string, value) {
+        state[prop] = value
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+
+  return { ctx, log, restores }
+}
+
+function fakeCanvas(w: number, h: number, ctx: CanvasRenderingContext2D): HTMLCanvasElement {
+  return {
+    width: 0,
+    height: 0,
+    style: {},
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width: w, height: h, left: 0, top: 0 }),
+    remove() {},
+  } as unknown as HTMLCanvasElement
+}
+
+/**
+ * Run `body` with a document whose `env(safe-area-inset-*)` resolve to `insets`.
+ *
+ * `safeInsets` measures the real thing through a hidden probe and
+ * `getComputedStyle`, so this is the only way to put a notch on a machine that
+ * has no screen — and it exercises the same code the device runs.
+ */
+function withInsets(insets: Insets, body: () => void): void {
+  const saved = new Map<string, PropertyDescriptor | undefined>()
+  const set = (key: string, value: unknown): void => {
+    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+  const element = { style: {} as Record<string, string>, setAttribute() {} }
+  set("document", {
+    body: { appendChild() {} },
+    getElementById: () => null,
+    createElement: () => element,
+  })
+  set("getComputedStyle", () => ({
+    paddingTop: `${insets.top}px`,
+    paddingRight: `${insets.right}px`,
+    paddingBottom: `${insets.bottom}px`,
+    paddingLeft: `${insets.left}px`,
+  }))
+  try {
+    body()
+  } finally {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+      else Reflect.deleteProperty(globalThis, key)
+    }
+  }
+}
+
+type Frame = { scene: Scene; chrome: Drawn[] }
+
+/**
+ * Play a few seconds of a real sitting and draw one real frame.
+ *
+ * The hold is filled first, because an empty tile bar draws nothing and a test
+ * that never renders the tiles is a test that cannot see them collide.
+ */
+function frame(w: number, h: number, opts: { stalled: boolean; paused: boolean }): Frame {
+  const seed = 0x1a771ce
+  const host = createStubHost({ seed, reducedMotion: true })
+  const { ctx, log, restores } = recorder()
+  const scene = new Scene(fakeCanvas(w, h, ctx), true)
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: w, height: h })
+  const grid = new Grid({ cols: 8, rows: 8, width: w, height: h, reduced: true })
+  arena.begin(0)
+
+  // Grind the field to primes and sweep a handful, so the tile bar has tiles
+  // and a running product beside them.
+  grindToPrimes(arena)
+  for (const body of arena.bodies.slice(0, 5)) arena.touch(body.id)
+  assert.ok(arena.bank.size > 0, "the hold stayed empty, so the tile bar drew nothing")
+
+  scene.say("RESONANCE", "#f0d878")
+  scene.draw(arena, grid, { best: 12, paused: opts.paused, stalled: opts.stalled })
+
+  // Everything after the LAST `restore()` is chrome: the world is drawn inside
+  // one save/restore pair and the tile bar, the counters and the banner are
+  // drawn after it. Bodies and the resonator's prompt are playfield — they
+  // drift wherever the physics takes them, including under a corner, and that
+  // is the point of `cover`.
+  const last = restores[restores.length - 1] ?? 0
+  return { scene, chrome: log.slice(last) }
+}
+
+const inside = (box: Rect, area: Rect): boolean =>
+  box.x >= area.x - 0.5 &&
+  box.y >= area.y - 0.5 &&
+  box.x + box.w <= area.x + area.w + 0.5 &&
+  box.y + box.h <= area.y + area.h + 0.5
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const insets of [NO_INSETS, w > h ? LANDSCAPE_NOTCH : PORTRAIT_NOTCH]) {
+    const label = insets === NO_INSETS ? "no insets" : "with a notch"
+    test(`nothing the child reads is under the host's chrome at ${name} (${w}×${h}), ${label}`, () => {
+      withInsets(insets, () => {
+        const area = safeRect(w, h)
+        for (const state of [
+          { stalled: false, paused: false },
+          { stalled: true, paused: false },
+          { stalled: false, paused: true },
+        ]) {
+          const { chrome } = frame(w, h, state)
+          assert.ok(chrome.length > 0, "no chrome was drawn at all")
+          for (const drawn of chrome) {
+            assert.equal(
+              hitsHostChrome(drawn.box, w),
+              false,
+              `"${drawn.text}" is under the host's chrome at ${w}×${h}`,
+            )
+            assert.ok(
+              inside(drawn.box, area),
+              `"${drawn.text}" is outside the safe area at ${w}×${h}: ` +
+                `${JSON.stringify(drawn.box)} vs ${JSON.stringify(area)}`,
+            )
+          }
+        }
+      })
+    })
+
+    test(`the tile bar can be tapped at ${name} (${w}×${h}), ${label}`, () => {
+      // The bar is not decoration: tapping it throws the hold back on the field,
+      // which is the only way out of a wrong hold. So it is a touch target, and
+      // it must be neither under a host button nor under the home indicator.
+      withInsets(insets, () => {
+        const area = safeRect(w, h)
+        const { scene } = frame(w, h, { stalled: false, paused: false })
+
+        const corners: Rect[] = [
+          { x: insets.left + HOST_MARGIN, y: insets.top + HOST_PROGRESS_H + HOST_MARGIN, w: HOST_CONTROL, h: HOST_CONTROL },
+          {
+            x: w - insets.right - HOST_MARGIN - HOST_CONTROL,
+            y: insets.top + HOST_PROGRESS_H + HOST_MARGIN,
+            w: HOST_CONTROL,
+            h: HOST_CONTROL,
+          },
+        ]
+        for (const corner of corners) {
+          for (let i = 0; i <= 4; i++) {
+            for (let j = 0; j <= 4; j++) {
+              const x = corner.x + (corner.w * i) / 4
+              const y = corner.y + (corner.h * j) / 4
+              assert.equal(scene.hitsTileBar(x, y), false, `the tile bar reaches ${x},${y}`)
+            }
+          }
+        }
+
+        // And nothing of it hangs below the safe area, where a swipe belongs to
+        // the operating system rather than to the game.
+        const floor = area.y + area.h
+        for (let i = 0; i <= 20; i++) {
+          const x = (w * i) / 20
+          assert.equal(
+            scene.hitsTileBar(x, floor + 1),
+            false,
+            `the tile bar hangs into the home indicator at x=${x}`,
+          )
+          assert.equal(scene.hitsTileBar(x, h - 1), false, "the tile bar reaches the canvas floor")
+        }
+
+        // It is still a real target where it says it is, rather than merely
+        // being somewhere harmless.
+        assert.equal(
+          scene.hitsTileBar(area.x + area.w / 2, floor - 30),
+          true,
+          "the tile bar is not where it says",
+        )
+      })
+    })
+  }
+}
+
+test("the layout consumes the insets it is given", () => {
+  // The safe rectangle is the whole contract with the notch, and `hudLayout`
+  // takes it as a REQUIRED argument for the same reason `layoutFor` does in
+  // SKY LEDGER: optional, a caller that forgets it compiles and draws the score
+  // under the sensor housing, and the only way to find out is on a device.
+  const w = 390
+  const h = 844
+  const plain = hudLayout(w, safeRect(w, h, NO_INSETS))
+  const notched = hudLayout(w, safeRect(w, h, PORTRAIT_NOTCH))
+
+  assert.ok(notched.status.top >= plain.status.top + 47, "the counters ignored the notch")
+  assert.ok(notched.status.top >= 47, "the counters are inside the notch")
+  assert.ok(notched.bar.y <= plain.bar.y - 34, "the tile bar ignored the home indicator")
+  assert.equal(plain.status.left, 14)
+  assert.ok(
+    plain.status.top >= HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL,
+    "the counters begin inside the host's corner controls",
+  )
+})

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -49,12 +49,15 @@ function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderin
 }
 
 type FakeElement = {
-  style: { cssText: string }
+  style: Record<string, string>
   width: number
   height: number
   listeners: Map<string, Listener[]>
   appendChild(child: unknown): void
+  append(...children: unknown[]): void
   remove(): void
+  setAttribute(name: string, value: string): void
+  focus(): void
   addEventListener(type: string, fn: Listener): void
   removeEventListener(type: string, fn: Listener): void
   setPointerCapture(): void
@@ -73,7 +76,10 @@ function harness(size: { w: number; h: number }, counter: { calls: number; text:
       height: 0,
       listeners,
       appendChild() {},
+      append() {},
       remove() {},
+      setAttribute() {},
+      focus() {},
       addEventListener(type, fn) {
         const list = listeners.get(type) ?? []
         list.push(fn)
@@ -92,7 +98,13 @@ function harness(size: { w: number; h: number }, counter: { calls: number; text:
     }
   }
   const created: FakeElement[] = []
+  // Enough document for the shared how-to-play chrome, which mounts a button
+  // and a panel and asks the safe-area probe where the notch is. `document.body`
+  // is real machinery here, not padding: `safeInsets` appends its probe to it.
   const doc = {
+    body: make(),
+    activeElement: null,
+    getElementById: () => null,
     createElement() {
       const el = make()
       created.push(el)
@@ -232,6 +244,134 @@ for (const [w, h] of [
     })
   }
 }
+
+test("flying into the resonator actually asserts the hold", () => {
+  // The rule for this lives in `Arena.enter`, it is asserted to death in
+  // `arena.test.ts` and `resonance.test.ts` — and the shell never called it.
+  // Every unit test in this package passed while the one act the whole game is
+  // for did nothing at all: a child could fly through the ring for an hour and
+  // the host would never hear a single answer. Nothing threw. Nothing went red.
+  //
+  // Rules tests cannot catch that, because the missing call is not in the
+  // rules. So this flies the REAL shell — the real loop, the real physics, the
+  // real collision — and asserts the host was told something.
+  //
+  // `Date.now` is pinned because `mount` seeds its generator from it. Left
+  // alone, this test would be a different arena every run.
+  const realNow = Date.now
+  Date.now = () => 1_700_000_000_000
+  try {
+    const counter = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 900, h: 700 }, counter, ({ host, frames, created }) => {
+      const answered: string[] = []
+      const stub = createStubHost({
+        seed: 0x1a771ce,
+        reducedMotion: true,
+        onReport: (r) => answered.push(r.answered),
+      })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      const move = canvas.listeners.get("pointermove")?.[0]
+      assert.ok(down && move, "the twin-stick listeners were not installed")
+
+      // Both thumbs down: the left one sweeps the arena on a slow figure that
+      // does not repeat, the right one holds the trigger and turns the guns.
+      down({ preventDefault() {}, pointerId: 1, pointerType: "touch", clientX: 225, clientY: 350 })
+      down({ preventDefault() {}, pointerId: 2, pointerType: "touch", clientX: 675, clientY: 350 })
+
+      let t = 0
+      for (let i = 0; i < 5000 && answered.length === 0; i++) {
+        move({
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 225 + Math.sin(i / 37) * 70,
+          clientY: 350 + Math.cos(i / 23) * 70,
+        })
+        move({
+          pointerId: 2,
+          pointerType: "touch",
+          clientX: 675 + Math.cos(i / 11) * 50,
+          clientY: 350 + Math.sin(i / 13) * 50,
+        })
+        t = pump(frames, 1, t)
+      }
+
+      assert.ok(
+        answered.length > 0,
+        "a ship flew through the resonator for 5000 frames and the host was never told anything",
+      )
+      handle.unmount()
+    })
+  } finally {
+    Date.now = realNow
+  }
+})
+
+test("reading the rules holds the world, and closing them lets it go", () => {
+  // A manual that leaves a twin-stick arena running is a manual a child cannot
+  // afford to open. They come back to a ship that drifted through the resonator
+  // and asserted a hold they were not there for — the host's sheet does exactly
+  // that damage unguarded, and the how-to-play button is a door this pack owns.
+  const realNow = Date.now
+  Date.now = () => 1_700_000_000_000
+  try {
+    const counter = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 900, h: 700 }, counter, ({ host, frames, created }) => {
+      const answered: string[] = []
+      const stub = createStubHost({
+        seed: 0x1a771ce,
+        reducedMotion: true,
+        onReport: (r) => answered.push(r.answered),
+      })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      const move = canvas.listeners.get("pointermove")?.[0]
+      assert.ok(down && move)
+
+      // The how-to-play button and its PLAY button are the two things the
+      // shared chrome puts a click handler on, in that order.
+      const clickable = created.filter((el) => (el.listeners.get("click")?.length ?? 0) > 0)
+      const help = clickable[0]
+      const play = clickable[1]
+      assert.ok(help && play, "the how-to-play chrome was not mounted")
+
+      down({ preventDefault() {}, pointerId: 1, pointerType: "touch", clientX: 225, clientY: 350 })
+      down({ preventDefault() {}, pointerId: 2, pointerType: "touch", clientX: 675, clientY: 350 })
+
+      /** Fly the same unrepeating sweep as the sitting above, for `n` frames. */
+      let i = 0
+      let t = 0
+      const fly = (n: number, until?: () => boolean): void => {
+        for (let k = 0; k < n; k++, i++) {
+          move({
+            pointerId: 1,
+            pointerType: "touch",
+            clientX: 225 + Math.sin(i / 37) * 70,
+            clientY: 350 + Math.cos(i / 23) * 70,
+          })
+          t = pump(frames, 1, t)
+          if (until?.() === true) return
+        }
+      }
+
+      // Open the manual, then hold both thumbs on the glass for a long time.
+      help.listeners.get("click")?.[0]?.({})
+      fly(3000)
+      assert.equal(answered.length, 0, "an answer was asserted while the child was reading")
+      assert.ok(counter.calls > 0, "the frame stopped being drawn behind the manual")
+
+      // PLAY, and the same arena carries on being an arena.
+      play.listeners.get("click")?.[0]?.({})
+      fly(8000, () => answered.length > 0)
+      assert.ok(answered.length > 0, "the world never came back after the manual closed")
+      handle.unmount()
+    })
+  } finally {
+    Date.now = realNow
+  }
+})
 
 test("a pause that arrives while a thumb is down does not fly the ship on", () => {
   // The shell half of the pause. `Arena` refuses the input; this is the guard


### PR DESCRIPTION
## What

Lay THE LATTICE's chrome out inside the safe area and clear of the host's two
44px corners, add a how-to-play manual from `packs/shared/game-chrome`, and wire
up flying into the resonator — which the shell never did.

## Why

Two defects the whole fleet shares, and one that is this game's alone.

**The safe area.** The pack declares `viewport-fit=cover`, which opts the canvas
*into* the notch, the home indicator and the rounded corners. A DOM HUD claws
that back with `env(safe-area-inset-*)`; a canvas HUD cannot, because `env()` is
a CSS value. So `OPENED` was drawn at `y = 12`, under a 47px sensor housing, and
the factor tile bar stood on the floor of the canvas, which on a phone is the
home indicator.

**The host's chrome.** The host paints an exit chevron top-LEFT and the shared
how-to-play button top-RIGHT over every pack. `OPENED` at `(14, 12)` is under the
first; `BEST` at `(w - 14, 12)` is under the second. The tile bar is not
decoration either — tapping it throws the hold back on the field, and it is the
only way out of a wrong hold — so it is a touch target that must be reachable.

`render/hud.ts` takes the safe rectangle as a **required** argument, following
SKY LEDGER's `layoutFor`. Optional, a caller that forgets it compiles and quietly
draws the score under the notch, discoverable only on a device. The world is not
moved: the sheet, the husks, the motes, the ship and the resonator still use
every pixel, edge to edge and under the notch, which is what `cover` is for.
Chrome overlays; it does not reserve a band. Reserving one costs 67px, 12% of a
568px phone, and broke SKY LEDGER's own lattice when it was tried.

**No instructions.** Nothing on screen said the ring wants the ANSWER to the sum
on its face, built out of numbers that multiply. A child who does not know that
plays the passive layer forever — shooting husks apart, sweeping primes up — and
never once does the reasoning the game exists for.

**A manual that leaves the arena running.** The how-to-play panel is a door this
pack owns, and behind it a twin-stick ship keeps its velocity: a child who opens
the rules comes back to a ship that drifted into a husk, or through the
resonator, having asserted a hold they were not there for. That is precisely the
damage the header comment of `mount.ts` says the host's sheet does unguarded. The
manual now holds the world on the same guards.

**And `Arena.enter` was never called.** Flying into the resonator is the only act
that crosses to the host, it is asserted to death in `arena.test.ts`,
`resonance.test.ts` and `loop.test.ts` — and `mount.ts` did not call it. In the
shipped game a child could fly through the ring for an hour and the host would
never hear an answer. Every test was green, because the missing call is not in
the rules. Found while checking the README's claims before writing the manual.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/lattice/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no `voiceId`
      renamed; no catalog entry dropped. `node build.mjs lattice` builds, checks
      and stages as before.
- [x] **Native integrity.** N/A — no Rust touched.
- [x] **Strings.** N/A — the new strings are pack-local, in the game's own
      instructions spec, not in `corpan-app/public/locales/`.
- [x] **Curriculum.** N/A — no skill id, grade or answer schema touched. What the
      resonator reports is unchanged.
- [x] **Secrets.** None. `gitleaks` clean over the branch.

One behaviour change beyond layout: the resonator can now be entered, so the
host will begin receiving `report()` calls from this pack that it never received
before. They are the exact reports `arena.test.ts` has always specified — one per
question, exact integer, judged by the host.

## Proof

```
$ cd dynawalla/games/lattice && for i in 1 2 3 4 5; do npm test; done
===== RUN 1 =====
# tests 94
# pass 94
# fail 0
# duration_ms 3783.083166
===== RUN 2 =====
# tests 94
# pass 94
# fail 0
# duration_ms 3514.155792
===== RUN 3 =====
# tests 94
# pass 94
# fail 0
# duration_ms 3689.829375
===== RUN 4 =====
# tests 94
# pass 94
# fail 0
# duration_ms 3837.296958
===== RUN 5 =====
# tests 94
# pass 94
# fail 0
# duration_ms 3692.374959

$ npm run tsc
> tsc --noEmit
(0 errors)

$ npm run build
✓ 21 modules transformed.
dist/lattice.js  48.33 kB │ gzip: 15.51 kB
✓ built in 18ms

$ cd ../../packs && node build.mjs lattice
✓ 30 modules transformed.
dist-pack/pack.html                 1.12 kB │ gzip:  0.58 kB
dist-pack/assets/pack-DzlOtzKQ.js  43.44 kB │ gzip: 15.85 kB
dynawalla.lattice@0.1.0 — THE LATTICE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 45685 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~31350 bytes (31.35 KB) in 41.7ms
INF no leaks found
```

### The clearance test goes RED without the fix

A clearance test that passes either way is worthless, so the layout was reverted
in `scene.ts` — counters back to `(14, 12)` / `(w - 14, 12)`, tile bar back to
`h - size * 1.5` and `w / 2` — and the suite re-run:

```
not ok 25 - nothing the child reads is under the host's chrome at phone portrait, small (320×568), no insets
  error: |-
    "OPENED 0" is under the host's chrome at 320×568
    true !== false
  stack: src/test/chrome.test.ts:223:20

not ok 28 - the tile bar can be tapped at phone portrait, small (320×568), with a notch
  error: |-
    the tile bar hangs into the home indicator at x=16
    true !== false
  stack: src/test/chrome.test.ts:270:18

# tests 92
# pass 77
# fail 15
```

Fifteen of them, across every viewport. The test drives the real `Scene.draw`
against a context that records `fillText` with the live `font`/`textAlign`/
`textBaseline`, and probes the real `scene.hitsTileBar` — so it fails when the
renderer stops consulting the layout, not merely when the layout is wrong.

### The resonator wiring goes RED without the fix

With the four lines in `mount.ts` removed:

```
not ok 69 - flying into the resonator actually asserts the hold
  error: 'a ship flew through the resonator for 5000 frames and the host was never told anything'
  stack: src/test/mount.test.ts:300:14
```

### The manual's hold goes RED without the guards

With `const held = paused || guide.isOpen` put back to `paused`, and the two
input gates removed:

```
not ok 70 - reading the rules holds the world, and closing them lets it go
  error: |-
    an answer was asserted while the child was reading
    1 !== 0
```

A ship left flying behind the panel reached the resonator and reported an answer
inside 3000 frames.

All three tests are seeded — `Date.now` is pinned in the shell test because `mount`
seeds its generator from it — so they pass every run or fail every run.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
