### PR TITLE
fix(dynawalla/games/beam): the question stays on the wall, and the clock belongs to the child

### DIFF
--- a/dynawalla/games/beam/README.md
+++ b/dynawalla/games/beam/README.md
@@ -50,12 +50,42 @@ A **CORE** descends the middle of the lattice two seconds after the last one cle
 carrying a problem the host served — `247 + 158` — and fractures into one automaton per
 candidate value. Killing one hands it in.
 
-The number that is tuned here is the **dead time**, not the thinking time: the gap plus
-the core's approach is about four seconds, and the answering window — the candidates'
-fall from the fracture line to the floor — is about ten seconds early in a run, closing
-to six at full pressure. Comprehension is measured, never rationed; what was cut is the
-time with nothing on the lattice to think about. A wave ends the moment it is answered,
-so reading quickly is what buys the next problem.
+### The comprehension window
+
+The problem is carved into the far wall the moment the CORE enters and it stays there,
+at the size of the beam labels, until the wave is over. It is not on the slab and only
+on the slab: a slab near the vanishing point pins at the renderer's 9px floor, and a
+slab is deleted when it fractures. For a while this game asked a child to do a
+three-digit column sum from memory while sustaining a kill a second, and said in a
+comment that it did not.
+
+The answering window — the candidates' fall from the fracture line to the floor — comes
+from `sim/window.ts` and is a pure function of **the item**: its widest column, and
+whether it regroups. Nothing about the run's pressure can move it.
+
+| item | window |
+|---|---|
+| `4 + 3` | 6s |
+| `31 + 24` | 11s |
+| `27 + 15` | 14s |
+| `342 + 216` | 18s |
+| `247 + 158` | 23s |
+| `5,001 − 2,798` | 40s |
+
+Those are the house p90s from `docs/EXPERIENCE_DESIGN.md`, and the invariant they exist
+to keep is one line: **the window is monotone non-decreasing in the item's difficulty.**
+A harder question may never get less time than an easier one. It used to get exactly
+that — the window was `1.184 × descentSeconds`, and `descentSeconds` is the motion
+constant the pressure curve tightens, so it ran 11.84s down to 6.87s on the same curve
+that takes the requested difficulty from 2 to 9.
+
+The number the director still tunes is the **dead time** — the gap with nothing on the
+lattice to think about. A wave ends the moment it is answered, so reading quickly is
+what buys the next problem, and a fluent child never sees the end of a window.
+
+While a question is in the air the lattice **thins out**: fewer automata, further apart,
+crossing more slowly. Sparser and slower, never duller — the tight-divisor bias is
+untouched and the field is never empty.
 
 So a submission costs four real steps, three of them mathematics:
 
@@ -83,6 +113,15 @@ ladder hands it, and a quotient on the hull is the same object as a sum on the h
 The stream of ordinary automata is the game's own mathematics — divisibility over numbers
 the game itself made up. Nobody asked those questions, so nothing about them is reported.
 
+A wave that **runs out** is not reported either. It used to be, as
+`report({ correct: false, answered: "" })` — and the shared adapter throws `correct` away
+and forwards `answered` as the response to `items.answer`, where an empty string does not
+parse, so the host recorded a miss and stepped the ladder down. A child who was still
+carrying the hundreds column was written down as a child who cannot add, and guessing was
+strictly cheaper than thinking. The game now calls the optional `skip` hook, which is the
+SDK's `items.skip` — closed, unrecorded, ladder untouched — and where the adapter does
+not surface it yet, says nothing at all.
+
 ### Items that are passed over
 
 An answer with no divisor in the readable beam range — a prime like 83, or 169 — cannot
@@ -96,11 +135,25 @@ label at the foot of the lattice would print the answer. `usableCoreValue()` req
 divisor **strictly smaller** than the value, and `src/test/core.test.ts` asserts that no
 beam label is ever equal to a candidate's number.
 
+### When it is missed
+
+A wrong submission or a wave that runs out **finishes the sum on the wall** — `247 + 158`
+becomes `247 + 158 = 405`, the new part in the resonance colour, the same colour a
+correct answer is celebrated in — and the hall is **held still** while it is read. That
+hold is after STACK, whose sweep stops for its reveal so the child never reads one thing
+while aiming at another; here it also means a frozen lattice cannot take an anchor while
+the child is looking at arithmetic.
+
+A five-year-old putting nonsense in is still watching numerals, a `+`, and a column sum
+resolving, and that exposure is worth something even when the answer is not. It is the
+reason the miss is spent on the mathematics rather than on feedback about the miss:
+there is no red, no shake, no word for what happened, and no lamp goes out.
+
 ## Stakes
 
 Three anchors. An ordinary automaton reaching the floor breaches one; at zero the lattice
 goes dark. A wrong submission costs **no anchor** — it collapses the resonance multiplier
-to one, which is the entire economy, and the true statement is shown once, plainly. Two
+to one, which is the entire economy, and the sum is finished on the wall. Two
 cores read relights an anchor, cumulatively, and that progress is never taken away.
 
 Escalation is on the size of the run — elapsed time and total kills — and never on an
@@ -140,6 +193,7 @@ audio, which is not motion, is unchanged.
 | `src/sim/core.ts` | turning a served item into a wave |
 | `src/sim/field.ts` | the automata and their walk down the lattice |
 | `src/sim/director.ts` | pacing, the value stream, and the scoring gradient |
+| `src/sim/window.ts` | how long the child may have — a function of the item, and of nothing else |
 | `src/render/geom.ts` | the hall's perspective, pure and tested |
 | `src/render/hall.ts` | drawing, including the phasing traces |
 | `src/mount.ts` | the game: input, the frame loop, and the reporting seam |

--- a/dynawalla/games/beam/src/contract.ts
+++ b/dynawalla/games/beam/src/contract.ts
@@ -17,9 +17,38 @@ export type Question = {
 
 export type Host = {
   next(opts?: { domain?: string; difficulty?: number }): Question
+  /**
+   * An attempt the child made. **Only ever an attempt.**
+   *
+   * `report` is not a place to say "nothing happened". The shared adapter
+   * discards `correct` — the host judges, not the game — and forwards
+   * `answered` as the response to `items.answer`, so a report with an empty
+   * answer is not recorded as "unanswered", it is recorded as a MISS: the
+   * empty string does not parse, the learner model takes a wrong answer, and
+   * the ladder steps down. Against a child who may simply have still been
+   * carrying the hundreds column.
+   *
+   * So this game reports exactly one thing: a value that was struck.
+   */
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean
+
+  /**
+   * The item ran out of time on the lattice and nothing was handed in.
+   *
+   * OPTIONAL and feature-detected, exactly like `transition`. The SDK has the
+   * method this is for — `items.skip` marks an item closed **without recording
+   * an outcome and without moving the ladder**, which is the only honest thing
+   * to say about a child who was still computing — but the shared
+   * `game-host` adapter does not surface it yet. Until it does, a timeout here
+   * is reported as *nothing at all*, which is the safe direction: an unmeasured
+   * item costs a child nothing, and a fabricated miss costs them a rung.
+   *
+   * Never a judgement, never a latency worth modelling: the child did not
+   * answer, so there is no answer time to record.
+   */
+  skip?(questionId: string): void
 
   /**
    * A natural stopping point the child *reached*: a level cleared, a run

--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -34,6 +34,7 @@ import {
   drawAutomaton,
   drawBeams,
   drawHall,
+  drawPrompt,
   drawPulse,
   drawRunner,
   drawScore,
@@ -54,10 +55,11 @@ import {
 } from "./render/palette.ts"
 import { KIND_MOTE, KIND_SHARD, Particles } from "./render/particles.ts"
 import { buildCore, type CoreWave } from "./sim/core.ts"
-import { Director, fieldValue, killScore } from "./sim/director.ts"
+import { revealSeconds } from "./sim/window.ts"
+import { Director, fieldValue, killScore, readingRelief } from "./sim/director.ts"
 import { A_CANDIDATE, A_CORE, A_ORDINARY, type Automaton, Field } from "./sim/field.ts"
 import { phaseOffset, resonates, tuneLattice, validBeamCount } from "./sim/lattice.ts"
-import { resolveStrike } from "./sim/pulse.ts"
+import { resolveStrike, shovedUrgency } from "./sim/pulse.ts"
 
 const N_BEAMS = 5
 const ANCHORS = 3
@@ -141,6 +143,8 @@ export function mountBeam(el: HTMLElement, host: Host): {
           "Every so often a big blue robot comes down the middle with a sum on it, like 247 + 158.",
           "It breaks into several robots, each carrying a different number.",
           "Work out the sum, find the robot with the right number, and shoot that one.",
+          "Take as long as you like. Nothing lands while you are working it out.",
+          "If you miss it, the hall stops and the sum finishes itself so you can see it.",
           "Getting it wrong does not cost a light. It only resets how much each robot is worth.",
         ],
       },
@@ -208,6 +212,19 @@ export function mountBeam(el: HTMLElement, host: Host): {
   let wave: CoreWave | null = null
   let waveAskedAt = 0
   let coreBody: Automaton | null = null
+
+  /**
+   * THE FINISHED STATEMENT, after a miss or a wave that ran out.
+   *
+   * `left` runs the text down; `hold` freezes the lattice for exactly as long,
+   * which is the part of STACK's reveal that makes it work — its sweep is HELD
+   * so the child never reads one thing while aiming at another. A frozen hall
+   * costs the child nothing: no wave is live, so no answering window is
+   * running, and every automaton that was descending is exactly where it was
+   * when the hold lifts.
+   */
+  let reveal: { text: string; answer: string; left: number; max: number } | null = null
+  let hold = 0
 
   const pulses: Pulse[] = []
   for (let i = 0; i < 4; i++) pulses.push({ alive: false, col: 0, t: 0, prevT: 0, hits: 0 })
@@ -336,7 +353,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function spawnOrdinary(): void {
-    const p = director.pressure()
+    const p = wave ? readingRelief(director.pressure()) : director.pressure()
     const b = field.spawn()
     if (!b) return
     b.kind = A_ORDINARY
@@ -392,8 +409,17 @@ export function mountBeam(el: HTMLElement, host: Host): {
       return
     }
     wave = built
-    retune(built.candidates.map((c) => c.value))
-    const p = director.pressure()
+    const p = readingRelief(director.pressure())
+    // THE BODY IS DRESSED BEFORE THE LATTICE IS RETUNED, and the order is not a
+    // tidiness. `field.spawn()` hands back a body still wearing the blank
+    // defaults — `kind: A_ORDINARY, value: 0` — and `retune` disperses every
+    // ORDINARY body no beam divides. No beam divides zero. So the CORE was
+    // killed on the frame it was created, every single wave, since the day this
+    // function was written: it never descended, never fractured and never once
+    // painted its problem on the screen. What the child saw instead was an
+    // ordinary automaton hijacked mid-descent when `coreBody`'s pooled slot was
+    // handed out again, bursting into candidates for a question nobody had
+    // read.
     b.kind = A_CORE
     b.value = built.answer
     b.text = built.prompt
@@ -406,6 +432,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
     // approach.
     b.speed = 1 / (p.descentSeconds * 0.85)
     b.stepIn = 1e9
+    retune(built.candidates.map((c) => c.value))
     coreBody = b
     waveAskedAt = performance.now()
     asked++
@@ -417,7 +444,6 @@ export function mountBeam(el: HTMLElement, host: Host): {
     const w = wave
     if (!w) return
     core.fractured = true
-    const p = director.pressure()
     const cp = project(geom, core.slide, core.t)
     burst(cp.x, cp.y, colLapis, 40, 320, true)
     feel.addTrauma(0.25)
@@ -435,12 +461,18 @@ export function mountBeam(el: HTMLElement, host: Host): {
       b.beam = cols[i % cols.length] as number
       b.slide = core.slide
       b.t = core.t
-      // Slower than the stream, and it steps: a candidate has to be reachable
-      // from more than the beam it happened to land on. The fall from the
-      // fracture line to the floor is the answering window — about ten seconds
-      // early in a run, closing to six at full pressure, which brackets the
-      // house p50 of six and p90 of fourteen for two-digit regrouping.
-      b.speed = 1 / (p.descentSeconds * 1.6)
+      // THE ANSWERING WINDOW. The fall from wherever the core actually
+      // fractured to the floor takes exactly `windowSeconds`, which
+      // `sim/window.ts` computed from the ITEM — its columns and its
+      // regrouping — and which nothing about the run's pressure can move.
+      //
+      // It used to be `1 / (descentSeconds * 1.6)`, and `descentSeconds` is the
+      // motion constant the pressure curve tightens: the window ran 11.84s down
+      // to 6.87s on exactly the curve that took the requested difficulty from 2
+      // to 9. Harder question, 42% less time. The divisor here is the remaining
+      // distance rather than a constant so the window is the same length
+      // whichever frame the fracture landed on.
+      b.speed = Math.max(1e-4, (1 - core.t) / w.windowSeconds)
       b.stepIn = 0.55 + i * 0.12
       b.stepDir = i % 2 === 0 ? 1 : -1
     })
@@ -458,19 +490,43 @@ export function mountBeam(el: HTMLElement, host: Host): {
     }
   }
 
+  /**
+   * Finish the sum on the wall, and hold the hall still while it is read.
+   *
+   * The only thing that happens after a miss. It is deliberately built out of
+   * the same parts a success is — the resonance colour, a `light` cue, the
+   * plate lighting up — and none of the parts a scolding is. There is no word
+   * for what happened, no red, no shake and no lamp going out: a wrong
+   * submission has never cost an anchor in this game and it does not start now.
+   */
+  function completeSum(w: CoreWave): void {
+    const seconds = revealSeconds({ prompt: w.prompt, answer: w.answer })
+    reveal = { text: w.prompt, answer: String(w.answer), left: seconds, max: seconds }
+    hold = seconds
+    audio.riser()
+  }
+
   function expireWave(): void {
     const w = wave
     if (!w) return
-    // Reported, and honestly: the child did not answer. `answered` is empty
-    // because nothing was handed in, and this is the one report in the game
-    // that is not the result of an action.
-    host.report({
-      questionId: w.questionId,
-      correct: false,
-      ms: Math.round(performance.now() - waveAskedAt),
-      answered: "",
-    })
-    showBanner(`${w.prompt} = ${w.answer}`, "", LAPIS_HOT, 1.6)
+    // A TIMEOUT IS NOT A WRONG ANSWER.
+    //
+    // This used to call `host.report({ correct: false, answered: "" })` under a
+    // comment claiming that was the honest thing. It was the opposite. The
+    // shared adapter throws `correct` away — the host judges, not the game —
+    // and forwards `answered` as the response to `items.answer`; an empty
+    // string does not parse as a number, so the host recorded a MISS and
+    // stepped the ladder down. A child who was still carrying the hundreds
+    // column was written into the learner model as a child who cannot add, and
+    // guessing was strictly cheaper than thinking.
+    //
+    // `skip` is the SDK's word for this and it records nothing and moves
+    // nothing. It is feature-detected: a host without it hears silence, which
+    // is what an unmeasured item should sound like.
+    host.skip?.(w.questionId)
+    // Not a buzzer and not a life ticking down: the sum finishes on the wall,
+    // in the same place it has been legible all along.
+    completeSum(w)
     clearCandidates(true)
     wave = null
     coreBody = null
@@ -558,8 +614,10 @@ export function mountBeam(el: HTMLElement, host: Host): {
   function dissonance(body: Automaton): void {
     body.ring = 0.5
     // The cost of a wrong read is time, not damage: the automaton is shoved
-    // down the lattice. Nothing is deducted, nothing is scolded.
-    body.urgency = Math.min(2.4, body.urgency + 0.35)
+    // down the lattice. Nothing is deducted, nothing is scolded — and a
+    // CANDIDATE is not shoved at all, because its fall is the child's thinking
+    // time and probing the beams is this game's listening verb.
+    body.urgency = shovedUrgency(body.kind, body.urgency)
     const p = project(geom, body.slide, body.t)
     burst(p.x, p.y, colWrong, 8, 130)
     audio.dissonance()
@@ -615,17 +673,24 @@ export function mountBeam(el: HTMLElement, host: Host): {
         host.transition?.("level", `${coresRead} cores`)
       }
     } else {
+      // What a miss is made of, and what it is deliberately NOT made of.
+      //
+      // It used to be a copper-oxide screen flash, a screenshake, a `failure`
+      // haptic and a red burst — four channels of feedback about having been
+      // wrong — followed by the statement being taken away after a second and a
+      // half. Maximum discouragement, minimum information, in that order.
+      //
+      // What is left is a hull coming apart in brass, a figure that falls
+      // without scolding, and the sum completing on the wall. A wrong
+      // submission still costs the multiplier, which is the whole economy and
+      // is the reason a guess is not free; it has never cost an anchor.
       audio.settleWrong()
-      feel.kick(0, 1, 9)
-      feel.addTrauma(0.28)
-      feel.requestFlash(0.12, DISSONANT)
-      host.haptic("failure")
-      // The whole economy, gone. That is the cost of a guess — never an anchor,
-      // never a lecture, and the true statement is shown once, plainly.
+      feel.kick(0, 1, 3)
+      host.haptic("light")
       resonance = 1
       resonanceLeft = 0
-      burst(p.x, p.y, colWrong, 26, 300)
-      showBanner(`${w.prompt} = ${w.answer}`, "", LAPIS_HOT, 1.7)
+      burst(p.x, p.y, colBrass, 18, 220)
+      completeSum(w)
       clearCandidates(true)
       wave = null
     }
@@ -678,6 +743,8 @@ export function mountBeam(el: HTMLElement, host: Host): {
     wave = null
     coreBody = null
     banner = null
+    reveal = null
+    hold = 0
     field.clear()
     parts.clear()
     feel.reset()
@@ -766,7 +833,34 @@ export function mountBeam(el: HTMLElement, host: Host): {
   let raf = 0
 
   function step(dt: number): void {
-    const p = director.pressure()
+    if (reveal) {
+      reveal.left -= dt
+      if (reveal.left <= 0) reveal = null
+    }
+    if (hold > 0) {
+      // THE HOLD. The lattice is still while the sum finishes: nothing
+      // descends, nothing spawns, no pulse travels and the clock the director
+      // escalates on does not advance. Only the decoration keeps moving, so a
+      // held hall reads as held rather than as crashed.
+      hold -= dt
+      parts.update(dt)
+      for (const q of pops) {
+        if (!q.alive) continue
+        q.life -= dt
+        q.y -= dt * 46
+        if (q.life <= 0) q.alive = false
+      }
+      if (banner) {
+        banner.life -= dt
+        if (banner.life <= 0) banner = null
+      }
+      return
+    }
+    // While a question is on the lattice the stream backs off — fewer automata,
+    // further apart, crossing more slowly. Sparser and slower around the
+    // answering moment, never duller: the tight-divisor bias and every effect
+    // in the game are untouched, and the floor never reaches zero.
+    const p = wave ? readingRelief(director.pressure()) : director.pressure()
     director.advance(dt)
     fireCooldown = Math.max(0, fireCooldown - dt)
     if (chainTimer > 0) {
@@ -907,7 +1001,13 @@ export function mountBeam(el: HTMLElement, host: Host): {
     drawRunner(g, geom, runnerSlide, fireCooldown > 0 ? 1 : locked ? 0.7 : 0.2, q.glow)
     g.restore()
 
-    // Chrome sits outside the shake so the numbers never blur.
+    // Chrome sits outside the shake so the numbers never blur. THE PROMPT MOST
+    // OF ALL: it is drawn here, after `g.restore()`, for every frame the wave
+    // is live — which is every frame an answer is still accepted, approach and
+    // fall alike. It is never a memory test. It is never 9px. It does not move,
+    // it does not shake, and it is not deleted at the fracture line.
+    if (wave) drawPrompt(g, geom, wave.prompt, null)
+    else if (reveal) drawPrompt(g, geom, reveal.text, reveal.answer)
     drawScore(g, geom, score, resonance)
     drawAnchors(g, geom, anchors, ANCHORS, credit, READ_PER_ANCHOR)
 

--- a/dynawalla/games/beam/src/render/geom.ts
+++ b/dynawalla/games/beam/src/render/geom.ts
@@ -37,6 +37,19 @@ export type Geom = {
   margin: number
   /** Where the beam labels are carved. Inside the safe area, by construction. */
   labelY: number
+  /**
+   * Where the CORE's problem is carved into the far wall.
+   *
+   * This is the most important text in the game and it used to have nowhere to
+   * live: the prompt was painted on the descending slab, which pins at the 9px
+   * floor near the vanishing point, and the slab was killed at the fracture
+   * line. The child then did three-digit column arithmetic from memory.
+   *
+   * The band sits BETWEEN the host's two 44px corners horizontally and above
+   * the score block vertically, so it collides with neither at any viewport —
+   * `hitsHostChrome` asserts exactly that in `render/geom.test.ts`.
+   */
+  prompt: Rect
   /** The score and resonance block, clear of the host's exit control. */
   hud: Rect
   /** The anchor lamps: the RIGHTMOST lamp's centre, and the row's metrics. */
@@ -60,6 +73,11 @@ function insetsOf(w: number, h: number, area: Rect): Insets {
   }
 }
 
+/** One expression, so the horizon cannot drift from what the prompt band uses. */
+function horizonYOf(area: Rect, ah: number): number {
+  return area.y + ah * 0.155
+}
+
 /**
  * @param area the safe rectangle, from `safeRect(w, h)`. REQUIRED — optional
  * would mean a caller that forgets it still compiles and quietly draws the
@@ -81,14 +99,28 @@ export function makeGeom(w: number, h: number, columns: number, area: Rect): Geo
   const r = 6
   const gap = 18
 
+  // The far wall, between the host's corners: the prompt's home. Bounded below
+  // by the score block as well as by the horizon, because on a 320x480 lattice
+  // the horizon sits *under* the score and the two would overprint.
+  const promptGap = 8
+  const promptLeft = exit.x + exit.w + promptGap
+  const hudY = exit.y + exit.h + 8
+  const promptRect: Rect = {
+    x: promptLeft,
+    y: area.y,
+    w: Math.max(80, help.x - promptGap - promptLeft),
+    h: Math.max(30, Math.min(horizonYOf(area, ah), hudY - 4) - area.y),
+  }
+
   return {
     w,
     h,
     area,
     columns: Math.max(1, columns),
     vpX: area.x + aw * 0.5,
-    horizonY: area.y + ah * 0.155,
+    horizonY: horizonYOf(area, ah),
     floorY,
+    prompt: promptRect,
     // Wide enough that the outermost beam's label is never clipped.
     margin: Math.max(26, Math.min(aw * 0.11, 74)),
     labelY: floorY + (area.y + ah - floorY) * 0.5,

--- a/dynawalla/games/beam/src/render/hall.ts
+++ b/dynawalla/games/beam/src/render/hall.ts
@@ -96,6 +96,132 @@ export function drawHall(g: CanvasRenderingContext2D, geom: Geom): void {
   g.fillRect(0, geom.floorY + 2, geom.w, 2)
 }
 
+/**
+ * The floor under the prompt's type size, in CSS pixels.
+ *
+ * The prompt used to be painted on the descending slab at
+ * `max(9, r * 0.78)` — and `r` pins at 7 near the vanishing point, so the value
+ * was **9px, at every difficulty, for its entire life**. Nine pixels is the
+ * size the renderer falls back to so that a thing far up the lattice still has
+ * *some* mark on it; it is not a size a seven-year-old reads a column sum at.
+ *
+ * Below this number the prompt is not a question, it is a decoration of one.
+ */
+export const PROMPT_MIN_PX = 18
+
+export type PromptPlate = {
+  /** The carved recess. Never overlapping the host's two corners. */
+  box: { x: number; y: number; w: number; h: number }
+  /** Type size, already fitted to the box. Never below `PROMPT_MIN_PX`. */
+  px: number
+  cx: number
+  cy: number
+}
+
+/**
+ * Where and how large the CORE's problem is carved, for this hall and this text.
+ *
+ * Pure, and exported, so the legibility floor is a thing tests assert rather
+ * than a thing a screenshot might have caught. The width fit is done against a
+ * measured advance where one is available, which is what keeps a long prompt
+ * from running out over the beams instead of shrinking.
+ */
+export function promptPlate(
+  geom: Geom,
+  text: string,
+  measure?: (t: string, px: number) => number,
+): PromptPlate {
+  const box = geom.prompt
+  // Big: this is the question. Capped so it does not become a headline on a
+  // desktop, floored so it stays a question on a phone.
+  let px = Math.max(PROMPT_MIN_PX, Math.min(box.h * 0.62, box.w * 0.13, 42))
+  const width = measure ? measure(text, px) : text.length * px * 0.56
+  if (width > box.w && width > 0) px = Math.max(PROMPT_MIN_PX, (px * box.w) / width)
+  return { box, px, cx: box.x + box.w / 2, cy: box.y + box.h / 2 }
+}
+
+/**
+ * THE QUESTION, carved into the far wall for as long as it can be answered —
+ * and then, if it was missed, **completed there.**
+ *
+ * Not a HUD card and not a banner: a recess cut into the stone the beams come
+ * out of, in the same material language as the beam labels at their feet. The
+ * child's eye travels wall → lattice → floor, and the two numbers that decide
+ * the submission — the sum up there, the divisors down here — sit at the two
+ * ends of that travel at comparable size.
+ *
+ * There is deliberately **no clock on it.** How long is left is already told by
+ * where the candidates are, which is information the child reads without being
+ * counted down at.
+ *
+ * `reveal` is the finished statement, after STACK, whose HUD substitutes the
+ * answer into the prompt it was already showing rather than raising a second
+ * surface: the eye lands on exactly the thing that changed. `473 + 168` becomes
+ * `473 + 168 = 641`, in place, and the completed part is drawn in the
+ * **resonance colour — the one a correct answer celebrates in.** A miss is
+ * completed the same way a success is, only quieter. There is no red here and
+ * there is no word for what happened.
+ *
+ * A five-year-old typing nonsense is still watching a column sum resolve, and
+ * that exposure is the whole reason this branch exists.
+ */
+export function drawPrompt(
+  g: CanvasRenderingContext2D,
+  geom: Geom,
+  text: string,
+  reveal: string | null = null,
+): void {
+  if (text === "") return
+  // A surface that cannot measure falls back to the estimate rather than
+  // throwing inside the frame loop. Nothing about the question a child is
+  // reading may depend on `measureText` having worked.
+  const advance = (t: string, px: number): number => {
+    g.font = font(NUM_FONT, px)
+    const w = g.measureText(t).width
+    return Number.isFinite(w) && w > 0 ? w : t.length * px * 0.56
+  }
+  const tail = reveal === null ? "" : ` = ${reveal}`
+  const whole = text + tail
+  // Sized against the WHOLE statement, so the completed sum is what fits and
+  // the type does not jump when the answer arrives.
+  const plate = promptPlate(geom, whole, advance)
+  const padX = plate.px * 0.5
+  const padY = plate.px * 0.36
+  const wholeW = advance(whole, plate.px)
+  const w = Math.min(plate.box.w, wholeW + padX * 2)
+  const h = plate.px + padY * 2
+
+  // The recess: a darker cut with a lit lower lip, so it reads as carved into
+  // the wall rather than laid on top of it. On a completed sum the lip takes
+  // the resonance colour — the recess lights up, it does not turn red.
+  g.fillStyle = withAlpha(INK, 0.5)
+  g.fillRect(plate.cx - w / 2, plate.cy - h / 2, w, h)
+  g.fillStyle = reveal === null ? withAlpha(STONE_EDGE, 0.55) : withAlpha(RESONANT, 0.8)
+  g.fillRect(plate.cx - w / 2, plate.cy + h / 2 - 1.5, w, 1.5)
+
+  g.font = font(NUM_FONT, plate.px)
+  g.textBaseline = "middle"
+  if (reveal === null) {
+    g.textAlign = "center"
+    g.fillStyle = withAlpha(INK, 0.85)
+    g.fillText(text, plate.cx, plate.cy + 1.5)
+    g.fillStyle = LAPIS_HOT
+    g.fillText(text, plate.cx, plate.cy)
+    return
+  }
+  // Two runs on one baseline: the question as it was, then the part that is
+  // new, in the resonance colour.
+  g.textAlign = "left"
+  const x0 = plate.cx - wholeW / 2
+  g.fillStyle = withAlpha(INK, 0.85)
+  g.fillText(whole, x0, plate.cy + 1.5)
+  g.fillStyle = LAPIS_HOT
+  g.fillText(text, x0, plate.cy)
+  g.fillStyle = RESONANT
+  g.fillText(tail, x0 + advance(text, plate.px), plate.cy)
+  g.textAlign = "center"
+}
+
 export type BeamStyle = {
   /** 0..1 — how lit this beam is. The ridden beam sits near 1. */
   lit: number

--- a/dynawalla/games/beam/src/sim/core.ts
+++ b/dynawalla/games/beam/src/sim/core.ts
@@ -16,6 +16,7 @@
 // what was struck.
 
 import { beamDivisors, resonates, tuneLattice, usableCoreValue } from "./lattice.ts"
+import { comprehensionWindow } from "./window.ts"
 
 export type Candidate = { value: number; correct: boolean }
 
@@ -27,6 +28,15 @@ export type CoreWave = {
   /** Beam labels, ascending. Tuned so every candidate below is killable. */
   beams: number[]
   candidates: Candidate[]
+  /**
+   * How long the candidates are answerable for, in seconds.
+   *
+   * Carried on the wave rather than read off the pressure curve at fracture
+   * time, because it belongs to the ITEM: this is the number that must never
+   * fall when the question gets harder, and it is computed by
+   * `sim/window.ts` from the prompt and the answer alone.
+   */
+  windowSeconds: number
 }
 
 /**
@@ -142,5 +152,6 @@ export function buildCore(
     answer,
     beams,
     candidates: order.map((value) => ({ value, correct: value === answer })),
+    windowSeconds: comprehensionWindow({ prompt: source.prompt, answer }),
   }
 }

--- a/dynawalla/games/beam/src/sim/director.ts
+++ b/dynawalla/games/beam/src/sim/director.ts
@@ -97,11 +97,17 @@ export class Director {
    * curriculum item in front of a child every twenty-four seconds of play. That
    * is a shooter with some arithmetic in it rather than the other way round.
    *
-   * The answering window is deliberately NOT part of the tightening: a child's
-   * comprehension time is measured, never rationed. What was cut is the time
-   * with nothing to think about. A wave ends the moment it is answered, so
-   * reading quickly is what buys the next problem — the pacing rewards fluency
-   * instead of running on a fixed clock.
+   * **The answering window is not in this file at all**, and the sentence that
+   * used to sit here — "comprehension time is measured, never rationed" — was
+   * false when it was written. The window WAS in this file, as
+   * `descentSeconds`, and every line of the pressure curve above tightened it:
+   * 11.84s at a cold start down to 6.87s at the top, a 42% cut applied on
+   * exactly the curve that raises the requested item difficulty from 2 to 9.
+   *
+   * It now lives in `sim/window.ts`, is a pure function of the item, and cannot
+   * see this class. What this file still tightens is the DEAD time — the gap
+   * with nothing on the lattice to think about — and the motion, which is the
+   * excitement. Those two may escalate. The child's thinking time may not.
    */
   wantsCore(coreLive: boolean): boolean {
     if (coreLive) return false
@@ -129,6 +135,38 @@ export class Director {
     this.sinceSpawn = 0
     this.sinceCore = 0
     this.coresRun = 0
+  }
+}
+
+/**
+ * The lattice while a question is being read: sparser and slower, never duller.
+ *
+ * The complaint this answers is a specific one. A child doing a three-digit
+ * column sum was also being asked to sustain roughly one divisibility kill per
+ * second or lose an anchor, which is not two things at once, it is one thing
+ * with the arithmetic squeezed out of it. So for as long as a CORE's candidates
+ * are in the air the stream backs off: fewer automata, further apart, crossing
+ * more slowly.
+ *
+ * What is deliberately NOT relieved:
+ *
+ *   * `tightness` — the bias toward values only one beam divides. That is the
+ *     pedagogy written into the economy, and turning it down during the one
+ *     moment the game is most about mathematics would be exactly backwards.
+ *   * `floorCount` never reaches zero. A lattice with nothing on it is a
+ *     lattice with no mathematics on it, and an empty screen is not calm, it
+ *     is dead air.
+ *
+ * The relief is applied at spawn time, so nothing already descending changes
+ * speed underneath the child's hands.
+ */
+export function readingRelief(p: Pressure): Pressure {
+  return {
+    ...p,
+    descentSeconds: p.descentSeconds * 1.3,
+    stepSeconds: p.stepSeconds * 1.2,
+    spawnGap: p.spawnGap * 1.75,
+    floorCount: Math.max(2, Math.round(p.floorCount * 0.55)),
   }
 }
 

--- a/dynawalla/games/beam/src/sim/pulse.ts
+++ b/dynawalla/games/beam/src/sim/pulse.ts
@@ -41,3 +41,25 @@ export function resolveStrike(
 export function canKill(beam: number, value: number): boolean {
   return resonates(beam, value)
 }
+
+/** Ceiling on the shove, so a column of stray shots cannot teleport a hull. */
+const MAX_URGENCY = 2.4
+const SHOVE = 0.35
+
+/**
+ * What a dissonant strike does to how fast a body is walking.
+ *
+ * On an ORDINARY automaton the cost of a wrong read is time: it is shoved
+ * further down the lattice. Nothing is deducted and nothing is scolded, and
+ * that is the right cost for a number the game itself made up.
+ *
+ * On a **CANDIDATE it is nothing at all.** A candidate's fall IS the
+ * comprehension window, probing the beams is this game's listening verb, and
+ * charging the child's thinking time for using it rations precisely what
+ * `docs/EXPERIENCE_DESIGN.md` forbids rationing — by up to 2.4× at that. A
+ * candidate rings, and stays exactly where the arithmetic left it.
+ */
+export function shovedUrgency(kind: number, urgency: number): number {
+  if (kind === A_CANDIDATE) return urgency
+  return Math.min(MAX_URGENCY, urgency + SHOVE)
+}

--- a/dynawalla/games/beam/src/sim/window.ts
+++ b/dynawalla/games/beam/src/sim/window.ts
@@ -1,0 +1,143 @@
+// THE COMPREHENSION WINDOW — how long the child may have.
+//
+// `docs/EXPERIENCE_DESIGN.md` is unambiguous about this and it is the one line
+// in the house design that is a prohibition rather than a target:
+//
+//     T=0→C COMPREHENSION | not budgeted | The child's time. Measured, never
+//     limited.
+//
+// A game where the question walks down a lattice cannot take that literally —
+// something has to reach the floor eventually or the board never clears. What
+// it CAN do, and what this module exists to guarantee, is the invariant
+// underneath it:
+//
+//     **The window is monotone non-decreasing in the item's difficulty.**
+//     A harder question may never get less time than an easier one.
+//
+// This game used to break that outright. The window was the candidates' fall,
+// the fall was `1.184 × descentSeconds`, and `descentSeconds` is the MOTION
+// constant the pressure curve tightens as a run escalates — so the window ran
+// 11.84s down to 6.87s on exactly the curve that took the requested item
+// difficulty from 2 to 9. Harder maths, 42% less time. Excitement and
+// comprehension were on one knob, and the knob was labelled excitement.
+//
+// So the window is computed HERE, from the item and nothing else. Nothing in
+// this file may import the director, read a pressure level, or take a run's
+// elapsed time as an argument. That is the decoupling, stated structurally.
+//
+// The numbers are the house cadence table's **p90**, not its p50: the window is
+// the point at which the board takes the question away, so it is sized for the
+// child who is slow today, not the median one.
+//
+//     single-digit fact          2.8s / 6s
+//     two-digit with regrouping    6s / 14s
+//     the `5,001 − 2,798` class   16s / 40s
+
+/** Nothing is ever answerable for less than this, whatever the parser makes of it. */
+export const MIN_WINDOW_SECONDS = 6
+/**
+ * Nor for more. Not a budget — a guard against a malformed prompt parsing as
+ * nine columns and leaving a wave drifting for a minute and a half.
+ */
+export const MAX_WINDOW_SECONDS = 44
+
+/**
+ * Seconds by column count, straight off the table: index 1 is the single-digit
+ * fact's p90, index 2 and index 4 are the two rows the table names, and index 3
+ * is between them. Strictly increasing, which is half of the invariant.
+ */
+const BY_COLUMNS = [6, 6, 11, 18, 32] as const
+
+/**
+ * What regrouping is worth on top, per column count.
+ *
+ * `11 + 3 = 14` is the two-digit-with-regrouping row exactly, and `32 + 8 = 40`
+ * is the `5,001 − 2,798` row exactly. Each of these is small enough that
+ * `BY_COLUMNS[n] + REGROUPING[n] <= BY_COLUMNS[n + 1]` — which is the other
+ * half of the invariant, and is asserted rather than assumed.
+ */
+const REGROUPING = [0, 0, 3, 5, 8] as const
+
+export type Item = {
+  /** As the child reads it: `247 + 158`. */
+  prompt: string
+  /** The canonical value the host revealed. Never computed here. */
+  answer: number
+}
+
+/**
+ * The widest column count in the item — the operands and the answer together.
+ *
+ * The answer counts because it is a column wider than either operand whenever
+ * the top place carries, and that carried column is the one the child is still
+ * holding when the board decides they are out of time.
+ */
+export function widestColumn(item: Item): number {
+  let widest = 1
+  for (const run of item.prompt.match(/\d+/g) ?? []) widest = Math.max(widest, run.length)
+  if (Number.isInteger(item.answer) && item.answer > 0) {
+    widest = Math.max(widest, String(Math.abs(item.answer)).length)
+  }
+  return widest
+}
+
+const OPERATOR = /^\s*(\d+)\s*([+\-−])\s*(\d+)\s*$/
+
+/**
+ * Does this item need a carry or a borrow anywhere?
+ *
+ * A prompt this cannot parse — a word problem, a form this game has not met yet
+ * — reads as **true**, which is the longer window. Guessing in the child's
+ * favour is the only direction this function is allowed to be wrong in.
+ */
+export function needsRegrouping(prompt: string): boolean {
+  const m = OPERATOR.exec(prompt)
+  if (!m) return true
+  const a = Number(m[1])
+  const b = Number(m[3])
+  if (!Number.isSafeInteger(a) || !Number.isSafeInteger(b)) return true
+  const add = m[2] === "+"
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    if (add && (x % 10) + (y % 10) >= 10) return true
+    if (!add && x % 10 < y % 10) return true
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return false
+}
+
+/**
+ * How long this item is answerable for, in seconds.
+ *
+ * Monotone non-decreasing in both of its inputs — more columns is never less
+ * time, and needing to regroup is never less time than not needing to — and
+ * a function of the item alone. A wave still ends the moment it is answered, so
+ * this is a ceiling a fluent child never touches, not a pace anybody is held to.
+ */
+export function comprehensionWindow(item: Item): number {
+  const columns = Math.max(1, Math.min(BY_COLUMNS.length - 1, widestColumn(item)))
+  const base = BY_COLUMNS[columns] ?? MIN_WINDOW_SECONDS
+  const extra = needsRegrouping(item.prompt) ? (REGROUPING[columns] ?? 0) : 0
+  return Math.max(MIN_WINDOW_SECONDS, Math.min(MAX_WINDOW_SECONDS, base + extra))
+}
+
+/**
+ * How long the finished statement is held on the wall after a miss.
+ *
+ * This is the other half of the same argument and it is not a punishment
+ * interval. A child who cannot yet produce `473 + 168` can still absorb it if
+ * the game shows the whole thing completing — learning by exposure, at the
+ * bottom of the range, which is a stated goal of the product. The miss is the
+ * teaching moment, so the game spends it on the mathematics rather than on
+ * feedback about the failure.
+ *
+ * Longer for a wider sum, because a wider sum takes longer to read. Bounded at
+ * both ends: never so short that it flashes past, never so long that a child
+ * who knows what happened is kept waiting.
+ */
+export function revealSeconds(item: Item): number {
+  const columns = Math.max(1, Math.min(BY_COLUMNS.length - 1, widestColumn(item)))
+  return Math.min(3, 1.5 + columns * 0.3)
+}

--- a/dynawalla/games/beam/src/stubHost.ts
+++ b/dynawalla/games/beam/src/stubHost.ts
@@ -106,6 +106,12 @@ export type StubHostOptions = {
   reducedMotion?: boolean
   /** Observe reports — the dev harness draws a running accuracy readout. */
   onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /**
+   * Observe items that ran out of time. Separate from `onReport` on purpose:
+   * these are NOT attempts, they do not enter the accuracy readout, and the
+   * whole point of the seam is that the two can never be conflated again.
+   */
+  onSkip?: (questionId: string) => void
   /** Observe haptics so the harness can show they fired on a device with none. */
   onHaptic?: (k: string) => void
 }
@@ -159,6 +165,10 @@ export function createStubHost(opts: StubHostOptions = {}): Host {
 
     report(r) {
       opts.onReport?.(r)
+    },
+
+    skip(questionId) {
+      opts.onSkip?.(questionId)
     },
 
     haptic(k) {

--- a/dynawalla/games/beam/src/test/comprehension.test.ts
+++ b/dynawalla/games/beam/src/test/comprehension.test.ts
@@ -1,0 +1,1072 @@
+// THE COMPREHENSION WINDOW — the child's time, and what they can see while
+// they spend it.
+//
+// `docs/EXPERIENCE_DESIGN.md`: **"T=0→C COMPREHENSION — not budgeted. The
+// child's time. Measured, never limited."**
+//
+// Three things have to be true for that sentence to mean anything in a game
+// where the question walks down a lattice, and each of them is a test below:
+//
+//   1. **The question is on the screen, legibly, for as long as an answer is
+//      accepted.** A prompt that is deleted at the fracture line turns column
+//      arithmetic into a memory test with a shooter running underneath it.
+//   2. **The window follows the ITEM, never the motion.** The descent speed is
+//      the excitement knob. If the two share a knob then the harder question
+//      gets the shorter window, which is the exact inversion of the rule.
+//   3. **Running out of time is not being wrong.** A child who was still
+//      computing must not be written into the learner model as a child who
+//      cannot do the skill.
+//
+// These are asserted through the real `mountBeam` on a virtual clock, with a
+// recording 2D context, because every one of them was true of the code's
+// *comments* while being false of the code.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { mount } from "../contract.ts"
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { geomForViewport } from "../render/geom.ts"
+import { promptPlate, PROMPT_MIN_PX } from "../render/hall.ts"
+import { buildCore } from "../sim/core.ts"
+import { Director, readingRelief } from "../sim/director.ts"
+import { A_CANDIDATE, A_ORDINARY } from "../sim/field.ts"
+import { shovedUrgency } from "../sim/pulse.ts"
+import {
+  comprehensionWindow,
+  MAX_WINDOW_SECONDS,
+  MIN_WINDOW_SECONDS,
+  needsRegrouping,
+  widestColumn,
+} from "../sim/window.ts"
+import { createStubHost } from "../stubHost.ts"
+
+// ─── A surface that remembers what was painted ────────────────────────────────
+
+type Painted = { text: string; px: number; x: number; y: number }
+
+type Recorder = {
+  el: HTMLElement
+  install(): () => void
+  step(ms: number): void
+  /** What `fillText` drew, frame by frame. Index is the frame number. */
+  readonly frames: Painted[][]
+  press(key: string): void
+}
+
+/**
+ * Like `loop.test.ts`'s stub surface, but the 2D context is a recorder rather
+ * than a black hole: `font` is parsed and every `fillText` is filed under the
+ * frame it happened in. That is the only way to assert the thing that actually
+ * matters here — that a child looking at the screen can READ the question.
+ *
+ * `measureText` returns a realistic advance width for the current size, so a
+ * plate that shrinks its type to fit shrinks it in this test too.
+ */
+function recorder(width: number, height: number, wallClock: number): Recorder {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const keys = new Map<string, (e: unknown) => void>()
+  const frames: Painted[][] = []
+  let px = 10
+
+  const ctx = {
+    font: "",
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    globalAlpha: 1,
+    textAlign: "",
+    textBaseline: "",
+    globalCompositeOperation: "",
+    canvas: { width, height },
+    setTransform: () => undefined,
+    save: () => undefined,
+    restore: () => undefined,
+    translate: () => undefined,
+    scale: () => undefined,
+    rotate: () => undefined,
+    transform: () => undefined,
+    resetTransform: () => undefined,
+    beginPath: () => undefined,
+    closePath: () => undefined,
+    moveTo: () => undefined,
+    lineTo: () => undefined,
+    arc: () => undefined,
+    ellipse: () => undefined,
+    rect: () => undefined,
+    fill: () => undefined,
+    stroke: () => undefined,
+    fillRect: () => undefined,
+    clearRect: () => undefined,
+    clip: () => undefined,
+    createLinearGradient: () => ({ addColorStop: () => undefined }),
+    createRadialGradient: () => ({ addColorStop: () => undefined }),
+    measureText: (t: string) => ({ width: t.length * px * 0.56 }),
+    fillText: (t: string, x: number, y: number) => {
+      const frame = frames[frames.length - 1]
+      // Position too: it is what proves the hall is HELD during a reveal
+      // rather than merely still carrying the same numerals.
+      if (frame) frame.push({ text: t, px, x, y })
+    },
+  }
+  // `font` is a plain property on a real context and the size has to be read
+  // back out of the shorthand, which is what a browser does too.
+  Object.defineProperty(ctx, "font", {
+    get: () => `${String(px)}px sans-serif`,
+    set: (value: string) => {
+      const m = /(\d+(?:\.\d+)?)px/.exec(value)
+      if (m?.[1] !== undefined) px = Number(m[1])
+    },
+    configurable: true,
+  })
+
+  const makeEl = (): HTMLElement => {
+    const el = {
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      appendChild: () => undefined,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener: (k: string, h: (e: unknown) => void) => keys.set(k, h),
+      removeEventListener: (k: string) => keys.delete(k),
+    }
+    return el as unknown as HTMLElement
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    key: globalThis.addEventListener,
+    unkey: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    dateNow: Date.now,
+    nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
+  }
+
+  return {
+    el: makeEl(),
+    frames,
+    install: () => {
+      globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+        pending = cb
+        return 1
+      }) as typeof globalThis.requestAnimationFrame
+      globalThis.cancelAnimationFrame = ((): void => {
+        pending = null
+      }) as typeof globalThis.cancelAnimationFrame
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+        observe(): void {}
+        disconnect(): void {}
+      }
+      performance.now = () => clock
+      Date.now = () => wallClock
+      Object.defineProperty(globalThis, "navigator", {
+        value: { hardwareConcurrency: 12 },
+        configurable: true,
+        writable: true,
+      })
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+      globalThis.addEventListener = ((k: string, h: (e: unknown) => void): void => {
+        keys.set(k, h)
+      }) as unknown as typeof globalThis.addEventListener
+      globalThis.removeEventListener = ((k: string): void => {
+        keys.delete(k)
+      }) as unknown as typeof globalThis.removeEventListener
+      ;(globalThis as { document?: unknown }).document = {
+        createElement: () => makeEl(),
+        getElementById: () => null,
+        body: makeEl(),
+      }
+      return () => {
+        globalThis.requestAnimationFrame = saved.raf
+        globalThis.cancelAnimationFrame = saved.caf
+        ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+        performance.now = saved.now
+        ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+        globalThis.addEventListener = saved.key
+        globalThis.removeEventListener = saved.unkey
+        ;(globalThis as { document?: unknown }).document = saved.doc
+        Date.now = saved.dateNow
+        if (saved.nav) Object.defineProperty(globalThis, "navigator", saved.nav)
+      }
+    },
+    step: (ms: number) => {
+      clock += ms
+      frames.push([])
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+    press: (key: string) => {
+      keys.get("keydown")?.({ key, preventDefault: () => undefined })
+    },
+  }
+}
+
+type Wave = {
+  id: string
+  prompt: string
+  /** The frame the item became the live CORE. */
+  from: number
+  /** The frame the wave was resolved — answered, or run out. */
+  to: number
+  /** How it ended. */
+  end: "answered" | "unanswered"
+}
+
+/**
+ * Play the real game and return every wave that ran to a conclusion, with the
+ * frames it was on the lattice for.
+ *
+ * The stub host is wrapped rather than replaced: `next` is what tells us which
+ * item became a CORE and when, and `report`/`skip` are what tell us the wave
+ * ended. Items drawn and passed over never end, so they never appear.
+ */
+function playRecording(
+  seed: number,
+  frames: number,
+  input: (frame: number, press: (k: string) => void, rng: Rng) => void,
+  size: [number, number] = [768, 1024],
+): { waves: Wave[]; painted: Painted[][]; reports: Question["id"][] } {
+  const rec = recorder(size[0], size[1], seed * 7919)
+  const restore = rec.install()
+  const stub = createStubHost({ seed, reducedMotion: false })
+  const promptById = new Map<string, string>()
+  const open = new Map<string, { prompt: string; from: number }>()
+  const waves: Wave[] = []
+  const reports: string[] = []
+  let frame = 0
+
+  const close = (id: string, end: Wave["end"]): void => {
+    const live = open.get(id)
+    if (!live) return
+    open.delete(id)
+    waves.push({ id, prompt: live.prompt, from: live.from, to: frame, end })
+  }
+
+  const host: Host = {
+    next: (o) => {
+      const q = stub.next(o)
+      promptById.set(q.id, q.prompt)
+      // Every draw is a candidate for becoming the CORE; the one that does is
+      // the one that is later reported or skipped. Overwriting is right: only
+      // the last draw of a frame can be the one that was built.
+      open.set(q.id, { prompt: q.prompt, from: frame })
+      return q
+    },
+    report: (r) => {
+      reports.push(r.questionId)
+      close(r.questionId, "answered")
+    },
+    skip: (id) => {
+      close(id, "unanswered")
+    },
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+
+  const handle = mount(rec.el, host)
+  const rng = new Rng(seed ^ 0x51de)
+  try {
+    for (let i = 0; i < frames; i++) {
+      frame = i
+      rec.step(16)
+      input(i, rec.press, rng)
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  return { waves, painted: rec.frames, reports }
+}
+
+/** A child's hands: mostly moving, firing often. Same shape as `loop.test.ts`. */
+const flailing = (_i: number, press: (k: string) => void, rng: Rng): void => {
+  if (rng.chance(0.09)) press(rng.chance(0.5) ? "ArrowLeft" : "ArrowRight")
+  if (rng.chance(0.22)) press(" ")
+}
+
+type Ending = {
+  id: string
+  prompt: string
+  answer: string
+  /** The frame the item became the live CORE. */
+  from: number
+  /** The frame it was resolved. */
+  frame: number
+  end: Wave["end"]
+}
+
+/**
+ * A run against ONE fixed, deliberately small item, played by a child who never
+ * touches the controls.
+ *
+ * This exists because a wave running out is nearly unreachable by accident:
+ * random flailing hits a candidate long before a twenty-three second window
+ * closes, and a child who fires at nothing loses their anchors first. Both of
+ * those are the game working. But the timeout path still has to be RIGHT, so it
+ * is reached on purpose: `4 + 4` earns the six-second floor, which closes well
+ * inside the first anchor's life.
+ *
+ * That is also the only reason this file can assert anything about it. The
+ * suite's existing `if (r.answered === "") assert.equal(r.correct, false)` was
+ * guarding a branch no test in the package had ever executed.
+ */
+function playOneSmallItem(
+  size: [number, number],
+  frames: number,
+): { endings: Ending[]; painted: Painted[][]; reports: number } {
+  const rec = recorder(size[0], size[1], 0x5a1e)
+  const restore = rec.install()
+  const endings: Ending[] = []
+  let served = 0
+  let reports = 0
+  let frame = 0
+  const items = new Map<string, { prompt: string; answer: string; from: number }>()
+
+  const host: Host = {
+    next: () => {
+      served++
+      const id = `tiny-${String(served)}`
+      const q: Question = {
+        id,
+        prompt: "4 + 4",
+        answer: "8",
+        distractors: ["6", "9", "12"],
+        domain: "add",
+        difficulty: 1,
+      }
+      items.set(id, { prompt: q.prompt, answer: q.answer, from: frame })
+      return q
+    },
+    report: (r) => {
+      reports++
+      const it = items.get(r.questionId)
+      if (it) endings.push({ id: r.questionId, ...it, frame, end: "answered" })
+    },
+    skip: (id) => {
+      const it = items.get(id)
+      if (it) endings.push({ id, ...it, frame, end: "unanswered" })
+    },
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+
+  const handle = mount(rec.el, host)
+  try {
+    for (let i = 0; i < frames; i++) {
+      frame = i
+      rec.step(16)
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  return { endings, painted: rec.frames, reports }
+}
+
+// ─── 1. The question stays on the screen ──────────────────────────────────────
+
+test("THE PROMPT IS LEGIBLE FOR AS LONG AS AN ANSWER IS ACCEPTED", () => {
+  // The defect this exists to make impossible: the three-digit column sum was
+  // painted at the 9px floor near the vanishing point for about one and a
+  // third seconds, and then the CORE body was killed at the fracture line and
+  // the prompt was drawn NOWHERE. From that frame the child was doing column
+  // arithmetic from memory while an automaton reached the floor every second.
+  //
+  // So: every frame from the CORE arriving to the wave being resolved must
+  // paint the prompt, at a size a seven-year-old can read across a tablet.
+  // First, deterministically, where the window is spent in full rather than
+  // cut short by a lucky shot: a child who is thinking, and a wave that runs
+  // the whole way to the floor. This is the case the old code turned into a
+  // memory test with a shooter running underneath it.
+  const small = playOneSmallItem([768, 1024], 1400)
+  const ran = small.endings.find((e) => e.end === "unanswered")
+  assert.ok(ran, "the deliberate wave never ran out")
+  const blind: number[] = []
+  let smallest = Infinity
+  for (let f = ran.from; f < ran.frame; f++) {
+    const hit = (small.painted[f] ?? []).filter((p) => p.text === ran.prompt)
+    if (hit.length === 0) blind.push(f)
+    else smallest = Math.min(smallest, Math.max(...hit.map((p) => p.px)))
+  }
+  assert.equal(
+    blind.length,
+    0,
+    `"${ran.prompt}" vanished for ${String(blind.length)} of ` +
+      `${String(ran.frame - ran.from)} frames it could still be answered in`,
+  )
+  assert.ok(smallest >= PROMPT_MIN_PX, `it fell to ${smallest.toFixed(1)}px`)
+  // And then across three runs of a child flailing at the controls.
+  let checked = 0
+  for (const seed of [0x11be, 0x22be, 0x33be]) {
+    const { waves, painted } = playRecording(seed, 2600, flailing)
+    assert.ok(waves.length > 0, `seed ${String(seed)} never resolved a wave`)
+    for (const w of waves) {
+      const blind: number[] = []
+      let smallest = Infinity
+      // Up to but not including `to`: the wave is resolved inside that frame's
+      // simulation step, so nothing drawn afterwards is still answerable.
+      for (let f = w.from; f < w.to; f++) {
+        const hit = (painted[f] ?? []).filter((p) => p.text === w.prompt)
+        if (hit.length === 0) {
+          blind.push(f)
+          continue
+        }
+        smallest = Math.min(smallest, Math.max(...hit.map((p) => p.px)))
+      }
+      assert.equal(
+        blind.length,
+        0,
+        `"${w.prompt}" was not on the screen at all for ${String(blind.length)} of ` +
+          `${String(w.to - w.from + 1)} frames it could still be answered in`,
+      )
+      assert.ok(
+        smallest >= PROMPT_MIN_PX,
+        `"${w.prompt}" fell to ${smallest.toFixed(1)}px while it was still answerable ` +
+          `(floor ${String(PROMPT_MIN_PX)}px)`,
+      )
+      checked++
+    }
+  }
+  assert.ok(checked >= 6, `only ${String(checked)} waves were checked`)
+
+})
+
+test("THE CORE ACTUALLY WALKS DOWN THE LATTICE CARRYING THE PROBLEM", () => {
+  // Not a duplicate of the plate. `spawnCore` claimed a body from the pool and
+  // called `retune` before dressing it, and `retune` disperses every ORDINARY
+  // body that no beam divides — the blank defaults are `kind: A_ORDINARY,
+  // value: 0`, and no beam divides zero. So the CORE was killed on the frame it
+  // was born, every wave, since the function was written. The wide lapis slab
+  // the how-to-play sheet describes as "a big blue robot comes down the middle
+  // with a sum on it" has never existed. What fractured instead was whichever
+  // ordinary automaton the pool handed that slot to next, deleted mid-descent
+  // for a question nobody had read.
+  //
+  // The plate alone hides this perfectly, which is exactly why it is asserted
+  // separately: the problem must be ON something that descends.
+  const { endings, painted } = playOneSmallItem([768, 1024], 1400)
+  const ran = endings.find((e) => e.end === "unanswered")
+  assert.ok(ran, "the wave never ran out")
+
+  // Every y the prompt was painted at, in order. The plate is one fixed
+  // position; the slab is a moving one.
+  const ys: number[] = []
+  for (let f = ran.from; f < ran.frame; f++) {
+    for (const p of painted[f] ?? []) if (p.text === ran.prompt) ys.push(p.y)
+  }
+  const distinct = new Set(ys.map((y) => y.toFixed(1)))
+  assert.ok(
+    distinct.size > 3,
+    `the problem was only ever painted at ${String(distinct.size)} position(s) — ` +
+      `nothing carried it down the lattice`,
+  )
+  const moving = ys.filter((y) => ys.filter((z) => z === y).length < ys.length / 4)
+  const first = moving[0]
+  const last = moving[moving.length - 1]
+  assert.ok(first !== undefined && last !== undefined)
+  assert.ok(last > first, "whatever carried the problem was not descending")
+})
+
+test("the prompt plate is legible on the smallest lattice, and clear of the host's corners", () => {
+  for (const [w, h] of [
+    [320, 480],
+    [360, 640],
+    [768, 1024],
+    [1024, 768],
+    [1366, 1024],
+  ] as const) {
+    const geom = geomForViewport(w, h, 5)
+    const plate = promptPlate(geom, "1,234 + 5,678")
+    // And a prompt far longer than anything the curriculum serves today. The
+    // plate shrinks to fit, but never below the floor: an unreadable question
+    // is worse than one that runs a little wide.
+    const long = promptPlate(geom, "123,456,789 + 987,654,321")
+    assert.ok(
+      long.px >= PROMPT_MIN_PX,
+      `${String(w)}x${String(h)}: a long prompt shrank to ${long.px.toFixed(1)}px`,
+    )
+    assert.ok(
+      plate.px >= PROMPT_MIN_PX,
+      `${String(w)}x${String(h)}: prompt would be ${plate.px.toFixed(1)}px`,
+    )
+    // Inside the safe rectangle: `viewport-fit=cover` means the notch and the
+    // home indicator are ours to avoid, and the prompt is the most important
+    // text in the game.
+    assert.ok(plate.box.x >= geom.area.x, `${String(w)}x${String(h)}: plate crosses the left inset`)
+    assert.ok(
+      plate.box.x + plate.box.w <= geom.area.x + geom.area.w + 0.001,
+      `${String(w)}x${String(h)}: plate crosses the right inset`,
+    )
+    assert.ok(plate.box.y >= geom.area.y, `${String(w)}x${String(h)}: plate crosses the top inset`)
+  }
+})
+
+// ─── 2. The window follows the item, not the motion ───────────────────────────
+
+test("THE WINDOW IS MONOTONE NON-DECREASING IN THE ITEM'S DIFFICULTY", () => {
+  // The invariant, stated once: a harder question may never get less time than
+  // an easier one. The old window was `1.184 × descentSeconds`, and
+  // `descentSeconds` is the motion constant the pressure curve tightens — so
+  // the window ran 11.84s down to 6.87s on exactly the curve that took the
+  // requested difficulty from 2 to 9.
+  const classes: { prompt: string; answer: number }[] = [
+    { prompt: "4 + 3", answer: 7 },
+    { prompt: "6 + 2", answer: 8 },
+    { prompt: "31 + 24", answer: 55 },
+    { prompt: "27 + 15", answer: 42 },
+    { prompt: "342 + 216", answer: 558 },
+    { prompt: "247 + 158", answer: 405 },
+    { prompt: "5341 + 2216", answer: 7557 },
+    { prompt: "5001 − 2798", answer: 2203 },
+  ]
+  let previous = 0
+  for (const item of classes) {
+    const w = comprehensionWindow(item)
+    assert.ok(
+      w >= previous,
+      `"${item.prompt}" gets ${w.toFixed(1)}s, less than the easier item before it ` +
+        `at ${previous.toFixed(1)}s`,
+    )
+    assert.ok(w >= MIN_WINDOW_SECONDS && w <= MAX_WINDOW_SECONDS, `"${item.prompt}" → ${String(w)}s`)
+    previous = w
+  }
+  // And the house cadence table is actually met, not merely bracketed.
+  // p90 for two-digit-with-regrouping is 14s; for the `5,001 − 2,798` class, 40s.
+  assert.ok(
+    comprehensionWindow({ prompt: "27 + 15", answer: 42 }) >= 14,
+    "two-digit regrouping is served under the house p90 of 14s",
+  )
+  assert.ok(
+    comprehensionWindow({ prompt: "5001 − 2798", answer: 2203 }) >= 40,
+    "the `5,001 − 2,798` class is served under the house p90 of 40s",
+  )
+})
+
+test("the window is monotone over every column width and every regrouping", () => {
+  // Over the whole partial order the window is defined on, rather than a
+  // handful of examples: more columns is never less time, and needing to
+  // regroup is never less time than not needing to. Every item below is a real
+  // item — its answer really has that many columns, and it really does or does
+  // not carry — because the function reads the item, not a label on it.
+  const plain: Record<number, { prompt: string; answer: number }> = {
+    1: { prompt: "4 + 3", answer: 7 },
+    2: { prompt: "31 + 24", answer: 55 },
+    3: { prompt: "342 + 216", answer: 558 },
+    4: { prompt: "5341 + 2216", answer: 7557 },
+  }
+  const carried: Record<number, { prompt: string; answer: number }> = {
+    2: { prompt: "27 + 15", answer: 42 },
+    3: { prompt: "247 + 158", answer: 405 },
+    4: { prompt: "5001 − 2798", answer: 2203 },
+  }
+  for (let d = 1; d <= 4; d++) {
+    const flat = plain[d]
+    assert.ok(flat, `no ${String(d)}-column item`)
+    assert.equal(widestColumn(flat), d)
+    assert.equal(needsRegrouping(flat.prompt), false)
+    const carry = carried[d]
+    if (carry) {
+      assert.equal(widestColumn(carry), d)
+      assert.equal(needsRegrouping(carry.prompt), true)
+      assert.ok(
+        comprehensionWindow(flat) <= comprehensionWindow(carry),
+        `${String(d)} columns: regrouping got less time than not regrouping`,
+      )
+    }
+    // The step up a column is never a step down in time — including from a
+    // regrouping item to a wider one that does not regroup, which is the
+    // crossing the two terms could most easily have got wrong.
+    const wider = plain[d + 1]
+    if (wider) {
+      assert.ok(
+        comprehensionWindow(carry ?? flat) <= comprehensionWindow(wider),
+        `${String(d)} → ${String(d + 1)} columns went down`,
+      )
+    }
+  }
+})
+
+test("EXCITEMENT AND COMPREHENSION DO NOT SHARE A KNOB", () => {
+  // The window may not move when the motion constant moves. `Director.pressure`
+  // is the whole difficulty curve of the run; drive it from a cold start to the
+  // top and the window for one fixed item must not budge by a millisecond.
+  const item = { prompt: "247 + 158", answer: 405 }
+  const cold = comprehensionWindow(item)
+  const director = new Director()
+  const seen = new Set<number>()
+  for (let i = 0; i < 200; i++) {
+    director.advance(1)
+    director.recordKill()
+    seen.add(comprehensionWindow(item))
+  }
+  const hot = director.pressure()
+  assert.ok(hot.level > 0.99, `the pressure curve never reached the top (${String(hot.level)})`)
+  assert.ok(hot.descentSeconds < 6, "the motion constant did not tighten")
+  assert.deepEqual(
+    [...seen],
+    [cold],
+    "the comprehension window moved while the run escalated — it is still on the motion knob",
+  )
+})
+
+test("the answering window a wave is built with is the window its item earns", () => {
+  const rng = new Rng(0xc0de)
+  for (const source of [
+    { id: "a", prompt: "27 + 15", answer: "42", distractors: ["32", "52", "24"] },
+    { id: "b", prompt: "247 + 158", answer: "405", distractors: ["395", "415", "504"] },
+  ]) {
+    const built = buildCore(source, 5, () => rng.next())
+    assert.ok(built, `${source.prompt} could not be built`)
+    assert.equal(
+      built.windowSeconds,
+      comprehensionWindow({ prompt: source.prompt, answer: Number(source.answer) }),
+    )
+  }
+})
+
+test("A WAVE REALLY IS ANSWERABLE FOR ITS WHOLE WINDOW, ON THE CLOCK", () => {
+  // End to end, on a virtual clock, through the real frame loop: how long the
+  // candidates of a six-second item are actually on the lattice.
+  const { endings } = playOneSmallItem([768, 1024], 1400)
+  const ran = endings.filter((e) => e.end === "unanswered")
+  assert.ok(
+    ran.length > 0,
+    "a six-second item never ran out inside a whole run — its fall is being timed by " +
+      "something other than the item, and that something is longer than the lattice lasts",
+  )
+  const first = ran[0]
+  assert.ok(first)
+  const seconds = (first.frame * 16) / 1000
+  const earned = comprehensionWindow({ prompt: first.prompt, answer: Number(first.answer) })
+  assert.equal(earned, MIN_WINDOW_SECONDS)
+  // Spawned two seconds in, approached, fractured, then fell for the window.
+  // Never less than the window itself; the old code would have given this same
+  // item 6.87s at the top of the pressure curve and 11.84s at the bottom, on
+  // the same knob that decides how fast the room is.
+  assert.ok(
+    seconds >= earned,
+    `the wave was on the lattice for ${seconds.toFixed(2)}s, under its ${String(earned)}s window`,
+  )
+  // And bounded above, which is the half that catches a window quietly going
+  // back onto the motion knob. Everything before the fall is the two-second
+  // dead gap plus the core's approach, `0.26 x descentSeconds x 0.85`, which is
+  // under five seconds at every point on the pressure curve. A window taken
+  // from `descentSeconds` would put this item at fifteen seconds or more.
+  assert.ok(
+    seconds <= earned + 7,
+    `the wave was on the lattice for ${seconds.toFixed(2)}s against a ${String(earned)}s window ` +
+      `— the fall is not being timed by the item`,
+  )
+})
+
+// ─── 3. Running out of time is not being wrong ────────────────────────────────
+
+test("A WAVE THAT RUNS OUT IS NOT REPORTED AS A WRONG ANSWER", () => {
+  // What the old code did: `host.report({ correct: false, answered: "" })`.
+  // The shared adapter discards `correct` and forwards `answered` as the
+  // response to `items.answer`, and an empty response does not parse, so the
+  // host recorded a MISS and stepped the ladder down — against a child who may
+  // simply have still been carrying the hundreds column.
+  const { endings, reports } = playOneSmallItem([768, 1024], 2400)
+  // The report count comes first, deliberately: a timeout that goes out as an
+  // answer would otherwise be misread as "no wave ran out" and the failure
+  // would name the wrong thing.
+  assert.equal(
+    reports,
+    0,
+    `a child who never touched the controls was reported on as having answered ` +
+      `${String(reports)} time(s)`,
+  )
+  const ran = endings.filter((e) => e.end === "unanswered")
+  assert.ok(ran.length > 0, "no wave ever ran out, so nothing was proved")
+})
+
+test("nothing is ever reported with an empty answer", () => {
+  // The one report in the game that was not the result of an action. There is
+  // no longer any such report: an unanswered item is skipped, not answered.
+  const seen: string[] = []
+  const rec = recorder(768, 1024, 0x99)
+  const restore = rec.install()
+  const stub = createStubHost({ seed: 0x99, reducedMotion: false })
+  const host: Host = {
+    next: (o) => stub.next(o),
+    report: (r) => {
+      seen.push(r.answered)
+    },
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(rec.el, host)
+  const rng = new Rng(0x99 ^ 0x51de)
+  try {
+    for (let i = 0; i < 5000; i++) {
+      rec.step(16)
+      flailing(i, rec.press, rng)
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  assert.ok(seen.length > 0, "nothing was reported at all")
+  for (const answered of seen) {
+    assert.ok(/^\d+$/.test(answered), `a report carried "${answered}" — nothing was handed in`)
+  }
+  // And the run that actually times out: not one report, empty or otherwise.
+  assert.equal(playOneSmallItem([768, 1024], 2400).reports, 0)
+})
+
+test("a host with no skip hook is not a crash — the timeout is simply silent", () => {
+  // `skip` is feature-detected exactly like `transition`. The shared adapter
+  // does not implement it today, so on a real tablet an unanswered item is
+  // reported as nothing at all, which is the honest thing and is never a miss.
+  const rec = recorder(768, 1024, 0x5150)
+  const restore = rec.install()
+  const stub = createStubHost({ seed: 0x5150, reducedMotion: false })
+  const bare: Host = {
+    next: (o) => stub.next(o),
+    report: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(rec.el, bare)
+  const rng = new Rng(0x5150 ^ 0x51de)
+  try {
+    for (let i = 0; i < 3000; i++) {
+      rec.step(16)
+      flailing(i, rec.press, rng)
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+// ─── 4. The sum finishes on the screen ────────────────────────────────────────
+
+test("AFTER A TIMEOUT THE SUM IS COMPLETED ON SCREEN, LEGIBLY, AND HELD", () => {
+  // A five-year-old getting everything wrong and putting nonsense in is still
+  // watching numerals, a `+`, and a column sum resolving — and that exposure is
+  // worth something even when the answer is not. It only works if the game
+  // shows the arithmetic HAPPEN. The miss is the teaching moment, and spending
+  // it on feedback about the failure and then deleting the evidence is the
+  // worst available arrangement.
+  //
+  // So, after the wave runs out: the finished statement, at the same size the
+  // question was, for long enough to read it.
+  for (const size of [
+    [320, 480],
+    [360, 640],
+    [768, 1024],
+  ] as const) {
+    const { endings, painted } = playOneSmallItem([size[0], size[1]], 1400)
+    const ran = endings.find((e) => e.end === "unanswered")
+    assert.ok(ran, `${String(size[0])}x${String(size[1])}: the wave never ran out`)
+    const finished = `${ran.prompt} = ${ran.answer}`
+    let held = 0
+    let smallest = Infinity
+    for (let f = ran.frame; f < painted.length; f++) {
+      const hit = (painted[f] ?? []).filter((p) => p.text === finished)
+      if (hit.length === 0) continue
+      held++
+      smallest = Math.min(smallest, Math.max(...hit.map((p) => p.px)))
+    }
+    // Long enough to read a completed sum, not a frame of it.
+    assert.ok(
+      held >= 60,
+      `${String(size[0])}x${String(size[1])}: "${finished}" was on screen for ` +
+        `${String(held)} frames (${((held * 16) / 1000).toFixed(2)}s)`,
+    )
+    assert.ok(
+      smallest >= PROMPT_MIN_PX,
+      `${String(size[0])}x${String(size[1])}: the completed sum was ${smallest.toFixed(1)}px`,
+    )
+  }
+})
+
+test("after a wrong submission the sum is completed on screen too", () => {
+  // The same beat, reached the other way: the child handed in a value and it
+  // was not the one. Nothing about what follows says so — the statement simply
+  // finishes, in the colour a correct answer is celebrated in.
+  let seen = 0
+  for (const seed of [0x2b1, 0x2b2, 0x2b3, 0x2b4]) {
+    const rec = recorder(360, 640, seed * 31)
+    const restore = rec.install()
+    const stub = createStubHost({ seed, reducedMotion: false })
+    const items = new Map<string, string>()
+    const misses: { finished: string; frame: number }[] = []
+    let frame = 0
+    const host: Host = {
+      next: (o) => {
+        const q = stub.next(o)
+        items.set(q.id, `${q.prompt} = ${q.answer}`)
+        return q
+      },
+      report: (r) => {
+        const finished = items.get(r.questionId)
+        if (!r.correct && finished !== undefined) misses.push({ finished, frame })
+      },
+      skip: () => undefined,
+      haptic: () => undefined,
+      prefersReducedMotion: () => false,
+    }
+    const handle = mount(rec.el, host)
+    const rng = new Rng(seed ^ 0x51de)
+    try {
+      for (let i = 0; i < 3000; i++) {
+        frame = i
+        rec.step(16)
+        flailing(i, rec.press, rng)
+      }
+    } finally {
+      handle.unmount()
+      restore()
+    }
+    for (const miss of misses) {
+      let held = 0
+      let smallest = Infinity
+      for (let f = miss.frame; f < rec.frames.length; f++) {
+        const hit = (rec.frames[f] ?? []).filter((p) => p.text === miss.finished)
+        if (hit.length === 0) continue
+        held++
+        smallest = Math.min(smallest, Math.max(...hit.map((p) => p.px)))
+      }
+      assert.ok(held >= 60, `"${miss.finished}" was completed for only ${String(held)} frames`)
+      assert.ok(smallest >= PROMPT_MIN_PX, `the completed sum was ${smallest.toFixed(1)}px`)
+      seen++
+    }
+  }
+  assert.ok(seen > 0, "random play never once missed, so nothing was proved")
+})
+
+test("THE REVEAL HOLDS THE HALL, AND THE HOLD IS BILLED TO NOBODY", () => {
+  // STACK holds its sweep for the whole reveal so the child never reads one
+  // thing while aiming at another, and that hold is the part that makes it
+  // work. Here it has a second job: a frozen lattice cannot land an automaton
+  // on an anchor while the child is reading, so the time this game spends
+  // teaching is never time it takes off them.
+  const { endings, painted } = playOneSmallItem([768, 1024], 1400)
+  const ran = endings.find((e) => e.end === "unanswered")
+  assert.ok(ran, "the wave never ran out")
+  const finished = `${ran.prompt} = ${ran.answer}`
+  const shown = painted
+    .map((frame, i) => ({ i, frame }))
+    .filter(({ frame }) => frame.some((p) => p.text === finished))
+    .map(({ i }) => i)
+  assert.ok(shown.length >= 60, `the completed sum held for only ${String(shown.length)} frames`)
+
+  // Everything on the lattice, frame by frame, with the completed statement
+  // itself taken out — that one is supposed to be there and is supposed to be
+  // still. If the hall were running, a hull would have moved a pixel.
+  const world = (i: number): string =>
+    (painted[i] ?? [])
+      .filter((p) => p.text !== finished)
+      .map((p) => `${p.text}@${p.x.toFixed(2)},${p.y.toFixed(2)}`)
+      .join("|")
+  for (let k = 1; k < shown.length - 1; k++) {
+    const a = shown[k - 1]
+    const b = shown[k]
+    assert.ok(a !== undefined && b !== undefined)
+    assert.equal(
+      world(b),
+      world(a),
+      `the lattice moved on frame ${String(b)} while the sum was being read`,
+    )
+  }
+})
+
+// ─── The pause, closed properly ───────────────────────────────────────────────
+
+test("BEHIND THE HOST'S SHEET, NOTHING STEPS AND NOTHING IS DRAWN", () => {
+  // `loop.test.ts` has had a pause test since the day the guard was written and
+  // it does not cover this. Take the `if (paused) return` out of the frame loop
+  // and that test still passes: input is refused by its own separate guards, so
+  // with nobody firing, nothing gets answered — and the run quietly dies of
+  // breaches behind the sheet instead, which resolves nothing and reports
+  // nothing. A pack whose lattice keeps running under a purchase surface would
+  // have shipped green.
+  //
+  // What is asserted here is the promise the frame loop actually makes: while
+  // paused the canvas holds its last frame. Not one `fillText`, and when the
+  // sheet lifts the hall is exactly where it was left.
+  const rec = recorder(768, 1024, 0x9ee9)
+  const restore = rec.install()
+  const stub = createStubHost({ seed: 0x9ee9, reducedMotion: false })
+  const host: Host = {
+    next: (o) => stub.next(o),
+    report: () => undefined,
+    skip: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(rec.el, host)
+  const rng = new Rng(0x9ee9 ^ 0x51de)
+  let lastLive = 0
+  try {
+    for (let i = 0; i < 400; i++) {
+      rec.step(16)
+      flailing(i, rec.press, rng)
+    }
+    lastLive = rec.frames.length - 1
+    handle.setPaused(true)
+    const from = rec.frames.length
+    // Three minutes behind the sheet, with a child leaning on the controls.
+    for (let i = 0; i < 11_250; i++) {
+      rec.step(16)
+      if (i % 5 === 0) rec.press(" ")
+      if (i % 11 === 0) rec.press("ArrowLeft")
+    }
+    let painted = 0
+    for (let f = from; f < rec.frames.length; f++) painted += (rec.frames[f] ?? []).length
+    assert.equal(painted, 0, `${String(painted)} things were drawn while the game was paused`)
+
+    handle.setPaused(false)
+    rec.step(16)
+    const before = (rec.frames[lastLive] ?? []).map((p) => `${p.text}@${p.x.toFixed(1)}`).join("|")
+    const after = (rec.frames[rec.frames.length - 1] ?? [])
+      .map((p) => `${p.text}@${p.x.toFixed(1)}`)
+      .join("|")
+    assert.ok(after.length > 0, "the game did not come back after the sheet lifted")
+    assert.equal(after, before, "the lattice moved behind the sheet")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the sheet's minutes are not billed to the child as thinking time", () => {
+  // The other half of the pause, and the half that reaches the learner model:
+  // `waveAskedAt` is a wall-clock mark, so without shifting it forward by
+  // exactly the time the sheet was up, the next report carries the sheet's
+  // three minutes as the child's latency. The host reads latency to decide
+  // whether the ladder climbs.
+  const rec = recorder(768, 1024, 0x1a7e)
+  const restore = rec.install()
+  const latencies: number[] = []
+  let served = 0
+  const host: Host = {
+    next: () => {
+      served++
+      return {
+        id: `slow-${String(served)}`,
+        // Three columns and a carry, so the window is long enough to still be
+        // open on the far side of three minutes behind a sheet.
+        prompt: "247 + 158",
+        answer: "405",
+        distractors: ["395", "415", "504"],
+        domain: "add",
+        difficulty: 5,
+      }
+    },
+    report: (r) => latencies.push(r.ms),
+    skip: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(rec.el, host)
+  try {
+    // Far enough in that a wave is certainly on the lattice.
+    for (let i = 0; i < 400; i++) rec.step(16)
+    handle.setPaused(true)
+    for (let i = 0; i < 11_250; i++) rec.step(16)
+    handle.setPaused(false)
+    // And now answer it, by sweeping the lattice and firing.
+    for (let i = 0; i < 900; i++) {
+      rec.step(16)
+      rec.press(" ")
+      if (i % 9 === 0) rec.press(i % 18 === 0 ? "ArrowLeft" : "ArrowRight")
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  assert.ok(latencies.length > 0, "nothing was answered after the sheet lifted")
+  for (const ms of latencies) {
+    assert.ok(
+      ms < 60_000,
+      `a report carried ${String(ms)}ms — the sheet's three minutes leaked into the ` +
+        `child's thinking time`,
+    )
+  }
+})
+
+// ─── 5. Space around the answering moment ─────────────────────────────────────
+
+test("the lattice thins out while a question is being read — sparser, not duller", () => {
+  // The founder's direction: keep the juice, give the space AROUND the
+  // answering moment room. So while a CORE's candidates are in the air the
+  // stream backs off — fewer automata, further apart, descending slower — and
+  // it does so at every point on the pressure curve, not just at the start.
+  const director = new Director()
+  for (let i = 0; i <= 20; i++) {
+    const p = director.pressure()
+    const r = readingRelief(p)
+    assert.ok(r.floorCount <= p.floorCount, "the field did not thin while reading")
+    assert.ok(r.spawnGap > p.spawnGap, "spawns did not spread out while reading")
+    assert.ok(r.descentSeconds > p.descentSeconds, "the stream did not slow while reading")
+    assert.ok(r.floorCount >= 1, "the lattice went empty — there is no mathematics on an empty one")
+    // Relief is not a difficulty reset: the tight-divisor bias, which is the
+    // pedagogy in the economy, is untouched.
+    assert.equal(r.tightness, p.tightness)
+    assert.equal(r.level, p.level)
+    for (let k = 0; k < 8; k++) director.advance(1)
+    director.recordKill()
+  }
+})
+
+test("RINGING A CANDIDATE DOES NOT SHORTEN THE TIME TO ANSWER IT", () => {
+  // A dissonant strike shoves an ORDINARY automaton down the lattice — the cost
+  // of a wrong read is time, which is the right cost. Applied to a CANDIDATE it
+  // is something else entirely: probing the beams is the listening verb, and
+  // charging the comprehension window for it rations exactly what may not be
+  // rationed. A candidate rings and does not move.
+  assert.ok(shovedUrgency(A_ORDINARY, 1) > 1, "an ordinary automaton was not shoved")
+  assert.equal(shovedUrgency(A_CANDIDATE, 1), 1, "a candidate was shoved: the window shrank")
+  assert.equal(shovedUrgency(A_CANDIDATE, 2.4), 2.4)
+  // And the shove is bounded, so a column of stray shots cannot teleport one.
+  let u = 1
+  for (let i = 0; i < 40; i++) u = shovedUrgency(A_ORDINARY, u)
+  assert.ok(u <= 2.4, `urgency ran away to ${String(u)}`)
+})
+
+// ─── The window function itself ───────────────────────────────────────────────
+
+test("the window reads the item's columns and its regrouping, not its prose", () => {
+  assert.equal(widestColumn({ prompt: "4 + 3", answer: 7 }), 1)
+  assert.equal(widestColumn({ prompt: "27 + 15", answer: 42 }), 2)
+  // The answer is a column wider than either operand, and it counts.
+  assert.equal(widestColumn({ prompt: "62 + 79", answer: 141 }), 3)
+  assert.equal(widestColumn({ prompt: "5001 − 2798", answer: 2203 }), 4)
+  assert.equal(needsRegrouping("27 + 15"), true)
+  assert.equal(needsRegrouping("31 + 24"), false)
+  assert.equal(needsRegrouping("52 − 27"), true)
+  assert.equal(needsRegrouping("59 − 27"), false)
+  // A prompt shaped like nothing the parser knows is given the LONGER window,
+  // never the shorter one. Guessing against the child is not an option.
+  assert.equal(needsRegrouping("what is the tessera count"), true)
+})

--- a/dynawalla/games/beam/src/test/geom.test.ts
+++ b/dynawalla/games/beam/src/test/geom.test.ts
@@ -131,6 +131,14 @@ test("nothing a child must read sits under the host's two corners", () => {
       )
     }
 
+    // And the question itself, which is the most important text in the game
+    // and the one it went longest without drawing at all.
+    assert.equal(
+      hitsHostChrome(g.prompt, w),
+      false,
+      `${name} (${w}×${h}): the CORE's problem is under host chrome`,
+    )
+
     // The two blocks must not collide with each other either, which is the
     // failure mode of "just move everything down".
     assert.ok(
@@ -138,6 +146,18 @@ test("nothing a child must read sits under the host's two corners", () => {
         g.hud.y + g.hud.h <= anchorsRect(g, ANCHORS).y ||
         anchorsRect(g, ANCHORS).y + anchorsRect(g, ANCHORS).h <= g.hud.y,
       `${name}: the score and the anchor lamps overlap`,
+    )
+
+    // The question must not sit on the score or the lamps either. Three
+    // things now share the top of the screen and "move it up" is exactly how
+    // the third one ends up on top of the first.
+    assert.ok(
+      g.prompt.y + g.prompt.h <= g.hud.y + 0.5,
+      `${name}: the question overlaps the score block`,
+    )
+    assert.ok(
+      g.prompt.x + g.prompt.w <= anchorsRect(g, ANCHORS).x + 0.5,
+      `${name}: the question overlaps the anchor lamps`,
     )
   }
 })

--- a/dynawalla/games/beam/src/test/loop.test.ts
+++ b/dynawalla/games/beam/src/test/loop.test.ts
@@ -246,10 +246,15 @@ test("nothing is ever reported that the host did not serve", () => {
   for (const r of play(0x2222, 5000, false)) {
     assert.ok(r.questionId.length > 0, "a report carried no item id")
     assert.ok(Number.isInteger(r.ms) && r.ms >= 0, `bad latency ${r.ms}`)
-    // Either a value was struck, or the candidates landed and nothing was
-    // handed in. Never a float, never a sign, never a fragment.
-    assert.ok(r.answered === "" || /^\d+$/.test(r.answered), `bad answer "${r.answered}"`)
-    if (r.answered === "") assert.equal(r.correct, false)
+    // A value was struck. That is the only thing this game reports, so the
+    // answer is always a numeral — never a float, never a sign, never a
+    // fragment, and never the empty string.
+    //
+    // The clause here used to be `r.answered === "" || /^\d+$/` with a
+    // follow-up asserting that an empty answer came with `correct: false`.
+    // Both were dead: they described the timeout report, which is now a
+    // `skip`, and no test in this package had ever reached one anyway.
+    assert.ok(/^\d+$/.test(r.answered), `bad answer "${r.answered}"`)
   }
 })
 
@@ -302,7 +307,20 @@ test("PAUSE STOPS THE CLOCK: a wave cannot expire behind the host's sheet", () =
   const surface = stubSurface(768, 1024, 0xba5e0, 12)
   const restore = surface.install()
   const reports: Report[] = []
-  const host = createStubHost({ seed: 0x9e11, reducedMotion: false, onReport: (r) => reports.push(r) })
+  // BOTH endings are watched, and that is not tidiness. An item that runs out
+  // is no longer an answer — it is a `skip` — so a test that watched only
+  // `report` would have gone quiet about the exact failure this test is named
+  // after: a wave expiring behind a sheet the child was never shown.
+  const resolved: string[] = []
+  const host = createStubHost({
+    seed: 0x9e11,
+    reducedMotion: false,
+    onReport: (r) => {
+      reports.push(r)
+      resolved.push(r.questionId)
+    },
+    onSkip: (id) => resolved.push(id),
+  })
   const handle = mount(surface.el, host)
   const step = surface.pump()
   const press = (key: string): void => {
@@ -314,8 +332,8 @@ test("PAUSE STOPS THE CLOCK: a wave cannot expire behind the host's sheet", () =
       step(16)
       if (i % 5 === 0) press(" ")
     }
-    assert.ok(reports.length > 0, "nothing was reported before the pause")
-    const before = reports.length
+    assert.ok(resolved.length > 0, "nothing was resolved before the pause")
+    const before = resolved.length
 
     handle.setPaused(true)
     // Three minutes behind the sheet, with the child mashing at it throughout.
@@ -324,7 +342,7 @@ test("PAUSE STOPS THE CLOCK: a wave cannot expire behind the host's sheet", () =
       if (i % 5 === 0) press(" ")
       if (i % 11 === 0) press("ArrowLeft")
     }
-    assert.equal(reports.length, before, "an item was resolved while the game was paused")
+    assert.equal(resolved.length, before, "an item was resolved while the game was paused")
 
     handle.setPaused(false)
     for (let i = 0; i < 3000; i++) {
@@ -332,7 +350,7 @@ test("PAUSE STOPS THE CLOCK: a wave cannot expire behind the host's sheet", () =
       if (i % 5 === 0) press(" ")
       if (i % 13 === 0) press("ArrowRight")
     }
-    assert.ok(reports.length > before, "the game did not come back after the sheet lifted")
+    assert.ok(resolved.length > before, "the game did not come back after the sheet lifted")
   } finally {
     handle.unmount()
     restore()


### PR DESCRIPTION
BEAM served three-digit column sums and then deleted them. An audit called it "structurally not a maths game." Five defects, each proved by a test that was **run with the fix removed before it was trusted**.

## The one the audit did not find

`spawnCore` claimed a body from the pool and called `retune()` **before dressing it**. `retune` disperses every ORDINARY body no beam divides; the blank defaults are `kind: A_ORDINARY, value: 0`; no beam divides zero.

So the CORE was killed on the frame it was born, **every wave, since the function was written**. The wide lapis slab the how-to-play sheet describes as "a big blue robot comes down the middle with a sum on it" has never existed. What fractured instead was whichever ordinary automaton the pool handed that slot to next — deleted mid-descent, for a question nobody had read.

The audit said the prompt was legible at 9px for ~1.3 s. It was legible for **0 s**.

## The window

| host difficulty | before | after (by item) |
|---|---|---|
| 2 | 11.84 s | `4 + 3` → 6 s |
| 3 | 11.22 s | `31 + 24` → 11 s |
| 4 | 10.60 s | `27 + 15` → 14 s |
| 5 | 9.98 s | `342 + 216` → 18 s |
| 6 | 9.35 s | `247 + 158` → 23 s |
| 7 | 8.11 s | |
| 8 | 7.49 s | |
| 9 | **6.87 s** | `5,001 − 2,798` → 40 s |

Before: `1.184 × descentSeconds`, and `descentSeconds` is the motion constant the pressure curve tightens — a 42% cut applied on exactly the curve that raises the requested difficulty from 2 to 9. After: `sim/window.ts`, a pure function of the item's widest column and whether it regroups, on the house p90s from `docs/EXPERIENCE_DESIGN.md`. It cannot see the director.

**The invariant is asserted directly**: the window is monotone non-decreasing in item difficulty, over every column width crossed with every regrouping; and a fixed item's window does not move by a millisecond while a run escalates to the top of the pressure curve.

## The rest

- **The prompt is carved into the far wall** at 23–42px and stays there for every frame an answer is accepted — approach and fall alike. Clear of the host's two 44px corners at every viewport (`hitsHostChrome`), and never below an 18px floor.
- **A timeout is not a wrong answer.** It went out as `report({ correct: false, answered: "" })`. The shared adapter throws `correct` away and forwards `answered` to `items.answer`, where an empty string does not parse — so the host recorded a **miss** and stepped the ladder **down**, against a child who may still have been carrying the hundreds column. Guessing was strictly cheaper than thinking. It now calls an optional, feature-detected `skip` (the SDK's `items.skip`: closed, unrecorded, ladder untouched); where the shared adapter does not surface it yet, it says nothing at all. `game-host/` is untouched.
- **Probing no longer costs thinking time.** A dissonant strike shoved a CANDIDATE at up to 2.4×, so using the game's own listening verb shrank the comprehension window by more than half.
- **The miss is spent on the mathematics.** A wrong submission or a wave that runs out finishes the sum on the wall — `247 + 158` becomes `247 + 158 = 405`, the new part in the resonance colour a *correct* answer is celebrated in — with the hall **held still** while it is read, after STACK. Gone: the copper-oxide screen flash, the shake, the `failure` haptic. A five-year-old putting nonsense in is still watching a column sum resolve, and a frozen lattice cannot take an anchor while they are looking at it.
- **Sparser and slower around the answering moment, not duller.** While a question is in the air the stream backs off; the tight-divisor bias is untouched and the field is never empty.

## Two tests that were passing on nothing

- `if (r.answered === "") assert.equal(r.correct, false)` guarded a branch **no test in the package had ever reached**.
- The pause test still passed with the frame loop's `if (paused) return` **deleted** — input is refused by its own separate guards, so with nobody firing nothing gets answered, and the run quietly died of breaches behind the sheet instead. A pack whose lattice kept running under a purchase surface would have shipped green. The replacement asserts what the loop actually promises: not one `fillText` behind the sheet, the hall exactly where it was left, and the sheet's three minutes never reaching the child's latency.

## Verification

97 tests, run 5×, all green. `tsc --noEmit` clean. `npm run build:pack` clean. Every fix was deleted and the run re-run; 15 mutations, each caught by a targeted assertion:

```
prompt plate not drawn      → "4 + 4" vanished for 375 of 553 frames it could still be answered in
retune before dressing      → the problem was only ever painted at 2 position(s) — nothing carried it down the lattice
legibility floor removed    → 320x480: a long prompt shrank to 14.0px
window back on descent      → a six-second item never ran out inside a whole run
timeout reported            → a child who never touched the controls was reported on as having answered 1 time(s)
BY_COLUMNS unsorted         → "342 + 216" gets 11.0s, less than the easier item before it at 21.0s
reveal removed              → "4 + 4 = 8" was on screen for 0 frames (0.00s)
hold removed                → the completed sum held for only 1 frames
candidate shove restored    → a candidate was shoved: the window shrank
relief made identity        → spawns did not spread out while reading
prompt band over the corner → phone portrait, small (320×568): the CORE's problem is under host chrome
frame-loop pause guard      → 189874 things were drawn while the game was paused
waveAskedAt shift removed   → a report carried 185136ms — the sheet's three minutes leaked
```

## What only a device can confirm

The plate's type against a real font at real DPI (the harness measures with an estimated advance width); whether a 23-second candidate fall reads as calm or as slack on a tablet; and whether the ~2 s hold after a miss feels like a beat or like a stall in the hand.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
