### PR TITLE
fix(dynawalla/games/stack): move the floor count and best out of the host's two corners

### DIFF
--- a/dynawalla/games/stack/README.md
+++ b/dynawalla/games/stack/README.md
@@ -71,7 +71,7 @@ death line, so a chain of revives ends by itself rather than by a rule.
 ```sh
 npm install
 npm run dev            # http://127.0.0.1:4310
-npm test               # 32 tests, no browser needed
+npm test               # 36 tests, no browser needed
 npm run tsc
 npm run build:pack     # what installs on a tablet: pack.html only, no stub host
 ```
@@ -106,6 +106,7 @@ src/view/*             sky, post chain, slabs, plaques, particles, rings, tiers
 src/feel/feel.ts       trauma shake, springs, hit-stop, rate-limited flash
 src/audio/audio.ts     procedural WebAudio, no assets
 src/ui/hud.ts          DOM chrome
+src/ui/place.ts        where the chrome may sit: safe area, and the host's two corners
 ```
 
 `sim.ts` is deliberately free of THREE, the DOM and time-of-day, so the rules
@@ -130,6 +131,14 @@ guarantees are proven.
 - **A decoy can be secretly correct.** `2/4 + ? = 1` offered `2/4`, because the
   "copied the fraction" mal-rule *is* the answer when the numerator is half the
   denominator. Decoys are now filtered by exact value, not by string.
+- **The host paints over the pack, in the two top corners.** An exit control
+  top-left and how-to-play top-right, 44px each. The floor count was at
+  `left:14px` and the best at `right:14px`, flush to the top, so both sat under
+  them. The readouts now step in past the corners onto the same row, and
+  `place.ts` holds those offsets in both dialects at once — the `calc(env(…))`
+  the stylesheet is built from, and the numbers `place.test.ts` proves at five
+  viewports. Reserving a top band instead was tried across the arcade and
+  rejected: it costs 12% of a 568px phone.
 - **Plaques are sized so they are a constant number of screen pixels.** The
   camera solves its own distance every frame; a number a child has half a second
   to read cannot be allowed to shrink when the shot pulls back.
@@ -143,6 +152,8 @@ guarantees are proven.
   exposure event rather than a sheet of white, so they never strobe.
 - Nothing is carried by colour alone; sound is disableable and always has a
   visual twin.
+- The rules are one tap away at any moment, from the shared how-to-play panel —
+  a child needs them when they are stuck, which is never the title screen.
 - Readable at 320 px. Touch is primary, keyboard (`Space` / `R`) is first class.
 - No ads, no loot boxes, no variable-ratio rewards, no daily streak, no
   scarcity, no social pressure, no timer.

--- a/dynawalla/games/stack/src/game/mount.ts
+++ b/dynawalla/games/stack/src/game/mount.ts
@@ -26,6 +26,7 @@ import {
   SRGBColorSpace,
 } from "three";
 
+import { createInstructions } from "../../../../packs/shared/game-chrome/index.ts";
 import type { Host } from "../contract.ts";
 import { Sim, type PlaceEvent, type SimEvent } from "./sim.ts";
 import { T } from "./tuning.ts";
@@ -225,6 +226,51 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     },
     reduced,
   );
+
+  // How to play. MONUMENT asks for two judgements in one tap — is this the
+  // right value, and is it over the tower — and shipped saying only "Tap to set
+  // the stone". A child who does not know the value matters reads the tap as
+  // the whole game, drops on the first pass every time, and watches the tower
+  // shear for reasons nothing on screen explains.
+  //
+  // It goes on `el` rather than on `holder`, so a tap on the panel is not also
+  // a tap on the game: `holder` is what listens for the drop.
+  const guide = createInstructions(el, {
+    title: "MONUMENT",
+    summary: [
+      "A stone slides back and forth above your tower. Tap once to drop it.",
+      "Drop it when the number on the stone is the right answer, and when it lines up with the tower.",
+    ],
+    sections: [
+      {
+        heading: "Two things have to be right",
+        lines: [
+          "There is a sum near the top, like 3 + ? = 10.",
+          "The stone has a number on it. That number changes every time the stone turns around.",
+          "Wait until the stone is showing the answer.",
+          "Then tap when the stone is sitting right over the tower.",
+        ],
+      },
+      {
+        heading: "The tower",
+        lines: [
+          "Any part of the stone that hangs over the edge breaks off, so the tower gets thinner.",
+          "Land it dead straight and the tower gets wider instead.",
+          "Drop a wrong number and the stone cracks and takes even more off.",
+          "If the tower gets too thin, it falls over and the run is done.",
+        ],
+      },
+      {
+        heading: "Waiting is free",
+        lines: [
+          "If the stone is showing a wrong number, do not tap. Let it go round again.",
+          "You get a whole pass to read a number and decide.",
+          "Waiting never costs you anything.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  });
 
   /* ── palette blending ───────────────────────────────────────────────── */
 
