### PR TITLE
dynawalla/games/rhythm: the question, the score and the gear come out from under the notch and the host's two corners

### DIFF
--- a/dynawalla/games/rhythm/src/index.ts
+++ b/dynawalla/games/rhythm/src/index.ts
@@ -9,8 +9,10 @@
  * jitter — 16ms, which is a third of the Perfect window.
  */
 
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, Mount } from "./contract.ts";
 import { Game, type Lane } from "./game/core.ts";
+import { GEAR_EDGE, GEAR_SIZE, GEAR_TOP, PANEL_TOP } from "./render/layout.ts";
 import { Renderer } from "./render/renderer.ts";
 import { autoTier, type Tier } from "./theme.ts";
 
@@ -20,7 +22,9 @@ const CSS = `
   color:#eaf2ff;-webkit-user-select:none;user-select:none;touch-action:none}
 .sb-canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
 .sb-overlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
-  flex-direction:column;gap:2.2vh;text-align:center;padding:4vmin;
+  flex-direction:column;gap:2.2vh;text-align:center;overflow:auto;
+  padding:max(4vmin,env(safe-area-inset-top)) max(4vmin,env(safe-area-inset-right))
+          max(4vmin,env(safe-area-inset-bottom)) max(4vmin,env(safe-area-inset-left));
   background:radial-gradient(120% 90% at 50% 40%,rgba(10,16,48,.72),rgba(3,4,12,.94));
   backdrop-filter:blur(3px)}
 .sb-title{font-size:clamp(38px,11vmin,120px);font-weight:900;letter-spacing:-.03em;margin:0;
@@ -39,10 +43,16 @@ const CSS = `
   letter-spacing:.1em;padding:.55em 1em;border-radius:10px;background:rgba(255,255,255,.05);
   border:1px solid rgba(255,255,255,.1)}
 .sb-dot{width:1.05em;height:1.05em;flex:none}
-.sb-gear{position:absolute;top:max(8px,env(safe-area-inset-top));right:max(8px,env(safe-area-inset-right));
-  width:40px;height:40px;border-radius:12px;border:1px solid rgba(255,255,255,.16);
+.sb-gear{position:absolute;
+  top:calc(max(${GEAR_EDGE}px,env(safe-area-inset-top)) + ${GEAR_TOP}px);
+  right:max(${GEAR_EDGE}px,env(safe-area-inset-right));
+  width:${GEAR_SIZE}px;height:${GEAR_SIZE}px;border-radius:12px;border:1px solid rgba(255,255,255,.16);
   background:rgba(6,10,26,.72);color:#cfe4ff;font:800 17px/1 inherit;cursor:pointer;z-index:6}
-.sb-panel{position:absolute;top:56px;right:max(8px,env(safe-area-inset-right));width:min(290px,86vw);
+.sb-panel{position:absolute;
+  top:calc(max(${GEAR_EDGE}px,env(safe-area-inset-top)) + ${PANEL_TOP}px);
+  right:max(${GEAR_EDGE}px,env(safe-area-inset-right));width:min(290px,86vw);
+  max-height:calc(100% - max(${GEAR_EDGE}px,env(safe-area-inset-top)) - ${PANEL_TOP}px
+    - max(${GEAR_EDGE}px,env(safe-area-inset-bottom)));overflow-y:auto;overscroll-behavior:contain;
   background:rgba(6,10,26,.96);border:1px solid rgba(255,255,255,.14);border-radius:16px;
   padding:16px;display:grid;gap:14px;z-index:6;box-shadow:0 18px 60px rgba(0,0,0,.6)}
 .sb-row{display:grid;gap:7px}
@@ -53,7 +63,7 @@ const CSS = `
 .sb-seg button[aria-pressed=true]{background:rgba(120,220,255,.22);border-color:rgba(120,220,255,.75);color:#fff}
 .sb-panel input[type=range]{width:100%;accent-color:#7ee8ff}
 .sb-val{font:700 12px/1 inherit;color:rgba(190,215,255,.8)}
-.sb-perf{position:absolute;left:6px;bottom:6px;font:700 11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;
+.sb-perf{position:absolute;left:max(6px,env(safe-area-inset-left));bottom:max(6px,env(safe-area-inset-bottom));font:700 11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;
   color:rgba(150,200,255,.75);z-index:5;pointer-events:none;white-space:pre}
 .sb-hide{display:none!important}
 @media (prefers-reduced-motion:reduce){.sb-btn{transition:none}}
@@ -143,6 +153,58 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
   const perfBox = document.createElement("div");
   perfBox.className = "sb-perf sb-hide";
   root.appendChild(perfBox);
+
+  /* ---------------- how to play ---------------- */
+  // Splitbeat shipped with a legend of three coloured chips and the line "Tap
+  // the lane on the beat", which says which key is which lane and nothing about
+  // WHEN. In a timing game that is the whole rule: a child who does not know
+  // there is a window either taps early forever or decides the game is broken.
+  const guide = createInstructions(root, {
+    title: "SPLITBEAT",
+    summary: [
+      "Notes fly toward the bright line. Tap the lane when a note reaches it.",
+      "There are three lanes. Tap the one the note is in.",
+    ],
+    sections: [
+      {
+        heading: "Tapping",
+        lines: [
+          "Touch the top, middle or bottom of the screen. The part you touch is the lane you play.",
+          "Tap when the note is sitting on the bright line, not before it gets there.",
+          "A little early or a little late still counts. Right on the line gives you PERFECT.",
+          "If nothing happens when you tap, the note was still too far away. Wait for it to reach the line.",
+          "On a keyboard: A, S and D, or J, K and L, or the arrow keys.",
+        ],
+      },
+      {
+        heading: "Splitting the beat",
+        lines: [
+          "The music is counted in bars. One bar is one whole.",
+          "The notes cut the bar into equal pieces: two halves, then four quarters, then eight eighths.",
+          "You feel the piece in your hands first. Then you see it written down.",
+        ],
+      },
+      {
+        heading: "Questions",
+        lines: [
+          "Now and then a question appears at the top of the screen.",
+          "Three notes come at you, one in each lane, and each one has an answer on it.",
+          "Tap the lane with the right answer when it reaches the line.",
+          "A right answer adds one block of charge. A wrong one takes two away.",
+        ],
+      },
+      {
+        heading: "Charge",
+        lines: [
+          "The five blocks near the top are your charge.",
+          "If they all run out the music breaks down. Answer one more question right and it starts again.",
+          "The run never ends. You always get another go.",
+        ],
+      },
+    ],
+    reducedMotion: host.prefersReducedMotion(),
+    onClose: () => game.resumeFromPause(),
+  });
   const showPerf = new URLSearchParams(location.search).has("perf");
   if (showPerf) perfBox.classList.remove("sb-hide");
 
@@ -199,6 +261,13 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
 
   const onPointer = (e: PointerEvent) => {
     if (panel.contains(e.target as Node) || gear.contains(e.target as Node)) return;
+    // The shared how-to-play surface floats over the whole field. A tap on it is
+    // a tap on it, never a note in the lane that happens to be underneath.
+    const inGuide = (e.target as HTMLElement | null)?.closest?.(".dwc-help, .dwc-scrim");
+    if (inGuide) {
+      if (inGuide.classList.contains("dwc-help")) game.pause();
+      return;
+    }
     e.preventDefault();
     if (game.phase === "title") {
       void begin();
@@ -212,6 +281,7 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
 
   const onKey = (e: KeyboardEvent) => {
     if (e.repeat) return;
+    if (guide.isOpen) return;
     if (e.key === "Escape") {
       panel.classList.toggle("sb-hide");
       if (panel.classList.contains("sb-hide")) game.resumeFromPause();
@@ -239,6 +309,10 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
   const ro = new ResizeObserver(() => renderer.resize());
   ro.observe(root);
   window.addEventListener("orientationchange", () => renderer.resize());
+  // Insets are not fixed: rotation swaps top/bottom with left/right, and iPadOS
+  // changes them when the pack is resized in Split View. A layout read once at
+  // mount is right until the first rotation and wrong after it.
+  const stopInsets = onInsetsChange(() => renderer.resize());
 
   /* ---------------- loop ---------------- */
   let raf = 0;
@@ -328,6 +402,8 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
     unmount() {
       alive = false;
       cancelAnimationFrame(raf);
+      guide.destroy();
+      stopInsets();
       ro.disconnect();
       root.removeEventListener("pointerdown", onPointer);
       window.removeEventListener("keydown", onKey);

--- a/dynawalla/games/rhythm/src/render/layout.test.ts
+++ b/dynawalla/games/rhythm/src/render/layout.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The two promises this game makes about its frame, checked at every shape a
+ * child might hold the thing in.
+ *
+ * 1. Nothing readable or touchable is under the notch, the home indicator or a
+ *    rounded corner. Splitbeat declares `viewport-fit=cover`, so that is opt-in
+ *    damage, not bad luck.
+ * 2. Nothing readable or touchable is in the host's two 44px corner controls.
+ *    The host's exit sits top-left and its how-to-play top-right, floating over
+ *    the pack. This game's OWN settings gear used to sit in the second one.
+ *
+ * These are asserted with the same `hitsHostChrome` the host's constants come
+ * from, so if the host moves a control this test moves with it.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  hitsHostChrome,
+  NO_INSETS,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { gearRect, layoutFor, type Layout } from "./layout.ts";
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["small phone portrait", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+/** A notched phone held upright, and the same phone on its side. */
+const PORTRAIT_NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+const LANDSCAPE_NOTCH: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const INSETS: Array<[string, Insets]> = [
+  ["no insets", NO_INSETS],
+  ["portrait notch", PORTRAIT_NOTCH],
+  ["landscape notch", LANDSCAPE_NOTCH],
+];
+
+/**
+ * Every box a child must read or touch, in screen pixels.
+ *
+ * The widths are the widest the drawing code can produce: six digits of score at
+ * weight 900 is about 7.6 units; the sector line is the longest string on the
+ * screen; the question plate's own size cap holds it to `area.w * 0.86` plus its
+ * padding. Measuring generously is the point — a box that is too wide can only
+ * make this test stricter.
+ */
+function readables(l: Layout, w: number, insets: Insets): Array<[string, Rect]> {
+  const u = l.u;
+  const promptW = l.area.w * 0.86 + u * 2.4;
+  // The combo grows with the streak; this is the largest it gets.
+  const comboH = u * 4.13;
+  return [
+    ["score", { x: l.hudX, y: l.scoreTop, w: u * 7.6, h: l.scoreH }],
+    ["sector line", { x: l.hudX, y: l.sectorY - u * 0.39, w: u * 16, h: u * 0.78 }],
+    [
+      "charge strip",
+      {
+        x: l.chargeX,
+        y: l.chargeY,
+        w: l.chargeCellW * 5 + u * 0.1 * 4,
+        h: l.chargeCellH,
+      },
+    ],
+    ["question plate", { x: l.cx - promptW / 2, y: l.promptY, w: promptW, h: l.promptMaxH }],
+    ["combo", { x: l.strikeX - u * 0.2, y: l.playTop - u * 0.9 - comboH / 2, w: u * 6, h: comboH }],
+    // The play line itself. A note that passes behind a button is a note the
+    // child cannot read the answer off, and in a gate bar that is the question.
+    // The strike pad is `u * 1.15` wide, centred on the line; everything to the
+    // right of it is the note's approach, and everything to the left is history.
+    [
+      "note run",
+      {
+        x: l.strikeX - u * 0.6,
+        y: l.playTop,
+        w: l.area.x + l.area.w - l.strikeX + u * 0.6,
+        h: l.playH,
+      },
+    ],
+    ["settings gear", gearRect(w, insets)],
+  ];
+}
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    const area = safeRect(w, h, insets);
+    const l = layoutFor(w, area, insets);
+
+    test(`nothing readable is under host chrome — ${vname} ${w}×${h}, ${iname}`, () => {
+      for (const [what, box] of readables(l, w, insets)) {
+        assert.equal(
+          hitsHostChrome(box, w, insets),
+          false,
+          `${vname}/${iname}: the ${what} is under the host's chrome ` +
+            `(${box.x.toFixed(1)},${box.y.toFixed(1)} ${box.w.toFixed(1)}×${box.h.toFixed(1)})`,
+        );
+      }
+    });
+
+    test(`nothing readable is outside the safe area — ${vname} ${w}×${h}, ${iname}`, () => {
+      for (const [what, box] of readables(l, w, insets)) {
+        assert.ok(box.x >= area.x - 0.5, `${vname}/${iname}: the ${what} runs off the left`);
+        assert.ok(box.y >= area.y - 0.5, `${vname}/${iname}: the ${what} runs off the top`);
+        assert.ok(
+          box.x + box.w <= area.x + area.w + 0.5,
+          `${vname}/${iname}: the ${what} runs off the right`,
+        );
+        assert.ok(
+          box.y + box.h <= area.y + area.h + 0.5,
+          `${vname}/${iname}: the ${what} runs off the bottom`,
+        );
+      }
+    });
+
+    test(`the playfield is still playable — ${vname} ${w}×${h}, ${iname}`, () => {
+      // Chrome OVERLAYS; it does not reserve a band. Pushing the HUD down must
+      // not quietly shrink the lanes past a thumb.
+      assert.ok(l.laneH >= 44, `${vname}/${iname}: lane is only ${l.laneH.toFixed(0)}px tall`);
+      assert.ok(l.playH >= 120, `${vname}/${iname}: playfield is only ${l.playH.toFixed(0)}px`);
+      // A note must have room to be read on its way in.
+      assert.ok(
+        l.pps * 1.85 >= 150,
+        `${vname}/${iname}: only ${(l.pps * 1.85).toFixed(0)}px of run`,
+      );
+      // The run ends inside the safe area, so a label is readable as it enters.
+      assert.ok(Math.abs(l.strikeX + l.pps * 1.85 - (area.x + area.w)) < 0.5);
+    });
+  }
+}
+
+test("the settings gear is not in the corner the host puts its help button in", () => {
+  // This is the collision most likely to come back: the gear used to be
+  // `top:max(8px,env(top)); right:max(8px,env(right))`, which is exactly where
+  // the host's how-to-play control lands.
+  for (const [, w, h] of VIEWPORTS) {
+    for (const [, insets] of INSETS) {
+      void h;
+      assert.equal(hitsHostChrome(gearRect(w, insets), w, insets), false);
+    }
+  }
+});
+
+test("the question keeps its full width rather than squeezing between the corners", () => {
+  // The alternative fix — capping the plate so it fits in the 212px between the
+  // two corners at 320px — would shrink the one thing on screen that is being
+  // asked. Instead it drops below them, and this asserts it really is below.
+  const w = 320;
+  const insets = NO_INSETS;
+  const l = layoutFor(w, safeRect(w, 568, insets), insets);
+  assert.ok(l.promptY >= 57, `the plate starts at ${l.promptY}, inside the corner band`);
+  assert.ok(
+    l.playTop >= l.promptY + l.promptMaxH,
+    "a gate's own plate would cover the lane its answers ride down",
+  );
+});

--- a/dynawalla/games/rhythm/src/render/layout.ts
+++ b/dynawalla/games/rhythm/src/render/layout.ts
@@ -1,0 +1,175 @@
+/**
+ * Where everything goes, as numbers a test can check without a canvas.
+ *
+ * **Why this file exists.** Splitbeat declares `viewport-fit=cover`, which is not
+ * a neutral setting: it opts the document *into* the notch, the home indicator
+ * and the rounded corners. The DOM chrome could claw that back with `env()` and
+ * partly did — the gear guarded `top` and `right` and nothing guarded `bottom`
+ * or `left` — but the HUD that actually matters is drawn on a canvas, and a
+ * canvas cannot read `env()`. So the score sat at `y = u * 1.55` and the question
+ * plate at `y = u * 0.55`, which on a notched phone is behind the notch.
+ *
+ * On top of that the host paints its own controls over every pack: an exit
+ * control in the top-LEFT corner and a how-to-play control in the top-RIGHT,
+ * each a 44px square. Those overlay; they do not reserve a band, because
+ * reserving one costs 12% of a 568px phone and broke SKY LEDGER's own layout.
+ * What a game promises instead is that nothing a child must READ or TOUCH lands
+ * in those two squares — and in Splitbeat the score, the charge strip and the
+ * QUESTION all did.
+ *
+ * `area` is required, not optional. Made optional, a caller that forgets it
+ * compiles and quietly draws under the notch, and the only way to find out is on
+ * a device.
+ */
+
+import {
+  chromeRects,
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+
+export type { Rect };
+
+/** Seconds a note is visible before it reaches the strike line. */
+export const LEAD = 1.85;
+
+/**
+ * The game's own settings gear, which used to sit exactly where the host's
+ * how-to-play control lands. It drops below that square instead of moving to a
+ * different corner: every other corner is inside a lane a child is tapping, and
+ * a settings button that eats a note is worse than one that has moved 65px.
+ */
+export const GEAR_SIZE = 40;
+export const GEAR_EDGE = 8;
+export const GEAR_TOP = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + 8;
+export const PANEL_TOP = GEAR_TOP + GEAR_SIZE + 8;
+
+/** Where the gear ends up, for a test that will not take the CSS's word for it. */
+export function gearRect(w: number, insets: Insets): Rect {
+  return {
+    x: w - Math.max(GEAR_EDGE, insets.right) - GEAR_SIZE,
+    y: Math.max(GEAR_EDGE, insets.top) + GEAR_TOP,
+    w: GEAR_SIZE,
+    h: GEAR_SIZE,
+  };
+}
+
+export type Layout = {
+  /** The rectangle everything readable lives inside. */
+  area: Rect;
+  /** Type unit, from the short axis of the safe area. */
+  u: number;
+  /** Centre of the safe area, for everything that is centred. */
+  cx: number;
+  playTop: number;
+  playH: number;
+  laneH: number;
+  strikeX: number;
+  /** Pixels per second a note travels. */
+  pps: number;
+  /** Left edge of the score and the sector line. */
+  hudX: number;
+  /** Middle baseline of the score, plus the box it was cleared as. */
+  scoreY: number;
+  scoreTop: number;
+  scoreH: number;
+  /** Middle baseline of the sector / BPM / level line. */
+  sectorY: number;
+  /** Left edge and top of the five charge cells. */
+  chargeX: number;
+  chargeY: number;
+  chargeCellW: number;
+  chargeCellH: number;
+  /** Top of the question plate, and the tallest it can be. */
+  promptY: number;
+  promptMaxH: number;
+};
+
+/**
+ * The smallest `y` at or below `top` where a box spanning `left`..`right`
+ * touches no host control.
+ *
+ * There is no branch here on "is the corner over the playfield" — in landscape
+ * the corners simply do not overlap the span and nothing moves.
+ */
+function clearOf(top: number, left: number, right: number, chrome: readonly Rect[]): number {
+  let y = top;
+  for (const c of chrome) {
+    if (right > c.x && c.x + c.w > left && y < c.y + c.h) y = c.y + c.h;
+  }
+  return y;
+}
+
+/**
+ * @param w      canvas width in CSS pixels — the host's help control is measured
+ *               from the canvas's right edge, not the safe area's.
+ * @param area   the safe rectangle — `safeRect(w, h)`. REQUIRED, so that a
+ *               caller who forgets it does not compile.
+ * @param insets the same insets `area` was built from, for the host's corners.
+ */
+export function layoutFor(w: number, area: Rect, insets: Insets): Layout {
+  const chrome = chromeRects(w, insets);
+  const u = Math.min(area.w, area.h) / 46;
+  const cx = area.x + area.w / 2;
+
+  // The question is the most critical thing on the screen, so it keeps its full
+  // width and moves DOWN past the corners rather than being shrunk to fit
+  // between them. At 320px the between-the-corners budget is 212px, and a
+  // question squeezed into that is a question a nine-year-old squints at.
+  const promptMaxH = u * 5.75;
+  const promptY = clearOf(area.y + u * 0.55, area.x, area.x + area.w, chrome);
+
+  // The playfield starts below whatever the question plate can occupy, so a
+  // gate never covers the lane its own answers are travelling down.
+  const playTop = Math.max(
+    area.y + Math.max(58, area.h * 0.155),
+    promptY + promptMaxH + u * 0.5,
+  );
+  const botPad = Math.max(40, area.h * 0.11);
+  const playH = Math.max(120, area.y + area.h - playTop - botPad);
+  const laneH = playH / 3;
+
+  const strikeX = area.x + Math.min(Math.max(area.w * 0.235, 62), 240);
+  const pps = (area.x + area.w - strikeX) / LEAD;
+
+  // Score column, top-left. Six digits at weight 900 is about 7.6 units wide;
+  // the sector line under it is longer, so the span is measured generously.
+  const hudX = area.x + u * 0.9;
+  const scoreH = u * 2.05;
+  const colRight = area.x + area.w * 0.6;
+  const scoreTop = clearOf(area.y + u * 1.55 - scoreH / 2, hudX, colRight, chrome);
+  const scoreY = scoreTop + scoreH / 2;
+  const sectorY = scoreY + u * 1.4;
+
+  // Charge strip, top-right.
+  const chargeCellW = u * 1.15;
+  const chargeCellH = u * 0.72;
+  const chargeW = chargeCellW * 5 + u * 0.1 * 4;
+  const chargeX = area.x + area.w - u * 0.9 - chargeCellW * 5 - u * 0.4;
+  const chargeY = clearOf(area.y + u * 0.85, chargeX, chargeX + chargeW, chrome);
+
+  return {
+    area,
+    u,
+    cx,
+    playTop,
+    playH,
+    laneH,
+    strikeX,
+    pps,
+    hudX,
+    scoreY,
+    scoreTop,
+    scoreH,
+    sectorY,
+    chargeX,
+    chargeY,
+    chargeCellW,
+    chargeCellH,
+    promptY,
+    promptMaxH,
+  };
+}

--- a/dynawalla/games/rhythm/src/render/renderer.ts
+++ b/dynawalla/games/rhythm/src/render/renderer.ts
@@ -22,12 +22,12 @@ import {
   LANE_COLOR, LANE_NAME, LANE_SHAPE, font, mix, rgba, themeFor,
   TIER_SPEC, type Rgb, type Tier,
 } from "../theme.ts";
+import { safeInsets, safeRect } from "../../../../packs/shared/game-chrome/index.ts";
+import { layoutFor, LEAD, type Layout } from "./layout.ts";
 import { drawRich, measureRich } from "./typeset.ts";
 import {
   Particles, PAL_BLOOM, PAL_DIM, PAL_GOLD, PAL_HORIZON, PAL_WHITE,
 } from "./particles.ts";
-
-const LEAD = 1.85; // seconds a note is visible before its strike
 const HISTORY = 110;
 const FLASH_MIN_GAP = 0.34;
 const FLASH_MAX = 0.42;
@@ -49,6 +49,14 @@ export class Renderer {
   private strikeX = 0;
   private pps = 200;
   private u = 10; // type unit, from the short axis
+  /**
+   * Where the readable things go. Rebuilt on every resize from the measured
+   * safe area, so the HUD is never under the notch and never under the host's
+   * two 44px corner controls.
+   */
+  private lay: Layout = layoutFor(320, { x: 0, y: 0, w: 320, h: 240 }, {
+    top: 0, right: 0, bottom: 0, left: 0,
+  });
 
   private spec = TIER_SPEC.mid;
   tier: Tier = "mid";
@@ -111,15 +119,19 @@ export class Renderer {
     this.canvas.width = Math.round(w * this.dpr);
     this.canvas.height = Math.round(h * this.dpr);
 
-    const short = Math.min(w, h);
-    this.u = short / 46;
-    const topPad = Math.max(58, h * 0.155);
-    const botPad = Math.max(40, h * 0.11);
-    this.playTop = topPad;
-    this.playH = Math.max(120, h - topPad - botPad);
-    this.laneH = this.playH / 3;
-    this.strikeX = Math.min(Math.max(w * 0.235, 62), 240);
-    this.pps = (w - this.strikeX) / LEAD;
+    // The canvas still covers the whole frame — the canyon, the skyline and the
+    // dust are meant to bleed under the notch, which is what `viewport-fit=cover`
+    // is for. It is the lanes, the strike line and every numeral that move
+    // inside the safe rectangle.
+    const insets = safeInsets();
+    const lay = layoutFor(w, safeRect(w, h, insets), insets);
+    this.lay = lay;
+    this.u = lay.u;
+    this.playTop = lay.playTop;
+    this.playH = lay.playH;
+    this.laneH = lay.laneH;
+    this.strikeX = lay.strikeX;
+    this.pps = lay.pps;
 
     const bw = Math.max(64, Math.round(this.canvas.width / 4));
     const bh = Math.max(48, Math.round(this.canvas.height / 4));
@@ -865,23 +877,25 @@ export class Renderer {
     ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
     ctx.textBaseline = "middle";
 
+    const lay = this.lay;
+
     // --- score -------------------------------------------------------
     ctx.textAlign = "left";
     ctx.font = font(u * 2.05, 900);
     ctx.fillStyle = "rgba(255,255,255,0.97)";
-    ctx.fillText(String(Math.round(g.score)).padStart(6, "0"), u * 0.9, u * 1.55);
+    ctx.fillText(String(Math.round(g.score)).padStart(6, "0"), lay.hudX, lay.scoreY);
     ctx.font = font(u * 0.78, 700);
     ctx.fillStyle = rgba(th.horizon, 0.75);
-    ctx.fillText(`${g.sector.name}  ·  ${Math.round(g.bpm)} BPM  ·  LV ${g.difficulty.toFixed(1)}`, u * 0.95, u * 2.95);
+    ctx.fillText(`${g.sector.name}  ·  ${Math.round(g.bpm)} BPM  ·  LV ${g.difficulty.toFixed(1)}`, lay.hudX + u * 0.05, lay.sectorY);
 
     // --- charge ------------------------------------------------------
-    const cellW = u * 1.15;
-    const cx0 = this.W - u * 0.9 - cellW * 5 - u * 0.4;
+    const cellW = lay.chargeCellW;
+    const cx0 = lay.chargeX;
     for (let i = 0; i < 5; i++) {
       const on = i < g.charge;
       const x = cx0 + i * (cellW + u * 0.1);
       ctx.fillStyle = on ? rgba(th.horizon, 0.95) : "rgba(255,255,255,0.13)";
-      this.roundRect(ctx, x, u * 0.85, cellW, u * 0.72, u * 0.16);
+      this.roundRect(ctx, x, lay.chargeY, cellW, lay.chargeCellH, u * 0.16);
       ctx.fill();
       if (!on) {
         ctx.strokeStyle = "rgba(255,255,255,0.22)";
@@ -914,11 +928,11 @@ export class Renderer {
     // --- the question ------------------------------------------------
     const gate = g.phase === "breakdown" ? g.reviveGate : g.activeGate;
     if (gate && gate.q && !gate.resolved && now >= gate.revealAt - 0.05) {
-      const size = Math.min(u * 2.5, this.W / (measureRich(ctx, gate.q.prompt, 100) / 100) * 0.86);
+      const size = Math.min(u * 2.5, lay.area.w / (measureRich(ctx, gate.q.prompt, 100) / 100) * 0.86);
       const bw = measureRich(ctx, gate.q.prompt, size) + u * 2.4;
       const bh = size * 2.3;
-      const bx = this.W / 2 - bw / 2;
-      const by = u * 0.55;
+      const bx = lay.cx - bw / 2;
+      const by = lay.promptY;
       ctx.fillStyle = "rgba(4,6,18,0.82)";
       this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
       ctx.fill();
@@ -926,7 +940,7 @@ export class Renderer {
       ctx.lineWidth = Math.max(1.5, u * 0.1);
       this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
       ctx.stroke();
-      drawRich(ctx, gate.q.prompt, this.W / 2, by + bh / 2, size, {
+      drawRich(ctx, gate.q.prompt, lay.cx, by + bh / 2, size, {
         fill: "#ffffff",
         glow: rgba(th.horizon, 0.8),
         glowWidth: size * 0.4,
@@ -941,26 +955,26 @@ export class Renderer {
 
     // --- timing meter ------------------------------------------------
     if (now - g.lastJudgeAt < 1.1 && g.lastVerdict) {
-      const mw = Math.min(this.W * 0.5, u * 13);
-      const mx = this.W / 2 - mw / 2;
+      const mw = Math.min(lay.area.w * 0.5, u * 13);
+      const mx = lay.cx - mw / 2;
       const my = this.playTop + this.playH + u * 1.5;
       const a = 1 - (now - g.lastJudgeAt) / 1.1;
       ctx.globalAlpha = a;
       ctx.fillStyle = "rgba(255,255,255,0.14)";
       ctx.fillRect(mx, my - u * 0.1, mw, u * 0.2);
       ctx.fillStyle = "rgba(255,255,255,0.4)";
-      ctx.fillRect(this.W / 2 - u * 0.05, my - u * 0.4, u * 0.1, u * 0.8);
+      ctx.fillRect(lay.cx - u * 0.05, my - u * 0.4, u * 0.1, u * 0.8);
       if (g.lastVerdict !== "miss") {
         const p = Math.max(-1, Math.min(1, g.lastDelta / 0.2));
         ctx.fillStyle = rgba(th.horizon, 1);
-        ctx.fillRect(this.W / 2 + (p * mw) / 2 - u * 0.12, my - u * 0.5, u * 0.24, u);
+        ctx.fillRect(lay.cx + (p * mw) / 2 - u * 0.12, my - u * 0.5, u * 0.24, u);
       }
       ctx.textAlign = "center";
       ctx.font = font(u * 0.72, 800);
       ctx.fillStyle = "rgba(255,255,255,0.85)";
       const word = g.lastVerdict.toUpperCase();
       const side = g.lastVerdict === "miss" ? "" : g.lastDelta < -0.012 ? "  EARLY" : g.lastDelta > 0.012 ? "  LATE" : "";
-      ctx.fillText(word + side, this.W / 2, my + u * 1.1);
+      ctx.fillText(word + side, lay.cx, my + u * 1.1);
       ctx.globalAlpha = 1;
     }
 
@@ -979,7 +993,7 @@ export class Renderer {
       ctx.textAlign = "center";
       ctx.font = font(u * 4.2, 900);
       ctx.fillStyle = rgba(th.horizon, 0.9);
-      ctx.fillText(g.sector.name, this.W / 2, this.playTop + this.playH / 2);
+      ctx.fillText(g.sector.name, lay.cx, this.playTop + this.playH / 2);
       ctx.globalAlpha = 1;
     }
 
@@ -991,21 +1005,21 @@ export class Renderer {
       ctx.textAlign = "center";
       ctx.font = font(u * 1.15, 900);
       ctx.fillStyle = rgba(th.horizon, 0.7 + pulse * 0.3);
-      ctx.fillText("RESTART THE HEART", this.W / 2, this.playTop - u * 1.2);
+      ctx.fillText("RESTART THE HEART", lay.cx, this.playTop - u * 1.2);
 
       for (let l = 0; l < 3; l++) {
         const y = this.laneY(l);
         const c = LANE_COLOR[l]!;
-        const w = Math.min(this.W * 0.82, u * 20);
+        const w = Math.min(lay.area.w * 0.82, u * 20);
         const h = this.laneH * 0.78;
         ctx.fillStyle = "rgba(7,10,24,0.95)";
-        this.roundRect(ctx, this.W / 2 - w / 2, y - h / 2, w, h, u * 0.6);
+        this.roundRect(ctx, lay.cx - w / 2, y - h / 2, w, h, u * 0.6);
         ctx.fill();
         ctx.strokeStyle = rgba(c, 0.75 + pulse * 0.25);
         ctx.lineWidth = Math.max(3, u * 0.24);
-        this.roundRect(ctx, this.W / 2 - w / 2, y - h / 2, w, h, u * 0.6);
+        this.roundRect(ctx, lay.cx - w / 2, y - h / 2, w, h, u * 0.6);
         ctx.stroke();
-        drawRich(ctx, g.reviveGate.labels[l]!, this.W / 2, y, Math.min(h * 0.44, u * 2.6), {
+        drawRich(ctx, g.reviveGate.labels[l]!, lay.cx, y, Math.min(h * 0.44, u * 2.6), {
           fill: "#ffffff", glow: rgba(c, 0.9), glowWidth: u,
         }, true);
       }


### PR DESCRIPTION
## What

SPLITBEAT adopts the shared game chrome: the canvas HUD moves inside the measured
safe area, the score, the charge strip, the question plate and the game's own
settings gear move out of the host's two 44px corners, every DOM surface gets
`env()` on all four edges it touches, and the game gets a how-to-play manual.

## Why

Two defects, both real on a device and neither visible in a desktop browser.

**Safe area.** `rhythm` was counted among the seven games that consume
`env(safe-area-inset-*)`. That count was generous: what it had was a top/right
half-fix on one button. `.sb-gear` guarded `top` and `right`; `.sb-panel` guarded
`right` and hard-coded `top:56px`; `.sb-overlay` — the title screen, with the PLAY
button on it — guarded nothing; `.sb-perf` was bare pixels. Meanwhile the HUD that
matters is drawn on a canvas, where `env()` is unreachable, so it was never
covered at all: the score sat at `y = u * 1.55` and the QUESTION plate at
`y = u * 0.55`, which on a notched phone is behind the notch.

**Host chrome.** The host paints an exit control top-left and a how-to-play
control top-right over every pack. Measured at 320×568 (`u = 6.96`) the score box
was x 6..67, y 4..18 — squarely inside the exit square (10..54, 13..57). The
question plate ran y 4..44, entirely inside the corner band; it is the thing being
asked, and it was under a button. And the game's own settings gear was pinned to
`top:max(8px,env(top)); right:max(8px,env(right))`, which is exactly where the
host's help control — and the new shared how-to-play button — land.

Chrome **overlays**; it does not reserve a band. Reserving one costs 12% of a
568px phone and broke SKY LEDGER's own lattice. So each element is pushed down
only past the host control that actually overlaps it horizontally, and in
landscape — where the corners fall outside the safe area entirely — nothing moves.

The question keeps its full width and drops below the corners rather than being
squeezed into the 212px between them; shrinking the one thing on screen that is
being asked is the wrong trade at 320px. The playfield then starts below the
plate's tallest possible box, so a gate never covers the lane its own answers are
travelling down. Lane pitch stays over 44px at every tested viewport.

Notes now run from the safe area's right edge rather than the canvas edge, so a
gate candidate's label is readable as it enters in landscape, where the left and
right insets are the notch.

The old onboarding was three coloured chips and "Tap the lane on the beat" — which
says which key is which lane and nothing about WHEN. In a timing game that is the
whole rule: a child who does not know there is a window taps early forever and
concludes the game is broken. The manual says it, stays reachable during play, and
pauses the run while it is open.

## Blast radius

**Areas touched:** dynawalla (one game pack)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no `voiceId`
      renamed; no catalog entry dropped or narrowed.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri` manifest touched.
- [x] **Strings.** N/A — pack-local copy, not `corpan-app` locales.
- [x] **Curriculum.** N/A — no skill, generator, schema or grade touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

## Proof

```
$ npm test   (run 1)
# tests 63
# pass 63
# fail 0
$ npm test   (run 2)
# tests 63
# pass 63
# fail 0
$ npm test   (run 3)
# tests 63
# pass 63
# fail 0
$ npm test   (run 4)
# tests 63
# pass 63
# fail 0
$ npm test   (run 5)
# tests 63
# pass 63
# fail 0
```

The clearance test bites. Neutering the corner-clearance helper so it returns its
input unchanged:

```
$ npm test          # with the corner fix removed
    small phone portrait/no insets:  the score is under the host's chrome (6.3,3.7 52.9x14.3)
    small phone portrait/portrait notch: the score is under the host's chrome (6.3,50.7 52.9x14.3)
    small phone portrait/landscape notch: the sector line is under the host's chrome (51.4,12.6 78.6x3.8)
    phone portrait/no insets: the score is under the host's chrome (7.6,4.5 64.4x17.4)
    phone portrait/portrait notch: the score is under the host's chrome (7.6,51.5 64.4x17.4)
    phone portrait/landscape notch: the score is under the host's chrome (52.8,3.4 48.9x13.2)
    tablet portrait/no insets: the score is under the host's chrome (15.0,8.8 126.9x34.2)
    tablet portrait/portrait notch: the score is under the host's chrome (15.0,55.8 126.9x34.2)
    tablet portrait/landscape notch: the score is under the host's chrome (60.2,7.7 111.4x30.0)
    tablet landscape/no insets: the score is under the host's chrome (15.0,8.8 126.9x34.2)
    tablet landscape/portrait notch: the score is under the host's chrome (13.4,54.8 113.5x30.6)
    tablet landscape/landscape notch: the score is under the host's chrome (61.6,8.5 123.4x33.3)
    phone landscape/no insets: the score is under the host's chrome (7.6,4.5 64.4x17.4)
    phone landscape/portrait notch: the score is under the host's chrome (6.0,50.5 51.1x13.8)
    phone landscape/landscape notch: the score is under the host's chrome (54.2,4.2 61.0x16.4)
# pass 47
# fail 16
```

And the safe-area half of it bites too. Feeding `layoutFor` the full canvas
instead of `safeRect(w, h)`:

```
$ npm test          # layoutFor(w, {x:0,y:0,w,h}, insets)
  error: 'small phone portrait/landscape notch: the score runs off the left'
  error: 'phone portrait/landscape notch: the score runs off the left'
  error: 'tablet portrait/landscape notch: the score runs off the left'
  error: 'tablet landscape/landscape notch: the score runs off the left'
  error: 'phone landscape/landscape notch: the score runs off the left'
# pass 53
# fail 10
```

```
$ npm run tsc
> tsc --noEmit
(0 errors)

$ npm run build
vite v7.3.6 building client environment for production...
✓ 20 modules transformed.
dist/index.html                 0.79 kB │ gzip:  0.44 kB
dist/assets/index-3No6_5ds.js  82.48 kB │ gzip: 28.25 kB
✓ built in 159ms
```

```
$ node build.mjs rhythm          # from dynawalla/packs
dynawalla.rhythm@0.1.0 — SPLITBEAT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       6 skills, grades 3–5
  on disk      3 files, 87134 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

The shared code is bundled into the built pack, not merely compiling:

```
$ grep -o "Notes fly toward the bright line" dist-pack/assets/pack-*.js
Notes fly toward the bright line
$ grep -o "safe-area-inset-top" dist-pack/assets/pack-*.js | head -1
safe-area-inset-top
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF no leaks found

$ git diff --name-only origin/main..HEAD
dynawalla/games/rhythm/src/index.ts
dynawalla/games/rhythm/src/render/layout.test.ts
dynawalla/games/rhythm/src/render/layout.ts
dynawalla/games/rhythm/src/render/renderer.ts

$ git diff --name-only --diff-filter=D origin/main..HEAD
(empty)
```
