### PR TITLE
dynawalla/games/trebuchet: lay the HUD out from the safe rect and clear the host's two corners

### DIFF
--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -27,7 +27,17 @@ import {
 import { Rings } from './fx/rings.ts'
 import { Trail } from './fx/trail.ts'
 import { Backdrop } from './render/backdrop.ts'
-import { drawHud, hitBtn, hudButtons, rackLayout, type Btn, type HudState } from './render/hud.ts'
+import { safeRect } from '../../../packs/shared/game-chrome/index.ts'
+import {
+  dialNumeralBox,
+  drawHud,
+  hitBtn,
+  hudLayout,
+  rackLayout,
+  type Btn,
+  type HudLayout,
+  type HudState,
+} from './render/hud.ts'
 import {
   ARMED_DEG,
   RELEASE_DEG,
@@ -42,7 +52,7 @@ import {
   drawTrebuchet,
   drawWall,
 } from './render/pieces.ts'
-import { C, font, worldText, type Frame } from './render/theme.ts'
+import { C, font, type Frame } from './render/theme.ts'
 import {
   G,
   LAUNCH_H,
@@ -180,6 +190,8 @@ export class TrebuchetGame {
 
   // hud
   private btns: Btn[] = []
+  /** The HUD's geometry, re-derived from the SAFE rect on every resize. */
+  private hud: HudLayout = hudLayout(320, 240, { x: 0, y: 0, w: 320, h: 240 }, false)
   private clearT = -1
   private introT = 0
   private muted = false
@@ -272,9 +284,13 @@ export class TrebuchetGame {
     this.h = h
     this.canvas.width = Math.round(w * this.dpr)
     this.canvas.height = Math.round(h * this.dpr)
-    this.unit = clamp(Math.min(w, h) * 0.115, 42, 82)
+    // The notch, the home indicator and the rounded corners are re-measured
+    // here, not once at mount: a rotation swaps top/bottom for left/right, and
+    // Split View changes them without the game ever unmounting.
+    this.hud = hudLayout(w, h, safeRect(w, h), this.cfg.loft)
+    this.unit = this.hud.unit
     this.backdrop.resize(w, h, this.dpr)
-    this.btns = hudButtons(w, h, this.unit, this.cfg.loft)
+    this.btns = this.hud.buttons
   }
 
   /* ---------------------------------------------------------------- waves */
@@ -345,7 +361,9 @@ export class TrebuchetGame {
       sc.push(this.cosmetic.range(-20, worldX(FIELD_MAX) + 20), this.cosmetic.range(0.3, 1.1))
     }
     this.scrub = new Float32Array(sc)
-    this.btns = hudButtons(this.w, this.h, this.unit, cfg.loft)
+    // The loft lever appears mid-run, and it changes where mute sits.
+    this.hud = hudLayout(this.w, this.h, this.hud.area, cfg.loft)
+    this.btns = this.hud.buttons
     this.audio.horn(true)
     if (!this.reduced && n % 3 === 0 && this.flash.add(0.16, 0.22, 0.5, 0.2, 1.2)) {
       this.backdrop.strike(this.cosmetic)
@@ -514,9 +532,7 @@ export class TrebuchetGame {
     this.liveIdx = live.map((x) => x.i)
     const b = this.activeBoulder
     return {
-      w: this.w,
-      h: this.h,
-      unit: this.unit,
+      layout: this.hud,
       equation: b ? b.q.prompt : '',
       rack: live.map((x) => x.r.q.prompt),
       rackActive: live.findIndex((x) => x.i === this.activeIdx),
@@ -1077,9 +1093,12 @@ export class TrebuchetGame {
     const wide = this.w / this.h >= 1.25
     const pts: Array<{ x: number; y: number }> = []
     // Keep the field clear of the two things pinned to the glass: the equation
-    // at the top and the firing controls at the bottom right.
-    const padTop = this.unit * 2.5
-    const strip = this.unit * 2.5
+    // at the top and the firing controls at the bottom right. Both are measured
+    // from the safe rect now, so both pads carry the inset that pushed them in —
+    // and nothing else changes, because on a screen with no notch this is the
+    // same framing the game shipped with.
+    const padTop = this.unit * 2.5 + this.hud.area.y
+    const strip = this.h - (this.hud.area.y + this.hud.area.h) + this.unit * 2.5
     const gf = clamp(1 - strip / this.h - 0.02, 0.58, 0.84)
     if (this.phase === 'flight' && this.shot) {
       // follow with lead: look where the shot is going, not where it is
@@ -1210,6 +1229,9 @@ export class TrebuchetGame {
     ctx.fillRect(0, 0, w, h)
     ctx.restore()
 
+    if (this.phase === 'aim' || this.phase === 'intro' || this.phase === 'windup') {
+      this.drawDialNumeral(ctx)
+    }
     drawHud(ctx, this.hudState(), this.btns, this.wallTime)
   }
 
@@ -1257,22 +1279,37 @@ export class TrebuchetGame {
       ctx.globalAlpha = a
     }
 
-    // the dial numeral rides the marker
+    ctx.restore()
+  }
+
+  /**
+   * The dialled number, drawn on the glass rather than in the world.
+   *
+   * It rides the aim marker, so its position comes from the camera — but the
+   * camera does not know about the notch or the host's two corners, and this is
+   * the one number the whole game is about. `dialNumeralBox` puts it where the
+   * marker is and keeps it where it can be read.
+   */
+  private drawDialNumeral(ctx: CanvasRenderingContext2D): void {
+    const a = this.aimEmphasis
+    if (a < 0.02) return
+    const s = this.cam.ppm * this.cam.zoom
+    const anchor = this.cam.toScreen(worldX(this.dial), 3.2, { w: this.w, h: this.h })
+    const text = String(this.dial)
+    const box = dialNumeralBox(anchor.x, anchor.y, s, text.length, this.hud)
     const pop = 1 + (1 - easeOutBack(clamp01(this.dialPop))) * 0.24
-    worldText(ctx, s, x, 3.2, (c) => {
-      const size = Math.max(20, Math.min(46, s * 3.4))
-      c.font = font(size, 900)
-      c.textAlign = 'center'
-      c.textBaseline = 'bottom'
-      c.save()
-      c.scale(pop, pop)
-      c.lineWidth = 4
-      c.strokeStyle = 'rgba(3,5,13,0.85)'
-      c.strokeText(String(this.dial), 0, 0)
-      c.fillStyle = C.steel
-      c.fillText(String(this.dial), 0, 0)
-      c.restore()
-    })
+    ctx.save()
+    ctx.globalAlpha = a
+    ctx.translate(box.cx, box.baseline)
+    ctx.scale(pop, pop)
+    ctx.font = font(box.size, 900)
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'bottom'
+    ctx.lineWidth = 4
+    ctx.strokeStyle = 'rgba(3,5,13,0.85)'
+    ctx.strokeText(text, 0, 0)
+    ctx.fillStyle = C.steel
+    ctx.fillText(text, 0, 0)
     ctx.restore()
   }
 

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -3,6 +3,7 @@
  * private to the game.
  */
 
+import { createInstructions } from '../../../packs/shared/game-chrome/index.ts'
 import type { Host, Mounted } from './contract.ts'
 import { TrebuchetGame } from './game.ts'
 
@@ -12,8 +13,51 @@ export function mount(el: HTMLElement, host: Host): Mounted {
   const game = new TrebuchetGame(el, host)
   // The harness reads frame stats and drives shots through the real input path.
   ;(el as HTMLElement & { __trebuchet?: TrebuchetGame }).__trebuchet = game
+
+  // How to play. The HUD is deliberately wordless — a glyph costs no
+  // translations and a child reading a label is a child not watching the arc —
+  // so this panel is the ONLY place the rules are ever stated. It stays
+  // reachable during play, because the moment a child needs the rules is never
+  // the title.
+  const guide = createInstructions(el, {
+    title: 'TREBUCHET',
+    summary: [
+      'Your boulder has a sum written on it. Work out the answer.',
+      'Set the range dial to that number and fire. The keep standing at that many metres comes down.',
+    ],
+    sections: [
+      {
+        heading: 'Taking a shot',
+        lines: [
+          'The boulder says something like 7 x 8. The answer is 56.',
+          'Out on the field there is a keep standing at 56 metres.',
+          'Use the plus and minus buttons to wind the dial to 56.',
+          'You can also drag across the field to move the dial a long way at once.',
+          'Then fire, and the boulder flies exactly that far and knocks it down.',
+        ],
+      },
+      {
+        heading: 'When you are wrong',
+        lines: [
+          'Say you dial 54 instead of 56. The boulder lands two metres short.',
+          'It leaves a crater with 54 written in it, out where you can see it.',
+          'So you do not just get told you were wrong. You get to see how far off you were.',
+        ],
+      },
+      {
+        heading: 'Take your time',
+        lines: [
+          'There is no clock. Nothing happens until you fire.',
+          'Wind the dial as much as you like before you let the shot go.',
+        ],
+      },
+    ],
+    reducedMotion: host.prefersReducedMotion(),
+  })
+
   return {
     unmount(): void {
+      guide.destroy()
       game.unmount()
       delete (el as HTMLElement & { __trebuchet?: TrebuchetGame }).__trebuchet
     },

--- a/dynawalla/games/trebuchet/src/render/hud.ts
+++ b/dynawalla/games/trebuchet/src/render/hud.ts
@@ -3,18 +3,212 @@
  * translations and a child reading a label is a child not watching the arc. The
  * whole interface is: the equation you were handed, the number you are dialling,
  * and the wind trying to spoil it.
+ *
+ * **Everything here is laid out from the SAFE rectangle, never from `w`/`h`.**
+ * The pack declares `viewport-fit=cover`, which opts the document into the notch,
+ * the home indicator and the rounded corners — and this HUD is drawn on canvas,
+ * where `env()` cannot be reached. So the safe rect arrives as a REQUIRED argument
+ * to `hudLayout`: a caller that forgets it does not compile, instead of shipping a
+ * fire button under the home indicator and finding out on a device.
+ *
+ * The sky, the ground, the keeps, the craters and the smoke keep bleeding to the
+ * glass edges — that is what `cover` is FOR. Only what a child must read or touch
+ * comes inside the rect.
+ *
+ * **The host's two corners.** The host paints an exit control top-left and a
+ * how-to-play control top-right, 44px each, floating OVER the game; it reserves no
+ * band. The equation plaque is centred and as wide as the question makes it, so at
+ * 320px it reaches both of them — and the equation IS the question; a child who
+ * cannot read it cannot play. Where there is width to spare between the corners
+ * the plaque fits between them and the pinned stack stays where it was drawn;
+ * where there is not, the whole stack starts underneath them instead. See `roomy`
+ * in `hudLayout`.
  */
 
-import { clamp01, easeOutBack, easeOutCubic, easeOutExpo } from '../core/ease.ts'
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Rect,
+} from '../../../../packs/shared/game-chrome/index.ts'
+import { clamp, clamp01, easeOutBack, easeOutCubic, easeOutExpo } from '../core/ease.ts'
 import { C, font, roundRect } from './theme.ts'
 
 export type Btn = { x: number; y: number; w: number; h: number; id: string }
 
-export type HudState = {
+/**
+ * Every fixed measurement the HUD has, derived once per resize.
+ *
+ * One value, computed in one place, used by the renderer AND the hit test, so a
+ * tap can never land somewhere the eye disagrees with — and asserted in
+ * `layout.test.ts` at every viewport the fleet has.
+ */
+export type HudLayout = {
   w: number
   h: number
   /** css pixels of the shortest sensible touch target */
   unit: number
+  /** the rect inside the notch and the home indicator */
+  area: Rect
+  /** the first y a full-width readout may use: clear of the host's 44px corners */
+  topClear: number
+  /** the widest the equation plaque may ever be, at the y it sits at */
+  plaqueMax: Rect
+  /** top edge of the ammunition rack row */
+  rackTop: number
+  /** height of one rack slot */
+  rackH: number
+  /** centre line of the wind chip */
+  windY: number
+  /** middle of the wave counter and the score */
+  readoutY: number
+  /** the wave counter, with its pips */
+  wave: Rect
+  /** the score, with room for the combo line under it */
+  score: Rect
+  /** the bottom of the pinned top stack — the camera frames the field under it */
+  stackBottom: number
+  buttons: Btn[]
+}
+
+/** The HUD's scale unit. The game's camera pads itself with this too. */
+export function hudUnit(w: number, h: number): number {
+  return clamp(Math.min(w, h) * 0.115, 42, 82)
+}
+
+const eqSizeFor = (unit: number, area: Rect): number =>
+  Math.round(Math.min(unit * 1.15, area.w * 0.09))
+
+/**
+ * The whole HUD, measured from the safe rect.
+ *
+ * `area` is required on purpose — see the file header.
+ */
+export function hudLayout(w: number, h: number, area: Rect, loftUnlocked: boolean): HudLayout {
+  const unit = hudUnit(w, h)
+  const pad = Math.round(unit * 0.4)
+  const right = area.x + area.w
+  const bottom = area.y + area.h
+
+  // Under the host's exit / how-to-play squares, plus a hair of daylight.
+  const topClear =
+    area.y + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + Math.round(unit * 0.16)
+
+  const eqSize = eqSizeFor(unit, area)
+  const ph = eqSize * 1.62
+  // How much clear width there is BETWEEN the host's two corners.
+  const corner = HOST_MARGIN + HOST_CONTROL
+  const band = area.w - corner * 2
+  // A tablet or a phone held sideways has width to spare: the equation fits
+  // between the two corners with room around it, so the stack stays at the top
+  // where it was designed to be and the camera keeps all its headroom. A phone
+  // held upright does not — a sum on a 320px screen needs the whole width — so
+  // there the stack starts under the corners instead. Either way the plaque is
+  // clear of them; only the price differs, and this pays the cheaper one.
+  const roomy = band >= eqSize * 9
+  const plaqueY = roomy ? area.y + Math.round(unit * 0.32) : topClear
+  const plaqueW = Math.max(0, roomy ? band - 8 : area.w - pad * 2)
+  const plaqueMax: Rect = { x: area.x + (area.w - plaqueW) / 2, y: plaqueY, w: plaqueW, h: ph }
+
+  const rackH = Math.round(unit * 0.5)
+  const rowCentre = plaqueY + ph + rackH * 0.9
+  const rackTop = rowCentre - rackH / 2
+  const windY = rowCentre + rackH * 1.15
+  const readoutY = plaqueY + Math.round(unit * 0.23)
+  const stackBottom = windY + unit * 0.3
+
+  // The wave counter and the score ride the top corners of the plaque's row, so
+  // when the stack is at the top they have to step INSIDE the host's squares.
+  const cs = Math.round(unit * 0.44)
+  const edge = roomy ? corner + 6 : Math.round(unit * 0.42)
+  const wave: Rect = {
+    x: area.x + edge,
+    y: readoutY - cs * 0.7,
+    // twelve pips at 5px is the widest the counter ever gets
+    w: Math.max(cs * 2.6, 64),
+    h: cs * 1.9,
+  }
+  const scoreRight = area.x + area.w - (roomy ? corner + 6 : Math.round(unit * 0.5))
+  const score: Rect = {
+    x: scoreRight - cs * 3.4,
+    y: readoutY - cs * 0.7,
+    w: cs * 3.4,
+    h: cs * 2.4,
+  }
+
+  // Controls. Fire and its steppers ride the bottom-right corner of the SAFE
+  // rect; the loft lever the bottom-left. Mute used to sit top-right, directly
+  // under the host's how-to-play button — it moves to the bottom-left, beside
+  // the lever when there is one, where nothing floats over it.
+  const fire = Math.round(unit * 1.6)
+  const small = Math.round(unit * 0.72)
+  const gap = Math.round(fire - small * 2)
+  const by = bottom - pad - fire
+  const bx = right - pad - fire
+  const mute = Math.round(small * 0.8)
+  const lw = Math.round(unit * 0.95)
+  const lh = Math.round(unit * 2.6)
+  // A full pad between the lever and mute: the lever is tall and a child
+  // grabbing the bottom of it must not silence the game by accident.
+  const muteX = area.x + pad + (loftUnlocked ? lw + pad : 0)
+  const buttons: Btn[] = [
+    { id: 'fire', x: bx, y: by, w: fire, h: fire },
+    { id: 'plus', x: bx - Math.round(pad * 0.6) - small, y: by, w: small, h: small },
+    { id: 'minus', x: bx - Math.round(pad * 0.6) - small, y: by + small + gap, w: small, h: small },
+    { id: 'mute', x: muteX, y: bottom - pad - mute, w: mute, h: mute },
+  ]
+  if (loftUnlocked) buttons.push({ id: 'loft', x: area.x + pad, y: bottom - pad - lh, w: lw, h: lh })
+
+  return {
+    w,
+    h,
+    unit,
+    area,
+    topClear,
+    plaqueMax,
+    rackTop,
+    rackH,
+    windY,
+    readoutY,
+    wave,
+    score,
+    stackBottom,
+    buttons,
+  }
+}
+
+/**
+ * Where the dialled number is allowed to land on the glass.
+ *
+ * The numeral rides the aim marker out in the world, so the CAMERA decides where
+ * it goes — and the camera knows nothing about the notch or the host's corners.
+ * The world hands over an anchor; this decides where the numeral may actually sit.
+ * It is the one number the whole game is about, so it is never allowed off the
+ * safe rect and never allowed under the chrome, whatever the camera is doing.
+ */
+export function dialNumeralBox(
+  anchorX: number,
+  baselineY: number,
+  s: number,
+  digits: number,
+  layout: HudLayout,
+): { x: number; y: number; w: number; h: number; size: number; cx: number; baseline: number } {
+  const { area } = layout
+  const size = Math.max(20, Math.min(46, s * 3.4))
+  // 0.62em per digit is the advance of a heavy sans numeral; 8px is the dark
+  // stroke drawn around it.
+  const bw = Math.min(area.w, size * 0.62 * Math.max(1, digits) + 8)
+  const bh = size * 1.12
+  const pad = Math.round(layout.unit * 0.2)
+  const cx = clamp(anchorX, area.x + bw / 2, area.x + area.w - bw / 2)
+  const floor = Math.min(layout.topClear + bh, area.y + area.h)
+  const ceil = Math.max(floor, area.y + area.h - pad)
+  const baseline = clamp(baselineY, floor, ceil)
+  return { x: cx - bw / 2, y: baseline - bh, w: bw, h: bh, size, cx, baseline }
+}
+
+export type HudState = {
+  layout: HudLayout
   equation: string
   rack: string[]
   rackActive: number
@@ -39,42 +233,28 @@ export type HudState = {
   canFire: boolean
 }
 
-export function hudButtons(w: number, h: number, unit: number, loftUnlocked: boolean): Btn[] {
-  const pad = Math.round(unit * 0.4)
-  const fire = Math.round(unit * 1.6)
-  const small = Math.round(unit * 0.72)
-  const gap = Math.round(fire - small * 2)
-  const by = h - pad - fire
-  const bx = w - pad - fire
-  const btns: Btn[] = [
-    { id: 'fire', x: bx, y: by, w: fire, h: fire },
-    { id: 'plus', x: bx - Math.round(pad * 0.6) - small, y: by, w: small, h: small },
-    { id: 'minus', x: bx - Math.round(pad * 0.6) - small, y: by + small + gap, w: small, h: small },
-    { id: 'mute', x: w - pad - small * 0.8, y: pad * 0.6, w: small * 0.8, h: small * 0.8 },
-  ]
-  if (loftUnlocked) {
-    const lw = Math.round(unit * 0.95)
-    const lh = Math.round(unit * 2.6)
-    btns.push({ id: 'loft', x: pad, y: h - pad - lh, w: lw, h: lh })
-  }
-  return btns
-}
-
 export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[], time: number): void {
-  const { w, h, unit } = st
+  const { unit, area } = st.layout
   ctx.save()
   ctx.textBaseline = 'middle'
 
   /* ---- the equation: the most legible thing on the screen ---- */
-  const eqSize = Math.round(Math.min(unit * 1.15, w * 0.09))
   const intro = easeOutExpo(clamp01(st.introT))
-  const plaqueW = Math.max(ctx.measureText(st.equation).width, eqSize * 5.4)
+  const maxW = st.layout.plaqueMax.w
+  let eqSize = eqSizeFor(unit, area)
   ctx.font = font(eqSize, 900)
-  const mw = ctx.measureText(st.equation).width
-  const pw = Math.max(mw + eqSize * 1.6, plaqueW)
+  let mw = ctx.measureText(st.equation).width
+  // A long question used to run off both edges of a 320px phone. Shrink to fit
+  // the safe width instead — the sum has to be readable more than it has to be big.
+  if (mw + eqSize * 1.6 > maxW && mw > 0) {
+    eqSize = Math.max(11, Math.floor((eqSize * maxW) / (mw + eqSize * 1.6)))
+    ctx.font = font(eqSize, 900)
+    mw = ctx.measureText(st.equation).width
+  }
+  const pw = Math.min(maxW, Math.max(mw + eqSize * 1.6, eqSize * 5.4))
   const ph = eqSize * 1.62
-  const px = (w - pw) / 2
-  const py = Math.round(unit * 0.32) + (1 - intro) * -60
+  const px = area.x + (area.w - pw) / 2
+  const py = st.layout.plaqueMax.y + (1 - intro) * -60
   ctx.globalAlpha = intro
   roundRect(ctx, px, py, pw, ph, 6)
   ctx.fillStyle = 'rgba(6,8,18,0.62)'
@@ -84,13 +264,11 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
   ctx.stroke()
   ctx.fillStyle = C.bone
   ctx.textAlign = 'center'
-  ctx.fillText(st.equation, w / 2, py + ph / 2 + 1)
+  ctx.fillText(st.equation, area.x + area.w / 2, py + ph / 2 + 1)
   ctx.globalAlpha = 1
 
   /* ---- the rack: every boulder left, and what is written on it ---- */
   const slots = rackLayout(st)
-  const rowH = slots.length ? slots[0].h : Math.round(unit * 0.5)
-  const ry = py + ph + rowH * 0.9
   for (let i = 0; i < slots.length; i++) {
     const s = slots[i]
     const active = i === st.rackActive
@@ -116,13 +294,13 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
 
   /* ---- wind ---- */
   if (st.showWind) {
-    const wy = ry + rowH * 1.15
+    const wy = st.layout.windY
     const s = Math.round(unit * 0.5)
     ctx.font = font(s, 900)
     const txt = (st.wind > 0 ? '+' : '') + String(st.wind)
     const tw = ctx.measureText(txt).width
     const aw = s * 1.5
-    const cx = w / 2
+    const cx = area.x + area.w / 2
     ctx.globalAlpha = intro
     // the arrow: direction is shape, not colour
     const dir = Math.sign(st.wind) || 1
@@ -146,19 +324,21 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
 
   /* ---- wave + score, small, out of the way ---- */
   const cs = Math.round(unit * 0.44)
+  const wx = st.layout.wave.x
+  const ry2 = st.layout.readoutY
   ctx.font = font(cs, 800)
   ctx.textAlign = 'left'
   ctx.fillStyle = C.boneDim
-  ctx.fillText(String(st.wave), Math.round(unit * 0.42), Math.round(unit * 0.55))
+  ctx.fillText(String(st.wave), wx, ry2)
   // wave pips
   for (let i = 0; i < Math.min(st.wave, 12); i++) {
-    ctx.fillRect(Math.round(unit * 0.42) + i * 5, Math.round(unit * 0.55) + cs * 0.7, 3, 3)
+    ctx.fillRect(wx + i * 5, ry2 + cs * 0.7, 3, 3)
   }
   ctx.textAlign = 'right'
   const pop = 1 + easeOutBack(clamp01(st.scorePop)) * (1 - clamp01(st.scorePop)) * 0.5
   ctx.save()
-  const sx = w - Math.round(unit * 1.5)
-  const sy = Math.round(unit * 0.55)
+  const sx = st.layout.score.x + st.layout.score.w
+  const sy = ry2
   ctx.translate(sx, sy)
   ctx.scale(pop, pop)
   ctx.fillStyle = st.combo > 1 ? C.fire1 : C.boneDim
@@ -185,10 +365,10 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
     const k = easeOutCubic(clamp01(st.clearT))
     const a = st.clearT > 0.75 ? 1 - (st.clearT - 0.75) / 0.25 : 1
     ctx.globalAlpha = clamp01(a)
-    const cw = Math.min(w * 0.5, unit * 4.4)
+    const cw = Math.min(area.w * 0.5, unit * 4.4)
     const chh = unit * 1.9
-    const cx = (w - cw) / 2
-    const cy = h * 0.34 + (1 - k) * 40
+    const cx = area.x + (area.w - cw) / 2
+    const cy = Math.max(st.layout.topClear, area.y + area.h * 0.34) + (1 - k) * 40
     roundRect(ctx, cx, cy, cw, chh, 8)
     ctx.fillStyle = 'rgba(6,8,18,0.78)'
     ctx.fill()
@@ -198,7 +378,7 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
     ctx.textAlign = 'center'
     ctx.fillStyle = st.clearHits === st.clearOf ? C.fire1 : C.bone
     ctx.font = font(Math.round(unit * 1.15), 900)
-    ctx.fillText(`${st.clearHits}/${st.clearOf}`, w / 2, cy + chh * 0.5)
+    ctx.fillText(`${st.clearHits}/${st.clearOf}`, area.x + area.w / 2, cy + chh * 0.5)
     ctx.globalAlpha = 1
   }
 
@@ -319,16 +499,13 @@ function drawLoft(ctx: CanvasRenderingContext2D, b: Btn, idx: number, count: num
  * the hit test, so a tap can never land somewhere the eye disagrees with.
  */
 export function rackLayout(st: HudState): Array<{ x: number; y: number; w: number; h: number }> {
-  const { w, unit } = st
-  const eqSize = Math.round(Math.min(unit * 1.15, w * 0.09))
-  const ph = eqSize * 1.62
-  const py = Math.round(unit * 0.32)
-  const h = Math.round(unit * 0.5)
+  const { area } = st.layout
+  const h = st.layout.rackH
   const gap = Math.round(h * 0.28)
   const widths = st.rack.map((t) => Math.round(h * 0.9 + t.length * h * 0.27 + h * 0.35))
   const total = widths.reduce((a, b) => a + b, 0) + Math.max(0, st.rack.length - 1) * gap
-  let x = (w - total) / 2
-  const y = py + ph + h * 0.9 - h / 2
+  let x = area.x + (area.w - total) / 2
+  const y = st.layout.rackTop
   return widths.map((wd) => {
     const slot = { x, y, w: wd, h }
     x += wd + gap

--- a/dynawalla/games/trebuchet/src/render/layout.test.ts
+++ b/dynawalla/games/trebuchet/src/render/layout.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The gate on where things land.
+ *
+ * Two bugs live here and neither is visible to a test about ballistics:
+ *
+ *  1. **The notch.** The pack declares `viewport-fit=cover` and draws its whole
+ *     HUD on canvas, where `env()` cannot be reached — so the fire button used to
+ *     be measured from bare `h` and sat under the home indicator, and the
+ *     equation plaque sat under the notch. `hudLayout` now takes the safe rect as
+ *     a REQUIRED argument, and this runs it with the insets a real iPhone
+ *     reports, because node measures zero.
+ *
+ *  2. **The host's chrome.** Exit (top-left) and how-to-play (top-right), 44px
+ *     each, float OVER the game. Mute used to sit exactly under the how-to-play
+ *     button, and a centred equation plaque reaches both corners on a 320px
+ *     phone. Nothing a child must read or touch may land in those two squares.
+ *
+ * Everything here goes through `hudLayout(w, h, safeRect(w, h, insets), loft)` —
+ * the exact call `TrebuchetGame.resize()` makes — rather than a hand-built rect,
+ * so removing the fix turns this red.
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from '../../../../packs/shared/game-chrome/index.ts'
+import { dialNumeralBox, hudLayout, rackLayout, type HudLayout, type HudState } from './hud.ts'
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ['phone portrait, small', 320, 568],
+  ['phone portrait, tall', 390, 844],
+  ['tablet portrait', 768, 1024],
+  ['tablet landscape', 1024, 768],
+  ['phone landscape', 844, 390],
+]
+
+/** Node reports no insets, so the device profiles are supplied by hand. */
+const PROFILES: Array<[string, Insets]> = [
+  ['no insets', { top: 0, right: 0, bottom: 0, left: 0 }],
+  ['notch, portrait', { top: 47, right: 0, bottom: 34, left: 0 }],
+  ['notch, landscape', { top: 0, right: 44, bottom: 21, left: 44 }],
+]
+
+const inside = (r: Rect, a: Rect): boolean =>
+  r.x >= a.x - 0.5 &&
+  r.y >= a.y - 0.5 &&
+  r.x + r.w <= a.x + a.w + 0.5 &&
+  r.y + r.h <= a.y + a.h + 0.5
+
+const show = (r: Rect): string =>
+  `[${r.x.toFixed(1)},${r.y.toFixed(1)} ${r.w.toFixed(1)}x${r.h.toFixed(1)}]`
+
+/** A state that only exists to be measured; the rack is what a real wave holds. */
+function stateFor(layout: HudLayout): HudState {
+  return {
+    layout,
+    equation: '347 + 268',
+    rack: ['347 + 268', '91 − 47', '8 × 7', '120 − 65', '46 + 39'],
+    rackActive: 0,
+    wave: 3,
+    score: 1200,
+    scorePop: 1,
+    combo: 1,
+    wind: -2,
+    showWind: true,
+    loftUnlocked: true,
+    loftIndex: 2,
+    loftCount: 5,
+    muted: false,
+    introT: 1,
+    clearT: -1,
+    clearHits: 0,
+    clearOf: 5,
+    dialPop: 1,
+    canFire: true,
+  }
+}
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [pname, insets] of PROFILES) {
+    for (const loft of [false, true]) {
+      const label = `${vname} (${w}×${h}), ${pname}${loft ? ', loft' : ''}`
+
+      test(`every control is inside the safe rect — ${label}`, () => {
+        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        assert.ok(layout.buttons.length >= 4, 'the controls went missing')
+        for (const b of layout.buttons) {
+          assert.ok(
+            inside(b, layout.area),
+            `${b.id} ${show(b)} is outside the safe rect ${show(layout.area)}`,
+          )
+        }
+        if (loft) assert.ok(layout.buttons.some((b) => b.id === 'loft'), 'no loft lever')
+      })
+
+      test(`nothing a child touches sits under the host's chrome — ${label}`, () => {
+        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        for (const b of layout.buttons) {
+          assert.equal(
+            hitsHostChrome(b, w, insets),
+            false,
+            `${b.id} ${show(b)} is under the host chrome`,
+          )
+        }
+      })
+
+      test(`the question stays readable — ${label}`, () => {
+        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        // `plaqueMax` is the widest the plaque can ever be drawn: a long sum on a
+        // narrow phone reaches BOTH corners, so the whole pinned stack starts
+        // under them.
+        assert.equal(
+          hitsHostChrome(layout.plaqueMax, w, insets),
+          false,
+          `the equation plaque ${show(layout.plaqueMax)} is under the host chrome`,
+        )
+        assert.ok(
+          inside(layout.plaqueMax, layout.area),
+          `the equation plaque ${show(layout.plaqueMax)} runs outside the safe rect`,
+        )
+        // The rack is read AND tapped — a stone loads that boulder.
+        for (const s of rackLayout(stateFor(layout))) {
+          assert.equal(hitsHostChrome(s, w, insets), false, `a rack stone ${show(s)} is under chrome`)
+        }
+        // The wave counter and the score are read, so they move too.
+        for (const [what, r] of [
+          ['the wave counter', layout.wave],
+          ['the score', layout.score],
+        ] as const) {
+          assert.equal(hitsHostChrome(r, w, insets), false, `${what} ${show(r)} is under chrome`)
+          assert.ok(inside(r, layout.area), `${what} ${show(r)} runs outside the safe rect`)
+        }
+      })
+
+      test(`the dial numeral is legible wherever the camera puts it — ${label}`, () => {
+        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        // The numeral rides the aim marker in the world, so the camera decides
+        // its anchor — which means every anchor on the glass has to be safe, not
+        // just the one a particular shot produces.
+        for (let ax = -40; ax <= w + 40; ax += 20) {
+          for (let ay = -40; ay <= h + 40; ay += 20) {
+            for (const s of [4, 9, 20]) {
+              for (const digits of [1, 2, 3]) {
+                const box = dialNumeralBox(ax, ay, s, digits, layout)
+                assert.equal(
+                  hitsHostChrome(box, w, insets),
+                  false,
+                  `the dial numeral ${show(box)} is under the host chrome (anchor ${ax},${ay})`,
+                )
+                assert.ok(
+                  inside(box, layout.area),
+                  `the dial numeral ${show(box)} is outside the safe rect ${show(layout.area)}`,
+                )
+              }
+            }
+          }
+        }
+      })
+    }
+  }
+}
+
+test('the pinned stack is ordered, and leaves the field its room', () => {
+  for (const [, w, h] of VIEWPORTS) {
+    const layout = hudLayout(w, h, safeRect(w, h), true)
+    assert.ok(layout.topClear > layout.area.y, 'the stack starts at the very top edge')
+    assert.ok(layout.rackTop > layout.plaqueMax.y + layout.plaqueMax.h - 1, 'the rack is on the plaque')
+    assert.ok(layout.windY > layout.rackTop + layout.rackH, 'the wind chip is on the rack')
+    assert.ok(layout.stackBottom < layout.area.y + layout.area.h * 0.5, 'the HUD eats half the glass')
+  }
+})


### PR DESCRIPTION
## What

Adopt the shared game chrome in TREBUCHET: lay the whole HUD out from the safe
rect, keep everything a child must read or touch out of the host's two 44px
corners, and give the game its first written rules.

## Why

TREBUCHET declares `viewport-fit=cover` — which opts the document *into* the
notch, the home indicator and the rounded corners — and draws its entire HUD on
canvas, where `env()` cannot be reached. So every measurement came from bare
`w`/`h`:

- `fire`, `plus` and `minus` were placed at `h - pad - fire`, i.e. inside the
  home indicator; `loft` at `x: pad`, inside the left rounded corner.
- the equation plaque sat at `py = unit*0.32` — 13px on a 320px phone — under
  the notch.

And the host floats an exit control (top-left) and a how-to-play control
(top-right) over the game, which covered two things:

- `mute` was at `x: w - pad - small*0.8, y: pad*0.6` — the top-right corner,
  exactly under the how-to-play button. Confirmed: `mute [279.0,10.2 24.0x24.0]`
  overlaps `helpRect` at 320px.
- the equation plaque is centred and as wide as the question makes it. Its
  widest form at 320px is `[17.0,13.0 286.0x47.0]`, which reaches BOTH corners.
  The equation is the question; a child who cannot read it cannot play.

Fixes:

- `hudButtons(w, h, unit, loft)` is replaced by `hudLayout(w, h, area, loft)`,
  with `area` a **required** argument. A caller that forgets the safe rect does
  not compile, instead of silently drawing under the notch and being found on a
  device. It is re-derived on every `resize()`, so rotation and Split View are
  handled.
- `mute` moves to the bottom-left of the safe rect, beside the loft lever when
  there is one.
- The pinned stack pays the cheaper of two prices, per shape. Where there is
  width to spare between the corners — tablets, and phones held sideways — the
  plaque fits between them and the stack stays exactly where it was drawn, so
  the camera keeps all its headroom (a first attempt that pushed the stack down
  unconditionally cost an 844×390 phone most of its zoom). On a phone held
  upright, where a sum needs the full width, the stack starts under the corners
  instead. The wave counter and the score follow it either way.
- The dialled number rides the aim marker out in the world, so the *camera*
  places it and the camera knows nothing about the notch or the corners. It is
  drawn on the glass now, through `dialNumeralBox`, which keeps it inside the
  safe rect and clear of the chrome for **every** camera state, not just the one
  a particular shot produces.
- A long question now shrinks to fit the safe width instead of running off both
  edges of a small phone.

The sky, the ground, the field, the keeps, the craters and the particles still
bleed to the glass edges — that is what `cover` is for. Only what a child must
read or touch came inside the rect.

`createInstructions` adds the how-to-play panel. The HUD is deliberately
wordless, so that panel is the only place the rules are ever stated. One line
was added to the supplied copy: the dial can also be set by dragging across the
field (`onPointerDown` jumps the dial to the metre under the finger, then drag
is a 0.42-gain sweep), which is how most children will actually move it and was
otherwise undocumented.

## The one file outside this game

`createInstructions` cannot be adopted as it stands. The scrim is hidden with
the `hidden` attribute, but an author `display:flex` beats the user agent's
`[hidden]{display:none}`, so the panel is painted over the game from the moment
it mounts, at `z-index:40`, swallowing every touch — and `doClose` returns early
while `open` is false, so the PLAY button cannot dismiss it. The game would ship
unplayable.

Verified in headless Chrome rather than reasoned about:

```
$ chrome --headless --dump-dom  (scrim rule + hidden attribute, no fix)
display=flex

$ chrome --headless --dump-dom  (with .dwc-scrim[hidden]{display:none})
hidden=none shown=flex rehidden=none
```

So the fix is the one additive CSS rule in the shared sheet, which repairs every
adopter at once, rather than an `!important` override duplicated into this game's
HTML. It is the only change outside `dynawalla/games/trebuchet/`.

## Blast radius

**Areas touched:** dynawalla — one game (`dynawalla/games/trebuchet`) plus **one line
in `dynawalla/packs/shared/game-chrome/instructions.ts`**, see below.

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** No published zip changed in place, no catalog entry
      touched, no `voiceId` renamed. `pack.json` is unchanged — same id, same
      version, same capabilities.
- [x] **Native integrity.** N/A — no Rust, no manifest touched.
- [x] **Shared chrome.** `.dwc-scrim[hidden]{display:none}` is additive: it only
      applies when the attribute is set, which is exactly when the panel is meant
      to be invisible. Open and close are unaffected. Every other adopter of
      `createInstructions` is fixed by it, not changed by it.
- [x] **Strings.** N/A for `corpan-app` locales. The instructions copy is the
      game's own English, matching the pilot (skyledger); the HUD itself remains
      wordless.
- [x] **Curriculum.** N/A — no skill, generator or schema touched.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

Behaviour on a screen with no insets and no host chrome is unchanged except for
where `mute` sits and, on upright phones, the top stack starting 50px lower.
The camera's framing is deliberately unchanged: `padTop` gained only the top
inset.

## Proof

```
$ npm test        # five consecutive runs — one green run is not proof
run 1: # tests 151 # pass 151 # fail 0
run 2: # tests 151 # pass 151 # fail 0
run 3: # tests 151 # pass 151 # fail 0
run 4: # tests 151 # pass 151 # fail 0
run 5: # tests 151 # pass 151 # fail 0

$ npm run tsc
> @dynawalla/game-trebuchet@0.1.0 tsc
> tsc --noEmit
(0 errors)

$ npm run build
dist/trebuchet.js  86.58 kB │ gzip: 25.97 kB
✓ built in 25ms

$ cd dynawalla/packs && node build.mjs trebuchet
dynawalla.trebuchet@0.1.0 — TREBUCHET
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       4 skills, grades 1–3
  on disk      3 files, 77641 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~20564 bytes (20.56 KB) in 34.2ms
INF no leaks found

$ git diff origin/main..HEAD --diff-filter=D --name-only
(empty — nothing deleted)

$ git diff origin/main..HEAD --name-only
dynawalla/games/trebuchet/src/game.ts
dynawalla/games/trebuchet/src/index.ts
dynawalla/games/trebuchet/src/render/hud.ts
dynawalla/games/trebuchet/src/render/layout.test.ts
dynawalla/packs/shared/game-chrome/instructions.ts
```

**The clearance test was verified RED.** With the layout reverted in place — the
buttons measured from bare `w`/`h`, `mute` back in the top-right, the plaque
back at `unit*0.32`, and `dialNumeralBox`'s clamp removed — 98 of the 151 tests
fail:

```
# tests 151
# pass 53
# fail 98

not ok 7 - nothing a child touches sits under the host's chrome — phone portrait, small (320×568), no insets
  error: |-
    mute [279.0,10.2 24.0x24.0] is under the host chrome
    true !== false

not ok 8 - the question stays readable — phone portrait, small (320×568), no insets
  error: |-
    the equation plaque [17.0,13.0 286.0x47.0] is under the host chrome
    true !== false

not ok 14 - every control is inside the safe rect — phone portrait, small (320×568), notch, portrait
  error: 'fire [236.0,484.0 67.0x67.0] is outside the safe rect [0.0,47.0 320.0x487.0]'

not ok 17 - the dial numeral is legible wherever the camera puts it — phone portrait, small (320×568), notch, portrait
  error: 'the dial numeral [-50.2,-62.4 20.4x22.4] is outside the safe rect [0.0,47.0 320.0x487.0]'
```

The test goes through `hudLayout(w, h, safeRect(w, h, insets), loft)` — the exact
call `TrebuchetGame.resize()` makes — never a hand-built rect, at 320×568,
390×844, 768×1024, 1024×768 and 844×390, across three inset profiles (none, and
a notch in both orientations, because node measures zero insets) and both loft
states.
