### PR TITLE
fix(dynawalla): a pack cannot measure its own safe area — the host must send it

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -48,10 +48,37 @@ export type SettingsInput = {
   readonly theme: ThemeMode
   readonly systemPrefersDark: boolean
   /** BCP-47. One locale until the i18n runtime lands; a pack must not guess. */
-  readonly locale?: string
+  readonly locale?: string  /** Override for tests; production measures the live tokens. */
+  readonly safeArea?: { top: number; right: number; bottom: number; left: number }
 }
 
 /** The device facts a pack is handed. No name, no birthday, no identifier. */
+/**
+ * The device's safe-area insets, measured HERE because a pack cannot measure
+ * them itself: it lives in an iframe sandboxed `allow-scripts` with no
+ * `allow-same-origin`, and `env(safe-area-inset-*)` belongs to the top-level
+ * browsing context, so a cross-origin child reads all four as 0.
+ *
+ * `env()` is not readable from JavaScript either, so this measures the tokens
+ * the app already defines (`--safe-top` and friends in `design/tokens.css`) off
+ * the document element.
+ */
+export function readSafeArea(): { top: number; right: number; bottom: number; left: number } {
+  const zero = { top: 0, right: 0, bottom: 0, left: 0 }
+  if (typeof document === "undefined" || typeof getComputedStyle !== "function") return zero
+  const cs = getComputedStyle(document.documentElement)
+  const px = (name: string): number => {
+    const n = Number.parseFloat(cs.getPropertyValue(name))
+    return Number.isFinite(n) && n > 0 ? n : 0
+  }
+  return {
+    top: px("--safe-top"),
+    right: px("--safe-right"),
+    bottom: px("--safe-bottom"),
+    left: px("--safe-left"),
+  }
+}
+
 export function packSettings(input: SettingsInput): Settings {
   const { settings } = input
   return {
@@ -62,6 +89,7 @@ export function packSettings(input: SettingsInput): Settings {
     colorScheme: resolveTheme(input.theme, input.systemPrefersDark),
     sound: settings.sound,
     haptics: settings.haptics,
+    safeArea: input.safeArea ?? readSafeArea(),
   }
 }
 

--- a/dynawalla/packs/sdk/src/protocol.ts
+++ b/dynawalla/packs/sdk/src/protocol.ts
@@ -110,6 +110,20 @@ export type Settings = {
   readonly colorScheme: "light" | "dark"
   readonly sound: boolean
   readonly haptics: boolean
+  /**
+   * The device's safe-area insets in CSS pixels, measured by the HOST.
+   *
+   * A pack cannot measure these itself. It runs in an iframe sandboxed
+   * `allow-scripts` with deliberately no `allow-same-origin`, and
+   * `env(safe-area-inset-*)` is a property of the TOP-LEVEL browsing context —
+   * a cross-origin child resolves all four to 0. Every pack that tried to read
+   * them got zeros and drew its HUD under the notch believing it was safe.
+   *
+   * Optional so an older host is not a breaking change; a pack that sees
+   * `undefined` should fall back to zeros, which is exactly what it was already
+   * getting.
+   */
+  readonly safeArea?: { top: number; right: number; bottom: number; left: number }
 }
 
 export type ItemChoice = {

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -6,7 +6,7 @@
  * `hostChrome`  — where the HOST draws over the game, so nothing is covered.
  * `instructions`— one "how to play" surface, populated per game.
  */
-export { safeInsets, onInsetsChange, safeRect, NO_INSETS, type Insets } from "./insets.ts"
+export { safeInsets, setHostInsets, onInsetsChange, safeRect, NO_INSETS, type Insets } from "./insets.ts"
 export {
   exitRect,
   helpRect,

--- a/dynawalla/packs/shared/game-chrome/insets.test.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { NO_INSETS, safeInsets, safeRect } from "./insets.ts"
+import { NO_INSETS, safeInsets, setHostInsets, safeRect } from "./insets.ts"
 import { HOST_CONTROL, chromeRects, exitRect, helpRect, hitsHostChrome } from "./hostChrome.ts"
 
 test("with no document to measure, the insets are zero rather than undefined", () => {
@@ -90,4 +90,35 @@ test("hitsHostChrome finds a score placed in either corner, and clears the middl
   assert.equal(hitsHostChrome({ x: w - 90, y: 14, w: 80, h: 30 }, w, NO_INSETS), true, "top-right missed")
   assert.equal(hitsHostChrome({ x: 120, y: 14, w: 100, h: 30 }, w, NO_INSETS), false, "top-centre is free")
   assert.equal(hitsHostChrome({ x: 0, y: 300, w: 390, h: 40 }, w, NO_INSETS), false, "mid-screen is free")
+})
+
+// ---------------------------------------------------------------------------
+// Host-supplied insets. Inside the shipped app the probe can only return zeros
+// — a pack is a cross-origin child and env() belongs to the top-level document
+// — so the host measures and sends them.
+// ---------------------------------------------------------------------------
+
+test("host insets win over the probe, which is blind inside a pack", () => {
+  setHostInsets({ top: 47, right: 0, bottom: 34, left: 0 })
+  assert.deepEqual(safeInsets(), { top: 47, right: 0, bottom: 34, left: 0 })
+  setHostInsets(null)
+  assert.deepEqual(safeInsets(), NO_INSETS, "clearing must fall back, not stick")
+})
+
+test("a malformed payload from the host is refused, not trusted", () => {
+  // An older host sends nothing; a broken one could send anything. Neither may
+  // produce a NaN inset, which would poison every layout downstream.
+  for (const bad of [
+    undefined,
+    null,
+    { top: Number.NaN, right: 0, bottom: 0, left: 0 },
+    { top: -5, right: 0, bottom: 0, left: 0 },
+  ]) {
+    setHostInsets(bad as never)
+    const got = safeInsets()
+    for (const v of [got.top, got.right, got.bottom, got.left]) {
+      assert.ok(Number.isFinite(v) && v >= 0, `bad payload produced ${v}`)
+    }
+  }
+  setHostInsets(null)
 })

--- a/dynawalla/packs/shared/game-chrome/insets.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.ts
@@ -25,6 +25,30 @@
 
 export type Insets = { top: number; right: number; bottom: number; left: number }
 
+/**
+ * Insets supplied by the HOST, which are the only trustworthy ones inside a
+ * pack.
+ *
+ * A pack runs in an iframe sandboxed `allow-scripts` with deliberately no
+ * `allow-same-origin`. `env(safe-area-inset-*)` is a property of the TOP-LEVEL
+ * browsing context, so a cross-origin child resolves all four to 0 — the probe
+ * below is correct in a browser tab and useless in the shipped app. Every game
+ * that trusted it drew its HUD under the notch believing it was safe.
+ *
+ * The host measures the real values and sends them on the `settings` channel;
+ * `pack.ts` calls this once the host handshake completes. Until then, and in
+ * the dev harness where there is no host, the probe is the best available
+ * answer and costs nothing.
+ */
+let hostInsets: Insets | null = null
+
+export function setHostInsets(i: Insets | null | undefined): void {
+  hostInsets =
+    i && [i.top, i.right, i.bottom, i.left].every((n) => Number.isFinite(n) && n >= 0)
+      ? { top: i.top, right: i.right, bottom: i.bottom, left: i.left }
+      : null
+}
+
 export const NO_INSETS: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
 
 const PROBE_ID = "dw-safe-probe"
@@ -56,6 +80,9 @@ const px = (v: string): number => {
  * device without insets — so a caller never has to branch on platform.
  */
 export function safeInsets(): Insets {
+  // The host's measurement wins whenever there is one: inside the shipped app
+  // the probe below can only ever return zeros.
+  if (hostInsets) return { ...hostInsets }
   const el = probe()
   if (!el || typeof getComputedStyle !== "function") return { ...NO_INSETS }
   const s = getComputedStyle(el)

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -26,6 +26,7 @@
 // would otherwise inflate a child's record, and the record only ever rises.
 
 import type { Capability, HostClient, Item, TransitionKind } from "../../sdk/src/index.ts"
+import { setHostInsets } from "../game-chrome/insets.ts"
 import { connect } from "../../sdk/src/index.ts"
 
 /** The shape both games declare locally. Kept structurally identical. */
@@ -133,6 +134,12 @@ function questionFrom(item: Item, canonical: string, domain: string): Question {
  */
 export async function createGameHost(options: GameHostOptions = {}): Promise<MountedHost> {
   const client = await connect()
+  // A pack cannot measure its own safe area: it is a cross-origin child, and
+  // `env(safe-area-inset-*)` belongs to the top-level browsing context, so it
+  // reads zeros. The host measures and sends them; publish them to game-chrome
+  // here, once, so every pack gets it without each game remembering to.
+  setHostInsets(client.settings.safeArea)
+  client.on("settings", () => setHostInsets(client.settings.safeArea))
   const domain = options.domain ?? "arith"
   const granted = new Set<Capability>(client.granted)
 


### PR DESCRIPTION
fix(dynawalla): a pack cannot measure its own safe area — the host must send it

The safe-area half of the game-chrome programme was inert on device, and would
have stayed inert in all 27 games.

A pack runs in an iframe with `sandbox="allow-scripts"` and deliberately no
`allow-same-origin` (`packs/frame.ts:86`, asserted in `frame.test.ts`).
`env(safe-area-inset-*)` is a property of the TOP-LEVEL browsing context, so a
cross-origin child resolves all four to 0. The hidden-probe trick in
`game-chrome/insets.ts` is correct in a browser tab and useless in the shipped
app: every game that adopted it got zeros, laid its HUD out against a full-size
rect, and drew under the notch believing it was safe.

Found by an adopting agent reading the sandbox flags, not by me, and not by any
test — node also reports zeros, so the whole fleet's suites agreed with the bug.

The host can measure it, so the host sends it:

  - `Settings` gains an OPTIONAL `safeArea`, so an older host is not a breaking
    change and a pack that sees `undefined` falls back to zeros, which is
    exactly what it already had.
  - `packSettings()` fills it from `readSafeArea()`, which reads the
    `--safe-top/right/bottom/left` tokens the app already defines off the
    document element — `env()` is not readable from JS on the host either.
  - `createGameHost()` publishes it into game-chrome via `setHostInsets()` on
    connect and on every `settings` event, so all 27 games get it without one
    line of per-game change.
  - `safeInsets()` prefers the host's numbers and keeps the probe as the
    fallback for `npm run dev`, where there is no host at all.

`setHostInsets` refuses a malformed payload rather than trusting it: a NaN or a
negative inset would poison every layout downstream, and a broken host should
degrade to zeros rather than to nonsense. Two tests cover that and the
host-wins-over-probe precedence.
