### PR TITLE
fix(dynawalla/games): VOLTA and MOSAIC kept playing behind the open manual

### DIFF
--- a/dynawalla/games/mosaic/src/mount.ts
+++ b/dynawalla/games/mosaic/src/mount.ts
@@ -599,7 +599,10 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
     raf = requestAnimationFrame(frame);
     const dtReal = (now - last) / 1000;
     last = now;
-    if (paused) return;
+    // `guide.isOpen` joins `paused` for the same reason: the wall keeps rising
+    // and the ball keeps travelling, so a child who opens the rules comes back
+    // to a lost life they never had a chance to save.
+    if (paused || guide.isOpen) return;
     tick(dtReal);
   };
 

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -853,6 +853,13 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     last = now;
     if (rawDt <= 0) return;
 
+    // The manual is open: hold the world still. VOLTA answers by which lane you
+    // are in, so a road that kept moving while a child read the rules would
+    // carry them through gate after gate and report each one as a wrong answer
+    // they never gave. `last` is already advanced above, so lifting the manual
+    // does not deliver one enormous frame.
+    if (guide.isOpen) return;
+
     fpsAcc += rawDt;
     fpsFrames++;
     if (rawDt > worstFrame) worstFrame = rawDt;


### PR DESCRIPTION
fix(dynawalla/games): VOLTA and MOSAIC kept playing behind the open manual

25 of the 27 games hold the world still while a child reads the rules. These two
did not: they built the guide and destroyed it, and never asked whether it was
open.

VOLTA is the worse of the pair, and close to the worst case there is. The lane
you are driving in IS the answer you give. A road that keeps moving while the
manual is up carries the child through gate after gate, and every one is
reported as a wrong answer they never gave — written into the learner model for
questions that were never on screen. Opening the rules made the game think the
child could not do arithmetic.

MOSAIC is the same shape, cheaper: the wall keeps rising and the ball keeps
travelling, so a child who opens the rules comes back to a lost life they had no
chance to save.

Both now hold at the top of the frame. `last` is advanced before the guard in
each, so closing the manual does not deliver one enormous catch-up frame — the
same trap the host-pause fixes in #592 and #594 had to avoid.

Found by auditing all 27 for `isOpen` after three separate adopting agents
reported the same class of bug in their own games — FUSE's version could burn
its one rescue and post a miss to the host unprompted. The pattern is a property
of the shared instructions surface rather than of any one game, which is why it
recurred; a shared test seam for it is worth queuing, since neither of these
games has a DOM harness to assert it in.
