### PR TITLE
fix(dynawalla/games/polarity): the register was careful about the notch and still sat under the host's buttons

### DIFF
--- a/dynawalla/games/polarity/src/mount.ts
+++ b/dynawalla/games/polarity/src/mount.ts
@@ -1,4 +1,5 @@
 import styles from "./ui/styles.css?inline";
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, Question } from "./contract.ts";
 import { TierMonitor, detectTier } from "./core/tier.ts";
 import { clamp01 } from "./core/util.ts";
@@ -266,6 +267,80 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     hud.showRevive(reviveQ.prompt, opts, reviveQ.answer);
   }
 
+  // --- how to play ----------------------------------------------------------
+  //
+  // The title card says "MATCH A BULLET'S SIGN TO DRINK IT. YOUR TOTAL IS THE
+  // WEAPON. VENT IT AT THE EDGE." — which is exactly right and completely
+  // opaque to a nine-year-old, and it is gone the instant they press PLAY.
+  // Nothing anywhere said that an orb of the wrong sign passes straight
+  // through you, or that the last shield buys one question rather than ending
+  // the run. The manual stays behind the how-to-play button for the whole
+  // session, because the moment a child needs the rules is never the title.
+  const guide = createInstructions(root, {
+    title: "POLARITY",
+    summary: [
+      "Your ship has a sign: plus or minus. Drink every bullet that has the same sign as you.",
+      "The numbers you drink add up. Fire that total back out before it gets too big.",
+    ],
+    sections: [
+      {
+        heading: "Moving and flipping",
+        lines: [
+          "Drag your finger on the screen. The ship follows your finger.",
+          "Tap FLIP to change your sign from plus to minus, or back again.",
+          "On a keyboard: arrow keys or W, A, S, D to move, SPACE to flip, SHIFT to vent.",
+        ],
+      },
+      {
+        heading: "Matching signs",
+        lines: [
+          "Every bullet has a number on it, like +3 or −5.",
+          "A bullet with your sign is food. Fly into it and you drink it.",
+          "A bullet with the other sign hurts you. Flip your sign, or get out of the way.",
+          "A bullet marked 0 is safe either way.",
+        ],
+      },
+      {
+        heading: "Your total",
+        lines: [
+          "The big number at the top is your total. Drinking +3 adds 3. Drinking −5 takes 5 away.",
+          "The bar under it grows right for plus and left for minus.",
+          "The numbers at the ends of the bar are your limit. It starts at 20 each way.",
+          "Go past the limit and the ship overloads: you lose the whole total and cannot move for a moment.",
+          "Keep drinking without being hit and the small × number climbs. It multiplies your score.",
+        ],
+      },
+      {
+        heading: "Venting",
+        lines: [
+          "Tap VENT to fire your whole total back out as darts that chase enemies.",
+          "A bigger total makes more darts. A total smaller than 3 does nothing at all.",
+          "The bar turns red when you are near the limit. That is the moment to vent.",
+          "Vent right at the limit and you get a PERFECT: three times the points and twice the damage.",
+        ],
+      },
+      {
+        heading: "The orbs",
+        lines: [
+          "Now and then a large enemy floats in with a math problem written on it.",
+          "It drops four orbs. Each orb holds a number, and one of them is the answer.",
+          "An orb only touches you if its sign matches yours. Orbs of the other sign pass straight through you.",
+          "So set your sign first, then fly into the orb you picked. A wrong orb blows up and costs a shield.",
+        ],
+      },
+      {
+        heading: "Shields, and coming back",
+        lines: [
+          "The three small diamonds near the top are your shields.",
+          "Being hit costs one shield, halves your total and ends your streak.",
+          "When the last shield goes you get one question. Answer it right and you come back with every shield and a blast that clears the screen.",
+          "Answer it wrong and the run is over.",
+        ],
+      },
+    ],
+    reducedMotion: host.prefersReducedMotion(),
+  });
+
   // --- sizing ---------------------------------------------------------------
   let cssW = 1;
   let cssH = 1;
@@ -297,7 +372,12 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
 
     world.reduced = host.prefersReducedMotion();
 
