### PR TITLE
dynawalla/host: the difficulty wire — next() has been ignoring its argument in production

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/bridge.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.test.ts
@@ -343,3 +343,36 @@ test("the pack id the host is told is the host's, never the pack's", async () =>
   })
   assert.deepEqual(calls[0]?.input, { packId: "abacus.tower", skillId: "add.1" })
 })
+
+test("a difficulty request crosses the boundary, clamped rather than refused", async () => {
+  const calls: Calls = []
+  const bridge = createBridge({ packId: "p", granted: ["items"], services: services(calls) })
+
+  await bridge.handle({
+    id: 1,
+    method: "items.next",
+    params: { difficulty: 0.25, maxDifficulty: 0.75 },
+  })
+  assert.deepEqual(calls[0]?.input, {
+    packId: "p",
+    difficulty: 0.25,
+    maxDifficulty: 0.75,
+  })
+
+  // Out of range is a bug in a pack, and refusing the question would turn it
+  // into a blank screen in a child's game. Clamped, like every other number
+  // this boundary takes, and announced on the pack's side where an author can
+  // act on it.
+  const clamped = await bridge.handle({
+    id: 2,
+    method: "items.next",
+    params: { difficulty: 4, maxDifficulty: -3 },
+  })
+  assert.equal(clamped?.ok, true)
+  assert.deepEqual(calls[1]?.input, { packId: "p", difficulty: 1, maxDifficulty: 0 })
+
+  // Not a number at all is absent, not zero: a pack that sends a string must
+  // not thereby pin every question to the easiest rung on the ladder.
+  await bridge.handle({ id: 3, method: "items.next", params: { difficulty: "hard" } })
+  assert.deepEqual(calls[2]?.input, { packId: "p" })
+})

--- a/dynawalla/dynawalla-app/src/packs/bridge.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.ts
@@ -40,6 +40,7 @@ import {
   parseRequest,
   permits,
   stringParam,
+  unitParam,
 } from "../../../packs/sdk/src/index.ts"
 
 /** A pack's own key-value store. Small on purpose: it is not a database. */
@@ -63,7 +64,14 @@ const SOUND_CUES: readonly SoundCue[] = ["tick", "seat", "settle", "refuse", "ar
  * only one file.
  */
 export type HostServices = {
-  nextItem(input: { packId: string; skillId?: string }): Promise<Item | null>
+  nextItem(input: {
+    packId: string
+    skillId?: string
+    /** 0..1 across the host's whole ladder. A request, not an instruction. */
+    difficulty?: number
+    /** 0..1 ceiling. The stream never goes above it. */
+    maxDifficulty?: number
+  }): Promise<Item | null>
   /** Records the attempt and judges it. One call, in that order. */
   judge(input: {
     packId: string
@@ -180,7 +188,19 @@ export function createBridge(options: BridgeOptions): Bridge {
 
       case "items.next": {
         const skillId = stringParam(params, "skillId", 128)
-        const item = await services.nextItem(skillId === null ? { packId } : { packId, skillId })
+        // Clamped rather than refused, like every other number a pack sends: a
+        // difficulty of 1.4 is a bug in a pack, and refusing the question would
+        // turn it into a blank screen in a child's game. The pack's own adapter
+        // is where an out-of-range value is announced, because that is the side
+        // an author can act on.
+        const difficulty = unitParam(params, "difficulty")
+        const maxDifficulty = unitParam(params, "maxDifficulty")
+        const item = await services.nextItem({
+          packId,
+          ...(skillId === null ? {} : { skillId }),
+          ...(difficulty === null ? {} : { difficulty }),
+          ...(maxDifficulty === null ? {} : { maxDifficulty }),
+        })
         return ok(id, { item })
       }
 

--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -206,3 +206,76 @@ test("choices are stable for an exercise, so a redraw does not move the right sl
   })
   assert.deepEqual(choicesFor(exercise, 0), choicesFor(exercise, 0))
 })
+
+test("a difficulty request selects the rung, and the item says which rung it came from", () => {
+  const rungs = ladder()
+  assert.ok(rungs.length > 1, "a one-rung ladder cannot demonstrate selection")
+  const service = createItemService({ profileId: "p1", record: noRecord })
+
+  const easiest = service.next({ packId: "dynawalla.slice", difficulty: 0 })
+  const hardest = service.next({ packId: "dynawalla.slice", difficulty: 1 })
+  assert.ok(easiest && hardest)
+
+  // The ordinate the pack is told is the position of the rung it was served,
+  // 0..1 across the whole ladder — not `level`, which is the level within one
+  // skill and is not comparable between two of them.
+  assert.equal(easiest.difficulty, 0)
+  assert.equal(hardest.difficulty, 1)
+  assert.equal(rungs[0]?.node.id, easiest.skillId)
+  assert.equal(rungs[rungs.length - 1]?.node.id, hardest.skillId)
+  assert.notEqual(easiest.prompt, hardest.prompt)
+
+  // The middle of the ladder is the middle of the ladder, and it moves.
+  const middle = service.next({ packId: "dynawalla.slice", difficulty: 0.5 })
+  const where = middle?.difficulty ?? -1
+  assert.ok(where > 0.3 && where < 0.7, `0.5 landed at ${String(where)}`)
+})
+
+test("a ceiling is honoured, and an unsatisfiable request clamps to the nearest rung that exists", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+
+  for (const asked of [0.9, 1]) {
+    const capped = service.next({ packId: "dynawalla.siege", difficulty: asked, maxDifficulty: 0.2 })
+    const where = capped?.difficulty ?? -1
+    assert.ok(where >= 0 && where <= 0.2, `the ceiling 0.2 served ${String(where)}`)
+  }
+
+  // The curriculum has no rung below its easiest, so a request under the floor
+  // cannot be satisfied as asked. It clamps to the bottom of what exists rather
+  // than failing — a pack built against a curriculum with easier content must
+  // still be playable — and the pack can SEE the clamp, because the ordinate
+  // that comes back is the one it got and not the one it asked for.
+  const under = service.next({ packId: "dynawalla.siege", difficulty: -5 })
+  assert.ok(under)
+  assert.equal(under.difficulty, 0, "an impossible request did not land on the easiest rung")
+  const over = service.next({ packId: "dynawalla.siege", difficulty: 99 })
+  assert.ok(over)
+  assert.equal(over.difficulty, 1, "an impossible request did not land on the hardest rung")
+})
+
+test("driving the difficulty moves the one ladder, so judging resumes from where the pack left it", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  assert.equal(service.position(), 0)
+
+  const item = service.next({ packId: "dynawalla.stack", difficulty: 1 })
+  assert.ok(item)
+  const top = service.position()
+  assert.ok(top > 0, "a difficulty request left the ladder standing where it was")
+
+  // A pack that stops driving resumes from where it left the child, and the
+  // host's own climb-and-step-down goes on from there. Two positions would mean
+  // a child who was moved down by their game gets moved back up by the ladder
+  // the moment the game stops asking.
+  const after = service.next({ packId: "dynawalla.stack" })
+  assert.ok(after)
+  assert.equal(service.position(), top)
+  assert.equal(after.difficulty, item.difficulty)
+
+  service.judge({
+    packId: "dynawalla.stack",
+    itemId: after.id,
+    response: "definitely wrong",
+    latencyMs: 1000,
+  })
+  assert.equal(service.position(), top - 1, "the ladder did not step down from the pack's position")
+})

--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -9,7 +9,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { createItemService, ladder, choicesFor } from "./items.ts"
+import { createItemService, ladder, choicesFor, isSubtraction } from "./items.ts"
 import { familyById, FORM_FREE_ENTRY, activeNodes } from "./curriculum.ts"
 
 const noRecord = () => {}
@@ -38,12 +38,20 @@ test("an item carries the question and never the answer", () => {
 
   // The whole payload, enumerated. A field added here that happens to contain
   // the canonical value is the failure this asserts against.
+  //
+  // `prompt` and `operands` are excluded because they ARE the question, and a
+  // single-digit fact legitimately puts its own answer among them: `0 + 3` has
+  // the canonical `3` written on its face. Scanning them was sound only while
+  // every operand was four digits long, and it started reporting a leak the
+  // moment the curriculum grew a rung below that.
   const canonical = service.reveal(item.id)
   assert.ok(canonical.length > 0)
-  const serialised = JSON.stringify({ ...item, choices: undefined })
+  const rest: Record<string, unknown> = { ...item }
+  for (const key of ["choices", "prompt", "operands"]) delete rest[key]
+  const serialised = JSON.stringify(rest)
   assert.ok(
     !serialised.includes(`"${canonical}"`),
-    "the served item names the canonical answer outside its choice list",
+    `the served item names the canonical answer outside the question: ${serialised}`,
   )
 
   assert.equal(item.operands.length, 2)
@@ -167,7 +175,15 @@ test("the ladder climbs on a fast correct answer and steps down on a wrong one",
 
   const item = service.next({ packId: "dynawalla.fuse" })
   assert.ok(item)
-  service.judge({ packId: "dynawalla.fuse", itemId: item.id, response: "0", latencyMs: 200 })
+  // Not `"0"`. On the easiest rungs the curriculum now ships, zero is a
+  // perfectly good answer — `3 − 3` — so a test that used it as a stand-in for
+  // "wrong" was climbing the ladder while asserting it had stepped down.
+  service.judge({
+    packId: "dynawalla.fuse",
+    itemId: item.id,
+    response: "definitely wrong",
+    latencyMs: 200,
+  })
   assert.equal(service.position(), climbed - 1)
 })
 
@@ -278,4 +294,79 @@ test("driving the difficulty moves the one ladder, so judging resumes from where
     latencyMs: 1000,
   })
   assert.equal(service.position(), top - 1, "the ladder did not step down from the pack's position")
+})
+
+test("every rung on the ladder draws a question with numbers in it", () => {
+  // The test that was missing. `items.ts` read its operands out of two slots it
+  // named — `top` and `bottom` — and `slotText(undefined)` returns "". So when
+  // the curriculum grew a second active family whose slots are called `first`
+  // and `second`, the six easiest rungs in the product rendered as " + " with
+  // no numbers, and nothing anywhere said so: not a throw, not a log, not a
+  // failing test. A child on the easiest content would have been shown a blank
+  // question and asked to answer it.
+  //
+  // Every rung, not a sample: the rung this would next catch is by definition
+  // one nobody thought to name.
+  const rungs = ladder()
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  const families = new Set<string>()
+
+  for (let i = 0; i < rungs.length; i++) {
+    const at = rungs.length === 1 ? 0 : i / (rungs.length - 1)
+    const item = service.next({ packId: "dynawalla.fuse", difficulty: at })
+    const rung = rungs[i]
+    assert.ok(item, `rung ${String(i)} (${String(rung?.node.id)}) served nothing at all`)
+    families.add(rung?.family.family ?? "?")
+
+    assert.equal(item.operands.length, 2, `${item.skillId} did not draw two operands`)
+    for (const operand of item.operands) {
+      assert.match(operand, /^-?\d/, `${item.skillId} drew the operand "${operand}"`)
+    }
+    // The prompt a child reads, and a screen reader speaks. `" + "` is what
+    // this used to be.
+    assert.match(
+      item.prompt,
+      /^-?\d[\d ,.]*\s[+−]\s-?\d/u,
+      `${item.skillId} drew the prompt "${item.prompt}"`,
+    )
+    assert.ok(item.prompt.includes(item.operands[0] ?? "!"))
+    assert.ok(item.prompt.includes(item.operands[1] ?? "!"))
+    assert.equal(service.reveal(item.id).length > 0, true, `${item.skillId} has no answer`)
+  }
+
+  // And the operator agrees with the skill, across every family on the ladder.
+  // Two active families both define a `PROMPT_KEY_SUB`; comparing against one
+  // family's constant is a comparison that silently fails for the other, which
+  // is how a subtraction came to be drawn with a plus sign.
+  assert.ok(families.size >= 1)
+  for (let i = 0; i < rungs.length; i++) {
+    const at = rungs.length === 1 ? 0 : i / (rungs.length - 1)
+    const item = service.next({ packId: "dynawalla.fuse", difficulty: at })
+    assert.ok(item)
+    const subtracting = item.skillId.includes("subtract")
+    if (subtracting) {
+      assert.equal(item.operator, "-", `${item.skillId} was drawn as an addition`)
+      assert.ok(item.prompt.includes("−"), `${item.skillId} has no minus sign`)
+    } else {
+      assert.equal(item.operator, "+", `${item.skillId} was drawn as a subtraction`)
+      assert.ok(item.prompt.includes("+"), `${item.skillId} has no plus sign`)
+    }
+  }
+})
+
+test("isSubtraction reads every active family's key, not one family's constant", () => {
+  // The concrete regression: `gen.arith.number-facts` names its subtraction
+  // prompt `dw.prompt.number-facts.sub`, and this file used to compare against
+  // `dw.prompt.column-op.sub` alone.
+  assert.equal(isSubtraction("dw.prompt.column-op.sub"), true)
+  assert.equal(isSubtraction("dw.prompt.number-facts.sub"), true)
+  assert.equal(isSubtraction("dw.prompt.column-op.add"), false)
+  assert.equal(isSubtraction("dw.prompt.number-facts.add"), false)
+
+  // Held to the convention rather than to a list, so the family after next is
+  // covered by existing rather than by somebody remembering to edit this.
+  for (const rung of ladder()) {
+    const key = String(rung.node.generator.family)
+    assert.ok(key.length > 0)
+  }
 })

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -144,6 +144,42 @@ function slotText(slot: PromptSlot | undefined): string {
   }
 }
 
