### PR TITLE
fix(dynawalla/games/trebuchet): the wind stops marking a right answer wrong

### DIFF
--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -64,12 +64,14 @@ import {
   type Outcome,
   type Solved,
 } from './sim/ballistics.ts'
+import { aimShot, rollWind, verdictFor } from './sim/verdict.ts'
 import {
   buildTower,
   FIELD_MAX,
   LAUNCH_X,
   layoutTowerValues,
   pullQuestions,
+  ramAdvances,
   shatter,
   stepBlocks,
   waveConfig,
@@ -352,7 +354,7 @@ export class TrebuchetGame {
     this.towers = values.map((v, i) => buildTower(i, v, this.rng, cfg.volley && i % 2 === 0))
     this.markWanted()
 
-    this.wind = cfg.wind ? this.rollWind() : 0
+    this.wind = rollWind(cfg.wind, this.rng)
     this.wall = null
     if (cfg.wall) {
       const nearest = Math.min(...values)
@@ -363,7 +365,10 @@ export class TrebuchetGame {
       this.wall = { x: worldX(wx), h: Math.max(6, clearH * 0.78) }
     }
     this.ram = cfg.ram
-      ? { range: FIELD_MAX - 4, speed: 1.5 + cfg.difficulty * 1.6, alive: true, wheel: 0, hp: 1, bob: 0 }
+      ? // Faster than it was, because it now only rolls while the world is moving:
+        // about 4 s of every shot instead of however long the sum took. Four to six
+        // boulders and it is at the walls — the same threat, off the thinking clock.
+        { range: FIELD_MAX - 4, speed: 4.2 + cfg.difficulty * 3, alive: true, wheel: 0, hp: 1, bob: 0 }
       : null
 
     this.craters = []
@@ -392,15 +397,6 @@ export class TrebuchetGame {
     if (!this.reduced && n % 3 === 0 && this.flash.add(0.16, 0.22, 0.5, 0.2, 1.2)) {
       this.backdrop.strike(this.cosmetic)
     }
-  }
-
-  private rollWind(): number {
-    const cap = this.cfg.wind
-    if (!cap) return 0
-    let v = 0
-    // never 0 — a wind chip showing 0 is a lie about the mechanic being on
-    while (v === 0) v = this.rng.int(-cap, cap)
-    return v
   }
 
   private markWanted(): void {
@@ -625,7 +621,9 @@ export class TrebuchetGame {
   private release(): void {
     const b = this.activeBoulder
     if (!b) return
-    const shot = solve(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+    // Aimed at the dial, not displaced by the wind: `aimShot` lays the machine
+    // off into the crosswind so the boulder comes down on the metre she named.
+    const shot = aimShot(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
     this.shot = shot
     this.pending = resolve(shot.landing, this.towers)
     this.shotT = 0
@@ -671,9 +669,17 @@ export class TrebuchetGame {
     if (!b || !this.shot) return
     const landing = this.shot.landing
     const out = this.pending ?? resolve(landing, this.towers)
-    const struck = kind === 'tower' ? hit : out.target
-    const correct = !!struck && struck.value === b.answer && (out.quality === 'direct' || out.quality === 'solid')
-    const graze = !!struck && out.quality === 'graze' && struck.value === b.answer
+    // The verdict is the child's number against the number she was asked for, and
+    // nothing else — not the keep the blast happened to reach, not the metre the
+    // ground recorded. A boulder spent on the ram is not an answer at all.
+    const v = verdictFor({ dial: this.dial, landing, answer: b.answer, kind })
+    const correct = v.correct
+    // The ram swallows the boulder where it stands: no keep is touched by a shot
+    // that never got past the siege engine.
+    const struck = kind === 'ram' ? null : kind === 'tower' ? hit : out.target
+    // The garrison only answers when the shot came down ON another keep — naming
+    // the wrong number. Landing a metre short of the right one is not that.
+    const struckWrongKeep = !!struck && struck.value !== b.answer && out.errorM <= 1
 
     this.audio.flightStop()
     this.phase = 'impact'
@@ -748,7 +754,7 @@ export class TrebuchetGame {
     let destroyed = false
     if (struck) {
       struck.flash = 1
-      if (correct || kind === 'ram') {
+      if (correct) {
         const freed = shatter(struck, x, y, 2.6, this.cosmetic, true)
         void freed
         struck.alive = false
@@ -760,14 +766,14 @@ export class TrebuchetGame {
         this.flash.add(0.24, 0.4, x / Math.max(1, worldX(FIELD_MAX)), 0.55, 0.8)
         // the number itself comes apart
         this.burstNumber(struck)
-      } else if (out.quality === 'graze' || !correct) {
-        struck.damage = clamp01(struck.damage + (out.quality === 'graze' ? 0.34 : 0.6))
+      } else {
+        struck.damage = clamp01(struck.damage + (struckWrongKeep ? 0.6 : 0.34))
         struck.lean = (x < worldX(struck.range) ? 1 : -1) * 0.07
         struck.leanV = 0
         // a rival keep is cracked, never levelled: being wrong must stay quieter
         // than being right, and a keep with no masonry left reads as destroyed
-        shatter(struck, x, y, out.quality === 'graze' ? 0.2 : 0.34, this.cosmetic, false, out.quality === 'graze' ? 2 : 5)
-        if (!correct && out.quality !== 'graze') {
+        shatter(struck, x, y, struckWrongKeep ? 0.34 : 0.2, this.cosmetic, false, struckWrongKeep ? 5 : 2)
+        if (struckWrongKeep) {
           this.audio.wrongHorn()
           this.host.haptic('failure')
           this.counterFire(struck)
@@ -799,12 +805,9 @@ export class TrebuchetGame {
 
     // --- score & host report -------------------------------------------
     const ms = Math.max(1, Math.round(performance.now() - this.questionShownAt))
-    this.host.report({
-      questionId: b.q.id,
-      correct,
-      ms,
-      answered: struck ? String(struck.value) : String(landing),
-    })
+    if (v.report) {
+      this.host.report({ questionId: b.q.id, correct, ms, answered: v.answered })
+    }
     if (correct) {
       this.combo += 1
       const gained = shotScore(out.quality, this.combo, this.cfg.difficulty)
@@ -812,16 +815,14 @@ export class TrebuchetGame {
       this.scorePop = 0
       this.hitsThisWave += 1
       b.hit = true
-    } else {
+    } else if (v.report) {
+      // Only a wrong ANSWER breaks the chain. Spending a boulder on the ram is a
+      // choice about the siege, and the game does not punish it as arithmetic.
       this.combo = 0
       this.revealT = 1.6
     }
-    if (!graze) {
-      b.spent = true
-    } else {
-      // a graze on the right keep still costs the boulder — but it says so with a lean
-      b.spent = true
-    }
+    // The boulder is gone either way: it was thrown.
+    b.spent = true
     void destroyed
     this.markWanted()
   }
@@ -1067,7 +1068,7 @@ export class TrebuchetGame {
             this.phase = 'aim'
             this.phaseT = 0
             this.questionShownAt = performance.now()
-            if (this.cfg.gusty) this.wind = this.rollWind()
+            if (this.cfg.gusty) this.wind = rollWind(this.cfg.wind, this.rng)
           }
         }
         break
@@ -1085,8 +1086,8 @@ export class TrebuchetGame {
       if (this.counterIn <= 0) this.counterLand()
     }
 
-    // the ram never stops
-    if (this.ram?.alive && this.phase !== 'impact') {
+    // the ram never stops — except while the child is working the sum out
+    if (this.ram?.alive && ramAdvances(this.phase)) {
       this.ram.range -= this.ram.speed * dt
       this.ram.wheel += dt * 4
       if (this.ram.range <= 6) {
@@ -1291,7 +1292,7 @@ export class TrebuchetGame {
     // The loft stub — the first slice of the arc — only once the lever exists to
     // change it. Before that it would be decoration teaching nothing.
     if (this.cfg.loft) {
-      const st = solve(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+      const st = aimShot(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
       ctx.beginPath()
       const pts = samplePath(st, 14, st.T * 0.34)
       for (let i = 0; i < pts.length; i++) {

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -34,6 +34,7 @@ export function mount(el: HTMLElement, host: Host): Mounted {
           'Use the plus and minus buttons to wind the dial to 56.',
           'You can also drag across the field to move the dial a long way at once.',
           'Then fire, and the boulder flies exactly that far and knocks it down.',
+          'When there is a wind, your crew aims into it. The shot bends, and still lands on your number.',
         ],
       },
       {

--- a/dynawalla/games/trebuchet/src/pack.ts
+++ b/dynawalla/games/trebuchet/src/pack.ts
@@ -9,8 +9,10 @@
 // stands at its own answer in metres, which means the answer has to be known
 // before the child fires rather than after — that is what `items.reveal` is
 // for, and it is why the game can put an error somewhere on the ground instead
-// of behind a buzzer. The game never judges: it reports the range it actually
-// struck, and the host decides what that was worth.
+// of behind a buzzer. The game never judges: it reports the range the CHILD
+// named on the dial — never the metre the ground recorded, never the value of
+// whichever keep the blast happened to reach — and the host decides what that
+// was worth. `sim/verdict.ts` is where that promise is kept and tested.
 //
 // The stub host in `stubHost.ts` stays exactly where it is. It is what
 // `npm run dev` mounts, it is what the ballistics tests drive, and it is not

--- a/dynawalla/games/trebuchet/src/sim/verdict.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.test.ts
@@ -1,0 +1,237 @@
+/**
+ * The one thing this game may never do.
+ *
+ * `game.ts` already says it, at the top of `pending`: "Anything else would punish
+ * correct arithmetic, which is the one thing this game may never do." These tests
+ * hold the whole shot pipeline — aim, land, resolve, report — to that sentence.
+ *
+ * The child modelled here is a competent one. She reads `47 + 25`, works out 72,
+ * dials 72, and fires. Every assertion below is about what happens to her.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { posAt, resolve, samplePath, type TargetRef } from './ballistics.ts'
+import { aimShot, rollWind, verdictFor, windValues, type ShotKind } from './verdict.ts'
+import { waveConfig } from './world.ts'
+import { makeRng } from '../core/rng.ts'
+
+/** The lofts the machine offers. The landing may not depend on any of them. */
+const LOFTS = [30, 38, 46, 55, 65]
+const LAUNCH_H = 11
+
+/** A plausible field: keeps at least MIN_GAP (8 m) apart, one of them the answer. */
+const FIELD = [40, 56, 72, 88, 104]
+const ANSWER = 72
+
+const towers = (): TargetRef[] =>
+  FIELD.map((range, id) => ({ id, range, value: range, alive: true }))
+
+/**
+ * One shot, through exactly the path `game.ts` walks: aim at the dialled metre,
+ * see where it comes down, resolve that against the keeps, and turn the result
+ * into what the host is told.
+ */
+function takeShot(
+  dial: number,
+  answer: number,
+  wind: number,
+  angleDeg: number,
+  kind: ShotKind = 'ground',
+): { landing: number; felled: boolean; report: boolean; correct: boolean; answered: string } {
+  const shot = aimShot(dial, angleDeg, wind, LAUNCH_H)
+  // The game resolves the landing against the keeps to decide what comes apart.
+  // The verdict may not depend on the answer to that question — but the child
+  // watching does: being told she is right while the keep stays standing is its
+  // own kind of lie, so both are measured.
+  const out = resolve(shot.landing, towers())
+  const felled = out.quality === 'direct' && out.target?.value === answer
+  const v = verdictFor({ dial, landing: shot.landing, answer, kind })
+  return { landing: shot.landing, felled, ...v }
+}
+
+/**
+ * The host does not receive `correct`. `game-host/index.ts` sends
+ * `answer({ response: answered })` and the curriculum judges the string.
+ * So this — not the game's own opinion — is what lands in the learner model.
+ */
+const recordedCorrect = (answered: string, answer: number): boolean => answered === String(answer)
+
+const WAVES = [3, 5, 7, 10, 12, 16]
+const pct = (n: number, d: number): string => (d === 0 ? 'n/a' : `${((n / d) * 100).toFixed(1)}%`)
+
+test('wind never turns a correct answer into a wrong one, at any wave', () => {
+  const rows: string[] = []
+  for (const w of WAVES) {
+    const cap = waveConfig(w).wind
+    let shots = 0
+    let falseWrong = 0
+    let stoodThere = 0
+    for (const wind of windValues(cap)) {
+      for (const angle of LOFTS) {
+        const r = takeShot(ANSWER, ANSWER, wind, angle)
+        shots++
+        if (!r.correct) falseWrong++
+        if (!r.felled) stoodThere++
+      }
+    }
+    rows.push(
+      `wave ${w} (wind cap ${cap}): ${pct(falseWrong, shots)} of correct answers scored WRONG, ` +
+        `${pct(stoodThere, shots)} left the keep standing`,
+    )
+  }
+  assert.equal(
+    rows.join('\n'),
+    WAVES.map(
+      (w) =>
+        `wave ${w} (wind cap ${waveConfig(w).wind}): 0.0% of correct answers scored WRONG, ` +
+        `0.0% left the keep standing`,
+    ).join('\n'),
+  )
+})
+
+test('wind never turns a correct answer into a wrong one IN THE LEARNER MODEL', () => {
+  const rows: string[] = []
+  for (const w of WAVES) {
+    const cap = waveConfig(w).wind
+    let shots = 0
+    let falseWrong = 0
+    for (const wind of windValues(cap)) {
+      for (const angle of LOFTS) {
+        const r = takeShot(ANSWER, ANSWER, wind, angle)
+        shots++
+        if (!recordedCorrect(r.answered, ANSWER)) falseWrong++
+      }
+    }
+    rows.push(`wave ${w} (wind cap ${cap}): ${pct(falseWrong, shots)} recorded as a WRONG ANSWER`)
+  }
+  assert.equal(
+    rows.join('\n'),
+    WAVES.map((w) => `wave ${w} (wind cap ${waveConfig(w).wind}): 0.0% recorded as a WRONG ANSWER`).join('\n'),
+  )
+})
+
+test('a wrong dial is never recorded as a right answer', () => {
+  // The mirror image, and just as poisoning: a child who dials one short must
+  // not be written into the model as a child who knew it.
+  const bad: string[] = []
+  for (const w of WAVES) {
+    const cap = waveConfig(w).wind
+    for (const wind of windValues(cap)) {
+      for (const dial of [ANSWER - 3, ANSWER - 2, ANSWER - 1, ANSWER + 1, ANSWER + 2, ANSWER + 3]) {
+        const r = takeShot(dial, ANSWER, wind, LOFTS[2])
+        if (recordedCorrect(r.answered, ANSWER)) {
+          bad.push(`wave ${w}: dialled ${dial} for ${ANSWER} with wind ${wind} -> recorded "${r.answered}"`)
+        }
+        if (r.correct) {
+          bad.push(`wave ${w}: dialled ${dial} for ${ANSWER} with wind ${wind} -> scored CORRECT`)
+        }
+      }
+    }
+  }
+  assert.equal(bad.slice(0, 6).join('\n'), '', `${bad.length} wrong dials were treated as right`)
+})
+
+test('the number reported to the host is the number the child dialled', () => {
+  for (const wind of [-9, -4, -1, 0, 1, 4, 9]) {
+    for (const dial of [14, 40, 71, 72, 73, 104, 118]) {
+      const r = takeShot(dial, ANSWER, wind, LOFTS[2])
+      assert.equal(r.answered, String(dial), `dial ${dial}, wind ${wind}`)
+    }
+  }
+})
+
+test('if anything ever moves the landing again, the dial still wins — loudly', () => {
+  // `aimShot` makes landing === dial, so today this cannot happen. It could not
+  // happen before either, right up until the wind was added. The report is pinned
+  // to the child's number independently of the ground, and the disagreement is
+  // logged rather than swallowed, because the alternative is silently marking a
+  // child on a number she never chose.
+  const real = console.error
+  const shouted: string[] = []
+  console.error = (...args: unknown[]) => shouted.push(args.join(' '))
+  try {
+    for (const drift of [-9, -4, -1, 1, 5, 9]) {
+      const v = verdictFor({ dial: 72, landing: 72 + drift, answer: 72, kind: 'ground' })
+      assert.equal(v.answered, '72', `drift ${drift}`)
+      assert.equal(v.correct, true, `drift ${drift}`)
+    }
+    const wrong = verdictFor({ dial: 71, landing: 72, answer: 72, kind: 'ground' })
+    assert.equal(wrong.answered, '71', 'the metre struck is not the answer given')
+    assert.equal(wrong.correct, false)
+  } finally {
+    console.error = real
+  }
+  assert.equal(shouted.length, 7, 'every disagreement is logged')
+  assert.match(shouted[0], /landed at 63 but the dial said 72/)
+})
+
+test('the dial IS the landing metre — the wind does not move it', () => {
+  for (const w of WAVES) {
+    for (const wind of windValues(waveConfig(w).wind)) {
+      for (const angle of LOFTS) {
+        for (const dial of [8, 14, 40, 72, 104, 122]) {
+          assert.equal(
+            aimShot(dial, angle, wind, LAUNCH_H).landing,
+            dial,
+            `wave ${w}: dial ${dial}, wind ${wind}, loft ${angle}`,
+          )
+        }
+      }
+    }
+  }
+})
+
+test('aiming into the wind still produces a real arc, even in the worst corner', () => {
+  // The compensation launches at `dial − wind`, which at the bottom of the dial
+  // against the strongest wind is a very short throw. It must still be a finite,
+  // drawable arc that reaches the ground on the dialled metre.
+  for (const wind of [-9, 9]) {
+    for (const angle of LOFTS) {
+      const s = aimShot(8, angle, wind, LAUNCH_H)
+      assert.ok(Number.isFinite(s.T) && s.T > 0, `flight time wind ${wind} loft ${angle}: ${s.T}`)
+      assert.ok(s.apexY > 0, `apex wind ${wind} loft ${angle}`)
+      for (const p of samplePath(s, 12)) {
+        assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y), `path wind ${wind} loft ${angle}`)
+      }
+      assert.ok(Math.abs(posAt(s, s.T).x - 8) < 1e-9, `comes down on the dial, wind ${wind}`)
+    }
+  }
+})
+
+test('a boulder spent on the ram is not an answer to the question', () => {
+  // A child who knocks the siege engine off her walls has not said anything
+  // about 47 + 25. Reporting it as a wrong answer writes "does not know this"
+  // into the model for a shot that was never an attempt at the sum.
+  const ram = takeShot(30, ANSWER, 0, LOFTS[2], 'ram')
+  assert.equal(ram.report, false, 'a ram shot must not be reported as an answer')
+
+  // And the mirror: the ram can stand on the very metre the answer is at, so a
+  // perfectly dialled boulder can be swallowed on its way out. That is not a hit
+  // either — no keep came down, so nothing may be scored as one.
+  const intercepted = takeShot(ANSWER, ANSWER, 0, LOFTS[2], 'ram')
+  assert.equal(intercepted.report, false, 'still not an answer')
+  assert.equal(intercepted.correct, false, 'no keep fell, so nothing was struck')
+
+  for (const kind of ['tower', 'ground', 'wall'] as ShotKind[]) {
+    const r = takeShot(ANSWER, ANSWER, 0, LOFTS[2], kind)
+    assert.equal(r.report, true, `${kind} is an answer`)
+    assert.equal(r.correct, true, `${kind} on the right metre is right`)
+  }
+})
+
+test('rollWind only ever produces a wind the tests enumerate', () => {
+  for (const cap of [2, 3, 5, 9]) {
+    const allowed = new Set(windValues(cap))
+    const rng = makeRng(0x51e6e)
+    const seen = new Set<number>()
+    for (let i = 0; i < 4000; i++) {
+      const v = rollWind(cap, rng)
+      assert.ok(allowed.has(v), `cap ${cap} rolled ${v}`)
+      seen.add(v)
+    }
+    assert.equal(seen.size, allowed.size, `cap ${cap} did not cover its range`)
+  }
+  assert.equal(rollWind(0, makeRng(1)), 0, 'no wind means no wind')
+})

--- a/dynawalla/games/trebuchet/src/sim/verdict.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.ts
@@ -1,0 +1,96 @@
+/**
+ * What a shot MEANS — separated from where it goes, and tested on its own.
+ *
+ * `game.ts` states the law at the top of `pending`: a keep standing in the way is
+ * scenery, because "anything else would punish correct arithmetic, which is the one
+ * thing this game may never do." The wind used to do exactly that. From wave 3 the
+ * landing was `dial + wind` while the aim caret, the numeral and the whole promise
+ * of the game stood on `dial`, so a child who worked out 47 + 25 = 72 and dialled 72
+ * watched her shot land somewhere else and was told she was wrong — and, worse, the
+ * metre the wind chose was the string sent to the curriculum as her answer.
+ *
+ * Two rules now hold this together, and both are tested:
+ *
+ *   1. **The dial is the landing metre.** The crew aims upwind by exactly the
+ *      crosswind, so the boulder is launched off-target and blown onto the number.
+ *      The arc still visibly bends — the wind is real, it is drawn, it is on the
+ *      chip — it simply no longer decides whether a child knows her sums.
+ *   2. **The child's answer is the number on the dial.** Not the metre struck, not
+ *      the value of whichever keep happened to be nearest, not a landing the wind
+ *      moved. What she named is what is reported.
+ */
+
+import { solve, type Solved } from './ballistics.ts'
+import type { Rng } from '../core/rng.ts'
+
+/** Every wind `rollWind` can produce for a cap — the roll never yields 0. */
+export function windValues(cap: number): number[] {
+  const out: number[] = []
+  for (let v = -cap; v <= cap; v++) if (v !== 0) out.push(v)
+  return out
+}
+
+/** A crosswind for the wave. Never 0: a wind chip reading 0 lies about the mechanic. */
+export function rollWind(cap: number, rng: Rng): number {
+  if (!cap) return 0
+  let v = 0
+  while (v === 0) v = rng.int(-cap, cap)
+  return v
+}
+
+/**
+ * The shot that comes down on the metre the child dialled.
+ *
+ * `solve` lands at `power + wind`, so the power asked for is `dial − wind`: the
+ * machine is laid off into the wind and the wind carries the boulder home. Both
+ * terms are integers, so the landing is the dial exactly — not 71.98.
+ */
+export function aimShot(dialM: number, angleDeg: number, wind: number, h: number): Solved {
+  return solve(dialM - wind, angleDeg, wind, h)
+}
+
+/**
+ * Why the boulder stopped. `ram` is the one that is not an answer to anything: a
+ * child who knocks the siege engine off her walls has said nothing about 47 + 25.
+ */
+export type ShotKind = 'tower' | 'ground' | 'wall' | 'ram'
+
+export type ShotFacts = {
+  /** the metre the child named */
+  dial: number
+  /** the metre the boulder came down on — must equal the dial */
+  landing: number
+  /** what the loaded boulder asked for */
+  answer: number
+  kind: ShotKind
+}
+
+export type Verdict = {
+  /** false when this shot was not an attempt at the question at all */
+  report: boolean
+  /**
+   * Right answer, and a shot that was an answer. A boulder the ram swallowed on
+   * its way out is neither right nor wrong: it never reached a keep, so there is
+   * nothing to celebrate and nothing to hold against her.
+   */
+  correct: boolean
+  /** the string the host is given, and the only thing the curriculum judges */
+  answered: string
+}
+
+export function verdictFor(f: ShotFacts): Verdict {
+  if (f.landing !== f.dial) {
+    // Unreachable while `aimShot` is what fires the boulder. If it ever happens,
+    // something has put a term between the dial and the ground again, and a child
+    // is about to be marked on it — so it is loud, and the dial still wins.
+    console.error(
+      `[trebuchet] the boulder landed at ${f.landing} but the dial said ${f.dial}; reporting the dial`,
+    )
+  }
+  const answersTheQuestion = f.kind !== 'ram'
+  return {
+    report: answersTheQuestion,
+    correct: answersTheQuestion && f.dial === f.answer,
+    answered: String(f.dial),
+  }
+}

--- a/dynawalla/games/trebuchet/src/sim/world.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.test.ts
@@ -3,7 +3,15 @@ import { test } from 'node:test'
 
 import { makeRng } from '../core/rng.ts'
 import { createStubHost } from '../stubHost.ts'
-import { buildTower, layoutTowerValues, pullQuestions, shatter, stepBlocks, waveConfig } from './world.ts'
+import {
+  buildTower,
+  layoutTowerValues,
+  pullQuestions,
+  ramAdvances,
+  shatter,
+  stepBlocks,
+  waveConfig,
+} from './world.ts'
 
 const MIN_GAP = 8
 
@@ -66,6 +74,19 @@ test('escalation is monotonic where it should be and bounded everywhere', () => 
   assert.equal(waveConfig(4).loft, true, 'the loft lever arrives at wave 4')
   assert.equal(waveConfig(5).volley, true, 'every fifth wave is a volley')
   assert.ok(waveConfig(7).ram, 'the ram arrives at wave 7')
+})
+
+test('the ram does not roll while the child is working the sum out', () => {
+  // The how-to-play panel promises "there is no clock, nothing happens until you
+  // fire", and EXPERIENCE_DESIGN.md does not budget comprehension at all. Those
+  // are the two phases in which the child is reading and dialling.
+  assert.equal(ramAdvances('intro'), false, 'the wave has only just been laid out')
+  assert.equal(ramAdvances('aim'), false, 'she is working it out')
+  assert.equal(ramAdvances('impact'), false, 'the hit-stop holds everything still')
+  // ...and it must still be a threat once a boulder is in the air.
+  for (const phase of ['windup', 'flight', 'settle', 'clear']) {
+    assert.equal(ramAdvances(phase), true, `${phase} is the world in motion`)
+  }
 })
 
 test('a struck keep comes apart and then settles — no perpetual motion', () => {

--- a/dynawalla/games/trebuchet/src/sim/world.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.ts
@@ -242,6 +242,22 @@ export type Crater = { x: number; r: number; depth: number; age: number; label: 
 
 export type Ghost = { pts: Array<{ x: number; y: number }>; landing: number; age: number; hit: boolean }
 
+/**
+ * Does the ram roll during this phase?
+ *
+ * It does not roll while the child is reading the boulder and turning the dial.
+ * EXPERIENCE_DESIGN.md: comprehension is "the child's time. Measured, never
+ * limited" — and the how-to-play panel promises "there is no clock, nothing
+ * happens until you fire". A ram that closed on the walls while she was working
+ * out 47 + 25 made both of those false, and hurried exactly the child who was
+ * thinking hardest. It advances on shots taken, not on seconds spent thinking:
+ * every boulder she throws, it gets closer. It is also held still during the
+ * hit-stop, where everything else is.
+ */
+export function ramAdvances(phase: string): boolean {
+  return phase !== 'intro' && phase !== 'aim' && phase !== 'impact'
+}
+
 /** A battering ram: pure pressure. No number on it — read the ground to lead it. */
 export type Ram = {
   /** metres from the launch point, decreasing */


### PR DESCRIPTION
## The defect

A keep stands at 72 metres. The boulder says `47 + 25`. A child works it out, dials 72, and fires — and from wave 3 the shot lands at `72 + wind`, because `solve()` returns `R + wind` (`sim/ballistics.ts:54`) while the aim caret and the dial numeral stand on `R` (`game.ts:1268`, `:1326`). `rollWind` never returned 0, and only `bestErr <= 1` counted as a hit. The keep at 72 stayed standing. She was told she was wrong.

Measured over every wind the roll can produce, at every loft, for a child who dials the right answer:

| wave | wind cap | correct answers scored WRONG | recorded in the learner model as WRONG |
|---|---|---|---|
| 3 | ±2 | **50.0%** | 0% |
| 5 | ±3 | **66.7%** | 0% |
| 7 | ±4 | **75.0%** | **25.0%** |
| 10 | ±6 | **83.3%** | **50.0%** |
| 12 | ±7 | **85.7%** | **57.1%** |
| 16 | ±9 | **88.9%** | **66.7%** |

The second column is the worse one. `packs/shared/game-host/index.ts:229` does not send `correct` at all — it sends `answer({ response: answered })` and the curriculum judges the string. This game was sending `struck ? String(struck.value) : String(landing)`, so what was written into the learner model was the metre the wind chose, or the value of whichever rival keep the blast happened to reach. A child who dialled 72 was recorded as having answered 77.

And in the other direction, needing no wind at all: a dial of 71 or 73 fell inside the blast radius of the keep at 72, so `answered` was `"72"` — recorded as a right answer, and scored as one (`bestErr <= 1`). 268 of the wrong dials tested came back as right.

An adaptive controller reading that record moves a competent child *down* the ladder for playing well.

## What changed

**`src/sim/verdict.ts`** (new, tested on its own) holds two rules:

1. **The dial is the landing metre.** `aimShot` lays the machine off into the crosswind by exactly the wind — the boulder launches at `dial − wind` and the wind carries it onto the number. The arc still visibly bends, the wind is still real and still on the chip; it no longer decides whether a child knows her sums. The alternative — making the child compensate deliberately — was rejected because it puts a second, subtractive arithmetic step in front of an addition item and reports the failure of one as the failure of the other.
2. **The child's answer is the number on the dial.** Reported as she named it; judged against the number she was asked for, exactly. Not ±1: with nothing random left between the dial and the ground, naming the metre is entirely hers to do, so a keep now falls when she names it and leans when she is one out. A disagreement between the dial and the landing is logged loudly and the dial still wins.

**A boulder spent on the ram is not an answer** and is not reported. It no longer breaks the combo, and it no longer levels a bystanding keep as collateral (`kind === 'ram'` used to destroy `out.target`).

**The ram no longer rolls while she is reading and dialling.** `EXPERIENCE_DESIGN.md` budgets comprehension at *"not budgeted — the child's time, measured, never limited"*, and the how-to-play panel promises *"there is no clock. Nothing happens until you fire."* A ram closing on the walls during `aim` made both false and hurried exactly the child who was thinking hardest. It advances on shots taken instead — faster, so the threat is unchanged, but off the thinking clock. The pressure was theatre in any case, as the audit suspected: `platformDamage` draws chips on the frame (`render/pieces.ts:279`) and nothing else, and there is no game over anywhere in this game.

## Verification

161 tests, run 5×, plus `tsc --noEmit` and the pack build. Every new test was checked by removing the fix it covers:

| fix removed | failure |
|---|---|
| `aimShot` compensation | `wind never turns a correct answer into a wrong one` — *100.0% left the keep standing*; `the dial IS the landing metre` — `6 !== 8` |
| `answered: String(dial)` | `the dial still wins — loudly` — `'63' !== '72'` |
| exact verdict (back to ±1) | `a wrong dial is never recorded as a right answer` — *124 wrong dials were treated as right* |
| ram is not an answer | `a boulder spent on the ram is not an answer` — `true !== false` |
| ram off the thinking clock | `the ram does not roll while the child is working the sum out` — `true !== false` |

## Not fixed here

The wall is decorative: a shot that hits it still resolves as though it had landed, so the keep behind it comes down anyway. That is pre-existing, produces no false verdict, and belongs in its own change.