-    if (!paused) {
+    // Reading the rules is not playing. With the manual open the field holds
+    // its shape, no bullet moves, and the finger resting on the panel is not a
+    // steer — a child who looks something up must not be killed for it.
+    const reading = guide.isOpen;
+
+    if (!paused && !reading) {
       input.step(dt);
       step(world, dt);
       drain();
@@ -313,7 +393,7 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     }
 
     hud.update(world, Math.abs(world.core) >= world.cap - 4);
-    renderer.draw(world, paused ? 0 : dt);
+    renderer.draw(world, paused || reading ? 0 : dt);
 
     monitor.sample(performance.now() - t0, dt);
   };
@@ -338,6 +418,7 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       saveSeen(world.cues);
       saveBest(world.stats.best);
       input.dispose();
+      guide.destroy();
       hud.dispose();
       renderer.dispose();
       audio.dispose();

--- a/dynawalla/games/polarity/src/ui/hud.ts
+++ b/dynawalla/games/polarity/src/ui/hud.ts
@@ -2,6 +2,7 @@ import { clamp01, fmtScore } from "../core/util.ts";
 import { fmtInt, fmtSigned, parseInt_ } from "../math/signed.ts";
 import { PLAYER } from "../game/constants.ts";
 import type { World } from "../game/world.ts";
+import { applyChromeVars } from "./layout.ts";
 
 /**
  * The HUD is DOM, not canvas: crisp numerals at every density, real safe-area
@@ -83,6 +84,12 @@ export class Hud {
   private touch = false;
 
   constructor(host: HTMLElement, private readonly hooks: HudHooks) {
+    // The stylesheet is a static file and cannot be asserted about, so the
+    // numbers that keep this register clear of the host's two 44px corners
+    // live in `layout.ts` and are handed to the CSS here. The tests read the
+    // same source, so the two cannot drift.
+    applyChromeVars(host);
+
     this.root = el("div", "pol-hud");
 
     // --- top -------------------------------------------------------------

--- a/dynawalla/games/polarity/src/ui/layout.test.ts
+++ b/dynawalla/games/polarity/src/ui/layout.test.ts
@@ -1,0 +1,119 @@
+// THE TWO CORNERS.
+//
+// The host floats a 44px back chevron over the top-LEFT of every game and the
+// how-to-play button over the top-RIGHT. It reserves no band — reserving one
+// costs a twelfth of a 568px phone to hold two buttons, and it broke SKY
+// LEDGER's lattice outright. The promise a game makes instead is narrow and
+// testable: nothing a child must READ or TOUCH lands in those two squares.
+//
+// POLARITY's HUD was careful about the safe area and always had been —
+// `.pol-hud` padded all four edges with `env()` — and that is exactly why it
+// collided. Host chrome floats INSIDE the safe area, which is where a careful
+// HUD puts things. So the score and the chain multiplier sat in the chevron's
+// square, the shield pips and the STRATUM label sat under the question mark,
+// and `.pol-mini` — the game's own sound and pause buttons — was pinned to the
+// how-to-play button's coordinates exactly.
+//
+// The rects come from `hudRects`, and the same constants are written onto the
+// root as custom properties at mount, so this cannot pass while the stylesheet
+// says something else.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts";
+import { CHROME_TOP, MINI, MINI_GAP, hudRects, padSize } from "./layout.ts";
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+const NOTCH_PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+const NOTCH_LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["the smallest phone we support", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const [insetName, insets] of [
+    ["no insets", NONE],
+    ["a notch", w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT],
+  ] as const) {
+    test(`the register clears the host's corners at ${name} (${w}×${h}, ${insetName})`, () => {
+      const r = hudRects(w, h, insets);
+
+      // The whole top row: score and chain on the left, the core gauge in the
+      // middle, shields and STRATUM on the right. All of it is read.
+      assert.equal(
+        hitsHostChrome(r.top, w, insets),
+        false,
+        `${w}×${h}: the score, the gauge or the shields are under host chrome`,
+      );
+      assert.equal(
+        hitsHostChrome(r.mini, w, insets),
+        false,
+        `${w}×${h}: the sound and pause buttons are under the host's how-to-play button`,
+      );
+      // The pads are the only two things a finger must land on during play.
+      assert.equal(hitsHostChrome(r.padFlip, w, insets), false, `${w}×${h}: FLIP is covered`);
+      assert.equal(hitsHostChrome(r.padVent, w, insets), false, `${w}×${h}: VENT is covered`);
+    });
+  }
+}
+
+test("every HUD box stays inside the safe area on all four edges", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const insets = w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT;
+    const r = hudRects(w, h, insets);
+
+    for (const [what, box] of [
+      ["the top row", r.top],
+      ["the sound and pause buttons", r.mini],
+      ["the FLIP pad", r.padFlip],
+      ["the VENT pad", r.padVent],
+    ] as const) {
+      assert.ok(box.x >= insets.left, `${name}: ${what} runs into the left inset`);
+      assert.ok(
+        box.x + box.w <= w - insets.right + 0.5,
+        `${name}: ${what} runs into the right inset`,
+      );
+      assert.ok(box.y >= insets.top, `${name}: ${what} runs under the notch`);
+      assert.ok(
+        box.y + box.h <= h - insets.bottom + 0.5,
+        `${name}: ${what} runs under the home indicator`,
+      );
+    }
+  }
+});
+
+test("the two buttons keep real air between them and the host's", () => {
+  // Abutting is not clearing. `hitsHostChrome` uses a strict overlap, so two
+  // boxes sharing an edge pass it — and a child's thumb does not know that.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const insets of [NONE, w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT]) {
+      const r = hudRects(w, h, insets);
+      const helpLeft = w - insets.right - 10 - 44;
+      assert.ok(
+        helpLeft - (r.mini.x + r.mini.w) >= 10,
+        `${name}: only ${(helpLeft - (r.mini.x + r.mini.w)).toFixed(0)}px between the game's buttons and the host's`,
+      );
+      assert.equal(r.mini.w, MINI * 2 + MINI_GAP);
+    }
+  }
+});
+
+test("the pads stay a thumb's size, not merely legal", () => {
+  // Clearing the corners by shrinking to nothing would satisfy every assert
+  // above. 44 is the platform floor for a touch target.
+  for (const [name, w] of VIEWPORTS) {
+    assert.ok(padSize(w) >= 44, `${name}: the pad is ${padSize(w)}px`);
+  }
+});
+
+test("the offset is the host's own number, not one somebody typed", () => {
+  // 57 is the bottom of the host's corner squares: a 3px hairline, a 10px
+  // margin and a 44px control. This is the inequality the file exists to hold.
+  assert.ok(CHROME_TOP >= 57, `CHROME_TOP is ${CHROME_TOP} — the host's corners end at 57`);
+});

--- a/dynawalla/games/polarity/src/ui/layout.ts
+++ b/dynawalla/games/polarity/src/ui/layout.ts
@@ -1,0 +1,103 @@
+/**
+ * Where the HUD sits, in numbers, and how the stylesheet learns them.
+ *
+ * **What this is for.** The host does not hand a pack the whole frame. It
+ * floats a 44px back chevron over the top-LEFT corner and the how-to-play
+ * button over the top-RIGHT, and both of those live *inside* the safe area,
+ * which is exactly where a careful HUD puts things. POLARITY's HUD is careful
+ * — `.pol-hud` pads all four edges with `env()` and always did — and that is
+ * precisely why it collided: the score and the chain multiplier sat in the
+ * chevron's square, the shield pips and the STRATUM label sat under the
+ * question mark, and the game's own sound and pause buttons were pinned to the
+ * how-to-play button's exact coordinates.
+ *
+ * **Why no band is reserved.** Reserving the top strip costs 67px — a twelfth
+ * of a 568px phone — to hold two buttons, and it broke SKY LEDGER's lattice
+ * outright. So the chrome floats and a game keeps only TWO 44px corners free of
+ * anything a child must read or touch. The starfield, the ship and every bullet
+ * still bleed to the edges, which is what `viewport-fit=cover` is for.
+ *
+ * **Why the numbers live here.** `ui/styles.css` is a static file and cannot be
+ * asserted about. These constants are written onto the root as custom
+ * properties at mount, the stylesheet reads them through `var()`, and
+ * `hudRects` reports the same geometry to the tests. One source.
+ */
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+
+/**
+ * How far below the safe top edge the register's top row starts.
+ *
+ * Derived from the host's own published constants rather than typed here, so if
+ * the host moves its chrome this game follows on the next build.
+ */
+export const CHROME_TOP = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + 6;
+
+/** The HUD's gap from every safe edge, unchanged from the original stylesheet. */
+export const HUD_EDGE = 10;
+
+/** Sound and pause: the game's own two buttons. */
+export const MINI = 34;
+export const MINI_GAP = 8;
+
+/**
+ * How far in from the safe right edge those two buttons start.
+ *
+ * They used to be at `right: max(10px, env())` — the how-to-play button's
+ * square, exactly. They now sit BESIDE it rather than under it, which keeps
+ * them where a player already looks for them and leaves at least 10px of air
+ * between the game's chrome and the host's at every inset.
+ */
+export const MINI_RIGHT = HOST_CONTROL + HOST_MARGIN * 2;
+
+/** The top row: score over chain on the left, gauge centred, pips right. */
+export const TOP_H = 96;
+
+/** The two touch pads, from the stylesheet's `clamp(64px, 19vw, 108px)`. */
+export const padSize = (w: number): number => Math.min(108, Math.max(64, w * 0.19));
+
+/**
+ * The boxes the HUD occupies, so a test can assert they clear the host's two
+ * corners at every viewport instead of a device finding out.
+ */
+export function hudRects(
+  w: number,
+  h: number,
+  insets: Insets,
+): { top: Rect; mini: Rect; padFlip: Rect; padVent: Rect } {
+  const padL = Math.max(HUD_EDGE, insets.left);
+  const padR = Math.max(HUD_EDGE, insets.right);
+  const padB = Math.max(HUD_EDGE, insets.bottom);
+  const padT = insets.top + CHROME_TOP;
+  const pad = padSize(w);
+  const miniW = MINI * 2 + MINI_GAP;
+  return {
+    top: { x: padL, y: padT, w: Math.max(0, w - padL - padR), h: TOP_H },
+    mini: {
+      x: Math.max(0, w - padR - MINI_RIGHT - miniW),
+      y: Math.max(HUD_EDGE, insets.top),
+      w: miniW,
+      h: MINI,
+    },
+    padFlip: { x: padL, y: h - padB - pad, w: pad, h: pad },
+    padVent: { x: Math.max(0, w - padR - pad), y: h - padB - pad, w: pad, h: pad },
+  };
+}
+
+/**
+ * Hand the stylesheet the numbers above.
+ *
+ * `styles.css` carries the same values as fallbacks, so a stylesheet loaded
+ * without a mounted root still looks right; these overwrite them, and these are
+ * what the tests read.
+ */
+export function applyChromeVars(root: HTMLElement): void {
+  root.style.setProperty("--pol-chrome-top", `${CHROME_TOP}px`);
+  root.style.setProperty("--pol-mini-right", `${MINI_RIGHT}px`);
+}

--- a/dynawalla/games/polarity/src/ui/styles.css
+++ b/dynawalla/games/polarity/src/ui/styles.css
@@ -1,7 +1,15 @@
 /* POLARITY — vector-monitor register. Hard edges, hairline rules, additive
    neon. No cards, no gradients-as-decoration, no rounded SaaS chrome. */
 
+/* The host's chrome floats over this game: a 44px back chevron top-LEFT and a
+   44px how-to-play button top-RIGHT. `ui/layout.ts` owns the numbers that keep
+   this HUD out of those two squares and writes them onto the root at mount;
+   the values here are the same numbers, as fallbacks. Nothing a child reads or
+   touches may land in the corners — the field itself still bleeds to the
+   edges, which is what `viewport-fit=cover` is for. */
 .pol-root {
+  --pol-chrome-top: 63px;
+  --pol-mini-right: 64px;
   --pos: #ffcd52;
   --pos-dim: #7a5a1c;
   --neg: #38dcff;
@@ -37,7 +45,13 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right))
+  /* The four edges were already right. The top now also clears the host's two
+     44px corners: the score and the chain sat in the chevron's square and the
+     shield pips and STRATUM sat under the question mark, and no amount of
+     `env()` can help with that — the chrome floats INSIDE the safe area. Only
+     the top row moves; the middle row absorbs it and the pads stay put. */
+  padding: calc(env(safe-area-inset-top) + var(--pol-chrome-top))
+    max(10px, env(safe-area-inset-right))
     max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
   display: grid;
   grid-template-rows: auto 1fr auto;
