### PR TITLE
dynawalla/games/serpent: a canvas cannot read env(), so the HUD went under the notch

### DIFF
--- a/dynawalla/games/serpent/src/game/mount.ts
+++ b/dynawalla/games/serpent/src/game/mount.ts
@@ -7,11 +7,17 @@
  * is the entire point of hitstop.
  */
 
+import {
+  createInstructions,
+  onInsetsChange,
+  safeInsets,
+} from "../../../../packs/shared/game-chrome/index.ts";
 import type { Host, Mounted } from "../contract.ts";
 import { createAudio } from "./audio.ts";
 import { createInput } from "./input.ts";
 import { simDelta, updateCamera } from "./fx/camera.ts";
 import { createRenderer, type View } from "./render/scene.ts";
+import { hudLayout, soundTarget } from "./render/chrome.ts";
 import { drawHud } from "./render/hud.ts";
 import { confirmPressed, createWorld, stepWorld, type World } from "./world.ts";
 import { clamp } from "./num.ts";
@@ -59,9 +65,15 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
     const rect = el.getBoundingClientRect();
     const w = Math.max(200, Math.round(rect.width || window.innerWidth));
     const h = Math.max(200, Math.round(rect.height || window.innerHeight));
-    renderer.resize(w, h, Math.min(window.devicePixelRatio || 1, 2.5));
+    // Measured every layout, never cached from mount: a rotation trades one top
+    // inset for two side ones, and iPadOS changes them when the pack is resized
+    // in Split View. Read once and you are correct until the first rotation.
+    renderer.resize(w, h, Math.min(window.devicePixelRatio || 1, 2.5), safeInsets());
   }
   layout();
+  // A rotation does not always change the element's box — a square-ish split
+  // view can rotate and keep its size — but it always changes the insets.
+  const stopInsets = onInsetsChange(() => layout());
 
   const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => layout()) : null;
   ro?.observe(el);
@@ -90,15 +102,18 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
   let showDebug = false;
   let disposed = false;
 
+  /**
+   * Does this tap land on the sound switch?
+   *
+   * The switch's position comes from the same `hudLayout` the renderer draws it
+   * with. This used to carry its own copy of the four expressions, which is one
+   * copy too many — the drawn control and its target would have parted company
+   * the moment either moved, and honouring the home indicator moves it.
+   */
   function soundHit(x: number, y: number): boolean {
     const v = renderer.view;
-    const u = Math.min(v.w, v.h);
-    const pad = Math.max(14, u * 0.045);
-    const sr = Math.max(13, u * 0.032);
-    const cx = v.w - pad - sr;
-    const cy = v.h - pad - sr;
-    const box = Math.max(24, sr * 1.9);
-    return Math.abs(x - cx) < box && Math.abs(y - cy) < box;
+    const t = soundTarget(hudLayout(v.w, v.h, v.insets));
+    return x >= t.x && x <= t.x + t.w && y >= t.y && y <= t.y + t.h;
   }
 
   function frame(t: number): void {
@@ -158,6 +173,67 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
   }
   raf = requestAnimationFrame(frame);
 
+  /* ------------------------------ how to play ---------------------------- */
+
+  // SERPENT taught nothing. A child was shown a snake, a field of numbers and
+  // the words "TAP TO DIVE", and the one rule that IS the game — that the thing
+  // written across the arena floor decides which numbers you may eat, and that
+  // it changes — was never said anywhere. Watching a tail get shorter is not an
+  // explanation. The manual stays reachable during a dive, because the moment a
+  // child needs the rules is never the title screen.
+  const guide = createInstructions(el, {
+    title: "SERPENT",
+    summary: [
+      "You are a sea snake. Numbers float in the water.",
+      "A rule is written big across the middle. Eat only the numbers that follow it.",
+    ],
+    sections: [
+      {
+        heading: "Swimming",
+        lines: [
+          "Hold your finger on the screen and drag. The snake swims that way.",
+          "Drag further from where you started and the snake goes faster.",
+          "On a keyboard, use the arrow keys. Hold shift to go faster.",
+        ],
+      },
+      {
+        heading: "The rule in the middle",
+        lines: [
+          "It says which numbers you are allowed to eat.",
+          "\u201C= 12\u201D means eat numbers that equal 12.",
+          "\u201C> 5\u201D means eat numbers bigger than 5.",
+          "\u201C< 5\u201D means eat numbers smaller than 5.",
+          "\u201C6 \u00d7 ?\u201D means eat numbers you get by counting up in sixes: 6, 12, 18, 24.",
+        ],
+      },
+      {
+        heading: "The rule changes",
+        lines: [
+          "After a while the rule in the middle swaps to a new one.",
+          "When it swaps, the numbers you were chasing may now be the wrong ones.",
+          "Read it again every time it changes. That is the whole game.",
+        ],
+      },
+      {
+        heading: "Eating",
+        lines: [
+          "Eat a right number and your tail grows longer.",
+          "Eat a wrong number and you cough up part of your tail.",
+          "Eat several right ones in a row and the ring in the corner fills up. A full ring gives you a shield.",
+        ],
+      },
+      {
+        heading: "Staying alive",
+        lines: [
+          "Do not swim into your own tail.",
+          "Do not push into the glowing edge of the water for long.",
+          "Deeper down, the water gets smaller and some numbers start chasing you.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  });
+
   return {
     world,
     view: renderer.view,
@@ -166,6 +242,8 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
     unmount(): void {
       disposed = true;
       cancelAnimationFrame(raf);
+      guide.destroy();
+      stopInsets();
       ro?.disconnect();
       window.removeEventListener("resize", layout);
       window.removeEventListener("orientationchange", layout);

--- a/dynawalla/games/serpent/src/game/render/chrome.test.ts
+++ b/dynawalla/games/serpent/src/game/render/chrome.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The HUD, at every shape the fleet actually has.
+ *
+ * SERPENT draws its whole HUD on the canvas, and a canvas cannot read
+ * `env(safe-area-inset-*)`: that is a CSS value, and `fillText` at `y = 24` has
+ * never heard of it. `pack.html` declares `viewport-fit=cover`, which opts this
+ * document *into* the display cutout and the home indicator. So the depth went
+ * under the cutout, the sound switch — a control a child taps — went under the
+ * home indicator, and the depth and the combo gauge sat in the two 44px corners
+ * the host paints its exit and how-to-play controls over.
+ *
+ * None of that is visible in `npm run dev`, all of it is certain on a device,
+ * and all of it is arithmetic. So it lives here.
+ *
+ * **Removing the fix fails this file.** Point `hudLayout` back at the raw
+ * viewport (`safe = {x:0, y:0, w, h}`) and the safe-area tests trip; set
+ * `READOUT_CLEAR` back to the old `pad` and every `hitsHostChrome` assertion
+ * trips.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  HOST_CONTROL,
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../../packs/shared/game-chrome/index.ts";
+import {
+  READOUT_CLEAR,
+  depthTarget,
+  gaugeTarget,
+  hudLayout,
+  scoreTarget,
+  soundTarget,
+} from "./chrome.ts";
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+/** A tall phone: cutout at the top, home indicator at the bottom. */
+const PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+/** The same phone on its side: the cutout becomes an inset on BOTH sides. */
+const LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+/**
+ * The insets a viewport can actually have, paired with its orientation rather
+ * than crossed with it. A 320-wide portrait phone never has 47 pixels of cutout
+ * down each side, and asserting against shapes no device produces only tempts
+ * the fix into clamping the safe area away to make an imaginary case pass.
+ */
+function insetsFor(w: number, h: number): Array<[string, Insets]> {
+  return [
+    ["no insets", NONE],
+    w > h ? ["cutout at the side", LANDSCAPE] : ["cutout at the top", PORTRAIT],
+  ];
+}
+
+/** Every readout, by the name a failure should print. */
+function readouts(w: number, h: number, insets: Insets): Array<[string, Rect]> {
+  const l = hudLayout(w, h, insets);
+  return [
+    ["the depth", depthTarget(l)],
+    ["the score", scoreTarget(l)],
+    ["the combo gauge", gaugeTarget(l)],
+    ["the sound switch", soundTarget(l)],
+  ];
+}
+
+/* -------------------------------------------------------------------------- */
+/* The host's two corners.                                                    */
+/* -------------------------------------------------------------------------- */
+
+test("nothing a child reads or taps sits under the host's chrome", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      for (const [what, rect] of readouts(w, h, insets)) {
+        assert.equal(
+          hitsHostChrome(rect, w, insets),
+          false,
+          `${name} (${w}x${h}), ${label}: ${what} is under the host's chrome`,
+        );
+      }
+    }
+  }
+});
+
+test("the readouts clear the control and no more", () => {
+  // A promise about two 44px squares, not a reserved band: reserving the whole
+  // top strip cost a sibling game 12% of a small phone's height and broke its
+  // layout outright. If this ever becomes a band it should fail here first.
+  assert.ok(READOUT_CLEAR >= HOST_CONTROL, "the readouts do not clear the control at all");
+  assert.ok(READOUT_CLEAR <= HOST_CONTROL + 24, `READOUT_CLEAR is ${READOUT_CLEAR}px — that is a band`);
+});
+
+/* -------------------------------------------------------------------------- */
+/* The safe area.                                                             */
+/* -------------------------------------------------------------------------- */
+
+test("nothing a child reads or taps leaves the safe area", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const safe = safeRect(w, h, insets);
+      for (const [what, r] of readouts(w, h, insets)) {
+        const where = `${name} (${w}x${h}), ${label}: ${what}`;
+        assert.ok(r.x >= safe.x - 1e-9, `${where} crosses the left inset`);
+        assert.ok(r.y >= safe.y - 1e-9, `${where} crosses the top inset`);
+        assert.ok(r.x + r.w <= safe.x + safe.w + 1e-9, `${where} crosses the right inset`);
+        assert.ok(r.y + r.h <= safe.y + safe.h + 1e-9, `${where} crosses the bottom inset`);
+      }
+    }
+  }
+});
+
+test("the sound switch is a target a child can actually hit", () => {
+  // It is the only control the game draws itself. Under the home indicator it
+  // was not merely ugly: an edge swipe there belongs to the OS, so the tap went
+  // to the system and the sound never changed.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const t = soundTarget(hudLayout(w, h, insets));
+      assert.ok(
+        t.w >= HOST_CONTROL && t.h >= HOST_CONTROL,
+        `${name}, ${label}: the sound target is ${t.w.toFixed(0)}x${t.h.toFixed(0)}`,
+      );
+    }
+  }
+});
+
+test("with no insets the layout is the one the game always had, only lower", () => {
+  // The safe-area work must be a no-op on a device without insets, or it is not
+  // a fix, it is a redesign. The only intended change is the vertical drop.
+  const plain = hudLayout(390, 844, NONE);
+  assert.equal(plain.safe.x, 0);
+  assert.equal(plain.safe.y, 0);
+  assert.equal(plain.safe.w, 390);
+  assert.equal(plain.safe.h, 844);
+  const u = Math.min(390, 844);
+  assert.equal(plain.pad, Math.max(14, u * 0.045));
+  assert.equal(plain.depthSize, Math.max(24, u * 0.062));
+  assert.equal(plain.scoreSize, Math.max(26, u * 0.075));
+  assert.equal(plain.scoreX, 195);
+  assert.equal(plain.depthY, READOUT_CLEAR + plain.depthSize * 0.6);
+  // The ink starts exactly where the host control ends, not a pixel lower.
+  assert.equal(depthTarget(plain).y, READOUT_CLEAR);
+});
+
+test("every readout is placed off the safe box's edges, not the glass's", () => {
+  // Asserted as an identity rather than as a delta, because a cutout also
+  // shrinks the box the type scale keys off — the readouts do not simply
+  // translate by 47px, they are re-laid-out inside a smaller room.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const l = hudLayout(w, h, insets);
+      const where = `${name}, ${label}`;
+      const right = l.safe.x + l.safe.w;
+      const bottom = l.safe.y + l.safe.h;
+      assert.ok(Math.abs(l.soundX + l.soundR + l.pad - right) < 1e-9, `${where}: the sound switch is not on the safe right edge`);
+      assert.ok(Math.abs(l.soundY + l.soundR + l.pad - bottom) < 1e-9, `${where}: the sound switch is not on the safe bottom edge`);
+      assert.ok(Math.abs(l.gaugeX + l.gaugeR + l.pad - right) < 1e-9, `${where}: the gauge is not on the safe right edge`);
+      assert.ok(l.depthX > l.safe.x, `${where}: the depth is not inside the safe left edge`);
+      assert.ok(Math.abs(l.scoreX - (l.safe.x + l.safe.w / 2)) < 1e-9, `${where}: the score is not centred in the safe box`);
+    }
+  }
+
+  // And a cutout really does move things: same viewport, insets on, everything
+  // steps inward. If this passes with the safe box replaced by the raw
+  // viewport, the fix is not in the build.
+  const plain = hudLayout(844, 390, NONE);
+  const cut = hudLayout(844, 390, LANDSCAPE);
+  assert.ok(cut.depthX > plain.depthX, "the depth did not move in from the left cutout");
+  assert.ok(cut.soundX < plain.soundX, "the sound switch did not move in from the right cutout");
+  assert.ok(cut.soundY < plain.soundY, "the sound switch did not clear the home indicator");
+});
+
+test("the readouts stay on screen even on a viewport smaller than its own insets", () => {
+  // Only reachable on an absurd surface, which is exactly when nobody is
+  // watching. A negative safe box silently flips every expression downstream.
+  for (const [w, h] of [
+    [40, 40],
+    [1, 1],
+    [200, 60],
+  ] as const) {
+    const l = hudLayout(w, h, { top: 100, right: 100, bottom: 100, left: 100 });
+    assert.ok(Number.isFinite(l.soundX) && Number.isFinite(l.soundY), "the layout produced NaN");
+    assert.ok(l.safe.w >= 0 && l.safe.h >= 0, "the safe box went negative");
+    assert.ok(l.pad > 0 && l.depthSize > 0, "a size went to zero or below");
+  }
+});

