### PR TITLE
fix(dynawalla/games/polarity): four blank glowing discs are not a question, and 20 is not what the child answered

### DIFF
--- a/dynawalla/games/polarity/src/core/labels.test.ts
+++ b/dynawalla/games/polarity/src/core/labels.test.ts
@@ -1,0 +1,229 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  LABEL_ASPECT,
+  LABEL_CAPACITY,
+  LABEL_FAULT,
+  LabelBook,
+  isPrintable,
+  labelText,
+} from "./labels.ts";
+import { BULLET, HALF_W } from "../game/constants.ts";
+import { orbValues } from "../game/seal.ts";
+import type { Question } from "../contract.ts";
+// The REAL stream. `ladder()`, `choicesFor()` and `answerText()` are the host's
+// own item service — the same functions that build what `items.next` hands this
+// pack — over `@dynawalla/curriculum`'s generators. Nothing here is a stand-in
+// for the curriculum, because a stand-in is exactly how the bug this file exists
+// for survived: the dev stub host clamps itself to ±40, so the harness never
+// showed a single blank orb and the shipped pack showed almost nothing else.
+import { answerText, choicesFor, ladder } from "../../../../dynawalla-app/src/packs/items.ts";
+import { seedFrom } from "../../../../packs/shared/curriculum/src/index.ts";
+
+const SEEDS = 250;
+
+type Sample = { question: Question; level: number; skill: string };
+
+/** Every item the shipping ladder can serve this pack, as the pack sees it. */
+function sweep(): Sample[] {
+  const out: Sample[] = [];
+  for (const rung of ladder()) {
+    for (let s = 0; s < SEEDS; s++) {
+      const exercise = rung.family.generate({
+        skillId: rung.node.id,
+        level: rung.level,
+        seed: seedFrom("polarity-test", "dynawalla.polarity", String(s)),
+        params: rung.params,
+        forms: ["free-entry"],
+      });
+      const schema = exercise.schema;
+      const places =
+        schema.kind === "integer" || schema.kind === "columnAlgorithm" ? schema.decimalPlaces : 0;
+      const canonical = answerText(exercise.answer.canonical, places);
+      if (canonical === null) continue;
+      const choices = choicesFor(exercise, places);
+      out.push({
+        level: rung.level,
+        skill: rung.node.id,
+        question: {
+          id: exercise.exerciseId,
+          prompt: "",
+          answer: canonical,
+          distractors: choices.map((c) => c.text).filter((t) => t !== canonical),
+          domain: "add-sub",
+          difficulty: 0,
+        },
+      });
+    }
+  }
+  return out;
+}
+
+test("not one orb the shipping curriculum can put on the field comes out blank", () => {
+  const items = sweep();
+  assert.ok(items.length > 4000, `the sweep only saw ${String(items.length)} items`);
+
+  const book = new LabelBook();
+  let orbs = 0;
+  let blank = 0;
+  let blankItems = 0;
+  const worst: string[] = [];
+
+  for (const { question, skill, level } of items) {
+    const values = orbValues(question, 4);
+    // A value the game cannot display must never be offered. Declining is the
+    // sanctioned way to fail; this asserts it never even has to.
+    assert.ok(values, `${skill} L${String(level)} produced an item with no drawable answer`);
+    assert.ok(values.length >= 1);
+    book.beginFrame();
+    let blankHere = 0;
+    for (const v of values) {
+      orbs++;
+      const tile = book.tileFor(v);
+      const printed = tile < 0 ? null : book.textAt(tile);
+      if (printed === null || printed === LABEL_FAULT) {
+        blank++;
+        blankHere++;
+        if (worst.length < 8) worst.push(`${skill} L${String(level)}: ${String(v)}`);
+      }
+    }
+    if (blankHere === values.length) blankItems++;
+  }
+
+  const pct = (blank / orbs) * 100;
+  assert.equal(
+    blank,
+    0,
+    `${String(blank)}/${String(orbs)} orbs (${pct.toFixed(1)}%) were unlabelled glowing discs, ` +
+      `and ${String(blankItems)} items had NO readable option at all. First few: ${worst.join(", ")}`,
+  );
+  assert.equal(book.faults, 0, "the book was asked to print something that is not an integer");
+});
+
+test("every value the ladder emits survives a round trip through a printed numeral", () => {
+  for (const { question } of sweep()) {
+    const values = orbValues(question, 4);
+    assert.ok(values);
+    for (const v of values) {
+      assert.ok(isPrintable(v), `${String(v)} is not printable`);
+      const printed = labelText(v);
+      assert.notEqual(printed, LABEL_FAULT, `${String(v)} printed as a fault`);
+      // U+2212 in, ASCII out: what is drawn is the value, exactly.
+      assert.equal(Number(printed.replace(/−/g, "-")), v);
+    }
+  }
+});
+
+test("a numeral is never absent — magnitude is not a reason to be blank", () => {
+  const book = new LabelBook();
+  book.beginFrame();
+  for (const v of [0, 7, -7, 40, 41, -41, 99, 137, 3916, 998232, -998232]) {
+    const tile = book.tileFor(v);
+    assert.ok(tile >= 0, `no tile for ${String(v)}`);
+    assert.equal(book.textAt(tile), labelText(v));
+  }
+});
+
+test("a value that is not an integer prints a question mark, loudly, never nothing", () => {
+  const book = new LabelBook();
+  book.beginFrame();
+  const tile = book.tileFor(1.5);
+  assert.equal(tile, book.faultTile);
+  assert.equal(book.textAt(tile), LABEL_FAULT);
+  assert.equal(book.faults, 1);
+  assert.equal(isPrintable(1.5), false);
+  // and it is refused before it can ever reach an orb
+  assert.equal(
+    orbValues({ id: "x", prompt: "", answer: "1.5", distractors: [], domain: "d", difficulty: 0 }, 4),
+    null,
+  );
+});
+
+test("a tile is never taken from a numeral that is on screen this frame", () => {
+  const book = new LabelBook(9); // eight claimable plus the reserved `?`
+  // Ten frames of the same eight numerals, then a ninth arrives: the evicted
+  // tile must be one nothing drew this frame, and the on-screen eight must keep
+  // printing what they printed.
+  const live = [2, -2, 3, -3, 7, 137, 3916, 41];
+  let tiles: number[] = [];
+  for (let frame = 0; frame < 10; frame++) {
+    book.beginFrame();
+    tiles = live.map((v) => book.tileFor(v));
+    for (let i = 0; i < live.length; i++) {
+      assert.equal(book.textAt(tiles[i] as number), labelText(live[i] as number));
+    }
+  }
+  book.beginFrame();
+  const kept = live.slice(0, 7).map((v) => book.tileFor(v));
+  const fresh = book.tileFor(555);
+  assert.ok(!kept.includes(fresh), "a numeral drawn this frame had its tile taken");
+  for (let i = 0; i < kept.length; i++) {
+    assert.equal(book.textAt(kept[i] as number), labelText(live[i] as number));
+  }
+  assert.equal(book.overflows, 0);
+});
+
+test("a frame that wants too many numerals gets a question mark, not a swap", () => {
+  // Deliberately undersized. Nine distinct values into four claimable tiles, all
+  // of them drawn in the same frame: the four that got tiles must still be
+  // printing what they printed, and the rest must be `?` — never a numeral that
+  // silently became a different numeral under a child mid-read, and never blank.
+  const errors: unknown[][] = [];
+  const real = console.error;
+  console.error = (...a: unknown[]) => errors.push(a);
+  let book: LabelBook;
+  try {
+    book = new LabelBook(5);
+    book.beginFrame();
+    const wanted = [11, 22, 33, 44, 55, 66, 77, 88, 99];
+    const got = wanted.map((v) => book.tileFor(v));
+    for (let i = 0; i < wanted.length; i++) {
+      const printed = book.textAt(got[i] as number);
+      assert.ok(printed !== null, `${String(wanted[i])} came out blank`);
+      assert.ok(
+        printed === labelText(wanted[i] as number) || printed === LABEL_FAULT,
+        `${String(wanted[i])} is printing ${String(printed)} — somebody else's numeral`,
+      );
+    }
+    assert.ok(got.includes(book.faultTile), "nothing overflowed, so this test proves nothing");
+  } finally {
+    console.error = real;
+  }
+  assert.ok(book.overflows > 0, "the atlas ran out of tiles and said nothing");
+  assert.match(String(errors[0]?.[0]), /ran out of tiles/);
+});
+
+test("a wide numeral still fits its own orb's lane", () => {
+  // Cells got wider so a four-digit answer keeps its glyph HEIGHT instead of
+  // being squeezed flat. That only helps if the wide quad still fits the slot an
+  // orb is given: four orbs share `(HALF_W - 12) * 2` of playfield, and the
+  // renderer boosts label size by 1.18 on a narrow phone.
+  const lane = ((HALF_W - 12) * 2) / 4;
+  const widest = BULLET.orbR * 1.35 * LABEL_ASPECT * 1.18;
+  assert.ok(
+    widest < lane,
+    `a numeral is ${widest.toFixed(1)} wide in a ${lane.toFixed(1)} lane — orbs would collide`,
+  );
+});
+
+test("the shipping grid is never asked for more numerals in a frame than it holds", () => {
+  // The playfield's entire vocabulary at once: chaff ±2..9, charge ±2..8, the
+  // float texts they leave behind, four orbs of any magnitude and a lock.
+  const distinct = new Set<number>();
+  for (let m = 2; m <= 9; m++) {
+    distinct.add(m);
+    distinct.add(-m);
+  }
+  for (const v of [3916, 998232, 41, 137, 12]) distinct.add(v);
+  // Twice the vocabulary, so the grid is not sized to the exact worst case.
+  assert.ok(
+    distinct.size * 2 < LABEL_CAPACITY,
+    `a frame can want ${String(distinct.size)} numerals and the grid holds ${String(LABEL_CAPACITY)}`,
+  );
+
+  const book = new LabelBook();
+  book.beginFrame();
+  for (const v of distinct) book.tileFor(v);
+  assert.equal(book.overflows, 0);
+});

--- a/dynawalla/games/polarity/src/core/labels.ts
+++ b/dynawalla/games/polarity/src/core/labels.ts
@@ -1,26 +1,195 @@
 /**
- * Numeral atlas addressing. Every printed number in the playfield is one quad
- * sampling one tile, so a screen full of labelled bullets costs a single draw
- * call and no text layout at all.
+ * Numeral addressing. Every printed number in the playfield is one quad
+ * sampling one tile of one texture, so a screen full of labelled bullets costs
+ * a single draw call and no text layout at all.
  *
  * Legibility rule learned the hard way elsewhere in this program: a numeral a
  * child has 0.45s to read gets a heavy geometric face, a solid backing plate
  * and a real U+2212 minus — never an engraved serif.
+ *
+ * **Why this is a book and not a baked range.** It used to bake −40…+40 into a
+ * fixed 9×9 grid and return −1 for anything else, and the renderer skipped a −1
+ * silently. The curriculum this pack actually asks for answers in the hundreds
+ * and thousands: measured over the whole shipping ladder, 89.9% of the orb
+ * values a Seal Bearer drops fell outside that range, and 87.3% of items put
+ * FOUR blank glowing discs in front of the child, with no error and no warning.
+ * A child cannot choose between four unlabelled circles.
+ *
+ * So tiles are claimed on demand instead. Any finite integer prints, whatever
+ * its magnitude, and a value that is somehow not one prints `?` — loud in the
+ * console and visible on the field, because the one thing a numeral must never
+ * be is absent.
  */
 
-export const LABEL_MIN = -40;
-export const LABEL_MAX = 40;
-export const LABEL_COLS = 9;
-export const LABEL_ROWS = 9;
-export const LABEL_COUNT = LABEL_COLS * LABEL_ROWS; // 81 == the whole range
+import { MINUS } from "../math/signed.ts";
 
-/** Atlas tile for an integer, or -1 if it is outside the printable range. */
-export function labelTile(v: number): number {
-  if (!Number.isInteger(v) || v < LABEL_MIN || v > LABEL_MAX) return -1;
-  return v - LABEL_MIN;
+/**
+ * The grid. 48 cells: 47 claimable and one reserved.
+ *
+ * The playfield's entire numeric vocabulary in one frame is chaff at ±2…9,
+ * charge at ±2…9, the float texts they leave behind (a subset of those), four
+ * orbs and one lock — about two dozen distinct values, measured in
+ * `labels.test.ts`. Twice that is headroom; more than that is texture nobody
+ * looks at, and the cell has to stay big enough to read.
+ */
+export const LABEL_COLS = 8;
+export const LABEL_ROWS = 6;
+export const LABEL_CAPACITY = LABEL_COLS * LABEL_ROWS;
+
+/**
+ * The last cell, reserved and never claimable: it always prints `?`.
+ *
+ * It is what a numeral becomes when something has gone wrong — a value that is
+ * not an integer, or a frame that somehow wanted more numerals than the grid
+ * holds. Reserving it is what lets `claim` refuse to evict a tile that is on
+ * screen: the choice under pressure is "show a question mark and shout", never
+ * "quietly repaint a numeral a child is mid-way through reading", and never the
+ * old answer of showing nothing at all.
+ */
+export const LABEL_FAULT_TILE = LABEL_CAPACITY - 1;
+
+/**
+ * Cells are twice as wide as they are tall, so a four-digit answer gets ROOM
+ * rather than being squeezed to a smear at the same height as a `7`. The quad
+ * the shader draws is `size * LABEL_ASPECT` wide by `size` tall, and a short
+ * numeral simply leaves transparent margin either side.
+ */
+export const LABEL_ASPECT = 2;
+
+/**
+ * The longest numeral a tile is expected to hold. Evidence, not a guess: the
+ * widest value the shipping ladder emits across 44,000 measured orbs is
+ * `998232` — six characters — and the longest a mal-rule or near-miss
+ * distractor pushes it to is seven. Eight leaves a character of headroom and
+ * still fits the cell without squeezing.
+ */
+export const LABEL_MAX_CHARS = 8;
+
+/** What a tile with nothing legible to print shows. Never blank. */
+export const LABEL_FAULT = "?";
+
+/** The printed form of a value: `7`, `0`, `−5`, `3916`. */
+export function labelText(v: number): string {
+  if (!Number.isInteger(v)) return LABEL_FAULT;
+  return v < 0 ? MINUS + String(-v) : String(v);
 }
 
-/** Inverse of `labelTile`, for tests and debugging. */
-export function tileValue(tile: number): number {
-  return tile + LABEL_MIN;
+/**
+ * Can this value be an orb?
+ *
+ * The one question `askQuestion` asks before it drops anything: a value the
+ * game cannot print must never be offered as an answer. Magnitude is no longer
+ * a reason to say no — only a value that is not a finite integer, or one so
+ * long the cell could not hold it legibly, is refused, and both are refused out
+ * loud where they happen.
+ */
+export function isPrintable(v: number): boolean {
+  if (!Number.isInteger(v)) return false;
+  return labelText(v).length <= LABEL_MAX_CHARS;
+}
+
+/**
+ * Which tile prints which numeral, right now.
+ *
+ * DOM-free and allocation-free in the steady state, so the whole policy is
+ * testable in node without a canvas. `render/atlas.ts` owns the pixels and asks
+ * this what to paint.
+ *
+ * Tiles are resolved at DRAW time, once per label per frame, which is what
+ * makes eviction safe: a tile is only ever reclaimed if it was not asked for
+ * this frame, so nothing on screen can have its numeral pulled out from under
+ * it. `overflows` counts the impossible case — a single frame asking for more
+ * distinct numerals than the grid holds — and it is loud, not silent.
+ */
+export class LabelBook {
+  readonly capacity: number;
+  /** Values asked for that are not integers. A bug upstream; the tile says `?`. */
+  faults = 0;
+  /** Frames that wanted more distinct numerals than the grid holds. */
+  overflows = 0;
+
+  private readonly tileOf = new Map<number, number>();
+  private readonly text: (string | null)[];
+  private readonly key: number[];
+  private readonly touched: number[];
+  private readonly dirty = new Set<number>();
+  private frame = 0;
+
+  /** The reserved `?` cell. Always the last one, whatever the capacity is. */
+  readonly faultTile: number;
+
+  constructor(capacity: number = LABEL_CAPACITY) {
+    this.capacity = capacity;
+    this.faultTile = capacity - 1;
+    this.text = new Array<string | null>(capacity).fill(null);
+    this.key = new Array<number>(capacity).fill(0);
+    this.touched = new Array<number>(capacity).fill(-1);
+    this.text[this.faultTile] = LABEL_FAULT;
+    this.dirty.add(this.faultTile);
+  }
+
+  /** Call once per frame, before any `tileFor`. */
+  beginFrame(): void {
+    this.frame++;
+  }
+
+  /**
+   * The tile printing `v`, claiming one if this is the first time it has been
+   * asked for. Never negative: every value gets a tile, and a value that is not
+   * an integer gets one that prints `?`.
+   */
+  tileFor(v: number): number {
+    if (!Number.isInteger(v)) {
+      this.faults++;
+      return this.faultTile;
+    }
+    const found = this.tileOf.get(v);
+    if (found !== undefined) {
+      this.touched[found] = this.frame;
+      return found;
+    }
+    const tile = this.claim();
+    if (tile < 0) return this.faultTile;
+    this.tileOf.set(v, tile);
+    this.key[tile] = v;
+    this.text[tile] = labelText(v);
+    this.touched[tile] = this.frame;
+    this.dirty.add(tile);
+    return tile;
+  }
+
+  /** What a tile currently prints, or null if it has never been claimed. */
+  textAt(tile: number): string | null {
+    return this.text[tile] ?? null;
+  }
+
+  /** Tiles whose contents changed since the last call. The painter's worklist. */
+  takeDirty(): number[] {
+    if (this.dirty.size === 0) return [];
+    const out = [...this.dirty];
+    this.dirty.clear();
+    return out;
+  }
+
+  /** A free tile, or -1 when every one of them is already on screen. */
+  private claim(): number {
+    let lru = 0;
+    for (let i = 0; i < this.faultTile; i++) {
+      if (this.text[i] === null) return i;
+      if ((this.touched[i] as number) < (this.touched[lru] as number)) lru = i;
+    }
+    if (this.touched[lru] === this.frame) {
+      // Unreachable with the shipping grid — the whole playfield vocabulary is
+      // half the capacity — and loud rather than silent, because the only two
+      // ways out are a `?` and a numeral changing under a child mid-read.
+      this.overflows++;
+      console.error(
+        `[polarity] the label atlas ran out of tiles in one frame (${String(this.capacity)})`,
+      );
+      return -1;
+    }
+    this.tileOf.delete(this.key[lru] as number);
+    this.text[lru] = null;
+    return lru;
+  }
 }

--- a/dynawalla/games/polarity/src/core/tier.ts
+++ b/dynawalla/games/polarity/src/core/tier.ts
@@ -93,14 +93,18 @@ export function detectTier(): Tier {
  * detected ceiling) so a wrong guess costs ~1.5s of judder, not a session.
  */
 export class TierMonitor {
+  tier: Tier;
   private samples: number[] = [];
   private cursor = 0;
   private cooldown = 0;
-  constructor(
-    public tier: Tier,
-    private readonly onChange: (t: Tier) => void,
-    private readonly ceiling: TierName = tier.name,
-  ) {
+  private readonly onChange: (t: Tier) => void;
+  private readonly ceiling: TierName;
+  // Written out rather than as constructor parameter properties: this module is
+  // imported by the game-layer tests, and node's type stripping refuses them.
+  constructor(tier: Tier, onChange: (t: Tier) => void, ceiling: TierName = tier.name) {
+    this.tier = tier;
+    this.onChange = onChange;
+    this.ceiling = ceiling;
     for (let i = 0; i < 90; i++) this.samples.push(16.7);
   }
 

--- a/dynawalla/games/polarity/src/game/constants.ts
+++ b/dynawalla/games/polarity/src/game/constants.ts
@@ -48,14 +48,21 @@ export const CORE = {
 } as const;
 
 // --- bullets ----------------------------------------------------------------
-export const enum BK {
-  Chaff = 0,
-  Charge = 1,
-  Orb = 2,
-  Shot = 3,
-  Dart = 4,
-  Lance = 5,
-}
+/**
+ * Bullet kinds. A frozen object rather than a `const enum` so the game layer is
+ * importable by `node --experimental-strip-types`, which refuses an enum — and
+ * an untestable game layer is precisely where this pack's blank orbs and
+ * corrupted reports lived.
+ */
+export const BK = {
+  Chaff: 0,
+  Charge: 1,
+  Orb: 2,
+  Shot: 3,
+  Dart: 4,
+  Lance: 5,
+} as const;
+export type BK = (typeof BK)[keyof typeof BK];
 
 export const BULLET = {
   chaffR: 1.9,
@@ -67,15 +74,17 @@ export const BULLET = {
 } as const;
 
 // --- enemies ----------------------------------------------------------------
-export const enum EK {
-  Mote = 0,
-  Weaver = 1,
-  Spinner = 2,
-  Battery = 3,
-  Lancer = 4,
-  Bearer = 5,
-  Warden = 6,
-}
+/** Enemy kinds. Same shape and the same reason as `BK`. */
+export const EK = {
+  Mote: 0,
+  Weaver: 1,
+  Spinner: 2,
+  Battery: 3,
+  Lancer: 4,
+  Bearer: 5,
+  Warden: 6,
+} as const;
+export type EK = (typeof EK)[keyof typeof EK];
 
 export type EnemySpec = {
   hp: number;
@@ -97,8 +106,8 @@ export const ENEMY: Record<number, EnemySpec> = {
 
 // --- pacing -----------------------------------------------------------------
 export const PACE = {
-  /** seconds per stratum; the HUD counts these */
-  stratum: 30,
+  // There is no seconds-per-stratum. A stratum is a seal the child broke — see
+  // `stratumOf` in sim.ts — because the clock is not something a child earns.
   firstBearer: 14,
   bearerEvery: 34,
   bearerEveryMin: 26,

--- a/dynawalla/games/polarity/src/game/enemies.ts
+++ b/dynawalla/games/polarity/src/game/enemies.ts
@@ -1,5 +1,4 @@
 import { TAU, approach, clamp } from "../core/util.ts";
-import { labelTile } from "../core/labels.ts";
 import { BK, BULLET, COL, EK, ENEMY, HALF_W, polColor } from "./constants.ts";
 import type { Bullet, Enemy } from "./types.ts";
 import { addBullet, addEnemy, burst, inField, ring, type World } from "./world.ts";
@@ -31,7 +30,8 @@ export function fireChaff(
   b.dmg = 1;
   b.rot = ang;
   b.spin = pol > 0 ? 2.2 : -1.4;
-  b.label = mag > 1 ? labelTile(b.v) : -1;
+  // a ±1 speck is not arithmetic worth reading; anything bigger prints
+  b.labelled = mag > 1 ? 1 : 0;
   return b;
 }
 
@@ -57,7 +57,7 @@ export function fireCharge(
   b.dmg = 1;
   b.rot = 0;
   b.spin = value > 0 ? 1.1 : -0.8;
-  b.label = labelTile(value);
+  b.labelled = 1;
   b.grow = 1;
   return b;
 }

--- a/dynawalla/games/polarity/src/game/seal.test.ts
+++ b/dynawalla/games/polarity/src/game/seal.test.ts
@@ -1,0 +1,411 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host, Question } from "../contract.ts";
+import { tierByName } from "../core/tier.ts";
+import { BK, EK, PACE } from "./constants.ts";
+import { bossDefeated, launchBoss, onOrbTouched, stepBoss, tryLock } from "./seal.ts";
+import { startRun, step, stratumOf, rosterOf } from "./sim.ts";
+import type { Bullet, Enemy } from "./types.ts";
+import { makeWorld, type World } from "./world.ts";
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string };
+
+/**
+ * A host with the shape and the MAGNITUDES the shipping curriculum has.
+ *
+ * `dw.add.column.add-no-regroup` L0 — the first rung of the ladder, the one a
+ * child actually starts on — answers in the twenties to the nineties, and the
+ * rungs above it answer in the thousands. Nothing here fits the ±20 core band,
+ * which is the whole point: it is what the Warden's clamp was silently doing to
+ * every answer it reported.
+ */
+function fakeHost(answers: readonly { answer: string; distractors: string[] }[]): {
+  host: Host;
+  reports: Report[];
+  served: Question[];
+} {
+  const reports: Report[] = [];
+  const served: Question[] = [];
+  let n = 0;
+  const host: Host = {
+    next: () => {
+      const spec = answers[n % answers.length] as { answer: string; distractors: string[] };
+      n++;
+      const q: Question = {
+        id: `q${String(n)}`,
+        prompt: `item ${String(n)}`,
+        answer: spec.answer,
+        distractors: spec.distractors,
+        domain: "add-sub",
+        difficulty: 0.2,
+      };
+      served.push(q);
+      return q;
+    },
+    report: (r) => reports.push(r),
+    haptic: () => {},
+    prefersReducedMotion: () => true,
+  };
+  return { host, reports, served };
+}
+
+const CURRICULUM = [
+  { answer: "3916", distractors: ["3906", "4916", "3917"] },
+  { answer: "137", distractors: ["127", "237", "138"] },
+  { answer: "64", distractors: ["54", "74", "65"] },
+];
+
+function world(host: Host): World {
+  const w = makeWorld(host, tierByName("low"), 0x50147);
+  startRun(w);
+  return w;
+}
+
+/** Run a boss's choreography until it has asked, or give up. */
+function askUntilSeal(w: World, e: Enemy): void {
+  for (let i = 0; i < 2000 && w.seal.state !== "asking"; i++) {
+    w.t += 1 / 60;
+    stepBoss(w, e, 1 / 60, 1);
+  }
+}
+
+function orbs(w: World, serial: number): Bullet[] {
+  const out: Bullet[] = [];
+  for (let i = 0; i < w.bulletN; i++) {
+    const b = w.bullets[i] as Bullet;
+    if (b.kind === BK.Orb && b.seal === serial) out.push(b);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// what is reported is what the child did
+// ---------------------------------------------------------------------------
+
+test("a Bearer reports the value the child actually flew into", () => {
+  const { host, reports } = fakeHost(CURRICULUM);
+  const w = world(host);
+  launchBoss(w);
+  const e = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, e);
+  assert.equal(w.seal.state, "asking");
+
+  const wrong = orbs(w, w.seal.serial).find((b) => !b.correct);
+  assert.ok(wrong, "the Bearer dropped no wrong orb to fly into");
+  const touched = wrong.v;
+  onOrbTouched(w, wrong);
+
+  assert.equal(reports.length, 1);
+  const r = reports[0] as Report;
+  assert.equal(r.answered, String(touched));
+  assert.equal(r.correct, false);
+  assert.ok(
+    CURRICULUM.some((c) => c.distractors.includes(r.answered)),
+    `${r.answered} is not one of the options that were on the field`,
+  );
+});
+
+test("a correct Bearer answer is reported as the canonical answer, unaltered", () => {
+  const { host, reports, served } = fakeHost(CURRICULUM);
+  const w = world(host);
+  launchBoss(w);
+  const e = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, e);
+
+  const right = orbs(w, w.seal.serial).find((b) => b.correct);
+  assert.ok(right);
+  onOrbTouched(w, right);
+
+  const r = reports[0] as Report;
+  const q = served[0] as Question;
+  assert.equal(r.correct, true);
+  assert.equal(
+    r.answered,
+    q.answer,
+    "a child who flew into the right orb was reported as answering something else",
+  );
+});
+
+/** A Warden, already on the field, driven to the moment its lock opens. */
+function warden(w: World): Enemy {
+  for (let i = 0; i < PACE.wardenEvery - 1; i++) w.bearerCount++;
+  launchBoss(w);
+  const e = w.enemies[w.enemyN - 1] as Enemy;
+  assert.equal(e.kind, EK.Warden, "wanted a Warden");
+  for (let i = 0; i < 2000 && e.lockState !== 1; i++) {
+    w.t += 1 / 60;
+    stepBoss(w, e, 1 / 60, 1);
+  }
+  assert.equal(e.lockState, 1, "the lock never opened");
+  return e;
+}
+
+test("the core band never rewrites what a Warden reports", () => {
+  const { host, reports, served } = fakeHost(CURRICULUM);
+  const w = world(host);
+  const e = warden(w);
+
+  // The lock demands a total inside the band the core can actually reach, and
+  // it is the game's own number: no item was drawn for it at all.
+  assert.ok(
+    Math.abs(e.lockWant) <= w.cap && Math.abs(e.lockWant) >= 3,
+    `the lock wants ${String(e.lockWant)}, and the core band is ±${String(w.cap)}`,
+  );
+  assert.equal(served.length, 0, "the Warden pulled an item it has no way to ask");
+  assert.equal(w.seal.state, "idle");
+
+  // Play the lock perfectly. It scores, it hurts the boss, and it reports
+  // NOTHING — because the curriculum never asked for a core total.
+  const hpBefore = e.hp;
+  w.core = e.lockWant;
+  assert.equal(tryLock(w, e), "exact");
+  assert.ok(e.hp < hpBefore, "an exact lock did no damage");
+  assert.equal(
+    reports.length,
+    0,
+    `breaking the lock reported ${JSON.stringify(reports)} — the band's number, not the child's answer`,
+  );
+});
+
+test("a Warden's lock is reachable and its target never leaves the band", () => {
+  const { host } = fakeHost(CURRICULUM);
+  for (let run = 0; run < 40; run++) {
+    const w = makeWorld(host, tierByName("low"), 0x1000 + run);
+    startRun(w);
+    const e = warden(w);
+    // `releaseYield` refuses to vent below a magnitude of 3, so a target of 1 or
+    // 2 would be a lock with no key.
+    assert.ok(Math.abs(e.lockWant) >= 3, `unventable lock target ${String(e.lockWant)}`);
+    assert.ok(Math.abs(e.lockWant) <= w.cap, `lock target ${String(e.lockWant)} outside the band`);
+  }
+});
+
+test("nothing this game reports is a value that was never on the field", () => {
+  const { host, reports, served } = fakeHost(CURRICULUM);
+  const w = world(host);
+  let answered = 0;
+  for (let boss = 0; boss < 9; boss++) {
+    launchBoss(w);
+    const e = w.enemies[w.enemyN - 1] as Enemy;
+    if (e.kind === EK.Warden) {
+      // No question, so nothing to answer. Break its lock and move on. (Stepped
+      // only to the moment the lock opens: a Warden left running fills the
+      // bullet pool, and that is the harness's problem, not the game's.)
+      for (let i = 0; i < 2000 && e.lockState !== 1; i++) {
+        w.t += 1 / 60;
+        stepBoss(w, e, 1 / 60, 1);
+      }
+      w.core = e.lockWant;
+      tryLock(w, e);
+      w.bossActive = false;
+      continue;
+    }
+    askUntilSeal(w, e);
+    assert.equal(w.seal.state, "asking");
+    const pool = orbs(w, w.seal.serial);
+    assert.ok(pool.length >= 2, "a seal was asked with nothing to choose between");
+    onOrbTouched(w, pool[boss % pool.length] as Bullet);
+    answered++;
+    bossDefeated(w, e);
+  }
+  assert.equal(reports.length, answered);
+  assert.ok(answered >= 5);
+  for (const r of reports) {
+    const q = served.find((s) => s.id === r.questionId);
+    assert.ok(q, `reported an id nothing served: ${r.questionId}`);
+    assert.ok(
+      [q.answer, ...q.distractors].includes(r.answered),
+      `reported ${JSON.stringify(r.answered)}, which was never an option for ${q.prompt}`,
+    );
+  }
+});
+
+test("an orb left over from a finished seal is never an answer to the next one", () => {
+  const { host, reports, served } = fakeHost(CURRICULUM);
+  const w = world(host);
+
+  // Seal one: answer it WRONG. That deliberately leaves the correct orb hanging
+  // on the field, and it carries `life = 40` — longer than the gap to the next
+  // Bearer.
+  launchBoss(w);
+  const first = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, first);
+  const q1 = served[0] as Question;
+  const stale = orbs(w, w.seal.serial).find((b) => b.correct);
+  assert.ok(stale);
+  const staleValue = stale.v;
+  const wrong = orbs(w, w.seal.serial).find((b) => !b.correct);
+  assert.ok(wrong);
+  onOrbTouched(w, wrong);
+  assert.equal(reports.length, 1);
+  assert.ok(stale.live, "the leftover orb is the whole point of this test");
+
+  // Seal two, from a different Bearer with a different answer.
+  w.bossActive = false;
+  launchBoss(w);
+  const second = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, second);
+  const q2 = served[1] as Question;
+  assert.notEqual(q2.answer, q1.answer, "the two seals must differ for this to mean anything");
+
+  if (stale.live) {
+    onOrbTouched(w, stale);
+    assert.equal(
+      reports.length,
+      1,
+      `a leftover orb worth ${String(staleValue)} was reported as an answer to ${q2.prompt}: ` +
+        JSON.stringify(reports.at(1)),
+    );
+  }
+  assert.equal(w.seal.state, "asking", "the leftover orb resolved a seal it does not belong to");
+});
+
+test("a defeated Bearer takes its orbs with it", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  launchBoss(w);
+  const e = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, e);
+  const wrong = orbs(w, w.seal.serial).find((b) => !b.correct);
+  assert.ok(wrong);
+  onOrbTouched(w, wrong);
+  assert.ok(orbs(w, w.seal.serial).some((b) => b.live), "nothing was left to clean up");
+  bossDefeated(w, e);
+  assert.equal(
+    orbs(w, w.seal.serial).filter((b) => b.live).length,
+    0,
+    "an orb outlived the boss that dropped it",
+  );
+});
+
+test("a seal with only one option is declined — that is not a question", () => {
+  const errors: unknown[][] = [];
+  const real = console.error;
+  console.error = (...a: unknown[]) => errors.push(a);
+  try {
+    const { host, reports } = fakeHost([{ answer: "64", distractors: [] }]);
+    const w = world(host);
+    launchBoss(w);
+    const e = w.enemies[w.enemyN - 1] as Enemy;
+    askUntilSeal(w, e);
+    assert.notEqual(w.seal.state, "asking", "a one-orb seal was asked");
+    assert.equal(reports.length, 0, "a child was credited for touching the only thing on screen");
+  } finally {
+    console.error = real;
+  }
+  assert.ok(errors.length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// an item the game cannot draw is declined out loud, never drawn blank
+// ---------------------------------------------------------------------------
+
+test("an item with an answer this game cannot print is declined, not shown unlabelled", () => {
+  const errors: unknown[][] = [];
+  const real = console.error;
+  console.error = (...a: unknown[]) => errors.push(a);
+  try {
+    const { host, reports } = fakeHost([{ answer: "1/2", distractors: ["1/3"] }]);
+    const w = world(host);
+    launchBoss(w);
+    const e = w.enemies[w.enemyN - 1] as Enemy;
+    askUntilSeal(w, e);
+    assert.notEqual(w.seal.state, "asking", "an undrawable item was asked anyway");
+    assert.equal(orbs(w, w.seal.serial).length, 0, "an undrawable item put orbs on the field");
+    assert.equal(reports.length, 0);
+  } finally {
+    console.error = real;
+  }
+  assert.ok(errors.length > 0, "an item was silently dropped — the whole failure mode, again");
+  assert.match(String(errors[0]?.[0]), /declined an item/);
+});
+
+test("a boss that could not ask does not sweep the playfield clean", () => {
+  const real = console.error;
+  console.error = () => {};
+  try {
+    const { host } = fakeHost([{ answer: "1/2", distractors: [] }]);
+    const w = world(host);
+    for (let i = 0; i < PACE.wardenEvery - 1; i++) w.bearerCount++;
+    launchBoss(w);
+    const e = w.enemies[w.enemyN - 1] as Enemy;
+    // Right through the lock phase and its timeout, with the ask refused.
+    for (let i = 0; i < 3000; i++) {
+      w.t += 1 / 60;
+      stepBoss(w, e, 1 / 60, 1);
+    }
+    // Its own chaff is still in flight. `killSealOrbs(serial 0)` would have
+    // taken every bullet on the field with it.
+    let live = 0;
+    for (let i = 0; i < w.bulletN; i++) if ((w.bullets[i] as Bullet).live) live++;
+    assert.ok(live > 0, "a declined ask wiped the playfield");
+  } finally {
+    console.error = real;
+  }
+});
+
+test("every orb a Bearer drops carries a numeral", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  for (let boss = 0; boss < 12; boss++) {
+    launchBoss(w);
+    const e = w.enemies[w.enemyN - 1] as Enemy;
+    askUntilSeal(w, e);
+    assert.equal(w.seal.state, "asking", "the Bearer never asked anything");
+    const dropped = orbs(w, w.seal.serial);
+    assert.equal(dropped.length, 4, `the Bearer dropped ${String(dropped.length)} orbs, not four`);
+    for (const b of dropped) {
+      assert.equal(b.labelled, 1, `an orb worth ${String(b.v)} was going to be drawn blank`);
+    }
+    w.bossActive = false;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// pacing
+// ---------------------------------------------------------------------------
+
+test("the run does not get harder while a child is still reading", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  // Ten minutes of wall clock and not one seal broken: a child taking their time
+  // over an answer is not a thing this game charges for. (Shields are topped up
+  // because nobody is flying the ship — the run has to survive to be measured.)
+  for (let i = 0; i < 60 * 800; i++) {
+    w.shields = 3;
+    w.invuln = 1;
+    if (w.phase !== "play") w.phase = "play";
+    step(w, 1 / 60);
+  }
+  assert.ok(w.t > 300, `only ${String(w.t)}s elapsed`);
+  assert.equal(w.stats.right, 0, "the run answered something on its own");
+  assert.equal(
+    w.stratum,
+    0,
+    `the run climbed to stratum ${String(w.stratum)} on the clock alone, ` +
+      "with nothing answered — comprehension time is the child's, measured, never limited",
+  );
+});
+
+test("the world still widens for a child who is flying and not answering", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  assert.equal(rosterOf(w), 0);
+  // Charge absorbed is the ship's own arithmetic, performed by flying. A child
+  // doing that well meets more of the world without having answered anything.
+  w.stats.absorbs = 200;
+  assert.ok(rosterOf(w) > 0, "the sky stayed empty for a child who was playing well");
+  assert.equal(stratumOf(w), 0, "absorbing charge is not answering a question");
+});
+
+test("the run gets harder on seals broken", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  assert.equal(stratumOf(w), 0);
+  w.stats.right = 3;
+  assert.equal(stratumOf(w), 3);
+  step(w, 1 / 60);
+  assert.equal(w.stratum, 3);
+  assert.ok(w.events.includes("stratum"), "nothing marked the depth the child earned");
+});

--- a/dynawalla/games/polarity/src/game/seal.ts
+++ b/dynawalla/games/polarity/src/game/seal.ts
@@ -1,6 +1,7 @@
-import { labelTile } from "../core/labels.ts";
+import { isPrintable } from "../core/labels.ts";
 import { TAU, approach, clamp } from "../core/util.ts";
-import { parseInt_ } from "../math/signed.ts";
+import { tryParseInt } from "../math/signed.ts";
+import type { Question } from "../contract.ts";
 import {
   BK,
   BULLET,
@@ -36,7 +37,9 @@ import {
  *
  * The whole integration is motion, not UI. A Seal Bearer holds the prompt on
  * its hull and drops four ORBS carrying the answer and three mal-rule
- * distractors. An orb's SIGN is its polarity, so:
+ * distractors. (The Warden does not: its lock is the ship's own running sum, a
+ * number this game invented, and it asks the child nothing — see `stepWarden`.)
+ * An orb's SIGN is its polarity, so:
  *
  *   - you can fly straight through any orb whose sign is not yours — wrong
  *     answers of the opposite sign are ghosts;
@@ -83,8 +86,61 @@ export function launchBoss(w: World): void {
 // asking
 // ---------------------------------------------------------------------------
 
-function askQuestion(w: World, e: Enemy, orbCount: number): void {
-  const q = w.host.next({ difficulty: clamp(0.14 + w.stratum * 0.06, 0, 1) });
+/**
+ * How many items to refuse before giving up on this Bearer.
+ *
+ * Refusing is meant to be a rarity — the atlas prints any integer, so the only
+ * thing left to refuse is an answer that is not one. A bound exists so a host
+ * serving a whole domain this game cannot draw costs a bearer, not a hang.
+ */
+const MAX_ASK_TRIES = 6;
+
+/**
+ * The values an item would put on the field: the answer first, then its wrongs.
+ *
+ * Null means "this game cannot ask this item" — the seal declines it and the
+ * host serves another. Two reasons, both loud where they happen:
+ *
+ *   * a value that will not print, and
+ *   * fewer than two values, which is not a question. One orb on the field is
+ *     the right answer by elimination; a child touching it is not retrieval, and
+ *     reporting it as a correct answer inflates a record that only ever rises.
+ */
+export function orbValues(q: Question, orbCount: number): number[] | null {
+  const answer = tryParseInt(q.answer);
+  // A value the game cannot print must never be offered. There is no third
+  // option where it is offered and comes out blank.
+  if (answer === null || !isPrintable(answer)) return null;
+  const out = [answer];
+  for (const d of q.distractors) {
+    if (out.length >= orbCount) break;
+    const v = tryParseInt(d);
+    // A wrong answer that will not print is dropped, not drawn: three orbs a
+    // child can read beat four where one is a blank disc.
+    if (v === null || !isPrintable(v) || out.includes(v)) continue;
+    out.push(v);
+  }
+  return out.length >= Math.min(2, orbCount) ? out : null;
+}
+
+/** Draw an item this game can actually put on the field, or nothing. */
+function drawAskable(w: World, orbCount: number): { q: Question; values: number[] } | null {
+  for (let i = 0; i < MAX_ASK_TRIES; i++) {
+    const q = w.host.next({ difficulty: clamp(0.14 + w.stratum * 0.06, 0, 1) });
+    const values = orbValues(q, orbCount);
+    if (values) return { q, values };
+    console.error(
+      `[polarity] declined an item POLARITY cannot print: ${q.prompt} = ${JSON.stringify(q.answer)}`,
+    );
+  }
+  console.error("[polarity] no printable item after " + String(MAX_ASK_TRIES) + " tries");
+  return null;
+}
+
+function askQuestion(w: World, e: Enemy, orbCount: number): boolean {
+  const drawn = drawAskable(w, orbCount);
+  if (!drawn) return false;
+  const { q, values } = drawn;
   w.sealSerial++;
   w.seal.serial = w.sealSerial;
   w.seal.state = "asking";
@@ -96,8 +152,6 @@ function askQuestion(w: World, e: Enemy, orbCount: number): void {
   w.promptV++;
   w.stats.asked++;
 
-  const values: number[] = [parseInt_(q.answer)];
-  for (const d of q.distractors) values.push(parseInt_(d));
   const order = w.rng.shuffle(values.map((v, i) => ({ v, correct: i === 0 })));
   const n = Math.min(orbCount, order.length);
 
@@ -117,7 +171,7 @@ function askQuestion(w: World, e: Enemy, orbCount: number): void {
     b.kind = BK.Orb;
     b.owner = 0;
     b.life = 40;
-    b.label = labelTile(o.v);
+    b.labelled = 1;
     b.seal = w.sealSerial;
     b.correct = o.correct ? 1 : 0;
     b.wob = w.rng.f() * TAU;
@@ -128,6 +182,7 @@ function askQuestion(w: World, e: Enemy, orbCount: number): void {
   burst(w, e.x, e.y, 26, 42, COL.gold, { life: 0.6, size: 1.8 });
   punch(w, 0.35);
   cue(w, "seal");
+  return true;
 }
 
 /** Orb flight: glide to the presentation band, hover and weave, then leave. */
@@ -152,6 +207,10 @@ export function stepOrb(w: World, b: Bullet, dt: number, hurry: number): void {
 // ---------------------------------------------------------------------------
 
 function killSealOrbs(w: World, serial: number, correctToo: boolean): void {
+  // Serial 0 is "belongs to no seal", which every chaff round on the field also
+  // carries. A boss whose ask was declined still runs its timeout, and without
+  // this it would sweep the whole playfield clean.
+  if (serial <= 0) return;
   for (let i = 0; i < w.bulletN; i++) {
     const b = w.bullets[i] as Bullet;
     if (b.seal !== serial) continue;
@@ -162,6 +221,21 @@ function killSealOrbs(w: World, serial: number, correctToo: boolean): void {
 }
 
 export function onOrbTouched(w: World, b: Bullet): void {
+  // An orb from a seal that is already over is scenery, not an answer.
+  //
+  // They exist: a wrong answer deliberately leaves the correct orb hanging
+  // there ("the correct orb is still sitting there waiting"), it carries
+  // `life = 40`, and the next Bearer arrives 26 seconds later. Without this
+  // check, flying into that leftover reports its value — and its `correct`
+  // flag — against whichever question is CURRENT, crediting a child with an
+  // answer to a question nobody asked them. It reads as generosity and it is a
+  // false record.
+  if (b.seal !== w.seal.serial) {
+    burst(w, b.x, b.y, 10, 34, polColor(b.v), { life: 0.4, size: 1.4, kind: 1 });
+    b.live = false;
+    return;
+  }
+
   const q = w.seal.q;
   const first = w.seal.state === "asking";
   const correct = b.correct === 1;
@@ -276,9 +350,10 @@ export function stepBoss(w: World, e: Enemy, dt: number, spd: number): void {
 
 function stepBearer(w: World, e: Enemy, _dt: number, spd: number): void {
   if (e.phase === 0 && e.age > 1.15) {
-    e.phase = 1;
-    askQuestion(w, e, 4);
-    e.lockState = 0;
+    // A Bearer with nothing printable to carry is just a boss. It cracks open
+    // rather than hovering over a seal that was never set.
+    e.phase = askQuestion(w, e, 4) ? 1 : 2;
+    e.lockState = e.phase === 1 ? 0 : 2;
     e.fireT = 1.2;
   }
   if (e.phase === 1) {
@@ -308,11 +383,53 @@ function stepBearer(w: World, e: Enemy, _dt: number, spd: number): void {
   }
 }
 
+/** How long a lock stays open, and how long the enrage after it lasts. */
+const LOCK_OPEN_FOR = 15;
+const LOCK_ENRAGE_FOR = 7;
+
 /**
- * The Warden is the deep end: it locks itself to an exact core value taken from
- * a host question, and only a RELEASE at that exact total breaks the lock.
- * Getting within two still does real damage, so a younger player still makes
- * progress; exactness is worth three times as much.
+ * The core value a lock demands.
+ *
+ * The game's OWN number, drawn from inside the band the core can actually reach,
+ * and reported to nobody.
+ *
+ * It used to be a curriculum answer squeezed through `clamp(answer, -cap, cap)`.
+ * With a cap that starts at 20 and an answer stream in the hundreds and
+ * thousands, that clamp fired on essentially every Warden: the boss demanded a
+ * total that had nothing to do with the question printed on its hull, and then
+ * reported that total as the child's answer. A child who played it perfectly was
+ * recorded as answering `20` to `4003 − 87`, and an adaptive controller reading
+ * that record would push them DOWN the ladder for playing well.
+ *
+ * A clamp that changes the question is not a clamp, it is a corruption. The band
+ * now constrains what is ASKED — the lock asks for a number the core can hold —
+ * and it asks it on the game's own behalf, so there is nothing to corrupt.
+ */
+function drawLockTarget(w: World): number {
+  const reach = Math.max(4, Math.min(w.cap, 18));
+  return w.rng.sign() * w.rng.i(3, reach);
+}
+
+/**
+ * The Warden is the deep end: it locks itself to an exact core total, and only a
+ * RELEASE at that exact total breaks the lock. Getting within two still does
+ * real damage, so a younger player still makes progress; exactness is worth
+ * three times as much.
+ *
+ * **It asks the child nothing, and it reports nothing.** The lock is the ship's
+ * own running sum — the arithmetic a child performs by flying — and `pack.ts`
+ * has always said that is "not a question anybody asked, so nothing about it is
+ * reported". The curriculum's questions belong to the Bearer, which can put four
+ * readable values on the field and be answered by touching one.
+ *
+ * Giving the Warden orbs as well was tried and reverted in the same change: the
+ * lock and a live seal share one boss and fight each other — answering cracks
+ * the hull open, which closes the lock, so a right answer would delete the
+ * mechanic and a wrong one would not. Two things at once in a bullet phase is a
+ * design decision that wants a tablet and a child, not a patch.
+ *
+ * Its timing runs off `e.age` rather than `w.seal.askedAt`, because it no longer
+ * owns a seal and a stale `askedAt` would open and close the lock in one frame.
  */
 function stepWarden(w: World, e: Enemy, _dt: number, spd: number): void {
   const hpf = e.hp / e.maxHp;
@@ -337,8 +454,8 @@ function stepWarden(w: World, e: Enemy, _dt: number, spd: number): void {
     }
     if (e.age > 6.5) {
       e.phase = 2;
-      askQuestion(w, e, 0); // no orbs — the lock IS the answer
-      e.lockWant = clamp(parseInt_(w.seal.q?.answer ?? "0"), -w.cap, w.cap);
+      e.age = 0;
+      e.lockWant = drawLockTarget(w);
       e.lockState = 1;
       e.fireT = 0.6;
       cue(w, "lock");
@@ -361,9 +478,9 @@ function stepWarden(w: World, e: Enemy, _dt: number, spd: number): void {
         fireChaff(w, e.x, e.y, -Math.PI / 2 + (i - 1.5) * 0.7, 32 * spd, w.rng.sign());
       }
     }
-    if (w.t - w.seal.askedAt > 15) {
-      sealTimedOut(w);
+    if (e.age > LOCK_OPEN_FOR) {
       e.phase = 3;
+      e.age = 0;
       e.lockState = 0;
       e.fireT = 0.2;
     }
@@ -379,7 +496,7 @@ function stepWarden(w: World, e: Enemy, _dt: number, spd: number): void {
         fireChaff(w, e.x, e.y, t, 38 * spd, arm % 2 ? 1 : -1, hpf < 0.4 ? 2 : 1);
       }
     }
-    if (e.age > 0 && w.t - w.seal.askedAt > 22) {
+    if (e.age > LOCK_ENRAGE_FOR) {
       e.phase = 1;
       e.age = 0;
       e.fireT = 0.5;
@@ -401,18 +518,13 @@ export function tryLock(w: World, e: Enemy): "exact" | "near" | "miss" {
   e.hp -= exact ? Math.ceil(e.maxHp * 0.42) : Math.ceil(e.maxHp * 0.14);
   e.hitFlash = 1;
   e.phase = 3;
+  e.age = 0;
   e.lockState = 0;
   w.stats.score += exact ? SCORE.wardenLockExact : SCORE.wardenLockNear;
-  if (exact && w.seal.state === "asking" && w.seal.q) {
-    w.seal.state = "won";
-    w.stats.right++;
-    w.host.report({
-      questionId: w.seal.q.id,
-      correct: true,
-      ms: Math.max(1, Math.round((w.t - w.seal.askedAt) * 1000)),
-      answered: String(w.core),
-    });
-  }
+  // Nothing is reported here, deliberately. The lock is the ship's own running
+  // sum — a number this game invented, inside a band this game chose — and the
+  // curriculum never asked it. The Warden's actual question is committed by
+  // touching an orb, same as every other question, and that is what is reported.
   hitstop(w, exact ? 0.13 : 0.06);
   slowmo(w, exact ? 0.5 : 0.2, 0.7);
   punch(w, exact ? 1 : 0.5);
@@ -432,8 +544,12 @@ export function tryLock(w: World, e: Enemy): "exact" | "near" | "miss" {
 export function bossDefeated(w: World, e: Enemy): void {
   if (w.seal.state === "asking" && e.seal === w.seal.serial) {
     sealTimedOut(w);
-    killSealOrbs(w, e.seal, true);
   }
+  // Unconditionally, not only when the seal was still open. A seal LOST to a
+  // wrong answer deliberately leaves its correct orb hovering, and that orb
+  // outlives the boss by half a minute — long enough to be flown into while the
+  // next Bearer's question is on screen.
+  killSealOrbs(w, e.seal, true);
   w.bossActive = false;
   w.hush = 0;
   w.stats.score += e.kind === EK.Warden ? SCORE.wardenLockExact : SCORE.bearerKill;

--- a/dynawalla/games/polarity/src/game/sim.ts
+++ b/dynawalla/games/polarity/src/game/sim.ts
@@ -1,4 +1,3 @@
-import { labelTile } from "../core/labels.ts";
 import { TAU, angDiff, approach, clamp, clamp01 } from "../core/util.ts";
 import { absorbable, chainMult, overloaded, releaseYield } from "../math/signed.ts";
 import {
@@ -67,8 +66,46 @@ const UNLOCK: readonly EK[][] = [
   [EK.Mote, EK.Weaver, EK.Spinner, EK.Battery, EK.Lancer],
 ];
 
+/**
+ * How deep the run is, and therefore how hard: spawn rate, enemy speed, which
+ * enemies exist at all, and how much hull a boss has.
+ *
+ * **A seal broken, not a clock tick.** It used to be `floor(t / 30)`, so the
+ * arithmetic got faster and more crowded every thirty seconds whether or not the
+ * child had read a single answer — a child still working out `43 + 25` was being
+ * charged rent for thinking. EXPERIENCE_DESIGN.md is explicit that comprehension
+ * time is "not budgeted — the child's time, measured, never limited", and the
+ * rest of this fleet escalates on what the child FINISHED. So does this now.
+ *
+ * A child who is not getting them right stays where they are, for as long as
+ * they like, and the game is still a game: bearers keep arriving, the dodging is
+ * still the dodging. Nothing about the run punishes a slow read.
+ */
+export function stratumOf(w: World): number {
+  return w.stats.right;
+}
+
+/**
+ * How many kinds of enemy exist yet.
+ *
+ * Split off the stratum on purpose. Pressure — spawn rate, speed, boss hull —
+ * rises on what the child ANSWERED, and it must, or the arithmetic charges rent
+ * for thinking. But a roster that also waited on answers would leave a child who
+ * is flying beautifully and reading slowly alone in an empty sky with one kind
+ * of mote, forever, which is not "the dodging is still the dodging" — it is the
+ * floor of it.
+ *
+ * So the world widens on CHARGE ABSORBED: the ship's own arithmetic, performed
+ * by flying, which a child accrues by playing well whether or not they have
+ * broken a seal yet. Idle in the corner and nothing arrives, because nobody is
+ * playing.
+ */
+export function rosterOf(w: World): number {
+  return Math.min(UNLOCK.length - 1, Math.floor(w.stats.absorbs / 40));
+}
+
 function direct(w: World, dt: number): void {
-  const lvl = Math.floor(w.t / PACE.stratum);
+  const lvl = stratumOf(w);
   if (lvl !== w.stratum) {
     w.stratum = lvl;
     if (lvl > 0) {
@@ -80,7 +117,7 @@ function direct(w: World, dt: number): void {
 
   const rate = Math.min(PACE.spawnMax, PACE.spawnBase + lvl * PACE.spawnPerLvl);
   w.spawnAcc += dt * rate;
-  const table = UNLOCK[Math.min(UNLOCK.length - 1, Math.floor(lvl / 1.5))] ?? UNLOCK[0];
+  const table = UNLOCK[rosterOf(w)] ?? UNLOCK[0];
   while (w.spawnAcc >= 1) {
     w.spawnAcc -= 1;
     if (!table) break;
@@ -226,8 +263,7 @@ function absorb(w: World, b: Bullet): void {
   });
   if (big) {
     ring(w, w.px, w.py, 3.2, polHot(b.v), 0.3, 1.4);
-    const tile = labelTile(b.v);
-    if (tile >= 0) addText(w, tile, b.x, b.y, polHot(b.v));
+    addText(w, b.v, b.x, b.y, polHot(b.v));
     punch(w, 0.18);
     w.host.haptic("light");
   }

--- a/dynawalla/games/polarity/src/game/types.ts
+++ b/dynawalla/games/polarity/src/game/types.ts
@@ -24,8 +24,14 @@ export type Bullet = {
   spin: number;
   age: number;
   life: number;
-  /** atlas tile for the printed numeral, -1 for none */
-  label: number;
+  /**
+   * 1 = print `v` on this bullet, 0 = no numeral.
+   *
+   * The VALUE, not a tile: which tile prints it is settled at draw time by
+   * `LabelBook`, so there is no way to spawn a bullet whose numeral the atlas
+   * has no room for and no way for one to come out blank.
+   */
+  labelled: number;
   /** >0 = homing strength (darts) */
   homing: number;
   /** currently being sucked into the ship: 0..1 */
@@ -96,8 +102,8 @@ export type FloatText = {
   vy: number;
   age: number;
   life: number;
-  /** atlas tile index */
-  label: number;
+  /** the number to print */
+  value: number;
   size: number;
   r: number;
   g: number;

--- a/dynawalla/games/polarity/src/game/world.ts
+++ b/dynawalla/games/polarity/src/game/world.ts
@@ -161,7 +161,7 @@ const mkBullet = (): Bullet => ({
   spin: 0,
   age: 0,
   life: 8,
-  label: -1,
+  labelled: 0,
   homing: 0,
   pull: 0,
   seal: 0,
@@ -224,7 +224,7 @@ const mkText = (): FloatText => ({
   vy: 0,
   age: 0,
   life: 1,
-  label: 0,
+  value: 0,
   size: 1,
   r: 1,
   g: 1,
@@ -334,7 +334,7 @@ export function addBullet(w: World): Bullet | null {
   b.live = true;
   b.age = 0;
   b.life = 9;
-  b.label = -1;
+  b.labelled = 0;
   b.homing = 0;
   b.pull = 0;
   b.seal = 0;
@@ -382,7 +382,7 @@ export function addPart(w: World): Particle | null {
   return p;
 }
 
-export function addText(w: World, label: number, x: number, y: number, c: readonly number[]): void {
+export function addText(w: World, value: number, x: number, y: number, c: readonly number[]): void {
   if (w.textN >= w.texts.length) return;
   const t = w.texts[w.textN] as FloatText;
   w.textN++;
@@ -392,7 +392,7 @@ export function addText(w: World, label: number, x: number, y: number, c: readon
   t.vy = 26;
   t.age = 0;
   t.life = 0.95;
-  t.label = label;
+  t.value = value;
   t.size = 6.4;
   t.r = c[0] as number;
   t.g = c[1] as number;

--- a/dynawalla/games/polarity/src/math/signed.ts
+++ b/dynawalla/games/polarity/src/math/signed.ts
@@ -31,6 +31,18 @@ export function parseInt_(s: string): number {
 }
 
 /**
+ * `parseInt_` without the throw, for the one caller that is inside the frame
+ * loop. A host is free to hand a pack a value this game has no orb for; that is
+ * a thing to decline out loud, not a thing to crash a child's run over.
+ */
+export function tryParseInt(s: string): number | null {
+  const t = s.trim().replace(/−/g, "-").replace(/^\+/, "");
+  if (!/^-?\d+$/.test(t)) return null;
+  const n = Number(t);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
  * The polarity a value belongs to. Zero is the origin: it is absorbable in
  * EITHER polarity, which is both a nice mechanic and arithmetically honest.
  */

--- a/dynawalla/games/polarity/src/mount.ts
+++ b/dynawalla/games/polarity/src/mount.ts
@@ -121,13 +121,15 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       revive(world);
       audio.sealWon();
     },
-    onSkipRevive: () => {
+    onSkipRevive: (answered) => {
       if (reviveQ) {
+        // What the child touched, not an empty string. A wrong answer a child
+        // gave is data; a blank is a claim they gave none, and it is false.
         host.report({
           questionId: reviveQ.id,
           correct: false,
           ms: Math.max(1, Math.round(performance.now() - reviveAt)),
-          answered: "",
+          answered,
         });
         world.stats.asked++;
       }

--- a/dynawalla/games/polarity/src/pack.ts
+++ b/dynawalla/games/polarity/src/pack.ts
@@ -15,10 +15,16 @@
 // that way: absorbing +7 and then −4 is arithmetic the child performs by
 // flying, not a question anybody asked, so nothing about it is reported.
 //
-// One honest limit, written down rather than discovered on a tablet: an orb's
-// numeral comes from a 9×9 atlas covering −40…+40 (`core/labels.ts`), so it is
-// the low levels of the rows in `pack.json` this game can actually print. There
-// are no signed-integer rows in the graph yet; when there are, they belong
+// There used to be an "honest limit" written here: an orb's numeral came from a
+// baked 9×9 atlas covering −40…+40, so only the low end of the rows in
+// `pack.json` could be printed at all. It was not a limit, it was a defect —
+// nothing declined an item outside the range, the renderer simply skipped the
+// numeral, and 89.9% of the orb values this pack requests across the shipping
+// ladder came out as blank glowing discs. Tiles are claimed on demand now
+// (`core/labels.ts`) and any integer prints; `askQuestion` refuses anything it
+// cannot print, out loud, rather than dropping it on the field unlabelled.
+//
+// There are no signed-integer rows in the graph yet; when there are, they belong
 // here.
 
 import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"

--- a/dynawalla/games/polarity/src/render/atlas.ts
+++ b/dynawalla/games/polarity/src/render/atlas.ts
@@ -1,40 +1,97 @@
 import { CanvasTexture, LinearFilter, SRGBColorSpace, Texture } from "three";
-import { LABEL_COLS, LABEL_COUNT, LABEL_MIN, LABEL_ROWS } from "../core/labels.ts";
+import { LABEL_ASPECT, LABEL_COLS, LABEL_ROWS, LabelBook } from "../core/labels.ts";
 
 const FACE =
   '900 76px ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", ' +
   '"Nimbus Sans", Inter, system-ui, sans-serif';
 
 /**
- * Bakes -40..40 into one square-tiled texture. White on transparent so the
- * shader can tint per instance; a soft dark rim is baked in so a numeral stays
- * readable when it lands on top of its own additive glow.
+ * The numerals on the playfield, painted on demand.
+ *
+ * White on transparent so the shader can tint per instance; a soft dark rim is
+ * baked in so a numeral stays readable when it lands on top of its own additive
+ * glow. Nothing is baked ahead of time — a cell is painted the first frame its
+ * value is asked for, which is what lets an orb carry `3916` as easily as `7`.
+ *
+ * Cells are `LABEL_ASPECT` times wider than they are tall. A long answer gets
+ * width, not a horizontal squeeze: every numeral on the field is drawn at the
+ * same glyph HEIGHT, which is the thing a child reads at speed.
  */
-export function buildLabelAtlas(tilePx: number): Texture {
-  const c = document.createElement("canvas");
-  c.width = LABEL_COLS * tilePx;
-  c.height = LABEL_ROWS * tilePx;
-  const g = c.getContext("2d");
-  if (!g) throw new Error("[polarity] 2d context unavailable for the label atlas");
+export class LabelAtlas {
+  readonly book: LabelBook;
+  readonly texture: Texture;
+  readonly cols = LABEL_COLS;
+  readonly rows = LABEL_ROWS;
+  readonly aspect = LABEL_ASPECT;
 
-  g.textAlign = "center";
-  g.textBaseline = "middle";
+  private readonly canvas: HTMLCanvasElement;
+  private readonly g: CanvasRenderingContext2D;
+  private readonly cellW: number;
+  private readonly cellH: number;
 
-  for (let i = 0; i < LABEL_COUNT; i++) {
-    const v = i + LABEL_MIN;
-    const col = i % LABEL_COLS;
-    const row = (i / LABEL_COLS) | 0;
-    const cx = col * tilePx + tilePx / 2;
-    const cy = row * tilePx + tilePx / 2;
-    const s = v < 0 ? "−" + -v : String(v);
+  constructor(cellPx: number) {
+    this.book = new LabelBook(LABEL_COLS * LABEL_ROWS);
+    this.cellH = cellPx;
+    this.cellW = cellPx * LABEL_ASPECT;
+    this.canvas = document.createElement("canvas");
+    this.canvas.width = this.cols * this.cellW;
+    this.canvas.height = this.rows * this.cellH;
+    const g = this.canvas.getContext("2d");
+    if (!g) throw new Error("[polarity] 2d context unavailable for the label atlas");
+    this.g = g;
+    g.textAlign = "center";
+    g.textBaseline = "middle";
 
+    const tex = new CanvasTexture(this.canvas);
+    tex.colorSpace = SRGBColorSpace;
+    tex.minFilter = LinearFilter;
+    tex.magFilter = LinearFilter;
+    tex.generateMipmaps = false;
+    tex.anisotropy = 1;
+    tex.needsUpdate = true;
+    this.texture = tex;
+  }
+
+  /** Once per frame, before any `tileFor`. */
+  beginFrame(): void {
+    this.book.beginFrame();
+  }
+
+  /** The tile that prints `v`. Never negative — see `LabelBook.tileFor`. */
+  tileFor(v: number): number {
+    return this.book.tileFor(v);
+  }
+
+  /** Paint whatever changed this frame. A no-op on the frames nothing did. */
+  flush(): void {
+    const dirty = this.book.takeDirty();
+    if (dirty.length === 0) return;
+    for (const tile of dirty) this.paint(tile);
+    this.texture.needsUpdate = true;
+  }
+
+  dispose(): void {
+    this.texture.dispose();
+  }
+
+  private paint(tile: number): void {
+    const s = this.book.textAt(tile);
+    if (s === null) return;
+    const col = tile % this.cols;
+    const row = (tile / this.cols) | 0;
+    const x = col * this.cellW;
+    const y = row * this.cellH;
+    const g = this.g;
+
+    g.clearRect(x, y, this.cellW, this.cellH);
     g.save();
-    g.translate(cx, cy);
-    g.scale(tilePx / 128, tilePx / 128);
+    g.translate(x + this.cellW / 2, y + this.cellH / 2);
+    g.scale(this.cellH / 128, this.cellH / 128);
     g.font = FACE;
-    // squeeze 3-glyph labels so "−40" occupies the same box as "7"
+    // The cell is 256 units wide in this space. Squeeze only what genuinely
+    // overflows it — which the shipping curriculum never does.
     const w = g.measureText(s).width;
-    const maxW = 104;
+    const maxW = 128 * LABEL_ASPECT - 24;
     if (w > maxW) g.scale(maxW / w, 1);
 
     // dark contrast rim first, then the solid face
@@ -47,15 +104,6 @@ export function buildLabelAtlas(tilePx: number): Texture {
     g.fillText(s, 0, 2);
     g.restore();
   }
-
-  const tex = new CanvasTexture(c);
-  tex.colorSpace = SRGBColorSpace;
-  tex.minFilter = LinearFilter;
-  tex.magFilter = LinearFilter;
-  tex.generateMipmaps = false;
-  tex.anisotropy = 1;
-  tex.needsUpdate = true;
-  return tex;
 }
 
 /**

--- a/dynawalla/games/polarity/src/render/renderer.ts
+++ b/dynawalla/games/polarity/src/render/renderer.ts
@@ -19,13 +19,13 @@ import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { ShaderPass } from "three/examples/jsm/postprocessing/ShaderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
-import { LABEL_COLS, LABEL_ROWS, labelTile } from "../core/labels.ts";
+import { LABEL_COLS, LABEL_ROWS } from "../core/labels.ts";
 import type { Tier } from "../core/tier.ts";
 import { clamp, clamp01, wobble } from "../core/util.ts";
 import { BK, COL, EK, HALF_W, PLAYER, polColor, polHot } from "../game/constants.ts";
 import type { Bullet, Enemy, FloatText, Particle } from "../game/types.ts";
 import type { World } from "../game/world.ts";
-import { buildLabelAtlas, buildPromptTexture } from "./atlas.ts";
+import { LabelAtlas, buildPromptTexture } from "./atlas.ts";
 import {
   BACKDROP_FRAG,
   BACKDROP_VERT,
@@ -124,7 +124,9 @@ export class Renderer {
   private readonly uEnemy: Record<string, { value: unknown }>;
   private readonly uPrompt: Record<string, { value: unknown }>;
 
-  private atlas: Texture;
+  private atlas: LabelAtlas;
+  /** values already reported as undrawable, so the log stays one line each */
+  private readonly faulted = new Set<number>();
   private tier: Tier;
   private w = 1;
   private h = 1;
@@ -150,7 +152,10 @@ export class Renderer {
     this.gl.setClearColor(0x03040b, 1);
     this.gl.autoClear = true;
 
-    this.atlas = buildLabelAtlas(tier.name === "low" ? 96 : 128);
+    // Cell HEIGHT, and the same as the tile size the baked atlas used: the cell
+    // got wider, not shorter, so a numeral has exactly the texels it always had
+    // and a four-digit answer is drawn wide rather than crushed.
+    this.atlas = new LabelAtlas(tier.name === "low" ? 96 : 128);
 
     this.uBack = {
       uTime: { value: 0 },
@@ -220,8 +225,9 @@ export class Renderer {
       512,
       { iPos: 2, iSize: 1, iTile: 1, iAlpha: 1, iCol: 3 },
       shader(LABEL_VERT, LABEL_FRAG, {
-        uMap: { value: this.atlas },
+        uMap: { value: this.atlas.texture },
         uGrid: { value: new Vector2(LABEL_COLS, LABEL_ROWS) },
+        uAspect: { value: this.atlas.aspect },
       }),
       40,
     );
@@ -493,8 +499,19 @@ export class Renderer {
     for (const k of Object.keys(L.attrs)) (L.attrs[k] as InstancedBufferAttribute).needsUpdate = true;
   }
 
+  /**
+   * Every numeral on the field, resolved to a tile HERE rather than at spawn.
+   *
+   * That ordering is the whole guard. A tile is claimed the frame its value is
+   * first drawn and reclaimed only from a value nothing drew this frame, so an
+   * orb can never be handed a tile that has since been repainted, and — because
+   * `tileFor` never refuses — never be handed no tile at all. The one branch
+   * that could still drop a numeral is `orbFault`, and it shouts.
+   */
   private fillLabels(w: World): void {
     const L = this.labels;
+    const A = this.atlas;
+    A.beginFrame();
     const pos = (L.attrs.iPos as InstancedBufferAttribute).array as Float32Array;
     const size = (L.attrs.iSize as InstancedBufferAttribute).array as Float32Array;
     const tile = (L.attrs.iTile as InstancedBufferAttribute).array as Float32Array;
@@ -524,25 +541,44 @@ export class Renderer {
     const boost = this.w < 520 ? 1.18 : 1;
     for (let i = 0; i < w.bulletN; i++) {
       const b = w.bullets[i] as Bullet;
-      if (b.label < 0) continue;
+      if (!b.labelled) continue;
+      const t = A.tileFor(b.v);
+      if (t < 0) {
+        this.orbFault(b.v, b.kind === BK.Orb);
+        continue;
+      }
       const s = (b.kind === BK.Orb ? b.r * 1.35 : b.r * 1.55) * boost;
-      put(b.x, b.y, s, b.label, 1, polHot(b.v));
+      put(b.x, b.y, s, t, 1, polHot(b.v));
     }
     for (let i = 0; i < w.textN; i++) {
       const t = w.texts[i] as FloatText;
       const k = clamp01(t.age / t.life);
-      put(t.x, t.y, t.size * (1 + k * 0.5), t.label, (1 - k) * (1 - k), [t.r, t.g, t.b]);
+      put(t.x, t.y, t.size * (1 + k * 0.5), A.tileFor(t.value), (1 - k) * (1 - k), [t.r, t.g, t.b]);
     }
     // the Warden prints the exact total it demands, right on its hull
     for (let i = 0; i < w.enemyN; i++) {
       const e = w.enemies[i] as Enemy;
       if (e.kind !== EK.Warden || e.lockState !== 1) continue;
-      const tl = labelTile(e.lockWant);
       const pulse = 0.7 + 0.3 * Math.sin(w.wall * 5);
-      put(e.x, e.y, e.r * 1.15, tl, pulse, COL.gold);
+      put(e.x, e.y, e.r * 1.15, A.tileFor(e.lockWant), pulse, COL.gold);
     }
+    A.flush();
     L.geo.instanceCount = n;
     for (const k of Object.keys(L.attrs)) (L.attrs[k] as InstancedBufferAttribute).needsUpdate = true;
+  }
+
+  /**
+   * A numeral that could not be drawn. Unreachable, and deliberately noisy
+   * anyway: this is the exact shape of the bug that shipped four blank glowing
+   * discs to a child and said nothing. Logged once per value so a broken frame
+   * does not become a broken console.
+   */
+  private orbFault(v: number, isOrb: boolean): void {
+    if (this.faulted.has(v)) return;
+    this.faulted.add(v);
+    console.error(
+      `[polarity] no tile for ${String(v)}${isOrb ? " — AN ORB WOULD HAVE BEEN BLANK" : ""}`,
+    );
   }
 
   private fillPlayer(w: World, load: number, alive: number): void {

--- a/dynawalla/games/polarity/src/render/shaders.ts
+++ b/dynawalla/games/polarity/src/render/shaders.ts
@@ -394,12 +394,16 @@ export const LABEL_VERT = /* glsl */ `
   varying float vAlpha;
   varying vec3 vCol;
   uniform vec2 uGrid;
+  // Cells are wider than they are tall, so a four-digit answer is drawn WIDE
+  // rather than squeezed: iSize is the numeral's height, always.
+  uniform float uAspect;
   void main(){
     float col = mod(iTile, uGrid.x);
     float row = floor(iTile / uGrid.x);
     vUv = (uv + vec2(col, uGrid.y - 1.0 - row)) / uGrid;
     vAlpha = iAlpha; vCol = iCol;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + position.xy * iSize, 0.0, 1.0);
+    vec2 quad = position.xy * vec2(iSize * uAspect, iSize);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + quad, 0.0, 1.0);
   }
 `;
 

--- a/dynawalla/games/polarity/src/stubHost.ts
+++ b/dynawalla/games/polarity/src/stubHost.ts
@@ -185,7 +185,15 @@ const BY_DOMAIN: Record<string, Gen> = {
 // assembly
 // ---------------------------------------------------------------------------
 
-/** Orb values have to fit a two-character label and stay readable at speed. */
+/**
+ * The range THIS stub draws from, and nothing more.
+ *
+ * It is not what the game can print — `core/labels.ts` claims a tile for any
+ * integer — and reading it as a limit is how a defect survived a whole build:
+ * the dev harness stayed inside ±40, so `npm run dev` never showed a blank orb
+ * while the shipped pack showed almost nothing else. `core/labels.test.ts`
+ * measures the real curriculum instead of this.
+ */
 export const VALUE_MIN = -40;
 export const VALUE_MAX = 40;
 

--- a/dynawalla/games/polarity/src/ui/hud.ts
+++ b/dynawalla/games/polarity/src/ui/hud.ts
@@ -1,5 +1,5 @@
 import { clamp01, fmtScore } from "../core/util.ts";
-import { fmtInt, fmtSigned, parseInt_ } from "../math/signed.ts";
+import { fmtInt, fmtSigned, tryParseInt } from "../math/signed.ts";
 import { PLAYER } from "../game/constants.ts";
 import type { World } from "../game/world.ts";
 import { applyChromeVars } from "./layout.ts";
@@ -40,7 +40,8 @@ export type HudHooks = {
   onStart: () => void;
   onAgain: () => void;
   onRevive: (answered: string) => void;
-  onSkipRevive: () => void;
+  /** The option the child actually touched. Never blank — it is a real answer. */
+  onSkipRevive: (answered: string) => void;
   onToggleSound: () => void;
   onTogglePause: () => void;
 };
@@ -350,17 +351,19 @@ export class Hud {
     const p = el("div", "pol-prompt", prompt);
     const row = el("div", "pol-orbs");
     for (const o of options) {
-      const v = parseInt_(o);
+      // A host is free to hand back something this pack did not expect; the
+      // last screen of a run is not the place to throw over it.
+      const v = tryParseInt(o);
       const btn = el("button", "pol-orb") as HTMLButtonElement;
-      btn.dataset.neg = v < 0 ? "1" : "0";
-      btn.appendChild(el("span", undefined, fmtInt(v)));
+      btn.dataset.neg = v !== null && v < 0 ? "1" : "0";
+      btn.appendChild(el("span", undefined, v === null ? o : fmtInt(v)));
       btn.addEventListener("pointerdown", (e) => {
         e.preventDefault();
         if (btn.dataset.dead === "1") return;
         if (o === correct) this.hooks.onRevive(o);
         else {
           btn.dataset.dead = "1";
-          this.hooks.onSkipRevive();
+          this.hooks.onSkipRevive(o);
         }
       });
       row.appendChild(btn);
@@ -381,7 +384,8 @@ export class Hud {
     const secs = Math.floor(st.depth % 60);
     const rows: [string, string][] = [
       ["TIME", `${mins}:${String(secs).padStart(2, "0")}`],
-      ["STRATUM", String(w.stratum)],
+      // No STRATUM row: the stratum IS the number of seals broken now, and
+      // SEALS below already says it with its denominator attached.
       ["ABSORBED", String(st.absorbs)],
       ["BEST CHAIN", String(st.bestChain)],
       ["CLUTCH FLIPS", String(st.clutches)],


### PR DESCRIPTION
POLARITY could not ask a question with the curriculum that actually ships.

## The orbs were blank

A Seal Bearer drops four orbs carrying the answer and three mal-rule distractors. Each orb's numeral came from a 9×9 atlas baked with −40…+40; anything outside got tile `-1`, and `renderer.ts` skipped a `-1` without a word.

The active graph is the column-op rows: two-digit sums at the first rung, four-, five- and six-digit answers above it. Measured with the host's own `ladder()` / `choicesFor()` over the real generators — 22,000 orbs, 250 seeds per rung, every rung on the shipping ladder:

| | before | after |
|---|---|---|
| orbs with no numeral | **89.9%** | **0%** |
| items where all four options were blank | **87.3%** | **0%** |
| first rung a child touches (`add-no-regroup` L0) | **94.9%** blank | 0% |
| `add-no-regroup` L1 and above | **100%** blank | 0% |

What the child was actually being shown: a prompt on the boss hull, and four unlabelled glowing circles to choose between. No error, no warning, no fallback.

Nobody caught it because the dev stub host clamps itself to ±40, so `npm run dev` never showed a blank orb.

**Fix.** Tiles are claimed on demand. `LabelBook` interns a value the first frame it is *drawn* and reclaims a tile only from a value nothing drew this frame, so no numeral can change under a child mid-read. Cells are twice as wide as they are tall, so `3916` gets width rather than a horizontal squeeze — same glyph height as `7`. Not extending a fixed range, because the range needed is 0…999,999.

**The guard, three layers:**
- `tileFor` cannot refuse a finite integer, so blankness is unreachable by construction.
- A value that is not an integer, or a frame wanting more numerals than the grid holds, gets a **reserved `?` cell** and a `console.error`. Loud and visible; never absent.
- `askQuestion` declines an item it cannot print — or one with fewer than two readable options, which is not a question — and logs it. An unprintable distractor is dropped rather than drawn.

## Perfect play was recorded as wrong

The Warden clamped a curriculum answer to the core band (`clamp(answer, -cap, cap)`, cap starting at 20) and then reported the clamp as `answered`. A child who broke the lock exactly was reported as answering `20` to `4003 − 87` — and `game-host` sends `answered` to the grader, so it was recorded **wrong**. An adaptive controller reading that record pushes them *down* the ladder for playing perfectly.

A clamp that changes the question is not a clamp, it is a corruption. The lock target is now the game's own number, drawn inside the band it can actually reach, and it reports nothing — which is what `pack.ts` has always said about the core sum. Curriculum questions belong to the Bearer, which can put four readable values on the field and be answered by touching one.

Two more report paths were lying, both found in self-review:
- A **leftover orb** from a finished seal — the correct one, which a wrong answer deliberately leaves hovering for 40s — could be flown into while the *next* question was on screen and was reported, `correct` flag and all, against that question's id. Fixed at the root (`bossDefeated` always clears its orbs) and at the report (`onOrbTouched` ignores an orb that is not the current seal's).
- Declining a **revive** reported `answered: ""` when the child had touched a specific wrong option.

## Difficulty advanced on a clock

`floor(t / 30)` — the arithmetic got faster and more crowded every thirty seconds whether or not the child had read a single answer. `EXPERIENCE_DESIGN.md`: comprehension time is *"not budgeted — the child's time, measured, never limited."*

Pressure (spawn rate, speed, boss hull) now rises on **seals broken**. Which enemies exist is split onto **charge absorbed**, so a child flying well and reading slowly still meets the world rather than sitting in an empty sky with one kind of mote.

## Tests

51, run 5×; `tsc` clean on both projects; `build:pack` clean. `core/labels.test.ts` measures the **real** curriculum, not a stand-in — the stand-in is how this shipped.

Every test was checked by deleting its fix:

| fix removed | failure |
|---|---|
| ±40 baked range | `19771/22000 orbs (89.9%) were unlabelled glowing discs, and 4804 items had NO readable option at all` |
| Warden clamp + report | `the Warden pulled an item it has no way to ask` / `answered: "20"` for an answer of `3916` |
| wall-clock stratum | `the run climbed to stratum 26 on the clock alone, with nothing answered` |
| stale-orb guard | `a leftover orb worth 3916 was reported as an answer to item 2` |
| `bossDefeated` cleanup | `an orb outlived the boss that dropped it` |
| two-option floor | `a one-orb seal was asked` |
| overflow → `?` | `11 is printing 99 — somebody else's numeral` |
| roster on absorbs | `the sky stayed empty for a child who was playing well` |

Two `const enum`s became const objects and `TierMonitor` lost its parameter properties — that is what makes the game layer importable by node's type stripping. The layer all three defects lived in had **no tests at all**.

## Not verified without a device

The atlas paints on a real `<canvas>`, so glyph rendering, the widened label quad in the GL layer and the Warden's re-timed choreography are argued and unit-tested but not seen on a tablet. Cell height is unchanged from the old baked tile (96/128), so numerals have exactly the texels they always had.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb