### PR TITLE
test(dynawalla-app): a failing frame test hung the runner for fifteen minutes

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/frame.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.test.ts
@@ -7,7 +7,7 @@
 // `allow-same-origin` back in would be invisible in every other test in this
 // repository. This is the one that fails.
 
-import { test } from "node:test"
+import { test, type TestContext } from "node:test"
 import assert from "node:assert/strict"
 
 import { mountPack } from "./frame.ts"
@@ -57,7 +57,21 @@ type Harness = {
   fire(event: { source: unknown; data: unknown }): void
 }
 
-function harness(granted: readonly Capability[] = ["items"]): Harness {
+/**
+ * Mount a pack against a fake frame.
+ *
+ * Takes the test context so teardown can be registered as an `after` hook
+ * rather than trailing the assertions. A `mountPack` holds a live
+ * `MessageChannel`, and an open port is a handle: if an assertion throws before
+ * the `dispose()` at the foot of a test, the port is never closed, node's event
+ * loop never drains and the process never exits. That is not a slow test, it is
+ * a hung job — one flake here cost fifteen minutes of runner time and a
+ * merge-queue slot on a suite that finishes in twenty seconds.
+ *
+ * `dispose()` is idempotent (there is a test for it), so tests may still call it
+ * themselves where the call is the thing being asserted.
+ */
+function harness(t: TestContext, granted: readonly Capability[] = ["items"]): Harness {
   const posted: Posted[] = []
   const children: unknown[] = []
   const listeners = new Map<string, Set<(event: unknown) => void>>()
@@ -107,6 +121,7 @@ function harness(granted: readonly Capability[] = ["items"]): Harness {
     document: doc,
     window: win,
   })
+  t.after(() => mounted.dispose())
 
   return {
     mounted,
@@ -125,8 +140,24 @@ function harness(granted: readonly Capability[] = ["items"]): Harness {
 
 const shake = (test: Harness) => test.fire({ source: test.frame["contentWindow"], data: { event: "ready" } })
 
-test("the frame is sandboxed without allow-same-origin — this is the boundary", () => {
-  const test = harness()
+/**
+ * Wait for a condition, not for a duration.
+ *
+ * A fixed sleep is a bet that a two-core CI runner schedules a `MessageChannel`
+ * round trip as fast as this laptop does, and it is a bet that is only ever
+ * settled in one direction: too short and the suite fails for no reason, too
+ * long and every green run pays for it. Polling costs a few milliseconds in the
+ * normal case and tolerates a contended runner.
+ */
+async function until(done: () => boolean, ms = 2000): Promise<void> {
+  const deadline = Date.now() + ms
+  while (!done() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
+test("the frame is sandboxed without allow-same-origin — this is the boundary", (t) => {
+  const test = harness(t)
   const sandbox = (test.frame["getAttribute"] as (n: string) => string | null)("sandbox")
   assert.equal(sandbox, "allow-scripts")
   assert.ok(!sandbox?.includes("allow-same-origin"), "the pack would share the app's origin")
@@ -135,25 +166,25 @@ test("the frame is sandboxed without allow-same-origin — this is the boundary"
   test.mounted.dispose()
 })
 
-test("the frame asks for no device permissions and leaks no referrer", () => {
-  const test = harness()
+test("the frame asks for no device permissions and leaks no referrer", (t) => {
+  const test = harness(t)
   const get = test.frame["getAttribute"] as (n: string) => string | null
   assert.equal(get("allow"), "", "a permissions-policy grant would reach the camera or the mic")
   assert.equal(get("referrerpolicy"), "no-referrer")
   test.mounted.dispose()
 })
 
-test("the pack is framed at the pack scheme and nothing else", () => {
-  const test = harness()
+test("the pack is framed at the pack scheme and nothing else", (t) => {
+  const test = harness(t)
   assert.match(String(test.frame["src"]), /^dynawalla-pack:\/\//)
   assert.equal(test.children.length, 1)
   test.mounted.dispose()
 })
 
-test("a ready from anywhere but this frame is ignored", () => {
+test("a ready from anywhere but this frame is ignored", (t) => {
   // `event.origin` is the string "null" for a sandboxed frame and authenticates
   // nothing. The frame identity is the only thing that can.
-  const test = harness()
+  const test = harness(t)
   test.fire({ source: { not: "our frame" }, data: { event: "ready" } })
   test.fire({ source: test.frame["contentWindow"], data: { event: "hello" } })
   test.fire({ source: test.frame["contentWindow"], data: null })
@@ -162,8 +193,8 @@ test("a ready from anywhere but this frame is ignored", () => {
   test.mounted.dispose()
 })
 
-test("the handshake transfers exactly one port and states the grant set", () => {
-  const test = harness(["items", "haptics"])
+test("the handshake transfers exactly one port and states the grant set", (t) => {
+  const test = harness(t, ["items", "haptics"])
   shake(test)
   assert.equal(test.mounted.connected(), true)
   assert.equal(test.posted.length, 1)
@@ -182,19 +213,20 @@ test("the handshake transfers exactly one port and states the grant set", () => 
   test.mounted.dispose()
 })
 
-test("a second ready does not hand out a second port", () => {
-  const test = harness()
+test("a second ready does not hand out a second port", (t) => {
+  const test = harness(t)
   shake(test)
   shake(test)
   assert.equal(test.posted.length, 1)
   test.mounted.dispose()
 })
 
-test("traffic on the port reaches the bridge and comes back", async () => {
-  const test = harness(["items"])
+test("traffic on the port reaches the bridge and comes back", async (t) => {
+  const test = harness(t, ["items"])
   shake(test)
   const packPort = test.posted[0]?.transfer[0]
   assert.ok(packPort)
+  t.after(() => packPort.close())
 
   const replies: unknown[] = []
   packPort.onmessage = (event: MessageEvent) => replies.push(event.data)
@@ -203,22 +235,20 @@ test("traffic on the port reaches the bridge and comes back", async () => {
   // And something the pack was not granted, to prove the bridge is in the path.
   packPort.postMessage({ id: 2, method: "storage.get", params: { key: "k" } })
 
-  await new Promise((resolve) => setTimeout(resolve, 20))
+  await until(() => replies.length >= 2)
   assert.deepEqual(replies[0], { id: 1, ok: true, result: { item: null } })
   assert.deepEqual(replies[1], { id: 2, ok: false, error: { code: "denied", message: "storage.get was not granted to this pack" } })
-  packPort.close()
-  test.mounted.dispose()
 })
 
-test("host events only go out once a pack is connected", () => {
-  const test = harness()
+test("host events only go out once a pack is connected", (t) => {
+  const test = harness(t)
   test.mounted.send("pause")
   assert.deepEqual(test.posted, [], "an event was sent to a frame that had not connected")
   test.mounted.dispose()
 })
 
-test("dispose is idempotent, unhooks the listener and destroys the frame", () => {
-  const test = harness()
+test("dispose is idempotent, unhooks the listener and destroys the frame", (t) => {
+  const test = harness(t)
   shake(test)
   assert.equal(test.listeners.get("message")?.size, 1)
 
@@ -230,19 +260,19 @@ test("dispose is idempotent, unhooks the listener and destroys the frame", () =>
   assert.equal(test.frame["src"], "about:blank")
 })
 
-test("dispose before the handshake is safe, and the frame never connects afterwards", () => {
-  const test = harness()
+test("dispose before the handshake is safe, and the frame never connects afterwards", (t) => {
+  const test = harness(t)
   test.mounted.dispose()
   shake(test)
   assert.equal(test.mounted.connected(), false)
   assert.deepEqual(test.posted, [])
 })
 
-test("mounting twice makes two independent packs — StrictMode does exactly this", () => {
+test("mounting twice makes two independent packs — StrictMode does exactly this", (t) => {
   // Two Babylon engines in one console is the tell for the bug this prevents.
   // The contract is that disposing the first leaves the second untouched.
-  const first = harness()
-  const second = harness()
+  const first = harness(t)
+  const second = harness(t)
   shake(first)
   shake(second)
   first.mounted.dispose()


### PR DESCRIPTION
`mountPack` holds a live `MessageChannel`. Every test in `frame.test.ts` closed
it with a `dispose()` on the **last line** — after the assertions — so the one
path that mattered was the one it did not cover: when an assertion throws, the
port is never closed, node's event loop never drains, and the process never
exits.

That is not a slow test, it is a hung job. It happened on #640: one failing
assertion in `traffic on the port reaches the bridge and comes back` turned a
twenty-second suite into a **fifteen-minute cancellation**, holding a
merge-queue slot the whole time. Re-running the same commit unchanged went green
in 36s, so the failure itself was a flake — but the cost was not the flake, it
was the fifteen minutes.

## What changed

- Teardown moved to `t.after()`, registered inside `harness()` at the moment the
  pack is mounted, so it runs on pass, fail or throw. The hand-opened port in
  the traffic test is registered the same way.
- Tests still call `dispose()` themselves where the call is the thing under
  test. `dispose()` is idempotent and there is a test asserting that.
- The fixed `setTimeout(..., 20)` is replaced by `until()`, which polls for the
  condition. A fixed sleep is a bet that a two-core runner schedules a
  `MessageChannel` round trip as fast as this laptop does, and it is only ever
  settled in one direction: too short and the suite fails for no reason, too
  long and every green run pays for it.

## Proof, not argument

With the traffic assertion deliberately broken:

| | outcome |
|---|---|
| before | still running when a 90s timeout killed it — `exit 124` |
| after | failure reported, `exit 1`, **0.2s** |

## Verification

221 tests pass, 5 runs out of 5. `tsc --noEmit` and `eslint` clean.

## What this does not do

I could not reproduce the original flake — 5/5 with the exact CI command, then
25/25 with six spinner processes pinning the cores. This fixes what a failure
*costs*, not what caused one.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb