### PR TITLE
fix(dynawalla/games): give the comprehension window back in TRUEDRAW and THE SPLIT — not doing the maths was the winning strategy

### DIFF
--- a/dynawalla/games/slice/README.md
+++ b/dynawalla/games/slice/README.md
@@ -23,11 +23,19 @@ npm run build:pack # what installs on a tablet: pack.html only, no stub Host
 | a **composite** gourd | splits along your blade; **its two factors burst out of the wound** as real objects you can cut again |
 | a **prime** gourd | detonates gold. Primes are the payoff, not a trap |
 | a **sigil** tablet | the equation on it explodes into four floating candidates |
-| a **candidate** | right one → the biggest response in the game. Wrong one → a lamp |
+| a **candidate** | right one → the biggest response in the game. Wrong one → the market's favour, gone |
 | a **bomb** | a lamp, and you will feel it |
 
-Three lamps. Lose them all and the market closes; one tap opens it again.
-Nothing ever completes — the only direction is up.
+Three lamps, and **a bomb is the only thing that takes one.** Lose them all and
+the market closes; one tap opens it again. Nothing ever completes — the only
+direction is up.
+
+**While a sum is up, the market stops.** No gourds, no bombs, no rush, no second
+tablet — the whole thing holds its breath for as long as the child needs, and
+comes back louder the moment they answer. That is also the stakes model: letting
+a sigil expire costs every second of market it was hushing, which is how a
+timeout comes to cost *more* than an honest wrong answer without ever costing a
+lamp.
 
 ## Where the math lives
 
@@ -45,10 +53,25 @@ Nothing ever completes — the only direction is up.
    The whole game — flow, decision, and the arithmetic — is one gesture from top
    to bottom. There is no mode switch, no modal, no keypad.
 
-A wrong candidate costs a lamp, so guessing is real. **Hesitation never costs a
-lamp** — the timer running out forfeits the bonus and flashes the right answer,
-and that is all. Punishing a child for thinking is the failure mode this whole
-program exists to avoid.
+A wrong candidate drops **favour** — the global multiplier that applies to every
+gourd, every prime and every cascade — straight back to one, so guessing is real.
+It does not cost a lamp, and this is deliberate: it used to, while a timeout cost
+almost nothing, which made *never answering* the strictly dominant strategy. A
+child unsure of the sum was better off looking away. `src/sim/economy.ts` holds
+the whole ordering now and `src/test/economy.test.ts` plays bots against it —
+reading beats guessing beats refusing, at every difficulty and at every value the
+slicing could plausibly be worth.
+
+**Hesitation never costs a lamp, and it is never reported to the ladder.** A
+window that closed on an untouched screen is not evidence that a child does not
+know the skill; it is evidence they were still working. Punishing a child for
+thinking is the failure mode this whole program exists to avoid.
+
+The window itself is `EXPERIENCE_DESIGN.md`'s **p90 for the item's own class**,
+monotone non-decreasing in difficulty and clamped by nothing: 6 s for a
+single-digit fact, 13 s for two-digit regrouping, 40 s for the
+`5,001 − 2,798` class. It was a flat 4.2 s — 3.78 s usable after the read-lock —
+against a documented 6 s p50 for the exact skills `pack.json` declares.
 
 ## The register
 
@@ -209,8 +232,8 @@ must not drift. `src/stubHost.ts` is a local, seeded, deterministic Host with
 exact integer arithmetic and distractors that are **real mal-rule outputs** —
 the neighbouring times-table row, addition with every carry dropped, the
 smaller-from-larger subtraction bug, the reversal. Not `answer ± 1` noise: a
-wrong slice costs a lamp here, so the wrong values have to be the ones worth
-learning to reject. A test asserts that >95% of multiplication items carry at
+wrong slice costs the whole multiplier economy here, so the wrong values have to
+be the ones worth learning to reject. A test asserts that >95% of multiplication items carry at
 least one true mal-rule.
 
 ## Known weaknesses

--- a/dynawalla/games/slice/src/mount.ts
+++ b/dynawalla/games/slice/src/mount.ts
@@ -56,6 +56,18 @@ import { KIND_DOT, KIND_SHARD, KIND_SPARK, Particles } from "./render/particles.
 import { Scene } from "./render/scene.ts"
 import { B_BOMB, B_MOTE, B_NUMERAL, B_SIGIL, World, type Body } from "./sim/body.ts"
 import { Director, type Throw } from "./sim/director.ts"
+import {
+  answerGain,
+  CANDIDATE_READ_LOCK_MS,
+  favourAfter,
+  FAVOUR_SECONDS,
+  LAMPS,
+  lampCost,
+  moteSecondsFor,
+  READ_PER_LAMP,
+  reportsToCurriculum,
+  type Verdict,
+} from "./sim/economy.ts"
 import { buildNumberPool, chooseSplit, isPrime } from "./sim/factor.ts"
 
 type Pop = {
@@ -92,11 +104,6 @@ type Slash = {
 }
 
 const CHAIN_WINDOW = 0.75 // seconds; a cut inside this extends the chain
-const MOTE_SECONDS = 4.2
-/** Harder questions get a little more clock. Never less than the base. */
-function moteSecondsFor(difficulty: number): number {
-  return MOTE_SECONDS + Math.max(0, Math.min(9, difficulty - 1)) * 0.2
-}
 
 export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   // ── surface ──────────────────────────────────────────────────────────────
@@ -147,11 +154,19 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
         ],
       },
       {
+        heading: "The market waits for you",
+        lines: [
+          "While a sum is up, the whole market stops. Nothing is thrown and no bombs come out.",
+          "Take as long as you need. A big sum keeps the lanterns up for much longer than a small one.",
+          "The market only starts again once you have answered, so answering is how you get it back.",
+        ],
+      },
+      {
         heading: "Your three lamps",
         lines: [
-          "You have three lamps. You lose one if you swipe a wrong answer.",
-          "You also lose one if you cut a bomb. Bombs are small and spiky and have a lit fuse.",
-          "Thinking is always free. If you run out of time on a question you keep every lamp.",
+          "You lose a lamp if you cut a bomb. Bombs are small and spiky and have a lit fuse.",
+          "A wrong answer never costs a lamp. It costs the market's favour, which is your multiplier.",
+          "Thinking is always free, and so is running out of time.",
           "When all three lamps go out the market shuts. One tap opens it again.",
         ],
       },
@@ -188,7 +203,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   let overAt = 0
   let score = 0
   let best = readBest()
-  let lamps = 3
+  let lamps = LAMPS
   let chain = 0
   let chainTimer = 0
   let bestChain = 0
@@ -213,24 +228,24 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   // points, it is worth all of your other points again. A wrong answer drops it
   // straight back to one. Guessing does not cost the child a lecture; it costs
   // them the entire economy.
+  //
+  // And the reason it is now the ONLY cost a wrong lantern carries. Stacking a
+  // lamp on top of it is what made never answering the rational play: a timeout
+  // cost a point of favour and nothing else, a wrong answer cost a lamp and all
+  // of it, so a child unsure of the sum was strictly better off letting the
+  // sigil expire. Lamps are spent on bombs now — the one hazard a child chooses
+  // to touch. See `economy.ts`.
   let favour = 1
   let favourLeft = 0
-  const FAVOUR_SECONDS = 9
-  const FAVOUR_MAX = 4
   /**
    * Progress toward relighting a lamp, in sigils read. Deliberately
-   * **cumulative, not consecutive**: three correct answers at any point in the
+   * **cumulative, not consecutive**: two correct answers at any point in the
    * run buy a lamp back, and a wrong one never takes that progress away. The
    * house rule against streak-keyed escalation is right — "don't break it" is
    * the anxiety this product does not sell — and a recovery meter that only
    * ever fills is both kinder and a better reason to keep reading.
    */
   let readCredit = 0
-  // Two, not three. At one sigil every ~4.5s this makes a child reading at 50%
-  // accuracy net-positive on lamps while a child guessing at 25% still bleeds
-  // out — which is the curve we want: a learner climbs, a button-masher does
-  // not, and neither ever gets a lecture.
-  const READ_PER_LAMP = 2
   let bestFavour = 1
   /**
    * Where the score actually came from. Exposed on the debug object so the
@@ -333,7 +348,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   let liveQ: Question | null = null
   let liveQAt = 0
   let moteLeft = 0
-  let moteWindow = MOTE_SECONDS
+  let moteWindow = moteSecondsFor(1)
   // Questions riding on sigils that are in the air but not yet cut, by id. A
   // Map and not a single slot: two sigils can legitimately overlap, and holding
   // one variable made the older tablet cut into nothing at all.
@@ -624,7 +639,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       m.bornAt = performance.now()
       // A candidate has to be *read* before it can be cut. Without this the
       // stroke that opened the tablet answered the question itself, in 0ms.
-      m.cuttableAt = m.bornAt + 420
+      m.cuttableAt = m.bornAt + CANDIDATE_READ_LOCK_MS
       m.glyphH = m.r * 1.24
       world.shape(m, rng)
     }
@@ -1056,21 +1071,27 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   ): void {
     const ms = Math.round(performance.now() - liveQAt)
     lastAnswerMs = ms
-    host.report({ questionId: qid, correct, ms, answered })
+    const verdict: Verdict = correct ? "correct" : "wrong"
+    if (reportsToCurriculum(verdict)) host.report({ questionId: qid, correct, ms, answered })
+    // The hush ends the instant the question is settled, whichever way it went.
+    // A child who answers hands the market back now; a child who lets it expire
+    // hands it back at the end of the window. That difference is the entire
+    // reason answering beats not answering.
+    director.settleQuestion()
 
     if (correct) {
       right++
       // Recovery is only earned while there is something to recover. Banking
       // credit at full lamps would make the first mistake of a long run free.
-      if (lamps < 3) readCredit = Math.min(READ_PER_LAMP, readCredit + 1)
+      if (lamps < LAMPS) readCredit = Math.min(READ_PER_LAMP, readCredit + 1)
       const q = liveQ
       // Favour is raised *before* the gain is scored, so the answer that earns
       // the multiplier is also the first thing paid at it.
-      favour = Math.min(FAVOUR_MAX, favour + 1)
+      favour = favourAfter(verdict, favour)
       favourLeft = FAVOUR_SECONDS
       bestFavour = Math.max(bestFavour, favour)
       const mult = scoreMul()
-      const gain = Math.round((320 + (q?.difficulty ?? 3) * 110) * mult)
+      const gain = answerGain(q?.difficulty ?? 3, mult)
       score += gain
       earnedAnswering += gain
       audio.ascend()
@@ -1106,11 +1127,11 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       // Three sigils read buys a lamp back. This is the "math instead of an ad"
       // beat: where a free-to-play game would show a video to continue, this
       // asks for arithmetic — and it never takes the progress away again.
-      if (readCredit >= READ_PER_LAMP && lamps < 3) {
+      if (readCredit >= READ_PER_LAMP && lamps < LAMPS) {
         lamps++
         readCredit -= READ_PER_LAMP
         audio.riser()
-        showBanner("A LAMP RELIT", "three sigils read", LAMP, 1.4)
+        showBanner("A LAMP RELIT", "two sigils read", LAMP, 1.4)
         host.haptic("success")
       }
     } else {
@@ -1123,8 +1144,13 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       vignette = 1
       chain = 0
       chainTimer = 0
-      // The whole economy, gone. This is the cost that makes guessing lose.
-      favour = 1
+      // The whole economy, gone — and that is now the *entire* cost. Favour
+      // multiplies every gourd, every prime and every cascade, so a wrong
+      // lantern is still the most expensive mistake in the game; it just no
+      // longer costs a lamp on top, because a lamp was the thing that made
+      // never answering the safe play. `lampCost` is where that is written
+      // down and `economy.test.ts` is where it is enforced.
+      favour = favourAfter(verdict, favour)
       favourLeft = 0
       // No bare red numeral floating over the field — the equation completes
       // itself instead, in the sigil's own colour. Never a lecture, never a
@@ -1132,7 +1158,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       if (liveQ) showBanner(`${liveQ.prompt} = ${liveQ.answer}`, "", SIGIL_HOT, 1.4)
       burst(x, y, WRONG, 26, 320)
       clearMotes(true)
-      loseLamp()
+      for (let i = 0; i < lampCost(verdict); i++) loseLamp()
     }
   }
 
@@ -1160,7 +1186,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   function restart(): void {
     over = false
     score = 0
-    lamps = 3
+    lamps = LAMPS
     chain = 0
     chainTimer = 0
     bestChain = 0
@@ -1413,10 +1439,27 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   function expireQuestion(): void {
     const q = liveQ
     if (!q) return
-    // Hesitation is never punished with damage — only with the missed bonus,
-    // and with favour cooling back toward one.
-    host.report({ questionId: q.id, correct: false, ms: Math.round(performance.now() - liveQAt), answered: "" })
-    favour = Math.max(1, favour - 1)
+    const verdict: Verdict = "timeout"
+    // **Nothing crosses the wire.** A window that closed on an untouched screen
+    // is not evidence that the child does not know the skill — it is evidence
+    // that they were still working, and the ladder is the one place that
+    // mistake compounds. It used to report `correct: false` here.
+    if (reportsToCurriculum(verdict)) {
+      host.report({
+        questionId: q.id,
+        correct: false,
+        ms: Math.round(performance.now() - liveQAt),
+        answered: "",
+      })
+    }
+    // Never punished with damage, and never with less than an honest wrong
+    // answer either: favour falls all the way to one, exactly as a wrong lantern
+    // does. What a timeout costs *more* of is market — the hush ran the whole
+    // window rather than ending at the cut.
+    favour = favourAfter(verdict, favour)
+    favourLeft = 0
+    for (let i = 0; i < lampCost(verdict); i++) loseLamp()
+    director.settleQuestion()
     showBanner(`${q.prompt} = ${q.answer}`, "", SIGIL_EDGE, 1.2)
     clearMotes(true)
   }
@@ -1715,7 +1758,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     // lamp to win back, so it is never decoration. Three filled ticks and the
     // dark lamp comes on — this is the game's "watch an ad to continue", and
     // the price is arithmetic.
-    if (lamps < 3) {
+    if (lamps < LAMPS) {
       for (let i = 0; i < READ_PER_LAMP; i++) {
         const t = tickRect(i, hud)
         ctx.fillStyle =

--- a/dynawalla/games/slice/src/sim/director.ts
+++ b/dynawalla/games/slice/src/sim/director.ts
@@ -23,6 +23,18 @@
 // a hard minimum number of live cuttable objects that the director tops up the
 // instant the field drops below it, on any viewport, at any tier. The timer
 // makes the market feel like it breathes; the floor makes sure it never stops.
+//
+// ── and the one thing that outranks it ──────────────────────────────────────
+//
+// The floor is a promise about the market. It is not a promise about the child's
+// attention, and it was being kept at the child's expense: `quiet` throttled the
+// wave timer and the wave size and never touched `floorCount()`, so the
+// guaranteed six-to-eight cuttable objects and the bomb spawner were both fully
+// enforced *while a live equation was on screen*. The moment the game had
+// designated for thinking was the busiest moment in it.
+//
+// `quiet` now stops the market outright, and the market comes back with a surge
+// rather than a trickle. Sparser around the answer, louder after it.
 
 import { Rng } from "../core/rng.ts"
 import type { NumberPool } from "./factor.ts"
@@ -68,6 +80,8 @@ export class Director {
     this.rushLeft = 0
     this.nextRushIn = FIRST_RUSH_AT
     this.rushCount = 0
+    this.quiet = false
+    this.surgeLeft = 0
     this.queue.length = 0
     this.queueT.length = 0
   }
@@ -102,9 +116,15 @@ export class Director {
   /**
    * The promise. At least this many cuttable objects are live at all times, on
    * every viewport. Nothing else in this file is allowed to break it.
+   *
+   * …except the hush, which is not a pacing knob but the child's own time. See
+   * `quiet`. The floor is a promise about the *market*, and while a question is
+   * up there is no market.
    */
   floorCount(): number {
+    if (this.quiet) return 0
     if (this.rushLeft > 0) return 11
+    if (this.surgeLeft > 0) return Math.round(8 + this.heat * 6)
     return Math.round(4 + this.heat * 6)
   }
 
@@ -118,23 +138,64 @@ export class Director {
     if (this.rushLeft > 0) return 0.32
     const h = this.heat
     const base = 1.18 - h * 0.68 // 1.18s → 0.50s
-    // A live question thins the market; it must never freeze it. 1.5× used to
-    // stack with a 4.2s answer window and put the game in slow motion for a
-    // third of every minute.
-    return this.quiet ? base * 1.14 : base
+    // The market comes back louder than it left. A question is a held breath and
+    // the breath has to be let out, or "sparser" reads as "the game got worse".
+    return this.surgeLeft > 0 ? base * 0.55 : base
   }
 
-  /** Set while a question is on screen; the market throttles, never stops. */
+  /**
+   * Set while a question is on screen. **The market stops.**
+   *
+   * It used to throttle: the wave timer stretched by 14% and the wave shrank to
+   * two or three — and `floorCount()` was never consulted, so the guaranteed six
+   * to eight cuttable objects and the bomb spawner ran at full strength while
+   * the child was doing arithmetic. The moment designated for thinking was the
+   * busiest moment in the game.
+   *
+   * A designated thinking moment either pauses everything that competes for the
+   * child's attention or it is not a thinking moment. So while this is set the
+   * director launches nothing at all: no waves, no floor top-up, no bombs, no
+   * further sigils, and no rush may open across it. Objects already in the air
+   * finish their arcs and retire; the field empties in about two seconds and
+   * stays empty until the question is settled.
+   *
+   * That is also, quietly, the whole stakes model. The hush lasts exactly as
+   * long as the question does, so letting a sigil expire costs the child every
+   * second of market they could have been cutting — which is how a timeout comes
+   * to cost *more* than an honest wrong answer without ever costing a lamp. See
+   * `economy.ts`, `marketHushSeconds`.
+   */
   quiet = false
+
+  /** Seconds of the post-question surge remaining. */
+  surgeLeft = 0
+
+  /**
+   * The question settled. Let the breath out, and do not fire the next sigil
+   * straight into the child's face.
+   *
+   * The settle gap matters more than it looks: `nextSigilIn` used to keep
+   * counting down through the whole live question, so it was always due the
+   * instant the question resolved. With a comprehension-sized window that would
+   * put the next tablet in the air before the favour wave had finished
+   * sweeping, forever.
+   */
+  settleQuestion(): void {
+    this.surgeLeft = 2.6
+    this.nextSigilIn = Math.max(this.nextSigilIn, this.sigilInterval() * 0.85)
+  }
+
+  private sigilInterval(): number {
+    return 6.2 - this.heat * 2.6
+  }
 
   private waveSize(): number {
     if (this.rushLeft > 0) return this.rng.int(4, 7)
     const h = this.heat
-    if (this.quiet) return this.rng.int(2, 3)
     // Never one lonely object: an empty screen in the first ten seconds is the
     // difference between "a game" and "a worksheet with a countdown".
-    const lo = 3 + Math.floor(h * 3)
-    const hi = 4 + Math.floor(h * 4)
+    const lo = 3 + Math.floor(h * 3) + (this.surgeLeft > 0 ? 2 : 0)
+    const hi = 4 + Math.floor(h * 4) + (this.surgeLeft > 0 ? 3 : 0)
     return this.rng.int(lo, hi)
   }
 
