### PR TITLE
fix(dynawalla): the chrome stops reading as a web page in a wrapper

### DIFF
--- a/dynawalla/docs/HARNESS_FEEDBACK.md
+++ b/dynawalla/docs/HARNESS_FEEDBACK.md
@@ -1,0 +1,85 @@
+# Dynawalla — harness feedback
+
+Founder feedback on the **host app** — the shell, the chrome, the navigation,
+the parent area. Not the games; those have their own review loop.
+
+The point of this file is that feedback given once should not need giving twice.
+Each item records what was said, what was actually wrong underneath it, and
+whether it is done. An item is only ticked when it was verified on a rendered
+screen, not when the code looked right.
+
+## The standing bar
+
+> "we need premium native-like behavior"
+
+That is the test every item here is measured against: nothing may read as a web
+page in a wrapper. The tells are specific and worth naming, because they are
+what gets noticed without being articulated — a drawn scrollbar track, a
+selection handle raised by a long press, a page that slides sideways, a tap
+highlight, a bounce at the wrong edge.
+
+## Open
+
+_(nothing currently open)_
+
+## Done
+
+### Wordmark and mark were not a lockup — 2026-07-29
+
+> "I think the Dynawalla word should be better laid out next to the logo - like
+> maybe even with the bottom and let the logo be taller."
+
+A 28px emblem was vertically centred against 18px uppercase, which made it read
+as a bullet beside the word rather than as a mark.
+
+Fixed: the mark is 40px, so the spire rises above cap height, and the two are
+aligned at the letters' feet. `items-end` alone is not enough — a text box
+extends below its baseline by the font's descender space even for all-caps with
+no descenders, so the emblem hangs low. The mark's `margin-bottom: 0.16em` takes
+up exactly that slack; the value was rendered at 0 / 0.10 / 0.16 / 0.22em and
+compared rather than guessed. `items-baseline` cannot do this job because an SVG
+has no baseline of its own.
+
+### The parent area scrolled sideways — 2026-07-29
+
+> "parent tab has some horizontal scroll ish behavior. the text goes off the
+> side."
+
+`Fact`'s value carried `shrink-0`. For "35 kB" or "Native (Tauri)" that looked
+free; developer mode then printed `@tauri-apps/api/app.getVersion`, and a flex
+child that will neither shrink nor wrap pushes its parent wider than the screen
+— taking the header with it.
+
+Fixed: the value shrinks and wraps. **Both** children also carry `min-w-0`,
+because a flex item's default `min-width: auto` refuses to shrink below its
+content no matter what `shrink` says — that is the version of this bug that
+survives a naive fix. `overflow-x: hidden` on `html, body` is the backstop: wide
+content scrolls in its own box, the page never does.
+
+### A drawn scrollbar in the app — 2026-07-29
+
+> "I dont want to see scrollbar in mobile, do I?"
+
+No. Touch platforms draw their own transient indicator during the gesture, so a
+persistent track is noise and one of the loudest web-view tells.
+
+Fixed under `@media (pointer: coarse)` only — a mouse user genuinely needs a
+scrollbar, so this is scoped to touch rather than applied everywhere.
+
+### Long-press raised a selection handle — 2026-07-29
+
+Not reported, found while fixing the above, and the same class of tell: a child
+pressing hard on a card got a text-selection handle over the label. `user-select:
+none` on `body`, with `input`, `textarea` and `[contenteditable]` opting back in
+so a parent can still edit a name they typed.
+
+## Noted, not yet acted on
+
+- **"Erase everything" is coral** (`--dw-strike`, from the copper ramp) against a
+  violet ground. Semantically a destructive action should read as danger, but the
+  hue is the one leftover from the pre-purple palette and sits oddly. Worth a
+  deliberate decision rather than a drive-by change.
+- **The strapwork bands** at the top and bottom of the chrome carry the gold
+  index colour across the full width. The brand rule in
+  [`../brand/README.md`](../brand/README.md) is *one warm point per screen*;
+  a repeating full-width band is arguably two.

--- a/dynawalla/dynawalla-app/src/app/Shell.tsx
+++ b/dynawalla/dynawalla-app/src/app/Shell.tsx
@@ -23,12 +23,26 @@ function Lintel() {
   return (
     <header className="bg-ground-raised">
       <div className="flex items-center px-[max(var(--safe-left),1rem)] pt-[max(var(--safe-top),var(--dw-lintel-pad))] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-lintel-pad)]">
+        {/* The mark sits on the wordmark's baseline and stands taller than the
+            letters, rather than being centred against them at their own height.
+            Centring a 28px emblem on 18px uppercase left it looking like a
+            bullet point beside the word.
+
+            `items-end` aligns the two BOXES at the bottom, which is not the
+            same as aligning the mark to the letters' feet: a text box extends
+            below its baseline by the font's descender space even when the text
+            is all caps and has none. Left alone the emblem hangs below the
+            word. The mark's `mb` takes up exactly that slack.
+
+            0.16em is measured, not guessed — rendered against this stylesheet
+            at 0, 0.10, 0.16 and 0.22em and compared. An SVG has no baseline of
+            its own, so `items-baseline` cannot do this job. */}
         <Link
           to="/"
-          className="inscription rounded-cut-sm text-ink flex items-center gap-2.5 text-lg tracking-[0.22em] uppercase"
+          className="inscription rounded-cut-sm text-ink flex items-end gap-3 text-lg tracking-[0.22em] uppercase"
         >
-          <Mark className="h-7 w-7 shrink-0" />
-          {strings.appName}
+          <Mark className="mb-[0.16em] h-10 w-10 shrink-0" />
+          <span className="leading-none">{strings.appName}</span>
         </Link>
       </div>
 

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -46,6 +46,44 @@
     -webkit-touch-callout: none;
     touch-action: manipulation;
     overscroll-behavior: none;
+    /* Nothing here is a document. A long-press that raises a selection handle
+       over a label is the single loudest tell that an app is a web view, and a
+       child pressing hard on a card gets one every time. Inputs opt back in
+       below — a parent typing a name must be able to select what they typed. */
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  input,
+  textarea,
+  [contenteditable] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  /* The chrome must never scroll sideways. A single row whose value refuses to
+     shrink drags the whole page with it — which is exactly what the parent area
+     did on a phone, with `@tauri-apps/api/app.getVersion` running off the right
+     edge and taking the header with it. Wide content scrolls inside its own
+     box; the page does not. */
+  html,
+  body {
+    overflow-x: hidden;
+  }
+
+  /* A persistent scrollbar track is a web-view tell. Touch platforms draw a
+     transient indicator of their own during the gesture, so the drawn track is
+     pure noise there — but a mouse user genuinely needs it, so this is scoped to
+     coarse pointers rather than applied everywhere. */
+  @media (pointer: coarse) {
+    * {
+      scrollbar-width: none;
+    }
+
+    *::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
   }
 
   /* One focus treatment for the whole app, keyboard-only. Children on tablets

--- a/dynawalla/dynawalla-app/src/shell/Surface.tsx
+++ b/dynawalla/dynawalla-app/src/shell/Surface.tsx
@@ -32,9 +32,22 @@ type Keyless<K extends Row["kind"]> = Omit<Extract<Row, { kind: K }>, "key">
  */
 function Fact({ name, value }: { name: string; value: string }) {
   return (
+    // `shrink-0` on the value was the bug behind the parent area scrolling
+    // sideways on a phone. A fact's value is usually two words — "35 kB",
+    // "Native (Tauri)" — so refusing to shrink looked free, until developer
+    // mode started printing capability strings like
+    // `@tauri-apps/api/app.getVersion`. A flex child that will not shrink and
+    // will not wrap pushes its parent wider than the screen, and the whole page
+    // goes with it, header included.
+    //
+    // Both children get `min-w-0` because a flex item's default `min-width:
+    // auto` refuses to shrink below its content regardless of any `shrink`
+    // setting — the classic version of this bug that survives a naive fix.
     <div className="flex min-h-16 items-center justify-between gap-4 py-3">
-      <span className="inscription text-lg tracking-wide">{name}</span>
-      <span className="numeral text-ink-muted shrink-0 text-sm">{value}</span>
+      <span className="inscription min-w-0 text-lg tracking-wide">{name}</span>
+      <span className="numeral text-ink-muted min-w-0 text-right text-sm break-words">
+        {value}
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
## What

Four fixes to the host chrome from founder feedback on a real phone, plus
`dynawalla/docs/HARNESS_FEEDBACK.md` so the feedback is recorded rather than
re-given.

## Why

The standing bar is *"we need premium native-like behavior"*. The tells are
specific, and three of these four are exactly the ones that get noticed without
being articulated.

**The wordmark and the mark were not a lockup.** A 28px emblem vertically centred
against 18px uppercase reads as a bullet point beside the word. The mark is now
40px — the spire rises above cap height — and the two align at the letters' feet.

`items-end` does not achieve that by itself: a text box extends below its
baseline by the font's descender space *even for all-caps with no descenders*,
so the emblem hangs low. The mark carries `margin-bottom: 0.16em` to take up
exactly that slack, and the value was rendered at 0 / 0.10 / 0.16 / 0.22em
against this stylesheet and compared, not guessed. `items-baseline` cannot do
this job — an SVG has no baseline of its own.

**The parent area scrolled sideways.** `Fact`'s value carried `shrink-0`. For
"35 kB" or "Native (Tauri)" that looked free; developer mode then printed
`@tauri-apps/api/app.getVersion`, and a flex child that will neither shrink nor
wrap pushes its parent wider than the screen — taking the header with it.

Both children now also carry `min-w-0`, because a flex item's default
`min-width: auto` refuses to shrink below its content regardless of `shrink` —
that is the version of this bug that survives a naive fix.

**A drawn scrollbar track is a web-view tell.** Touch platforms draw their own
transient indicator during the gesture. Hidden under `@media (pointer: coarse)`
only — a mouse user genuinely needs a scrollbar.

**A long press raised a text-selection handle** over a label. Not reported;
found while fixing the others, same class of tell.

## Blast radius

- [x] Chrome only. No game, no pack, no launch path, no native code.
- [x] `surfaces.test.ts` and the capabilities test untouched and passing.
- [x] Scrollbar hiding is scoped to coarse pointers, so desktop keeps its
      scrollbar.
- [x] `user-select: none` is on `body`, with `input`, `textarea` and
      `[contenteditable]` opting back in — a parent can still select a name they
      typed.
- [ ] `overflow-x: hidden` on `html, body` is a backstop, not a licence: any
      genuinely wide content must still scroll inside its own box, or it will be
      clipped rather than reachable.

## Proof

```
npm run tsc     clean
npm test        tests 221 / pass 221 / fail 0
npm run lint    clean
npm run build   ✓ built in 166ms
```

Rendered the real markup against the built stylesheet at 390px and measured:

```
scrollW=500 clientW=500 NO-OVERFLOW
```

`@tauri-apps/api/app.getVersion` now wraps inside its row. Confirmed the rules
survive minification into the shipped bundle:

```
$ grep -o "pointer:coarse[^}]*}" dist/assets/*.css
pointer:coarse){*{scrollbar-width:none}
```
