### PR TITLE
fix(dynawalla/games/guilty): the accusation ran under both host buttons, and nobody was told the rule

### DIFF
--- a/dynawalla/games/guilty/src/game/game.ts
+++ b/dynawalla/games/guilty/src/game/game.ts
@@ -10,6 +10,11 @@
  * `./ship.ts`.
  */
 
+import {
+  createInstructions,
+  onInsetsChange,
+  safeRect,
+} from "../../../../packs/shared/game-chrome/index.ts";
 import type { GameHandle, Host, Question } from "../contract.ts";
 import { createAudio } from "../audio/audio.ts";
 import { beginFrame, fitCamera, makeCamera } from "../core/camera.ts";
@@ -64,6 +69,7 @@ import {
   stepBullets,
   updateShip,
 } from "./ship.ts";
+import { hudLayout } from "./hudLayout.ts";
 import { bannerFor, specFor } from "./waves.ts";
 import { Mode, Phase, freeHusk, makePools, type Husk, type World } from "./world.ts";
 
@@ -101,6 +107,7 @@ export function mount(
     w: 1,
     h: 1,
     dpr: 1,
+    hud: hudLayout(1, 1, { x: 0, y: 0, w: 1, h: 1 }),
     ...makePools(),
     ship: {
       x: 0,
@@ -189,7 +196,11 @@ export function mount(
     canvas.style.width = `${w}px`;
     canvas.style.height = `${h}px`;
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    // The camera is fitted to the whole GLASS: the trench, the gate, the husks
+    // and the ship are supposed to bleed under the notch, which is why
+    // `viewport-fit=cover` is set at all. Only the type moves.
     fitCamera(world.cam, w, h);
+    world.hud = hudLayout(w, h, safeRect(w, h));
     bakeScene(w, h);
     vignette = bakeVignette(w, h);
   }
@@ -197,6 +208,12 @@ export function mount(
   const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => resize()) : null;
   observer?.observe(el);
   window.addEventListener("resize", resize);
+  // Rotation swaps the insets and iPadOS changes them when the pack is resized
+  // in Split View, neither of which is guaranteed to change the canvas size. A
+  // layout read once at mount is right until the first turn of the tablet.
+  const stopInsets = onInsetsChange(() => {
+    resize();
+  });
   resize();
   seedMotes(world, 150);
 
@@ -867,7 +884,9 @@ export function mount(
     raf = requestAnimationFrame(frame);
     const realDt = Math.min(0.05, Math.max(0.0005, (now - last) / 1000));
     last = now;
-    if (world.paused) return;
+    // The manual freezes the trench. A child who went to read the rules must
+    // not come back to a life they lost while reading them.
+    if (world.paused || guide.isOpen) return;
 
     const t0 = performance.now();
     update(realDt);
@@ -937,6 +956,81 @@ export function mount(
     },
   });
 
+  /* ------------------------------------------------------- how to play */
+  //
+  // GUILTY shipped with no rules anywhere. A child was shown a trench, four
+  // sinking shapes with numbers on them, and the word GUILTY — and the rule
+  // that makes the game a maths game rather than a shooting game, that three of
+  // those four numbers are mistakes somebody really makes and you must destroy
+  // only the true one, was never stated. Shooting an innocent turns it hostile,
+  // which reads as the game being unfair rather than as a punishment for
+  // guessing.
+  //
+  // The panel stays reachable during play, and opening it freezes the descent:
+  // a child who goes to read the rules must not lose a life while reading them.
+  const guide = createInstructions(el, {
+    title: "GUILTY",
+    summary: [
+      "A sum hangs over the trench. Four shells sink out of it, each with a different answer on it.",
+      "Only one answer is right. Shoot that one. Shoot a wrong one and it turns on you.",
+    ],
+    sections: [
+      {
+        heading: "How to play",
+        lines: [
+          "Read the sum at the top and work out the answer yourself.",
+          "Four shells sink towards the line above your ship. Each shell carries a number.",
+          "Find the shell with your answer on it and shoot it. The other three scatter and you are safe.",
+          "Do not let a shell reach the line. If one crosses it, you lose a life.",
+        ],
+      },
+      {
+        heading: "The wrong answers are real mistakes",
+        lines: [
+          "The three wrong numbers are not random. Each one is what you get if you make a mistake people really make.",
+          "So a wrong number can look very close to the right one. Work the sum out properly instead of picking the one that looks about right.",
+          "Shoot a wrong shell and it turns red and starts shooting back. That is why guessing is a bad plan.",
+        ],
+      },
+      {
+        heading: "Moving and shooting",
+        lines: [
+          "On a touch screen, drag anywhere to steer. Your finger does not have to be on the ship, so your hand never covers what you are aiming at.",
+          "With a mouse, just move it. The ship follows the pointer.",
+          "The arrow keys and A and D work too.",
+          "Your gun fires by itself. It stops while you are sliding fast and starts again the moment you settle, so aim first, then hold still.",
+        ],
+      },
+      {
+        heading: "Deep focus",
+        lines: [
+          "Every right answer fills the thin bar along the bottom of the screen.",
+          "When it is full, tap once quickly, or press the space bar, to slow the whole trench down.",
+          "Use it when the shells are close to the line and you need a moment to think.",
+        ],
+      },
+      {
+        heading: "Waves and lives",
+        lines: [
+          "You start with three lives. Clear a wave and the next one sinks faster.",
+          "Every sixth wave is a big one.",
+          "Get a lot right in a row and each one is worth more.",
+        ],
+      },
+      {
+        heading: "Keyboard",
+        lines: [
+          "Left and right arrows, or A and D, steer.",
+          "Space uses deep focus. M turns the sound off. P pauses.",
+        ],
+      },
+    ],
+    onClose: (): void => {
+      last = performance.now();
+    },
+    reducedMotion: reduced,
+  });
+
   /* --------------------------------------------------------------- the bot */
 
   let bot: ((dt: number) => void) | null = null;
@@ -956,6 +1050,8 @@ export function mount(
     unmount() {
       running = false;
       cancelAnimationFrame(raf);
+      guide.destroy();
+      stopInsets();
       input.detach();
       observer?.disconnect();
       window.removeEventListener("resize", resize);

--- a/dynawalla/games/guilty/src/game/hud.ts
+++ b/dynawalla/games/guilty/src/game/hud.ts
@@ -1,14 +1,20 @@
 /**
  * Head-up display.
  *
- * The equation lives in the *world*, at the top of the trench, because the
- * husks are born out of it — that fan-out is the entire tutorial. Everything
- * else is deliberately tiny and in the corners: score, lives, and a focus bar
- * one pixel thick along the bottom edge. Nothing explains anything.
+ * The equation belongs at the top of the trench, because the husks are born out
+ * of it — that fan-out is the entire tutorial. Everything else is deliberately
+ * tiny and in the corners: score, lives, and a focus bar one pixel thick along
+ * the bottom edge. Nothing explains anything.
+ *
+ * Every position here comes from `hudLayout.ts` rather than from `w`/`h`
+ * directly, because `w`/`h` are the whole glass and this game's `cover`
+ * viewport means the glass includes the notch, the home indicator and two 44px
+ * squares the host paints its own controls into. The trench still uses the
+ * whole glass; only the type moves.
  */
 
 import { project } from "../core/camera.ts";
-import { EQUATION_Y, SHIP_Y } from "../core/config.ts";
+import { SHIP_Y } from "../core/config.ts";
 import { C, rgba } from "../core/palette.ts";
 import { drawGlow, drawGlyph, getGlyph } from "../render/bake.ts";
 import { clamp, ease } from "../render/draw.ts";
@@ -20,16 +26,21 @@ const font = (size: number): string => UI_FONT.replace("%SIZE%", String(Math.rou
 export function drawEquation(world: World): void {
   const q = world.question;
   if (!q) return;
-  const { ctx, cam } = world;
+  const { ctx, hud } = world;
   const age = world.time - world.askedAt;
   const pop = ease.outBack(clamp(age / 0.42, 0, 1));
   const bob = Math.sin(world.time * 1.3) * 1.6;
-  const p = project(cam, 0, EQUATION_Y + bob, 0);
+  // The box, not the raw projection: the accusation is the one thing in this
+  // game a child MUST read, and it is centred and wide, so on a phone it ran
+  // under the exit control at one end and the how-to-play control at the other.
+  // `hudLayout` keeps it in the channel between them and lets the trench behind
+  // it carry on to the glass.
+  const p = { x: hud.cx, y: hud.equation.y + hud.equation.h / 2 - bob * 1.2 };
   const glyphMetrics = getGlyph(q.prompt, C.amber, 800);
   // A two-step prompt is three times the width of "8 + 5", so the type size
-  // fits the *sprite* to the viewport rather than trusting a constant.
-  const widthLimited = (world.w * 0.9 * 92) / glyphMetrics.w;
-  const size = Math.min(world.h * 0.085, widthLimited) * (0.55 + pop * 0.45);
+  // fits the *sprite* to the box rather than trusting a constant.
+  const widthLimited = (hud.equation.w * 92) / glyphMetrics.w;
+  const size = Math.min(hud.equation.h / 1.35, widthLimited) * (0.55 + pop * 0.45);
 
   ctx.globalCompositeOperation = "lighter";
   drawGlow(ctx, C.amber, p.x, p.y, size * 2.2, 0.05 + (1 - clamp(age / 0.6, 0, 1)) * 0.14);
@@ -46,13 +57,12 @@ export function drawEquation(world: World): void {
 }
 
 export function drawHud(world: World): void {
-  const { ctx, w, h } = world;
-  const pad = Math.max(14, Math.min(w, h) * 0.045);
+  const { ctx, hud } = world;
 
-  // Lives — small ship silhouettes, top left.
+  // Lives — small ship silhouettes, top left, clear of the host's exit control.
   for (let i = 0; i < world.lives; i++) {
-    const x = pad + i * 20;
-    const y = pad;
+    const x = hud.lives.x + 7 + i * 20;
+    const y = hud.lives.y + hud.lives.h / 2;
     ctx.beginPath();
     ctx.moveTo(x, y - 8);
     ctx.lineTo(x + 6.5, y + 6);
@@ -63,28 +73,32 @@ export function drawHud(world: World): void {
     ctx.fill();
   }
 
-  // Score — top right, warm, with a soft halo instead of a shadow pass.
+  // Score — top right, warm, with a soft halo instead of a shadow pass. Right
+  // edge clear of the host's how-to-play control; a long score grows leftwards,
+  // away from it.
   const scoreText = String(Math.round(world.displayScore));
-  const size = Math.max(20, Math.min(w, h) * 0.052);
+  const size = hud.scoreSize;
+  const scoreRight = hud.score.x + hud.score.w;
+  const scoreY = hud.score.y + hud.score.h / 2;
   ctx.font = font(size);
   ctx.textAlign = "right";
   ctx.textBaseline = "middle";
   ctx.globalCompositeOperation = "lighter";
-  drawGlow(ctx, C.amber, w - pad - ctx.measureText(scoreText).width / 2, pad, size * 1.5, 0.1);
+  drawGlow(ctx, C.amber, scoreRight - ctx.measureText(scoreText).width / 2, scoreY, size * 1.5, 0.1);
   ctx.globalCompositeOperation = "source-over";
   ctx.fillStyle = C.amber;
-  ctx.fillText(scoreText, w - pad, pad);
+  ctx.fillText(scoreText, scoreRight, scoreY);
 
   // Wave, small and quiet beneath the score.
   ctx.font = font(size * 0.42);
   ctx.fillStyle = rgba(C.cyan, 0.55);
-  ctx.fillText(`WAVE ${world.wave}`, w - pad, pad + size * 0.85);
+  ctx.fillText(`WAVE ${world.wave}`, scoreRight, hud.wave.y + hud.wave.h / 2);
 
   // Combo, beside the ship, only once it means something.
   if (world.combo >= 2) {
     const p = project(world.cam, world.ship.x, SHIP_Y + 30, 0);
     const grow = 1 + Math.min(0.7, world.combo * 0.04);
-    const cs = Math.max(16, Math.min(w, h) * 0.036) * grow;
+    const cs = Math.max(16, Math.min(hud.safe.w, hud.safe.h) * 0.036) * grow;
     ctx.font = font(cs);
     ctx.textAlign = "center";
     ctx.fillStyle = rgba(C.cyan, 0.5 + Math.min(0.45, world.combo * 0.03));
@@ -98,121 +112,130 @@ export function drawHud(world: World): void {
 }
 
 function drawFocusBar(world: World): void {
-  const { ctx, w, h } = world;
+  const { ctx, hud } = world;
   const full = world.focus >= 1;
   const barH = full ? 5 : 3;
-  const y = h - barH - 2;
-  const half = (w * 0.5 - 12) * clamp(world.focus, 0, 1);
+  // Above the home indicator, not under it. It is thin, but it is the only
+  // thing that tells a child the slow-motion is charged.
+  const y = hud.focusY - barH;
+  const reach = hud.focusHalfW;
+  const half = reach * clamp(world.focus, 0, 1);
   ctx.fillStyle = rgba(full ? C.white : C.ship, full ? 0.55 + Math.sin(world.time * 8) * 0.3 : 0.42);
-  ctx.fillRect(w / 2 - half, y, half * 2, barH);
+  ctx.fillRect(hud.cx - half, y, half * 2, barH);
   if (world.focusT > 0) {
     // Burning down: the bar drains from the middle out, in the focus colour.
     const t = clamp(world.focusT / 2.6, 0, 1);
     ctx.fillStyle = rgba(C.plankton, 0.7);
-    ctx.fillRect(w / 2 - (w * 0.5 - 12) * t, y, (w - 24) * t, barH);
+    ctx.fillRect(hud.cx - reach * t, y, reach * 2 * t, barH);
   }
 }
 
 function drawBanner(world: World): void {
   if (world.bannerT <= 0 || !world.banner) return;
-  const { ctx, w, h } = world;
+  const { ctx, hud } = world;
+  const { w, h } = hud.safe;
   const t = clamp(world.bannerT / 1.5, 0, 1);
   const pop = ease.outCubic(clamp((1.5 - world.bannerT) / 0.3, 0, 1));
   const size = Math.min(w * 0.1, h * 0.062) * (0.7 + pop * 0.3);
   // Low in the frame: the top third is where the problem and the husks live,
   // and a banner across them would hide the only thing that matters.
-  const y = h * 0.66;
+  const y = hud.safe.y + h * 0.66;
   ctx.globalAlpha = Math.min(1, t * 2) * 0.9;
   ctx.globalCompositeOperation = "lighter";
-  drawGlow(ctx, C.cyan, w / 2, y, size * 3.4, 0.12);
+  drawGlow(ctx, C.cyan, hud.cx, y, size * 3.4, 0.12);
   ctx.globalCompositeOperation = "source-over";
   ctx.font = font(size);
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.fillStyle = C.white;
-  ctx.fillText(world.banner, w / 2, y);
+  ctx.fillText(world.banner, hud.cx, y);
   if (world.bannerSub) {
     ctx.font = font(size * 0.4);
     ctx.fillStyle = rgba(C.cyan, 0.75);
-    ctx.fillText(world.bannerSub, w / 2, y + size * 0.85);
+    ctx.fillText(world.bannerSub, hud.cx, y + size * 0.85);
   }
   ctx.globalAlpha = 1;
 }
 
 export function drawTitle(world: World): void {
-  const { ctx, w, h } = world;
+  const { ctx, hud } = world;
+  const { w, h } = hud.safe;
   const t = clamp(world.phaseT / 0.9, 0, 1);
   const size = Math.min(w * 0.22, h * 0.16);
-  const y = h * 0.4;
+  const y = hud.safe.y + h * 0.4;
   ctx.globalAlpha = ease.outCubic(t);
   ctx.globalCompositeOperation = "lighter";
-  drawGlow(ctx, C.amber, w / 2, y, size * 1.9, 0.09);
+  drawGlow(ctx, C.amber, hud.cx, y, size * 1.9, 0.09);
   ctx.globalCompositeOperation = "source-over";
-  drawGlyph(ctx, getGlyph("GUILTY", C.amber, 900), w / 2, y, size * ease.outBack(clamp(t, 0, 1)));
+  drawGlyph(ctx, getGlyph("GUILTY", C.amber, 900), hud.cx, y, size * ease.outBack(clamp(t, 0, 1)));
 
   ctx.font = font(Math.max(13, size * 0.13));
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.fillStyle = rgba(C.cyan, 0.5 + Math.sin(world.time * 3) * 0.28);
-  ctx.fillText(world.touch ? "TAP TO BEGIN" : "PRESS ANY KEY", w / 2, y + size * 0.72);
+  ctx.fillText(world.touch ? "TAP TO BEGIN" : "PRESS ANY KEY", hud.cx, y + size * 0.72);
   if (world.best > 0) {
     ctx.fillStyle = rgba(C.amber, 0.45);
     ctx.font = font(Math.max(11, size * 0.1));
-    ctx.fillText(`BEST ${world.best}`, w / 2, y + size * 0.95);
+    ctx.fillText(`BEST ${world.best}`, hud.cx, y + size * 0.95);
   }
   ctx.globalAlpha = 1;
 }
 
 export function drawGameOver(world: World): void {
-  const { ctx, w, h } = world;
+  const { ctx, hud } = world;
+  const { w, h } = hud.safe;
   const t = clamp(world.phaseT / 0.8, 0, 1);
+  // The dim covers the whole GLASS — a scrim that stopped at the safe area
+  // would draw a bright band across the notch.
   ctx.fillStyle = rgba("#02060c", 0.55 * t);
-  ctx.fillRect(0, 0, w, h);
+  ctx.fillRect(0, 0, world.w, world.h);
   const size = Math.min(w * 0.16, h * 0.1);
-  const y = h * 0.38;
+  const y = hud.safe.y + h * 0.38;
   ctx.globalCompositeOperation = "lighter";
-  drawGlow(ctx, C.hostile, w / 2, y, size * 2.4, 0.12 * t);
+  drawGlow(ctx, C.hostile, hud.cx, y, size * 2.4, 0.12 * t);
   ctx.globalCompositeOperation = "source-over";
   ctx.font = font(size * 0.62);
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.globalAlpha = t;
   ctx.fillStyle = rgba(C.hostile, 0.9);
-  ctx.fillText("THE TRENCH TAKES YOU", w / 2, y);
+  ctx.fillText("THE TRENCH TAKES YOU", hud.cx, y);
 
   ctx.font = font(size * 1.1);
   ctx.fillStyle = C.amber;
-  ctx.fillText(String(world.score), w / 2, y + size * 1.05);
+  ctx.fillText(String(world.score), hud.cx, y + size * 1.05);
   ctx.font = font(size * 0.3);
   ctx.fillStyle = rgba(C.cyan, 0.6);
   ctx.fillText(
     `BEST ${world.best}   ·   WAVE ${world.wave}   ·   BEST RUN ×${world.bestCombo}`,
-    w / 2,
+    hud.cx,
     y + size * 1.75,
   );
   ctx.fillStyle = rgba(C.white, 0.35 + Math.sin(world.time * 3) * 0.25);
   ctx.font = font(size * 0.32);
-  ctx.fillText(world.touch ? "TAP TO DIVE AGAIN" : "PRESS ANY KEY", w / 2, y + size * 2.5);
+  ctx.fillText(world.touch ? "TAP TO DIVE AGAIN" : "PRESS ANY KEY", hud.cx, y + size * 2.5);
   ctx.globalAlpha = 1;
 }
 
 /** Second wind: the run is over unless one more answer lands. */
 export function drawSecondWind(world: World): void {
-  const { ctx, w, h } = world;
+  const { ctx, hud } = world;
+  const { w, h } = hud.safe;
   const t = clamp(world.phaseT / 0.6, 0, 1);
   ctx.fillStyle = rgba("#01040a", 0.42 * t);
-  ctx.fillRect(0, 0, w, h);
+  ctx.fillRect(0, 0, world.w, world.h);
   const size = Math.min(w * 0.1, h * 0.06);
   ctx.font = font(size * 0.5);
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.fillStyle = rgba(C.hostile, 0.6 + Math.sin(world.time * 4) * 0.3);
   // Above the ship, under the action: the husks stay readable.
-  ctx.fillText("ONE MORE", w / 2, h * 0.8);
+  ctx.fillText("ONE MORE", hud.cx, hud.safe.y + h * 0.8);
 }
 
 function drawStats(world: World): void {
-  const { ctx, h } = world;
+  const { ctx, hud } = world;
   const s = frameStats(world);
   ctx.font = font(12);
   ctx.textAlign = "left";
@@ -220,8 +243,8 @@ function drawStats(world: World): void {
   ctx.fillStyle = "rgba(140,255,220,0.75)";
   ctx.fillText(
     `${s.fps.toFixed(1)} fps · present ${s.present.toFixed(2)}ms (p95 ${s.p95.toFixed(1)}) · cost ${s.cost.toFixed(2)}ms · p${s.particles} · q${world.quality.toFixed(2)}`,
-    10,
-    h - 10,
+    hud.safe.x + 10,
+    hud.safe.y + hud.safe.h - 10,
   );
 }
 

--- a/dynawalla/games/guilty/src/game/hudLayout.test.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.test.ts
@@ -1,0 +1,154 @@
+// THE TWO CORNERS AND THE NOTCH.
+//
+// GUILTY paints one canvas and nothing else. That is a virtue — it drops into
+// any host container without dragging styles along — and it is also why the
+// safe area was never honoured: `env(safe-area-inset-*)` is a CSS value and a
+// canvas cannot see it. The game declares `viewport-fit=cover`, which opts the
+// document *into* the notch, so `fillText` at `y = pad` landed under the status
+// bar and the focus bar at `h - 5` sat under the home indicator.
+//
+// The host also floats two 44px controls over every pack. The lives sat under
+// the exit control, the score sat under the how-to-play control, and the
+// equation — the accusation, the only thing a child has to read — is centred
+// and was sized to 90% of the screen width, so it ran under both.
+//
+// **What counts as critical here:** the equation, the score, the wave counter,
+// the row of lives, and the focus bar. That is the whole readable surface;
+// `hud.ts` says so itself.
+//
+// **What is deliberately NOT critical**, and must keep bleeding to the glass:
+// the water, the light shafts, the plankton, the seabed grid, the gate line,
+// the husks, the ship, the bolts, the particles and the vignette. Those are
+// projected through a camera fitted to the whole viewport, which is the entire
+// reason `cover` is set. A test below pins that.
+//
+// The insets are passed explicitly rather than measured, because node has no
+// notch and a test that measures zero proves nothing about a device.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { EQUATION_Y, VIEW_HALF_H } from "../core/config.ts";
+import { hudLayout } from "./hudLayout.ts";
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+/** No insets — a laptop, an older tablet, a desktop browser. */
+const FLAT: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+/** A notched phone held upright: status bar above, home indicator below. */
+const NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+/** The same phone on its side. Both long edges lose room. */
+const NOTCH_SIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const INSETS: Array<[string, Insets]> = [
+  ["flat", FLAT],
+  ["notched", NOTCH],
+  ["notched, on its side", NOTCH_SIDE],
+];
+
+const inside = (r: Rect, a: Rect): boolean =>
+  r.x >= a.x - 0.5 &&
+  r.y >= a.y - 0.5 &&
+  r.x + r.w <= a.x + a.w + 0.5 &&
+  r.y + r.h <= a.y + a.h + 0.5;
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    test(`nothing readable is covered — ${vname} (${w}×${h}), ${iname}`, () => {
+      const area = safeRect(w, h, insets);
+      const l = hudLayout(w, h, area);
+
+      const named: Array<[string, Rect]> = [
+        ["the equation", l.equation],
+        ["the score", l.score],
+        ["the wave counter", l.wave],
+        ["the lives", l.lives],
+        [
+          "the focus bar",
+          { x: l.cx - l.focusHalfW, y: l.focusY - 5, w: l.focusHalfW * 2, h: 5 },
+        ],
+      ];
+
+      for (const [name, r] of named) {
+        // 1. Inside the safe rectangle. If `hudLayout` ignored `area` these fail
+        //    on the notched profiles — the device-only bug, caught here.
+        assert.ok(inside(r, area), `${name} leaves the safe area: ${JSON.stringify(r)}`);
+
+        // 2. Clear of the two host corners. The exit and help squares exist on
+        //    every device, insets or not, so these hold at FLAT too — this gate
+        //    fails on a laptop as well as on a phone, and cannot pass by
+        //    accident the way a zero-inset-only assertion would.
+        assert.equal(
+          hitsHostChrome(r, w, insets),
+          false,
+          `${name} is under a host control: ${JSON.stringify(r)}`,
+        );
+      }
+    });
+  }
+}
+
+test("the accusation stays big enough to read after it narrows", () => {
+  // `drawEquation` fits the sprite to `equation.w` and caps it at
+  // `equation.h / 1.35`. The longest prompt the arith domain serves is about
+  // eleven characters. The bake is ~92 units of sprite height per glyph run, so
+  // the width budget per character is what decides legibility.
+  for (const [name, w, h] of VIEWPORTS) {
+    const l = hudLayout(w, h, safeRect(w, h, NOTCH));
+    assert.ok(
+      l.equation.w / 11 >= 14,
+      `${name}: only ${(l.equation.w / 11).toFixed(1)}px per character of sum`,
+    );
+    assert.ok(l.equation.h >= 40, `${name}: the sum box is ${l.equation.h.toFixed(1)}px tall`);
+  }
+});
+
+test("the accusation does not move at all when there is no notch", () => {
+  // The husks are born out of the equation and that fan-out is the entire
+  // tutorial, so the type must not wander away from where the camera puts the
+  // spawn point. With no insets it sits exactly on the projection of
+  // `EQUATION_Y`; with a notch it comes down by the notch and no further.
+  for (const [name, w, h] of VIEWPORTS) {
+    const flat = hudLayout(w, h, safeRect(w, h, FLAT));
+    const worldCy = (h / 2) * (1 - EQUATION_Y / VIEW_HALF_H);
+    assert.ok(
+      Math.abs(flat.equation.y + flat.equation.h / 2 - worldCy) < 0.5,
+      `${name}: the sum drifted off the husks' birth point`,
+    );
+
+    const notched = hudLayout(w, h, safeRect(w, h, NOTCH));
+    const drop = notched.equation.y + notched.equation.h / 2 - worldCy;
+    assert.ok(drop >= 0, `${name}: the sum moved up into the notch`);
+    assert.ok(drop <= 47, `${name}: the sum dropped ${drop.toFixed(1)}px for a 47px notch`);
+  }
+});
+
+test("the trench is not letterboxed by the insets", () => {
+  // The counterpart assertion, and the reason `safeRect` is not simply applied
+  // to everything. The camera is fitted to the whole glass in `game.ts`, and
+  // nothing in this layout may be used to shrink it. What is pinned here is
+  // that the layout reports the full viewport back, so a change that "fixed"
+  // the notch by shrinking the canvas would be visible.
+  for (const [name, w, h] of VIEWPORTS) {
+    const flat = hudLayout(w, h, safeRect(w, h, FLAT));
+    const notched = hudLayout(w, h, safeRect(w, h, NOTCH));
+    assert.equal(flat.glass.w, w, `${name}: the layout narrowed the glass`);
+    assert.equal(flat.glass.h, h, `${name}: the layout shortened the glass`);
+    assert.equal(notched.glass.w, w, `${name}: a notch narrowed the glass`);
+    assert.equal(notched.glass.h, h, `${name}: a notch shortened the glass`);
+    assert.equal(flat.safe.h, h, `${name}: the flat safe area is not the whole height`);
+    assert.ok(notched.safe.h < h, `${name}: the notch cost the HUD nothing, which cannot be right`);
+  }
+});

--- a/dynawalla/games/guilty/src/game/hudLayout.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.ts
@@ -1,0 +1,142 @@
+/**
+ * Where the readable things go.
+ *
+ * GUILTY paints one canvas and nothing else, which is why it drops into any
+ * host container without dragging styles along — and is also why none of this
+ * was ever right. `env(safe-area-inset-*)` is a CSS value; a canvas cannot see
+ * it. This game declares `viewport-fit=cover`, which opts the document *into*
+ * the notch, the home indicator and the rounded corners, so `fillText` at
+ * `y = pad` landed under the status bar on every phone that has one, and the
+ * focus bar at `h - 5` sat under the home indicator.
+ *
+ * On top of that the host floats two 44px controls over every pack: exit at the
+ * top-left, how-to-play at the top-right. The lives sat under the first and the
+ * score sat under the second, and the equation — the accusation, the one thing
+ * a child has to read — is centred and up to 90% of the screen wide, so it ran
+ * under both.
+ *
+ * **The chrome overlays; it does not reserve a band.** Taking a strip off the
+ * top of a trench would be absurd — the trench is the game. So everything here
+ * moves *sideways* into the channel between the two corners, and nothing moves
+ * down except by the height of the notch itself.
+ *
+ * **What is NOT in here, on purpose:** the water, the light shafts, the
+ * plankton, the seabed grid, the gate, the husks, the ship, the bolts, the
+ * particles and the vignette. Those are projected through the camera, which is
+ * fitted to the whole glass, and they are supposed to bleed under the notch —
+ * it is the entire reason `cover` is set. This module is only the things a
+ * child must read.
+ */
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { EQUATION_Y, VIEW_HALF_H } from "../core/config.ts";
+
+/** Breathing room between a HUD edge and a host control. */
+const CHROME_GAP = 8;
+
+export type HudLayout = {
+  /**
+   * The whole glass, notch and all.
+   *
+   * Kept beside `safe` so the difference between the two is legible rather than
+   * implied: the trench, the gate, the husks and the scrims use THIS, and only
+   * the type uses `safe`.
+   */
+  glass: { w: number; h: number };
+  /** The safe rectangle this was built from. */
+  safe: Rect;
+  /** Common inset, and the type scale everything in the corners is cut from. */
+  pad: number;
+  /** Type size for the score. */
+  scoreSize: number;
+  /** The row of ship silhouettes. Left-aligned inside this box. */
+  lives: Rect;
+  /** The score numeral. RIGHT-aligned to `score.x + score.w`. */
+  score: Rect;
+  /** `WAVE n`, under the score, right-aligned to the same edge. */
+  wave: Rect;
+  /**
+   * The accusation. The glyph is centred in this box and sized to fit it.
+   *
+   * Its centre is the world position `EQUATION_Y` projects to, pushed down only
+   * as far as the notch requires, so the husks still visibly fan out of it —
+   * that fan-out is the whole tutorial and must not come apart.
+   */
+  equation: Rect;
+  /** Baseline for the focus bar, clear of the home indicator. */
+  focusY: number;
+  /** Half-width the focus bar may grow to, each side of centre. */
+  focusHalfW: number;
+  /** Centre of anything full-screen: the banner, the title, the game-over. */
+  cx: number;
+  cy: number;
+};
+
+export function hudLayout(w: number, h: number, area: Rect): HudLayout {
+  const pad = Math.max(14, Math.min(area.w, area.h) * 0.045);
+  const scoreSize = Math.max(20, Math.min(area.w, area.h) * 0.052);
+
+  // The channel between the two host controls. On a 320px phone this is 196 of
+  // the 320, which is plenty for three ship silhouettes on one side and a score
+  // on the other.
+  const rail = HOST_MARGIN + HOST_CONTROL + CHROME_GAP;
+  const left = area.x + rail;
+  const right = area.x + area.w - rail;
+
+  // The corner row. Both boxes are one line tall and sit on the same baseline.
+  const rowY = area.y + pad;
+  const rowH = Math.max(18, scoreSize);
+  const livesW = Math.min(120, (right - left) * 0.42);
+
+  const lives: Rect = { x: left, y: rowY - rowH / 2, w: livesW, h: rowH };
+  const score: Rect = {
+    x: right - (right - left) * 0.5,
+    y: rowY - rowH / 2,
+    w: (right - left) * 0.5,
+    h: rowH,
+  };
+  const wave: Rect = {
+    x: score.x,
+    y: score.y + scoreSize * 0.85,
+    w: score.w,
+    h: scoreSize * 0.5,
+  };
+
+  // The equation, where the camera would put it: `fitCamera` maps the world's
+  // half-height onto half the glass, so `EQUATION_Y` lands at this fraction of
+  // the viewport. Recomputed rather than hard-coded so a change to the camera's
+  // framing moves the type with the husks.
+  const eqH = Math.min(h * 0.085, area.h * 0.12) * 1.35;
+  const eqW = right - left;
+  const worldCy = (h / 2) * (1 - EQUATION_Y / VIEW_HALF_H);
+  // Pushed down only as far as the NOTCH requires — never as far as the host's
+  // controls, because the width above already keeps it out of their columns.
+  // On a flat screen this does nothing at all and the type stays exactly where
+  // the husks are born.
+  const eqCy = Math.max(worldCy, area.y + eqH / 2);
+  const equation: Rect = {
+    x: area.x + area.w / 2 - eqW / 2,
+    y: eqCy - eqH / 2,
+    w: eqW,
+    h: eqH,
+  };
+
+  return {
+    glass: { w, h },
+    safe: area,
+    pad,
+    scoreSize,
+    lives,
+    score,
+    wave,
+    equation,
+    focusY: area.y + area.h - 7,
+    focusHalfW: Math.max(20, area.w * 0.5 - 12),
+    cx: area.x + area.w / 2,
+    cy: area.y + area.h / 2,
+  };
+}

--- a/dynawalla/games/guilty/src/game/world.ts
+++ b/dynawalla/games/guilty/src/game/world.ts
@@ -15,6 +15,7 @@ import type { Juice } from "../core/juice.ts";
 import type { LineBatch } from "../render/draw.ts";
 import type { Rng } from "../math/rng.ts";
 import { MAX_BULLETS, MAX_HUSKS, MAX_PARTICLES } from "../core/config.ts";
+import type { HudLayout } from "./hudLayout.ts";
 
 export const enum Mode {
   Entering = 0,
@@ -165,6 +166,12 @@ export type World = {
   w: number;
   h: number;
   dpr: number;
+  /**
+   * Where the readable things go, recomputed on every resize and on every
+   * change of the safe-area insets. See `hudLayout.ts` — a canvas cannot read
+   * `env()`, so this is the only thing that knows about the notch.
+   */
+  hud: HudLayout;
 
   husks: Husk[];
   bullets: Bullet[];


### PR DESCRIPTION
## What

Make GUILTY respect the safe area, keep the host's two 44px corners free of
anything a child must read, and tell a child the rule the game is built on.

## Why

**1 · The notch.** GUILTY paints one canvas and nothing else. That is a virtue —
it drops into any host container without dragging styles along — and it is also
why the safe area was never honoured: `env(safe-area-inset-*)` is a CSS value
and a canvas cannot see it. The game declares `viewport-fit=cover`, which opts
the document *into* the notch, the home indicator and the rounded corners. So
`fillText` at `y = pad` landed under the status bar, and the focus bar at
`h - barH - 2` sat under the home indicator.

**2 · Host chrome.** The host floats a 44px exit control top-left and the
how-to-play control top-right. The lives were drawn at `x = pad`, the score at
`x = w - pad`, and the equation — the accusation, the one thing a child *must*
read — is centred and was sized to 90% of the screen width, so it ran under
**both**. At 320×568 its box was `{x:16, y:24, w:288, h:65}` against corners at
`10..54` and `266..310`.

There was no layout module at all — `hud.ts` measured off `world.w` and
`world.h` in eight places. This adds `game/hudLayout.ts` with the safe rect as a
**required** argument, and `hud.ts` now reads every position from it.

**3 · No rules, anywhere.** A child was shown a trench, four sinking shapes with
numbers on them, and the word GUILTY. The rule that makes this a maths game
rather than a shooting game — that three of the four numbers are mistakes people
really make, and you must destroy only the true one — was never stated. Shooting
an innocent turns it hostile, which without that rule reads as the game being
unfair rather than as the price of guessing.

### What was judged critical for corner clearance

Critical: **the equation**, **the score**, **the wave counter**, **the row of
lives**, **the focus bar**. That is the entire readable surface — `hud.ts` says
so itself — and every one of them was in a corner or on an inset.

Not critical, and still full-bleed: the water, the light shafts, the plankton,
the seabed grid, the gate line, the husks, the ship, the bolts, the particles,
the vignette and the game-over scrim. `fitCamera` is still given the whole
glass; a trench that stopped at the notch would make `cover` pointless. A test
pins `glass.w === w` and `glass.h === h` under insets so nobody "fixes" this
later by letterboxing.

**No band is reserved**, because the chrome overlays — and taking a strip off
the top of a trench would be absurd, the trench *is* the game. Everything moves
**sideways** into the channel between the two corners. The only thing that moves
*down* is the equation, by the height of the notch and not one pixel more: a
test asserts that with no insets the type sits exactly on the projection of
`EQUATION_Y`, because the husks are born out of it and that fan-out is the whole
tutorial.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/guilty/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched — same id, version, sdk, host
      range, capabilities and covers. No published zip changed in place, no
      catalog entry dropped, no `minAppVersion` moved. `node build.mjs guilty`
      rebuilds and re-stages it.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app/public/locales/`. The new strings are the
      how-to-play copy inside this pack; `pack.json` declares `"locales": ["en"]`
      and is unchanged.
- [x] **Curriculum.** N/A — no skill id, grade, generator or schema touched. The
      mal-rule distractors, the wave ladder and the boss are untouched; the game
      still places the revealed answer and reports which husk was shot, and the
      host is still the judge.
- [x] **Secrets.** None. `gitleaks` output below.

Behavioural risk: this moves pixels. On a 320px phone the equation's width
budget drops from 288 to 196, so a long prompt is set smaller; a test asserts at
least 14px of width per character at every viewport under a notch. Opening the
manual now freezes the descent, which is new behaviour and the correct one — a
child who left to read the rules must not come back to a life they lost while
reading them. The camera, the physics, the scoring and the save key are not in
the diff.

## Proof

All output is real, from `dynawalla/games/guilty/` unless stated, on the rebased
branch.

**`npm test`, five times** — one green run is not proof.

```
--- run 1
# tests 32
# pass 32
# fail 0
--- run 2
# tests 32
# pass 32
# fail 0
--- run 3
# tests 32
# pass 32
# fail 0
--- run 4
# tests 32
# pass 32
# fail 0
--- run 5
# tests 32
# pass 32
# fail 0
```

**The clearance test fails when the fix is removed.** A clearance test that
passes either way is worthless, so this was checked rather than assumed. With
`hudLayout` reverted to ignoring `area`, to a full-width equation and to a focus
bar at `h - 2`:

```
# tests 32
# pass 16
# fail 16
not ok 1 - nothing readable is covered — phone portrait, small (320×568), flat
not ok 2 - nothing readable is covered — phone portrait, small (320×568), notched
not ok 3 - nothing readable is covered — phone portrait, small (320×568), notched, on its side
not ok 4 - nothing readable is covered — phone portrait (390×844), flat
not ok 5 - nothing readable is covered — phone portrait (390×844), notched
not ok 6 - nothing readable is covered — phone portrait (390×844), notched, on its side
not ok 7 - nothing readable is covered — tablet portrait (768×1024), flat
not ok 8 - nothing readable is covered — tablet portrait (768×1024), notched
not ok 9 - nothing readable is covered — tablet portrait (768×1024), notched, on its side
not ok 10 - nothing readable is covered — tablet landscape (1024×768), flat
not ok 11 - nothing readable is covered — tablet landscape (1024×768), notched
not ok 12 - nothing readable is covered — tablet landscape (1024×768), notched, on its side
not ok 13 - nothing readable is covered — phone landscape (844×390), flat
not ok 14 - nothing readable is covered — phone landscape (844×390), notched
not ok 15 - nothing readable is covered — phone landscape (844×390), notched, on its side
not ok 18 - the trench is not letterboxed by the insets
```

Failure detail from the first case, which is the shipped bug exactly:

```
error: |-
  the equation is under a host control: {"x":16,"y":24.210999999999984,"w":288,"h":65.17800000000001}
```

Every viewport fails at **flat** insets too. The exit and help squares exist on
every device, so this gate holds on a laptop as well as on a phone — it cannot
pass by accident the way a zero-inset-only test would.

**`npm run tsc`** — 0 errors.

```
> @dynawalla/game-guilty@0.1.0 tsc
> tsc --noEmit

```

**`npm run build`**

```
transforming...
✓ 30 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  0.54 kB │ gzip:  0.32 kB
dist/assets/index-CFU8HKqn.css   0.23 kB │ gzip:  0.18 kB
dist/assets/index-Bhsl1Mls.js   61.51 kB │ gzip: 23.98 kB
✓ built in 174ms
```

**`node build.mjs guilty`**, from `dynawalla/packs/`

```
rendering chunks...
computing gzip size...
dist-pack/pack.html                 1.31 kB │ gzip:  0.69 kB
dist-pack/assets/pack-DEUOEoXV.js  63.22 kB │ gzip: 24.89 kB
✓ built in 176ms
dynawalla.guilty@0.1.0 — GUILTY
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–5
  on disk      3 files, 65600 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`**

```
INF 1 commits scanned.
INF scanned ~20971 bytes (20.97 KB) in 35.3ms
INF no leaks found
```

**Scope** — one game directory, nothing deleted.

```
$ git diff --stat origin/main..HEAD
 dynawalla/games/guilty/src/game/game.ts           |  98 +++++++++++++-
 dynawalla/games/guilty/src/game/hud.ts            | 125 +++++++++++-------
 dynawalla/games/guilty/src/game/hudLayout.test.ts | 154 ++++++++++++++++++++++
 dynawalla/games/guilty/src/game/hudLayout.ts      | 142 ++++++++++++++++++++
 dynawalla/games/guilty/src/game/world.ts          |   7 +
 5 files changed, 474 insertions(+), 52 deletions(-)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty)
```
