### PR TITLE
dynawalla/games/truedraw: put the slate inside the safe area and clear of the host's corners

### DIFF
--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -18,6 +18,7 @@
 // calls before the street clears. There is no percentage anywhere in this game
 // to misread as a pass.
 
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import { Audio } from "./audio/audio.ts"
 import type { Host } from "./contract.ts"
 import { bestCalls, recordCalls } from "./game/best.ts"
@@ -55,6 +56,55 @@ export function mountTrueDraw(
   const rng = new Rng((Date.now() ^ 0x51ed) >>> 0)
   const dealer = new Dealer(host, rng)
   const round = new Round(() => dealer.deal(), reduced ? TIMING_REDUCED : TIMING)
+
+  // How to play. Everything about this game is a rule you have to know before
+  // the first slate lights: the whole of it is a decision between two moves,
+  // and a child who has not been told that holding is a move will draw at
+  // everything and be off the street in three sums. The manual stays reachable
+  // during play, because the moment a child needs the rules is never the title.
+  const guide = createInstructions(el, {
+    title: "THE TRUE DRAW",
+    summary: [
+      "A sum lights up on the slate. If it is right, tap to draw. If it is wrong, keep still.",
+      "You have three shots. Getting it wrong either way costs one.",
+    ],
+    sections: [
+      {
+        heading: "The two moves",
+        lines: [
+          "Read the slate. It says something like 47 + 25 = 62.",
+          "If that sum is right, tap the screen to draw.",
+          "If that sum is wrong, do nothing at all and let it stand.",
+          "Getting it right either way keeps all three of your shots.",
+        ],
+      },
+      {
+        heading: "Your three shots",
+        lines: [
+          "Draw at a sum that is wrong and nothing happens at all. No sound, no flash, nobody moves. But a shot is gone.",
+          "Keep still when the sum was right, and the caller draws first. That costs a shot too.",
+          "When all three shots are gone, the street clears and the run is over.",
+        ],
+      },
+      {
+        heading: "You cannot just tap every time",
+        lines: [
+          "About half the slates are wrong.",
+          "If you draw at every single one, your three shots are gone in about three sums.",
+          "Reading the sum every time is the only way to keep the run going.",
+        ],
+      },
+      {
+        heading: "Why the wrong sums look right",
+        lines: [
+          "A wrong slate is never just one off. That would be too easy to spot.",
+          "It shows the answer you get if you make a real mistake, like forgetting to carry.",
+          "So the only way to know is to work the sum out yourself.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
 
   let best = bestCalls()
   let running = true
@@ -115,7 +165,11 @@ export function mountTrueDraw(
     frame = requestAnimationFrame(tick)
     const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, now - last)
     last = now
-    handle(round.advance(dt))
+    // Reading the rules is not playing. The manual opens over a live street,
+    // and a draw window that ran while a child was reading would take all three
+    // shots before they looked up — which would teach them that asking how to
+    // play is punished.
+    if (!guide.isOpen) handle(round.advance(dt))
     scene.draw({
       phase: round.phase,
       progress: round.progress,
@@ -138,6 +192,9 @@ export function mountTrueDraw(
 
   const key = (event: KeyboardEvent): void => {
     if (event.repeat) return
+    // The manual takes the keyboard while it is up: space is how it is
+    // dismissed, not a draw at a slate nobody can see.
+    if (guide.isOpen) return
     if (event.key !== " " && event.key !== "Enter") return
     press(event)
   }
@@ -145,6 +202,11 @@ export function mountTrueDraw(
   const resize = (): void => {
     scene.resize()
   }
+
+  // Rotation swaps the insets top-for-left, and iPadOS changes them when the
+  // pack is resized in Split View. A layout derived from them once at mount is
+  // correct until the first rotation and wrong after it.
+  const stopInsets = onInsetsChange(resize)
 
   canvas.addEventListener("pointerdown", press)
   globalThis.addEventListener("keydown", key)
@@ -176,6 +238,8 @@ export function mountTrueDraw(
     },
     unmount(): void {
       running = false
+      guide.destroy()
+      stopInsets()
       cancelAnimationFrame(frame)
       canvas.removeEventListener("pointerdown", press)
       globalThis.removeEventListener("keydown", key)

--- a/dynawalla/games/truedraw/src/render/scene.ts
+++ b/dynawalla/games/truedraw/src/render/scene.ts
@@ -10,12 +10,14 @@
 // cold celestial, the brass frame catches it, and that is the go signal. Total
 // stillness, then a slate-flash. Restraint as the whole design.
 
+import { safeInsets, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
 import type { Outcome } from "../game/response.ts"
 import type { Phase } from "../game/round.ts"
 import type { Run } from "../game/run.ts"
 import { SHOTS } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
 import { correctionFor, digitCellWidth, layout, type Layout } from "./glyphs.ts"
+import { layoutFor, type Layout as Street } from "./street.ts"
 import {
   BRASS,
   BRASS_DIM,
@@ -68,16 +70,33 @@ export class Scene {
   private w = 0
   private h = 0
   private dpr = 1
+  private street: Street
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     const ctx = canvas.getContext("2d", { alpha: false })
     if (!ctx) throw new Error("truedraw: no 2d context")
     this.ctx = ctx
+    this.street = layoutFor(1, 1, safeRect(1, 1))
     this.resize()
   }
 
-  resize(): void {
+  /**
+   * Where the readable things ended up. Exposed so the layout can be asserted
+   * at every viewport the fleet has, through the same call the game makes at
+   * resize — a clearance test that builds its own rectangle is a test of the
+   * rectangle it built.
+   */
+  get layout(): Street {
+    return this.street
+  }
+
+  /**
+   * `insets` defaults to the live safe-area insets, which is what the game
+   * passes. A test passes a device's insets instead, because a notch is the one
+   * thing a headless canvas will never report.
+   */
+  resize(insets: Insets = safeInsets()): void {
     const rect = this.canvas.getBoundingClientRect()
     // A zero-sized parent happens for one frame during mount; refusing to
     // divide by it is cheaper than guarding every call site.
@@ -86,6 +105,7 @@ export class Scene {
     this.dpr = Math.min(3, globalThis.devicePixelRatio || 1)
     this.canvas.width = Math.round(this.w * this.dpr)
     this.canvas.height = Math.round(this.h * this.dpr)
+    this.street = layoutFor(this.w, this.h, safeRect(this.w, this.h, insets))
   }
 
   draw(state: SceneState): void {
@@ -93,7 +113,7 @@ export class Scene {
     ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
     ctx.clearRect(0, 0, this.w, this.h)
 
-    const horizon = this.h * 0.6
+    const horizon = this.street.horizon
     this.drawSky(horizon)
     this.drawGround(horizon, state)
     this.drawWitnesses(horizon, state)
@@ -258,10 +278,10 @@ export class Scene {
   }
 
   private slateBox(state: SceneState): { x: number; y: number; w: number; h: number; a: number } {
-    const w = Math.min(this.w * 0.88, 640)
-    const h = w * 0.3
-    const cx = this.w * 0.5
-    const cy = this.h * 0.4
+    // Where the slate stands is `street.ts`'s business — inside the safe area
+    // and clear of the host's corners. All that happens here is the raise and
+    // the clear, which are motion about that rest position.
+    const { x, y, w, h } = this.street.slate
 
     let drop = 0
     let a = 1
@@ -276,7 +296,7 @@ export class Scene {
     } else if (state.phase === "idle") {
       a = 0
     }
-    return { x: cx - w / 2, y: cy - h / 2 + drop, w, h, a }
+    return { x, y: y + drop, w, h, a }
   }
 
   private drawSlate(state: SceneState): void {
@@ -495,10 +515,12 @@ export class Scene {
     if (state.phase === "idle") {
       ctx.globalAlpha = state.reduced ? 0.7 : 0.45 + 0.35 * (0.5 + 0.5 * Math.sin(state.elapsedMs / 620))
     }
-    const r = Math.max(3.5, this.h * 0.0075)
-    const gap = r * 3.4
-    const cx = this.w * 0.5
-    const y = this.h * 0.4 + Math.min(this.w * 0.88, 640) * 0.3 * 0.5 + r * 5
+    // The shots are the only resource in the game, so they travel with the
+    // slate: inside the safe area, under the host's corners, never under a
+    // rounded corner of the glass.
+    const { pip: r, pipGap: gap, shots } = this.street
+    const cx = shots.x + shots.w / 2
+    const y = shots.y + shots.h / 2
     for (let i = 0; i < SHOTS; i++) {
       const x = cx + (i - (SHOTS - 1) / 2) * gap
       ctx.beginPath()
@@ -519,11 +541,11 @@ export class Scene {
   private drawTally(state: SceneState): void {
     if (state.phase === "idle" || state.phase === "over") return
     const { ctx } = this
-    const px = Math.round(Math.max(15, this.h * 0.026))
-    ctx.font = `${String(px)}px ${SLATE_FONT}`
+    const { tally, tallyPx } = this.street
+    ctx.font = `${String(tallyPx)}px ${SLATE_FONT}`
     ctx.textAlign = "center"
     ctx.textBaseline = "top"
     ctx.fillStyle = withAlpha(BRASS, state.run.calls > 0 ? 0.8 : 0.3)
-    ctx.fillText(String(state.run.calls), this.w * 0.5, this.h * 0.055)
+    ctx.fillText(String(state.run.calls), tally.x + tally.w / 2, tally.y)
   }
 }

--- a/dynawalla/games/truedraw/src/render/street.test.ts
+++ b/dynawalla/games/truedraw/src/render/street.test.ts
@@ -1,0 +1,151 @@
+// THE SAFE STREET.
+//
+// Two things can be true at once and both are here.
+//
+//   1. The world may bleed. `viewport-fit=cover` is set on purpose: the dust,
+//      the haze, the crowd and the caller are supposed to reach the glass, and
+//      a test that demanded otherwise would be asking for a letterboxed game.
+//   2. The slate may not. It carries `47 + 25 = 62`, and a digit behind the
+//      camera housing is a wrong call the child did not make. The three shots
+//      are the same: the only resource in the game, and the only thing that
+//      tells a child the run is nearly over.
+//
+// So this file asserts the second while deliberately declining to assert the
+// first, at the shapes the fleet actually has, WITH the insets a device
+// actually reports — a headless canvas reports none, so every one of these
+// numbers would pass vacuously if the insets were left at zero.
+//
+// It runs the layout through `Scene.resize`, which is the exact call `mount.ts`
+// makes on rotation. A clearance test that calls `layoutFor` itself is a test
+// of the arguments the test chose, not of the ones the game passes.
+
+import { hitsHostChrome, NO_INSETS, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { fakeCanvas } from "./fakeCanvas.ts"
+import { Scene } from "./scene.ts"
+import { layoutFor, type Rect } from "./street.ts"
+
+const VIEWPORTS: readonly (readonly [string, number, number])[] = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape, tall", 844, 390],
+  ["phone landscape, small", 568, 320],
+]
+
+/**
+ * What devices actually report. The portrait notch is an iPhone 14/15 class
+ * phone; the landscape pair is the same phone turned, where the camera housing
+ * moves to a side and the home indicator stays at the bottom.
+ */
+const INSETS: readonly (readonly [string, Insets])[] = [
+  ["no insets", NO_INSETS],
+  ["portrait notch", { top: 47, right: 0, bottom: 34, left: 0 }],
+  ["landscape notch", { top: 0, right: 47, bottom: 21, left: 47 }],
+]
+
+function streetAt(w: number, h: number, insets: Insets): Scene {
+  const { canvas } = fakeCanvas(w, h)
+  const scene = new Scene(canvas as HTMLCanvasElement)
+  // The same call `mount.ts` makes on resize and on an inset change.
+  scene.resize(insets)
+  return scene
+}
+
+const inside = (box: Rect, area: Rect): boolean =>
+  box.x >= area.x - 0.5 &&
+  box.y >= area.y - 0.5 &&
+  box.x + box.w <= area.x + area.w + 0.5 &&
+  box.y + box.h <= area.y + area.h + 0.5
+
+const show = (r: Rect): string =>
+  `[${r.x.toFixed(1)},${r.y.toFixed(1)} ${r.w.toFixed(1)}×${r.h.toFixed(1)}]`
+
+for (const [shape, w, h] of VIEWPORTS) {
+  for (const [where, insets] of INSETS) {
+    test(`the slate and the shots clear the host's corners — ${shape} (${String(w)}×${String(h)}), ${where}`, () => {
+      const l = streetAt(w, h, insets).layout
+
+      // The promise, and the whole of it: nothing a child must read or touch
+      // lands in the two 44px corners the host paints over. Not a reserved
+      // band — reserving one costs a twelfth of a 568px phone.
+      for (const [name, box] of [
+        ["the slate", l.slate],
+        ["the shots", l.shots],
+        ["the tally", l.tally],
+      ] as const) {
+        assert.equal(
+          hitsHostChrome(box, w, insets),
+          false,
+          `${name} ${show(box)} is under host chrome at ${String(w)}×${String(h)} ${where}`,
+        )
+      }
+    })
+
+    test(`the readable things stay inside the safe area — ${shape} (${String(w)}×${String(h)}), ${where}`, () => {
+      const l = streetAt(w, h, insets).layout
+      const area: Rect = {
+        x: insets.left,
+        y: insets.top,
+        w: w - insets.left - insets.right,
+        h: h - insets.top - insets.bottom,
+      }
+      for (const [name, box] of [
+        ["the slate", l.slate],
+        ["the shots", l.shots],
+        ["the tally", l.tally],
+      ] as const) {
+        assert.ok(
+          inside(box, area),
+          `${name} ${show(box)} runs outside the safe area ${show(area)} at ${String(w)}×${String(h)} ${where}`,
+        )
+      }
+    })
+  }
+}
+
+test("the world still bleeds to the edges — that is what cover is for", () => {
+  // The counterweight to everything above. If a future change "fixed" the
+  // safe area by insetting the whole scene, the game would letterbox itself on
+  // every notched phone and this is the test that would say so.
+  const l = layoutFor(390, 844, { x: 0, y: 47, w: 390, h: 763 })
+  assert.equal(l.horizon, 844 * 0.6, "the horizon was pulled inside the safe area")
+  assert.equal(l.w, 390)
+  assert.equal(l.h, 844)
+})
+
+test("the slate is centred in the safe area, not in the glass", () => {
+  // A landscape notch is asymmetric in nothing but its presence: 47 either
+  // side. A portrait one is not — 47 top, 34 bottom — and a slate centred on
+  // the raw canvas sits too high by half that difference.
+  const notched = layoutFor(390, 844, { x: 0, y: 47, w: 390, h: 763 })
+  const plain = layoutFor(390, 844, { x: 0, y: 0, w: 390, h: 844 })
+  assert.ok(
+    notched.slate.y > plain.slate.y,
+    `the slate did not move down for the notch (${String(notched.slate.y)} vs ${String(plain.slate.y)})`,
+  )
+})
+
+test("the shots hang below the slate, always", () => {
+  for (const [, w, h] of VIEWPORTS) {
+    for (const [, insets] of INSETS) {
+      const l = streetAt(w, h, insets).layout
+      assert.ok(
+        l.shots.y >= l.slate.y + l.slate.h,
+        `the shots ride up onto the slate at ${String(w)}×${String(h)}`,
+      )
+      assert.ok(l.tally.y + l.tally.h <= l.slate.y, `the tally overlaps the slate at ${String(w)}×${String(h)}`)
+    }
+  }
+})
+
+test("the statement stays big enough to read at the smallest phone", () => {
+  // The clamp that keeps the slate clear of the corners must not do it by
+  // shrinking the one thing in the game a child has to read.
+  const l = streetAt(320, 568, { top: 47, right: 0, bottom: 34, left: 0 }).layout
+  assert.ok(l.slate.w >= 240, `the slate is ${l.slate.w.toFixed(1)}px wide`)
+  assert.ok(l.slate.h >= 70, `the slate is ${l.slate.h.toFixed(1)}px tall`)
+})

--- a/dynawalla/games/truedraw/src/render/street.ts
+++ b/dynawalla/games/truedraw/src/render/street.ts
@@ -1,0 +1,139 @@
+// Where the readable things stand.
+//
+// THE TRUE DRAW is drawn entirely on a canvas, and a canvas cannot read
+// `env(safe-area-inset-*)`. The pack declares `viewport-fit=cover`, which is a
+// deliberate choice — the dust, the street, the caller, the crowd and the haze
+// SHOULD run under the notch and past the rounded corners, because a world that
+// stops short of the glass is not a world. But the slate is not the world. The
+// slate carries `47 + 25 = 62`, and a statement a child cannot read is a wrong
+// call they did not make.
+//
+// So this module splits the frame in two:
+//
+//   * the WORLD — horizon, sky, dust, figures — laid out on the full canvas;
+//   * the READABLE things — the slate, the three shots, the tally — laid out
+//     inside `area`, the safe rectangle, and clear of the host's two corners.
+//
+// The host paints an exit control top-LEFT and a how-to-play control top-RIGHT,
+// 44px each, floating over the game. They do not reserve a band: reserving one
+// costs a twelfth of a 568px phone and broke a sibling game's own layout. The
+// promise each game makes instead is narrow and absolute — nothing a child must
+// read or touch lands in those two squares. The slate is 88% of the width, so
+// at most viewports it cannot pass between them; when it cannot, it goes below
+// them, and that is the whole of the clamp.
+
+import {
+  exitRect,
+  helpRect,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { SHOTS } from "../game/run.ts"
+
+export type { Rect }
+
+export type Layout = {
+  readonly w: number
+  readonly h: number
+  /** Where the dust meets the sky. Full bleed, deliberately. */
+  readonly horizon: number
+  /** The slate, at rest. The statement lives here and it is the whole game. */
+  readonly slate: Rect
+  /** The three shots as one box: the only resource there is. */
+  readonly shots: Rect
+  /** Radius of one shot pip, and the spacing between their centres. */
+  readonly pip: number
+  readonly pipGap: number
+  /** The call tally, small, in brass, above the slate. */
+  readonly tally: Rect
+  readonly tallyPx: number
+}
+
+/** The insets `area` was cut from. Exact: `safeRect` is the only thing that cuts it. */
+function insetsOf(w: number, h: number, area: Rect): {
+  top: number
+  right: number
+  bottom: number
+  left: number
+} {
+  return {
+    top: area.y,
+    left: area.x,
+    right: Math.max(0, w - area.x - area.w),
+    bottom: Math.max(0, h - area.y - area.h),
+  }
+}
+
+/**
+ * The street, at `w` x `h`, with `area` as the region a child may be asked to
+ * read.
+ *
+ * `area` is REQUIRED, and that is the point of this signature. Made optional it
+ * would default to the full canvas, a caller that forgot it would compile
+ * cleanly, and the only way anyone would find out is a child on a notched phone
+ * being asked to judge a sum whose last digit is behind the camera. Required,
+ * forgetting it is a type error.
+ */
+export function layoutFor(w: number, h: number, area: Rect): Layout {
+  // The world. Not derived from `area`: the ground is supposed to reach the
+  // bottom of the glass, under the home indicator, and the sky the top.
+  const horizon = h * 0.6
+
+  const slateW = Math.min(area.w * 0.88, 640)
+  const slateH = slateW * 0.3
+  const slateX = area.x + (area.w - slateW) / 2
+
+  const pip = Math.max(3.5, h * 0.0075)
+  const pipGap = pip * 3.4
+  const shotsW = pipGap * (SHOTS - 1) + pip * 2
+  /** From the bottom of the slate down to the centre of the pips. */
+  const shotsDrop = pip * 5
+
+  const tallyPx = Math.round(Math.max(15, h * 0.026))
+
+  // The host's chrome, rebuilt from `area` rather than measured again, so the
+  // game and the host cannot end up disagreeing about where the buttons are.
+  const insets = insetsOf(w, h, area)
+  const exit = exitRect(insets)
+  const help = helpRect(w, insets)
+  const chromeBottom = Math.max(exit.y + exit.h, help.y + help.h)
+  const passesBetween =
+    slateX >= exit.x + exit.w + HOST_MARGIN && slateX + slateW <= help.x - HOST_MARGIN
+  const ceiling = passesBetween ? area.y : chromeBottom + HOST_MARGIN
+
+  // Centred four tenths down the safe area — high enough that a thumb is not
+  // over the statement it is about to judge.
+  let slateY = Math.max(ceiling, area.y + area.h * 0.4 - slateH / 2)
+  // ...and lifted back up if the shots would fall off the safe bottom. The
+  // ceiling still wins: a slate under the exit button is worse than pips near
+  // the home indicator, and on no shape the fleet has does it come to that.
+  const overflow = slateY + slateH + shotsDrop + pip - (area.y + area.h)
+  if (overflow > 0) slateY = Math.max(ceiling, slateY - overflow)
+
+  const cx = area.x + area.w / 2
+  const shotsY = slateY + slateH + shotsDrop
+
+  // The tally sits above the slate, and gives way to it: when the slate has
+  // been pushed clear of the corners there may be very little room up there,
+  // and the tally is the thing that yields.
+  const tallyY = Math.max(
+    area.y + HOST_PROGRESS_H,
+    Math.min(area.y + area.h * 0.055, slateY - tallyPx * 1.5),
+  )
+  // Three digits' worth, generously: this box exists to be tested against the
+  // host's corners, so it errs wide.
+  const tallyW = tallyPx * 3
+
+  return {
+    w,
+    h,
+    horizon,
+    slate: { x: slateX, y: slateY, w: slateW, h: slateH },
+    shots: { x: cx - shotsW / 2, y: shotsY - pip, w: shotsW, h: pip * 2 },
+    pip,
+    pipGap,
+    tally: { x: cx - tallyW / 2, y: tallyY, w: tallyW, h: tallyPx },
+    tallyPx,
+  }
+}


### PR DESCRIPTION
## What

Adopt the shared game chrome in THE TRUE DRAW: derive the layout from the safe
rect, keep the slate and the three shots clear of the host's two 44px corners,
and add the shared how-to-play surface.

## Why

Two defects, both invisible on a desktop and both certain on a phone.

**The safe area.** truedraw draws everything on a canvas and declares
`viewport-fit=cover`, which opts the document *into* the notch, the home
indicator and the rounded corners. A canvas cannot read `env(safe-area-inset-*)`,
and nothing here read it back. The call tally sat at `h * 0.055` — 31px on a
320×568 phone, behind a 47px notch — and the slate was centred on the raw canvas
rather than on the part of it a child can see.

`render/street.ts` now owns the layout and takes the safe rect as a **required**
argument. Optional would mean a future caller that forgets it compiles cleanly
and silently draws under the notch, discoverable only on a device.

The world still bleeds, deliberately. The horizon, the dust, the haze, the caller
and the crowd are laid out on the full canvas — that is what `cover` is for. Only
the slate, the shots and the tally moved inside the rect.

**Host chrome.** The host paints an exit control top-left and a how-to-play
control top-right, 44px each, overlaying the game rather than reserving a band —
reserving one costs a twelfth of a 568px phone and broke a sibling game's own
lattice. So the promise is only that nothing a child must read or touch lands in
those two squares.

For truedraw the slate **is** the game: it carries `47 + 25 = 62`, and a
statement a child cannot read is a wrong call they did not make. The shots are
the only resource there is. Both are treated as critical. The slate is 88% of the
width and cannot pass between the two corners on a small phone, so when it cannot
it goes below them — at 568×320 it was landing at `y=53` with the chrome band
ending at 57.

**Instructions.** `createInstructions` in mount, `guide.destroy()` in unmount,
`reducedMotion: host.prefersReducedMotion()`. The round is held while the manual
is open: a draw window that ran while a child read the rules would spend all
three shots before they looked up, which would teach them that asking how to play
is punished.

## Blast radius

**Areas touched:** dynawalla (one game pack, `dynawalla/games/truedraw/` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place, no `voiceId`
      renamed, no catalog entry dropped or version-gated. `node build.mjs truedraw`
      rebuilds and re-stages the pack from source as it does on every main push.
- [x] **Native integrity.** N/A — no Rust, no manifest, no `links =` touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are the
      how-to-play copy, which lives in the pack and is English-only like every
      other Dynawalla game's instructions.
- [x] **Curriculum.** N/A — no skill id, grade, generator or schema touched. The
      game's item stream is unchanged.
- [x] **Secrets.** None. `gitleaks` clean, below.

## Proof

Five test runs, because one green run is not proof — a sibling game failed 3 of 5
from unseeded `Math.random`, and `game/inhibition.test.ts` here plays strategies
out over thousands of runs.

```
$ cd dynawalla/games/truedraw
$ for i in 1 2 3 4 5; do npm test; done
--- run 1 ---
# tests 132
# pass 132
# fail 0
--- run 2 ---
# tests 132
# pass 132
# fail 0
--- run 3 ---
# tests 132
# pass 132
# fail 0
--- run 4 ---
# tests 132
# pass 132
# fail 0
--- run 5 ---
# tests 132
# pass 132
# fail 0
```

**The clearance test goes RED when the fix is removed.** Verified in both halves,
then restored.

Half one — `Scene.resize` passing the full canvas instead of `safeRect`:

```
# tests 132
# pass 123
# fail 9

not ok 90 - the readable things stay inside the safe area — phone portrait, small (320×568), portrait notch
  error: 'the tally [137.5,31.2 45.0×15.0] runs outside the safe area [0.0,47.0 320.0×487.0] at 320×568 portrait notch'

not ok 119 - the slate and the shots clear the host's corners — phone landscape, small (568×320), portrait notch
  error: |-
    the slate [34.1,67.0 499.8×150.0] is under host chrome at 568×320 portrait notch
    true !== false
```

Half two — the corner clamp alone removed (`const ceiling = area.y`):

```
# tests 132
# pass 130
# fail 2

not ok 117 - the slate and the shots clear the host's corners — phone landscape, small (568×320), no insets
  error: |-
    the slate [34.1,53.0 499.8×150.0] is under host chrome at 568×320 no insets
    true !== false
```

The test drives the layout through `Scene.resize` — the exact call `mount.ts`
makes on resize and on an inset change — rather than calling `layoutFor` with a
rectangle of its own, which would be a test of the arguments the test chose.

```
$ npm run tsc
> tsc --noEmit
TSC_EXIT=0

$ npm run build
vite v8.1.5 building client environment for production...
✓ 25 modules transformed.
dist/truedraw.js  35.55 kB │ gzip: 12.12 kB
✓ built in 16ms

$ cd dynawalla/packs && node build.mjs truedraw
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 34926 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~16448 bytes (16.45 KB) in 38.7ms
INF no leaks found

$ git diff origin/main..HEAD --name-only
dynawalla/games/truedraw/src/mount.ts
dynawalla/games/truedraw/src/render/scene.ts
dynawalla/games/truedraw/src/render/street.test.ts
dynawalla/games/truedraw/src/render/street.ts

$ git diff origin/main..HEAD --diff-filter=D --name-only
(empty)
```
