### PR TITLE
fix(dynawalla/games): escalate on right answers, and stop filing a timeout as a wrong answer

### DIFF
--- a/dynawalla/games/horde/src/game/curriculum.test.ts
+++ b/dynawalla/games/horde/src/game/curriculum.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Bots, not assertions about arithmetic.
+ *
+ * Every test here drives the real ledger the game drives — `openQuestion`,
+ * `answer`, `closeQuestion`, the sealed cache and the rift all go through
+ * `Curriculum` and nothing else in DEEPSWARM calls `host.next` or
+ * `host.report`. So a bot that plays badly here is a child playing badly there.
+ */
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Host, Question } from "../contract.ts"
+import { BASE_THINKING_SECONDS, Curriculum, MAX_DIFFICULTY } from "./curriculum.ts"
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+/** A host that remembers everything it was asked and everything it was told. */
+function recordingHost(): {
+  host: Host
+  asks: number[]
+  reports: Report[]
+} {
+  const asks: number[] = []
+  const reports: Report[] = []
+  let n = 0
+  const host: Host = {
+    next(opts) {
+      asks.push(opts?.difficulty ?? 0)
+      n++
+      return {
+        id: `q${n}`,
+        prompt: `${n} + 1`,
+        answer: String(n + 1),
+        distractors: [String(n), String(n + 2)],
+        domain: "add",
+        difficulty: 0.5,
+      } satisfies Question
+    },
+    report(r) {
+      reports.push(r)
+    },
+    haptic() {},
+    prefersReducedMotion() {
+      return false
+    },
+  }
+  return { host, asks, reports }
+}
+
+/**
+ * Eleven minutes of DEEPSWARM, roughly. A core opens every ~40 s, a sealed
+ * cache lands every third level-up, and a rift asks until it is charged — call
+ * it fifty questions in a long run.
+ */
+const LONG_RUN = 50
+
+test("a bot that answers everything WRONG never climbs past the first rung", () => {
+  const { host, asks } = recordingHost()
+  const c = new Curriculum()
+
+  for (let i = 0; i < LONG_RUN; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.distractors[0]!, false, 1400)
+  }
+
+  // Three-digit addition lives high on the host ladder. This bot must not be
+  // anywhere near it: it has demonstrated nothing.
+  assert.equal(c.difficulty(), 1, "a run with no right answers must stay on rung 1")
+  assert.deepEqual(
+    [...new Set(asks)],
+    [1],
+    "every question in a run with no right answers must be asked at rung 1",
+  )
+  assert.equal(c.solved, 0)
+  assert.equal(c.asked, LONG_RUN)
+})
+
+test("a bot that never answers at all never climbs either", () => {
+  const { host, asks } = recordingHost()
+  const c = new Curriculum()
+
+  for (let i = 0; i < LONG_RUN; i++) {
+    c.ask(host)
+    c.expired()
+  }
+
+  assert.equal(c.difficulty(), 1, "surviving is not an achievement")
+  assert.equal(Math.max(...asks), 1)
+  assert.equal(c.unanswered, LONG_RUN)
+})
+
+test("a bot that answers everything RIGHT climbs, and reaches the top", () => {
+  const { host, asks } = recordingHost()
+  const c = new Curriculum()
+
+  for (let i = 0; i < LONG_RUN; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.answer, true, 1400)
+  }
+
+  assert.equal(c.difficulty(), MAX_DIFFICULTY, "a run that is all right answers must top out")
+  assert.equal(asks[0], 1, "it still starts at the bottom")
+  assert.ok(
+    asks[asks.length - 1]! > asks[0]!,
+    "the ladder has to actually move for a child who is getting them right",
+  )
+})
+
+test("the ladder tracks right answers alone — the clock is not an input", () => {
+  const c = new Curriculum()
+  assert.equal(c.difficulty(), 1)
+  // Six right answers, at whatever pace: three rungs.
+  for (let i = 0; i < 6; i++) c.solved++
+  assert.equal(c.difficulty(), 4)
+  // Two hundred wrong answers and a hundred timeouts change nothing about it.
+  c.asked += 300
+  c.unanswered += 100
+  assert.equal(c.difficulty(), 4, "wrong answers and timeouts must not move the rung")
+})
+
+test("a timeout reports NOTHING to the host", () => {
+  const { host, reports } = recordingHost()
+  const c = new Curriculum()
+
+  const q = c.ask(host)
+  c.expired()
+
+  assert.deepEqual(
+    reports,
+    [],
+    "a child who was still computing has told the host nothing; the host must be told nothing",
+  )
+  // And in particular, not the old payload.
+  const filed: Report[] = reports
+  assert.equal(
+    filed.find((r) => r.questionId === q.id && r.answered === "" && !r.correct),
+    undefined,
+    "an empty answer marked incorrect is a wrong answer the child never gave",
+  )
+})
+
+test("an answer — right or wrong — reports the exact payload the host expects", () => {
+  const { host, reports } = recordingHost()
+  const c = new Curriculum()
+
+  const a = c.ask(host)
+  c.answered(host, a, a.answer, true, 1234.6)
+  const b = c.ask(host)
+  c.answered(host, b, b.distractors[0]!, false, 987.2)
+
+  assert.deepEqual(reports, [
+    { questionId: a.id, correct: true, ms: 1235, answered: a.answer },
+    { questionId: b.id, correct: false, ms: 987, answered: b.distractors[0]! },
+  ])
+})
+
+test("the thinking window grows with the ladder and never shrinks", () => {
+  const c = new Curriculum()
+  const easy = c.thinkingSeconds()
+  assert.equal(easy, BASE_THINKING_SECONDS)
+
+  let previous = easy
+  for (let i = 0; i < 40; i++) {
+    c.solved++
+    const now = c.thinkingSeconds()
+    assert.ok(now >= previous, `window shrank at ${c.solved} solved: ${previous} -> ${now}`)
+    previous = now
+  }
+
+  // At the top of the ladder the child has at least the p90 cadence target for
+  // two-digit-with-regrouping from EXPERIENCE_DESIGN.md.
+  assert.ok(previous >= 14, `top-rung window is ${previous}s, under the 14s p90`)
+})
+
+test("the rift asks below what the run has earned, never above", () => {
+  const c = new Curriculum()
+  for (let i = 0; i < 8; i++) c.solved++
+  assert.equal(c.difficulty(), 5)
+  assert.equal(c.difficulty(-1), 4)
+  // ...and it cannot fall off the bottom.
+  const fresh = new Curriculum()
+  assert.equal(fresh.difficulty(-1), 1)
+})

--- a/dynawalla/games/horde/src/game/curriculum.ts
+++ b/dynawalla/games/horde/src/game/curriculum.ts
@@ -1,0 +1,136 @@
+/**
+ * What the swarm is allowed to ask, and what the host is told about it.
+ *
+ * Every question in DEEPSWARM — the CORE orbs, the sealed CACHE at level-up, the
+ * RIFT you charge to come back — goes through here, and nothing else in the game
+ * calls `host.next` or `host.report`. That is the point of the file: the two
+ * decisions below were previously spread across three call sites and both of
+ * them were wrong in the same way.
+ *
+ * ── Escalation is on demonstrated success, never on survival ─────────────────
+ *
+ * The old rule was `1 + floor(runT / 88)`: one step harder every eighty-eight
+ * seconds of *being alive*. A child who missed every single orb still met
+ * three-digit addition at minute eleven, purely for not dying — and the counters
+ * that would have caught it (`correct`, `asked`) were already being kept and
+ * already being printed on the game-over panel. The signal existed and was
+ * ignored.
+ *
+ * So the ladder is climbed with right answers and nothing else. Two solved
+ * questions earn one step. A run that answers nothing correctly stays on step 1
+ * forever, however long it lasts, which is the whole fix: a child who is not
+ * getting them right is never handed harder arithmetic as a reward for
+ * surviving. This matches every well-paced game in the fleet — STACK on floors
+ * built, SIEGE on waves cleared, SERPENT on eats, SPLITBEAT on gate outcome —
+ * and `dynawalla/docs/EXPERIENCE_DESIGN.md`: *"Escalation is on difficulty and
+ * repair, never run length."*
+ *
+ * ── A non-answer is not a wrong answer ──────────────────────────────────────
+ *
+ * When the CORE closes on its own, the old code reported
+ * `{ correct: false, ms: 8500, answered: "" }`. The host does not keep the
+ * game's opinion of `correct` — it records the *response* — so an empty
+ * response was filed as an attempt the child got wrong. A child who knew the
+ * answer and was slow with their hands became, in the record, a child who does
+ * not know the skill.
+ *
+ * The `Host` contract this game mounts against
+ * (`dynawalla/packs/shared/game-host/index.ts`) offers exactly one way to say
+ * anything about a question: `report`, which forwards to `items.answer`. There
+ * is no "unanswered" flag on it, and `items.skip` — which the SDK does have —
+ * is not exposed on the game-facing `Host`. So the only truthful thing this
+ * game can do with a timeout is *say nothing*, and that is what `expired` does.
+ * An unreported item is simply an item the child was served and never answered,
+ * which is what happened.
+ *
+ * ── The thinking window grows with the arithmetic ───────────────────────────
+ *
+ * `COMPREHENSION — not budgeted. The child's time. Measured, never limited.`
+ * The CORE cannot literally be unlimited — it is a hole in a swarm, not a
+ * worksheet — but the window must at least not shrink as the sums get harder.
+ * It widens instead, and it is always at or above the p90 cadence target for
+ * the class of problem being asked (6 s single-digit, 14 s two-digit with
+ * regrouping).
+ */
+
+import type { Host, Question } from "../contract.ts"
+
+/** The host ladder this game asks against. */
+export const MIN_DIFFICULTY = 1
+export const MAX_DIFFICULTY = 10
+
+/** Right answers needed per step up the ladder. */
+export const SOLVES_PER_STEP = 2
+
+/** Seconds on the clock at step 1 — the p90 for a single-digit fact, plus room. */
+export const BASE_THINKING_SECONDS = 8.5
+
+/** Extra seconds granted for every step up the ladder. */
+export const THINKING_SECONDS_PER_STEP = 1.2
+
+const clamp = (v: number, lo: number, hi: number): number => (v < lo ? lo : v > hi ? hi : v)
+
+export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+/**
+ * The run's arithmetic ledger. One per run; `reset()` starts a new one.
+ *
+ * `asked` and `solved` are the numbers the game-over panel prints, so the panel
+ * and the ladder cannot disagree about what happened.
+ */
+export class Curriculum {
+  /** Questions served this run, answered or not. */
+  asked = 0
+  /** Questions answered correctly. The only thing that moves the ladder. */
+  solved = 0
+  /** Questions that closed with no answer at all. Never reported, never punished. */
+  unanswered = 0
+
+  reset(): void {
+    this.asked = 0
+    this.solved = 0
+    this.unanswered = 0
+  }
+
+  /**
+   * The step of the ladder this run has earned.
+   *
+   * `offset` is the one thing a surface may say about its own stakes — the RIFT
+   * asks a touch easier than the run has earned, because it is asked of a child
+   * who has just died. It never reads the clock.
+   */
+  difficulty(offset = 0): number {
+    const earned = 1 + Math.floor(this.solved / SOLVES_PER_STEP)
+    return clamp(earned + offset, MIN_DIFFICULTY, MAX_DIFFICULTY)
+  }
+
+  /** Seconds the CORE stays open. Grows with the ladder; never shrinks. */
+  thinkingSeconds(): number {
+    return BASE_THINKING_SECONDS + (this.difficulty() - 1) * THINKING_SECONDS_PER_STEP
+  }
+
+  /** Pull the next question at the difficulty this run has earned. */
+  ask(host: Host, offset = 0): Question {
+    this.asked++
+    return host.next({ difficulty: this.difficulty(offset) })
+  }
+
+  /**
+   * The child answered. This is the only path that reports, and the only path
+   * that moves the ladder.
+   */
+  answered(host: Host, q: Question, answered: string, correct: boolean, ms: number): void {
+    if (correct) this.solved++
+    host.report({ questionId: q.id, correct, ms: Math.max(0, Math.round(ms)), answered })
+  }
+
+  /**
+   * The question closed with no answer. Nothing is reported and nothing moves:
+   * a child who was still computing has not told the host anything about what
+   * they know, and inventing a wrong answer on their behalf is a lie the
+   * adaptive controller downstream would act on.
+   */
+  expired(): void {
+    this.unanswered++
+  }
+}

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -25,6 +25,7 @@ import {
   cooldown, makeBuild, realDamage, reach, rollCards, xpForLevel,
   type Build, type Card,
 } from "./loadout.ts"
+import { Curriculum } from "./curriculum.ts"
 import { Bullets, Enemies, Gems, Grid, Numbers, Particles, Shocks } from "./world.ts"
 import { Overlay } from "../ui/overlay.ts"
 
@@ -93,8 +94,12 @@ export class Game {
   private revives = 0
   private hurtCd = 0
   private levelUps = 0
-  private correct = 0
-  private asked = 0
+  /**
+   * Every question this run: which one to ask next, and what the host is told
+   * about it. Escalation lives in here and it reads right answers, not the
+   * clock — see curriculum.ts.
+   */
+  private curriculum = new Curriculum()
   private bestMs = 0
 
   private camX = 0
@@ -117,6 +122,7 @@ export class Game {
   private q: Question | null = null
   private orbs: Orb[] = []
   private qT = 0
+  private qTMax = 0
   private qStart = 0
   private qAnswered = false
 
@@ -327,8 +333,7 @@ export class Game {
     this.overcharge = 0
     this.revives = 0
     this.levelUps = 0
-    this.correct = 0
-    this.asked = 0
+    this.curriculum.reset()
     this.bestMs = 0
     this.spawnAcc = 0
     this.wardenAt = 42
@@ -1411,12 +1416,13 @@ export class Game {
   /* ------------------------------------------------------------ the core Q */
 
   private openQuestion(): void {
-    const difficulty = Math.max(1, Math.min(10, 1 + Math.floor(this.runT / 88)))
-    const q = this.host.next({ difficulty })
+    const q = this.curriculum.ask(this.host)
     this.q = q
-    this.asked++
     this.qAnswered = false
-    this.qT = 8.5
+    // The window widens with the arithmetic; it never narrows. Time here is
+    // measured, not budgeted.
+    this.qTMax = this.curriculum.thinkingSeconds()
+    this.qT = this.qTMax
     this.qStart = performance.now()
     this.mode = "core"
     this.timeScaleTarget = 0.15
@@ -1475,9 +1481,8 @@ export class Game {
     const ms = performance.now() - this.qStart
     if (!this.bestMs || ms < this.bestMs) this.bestMs = ms
     o.state = o.correct ? 1 : 2
-    this.host.report({ questionId: this.q.id, correct: o.correct, ms, answered: o.text })
-    if (o.correct) this.correct++
-    else for (const other of this.orbs) if (other.correct) other.state = 1
+    this.curriculum.answered(this.host, this.q, o.text, o.correct, ms)
+    if (!o.correct) for (const other of this.orbs) if (other.correct) other.state = 1
 
     if (o.correct) {
       this.audio.answerRight()
@@ -1523,7 +1528,10 @@ export class Game {
     if (!o) {
       this.ui.say("IT CLOSED", "", "#8fb6d8")
       this.audio.tick()
-      if (this.q) this.host.report({ questionId: this.q.id, correct: false, ms: 8500, answered: "" })
+      // Nothing is reported. The child did not answer, so there is no answer to
+      // file, and filing an empty one would record them as not knowing a skill
+      // they may simply have been slow to reach. See curriculum.ts.
+      if (this.q) this.curriculum.expired()
     }
     this.q = null
     this.orbs.length = 0
@@ -1549,9 +1557,7 @@ export class Game {
     this.cards = rollCards(this.build, this.rng, 3, this.runT / 60)
     this.sealedQ = null
     if (this.levelUps % 3 === 0) {
-      const difficulty = Math.max(1, Math.min(10, 1 + Math.floor(this.runT / 88)))
-      this.sealedQ = this.host.next({ difficulty })
-      this.asked++
+      this.sealedQ = this.curriculum.ask(this.host)
     }
     this.ui.showCards(this.cards, this.sealedQ, this.level)
   }
@@ -1573,9 +1579,8 @@ export class Game {
 
   private sealedAnswer(res: { correct: boolean; ms: number; answered: string }): void {
     if (!this.sealedQ) return
-    this.host.report({ questionId: this.sealedQ.id, correct: res.correct, ms: res.ms, answered: res.answered })
+    this.curriculum.answered(this.host, this.sealedQ, res.answered, res.correct, res.ms)
     if (res.correct) {
-      this.correct++
       this.audio.evolve()
       this.host.haptic("success")
       const reward = rollCards(this.build, this.rng, 1, this.runT / 60, true)[0]
@@ -1622,17 +1627,16 @@ export class Game {
   }
 
   private nextRiftQuestion(): void {
-    const difficulty = Math.max(1, Math.min(10, 1 + Math.floor(this.runT / 88)))
-    this.riftQ = this.host.next({ difficulty })
-    this.asked++
+    // A rift question is asked of a child who has just died, so it sits one
+    // step below what the run has earned. It is still earned, not clocked.
+    this.riftQ = this.curriculum.ask(this.host, -1)
     this.ui.showRift(this.riftQ, this.riftCharges, this.riftNeeded)
   }
 
   private riftAnswer(res: { correct: boolean; ms: number; answered: string }): void {
     if (!this.riftQ) return
-    this.host.report({ questionId: this.riftQ.id, correct: res.correct, ms: res.ms, answered: res.answered })
+    this.curriculum.answered(this.host, this.riftQ, res.answered, res.correct, res.ms)
     if (res.correct) {
-      this.correct++
       this.riftCharges++
       this.audio.answerRight()
       this.host.haptic("success")
@@ -1703,7 +1707,7 @@ export class Game {
         { label: "SURVIVED", value: `${mm}:${ss < 10 ? "0" : ""}${ss}` },
         { label: "SLAIN", value: String(this.kills) },
         { label: "LEVEL", value: String(this.level) },
-        { label: "ANSWERED", value: `${this.correct}/${this.asked}` },
+        { label: "ANSWERED", value: `${this.curriculum.solved}/${this.curriculum.asked}` },
         { label: "BEST", value: `${Math.floor(best / 60)}:${String(Math.floor(best % 60)).padStart(2, "0")}` },
       ],
       "THE DARK TOOK YOU",
@@ -1855,7 +1859,7 @@ export class Game {
       const ring = 172
       r.sprite(this.px, this.py, ring, ring, t * 0.4, 1, 0.86, 0.44, 0.30 * fade, SHAPE.RING, 0.012, 0.2)
       // Time as a closing iris, not a number.
-      const frac = Math.max(0, this.qT / 8.5)
+      const frac = Math.max(0, this.qT / Math.max(0.001, this.qTMax))
       r.sprite(this.px, this.py, ring * (0.35 + frac * 0.62), ring * (0.35 + frac * 0.62), -t * 0.9, 1, 0.7, 0.3, 0.34 * fade, SHAPE.RING, 0.02, 0)
       for (const o of this.orbs) {
         const hot = o.state === 1 ? 1 : 0

--- a/dynawalla/games/pulse/src/dev/fakeAudio.ts
+++ b/dynawalla/games/pulse/src/dev/fakeAudio.ts
@@ -1,0 +1,174 @@
+/**
+ * A Web Audio graph that makes no sound — QA only, never shipped.
+ *
+ * PULSE's escalation and its gate reporting live in `Run`, and `Run` owns the
+ * transport, so the only honest way to test either is to run the real thing.
+ * That needs an `AudioContext`, and node does not have one. This is a stand-in
+ * with a hand-driven clock: `advance(seconds)` moves `currentTime`, which is
+ * the *only* clock the game reads, so a test can play a five-minute run in a
+ * few milliseconds and every bar line, note time and judgment window lands
+ * exactly where it would on a device.
+ *
+ * Nothing here models sound. Every node accepts every call and remembers only
+ * what the engine reads back (`gain.value`, `frequency.value`, `fftSize`).
+ */
+
+class FakeParam {
+  value = 0
+  setValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  linearRampToValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  exponentialRampToValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  setTargetAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  cancelScheduledValues(): this {
+    return this
+  }
+  setValueCurveAtTime(): this {
+    return this
+  }
+}
+
+class FakeNode {
+  readonly gain = new FakeParam()
+  readonly frequency = new FakeParam()
+  readonly Q = new FakeParam()
+  readonly detune = new FakeParam()
+  readonly playbackRate = new FakeParam()
+  readonly delayTime = new FakeParam()
+  readonly threshold = new FakeParam()
+  readonly knee = new FakeParam()
+  readonly ratio = new FakeParam()
+  readonly attack = new FakeParam()
+  readonly release = new FakeParam()
+
+  type = "sine"
+  curve: Float32Array | null = null
+  oversample = "none"
+  buffer: unknown = null
+  loop = false
+  onended: (() => void) | null = null
+
+  fftSize = 2048
+  smoothingTimeConstant = 0
+  minDecibels = -100
+  maxDecibels = 0
+  get frequencyBinCount(): number {
+    return this.fftSize / 2
+  }
+
+  connect<T>(destination: T): T {
+    return destination
+  }
+  disconnect(): void {}
+  start(): void {}
+  stop(): void {}
+  getFloatTimeDomainData(): void {}
+  getByteFrequencyData(): void {}
+}
+
+class FakeBuffer {
+  readonly numberOfChannels: number
+  readonly length: number
+  readonly sampleRate: number
+  private readonly channels = new Map<number, Float32Array>()
+
+  constructor(numberOfChannels: number, length: number, sampleRate: number) {
+    this.numberOfChannels = numberOfChannels
+    this.length = length
+    this.sampleRate = sampleRate
+  }
+
+  getChannelData(i: number): Float32Array {
+    let ch = this.channels.get(i)
+    if (!ch) {
+      ch = new Float32Array(Math.max(0, this.length))
+      this.channels.set(i, ch)
+    }
+    return ch
+  }
+}
+
+export class FakeAudioContext {
+  /** The one clock. Tests move it; the game only ever reads it. */
+  currentTime = 0
+  readonly sampleRate = 48000
+  state: "running" | "suspended" | "closed" = "running"
+  readonly baseLatency = 0.008
+  readonly outputLatency = 0.012
+  readonly destination = new FakeNode()
+
+  createGain(): FakeNode {
+    return new FakeNode()
+  }
+  createAnalyser(): FakeNode {
+    return new FakeNode()
+  }
+  createDynamicsCompressor(): FakeNode {
+    return new FakeNode()
+  }
+  createWaveShaper(): FakeNode {
+    return new FakeNode()
+  }
+  createBiquadFilter(): FakeNode {
+    return new FakeNode()
+  }
+  createConvolver(): FakeNode {
+    return new FakeNode()
+  }
+  createDelay(): FakeNode {
+    return new FakeNode()
+  }
+  createOscillator(): FakeNode {
+    return new FakeNode()
+  }
+  createBufferSource(): FakeNode {
+    return new FakeNode()
+  }
+  createBuffer(channels: number, length: number, rate: number): FakeBuffer {
+    // Short buffers keep the impulse-response and noise loops cheap; nothing
+    // reads a sample back.
+    return new FakeBuffer(channels, Math.min(length, 256), rate)
+  }
+  resume(): Promise<void> {
+    this.state = "running"
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    this.state = "closed"
+    return Promise.resolve()
+  }
+}
+
+/**
+ * Publish the fake as `window.AudioContext` and hand back the live instance
+ * once something constructs it. Call BEFORE importing anything that builds an
+ * engine.
+ */
+export function installFakeAudio(): { latest(): FakeAudioContext } {
+  let latest: FakeAudioContext | null = null
+  class Tracked extends FakeAudioContext {
+    constructor() {
+      super()
+      latest = this
+    }
+  }
+  const g = globalThis as unknown as { window?: Record<string, unknown> }
+  g.window = { ...(g.window ?? {}), AudioContext: Tracked }
+  return {
+    latest: () => {
+      if (!latest) throw new Error("no AudioContext has been constructed yet")
+      return latest
+    },
+  }
+}

--- a/dynawalla/games/pulse/src/game/run.test.ts
+++ b/dynawalla/games/pulse/src/game/run.test.ts
@@ -1,0 +1,275 @@
+/**
+ * The run, played by bots, on a hand-driven clock.
+ *
+ * Nothing here reaches into `Run` to award a point or force a stage. The bots
+ * strike through `run.input(lane, perfMs)` — the same call a thumb makes,
+ * including the clock conversion and the judgment windows — and every
+ * assertion is about what the *host* was told or what the *stage* did.
+ *
+ * `FakeAudioContext.currentTime` is the only clock PULSE reads, so advancing it
+ * in 20 ms steps plays a real four-minute run in a few milliseconds. Steps have
+ * to stay under 0.6 s: a longer gap is what `Run.update` calls a stall, and it
+ * sweeps notes off the board unjudged rather than punishing a child for a hitch
+ * the game caused — so a coarser step would silently stop testing the misses.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { installFakeAudio } from "../dev/fakeAudio.ts";
+
+const audio = installFakeAudio();
+
+// After the fake is installed, so `createEngine()` finds it.
+const { GATE_READ_SEC, Run } = await import("./run.ts");
+const { gatesToClear, stageAt } = await import("./stages.ts");
+
+import type { Host } from "../contract.ts";
+import type { Fx } from "./run.ts";
+import type { LiveNote } from "./judge.ts";
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string };
+
+/** 3/4 is in the bar, so the gate stays a number line. */
+function question(n: number) {
+  return {
+    id: `q${n}`,
+    prompt: `1/2 + 1/4 (${n})`,
+    answer: "3/4",
+    distractors: ["1/4", "1/2", "1/8"],
+    domain: "fractions",
+    difficulty: 0.5,
+  };
+}
+
+type Rig = {
+  run: InstanceType<typeof Run>;
+  reports: Report[];
+  /** Stage indices the run actually reached, in order. */
+  stages: number[];
+  /** Audio-clock seconds between a gate appearing and its answer arriving. */
+  readingWindows: number[];
+  play(seconds: number): void;
+  dispose(): void;
+};
+
+/**
+ * @param answer what the bot does at every gate: strike the right candidate,
+ *               strike a wrong one, or nothing at all.
+ */
+function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
+  const reports: Report[] = [];
+  const stages: number[] = [];
+  const readingWindows: number[] = [];
+  let n = 0;
+
+  const host: Host = {
+    next() {
+      n += 1;
+      return question(n);
+    },
+    report(r) {
+      reports.push(r);
+    },
+    haptic() {},
+    prefersReducedMotion() {
+      return true;
+    },
+  };
+
+  const fx: Fx = {
+    hit() {},
+    miss() {},
+    stray() {},
+    gateOpen(built) {
+      // The window a child gets to read this question: from the moment it is
+      // on screen to the moment the right answer crosses the strike line.
+      const target = run.notes
+        .all()
+        .find((x) => x.gate?.questionId === built.questionId && x.gate.correct);
+      if (target) readingWindows.push(target.time - ctx.currentTime);
+    },
+    gateResolved() {},
+    bar() {},
+    stageChanged(_spec, index) {
+      stages.push(index);
+    },
+    drop() {},
+    stumble() {},
+    overdrive() {},
+    layerEarned() {},
+  };
+
+  const run = new Run({ host, fx, seed: "bots", startStage });
+  const ctx = audio.latest();
+  run.start();
+
+  const planned = new Set<number>();
+
+  /** Strike a note by working back through the same conversion `input` does. */
+  const strike = (note: LiveNote, lane: number): void => {
+    const offset = ctx.currentTime - performance.now() / 1000;
+    const perfMs = (note.time - offset + 0.012) * 1000;
+    run.input(lane, perfMs);
+  };
+
+  /**
+   * The bot drums every ordinary note dead on. That is not decoration: missing
+   * them drains health, and a stumble steps the stage back down, so a bot that
+   * only ever touched gates would spend the whole run pinned to stage 0 and
+   * prove nothing about the stages above it.
+   */
+  const botTick = (): void => {
+    const heard = run.heard();
+    for (const note of run.notes.all()) {
+      if (note.judged !== null || planned.has(note.id)) continue;
+      if (Math.abs(note.time - heard) > 0.02) continue;
+      if (note.gate) {
+        if (answer === "never") continue;
+        const wanted = answer === "right" ? note.gate.correct : !note.gate.correct;
+        if (!wanted) continue;
+      }
+      planned.add(note.id);
+      // A gate tile is struck from a lane it is NOT in, on purpose: its position
+      // in the bar is its value and the lane your thumb was over is not part of
+      // the answer. If that licence ever narrows, these runs stop resolving.
+      strike(note, note.gate ? (note.lane + 2) % 3 : note.lane);
+    }
+  };
+
+  const step = (): void => {
+    ctx.currentTime += 0.02;
+    botTick();
+    run.update();
+  };
+
+  return {
+    run,
+    reports,
+    stages,
+    readingWindows,
+    play(seconds) {
+      const steps = Math.round(seconds / 0.02);
+      for (let i = 0; i < steps; i++) step();
+    },
+    dispose() {
+      run.dispose();
+    },
+  };
+}
+
+/** Four minutes. Long past the point where the old bar counter had climbed. */
+const LONG_RUN_SEC = 240;
+
+test("a bot that answers every gate WRONG never leaves the first stage", () => {
+  const r = rig("wrong");
+  r.play(LONG_RUN_SEC);
+  const reached = Math.max(0, ...r.stages);
+  r.dispose();
+
+  assert.ok(
+    r.run.gatesSeen > 4,
+    `the bot has to have actually been asked things; it saw ${r.run.gatesSeen} gates`,
+  );
+  assert.equal(r.run.gatesCorrect, 0, "the bot answered everything wrong, by construction");
+  assert.equal(
+    reached,
+    0,
+    `a run with no correct gate reached stage ${reached}; escalation is on achievement, not bars`,
+  );
+});
+
+test("a bot that never answers at all never leaves the first stage either", () => {
+  const r = rig("never");
+  r.play(LONG_RUN_SEC);
+  const reached = Math.max(0, ...r.stages);
+  r.dispose();
+
+  assert.ok(r.run.gatesSeen > 4);
+  assert.equal(reached, 0, `surviving ${LONG_RUN_SEC}s reached stage ${reached}`);
+});
+
+test("a bot that answers every gate RIGHT does climb", () => {
+  const r = rig("right");
+  r.play(LONG_RUN_SEC);
+  const reached = Math.max(0, ...r.stages);
+  const correct = r.run.gatesCorrect;
+  r.dispose();
+
+  assert.ok(correct > 2, `the bot only got ${correct} gates right; it should get nearly all`);
+  assert.ok(reached > 0, "a child who is getting them right must be given harder rhythm");
+});
+
+test("a stage is passed on gates cleared, not on bars survived", () => {
+  // The rule itself, stated once, so the shape is not only inferable from a bot.
+  for (let i = 0; i < 12; i++) {
+    const spec = stageAt(i);
+    assert.ok(gatesToClear(spec) >= 1, `stage ${i} must need at least one right answer`);
+  }
+});
+
+test("a gate that expires reports NOTHING to the host", () => {
+  const r = rig("never");
+  r.play(LONG_RUN_SEC);
+  const seen = r.run.gatesSeen;
+  const reports = [...r.reports];
+  r.dispose();
+
+  assert.ok(seen > 4, `only ${seen} gates were served`);
+  assert.deepEqual(
+    reports,
+    [],
+    "a gate nobody struck is a question nobody answered; the host must hear nothing about it",
+  );
+  const filed: Report[] = reports;
+  assert.equal(
+    filed.find((x) => x.answered === "" && !x.correct),
+    undefined,
+    "an empty response filed as an attempt is a wrong answer the child never gave",
+  );
+});
+
+test("an answered gate reports the exact payload, right or wrong", () => {
+  const right = rig("right");
+  right.play(60);
+  const goodReports = [...right.reports];
+  right.dispose();
+
+  assert.ok(goodReports.length > 0, "the bot answered gates; something must have been reported");
+  for (const report of goodReports) {
+    assert.equal(report.correct, true);
+    assert.equal(report.answered, "3/4");
+    assert.match(report.questionId, /^q\d+$/);
+    assert.ok(report.ms >= 1 && Number.isInteger(report.ms));
+  }
+
+  const wrong = rig("wrong");
+  wrong.play(60);
+  const badReports = [...wrong.reports];
+  wrong.dispose();
+
+  assert.ok(badReports.length > 0);
+  for (const report of badReports) {
+    assert.equal(report.correct, false);
+    assert.notEqual(report.answered, "", "a struck candidate always has a label");
+  }
+});
+
+test("the reading window never shrinks because the tempo went up", () => {
+  // Stage 9 is deep in the endless loop: 113+ BPM, the shortest bars the game
+  // ever plays, and the hardest fractions the host will serve.
+  for (const startStage of [0, 4, 9, 14]) {
+    const r = rig("right", startStage);
+    r.play(120);
+    const windows = [...r.readingWindows];
+    r.dispose();
+
+    assert.ok(windows.length > 0, `no gate opened at stage ${startStage}`);
+    const worst = Math.min(...windows);
+    assert.ok(
+      worst >= GATE_READ_SEC,
+      `at stage ${startStage} a child got ${worst.toFixed(2)}s to read a question; ` +
+        `the floor is ${GATE_READ_SEC}s and it must not depend on the tempo`,
+    );
+  }
+});

--- a/dynawalla/games/pulse/src/game/run.ts
+++ b/dynawalla/games/pulse/src/game/run.ts
@@ -30,7 +30,7 @@ import {
 import { barNotes, BEATS_PER_BAR, laneVoices, type ChartNote } from "./chart.ts";
 import { buildGate, DEFAULT_FIT, type BuiltGate } from "./gate.ts";
 import { classify, multiplierFor, NoteQueue, WINDOWS, type Judgment, type LiveNote } from "./judge.ts";
-import { stageAt, type StageSpec } from "./stages.ts";
+import { gatesToClear, stageAt, type StageSpec } from "./stages.ts";
 import { makeRng, hashSeed, type Rng } from "../rng.ts";
 
 export type GateOutcome = "correct" | "wrong" | "expired";
@@ -59,6 +59,24 @@ export type RunOptions = {
   /** Start partway up the escalation. For QA and for showing someone the top end. */
   startStage?: number;
 };
+
+/**
+ * The floor on how long a fraction question is on screen before its answer
+ * crosses the strike line, in seconds.
+ *
+ * The gate window used to be one bar plus whatever the lookahead happened to
+ * be, and the lookahead is a multiple of the bar — so the reading window was
+ * `f(BPM)`, and BPM is this game's difficulty knob. Getting good made the
+ * music faster, and faster music gave a child *less* time to work out a harder
+ * sum. That is the coupling `dynawalla/docs/EXPERIENCE_DESIGN.md` forbids:
+ * "COMPREHENSION — not budgeted. The child's time. Measured, never limited."
+ *
+ * Six seconds is the p50 cadence target for two-digit-with-regrouping and the
+ * p90 for a single-digit fact. It is a floor, not a cap: at slow tempos the
+ * bar is longer and the child gets more. Nothing about it moves with the
+ * tempo, which is the entire point.
+ */
+export const GATE_READ_SEC = 6;
 
 const HEALTH = {
   miss: -0.05,
@@ -101,6 +119,8 @@ export class Run {
   misses = 0;
   gatesCorrect = 0;
   gatesSeen = 0;
+  /** Gates cleared IN THE CURRENT STAGE. This, not the bar count, passes it. */
+  stageGatesCorrect = 0;
 
   layers = new Set<LayerId>(["bass"]);
   gate: ActiveGate | null = null;
@@ -135,7 +155,12 @@ export class Run {
       () => this.engine.now(),
       this.timeline,
       (bar, t) => this.fillBar(bar, t),
-      { lookaheadSec: () => this.barSeconds() * 1.2 + 0.25 },
+      {
+        // One bar of future for the playfield, plus a floor that does not move
+        // with the tempo so a gate is always readable for GATE_READ_SEC before
+        // its answer arrives. See GATE_READ_SEC.
+        lookaheadSec: () => Math.max(this.barSeconds() * 1.2 + 0.25, GATE_READ_SEC),
+      },
     );
   }
 
@@ -200,8 +225,15 @@ export class Run {
     this.bar = bar;
     const beat0 = this.timeline.beatOfBar(bar);
 
-    // --- Stage advance lands on the bar line, tempo and all.
-    if (bar > 0 && bar - this.stageStartBar >= this.stage.bars) {
+    // --- Stage advance lands on the bar line, tempo and all — but only once
+    // the child has actually cleared the stage. Bars are how a stage is paced;
+    // right answers are how it is passed. A stage whose gates are still being
+    // missed simply comes round again, with more gates on it.
+    if (
+      bar > 0 &&
+      bar - this.stageStartBar >= this.stage.bars &&
+      this.stageGatesCorrect >= gatesToClear(this.stage)
+    ) {
       this.setStage(this.stageIndex + 1, beat0);
     }
 
@@ -307,6 +339,7 @@ export class Run {
     this.stageIndex = Math.max(0, index);
     this.stage = stageAt(this.stageIndex);
     this.stageStartBar = this.timeline.barOfBeat(atBeat);
+    this.stageGatesCorrect = 0;
     this.timeline.setTempoAtBeat(atBeat, this.stage.bpm);
     const anyHost = this.host as Host & { setFloor?: (d: number) => void };
     anyHost.setFloor?.(this.stage.gateFloor);
@@ -325,7 +358,15 @@ export class Run {
     // the moment it stops.
     if (this.engine.ctx.state !== "running") void this.engine.resume();
     const tHit = this.perfToHeard(perfMs);
-    const gateActive = this.gate !== null && !this.gate.resolved;
+    // A gate candidate may be struck from ANY lane — its position in the bar is
+    // its value, and which lane your thumb was over is not part of the answer.
+    // That licence lasts exactly as long as a candidate is strikeable, not for
+    // the whole time the question is on screen: with a tempo-independent
+    // reading window the question is up for seconds, and lane discipline has to
+    // survive it.
+    const gateActive = this.notes
+      .gateNotes()
+      .some((n) => Math.abs(n.time - tHit) <= WINDOWS.good);
     const res = this.notes.hit(lane, tHit, gateActive);
     if (!res) {
       this.onStray(lane, tHit);
@@ -397,6 +438,7 @@ export class Run {
 
     if (info.correct) {
       this.gatesCorrect++;
+      this.stageGatesCorrect++;
       this.gateStreak++;
       this.combo++;
       this.bestCombo = Math.max(this.bestCombo, this.combo);
@@ -478,6 +520,19 @@ export class Run {
     this.fx.stumble();
   }
 
+  /**
+   * Whether the gate bar is close enough that the playfield should get out of
+   * the way. Separate from `gate` being set, because the question now appears
+   * seconds ahead of the bar it lands on and the field must not sit dimmed for
+   * all of it.
+   */
+  gateImminent(): boolean {
+    const g = this.gate;
+    if (!g || g.resolved) return false;
+    const start = this.timeline.timeAt(this.timeline.beatOfBar(g.bar));
+    return this.heard() > start - this.barSeconds();
+  }
+
   multiplier(): number {
     const m = multiplierFor(this.combo);
     return this.bar <= this.overdriveUntilBar ? m * 2 : m;
@@ -526,12 +581,14 @@ export class Run {
         g.resolved = true;
         this.gateStreak = 0;
         this.health = Math.max(0, this.health + HEALTH.gateExpired);
-        this.host.report({
-          questionId: g.built.questionId,
-          correct: false,
-          ms: Math.max(1, Math.round(performance.now() - g.openedAtPerf)),
-          answered: "",
-        });
+        // Nothing is reported. Nobody struck a candidate, so there is no
+        // response to file; the old code filed an empty one marked incorrect,
+        // which recorded a child who was still working as a child who cannot do
+        // the sum. The `Host` this game mounts against
+        // (dynawalla/packs/shared/game-host/index.ts) forwards `report` straight
+        // to `items.answer` and drops the game's own `correct` — so an empty
+        // `answered` IS a wrong attempt in the learner's record. Silence is the
+        // only truthful option the contract offers.
         this.duck(0.5);
         this.fx.gateResolved("expired", null, g.built);
         this.checkStumble();

--- a/dynawalla/games/pulse/src/game/stages.ts
+++ b/dynawalla/games/pulse/src/game/stages.ts
@@ -139,6 +139,26 @@ export const STAGES: readonly StageSpec[] = [
 ];
 
 /**
+ * Right answers that pass a stage.
+ *
+ * A stage used to end when its bars ran out, which meant the escalation was a
+ * wall clock wearing a bar counter: a child who missed every fraction gate for
+ * four minutes was still handed sixteenths and five-over-four, and — because
+ * `gateFloor` rises with the stage and the host reads it — harder arithmetic
+ * too. Surviving twenty bars is not evidence of anything; striking the right
+ * fraction is.
+ *
+ * Half the gates a stage offers, rounded up, and never fewer than one. That is
+ * demanding enough to mean something and forgiving enough that one fumbled
+ * fraction does not cost a stage — the bars simply come round again, with more
+ * gates on them, until the child has shown they can do it.
+ */
+export function gatesToClear(spec: StageSpec): number {
+  const gatesInStage = Math.max(1, Math.floor(spec.bars / spec.gateEvery));
+  return Math.max(1, Math.ceil(gatesInStage / 2));
+}
+
+/**
  * After the last written stage the game keeps going forever: the hardest shapes
  * come back a little faster each loop, capped so it stays humanly playable.
  */

--- a/dynawalla/games/pulse/src/render/scene.ts
+++ b/dynawalla/games/pulse/src/render/scene.ts
@@ -637,7 +637,10 @@ export class Scene {
     const tickDiv = run.stage.tickDiv;
     const first = Math.floor(nowBeat + l.uMin * BEATS_PER_BAR);
     const last = Math.ceil(nowBeat + l.uMax * BEATS_PER_BAR);
-    const gate = run.gate && !run.gate.resolved ? 1 : 0;
+    // Imminent, not merely open: the question now appears several seconds
+    // ahead of the bar it lands on, and the floor must not sit dimmed for all of
+    // it — the child is still playing notes while they read.
+    const gate = run.gateImminent() ? 1 : 0;
     const dim = 1 - gate * 0.45;
 
     // Lane rails: each lane is a track, not a row of floating things.
@@ -777,7 +780,7 @@ export class Scene {
     const l = this.layout;
     const laneCount = l.laneCount;
     const r = this.noteRadius();
-    const gateDim = run.gate && !run.gate.resolved ? 0.35 : 1;
+    const gateDim = run.gateImminent() ? 0.35 : 1;
 
     for (const n of run.notes.all()) {
       const u = (n.beat - nowBeat) / BEATS_PER_BAR;

--- a/dynawalla/games/rhythm/src/dev/fakeAudio.ts
+++ b/dynawalla/games/rhythm/src/dev/fakeAudio.ts
@@ -1,0 +1,175 @@
+/**
+ * A Web Audio graph that makes no sound — QA only, never shipped.
+ *
+ * Splitbeat's gates, its difficulty and its transport all hang off
+ * `AudioContext.currentTime`, which the file header calls the ONLY musical
+ * clock — and node does not have one. This is a stand-in whose clock a test
+ * drives by hand, so a four-minute run plays in a few milliseconds and every
+ * bar line, note time and judgment window lands exactly where it would on a
+ * device.
+ *
+ * Nothing here models sound. Every node accepts every call and remembers only
+ * what the engine reads back (`gain.value`, `frequency.value`, `fftSize`).
+ */
+
+class FakeParam {
+  value = 0
+  setValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  linearRampToValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  exponentialRampToValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  setTargetAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  cancelScheduledValues(): this {
+    return this
+  }
+  setValueCurveAtTime(): this {
+    return this
+  }
+}
+
+class FakeNode {
+  readonly gain = new FakeParam()
+  readonly frequency = new FakeParam()
+  readonly Q = new FakeParam()
+  readonly detune = new FakeParam()
+  readonly playbackRate = new FakeParam()
+  readonly delayTime = new FakeParam()
+  readonly threshold = new FakeParam()
+  readonly knee = new FakeParam()
+  readonly ratio = new FakeParam()
+  readonly attack = new FakeParam()
+  readonly release = new FakeParam()
+
+  type = "sine"
+  curve: Float32Array | null = null
+  oversample = "none"
+  buffer: unknown = null
+  loop = false
+  onended: (() => void) | null = null
+
+  fftSize = 2048
+  smoothingTimeConstant = 0
+  minDecibels = -100
+  maxDecibels = 0
+  get frequencyBinCount(): number {
+    return this.fftSize / 2
+  }
+
+  connect<T>(destination: T): T {
+    return destination
+  }
+  disconnect(): void {}
+  start(): void {}
+  stop(): void {}
+  getFloatTimeDomainData(): void {}
+  getByteFrequencyData(): void {}
+}
+
+class FakeBuffer {
+  readonly numberOfChannels: number
+  readonly length: number
+  readonly sampleRate: number
+  private readonly channels = new Map<number, Float32Array>()
+
+  constructor(numberOfChannels: number, length: number, sampleRate: number) {
+    this.numberOfChannels = numberOfChannels
+    this.length = length
+    this.sampleRate = sampleRate
+  }
+
+  getChannelData(i: number): Float32Array {
+    let ch = this.channels.get(i)
+    if (!ch) {
+      ch = new Float32Array(Math.max(0, this.length))
+      this.channels.set(i, ch)
+    }
+    return ch
+  }
+}
+
+export class FakeAudioContext {
+  /** The one clock. Tests move it; the game only ever reads it. */
+  currentTime = 0
+  readonly sampleRate = 48000
+  state: "running" | "suspended" | "closed" = "running"
+  readonly baseLatency = 0.008
+  readonly outputLatency = 0.012
+  readonly destination = new FakeNode()
+
+  createGain(): FakeNode {
+    return new FakeNode()
+  }
+  createAnalyser(): FakeNode {
+    return new FakeNode()
+  }
+  createDynamicsCompressor(): FakeNode {
+    return new FakeNode()
+  }
+  createWaveShaper(): FakeNode {
+    return new FakeNode()
+  }
+  createBiquadFilter(): FakeNode {
+    return new FakeNode()
+  }
+  createConvolver(): FakeNode {
+    return new FakeNode()
+  }
+  createDelay(): FakeNode {
+    return new FakeNode()
+  }
+  createOscillator(): FakeNode {
+    return new FakeNode()
+  }
+  createBufferSource(): FakeNode {
+    return new FakeNode()
+  }
+  createBuffer(channels: number, length: number, rate: number): FakeBuffer {
+    // Short buffers keep the impulse-response and noise loops cheap; nothing
+    // reads a sample back.
+    return new FakeBuffer(channels, Math.min(length, 256), rate)
+  }
+  resume(): Promise<void> {
+    this.state = "running"
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    this.state = "closed"
+    return Promise.resolve()
+  }
+}
+
+/**
+ * Publish the fake as `window.AudioContext`, and `self` alongside it because
+ * the transport schedules on `self.setInterval`. Hand back the live instance
+ * once something constructs it. Call BEFORE importing anything that builds an
+ * engine.
+ */
+export function installFakeAudio(): { latest(): FakeAudioContext } {
+  let latest: FakeAudioContext | null = null
+  class Tracked extends FakeAudioContext {
+    constructor() {
+      super()
+      latest = this
+    }
+  }
+  const g = globalThis as unknown as { window?: Record<string, unknown>; self?: unknown }
+  g.window = { ...(g.window ?? {}), AudioContext: Tracked }
+  g.self = globalThis
+  return {
+    latest: () => {
+      if (!latest) throw new Error("no AudioContext has been constructed yet")
+      return latest
+    },
+  }
+}

--- a/dynawalla/games/rhythm/src/game/core.test.ts
+++ b/dynawalla/games/rhythm/src/game/core.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Splitbeat, played by bots, on a hand-driven clock.
+ *
+ * The bots strike through `game.hit(lane, audioTime)` — the same call the
+ * keyboard and the pointer make — and every assertion is about what the *host*
+ * was told, what the *difficulty* did, or how long a question was on screen.
+ * Nothing here forces a verdict or writes a score.
+ *
+ * They all drum the ordinary notes dead on, because missing notes costs charge
+ * and a run at zero charge stops planning bars: a bot that only touched gates
+ * would break down in the first eight seconds and prove nothing.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { installFakeAudio } from "../dev/fakeAudio.ts";
+
+const audio = installFakeAudio();
+
+// After the fake is installed, so `new AudioEngine()` finds it.
+const { Game, MAX_CHARGE, READ_SEC } = await import("./core.ts");
+
+import type { Host } from "../contract.ts";
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string };
+
+type Played = {
+  difficulty: number;
+  bpm: number;
+  /** Gates the child actually answered. */
+  answered: number;
+  correct: number;
+  charge: number;
+  phase: string;
+  reports: Report[];
+  /** Seconds between a question appearing and its answer having to be struck. */
+  readingWindows: number[];
+  difficultyAsked: number[];
+};
+
+/**
+ * @param answer what the bot does at a gate: strike the right tile, strike a
+ *               wrong one, or leave it alone and let it close.
+ */
+async function play(
+  answer: "right" | "wrong" | "never",
+  seconds: number,
+  startDifficulty = 1,
+): Promise<Played> {
+  const reports: Report[] = [];
+  const difficultyAsked: number[] = [];
+  const readingWindows: number[] = [];
+  let n = 0;
+
+  const host: Host = {
+    next(opts) {
+      n += 1;
+      difficultyAsked.push(opts?.difficulty ?? 0);
+      return {
+        id: `q${n}`,
+        prompt: `${n} + 3`,
+        answer: "4",
+        distractors: ["3", "6"],
+        domain: "add-sub",
+        difficulty: (opts?.difficulty ?? 1) / 10,
+      };
+    },
+    report(r) {
+      reports.push(r);
+    },
+    haptic() {},
+    prefersReducedMotion() {
+      return true;
+    },
+  };
+
+  const game = new Game(host);
+  game.difficulty = startDifficulty;
+  game.soundOn = false;
+  const ctx = audio.latest();
+  await game.start();
+
+  const pump = (game as unknown as { pump(): void }).pump.bind(game);
+  const measured = new Set<number>();
+
+  for (let i = 0; i < Math.round(seconds / 0.02); i++) {
+    ctx.currentTime += 0.02;
+    pump();
+
+    // A choice tile exists once the gate bar is planned, so its strike time is
+    // final. The window the child got is that time minus when the question
+    // appeared.
+    for (const note of game.notes) {
+      if (!note.active || !note.isChoice || measured.has(note.gateId)) continue;
+      const gate = game.gates.find((g) => g.active && g.id === note.gateId);
+      if (!gate) continue;
+      measured.add(note.gateId);
+      readingWindows.push(note.time - gate.revealAt);
+    }
+
+    // `hit` finds the nearest pending note in the lane itself, so the bot only
+    // has to say "there is something due in this lane, now".
+    const due = ctx.currentTime - 0.012;
+    for (const note of game.notes) {
+      if (!note.active || note.state !== 0) continue;
+      if (Math.abs(note.time - due) > 0.015) continue;
+      if (note.isChoice) {
+        if (answer === "never") continue;
+        if (note.correct !== (answer === "right")) continue;
+      }
+      game.hit(note.lane, note.time + 0.012);
+    }
+
+    game.update(0.02);
+  }
+
+  const out: Played = {
+    difficulty: game.difficulty,
+    bpm: game.bpm,
+    answered: game.gatesTotal,
+    correct: game.gatesCorrect,
+    charge: game.charge,
+    phase: game.phase,
+    reports,
+    readingWindows,
+    difficultyAsked,
+  };
+  game.destroy();
+  return out;
+}
+
+/** Four minutes — long enough for the ladder to move several rungs. */
+const LONG_RUN_SEC = 240;
+
+test("a gate that expires reports NOTHING to the host", async () => {
+  const r = await play("never", LONG_RUN_SEC);
+
+  assert.ok(
+    r.difficultyAsked.length > 4,
+    `only ${r.difficultyAsked.length} gates were served; the bot has to have been asked things`,
+  );
+  assert.deepEqual(
+    r.reports,
+    [],
+    "nobody struck a tile, so nobody answered; the host must hear nothing about it",
+  );
+  const filed: Report[] = r.reports;
+  assert.equal(
+    filed.find((x) => x.answered === "" && !x.correct),
+    undefined,
+    "motor lateness filed as an empty wrong answer is indistinguishable from not knowing the sum",
+  );
+});
+
+test("a gate that expires does not move the difficulty and does not cost charge", async () => {
+  const r = await play("never", LONG_RUN_SEC, 5);
+
+  assert.ok(r.difficultyAsked.length > 4);
+  assert.equal(
+    r.difficulty,
+    5,
+    "a child who was still computing has said nothing about the maths; the ladder must not move",
+  );
+  assert.equal(r.charge, MAX_CHARGE, "the run was played perfectly; only the gates went unanswered");
+  assert.equal(r.phase, "playing", "an unanswered gate must not be able to end a run on its own");
+});
+
+test("an answered gate reports the exact payload, right or wrong", async () => {
+  const right = await play("right", 120);
+  assert.ok(right.reports.length > 0);
+  for (const report of right.reports) {
+    assert.equal(report.correct, true);
+    assert.equal(report.answered, "4");
+    assert.match(report.questionId, /^q\d+$/);
+    assert.ok(report.ms > 0 && Number.isInteger(report.ms));
+  }
+
+  const wrong = await play("wrong", 120);
+  assert.ok(wrong.reports.length > 0);
+  for (const report of wrong.reports) {
+    assert.equal(report.correct, false);
+    assert.notEqual(report.answered, "", "a struck tile always has a label on it");
+  }
+});
+
+/**
+ * SPLITBEAT was already the fleet's reference for this: it has never escalated
+ * on the clock. The test is here to keep it that way.
+ */
+test("escalation is on the gate outcome, and only on the gate outcome", async () => {
+  const right = await play("right", LONG_RUN_SEC);
+  assert.ok(right.correct > 4, `only ${right.correct} gates were answered right`);
+  assert.ok(
+    right.difficulty > 1,
+    "a child who is getting them right must be given harder maths",
+  );
+  assert.ok(
+    Math.max(...right.difficultyAsked) > Math.min(...right.difficultyAsked),
+    "the host must actually be asked for harder questions, not just told internally",
+  );
+
+  const wrong = await play("wrong", LONG_RUN_SEC, 5);
+  assert.ok(wrong.answered > 4);
+  assert.ok(
+    wrong.difficulty < 5,
+    `a run of nothing but wrong answers ended at difficulty ${wrong.difficulty}; it must come down`,
+  );
+});
+
+test("the reading window never shrinks because the tempo went up", async () => {
+  const r = await play("right", LONG_RUN_SEC);
+
+  assert.ok(r.readingWindows.length > 4, "no gates were measured");
+  assert.ok(r.difficulty > 3, `the run only reached difficulty ${r.difficulty}; push it harder`);
+  assert.ok(r.bpm > 110, `the tempo only reached ${r.bpm} BPM; the coupling would not show`);
+
+  const worst = Math.min(...r.readingWindows);
+  assert.ok(
+    worst >= READ_SEC,
+    `a child got ${worst.toFixed(2)}s to read a question at ${r.bpm} BPM; the floor is ` +
+      `${READ_SEC}s and it must not fall as the music speeds up`,
+  );
+});

--- a/dynawalla/games/rhythm/src/game/core.ts
+++ b/dynawalla/games/rhythm/src/game/core.ts
@@ -40,7 +40,26 @@ const BAR_RING = 64;
 const NOTE_HORIZON = 3.4;
 const AUDIO_HORIZON = 0.3;
 const LEAD_IN = 0.45;
-const MAX_CHARGE = 5;
+export const MAX_CHARGE = 5;
+
+/**
+ * The floor on how long a question is on screen before its answer has to be
+ * struck, in seconds.
+ *
+ * The lead used to be a flat two bars — `revealT0 + spb * 8` — and `spb` comes
+ * straight off `bpm`, which `applyDifficulty` raises with the difficulty. So
+ * the reading window was `f(difficulty)` and it pointed the wrong way: getting
+ * good sped the music up, and faster music gave a child LESS time to work out a
+ * HARDER sum. At difficulty 1 that was 4.9 s; by difficulty 10 it was 3.2 s.
+ *
+ * `dynawalla/docs/EXPERIENCE_DESIGN.md`: "COMPREHENSION — not budgeted. The
+ * child's time. Measured, never limited." A gate cannot be literally unlimited
+ * — it is a bar of music — but the lead is now measured in seconds and the
+ * inhale is stretched by however many bars it takes to cover them. Six seconds
+ * is the p50 cadence target for two-digit-with-regrouping and the p90 for a
+ * single-digit fact; at slow tempos a child gets more, never less.
+ */
+export const READ_SEC = 6;
 
 export type Note = {
   active: boolean;
@@ -145,8 +164,11 @@ export class Game {
   bestCombo = 0;
   charge = MAX_CHARGE;
   difficulty = 1;
+  /** Gates the child actually answered. An unanswered one is not an attempt. */
   gatesTotal = 0;
   gatesCorrect = 0;
+  /** Gates that closed with nobody striking a tile. Never reported, never punished. */
+  gatesExpired = 0;
   notesHit = 0;
   notesMissed = 0;
   perfectRun = 0;
@@ -189,6 +211,14 @@ export class Game {
   private audioCursor = 0;
   private cycleStartBar = 0;
   private grooveBars = 6;
+  /**
+   * Bars of inhale between the reveal and the gate, fixed for the whole of the
+   * current cycle so a sector change mid-cycle cannot move the gate bar out
+   * from under a question that is already on screen. Sized in `applyDifficulty`
+   * so the reveal-to-strike lead is never under READ_SEC.
+   */
+  private inhaleBars = 1;
+  private cycleInhale = 1;
   private gateSeq = 0;
   private schedTimer = 0;
   private laneLock = [0, 0, 0];
@@ -273,6 +303,7 @@ export class Game {
     this.barTime[0] = t;
     this.barSpb[0] = 60 / this.bpm;
     this.applyDifficulty();
+    this.cycleInhale = this.inhaleBars;
     this.barSpb[0] = 60 / this.bpm;
   }
 
@@ -320,6 +351,12 @@ export class Game {
     const d = this.difficulty;
     this.bpm = 92 + d * 6 + this.sector.bpmBias;
     this.grooveBars = d < 3 ? 6 : d < 6 ? 5 : 4;
+    // Bars get shorter as the tempo climbs, so the inhale gets longer to hold
+    // the reading window at or above READ_SEC. The lead is [reveal][inhale × n],
+    // so n bars of inhale buy (1 + n) bars of reading. Sparseness and time, not
+    // less feedback: an inhale bar is the sparsest bar the game plays.
+    const barDur = (60 / this.bpm) * 4;
+    this.inhaleBars = Math.max(1, Math.ceil(READ_SEC / barDur) - 1);
     this.eng.setDelayTime((60 / this.bpm) * 0.75);
   }
 
@@ -373,11 +410,12 @@ export class Game {
   private roleOf(bar: number): "groove" | "reveal" | "inhale" | "gate" | "aftermath" | "payoff" {
     const i = bar - this.cycleStartBar;
     const G = this.grooveBars;
+    const H = this.cycleInhale;
     if (i < G - 1) return "groove";
     if (i === G - 1) return "reveal";
-    if (i === G) return "inhale";
-    if (i === G + 1) return "gate";
-    if (i === G + 2) return "aftermath";
+    if (i < G + H) return "inhale";
+    if (i === G + H) return "gate";
+    if (i === G + H + 1) return "aftermath";
     return "payoff";
   }
 
@@ -385,9 +423,12 @@ export class Game {
   private planBar(bar: number): boolean {
     const idx = bar % BAR_RING;
     // Roll the cycle over first, so roleOf() is asked about the right cycle.
-    if (bar - this.cycleStartBar >= this.grooveBars + 5) {
+    if (bar - this.cycleStartBar >= this.grooveBars + 4 + this.cycleInhale) {
       this.cycleStartBar = bar;
       this.applyDifficulty();
+      // Pinned for the whole cycle: roleOf must not change shape underneath a
+      // gate that is already planned.
+      this.cycleInhale = this.inhaleBars;
     }
     const role = this.roleOf(bar);
     const t0 = this.barTime[idx]!;
@@ -510,8 +551,9 @@ export class Game {
     g.active = true;
     g.q = q;
     g.revealAt = revealT0;
-    // Two bars after the reveal bar starts: [reveal][inhale][gate]
-    g.time = revealT0 + spb * 8;
+    // [reveal][inhale × cycleInhale][gate] — as many inhale bars as it takes for
+    // the lead to cover READ_SEC seconds. See READ_SEC.
+    g.time = revealT0 + spb * 4 * (1 + this.cycleInhale);
     g.resolved = false;
     g.correct = false;
     g.answered = "";
@@ -533,8 +575,9 @@ export class Game {
     g.correctLane = lane;
     this.activeGate = g;
 
-    // Tension: a riser through the inhale bar into the gate.
-    if (this.soundOn) this.eng.riser(revealT0 + spb * 4, spb * 4, 0.85);
+    // Tension: a riser through the LAST inhale bar into the gate, so a longer
+    // inhale reads as more room to think rather than a longer wind-up.
+    if (this.soundOn) this.eng.riser(revealT0 + spb * 4 * this.cycleInhale, spb * 4, 0.85);
   }
 
   private placeChoiceNotes(t0: number, spb: number): void {
@@ -614,6 +657,46 @@ export class Game {
       this.kick(1.0, 0.965, 0.85);
       if (this.charge <= 0) this.enterBreakdown();
     }
+  }
+
+  /**
+   * The gate closed and nobody struck a tile.
+   *
+   * This used to run the whole wrong path — charge −2, difficulty −0.22, and a
+   * `report` of `{ correct: false, answered: "" }`. The `Host` this game mounts
+   * against (dynawalla/packs/shared/game-host/index.ts) forwards `report`
+   * straight to `items.answer` and *discards* the game's own `correct`, so an
+   * empty response was filed as an attempt the child got wrong. Motor lateness
+   * became indistinguishable from an arithmetic error, in the one record that
+   * decides what a child is asked next.
+   *
+   * There is no way to say "unanswered" on that contract — `report` is the only
+   * method the game-facing `Host` exposes, and the SDK's `items.skip` is not on
+   * it. So the truthful move is silence, and the ladder does not move either: a
+   * child who was still computing has told us nothing about what they know.
+   *
+   * The feedback stays. The mix muffles and the bell plays the correct
+   * subdivision as a ghost rhythm — the game demonstrates the answer rather
+   * than lecturing about it — but nothing is recorded and nothing is taken.
+   */
+  private expireGate(g: Gate): void {
+    if (g.resolved) return;
+    g.resolved = true;
+    g.correct = false;
+    g.answered = "";
+    this.gatesExpired++;
+    const t = this.eng.now;
+    const spb = 60 / this.bpm;
+    this.emit("gate-wrong", g.correctLane, null, true, 0.55);
+    if (this.soundOn) {
+      this.eng.muffle(spb * 4, 520);
+      const dcells = g.cells ?? 4;
+      const n = Math.min(dcells, 8);
+      for (let i = 0; i < n; i++) {
+        this.eng.bell(t + 0.35 + (i * spb * 4) / n, this.sector.root + 48, 0.4, 0.3, 0.6);
+      }
+    }
+    this.kick(0.45, 0.99, 0.3);
   }
 
   private advanceSector(): void {
@@ -892,7 +975,7 @@ export class Game {
           n.state = 2;
           if (g && !g.resolved) {
             for (const o of this.notes) if (o.active && o.isChoice && o.gateId === n.gateId) o.state = 2;
-            this.resolveGate(g, "", false, (now - g.revealAt) * 1000);
+            this.expireGate(g);
           }
         } else {
           this.registerMiss(n, false);

--- a/dynawalla/games/rhythm/src/index.ts
+++ b/dynawalla/games/rhythm/src/index.ts
@@ -390,7 +390,7 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
       return {
         phase: game.phase, score: game.score, combo: game.combo, charge: game.charge,
         difficulty: game.difficulty, bpm: game.bpm, cells: game.cells,
-        gates: game.gatesTotal, correct: game.gatesCorrect,
+        gates: game.gatesTotal, correct: game.gatesCorrect, expired: game.gatesExpired,
         accuracy: game.accuracy, notesHit: game.notesHit, notesMissed: game.notesMissed,
       };
     },


### PR DESCRIPTION
Two cross-cutting defects in `horde`, `pulse` and `rhythm`.

## A — escalation ran on the wall clock

| game | before | after |
|---|---|---|
| **horde** | `difficulty = 1 + floor(runT / 88)` — one rung every 88 s of *being alive* | `1 + floor(solved / 2)`, clamped 1–10. Right answers only |
| **pulse** | stage advanced when `bar - stageStartBar >= stage.bars` | that, **and** `stageGatesCorrect >= gatesToClear(stage)` (half the stage's gates, rounded up) |
| **rhythm** | already `+0.34` on a correct gate, `−0.22` on a wrong one | unchanged — it was the reference implementation. A test now pins it |

horde is the damning one: `this.correct` and `this.asked` were already tracked and already printed on the game-over panel. The signal existed and was ignored. pulse's stage index is not cosmetic either — it drives BPM, lane count, subdivision *and* `gateFloor`, which the host reads for question difficulty.

A stage that is not cleared simply comes round again, with more gates on it. Nobody is stuck without being asked.

## B — a timeout was reported as a WRONG ANSWER

All three filed `{ questionId, correct: false, ms, answered: "" }` on expiry. `rhythm` also ran the entire wrong path around it: charge −2, difficulty −0.22.

`dynawalla/packs/shared/game-host/index.ts` forwards `report` to `items.answer` and then `void correct` — **the host judges, and the game's opinion is discarded**. So an empty `answered` is recorded as an attempt the child got wrong. Motor lateness became indistinguishable from an arithmetic error, in exactly the record an adaptive controller reads.

**Why "report nothing" and not "report unanswered":** the game-facing `Host` type is `next / report / haptic / prefersReducedMotion`. There is no unanswered flag on `report`. The SDK *does* have `items.skip` (`packs/sdk/src/capabilities.ts`, `guest.ts:71`), but the shared `GameHost` adapter does not expose it, and that adapter is off-limits here. Within the contract as it stands, silence is the only truthful option — an unreported item is an item the child was served and never answered, which is what happened.

Audiovisual feedback is kept everywhere. Only the record and the punishment go.

## The root cause under both rhythm games

The thinking window was derived from the tempo, and **the tempo is the difficulty knob**. Getting good sped the music up, and faster music gave a child *less* time to do a *harder* sum.

Measured over a four-minute bot run:

| | before | after |
|---|---|---|
| pulse, stage 0 → 17 | 5.12 s → 3.75 s | 7.86 s → 7.33 s |
| rhythm, difficulty 1 → 4.4 (98 → 126 BPM) | 4.90 s → 3.86 s | ≥ 6 s throughout |

Both leads are now measured in seconds with a 6 s floor — the p50 cadence target for two-digit-with-regrouping in `EXPERIENCE_DESIGN.md`, and the p90 for a single-digit fact. pulse floors its lookahead; rhythm stretches the *inhale* by as many bars as the tempo needs, which is the sparsest bar it plays. horde's core window was already tempo-free but flat at 8.5 s; it now widens with the ladder to 19.3 s at the top.

> COMPREHENSION — not budgeted. The child's time. Measured, never limited.

## Tests

Bots, not assertions about arithmetic. `pulse` and `rhythm` get a fake Web Audio graph with a hand-driven clock (`src/dev/fakeAudio.ts`), so a four-minute run plays headlessly in milliseconds **through the real transport and the real `input`/`hit` path** — nothing forces a verdict or writes a score. Three bots each: answers every gate wrong, never answers, answers everything right. pulse's bot deliberately strikes gate tiles from a lane they are *not* in, which is the licence the any-lane rewrite has to keep.

Every fix was deleted and the suite re-run. Sample:

- horde, escalation on questions *served*: `a run with no right answers must stay on rung 1 — 10 !== 1`
- horde, old expiry report: `+ [ { answered: '', correct: false, ms: 8500, questionId: 'q1' } ]`
- pulse, bar-only advance: `a run with no correct gate reached stage 1; escalation is on achievement, not bars`
- pulse, tempo-derived lookahead: `at stage 0 a child got 5.81s to read a question; the floor is 6s`
- rhythm, expiry back on the wrong path: `a child who was still computing has said nothing about the maths; the ladder must not move — 2.8 !== 5`
- rhythm, single inhale bar: `a child got 3.86s to read a question at 126.4 BPM; the floor is 6s`

`npm test` and `npm run tsc` green in all three, five consecutive runs each: horde 28, pulse 96, rhythm 68. `build:pack` builds clean.