### PR TITLE
feat(dynawalla/games/claim): the ground stops at the safe edge, and the score comes out from under the host's button

### DIFF
--- a/dynawalla/games/claim/src/game/hud.ts
+++ b/dynawalla/games/claim/src/game/hud.ts
@@ -6,7 +6,9 @@
 // the whole pedagogy, and it needs real type at real weights, which is DOM.
 
 import { cleanFraction, percentTenths } from "./exact.ts"
+import { hudFrame } from "./layout.ts"
 import { css, type LevelInk } from "./palette.ts"
+import type { Insets } from "../../../../packs/shared/game-chrome/index.ts"
 
 export class Hud {
   root: HTMLDivElement
@@ -72,6 +74,25 @@ export class Hud {
     this.card = document.createElement("div")
     this.card.className = "cl-card"
     parent.appendChild(this.card)
+  }
+
+  /**
+   * Publish the frame as custom properties the stylesheet consumes.
+   *
+   * The stylesheet keeps `env()` fallbacks on every one of these, so a HUD that
+   * never gets laid out is still inside the notch — but the values under test
+   * are these, and these win.
+   */
+  layout(w: number, h: number, insets: Insets): void {
+    const f = hudFrame(w, h, insets)
+    const s = this.root.style
+    s.setProperty("--cl-pt", `${f.padTop}px`)
+    s.setProperty("--cl-pl", `${f.padLeft}px`)
+    s.setProperty("--cl-pr", `${f.padRight}px`)
+    s.setProperty("--cl-gl", `${f.gutterLeft}px`)
+    s.setProperty("--cl-gr", `${f.gutterRight}px`)
+    s.setProperty("--cl-toph", `${f.topMinH}px`)
+    s.setProperty("--cl-cluster", `${f.clusterW}px`)
   }
 
   setLevel(level: number, ink: LevelInk, goal: { n: number; d: number; target: number }): void {

--- a/dynawalla/games/claim/src/game/index.ts
+++ b/dynawalla/games/claim/src/game/index.ts
@@ -7,6 +7,12 @@
 // a cut that pushes you past the band does not show you a red X — it falls
 // apart and gives the ground back to the hunters.
 
+import {
+  createInstructions,
+  onInsetsChange,
+  safeInsets,
+  type Instructions,
+} from "../../../../packs/shared/game-chrome/index.ts"
 import type { Host, Question } from "../contract.ts"
 import { Audio } from "./audio.ts"
 import { cleanFraction, clamp } from "./exact.ts"
@@ -35,6 +41,7 @@ import {
 import { Hud } from "./hud.ts"
 import { Input } from "./input.ts"
 import { Juice } from "./juice.ts"
+import { arenaRect, muteRect } from "./layout.ts"
 import { goalFromQuestion, levelAt, type Goal, type Level } from "./levels.ts"
 import { css, INK, levelInk } from "./palette.ts"
 import { Particles } from "./particles.ts"
@@ -148,6 +155,8 @@ class Claim {
   private fpsAcc = 0
   private fps = 60
   private worstFrame = 0
+  private guide: Instructions
+  private stopInsets: () => void
 
   constructor(el: HTMLElement, host: Host) {
     this.host = host
@@ -197,10 +206,75 @@ class Claim {
 
     this.g = makeGrid(pickArena(this.stageAspect()))
     this.r = new Renderer(canvas, this.g, levelInk(1))
-    this.input = new Input(root, () => this.audio.unlock())
+    // The stick anchors anywhere on the game itself — `shake` is the HUD and
+    // the arena — but never on the controls floating over it.
+    this.input = new Input(root, shake, () => this.audio.unlock())
 
     this.ro = new ResizeObserver(() => this.layout())
     this.ro.observe(stage)
+    // Rotation swaps top/bottom with left/right and Split View changes them
+    // outright, and neither necessarily resizes the stage. Without this the HUD
+    // is laid out for the shape the tablet was in when the pack opened.
+    this.stopInsets = onInsetsChange(() => this.layout())
+
+    // How to play. CLAIM shipped showing a child a stacked fraction, a bar and
+    // an empty field, with nothing anywhere saying that the loop you draw is
+    // filled in, or that being touched while drawing is what kills you. The
+    // manual stays reachable during play, because the moment a child needs the
+    // rules is never the title screen.
+    this.guide = createInstructions(root, {
+      title: "CLAIM",
+      summary: [
+        "Drive out into the empty ground, draw a loop, and come back to the edge. The inside of your loop fills in and becomes yours.",
+        "The number at the top says how much of the field to take. Stop when the bar reaches the bright stripe.",
+      ],
+      sections: [
+        {
+          heading: "Moving",
+          lines: [
+            "Touch anywhere and slide your thumb to steer. Let go to keep going straight.",
+            "On a keyboard: arrow keys or W A S D.",
+            "You are safe while you are on ground you already own.",
+          ],
+        },
+        {
+          heading: "Taking ground",
+          lines: [
+            "Leave your ground and a bright trail follows you.",
+            "Get back to your own ground and the trail closes. Everything inside turns your colour.",
+            "A big loop takes a lot of ground at once. A small loop is safer.",
+          ],
+        },
+        {
+          heading: "The number at the top",
+          lines: [
+            "The fraction is how much of the field you have to take. 3 over 4 means three quarters of it.",
+            "The bar underneath is cut into that many parts, so you can watch the pieces fill up.",
+            "The bright stripe on the bar is where you should stop. Land on it and the level is done.",
+            "Go past the stripe and the cut falls apart. The ground goes back to the shapes.",
+          ],
+        },
+        {
+          heading: "Staying alive",
+          lines: [
+            "Shapes float around in the ground you have not taken yet.",
+            "You lose a life if a shape touches you, or if it touches your trail before you close it.",
+            "You lose a life if you drive into your own trail.",
+            "Do not stop in the middle of a trail. If you stand still too long the trail burns away behind you.",
+            "You start with three lives. They are the pink squares at the top.",
+          ],
+        },
+        {
+          heading: "One more chance",
+          lines: [
+            "When your last life goes, a sum appears and squares with answers drop into the field.",
+            "Drive over the square with the right answer and you get a life back.",
+            "You have a few seconds, and nothing can hurt you while you decide.",
+          ],
+        },
+      ],
+      reducedMotion: this.reduced,
+    })
   }
 
   // ---- lifecycle --------------------------------------------------------
@@ -216,6 +290,8 @@ class Claim {
   destroy(): void {
     this.alive = false
     cancelAnimationFrame(this.raf)
+    this.stopInsets()
+    this.guide.destroy()
     this.ro?.disconnect()
     this.input.destroy()
     this.audio.dispose()
@@ -226,11 +302,30 @@ class Claim {
   private layout(): void {
     const w = this.stage.clientWidth || 1
     const h = this.stage.clientHeight || 1
-    this.r.resize(w, h)
+    // Measured every time rather than cached: the insets change on rotation and
+    // when a pack is resized in Split View, and a game that reads them once at
+    // mount is correct until the first rotation and wrong after it.
+    const insets = safeInsets()
+    this.r.resize(w, h, arenaRect(w, h, insets))
+    const fw = this.root.clientWidth || w
+    const fh = this.root.clientHeight || h
+    this.hud.layout(fw, fh, insets)
+    // The mute button is positioned from the same function the test asserts,
+    // rather than from a second copy of the numbers in the stylesheet.
+    const m = muteRect(fw, fh, insets)
+    this.root.style.setProperty("--cl-mute-r", `${fw - (m.x + m.w)}px`)
+    this.root.style.setProperty("--cl-mute-b", `${fh - (m.y + m.h)}px`)
+    this.root.style.setProperty("--cl-mute-s", `${m.w}px`)
   }
 
+  /**
+   * The shape the arena is fitted to — the SAFE part of the stage, not the
+   * whole of it. Every arena is exactly 7200 cells in exactly 40 blocks, so
+   * this only ever picks which 7200, never how many.
+   */
   private stageAspect(): number {
-    return (this.stage.clientWidth || 4) / (this.stage.clientHeight || 3)
+    const a = arenaRect(this.stage.clientWidth || 4, this.stage.clientHeight || 3, safeInsets())
+    return a.w / a.h
   }
 
   // ---- level setup ------------------------------------------------------
@@ -359,6 +454,15 @@ class Claim {
       this.fps = Math.round(this.frames / this.fpsAcc)
       this.frames = 0
       this.fpsAcc = 0
+    }
+
+    // A child reading the rules is not playing. The hunt must not close on
+    // them behind the panel, and an arrow key behind it is not a move.
+    this.input.enabled = !this.guide.isOpen
+    if (this.guide.isOpen) {
+      this.input.consumePress()
+      this.draw()
+      return
     }
 
     const dt = this.juice.step(realDt)

--- a/dynawalla/games/claim/src/game/input.ts
+++ b/dynawalla/games/claim/src/game/input.ts
@@ -36,12 +36,30 @@ export class Input {
   /** Pointer position in CSS pixels relative to the element, or null. */
   pointer: { x: number; y: number } | null = null
 
+  /**
+   * False while something is in front of the game — the how-to-play panel.
+   * Input behind a sheet is not something the child did.
+   */
+  enabled = true
+
   private el: HTMLElement
+  /**
+   * The part of `el` that is the GAME.
+   *
+   * `el` is the pack's root, and the root also holds controls: the mute button,
+   * and the shared how-to-play button and its panel. A pointerdown on one of
+   * those bubbles to the root, and `onPointerDown` calls `preventDefault()`,
+   * which suppresses the compatibility mouse events a `click` is synthesised
+   * from — so binding to the root alone makes every button in the pack dead to
+   * a finger. Anything outside this box is somebody else's control.
+   */
+  private surface: HTMLElement
   private onAny: () => void
   private handlers: Array<[EventTarget, string, EventListener]> = []
 
-  constructor(el: HTMLElement, onAny: () => void) {
+  constructor(el: HTMLElement, surface: HTMLElement, onAny: () => void) {
     this.el = el
+    this.surface = surface
     this.onAny = onAny
     this.bind(window, "keydown", this.onKeyDown as EventListener)
     this.bind(window, "keyup", this.onKeyUp as EventListener)
@@ -70,6 +88,7 @@ export class Input {
   }
 
   private onKeyDown = (e: KeyboardEvent): void => {
+    if (!this.enabled) return
     const k = e.key.toLowerCase()
     const mapped =
       k === "arrowleft" || k === "a"
@@ -100,7 +119,15 @@ export class Input {
     return { x: e.clientX - r.left, y: e.clientY - r.top }
   }
 
+  /** Did this pointer land on the game, or on a control floating over it? */
+  private mine(e: PointerEvent): boolean {
+    if (!this.enabled) return false
+    const t = e.target as Node | null
+    return t === this.el || (t !== null && this.surface.contains(t))
+  }
+
   private onPointerDown = (e: PointerEvent): void => {
+    if (!this.mine(e)) return
     e.preventDefault()
     this.anyPress = true
     this.onAny()

--- a/dynawalla/games/claim/src/game/layout.ts
+++ b/dynawalla/games/claim/src/game/layout.ts
@@ -1,0 +1,155 @@
+// WHERE THE FRAME ACTUALLY IS.
+//
+// CLAIM declares `viewport-fit=cover`, which is not a neutral setting: it opts
+// the document *into* the notch, the rounded corners and the home indicator.
+// The HUD is DOM, so it could claw the top back with `env(safe-area-inset-top)`
+// and did — but only the top, and only for the HUD. Three things were left out:
+//
+//   1. **The arena.** The grid is centred in a canvas that runs to the bottom
+//      and both sides of the frame. Cells are not decoration: they are the
+//      ground the child drives across and the thing the fraction is measured
+//      in. A row of cells under the home indicator is ground that cannot be
+//      seen and cannot be cut, and an upward drag there is a system gesture.
+//   2. **The sides.** `padding: ... 12px` ignores the left and right insets, so
+//      in landscape the level counter sat behind the notch.
+//   3. **The host's two corners.** The host floats a 44px exit control at the
+//      top-left and the shared how-to-play control at the top-right, over every
+//      pack. `LVL 4` was under one and the score and the LIVES were under the
+//      other.
+//
+// **Why this file exists at all, given the HUD is CSS.** Because `env()` cannot
+// be asserted. A CSS-only fix is invisible to every test in this package and is
+// checked by looking at a device, which is how all three of the above shipped.
+// So the numbers live here, in one pure function per surface; `Hud` publishes
+// them as custom properties and the stylesheet consumes them; and
+// `test/layout.test.ts` asserts the same numbers against `hitsHostChrome`.
+// One source of truth, and it is the one under test.
+//
+// **The chrome overlays; nothing reserves a band.** Reserving the top strip
+// cost 12% of a small phone's height in SKY LEDGER and broke its own layout.
+// Here the clusters move INBOARD — a horizontal gutter, which costs the arena
+// nothing at all — rather than downward.
+
+import {
+  exitRect,
+  helpRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts"
+
+/** Gap between the host's controls and anything of ours beside them. */
+const CHROME_GAP = 8
+
+/** The HUD's own padding, before any inset. Matches the original stylesheet. */
+const PAD_TOP = 8
+const PAD_SIDE = 12
+
+/** The fraction bar's height and the gap above it, from the stylesheet. */
+const METER_H = 20
+const METER_GAP = 7
+
+export type HudFrame = {
+  /** `.cl-hud` padding. */
+  padTop: number
+  padLeft: number
+  padRight: number
+  /** Extra `.cl-top` padding that walks the clusters past the host's corners. */
+  gutterLeft: number
+  gutterRight: number
+  /** `.cl-top` min-height, which is what puts the fraction bar below the corners. */
+  topMinH: number
+  /** How wide either cluster may grow. Enforced by `max-width`, not estimated. */
+  clusterW: number
+  /** The box the level counter may occupy. */
+  left: Rect
+  /** The box the score and the lives may occupy. */
+  right: Rect
+  /** The fraction bar. It IS the pedagogy; both of its ends must be visible. */
+  meter: Rect
+}
+
+/**
+ * Where the HUD's parts go, on a frame of `w` x `h` with these insets.
+ *
+ * `insets` is REQUIRED. Optional would mean a caller that forgets it still
+ * compiles and quietly lays the score out under the host's button, discoverable
+ * only on a device — which is exactly how this shipped.
+ */
+export function hudFrame(w: number, _h: number, insets: Insets): HudFrame {
+  const padTop = PAD_TOP + insets.top
+  const padLeft = PAD_SIDE + insets.left
+  const padRight = PAD_SIDE + insets.right
+
+  const exit = exitRect(insets)
+  const help = helpRect(w, insets)
+
+  // The `.cl-hud` content box: what is left after the padding.
+  const innerX = padLeft
+  const innerW = Math.max(1, w - padLeft - padRight)
+
+  // Walk the top row's two clusters past the host's corners, and no further.
+  const gutterLeft = Math.max(0, exit.x + exit.w + CHROME_GAP - innerX)
+  const gutterRight = Math.max(0, innerX + innerW - (help.x - CHROME_GAP))
+
+  const rowX = innerX + gutterLeft
+  const rowW = Math.max(1, innerW - gutterLeft - gutterRight)
+
+  // The fraction bar spans the full inner width, so it cannot dodge the corners
+  // sideways — it has to start below them. The top row is given exactly enough
+  // height to guarantee that and not a pixel more, and in practice the stacked
+  // goal fraction is already taller than this, so nothing moves on most screens.
+  const topMinH = Math.max(44, exit.y + exit.h + 4 - padTop)
+
+  // A third each, so the centred goal fraction — the loudest thing on screen and
+  // the whole instruction set — keeps the middle third even when the score is
+  // six digits long.
+  const clusterW = Math.max(40, rowW * 0.32)
+
+  return {
+    padTop,
+    padLeft,
+    padRight,
+    gutterLeft,
+    gutterRight,
+    topMinH,
+    clusterW,
+    left: { x: rowX, y: padTop, w: clusterW, h: topMinH },
+    right: { x: rowX + rowW - clusterW, y: padTop, w: clusterW, h: topMinH },
+    meter: { x: innerX, y: padTop + topMinH + METER_GAP, w: innerW, h: METER_H },
+  }
+}
+
+/**
+ * The rectangle the arena may occupy inside the stage canvas, in canvas-local
+ * CSS pixels.
+ *
+ * The stage sits below the HUD and is flush to the frame's left, right and
+ * bottom edges — `.cl-root` is `100% x 100%`, `.cl-shake` fills it, and
+ * `.cl-stage` is the flex remainder — so the stage's own unsafe margins are the
+ * frame's left, right and bottom insets, and its top is already well clear of
+ * the notch. That is the whole of the mapping, and it is why this takes insets
+ * rather than a rect: there is no other correspondence to get wrong.
+ *
+ * The paper and the vignette still fill the entire canvas. Only the grid is
+ * constrained, because only the grid is ground.
+ */
+export function arenaRect(w: number, h: number, insets: Insets): Rect {
+  const x = Math.min(insets.left, w)
+  return {
+    x,
+    y: 0,
+    w: Math.max(1, w - x - Math.min(insets.right, w)),
+    h: Math.max(1, h - Math.min(insets.bottom, h)),
+  }
+}
+
+/** Where the mute button's 44px touch target sits, from the bottom-right. */
+export function muteRect(w: number, h: number, insets: Insets): Rect {
+  const side = 44
+  return {
+    x: w - insets.right - 10 - side,
+    y: h - insets.bottom - 10 - side,
+    w: side,
+    h: side,
+  }
+}

--- a/dynawalla/games/claim/src/game/render.ts
+++ b/dynawalla/games/claim/src/game/render.ts
@@ -170,7 +170,21 @@ export class Renderer {
    */
   private static readonly PIXEL_BUDGET = 2_100_000
 
-  resize(cssW: number, cssH: number): void {
+  /**
+   * @param area where the GRID may live, in canvas-local CSS pixels. Required.
+   *
+   * The canvas still covers the whole stage: the paper and the vignette bleed
+   * to the edges, which is the entire point of `viewport-fit=cover`. What is
+   * constrained is the grid, because the grid is not decoration — it is the
+   * ground the child drives across and the thing the fraction is measured in. A
+   * row of cells under the home indicator is ground that cannot be seen, cannot
+   * be cut, and swallows an upward drag as a system gesture.
+   *
+   * Making it required is the point. Optional would mean a caller that forgets
+   * it still compiles and quietly centres the arena on the glass, discoverable
+   * only on a device.
+   */
+  resize(cssW: number, cssH: number, area: { x: number; y: number; w: number; h: number }): void {
     const want = Math.min(2, globalThis.devicePixelRatio || 1)
     const px = cssW * cssH * want * want
     this.dpr =
@@ -184,10 +198,10 @@ export class Renderer {
     this.canvas.style.width = `${cssW}px`
     this.canvas.style.height = `${cssH}px`
     // Integer cell size: every cell the same width, no shimmer on the blit.
-    const cs = Math.max(2, Math.floor(Math.min(cssW / this.g.w, cssH / this.g.h)))
+    const cs = Math.max(2, Math.floor(Math.min(area.w / this.g.w, area.h / this.g.h)))
     this.cs = cs
-    this.ox = Math.round((cssW - cs * this.g.w) / 2)
-    this.oy = Math.round((cssH - cs * this.g.h) / 2)
+    this.ox = area.x + Math.round((area.w - cs * this.g.w) / 2)
+    this.oy = area.y + Math.round((area.h - cs * this.g.h) / 2)
     this.buildPaper()
   }
 

--- a/dynawalla/games/claim/src/style.css
+++ b/dynawalla/games/claim/src/style.css
@@ -85,7 +85,12 @@
   position: relative;
   z-index: 2;
   flex: 0 0 auto;
-  padding: calc(8px + env(safe-area-inset-top)) 12px 0;
+  /* Published by `Hud.layout` from `layout.ts`, which is the version under
+     test. The `env()` fallbacks are what a HUD that never gets laid out
+     falls back to — correct for the notch, blind to the host's controls. */
+  padding: var(--cl-pt, calc(8px + env(safe-area-inset-top)))
+    var(--cl-pr, calc(12px + env(safe-area-inset-right))) 0
+    var(--cl-pl, calc(12px + env(safe-area-inset-left)));
   will-change: transform;
 }
 .cl-hud.cl-punch {
@@ -105,6 +110,26 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
+  /* The host floats a 44px exit control top-left and the how-to-play control
+     top-right, over every pack. The two clusters step INBOARD of them rather
+     than downward, which costs the arena nothing. The min-height is what puts
+     the fraction bar below the corners — it spans the full width and so cannot
+     dodge them sideways. */
+  padding-left: var(--cl-gl, 52px);
+  padding-right: var(--cl-gr, 52px);
+  min-height: var(--cl-toph, 49px);
+}
+.cl-lvl,
+.cl-right {
+  /* Enforced, not estimated: the test asserts a box this wide, so the content
+     is not allowed to grow out of it. */
+  max-width: var(--cl-cluster, 33%);
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.cl-goal {
+  min-width: 0;
 }
 
 .cl-lvl,
@@ -252,7 +277,7 @@
     margin: 2px 0;
   }
   .cl-hud {
-    padding-top: calc(6px + env(safe-area-inset-top));
+    padding-top: var(--cl-pt, calc(6px + env(safe-area-inset-top)));
   }
 }
 
@@ -425,10 +450,15 @@
 .cl-mute {
   position: absolute;
   z-index: 8;
-  right: 10px;
-  bottom: 10px;
-  width: 34px;
-  height: 34px;
+  /* Was `right: 10px; bottom: 10px`, which on a phone is inside the home
+     indicator: a control a child cannot press without the system taking the
+     gesture. 44px is the platform touch floor, and the box was 34.
+     Published by `Claim.layout` from `muteRect`, which is the version under
+     test; the `env()` fallbacks cover a layout that never runs. */
+  right: var(--cl-mute-r, calc(10px + env(safe-area-inset-right)));
+  bottom: var(--cl-mute-b, calc(10px + env(safe-area-inset-bottom)));
+  width: var(--cl-mute-s, 44px);
+  height: var(--cl-mute-s, 44px);
   border: 2px solid rgba(244, 241, 232, 0.22);
   background: rgba(8, 8, 14, 0.7);
   color: rgba(244, 241, 232, 0.66);

--- a/dynawalla/games/claim/test/layout.test.ts
+++ b/dynawalla/games/claim/test/layout.test.ts
@@ -1,0 +1,141 @@
+// THE FRAME.
+//
+// `claim.test.ts` proves the arithmetic: that a flood fills the right cells,
+// that a fraction reduces, that a band is exact in cells. Not one of its
+// assertions can see WHERE anything is drawn, which is why CLAIM shipped with
+// `LVL 4` underneath the host's exit control, the score and the three lives
+// underneath the how-to-play control, the arena centred into the home
+// indicator, and the mute button at `bottom: 10px` where the system takes the
+// gesture.
+//
+// A CSS-only fix would be just as invisible. So the numbers live in
+// `src/game/layout.ts`, the stylesheet consumes them as custom properties, and
+// this file asserts them.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  HOST_CONTROL,
+  hitsHostChrome,
+  type Insets,
+} from "../../../packs/shared/game-chrome/index.ts"
+import { arenaRect, hudFrame, muteRect } from "../src/game/layout.ts"
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+
+/** Phones both ways, tablets both ways, and the smallest phone that ships. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+  ["laptop", 1440, 900],
+]
+
+/** The same devices with the insets a real notch and home indicator produce. */
+const NOTCHED: Array<[string, number, number, Insets]> = [
+  ["phone portrait, notch + home indicator", 390, 844, { top: 59, right: 0, bottom: 34, left: 0 }],
+  ["phone landscape, notch on the left", 844, 390, { top: 0, right: 59, bottom: 21, left: 59 }],
+  ["small phone", 320, 568, { top: 44, right: 0, bottom: 34, left: 0 }],
+]
+
+const ALL: Array<[string, number, number, Insets]> = [
+  ...VIEWPORTS.map(([n, w, h]) => [n, w, h, NONE] as [string, number, number, Insets]),
+  ...NOTCHED,
+]
+
+for (const [name, w, h, insets] of ALL) {
+  test(`nothing a child must read sits under the host's corners — ${name} (${w}×${h})`, () => {
+    const f = hudFrame(w, h, insets)
+
+    // `LVL 4`. Read every level.
+    assert.equal(hitsHostChrome(f.left, w, insets), false, `${name}: the level counter is covered`)
+
+    // The score and the LIVES. A child who cannot see three pink squares go to
+    // two does not know the run is ending.
+    assert.equal(
+      hitsHostChrome(f.right, w, insets),
+      false,
+      `${name}: the score and lives are covered`,
+    )
+
+    // The fraction bar. It IS the pedagogy — cut into the goal's denominator —
+    // and it spans the full width, so it cannot dodge the corners sideways. It
+    // has to sit below them, and BOTH of its ends have to be visible.
+    assert.equal(hitsHostChrome(f.meter, w, insets), false, `${name}: the fraction bar is covered`)
+
+    // The two clusters must not have been pushed into each other, which is the
+    // failure mode of "just add padding until the test goes green".
+    assert.ok(
+      f.left.x + f.left.w <= f.right.x + 0.5,
+      `${name}: the level counter and the score overlap`,
+    )
+    // And the goal fraction, which sits between them, must keep real room.
+    assert.ok(
+      f.right.x - (f.left.x + f.left.w) >= 40,
+      `${name}: only ${(f.right.x - f.left.x - f.left.w).toFixed(0)}px left for the goal fraction`,
+    )
+  })
+
+  test(`the HUD stays inside the safe area — ${name} (${w}×${h})`, () => {
+    const f = hudFrame(w, h, insets)
+    assert.ok(f.left.x >= insets.left, `${name}: the level counter is under the left inset`)
+    assert.ok(
+      f.right.x + f.right.w <= w - insets.right + 0.5,
+      `${name}: the score is under the right inset`,
+    )
+    assert.ok(f.meter.x >= insets.left, `${name}: the fraction bar starts under the left inset`)
+    assert.ok(
+      f.meter.x + f.meter.w <= w - insets.right + 0.5,
+      `${name}: the fraction bar runs under the right inset`,
+    )
+    assert.ok(f.padTop >= insets.top, `${name}: the HUD starts above the safe area`)
+  })
+
+  test(`the mute button is a real, reachable target — ${name} (${w}×${h})`, () => {
+    const m = muteRect(w, h, insets)
+    assert.equal(m.w, HOST_CONTROL, "the mute button is under the platform touch floor")
+    assert.equal(m.h, HOST_CONTROL, "the mute button is under the platform touch floor")
+    assert.ok(
+      m.y + m.h <= h - insets.bottom + 0.5,
+      `${name}: the mute button is inside the home indicator`,
+    )
+    assert.ok(
+      m.x + m.w <= w - insets.right + 0.5,
+      `${name}: the mute button is under the right inset`,
+    )
+    assert.equal(hitsHostChrome(m, w, insets), false, `${name}: the mute button is under chrome`)
+  })
+}
+
+// The arena is measured in stage-local pixels, and the stage is flush to the
+// frame's left, right and bottom edges. Its height here is the frame height
+// minus a plausible HUD; the assertion does not depend on the exact value.
+for (const [name, w, h, insets] of NOTCHED) {
+  test(`the arena keeps its ground out of the unsafe edges — ${name}`, () => {
+    const stageH = Math.max(120, h - 130)
+    const a = arenaRect(w, stageH, insets)
+
+    assert.ok(a.x >= insets.left, `${name}: the arena starts under the left inset`)
+    assert.ok(
+      a.x + a.w <= w - insets.right + 0.5,
+      `${name}: the arena runs under the right inset`,
+    )
+    assert.ok(
+      a.y + a.h <= stageH - insets.bottom + 0.5,
+      `${name}: the bottom rows of cells are under the home indicator`,
+    )
+    // And it did not collapse to nothing doing it.
+    assert.ok(a.w > w * 0.6, `${name}: the arena lost ${(100 - (a.w * 100) / w).toFixed(0)}% width`)
+    assert.ok(a.h > stageH * 0.7, `${name}: the arena lost too much height`)
+  })
+}
+
+test("with no insets the arena is the whole stage, exactly as it was", () => {
+  // The safe-area work must be a no-op on a device with nothing to avoid, or it
+  // is a regression dressed as a fix.
+  const a = arenaRect(1024, 600, NONE)
+  assert.deepEqual(a, { x: 0, y: 0, w: 1024, h: 600 })
+})


### PR DESCRIPTION
## What

Lay CLAIM's arena and HUD out inside the safe rectangle, move the level counter,
the score and the lives out from under the host's two 44px corners, give the
mute button a real touch target off the home indicator, and add a how-to-play
surface the game has never had.

## Why

CLAIM declares `viewport-fit=cover`. Its HUD is DOM, so it *could* claw the
notch back with `env(safe-area-inset-top)` — and did. Only the top, and only for
the HUD. Four things were left out:

- **The arena.** The grid is centred in a canvas that runs to the bottom and
  both sides of the frame. Cells are not decoration: they are the ground the
  child drives across and the thing the fraction is measured in. A row of cells
  under the home indicator is ground that cannot be seen, cannot be cut, and
  swallows an upward drag as a system gesture.
- **The sides.** `padding: ... 12px` ignored the left and right insets, so in
  landscape `LVL 4` sat behind the notch.
- **The host's two corners.** The level counter was under the exit control; the
  score and the three lives were under how-to-play. A child who cannot watch
  three pink squares go to two does not know the run is ending.
- **The mute button.** `right: 10px; bottom: 10px` — inside the home indicator —
  and 34px square against a 44px platform floor.

**Why a new module rather than more CSS.** `env()` cannot be asserted from a
test. A CSS-only fix would be exactly as invisible to this package's suite as
the four bugs were, and "check it on a device" is precisely how all four
shipped. So the numbers moved into `src/game/layout.ts` — one pure function per
surface, `insets` **required**, not optional — `Hud.layout` publishes them as
custom properties, the stylesheet consumes them (keeping `env()` fallbacks for a
HUD that somehow never gets laid out), and `test/layout.test.ts` asserts the
same values through `hitsHostChrome`.

Host chrome **overlays**; nothing reserves a band. The two clusters step
**inboard** of the corners rather than downward, which costs the arena nothing —
reserving a top strip cost 12% of a small phone's height in SKY LEDGER and broke
its own layout. The fraction bar spans the full width and so cannot dodge
sideways, so the top row gets exactly enough `min-height` to put the bar below
the corners and not a pixel more; the stacked goal fraction is already taller
than that on most screens, so in practice nothing moves.

## Blast radius

**Areas touched:** dynawalla (one game pack, `dynawalla/games/claim` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published zip changed in place; `pack.json`
      untouched (id, version, capabilities, the three declared `dw.frac.*` rows
      all unchanged). No `voiceId`, no catalog entry.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are instruction
      copy inside the pack; it declares `"locales": ["en"]` and has no i18n
      catalogue, same as SKY LEDGER's adoption.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema
      touched. `exact.ts`, `levels.ts` and the exact-cell band are untouched and
      `claim.test.ts` passes unchanged.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

**What a reviewer cannot reconstruct from the diff:**

*The arena still owns every pixel it used to on a device with no insets.*
`arenaRect(w, h, {0,0,0,0})` is asserted to equal `{0,0,w,h}` exactly — the
safe-area work has to be a no-op where there is nothing to avoid, or it is a
regression dressed as a fix. Only the **grid** is constrained; the canvas still
covers the whole stage and the paper and vignette still bleed to the edges,
which is the entire point of `cover`.

*`stageAspect()` now measures the safe part of the stage.* `pickArena` chooses
which 7200-cell arena shape to use; every shape is exactly 7200 cells in exactly
40 blocks, so this changes *which* 7200 on a notched landscape phone, never how
many. The goal's meaning is unaffected — that invariant is what `claim.test.ts`
already guards.

*Insets are re-read on every layout, not cached.* `onInsetsChange` is subscribed
in the constructor and unsubscribed in `destroy`, because rotation swaps
top/bottom with left/right and Split View changes them outright, and neither
necessarily resizes the stage. Without it the HUD is laid out for the shape the
tablet was in when the pack opened.

*`destroy()` now calls `stopInsets()` and `guide.destroy()`*, removing the help
button, the panel, the injected stylesheet, the `keydown` handler and the inset
watcher.

## Proof

`npm test` five times — one green run is not proof:

```
$ for i in 1 2 3 4 5; do npm test 2>&1 | grep -E "^# (tests|pass|fail)"; done
--- run 1 ---
# tests 57
# pass 57
# fail 0
--- run 2 ---
# tests 57
# pass 57
# fail 0
--- run 3 ---
# tests 57
# pass 57
# fail 0
--- run 4 ---
# tests 57
# pass 57
# fail 0
--- run 5 ---
# tests 57
# pass 57
# fail 0
```

**Both halves fail when the fix is removed.** A clearance test that passes
either way is worthless.

Corner clearance — drop the gutters and the top row's min-height:

```
not ok 27 - nothing a child must read sits under the host's corners — phone portrait, small (320×568)
not ok 30 - nothing a child must read sits under the host's corners — phone portrait, tall (390×844)
not ok 33 - nothing a child must read sits under the host's corners — tablet portrait (768×1024)
not ok 36 - nothing a child must read sits under the host's corners — tablet landscape (1024×768)
not ok 39 - nothing a child must read sits under the host's corners — phone landscape (844×390)
not ok 42 - nothing a child must read sits under the host's corners — laptop (1440×900)
not ok 45 - nothing a child must read sits under the host's corners — phone portrait, notch + home indicator (390×844)
not ok 48 - nothing a child must read sits under the host's corners — phone landscape, notch on the left (844×390)
not ok 51 - nothing a child must read sits under the host's corners — small phone (320×568)
# tests 57
# pass 48
# fail 9
```

Safe area — `arenaRect` back to the full canvas, HUD padding back to a bare
12px, mute back to 34px at `bottom: 10px`:

```
not ok 29 - the mute button is a real, reachable target — phone portrait, small (320×568)
not ok 32 - the mute button is a real, reachable target — phone portrait, tall (390×844)
not ok 35 - the mute button is a real, reachable target — tablet portrait (768×1024)
not ok 38 - the mute button is a real, reachable target — tablet landscape (1024×768)
not ok 41 - the mute button is a real, reachable target — phone landscape (844×390)
not ok 44 - the mute button is a real, reachable target — laptop (1440×900)
not ok 47 - the mute button is a real, reachable target — phone portrait, notch + home indicator (390×844)
not ok 49 - the HUD stays inside the safe area — phone landscape, notch on the left (844×390)
not ok 50 - the mute button is a real, reachable target — phone landscape, notch on the left (844×390)
not ok 53 - the mute button is a real, reachable target — small phone (320×568)
not ok 54 - the arena keeps its ground out of the unsafe edges — phone portrait, notch + home indicator
not ok 55 - the arena keeps its ground out of the unsafe edges — phone landscape, notch on the left
not ok 56 - the arena keeps its ground out of the unsafe edges — small phone
# tests 57
# pass 44
# fail 13
```

Node reports zero insets, so the safe-area half runs against three *simulated*
notched devices — without those it could not fail at all.

```
$ npm run tsc
> @dynawalla/game-claim@0.1.0 tsc
> tsc --noEmit

$ npm run build
✓ 23 modules transformed.
dist/index.html                  0.56 kB │ gzip:  0.33 kB
dist/assets/index-CcKH7mjn.css   7.22 kB │ gzip:  2.30 kB
dist/assets/index-CjCE8Sh_.js   65.26 kB │ gzip: 22.67 kB
✓ built in 153ms
```

```
$ cd dynawalla/packs && node build.mjs claim
dynawalla.claim@0.1.0 — CLAIM
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       3 skills, grades 3–5
  on disk      4 files, 77404 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~19832 bytes (19.83 KB) in 34.6ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/claim/src/game/hud.ts
dynawalla/games/claim/src/game/index.ts
dynawalla/games/claim/src/game/layout.ts
dynawalla/games/claim/src/game/render.ts
dynawalla/games/claim/src/style.css
dynawalla/games/claim/test/layout.test.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```