@@ -1117,6 +1163,7 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       ro.disconnect();
       holder.removeEventListener("pointerdown", onPointerDown);
       window.removeEventListener("keydown", onKey);
+      guide.destroy();
       hud.dispose();
       audio.dispose();
       sparks.dispose();

--- a/dynawalla/games/stack/src/ui/hud.ts
+++ b/dynawalla/games/stack/src/ui/hud.ts
@@ -9,7 +9,30 @@
  * got thinner and you can see it.
  *
  * Total translatable surface: four words.
+ *
+ * Every offset that touches an edge comes from `place.ts`, which holds the
+ * safe-area arithmetic and the host's two reserved corners in one place and
+ * hands this stylesheet the `calc(env(...))` strings — so `place.test.ts` is
+ * asserting against the geometry that actually ships, not a copy of it.
  */
+
+import {
+  BEST_NUM,
+  CSS_CLEAR_LEFT,
+  CSS_CLEAR_RIGHT,
+  CSS_EDGE_LEFT,
+  CSS_HINT_BOTTOM,
+  CSS_PROMPT_TOP,
+  CSS_ROW_TOP,
+  CSS_TOOL_BOTTOM,
+  CSS_TOOL_RIGHT,
+  FLOOR_GAP,
+  FLOOR_NUM,
+  LABEL,
+  PROMPT,
+  TOOL_SIZE,
+  cssScale,
+} from "./place.ts";
 
 const CSS = `
 .mn { position:absolute; inset:0; pointer-events:none; overflow:hidden;
@@ -19,29 +42,29 @@ const CSS = `
   contain:layout style; user-select:none; -webkit-user-select:none; -webkit-tap-highlight-color:transparent; }
 .mn * { box-sizing:border-box; margin:0; }
 
-.mn-floor { position:absolute; top:max(10px,env(safe-area-inset-top)); left:14px; display:flex; align-items:baseline; gap:10px;
+.mn-floor { position:absolute; top:${CSS_ROW_TOP}; left:${CSS_CLEAR_LEFT}; display:flex; align-items:baseline; gap:${FLOOR_GAP}px;
   transform-origin:left center; will-change:transform; }
-.mn-floor b { font-size:clamp(40px,10.5vmin,84px); font-weight:800; letter-spacing:-.045em; line-height:.85;
+.mn-floor b { font-size:${cssScale(FLOOR_NUM)}; font-weight:800; letter-spacing:-.045em; line-height:.85;
   font-variant-numeric:tabular-nums; text-shadow:var(--shadow); }
-.mn-floor i { font-style:normal; font-size:clamp(9px,2.2vmin,12px); font-weight:800; letter-spacing:.22em;
+.mn-floor i { font-style:normal; font-size:${cssScale(LABEL)}; font-weight:800; letter-spacing:.22em;
   color:var(--dim); text-transform:uppercase; }
 
-.mn-best { position:absolute; top:max(10px,env(safe-area-inset-top)); right:14px; text-align:right;
-  font-size:clamp(9px,2.2vmin,12px); font-weight:800; letter-spacing:.2em; color:var(--dim); text-transform:uppercase; }
-.mn-best em { font-style:normal; display:block; font-size:clamp(15px,4vmin,26px); letter-spacing:-.02em; color:var(--fg);
+.mn-best { position:absolute; top:${CSS_ROW_TOP}; right:${CSS_CLEAR_RIGHT}; text-align:right;
+  font-size:${cssScale(LABEL)}; font-weight:800; letter-spacing:.2em; color:var(--dim); text-transform:uppercase; }
+.mn-best em { font-style:normal; display:block; font-size:${cssScale(BEST_NUM)}; letter-spacing:-.02em; color:var(--fg);
   font-variant-numeric:tabular-nums; opacity:.85; }
 
-.mn-prompt { position:absolute; left:50%; top:18%; transform:translate(-50%,-50%);
+.mn-prompt { position:absolute; left:50%; top:${CSS_PROMPT_TOP}; transform:translate(-50%,-50%);
   display:flex; align-items:center; gap:0; padding:.42em .72em .5em;
   background:var(--bg); border-bottom:3px solid var(--ac);
-  font-size:clamp(21px,6.6vmin,46px); font-weight:800; letter-spacing:-.02em; white-space:nowrap;
+  font-size:${cssScale(PROMPT)}; font-weight:800; letter-spacing:-.02em; white-space:nowrap;
   font-variant-numeric:tabular-nums; box-shadow:0 10px 40px rgba(0,0,0,.45);
   will-change:transform,opacity; }
 .mn-prompt.reveal { border-bottom-color:var(--fg); }
 .mn-prompt .fill { color:var(--ac); }
 .mn-prompt .q { color:var(--ac); }
 
-.mn-combo { position:absolute; left:50%; top:calc(18% + 2.9em); transform:translate(-50%,0) scale(1);
+.mn-combo { position:absolute; left:50%; top:calc(${CSS_PROMPT_TOP} + 2.9em); transform:translate(-50%,0) scale(1);
   font-size:clamp(13px,3.4vmin,22px); font-weight:800; letter-spacing:.02em; color:var(--ac);
   font-variant-numeric:tabular-nums; opacity:0; will-change:transform,opacity; }
 
@@ -49,12 +72,13 @@ const CSS = `
   font-size:clamp(34px,12vmin,104px); font-weight:800; letter-spacing:-.05em; color:var(--ac);
   opacity:0; will-change:transform,opacity; text-shadow:0 0 60px color-mix(in srgb,var(--ac) 60%,transparent); }
 
-.mn-band { position:absolute; left:0; right:0; top:57%; text-align:center; opacity:0; will-change:transform,opacity; }
+.mn-band { position:absolute; left:0; right:0; top:57%; text-align:center; opacity:0; will-change:transform,opacity;
+  padding-left:env(safe-area-inset-left); padding-right:env(safe-area-inset-right); box-sizing:border-box; }
 .mn-band u { text-decoration:none; display:block; font-size:clamp(9px,2.4vmin,13px); font-weight:800; letter-spacing:.42em;
   color:var(--dim); text-transform:uppercase; }
 .mn-band b { display:block; font-size:clamp(28px,8.5vmin,62px); font-weight:800; letter-spacing:.06em; }
 
-.mn-hint { position:absolute; left:50%; bottom:12%; transform:translateX(-50%);
+.mn-hint { position:absolute; left:50%; bottom:${CSS_HINT_BOTTOM}; transform:translateX(-50%);
   font-size:clamp(10px,2.6vmin,14px); font-weight:800; letter-spacing:.3em; color:var(--dim); text-transform:uppercase;
   animation:mnpulse 1.9s ease-in-out infinite; }
 @keyframes mnpulse { 0%,100%{opacity:.28} 50%{opacity:.85} }
@@ -62,7 +86,9 @@ const CSS = `
 .mn-over { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center;
   gap:clamp(12px,3vmin,24px); pointer-events:auto; opacity:0; visibility:hidden;
   background:radial-gradient(120% 90% at 50% 45%, transparent 18%, color-mix(in srgb,var(--bg) 99%,transparent) 62%);
-  padding:20px; transition:opacity .28s ease; }
+  padding:calc(env(safe-area-inset-top) + 20px) calc(env(safe-area-inset-right) + 20px)
+    calc(env(safe-area-inset-bottom) + 20px) calc(env(safe-area-inset-left) + 20px);
+  transition:opacity .28s ease; }
 .mn-over.on { opacity:1; visibility:visible; }
 .mn-over h1 { font-size:clamp(11px,2.8vmin,15px); font-weight:800; letter-spacing:.42em; color:var(--dim); text-transform:uppercase; }
 .mn-over .big { font-size:clamp(56px,20vmin,150px); font-weight:800; letter-spacing:-.06em; line-height:.82;
@@ -83,13 +109,13 @@ const CSS = `
   background:transparent; color:var(--fg); border:2px solid color-mix(in srgb,var(--fg) 45%,transparent); }
 .mn-btn.solid { background:var(--ac); color:var(--bg); border-color:var(--ac); }
 
-.mn-tools { position:absolute; right:12px; bottom:max(12px,env(safe-area-inset-bottom)); display:flex; gap:8px; pointer-events:auto; }
-.mn-tools button { pointer-events:auto; width:40px; height:40px; border:2px solid color-mix(in srgb,var(--fg) 28%,transparent);
+.mn-tools { position:absolute; right:${CSS_TOOL_RIGHT}; bottom:${CSS_TOOL_BOTTOM}; display:flex; gap:8px; pointer-events:auto; }
+.mn-tools button { pointer-events:auto; width:${TOOL_SIZE}px; height:${TOOL_SIZE}px; border:2px solid color-mix(in srgb,var(--fg) 28%,transparent);
   background:var(--bg); color:var(--fg); font:inherit; font-size:13px; font-weight:800;
   border-radius:0; cursor:pointer; letter-spacing:0; touch-action:manipulation; }
 .mn-tools button[aria-pressed="false"] { opacity:.42; }
 
-.mn-perf { position:absolute; background:rgba(0,0,0,.55); padding:6px 9px; color:#fff !important; left:14px; bottom:max(12px,env(safe-area-inset-bottom)); font-size:11px; font-weight:700;
+.mn-perf { position:absolute; background:rgba(0,0,0,.55); padding:6px 9px; color:#fff !important; left:${CSS_EDGE_LEFT}; bottom:${CSS_TOOL_BOTTOM}; font-size:11px; font-weight:700;
   letter-spacing:.06em; color:var(--dim); font-variant-numeric:tabular-nums; white-space:pre; line-height:1.45; display:none; }
 .mn-perf.on { display:block; }
 

--- a/dynawalla/games/stack/src/ui/place.test.ts
+++ b/dynawalla/games/stack/src/ui/place.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The promise the HUD makes about the host's chrome, at every shape a tablet or
+ * phone can hand it.
+ *
+ * These run against `place.ts` — the module the stylesheet is actually built
+ * from — rather than against a copy of its arithmetic, because a test that
+ * re-derives the layout proves only that it agrees with itself.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  chromeRects,
+  hitsHostChrome,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { hudRects } from "./place.ts";
+
+/** Phone upright, phone on its side, tablet both ways, and the smallest shape. */
+const PORTRAIT: readonly (readonly [number, number])[] = [
+  [320, 568],
+  [390, 844],
+  [768, 1024],
+];
+const LANDSCAPE: readonly (readonly [number, number])[] = [
+  [1024, 768],
+  [844, 390],
+];
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+/** A notched phone held upright: the status bar and the home indicator. */
+const NOTCH_UP: Insets = { top: 59, right: 0, bottom: 34, left: 0 };
+/** The same phone on its side: the notch moves to a cheek. */
+const NOTCH_SIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const CASES: readonly (readonly [string, number, number, Insets])[] = [
+  ...PORTRAIT.flatMap(
+    ([w, h]) =>
+      [
+        [`${w}x${h}`, w, h, NONE],
+        [`${w}x${h} notched`, w, h, NOTCH_UP],
+      ] as const,
+  ),
+  ...LANDSCAPE.flatMap(
+    ([w, h]) =>
+      [
+        [`${w}x${h}`, w, h, NONE],
+        [`${w}x${h} notched`, w, h, NOTCH_SIDE],
+      ] as const,
+  ),
+];
+
+const overlaps = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+
+const show = (r: Rect): string =>
+  `x ${r.x.toFixed(1)}..${(r.x + r.w).toFixed(1)}, y ${r.y.toFixed(1)}..${(r.y + r.h).toFixed(1)}`;
+
+test("nothing a child must read or touch lands in the host's two corners", () => {
+  for (const [name, w, h, insets] of CASES) {
+    const r = hudRects(w, h, insets);
+    for (const [what, rect] of Object.entries(r)) {
+      assert.equal(
+        hitsHostChrome(rect, w, insets),
+        false,
+        `${name}: the ${what} is under host chrome — ${show(rect)} vs ` +
+          chromeRects(w, insets).map(show).join(" and "),
+      );
+    }
+  }
+});
+
+test("the floor count and the best score never run into each other", () => {
+  // Stepping in past the two corner controls costs 54px off each side. On a
+  // 320px phone that is a third of the width, so the two readouts have to be
+  // proven to still fit beside each other, at a three-digit floor.
+  for (const [name, w, h, insets] of CASES) {
+    const { floor, best } = hudRects(w, h, insets);
+    assert.ok(
+      floor.x + floor.w < best.x,
+      `${name}: the readouts collide — floor ${show(floor)}, best ${show(best)}`,
+    );
+  }
+});
+
+test("the equation plate never touches the floor count", () => {
+  // Pushing the readout in from the corner moved it toward a centred plate, and
+  // on a landscape tablet the numeral is 80px tall against 18% of 768. The
+  // plate's `max()` is what keeps this true rather than nearly true.
+  for (const [name, w, h, insets] of CASES) {
+    const { floor, prompt } = hudRects(w, h, insets);
+    assert.equal(
+      overlaps(floor, prompt),
+      false,
+      `${name}: the plate is over the floor count — floor ${show(floor)}, plate ${show(prompt)}`,
+    );
+  }
+});
+
+test("every readout stays inside the safe area", () => {
+  // The sky, the tower and the sparks bleed to the edges on purpose; text does
+  // not. A landscape notch is 47px of cheek, and 14px of gutter is not enough.
+  for (const [name, w, h, insets] of CASES) {
+    const r = hudRects(w, h, insets);
+    for (const [what, rect] of Object.entries(r)) {
+      assert.ok(rect.x >= insets.left, `${name}: the ${what} runs into the left inset`);
+      assert.ok(rect.y >= insets.top, `${name}: the ${what} runs into the top inset`);
+      assert.ok(
+        rect.x + rect.w <= w - insets.right + 0.5,
+        `${name}: the ${what} runs into the right inset — ${show(rect)}`,
+      );
+      assert.ok(
+        rect.y + rect.h <= h - insets.bottom + 0.5,
+        `${name}: the ${what} runs into the bottom inset — ${show(rect)}`,
+      );
+    }
+  }
+});

--- a/dynawalla/games/stack/src/ui/place.ts
+++ b/dynawalla/games/stack/src/ui/place.ts
@@ -1,0 +1,212 @@
+/**
+ * Where the chrome is ALLOWED to sit, as numbers — so the placement can be
+ * proven at every viewport instead of discovered on a tablet.
+ *
+ * Two forces decide this file.
+ *
+ * **The host paints over the game.** It draws an exit control in the top-LEFT
+ * 44px corner and a how-to-play control in the top-RIGHT 44px corner, over the
+ * pack, plus a 3px progress hairline. MONUMENT shipped its floor count at
+ * `left:14px` and its best at `right:14px`, both flush to the top — which is
+ * exactly where those two controls now land. The single most important number
+ * in the game was going to sit under the exit chevron.
+ *
+ * The host chrome OVERLAYS rather than reserving a band, and that is
+ * deliberate: reserving one cost 12% of a 568px phone and broke a sibling's
+ * layout outright. So the sky, the tower and the sparks still bleed to every
+ * edge — that is what `viewport-fit=cover` is for. The promise is narrower and
+ * absolute: nothing a child must READ or TOUCH lands in those two corners.
+ * Here that means the readouts step INWARD, past the corner squares, onto the
+ * same row as the host's own controls.
+ *
+ * **`env()` cannot be read from JavaScript.** So this module owns the numbers
+ * in both dialects at once: a `calc(env(...) + Npx)` string that `hud.ts`
+ * interpolates into its stylesheet, and the same N as a number that
+ * `place.test.ts` feeds to `hitsHostChrome`. One source, two readers — a test
+ * that re-derived the geometry would prove only that it agreed with itself.
+ */
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  NO_INSETS,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+
+/* ── the geometry ───────────────────────────────────────────────────────── */
+
+/** Air between a host control and whatever the game puts beside or under it. */
+export const GUTTER = 8;
+
+/** Down from the safe top edge to the top of the host's row of controls. */
+export const CHROME_TOP = HOST_PROGRESS_H + HOST_MARGIN;
+
+/** In from a safe side edge to the first column a readout may use. */
+export const CHROME_CLEAR = HOST_MARGIN + HOST_CONTROL + GUTTER;
+
+/** The gutter along the bottom, which the host does not contest. */
+export const EDGE = 14;
+/** The tool row's own gutter, kept as authored. */
+export const TOOL_EDGE = 12;
+
+/** Gap between the floor numeral and its label. */
+export const FLOOR_GAP = 10;
+
+/** The stone's tap target, and the tool buttons, are square. */
+export const TOOL_SIZE = 40;
+
+/* ── type scale ─────────────────────────────────────────────────────────── */
+
+/**
+ * A `clamp(min, vmin, max)` type step, in a form both dialects can read.
+ * `cssScale` writes the declaration; `scalePx` resolves the same step for a
+ * given viewport. They cannot drift because they read the same record.
+ */
+export type Scale = { readonly min: number; readonly vmin: number; readonly max: number };
+
+export const cssScale = (s: Scale): string => `clamp(${s.min}px,${s.vmin}vmin,${s.max}px)`;
+
+export const scalePx = (s: Scale, w: number, h: number): number =>
+  Math.min(s.max, Math.max(s.min, (Math.min(w, h) * s.vmin) / 100));
+
+export const FLOOR_NUM: Scale = { min: 40, vmin: 10.5, max: 84 };
+export const LABEL: Scale = { min: 9, vmin: 2.2, max: 12 };
+export const BEST_NUM: Scale = { min: 15, vmin: 4, max: 26 };
+export const PROMPT: Scale = { min: 21, vmin: 6.6, max: 46 };
+
+/** Letter-spacing of the two uppercase labels, in em, as authored. */
+const FLOOR_TRACK = 0.22;
+const BEST_TRACK = 0.2;
+
+/** The prompt plate's padding and rule, in em and px, as authored. */
+const PROMPT_PAD_Y = 0.42 + 0.5;
+const PROMPT_LINE = 1.2;
+const PROMPT_PAD_X = 0.72;
+const PROMPT_RULE = 3;
+
+/** Half the prompt plate's border box — it is centred on its own `top`. */
+export const promptHalf = (w: number, h: number): number => {
+  const f = scalePx(PROMPT, w, h);
+  return (f * (PROMPT_PAD_Y + PROMPT_LINE) + PROMPT_RULE) / 2;
+};
+const PROMPT_HALF_EM = (PROMPT_PAD_Y + PROMPT_LINE) / 2;
+
+/**
+ * The floor block's height, as a multiple of the numeral.
+ *
+ * The numeral's line box is `.85em`, and the run-up pulse scales it to 1.16 for
+ * 240ms around its own centre. `1` covers the line box, the label's descender
+ * and the pulse, and is what the gap below it is measured from.
+ */
+const FLOOR_BOX = 1;
+
+/**
+ * Glyph advance for the heavy tabular face, in em. Measured against the real
+ * face it over-estimates slightly, which is the direction a clearance model is
+ * allowed to be wrong in.
+ */
+const ADVANCE = 0.66;
+
+const textW = (chars: number, size: number, track = 0): number => chars * size * (ADVANCE + track);
+
+/** The largest floor a run realistically reaches, in digits. */
+export const FLOOR_DIGITS = 3;
+
+/* ── the CSS dialect ────────────────────────────────────────────────────── */
+
+const safe = (side: "top" | "right" | "bottom" | "left", px: number): string =>
+  `calc(env(safe-area-inset-${side}) + ${px}px)`;
+
+/** The row the host's controls sit on. The readouts join it, beside them. */
+export const CSS_ROW_TOP = safe("top", CHROME_TOP);
+export const CSS_CLEAR_LEFT = safe("left", CHROME_CLEAR);
+export const CSS_CLEAR_RIGHT = safe("right", CHROME_CLEAR);
+export const CSS_EDGE_LEFT = safe("left", EDGE);
+export const CSS_TOOL_RIGHT = safe("right", TOOL_EDGE);
+export const CSS_TOOL_BOTTOM = safe("bottom", TOOL_EDGE);
+export const CSS_HINT_BOTTOM = `calc(env(safe-area-inset-bottom) + 12%)`;
+
+/**
+ * The prompt's centre: 18% down, or below the floor readout, whichever is
+ * lower.
+ *
+ * 18% is the authored composition and wins on every phone. It stops winning on
+ * a landscape tablet, where `10.5vmin` makes the floor numeral 80px tall and
+ * 18% of 768 puts the plate straight through it — and pushing the readout in
+ * from the corner moved it toward the plate rather than away. The `max()` is
+ * what makes "the plate never touches the readout" true by construction rather
+ * than by luck, at every shape.
+ */
+export const CSS_PROMPT_TOP =
+  `max(18%, calc(${safe("top", CHROME_TOP + GUTTER + PROMPT_RULE / 2)}` +
+  ` + ${FLOOR_BOX} * ${cssScale(FLOOR_NUM)} + ${PROMPT_HALF_EM} * ${cssScale(PROMPT)}))`;
+
+/* ── the numeric dialect ────────────────────────────────────────────────── */
+
+export type HudRects = {
+  /** The floor count. The one number the whole game is about. */
+  readonly floor: Rect;
+  /** The best-ever floor. */
+  readonly best: Rect;
+  /** The equation plate. */
+  readonly prompt: Rect;
+  /** The sound toggle. */
+  readonly tools: Rect;
+};
+
+/**
+ * Every box a child must read or touch, in CSS pixels, for a viewport.
+ *
+ * The text boxes are modelled from the same type scale and the same offsets the
+ * stylesheet is built from; glyph widths are estimated generously. Pass these
+ * to `hitsHostChrome` to prove the promise.
+ */
+export function hudRects(w: number, h: number, insets: Insets = NO_INSETS): HudRects {
+  const num = scalePx(FLOOR_NUM, w, h);
+  const label = scalePx(LABEL, w, h);
+  const best = scalePx(BEST_NUM, w, h);
+  const prompt = scalePx(PROMPT, w, h);
+
+  const rowTop = insets.top + CHROME_TOP;
+
+  const floorW = textW(FLOOR_DIGITS, num) + FLOOR_GAP + textW(5, label, FLOOR_TRACK);
+  const floorRect: Rect = {
+    x: insets.left + CHROME_CLEAR,
+    y: rowTop,
+    w: floorW,
+    h: num * FLOOR_BOX,
+  };
+
+  const bestW = Math.max(textW(4, label, BEST_TRACK), textW(FLOOR_DIGITS, best));
+  const bestRect: Rect = {
+    x: w - insets.right - CHROME_CLEAR - bestW,
+    y: rowTop,
+    w: bestW,
+    h: label * 1.2 + best * 1.2,
+  };
+
+  const half = promptHalf(w, h);
+  const centre = Math.max(
+    0.18 * h,
+    insets.top + CHROME_TOP + num * FLOOR_BOX + GUTTER + prompt * PROMPT_HALF_EM + PROMPT_RULE / 2,
+  );
+  // Long as this game ever asks: "12 + ? = 100" and its kin.
+  const promptW = textW(14, prompt) + prompt * PROMPT_PAD_X * 2;
+  const promptRect: Rect = {
+    x: w / 2 - promptW / 2,
+    y: centre - half,
+    w: promptW,
+    h: half * 2,
+  };
+
+  const toolsRect: Rect = {
+    x: w - insets.right - TOOL_EDGE - TOOL_SIZE,
+    y: h - insets.bottom - TOOL_EDGE - TOOL_SIZE,
+    w: TOOL_SIZE,
+    h: TOOL_SIZE,
+  };
+
+  return { floor: floorRect, best: bestRect, prompt: promptRect, tools: toolsRect };
+}


### PR DESCRIPTION
## What

Move MONUMENT's floor count and best score out of the two 44px corners the host
paints its own controls in, fix every safe-area edge the HUD touches, and add
the shared how-to-play panel.

## Why

The host draws an exit control in the top-LEFT 44px corner and how-to-play in
the top-RIGHT, over the pack, plus a 3px progress hairline. MONUMENT put its
floor count at `left:14px` and its best at `right:14px`, both flush to the top.
The single most important number in the game — the floor you have reached — sat
directly under the exit chevron.

The safe-area handling was a half-fix throughout: `.mn-floor` and `.mn-best`
handled `top` and left the side bare; `.mn-tools` and `.mn-perf` handled
`bottom` and left the side bare; `.mn-hint`, `.mn-band` and the game-over
overlay handled nothing. On a landscape iPhone the tool row and the perf
overlay sit in a 47px cheek.

And nothing anywhere taught the game. MONUMENT asks for two judgements in one
tap — is this the right value, and is it over the tower — and shipped saying
only "Tap to set the stone". A child who does not know the value matters drops
on the first pass every time and watches the tower shear for reasons nothing on
screen explains.

## How

Chrome **overlays**; no band is reserved (reserving one costs 12% of a 568px
phone and broke a sibling's layout). The sky, the tower and the sparks still
bleed to every edge — that is what `viewport-fit=cover` is for. The promise is
only that nothing a child must read or touch lands in those two corners.

- Both readouts step **inward** past the corner squares, onto the same row as
  the host's controls: `left: calc(env(safe-area-inset-left) + 62px)` and
  `right: calc(env(safe-area-inset-right) + 62px)`, `top:
  calc(env(safe-area-inset-top) + 13px)`. 62 and 13 are `HOST_MARGIN +
  HOST_CONTROL + gutter` and `HOST_PROGRESS_H + HOST_MARGIN`, imported from the
  shared module, not hardcoded.
- Every other edge fixed: `.mn-tools` right, `.mn-perf` left, `.mn-hint`
  bottom, `.mn-band` side padding, `.mn-over` padding on all four.
- New `src/ui/place.ts` owns the geometry in **both dialects at once** — the
  `calc(env(…))` strings `hud.ts` interpolates into its stylesheet, and the
  same numbers as `hudRects()`. `env()` cannot be read from JS, so this is the
  only way a test can assert what actually ships. `place.test.ts` drives
  `hudRects()`, not a re-implementation.
- Pushing the readout in from the corner moved it *toward* the centred equation
  plate, which on a landscape tablet is 80px of numeral against 18% of 768. The
  plate's `top` is now `max(18%, below the readout)` — built from the same
  constants — so "the plate never touches the floor count" holds by
  construction at every shape. 18% still wins on every phone.
- `createInstructions(el, …)` in `mount`, `guide.destroy()` in `unmount`. It
  mounts on `el` rather than on `holder`, so a tap on the panel is not also a
  tap that drops a stone — `holder` is what listens for the drop.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/stack`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place, no
      `voiceId` renamed, no catalog entry dropped. `dynawalla.stack@0.1.0`
      rebuilds and stages clean.
- [x] **Native integrity.** No native/Rust/Tauri file touched.
- [x] **Strings.** No corpan-app locale key added or changed. The new strings
      are the pack's own how-to-play copy, written for a 7–11 year old.
- [x] **Curriculum.** No skill id, grade or generator touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

## Proof

The clearance test is worthless if it passes either way, so it was proven RED
first: reverting the placement in `place.ts` to the shipped values
(`left: 14px`, `top: max(10px, env(top))`) fails immediately —

```
✖ nothing a child must read or touch lands in the host's two corners (0.890958ms)
  AssertionError [ERR_ASSERTION]: 320x568: the floor is under host chrome — x 14.0..142.8, y 10.0..50.0 vs x 10.0..54.0, y 13.0..57.0 and x 266.0..310.0, y 13.0..57.0
```

Five consecutive `npm test` runs (`dynawalla/games/stack`, node 24.18.0):

```
===== run 1 =====      ===== run 2 =====      ===== run 3 =====
ℹ tests 36             ℹ tests 36             ℹ tests 36
ℹ pass 36              ℹ pass 36              ℹ pass 36
ℹ fail 0               ℹ fail 0               ℹ fail 0

===== run 4 =====      ===== run 5 =====
ℹ tests 36             ℹ tests 36
ℹ pass 36              ℹ pass 36
ℹ fail 0               ℹ fail 0
```

The four new tests, from `src/ui/place.test.ts`, each across 320x568, 390x844,
768x1024, 1024x768 and 844x390, with and without a notch (portrait insets for
portrait shapes, landscape for landscape):

```
✔ nothing a child must read or touch lands in the host's two corners
✔ the floor count and the best score never run into each other
✔ the equation plate never touches the floor count
✔ every readout stays inside the safe area
```

`npm run tsc` — 0 errors:

```
> @dynawalla/game-stack@0.1.0 tsc
> tsc --noEmit
```

`npm run build`:

```
dist/assets/index-DeyjAkAo.js  607.57 kB │ gzip: 159.95 kB
✓ built in 121ms
```

`node build.mjs stack`, from `dynawalla/packs/`:

```
dynawalla.stack@0.1.0 — MONUMENT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 612184 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`:

```
INF 1 commits scanned.
INF scanned ~18313 bytes (18.31 KB) in 37.7ms
INF no leaks found
```

Because a model of a DOM layout is only as good as its agreement with the real
stylesheet, the built page was also driven headless at three viewports and the
live `getBoundingClientRect()` of each element compared to `hudRects()`. Every
anchored edge matches exactly, and the model is the conservative side of the
live box everywhere (it assumes a 3-digit floor and a 14-character equation):

```
320x568
  floor   live x 62..133.6 y 13..47.0     model x 62.0..190.8 y 13.0..53.0
  best    live x 227.3..258.0 y 13..42.0  model x 227.0..258.0 y 13.0..41.8
  prompt  live x 104.4..215.5 y 77.5..126.9
  help (host chrome, live) x 266..310 y 10..54
1024x768
  floor   live x 62..168.0 y 13..81.5     model x 62.0..284.5 y 13.0..93.6
  best    live x 921..962.0 y 13..60.0    model x 910.5..962.0 y 13.0..58.6
  help (host chrome, live) x 970..1014 y 10..54
844x390
  floor   live x 62..134.0 y 13..47.8     model x 62.0..192.7 y 13.0..54.0
  best    live x 751.3..782.0 y 13..42.0  model x 751.0..782.0 y 13.0..42.5
  help (host chrome, live) x 790..834 y 10..54
```

Scope: only `dynawalla/games/stack/` changed; `git diff origin/main..HEAD
--diff-filter=D --name-only` is empty.
