### PR TITLE
fix(dynawalla/games/forge): Space quenched the run through the manual, and rotating a phone shrank the answer buttons to 24px

### DIFF
--- a/dynawalla/games/forge/src/game/chrome.test.ts
+++ b/dynawalla/games/forge/src/game/chrome.test.ts
@@ -40,6 +40,12 @@ const VIEWPORTS: Array<[string, number, number]> = [
   ["tablet portrait", 768, 1024],
   ["tablet landscape", 1024, 768],
   ["phone landscape", 844, 390],
+  // The small rotated phones matter more than the big one and were the gap
+  // that let a regression through: with only 844×390 in this list, a landscape
+  // change that halved the workbench's width still passed. 568×320 is a
+  // rotated iPhone SE and 667×375 is a rotated iPhone 8.
+  ["phone landscape, small", 568, 320],
+  ["phone landscape, medium", 667, 375],
   ["desktop wide", 1920, 1080],
 ]
 
@@ -55,6 +61,20 @@ const INSETS: Array<[string, Insets]> = [
   ["notched", NOTCH],
   ["notched, on its side", NOTCH_SIDE],
 ]
+
+/**
+ * The inset profiles a given frame can actually be handed.
+ *
+ * iOS reports room for the notch on the LONG edges: top and bottom when the
+ * frame is taller than it is wide, left and right when it is wider. It never
+ * reports both at once, so a tall frame with 47px side insets is a shape no
+ * device produces. The containment test still probes every profile against
+ * every viewport — containment must hold whatever it is handed — but the tests
+ * about how much room is LEFT use this, because measuring a shape that cannot
+ * exist only invents failures.
+ */
+const realProfiles = (w: number, h: number): Array<[string, Insets]> =>
+  w > h ? INSETS : INSETS.filter(([n]) => n !== "notched, on its side")
 
 const inside = (r: Rect, a: Rect): boolean =>
   r.x >= a.x - 0.5 &&
