### PR TITLE
fix(dynawalla/games/beam): the relief that made the lattice denser, and the two tests that let it

### DIFF
--- a/dynawalla/games/beam/README.md
+++ b/dynawalla/games/beam/README.md
@@ -83,9 +83,18 @@ The number the director still tunes is the **dead time** — the gap with nothin
 lattice to think about. A wave ends the moment it is answered, so reading quickly is
 what buys the next problem, and a fluent child never sees the end of a window.
 
-While a question is in the air the lattice **thins out**: fewer automata, further apart,
-crossing more slowly. Sparser and slower, never duller — the tight-divisor bias is
+While a question is in the air the lattice **thins out**: the stream runs every 3.5s
+instead of every 2s at a cold start, the floor on live automata drops, and everything
+crosses more slowly. Sparser and slower, never duller — the tight-divisor bias is
 untouched and the field is never empty.
+
+That is asserted **on the real lattice**, by watching automata arrive on the horizon
+line frame by frame, and not only on `readingRelief` itself. The first version of it was
+asserted only on the pure function, and underneath it `Director.wantsSpawn` was looking
+its own pressure up instead of taking the one it was handed — so the relieved spawn gap
+and floor reached nothing, only `descentSeconds` arrived, every hull lingered 30% longer
+at an unchanged cadence, and the lattice got *denser* during the one moment it is meant
+to thin.
 
 So a submission costs four real steps, three of them mathematics:
 

--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -223,7 +223,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
    * running, and every automaton that was descending is exactly where it was
    * when the hold lifts.
    */
-  let reveal: { text: string; answer: string; left: number; max: number } | null = null
+  let reveal: { text: string; answer: string; left: number } | null = null
   let hold = 0
 
   const pulses: Pulse[] = []
@@ -501,7 +501,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
    */
   function completeSum(w: CoreWave): void {
     const seconds = revealSeconds({ prompt: w.prompt, answer: w.answer })
-    reveal = { text: w.prompt, answer: String(w.answer), left: seconds, max: seconds }
+    reveal = { text: w.prompt, answer: String(w.answer), left: seconds }
     hold = seconds
     audio.riser()
   }
@@ -716,6 +716,14 @@ export function mountBeam(el: HTMLElement, host: Host): {
   function endRun(): void {
     over = true
     overAt = performance.now()
+    // A wave still in the air is over too, and unreported: nothing was handed
+    // in and nothing ran out — the lattice went dark underneath it. Without
+    // this the question stays carved on the wall under the game-over scrim,
+    // because the landed loop stops clearing candidates once `over` is set.
+    wave = null
+    coreBody = null
+    reveal = null
+    hold = 0
     if (score > best) {
       best = score
       writeBest(best)
@@ -778,7 +786,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function onDown(e: PointerEvent): void {
-    if (paused) return
+    if (paused || hold > 0) return
     void audio.start()
     if (over) {
       if (performance.now() - overAt > 550) restart()
@@ -795,7 +803,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function onMove(e: PointerEvent): void {
-    if (paused || !pointerDown) return
+    if (paused || hold > 0 || !pointerDown) return
     if (!dragged && Math.hypot(e.clientX - downX, e.clientY - downY) > 14) dragged = true
     if (!dragged) return
     // A drag is the *listening* verb: it rides the lattice without firing, so a
@@ -811,7 +819,10 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function onKey(e: KeyboardEvent): void {
-    if (paused) return
+    // Refused, not queued. The runner cannot move while the hall is held, so a
+    // tap that set `fireOnArrive` would sit there looking like a dead control
+    // and then go off on its own two seconds later.
+    if (paused || hold > 0) return
     if (e.key === "ArrowLeft") rideTo(runnerCol - 1, false)
     else if (e.key === "ArrowRight") rideTo(runnerCol + 1, false)
     else if (e.key === " " || e.key === "Enter") {
@@ -840,9 +851,11 @@ export function mountBeam(el: HTMLElement, host: Host): {
     if (hold > 0) {
       // THE HOLD. The lattice is still while the sum finishes: nothing
       // descends, nothing spawns, no pulse travels and the clock the director
-      // escalates on does not advance. Only the decoration keeps moving, so a
+      // escalates on does not advance, and input is refused. Only the
+      // decoration keeps moving — the sparks and the resonance traces — so a
       // held hall reads as held rather than as crashed.
       hold -= dt
+      if (!reduced) traceScroll += dt * 0.42
       parts.update(dt)
       for (const q of pops) {
         if (!q.alive) continue
@@ -886,7 +899,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
 
     if (!over) {
       if (director.wantsCore(wave !== null)) spawnCore()
-      if (field.liveCount(A_ORDINARY) < 9 && director.wantsSpawn(field.liveCount(A_ORDINARY))) {
+      if (field.liveCount(A_ORDINARY) < 9 && director.wantsSpawn(field.liveCount(A_ORDINARY), p)) {
         spawnOrdinary()
       }
     }

--- a/dynawalla/games/beam/src/sim/director.ts
+++ b/dynawalla/games/beam/src/sim/director.ts
@@ -76,9 +76,21 @@ export class Director {
     }
   }
 
-  /** True when it is time to put another ordinary automaton on the lattice. */
-  wantsSpawn(live: number): boolean {
-    const p = this.pressure()
+  /**
+   * True when it is time to put another ordinary automaton on the lattice.
+   *
+   * @param p the pressure to spawn AGAINST, which is not always this
+   *   director's own. It reads `this.pressure()` by default and that default
+   *   is the trap: while a question is being read the caller passes
+   *   `readingRelief(...)`, and a version of this method that helpfully looked
+   *   the pressure up for itself discarded the relieved `spawnGap` and
+   *   `floorCount` silently. The relief then reached only `descentSeconds`,
+   *   every hull lingered 30% longer at an unchanged spawn cadence, and the
+   *   lattice got about 25% DENSER during the one moment it was supposed to
+   *   thin — the exact opposite of what the relief exists to do, with a passing
+   *   test suite over it because the test only ever called the pure function.
+   */
+  wantsSpawn(live: number, p: Pressure = this.pressure()): boolean {
     if (live < p.floorCount) return true
     return this.sinceSpawn >= p.spawnGap
   }
@@ -157,8 +169,12 @@ export class Director {
  *     lattice with no mathematics on it, and an empty screen is not calm, it
  *     is dead air.
  *
- * The relief is applied at spawn time, so nothing already descending changes
- * speed underneath the child's hands.
+ * `descentSeconds` is read at spawn time, so nothing already descending changes
+ * pace underneath the child's hands. `stepSeconds` is not — the frame loop
+ * passes it live — so every automaton on the lattice does widen its sideways
+ * cadence for the length of the wave. That is deliberate and it is the calm:
+ * a board that is stepping more slowly is a board that is easier to read
+ * while thinking about something else.
  */
 export function readingRelief(p: Pressure): Pressure {
   return {

--- a/dynawalla/games/beam/src/test/comprehension.test.ts
+++ b/dynawalla/games/beam/src/test/comprehension.test.ts
@@ -339,6 +339,8 @@ type Ending = {
 function playOneSmallItem(
   size: [number, number],
   frames: number,
+  /** Frames the child pulls the trigger on. Nothing else is ever pressed. */
+  fireAt: readonly number[] = [],
 ): { endings: Ending[]; painted: Painted[][]; reports: number } {
   const rec = recorder(size[0], size[1], 0x5a1e)
   const restore = rec.install()
@@ -381,6 +383,7 @@ function playOneSmallItem(
     for (let i = 0; i < frames; i++) {
       frame = i
       rec.step(16)
+      if (fireAt.includes(i)) rec.press(" ")
     }
   } finally {
     handle.unmount()
@@ -1017,6 +1020,54 @@ test("the sheet's minutes are not billed to the child as thinking time", () => {
 
 // ─── 5. Space around the answering moment ─────────────────────────────────────
 
+test("ON THE REAL LATTICE, THE STREAM REALLY DOES BACK OFF WHILE READING", () => {
+  // The test below this one asserts `readingRelief` and NOTHING ELSE. Both of
+  // its call sites in `mount.ts` could be deleted and the suite would stay
+  // green — and worse than that had already happened: `Director.wantsSpawn`
+  // looked its own pressure up instead of taking the one it was handed, so the
+  // relieved `spawnGap` and `floorCount` reached nothing at all. The only field
+  // that DID arrive was `descentSeconds`, which makes every hull linger 30%
+  // longer, so the lattice got about 25% denser during the one moment it is
+  // supposed to thin. A tautological test sat on top of that the whole time.
+  //
+  // An automaton is born at `t = 0`, which projects to exactly the horizon, so
+  // a spawn is directly observable: a numeral painted on the horizon line. The
+  // score is a numeral too and sits well above it, which is why this is pinned
+  // to the horizon rather than to "near the top".
+  const geom = geomForViewport(768, 1024, 5)
+  const { endings, painted } = playOneSmallItem([768, 1024], 1400)
+  const ran = endings.find((e) => e.end === "unanswered")
+  assert.ok(ran, "the wave never ran out")
+
+  const births: number[] = []
+  for (let f = 0; f < painted.length; f++) {
+    const born = (painted[f] ?? []).some(
+      (p) => /^\d+$/.test(p.text) && Math.abs(p.y - geom.horizonY) < 0.5,
+    )
+    // A hull sits on the horizon for a frame or three; one arrival, not three.
+    if (born && (births.length === 0 || f - (births[births.length - 1] ?? 0) > 10) ) births.push(f)
+  }
+  const during = births.filter((f) => f >= ran.from && f < ran.frame)
+  assert.ok(during.length >= 2, `only ${String(during.length)} automata arrived during the wave`)
+
+  const relieved = readingRelief(new Director().pressure())
+  for (let i = 1; i < during.length; i++) {
+    const a = during[i - 1]
+    const b = during[i]
+    assert.ok(a !== undefined && b !== undefined)
+    const gap = ((b - a) * 16) / 1000
+    // At a cold start the stream runs every 2.0s and the relief widens it to
+    // 3.5s. Measured at 3.42s, which is the gap minus the frame the spawn is
+    // noticed on; the floor here sits between the two so it cannot be met by
+    // an unrelieved lattice.
+    assert.ok(
+      gap > 3,
+      `automata arrived ${gap.toFixed(2)}s apart while a question was being read — ` +
+        `the relief wants ${relieved.spawnGap.toFixed(2)}s and the plain stream gives 2.00s`,
+    )
+  }
+})
+
 test("the lattice thins out while a question is being read — sparser, not duller", () => {
   // The founder's direction: keep the juice, give the space AROUND the
   // answering moment room. So while a CORE's candidates are in the air the
@@ -1037,6 +1088,40 @@ test("the lattice thins out while a question is being read — sparser, not dull
     for (let k = 0; k < 8; k++) director.advance(1)
     director.recordKill()
   }
+})
+
+test("ON THE REAL LATTICE, A STRAY SHOT DOES NOT SHORTEN THE WINDOW", () => {
+  // The test below this one asserts the pure function and NOTHING ELSE, which
+  // means the whole fix could be unwired from `dissonance()` and the suite
+  // would stay green. It was, and it did. So: the same deterministic run,
+  // played once with no input and then once per single trigger pull, and every
+  // pull that did not hand a value in must leave the wave running out on
+  // exactly the same frame.
+  //
+  // With the shove restored, eight of the nine non-submitting timings below
+  // close the window early — by up to 92 frames, a second and a half taken off
+  // a six-second window for one stray shot at a hexagon.
+  const quiet = playOneSmallItem([768, 1024], 1400).endings.find((e) => e.end === "unanswered")
+  assert.ok(quiet, "the silent run never ran out")
+
+  let rung = 0
+  for (let f = 300; f < 660; f += 20) {
+    const { endings } = playOneSmallItem([768, 1024], 1400, [f])
+    const ran = endings.find((e) => e.end === "unanswered")
+    // A shot that submitted resolved the wave honestly and is not a sample.
+    if (!ran || endings.some((e) => e.end === "answered" && e.frame < ran.frame)) continue
+    rung++
+    // Never EARLIER. Later is fine and is sometimes right: three kills on one
+    // pulse is a HARMONIC and spends slow-motion, which hands the child a few
+    // more frames. The invariant is one-directional — a stray shot may not
+    // take thinking time away.
+    assert.ok(
+      ran.frame >= quiet.frame,
+      `a shot on frame ${String(f)} moved the wave's end from ${String(quiet.frame)} ` +
+        `to ${String(ran.frame)} — firing at the candidates costs thinking time`,
+    )
+  }
+  assert.ok(rung >= 6, `only ${String(rung)} shots landed without submitting`)
 })
 
 test("RINGING A CANDIDATE DOES NOT SHORTEN THE TIME TO ANSWER IT", () => {


### PR DESCRIPTION
Follow-up to #658, found by its own adversarial review. Three findings, all real.

## The lattice got denser during the one moment it was supposed to thin

`readingRelief` relieves four fields. `Director.wantsSpawn` computed its own pressure instead of taking the one it was handed:

```ts
wantsSpawn(live: number): boolean {
  const p = this.pressure()          // NOT the relieved one
  if (live < p.floorCount) return true
  return this.sinceSpawn >= p.spawnGap
}
```

So the relieved `spawnGap` (×1.75) and `floorCount` (×0.55) reached **no consumer**. The only field that arrived was `descentSeconds`, which makes every hull linger 30% longer — at an unchanged spawn cadence. The feature shipped doing the opposite of what it says, and the README said the other thing.

`wantsSpawn` now takes the pressure to spawn *against*, and the default argument is documented as the trap it was.

Measured on the real lattice, deterministic run, arrivals during a wave:

| | gap between arrivals |
|---|---|
| relieved (now) | **3.42 s** |
| unrelieved (shipped) | 1.98 s |

## Two of the tests were tautologies

Both call sites of `readingRelief` could be deleted from `mount.ts`, and `dissonance()` could go back to the unconditional shove, and the suite stayed at **97 pass / 0 fail**. Each was asserted only on its own pure function — exactly the failure mode #658's own commit message complained about elsewhere. Replaced with assertions on the real lattice:

- **Spawn cadence.** An automaton is born at `t = 0`, which projects to *exactly* the horizon, so a spawn is directly observable as a numeral painted on the horizon line. (The score is a numeral too and sits well above it, which is why this is pinned to the line rather than to "near the top".)
- **The stray shot.** The same deterministic run, played once silently and then once per single trigger pull. Every pull that did not hand a value in must leave the wave running out **no earlier** than the silent run did. One-directional on purpose: *later* is fine and is sometimes right — three kills on one pulse is a HARMONIC and spends slow-motion, which hands the child frames back.

With the shove restored, eight of the nine non-submitting timings close the window early — up to **92 frames, a second and a half off a six-second window, for one stray shot at a hexagon**.

## Smaller, also from the review

- Input is **refused** while the hall is held rather than accepted and looking dead. A tap used to set `fireOnArrive` on a runner that cannot move, then go off on its own two seconds later.
- `traceScroll` now advances during the hold, so the comment claiming the decoration keeps moving is true.
- `endRun` clears a wave still in the air. The landed loop stops clearing candidates once `over` is set, so the question stayed carved on the wall under the game-over scrim until restart.
- `reveal.max` was written and never read — `noUnusedLocals` does not see object properties.
- The `readingRelief` doc claimed the relief applies only at spawn time. `stepSeconds` is passed live to `field.update`, so every in-flight body *does* widen its sideways cadence. Deliberate, and now what the comment says.

Left alone deliberately: `PROMPT_MIN_PX` winning over the box fit can overflow into the host's corners for a synthetic 9-digit prompt, which nothing the curriculum serves reaches (probed every shape up to `5001 − 2798`); and `widestColumn`'s zero/negative-answer guard, which `pack.json`'s declared skills cannot produce.

## Verification

99 tests, 5×, green. `tsc --noEmit` clean. `build:pack` clean. Each fix deleted and re-run:

```
wantsSpawn ignores its argument   → automata arrived 1.98s apart while a question was being read
mount stops passing the relief    → automata arrived 1.98s apart while a question was being read
mount stops relieving at all      → automata arrived 1.98s apart while a question was being read
the candidate shove guard         → a shot on frame 300 moved the wave's end from 677 to 585
mount stops calling shovedUrgency → a shot on frame 300 moved the wave's end from 677 to 585
```

The last one is the important line: it is the mutation that #658's suite could not see.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
