### PR TITLE
fix(dynawalla/games/guilty): Escape closed the manual straight into a fresh run

### DIFF
--- a/dynawalla/games/guilty/src/game/game.ts
+++ b/dynawalla/games/guilty/src/game/game.ts
@@ -944,6 +944,9 @@ export function mount(
   }
 
   const input = attachInput(canvas, world, {
+    // `guide` is declared below; this is only ever called from a DOM event, so
+    // it is read long after the whole mount has finished.
+    blocked: () => guide.isOpen,
     onStart: begin,
     onFocus: spendFocus,
     onToggleMute: () => world.audio.setMuted(!world.audio.muted()),

--- a/dynawalla/games/guilty/src/game/hudLayout.test.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.test.ts
@@ -135,6 +135,30 @@ test("the accusation does not move at all when there is no notch", () => {
   }
 });
 
+test("the accusation stays over the point the shells fan out of", () => {
+  // `fitCamera` maps world x = 0 to `w / 2`, and the husks are born at world
+  // x = 0. iOS reports the notch on ONE long edge, so a phone rotated left and
+  // a phone rotated right give asymmetric insets — and a sum centred on the
+  // safe area would slide sideways off the fan-out. The box gives up width
+  // instead of moving.
+  const LOPSIDED: Insets = { top: 0, right: 0, bottom: 21, left: 47 };
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const insets of [FLAT, NOTCH, NOTCH_SIDE, LOPSIDED]) {
+      const l = hudLayout(w, h, safeRect(w, h, insets));
+      assert.equal(
+        l.equation.x + l.equation.w / 2,
+        w / 2,
+        `${name}: the sum drifted off the husks' lane`,
+      );
+      assert.equal(
+        hitsHostChrome(l.equation, w, insets),
+        false,
+        `${name}: the sum is under a host control`,
+      );
+    }
+  }
+});
+
 test("the trench is not letterboxed by the insets", () => {
   // The counterpart assertion, and the reason `safeRect` is not simply applied
   // to everything. The camera is fitted to the whole glass in `game.ts`, and

--- a/dynawalla/games/guilty/src/game/hudLayout.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.ts
@@ -111,17 +111,31 @@ export function hudLayout(w: number, h: number, area: Rect): HudLayout {
   // the viewport. Recomputed rather than hard-coded so a change to the camera's
   // framing moves the type with the husks.
   const eqH = Math.min(h * 0.085, area.h * 0.12) * 1.35;
-  const eqW = right - left;
   const worldCy = (h / 2) * (1 - EQUATION_Y / VIEW_HALF_H);
   // Pushed down only as far as the NOTCH requires — never as far as the host's
-  // controls, because the width above already keeps it out of their columns.
+  // controls, because the width below already keeps it out of their columns.
   // On a flat screen this does nothing at all and the type stays exactly where
   // the husks are born.
   const eqCy = Math.max(worldCy, area.y + eqH / 2);
+  // Centred on the GLASS, not on the safe area, because the husks are born at
+  // world x = 0 and `fitCamera` maps that to `w / 2`. iOS reports the notch on
+  // one long edge only, so a phone rotated left and a phone rotated right give
+  // asymmetric insets — and centring on the safe area would slide the sum ~23px
+  // off the point the four shells fan out of. That fan-out is the whole
+  // tutorial. So the box keeps the glass centre and gives up WIDTH instead,
+  // taking the widest symmetric span that still clears both corners.
+  // The floor is 40, not something comfortable: it is a guard against a degenerate
+  // box, never a licence to overhang a control. `game.ts` clamps the canvas to at
+  // least 320 CSS px and the two insets cannot exceed 47 each, so the channel is
+  // always at least 102px and this never binds on anything real.
+  const eqHalf = Math.max(
+    40,
+    Math.min(right - left, (w / 2 - left) * 2, (right - w / 2) * 2) / 2,
+  );
   const equation: Rect = {
-    x: area.x + area.w / 2 - eqW / 2,
+    x: w / 2 - eqHalf,
     y: eqCy - eqH / 2,
-    w: eqW,
+    w: eqHalf * 2,
     h: eqH,
   };
 

--- a/dynawalla/games/guilty/src/game/input.test.ts
+++ b/dynawalla/games/guilty/src/game/input.test.ts
@@ -1,0 +1,204 @@
+// A DOM scrim stops the pointer. It does not stop the keyboard.
+//
+// Every listener in `attachInput` is on `window`, not on the canvas, so when
+// the how-to-play panel is up the game is still reading keys — and `keyDown`
+// falls out of its switch into `on.onStart()` for EVERY key. `onStart` is
+// `begin()`, which resets the wave, the lives, the score and the best combo.
+//
+// The path that mattered: a child dies, the screen says PRESS ANY KEY, they
+// open the manual to work out what the wrong answers meant, and press Escape to
+// close it. The shared panel calls `preventDefault` but not `stopPropagation`,
+// so both listeners fire — the panel closes AND the run restarts. The
+// game-over screen they were reading is gone and there is nothing to say why.
+//
+// `p` was worse still: it toggled pause on a loop that returns before it
+// renders anything, so the panel closed onto a frozen trench with no
+// indication that it was paused.
+//
+// This file drives the real `attachInput` against a fake window and asserts
+// that nothing reaches the game while `blocked()` is true — and that everything
+// does the moment it is false, because an input gate stuck shut is the same bug
+// wearing a different hat.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { attachInput, type InputHandlers } from "./input.ts";
+import type { World } from "./world.ts";
+
+type Listener = (event: unknown) => void;
+
+/** A window and a canvas that only record what was attached to them. */
+function rig(): {
+  fire(type: string, event: Record<string, unknown>): void;
+  listenerCount(): number;
+  restore(): void;
+  canvas: HTMLCanvasElement;
+} {
+  const listeners = new Map<string, Listener[]>();
+  const add = (type: string, fn: Listener): void => {
+    listeners.set(type, [...(listeners.get(type) ?? []), fn]);
+  };
+  const remove = (type: string, fn: Listener): void => {
+    listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn));
+  };
+
+  const canvas = {
+    addEventListener: add,
+    removeEventListener: remove,
+    setPointerCapture: () => undefined,
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }),
+  } as unknown as HTMLCanvasElement;
+
+  const fakeWindow = { addEventListener: add, removeEventListener: remove };
+  const g = globalThis as Record<string, unknown>;
+  const savedWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const savedPerf = g.performance;
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    writable: true,
+    value: fakeWindow,
+  });
+  if (typeof savedPerf !== "object") g.performance = { now: () => 0 };
+
+  return {
+    canvas,
+    fire(type, event) {
+      // Every real event has these; supplying them here means a gate that is
+      // removed fails on the ASSERTION rather than on a TypeError, which is the
+      // difference between a test that reports the bug and one that just goes
+      // red for its own reasons.
+      const full = { preventDefault: () => undefined, stopPropagation: () => undefined, ...event };
+      for (const fn of [...(listeners.get(type) ?? [])]) fn(full);
+    },
+    listenerCount() {
+      let n = 0;
+      for (const list of listeners.values()) n += list.length;
+      return n;
+    },
+    restore() {
+      if (savedWindow) Object.defineProperty(globalThis, "window", savedWindow);
+      else Reflect.deleteProperty(globalThis, "window");
+      if (typeof savedPerf !== "object") Reflect.deleteProperty(g, "performance");
+    },
+  };
+}
+
+/** Only the two fields the input layer ever touches. */
+const fakeWorld = (): World =>
+  ({
+    touch: false,
+    ship: { x: 0, targetX: 0 },
+    cam: { f: 600, z: 300, cx: 400, x: 0 },
+  }) as unknown as World;
+
+function counted(blocked: () => boolean): {
+  handlers: InputHandlers;
+  calls: Record<string, number>;
+} {
+  const calls: Record<string, number> = {
+    onStart: 0,
+    onFocus: 0,
+    onToggleMute: 0,
+    onTogglePause: 0,
+    onToggleStats: 0,
+  };
+  const bump = (k: string) => (): void => {
+    calls[k] = (calls[k] ?? 0) + 1;
+  };
+  return {
+    calls,
+    handlers: {
+      blocked,
+      onStart: bump("onStart"),
+      onFocus: bump("onFocus"),
+      onToggleMute: bump("onToggleMute"),
+      onTogglePause: bump("onTogglePause"),
+      onToggleStats: bump("onToggleStats"),
+    },
+  };
+}
+
+const KEYS = [
+  { key: "Escape" },
+  { key: "p" },
+  { key: " " },
+  { key: "m" },
+  { key: "`" },
+  { key: "Tab" },
+  { key: "ArrowLeft" },
+  { key: "Enter" },
+];
+
+test("no key reaches the game while the manual is open", () => {
+  const r = rig();
+  try {
+    const { handlers, calls } = counted(() => true);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+    for (const k of KEYS) r.fire("keydown", k);
+    r.fire("pointerdown", { pointerId: 1, clientX: 400, pointerType: "touch" });
+    r.fire("pointerup", { pointerId: 1 });
+
+    for (const [name, n] of Object.entries(calls)) {
+      assert.equal(n, 0, `${name} fired ${n} times through the manual`);
+    }
+    // And the steering axis never latched, so closing the panel does not fly
+    // the ship into a wall.
+    assert.equal(input.axis(), 0, "an arrow key latched behind the panel");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});
+
+test("every key reaches the game the moment the manual closes", () => {
+  // The counterpart. A gate that is stuck shut is the same bug in a hat: it
+  // would pass the test above and make the game unplayable.
+  const r = rig();
+  try {
+    const { handlers, calls } = counted(() => false);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+
+    r.fire("keydown", { key: "Escape" });
+    assert.equal(calls.onStart, 1, "a key press no longer starts the game");
+
+    r.fire("keydown", { key: "p" });
+    assert.equal(calls.onTogglePause, 1, "p no longer pauses");
+
+    r.fire("keydown", { key: " " });
+    assert.equal(calls.onFocus, 1, "space no longer spends deep focus");
+
+    r.fire("keydown", { key: "m" });
+    assert.equal(calls.onToggleMute, 1, "m no longer mutes");
+
+    r.fire("keydown", { key: "ArrowLeft" });
+    assert.equal(input.axis(), -1, "the left arrow no longer steers");
+    r.fire("keyup", { key: "ArrowLeft" });
+    assert.equal(input.axis(), 0, "the left arrow never let go");
+
+    input.detach();
+    assert.equal(r.listenerCount(), 0, "detach left a listener on the window");
+  } finally {
+    r.restore();
+  }
+});
+
+test("a key released while the manual is open still lets go", () => {
+  // `keyUp` is deliberately NOT gated. A child holding left when they tapped
+  // the `?` would otherwise come back to a ship steering by itself.
+  const r = rig();
+  try {
+    let open = false;
+    const { handlers } = counted(() => open);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+
+    r.fire("keydown", { key: "ArrowRight" });
+    assert.equal(input.axis(), 1);
+    open = true;
+    r.fire("keyup", { key: "ArrowRight" });
+    assert.equal(input.axis(), 0, "the held key survived the panel");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});

--- a/dynawalla/games/guilty/src/game/input.ts
+++ b/dynawalla/games/guilty/src/game/input.ts
@@ -22,6 +22,20 @@ export type Input = {
 };
 
 export type InputHandlers = {
+  /**
+   * True while something the player can see is covering the game — today, the
+   * how-to-play panel.
+   *
+   * Every listener below is on `window`, not on the canvas, so a DOM scrim
+   * stops the pointer but not the keyboard. Without this, `keyDown` falls out
+   * of its switch into `onStart()` for EVERY key, so a child who opened the
+   * rules on the game-over screen and pressed Escape to close them closed the
+   * panel into a brand new run — wave, lives, score and best combo all reset,
+   * the game-over screen gone. `p` was worse: it paused a game that returns
+   * before it renders, so the panel closed onto a frozen trench with nothing
+   * on screen saying why.
+   */
+  blocked(): boolean;
   onStart(): void;
   onFocus(): void;
   onToggleMute(): void;
@@ -42,6 +56,7 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
   const rectX = (): number => canvas.getBoundingClientRect().left;
 
   const pointerDown = (e: PointerEvent): void => {
+    if (on.blocked()) return;
     canvas.setPointerCapture?.(e.pointerId);
     pointerId = e.pointerId;
     dragging = true;
@@ -71,14 +86,14 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
   };
 
   const pointerUp = (e: PointerEvent): void => {
-    if (e.pointerId !== pointerId) return;
+    if (e.pointerId !== pointerId || on.blocked()) return;
     dragging = false;
     pointerId = -1;
     if (performance.now() - downAt < 230 && moved < 14) on.onFocus();
   };
 
   const keyDown = (e: KeyboardEvent): void => {
-    if (e.repeat) return;
+    if (e.repeat || on.blocked()) return;
     switch (e.key) {
       case "ArrowLeft":
       case "a":
@@ -111,6 +126,8 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
   };
 
   const keyUp = (e: KeyboardEvent): void => {
+    // Not gated: a key held down when the panel opened must still be released,
+    // or the ship steers into the wall the moment the child closes it.
     if (e.key === "ArrowLeft" || e.key === "a" || e.key === "A") left = false;
     if (e.key === "ArrowRight" || e.key === "d" || e.key === "D") right = false;
   };


### PR DESCRIPTION
## What

Fix two defects I shipped in #635: the keyboard reaching GUILTY through the
manual's scrim (Escape closed the rules straight into a fresh run), and the
equation drifting off the point the shells fan out of on a rotated phone.

## Why

Follow-up to #635, found by an adversarial review of the branch.

**1 · The keyboard went through the scrim.** The how-to-play panel is a DOM
scrim, which stops the pointer. Every listener in `attachInput` is on `window`,
so it stops nothing there — and `keyDown` falls out of its switch into
`on.onStart()` for **every** key. `onStart` is `begin()`, which resets the wave,
the lives, the score, the combo and the best combo.

The path that mattered: a child dies, the screen says PRESS ANY KEY, they open
the manual to work out what the wrong answers meant, and press **Escape** to
close it. The shared panel calls `preventDefault` but not `stopPropagation`, so
both listeners fire — the panel closes *and* the run restarts. The game-over
screen they were reading is simply gone, with nothing to say why.

`p` was worse. It toggled pause on a loop that returns *before it renders
anything*, so the panel closed onto a frozen trench with no indication that it
was paused at all.

#635 gated the simulation (`world.paused || guide.isOpen`) and left the input
wide open, which is half a fix. `InputHandlers` now carries `blocked()`, checked
in `keyDown`, `pointerDown` and `pointerUp`. `keyUp` is deliberately **not**
gated: a child holding left when they tapped the `?` must still be able to let
go, or they come back to a ship steering itself into the wall.

**2 · The accusation drifted off the shells it births.** `hudLayout` centred the
equation on the safe rectangle, but `fitCamera` maps world `x = 0` — where the
husks are born — to `w / 2`. iOS reports the notch on **one** long edge, so a
phone rotated left and a phone rotated right give asymmetric insets, and the sum
slid about 23px off the point the four shells fan out of. That fan-out is the
entire tutorial; `hud.ts` has said so since the game was written. The box now
keeps the glass centre and gives up **width** instead, taking the widest
symmetric span that still clears both host corners.

## Blast radius

**Areas touched:** dynawalla (one game pack: `dynawalla/games/guilty/`)

- [x] Every touched path is covered by a `ci.yml` area filter.
- [x] **Pack back-compat.** `pack.json` untouched — same id, version, sdk, host
      range, capabilities, covers. No published zip changed in place.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest.
- [x] **Strings.** No new user-visible strings;
      `corpan-app/public/locales/` untouched.
- [x] **Curriculum.** N/A — no skill id, grade, generator or schema touched. The
      mal-rule distractors, the wave ladder and the boss are not in the diff.
- [x] **Secrets.** None. `gitleaks` below.

Behavioural risk: `InputHandlers` gains a required member, which is a
pack-internal type with one implementation (`game.ts`) — `tsc` covers it. On a
rotated phone with asymmetric insets the equation is a little narrower and
correctly placed rather than a little wider and off-centre.

## Proof

From `dynawalla/games/guilty/`, rebased onto current `origin/main`.

**`npm test`, five times**

```
# tests 36 # pass 36 # fail 0
# tests 36 # pass 36 # fail 0
# tests 36 # pass 36 # fail 0
# tests 36 # pass 36 # fail 0
# tests 36 # pass 36 # fail 0
```

**The new input test catches the bug it was written for.** Removing the
`on.blocked()` guard from `keyDown`:

```
# tests 36
# pass 35
# fail 1
not ok 20 - no key reaches the game while the manual is open
  error: 'onStart fired 8 times through the manual'
```

`src/game/input.test.ts` drives the *real* `attachInput` against a fake window,
and asserts all four halves of the invariant: nothing fires while `blocked()` is
true; **everything** fires the moment it is false, because a gate stuck shut is
the same bug in a hat; a key released behind the panel still lets go; and
`detach()` leaves no listener on the window. The fake events carry
`preventDefault`/`stopPropagation` so that a removed gate fails on the
**assertion** rather than on a TypeError — the difference between a test that
reports the bug and one that just goes red for its own reasons.

**`npm run tsc`** — 0 errors.

```
> @dynawalla/game-guilty@0.1.0 tsc
> tsc --noEmit

```

**`npm run build`**

```
dist/index.html                  0.54 kB │ gzip:  0.32 kB
dist/assets/index-CFU8HKqn.css   0.23 kB │ gzip:  0.18 kB
dist/assets/index-CCSMDfvp.js   62.30 kB │ gzip: 24.33 kB
✓ built in 172ms
```

**`node build.mjs guilty`**, from `dynawalla/packs/`

```
  on disk      3 files, 66388 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**`gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`**

```
INF no leaks found
```

**Scope**

```
$ git diff --stat origin/main..HEAD
 dynawalla/games/guilty/src/game/game.ts           |   3 +
 dynawalla/games/guilty/src/game/hudLayout.test.ts |  24 +++
 dynawalla/games/guilty/src/game/hudLayout.ts      |  22 ++-
 dynawalla/games/guilty/src/game/input.test.ts     | 204 ++++++++++++++++++++++
 dynawalla/games/guilty/src/game/input.ts          |  21 ++-
 5 files changed, 268 insertions(+), 6 deletions(-)

$ git diff --diff-filter=D --name-only origin/main..HEAD
(empty)
```