@@ -184,8 +198,8 @@
 .pol-keyhint {
   position: absolute;
   bottom: max(10px, env(safe-area-inset-bottom));
-  left: 0;
-  right: 0;
+  left: max(10px, env(safe-area-inset-left));
+  right: max(10px, env(safe-area-inset-right));
   text-align: center;
   font-size: clamp(9px, 1.9vw, 12px);
   letter-spacing: 0.2em;
@@ -201,7 +215,13 @@
   place-items: center;
   background: radial-gradient(120% 90% at 50% 40%, #03040bd0, #03040bfa);
   backdrop-filter: blur(3px);
-  padding: 20px;
+  /* Was a flat `20px`, on all four sides, with no `env()` anywhere — the one
+     surface in this game that ignored the insets entirely. It carries the
+     REPOLARIZE answer orbs, which a child taps, so in landscape on a notched
+     phone the outermost orb ran under the sensor housing. Its contents are
+     centred, so the corners are clear by construction. */
+  padding: max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right))
+    max(20px, env(safe-area-inset-bottom)) max(20px, env(safe-area-inset-left));
   text-align: center;
 }
 .pol-veil[hidden] { display: none; }
@@ -281,10 +301,15 @@
 .pol-final { font-size: clamp(34px, 11vw, 78px); color: var(--gold); line-height: 1; }
 .pol-over { font-size: clamp(12px, 3vw, 17px); letter-spacing: 0.34em; opacity: 0.55; }
 
+/* Sound and pause. These were `top: max(10px, env())`, `right: max(10px,
+   env())` — the how-to-play button's coordinates, exactly, so the host's `?`
+   printed straight through them. They now sit BESIDE it rather than under it,
+   which is where a player already looks, with at least 10px of air between the
+   game's chrome and the host's at every inset. */
 .pol-mini {
   position: absolute;
   top: max(10px, env(safe-area-inset-top));
-  right: max(10px, env(safe-area-inset-right));
+  right: calc(max(10px, env(safe-area-inset-right)) + var(--pol-mini-right));
   display: flex;
   gap: 8px;
   pointer-events: auto;


### PR DESCRIPTION
## What

Adopt the shared game chrome in POLARITY: drop the register below the host's
two 44px corners, move the game's own sound and pause buttons out from under
the how-to-play button, close two genuine safe-area holes, and add a
`createInstructions` manual.

## Why

**The safe area was the best of the three, and that is why it collided.**
`.pol-hud` padded all four edges with `max(10px, env(...))` and always had.
But host chrome floats *inside* the safe area — a 44px back chevron top-LEFT,
the how-to-play button top-RIGHT — which is precisely where a careful HUD puts
things. So:

- The score and the chain multiplier sat in the chevron's square.
- The shield pips and the STRATUM label sat under the question mark.
- `.pol-mini` — the game's own sound and pause buttons — was `top: max(10px,
  env())`, `right: max(10px, env())`. The how-to-play button's coordinates,
  exactly. The host's `?` printed straight through them.
- At ≤360px the core gauge widens to `74vw` and reached into both corners. It
  is the one thing in this game a player really has to read.

No band is reserved. 67px is a twelfth of a 568px phone spent on two buttons,
and it broke SKY LEDGER's lattice outright. The top row drops below the
corners by `HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + 6`, computed from
the host's published constants rather than typed; the middle row absorbs it,
the two pads do not move, and the field still bleeds to every edge. The mini
buttons move BESIDE the how-to-play button rather than under it, with at least
10px of air at every inset — a test asserts the gap, because
`hitsHostChrome` uses a strict overlap and two boxes sharing an edge would
otherwise "pass".

**Two genuine safe-area holes, found while checking.**

- `.pol-veil` — the title, PAUSED, REPOLARIZE and game-over surface — had a
  flat `padding: 20px` and **no `env()` anywhere**, the one surface in this
  game that ignored the insets entirely. It carries the REPOLARIZE answer
  orbs, which a child taps, so in landscape on a notched phone the outermost
  orb ran under the sensor housing. All four edges now. Its contents are
  centred, so the top corners are clear by construction rather than by
  padding — spending 63px of a 390px-tall landscape screen on a top pad would
  have squeezed the game-over stats instead.
- `.pol-keyhint` was `left: 0; right: 0`. Both inset now.

**Nobody was ever taught the game.** The title card says "MATCH A BULLET'S
SIGN TO DRINK IT. YOUR TOTAL IS THE WEAPON. VENT IT AT THE EDGE." — exactly
right, completely opaque to a nine-year-old, and gone the instant they press
PLAY. Nothing anywhere said that an orb of the wrong sign passes straight
through you, which is the entire trick of answering a Seal Bearer; or that the
last shield buys one question rather than ending the run. The manual sits
behind the how-to-play button for the whole session and the field holds still
while it is open.

## Blast radius

**Areas touched:** dynawalla (`dynawalla/games/polarity/` only)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published pack zip changed in place; no
      `voiceId` renamed; no catalog entry dropped. `pack.json` untouched.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifests.
- [x] **Strings.** N/A — pack-local copy, not `corpan-app` locales.
- [x] **Curriculum.** N/A — no skill, generator, schema or renderer touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`. The
      pre-existing `gitleaks:allow` on `SEEN_SLOT` in `mount.ts` is untouched.