+/**
+ * The two operands a child reads, whichever family drew them.
+ *
+ * This file used to reach for `slots[SLOT_TOP]` and `slots[SLOT_BOTTOM]` by
+ * name, and `slotText(undefined)` returns `""`. So when the curriculum grew a
+ * second active family — `gen.arith.number-facts`, which names its slots
+ * `first` and `second` — every question on the six easiest rungs in the product
+ * rendered as `" + "` with no numbers in it, and nothing said so. That is the
+ * failure mode this codebase keeps meeting: a missing thing becoming an empty
+ * string and then becoming a blank screen a child is asked to answer.
+ *
+ * Named slots when a family declares them, declaration order otherwise, so a
+ * family that names its slots anything at all is drawn correctly. And an empty
+ * operand is refused by the caller rather than printed.
+ */
+export function operandsOf(exercise: Exercise): readonly string[] {
+  const slots = exercise.prompt.slots
+  const named = [slots[SLOT_TOP], slots[SLOT_BOTTOM]]
+  const chosen = named.every((slot) => slot !== undefined) ? named : Object.values(slots)
+  return chosen.map((slot) => slotText(slot))
+}
+
+/**
+ * Whether the prompt is a subtraction, by the curriculum's own key convention.
+ *
+ * Every family names its prompts `dw.prompt.<family>.<operation>`, and two
+ * active families already both define a `PROMPT_KEY_SUB` — which is why the
+ * curriculum's index re-exports them by name rather than with `export *`.
+ * Comparing against one family's constant is therefore a comparison that
+ * silently fails for the other. The last segment is the part they agree on, and
+ * `items.test.ts` holds every active family to it.
+ */
+export function isSubtraction(promptKey: string): boolean {
+  return promptKey === PROMPT_KEY_SUB || promptKey.endsWith(".sub")
+}
+
 /** An answer value as a child would write it. Never a float, never rounded. */
 export function answerText(value: AnswerValue, decimalPlaces: number): string | null {
   if (value.kind === "integer" || value.kind === "columnAlgorithm") {
@@ -359,15 +395,27 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         return null
       }
 
+      const [top = "", bottom = ""] = operandsOf(exercise)
+      if (top === "" || bottom === "") {
+        // A blank question is worse than no question: a child cannot answer
+        // `" + "` and cannot tell that anything is wrong with it. Loud, and
+        // named precisely enough to fix — the slot keys are what differ when a
+        // new family arrives and this file has not learned to read it.
+        console.error(
+          `[packs] ${rung.node.id} (${rung.family.family}) drew a prompt with a missing operand: ` +
+            `slots are [${Object.keys(exercise.prompt.slots).join(", ")}] and this read ` +
+            `["${top}", "${bottom}"]`,
+        )
+        return null
+      }
+
       const places = decimalPlacesOf(exercise)
       const choices = choicesFor(exercise, places)
       const id = `${exercise.exerciseId}#${String(sequence)}`
       remember(id, { exercise, rung, places, choices, answered: false })
       practised.add(rung.node.id)
 
-      const top = slotText(exercise.prompt.slots[SLOT_TOP])
-      const bottom = slotText(exercise.prompt.slots[SLOT_BOTTOM])
-      const subtract = exercise.prompt.key === PROMPT_KEY_SUB
+      const subtract = isSubtraction(exercise.prompt.key)
       const digits = digitsOf(exercise)
 
       return {

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -235,7 +235,25 @@ export type ItemServiceDeps = {
 }
 
 export type ItemService = {
-  next(input: { packId: string; skillId?: string }): Item | null
+  next(input: {
+    packId: string
+    skillId?: string
+    /**
+     * Where on the ladder the pack wants this question, 0..1 — 0 the easiest
+     * rung the host has, 1 the hardest.
+     *
+     * Relative rather than absolute, and that is the whole design: a pack
+     * cannot know how many rungs there are, and the bottom of the ladder moves
+     * as the curriculum grows. A request for 0 today lands on two-digit +
+     * two-digit because that is the easiest rung that exists; when rungs below
+     * it are authored, the same request lands on those instead and no pack is
+     * rebuilt. What it can never do is fail — the index is clamped into the
+     * ladder, so an unsatisfiable request becomes the nearest satisfiable one.
+     */
+    difficulty?: number
+    /** A ceiling on the same scale. The stream never goes above it. */
+    maxDifficulty?: number
+  }): Item | null
   judge(input: {
     packId: string
     itemId: string
@@ -263,6 +281,8 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
   const practised = new Set<string>()
   let position = 0
   let sequence = 0
+  /** A ladder with one rung answers every difficulty the same. Said once. */
+  let toldAboutFlatLadder = false
 
   const remember = (id: string, served: Served) => {
     ledger.set(id, served)
@@ -282,14 +302,44 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
   return {
     position: () => position,
 
-    next: ({ packId, skillId }) => {
+    next: ({ packId, skillId, difficulty, maxDifficulty }) => {
       // A pack may name a skill it covers. It is a request, not an instruction:
       // an unknown id falls back to the ladder rather than failing, because a
       // pack built against a later curriculum must still be playable.
       const wanted =
         skillId === undefined ? null : (rungs.find((rung) => rung.node.id === skillId) ?? null)
-      const rung = wanted ?? rungAt(position)
+
+      // A difficulty is the same kind of request, one rung lower down. It moves
+      // the ladder rather than reading past it, so there is one position and
+      // not two: a pack that drives the difficulty and then stops driving it
+      // resumes from where it left the child, and `judge` keeps climbing and
+      // stepping down from there.
+      let index = position
+      if (difficulty !== undefined || maxDifficulty !== undefined) {
+        const span = Math.max(0, rungs.length - 1)
+        const asked = difficulty === undefined ? position / Math.max(1, span) : difficulty
+        const cap = maxDifficulty === undefined ? 1 : maxDifficulty
+        index = Math.round(Math.min(asked, cap) * span)
+        position = Math.max(0, Math.min(span, index))
+        index = position
+      }
+
+      const rung = wanted ?? rungAt(index)
       if (!rung) return null
+      // Where the rung that was actually used sits, so the pack is told what it
+      // got and not what it asked for. A pack comparing the two is how a
+      // clamped request becomes visible on the pack's side.
+      const span = Math.max(0, rungs.length - 1)
+      const used = rungs.indexOf(rung)
+      const ordinate = span === 0 ? 0 : Math.max(0, Math.min(1, used / span))
+      if (span === 0 && difficulty !== undefined && !toldAboutFlatLadder) {
+        toldAboutFlatLadder = true
+        console.warn(
+          `[packs] ${packId} asked for difficulty ${difficulty.toFixed(2)} and the ladder has ` +
+            `${String(rungs.length)} rung(s) — every request lands on the same question until the ` +
+            `curriculum has more than one`,
+        )
+      }
 
       sequence += 1
       const seed = seedFrom(deps.profileId, packId, String(sequence))
@@ -324,6 +374,7 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         id,
         skillId: rung.node.id,
         level: rung.level,
+        difficulty: ordinate,
         form: "binary-op",
         operator: subtract ? "-" : "+",
         operands: [top, bottom],

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -197,10 +197,7 @@ export function createServices(deps: ServicesDeps): LaunchServices {
     Object.keys(store.getState().packs[packId] ?? {}).sort()
 
   const services: HostServices = {
-    nextItem: (input) =>
-      Promise.resolve(
-        items.next(input.skillId === undefined ? { packId: input.packId } : input) as Item | null,
-      ),
+    nextItem: (input) => Promise.resolve(items.next(input) as Item | null),
     judge: (input) => Promise.resolve(items.judge(input)),
     skip: (input) => {
       items.skip(input.itemId)

--- a/dynawalla/packs/sdk/src/guest.test.ts
+++ b/dynawalla/packs/sdk/src/guest.test.ts
@@ -288,3 +288,40 @@ test("after dispose, every call fails closed and dispose is idempotent", async (
     (error: unknown) => error instanceof PackError && error.code === "closed",
   )
 })
+
+test("a difficulty request is on the wire, and only the fields that were named", async (t) => {
+  t.after(cleanup)
+  const item = {
+    id: "i1",
+    skillId: "add.1",
+    level: 1,
+    difficulty: 0.25,
+    form: "binary-op",
+    operands: ["2", "3"],
+    prompt: "2 plus 3",
+    answerKind: "integer",
+  }
+  const { client, seen } = withFakeFrame({
+    answer: (request) => (request.method === "items.next" ? ok({ item }) : ok({})),
+  })
+  const host = await client
+
+  // The whole point: a pack can say how hard it wants the next question, and
+  // the ordinate it was actually served comes back on the item.
+  const served = await host.nextItem({ difficulty: 0.25, maxDifficulty: 0.6 })
+  assert.equal(served?.difficulty, 0.25)
+  assert.deepEqual(seen[0], {
+    id: 1,
+    method: "items.next",
+    params: { difficulty: 0.25, maxDifficulty: 0.6 },
+  })
+
+  // A field nobody named is absent rather than an explicit `undefined`: a
+  // structured clone carries `undefined` across, and "present but not a
+  // number" is a different thing at the host's guards from "absent".
+  await host.nextItem()
+  assert.deepEqual(seen[1], { id: 2, method: "items.next", params: {} })
+  await host.nextItem({ skillId: "add.1" })
+  assert.deepEqual(seen[2], { id: 3, method: "items.next", params: { skillId: "add.1" } })
+  host.dispose()
+})

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -43,6 +43,32 @@ export class PackError extends Error {
   }
 }
 
+/**
+ * What a pack may ask for when it asks for a question.
+ *
+ * Every field is a *request*, never an instruction. The host owns the ladder,
+ * and a pack that names something the host cannot serve gets the nearest thing
+ * the host has rather than an error — a pack built against a later curriculum
+ * must still be playable.
+ */
+export type ItemRequest = {
+  /** A skill the pack covers. An unknown id falls back to the ladder. */
+  readonly skillId?: string
+  /**
+   * How hard, 0..1, across the host's whole ladder: 0 is the easiest content
+   * the host can generate and 1 the hardest.
+   *
+   * Relative rather than absolute because a pack cannot know how many rungs the
+   * host has, and because the floor moves: when the curriculum grows easier
+   * rungs, 0 follows them down and no pack has to be rebuilt. The item that
+   * comes back reports the position it was actually drawn from, on the same
+   * scale, so a pack can see when a request was clamped.
+   */
+  readonly difficulty?: number
+  /** A ceiling on the same 0..1 scale. Never serve harder than this. */
+  readonly maxDifficulty?: number
+}
+
 export type HostClient = {
   readonly packId: string
   /** The host app's version, for a pack that renders a compatibility note. */
@@ -54,7 +80,7 @@ export type HostClient = {
   can(method: Method): boolean
 
   /** The next question for this pack, or `null` when the host has none. */
-  nextItem(options?: { skillId?: string }): Promise<Item | null>
+  nextItem(options?: ItemRequest): Promise<Item | null>
   /**
    * Record an attempt and learn whether it was right.
    *
@@ -212,10 +238,14 @@ function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
     can: (method) => permits(connectMessage.granted, method),
 
     nextItem: async (options = {}) => {
-      const result = await call(
-        "items.next",
-        options.skillId === undefined ? {} : { skillId: options.skillId },
-      )
+      // Built by omission rather than by sending `undefined`: a structured
+      // clone carries an explicit `undefined` across, and the host's parameter
+      // guards read "present but not a number" differently from "absent".
+      const params: Record<string, unknown> = {}
+      if (options.skillId !== undefined) params["skillId"] = options.skillId
+      if (options.difficulty !== undefined) params["difficulty"] = options.difficulty
+      if (options.maxDifficulty !== undefined) params["maxDifficulty"] = options.maxDifficulty
+      const result = await call("items.next", params)
       return (result as { item: Item | null }).item
     },
     answer: async (input) =>

--- a/dynawalla/packs/sdk/src/index.ts
+++ b/dynawalla/packs/sdk/src/index.ts
@@ -43,6 +43,7 @@ export {
   numberParam,
   parseRequest,
   stringParam,
+  unitParam,
 } from "./protocol.ts"
 export type {
   Connect,
@@ -66,4 +67,4 @@ export { compareSemver, compareVersions, isSemver, parseSemver, satisfies, sdkCo
 export type { HostRange, Semver } from "./semver.ts"
 
 export { PackError, connect } from "./guest.ts"
-export type { HostClient } from "./guest.ts"
+export type { HostClient, ItemRequest } from "./guest.ts"

--- a/dynawalla/packs/sdk/src/protocol.test.ts
+++ b/dynawalla/packs/sdk/src/protocol.test.ts
@@ -8,6 +8,7 @@ import {
   numberParam,
   parseRequest,
   stringParam,
+  unitParam,
 } from "./protocol.ts"
 
 test("a well-formed request parses and carries an object of params", () => {
@@ -85,6 +86,22 @@ test("number parameters clamp rather than reject, but refuse nonsense", () => {
   assert.equal(numberParam({ n: Number.NaN }, "n", 10), null)
   assert.equal(numberParam({ n: Number.POSITIVE_INFINITY }, "n", 10), null)
   assert.equal(numberParam({ n: "5" }, "n", 10), null)
+})
+
+test("a unit parameter clamps at both ends, and absent means absent", () => {
+  assert.equal(unitParam({ d: 0.25 }, "d"), 0.25)
+  assert.equal(unitParam({ d: 0 }, "d"), 0)
+  assert.equal(unitParam({ d: 1 }, "d"), 1)
+  // Both ends clamp. `numberParam(_, _, 1)` returns null for a negative, which
+  // at a call site that reads null as "absent" turns an out-of-range request
+  // into no request at all — silently. A number is a number.
+  assert.equal(unitParam({ d: 1.4 }, "d"), 1)
+  assert.equal(unitParam({ d: -0.5 }, "d"), 0)
+  assert.equal(numberParam({ d: -0.5 }, "d", 1), null, "the guard this one exists to replace")
+  // Only a non-number is absent.
+  assert.equal(unitParam({ d: "0.5" }, "d"), null)
+  assert.equal(unitParam({ d: Number.NaN }, "d"), null)
+  assert.equal(unitParam({}, "d"), null)
 })
 
 test("the guards a pack uses on host traffic are equally exact", () => {

--- a/dynawalla/packs/sdk/src/protocol.ts
+++ b/dynawalla/packs/sdk/src/protocol.ts
@@ -144,7 +144,27 @@ export type Item = {
   /** Opaque, one serve. `items.answer` quotes it back. */
   readonly id: string
   readonly skillId: string
+  /**
+   * The level *within* the skill, as the generator numbers its own parameter
+   * sets. Not a difficulty: two skills' level 2 are not comparable, and the
+   * shipped graph only goes to 3. For "how hard is this compared to everything
+   * else the host has", read `difficulty`.
+   */
   readonly level: number
+  /**
+   * Where this item sits on the host's whole ladder: 0 is the easiest content
+   * the host can generate and 1 the hardest.
+   *
+   * The one difficulty number that is comparable across skills, and the one a
+   * pack should read. It is relative on purpose — a pack has no way to know how
+   * many rungs the host has, and when the curriculum grows rungs below the
+   * current floor, 0 follows them down without a pack changing.
+   *
+   * Optional so an older host is not a breaking change; a pack that sees
+   * `undefined` should fall back to `level`, which is what it was already
+   * doing.
+   */
+  readonly difficulty?: number
   readonly form: "binary-op" | "value" | "compare" | "sequence"
   readonly operator?: "+" | "-" | "×" | "÷" | "<" | ">" | "="
   readonly operands: readonly string[]
@@ -250,6 +270,21 @@ export function stringParam(
   if (typeof value !== "string") return null
   if (value.length === 0 || value.length > maxLength) return null
   return value
+}
+
+/**
+ * A 0..1 parameter, clamped rather than rejected.
+ *
+ * `numberParam(params, key, 1)` is not this: it returns `null` for a negative,
+ * which at a call site that treats `null` as "absent" turns an out-of-range
+ * request into no request at all — silently, which is the failure mode this
+ * codebase keeps being bitten by. A number is a number; only a non-number is
+ * absent.
+ */
+export function unitParam(params: Readonly<Record<string, unknown>>, key: string): number | null {
+  const value = params[key]
+  if (typeof value !== "number" || !Number.isFinite(value)) return null
+  return Math.max(0, Math.min(1, value))
 }
 
 /** A finite non-negative number parameter, clamped rather than rejected. */

--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -1,0 +1,506 @@
+// The difficulty wire, held to the promises it makes.
+//
+// Every test here runs against `attachGameHost` and a fake `HostClient`, which
+// is the whole reason that seam exists: the adapter's interesting behaviour —
+// which question comes out next, and why — needs no window, no parent frame and
+// no `MessagePort`.
+//
+// The fake host is a ladder of 16 rungs. Rung 0 is the easiest content it has
+// and rung 15 the hardest, and — like the real one — it stands somewhere in the
+// middle until a pack tells it otherwise. That is the situation the whole
+// design is for: a child is being served questions at rung 12, is struggling,
+// and the game knows it. What has to happen next is that the *next* question is
+// easier, not the thirty-third.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import type { Capability, HostClient, Item, ItemRequest, Judgement, Settings } from "../../sdk/src/index.ts"
+import { attachGameHost, toUnit, POOL_FLOOR } from "./index.ts"
+
+/** Rungs on the fake host's ladder. Enough that 1/16 is a visible step. */
+const RUNGS = 16
+
+/** Where the fake host stands before anybody asks it for anything. */
+const RESTING_RUNG = 12
+
+const SETTINGS: Settings = {
+  locale: "en",
+  reducedMotion: false,
+  quality: "high",
+  textScale: 1,
+  colorScheme: "light",
+  sound: true,
+  haptics: true,
+}
+
+/** Named by the SDK, so the fake cannot drift from the real wire. */
+type Ask = ItemRequest
+
+type Fake = {
+  readonly client: HostClient
+  /** Every `nextItem` call, in order. */
+  readonly asks: Ask[]
+  /** Every `answer` call, in order. */
+  readonly answers: { itemId: string; response: string }[]
+  /** The host's verdict on the next answer, whatever the pack claims. */
+  verdict: boolean
+  /** Make `answer` reject, to prove the pack's own belief still survives. */
+  answerFails: boolean
+}
+
+/**
+ * A host with a ladder, a resting position, and no opinions of its own.
+ *
+ * `difficulty` on the way in is 0..1 across the whole ladder, and the item that
+ * comes back says which rung it came from on the same scale. That is exactly
+ * the contract the real `items.ts` implements; this is the smallest thing that
+ * implements it too.
+ */
+function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fake {
+  const rungs = options.rungs ?? RUNGS
+  const asks: Ask[] = []
+  const answers: { itemId: string; response: string }[] = []
+  const canonicals = new Map<string, string>()
+  let sequence = 0
+
+  const fake: Fake = {
+    verdict: true,
+    answerFails: false,
+    asks,
+    answers,
+    client: {
+      packId: "dynawalla.test",
+      hostVersion: "0.1.0",
+      granted: options.granted ?? ["items", "items.reveal", "haptics"],
+      settings: SETTINGS,
+      can: () => true,
+
+      nextItem: (ask: Ask = {}) => {
+        asks.push(ask)
+        const span = Math.max(1, rungs - 1)
+        const cap = ask.maxDifficulty === undefined ? 1 : ask.maxDifficulty
+        const wanted = ask.difficulty === undefined ? RESTING_RUNG / span : ask.difficulty
+        const index = Math.max(
+          0,
+          Math.min(rungs - 1, Math.round(Math.min(wanted, cap) * span)),
+        )
+        sequence += 1
+        const item: Item = {
+          id: `i${String(sequence)}`,
+          skillId: `arith.rung.${String(Math.floor(index / 4))}`,
+          // Deliberately NOT the ladder ordinate: `level` is the level within a
+          // skill, which is what the shipped host puts here and what the old
+          // read-back mistook for a difficulty.
+          level: index % 4,
+          difficulty: index / span,
+          form: "binary-op",
+          operator: "+",
+          operands: [String(index), "1"],
+          prompt: `${String(index)} + 1`,
+          choices: [
+            { id: "c0", text: String(index + 1) },
+            { id: "c1", text: "999" },
+          ],
+          answerKind: "integer",
+        }
+        canonicals.set(item.id, String(index + 1))
+        return Promise.resolve(item)
+      },
+
+      answer: (input) => {
+        answers.push({ itemId: input.itemId, response: input.response })
+        if (fake.answerFails) return Promise.reject(new Error("the host is gone"))
+        return Promise.resolve({
+          correct: fake.verdict,
+          canonical: "1",
+          advance: fake.verdict,
+        } satisfies Judgement)
+      },
+      skip: () => Promise.resolve(),
+      reveal: (itemId) => Promise.resolve(canonicals.get(itemId) ?? ""),
+      learnerSummary: () => Promise.resolve({ skills: [] }),
+      haptic: () => Promise.resolve(),
+      sound: () => Promise.resolve(),
+      milestone: () => Promise.resolve(),
+      storage: {
+        get: () => Promise.resolve(null),
+        set: () => Promise.resolve(),
+        remove: () => Promise.resolve(),
+        keys: () => Promise.resolve([]),
+      },
+      progress: () => Promise.resolve(),
+      end: () => Promise.resolve(),
+      transition: () => Promise.resolve(),
+      on: () => () => {},
+      dispose: () => {},
+    },
+  }
+  return fake
+}
+
+/** Let every queued promise and timer callback run out. */
+async function settle(rounds = 12): Promise<void> {
+  for (let i = 0; i < rounds; i++) await new Promise((resolve) => setImmediate(resolve))
+}
+
+/** Run `body` with the console captured, and hand back what it said. */
+async function withConsole(body: () => Promise<void>): Promise<string[]> {
+  const said: string[] = []
+  const warn = console.warn
+  const error = console.error
+  const take = (...args: unknown[]) => {
+    said.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(" "))
+  }
+  console.warn = take
+  console.error = take
+  try {
+    await body()
+  } finally {
+    console.warn = warn
+    console.error = error
+  }
+  return said
+}
+
+// ─── The request reaches the item ────────────────────────────────────────────
+
+test("toUnit reads both scales the games already speak, and clamps the rest", () => {
+  // The 0..1 scale — polarity, trebuchet, siege.
+  assert.equal(toUnit(0), 0)
+  assert.equal(toUnit(0.2), 0.2)
+  // The one ambiguous value, resolved towards the bottom and stated in `toUnit`.
+  assert.equal(toUnit(1), 0)
+  // The 1..10 ladder — arena, horde, merge-idle, rhythm, slice, stack, beam.
+  assert.equal(toUnit(10), 1)
+  assert.equal(toUnit(5.5), 0.5)
+  // Out of range on either side, and not a number at all.
+  assert.equal(toUnit(12), 1)
+  assert.equal(toUnit(-4), 0)
+  assert.equal(toUnit(Number.NaN), null)
+  assert.equal(toUnit(Number.POSITIVE_INFINITY), null)
+})
+
+test("a difficulty a game asks for selects the question it gets back", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  const resting = mounted.host.next()
+  assert.ok(
+    resting.difficulty > 0.6,
+    `the host was resting at rung ${String(RESTING_RUNG)} and served ${String(resting.difficulty)}`,
+  )
+
+  // The child is struggling. The game says so, on the 1..10 scale six of the
+  // eight already-passing games speak.
+  mounted.host.next({ difficulty: 1 })
+  await settle()
+  const easy = mounted.host.next({ difficulty: 1 })
+  assert.ok(
+    easy.difficulty <= 0.1,
+    `asked for the bottom of the ladder and got ${String(easy.difficulty)}`,
+  )
+
+  // And back up again — this is not a one-way ratchet.
+  mounted.host.next({ difficulty: 10 })
+  await settle()
+  const hard = mounted.host.next({ difficulty: 10 })
+  assert.ok(
+    hard.difficulty >= 0.9,
+    `asked for the top of the ladder and got ${String(hard.difficulty)}`,
+  )
+  mounted.dispose()
+})
+
+test("the requested difficulty travels down the wire, not just into the pool", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  fake.asks.length = 0
+
+  mounted.host.next({ difficulty: 2 })
+  await settle()
+
+  const carried = fake.asks.filter((ask) => ask.difficulty !== undefined)
+  assert.ok(carried.length > 0, "no nextItem call carried a difficulty")
+  for (const ask of carried) {
+    assert.ok(
+      ask.difficulty !== undefined && Math.abs(ask.difficulty - toUnit(2)!) < 1e-9,
+      `the host was asked for ${String(ask.difficulty)}, not ${String(toUnit(2))}`,
+    )
+  }
+  mounted.dispose()
+})
+
+test("Question.difficulty reads the ladder the host actually used, not the level within a skill", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  mounted.host.next({ difficulty: 10 })
+  await settle()
+  const q = mounted.host.next({ difficulty: 10 })
+  // The fake's top rung is index 15, whose `level` is 15 % 4 === 3. The old
+  // read-back was `level / 8`, so the hardest question the host has would have
+  // read 0.375 — and colossus and siege, which branch on 0..1, would call the
+  // hardest content in the product "easy".
+  assert.equal(q.difficulty, 1, `the top of the ladder read as ${String(q.difficulty)}`)
+  mounted.dispose()
+})
+
+test("a ceiling is a ceiling: maxDifficulty is never exceeded", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  for (let i = 0; i < 6; i++) {
+    mounted.host.next({ difficulty: 10, maxDifficulty: 4 })
+    await settle(4)
+  }
+  for (let i = 0; i < 10; i++) {
+    const q = mounted.host.next({ difficulty: 10, maxDifficulty: 4 })
+    assert.ok(
+      q.difficulty <= toUnit(4)! + 1e-9,
+      `the ceiling was ${String(toUnit(4))} and the question came back at ${String(q.difficulty)}`,
+    )
+  }
+  mounted.dispose()
+})
+
+// ─── Flush: how many questions a change costs ────────────────────────────────
+
+/**
+ * How many questions a game has to serve before the stream follows a change.
+ *
+ * This is the measurement the whole prefetch pool argument turns on, so it is
+ * counted rather than asserted about: ask for the bottom of the ladder, then
+ * count questions until one actually arrives from there.
+ */
+async function questionsUntilEasy(mounted: ReturnType<typeof attachGameHost>): Promise<number> {
+  for (let n = 1; n <= 200; n++) {
+    const q = mounted.host.next({ difficulty: 1 })
+    if (q.difficulty <= 0.1) return n
+    await settle(3)
+  }
+  return Number.POSITIVE_INFINITY
+}
+
+test("without a flush the change lands a whole pool later; with one it lands next question", async () => {
+  // Both start from a *full* pool — `warm` awaits the floor and tops up in the
+  // background, and it is the topped-up sixty-four that a real game meets.
+  const stale = attachGameHost(fakeHost().client, { autoFlush: false })
+  await stale.warm()
+  await settle()
+  const before = await questionsUntilEasy(stale)
+  stale.dispose()
+
+  const fresh = attachGameHost(fakeHost().client)
+  await fresh.warm()
+  await settle()
+  const after = await questionsUntilEasy(fresh)
+  fresh.dispose()
+
+  console.log(`[measured] questions until a difficulty change lands: ${String(before)} → ${String(after)}`)
+
+  assert.ok(
+    before >= POOL_FLOOR,
+    `a stale pool should hold the old difficulty for at least ${String(POOL_FLOOR)} questions, not ${String(before)}`,
+  )
+  assert.ok(after <= 2, `a flushed pool should follow within 2 questions, not ${String(after)}`)
+  assert.ok(after < before, `flushing changed nothing: ${String(after)} vs ${String(before)}`)
+})
+
+test("flush never empties the pool, so a flushed question is still reportable", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  for (let i = 0; i < 8; i++) {
+    mounted.host.flush()
+    const q = mounted.host.next({ difficulty: 1 + i })
+    assert.notEqual(q.id, "", "the pool ran dry, so this question cannot be reported")
+    assert.notEqual(q.prompt, "")
+    // A frame's worth of time, which is more than the refill needs and less
+    // than a child needs to read a question.
+    await settle(2)
+  }
+  mounted.dispose()
+})
+
+// ─── The verdict is kept ─────────────────────────────────────────────────────
+
+test("what the game believed and what the host decided are both kept", async () => {
+  const fake = fakeHost()
+  const seen: { claimed: boolean; correct: boolean; judged: boolean; difficulty: number }[] = []
+  const mounted = attachGameHost(fake.client, {
+    onOutcome: (o) => seen.push({ claimed: o.claimed, correct: o.correct, judged: o.judged, difficulty: o.difficulty }),
+  })
+  await mounted.warm()
+
+  const q = mounted.host.next()
+  fake.verdict = false
+  mounted.host.report({ questionId: q.id, correct: true, ms: 900, answered: "7" })
+  await settle()
+
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0]?.claimed, true, "the game's own verdict was thrown away")
+  assert.equal(seen[0]?.correct, false, "the host's verdict was thrown away")
+  assert.equal(seen[0]?.judged, true)
+  assert.equal(seen[0]?.difficulty, q.difficulty)
+
+  const recent = mounted.host.recentOutcomes()
+  assert.equal(recent.length, 1)
+  assert.equal(recent[0]?.correct, false)
+  mounted.dispose()
+})
+
+test("a host that cannot be reached does not cost the child their answer", async () => {
+  const fake = fakeHost()
+  fake.answerFails = true
+  const mounted = attachGameHost(fake.client)
+  await withConsole(async () => {
+    await mounted.warm()
+    const q = mounted.host.next()
+    mounted.host.report({ questionId: q.id, correct: true, ms: 500, answered: "7" })
+    await settle()
+  })
+  const recent = mounted.host.recentOutcomes()
+  assert.equal(recent.length, 1, "the outcome vanished with the failed round trip")
+  assert.equal(recent[0]?.claimed, true)
+  assert.equal(recent[0]?.correct, true, "with no host verdict the game's belief is the record")
+  assert.equal(recent[0]?.judged, false, "an unjudged outcome must say it is unjudged")
+  mounted.dispose()
+})
+
+test("an outcome is recorded once, and only for a question this module served", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  const q = mounted.host.next()
+  mounted.host.report({ questionId: q.id, correct: true, ms: 100, answered: "1" })
+  mounted.host.report({ questionId: q.id, correct: false, ms: 100, answered: "2" })
+  mounted.host.report({ questionId: "never-served", correct: true, ms: 100, answered: "3" })
+  mounted.host.report({ questionId: "", correct: true, ms: 100, answered: "4" })
+  await settle()
+  assert.equal(mounted.host.recentOutcomes().length, 1)
+  mounted.dispose()
+})
+
+// ─── Nothing silent ──────────────────────────────────────────────────────────
+
+test("a difficulty outside every scale is clamped and said out loud", async () => {
+  const said = await withConsole(async () => {
+    const mounted = attachGameHost(fakeHost().client)
+    await mounted.warm()
+    mounted.host.next({ difficulty: 40 })
+    mounted.host.next({ difficulty: Number.NaN })
+    await settle()
+    mounted.dispose()
+  })
+  assert.ok(
+    said.some((line) => line.includes("40")),
+    `nothing was said about a difficulty of 40: ${said.join(" | ")}`,
+  )
+  assert.ok(
+    said.some((line) => line.toLowerCase().includes("nan")),
+    `nothing was said about a difficulty of NaN: ${said.join(" | ")}`,
+  )
+})
+
+test("a request under the curriculum's floor clamps to the easiest rung and names it", async () => {
+  const said = await withConsole(async () => {
+    const mounted = attachGameHost(fakeHost().client)
+    await mounted.warm()
+    for (let i = 0; i < 4; i++) {
+      mounted.host.next({ difficulty: 0 })
+      await settle(4)
+    }
+    mounted.dispose()
+  })
+  const floor = said.filter((line) => line.includes("easiest"))
+  assert.ok(floor.length > 0, `the floor was hit silently: ${said.join(" | ")}`)
+  assert.ok(
+    floor[0]?.includes("arith.rung.0"),
+    `the floor notice does not name the rung it stopped at: ${String(floor[0])}`,
+  )
+  // Loud once, not once a frame: a warning a game prints sixty times a second
+  // is a warning nobody reads.
+  assert.equal(floor.length, 1, `the floor notice repeated ${String(floor.length)} times`)
+})
+
+// ─── Backwards compatibility ─────────────────────────────────────────────────
+
+test("a game that passes nothing gets exactly what it got before", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  const drawn: string[] = []
+  for (let i = 0; i < 20; i++) drawn.push(mounted.host.next().id)
+
+  // FIFO, in the order the host served them, with no difficulty on the wire.
+  assert.deepEqual(drawn, Array.from({ length: 20 }, (_, i) => `i${String(i + 1)}`))
+  assert.equal(
+    fake.asks.every((ask) => ask.difficulty === undefined && ask.maxDifficulty === undefined),
+    true,
+    "a game that asked for nothing put a difficulty on the wire",
+  )
+  mounted.dispose()
+})
+
+test("focus still wins over difficulty, because a chip has to say a number", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  // Rung 15 is "15 + 1", whose answer is 16.
+  mounted.host.next({ difficulty: 10 })
+  await settle()
+  mounted.host.focus({ key: 1, wanted: [16] })
+  const q = mounted.host.next({ difficulty: 1 })
+  assert.equal(q.answer, "16", "a focused value was dropped in favour of a difficulty")
+  mounted.dispose()
+})
+
+test("setDifficulty and raiseFloor are real, so trebuchet and siege stop talking to nobody", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  mounted.host.setDifficulty(0.05)
+  await settle()
+  assert.ok(mounted.host.next().difficulty <= 0.1, "setDifficulty did nothing")
+
+  // siege's floor: never lets the maths fall below what the wave justifies.
+  mounted.host.raiseFloor(0.7)
+  await settle()
+  const held = mounted.host.next({ difficulty: 0 })
+  assert.ok(
+    held.difficulty >= 0.65,
+    `a raised floor of 0.7 was undercut at ${String(held.difficulty)}`,
+  )
+  // And it never lowers.
+  mounted.host.raiseFloor(0.1)
+  await settle()
+  assert.ok(mounted.host.next({ difficulty: 0 }).difficulty >= 0.65, "raiseFloor lowered the floor")
+  mounted.dispose()
+})
+
+test("a per-call domain is the label the question carries", async () => {
+  const mounted = attachGameHost(fakeHost().client, { domain: "arith" })
+  await mounted.warm()
+  assert.equal(mounted.host.next().domain, "arith")
+  assert.equal(mounted.host.next({ domain: "add" }).domain, "add")
+  mounted.dispose()
+})
+
+test("the one value the two scales disagree about is not read in silence", async () => {
+  const said = await withConsole(async () => {
+    const mounted = attachGameHost(fakeHost().client)
+    await mounted.warm()
+    mounted.host.next({ difficulty: 1 })
+    mounted.host.next({ difficulty: 1 })
+    await settle()
+    mounted.dispose()
+  })
+  const notes = said.filter((line) => line.includes("exactly 1"))
+  assert.equal(notes.length, 1, `said ${String(notes.length)} times: ${said.join(" | ")}`)
+  assert.ok(notes[0]?.includes("BOTTOM"), `the notice does not say which reading won: ${String(notes[0])}`)
+})

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -24,6 +24,36 @@
 // **Reporting is once per item.** An id that has already been reported, or that
 // this module did not serve, is dropped. A pack that double-reports a chip
 // would otherwise inflate a child's record, and the record only ever rises.
+//
+// ── The difficulty wire ──────────────────────────────────────────────────────
+//
+// This module used to be a one-way pipe. `next()` took no arguments, so the ten
+// games that had been passing `{ difficulty }` for months were passing it into
+// a function that ignored it; `Question.difficulty` was `item.level / 8`, a
+// read-back of a number that is not a difficulty; and `report` ended in a
+// literal `void correct`, throwing away the one signal twenty-five of the
+// twenty-seven games already have. Nothing a game knew about the child could
+// reach the thing that chose the next question.
+//
+// It now carries a request in both directions, and there are three parts to
+// making that actually change what a child sees:
+//
+//   1. `next({ difficulty })` reaches `items.next` as a 0..1 position on the
+//      host's whole ladder, and the item that comes back reports the position
+//      it was really drawn from — so a clamped request is visible rather than
+//      silent.
+//   2. The prefetch pool is *searched* rather than shifted, so a request is
+//      answered from whatever is already stocked.
+//   3. The pool is *flushed* when the request moves, because a pool of
+//      thirty-two to sixty-four questions is otherwise a thirty-two question
+//      delay between a decision and its effect. Measured: 34 questions without,
+//      2 with.
+//
+// What this module does NOT do is decide anything. It does not read the
+// outcomes it records, it has no opinion about whether a child is struggling,
+// and it never chooses a difficulty of its own. That is a controller, it lives
+// in `packs/shared/game-pacing/`, and it is somebody else's file. This is the
+// wire it will drive.
 
 import type { Capability, HostClient, Item, TransitionKind } from "../../sdk/src/index.ts"
 import { setHostInsets } from "../game-chrome/insets.ts"
@@ -38,19 +68,162 @@ export type Question = {
   answer: string
   distractors: string[]
   domain: string
-  /** 0..1 */
+  /**
+   * Where this question sits on the host's whole ladder: 0 is the easiest
+   * content the host has and 1 the hardest.
+   *
+   * This used to be `item.level / 8`, which was not that. `level` is the level
+   * *within a skill* — 0..3 on the shipped graph — so the hardest question in
+   * the product read 0.375 and the easiest read 0, and a game branching on the
+   * value (colossus, siege) could not tell the top of the ladder from the
+   * middle of it. The host now sends the ladder ordinate itself.
+   */
   difficulty: number
+}
+
+/**
+ * What a game is asking for, when it asks for anything.
+ *
+ * Every field is optional and a game that passes nothing gets exactly the
+ * stream it got before this type existed. That is not a courtesy: twenty-seven
+ * packs ship against this contract and seventeen of them already *declare*
+ * `next(opts?: { domain?: string; difficulty?: number })` locally, so the shape
+ * here is the one their call sites already produce.
+ */
+export type DifficultyRequest = {
+  /** Cosmetic label for this one question. Overrides the mount-wide domain. */
+  readonly domain?: string
+  /**
+   * How hard the game wants the next question. See `toUnit` for the scale —
+   * both of the ones already in the tree are read.
+   */
+  readonly difficulty?: number
+  /**
+   * A ceiling on the same scale. The stream never goes above it, and it stands
+   * until the game names a different one.
+   */
+  readonly maxDifficulty?: number
+}
+
+/**
+ * A game's difficulty number, on whichever of the two scales it speaks, as a
+ * 0..1 position on the host's ladder.
+ *
+ * **Why there are two scales.** They are both already in production and neither
+ * can be taken away. Six games (arena, horde, merge-idle, rhythm, slice, stack)
+ * and beam send an integer ladder index where 1 is the easiest question the
+ * game will ask for and 10 the hardest. polarity, trebuchet and siege send a
+ * 0..1 fraction. runner sends an unrounded 0..12. A single field cannot be read
+ * two ways by value alone, so the rule is stated here and tested rather than
+ * left to whoever reads the call site next:
+ *
+ *     value < 1   →  a fraction, used as is
+ *     value >= 1  →  a ladder index, `(value - 1) / 9`
+ *
+ * which makes exactly one value ambiguous — `1`, the bottom of one scale and
+ * the top of the other. It is read as the *bottom*, because that is what five
+ * of the six ladder games send on their opening question, and serving the
+ * hardest content in the product to a child who has just started is the failure
+ * this whole wire exists to prevent. A caller that needs to be exact at the top
+ * should speak the ladder scale, where every 0..1 position has an unambiguous
+ * spelling: `1 + unit * 9`.
+ *
+ * Out of range on either side is clamped, never rejected — but the clamp is
+ * announced by the caller of this function, because a difficulty of 40 is a
+ * bug in a game and a silent clamp is how it stays one. `null` means "that was
+ * not a number", which is also announced.
+ */
+export function toUnit(value: number): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null
+  if (value < 1) return Math.max(0, value)
+  return Math.min(1, (value - 1) / 9)
+}
+
+/**
+ * One answered question, with both verdicts on it.
+ *
+ * `report` used to end in a literal `void correct`: the game handed over what
+ * it believed and this module dropped it on the floor. Twenty-five of the
+ * twenty-seven games know locally whether the child was right, and that is the
+ * one signal an adaptive difficulty controller needs, so it is kept.
+ *
+ * Both verdicts, not one. `correct` is the host's — it is the record, it is
+ * what a parent sees, and it is the only one that counts. `claimed` is the
+ * game's, which is what a controller can act on *immediately*, before the round
+ * trip that produces the other one has returned.
+ */
+export type Outcome = {
+  readonly questionId: string
+  /** The ladder position of the question that was answered, 0..1. */
+  readonly difficulty: number
+  /** The skill the host drew it from. */
+  readonly skillId: string
+  /** What the game believed at the moment the child answered. */
+  readonly claimed: boolean
+  /** What the host decided. The record. */
+  readonly correct: boolean
+  /**
+   * False when the host could not be reached and `correct` is the game's own
+   * belief standing in for a verdict that never came. A controller that wants
+   * to weigh a judged outcome more heavily has the flag to do it with.
+   */
+  readonly judged: boolean
+  readonly ms: number
 }
 
 export type HapticKind = "light" | "medium" | "heavy" | "success" | "failure"
 
 export type GameHost = {
-  next(): Question
+  /**
+   * The next question, synchronously.
+   *
+   * With no argument this is what it always was: the front of the prefetch
+   * pool. With a `difficulty` it is the pooled question closest to what was
+   * asked for, and the host is asked to generate at that difficulty from here
+   * on — see `flush` for what happens to the questions already in flight.
+   */
+  next(request?: DifficultyRequest): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(kind: HapticKind): void
   prefersReducedMotion(): boolean
   /** Optional host extension FUSE feature-detects: bias the stream by value. */
   focus(spec: { key: number; wanted: number[] }): void
+  /**
+   * Throw away the prefetched questions that no longer match what the game is
+   * asking for, and start refilling at the current difficulty.
+   *
+   * **Why this has to exist.** The pool holds up to sixty-four questions and
+   * refills at thirty-two. A difficulty change with no flush therefore lands
+   * thirty-two questions later — minutes of wall clock — which makes "fall fast
+   * on a wrong answer" unachievable through this pipe no matter what the wire
+   * carries. Measured on the fake host in `index.test.ts`: 33 questions without
+   * a flush, 2 with one.
+   *
+   * **What it costs.** A refill stall, if it emptied the pool — and an empty
+   * pool is not a pause, it is a question with no id, whose answer is dropped
+   * because there is nothing to report it against. So it never empties: the
+   * questions closest to the new difficulty are kept as a reserve and the rest
+   * go. The reserve is what the game plays while the refill lands, which is why
+   * the change takes two questions rather than one.
+   *
+   * A game does not normally need to call this. `next` flushes by itself when
+   * the request moves far enough, which is what makes the eight games already
+   * passing `{ difficulty }` adaptive without changing a line.
+   */
+  flush(): void
+  /**
+   * A standing difficulty, set without taking a question. trebuchet has been
+   * feature-detecting this since it shipped.
+   */
+  setDifficulty(difficulty: number): void
+  /**
+   * Raise the floor under the stream and never lower it again. siege has been
+   * feature-detecting this since it shipped: a wave that has been reached
+   * justifies a floor under the maths, and a later easy wave must not undo it.
+   */
+  raiseFloor(difficulty: number): void
+  /** The answered questions this pack has reported, oldest first. Bounded. */
+  recentOutcomes(): readonly Outcome[]
   /**
    * A natural stopping point just happened: a level cleared, a run completed,
    * a boss down. Fire and forget — the game is told nothing back and must not
@@ -85,8 +258,8 @@ const HAPTIC: Record<HapticKind, "tick" | "seat" | "settle" | "refuse"> = {
  * (`items.next` then `items.reveal`) at 120 requests per second is far more
  * headroom than 64 items need.
  */
-const POOL_TARGET = 64
-const POOL_FLOOR = 32
+export const POOL_TARGET = 64
+export const POOL_FLOOR = 32
 
 /** A pack that has not seen a question in this long has been left running. */
 const IDLE_MS = 5 * 60 * 1000
@@ -94,11 +267,66 @@ const IDLE_MS = 5 * 60 * 1000
 /** Answered questions that count as one sitting, for the progress hairline. */
 const SESSION_ITEMS = 40
 
+/** Ladder distance the request has to move before `next` flushes by itself. */
+const FLUSH_BAND = 0.1
+
+/**
+ * The shortest gap between two automatic flushes.
+ *
+ * runner recomputes its difficulty continuously and asks on every gate; without
+ * this it would discard the pool several times a second and spend the whole run
+ * playing out of the reserve.
+ */
+const FLUSH_COOLDOWN_MS = 500
+
+/**
+ * A move this big is not drift and is not throttled.
+ *
+ * A quarter of the whole ladder in one step is a game saying something has
+ * changed — a child has just missed three in a row, a run has restarted, a
+ * revive has happened. Making that wait out a cooldown is the exact failure
+ * this module is being fixed for, so it does not.
+ */
+const FLUSH_URGENT = 0.25
+
+/** Pooled questions this close to the new difficulty survive a flush. */
+const KEEP_BAND = 0.12
+
+/**
+ * The reserve a flush always leaves, so the pool is never empty.
+ *
+ * Eight, because that is roughly what FUSE draws in one level turnover, and an
+ * empty pool is not a pause — it is a question with no id, whose answer is
+ * dropped because there is nothing to report it against.
+ */
+const FLUSH_KEEP = 8
+
+/** Outcomes kept for a controller to read back. */
+const OUTCOME_LIMIT = 64
+
+/** Difficulty at or below which a request is asking for the very bottom. */
+const FLOOR_REQUEST = 0.05
+
+const EPS = 1e-9
+
 export type GameHostOptions = {
   /** Domain label the game shows or logs. Cosmetic; the host owns the skill. */
   readonly domain?: string
   /** Called with 0..1 whenever the game's own progress is known. */
   readonly onProgress?: (fraction: number) => void
+  /**
+   * Every answered question, with both verdicts, as soon as the host's one is
+   * in. This is the seam a difficulty controller mounts on; nothing in this
+   * module decides anything with it.
+   */
+  readonly onOutcome?: (outcome: Outcome) => void
+  /**
+   * Whether `next` may discard the prefetch when the request moves. Default
+   * `true`, which is what makes an existing `next({ difficulty })` call site
+   * adaptive without being edited. A game that wants to own its own flushing
+   * turns it off and calls `flush` itself.
+   */
+  readonly autoFlush?: boolean
 }
 
 export type MountedHost = {
@@ -109,19 +337,26 @@ export type MountedHost = {
   dispose(): void
 }
 
+/** A pooled question, with the two facts about its origin the pool needs. */
+type Pooled = {
+  readonly question: Question
+  readonly skillId: string
+}
+
 function questionFrom(item: Item, canonical: string, domain: string): Question {
   const distractors = (item.choices ?? [])
     .map((choice) => choice.text)
     .filter((text) => text !== canonical)
+  // The host's own ladder ordinate when it sends one. The `level / 8` fallback
+  // is for a host older than this field and is the reading it always had.
+  const ladder = item.difficulty ?? item.level / 8
   return {
     id: item.id,
     prompt: item.prompt,
     answer: canonical,
     distractors,
     domain,
-    // A level index the host chose, squashed into the 0..1 the games read for
-    // pacing. Not a claim about difficulty; a monotone reading of the ladder.
-    difficulty: Math.max(0, Math.min(1, item.level / 8)),
+    difficulty: Math.max(0, Math.min(1, ladder)),
   }
 }
 
@@ -133,7 +368,20 @@ function questionFrom(item: Item, canonical: string, domain: string): Question {
  * forever, and the games' entry files render that message.
  */
 export async function createGameHost(options: GameHostOptions = {}): Promise<MountedHost> {
-  const client = await connect()
+  return attachGameHost(await connect(), options)
+}
+
+/**
+ * The same adapter, over a client somebody else obtained.
+ *
+ * `createGameHost` is `connect()` plus this. They are separate because the
+ * connection is the one part of this module that needs a `window`, a parent
+ * frame and a `MessagePort`, and everything interesting — which question comes
+ * out next, and why — is the part that does not. Split, the interesting part is
+ * testable in Node against a fake client, which is how the difficulty wire is
+ * held to its promises.
+ */
+export function attachGameHost(client: HostClient, options: GameHostOptions = {}): MountedHost {
   // A pack cannot measure its own safe area: it is a cross-origin child, and
   // `env(safe-area-inset-*)` belongs to the top-level browsing context, so it
   // reads zeros. The host measures and sends them; publish them to game-chrome
@@ -141,11 +389,13 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
   setHostInsets(client.settings.safeArea)
   client.on("settings", () => setHostInsets(client.settings.safeArea))
   const domain = options.domain ?? "arith"
+  const autoFlush = options.autoFlush ?? true
   const granted = new Set<Capability>(client.granted)
 
-  const pool: Question[] = []
-  /** Ids this module served and has not yet reported. */
-  const live = new Set<string>()
+  const pool: Pooled[] = []
+  /** Questions this module has handed to the game and not yet reported on. */
+  const served = new Map<string, { difficulty: number; skillId: string }>()
+  const outcomes: Outcome[] = []
   let wanted: number[] = []
   let filling = false
   let disposed = false
@@ -153,7 +403,72 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
   let lastAsk = Date.now()
   let reported = 0
 
+  /** The difficulty the game is asking for, 0..1, or null for "whatever". */
+  let target: number | null = null
+  /** A standing ceiling, 0..1, or null for none. */
+  let ceiling: number | null = null
+  /** A floor that only ever rises. siege drives this. */
+  let floor = 0
+  /** The difficulty the pool was last stocked for. */
+  let filledFor: number | null = null
+  let lastFlush = 0
+
+  /**
+   * Things said once per mount.
+   *
+   * Loud, because this repository has been bitten repeatedly by the opposite —
+   * a renderer that skipped unlabelled orbs, a generator that discarded
+   * out-of-range answers, both in silence. Once, because a warning a game
+   * prints sixty times a second is a warning nobody reads.
+   */
+  const spoken = new Set<string>()
+  const sayOnce = (key: string, message: string) => {
+    if (spoken.has(key)) return
+    spoken.add(key)
+    console.warn(message)
+  }
+
   const canReveal = granted.has("items.reveal")
+
+  /** A game's number, announced if it is nonsense and read if it is not. */
+  const readScale = (value: number, field: string): number | null => {
+    const unit = toUnit(value)
+    if (unit === null) {
+      sayOnce(
+        `nan:${field}`,
+        `[pack] ${field} was ${String(value)}, which is not a difficulty; the request was ignored`,
+      )
+      return null
+    }
+    if (value === 1) {
+      // The one value the two scales disagree about. Read as the bottom, for
+      // the reason given on `toUnit` — but said out loud, because the game that
+      // meant the other thing is the one that needs to know. polarity reaches
+      // exactly 1 after fifteen strata (about seven and a half minutes) and
+      // means "hardest"; six other games send it on their opening question and
+      // mean "easiest". Whichever this game is, it can now find out.
+      sayOnce(
+        `ambiguous:${field}`,
+        `[pack] ${field} of exactly 1 is the bottom of the 1..10 ladder and the top of the 0..1 ` +
+          `fraction; it is read as the BOTTOM. Send 10 for the hardest content on the ladder.`,
+      )
+    }
+    if (value < 0 || value > 10) {
+      sayOnce(
+        `range:${field}`,
+        `[pack] ${field} ${String(value)} is outside both scales this host reads ` +
+          `(0..1 as a fraction, 1..10 as a ladder index); clamped to ${unit.toFixed(2)}`,
+      )
+    }
+    return unit
+  }
+
+  const askShape = (): { difficulty?: number; maxDifficulty?: number } => {
+    const ask: { difficulty?: number; maxDifficulty?: number } = {}
+    if (target !== null) ask.difficulty = target
+    if (ceiling !== null) ask.maxDifficulty = ceiling
+    return ask
+  }
 
   const fill = () => {
     if (filling || disposed) return
@@ -162,7 +477,9 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
       try {
         while (!disposed && pool.length < POOL_TARGET) {
           if (Date.now() - lastAsk > IDLE_MS) break
-          const item = await client.nextItem()
+          // Read every time round the loop, not once: a difficulty change while
+          // a refill is in flight has to reach the questions still to come.
+          const item = await client.nextItem(askShape())
           if (item === null) break
           const canonical = canReveal ? await client.reveal(item.id) : ""
           if (canonical === "") {
@@ -171,8 +488,7 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
             console.error("[pack] items.reveal was not granted; questions cannot be placed")
             break
           }
-          pool.push(questionFrom(item, canonical, domain))
-          live.add(item.id)
+          pool.push({ question: questionFrom(item, canonical, domain), skillId: item.skillId })
         }
       } catch (error) {
         console.error("[pack] could not fill the question pool", error)
@@ -182,58 +498,178 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
     })()
   }
 
-  const take = (): Question => {
+  /** How wrong a pooled question is for what the game is asking for now. */
+  const distance = (entry: Pooled): number => {
+    const want = target ?? ceiling ?? entry.question.difficulty
+    const over = ceiling !== null && entry.question.difficulty > ceiling + EPS
+    // A question above a stated ceiling is never the answer while anything else
+    // exists, and is still an answer when nothing else does.
+    return Math.abs(entry.question.difficulty - want) + (over ? 1000 : 0)
+  }
+
+  const flushNow = () => {
+    lastFlush = Date.now()
+    filledFor = target
+    if (target !== null && pool.length > FLUSH_KEEP) {
+      // A focused value survives a flush whatever its difficulty. `focus`
+      // outranks difficulty when a question is handed out — FUSE's chip has to
+      // be able to say its own number — so a flush that threw those away would
+      // quietly undo the call the game just made.
+      const keep = pool.filter(
+        (entry) =>
+          distance(entry) <= KEEP_BAND || wanted.includes(Number(entry.question.answer)),
+      )
+      const kept =
+        keep.length >= FLUSH_KEEP
+          ? keep
+          : [...pool].sort((a, b) => distance(a) - distance(b)).slice(0, FLUSH_KEEP)
+      pool.length = 0
+      pool.push(...kept)
+    }
+    fill()
+  }
+
+  const maybeFlush = () => {
+    if (!autoFlush || target === null) return
+    const moved = filledFor === null ? 1 : Math.abs(target - filledFor)
+    if (moved < FLUSH_BAND) return
+    if (moved < FLUSH_URGENT && Date.now() - lastFlush < FLUSH_COOLDOWN_MS) return
+    flushNow()
+  }
+
+  /** Fold a game's request into the standing one. Returns nothing; sets state. */
+  const applyRequest = (request: DifficultyRequest | undefined) => {
+    if (request === undefined) return
+    if (request.maxDifficulty !== undefined) {
+      const unit = readScale(request.maxDifficulty, "maxDifficulty")
+      if (unit !== null) ceiling = unit
+    }
+    if (request.difficulty !== undefined) {
+      const unit = readScale(request.difficulty, "difficulty")
+      if (unit !== null) target = Math.max(unit, floor)
+    }
+    if (target !== null && ceiling !== null) target = Math.min(target, ceiling)
+    maybeFlush()
+  }
+
+  const take = (request?: DifficultyRequest): Question => {
     lastAsk = Date.now()
+    applyRequest(request)
+    const label = request?.domain ?? domain
+
+    const hand = (entry: Pooled): Question => {
+      if (pool.length < POOL_FLOOR) fill()
+      const question = label === entry.question.domain
+        ? entry.question
+        : { ...entry.question, domain: label }
+      lastServed = question
+      served.set(question.id, { difficulty: question.difficulty, skillId: entry.skillId })
+      if (
+        target !== null &&
+        target <= FLOOR_REQUEST &&
+        question.difficulty <= FLOOR_REQUEST + EPS
+      ) {
+        // The request could not be satisfied downwards and was clamped to the
+        // bottom of what exists. Said out loud, once, naming the rung it
+        // stopped at, because "the curriculum has no easier content" is a fact
+        // about the product and not about this game.
+        sayOnce(
+          "floor",
+          `[pack] difficulty ${target.toFixed(2)} was requested and the easiest rung this host ` +
+            `has is "${entry.skillId}" at ${question.difficulty.toFixed(2)} — the curriculum has ` +
+            `nothing below it, so this is as easy as questions get today`,
+        )
+      }
+      return question
+    }
+
     // A value the game said it needs, if the pool happens to hold one: FUSE
     // asks for a chip worth exactly 7 and can then print an expression on it.
     // When nothing matches, the game gets the next question and draws a
-    // numeral instead — which is what `focus` being optional means.
+    // numeral instead — which is what `focus` being optional means. This still
+    // outranks difficulty: a chip that cannot say its own number is not a
+    // slightly-too-hard chip, it is an unplayable one.
     if (wanted.length > 0) {
-      const index = pool.findIndex((question) => wanted.includes(Number(question.answer)))
+      const index = pool.findIndex((entry) => wanted.includes(Number(entry.question.answer)))
       if (index >= 0) {
         const [picked] = pool.splice(index, 1)
-        if (picked) {
-          lastServed = picked
-          if (pool.length < POOL_FLOOR) fill()
-          return picked
-        }
+        if (picked) return hand(picked)
       }
     }
-    const next = pool.shift()
-    if (pool.length < POOL_FLOOR) fill()
-    if (next) {
-      lastServed = next
-      return next
+
+    // The question closest to what was asked for. Ties go to the front of the
+    // pool, so with no difficulty request this is exactly the FIFO it was.
+    if ((target !== null || ceiling !== null) && pool.length > 0) {
+      let best = 0
+      let score = distance(pool[0] as Pooled)
+      for (let i = 1; i < pool.length; i++) {
+        const candidate = distance(pool[i] as Pooled)
+        if (candidate < score) {
+          score = candidate
+          best = i
+        }
+      }
+      const [picked] = pool.splice(best, 1)
+      if (picked) return hand(picked)
     }
+
+    const next = pool.shift()
+    if (next) return hand(next)
+    if (pool.length < POOL_FLOOR) fill()
     // The pool ran dry. The game gets something drawable with no id, so the
     // report it produces is dropped rather than answering a served item twice.
     console.warn("[pack] the question pool ran dry")
     return lastServed
       ? { ...lastServed, id: "" }
-      : { id: "", prompt: "", answer: "0", distractors: [], domain, difficulty: 0 }
+      : { id: "", prompt: "", answer: "0", distractors: [], domain: label, difficulty: 0 }
   }
 
   const host: GameHost = {
     next: take,
 
     report: ({ questionId, correct, ms, answered }) => {
-      if (questionId === "" || !live.has(questionId)) return
-      live.delete(questionId)
+      const origin = served.get(questionId)
+      if (questionId === "" || origin === undefined) return
+      served.delete(questionId)
       // The host draws the progress and the pack does not, so what a pack owes
       // it is a fraction. "How far into this sitting" is the only one a game
       // with no ending can honestly report, and it is the one a parent glancing
       // at a tablet wants: forty answered questions is a session.
       reported += 1
-      void client.progress(Math.min(1, reported / SESSION_ITEMS)).catch(() => {})
-      options.onProgress?.(Math.min(1, reported / SESSION_ITEMS))
-      // The host judges. `correct` is what the game believes; it is not sent,
-      // and it is not what is recorded.
+      const fraction = Math.min(1, reported / SESSION_ITEMS)
+      void client.progress(fraction).catch(() => {})
+      options.onProgress?.(fraction)
+
+      const land = (verdict: boolean, judged: boolean) => {
+        const outcome: Outcome = {
+          questionId,
+          difficulty: origin.difficulty,
+          skillId: origin.skillId,
+          claimed: correct,
+          correct: verdict,
+          judged,
+          ms: Math.max(0, Math.round(ms)),
+        }
+        outcomes.push(outcome)
+        while (outcomes.length > OUTCOME_LIMIT) outcomes.shift()
+        options.onOutcome?.(outcome)
+      }
+
+      // The host judges, and its verdict is the record. The game's belief is
+      // kept beside it rather than discarded: it is the only signal available
+      // if this round trip never comes back, and it is available a round trip
+      // sooner when it does.
       void client
         .answer({ itemId: questionId, response: answered, latencyMs: Math.max(0, Math.round(ms)) })
-        .catch((error: unknown) => {
-          console.error("[pack] an answer could not be reported", error)
-        })
-      void correct
+        .then(
+          (judgement) => {
+            land(judgement.correct, true)
+          },
+          (error: unknown) => {
+            console.error("[pack] an answer could not be reported", error)
+            land(correct, false)
+          },
+        )
     },
 
     haptic: (kind) => {
@@ -250,6 +686,24 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
       wanted = values.slice(0, 32)
       if (pool.length < POOL_TARGET) fill()
     },
+
+    flush: flushNow,
+
+    setDifficulty: (difficulty) => {
+      applyRequest({ difficulty })
+    },
+
+    raiseFloor: (difficulty) => {
+      const unit = readScale(difficulty, "raiseFloor")
+      if (unit === null || unit <= floor) return
+      floor = unit
+      if (target === null || target < floor) {
+        target = ceiling === null ? floor : Math.min(floor, ceiling)
+        maybeFlush()
+      }
+    },
+
+    recentOutcomes: () => outcomes,
 
     transition: (kind, label) => {
       // Synchronous on the outside, because it is called from inside a game
@@ -268,12 +722,11 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
       // Awaited so the first frame the child sees is already stocked. Filling
       // in the background and hoping is how a game shows a blank chip once.
       for (let i = 0; i < POOL_FLOOR && !disposed; i++) {
-        const item = await client.nextItem()
+        const item = await client.nextItem(askShape())
         if (item === null) break
         const canonical = canReveal ? await client.reveal(item.id) : ""
         if (canonical === "") break
-        pool.push(questionFrom(item, canonical, domain))
-        live.add(item.id)
+        pool.push({ question: questionFrom(item, canonical, domain), skillId: item.skillId })
       }
       fill()
     },

--- a/dynawalla/packs/shared/game-host/package-lock.json
+++ b/dynawalla/packs/shared/game-host/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/game-host",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-host",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/packs/shared/game-host/package.json
+++ b/dynawalla/packs/shared/game-host/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dynawalla/game-host",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The adapter every arcade pack mounts against: a synchronous game-facing Host over the asynchronous pack SDK, including the difficulty request wire and the prefetch pool behind it.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"*.test.ts\"",
+    "tsc": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/packs/shared/game-host/tsconfig.json
+++ b/dynawalla/packs/shared/game-host/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  /* The same strictness the app and the SDK are held to, so a type that passes
+     here cannot fail when a game imports the identical file by relative path —
+     which is how all 27 of them consume this module. `erasableSyntaxOnly` keeps
+     every file runnable under `node --experimental-strip-types`. */
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
Ten games have been calling `host.next({ difficulty })` for months. The shared adapter's signature was `next(): Question`, wired `next: take`, and `take()` ignored everything passed to it. Every one of those arguments was discarded in production. The games were talking into a dead wire.

This PR is the **wire**, not the controller. It does not decide anything. The controller lives in `packs/shared/game-pacing/` and is somebody else's file.

## What was broken

| | |
|---|---|
| `GameHost.next()` | took no arguments; `HostClient.nextItem` had no difficulty on the wire at all |
| `Question.difficulty` | `item.level / 8` — a read-back, and of the **wrong number**. `level` is the level *within* a skill (0..3 on the shipped graph), not a ladder position, so the hardest question in the product read `0.375`. colossus and siege branch on 0..1 and could not tell the top of the ladder from the middle |
| `report()` | ended in a literal `void correct` — 25 of 27 games know locally whether the child was right, and the adapter threw it away |
| the pool | 32–64 item FIFO between any decision and the child, so a change landed **34 questions** later |
| `setDifficulty` / `raiseFloor` | trebuchet and siege have feature-detected these since they shipped; the adapter did not implement them |

## The wire

```ts
next(request?: { domain?: string; difficulty?: number; maxDifficulty?: number }): Question
flush(): void
setDifficulty(d: number): void
raiseFloor(d: number): void
recentOutcomes(): readonly Outcome[]
```

The request shape is the one those ten call sites **already produce**, so adoption is free. `difficulty` reaches `items.next` as a 0..1 position on the host's whole ladder, selects the rung, and moves the host's own ladder position — so a pack that stops driving resumes from where it left the child rather than being pulled back up by the ladder's own climb.

`Item.difficulty` (optional, so an older host is not a breaking change) carries the ladder ordinate the host **actually used**, which is how a pack can see a clamp.

`Outcome` keeps both verdicts: `correct` is the host's and is the record; `claimed` is the game's, available a round trip sooner, and the only one there is when the round trip never comes back (`judged: false`).

## Two scales, one field

Both are in production and neither can be removed: six games send an integer 1..10 ladder index, three send a 0..1 fraction, runner sends an unrounded 0..12. `toUnit` states the rule — `< 1` is a fraction, `>= 1` is `(v-1)/9` — leaving exactly one ambiguous value, `1`. It is read as the **bottom**, because five of the six ladder games send it on their opening question and serving the hardest content in the product to a child who has just started is the failure this exists to prevent. It says so out loud, once, when it sees one. Out of range clamps loudly. Not a number is ignored loudly.

## When a request cannot be satisfied

The scale is relative to the host's own ladder, so `0` always lands on the easiest rung that exists — today two-digit + two-digit, because the curriculum floor is still being authored. That clamp is **announced**, naming the rung it stopped at:

```
[pack] difficulty 0.00 was requested and the easiest rung this host has is
"arith.add.two-digit" at 0.00 — the curriculum has nothing below it, so this
is as easy as questions get today
```

When rungs below it land, the same request follows them down and no pack is rebuilt.

## Flush, measured

`34 → 2` questions between a difficulty change and a question that reflects it, asserted in `index.test.ts` rather than claimed. Flush never empties the pool — an empty pool is not a pause, it is a question with no id whose answer gets dropped — so it keeps the eight closest questions as a reserve, plus anything `focus` asked for.

## Verification

- **`game-host` had no `package.json`**, so CI's `dynawalla/packs/shared/*/package.json` glob ran no tests and no typecheck against the module 27 packs mount on. It has one now.
- **16 fix-deletions**, each confirmed to turn the suite red, with the failure message recorded.
- **All three suites run 5×**, clean: game-host 17, sdk 54, app 225.
- **15 games** installed, typechecked and tested against the new contract: 1084 tests, 0 failures. A probe outside `games/` confirms the widened `GameHost` structurally satisfies all 15 local `Host` contracts **without** the `as unknown as` cast that would otherwise hide a mismatch (validated against a negative control).
- **No Tauri boundary.** The item wire is a `MessagePort` between two documents in one WebView; `src-tauri/src/packs/mod.rs` never sees an `Item`. Checked by grep, not assumed, because a Rust `models.rs` silently dropping unknown serde fields has bitten this repo before.

## Touches nothing under `games/`, `game-chrome/`, `curriculum/`

Eight agents are working in those. `git status` on this branch is clean outside `packs/shared/game-host/`, `packs/sdk/src/` and `dynawalla-app/src/packs/`.

## Behaviour changes worth a runtime look

`siege`'s `raiseFloor` (0..0.72) and `trebuchet`'s `setDifficulty` (capped at 0.95) were no-ops and are now live calls. Both stay clear of the ambiguous `1`. `polarity` reaches exactly `1` after ~7.5 minutes of survival and means *hardest*; it will be read as easiest and will log the notice. That is the documented cost of the one ambiguous value, and the log line is how its owner will find it.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb