### PR TITLE
dynawalla/games/street: say how you swing, and say what the shutter is

### DIFF
--- a/dynawalla/games/street/src/mount.ts
+++ b/dynawalla/games/street/src/mount.ts
@@ -79,6 +79,7 @@ export function mountStreet(
       {
         heading: "Swinging",
         lines: [
+          "Tap the crowd itself to swing your fists at them.",
           "Your fists only work on a row that cannot be broken into smaller rows.",
           "Swing at a row that could still be split and your fists bounce off it.",
           "So the fast way through is to break the crowd down first, then punch the rows one at a time.",
@@ -90,6 +91,16 @@ export function mountStreet(
           "There is no clock. Standing still and looking at the crowd costs you nothing.",
           "A wrong tap makes the crowd lean on you. Enough of them in a row and it shoves you back a block.",
           "Even then you keep everything you already built.",
+        ],
+      },
+      {
+        heading: "Between crowds",
+        lines: [
+          "Before each crowd, a steel shutter rolls down across the street.",
+          "There is a problem chalked on it and four rivets, each with a number.",
+          "Work out the answer and tap the rivet it is on.",
+          "Get it wrong and that rivet goes dark. Try another one — the crowd does not lean on you for this.",
+          "Get it right and the shutter rolls up, and the next crowd comes.",
         ],
       },
     ],


### PR DESCRIPTION
## What

Close the two gaps in FOUNDRY STREET's how-to-play copy that #618 flagged and
deliberately did not silently reword: say how you swing, and say what the
shutter is. Copy only — no layout, no logic.

## Why

**Swinging never said how.** The section explained what a swing does and what
it bounces off, and never that *tapping the crowd* is what does it. The crowd
is the one control on screen with no label on it, so a child who does not
already know is left with a verb and no way to spend it. The input is
`hit(layout.mob, x, y) → swing()`, accepted in `melee` and `fall` and silently
ignored in every other phase — no bounce, no push mark — so "tap the crowd
itself" is the whole truth and needs no phase caveat a child would have to
carry.

**The shutter was not mentioned at all.** A child cleared a crowd and met a
steel plate, a chalked problem and four rivets having been told nothing about
any of them. It is also the only surface the host judges — the factoring is the
game's own arithmetic and is never reported — so it is the one place a child's
answer actually goes on the record.

Four things I corrected against `src/game/shutter.ts` and `src/game/street.ts`
rather than writing the requested words as given:

1. **"When a wave is done" → "Before each crowd".** `raisePlate()` is called
   from `begin()` as well as from `afterWave()`, so the plate comes *before*
   every crowd, the first one included. The original phrasing described every
   plate except the one a child meets first.
2. **"a sum" → "a problem".** The prompt is whatever the host deals, and
   `stubHost` deals subtraction as well as addition — `subtraction never goes
   below zero` is one of its tests. "Sum" would read as addition-only to the
   audience.
3. **A wrong rivet does not end the plate.** `strikeRivet` marks it `dead` and
   leaves `open: false`; the child strikes another. Stopping at "then the
   shutter goes up" would have implied one strike always opens it.
4. **A wrong rivet does not press the mob.** `hitRivet` is explicit that this is
   deliberate — "charging for it twice would make the arithmetic the thing to
   be afraid of". A child who has just read that the crowd leans on wrong taps
   needs to be told that this one is the exception.

Two smaller judgement calls, both flagged rather than buried: the heading is
**"Between crowds"** rather than "Between waves", because "wave" appears
nowhere else in the copy and "crowd" is the word the whole guide uses; and the
verb is **tap**, not "strike", because it is a `pointerdown` hit test and every
other instruction in the guide says "tap".

`RIVETS = 4` is the designed count, and `newShutter` falls back to fewer only
if the host supplies fewer distinct distractors, which the real curriculum host
does not. "Four rivets" is left as the concrete number.

## Blast radius

**Areas touched:** dynawalla (one game pack, one file, strings only).

- [x] Every touched path is covered by a `ci.yml` area filter — only
      `dynawalla/games/street/src/mount.ts` changed.
- [x] **Pack back-compat.** No published pack zip changed in place, no
      `voiceId` renamed, no catalog entry dropped. `capabilities` and `covers`
      unchanged; the pack is rebuilt and re-staged by `node build.mjs street`.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** The added strings are in the game pack's own
      `createInstructions` spec, English-only, as every game pack's are today.
      No `corpan-app` locale key added or removed, so `check:i18n` is unaffected.
- [x] **Curriculum.** N/A — no skill id, grade, generator or renderer touched.
      Nothing reported to the host changed.
- [x] **Secrets.** None. `gitleaks` clean over `origin/main..HEAD`.

## Proof

```
$ cd dynawalla/games/street && for i in 1 2 3 4 5; do npm test; done
--- run 1 ---            --- run 2 ---            --- run 3 ---
# tests 99               # tests 99               # tests 99
# pass 99                # pass 99                # pass 99
# fail 0                 # fail 0                 # fail 0
--- run 4 ---            --- run 5 ---
# tests 99               # tests 99
# pass 99                # pass 99
# fail 0                 # fail 0

$ npm run tsc
> tsc --noEmit
(0 errors)

$ npm run build
rendering chunks...
computing gzip size...
dist/street.js  42.49 kB │ gzip: 13.69 kB
✓ built in 17ms

$ cd dynawalla/packs && node build.mjs street
dynawalla.street@0.1.0 — FOUNDRY STREET
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 40771 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~556 bytes (556 bytes) in 35.4ms
INF no leaks found

$ git diff origin/main..HEAD --diff-filter=D --name-only
(empty)

$ git diff origin/main..HEAD --name-only
dynawalla/games/street/src/mount.ts
```