--- a/dynawalla/games/serpent/src/game/render/chrome.ts
+++ b/dynawalla/games/serpent/src/game/render/chrome.ts
@@ -1,0 +1,170 @@
+/**
+ * Where the screen-space chrome is allowed to sit.
+ *
+ * SERPENT draws its entire HUD on the canvas, and a canvas cannot read
+ * `env(safe-area-inset-*)` — that is a CSS value, and `fillText` at `y = 24` has
+ * never heard of it. `pack.html` declares `viewport-fit=cover`, which is not a
+ * neutral setting: it opts the document *into* the display cutout, the home
+ * indicator and the rounded corners. So the depth readout went under the cutout
+ * and the sound switch — a control, one a child taps — went under the home
+ * indicator.
+ *
+ * On top of that the host paints an exit control over the top-left 44px corner
+ * and a how-to-play control over the top-right one. The depth was in the first
+ * and the combo gauge in the second.
+ *
+ * **The chrome overlays; it does not reserve a band.** The water, the snow, the
+ * vignette and the arena all still fill the frame. Only the four readouts move,
+ * and they move by the smallest amount that clears a 44px square.
+ *
+ * Everything here is pure arithmetic over a viewport and a set of insets, which
+ * is the point: `chrome.test.ts` can assert it at every shape the fleet has
+ * instead of the bug being found on a device.
+ */
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../../packs/shared/game-chrome/index.ts";
+
+/** Clear air between the bottom of a host control and the readout under it. */
+const GAP = 6;
+
+/**
+ * How far below the top safe edge the two top-corner readouts start.
+ *
+ * The hairline, the control's margin, the control, and a gap — derived from the
+ * shared constants rather than typed out, so if the host moves its chrome this
+ * pack follows on the next build instead of drifting away from it.
+ */
+export const READOUT_CLEAR = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + GAP;
+
+export type HudLayout = {
+  /** The rectangle inside the insets. The playfield may leave it; readouts may not. */
+  safe: Rect;
+  /** The HUD's own margin from the safe edge. */
+  pad: number;
+  /** Type size of the depth figure, and of the small length figure under it. */
+  depthSize: number;
+  lengthSize: number;
+  /** Left edge and baseline of the depth marker's triangle. */
+  depthX: number;
+  depthY: number;
+  /** Type size of the score, and the centre it is set on. */
+  scoreSize: number;
+  scoreX: number;
+  scoreY: number;
+  /** The combo gauge: centre and radius. */
+  gaugeX: number;
+  gaugeY: number;
+  gaugeR: number;
+  /** The sound switch: centre and radius. It is a control, so it is also a target. */
+  soundX: number;
+  soundY: number;
+  soundR: number;
+  /** Baseline of the lowest debug line. */
+  debugBottom: number;
+};
+
+/**
+ * The whole HUD, as numbers.
+ *
+ * `insets` is a required argument on purpose. An optional safe area is a game
+ * that forgets to pass one, compiles clean, and draws its score under the
+ * cutout — a defect that only exists on hardware, which is the worst place to
+ * discover anything.
+ */
+export function hudLayout(w: number, h: number, insets: Insets): HudLayout {
+  const safe = safeRect(w, h, insets);
+  // The type scale keys off the short side of the SAFE box, not the viewport:
+  // in landscape the cutout takes 94px off the width, and sizing off a width
+  // the game cannot use makes the figures overhang the part it can.
+  const u = Math.max(1, Math.min(safe.w, safe.h));
+  const pad = Math.max(14, u * 0.045);
+
+  const depthSize = Math.max(24, u * 0.062);
+  const tri = depthSize * 0.3;
+  const scoreSize = Math.max(26, u * 0.075);
+  const gaugeR = Math.max(15, u * 0.042);
+  const soundR = Math.max(13, u * 0.032);
+
+  // The two top corners belong to the host. The depth and the gauge drop under
+  // them; the score sits between them and keeps its own top margin, because the
+  // middle of the top edge is the one part of it nothing is painted over.
+  const top = safe.y + READOUT_CLEAR;
+
+  return {
+    safe,
+    pad,
+    depthSize,
+    lengthSize: Math.max(11, u * 0.028),
+    depthX: safe.x + pad + tri * 0.6,
+    // The figures are set with `textBaseline = "middle"`, so half the ink is
+    // ABOVE this line. Dropping the centre by the control's height would still
+    // have left the top of the numeral inside the corner on a tablet, where the
+    // type scale is largest — which is exactly how this was found.
+    depthY: top + depthSize * 0.6,
+    scoreSize,
+    scoreX: safe.x + safe.w / 2,
+    scoreY: safe.y + pad + scoreSize * 0.6,
+    gaugeX: safe.x + safe.w - pad - gaugeR,
+    // Measured to the SHIELD ring, which is drawn at 1.5x the gauge's radius.
+    // Clearing the control by the gauge alone left the shield poking up into
+    // the corner, and the shield is the one thing on that dial a child watches
+    // for — it is the reward for six right answers in a row.
+    gaugeY: top + gaugeR * 1.5,
+    gaugeR,
+    soundX: safe.x + safe.w - pad - soundR,
+    soundY: safe.y + safe.h - pad - soundR,
+    soundR,
+    debugBottom: safe.y + safe.h - pad,
+  };
+}
+
+/**
+ * The square the sound switch answers taps in.
+ *
+ * Shared by the renderer and by `mount.ts`'s hit test, which used to carry its
+ * own copy of the same four expressions. Two copies of a control's position is
+ * one copy too many: they drifted the moment either moved.
+ */
+export function soundTarget(l: HudLayout): Rect {
+  const box = Math.max(24, l.soundR * 1.9);
+  return { x: l.soundX - box, y: l.soundY - box, w: box * 2, h: box * 2 };
+}
+
+/**
+ * The box the depth readout's ink occupies.
+ *
+ * Both figures are set `textBaseline = "middle"` and `textAlign = "center"`, so
+ * the ink straddles the baseline rather than sitting on it. Getting that
+ * backwards is how a readout ends up half a numeral inside a button.
+ */
+export function depthTarget(l: HudLayout): Rect {
+  const left = l.depthX - l.depthSize * 0.2;
+  // The marker, the gap, and up to four figures of depth at roughly 0.6em each.
+  const right = l.depthX + l.depthSize * (0.48 + 0.22 + 1.2);
+  const top = l.depthY - l.depthSize * 0.6;
+  const bottom = l.depthY + l.depthSize * 0.72 + l.lengthSize * 0.6;
+  return { x: left, y: top, w: right - left, h: bottom - top };
+}
+
+/** The box the combo gauge occupies, including the shield ring outside it. */
+export function gaugeTarget(l: HudLayout): Rect {
+  const r = l.gaugeR * 1.5;
+  return { x: l.gaugeX - r, y: l.gaugeY - r, w: r * 2, h: r * 2 };
+}
+
+/** The box the score and the best-so-far line occupy, for tests. */
+export function scoreTarget(l: HudLayout): Rect {
+  // Six figures is more score than a run produces, which is what a clearance
+  // box wants to be: wider than the thing it stands for.
+  const w = l.scoreSize * 3.6;
+  const top = l.scoreY - l.scoreSize * 0.6;
+  const bottom = l.scoreY + l.scoreSize * 0.68 + l.scoreSize * 0.35;
+  return { x: l.scoreX - w / 2, y: top, w, h: bottom - top };
+}

