### PR TITLE
dynawalla/games/pulse: the notes and the question move out from under the notch and the host's two corners

### DIFF
--- a/dynawalla/games/pulse/src/mount.ts
+++ b/dynawalla/games/pulse/src/mount.ts
@@ -6,6 +6,10 @@
  * pure drawing; everything below is the browser.
  */
 
+import {
+  createInstructions,
+  onInsetsChange,
+} from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, Mounted } from "./contract.ts";
 import { Run, type Fx } from "./game/run.ts";
 import { bindInput } from "./input.ts";
@@ -54,6 +58,57 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
   const scene = new Scene(surfaces, {
     reducedMotion: () => host.prefersReducedMotion() || prefersReducedMotion(),
     lowPower,
+  });
+
+  /**
+   * How to play. A timing game has to say what its window is: a child who taps
+   * a beat early, sees nothing happen and is told nothing decides the game is
+   * broken rather than that they were early. The manual stays reachable during
+   * play, because the moment a child needs the rules is never the title screen.
+   */
+  const guide = createInstructions(el, {
+    title: "PULSE",
+    summary: [
+      "Notes slide toward the bright line. Tap the lane when a note touches the line.",
+      "Tap on the beat — not early, not late.",
+    ],
+    sections: [
+      {
+        heading: "Tapping",
+        lines: [
+          "Tap anywhere inside a note's lane. You do not have to hit the note itself.",
+          "Tap when the note is sitting on the bright line.",
+          "A little early or a little late still counts. Right on the line gives you PERFECT.",
+          "If nothing happens when you tap, the note was still too far from the line. Wait for it.",
+          "On a keyboard: F, G and H, or J, K and L, or the arrow keys.",
+        ],
+      },
+      {
+        heading: "The bar",
+        lines: [
+          "The space between the line and the far edge is one whole bar of music.",
+          "So a note halfway across is at one half, and it reaches the line halfway through the bar.",
+          "Where a note sits and what it is worth are the same thing.",
+        ],
+      },
+      {
+        heading: "Questions",
+        lines: [
+          "Sometimes a sum appears at the top, like 1/2 + 1/4.",
+          "Several answers ride toward the line together. Each one sits at the place that matches its own value.",
+          "Tap the lane when the right answer reaches the line. Your timing is your answer.",
+        ],
+      },
+      {
+        heading: "Keeping going",
+        lines: [
+          "The little bar under your score is your health. Missed notes and wrong answers make it shrink.",
+          "Hits in a row build a combo, and a big combo makes every note worth more.",
+          "The music keeps splitting into smaller pieces as you go: quarters, then eighths, then triplets.",
+        ],
+      },
+    ],
+    reducedMotion: host.prefersReducedMotion() || prefersReducedMotion(),
   });
 
   const fx: Fx = {
@@ -137,11 +192,13 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
   };
 
   const input = bindInput(
-    el,
+    surfaces.main,
     () => scene.layout,
     () => run.stage.lanes,
     {
       hit(lane, perfMs) {
+        // The rules panel is modal: keys typed while it is open belong to it.
+        if (guide.isOpen) return;
         if (phase === "title") {
           startPlaying();
           return;
@@ -153,7 +210,7 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
         run.input(lane, perfMs);
       },
       tap(x, y) {
-        const b = hitButton(x, y, surfaces.w, surfaces.h, scene.layout.compact);
+        const b = hitButton(x, y, scene.layout.area, scene.layout.compact);
         if (!b) return false;
         if (b === "mute") {
           settings.muted = !settings.muted;
@@ -166,6 +223,7 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
         return true;
       },
       pause() {
+        if (guide.isOpen) return;
         if (phase === "title") startPlaying();
         else setPaused(phase === "playing");
       },
@@ -184,6 +242,14 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
     if (surfaces.resize()) scene.resize(run.stage.lanes);
   });
   ro.observe(el);
+
+  /**
+   * The insets change more often than "never": a rotation swaps the notch for
+   * the home indicator, and iPadOS changes them when the pack is resized in
+   * Split View. The canvas size may not change at all across some of those, so
+   * `ResizeObserver` alone would leave the field laid out against stale numbers.
+   */
+  const stopInsets = onInsetsChange(() => scene.resize(run.stage.lanes));
   window.addEventListener("resize", onWindowResize);
   function onWindowResize(): void {
     if (surfaces.resize()) scene.resize(run.stage.lanes);
@@ -215,6 +281,10 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
     // background when the game mounted never gets one, and then plays on unwatched.
     if (document.hidden && phase === "playing" && !options.ignoreVisibility) setPaused(true);
 
+    // Reading the rules must not cost health. The panel is modal, so treat it
+    // exactly like a tab switch.
+    if (guide.isOpen && phase === "playing") setPaused(true);
+
     if (surfaces.resize()) scene.resize(run.stage.lanes);
     if (scene.layout.laneCount !== run.stage.lanes) scene.resize(run.stage.lanes);
 
@@ -227,12 +297,20 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
       ctx.globalCompositeOperation = "source-over";
       ctx.fillStyle = "#04050a";
       ctx.fillRect(0, 0, w, h);
-      drawTitle(ctx, w, h, titleT, Math.max(settings.best, run.score), scene.layout.compact);
+      drawTitle(
+        ctx,
+        w,
+        h,
+        scene.layout.area,
+        titleT,
+        Math.max(settings.best, run.score),
+        scene.layout.compact,
+      );
     } else {
       if (phase === "playing") run.update();
       const drawMs = scene.draw(run, phase === "paused" ? 0 : dt);
       pauseK = phase === "paused" ? Math.min(1, pauseK + dt * 5) : Math.max(0, pauseK - dt * 6);
-      if (pauseK > 0.002) drawPause(ctx, w, h, pauseK);
+      if (pauseK > 0.002) drawPause(ctx, w, h, scene.layout.area, pauseK);
       if (run.score > settings.best) {
         settings.best = run.score;
         settings.bestCombo = Math.max(settings.bestCombo, run.bestCombo);
@@ -240,7 +318,7 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
       }
       if (showPerf) {
         const sorted = [...frameTimes].sort((a, b) => a - b);
-        drawPerf(ctx, w, {
+        drawPerf(ctx, scene.layout.area, {
           fps,
           frameMs: frameTimes.reduce((a, b) => a + b, 0) / Math.max(1, frameTimes.length),
           p95Ms: sorted[Math.floor(sorted.length * 0.95)] ?? 0,
@@ -254,7 +332,7 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
     }
 
     ctx.globalCompositeOperation = "lighter";
-    drawButtons(ctx, w, h, scene.layout.compact, settings.muted, phase === "paused");
+    drawButtons(ctx, scene.layout.area, scene.layout.compact, settings.muted, phase === "paused");
   };
 
   const frame = (t: number): void => {
@@ -284,6 +362,8 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
   return {
     unmount() {
       cancelAnimationFrame(raf);
+      guide.destroy();
+      stopInsets();
       input.dispose();
       ro.disconnect();
       window.removeEventListener("resize", onWindowResize);

--- a/dynawalla/games/pulse/src/render/chrome.ts
+++ b/dynawalla/games/pulse/src/render/chrome.ts
@@ -8,6 +8,7 @@
  * how the title says "press", in every language.
  */
 
+import type { Rect } from "../../../../packs/shared/game-chrome/index.ts";
 import { clamp01, outCubic, outQuint } from "../juice/ease.ts";
 import { glow } from "./glow.ts";
 import { INK, type Ink } from "./palette.ts";
@@ -22,22 +23,31 @@ function metrics(compact: boolean): typeof BTN {
   return compact ? BTN_COMPACT : BTN;
 }
 
+/**
+ * Pause and mute, bottom-right.
+ *
+ * `area` is the safe rect and is REQUIRED, for the same reason it is required on
+ * `computeLayout`: measured from the raw canvas these two buttons sit in the home
+ * indicator's strip on every modern phone, where a swipe up is the system's gesture
+ * and not ours. Optional, a caller that forgets it compiles and the bug only exists
+ * on hardware. `hitButton` reads the same rect, so the touch target can never drift
+ * away from the drawn square.
+ */
 export function buttonRect(
   i: number,
-  w: number,
-  h: number,
+  area: Rect,
   compact: boolean,
 ): { x: number; y: number; s: number } {
   const m = metrics(compact);
   const s = m.size;
-  const x = w - m.margin - s - i * (s + m.gap);
-  const y = h - m.margin - s;
+  const x = area.x + area.w - m.margin - s - i * (s + m.gap);
+  const y = area.y + area.h - m.margin - s;
   return { x, y, s };
 }
 
-export function hitButton(x: number, y: number, w: number, h: number, compact: boolean): ChromeButton | null {
+export function hitButton(x: number, y: number, area: Rect, compact: boolean): ChromeButton | null {
   for (let i = 0; i < 2; i++) {
-    const r = buttonRect(i, w, h, compact);
+    const r = buttonRect(i, area, compact);
     const pad = 6;
     if (x >= r.x - pad && x <= r.x + r.s + pad && y >= r.y - pad && y <= r.y + r.s + pad) {
       return i === 0 ? "pause" : "mute";
@@ -48,14 +58,13 @@ export function hitButton(x: number, y: number, w: number, h: number, compact: b
 
 export function drawButtons(
   ctx: CanvasRenderingContext2D,
-  w: number,
-  h: number,
+  area: Rect,
   compact: boolean,
   muted: boolean,
   paused: boolean,
 ): void {
   const draw = (i: number, fn: (x: number, y: number, s: number) => void, ink: Ink, on: boolean): void => {
-    const r = buttonRect(i, w, h, compact);
+    const r = buttonRect(i, area, compact);
     const c = INK[ink];
     ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${on ? 0.5 : 0.24})`;
     ctx.lineWidth = 1;
@@ -125,12 +134,13 @@ export function drawTitle(
   ctx: CanvasRenderingContext2D,
   w: number,
   h: number,
+  area: Rect,
   t: number,
   best: number,
   compact: boolean,
 ): void {
-  const cx = w / 2;
-  const cy = h * 0.44;
+  const cx = area.x + area.w / 2;
+  const cy = area.y + area.h * 0.44;
   const bpm = 84;
   const beat = (t * bpm) / 60;
   const frac = beat - Math.floor(beat);
@@ -145,10 +155,11 @@ export function drawTitle(
     const x = (i / 240) * w;
     const p = i / 240;
     const y =
-      h * 0.78 +
-      Math.sin(p * 26 + t * 2.1) * h * 0.02 * (0.4 + pulse) +
-      Math.sin(p * 61 - t * 3.4) * h * 0.012 +
-      Math.sin(p * 7 + t * 0.9) * h * 0.02;
+      area.y +
+      area.h * 0.78 +
+      Math.sin(p * 26 + t * 2.1) * area.h * 0.02 * (0.4 + pulse) +
+      Math.sin(p * 61 - t * 3.4) * area.h * 0.012 +
+      Math.sin(p * 7 + t * 0.9) * area.h * 0.02;
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }
@@ -185,14 +196,22 @@ export function drawTitle(
   }
 }
 
-export function drawPause(ctx: CanvasRenderingContext2D, w: number, h: number, k: number): void {
+export function drawPause(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  area: Rect,
+  k: number,
+): void {
   ctx.globalCompositeOperation = "source-over";
+  // The scrim covers the whole frame — a background may bleed under the notch,
+  // and should. The glyph is centred on the safe rect instead.
   ctx.fillStyle = `rgba(4,5,10,${(0.72 * k).toFixed(3)})`;
   ctx.fillRect(0, 0, w, h);
   ctx.globalCompositeOperation = "lighter";
   const s = Math.min(64, w * 0.08);
-  const cx = w / 2;
-  const cy = h / 2;
+  const cx = area.x + area.w / 2;
+  const cy = area.y + area.h / 2;
   const g = outQuint(clamp01(k));
   ctx.strokeStyle = `rgba(235,245,255,${(0.85 * k).toFixed(3)})`;
   ctx.lineWidth = s * 0.2;
@@ -216,7 +235,7 @@ export type PerfStats = {
   calibrationMs: number;
 };
 
-export function drawPerf(ctx: CanvasRenderingContext2D, w: number, s: PerfStats): void {
+export function drawPerf(ctx: CanvasRenderingContext2D, area: Rect, s: PerfStats): void {
   const lines = [
     `${s.fps.toFixed(1)} fps`,
     `frame ${s.frameMs.toFixed(2)} ms  p95 ${s.p95Ms.toFixed(2)}`,
@@ -224,13 +243,17 @@ export function drawPerf(ctx: CanvasRenderingContext2D, w: number, s: PerfStats)
     `parts ${s.particles}  notes ${s.notes}`,
     `latency ${(s.latencyMs * 1000).toFixed(1)} ms  cal ${s.calibrationMs.toFixed(0)} ms`,
   ];
+  // Developer overlay (`?perf`), tucked under the host's help button rather
+  // than behind it.
+  const right = area.x + area.w;
+  const top = area.y + 64;
   ctx.globalCompositeOperation = "source-over";
   ctx.fillStyle = "rgba(0,0,0,0.55)";
-  ctx.fillRect(w - 214, 8, 206, 12 + lines.length * 15);
+  ctx.fillRect(right - 214, top, 206, 12 + lines.length * 15);
   ctx.globalCompositeOperation = "lighter";
-  let y = 24;
+  let y = top + 16;
   for (const l of lines) {
-    neon(ctx, l, w - 202, y, 12, s.fps < 55 ? "rose" : "lime", {
+    neon(ctx, l, right - 202, y, 12, s.fps < 55 ? "rose" : "lime", {
       align: "left",
       mono: true,
       alpha: 0.9,

--- a/dynawalla/games/pulse/src/render/layout.test.ts
+++ b/dynawalla/games/pulse/src/render/layout.test.ts
@@ -1,6 +1,42 @@
+/**
+ * Playfield and HUD geometry.
+ *
+ * The second half of this file is about the frame PULSE does not own. `pack.html`
+ * declares `viewport-fit=cover`, so the document is opted into the notch and the
+ * home indicator; and the host floats an exit control over the top-left corner and
+ * a how-to-play control over the top-right, 44px each. The chrome OVERLAYS rather
+ * than reserving a band — reserving 67px of a 568px phone cost SKY LEDGER its own
+ * layout — so the promise a game makes is narrow: nothing a child must read or
+ * touch lands in those two squares, and everything readable stays inside the safe
+ * rect. Backgrounds may bleed anywhere, and do.
+ *
+ * These assert on the SAME rectangles the renderer draws from, which is the only
+ * version of this test worth having.
+ */
+
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { computeLayout, laneAtPoint } from "./layout.ts";
+
+import {
+  NO_INSETS,
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { buttonRect } from "./chrome.ts";
+import {
+  comboBox,
+  computeLayout,
+  healthBox,
+  laneAtPoint,
+  multBox,
+  noteBox,
+  promptBox,
+  scoreBox,
+  stageBox,
+  type Layout,
+} from "./layout.ts";
 
 const SIZES: [number, number, string][] = [
   [1440, 900, "desktop"],
@@ -10,10 +46,12 @@ const SIZES: [number, number, string][] = [
   [844, 390, "phone landscape"],
 ];
 
+const full = (w: number, h: number): Rect => safeRect(w, h, NO_INSETS);
+
 test("the visible field is exactly one bar, in every orientation", () => {
   for (const [w, h, name] of SIZES) {
     for (const lanes of [1, 2, 3]) {
-      const l = computeLayout(w, h, lanes);
+      const l = computeLayout(w, h, lanes, full(w, h));
       const a = l.pt(0, 0.5);
       const b = l.pt(1, 0.5);
       const d = Math.hypot(b.x - a.x, b.y - a.y);
@@ -28,7 +66,7 @@ test("the visible field is exactly one bar, in every orientation", () => {
 
 test("nothing is laid out off screen", () => {
   for (const [w, h, name] of SIZES) {
-    const l = computeLayout(w, h, 3);
+    const l = computeLayout(w, h, 3, full(w, h));
     for (const u of [0, 0.25, 0.5, 0.75, 1]) {
       for (const v of [0, 0.5, 1]) {
         const p = l.pt(u, v);
@@ -40,19 +78,19 @@ test("nothing is laid out off screen", () => {
 });
 
 test("portrait falls, landscape scrolls", () => {
-  assert.equal(computeLayout(390, 844, 3).orient, "v");
-  assert.equal(computeLayout(844, 390, 3).orient, "h");
-  assert.equal(computeLayout(1440, 900, 3).orient, "h");
-  const v = computeLayout(390, 844, 3);
+  assert.equal(computeLayout(390, 844, 3, full(390, 844)).orient, "v");
+  assert.equal(computeLayout(844, 390, 3, full(844, 390)).orient, "h");
+  assert.equal(computeLayout(1440, 900, 3, full(1440, 900)).orient, "h");
+  const v = computeLayout(390, 844, 3, full(390, 844));
   assert.ok(v.along.y < 0, "notes must approach from the top");
-  const hz = computeLayout(1440, 900, 3);
+  const hz = computeLayout(1440, 900, 3, full(1440, 900));
   assert.ok(hz.along.x > 0, "future is to the right");
 });
 
 test("a tap lands in the lane it looks like it landed in", () => {
   for (const [w, h] of SIZES) {
     for (const lanes of [1, 2, 3]) {
-      const l = computeLayout(w, h, lanes);
+      const l = computeLayout(w, h, lanes, full(w, h));
       for (let i = 0; i < lanes; i++) {
         const p = l.pt(0, l.laneV(i));
         assert.equal(laneAtPoint(l, p.x, p.y), i, `${w}x${h}/${lanes}: lane ${i} centre`);
@@ -73,7 +111,182 @@ test("a tap lands in the lane it looks like it landed in", () => {
 
 test("touch targets stay fat enough for a thumb", () => {
   for (const [w, h, name] of SIZES) {
-    const l = computeLayout(w, h, 3);
+    const l = computeLayout(w, h, 3, full(w, h));
     assert.ok(l.lanePitch >= 44, `${name}: lane pitch is only ${l.lanePitch.toFixed(0)} px`);
+  }
+});
+
+// ------------------------------------------------------- the frame we share
+
+/** Every viewport this game promises to be playable on. */
+const VIEWPORTS: [number, number][] = [
+  [320, 568],
+  [390, 844],
+  [768, 1024],
+  [1024, 768],
+  [844, 390],
+];
+
+/** A notched phone held upright, and the same phone turned sideways. */
+const NOTCHED_PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+const NOTCHED_LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+const insetsFor = (w: number, h: number): Insets[] => [
+  NO_INSETS,
+  w >= h ? NOTCHED_LANDSCAPE : NOTCHED_PORTRAIT,
+];
+
+const label = (i: Insets): string =>
+  i.top === 0 && i.right === 0 && i.bottom === 0 && i.left === 0 ? "no insets" : "notched";
+
+/**
+ * Text widths a real run actually reaches. Deliberately at the generous end — a
+ * seven-figure score, a three-token sum — because the box has to hold the worst
+ * case, not the first frame.
+ */
+function readables(l: Layout): Array<[string, Rect]> {
+  const mono = 0.62;
+  const stage = l.hud.stage;
+  return [
+    ["score", scoreBox(l, l.hud.score.size * mono * 9)],
+    ["multiplier", multBox(l, l.hud.mult.size * mono * 4)],
+    ["health bar", healthBox(l)],
+    ["stage strip", stageBox(l, stage.size * 8 + stage.glyphSize * 6)],
+    ["gate prompt", promptBox(l, l.hud.prompt.size * 6)],
+    ["combo", comboBox(l, l.hud.combo.size * mono * 3)],
+  ];
+}
+
+/** Pulse's own two buttons, as squares. */
+function ownButtons(l: Layout): Array<[string, Rect]> {
+  return [0, 1].map((i) => {
+    const r = buttonRect(i, l.area, l.compact);
+    const box: Rect = { x: r.x, y: r.y, w: r.s, h: r.s };
+    return [i === 0 ? "pause button" : "mute button", box] as [string, Rect];
+  });
+}
+
+/**
+ * Every note a child is asked to read, at every point along its run.
+ *
+ * This is not cosmetic in a timing game. A note that passes behind the exit
+ * button is a note the child cannot see coming and cannot judge, and during a
+ * gate it carries the fraction that IS the answer. `uMax` is where a note first
+ * appears; `0` is the strike line.
+ */
+function noteBoxes(l: Layout): Array<[string, Rect]> {
+  const out: Array<[string, Rect]> = [];
+  for (const u of [0, 0.25, 0.5, 0.75, 1, l.uMax]) {
+    for (let lane = 0; lane < l.laneCount; lane++) {
+      out.push([`note lane ${lane} at u=${u.toFixed(2)}`, noteBox(l, u, lane, false)]);
+      out.push([`gate note lane ${lane} at u=${u.toFixed(2)}`, noteBox(l, u, lane, true)]);
+    }
+  }
+  return out;
+}
+
+/**
+ * The bright line itself: the thing the whole game asks you to look at, with the
+ * per-lane strike markers on it. It spans the field across the lanes and is a
+ * note's width along the direction of travel.
+ */
+function strikeLineBox(l: Layout): Rect {
+  const r = l.noteR;
+  return l.orient === "h"
+    ? { x: l.strikeA.x - r, y: l.strikeA.y, w: r * 2, h: l.fieldThickness }
+    : { x: l.strikeA.x, y: l.strikeA.y - r, w: l.fieldThickness, h: r * 2 };
+}
+
+const inside = (r: Rect, area: Rect): boolean =>
+  r.x >= area.x - 0.5 &&
+  r.y >= area.y - 0.5 &&
+  r.x + r.w <= area.x + area.w + 0.5 &&
+  r.y + r.h <= area.y + area.h + 0.5;
+
+const span = (r: Rect): string =>
+  `x ${r.x.toFixed(1)}..${(r.x + r.w).toFixed(1)}, y ${r.y.toFixed(1)}..${(r.y + r.h).toFixed(1)}`;
+
+for (const [w, h] of VIEWPORTS) {
+  for (const insets of insetsFor(w, h)) {
+    const tag = `${w}×${h} ${label(insets)}`;
+
+    test(`nothing readable is under the host's two corners at ${tag}`, () => {
+      // Collected rather than asserted one at a time: when this breaks, the
+      // useful answer is everything that collides, not the first thing.
+      const offenders: string[] = [];
+      for (const lanes of [1, 2, 3]) {
+        const l = computeLayout(w, h, lanes, safeRect(w, h, insets));
+        const boxes: Array<[string, Rect]> = [
+          ...readables(l),
+          ...ownButtons(l),
+          ...noteBoxes(l),
+          ["strike line", strikeLineBox(l)],
+        ];
+        for (const [name, box] of boxes) {
+          if (hitsHostChrome(box, w, insets)) {
+            offenders.push(`${lanes} lanes: ${name} — ${span(box)}`);
+          }
+        }
+      }
+      assert.deepEqual(offenders, [], `${tag}: under host chrome:\n  ${offenders.join("\n  ")}`);
+    });
+
+    test(`nothing readable is under the notch or the home indicator at ${tag}`, () => {
+      const area = safeRect(w, h, insets);
+      const offenders: string[] = [];
+      for (const lanes of [1, 2, 3]) {
+        const l = computeLayout(w, h, lanes, area);
+        // A note beyond one whole bar is still arriving from off-screen, by
+        // design. Everything inside the bar is inside the safe rect.
+        const boxes: Array<[string, Rect]> = [
+          ...readables(l),
+          ...ownButtons(l),
+          ...noteBoxes(l).filter(([n]) => !n.includes("1.06")),
+          ["strike line", strikeLineBox(l)],
+        ];
+        for (const [name, box] of boxes) {
+          if (!inside(box, area)) {
+            offenders.push(`${lanes} lanes: ${name} — ${span(box)}`);
+          }
+        }
+      }
+      assert.deepEqual(
+        offenders,
+        [],
+        `${tag}: outside the safe rect ${span(safeRect(w, h, insets))}:\n  ${offenders.join("\n  ")}`,
+      );
+    });
+
+    test(`there is still a bar to read at ${tag}`, () => {
+      const l = computeLayout(w, h, 3, safeRect(w, h, insets));
+      assert.ok(l.runLen > 120, `${tag}: only ${l.runLen.toFixed(0)} px of bar`);
+      assert.ok(l.lanePitch >= 44, `${tag}: lane pitch is only ${l.lanePitch.toFixed(0)} px`);
+    });
+  }
+}
+
+test("the layout follows the insets rather than reading them once", () => {
+  // The same canvas, rotated: the safe rect moves and every readable moves with
+  // it. A game that measured the insets once at mount would fail this.
+  const upright = computeLayout(390, 844, 3, safeRect(390, 844, NOTCHED_PORTRAIT));
+  const flat = computeLayout(390, 844, 3, safeRect(390, 844, NO_INSETS));
+  assert.ok(
+    upright.hud.score.cy > flat.hud.score.cy,
+    "the score must sit lower once there is a notch above it",
+  );
+  assert.ok(
+    buttonRect(0, upright.area, upright.compact).y < buttonRect(0, flat.area, flat.compact).y,
+    "the buttons must sit higher once there is a home indicator below them",
+  );
+});
+
+test("the touch target of pulse's own buttons is the square it draws", () => {
+  // `hitButton` reads `buttonRect`, so moving the buttons into the safe rect
+  // cannot leave the tappable squares behind at the old place.
+  const l = computeLayout(390, 844, 3, safeRect(390, 844, NOTCHED_PORTRAIT));
+  for (const i of [0, 1]) {
+    const r = buttonRect(i, l.area, l.compact);
+    assert.ok(r.y + r.s <= l.area.y + l.area.h, `button ${i} is in the home indicator`);
+    assert.ok(r.x + r.s <= l.area.x + l.area.w, `button ${i} is past the safe edge`);
   }
 });

--- a/dynawalla/games/pulse/src/render/layout.ts
+++ b/dynawalla/games/pulse/src/render/layout.ts
@@ -11,9 +11,62 @@
  * already played); `v` runs across lanes, 0..1. Landscape scrolls right-to-left like
  * a drum score; portrait falls top-to-bottom like every phone rhythm game since
  * Cytus, and it is the same code with the axes swapped.
+ *
+ * **The frame is not ours alone.** `pack.html` declares `viewport-fit=cover`, which
+ * opts this document into the notch, the home indicator and the rounded corners; and
+ * the host floats an exit control over the top-left corner and a how-to-play control
+ * over the top-right, 44px each. Everything below lays out inside `area` — the safe
+ * rectangle — and below those two corners. The BACKGROUND still bleeds to every
+ * edge, because that is what `cover` is for; it is the notes, the question and the
+ * numbers that move.
  */
 
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+
 export type Orientation = "h" | "v";
+
+/**
+ * How far below the top of the safe rect the host's two corner squares reach.
+ * Read from the shared constants so the host can move its chrome and every game
+ * follows on the next build.
+ */
+const CHROME_BAND = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL;
+const CHROME_GAP = 6;
+
+/** A middle-baselined line of text of `size` px occupies about this much height. */
+const LINE_H = 1.24;
+/** A stacked fraction reaches ±1.18·size from its centre: numerator plus its own body. */
+const STACK_H = 2.36;
+/** The multiplier punches up to 1.3× when it changes; reserve for the punched size. */
+const MULT_PUNCH = 1.3;
+/** The combo count punches up to 1.28× on a hit. Same reasoning. */
+const COMBO_PUNCH = 1.28;
+
+const UMAX = 1.06;
+
+/** A left/right/centre anchored line of text: `x` is the anchored edge. */
+export type Anchor = { x: number; cy: number; size: number };
+
+/** Where every readable thing in the HUD sits, already clear of the host's corners. */
+export type Hud = {
+  pad: number;
+  /** Score, left-aligned. */
+  score: Anchor;
+  /** Multiplier, right-aligned: `x` is its RIGHT edge. */
+  mult: Anchor & { boxH: number };
+  health: Rect;
+  /** The stage strip and the note-value glyph chain that trails it. */
+  stage: Anchor & { glyphSize: number; rowH: number };
+  /** The gate question, centred. */
+  prompt: { cx: number; cy: number; size: number };
+  /** The combo count. */
+  combo: { cx: number; cy: number; size: number };
+};
 
 export type Layout = {
   orient: Orientation;
@@ -26,6 +79,12 @@ export type Layout = {
   lanePitch: number;
   fieldThickness: number;
   compact: boolean;
+  /** The safe rectangle this layout was built inside. */
+  area: Rect;
+  /** Drawn radius of an ordinary note, and of a gate note (which carries a label). */
+  noteR: number;
+  gateR: number;
+  hud: Hud;
   pt(u: number, v: number, out?: { x: number; y: number }): { x: number; y: number };
   laneV(lane: number): number;
   /** Unit vector along +u, in screen space. */
@@ -40,16 +99,73 @@ export type Layout = {
   uMin: number;
 };
 
-export function computeLayout(w: number, h: number, laneCount: number): Layout {
+/**
+ * `area` is the region a child may be asked to read or touch: the safe rect from
+ * `packs/shared/game-chrome`, free of the notch and the home indicator.
+ *
+ * It is REQUIRED, deliberately. Made optional, a caller that forgets it compiles
+ * and quietly draws the question under the notch and the top of the note run
+ * under the host's exit button — and the only way to find out is on a notched
+ * device, which is not where this is tested.
+ */
+export function computeLayout(w: number, h: number, laneCount: number, area: Rect): Layout {
   const orient: Orientation = w >= h * 1.02 ? "h" : "v";
   const compact = Math.min(w, h) < 460;
+  const lanes = Math.max(1, laneCount);
+
+  const pad = compact ? 14 : 26;
+  const big = compact ? 26 : 38;
+  const gap = compact ? 8 : 12;
+  const stageSize = compact ? 10 : 12;
+  const glyphSize = compact ? 9 : 11;
+  const healthW = compact ? 110 : 168;
+  const healthH = compact ? 5 : 7;
+  const comboSize = compact ? 30 : 46;
+  const promptSize = compact ? 26 : Math.min(46, w * 0.05);
+
+  // The top row starts below the host's two corners, not below the top of the
+  // canvas. Pushing a HUD row down costs nothing: the chrome OVERLAYS the game,
+  // so this takes no playfield away — it only stops the score being printed
+  // underneath the exit button.
+  const hudTop = area.y + CHROME_BAND + CHROME_GAP;
+  const rowH = big * MULT_PUNCH * LINE_H;
+  const rowCy = hudTop + rowH / 2;
+  const stageRowH = Math.max(stageSize * LINE_H, glyphSize * STACK_H);
+  const promptH = promptSize * STACK_H;
+  const promptCy = hudTop + promptH / 2;
+  const promptBottom = hudTop + promptH;
+
+  const score: Anchor = { x: area.x + pad, cy: rowCy, size: big };
+  const mult = { x: area.x + area.w - pad, cy: rowCy, size: big * 0.8, boxH: rowH };
 
   if (orient === "h") {
-    const fieldThickness = Math.min(h * 0.56, Math.max(196, 128 * Math.max(1, laneCount) + 40));
-    const top = h * 0.5 - fieldThickness / 2 + h * 0.02;
-    const strikeX = Math.max(72, Math.min(160, w * 0.19));
-    const runLen = w - strikeX - Math.max(12, w * 0.02);
-    const lanePitch = fieldThickness / laneCount;
+    // Landscape: the HUD column stands BESIDE the field, left of the strike
+    // line, so it stacks the way it always has — score, health, stage — and the
+    // field band starts below both it and the question.
+    const healthY = rowCy + rowH / 2 + gap;
+    const stageCy = healthY + healthH + gap + stageRowH / 2;
+    const hudBottom = stageCy + stageRowH / 2;
+    const reservedTop = Math.max(hudBottom, promptBottom) + CHROME_GAP;
+    const bottomPad = compact ? 12 : 16;
+
+    const room = area.y + area.h - bottomPad - reservedTop;
+    const fieldThickness = Math.min(
+      Math.min(area.h * 0.56, Math.max(196, 128 * lanes + 40)),
+      Math.max(132, room),
+    );
+    const centred = area.y + area.h * 0.5 - fieldThickness / 2 + area.h * 0.02;
+    const top = Math.max(
+      reservedTop,
+      Math.min(centred, area.y + area.h - bottomPad - fieldThickness),
+    );
+    const lanePitch = fieldThickness / lanes;
+    const noteR = Math.min(lanePitch * 0.3, compact ? 17 : 24);
+    const gateR = noteR * (compact ? 1.7 : 2.0);
+    const strikeX = area.x + Math.max(72, Math.min(160, area.w * 0.19));
+    // The trailing margin is at least a gate note's radius, so a note one whole
+    // bar out is drawn complete rather than clipped by the safe edge.
+    const runLen = area.x + area.w - strikeX - Math.max(gateR + 2, area.w * 0.02);
+
     return {
       orient,
       w,
@@ -59,27 +175,57 @@ export function computeLayout(w: number, h: number, laneCount: number): Layout {
       lanePitch,
       fieldThickness,
       compact,
+      area,
+      noteR,
+      gateR,
+      hud: {
+        pad,
+        score,
+        mult,
+        health: { x: area.x + pad, y: healthY, w: healthW, h: healthH },
+        stage: { x: area.x + pad, cy: stageCy, size: stageSize, glyphSize, rowH: stageRowH },
+        prompt: { cx: area.x + area.w / 2, cy: promptCy, size: promptSize },
+        combo: {
+          cx: strikeX + runLen * 0.02,
+          cy: Math.max(top - fieldThickness * 0.22, hudTop + (comboSize * COMBO_PUNCH * LINE_H) / 2),
+          size: comboSize,
+        },
+      },
       pt(u, v, out) {
         const o = out ?? { x: 0, y: 0 };
         o.x = strikeX + u * runLen;
         o.y = top + v * fieldThickness;
         return o;
       },
-      laneV: (lane) => (lane + 0.5) / laneCount,
+      laneV: (lane) => (lane + 0.5) / lanes,
       along: { x: 1, y: 0 },
       across: { x: 0, y: 1 },
       strikeA: { x: strikeX, y: top },
       strikeB: { x: strikeX, y: top + fieldThickness },
-      uMax: 1.06,
+      uMax: UMAX,
       uMin: -strikeX / runLen - 0.06,
     };
   }
 
-  const fieldThickness = Math.min(w * 0.94, Math.max(190, 132 * Math.max(1, laneCount) + 30));
-  const left = w / 2 - fieldThickness / 2;
-  const strikeY = h * 0.775;
-  const runLen = strikeY - Math.max(64, h * 0.13);
-  const lanePitch = fieldThickness / laneCount;
+  // Portrait: the field is nearly the full width, so a stacked HUD column at the
+  // top-left would sit ON the lanes and, at 320px, collide with the question. So
+  // the top carries only the score and the multiplier — the question centred
+  // between them — and the health bar and the stage strip move to the dead strip
+  // below the strike line, which nothing else uses.
+  const fieldThickness = Math.min(area.w * 0.94, Math.max(190, 132 * lanes + 30));
+  const left = area.x + (area.w - fieldThickness) / 2;
+  const strikeY = area.y + area.h * 0.775;
+  const lanePitch = fieldThickness / lanes;
+  const noteR = Math.min(lanePitch * 0.3, compact ? 17 : 24);
+  const gateR = noteR * (compact ? 1.7 : 2.0);
+  // A note at uMax is the first frame a child could read it. Its own radius has
+  // to clear the question above it, which in turn clears the host's corners.
+  const runTop = promptBottom + gateR + CHROME_GAP;
+  const runLen = Math.max(60, (strikeY - runTop) / UMAX);
+
+  const bottomH = healthH + gap + stageRowH;
+  const blockTop = area.y + area.h - pad - bottomH;
+
   return {
     orient,
     w,
@@ -89,18 +235,36 @@ export function computeLayout(w: number, h: number, laneCount: number): Layout {
     lanePitch,
     fieldThickness,
     compact,
+    area,
+    noteR,
+    gateR,
+    hud: {
+      pad,
+      score,
+      mult,
+      health: { x: area.x + pad, y: blockTop, w: healthW, h: healthH },
+      stage: {
+        x: area.x + pad,
+        cy: blockTop + healthH + gap + stageRowH / 2,
+        size: stageSize,
+        glyphSize,
+        rowH: stageRowH,
+      },
+      prompt: { cx: area.x + area.w / 2, cy: promptCy, size: promptSize },
+      combo: { cx: left + fieldThickness / 2, cy: strikeY + comboSize * 0.9, size: comboSize },
+    },
     pt(u, v, out) {
       const o = out ?? { x: 0, y: 0 };
       o.x = left + v * fieldThickness;
       o.y = strikeY - u * runLen;
       return o;
     },
-    laneV: (lane) => (lane + 0.5) / laneCount,
+    laneV: (lane) => (lane + 0.5) / lanes,
     along: { x: 0, y: -1 },
     across: { x: 1, y: 0 },
     strikeA: { x: left, y: strikeY },
     strikeB: { x: left + fieldThickness, y: strikeY },
-    uMax: 1.06,
+    uMax: UMAX,
     uMin: -(h - strikeY) / runLen - 0.06,
   };
 }
@@ -113,4 +277,67 @@ export function laneAtPoint(l: Layout, x: number, y: number): number {
   }
   const v = (x - l.strikeA.x) / l.fieldThickness;
   return Math.max(0, Math.min(l.laneCount - 1, Math.floor(v * l.laneCount)));
+}
+
+// --------------------------------------------------------------------- boxes
+//
+// The renderer draws FROM these rectangles and the tests assert ON them. That is
+// the point of them existing at all: a clearance test that rebuilds the HUD's
+// arithmetic out of its own magic numbers goes on passing while the renderer
+// drifts away underneath it.
+
+/** The box a line of text of `size` occupies, anchored at `x` by `align`. */
+export function textRect(
+  x: number,
+  cy: number,
+  width: number,
+  size: number,
+  align: "left" | "right" | "centre",
+): Rect {
+  const h = size * LINE_H;
+  const rx = align === "left" ? x : align === "right" ? x - width : x - width / 2;
+  return { x: rx, y: cy - h / 2, w: width, h };
+}
+
+export function scoreBox(l: Layout, textW: number): Rect {
+  return textRect(l.hud.score.x, l.hud.score.cy, textW, l.hud.score.size, "left");
+}
+
+/**
+ * Reserved at the PUNCHED size: the multiplier grows when it changes, and it
+ * grows right next to the host's help button.
+ */
+export function multBox(l: Layout, textW: number): Rect {
+  const m = l.hud.mult;
+  const width = textW * MULT_PUNCH;
+  return { x: m.x - width, y: m.cy - m.boxH / 2, w: width, h: m.boxH };
+}
+
+export function healthBox(l: Layout): Rect {
+  return { ...l.hud.health };
+}
+
+/** `textW` covers the strip AND the glyph chain that trails it. */
+export function stageBox(l: Layout, textW: number): Rect {
+  const s = l.hud.stage;
+  return { x: s.x, y: s.cy - s.rowH / 2, w: textW, h: s.rowH };
+}
+
+export function promptBox(l: Layout, textW: number): Rect {
+  const p = l.hud.prompt;
+  const height = p.size * STACK_H;
+  return { x: p.cx - textW / 2, y: p.cy - height / 2, w: textW, h: height };
+}
+
+/** Also reserved punched: the combo swells on every hit, which is most frames. */
+export function comboBox(l: Layout, textW: number): Rect {
+  const c = l.hud.combo;
+  return textRect(c.cx, c.cy, textW * COMBO_PUNCH, c.size * COMBO_PUNCH, "centre");
+}
+
+/** The box a note occupies on screen. Gate notes are drawn larger and carry a label. */
+export function noteBox(l: Layout, u: number, lane: number, gate = false): Rect {
+  const p = l.pt(u, l.laneV(lane));
+  const r = gate ? l.gateR : l.noteR;
+  return { x: p.x - r, y: p.y - r, w: r * 2, h: r * 2 };
 }

--- a/dynawalla/games/pulse/src/render/scene.ts
+++ b/dynawalla/games/pulse/src/render/scene.ts
@@ -13,6 +13,7 @@
  * score never becomes unreadable at the exact moment the score changes.
  */
 
+import { safeRect } from "../../../../packs/shared/game-chrome/index.ts";
 import { BEATS_PER_BAR } from "../game/chart.ts";
 import { WINDOWS, type Judgment, type LiveNote } from "../game/judge.ts";
 import type { Run } from "../game/run.ts";
@@ -25,7 +26,16 @@ import { Hitstop } from "../juice/hitstop.ts";
 import { Shake } from "../juice/shake.ts";
 import type { Surfaces } from "./canvas.ts";
 import { glow, halo, warmGlow } from "./glow.ts";
-import { computeLayout, type Layout } from "./layout.ts";
+import {
+  comboBox,
+  computeLayout,
+  healthBox,
+  multBox,
+  promptBox,
+  scoreBox,
+  stageBox,
+  type Layout,
+} from "./layout.ts";
 import { BG_RGB, INK, JUDGE_INK, laneInk, rgb, type Ink } from "./palette.ts";
 import { KIND_MOTE, KIND_SHARD, Particles, Ripples } from "./particles.ts";
 import { fraction, fractionBar, measure, neon, setFont } from "./text.ts";
@@ -92,7 +102,7 @@ export class Scene {
     this.particles = new Particles(opts.lowPower ? 520 : 900);
     this.shake = new Shake(2.05, 7);
     this.flash = new FlashGovernor(opts.reducedMotion);
-    this.layout = computeLayout(s.w, s.h, 3);
+    this.layout = computeLayout(s.w, s.h, 3, safeRect(s.w, s.h));
     this.seedDust();
   }
 
@@ -109,8 +119,13 @@ export class Scene {
     }
   }
 
+  /**
+   * Re-measures the safe area every time, so a rotation or an iPad Split View
+   * resize relays out against the new insets rather than the mount-time ones.
+   */
   resize(laneCount: number): void {
-    this.layout = computeLayout(this.s.w, this.s.h, Math.max(1, laneCount));
+    const { w, h } = this.s;
+    this.layout = computeLayout(w, h, Math.max(1, laneCount), safeRect(w, h));
   }
 
   // ------------------------------------------------------------------ fx in
@@ -302,7 +317,7 @@ export class Scene {
   }
 
   private noteRadius(): number {
-    return Math.min(this.layout.lanePitch * 0.3, this.layout.compact ? 17 : 24);
+    return this.layout.noteR;
   }
 
   // ------------------------------------------------------------------- frame
@@ -790,7 +805,7 @@ export class Scene {
       }
       if (alpha <= 0.01) continue;
 
-      const rr = (isGate ? r * (l.compact ? 1.7 : 2.0) : r) * scale;
+      const rr = (isGate ? l.gateR : r) * scale;
       if (toTrail) {
         glow(ctx, ink, p.x, p.y, rr * 2.1, alpha * (isGate ? 0.5 : 0.34));
         continue;
@@ -826,19 +841,25 @@ export class Scene {
     }
   }
 
+  /**
+   * The question. It used to sit at `h * 0.075` in portrait — 42.6px on a 568px
+   * phone, which is inside the host's two corner squares and under the notch on
+   * anything with one. It is the single most important readable in the game, so
+   * it now lives in a band the layout reserves for it, below both corners, with
+   * the note run starting below IT in turn.
+   */
   private drawGatePrompt(run: Run): void {
     const g = run.gate;
     if (!g) return;
     const k = this.gateGlow;
     if (k <= 0.02) return;
-    const { ctx, w, h } = this.s;
+    const { ctx } = this.s;
     const l = this.layout;
-    const size = l.compact ? 26 : Math.min(46, w * 0.05);
-    const y = l.orient === "h" ? Math.min(l.strikeA.y - size * 1.9, h * 0.2) : h * 0.075;
-    const cx = w / 2;
+    const size = l.hud.prompt.size;
+    const box = promptBox(l, promptWidth(ctx, g.built.prompt, size));
     const grow = outBack(clamp01(k * 1.4)) * k;
     ctx.save();
-    ctx.translate(cx, y);
+    ctx.translate(box.x + box.w / 2, box.y + box.h / 2);
     ctx.scale(0.86 + grow * 0.14, 0.86 + grow * 0.14);
     drawPromptTokens(ctx, g.built.prompt, 0, 0, size, k);
     ctx.restore();
@@ -856,28 +877,46 @@ export class Scene {
 
   // --------------------------------------------------------------------- hud
 
+  /**
+   * Every readable here is drawn FROM a box the layout owns, and the layout puts
+   * those boxes clear of the host's two 44px corners and inside the safe rect.
+   * Before this, at 320×568, the score sat at y 14..40 and the health bar at
+   * x 14..124 / y 48..53 — both inside the exit button's square (10..54, 13..57),
+   * and the multiplier was under the how-to-play button on the other side.
+   */
   private drawHud(run: Run): void {
-    const { ctx, w, h } = this.s;
+    const { ctx } = this.s;
     const l = this.layout;
-    const pad = l.compact ? 14 : 26;
-    const big = l.compact ? 26 : 38;
+    const hud = l.hud;
 
     // Score, monospaced so the digits never dance.
     const score = Math.round(this.displayScore).toLocaleString("en-US");
-    neon(ctx, score, pad, pad + big * 0.5, big, "white", { align: "left", mono: true, alpha: 0.95 });
+    const sb = scoreBox(l, measure(ctx, score, hud.score.size, true));
+    neon(ctx, score, sb.x, sb.y + sb.h / 2, hud.score.size, "white", {
+      align: "left",
+      mono: true,
+      alpha: 0.95,
+    });
 
-    // Multiplier.
+    // Multiplier. Its box is reserved at the PUNCHED size, because it swells at
+    // the exact moment it changes, and it swells beside the host's help button.
     const mult = run.multiplier();
     const mtxt = `×${mult}`;
-    const msize = big * (0.8 + this.multPunch * 0.5);
+    const msize = hud.score.size * (0.8 + this.multPunch * 0.5);
     const mink: Ink = run.overdriveActive() ? "violet" : mult >= 4 ? "lime" : "cyan";
-    neon(ctx, mtxt, w - pad, pad + big * 0.5, msize, mink, { align: "right", mono: true, alpha: 0.95 });
+    const mb = multBox(l, measure(ctx, mtxt, hud.mult.size, true));
+    neon(ctx, mtxt, mb.x + mb.w, mb.y + mb.h / 2, msize, mink, {
+      align: "right",
+      mono: true,
+      alpha: 0.95,
+    });
 
     // Combo, near the strike line where the eye already is.
     if (run.combo >= 3) {
-      const p = l.pt(l.orient === "h" ? 0.02 : 0.02, l.orient === "h" ? -0.22 : 1.24);
-      const cs = (l.compact ? 30 : 46) * (1 + this.comboPunch * 0.28);
-      neon(ctx, String(run.combo), p.x, p.y, cs, run.combo >= 25 ? "lime" : "white", {
+      const ctext = String(run.combo);
+      const cs = hud.combo.size * (1 + this.comboPunch * 0.28);
+      const cb = comboBox(l, measure(ctx, ctext, hud.combo.size, true));
+      neon(ctx, ctext, cb.x + cb.w / 2, cb.y + cb.h / 2, cs, run.combo >= 25 ? "lime" : "white", {
         align: "center",
         mono: true,
         alpha: 0.5 + Math.min(0.5, run.combo / 60),
@@ -886,33 +925,28 @@ export class Scene {
 
     // Health: segmented, plus a label so it is not colour alone.
     const segs = 10;
-    const bw = l.compact ? 110 : 168;
-    const bh = l.compact ? 5 : 7;
-    const bx = pad;
-    const by = pad + big + (l.compact ? 8 : 12);
+    const hb = healthBox(l);
     const filled = Math.ceil(run.health * segs - 0.0001);
     for (let i = 0; i < segs; i++) {
-      const cw = bw / segs;
+      const cw = hb.w / segs;
       const on = i < filled;
       const ink: Ink = run.health < 0.3 ? "rose" : run.health < 0.6 ? "amber" : "cyan";
       const c = INK[ink];
       ctx.fillStyle = `rgba(${c[0]},${c[1]},${c[2]},${on ? 0.75 : 0.09})`;
-      ctx.fillRect(bx + i * cw, by, cw - 2, bh);
+      ctx.fillRect(hb.x + i * cw, hb.y, cw - 2, hb.h);
     }
 
-    // Stage strip: the subdivision you are currently living in.
-    const sy = by + bh + (l.compact ? 12 : 16);
-    neon(ctx, run.stage.title, bx, sy, l.compact ? 10 : 12, "cyan", {
-      align: "left",
-      alpha: 0.55,
-    });
-
-    // The stage's note value, drawn as the fraction it is.
-    const glyph = run.stage.glyph;
-    const gx = bx + measure(ctx, run.stage.title, l.compact ? 10 : 12) + (l.compact ? 12 : 16);
-    drawGlyphChain(ctx, glyph, gx, sy, l.compact ? 9 : 11, 0.6);
-
-    void h;
+    // Stage strip: the subdivision you are currently living in, and the stage's
+    // note value drawn as the fraction it is.
+    const title = run.stage.title;
+    const tsize = hud.stage.size;
+    const gsize = hud.stage.glyphSize;
+    const titleW = measure(ctx, title, tsize);
+    const glyphGap = l.compact ? 12 : 16;
+    const stb = stageBox(l, titleW + glyphGap + glyphChainWidth(ctx, run.stage.glyph, gsize));
+    const scy = stb.y + stb.h / 2;
+    neon(ctx, title, stb.x, scy, tsize, "cyan", { align: "left", alpha: 0.55 });
+    drawGlyphChain(ctx, run.stage.glyph, stb.x + titleW + glyphGap, scy, gsize, 0.6);
   }
 
   private drawStageCard(): void {
@@ -1009,6 +1043,53 @@ function shape(ctx: CanvasRenderingContext2D, div: number, x: number, y: number,
   ctx.stroke();
 }
 
+/**
+ * Token widths for a chain of stacked fractions and plain words.
+ *
+ * Shared by the drawing and by the width query beside it, so the box a caller
+ * reserves and the marks that land in it are measured exactly once.
+ */
+function tokenWidths(
+  ctx: CanvasRenderingContext2D,
+  tokens: readonly string[],
+  size: number,
+  fracPad: number,
+  wordScale: number,
+): number[] {
+  const widths: number[] = [];
+  for (const tk of tokens) {
+    const m = FRACTION_TOKEN.exec(tk);
+    if (m) {
+      setFont(ctx, size);
+      widths.push(
+        Math.max(ctx.measureText(m[1]!).width, ctx.measureText(m[2]!).width) + size * fracPad,
+      );
+    } else {
+      widths.push(measure(ctx, tk, size * wordScale));
+    }
+  }
+  return widths;
+}
+
+const sum = (a: number[], gap: number): number =>
+  a.reduce((x, y) => x + y, 0) + gap * Math.max(0, a.length - 1);
+
+/** How wide `drawPromptTokens` will be. The layout reserves exactly this. */
+export function promptWidth(ctx: CanvasRenderingContext2D, prompt: string, size: number): number {
+  const tokens = prompt.split(/\s+/).filter(Boolean);
+  return sum(tokenWidths(ctx, tokens, size, 0.2, 1.05), size * 0.42);
+}
+
+/** How wide `drawGlyphChain` will be. */
+export function glyphChainWidth(
+  ctx: CanvasRenderingContext2D,
+  glyph: string,
+  size: number,
+): number {
+  const parts = glyph.split(/\s+/).filter(Boolean);
+  return sum(tokenWidths(ctx, parts, size, 0.24, 1), size * 0.4);
+}
+
 /** Render "1/2 + 1/4" with real stacked fractions and the operator between them. */
 export function drawPromptTokens(
   ctx: CanvasRenderingContext2D,
@@ -1019,18 +1100,9 @@ export function drawPromptTokens(
   alpha: number,
 ): void {
   const tokens = prompt.split(/\s+/).filter(Boolean);
-  const widths: number[] = [];
   const gap = size * 0.42;
-  for (const tk of tokens) {
-    const m = FRACTION_TOKEN.exec(tk);
-    if (m) {
-      setFont(ctx, size);
-      widths.push(Math.max(ctx.measureText(m[1]!).width, ctx.measureText(m[2]!).width) + size * 0.2);
-    } else {
-      widths.push(measure(ctx, tk, size * 1.05));
-    }
-  }
-  const total = widths.reduce((a, b) => a + b, 0) + gap * (tokens.length - 1);
+  const widths = tokenWidths(ctx, tokens, size, 0.2, 1.05);
+  const total = sum(widths, gap);
   let x = cx - total / 2;
   for (let i = 0; i < tokens.length; i++) {
     const tk = tokens[i]!;
@@ -1053,16 +1125,9 @@ function drawGlyphChain(
   centred = false,
 ): void {
   const parts = glyph.split(/\s+/).filter(Boolean);
-  const widths = parts.map((p) => {
-    const m = FRACTION_TOKEN.exec(p);
-    if (m) {
-      setFont(ctx, size);
-      return Math.max(ctx.measureText(m[1]!).width, ctx.measureText(m[2]!).width) + size * 0.24;
-    }
-    return measure(ctx, p, size);
-  });
+  const widths = tokenWidths(ctx, parts, size, 0.24, 1);
   const gap = size * 0.4;
-  const total = widths.reduce((a, b) => a + b, 0) + gap * (parts.length - 1);
+  const total = sum(widths, gap);
   let cx = centred ? x - total / 2 : x;
   for (let i = 0; i < parts.length; i++) {
     const p = parts[i]!;


### PR DESCRIPTION
## What

PULSE adopts the shared game chrome: the safe rect becomes a **required** argument on the layout seam, everything a child reads or touches moves out of the host's two 44px corners, and the game gets a how-to-play panel.

## Why

`index.html` and `pack.html` both declare `viewport-fit=cover` and the game never read an inset back. `cover` is not neutral — it opts the document INTO the notch, the home indicator and the rounded corners — and PULSE draws every pixel on a canvas, where `env()` is unreachable. On top of that the host floats an exit control top-left and a how-to-play control top-right, 44px each, and PULSE laid out as if it owned the frame.

Measured before the fix, at 320×568, against `exitRect` (x 10..54, y 13..57) and `helpRect` (x 266..310, y 13..57):

```
  HIT  score                    x  14.0..159.1  y 10.9..43.1
  HIT  multiplier               x 238.9..306.0  y  6.0..48.0
  HIT  health bar               x  14.0..124.0  y 48.0..53.0
  HIT  stage strip              x  14.0..148.0  y 54.4..75.6
  HIT  note lane 0 u=1          x  42.7..76.7   y 56.8..90.8
  HIT  gate note lane 0 u=1     x  30.8..88.6   y 44.9..102.7
  HIT  note lane 2 u=1.06       x 243.3..277.3  y 34.9..68.9
  HIT  gate note lane 2 u=1.06  x 231.4..289.2  y 23.0..80.8
```

The notes are the point. This is a timing game: a note that passes behind a button is a note the child cannot see coming and cannot judge, and during a gate it carries the fraction that IS the answer. At 320×568 the lane band spans x 9.6..310.4, so the top of the run went under BOTH corners; at 390×844 the gate notes still hit both. Score and multiplier collide at every viewport tested, phone through desktop. The question — the single most important readable — sat at `h * 0.075`, y 11.9..73.3 on a 568px phone, i.e. under the notch on any device that has one.

Chrome **overlays** rather than reserving a band (a 67px reservation is 12% of a 568px phone and broke SKY LEDGER's own invariants), so the fix pushes elements DOWN rather than shrinking anything: lowering a HUD row costs no playfield when the chrome floats over it. The safe-rect argument is required, not optional, because optional means a caller that forgets it compiles and the bug exists only on hardware.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/pulse/`)

- [x] Every touched path is covered by a `ci.yml` area filter — `dynawalla/games/**`.
- [x] **Pack back-compat.** No published zip changed in place, no `voiceId` renamed, no catalog entry dropped or narrowed. `pack.json` untouched; `node build.mjs pulse` rebuilds and re-stages the pack.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app` locales. The new strings are the how-to-play copy inside the pack, which has no locale directories.
- [x] **Curriculum.** N/A — no skill id, grade, generator or answer schema touched.
- [x] **Secrets.** None. `gitleaks` clean over the branch.

Behaviour changes a reviewer cannot see from the diff:
- Portrait moves the health bar and stage strip below the strike line. The portrait field is nearly the full width, so a top-left column sits on the lanes and, at 320px, runs into the question. Landscape keeps them stacked top-left, beside the field.
- Portrait's combo count was drawn at `v = 1.24`, which is 1.2× the screen width — it has been invisible in portrait; it now sits under the strike line.
- The bar shortens at the smallest phone, 366px → 265px, to buy the question a band of its own. `runLen > 120` and `lanePitch >= 44` still hold at every viewport, notched and not.
- Input binds to the canvas rather than the root, because the how-to-play button is a real DOM child of the root and a tap on it was also a lane tap. Opening the panel pauses the run.

## Proof

**Five separate `npm test` runs, from `dynawalla/games/pulse`:**

```
# tests 89 # pass 89 # fail 0   <- run 1
# tests 89 # pass 89 # fail 0   <- run 2
# tests 89 # pass 89 # fail 0   <- run 3
# tests 89 # pass 89 # fail 0   <- run 4
# tests 89 # pass 89 # fail 0   <- run 5
```

**`npm run tsc` — 0 errors; `npm run build`:**

```
> @dynawalla/game-pulse@0.1.0 tsc
> tsc --noEmit

dist/index.html                 0.48 kB │ gzip:  0.30 kB
dist/assets/bot-BgOsqZj3.js     1.38 kB │ gzip:  0.76 kB
dist/assets/index-CJFDgnJT.js  81.18 kB │ gzip: 29.53 kB
✓ built in 205ms
```

**`node build.mjs pulse`, from `dynawalla/packs`:**

```
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       4 skills, grades 3–5
  on disk      3 files, 82856 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

The shared code is bundled into the built pack, not merely compiling — `grep dwc-help dist-pack/assets/pack-*.js` hits, as does `Tap when the note is sitting on the bright line`.

**`gitleaks detect --log-opts="origin/main..HEAD"`:**

```
INF 1 commits scanned.
INF scanned ~28865 bytes (28.86 KB) in 42.8ms
INF no leaks found
```

**The clearance test bites.** Removing the fix and re-running — first, the HUD push (`CHROME_BAND = 0`):

```
not ok 52 - nothing readable is under the host's two corners at 320×568 no insets
  error: |-
    320×568 no insets: under host chrome:
      1 lanes: score — x 14.0..159.1, y 4.8..37.1
      1 lanes: multiplier — x 238.9..306.0, y 0.0..41.9
      2 lanes: score — x 14.0..159.1, y 4.8..37.1
      2 lanes: multiplier — x 238.9..306.0, y 0.0..41.9
      3 lanes: score — x 14.0..159.1, y 4.8..37.1
      3 lanes: multiplier — x 238.9..306.0, y 0.0..41.9
```

Then the note run and the question, put back where they were (`runLen = strikeY - max(64, h*0.13)`, prompt at raw `h * 0.075`):

```
not ok 52 - nothing readable is under the host's two corners at 320×568 no insets
  error: |-
    320×568 no insets: under host chrome:
      3 lanes: note lane 0 at u=1.00 — x 42.7..76.7, y 56.8..90.8
      3 lanes: gate note lane 0 at u=1.00 — x 30.8..88.6, y 44.9..102.7
      3 lanes: note lane 2 at u=1.00 — x 243.3..277.3, y 56.8..90.8
      3 lanes: gate note lane 2 at u=1.00 — x 231.4..289.2, y 44.9..102.7
      3 lanes: note lane 0 at u=1.06 — x 42.7..76.7, y 34.9..68.9
      3 lanes: gate note lane 0 at u=1.06 — x 30.8..88.6, y 23.0..80.8
      3 lanes: note lane 2 at u=1.06 — x 243.3..277.3, y 34.9..68.9
      3 lanes: gate note lane 2 at u=1.06 — x 231.4..289.2, y 23.0..80.8

not ok 56 - nothing readable is under the notch or the home indicator at 320×568 notched
  error: |-
    320×568 notched: outside the safe rect x 0.0..320.0, y 47.0..534.0:
      1 lanes: gate prompt — x 82.0..238.0, y 11.9..73.3
      1 lanes: gate note lane 0 at u=1.00 — x 131.1..188.9, y 35.1..92.9
      2 lanes: gate prompt — x 82.0..238.0, y 11.9..73.3
      ...
      3 lanes: gate prompt — x 82.0..238.0, y 11.9..73.3
      3 lanes: gate note lane 2 at u=1.00 — x 231.4..289.2, y 35.1..92.9
```

The fix was restored and all five runs above are after the restore. The test asserts on the same rectangles the renderer draws from — `scoreBox`, `multBox`, `healthBox`, `stageBox`, `promptBox`, `comboBox`, `noteBox`, `buttonRect` — at 320×568, 390×844, 768×1024, 1024×768 and 844×390, with `NO_INSETS` and with realistic notched insets, for one, two and three lanes.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
