### PR TITLE
fix(dynawalla/games): a rhythm game's forced wait is not the child's thinking time

### DIFF
--- a/dynawalla/games/horde/src/game/curriculum.test.ts
+++ b/dynawalla/games/horde/src/game/curriculum.test.ts
@@ -182,3 +182,21 @@ test("the rift asks below what the run has earned, never above", () => {
   const fresh = new Curriculum()
   assert.equal(fresh.difficulty(-1), 1)
 })
+
+test("the run panel counts questions the child ANSWERED, not questions it served", () => {
+  const { host } = recordingHost()
+  const c = new Curriculum()
+
+  for (let i = 0; i < 5; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.answer, true, 1200)
+  }
+  for (let i = 0; i < 3; i++) {
+    c.ask(host)
+    c.expired()
+  }
+
+  assert.equal(c.asked, 8)
+  assert.equal(c.answeredCount, 5, "three cores closed unanswered; they are not answers")
+  assert.equal(c.solved, 5)
+})

--- a/dynawalla/games/horde/src/game/curriculum.ts
+++ b/dynawalla/games/horde/src/game/curriculum.ts
@@ -86,6 +86,11 @@ export class Curriculum {
   /** Questions that closed with no answer at all. Never reported, never punished. */
   unanswered = 0
 
+  /** Questions the child actually answered. A timeout is not an answer. */
+  get answeredCount(): number {
+    return Math.max(0, this.asked - this.unanswered)
+  }
+
   reset(): void {
     this.asked = 0
     this.solved = 0

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -1707,7 +1707,7 @@ export class Game {
         { label: "SURVIVED", value: `${mm}:${ss < 10 ? "0" : ""}${ss}` },
         { label: "SLAIN", value: String(this.kills) },
         { label: "LEVEL", value: String(this.level) },
-        { label: "ANSWERED", value: `${this.curriculum.solved}/${this.curriculum.asked}` },
+        { label: "ANSWERED", value: `${this.curriculum.solved}/${this.curriculum.answeredCount}` },
         { label: "BEST", value: `${Math.floor(best / 60)}:${String(Math.floor(best % 60)).padStart(2, "0")}` },
       ],
       "THE DARK TOOK YOU",

--- a/dynawalla/games/pulse/src/game/run.test.ts
+++ b/dynawalla/games/pulse/src/game/run.test.ts
@@ -30,6 +30,15 @@ import type { LiveNote } from "./judge.ts";
 
 type Report = { questionId: string; correct: boolean; ms: number; answered: string };
 
+/**
+ * `dynawalla-app/src/packs/items.ts` moves the arithmetic ladder UP only on
+ * `verdict.correct && latencyMs <= QUICK_MS`, and `QUICK_MS` is 6000. A game
+ * that reports a latency structurally above it can never raise the maths a
+ * child is served, however well they play — which is the same defect as
+ * escalating on the clock, wearing a different hat.
+ */
+const HOST_QUICK_MS = 6000;
+
 /** 3/4 is in the bar, so the gate stays a number line. */
 function question(n: number) {
   return {
@@ -49,6 +58,8 @@ type Rig = {
   stages: number[];
   /** Audio-clock seconds between a gate appearing and its answer arriving. */
   readingWindows: number[];
+  /** Every `gateResolved` outcome, in order. */
+  outcomes: string[];
   play(seconds: number): void;
   dispose(): void;
 };
@@ -61,6 +72,7 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
   const reports: Report[] = [];
   const stages: number[] = [];
   const readingWindows: number[] = [];
+  const outcomes: string[] = [];
   let n = 0;
 
   const host: Host = {
@@ -89,7 +101,9 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
         .find((x) => x.gate?.questionId === built.questionId && x.gate.correct);
       if (target) readingWindows.push(target.time - ctx.currentTime);
     },
-    gateResolved() {},
+    gateResolved(outcome) {
+      outcomes.push(outcome);
+    },
     bar() {},
     stageChanged(_spec, index) {
       stages.push(index);
@@ -148,6 +162,7 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
     reports,
     stages,
     readingWindows,
+    outcomes,
     play(seconds) {
       const steps = Math.round(seconds / 0.02);
       for (let i = 0; i < steps; i++) step();
@@ -272,4 +287,45 @@ test("the reading window never shrinks because the tempo went up", () => {
         `the floor is ${GATE_READ_SEC}s and it must not depend on the tempo`,
     );
   }
+});
+
+test("a correct answer is reported as a latency the host can still climb on", () => {
+  // Not decoration: the reported `ms` used to run from the moment the question
+  // APPEARED, and the reading-window floor put that above HOST_QUICK_MS by
+  // construction. A child answering every gate right would then have been held
+  // on the easiest rung of the host's ladder for the whole session.
+  for (const startStage of [0, 6, 12]) {
+    const r = rig("right", startStage);
+    r.play(120);
+    const reports = [...r.reports];
+    r.dispose();
+
+    assert.ok(reports.length > 0, `no gate was answered at stage ${startStage}`);
+    const slowest = Math.max(...reports.map((x) => x.ms));
+    assert.ok(
+      slowest < HOST_QUICK_MS,
+      `at stage ${startStage} the slowest correct answer reported ${slowest}ms; the host ` +
+        `stops raising the maths above ${HOST_QUICK_MS}ms, so the ladder would never move`,
+    );
+  }
+});
+
+test("every gate served is resolved exactly once, even at the top of the loop", () => {
+  // At 168 BPM a gate comes every 5 bars — 7.1 s — against a 6 s scheduling
+  // horizon plus the expiry window, so the next gate bar is filled while the
+  // last gate is still live. The single `gate` slot has to be cleared on
+  // purpose; overwritten, its candidates stay strikeable and a stale tap
+  // resolves the question being served right now.
+  const r = rig("never", 40);
+  r.play(180);
+  const seen = r.run.gatesSeen;
+  const expired = r.outcomes.filter((o) => o === "expired").length;
+  r.dispose();
+
+  assert.ok(seen > 8, `only ${seen} gates were served at the top of the loop`);
+  assert.ok(
+    expired >= seen - 1,
+    `${seen} gates were served but only ${expired} ever resolved — the rest were ` +
+      `overwritten in the slot while still live`,
+  );
 });

--- a/dynawalla/games/pulse/src/game/run.ts
+++ b/dynawalla/games/pulse/src/game/run.ts
@@ -91,7 +91,11 @@ const HEALTH = {
 export type ActiveGate = {
   built: BuiltGate;
   bar: number;
-  openedAtPerf: number;
+  /**
+   * Audio time of the first instant a candidate could be struck — the start of
+   * the gate bar. NOT when the question appeared: see `resolveGate`.
+   */
+  strikeableAt: number;
   resolved: boolean;
 };
 
@@ -315,6 +319,26 @@ export class Run {
       this.voices.hat(bt + spb * 0.5, 0.3, false);
     }
 
+    // One gate at a time, deliberately rather than by luck. The reading-window
+    // floor made the lookahead longer than `gateEvery` bars at the top of the
+    // endless loop (a gate every 5 bars at 168 BPM is 7.1 s, against a 6 s
+    // horizon plus the 0.17 s expiry window), so this bar can be filled while
+    // the previous gate is still unresolved. Overwriting the slot would leave
+    // its candidates strikeable: a stale tap would then resolve the question
+    // being served RIGHT NOW and mark every one of its candidates spent, so
+    // that question could never be answered and never be reported.
+    const stale = this.gate;
+    if (stale && !stale.resolved) {
+      stale.resolved = true;
+      this.gateStreak = 0;
+      this.health = Math.max(0, this.health + HEALTH.gateExpired);
+      for (const n of this.notes.gateNotes()) n.judged = "miss";
+      this.fx.gateResolved("expired", null, stale.built);
+      // No `checkStumble()` here on purpose: it can step the stage down and
+      // cancel notes, and this runs INSIDE the fill of the bar it would be
+      // cancelling. The next miss or gate in `update` reaches it a beat later.
+    }
+
     const q = this.host.next();
     const built = buildGate(q, this.rng, { ...DEFAULT_FIT, maxCandidates: 4 });
     this.gatesSeen++;
@@ -331,7 +355,12 @@ export class Run {
         gate: { questionId: q.id, label: c.label, correct: c.correct, pos: c.pos },
       });
     }
-    this.gate = { built, bar, openedAtPerf: performance.now(), resolved: false };
+    this.gate = {
+      built,
+      bar,
+      strikeableAt: this.timeline.timeAt(beat0),
+      resolved: false,
+    };
     this.fx.gateOpen(built);
   }
 
@@ -423,12 +452,29 @@ export class Run {
     this.fx.stray(lane);
   }
 
-  private resolveGate(note: LiveNote, judgment: Judgment, _delta: number): void {
+  private resolveGate(note: LiveNote, judgment: Judgment, delta: number): void {
     const g = this.gate;
     if (!g || g.resolved) return;
     const info = note.gate!;
     g.resolved = true;
-    const ms = Math.max(1, Math.round(performance.now() - g.openedAtPerf));
+    /**
+     * How long the CHILD took, measured from the first instant they could have
+     * answered — not from when the question appeared.
+     *
+     * A candidate cannot be struck before it reaches the strike line, so the
+     * `GATE_READ_SEC`-plus seconds before the gate bar are the game's wait, not
+     * the child's thinking. Reporting them was reporting a property of the
+     * tempo. It also put every single correct answer over the host's fluency
+     * threshold — `dynawalla-app/src/packs/items.ts` climbs the arithmetic
+     * ladder only on `correct && latencyMs <= 6000` — so a child answering
+     * every gate right would have been pinned to the easiest rung forever,
+     * which is the exact failure this game was just fixed for having.
+     *
+     * What is left is honest and small: how far past the first opportunity the
+     * strike landed. In a game whose commit moment is set by the music, that is
+     * the only part of the interval a child owns.
+     */
+    const ms = Math.max(1, Math.round((note.time + delta - g.strikeableAt) * 1000));
     this.host.report({
       questionId: info.questionId,
       correct: info.correct,

--- a/dynawalla/games/rhythm/src/game/core.test.ts
+++ b/dynawalla/games/rhythm/src/game/core.test.ts
@@ -25,6 +25,15 @@ import type { Host } from "../contract.ts";
 
 type Report = { questionId: string; correct: boolean; ms: number; answered: string };
 
+/**
+ * `dynawalla-app/src/packs/items.ts` moves the arithmetic ladder UP only on
+ * `verdict.correct && latencyMs <= QUICK_MS`, and `QUICK_MS` is 6000. A game
+ * that reports a latency structurally above it can never raise the maths a
+ * child is served, however well they play — which is the defect this game was
+ * just fixed for, wearing a different hat.
+ */
+const HOST_QUICK_MS = 6000;
+
 type Played = {
   difficulty: number;
   bpm: number;
@@ -221,4 +230,63 @@ test("the reading window never shrinks because the tempo went up", async () => {
     `a child got ${worst.toFixed(2)}s to read a question at ${r.bpm} BPM; the floor is ` +
       `${READ_SEC}s and it must not fall as the music speeds up`,
   );
+});
+
+test("a correct answer is reported as a latency the host can still climb on", async () => {
+  const r = await play("right", LONG_RUN_SEC);
+
+  assert.ok(r.reports.length > 4);
+  // The run really did speed up, so the lead really was long: this is the case
+  // where reporting reveal-to-strike would have been furthest over the line.
+  assert.ok(r.bpm > 110, `the tempo only reached ${r.bpm} BPM`);
+  const slowest = Math.max(...r.reports.map((x) => x.ms));
+  assert.ok(
+    slowest < HOST_QUICK_MS,
+    `the slowest correct answer reported ${slowest}ms at ${r.bpm} BPM; the host stops ` +
+      `raising the maths above ${HOST_QUICK_MS}ms, so the ladder would never move`,
+  );
+});
+
+test("the reading window survives a pause taken after a sector change", async () => {
+  // `advanceSector` calls applyDifficulty mid-cycle and can move the tempo by
+  // 14 BPM, so the pinned inhale can be one bar short of what the new tempo
+  // needs. `reanchorSoft` starts a fresh cycle; if it does not re-pin, the very
+  // next question is read against the OLD tempo's bar count.
+  const game = new Game({
+    next: (opts) => ({
+      id: `q${opts?.difficulty ?? 0}`,
+      prompt: "2 + 3",
+      answer: "4",
+      distractors: ["3", "6"],
+      domain: "add-sub",
+      difficulty: 0.5,
+    }),
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => true,
+  });
+  game.soundOn = false;
+  const inner = game as unknown as {
+    inhaleBars: number;
+    cycleInhale: number;
+    reanchorSoft(): void;
+    applyDifficulty(): void;
+  };
+
+  for (const difficulty of [1, 3, 5, 7, 10]) {
+    game.difficulty = difficulty;
+    inner.applyDifficulty();
+    inner.reanchorSoft();
+    assert.equal(
+      inner.cycleInhale,
+      inner.inhaleBars,
+      `at difficulty ${difficulty} a resumed cycle kept a stale inhale of ${inner.cycleInhale}`,
+    );
+    const barDur = (60 / game.bpm) * 4;
+    assert.ok(
+      barDur * (1 + inner.cycleInhale) >= READ_SEC,
+      `a resumed cycle at ${game.bpm} BPM leads by ${(barDur * (1 + inner.cycleInhale)).toFixed(2)}s`,
+    );
+  }
+  game.destroy();
 });

--- a/dynawalla/games/rhythm/src/game/core.ts
+++ b/dynawalla/games/rhythm/src/game/core.ts
@@ -329,6 +329,10 @@ export class Game {
     this.barSpb[bar % BAR_RING] = 60 / this.bpm;
     this.audioCursor = bar;
     this.cycleStartBar = bar;
+    // A fresh cycle, so re-pin it like the other two cycle starts do. Without
+    // this a sector change (which calls applyDifficulty mid-cycle) leaves the
+    // pinned value one short and the next question's lead falls under READ_SEC.
+    this.cycleInhale = this.inhaleBars;
   }
 
   private flushNotes(): void {
@@ -615,7 +619,18 @@ export class Game {
     const spb = 60 / this.bpm;
 
     if (g.q) {
-      this.host.report({ questionId: g.q.id, correct, ms: Math.max(0, Math.round(ms)), answered });
+      /**
+       * `ms` is how long the CHILD took, measured from the first instant a tile
+       * could be struck — not from when the question was revealed.
+       *
+       * All three tiles land on the same beat, so the READ_SEC-plus seconds
+       * before the gate bar are the game's wait and not the child's thinking.
+       * Reporting them also put every correct answer over the host's fluency
+       * threshold — `dynawalla-app/src/packs/items.ts` climbs the arithmetic
+       * ladder only on `correct && latencyMs <= 6000` — so a run of nothing but
+       * right answers would have been pinned to the easiest rung forever.
+       */
+      this.host.report({ questionId: g.q.id, correct, ms: Math.max(1, Math.round(ms)), answered });
     }
 
     if (correct) {
@@ -866,7 +881,9 @@ export class Game {
       const g = this.gates.find((x) => x.active && x.id === n.gateId);
       // Every choice tile in the row is spent the moment one is struck.
       for (const o of this.notes) if (o.active && o.isChoice && o.gateId === n.gateId && o !== n) o.state = 2;
-      if (g) this.resolveGate(g, n.label, n.correct, (this.eng.now - g.revealAt) * 1000);
+      // Measured from `g.time` — the instant the tiles became strikeable —
+      // and NOT from `g.revealAt`. See resolveGate.
+      if (g) this.resolveGate(g, n.label, n.correct, (this.eng.now - g.time) * 1000);
       return;
     }
 


### PR DESCRIPTION
Follow-up to #656. That PR fixed the reading window and, in doing so, broke the thing the reading window exists to protect. Caught by adversarial review after it merged.

## The ladder could no longer climb

`dynawalla-app/src/packs/items.ts:370` is the only thing in the system that raises what maths a child is served:

```ts
if (verdict.correct && latencyMs <= QUICK_MS) position = Math.min(rungs.length - 1, position + 1)
else if (!verdict.correct) position = Math.max(0, position - 1)
```

`QUICK_MS = 6_000`. #656 floored the reveal-to-strike lead at six seconds in both rhythm games — while both were still measuring `ms` from the moment the question **appeared**. So every correct answer arrived over the threshold *by construction*:

| | before #656 | after #656 | this PR |
|---|---|---|---|
| pulse | 4.6 – 5.8 s | 7.7 – 8.1 s | 0.3 – 2.7 s |
| rhythm | 3.9 – 4.9 s | 6.2 – 7.9 s | < 0.2 s |

A child answering every fraction gate correctly for ten minutes would have had `position` never increment, and the first fumble decrement it. Pinned to the easiest rung for the session — the exact failure #656 was written to fix, wearing a different hat. Nothing in either suite could see it: the two tests that touched `ms` only asserted `>= 1 && Number.isInteger`.

**The fix.** A candidate cannot be struck before it reaches the strike line, and all three of SPLITBEAT's tiles land on the same beat. The `GATE_READ_SEC`/`READ_SEC` seconds before the gate bar are the **game's** wait, not the child's thinking — reporting them was reporting a property of the tempo. Both games now measure from the first instant an answer was possible. In a game whose commit moment is set by the music, that is the only part of the interval a child owns.

## One gate at a time

The lookahead floor also made pulse's horizon longer than `gateEvery` bars at the top of the endless loop — a gate every 5 bars at 168 BPM is 7.1 s against a 6 s horizon plus the 0.17 s expiry window — so the next gate bar was filled while the previous gate was still live and **overwrote the single `gate` slot**.

Measured at `startStage: 40`, never-answering bot, 180 s: **25 gates served, 0 ever resolved.** No expiry feedback, no health penalty, and — the real damage — a stale candidate stayed strikeable for up to 0.46 s after the rollover. Striking one sets `resolved` on the *new* gate and then marks every one of its candidates `"miss"`, so the question being served right then could never be answered and never be reported.

The slot is now cleared deliberately, before the new question is pulled. No `checkStumble()` on that path: it can step the stage down and cancel notes, and it would be running inside the fill of the bar it was cancelling.

## Two smaller ones from the same review

- **rhythm** `reanchorSoft()` starts a fresh cycle but did not re-pin `cycleInhale`, unlike the other two cycle-start sites. `advanceSector()` calls `applyDifficulty()` mid-cycle and can move BPM by 14, so a pause taken after a sector change read the next question against the old tempo's bar count — 5.37 s against a documented 6 s floor, for one cycle.
- **horde** `Curriculum.unanswered` was written and never read, and the run panel said `ANSWERED 3/8` when three of those eight were cores that closed unanswered. It now counts answers.

## Removal proofs

- pulse latency: `at stage 0 the slowest correct answer reported 8141ms; the host stops raising the maths above 6000ms, so the ladder would never move`
- pulse slot: `25 gates were served but only 0 ever resolved — the rest were overwritten in the slot while still live`
- rhythm latency: `the slowest correct answer reported 7863ms at 124.36 BPM; the host stops raising the maths above 6000ms`
- rhythm cycle: `at difficulty 1 a resumed cycle kept a stale inhale of 1 — 1 !== 2`
- horde panel: `three cores closed unanswered; they are not answers — 8 !== 5`

`npm test` and `npm run tsc` green in all three, five consecutive runs each: horde 29, pulse 98, rhythm 70. `build:pack` clean.