### PR TITLE
fix(dynawalla/games/forge): the score was under the notch and QUENCH was under the host's button

### DIFF
--- a/dynawalla/games/forge/README.md
+++ b/dynawalla/games/forge/README.md
@@ -26,8 +26,14 @@ seconds later the curve you are watching is visibly steeper.
 The workbench is on the right: a bar of hot iron on the anvil with `15 − 8`
 burned into it, four cast ingots below it, and a hammer. Hit the right one.
 
-No instructions, because none are needed. Everything appears when it becomes
-relevant and nothing arrives with a tutorial attached.
+Nothing arrives with a tutorial attached: everything appears when it becomes
+relevant, and the anvil teaches itself. But the rest of the forge does not.
+Nothing on screen says a CRUCIBLE makes BELLOWS rather than sparks, that heat
+leaks away while you think, or that the two glowing ingots are a comparison you
+settle by *looking at the row*. So there is a manual, on the shared `?` control
+from `packs/shared/game-chrome/`, reachable during play rather than only before
+it — a child needs the rules at the moment they are stuck, which is never the
+title screen.
 
 ---
 

--- a/dynawalla/games/forge/src/game/chrome.test.ts
+++ b/dynawalla/games/forge/src/game/chrome.test.ts
@@ -1,0 +1,157 @@
+// THE TWO CORNERS AND THE NOTCH.
+//
+// FORGE draws everything on one canvas — the SPARKS readout, the heat gauge,
+// the six station rows, the four ingots, the QUENCH plate. A canvas cannot read
+// `env(safe-area-inset-*)`, because that is a CSS value, and this game declares
+// `viewport-fit=cover`, which opts the document *into* the notch. So the
+// readout was laid out from the raw viewport height and sat under the status
+// bar, and the ingots sat on the home indicator.
+//
+// On top of that the host floats two 44px controls over the pack: exit at the
+// top-left, how-to-play at the top-right. The header ran the full width, so the
+// SPARKS label and the top of the number were under the exit control, and the
+// QUENCH plate — a button — was under the help control. In landscape the
+// station column reaches the very top of the screen, so the REACTOR row was
+// under the exit control too.
+//
+// **What counts as critical here**, and it is a short list: the SPARKS readout
+// and its rate (the score, and the number the whole game is about), the heat
+// gauge and its printed multiplier, the six station rows (the buy targets), the
+// four ingots (the answer targets), the QUENCH plate and the audio toggle.
+//
+// **What is deliberately NOT critical**, and must keep bleeding to the glass:
+// the backdrop, the hammered-iron pattern, the furnace body, the crucible glow,
+// the ambient embers, the full-screen flash. Those use the raw `w`/`h` on
+// purpose — it is the entire reason `cover` is set — and a test below asserts
+// they are untouched by the insets so nobody "fixes" this by letterboxing.
+//
+// The insets are passed explicitly rather than measured, because node has no
+// notch and a test that measures zero proves nothing about a device.
+
+import { strict as assert } from "node:assert"
+import { test } from "node:test"
+
+import { hitsHostChrome, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import { computeLayout, type Rect } from "./layout.ts"
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+  ["desktop wide", 1920, 1080],
+]
+
+/** No insets — a laptop, an older tablet, a desktop browser. */
+const FLAT: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+/** A notched phone held upright: status bar above, home indicator below. */
+const NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+/** The same phone on its side. Both long edges lose room. */
+const NOTCH_SIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+const INSETS: Array<[string, Insets]> = [
+  ["flat", FLAT],
+  ["notched", NOTCH],
+  ["notched, on its side", NOTCH_SIDE],
+]
+
+const inside = (r: Rect, a: Rect): boolean =>
+  r.x >= a.x - 0.5 &&
+  r.y >= a.y - 0.5 &&
+  r.x + r.w <= a.x + a.w + 0.5 &&
+  r.y + r.h <= a.y + a.h + 0.5
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    test(`nothing readable or tappable is covered — ${vname} (${w}×${h}), ${iname}`, () => {
+      const area = safeRect(w, h, insets)
+      // Six revealed: a developed save is the worst case, because that is when
+      // the station column is at its tallest and its top row reaches furthest
+      // up the screen.
+      const l = computeLayout(w, h, 6, area)
+
+      const named: Array<[string, Rect]> = [
+        ["the SPARKS readout", l.header],
+        ["the QUENCH plate", l.quench],
+        ["the audio toggle", l.audio],
+        ["the station column", l.chain],
+        ["the anvil", l.anvil],
+        ["the work bar", l.billet],
+      ]
+      l.rows.forEach((r, i) => named.push([`station row ${i}`, r]))
+      l.slugs.forEach((r, i) => named.push([`ingot ${i}`, r]))
+
+      for (const [name, r] of named) {
+        // 1. Inside the safe rectangle. If `computeLayout` ignored `area` these
+        //    fail on the notched profiles — the device-only bug, caught here.
+        assert.ok(inside(r, area), `${name} leaves the safe area: ${JSON.stringify(r)}`)
+
+        // 2. Clear of the two host corners. The exit and help squares exist on
+        //    every device, insets or not, so these hold at FLAT too — this gate
+        //    fails on a laptop as well as on a phone, and cannot pass by
+        //    accident the way a zero-inset-only assertion would.
+        assert.equal(
+          hitsHostChrome(r, w, insets),
+          false,
+          `${name} is under a host control: ${JSON.stringify(r)}`,
+        )
+      }
+    })
+  }
+}
+
+test("the tap targets stay big enough for a child's thumb", () => {
+  // Narrowing the header is only acceptable while nothing shrinks below the
+  // platform's minimum touch target. The ingots are the answer buttons and the
+  // rows are the buy buttons.
+  for (const [name, w, h] of VIEWPORTS) {
+    const l = computeLayout(w, h, 6, safeRect(w, h, NOTCH))
+    for (const s of l.slugs) {
+      assert.ok(s.h >= 44, `${name}: an ingot is ${s.h.toFixed(1)}px tall`)
+      assert.ok(s.w >= 44, `${name}: an ingot is ${s.w.toFixed(1)}px wide`)
+    }
+    // `rowH` is the pitch, not the plate: the rows are contiguous and the
+    // `5 * scale` taken off each plate is a drawn gap, so the pitch is the
+    // target a thumb actually has. Honouring the safe area costs the column
+    // about 6px of pitch on a 320×568 notched phone — 36 down to 30 — which is
+    // real, and is the price of every row being reachable instead of the top
+    // and bottom ones being under the status bar and the home indicator.
+    assert.ok(l.rowH >= 28, `${name}: the station pitch is ${l.rowH.toFixed(1)}px`)
+    assert.ok(l.quench.h >= 30, `${name}: the quench plate is ${l.quench.h.toFixed(1)}px tall`)
+    // Room left for the number itself. `header.ts` fits the mantissa into
+    // `header.w - 20 * scale`, so a header squeezed to nothing would print an
+    // unreadable score rather than throw.
+    assert.ok(l.header.w >= 180, `${name}: the header is ${l.header.w.toFixed(1)}px wide`)
+  }
+})
+
+test("the world behind the HUD is not letterboxed by the insets", () => {
+  // The counterpart assertion. `scene/backdrop.ts` fills `0,0,L.w,L.h` and
+  // `draw.ts` flashes over the same rect; those must keep reaching the glass,
+  // which is the whole point of `viewport-fit=cover`. A change that solved the
+  // notch by shrinking the canvas would pass every assertion above and be
+  // wrong, so it is pinned here.
+  for (const [, w, h] of VIEWPORTS) {
+    const notched = computeLayout(w, h, 6, safeRect(w, h, NOTCH))
+    assert.equal(notched.w, w, "the layout narrowed the world")
+    assert.equal(notched.h, h, "the layout shortened the world")
+  }
+})
+
+test("the header moves for the notch and the corners, and only the header", () => {
+  // Portrait: the station column keeps the full width it always had, because
+  // its top is nowhere near the host's band. Only the header narrows. Reserving
+  // a top strip instead would have come straight out of the station rows, which
+  // are already down to 36px on a 320px phone.
+  const flat = computeLayout(320, 568, 6, safeRect(320, 568, FLAT))
+  const notched = computeLayout(320, 568, 6, safeRect(320, 568, NOTCH))
+
+  assert.ok(flat.header.x > 54, "the header did not clear the exit control")
+  assert.ok(flat.header.x + flat.header.w < 320 - 54, "the header did not clear the help control")
+  assert.ok(flat.chain.w > flat.header.w, "the station column narrowed along with the header")
+  assert.equal(flat.chain.x, 11, "the station column moved when it did not need to")
+
+  assert.ok(notched.header.y > flat.header.y, "the header ignored the notch")
+  assert.ok(notched.rowH < flat.rowH, "the rows did not give up the height the notch took")
+})

--- a/dynawalla/games/forge/src/game/forge.ts
+++ b/dynawalla/games/forge/src/game/forge.ts
@@ -43,6 +43,11 @@ import {
   KIND_STEAM,
   makeParticles,
 } from "../render/particles.ts"
+import {
+  createInstructions,
+  onInsetsChange,
+  safeRect,
+} from "../../../../packs/shared/game-chrome/index.ts"
 import { drawScene, markRects, overlayQuestionRects } from "../scene/draw.ts"
 import { computeLayout, hit, type Rect } from "./layout.ts"
 import { applyOffer, makeMarkRound } from "./marks.ts"
@@ -69,8 +74,17 @@ export function mount(el: HTMLElement, host: Host): Mounted {
   const pointerFine =
     typeof matchMedia === "function" ? matchMedia("(pointer: fine)").matches : true
 
+  // Rotation swaps the safe-area insets and iPadOS changes them when the pack
+  // is resized in Split View, both of which can happen without the canvas
+  // changing size — and `surface.resize()` reports false in that case. A layout
+  // read once at mount is right until the first turn of the tablet.
+  let relayout = false
+  const stopInsets = onInsetsChange(() => {
+    relayout = true
+  })
+
   const g: Game = {
-    layout: computeLayout(surface.w, surface.h, 1),
+    layout: computeLayout(surface.w, surface.h, 1, safeRect(surface.w, surface.h)),
     economy,
     juice,
     particles,
@@ -732,6 +746,89 @@ export function mount(el: HTMLElement, host: Host): Mounted {
     }
   }
 
+  // --- how to play ---------------------------------------------------------
+  //
+  // The README says "no instructions, because none are needed. Everything
+  // appears when it becomes relevant." That is true of the anvil and false of
+  // everything else. Nothing on screen says a CRUCIBLE makes BELLOWS rather
+  // than sparks, nothing says heat leaks away while you think, and nothing says
+  // the two glowing ingots are a comparison you are supposed to LOOK at the row
+  // to settle. A child who never works that out plays a tapping game.
+  //
+  // It is a manual and not a tutorial: the panel stays reachable during play,
+  // because the moment a child needs the rules is never the title screen.
+  const guide = createInstructions(el, {
+    title: "FORGE",
+    summary: [
+      "You run a forge. Answer the sum on the anvil and you earn sparks.",
+      "Spend sparks on machines. The machines build other machines, and everything you own starts making more, faster.",
+    ],
+    sections: [
+      {
+        heading: "The anvil",
+        lines: [
+          "A bar of hot iron shows a sum, like 15 − 8.",
+          "Four ingots sit under it, each with a number on it. Hit the one that is the answer.",
+          "You are paid the answer itself, plus one second of everything your machines make.",
+          "So a big answer pays more. 12 × 11 pays 132 sparks. 4 + 5 pays 9. Pick the big ones when you can.",
+          "Get several right in a row and each one pays more than the last.",
+        ],
+      },
+      {
+        heading: "The six machines",
+        lines: [
+          "Down the side: BELLOWS, CRUCIBLE, HAMMER, ANVIL, FOUNDRY, REACTOR.",
+          "Bellows make sparks. Crucibles make bellows. Hammers make crucibles. Each machine builds the one above it in the list.",
+          "Tap a machine to buy one. Press and hold to keep buying, and it speeds up the longer you hold.",
+          "A REACTOR makes no sparks at all by itself. It makes the thing that makes the thing that makes sparks. Buy one and watch the counter a minute later.",
+          "The last four machines arrive chained shut. Answer a sum to break the chain. Getting it wrong here costs you nothing — it just asks again.",
+        ],
+      },
+      {
+        heading: "Heat",
+        lines: [
+          "Every right answer pours heat into the forge, and heat multiplies everything you make.",
+          "Heat leaks away all the time, so the bar is dropping while you think.",
+          "A wrong answer costs you a quarter of the heat you had. The better you are doing, the more a guess costs you.",
+        ],
+      },
+      {
+        heading: "Forge marks",
+        lines: [
+          "Sometimes two glowing ingots rise out of the crucible. One says something like +14 HAMMER. The other says ×2 HAMMER.",
+          "Look at the HAMMER row to see how many you own, then work out which ingot gives you more.",
+          "Own 9 hammers? ×2 gives 18, and +14 gives 23. Take the +14.",
+          "Own 400 hammers? ×2 gives 800, and +14 gives 414. Now take the ×2.",
+          "Neither one is wrong and nothing is lost. But the better one changes as you play, so look at the row every time.",
+        ],
+      },
+      {
+        heading: "The quench",
+        lines: [
+          "When the QUENCH plate lights up blue you can plunge the forge, start again from nothing, and keep some carbon.",
+          "Carbon is permanent. It multiplies everything from now on, so the next run gets as far in ninety seconds as this one did in four minutes.",
+          "The screen shows you the square root it worked out to decide how much carbon you get.",
+        ],
+      },
+      {
+        heading: "While you are away",
+        lines: [
+          "The forge keeps working when you close the app, for up to four hours.",
+          "When you come back, one strike claims what it made. A right answer claims all of it, a wrong answer claims half. Nothing is ever taken away.",
+        ],
+      },
+      {
+        heading: "Keyboard",
+        lines: [
+          "A S D F G H buy the six machines.",
+          "1 2 3 4 pick an ingot.",
+          "Space quenches. M turns the sound off.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+  })
+
   surface.canvas.addEventListener("pointerdown", onDown, { passive: false })
   globalThis.addEventListener("pointerup", onUp)
   globalThis.addEventListener("pointercancel", onUp)
@@ -772,7 +869,10 @@ export function mount(el: HTMLElement, host: Host): Mounted {
     const dt = realDt * juice.timeScale
     g.clock += dt
 
-    if (surface.resize()) g.layout = computeLayout(surface.w, surface.h, g.revealed)
+    if (surface.resize() || relayout) {
+      relayout = false
+      g.layout = computeLayout(surface.w, surface.h, g.revealed, safeRect(surface.w, surface.h))
+    }
 
     // Economy: fixed 60 Hz, frozen during hitstop. Deterministic regardless of
     // display refresh rate — a 120 Hz tablet earns exactly what a 60 Hz one does.
@@ -1058,6 +1158,8 @@ export function mount(el: HTMLElement, host: Host): Mounted {
     unmount() {
       cancelAnimationFrame(raf)
       save(economy, markOom, g.audioOn)
+      guide.destroy()
+      stopInsets()
       surface.canvas.removeEventListener("pointerdown", onDown)
       surface.canvas.removeEventListener("pointermove", onMove)
       globalThis.removeEventListener("pointerup", onUp)

--- a/dynawalla/games/forge/src/game/layout.ts
+++ b/dynawalla/games/forge/src/game/layout.ts
@@ -7,6 +7,27 @@
 // LANDSCAPE (a tablet on its side, or a desktop) puts the furnace column down
 // the left and the workbench on the right, so the two things you alternate
 // between are never more than one saccade apart and neither ever moves.
+//
+// **The frame is not the screen.** `computeLayout` takes the safe rectangle,
+// and takes it as a REQUIRED argument. This game declares `viewport-fit=cover`
+// and draws its entire HUD on a canvas; `env(safe-area-inset-*)` is a CSS value
+// a canvas cannot read, so before this the SPARKS readout was laid out from the
+// raw viewport and its top sat under the notch. An optional argument would mean
+// a caller that forgets it still compiles and only fails on a device.
+//
+// **Two corners stay clear.** The host floats a 44px exit control over the
+// top-left and the how-to-play control over the top-right. It does not reserve
+// a band and this layout must not pretend it did — taking a strip off the top
+// would come straight out of the station rows, which are already only 36px on a
+// 320px phone. Instead the top of the frame is confined HORIZONTALLY to the
+// channel between the two corners: `chanX`..`chanR`. The header sits in it in
+// both orientations, and in landscape so does the station column, because there
+// the top row reaches the very top of the screen.
+//
+// The backdrop, the furnace body, the glow and the particles all still use the
+// full `w`/`h` and bleed under the notch, which is the point of `cover`.
+
+import { HOST_CONTROL, HOST_MARGIN } from "../../../../packs/shared/game-chrome/index.ts"
 
 export type Rect = { x: number; y: number; w: number; h: number }
 
@@ -14,10 +35,15 @@ export function hit(r: Rect, x: number, y: number, slop = 0): boolean {
   return x >= r.x - slop && x <= r.x + r.w + slop && y >= r.y - slop && y <= r.y + r.h + slop
 }
 
+/** Breathing room between a HUD edge and a host control. */
+const CHROME_GAP = 8
+
 export type Layout = {
   portrait: boolean
   w: number
   h: number
+  /** The safe rectangle this layout was built from. */
+  safe: Rect
   pad: number
   /** The station column, bottom-anchored: BELLOWS never moves. */
   chain: Rect
@@ -41,28 +67,41 @@ export type Layout = {
 
 const MAX_W = 1280
 
-export function computeLayout(w: number, h: number, revealed: number): Layout {
-  const portrait = h >= w * 0.98
+export function computeLayout(w: number, h: number, revealed: number, area: Rect): Layout {
+  const portrait = area.h >= area.w * 0.98
   // One scale factor for every type size and inset, tied to the short edge, so
   // a 320 px phone and a 1280 px desktop look like the same game rather than
   // the same game with different amounts of empty space.
-  const scale = Math.max(0.72, Math.min(1.55, Math.min(w, h) / (portrait ? 420 : 700)))
+  const scale = Math.max(
+    0.72,
+    Math.min(1.55, Math.min(area.w, area.h) / (portrait ? 420 : 700)),
+  )
   const pad = Math.round(14 * scale)
   const n = Math.max(1, revealed)
 
   // Centre the playfield on very wide screens instead of stretching it.
-  const cw = Math.min(w, MAX_W)
-  const ox = (w - cw) / 2
+  const cw = Math.min(area.w, MAX_W)
+  const ox = area.x + (area.w - cw) / 2
+
+  // The channel between the host's two 44px corners, never narrower than the
+  // centred playfield already was. On a 1920px desktop the playfield is already
+  // inset 320px and the corners cost nothing; on a 320px phone this is what
+  // moves the readout out from under the exit chevron.
+  const rail = HOST_MARGIN + HOST_CONTROL + CHROME_GAP
+  const chanX = Math.max(ox + pad, area.x + rail)
+  const chanR = Math.min(ox + cw - pad, area.x + area.w - rail)
 
   if (portrait) {
-    const headerH = Math.round(Math.min(h * 0.175, 152 * scale))
-    const anvilH = Math.round(Math.min(h * 0.35, 318 * scale))
-    const header: Rect = { x: ox + pad, y: pad, w: cw - pad * 2, h: headerH }
+    const headerH = Math.round(Math.min(area.h * 0.175, 152 * scale))
+    const anvilH = Math.round(Math.min(area.h * 0.35, 318 * scale))
+    // Only the header reaches into the host's band, so only the header narrows.
+    // The station column below it keeps the full width it always had.
+    const header: Rect = { x: chanX, y: area.y + pad, w: chanR - chanX, h: headerH }
     const chain: Rect = {
       x: ox + pad,
       y: header.y + header.h + pad * 0.5,
       w: cw - pad * 2,
-      h: h - headerH - anvilH - pad * 1.6 - 46 * scale,
+      h: area.h - headerH - anvilH - pad * 1.6 - 46 * scale,
     }
     const rowH = Math.min(chain.h / 6, 86 * scale)
     const rows: Rect[] = []
@@ -74,9 +113,11 @@ export function computeLayout(w: number, h: number, revealed: number): Layout {
         h: rowH - Math.round(5 * scale),
       })
     }
-    const anvil: Rect = { x: ox, y: h - anvilH, w: cw, h: anvilH }
+    // Bottom-anchored to the SAFE area, so the ingots a child taps sit above
+    // the home indicator rather than under it.
+    const anvil: Rect = { x: ox, y: area.y + area.h - anvilH, w: cw, h: anvilH }
     const slugH = Math.min(anvilH * 0.42, 120 * scale)
-    const slugY = h - slugH - pad
+    const slugY = area.y + area.h - slugH - pad
     const sgap = Math.round(9 * scale)
     const slugW = (cw - pad * 2 - sgap * 3) / 4
     const slugs: Rect[] = []
@@ -96,6 +137,7 @@ export function computeLayout(w: number, h: number, revealed: number): Layout {
       portrait,
       w,
       h,
+      safe: area,
       pad,
       chain,
       rowH,
@@ -122,7 +164,15 @@ export function computeLayout(w: number, h: number, revealed: number): Layout {
 
   // --- landscape -----------------------------------------------------------
   const colW = Math.min(cw * 0.46, 560 * scale)
-  const chain: Rect = { x: ox + pad, y: pad * 2.2, w: colW, h: h - pad * 3.2 - 104 * scale }
+  // In landscape the column reaches the top of the frame, so it — not just the
+  // header — has to start clear of the exit control. The whole workbench slides
+  // with it, which keeps the one-saccade spacing the two halves are built on.
+  const chain: Rect = {
+    x: chanX,
+    y: area.y + pad * 2.2,
+    w: colW,
+    h: area.h - pad * 3.2 - 104 * scale,
+  }
   const rowH = Math.min(chain.h / 6, 100 * scale)
   const rows: Rect[] = []
   for (let i = 0; i < 6; i++) {
@@ -134,10 +184,15 @@ export function computeLayout(w: number, h: number, revealed: number): Layout {
     })
   }
   const rx = chain.x + chain.w + pad * 1.6
-  const rw = ox + cw - pad - rx
-  const headerH = Math.min(h * 0.3, 190 * scale)
-  const header: Rect = { x: rx, y: pad * 2.2, w: rw, h: headerH }
-  const anvil: Rect = { x: rx, y: header.y + headerH + pad, w: rw, h: h - header.y - headerH - pad * 2.2 }
+  const rw = chanR - rx
+  const headerH = Math.min(area.h * 0.3, 190 * scale)
+  const header: Rect = { x: rx, y: chain.y, w: rw, h: headerH }
+  const anvil: Rect = {
+    x: rx,
+    y: header.y + headerH + pad,
+    w: rw,
+    h: area.y + area.h - header.y - headerH - pad * 2.2,
+  }
   const slugH = Math.min(anvil.h * 0.42, 132 * scale)
   const slugY = anvil.y + anvil.h - slugH
   const sgap = Math.round(10 * scale)
@@ -153,12 +208,13 @@ export function computeLayout(w: number, h: number, revealed: number): Layout {
     portrait,
     w,
     h,
+    safe: area,
     pad,
     chain,
     rowH,
     rows,
-    crucible: { x: chain.x + chain.w / 2, y: h - 26 * scale, r: 170 * scale },
-    furnaceBottom: h - 6 * scale,
+    crucible: { x: chain.x + chain.w / 2, y: area.y + area.h - 26 * scale, r: 170 * scale },
+    furnaceBottom: area.y + area.h - 6 * scale,
     header,
     readoutY: header.y + headerH * 0.5,
     anvil,

--- a/dynawalla/games/forge/src/scene/overlays.ts
+++ b/dynawalla/games/forge/src/scene/overlays.ts
@@ -29,9 +29,14 @@ export function drawOverlay(ctx: CanvasRenderingContext2D, g: Game): void {
 export function overlayQuestionRects(g: Game): { panel: Rect; slugs: Rect[] } {
   const L = g.layout
   const S = L.scale
-  const pw = Math.min(L.w - L.pad * 2, 720 * S)
-  const ph = Math.min(L.h - L.pad * 2, 430 * S)
-  const panel: Rect = { x: (L.w - pw) / 2, y: (L.h - ph) / 2, w: pw, h: ph }
+  const pw = Math.min(L.safe.w - L.pad * 2, 720 * S)
+  const ph = Math.min(L.safe.h - L.pad * 2, 430 * S)
+  const panel: Rect = {
+    x: L.safe.x + (L.safe.w - pw) / 2,
+    y: L.safe.y + (L.safe.h - ph) / 2,
+    w: pw,
+    h: ph,
+  }
   const gap = 10 * S
   const sw = (pw - 40 * S - gap * 3) / 4
   const sh = Math.min(110 * S, ph * 0.26)
@@ -172,9 +177,14 @@ function drawHaul(ctx: CanvasRenderingContext2D, g: Game): void {
 export function markRects(g: Game): { panel: Rect; a: Rect; b: Rect } {
   const L = g.layout
   const S = L.scale
-  const pw = Math.min(L.w - L.pad * 2, 760 * S)
-  const ph = Math.min(L.h - L.pad * 2, 396 * S)
-  const panel: Rect = { x: (L.w - pw) / 2, y: (L.h - ph) / 2, w: pw, h: ph }
+  const pw = Math.min(L.safe.w - L.pad * 2, 760 * S)
+  const ph = Math.min(L.safe.h - L.pad * 2, 396 * S)
+  const panel: Rect = {
+    x: L.safe.x + (L.safe.w - pw) / 2,
+    y: L.safe.y + (L.safe.h - ph) / 2,
+    w: pw,
+    h: ph,
+  }
   const stacked = pw < 520 * S
   if (stacked) {
     const ih = (ph - 190 * S) / 2
@@ -291,9 +301,14 @@ function drawQuench(ctx: CanvasRenderingContext2D, g: Game): void {
   if (g.quenchPhase === "confirm") {
     const k = ease.outQuint(clamp01(g.quenchT))
     scrim(ctx, g, k)
-    const pw = Math.min(L.w - L.pad * 2, 700 * S)
-    const ph = Math.min(L.h - L.pad * 2, 470 * S)
-    const panel: Rect = { x: (L.w - pw) / 2, y: (L.h - ph) / 2, w: pw, h: ph }
+    const pw = Math.min(L.safe.w - L.pad * 2, 700 * S)
+    const ph = Math.min(L.safe.h - L.pad * 2, 470 * S)
+    const panel: Rect = {
+      x: L.safe.x + (L.safe.w - pw) / 2,
+      y: L.safe.y + (L.safe.h - ph) / 2,
+      w: pw,
+      h: ph,
+    }
     ctx.save()
     ctx.globalAlpha = k
     plate(ctx, panel.x, panel.y, panel.w, panel.h, {


### PR DESCRIPTION
## What

Make FORGE respect the safe area, keep the host's two 44px corners free of
anything a child must read or touch, and add a manual for the parts of the game
that were never explained.

## Why

**1 · The notch.** FORGE declares `viewport-fit=cover`, which opts the document
*into* the notch, the home indicator and the rounded corners. Everything it
draws is on one canvas — the SPARKS readout, the heat gauge, the six station
rows, the four ingots, the QUENCH plate — and a canvas cannot read
`env(safe-area-inset-*)`, because that is a CSS value. `computeLayout` took
`(w, h, revealed)` and put the header at `y = pad`, so the SPARKS label and the
top of the number sat under the status bar. `slugY = h - slugH - pad` put the
four answer ingots on the home indicator.

**2 · Host chrome.** The host floats a 44px exit control top-left and the
how-to-play control top-right. At 320×568 the header ran `x = 11..309`, so:

- the SPARKS label and the big number were under the exit chevron;
- the QUENCH plate — a *button*, and the only cyan thing in the game — was under
  the how-to-play control;
- in landscape the station column starts at the very top of the screen, so the
  REACTOR row was under the exit chevron too.

**3 · The manual.** The README claimed "no instructions, because none are
needed". That is true of the anvil and false of everything else. Nothing on
screen says a CRUCIBLE makes BELLOWS rather than sparks, that heat leaks away
while you think, or that the two glowing forge-mark ingots are a comparison you
settle by *looking at the row*. A child who never works that out is playing a
tapping game, and the best mathematics in this pack is the part with no question
attached.

### What was judged critical for corner clearance

Critical: the **SPARKS readout** and its rate (the score, and the number the
whole game is about), the **heat gauge** and its printed multiplier, the **six
station rows** (buy targets), the **four ingots** (answer targets), the **QUENCH
plate** and the **audio toggle**.

Not critical, and deliberately still full-bleed: the backdrop, the
hammered-iron pattern, the furnace body, the crucible glow, the ambient embers,
the full-screen flash. Those still use the raw `w`/`h` and bleed under the notch
— it is the entire reason `cover` is set. A test pins `l.w === w` and
`l.h === h` under insets so nobody "fixes" this later by letterboxing.

**No band is reserved**, because the chrome overlays. A 57px strip off the top
would come straight out of the station rows, which are already only 36px of
pitch on a 320px phone. Instead the top of the frame is confined *horizontally*
to a channel between the two corners (`chanX`..`chanR`). The header sits in it in
both orientations; in landscape the station column does too, and the workbench
slides with it so the one-saccade spacing between the two halves is preserved.
In portrait the station column keeps the full width it always had — its top is
nowhere near the band — and a test asserts `chain.w > header.w` and that
`chain.x` did not move.

The channel is `max(ox + pad, area.x + rail)`, so on a 1920px desktop, where the
playfield is already centred and inset 320px, the corners cost nothing and the
layout is byte-identical to before.

`computeLayout(w, h, revealed, area)` takes the safe rect as a **required**
argument. Optional would mean a caller that forgets it still compiles and only
fails on a device.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/forge/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched — same id, version, sdk, host
      range, capabilities and covers. No published zip changed in place, no
      catalog entry dropped, no `minAppVersion` moved. `node build.mjs forge`
      rebuilds and re-stages it.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app/public/locales/`. The new strings are the
      how-to-play copy inside this pack; `pack.json` is unchanged.
- [x] **Curriculum.** N/A — no skill id, grade, generator or schema touched. The
      game consumes items through the host seam exactly as before, and the
      economy, save format and mal-rule distractors are untouched.
- [x] **Secrets.** None. `gitleaks` output below.

Behavioural risk: this moves pixels, and it costs the station column about 6px
of pitch on a 320×568 notched phone (36 → 30). That is real and it is the price
of *every* row being reachable, instead of the top and bottom ones sitting under
the status bar and the home indicator. The saved game, the offline haul and the
quench maths are untouched; `save.ts` is not in the diff.

## Proof

All output is real, from `dynawalla/games/forge/` unless stated, after rebasing
onto the current `origin/main`.

**`npm test`, five times** — one green run is not proof.

```
--- run 1
# tests 72
# pass 72
# fail 0
--- run 2
# tests 72
# pass 72
# fail 0
--- run 3
# tests 72
# pass 72
# fail 0
--- run 4
# tests 72
# pass 72
# fail 0
--- run 5
# tests 72
# pass 72
# fail 0
```

**The clearance test fails when the fix is removed.** A clearance test that
passes either way is worthless, so this was checked rather than assumed. With
`computeLayout` reverted to ignoring `area` and to giving the header the full
playfield width again:

```
# tests 72
# pass 55
# fail 17
not ok 22 - nothing readable or tappable is covered — phone portrait, small (320×568), flat
not ok 23 - nothing readable or tappable is covered — phone portrait, small (320×568), notched
not ok 24 - nothing readable or tappable is covered — phone portrait, small (320×568), notched, on its side
not ok 25 - nothing readable or tappable is covered — phone portrait (390×844), flat
not ok 26 - nothing readable or tappable is covered — phone portrait (390×844), notched
not ok 27 - nothing readable or tappable is covered — phone portrait (390×844), notched, on its side
not ok 28 - nothing readable or tappable is covered — tablet portrait (768×1024), flat
not ok 29 - nothing readable or tappable is covered — tablet portrait (768×1024), notched
not ok 30 - nothing readable or tappable is covered — tablet portrait (768×1024), notched, on its side
not ok 31 - nothing readable or tappable is covered — tablet landscape (1024×768), flat
not ok 32 - nothing readable or tappable is covered — tablet landscape (1024×768), notched
not ok 33 - nothing readable or tappable is covered — tablet landscape (1024×768), notched, on its side
not ok 34 - nothing readable or tappable is covered — phone landscape (844×390), flat
not ok 35 - nothing readable or tappable is covered — phone landscape (844×390), notched
not ok 36 - nothing readable or tappable is covered — phone landscape (844×390), notched, on its side
not ok 38 - nothing readable or tappable is covered — desktop wide (1920×1080), notched
not ok 42 - the header moves for the notch and the corners, and only the header
```

Failure detail from the first case, which is the shipped bug:

```
error: |-
  the SPARKS readout is under a host control: {"x":11,"y":11,"w":298,"h":99}
  true !== false
```

Note the corner cases fail at **flat** insets too — the exit and help squares
exist on every device, so this gate holds on a laptop as well as on a phone. It
cannot pass by accident the way a zero-inset-only test would. Note also that
`desktop wide (1920×1080), flat` still passes with the fix removed, which is the
test correctly reporting that a centred 1280px playfield never had this bug.

**`npm run tsc`** — 0 errors. (This runs twice here: source, then
`tsconfig.test.json`, so the new test is type-checked as well.)

```
> @dynawalla/game-forge@0.1.0 tsc
> tsc --noEmit && tsc --noEmit -p tsconfig.test.json

```

**`npm run build`**

```
vite v8.1.5 building client environment for production...
transforming...✓ 31 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                 0.89 kB │ gzip:  0.46 kB
dist/assets/index-CYXn32tn.js  70.85 kB │ gzip: 26.11 kB

✓ built in 34ms
```

**`node build.mjs forge`**, from `dynawalla/packs/`

```
dist-pack/assets/pack-BrPghFA_.js  74.44 kB │ gzip: 27.47 kB

✓ built in 30ms
dynawalla.forge@0.1.0 — FORGE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics, storage
  covers       7 skills, grades 1–4
  on disk      3 files, 76637 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`**

```
INF 1 commits scanned.
INF scanned ~17888 bytes (17.89 KB) in 35.8ms
INF no leaks found
```

**Scope** — one game directory, nothing deleted.

```
$ git diff --stat origin/main..HEAD
 dynawalla/games/forge/README.md               |  10 +-
 dynawalla/games/forge/src/game/chrome.test.ts | 157 ++++++++++++++++++++++++++
 dynawalla/games/forge/src/game/forge.ts       | 106 ++++++++++++++++-
 dynawalla/games/forge/src/game/layout.ts      |  92 ++++++++++++---
 dynawalla/games/forge/src/scene/overlays.ts   |  33 ++++--
 5 files changed, 367 insertions(+), 31 deletions(-)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty)
```