--- a/dynawalla/games/serpent/src/game/render/hud.ts
+++ b/dynawalla/games/serpent/src/game/render/hud.ts
@@ -11,6 +11,7 @@ import { TAU, clamp, easeOutCubic } from "../num.ts";
 import { COLORS, TUNE } from "../tuning.ts";
 import { stickBoostPush, stickRadiusPx, type Pointer } from "../input.ts";
 import type { World } from "../world.ts";
+import { hudLayout } from "./chrome.ts";
 import { drawLabel, type LabelStyle } from "./glyphs.ts";
 import type { View } from "./scene.ts";
 
@@ -36,19 +37,23 @@ const base: LabelStyle = {
 const styled = (over: Partial<LabelStyle>): LabelStyle => ({ ...base, ...over });
 
 export function drawHud(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
-  const u = Math.min(view.w, view.h);
-  const pad = Math.max(14, u * 0.045);
+  // Every position in this file comes out of `chrome.ts`, which knows about the
+  // display cutout, the home indicator and the host's two 44px corners. Nothing
+  // here measures off `view.w` and `view.h` any more: those are the glass, and
+  // the glass is not all ours.
+  const l = hudLayout(view.w, view.h, view.insets);
+  const u = Math.max(1, Math.min(l.safe.w, l.safe.h));
   const dpr = view.dpr;
 
-  // --- depth, top left ----------------------------------------------------
-  const depthSize = Math.max(24, u * 0.062);
+  // --- depth, under the host's exit control --------------------------------
+  const depthSize = l.depthSize;
   const dp = easeOutCubic(w.depthPulse);
   g.save();
   g.globalAlpha = 0.9;
   g.fillStyle = COLORS.rim;
   const tri = depthSize * 0.3;
-  const tx = pad + tri * 0.6;
-  const ty = pad + depthSize * 0.62;
+  const tx = l.depthX;
+  const ty = l.depthY;
   g.beginPath();
   g.moveTo(tx - tri * 0.62, ty - tri * 0.45);
   g.lineTo(tx + tri * 0.62, ty - tri * 0.45);
@@ -67,7 +72,7 @@ export function drawHud(g: CanvasRenderingContext2D, view: View, w: World, o: Hu
     0.95,
   );
 
-  const lengthSize = Math.max(11, u * 0.028);
+  const lengthSize = l.lengthSize;
   drawLabel(
     g,
     `${Math.round(w.serpent.targetSegments)}`,
@@ -79,15 +84,15 @@ export function drawHud(g: CanvasRenderingContext2D, view: View, w: World, o: Hu
     0.9,
   );
 
-  // --- score, top centre --------------------------------------------------
-  const scoreSize = Math.max(26, u * 0.075);
+  // --- score, top centre: the one part of the top edge nothing is painted over
+  const scoreSize = l.scoreSize;
   const sp = easeOutCubic(w.scorePulse);
   drawLabel(
     g,
     String(w.score),
     styled({ size: scoreSize, fill: "#ffffff" }),
-    view.cx,
-    pad + scoreSize * 0.6,
+    l.scoreX,
+    l.scoreY,
     dpr,
     1 + sp * 0.12,
     0.97,
@@ -97,18 +102,18 @@ export function drawHud(g: CanvasRenderingContext2D, view: View, w: World, o: Hu
       g,
       String(w.best),
       styled({ size: Math.max(10, u * 0.026), fill: "rgba(255,215,106,0.7)" }),
-      view.cx,
-      pad + scoreSize * 1.28,
+      l.scoreX,
+      l.scoreY + scoreSize * 0.68,
       dpr,
       1,
       0.9,
     );
   }
 
-  // --- combo gauge, top right ---------------------------------------------
-  const gaugeR = Math.max(15, u * 0.042);
-  const gx = view.w - pad - gaugeR;
-  const gy = pad + gaugeR;
+  // --- combo gauge, under the host's how-to-play control -------------------
+  const gaugeR = l.gaugeR;
+  const gx = l.gaugeX;
+  const gy = l.gaugeY;
   const frac = w.combo / TUNE.comboMax;
   g.save();
   g.lineCap = "round";
@@ -147,10 +152,10 @@ export function drawHud(g: CanvasRenderingContext2D, view: View, w: World, o: Hu
     g.restore();
   }
 
-  // --- sound switch, bottom right -----------------------------------------
-  const sr = Math.max(13, u * 0.032);
-  const sx = view.w - pad - sr;
-  const sy = view.h - pad - sr;
+  // --- sound switch, bottom right, clear of the home indicator -------------
+  const sr = l.soundR;
+  const sx = l.soundX;
+  const sy = l.soundY;
   g.save();
   g.globalAlpha = o.soundOn ? 0.55 : 0.3;
   g.fillStyle = COLORS.ink;
@@ -223,7 +228,7 @@ function scrim(g: CanvasRenderingContext2D, view: View, alpha: number): void {
 }
 
 function drawAttract(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
-  const u = Math.min(view.w, view.h);
+  const u = Math.max(1, Math.min(view.safe.w, view.safe.h));
   scrim(g, view, 0.42);
   const titleSize = Math.max(34, u * 0.13);
   drawLabel(
@@ -250,7 +255,7 @@ function drawAttract(g: CanvasRenderingContext2D, view: View, w: World, o: HudOp
 }
 
 function drawGameOver(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
-  const u = Math.min(view.w, view.h);
+  const u = Math.max(1, Math.min(view.safe.w, view.safe.h));
   const k = clamp(w.deathT / 0.7, 0, 1);
   scrim(g, view, 0.5 * k);
   const e = easeOutCubic(k);
@@ -291,7 +296,7 @@ function drawGameOver(g: CanvasRenderingContext2D, view: View, w: World, o: HudO
 }
 
 function drawPaused(g: CanvasRenderingContext2D, view: View): void {
-  const u = Math.min(view.w, view.h);
+  const u = Math.max(1, Math.min(view.safe.w, view.safe.h));
   scrim(g, view, 0.5);
   drawLabel(
     g,
@@ -311,14 +316,15 @@ function drawDebug(g: CanvasRenderingContext2D, view: View, w: World, o: HudOpti
     `body ${w.serpent.bodyCount}   orbs ${w.orbs.length}   particles ${w.particles.count}   rings ${w.rings.count}`,
     `answer ${w.lastAnswerMs}ms   depth ${w.depth}   arena ${w.arenaR.toFixed(3)}   ${w.prompt}`,
   ];
-  const size = Math.max(10, Math.min(view.w, view.h) * 0.022);
-  let y = view.h - size * 3.6;
+  const l = hudLayout(view.w, view.h, view.insets);
+  const size = Math.max(10, Math.min(l.safe.w, l.safe.h) * 0.022);
+  let y = l.debugBottom - size * 2.6;
   for (const line of lines) {
     drawLabel(
       g,
       line,
       styled({ size, fill: "rgba(180,255,230,0.85)", weight: 600, outlineWidth: 3 }),
-      view.w / 2,
+      l.safe.x + l.safe.w / 2,
       y,
       view.dpr,
       1,

--- a/dynawalla/games/serpent/src/game/render/scene.ts
+++ b/dynawalla/games/serpent/src/game/render/scene.ts
@@ -17,18 +17,44 @@ import { TAU, clamp, easeOutBack, easeOutCubic, easeOutExpo } from "../num.ts";
 import { COLORS, TUNE } from "../tuning.ts";
 import { bolusTintAt } from "../serpent.ts";
 import { orbDrawRadius } from "../orbs.ts";
+import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
 import type { World } from "../world.ts";
 import { GLOW_PX, MOTE_PX, sprites } from "./sprites.ts";
 import { drawLabel, labelWidth, type LabelStyle } from "./glyphs.ts";
 import { PK_BUBBLE, PK_MOTE, PK_SHARD } from "../fx/particles.ts";
 
-export type View = { cx: number; cy: number; scale: number; w: number; h: number; dpr: number };
+/**
+ * The frame, as the renderer sees it.
+ *
+ * `safe` is the rectangle inside the display cutout and the home indicator. The
+ * water, the snow and the vignette ignore it and fill the whole viewport, which
+ * is what `viewport-fit=cover` is for; the arena and every readout are laid out
+ * inside it, because a rim a child cannot see is a wall they die on and a figure
+ * under the cutout is a figure nobody reads.
+ */
+export type View = {
+  cx: number;
+  cy: number;
+  scale: number;
+  w: number;
+  h: number;
+  dpr: number;
+  /** The measured safe-area insets. Everything a child reads is laid out inside them. */
+  insets: Insets;
+  /** The viewport minus those insets. */
+  safe: { x: number; y: number; w: number; h: number };
+};
 
 type Snow = { x: number; y: number; r: number; vy: number; vx: number; a: number; phase: number };
 
 export type Renderer = {
   view: View;
-  resize(w: number, h: number, dpr: number): void;
+  /**
+   * `insets` is required, not optional. A defaulted safe area is a game that
+   * forgets to measure one, compiles clean, and draws under the cutout — which
+   * is a defect that exists only on hardware.
+   */
+  resize(w: number, h: number, dpr: number, insets: Insets): void;
   draw(world: World, stickAlpha: number): void;
   toWorld(clientX: number, clientY: number, rect: DOMRect): { x: number; y: number };
 };
@@ -57,7 +83,16 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
   const g: CanvasRenderingContext2D = ctx;
   const sp = sprites();
 
-  const view: View = { cx: 0, cy: 0, scale: 1, w: 1, h: 1, dpr: 1 };
+  const view: View = {
+    cx: 0,
+    cy: 0,
+    scale: 1,
+    w: 1,
+    h: 1,
+    dpr: 1,
+    insets: NO_INSETS,
+    safe: { x: 0, y: 0, w: 1, h: 1 },
+  };
   let bg: HTMLCanvasElement | null = null;
   const snowFar: Snow[] = [];
   const snowNear: Snow[] = [];
@@ -134,13 +169,20 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     }
   }
 
-  function resize(w: number, h: number, dpr: number): void {
+  function resize(w: number, h: number, dpr: number, insets: Insets): void {
+    const safe = safeRect(w, h, insets);
     view.w = w;
     view.h = h;
     view.dpr = dpr;
-    view.cx = w / 2;
-    view.cy = h / 2;
-    view.scale = Math.min(w, h) * 0.44;
+    view.insets = insets;
+    view.safe = safe;
+    // The arena is centred in the SAFE box and sized off its short side. On a
+    // device with no insets this is exactly what it always was; on a phone held
+    // sideways it stops the rim — a wall you can die against — from sliding
+    // under the rounded corner.
+    view.cx = safe.x + safe.w / 2;
+    view.cy = safe.y + safe.h / 2;
+    view.scale = Math.min(safe.w, safe.h) * 0.44;
     canvas.width = Math.max(1, Math.floor(w * dpr));
     canvas.height = Math.max(1, Math.floor(h * dpr));
     canvas.style.width = `${w}px`;


### PR DESCRIPTION
## What

Adopt the shared game chrome in **SERPENT** (`dynawalla/games/serpent`): lay the
canvas HUD out inside the measured safe area, move the depth and the combo gauge
out of the host's two 44px corners, and add a how-to-play manual — the game
previously taught nothing at all.

## Why

**A canvas cannot read `env()`.** `pack.html` declares `viewport-fit=cover`,
which is not a neutral setting: it opts the document *into* the display cutout,
the home indicator and the rounded corners. A DOM HUD can claw that back with
`padding: env(safe-area-inset-top)`. SERPENT's HUD is entirely `fillText` and
`arc` on the canvas, and `env()` is a CSS value — a canvas has never heard of
it. So the depth readout drew under the cutout, and the **sound switch**, the
one control the game draws itself, drew under the home indicator, where an edge
swipe belongs to the OS and the tap never reaches the pack at all.

**The host's two corners.** The app paints an exit control top-left and a
how-to-play control top-right, over the pack. The depth was in the first and the
combo gauge in the second.

`render/chrome.ts` is now the single place any of it is decided.
`hudLayout(w, h, insets)` takes **required** insets — an optional safe area is a
game that forgets to pass one, compiles clean, and is discovered on hardware.
The renderer's `View` carries the measured insets; `mount` re-measures on every
layout *and* on `onInsetsChange`, because a rotation trades one top inset for
two side ones and iPadOS changes them in Split View.

The chrome **overlays** — no band is reserved. The water, the vignette and the
marine snow still fill the whole frame. Only the four readouts move. The one
playfield change is that the arena is now centred and sized inside the safe box:
its rim is a wall you can die against, and a wall under a rounded corner is a
death a child cannot see coming.

**Two things this shook out.**

- The combo gauge has to clear the corner by its **shield ring at 1.5× the
  radius**, not by the gauge itself. Clearing by the gauge left the shield
  poking into the button, and the shield is what a child watches for — it is the
  reward for six right answers in a row.
- The figures are set `textBaseline = "middle"`, so **half the ink is above the
  line**. Dropping the centre by the control's height still left the top of the
  numeral inside the button at 768×1024, where the type scale is largest. The
  test caught it; a browser window never would.

`mount.ts`'s sound hit-test also carried its own copy of the switch's four
coordinates. Two copies of a control's position is one copy too many — they
would have parted company the moment either moved, and honouring the home
indicator moves it. Both now come from `hudLayout`.

**How to play.** A child was shown a snake, a field of numbers and the words
"TAP TO DIVE". The one rule that *is* the game — that the thing written across
the arena floor decides which numbers you may eat, and that it **changes** — was
never stated anywhere. Watching your tail get shorter is not an explanation.

`world.test.ts`'s seeded `Math.random` pin is untouched.

## Blast radius

**Areas touched:** dynawalla (one game pack)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched: same id, same version, same
      capabilities (`items`, `items.reveal`, `haptics`), same 8 `covers.skills`.
      No catalog entry changed, no published zip changed in place.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifests.
- [x] **Strings.** N/A — no `corpan-app` locale keys. The new strings are the
      pack's own instruction copy, written for a 7–11 year old.
- [x] **Curriculum.** N/A — no skill ids, generators or schemas touched.
- [x] **Secrets.** None. `gitleaks` output below.

## Proof

```
$ cd dynawalla/games/serpent && for i in 1 2 3 4 5; do npm test; done
run 1: # pass 38 # fail 0
run 2: # pass 38 # fail 0
run 3: # pass 38 # fail 0
run 4: # pass 38 # fail 0
run 5: # pass 38 # fail 0

$ npm run tsc
> tsc --noEmit
(no output — 0 errors)

$ npm run build
✓ 25 modules transformed.
dist/serpent.js  86.16 kB │ gzip: 26.97 kB
✓ built in 19ms

$ cd ../../packs && node build.mjs serpent
dynawalla.serpent@0.1.0 — SERPENT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       8 skills, grades 1–5
  on disk      3 files, 71067 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~22628 bytes (22.63 KB) in 37.1ms
INF no leaks found

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)

$ git diff --name-only origin/main...HEAD
dynawalla/games/serpent/src/game/mount.ts
dynawalla/games/serpent/src/game/render/chrome.test.ts
dynawalla/games/serpent/src/game/render/chrome.ts
dynawalla/games/serpent/src/game/render/hud.ts
dynawalla/games/serpent/src/game/render/scene.ts
```

### The clearance test fails without the fix

A clearance test that passes either way is worthless, so each fix was removed on
its own and the suite re-run:

```
### FIX 1 REMOVED (hudLayout pointed back at the raw viewport) ###
not ok 1 - nothing a child reads or taps sits under the host's chrome
not ok 3 - nothing a child reads or taps leaves the safe area
not ok 6 - every readout is placed off the safe box's edges, not the glass's
# pass 4
# fail 3

### FIX 2 REMOVED (READOUT_CLEAR back to the old pad) ###
not ok 1 - nothing a child reads or taps sits under the host's chrome
not ok 2 - the readouts clear the control and no more
not ok 5 - with no insets the layout is the one the game always had, only lower
# pass 4
# fail 3

### RESTORED ###
# pass 38
# fail 0
```

Viewports swept: 320×568, 390×844, 768×1024, 1024×768, 844×390 — each with no
insets and with the insets its own orientation actually produces.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
