### PR TITLE
dynawalla/games/trebuchet: stop the game running behind the manual, and keep the rack on the glass

### DIFF
--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -190,6 +190,17 @@ export class TrebuchetGame {
 
   // hud
   private btns: Btn[] = []
+  /**
+   * True while something is over the game — today, the how-to-play panel.
+   *
+   * A sheet the host or the chrome raises is not a pause: the rAF loop is still
+   * running and `window` still has this game's key handlers on it, so a child
+   * reading the rules with a keyboard fires the loaded boulder with the space
+   * bar. Worse, the answer clock keeps running behind the sheet and the time
+   * spent READING gets reported as time spent THINKING, which is what feeds the
+   * difficulty. Both stop here.
+   */
+  private blocked: () => boolean = () => false
   /** The HUD's geometry, re-derived from the SAFE rect on every resize. */
   private hud: HudLayout = hudLayout(320, 240, { x: 0, y: 0, w: 320, h: 240 }, false)
   private clearT = -1
@@ -259,6 +270,19 @@ export class TrebuchetGame {
   }
 
   /* ------------------------------------------------------------ lifecycle */
+
+  /**
+   * Tell the game when something is covering it, and start the answer clock
+   * again when it goes away.
+   */
+  setInputGuard(blocked: () => boolean): void {
+    this.blocked = blocked
+  }
+
+  /** The sheet is gone: the child is looking at the question again, now. */
+  restartAnswerClock(): void {
+    this.questionShownAt = performance.now()
+  }
 
   unmount(): void {
     this.running = false
@@ -396,6 +420,7 @@ export class TrebuchetGame {
   }
 
   private onPointerDown = (e: PointerEvent): void => {
+    if (this.blocked()) return
     this.audio.resume()
     const p = this.pointerPos(e)
     const b = hitBtn(this.btns, p.x, p.y)
@@ -441,11 +466,12 @@ export class TrebuchetGame {
 
   private onWheel = (e: WheelEvent): void => {
     e.preventDefault()
+    if (this.blocked()) return
     this.setDial(this.dial + (e.deltaY > 0 ? -1 : 1))
   }
 
   private key(e: KeyboardEvent, down: boolean): void {
-    if (!down) return
+    if (!down || this.blocked()) return
     const big = e.shiftKey ? 10 : 1
     switch (e.key) {
       case 'ArrowLeft':
@@ -1094,10 +1120,13 @@ export class TrebuchetGame {
     const pts: Array<{ x: number; y: number }> = []
     // Keep the field clear of the two things pinned to the glass: the equation
     // at the top and the firing controls at the bottom right. Both are measured
-    // from the safe rect now, so both pads carry the inset that pushed them in —
-    // and nothing else changes, because on a screen with no notch this is the
-    // same framing the game shipped with.
-    const padTop = this.unit * 2.5 + this.hud.area.y
+    // from the safe rect now, so both pads carry the inset that pushed them in,
+    // and the top pad also carries however far the stack had to drop to clear
+    // the host's corners — otherwise the tallest keep in the wave is framed
+    // straight into the rack row. Where the stack did not move (tablets, and
+    // phones held sideways) `stackShift` is zero and this is byte-for-byte the
+    // framing the game shipped with.
+    const padTop = this.unit * 2.5 + this.hud.area.y + this.hud.stackShift
     const strip = this.h - (this.hud.area.y + this.hud.area.h) + this.unit * 2.5
     const gf = clamp(1 - strip / this.h - 0.02, 0.58, 0.84)
     if (this.phase === 'flight' && this.shot) {

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -53,7 +53,15 @@ export function mount(el: HTMLElement, host: Host): Mounted {
       },
     ],
     reducedMotion: host.prefersReducedMotion(),
+    // Reading the rules is not thinking about the sum. The answer clock starts
+    // again when the panel closes, so the time spent reading is not reported as
+    // the child's answer latency.
+    onClose: () => game.restartAnswerClock(),
   })
+
+  // Nothing behind the panel is something the child did: the space bar would
+  // otherwise fire the loaded boulder at whatever the dial happens to hold.
+  game.setInputGuard(() => guide.isOpen)
 
   return {
     unmount(): void {

--- a/dynawalla/games/trebuchet/src/render/hud.ts
+++ b/dynawalla/games/trebuchet/src/render/hud.ts
@@ -68,6 +68,8 @@ export type HudLayout = {
   score: Rect
   /** the bottom of the pinned top stack — the camera frames the field under it */
   stackBottom: number
+  /** how far the stack had to drop to clear the corners; the camera pays it back */
+  stackShift: number
   buttons: Btn[]
 }
 
@@ -106,7 +108,9 @@ export function hudLayout(w: number, h: number, area: Rect, loftUnlocked: boolea
   // there the stack starts under the corners instead. Either way the plaque is
   // clear of them; only the price differs, and this pays the cheaper one.
   const roomy = band >= eqSize * 9
-  const plaqueY = roomy ? area.y + Math.round(unit * 0.32) : topClear
+  const restY = area.y + Math.round(unit * 0.32)
+  const plaqueY = roomy ? restY : topClear
+  const stackShift = plaqueY - restY
   const plaqueW = Math.max(0, roomy ? band - 8 : area.w - pad * 2)
   const plaqueMax: Rect = { x: area.x + (area.w - plaqueW) / 2, y: plaqueY, w: plaqueW, h: ph }
 
@@ -173,6 +177,7 @@ export function hudLayout(w: number, h: number, area: Rect, loftUnlocked: boolea
     wave,
     score,
     stackBottom,
+    stackShift,
     buttons,
   }
 }
@@ -497,18 +502,34 @@ function drawLoft(ctx: CanvasRenderingContext2D, b: Btn, idx: number, count: num
 /**
  * Where each boulder in the rack sits. One function, used by both the renderer and
  * the hit test, so a tap can never land somewhere the eye disagrees with.
+ *
+ * The row is sized from the slot height, and if five multi-digit sums do not fit
+ * the safe width — five is a normal wave, and `347 + 268` is a normal question —
+ * the whole row scales down until they do. A stone half off the glass is one a
+ * child can neither read nor load.
  */
 export function rackLayout(st: HudState): Array<{ x: number; y: number; w: number; h: number }> {
   const { area } = st.layout
-  const h = st.layout.rackH
-  const gap = Math.round(h * 0.28)
-  const widths = st.rack.map((t) => Math.round(h * 0.9 + t.length * h * 0.27 + h * 0.35))
-  const total = widths.reduce((a, b) => a + b, 0) + Math.max(0, st.rack.length - 1) * gap
-  let x = area.x + (area.w - total) / 2
-  const y = st.layout.rackTop
-  return widths.map((wd) => {
+  const pad = Math.round(st.layout.unit * 0.4)
+  const room = Math.max(1, area.w - pad * 2)
+  const row = (h: number): { widths: number[]; gap: number; total: number } => {
+    const gap = Math.round(h * 0.28)
+    const widths = st.rack.map((t) => Math.round(h * 0.9 + t.length * h * 0.27 + h * 0.35))
+    const total = widths.reduce((a, b) => a + b, 0) + Math.max(0, st.rack.length - 1) * gap
+    return { widths, gap, total }
+  }
+  let h = st.layout.rackH
+  let laid = row(h)
+  if (laid.total > room) {
+    h = Math.max(10, Math.floor(h * (room / laid.total)))
+    laid = row(h)
+  }
+  // The row keeps its centre line whatever height it ended up at.
+  const y = st.layout.rackTop + (st.layout.rackH - h) / 2
+  let x = area.x + (area.w - laid.total) / 2
+  return laid.widths.map((wd) => {
     const slot = { x, y, w: wd, h }
-    x += wd + gap
+    x += wd + laid.gap
     return slot
   })
 }

--- a/dynawalla/games/trebuchet/src/render/layout.test.ts
+++ b/dynawalla/games/trebuchet/src/render/layout.test.ts
@@ -123,9 +123,12 @@ for (const [vname, w, h] of VIEWPORTS) {
           inside(layout.plaqueMax, layout.area),
           `the equation plaque ${show(layout.plaqueMax)} runs outside the safe rect`,
         )
-        // The rack is read AND tapped — a stone loads that boulder.
+        // The rack is read AND tapped — a stone loads that boulder. Five
+        // multi-digit sums is an ordinary wave, and they must all be on the
+        // glass, not just clear of the chrome.
         for (const s of rackLayout(stateFor(layout))) {
           assert.equal(hitsHostChrome(s, w, insets), false, `a rack stone ${show(s)} is under chrome`)
+          assert.ok(inside(s, layout.area), `a rack stone ${show(s)} runs off the safe rect`)
         }
         // The wave counter and the score are read, so they move too.
         for (const [what, r] of [


### PR DESCRIPTION
## What

Three fixes to TREBUCHET's chrome adoption (#632), found reviewing that PR after
it had already entered the merge queue.

## Why

**The game kept playing behind the how-to-play panel.** `game.ts` binds `key()`
to `window` and the rAF loop never stops, so a child reading the rules with a
keyboard fires the loaded boulder with the space bar — `report({correct:false})`
for a question that was not on screen, and a boulder gone from the rack. Arrows
turned the dial too. `foundry` and `arena` already gate on `guide.isOpen`;
trebuchet did not.

**And it billed them for the reading.** `questionShownAt` starts when a boulder
is loaded and `host.report` sends the difference as answer latency, which feeds
difficulty. A child who opens the manual on `347 + 268`, reads for 60s, then
fires 2s later was reported at ~62000ms. The clock restarts on the shared
`onClose`. Same class as #594 for beam.

**The camera framed keeps into the rack.** #632 moved the pinned stack down 51px
on an upright phone to clear the host's corners, but `padTop` did not follow —
measured at 320x568 with no insets: `rackTop` 119, `windY` 154, `stackBottom`
167, against a camera still framing the tallest keep to y ≈ 105. From wave 3 (the
first wave with wind) the tallest keep was drawn behind the rack row. `hudLayout`
now reports `stackShift`, the exact distance the stack moved, and the camera pays
it back. On tablets and phones held sideways `stackShift` is 0 and the framing is
byte-identical.

**Five sums did not fit a 320px screen.** `waveConfig` gives up to 5 boulders (6
on a boss) and this pack's `covers` are multi-digit column sums, so the rack row
measured 360px on a 320px phone and the first and last stone hung off both edges
— unreadable, and untappable, though tapping one is how you load it. The row now
scales down until it fits. This was pre-existing (it centred on `w` before and on
`area` after — identical for symmetric insets), but #632's new test advertised
itself as the gate on the rack and only checked chrome clearance, which for the
rack is a tautology.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/trebuchet`)

- [x] Every touched path is covered by a `ci.yml` area filter (`dynawalla_packs`).
- [x] **Pack back-compat.** `pack.json` untouched — same id, version, capabilities.
- [x] **Native integrity.** N/A.
- [x] **Strings.** N/A — no new user-visible string; the guard and the clock are
      behaviour, not copy.
- [x] **Curriculum.** N/A. Note the latency change makes `report({ms})` MORE
      accurate, not different in kind: it no longer includes time behind a sheet.
- [x] **Secrets.** None; `gitleaks` clean over `origin/main..HEAD`.

## Proof

```
$ npm test        # five consecutive runs
run 1: # tests 151 # pass 151 # fail 0
run 2: # tests 151 # pass 151 # fail 0
run 3: # tests 151 # pass 151 # fail 0
run 4: # tests 151 # pass 151 # fail 0
run 5: # tests 151 # pass 151 # fail 0

$ npm run tsc
> tsc --noEmit
(0 errors)

$ npm run build
✓ built in 23ms

$ cd dynawalla/packs && node build.mjs trebuchet
1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF no leaks found
```

The new rack assertion was verified RED. With the scaling removed from
`rackLayout` and nothing else changed:

```
# pass 141
# fail 10
  error: 'a rack stone [-20.0,119.4 77.0x21.0] runs off the safe rect'
```

Restored: 151/151.
