### PR TITLE
dynawalla/games/arena: the arena breathes — one scalar for difficulty, pace and density, in both directions

### DIFF
--- a/dynawalla/games/arena/src/feel/camera.test.ts
+++ b/dynawalla/games/arena/src/feel/camera.test.ts
@@ -1,0 +1,101 @@
+// PHOTOSENSITIVITY. A safety gate, not a matter of taste.
+//
+// `camera.ts` claims in its own docstring that "full-screen luminance jumps are
+// rate-capped to WCAG's three per second". That claim was a comment, and a
+// comment is not a gate — a children's product may not carry a seizure-risk
+// promise that nothing enforces. These tests are the enforcement.
+//
+// WCAG 2.3.1 (Three Flashes or Below Threshold) permits no MORE than three
+// general flashes in any one-second period. Three is allowed; four is not.
+//
+// **What this covers, and what it does not.** `Camera.flash` is a full-screen
+// additive white-out and it is what the cap governs. It is not the only source
+// of a bright frame: `post.ts` composites a bloom chain over the scene, and a
+// dense field of overlapping bright cores can drive that to clipped white with
+// no rate limit anywhere. That is documented in the PR rather than silently
+// retuned, because the fix for it is fewer things on screen, not less bloom.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Camera } from "./camera.ts"
+
+/** The amplitude one `addFlash` call was actually granted. */
+function grant(cam: Camera, amount: number): number {
+  cam.flash = 0
+  cam.addFlash(amount, 1, 1, 1)
+  return cam.flash
+}
+
+test("no more than three full flashes are granted in any one second", () => {
+  const cam = new Camera()
+  const granted: number[] = []
+  // Every call inside the same millisecond, which is the worst case the game
+  // can actually produce: a resonance hit landing on the same frame as a kill
+  // and a depth boundary.
+  for (let i = 0; i < 12; i++) granted.push(grant(cam, 1))
+
+  const full = granted.filter((g) => g > 0.05).length
+  assert.ok(full <= 3, `${full} full-amplitude flashes were granted inside one second`)
+  assert.equal(granted[0], 0.34, "the first flash must still be a real flash")
+  assert.ok(
+    (granted[3] as number) <= 0.05,
+    `the fourth flash was granted ${granted[3]} — the WCAG limit is three`,
+  )
+  assert.equal(granted[6], 0, "past six calls in a second the flash must be switched off entirely")
+  for (let i = 6; i < 12; i++) assert.equal(granted[i], 0)
+})
+
+test("no single flash can exceed the hard cap, however much is asked for", () => {
+  const cam = new Camera()
+  assert.equal(grant(cam, 1e9), 0.34, "an absurd request must be clamped, not honoured")
+  const calm = new Camera()
+  calm.reduced = true
+  assert.equal(grant(calm, 1e9), 0.1, "reduced motion must clamp far harder still")
+})
+
+test("the counter counts CALLS, which is the conservative direction", () => {
+  // Two calls a millisecond apart produce one perceived flash but consume two
+  // budget slots. Erring that way is correct: the alternative is a counter that
+  // under-counts, and under-counting a seizure risk is not a trade to make.
+  const cam = new Camera()
+  grant(cam, 1)
+  grant(cam, 1)
+  grant(cam, 1)
+  assert.ok(grant(cam, 1) <= 0.05, "three calls did not consume the budget")
+})
+
+test("a flash decays inside a third of a second, so it is a flash and not a wash", () => {
+  const cam = new Camera()
+  cam.addFlash(1, 1, 1, 1)
+  assert.equal(cam.flash, 0.34)
+  // `update` is driven with REAL time, never the frozen simulation time, so a
+  // hit-stop cannot hold a white frame on screen.
+  for (let i = 0; i < 6; i++) cam.update(1 / 60, 0, 0, 0, 0, 400)
+  assert.ok(cam.flash < 0.34, "the flash did not decay")
+  for (let i = 0; i < 24; i++) cam.update(1 / 60, 0, 0, 0, 0, 400)
+  assert.equal(cam.flash, 0, "half a second later the screen is still lit")
+})
+
+test("reduced motion removes travel and zoom but never removes the signal", () => {
+  const cam = new Camera()
+  cam.reduced = true
+  cam.addTrauma(0.8)
+  cam.update(1 / 60, 0, 0, 0, 0, 400)
+  assert.equal(cam.shakeX, 0, "reduced motion still shook the camera")
+  assert.equal(cam.shakeY, 0)
+  assert.ok(cam.desat > 0, "reduced motion dropped the impact signal instead of translating it")
+
+  cam.addAberration(0.01)
+  assert.equal(cam.aberration, 0, "reduced motion still aberrated")
+  cam.addRipple(0, 0, 1)
+  assert.equal(cam.rippleAmp, 0)
+})
+
+test("hit-stop is bounded — the simulation can never be frozen for long", () => {
+  const cam = new Camera()
+  cam.addHitstop(10)
+  assert.ok(cam.hitstop <= 0.14, `hit-stop of ${cam.hitstop}s would read as a dropped frame`)
+  cam.addHitstop(0.05)
+  assert.equal(cam.hitstop, 0.14, "hit-stop must take the maximum, not accumulate")
+})

--- a/dynawalla/games/arena/src/mount.ts
+++ b/dynawalla/games/arena/src/mount.ts
@@ -352,22 +352,67 @@ export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { 
         break
       }
       case "resonance-hit": {
-        cam.addTrauma(0.85)
-        cam.addHitstop(0.11)
-        cam.addPunch(0.16)
-        cam.addFlash(0.32, 1, 0.98, 0.85)
-        cam.addRipple(world.px, world.py, 1, 0.55)
-        burst(world.px, world.py, 140, 1300, 1.6, pr * 0.2 + 8, 1, 0.95, 0.7, 1)
-        burst(world.px, world.py, 60, 500, 2.4, pr * 0.16 + 6, 0.6, 0.95, 1, 0)
+        // THE BIGGEST THING IN THE GAME, and it was not.
+        //
+        // Audited before this change: `rupture` — bursting, a FAILURE — carried
+        // trauma 1.00 and hitstop 0.13, and a right answer carried 0.85 and
+        // 0.11. The loudest single moment in a mathematics product was a
+        // mistake. Celebration on successful retrieval is what reinforces the
+        // retrieval, so the maths moment now outranks everything, on every axis,
+        // and it gets a second beat nothing else has: a slow outer wave that
+        // lands a quarter-second after the first, which is the "BOOOOOOOM".
+        //
+        // The flash is 0.34 because that is `Camera.addFlash`'s own hard cap —
+        // asked for more, it would be given 0.34 anyway, and asking for the cap
+        // rather than past it keeps the WCAG rate limiter's arithmetic honest.
+        // `e.r` is how QUICK the answer was, 0..1. Speed is paid out in
+        // spectacle as well as in mass — a brisk answer gets a visibly bigger
+        // celebration — and a slow correct answer still gets all of the above,
+        // which is the floor this may never drop below.
+        const quick = e.r
+        cam.addTrauma(1)
+        cam.addHitstop(0.14)
+        cam.addPunch(0.24 + quick * 0.06)
+        cam.addFlash(0.34, 1, 0.98, 0.85)
+        cam.addRipple(world.px, world.py, 1, 0.5)
+        burst(world.px, world.py, Math.round(220 + quick * 140), 1500, 1.8, pr * 0.22 + 9, 1, 0.95, 0.7, 1)
+        burst(world.px, world.py, Math.round(110 + quick * 70), 560, 2.8, pr * 0.18 + 7, 0.6, 0.95, 1, 0)
+        burst(world.px, world.py, 70, 260, 3.6, pr * 0.12 + 5, 1, 1, 1, 0)
         gfx.rings.spawn(world.px, world.py, pr, pr * 9, 1.3, 0.075, 2, 1, 0.95, 0.75, time)
         gfx.rings.spawn(world.px, world.py, pr, pr * 6, 0.95, 0.14, 0, 1, 1, 1, time)
         gfx.rings.spawn(world.px, world.py, pr, pr * 13, 1.8, 0.045, 1, 0.6, 0.9, 1, time)
-        floaters.push(Math.round(e.a), world.px, world.py, Math.max(cam.span * 0.033, pr * 0.44), 1, 1, 0.75, 1.5)
+        gfx.rings.spawn(world.px, world.py, pr * 0.4, pr * 20, 2.6, 0.030, 2, 1, 0.9, 0.6, time + 0.26)
+        floaters.push(Math.round(e.a), world.px, world.py, Math.max(cam.span * 0.038, pr * 0.5), 1, 1, 0.75, 1.7)
+        // The sum that earned it, in the ribbon, held long enough to read. A
+        // correct answer wipes every mote inside seven player radii, and each
+        // of those absorbs would otherwise overwrite the line within a frame.
+        const q = world.resonance.question
+        if (q) {
+          const p = q.prompt
+          hud.showEquation(p.length <= 28 && !p.includes("?") ? `${p} = ${q.answer}` : `${q.answer}`, 2.8, "solved")
+        }
         hud.showVerdict(e.b >= 3 ? `RESONANT ×${e.b}` : "RESONANT", "#b9ffe4")
         audio.resonanceHit(e.b)
         break
       }
       case "resonance-miss": {
+        // THE REVEAL. Not a correction — there is no "wrong", no red cross and
+        // no scolding anywhere in this branch. The arena simply finishes the
+        // sum, in the ribbon, the same way it would have celebrated it and
+        // merely quieter, and holds it for as long as the player's own pace
+        // says they want. A child at the bottom of the ladder gets four
+        // patient seconds of `12 + 5 = 17`; a player in wizard mode gets none,
+        // because being held for it would be a punishment for being good.
+        const rq = world.resonance.question
+        const hold = world.revealSeconds
+        if (rq && hold >= 0.25) {
+          const rp = rq.prompt
+          hud.showEquation(
+            rp.length <= 28 && !rp.includes("?") ? `${rp} = ${rq.answer}` : `${rq.answer}`,
+            hold,
+            "reveal",
+          )
+        }
         cam.addTrauma(0.5)
         cam.addHitstop(0.07)
         cam.addAberration(0.009)

--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, FLOOR_MASS } from "./world.ts"
+import { Rng } from "../core/rng.ts"
 import { DEPTHS, depthFor, overdrive } from "./depths.ts"
 import { specFor } from "../core/tier.ts"
 import { createStubHost } from "../host/stubHost.ts"
@@ -353,6 +354,32 @@ test("hunting nothing but rivals for twenty minutes is not an exponential", () =
   let peak = 0
 
   for (let f = 0; f < 60 * 60 * 20; f++) {
+    // Answer every Resonance correctly, then go back to hunting.
+    //
+    // This is new, and it is what makes the test a worst case again rather than
+    // merely a hostile one. The world's density, rival count and pace are now
+    // driven by a controller fed on the child's ANSWERS, so a bot that ignores
+    // every question is a bot playing in the emptiest, calmest ocean the game
+    // has — four rivals and a sparse field — and it simply cannot find enough
+    // prey to run away with anything. Measured: peak 92 over twenty minutes,
+    // which proves nothing about the kill economy at all.
+    //
+    // A determined child does not ignore the questions; answering them is how
+    // the water fills up with things to eat. So the bot answers perfectly AND
+    // hunts nothing but the largest rival it is legally allowed to swallow,
+    // which is the genuinely highest-yield line of play available. If kills are
+    // an exponential route, this is the run that finds it.
+    const res = world.resonance
+    if (res.active && res.phase === 2) {
+      const i = res.spheres[res.correctSlot] as number
+      if (i >= 0 && world.malive[i]) {
+        world.aimX = world.mx[i] as number
+        world.aimY = world.my[i] as number
+        world.step(1 / 60)
+        peak = Math.max(peak, world.mass)
+        continue
+      }
+    }
     let best = -1
     let bestScore = -1
     for (let k = 0; k < world.rmass.length; k++) {
@@ -432,4 +459,412 @@ test("a rupture costs real mass at your peak, and can never pay you", () => {
   rupture(9999)
   assert.ok(world.mass <= 5000, `rupture paid the player: 5000 -> ${world.mass}`)
   assert.ok(world.mass >= FLOOR_MASS)
+})
+
+// ---------------------------------------------------------------------------
+// THE BREATH — pace, crowding, control, and the numbers a child has to read
+// ---------------------------------------------------------------------------
+
+/** Fly a competent-but-not-perfect child for `seconds`, answering at `accuracy`. */
+function fly(
+  world: World,
+  seconds: number,
+  accuracy: number,
+  seed: number,
+  onFrame?: (f: number) => void,
+): void {
+  const coin = new Rng(seed)
+  let target = -1
+  for (let f = 0; f < 60 * seconds; f++) {
+    const res = world.resonance
+    if (res.active && res.phase === 2) {
+      if (target < 0) target = coin.f() < accuracy ? res.correctSlot : (res.correctSlot + 1 + coin.int(0, 2)) % 4
+      const i = res.spheres[target] as number
+      if (i >= 0 && world.malive[i]) {
+        world.aimX = world.mx[i] as number
+        world.aimY = world.my[i] as number
+      }
+    } else {
+      target = -1
+      let best = -1
+      let bs = -1
+      for (let i = 0; i < world.mx.length; i++) {
+        if (!world.malive[i] || world.mkind[i] === 3) continue
+        const v = world.mval[i] as number
+        if (v < 0 || v >= world.mass * 0.92) continue
+        const d = Math.hypot((world.mx[i] as number) - world.px, (world.my[i] as number) - world.py)
+        const s = (v + 6) / (d + 90)
+        if (s > bs) {
+          bs = s
+          best = i
+        }
+      }
+      if (best >= 0) {
+        world.aimX = world.mx[best] as number
+        world.aimY = world.my[best] as number
+      }
+    }
+    world.step(1 / 60)
+    onFrame?.(f)
+  }
+}
+
+/**
+ * The founder's headline complaint, as an assertion.
+ *
+ *   "arena gets so crowded so fast I can hardly move"
+ *
+ * Measured before this pass, mid tier: the FIRST FRAME of a run carried 155
+ * motes and 16 rivals — the same counts the twentieth minute carries, because
+ * `reset()` spawned the tier ceiling and nothing ever ramped. There was no
+ * onset of any kind.
+ */
+test("a run opens sparse and fills up only as the world is earned", () => {
+  const spec = specFor("mid")
+  const world = new World(createStubHost({ seed: 2 }), spec, 808)
+
+  let rivals = 0
+  let motes = 0
+  for (let k = 0; k < world.rmass.length; k++) if (world.ralive[k]) rivals++
+  for (let i = 0; i < world.malive.length; i++) if (world.malive[i]) motes++
+
+  assert.ok(rivals <= spec.rivals * 0.4, `the opening frame carried ${rivals} rivals of a ${spec.rivals} ceiling`)
+  assert.ok(motes <= spec.motes * 0.55, `the opening frame carried ${motes} motes of a ${spec.motes} ceiling`)
+  assert.ok(rivals >= 2, "…but an arena with nobody in it is a screensaver, not an arena")
+  assert.ok(motes >= 20, "…and a child must have something to eat from the first second")
+
+  // Fifteen seconds in it has not quietly filled up behind the ramp.
+  fly(world, 15, 0, 5)
+  let r15 = 0
+  for (let k = 0; k < world.rmass.length; k++) if (world.ralive[k]) r15++
+  assert.ok(r15 <= spec.rivals * 0.45, `fifteen seconds in there were already ${r15} rivals`)
+
+  // A player who answers well gets the full ocean; the ceiling is still real.
+  const busy = new World(createStubHost({ seed: 2 }), spec, 808)
+  fly(busy, 300, 1, 5)
+  let rBusy = 0
+  for (let k = 0; k < busy.rmass.length; k++) if (busy.ralive[k]) rBusy++
+  assert.ok(rBusy > r15, `answering well did not fill the ocean: ${r15} -> ${rBusy} rivals`)
+})
+
+/**
+ * "we go from 10 to >1000 in minutes .. it should start with 1,2,3 and really
+ *  get into the 2nd and 3rd grade for a while"
+ *
+ * Measured before, seeded, mid tier, an ordinary mote-chasing player:
+ * mass 104 at five seconds, 537 at fifteen, 1,771 at thirty, 2,624 at sixty.
+ * Four digits inside the first minute, for everybody, forever after.
+ *
+ * The assertion is on BANDS rather than on numbers, because the exact value is
+ * seed-dependent and the property is not.
+ */
+test("the numbers a child reads stay in a workable range for a long time", () => {
+  const world = new World(createStubHost({ seed: 4 }), specFor("mid"), 0xbeef)
+  const at: Record<number, number> = {}
+  const marks = [15, 30, 60, 120, 300]
+  fly(world, 300, 0.3, 9, (f) => {
+    const t = (f + 1) / 60
+    for (const m of marks) if (Math.abs(t - m) < 1 / 120) at[m] = world.mass
+  })
+
+  assert.ok((at[15] as number) < 100, `mass was already ${Math.round(at[15] as number)} after fifteen seconds`)
+  assert.ok((at[30] as number) < 200, `mass was already ${Math.round(at[30] as number)} after half a minute`)
+  assert.ok((at[60] as number) < 600, `mass was already ${Math.round(at[60] as number)} after one minute`)
+  // …and it must still be a climb, not a stall. A game where nothing grows is
+  // not calmer, it is dead.
+  assert.ok((at[300] as number) > (at[30] as number) * 3, "five minutes of play went nowhere")
+})
+
+/**
+ * The whole point of the controller, end to end through the simulation.
+ * Struggle and the world gets sparser AND calmer AND easier, together.
+ */
+test("the world breathes out for a child who is struggling, and in for one who is not", () => {
+  const mk = (): World => new World(createStubHost({ seed: 6 }), specFor("mid"), 31337)
+
+  const lost = mk()
+  fly(lost, 420, 0, 11)
+  const thriving = mk()
+  fly(thriving, 420, 1, 11)
+
+  const count = (w: World): { rivals: number; motes: number } => {
+    let rivals = 0
+    let motes = 0
+    for (let k = 0; k < w.rmass.length; k++) if (w.ralive[k]) rivals++
+    for (let i = 0; i < w.malive.length; i++) if (w.malive[i]) motes++
+    return { rivals, motes }
+  }
+  const a = count(lost)
+  const b = count(thriving)
+
+  assert.ok(b.rivals > a.rivals, `struggling and thriving got the same crowd: ${a.rivals} vs ${b.rivals} rivals`)
+  assert.ok(b.motes > a.motes, `struggling and thriving got the same field: ${a.motes} vs ${b.motes} motes`)
+  assert.ok(thriving.rung > lost.rung, `the maths did not adapt: rung ${lost.rung} vs ${thriving.rung}`)
+  assert.equal(lost.rung, 0, "a child getting everything wrong must reach the very bottom of the ladder")
+  assert.ok(lost.voidRate < thriving.voidRate, "the water did not calm down for the struggling child")
+})
+
+/**
+ * Time is MEASURED and REWARDED, never imposed.
+ *
+ *   "I like infinite time to think in most cases too ... we can usually
+ *    measure, pace and reward, not cause anxiety"
+ *
+ * Two clocks used to run on every child regardless: a window that shrank with
+ * the number of questions asked — `max(6.5, 10.5 - resonanceCount * 0.16)` —
+ * and spheres that drifted away at a flat 22 units a second while you thought.
+ */
+test("a struggling player is never put on a clock, and a fast one is paid for being fast", () => {
+  const world = new World(createStubHost({ seed: 8 }), specFor("mid"), 55)
+  assert.ok(
+    world.resonanceSeconds >= 24,
+    `a fresh run gives only ${world.resonanceSeconds.toFixed(1)}s to think`,
+  )
+  assert.ok(
+    world.sphereDrift * world.resonanceSeconds < 2,
+    `the spheres drift ${(world.sphereDrift * world.resonanceSeconds).toFixed(1)} units over a whole window — the answer walks away from a child at the bottom of the ladder`,
+  )
+
+  // Struggle: the window gets LONGER, never shorter.
+  const before = world.resonanceSeconds
+  fly(world, 300, 0, 13)
+  assert.ok(
+    world.resonanceSeconds >= before - 1e-9,
+    `five minutes of struggle SHRANK the window ${before.toFixed(1)} -> ${world.resonanceSeconds.toFixed(1)}`,
+  )
+
+  // Climb, and a real countdown appears — earned, not imposed.
+  const ace = new World(createStubHost({ seed: 8 }), specFor("mid"), 55)
+  fly(ace, 420, 1, 13)
+  assert.ok(ace.resonanceSeconds < 14, `a mathlete was still given ${ace.resonanceSeconds.toFixed(1)}s`)
+  assert.ok(ace.sphereDrift > 5, "…and the spheres never started moving")
+  assert.ok(ace.intensity > world.intensity)
+})
+
+/** Mashing must not be a strategy, and must not be punished either. */
+test("swimming into a random sphere parks a child at the bottom, and costs them almost nothing", () => {
+  let answered = 0
+  const world = new World(createStubHost({ seed: 12, onReport: () => answered++ }), specFor("mid"), 99)
+  const coin = new Rng(7)
+  let pick = -1
+  let worstDrop = 0
+  for (let f = 0; f < 60 * 420; f++) {
+    const res = world.resonance
+    if (res.active && res.phase === 2) {
+      // One sphere per question, chosen at random. Re-rolling every frame is
+      // not mashing, it is oscillating between four points and never arriving.
+      if (pick < 0) pick = coin.int(0, 3)
+      const i = res.spheres[pick] as number
+      if (i >= 0 && world.malive[i]) {
+        world.aimX = world.mx[i] as number
+        world.aimY = world.my[i] as number
+      }
+    } else {
+      pick = -1
+    }
+    const before = world.mass
+    world.step(1 / 60)
+    // Scoped to the MISS specifically. A rupture is a separate mechanic with its
+    // own checkpoint and its own mercy, and folding it in here would measure
+    // something this test is not about.
+    for (let e = 0; e < world.eventLen; e++) {
+      if ((world.events[e] as { kind: string }).kind !== "resonance-miss") continue
+      worstDrop = Math.max(worstDrop, (before - world.mass) / before)
+    }
+  }
+  assert.ok(answered > 0, "the masher never actually reached a sphere")
+  assert.ok(world.intensity < 0.35, `mashing climbed to ${world.intensity.toFixed(2)} — guessing must not pay`)
+  assert.ok(
+    worstDrop < 0.06,
+    `a wrong answer cost ${(worstDrop * 100).toFixed(0)}% of the run — a child who is guessing is a child who is stuck`,
+  )
+})
+
+/**
+ * "The other 'players' can get so big that they are bigger than the whole
+ *  screen on a mobile device and they just basically envelope me and I can't do
+ *  anything."
+ *
+ * Measured before, five minutes, seeded: the largest core on the field reached
+ * 27.4x the player's mass — 1.99 times the WIDTH of a 1080x2340 phone. The
+ * exemption `!this.rleviathan[k]` on the size recycler was the whole bug.
+ */
+test("nothing in the water may ever be wider than the screen", () => {
+  const PORTRAIT = 1080 / 2340
+  for (const [tier, accuracy] of [["mid", 1], ["high", 0.5], ["low", 0]] as const) {
+    const world = new World(createStubHost({ seed: 21 }), specFor(tier), 1234)
+    world.viewAspect = PORTRAIT
+    let worstRatio = 0
+    let worstCover = 0
+    fly(world, 600, accuracy, 3, () => {
+      const width = viewSpanFor(world.mass) * PORTRAIT
+      for (let k = 0; k < world.rmass.length; k++) {
+        if (!world.ralive[k]) continue
+        const m = world.rmass[k] as number
+        worstRatio = Math.max(worstRatio, m / world.mass)
+        worstCover = Math.max(worstCover, (2 * 9 * Math.sqrt(m)) / width)
+      }
+    })
+    assert.ok(
+      worstCover < 1,
+      `${tier}: a rival reached ${worstCover.toFixed(2)}x the width of a phone held tall — it can enclose a child`,
+    )
+    assert.ok(
+      worstRatio < 4.6,
+      `${tier}: a rival reached ${worstRatio.toFixed(1)}x the player's mass`,
+    )
+  }
+})
+
+/**
+ * "Why is there an edge of the board?"
+ *
+ * Because there was one, five seconds away. `arenaRadiusFor` was
+ * `max(2600, span * 3.4)` and at the starting mass the `max` chose the
+ * constant, so a 2,600-unit pond surrounded a 463-unit view. Measured:
+ * swimming in one straight line from the centre, the wall arrived after 4.77
+ * seconds — inside a child's first attempt at moving.
+ */
+test("a child cannot find the edge of the world by swimming at it", () => {
+  const world = new World(createStubHost({ seed: 14 }), specFor("mid"), 5)
+  let touched = -1
+  for (let f = 0; f < 60 * 150; f++) {
+    world.aimX = world.px + 500_000
+    world.aimY = world.py
+    world.step(1 / 60)
+    const rad = Math.hypot(world.px, world.py)
+    if (touched < 0 && rad > world.arenaR - 9 * Math.sqrt(world.mass) - 2) touched = f / 60
+  }
+  assert.equal(touched, -1, `the membrane was reached after ${touched}s of swimming in one direction`)
+  // …and it is still there, because Float32 positions need bounding.
+  for (const m of [10, 500, 40_000, 5_000_000]) {
+    assert.ok(Number.isFinite(arenaRadiusFor(m)))
+    assert.ok(arenaRadiusFor(m) > viewSpanFor(m) * 60, `the arena is only ${arenaRadiusFor(m) / viewSpanFor(m)} spans wide at mass ${m}`)
+  }
+})
+
+/**
+ * The ribbon may never print a sum that is false.
+ *
+ * `Math.round(before)`, `Math.round(delta)` and `Math.round(after)` do not have
+ * to agree — 10.4 + 4.4 = 14.8 rounds to "10 + 4 = 15" — so the ends are
+ * rounded and the middle is derived from them. This is a maths product; there
+ * is no acceptable rate of printing wrong arithmetic.
+ */
+test("the running equation is always true, and never fires for a change of nothing", () => {
+  for (const seed of [1, 77, 4242]) {
+    const world = new World(createStubHost({ seed }), specFor("mid"), seed * 7)
+    let seq = world.eqSeq
+    let lines = 0
+    fly(world, 420, 0.6, seed, () => {
+      if (world.eqSeq === seq) return
+      seq = world.eqSeq
+      lines++
+      assert.equal(
+        world.eqA + world.eqD,
+        world.eqC,
+        `the ribbon printed ${world.eqA} ${world.eqD < 0 ? "−" : "+"} ${Math.abs(world.eqD)} = ${world.eqC}`,
+      )
+      assert.ok(Number.isInteger(world.eqA) && Number.isInteger(world.eqD) && Number.isInteger(world.eqC))
+      assert.notEqual(world.eqD, 0, "the ribbon printed a change of zero")
+    })
+    assert.ok(lines > 40, `only ${lines} equations in seven minutes — the ribbon is barely alive`)
+  }
+})
+
+/**
+ * A seeded run must be reproducible, and it very nearly stopped being.
+ *
+ * The controller is fed by how long an answer took, and the first cut fed it
+ * `performance.now()` — the wall clock — which made the difficulty ladder, and
+ * therefore the whole world, depend on how fast the machine was. `?seed=`
+ * reproducing a run is the only way a playtest can be discussed.
+ */
+test("the same seed and the same inputs give the same run, on any machine", () => {
+  const runOnce = (): number[] => {
+    const world = new World(createStubHost({ seed: 3 }), specFor("mid"), 24601)
+    const out: number[] = []
+    fly(world, 240, 0.7, 42, (f) => {
+      if ((f + 1) % (60 * 30) === 0) out.push(Math.round(world.mass * 1000), world.rung, Math.round(world.intensity * 1e6))
+    })
+    return out
+  }
+  assert.deepEqual(runOnce(), runOnce(), "two runs of the same seed diverged — something wall-clock is steering the world")
+})
+
+/**
+ * Two properties of the ribbon that a full-run test cannot reach, so they are
+ * exercised against `note` directly.
+ *
+ * Both were found by deleting the fix and watching NOTHING fail: a run simply
+ * does not happen to produce a sub-rounding mass change often enough for a
+ * seeded soak to catch one.
+ */
+test("the ribbon derives its middle term, and stays silent for a change of nothing", () => {
+  const world = new World(createStubHost({ seed: 9 }), specFor("low"), 17)
+  const note = (world as unknown as { note(before: number): void }).note.bind(world)
+
+  // A change too small to round to anything is not arithmetic; it is noise, and
+  // printing "1503 + 0 = 1503" sixty times a second buries every real line.
+  world.mass = 100.4
+  const quiet = world.eqSeq
+  note(100.2)
+  assert.equal(world.eqSeq, quiet, "the ribbon fired for a change that rounds to zero")
+
+  // The middle term is DERIVED from the two rounded ends, never rounded on its
+  // own. Rounding it independently is how "10 + 4 = 15" gets printed: here the
+  // ends round to 90 and 100 while the true delta is 10.4, which rounds to 10 —
+  // agreeing by luck — and the case below does not.
+  world.mass = 652.6
+  note(687.4)
+  assert.equal(world.eqA, 687)
+  assert.equal(world.eqC, 653)
+  assert.equal(world.eqD, -34, "the delta was rounded on its own: 687 − 35 = 653 is not true")
+  assert.equal(world.eqA + world.eqD, world.eqC)
+  assert.equal(world.eqSeq, quiet + 1)
+})
+
+/**
+ * The reveal: patience where it teaches, and nowhere else.
+ *
+ * At the bottom of the range a child who is not producing answers is still
+ * absorbing numerals and the shape of an equation resolving, so the arena
+ * finishes the sum for them and holds it. At the top, holding a player who
+ * already knew it would be a punishment for being good.
+ */
+test("a missed answer is completed patiently at the floor and skipped at the ceiling", () => {
+  const calm = new World(createStubHost({ seed: 15 }), specFor("mid"), 606)
+  assert.ok(calm.revealSeconds > 3, `a fresh run gives only ${calm.revealSeconds.toFixed(1)}s of reveal`)
+
+  const ace = new World(createStubHost({ seed: 15 }), specFor("mid"), 606)
+  fly(ace, 420, 1, 4)
+  assert.ok(ace.revealSeconds < 0.5, `a player in wizard mode is still held for ${ace.revealSeconds.toFixed(1)}s`)
+
+  // …and the hold is real, not just a number: a miss at the floor keeps the
+  // question on screen for meaningfully longer than a right answer does.
+  const holdAfterMiss = (accuracy: number): number => {
+    const w = new World(createStubHost({ seed: 15 }), specFor("mid"), 606)
+    if (accuracy > 0) fly(w, 420, 1, 4)
+    let held = -1
+    let frames = 0
+    const coin = new Rng(3)
+    let pick = -1
+    for (let f = 0; f < 60 * 400 && held < 0; f++) {
+      const res = w.resonance
+      if (res.active && res.phase === 2) {
+        if (pick < 0) pick = (res.correctSlot + 1 + coin.int(0, 2)) % 4
+        const i = res.spheres[pick] as number
+        if (i >= 0 && w.malive[i]) {
+          w.aimX = w.mx[i] as number
+          w.aimY = w.my[i] as number
+        }
+      }
+      w.step(1 / 60)
+      if (w.resonance.phase === 3 && !w.resonance.wasCorrect) frames++
+      else if (frames > 0) held = frames / 60
+    }
+    return held
+  }
+  const calmHold = holdAfterMiss(0)
+  assert.ok(calmHold > 2.5, `the reveal at the floor lasted only ${calmHold.toFixed(1)}s`)
 })

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -1,3 +1,15 @@
+import {
+  SECOND_GRADE_FLOW,
+  countAt,
+  curved,
+  observe,
+  quickness,
+  revealMs,
+  rungAt,
+  seedSuccess,
+  settle,
+  valueAt,
+} from "../../../../packs/shared/game-pacing/index.ts"
 import { Rng } from "../core/rng.ts"
 import { Grid } from "../core/grid.ts"
 import { tidyValue } from "../core/digits.ts"
@@ -34,6 +46,113 @@ export const FLOOR_MASS = 6
 const MAX_MOTES = 360
 
 /**
+ * THE BREATH.
+ *
+ * ARENA had no adaptation of any kind. Density, rival count, speed and question
+ * difficulty were all functions of the DEPTH, the depth was a ratchet that can
+ * only ever go up, and the ratchet was driven by the clock and by mass. Nothing
+ * anywhere in this file asked whether the child was getting the maths right.
+ * Measured on the first frame of a seeded mid-tier run: 155 motes and 16
+ * rivals, which are the same counts the twentieth minute carries. There was no
+ * onset, and there was no way back down.
+ *
+ * So one number now drives density, rival count, player speed, void rate,
+ * hunter budget, question difficulty and how long a question stays open — all
+ * of it, together, in both directions. Struggle and the whole world breathes
+ * out. Succeed for a while and it leans in. The controller is shared rather
+ * than local (`packs/shared/game-pacing`) because every game in this catalogue
+ * wants exactly this and none of them should re-derive it.
+ *
+ * The depth ratchet is deliberately left alone. It still runs the palette, the
+ * water and the leviathan, because "how deep this run has been" is a record and
+ * a record should not un-happen. What it no longer runs is anything a child has
+ * to compute against.
+ */
+const FLOW = SECOND_GRADE_FLOW
+
+/**
+ * Motes and rivals at the floor of the breath, as a fraction of the tier's
+ * ceiling.
+ *
+ * A quarter of the rivals, a third of the motes. Both were chosen against a
+ * measured ON-SCREEN count rather than against the pool size, because the pool
+ * is spread over a disc of 1.65 view-spans and only a fixed fraction of it is
+ * ever in frame: the old field put ~15 motes on a phone held tall and 35-70 on
+ * a tablet held wide, in the FIRST FIFTEEN SECONDS. A third takes the tablet's
+ * opening frame from seventy numbers to about twenty-three, which is a field a
+ * seven-year-old can actually read.
+ */
+const MOTE_FLOOR = 0.45
+const RIVAL_FLOOR = 0.28
+
+/**
+ * Rungs on the difficulty ladder ARENA hands the Host.
+ *
+ * The ladder itself is the curriculum's, not this file's: `host.next` takes a
+ * difficulty in 1..10 and the Host decides what that means. ARENA's job is only
+ * to stand on the right rung, which is why the mapping goes through the shared
+ * `rungAt` — with hysteresis, so a difficulty sitting on a band edge cannot
+ * hand a child alternating easy and hard questions.
+ *
+ * What rung 1 actually *contains* is content, not tuning. Today the active
+ * curriculum's easiest generator starts at two-digit + two-digit, so the bottom
+ * of this ladder is currently clamped by what exists rather than by anything
+ * here. When the first-grade fact spine lands, this reaches down to it with no
+ * change to this file.
+ */
+const DIFFICULTY_RUNGS = 10
+
+/**
+ * THE QUIET TIDE, and why the world's pace is not simply the breath.
+ *
+ * A Resonance can be ignored. Miss one and it times out, nothing is reported,
+ * and the controller — which is fed by answers and by nothing else — never
+ * moves. Drive that to its conclusion and a child who only wants to swim spends
+ * twenty minutes in a four-rival ocean that never builds. Measured exactly
+ * that: a bot that hunts rivals and never answers a question peaked at mass 60
+ * in twenty minutes.
+ *
+ * So the two things the intensity drives are separated, and the split is the
+ * honest one:
+ *
+ *   * The MATHS — which rung of the ladder, how long a question stays open —
+ *     follows the breath alone, and falls all the way to the bottom. Nothing a
+ *     clock does may make a struggling child's questions harder.
+ *
+ *   * The WORLD — density, rivals, speed, growth, the temper of the water —
+ *     follows whichever is higher, the breath or this tide. A long run fills up
+ *     whether or not anybody is answering, which is the escalation a growth game
+ *     needs, and answering well still gets there far sooner.
+ *
+ * Capped at half, so the tide alone never delivers the mayhem. The top half of
+ * the world is earned.
+ */
+const QUIET_TIDE_SECONDS = 420
+const QUIET_TIDE_CEILING = 0.62
+
+/**
+ * The largest any rival may be, as a multiple of the player's mass.
+ *
+ * Stated as a multiple of mass but DERIVED from the screen, which is the only
+ * place the constraint actually lives. Radius is `R_K * sqrt(mass)` and the
+ * view is `11 * R_K * sqrt(mass) + 520`, so once the constant term stops
+ * mattering a rival at `k` times your mass has
+ *
+ *     diameter / viewport width = 2*sqrt(k) / (11 * aspect)
+ *
+ * and the worst aspect we ship into is a phone held tall, 1080x2340, where
+ * `aspect` is 0.4615. That makes the fraction `0.394 * sqrt(k)`:
+ *
+ *     k = 2.6  ->  0.63 of the width      k = 4.0  ->  0.79 of the width
+ *
+ * So an ordinary rival may reach two thirds of the narrow dimension and a
+ * leviathan four fifths. Both are enormous. Neither can enclose a child, which
+ * is the whole difference between a threat and a coin flip.
+ */
+const RIVAL_MAX_RATIO = 2.6
+const LEVIATHAN_MAX_RATIO = 4.0
+
+/**
  * Broad-phase resolution. The cell COUNT is fixed here; the cell SIZE is set
  * per frame from `gridSpan`, so the grid costs the same 62×62 whether the
  * player is at mass 10 or mass 350,000.
@@ -45,9 +164,41 @@ const GRID_COLS = 62
  * A fraction compounds, and compounding turns a twenty-minute climb into a
  * ninety-second explosion followed by nothing. These two numbers are the
  * whole difficulty curve and they were fitted by simulating full runs.
+ *
+ * **They were fitted against the wrong objective, and this is the deepest of
+ * the founder's complaints.** At 0.62 / 0.60 a seeded run measured
+ *
+ *     t=5s  mass 104   t=15s  mass 537   t=30s  mass 1,771   t=60s  mass 2,624
+ *
+ * — the player's own number is four digits before the first minute is out, and
+ * the numbers in the water with it are four and five digits from then on. The
+ * pack declares `dw.ns.compare.whole-numbers`, whose generator poses 3-digit
+ * comparisons at its first two levels and does not reach 5 digits until its
+ * fourth. So the arena was spending twenty-nine seconds in the range the
+ * curriculum starts at and the following twenty minutes past the range it ends
+ * at. As the founder put it: "5000 versus 8000 in like 2 minutes". Reading
+ * 3,418 against 3,481 is genuinely the declared skill; arriving there in half a
+ * minute and never coming back is not.
+ *
+ * Both numbers matter and they do different jobs.
+ *
+ *   FOOD_A 0.62 -> 0.30 scales the whole curve down. Because the field's own
+ *   size scales with the player, the eat RATE goes as M^-0.35 and the gain per
+ *   mote as M^FOOD_B, so dM/dt is proportional to M^(FOOD_B - 0.35) and the
+ *   solution is a power of t. Halving A slows the clock on the whole climb.
+ *
+ *   FOOD_B 0.60 -> 0.46 is the shape, and it is the one that decides whether
+ *   the twelfth minute is still a maths game. At 0.60, dM/dt goes as M^0.25 and
+ *   mass runs as t^(4/3) — super-linear, so the run accelerates away from the
+ *   curriculum forever. At 0.46 the exponent is 0.11 and mass runs as t^1.12:
+ *   very nearly linear, which is a climb a child can stay inside.
+ *
+ * Measured after: 2 digits for the first half-minute, 3 digits for the next
+ * several minutes, 4 digits past ten. See `sim.test.ts`, which asserts the
+ * bands rather than the numbers.
  */
-const FOOD_A = 0.62
-const FOOD_B = 0.60
+const FOOD_A = 0.40
+const FOOD_B = 0.50
 
 /**
  * How much of a mote actually becomes you.
@@ -119,20 +270,51 @@ export function devourGain(rivalMass: number, mass: number): number {
 const MAX_RIVALS = 26
 const MAX_EVENTS = 96
 
-/** World units of view across the smaller screen dimension. */
+/**
+ * World units of view across the screen's HEIGHT — `gfx.worldPerPx` divides by
+ * the canvas height, so on a phone held tall this is the LONG dimension and the
+ * width is only `span * aspect`, which on a 1080×2340 is 0.46 of it.
+ *
+ * The constant term is the opening's whole sense of space. At 150 a run began
+ * with a 463-unit view and a 28-unit player: 16 player-radii of visible world,
+ * crossed at 2.44 screen-widths per second. There was nowhere to be. At 520 the
+ * opening view is 833 units — 29 player-radii — and by mass 1,000 the term is a
+ * 10% correction, so this buys room exactly where a child needs it and costs
+ * nothing once they are large.
+ */
 export function viewSpanFor(mass: number): number {
-  return R_K * Math.sqrt(mass) * 11 + 150
+  return R_K * Math.sqrt(mass) * 11 + 520
 }
+
+/**
+ * How many view-spans of world lie between the player and the membrane.
+ *
+ * "Why is there an edge of the board?" — because there was one, five seconds
+ * away. `arenaRadiusFor` used to be `max(2600, span * 3.4)`, and at the
+ * starting mass the `max` chose the constant: a 2,600-unit pond around a
+ * 463-unit view. Measured: swimming in one straight line from the centre, the
+ * wall arrived after 4.77 seconds. A child finds that inside their first
+ * attempt at moving.
+ *
+ * The membrane is kept, and only kept, because positions live in Float32Array
+ * and an unbounded world eventually loses sub-unit precision. Ninety spans puts
+ * the wall over three minutes of dead-straight swimming away at the open, and
+ * further at every larger size, so it bounds the coordinates without ever being
+ * a thing a child can play against. Thirty was the first number tried and the
+ * test below found the wall at 63.9 s — long, but not longer than a determined
+ * nine-year-old.
+ */
+const ARENA_SPANS = 90
 
 export function radiusForValue(v: number): number {
   return Math.max(MOTE_MIN_R, R_K * Math.sqrt(Math.abs(v)))
 }
 
 export function arenaRadiusFor(mass: number): number {
-  // The membrane must always sit well outside the frame. Tied to a constant it
-  // fell *inside* the view once you were large, and the picture became a lit
-  // disc floating in a black void with the player pinned to the edge.
-  return Math.max(2600, viewSpanFor(mass) * 3.4)
+  // Proportional to the view at every size, with no constant floor. The floor
+  // was the bug: it made the arena a fixed pond that the opening view was small
+  // enough to cross.
+  return viewSpanFor(mass) * ARENA_SPANS
 }
 
 // Mote kinds.
@@ -211,6 +393,17 @@ export type Resonance = {
   correctSlot: number
   openedAt: number
   /**
+   * The same instant on the SIMULATION clock.
+   *
+   * `openedAt` is `performance.now()` and must stay that way: the Host's
+   * mastery model wants the real seconds a real child took. But the moment
+   * latency also began steering the difficulty controller, wall time became an
+   * INPUT to the simulation — and a run seeded with `?seed=` stopped being
+   * reproducible, because the same seed on a slower machine took a different
+   * ladder. Anything that feeds the world reads this instead.
+   */
+  openedT: number
+  /**
    * Milliseconds from opening to the answer being registered, frozen at the
    * moment of the answer. The harness used to recompute this from `openedAt`
    * on every frame of the 0.9 s resolve, so the metric it reported was the
@@ -254,6 +447,35 @@ export class World {
   aimY = 120
   /** Set by the renderer so spawns can land just outside the actual frame. */
   viewAspect = 1.6
+
+  // -- the breath ---------------------------------------------------------
+  /**
+   * How hard the world is pushing, 0..1. Drives density, rivals, speed, void
+   * rate, hunters, question difficulty and question duration — all of it, at
+   * once, so escalation reads as one thing rather than as six.
+   */
+  intensity = FLOW.start
+  /** Smoothed estimate of how the child is doing. Never rendered anywhere. */
+  success = seedSuccess(FLOW)
+  /** The rung of the difficulty ladder currently stood on, 0-based. */
+  rung = rungAt(FLOW.start, DIFFICULTY_RUNGS)
+
+  // -- the running equation -----------------------------------------------
+  /**
+   * The last piece of arithmetic that happened to the player, as three integers
+   * that are exactly consistent: `eqA + eqD === eqC`, always.
+   *
+   * Consistency is the whole point and it is why these are integers rather than
+   * the floats the simulation runs on. `Math.round(before)`, `Math.round(delta)`
+   * and `Math.round(after)` do not have to agree — 10.4 + 4.4 = 14.8 rounds to
+   * "10 + 4 = 15" — and a maths product may not print a sum that is false. So
+   * the ends are rounded and the middle is DERIVED from them.
+   */
+  eqA = Math.round(START_MASS)
+  eqD = 0
+  eqC = Math.round(START_MASS)
+  /** Bumped whenever the three above change, so a HUD can tell new from same. */
+  eqSeq = 0
 
   // -- motes (SoA) --------------------------------------------------------
   readonly mx = new Float32Array(MAX_MOTES)
@@ -314,6 +536,7 @@ export class World {
     labels: ["", "", "", ""],
     correctSlot: 0,
     openedAt: 0,
+    openedT: 0,
     answerMs: 0,
     ringR: 0,
     chosen: -1,
@@ -350,6 +573,172 @@ export class World {
    */
   private get gridSpan(): number {
     return viewSpanFor(this.mass) * 3.6
+  }
+
+  /**
+   * Motes the world wants alive right now.
+   *
+   * Three factors, and the order of the words matters: the TIER says what this
+   * machine can draw, the DEPTH says what this band of the water is like, and
+   * the ONSET says how far into the run we are. Only the third is new, and it
+   * is the one the founder was missing.
+   */
+  get moteBudget(): number {
+    const ceiling = Math.round(this.spec.motes * this.depth.density)
+    return countAt(this.worldIntensity, Math.round(this.spec.motes * MOTE_FLOOR), ceiling, "gentle")
+  }
+
+  /**
+   * How hard the WORLD is pushing: the breath, or the quiet tide, whichever is
+   * higher. Everything except the maths reads this rather than `intensity`.
+   */
+  get worldIntensity(): number {
+    const tide = QUIET_TIDE_CEILING * curved(Math.min(1, this.time / QUIET_TIDE_SECONDS), "gentle")
+    return Math.max(this.intensity, tide)
+  }
+
+  /**
+   * Rivals the world wants alive right now.
+   *
+   * Floored at two rather than at the fraction alone: a growth arena with one
+   * other creature in it is not an arena, and the ladder — which is the entire
+   * reason to keep playing — needs somebody on it.
+   */
+  get rivalBudget(): number {
+    const open = Math.max(2, Math.round(this.spec.rivals * RIVAL_FLOOR))
+    return countAt(this.worldIntensity, open, this.spec.rivals, "gentle")
+  }
+
+  /**
+   * How much of the depth's aggression the breath is currently letting through.
+   *
+   * The depth ratchets and cannot fall; this can, and it is what lets a
+   * struggling child's water genuinely calm down rather than merely hand them
+   * easier questions inside the same storm. Floored at a quarter so the world
+   * never becomes inert — an arena with nothing to be afraid of is not an
+   * arena, it is a screensaver.
+   */
+  private get pressure(): number {
+    return valueAt(this.worldIntensity, 0.25, 1, "settle")
+  }
+
+  /** Void motes as a fraction of the field, after the breath. */
+  get voidRate(): number {
+    return this.depth.voidRate * this.pressure
+  }
+
+  /** Rivals allowed to lock on and pursue, after the breath. */
+  get hunterBudget(): number {
+    return Math.round(this.depth.hunters * this.pressure)
+  }
+
+  /**
+   * Seconds a Resonance stays open — and the reason it is a curve rather than a
+   * constant is the most important pacing decision in this file.
+   *
+   * It was `max(6.5, 10.5 - resonanceCount * 0.16)`: a window that shrank
+   * toward six and a half seconds for EVERY player, regardless of whether they
+   * were keeping up. That is a countdown imposed on a child, and a countdown
+   * imposed on a child is the thing that converts arithmetic into guessing.
+   *
+   * The founder's rule is that time should be measured and REWARDED, never
+   * used to cause anxiety: "I like infinite time to think in most cases ... we
+   * can usually measure, pace and reward, not cause anxiety". So the clock is
+   * something a player EARNS by demonstrating they are comfortably fast.
+   *
+   *   at the floor    26 s — three times the curriculum's own p50 for this
+   *                          skill, which is as close to "unlimited" as ARENA
+   *                          can honestly offer
+   *   mid-ladder      20 s — still nowhere near pressure
+   *   at the ceiling   6 s — a real countdown, and the player climbed here
+   *
+   * `gentle` is what makes that true: two thirds of the way up the ladder the
+   * window is still over sixteen seconds. A struggling child never meets a
+   * clock. A mathlete opts into one by being visibly ready for it.
+   *
+   * It is not literally unbounded, and the reason is structural rather than
+   * pedagogical: the arena holds its breath during a Resonance — nothing can
+   * touch you and you cannot eat — so a window that never closes is a game that
+   * never resumes for a player who put the tablet down mid-question. What the
+   * floor gives instead is a window nobody working at this level will ever
+   * reach the end of, and no visible clock at all (see `sphereDrift`).
+   *
+   * It reads `intensity`, not `worldIntensity`: the quiet tide may fill the
+   * ocean up around a player who is not answering, but it may never put them
+   * on a clock they did not earn.
+   */
+  get resonanceSeconds(): number {
+    return valueAt(this.intensity, 26, 6, "gentle")
+  }
+
+  /**
+   * How fast the four spheres drift outward while a question is open.
+   *
+   * The other clock, and the one that was invisible as a clock. At a flat 22
+   * units a second the answer physically walked away from a hesitating child,
+   * so "a hesitant answer costs distance" was a countdown wearing a different
+   * hat. It is now earned on exactly the same terms as the window: zero at the
+   * floor, so a child may think for as long as they like with the answer
+   * staying where they found it.
+   */
+  get sphereDrift(): number {
+    return valueAt(this.intensity, 0, 22, "gentle")
+  }
+
+  /**
+   * How fast the player's own number is allowed to grow, as a fraction of full.
+   *
+   * The founder: "we meant to start in the first grade range of numbers and
+   * ramp into 3rd and 4th really as the sweet spot. we go from 10 to >1000 in
+   * minutes .. it should start with 1,2,3 and really get into the 2nd and 3rd
+   * grade for a while."
+   *
+   * Sparser water and a gentler food curve slow the climb for everybody; this
+   * is what makes the climb *earned*. At the floor of the breath a run creeps,
+   * so the numbers a child is comparing stay small while they are finding their
+   * feet. Answer well and the world lets you grow into three digits, and then
+   * four. The digits are the reward, which is the right way round — they used
+   * to be a side effect of the clock.
+   *
+   * **It applies to the MOTE economy and to nothing else**, and the first cut of
+   * this got that wrong. Scaling the kill and the right answer down with it took
+   * the two deliberate payoff moments of the game and made them small at exactly
+   * the moment a player most needs them to be large; measured, a bot that hunts
+   * nothing but rivals for twenty minutes peaked at mass 58 instead of several
+   * thousand, because a kill was worth 8% of it rather than 28%. Motes are the
+   * continuous supply and therefore the right place to meter the climb. A kill
+   * and a correct answer are events, they are rare, and they pay in full.
+   */
+  private get growth(): number {
+    // `intensity`, not `worldIntensity`. The quiet tide may fill the ocean up
+    // around a player who is not answering — a growth game has to escalate —
+    // but it may not inflate the NUMBERS they are being asked to read. The
+    // digits on the field track the player's own mass, so this is the line
+    // that keeps a struggling child in two and three figures for as long as
+    // they need, however long the run has been going.
+    return valueAt(this.intensity, 0.60, 1, "settle")
+  }
+
+  /**
+   * Seconds the finished sum is held in front of the player after a miss.
+   *
+   * The teaching moment, and at the bottom of the range it may be the only
+   * channel that is working: a child who is not producing answers is still
+   * absorbing numerals, symbols and the shape of an equation resolving. So the
+   * arena completes the sum for them, calmly, for as long as it takes to read —
+   * and shorter and shorter as they climb, until a player in wizard mode is not
+   * held at all. Skipping it is the reward for not needing it.
+   *
+   * It is never inside an answering window. The answer is already given; this
+   * hold costs the child nothing.
+   */
+  get revealSeconds(): number {
+    return revealMs(FLOW, this.intensity) / 1000
+  }
+
+  /** The largest rival `k` may be before the world recycles it. */
+  private rivalCeiling(k: number): number {
+    return this.rleviathan[k] === 1 ? LEVIATHAN_MAX_RATIO : RIVAL_MAX_RATIO
   }
 
   get events(): readonly GameEvent[] {
@@ -414,11 +803,12 @@ export class World {
    * mass you already had, because a high water mark that *pays* for being hit
    * is the bug that once produced six orders of magnitude of free mass.
    */
-  private damage(loss: number): number {
+  private damage(loss: number, ledger = true): number {
     const before = this.mass
     const floor = Math.min(before, this.checkpoint)
     const raw = before - loss
     this.mass = Math.max(floor, raw)
+    if (ledger) this.note(before)
     // The floor HELD. This is the one rule in the game a child cannot see, so
     // the moment it saves them is the moment it gets shown: a gold pulse
     // exactly where the hit landed, no words, no number, no modal. Rate-limited
@@ -430,6 +820,36 @@ export class World {
     return before - this.mass
   }
   private heldCool = 0
+
+  /**
+   * Record one change to the player's mass as an equation a child can read.
+   *
+   * The founder's idea, and it is the best one in the batch: "an animation of
+   * the math as we 'eat' numbers ... 10 + 4 = 14 / 14 + 10 = 24 / 24 - 5 = 19".
+   * It turns eating numbers into arithmetic that is visible and reviewable
+   * instead of implicit.
+   *
+   * **It shows the TRUE change, and that is not always the number printed on
+   * the thing you ate.** A mote's label is a SIZE — the quantity you compare
+   * against your own, which is the whole mathematics of this game and is exact
+   * — and absorption saturates, so swallowing a `4` at mass 10 is worth +1, not
+   * +4. A ribbon reading "10 + 4 = 14" would print a sum the game did not
+   * perform, and a maths product may not do that at any price. So it prints
+   * "10 + 1 = 11".
+   *
+   * Both ends are rounded and the middle is derived, never the other way round,
+   * so `eqA + eqD === eqC` holds exactly however the floats fell. A change that
+   * rounds to nothing is not recorded at all: "1503 + 0 = 1503" is noise.
+   */
+  private note(before: number): void {
+    const a = Math.round(before)
+    const c = Math.round(this.mass)
+    if (a === c) return
+    this.eqA = a
+    this.eqD = c - a
+    this.eqC = c
+    this.eqSeq++
+  }
 
   // -------------------------------------------------------------------------
 
@@ -454,14 +874,27 @@ export class World {
     this.bestMass = START_MASS
     this.deepest = 0
     this.depth = DEPTHS[0] as Depth
+    this.intensity = FLOW.start
+    this.success = seedSuccess(FLOW)
+    this.rung = rungAt(FLOW.start, DIFFICULTY_RUNGS)
     this.refreshDepth()
-    for (let i = 0; i < this.spec.motes; i++) this.spawnMote(true)
-    for (let i = 0; i < this.spec.rivals; i++) this.spawnRival(true)
+    this.eqA = Math.round(START_MASS)
+    this.eqD = 0
+    this.eqC = Math.round(START_MASS)
+    this.eqSeq = 0
+    // The opening field is the ramp's floor, not the tier's ceiling, and it is
+    // laid down PLAYER-RELATIVE rather than scattered over the whole arena.
+    // Scattering was always wasted work — `maintain` culls past 1.65 view-spans
+    // on the very first step and re-spawns near the player anyway — and with
+    // the membrane now thirty spans out it would have been worse than wasted:
+    // the first frame of a run would have been empty water.
+    for (let i = 0; i < this.moteBudget; i++) this.spawnMote(false)
+    for (let i = 0; i < this.rivalBudget; i++) this.spawnRival(false)
   }
 
   applySpec(spec: TierSpec): void {
     this.spec = spec
-    while (this.moteCount > spec.motes) {
+    while (this.moteCount > this.moteBudget) {
       // Retire the mote furthest from the player rather than a random one.
       let worst = -1
       let worstD = -1
@@ -483,7 +916,7 @@ export class World {
     // to sit at the bottom of this loop meant an ultra→low demotion (24 → 12)
     // removed exactly one, and the tier the governor had just decided the
     // machine could not afford stayed on screen.
-    while (this.rivalCount > spec.rivals) {
+    while (this.rivalCount > this.rivalBudget) {
       let victim = -1
       for (let i = MAX_RIVALS - 1; i >= 0; i--) {
         if (this.ralive[i] && !this.rleviathan[i]) {
@@ -547,7 +980,7 @@ export class World {
   private rollValue(): { v: number; kind: number } {
     const M = this.mass
     const r = this.rng
-    if (r.chance(this.depth.voidRate)) {
+    if (r.chance(this.voidRate)) {
       const mag = Math.max(2, tidyValue(FOOD_A * Math.pow(M, FOOD_B) * r.range(1.0, 3.0)))
       return { v: -mag, kind: MK_VOID }
     }
@@ -725,7 +1158,7 @@ export class World {
     // target left over from whoever last occupied this slot.
     this.decide(i, x, y, m, R_K * Math.sqrt(m))
 
-    const hunterBudget = this.depth.hunters
+    const hunterBudget = this.hunterBudget
     let hunters = 0
     for (let k = 0; k < MAX_RIVALS; k++) if (this.ralive[k] && this.rhunter[k]) hunters++
     this.rhunter[i] = hunters < hunterBudget && r.chance(0.5) ? 1 : 0
@@ -742,7 +1175,11 @@ export class World {
     const d = viewSpanFor(this.mass) * 2.4
     this.rx[i] = this.px + Math.cos(a) * d
     this.ry[i] = this.py + Math.sin(a) * d
-    const m = Math.round(this.mass * r.range(3.4, 5.2))
+    // 3.4-5.2 -> 2.4-3.2. The old range was already ABOVE the ceiling the
+    // recycler now enforces, so a leviathan was born condemned or born
+    // screen-filling depending on which ran first. Spawning inside the ceiling
+    // means it arrives frightening and stays alive long enough to matter.
+    const m = Math.round(this.mass * r.range(2.4, 3.2))
     this.rmass[i] = m
     this.rMassVis[i] = m
     this.ralive[i] = 1
@@ -764,6 +1201,10 @@ export class World {
   step(dt: number): void {
     this.eventCount = 0
     this.time += dt
+    // The breath, before anything reads it. One call, one number, and every
+    // budget below is a pure function of it.
+    this.intensity = settle(FLOW, this.intensity, this.success, dt)
+    this.rung = rungAt(this.intensity, DIFFICULTY_RUNGS, this.rung)
     this.invuln = Math.max(0, this.invuln - dt)
     this.stingGrace = Math.max(0, this.stingGrace - dt)
     this.heldCool = Math.max(0, this.heldCool - dt)
@@ -794,8 +1235,24 @@ export class World {
     // quickly and turns like a barge. Making size cost *agility* rather than
     // *speed* is what keeps the twelfth minute from becoming a slow crawl
     // across an empty screen, while still letting a minnow dance out of reach.
-    const base = 520
-    let speed = base * Math.pow(Math.max(18, r) / 28, 0.30)
+    //
+    // The two numbers were tuned in world units, where 520 looks brisk. In
+    // SCREEN units they were the founder's "the character zips too fast it's
+    // hard to control": at the starting mass, 520 with an exponent of 0.30 was
+    // 1.13 screen-heights per second and 2.44 screen-WIDTHS per second on a
+    // phone held tall — the width of the glass crossed in 0.41 s, before the
+    // surge multiplier. Worse, it was the FASTEST the game ever was in screen
+    // terms. By mass 20,000 the same formula gives 0.12 screen-heights per
+    // second, a nine-fold swing, and it ran the wrong way round: hardest to
+    // control in the first ten seconds, sluggish by the twentieth minute.
+    //
+    // 520 -> 400 slows the opening. 0.30 -> 0.42 gives size more of its speed
+    // back, which flattens the swing to 3.7x and leaves Agar's law intact —
+    // mass still costs agility, below, which is where "majestic" actually comes
+    // from. Measured, with the wider opening view: 0.48 screen-heights per
+    // second at the start (was 1.13) and 0.13 at mass 20,000 (was 0.12).
+    const base = 400
+    let speed = base * Math.pow(Math.max(18, r) / 28, 0.42)
     // Inside a Resonance the arena is a fixed-size room however large you are.
     // Distance to a sphere grows with your radius while ordinary speed only
     // grows as r^0.30, so past a certain size the answer becomes physically
@@ -824,7 +1281,15 @@ export class World {
     const desiredY = (dy / d) * speed * mult * grip
 
     // Heavier cores turn slower. This is where "majestic" comes from.
-    const agility = 8.0 * Math.pow(30 / Math.max(24, r), 0.45)
+    //
+    // 8.0 -> 10.0 is turn AUTHORITY, and it is the other half of "I can hardly
+    // move": a first-order lag at 8.0 takes 0.12 s to reach 63% of a new
+    // heading, which at the old top speed meant a third of the screen's width
+    // travelled in the direction the child had already decided against. At 10.0
+    // that settling is 0.10 s. It buys deliberate placement without buying
+    // twitch, because the ceiling on how fast you may travel came down at the
+    // same time.
+    const agility = 10.0 * Math.pow(30 / Math.max(24, r), 0.45)
     const kk = 1 - Math.exp(-dt * agility)
     this.pvx += (desiredX - this.pvx) * kk
     this.pvy += (desiredY - this.pvy) * kk
@@ -841,7 +1306,10 @@ export class World {
       // never trapped without an escape — but the exhaust is real mass, so it
       // stops being shed the moment there is nothing left to pay with. Without
       // that guard a floored player is a free mote printer.
-      const paid = this.damage(burn) > burn * 0.5
+      // `false`: surge burn is a continuous drain, not an event. Left on the
+      // ledger it would rewrite the ribbon sixty times a second with
+      // "1503 - 1 = 1502" and bury every real piece of arithmetic.
+      const paid = this.damage(burn, false) > burn * 0.5
       const sp = Math.hypot(this.pvx, this.pvy)
       if (paid && sp > 1 && this.rng.chance(Math.min(1, dt * 26))) {
         const i = this.freeMote()
@@ -944,7 +1412,7 @@ export class World {
         this.rrespawn[i] = (this.rrespawn[i] as number) - dt
         if ((this.rrespawn[i] as number) <= 0) {
           this.rrespawn[i] = 0
-          if (this.rivalCount < this.spec.rivals) this.spawnRival(false)
+          if (this.rivalCount < this.rivalBudget) this.spawnRival(false)
         }
         continue
       }
@@ -975,10 +1443,26 @@ export class World {
       dx += Math.cos(wob) * 0.22
       dy += Math.sin(wob) * 0.22
 
-      const temper = this.depth.temper + this.over * 0.2
+      // Multiplied by the breath, like every other pressure in the world. The
+      // depth's temper is a ratchet the CLOCK turns, and a ratchet the clock
+      // turns is an escalate-on-failure line by another route: a child who is
+      // struggling has, by definition, been playing for a while.
+      const temper = (this.depth.temper + this.over * 0.2) * this.pressure
       const lev = this.rleviathan[i] === 1
-      const base = lev ? 330 : 470 + temper * 120
-      let speed = base * Math.pow(Math.max(18, rr) / 28, lev ? 0.22 : 0.30)
+      // Rival speed is a RATIO to the player's, and it was only ever written as
+      // an absolute because the player's was. Dropping the player's base from
+      // 520 to 400 silently made every rival in the game faster than the player
+      // at every size below a few hundred mass — measured: a bot that hunts
+      // nothing but rivals for twenty minutes peaked at mass 59, because it
+      // could not catch anything. So both ends move together.
+      //
+      // 470 + temper*120 -> 300 + temper*110, and the exponent matched to the
+      // player's 0.42, which also gives the escalation the flat exponent never
+      // did: at DRIFT's temper of 0.22 a rival makes 324 against the player's
+      // 403, so early prey is genuinely catchable; at THE LAST LIGHT's 1.0 it
+      // makes 410 and nothing is safe.
+      const base = lev ? 240 : 300 + temper * 110
+      let speed = base * Math.pow(Math.max(18, rr) / 28, lev ? 0.35 : 0.42)
 
       // Surging costs a rival mass exactly as it costs the player, so a long
       // chase genuinely wears the hunter down and the leaderboard churns.
@@ -1093,7 +1577,7 @@ export class World {
     // 2. Is there prey worth chasing? Hunters and leviathans prefer the player.
     let bestPrey = -1
     let bestPreyScore = -1
-    const aggro = this.depth.temper + this.over * 0.25
+    const aggro = (this.depth.temper + this.over * 0.25) * this.pressure
     const wantsPlayer = (this.rhunter[i] === 1 || lev) && this.mass < m * 0.94 && this.invuln <= 0
     if (wantsPlayer) {
       const d = Math.hypot(x - this.px, y - this.py)
@@ -1219,8 +1703,10 @@ export class World {
         // Absorb once the mote is meaningfully inside you — the little bit of
         // required overlap is what makes a near-miss feel like a near-miss.
         if (d > pr - mr * 0.35) return
-        const gain = absorbGain(v, this.mass)
+        const gain = Math.max(1, Math.round(absorbGain(v, this.mass) * this.growth))
+        const before = this.mass
         this.mass += gain
+        this.note(before)
         this.absorbed++
         this.combo++
         this.malive[i] = 0
@@ -1285,7 +1771,9 @@ export class World {
         if (d < Math.max(rr, pr) && this.invuln <= 0) {
           if (this.mass > m * 1.06 && d < pr - rr * 0.5) {
             // You ate a rival. This is the payoff moment of the genre.
+            const before = this.mass
             this.mass += devourGain(m, this.mass)
+            this.note(before)
             this.combo++
             this.killRival(k, false)
             this.emit("kill", this.rx[k] as number, this.ry[k] as number, m, this.combo)
@@ -1352,7 +1840,9 @@ export class World {
     let target = Math.min(Math.max(hard, this.mass * 0.54), this.mass * 0.92)
     target = Math.max(target, hard)
     const lost = Math.max(0, this.mass - target)
+    const beforeRupture = this.mass
     this.mass = target
+    this.note(beforeRupture)
     this.ruptures++
     this.combo = 0
     this.invuln = 4.2
@@ -1399,10 +1889,18 @@ export class World {
     if (res.phase === 1 && res.t > 0.55) res.phase = 2
     if (res.phase === 2 && res.t > res.duration) {
       this.emit("resonance-fade", this.px, this.py, 0, 0)
+      // A question that went unanswered comes back LATER, not on the usual
+      // cadence. A player who is not engaging with the maths right now should
+      // not be interrupted every twenty seconds to be asked again — and while a
+      // Resonance is open the arena is inert, so a stream of ignored questions
+      // is also a stream of seconds in which the game is not a game.
+      this.nextResonanceAt = this.time + this.rng.range(40, 55)
       this.closeResonance()
       return
     }
-    if (res.phase === 3 && res.t > res.duration + 0.9) {
+    // A right answer resolves in a beat. A miss is held for the reveal, which
+    // is long and calm at the bottom of the ladder and absent at the top.
+    if (res.phase === 3 && res.t > res.duration + (res.wasCorrect ? 0.9 : Math.max(0.9, this.revealSeconds))) {
       this.closeResonance()
       return
     }
@@ -1415,7 +1913,7 @@ export class World {
       const dx = (this.mx[i] as number) - this.px
       const dy = (this.my[i] as number) - this.py
       const d = Math.hypot(dx, dy) || 1
-      const drift = res.phase === 2 ? 22 : 0
+      const drift = res.phase === 2 ? this.sphereDrift : 0
       const tangent = 0.32
       this.mvx[i] = (dx / d) * drift - (dy / d) * drift * tangent
       this.mvy[i] = (dy / d) * drift + (dx / d) * drift * tangent
@@ -1427,7 +1925,16 @@ export class World {
 
   private openResonance(): void {
     const res = this.resonance
-    const diff = Math.max(1, Math.min(10, Math.round(this.depth.difficulty + this.over * 2)))
+    // The difficulty comes from the BREATH, not from the depth.
+    //
+    // This one line is the founder's whole complaint about adaptation. It used
+    // to be `depth.difficulty + over * 2` — the depth is a ratchet that can
+    // never fall and the overdrive is a function of mass and the clock, so the
+    // questions got harder because time had passed and for no other reason. A
+    // child who had missed the last four in a row was handed a fifth that was
+    // harder than all of them. Now the rung is the rung the run's recent work
+    // has earned, and it goes down as readily as it goes up.
+    const diff = this.rung + 1
     let q: Question
     try {
       q = this.host.next({ difficulty: diff })
@@ -1485,10 +1992,11 @@ export class World {
     res.active = true
     res.phase = 1
     res.t = 0
-    res.duration = Math.max(6.5, 10.5 - this.resonanceCount * 0.16)
+    res.duration = this.resonanceSeconds
     res.question = q
     res.chosen = -1
     res.openedAt = performance.now()
+    res.openedT = this.time
     this.resonanceCount++
 
     const ringR = Math.max(viewSpanFor(this.mass) * 0.30, this.playerRTrue * 3.4)
@@ -1537,6 +2045,8 @@ export class World {
     res.wasCorrect = correct
     const ms = Math.round(performance.now() - res.openedAt)
     res.answerMs = ms
+    /** Thinking time on the simulation clock — deterministic, and what steers. */
+    const took = Math.max(0, this.time - res.openedT)
 
     try {
       this.host.report({
@@ -1549,6 +2059,17 @@ export class World {
       console.error("[arena] host.report failed", err)
     }
 
+    // The only place the breath is fed. A child's answers are the only evidence
+    // this game has about a child, and they are the only thing allowed to move
+    // the world's difficulty.
+    //
+    // The LATENCY goes in with the verdict, and it is what separates "already
+    // knew it" from "worked it out" — two outcomes that want opposite things
+    // from the world. ARENA has always measured this: `res.answerMs` is frozen
+    // at the moment of the answer and reported to the Host. It has simply never
+    // been used to decide anything until now.
+    this.success = observe(FLOW, this.success, correct, took)
+
     if (correct) {
       this.combo++
       const streak = Math.min(6, this.combo)
@@ -1560,7 +2081,13 @@ export class World {
       // Capped against the same sub-linear ceiling as everything else, or the
       // curriculum beat quietly becomes the exponential the rest of the economy
       // just stopped being.
-      const cap = Math.min(before * (0.30 + streak * 0.045), 26 * Math.sqrt(before) + 12)
+      // SPEED PAYS. Not "slowness costs" — the same measurement with the
+      // opposite valence, and the difference is the whole feel of the beat. A
+      // laboured correct answer earns the full base reward; a brisk one earns
+      // up to 70% more on top, and the celebration scales with it. Nothing is
+      // ever taken away for thinking.
+      const quick = quickness(FLOW, took)
+      const cap = Math.min(before * (0.30 + streak * 0.045), 26 * Math.sqrt(before) + 12) * (1 + 0.7 * quick)
       let gained = cap * 0.55
       const wave = this.playerRTrue * 7.5
       for (let i = 0; i < MAX_MOTES; i++) {
@@ -1575,6 +2102,7 @@ export class World {
       }
       const gain = gained
       this.mass += gain
+      this.note(before)
       for (let k = 0; k < MAX_RIVALS; k++) {
         if (!this.ralive[k]) continue
         const dx = (this.rx[k] as number) - this.px
@@ -1585,11 +2113,18 @@ export class World {
         this.rvy[k] = (dy / d) * 900
         this.rstate[k] = RS_FLEE
       }
-      this.emit("resonance-hit", this.px, this.py, gain, this.combo)
+      // `r` carries the quickness so the presentation layer can pay it out in
+      // spectacle as well as in mass, without recomputing anything.
+      this.emit("resonance-hit", this.px, this.py, gain, this.combo, quick)
       this.emit("shockwave", this.px, this.py, wave, 2)
       this.host.haptic("success")
     } else {
-      const loss = this.damage(this.mass * 0.24)
+      // A wrong answer cost a flat 24% of the run. That is a punishment aimed
+      // squarely at the child who is finding it hard, and it is the exact
+      // shape of thing this pass exists to remove: at the bottom of the ladder
+      // it is now 2%, a nudge, and it only becomes real stakes at the top —
+      // where the player climbed on purpose and the stakes are the point.
+      const loss = this.damage(this.mass * valueAt(this.intensity, 0.02, 0.14, "settle"))
       this.combo = 0
       this.emit("resonance-miss", this.mx[moteIndex] as number, this.my[moteIndex] as number, loss, res.correctSlot)
       this.host.haptic("failure")
@@ -1683,7 +2218,7 @@ export class World {
       })
     }
 
-    const want = Math.round(this.spec.motes * this.depth.density)
+    const want = this.moteBudget
     let guard = 40
     while (this.moteCount < want && guard-- > 0) this.spawnMote(false)
 
@@ -1702,8 +2237,24 @@ export class World {
       }
       // A rival that outgrows the ladder leaves; otherwise one lucky bot
       // snowballs off the top of the board and the run becomes unwinnable.
-      if (this.ralive[k] && !this.rleviathan[k] && (this.rmass[k] as number) > this.mass * 2.6) {
+      //
+      // **`!this.rleviathan[k]` was the bug.** Leviathans were exempt from this
+      // rule and from every other size rule, they are spawned at a multiple of
+      // your mass, they eat, and a rupture cuts your own mass by nearly half —
+      // so the ratio compounds and nothing ever collected it. Measured over a
+      // five-minute seeded run: the largest core on the field reached 27.4x the
+      // player's mass, which is 1.99 times the WIDTH of a phone held tall.
+      // Exactly the founder's "they can get so big that they are bigger than
+      // the whole screen ... they just basically envelope me and I can't do
+      // anything". A creature that fills the screen and cannot be escaped is
+      // not difficulty; it is a coin flip.
+      //
+      // So the rule applies to everything, with the leviathan allowed a bigger
+      // ceiling because being frightening is its entire job. See
+      // `RIVAL_MAX_RATIO` for where the two numbers come from.
+      if (this.ralive[k] && (this.rmass[k] as number) > this.mass * this.rivalCeiling(k)) {
         this.ralive[k] = 0
+        this.rleviathan[k] = 0
         this.rhunter[k] = 0
         this.rivalCount--
         this.rrespawn[k] = this.rng.range(0.8, 2.0)
@@ -1717,7 +2268,7 @@ export class World {
       }
     }
 
-    if (this.rivalCount < this.spec.rivals) this.spawnRival(false)
+    if (this.rivalCount < this.rivalBudget) this.spawnRival(false)
 
     if (this.depth.leviathan) {
       let has = false

--- a/dynawalla/games/arena/src/ui/hud.ts
+++ b/dynawalla/games/arena/src/ui/hud.ts
@@ -53,6 +53,32 @@ export const DEPTH_H = 62
 export const Q_EDGE = 12
 
 /**
+ * THE RIBBON — the running equation.
+ *
+ * The founder's idea and the best one in the batch: "it might be nice to have
+ * an animation of the math as we 'eat' numbers it could show the simple
+ * equation, maybe fixed to the bottom that replaces as it goes: 10 + 4 = 14 /
+ * 14 + 10 = 24 / 24 - 5 = 19". It turns eating numbers into arithmetic that is
+ * VISIBLE and reviewable rather than implicit, which is the difference between
+ * a growth game with numbers on it and a maths game.
+ *
+ * Three constraints decide where it goes, and all three are asserted in
+ * `layout.test.ts` rather than eyeballed on one phone:
+ *
+ *   * clear of the host's two 44px corners — it is a thing a child reads;
+ *   * clear of the safe-area insets on every edge it touches;
+ *   * clear of ARENA's own bottom-left sound button and bottom-right perf
+ *     readout, which are 44px and sit exactly where a bottom strip wants to be.
+ *
+ * `RIBBON_LIFT` is that third clearance: the button row is 44 tall on a 12px
+ * bottom margin, so the ribbon's own bottom edge starts above all of it.
+ */
+export const RIBBON_LIFT = 56
+export const RIBBON_H = 40
+export const RIBBON_EDGE = 12
+export const RIBBON_MAX_W = 460
+
+/**
  * Where the readouts land, in numbers, so a test can assert they clear the
  * host's two corners at every viewport instead of a device finding out.
  *
@@ -66,17 +92,40 @@ export const Q_EDGE = 12
 export function hudRects(
   w: number,
   insets: Insets = { top: 0, right: 0, bottom: 0, left: 0 },
-): { depth: Rect; board: Rect; question: Rect } {
+  h = 0,
+): { depth: Rect; board: Rect; question: Rect; ribbon: Rect } {
   const top = insets.top + HUD_TOP
   const left = Math.max(HUD_EDGE, insets.left)
   const right = Math.max(HUD_EDGE, insets.right)
   const qLeft = Math.max(Q_EDGE, insets.left)
   const qRight = Math.max(Q_EDGE, insets.right)
+
+  // The ribbon is anchored to the BOTTOM, so it is the one readout whose rect
+  // needs the viewport height. It is centred inside the safe edges and capped,
+  // exactly as the CSS below does it.
+  const rLeft = Math.max(RIBBON_EDGE, insets.left)
+  const rRight = Math.max(RIBBON_EDGE, insets.right)
+  const rAvail = Math.max(0, w - rLeft - rRight)
+  const rW = Math.min(RIBBON_MAX_W, rAvail)
+  const rBottom = Math.max(RIBBON_EDGE, insets.bottom) + RIBBON_LIFT
   return {
     depth: { x: left, y: top, w: Math.min(DEPTH_W, w - left - right), h: DEPTH_H },
     board: { x: Math.max(0, w - right - BOARD_W), y: top, w: BOARD_W, h: BOARD_H },
     question: { x: qLeft, y: top, w: Math.max(0, w - qLeft - qRight), h: 96 },
+    ribbon: { x: rLeft + (rAvail - rW) / 2, y: h - rBottom - RIBBON_H, w: rW, h: RIBBON_H },
   }
+}
+
+/**
+ * The 44px square ARENA's own sound button occupies, bottom-LEFT.
+ *
+ * Exported for the same reason `hudRects` is: the ribbon has to clear it, and
+ * "has to clear it" is a claim a test should be able to check rather than a
+ * claim a comment makes.
+ */
+export function soundRect(h: number, insets: Insets = { top: 0, right: 0, bottom: 0, left: 0 }): Rect {
+  const bottom = Math.max(12, insets.bottom)
+  return { x: Math.max(12, insets.left), y: h - bottom - 44, w: 44, h: 44 }
 }
 
 const CSS = `
@@ -100,7 +149,35 @@ const CSS = `
   box-shadow:inset 0 0 0 1px rgba(140,240,255,.28);color:#eafcff}
 .arena-row .n{opacity:.72}
 .arena-row .v{font-weight:800}
-.arena-combo{position:absolute;left:50%;bottom:max(16px,env(safe-area-inset-bottom));transform:translate(-50%,0);
+/* THE RIBBON. Pinned above the button row, centred inside the safe edges, and
+   carrying its OWN scrim — a plate and a blur — because the frame behind it can
+   legitimately be a white bloom-out and a maths product may not have the one
+   line of arithmetic on screen be the thing that disappears. Tabular numerals,
+   so a replacing line does not jitter its own digits sideways. */
+.arena-eq{position:absolute;left:max(${RIBBON_EDGE}px,env(safe-area-inset-left));right:max(${RIBBON_EDGE}px,env(safe-area-inset-right));
+  bottom:calc(max(${RIBBON_EDGE}px,env(safe-area-inset-bottom)) + ${RIBBON_LIFT}px);
+  max-width:${RIBBON_MAX_W}px;margin-inline:auto;height:${RIBBON_H}px;
+  display:grid;place-items:center;pointer-events:none}
+.arena-eq>span{display:inline-block;padding:6px 16px;border-radius:8px;
+  background:rgba(2,10,20,.72);box-shadow:inset 0 0 0 1px rgba(140,235,255,.20),0 2px 14px rgba(0,0,0,.55);
+  backdrop-filter:blur(7px);-webkit-backdrop-filter:blur(7px);
+  font-size:clamp(15px,4.2vw,26px);font-weight:800;letter-spacing:.06em;font-variant-numeric:tabular-nums;
+  color:#eafcff;text-shadow:0 1px 3px rgba(0,0,0,.95);white-space:nowrap;
+  opacity:0;transform:translateY(5px) scale(.97);
+  transition:opacity .16s,transform .26s cubic-bezier(.16,1.2,.3,1)}
+.arena-eq.on>span{opacity:1;transform:none}
+/* The maths moment gets the ribbon too, and gets it LOUDER. A right answer is
+   the biggest thing that happens in this game and the sum that earned it should
+   be the biggest thing in the strip. */
+.arena-eq.solved>span{background:rgba(6,26,20,.80);color:#ffffff;
+  box-shadow:inset 0 0 0 1px rgba(150,255,220,.55),0 0 30px rgba(120,255,210,.45),0 2px 14px rgba(0,0,0,.6);
+  font-size:clamp(19px,5.6vw,34px)}
+/* The reveal. A quieter celebration, never a correction: the same plate, a cool
+   calm light instead of the green flare, and no red anywhere. */
+.arena-eq.reveal>span{background:rgba(4,18,32,.80);color:#eafcff;
+  box-shadow:inset 0 0 0 1px rgba(150,220,255,.45),0 0 22px rgba(110,190,255,.28),0 2px 14px rgba(0,0,0,.6);
+  font-size:clamp(17px,5vw,30px)}
+.arena-combo{position:absolute;left:50%;bottom:calc(max(16px,env(safe-area-inset-bottom)) + ${RIBBON_LIFT + RIBBON_H + 8}px);transform:translate(-50%,0);
   font-size:clamp(14px,4vw,26px);font-weight:900;letter-spacing:.10em;opacity:0;transition:opacity .18s;
   text-shadow:0 0 26px rgba(120,255,220,.7),0 2px 8px rgba(0,0,0,.9);font-variant-numeric:tabular-nums}
 .arena-combo.on{opacity:.95}
@@ -146,7 +223,7 @@ const CSS = `
 .arena-perf{position:absolute;right:max(12px,env(safe-area-inset-right));bottom:max(12px,env(safe-area-inset-bottom));
   font-size:10px;letter-spacing:.14em;opacity:.28;font-variant-numeric:tabular-nums;font-weight:700}
 @media (max-width:360px){.arena-board{min-width:92px}}
-@media (prefers-reduced-motion:reduce){.arena-q,.arena-verdict,.arena-combo,.arena-btn{transition-duration:.01ms}}
+@media (prefers-reduced-motion:reduce){.arena-q,.arena-verdict,.arena-combo,.arena-btn,.arena-eq>span{transition-duration:.01ms}}
 `
 
 const ROWS = 6
@@ -157,6 +234,8 @@ export class Hud {
   private depthSub: HTMLElement
   private rows: { el: HTMLDivElement; name: HTMLSpanElement; val: HTMLSpanElement }[] = []
   private comboEl: HTMLDivElement
+  private eqEl: HTMLDivElement
+  private eqText: HTMLSpanElement
   private qEl: HTMLDivElement
   private qPrompt: HTMLDivElement
   private verdictEl: HTMLDivElement
@@ -175,6 +254,17 @@ export class Hud {
   private readonly lastRowKey: string[] = new Array(ROWS).fill("")
   private boardTimer = 0
   private verdictTimer = 0
+  private lastEqSeq = -1
+  private eqTimer = 0
+  /**
+   * Seconds the maths moment's own equation owns the ribbon.
+   *
+   * While this is running the ordinary mass ledger cannot overwrite it, and it
+   * has to be able to: a correct answer clears every mote inside seven player
+   * radii, so the frame after "3 + 5 = 8" carries a dozen absorbs that would
+   * otherwise wipe the sum off the screen before a child had read it.
+   */
+  private eqHold = 0
 
   constructor(container: HTMLElement, onToggleSound: (on: boolean) => boolean) {
     const style = document.createElement("style")
@@ -221,6 +311,11 @@ export class Hud {
     this.comboEl = document.createElement("div")
     this.comboEl.className = "arena-combo"
 
+    this.eqEl = document.createElement("div")
+    this.eqEl.className = "arena-eq"
+    this.eqText = document.createElement("span")
+    this.eqEl.appendChild(this.eqText)
+
     this.qEl = document.createElement("div")
     this.qEl.className = "arena-q"
     const k = document.createElement("div")
@@ -254,7 +349,7 @@ export class Hud {
     this.perfEl = document.createElement("div")
     this.perfEl.className = "arena-perf"
 
-    this.root.append(this.depthEl, board, this.comboEl, this.qEl, this.verdictEl, btns, this.perfEl)
+    this.root.append(this.depthEl, board, this.comboEl, this.eqEl, this.qEl, this.verdictEl, btns, this.perfEl)
     container.appendChild(this.root)
   }
 
@@ -262,6 +357,33 @@ export class Hud {
     if (band === this.lastEarned) return
     this.lastEarned = band
     for (let i = 0; i < this.pips.length; i++) this.pips[i]!.classList.toggle("on", i <= band)
+  }
+
+  /**
+   * The equation for one piece of arithmetic. Formatting only — the numbers are
+   * decided in the simulation, where they are guaranteed consistent.
+   *
+   * U+2212 MINUS SIGN, not a hyphen: this is a maths product and the glyph a
+   * child reads on a worksheet is the one they should read here.
+   */
+  static line(a: number, d: number, c: number): string {
+    return d < 0 ? `${a} − ${-d} = ${c}` : `${a} + ${d} = ${c}`
+  }
+
+  /**
+   * Put a whole piece of arithmetic in the ribbon and hold it there.
+   *
+   * `solved` is the celebration; `reveal` is the patient completion after a
+   * miss. The reveal is deliberately styled as a quieter version of the
+   * celebration rather than as its opposite — no red, no cross, nothing a child
+   * could read as being told off. It is the same sum, shown calmly.
+   */
+  showEquation(text: string, seconds: number, kind: "solved" | "reveal"): void {
+    this.eqText.textContent = text
+    this.eqEl.classList.remove("solved", "reveal")
+    this.eqEl.classList.add("on", kind)
+    this.eqTimer = seconds
+    this.eqHold = seconds
   }
 
   showVerdict(text: string, color: string): void {
@@ -319,6 +441,22 @@ export class Hud {
       } else {
         this.comboEl.classList.remove("on")
       }
+    }
+
+    // The ribbon. Every change to the player's own number, replacing as it goes.
+    this.eqHold = Math.max(0, this.eqHold - dt)
+    if (world.eqSeq !== this.lastEqSeq) {
+      this.lastEqSeq = world.eqSeq
+      if (this.eqHold <= 0) {
+        this.eqText.textContent = Hud.line(world.eqA, world.eqD, world.eqC)
+        this.eqEl.classList.add("on")
+        this.eqEl.classList.remove("solved", "reveal")
+        this.eqTimer = 2.6
+      }
+    }
+    if (this.eqTimer > 0) {
+      this.eqTimer -= dt
+      if (this.eqTimer <= 0) this.eqEl.classList.remove("on", "solved", "reveal")
     }
 
     this.setRungs(world.depth.index)

--- a/dynawalla/games/arena/src/ui/layout.test.ts
+++ b/dynawalla/games/arena/src/ui/layout.test.ts
@@ -18,7 +18,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
-import { BOARD_W, DEPTH_W, HUD_EDGE, HUD_TOP, hudRects } from "./hud.ts"
+import { BOARD_W, DEPTH_W, HUD_EDGE, HUD_TOP, RIBBON_H, hudRects, soundRect } from "./hud.ts"
 
 const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
 
@@ -40,7 +40,7 @@ for (const [name, w, h] of VIEWPORTS) {
     ["a notch", w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT],
   ] as const) {
     test(`the readouts clear the host's corners at ${name} (${w}×${h}, ${insetName})`, () => {
-      const r = hudRects(w, insets)
+      const r = hudRects(w, insets, h)
 
       assert.equal(
         hitsHostChrome(r.depth, w, insets),
@@ -59,6 +59,14 @@ for (const [name, w, h] of VIEWPORTS) {
         false,
         `${w}×${h}: the Resonance question is under host chrome`,
       )
+      // The ribbon is the running equation — the single most read thing on the
+      // screen in a maths game, and it is anchored to the opposite edge from
+      // everything else here, so it needs its own assertion at every viewport.
+      assert.equal(
+        hitsHostChrome(r.ribbon, w, insets),
+        false,
+        `${w}×${h}: the equation ribbon is under host chrome`,
+      )
     })
   }
 }
@@ -66,7 +74,7 @@ for (const [name, w, h] of VIEWPORTS) {
 test("the readouts stay inside the safe area on every edge they touch", () => {
   for (const [name, w, h] of VIEWPORTS) {
     const insets = w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT
-    const r = hudRects(w, insets)
+    const r = hudRects(w, insets, h)
 
     // Left, right and top. A HUD that pads only the top is correct in portrait
     // on one device and wrong the moment the child turns the tablet.
@@ -91,4 +99,53 @@ test("the constants are the ones the host publishes, not numbers somebody typed"
   // again; this is the inequality the whole file exists to hold.
   assert.ok(HUD_TOP >= 57, `HUD_TOP is ${HUD_TOP} — the host's corners end at 57`)
   assert.ok(HUD_EDGE > 0 && BOARD_W > 0 && DEPTH_W > 0)
+})
+
+// THE RIBBON.
+//
+// It is anchored to the BOTTOM, which is the one edge nothing else in this file
+// tested, and the bottom of an ARENA frame is already occupied: the sound
+// button is a 44px square in the bottom-left and the perf readout sits in the
+// bottom-right. A strip pinned to the bottom lands on both unless it is lifted
+// clear, and "lifted clear" is arithmetic, not judgement.
+
+const overlaps = (a: { x: number; y: number; w: number; h: number }, b: typeof a): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+for (const [name, w, h] of VIEWPORTS) {
+  for (const [insetName, insets] of [
+    ["no insets", NONE],
+    ["a notch", w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT],
+  ] as const) {
+    test(`the equation ribbon is legible and unobstructed at ${name} (${w}×${h}, ${insetName})`, () => {
+      const r = hudRects(w, insets, h).ribbon
+
+      assert.equal(hitsHostChrome(r, w, insets), false, `${w}×${h}: the ribbon is under host chrome`)
+      assert.ok(r.x >= insets.left, `${w}×${h}: the ribbon runs into the left inset`)
+      assert.ok(r.x + r.w <= w - insets.right, `${w}×${h}: the ribbon runs into the right inset`)
+      assert.ok(
+        r.y + r.h <= h - insets.bottom,
+        `${w}×${h}: the ribbon runs under the home indicator`,
+      )
+      assert.ok(r.y >= insets.top, `${w}×${h}: the ribbon runs under the notch`)
+      assert.equal(
+        overlaps(r, soundRect(h, insets)),
+        false,
+        `${w}×${h}: the ribbon sits on ARENA's own sound button`,
+      )
+      // It has to be wide enough to hold the longest line the game can print.
+      // "1301388804 − 1301388804 = 0" is 26 characters; at the ribbon's smallest
+      // clamp step of 15px that is roughly 250px of tabular digits.
+      assert.ok(r.w >= 250, `${w}×${h}: the ribbon is only ${r.w}px wide — a long equation cannot fit`)
+      assert.equal(r.h, RIBBON_H)
+    })
+  }
+}
+
+test("the ribbon is centred, and stays centred inside an asymmetric notch", () => {
+  const w = 844
+  const r = hudRects(w, NOTCH_LANDSCAPE, 390).ribbon
+  const leftGap = r.x - NOTCH_LANDSCAPE.left
+  const rightGap = w - NOTCH_LANDSCAPE.right - (r.x + r.w)
+  assert.ok(Math.abs(leftGap - rightGap) < 1, `the ribbon is off-centre by ${Math.abs(leftGap - rightGap)}px`)
 })

--- a/dynawalla/packs/shared/game-pacing/README.md
+++ b/dynawalla/packs/shared/game-pacing/README.md
@@ -1,0 +1,46 @@
+# game-pacing
+
+One number, `intensity` in `[0,1]`, that drives a game's **maths difficulty**,
+its **speed** and its **density** together, in both directions.
+
+```ts
+import {
+  SECOND_GRADE_FLOW, observe, settle, seedSuccess,
+  countAt, valueAt, rungAt, revealMs,
+} from "../../packs/shared/game-pacing/index.ts"
+
+// state the GAME owns
+let intensity = SECOND_GRADE_FLOW.start
+let success = seedSuccess(SECOND_GRADE_FLOW)
+let rung = 0
+
+// once per frame
+intensity = settle(SECOND_GRADE_FLOW, intensity, success, dt)
+rung = rungAt(intensity, DIFFICULTY_RUNGS, rung)
+
+// once per answer — `seconds` is thinking time on YOUR clock, not the wall's
+success = observe(SECOND_GRADE_FLOW, success, correct, seconds)
+
+// spend it
+const enemies = countAt(intensity, 4, 26)
+const speed = valueAt(intensity, 300, 520)
+const holdTheAnswerMs = revealMs(SECOND_GRADE_FLOW, intensity)
+```
+
+## The rules it encodes
+
+* **Drops on a single failure, climbs on sustained success** — and the climb
+  rate scales with the strength of the evidence, so a competent player is never
+  trapped walking every rung from `0 + 1`.
+* **Time is measured and rewarded, never imposed.** `quickness()` is a bonus
+  signal. A countdown, if a game has one, is something a player earns.
+* **Silent.** No strings. Nothing here can be rendered, so nothing here can tell
+  a child what it thinks of them.
+* **Bounded, with a trivial floor and a patient reveal at it.** At the bottom
+  the game's job is exposure and confidence, not throughput.
+
+## Rules for this module
+
+Pure functions over plain numbers. No DOM, no rendering, no timers, no module
+state — `tsconfig.json` omits `"DOM"` from `lib` so the compiler enforces it.
+The game owns every piece of state; this only ever computes the next value.

--- a/dynawalla/packs/shared/game-pacing/curve.ts
+++ b/dynawalla/packs/shared/game-pacing/curve.ts
@@ -1,0 +1,120 @@
+/**
+ * The mapping seam: ONE intensity in, a game's own constants out.
+ *
+ * `flow.ts` produces a single number in [0,1] — how hard the world is pushing
+ * right now. This file is how a game spends it. Nothing here knows what a mote
+ * or a spawn interval is; the game supplies both ends of every range and this
+ * supplies the walk between them.
+ *
+ * Pure arithmetic. No DOM, no state, no allocation.
+ */
+
+/** How a range is distributed across the intensity it is driven by. */
+export type Curve =
+  /** Even. Half the intensity is half the range. */
+  | "linear"
+  /** Back-loaded. Most of the range is spent low; the top arrives late. */
+  | "gentle"
+  /** Front-loaded. Leaves the calm quickly, then eases into the top. */
+  | "steep"
+  /** Smoothstep. No corner at either end. */
+  | "settle"
+
+export const clamp01 = (x: number): number => (Number.isNaN(x) ? 0 : x < 0 ? 0 : x > 1 ? 1 : x)
+
+/** Shape `u` in [0,1]. Monotone on [0,1] for every curve, and fixes both ends. */
+export function curved(u: number, curve: Curve = "linear"): number {
+  const t = clamp01(u)
+  switch (curve) {
+    case "linear":
+      return t
+    case "gentle":
+      return t * t
+    case "steep":
+      return 1 - (1 - t) * (1 - t)
+    case "settle":
+      return t * t * (3 - 2 * t)
+  }
+}
+
+/** The inverse of `curved`. Exact rather than a search — every curve inverts. */
+export function uncurved(v: number, curve: Curve = "linear"): number {
+  const t = clamp01(v)
+  switch (curve) {
+    case "linear":
+      return t
+    case "gentle":
+      return Math.sqrt(t)
+    case "steep":
+      return 1 - Math.sqrt(1 - t)
+    case "settle": {
+      // Closed-form inverse of the smoothstep. It goes through `asin`/`sin`,
+      // which leaves 5.5e-17 where it should leave 0 — and a demand of
+      // 5.5e-17 instead of the floor is a world that is very slightly not at
+      // rest, forever. Snap both ends.
+      const u = 0.5 - Math.sin(Math.asin(1 - 2 * t) / 3)
+      return u < 1e-12 ? 0 : u > 1 - 1e-12 ? 1 : u
+    }
+  }
+}
+
+/**
+ * A scalar that walks from `atCalm` to `atFull` as intensity rises.
+ *
+ * `atCalm` may be the LARGER of the two — a spawn interval, a grace period or a
+ * question's time limit all get shorter as the world pushes harder, and that is
+ * the same walk read the other way. This is the function a game calls for
+ * speed, radius, interval, anything continuous.
+ */
+export function valueAt(intensity: number, atCalm: number, atFull: number, curve: Curve = "linear"): number {
+  return atCalm + (atFull - atCalm) * curved(intensity, curve)
+}
+
+/**
+ * An entity budget: how many of a thing may exist at this intensity.
+ *
+ * Rounded, then clamped into the range the caller named. The clamp is not
+ * decoration: `Math.round` of a value a hair outside the range is exactly how a
+ * fixed-size pool gets asked for one more slot than it owns, and this module is
+ * meant to be safe to wire straight into a spawner.
+ */
+export function countAt(intensity: number, atCalm: number, atFull: number, curve: Curve = "linear"): number {
+  const lo = Math.min(atCalm, atFull)
+  const hi = Math.max(atCalm, atFull)
+  const v = Math.round(valueAt(intensity, atCalm, atFull, curve))
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/**
+ * A rung on an ordered ladder — the curriculum seam.
+ *
+ * The ladder itself is NOT defined here. Its length and its ordering belong to
+ * the curriculum, and a game passes in however many rungs its host actually
+ * offers. This decides only which one the current intensity is standing on.
+ *
+ * **Hysteresis, and why it is not optional.** Without `current`, a difficulty
+ * that sits on a band edge flickers between two rungs every frame, and a child
+ * gets alternating easy and hard questions for no reason they can see. Pass the
+ * rung you are on and this will move at most ONE rung at a time, and only once
+ * intensity has travelled `margin` past the boundary. Falling and rising
+ * therefore happen at different intensities, which is what "smoothly" means
+ * when a continuous quantity drives a discrete one.
+ */
+export function rungAt(
+  intensity: number,
+  rungs: number,
+  current?: number,
+  margin = 0.04,
+): number {
+  const n = Math.max(1, Math.floor(rungs))
+  const i = clamp01(intensity)
+  const raw = Math.min(n - 1, Math.floor(i * n))
+  if (current === undefined || !Number.isFinite(current)) return raw
+  const cur = Math.min(n - 1, Math.max(0, Math.floor(current)))
+  if (raw === cur) return cur
+  const top = (cur + 1) / n
+  const bottom = cur / n
+  if (raw > cur && i >= top + margin) return cur + 1
+  if (raw < cur && i <= bottom - margin) return cur - 1
+  return cur
+}

--- a/dynawalla/packs/shared/game-pacing/flow.test.ts
+++ b/dynawalla/packs/shared/game-pacing/flow.test.ts
@@ -1,0 +1,425 @@
+// The four properties the founder asked for, asserted rather than commented.
+//
+// Every test here was mutation-checked: the line in `flow.ts` or `curve.ts`
+// that implements the property was deleted or inverted, and the named
+// assertion is the one that fired.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  SECOND_GRADE_FLOW,
+  countAt,
+  curved,
+  demandFor,
+  observe,
+  outcomeScore,
+  rungAt,
+  revealMs,
+  revealShown,
+  secondsBetween,
+  seedSuccess,
+  settle,
+  uncurved,
+  valueAt,
+  type Curve,
+  type FlowSpec,
+} from "./index.ts"
+
+const CURVES: Curve[] = ["linear", "gentle", "steep", "settle"]
+const S = SECOND_GRADE_FLOW
+
+/** Drive the controller for `seconds` with a fixed answer cadence. */
+function run(
+  spec: FlowSpec,
+  seconds: number,
+  opts: { correct: boolean; everySeconds: number; from?: number; answerSeconds?: number },
+) {
+  let intensity = opts.from ?? spec.start
+  let success = seedSuccess(spec, intensity)
+  const dt = 1 / 60
+  let sinceAnswer = 0
+  for (let f = 0; f < seconds * 60; f++) {
+    sinceAnswer += dt
+    if (sinceAnswer >= opts.everySeconds) {
+      sinceAnswer = 0
+      success = observe(spec, success, opts.correct, opts.answerSeconds)
+    }
+    intensity = settle(spec, intensity, success, dt)
+  }
+  return { intensity, success }
+}
+
+// -- 1. asymmetric ----------------------------------------------------------
+
+test("relief is immediate and predictable", () => {
+  const down = secondsBetween(S, S.ceiling, S.floor)
+  assert.equal(down, S.fallSeconds, "falling must stay linear — relief is the half that has to be predictable")
+  const fell = run(S, S.fallSeconds + 5, { correct: false, everySeconds: 4, from: 1 })
+  assert.ok(fell.intensity <= S.floor + 1e-9, `struggle did not reach the floor: ${fell.intensity}`)
+})
+
+test("a competent player is NOT trapped at the bottom of the ladder", () => {
+  // The founder's correction, and the reason "climbs slow" was wrong: everybody
+  // starts at 0 + 1, and an adult made to walk every rung quits.
+  const quick = run(S, 75, { correct: true, everySeconds: 22, answerSeconds: 1.4, from: S.floor })
+  assert.ok(
+    quick.intensity > 0.7,
+    `three fast correct answers in 75s only reached ${quick.intensity.toFixed(2)} — an adult is trapped at 0 + 1`,
+  )
+})
+
+test("correct-but-slow holds roughly steady — that is where you want a child", () => {
+  // Nine seconds is the curriculum's own p50 for this skill. It must neither
+  // punish nor promote; it must park you mid-ladder and leave you there.
+  const from = 0.5
+  const slow = run(S, 420, { correct: true, everySeconds: 20, answerSeconds: 9, from })
+  assert.ok(
+    Math.abs(slow.intensity - from) < 0.22,
+    `working steadily at the curriculum's own median speed moved the world ${from} -> ${slow.intensity.toFixed(2)}`,
+  )
+  // …and it is strictly between the two extremes, not at either end.
+  assert.ok(slow.intensity > S.floor + 0.1 && slow.intensity < S.ceiling - 0.1)
+})
+
+test("evidence strength, not just correctness, decides how fast the climb is", () => {
+  const fast = run(S, 120, { correct: true, everySeconds: 20, answerSeconds: 1, from: S.floor })
+  const slow = run(S, 120, { correct: true, everySeconds: 20, answerSeconds: 11.5, from: S.floor })
+  assert.ok(
+    fast.intensity > slow.intensity + 0.25,
+    `fast (${fast.intensity.toFixed(2)}) and slow (${slow.intensity.toFixed(2)}) correct answers climbed the same — latency is being ignored`,
+  )
+})
+
+test("outcomeScore reads latency the way the curriculum does", () => {
+  assert.equal(outcomeScore(S, false, 0.1), 0, "a wrong answer is worth nothing however fast it was")
+  assert.equal(outcomeScore(S, false, 30), 0)
+  assert.equal(outcomeScore(S, true, 0), 1)
+  assert.equal(outcomeScore(S, true, S.briskSeconds), 1)
+  assert.equal(outcomeScore(S, true, S.laboredSeconds), S.laboredScore)
+  assert.equal(outcomeScore(S, true, 60), S.laboredScore, "slower than labored is still just labored, never worse")
+  assert.equal(
+    outcomeScore(S, true, undefined),
+    S.laboredScore,
+    "a game that cannot see the clock must get the CONSERVATIVE reading, not a free full mark",
+  )
+  // Monotone in speed.
+  let prev = -Infinity
+  for (let sec = 30; sec >= 0; sec -= 0.25) {
+    const v = outcomeScore(S, true, sec)
+    assert.ok(v >= prev - 1e-12, `score fell as the answer got faster, at ${sec}s`)
+    prev = v
+  }
+  // The curriculum's p50 lands in the middle, which is the calibration claim.
+  const p50 = outcomeScore(S, true, 9)
+  assert.ok(p50 > 0.6 && p50 < 0.8, `the curriculum p50 of 9s scored ${p50} — it must sit mid-ladder`)
+})
+
+test("one wrong answer does not yo-yo the world", () => {
+  // A child at the top who slips once must lose ground, but not the run.
+  const spec = S
+  let intensity = spec.ceiling
+  let success = seedSuccess(spec, spec.ceiling)
+  success = observe(spec, success, false, 5)
+  for (let f = 0; f < 60 * 10; f++) intensity = settle(spec, intensity, success, 1 / 60)
+  assert.ok(intensity < spec.ceiling, "a wrong answer must actually cost something")
+  assert.ok(
+    intensity > 0.5,
+    `one mistake took the world from 1.00 to ${intensity.toFixed(2)} in ten seconds — that is a yo-yo, not a breath`,
+  )
+})
+
+// -- 2. smoothed ------------------------------------------------------------
+
+test("the estimate is a moving one, so no single answer flips the world", () => {
+  let s = 1
+  s = observe(S, s, false, 5)
+  assert.ok(s > 0.5, `one wrong answer took the estimate from 1.00 to ${s} — that is a per-answer flip`)
+  assert.ok(s < 1, "…but it must move")
+  // It converges, from either side, and never leaves [0,1].
+  let hi = 0
+  for (let i = 0; i < 200; i++) hi = observe(S, hi, true, 0.5)
+  assert.ok(hi > 0.99 && hi <= 1)
+  let lo = 1
+  for (let i = 0; i < 200; i++) lo = observe(S, lo, false, 5)
+  assert.ok(lo < 0.01 && lo >= 0)
+  // A larger window is genuinely smoother.
+  const wide: FlowSpec = { ...S, window: 20 }
+  assert.ok(observe(wide, 1, false, 5) > observe(S, 1, false, 5), "a wider window must react less, not more")
+})
+
+test("intensity moves continuously — no step in a single frame is visible", () => {
+  const spec = S
+  let intensity = 1
+  const success = 0
+  let biggest = 0
+  for (let f = 0; f < 60 * 120; f++) {
+    const next = settle(spec, intensity, success, 1 / 60)
+    biggest = Math.max(biggest, Math.abs(next - intensity))
+    intensity = next
+  }
+  assert.ok(
+    biggest <= 1 / spec.fallSeconds / 60 + 1e-9,
+    `a single frame moved intensity by ${biggest} — "smoothly" is load-bearing`,
+  )
+  // …and climbing, where the rate is gap-scaled and therefore larger, is still
+  // far below anything a frame could show as a jump.
+  let up = 0
+  let x = 0
+  for (let f = 0; f < 60 * 120; f++) {
+    const next = settle(spec, x, 1, 1 / 60)
+    up = Math.max(up, next - x)
+    x = next
+  }
+  assert.ok(up < 0.02, `the fastest single climbing frame moved intensity by ${up}`)
+})
+
+// -- 3. silent --------------------------------------------------------------
+
+test("the module has nothing a child could read", () => {
+  // A structural assertion, not a stylistic one: the moment this module grows a
+  // string it has grown an opinion about a child that could be rendered.
+  const exported: unknown[] = [
+    SECOND_GRADE_FLOW, observe, outcomeScore, demandFor, seedSuccess, settle, secondsBetween,
+    curved, uncurved, valueAt, countAt, rungAt,
+  ]
+  for (const e of exported) {
+    assert.notEqual(typeof e, "string", "a string escaped the pacing module")
+  }
+  for (const v of Object.values(SECOND_GRADE_FLOW)) {
+    assert.ok(
+      typeof v === "number" || CURVES.includes(v as Curve),
+      `the spec carries ${JSON.stringify(v)} — the only strings allowed here are curve names`,
+    )
+  }
+})
+
+// -- 4. bounded -------------------------------------------------------------
+
+test("the floor is a real destination and the ceiling is a real limit", () => {
+  const spec = S
+  // Sustained struggle parks at the floor and STAYS there — it does not creep
+  // back up on its own, because nothing here is on a timer.
+  let intensity = 1
+  let success = seedSuccess(spec, 1)
+  for (let f = 0; f < 60 * 600; f++) {
+    if (f % 240 === 0) success = observe(spec, success, false, 5)
+    intensity = settle(spec, intensity, success, 1 / 60)
+    assert.ok(intensity >= spec.floor - 1e-9 && intensity <= spec.ceiling + 1e-9, `intensity left its bounds: ${intensity}`)
+  }
+  assert.ok(Math.abs(intensity - spec.floor) < 1e-9, `ten minutes of struggle settled at ${intensity}, not at the floor`)
+})
+
+test("a perfect run reaches the ceiling, and an even run sits in the middle", () => {
+  const perfect = run(S, S.climbSeconds + 30, { correct: true, everySeconds: 5, answerSeconds: 1 })
+  assert.ok(perfect.intensity > 0.99, `unbroken success only reached ${perfect.intensity}`)
+
+  // Alternating right and wrong is a 50% success rate, which is below
+  // `strugglingBelow` — that is deliberate. Half wrong is struggling.
+  const spec = S
+  let intensity = 0.9
+  let success = seedSuccess(spec, 0.9)
+  for (let f = 0; f < 60 * 400; f++) {
+    if (f % 300 === 0) success = observe(spec, success, (f / 300) % 2 === 0, 2)
+    intensity = settle(spec, intensity, success, 1 / 60)
+  }
+  assert.ok(intensity < 0.35, `a 50% success rate parked at ${intensity} — half wrong should be a calm world`)
+})
+
+test("demandFor is monotone, flat at both marks, and respects a shifted range", () => {
+  let prev = -Infinity
+  for (let s = 0; s <= 1.0001; s += 0.005) {
+    const d = demandFor(S, s)
+    assert.ok(d >= prev - 1e-12, `demand FELL as success rose, at ${s}`)
+    assert.ok(d >= S.floor - 1e-12 && d <= S.ceiling + 1e-12)
+    prev = d
+  }
+  assert.equal(demandFor(S, 0), S.floor)
+  assert.equal(demandFor(S, S.strugglingBelow), S.floor)
+  assert.equal(demandFor(S, S.strugglingBelow - 0.2), S.floor, "everything below the low mark wants the same easy world")
+  assert.equal(demandFor(S, S.thrivingAbove), S.ceiling)
+  assert.equal(demandFor(S, 1), S.ceiling)
+
+  const shifted: FlowSpec = { ...S, floor: 0.2, ceiling: 0.8 }
+  assert.equal(demandFor(shifted, 0), 0.2)
+  assert.equal(demandFor(shifted, 1), 0.8)
+})
+
+test("seedSuccess round-trips, so a fresh run starts at rest", () => {
+  for (const curve of CURVES) {
+    const spec: FlowSpec = { ...S, curve }
+    for (const i of [spec.floor, 0.08, 0.3, 0.5, 0.77, spec.ceiling]) {
+      const back = demandFor(spec, seedSuccess(spec, i))
+      assert.ok(Math.abs(back - i) < 1e-9, `${curve}: seed round-trip lost ${i} -> ${back}`)
+    }
+    // At rest means it does not move on the first frame.
+    const s = seedSuccess(spec)
+    assert.ok(
+      Math.abs(settle(spec, spec.start, s, 1 / 60) - spec.start) < 1e-9,
+      `${curve}: a fresh run lurched on frame one`,
+    )
+  }
+})
+
+test("degenerate specs cannot divide by zero or hand back NaN", () => {
+  const flat: FlowSpec = { ...S, floor: 0.5, ceiling: 0.5 }
+  assert.equal(settle(flat, 0, 1, 1 / 60), 0.5)
+  assert.equal(demandFor(flat, 0.3), 0.5)
+
+  const instant: FlowSpec = { ...S, climbSeconds: 0, fallSeconds: 0 }
+  assert.equal(settle(instant, 0, 1, 1 / 60), 1)
+  assert.equal(settle(instant, 1, 0, 1 / 60), 0)
+
+  const crossed: FlowSpec = { ...S, strugglingBelow: 0.9, thrivingAbove: 0.4 }
+  assert.ok(Number.isFinite(demandFor(crossed, 0.5)))
+
+  for (const bad of [NaN, Infinity, -Infinity]) {
+    assert.ok(Number.isFinite(settle(S, bad, 0.8, 1 / 60)), `settle produced a non-number from intensity ${bad}`)
+    assert.ok(Number.isFinite(settle(S, 0.4, 0.8, bad)), `settle produced a non-number from dt ${bad}`)
+    assert.ok(Number.isFinite(observe(S, bad, true, 1)))
+    assert.ok(Number.isFinite(outcomeScore(S, true, bad)), `outcomeScore produced a non-number from ${bad}s`)
+  }
+  const noBand: FlowSpec = { ...S, briskSeconds: 9, laboredSeconds: 9 }
+  assert.ok(Number.isFinite(outcomeScore(noBand, true, 9)))
+  assert.equal(settle(S, 0.4, 0.8, 0), 0.4, "a zero-length frame must not move the world")
+})
+
+// -- the mapping seam -------------------------------------------------------
+
+test("valueAt and countAt walk both directions and stay inside their range", () => {
+  for (const curve of CURVES) {
+    assert.equal(valueAt(0, 300, 520, curve), 300)
+    assert.equal(valueAt(1, 300, 520, curve), 520)
+    // Descending: a question's time limit, which SHRINKS as the world pushes.
+    assert.equal(valueAt(0, 16, 9, curve), 16)
+    assert.equal(valueAt(1, 16, 9, curve), 9)
+    for (let i = -0.5; i <= 1.5; i += 0.05) {
+      for (const [a, b] of [[4, 26], [26, 4], [7, 7]] as const) {
+        const n = countAt(i, a, b, curve)
+        assert.ok(Number.isInteger(n), `${curve}: countAt gave a non-integer ${n}`)
+        assert.ok(
+          n >= Math.min(a, b) && n <= Math.max(a, b),
+          `${curve}: countAt gave ${n} outside [${Math.min(a, b)},${Math.max(a, b)}] — a fixed-size pool would be asked for a slot it does not own`,
+        )
+      }
+    }
+  }
+})
+
+test("curved and uncurved are inverses and fix both ends", () => {
+  for (const curve of CURVES) {
+    assert.equal(curved(0, curve), 0)
+    assert.equal(curved(1, curve), 1)
+    for (let u = 0; u <= 1.0001; u += 0.01) {
+      assert.ok(Math.abs(uncurved(curved(u, curve), curve) - Math.min(1, u)) < 1e-6, `${curve} did not invert at ${u}`)
+    }
+    // Monotone.
+    let prev = -Infinity
+    for (let u = 0; u <= 1; u += 0.01) {
+      const v = curved(u, curve)
+      assert.ok(v >= prev - 1e-12, `${curve} is not monotone at ${u}`)
+      prev = v
+    }
+  }
+  assert.equal(curved(NaN, "linear"), 0, "a NaN intensity must read as the calmest world, not propagate")
+})
+
+test("rungAt never flickers on a band edge, and never jumps two rungs", () => {
+  const rungs = 10
+  // Without hysteresis it is a plain floor.
+  assert.equal(rungAt(0, rungs), 0)
+  assert.equal(rungAt(0.999, rungs), 9)
+  assert.equal(rungAt(1, rungs), 9, "intensity 1 must not index past the ladder")
+  assert.equal(rungAt(-1, rungs), 0)
+
+  // Sitting exactly on the 0.3 boundary and jittering must not move the rung.
+  let cur = 2
+  for (let f = 0; f < 500; f++) {
+    const jitter = 0.30 + Math.sin(f) * 0.02
+    const next = rungAt(jitter, rungs, cur)
+    assert.equal(next, cur, `the rung flickered ${cur} -> ${next} on a band edge at intensity ${jitter}`)
+  }
+
+  // A real move happens once intensity travels past the margin, and it is one
+  // rung at a time however far intensity jumped.
+  cur = rungAt(0.99, rungs, 2)
+  assert.equal(cur, 3, "a jump from 0.2 to 0.99 must climb ONE rung, not eight")
+  cur = rungAt(0.0, rungs, 8)
+  assert.equal(cur, 7, "…and falling is one rung at a time too")
+
+  // Walking all the way up and all the way down is monotone in each direction.
+  cur = 0
+  for (let i = 0; i <= 1; i += 0.005) {
+    const next = rungAt(i, rungs, cur)
+    assert.ok(next >= cur && next - cur <= 1, `rung went ${cur} -> ${next}`)
+    cur = next
+  }
+  assert.equal(cur, 9)
+  for (let i = 1; i >= 0; i -= 0.005) {
+    const next = rungAt(i, rungs, cur)
+    assert.ok(next <= cur && cur - next <= 1, `rung went ${cur} -> ${next}`)
+    cur = next
+  }
+  assert.equal(cur, 0)
+
+  assert.equal(rungAt(0.5, 1, 0), 0, "a one-rung ladder has exactly one answer")
+  assert.equal(rungAt(0.5, 0), 0, "a zero-length ladder must not index -1")
+})
+
+test("falling and rising cross a band at DIFFERENT intensities — that is the hysteresis", () => {
+  const rungs = 10
+  // Rising out of rung 3 needs 0.4 + margin; falling out of rung 4 needs
+  // 0.4 - margin. The gap between them is what stops the flicker.
+  assert.equal(rungAt(0.401, rungs, 3), 3, "rose a rung the instant it touched the boundary")
+  assert.equal(rungAt(0.45, rungs, 3), 4)
+  assert.equal(rungAt(0.399, rungs, 4), 4, "fell a rung the instant it touched the boundary")
+  assert.equal(rungAt(0.35, rungs, 4), 3)
+})
+
+test("the whole loop composes: struggle makes the world sparser AND the maths easier", () => {
+  // This is the coupling the design is actually about, exercised end to end
+  // through the same three functions a game calls.
+  const spec = S
+  let intensity = 1
+  let success = seedSuccess(spec, 1)
+  let rung = 9
+  const at = () => ({
+    rivals: countAt(intensity, 4, 26),
+    speed: Math.round(valueAt(intensity, 300, 520)),
+    rung,
+  })
+  const before = at()
+  for (let f = 0; f < 60 * 90; f++) {
+    if (f % 300 === 0) success = observe(spec, success, false, 6)
+    intensity = settle(spec, intensity, success, 1 / 60)
+    rung = rungAt(intensity, 10, rung)
+  }
+  const after = at()
+  assert.ok(after.rivals < before.rivals, `the world did not get sparser: ${before.rivals} -> ${after.rivals} rivals`)
+  assert.ok(after.speed < before.speed, `the world did not get slower: ${before.speed} -> ${after.speed}`)
+  assert.ok(after.rung < before.rung, `the maths did not get easier: rung ${before.rung} -> ${after.rung}`)
+  assert.equal(after.rung, 0, "ninety seconds of struggle must reach the bottom of the ladder")
+})
+
+// -- the reveal -------------------------------------------------------------
+
+test("the answer reveal is patient at the bottom and skipped at the top", () => {
+  assert.equal(revealMs(S, 0), S.revealCalmMs)
+  assert.equal(revealMs(S, 1), S.revealFullMs)
+  assert.ok(revealShown(S, 0), "a player at the floor must be shown the finished sum")
+  assert.ok(!revealShown(S, 1), "…and a player at the ceiling must not be held for it")
+
+  // Monotone: more mastery is never MORE patience.
+  let prev = Infinity
+  for (let i = 0; i <= 1.0001; i += 0.01) {
+    const v = revealMs(S, i)
+    assert.ok(v <= prev + 1e-9, `the reveal got LONGER as intensity rose, at ${i}`)
+    assert.ok(v >= 0, "a negative reveal is a negative hold")
+    prev = v
+  }
+  // Patience is spent at the bottom, not smeared across the whole range: the
+  // reveal is already mostly gone by the middle of the ladder.
+  assert.ok(revealMs(S, 0.15) > S.revealCalmMs * 0.6, `at 0.15 the reveal was already down to ${revealMs(S, 0.15)}ms`)
+  assert.ok(revealMs(S, 0.6) < S.revealCalmMs * 0.25, `at 0.6 the reveal was still ${revealMs(S, 0.6)}ms`)
+  assert.ok(Number.isFinite(revealMs(S, NaN)))
+})

--- a/dynawalla/packs/shared/game-pacing/flow.ts
+++ b/dynawalla/packs/shared/game-pacing/flow.ts
@@ -1,0 +1,369 @@
+/**
+ * THE FLOW CONTROLLER.
+ *
+ * One number — `intensity`, in [0,1] — drives a Dynawalla game's maths
+ * difficulty AND its pace AND its density, together, in BOTH directions. That
+ * coupling is the design, not an implementation convenience. A child who is
+ * struggling with 11 + 16 is not helped by easier questions arriving in the
+ * same crowded, fast world; they are helped by the whole game breathing out.
+ * And a child who is crushing double digits should feel the world lean in as
+ * the numbers grow, all at once, so the escalation reads as one thing.
+ *
+ * The founder's statement of it:
+ *
+ *   "it should naturally shrink back down when you get something wrong ... and
+ *    get more sparse and slow .. so if someone gets up to 11+16 and is
+ *    struggling, it should go back down all the way to 2+3 and friends ... if
+ *    they are just crushing double digits for a nice little while then the
+ *    triple digits come in. it should expand and contract the difficulty and
+ *    speed smoothly"
+ *
+ * Five properties follow, and every one of them is asserted in `flow.test.ts`:
+ *
+ *   1. **Asymmetric, but not crudely so.** It drops on a single failure and
+ *      climbs on sustained success — and the CLIMB RATE SCALES WITH THE
+ *      STRENGTH OF THE EVIDENCE. "Falls fast, climbs slow" was the first
+ *      formulation and it is wrong: everybody, adult included, starts at the
+ *      very bottom of the ladder, and an adult made to walk every rung from
+ *      `0 + 1` quits before the third question. So somebody answering correctly
+ *      AND fast climbs steeply, several rungs if warranted; somebody answering
+ *      correctly but slowly holds roughly steady, which is precisely where you
+ *      want them; and somebody getting it wrong drops immediately.
+ *
+ *   2. **Time-aware.** Correctness alone cannot tell mastery from effort. The
+ *      separating signal is how long the answer took, so `observe` takes it.
+ *      A game that cannot measure latency may omit it and gets the conservative
+ *      reading — correct-but-slow — which costs a slower climb and nothing else.
+ *
+ *   3. **Smoothed.** The controller steers on a moving estimate of recent
+ *      outcomes, never on the last answer alone. A per-answer flip oscillates,
+ *      and an oscillating difficulty reads to a child as the game being
+ *      arbitrary rather than as the game being alive.
+ *
+ *   4. **Silent.** There is nothing here to render. No level number, no banner,
+ *      no "that was too hard for you". A child must never be able to read the
+ *      controller's opinion of them, which is why this module has no strings in
+ *      it at all and never will.
+ *
+ *   5. **Bounded, with a trivial floor.** The floor is genuinely `0 + 1`. That
+ *      is not condescending, because the dignity comes from the celebration and
+ *      from the visible climb, not from making the easy end harder — so the
+ *      floor stays calm and sparse, and the climb does the work.
+ *
+ * Pure functions over plain numbers. The GAME owns the two pieces of state
+ * (`intensity` and `success`); this module only ever computes the next value.
+ * That keeps a sixty-times-a-second call path allocation-free and makes every
+ * transition trivially testable.
+ */
+
+import { clamp01, uncurved, valueAt, type Curve } from "./curve.ts"
+
+export type FlowSpec = {
+  /** The calmest the world may ever get. A real destination, not a limit case. */
+  floor: number
+  /** The hardest the world may ever get. */
+  ceiling: number
+  /** Where a fresh run starts. Near the floor: the opening is earned, not granted. */
+  start: number
+  /**
+   * Seconds to travel the whole range floor -> ceiling at the SLOWEST climb —
+   * the one a player earns by being right without being quick.
+   */
+  climbSeconds: number
+  /**
+   * How much faster the climb goes when the target is far above where the world
+   * currently is, which is what strong evidence looks like from here.
+   *
+   * The rate is `(span / climbSeconds) * (1 + climbBoost * gap)`, so a player
+   * who has just proved they belong several rungs up is carried there in tens
+   * of seconds, and the last stretch — where the gap is small — eases in. This
+   * is the single constant that decides whether an adult is trapped at the
+   * bottom of the ladder.
+   */
+  climbBoost: number
+  /**
+   * Seconds at or under which a correct answer is STRONG evidence of mastery.
+   * Anything this fast scores a full 1.
+   */
+  briskSeconds: number
+  /**
+   * Seconds at or over which a correct answer is WEAK evidence — the child is
+   * working, and working is the point. Scores `laboredScore`.
+   */
+  laboredSeconds: number
+  /**
+   * What a correct-but-slow answer is worth. Chosen so a run of them converges
+   * to the middle of the ladder rather than to either end.
+   */
+  laboredScore: number
+  /**
+   * Seconds of unbroken struggle to travel ceiling -> floor.
+   * Much shorter than `climbSeconds`. Relief is not something to be earned.
+   */
+  fallSeconds: number
+  /**
+   * Answers the success estimate is effectively drawn from. Larger is smoother
+   * and slower to react; smaller is twitchier. Three is deliberately short —
+   * long enough that no single answer decides the world, short enough that
+   * three quick correct answers are allowed to say something.
+   */
+  window: number
+  /**
+   * How long a completed answer is held in front of a player at the FLOOR,
+   * in milliseconds.
+   *
+   * At the bottom of the range this is the channel that is working. A player
+   * who is not producing answers is still absorbing numerals, symbols and the
+   * shape of an equation resolving, and that exposure is a real mechanism
+   * rather than a consolation — the founder: "if the game is calmly showing
+   * them the answer in a pleasing way, with tons of patience, the youngster
+   * might really start picking stuff up like wild". Patience is the feature.
+   */
+  revealCalmMs: number
+  /**
+   * …and at the CEILING. Zero, meaning skipped.
+   *
+   * The same reveal is an obstacle at the top: somebody blowing through at
+   * speed does not want to be held for a patient explanation of a sum they
+   * already know. Skipping it is itself a reward for mastery.
+   */
+  revealFullMs: number
+  /** At or below this success rate the controller steers all the way to the floor. */
+  strugglingBelow: number
+  /** At or above this success rate it steers all the way to the ceiling. */
+  thrivingAbove: number
+  /** How demand is distributed across the success rate between those two marks. */
+  curve: Curve
+}
+
+/**
+ * The recommended shape, and the one ARENA uses.
+ *
+ * The three timing constants are calibrated against the curriculum rather than
+ * guessed. `dw.ns.compare.whole-numbers` publishes `fluencyTarget.p50Ms: 9000`
+ * — nine seconds is the median a fluent child is expected to take — so nine
+ * seconds must score in the MIDDLE, and it does: it lands at 0.70, which
+ * `demandFor` maps to the middle of the ladder. Three seconds is unambiguously
+ * "already knew it"; twelve is unambiguously "worked it out".
+ *
+ * `settle` because both ends of the range want a soft approach: a world that
+ * snaps to its floor is as jarring as one that snaps to its ceiling.
+ */
+export const SECOND_GRADE_FLOW: FlowSpec = {
+  floor: 0,
+  ceiling: 1,
+  start: 0.04,
+  climbSeconds: 300,
+  climbBoost: 14,
+  fallSeconds: 50,
+  briskSeconds: 3,
+  laboredSeconds: 12,
+  laboredScore: 0.55,
+  revealCalmMs: 4200,
+  revealFullMs: 0,
+  window: 3,
+  strugglingBelow: 0.55,
+  thrivingAbove: 0.85,
+  curve: "settle",
+}
+
+/**
+ * How quick an answer was, 0 (laboured or slower) to 1 (brisk or faster).
+ *
+ * **This is a reward signal, never a penalty one, and the distinction is the
+ * whole design.** A countdown that kills you and a bonus that accrues when you
+ * are fast read the same clock and produce opposite emotional experiences. The
+ * founder's rule: "we can usually measure, pace and reward, not cause anxiety".
+ * So a game spends this on multipliers, on richer celebration, on loot — on
+ * things a fast player GAINS — and never on a window a slow player LOSES.
+ *
+ * A game that cannot measure latency gets 0, which costs a bonus and nothing
+ * else.
+ */
+export function quickness(spec: FlowSpec, seconds?: number): number {
+  if (seconds === undefined || !Number.isFinite(seconds)) return 0
+  const brisk = spec.briskSeconds
+  const labored = spec.laboredSeconds
+  if (!(labored > brisk)) return seconds <= brisk ? 1 : 0
+  return clamp01((labored - seconds) / (labored - brisk))
+}
+
+/**
+ * What one answer is worth as evidence, in [0,1].
+ *
+ * Wrong is zero, however fast. Correct is worth at LEAST `laboredScore`
+ * however slow — a correct answer is a correct answer, and taking four minutes
+ * over it can knock a player back a little but can never make it worthless.
+ * Above that floor it walks to 1 as the answer gets quicker, which is the only
+ * way the controller can tell "already knew it" from "worked it out", and those
+ * two want opposite things from the world.
+ *
+ * `seconds` may be omitted by a game that cannot measure it. That reads as the
+ * slow case on purpose: the conservative direction is the one that keeps a
+ * player in the range they are demonstrably succeeding in.
+ */
+export function outcomeScore(spec: FlowSpec, correct: boolean, seconds?: number): number {
+  if (!correct) return 0
+  if (seconds === undefined || !Number.isFinite(seconds)) return clamp01(spec.laboredScore)
+  const q = quickness(spec, seconds)
+  return clamp01(spec.laboredScore + (1 - spec.laboredScore) * q)
+}
+
+/**
+ * The success estimate after one more outcome.
+ *
+ * An exponential moving average with `1/window` as its weight, which is the
+ * cheapest thing that is genuinely a moving estimate: no ring buffer for the
+ * caller to own and no allocation. A window of three is deliberately short —
+ * long enough that no single answer decides the world, short enough that three
+ * quick correct answers are allowed to say something.
+ */
+export function observe(spec: FlowSpec, success: number, correct: boolean, seconds?: number): number {
+  const w = Math.max(1, spec.window)
+  const k = 1 / w
+  const prev = clamp01(success)
+  return clamp01(prev + (outcomeScore(spec, correct, seconds) - prev) * k)
+}
+
+/**
+ * Where the controller WANTS intensity to be, given the success estimate.
+ *
+ * Flat at the floor at or below `strugglingBelow`, flat at the ceiling at or
+ * above `thrivingAbove`, and shaped by `curve` between them. The flats matter:
+ * a child at 30% correct and a child at 45% correct both need the same thing,
+ * which is the easiest world the game has.
+ */
+export function demandFor(spec: FlowSpec, success: number): number {
+  const lo = spec.strugglingBelow
+  const hi = spec.thrivingAbove
+  const s = clamp01(success)
+  if (hi <= lo) return s >= hi ? spec.ceiling : spec.floor
+  const u = clamp01((s - lo) / (hi - lo))
+  // `uncurved` rather than `curved`, and the direction is the point: it makes
+  // the LOW end of the success range spend more of the intensity range, so
+  // pulling out of a struggle is felt immediately while the last stretch to the
+  // ceiling stays something to earn.
+  return spec.floor + (spec.ceiling - spec.floor) * uncurved(u, spec.curve)
+}
+
+/**
+ * How long to hold a completed answer in front of the player, in milliseconds.
+ *
+ * The last thing that touches a player and was still a constant. It rides the
+ * same scalar as everything else, and it rides it BACKWARDS: long, calm and
+ * generous at the floor; brief or skipped at the ceiling.
+ *
+ * `steep` is deliberate. It keeps the reveal near its full length only for the
+ * bottom of the range and sheds it quickly thereafter, so patience is spent
+ * where it teaches and nowhere else.
+ *
+ * The reveal is a REVEAL, not a lesson: the finished equation, shown the way
+ * you would celebrate one and merely quieter. It may never read as correction.
+ * There is no string in this module to make it read as anything.
+ */
+export function revealMs(spec: FlowSpec, intensity: number): number {
+  return Math.max(0, valueAt(clamp01(intensity), spec.revealCalmMs, spec.revealFullMs, "steep"))
+}
+
+/** Is the reveal worth showing at all at this intensity? */
+export function revealShown(spec: FlowSpec, intensity: number): boolean {
+  return revealMs(spec, intensity) >= 250
+}
+
+/**
+ * The success estimate that would demand a given intensity.
+ *
+ * The inverse of `demandFor`, and it exists so a fresh run can be seeded
+ * consistently: a game starting at `spec.start` sets `success = seedSuccess(
+ * spec)` and the controller is immediately at rest rather than lurching on the
+ * first frame toward a target its own state disagrees with.
+ */
+export function seedSuccess(spec: FlowSpec, intensity = spec.start): number {
+  const span = spec.ceiling - spec.floor
+  if (span <= 0) return spec.thrivingAbove
+  const v = clamp01((intensity - spec.floor) / span)
+  // `uncurved` was applied in `demandFor`, so `curved` undoes it.
+  const u = v <= 0 ? 0 : v >= 1 ? 1 : curvedInverse(v, spec.curve)
+  return spec.strugglingBelow + (spec.thrivingAbove - spec.strugglingBelow) * u
+}
+
+/** Local, so `flow.ts` does not export a second name for `curved`. */
+function curvedInverse(v: number, curve: Curve): number {
+  switch (curve) {
+    case "linear":
+      return v
+    case "gentle":
+      return v * v
+    case "steep":
+      return 1 - (1 - v) * (1 - v)
+    case "settle":
+      return v * v * (3 - 2 * v)
+  }
+}
+
+/**
+ * Intensity after `dt` seconds of moving toward what `success` demands.
+ *
+ * Falling is LINEAR in time, on purpose: "fifty seconds to the floor" is then a
+ * real, testable number rather than a half-life that never quite arrives, and
+ * relief is the half of this that must be predictable.
+ *
+ * Climbing is GAP-SCALED. The rate is
+ *
+ *     (span / climbSeconds) * (1 + climbBoost * gap)
+ *
+ * where `gap` is how far above the current world the target sits, as a fraction
+ * of the range. A player who has just demonstrated they belong near the top is
+ * carried most of the way in tens of seconds and then eases in; a player
+ * holding steady one rung up walks. That is the whole difference between a
+ * ladder an adult can leave and a ladder an adult is trapped on.
+ *
+ * Never overshoots the target, and is clamped into `[floor, ceiling]` whatever
+ * it is handed.
+ */
+export function settle(spec: FlowSpec, intensity: number, success: number, dt: number): number {
+  const lo = Math.min(spec.floor, spec.ceiling)
+  const hi = Math.max(spec.floor, spec.ceiling)
+  const cur = Number.isFinite(intensity) ? Math.min(hi, Math.max(lo, intensity)) : spec.start
+  if (!Number.isFinite(dt) || dt <= 0) return cur
+
+  const target = Math.min(hi, Math.max(lo, demandFor(spec, success)))
+  const span = hi - lo
+  if (span <= 0) return lo
+
+  if (target > cur) {
+    if (!(spec.climbSeconds > 0)) return target
+    const gap = (target - cur) / span
+    const rate = (span / spec.climbSeconds) * (1 + Math.max(0, spec.climbBoost) * gap)
+    return Math.min(target, cur + rate * dt)
+  }
+  if (!(spec.fallSeconds > 0)) return target
+  return Math.max(target, cur - (span / spec.fallSeconds) * dt)
+}
+
+/**
+ * Seconds for `settle` to carry intensity from `from` to `to`, holding the
+ * success estimate wherever it has to be to demand `to`.
+ *
+ * Integrated rather than divided, because the climb rate is not constant. Only
+ * for tests and design notes — nothing on a frame path calls it — but it is the
+ * honest way to state a claim like "an adult answering fast leaves the bottom
+ * of the ladder inside a minute", because it is derived from the same constants
+ * the controller actually uses rather than from a comment.
+ */
+export function secondsBetween(spec: FlowSpec, from: number, to: number): number {
+  const span = Math.abs(spec.ceiling - spec.floor)
+  if (span <= 0) return 0
+  if (to <= from) return ((from - to) / span) * spec.fallSeconds
+  const dt = 1 / 120
+  let t = 0
+  let x = from
+  // The rate falls as the gap closes, so the last sliver is asymptotic. Stop at
+  // a thousandth of the range, which is far finer than any rung.
+  while (x < to - span * 1e-3 && t < spec.climbSeconds * 20) {
+    const gap = (to - x) / span
+    x += (span / spec.climbSeconds) * (1 + Math.max(0, spec.climbBoost) * gap) * dt
+    t += dt
+  }
+  return t
+}

--- a/dynawalla/packs/shared/game-pacing/index.ts
+++ b/dynawalla/packs/shared/game-pacing/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared game pacing: ONE intensity scalar that drives a game's maths
+ * difficulty, its speed and its density together, in both directions.
+ *
+ * `flow`  — the adaptive controller. Falls fast on struggle, climbs slow on
+ *           success, smoothed, silent, bounded.
+ * `curve` — how a game spends that intensity on its own constants, and how a
+ *           continuous intensity picks a discrete rung on a curriculum ladder
+ *           without flickering.
+ *
+ * Pure functions only. No DOM, no rendering, no timers, no module state — the
+ * game owns every piece of state and this only ever computes the next value.
+ */
+export {
+  SECOND_GRADE_FLOW,
+  observe,
+  outcomeScore,
+  quickness,
+  revealMs,
+  revealShown,
+  demandFor,
+  seedSuccess,
+  settle,
+  secondsBetween,
+  type FlowSpec,
+} from "./flow.ts"
+export {
+  clamp01,
+  curved,
+  uncurved,
+  valueAt,
+  countAt,
+  rungAt,
+  type Curve,
+} from "./curve.ts"

--- a/dynawalla/packs/shared/game-pacing/package-lock.json
+++ b/dynawalla/packs/shared/game-pacing/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/game-pacing",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-pacing",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/packs/shared/game-pacing/package.json
+++ b/dynawalla/packs/shared/game-pacing/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dynawalla/game-pacing",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The onset ramp: calm and roomy at the open, climbing to whatever mayhem a game is capable of. Pure functions, no DOM, no state — so a hundred games can share the curve without sharing any of the integration risk.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"*.test.ts\"",
+    "tsc": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/packs/shared/game-pacing/tsconfig.json
+++ b/dynawalla/packs/shared/game-pacing/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  /* The same strictness the app, the SDK and game-chrome are held to, so a type
+     that passes here cannot fail when a game imports the identical file by
+     relative path — which is how every game consumes this module.
+     `erasableSyntaxOnly` keeps every file runnable under
+     `node --experimental-strip-types`.
+
+     No "DOM" in `lib`, unlike game-chrome: this module is pure arithmetic and
+     the absence of the DOM types is the compiler enforcing that promise. */
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}


### PR DESCRIPTION

"Arena is almost really cool but it's a little bit too crowded, a bit too hard
and a bit too fast to start ... arena gets so crowded so fast I can hardly move."

Every complaint in that playtest turned out to be the same missing thing. ARENA
had no adaptation of any kind. Density, rival count, speed and question
difficulty were all functions of the DEPTH; the depth is a ratchet that only
ever goes up; and the ratchet is turned by the clock and by mass. Nothing
anywhere in the simulation asked whether the child was getting the maths right.

Measured on the first frame of a seeded mid-tier run: 155 motes and 16 rivals —
the same counts the twentieth minute carries, because `reset()` spawned the tier
ceiling. There was no onset. There was a cold start into the top of the
difficulty curve, and no way back down from it.

## The breath

`dynawalla/packs/shared/game-pacing/` is new: one `intensity` in [0,1] driving
maths difficulty, spawn density, rival count, player speed, void rate, hunter
budget, question window and answer-reveal patience — all of it, together, in
both directions. Pure functions, no DOM, no state, no strings (`tsconfig` omits
`"DOM"` from `lib` so the compiler enforces the first two). 20 tests.

It drops on a single failure and climbs on sustained success, and the climb rate
scales with the strength of the evidence: correct AND fast climbs steeply,
correct but slow holds steady, wrong drops immediately. Everybody starts at the
bottom, so an adult made to walk every rung would quit — measured, three fast
correct answers now carry a player from the floor to 0.87.

Latency is the signal that separates those cases. ARENA already measured it and
had never used it to decide anything.

## Time is measured and rewarded, never imposed

Two clocks ran on every child regardless of how they were doing. The question
window was `max(6.5, 10.5 - resonanceCount * 0.16)` — it shrank with the number
of questions ASKED — and the four answer spheres drifted away at a flat 22 units
a second while you thought. Both are now earned: 26 s and no drift at the floor,
6 s and a real countdown at the ceiling. A wrong answer cost a flat 24% of the
run; at the bottom of the ladder it is now 2%.

And the reveal: on a miss the arena now completes the sum in the ribbon and
holds it — 3.9 s at the floor, skipped entirely at the top, because holding a
player who already knew it is a punishment for being good.

## The numbers a child reads

    before   t=5s 104   t=15s 537   t=30s 1,771   t=60s 2,624   — for everyone
    after    t=15s 47   t=60s 202   t=2m 681   t=20m 799        — struggling
             t=15s 47   t=60s 729   t=2m 7,695                  — answering well

Four digits inside the first minute, forever, became a climb that is earned.
`FOOD_A` 0.62 -> 0.40 and `FOOD_B` 0.60 -> 0.50: the second is the shape, and it
takes dM/dt from M^0.25 (mass as t^4/3, accelerating away from the curriculum
forever) to M^0.15 (very nearly linear).

## The rest of the playtest

* **"they can get so big that they are bigger than the whole screen ... and I
  can't do anything"** — `!this.rleviathan[k]` exempted leviathans from the size
  recycler. Measured: 27.4x the player's mass, 1.99x the WIDTH of a phone held
  tall. The rule now applies to everything, and the two ceilings are derived from
  the viewport rather than typed.

* **"why is there an edge of the board?"** — the membrane, not the Resonance.
  `arenaRadiusFor` was `max(2600, span * 3.4)` and at the starting mass the `max`
  chose the constant: a 2,600-unit pond around a 463-unit view. Measured: 4.77 s
  of swimming in one straight line. Now 90 spans, and the test walks at it for
  150 s without finding it.

* **"the character zips too fast it's hard to control"** — 520 at exponent 0.30
  was 2.44 screen-WIDTHS per second on a phone held tall, and it was the fastest
  the game ever was. 400 at 0.42 with a wider opening view: 0.48 screen-heights
  per second at the start, down from 1.13, and the nine-fold swing across the run
  is now 3.7-fold. Turn authority 8.0 -> 10.0.

* **the running equation** — the founder's idea, and the best one here. A ribbon
  above the button row, `1503 + 12 = 1515`, replacing as it goes, with its own
  scrim so it survives the brightest frame. It shows the TRUE change: a mote's
  label is a size, not an addend, and a maths product may not print a sum it did
  not perform. Both ends are rounded and the middle is derived, so
  `eqA + eqD === eqC` exactly.

## Juice: more, and on the maths

Audited: `rupture` — bursting, a FAILURE — carried trauma 1.00 and hitstop 0.13,
and a right answer carried 0.85 and 0.11. The loudest single moment in a
mathematics product was a mistake. The maths moment now outranks everything on
every axis, gets a second delayed wave nothing else has, and scales with how
quick the answer was. Nothing was turned down.

The WCAG flash cap was checked as a safety item rather than an aesthetic one and
IS genuinely enforced — three full flashes per second, then 0.05, then nothing —
but it governs `cam.flash` ONLY. The bloom chain in `post.ts` can drive a frame
to clipped white with no rate limit at all, which is what the founder's white-out
screenshot actually shows. Not retuned: the fix for that is fewer things on
screen, which is this change.

## Verification

64 arena tests and 20 pacing tests, five clean runs each. Every fix was deleted
and the resulting failure recorded; three were unguarded when first checked and
now have tests. One of those was a real latent bug the mutation run surfaced.

Claude-Session: https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