@@ -105,24 +125,71 @@ test("the tap targets stay big enough for a child's thumb", () => {
   // Narrowing the header is only acceptable while nothing shrinks below the
   // platform's minimum touch target. The ingots are the answer buttons and the
   // rows are the buy buttons.
-  for (const [name, w, h] of VIEWPORTS) {
-    const l = computeLayout(w, h, 6, safeRect(w, h, NOTCH))
+  //
+  // This runs over EVERY inset profile, not just the top/bottom one. Landscape
+  // insets sit on the long edges, so `NOTCH_SIDE` is the only profile in which
+  // a landscape layout loses horizontal room — and it is the profile under
+  // which the ingots first fell to 24px wide. Testing only `NOTCH` here made
+  // the assertion unable to see the very case it was written for.
+  for (const [[name, w, h], [iname, insets]] of VIEWPORTS.flatMap((v) =>
+    realProfiles(v[1], v[2]).map((i) => [v, i] as const),
+  )) {
+    const l = computeLayout(w, h, 6, safeRect(w, h, insets))
+    const label = `${name}, ${iname}`
+
+    // 44px is the platform floor and about the smallest square a seven-year-old
+    // hits reliably. The ingots are the answer buttons; this one is absolute.
     for (const s of l.slugs) {
-      assert.ok(s.h >= 44, `${name}: an ingot is ${s.h.toFixed(1)}px tall`)
-      assert.ok(s.w >= 44, `${name}: an ingot is ${s.w.toFixed(1)}px wide`)
+      assert.ok(s.h >= 44, `${label}: an ingot is ${s.h.toFixed(1)}px tall`)
+      assert.ok(s.w >= 44, `${label}: an ingot is ${s.w.toFixed(1)}px wide`)
     }
-    // `rowH` is the pitch, not the plate: the rows are contiguous and the
-    // `5 * scale` taken off each plate is a drawn gap, so the pitch is the
-    // target a thumb actually has. Honouring the safe area costs the column
-    // about 6px of pitch on a 320×568 notched phone — 36 down to 30 — which is
-    // real, and is the price of every row being reachable instead of the top
-    // and bottom ones being under the status bar and the home indicator.
-    assert.ok(l.rowH >= 28, `${name}: the station pitch is ${l.rowH.toFixed(1)}px`)
-    assert.ok(l.quench.h >= 30, `${name}: the quench plate is ${l.quench.h.toFixed(1)}px tall`)
-    // Room left for the number itself. `header.ts` fits the mantissa into
-    // `header.w - 20 * scale`, so a header squeezed to nothing would print an
-    // unreadable score rather than throw.
-    assert.ok(l.header.w >= 180, `${name}: the header is ${l.header.w.toFixed(1)}px wide`)
+    assert.ok(l.quench.h >= 30, `${label}: the quench plate is ${l.quench.h.toFixed(1)}px tall`)
+    // `header.ts` fits the mantissa into `header.w - 20 * scale`, so a header
+    // squeezed to nothing prints an unreadable score rather than throwing. 150
+    // is what the narrowest supported landscape leaves once the QUENCH corner
+    // is cleared: a rotated iPhone SE with insets on both long edges.
+    assert.ok(l.header.w >= 150, `${label}: the header is ${l.header.w.toFixed(1)}px wide`)
+
+    // The QUENCH plate is right-anchored inside the header and must stay in it.
+    assert.ok(l.quench.x >= l.header.x - 0.5, `${label}: the quench plate overhangs its header`)
+  }
+})
+
+test("the station column gives up the notch and not a pixel more", () => {
+  // The pitch cannot have an absolute floor: on a short landscape frame the
+  // column is six rows in whatever is left after the crucible, and that is
+  // small before any of this. What CAN be pinned is the thing a regression
+  // would break — that honouring the safe area costs the column exactly the
+  // height the inset took, shared out over its six rows, and nothing extra.
+  //
+  // This is the shape of the bug that shipped in landscape: the workbench was
+  // slid sideways by a whole 62px rail it did not need, so the loss was far
+  // larger than the inset. An absolute floor would not have caught it.
+  for (const [name, w, h] of VIEWPORTS) {
+    const flat = computeLayout(w, h, 6, safeRect(w, h, FLAT))
+    for (const [iname, insets] of realProfiles(w, h)) {
+      const area = safeRect(w, h, insets)
+      const l = computeLayout(w, h, 6, area)
+      const lostH = h - area.h
+      assert.ok(
+        flat.rowH - l.rowH <= lostH / 6 + 1,
+        `${name}, ${iname}: the pitch fell ${(flat.rowH - l.rowH).toFixed(1)}px for a ${lostH}px inset`,
+      )
+      const lostW = w - area.w
+      const widest = flat.slugs[0]
+      const got = l.slugs[0]
+      assert.ok(widest !== undefined && got !== undefined)
+      assert.ok(
+        widest.w - got.w <= lostW / 4 + 1,
+        `${name}, ${iname}: an ingot lost ${(widest.w - got.w).toFixed(1)}px for a ${lostW}px inset`,
+      )
+    }
+  }
+
+  // And on the frame a device actually has, the pitch clears a thumb.
+  for (const [name, w, h] of VIEWPORTS) {
+    const l = computeLayout(w, h, 6, safeRect(w, h, FLAT))
+    assert.ok(l.rowH >= 28, `${name}: the station pitch is ${l.rowH.toFixed(1)}px with no insets`)
   }
 })
 

--- a/dynawalla/games/forge/src/game/forge.ts
+++ b/dynawalla/games/forge/src/game/forge.ts
@@ -715,6 +715,12 @@ export function mount(el: HTMLElement, host: Host): Mounted {
   }
 
   function onKey(ev: KeyboardEvent): void {
+    // The manual is a full-screen DOM scrim over the canvas, and this listener
+    // is on `globalThis`, so without this line a child reading the Keyboard
+    // section and pressing the key it names would fire it into a game they
+    // cannot see. Space is the worst case: it starts a quench and the second
+    // press plunges, wiping the whole run behind a panel.
+    if (guide.isOpen) return
     audio.resume()
     const k = ev.key.toLowerCase()
     if (k >= "1" && k <= "4") {
@@ -873,6 +879,13 @@ export function mount(el: HTMLElement, host: Host): Mounted {
       relayout = false
       g.layout = computeLayout(surface.w, surface.h, g.revealed, safeRect(surface.w, surface.h))
     }
+
+    // The manual freezes the forge. Heat bleeds at 1/16 per second, so a minute
+    // spent reading the seven sections would leave 2.4% of the multiplier — and
+    // the manual is where it says "heat leaks away all the time". Charging a
+    // child for reading the rules is not a mechanic. The resize above still
+    // runs, so a rotation behind the panel is honoured the moment it closes.
+    if (guide.isOpen) return
 
     // Economy: fixed 60 Hz, frozen during hitstop. Deterministic regardless of
     // display refresh rate — a 120 Hz tablet earns exactly what a 60 Hz one does.

--- a/dynawalla/games/forge/src/game/layout.ts
+++ b/dynawalla/games/forge/src/game/layout.ts
@@ -27,7 +27,11 @@
 // The backdrop, the furnace body, the glow and the particles all still use the
 // full `w`/`h` and bleed under the notch, which is the point of `cover`.
 
-import { HOST_CONTROL, HOST_MARGIN } from "../../../../packs/shared/game-chrome/index.ts"
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+} from "../../../../packs/shared/game-chrome/index.ts"
 
 export type Rect = { x: number; y: number; w: number; h: number }
 
@@ -37,6 +41,18 @@ export function hit(r: Rect, x: number, y: number, slop = 0): boolean {
 
 /** Breathing room between a HUD edge and a host control. */
 const CHROME_GAP = 8
+
+/**
+ * The narrowest channel the header is still worth squeezing into.
+ *
+ * Above this, the header narrows between the two corners and nothing else in
+ * the frame moves — which is the cheap outcome, because the alternative costs
+ * the station rows height they do not have. Below it, squeezing would leave a
+ * readout too narrow to set the score in, so the header drops BENEATH the
+ * corners instead and takes the full width back. That happens on a very narrow
+ * Split View and on a tall frame with insets on both long edges.
+ */
+const MIN_CHANNEL = 180
 
 export type Layout = {
   portrait: boolean
@@ -96,12 +112,28 @@ export function computeLayout(w: number, h: number, revealed: number, area: Rect
     const anvilH = Math.round(Math.min(area.h * 0.35, 318 * scale))
     // Only the header reaches into the host's band, so only the header narrows.
     // The station column below it keeps the full width it always had.
-    const header: Rect = { x: chanX, y: area.y + pad, w: chanR - chanX, h: headerH }
+    const narrow = chanR - chanX < MIN_CHANNEL
+    const header: Rect = narrow
+      ? {
+          x: ox + pad,
+          y: area.y + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + CHROME_GAP,
+          w: cw - pad * 2,
+          h: headerH,
+        }
+      : { x: chanX, y: area.y + pad, w: chanR - chanX, h: headerH }
+    // The anvil is bottom-anchored and the column fills what is left, so the
+    // column absorbs a dropped header rather than running into the workbench.
+    // Written as "the anvil, minus the mouth" so the relationship survives the
+    // header moving; in the ordinary case it is the value it always was.
+    const anvilTop = area.y + area.h - anvilH
     const chain: Rect = {
       x: ox + pad,
       y: header.y + header.h + pad * 0.5,
       w: cw - pad * 2,
-      h: area.h - headerH - anvilH - pad * 1.6 - 46 * scale,
+      h: Math.max(
+        60,
+        anvilTop - (header.y + header.h + pad * 0.5) - pad * 0.1 - 46 * scale,
+      ),
     }
     const rowH = Math.min(chain.h / 6, 86 * scale)
     const rows: Rect[] = []
@@ -115,7 +147,7 @@ export function computeLayout(w: number, h: number, revealed: number, area: Rect
     }
     // Bottom-anchored to the SAFE area, so the ingots a child taps sit above
     // the home indicator rather than under it.
-    const anvil: Rect = { x: ox, y: area.y + area.h - anvilH, w: cw, h: anvilH }
+    const anvil: Rect = { x: ox, y: anvilTop, w: cw, h: anvilH }
     const slugH = Math.min(anvilH * 0.42, 120 * scale)
     const slugY = area.y + area.h - slugH - pad
     const sgap = Math.round(9 * scale)
@@ -156,21 +188,31 @@ export function computeLayout(w: number, h: number, revealed: number, area: Rect
       },
       hammerY: billet.y - 4 * scale,
       slugs,
-      quench: { x: header.x + header.w - 132 * scale, y: header.y + 6, w: 132 * scale, h: 46 * scale },
+      quench: quenchRect(header, Math.min(132 * scale, header.w - 8), 46 * scale, 6),
       audio: { x: header.x + header.w - 34 * scale, y: header.y + header.h - 30 * scale, w: 30 * scale, h: 26 * scale },
       scale,
     }
   }
 
   // --- landscape -----------------------------------------------------------
+  //
+  // In landscape the station column reaches the very top of the frame, so its
+  // REACTOR row sits under the exit control. The column therefore starts at the
+  // channel — but it gives up that width on its own LEFT EDGE and keeps its
+  // right edge exactly where it was.
+  //
+  // That distinction is the whole point. Sliding the column right would slide
+  // the workbench right with it, and the workbench's four ingots are the answer
+  // buttons: on a rotated phone (568×320) that took them from 62px wide to
+  // 36px, and to 24px with insets on both long edges. Buying a station is a
+  // wide row that can afford to be narrower; a 24px answer button cannot be
+  // hit. So only the column pays, and it pays on the side the control is on.
   const colW = Math.min(cw * 0.46, 560 * scale)
-  // In landscape the column reaches the top of the frame, so it — not just the
-  // header — has to start clear of the exit control. The whole workbench slides
-  // with it, which keeps the one-saccade spacing the two halves are built on.
+  const colRight = ox + pad + colW
   const chain: Rect = {
     x: chanX,
     y: area.y + pad * 2.2,
-    w: colW,
+    w: Math.max(120, colRight - chanX),
     h: area.h - pad * 3.2 - 104 * scale,
   }
   const rowH = Math.min(chain.h / 6, 100 * scale)
@@ -183,10 +225,14 @@ export function computeLayout(w: number, h: number, revealed: number, area: Rect
       h: rowH - Math.round(6 * scale),
     })
   }
-  const rx = chain.x + chain.w + pad * 1.6
-  const rw = chanR - rx
+  // The workbench keeps the full right column it always had: the anvil, the
+  // work bar and the four ingots all live in the BOTTOM half of the frame,
+  // nowhere near the host's controls. Only the header, which carries the QUENCH
+  // plate in its top-right corner, is pulled in to the channel.
+  const rx = colRight + pad * 1.6
+  const rw = ox + cw - pad - rx
   const headerH = Math.min(area.h * 0.3, 190 * scale)
-  const header: Rect = { x: rx, y: chain.y, w: rw, h: headerH }
+  const header: Rect = { x: rx, y: chain.y, w: Math.max(120, chanR - rx), h: headerH }
   const anvil: Rect = {
     x: rx,
     y: header.y + headerH + pad,
@@ -227,8 +273,20 @@ export function computeLayout(w: number, h: number, revealed: number, area: Rect
     },
     hammerY: billet.y - 5 * scale,
     slugs,
-    quench: { x: header.x + header.w - 150 * scale, y: header.y, w: 150 * scale, h: 50 * scale },
+    quench: quenchRect(header, Math.min(150 * scale, header.w - 8), 50 * scale, 0),
     audio: { x: header.x + header.w - 34 * scale, y: header.y + headerH - 30 * scale, w: 30 * scale, h: 26 * scale },
     scale,
   }
+}
+
+/**
+ * The QUENCH plate, right-anchored inside its header.
+ *
+ * Clamped to the header's own width, because the header is now the narrower of
+ * the two halves in landscape: an unclamped 150px plate on a 68px header starts
+ * 40px to the LEFT of the panel it belongs to and sits over the station column.
+ */
+function quenchRect(header: Rect, w: number, h: number, dy: number): Rect {
+  const width = Math.max(64, w)
+  return { x: header.x + header.w - width, y: header.y + dy, w: width, h }
 }


### PR DESCRIPTION
## What

Fix three defects I shipped in #633: the keyboard reaching FORGE through the
manual's scrim (Space wiped the run), the forge burning while a child reads
about it, and a landscape regression that took the four answer buttons down to
24px on a rotated phone.

## Why

Follow-up to #633, found by an adversarial review of the merged diff.

**1 · The keyboard went straight through the scrim.** `onKey` is registered on
`globalThis` and the manual is a full-screen DOM panel over the canvas, so every
key a child pressed while reading arrived at a game they could not see. The
manual's own Keyboard section says *"Space quenches."* Press it while the QUENCH
plate is lit and the first press calls `startQuench()`, the second `plunge()` —
the entire run wiped, behind a panel, with no visible feedback. `1`–`4` called
`resolveAnswer(i)`; a wrong one cost a quarter of the heat.

This is not a novel judgement — it is the repo's own already-merged pattern.
`coil/src/mount.ts` is `if (guide.isOpen) return`, and the comment above it
describes this exact failure. `truedraw` and `foundry` have the same guard.
FORGE was the outlier.

**2 · The forge burned while the child read about it.** Heat bleeds `1/16` per
second, so a minute on the seven sections leaves **2.4%** of the multiplier. The
manual is where the game says *"heat leaks away all the time, so the bar is
dropping while you think"* — charging a child for taking that at its word and
opening the rules is not a mechanic. The loop now returns early while the panel
is up, placed *after* the resize check so a rotation behind the panel is still
honoured the moment it closes.

**3 · Landscape gave up 62px it did not need, out of the answer buttons.** #633
moved the station column to `chanX` to clear the exit control, and `rx` was
derived from the column's *new* position — so the whole workbench slid right
with it, and then the header pulled the right edge in by another rail. The four
ingots are `(rw - 3*gap) / 4`:

| viewport | insets | ingot before #633 | after #633 |
|---|---|---|---|
| 568×320 (rotated iPhone SE) | long edges | 62.4px | **23.7px** |
| 667×375 (rotated iPhone 8) | long edges | 75.8px | **37.1px** |
| 480×320 | none | 50.5px | **24.5px** |

A 24px answer button is not hittable by a seven-year-old, and these are the
primary interaction in the game.

The column now gives up that width on its own **left edge** and keeps its right
edge where it was, so `rx` is unchanged and the workbench is untouched. Only the
header — which carries the QUENCH plate in its top-right corner — is pulled in
to the channel. A wide station row can afford to be narrower; an answer button
cannot.

Also in this diff:

- The QUENCH plate is clamped to its header's width. At 480×320 with side
  insets, a 108px plate anchored inside a 68px header started 40px *left* of the
  panel it belongs to and sat over the station column.
- Portrait gains the same `MIN_CHANNEL` fallback FOUNDRY has: below 180px of
  channel the header drops beneath the corners and takes the full width back,
  rather than squeezing the score into 102px.

### Why the test did not catch any of this

`chrome.test.ts` listed exactly one landscape phone — 844×390, the widest — and
applied only the top/bottom inset profile to the thumb assertions. Side insets
are the only profile in which a *landscape* layout loses horizontal room, so the
assertion structurally could not see the case it was written for. Fixed:

- 568×320 and 667×375 are in the viewport list;
- the thumb assertions run over every inset profile the frame can actually be
  handed. `realProfiles()` encodes the platform rule — iOS puts the notch on the
  **long** edges, top/bottom when the frame is tall and left/right when it is
  wide, never both pairs at once. The containment test still probes every
  profile against every viewport, because containment must hold whatever it is
  handed; the tests about how much room is *left* use `realProfiles`, because
  measuring a shape no device produces only invents failures;
- a new proportional test asserts the column loses at most the height the inset
  took divided over its six rows, and an ingot at most the width it took over
  four. An absolute floor could never have caught a sideways slide. This does.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/forge/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched — same id, version, sdk, host
      range, capabilities, covers. No published zip changed in place.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest.
- [x] **Strings.** No new user-visible strings; `corpan-app/public/locales/`
      untouched.
- [x] **Curriculum.** N/A — no skill id, grade, generator or schema touched. The
      economy, the save format and the mal-rule distractors are not in the diff.
- [x] **Secrets.** None. `gitleaks` below.

Behavioural risk: landscape moves pixels back toward where they were before
#633; the station column is narrower on its left and the workbench returns to
full width. Freezing the loop while the manual is open is new behaviour and the
intended one.

## Proof

From `dynawalla/games/forge/`, rebased onto current `origin/main`.

**`npm test`, five times**

```
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
```

**The new landscape assertion catches the regression it was written for.**
Reinstating the shipped bug (`rx = chain.x + chain.w + pad * 1.6`,
`rw = chanR - rx`):

```
# tests 79
# pass 78
# fail 1
not ok 46 - the tap targets stay big enough for a child's thumb
  error: 'phone landscape, small, notched, on its side: an ingot is 36.7px wide'
```

The old test file passed with that same bug in place.

**`npm run tsc`** — 0 errors, source and `tsconfig.test.json`.

```
> @dynawalla/game-forge@0.1.0 tsc
> tsc --noEmit && tsc --noEmit -p tsconfig.test.json

```

**`npm run build`**

```
computing gzip size...
dist/index.html                 0.89 kB │ gzip:  0.45 kB
dist/assets/index-DsrnB1g8.js  71.76 kB │ gzip: 26.53 kB

✓ built in 34ms
```

**`node build.mjs forge`**, from `dynawalla/packs/`

```
  on disk      3 files, 77543 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`**

```
INF scanned ~8777 bytes (8.78 KB) in 34.1ms
INF no leaks found
```

**Scope**

```
$ git diff --stat origin/main..HEAD
 dynawalla/games/forge/src/game/chrome.test.ts | 99 ++++++++++++++++++++++-----
 dynawalla/games/forge/src/game/forge.ts       | 13 ++++
 dynawalla/games/forge/src/game/layout.ts      | 84 +++++++++++++++++++----
 3 files changed, 167 insertions(+), 29 deletions(-)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty)
```