Behaviour that changed for a player: the top row of the register sits ~53px
lower; sound and pause move left, beside the how-to-play button; the veil and
the key hint pad to the insets; a `?` button appears top-right; the simulation
and the renderer freeze while the manual is open.

## Proof

```
$ npm test    # five runs — one green run is not proof
--- run 1 ---
# tests 29
# pass 29
# fail 0
--- run 2 ---
# tests 29
# pass 29
# fail 0
--- run 3 ---
# tests 29
# pass 29
# fail 0
--- run 4 ---
# tests 29
# pass 29
# fail 0
--- run 5 ---
# tests 29
# pass 29
# fail 0

$ npm run tsc
> @dynawalla/game-polarity@0.1.0 tsc
> tsc --noEmit && tsc --noEmit -p tsconfig.test.json
(0 errors)

$ npm run build
✓ built

$ cd dynawalla/packs && node build.mjs polarity
dynawalla.polarity@0.1.0 — POLARITY
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       5 skills, grades 1–5
  on disk      3 files, 613444 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF no leaks found

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty — nothing deleted)

$ git diff --name-only origin/main..HEAD
dynawalla/games/polarity/src/mount.ts
dynawalla/games/polarity/src/ui/hud.ts
dynawalla/games/polarity/src/ui/layout.test.ts
dynawalla/games/polarity/src/ui/layout.ts
dynawalla/games/polarity/src/ui/styles.css
```

**The clearance test fails when the fix is removed.** `CHROME_TOP` and
`MINI_RIGHT` back to 0, and the top padding back to `max(10px, env(top))`:

```
$ node --test src/ui/layout.test.ts     # with the fix reverted
not ok 1 - the register clears the host's corners at the smallest phone we support (320×568, no insets)
not ok 2 - the register clears the host's corners at the smallest phone we support (320×568, a notch)
not ok 3 - the register clears the host's corners at phone portrait (390×844, no insets)
not ok 4 - the register clears the host's corners at phone portrait (390×844, a notch)
not ok 5 - the register clears the host's corners at tablet portrait (768×1024, no insets)
not ok 6 - the register clears the host's corners at tablet portrait (768×1024, a notch)
not ok 7 - the register clears the host's corners at tablet landscape (1024×768, no insets)
not ok 8 - the register clears the host's corners at tablet landscape (1024×768, a notch)
not ok 9 - the register clears the host's corners at phone landscape (844×390, no insets)
not ok 10 - the register clears the host's corners at phone landscape (844×390, a notch)
not ok 12 - the two buttons keep real air between them and the host's
not ok 14 - the offset is the host's own number, not one somebody typed
# tests 14
# pass 2
# fail 12

$ node --test src/ui/layout.test.ts     # restored
# tests 14
# pass 14
# fail 0
```

The rects the test asserts come from `hudRects()` in `src/ui/layout.ts`, and
the same constants are written onto `.pol-root` as custom properties at mount
and read back by `styles.css` through `var()`. The test cannot pass while the
stylesheet says something different.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
