### PR TITLE
feat(dynawalla/games/merge): the well clears the notch and the two host corners, and there are instructions

### DIFF
--- a/dynawalla/games/merge/README.md
+++ b/dynawalla/games/merge/README.md
@@ -12,7 +12,7 @@ you the whole time.
 ```bash
 npm install
 npm run dev      # http://127.0.0.1:5183
-npm test         # 69 tests, no framework
+npm test         # 73 tests, no framework
 npm run tsc      # strict, noUncheckedIndexedAccess
 npm run build
 ```
@@ -125,8 +125,24 @@ touches the mouse.
 
 Portrait puts the instruments in a band above the well; landscape puts them in
 rails either side. Two designs, not one stretched. `layout.test.ts` asserts on
-ten viewports from a 320-wide phone to a 1920 desktop that the well fits, the
+twelve viewports from a 320-wide phone to a 1920 desktop that the well fits, the
 held chip has headroom, and nothing overlaps the well.
+
+`computeLayout` takes the safe rectangle as a **required** argument —
+`safeRect(w, h)` from `packs/shared/game-chrome`. The pack declares
+`viewport-fit=cover`, so without it the score is drawn under the notch, and a
+canvas cannot read `env(safe-area-inset-*)` for itself. Required rather than
+optional, because a game that forgets it should not compile.
+
+The host paints its exit chevron over the top-left 44px and the how-to-play
+button over the top-right 44px. Those overlay the pack rather than reserving a
+band — a band costs a twelfth of a small phone's height — so the layout moves
+the score, the LV readout, the next-chip strip, the mute toggle and the
+tappable reactor out from under them, and `hitsHostChrome` asserts it on every
+viewport. The plasma, the well walls and the sparks still bleed to the edges.
+
+How to play is the shared `createInstructions` panel, reachable during a run,
+not just before it.
 
 ## Structure
 

--- a/dynawalla/games/merge/src/input.ts
+++ b/dynawalla/games/merge/src/input.ts
@@ -22,10 +22,20 @@ function hit(x: number, y: number, cx: number, cy: number, r: number): boolean {
   return dx * dx + dy * dy <= r * r;
 }
 
+/**
+ * `suspended` is the how-to-play panel being open.
+ *
+ * The panel's scrim swallows pointer events, but the keyboard is bound to
+ * `window` and does not care what is on top of the canvas: without this, Space
+ * and Enter drop a chip instead of pressing the panel's PLAY button — they are
+ * `preventDefault`ed here before the button ever sees them — and `R` silently
+ * restarts the run from behind a page of rules.
+ */
 export function bindInput(
   canvas: HTMLCanvasElement,
   game: Game,
   getLayout: () => Layout | null,
+  suspended: () => boolean,
 ): InputBinding {
   let aiming = false;
   let pointerId = -1;
@@ -43,6 +53,7 @@ export function bindInput(
   };
 
   const onDown = (e: PointerEvent) => {
+    if (suspended()) return;
     const l = getLayout();
     if (!l) return;
     const { x, y } = local(e);
@@ -85,6 +96,7 @@ export function bindInput(
   };
 
   const onMove = (e: PointerEvent) => {
+    if (suspended()) return;
     const l = getLayout();
     if (!l || game.phase !== "aim") return;
     const { x, y } = local(e);
@@ -97,6 +109,8 @@ export function bindInput(
   };
 
   const onUp = (e: PointerEvent) => {
+    // The drag state is always released, even suspended — a pointer that came
+    // up while the manual was opening must not leave the game aiming forever.
     if (!aiming || e.pointerId !== pointerId) return;
     aiming = false;
     pointerId = -1;
@@ -105,7 +119,7 @@ export function bindInput(
     } catch {
       /* already released */
     }
-    if (game.phase === "aim") game.drop();
+    if (!suspended() && game.phase === "aim") game.drop();
   };
 
   const onCancel = () => {
@@ -114,6 +128,7 @@ export function bindInput(
   };
 
   const onKey = (e: KeyboardEvent) => {
+    if (suspended()) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     const k = e.key;
     game.audio.resume();

--- a/dynawalla/games/merge/src/layout.test.ts
+++ b/dynawalla/games/merge/src/layout.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { hitsHostChrome, safeRect } from "../../../packs/shared/game-chrome/index.ts";
 import { COLS, ROWS } from "./core/rules.ts";
 import { cellCenter, colAt, computeLayout } from "./layout.ts";
 
@@ -10,16 +11,24 @@ const SIZES: [string, number, number][] = [
   ["iPhone 13 landscape", 844, 390],
   ["Pixel 7 portrait", 412, 915],
   ["iPad mini portrait", 744, 1133],
+  ["iPad portrait", 768, 1024],
+  ["iPad landscape", 1024, 768],
   ["iPad Pro landscape", 1366, 1024],
   ["small desktop", 1024, 640],
   ["wide desktop", 1920, 1080],
   ["absurdly narrow", 280, 760],
+  ["absurdly narrow and tall", 280, 1200],
   ["absurdly short", 900, 320],
+  // A wide-and-short window is the case that walks the next-chip strip off the
+  // bottom: the reactor has to move down to clear the how-to-play button and
+  // the strip hangs off the reactor. 1024x330 was found by sweep, not by taste.
+  ["short landscape", 1024, 330],
+  ["shorter landscape", 1200, 300],
 ];
 
 test("the well always fits inside the viewport", () => {
   for (const [name, w, h] of SIZES) {
-    const l = computeLayout(w, h, 2);
+    const l = computeLayout(w, h, 2, safeRect(w, h));
     assert.ok(l.wellX >= 0, `${name}: well hangs off the left (${l.wellX})`);
     assert.ok(l.wellX + l.wellW <= w, `${name}: well hangs off the right`);
     assert.ok(l.wellY >= 0, `${name}: well hangs off the top (${l.wellY})`);
@@ -29,7 +38,7 @@ test("the well always fits inside the viewport", () => {
 
 test("there is always headroom above the well for the held chip", () => {
   for (const [name, w, h] of SIZES) {
-    const l = computeLayout(w, h, 2);
+    const l = computeLayout(w, h, 2, safeRect(w, h));
     assert.ok(l.headY > 0, `${name}: the held chip is off screen`);
     assert.ok(l.headY < l.boardY, `${name}: the held chip is inside the well`);
     assert.ok(
@@ -41,13 +50,12 @@ test("there is always headroom above the well for the held chip", () => {
 
 test("the sound toggle never sits on the well", () => {
   for (const [name, w, h] of SIZES) {
-    const l = computeLayout(w, h, 2);
-    const r = l.soundR + 6;
+    const l = computeLayout(w, h, 2, safeRect(w, h));
+    // `soundBox` is the TOUCH square — `input.ts` hit-tests at `soundR + 10`,
+    // so anything smaller measures a button that is not the one on the glass.
+    const b = l.soundBox;
     const overlaps =
-      l.soundX + r > l.wellX &&
-      l.soundX - r < l.wellX + l.wellW &&
-      l.soundY + r > l.wellY &&
-      l.soundY - r < l.wellY + l.wellH;
+      b.x < l.wellX + l.wellW && l.wellX < b.x + b.w && b.y < l.wellY + l.wellH && l.wellY < b.y + b.h;
     assert.equal(overlaps, false, `${name}: the sound toggle covers the well`);
     assert.ok(l.soundX > 0 && l.soundX < w, `${name}: sound toggle off screen`);
     assert.ok(l.soundY > 0 && l.soundY < h, `${name}: sound toggle off screen`);
@@ -56,7 +64,7 @@ test("the sound toggle never sits on the well", () => {
 
 test("the reactor orb never sits on the well", () => {
   for (const [name, w, h] of SIZES) {
-    const l = computeLayout(w, h, 2);
+    const l = computeLayout(w, h, 2, safeRect(w, h));
     const r = l.keyR * 1.35;
     const overlaps =
       l.keyX + r > l.wellX &&
@@ -69,7 +77,7 @@ test("the reactor orb never sits on the well", () => {
 
 test("the incoming strip stays on screen", () => {
   for (const [name, w, h] of SIZES) {
-    const l = computeLayout(w, h, 2);
+    const l = computeLayout(w, h, 2, safeRect(w, h));
     for (let i = 0; i < 3; i++) {
       const x = l.incomingVertical ? l.incomingX : l.incomingX + i * l.incomingStep;
       const y = l.incomingVertical ? l.incomingY + i * l.incomingStep : l.incomingY;
@@ -80,7 +88,7 @@ test("the incoming strip stays on screen", () => {
 });
 
 test("cells tile the board exactly, with no gap and no overlap", () => {
-  const l = computeLayout(900, 1200, 2);
+  const l = computeLayout(900, 1200, 2, safeRect(900, 1200));
   const first = cellCenter(l, 0, 0);
   const last = cellCenter(l, ROWS - 1, COLS - 1);
   assert.equal(Math.round(first.x - l.cell / 2), l.boardX);
@@ -91,7 +99,7 @@ test("cells tile the board exactly, with no gap and no overlap", () => {
 
 test("colAt inverts cellCenter and clamps outside the board", () => {
   for (const [, w, h] of SIZES) {
-    const l = computeLayout(w, h, 2);
+    const l = computeLayout(w, h, 2, safeRect(w, h));
     for (let c = 0; c < COLS; c++) {
       assert.equal(colAt(l, cellCenter(l, 0, c).x), c);
     }
@@ -101,11 +109,11 @@ test("colAt inverts cellCenter and clamps outside the board", () => {
 });
 
 test("orientation picks a different design, not a stretched one", () => {
-  assert.equal(computeLayout(390, 844, 2).landscape, false);
-  assert.equal(computeLayout(844, 390, 2).landscape, true);
+  assert.equal(computeLayout(390, 844, 2, safeRect(390, 844)).landscape, false);
+  assert.equal(computeLayout(844, 390, 2, safeRect(844, 390)).landscape, true);
   // portrait puts the score on the left of a top band; landscape centres it in a rail
-  assert.equal(computeLayout(390, 844, 2).scoreAlign, "left");
-  assert.equal(computeLayout(844, 390, 2).scoreAlign, "center");
+  assert.equal(computeLayout(390, 844, 2, safeRect(390, 844)).scoreAlign, "left");
+  assert.equal(computeLayout(844, 390, 2, safeRect(844, 390)).scoreAlign, "center");
 });
 
 test("cells stay aimable on every real phone and tablet", () => {
@@ -116,16 +124,131 @@ test("cells stay aimable on every real phone and tablet", () => {
   // is; portrait, which is how a well-shaped board is actually held, is roomy.
   for (const [name, w, h] of SIZES) {
     if (Math.min(w, h) < 360) continue;
-    const l = computeLayout(w, h, 2);
+    const l = computeLayout(w, h, 2, safeRect(w, h));
     assert.ok(l.cell >= 28, `${name}: ${l.cell}px cells are too small to aim`);
   }
-  assert.ok(computeLayout(390, 844, 2).cell >= 50, "portrait phone should be roomy");
-  assert.ok(computeLayout(744, 1133, 2).cell >= 70, "tablet should be generous");
+  assert.ok(computeLayout(390, 844, 2, safeRect(390, 844)).cell >= 50, "portrait phone should be roomy");
+  assert.ok(computeLayout(744, 1133, 2, safeRect(744, 1133)).cell >= 70, "tablet should be generous");
 });
 
 test("a squashed window still lays out legally, just smaller", () => {
-  const l = computeLayout(900, 320, 2);
+  const l = computeLayout(900, 320, 2, safeRect(900, 320));
   assert.ok(l.cell >= 18);
   assert.ok(l.wellY >= 0 && l.wellY + l.wellH <= 320);
   assert.ok(l.headY > 0 && l.headY < l.boardY);
+});
+
+/** everything a child has to read or touch, as boxes */
+function critical(l: ReturnType<typeof computeLayout>): [string, { x: number; y: number; w: number; h: number }][] {
+  return [
+    ["the score", l.scoreBox],
+    ["the level readout", l.levelBox],
+    ["the reactor", l.reactorBox],
+    ["the incoming strip", l.incomingBox],
+    ["the mute toggle", l.soundBox],
+    ["the well", { x: l.wellX, y: l.wellY, w: l.wellW, h: l.wellH }],
+  ];
+}
+
+/** the four inset profiles the game actually meets */
+const INSETS: [string, { top: number; right: number; bottom: number; left: number }][] = [
+  ["no insets", { top: 0, right: 0, bottom: 0, left: 0 }],
+  ["notched portrait", { top: 47, right: 0, bottom: 34, left: 0 }],
+  ["notched landscape", { top: 0, right: 47, bottom: 21, left: 47 }],
+  ["android gesture bar", { top: 24, right: 0, bottom: 24, left: 0 }],
+];
+
+test("nothing a child reads or touches sits under the host's chrome", () => {
+  // The host paints an exit chevron over the top-left 44px and the how-to-play
+  // button over the top-right 44px, on top of the pack. It overlays rather than
+  // reserving a band — a band cost a twelfth of a small phone's height — so the
+  // promise this layout keeps is that those two squares are clear of anything
+  // that has to be read or tapped: the score, the LV readout, the next-chip
+  // strip, the mute toggle, the RESONANCE reactor (which is tapped) and the
+  // well itself (every chip in it is a numeral you have to add).
+  //
+  // The plasma, the well walls and the sparks still bleed under both, which is
+  // the whole point of `viewport-fit=cover`.
+  // Every viewport against every inset profile, because the corners move with
+  // the insets: asserting this only on a device with no notch would be
+  // asserting it in the one case the notch cannot break.
+  for (const [name, w, h] of SIZES) {
+    for (const [where, insets] of INSETS) {
+      const l = computeLayout(w, h, 2, safeRect(w, h, insets));
+      for (const [what, box] of critical(l)) {
+        assert.equal(
+          hitsHostChrome(box, w, insets),
+          false,
+          `${name} (${w}x${h}, ${where}): ${what} is under the host's chrome`,
+        );
+      }
+    }
+  }
+});
+
+test("a notch pushes the instruments down instead of under it", () => {
+  // What a canvas HUD cannot do is read `env(safe-area-inset-*)`, so it is
+  // handed the rectangle as numbers. Give it a phone-shaped notch and a home
+  // indicator and everything readable has to be inside what is left.
+  const insets = { top: 47, right: 0, bottom: 34, left: 0 };
+  for (const [name, w, h] of [
+    ["iPhone SE portrait", 320, 568],
+    ["iPhone 13 portrait", 390, 844],
+    ["iPad portrait", 768, 1024],
+  ] as const) {
+    const area = safeRect(w, h, insets);
+    const l = computeLayout(w, h, 2, area);
+    const bottom = area.y + area.h;
+    assert.ok(l.scoreBox.y >= area.y, `${name}: the score is under the notch`);
+    assert.ok(l.wellY >= area.y, `${name}: the well is under the notch`);
+    assert.ok(
+      l.wellY + l.wellH <= bottom,
+      `${name}: the well is under the home indicator`,
+    );
+    assert.ok(l.soundBox.y + l.soundBox.h <= bottom, `${name}: the mute toggle is off the safe area`);
+    assert.ok(l.keyY >= area.y, `${name}: the KEY numeral is under the notch`);
+    assert.ok(l.incomingBox.y >= area.y, `${name}: the incoming strip is under the notch`);
+    // and it really did move, rather than the insets being ignored
+    const flat = computeLayout(w, h, 2, safeRect(w, h));
+    assert.ok(l.wellY > flat.wellY, `${name}: the well ignored the notch`);
+  }
+});
+
+test("a landscape notch is honoured on the sides too", () => {
+  const area = safeRect(844, 390, { top: 0, right: 47, bottom: 21, left: 47 });
+  const l = computeLayout(844, 390, 2, area);
+  assert.equal(l.landscape, true);
+  assert.ok(l.wellX >= area.x, "the well is under the left inset");
+  assert.ok(l.wellX + l.wellW <= area.x + area.w, "the well is under the right inset");
+  assert.ok(l.scoreBox.x >= area.x, "the score is under the left inset");
+  assert.ok(
+    l.incomingBox.x + l.incomingBox.w <= area.x + area.w,
+    "the incoming strip is under the right inset",
+  );
+});
+
+test("the incoming strip stays inside the safe area once it has moved clear", () => {
+  // It moves twice — down off the how-to-play button, and down again to hang
+  // under the reactor — so a short, wide window is exactly where it walks off
+  // the bottom edge and under a phone's gesture bar.
+  for (const [name, w, h] of SIZES) {
+    for (const [where, insets] of INSETS) {
+      const area = safeRect(w, h, insets);
+      const b = computeLayout(w, h, 2, area).incomingBox;
+      assert.ok(b.x >= area.x, `${name} ${where}: incoming strip past the left inset`);
+      assert.ok(b.x + b.w <= area.x + area.w, `${name} ${where}: incoming strip past the right inset`);
+      assert.ok(b.y >= area.y, `${name} ${where}: incoming strip under the notch`);
+      assert.ok(
+        b.y + b.h <= area.y + area.h,
+        `${name} ${where}: incoming strip under the home indicator`,
+      );
+    }
+    const l = computeLayout(w, h, 2, safeRect(w, h));
+    const b = l.incomingBox;
+    assert.ok(b.x >= 0 && b.x + b.w <= w, `${name}: incoming strip off x`);
+    assert.ok(b.y >= 0 && b.y + b.h <= h, `${name}: incoming strip off y`);
+    const onWell =
+      b.x < l.wellX + l.wellW && l.wellX < b.x + b.w && b.y < l.wellY + l.wellH && l.wellY < b.y + b.h;
+    assert.equal(onWell, false, `${name}: the incoming strip covers the well`);
+  }
 });

--- a/dynawalla/games/merge/src/layout.ts
+++ b/dynawalla/games/merge/src/layout.ts
@@ -1,3 +1,4 @@
+import { chromeRects, HOST_CONTROL, HOST_MARGIN, type Rect } from "../../../packs/shared/game-chrome/index.ts";
 import { COLS, ROWS } from "./core/rules.ts";
 
 /**
@@ -7,12 +8,29 @@ import { COLS, ROWS } from "./core/rules.ts";
  * instrument band above the well, landscape puts it in rails either side, and
  * in both the well is as large as it can possibly be. The well never scrolls
  * and never clips.
+ *
+ * Two things outside this file own where it may draw.
+ *
+ * **The safe area.** The pack declares `viewport-fit=cover`, which opts the
+ * document *into* the notch, the home indicator and the rounded corners. A DOM
+ * HUD claws that back with `env(safe-area-inset-*)`; this HUD is painted on a
+ * canvas, where `env()` does not exist, so it has to be handed the rectangle as
+ * numbers. That is `area`.
+ *
+ * **The host's two corners.** The host paints an exit chevron top-left and the
+ * how-to-play button top-right, 44px each, *over* the pack. They are not a
+ * reserved band — reserving one costs a twelfth of a small phone's height — so
+ * the promise this layout keeps is narrower: nothing a child must read or touch
+ * lands inside those two squares. The plasma, the well walls and the sparks
+ * still bleed to the edges, which is the point of `cover`.
  */
 
 export type Layout = {
   w: number;
   h: number;
   dpr: number;
+  /** the safe rectangle everything readable was laid out inside */
+  area: Rect;
   landscape: boolean;
   pad: number;
   cell: number;
@@ -45,30 +63,138 @@ export type Layout = {
   soundX: number;
   soundY: number;
   soundR: number;
+  /** type sizes, here rather than in the renderer so the boxes below are honest */
+  scoreSize: number;
+  bestSize: number;
+  levelSize: number;
+  /**
+   * Bounding boxes of everything a child reads or touches.
+   *
+   * The renderer draws from the anchors above and these are computed from the
+   * same anchors, so a test that asserts on them is asserting on what is
+   * actually on the glass — which is the only kind of assertion worth having
+   * about the notch.
+   */
+  scoreBox: Rect;
+  levelBox: Rect;
+  reactorBox: Rect;
+  incomingBox: Rect;
+  soundBox: Rect;
 };
 
 export const HEADROOM = 1.85;
 /** A squashed landscape window has no height to spare; give it back to the well. */
 export const HEADROOM_SHORT = 1.3;
 
-export function computeLayout(w: number, h: number, dpr: number): Layout {
-  const landscape = w / h > 1.15;
-  const pad = Math.max(10, Math.round(Math.min(w, h) * 0.028));
-  const headroom = h < 440 ? HEADROOM_SHORT : HEADROOM;
+/** Five digits of score, as a multiple of the score type size. Deliberately generous. */
+const SCORE_DIGITS = 3.1;
+/** Clear air left between a moved instrument and the corner it moved out of. */
+const CHROME_GAP = 4;
+/** How far the reactor's octagon reaches past `keyR`. */
+const REACTOR_EXTENT = 1.62;
+/** The sound toggle's touch target is bigger than its outline; `input.ts` adds 10. */
+const SOUND_TOUCH = 10;
+
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+
+/**
+ * How far `box` must move DOWN to sit clear of the host's corner squares.
+ *
+ * Down, never sideways: the score belongs on the left and the level belongs on
+ * the right, and a game that slides its readouts toward the middle to dodge a
+ * button ends up with everything piled in the centre. A box that already clears
+ * them — including one entirely above them, like the reactor's halo bleeding off
+ * the top edge — is not moved at all.
+ */
+function clearOfChrome(box: Rect, corners: readonly Rect[]): number {
+  let dy = 0;
+  for (const c of corners) {
+    if (!overlaps({ ...box, y: box.y + dy }, c)) continue;
+    dy = Math.max(dy, c.y + c.h + CHROME_GAP - box.y);
+  }
+  return dy;
+}
+
+const scoreRect = (
+  x: number,
+  y: number,
+  align: "left" | "center",
+  scoreSize: number,
+  bestSize: number,
+): Rect => {
+  const w = scoreSize * SCORE_DIGITS;
+  // The chain readout rides above the numerals and BEST sits under them; both
+  // are part of what has to stay legible, so both are part of the box.
+  const top = y - scoreSize * 0.62 - scoreSize * 0.19;
+  const bottom = y + scoreSize * 0.62 + bestSize * 0.75;
+  return { x: align === "left" ? x : x - w / 2, y: top, w, h: bottom - top };
+};
+
+const levelRect = (x: number, y: number, landscape: boolean, size: number): Rect => ({
+  // Portrait draws "LV 7" ending at `levelX`; landscape centres it on the rail.
+  x: landscape ? x - size * 2.5 : x - size * 4,
+  y: y - size * 0.75,
+  w: landscape ? size * 5 : size * 4,
+  h: size * 1.5,
+});
+
+const reactorRect = (x: number, y: number, r: number): Rect => ({
+  x: x - r * REACTOR_EXTENT,
+  y: y - r * REACTOR_EXTENT,
+  w: r * REACTOR_EXTENT * 2,
+  h: r * REACTOR_EXTENT * 2,
+});
+
+const incomingRect = (x: number, y: number, step: number, size: number, vertical: boolean): Rect => ({
+  x: x - size / 2,
+  y: y - size / 2,
+  w: vertical ? size : step * 2 + size,
+  h: vertical ? step * 2 + size : size,
+});
+
+const soundRect = (x: number, y: number, r: number): Rect => {
+  const t = r + SOUND_TOUCH;
+  return { x: x - t, y: y - t, w: t * 2, h: t * 2 };
+};
+
+/**
+ * `area` is the safe rectangle — `safeRect(w, h)` from
+ * `packs/shared/game-chrome`. Everything a child reads or touches is laid out
+ * inside it; the background and the particles still use `w`/`h` and bleed.
+ *
+ * It is REQUIRED, deliberately. Optional, a caller that forgets it compiles and
+ * quietly draws the score under the notch, and the only way to find out is on a
+ * notched device with the game in your hand.
+ */
+export function computeLayout(w: number, h: number, dpr: number, area: Rect): Layout {
+  const aw = Math.max(1, area.w);
+  const ah = Math.max(1, area.h);
+  const landscape = aw / ah > 1.15;
+  const pad = Math.max(10, Math.round(Math.min(aw, ah) * 0.028));
+  const headroom = ah < 440 ? HEADROOM_SHORT : HEADROOM;
+
+  const corners = chromeRects(w, {
+    top: area.y,
+    left: area.x,
+    right: Math.max(0, w - area.x - aw),
+    bottom: Math.max(0, h - area.y - ah),
+  });
+  const cornerBottom = (corners[0] as Rect).y + HOST_CONTROL;
 
   let cell: number;
   let bandH = 0;
   let rail = 0;
 
   if (landscape) {
-    rail = Math.max(140, Math.min(280, w * 0.21));
-    const availW = w - rail * 2 - pad * 2;
-    const availH = h - pad * 2;
+    rail = Math.max(140, Math.min(280, aw * 0.21));
+    const availW = aw - rail * 2 - pad * 2;
+    const availH = ah - pad * 2;
     cell = Math.floor(Math.min(availW / COLS, availH / (ROWS + headroom)));
   } else {
-    bandH = Math.max(96, Math.min(168, h * 0.17));
-    const availW = w - pad * 2;
-    const availH = h - bandH - pad * 2;
+    bandH = Math.max(96, Math.min(168, ah * 0.17));
+    const availW = aw - pad * 2;
+    const availH = ah - bandH - pad * 2;
     cell = Math.floor(Math.min(availW / COLS, availH / (ROWS + headroom)));
   }
   cell = Math.max(18, cell);
@@ -77,22 +203,48 @@ export function computeLayout(w: number, h: number, dpr: number): Layout {
   const boardH = cell * ROWS;
   const blockH = boardH + cell * headroom;
 
-  const boardX = Math.round((w - boardW) / 2);
+  const boardX = area.x + Math.round((aw - boardW) / 2);
   const boardY = landscape
-    ? Math.round((h - blockH) / 2 + cell * headroom)
-    : Math.round(bandH + (h - bandH - blockH) / 2 + cell * headroom);
+    ? area.y + Math.round((ah - blockH) / 2 + cell * headroom)
+    : area.y + Math.round(bandH + (ah - bandH - blockH) / 2 + cell * headroom);
 
   const rim = Math.max(6, Math.round(cell * 0.16));
   const chipSize = Math.max(16, Math.round(cell * 0.52));
+  const incomingStep = chipSize * 1.22;
+  /** the three incoming chips, end to end */
+  const stripSpan = incomingStep * 2 + chipSize;
 
-  const keyR = landscape
+  let keyR = landscape
     ? Math.max(34, Math.min(64, rail * 0.3))
     : Math.max(30, Math.min(56, bandH * 0.36));
+  if (landscape) {
+    // The right rail stacks the reactor above the next-chip strip, and in a
+    // short window both have to fit between the how-to-play button and the
+    // bottom of the safe area. Shrink the reactor rather than let the strip walk
+    // off the screen: a smaller KEY is legible, a KEY under the gesture bar is
+    // not.
+    const room = area.y + ah - CHROME_GAP - (cornerBottom + CHROME_GAP) - stripSpan - 8;
+    keyR = Math.max(34, Math.min(keyR, room / (REACTOR_EXTENT * 2)));
+  } else {
+    // Portrait keeps the reactor dead centre, so instead of moving it down onto
+    // the well when it grows wide enough to touch a corner, it is allowed to be
+    // a little smaller. A smaller KEY is a much cheaper loss than a covered one.
+    const room = (aw / 2 - HOST_MARGIN - HOST_CONTROL - CHROME_GAP) / REACTOR_EXTENT;
+    keyR = Math.max(22, Math.min(keyR, room));
+  }
+
+  const scoreSize = Math.max(24, Math.min(58, cell * 0.86));
+  const bestSize = Math.max(10, Math.min(16, cell * 0.26));
+  const levelSize = Math.max(14, Math.min(26, cell * 0.42));
+
+  const wellY = boardY - rim;
+  const soundR = 16;
 
   const base: Layout = {
     w,
     h,
     dpr,
+    area,
     landscape,
     pad,
     cell,
@@ -101,7 +253,7 @@ export function computeLayout(w: number, h: number, dpr: number): Layout {
     boardW,
     boardH,
     wellX: boardX - rim,
-    wellY: boardY - rim,
+    wellY,
     wellW: boardW + rim * 2,
     wellH: boardH + rim * 2,
     headY: boardY - cell * (headroom * 0.58),
@@ -115,47 +267,113 @@ export function computeLayout(w: number, h: number, dpr: number): Layout {
     levelY: 0,
     incomingX: 0,
     incomingY: 0,
-    incomingStep: chipSize * 1.22,
+    incomingStep,
     incomingVertical: landscape,
     chipSize,
-    soundX: w - pad - 18,
-    soundY: pad + 18,
-    soundR: 16,
+    soundX: 0,
+    soundY: 0,
+    soundR,
+    scoreSize,
+    bestSize,
+    levelSize,
+    scoreBox: { x: 0, y: 0, w: 0, h: 0 },
+    levelBox: { x: 0, y: 0, w: 0, h: 0 },
+    reactorBox: { x: 0, y: 0, w: 0, h: 0 },
+    incomingBox: { x: 0, y: 0, w: 0, h: 0 },
+    soundBox: { x: 0, y: 0, w: 0, h: 0 },
   };
 
   if (landscape) {
-    const lx = pad + rail * 0.5;
-    const rx = w - pad - rail * 0.5;
+    const lx = area.x + pad + rail * 0.5;
+    const rx = area.x + aw - pad - rail * 0.5;
     base.scoreX = lx;
-    base.scoreY = h * 0.34;
+    base.scoreY = area.y + ah * 0.34;
     base.scoreAlign = "center";
     base.levelX = lx;
-    base.levelY = h * 0.5;
+    base.levelY = area.y + ah * 0.5;
     base.keyX = rx;
-    base.keyY = h * 0.36;
+    base.keyY = area.y + ah * 0.36;
     base.incomingX = rx;
-    base.incomingY = h * 0.56;
-    base.soundX = pad + 22;
-    base.soundY = h - pad - 22;
+    base.incomingY = area.y + ah * 0.56;
+    base.soundX = area.x + pad + 22;
+    base.soundY = area.y + ah - pad - 22;
+
+    // A short landscape window pushes the rails up under the corners; the rails
+    // have the room to give, so each stack slides down until it is clear.
+    base.scoreY += clearOfChrome(
+      scoreRect(base.scoreX, base.scoreY, "center", scoreSize, bestSize),
+      corners,
+    );
+    base.levelY += clearOfChrome(levelRect(base.levelX, base.levelY, true, levelSize), corners);
+    base.keyY += clearOfChrome(reactorRect(base.keyX, base.keyY, keyR), corners);
+    // The incoming strip hangs off the reactor, so it follows it down rather
+    // than being overrun by it — but never past the bottom of the safe area,
+    // where a phone's gesture bar is. The reactor was already shrunk above so
+    // that both fit; this is the backstop for a window too short even for that.
+    base.incomingY = Math.max(
+      base.incomingY,
+      base.keyY + base.keyR * REACTOR_EXTENT + chipSize / 2 + 8,
+    );
+    base.incomingY = Math.min(
+      base.incomingY,
+      area.y + ah - CHROME_GAP - stripSpan + chipSize / 2,
+    );
   } else {
-    const top = pad + (bandH - pad) * 0.5;
-    base.scoreX = pad + 4;
+    const top = area.y + pad + (bandH - pad) * 0.5;
+    base.scoreX = area.x + pad + 4;
     base.scoreY = top;
     base.scoreAlign = "left";
-    base.keyX = w / 2;
+    base.keyX = area.x + aw / 2;
     base.keyY = top;
-    base.levelX = w - pad - 4;
+    base.levelX = area.x + aw - pad - 4;
     base.levelY = top - keyR * 0.5;
     // The next chip is leftmost and the queue fades to the right, so it reads
     // in the direction the eye already travels.
-    base.incomingStep = chipSize * 1.22;
-    base.incomingX = w - pad - chipSize / 2 - base.incomingStep * 2;
-    base.incomingY = top + keyR * 0.52;
-    // Portrait has no room beside the well, so the toggle lives in the band's
-    // top-left corner where nothing else is drawn.
-    base.soundX = pad + 16;
-    base.soundY = pad + 16;
+    base.incomingX = area.x + aw - pad - chipSize / 2 - base.incomingStep * 2;
+    base.incomingY = base.levelY + keyR * 1.02;
+
+    // The exit chevron owns the top-left square, so the score — the biggest,
+    // most-read thing in the band — starts under it. The band is deep enough
+    // to absorb that on every phone; where it is not, the score spills into the
+    // empty air above the well, which is the one place nothing else is drawn.
+    base.scoreY += clearOfChrome(
+      scoreRect(base.scoreX, base.scoreY, "left", scoreSize, bestSize),
+      corners,
+    );
+    // Same on the right, under the how-to-play button. The incoming strip keeps
+    // its distance from the level readout.
+    const levelShift = clearOfChrome(levelRect(base.levelX, base.levelY, false, levelSize), corners);
+    base.levelY += levelShift;
+    base.incomingY += levelShift;
+    base.incomingY += clearOfChrome(
+      incomingRect(base.incomingX, base.incomingY, base.incomingStep, chipSize, false),
+      corners,
+    );
+
+    // Portrait has no rail and no room under the well, so the mute toggle goes
+    // at the foot of the left column, under the score — never in the corner the
+    // host's exit chevron is already sitting in, which is exactly where it was.
+    const score = scoreRect(base.scoreX, base.scoreY, "left", scoreSize, bestSize);
+    const scoreBottom = score.y + score.h;
+    const touch = soundR + SOUND_TOUCH;
+    base.soundX = area.x + pad + soundR + 2;
+    base.soundY = Math.max(
+      cornerBottom + CHROME_GAP + touch,
+      Math.min(scoreBottom + SOUND_TOUCH + soundR, wellY - touch - 6),
+    );
   }
+
+  base.scoreBox = scoreRect(base.scoreX, base.scoreY, base.scoreAlign, scoreSize, bestSize);
+  base.levelBox = levelRect(base.levelX, base.levelY, landscape, levelSize);
+  base.reactorBox = reactorRect(base.keyX, base.keyY, base.keyR);
+  base.incomingBox = incomingRect(
+    base.incomingX,
+    base.incomingY,
+    base.incomingStep,
+    chipSize,
+    landscape,
+  );
+  base.soundBox = soundRect(base.soundX, base.soundY, soundR);
 
   return base;
 }

--- a/dynawalla/games/merge/src/mount.ts
+++ b/dynawalla/games/merge/src/mount.ts
@@ -1,3 +1,4 @@
+import { createInstructions, safeRect } from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, FocusableHost } from "./contract.ts";
 import { Game } from "./game.ts";
 import { Renderer } from "./render.ts";
@@ -33,6 +34,79 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
   el.style.position = el.style.position || "relative";
   el.appendChild(canvas);
 
+  // How to play, on the shared surface every Dynawalla game uses. Nobody can
+  // play a game they have not been taught, and a child who is stuck will not go
+  // looking for the rules — so the button stays there during the run, not only
+  // before it.
+  const guide = createInstructions(el, {
+    title: "FUSE",
+    summary: [
+      "Drop number chips into the well. Chips that touch and add up to the KEY disappear.",
+      "The KEY is the big number in the circle. It starts at 10.",
+    ],
+    sections: [
+      {
+        heading: "Dropping a chip",
+        lines: [
+          "Your next chip waits above the well.",
+          "Put your finger anywhere on the screen and slide it left or right. The chip follows your finger.",
+          "A faint chip shows you where it will land. Lift your finger and it drops.",
+          "On a computer, move the mouse and click. Or use the left and right arrow keys, then the space bar.",
+          "If you wait too long, the chip drops by itself.",
+        ],
+      },
+      {
+        heading: "Making chips fuse",
+        lines: [
+          "Say the KEY is 10. Land a 4 next to a 6. 4 + 6 = 10, so both chips disappear and you score.",
+          "The chips have to be touching — side by side, or one straight above the other.",
+          "Three chips work too. 2 + 3 + 5 = 10.",
+          "When chips disappear, the chips above them fall down. If they land next to a new partner they fuse again. Lots of fuses in a row is a chain, and a chain is worth more.",
+          "The KEY gets bigger as you go: 10, 12, 15, 20, 24, 25, 30, 40, 50, 60, 75, 100.",
+        ],
+      },
+      {
+        heading: "Chips that show a sum",
+        lines: [
+          "After a while a chip shows something like 15 − 8 instead of 7.",
+          "Work it out. 15 − 8 = 7, so that chip is a 7, and a 7 still fuses with a 3.",
+        ],
+      },
+      {
+        heading: "The well keeps rising",
+        lines: [
+          "Every few drops, a new row is pushed in at the bottom and everything moves up.",
+          "If chips reach the top row, the run is over.",
+          "So fuse chips quickly. Every fuse takes chips out of the well.",
+        ],
+      },
+      {
+        heading: "The big question",
+        lines: [
+          "Every fuse charges the circle. After eight fuses it turns green and pulses.",
+          "Tap the circle. Time slows right down and one question appears.",
+          "Now every chip on the board is an answer button. Tap a chip with the right answer on it.",
+          "Right answer: every chip with that number blows up, and so do the chips next to them.",
+          "Wrong answer, or too slow, and nothing blows up. You have to fuse eight more times to charge the circle again.",
+          "If you never tap it, the circle asks you the question by itself.",
+        ],
+      },
+      {
+        heading: "One rescue",
+        lines: [
+          "When the well fills right up, you get one question to save the run. Only one, and only once.",
+          "Get it right and a big piece of the board is cleared away.",
+          "Get it wrong and the run is over.",
+        ],
+      },
+      {
+        heading: "Sound",
+        lines: ["Tap the speaker button to turn the sound off and on."],
+      },
+    ],
+    reducedMotion: host.prefersReducedMotion(),
+  });
+
   const g = canvas.getContext("2d", { alpha: false }) as CanvasRenderingContext2D;
   const game = new Game(host as FocusableHost, opts.seed);
   const renderer = new Renderer();
@@ -52,7 +126,7 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
     canvas.height = Math.round(h * dpr);
     canvas.style.width = `${w}px`;
     canvas.style.height = `${h}px`;
-    layout = computeLayout(w, h, dpr);
+    layout = computeLayout(w, h, dpr, safeRect(w, h));
     game.layout = layout;
     renderer.resize(layout);
   };
@@ -76,13 +150,25 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
   };
   motionQuery?.addEventListener?.("change", onMotion);
 
-  const input = bindInput(canvas, game, () => layout);
+  const input = bindInput(canvas, game, () => layout, () => guide.isOpen);
 
   const loop = (now: number) => {
     raf = requestAnimationFrame(loop);
     let dt = (now - last) / 1000;
     last = now;
     if (dt > 0.1) dt = 0.1; // a backgrounded tab must not teleport the well
+
+    // Reading the rules is not playing. A child who opens the manual is a child
+    // who is stuck, and FUSE has three ways to punish them for looking: the
+    // held chip drops itself after `fuseTime`, the well rises under it, and a
+    // charged reactor asks a question by itself and reports a miss to the host
+    // when nobody answers — a wrong answer in the learner model for a question
+    // that was never on screen. So the simulation stops and only the picture
+    // keeps being drawn.
+    if (guide.isOpen) {
+      if (layout) renderer.draw(g, game, layout, now / 1000);
+      return;
+    }
 
     frameTimes.push(dt);
     if (frameTimes.length > 45) frameTimes.shift();
@@ -117,6 +203,7 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
 
   return {
     unmount() {
+      guide.destroy();
       cancelAnimationFrame(raf);
       input.dispose();
       ro?.disconnect();

--- a/dynawalla/games/merge/src/render.ts
+++ b/dynawalla/games/merge/src/render.ts
@@ -651,8 +651,11 @@ export class Renderer {
   /* ---------------- instruments ---------------- */
 
   private hud(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
-    const big = Math.max(24, Math.min(58, l.cell * 0.86));
-    const small = Math.max(10, Math.min(16, l.cell * 0.26));
+    // The type sizes come from the layout, not from `cell`, because the layout
+    // sized the boxes it kept clear of the notch and the host's corners with
+    // them. Recomputing them here is how those boxes would start lying.
+    const big = l.scoreSize;
+    const small = l.bestSize;
 
     // score
     const sx = l.scoreX;
@@ -704,7 +707,7 @@ export class Renderer {
 
     // level
     const lv = `${game.levelN}`;
-    const lvSize = Math.max(14, Math.min(26, l.cell * 0.42));
+    const lvSize = l.levelSize;
     const lx = l.landscape ? l.levelX : l.levelX - this.sprites.measure(lv, lvSize) / 2 - 12;
     this.sprites.drawText(g, "LV", lvSize * 0.6, [120, 145, 200], lx - lvSize * 0.85, l.levelY, 800);
     this.sprites.drawText(g, lv, lvSize, KEYC, lx, l.levelY, 900);


### PR DESCRIPTION
## What

Lay FUSE out inside the safe rectangle, keep the host's two 44px corners clear of
everything a child reads or touches, and add the shared how-to-play panel.

## Why

FUSE ships `viewport-fit=cover`, which opts the document *into* the notch, the
home indicator and the rounded corners — and it draws its whole HUD on a canvas,
where `env(safe-area-inset-*)` cannot be read. So the score, the KEY reactor and
the level readout were being drawn into the unsafe region deliberately and then
ignored.

On top of that the host paints an exit chevron over the top-left 44px and the
how-to-play button over the top-right 44px. FUSE never planned around either.
Probed at the shipped geometry, the collisions were real on every phone and
tablet in portrait:

```
320x568: UNDER CHROME -> score, level, mute
390x844: UNDER CHROME -> score, level, mute
768x1024: UNDER CHROME -> score, level, mute
1024x768: clear
844x390: UNDER CHROME -> reactor
```

The mute toggle sat at `pad+16, pad+16` — dead centre of the exit chevron — so
a child aiming for "back" hit mute, and a child aiming for mute left the game.
In landscape the RESONANCE reactor, which is **tapped** to start the big
question, reached under the how-to-play button.

## How

`computeLayout(w, h, dpr, area)` takes the safe rect as a **required** fourth
argument — `safeRect(w, h)` from `packs/shared/game-chrome`. Required, not
optional, exactly as SKY LEDGER's `layoutFor`: optional means a game that forgets
it compiles and quietly draws under the notch, discoverable only on a device.

Host chrome **overlays**, so nothing reserves a band — an earlier attempt
elsewhere reserved 67px and broke a game's own layout at 320x568. Instead each
instrument that would land in a corner slides **down** out of it:

- the score (with the chain readout above it and BEST below it) starts under the
  exit chevron;
- LV, and the next-chip strip that hangs off it, start under the how-to-play
  button;
- the mute toggle moves to the foot of the left column, under the score, clamped
  so it never reaches the well;
- portrait shrinks the reactor rather than moving it, when it grows wide enough
  to touch a corner — a smaller KEY is a cheaper loss than a covered one;
- short landscape slides the whole right rail down instead, and shrinks the
  reactor first so the next-chip strip that hangs off it still fits above the
  bottom of the safe area. Without that the strip walked off the screen on any
  landscape window shorter than ~330px (and under the Android gesture bar at
  1280x360) — a regression the first draft of this PR introduced and the
  self-review caught.

The well, the plasma, the well walls and the sparks still bleed to the edges.
That is what `cover` is for.

Type sizes (`scoreSize`, `bestSize`, `levelSize`) moved from `render.ts` into the
layout, so the boxes the test asserts on are computed from the same numbers the
renderer draws with. The layout publishes `scoreBox`, `levelBox`, `reactorBox`,
`incomingBox` and `soundBox`, and the test runs `hitsHostChrome` over all of them
plus the well, on **fourteen viewports x four inset profiles** — flat, notched
portrait, notched landscape and an Android gesture bar — because the corners move
with the insets, so asserting only the flat case asserts the one case a notch
cannot break.

`createInstructions` is mounted in `mount.ts` with `reducedMotion:
host.prefersReducedMotion()` and destroyed first thing in `unmount()`. **Opening
it stops the simulation** — FUSE has three ways to punish a child for reading the
rules: the held chip drops itself after `fuseTime` (2.4s by level 12), the well
rises under it, and a charged reactor asks a question by itself and reports a
miss to the host when nobody answers, writing a wrong answer into the learner
model for a question that was never on screen. Worse, the panel's own PLAY button
could not be pressed: `input.ts` binds `keydown` on `window` and
`preventDefault`s Space and Enter, so they dropped a chip instead, and `R` reset
the run from behind a page of rules. `bindInput` now takes a `suspended()`
predicate. The copy
is written for a seven-year-old and describes what FUSE actually does — the drag
aim with the landing ghost, the auto-drop, 2-or-3 touching chips summing to the
KEY, cascades, expression faces from level 3, the rise, the eight-fuse charge and
the one rescue.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/merge`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no `voiceId`
      renamed; no catalog entry dropped. `pack.json` untouched.
- [x] **Native integrity.** No native/Rust/Tauri file touched.
- [x] **Strings.** No `corpan-app` locale strings touched. The new strings are
      pack-local how-to-play copy, `"locales": ["en"]` as before.
- [x] **Curriculum.** No skill id, grade or answer schema touched.
- [x] **Secrets.** None. `gitleaks` clean, output below.

## Proof

`npm test`, five separate runs, in `dynawalla/games/merge/`:

```
=== run 1 ===
# tests 73
# pass 73
# fail 0
=== run 2 ===
# tests 73
# pass 73
# fail 0
=== run 3 ===
# tests 73
# pass 73
# fail 0
=== run 4 ===
# tests 73
# pass 73
# fail 0
=== run 5 ===
# tests 73
# pass 73
# fail 0
```

**The clearance test goes RED without the fix.** With `clearOfChrome` returning
0, the reactor clamp removed and the mute toggle put back at `pad+16, pad+16`:

```
not ok 70 - nothing a child reads or touches sits under the host's chrome
  ---
  location: 'src/layout.test.ts:136:1'
  failureType: 'testCodeFailure'
  error: |-
    iPhone SE portrait (320x568): the score is under the host's chrome

    true !== false

  code: 'ERR_ASSERTION'
  expected: false
  actual: true
  operator: 'strictEqual'
  ...
# tests 73
# pass 72
# fail 1
```

The assertion stops at the first offender, so the same broken layout was also
probed element by element — that is the `UNDER CHROME` table in **Why** above.
Restored, all 73 pass.

**The short-landscape fix is load-bearing too.** With the reactor cap and the
bottom clamp removed:

```
not ok 64 - the incoming strip stays on screen
  error: 'short landscape: incoming 2 off y'
not ok 73 - the incoming strip stays inside the safe area once it has moved clear
  error: 'short landscape: incoming strip off y'
# tests 73
# pass 71
# fail 2
```

`npm run tsc`:

```
> @dynawalla/game-merge@0.1.0 tsc
> tsc --noEmit

```

`npm run build`:

```
vite v8.1.5 building client environment for production...
transforming...
✓ 25 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                 0.84 kB │ gzip:  0.44 kB
dist/assets/index-BXtwO-Gw.js  74.75 kB │ gzip: 26.09 kB

✓ built in 31ms
```

`node build.mjs dynawalla.fuse` from `dynawalla/packs/` (the id, not the folder
name — `build.mjs merge` substring-matches the sibling `merge-idle` too and
prints `2 pack(s)`):

```
✓ built in 30ms
dynawalla.fuse@0.1.0 — FUSE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       4 skills, grades 1–4
  on disk      3 files, 82286 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`:

```
INF 1 commits scanned.
INF scanned ~24533 bytes (24.53 KB) in 38.1ms
INF no leaks found
```

Scope — only `dynawalla/games/merge/`, no deletions:

```
$ git diff --stat origin/main..HEAD
 dynawalla/games/merge/README.md          |  20 ++-
 dynawalla/games/merge/src/input.ts       |  17 +-
 dynawalla/games/merge/src/layout.test.ts | 163 ++++++++++++++---
 dynawalla/games/merge/src/layout.ts      | 294 +++++++++++++++++++++++++++----
 dynawalla/games/merge/src/mount.ts       |  91 +++++++++-
 dynawalla/games/merge/src/render.ts      |   9 +-
 6 files changed, 528 insertions(+), 66 deletions(-)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty)
```

## Self-review

Run through the adversarial lenses before pushing. It found one HIGH (the game
kept running behind the open manual, including reporting a phantom miss to the
host and burning the one rescue) and one MEDIUM (the next-chip strip walking off
the bottom in short landscape). Both are fixed above, both now have a test, and
both tests were checked to go red without the fix.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
