### PR TITLE
dynawalla/games/mosaic: the HUD moves inside the safe area and out of the host's two corners

### DIFF
--- a/dynawalla/games/mosaic/src/fx/hud.test.ts
+++ b/dynawalla/games/mosaic/src/fx/hud.test.ts
@@ -1,0 +1,151 @@
+// The HUD's two promises, asserted at every viewport MOSAIC ships to.
+//
+//   1. Nothing a child must READ lands in the host's two 44px corners. The host
+//      paints an exit control top-left and a how-to-play control top-right, over
+//      the game, and does not reserve a band for them.
+//   2. Nothing a child must read lands outside the safe rect, on a device with a
+//      notch or a home indicator.
+//
+// Both used to be false. At 320x568 with no insets the cleared-fraction dial sat
+// at screen 12.8..34.5 in both axes and the exit square is 10..54 by 13..57 —
+// dead centre under it — and the right-aligned score sat under the help square.
+// At 768x1024 the dial collided too. This is a canvas HUD, so `env()` was never
+// reachable and there was nothing on the device to notice it with.
+//
+// Tablet and desktop are first-class here. Landscape is not a stretched phone:
+// there the piers hold both corners outside the play rect entirely, the mapped
+// squares do not overlap anything, and the layout correctly does not move.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  hitsHostChrome,
+  NO_INSETS,
+  safeRect,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { fitPlay, hudLayout, toScreenRect } from "./hud.ts";
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["small phone portrait", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+// Every rule shape the game can put on the plate, shortest and longest, because
+// the plate's width decides whether it can reach a corner at all.
+const BANNERS = ["× 6", "24 ÷ ▪", "= 1/2", "> 40", "= 50%", "1000 ÷ ▪"];
+
+/** A notched phone held upright, and the same phone turned on its side. */
+const PORTRAIT_NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+const LANDSCAPE_NOTCH: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const CASES: Array<[string, Insets]> = [
+  ["no insets", NO_INSETS],
+  ["notched, upright", PORTRAIT_NOTCH],
+  ["notched, on its side", LANDSCAPE_NOTCH],
+];
+
+const inside = (a: { x: number; y: number; w: number; h: number }, b: typeof a): boolean =>
+  a.x >= b.x - 0.01 &&
+  a.y >= b.y - 0.01 &&
+  a.x + a.w <= b.x + b.w + 0.01 &&
+  a.y + a.h <= b.y + b.h + 0.01;
+
+for (const [vpName, w, h] of VIEWPORTS) {
+  for (const [caseName, insets] of CASES) {
+    test(`the HUD clears the host's corners at ${vpName} (${w}×${h}), ${caseName}`, () => {
+      const area = safeRect(w, h, insets);
+      const view = fitPlay(w, h, area);
+      for (const banner of BANNERS) {
+        const l = hudLayout(view, insets, banner);
+        for (const [name, box] of Object.entries(l.boxes)) {
+          const screen = toScreenRect(box, view);
+          assert.equal(
+            hitsHostChrome(screen, w, insets),
+            false,
+            `${vpName} ${caseName} "${banner}": the ${name} is under host chrome ` +
+              `(${screen.x.toFixed(1)},${screen.y.toFixed(1)} ` +
+              `${screen.w.toFixed(1)}×${screen.h.toFixed(1)})`,
+          );
+        }
+      }
+    });
+
+    test(`the HUD stays inside the safe rect at ${vpName} (${w}×${h}), ${caseName}`, () => {
+      const area = safeRect(w, h, insets);
+      const view = fitPlay(w, h, area);
+      for (const banner of BANNERS) {
+        const l = hudLayout(view, insets, banner);
+        for (const [name, box] of Object.entries(l.boxes)) {
+          const screen = toScreenRect(box, view);
+          assert.ok(
+            inside(screen, area),
+            `${vpName} ${caseName} "${banner}": the ${name} is outside the safe rect ` +
+              `(${screen.x.toFixed(1)},${screen.y.toFixed(1)} ` +
+              `${screen.w.toFixed(1)}×${screen.h.toFixed(1)} vs ` +
+              `${area.x},${area.y} ${area.w}×${area.h})`,
+          );
+        }
+      }
+    });
+  }
+}
+
+test("the play rect is fitted inside the safe rect, not the canvas", () => {
+  // The failure this replaces: `viewport-fit=cover` opts the document into the
+  // notch, and a canvas cannot read `env()` back, so the window filled the whole
+  // screen and the HUD went under the hardware.
+  const insets = PORTRAIT_NOTCH;
+  const area = safeRect(390, 844, insets);
+  const view = fitPlay(390, 844, area);
+  assert.ok(view.playY >= insets.top, `play rect starts at ${view.playY}, above the notch`);
+  assert.ok(
+    view.playY + view.playH <= 844 - insets.bottom + 0.01,
+    "the play rect runs under the home indicator",
+  );
+  assert.ok(view.playX >= 0 && view.playX + view.playW <= 390.01);
+});
+
+test("the background still bleeds: the play rect is smaller than the canvas it sits in", () => {
+  // Full bleed is the point of `viewport-fit=cover`. What moves inside the safe
+  // rect is what must be READ; the gradient and the stone piers still fill the
+  // canvas, and the leftover they fill is no longer symmetric.
+  const insets = PORTRAIT_NOTCH;
+  const view = fitPlay(390, 844, safeRect(390, 844, insets));
+  const top = view.playY;
+  const bottom = 844 - view.playY - view.playH;
+  assert.ok(top > 0 && bottom > 0, "there is stone to draw above and below the window");
+  assert.notEqual(Math.round(top), Math.round(bottom));
+});
+
+test("landscape leaves the layout alone, because the corners fall on the piers", () => {
+  // A guard against over-correction: the aspect clamp already holds both host
+  // squares outside the play rect in landscape, so mapping them in must move
+  // nothing. If this starts failing, the clearance push has grown a branch.
+  const wide = fitPlay(1024, 768, safeRect(1024, 768, NO_INSETS));
+  const l = hudLayout(wide, NO_INSETS, "× 6");
+  assert.equal(l.dial.cy, 74);
+  assert.equal(l.banner.cy, 78);
+  assert.equal(l.right.scoreY, 58);
+});
+
+test("portrait pushes the dial and the score column down, and says by how much", () => {
+  // The numbers this game shipped with, and the numbers it ships with now.
+  const view = fitPlay(320, 568, safeRect(320, 568, NO_INSETS));
+  const l = hudLayout(view, NO_INSETS, "× 6");
+  // The exit square is 10..54 by 13..57 CSS px; at scale 0.32 that is
+  // 31.3..168.8 by 40.6..178.1 virtual units, and the dial rested at 40..108.
+  assert.ok(l.dial.cy > 74, `the dial did not move: ${l.dial.cy}`);
+  assert.ok(
+    l.dial.cy - l.dial.r >= 178.1,
+    `the dial's top is ${l.dial.cy - l.dial.r}, still inside the exit square`,
+  );
+  assert.ok(l.right.scoreY > 58, `the score did not move: ${l.right.scoreY}`);
+  // And the wall the tiles hang on starts far below all of it, so nothing the
+  // push moved has landed on the playfield.
+  assert.ok(l.right.comboY + 35 < Math.max(150, view.vh * 0.28));
+});

--- a/dynawalla/games/mosaic/src/fx/hud.ts
+++ b/dynawalla/games/mosaic/src/fx/hud.ts
@@ -1,0 +1,240 @@
+/**
+ * Where the play rect goes, and where the HUD goes inside it.
+ *
+ * Two facts about the frame MOSAIC is handed, neither of which it used to know:
+ *
+ * **The safe area.** `pack.html` declares `viewport-fit=cover`, which is not a
+ * neutral setting — it opts the document *into* the notch, the home indicator
+ * and the rounded corners. A DOM HUD claws that back with `env(safe-area-inset-
+ * *)`. MOSAIC's HUD is drawn on a canvas, where `env()` is unreachable, so it
+ * drew the cleared-fraction dial and the score straight under the notch.
+ * `fitPlay` therefore fits the aspect-clamped window inside the SAFE rect
+ * instead of inside the whole canvas. The background gradient and the stone
+ * piers still fill the whole canvas — a full-bleed nave under the notch is what
+ * `cover` is for. It is what a child must READ that moves.
+ *
+ * **The host's two corners.** The host paints an exit control top-left and the
+ * shared how-to-play control top-right, each a 44px square, OVER the game. It
+ * does not reserve a band: reserving one cost 12% of a 568px phone's height and
+ * broke a sibling game's own layout outright. So a game promises only that
+ * nothing a child must read or touch lands in those two squares.
+ *
+ * At 320x568 with no insets MOSAIC broke that promise twice: the dial sat at
+ * screen 12.8..34.5 in both axes and the exit square is 10..54 x 13..57, and the
+ * right-aligned score sat under the help square. `hudLayout` maps the two
+ * squares back into virtual units and pushes the dial, the score column and the
+ * rule banner clear of whichever of them overlaps horizontally. Where the corner
+ * falls outside the play rect entirely — landscape, where the piers hold it out
+ * there — the mapped rect does not overlap and nothing moves.
+ *
+ * Everything here is pure arithmetic so the promise can be asserted in a test at
+ * every viewport, rather than discovered on a device.
+ */
+
+import { exitRect, helpRect, type Insets, type Rect } from "../../../../packs/shared/game-chrome/index.ts";
+import { VW } from "../game/state.ts";
+
+/** The window is always a window: a wide desktop gets piers, not a squashed wall. */
+export const ASPECT_MIN = 1.06;
+export const ASPECT_MAX = 1.86;
+
+export type Box = { x: number; y: number; w: number; h: number };
+
+/** The play rect, and the virtual-unit frame drawn inside it. */
+export type View = {
+  cssW: number;
+  cssH: number;
+  playX: number;
+  playY: number;
+  playW: number;
+  playH: number;
+  /** CSS pixels per virtual unit. */
+  scale: number;
+  /** The virtual playfield height, given `VW` across. */
+  vh: number;
+};
+
+/**
+ * Fit the aspect-clamped play rect inside `area` — the SAFE rect, not the
+ * canvas.
+ *
+ * `area` is required rather than defaulted. Made optional, a caller that forgets
+ * it compiles, runs, and quietly draws under the notch, and the only way to find
+ * that out is on a device with a notch.
+ */
+export function fitPlay(cssW: number, cssH: number, area: Rect): View {
+  const w = Math.max(1, area.w);
+  const h = Math.max(1, area.h);
+  const want = h / w;
+  const aspect = Math.max(ASPECT_MIN, Math.min(ASPECT_MAX, want));
+  let playW: number;
+  let playH: number;
+  if (want > aspect) {
+    playW = w;
+    playH = w * aspect;
+  } else {
+    playH = h;
+    playW = h / aspect;
+  }
+  return {
+    cssW,
+    cssH,
+    playX: area.x + (w - playW) / 2,
+    playY: area.y + (h - playH) / 2,
+    playW,
+    playH,
+    scale: playW / VW,
+    vh: VW * aspect,
+  };
+}
+
+/**
+ * The insets a safe rect implies. Exact for any rect `safeRect` produced, and it
+ * means the renderer takes ONE frame argument rather than two that can disagree.
+ */
+export function insetsFromArea(cssW: number, cssH: number, area: Rect): Insets {
+  return {
+    top: area.y,
+    right: Math.max(0, cssW - area.x - area.w),
+    bottom: Math.max(0, cssH - area.y - area.h),
+    left: area.x,
+  };
+}
+
+// -- HUD ---------------------------------------------------------------------
+
+// Resting positions, in virtual units. These are the numbers `drawHud` used to
+// hard-code; the layout below only ever pushes them DOWN, and only far enough.
+const BANNER_CY = 78;
+const BANNER_H = 100;
+const DIAL_CX = 74;
+const DIAL_CY = 74;
+const DIAL_R = 34;
+const RIGHT_X = VW - 26;
+const RIGHT_TOP = 38;
+const SCORE_DY = 20;
+const WAVE_DY = 58;
+const COMBO_DY = 108;
+const BEAD_X = 30;
+const BEAD_STEP = 26;
+const BEAD_R = 7;
+const CHARGE_X = 150;
+const CHARGE_H = 10;
+
+// Text is measured by the canvas, not here, so the boxes a test asserts on use
+// declared maxima. Roughly `chars * size * 0.62` for this weight, rounded up:
+// an eight-figure score at 40, a three-figure wave at 22, "x99" at the largest
+// chain size (34 + 30, x1.08). Generous on purpose — a box that is too big can
+// only make the layout more careful.
+const SCORE_W = 200;
+const SCORE_H = 40;
+const WAVE_W = 46;
+const WAVE_H = 22;
+const COMBO_W = 140;
+const COMBO_H = 70;
+/** Beads are one per ball left. Six is past anything the forge can hand out. */
+const BEAD_MAX = 6;
+
+/**
+ * Slack under a chrome square, in virtual units (~2.5px on a 320px phone).
+ *
+ * The mapped square is exact; the text boxes around it are estimates, and the
+ * glass in this game is bright enough that a numeral kissing the exit chevron
+ * still reads as a collision.
+ */
+const CLEAR_PAD = 8;
+
+export type HudLayout = {
+  readonly banner: { cx: number; cy: number; plateW: number; plateH: number };
+  readonly dial: { cx: number; cy: number; r: number };
+  readonly right: { x: number; scoreY: number; waveY: number; comboY: number };
+  readonly beads: { x: number; y: number; step: number; r: number };
+  readonly charge: { x: number; y: number; w: number; h: number };
+  /**
+   * Every box a child must READ, in virtual units, keyed by name. The game draws
+   * from the anchors above; the test asserts on these.
+   */
+  readonly boxes: Readonly<Record<string, Box>>;
+};
+
+/** The rule plate's width, which depends on how long the rule reads. */
+export function bannerPlateW(banner: string): number {
+  return Math.max(240, banner.length * 46 + 96);
+}
+
+/** Screen pixels -> virtual units, for a rectangle. */
+function toVirtualRect(r: Rect, view: View): Box {
+  return {
+    x: (r.x - view.playX) / view.scale,
+    y: (r.y - view.playY) / view.scale,
+    w: r.w / view.scale,
+    h: r.h / view.scale,
+  };
+}
+
+/**
+ * The lowest bottom edge of any chrome box that overlaps `left..right`, or `y`.
+ *
+ * One loop, no branch to get wrong: a box that does not overlap horizontally
+ * cannot push anything, and a box already above `y` cannot either.
+ */
+function clearOf(y: number, left: number, right: number, chrome: readonly Box[]): number {
+  let out = y;
+  for (const c of chrome) {
+    if (right > c.x && c.x + c.w > left && out < c.y + c.h + CLEAR_PAD) out = c.y + c.h + CLEAR_PAD;
+  }
+  return out;
+}
+
+/** Where the HUD goes, given the frame it is drawn in and the rule it must show. */
+export function hudLayout(view: View, insets: Insets, banner: string): HudLayout {
+  const chrome = [exitRect(insets), helpRect(view.cssW, insets)].map((r) => toVirtualRect(r, view));
+
+  const plateW = bannerPlateW(banner);
+  const bannerCy =
+    clearOf(BANNER_CY - BANNER_H / 2, VW / 2 - plateW / 2, VW / 2 + plateW / 2, chrome) + BANNER_H / 2;
+
+  const dialCy = clearOf(DIAL_CY - DIAL_R, DIAL_CX - DIAL_R, DIAL_CX + DIAL_R, chrome) + DIAL_R;
+
+  // The score, the wave and the chain are one right-aligned column and move
+  // together: splitting them would let the chain slide up past the score.
+  const rightTop = clearOf(RIGHT_TOP, RIGHT_X - SCORE_W, RIGHT_X, chrome);
+  const scoreY = rightTop + SCORE_DY;
+  const waveY = rightTop + WAVE_DY;
+  const comboY = rightTop + COMBO_DY;
+
+  const beadY = view.vh - 26;
+  const chargeY = view.vh - 26;
+
+  return {
+    banner: { cx: VW / 2, cy: bannerCy, plateW, plateH: BANNER_H },
+    dial: { cx: DIAL_CX, cy: dialCy, r: DIAL_R },
+    right: { x: RIGHT_X, scoreY, waveY, comboY },
+    beads: { x: BEAD_X, y: beadY, step: BEAD_STEP, r: BEAD_R },
+    charge: { x: CHARGE_X, y: chargeY, w: VW - 220, h: CHARGE_H },
+    boxes: {
+      banner: { x: VW / 2 - plateW / 2, y: bannerCy - BANNER_H / 2, w: plateW, h: BANNER_H },
+      dial: { x: DIAL_CX - DIAL_R, y: dialCy - DIAL_R, w: DIAL_R * 2, h: DIAL_R * 2 },
+      score: { x: RIGHT_X - SCORE_W, y: scoreY - SCORE_H / 2, w: SCORE_W, h: SCORE_H },
+      wave: { x: RIGHT_X - WAVE_W, y: waveY - WAVE_H / 2, w: WAVE_W, h: WAVE_H },
+      combo: { x: RIGHT_X - COMBO_W, y: comboY - COMBO_H / 2, w: COMBO_W, h: COMBO_H },
+      beads: {
+        x: BEAD_X - BEAD_R,
+        y: beadY - BEAD_R,
+        w: (BEAD_MAX - 1) * BEAD_STEP + BEAD_R * 2,
+        h: BEAD_R * 2,
+      },
+      charge: { x: CHARGE_X, y: chargeY - CHARGE_H / 2, w: VW - 220, h: CHARGE_H },
+    },
+  };
+}
+
+/** A virtual-unit box back to screen pixels. The inverse of `toVirtualRect`. */
+export function toScreenRect(b: Box, view: View): Rect {
+  return {
+    x: view.playX + b.x * view.scale,
+    y: view.playY + b.y * view.scale,
+    w: b.w * view.scale,
+    h: b.h * view.scale,
+  };
+}

--- a/dynawalla/games/mosaic/src/fx/render.ts
+++ b/dynawalla/games/mosaic/src/fx/render.ts
@@ -8,6 +8,11 @@
  *
  * The play area's aspect is clamped, so a wide desktop window gets stone piers
  * down each side rather than a squashed wall — the window is always a window.
+ * It is fitted inside the SAFE rect rather than the canvas, so the HUD clears
+ * the notch and the home indicator; the gradient and the piers still bleed to
+ * every edge, which is what `viewport-fit=cover` is for. `fx/hud.ts` owns that
+ * arithmetic and the HUD's clearance of the host's two corners, because both
+ * have to be assertable in a test rather than on a device.
  */
 import type { Sim } from "../game/state.ts";
 import { VW } from "../game/state.ts";
@@ -15,8 +20,12 @@ import { MOLTEN_AT, paddleHalf, tileX, tileY, TRAIL_LEN } from "../game/sim.ts";
 import { MASONRY_HP } from "../game/wall.ts";
 import { ruleBanner } from "../game/rules.ts";
 import { FORGE_TIMEOUT } from "../game/forge.ts";
+import type { Rect } from "../../../../packs/shared/game-chrome/index.ts";
+import { NO_INSETS, type Insets } from "../../../../packs/shared/game-chrome/index.ts";
 import type { Camera } from "./camera.ts";
 import { clamp01, easeOutCubic, easeOutQuint } from "./camera.ts";
+import type { HudLayout, View } from "./hud.ts";
+import { fitPlay, hudLayout, insetsFromArea } from "./hud.ts";
 import type { Particles } from "./particles.ts";
 import { Sprites, FONT, TILE_BLEED, roundRect } from "./sprites.ts";
 import {
@@ -33,9 +42,6 @@ import {
   STONE,
   STONE_HI,
 } from "./palette.ts";
-
-const ASPECT_MIN = 1.06;
-const ASPECT_MAX = 1.86;
 
 export type Hud = {
   /** 0..1 pulse used by the charge bar when it is full. */
@@ -62,6 +68,12 @@ export class Renderer {
   private backdrop: HTMLCanvasElement | null = null;
   private fontCache = new Map<string, string>();
   private t = 0;
+  private view: View = fitPlay(360, 640, { x: 0, y: 0, w: 360, h: 640 });
+  private insets: Insets = { ...NO_INSETS };
+  // The HUD layout only changes on a resize or a new rule, so it is computed
+  // then rather than sixty times a second.
+  private layout: HudLayout | null = null;
+  private layoutBanner = "";
 
   constructor(readonly canvas: HTMLCanvasElement) {
     const ctx = canvas.getContext("2d", { alpha: false });
@@ -69,8 +81,16 @@ export class Renderer {
     this.ctx = ctx;
   }
 
-  /** @returns the virtual playfield height the sim should use. */
-  resize(cssW: number, cssH: number, dprCap = 2): number {
+  /**
+   * Size the canvas and fit the window inside `area`.
+   *
+   * `area` is the SAFE rect — `safeRect(cssW, cssH)` — and it is required, not
+   * defaulted. Made optional, a caller that forgets it compiles and quietly
+   * draws the score under the notch, discoverable only on a device that has one.
+   *
+   * @returns the virtual playfield height the sim should use.
+   */
+  resize(cssW: number, cssH: number, area: Rect, dprCap = 2): number {
     this.cssW = cssW;
     this.cssH = cssH;
     this.dpr = Math.min(dprCap, globalThis.devicePixelRatio || 1);
@@ -79,19 +99,16 @@ export class Renderer {
     this.canvas.style.width = `${cssW}px`;
     this.canvas.style.height = `${cssH}px`;
 
-    const want = cssH / cssW;
-    const aspect = Math.max(ASPECT_MIN, Math.min(ASPECT_MAX, want));
-    if (want > aspect) {
-      this.playW = cssW;
-      this.playH = cssW * aspect;
-    } else {
-      this.playH = cssH;
-      this.playW = cssH / aspect;
-    }
-    this.playX = (cssW - this.playW) / 2;
-    this.playY = (cssH - this.playH) / 2;
-    this.scale = this.playW / VW;
-    this.vh = VW * aspect;
+    this.insets = insetsFromArea(cssW, cssH, area);
+    const view = fitPlay(cssW, cssH, area);
+    this.view = view;
+    this.playX = view.playX;
+    this.playY = view.playY;
+    this.playW = view.playW;
+    this.playH = view.playH;
+    this.scale = view.scale;
+    this.vh = view.vh;
+    this.layout = null;
     this.lightSprite = null;
     this.shaftSprite = null;
     this.backdrop = null;
@@ -151,21 +168,11 @@ export class Renderer {
     g.fillRect(0, 0, this.cssW, this.cssH);
     this.drawPiers();
 
-    // Play transform: shake, zoom punch, camera roll.
-    g.save();
-    g.translate(this.playX + cam.offX * this.scale, this.playY + cam.offY * this.scale);
-    g.scale(this.scale, this.scale);
-    g.translate(VW / 2, this.vh / 2);
-    g.scale(cam.zoom, cam.zoom);
-    g.rotate(cam.rot);
-    g.translate(-VW / 2, -this.vh / 2);
-
-    g.beginPath();
-    g.rect(-4, -4, VW + 8, this.vh + 8);
-    g.clip();
-
     const total = Math.max(1, sim.wave.guiltyTotal);
     const clearedFrac = clamp01(sim.broken / total);
+
+    // The world, under the camera: shake, zoom punch, camera roll.
+    this.enter(cam);
 
     if (!this.backdrop) this.backdrop = this.makeBackdrop();
     g.drawImage(this.backdrop, 0, 0, VW, this.vh);
@@ -183,12 +190,26 @@ export class Renderer {
     p.drawRings(g);
     p.drawSparks(g);
     p.drawFloaters(g, FONT);
-
-    this.drawHud(sim, hud, clearedFrac);
-    if (sim.forge) this.drawForge(sim);
-    if (sim.phase === "gameover") this.drawGameOver(sim);
-
     g.restore();
+
+    // The HUD is chrome, not scenery. It now carries a promise — it clears the
+    // host's two 44px corners — and a promise a zoom punch breaks for 100ms is
+    // not one: at 1.17x zoom about the centre, a plate resting 78 units from the
+    // top of a 1775-unit window travels about 66 units further up, which is
+    // straight back under the exit chevron. So it is drawn in the play rect
+    // without the camera. The world still shakes; the score no longer does.
+    this.enter(null);
+    this.drawHud(sim, hud, clearedFrac);
+    g.restore();
+
+    // The forge and the game-over card dim everything under them, so they are
+    // drawn last and stay with the camera.
+    if (sim.forge || sim.phase === "gameover") {
+      this.enter(cam);
+      if (sim.forge) this.drawForge(sim);
+      if (sim.phase === "gameover") this.drawGameOver(sim);
+      g.restore();
+    }
 
     // Flash, budgeted in `Camera`.
     if (cam.flash > 0.002) {
@@ -200,13 +221,51 @@ export class Renderer {
     }
   }
 
+  /**
+   * Enter the play rect. With a camera, the world's transform; without one, the
+   * same frame held still, which is where the HUD is drawn.
+   *
+   * Balanced by the caller's `g.restore()`.
+   */
+  private enter(cam: Camera | null): void {
+    const g = this.ctx;
+    g.save();
+    if (cam) {
+      g.translate(this.playX + cam.offX * this.scale, this.playY + cam.offY * this.scale);
+      g.scale(this.scale, this.scale);
+      g.translate(VW / 2, this.vh / 2);
+      g.scale(cam.zoom, cam.zoom);
+      g.rotate(cam.rot);
+      g.translate(-VW / 2, -this.vh / 2);
+    } else {
+      g.translate(this.playX, this.playY);
+      g.scale(this.scale, this.scale);
+    }
+    g.beginPath();
+    g.rect(-4, -4, VW + 8, this.vh + 8);
+    g.clip();
+  }
+
   // -- layers ---------------------------------------------------------------
 
+  /**
+   * Stone around the window.
+   *
+   * The leftover is no longer symmetric: the play rect is fitted inside the SAFE
+   * rect, so a left notch inset makes the left pier wider than the right one and
+   * a top inset makes the top band taller than the bottom. Each band is drawn
+   * from its own measured width, so the stone still reaches every edge of the
+   * canvas — full bleed under the notch is exactly what `cover` is for.
+   */
   private drawPiers(): void {
     const g = this.ctx;
-    if (this.playX > 1) {
-      const w = this.playX;
-      for (const x of [0, this.playX + this.playW]) {
+    const rightX = this.playX + this.playW;
+    const rightW = this.cssW - rightX;
+    const piers: Array<[number, number]> = [];
+    if (this.playX > 1) piers.push([0, this.playX]);
+    if (rightW > 1) piers.push([rightX, rightW]);
+    if (piers.length) {
+      for (const [x, w] of piers) {
         const grad = g.createLinearGradient(x, 0, x + w, 0);
         grad.addColorStop(0, "#08071a");
         grad.addColorStop(0.5, STONE);
@@ -218,15 +277,16 @@ export class Renderer {
       g.globalAlpha = 0.35;
       const step = Math.max(48, this.cssH / 14);
       for (let y = 0; y < this.cssH; y += step) {
-        g.fillRect(0, y, this.playX, 1.5);
-        g.fillRect(this.playX + this.playW, y, this.playX, 1.5);
+        for (const [x, w] of piers) g.fillRect(x, y, w, 1.5);
       }
       g.globalAlpha = 1;
     }
-    if (this.playY > 1) {
+    const bottomY = this.playY + this.playH;
+    const bottomH = this.cssH - bottomY;
+    if (this.playY > 1 || bottomH > 1) {
       g.fillStyle = "#0a0918";
-      g.fillRect(0, 0, this.cssW, this.playY);
-      g.fillRect(0, this.playY + this.playH, this.cssW, this.playY + 2);
+      if (this.playY > 1) g.fillRect(0, 0, this.cssW, this.playY);
+      if (bottomH > 1) g.fillRect(0, bottomY, this.cssW, bottomH);
     }
   }
 
@@ -678,12 +738,21 @@ export class Renderer {
 
     // THE RULE. The only instruction the game has.
     const banner = ruleBanner(sim.rule);
+    // Where all of this goes is `fx/hud.ts`'s answer, not a column of constants
+    // here: it has to clear the host's two corners, and that is arithmetic a
+    // test can check at every viewport.
+    if (!this.layout || this.layoutBanner !== banner) {
+      this.layoutBanner = banner;
+      this.layout = hudLayout(this.view, this.insets, banner);
+    }
+    const L = this.layout;
+
     const introT = clamp01(hud.waveIntro);
     const pop = 1 + easeOutQuint(1 - introT) * 0 + introT * 0.22;
     g.save();
-    g.translate(VW / 2, 78);
+    g.translate(L.banner.cx, L.banner.cy);
     g.scale(pop, pop);
-    const plateW = Math.max(240, banner.length * 46 + 96);
+    const plateW = L.banner.plateW;
     roundRect(g, -plateW / 2, -50, plateW, 100, 16);
     g.fillStyle = "rgba(10,8,26,0.72)";
     g.fill();
@@ -700,18 +769,19 @@ export class Renderer {
     g.restore();
 
     // Fraction cleared, as a fraction, with the same value drawn as an arc.
-    const fx = 74;
-    const fy = 74;
+    const fx = L.dial.cx;
+    const fy = L.dial.cy;
+    const fr = L.dial.r;
     g.strokeStyle = "rgba(255,255,255,0.13)";
     g.lineWidth = 6;
     g.beginPath();
-    g.arc(fx, fy, 34, 0, Math.PI * 2);
+    g.arc(fx, fy, fr, 0, Math.PI * 2);
     g.stroke();
     g.strokeStyle = CHARGE_HOT;
     g.lineWidth = 6;
     g.lineCap = "round";
     g.beginPath();
-    g.arc(fx, fy, 34, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * cleared);
+    g.arc(fx, fy, fr, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * cleared);
     g.stroke();
     this.text(`${sim.broken}`, fx, fy - 10, 26, 800, "#fff6e4");
     g.strokeStyle = "rgba(255,246,228,0.5)";
@@ -723,8 +793,17 @@ export class Renderer {
     this.text(`${sim.wave.guiltyTotal}`, fx, fy + 16, 22, 700, "rgba(255,246,228,0.75)");
 
     // Score.
-    this.text(String(sim.score), VW - 26, 58, 40, 800, "#fff6e4", "right");
-    this.text(`${sim.wave.index + 1}`, VW - 26, 96, 22, 700, "rgba(255,236,203,0.55)", "right");
+    const rx = L.right.x;
+    this.text(String(sim.score), rx, L.right.scoreY, 40, 800, "#fff6e4", "right");
+    this.text(
+      `${sim.wave.index + 1}`,
+      rx,
+      L.right.waveY,
+      22,
+      700,
+      "rgba(255,236,203,0.55)",
+      "right",
+    );
     // The chain. It is the thing that decides whether the ball catches fire, so
     // it is drawn at a size that says so, and it burns white once it has.
     if (sim.combo > 1) {
@@ -734,39 +813,40 @@ export class Renderer {
       const colour = molten ? "#eaf8ff" : JEWELS[sim.combo % JEWELS.length]!.glow;
       g.globalCompositeOperation = "lighter";
       g.globalAlpha = (0.3 + t * 0.5) * (molten ? 1 : 0.7);
-      this.text(`×${sim.combo}`, VW - 26, 146, size * 1.08, 800, colour, "right");
+      this.text(`×${sim.combo}`, rx, L.right.comboY, size * 1.08, 800, colour, "right");
       g.globalAlpha = 1;
       g.globalCompositeOperation = "source-over";
       g.globalAlpha = 0.45 + t * 0.55;
-      this.text(`×${sim.combo}`, VW - 26, 146, size, 800, colour, "right");
+      this.text(`×${sim.combo}`, rx, L.right.comboY, size, 800, colour, "right");
       g.globalAlpha = 1;
     }
 
     // Beads: how many balls are left, as objects rather than a number.
     for (let i = 0; i < sim.beads; i++) {
-      const x = 30 + i * 26;
-      const y = this.vh - 26;
+      const x = L.beads.x + i * L.beads.step;
+      const y = L.beads.y;
       g.fillStyle = BALL_GLOW;
       g.globalAlpha = 0.9;
       g.beginPath();
-      g.arc(x, y, 7, 0, Math.PI * 2);
+      g.arc(x, y, L.beads.r, 0, Math.PI * 2);
       g.fill();
       g.globalAlpha = 1;
     }
 
     // Charge: a seam of light along the bottom of the window.
-    const cw = VW - 220;
-    const cx = 150;
-    const cy = this.vh - 26;
+    const cw = L.charge.w;
+    const cx = L.charge.x;
+    const cy = L.charge.y;
+    const ch = L.charge.h;
     const frac = clamp01(sim.charge / sim.chargeMax);
     g.fillStyle = "rgba(255,255,255,0.08)";
-    roundRect(g, cx, cy - 5, cw, 10, 5);
+    roundRect(g, cx, cy - ch / 2, cw, ch, ch / 2);
     g.fill();
     if (frac > 0) {
       g.globalCompositeOperation = "lighter";
       g.globalAlpha = 0.6 + hud.chargePulse * 0.4;
       g.fillStyle = CHARGE_HOT;
-      roundRect(g, cx, cy - 5, cw * frac, 10, 5);
+      roundRect(g, cx, cy - ch / 2, cw * frac, ch, ch / 2);
       g.fill();
       g.globalAlpha = 1;
       g.globalCompositeOperation = "source-over";

--- a/dynawalla/games/mosaic/src/mount.ts
+++ b/dynawalla/games/mosaic/src/mount.ts
@@ -12,6 +12,11 @@
  * Hitstop survives reduced motion (it is information: something was hit).
  * Shake, punch and roll do not. Flashes are budgeted by `Camera`.
  */
+import {
+  createInstructions,
+  onInsetsChange,
+  safeRect,
+} from "../../../packs/shared/game-chrome/index.ts";
 import type { GameHandle, Host } from "./contract.ts";
 import { Audio } from "./audio/audio.ts";
 import { Camera, clamp01, lerp } from "./fx/camera.ts";
@@ -53,8 +58,67 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
   particles.density = reduced ? 0.34 : 1;
 
   const seed = (Date.now() ^ 0x5eed1e) >>> 0;
-  let vh = renderer.resize(el.clientWidth || 360, el.clientHeight || 640);
+  const w0 = el.clientWidth || 360;
+  const h0 = el.clientHeight || 640;
+  let vh = renderer.resize(w0, h0, safeRect(w0, h0));
   const sim = createSim(seed, vh);
+
+  // How to play. MOSAIC's whole instruction set used to be the two or three
+  // characters on the plate at the top: nothing told a child that stone tiles
+  // are meant to bounce, that a chain sets the ball alight, or that the glowing
+  // paddle is a question waiting to be asked. The manual stays reachable during
+  // play, because the moment a child needs the rules is never the title screen.
+  const guide = createInstructions(el, {
+    title: "MOSAIC",
+    summary: [
+      "Slide your finger to move the paddle. Bounce the ball up into the glass.",
+      "The sign at the top says which tiles to break.",
+    ],
+    sections: [
+      {
+        heading: "Moving",
+        lines: [
+          "Slide your finger anywhere on the lower part of the screen. The paddle follows it.",
+          "The ball waits on the paddle. Tap once to send it up.",
+          "On a keyboard: left and right arrow keys move, space sends the ball.",
+        ],
+      },
+      {
+        heading: "The sign at the top",
+        lines: [
+          "× 6 means break every tile that is a multiple of 6, like 6, 12, 18 and 24.",
+          "24 ÷ ▪ means break every tile that goes into 24 with nothing left over, like 3, 4 and 8.",
+          "= 12 means break every tile worth 12. It can also say = 1/2 or = 50%. Those two are the same amount.",
+          "> 40 means break every tile bigger than 40. < 40 means smaller than 40.",
+          "Tiles that do not match the rule are stone. The ball bounces off them and nothing bad happens.",
+        ],
+      },
+      {
+        heading: "Chains",
+        lines: [
+          "Break one tile after another without missing and your chain grows.",
+          "A long chain makes the ball hot. A hot ball burns straight through tiles instead of bouncing off them.",
+        ],
+      },
+      {
+        heading: "The forge",
+        lines: [
+          "Every 8 tiles you break, the paddle starts to glow.",
+          "Tap once while it glows. Time slows down and four glass shapes float up with a question above them.",
+          "Each shape holds an answer and a prize. Tap the one with the right answer to win its prize: a wider paddle, a laser, extra balls, or a slower ball.",
+          "A wrong answer only costs the glow. You do not lose a ball.",
+        ],
+      },
+      {
+        heading: "Staying in",
+        lines: [
+          "The dots at the bottom are the balls you have left. You lose one when the ball goes past the paddle.",
+          "The wall slides down while you play, so keep breaking.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  });
 
   const hud = { chargePulse: 0, dangerPulse: 0, clearFlash: 0, waveIntro: 0 };
   const events: SimEvent[] = [];
@@ -98,11 +162,15 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
   const doResize = () => {
     const w = el.clientWidth || canvas.clientWidth || 360;
     const h = el.clientHeight || canvas.clientHeight || 640;
-    vh = renderer.resize(w, h);
+    vh = renderer.resize(w, h, safeRect(w, h));
     resizeSim(sim, vh);
   };
   const ro = new ResizeObserver(doResize);
   ro.observe(el);
+  // The insets are not a constant: rotation swaps top and bottom for left and
+  // right, and iPadOS changes them when the pack is resized in Split View. A
+  // ResizeObserver alone misses the case where only the insets moved.
+  const stopInsets = onInsetsChange(doResize);
   doResize();
 
   // -- input ----------------------------------------------------------------
@@ -540,8 +608,10 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
   return {
     unmount() {
       running = false;
+      guide.destroy();
       cancelAnimationFrame(raf);
       ro.disconnect();
+      stopInsets();
       canvas.removeEventListener("pointerdown", onPointerDown);
       canvas.removeEventListener("pointermove", onPointerMove);
       canvas.removeEventListener("pointerup", onPointerUp);


### PR DESCRIPTION
## What

MOSAIC adopts the shared game chrome: the play rect is fitted inside the safe
rectangle instead of the canvas, the HUD is pushed clear of the host's two 44px
corners, and the game gains a how-to-play manual.

## Why

`pack.html` declares `viewport-fit=cover`, which is not neutral — it opts the
document INTO the notch, the home indicator and the rounded corners. MOSAIC's HUD
is drawn on a canvas, where `env()` is unreachable, so it drew into the hardware
with no way to notice.

Two measured collisions, both real, both now covered by a test:

- **320x568, no insets.** The play rect was the whole canvas (`playX=playY=0`,
  `scale=0.32`), so the cleared-fraction dial — centre (74,74), r=34 virtual —
  landed at screen `12.8..34.5` in both axes. The host's exit square is
  `10..54` by `13..57`. Dead centre under it. The right-aligned score at
  `(VW-26, 58)` sat under the help square the same way.
- **768x1024.** The dial collided too.

Chrome **overlays** rather than reserving a band, and this keeps it that way:
reserving the top 67px costs 12% of a 568px phone's height and broke SKY LEDGER's
own layout outright when it was tried (#606). The playfield, the gradient and the
stone piers still bleed to every edge — that is what `cover` is for. The promise
is only that nothing a child must READ or TOUCH lands in the two squares.

`Renderer.resize` now takes the safe rectangle as a **required** argument. Made
optional, a caller that forgets it compiles, runs, and quietly draws the score
under the notch, discoverable only on a device with a notch.

Three things worth a reviewer's attention beyond the mechanical adoption:

1. **The HUD left the camera transform.** It was drawn inside it, and a clearance
   promise a zoom punch breaks for 100ms is not a promise: at 1.17x zoom about
   the centre, a plate resting 78 units from the top of a 1775-unit window
   travels ~66 units further up — back under the exit chevron. The world still
   shakes; the score no longer does. The forge and the game-over card still ride
   the camera and are still drawn last, so they still dim what is under them.
2. **The piers measure each leftover band separately.** With the window inside
   the safe rect the leftover is no longer symmetric (a left inset widens the
   left pier, a top inset heightens the top band); the old code drew both from
   `playX`/`playY` and would have left an unpainted strip.
3. **`onInsetsChange` as well as `ResizeObserver`**, because rotation and iPad
   Split View move the insets without necessarily resizing the element.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/mosaic/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no `voiceId`
      renamed; no catalog entry dropped or narrowed. `pack.json` is untouched —
      same id, version, capabilities and skill coverage.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri` manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are the MOSAIC
      manual, which lives in the pack alongside the rest of the game's copy, as
      SKY LEDGER's does.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema
      touched.
- [x] **Secrets.** None. `gitleaks` clean over the branch.

Behaviour a reviewer should sanity-check on a device: the HUD sits lower on a
small portrait phone than it did, by design, and the dial/score no longer shake
with impacts.

## Proof

```
$ cd dynawalla/games/mosaic && npm run tsc
> @dynawalla/game-mosaic@0.1.0 tsc
> tsc --noEmit && tsc --noEmit -p tsconfig.test.json
(0 errors)

$ for i in 1 2 3 4 5; do npm test; done
=== run 1 ===
# tests 72
# pass 72
# fail 0
=== run 2 ===
# tests 72
# pass 72
# fail 0
=== run 3 ===
# tests 72
# pass 72
# fail 0
=== run 4 ===
# tests 72
# pass 72
# fail 0
=== run 5 ===
# tests 72
# pass 72
# fail 0

$ npm run build
dist/index.html                 0.80 kB │ gzip:  0.42 kB
dist/assets/index-CmxnkHw1.js  75.89 kB │ gzip: 27.22 kB
✓ built in 32ms

$ cd ../../packs && node build.mjs mosaic
✓ built in 33ms
dynawalla.mosaic@0.1.0 — MOSAIC
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       5 skills, grades 2–5
  on disk      3 files, 80167 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ grep -c "dwc-panel\|safe-area-inset-top" dynawalla/games/mosaic/dist-pack/assets/pack-*.js
3
1
(the shared chrome is bundled into the built pack, not merely compiling)

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF no leaks found

$ git diff --name-only origin/main..HEAD
dynawalla/games/mosaic/src/fx/hud.test.ts
dynawalla/games/mosaic/src/fx/hud.ts
dynawalla/games/mosaic/src/fx/render.ts
dynawalla/games/mosaic/src/mount.ts

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty — nothing deleted)
```

### The clearance test bites

With the clearance push removed (`clearOf` made to return `y` unchanged) and
nothing else changed:

```
$ npm test | grep -E "^not ok|^# (tests|pass|fail)"
not ok 7 - the HUD clears the host's corners at small phone portrait (320×568), no insets
not ok 9 - the HUD clears the host's corners at small phone portrait (320×568), notched, upright
not ok 15 - the HUD clears the host's corners at phone portrait (390×844), notched, upright
not ok 19 - the HUD clears the host's corners at tablet portrait (768×1024), no insets
not ok 21 - the HUD clears the host's corners at tablet portrait (768×1024), notched, upright
not ok 23 - the HUD clears the host's corners at tablet portrait (768×1024), notched, on its side
not ok 40 - portrait pushes the dial and the score column down, and says by how much
# tests 72
# pass 65
# fail 7

not ok 7 - the HUD clears the host's corners at small phone portrait (320×568), no insets
  error: |-
    small phone portrait no insets "× 6": the dial is under host chrome (12.8,12.8 21.8×21.8)
    true !== false

not ok 40 - portrait pushes the dial and the score column down, and says by how much
  error: 'the dial did not move: 74'
```

`12.8,12.8 21.8×21.8` is the exact collision described above. 390x844 with no
insets keeps passing without the push, because at that shape the aspect clamp
already letterboxes the window below both corners — the honest result, and the
reason the promise is asserted at five shapes rather than one. The fix was
restored and all 72 pass again.
