### PR TITLE
fix(dynawalla/games/coil): stop the manual firing a shear, and rebuild the layout when the insets move

### DIFF
--- a/dynawalla/games/coil/src/mount.ts
+++ b/dynawalla/games/coil/src/mount.ts
@@ -25,7 +25,7 @@
 // cut smashes two lumps on its way to the wall. The board you have to play on
 // is the board you made.
 
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import type { Host } from "./contract.ts"
 import { Audio } from "./audio/audio.ts"
 import { SLAG_CELLS, buried as buriedCount } from "./game/board.ts"
@@ -332,8 +332,18 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
     cutOnDown = -1
   }
 
-  /** Keyboard, for a desk. Same three verbs, nothing extra. */
+  /**
+   * Keyboard, for a desk. Same three verbs, nothing extra.
+   *
+   * Nothing behind the manual is something the child did. Space and Enter are
+   * how a panel is dismissed on a keyboard, and without this gate the dismissal
+   * fell through to `commit()` — firing a shear at whatever joint the jaws were
+   * parked on, reporting that answer, and dropping slag that costs lane cells
+   * for the rest of the run. A child cannot see the shear happen; the scrim is
+   * over it.
+   */
   const onKey = (e: KeyboardEvent): void => {
+    if (guide.isOpen) return
     const board = session.board
     lastInputAt = performance.now()
     fx.hint = 0
@@ -388,6 +398,14 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
       : null
   observer?.observe(container)
   globalThis.addEventListener("resize", resize)
+
+  // Rotating a notched phone from landscape-left to landscape-right changes the
+  // insets and nothing else — same width, same height, same pixel ratio — so
+  // neither the `ResizeObserver` nor `resize` would rebuild the layout, and the
+  // carved problem would stay where the help control used to be.
+  const stopInsets = onInsetsChange(() => {
+    resize()
+  })
   resize()
 
   // ------------------------------------------------------------------ frame
@@ -468,6 +486,7 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
       globalThis.removeEventListener("pointercancel", onCancel)
       globalThis.removeEventListener("keydown", onKey)
       globalThis.removeEventListener("resize", resize)
+      stopInsets()
       observer?.disconnect()
       media?.removeEventListener("change", onMedia)
       audio.dispose()

--- a/dynawalla/games/coil/src/render/layout.ts
+++ b/dynawalla/games/coil/src/render/layout.ts
@@ -116,10 +116,15 @@ export function layout(w: number, h: number, area: Rect): Layout {
   const clearR = area.x + area.w - CORNER
   const recessL = Math.max(wall.x + wall.w * 0.045, clearL)
   const recessR = Math.min(wall.x + wall.w * 0.955, clearR)
+  // No minimum width here, deliberately. A floor would widen the recess back
+  // out past `clearR` and under the help control — defeating the one thing the
+  // rect exists for, silently. The `1` only keeps the geometry from going
+  // negative; that the strip is actually wide enough to carve a problem into is
+  // asserted at every viewport in `chrome.test.ts`, where it fails loudly.
   const recess: Rect = {
     x: recessL,
     y: wall.y + wall.h * 0.12,
-    w: Math.max(60, recessR - recessL),
+    w: Math.max(1, recessR - recessL),
     h: wall.h * 0.52,
   }
 

--- a/dynawalla/games/coil/src/render/scene.ts
+++ b/dynawalla/games/coil/src/render/scene.ts
@@ -14,6 +14,7 @@ import type { Round } from "../game/round.ts"
 import { coilOf, linkValue } from "../game/place.ts"
 import { COURSE } from "../game/session.ts"
 import { SLAG_CELLS } from "../game/board.ts"
+import { safeInsets } from "../../../../packs/shared/game-chrome/index.ts"
 import { type Layout, type Lane, cellAt, viewLayout } from "./layout.ts"
 import { KIND_DUST, KIND_FILING, KIND_SPARK, Particles } from "./particles.ts"
 import {
@@ -201,8 +202,17 @@ export class Scene {
   private lattice: HTMLCanvasElement | null = null
   layout: Layout
   private dpr = 1
-  /** What `resize` last actually rebuilt for, so a no-op resize stays a no-op. */
-  private sized = { w: 0, h: 0 }
+  /**
+   * What `resize` last actually rebuilt for, so a no-op resize stays a no-op.
+   *
+   * The insets are part of this key, not just the size. Turning a notched phone
+   * from landscape-left to landscape-right changes neither `w`, `h` nor `dpr`
+   * but swaps `insets.left` and `insets.right` 59↔0 — and the memo would have
+   * held the old layout, leaving the carved problem under the help control that
+   * had moved to the other side. `insets.ts` warns about exactly this: a game
+   * that reads them once is correct until the first rotation.
+   */
+  private sized = { w: 0, h: 0, insets: "" }
 
   constructor(host: HTMLElement) {
     const canvas = document.createElement("canvas")
@@ -220,16 +230,25 @@ export class Scene {
     const width = Math.max(320, Math.round(w))
     const height = Math.max(360, Math.round(h))
     const dpr = Math.min(3, globalThis.devicePixelRatio || 1)
+    const insets = safeInsets()
+    const key = `${String(insets.top)},${String(insets.right)},${String(insets.bottom)},${String(insets.left)}`
     // A `ResizeObserver` fires on every frame of a window drag and on every
     // rotation animation step. Rasterising the lattice — a full-page offscreen
     // canvas of a hundred stars — on each of those is how a mid-range tablet
     // loses its frame budget to a gesture that changed nothing.
-    if (width === this.sized.w && height === this.sized.h && dpr === this.dpr) return this.layout
+    if (
+      width === this.sized.w &&
+      height === this.sized.h &&
+      key === this.sized.insets &&
+      dpr === this.dpr
+    ) {
+      return this.layout
+    }
     this.dpr = dpr
-    this.sized = { w: width, h: height }
+    this.sized = { w: width, h: height, insets: key }
     this.canvas.width = Math.round(width * dpr)
     this.canvas.height = Math.round(height * dpr)
-    this.layout = viewLayout(width, height)
+    this.layout = viewLayout(width, height, insets)
     this.lattice = this.buildLattice(width, height)
     return this.layout
   }
@@ -374,15 +393,29 @@ export class Scene {
       return
     }
 
-    const size = Math.min(w / Math.max(6, round.prompt.length) * 1.9, h * 0.5)
-    ctx.font = numerals(size)
     const demandText = String(round.demand)
     const head = round.prompt.endsWith(demandText)
       ? round.prompt.slice(0, round.prompt.length - demandText.length)
       : `${round.prompt} → `
+
+    // Size from the string that is actually drawn, not from `round.prompt`.
+    // On the fallback branch above, `head` gains three characters and the
+    // demand again — which the character count never knew about, so a long
+    // problem ran off the right of the recess and under the help control. The
+    // measure is the only honest fit: guess a size, then shrink it until what
+    // will be painted fits between the walls of the recess.
+    const inset = Math.min(12, w * 0.06)
+    const room = Math.max(1, w - inset * 2)
+    let size = Math.min((w / Math.max(6, head.length + demandText.length)) * 1.9, h * 0.5)
+    ctx.font = numerals(size)
+    const wanted = ctx.measureText(head).width + ctx.measureText(demandText).width
+    if (wanted > room) {
+      size = Math.max(9, (size * room) / wanted)
+      ctx.font = numerals(size)
+    }
     const headW = ctx.measureText(head).width
     const demandW = ctx.measureText(demandText).width
-    const startX = x + Math.max(12, (w - headW - demandW) / 2)
+    const startX = x + Math.max(inset, (w - headW - demandW) / 2)
     const midY = y + h * 0.44
 
     ctx.textAlign = "left"


### PR DESCRIPTION
## What

Four follow-ups to #611 in THE COIL OF NINETY-SIX: gate the game's global keyboard handler while the manual is open, rebuild the layout when the safe-area insets change, stop the recess width floor from defeating the corner clearance it exists for, and size the prompt from the string that is actually painted.

## Why

Three of these are regressions #611 introduced. They came out of an adversarial self-review of that diff, after it had merged.

**The manual could cut the coil.** #611 added `createInstructions`, which opens a modal panel and focuses a `tabIndex=-1` div — that consumes nothing. Space and Enter are how a child dismisses a panel on a keyboard, and coil's `globalThis.addEventListener("keydown", onKey)` was still live behind the scrim. The dismissal fell through to `commit()`: a shear fires at whatever joint the jaws happen to be parked on, `session.commit()` reports that (wrong) answer to the host, and the piece drops in the lane as slag — which permanently costs lane cells for the rest of the run. The child cannot see any of it; the scrim is over the alley. `b` cracked a link and the arrows re-aimed the same way. This is a fleet pattern — `dynawalla/games/skyledger/src/mount.ts` has the identical shape on main today — but coil acquired it in #611 and `guide.isOpen` was already in scope.

**Rotation held a stale layout.** `Scene.resize` memoised on `(w, h, dpr)`, which was sound while the layout was a pure function of the size. #611 made it a function of the insets too. Turning a notched phone from landscape-left to landscape-right changes neither `w`, `h` nor `dpr`, and swaps `insets.left`/`insets.right` 59↔0 — so the memo returned the old layout, with the recess still inset away from the corner the help control had just left and sitting under the one it had moved to. `insets.ts` warns about exactly this ("correct until the first rotation and wrong after it") and ships `onInsetsChange`; #611 never subscribed. The insets now join the memo key, and `onInsetsChange` drives a resize, because that rotation fires no size change for the `ResizeObserver` to see either.

**The recess width floor defeated its own purpose.** `w: Math.max(60, recessR - recessL)` widened the rect back out past `clearR`, under the help control, whenever the safe area was narrower than ~172px — silently, which is the precise failure mode the inset exists to prevent. Dead code at the 320px floor the app designs to (the narrowest tested case leaves 208px), and the wrong clamp regardless. It is now `Math.max(1, …)`, which only stops `roundRect` being handed a negative width; that the strip is genuinely wide enough to carve a problem into is asserted at every viewport by `chrome.test.ts`, where it fails loudly instead.

**The prompt could still overflow.** `drawPrompt` sized the type from `round.prompt.length`, but the string it paints is `head + demand`, and on the fallback branch (`round.ts`, when the prompt does not end with the demand) `head` gains `" → "` plus the demand again — three-plus characters the count never knew about — while `size` is capped by `h * 0.5` and cannot shrink to fit a narrower box. The clamp predates #611; #611 narrowed the recess and removed the slack that was hiding it, so a long fallback prompt could run past the recess edge into the help control. It now measures what will actually be painted and shrinks to fit.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/coil/`)

- [x] Every touched path is covered by a `ci.yml` area filter — all three files are under `dynawalla/games/coil/src/`.
- [x] **Pack back-compat.** No published zip changed in place; `pack.json` untouched — same id, version, capabilities, skill coverage. No `voiceId`, no catalog entry.
- [x] **Native integrity.** N/A — no Rust, no manifest.
- [x] **Strings.** No new user-visible string; the guide copy is unchanged from #611.
- [x] **Curriculum.** N/A — no skill, generator, schema or grade touched. The rules of the game are unchanged: `session`, `board`, `place` and `round` are not in the diff.
- [x] **Secrets.** None. `gitleaks` below.

**What a reviewer cannot reconstruct from the diff:** the keyboard gate is an early `return` in `onKey`, so nothing behind the scrim is reachable — including the arrows, which only mutate `board.cut` and are harmless, but a jaw that moved while the child was reading the manual is still a surprise on dismissal. The insets are now read inside `Scene.resize` rather than defaulted inside `viewLayout`; in node and in any frame without insets both paths return zeros, so no test moves.

**One thing this PR does NOT fix, and it is worth a fleet decision.** Packs run in a sandboxed cross-origin iframe (`dynawalla-app/src/packs/frame.ts` — `sandbox="allow-scripts"`, no `allow-same-origin`), and `env(safe-area-inset-*)` is a property of the *top-level* browsing context: a child frame resolves it to 0. Nothing plumbs the host's real insets across the bridge. So on a real notched iPhone `safeInsets()` inside coil very likely returns zeros, `safeRect` is the full rect, and the safe-area half of #611 does not take effect — the corner half still does, because `CORNER` is measured from `area` and not from `env()`. That is a bug in the shared module's contract, not in this game, and it is the same for every game adopting the chrome. It wants a `Stage.tsx` → pack inset message, and it should be fixed once rather than 27 times.

## Proof

```
$ for i in 1 2 3 4 5; do npm test 2>&1 | grep -E "^# (tests|pass|fail)" | tr '\n' ' '; echo "(run $i)"; done
# tests 109 # pass 109 # fail 0 (run 1)
# tests 109 # pass 109 # fail 0 (run 2)
# tests 109 # pass 109 # fail 0 (run 3)
# tests 109 # pass 109 # fail 0 (run 4)
# tests 109 # pass 109 # fail 0 (run 5)

$ npm run tsc
> @dynawalla/game-coil@0.1.0 tsc
> tsc --noEmit
(exit 0, no output)

$ npm run build
computing gzip size...
dist/coil.js  43.78 kB │ gzip: 14.67 kB

✓ built in 21ms

$ node build.mjs coil
1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF scanned ~3461 bytes (3.46 KB) in 32.1ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/coil/src/mount.ts
dynawalla/games/coil/src/render/layout.ts
dynawalla/games/coil/src/render/scene.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