@@ -220,6 +281,17 @@ export class Director {
     this.elapsed += dt
     let n = 0
 
+    // ── the hush ────────────────────────────────────────────────────────────
+    //
+    // Nothing is launched, nothing is queued, and no timer moves. Heat still
+    // climbs with `elapsed`, because heat is how long the child has been playing
+    // and thinking is playing — but every clock that would *put something on
+    // screen* is frozen, including the rush. A rush opening over a live equation
+    // would be the loudest possible contradiction of the word "quiet".
+    if (this.quiet) return 0
+
+    if (this.surgeLeft > 0) this.surgeLeft -= dt
+
     if (this.rushLeft > 0) {
       this.rushLeft -= dt
       // The crest passed and the board is coming down. THE SPLIT has no
@@ -287,7 +359,7 @@ export class Director {
       // may refuse the launch (a tablet is already in the air, or a question is
       // live); `sigilRefused` reschedules it in a moment rather than dropping
       // it, which is what used to stretch the real gap out to 10.6 seconds.
-      this.nextSigilIn = (6.2 - this.heat * 2.6) * this.rng.range(0.92, 1.1)
+      this.nextSigilIn = this.sigilInterval() * this.rng.range(0.92, 1.1)
       this.queue.push({
         kind: "sigil",
         value: 0,

--- a/dynawalla/games/slice/src/sim/economy.ts
+++ b/dynawalla/games/slice/src/sim/economy.ts
@@ -1,0 +1,189 @@
+// What a question costs, what it pays, and how long the child gets.
+//
+// This used to be five constants and three `if`s scattered through a 2,000-line
+// `mount.ts`, which is why nothing noticed that they added up to a game where
+// **the winning move was to never answer**:
+//
+//   * a wrong lantern cost a lamp;
+//   * a timeout cost nothing but a point of favour;
+//   * and the window was 4.2 s, of which 0.42 s is spent under the read-lock, so
+//     3.78 s of it was usable — against this repo's own 6 s p50 for the exact
+//     skill `pack.json` declares.
+//
+// A child who read the equation honestly could not finish inside the window, and
+// a child who guessed to beat the window lost a lamp three times in four. The
+// only strategy that never lost anything was to let every sigil expire. The
+// pressure did not make the game harder. It made the maths optional.
+//
+// Everything that decides that is in this file, it is pure, and
+// `economy.test.ts` plays bots against it.
+
+/**
+ * `EXPERIENCE_DESIGN.md`'s cadence table, in milliseconds. Instrumented p50/p90,
+ * never shown to the child.
+ */
+export const CADENCE = {
+  /** `7 × 8`. */
+  fact: { p50: 2800, p90: 6000 },
+  /** `47 + 25`, carry and all — the middle of what `pack.json` declares. */
+  regroup: { p50: 6000, p90: 14000 },
+  /** `5,001 − 2,798` — `dw.add.regroup.subtract-across-zero`, also declared. */
+  wide: { p50: 16000, p90: 40000 },
+} as const
+
+const ANCHORS = [CADENCE.fact, CADENCE.regroup, CADENCE.wide] as const
+
+/**
+ * A candidate cannot be cut for this long after it is hoisted.
+ *
+ * It exists so the stroke that opens the tablet cannot also answer the question,
+ * and it is real time the child does not have. Every window below is quoted
+ * gross and *usable*, and the invariant is on the usable one.
+ */
+export const CANDIDATE_READ_LOCK_MS = 420
+
+/** Host difficulty runs 1…10. */
+export const MIN_DIFFICULTY = 1
+export const MAX_DIFFICULTY = 10
+
+/**
+ * Where an item of this difficulty sits on the cadence table's axis, 1…3.
+ *
+ * Strictly non-decreasing in `difficulty`, which is what makes every window
+ * derived from it non-decreasing too — the fleet invariant. A harder item may
+ * never get less time than an easier one.
+ */
+export function comprehensionLoad(difficulty: number): number {
+  const d = Math.max(MIN_DIFFICULTY, Math.min(MAX_DIFFICULTY, difficulty))
+  return 1 + ((d - MIN_DIFFICULTY) / (MAX_DIFFICULTY - MIN_DIFFICULTY)) * 2
+}
+
+function interpolate(load: number, key: "p50" | "p90"): number {
+  const clamped = Math.max(1, Math.min(3, load))
+  const lo = Math.min(1, Math.max(0, Math.ceil(clamped) - 2))
+  const t = clamped - (lo + 1)
+  const a = ANCHORS[lo] ?? CADENCE.fact
+  const b = ANCHORS[lo + 1] ?? CADENCE.wide
+  return a[key] + (b[key] - a[key]) * t
+}
+
+/** Half the class is done by here. This is the beat, not the window. */
+export function comprehensionP50Ms(difficulty: number): number {
+  return interpolate(comprehensionLoad(difficulty), "p50")
+}
+
+/** Nine in ten are done by here. This is what a window has to be. */
+export function comprehensionP90Ms(difficulty: number): number {
+  return interpolate(comprehensionLoad(difficulty), "p90")
+}
+
+/**
+ * How long the lanterns hang, in seconds.
+ *
+ * p90 for the item's class **plus** the read-lock, so that the time a child can
+ * actually act in is never less than the time the repo measured them needing. It
+ * was `4.2 + (difficulty − 1) × 0.2`, which topped out at 6 s gross for the
+ * hardest item the pack covers — against a 40 s p90.
+ */
+export function moteSecondsFor(difficulty: number): number {
+  return usableAnswerSeconds(difficulty) + CANDIDATE_READ_LOCK_MS / 1000
+}
+
+/**
+ * The part of the window a child can actually cut in, and the number the fleet
+ * invariant is quoted against. Derived first, so no float rounding can shave a
+ * millisecond off the p90 on its way back out of `moteSecondsFor`.
+ */
+export function usableAnswerSeconds(difficulty: number): number {
+  return comprehensionP90Ms(difficulty) / 1000
+}
+
+// ── what an answer is worth, and what it costs ──────────────────────────────
+
+export type Verdict = "correct" | "wrong" | "timeout"
+
+export const FAVOUR_MAX = 4
+export const FAVOUR_SECONDS = 9
+/** Sigils read to buy a lamp back. Cumulative, never consecutive. */
+export const READ_PER_LAMP = 2
+export const LAMPS = 3
+
+/**
+ * Lamps a verdict costs. **Zero, for all three.**
+ *
+ * This is the fix, and it is a subtraction rather than an addition. The rule the
+ * audit set is that a timeout may never cost *less* than an honest wrong answer,
+ * because the moment it does, not-answering strictly dominates answering and the
+ * arithmetic becomes optional. There are two ways to satisfy that and only one
+ * of them is allowed: taking a lamp on a timeout punishes a child for still
+ * thinking, which is the one thing this product does not do. So the wrong answer
+ * gives its lamp up instead.
+ *
+ * A wrong lantern still costs the whole economy — favour drops to one, and
+ * favour multiplies *everything*, every gourd and every prime and every cascade.
+ * That was always the real deterrent to guessing; the lamp was a second, harsher
+ * one stacked on top of it, and it was the reason a rational child never
+ * answered at all. Lamps are now spent on bombs, which are the one hazard a
+ * child chooses to touch.
+ */
+export function lampCost(verdict: Verdict): number {
+  void verdict
+  return 0
+}
+
+/**
+ * Favour after a verdict.
+ *
+ * Correct climbs; **wrong and timeout both fall all the way to one**. Equal, to
+ * the point. The timeout used to cost a single point where a wrong answer cost
+ * the lot, which is the same inversion the lamp made.
+ */
+export function favourAfter(verdict: Verdict, favour: number): number {
+  if (verdict === "correct") return Math.min(FAVOUR_MAX, favour + 1)
+  return 1
+}
+
+/**
+ * Whether a verdict is evidence about the child, fit to send to the ladder.
+ *
+ * A timeout is not. A child who was still computing is not a child who does not
+ * know the skill, and the ladder is the one place that mistake compounds: it
+ * would feed them easier items, which is exactly the wrong medicine for somebody
+ * who is merely deliberate. The game still charges the timeout — see
+ * `marketHushSeconds` — it just does not lie to the curriculum about it.
+ */
+export function reportsToCurriculum(verdict: Verdict): boolean {
+  return verdict !== "timeout"
+}
+
+/** What a correct lantern pays, before the favour wave doubles it. */
+export function answerGain(difficulty: number, mult: number): number {
+  return Math.round((320 + difficulty * 110) * mult)
+}
+
+/**
+ * How long the market stays hushed for, given a verdict at `answeredAtSeconds`.
+ *
+ * **This is where a timeout costs more than a wrong answer.**
+ *
+ * The market holds its breath for as long as a question is live — see
+ * `Director.quiet`, which is now genuinely quiet — so the hush ends when the
+ * question is settled, however it is settled. A child who answers, right or
+ * wrong, hands the market back at the moment they cut. A child who lets the
+ * sigil expire hands it back at the end of the window, and everything they could
+ * have been slicing in between is gone.
+ *
+ * So the cost ordering is: correct (short hush, plus favour, plus the wave) <
+ * wrong (short hush, favour gone) < timeout (the entire window, favour gone).
+ * Never-answering is strictly dominated, and nothing in that chain punishes a
+ * slow child — the time a deliberate child spends is time they are using.
+ */
+export function marketHushSeconds(
+  verdict: Verdict,
+  difficulty: number,
+  answeredAtSeconds: number,
+): number {
+  const window = moteSecondsFor(difficulty)
+  if (verdict === "timeout") return window
+  return Math.max(0, Math.min(window, answeredAtSeconds))
+}

--- a/dynawalla/games/slice/src/test/director.test.ts
+++ b/dynawalla/games/slice/src/test/director.test.ts
@@ -214,3 +214,119 @@ test("rushes get longer and closer together, forever", () => {
     `last rush ${lengths.at(-1)}s vs first ${lengths[0]}s`,
   )
 })
+
+// ── the hush ────────────────────────────────────────────────────────────────
+//
+// `quiet` used to throttle the wave timer by 14% and shrink the wave to two or
+// three objects — and never touch `floorCount()`, which is the only thing in
+// this file that actually promises anything. So while a child was working out
+// `47 + 25`, the director was still topping the field up to its guaranteed six
+// to eight cuttable objects and still rolling for bombs on every one of them.
+// The moment designated for thinking was the busiest moment in the game.
+//
+// A designated thinking moment either pauses everything that competes for the
+// child's attention or it is not a thinking moment. These are the tests that say
+// so, and the *last* one is the one that stops the fix from becoming a nerf.
+
+test("nothing at all is launched while a question is live", () => {
+  const d = new Director(new Rng(21), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  // Run the market up to full heat first, so this is the hardest case: a hush
+  // at minute ten, when the floor would otherwise be at its highest.
+  for (let i = 0; i < 60 * 600; i++) d.step(1 / 60, out, 6)
+
+  d.quiet = true
+  let launched = 0
+  for (let i = 0; i < 60 * 45; i++) {
+    // `live = 0` is a starved field — the exact condition that used to make the
+    // floor fire a top-up wave immediately.
+    launched += d.step(1 / 60, out, 0)
+  }
+  assert.equal(launched, 0, `${launched} objects were thrown at a child who was reading`)
+  assert.equal(d.floorCount(), 0, "the density floor still applies during a hush")
+})
+
+test("no bomb is ever spawned into a live question", () => {
+  const d = new Director(new Rng(22), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  let bombs = 0
+  for (let i = 0; i < 60 * 600; i++) {
+    // Alternate ten seconds of market with ten of hush, all run long enough for
+    // the bomb rate to be at its ceiling.
+    d.quiet = Math.floor(i / (60 * 10)) % 2 === 1
+    const n = d.step(1 / 60, out, 4)
+    if (!d.quiet) continue
+    for (let k = 0; k < n; k++) if ((out[k] as Throw).kind === "bomb") bombs++
+  }
+  assert.equal(bombs, 0, `${bombs} bombs landed during a hush`)
+})
+
+test("no second sigil, and no market rush, opens across a live question", () => {
+  const d = new Director(new Rng(23), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  for (let i = 0; i < 60 * 30; i++) d.step(1 / 60, out, 6)
+  const rushesBefore = d.rushCount
+  d.quiet = true
+  let sigils = 0
+  // Forty seconds — the whole window the hardest item in the pack is given.
+  for (let i = 0; i < 60 * 40; i++) {
+    const n = d.step(1 / 60, out, 6)
+    for (let k = 0; k < n; k++) if ((out[k] as Throw).kind === "sigil") sigils++
+  }
+  assert.equal(sigils, 0, "a second tablet was offered while one was being read")
+  assert.equal(d.rushCount, rushesBefore, "a MARKET RUSH opened over a live equation")
+  assert.ok(d.rushLeft <= 0, `a rush was running with ${String(d.rushLeft)}s left`)
+})
+
+test("the market comes back louder than it left", () => {
+  // The fix must not read as "the game got worse". A question is a held breath
+  // and the breath is let out: `settleQuestion` raises the floor and shortens
+  // the wave interval for a couple of seconds.
+  const d = new Director(new Rng(24), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  for (let i = 0; i < 60 * 120; i++) d.step(1 / 60, out, 6)
+  const calm = d.floorCount()
+
+  d.quiet = true
+  for (let i = 0; i < 60 * 8; i++) d.step(1 / 60, out, 0)
+  d.quiet = false
+  d.settleQuestion()
+  assert.ok(d.floorCount() > calm, `surge floor ${d.floorCount()} did not beat calm ${calm}`)
+
+  let launched = 0
+  for (let i = 0; i < 60 * 2; i++) launched += d.step(1 / 60, out, 0)
+  assert.ok(launched >= calm, `only ${launched} objects in the two seconds after an answer`)
+})
+
+test("the hush ends and the floor is restored within a second", () => {
+  const d = new Director(new Rng(25), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  for (let i = 0; i < 60 * 200; i++) d.step(1 / 60, out, 6)
+  d.quiet = true
+  for (let i = 0; i < 60 * 20; i++) d.step(1 / 60, out, 0)
+  d.quiet = false
+  d.settleQuestion()
+  let launched = 0
+  for (let i = 0; i < 60; i++) launched += d.step(1 / 60, out, 0)
+  assert.ok(launched >= 4, `only ${launched} objects in the first second back`)
+})
+
+test("the next sigil is not fired into the child's face the moment they answer", () => {
+  // `nextSigilIn` used to keep counting down through the whole live question, so
+  // it was always overdue the instant the question resolved. With a
+  // comprehension-sized window that would put the next tablet in the air before
+  // the favour wave had finished sweeping, every single time.
+  const d = new Director(new Rng(26), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  for (let i = 0; i < 60 * 120; i++) d.step(1 / 60, out, 6)
+  d.quiet = true
+  for (let i = 0; i < 60 * 30; i++) d.step(1 / 60, out, 0)
+  d.quiet = false
+  d.settleQuestion()
+  let sigils = 0
+  for (let i = 0; i < 60 * 2; i++) {
+    const n = d.step(1 / 60, out, 6)
+    for (let k = 0; k < n; k++) if ((out[k] as Throw).kind === "sigil") sigils++
+  }
+  assert.equal(sigils, 0, "the next tablet arrived within two seconds of the last answer")
+})

--- a/dynawalla/games/slice/src/test/economy.test.ts
+++ b/dynawalla/games/slice/src/test/economy.test.ts
@@ -1,0 +1,454 @@
+// The dominant strategy, measured.
+//
+// The audit's finding about THE SPLIT was not "the window is a bit tight". It
+// was that **not doing the maths was the winning move**, and that is a claim
+// about an ordering of strategies, so it is testable and it was never tested.
+//
+// Three numbers made it true:
+//
+//   1. the answer window was 4.2 s gross, 3.78 s usable after the read-lock,
+//      against this repo's own 6 s p50 for the two-digit regrouping skills
+//      `pack.json` declares — so a child reading honestly could not finish;
+//   2. a wrong lantern cost a lamp and a timeout cost nothing, so a child who
+//      could not finish was better off letting the sigil expire than guessing;
+//   3. `quiet` throttled the wave timer and the wave size and never touched
+//      `floorCount()`, so the market kept its guaranteed six-to-eight objects
+//      and its bomb spawner running the whole time — which meant refusing to
+//      engage was not even a pause. It was uninterrupted slicing.
+//
+// The bots below play both rulebooks over the same seeds. The old one is not a
+// straw man: it is the three functions this game shipped with, inlined.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  answerGain,
+  CADENCE,
+  CANDIDATE_READ_LOCK_MS,
+  comprehensionP50Ms,
+  comprehensionP90Ms,
+  favourAfter,
+  lampCost,
+  LAMPS,
+  marketHushSeconds,
+  moteSecondsFor,
+  reportsToCurriculum,
+  usableAnswerSeconds,
+  type Verdict,
+} from "../sim/economy.ts"
+
+// ── the window ──────────────────────────────────────────────────────────────
+
+test("the usable window is monotone non-decreasing in difficulty", () => {
+  // The fleet invariant. A harder item may never get less time than an easier
+  // one — not by a millisecond, at any difficulty, ever.
+  let previous = 0
+  for (let d = 1; d <= 10; d++) {
+    const s = usableAnswerSeconds(d)
+    assert.ok(s >= previous, `difficulty ${String(d)} got ${s.toFixed(2)}s after ${previous.toFixed(2)}s`)
+    previous = s
+  }
+})
+
+test("no item gets less usable window than the child's measured p90", () => {
+  // Usable, not gross: 420 ms of every window is spent under the read-lock that
+  // stops the stroke which opened the tablet from also answering it. That is
+  // real time the child does not have, so the invariant is quoted net of it.
+  for (let d = 1; d <= 10; d++) {
+    const usable = usableAnswerSeconds(d) * 1000
+    assert.ok(
+      usable >= comprehensionP90Ms(d),
+      `difficulty ${String(d)}: ${(usable / 1000).toFixed(2)}s usable against a ${(comprehensionP90Ms(d) / 1000).toFixed(1)}s p90`,
+    )
+  }
+})
+
+test("the declared skills get the cadence the declared skills were measured at", () => {
+  // `pack.json` covers `dw.add.regroup.*` including `subtract-across-zero`. The
+  // table's own rows for those are 6 s / 14 s and 16 s / 40 s.
+  assert.ok(usableAnswerSeconds(1) * 1000 >= CADENCE.fact.p90)
+  assert.ok(usableAnswerSeconds(10) * 1000 >= CADENCE.wide.p90)
+  assert.ok(comprehensionP50Ms(1) === CADENCE.fact.p50)
+  assert.ok(comprehensionP50Ms(10) === CADENCE.wide.p50)
+})
+
+test("the shipped window, and this one, per difficulty", () => {
+  const shipped = (d: number): number => 4.2 + Math.max(0, Math.min(9, d - 1)) * 0.2
+  const rows = []
+  for (let d = 1; d <= 10; d++) {
+    const beforeUsable = shipped(d) - CANDIDATE_READ_LOCK_MS / 1000
+    const afterUsable = usableAnswerSeconds(d)
+    rows.push({
+      difficulty: d,
+      p50s: (comprehensionP50Ms(d) / 1000).toFixed(1),
+      p90s: (comprehensionP90Ms(d) / 1000).toFixed(1),
+      beforeUsableS: beforeUsable.toFixed(2),
+      beforePctOfP50: `${((beforeUsable * 1000) / comprehensionP50Ms(d) * 100).toFixed(0)}%`,
+      afterUsableS: afterUsable.toFixed(2),
+      afterPctOfP50: `${((afterUsable * 1000) / comprehensionP50Ms(d) * 100).toFixed(0)}%`,
+    })
+  }
+  console.table(rows)
+  // The property the table exists to show: the shipped window gave a smaller
+  // share of the child's need the harder the item got. The ramp was inverted.
+  const first = (shipped(1) * 1000 - CANDIDATE_READ_LOCK_MS) / comprehensionP50Ms(1)
+  const last = (shipped(10) * 1000 - CANDIDATE_READ_LOCK_MS) / comprehensionP50Ms(10)
+  assert.ok(last < first, "the old ramp was not inverted after all — re-derive this whole file")
+})
+
+// ── the costs ───────────────────────────────────────────────────────────────
+
+test("a timeout never costs less than an honest wrong answer", () => {
+  // The rule the whole failure comes down to. Lamps equal, favour equal — and
+  // the tiebreak, market time, goes *against* the timeout. See below.
+  assert.equal(lampCost("timeout"), lampCost("wrong"))
+  assert.equal(favourAfter("timeout", 4), favourAfter("wrong", 4))
+  assert.equal(favourAfter("timeout", 4), 1)
+})
+
+test("no verdict costs a lamp — a slow child is never a punished child", () => {
+  // The other half of the same rule. There are two ways to stop a timeout being
+  // cheaper than a wrong answer and only one of them is allowed: charging the
+  // timeout a lamp would bill a child for still thinking.
+  for (const v of ["correct", "wrong", "timeout"] as const) assert.equal(lampCost(v), 0)
+})
+
+test("a timeout is not reported to the ladder as a wrong answer", () => {
+  assert.equal(reportsToCurriculum("correct"), true)
+  assert.equal(reportsToCurriculum("wrong"), true)
+  assert.equal(reportsToCurriculum("timeout"), false)
+})
+
+test("a timeout costs the whole market; an answer hands it straight back", () => {
+  const d = 5
+  const window = moteSecondsFor(d)
+  assert.equal(marketHushSeconds("timeout", d, window), window)
+  assert.ok(marketHushSeconds("correct", d, 3) < window)
+  assert.ok(marketHushSeconds("wrong", d, 3) < window)
+  // Strictly more, for every answering time the window allows.
+  for (let at = 0; at < window; at += 0.5) {
+    assert.ok(
+      marketHushSeconds("timeout", d, at) >= marketHushSeconds("wrong", d, at),
+      `answering at ${at.toFixed(1)}s cost more market than refusing to`,
+    )
+  }
+})
+
+// ── the bots ────────────────────────────────────────────────────────────────
+
+/** The three functions that decide whether the maths is optional. */
+type Rules = {
+  readonly name: string
+  usableSeconds(difficulty: number): number
+  lampCost(verdict: Verdict): number
+  favourAfter(verdict: Verdict, favour: number): number
+  /** Seconds of market the child loses to a question settled this way. */
+  hushSeconds(verdict: Verdict, difficulty: number, atSeconds: number): number
+  /** Does the market keep throwing while an equation is on screen? */
+  readonly marketAliveDuringQuestion: boolean
+}
+
+const AFTER: Rules = {
+  name: "after",
+  usableSeconds: usableAnswerSeconds,
+  lampCost,
+  favourAfter,
+  hushSeconds: marketHushSeconds,
+  marketAliveDuringQuestion: false,
+}
+
+/** The three functions THE SPLIT shipped with, inlined verbatim. */
+const BEFORE: Rules = {
+  name: "before",
+  usableSeconds: (d) => 4.2 + Math.max(0, Math.min(9, d - 1)) * 0.2 - CANDIDATE_READ_LOCK_MS / 1000,
+  lampCost: (v) => (v === "wrong" ? 1 : 0),
+  favourAfter: (v, f) => (v === "correct" ? Math.min(4, f + 1) : v === "wrong" ? 1 : Math.max(1, f - 1)),
+  // `quiet` throttled two knobs and left the density floor and the bomb spawner
+  // alone, so a live question cost the child nothing they were not choosing to
+  // spend. Refusing to engage was uninterrupted slicing.
+  hushSeconds: () => 0,
+  marketAliveDuringQuestion: true,
+}
+
+type Bot = {
+  readonly name: string
+  /** Seconds this child needs to work the item out. `Infinity` = never engages. */
+  readSeconds(difficulty: number, rng: Rng): number
+  /** Given that they finished in time, are they right? */
+  isRight(rng: Rng): boolean
+}
+
+/** Never touches a lantern. The strategy the format has to defeat. */
+const REFUSER: Bot = {
+  name: "never answers",
+  readSeconds: () => Number.POSITIVE_INFINITY,
+  isRight: () => false,
+}
+
+/**
+ * Reads the equation and works it out, at the pace this repo says a child works
+ * at: a spread whose median is the table's p50 and whose ninth decile is its
+ * p90. Right nine times in ten once they have finished.
+ */
+const READER: Bot = {
+  name: "reads it, honestly and slowly",
+  readSeconds: (d, rng) => {
+    const p50 = comprehensionP50Ms(d) / 1000
+    const p90 = comprehensionP90Ms(d) / 1000
+    // Log-normal through the two quantiles: exp(mu) = p50, and the 1.2816 is the
+    // standard normal's 90th percentile.
+    const mu = Math.log(p50)
+    const sigma = Math.log(p90 / p50) / 1.2816
+    // Box–Muller off the seeded stream; no Math.random anywhere in this file.
+    const u1 = Math.max(1e-9, rng.next())
+    const u2 = rng.next()
+    const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2)
+    return Math.exp(mu + sigma * z)
+  },
+  isRight: (rng) => rng.chance(0.9),
+}
+
+/**
+ * Works it out and gets it right — and takes the number of seconds this repo
+ * says that costs. Right every single time, once finished.
+ *
+ * This is the bot the audit named: "answers correctly but slowly". It carries no
+ * distribution and no luck, so what it measures is unambiguous — whether a child
+ * working at the documented pace can land an answer at all.
+ */
+const SLOW_READER: Bot = {
+  name: "answers correctly, at the documented p50",
+  readSeconds: (d) => comprehensionP50Ms(d) / 1000,
+  isRight: () => true,
+}
+
+/** Swipes a lantern the moment it can. One in four. */
+const GUESSER: Bot = {
+  name: "guesses immediately",
+  readSeconds: () => 0.05,
+  isRight: (rng) => rng.chance(0.25),
+}
+
+type RunOptions = {
+  readonly seconds: number
+  readonly difficulty: number
+  /** Points a second of live market is worth at multiplier one. */
+  readonly slicePerSecond: number
+  /** Seconds of live market between sigils. */
+  readonly sigilGap: number
+  /** Chance per live-market second that the child clips a bomb. */
+  readonly bombPerSecond: number
+}
+
+type RunResult = { score: number; answered: number; correct: number; lampsLost: number; survived: number }
+
+/**
+ * One run, in market-seconds.
+ *
+ * Deliberately coarse: slicing is an income rate rather than a physics sim, and
+ * a question is a hole in that income. What it models exactly is the only thing
+ * under test — what each of the three ways a question can end actually costs.
+ */
+function simulate(rules: Rules, bot: Bot, seed: number, o: RunOptions): RunResult {
+  const rng = new Rng(seed)
+  let t = 0
+  let lamps = LAMPS
+  let favour = 1
+  let score = 0
+  let answered = 0
+  let correct = 0
+  let lampsLost = 0
+  let untilSigil = o.sigilGap
+  const step = 0.1
+
+  while (t < o.seconds && lamps > 0) {
+    // A live market second: income, and a chance of clipping a bomb.
+    score += o.slicePerSecond * favour * step
+    if (rng.chance(o.bombPerSecond * step)) {
+      lamps -= 1
+      lampsLost += 1
+      favour = 1
+      if (lamps <= 0) break
+    }
+    t += step
+    untilSigil -= step
+    if (untilSigil > 0) continue
+
+    // ── a sigil ───────────────────────────────────────────────────────────
+    untilSigil = o.sigilGap
+    const usable = rules.usableSeconds(o.difficulty)
+    const need = bot.readSeconds(o.difficulty, rng)
+    const finished = need <= usable
+    const verdict: Verdict = !finished ? "timeout" : bot.isRight(rng) ? "correct" : "wrong"
+    const at = finished ? need : usable
+
+    if (verdict === "correct") {
+      answered++
+      correct++
+      favour = rules.favourAfter(verdict, favour)
+      // The answer, and the favour wave it fires: the wave doubles, and it opens
+      // roughly a second's worth of market all at once.
+      score += answerGain(o.difficulty, favour) + o.slicePerSecond * favour * 2
+    } else {
+      if (verdict === "wrong") answered++
+      favour = rules.favourAfter(verdict, favour)
+    }
+    lamps -= rules.lampCost(verdict)
+    lampsLost += rules.lampCost(verdict)
+    if (lamps <= 0) break
+
+    // The hole the question left. Under the old rules the market never stopped,
+    // so a refusing child kept earning right through it; a reading child did
+    // not, because they were reading.
+    const hush = rules.hushSeconds(verdict, o.difficulty, at)
+    const blind = rules.marketAliveDuringQuestion ? (Number.isFinite(need) ? Math.min(need, usable) : 0) : hush
+    // Bomb exposure continues wherever the market is alive.
+    if (rules.marketAliveDuringQuestion) {
+      const exposed = Number.isFinite(need) ? Math.min(need, usable) : usable
+      if (rng.chance(o.bombPerSecond * exposed * 0.5)) {
+        lamps -= 1
+        lampsLost += 1
+        favour = 1
+      }
+      // A refusing child was slicing right through the window.
+      if (!Number.isFinite(need)) score += o.slicePerSecond * favour * usable
+    }
+    t += Math.max(blind, Number.isFinite(need) ? Math.min(need, usable) : usable)
+  }
+
+  return { score, answered, correct, lampsLost, survived: Math.min(t, o.seconds) }
+}
+
+function meanScore(rules: Rules, bot: Bot, o: RunOptions, runs = 60): number {
+  let total = 0
+  for (let i = 0; i < runs; i++) total += simulate(rules, bot, 1000 + i * 7919, o).score
+  return total / runs
+}
+
+const BASE: RunOptions = {
+  seconds: 300,
+  difficulty: 5,
+  slicePerSecond: 120,
+  sigilGap: 6,
+  bombPerSecond: 0.01,
+}
+
+test("BEFORE: never answering outscored answering correctly but slowly", () => {
+  // The defect, played out. Not an assertion about the fix — an assertion about
+  // what the game shipped as, kept green so the "before" column cannot rot.
+  //
+  // The slow reader is right every time. It loses no lamps, guesses at nothing
+  // and makes no mistakes. It simply takes the number of seconds this repo says
+  // the item takes, and the window it shipped with was shorter than that — so it
+  // never landed a single answer, and paid for the attempt in market time it did
+  // not spend slicing.
+  const refuser = meanScore(BEFORE, REFUSER, BASE)
+  const reader = meanScore(BEFORE, SLOW_READER, BASE)
+  const landed = simulate(BEFORE, SLOW_READER, 4242, BASE).answered
+  console.log(
+    `  before: refuser ${refuser.toFixed(0)} vs correct-but-slow ${reader.toFixed(0)} ` +
+      `(${String(landed)} answers landed in ${String(BASE.seconds)}s)`,
+  )
+  assert.equal(landed, 0, "the shipped window was answerable at the documented p50 after all")
+  assert.ok(
+    refuser > reader,
+    `the old rules did not actually favour refusing: ${refuser.toFixed(0)} vs ${reader.toFixed(0)}`,
+  )
+})
+
+test("BEFORE: refusing also beat guessing, which is the same bug from the other side", () => {
+  // A child at second 3.7 with the sum half-done had two moves: swipe, or let it
+  // go. Swiping cost a lamp three times in four. Letting it go cost one point of
+  // favour. The rational play was to look away.
+  const refuser = meanScore(BEFORE, REFUSER, BASE)
+  const guesser = meanScore(BEFORE, GUESSER, BASE)
+  assert.ok(
+    refuser > guesser,
+    `guessing was already worse than refusing: ${guesser.toFixed(0)} vs ${refuser.toFixed(0)}`,
+  )
+})
+
+test("AFTER: answering correctly but slowly beats never answering, at every difficulty", () => {
+  // The inversion, directly. Same bot, same seeds, same market.
+  for (let difficulty = 1; difficulty <= 10; difficulty++) {
+    const o = { ...BASE, difficulty }
+    const refuser = meanScore(AFTER, REFUSER, o)
+    const reader = meanScore(AFTER, SLOW_READER, o)
+    assert.ok(
+      reader > refuser,
+      `difficulty ${String(difficulty)}: refusing scored ${refuser.toFixed(0)}, correct-but-slow scored ${reader.toFixed(0)}`,
+    )
+  }
+})
+
+test("AFTER: reading the equation beats refusing to, at every difficulty", () => {
+  for (let difficulty = 1; difficulty <= 10; difficulty++) {
+    const o = { ...BASE, difficulty }
+    const refuser = meanScore(AFTER, REFUSER, o)
+    const reader = meanScore(AFTER, READER, o)
+    assert.ok(
+      reader > refuser,
+      `difficulty ${String(difficulty)}: refusing scored ${refuser.toFixed(0)}, reading scored ${reader.toFixed(0)}`,
+    )
+  }
+})
+
+test("AFTER: reading beats refusing however much the slicing is worth", () => {
+  // The one parameter a reader could reasonably argue about is how much a second
+  // of market is worth. So it is swept rather than chosen: the ordering has to
+  // survive a market worth ten times as much per second as this one.
+  for (const slicePerSecond of [20, 60, 120, 240, 600, 1200]) {
+    const o = { ...BASE, slicePerSecond }
+    const refuser = meanScore(AFTER, REFUSER, o)
+    const reader = meanScore(AFTER, READER, o)
+    assert.ok(
+      reader > refuser,
+      `at ${String(slicePerSecond)} points/s: refusing ${refuser.toFixed(0)}, reading ${reader.toFixed(0)}`,
+    )
+  }
+})
+
+test("AFTER: reading beats guessing, which beats refusing", () => {
+  // The whole ordering, in one line. Guessing above refusing is correct and
+  // deliberate: engaging badly must still beat not engaging, or the game is
+  // teaching a child that the safe move is to look away. Reading above guessing
+  // is what keeps it real maths — a guesser burns the favour economy three
+  // times in four.
+  const refuser = meanScore(AFTER, REFUSER, BASE)
+  const guesser = meanScore(AFTER, GUESSER, BASE)
+  const reader = meanScore(AFTER, READER, BASE)
+  console.log(
+    `  after:  refuser ${refuser.toFixed(0)} < guesser ${guesser.toFixed(0)} < reader ${reader.toFixed(0)}`,
+  )
+  assert.ok(guesser > refuser, `guessing ${guesser.toFixed(0)} did not beat refusing ${refuser.toFixed(0)}`)
+  assert.ok(reader > guesser, `reading ${reader.toFixed(0)} did not beat guessing ${guesser.toFixed(0)}`)
+})
+
+test("AFTER: the honest reader actually lands their answers", () => {
+  // The reason the old ordering existed at all: at 3.78 s usable against a 6 s
+  // p50, a child reading honestly finished about a fifth of the time. The fix is
+  // only a fix if that number moves.
+  const before = simulate(BEFORE, READER, 4242, BASE)
+  const after = simulate(AFTER, READER, 4242, BASE)
+  const beforeRate = before.answered / Math.max(1, Math.round(before.survived / BASE.sigilGap))
+  assert.ok(beforeRate < 0.5, `the shipped window already worked: ${(beforeRate * 100).toFixed(0)}%`)
+  assert.ok(after.answered > before.answered * 2, `${String(before.answered)} → ${String(after.answered)}`)
+})
+
+test("AFTER: an honest reader never loses a lamp to the arithmetic", () => {
+  // Lamps come off bombs, which are a thing a child chooses to touch. Nothing a
+  // child does with a lantern — right, wrong, or too slow — can put one out.
+  for (let difficulty = 1; difficulty <= 10; difficulty++) {
+    const o = { ...BASE, difficulty, bombPerSecond: 0 }
+    for (const bot of [REFUSER, READER, GUESSER]) {
+      const r = simulate(AFTER, bot, 555 + difficulty, o)
+      assert.equal(
+        r.lampsLost,
+        0,
+        `difficulty ${String(difficulty)}, ${bot.name}: lost ${String(r.lampsLost)} lamps with no bombs in play`,
+      )
+    }
+  }
+})

--- a/dynawalla/games/slice/src/test/wiring.test.ts
+++ b/dynawalla/games/slice/src/test/wiring.test.ts
@@ -1,0 +1,89 @@
+// The seam, guarded at the source.
+//
+// `economy.ts` is pure and `economy.test.ts` plays bots against it, and neither
+// of those facts is worth anything if `mount.ts` quietly stops calling it. The
+// numbers this batch fixed lived inline in a 2,000-line file precisely *because*
+// nothing could see them from a test, and the same thing will happen again the
+// first time somebody "just tweaks the feel" in the mount.
+//
+// So this file reads `mount.ts` as text. That is a blunt instrument and it is
+// used deliberately: the alternative is a DOM, a canvas, a pointer-event
+// harness and a rendering stack, to assert five call sites. Every assertion
+// below names the specific regression it exists to catch.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const MOUNT = readFileSync(fileURLToPath(new URL("../mount.ts", import.meta.url)), "utf8")
+
+/** Source with `//` line comments stripped, so prose about a rule is not the rule. */
+const CODE = MOUNT.split("\n")
+  .map((line) => {
+    const at = line.indexOf("//")
+    return at === -1 ? line : line.slice(0, at)
+  })
+  .join("\n")
+
+const count = (needle: string): number => CODE.split(needle).length - 1
+
+test("the answer window comes from the cadence table, not from a constant in the mount", () => {
+  // The regression: someone re-inlines `4.2 + (difficulty − 1) × 0.2` because
+  // forty seconds of lanterns "feels long". It is long. It is the number the
+  // repo measured.
+  assert.ok(CODE.includes("moteSecondsFor("), "mount.ts no longer asks economy.ts for the window")
+  assert.ok(!CODE.includes("MOTE_SECONDS"), "the old flat window constant is back in mount.ts")
+  assert.ok(!/4\.2\s*\+/.test(CODE), "the old window formula is back in mount.ts")
+})
+
+test("only a bomb can put a lamp out", () => {
+  // The regression: `loseLamp()` creeps back into the wrong-answer branch, and
+  // never answering becomes the safe play again.
+  // Four occurrences: the declaration, the call from `onBomb`, and the two
+  // `lampCost(verdict)` loops — which run zero times, for every verdict, so the
+  // lantern path and the timeout path cannot put a lamp out at all.
+  assert.equal(count("loseLamp()"), 4, "loseLamp is called from somewhere new")
+  assert.equal(count("lampCost(verdict); i++) loseLamp()"), 2, "a lamp is spent without asking lampCost")
+  const bomb = CODE.slice(CODE.indexOf("function onBomb"))
+  assert.ok(bomb.slice(0, bomb.indexOf("\n  }")).includes("loseLamp()"), "a bomb stopped costing a lamp")
+})
+
+test("favour after a verdict is economy.ts's decision, not the mount's", () => {
+  // The regression: a timeout goes back to `Math.max(1, favour - 1)` while a
+  // wrong answer stays at `favour = 1`, and the timeout is cheap again.
+  assert.equal(count("favourAfter(verdict, favour)"), 3, "a favour update bypassed favourAfter")
+  assert.ok(!/favour\s*=\s*Math\.min\(FAVOUR_MAX/.test(CODE), "the old inline favour climb is back")
+  // Scoped to `expireQuestion`: the slow *drain* elsewhere in the frame loop is
+  // a different mechanism and legitimately steps favour down by one.
+  const expire = CODE.slice(CODE.indexOf("function expireQuestion"))
+  const body = expire.slice(0, expire.indexOf("\n  }"))
+  assert.ok(!/favour\s*=\s*Math\.max\(1, favour - 1\)/.test(body), "the old cheap timeout is back")
+  assert.ok(body.includes("favourAfter(verdict, favour)"), "a timeout no longer costs what a wrong answer costs")
+})
+
+test("a timeout is never reported to the ladder", () => {
+  // The regression: `host.report` reappears unguarded in `expireQuestion`, and
+  // a child who was still computing is demoted for it.
+  assert.equal(count("host.report("), 2, "a new report call appeared in mount.ts")
+  assert.equal(count("reportsToCurriculum("), 2, "a report call is no longer guarded")
+  const expire = CODE.slice(CODE.indexOf("function expireQuestion"))
+  const body = expire.slice(0, expire.indexOf("\n  }"))
+  assert.ok(body.includes("reportsToCurriculum"), "expireQuestion reports without asking")
+  assert.ok(body.includes('const verdict: Verdict = "timeout"'))
+})
+
+test("the market is hushed for exactly as long as a question is live", () => {
+  // The regression: `quiet` gets set from something other than "is there a
+  // question up", or the settle stops being called, and the hush either never
+  // ends or never costs a refusing child anything.
+  assert.ok(CODE.includes("director.quiet = liveQ !== null"), "the hush is no longer the question")
+  assert.equal(count("director.settleQuestion()"), 2, "a question settles without ending the hush")
+})
+
+test("the read-lock is the one economy.ts quotes the window net of", () => {
+  // The regression: the lock is bumped to 600ms for feel, the window is not,
+  // and the usable window silently drops below the p90 the tests assert.
+  assert.ok(CODE.includes("CANDIDATE_READ_LOCK_MS"), "the read-lock is a bare number again")
+  assert.ok(!/bornAt \+ 420/.test(CODE))
+})

--- a/dynawalla/games/truedraw/README.md
+++ b/dynawalla/games/truedraw/README.md
@@ -50,7 +50,8 @@ Never drawing is the same coin the other way up, and just as short. And mashing
 does not even buy tempo: a wrong draw commits, but it **does not close the
 window** — the slate stays lit to the last millisecond with the world declining
 to react. Drawing correctly is the only thing in the game that makes time go
-faster.
+faster, and with a comprehension-sized window that is now a very large
+difference indeed.
 
 `src/game/inhibition.test.ts` plays these strategies out for thousands of runs
 and asserts every claim on this page.
@@ -66,6 +67,45 @@ read as ten. Rejecting one means doing the arithmetic.
 That also makes the reporting fall out for free: a wild draw reports the
 mal-rule value, so the host records the miss **and names the misconception the
 child just demonstrated.** No extra wiring.
+
+It is also why the window is what it is. This game used to defend a 1.75–3.6 s
+clamp with "verification is cheaper than computation — the ones column alone
+rejects most mal-rules". `src/game/malRule.test.ts` proves that false: a dropped
+carry reproduces the true ones digit *by construction* — 62 and 72 both end in
+2 — and so does a borrow left at ten. A last-digit check accepts the falsehoods
+this game most prefers to tell, so verifying costs what computing costs.
+
+## The window is the child's time
+
+`EXPERIENCE_DESIGN.md`: *"COMPREHENSION — not budgeted. The child's time.
+Measured, never limited."* The draw window is now that document's own **p90 for
+the item's class**, monotone non-decreasing in operand width and clamped by
+nothing:
+
+| item | p50 | p90 | window before | window now |
+|---|---|---|---|---|
+| `7 + 8 = 15` | 2.8 s | 6 s | 2.16 s | **6.0 s** |
+| `47 + 25 = 72` | 6 s | 14 s | 2.59 s | **14.0 s** |
+| `753 + 577 = 1330` | 11 s | 27 s | 3.45 s | **27.0 s** |
+| `5001 − 2798 = 2203` | 16 s | 40 s | 3.60 s | **40.0 s** |
+
+The old ceiling bit long before the difficulty did, so the *share* of the child's
+measured need fell as the item got harder — 77% of a p50 for a single-digit fact,
+23% for the widest class. The ramp was inverted by construction, and running out
+of time on a true slate settles as a hold and spends a shot, so a child who could
+not finish lost a shot half the time by pure arithmetic.
+
+A long window costs the child nothing: a correct draw stops the clock the instant
+they press. It is only spent in full by a correct hold — the standoff — and by a
+wrong draw, which is the one thing in the game the world declines to react to.
+
+**And a window that closed on an untouched screen is never sent to the ladder.**
+The shot still goes dark, so a timeout costs exactly what an honest wrong draw
+costs and refusing to call never dominates calling; but from inside this game "I
+say that sum is wrong" and "I am still working it out" are the same event, and
+betting on the first would demote a merely deliberate child. The obvious hole —
+hold at everything, be credited on every false slate — is closed by the shot
+budget: holding at everything is wrong half the time, and half is three calls.
 
 ## Domains
 

--- a/dynawalla/games/truedraw/src/game/cadence.test.ts
+++ b/dynawalla/games/truedraw/src/game/cadence.test.ts
@@ -1,0 +1,149 @@
+// The fleet invariant, asserted where it was broken.
+//
+// **The comprehension window is monotone non-decreasing in item difficulty, and
+// no item gets less than the child's own measured p90.**
+//
+// The window this game shipped with was `max(1750, min(3600, 1300 + 215d))`.
+// Against `EXPERIENCE_DESIGN.md`'s cadence table that upper clamp inverted the
+// ramp: it was more than a whole p50 for a single-digit fact and under a third
+// of one for the `5,001 − 2,798` class, so the harder the item, the smaller the
+// share of the child's need it received. The two tests at the bottom of this
+// file print that table so a reviewer can read the ramp rather than trust it.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  CADENCE,
+  comprehensionLoad,
+  comprehensionMsFor,
+  comprehensionP50Ms,
+  comprehensionP90Ms,
+  operandWidth,
+} from "./cadence.ts"
+import { stillFor, windowFor } from "./statement.ts"
+
+/** One statement per class, from the narrowest item this game serves to the widest. */
+const LADDER = [
+  { text: "7 + 8 = 15", label: "single-digit fact", class: CADENCE.fact },
+  { text: "47 + 25 = 62", label: "two-digit regrouping", class: CADENCE.regroup },
+  { text: "753 + 577 = 1330", label: "three-digit regrouping", class: null },
+  { text: "5001 − 2798 = 2203", label: "the 5,001 − 2,798 class", class: CADENCE.wide },
+] as const
+
+test("the widest operand is what sets the class, not the total ink", () => {
+  assert.equal(operandWidth("7 + 8 = 15"), 1, "the claimed 15 is compared, not computed")
+  assert.equal(operandWidth("47 + 25 = 72"), 2)
+  assert.equal(operandWidth("753 + 577 = 1330"), 3)
+  assert.equal(operandWidth("5001 − 2798 = 2203"), 4)
+  assert.equal(operandWidth("no digits at all"), 1, "an empty pool is the cheapest class")
+})
+
+test("the window is monotone non-decreasing in item difficulty", () => {
+  // The whole defect in one assertion. A harder item may never get less time
+  // than an easier one — not by a millisecond, at any width, ever.
+  let previous = 0
+  for (let width = 1; width <= 12; width++) {
+    const ms = comprehensionP90Ms(comprehensionLoad(width))
+    assert.ok(
+      ms >= previous,
+      `width ${String(width)} got ${String(ms)}ms after width ${String(width - 1)} got ${String(previous)}ms`,
+    )
+    previous = ms
+  }
+  assert.ok(previous >= CADENCE.wide.p90, `the widest item tops out at ${String(previous)}ms`)
+})
+
+test("the window is monotone non-decreasing across real statements", () => {
+  let previous = 0
+  for (const rung of LADDER) {
+    const ms = windowFor(rung.text)
+    assert.ok(ms >= previous, `${rung.label} got ${String(ms)}ms after ${String(previous)}ms`)
+    previous = ms
+  }
+})
+
+test("no item is capped below what the child measurably needs", () => {
+  // p90, not p50. p50 is by definition the window half the class does not
+  // finish inside, and in this game not finishing costs one of three shots.
+  for (const rung of LADDER) {
+    if (!rung.class) continue
+    const ms = windowFor(rung.text)
+    assert.ok(
+      ms >= rung.class.p90,
+      `${rung.label}: ${String(ms)}ms against a measured p90 of ${String(rung.class.p90)}ms`,
+    )
+    assert.ok(
+      ms / rung.class.p50 >= 2,
+      `${rung.label}: ${(ms / rung.class.p50).toFixed(2)}× p50 is not a comprehension window`,
+    )
+  }
+})
+
+test("there is no upper clamp left to invert the ramp", () => {
+  // The specific shape of the old bug: a ceiling that bit before the difficulty
+  // did, so the *share* of the child's need fell as the item got harder. The
+  // share must never fall.
+  let previousShare = 0
+  for (const rung of LADDER) {
+    if (!rung.class) continue
+    const share = windowFor(rung.text) / rung.class.p90
+    assert.ok(
+      share >= previousShare - 1e-9,
+      `${rung.label} received ${(share * 100).toFixed(0)}% of its p90 after the previous rung received ${(previousShare * 100).toFixed(0)}%`,
+    )
+    previousShare = share
+  }
+})
+
+test("the total budget — stillness plus window — is monotone too", () => {
+  // A child can read during the stillness; they cannot act. The window is what
+  // has to carry the comprehension, so it is asserted on its own above, but the
+  // sum must not go backwards either.
+  const rng = new Rng(0x51ed)
+  let previous = 0
+  for (const rung of LADDER) {
+    // Worst case of the jitter, so this is a floor and not a lucky draw.
+    let lowest = Number.POSITIVE_INFINITY
+    for (let i = 0; i < 300; i++) lowest = Math.min(lowest, stillFor(rung.text, rng))
+    const budget = windowFor(rung.text) + lowest
+    assert.ok(budget >= previous, `${rung.label}: ${String(budget)}ms after ${String(previous)}ms`)
+    previous = budget
+  }
+})
+
+test("the cadence table, before and after", () => {
+  // Not an assertion of style — a printed ramp. The old function is inlined so
+  // the two columns are read off the same input.
+  const old = (text: string): number => {
+    let d = 0
+    for (const ch of text) if (ch >= "0" && ch <= "9") d++
+    return Math.max(1750, Math.min(3600, 1300 + 215 * d))
+  }
+  const rows = LADDER.map((rung) => {
+    const p50 = comprehensionP50Ms(comprehensionLoad(operandWidth(rung.text)))
+    const p90 = comprehensionP90Ms(comprehensionLoad(operandWidth(rung.text)))
+    return {
+      item: rung.label,
+      p50s: (p50 / 1000).toFixed(1),
+      p90s: (p90 / 1000).toFixed(1),
+      beforeS: (old(rung.text) / 1000).toFixed(2),
+      beforePctOfP50: `${((old(rung.text) / p50) * 100).toFixed(0)}%`,
+      afterS: (windowFor(rung.text) / 1000).toFixed(1),
+      afterPctOfP50: `${((windowFor(rung.text) / p50) * 100).toFixed(0)}%`,
+    }
+  })
+  console.table(rows)
+  // The property the table exists to show: before, the share fell as the item
+  // got harder. After, it does not.
+  const beforeShares = LADDER.map((r) => old(r.text) / comprehensionP50Ms(comprehensionLoad(operandWidth(r.text))))
+  assert.ok(
+    (beforeShares.at(-1) as number) < (beforeShares[0] as number),
+    "the old ramp was not inverted after all — re-derive this whole file",
+  )
+})
+
+test("comprehensionMsFor is the one path everything else goes through", () => {
+  for (const rung of LADDER) assert.equal(windowFor(rung.text), comprehensionMsFor(rung.text))
+})

--- a/dynawalla/games/truedraw/src/game/cadence.ts
+++ b/dynawalla/games/truedraw/src/game/cadence.ts
@@ -1,0 +1,112 @@
+// The child's time, taken from the repo's own numbers.
+//
+// `dynawalla/docs/EXPERIENCE_DESIGN.md` writes the law down twice:
+//
+//   > `T=0→C` COMPREHENSION — not budgeted. The child's time. Measured, never
+//   > limited.
+//
+// and then gives the measurements it was made from — instrumented p50/p90, never
+// shown to the child:
+//
+//   | class                     | p50    | p90    |
+//   |---------------------------|--------|--------|
+//   | single-digit fact         |  2.8 s |  6 s   |
+//   | two-digit with regrouping |  6 s   | 14 s   |
+//   | the `5,001 − 2,798` class | 16 s   | 40 s   |
+//
+// A game cannot literally not budget the window — the slate has to go down
+// again — so the honest reading of "measured, never limited" is: **the window is
+// derived from the measurement, and it is derived per item.**
+//
+// That gives one invariant the whole fleet has to hold:
+//
+//   **the comprehension window is MONOTONE NON-DECREASING in item difficulty.**
+//
+// A harder item may never get less time than an easier one. This game used to
+// break it by construction — `max(1750, min(3600, 1300 + 215d))` — because the
+// upper clamp bit long before the difficulty did, so the harder the item, the
+// smaller the fraction of the child's own measured need it received. The ramp
+// was inverted by the cap.
+//
+// The target here is **p90, not p50**. p50 is by definition the window half the
+// children do not finish inside, and in this game not finishing inside the
+// window costs one of only three shots. Sizing to p50 would spend a shot on half
+// the class for having a normal amount of thinking to do.
+
+/** The cadence table, verbatim, in milliseconds. */
+export const CADENCE = {
+  /** `7 + 8`. */
+  fact: { p50: 2800, p90: 6000 },
+  /** `47 + 25`, carry and all. */
+  regroup: { p50: 6000, p90: 14000 },
+  /** `5,001 − 2,798` — four columns, a borrow travelling through a zero. */
+  wide: { p50: 16000, p90: 40000 },
+} as const
+
+/**
+ * The anchors the load axis interpolates between. Load 1 is a fact, load 2 is
+ * two-digit regrouping, load 3 is the widest class in the table.
+ */
+const ANCHORS = [CADENCE.fact, CADENCE.regroup, CADENCE.wide] as const
+
+/**
+ * How many digits are in the widest *operand*.
+ *
+ * The operands, not the whole statement: the columns a child has to work are the
+ * ones in `47 + 25`, and the claimed value on the right of the `=` is a thing
+ * they compare against, not a thing they compute. `"47 + 25 = 72"` is two.
+ *
+ * Text with no numeral in it at all — which only happens when the question pool
+ * has run dry — reads as one, the cheapest class. It is never a real item.
+ */
+export function operandWidth(text: string): number {
+  const left = text.split("=")[0] ?? text
+  let width = 0
+  let run = 0
+  for (const ch of left) {
+    if (ch >= "0" && ch <= "9") {
+      run += 1
+      if (run > width) width = run
+    } else run = 0
+  }
+  return Math.max(1, width)
+}
+
+/**
+ * Where an item of this operand width sits on the cadence table's axis, 1..3.
+ *
+ * Strictly non-decreasing in `width`, which is what makes every window derived
+ * from it non-decreasing too. Three digits sits halfway between two-digit
+ * regrouping and the four-column class because that is where the work sits: one
+ * more column than the former, one fewer than the latter.
+ */
+export function comprehensionLoad(width: number): number {
+  if (width <= 1) return 1
+  if (width === 2) return 2
+  if (width === 3) return 2.5
+  return 3
+}
+
+function interpolate(load: number, key: "p50" | "p90"): number {
+  const clamped = Math.max(1, Math.min(3, load))
+  const lo = Math.min(1, Math.floor(clamped) - 1)
+  const t = clamped - (lo + 1)
+  const a = ANCHORS[lo] ?? CADENCE.fact
+  const b = ANCHORS[lo + 1] ?? CADENCE.wide
+  return Math.round(a[key] + (b[key] - a[key]) * t)
+}
+
+/** Half the children are done by here. Not a window — a beat. */
+export function comprehensionP50Ms(load: number): number {
+  return interpolate(load, "p50")
+}
+
+/** Nine in ten children are done by here. This is what a window has to be. */
+export function comprehensionP90Ms(load: number): number {
+  return interpolate(load, "p90")
+}
+
+/** The whole chain, for a piece of statement text. */
+export function comprehensionMsFor(text: string): number {
+  return comprehensionP90Ms(comprehensionLoad(operandWidth(text)))
+}

--- a/dynawalla/games/truedraw/src/game/malRule.test.ts
+++ b/dynawalla/games/truedraw/src/game/malRule.test.ts
@@ -1,0 +1,172 @@
+// The defence this game used to make for its own short window, tested.
+//
+// `statement.ts` justified a 1750–3600 ms clamp with one sentence:
+//
+//   > Verification is cheaper than computation (the ones column alone rejects
+//   > most mal-rules), which is why the budget can be under the cadence target
+//   > at all.
+//
+// It is not true, and it is most spectacularly not true for the mal-rule this
+// game deliberately *prefers* — `pickFalsehood` puts 55% of its weight on the
+// head of the host's distractor list, and the head is the dropped carry.
+//
+// `47 + 25` is 72. Drop the carry and you write 62. Both end in 2.
+//
+// That is not a coincidence of those two operands. Every one of the three
+// procedural mal-rules the curriculum emits is *correct in the ones column* and
+// wrong further left — that is what makes them the mistakes a child actually
+// makes rather than noise:
+//
+//   * dropped carry      — the ones column is `(a+b) mod 10`, which is the true
+//                          ones digit by definition. Invisible, always.
+//   * borrow left at ten — the bug is in the zero the borrow travelled through,
+//                          which is never the ones column. Invisible, always.
+//   * smaller-from-larger— invisible whenever the ones column did not itself
+//                          need a borrow, which is most of the time.
+//
+// Measured across the dealer's own stream, a last-digit check rejects well under
+// half of the falsehoods this game puts on a slate, and none at all of the most
+// likely one. Verification costs what computation costs, and the window is now
+// budgeted at what computation costs.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stub/host.ts"
+import { addNoCarry, borrowAcrossZero, drawProblem, subSmallerFromLarger } from "../stub/questions.ts"
+import { Dealer } from "./dealer.ts"
+
+const ones = (n: number): number => Math.abs(n) % 10
+
+test("47 + 25 = 62 shares its ones digit with the true 72", () => {
+  // The exact collision the file's defence was checked against, spelled out.
+  assert.equal(addNoCarry(47, 25), 62)
+  assert.equal(47 + 25, 72)
+  assert.equal(ones(62), ones(72))
+  assert.equal(
+    ones(addNoCarry(47, 25)),
+    ones(72),
+    "the ones column cannot tell the dropped carry from the truth",
+  )
+})
+
+test("the dropped carry never changes the ones digit, on any operands", () => {
+  const rng = new Rng(0xca11)
+  for (let i = 0; i < 4000; i++) {
+    const a = rng.int(12, 9899)
+    const b = rng.int(12, 9899)
+    assert.equal(
+      ones(addNoCarry(a, b)),
+      ones(a + b),
+      `${String(a)} + ${String(b)}: the ones column rejected a dropped carry`,
+    )
+  }
+})
+
+test("smaller-from-larger survives a ones check whenever the ones column does not borrow", () => {
+  // The one procedural mal-rule a last-digit check *can* sometimes catch — and
+  // only sometimes. It is invisible unless the ones column itself needed a
+  // borrow, which is a little under half the time, and even then it stays
+  // invisible when the two digits are five apart.
+  const rng = new Rng(0xbeef)
+  let noBorrow = 0
+  let caught = 0
+  let total = 0
+  for (let i = 0; i < 4000; i++) {
+    const a = rng.int(100, 9899)
+    const b = rng.int(12, a - 1)
+    const wrong = subSmallerFromLarger(a, b)
+    if (wrong === a - b) continue
+    total++
+    const borrows = a % 10 < b % 10
+    if (!borrows) {
+      noBorrow++
+      assert.equal(
+        ones(wrong),
+        ones(a - b),
+        `${String(a)} − ${String(b)}: a non-borrowing ones column must be identical`,
+      )
+    }
+    if (ones(wrong) !== ones(a - b)) caught++
+  }
+  assert.ok(noBorrow > 500, `only ${String(noBorrow)} non-borrowing cases sampled`)
+  assert.ok(
+    caught / total < 0.5,
+    `the ones column caught ${((caught / total) * 100).toFixed(1)}% of smaller-from-larger`,
+  )
+})
+
+test("a borrow left at ten never changes the ones digit either", () => {
+  const rng = new Rng(0x0ff)
+  let checked = 0
+  for (let i = 0; i < 6000 && checked < 300; i++) {
+    const a = rng.int(1002, 9899)
+    const b = rng.int(12, a - 1)
+    const wrong = borrowAcrossZero(a, b)
+    if (wrong < 0 || wrong === a - b) continue
+    checked++
+    assert.equal(
+      ones(wrong),
+      ones(a - b),
+      `${String(a)} − ${String(b)}: the ones column rejected a borrow-at-ten`,
+    )
+  }
+  assert.ok(checked > 100, `only ${String(checked)} borrow-across-zero cases exercised`)
+})
+
+test("across the real stream, the ones column rejects a minority of falsehoods", () => {
+  // The claim under test is "the ones column alone rejects MOST mal-rules". It
+  // does not: the procedural ones all survive it, and only the transcription
+  // slips — a reversal, a ±10 — are ever caught by it. If this ever climbs back
+  // over half, the window may be revisited; until then it may not be.
+  const host = createStubHost({ seed: 0xa17e })
+  const dealer = new Dealer(host, new Rng(0xa17f))
+  let falsehoods = 0
+  let rejectedByOnes = 0
+  for (let i = 0; i < 4000; i++) {
+    const s = dealer.deal()
+    if (s.truth) continue
+    falsehoods++
+    if (ones(Number(s.claimed)) !== ones(Number(s.answer))) rejectedByOnes++
+  }
+  assert.ok(falsehoods > 1500, `only ${String(falsehoods)} falsehoods in 4000`)
+  const share = rejectedByOnes / falsehoods
+  assert.ok(
+    share < 0.5,
+    `the ones column rejected ${(share * 100).toFixed(1)}% of falsehoods — the old defence would be back`,
+  )
+})
+
+test("the mal-rule the dealer prefers is the one the ones column cannot see", () => {
+  // `pickFalsehood` weights the head of the distractor list at 55%, and the head
+  // is always the procedural mal-rule. So the *most likely* thing on a false
+  // slate is precisely the thing a last-digit check accepts.
+  const rng = new Rng(0xd00d)
+  let head = 0
+  let headSurvivesOnes = 0
+  let addHead = 0
+  let addSurvives = 0
+  for (let i = 0; i < 2000; i++) {
+    const drawn = drawProblem(3, rng)
+    const first = drawn.distractors[0]
+    if (first === undefined) continue
+    head++
+    const survives = ones(first) === ones(drawn.answer)
+    if (survives) headSurvivesOnes++
+    if (drawn.op === "add") {
+      addHead++
+      if (survives) addSurvives++
+    }
+  }
+  assert.ok(head > 1900, `only ${String(head)} items carried a mal-rule at the head`)
+  assert.equal(
+    addSurvives,
+    addHead,
+    "every dropped carry must be invisible to a ones check — that is what makes it the mistake a child makes",
+  )
+  assert.ok(
+    headSurvivesOnes / head > 0.75,
+    `only ${((headSurvivesOnes / head) * 100).toFixed(1)}% of preferred mal-rules survive a ones check`,
+  )
+})

--- a/dynawalla/games/truedraw/src/game/patience.test.ts
+++ b/dynawalla/games/truedraw/src/game/patience.test.ts
@@ -1,0 +1,100 @@
+// A child who is right but not fast must not lose a shot for it.
+//
+// `EXPERIENCE_DESIGN.md`: "T=0→C COMPREHENSION — not budgeted. The child's time.
+// Measured, never limited." The measurements it was made from are the cadence
+// table, and this file plays whole runs against them.
+//
+// The bots here do not act at "40% of whatever window they are given" — a bot
+// like that can never be timed out and so can never see a window that is too
+// short. They take the number of milliseconds the *repo* says the item costs,
+// and then the run reports what the game did about it.
+//
+// The failure this catches is the one the audit found: the window was capped at
+// 3.6 s, running out of time on a TRUE slate settles as a hold, and a hold is a
+// miss — so a child working at the documented p50 lost a shot on every true
+// slate, and the bag deals true slates in exact halves. Half their shots gone by
+// arithmetic, regardless of what they knew.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost } from "../stub/host.ts"
+import { perfect, playRun } from "../test/harness.ts"
+import { comprehensionLoad, comprehensionP50Ms, comprehensionP90Ms, operandWidth } from "./cadence.ts"
+import type { Statement } from "./statement.ts"
+
+/** Every rung of the stub ladder: two-digit at the bottom, four at the top. */
+const LEVELS = [0, 1, 2, 3, 4, 5, 6, 7]
+
+const p50 = (s: Statement): number => comprehensionP50Ms(comprehensionLoad(operandWidth(s.text)))
+const p90 = (s: Statement): number => comprehensionP90Ms(comprehensionLoad(operandWidth(s.text)))
+
+/** The window this game shipped with, inlined so the contrast is on one input. */
+function shippedWindow(text: string): number {
+  let d = 0
+  for (const ch of text) if (ch >= "0" && ch <= "9") d++
+  return Math.max(1750, Math.min(3600, 1300 + 215 * d))
+}
+
+test("a child working at the documented p50 is never timed out, at any rung", () => {
+  for (const level of LEVELS) {
+    const result = playRun(createStubHost({ seed: 900 + level, level }), 400 + level, perfect, {
+      limit: 60,
+      thinkMs: p50,
+    })
+    const timedOut = result.outcomes.filter((o) => o === "slow").length
+    assert.equal(
+      timedOut,
+      0,
+      `level ${String(level)}: ${String(timedOut)} of ${String(result.outcomes.length)} calls were lost to the clock`,
+    )
+    assert.equal(result.run.shots, 3, `level ${String(level)}: shots spent by a child who was right`)
+  }
+})
+
+test("even the slowest tenth of the class lands the call", () => {
+  // p90 minus one frame. The window is p90, so this is the last child the table
+  // says exists — and they get their call in.
+  for (const level of LEVELS) {
+    const result = playRun(createStubHost({ seed: 1900 + level, level }), 1400 + level, perfect, {
+      limit: 40,
+      thinkMs: (s) => p90(s) - 40,
+    })
+    const timedOut = result.outcomes.filter((o) => o === "slow").length
+    assert.equal(timedOut, 0, `level ${String(level)}: the slowest tenth lost ${String(timedOut)} calls`)
+  }
+})
+
+test("under the shipped window that same child lost a shot on every true slate", () => {
+  // The defect, played rather than argued. This asserts what the OLD function
+  // did, so it stays true after the fix and documents the size of the hole: a
+  // perfect player, working at the repo's own p50, could not finish a single
+  // statement inside the window they were given.
+  let unreachable = 0
+  let total = 0
+  for (const level of LEVELS) {
+    const host = createStubHost({ seed: 2900 + level, level })
+    const result = playRun(host, 2400 + level, perfect, { limit: 40, thinkMs: p50 })
+    for (const s of result.statements) {
+      total++
+      if (shippedWindow(s.text) < p50(s)) unreachable++
+    }
+  }
+  assert.ok(total > 200, `only ${String(total)} statements sampled`)
+  assert.equal(
+    unreachable,
+    total,
+    `${String(unreachable)} of ${String(total)} statements were unanswerable at the documented p50`,
+  )
+})
+
+test("a run at p50 is long, which is the whole point of the format", () => {
+  // `run.ts`: expected calls = shots × p / (1 − p). A player who is right every
+  // time is never stopped — and now they are not stopped by the clock either.
+  const result = playRun(createStubHost({ seed: 77, level: 5 }), 78, perfect, {
+    limit: 120,
+    thinkMs: p50,
+  })
+  assert.equal(result.run.over, false)
+  assert.ok(result.run.calls >= 120, `only ${String(result.run.calls)} calls`)
+})

--- a/dynawalla/games/truedraw/src/game/response.test.ts
+++ b/dynawalla/games/truedraw/src/game/response.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { isCorrect, outcomeOf, responseFor } from "./response.ts"
+import { isCorrect, outcomeOf, reportsToCurriculum, responseFor } from "./response.ts"
+import { applyOutcome, newRun, SHOTS } from "./run.ts"
 import type { Statement } from "./statement.ts"
 
 function statement(over: Partial<Statement> = {}): Statement {
@@ -56,7 +57,29 @@ test("a correct hold is credited rather than recorded as a miss", () => {
 
 test("letting a true statement stand reports nothing the host can parse", () => {
   const s = statement({ claimed: "72", truth: true })
-  // Unparseable, so it is recorded as a miss with no diagnosis. Refusing a
-  // true sentence is not a misconception with a name.
+  // Unparseable, so nothing is recorded. Refusing a true sentence is not a
+  // misconception with a name.
   assert.equal(responseFor("slow", s), "")
+})
+
+test("a window that closed on an untouched screen is not sent to the ladder", () => {
+  // The three outcomes somebody performed are evidence. `slow` is the window
+  // closing with nothing touched, and from inside this game "I say that is
+  // wrong" and "I am still working it out" are the same event. Sending it as a
+  // wrong answer bets on the first and demotes a merely deliberate child.
+  assert.equal(reportsToCurriculum("hit"), true)
+  assert.equal(reportsToCurriculum("bow"), true)
+  assert.equal(reportsToCurriculum("wild"), true)
+  assert.equal(reportsToCurriculum("slow"), false)
+})
+
+test("the shot still goes dark — a timeout costs exactly what a wrong draw costs", () => {
+  // Suppressing the report must not quietly make not-answering free. Inside the
+  // run a hold is a call like any other: `wild` and `slow` are both misses and
+  // both spend one of three shots, so refusing to call never dominates calling.
+  assert.equal(isCorrect("wild"), false)
+  assert.equal(isCorrect("slow"), false)
+  const budget = applyOutcome(applyOutcome(newRun(), "slow"), "wild")
+  assert.equal(budget.shots, SHOTS - 2, "one shot each, no discount for silence")
+  assert.equal(budget.calls, 0)
 })

--- a/dynawalla/games/truedraw/src/game/response.ts
+++ b/dynawalla/games/truedraw/src/game/response.ts
@@ -44,10 +44,40 @@ export function isCorrect(outcome: Outcome): boolean {
  *          perfectly as having missed, which would demote them down the ladder
  *          for being right.
  *   slow — "the answer is not 72", and it is. Nothing a child could have written
- *          expresses that, so nothing is: the empty response is unparseable, the
- *          host records a miss, and no mal-rule is named. Refusing a true
- *          sentence is not a misconception with a name.
+ *          expresses that, so nothing is: the empty response is unparseable and
+ *          no mal-rule is named. Refusing a true sentence is not a misconception
+ *          with a name — and, per `reportsToCurriculum`, it is not sent at all.
  */
+/**
+ * Whether this outcome is evidence about the child, fit to send to the ladder.
+ *
+ * Three of the four are. `slow` is not, and this is the one asymmetry in the
+ * file that is about the child rather than about the street.
+ *
+ * `slow` is the only outcome nobody performed. A `hit`, a `bow` and a `wild` are
+ * all things a child *did* — a press, at a moment, meaning something. A `slow`
+ * is the window closing with the screen untouched, and there is no way from
+ * inside this game to tell "I say that sum is wrong" apart from "I am still
+ * working it out". Reporting it as a wrong answer bets on the first reading and
+ * demotes the child down the ladder when the second is true. A child who was
+ * still computing is not a child who does not know the skill, and the ladder is
+ * the one place that mistake compounds: it would feed them easier items, which
+ * is precisely the wrong medicine for somebody who is merely deliberate.
+ *
+ * The shot still goes dark — inside the run a hold is a call like any other, and
+ * a timeout costs exactly what an honest wrong draw costs, never less. What
+ * changes is only what crosses the wire.
+ *
+ * The obvious hole — hold at everything, be reported correct on every false
+ * slate and reported not at all on every true one — is closed by the shot
+ * budget, not by the wire: holding at everything is wrong half the time, and
+ * half is three calls (`run.ts`). A passive holder gets about six rounds before
+ * the street clears, every time, forever.
+ */
+export function reportsToCurriculum(outcome: Outcome): boolean {
+  return outcome !== "slow"
+}
+
 export function responseFor(outcome: Outcome, statement: Statement): string {
   switch (outcome) {
     case "hit":

--- a/dynawalla/games/truedraw/src/game/statement.test.ts
+++ b/dynawalla/games/truedraw/src/game/statement.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import type { Question } from "../contract.ts"
+import { CADENCE } from "./cadence.ts"
 import { sameValue } from "../core/exact.ts"
 import { Rng } from "../core/rng.ts"
 import { createStubHost } from "../stub/host.ts"
@@ -101,18 +102,25 @@ test("the draw window is a function of the statement and of nothing else", () =>
   const long = windowFor("753 + 577 = 1330")
   assert.ok(long > short, "more numeral, more time")
   assert.equal(windowFor("12 + 5 = 17"), short, "the same statement always gets the same window")
-  assert.ok(short >= 1750 && long <= 3600, "clamped at both ends")
-  assert.equal(windowFor("no digits at all"), 1750)
+  // No upper clamp. The old one — 3600 ms — was the whole defect: it bit long
+  // before the difficulty did, so the ramp inverted. See `cadence.test.ts`.
+  assert.ok(long > 3600, `a three-digit sum still fits inside the old ceiling: ${String(long)}ms`)
+  assert.equal(windowFor("no digits at all"), CADENCE.fact.p90)
 })
 
 test("a four-digit sum gets time a child could actually use", () => {
-  // EXPERIENCE_DESIGN.md puts multi-digit regrouping at a 6 s p50. Verifying a
-  // claim is cheaper than computing one — the ones column alone rejects most
-  // mal-rules — but not so much cheaper that three seconds is honest.
+  // EXPERIENCE_DESIGN.md puts the `5,001 − 2,798` class at a 16 s p50 and a 40 s
+  // p90. Verification is *not* cheaper than computation here — every procedural
+  // mal-rule this game prefers reproduces the true ones digit, which
+  // `malRule.test.ts` proves — so the window is budgeted at the p90 for the
+  // class and nothing clamps it.
   const rng = new Rng(4)
-  const text = "753 + 577 = 1330"
+  const text = "5001 − 2798 = 2203"
   const budget = windowFor(text) + stillFor(text, rng)
-  assert.ok(budget >= 4400, `only ${String(budget)}ms to verify a four-digit sum`)
+  assert.ok(
+    budget >= CADENCE.wide.p90,
+    `only ${String(budget)}ms to work a four-column subtraction with a borrow across a zero`,
+  )
 })
 
 test("a short statement comes at you faster than a long one", () => {

--- a/dynawalla/games/truedraw/src/game/statement.ts
+++ b/dynawalla/games/truedraw/src/game/statement.ts
@@ -22,6 +22,7 @@
 // `distractors` and nothing else, so the day `mul`, `frac` or `alg` are promoted
 // out of draft this game covers them with no change: a claim is a claim.
 
+import { comprehensionMsFor } from "./cadence.ts"
 import { canonicalNumeral, digitCount, sameValue } from "../core/exact.ts"
 import type { Rng } from "../core/rng.ts"
 import type { Question } from "../contract.ts"
@@ -48,23 +49,39 @@ export type Statement = {
 /**
  * The draw window, and the stillness before it.
  *
- * Both are a function of how much numeral there is to verify and of nothing
- * else. In particular **neither depends on how long the run has been going**:
- * `EXPERIENCE_DESIGN.md` bans escalation on run length, and a reaction game that
- * quietly tightens its window every round is exactly that ban's target. A long
- * run in this game is not faster. It is only longer.
+ * Both are a function of the item and of nothing else. In particular **neither
+ * depends on how long the run has been going**: `EXPERIENCE_DESIGN.md` bans
+ * escalation on run length, and a reaction game that quietly tightens its window
+ * every round is exactly that ban's target. A long run in this game is not
+ * faster. It is only longer.
  *
- * The two slopes pull in opposite directions on purpose. The window climbs
- * steeply — `753 + 577 = 1330` needs real time, and `EXPERIENCE_DESIGN.md`'s own
- * cadence table puts multi-digit regrouping at a 6 s p50 — while the stillness
- * *flattens*, because a lead-in long enough for a four-digit sum is dead air on
- * `12 + 5 = 17`. Short statements come at you faster; long ones give more room.
- * Verification is cheaper than computation (the ones column alone rejects most
- * mal-rules), which is why the budget can be under the cadence target at all.
+ * ── the window is the child's time ──────────────────────────────────────────
+ *
+ * The window is `cadence.ts`'s p90 for the item's own class, and nothing here is
+ * allowed to clamp it. It used to be `max(1750, min(3600, 1300 + 215d))`, and
+ * that upper clamp inverted the ramp: measured against the repo's own cadence
+ * table it handed a single-digit fact more than its whole p50 and the
+ * `5,001 − 2,798` class under a third of one, so the harder the item, the less
+ * of the child's measured need it received. `windowMonotone` in the tests is now
+ * the standing guard on that.
+ *
+ * The old comment justified the clamp with "verification is cheaper than
+ * computation — the ones column alone rejects most mal-rules". **That claim is
+ * false**, and `malRule.test.ts` is the proof. Every mal-rule this game
+ * *prefers* — the dropped carry, the smaller-from-larger subtraction, the borrow
+ * left at ten — reproduces the true ones digit exactly, by construction: they
+ * are correct in the ones column and wrong further left. `47 + 25 = 62` and the
+ * true `72` share their last digit. A child who checks only the ones column
+ * accepts every one of them. Verification here costs what computation costs, so
+ * it is budgeted at what computation costs.
+ *
+ * The stillness, meanwhile, still *flattens*: it is the lead-in, not the
+ * thinking, and a lead-in long enough for a four-digit sum is dead air on
+ * `12 + 5 = 17`. The thinking happens with the slate lit, where the child can
+ * end it the moment they are ready by drawing.
  */
 export function windowFor(text: string): number {
-  const d = digitCount(text)
-  return Math.max(1750, Math.min(3600, 1300 + 215 * d))
+  return comprehensionMsFor(text)
 }
 
 export function stillFor(text: string, rng: Rng): number {

--- a/dynawalla/games/truedraw/src/game/wiring.test.ts
+++ b/dynawalla/games/truedraw/src/game/wiring.test.ts
@@ -1,0 +1,54 @@
+// The seam, guarded at the source.
+//
+// `cadence.ts` and `reportsToCurriculum` are pure and heavily tested, and
+// neither fact is worth anything if `mount.ts` stops calling them. This file
+// reads the mount as text — a blunt instrument, used deliberately: the
+// alternative is a DOM, a canvas and a rAF harness to assert two call sites.
+// Every assertion below names the regression it exists to catch.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const read = (relative: string): string =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8")
+
+/** Source with every comment stripped, so prose *about* a rule is not the rule. */
+const strip = (source: string): string =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .map((line) => {
+      const at = line.indexOf("//")
+      return at === -1 ? line : line.slice(0, at)
+    })
+    .join("\n")
+
+const MOUNT = strip(read("../mount.ts"))
+const STATEMENT = strip(read("./statement.ts"))
+
+const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1
+
+test("a window that closed on an untouched screen is never sent to the ladder", () => {
+  // The regression: the guard is dropped and `slow` goes back across the wire as
+  // a wrong answer, demoting a child who was merely deliberate.
+  assert.equal(count(MOUNT, "host.report("), 1, "a new report call appeared in mount.ts")
+  assert.ok(MOUNT.includes("reportsToCurriculum(event.outcome)"), "the report is unguarded again")
+  const settled = MOUNT.slice(MOUNT.indexOf('case "settled"'))
+  const guard = settled.indexOf("reportsToCurriculum(")
+  const call = settled.indexOf("host.report(")
+  assert.ok(guard !== -1 && guard < call, "the report is no longer behind the guard")
+})
+
+test("the window comes from the cadence table, with nothing clamping it", () => {
+  // The regression: the ceiling comes back — 3600, or any other number — because
+  // fourteen seconds "feels slow". It is the number the repo measured.
+  assert.ok(STATEMENT.includes("comprehensionMsFor(text)"), "windowFor stopped asking cadence.ts")
+  assert.ok(!/1300\s*\+\s*215/.test(STATEMENT), "the old linear window is back")
+  assert.ok(!/Math\.min\(3600/.test(STATEMENT), "the old upper clamp is back")
+  const fn = STATEMENT.slice(STATEMENT.indexOf("export function windowFor"))
+  const body = fn.slice(0, fn.indexOf("\n}"))
+  assert.ok(!body.includes("Math.min"), "something is capping the comprehension window again")
+  assert.ok(!body.includes("Math.max"), "something is flooring the comprehension window again")
+})

--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -24,7 +24,7 @@ import type { Host } from "./contract.ts"
 import { bestCalls, recordCalls } from "./game/best.ts"
 import { Dealer } from "./game/dealer.ts"
 import { HAPTIC } from "./game/energy.ts"
-import { isCorrect, responseFor } from "./game/response.ts"
+import { isCorrect, reportsToCurriculum, responseFor } from "./game/response.ts"
 import { Round, TIMING, TIMING_REDUCED, type RoundEvent } from "./game/round.ts"
 import { Rng } from "./core/rng.ts"
 import { Scene } from "./render/scene.ts"
@@ -79,6 +79,14 @@ export function mountTrueDraw(
         ],
       },
       {
+        heading: "The slate waits for you",
+        lines: [
+          "Work the sum out properly. There is no rush and there is no bar counting down.",
+          "A big sum keeps the slate lit for much longer than a small one does.",
+          "The light only goes out when you draw, or when the caller does.",
+        ],
+      },
+      {
         heading: "Your three shots",
         lines: [
           "Draw at a sum that is wrong and nothing happens at all. No sound, no flash, nobody moves. But a shot is gone.",
@@ -123,12 +131,19 @@ export function mountTrueDraw(
           // The host is the judge. What goes across is the value the child
           // effectively asserted — and on a wrong draw that value is a mal-rule
           // output, so the misconception routes itself.
-          host.report({
-            questionId: event.statement.questionId,
-            correct: isCorrect(event.outcome),
-            ms: event.reactionMs,
-            answered: responseFor(event.outcome, event.statement),
-          })
+          //
+          // A `slow` crosses nothing at all: nobody performed it, and it cannot
+          // be told apart from a child who was still working. See
+          // `reportsToCurriculum`. The shot still goes dark; the ladder just
+          // does not hear about it.
+          if (reportsToCurriculum(event.outcome)) {
+            host.report({
+              questionId: event.statement.questionId,
+              correct: isCorrect(event.outcome),
+              ms: event.reactionMs,
+              answered: responseFor(event.outcome, event.statement),
+            })
+          }
           audio.outcome(event.outcome)
           const cue = HAPTIC[event.outcome]
           if (cue) host.haptic(cue)

--- a/dynawalla/games/truedraw/src/test/harness.ts
+++ b/dynawalla/games/truedraw/src/test/harness.ts
@@ -32,6 +32,16 @@ export type PlayOptions = {
   readonly limit?: number
   /** Fraction into the draw window at which a draw is committed. */
   readonly drawAt?: number
+  /**
+   * How long this player takes to work the statement out, in absolute ms.
+   *
+   * The point of an absolute think time rather than a fraction is that it is
+   * the *child's* number, not the game's: a bot that always acts at 40% of
+   * whatever window it is given can never be timed out, so it can never detect
+   * a window that is too short. One that takes six seconds because six seconds
+   * is what the cadence table says the item costs can.
+   */
+  readonly thinkMs?: (statement: Statement) => number
 }
 
 export function playRun(
@@ -70,7 +80,10 @@ export function playRun(
     const index = statements.length - 1
     const current = statements[index]
     if (round.phase !== "call" || current === undefined || actedOn === index) continue
-    if (round.elapsedMs < current.windowMs * drawAt) continue
+    const readyAt = options.thinkMs ? options.thinkMs(current) : current.windowMs * drawAt
+    // Still working it out. If the window closes first the call is never made,
+    // which is exactly the failure this option exists to expose.
+    if (round.elapsedMs < readyAt) continue
     if (decide(current) === "draw") consume(round.press())
     actedOn = index
   }


### PR DESCRIPTION
An audit found two packs where **not doing the maths was the dominant strategy**. Both are fixed here, one commit each, against one governing rule from `dynawalla/docs/EXPERIENCE_DESIGN.md`:

> `T=0→C` COMPREHENSION — not budgeted. The child's time. Measured, never limited.

and the fleet invariant it implies: **the comprehension window is monotone non-decreasing in item difficulty.** A harder item may never get less time than an easier one.

---

## TRUEDRAW — the ramp was inverted by a cap

`windowFor = max(1750, min(3600, 1300 + 215d))`. The ceiling bit long before the difficulty did, so the *share* of the child's measured need fell as the item got harder.

| item | p50 | p90 | before | % of p50 | after | % of p50 |
|---|---|---|---|---|---|---|
| `7 + 8 = 15` | 2.8 s | 6 s | 2.16 s | 77% | **6.0 s** | 214% |
| `47 + 25 = 72` | 6 s | 14 s | 2.59 s | 43% | **14.0 s** | 233% |
| `753 + 577 = 1330` | 11 s | 27 s | 3.45 s | 31% | **27.0 s** | 245% |
| `5001 − 2798 = 2203` | 16 s | 40 s | 3.60 s | 23% | **40.0 s** | 250% |

Running out of time on a TRUE slate settles as a hold, which spends one of three shots, and the bag deals true/false in exact halves — so a child who could not finish lost a shot half the time by pure arithmetic. A bot taking the documented p50 could not finish a **single** statement inside the window it was given, at any rung of the ladder.

**The file's defence was false.** It claimed "the ones column alone rejects most mal-rules". `malRule.test.ts` proves otherwise, and most spectacularly for the mal-rule the dealer *prefers* — `pickFalsehood` weights the head of the distractor list at 55%, and the head is the dropped carry, whose ones column is `(a+b) mod 10`: the true ones digit, by construction. `47 + 25 = 62` and the true `72` both end in 2. Same for a borrow left at ten. Measured across the dealer's own stream, a last-digit check rejects **30%** of falsehoods.

`slow` is no longer reported to the curriculum. The shot still goes dark — so a timeout costs exactly what an honest wrong draw costs and refusing never dominates calling — but "I say that sum is wrong" and "I am still working it out" are the same event from inside the game, and betting on the first demotes a deliberate child. The hole (hold at everything, be credited on every false slate) is closed by the shot budget: half is three calls.

The window costs the child nothing: a correct draw stops the clock the instant they press.

## THE SPLIT — pressure that made the maths optional

Three numbers, all fixed:

1. **3.78 s usable** against a documented 6 s p50 for the exact skills `pack.json` declares — and 40 s p90 for `subtract-across-zero`, which it also declares. Now the cadence p90, monotone: **6.0 s** usable at difficulty 1, **13.1 s** at 5, **40.0 s** at 10 (before: 3.78 / 4.58 / 5.58).
2. **A wrong lantern cost a lamp; a timeout cost one point of favour.** `lampCost` is now zero for every verdict. Of the two ways to stop a timeout being cheaper than a wrong answer, charging the timeout a lamp bills a child for still thinking — so the wrong answer gives its lamp up instead. It still costs the whole favour economy, which was always the real deterrent. Lamps are spent on bombs, the one hazard a child chooses to touch. A timeout is not reported to the curriculum.
3. **`quiet` was not quiet.** It throttled the wave timer by 14% and never touched `floorCount()`, so the guaranteed 6–8 cuttable objects and the bomb spawner ran at full strength while the child computed. `Director.quiet` now stops the market outright — no waves, no floor, no bombs, no second sigil, no MARKET RUSH across a live equation — and comes back with a **surge**, not a trickle.

The hush lasts exactly as long as the question does. That is how a timeout ends up costing **more** than an honest wrong answer without costing a lamp: it forfeits the whole window of market a child who answers hands back the moment they cut. Nothing in that chain punishes a slow child — the time a deliberate child spends is time they are *using*.

### Does never-answering still dominate?

No, and it is asserted. `src/test/economy.test.ts` plays bots against both rulebooks over the same seeds:

```
before: refuser 32689 vs correct-but-slow 18756   (0 answers landed in 300s)
after:  refuser 11579 < guesser 59443 < reader 107564
```

Reading beats refusing at **every difficulty 1–10** and at **every slicing rate from 20 to 1200 points/second**. Guessing above refusing is deliberate: engaging badly must still beat looking away, or the game teaches a child that the safe move is not to try.

---

## Verification

Both suites pass 5×: truedraw 154/154, slice 114/114. `tsc --noEmit` clean, `build:pack` clean for both.

**Every new test was verified by deleting the fix and confirming failure** — exact messages in the working notes; a sample:

- truedraw window restored → `single-digit fact: 2160ms against a measured p90 of 6000ms` · `two-digit regrouping received 19% of its p90 after the previous rung received 36%` · `level 0: 3 of 5 calls were lost to the clock`
- truedraw report guard removed → `the report is unguarded again`
- mal-rules swapped for `answer + 1` noise → `every dropped carry must be invisible to a ones check` · `the ones column rejected 70.0% of falsehoods — the old defence would be back`
- slice window restored → `difficulty 1: 3.78s usable against a 6.0s p90` · `difficulty 3: refusing scored 19418, correct-but-slow scored 19418`
- slice lamp cost restored → `difficulty 1, reads it, honestly and slowly: lost 3 lamps with no bombs in play` · `guessing 5992 did not beat refusing 11579`
- slice hush reverted to a throttle → `5099 objects were thrown at a child who was reading` · `1073 bombs landed during a hush`
- slice mount unwired → `loseLamp is called from somewhere new` · `a favour update bypassed favourAfter`

Two new `wiring.test.ts` files read the mounts as text and guard the seams, because both defects existed precisely because the numbers were inline in a 2,000-line file where no test could see them.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb