### PR TITLE
release(dynawalla): 0.3.0 — every game is playable on a real phone, and every game teaches itself

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
One line, `tauri.conf.json` `0.2.1` → `0.3.0`, matching the convention of every
prior bump (`0.1.1`, `0.2.0`, `0.2.1` each touched that file and nothing else).

## What 0.2.1 actually shipped

Twenty-seven games a child could not reliably start and, on a notched phone,
could not fully read.

**Nobody was told the rules.** Not one game had an in-game manual. SKY LEDGER
shipped with a stats panel and the words "THE WATCH IS WRITTEN DOWN" and nothing
anywhere saying that you name a coordinate on an astrolabe. A child will not
hunt for the rules; they decide the game is broken and leave.

**Twenty of twenty-seven were drawing under the notch.** All twenty-seven
declare `viewport-fit=cover`, which opts the document *into* the notch, the home
indicator and the rounded corners. Only the seven DOM-HUD games clawed it back —
`env()` is a CSS value and a canvas cannot read one. The other twenty drew score,
timer and buttons at `y = 24`.

## What 0.3.0 does about it

`packs/shared/game-chrome`, adopted by all 27. Before it, `packs/shared/` held
only `curriculum` and `game-host` and **no game imported anything shared for UI**.

- **Safe insets, measured.** `env()` is unreadable from JS, so a hidden probe's
  resolved padding is read back instead.
- **The host sends them.** A pack is framed `sandbox="allow-scripts"` with no
  `allow-same-origin`, so it is cross-origin and `env()` resolves to **0** inside
  it. All 26 game-side layout fixes were worth nothing until #640 made the host
  post real values across the bridge.
- **Chrome overlays; it does not reserve a band.** The first design took the top
  67px — a twelfth of a 568px phone — and broke SKY LEDGER's own invariant:
  `the lattice cell is 15.3px, the figures collide`. Games without such a test
  would have shipped colliding text. Now two controls float with their own scrim
  and a game promises only that nothing a child must READ OR TOUCH sits in two
  44px corners. `hitsHostChrome(rect, w)` makes that assertable per viewport.
- **Exit is a `<` chevron, top left.** It was a translated "Leave" pill whose
  width changed with the language, so no game could reserve space for it.
- **The double-tap leak was the host, not the games.** 26 of 27 packs already set
  `touch-action:none` and `user-scalable=no`; the host had none of it, and
  `touch-action: manipulation` does not stop double-tap zoom.

## Honest note

Fourteen of the 36 commits behind this release are fixes to the shared module or
to games that had just adopted it — **every one found by an adopter, not by the
module's own tests**: the manual opened over every game at launch, could not be
scrolled with a finger, Escape closed it into a fresh run, Space quenched the run
behind it. Centralising was still right — one fix each instead of 27 — but a
pilot adoption was weaker evidence than it looked.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb