### PR TITLE
dynawalla/curriculum: the ladder now starts at 0 + 1

### DIFF
--- a/dynawalla/packs/shared/curriculum/CHANGELOG.md
+++ b/dynawalla/packs/shared/curriculum/CHANGELOG.md
@@ -9,6 +9,52 @@ installed pack until that pack is rebuilt and republished.
 
 ## 0.1.0 — Unreleased
 
+### The floor: `gen.arith.number-facts`, and a ladder that starts at `0 + 1`
+
+The easiest thing this library could give a child was `plus(2, 2, 0)` — a
+two-digit column sum. There was no first grade in it and no kindergarten at all,
+so a five-year-old opening the product met second-grade column arithmetic on the
+first card, and a struggling second grader sliding down the ladder hit that same
+card and stopped.
+
+- **A new family, `gen.arith.number-facts`.** A fact is bounded by a **value**
+  (`within twenty, crossing ten`) and a column is bounded by a **width**
+  (`two-digit minuend, one borrow`, which is `94 − 6` as readily as `15 − 8`), so
+  there is no parameter of `gen.arith.column-op` that means "within twenty". The
+  column family's digit-wise machinery does in fact run at one column — only
+  `MIN_DIGITS = 2` stops it — but its walkthrough is a walk down the columns and
+  all three of its mal-rules are bugs in that walk, neither of which is what a
+  child does to get `3 + 5`. The two families are siblings.
+- **Four active rows, `dw.add.facts.*`**, at difficulties −3.00 up to −1.25,
+  entirely below the previous floor of −0.90: sums within ten, differences within
+  ten, and each of those across ten. Level 0 of the first two is the trivial set —
+  `0 + 1`, `1 + 0`, `n − 0`, `n − n` — because a bottom rung that is still a small
+  challenge is not a bottom rung. Only `0 + 0` is excluded, and only because an
+  empty frame is not a question.
+- **The column rows now consume the fact rows.** A carry happens exactly when a
+  column sum crosses ten and a borrow exactly when a difference does, so
+  `cap.arith.sums-across-ten` and its three siblings make the ladder continuous
+  through CG-6 rather than through an editorial ordering. `dw.add.column.*` and
+  `dw.add.regroup.*` gain a `rev` and a prerequisite; no id moved.
+- **A fifth representation, `ten-frame`**, declared and unbuilt like the other
+  four. The counting board is a *place-value* board and handing it `2 + 3` would
+  draw a structure the item is not about, on the screen of the child least able to
+  tell the difference. The lowest three levels of each within-ten row emit the
+  spec; the rows list it as `optional`, because a `required` representation with
+  no renderer is the curriculum row CG-8 exists to stop.
+- **`GeneratorBinding.closedFactSet`, and CG-10's substituted check.** There are
+  thirty-six additions within ten and there is no thirty-seventh, so CG-10's
+  variant-space floor of 975 — derived from a model of generators that do not
+  close — would forbid teaching number facts at all. A level that declares its
+  closed size is measured against that declaration instead, and the substituted
+  check is the sharper one: it fails when the generator reaches a problem the row
+  says does not exist, which the floor could never have seen. CG-7 checks the
+  declaration lines up with the level table and does not undercut `minVariants`.
+- **`graph/ladder.test.ts`.** The active graph has exactly one root, every active
+  row climbs from it, and `activeNodes()` is already in prerequisite order — the
+  order a game walks. Before this change the active graph had two roots and both
+  were two-digit column arithmetic, which every gate in the set passed.
+
 ### Eight generator families across five new domains
 
 The library taught addition and subtraction and nothing else. It now generates

--- a/dynawalla/packs/shared/curriculum/README.md
+++ b/dynawalla/packs/shared/curriculum/README.md
@@ -35,10 +35,11 @@ npm run snapshots:update    # rewrite the CG-16 output hashes
 | `src/math/rational.ts` | Exact rational arithmetic over BigInt. Nothing that reaches an answer is a float. |
 | `src/rng/` | Seeded integer-only PRNG (FNV-1a + mulberry32) and the FNV-1a-64 used for output hashes. |
 | `src/types/` | `SkillNode`, `Exercise`, `AnswerSchema`, `PromptSpec`, the generator contract, the mal-rule contract. |
+| `src/generators/numberFacts/` | `gen.arith.number-facts` — the recalled facts, `0 + 1` through `15 − 8`, drawn uniformly from an enumerated closed set. |
 | `src/generators/columnOp/` | `gen.arith.column-op` — the column algorithm, add and subtract, with exact regrouping control including across zeros. |
-| `src/malrules/` | Three executable buggy procedures for that family, and the classifier. |
+| `src/malrules/` | Sixteen executable buggy procedures, and the classifier. |
 | `src/board/` | Reading a column item back out of the public prompt contract, and the **counting-board contrast pair**. |
-| `src/graph/` | The `add` domain seed: three active nodes and one draft. |
+| `src/graph/` | The graph, and `ladder.test.ts` — one root, everything climbing from it, `activeNodes()` in prerequisite order. |
 | `src/render/registry.ts` | Renderer *declarations*. The data behind CG-8. |
 | `src/validate/` | The gates and `dw-curriculum check`. Tooling: never imported by a pack. |
 | `src/boundary.test.ts` | The pack-consumability boundary, enforced. |
@@ -102,6 +103,15 @@ Implementation notes where the document and the code differ, all deliberate:
   which is 975 problems per level. The space itself is estimated from the collisions
   observed, and that estimator is optimistic at high collision rates, so a level
   near the floor deserves a look and CG-9's hard `minVariants` count backs it up.
+- **CG-10 does not apply to a closed fact set.** There are thirty-six additions
+  within ten and there is no thirty-seventh, so the floor above — which reads a
+  repeat as evidence of a shallow generator — would forbid teaching number facts.
+  A level that declares `GeneratorBinding.closedFactSet` is measured against that
+  number instead: the gate fails when the generator reaches a problem the row says
+  does not exist. That is a *sharper* claim than the floor, not a waiver, and it
+  is pinned from the other side by `numberFacts.test.ts`, which enumerates each
+  level's set from the level's stated rules and asserts the generator reaches
+  every member of it and nothing else.
 - **CG-12** also checks the *declaration* half of the mal-rule contract: every id in
   a node's `misconceptions` resolves in the registry and belongs to the family the
   node binds, and every diagnosis the node's own items emit as a distractor is

--- a/dynawalla/packs/shared/curriculum/src/board/countingBoard.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/board/countingBoard.test.ts
@@ -12,7 +12,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { rational, toScaled } from "../math/rational.ts";
 import { columnOpFamily } from "../generators/columnOp/family.ts";
-import { FORM_FREE_ENTRY, SLOT_BOTTOM, SLOT_TOP } from "../generators/columnOp/constants.ts";
+import { COLUMN_OP_FAMILY, FORM_FREE_ENTRY, SLOT_BOTTOM, SLOT_TOP } from "../generators/columnOp/constants.ts";
 import { activeNodes, allNodes } from "../graph/graph.ts";
 import { borrowAcrossZero, smallerFromLarger, REP_COUNTING_BOARD } from "../malrules/columnOp.ts";
 import { classify } from "../malrules/registry.ts";
@@ -192,6 +192,11 @@ test("no contrast card ever draws a hole the other plate fills", () => {
   let cards = 0;
 
   for (const node of activeNodes(allNodes)) {
+    // The board is a place-value drawing of a column subtraction, so only the rows
+    // that bind `gen.arith.column-op` can produce one. The number-fact rows below
+    // them are active and bind a different family, and `generateAt` would hand
+    // their parameters to the wrong schema.
+    if (node.generator.family !== COLUMN_OP_FAMILY) continue;
     node.generator.params.forEach((_params, level) => {
       for (let seed = 0; seed < SEEDS; seed++) {
         const exercise = generateAt(node.id, level, seed);

--- a/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
@@ -79,6 +79,8 @@ type Level = {
   readonly level: number;
   readonly status: string;
   readonly minVariants: number;
+  /** The level's whole problem space, where it is closed. See `GeneratorBinding`. */
+  readonly closedFactSet: number | undefined;
   readonly declared: ReadonlySet<string>;
   readonly exercises: readonly Exercise[];
   readonly timingsNs: readonly bigint[];
@@ -124,6 +126,7 @@ function sweep(): Level[] {
         level,
         status: node.status,
         minVariants: node.generator.minVariants,
+        closedFactSet: node.generator.closedFactSet?.[level],
         declared: new Set(node.misconceptions.map(String)),
         exercises,
         timingsNs,
@@ -322,6 +325,18 @@ test("sweep: every level clears its own minVariants, and the sub-floor levels ar
       distinct >= level.minVariants,
       `${level.label}: ${String(distinct)} distinct items over ${String(level.exercises.length)} seeds, below minVariants ${String(level.minVariants)}`,
     );
+    // A level whose problem space is closed is measured against its own
+    // declaration rather than against the floor, for the reason set out on
+    // `GeneratorBinding.closedFactSet`: on thirty-six additions within ten a
+    // repeat is retrieval practice, not a shallow draw. The substituted check is
+    // the sharper one — it fails on a generator that reaches a thirty-seventh.
+    if (level.closedFactSet !== undefined) {
+      assert.ok(
+        distinct <= level.closedFactSet,
+        `${level.label}: ${String(distinct)} distinct items, above the declared closed fact set of ${String(level.closedFactSet)}`,
+      );
+      continue;
+    }
     if (estimate < VARIANT_SPACE_FLOOR) {
       // The measured count leads and the estimate follows, because only one of the
       // two is a measurement. `N²/2C` is optimistic at high collision rates and the
@@ -364,6 +379,7 @@ test("sweep: every level clears its own minVariants, and the sub-floor levels ar
   // The one thing that must never silently become true: an *active* level under
   // the floor. CG-10 would fail on it, and this says so first and by name.
   const activeBelow = LEVELS.filter((level) => level.status === "active").filter((level) => {
+    if (level.closedFactSet !== undefined) return false;
     const distinct = new Set(level.exercises.map(fingerprintItem)).size;
     const collisions = level.exercises.length - distinct;
     if (collisions === 0) return false;

--- a/dynawalla/packs/shared/curriculum/src/generators/numberFacts/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/numberFacts/constants.ts
@@ -1,0 +1,112 @@
+/**
+ * `gen.arith.number-facts` constants — ids, locale keys and every difficulty
+ * coefficient, in one place.
+ *
+ * CURRICULUM.md pins the shape of the difficulty function:
+ *
+ *   b = b_skill
+ *     + 0.55·regroupings
+ *     + 0.30·(maxDigits − 2)
+ *     + 0.25·zeroBorrowThrough
+ *     + 0.20·noAnchor
+ *     − 0.35·specialCase
+ *     + repOffset + formOffset
+ *
+ * A number fact has no digits and no columns, so the two place-value terms are
+ * zero here and the slots are spent on the three parameters that do make one
+ * fact harder than another. Each substitution is a falsifiable claim, stated:
+ *
+ * - **`0.55·crossesTen` reuses the regrouping coefficient unchanged**, because
+ *   crossing ten *is* the regrouping — one column wide, with the ten carried in
+ *   the child's head instead of written above a line. Claiming a different number
+ *   for the same phenomenon measured on the same children would be two answers to
+ *   one question.
+ * - **`0.05` per unit of range** above the root spends the `noAnchor` slot. It is
+ *   small on purpose: `2 + 3` and `4 + 5` are not far apart, and a coefficient
+ *   large enough to separate them would put `9 + 1` above a crossing fact.
+ * - **`−0.35·picture`** is the `specialCase` slot, at its documented size. A
+ *   ten-frame drawn beside the numerals turns a recall question into a counting
+ *   question, which is the largest single scaffold this family has.
+ * - **`0.15·subtraction`** has no slot in the sketch and is a term this family
+ *   adds. Taking away is harder than putting together at the same range, on every
+ *   curriculum that orders the two, and a family that scored `5 − 2` and `2 + 3`
+ *   identically would order the ladder wrongly at its own root.
+ * - **`−0.10·includeZero`** is not a claim that `0 + 1` is only a tenth of a logit
+ *   below `1 + 1`. It is the claim that *admitting* the identity facts to a level
+ *   lowers that level's expected difficulty a little, because they are a minority
+ *   of a set that is otherwise unchanged.
+ *
+ * Every coefficient is an exact rational. `0.55` as a float would make `b` — and
+ * therefore `P̂` — platform-dependent in the last bits.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const NUMBER_FACTS_FAMILY = familyId("gen.arith.number-facts");
+
+/**
+ * Bump whenever generated output changes for any seed. CG-16 keys its committed
+ * output hashes on this value.
+ */
+export const NUMBER_FACTS_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const NUMBER_FACTS_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_ADD = locKey("dw.prompt.number-facts.add");
+export const PROMPT_KEY_SUB = locKey("dw.prompt.number-facts.sub");
+
+export const SOLUTION_KEY_READ = locKey("dw.solution.number-facts.read");
+/** Start at the larger number and count on. The within-ten addition strategy. */
+export const SOLUTION_KEY_COUNT_ON = locKey("dw.solution.number-facts.count-on");
+/** Start at the whole and count back. The within-ten subtraction strategy. */
+export const SOLUTION_KEY_COUNT_BACK = locKey("dw.solution.number-facts.count-back");
+/** `7 + 8` as `7 + 3` to ten and `5` more. The make-ten bridge. */
+export const SOLUTION_KEY_BRIDGE_UP = locKey("dw.solution.number-facts.bridge-up");
+/** `15 − 8` as `15 − 5` down to ten and `3` more. The same bridge, downward. */
+export const SOLUTION_KEY_BRIDGE_DOWN = locKey("dw.solution.number-facts.bridge-down");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.number-facts.result");
+
+/**
+ * Every locale key this family can emit. The i18n gate reads this rather than
+ * grepping, so a new template that nobody translated fails loudly.
+ */
+export const NUMBER_FACTS_LOC_KEYS = [
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  SOLUTION_KEY_READ,
+  SOLUTION_KEY_COUNT_ON,
+  SOLUTION_KEY_COUNT_BACK,
+  SOLUTION_KEY_BRIDGE_UP,
+  SOLUTION_KEY_BRIDGE_DOWN,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+/** Prompt slot names. Stable: they are part of the translated template. */
+export const SLOT_FIRST = "first";
+export const SLOT_SECOND = "second";
+export const SLOT_ANSWER = "answer";
+/** The larger addend a count-on starts from, and the count taken from there. */
+export const SLOT_FROM = "from";
+export const SLOT_COUNT = "count";
+/** How far the first number is from ten, and how much of the second is left. */
+export const SLOT_TO_TEN = "toTen";
+export const SLOT_REST = "rest";
+
+/** 0.55 for a fact that crosses ten — column-op's regrouping coefficient. */
+export const COEFF_CROSS_TEN = rational(55n, 100n);
+/** 0.05 per unit of range above the root's three. */
+export const COEFF_RANGE_OVER_ROOT = rational(5n, 100n);
+/** 0.15 for subtraction. */
+export const COEFF_SUBTRACTION = rational(15n, 100n);
+/** −0.35 when the quantity is drawn as well as written. */
+export const COEFF_PICTURE = rational(-35n, 100n);
+/** −0.10 when the identity facts are in the set. */
+export const COEFF_INCLUDE_ZERO = rational(-10n, 100n);
+
+/** The range every level is measured against — the root, `0 + 1`. */
+export const ROOT_MAX_TOTAL = 3;
+
+/** Free entry is the only form; the offset is stated so the contract is total. */
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/numberFacts/facts.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/numberFacts/facts.ts
@@ -1,0 +1,117 @@
+/**
+ * The fact set a level draws from, enumerated.
+ *
+ * ## Why this family enumerates instead of drawing digits
+ *
+ * Every other generator in this package draws a structure and then fills digits
+ * into the ranges that structure forces, because the space it draws from is far
+ * too large to write down: four-digit subtraction borrowing through two zeros has
+ * millions of instances.
+ *
+ * A number fact has the opposite problem. "Addition within ten" is **thirty-six
+ * problems in the world** — not thirty-six that this generator happens to reach,
+ * thirty-six that exist. Enumerating them and picking one uniformly is therefore
+ * both simpler and stronger than rejection sampling: the level's variant space
+ * stops being a number estimated from observed collisions and becomes a list that
+ * a test can compare against, in both directions. `numberFacts.test.ts` asserts
+ * that the generator reaches every fact in the list and never emits one outside
+ * it, which no amount of sampling could establish.
+ *
+ * It is also what makes `GeneratorBinding.closedFactSet` honest: the number a
+ * curriculum row declares is `factSet(params).length`, and CG-10 checks the
+ * measured draw against it rather than against a floor derived from a model of
+ * generators that do not close.
+ *
+ * ## The trivial facts are in the set
+ *
+ * `0 + 1`, `1 + 0`, `n − 0` and `n − n` are facts, and they are the bottom of the
+ * ladder every game reaches down to. A child who has slid down after struggling
+ * arrives at a guaranteed win, which is the only thing that rung is for.
+ *
+ * One pair is excluded and only one: **both operands zero**. An empty frame added
+ * to an empty frame is not a question a child can be asked — there is nothing on
+ * the screen to count — and `0 + 0` and `0 − 0` are the only two draws with that
+ * property.
+ *
+ * Ordering is a plain nested loop and never a sort, so the list is byte-stable on
+ * every platform (CG-16) without a comparator to get wrong.
+ */
+
+import type { NumberFactsParams } from "./params.ts";
+
+/** One fact: `first op second`, with the result the child writes. */
+export type Fact = {
+  readonly first: number;
+  readonly second: number;
+  readonly result: number;
+};
+
+/** Largest single-digit operand. A fact crossing ten still has both below ten. */
+const MAX_OPERAND = 9;
+
+/**
+ * Every fact this parameter set admits, in a fixed order.
+ *
+ * Never memoised. A cache keyed on a parameter object is a key-order assumption
+ * waiting to happen, and the largest list here is sixty-five entries.
+ */
+export function factSet(params: NumberFactsParams): Fact[] {
+  const { op, maxTotal, crossesTen, includeZero } = params;
+  const out: Fact[] = [];
+  const low = includeZero ? 0 : 1;
+
+  if (op === "add") {
+    if (crossesTen) {
+      // Both addends below ten and a sum above it: the crossing is the content, so
+      // an addend of ten or more would be a different skill wearing this level's
+      // name, and a zero addend cannot cross anything.
+      for (let first = 1; first <= MAX_OPERAND; first++) {
+        for (let second = 1; second <= MAX_OPERAND; second++) {
+          const sum = first + second;
+          if (sum <= 10 || sum > maxTotal) continue;
+          out.push({ first, second, result: sum });
+        }
+      }
+      return out;
+    }
+    for (let first = low; first <= maxTotal; first++) {
+      for (let second = low; second <= maxTotal; second++) {
+        const sum = first + second;
+        // `sum >= 1` is the both-operands-zero exclusion, and the only one.
+        if (sum < 1 || sum > maxTotal) continue;
+        out.push({ first, second, result: sum });
+      }
+    }
+    return out;
+  }
+
+  if (crossesTen) {
+    // A teen whole, a single-digit part, and a difference back below ten. Both
+    // ends of the subtraction sit on opposite sides of ten, which is what makes
+    // it the crossing fact rather than `18 − 3`.
+    for (let first = 11; first <= maxTotal; first++) {
+      for (let second = 1; second <= MAX_OPERAND; second++) {
+        const difference = first - second;
+        if (difference < 1 || difference > 9) continue;
+        out.push({ first, second, result: difference });
+      }
+    }
+    return out;
+  }
+
+  for (let first = 1; first <= maxTotal; first++) {
+    for (let second = low; second <= first; second++) {
+      const difference = first - second;
+      // `first >= 1` above is the both-operands-zero exclusion. `n − 0 = n` and
+      // `n − n = 0` are both in, deliberately: they are the identity facts.
+      if (!includeZero && difference < 1) continue;
+      out.push({ first, second, result: difference });
+    }
+  }
+  return out;
+}
+
+/** How many facts the level has. What a curriculum row declares and CG-10 checks. */
+export function factSetSize(params: NumberFactsParams): number {
+  return factSet(params).length;
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/numberFacts/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/numberFacts/family.ts
@@ -1,0 +1,255 @@
+/**
+ * `gen.arith.number-facts` — the number facts, from `0 + 1` up to `15 − 8`.
+ *
+ * ## Why this is not `gen.arith.column-op` with smaller parameters
+ *
+ * The column family *can* be made to emit a single-digit sum: its digit-wise
+ * procedure, its regrouping trace and its exact-arithmetic cross-check all work at
+ * one column, and only `MIN_DIGITS = 2` in its validator stands in the way. Two
+ * things make widening it the wrong move anyway.
+ *
+ * **A fact is bounded by a value and a column is bounded by a width.** "Two-digit
+ * minuend, one-digit subtrahend, one borrow" is `94 − 6` exactly as readily as
+ * `15 − 8`, and there is no digit count that means "within twenty". The
+ * subtraction milestone of first grade is unreachable through that parameter
+ * space, which is not a gap that a smaller number closes.
+ *
+ * **A fact is recalled and a column is performed.** The column family's worked
+ * solution is a walk down the columns — "line them up, take the units, regroup" —
+ * and its three mal-rules are all bugs in that walk. Run at one column, the
+ * walkthrough for `3 + 5` reads as a procedure with one step, which is not how a
+ * child gets `3 + 5`, and every mal-rule's `applies()` is false. The hint ladder
+ * here is count-on and bridge-through-ten instead, which is the strategy work the
+ * bottom of the ladder is actually made of.
+ *
+ * So the two families are siblings, and `dw.add.facts.*` sits under
+ * `dw.add.column.*` in the graph rather than beside it.
+ *
+ * ## No mal-rules, on purpose
+ *
+ * Every buggy procedure in `malrules/` is a column-algorithm bug. The documented
+ * error at this level is a counting slip — off by one, or the count started at the
+ * wrong end — and an off-by-one distractor would be a bug this program invented
+ * rather than one it has evidence for, which `README.md` forbids outright. The
+ * rows declare `misconceptions: []` and the items carry no distractors, and a
+ * wrong answer routes to the worked example, which is the honest outcome.
+ *
+ * ## Uniform over a closed set
+ *
+ * `facts.ts` enumerates the level's whole fact set and `generate` picks one
+ * uniformly. See that file for why enumeration is the stronger option here.
+ */
+
+import { add as ratAdd, mul, rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, RepSpec, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { REP_TEN_FRAME } from "../../render/representations.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { countSlot, numberSlot } from "../shared/slots.ts";
+import {
+  COEFF_CROSS_TEN,
+  COEFF_INCLUDE_ZERO,
+  COEFF_PICTURE,
+  COEFF_RANGE_OVER_ROOT,
+  COEFF_SUBTRACTION,
+  FORM_OFFSET_FREE_ENTRY,
+  NUMBER_FACTS_FAMILY,
+  NUMBER_FACTS_FAMILY_REV,
+  NUMBER_FACTS_FORMS,
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  ROOT_MAX_TOTAL,
+  SLOT_ANSWER,
+  SLOT_COUNT,
+  SLOT_FIRST,
+  SLOT_FROM,
+  SLOT_REST,
+  SLOT_SECOND,
+  SLOT_TO_TEN,
+  SOLUTION_KEY_BRIDGE_DOWN,
+  SOLUTION_KEY_BRIDGE_UP,
+  SOLUTION_KEY_COUNT_BACK,
+  SOLUTION_KEY_COUNT_ON,
+  SOLUTION_KEY_READ,
+  SOLUTION_KEY_RESULT,
+} from "./constants.ts";
+import { factSet } from "./facts.ts";
+import type { Fact } from "./facts.ts";
+import { numberFactsParamSchema } from "./params.ts";
+import type { NumberFactsParams } from "./params.ts";
+
+/** The frame the picture is drawn in. Ten cells, the standard one. */
+const FRAME_CAPACITY = 10;
+
+/**
+ * The answer field's width, which is the *level's* width and never this item's.
+ *
+ * Sizing the field to the answer would tell a child how many digits it has
+ * (ARCHITECTURE L3), which on a level whose answers straddle ten is the whole
+ * question. Both operations get the same width for the same reason: on a
+ * subtraction level reaching eighteen the answers are all single digits, and a
+ * field one cell wide would say so.
+ */
+function answerDigits(params: NumberFactsParams): number {
+  return String(params.maxTotal).length;
+}
+
+function schemaFor(params: NumberFactsParams): AnswerSchema {
+  return { kind: "integer", digits: answerDigits(params), decimalPlaces: 0 };
+}
+
+/**
+ * The frame beside the numerals, or nothing.
+ *
+ * Addition puts the second addend in a second group; subtraction crosses the part
+ * out of the whole. Never both — a frame that groups *and* crosses out asks two
+ * questions, and `repSpecDefect` rejects it.
+ *
+ * A subtraction picture holds `first` counters with `second` of them crossed, and
+ * not `first − second` counters beside `second`: the counters left standing are
+ * the answer, and a picture that draws the answer is not a question.
+ */
+function representationFor(params: NumberFactsParams, fact: Fact): RepSpec | undefined {
+  if (!params.picture) return undefined;
+  return params.op === "add"
+    ? { rep: REP_TEN_FRAME, params: { capacity: FRAME_CAPACITY, first: fact.first, second: fact.second, removed: 0 } }
+    : { rep: REP_TEN_FRAME, params: { capacity: FRAME_CAPACITY, first: fact.first, second: 0, removed: fact.second } };
+}
+
+/**
+ * The hint ladder: read the fact, apply the strategy, state the answer.
+ *
+ * The middle rung is the strategy the level is teaching, not a restatement of the
+ * arithmetic. Within ten it is counting on from the larger number — starting at
+ * the smaller one is the slower habit this rung exists to displace. Across ten it
+ * is the bridge: `7 + 8` is `7 + 3` to ten and `5` more, and `15 − 8` is `15 − 5`
+ * down to ten and `3` more.
+ */
+function solutionFor(params: NumberFactsParams, fact: Fact): SolutionStep[] {
+  const read: SolutionStep = {
+    key: SOLUTION_KEY_READ,
+    slots: { [SLOT_FIRST]: numberSlot(BigInt(fact.first)), [SLOT_SECOND]: numberSlot(BigInt(fact.second)) },
+  };
+  const result: SolutionStep = {
+    key: SOLUTION_KEY_RESULT,
+    slots: { [SLOT_ANSWER]: numberSlot(BigInt(fact.result)) },
+  };
+
+  if (params.crossesTen) {
+    // `toTen` is the step that lands exactly on ten and `rest` is what is left of
+    // the second number after it. Both are at least one on every crossing fact:
+    // the sum passes ten strictly, so the second number is strictly larger than
+    // the gap to it.
+    const toTen = params.op === "add" ? 10 - fact.first : fact.first - 10;
+    const rest = fact.second - toTen;
+    return [
+      read,
+      {
+        key: params.op === "add" ? SOLUTION_KEY_BRIDGE_UP : SOLUTION_KEY_BRIDGE_DOWN,
+        slots: {
+          [SLOT_FIRST]: numberSlot(BigInt(fact.first)),
+          [SLOT_TO_TEN]: countSlot(toTen),
+          [SLOT_REST]: countSlot(rest),
+        },
+      },
+      result,
+    ];
+  }
+
+  // Count on from the larger addend, whichever way round the fact is written.
+  const from = params.op === "add" ? Math.max(fact.first, fact.second) : fact.first;
+  const count = params.op === "add" ? Math.min(fact.first, fact.second) : fact.second;
+  return [
+    read,
+    {
+      key: params.op === "add" ? SOLUTION_KEY_COUNT_ON : SOLUTION_KEY_COUNT_BACK,
+      slots: { [SLOT_FROM]: numberSlot(BigInt(from)), [SLOT_COUNT]: countSlot(count) },
+    },
+    result,
+  ];
+}
+
+export const numberFactsFamily: GeneratorFamily<NumberFactsParams> = {
+  family: NUMBER_FACTS_FAMILY,
+  familyRev: NUMBER_FACTS_FAMILY_REV,
+  paramSchema: numberFactsParamSchema,
+  forms: NUMBER_FACTS_FORMS,
+  choiceOnly: false,
+  representations: [REP_TEN_FRAME],
+
+  answerSchema(params: NumberFactsParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: NumberFactsParams): Rational {
+    let b = mul(COEFF_RANGE_OVER_ROOT, rational(BigInt(params.maxTotal - ROOT_MAX_TOTAL)));
+    if (params.op === "sub") b = ratAdd(b, COEFF_SUBTRACTION);
+    if (params.crossesTen) b = ratAdd(b, COEFF_CROSS_TEN);
+    if (params.includeZero) b = ratAdd(b, COEFF_INCLUDE_ZERO);
+    if (params.picture) b = ratAdd(b, COEFF_PICTURE);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<NumberFactsParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(NUMBER_FACTS_FAMILY, NUMBER_FACTS_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+    const form = chooseForm(forms, NUMBER_FACTS_FORMS, rng);
+
+    const facts = factSet(params);
+    if (facts.length === 0) {
+      // The schema rejects every combination that empties the set, so reaching
+      // here is a disagreement between the validator and the enumeration — the one
+      // bug class a family of this shape is most likely to have.
+      throw new InfeasibleLevelError(`no fact satisfies the parameters of ${exerciseId}`);
+    }
+    const fact = rng.pick(facts);
+
+    // The enumeration and exact rational arithmetic agree, asserted on every call.
+    // `facts.ts` computes the result while it builds the pair, so this is the one
+    // place the two derivations meet.
+    const expected = params.op === "add" ? fact.first + fact.second : fact.first - fact.second;
+    if (fact.result !== expected) {
+      throw new Error(`the fact set disagreed with exact arithmetic on ${exerciseId}`);
+    }
+
+    const representation = representationFor(params, fact);
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: NUMBER_FACTS_FAMILY,
+      familyRev: NUMBER_FACTS_FAMILY_REV,
+      form,
+      prompt: {
+        key: params.op === "add" ? PROMPT_KEY_ADD : PROMPT_KEY_SUB,
+        slots: {
+          [SLOT_FIRST]: numberSlot(BigInt(fact.first)),
+          [SLOT_SECOND]: numberSlot(BigInt(fact.second)),
+        },
+      },
+      ...(representation === undefined ? {} : { representation }),
+      schema: schemaFor(params),
+      answer: { canonical: { kind: "integer", value: rational(BigInt(fact.result)) }, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, fact),
+    };
+
+    return { ...base, distractors: distractorsFor(NUMBER_FACTS_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/numberFacts/numberFacts.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/numberFacts/numberFacts.test.ts
@@ -1,0 +1,442 @@
+/**
+ * `gen.arith.number-facts`, held to the two things a generator binding has to
+ * prove before a row may be served to a child.
+ *
+ * The whole-graph sweep in `../families.property.test.ts` already runs every level
+ * of every row for schema defects, determinism, checker agreement and timing. What
+ * it cannot do is know what *this* family claims, and the claims are the point:
+ *
+ * 1. **Every stated answer is correct, re-derived from the prompt.** Never from
+ *    `Fact.result`, which is what the generator wrote — that would be re-running
+ *    the same expression and calling the agreement a test. The operands are read
+ *    back out of `prompt.slots` as `Rational`s and the arithmetic is done again,
+ *    in the inverse direction for subtraction.
+ * 2. **The fact set is closed, and the closure is exact in both directions.** The
+ *    generator reaches every fact the level admits and never one it does not.
+ *    This is what `GeneratorBinding.closedFactSet` and CG-10's substituted check
+ *    rest on, so it is asserted against an independently written enumeration
+ *    rather than against `factSet` itself.
+ * 3. **Every item is inside the band the row declares.** No operand above the
+ *    level's ceiling, no answer outside the range the skill claims to teach, and
+ *    no degenerate item — with `0 + 0` named, because it is the one draw this
+ *    family deliberately excludes and the one a future widening would let back in.
+ * 4. **The root is reachable.** `0 + 1` is in level 0 of `add-within-ten`, `n − 0`
+ *    and `n − n` are in level 0 of `subtract-within-ten`, and none of them is an
+ *    accident of a parameter that could be flipped without a test noticing.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rational, add as ratAdd, eq as ratEq, sub as ratSub, toString as ratToString } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { skillId } from "../../types/ids.ts";
+import { schemaDefect } from "../../types/answer.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { serializeExercise } from "../../serialize.ts";
+import { repSpecDefect } from "../../render/representations.ts";
+import { addDomainNodes } from "../../graph/domains/add.ts";
+import { numberFactsFamily } from "./family.ts";
+import { factSet } from "./facts.ts";
+import { numberFactsParamSchema } from "./params.ts";
+import type { NumberFactsParams } from "./params.ts";
+import { NUMBER_FACTS_FAMILY, PROMPT_KEY_ADD, PROMPT_KEY_SUB, SLOT_FIRST, SLOT_SECOND } from "./constants.ts";
+
+const SKILL = skillId("dw.add.facts.add-within-ten");
+const FORMS = ["free-entry"];
+
+/** Enough draws that a set of sixty-five is collected with room to spare. */
+const SEEDS = 4000;
+
+function params(
+  op: "add" | "sub",
+  maxTotal: number,
+  options: { crossesTen?: boolean; includeZero?: boolean; picture?: boolean } = {},
+): NumberFactsParams {
+  return {
+    op,
+    maxTotal,
+    crossesTen: options.crossesTen ?? false,
+    includeZero: options.includeZero ?? false,
+    picture: options.picture ?? false,
+  };
+}
+
+function generate(p: NumberFactsParams, seed: number, level = 0): Exercise {
+  return numberFactsFamily.generate({ skillId: SKILL, level, seed, params: p, forms: FORMS });
+}
+
+/** The written operands, read back out of the public prompt contract. */
+function operands(exercise: Exercise): { first: Rational; second: Rational } {
+  const first = exercise.prompt.slots[SLOT_FIRST];
+  const second = exercise.prompt.slots[SLOT_SECOND];
+  assert.ok(first !== undefined && first.kind === "number", exercise.exerciseId);
+  assert.ok(second !== undefined && second.kind === "number", exercise.exerciseId);
+  return { first: first.value, second: second.value };
+}
+
+function answerOf(exercise: Exercise): Rational {
+  const answer = exercise.answer.canonical;
+  assert.equal(answer.kind, "integer", exercise.exerciseId);
+  return answer.kind === "integer" ? answer.value : rational(0n);
+}
+
+/** Every level bound by a `gen.arith.number-facts` row, with its declared size. */
+const BOUND_LEVELS = addDomainNodes
+  .filter((node) => node.generator.family === NUMBER_FACTS_FAMILY)
+  .flatMap((node) =>
+    node.generator.params.map((raw, level) => {
+      const validated = numberFactsParamSchema.validate(raw);
+      assert.ok(validated.ok, `${node.id} L${String(level)} params rejected`);
+      return {
+        label: `${node.id} L${String(level)}`,
+        node,
+        level,
+        params: validated.ok ? validated.value : params("add", 3),
+        declared: node.generator.closedFactSet?.[level],
+      };
+    }),
+  );
+
+test("the graph binds this family, and every bound level declares its closed set", () => {
+  assert.ok(BOUND_LEVELS.length >= 14, `only ${String(BOUND_LEVELS.length)} bound level(s)`);
+  for (const bound of BOUND_LEVELS) {
+    assert.ok(bound.declared !== undefined, `${bound.label} declares no closedFactSet`);
+  }
+  process.stdout.write(`# number-facts: ${String(BOUND_LEVELS.length)} bound level(s)\n`);
+});
+
+test("every stated answer is correct, re-derived from the prompt and never from the draw", () => {
+  let checked = 0;
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+      const answer = answerOf(exercise);
+
+      // Addition forward, subtraction backward: `answer + second` must be the
+      // written whole. Re-running `first − second` would be the generator's own
+      // expression a second time and would agree with any consistent bug in it.
+      const rebuilt = bound.params.op === "add" ? ratAdd(first, second) : ratAdd(answer, second);
+      const against = bound.params.op === "add" ? answer : first;
+      assert.ok(
+        ratEq(rebuilt, against),
+        `${exercise.exerciseId}: ${ratToString(first)} ${bound.params.op} ${ratToString(second)} does not give ${ratToString(answer)}`,
+      );
+
+      // And the forward reading of a subtraction, as a second independent route.
+      if (bound.params.op === "sub") {
+        assert.ok(ratEq(ratSub(first, second), answer), exercise.exerciseId);
+      }
+      checked += 1;
+    }
+  }
+  process.stdout.write(`# number-facts: ${String(checked)} answers re-derived\n`);
+});
+
+test("every item is inside the band its level declares, and none is degenerate", () => {
+  for (const bound of BOUND_LEVELS) {
+    const { maxTotal, crossesTen, includeZero, op } = bound.params;
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const first = Number(operands(exercise).first.n);
+      const second = Number(operands(exercise).second.n);
+      const answer = Number(answerOf(exercise).n);
+      const whole = op === "add" ? answer : first;
+
+      assert.ok(whole <= maxTotal, `${exercise.exerciseId}: reaches ${String(whole)}, above ${String(maxTotal)}`);
+      assert.ok(whole >= 1, `${exercise.exerciseId}: nothing to count`);
+      assert.ok(answer >= 0, `${exercise.exerciseId}: negative answer`);
+      // The one draw this family excludes, named so a widening cannot let it back
+      // in unnoticed: both operands zero is an empty screen, not a question.
+      assert.ok(first + second > 0, `${exercise.exerciseId}: both operands are zero`);
+
+      if (!includeZero) {
+        assert.ok(first >= 1 && second >= 1, `${exercise.exerciseId}: a zero operand on a level without them`);
+        if (op === "sub") assert.ok(answer >= 1, `${exercise.exerciseId}: a zero answer on a level without them`);
+      }
+
+      if (crossesTen) {
+        assert.ok(whole > 10, `${exercise.exerciseId}: ${String(whole)} does not cross ten`);
+        assert.ok(first <= 9 || op === "sub", `${exercise.exerciseId}: an addend of ten or more`);
+        assert.ok(second <= 9, `${exercise.exerciseId}: a part of ten or more`);
+        // The crossing is what the level is for: both ends of a subtraction sit on
+        // opposite sides of ten, and both addends of a sum sit below it.
+        if (op === "sub") assert.ok(answer < 10 && first > 10, exercise.exerciseId);
+      } else {
+        assert.ok(whole <= 10, `${exercise.exerciseId}: ${String(whole)} crosses ten on a level that does not`);
+      }
+
+      // The answer field is the level's width, never this item's: an item whose
+      // answer needed more room than the field would be unanswerable, and one
+      // whose field was cut to fit would say how many digits the answer has.
+      assert.equal(schemaDefect(exercise.schema), null, exercise.exerciseId);
+      assert.ok(
+        String(answer).length <= (exercise.schema.kind === "integer" ? exercise.schema.digits : 0),
+        `${exercise.exerciseId}: the answer does not fit the field`,
+      );
+    }
+  }
+});
+
+/**
+ * The closure, against an enumeration written here and not imported.
+ *
+ * `factSet` is the generator's own list, so asserting the generator against it
+ * would prove only that the family calls the function it calls. This walks every
+ * pair of numbers a level could conceivably involve and decides membership from
+ * the level's *stated* rules, then compares the two sets whole.
+ */
+function independentSet(p: NumberFactsParams): Set<string> {
+  const out = new Set<string>();
+  for (let a = 0; a <= 20; a++) {
+    for (let b = 0; b <= 20; b++) {
+      if (!p.includeZero && (a === 0 || b === 0)) continue;
+      if (a === 0 && b === 0) continue;
+      if (p.op === "add") {
+        const sum = a + b;
+        if (sum < 1 || sum > p.maxTotal) continue;
+        if (p.crossesTen) {
+          if (sum <= 10 || a > 9 || b > 9 || a === 0 || b === 0) continue;
+        } else if (sum > 10) continue;
+        out.add(`${String(a)}+${String(b)}`);
+        continue;
+      }
+      const difference = a - b;
+      if (difference < 0 || a < 1 || a > p.maxTotal) continue;
+      if (p.crossesTen) {
+        if (a <= 10 || b > 9 || b < 1 || difference < 1 || difference > 9) continue;
+      } else {
+        if (a > 10) continue;
+        if (!p.includeZero && (b < 1 || difference < 1)) continue;
+      }
+      out.add(`${String(a)}-${String(b)}`);
+    }
+  }
+  return out;
+}
+
+test("the fact set is closed, and the generator reaches exactly it", () => {
+  const lines: string[] = [];
+  for (const bound of BOUND_LEVELS) {
+    const expected = independentSet(bound.params);
+    assert.equal(
+      factSet(bound.params).length,
+      expected.size,
+      `${bound.label}: factSet has ${String(factSet(bound.params).length)} facts, the rules give ${String(expected.size)}`,
+    );
+    assert.equal(
+      bound.declared,
+      expected.size,
+      `${bound.label}: the row declares a closed set of ${String(bound.declared)} and the mathematics has ${String(expected.size)}`,
+    );
+
+    const reached = new Set<string>();
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+      reached.add(`${first.n.toString()}${bound.params.op === "add" ? "+" : "-"}${second.n.toString()}`);
+    }
+    assert.deepEqual(
+      [...reached].filter((fact) => !expected.has(fact)).sort(),
+      [],
+      `${bound.label}: the generator reached a fact outside the closed set`,
+    );
+    assert.deepEqual(
+      [...expected].filter((fact) => !reached.has(fact)).sort(),
+      [],
+      `${bound.label}: the generator never reached a fact in the closed set`,
+    );
+    lines.push(`#   ${bound.label}: ${String(expected.size)} facts, all reached in ${String(SEEDS)} seeds`);
+  }
+  process.stdout.write(`# closed fact sets:\n${lines.join("\n")}\n`);
+});
+
+test("the root of the ladder is reachable: 0 + 1, n - 0 and n - n are all drawn", () => {
+  // The graph's own level 0, not a fixture written here. A row edited to start at
+  // `1 + 1` — by dropping `includeZero`, which is one word — has to fail this, and
+  // a test carrying its own parameters would go on passing while the product's
+  // bottom rung quietly moved up.
+  const rowLevel = (id: string): NumberFactsParams => {
+    const bound = BOUND_LEVELS.find((candidate) => String(candidate.node.id) === id && candidate.level === 0);
+    assert.ok(bound !== undefined, `the graph has no level 0 of ${id}`);
+    return bound.params;
+  };
+  const root = rowLevel("dw.add.facts.add-within-ten");
+  const drawn = new Set<string>();
+  for (let seed = 1; seed <= 200; seed++) {
+    const { first, second } = operands(generate(root, seed));
+    drawn.add(`${first.n.toString()}+${second.n.toString()}`);
+  }
+  // Named individually. A level table edited to start at `1 + 1` would still pass
+  // a set-size assertion, and the trivial facts are the rung a child who has slid
+  // all the way down lands on.
+  for (const fact of ["0+1", "1+0", "1+1", "0+2", "2+0", "0+3", "3+0", "1+2", "2+1"]) {
+    assert.ok(drawn.has(fact), `the root level never draws ${fact}`);
+  }
+  assert.ok(!drawn.has("0+0"), "the root level draws an empty question");
+
+  const rootSub = rowLevel("dw.add.facts.subtract-within-ten");
+  const drawnSub = new Set<string>();
+  for (let seed = 1; seed <= 200; seed++) {
+    const { first, second } = operands(generate(rootSub, seed));
+    drawnSub.add(`${first.n.toString()}-${second.n.toString()}`);
+  }
+  for (const fact of ["1-0", "1-1", "2-0", "2-2", "3-0", "3-3", "3-1"]) {
+    assert.ok(drawnSub.has(fact), `the root level never draws ${fact}`);
+  }
+  assert.ok(!drawnSub.has("0-0"), "the root level draws an empty question");
+});
+
+test("the quantity picture is drawable, and never shows the answer", () => {
+  let framed = 0;
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= 400; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      if (!bound.params.picture) {
+        assert.equal(exercise.representation, undefined, `${exercise.exerciseId}: an unasked-for picture`);
+        continue;
+      }
+      const spec = exercise.representation;
+      assert.ok(spec !== undefined, `${exercise.exerciseId}: the level asks for a picture and got none`);
+      assert.equal(repSpecDefect(spec.rep, spec.params), null, exercise.exerciseId);
+
+      const answer = Number(answerOf(exercise).n);
+      const standing = (spec.params["first"] ?? 0) + (spec.params["second"] ?? 0);
+      if (bound.params.op === "sub") {
+        // A subtraction frame holds the **whole** with the part crossed out.
+        // Drawing `first − second` counters beside `second` would put the answer
+        // on the screen, and the assertion that rules it out is that the counters
+        // standing are the minuend. The only item where that number is also the
+        // answer is `n − 0`, where drawing it is correct.
+        const minuend = Number(operands(exercise).first.n);
+        const subtrahend = Number(operands(exercise).second.n);
+        assert.equal(spec.params["first"], minuend, `${exercise.exerciseId}: the frame does not hold the whole`);
+        assert.equal(spec.params["second"], 0, exercise.exerciseId);
+        assert.equal(spec.params["removed"], subtrahend, exercise.exerciseId);
+        if (subtrahend > 0) {
+          assert.notEqual(spec.params["first"], answer, `${exercise.exerciseId}: the frame draws the answer`);
+        }
+      } else {
+        assert.equal(standing, answer, `${exercise.exerciseId}: the frame does not hold the sum`);
+        assert.equal(spec.params["removed"], 0, exercise.exerciseId);
+      }
+      framed += 1;
+    }
+  }
+  assert.ok(framed > 0, "no level in the graph draws a quantity picture");
+  process.stdout.write(`# number-facts: ${String(framed)} framed item(s) checked\n`);
+});
+
+test("the walkthrough's strategy rung is the strategy, and its last rung is the answer", () => {
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= 400; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      assert.equal(exercise.solution.length, 3, exercise.exerciseId);
+      const middle = exercise.solution[1];
+      const last = exercise.solution[2];
+      assert.ok(middle !== undefined && last !== undefined);
+
+      const stated = last.slots["answer"];
+      assert.ok(stated !== undefined && stated.kind === "number", exercise.exerciseId);
+      assert.ok(ratEq(stated.value, answerOf(exercise)), `${exercise.exerciseId}: the ladder ends elsewhere`);
+
+      if (!bound.params.crossesTen) {
+        // Count on from the *larger* addend. Starting at the smaller one is the
+        // slower habit this rung exists to displace, and a rung that taught it
+        // would be teaching the wrong strategy in the right place.
+        const from = middle.slots["from"];
+        const count = middle.slots["count"];
+        assert.ok(from !== undefined && from.kind === "number", exercise.exerciseId);
+        assert.ok(count !== undefined && count.kind === "count", exercise.exerciseId);
+        const { first, second } = operands(exercise);
+        if (bound.params.op === "add") {
+          assert.ok(from.value.n >= BigInt(count.value), `${exercise.exerciseId}: counts on from the smaller addend`);
+          assert.ok(
+            ratEq(ratAdd(from.value, rational(BigInt(count.value))), answerOf(exercise)),
+            exercise.exerciseId,
+          );
+        } else {
+          assert.ok(ratEq(from.value, first), exercise.exerciseId);
+          assert.equal(BigInt(count.value), second.n, exercise.exerciseId);
+        }
+        continue;
+      }
+
+      // The bridge: `toTen` lands exactly on ten and `rest` is what is left.
+      const toTen = middle.slots["toTen"];
+      const rest = middle.slots["rest"];
+      assert.ok(toTen !== undefined && toTen.kind === "count", exercise.exerciseId);
+      assert.ok(rest !== undefined && rest.kind === "count", exercise.exerciseId);
+      assert.ok(toTen.value >= 1 && rest.value >= 1, `${exercise.exerciseId}: a bridge with a step of nothing`);
+      const { first, second } = operands(exercise);
+      assert.equal(BigInt(toTen.value + rest.value), second.n, `${exercise.exerciseId}: the bridge is not the part`);
+      const landing = bound.params.op === "add" ? first.n + BigInt(toTen.value) : first.n - BigInt(toTen.value);
+      assert.equal(landing, 10n, `${exercise.exerciseId}: the bridge does not land on ten`);
+    }
+  }
+});
+
+test("the parameter schema rejects the combinations no fact could satisfy", () => {
+  const reject = (raw: unknown, pattern: RegExp): void => {
+    const result = numberFactsParamSchema.validate(raw);
+    assert.equal(result.ok, false, `expected a rejection of ${JSON.stringify(raw)}`);
+    if (!result.ok) {
+      assert.match(result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; "), pattern);
+    }
+  };
+
+  assert.equal(numberFactsParamSchema.validate(params("add", 3, { includeZero: true, picture: true })).ok, true);
+
+  reject(params("add", 5, { crossesTen: true }), /crossing ten reaches at least 11/);
+  reject(params("add", 14), /does not cross ten reaches at most ten/);
+  reject(params("add", 14, { crossesTen: true, includeZero: true }), /zero operand cannot cross ten/);
+  reject(params("add", 14, { crossesTen: true, picture: true }), /does not fit in it/);
+  reject({ op: "times", maxTotal: 5, crossesTen: false, includeZero: false, picture: false }, /op must be one of/);
+  reject({ op: "add", maxTotal: 1, crossesTen: false, includeZero: false, picture: false }, /maxTotal must be 2/);
+  reject({ op: "add", maxTotal: 19, crossesTen: true, includeZero: false, picture: false }, /maxTotal must be 2/);
+});
+
+test("the difficulty contribution is exact, ordered, and never a float", () => {
+  const offset = (p: NumberFactsParams): Rational => numberFactsFamily.difficultyOffset(p);
+
+  // Hundredths of a logit, exactly. A float `0.55` would make the last bits of
+  // every `b` in this family platform-dependent.
+  assert.equal(ratToString(offset(params("add", 3))), "0");
+  assert.equal(ratToString(offset(params("add", 3, { includeZero: true, picture: true }))), "-9/20");
+  assert.equal(ratToString(offset(params("sub", 3, { includeZero: true, picture: true }))), "-3/10");
+  assert.equal(ratToString(offset(params("add", 18, { crossesTen: true }))), "13/10");
+
+  // The one ordering the whole change exists to produce: every fact item sits
+  // below the easiest column item in the graph, which is `43 + 25` at -0.90.
+  const columnFloor = rational(-90n, 100n);
+  const factLevels = addDomainNodes
+    .filter((node) => node.generator.family === NUMBER_FACTS_FAMILY)
+    .flatMap((node) => node.difficulty.levels);
+  assert.ok(factLevels.length > 0);
+  for (const level of factLevels) {
+    assert.ok(
+      ratToString(ratSub(level, columnFloor)).startsWith("-"),
+      `a fact level at ${ratToString(level)} is not below the column floor ${ratToString(columnFloor)}`,
+    );
+  }
+  const hardest = factLevels.reduce((a, c) => (ratToString(ratSub(c, a)).startsWith("-") ? a : c));
+  process.stdout.write(`# number-facts: hardest fact level b = ${ratToString(hardest)}, column floor -9/10\n`);
+});
+
+test("the same seed produces the identical item, and different seeds do not all agree", () => {
+  const p = params("sub", 18, { crossesTen: true });
+  const first = serializeExercise(generate(p, 7));
+  assert.equal(serializeExercise(generate(p, 7)), first);
+  assert.equal(serializeExercise(generate(p, 7)), first);
+
+  const distinct = new Set(Array.from({ length: 50 }, (_unused, i) => serializeExercise(generate(p, i + 1))));
+  assert.ok(distinct.size > 20, `50 seeds produced only ${String(distinct.size)} distinct items`);
+});
+
+test("the prompt is a spec with typed slots, never a rendered sentence", () => {
+  const exercise = generate(params("add", 18, { crossesTen: true }), 3);
+  assert.equal(exercise.prompt.key, PROMPT_KEY_ADD);
+  assert.deepEqual(Object.keys(exercise.prompt.slots).sort(), [SLOT_FIRST, SLOT_SECOND].sort());
+  assert.equal(generate(params("sub", 18, { crossesTen: true }), 3).prompt.key, PROMPT_KEY_SUB);
+});

--- a/dynawalla/packs/shared/curriculum/src/generators/numberFacts/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/numberFacts/params.ts
@@ -1,0 +1,83 @@
+/**
+ * `gen.arith.number-facts` parameters and their validator.
+ *
+ * A fact is bounded by a **value**, not by a digit count, and that is the whole
+ * reason this family exists beside `gen.arith.column-op`. Digit count says
+ * "two-digit minuend, one-digit subtrahend, one borrow", which is `94 − 6` as
+ * readily as `15 − 8`; only a value bound says "within twenty, crossing ten".
+ *
+ * `maxTotal` is the largest number the fact reaches — the sum for addition, the
+ * whole for subtraction. One parameter for both because it is one quantity:
+ * `7 + 8 = 15` and `15 − 8 = 7` are the same fact read two ways, and a level
+ * table that named them differently would obscure that.
+ *
+ * The validator rejects the combinations no fact could satisfy, so `generate()`
+ * can treat an empty fact set as a bug rather than as input it has to guess about.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type NumberFactsOp = "add" | "sub";
+
+export const NUMBER_FACTS_OPS: readonly NumberFactsOp[] = ["add", "sub"];
+
+export type NumberFactsParams = {
+  readonly op: NumberFactsOp;
+  /**
+   * The largest number the fact reaches: the sum for `add`, the whole for `sub`.
+   * The smallest useful level is `2`, which is `0 + 1`, `1 + 0`, `1 + 1`, `2 + 0`
+   * and `0 + 2`.
+   */
+  readonly maxTotal: number;
+  /** Only facts that cross ten — `7 + 8`, `15 − 8`. Excludes every zero operand. */
+  readonly crossesTen: boolean;
+  /** Admit the identity facts: `0 + n`, `n + 0`, `n − 0`, `n − n`. */
+  readonly includeZero: boolean;
+  /** Draw the quantity in a ten-frame beside the numerals. */
+  readonly picture: boolean;
+};
+
+/** `0 + 1` needs a total of one; a level of only `1 + 0` and `0 + 1` is thin. */
+export const MIN_MAX_TOTAL = 2;
+/** `9 + 9`, and the largest teen a single-digit part can be taken from. */
+export const MAX_MAX_TOTAL = 18;
+/** Below this a fact does not cross ten at all. */
+export const MIN_CROSSING_TOTAL = 11;
+/** The ten-frame holds ten. A picture beyond it would be a different frame. */
+export const MAX_PICTURE_TOTAL = 10;
+
+export const numberFactsParamSchema: ParamSchema<NumberFactsParams> = {
+  describe:
+    "{ op: 'add'|'sub', maxTotal: 2..18, crossesTen: boolean, includeZero: boolean, picture: boolean }",
+
+  validate(raw: unknown): ParamResult<NumberFactsParams> {
+    const read = reader(raw);
+    const op = read.choice<NumberFactsOp>("op", NUMBER_FACTS_OPS);
+    const maxTotal = read.int("maxTotal", MIN_MAX_TOTAL, MAX_MAX_TOTAL);
+    const crossesTen = read.boolean("crossesTen");
+    const includeZero = read.boolean("includeZero");
+    const picture = read.boolean("picture");
+
+    if (read.clean()) {
+      if (crossesTen && maxTotal < MIN_CROSSING_TOTAL) {
+        read.reject("maxTotal", `a fact crossing ten reaches at least ${String(MIN_CROSSING_TOTAL)}`);
+      }
+      if (!crossesTen && maxTotal > MAX_PICTURE_TOTAL) {
+        // A sum of eleven that does not cross ten needs an addend above nine, which
+        // is place-value addition (`13 + 4`) and belongs to `gen.arith.column-op`.
+        read.reject("maxTotal", "a fact that does not cross ten reaches at most ten");
+      }
+      if (crossesTen && includeZero) {
+        read.reject("includeZero", "a zero operand cannot cross ten");
+      }
+      if (picture && crossesTen) {
+        read.reject("picture", "the ten-frame holds ten; a crossing fact does not fit in it");
+      }
+      if (picture && maxTotal > MAX_PICTURE_TOTAL) {
+        read.reject("picture", `the ten-frame holds ${String(MAX_PICTURE_TOTAL)}`);
+      }
+    }
+    return read.finish({ op, maxTotal, crossesTen, includeZero, picture });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/registry.ts
@@ -12,10 +12,12 @@ import { fracEquivalenceFamily } from "./fracEquivalence/family.ts";
 import { longDivFamily } from "./longDiv/family.ts";
 import { missingOperandFamily } from "./missingOperand/family.ts";
 import { multidigitMulFamily } from "./multidigitMul/family.ts";
+import { numberFactsFamily } from "./numberFacts/family.ts";
 import { placeValueFamily } from "./placeValue/family.ts";
 import { roundEstimateFamily } from "./roundEstimate/family.ts";
 
 export const generatorFamilies: readonly AnyGeneratorFamily[] = [
+  erase(numberFactsFamily),
   erase(columnOpFamily),
   erase(placeValueFamily),
   erase(compareOrderFamily),

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
@@ -1,12 +1,18 @@
 /**
- * Domain `add` — addition and subtraction.
+ * Domain `add` — addition and subtraction, from `0 + 1` to `4,003 − 87`.
  *
- * The seed of the V1 graph: the three column-algorithm nodes M2 needs, plus one
- * `draft` node that exists to prove draft rows are excluded from the shipped graph
- * and from all coverage math (CG-7).
+ * Two clusters and two generator families, in one ladder. `facts` binds
+ * `gen.arith.number-facts` and holds the recalled facts a child needs before any
+ * column procedure means anything; `column` and `regroup` bind
+ * `gen.arith.column-op` and hold the procedure. The fact rows are underneath, and
+ * the capability tags below are what make that a mechanical fact rather than an
+ * editorial ordering — see the note on them.
  *
- * The full 32-node domain lands in the M4 promotion PR. Every id here is final —
- * ids are mastery keys on learner devices and are immutable forever.
+ * One `draft` node remains, and it earns its place: it proves draft rows are
+ * excluded from the shipped graph and from all coverage math (CG-7).
+ *
+ * Every id here is final — ids are mastery keys on learner devices and are
+ * immutable forever.
  *
  * `difficulty.levels` restates what `family.difficultyOffset(params)` computes.
  * That is deliberate redundancy: it makes "b is a pure function of generator
@@ -23,11 +29,18 @@ import {
   FORM_FREE_ENTRY,
 } from "../../generators/columnOp/constants.ts";
 import {
+  FORM_FREE_ENTRY as FACTS_FORM_FREE_ENTRY,
+  NUMBER_FACTS_FAMILY,
+  NUMBER_FACTS_FAMILY_REV,
+} from "../../generators/numberFacts/constants.ts";
+import type { NumberFactsParams } from "../../generators/numberFacts/params.ts";
+import {
   MIS_BORROW_ACROSS_ZERO,
   MIS_CARRY_DROPPED,
   MIS_SMALLER_FROM_LARGER,
   REP_COUNTING_BOARD,
 } from "../../malrules/columnOp.ts";
+import { REP_TEN_FRAME } from "../../render/representations.ts";
 import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
 import type { SkillNode } from "../../types/skill.ts";
 
@@ -35,6 +48,35 @@ const CAP_COLUMN_ALIGN = capabilityTag("cap.arith.column-align");
 const CAP_SUB_REGROUP = capabilityTag("cap.arith.sub-regroup");
 const CAP_SUB_ACROSS_ZERO = capabilityTag("cap.arith.sub-across-zero");
 const CAP_ADD_CARRY = capabilityTag("cap.arith.add-carry");
+
+/**
+ * The four fact capabilities, and why they are not decoration.
+ *
+ * A carry happens exactly when a column sum crosses ten, and a borrow happens
+ * exactly when a column difference does. So the column rows do not merely follow
+ * the fact rows in some editorial ordering — they *consume* them, and CG-6 will
+ * name the missing edge if anyone ever cuts one. This is the mechanism that makes
+ * the ladder from `0 + 1` to `4003 − 87` continuous rather than asserted.
+ */
+const CAP_SUMS_WITHIN_TEN = capabilityTag("cap.arith.sums-within-ten");
+const CAP_DIFFERENCES_WITHIN_TEN = capabilityTag("cap.arith.differences-within-ten");
+const CAP_SUMS_ACROSS_TEN = capabilityTag("cap.arith.sums-across-ten");
+const CAP_DIFFERENCES_ACROSS_TEN = capabilityTag("cap.arith.differences-across-ten");
+
+/** Written out so the fact level tables below read as tables. */
+function fact(
+  op: "add" | "sub",
+  maxTotal: number,
+  options: { crossesTen?: boolean; includeZero?: boolean; picture?: boolean } = {},
+): NumberFactsParams {
+  return {
+    op,
+    maxTotal,
+    crossesTen: options.crossesTen ?? false,
+    includeZero: options.includeZero ?? false,
+    picture: options.picture ?? false,
+  };
+}
 
 /** Written out so the level tables below read as tables. */
 function sub(
@@ -64,6 +106,11 @@ function b(hundredths: bigint) {
   return rational(hundredths, 100n);
 }
 
+export const SKILL_ADD_WITHIN_TEN = skillId("dw.add.facts.add-within-ten");
+export const SKILL_SUBTRACT_WITHIN_TEN = skillId("dw.add.facts.subtract-within-ten");
+export const SKILL_ADD_ACROSS_TEN = skillId("dw.add.facts.add-across-ten");
+export const SKILL_SUBTRACT_ACROSS_TEN = skillId("dw.add.facts.subtract-across-ten");
+
 export const SKILL_ADD_NO_REGROUP = skillId("dw.add.column.add-no-regroup");
 export const SKILL_SUBTRACT_NO_REGROUP = skillId("dw.add.column.subtract-no-regroup");
 export const SKILL_ADD_SHORT_ADDEND = skillId("dw.add.regroup.add-short-addend");
@@ -73,12 +120,274 @@ export const SKILL_SUBTRACT_ACROSS_ZERO = skillId("dw.add.regroup.subtract-acros
 export const SKILL_ADD_MULTIDIGIT = skillId("dw.add.regroup.add-multidigit");
 export const SKILL_SUBTRACT_TENTHS = skillId("dw.add.regroup.subtract-tenths");
 
+/**
+ * ## The four fact rows: the bottom of the graph
+ *
+ * Before these, the easiest thing this program could give a child was
+ * `plus(2, 2, 0)` — a two-digit sum. There was no first grade in the curriculum
+ * at all, and a five-year-old opening the product met second-grade column
+ * arithmetic on the first card.
+ *
+ * Four rows, and each one is here because something specific is missing without
+ * it. Two candidates were considered and cut, and they are named below the rows
+ * so that the next person does not re-propose them.
+ *
+ * **Why they are `active` and not `draft`.** Every other draft row in this graph
+ * waits on a statement renderer that no pack has landed, and so do these: CG-8
+ * warns on all of them and fails under `--strict-renderers`, which is unchanged.
+ * What is different is that these rows are the *floor of every game's difficulty
+ * range*. An adaptive controller that walks down when a child struggles walks
+ * down through `activeNodes`, and a draft row is not in it — so a struggling
+ * second grader slides to `43 + 25` and stops there, which is the exact failure
+ * this change exists to fix. A row nobody can draw is a warning; a floor that is
+ * not the floor is a child stuck.
+ *
+ * **The trivial facts are in, unhedged.** `0 + 1`, `1 + 0`, `n − 0` and `n − n`
+ * are all in level 0's set. They are not there for completeness — they are the
+ * rung a child who has slid all the way down lands on, and a bottom rung that is
+ * still a small challenge is not a bottom rung. Nothing about them is made harder
+ * to look more respectable.
+ *
+ * **The one gap that is honest and not filled.** Sorted, the fourteen fact levels
+ * run −3.00, −2.90, −2.85, −2.75, −2.65, −2.50, −2.20, −2.05, then −1.60, −1.55,
+ * −1.50, −1.45, −1.30, −1.25, and the easiest column item is −0.90. Every step is
+ * 0.05 to 0.30 except one: **0.45, between −2.05 and −1.60**, where the ladder
+ * leaves ten behind. That is not an authoring oversight. Crossing ten *is* the
+ * discontinuity of first-grade arithmetic, and the coefficient that produces the
+ * step is column-op's regrouping coefficient reused unchanged, on the argument
+ * that crossing ten and regrouping are one phenomenon measured twice. A row
+ * invented to sit in the gap would be a row with no mathematics of its own.
+ */
+const addWithinTen: SkillNode = {
+  id: SKILL_ADD_WITHIN_TEN,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.facts.add-within-ten.title"),
+  learnerGoal: locKey("dw.skill.add.facts.add-within-ten.goal"),
+  domain: "add",
+  cluster: "facts",
+  bigIdeas: [locKey("dw.idea.number.counting-tells-how-many")],
+  // Grade 0 is kindergarten. `earliest` is what the coverage matrix reads and the
+  // scheduler reads nothing at all: readiness is the prerequisite graph, and this
+  // row has no prerequisites, so it is the entry point at any age.
+  gradeBand: { earliest: 0, nominal: 0, latest: 2 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 1, strategic: 1, adaptive: 0 },
+  classification: "fluency",
+  fluencyTarget: { p50Ms: 6000 },
+  prereqs: [],
+  difficulty: { b: b(-255n), levels: [b(-300n), b(-290n), b(-265n), b(-220n)] },
+  misconceptions: [],
+  // Optional and not required, on the same terms as every other row in this file:
+  // no pack draws a representation yet, and a row that declared one `required`
+  // today would be a curriculum row the app cannot draw. The generator emits the
+  // spec on the first three levels regardless, so the picture arrives with the
+  // renderer rather than after a second authoring pass.
+  representations: { required: [], optional: [REP_TEN_FRAME] },
+  generator: {
+    family: NUMBER_FACTS_FAMILY,
+    familyRev: NUMBER_FACTS_FAMILY_REV,
+    // The root, then within five, then within ten, then within ten with the frame
+    // taken away and the identity facts with it. Four rungs across a range a
+    // five-year-old can walk in a sitting.
+    params: [
+      fact("add", 3, { includeZero: true, picture: true }),
+      fact("add", 5, { includeZero: true, picture: true }),
+      fact("add", 10, { includeZero: true, picture: true }),
+      fact("add", 10),
+    ],
+    forms: [FACTS_FORM_FREE_ENTRY],
+    // Nine: level 0's whole set, which the smallest gate sample already collects.
+    // `minVariants` counts distinct items *in a sample*, so on a closed set it can
+    // never assert more than the sample size makes reachable, and the assertion
+    // that matters is in `numberFacts.test.ts` — it enumerates each level's set
+    // from the level's stated rules and checks the generator reaches every member.
+    minVariants: 9,
+    closedFactSet: [9, 20, 65, 45],
+    consumes: [],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 3, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_SUMS_WITHIN_TEN],
+  standards: { ccss: ["K.OA.A.5", "1.OA.C.6"] },
+};
+
+const subtractWithinTen: SkillNode = {
+  id: SKILL_SUBTRACT_WITHIN_TEN,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.facts.subtract-within-ten.title"),
+  learnerGoal: locKey("dw.skill.add.facts.subtract-within-ten.goal"),
+  domain: "add",
+  cluster: "facts",
+  bigIdeas: [
+    locKey("dw.idea.number.counting-tells-how-many"),
+    locKey("dw.idea.equality.undoing-runs-both-ways"),
+  ],
+  gradeBand: { earliest: 0, nominal: 1, latest: 2 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 1, strategic: 1, adaptive: 0 },
+  classification: "fluency",
+  fluencyTarget: { p50Ms: 6000 },
+  // A separate row and not a level of its sibling: a child fluent in sums within
+  // ten is routinely not fluent in the differences, and one mastery record for
+  // both would report a fluency the child does not have in the direction that is
+  // actually failing.
+  prereqs: [{ kind: "requires", to: SKILL_ADD_WITHIN_TEN }],
+  difficulty: { b: b(-255n), levels: [b(-285n), b(-275n), b(-250n), b(-205n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [REP_TEN_FRAME] },
+  generator: {
+    family: NUMBER_FACTS_FAMILY,
+    familyRev: NUMBER_FACTS_FAMILY_REV,
+    params: [
+      fact("sub", 3, { includeZero: true, picture: true }),
+      fact("sub", 5, { includeZero: true, picture: true }),
+      fact("sub", 10, { includeZero: true, picture: true }),
+      fact("sub", 10),
+    ],
+    forms: [FACTS_FORM_FREE_ENTRY],
+    minVariants: 9,
+    closedFactSet: [9, 20, 65, 45],
+    consumes: [CAP_SUMS_WITHIN_TEN],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 3, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_DIFFERENCES_WITHIN_TEN],
+  standards: { ccss: ["K.OA.A.5", "1.OA.C.6"] },
+};
+
+const addAcrossTen: SkillNode = {
+  id: SKILL_ADD_ACROSS_TEN,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.facts.add-across-ten.title"),
+  learnerGoal: locKey("dw.skill.add.facts.add-across-ten.goal"),
+  domain: "add",
+  cluster: "facts",
+  bigIdeas: [locKey("dw.idea.number.ten-is-a-landmark")],
+  gradeBand: { earliest: 1, nominal: 1, latest: 3 },
+  strandRole: "spine",
+  // Strategic rather than procedural: the level table is a range of sums, and the
+  // thing being learned is the bridge through ten, not a sequence of steps.
+  proficiency: { conceptual: 2, procedural: 1, strategic: 2, adaptive: 1 },
+  classification: "fluency",
+  fluencyTarget: { p50Ms: 8000 },
+  prereqs: [{ kind: "requires", to: SKILL_ADD_WITHIN_TEN }],
+  difficulty: { b: b(-260n), levels: [b(-160n), b(-150n), b(-130n)] },
+  misconceptions: [],
+  // No frame: a sum past ten does not fit in one, and by this row the numerals
+  // are the thing being read. The picture is a scaffold for cardinality, not a
+  // decoration to carry up the ladder.
+  representations: { required: [], optional: [] },
+  generator: {
+    family: NUMBER_FACTS_FAMILY,
+    familyRev: NUMBER_FACTS_FAMILY_REV,
+    params: [
+      fact("add", 12, { crossesTen: true }),
+      fact("add", 14, { crossesTen: true }),
+      fact("add", 18, { crossesTen: true }),
+    ],
+    forms: [FACTS_FORM_FREE_ENTRY],
+    // Twelve, under the thirteen a forty-seed sample reaches of level 0's fifteen.
+    // See the note on the within-ten rows: on a closed set this number is bounded
+    // by the sample, not by the mathematics.
+    minVariants: 12,
+    closedFactSet: [15, 26, 36],
+    consumes: [CAP_SUMS_WITHIN_TEN],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_SUMS_ACROSS_TEN],
+  standards: { ccss: ["1.OA.C.6", "2.OA.B.2"] },
+};
+
+const subtractAcrossTen: SkillNode = {
+  id: SKILL_SUBTRACT_ACROSS_TEN,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.facts.subtract-across-ten.title"),
+  learnerGoal: locKey("dw.skill.add.facts.subtract-across-ten.goal"),
+  domain: "add",
+  cluster: "facts",
+  bigIdeas: [
+    locKey("dw.idea.number.ten-is-a-landmark"),
+    locKey("dw.idea.equality.undoing-runs-both-ways"),
+  ],
+  gradeBand: { earliest: 1, nominal: 1, latest: 3 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 1, strategic: 2, adaptive: 1 },
+  classification: "fluency",
+  fluencyTarget: { p50Ms: 8000 },
+  // Two prerequisites because `15 − 8` is reached two ways and both are taught:
+  // down through ten from the difference side, and as the addition fact `8 + 7`
+  // read backwards. Cutting either edge would leave a child who has only one of
+  // them eligible for a row they cannot get into.
+  prereqs: [
+    { kind: "requires", to: SKILL_SUBTRACT_WITHIN_TEN },
+    { kind: "requires", to: SKILL_ADD_ACROSS_TEN },
+  ],
+  difficulty: { b: b(-270n), levels: [b(-155n), b(-145n), b(-125n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: NUMBER_FACTS_FAMILY,
+    familyRev: NUMBER_FACTS_FAMILY_REV,
+    params: [
+      fact("sub", 12, { crossesTen: true }),
+      fact("sub", 14, { crossesTen: true }),
+      fact("sub", 18, { crossesTen: true }),
+    ],
+    forms: [FACTS_FORM_FREE_ENTRY],
+    // Twelve, under the thirteen a forty-seed sample reaches of level 0's fifteen.
+    // See the note on the within-ten rows: on a closed set this number is bounded
+    // by the sample, not by the mathematics.
+    minVariants: 12,
+    closedFactSet: [15, 26, 36],
+    consumes: [CAP_DIFFERENCES_WITHIN_TEN, CAP_SUMS_ACROSS_TEN],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_DIFFERENCES_ACROSS_TEN],
+  standards: { ccss: ["1.OA.C.6", "2.OA.B.2"] },
+};
+
+/**
+ * ## Two rows that were considered and are deliberately absent
+ *
+ * **Doubles (`7 + 7`, `8 + 8`).** A real anchor strategy, and not a row: there
+ * are nine doubles in the world and five of them cross ten, so a doubles level
+ * would be a five-item set carved out of `add-across-ten`. What doubles are for
+ * is anchoring the neighbours — `7 + 8` from `7 + 7` — and that is a *hint*, which
+ * belongs in the walkthrough of the row that already contains both facts.
+ *
+ * **Make-ten (`7 + 3`, `6 + 4`).** As a result-unknown question, `7 + 3` is
+ * already an item of `add-within-ten` and a make-ten row would draw the same
+ * cards under a second mastery key. The question that makes it a *strategy* is
+ * `7 + ☐ = 10`, where the unknown is the addend — which is a different family
+ * (`gen.arith.missing-operand`) and already has an id,
+ * `dw.alg.equality.missing-addend`. It stays draft here because promoting it is
+ * that row's own decision and not this change's; the note is so nobody mints a
+ * duplicate.
+ */
 const subtractMultidigit: SkillNode = {
   id: SKILL_SUBTRACT_MULTIDIGIT,
   // rev 2: gained the prerequisite it always had and never declared. Aligning the
   // columns and subtracting without regrouping is not the same skill as regrouping,
   // and a graph whose spine started at the harder one had no entry point.
-  rev: 2,
+  //
+  // rev 3: gained the second one. A borrow happens exactly when a column
+  // difference crosses ten, so `52 − 27` is `12 − 7` inside a procedure, and a
+  // child who cannot do `12 − 7` cannot do this row however well they align.
+  rev: 3,
   status: "active",
   title: locKey("dw.skill.add.regroup.subtract-multidigit.title"),
   learnerGoal: locKey("dw.skill.add.regroup.subtract-multidigit.goal"),
@@ -90,7 +399,10 @@ const subtractMultidigit: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 12000 },
-  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_NO_REGROUP }],
+  prereqs: [
+    { kind: "requires", to: SKILL_SUBTRACT_NO_REGROUP },
+    { kind: "requires", to: SKILL_SUBTRACT_ACROSS_TEN },
+  ],
   difficulty: {
     b: b(-50n),
     levels: [b(5n), b(35n), b(90n), b(120n)],
@@ -109,7 +421,7 @@ const subtractMultidigit: SkillNode = {
     params: [sub(2, 2, 1, 0), sub(3, 3, 1, 0), sub(3, 3, 2, 0), sub(4, 4, 2, 0)],
     forms: [FORM_FREE_ENTRY, FORM_COLUMN],
     minVariants: 24,
-    consumes: [CAP_COLUMN_ALIGN],
+    consumes: [CAP_COLUMN_ALIGN, CAP_DIFFERENCES_ACROSS_TEN],
   },
   probes: [
     { level: 0, seed: 1, purpose: "entry" },
@@ -160,8 +472,12 @@ const subtractAcrossZero: SkillNode = {
 
 const addMultidigit: SkillNode = {
   id: SKILL_ADD_MULTIDIGIT,
-  /** rev 2: same as its sibling — the non-regrouping column sum is its prerequisite. */
-  rev: 2,
+  /**
+   * rev 2: same as its sibling — the non-regrouping column sum is its prerequisite.
+   * rev 3: and so is the crossing-ten fact. A carry happens exactly when a column
+   * sum crosses ten, so `47 + 25` is `7 + 5` inside a procedure.
+   */
+  rev: 3,
   status: "active",
   title: locKey("dw.skill.add.regroup.add-multidigit.title"),
   learnerGoal: locKey("dw.skill.add.regroup.add-multidigit.goal"),
@@ -173,7 +489,10 @@ const addMultidigit: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 12000 },
-  prereqs: [{ kind: "requires", to: SKILL_ADD_NO_REGROUP }],
+  prereqs: [
+    { kind: "requires", to: SKILL_ADD_NO_REGROUP },
+    { kind: "requires", to: SKILL_ADD_ACROSS_TEN },
+  ],
   difficulty: {
     b: b(-60n),
     levels: [b(-5n), b(25n), b(80n)],
@@ -186,7 +505,7 @@ const addMultidigit: SkillNode = {
     params: [plus(2, 2, 1), plus(3, 3, 1), plus(3, 3, 2)],
     forms: [FORM_FREE_ENTRY, FORM_COLUMN],
     minVariants: 24,
-    consumes: [CAP_COLUMN_ALIGN],
+    consumes: [CAP_COLUMN_ALIGN, CAP_SUMS_ACROSS_TEN],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [CAP_ADD_CARRY],
@@ -253,7 +572,13 @@ const subtractTenths: SkillNode = {
  */
 const subtractNoRegroup: SkillNode = {
   id: SKILL_SUBTRACT_NO_REGROUP,
-  rev: 1,
+  /**
+   * rev 2: gained the prerequisite it always had. Every column of a no-regroup
+   * subtraction is a difference within ten, so this row consumes the fact row
+   * outright — and until the fact row existed, the graph's entry point was a
+   * two-digit column subtraction with nothing underneath it.
+   */
+  rev: 2,
   status: "active",
   title: locKey("dw.skill.add.column.subtract-no-regroup.title"),
   learnerGoal: locKey("dw.skill.add.column.subtract-no-regroup.goal"),
@@ -265,7 +590,7 @@ const subtractNoRegroup: SkillNode = {
   proficiency: { conceptual: 1, procedural: 3, strategic: 0, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 10000 },
-  prereqs: [],
+  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_WITHIN_TEN }],
   difficulty: { b: b(-90n), levels: [b(-90n), b(-60n), b(-30n)] },
   misconceptions: [],
   representations: { required: [], optional: [REP_COUNTING_BOARD] },
@@ -275,7 +600,7 @@ const subtractNoRegroup: SkillNode = {
     params: [sub(2, 2, 0, 0), sub(3, 3, 0, 0), sub(4, 4, 0, 0)],
     forms: [FORM_FREE_ENTRY, FORM_COLUMN],
     minVariants: 24,
-    consumes: [],
+    consumes: [CAP_DIFFERENCES_WITHIN_TEN],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [CAP_COLUMN_ALIGN],
@@ -284,7 +609,8 @@ const subtractNoRegroup: SkillNode = {
 
 const addNoRegroup: SkillNode = {
   id: SKILL_ADD_NO_REGROUP,
-  rev: 1,
+  /** rev 2: same as its sibling — every column here is a sum within ten. */
+  rev: 2,
   status: "active",
   title: locKey("dw.skill.add.column.add-no-regroup.title"),
   learnerGoal: locKey("dw.skill.add.column.add-no-regroup.goal"),
@@ -296,7 +622,7 @@ const addNoRegroup: SkillNode = {
   proficiency: { conceptual: 1, procedural: 3, strategic: 0, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 10000 },
-  prereqs: [],
+  prereqs: [{ kind: "requires", to: SKILL_ADD_WITHIN_TEN }],
   difficulty: { b: b(-90n), levels: [b(-90n), b(-60n), b(-30n)] },
   misconceptions: [],
   representations: { required: [], optional: [REP_COUNTING_BOARD] },
@@ -306,7 +632,7 @@ const addNoRegroup: SkillNode = {
     params: [plus(2, 2, 0), plus(3, 3, 0), plus(4, 4, 0)],
     forms: [FORM_FREE_ENTRY, FORM_COLUMN],
     minVariants: 24,
-    consumes: [],
+    consumes: [CAP_SUMS_WITHIN_TEN],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [CAP_COLUMN_ALIGN],
@@ -383,6 +709,10 @@ const addShortAddend: SkillNode = {
 };
 
 export const addDomainNodes: readonly SkillNode[] = [
+  addWithinTen,
+  subtractWithinTen,
+  addAcrossTen,
+  subtractAcrossTen,
   addNoRegroup,
   subtractNoRegroup,
   subtractMultidigit,

--- a/dynawalla/packs/shared/curriculum/src/graph/graph.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/graph.ts
@@ -5,11 +5,18 @@
  * from it and from every coverage count, so the graph can never become a wish list
  * (CG-7).
  *
- * Six domains are represented here and one of them has active rows. That is not an
- * accident of effort: `add` binds `gen.arith.column-op`, which is the only family
- * whose **prompt template** the app can draw, and CG-8 now says so mechanically
- * (`render/prompts.ts`). Every other row is a complete, property-tested generator
- * waiting on the statement renderer PR-2.13 lands.
+ * Six domains are represented here and one of them has active rows. `add` binds
+ * `gen.arith.column-op` and `gen.arith.number-facts`, which between them are the
+ * whole arithmetic ladder from `0 + 1` upward; every other row is a complete,
+ * property-tested generator waiting on the statement renderer PR-2.13 lands.
+ *
+ * Note that "waiting on a renderer" is true of the active rows too — CG-8 warns on
+ * all of them and fails under `--strict-renderers`. What distinguishes an active
+ * row is not that something can draw it. It is that a scheduler and a game can
+ * *reach* it: `activeNodes` is the list an adaptive controller walks in both
+ * directions, so a row that is draft is a rung that does not exist, and the floor
+ * of every game's difficulty range is whatever the lowest active row happens to
+ * be. `ladder.test.ts` holds that floor in place.
  *
  * For twelve of the thirty draft rows, `status` is then the only field that has to
  * change. For the other eighteen it is not: their level tables sit under CG-10's

--- a/dynawalla/packs/shared/curriculum/src/graph/ladder.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/ladder.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The shipped ladder: one connected climb from `0 + 1` to four-digit column work.
+ *
+ * The gates check the graph's *integrity* — acyclic, no dangling edge, every
+ * consumed capability provided somewhere upstream. None of them checks the thing
+ * a game actually needs, which is that `activeNodes()` is a ladder: a single
+ * rooted chain with a bottom rung a five-year-old can stand on, ordered so that
+ * walking it never puts a skill before its own prerequisites.
+ *
+ * That property has to be a test rather than a comment because it is what an
+ * adaptive controller walks in both directions. Before the fact rows the active
+ * graph had **two** roots, both of them two-digit column arithmetic, and a child
+ * who slid to the bottom landed on `43 + 25` and could go no further down. That
+ * failure was invisible to every gate in the set: the graph was perfectly valid,
+ * it simply had no floor.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { activeNodes, allNodes } from "./graph.ts";
+import {
+  SKILL_ADD_ACROSS_TEN,
+  SKILL_ADD_MULTIDIGIT,
+  SKILL_ADD_NO_REGROUP,
+  SKILL_ADD_WITHIN_TEN,
+  SKILL_SUBTRACT_ACROSS_TEN,
+  SKILL_SUBTRACT_MULTIDIGIT,
+  SKILL_SUBTRACT_NO_REGROUP,
+  SKILL_SUBTRACT_WITHIN_TEN,
+} from "./domains/add.ts";
+import { cmp, toString as ratToString } from "../math/rational.ts";
+import type { SkillId } from "../types/ids.ts";
+
+const ORDERING_KINDS = ["requires", "extends"];
+const ACTIVE = activeNodes(allNodes);
+const ACTIVE_IDS = new Set<string>(ACTIVE.map((node) => String(node.id)));
+
+/** Everything `id` transitively requires, within the active graph. */
+function ancestorsOf(id: SkillId): Set<string> {
+  const seen = new Set<string>();
+  const stack = [String(id)];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined) continue;
+    const node = ACTIVE.find((candidate) => String(candidate.id) === current);
+    for (const edge of node?.prereqs ?? []) {
+      if (!ORDERING_KINDS.includes(edge.kind)) continue;
+      if (seen.has(String(edge.to))) continue;
+      seen.add(String(edge.to));
+      stack.push(String(edge.to));
+    }
+  }
+  return seen;
+}
+
+test("the active graph has exactly one root, and it is the number facts", () => {
+  const roots = ACTIVE.filter(
+    (node) => !node.prereqs.some((edge) => ORDERING_KINDS.includes(edge.kind) && ACTIVE_IDS.has(String(edge.to))),
+  );
+  assert.deepEqual(
+    roots.map((node) => String(node.id)),
+    [String(SKILL_ADD_WITHIN_TEN)],
+    "the shipped graph does not have a single entry point",
+  );
+});
+
+test("every active skill climbs from the root, so nothing is stranded above the floor", () => {
+  for (const node of ACTIVE) {
+    if (String(node.id) === String(SKILL_ADD_WITHIN_TEN)) continue;
+    assert.ok(
+      ancestorsOf(node.id).has(String(SKILL_ADD_WITHIN_TEN)),
+      `${node.id} does not transitively require ${SKILL_ADD_WITHIN_TEN}: a child reaching it has no route down`,
+    );
+  }
+});
+
+test("the ladder's named rungs are wired the way the mathematics runs", () => {
+  const requires = (from: SkillId, to: SkillId): void => {
+    assert.ok(
+      ancestorsOf(from).has(String(to)),
+      `${from} should sit above ${to} and does not`,
+    );
+  };
+
+  // The column rows sit above the facts they are made of, and this is the whole
+  // point of the change: a carry is a sum across ten and a borrow is a difference
+  // across ten, so the multi-digit rows cannot be reached without the fact rows.
+  requires(SKILL_ADD_NO_REGROUP, SKILL_ADD_WITHIN_TEN);
+  requires(SKILL_SUBTRACT_NO_REGROUP, SKILL_SUBTRACT_WITHIN_TEN);
+  requires(SKILL_ADD_MULTIDIGIT, SKILL_ADD_ACROSS_TEN);
+  requires(SKILL_SUBTRACT_MULTIDIGIT, SKILL_SUBTRACT_ACROSS_TEN);
+  // And the two-digit rows are still above the facts they always needed.
+  requires(SKILL_ADD_MULTIDIGIT, SKILL_ADD_WITHIN_TEN);
+  requires(SKILL_SUBTRACT_MULTIDIGIT, SKILL_SUBTRACT_WITHIN_TEN);
+});
+
+test("activeNodes() is already in prerequisite order, which is the order games walk", () => {
+  // A game reads the list the host hands it and does not topologically sort. A row
+  // appearing before its own prerequisite would reorder difficulty everywhere at
+  // once, silently, for every pack — so the order is asserted rather than assumed.
+  const position = new Map<string, number>(ACTIVE.map((node, index) => [String(node.id), index]));
+  ACTIVE.forEach((node, index) => {
+    for (const edge of node.prereqs) {
+      if (!ORDERING_KINDS.includes(edge.kind)) continue;
+      const at = position.get(String(edge.to));
+      if (at === undefined) continue;
+      assert.ok(
+        at < index,
+        `${node.id} is at ${String(index)} and its prerequisite ${edge.to} is at ${String(at)}`,
+      );
+    }
+  });
+});
+
+test("the bottom rung is a number fact, and it is well below the column work", () => {
+  const levels = ACTIVE.flatMap((node) => node.difficulty.levels.map((b) => ({ node, b })));
+  const easiest = levels.reduce((low, current) => (cmp(current.b, low.b) < 0 ? current : low));
+  assert.equal(
+    String(easiest.node.id),
+    String(SKILL_ADD_WITHIN_TEN),
+    `the easiest active item belongs to ${easiest.node.id} at ${ratToString(easiest.b)}`,
+  );
+  assert.equal(ratToString(easiest.b), "-3", "the root rung is not where the level table puts it");
+
+  // Every fact item is below every column item, with no overlap. The two families
+  // are a ladder and not two ladders side by side.
+  const factLevels = ACTIVE.filter((node) => node.cluster === "facts").flatMap((node) => node.difficulty.levels);
+  const columnLevels = ACTIVE.filter((node) => node.cluster !== "facts").flatMap((node) => node.difficulty.levels);
+  assert.ok(factLevels.length >= 14 && columnLevels.length >= 13);
+  const hardestFact = factLevels.reduce((high, current) => (cmp(current, high) > 0 ? current : high));
+  const easiestColumn = columnLevels.reduce((low, current) => (cmp(current, low) < 0 ? current : low));
+  assert.ok(
+    cmp(hardestFact, easiestColumn) < 0,
+    `the hardest fact item ${ratToString(hardestFact)} is not below the easiest column item ${ratToString(easiestColumn)}`,
+  );
+});
+
+test("the fact rows are active, because a draft floor is not a floor", () => {
+  for (const id of [
+    SKILL_ADD_WITHIN_TEN,
+    SKILL_SUBTRACT_WITHIN_TEN,
+    SKILL_ADD_ACROSS_TEN,
+    SKILL_SUBTRACT_ACROSS_TEN,
+  ]) {
+    const node = allNodes.find((candidate) => candidate.id === id);
+    assert.ok(node !== undefined, `${id} is missing from the graph`);
+    assert.equal(node.status, "active", `${id} is ${node.status}: a controller walking activeNodes() cannot reach it`);
+  }
+});

--- a/dynawalla/packs/shared/curriculum/src/index.ts
+++ b/dynawalla/packs/shared/curriculum/src/index.ts
@@ -49,6 +49,19 @@ export type { LongDivParams } from "./generators/longDiv/params.ts";
 export { missingOperandFamily } from "./generators/missingOperand/family.ts";
 export { missingOperandParamSchema } from "./generators/missingOperand/params.ts";
 export type { MissingOperandParams } from "./generators/missingOperand/params.ts";
+export { numberFactsFamily } from "./generators/numberFacts/family.ts";
+export { numberFactsParamSchema } from "./generators/numberFacts/params.ts";
+export type { NumberFactsParams } from "./generators/numberFacts/params.ts";
+export { factSet, factSetSize } from "./generators/numberFacts/facts.ts";
+export type { Fact } from "./generators/numberFacts/facts.ts";
+// Named rather than `export *`: `gen.arith.column-op` already exports its whole
+// constants module here, and both families have a `PROMPT_KEY_ADD`.
+export {
+  NUMBER_FACTS_FAMILY,
+  NUMBER_FACTS_FAMILY_REV,
+  NUMBER_FACTS_FORMS,
+  NUMBER_FACTS_LOC_KEYS,
+} from "./generators/numberFacts/constants.ts";
 export { multidigitMulFamily } from "./generators/multidigitMul/family.ts";
 export { multidigitMulParamSchema } from "./generators/multidigitMul/params.ts";
 export type { MultidigitMulParams } from "./generators/multidigitMul/params.ts";
@@ -102,7 +115,9 @@ export {
   REP_BALANCE_SCALE,
   REP_GEAR_TRAIN,
   REP_NUMBER_LINE,
+  REP_TEN_FRAME,
   REQUIRED_REP_PARAMS,
+  TEN_FRAME_CAPACITIES,
   V1_REPRESENTATIONS,
 } from "./render/representations.ts";
 

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.ts
@@ -51,6 +51,7 @@ export type PromptTemplateDeclaration = {
   readonly testRef?: string;
 };
 
+const NUMBER_FACTS = familyId("gen.arith.number-facts");
 const COLUMN_OP = familyId("gen.arith.column-op");
 const PLACE_VALUE = familyId("gen.number.place-value-decompose");
 const COMPARE_ORDER = familyId("gen.number.compare-order");
@@ -77,6 +78,11 @@ const MISSING_OPERAND = familyId("gen.arith.missing-operand");
  * promote.
  */
 export const promptRegistry: readonly PromptTemplateDeclaration[] = [
+  // The bottom of the ladder. Two numbers and an operator, which is the smallest
+  // question this program can ask and the first one a five-year-old sees.
+  { id: locKey("dw.prompt.number-facts.add"), family: NUMBER_FACTS, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.number-facts.sub"), family: NUMBER_FACTS, owner: "PR-2.13", implemented: false },
+
   { id: locKey("dw.prompt.column-op.sub"), family: COLUMN_OP, owner: "PR-2.13", implemented: false },
   { id: locKey("dw.prompt.column-op.add"), family: COLUMN_OP, owner: "PR-2.13", implemented: false },
 

--- a/dynawalla/packs/shared/curriculum/src/render/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/registry.ts
@@ -66,6 +66,11 @@ export const rendererRegistry: readonly RendererDeclaration[] = [
   { id: "answer:fraction", kind: "answerSchema", owner: PACK, implemented: false },
   { id: "answer:choice", kind: "answerSchema", owner: PACK, implemented: false },
   { id: "rep:counting-board", kind: "representation", owner: PACK, implemented: false },
+  // The quantity picture for the bottom of the ladder. Declared and not built, on
+  // the same terms as everything else here: the rows that emit it list it as
+  // `optional`, because a row that declared it `required` today would be a
+  // curriculum row the app cannot draw, which is the failure CG-8 exists to stop.
+  { id: "rep:ten-frame", kind: "representation", owner: PACK, implemented: false },
   { id: "rep:number-line", kind: "representation", owner: PACK, implemented: false },
   { id: "rep:balance-scale", kind: "representation", owner: PACK, implemented: false },
   // Declared, not built, and for a second reason on top of the one above: the

--- a/dynawalla/packs/shared/curriculum/src/render/representations.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/representations.test.ts
@@ -92,6 +92,26 @@ test("a spec that cannot be drawn is rejected before anything draws it", () => {
   assert.match(String(drifted), /not a safe integer/);
 });
 
+test("a ten-frame that cannot be drawn is rejected, one reason each", () => {
+  const frame = (params: Record<string, number>): string | null => repSpecDefect("ten-frame", params);
+
+  // The two shapes the number-facts family emits, both drawable.
+  assert.equal(frame({ capacity: 10, first: 2, second: 3, removed: 0 }), null);
+  assert.equal(frame({ capacity: 10, first: 8, second: 0, removed: 3 }), null);
+  // The identity facts at the very bottom of the ladder.
+  assert.equal(frame({ capacity: 10, first: 0, second: 1, removed: 0 }), null);
+  assert.equal(frame({ capacity: 10, first: 1, second: 0, removed: 1 }), null);
+
+  assert.match(String(frame({ capacity: 7, first: 1, second: 1, removed: 0 })), /capacity must be one of/);
+  assert.match(String(frame({ capacity: 10, first: 6, second: 6, removed: 0 })), /more counters than it has cells/);
+  assert.match(String(frame({ capacity: 10, first: 3, second: 0, removed: 4 })), /more counters than it holds/);
+  assert.match(String(frame({ capacity: 10, first: -1, second: 2, removed: 0 })), /cannot be negative/);
+  // Two stories on one frame: the child cannot tell which of them the answer is.
+  assert.match(String(frame({ capacity: 10, first: 4, second: 2, removed: 1 })), /groups and takes away/);
+  // `0 + 0` drawn is an empty frame, which is a picture of the question missing.
+  assert.match(String(frame({ capacity: 10, first: 0, second: 0, removed: 0 })), /is empty/);
+});
+
 test("every V1 representation declares what it requires", () => {
   for (const rep of V1_REPRESENTATIONS) {
     // The gear train is declared and unbuilt, and has no params table yet; the

--- a/dynawalla/packs/shared/curriculum/src/render/representations.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/representations.ts
@@ -31,12 +31,29 @@ export const REP_NUMBER_LINE: RepId = "number-line";
 export const REP_BALANCE_SCALE: RepId = "balance-scale";
 /** Multiples, factors, LCM. Not built — see the renderer registry. */
 export const REP_GEAR_TRAIN: RepId = "gear-train";
+/**
+ * Cardinality. A frame of cells with counters in it, for the bottom of the ladder.
+ *
+ * The fifth representation, and the one CURRICULUM.md's four do not cover. The
+ * other four all answer a question about a number a child can already read: where
+ * it sits, what it is worth, what it balances. A five-year-old at `0 + 1` cannot
+ * yet read `1` fluently as a symbol, so the question has to be a quantity before
+ * it is a numeral, and none of the four draws a quantity.
+ *
+ * It is added rather than borrowed because the near miss is worse than a gap: the
+ * counting board is a **place-value** board, columns of units and tens, drawn to
+ * show what regrouping moves. Handing it `2 + 3` would draw two rows of a
+ * place-value structure that the item is not about, on the screen of the child
+ * least able to tell the difference.
+ */
+export const REP_TEN_FRAME: RepId = "ten-frame";
 
 export const V1_REPRESENTATIONS: readonly RepId[] = [
   REP_COUNTING_BOARD,
   REP_NUMBER_LINE,
   REP_BALANCE_SCALE,
   REP_GEAR_TRAIN,
+  REP_TEN_FRAME,
 ];
 
 /**
@@ -73,7 +90,16 @@ export const REQUIRED_REP_PARAMS: Readonly<Record<string, readonly string[]>> = 
   [REP_NUMBER_LINE]: ["from", "to", "denominator", "mark"],
   [REP_BALANCE_SCALE]: ["left", "right"],
   [REP_COUNTING_BOARD]: [],
+  [REP_TEN_FRAME]: ["capacity", "first", "second", "removed"],
 };
+
+/**
+ * Frames a child can read at a glance. Five for the earliest counting, ten for
+ * the standard frame, twenty for a double one. Not an arbitrary bound: a frame
+ * of seven has no structure to subitise against, which is the only thing a frame
+ * is for.
+ */
+export const TEN_FRAME_CAPACITIES: readonly number[] = [5, 10, 20];
 
 /** Why this spec cannot be drawn, or `null`. */
 export function repSpecDefect(rep: RepId, params: Readonly<Record<string, number>>): string | null {
@@ -103,6 +129,26 @@ export function repSpecDefect(rep: RepId, params: Readonly<Record<string, number
     const left = params["left"] ?? 0;
     const right = params["right"] ?? 0;
     if (left < 0 || right < 0) return "balance-scale pans cannot hold a negative amount";
+  }
+
+  if (rep === REP_TEN_FRAME) {
+    const capacity = params["capacity"] ?? 0;
+    const first = params["first"] ?? 0;
+    const second = params["second"] ?? 0;
+    const removed = params["removed"] ?? 0;
+    if (!TEN_FRAME_CAPACITIES.includes(capacity)) {
+      return `ten-frame capacity must be one of ${TEN_FRAME_CAPACITIES.join(", ")}`;
+    }
+    if (first < 0 || second < 0 || removed < 0) return "ten-frame counts cannot be negative";
+    if (first + second > capacity) return "ten-frame holds more counters than it has cells";
+    if (removed > first) return "ten-frame takes away more counters than it holds";
+    // A frame that both groups and crosses out is telling two stories at once, and
+    // the child has to decide which of them the answer is. `a + b` puts `b` in the
+    // second group; `m − s` crosses `s` out of the first. Never both.
+    if (second > 0 && removed > 0) return "ten-frame groups and takes away in the same picture";
+    // The counters that are left *are* the answer to a subtraction, so a picture
+    // that shows nothing at all is a picture of the whole question missing.
+    if (first + second === 0) return "ten-frame is empty";
   }
 
   return null;

--- a/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
+++ b/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
@@ -22,6 +22,20 @@
     "gen.arith.column-op@1|dw.add.regroup.add-short-addend|L2": "a7cb31b4352648b9",
     "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L0": "a365f4bf15426994",
     "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L1": "22835dd4f74725c5",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L2": "2ab4671d595a2162"
+    "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L2": "2ab4671d595a2162",
+    "gen.arith.number-facts@1|dw.add.facts.add-within-ten|L0": "66c3e6fdbfc565cf",
+    "gen.arith.number-facts@1|dw.add.facts.add-within-ten|L1": "857802faa99256e9",
+    "gen.arith.number-facts@1|dw.add.facts.add-within-ten|L2": "758ee340d60c895d",
+    "gen.arith.number-facts@1|dw.add.facts.add-within-ten|L3": "45f72e71d0aafb43",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-within-ten|L0": "a8da1d56bd080721",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-within-ten|L1": "60fd75fe220bd5b1",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-within-ten|L2": "7588473f494279a3",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-within-ten|L3": "3b8124684d636bd4",
+    "gen.arith.number-facts@1|dw.add.facts.add-across-ten|L0": "31ccf9ba5644983f",
+    "gen.arith.number-facts@1|dw.add.facts.add-across-ten|L1": "f410d4d8d0c1ab55",
+    "gen.arith.number-facts@1|dw.add.facts.add-across-ten|L2": "22c83a1f9c11e00f",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-across-ten|L0": "c133c17ac508e920",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-across-ten|L1": "a7ddbe5c832cdc22",
+    "gen.arith.number-facts@1|dw.add.facts.subtract-across-ten|L2": "60ab69ff4979cea7"
   }
 }

--- a/dynawalla/packs/shared/curriculum/src/types/skill.ts
+++ b/dynawalla/packs/shared/curriculum/src/types/skill.ts
@@ -60,6 +60,30 @@ export type GeneratorBinding = {
   readonly params: readonly unknown[];
   readonly forms: readonly FormId[];
   readonly minVariants: number;
+  /**
+   * How many problems the level has **in the world**, one entry per level.
+   *
+   * Declared only where the answer is a small finite number that no generator
+   * work can change: there are thirty-six additions within ten, and there is no
+   * thirty-seventh. CG-10's variant-space floor of 975 is derived from a model of
+   * generators that do *not* close — it asks whether a 40-item practice run would
+   * repeat itself, and treats a repeat as evidence of a shallow draw. On a closed
+   * fact set the repeat is not evidence of anything: it is retrieval practice,
+   * which is the entire pedagogy of a fluency row, and a floor of 975 would
+   * forbid teaching number facts at all.
+   *
+   * So this replaces the floor for the levels that declare it, and it is not a
+   * waiver. CG-10 checks the *measured* distinct count against the declared size,
+   * so a generator that can reach a thirty-seventh addition within ten fails the
+   * gate — which is the claim the row is really making, and the one worth
+   * checking. CG-7 checks that a level does not declare `minVariants` above its
+   * own set, and `numberFacts.test.ts` pins the sizes from the other side by
+   * enumerating the sets and asserting the generator reaches every member.
+   *
+   * Omitted means the ordinary floor applies. A level that could be widened and
+   * simply has not been must never carry this field.
+   */
+  readonly closedFactSet?: readonly number[];
   /** Capabilities the generated items assume the child already has (gate CG-6). */
   readonly consumes: readonly CapabilityTag[];
 };

--- a/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
@@ -418,6 +418,52 @@ test("CG-10: a level whose variant space is too small fails", () => {
   assert.equal(cg10(healthy, buildSamples(healthy)).status, "pass");
 });
 
+/**
+ * The closed-fact-set branch, from both sides.
+ *
+ * `closedFactSet` replaces CG-10's floor for the levels that declare it, and a
+ * substitution that only ever loosened a gate would be a waiver with a comment on
+ * it. The claim it substitutes is sharper than the floor and this is what checks
+ * it: a level that says "there are nine additions within three" and whose
+ * generator reaches a tenth is a row lying about its own mathematics, and the
+ * floor could never have detected that.
+ */
+test("CG-10: a closed fact set the generator overruns fails", () => {
+  const ADD_WITHIN_TEN = skillId("dw.add.facts.add-within-ten");
+  const understated = replace(ADD_WITHIN_TEN, {
+    generator: {
+      ...node(ADD_WITHIN_TEN).generator,
+      // The level really has nine facts. Claiming four is the shape of a row whose
+      // generator was widened and whose declaration was not.
+      closedFactSet: [4, 20, 65, 45],
+      minVariants: 4,
+    },
+  });
+  const broken = context({ nodes: understated, seedsPerLevel: 200 });
+  assertFails(cg10(broken, buildSamples(broken)), "above the declared closed fact set");
+
+  // And the substitution is doing work: without the declaration, a nine-item level
+  // is far under the 975 floor and the gate fails for the other reason.
+  const { closedFactSet: _dropped, ...withoutDeclaration } = node(ADD_WITHIN_TEN).generator;
+  const undeclared = replace(ADD_WITHIN_TEN, { generator: withoutDeclaration });
+  const floored = context({ nodes: undeclared, seedsPerLevel: 200 });
+  assertFails(cg10(floored, buildSamples(floored)), "below the floor");
+});
+
+test("CG-7: a closed-fact-set declaration that does not line up with the levels fails", () => {
+  const ADD_WITHIN_TEN = skillId("dw.add.facts.add-within-ten");
+  const short = replace(ADD_WITHIN_TEN, {
+    generator: { ...node(ADD_WITHIN_TEN).generator, closedFactSet: [9, 20] },
+  });
+  assertFails(cg7(context({ nodes: short })), "closedFactSet has 2 entries for 4 level(s)");
+
+  // A row cannot require more distinct items than the mathematics contains.
+  const impossible = replace(ADD_WITHIN_TEN, {
+    generator: { ...node(ADD_WITHIN_TEN).generator, minVariants: 30 },
+  });
+  assertFails(cg7(context({ nodes: impossible })), "closed fact set of 9 but minVariants 30");
+});
+
 test("CG-11: a checker that accepts a distractor fails", () => {
   const healthy = context();
   const samples = buildSamples(healthy);

--- a/dynawalla/packs/shared/curriculum/src/validate/gates/bindingGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates/bindingGates.ts
@@ -58,6 +58,36 @@ export function cg7(context: ValidationContext): GateResult {
     if (binding.minVariants <= 0) {
       findings.push(fail("CG-7", "minVariants must be positive", node.id));
     }
+    if (binding.closedFactSet !== undefined) {
+      // The declaration is per level, like `params` and `difficulty.levels`, and a
+      // length mismatch would silently leave the last levels on the ordinary floor
+      // while the row reads as though they were exempt.
+      if (binding.closedFactSet.length !== binding.params.length) {
+        findings.push(
+          fail(
+            "CG-7",
+            `closedFactSet has ${String(binding.closedFactSet.length)} entries for ${String(binding.params.length)} level(s)`,
+            node.id,
+          ),
+        );
+      }
+      binding.closedFactSet.forEach((size, level) => {
+        if (!Number.isSafeInteger(size) || size <= 0) {
+          findings.push(fail("CG-7", `L${String(level)} closedFactSet size must be a positive integer`, node.id));
+          return;
+        }
+        // A row cannot require more distinct items than the mathematics contains.
+        if (size < binding.minVariants) {
+          findings.push(
+            fail(
+              "CG-7",
+              `L${String(level)} declares a closed fact set of ${String(size)} but minVariants ${String(binding.minVariants)}`,
+              node.id,
+            ),
+          );
+        }
+      });
+    }
     if (node.difficulty.levels.length !== binding.params.length) {
       findings.push(
         fail(

--- a/dynawalla/packs/shared/curriculum/src/validate/gates/generatorGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates/generatorGates.ts
@@ -128,7 +128,17 @@ export function cg9(context: ValidationContext, samples: readonly LevelSample[])
   return resultOf("CG-9", "level coverage and difficulty table", findings, notes);
 }
 
-/** CG-10 — variant-space adequacy. See `VARIANT_SPACE_FLOOR`. */
+/**
+ * CG-10 — variant-space adequacy. See `VARIANT_SPACE_FLOOR`.
+ *
+ * A level that declares `closedFactSet` is measured against its own declaration
+ * instead of against the floor. The reasoning is on `GeneratorBinding`: the floor
+ * asks whether a practice run would repeat itself and reads a repeat as evidence
+ * of a shallow generator, and on a closed set of thirty-six additions within ten
+ * the repeat is the pedagogy. The substituted check is not weaker — it fails when
+ * the generator reaches a problem the declared set does not contain, which the
+ * floor could never have seen.
+ */
 export function cg10(_context: ValidationContext, samples: readonly LevelSample[]): GateResult {
   const findings: Finding[] = [];
   const notes: string[] = [];
@@ -139,6 +149,23 @@ export function cg10(_context: ValidationContext, samples: readonly LevelSample[
     if (draws === 0) continue;
     const distinct = new Set(sample.exercises.map(fingerprintItem)).size;
     const collisions = draws - distinct;
+
+    const declared = sample.node.generator.closedFactSet?.[sample.level];
+    if (declared !== undefined) {
+      if (distinct > declared) {
+        findings.push(
+          fail(
+            "CG-10",
+            `${String(distinct)} distinct items in ${String(draws)} draws, above the declared closed fact set of ${String(declared)}: the generator reaches problems the row says do not exist`,
+            sampleLabel(sample),
+          ),
+        );
+      }
+      notes.push(
+        `${sampleLabel(sample)}: ${String(distinct)}/${String(declared)} of a closed fact set, in ${String(draws)} draws`,
+      );
+      continue;
+    }
     // N^2 / 2C, integer, with C=0 meaning "no evidence of any bound below N^2/2".
     const estimate = collisions === 0 ? Math.floor((draws * draws) / 2) : Math.floor((draws * draws) / (2 * collisions));
 


### PR DESCRIPTION
The active curriculum was seven skills, all in `add`, and the easiest of them —
`SKILL_ADD_NO_REGROUP` — had `plus(2, 2, 0)` as its first level. The product
could not generate `3 + 5`. There was no first grade in the graph and no
kindergarten at all, so a five-year-old met second-grade column arithmetic on
the first card, and a second grader who slid down after struggling landed on
`43 + 25` and could go no further down.

Every gate passed on that graph. It was perfectly valid; it had no floor.

## Could the existing family already do it?

**Yes for the sums, no for the subtractions, and no for the pedagogy.** Probed
by calling `columnOpFamily.generate()` directly with `digits: 1`, bypassing the
validator:

```
add 1x1 r0   SCHEMA-REJECT digits: digits must be 2..6
   8 + 1 = 9  |  1 + 1 = 2  |  6 + 2 = 8  |  2 + 5 = 7  |  3 + 3 = 6
add 1x1 r1   SCHEMA-REJECT digits: digits must be 2..6
   2 + 9 = 11  |  7 + 9 = 16  |  6 + 8 = 14  |  2 + 8 = 10  |  8 + 8 = 16
sub 1x1 r0   SCHEMA-REJECT digits: digits must be 2..6
   5 - 3 = 2  |  3 - 1 = 2  |  6 - 5 = 1  |  9 - 7 = 2  |  5 - 2 = 3
sub 2x1 r1   SCHEMA-OK
   71 - 5 = 66  |  76 - 8 = 68  |  65 - 8 = 57  |  94 - 6 = 88
```

The digit-wise procedure, the regrouping trace and the exact-arithmetic
cross-check all work at one column. `MIN_DIGITS = 2` is the only thing in the
way, and it is one constant. So the sums were cheap.

The subtractions are not reachable at any parameter setting. A fact is bounded
by a **value** — "within twenty, crossing ten" — and a column is bounded by a
**width**. The nearest thing the column family can say is `sub(2, 1, 1)`, and
that is `94 - 6` as readily as `15 - 8`: see the fourth block above. The first
grade subtraction milestone is outside that parameter space and no smaller
number brings it in.

And the pedagogy does not survive the move either. Run at one column, the column
family's walkthrough reads as a procedure with one step, and all three of its
mal-rules have `applies() === false` on every item. That is not how a child gets
`3 + 5`.

So: **a sibling family, `gen.arith.number-facts`**, and `dw.add.facts.*` sits
under `dw.add.column.*` rather than beside it.

## The rows, and why each one

| id | levels | b | why this row exists |
|---|---|---|---|
| `dw.add.facts.add-within-ten` | 4 | −3.00 … −2.20 | The root. Level 0 is the trivial set. No prerequisites: the entry point at any age. |
| `dw.add.facts.subtract-within-ten` | 4 | −2.85 … −2.05 | A child fluent in the sums is routinely not fluent in the differences; one mastery record for both would report a fluency in the direction that is failing. |
| `dw.add.facts.add-across-ten` | 3 | −1.60 … −1.30 | Crossing ten is the discontinuity of first-grade arithmetic and the thing a carry is made of. |
| `dw.add.facts.subtract-across-ten` | 3 | −1.55 … −1.25 | `15 − 8`. Unreachable from the column family at any parameter setting; the thing a borrow is made of. |

**Two rows considered and cut**, named in the source so nobody re-proposes them.
*Doubles* — nine facts in the world, five of them crossing ten; what doubles are
for is anchoring their neighbours, which is a hint inside a row that already
holds both facts, not a row. *Make-ten* — as a result-unknown question `7 + 3` is
already an `add-within-ten` item; the question that makes it a strategy is
`7 + ☐ = 10`, which is a different family and already has an id
(`dw.alg.equality.missing-addend`, still draft).

**Nothing else was padded.** The `ns` counting/subitising rows the floor
arguably wants are *not* here, and the reason is not effort: for a counting item
the picture **is** the question, and no representation renders in this
repository. A "how many?" card today would draw an answer entry with nothing
above it. That is the exact CG-8 failure the repo keeps warning about, so it is
an honest gap rather than a bad row. It unblocks the day a pack lands a
`rep:ten-frame` renderer.

## Real generated output

At the graph's own parameters, first eight seeds, `[frame first/second/removed]`
is the ten-frame spec:

```
dw.add.facts.add-within-ten
L0  set=9 declared=9 reached=9  b=-3
    0 + 2 = 2 [frame 0/2/0] | 1 + 2 = 3 [frame 1/2/0] | 3 + 0 = 3 [frame 3/0/0] | 0 + 1 = 1 [frame 0/1/0]
    0 + 3 = 3 [frame 0/3/0] | 1 + 0 = 1 [frame 1/0/0] | 2 + 0 = 2 [frame 2/0/0] | 1 + 2 = 3 [frame 1/2/0]
L1  set=20 declared=20 reached=20  b=-2.90
    1 + 2 = 3 | 3 + 1 = 4 | 4 + 1 = 5 | 4 + 1 = 5 | 4 + 1 = 5 | 2 + 2 = 4 | 0 + 3 = 3 | 0 + 4 = 4
L3  set=45 declared=45 reached=45  b=-2.20
    4 + 1 = 5 | 6 + 4 = 10 | 3 + 3 = 6 | 5 + 2 = 7 | 3 + 6 = 9 | 5 + 3 = 8 | 5 + 3 = 8 | 8 + 1 = 9

dw.add.facts.subtract-within-ten
L0  set=9 declared=9 reached=9  b=-2.85
    2 − 2 = 0 [frame 2/0/2] | 3 − 1 = 2 [frame 3/0/1] | 3 − 0 = 3 [frame 3/0/0] | 1 − 0 = 1 [frame 1/0/0]
L2  set=65 declared=65 reached=65  b=-2.50
    7 − 1 = 6 | 10 − 5 = 5 | 8 − 3 = 5 | 8 − 1 = 7 | 6 − 1 = 5 | 6 − 4 = 2 | 8 − 6 = 2 | 9 − 4 = 5

dw.add.facts.add-across-ten
L2  set=36 declared=36 reached=36  b=-1.30
    9 + 4 = 13 | 6 + 7 = 13 | 8 + 3 = 11 | 8 + 9 = 17 | 8 + 5 = 13 | 9 + 9 = 18 | 7 + 9 = 16 | 5 + 7 = 12

dw.add.facts.subtract-across-ten
L2  set=36 declared=36 reached=36  b=-1.25
    11 − 4 = 7 | 14 − 6 = 8 | 12 − 7 = 5 | 12 − 3 = 9 | 11 − 9 = 2 | 15 − 6 = 9 | 12 − 9 = 3 | 15 − 6 = 9
```

`0 + 1`, `1 + 0`, `3 + 0`, `2 − 2`, `3 − 0`, `2 + 3` — the trivial cases are in
level 0's set unhedged, and nothing at the bottom was made harder to look more
respectable. The one draw excluded is **both operands zero**: an empty frame
added to an empty frame is not a question a child can be asked.

The draw is uniform over the set, measured rather than assumed — 20,000 seeds,
chi-square 5.5 on df 8 for the nine-fact level, 29.9 on df 44 for the
forty-five-fact level, consecutive-repeat rate at the expected 1/n.

## Difficulty, and the one honest gap

Sorted, the fourteen new levels run

```
-3.00 -2.90 -2.85 -2.75 -2.65 -2.50 -2.20 -2.05 | -1.60 -1.55 -1.50 -1.45 -1.30 -1.25 | -0.90
```

with `-0.90` the previous floor (`43 + 25`). Every step is 0.05–0.30 except one:
**0.45, between −2.05 and −1.60**, where the ladder leaves ten behind. That step
is produced by reusing column-op's regrouping coefficient (0.55) unchanged for
`crossesTen`, on the argument that crossing ten and regrouping are one
phenomenon measured twice. A row invented to sit in it would be a row with no
mathematics of its own.

The other coefficients spend CURRICULUM.md's documented slots and each
substitution is stated in `numberFacts/constants.ts`: 0.05 per unit of range
(the `noAnchor` slot), −0.35 for the quantity picture (`specialCase`, at its
documented size), and a new 0.15 for subtraction, which the sketch has no slot
for and which a family that scored `5 − 2` and `2 + 3` identically would need.

## Grade is still only a label

The new rows carry `gradeBand.nominal` 0 and 1. Moving any of them is a
one-line diff with no effect on ids, scheduling or mastery — the ordering is the
prerequisite graph, and the graph is now wired so that CG-6 enforces it
mechanically:

- `cap.arith.sums-within-ten` — every column of a no-regroup addition is one
- `cap.arith.differences-within-ten` — likewise for subtraction
- `cap.arith.sums-across-ten` — a carry happens *exactly* when a column sum crosses ten
- `cap.arith.differences-across-ten` — a borrow happens *exactly* when a difference does

`dw.add.column.*` and `dw.add.regroup.*` gain a `rev` and a prerequisite each.
**No id moved, no id was reused, no live skill changed what it teaches.**

`activeNodes()` was checked rather than assumed: the fact rows are first in
`addDomainNodes`, and the resulting order is already topological, which
`ladder.test.ts` now asserts — a game reads the list and does not sort it, so a
row appearing before its own prerequisite would reorder difficulty everywhere at
once, silently, for every pack.

## CG-10 had to be reconciled, not routed around

Every one of these levels is under CG-10's variant-space floor of 975, by a
factor of twenty. The floor asks whether a 40-item practice run would repeat
itself and reads a repeat as evidence of a shallow generator. There are
thirty-six additions within ten and there is no thirty-seventh: on a fluency row
the repeat is the pedagogy, and the floor as written forbids teaching number
facts at all. `promotionBlockers.ts` says a promotion PR has to reconcile this
with whoever owns CG-10. This is that PR.

`GeneratorBinding.closedFactSet` declares the size per level and CG-10 measures
against it instead. The substituted check is **sharper** than the floor, not a
waiver: it fails when the generator reaches a problem the row says does not
exist, which the floor could never have detected. CG-7 gained two checks that
the declaration lines up with the level table and does not undercut
`minVariants`, and `numberFacts.test.ts` pins the sizes from the other side by
enumerating each level's set from the level's *stated rules* — not by calling
`factSet` — and asserting the generator reaches every member and nothing else.

## Representations

Reported rather than assumed, because the coordinator asked. **No renderer
exists for any representation in this repository**, and no module draws a
curriculum item at all (ADR-0022). `REP_COUNTING_BOARD` is a *place-value* board
— columns of units and tens sockets, built to show what regrouping moves — so
handing it `2 + 3` would draw a structure the item is not about, on the screen
of the child least able to tell the difference.

So `rep:ten-frame` is added: `{ capacity, first, second, removed }`, validated by
`repSpecDefect` (capacity 5/10/20; counters fit; never groups *and* crosses out
in the same picture; never empty). Addition puts the second addend in a second
group; subtraction holds the **whole** with the part crossed out, because
drawing `first − second` counters beside `second` would put the answer on the
screen — there is a test for exactly that.

Cost: one `RepId`, one `REQUIRED_REP_PARAMS` entry, five defect rules, one
registry declaration, ten test cases. It is `implemented: false` with an owner,
like all four existing ones, and the rows list it **optional** — a `required`
representation with no renderer is the curriculum row CG-8 exists to stop, and
the existing rows already refuse to do that with the counting board.

## i18n cost: zero today

Checked, not assumed. **There is no translation catalogue for any `dw.*` locale
key anywhere in this repository**, and no CI job gates on i18n for dynawalla.
CG-19 is a *hygiene* gate: it checks emitted keys match `LOC_KEY_PATTERN` and
that no bare-string prompt appears in source. Both hold.

This adds **18 keys** (4 titles, 4 goals, 2 big ideas, 2 prompt templates, 6
solution rungs), joining roughly 200 the graph already carries with no catalogue
behind them. ADR-0007 fixes the launch locales at **five** — en, es, pt-BR, fr,
de — not fifty, so the eventual bill is 90 strings, payable when someone creates
the catalogue that does not yet exist. **Nothing was machine-translated and
nothing was shipped English-only into a gate.**

## Tests, and the removed-fix runs

`176 pass / 0 fail`, five consecutive runs. `npm run tsc`, `npm run check` and
`npm run check:full` all OK.

Each new guard was removed or inverted and the exact failure recorded:

| what was broken | test that went red | message |
|---|---|---|
| root level loses `includeZero` | closed-set + root | `the row declares a closed set of 9 and the mathematics has 3` / `the root level never draws 0+1` |
| `add-within-ten` demoted to draft | 3 ladder tests | `the shipped graph does not have a single entry point` |
| a fact prerequisite edge cut | 2 ladder tests | `dw.add.facts.subtract-within-ten does not transitively require dw.add.facts.add-within-ten: a child reaching it has no route down` |
| subtraction frame draws the answer | picture | `the quantity picture is drawable, and never shows the answer` |
| bridge `toTen` off by one | walkthrough | `the walkthrough's strategy rung is the strategy` |
| count-on starts from the smaller addend | walkthrough | `counts on from the smaller addend` |
| `repSpecDefect` drops the groups-and-crosses-out rule | ten-frame | `The input did not match the regular expression /groups and takes away/` |
| `facts.ts` readmits `0 + 0` | 4 tests | `the root level draws an empty question` |
| CG-10 loses the closed-set branch | 2 gate tests | `expected CG-10 to mention "above the declared closed fact set", got: … is below the floor 975` |
| CG-7 loses the declaration checks | gate test | `expected CG-7 to fail, got warn` |
| property sweep loses its branch | sweep | `the levels under CG-10's floor and promotionBlockers.ts disagree` |

## What I could not verify

- **That any of this draws.** Nothing in the repo renders a curriculum item;
  CG-8 warns on all eleven active rows and `--strict-renderers` fails, exactly
  as before this change. The rows are active because `activeNodes()` is what an
  adaptive controller walks and a draft row is a rung that does not exist — a
  row nobody can draw is a warning, a floor that is not the floor is a child
  stuck.
- **`dynawalla/games/skyledger/pack.json`** lists seven `covers.skills` ids and
  does not list the four new ones. It is a game's own metadata, copied into the
  catalog by `packs/build.mjs` and validated by nothing, and `dynawalla/games/`
  has other work in flight, so I left it. Worth a one-line follow-up.
- **`minVariants` is weak on a closed set** — 9 and 12. It counts distinct items
  *in a sample*, so on a set of nine it can never assert more than nine, and the
  gate's smallest sample is 40 seeds. The real coverage assertion is
  `numberFacts.test.ts` at 4,000 seeds, which asserts *exact* set equality.
- **CG-10 catches a closed-set declaration that is understated by a lot, not by
  one.** Declaring 4 where there are 9 fails the gate; declaring 44 where there
  are 45 does not, because the 200-seed sample does not exceed 44. The exact
  declaration is held by `numberFacts.test.ts`, which compares it against an
  independently written enumeration.

## Note for whoever takes negatives and pre-algebra

Explicitly **not** in this PR. Two things in the graph that will matter:

- `gen.arith.number-facts` has no negative results by construction — the fact set
  enumerator refuses `difference < 0`, and `families.property.test.ts` asserts
  no answer anywhere in the graph is negative. Integers will need that assertion
  scoped to the families that claim non-negativity rather than to the whole
  sweep.
- `AnswerValue.integer` is a `Rational` and already carries sign; `answerToString`
  and `serialize.ts` round-trip it. The blocker is not the answer type. It is
  `answerDigits`/`schemaDefect`, which size a field in digits with no column for
  a sign, and `numberLinePoint`, which is the one place a negative is already
  handled correctly and is worth reading first.
