### PR TITLE
fix(dynawalla/games/trebuchet): the shot carries its own answer

### DIFF
--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -1,0 +1,268 @@
+/**
+ * The whole game, driven the way a child drives it.
+ *
+ * The rest of the suite tests `sim/` in isolation, which is where the arithmetic
+ * lives — but the defect this file exists for did not live there. `release()`
+ * and `impact()` are separated by two to three seconds of boulder flight, and
+ * every input the game listens to is still live across them. So this test builds
+ * the real `TrebuchetGame` on a stub canvas, presses the real buttons through
+ * the real listeners, advances the real `tick`, and reads what the real host was
+ * told. Nothing is mocked but the paint.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { Host, Question } from './contract.ts'
+import { TrebuchetGame } from './game.ts'
+import { hudLayout } from './render/hud.ts'
+
+/* ---------------------------------------------------------------- the glass */
+
+type Listeners = Map<string, Array<(e: unknown) => void>>
+
+/** Everything a 2D context is asked for here, and nothing it is asked to draw. */
+function stubCtx(): CanvasRenderingContext2D {
+  const gradient = { addColorStop: () => undefined }
+  const target: Record<string, unknown> = {}
+  return new Proxy(target, {
+    get: (t, prop: string) => {
+      if (prop in t) return t[prop]
+      if (prop === 'measureText') return () => ({ width: 8 })
+      if (prop === 'createLinearGradient' || prop === 'createRadialGradient') return () => gradient
+      if (prop === 'canvas') return undefined
+      return () => undefined
+    },
+    set: (t, prop: string, value) => {
+      t[prop] = value
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+}
+
+function stubElement(tag: string, w: number, h: number): Record<string, unknown> {
+  const listeners: Listeners = new Map()
+  const el: Record<string, unknown> = {
+    tagName: tag.toUpperCase(),
+    style: { cssText: '' },
+    width: w,
+    height: h,
+    __listeners: listeners,
+    setAttribute: () => undefined,
+    appendChild: () => undefined,
+    remove: () => undefined,
+    setPointerCapture: () => undefined,
+    releasePointerCapture: () => undefined,
+    getContext: () => stubCtx(),
+    getBoundingClientRect: () => ({ x: 0, y: 0, top: 0, left: 0, right: w, bottom: h, width: w, height: h }),
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      const list = listeners.get(type) ?? []
+      list.push(fn)
+      listeners.set(type, list)
+    },
+    removeEventListener: (type: string, fn: (e: unknown) => void) => {
+      listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
+    },
+  }
+  return el
+}
+
+const VIEW = { w: 1024, h: 768 }
+
+/** Installs a canvas-shaped world on `globalThis`. Returns the mount element. */
+function installDom(): { el: HTMLElement; canvas: Record<string, unknown> } {
+  const created: Array<Record<string, unknown>> = []
+  const g = globalThis as unknown as Record<string, unknown>
+  g.document = {
+    createElement: (tag: string) => {
+      const el = stubElement(tag, VIEW.w, VIEW.h)
+      created.push(el)
+      return el
+    },
+    getElementById: () => null,
+    body: { appendChild: () => undefined },
+  }
+  g.window = {
+    devicePixelRatio: 1,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+  }
+  g.requestAnimationFrame = () => 1
+  g.cancelAnimationFrame = () => undefined
+  const el = stubElement('div', VIEW.w, VIEW.h)
+  // The game appends its canvas to the mount element; the first canvas created
+  // after that call is the one carrying the pointer listeners.
+  const mount = el as unknown as HTMLElement
+  return {
+    el: mount,
+    get canvas() {
+      return created.find((c) => c.tagName === 'CANVAS') as Record<string, unknown>
+    },
+  }
+}
+
+/* ---------------------------------------------------------------- the host */
+
+type Reported = { questionId: string; correct: boolean; ms: number; answered: string }
+
+function recordingHost(answers: number[]): { host: Host; reports: Reported[] } {
+  const reports: Reported[] = []
+  let n = 0
+  const host: Host = {
+    next: (): Question => {
+      const a = answers[n % answers.length]
+      n++
+      return {
+        id: `q${n}`,
+        prompt: `? = ${a}`,
+        answer: String(a),
+        distractors: [String(a + 11), String(a - 13)],
+        domain: 'add-sub',
+        difficulty: 0.4,
+      }
+    },
+    report: (r) => reports.push(r),
+    haptic: () => undefined,
+    prefersReducedMotion: () => true,
+  }
+  return { host, reports }
+}
+
+/* ---------------------------------------------------------------- driving */
+
+/** Tap a HUD button through the canvas's own pointerdown listener. */
+function tap(canvas: Record<string, unknown>, id: string): void {
+  const layout = hudLayout(VIEW.w, VIEW.h, { x: 0, y: 0, w: VIEW.w, h: VIEW.h }, true)
+  const btn = layout.buttons.find((b) => b.id === id)
+  assert.ok(btn, `no ${id} button in the HUD`)
+  const listeners = canvas.__listeners as Listeners
+  const down = listeners.get('pointerdown') ?? []
+  assert.ok(down.length > 0, 'the canvas has no pointerdown listener')
+  for (const fn of down) {
+    fn({ clientX: btn.x + btn.w / 2, clientY: btn.y + btn.h / 2, pointerId: 1 })
+  }
+}
+
+function runUntil(game: TrebuchetGame, done: () => boolean, maxFrames = 1200): boolean {
+  for (let i = 0; i < maxFrames; i++) {
+    game.stepFrames(1)
+    if (done()) return true
+  }
+  return false
+}
+
+function newGame(answers: number[], wave: number): ReturnType<typeof installDom> & {
+  game: TrebuchetGame
+  reports: Reported[]
+} {
+  const dom = installDom()
+  const { host, reports } = recordingHost(answers)
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  game.jumpToWave(wave)
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the wave never became playable')
+  return { ...dom, game, reports }
+}
+
+/* ------------------------------------------------------------------ tests */
+
+test('a bullseye stays a bullseye when the dial is nudged mid-flight', () => {
+  // Wave 8: wind up to ±5, and the +/- buttons are not phase-gated, so a child
+  // fidgeting with the dial while the boulder is in the air used to have her
+  // answer re-read at impact — a keep hit dead centre, scored wrong, and the
+  // nudged number sent to the curriculum as what she said.
+  const { game, canvas, reports } = newGame([42, 60, 78, 96], 8)
+  const answer = game.currentAnswer()
+  assert.ok(game.towerRanges().includes(answer), 'the answer must have a keep')
+
+  game.aimAt(answer)
+  game.fireNow()
+  assert.ok(runUntil(game, () => game.currentPhase === 'flight'), 'the shot never left')
+
+  tap(canvas, 'plus')
+  tap(canvas, 'plus')
+
+  assert.ok(runUntil(game, () => reports.length > 0), 'nothing was ever reported')
+  const r = reports[0]
+  assert.equal(r.answered, String(answer), 'the number she committed to is the number reported')
+  assert.equal(r.correct, true, 'a keep struck dead centre is a right answer')
+  assert.ok(!game.towerRanges().includes(answer), 'the keep she named must come down')
+})
+
+test('a wrong dial stays wrong when it is corrected mid-flight', () => {
+  // The mirror: turning the dial onto the answer after the boulder has gone must
+  // not buy the answer, and must not blow up a keep the shot never went near.
+  const { game, reports } = newGame([42, 60, 78, 96], 8)
+  const answer = game.currentAnswer()
+  const standing = game.towerRanges()
+  // A metre with no keep on it and none within blast range.
+  const wrong = standing.reduce((a, b) => Math.max(a, b), 0) + 4
+
+  game.aimAt(wrong)
+  game.fireNow()
+  assert.ok(runUntil(game, () => game.currentPhase === 'flight'), 'the shot never left')
+
+  game.aimAt(answer)
+
+  assert.ok(runUntil(game, () => reports.length > 0), 'nothing was ever reported')
+  const r = reports[0]
+  assert.equal(r.answered, String(wrong), 'what she fired is what she answered')
+  assert.equal(r.correct, false)
+  assert.deepEqual(game.towerRanges(), standing, 'no keep may fall for a wrong answer')
+})
+
+test('the reported latency is thinking time, not boulder flight time', () => {
+  // `ms` is what reaches the curriculum as `latencyMs`. Measuring it at impact
+  // adds the whole arc — two to three seconds — to every answer in the game, so
+  // the wall clock is taken over here and pushed forward only during the flight.
+  const realPerf = globalThis.performance
+  let clock = 1000
+  ;(globalThis as unknown as Record<string, unknown>).performance = { now: () => clock }
+  try {
+    const { game, reports } = newGame([42, 60, 78, 96], 4)
+    clock += 4000 // she thinks for four seconds
+    game.aimAt(game.currentAnswer())
+    game.fireNow()
+    assert.ok(
+      runUntil(game, () => {
+        // ...and the boulder is a long time in the air. Only the flight is on
+        // this clock: the wind-up is the machine's, and the thinking already
+        // happened above.
+        if (game.currentPhase === 'flight') clock += 100
+        return reports.length > 0
+      }),
+      'nothing was ever reported',
+    )
+    assert.ok(reports[0].ms >= 4000, `latency ${reports[0].ms} ms lost the thinking time`)
+    assert.ok(reports[0].ms < 4600, `latency ${reports[0].ms} ms includes the flight`)
+  } finally {
+    ;(globalThis as unknown as Record<string, unknown>).performance = realPerf
+  }
+})
+
+test('the whole rack can be answered without a false verdict', () => {
+  // Nine waves of perfect play, wind and all: every report must be correct, and
+  // must be the number that was dialled.
+  const { game, reports } = newGame([42, 60, 78, 96, 30, 110], 6)
+  const dialled: number[] = []
+  for (let shot = 0; shot < 12; shot++) {
+    if (game.currentPhase !== 'aim') {
+      if (!runUntil(game, () => game.currentPhase === 'aim')) break
+    }
+    const a = game.currentAnswer()
+    if (a < 0 || !game.towerRanges().includes(a)) break
+    dialled.push(a)
+    game.aimAt(a)
+    game.fireNow()
+    const want = reports.length + 1
+    if (!runUntil(game, () => reports.length >= want)) break
+    // Told she is right is only half of it: the keep she named has to fall, or
+    // the game is contradicting its own verdict on the screen in front of her.
+    assert.ok(!game.towerRanges().includes(a), `the keep at ${a} was named and stayed standing`)
+  }
+  assert.ok(reports.length >= 6, `only ${reports.length} shots resolved`)
+  for (let i = 0; i < reports.length; i++) {
+    assert.equal(reports[i].correct, true, `shot ${i + 1} on ${dialled[i]} was scored wrong`)
+    assert.equal(reports[i].answered, String(dialled[i]), `shot ${i + 1} reported the wrong number`)
+  }
+})

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -60,25 +60,28 @@ import {
   resolve,
   samplePath,
   shotScore,
-  solve,
   type Outcome,
   type Solved,
 } from './sim/ballistics.ts'
 import { aimShot, rollWind, verdictFor } from './sim/verdict.ts'
 import {
   buildTower,
+  DEFAULT_LOFT,
   FIELD_MAX,
   LAUNCH_X,
+  LOFTS,
   layoutTowerValues,
   pullQuestions,
   ramAdvances,
   shatter,
   stepBlocks,
+  wallFor,
   waveConfig,
   worldX,
   type Boulder,
   type Crater,
   type Ghost,
+  type Phase,
   type Ram,
   type Tower,
   type WaveConfig,
@@ -87,10 +90,6 @@ import {
 const MIN_GAP = 8
 const DIAL_MIN = 8
 const DIAL_MAX = FIELD_MAX
-const LOFTS = [30, 38, 46, 55, 65]
-const DEFAULT_LOFT = 2
-
-type Phase = 'intro' | 'aim' | 'windup' | 'flight' | 'impact' | 'settle' | 'clear'
 
 const PAL: Palette = {
   dust: C.dust,
@@ -174,6 +173,18 @@ export class TrebuchetGame {
    * correct arithmetic, which is the one thing this game may never do.
    */
   private pending: Outcome<Tower> | null = null
+  /**
+   * What the child committed to, frozen at the instant the sling let go.
+   *
+   * Two to three seconds pass between the release and the impact, and the dial,
+   * the loaded boulder and the answer clock are all live during them: the +/−
+   * buttons, the wheel and the arrow keys are not phase-gated, and tapping a rack
+   * stone changes which question is loaded. Reading any of that AT impact would
+   * mark a child on a number she is no longer looking at — a bullseye scored
+   * wrong because she nudged the dial while the boulder was in the air. The shot
+   * carries its own answer, and impact reads nothing else.
+   */
+  private fired: { dial: number; boulder: Boulder; ms: number } | null = null
   private proj = { x: 0, y: 0 }
   private armDeg = ARMED_DEG
   private recoil = 0
@@ -357,12 +368,8 @@ export class TrebuchetGame {
     this.wind = rollWind(cfg.wind, this.rng)
     this.wall = null
     if (cfg.wall) {
-      const nearest = Math.min(...values)
-      const wx = Math.max(14, Math.round(nearest * 0.46))
-      // Size it so a mid loft clears and the flattest does not: always solvable.
-      const probe = solve(nearest, LOFTS[1], 0)
-      const clearH = posAt(probe, timeAtXApprox(probe, wx)).y
-      this.wall = { x: worldX(wx), h: Math.max(6, clearH * 0.78) }
+      const w = wallFor(Math.min(...values), cfg.wind)
+      this.wall = { x: worldX(w.x), h: w.h }
     }
     this.ram = cfg.ram
       ? // Faster than it was, because it now only rolls while the world is moving:
@@ -624,6 +631,13 @@ export class TrebuchetGame {
     // Aimed at the dial, not displaced by the wind: `aimShot` lays the machine
     // off into the crosswind so the boulder comes down on the metre she named.
     const shot = aimShot(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+    // Her answer, and how long it took her — both as they stood when she fired.
+    // The flight is the game's time, not hers, so it is not in the latency.
+    this.fired = {
+      dial: this.dial,
+      boulder: b,
+      ms: Math.max(1, Math.round(performance.now() - this.questionShownAt)),
+    }
     this.shot = shot
     this.pending = resolve(shot.landing, this.towers)
     this.shotT = 0
@@ -665,14 +679,18 @@ export class TrebuchetGame {
   /* -------------------------------------------------------------- impact */
 
   private impact(x: number, y: number, hit: Tower | null, kind: 'ground' | 'tower' | 'wall' | 'ram'): void {
-    const b = this.activeBoulder
-    if (!b || !this.shot) return
+    const fired = this.fired
+    if (!fired || !this.shot) return
+    // The boulder that was thrown, not whichever one is loaded now.
+    const b = fired.boulder
+    this.fired = null
     const landing = this.shot.landing
     const out = this.pending ?? resolve(landing, this.towers)
     // The verdict is the child's number against the number she was asked for, and
     // nothing else — not the keep the blast happened to reach, not the metre the
-    // ground recorded. A boulder spent on the ram is not an answer at all.
-    const v = verdictFor({ dial: this.dial, landing, answer: b.answer, kind })
+    // ground recorded, not where the dial has drifted to since. A boulder spent on
+    // the ram is not an answer at all.
+    const v = verdictFor({ dial: fired.dial, landing, answer: b.answer, kind })
     const correct = v.correct
     // The ram swallows the boulder where it stands: no keep is touched by a shot
     // that never got past the siege engine.
@@ -804,9 +822,8 @@ export class TrebuchetGame {
     }
 
     // --- score & host report -------------------------------------------
-    const ms = Math.max(1, Math.round(performance.now() - this.questionShownAt))
     if (v.report) {
-      this.host.report({ questionId: b.q.id, correct, ms, answered: v.answered })
+      this.host.report({ questionId: b.q.id, correct, ms: fired.ms, answered: v.answered })
     }
     if (correct) {
       this.combo += 1
@@ -1420,9 +1437,4 @@ export class TrebuchetGame {
   currentWind(): number {
     return this.wind
   }
-}
-
-/** Cheap x->t inversion used only when sizing the wall (no wind at that point). */
-function timeAtXApprox(s: Solved, x: number): number {
-  return x / s.vx
 }

--- a/dynawalla/games/trebuchet/src/sim/verdict.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.test.ts
@@ -187,15 +187,22 @@ test('aiming into the wind still produces a real arc, even in the worst corner',
   // The compensation launches at `dial − wind`, which at the bottom of the dial
   // against the strongest wind is a very short throw. It must still be a finite,
   // drawable arc that reaches the ground on the dialled metre.
-  for (const wind of [-9, 9]) {
+  for (const wind of windValues(9)) {
     for (const angle of LOFTS) {
-      const s = aimShot(8, angle, wind, LAUNCH_H)
-      assert.ok(Number.isFinite(s.T) && s.T > 0, `flight time wind ${wind} loft ${angle}: ${s.T}`)
-      assert.ok(s.apexY > 0, `apex wind ${wind} loft ${angle}`)
-      for (const p of samplePath(s, 12)) {
-        assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y), `path wind ${wind} loft ${angle}`)
+      for (const dial of [8, 9, 10, 17, 122]) {
+        const where = `dial ${dial}, wind ${wind}, loft ${angle}`
+        const s = aimShot(dial, angle, wind, LAUNCH_H)
+        assert.ok(Number.isFinite(s.T) && s.T > 0, `flight time ${where}: ${s.T}`)
+        // Out of the sling forwards and upwards — never lobbed backwards off the
+        // escarpment to be dragged onto the target by the crosswind.
+        assert.ok(s.vx > 0, `${where}: launched backwards at ${s.vx} m/s`)
+        assert.ok(s.vy > 0, `${where}: launched downwards at ${s.vy} m/s`)
+        assert.ok(s.apexY > LAUNCH_H, `${where}: never rose above the sling`)
+        for (const p of samplePath(s, 12)) {
+          assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y), `path ${where}`)
+        }
+        assert.ok(Math.abs(posAt(s, s.T).x - dial) < 1e-9, `comes down on the dial, ${where}`)
       }
-      assert.ok(Math.abs(posAt(s, s.T).x - 8) < 1e-9, `comes down on the dial, wind ${wind}`)
     }
   }
 })

--- a/dynawalla/games/trebuchet/src/sim/verdict.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.ts
@@ -46,7 +46,12 @@ export function rollWind(cap: number, rng: Rng): number {
  * terms are integers, so the landing is the dial exactly — not 71.98.
  */
 export function aimShot(dialM: number, angleDeg: number, wind: number, h: number): Solved {
-  return solve(dialM - wind, angleDeg, wind, h)
+  // Never laid off past the launch point. A target nearer than the wind's push
+  // would ask for a backwards throw, so the offset stops at 1 m of power and the
+  // modelled bend gives instead — the LANDING is exact either way, which is the
+  // part a child is marked on. Only reachable by dialling below the whole field.
+  const power = Math.max(1, dialM - wind)
+  return solve(power, angleDeg, dialM - power, h)
 }
 
 /**

--- a/dynawalla/games/trebuchet/src/sim/world.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.test.ts
@@ -3,14 +3,20 @@ import { test } from 'node:test'
 
 import { makeRng } from '../core/rng.ts'
 import { createStubHost } from '../stubHost.ts'
+import { heightAtX, LAUNCH_H } from './ballistics.ts'
+import { aimShot, windValues } from './verdict.ts'
 import {
   buildTower,
+  DEFAULT_LOFT,
+  LOFTS,
   layoutTowerValues,
   pullQuestions,
   ramAdvances,
   shatter,
   stepBlocks,
+  wallFor,
   waveConfig,
+  type Phase,
 } from './world.ts'
 
 const MIN_GAP = 8
@@ -84,9 +90,38 @@ test('the ram does not roll while the child is working the sum out', () => {
   assert.equal(ramAdvances('aim'), false, 'she is working it out')
   assert.equal(ramAdvances('impact'), false, 'the hit-stop holds everything still')
   // ...and it must still be a threat once a boulder is in the air.
-  for (const phase of ['windup', 'flight', 'settle', 'clear']) {
+  for (const phase of ['windup', 'flight', 'settle', 'clear'] as Phase[]) {
     assert.equal(ramAdvances(phase), true, `${phase} is the world in motion`)
   }
+})
+
+test('the wall can always be cleared, in any wind, at the loft the lever starts on', () => {
+  // The wall is the only reason the loft lever exists. It may never stand between
+  // a child and a keep she has named correctly — and the compensation for the
+  // wind launches lower, so still air is not the case to size it against.
+  let blocks = 0
+  let walls = 0
+  for (let w = 1; w <= 40; w++) {
+    const cfg = waveConfig(w)
+    if (!cfg.wall) continue
+    for (let nearest = 14; nearest <= 118; nearest += 3) {
+      const wall = wallFor(nearest, cfg.wind)
+      walls++
+      assert.ok(wall.x < nearest, `wave ${w}: the wall stands on the keep at ${nearest}`)
+      let flatBlocked = false
+      for (const wind of cfg.wind ? windValues(cfg.wind) : [0]) {
+        const opened = aimShot(nearest, LOFTS[DEFAULT_LOFT], wind, LAUNCH_H)
+        assert.ok(
+          heightAtX(opened, wall.x) > wall.h,
+          `wave ${w}, keep ${nearest}, wind ${wind}: the default loft cannot clear a ${wall.h.toFixed(1)} m wall`,
+        )
+        if (heightAtX(aimShot(nearest, LOFTS[0], wind, LAUNCH_H), wall.x) < wall.h) flatBlocked = true
+      }
+      if (flatBlocked) blocks++
+    }
+  }
+  // ...and it must still be worth having: most walls stop the flattest shot.
+  assert.ok(blocks / walls > 0.6, `only ${blocks}/${walls} walls stop a flat shot`)
 })
 
 test('a struck keep comes apart and then settles — no perpetual motion', () => {

--- a/dynawalla/games/trebuchet/src/sim/world.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.ts
@@ -8,6 +8,8 @@
 
 import type { Question } from '../contract.ts'
 import { type Rng } from '../core/rng.ts'
+import { heightAtX, LAUNCH_H } from './ballistics.ts'
+import { aimShot } from './verdict.ts'
 
 /** World x of the launch point; ranges are measured from here. */
 export const LAUNCH_X = 6
@@ -51,6 +53,35 @@ export function waveConfig(i: number): WaveConfig {
     banners: i < 8 ? true : i % 3 !== 0,
     volley: boss,
   }
+}
+
+/** The lofts the lever offers, flattest first, and the one it starts on. */
+export const LOFTS = [30, 38, 46, 55, 65]
+export const DEFAULT_LOFT = 2
+
+/**
+ * Where the rival's outwork stands, and how tall.
+ *
+ * Two things must both be true of it, and neither was:
+ *
+ *   - **A shot at the nearest keep can always be made.** The wall used to be
+ *     placed at `max(14, nearest × 0.46)`, which for a keep at 14–17 m is the
+ *     keep's own ground — every shot at it hit the wall. And it was sized off a
+ *     still-air probe, while aiming into a tailwind launches at `dial − wind`
+ *     and flies lower, so on windy waves a correctly dialled shot smashed into
+ *     it. Height is taken from the LOWEST the default loft can ever be over that
+ *     point — the strongest tailwind of the wave — so it clears in any wind.
+ *   - **The flattest loft should not clear it**, or the lever it exists to teach
+ *     is decoration. Height is also kept above the HIGHEST the flattest can be
+ *     there. Where those two bounds cross — a keep so near that no wall can do
+ *     both — solvability wins and the wall is scenery for that wave.
+ */
+export function wallFor(nearest: number, windCap: number): { x: number; h: number } {
+  const x = Math.max(10, Math.min(Math.round(nearest * 0.46), Math.max(10, nearest - 6)))
+  const ceiling = heightAtX(aimShot(nearest, LOFTS[DEFAULT_LOFT], windCap, LAUNCH_H), x)
+  const floor = heightAtX(aimShot(nearest, LOFTS[0], -windCap, LAUNCH_H), x)
+  const h = floor + 0.7 < ceiling - 0.7 ? (floor + ceiling) / 2 : ceiling * 0.78
+  return { x, h: Math.max(4, h) }
 }
 
 /* ------------------------------------------------------------------ */
@@ -243,6 +274,14 @@ export type Crater = { x: number; r: number; depth: number; age: number; label: 
 export type Ghost = { pts: Array<{ x: number; y: number }>; landing: number; age: number; hit: boolean }
 
 /**
+ * The game loop's phases. They live here, next to the one piece of the sim that
+ * has to ask about them, so that `ramAdvances` is checked against the real set
+ * rather than against `string` — under which renaming a phase would silently
+ * put the ram back on the child's thinking time with every test still green.
+ */
+export type Phase = 'intro' | 'aim' | 'windup' | 'flight' | 'impact' | 'settle' | 'clear'
+
+/**
  * Does the ram roll during this phase?
  *
  * It does not roll while the child is reading the boulder and turning the dial.
@@ -254,7 +293,7 @@ export type Ghost = { pts: Array<{ x: number; y: number }>; landing: number; age
  * every boulder she throws, it gets closer. It is also held still during the
  * hit-stop, where everything else is.
  */
-export function ramAdvances(phase: string): boolean {
+export function ramAdvances(phase: Phase): boolean {
   return phase !== 'intro' && phase !== 'aim' && phase !== 'impact'
 }
 


### PR DESCRIPTION
Follow-up to #654, from its own adversarial review. #654 fixed the wind; it also introduced a way back into the same defect, which this closes.

## The regression

#654 moved the verdict onto the dial — and then read `this.dial` at impact. Two to three seconds of boulder flight sit between `release()` and `impact()`, and the dial is live through every one of them:

- `pressBtn` → `setDial` is reached from `onPointerDown` **before** the `phase !== 'aim'` guard, and `hitBtn` has no enabled state
- the wheel and `ArrowLeft`/`ArrowRight` are gated only on the how-to-play sheet
- the held-repeat accumulator runs in every phase

So: dial 78 (correct), fire, tap `+` while the boulder is in the air. At impact the keep at 78 is struck dead centre — and the shot is scored **wrong**, with `"112"` sent to the curriculum as the child's answer. The mirror is worse: dial 111, fire, spin the dial onto 78 during the flight, and the game reports a correct answer and destroys whichever keep the shot actually resolved against, because `correct` alone drove the destruction.

`release()` now freezes what she committed to — the dial, the boulder and how long she took — and `impact()` reads nothing else. That also closes the pre-existing case where tapping a rack stone mid-flight judged the shot against a different question.

**Latency is in the snapshot too.** `ms` was measured at impact, so every `latencyMs` the curriculum has ever seen from this game included the whole arc. The flight is the game's time, not the child's.

## Also from the review

**The wall.** Placed at `max(14, nearest × 0.46)` — for a keep at 14 m that is the keep's own ground, so every shot at it hit the wall — and sized off a still-air probe, while the wind compensation launches at `dial − wind` and flies lower. `wallFor()` now takes its height from the *lowest* the default loft can ever be over that point and keeps it above the *highest* the flattest can be:

| | before | after |
|---|---|---|
| default loft clears, any wind, any keep | not guaranteed | **always** (worst margin 0.53 m) |
| wall stops a flat shot | — | **83% of walls** |
| wall standing on the nearest keep | at every `nearest ≤ 17` | never |

Where a keep is too near for both to hold, being solvable wins and the wall is scenery for that wave.

**`aimShot` never throws backwards.** At a dial below the wind it solved for negative power — the boulder left the sling backwards and downwards and was dragged onto the target by the crosswind. The offset stops at 1 m of power; the landing stays exact. The old test asserted `apexY > 0`, which is `11 + vy²/2G` and can never fail; it now asserts the launch is forward and upward.

**`ramAdvances` is typed against `Phase`, not `string`.** Renaming a phase used to put the ram back on the child's thinking time with the whole suite green.

## The test that should have existed

`src/game.test.ts` is new and is the real point of this change. Both halves of #654 could be reverted with all 161 tests passing, because nothing drove `game.ts` — the suite tested `sim/` and the defect lived in the wiring. It builds the real `TrebuchetGame` on a stub canvas, taps the real HUD buttons through the real `pointerdown` listeners, advances the real `tick`, and asserts on what the real host was told. Nothing is mocked but the paint.

166 tests, 5 runs, `tsc --noEmit`, pack build. Every fix removed in turn:

| fix removed | failure |
|---|---|
| fired-dial snapshot | `a bullseye stays a bullseye when the dial is nudged mid-flight` — `'112' !== '78'`; `a wrong dial stays wrong` — `'78' !== '111'` |
| latency snapshot | `latency 17300 ms includes the flight` |
| wind compensation | `the whole rack can be answered without a false verdict` — *the keep at 42 was named and stayed standing* |
| wall sizing | `wave 5: the wall stands on the keep at 14` |
