### PR TITLE
dynawalla/games/slice: lay the HUD out inside the safe rect and clear of host chrome

### DIFF
--- a/dynawalla/games/slice/README.md
+++ b/dynawalla/games/slice/README.md
@@ -9,7 +9,7 @@ the arithmetic welded into the gesture rather than bolted onto it.
 ```bash
 npm install
 npm run dev     # http://127.0.0.1:4317 — playable standalone, stub Host included
-npm test        # 30 tests
+npm test        # 86 tests
 npm run tsc
 npm run build:pack # what installs on a tablet: pack.html only, no stub Host
 ```
@@ -172,6 +172,35 @@ Every one of these was found by playing, not by reading:
    clamped every partial with a console warning. Capped at three octaves.
 8. **The blade ribbon was visibly jagged** at low sample density. Catmull-Rom
    resampling doubles the point density before the ribbon is built.
+
+## The frame this game does not own
+
+The document declares `viewport-fit=cover` and the whole HUD is drawn on the
+canvas, where `env(safe-area-inset-*)` cannot be read — so the score was being
+painted at `y = 12`, which on a notched phone is not on the screen. The host
+compounds it: it floats a 44px exit control in the top-LEFT corner and a 44px
+how-to-play control in the top-RIGHT, over the pack rather than reserving a
+band, and the score and the three lamps were underneath them.
+
+`src/render/hud.ts` is the one place both facts are known. `hudLayout(w, h,
+area)` takes the safe rect as a **required** parameter — a default would compile
+at any call site that forgot it and only fail on a device with a notch in
+someone's hand — and `resize()` re-derives it from `safeRect(W, H)` every time,
+so rotation and Split View are handled rather than being right once at mount.
+
+Nothing reserves a band; reserving 67px costs a twelfth of a 568px phone. The
+promise is narrower: **the two 44px corners stay free of anything a child must
+read or touch.** That means the score/BEST/multiplier column, the three lamps
+and their relight ticks, the live-question banner, and the answer lanterns. The
+lanterns get the strictest treatment of the lot, being the one thing here that
+is both read *and* touched.
+
+The sky, the ridges, the canopies, the blade ribbon, the splat layer, the
+particles and the flying gourds still bleed to every edge. That is what
+`viewport-fit=cover` is *for*.
+
+`src/test/layout.test.ts` runs the same two functions the renderer runs, across
+five viewports and three real inset profiles, and asserts both promises.
 
 ## The contract
 

--- a/dynawalla/games/slice/src/mount.ts
+++ b/dynawalla/games/slice/src/mount.ts
@@ -15,6 +15,7 @@
 //
 // Nothing here ever ends. It escalates.
 
+import { createInstructions, safeRect } from "../../../packs/shared/game-chrome/index.ts"
 import type { Host, Question } from "./contract.ts"
 import { Audio } from "./audio.ts"
 import { Feel } from "./core/feel.ts"
@@ -23,6 +24,14 @@ import { Rng } from "./core/rng.ts"
 import { detectTier, TierGovernor, TIERS } from "./core/tiers.ts"
 import { createAtlases } from "./render/atlas.ts"
 import { Blade } from "./render/blade.ts"
+import {
+  candidateHome,
+  candidateRow,
+  hudLayout,
+  lampX,
+  tickRect,
+  type HudLayout,
+} from "./render/hud.ts"
 import { Bloom, Splats } from "./render/layers.ts"
 import {
   FLESHES,
@@ -106,6 +115,50 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
 
   // ── systems ──────────────────────────────────────────────────────────────
   const reduced = host.prefersReducedMotion()
+
+  // How to play. THE SPLIT shipped with none: a child was handed a screen of
+  // flying gourds and had to infer from nothing that a swipe cuts, that a cut
+  // number splits into its factors, and that the four lanterns are a question.
+  // The manual stays reachable during play, because the moment a child needs
+  // the rules is never the title.
+  const guide = createInstructions(el, {
+    title: "THE SPLIT",
+    summary: [
+      "Fruit flies up out of the market. Swipe your finger across it to cut it.",
+      "Cut a number and it splits into two smaller numbers. Cut those too.",
+    ],
+    sections: [
+      {
+        heading: "Cutting numbers",
+        lines: [
+          "Swipe your finger right across a gourd to slice it open.",
+          "A gourd with 48 on it splits into a 6 and an 8. Both of them fly out.",
+          "Cut the 8 and it splits again, into 2 and 4.",
+          "Some numbers do not split at all. A 7 just bursts into gold. Those are the best ones to find.",
+        ],
+      },
+      {
+        heading: "Answering a question",
+        lines: [
+          "Some things that fly up are flat tablets with a sum on them, like 7 x 8.",
+          "Cut the tablet and four numbers float up and stop in a row.",
+          "Work out the sum, then swipe the number that is the answer.",
+          "You cannot cut them straight away. You get a moment to read them first.",
+        ],
+      },
+      {
+        heading: "Your three lamps",
+        lines: [
+          "You have three lamps. You lose one if you swipe a wrong answer.",
+          "You also lose one if you cut a bomb. Bombs are small and spiky and have a lit fuse.",
+          "Thinking is always free. If you run out of time on a question you keep every lamp.",
+          "When all three lamps go out the market shuts. One tap opens it again.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
+
   const gov = new TierGovernor(detectTier())
   const atl = createAtlases()
   const parts = new Particles()
@@ -307,11 +360,22 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   // ── layout ───────────────────────────────────────────────────────────────
+  /**
+   * Where every readout goes.
+   *
+   * Re-derived on every resize, never cached across one: rotation swaps the
+   * insets top-for-side, and iPadOS changes them when the pack is resized in
+   * Split View. A layout solved once at mount is correct until the first
+   * rotation and wrong after it.
+   */
+  let hud: HudLayout = hudLayout(320, 300, safeRect(320, 300))
+
   function resize(): void {
     const q = gov.quality
     const rect = root.getBoundingClientRect()
     W = Math.max(320, Math.round(rect.width))
     H = Math.max(300, Math.round(rect.height))
+    hud = hudLayout(W, H, safeRect(W, H))
     dpr = Math.min(q.maxDpr, globalThis.devicePixelRatio || 1)
     canvas.width = Math.round(W * dpr)
     canvas.height = Math.round(H * dpr)
@@ -529,26 +593,16 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     // in — the child was punished for aiming correctly. Slots guarantee clear
     // air between any two candidates.
     //
-    // The width budget comes first and the radius bends to it. At 320px the
-    // preferred 3.4-radii gap made the row 326px wide and pushed the fourth
-    // candidate clean off the screen, where it could never be cut.
-    // Solve the radius from the width budget rather than clamping afterwards.
-    // A lantern is drawn out to 1.26r plus its progress arc, so the row needs
-    // 2.75r per gap and 1.4r of margin at each end. Clamping after the fact left
-    // the last candidate hanging off the right edge of a 320px screen, where it
-    // was literally impossible to cut.
-    const rPref = Math.max(20, Math.min(H * 0.062, H * 0.05))
-    const rFit = W / (2.75 * (n - 1) + 2.8)
-    const r = Math.max(14, Math.min(rPref, rFit))
-    const gap = Math.min(r * 3.4, (W - r * 2.8) / Math.max(1, n - 1))
-    const span = gap * (n - 1)
-    const margin = r * 1.4
-    const cx = Math.max(margin + span / 2, Math.min(W - margin - span / 2, b.x))
-    const cy = Math.max(H * 0.32, Math.min(H * 0.54, b.y))
+    // The row is solved in `render/hud.ts`, against the SAFE rect rather than
+    // the canvas and never rising into the host's two corner controls. These
+    // lanterns are the answer input: they are the one thing here a child must
+    // both read and touch, so they get the strictest clearance in the game.
+    const row = candidateRow(hud, n, b.x, b.y)
+    const r = row.r
     for (let i = 0; i < n; i++) {
       const m = world.spawnBody()
       if (!m) continue
-      const f = i / Math.max(1, n - 1) - 0.5
+      const home = candidateHome(row, i, n)
       m.kind = B_MOTE
       m.text = values[i] as string
       m.value = Number(values[i])
@@ -556,10 +610,10 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       m.qid = q.id
       m.x = b.x
       m.y = b.y
-      m.homeX = cx + f * span
       // A shallow arc, high in the middle: it reads as a row of raised lanterns
       // rather than a line of buttons.
-      m.homeY = cy - Math.cos(f * Math.PI) * r * 0.55
+      m.homeX = home.x
+      m.homeY = home.y
       m.vx = (m.homeX - b.x) * 2.4
       m.vy = (m.homeY - b.y) * 2.4 - H * 0.1
       m.grav = 0
@@ -1592,27 +1646,31 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function drawHud(ctx: CanvasRenderingContext2D, nowMs: number): void {
-    const pad = Math.max(12, W * 0.022)
-    const big = Math.max(24, Math.min(46, W * 0.042))
+    // Every number below comes off the layout, which knows two things this
+    // function must not have to: where the safe rect is, and where the host
+    // floats its exit and how-to-play controls. Nothing here is measured from
+    // the canvas edge any more.
+    const { big } = hud
 
-    // Score, top-left.
+    // Score, top-left — under the safe edge and clear of the exit control.
     ctx.textAlign = "left"
     ctx.textBaseline = "top"
     ctx.font = font(UI_FONT, big)
     ctx.fillStyle = "rgba(6,4,14,0.6)"
-    ctx.fillText(String(score), pad + 2, pad + 2)
+    ctx.fillText(String(score), hud.scoreX + 2, hud.scoreY + 2)
     ctx.fillStyle = PAPER
-    ctx.fillText(String(score), pad, pad)
+    ctx.fillText(String(score), hud.scoreX, hud.scoreY)
     ctx.font = font(UI_FONT, big * 0.36)
     ctx.fillStyle = withAlpha(PAPER, 0.5)
-    ctx.fillText(`BEST ${best}`, pad, pad + big * 1.05)
+    ctx.fillText(`BEST ${best}`, hud.scoreX, hud.bestY)
 
     // Lamps, top-right. Three hanging lanterns; a dead one is dark AND unlit AND
-    // struck through, so "how much life" never depends on colour.
-    const lr = Math.max(9, Math.min(15, W * 0.014))
+    // struck through, so "how much life" never depends on colour. They hang from
+    // BELOW the how-to-play control — they used to hang behind it.
+    const lr = hud.lampR
     for (let i = 0; i < 3; i++) {
-      const x = W - pad - lr - i * (lr * 2.9)
-      const y = pad + lr * 1.2
+      const x = lampX(hud, i)
+      const y = hud.lampY
       const on = i < lamps
       ctx.beginPath()
       ctx.moveTo(x, y - lr * 1.9)
@@ -1658,13 +1716,11 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     // dark lamp comes on — this is the game's "watch an ad to continue", and
     // the price is arithmetic.
     if (lamps < 3) {
-      const ty = pad + lr * 2.9
-      const tw = lr * 1.5
       for (let i = 0; i < READ_PER_LAMP; i++) {
-        const x = W - pad - tw - i * (tw + 4)
+        const t = tickRect(i, hud)
         ctx.fillStyle =
           i < readCredit ? withAlpha(SIGIL_HOT, 0.95) : "rgba(255,255,255,0.16)"
-        ctx.fillRect(x, ty, tw, 3.5)
+        ctx.fillRect(t.x, t.y, t.w, t.h)
       }
     }
 
@@ -1679,16 +1735,16 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       ctx.textAlign = "left"
       ctx.textBaseline = "top"
       const ms = big * (hot ? 0.78 : 0.62)
-      const y0 = pad + big * 1.55
+      const y0 = hud.mulY
       ctx.font = font(UI_FONT, ms)
       const label = `×${m}`
       ctx.fillStyle = withAlpha(hot ? PRIME_HOT : PRIME_GOLD, 0.62 + t * 0.38)
-      ctx.fillText(label, pad, y0)
+      ctx.fillText(label, hud.scoreX, y0)
       // MEASURED, not guessed. A fixed offset put "×36" straight through
       // "FAVOUR 3" the moment the multiplier reached two digits — the same
       // run-on-number defect this batch was told off for, in the HUD instead of
       // the playfield. Every offset below is derived from a real metric.
-      const lx = pad + ctx.measureText(label).width + big * 0.42
+      const lx = hud.scoreX + ctx.measureText(label).width + big * 0.42
       const sm = big * 0.34
       ctx.font = font(UI_FONT, sm)
       if (favour > 1) {
@@ -1714,12 +1770,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     // The live question banner. Pinned, legible, with a draining bar — a child
     // who lost track of which sigil they opened can always re-read it.
     if (liveQ) {
-      const bw = Math.min(W * 0.9, 460)
-      const bh = Math.max(42, Math.min(74, H * 0.085))
-      const bx = (W - bw) / 2
-      // On a narrow screen the centred banner used to land straight on top of
-      // the score and the lamps. Below 620px it drops under the whole HUD row.
-      const by = W < 620 ? pad + big * 2.55 : pad * 0.7
+      const { x: bx, y: by, w: bw, h: bh } = hud.banner
       ctx.fillStyle = "rgba(8,6,20,0.82)"
       roundRect(ctx, bx, by, bw, bh, 10)
       ctx.fill()
@@ -1731,7 +1782,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       ctx.textBaseline = "middle"
       ctx.font = font(UI_FONT, bh * 0.5)
       ctx.fillStyle = PAPER
-      ctx.fillText(`${liveQ.prompt} = ?`, W / 2, by + bh * 0.46)
+      ctx.fillText(`${liveQ.prompt} = ?`, bx + bw / 2, by + bh * 0.46)
       const frac = Math.max(0, moteLeft / moteWindow)
       ctx.fillStyle = withAlpha(frac < 0.3 ? WRONG : SIGIL_EDGE, 0.9)
       ctx.fillRect(bx + 6, by + bh - 7, (bw - 12) * frac, 4)
@@ -2004,6 +2055,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   return {
     unmount(): void {
       running = false
+      guide.destroy()
       cancelAnimationFrame(raf)
       ro.disconnect()
       canvas.removeEventListener("pointerdown", onDown)

--- a/dynawalla/games/slice/src/render/hud.ts
+++ b/dynawalla/games/slice/src/render/hud.ts
@@ -1,0 +1,284 @@
+// WHERE THE READOUTS GO.
+//
+// THE SPLIT draws its whole HUD on the canvas — the score, the three lamps, the
+// chain and favour lines, the question banner — and a canvas cannot read
+// `env(safe-area-inset-*)`. The document declares `viewport-fit=cover`, which is
+// not a neutral setting: it opts this game *into* the notch, the home indicator
+// and the rounded corners. So `fillText` at `y = 12` landed under the notch, and
+// on a device with a notch the score simply was not there.
+//
+// The host makes it worse in a second, independent way. It paints an exit
+// control in the top-LEFT corner and a how-to-play control in the top-RIGHT,
+// 44px each, and they float *over* the pack rather than reserving a band. The
+// score sat under the first one and the three lamps sat under the second.
+//
+// This module is the one place both facts are known.
+//
+//   * every readout is laid out inside `area`, the safe rect;
+//   * every readout starts below `chromeBottom`, so the two 44px corners stay
+//     free of anything a child must read or touch.
+//
+// **`area` is required, not optional.** A default would compile at every call
+// site that forgot it and then draw under the notch, discoverable only on a
+// device with a notch in someone's hand. Making it required moves that failure
+// to `tsc`.
+//
+// What deliberately does NOT obey any of this: the sky, the ridges, the
+// canopies, the blade ribbon, the splat layer, the particles and the flying
+// bodies themselves. Full-bleed art under the notch is the reason
+// `viewport-fit=cover` is set at all. Only what must be READ or TOUCHED is
+// pinned inside the safe rect.
+
+import {
+  chromeRects,
+  hitsHostChrome,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+
+/** Air between the host's controls and the first thing this game draws. */
+const CHROME_GAP = 8
+
+/** Air between the score column and the lamps hanging opposite it. */
+const COLUMN_GAP = 8
+
+/** A lantern is drawn out to this many radii, and rides this many above centre. */
+const LANTERN_EXTENT = 1.26
+const LANTERN_RISE = 0.55
+
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+export type HudLayout = {
+  readonly w: number
+  readonly h: number
+  /** The safe rect. Everything below is measured from its edges, not the canvas's. */
+  readonly area: Rect
+  readonly pad: number
+  /** Type size of the score numeral; every other size is a fraction of it. */
+  readonly big: number
+  /** The lowest edge of the host's two corner controls. */
+  readonly chromeBottom: number
+  /** The first line this game may use: clear of the safe edge AND of both corners. */
+  readonly top: number
+  /** Top-left of the score numeral, drawn `textAlign:left textBaseline:top`. */
+  readonly scoreX: number
+  readonly scoreY: number
+  readonly bestY: number
+  /** Baseline of the multiplier line, and of the CHAIN/FAVOUR lines beside it. */
+  readonly mulY: number
+  /** Everything in the left column: score, BEST, and the multiplier block. */
+  readonly left: Rect
+  readonly lampR: number
+  /** Centre of a lantern; the wire above it starts at `top`. */
+  readonly lampY: number
+  /** Top of the relight ticks. */
+  readonly tickY: number
+  /** The three lanterns and the ticks under them. */
+  readonly lamps: Rect
+  /** The live-question banner. */
+  readonly banner: Rect
+}
+
+/**
+ * The insets that produced `area`.
+ *
+ * The safe rect is the only thing passed in, so the insets are recovered from
+ * it rather than measured again — one source of truth per frame, and it works
+ * in a test where there is no document to measure.
+ */
+export function insetsOf(w: number, h: number, area: Rect): Insets {
+  return {
+    top: area.y,
+    left: area.x,
+    right: Math.max(0, w - area.x - area.w),
+    bottom: Math.max(0, h - area.y - area.h),
+  }
+}
+
+/** Everything the HUD needs, solved once per resize. `area` is required. */
+export function hudLayout(w: number, h: number, area: Rect): HudLayout {
+  const insets = insetsOf(w, h, area)
+  const chromeBottom = chromeRects(w, insets).reduce((m, r) => Math.max(m, r.y + r.h), 0)
+
+  const pad = Math.max(12, w * 0.022)
+  const big = Math.max(24, Math.min(46, w * 0.042))
+  // The band the host floats over is not reserved for the *playfield* — fruit
+  // still flies through it, which is the whole point. It is reserved only for
+  // the handful of glyphs a child reads, and those move down by 50-odd pixels.
+  const top = Math.max(area.y + pad, chromeBottom + CHROME_GAP)
+
+  const scoreX = area.x + pad
+  const bestY = top + big * 1.05
+  const mulY = top + big * 1.55
+
+  const lampR = Math.max(9, Math.min(15, w * 0.014))
+  // 1.9 and not 1.2: the wire above a lantern is part of the lantern, and
+  // hanging it from the centre put the wire back inside the help control.
+  const lampY = top + lampR * 1.9
+  const tickY = lampY + lampR * 1.7
+  const lampCentre = (i: number): number => area.x + area.w - pad - lampR - i * (lampR * 2.9)
+  const lampRight = lampCentre(0) + lampR
+  const lampLeft = lampCentre(2) - lampR
+  const lamps: Rect = {
+    x: lampLeft,
+    y: top,
+    w: lampRight - lampLeft,
+    h: tickY + 3.5 - top,
+  }
+
+  // The lamps are anchored to the right edge; the score column reads from the
+  // left and takes what is LEFT OVER rather than a fixed share of the width. A
+  // fixed 62% share and a right-anchored lamp block met in the middle the
+  // moment the safe rect got narrow — a phone held wide gives up 118px of its
+  // width to two rounded corners, and an iPad Split View pane is narrower
+  // still.
+  const left: Rect = {
+    // Four ems, because that is what the widest line actually measures: a
+    // six-digit score is 3.6em in this face, and `×36 · FAVOUR 3` comes out
+    // at about 3.8em. Six was a guess and it made the column claim a third of
+    // an iPad, which pushed the question banner off the top row for no reason.
+    x: scoreX,
+    y: top,
+    w: Math.max(0, Math.min(big * 4, lampLeft - COLUMN_GAP - scoreX)),
+    // The multiplier block runs to mulY plus three lines of `big * 0.34`.
+    h: big * 2.6,
+  }
+
+  const bw = Math.min(area.w * 0.9, 460)
+  const bh = Math.max(42, Math.min(74, h * 0.085))
+  // The banner wants the top row, centred, where it reads best.
+  const banner: Rect = {
+    x: area.x + (area.w - bw) / 2,
+    y: area.y + pad * 0.7,
+    w: bw,
+    h: bh,
+  }
+  // …and gives it up if the top row is taken, by the host's corner controls, by
+  // the score column or by the lamps. This used to be the breakpoint `w < 620`,
+  // which is a guess about width standing in for a fact about occupancy: it was
+  // wrong for a wide screen whose *safe* rect is narrow, and it stayed wrong
+  // once the readouts moved down out of the host's chrome. Three overlap tests
+  // cost nothing and cannot be wrong.
+  if (
+    hitsHostChrome(banner, w, insets) ||
+    overlaps(banner, left) ||
+    overlaps(banner, lamps)
+  ) {
+    banner.y = Math.max(left.y + left.h, lamps.y + lamps.h) + 4
+  }
+
+  return {
+    w,
+    h,
+    area,
+    pad,
+    big,
+    chromeBottom,
+    top,
+    scoreX,
+    scoreY: top,
+    bestY,
+    mulY,
+    left,
+    lampR,
+    lampY,
+    tickY,
+    lamps,
+    banner,
+  }
+}
+
+/** Centre x of lamp `i`, counting right to left from the safe right edge. */
+export function lampX(l: HudLayout, i: number): number {
+  return l.area.x + l.area.w - l.pad - l.lampR - i * (l.lampR * 2.9)
+}
+
+/** Left edge of relight tick `i`, and their width. */
+export function tickRect(i: number, l: HudLayout): Rect {
+  const tw = l.lampR * 1.5
+  return {
+    x: l.area.x + l.area.w - l.pad - tw - i * (tw + 4),
+    y: l.tickY,
+    w: tw,
+    h: 3.5,
+  }
+}
+
+export type CandidateRow = {
+  readonly r: number
+  readonly cx: number
+  readonly cy: number
+  readonly gap: number
+  readonly span: number
+  /** Everything the row occupies, lantern art included. */
+  readonly box: Rect
+}
+
+/**
+ * Where the answer lanterns hang.
+ *
+ * These are the one thing in this game that is both READ and TOUCHED — they are
+ * the answer input — so they get the strictest treatment of anything here. Two
+ * separate failures are prevented:
+ *
+ *   1. the row is solved inside `area`, so the fourth lantern cannot end up
+ *      under a rounded corner or off the edge of a 320px screen;
+ *   2. the row can never rise into the host's two corners. It was close enough
+ *      to matter — on a 300px-tall viewport the top of a lantern landed at
+ *      59.8px against a corner ending at 57px, and adding a 47px notch inset
+ *      put it 44px underneath the exit control.
+ */
+export function candidateRow(l: HudLayout, n: number, fromX: number, fromY: number): CandidateRow {
+  const { h, area } = l
+  const spans = Math.max(1, n - 1)
+  // The width budget comes first and the radius bends to it. Clamping the
+  // radius afterwards is what once pushed the fourth candidate off a 320px
+  // screen, where it could never be cut.
+  const rPref = Math.max(20, Math.min(h * 0.062, h * 0.05))
+  const rFit = area.w / (2.75 * spans + 2.8)
+  const r = Math.max(14, Math.min(rPref, rFit))
+  const gap = Math.min(r * 3.4, (area.w - r * 2.8) / spans)
+  const span = gap * Math.max(0, n - 1)
+  const margin = r * 1.4
+
+  const loX = area.x + margin + span / 2
+  const hiX = area.x + area.w - margin - span / 2
+  const cx = Math.max(loX, Math.min(Math.max(loX, hiX), fromX))
+
+  // Two ceilings, and the row obeys the lower of the screen. The host's corners
+  // are one. The question banner is the other: on a narrow screen the banner
+  // hangs under the readout row, and a lantern row that starts at 0.32h lands
+  // straight on top of it — the child cannot re-read the sum they are being
+  // asked, which is the one thing the banner exists for.
+  const loY = Math.max(
+    h * 0.32,
+    l.chromeBottom + (LANTERN_EXTENT + LANTERN_RISE) * r + CHROME_GAP,
+    l.banner.y + l.banner.h + (LANTERN_EXTENT + LANTERN_RISE) * r + CHROME_GAP,
+  )
+  const cy = Math.max(loY, Math.min(h * 0.54, fromY))
+
+  const reach = r * LANTERN_EXTENT
+  return {
+    r,
+    cx,
+    cy,
+    gap,
+    span,
+    box: {
+      x: cx - span / 2 - reach,
+      y: cy - r * LANTERN_RISE - reach,
+      w: span + reach * 2,
+      h: r * LANTERN_RISE + reach * 2,
+    },
+  }
+}
+
+/** Home position of candidate `i` of `n`: a shallow arc, high in the middle. */
+export function candidateHome(row: CandidateRow, i: number, n: number): { x: number; y: number } {
+  const f = i / Math.max(1, n - 1) - 0.5
+  return {
+    x: row.cx + f * row.span,
+    y: row.cy - Math.cos(f * Math.PI) * row.r * LANTERN_RISE,
+  }
+}

--- a/dynawalla/games/slice/src/test/layout.test.ts
+++ b/dynawalla/games/slice/src/test/layout.test.ts
@@ -1,0 +1,178 @@
+// THE ROOM.
+//
+// THE SPLIT draws its whole HUD on a canvas, and a canvas cannot read
+// `env(safe-area-inset-*)`. It also declares `viewport-fit=cover`, which opts
+// the document INTO the notch, the home indicator and the rounded corners. So
+// for as long as this game has existed its score has been drawn at `y = 12`,
+// which on a notched phone is not on the screen at all — and its three lamps
+// have been drawn underneath the host's how-to-play control.
+//
+// Neither defect is visible to a test about rules, and neither is visible in a
+// desktop browser. This file is the gate. It runs the SAME layout the renderer
+// runs at resize — `hudLayout(w, h, safeRect(w, h, insets))` and
+// `candidateRow(...)`, not a hand-built rect and not a copy of the arithmetic —
+// and asserts the two promises:
+//
+//   1. everything a child must READ or TOUCH is inside the safe rect;
+//   2. nothing a child must read or touch lands in the host's two 44px corners.
+//
+// The playfield is deliberately exempt from both. The sky, the ridges, the
+// canopies, the blade, the splats, the particles and the flying gourds bleed to
+// every edge, which is the reason `viewport-fit=cover` is set in the first
+// place.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  hitsHostChrome,
+  NO_INSETS,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { candidateHome, candidateRow, hudLayout, lampX, tickRect } from "../render/hud.ts"
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+/**
+ * The insets a real device hands back. Measured values, not invented ones: 47pt
+ * of notch and 34pt of home indicator held tall, 59pt of rounded corner each
+ * side held wide.
+ */
+const PROFILES: Array<[string, Insets]> = [
+  ["no insets", NO_INSETS],
+  ["notch, portrait", { top: 47, right: 0, bottom: 34, left: 0 }],
+  ["rounded corners, landscape", { top: 0, right: 59, bottom: 21, left: 59 }],
+]
+
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+const inside = (r: Rect, area: Rect): boolean =>
+  r.x >= area.x - 0.5 &&
+  r.y >= area.y - 0.5 &&
+  r.x + r.w <= area.x + area.w + 0.5 &&
+  r.y + r.h <= area.y + area.h + 0.5
+
+for (const [pname, insets] of PROFILES) {
+  for (const [vname, w, h] of VIEWPORTS) {
+    test(`the readouts clear the host's corners at ${vname} (${w}×${h}), ${pname}`, () => {
+      // Exactly what `resize()` does. If this line stops matching the renderer,
+      // this whole file stops being evidence.
+      const l = hudLayout(w, h, safeRect(w, h, insets))
+
+      for (const [what, box] of [
+        ["the score column", l.left],
+        ["the lamps", l.lamps],
+        ["the question banner", l.banner],
+      ] as const) {
+        assert.equal(
+          hitsHostChrome(box, w, insets),
+          false,
+          `${what} is under the host's chrome: ${JSON.stringify(box)}`,
+        )
+        assert.ok(inside(box, l.area), `${what} is outside the safe rect: ${JSON.stringify(box)}`)
+      }
+    })
+
+    test(`the answer lanterns clear the host's corners at ${vname} (${w}×${h}), ${pname}`, () => {
+      const l = hudLayout(w, h, safeRect(w, h, insets))
+      // The lanterns are the answer input — read AND touched — and where they
+      // hang depends on where the tablet was when it was cut. So try the
+      // extremes: a tablet cut in a corner, at the top, and off the edge.
+      for (const fromX of [-40, 0, w * 0.5, w, w + 40]) {
+        for (const fromY of [-40, 0, h * 0.1, h * 0.4, h]) {
+          const row = candidateRow(l, 4, fromX, fromY)
+          assert.equal(
+            hitsHostChrome(row.box, w, insets),
+            false,
+            `a lantern row from (${fromX.toFixed(0)},${fromY.toFixed(0)}) is under host chrome: ` +
+              JSON.stringify(row.box),
+          )
+          assert.ok(
+            inside(row.box, l.area),
+            `a lantern row from (${fromX.toFixed(0)},${fromY.toFixed(0)}) leaves the safe rect: ` +
+              JSON.stringify(row.box),
+          )
+          // The banner carries the sum being asked. A lantern row on top of it
+          // takes away the one place the question can be re-read.
+          assert.ok(
+            row.box.y >= l.banner.y + l.banner.h,
+            `a lantern row from (${fromX.toFixed(0)},${fromY.toFixed(0)}) covers the question ` +
+              `banner by ${(l.banner.y + l.banner.h - row.box.y).toFixed(1)}px`,
+          )
+          // Every lantern is individually reachable, not just the row's box.
+          for (let i = 0; i < 4; i++) {
+            const p = candidateHome(row, i, 4)
+            assert.ok(
+              p.x - row.r >= l.area.x - 0.5 && p.x + row.r <= l.area.x + l.area.w + 0.5,
+              `candidate ${i} of 4 hangs outside the safe rect at x=${p.x.toFixed(1)}`,
+            )
+            assert.ok(p.y > l.chromeBottom, `candidate ${i} of 4 hangs under the host's chrome`)
+          }
+        }
+      }
+    })
+
+    test(`the HUD holds together at ${vname} (${w}×${h}), ${pname}`, () => {
+      const l = hudLayout(w, h, safeRect(w, h, insets))
+
+      // The lamps hang from the right, the score column reads from the left,
+      // and they have never been allowed to touch.
+      assert.ok(
+        l.left.x + l.left.w <= l.lamps.x + 0.5,
+        `the score column runs into the lamps by ${(l.left.x + l.left.w - l.lamps.x).toFixed(1)}px`,
+      )
+
+      // The banner never lands on the readouts. It is drawn last and it is
+      // opaque, so an overlap does not crowd the score — it erases it.
+      assert.equal(overlaps(l.banner, l.left), false, "the question banner covers the score column")
+      assert.equal(overlaps(l.banner, l.lamps), false, "the question banner covers the lamps")
+
+      // Three lanterns, in order, all inside the safe rect.
+      let prev = Number.POSITIVE_INFINITY
+      for (let i = 0; i < 3; i++) {
+        const x = lampX(l, i)
+        assert.ok(x < prev, "the lamps are not laid out right to left")
+        prev = x
+        assert.ok(
+          x - l.lampR >= l.area.x - 0.5 && x + l.lampR <= l.area.x + l.area.w + 0.5,
+          `lamp ${i} hangs outside the safe rect at x=${x.toFixed(1)}`,
+        )
+      }
+
+      // The relight ticks live under the lamps, inside the lamps' own box.
+      for (let i = 0; i < 2; i++) {
+        const t = tickRect(i, l)
+        assert.ok(inside(t, l.lamps), `relight tick ${i} escapes the lamp block`)
+      }
+
+      // Legibility: the score is the largest thing on the HUD and it must not
+      // shrink below what a seven-year-old reads across a room.
+      assert.ok(l.big >= 24, `the score is ${l.big.toFixed(1)}px`)
+      assert.ok(l.lampR >= 9, `a lamp is ${l.lampR.toFixed(1)}px across`)
+    })
+  }
+}
+
+test("the layout is derived from the safe rect, not from the canvas", () => {
+  // `hudLayout` takes `area` as a REQUIRED parameter for exactly this reason: a
+  // default would let a call site forget it, compile, and draw under the notch,
+  // discoverable only on a device with a notch in someone's hand. Here is the
+  // proof the parameter is actually load-bearing rather than decorative.
+  const notch: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+  const flat = hudLayout(390, 844, safeRect(390, 844, NO_INSETS))
+  const notched = hudLayout(390, 844, safeRect(390, 844, notch))
+  assert.ok(
+    notched.top >= flat.top + notch.top,
+    `a 47px notch moved the readouts by ${(notched.top - flat.top).toFixed(1)}px`,
+  )
+  assert.ok(notched.scoreY > 47, "the score is drawn inside the notch")
+})


### PR DESCRIPTION
## What

Adopt the shared game chrome in **slice (THE SPLIT)**: lay every readout out
inside the safe rect, keep the host's two 44px corners free of anything a child
must read or touch, and add the shared how-to-play surface.

## Why

Two defects, both invisible in a desktop browser and to every test about rules.

**1. Safe area.** The document declares `viewport-fit=cover`, which is not a
neutral setting — it opts the game *into* the notch, the home indicator and the
rounded corners. THE SPLIT draws its entire HUD on the canvas, where
`env(safe-area-inset-*)` cannot be reached, so `fillText` of the score at
`y = 12` landed under the notch. On a notched phone the score was not on the
screen.

**2. Host chrome covered the game's UI.** The host floats a 44px exit control in
the top-LEFT and a 44px how-to-play control in the top-RIGHT. The score sat
under the first; the three lamps — the child's whole life count — sat under the
second.

**3. No instructions.** THE SPLIT shipped with none: a child was handed a screen
of flying gourds and had to infer that a swipe cuts, that a cut number splits
into its factors, and that four lanterns are a question.

### What is judged critical, and what is deliberately let bleed

Critical — inside the safe rect, clear of both corners:

* the **score / BEST / multiplier column** (top-left, straight under the exit control);
* the **three lamps** and the relight ticks under them (top-right, straight under the help control);
* the **live-question banner**, which is the only place the sum can be re-read;
* the **answer lanterns**. These are the strictest case in the game: they are
  the answer input, so they are both *read* and *touched*. Their row was solved
  against the canvas, so held wide — two 59px rounded-corner insets — the outer
  lantern was placed under a corner where it could not be cut. And on a short
  viewport the top of a lantern reached 59.8px against a corner ending at 57px;
  adding a 47px notch inset put the row 44px underneath the exit control.

Deliberately full-bleed, unchanged: the sky gradient, the silhouette ridges, the
stall canopies, the blade ribbon, the splat layer, the particles, and the flying
gourds/tablets/bombs themselves. That is what `viewport-fit=cover` is *for*.

Nothing reserves a band. Reserving 67px costs a twelfth of a 568px phone's
height, and it broke SKY LEDGER's own lattice invariant when it was tried.

### How

New `src/render/hud.ts` is the one place the safe rect and the host chrome are
both known. `hudLayout(w, h, area)` takes the safe rect as a **required**
parameter — a default would compile at every call site that forgot it and only
be discoverable on a device with a notch in someone's hand — and `mount.ts`'s
`resize()` re-derives it from `safeRect(W, H)` on every resize, so rotation and
Split View are handled rather than being right once at mount.

Two collisions this surfaced and fixed, both found by self-review rather than
by the device:

* the score column claimed a fixed 62% of the width while the lamps were
  anchored to the right edge, so on a narrow safe rect the two met in the
  middle. The column now takes what is left over, and is claimed at the 4em its
  widest line actually measures rather than a guessed 6em;
* moving the readouts down below the host's chrome moved the question banner
  down with them on a narrow screen, straight onto the answer lanterns — which
  are drawn last and opaque, so it would have erased the banner rather than
  crowded it. The banner's placement is no longer a `w < 620` breakpoint (a
  guess about width standing in for a fact about occupancy, and wrong for a
  wide screen whose *safe* rect is narrow). It takes the top row and gives it
  up only if three measured overlap tests say the row is taken. The lantern row
  in turn clears the banner as well as the corners.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/slice/`)

- [x] Every touched path is covered by a `ci.yml` area filter (or is docs/config with no gate by design).
- [x] **Pack back-compat.** No published pack zip changed in place; no `voiceId` renamed; no catalog entry dropped or version-gated. `pack.json` untouched.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new user-visible strings are the how-to-play copy, which lives in the pack's own `createInstructions` spec; `slice` declares `"locales": ["en"]`.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

### The clearance test goes RED without the fix

A clearance test that passes either way is worthless, so this was verified by
removing the fix. Reverting three lines of `hudLayout`/`candidateRow` — the
`chromeBottom` clamp on `top`, the `chromeBottom` clamp on the lantern row's
ceiling, and the safe-rect clamp on the row's `cx` — takes the suite from
86/86 to **64 pass, 22 fail**:

```
not ok 33 - the readouts clear the host's corners at phone portrait, small (320×568), no insets
  error: |-
    the score column is under the host's chrome: {"x":12,"y":12,"w":144,"h":62.400000000000006}

    true !== false

not ok 61 - the answer lanterns clear the host's corners at phone landscape (844×390), notch, portrait
  error: |-
    a lantern row from (-40,-40) is under host chrome: {"x":2.8000000000000007,"y":88.6,"w":254.4,"h":61.4}

    true !== false

not ok 64 - the answer lanterns clear the host's corners at phone portrait, small (320×568), rounded corners, landscape
  error: 'a lantern row from (-40,-40) leaves the safe rect: {"x":2.559276018099542,"y":148.67221719457015,"w":196.88144796380092,"h":56.12126696832579}'
```

The test runs the layout **through the renderer path** — the same
`hudLayout(w, h, safeRect(w, h, insets))` call `resize()` makes, and the same
`candidateRow(...)` call `openSigil()` makes — not a hand-built rect and not a
copy of the arithmetic. It covers 320×568, 390×844, 768×1024, 1024×768 and
844×390, each against three real inset profiles (none; 47/34 notch held tall;
59/59 rounded corners held wide).

## Proof

```
$ cd dynawalla/games/slice && for i in 1 2 3 4 5; do npm test --silent; done
run 1: # tests 86 # pass 86 # fail 0
run 2: # tests 86 # pass 86 # fail 0
run 3: # tests 86 # pass 86 # fail 0
run 4: # tests 86 # pass 86 # fail 0
run 5: # tests 86 # pass 86 # fail 0

$ npm run tsc
> @dynawalla/game-slice@0.1.0 tsc
> tsc --noEmit
(0 errors)

$ npm run build
vite v8.1.5 building client environment for production...
transforming...✓ 24 modules transformed.
rendering chunks...
computing gzip size...
dist/slice.js  89.87 kB │ gzip: 28.01 kB
✓ built in 25ms

$ cd ../../packs && node build.mjs slice
dist-pack/pack.html                 1.27 kB │ gzip:  0.66 kB
dist-pack/assets/pack-DYOo5ARO.js  74.51 kB │ gzip: 27.11 kB
✓ built in 32ms
dynawalla.slice@0.1.0 — THE SPLIT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 76822 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~24168 bytes (24.17 KB) in 33.3ms
INF no leaks found

$ git diff origin/main..HEAD --diff-filter=D --name-only
(empty — nothing deleted)

$ git diff origin/main..HEAD --stat
 dynawalla/games/slice/README.md               |  31 ++-
 dynawalla/games/slice/src/mount.ts            | 138 +++++++++----
 dynawalla/games/slice/src/render/hud.ts       | 284 ++++++++++++++++++++++++++
 dynawalla/games/slice/src/test/layout.test.ts | 178 ++++++++++++++++
 4 files changed, 587 insertions(+), 44 deletions(-)
```

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
