### PR TITLE
fix(dynawalla/games/merge-idle): the vents stop painting over the reef, the rail stops moving it, and the score is readable again

### DIFF
--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -50,7 +50,6 @@ import {
   flowAfter,
   growCost,
   offlineHaul,
-
   reefTrickle,
   SWELL_PERIOD_MS,
   targetStepFor,
@@ -77,8 +76,9 @@ import { Floaters } from './fx/floaters.ts'
 import { Particles, Shockwaves } from './fx/particles.ts'
 import { approach, ease, Punch } from './fx/shake.ts'
 import { CHALK, DANGER, hex, lift, rampAt, TIDE } from './render/palette.ts'
-import { cellAtPoint, cellCentre, Renderer } from './render/renderer.ts'
+import { cellAtPoint, cellCentre, Renderer, shelfCap, ventCap, ventRects } from './render/renderer.ts'
 import { chromeLayout, stageAreaFor } from './ui/chrome.ts'
+import { actionList } from './ui/actions.ts'
 import { Hud, type Action } from './ui/hud.ts'
 
 const MAX_ROWS = 9
@@ -327,29 +327,32 @@ class Game {
   }
 
   private layoutVents(): void {
-    const l = this.renderer.layout
-    const strip = l.ventStrip
-    const n = Math.max(1, this.s.vents.length)
-    if (l.ventColumn) {
-      const gap = Math.max(8, Math.min(16, strip.h * 0.02))
-      const h = Math.min((strip.h - gap * (n - 1)) / n, 190)
-      const top = strip.y + (strip.h - (h * n + gap * (n - 1))) / 2
-      this.s.vents.forEach((v, i) => {
-        v.rect = { x: strip.x, y: top + i * (h + gap), w: strip.w, h }
-      })
-      return
-    }
-    const gap = Math.max(6, Math.min(12, strip.w * 0.02))
-    const w = (strip.w - gap * (n - 1)) / n
+    const rects = ventRects(this.renderer.layout, this.s.vents.length)
     this.s.vents.forEach((v, i) => {
-      v.rect = { x: strip.x + i * (w + gap), y: strip.y, w, h: strip.h }
+      const r = rects[i]
+      if (r) v.rect = r
     })
   }
 
   private get ventCap(): number {
-    const l = this.renderer.layout
-    if (l.ventColumn) return Math.max(2, Math.min(5, Math.floor(l.ventStrip.h / 150)))
-    return l.w < 480 ? 2 : l.w < 760 ? 3 : l.w < 1100 ? 4 : 5
+    return ventCap(this.renderer.layout)
+  }
+
+  /**
+   * How far DEEPEN may grow the shelf.
+   *
+   * The designed ceiling, narrowed by what this particular glass can actually
+   * draw legibly above the vent band — a 9-row shelf does not fit a small
+   * notched phone, and growing into one used to mean the bottom row was drawn
+   * over the vents. Capping growth is the reflow nobody notices; the collision
+   * was one the founder photographed.
+   */
+  private get shelfLimit(): { maxCols: number; maxRows: number } {
+    const cap = shelfCap(this.renderer.layout)
+    return {
+      maxCols: Math.max(START_COLS, Math.min(this.renderer.layout.w < 380 ? 6 : 7, cap.cols)),
+      maxRows: Math.max(START_ROWS, Math.min(MAX_ROWS, cap.rows)),
+    }
   }
 
   /* --------------------------------------------------------------- persist */
@@ -1036,11 +1039,15 @@ class Game {
       this.audio.erupt(2)
     } else if (id === 'deepen') {
       const cost = growCost(s.grows + 1)
-      const maxCols = this.renderer.layout.w < 380 ? 6 : 7
+      const { maxCols, maxRows } = this.shelfLimit
       if (s.essence < cost) return
       const nextCols = s.board.cols < maxCols ? s.board.cols + 1 : s.board.cols
-      const nextRows = nextCols === s.board.cols ? Math.min(MAX_ROWS, s.board.rows + 1) : s.board.rows
-      if (nextCols === s.board.cols && nextRows === s.board.rows) return
+      const nextRows = nextCols === s.board.cols ? Math.min(maxRows, s.board.rows + 1) : s.board.rows
+      // `maxRows` is now what this glass can DRAW, so it can sit below the
+      // shelf a child already has — a save carried over from a tablet, or a
+      // rotation. `grow` refuses to shrink, so without this the cost would be
+      // taken, `grows` would rise and nothing would happen.
+      if (nextCols <= s.board.cols && nextRows <= s.board.rows) return
       s.essence -= cost
       s.grows++
       grow(s.board, nextCols, nextRows)
@@ -1301,55 +1308,19 @@ class Game {
 
   private actions(): Action[] {
     const s = this.s
-    const up = upwellCost(s.upwells)
-    const aw = ventCost(s.vents.length + 1)
-    const dp = growCost(s.grows + 1)
-    const oc = 10 ** (3 + s.overcharges) * 2
-    const maxCols = this.renderer.layout.w < 380 ? 6 : 7
-    const canGrow = s.board.cols < maxCols || s.board.rows < MAX_ROWS
-    const full = emptyCells(s.board).length === 0
-    return [
-      {
-        id: 'upwell',
-        label: 'UPWELL',
-        cost: up,
-        hint: fmtCompact(up),
-        enabled: s.essence >= up && !full,
-        visible: true,
-      },
-      {
-        id: 'awaken',
-        label: 'AWAKEN',
-        cost: aw,
-        hint: s.vents.length >= this.ventCap ? 'max' : fmtCompact(aw),
-        enabled: s.essence >= aw && s.vents.length < this.ventCap,
-        visible: true,
-      },
-      {
-        id: 'deepen',
-        label: 'DEEPEN',
-        cost: dp,
-        hint: canGrow ? fmtCompact(dp) : 'max',
-        enabled: s.essence >= dp && canGrow,
-        visible: true,
-      },
-      {
-        id: 'overcharge',
-        label: 'OVERCHARGE',
-        cost: oc,
-        hint: fmtCompact(oc),
-        enabled: s.essence >= oc,
-        visible: true,
-      },
-      {
-        id: 'purge',
-        label: 'DISSOLVE',
-        cost: 0,
-        hint: 'free',
-        enabled: true,
-        visible: full || s.crowded,
-        urgent: s.crowded,
-      },
-    ]
+    return actionList({
+      essence: s.essence,
+      upwells: s.upwells,
+      grows: s.grows,
+      overcharges: s.overcharges,
+      vents: s.vents.length,
+      ventCap: this.ventCap,
+      cols: s.board.cols,
+      rows: s.board.rows,
+      maxCols: this.shelfLimit.maxCols,
+      maxRows: this.shelfLimit.maxRows,
+      full: emptyCells(s.board).length === 0,
+      crowded: s.crowded,
+    })
   }
 }

--- a/dynawalla/games/merge-idle/src/render/layout.test.ts
+++ b/dynawalla/games/merge-idle/src/render/layout.test.ts
@@ -1,0 +1,185 @@
+// THE SHELF AND THE VENTS ARE TWO PLACES, NOT ONE PLACE TWICE.
+//
+// From a device photo: the four vent number-pills were painted along the bottom
+// edge of the reef, over the last row of polyps, whose digits a child then
+// could not read or aim a drag at. The founder asked the right question —
+// "shouldn't the pill numbers be under the polyps horizontally rather than over
+// them in Z?" — and the answer is that this is a layout bug, not a paint-order
+// one. The vents draw AFTER the polyps, on the same canvas, with a 0.95-alpha
+// chimney; whatever they overlap they erase. Restacking, dimming or shrinking
+// the pills would all be ways of not fixing it.
+//
+// What was wrong: `computeLayout` sized the grid as if a polyp were exactly its
+// cell. A polyp sprite is SPRITE_SCALE — 1.62 — cells across, centred on the
+// cell, so it reaches POLYP_BLEED (0.31) of a cell past the cell box on every
+// side. The clearance left between the grid's arithmetic bottom and the vent
+// strip was a single `pad`, 8 to 22px, which is smaller than that bleed at
+// every portrait size the fleet has.
+//
+// So this file asserts the thing the screenshot showed, at the shapes the fleet
+// actually has, for every shelf the game can grow into and every vent count a
+// screen can hold: the polyps as DRAWN and the vents as DRAWN are disjoint.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { safeRect, type Insets, type Rect } from '../../../../packs/shared/game-chrome/index.ts'
+import { makeBoard } from '../core/board.ts'
+import { chromeLayout, stageAreaFor } from '../ui/chrome.ts'
+import { computeLayout, LEGIBLE_CELL, promptPlate, shelfCap, ventCap, ventRects } from './renderer.ts'
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+const TALL: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+const WIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ['phone portrait, small', 320, 568],
+  ['phone portrait, tall', 390, 844],
+  // The founder's device: 1080x2340 physical, which is this in CSS px.
+  ['phone portrait, android', 360, 780],
+  ['phone landscape', 844, 390],
+  // Every portrait shape turned sideways. A vent is a drop target, and it is
+  // the SHORT landscape stage that squeezes the chimneys under 44px.
+  ['phone landscape, small', 568, 320],
+  ['phone landscape, android', 780, 360],
+  ['tablet portrait', 768, 1024],
+  ['tablet landscape', 1024, 768],
+  ['laptop', 1440, 900],
+]
+
+/** Every shelf the game can grow into: 5x6 at the start, 7x9 at the ceiling. */
+const SHELVES: Array<[number, number]> = [
+  [5, 6],
+  [6, 6],
+  [5, 9],
+  [6, 9],
+  [7, 9],
+]
+
+const insetCases = (w: number, h: number): Array<[string, Insets]> => [
+  ['no insets', NONE],
+  ['notched', w > h ? WIDE : TALL],
+]
+
+/** The overlap of two rectangles, or null when they do not touch. */
+function overlap(a: Rect, b: Rect): { w: number; h: number } | null {
+  const w = Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x)
+  const h = Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y)
+  return w > 0.001 && h > 0.001 ? { w, h } : null
+}
+
+const say = (r: Rect): string =>
+  `[${r.x.toFixed(1)},${r.y.toFixed(1)} ${r.w.toFixed(1)}x${r.h.toFixed(1)}]`
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const [label, ins] of insetCases(w, h)) {
+    for (const [cols, rows] of SHELVES) {
+      test(`the vents never touch the shelf at ${name} (${w}×${h}, ${label}, ${cols}×${rows})`, () => {
+        const c = chromeLayout(w, h, safeRect(w, h, ins))
+        const b = makeBoard(cols, rows)
+        const l = computeLayout(c.stage.w, c.stage.h, 2, b, stageAreaFor(c, c.stage.w, c.stage.h))
+        const vents = ventRects(l, ventCap(l))
+
+        for (let i = 0; i < vents.length; i++) {
+          const v = vents[i]
+          if (!v) continue
+          // The chimney: opaque, drawn last, and therefore the thing that
+          // actually erased the polyps.
+          const onVent = overlap(l.gridRect, v)
+          assert.equal(
+            onVent,
+            null,
+            `vent ${i} ${say(v)} covers the shelf ${say(l.gridRect)} by ` +
+              `${onVent?.w.toFixed(1)}x${onVent?.h.toFixed(1)}px — a child cannot read the bottom row`,
+          )
+          // And the number plate on it: the pill the founder photographed.
+          const onPill = overlap(l.gridRect, promptPlate(v))
+          assert.equal(
+            onPill,
+            null,
+            `the number pill on vent ${i} sits over the shelf by ` +
+              `${onPill?.w.toFixed(1)}x${onPill?.h.toFixed(1)}px`,
+          )
+        }
+
+        // A vent is a DROP target — a polyp dragged anywhere onto a chimney is
+        // fed to it — so the chimney, not the little pill, is what has to clear
+        // the platform's 44px minimum. (The pill is a label; nothing is bound
+        // to it.) The axis that matters is the one the vents stack along.
+        for (const v of vents) {
+          assert.ok(
+            v.w >= 44 && v.h >= 44,
+            `a vent is ${v.w.toFixed(0)}x${v.h.toFixed(0)}px — under the 44px touch minimum`,
+          )
+        }
+
+        // The shelf must still be worth playing on after the band is reserved:
+        // below LEGIBLE_CELL the numerals on the polyps collide. Only shelves
+        // the game will actually grow into are held to it — an oversized shelf
+        // carried in from a tablet save has to shrink, and shrinking is what
+        // `computeLayout` now does instead of overrunning the vents.
+        const cap = shelfCap(l)
+        if (cols <= cap.cols && rows <= cap.rows) {
+          assert.ok(
+            l.cell >= LEGIBLE_CELL,
+            `the cell is ${l.cell.toFixed(1)}px — the numerals on the polyps collide`,
+          )
+        }
+        // And the drawn shelf has to stay inside the region it was given, or
+        // "disjoint from the vents" is true only by luck.
+        assert.ok(
+          l.gridRect.x >= l.board.x - 0.5 &&
+            l.gridRect.y >= l.board.y - 0.5 &&
+            l.gridRect.x + l.gridRect.w <= l.board.x + l.board.w + 0.5 &&
+            l.gridRect.y + l.gridRect.h <= l.board.y + l.board.h + 0.5,
+          `the drawn shelf ${say(l.gridRect)} spills out of its region ${say(l.board)}`,
+        )
+      })
+    }
+  }
+}
+
+test('DEEPEN is never allowed to grow a shelf this glass cannot draw', () => {
+  // The other half of the fix: `computeLayout` shrinks a shelf that does not
+  // fit rather than overrunning the vents with it, and `shelfCap` stops the
+  // game ever CHOOSING one. Every shelf the cap admits must be legible.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      const probe = computeLayout(c.stage.w, c.stage.h, 2, makeBoard(5, 6), stageAreaFor(c, c.stage.w, c.stage.h))
+      const cap = shelfCap(probe)
+      assert.ok(cap.cols >= 5 && cap.rows >= 6, `${name} ${label}: cannot even hold the starting 5×6 shelf`)
+      const at = computeLayout(
+        c.stage.w,
+        c.stage.h,
+        2,
+        makeBoard(Math.min(7, cap.cols), Math.min(9, cap.rows)),
+        stageAreaFor(c, c.stage.w, c.stage.h),
+      )
+      assert.ok(
+        at.cell >= LEGIBLE_CELL,
+        `${name} ${label}: the cap admits a ${cap.cols}×${cap.rows} shelf whose cell is ${at.cell.toFixed(1)}px`,
+      )
+    }
+  }
+})
+
+test('the vent band is a band: it is below the shelf in portrait, beside it in landscape', () => {
+  // The regions are disjoint by CONSTRUCTION — the vents are placed first and
+  // the shelf gets the remainder — so this also documents which way round.
+  for (const [name, w, h] of VIEWPORTS) {
+    const c = chromeLayout(w, h, safeRect(w, h, NONE))
+    const l = computeLayout(c.stage.w, c.stage.h, 2, makeBoard(5, 6), stageAreaFor(c, c.stage.w, c.stage.h))
+    if (l.ventColumn) {
+      assert.ok(
+        l.board.x + l.board.w <= l.ventStrip.x,
+        `${name}: the shelf runs into the vent column`,
+      )
+    } else {
+      assert.ok(
+        l.board.y + l.board.h <= l.ventStrip.y,
+        `${name}: the shelf runs into the vent band`,
+      )
+    }
+  }
+})

--- a/dynawalla/games/merge-idle/src/render/renderer.ts
+++ b/dynawalla/games/merge-idle/src/render/renderer.ts
@@ -48,10 +48,60 @@ export type Layout = {
   gap: number
   originX: number
   originY: number
+  /**
+   * What the shelf actually COVERS: the grid grown by `POLYP_BLEED` on every
+   * side, because a polyp is drawn larger than the cell that addresses it.
+   * This — not the grid — is the rectangle the vents have to stay out of.
+   */
+  gridRect: Rect
   ventStrip: Rect
   /** true when the vents run down the right-hand side instead of along the bottom */
   ventColumn: boolean
 }
+
+/**
+ * How far a polyp is drawn PAST the cell that addresses it, as a fraction of
+ * the cell.
+ *
+ * A polyp sprite is `SPRITE_SCALE` (1.62) cells across and is centred on its
+ * cell, so it reaches 0.31 of a cell beyond the cell box on every side. The
+ * first version of this layout sized the grid as if a polyp were exactly its
+ * cell and then left a single `pad` — 8 to 22px — between the grid's arithmetic
+ * bottom and the vent strip. At every portrait phone size that gap was smaller
+ * than the bleed, so the bottom row's polyps reached into the strip, and the
+ * vents (drawn AFTER the polyps, with a 0.95-alpha chimney) painted over them.
+ *
+ * The fix is not a z-order or an opacity: the grid is sized so that its DRAWN
+ * extent fits the region left over after the vents take theirs. `gridRect` is
+ * that extent, and `layout.test.ts` asserts it never meets a vent.
+ */
+export const POLYP_BLEED = (SPRITE_SCALE - 1) / 2
+
+/**
+ * How far the rock the shelf sits on is drawn past the grid, in gaps.
+ *
+ * `drawShelf` rounds a plate `gap * 2.2` outside the cells on every side. On a
+ * small cell that lip is WIDER than the polyp bleed, so reserving only the
+ * bleed would leave the rock itself lapping over the vents — the same bug one
+ * layer down. Whichever of the two is larger is what gets reserved.
+ */
+export const SHELF_LIP = 2.2
+
+/**
+ * The smallest cell whose numeral a child can still read. `shelfCap` refuses to
+ * grow a shelf past this; it is not enforced during layout, because clamping a
+ * cell UP does not create room, it only pushes the shelf onto the vents.
+ */
+export const LEGIBLE_CELL = 18
+/**
+ * Purely so the arithmetic cannot reach zero. Deliberately far below anything
+ * playable: a floor high enough to matter is a floor that makes the shelf
+ * overflow its region instead of fitting it, which is the bug this file is
+ * about. A shelf that lands here is one carried in from a much bigger screen
+ * and it will be tiny until the child rotates back or DEEPEN is re-capped —
+ * unpleasant, but readable-and-wrong beats erased-by-a-vent.
+ */
+const MIN_CELL = 1
 
 /**
  * Portrait stacks the vents along the bottom under the thumbs. Landscape turns
@@ -72,28 +122,75 @@ export type Layout = {
  * in the first place.
  */
 export function computeLayout(w: number, h: number, dpr: number, b: Board, area: Rect): Layout {
-  const pad = Math.max(8, Math.min(22, w * 0.03))
+  // Padding scales off the SHORTER side of the stage, not the width. A phone
+  // held sideways is wide and barely 160px tall; charging it 22px of margin
+  // top and bottom because it happens to be 568px across is how a notched
+  // small phone ended up unable to draw a legible starting shelf at all.
+  const pad = Math.max(8, Math.min(22, Math.min(w, h) * 0.03))
   const ventColumn = w / Math.max(1, h) > 1.15
   const right = area.x + area.w
   const bottom = area.y + area.h
+  // The vents are placed FIRST and the shelf is given what is left. Doing it in
+  // this order is the whole point: the two regions are disjoint by
+  // construction, not by an offset that happens to work on one device.
   let board: Rect
   let ventStrip: Rect
   if (ventColumn) {
     const cw = Math.max(190, Math.min(300, area.w * 0.26))
-    board = { x: area.x + pad, y: area.y + pad, w: area.w - cw - pad * 2.5, h: area.h - pad * 2 }
     ventStrip = { x: right - cw - pad * 0.5, y: area.y + pad, w: cw, h: area.h - pad * 2 }
+    board = {
+      x: area.x + pad,
+      y: area.y + pad,
+      w: Math.max(1, ventStrip.x - pad - (area.x + pad)),
+      h: area.h - pad * 2,
+    }
   } else {
     const ventH = Math.max(104, Math.min(180, area.h * 0.21))
-    board = { x: area.x + pad, y: area.y + pad * 0.6, w: area.w - pad * 2, h: area.h - ventH - pad * 1.6 }
+    const top = area.y + pad * 0.6
     ventStrip = { x: area.x + pad, y: bottom - ventH, w: area.w - pad * 2, h: ventH - pad * 0.5 }
+    board = {
+      x: area.x + pad,
+      y: top,
+      w: area.w - pad * 2,
+      h: Math.max(1, ventStrip.y - pad - top),
+    }
   }
   const gap = Math.max(3, Math.min(9, Math.min(board.w, board.h) * 0.018))
+  // Solve for a cell whose DRAWN grid fits `board`, not one whose cell boxes
+  // do: a row of polyps is `rows + 2 * POLYP_BLEED` cells tall on screen.
+  //
+  // There used to be an 18px floor here, which sounds protective and is not:
+  // it does not create room, it only makes the shelf overflow the region it
+  // was given — downward, onto the vents, which then paint over it. A shelf
+  // too big for the glass (a save carried over from a tablet, or a rotation)
+  // has to get SMALLER. `shelfCap` below is what stops the game growing into
+  // that state in the first place; MIN_CELL exists only so the arithmetic
+  // cannot go to zero.
+  const spread = 2 * POLYP_BLEED
+  // The polyps' bleed scales with the cell; the rock's lip scales with the gap.
+  // Solve for both and take the smaller cell, so whichever binds is honoured.
+  const lipReserve = gap * SHELF_LIP * 2
   const cell = Math.max(
-    18,
-    Math.min((board.w - gap * (b.cols - 1)) / b.cols, (board.h - gap * (b.rows - 1)) / b.rows),
+    MIN_CELL,
+    Math.min(
+      (board.w - gap * (b.cols - 1)) / (b.cols + spread),
+      (board.h - gap * (b.rows - 1)) / (b.rows + spread),
+      (board.w - gap * (b.cols - 1) - lipReserve) / b.cols,
+      (board.h - gap * (b.rows - 1) - lipReserve) / b.rows,
+    ),
   )
+  const bleed = Math.max(cell * POLYP_BLEED, gap * SHELF_LIP)
   const gridW = cell * b.cols + gap * (b.cols - 1)
   const gridH = cell * b.rows + gap * (b.rows - 1)
+  // Centred when there is slack, pinned to the top-left corner of `board` when
+  // there is not. A shelf too big for the glass has nowhere good to go — the
+  // vents are below in portrait and to the right in landscape — so it overflows
+  // towards them from a known corner rather than from the middle, which at
+  // least keeps the top-left of the shelf where the eye expects it. Only
+  // reachable when MIN_CELL binds; `shelfCap` is what keeps the game out of
+  // that state.
+  const originX = board.x + bleed + Math.max(0, (board.w - gridW - bleed * 2) / 2)
+  const originY = board.y + bleed + Math.max(0, (board.h - gridH - bleed * 2) / 2)
   return {
     w,
     h,
@@ -101,11 +198,102 @@ export function computeLayout(w: number, h: number, dpr: number, b: Board, area:
     board,
     cell,
     gap,
-    originX: board.x + (board.w - gridW) / 2,
-    originY: board.y + (board.h - gridH) / 2,
+    originX,
+    originY,
+    gridRect: {
+      x: originX - bleed,
+      y: originY - bleed,
+      w: gridW + bleed * 2,
+      h: gridH + bleed * 2,
+    },
     ventStrip,
     ventColumn,
   }
+}
+
+/**
+ * Where each vent sits inside the strip.
+ *
+ * Pure, and out here rather than inside `Game`, so a test can ask for the very
+ * rectangles the child sees and check them against the shelf. The whole rect is
+ * the drop target — a polyp dragged anywhere onto a chimney is fed to it — so
+ * this, not the little number plate, is what has to clear 44px.
+ */
+export function ventRects(l: Layout, n: number): Rect[] {
+  const strip = l.ventStrip
+  const count = Math.max(1, n)
+  const out: Rect[] = []
+  if (l.ventColumn) {
+    const gap = Math.max(8, Math.min(16, strip.h * 0.02))
+    const h = Math.min((strip.h - gap * (count - 1)) / count, 190)
+    const top = strip.y + (strip.h - (h * count + gap * (count - 1))) / 2
+    for (let i = 0; i < count; i++) out.push({ x: strip.x, y: top + i * (h + gap), w: strip.w, h })
+    return out
+  }
+  const gap = Math.max(6, Math.min(12, strip.w * 0.02))
+  const w = (strip.w - gap * (count - 1)) / count
+  for (let i = 0; i < count; i++) out.push({ x: strip.x + i * (w + gap), y: strip.y, w, h: strip.h })
+  return out
+}
+
+/**
+ * The number plate on a chimney — the "pill" a child reads the target off.
+ * A label, not a target: the drop zone is the whole vent.
+ */
+export function promptPlate(r: Rect): Rect {
+  return { x: r.x + r.w * 0.06, y: r.y + r.h * 0.1, w: r.w * 0.88, h: r.h * 0.36 }
+}
+
+/**
+ * The largest shelf this glass can hold with every polyp still legible.
+ *
+ * DEEPEN used to grow the shelf to a flat 7×9 on any screen. On the smallest
+ * notched phone a 9-row shelf cannot be drawn above the vent band at a legible
+ * cell, so it was drawn over it. Growth is capped by what fits instead — the
+ * reflow the founder should never have to notice, rather than a collision he
+ * would.
+ */
+export function shelfCap(l: Layout): { cols: number; rows: number } {
+  const spread = 2 * POLYP_BLEED
+  const lipReserve = l.gap * SHELF_LIP * 2
+  // Both of the inequalities `computeLayout` minimises over, inverted. Solving
+  // only the polyp one let the cap admit a shelf whose real cell came out
+  // fractionally under LEGIBLE_CELL, because the rock's lip is what binds at
+  // small cells.
+  const fit = (extent: number): number =>
+    Math.max(
+      1,
+      Math.min(
+        Math.floor((extent + l.gap - LEGIBLE_CELL * spread) / (LEGIBLE_CELL + l.gap)),
+        Math.floor((extent + l.gap - lipReserve) / (LEGIBLE_CELL + l.gap)),
+      ),
+    )
+  return { cols: fit(l.board.w), rows: fit(l.board.h) }
+}
+
+/** The platform's minimum touch target, and a vent is one — you drop onto it. */
+export const VENT_MIN = 44
+
+/**
+ * How many vents this shape of screen will ever hold.
+ *
+ * Bounded by the 44px drop minimum as well as by taste. A phone held wide has
+ * barely 80px of stage between the band and the rail, and the old floor of two
+ * vents split that into a pair of 37px chimneys — a target a seven-year-old
+ * cannot hit with a polyp in flight. One vent that can be aimed at beats two
+ * that cannot.
+ */
+export function ventCap(l: Layout): number {
+  const strip = l.ventStrip
+  if (l.ventColumn) {
+    const gap = Math.max(8, Math.min(16, strip.h * 0.02))
+    const fits = Math.floor((strip.h + gap) / (VENT_MIN + gap))
+    return Math.max(1, Math.min(5, fits, Math.max(2, Math.floor(strip.h / 150))))
+  }
+  const gap = Math.max(6, Math.min(12, strip.w * 0.02))
+  const fits = Math.floor((strip.w + gap) / (VENT_MIN + gap))
+  const byWidth = l.w < 480 ? 2 : l.w < 760 ? 3 : l.w < 1100 ? 4 : 5
+  return Math.max(1, Math.min(5, fits, byWidth))
 }
 
 export function cellCentre(l: Layout, b: Board, i: number): { x: number; y: number } {
@@ -168,7 +356,7 @@ export class Renderer {
     this.wg = ctx(this.water)
     this.gg = ctx(this.glow)
     this.sg = ctx(this.sharp)
-    this.layout = { w: 1, h: 1, dpr: 1, board: { x: 0, y: 0, w: 1, h: 1 }, cell: 20, gap: 4, originX: 0, originY: 0, ventStrip: { x: 0, y: 0, w: 1, h: 1 }, ventColumn: false }
+    this.layout = { w: 1, h: 1, dpr: 1, board: { x: 0, y: 0, w: 1, h: 1 }, cell: 20, gap: 4, originX: 0, originY: 0, gridRect: { x: 0, y: 0, w: 1, h: 1 }, ventStrip: { x: 0, y: 0, w: 1, h: 1 }, ventColumn: false }
   }
 
   destroy(): void {
@@ -346,16 +534,12 @@ export class Renderer {
     const stride = l.cell + l.gap
     const r = l.cell * 0.26
 
-    // the rock the whole shelf sits on
+    // The rock the whole shelf sits on — drawn to `gridRect`, the same
+    // rectangle the layout reserved and the layout test checks against the
+    // vents, so the two cannot drift apart.
     sg.save()
-    roundRect(
-      sg,
-      l.originX - l.gap * 2.2,
-      l.originY - l.gap * 2.2,
-      b.cols * stride - l.gap + l.gap * 4.4,
-      b.rows * stride - l.gap + l.gap * 4.4,
-      l.cell * 0.34,
-    )
+    const rock = l.gridRect
+    roundRect(sg, rock.x, rock.y, rock.w, rock.h, l.cell * 0.34)
     const plate = sg.createLinearGradient(0, l.originY, 0, l.originY + b.rows * stride)
     plate.addColorStop(0, rgba(lift(base, 0.08), 0.55))
     plate.addColorStop(1, rgba(mix(base, INK, 0.55), 0.62))
@@ -525,8 +709,11 @@ export class Renderer {
       // the request
       const q = v.q
       if (q) {
-        const plateH = r.h * 0.36
-        roundRect(sg, r.w * 0.06, r.h * 0.1, r.w * 0.88, plateH, plateH * 0.28)
+        // Same arithmetic as `promptPlate`, in the vent's own coordinates —
+        // that function is what the layout test measures.
+        const plate = promptPlate(r)
+        const plateH = plate.h
+        roundRect(sg, plate.x - r.x, plate.y - r.y, plate.w, plateH, plateH * 0.28)
         sg.fillStyle = rgba(INK, 0.66)
         sg.fill()
         let fs = Math.min(plateH * 0.62, r.w * 0.2)

--- a/dynawalla/games/merge-idle/src/ui/actions.ts
+++ b/dynawalla/games/merge-idle/src/ui/actions.ts
@@ -1,0 +1,89 @@
+/**
+ * What the action rail offers, as a pure function of where the reef has got to.
+ *
+ * Out here rather than inside `Game` for one reason: **a control appearing must
+ * never reflow the playfield.** DISSOLVE used to be `visible: false` until the
+ * shelf filled up, a `display:none` button takes no grid cell, and so the rail
+ * grew from two rows to three the moment it appeared and shoved the whole reef
+ * upward mid-play. Pure, the rule is a test — `band.test.ts` asks for every
+ * combination of reef state and asserts the number of VISIBLE buttons never
+ * moves — instead of something a reviewer has to notice.
+ *
+ * The idiom for a control a child has not earned yet is therefore `visible` and
+ * `enabled: false`, which is what UPWELL already does when a child cannot
+ * afford it, and which has the side benefit of showing that the thing exists.
+ */
+
+import { growCost, upwellCost, ventCost } from '../core/economy.ts'
+import { fmtCompact } from '../core/ladder.ts'
+import type { Action } from './hud.ts'
+
+export type ActionInput = {
+  essence: number
+  upwells: number
+  grows: number
+  overcharges: number
+  vents: number
+  ventCap: number
+  cols: number
+  rows: number
+  maxCols: number
+  maxRows: number
+  /** No empty cell left on the shelf. */
+  full: boolean
+  /** Nearly full, for long enough that the game has started nagging. */
+  crowded: boolean
+}
+
+export function actionList(i: ActionInput): Action[] {
+  const up = upwellCost(i.upwells)
+  const aw = ventCost(i.vents + 1)
+  const dp = growCost(i.grows + 1)
+  const oc = 10 ** (3 + i.overcharges) * 2
+  const canGrow = i.cols < i.maxCols || i.rows < i.maxRows
+  return [
+    {
+      id: 'upwell',
+      label: 'UPWELL',
+      cost: up,
+      hint: fmtCompact(up),
+      enabled: i.essence >= up && !i.full,
+      visible: true,
+    },
+    {
+      id: 'awaken',
+      label: 'AWAKEN',
+      cost: aw,
+      hint: i.vents >= i.ventCap ? 'max' : fmtCompact(aw),
+      enabled: i.essence >= aw && i.vents < i.ventCap,
+      visible: true,
+    },
+    {
+      id: 'deepen',
+      label: 'DEEPEN',
+      cost: dp,
+      hint: canGrow ? fmtCompact(dp) : 'max',
+      enabled: i.essence >= dp && canGrow,
+      visible: true,
+    },
+    {
+      id: 'overcharge',
+      label: 'OVERCHARGE',
+      cost: oc,
+      hint: fmtCompact(oc),
+      enabled: i.essence >= oc,
+      visible: true,
+    },
+    {
+      id: 'purge',
+      label: 'DISSOLVE',
+      cost: 0,
+      hint: 'free',
+      // Always present, greyed until the shelf actually needs clearing. See
+      // the note at the top of this file: this is the whole point of it.
+      enabled: i.full || i.crowded,
+      visible: true,
+      urgent: i.crowded,
+    },
+  ]
+}

--- a/dynawalla/games/merge-idle/src/ui/band.test.ts
+++ b/dynawalla/games/merge-idle/src/ui/band.test.ts
@@ -1,0 +1,292 @@
+// THE TOP BAR, AND THE RAIL THAT MOVES THE REEF.
+//
+// Two device photos, one root cause each.
+//
+// 1. The essence readout rendered as a giant `K` with a stray `.` in front of
+//    it, the rate line `▲ 899 / sec` wrapped onto two rows inside a one-row
+//    box, the `×2.5 FLOW` pill sat on top of the number, and one orphan dot
+//    hung under the right end of the magnitude meter. All four are the same
+//    thing: the band's contents were sized against the WHOLE band while
+//    actually living in a fraction of it.
+//
+//    The `.K` in particular is worth naming. An odometer digit column is
+//    `overflow:hidden`, and a flex item with `overflow` other than `visible`
+//    has an automatic minimum size of ZERO. So when the odometer outgrew its
+//    column the digits shrank away to nothing while the `.` and the `K` —
+//    which are not `overflow:hidden`, and so are floored at their content —
+//    stayed. The child was shown the punctuation of their score and none of
+//    the number.
+//
+// 2. DISSOLVE appears only when the shelf fills, and a `display:none` button
+//    takes no grid cell. Four buttons made two rows; five made three; the rail
+//    grew, the stage shrank and the entire reef jumped upward mid-play.
+//
+// The rule behind (2) is general and is the one worth keeping: A CONTROL
+// APPEARING MUST NEVER REFLOW THE PLAYFIELD.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { safeRect, type Insets } from '../../../../packs/shared/game-chrome/index.ts'
+import { makeBoard } from '../core/board.ts'
+import { fmtCompact } from '../core/ladder.ts'
+import { computeLayout } from '../render/renderer.ts'
+import { actionList, type ActionInput } from './actions.ts'
+import {
+  chromeLayout,
+  ODO_MAX_EM,
+  odoWidth,
+  railButtonText,
+  railHeight,
+  RAIL_SLOTS,
+  stageAreaFor,
+} from './chrome.ts'
+
+const VIEWPORTS: Array<[string, number, number]> = [
+  ['phone portrait, small', 320, 568],
+  ['phone portrait, tall', 390, 844],
+  ['phone portrait, android', 360, 780],
+  ['phone landscape', 844, 390],
+  ['tablet portrait', 768, 1024],
+  ['tablet landscape', 1024, 768],
+  ['laptop', 1440, 900],
+]
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+const TALL: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+const WIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+const insetCases = (w: number, h: number): Array<[string, Insets]> => [
+  ['no insets', NONE],
+  ['notched', w > h ? WIDE : TALL],
+]
+
+/* ----------------------------------------------------- 1. the essence number */
+
+/**
+ * What the right-hand column has to hold, measured here rather than imported,
+ * so that shrinking the reservation in `chrome.ts` fails this file instead of
+ * silently agreeing with it.
+ *
+ *   `×9.9 FLOW` — nine characters at 10px and a 900 weight, plus 7px of
+ *   padding and a 1px border on each side.
+ *   one row of the magnitude meter — six 7px pips with 3px between them.
+ */
+const FLOW_NEEDS = 9 * 0.62 * 10 + 16
+const PIP_ROW_NEEDS = 6 * 7 + 5 * 3
+
+test('the essence number always fits its box', () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      const where = `${name} (${w}×${h}, ${label})`
+
+      // The FLOW pill and the meter get a column of their OWN. They used to be
+      // laid on top of the number's row and against a percentage max-width,
+      // which is how the pill ended up over the value and the twelfth pip
+      // ended up orphaned on a second row.
+      assert.ok(
+        c.side.w >= FLOW_NEEDS,
+        `${where}: the FLOW column is ${c.side.w.toFixed(0)}px and the pill needs ` +
+          `${FLOW_NEEDS.toFixed(0)}px — it will sit on the number`,
+      )
+      assert.ok(
+        c.side.w >= PIP_ROW_NEEDS,
+        `${where}: the meter column is ${c.side.w.toFixed(0)}px and a row of pips needs ` +
+          `${PIP_ROW_NEEDS}px — a pip wraps and hangs on its own`,
+      )
+      // ...and the two columns and the gap between them fit the readout.
+      assert.ok(
+        c.essence.x + c.essence.w <= c.side.x + 0.5,
+        `${where}: the number runs under the FLOW pill`,
+      )
+      assert.ok(
+        c.side.x + c.side.w <= c.readout.x + c.readout.w + 0.5,
+        `${where}: the FLOW pill and meter run past the readout`,
+      )
+      // The odometer is sized so its WIDEST possible string fits the column it
+      // is actually in — not the whole band, which is what it used to be sized
+      // against.
+      assert.ok(
+        c.odoPx * ODO_MAX_EM <= c.essence.w + 0.5,
+        `${where}: the odometer needs ${(c.odoPx * ODO_MAX_EM).toFixed(0)}px ` +
+          `and its column is ${c.essence.w.toFixed(0)}px — the digits get clipped`,
+      )
+      assert.ok(c.odoPx >= 22, `${where}: the odometer is ${c.odoPx}px — too small to read`)
+    }
+  }
+})
+
+test('the number fits at every width the pack can be given, not just fleet ones', () => {
+  // iPadOS resizes a pack continuously in Split View, and this file's own
+  // premise is that a layout is only correct if it is correct at every shape.
+  // A sweep also catches the widths BETWEEN the fleet's, which is where sizing
+  // the odometer against the whole band went wrong first.
+  for (let w = 240; w <= 1440; w += 4) {
+    const h = w < 620 ? 640 : 900
+    const c = chromeLayout(w, h, safeRect(w, h, NONE))
+    assert.ok(
+      c.odoPx * ODO_MAX_EM <= c.essence.w + 0.5,
+      `${w}px wide: the odometer needs ${(c.odoPx * ODO_MAX_EM).toFixed(0)}px in a ` +
+        `${c.essence.w.toFixed(0)}px column — the score gets clipped down to its punctuation`,
+    )
+  }
+})
+
+test('every number the game can actually produce fits', () => {
+  // Not "assume five digits". Walk the formatter across the whole range an
+  // idle game reaches — the reef compounds, and the string changes SHAPE at
+  // 100,000 when `fmtCompact` switches from `99,999` to `123.4K`.
+  const values: number[] = [0, 7, 99, 100, 1000, 12_345, 99_999, 100_000]
+  for (let e = 5; e <= 21; e++) {
+    values.push(10 ** e, 9.99 * 10 ** e, 1.234 * 10 ** e)
+  }
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      for (const v of values) {
+        const text = fmtCompact(v)
+        const px = odoWidth(text, c.odoPx)
+        assert.ok(
+          px <= c.essence.w + 0.5,
+          `${name} (${w}×${h}, ${label}): "${text}" needs ${px.toFixed(0)}px ` +
+            `in a ${c.essence.w.toFixed(0)}px column — the child cannot read their score`,
+        )
+      }
+    }
+  }
+})
+
+test('the rate line cannot wrap, and the FLOW pill is not on it', () => {
+  // `▲ 899 / sec` broke onto two lines because it shared its row with the FLOW
+  // pill. FLOW now lives in the right-hand column, and the rate is sized so the
+  // longest string the game emits fits on one line.
+  const LONGEST = '▲ 999.9Qi / sec'.length
+  // A deliberately fat advance for a 800-weight sans; the real font is
+  // narrower, so passing here is conservative.
+  const EM = 0.66
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      assert.ok(
+        LONGEST * EM * c.ratePx <= c.essence.w + 0.5,
+        `${name} (${w}×${h}, ${label}): the rate needs ` +
+          `${(LONGEST * EM * c.ratePx).toFixed(0)}px in a ${c.essence.w.toFixed(0)}px column`,
+      )
+      assert.ok(c.ratePx >= 9, `${name}: the rate is ${c.ratePx}px — unreadable`)
+    }
+  }
+})
+
+test('the band height does not depend on the number in it', () => {
+  // The header must not grow as the reef does. Everything with a variable
+  // width is on a fixed line box, so the only inputs to the band's height are
+  // the viewport and the insets.
+  for (const [, w, h] of VIEWPORTS) {
+    for (const [, ins] of insetCases(w, h)) {
+      const a = chromeLayout(w, h, safeRect(w, h, ins))
+      const b = chromeLayout(w, h, safeRect(w, h, ins))
+      assert.equal(a.band.h, b.band.h)
+      assert.equal(a.stage.y, b.stage.y)
+    }
+  }
+})
+
+/* ------------------------------------------------------ 2. the reflowing rail */
+
+const REEF: ActionInput = {
+  essence: 5000,
+  upwells: 1,
+  grows: 1,
+  overcharges: 0,
+  vents: 2,
+  ventCap: 3,
+  cols: 5,
+  rows: 6,
+  maxCols: 7,
+  maxRows: 9,
+  full: false,
+  crowded: false,
+}
+
+test('no reef state changes how many buttons the rail shows', () => {
+  const counts = new Set<number>()
+  for (const full of [false, true]) {
+    for (const crowded of [false, true]) {
+      for (const essence of [0, 5000, 1e9]) {
+        for (const vents of [1, 3]) {
+          const visible = actionList({ ...REEF, full, crowded, essence, vents }).filter(
+            (a) => a.visible,
+          )
+          counts.add(visible.length)
+        }
+      }
+    }
+  }
+  assert.deepEqual(
+    [...counts],
+    [RAIL_SLOTS],
+    `the rail shows ${[...counts].join(' or ')} buttons depending on state — ` +
+      'whichever count changes, the rail reflows and the reef jumps',
+  )
+})
+
+test('DISSOLVE is present before it is usable, and enabled when it is', () => {
+  const locked = actionList(REEF).find((a) => a.id === 'purge')
+  const live = actionList({ ...REEF, full: true }).find((a) => a.id === 'purge')
+  assert.equal(locked?.visible, true, 'DISSOLVE is hidden until the shelf fills — it will reflow')
+  assert.equal(locked?.enabled, false, 'DISSOLVE is pressable when there is nothing to dissolve')
+  assert.equal(live?.enabled, true, 'DISSOLVE does not light up when the shelf is full')
+})
+
+test('the longest button label still fits a three-across rail', () => {
+  // Three columns instead of two is what keeps five buttons in two rows. The
+  // buttons are narrower for it, and the labels are `nowrap` with a fixed
+  // button height — so a label that did not fit would be CLIPPED rather than
+  // wrapped, which would be silent. This is the guard.
+  //
+  // Honest about what it is: a character-advance model, not a measurement. The
+  // 0.72em advance is deliberately fatter than a 900-weight rounded sans
+  // actually sets, so passing here leaves room. It cannot replace looking at a
+  // device, and it does catch the label growing or the rail narrowing.
+  const LONGEST = 'OVERCHARGE'.length
+  const EM = 0.72
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      const px = c.w >= 620 ? 11 : 10 // `.ab-btn .n`, both sides of the media query
+      const need = LONGEST * EM * px
+      assert.ok(
+        need <= railButtonText(c),
+        `${name} (${w}×${h}, ${label}): OVERCHARGE needs ~${need.toFixed(0)}px and the ` +
+          `button gives ${railButtonText(c).toFixed(0)}px`,
+      )
+    }
+  }
+})
+
+test('the shelf does not move when DISSOLVE appears', () => {
+  // The assertion the founder's video would have made: lay the reef out with
+  // four buttons in the rail and with five, and compare the shelf.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, ins] of insetCases(w, h)) {
+      const c = chromeLayout(w, h, safeRect(w, h, ins))
+      const board = makeBoard(5, 6)
+
+      const shelfWith = (buttons: number) => {
+        const stageH = Math.max(1, h - c.band.h - railHeight(w, h, ins.bottom, buttons))
+        const stage = { ...c, stage: { x: 0, y: c.band.h, w, h: stageH } }
+        return computeLayout(w, stageH, 2, board, stageAreaFor(stage, w, stageH))
+      }
+
+      const before = shelfWith(RAIL_SLOTS - 1)
+      const after = shelfWith(RAIL_SLOTS)
+      assert.deepEqual(
+        { x: before.originX, y: before.originY, cell: before.cell },
+        { x: after.originX, y: after.originY, cell: after.cell },
+        `${name} (${w}×${h}, ${label}): a button appearing moves the shelf by ` +
+          `${(after.originY - before.originY).toFixed(1)}px and resizes every polyp from ` +
+          `${before.cell.toFixed(1)}px to ${after.cell.toFixed(1)}px`,
+      )
+    }
+  }
+})

--- a/dynawalla/games/merge-idle/src/ui/chrome.ts
+++ b/dynawalla/games/merge-idle/src/ui/chrome.ts
@@ -47,13 +47,158 @@ const ROW_GAP = 1
 const MUTE = 30
 const MUTE_GAP = 8
 
-/** The action rail: one row of buttons, its gaps and its padding. */
+/** The action rail: its button, its gaps and its padding. */
 const RAIL_BTN = 46
 const RAIL_GAP = 6
 const RAIL_TOP = 6
 const RAIL_BOTTOM = 10
-/** Above this width the rail is four across instead of two; matches the CSS. */
+/** Above this width the rail is five across instead of three. */
 const RAIL_WIDE = 620
+/**
+ * ...and below this height it is five across too, whatever the width.
+ *
+ * A small phone held sideways has about 320px of glass. Two rows of buttons
+ * take 52px of it, and once the band and the vent strip have taken theirs the
+ * shelf is left with too little to draw a legible 5x6 on — `layout.test.ts`
+ * says so out loud. Height is the scarce axis there and width is not, so the
+ * rail spends the width instead.
+ */
+const RAIL_SHORT = 480
+/**
+ * Every action the rail can EVER show, including the ones a child has not
+ * unlocked yet.
+ *
+ * DISSOLVE used to be `visible: false` until the shelf filled up, and a
+ * `display:none` button takes no grid cell — so the rail was two rows, then
+ * three, and the whole reef jumped upward the moment the shelf filled. A
+ * control appearing must never reflow the playfield, so the slot is counted
+ * here whether or not the button is usable yet, the grid is three across
+ * (five on a wide screen) so five buttons still make two rows (one), and the
+ * button is merely `disabled` until it works — the same greyed-out idiom
+ * UPWELL already uses when a child cannot afford it, which has the side
+ * benefit of advertising that DISSOLVE exists at all.
+ */
+export const RAIL_SLOTS = 5
+
+/** How many buttons the rail puts on a row. Applied to the grid by `hud.ts`. */
+function railColumns(w: number, h: number): number {
+  return w >= RAIL_WIDE || h < RAIL_SHORT ? 5 : 3
+}
+
+/**
+ * Font size of a button's label, px.
+ *
+ * Derived here rather than from a `@media` rule, because a media query
+ * resolves against the VIEWPORT while everything else in this file resolves
+ * against the element the pack was given — and in Split View those are not the
+ * same number.
+ */
+function railLabelPx(w: number): number {
+  return w >= RAIL_WIDE ? 11 : 10
+}
+
+/** `.ab-btn` horizontal padding, matching the stylesheet. */
+const BTN_PAD_X = 6
+
+/**
+ * The width of one rail button, and the width of the text INSIDE it.
+ *
+ * Narrowing the rail from two columns to three is what keeps five buttons in
+ * two rows and stops the reef jumping. It also makes each button narrower, and
+ * `OVERCHARGE` is a long word — so the room for it is arithmetic here and
+ * asserted in `band.test.ts` rather than discovered on a device.
+ */
+export function railButtonText(c: Chrome): number {
+  const inner = c.w - c.railPad.left - c.railPad.right
+  const cols = c.railCols
+  return Math.max(0, (inner - RAIL_GAP * (cols - 1)) / cols - BTN_PAD_X * 2)
+}
+
+/**
+ * How tall the rail is with `buttons` of them showing.
+ *
+ * Exported so the reflow rule can be MEASURED: `band.test.ts` lays the stage
+ * out at four buttons and at five and asserts the shelf does not move. The
+ * layout itself only ever asks for `RAIL_SLOTS`.
+ */
+export function railHeight(w: number, h: number, insetBottom: number, buttons: number): number {
+  const rows = Math.max(1, Math.ceil(buttons / railColumns(w, h)))
+  return RAIL_TOP + rows * RAIL_BTN + (rows - 1) * RAIL_GAP + RAIL_BOTTOM + insetBottom
+}
+
+/* ------------------------------------------------------------------ readout */
+
+/**
+ * Column widths inside the odometer, in units of the digit height.
+ *
+ * These are applied verbatim as inline `width`s by `hud.ts`, so the odometer's
+ * width is arithmetic rather than a font measurement — which is what lets the
+ * check below be a test instead of a screenshot.
+ */
+export const DIGIT_EM = 0.63
+export const SEP_EM = 0.3
+export const UNIT_EM = 0.62
+
+/**
+ * The magnitude meter, as a fixed two-row grid rather than a `flex-wrap` that
+ * breaks wherever it happens to run out of room. Twelve pips wrapped by
+ * `max-width:44%` left ONE orphan dot on a second row, hanging under the right
+ * end of the meter, which is exactly what a child sees as "broken".
+ */
+export const PIPS_PER_ROW = 6
+export const PIP = 7
+export const PIP_GAP = 3
+const PIPS_W = PIPS_PER_ROW * PIP + (PIPS_PER_ROW - 1) * PIP_GAP
+
+/**
+ * The FLOW pill, at the width `×9.9 FLOW` takes: nine characters at 10px and a
+ * 900 weight, plus 7px of padding and a 1px border on each side. It lives in
+ * the right-hand column and NOT on the rate line — sharing that line is what
+ * squeezed `▲ 899 / sec` onto two rows.
+ */
+const FLOW_W = 74
+
+/** The gap between the essence column and the pips/FLOW column beside it. */
+const COL_GAP = 10
+/** The right-hand column: FLOW above, the pip meter below. */
+const SIDE_W = Math.max(PIPS_W, FLOW_W)
+
+/** The longest rate line the game can emit: `▲ 999.9Qi / sec`. */
+const RATE_CHARS = 15
+/** A deliberately fat per-character advance for the rate line's font. */
+const RATE_EM = 0.66
+
+/**
+ * How wide `text` is in the odometer, in px.
+ *
+ * Digits are fixed-width columns; a comma or a decimal point is narrow; the
+ * magnitude suffix (`K`, `Qa`, …) is a letter. Nothing here measures a font,
+ * which is the point.
+ */
+export function odoWidth(text: string, px: number): number {
+  let em = 0
+  for (const ch of text) {
+    if (ch >= '0' && ch <= '9') em += DIGIT_EM
+    else if (ch === ',' || ch === '.') em += SEP_EM
+    else em += UNIT_EM
+  }
+  return em * px
+}
+
+/**
+ * The widest string `fmtCompact` can ever hand the odometer, in units of the
+ * digit height: `999.9Qa` — four digits, a point and a two-letter unit.
+ *
+ * Below 100,000 the formatter uses grouped digits, and `99,999` is 3.45em,
+ * narrower. The odometer's size is capped so that this fits the essence column
+ * at every viewport, because the alternative is what shipped: the digit
+ * columns are `overflow:hidden` flex items, whose automatic minimum size is
+ * therefore ZERO, so when the odometer overflowed they collapsed to nothing
+ * while the comma and the `K` — which are not `overflow:hidden`, and so cannot
+ * shrink below their content — survived. The child saw `.K`, and could not
+ * read their own score.
+ */
+export const ODO_MAX_EM = 4 * DIGIT_EM + SEP_EM + 2 * UNIT_EM
 
 export type Chrome = {
   w: number
@@ -67,16 +212,26 @@ export type Chrome = {
    * which is the assertion in `chrome.test.ts`.
    */
   readout: Rect
+  /** The left column of the readout: the ESSENCE cap, the odometer, the rate. */
+  essence: Rect
+  /** The right column: the FLOW pill above, the magnitude meter below. */
+  side: Rect
   /** Digit height of the odometer, px. */
   odoPx: number
+  /** Font size of the rate line, px — sized so it cannot wrap. */
+  ratePx: number
+  /** How many buttons the action rail puts on a row. */
+  railCols: number
+  /** Font size of a rail button's label, px. */
+  railLabelPx: number
   /** The mute button, in viewport coordinates. */
   mute: Rect
   /** The canvas stage, between the band and the rail. */
   stage: Rect
   /**
-   * The action rail, at the height it takes with the four standing buttons.
-   * DISSOLVE appears only on a crowded shelf and adds a row; the DOM measures
-   * that for itself, and only this nominal height is ever laid out against.
+   * The action rail, at the height it takes with every slot filled — which is
+   * always, now. Nothing in the rail is conditionally present, so this height
+   * is the real one and the stage below it never moves.
    */
   rail: Rect
   /** The band's padding, for the DOM to apply verbatim. */
@@ -124,12 +279,25 @@ export function chromeLayout(w: number, h: number, area: Rect): Chrome {
   const padTop = inset.top + BAND_TOP
   const readoutW = Math.max(1, w - padLeft - padRight)
 
-  const odoPx = Math.round(clamp(26, 48, readoutW * 0.14))
+  // The odometer does NOT get the whole band. It gets the left column, and it
+  // is sized so its widest possible string fits that column — see ODO_MAX_EM.
+  const sideW = Math.min(SIDE_W, Math.max(0, readoutW - COL_GAP - 90))
+  const essenceW = Math.max(1, readoutW - COL_GAP - sideW)
+  // On a short glass the odometer is capped harder. A phone held sideways has
+  // width to spare and no height at all, and a 48px score there costs the reef
+  // the room it needs to draw a legible shelf — `layout.test.ts` fails outright
+  // without this. Height is the scarce axis; spend it where the game is.
+  //
+  // FLOOR, not round: rounding up is how a number that "just fits" the
+  // arithmetic ends up one pixel too wide for the box on the glass.
+  const odoMax = h < RAIL_SHORT ? 34 : 48
+  const odoPx = Math.floor(clamp(22, odoMax, Math.min(essenceW * 0.26, essenceW / ODO_MAX_EM)))
+  const ratePx = Math.floor(clamp(9, 12, essenceW / (RATE_CHARS * RATE_EM)))
   const readoutH = CAP_H + ROW_GAP + odoPx + ROW_GAP + RATE_H
   const bandH = padTop + readoutH + BAND_BOTTOM
 
-  const rows = w >= RAIL_WIDE ? 1 : 2
-  const railH = RAIL_TOP + rows * RAIL_BTN + (rows - 1) * RAIL_GAP + RAIL_BOTTOM + inset.bottom
+  const railCols = railColumns(w, h)
+  const railH = railHeight(w, h, inset.bottom, RAIL_SLOTS)
   const stageH = Math.max(1, h - bandH - railH)
 
   return {
@@ -138,7 +306,12 @@ export function chromeLayout(w: number, h: number, area: Rect): Chrome {
     inset,
     band: { x: 0, y: 0, w, h: bandH },
     readout: { x: padLeft, y: padTop, w: readoutW, h: readoutH },
+    essence: { x: padLeft, y: padTop, w: essenceW, h: readoutH },
+    side: { x: padLeft + essenceW + COL_GAP, y: padTop, w: sideW, h: readoutH },
     odoPx,
+    ratePx,
+    railCols,
+    railLabelPx: railLabelPx(w),
     mute: { x: w - inset.right - MUTE_GAP - MUTE, y: bandH + MUTE_GAP, w: MUTE, h: MUTE },
     stage: { x: 0, y: bandH, w, h: stageH },
     rail: { x: 0, y: bandH + stageH, w, h: railH },

--- a/dynawalla/games/merge-idle/src/ui/hud.ts
+++ b/dynawalla/games/merge-idle/src/ui/hud.ts
@@ -10,7 +10,12 @@
  */
 
 import { fmtCompact } from '../core/ladder.ts'
-import type { Chrome } from './chrome.ts'
+import { DIGIT_EM, PIP, PIP_GAP, PIPS_PER_ROW, SEP_EM, UNIT_EM, type Chrome } from './chrome.ts'
+import { TapGuard, type TapEvent } from './tapGuard.ts'
+
+/** The width of one odometer column, in px, for the character it holds. */
+const colWidth = (ch: string, px: number): number =>
+  px * (ch >= '0' && ch <= '9' ? DIGIT_EM : ch === ',' || ch === '.' ? SEP_EM : UNIT_EM)
 
 export type Action = {
   id: string
@@ -39,34 +44,52 @@ const CSS = `
 .ab-essence{display:flex;flex-direction:column;gap:1px;min-width:0;flex:1 1 auto}
 /* Fixed line boxes: the band's height is the canvas stage's origin, and an
    origin that drifts with a platform font metric is an origin that is wrong. */
-.ab-cap{font-size:9px;line-height:11px;height:11px;flex:0 0 auto;letter-spacing:.24em;font-weight:800;opacity:.5;text-transform:uppercase}
+.ab-cap{font-size:9px;line-height:11px;height:11px;flex:0 0 auto;letter-spacing:.24em;font-weight:800;opacity:.5;text-transform:uppercase;white-space:nowrap}
 .ab-odo{display:flex;align-items:baseline;flex:0 0 auto;font-weight:900;line-height:1;
   font-variant-numeric:tabular-nums;letter-spacing:-.02em;
   filter:drop-shadow(0 0 12px var(--ab-odo-glow,rgba(120,232,255,.5)));}
-.ab-dig{position:relative;overflow:hidden;display:inline-block}
+/* flex:0 0 auto is load-bearing. A digit column is overflow:hidden, so its
+   automatic minimum size is ZERO — left shrinkable it collapsed to nothing the
+   moment the odometer outgrew its column, while the comma and the magnitude
+   letter (not overflow:hidden, so floored at their content) survived. The child
+   saw ".K" where their score should be. chrome.ts now sizes the digits so the
+   widest possible number fits; this makes sure they can never be squeezed. */
+.ab-dig{position:relative;overflow:hidden;display:inline-block;flex:0 0 auto}
 .ab-dig>span{display:block;text-align:center}
-.ab-sep{display:inline-block;opacity:.55}
-.ab-rate{font-size:11px;line-height:14px;height:14px;flex:0 0 auto;font-weight:800;opacity:.72;letter-spacing:.04em;display:flex;gap:8px;align-items:center}
-.ab-flow{font-weight:900;font-size:10px;line-height:12px;padding:1px 7px;border-radius:999px;
+.ab-sep{display:inline-block;flex:0 0 auto;text-align:center;opacity:.55}
+.ab-rate{line-height:14px;height:14px;flex:0 0 auto;font-weight:800;opacity:.72;letter-spacing:.04em;
+  white-space:nowrap;overflow:hidden}
+.ab-side{display:flex;flex-direction:column;align-items:flex-end;justify-content:flex-end;gap:4px;flex:0 0 auto}
+.ab-flow{font-weight:900;font-size:10px;line-height:12px;padding:1px 7px;border-radius:999px;white-space:nowrap;
   background:rgba(255,209,46,.16);color:#ffd12e;border:1px solid rgba(255,209,46,.34)}
-.ab-pips{display:flex;gap:3px;align-items:center;flex:0 0 auto;max-width:44%;flex-wrap:wrap;justify-content:flex-end}
+.ab-flow[hidden]{display:none}
+/* A fixed grid, not a wrap: twelve pips inside a percentage max-width broke
+   wherever they happened to run out of room and left one orphan dot hanging
+   under the right-hand end of the meter. */
+.ab-pips{display:grid;gap:3px;justify-content:end}
 .ab-pip{width:7px;height:7px;border-radius:2px;background:rgba(238,246,255,.14);transition:background .3s,box-shadow .3s}
 .ab-pip.on{background:var(--ab-pip,#78e8ff);box-shadow:0 0 8px var(--ab-pip,#78e8ff)}
 
+/* The rail's column count AND its label size come from chrome.ts, not from a
+   media query here. Two sources of truth for how many buttons fit on a row is
+   how the reserved rail height and the real rail height end up disagreeing —
+   and a media query resolves against the viewport while chrome.ts resolves
+   against the element the pack was actually given, which in Split View is a
+   different number. */
 .ab-rail{position:relative;z-index:3;flex:0 0 auto;display:grid;gap:6px;padding:6px 10px 10px;
-  grid-template-columns:repeat(2,1fr);
   background:linear-gradient(0deg,rgba(4,7,18,.96),rgba(4,7,18,.55));}
-@media (min-width:620px){.ab-rail{grid-template-columns:repeat(4,1fr)}}
+/* A FIXED height, not a minimum: a label that wrapped would grow the rail,
+   which shrinks the stage, which moves every polyp on the shelf. */
 .ab-btn{appearance:none;border:1px solid rgba(238,246,255,.16);border-radius:12px;
   background:linear-gradient(180deg,rgba(30,44,80,.85),rgba(10,16,36,.9));
-  color:#eef6ff;padding:7px 8px;display:flex;flex-direction:column;align-items:center;gap:1px;
+  color:#eef6ff;padding:7px 6px;display:flex;flex-direction:column;align-items:center;gap:1px;
   font-family:inherit;cursor:pointer;transition:transform .09s cubic-bezier(.2,1.6,.4,1),filter .12s,opacity .12s;
-  min-height:46px;justify-content:center}
+  height:46px;justify-content:center;overflow:hidden}
 .ab-btn:active{transform:scale(.94)}
 .ab-btn[disabled]{opacity:.34;cursor:default}
 .ab-btn[hidden]{display:none}
-.ab-btn .n{font-size:11px;font-weight:900;letter-spacing:.1em}
-.ab-btn .c{font-size:11px;font-weight:800;opacity:.78;font-variant-numeric:tabular-nums}
+.ab-btn .n{font-size:var(--ab-btn-px,10px);font-weight:900;letter-spacing:.05em;white-space:nowrap}
+.ab-btn .c{font-size:var(--ab-btn-px,10px);font-weight:800;opacity:.78;font-variant-numeric:tabular-nums;white-space:nowrap}
 .ab-btn.urgent{border-color:rgba(255,78,92,.7);box-shadow:0 0 0 1px rgba(255,78,92,.28),0 0 18px rgba(255,78,92,.35);
   animation:ab-urge 1.1s ease-in-out infinite}
 @keyframes ab-urge{0%,100%{filter:brightness(1)}50%{filter:brightness(1.35)}}
@@ -120,7 +143,11 @@ function installStyle(): void {
   styleInstalled = true
 }
 
-/** A rolling-digit odometer. Rebuilt only when the digit count changes. */
+/** `12.5K` -> `ddsdu`: which columns are digits, separators and unit letters. */
+const shapeOf = (text: string): string =>
+  Array.from(text, (c) => (c >= '0' && c <= '9' ? 'd' : c === ',' || c === '.' ? 's' : 'u')).join('')
+
+/** A rolling-digit odometer. Rebuilt only when the column shape changes. */
 class Odometer {
   readonly el = document.createElement('div')
   private cols: HTMLElement[] = []
@@ -140,18 +167,22 @@ class Odometer {
     // otherwise stretch the flex line past the digits and push the band taller
     // than `chrome.ts` computed — and the band's height is the stage's origin.
     this.el.style.height = `${px}px`
-    for (const c of this.cols) {
-      if (c.classList.contains('ab-dig')) {
-        c.style.height = `${px}px`
-        c.style.width = `${px * 0.63}px`
-        const stack = c.firstElementChild as HTMLElement | null
-        if (stack) stack.style.height = `${px * 10}px`
-      }
-    }
+    // A rebuild, not a patch. The ten digit `<span>`s inside a column carry
+    // their own `height` and `line-height`, and resizing only the column left
+    // them laid out at the OLD size while `set()` went on translating the
+    // stack by the new one — so after a rotation the odometer showed the wrong
+    // digit until the number happened to change shape. In an idle game that is
+    // seconds of a score that is simply false.
+    const text = this.chars
+    this.chars = ''
+    if (text) this.set(text)
   }
 
   set(text: string): void {
-    if (text.length !== this.chars.length) this.rebuild(text)
+    // Rebuilt on a change of SHAPE, not of length. `99,999` and `100.0K` are
+    // both six characters but their columns are not interchangeable: reusing
+    // them put a digit inside a separator column and read the `.` as a zero.
+    if (shapeOf(text) !== shapeOf(this.chars)) this.rebuild(text)
     for (let i = 0; i < text.length; i++) {
       const ch = text[i] ?? ''
       const col = this.cols[i]
@@ -175,7 +206,7 @@ class Odometer {
         const col = document.createElement('span')
         col.className = 'ab-dig'
         col.style.height = `${this.sizePx}px`
-        col.style.width = `${this.sizePx * 0.63}px`
+        col.style.width = `${colWidth(ch, this.sizePx)}px`
         const stack = document.createElement('span')
         stack.style.height = `${this.sizePx * 10}px`
         stack.style.transition = 'transform .34s cubic-bezier(.2,.9,.2,1)'
@@ -192,6 +223,7 @@ class Odometer {
       } else {
         const sep = document.createElement('span')
         sep.className = 'ab-sep'
+        sep.style.width = `${colWidth(ch, this.sizePx)}px`
         sep.textContent = ch
         this.el.appendChild(sep)
         this.cols.push(sep)
@@ -211,8 +243,9 @@ export class Hud {
   readonly stage = document.createElement('div')
   private top = document.createElement('div')
   private odo = new Odometer()
-  private rateEl = document.createElement('span')
+  private rateEl = document.createElement('div')
   private flowEl = document.createElement('span')
+  private sideEl = document.createElement('div')
   private pipsEl = document.createElement('div')
   private railEl = document.createElement('div')
   private toastEl = document.createElement('div')
@@ -228,6 +261,8 @@ export class Hud {
   private buttons = new Map<string, HTMLButtonElement>()
   private pips: HTMLElement[] = []
   private muted = false
+  /** Keeps the tap that OPENS the tide gate from also answering it. */
+  private guard = new TapGuard()
 
   private cb: HudCallbacks
 
@@ -243,15 +278,20 @@ export class Hud {
     const cap = document.createElement('div')
     cap.className = 'ab-cap'
     cap.textContent = 'Essence'
-    const rate = document.createElement('div')
-    rate.className = 'ab-rate'
-    this.rateEl.textContent = '0 / sec'
+    this.rateEl.className = 'ab-rate'
+    this.rateEl.textContent = '▲ 0 / sec'
     this.flowEl.className = 'ab-flow'
     this.flowEl.hidden = true
-    rate.append(this.rateEl, this.flowEl)
-    ess.append(cap, this.odo.el, rate)
+    ess.append(cap, this.odo.el, this.rateEl)
+    // FLOW and the magnitude meter share the right-hand column. FLOW used to
+    // sit on the rate line, where it left `▲ 899 / sec` too little room and the
+    // line wrapped onto two rows inside a one-row box.
+    this.sideEl.className = 'ab-side'
     this.pipsEl.className = 'ab-pips'
-    top.append(ess, this.pipsEl)
+    this.pipsEl.style.gridTemplateColumns = `repeat(${PIPS_PER_ROW},${PIP}px)`
+    this.pipsEl.style.gap = `${PIP_GAP}px`
+    this.sideEl.append(this.flowEl, this.pipsEl)
+    top.append(ess, this.sideEl)
 
     this.stage.className = 'ab-stage'
     this.railEl.className = 'ab-rail'
@@ -272,6 +312,12 @@ export class Hud {
     this.stage.append(this.toastEl, this.badge, this.muteBtn, this.gate)
     this.root.append(top, this.stage, this.railEl)
 
+    // The whole pack's gesture state, in the capture phase so it is known
+    // before any surface gets a look at the event.
+    this.root.addEventListener('pointerdown', () => this.guard.pointerDown(), true)
+    this.root.addEventListener('pointerup', () => this.guard.pointerUp(), true)
+    this.root.addEventListener('pointercancel', () => this.guard.pointerUp(), true)
+
     for (let i = 0; i < 12; i++) {
       const p = document.createElement('div')
       p.className = 'ab-pip'
@@ -283,6 +329,23 @@ export class Hud {
   private buildGate(): void {
     this.gate.className = 'ab-gate'
     this.gate.hidden = true
+    // The gate is opened from a `pointerdown` on the canvas beneath it, so the
+    // rest of that same tap — the `pointerup`, and the `click` the browser
+    // synthesises from it — would otherwise land on whichever answer chip has
+    // just appeared under the finger. Swallowed here, at the gate's own edge,
+    // rather than inside each chip: every future control on this card is
+    // covered without having to remember.
+    for (const kind of ['pointerdown', 'pointerup', 'click'] as TapEvent[]) {
+      this.gate.addEventListener(
+        kind,
+        (e) => {
+          if (this.guard.accept(kind)) return
+          e.stopPropagation()
+          e.preventDefault()
+        },
+        true,
+      )
+    }
     const card = document.createElement('div')
     card.className = 'ab-card'
     this.gateKicker.className = 'ab-gate-kicker'
@@ -326,8 +389,12 @@ export class Hud {
     t.paddingLeft = `${c.bandPad.left}px`
     t.height = `${c.band.h}px`
     this.odo.setSize(c.odoPx)
+    this.rateEl.style.fontSize = `${c.ratePx}px`
+    this.sideEl.style.width = `${c.side.w}px`
 
     const r = this.railEl.style
+    r.gridTemplateColumns = `repeat(${c.railCols},1fr)`
+    r.setProperty('--ab-btn-px', `${c.railLabelPx}px`)
     r.paddingTop = `${c.railPad.top}px`
     r.paddingRight = `${c.railPad.right}px`
     r.paddingBottom = `${c.railPad.bottom}px`
@@ -445,7 +512,12 @@ export class Hud {
       b.addEventListener('click', () => this.cb.onChip(i))
       this.gateChips.appendChild(b)
     })
+    const wasOpen = !this.gate.hidden
     this.gate.hidden = false
+    // Only a fresh appearance needs guarding. The next question after a wrong
+    // answer reuses a card that is already on screen and already armed, and
+    // disarming it there would cost the child a tap.
+    if (!wasOpen) this.guard.open()
   }
 
   markChip(index: number, right: boolean): void {
@@ -460,6 +532,7 @@ export class Hud {
 
   hideGate(): void {
     this.gate.hidden = true
+    this.guard.close()
   }
 
   get gateOpen(): boolean {

--- a/dynawalla/games/merge-idle/src/ui/tapGuard.test.ts
+++ b/dynawalla/games/merge-idle/src/ui/tapGuard.test.ts
@@ -1,0 +1,96 @@
+// ONE TAP, ONE THING.
+//
+// Reported from a device: "sometimes when I hit the 'tide' bubble, the tap goes
+// through to an answer in the overlay." The tide bubble is drawn on the canvas
+// and `Game.onDown` opens the tide gate from `pointerdown`, synchronously. The
+// gate is a child of the same stage, so the four answer chips are laid out
+// under the still-pressed finger before it lifts — and the `click` the browser
+// then synthesises for that tap is delivered to whichever chip is now at that
+// coordinate. One tap opened the gate and answered it. It was intermittent only
+// because it needed the bubble to be over where a chip happened to land.
+//
+// These tests drive the exact event sequence a real touch emits, in the exact
+// order the listeners see it — the pack-wide capture listeners on the root
+// first, then the gate's own — and assert what got through.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { TapGuard, type TapEvent } from './tapGuard.ts'
+
+/**
+ * A touch, as a browser actually delivers it.
+ *
+ * `openOn` names the event during which the surface appears; `undefined` means
+ * it was already there. Returns the events the surface was allowed to act on.
+ */
+function tap(g: TapGuard, openOn?: 'pointerdown'): TapEvent[] {
+  const acted: TapEvent[] = []
+  g.pointerDown()
+  if (openOn === 'pointerdown') g.open()
+  // The finger comes up. The root sees it first, then the gate.
+  g.pointerUp()
+  if (g.accept('pointerup')) acted.push('pointerup')
+  // ...and the browser synthesises the click from that same press.
+  if (g.accept('click')) acted.push('click')
+  return acted
+}
+
+test('the tap that opens the tide gate does not also answer it', () => {
+  const g = new TapGuard()
+  const acted = tap(g, 'pointerdown')
+  assert.ok(
+    !acted.includes('click'),
+    `the opening tap reached the gate as ${acted.join(' + ')} — that click picks an answer`,
+  )
+})
+
+test('the very next tap answers normally', () => {
+  const g = new TapGuard()
+  tap(g, 'pointerdown')
+  // A child who taps a chip must be heard the first time. A guard that eats
+  // two taps is a worse bug than the one it replaced.
+  const acted = tap(g)
+  assert.ok(acted.includes('click'), 'the answer tap after the gate opened was swallowed')
+})
+
+test('a gate that appears with no finger down is live immediately', () => {
+  // The offline tide at launch, and the next question after a wrong answer.
+  // Nobody is pressing anything; blocking there would cost the child a tap.
+  const g = new TapGuard()
+  g.open()
+  assert.equal(g.blocking, false)
+  assert.ok(tap(g).includes('click'), 'the first tap on an unprompted gate was swallowed')
+})
+
+test('a gesture that never produces its click does not veto the next one', () => {
+  // A drag that turns into a scroll, or a pointercancel: the click we were
+  // holding a veto for never arrives, and the veto must not outlive it.
+  const g = new TapGuard()
+  g.pointerDown()
+  g.open()
+  g.pointerUp() // no click follows
+  const acted = tap(g)
+  assert.ok(acted.includes('click'), 'a stale veto ate the next real tap')
+})
+
+test('a second finger cannot answer while the first is still opening', () => {
+  // Children put more than one finger on a screen. While the opening finger is
+  // still down the gate is `blocking`, and a `pointerdown` from another finger
+  // must not reach a chip either.
+  const g = new TapGuard()
+  g.pointerDown()
+  g.open()
+  assert.equal(g.blocking, true)
+  assert.equal(g.accept('pointerdown'), false, 'a second finger answered the gate it just opened')
+  assert.equal(g.accept('click'), false, 'and its click got through')
+})
+
+test('closing and reopening guards again', () => {
+  const g = new TapGuard()
+  tap(g, 'pointerdown')
+  tap(g)
+  g.close()
+  const acted = tap(g, 'pointerdown')
+  assert.ok(!acted.includes('click'), 'the second tide bubble tapped straight through')
+})

--- a/dynawalla/games/merge-idle/src/ui/tapGuard.ts
+++ b/dynawalla/games/merge-idle/src/ui/tapGuard.ts
@@ -1,0 +1,102 @@
+/**
+ * A gesture that OPENS a surface must never also act on that surface.
+ *
+ * The tide bubble is drawn on the canvas and answered in a DOM overlay that is
+ * a child of that same canvas stage. `Game.onDown` opens the gate from
+ * `pointerdown`, synchronously, so by the time the finger lifts the four answer
+ * chips are already laid out underneath it — and the browser then delivers the
+ * `click` for that same tap to whatever is now at that coordinate. One tap
+ * opened the gate AND picked an answer. It only happened "sometimes" because it
+ * needed the bubble to be over where a chip landed.
+ *
+ * Moving the opener to `pointerup` does not help: the `click` still follows, at
+ * the same coordinate, after the overlay exists.
+ *
+ * So the overlay is ARMED rather than merely shown. It ignores input for the
+ * remainder of the gesture that opened it, and swallows the one `click` that
+ * gesture synthesises on its way out. A guard, not a timeout: a timeout is a
+ * guess about how fast a finger is, and it is wrong on a slow device in one
+ * direction and on a quick tap in the other.
+ *
+ * How the two halves meet, because the order matters and is not obvious. The
+ * pack-wide `pointerDown`/`pointerUp` are bound on the ROOT in the capture
+ * phase and the overlay's `accept` on the GATE, also capture — and capture runs
+ * outside-in, so the root always sees an event first. In the single-touch case
+ * that means the lift is recorded before `accept` is asked about it, and what
+ * actually stops the tap-through is `eatClick`. The `blocked` branch of
+ * `accept` is for the second finger of a multi-touch: a `pointerdown` that
+ * lands on the gate while the opening finger is still down.
+ *
+ * It is a plain state machine with no DOM in it, so `tapGuard.test.ts` can
+ * drive the exact sequence a real touch emits — `pointerdown`, `pointerup`,
+ * `click` — and assert what got through.
+ *
+ * Opening WITHOUT a finger down is the normal case for the offline tide at
+ * launch and for the next question after a wrong answer, and it must not cost
+ * the child a tap. `open()` therefore blocks only when a pointer is actually
+ * down; otherwise the surface is live immediately.
+ */
+
+/** The pointer events the guard cares about, in the order a touch emits them. */
+export type TapEvent = 'pointerdown' | 'pointerup' | 'click'
+
+export class TapGuard {
+  /** Is a finger down anywhere in the pack right now? */
+  private down = false
+  /** The surface opened inside a gesture that has not finished. */
+  private blocked = false
+  /** ...and that gesture still owes us a `click` we must not honour. */
+  private eatClick = false
+
+  /* --- what the pack as a whole sees, bound in the capture phase on the root */
+
+  pointerDown(): void {
+    this.down = true
+    // A gesture that never produced its click (a cancel, a scroll) must not
+    // leave the guard holding a veto for the child's next real tap.
+    this.eatClick = false
+  }
+
+  pointerUp(): void {
+    this.down = false
+    if (this.blocked) {
+      this.blocked = false
+      this.eatClick = true
+    }
+  }
+
+  /* ------------------------------------------- what the surface itself sees */
+
+  /** The surface just appeared. */
+  open(): void {
+    this.blocked = this.down
+    this.eatClick = false
+  }
+
+  /** The surface went away; nothing is owed. */
+  close(): void {
+    this.blocked = false
+    this.eatClick = false
+  }
+
+  /** True while the opening gesture is still in flight. */
+  get blocking(): boolean {
+    return this.blocked
+  }
+
+  /**
+   * May the surface act on this event? Call it for every event the overlay
+   * receives, in the order they arrive, and act only when it returns true.
+   */
+  accept(e: TapEvent): boolean {
+    if (this.blocked) {
+      if (e === 'pointerup') this.eatClick = true
+      return false
+    }
+    if (e === 'click' && this.eatClick) {
+      this.eatClick = false
+      return false
+    }
+    return true
+  }
+}


### PR DESCRIPTION
Five defects the founder reported on ABYSSAL BLOOM from device photos. Four turn out to be layout, one is a gesture. They all live in the same four files of one pack, so they land together rather than as a stack of conflicting worktrees — the diff is sectioned by defect and each has its own test file.

## 1. The vent number-pills were painted over the bottom row of polyps

> *"I dont think the pull numbers over the reef board are very perfect. shouldn't the pill numbers be under the poly horizontally rather than over them in Z?"*

He is right about the fix and it is not a z-order. The vents draw **after** the polyps, on the same canvas, with a 0.95-alpha chimney — whatever they overlap they erase. Dimming, restacking or shrinking the pills would all have been ways of not fixing it.

`computeLayout` sized the shelf as if a polyp were exactly its cell. It is not: a sprite is `SPRITE_SCALE` (1.62) cells across and centred on the cell, so it reaches **0.31 of a cell past the cell box on every side**, and the rock the shelf sits on is drawn `gap * 2.2` outside that again. The clearance left between the grid's arithmetic bottom and the vent strip was one `pad` — 8 to 22px — which is smaller than the bleed at every portrait size the fleet has.

The vents are now placed **first** and the shelf is solved for the remainder, at a cell whose *drawn* extent fits. That extent is `layout.gridRect`, and `drawShelf` paints to it, so the reservation and the paint cannot drift apart.

| viewport | before | after |
|---|---|---|
| 320×568 | 15.5px **over** | 9.6px clear |
| 360×780 (the founder's, in CSS px) | 15.5px **over** | 34.2px clear |
| 390×844 notched | 6.1px **over** | 11.7px clear |
| 768×1024 | 17.6px **over** | 22.0px clear |

**The pills are labels, not targets.** The drop zone is the whole chimney — a polyp dragged anywhere onto a vent is fed to it — so the test holds the *chimney* to 44px, not the pill.

Reserving the band means a 9-row shelf will not fit a small notched phone. Rather than ship colliding numerals, `shelfCap` stops DEEPEN growing into a shelf the glass cannot draw, and `computeLayout` **shrinks** an oversized one (a tablet save, a rotation) instead of overrunning the vents with it. The old 18px cell floor did the opposite of what it looked like it did: it did not create room, it made the shelf overflow onto the vents.

## 2. DISSOLVE appearing pushed the whole board up

> *"the appearance of the dissolve button pushes the whole board up. maybe it should appear somewhere else so as not to move the layout."*

`visible: false` until the shelf filled, and a `display:none` button takes no grid cell. Four buttons made two rows; five made three; the rail grew, the stage shrank, the reef jumped.

**I reserved the slot rather than moving the button**, for three reasons: the locked-but-present idiom already exists here (UPWELL renders greyed when unaffordable, `.ab-btn[disabled]{opacity:.34}`); a visible DISSOLVE teaches that the escape hatch exists *before* a child is desperate for it, which the how-to-play sheet already promises ("You can never get stuck"); and an overlay would have covered the playfield it was meant to protect.

It costs nothing, because the rail also went from 2 columns to **3** (and from 4 to **5** when wide). Five buttons still fit the same two rows — rail height is byte-identical at every viewport. `.ab-btn` also gained a fixed `height` instead of `min-height` and `nowrap` labels, so a long label can never grow the rail either.

DISSOLVE is the only conditional control in the pack; the action list moved to a pure `ui/actions.ts` so that "no reef state changes how many buttons the rail shows" is a test over every combination, not something a reviewer has to notice.

## 3 & 5. The ESSENCE readout was clipped down to its punctuation

> *"the top is a little disordered and non-premium. I think it is even failing to show a score number?"*

**What the value actually was.** I could not recover the digits, but the *shape* is diagnostic and I did not have to guess at the mechanism. `fmtCompact` only emits a magnitude letter at ≥100,000, so the `.K` photo was a value in `[100000, 999999]` rendered as `NNN.NK`, and the earlier `,0`/`0,` sightings were the grouped form, `[1000, 99999]`. Every digit was clipped; the punctuation was not. That asymmetry is the whole bug:

> An odometer digit column is `overflow:hidden`, and **a flex item whose `overflow` is not `visible` has an automatic minimum size of zero**. So when the odometer outgrew its column the digit columns shrank to nothing, while the `.` and the `K` — plain spans, floored at their content — survived.

It outgrew its column because `odoPx` was computed from the **whole band** (`readoutW * 0.14`) while the odometer actually lived in whatever the pips left of it, and `.ab-pips` took up to 44% of the band. The same miscount explains the other three symptoms in that photo: the rate wrapped because it shared its row with the FLOW pill; the pill sat on the number because nothing reserved space for it; and **the stray dot below the meter is a wrapped meter cell** — twelve 7px pips with 3px gaps need 117px, `max-width:44%` gave them ~104px at 360, and the twelfth wrapped and hung alone.

The band is now two columns:

- a reserved right-hand column for FLOW (74px, the width of `×9.9 FLOW`) with the meter as a fixed **6-wide, 2-row grid** — a deliberate two rows, not a wrap that breaks wherever it runs out
- the essence column gets the rest; `odoPx` is floored so that the widest string `fmtCompact` can ever produce (`999.9Qa`, 4.06em) fits **that** column
- the rate has the essence column to itself, `nowrap`, sized to fit `▲ 999.9Qi / sec`
- digit columns are `flex:0 0 auto`, so they can never be squeezed away again even if the arithmetic is ever wrong

**The header's height cannot change as the numbers grow** — every variable-width thing sits on a fixed line box, and there is a test that the band height and stage origin depend only on the viewport.

Two more found in the same file while I was there: the odometer rebuilt only on a change of *length*, so `99,999` → `100.0K` reused a separator column for a digit and read the `.` as a zero; and resizing it moved the digit stacks without relaying the digit spans inside them, so after a rotation it showed the **wrong number** for as long as the shape held.

## 4. The tap that opened the tide gate also answered it

> *"sometimes when I hit the 'tide' bubble, the tap goes through to an answer in the overlay."*

The tide bubble is the floating `TIDE` ball on the canvas (`state.swell`). `Game.onDown` opens the gate from **`pointerdown`**, synchronously, and `.ab-gate` is a child of the same stage — so the four answer chips are laid out under a finger that is still down, and the `click` the browser then synthesises for that tap is delivered to whichever chip is now at that coordinate. "Sometimes" because it needed the bubble to be over where a chip landed. Moving the opener to `pointerup` would not have helped; the click still follows.

`TapGuard` arms the overlay rather than merely showing it. It is a plain state machine with no DOM in it, so the test drives the exact sequence a real touch emits (`pointerdown` → `pointerup` → `click`) in the exact order the listeners see it. A guard, not a timeout — a timeout is a guess about how fast a finger is.

It opens *live* when no pointer is down, so the offline tide at launch and the next question after a wrong answer still take the child's first tap; a gesture that never produces its click (a cancel, a scroll) does not leave a veto behind; and it is wired at the gate's own edge, so every future control on that card is covered without having to remember. The tide gate is the only DOM overlay this pack owns — the how-to-play sheet belongs to the shared chrome.

## Bonus: a small phone held sideways could not draw a legible shelf at all

Found by adding the **rotations** of the fleet's portrait shapes to the layout test, which the old matrix never had. At 568×320 the vents came out 37px tall — a drop target a seven-year-old cannot hit — and after the band and the rail had taken theirs the reef had 83px in which to draw six rows.

Height is the scarce axis on that glass and width is not, so it spends width instead: the rail goes to one row of five, the odometer caps at 34px rather than 48, `pad` scales off the **shorter** side of the stage rather than the width, and `ventCap` will not create more vents than fit at 44px. Starting-shelf cell at 568×320: **12px → 20px**; notched, 16.6 → 19.

## Verification

175 tests, run 5× (this pack has a documented history of flaky single runs). `tsc --noEmit` clean.

Every fix was **deleted and the tests confirmed to fail**:

| fix removed | message |
|---|---|
| the drawn-extent divisor | `vent 0 [9.6,282.0 147.4x99.2] covers the shelf [36.8,5.8 246.5x291.7] by 120.2x15.5px — a child cannot read the bottom row` — 90 of 92 |
| DISSOLVE conditional again | `the rail shows 4 or 5 buttons depending on state` · `a button appearing moves the shelf by -2.2px and resizes every polyp from 36.7px to 29.5px` |
| the reserved FLOW/meter column | `the FLOW column is 0px and the pill needs 72px — it will sit on the number` |
| the odometer's column cap | `240px wide: the odometer needs 106px in a 90px column — the score gets clipped down to its punctuation` |
| `TapGuard.accept` | `the opening tap reached the gate as pointerup + click — that click picks an answer` · `a second finger answered the gate it just opened` |

The first version of the essence test **passed with the fix removed**, because it measured against `chrome.essence.w` — a number the fix itself produces. It now measures against what the FLOW pill and a pip row independently require, which is why `sideW = 0` fails it.

`hitsHostChrome` still holds for the readout, the mute button, the rail, the shelf and the vents at every viewport in the matrix.

## What I could NOT verify without a device

- **Nothing here was seen rendered.** There is no `node_modules` in the tree and no headless browser wired up for this pack, so every number is arithmetic from the real layout functions. What that catches is geometry; what it cannot catch is a font behaving differently from the model.
- **Text width is modelled, not measured.** The rate line, the FLOW pill and the rail labels are guarded by deliberately fat per-character advances (0.66em for the rate, 0.72em for `OVERCHARGE`). The real 900-weight rounded face sets narrower, so passing leaves room — but if SF Pro Rounded is missing and a wide fallback is used, `OVERCHARGE` in a 3-across rail at 320px is the first thing that would clip. It is `nowrap` inside a fixed-height button, so it would clip rather than reflow; the reef would not move either way.
- **The `.K` mechanism is from the CSS spec, not from a rendered page.** The automatic-minimum-size behaviour of `overflow:hidden` flex items is what explains the photo exactly, and `flex:0 0 auto` on the digit columns removes the possibility regardless — but that specific line is not covered by a test, because there is no DOM in these tests.
- **I never reproduced the founder's exact pixel overlap**, because I do not have the screenshots. What I measured is that the drawn shelf and the vents overlapped by 1.4–17.6px depending on viewport and shelf, always along the bottom row, with the opaque chimney drawn last. That is consistent with what he described and it is unambiguously wrong on its own terms; I have not claimed a magnitude I cannot see.
- **The mute button is 30×30**, under the 44px minimum. Pre-existing, untouched, and worth a follow-up.
- **A save carried in from a much larger screen** can still put an oversized shelf on a small one. It now *shrinks* rather than overrunning the vents, which is the right failure, but the polyps will be small until the child rotates back. Culling the shelf would be destructive; capping growth is what this PR does.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb