### PR TITLE
feat(dynawalla/packs/shared): the manual becomes a drawer, and the module finally has tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,6 +806,56 @@ jobs:
           npm install
           npm test
           npm run tsc
+      # The shared UI contract, which until now was tested by NOTHING.
+      #
+      # `packs/shared/game-chrome/` is imported by all 27 games for safe-area
+      # insets, the two host-chrome corners and the how-to-play sheet. It had
+      # one test file, `insets.test.ts`, and no job ran it: the `shared_ts`
+      # filter above is `^(shared/|corpan/packs/shared/)`, which does not match
+      # `dynawalla/packs/shared/`, and no game's test glob reaches outside its
+      # own directory. So the module shipped four production defects — the sheet
+      # covering every game at launch, insets reading zero inside the pack
+      # frame, a manual that could not be scrolled, and Escape leaking into the
+      # game — and every one was found by a game adopting it rather than here.
+      #
+      # A directory glob, not a list, for the same reason the game loop below
+      # uses one: the next shared module should be covered by existing in it,
+      # not by somebody remembering to edit this file. `curriculum/` is skipped
+      # because it has its own gated job (`dynawalla-curriculum`) that runs a
+      # superset of this.
+      - name: Install, test and typecheck the shared pack modules
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          manifests=(dynawalla/packs/shared/*/package.json)
+          # Counted BEFORE the loop, exactly like the game loop below. Under
+          # `set -u` an empty array expansion is itself an error on some bash
+          # builds, so a guard placed after the loop reports "unbound variable"
+          # instead of saying what is actually wrong.
+          if [ "${#manifests[@]}" -eq 0 ]; then
+            echo "::error::no package.json under dynawalla/packs/shared/ — this glob has gone stale and the job is passing on nothing."
+            exit 1
+          fi
+          ran=0
+          for manifest in "${manifests[@]}"; do
+            dir="$(dirname "${manifest}")"
+            case "${dir}" in */curriculum) continue ;; esac
+            echo "::group::${dir}"
+            if [ -f "${dir}/package-lock.json" ]; then
+              npm ci --prefix "${dir}"
+            else
+              npm install --prefix "${dir}"
+            fi
+            npm run --prefix "${dir}" test
+            npm run --prefix "${dir}" tsc
+            ran=$((ran + 1))
+            echo "::endgroup::"
+          done
+          if [ "${ran}" -eq 0 ]; then
+            echo "::error::every shared module was skipped — the curriculum exclusion has swallowed the whole glob."
+            exit 1
+          fi
+          echo "${ran} shared module(s) tested."
       - name: Install, test and typecheck every game
         run: |
           set -euo pipefail

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -19,6 +19,7 @@ export {
 } from "./hostChrome.ts"
 export {
   createInstructions,
+  sheetTop,
   type Instructions,
   type InstructionsSpec,
   type Section,

--- a/dynawalla/packs/shared/game-chrome/instructions.test.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.test.ts
@@ -1,0 +1,458 @@
+// The manual, asserted rather than described.
+//
+// This file exists because the module it tests had four defects in production
+// and every single one was found by a game adopting it, never by this module:
+//
+//   #636  the sheet rendered OVER the game from the moment it mounted, in all
+//         27 games, because a UA `[hidden]{display:none}` is origin-weaker than
+//         an author `display:flex`
+//   #640  `safeInsets()` returned zeros inside the pack frame
+//   #641  the manual could not be scrolled with a finger
+//   #645  Escape closed the manual straight into the game, and the focus trap
+//         had been unreachable since the day the key swallow was added
+//
+// There was no test file at all, and `insets.test.ts` beside it is not run by
+// CI. So: a hand-rolled DOM, no dependencies, in the same shape as
+// `games/guilty/src/game/input.test.ts`.
+//
+// What this CAN'T see is real layout — whether the footer is genuinely pinned,
+// whether the body genuinely scrolls. Those need a browser. What it CAN see is
+// every invariant that is arithmetic or behaviour, which is where all four
+// defects actually lived.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createInstructions, sheetTop, type InstructionsSpec } from "./instructions.ts"
+import { setHostInsets, type Insets } from "./insets.ts"
+import { exitRect, helpRect, HOST_CONTROL } from "./hostChrome.ts"
+
+// --- the fake DOM -----------------------------------------------------------
+
+type Listener = (event: unknown) => void
+
+class El {
+  tagName: string
+  children: El[] = []
+  parent: El | null = null
+  attrs = new Map<string, string>()
+  listeners = new Map<string, Listener[]>()
+  className = ""
+  textContent = ""
+  type = ""
+  tabIndex = 0
+  hidden = false
+  scrollTop = 0
+  offsetHeight = 600
+  focused = false
+  // Deliberately a bag of named fields with NO `setProperty`, matching the
+  // fake DOMs four games already ship. The module must stay inside that
+  // vocabulary: when it reached for `style.setProperty`, BEAM, COUNTERWEIGHT,
+  // FOUNDRY and LATTICE all stopped rendering at every viewport.
+  style: Record<string, string> = {}
+  // No `classList`, deliberately — see the note on `style` above. The games'
+  // harnesses do not have one, and when this rig was richer than theirs the
+  // module reached for `classList.remove` and broke FOUNDRY and LATTICE while
+  // these tests stayed green. A test double that is MORE capable than the real
+  // callers is not a safety net, it is a blindfold.
+
+  constructor(tagName: string) {
+    this.tagName = tagName
+  }
+  setAttribute(k: string, v: string): void {
+    this.attrs.set(k, v)
+  }
+  getAttribute(k: string): string | null {
+    return this.attrs.get(k) ?? null
+  }
+  appendChild(c: El): void {
+    c.parent = this
+    this.children.push(c)
+  }
+  append(...cs: El[]): void {
+    cs.forEach((c) => this.appendChild(c))
+  }
+  remove(): void {
+    if (!this.parent) return
+    this.parent.children = this.parent.children.filter((c) => c !== this)
+    this.parent = null
+  }
+  addEventListener(t: string, fn: Listener): void {
+    this.listeners.set(t, [...(this.listeners.get(t) ?? []), fn])
+  }
+  removeEventListener(t: string, fn: Listener): void {
+    this.listeners.set(t, (this.listeners.get(t) ?? []).filter((f) => f !== fn))
+  }
+  focus(): void {
+    doc.activeElement = this
+    this.focused = true
+  }
+  setPointerCapture(): void {}
+  releasePointerCapture(): void {}
+  /** Deliver an event to this element's own listeners. */
+  fire(type: string, event: Record<string, unknown> = {}): void {
+    const e = { type, target: this, currentTarget: this, preventDefault() {}, stopPropagation() {}, ...event }
+    for (const fn of [...(this.listeners.get(type) ?? [])]) fn(e)
+  }
+  /** Find one descendant by class name. */
+  find(cls: string): El {
+    if (this.className.split(" ").includes(cls)) return this
+    for (const c of this.children) {
+      try {
+        return c.find(cls)
+      } catch {
+        /* keep looking */
+      }
+    }
+    throw new Error(`no .${cls} in the tree`)
+  }
+  has(cls: string): boolean {
+    try {
+      this.find(cls)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+// `safeInsets()` measures a hidden probe through `getComputedStyle`, so the
+// fake document has to offer the three things that path touches. It resolves to
+// zeros here, which is exactly what a device with no notch reports — the tests
+// that care about a real notch push one in with `setHostInsets()`.
+const doc = {
+  activeElement: null as El | null,
+  createElement: (t: string) => new El(t),
+  getElementById: () => null,
+  body: new El("body"),
+}
+
+/** Key listeners registered on `globalThis`, and the games that share them. */
+type Rig = {
+  root: El
+  ui: ReturnType<typeof createInstructions>
+  /** Dispatch a key the way a browser would: capture listeners, then the game. */
+  key(type: "keydown" | "keyup", key: string): { reachedGame: boolean; defaultPrevented: boolean }
+  gameSawKeys: string[]
+  restore(): void
+}
+
+function rig(spec?: Partial<InstructionsSpec>): Rig {
+  // Keyed BY TYPE, deliberately. A single bucket dispatched to every listener
+  // regardless of type, which made the swallow reachable through its `keyup`
+  // registration even when the `keydown` one was deleted — so the test that
+  // proves keys never reach the game passed with the whole guard removed.
+  // Mutation testing caught it; nothing else would have.
+  const capture = new Map<string, Listener[]>()
+  const gameSawKeys: string[] = []
+
+  const prevDoc = (globalThis as { document?: unknown }).document
+  const prevCS = (globalThis as { getComputedStyle?: unknown }).getComputedStyle
+  ;(globalThis as { document?: unknown }).document = doc
+  ;(globalThis as { getComputedStyle?: unknown }).getComputedStyle = () => ({
+    paddingTop: "0px",
+    paddingRight: "0px",
+    paddingBottom: "0px",
+    paddingLeft: "0px",
+  })
+  doc.activeElement = null
+
+  const realAdd = globalThis.addEventListener
+  const realRemove = globalThis.removeEventListener
+  ;(globalThis as { addEventListener: unknown }).addEventListener = (
+    t: string,
+    fn: Listener,
+    useCapture?: boolean,
+  ) => {
+    if (t.startsWith("key") && useCapture === true) {
+      capture.set(t, [...(capture.get(t) ?? []), fn])
+    }
+  }
+  ;(globalThis as { removeEventListener: unknown }).removeEventListener = (
+    t: string,
+    fn: Listener,
+    useCapture?: boolean,
+  ) => {
+    if (t.startsWith("key") && useCapture === true) {
+      capture.set(t, (capture.get(t) ?? []).filter((f) => f !== fn))
+    }
+  }
+
+  const root = new El("div")
+  const ui = createInstructions(root as unknown as HTMLElement, {
+    title: "ABYSSAL BLOOM",
+    summary: ["Two polyps with the same number join into one."],
+    sections: [{ heading: "JOINING POLYPS", lines: ["Drag a polyp onto another."] }],
+    ...spec,
+  })
+
+  return {
+    root,
+    ui,
+    gameSawKeys,
+    key(type, key) {
+      let stopped = false
+      let defaultPrevented = false
+      const e = {
+        type,
+        key,
+        preventDefault() {
+          defaultPrevented = true
+        },
+        stopPropagation() {
+          stopped = true
+        },
+      }
+      for (const fn of [...(capture.get(type) ?? [])]) fn(e)
+      // The game's own listener. In every real game it is on `globalThis` too,
+      // so it only runs if the capture handler did not stop the event.
+      if (!stopped) gameSawKeys.push(key)
+      return { reachedGame: !stopped, defaultPrevented }
+    },
+    restore() {
+      ;(globalThis as { addEventListener: unknown }).addEventListener = realAdd
+      ;(globalThis as { removeEventListener: unknown }).removeEventListener = realRemove
+      ;(globalThis as { document?: unknown }).document = prevDoc
+      ;(globalThis as { getComputedStyle?: unknown }).getComputedStyle = prevCS
+    },
+  }
+}
+
+/** Every inset profile that ships: no notch, portrait notch, landscape notch. */
+const PROFILES: readonly Insets[] = [
+  { top: 0, right: 0, bottom: 0, left: 0 },
+  { top: 47, right: 0, bottom: 34, left: 0 },
+  { top: 59, right: 0, bottom: 34, left: 0 },
+  { top: 0, right: 47, bottom: 21, left: 47 },
+]
+
+// --- the clearance the whole shape exists for -------------------------------
+
+test("the sheet's ceiling clears both host corners, at every inset profile", () => {
+  // This is the defect in the founder's screenshot: a centred card at 82vh put
+  // its top edge at ~73px on a notched phone while the exit chevron occupied
+  // 60..104px, so the chevron sat on top of the title and ate two letters of
+  // it. No z-index could fix it — the chevron is in the HOST document, above
+  // the iframe.
+  for (const i of PROFILES) {
+    const top = sheetTop(i)
+    const exit = exitRect(i)
+    const help = helpRect(390, i)
+    assert.ok(
+      top >= exit.y + exit.h,
+      `sheet ceiling ${top} is inside the exit control (${exit.y}..${exit.y + exit.h}) at top inset ${i.top}`,
+    )
+    assert.ok(
+      top >= help.y + help.h,
+      `sheet ceiling ${top} is inside the help control at top inset ${i.top}`,
+    )
+  }
+})
+
+test("the ceiling grows with the notch rather than being a fixed guess", () => {
+  const flat = sheetTop({ top: 0, right: 0, bottom: 0, left: 0 })
+  const notched = sheetTop({ top: 59, right: 0, bottom: 34, left: 0 })
+  assert.equal(notched - flat, 59, "the ceiling ignored the notch")
+  assert.ok(flat >= HOST_CONTROL, "the ceiling does not even clear one control")
+})
+
+// --- the four production defects, each pinned -------------------------------
+
+test("the sheet is hidden at mount — it does not cover the game on launch", () => {
+  // #636. The scrim shipped `display:flex` and `hidden=true` at once, and a UA
+  // stylesheet's [hidden] loses to an author display. Every game, every launch.
+  const r = rig()
+  const scrim = r.root.find("dwc-scrim")
+  assert.equal(scrim.hidden, true)
+  assert.equal(r.ui.isOpen, false)
+  // And the rule that makes `hidden` win must precede the block that would
+  // otherwise beat it on source order.
+  const css = r.root.children.find((c) => c.tagName === "style")?.textContent ?? ""
+  const hiddenAt = css.indexOf(".dwc-scrim[hidden]")
+  const displayAt = css.indexOf(".dwc-scrim{")
+  assert.ok(hiddenAt >= 0 && displayAt > hiddenAt, "the [hidden] rule must come first")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the body may be scrolled with a finger", () => {
+  // #641. Games set `touch-action:none` on their root so a stray drag cannot
+  // pan the page; that also forbids the one gesture the manual needs.
+  const r = rig()
+  const css = r.root.children.find((c) => c.tagName === "style")?.textContent ?? ""
+  const body = css.slice(css.indexOf(".dwc-body{"), css.indexOf(".dwc-sum"))
+  assert.match(body, /touch-action:pan-y/, "the manual cannot be scrolled by touch")
+  assert.match(body, /overflow-y:auto/)
+  r.ui.destroy()
+  r.restore()
+})
+
+test("Escape closes the manual and the game never sees it", () => {
+  // #645. Letting Escape through so a bubble handler could close the sheet
+  // meant the game saw it too. GUILTY starts a fresh run on ANY key, so a child
+  // who died, opened the rules and pressed Escape lost the wave, the lives, the
+  // score and the best combo to the act of reading.
+  const r = rig()
+  r.ui.open()
+  const out = r.key("keydown", "Escape")
+  assert.equal(r.ui.isOpen, false, "Escape did not close the manual")
+  assert.equal(out.reachedGame, false, "the game saw Escape")
+  assert.deepEqual(r.gameSawKeys, [])
+  r.ui.destroy()
+  r.restore()
+})
+
+test("every other key is swallowed while the manual is open", () => {
+  const r = rig()
+  r.ui.open()
+  for (const k of [" ", "Enter", "a", "ArrowLeft", "p"]) r.key("keydown", k)
+  assert.deepEqual(r.gameSawKeys, [], `the game saw ${r.gameSawKeys.join(",")} behind the manual`)
+  r.ui.destroy()
+  r.restore()
+})
+
+test("and NOTHING is swallowed once it is closed — a gate stuck shut is the same bug", () => {
+  const r = rig()
+  r.ui.open()
+  r.ui.close()
+  for (const k of [" ", "Escape", "a"]) r.key("keydown", k)
+  assert.deepEqual(r.gameSawKeys, [" ", "Escape", "a"], "the game was starved after the manual closed")
+  r.ui.destroy()
+  r.restore()
+})
+
+// --- the drawer itself ------------------------------------------------------
+
+test("a drag past the threshold dismisses the sheet", () => {
+  const r = rig()
+  r.ui.open()
+  const grab = r.root.find("dwc-grab")
+  grab.fire("pointerdown", { button: 0, clientY: 400, pointerId: 1, timeStamp: 0 })
+  grab.fire("pointermove", { clientY: 520, pointerId: 1, timeStamp: 400 })
+  grab.fire("pointerup", { clientY: 520, pointerId: 1, timeStamp: 400 })
+  assert.equal(r.ui.isOpen, false, "a 120px drag did not dismiss the sheet")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("a short slow drag springs back instead of dismissing", () => {
+  // A sheet that flies away on a 20px twitch is a sheet a child cannot read.
+  const r = rig()
+  r.ui.open()
+  const grab = r.root.find("dwc-grab")
+  grab.fire("pointerdown", { button: 0, clientY: 400, pointerId: 1, timeStamp: 0 })
+  grab.fire("pointermove", { clientY: 420, pointerId: 1, timeStamp: 500 })
+  grab.fire("pointerup", { clientY: 420, pointerId: 1, timeStamp: 500 })
+  assert.equal(r.ui.isOpen, true, "a 20px drag dismissed the sheet")
+  const sheet = r.root.find("dwc-sheet")
+  assert.equal(sheet.style.transform, "", "the sheet was left displaced")
+  assert.match(sheet.className, /\bdwc-settle\b/, "the sheet snapped back without animating")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("a fast flick dismisses even when it is short", () => {
+  const r = rig()
+  r.ui.open()
+  const grab = r.root.find("dwc-grab")
+  grab.fire("pointerdown", { button: 0, clientY: 400, pointerId: 1, timeStamp: 0 })
+  grab.fire("pointermove", { clientY: 460, pointerId: 1, timeStamp: 40 })
+  grab.fire("pointerup", { clientY: 460, pointerId: 1, timeStamp: 40 })
+  assert.equal(r.ui.isOpen, false, "a 60px flick in 40ms did not dismiss")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("dragging upward never lifts the sheet into the host chrome", () => {
+  const r = rig()
+  r.ui.open()
+  const grab = r.root.find("dwc-grab")
+  const sheet = r.root.find("dwc-sheet")
+  grab.fire("pointerdown", { button: 0, clientY: 400, pointerId: 1, timeStamp: 0 })
+  grab.fire("pointermove", { clientY: 120, pointerId: 1, timeStamp: 100 })
+  assert.equal(sheet.style.transform, "translateY(0px)", "the sheet moved up into the chrome")
+  grab.fire("pointerup", { clientY: 120, pointerId: 1, timeStamp: 100 })
+  assert.equal(r.ui.isOpen, true)
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the way out is pinned, not buried at the end of the manual", () => {
+  // In the centred card the PLAY button was the last child of the scrolling
+  // content, so a game with five sections made a child scroll the entire manual
+  // to leave it.
+  const r = rig()
+  const sheet = r.root.find("dwc-sheet")
+  const kinds = sheet.children.map((c) => c.className)
+  assert.deepEqual(kinds, ["dwc-grab", "dwc-head", "dwc-body", "dwc-foot"])
+  const foot = r.root.find("dwc-foot")
+  assert.ok(foot.has("dwc-close"), "PLAY is not in the pinned footer")
+  const body = r.root.find("dwc-body")
+  assert.equal(body.has("dwc-close"), false, "PLAY is inside the scrolling body")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the grab handle is a 44px target and announces itself", () => {
+  // Standing rule: a 44px wrapper hit zone around the pill, never a bare pill.
+  const r = rig()
+  const grab = r.root.find("dwc-grab")
+  assert.equal(grab.getAttribute("role"), "button")
+  assert.ok((grab.getAttribute("aria-label") ?? "").length > 0)
+  assert.equal(grab.tabIndex, 0, "the handle cannot be reached by keyboard")
+  const css = r.root.children.find((c) => c.tagName === "style")?.textContent ?? ""
+  assert.match(css.slice(css.indexOf(".dwc-grab{")), /^\.dwc-grab\{[^}]*height:44px/)
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the sheet is capped from the measured insets, not from a vh guess", () => {
+  const notch: Insets = { top: 59, right: 0, bottom: 34, left: 0 }
+  setHostInsets(notch)
+  const r = rig()
+  r.ui.open()
+  const sheet = r.root.find("dwc-sheet")
+  const foot = r.root.find("dwc-foot")
+  assert.equal(sheet.style.maxHeight, `calc(100% - ${sheetTop(notch)}px)`)
+  assert.equal(foot.style.paddingBottom, "calc(.7rem + 34px)", "the footer sits under the home indicator")
+  r.ui.destroy()
+  r.restore()
+  setHostInsets(null)
+})
+
+test("the help control sits exactly where hostChrome says it does", () => {
+  // Games assert their HUD clears `helpRect()`. A button three pixels off that
+  // rect makes every one of those tests a near-miss rather than a proof.
+  setHostInsets({ top: 47, right: 0, bottom: 34, left: 0 })
+  const r = rig()
+  const help = r.root.find("dwc-help")
+  const want = helpRect(390, { top: 47, right: 0, bottom: 34, left: 0 })
+  assert.equal(help.style.top, `${want.y}px`)
+  r.ui.destroy()
+  r.restore()
+  setHostInsets(null)
+})
+
+test("close fires onClose so the game can resume, and open/close are idempotent", () => {
+  let closes = 0
+  const r = rig({ onClose: () => (closes += 1) })
+  r.ui.open()
+  r.ui.open()
+  r.ui.close()
+  r.ui.close()
+  assert.equal(closes, 1, "onClose fired for a close that did not happen")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("destroy takes every listener with it", () => {
+  const r = rig()
+  r.ui.open()
+  r.ui.destroy()
+  // The game must get its keyboard back the moment the pack unmounts.
+  r.key("keydown", "Escape")
+  assert.deepEqual(r.gameSawKeys, ["Escape"], "a key listener outlived the manual")
+  assert.equal(r.root.has("dwc-scrim"), false, "the sheet outlived the manual")
+  assert.equal(r.root.has("dwc-help"), false, "the help control outlived the manual")
+  r.restore()
+})

--- a/dynawalla/packs/shared/game-chrome/instructions.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.ts
@@ -22,9 +22,22 @@
  * The manual stays reachable *during* play, not only before it. A child who
  * needs the rules needs them at the moment they are stuck, which is never the
  * title screen.
+ *
+ * **Why a bottom sheet and not a centred card.** The first version centred a
+ * card at `max-height:82vh`. On a notched phone that puts its top edge around
+ * 73px — and the host's exit chevron occupies 60px to 104px. They collided, and
+ * the chevron ate the first two letters of the title in every game with a long
+ * manual. That is not a z-index bug and no stacking order can fix it: the exit
+ * control lives in the HOST document, above the iframe, so a pack cannot draw
+ * over it and must instead lay out clear of it.
+ *
+ * A sheet rises from the bottom and is capped so its top edge can never reach
+ * the host's corners. The clearance is arithmetic, not judgement, and
+ * `sheetTop()` exposes it so a test can assert it at any viewport.
  */
 
-import { safeInsets, onInsetsChange } from "./insets.ts"
+import { safeInsets, onInsetsChange, type Insets } from "./insets.ts"
+import { HOST_CONTROL, HOST_MARGIN, HOST_PROGRESS_H } from "./hostChrome.ts"
 
 export type Section = { heading: string; lines: readonly string[] }
 
@@ -53,12 +66,36 @@ export type Instructions = {
 
 const FONT = "system-ui,-apple-system,'Segoe UI',sans-serif"
 
+/**
+ * The highest the sheet's top edge may ever go, in CSS pixels from the top.
+ *
+ * Everything above this line belongs to the host: the progress hairline, the
+ * exit chevron top-left and the how-to-play control top-right. The sheet stops
+ * one margin below them, so the two never share a pixel however long the
+ * manual is.
+ *
+ * Exported because "it clears the chrome" is a claim, and a claim in a
+ * children's product should be assertable at every viewport rather than
+ * eyeballed on one phone.
+ */
+export function sheetTop(insets: Insets = safeInsets()): number {
+  return insets.top + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + HOST_MARGIN
+}
+
+/** Drag further than this, or flick faster, and the sheet goes away. */
+const DISMISS_PX = 96
+const DISMISS_VELOCITY = 0.5
+
 function styleSheet(reduced: boolean): string {
   // Motion is a branch, not a degradation: reduced motion still gets a
-  // cross-fade so the panel does not appear without explanation, it just does
+  // cross-fade so the sheet does not appear without explanation, it just does
   // not travel. `EXPERIENCE_DESIGN.md` is explicit that switching animation off
   // entirely is the wrong reading.
-  const enter = reduced ? "dwc-fade 160ms ease-out" : "dwc-rise 220ms cubic-bezier(.2,.8,.2,1)"
+  const rise = reduced
+    ? "dwc-fade 160ms ease-out both"
+    : // The iOS sheet curve. It leaves fast and lands slowly, which is what
+      // makes a panel feel thrown rather than dragged along by the machine.
+      "dwc-rise 380ms cubic-bezier(.32,.72,0,1) both"
   return `
 /* The hidden attribute must win. A UA stylesheet's [hidden]{display:none} is
    origin-weaker than any author display, so without this rule the scrim below
@@ -67,45 +104,86 @@ function styleSheet(reduced: boolean): string {
    UA. This rule must also come BEFORE the .dwc-scrim block, or the later
    display:flex wins on source order. */
 .dwc-scrim[hidden]{display:none}
-.dwc-scrim{position:absolute;inset:0;z-index:40;display:flex;align-items:center;justify-content:center;
-  background:rgba(4,6,12,.72);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
-  font-family:${FONT};color:#f2eee4;overscroll-behavior:contain}
-.dwc-panel{position:relative;max-width:min(46rem,92vw);max-height:82vh;overflow-y:auto;overscroll-behavior:contain;
+.dwc-scrim{position:absolute;inset:0;z-index:40;display:flex;align-items:flex-end;justify-content:center;
+  background:rgba(4,6,12,.66);backdrop-filter:blur(7px);-webkit-backdrop-filter:blur(7px);
+  font-family:${FONT};color:#f2eee4;overscroll-behavior:contain;
+  animation:dwc-fade 240ms ease-out both}
+
+.dwc-sheet{position:relative;display:flex;flex-direction:column;
+  width:min(46rem,100%);
+  /* max-height is written from JS on open and on every inset change: it is the
+     height that keeps the sheet's top edge below the host's two corner
+     controls; see sheetTop(). The 82% here is only what a sheet gets before the
+     first measurement. */
+  max-height:82%;
+  border-radius:26px 26px 0 0;
+  border:1px solid rgba(255,255,255,.13);border-bottom:0;
+  background:linear-gradient(#161d2b,#0c1017);
+  box-shadow:0 -18px 60px rgba(0,0,0,.6);
+  animation:${rise};
+  will-change:transform}
+/* Suppressed while a finger is down, so the drag tracks 1:1 instead of easing
+   towards where the finger was a frame ago. */
+.dwc-sheet.dwc-drag{animation:none;transition:none}
+.dwc-sheet.dwc-settle{animation:none;transition:transform 260ms cubic-bezier(.32,.72,0,1)}
+
+/* The grab area is 44px of hit zone around a 40x5 pill. A bare pill is a 5px
+   target, which no child hits and no adult enjoys missing. */
+.dwc-grab{flex:none;height:44px;display:flex;align-items:center;justify-content:center;
+  cursor:grab;touch-action:none;-webkit-tap-highlight-color:transparent}
+.dwc-grab:active{cursor:grabbing}
+.dwc-pill{width:40px;height:5px;border-radius:3px;background:rgba(255,255,255,.3)}
+.dwc-grab:focus-visible{outline:3px solid #f3d089;outline-offset:-6px;border-radius:26px 26px 0 0}
+
+.dwc-head{flex:none;padding:0 clamp(20px,5vw,32px) .55rem;touch-action:none}
+.dwc-title{margin:0;font-size:clamp(1.3rem,4.2vw,1.85rem);font-weight:800;letter-spacing:-.02em}
+
+.dwc-body{flex:1 1 auto;min-height:0;overflow-y:auto;overscroll-behavior:contain;
   /* Every game sets touch-action:none on its root so a stray drag cannot pan
-     the page. That also forbids the finger drag this panel needs: overflow-y
+     the page. That also forbids the finger drag this body needs: overflow-y
      was live but unusable, and on a 320x568 phone about a third of the manual
      sat below the fold with no way to reach it. pan-y re-permits exactly the
      one gesture, and nothing else. */
-  touch-action:pan-y;
-  -webkit-overflow-scrolling:touch;border-radius:18px;border:1px solid rgba(255,255,255,.14);
-  background:linear-gradient(#141a26,#0d111a);box-shadow:0 24px 70px rgba(0,0,0,.6);
-  padding:clamp(20px,4vw,34px);animation:${enter}}
-.dwc-title{margin:0 0 .5rem;font-size:clamp(1.35rem,4.4vw,2rem);font-weight:800;letter-spacing:-.02em}
-.dwc-sum{margin:0 0 1.25rem;font-size:clamp(1rem,2.9vw,1.15rem);line-height:1.55;color:#d9e2f0}
-.dwc-sum p{margin:.3rem 0}
-.dwc-sec{margin:1.15rem 0 0}
-.dwc-h{margin:0 0 .35rem;font-size:.78rem;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:#8fa3c4}
-.dwc-l{margin:0;padding-left:1.1rem;line-height:1.6;font-size:clamp(.95rem,2.6vw,1.05rem)}
-.dwc-l li{margin:.28rem 0}
-.dwc-close{margin-top:1.6rem;width:100%;min-height:52px;border:0;border-radius:12px;cursor:pointer;
-  font:800 1rem/1 ${FONT};letter-spacing:.03em;color:#0b1020;background:#f3d089}
+  touch-action:pan-y;-webkit-overflow-scrolling:touch;
+  padding:0 clamp(20px,5vw,32px);
+  padding-bottom:.5rem}
+.dwc-sum{margin:0 0 1.1rem;font-size:clamp(1rem,2.9vw,1.12rem);line-height:1.55;color:#dbe4f2}
+.dwc-sum p{margin:.32rem 0}
+.dwc-sec{margin:1.1rem 0 0}
+.dwc-h{margin:0 0 .35rem;font-size:.76rem;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:#8fa3c4}
+.dwc-l{margin:0;padding-left:1.1rem;line-height:1.6;font-size:clamp(.95rem,2.6vw,1.04rem)}
+.dwc-l li{margin:.3rem 0}
+
+/* The button is pinned, not appended. In the centred card it lived at the foot
+   of the content, so in a game with five sections a child had to read or scroll
+   the whole manual to find the way out of it. */
+.dwc-foot{flex:none;position:relative;padding:.7rem clamp(20px,5vw,32px)}
+/* Fades the text under the footer rather than guillotining it, so it stays
+   visible that the manual continues. */
+.dwc-foot::before{content:"";position:absolute;left:0;right:0;bottom:100%;height:28px;pointer-events:none;
+  background:linear-gradient(rgba(12,16,23,0),#0c1017)}
+.dwc-close{width:100%;min-height:52px;border:0;border-radius:14px;cursor:pointer;
+  font:800 1rem/1 ${FONT};letter-spacing:.03em;color:#0b1020;background:#f3d089;
+  -webkit-tap-highlight-color:transparent}
 .dwc-close:focus-visible{outline:3px solid #f3d089;outline-offset:3px}
-.dwc-help{position:absolute;z-index:30;min-width:44px;min-height:44px;border-radius:50%;
+
+.dwc-help{position:absolute;z-index:30;min-width:${HOST_CONTROL}px;min-height:${HOST_CONTROL}px;border-radius:50%;
   border:1px solid rgba(255,255,255,.2);background:rgba(10,14,22,.62);color:#f2eee4;
   font:800 1.05rem/1 ${FONT};cursor:pointer;display:flex;align-items:center;justify-content:center}
 .dwc-help:focus-visible{outline:3px solid #f3d089;outline-offset:2px}
-@keyframes dwc-rise{from{opacity:0;transform:translateY(14px) scale(.985)}to{opacity:1;transform:none}}
+
+@keyframes dwc-rise{from{transform:translateY(100%)}to{transform:none}}
 @keyframes dwc-fade{from{opacity:0}to{opacity:1}}
-@media (prefers-reduced-motion:reduce){.dwc-panel{animation:dwc-fade 160ms ease-out}}
+@media (prefers-reduced-motion:reduce){.dwc-sheet{animation:dwc-fade 160ms ease-out both}}
 `
 }
 
 /**
  * Mount the instructions surface into `root`.
  *
- * Adds a persistent help button positioned inside the safe area, and a panel it
- * opens. The button is 44px minimum in both axes — the smallest target a child
- * reliably hits, and the platform floor.
+ * Adds a persistent help button positioned inside the safe area, and a sheet it
+ * opens. The button is `HOST_CONTROL` in both axes — the smallest target a
+ * child reliably hits, and the platform floor.
  */
 export function createInstructions(root: HTMLElement, spec: InstructionsSpec): Instructions {
   const reduced = spec.reducedMotion === true
@@ -123,17 +201,42 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
   scrim.className = "dwc-scrim"
   scrim.hidden = true
 
-  const panel = document.createElement("div")
-  panel.className = "dwc-panel"
-  panel.setAttribute("role", "dialog")
-  panel.setAttribute("aria-modal", "true")
-  panel.setAttribute("aria-label", `How to play ${spec.title}`)
-  panel.tabIndex = -1
+  const sheet = document.createElement("div")
+  sheet.className = "dwc-sheet"
+  // State goes on `className`, never `classList`. The 27 games mount against
+  // hand-rolled fake elements that expose `className` and nothing else, so a
+  // `classList.remove` here is a TypeError in FOUNDRY and LATTICE the moment a
+  // child opens the manual. The module must speak only the vocabulary its
+  // adopters implement — every defect this module has shipped came from
+  // assuming a richer environment than the one it actually runs in.
+  const sheetClass = (mod?: "dwc-drag" | "dwc-settle"): void => {
+    sheet.className = mod ? `dwc-sheet ${mod}` : "dwc-sheet"
+  }
+  sheet.setAttribute("role", "dialog")
+  sheet.setAttribute("aria-modal", "true")
+  sheet.setAttribute("aria-label", `How to play ${spec.title}`)
+  sheet.tabIndex = -1
 
+  const grab = document.createElement("div")
+  grab.className = "dwc-grab"
+  // It is a control: it dismisses the sheet by drag. Announce it as one rather
+  // than leaving a silent div a screen reader walks straight past.
+  grab.setAttribute("role", "button")
+  grab.setAttribute("aria-label", "Close how to play")
+  grab.tabIndex = 0
+  const pill = document.createElement("div")
+  pill.className = "dwc-pill"
+  grab.appendChild(pill)
+
+  const head = document.createElement("div")
+  head.className = "dwc-head"
   const h = document.createElement("h2")
   h.className = "dwc-title"
   h.textContent = spec.title
-  panel.appendChild(h)
+  head.appendChild(h)
+
+  const body = document.createElement("div")
+  body.className = "dwc-body"
 
   const sum = document.createElement("div")
   sum.className = "dwc-sum"
@@ -142,7 +245,7 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     p.textContent = line
     sum.appendChild(p)
   }
-  panel.appendChild(sum)
+  body.appendChild(sum)
 
   for (const sec of spec.sections ?? []) {
     const wrap = document.createElement("section")
@@ -158,43 +261,68 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
       ul.appendChild(li)
     }
     wrap.append(sh, ul)
-    panel.appendChild(wrap)
+    body.appendChild(wrap)
   }
 
+  const foot = document.createElement("div")
+  foot.className = "dwc-foot"
   const close = document.createElement("button")
   close.type = "button"
   close.className = "dwc-close"
   close.textContent = "PLAY"
-  panel.appendChild(close)
-  scrim.appendChild(panel)
+  foot.appendChild(close)
+
+  sheet.append(grab, head, body, foot)
+  scrim.appendChild(sheet)
   root.append(help, scrim)
 
-  // The help button sits inside the safe area, not merely inside the canvas.
-  // Top-right is the one corner no game here puts a primary control in.
+  // The help button sits at exactly the rect `hostChrome.helpRect()` reports —
+  // games lay out against that rect, so a button three pixels off it makes
+  // every one of those clearance tests a near-miss.
+  // Plain property assignment, not `style.setProperty` and a CSS custom
+  // property. The indirection bought nothing and cost four games: their
+  // mount-level test harnesses fake `style` as an object with named fields, so
+  // `setProperty` threw and BEAM, COUNTERWEIGHT, FOUNDRY and LATTICE all failed
+  // to render at every viewport. `help.style.top` was already the idiom that
+  // works in all 27 harnesses; there was no reason to invent a second one.
   const place = (): void => {
     const i = safeInsets()
-    help.style.top = `${i.top + 10}px`
-    help.style.right = `${i.right + 10}px`
+    help.style.top = `${i.top + HOST_PROGRESS_H + HOST_MARGIN}px`
+    help.style.right = `${i.right + HOST_MARGIN}px`
+    sheet.style.maxHeight = `calc(100% - ${sheetTop(i)}px)`
+    foot.style.paddingBottom = `calc(.7rem + ${i.bottom}px)`
   }
   place()
   const stopInsets = onInsetsChange(place)
 
   let open = false
   let restore: HTMLElement | null = null
+  let dragging = false
+  let startY = 0
+  let startAt = 0
+  let dy = 0
 
   const doOpen = (): void => {
     if (open) return
     open = true
     restore = (document.activeElement as HTMLElement) ?? null
+    place()
+    sheetClass()
+    sheet.style.transform = ""
+    scrim.style.opacity = ""
     scrim.hidden = false
     help.setAttribute("aria-expanded", "true")
-    panel.scrollTop = 0
-    panel.focus()
+    body.scrollTop = 0
+    sheet.focus()
   }
 
   const doClose = (): void => {
     if (!open) return
     open = false
+    dragging = false
+    sheetClass()
+    sheet.style.transform = ""
+    scrim.style.opacity = ""
     scrim.hidden = true
     help.setAttribute("aria-expanded", "false")
     restore?.focus?.()
@@ -202,13 +330,55 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     spec.onClose?.()
   }
 
-  // A tap on the scrim closes; a tap inside the panel must not. Children tap
+  // A tap on the scrim closes; a tap inside the sheet must not. Children tap
   // the background constantly and being thrown out of the rules mid-read is
   // worse than having to find the button.
   const onScrim = (e: Event): void => {
     if (e.target === scrim) doClose()
   }
-  // While the panel is up, the game must not see a key. The panel's own div is
+
+  // ---- drag to dismiss -----------------------------------------------------
+  // Only from the grab area and the title row. Dragging from the body would
+  // fight the scroll it needs, and a manual that sometimes scrolls and
+  // sometimes flies away is worse than one that only scrolls.
+  const onDown = (e: PointerEvent): void => {
+    if (!open || e.button !== 0) return
+    dragging = true
+    startY = e.clientY
+    startAt = e.timeStamp
+    dy = 0
+    sheetClass("dwc-drag")
+    ;(e.currentTarget as Element).setPointerCapture?.(e.pointerId)
+  }
+
+  const onMove = (e: PointerEvent): void => {
+    if (!dragging) return
+    // Down only. An upward drag would otherwise lift the sheet into the host
+    // chrome — the exact collision this shape exists to prevent.
+    dy = Math.max(0, e.clientY - startY)
+    sheet.style.transform = `translateY(${dy}px)`
+    const h = sheet.offsetHeight || 1
+    scrim.style.opacity = String(Math.max(0.15, 1 - dy / h))
+  }
+
+  const onUp = (e: PointerEvent): void => {
+    if (!dragging) return
+    dragging = false
+    ;(e.currentTarget as Element).releasePointerCapture?.(e.pointerId)
+    const ms = Math.max(1, e.timeStamp - startAt)
+    sheetClass()
+    if (dy > DISMISS_PX || dy / ms > DISMISS_VELOCITY) {
+      doClose()
+      return
+    }
+    // Not far enough: put it back, visibly, so the gesture reads as refused
+    // rather than ignored.
+    sheetClass("dwc-settle")
+    sheet.style.transform = ""
+    scrim.style.opacity = ""
+  }
+
+  // While the sheet is up, the game must not see a key. The sheet's own div is
   // `tabIndex=-1` and consumes nothing, so a Space or Enter meant to dismiss the
   // manual fell straight through to whatever the game bound on `globalThis` —
   // in one game that fired a shear, reported a wrong answer and cost the child
@@ -217,12 +387,20 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
   const swallow = (e: KeyboardEvent): void => {
     if (!open) return
     // Escape is handled HERE, in capture, and stopped like every other key.
-    // Letting it through so the bubble handler could close the panel meant the
+    // Letting it through so a bubble handler could close the sheet meant the
     // game saw it too: one game starts a fresh run on any key, so a child who
     // opened the rules after dying and pressed Escape to close them lost their
     // score, combo and best combo to the act of reading. preventDefault was
     // never enough — it stops the browser's default, not another listener.
     if (e.key === "Escape") {
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.type === "keydown") doClose()
+      return
+    }
+    // The grab handle is focusable and announces itself as a button, so it must
+    // answer a keyboard the way it answers a finger.
+    if ((e.key === "Enter" || e.key === " ") && document.activeElement === grab) {
       e.preventDefault()
       e.stopPropagation()
       if (e.type === "keydown") doClose()
@@ -240,9 +418,16 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
   globalThis.addEventListener("keydown", swallow, true)
   globalThis.addEventListener("keyup", swallow, true)
 
+  const draggers = [grab, head]
   help.addEventListener("click", doOpen)
   close.addEventListener("click", doClose)
   scrim.addEventListener("pointerdown", onScrim)
+  for (const el of draggers) {
+    el.addEventListener("pointerdown", onDown)
+    el.addEventListener("pointermove", onMove)
+    el.addEventListener("pointerup", onUp)
+    el.addEventListener("pointercancel", onUp)
+  }
 
   return {
     open: doOpen,
@@ -257,6 +442,12 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
       help.removeEventListener("click", doOpen)
       close.removeEventListener("click", doClose)
       scrim.removeEventListener("pointerdown", onScrim)
+      for (const el of draggers) {
+        el.removeEventListener("pointerdown", onDown)
+        el.removeEventListener("pointermove", onMove)
+        el.removeEventListener("pointerup", onUp)
+        el.removeEventListener("pointercancel", onUp)
+      }
       help.remove()
       scrim.remove()
       style.remove()

--- a/dynawalla/packs/shared/game-chrome/package-lock.json
+++ b/dynawalla/packs/shared/game-chrome/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/game-chrome",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-chrome",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/packs/shared/game-chrome/package.json
+++ b/dynawalla/packs/shared/game-chrome/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dynawalla/game-chrome",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Safe-area insets, the two host-chrome corners, and the how-to-play sheet — the UI contract every dynawalla game shares. Exists so 27 games do not each solve the notch alone.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"*.test.ts\"",
+    "tsc": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/packs/shared/game-chrome/tsconfig.json
+++ b/dynawalla/packs/shared/game-chrome/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  /* The same strictness the app and the SDK are held to, so a type that passes
+     here cannot fail when a game imports the identical file by relative path —
+     which is how all 27 of them consume this module. `erasableSyntaxOnly` keeps
+     every file runnable under `node --experimental-strip-types`. */
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
Founder opened ABYSSAL BLOOM and the host's exit chevron was sitting on the
title, eating the first two letters of "ABYSSAL".

**Not a z-index bug.** No stacking order can fix it — the exit control lives in
the HOST document, above the iframe, so a pack cannot draw over it and must lay
out clear of it. A centred card at `max-height:82vh` puts its top edge near 73px
on a notched phone; the chevron occupies 60–104px. It collided in every game
whose manual was long enough to fill the card.

## The drawer

A bottom sheet, capped so its top edge can never reach the host's corners.
`sheetTop()` is that clearance as arithmetic rather than judgement, exported so
a test can assert it at any viewport instead of it being eyeballed on one phone.

- 44px grab area around the pill — never a bare 5px target
- drag and flick to dismiss, spring back when the gesture is refused
- **PLAY pinned in a footer**, not buried at the end of the content. In a game
  with five sections a child had to scroll the entire manual to find the way out
- iOS sheet curve; reduced motion still cross-fades rather than appearing

## The actual content of this PR: the module had no tests

It has shipped four production defects — #636 the sheet covering every game at
launch, #640 insets reading zero inside the pack frame, #641 no finger scroll,
#645 Escape leaking into the game — and **every one was found by a game adopting
it, never here.**

`insets.test.ts` sat beside it and **CI never ran it**: the `shared_ts` filter is
`^(shared/|corpan/packs/shared/)`, which does not match `dynawalla/packs/shared/`,
and no game's test glob reaches outside its own directory.

This adds `instructions.test.ts` (17 tests — one per shipped defect, one per
drawer behaviour) and a CI step that globs `packs/shared/*/package.json` and runs
them. **29 tests now execute that executed nowhere before.**

## Mutation-tested, not trusted

Eight fixes deleted one at a time; each produced the failure it should:

| mutation | fails |
|---|---|
| `sheetTop` ignores the notch | 1, 2 |
| `[hidden]` rule removed | 3 |
| Escape allowed through | 5 |
| body loses `touch-action:pan-y` | 4 |
| upward drag unclamped | 11 |
| PLAY back in the scrolling body | 12 |
| key swallow removed | 5, 6 |
| grab shrinks to a bare pill | 13 |

That found **a vacuous test of my own**: with the whole key swallow removed,
nothing failed — the rig dispatched capture listeners without checking event
type, so the `keyup` registration kept the handler reachable after the `keydown`
one was deleted. Fixed.

## Two integration defects, both the same mistake

The module reached for `style.setProperty`, then `classList`. The 27 games mount
against hand-rolled fake elements that implement **neither**. BEAM,
COUNTERWEIGHT, FOUNDRY and LATTICE stopped rendering at every viewport while
this module's own tests stayed green — because **my test double was richer than
the real callers**, which is not a safety net but a blindfold.

Fixed in the module (plain `className`, plain `style.x =`), not by upgrading 27
harnesses. The rig is now cut back to exactly the vocabulary the games offer, so
it cannot happen a third time.

## Verification

29/29 here, 5 runs out of 5. All 27 games pass `test` and `tsc`.

Not covered: real layout — whether the footer is genuinely pinned and the body
genuinely scrolls need a browser. Every invariant that is arithmetic or
behaviour is covered, which is where all four shipped defects lived.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb