### PR TITLE
fix(dynawalla/games): runner's reading guard was dead code; claim's three answers shared a row

### DIFF
--- a/dynawalla/games/claim/src/game/index.ts
+++ b/dynawalla/games/claim/src/game/index.ts
@@ -43,6 +43,7 @@ import { Input } from "./input.ts"
 import { Juice } from "./juice.ts"
 import { arenaRect, muteRect } from "./layout.ts"
 import { goalFromQuestion, levelAt, type Goal, type Level } from "./levels.ts"
+import { PLATE_ARM, holdPlates, layoutPlates, type Plate } from "./plates.ts"
 import { css, INK, levelInk } from "./palette.ts"
 import { Particles } from "./particles.ts"
 import { Renderer } from "./render.ts"
@@ -61,8 +62,6 @@ type Flood = {
   edge: number
   duration: number
 }
-
-type Plate = { gx: number; gy: number; label: string; correct: boolean; taken: boolean; pop: number }
 
 const START_LIVES = 3
 /**
@@ -149,6 +148,8 @@ class Claim {
   private plates: Plate[] = []
   private gateLeft = 0
   private gateStart = 0
+  /** Which gate is open: the one death opens, or the one a level clear opens. */
+  private gateKind: "revive" | "vault" = "revive"
 
   private frames = 0
   private totalFrames = 0
@@ -508,8 +509,7 @@ class Claim {
         if (this.phaseT > 1.0 && this.card !== "shown") this.showClearCard()
         if (this.phaseT > 3.1 || (this.phaseT > 1.6 && this.input.consumePress())) {
           this.hud.hideCard()
-          this.card = ""
-          this.startLevel(this.levelIndex + 1)
+          this.openVault()
         }
         break
       case "over":
@@ -989,17 +989,37 @@ class Claim {
     this.lives--
     this.hud.setLives(this.lives)
     this.hud.toast(cause === "fuse" ? "BURNT" : "CUT", "bad")
-    this.openGate()
+    this.openGate("revive")
+  }
+
+  /**
+   * The vault: the same three plates, opened by winning instead of by dying.
+   *
+   * Until this existed, `finishGate` was the game's only report and `die()` was
+   * the only way to reach it — so **everything CLAIM ever told the host was
+   * preceded by a crash**. A child who cleared nine levels without dying
+   * answered nothing, as far as an adaptive controller could tell, and the
+   * sample it did get was drawn entirely from the worst moment of a run.
+   *
+   * Nothing is at stake here but score. Being wrong costs nothing (ADR-0009),
+   * which is exactly why it is a clean signal: a child has no reason to answer
+   * it any way other than honestly.
+   */
+  private openVault(): void {
+    this.card = ""
+    this.openGate("vault")
   }
 
   /**
    * Where a free-to-play game would show an ad, this asks for arithmetic.
    *
-   * Three plates, one right. Drive into the right one and you get the life
-   * back and three seconds of shield. Get it wrong, or dither past the ring,
-   * and the life stays spent. Nothing is ever taken for being wrong twice.
+   * Three plates, one right. Hold the right one and — at the revive gate — you
+   * get the life back and three seconds of shield. Get it wrong, or dither past
+   * the ring, and the life stays spent. Nothing is ever taken for being wrong
+   * twice.
    */
-  private openGate(): void {
+  private openGate(kind: "revive" | "vault"): void {
+    this.gateKind = kind
     let q: Question | null = this.spare
     this.spare = null
     if (!q) {
@@ -1016,19 +1036,14 @@ class Claim {
       this.finishGate(false)
       return
     }
-    const labels = this.rng.shuffle([
-      { label: q.answer, correct: true },
-      ...q.distractors.slice(0, 2).map((d) => ({ label: d, correct: false })),
-    ])
-    const n = labels.length
-    this.plates = labels.map((l, i) => ({
-      gx: this.g.w * ((i + 1) / (n + 1)),
-      gy: this.g.h * 0.5,
-      label: l.label,
-      correct: l.correct,
-      taken: false,
-      pop: 0,
-    }))
+    this.plates = layoutPlates(
+      this.g.w,
+      this.g.h,
+      this.rng.shuffle([
+        { label: q.answer, correct: true },
+        ...q.distractors.slice(0, 2).map((d) => ({ label: d, correct: false })),
+      ]),
+    )
     this.gateLeft = GATE_SECONDS
     this.gateStart = performance.now()
     this.phase = "gate"
@@ -1038,23 +1053,28 @@ class Claim {
 
   private updateGate(dt: number): void {
     this.gateLeft -= dt
-    for (const p of this.plates) p.pop = Math.min(1, p.pop + dt * 3.2)
     this.movePlayer(dt)
-    const px = this.px()
-    const py = this.py()
-    for (const p of this.plates) {
-      if (p.taken) continue
-      if (Math.abs(p.gx - px) < 4.2 && Math.abs(p.gy - py) < 3.4) {
-        p.taken = true
-        this.finishGate(p.correct, p.label)
-        return
-      }
+    // Driving over a plate is not answering with it — you have to hold it. See
+    // `plates.ts`: three labels used to share the middle row, so reaching the
+    // far one meant crossing the near ones and being marked wrong for it.
+    const i = holdPlates(this.plates, this.px(), this.py(), dt)
+    if (i >= 0) {
+      const p = this.plates[i] as Plate
+      p.taken = true
+      this.finishGate(p.correct, p.label)
+      return
     }
     if (this.gateLeft <= 0) this.finishGate(false)
   }
 
   private finishGate(correct: boolean, answered = ""): void {
-    if (this.gateQ) {
+    // A vault nobody touched is not a wrong answer, it is a child who wanted to
+    // keep playing. The revive gate is different — the ring closing there costs
+    // a life, so letting it close is a real "I could not do this" — but posting
+    // `correct: false` for an untouched bonus would feed an adaptive controller
+    // a stream of failures manufactured by the game's own pacing.
+    const attempted = answered !== ""
+    if (this.gateQ && (attempted || this.gateKind === "revive")) {
       this.host.report({
         questionId: this.gateQ.id,
         correct,
@@ -1065,6 +1085,31 @@ class Claim {
     this.plates = []
     this.gateQ = null
     this.hud.hideCard()
+
+    if (this.gateKind === "vault") {
+      // A bonus, not a toll. Right pays; wrong costs nothing at all, and the
+      // next level starts either way.
+      if (correct) {
+        this.score += 1200 * this.levelIndex
+        this.audio.gateRight()
+        this.host.haptic("success")
+        this.juice.addTrauma(0.45)
+        this.juice.punch(0.05, 0)
+        this.juice.doFlash(0.16, "#ffe800")
+        this.hud.toast("VAULT", "big")
+        const p = this.r.gridToPx(this.px(), this.py())
+        this.fx.burst(p.x, p.y, 46, 320, 0.85, this.r.cs * 1.4, css(INK.yellow), () => this.rng.next())
+      } else {
+        this.audio.gateWrong()
+        this.juice.addTrauma(0.25)
+      }
+      // `openGate` parks the player behind a 99-second shield so the gate is not
+      // played under fire. Hand back a real number before the next level starts.
+      this.invuln = correct ? 3 : 0
+      this.startLevel(this.levelIndex + 1)
+      return
+    }
+
     if (correct) {
       this.lives++
       this.hud.setLives(this.lives)
@@ -1180,7 +1225,7 @@ class Claim {
 
     if (this.phase === "gate") {
       for (const p of this.plates) {
-        this.r.drawPlate(p.gx, p.gy, p.label, p.pop, this.time)
+        this.r.drawPlate(p.gx, p.gy, p.label, p.pop, this.time, p.charge / PLATE_ARM)
       }
       this.r.drawGateRing(this.gateLeft / GATE_SECONDS)
     }

--- a/dynawalla/games/claim/src/game/plates.ts
+++ b/dynawalla/games/claim/src/game/plates.ts
@@ -1,0 +1,106 @@
+// The revive gate's three plates — where the child answers.
+//
+// This is the only surface in CLAIM that produces an answer an exact judge can
+// grade (see `Goal.questionId` in `levels.ts` for why a banded cut cannot be
+// one), so it is the one place where "the child computed it right and the game
+// said wrong" is unforgivable. It lives out here, away from the canvas and the
+// DOM, so that claim can be proved rather than played.
+//
+// Two rules, and they are both about the same thing:
+//
+//   1. **No two plates share a row or a column.** They used to sit at
+//      `gy = h * 0.5` with `gx` at a quarter, a half and three quarters of the
+//      width — three labels strung along one line, in a game whose player moves
+//      one cell at a time along rows and columns. Driving to the far plate meant
+//      driving *through* the near ones, and the first box entered took the
+//      answer. A child who computed 4500, saw it on the right-hand plate and
+//      drove right was recorded as having answered whatever was in the middle.
+//      The centre row was also exactly where the prompt card is drawn.
+//
+//   2. **Arriving is not answering.** Separation alone only makes a mis-take
+//      unlikely — the player still picks their own route. So a plate must be
+//      *held*: it fills while you stand on it and empties the instant you leave,
+//      and `PLATE_ARM` is longer than the time it takes to cross one at any
+//      speed the ladder can reach. Passing over an answer can no longer give it.
+
+export type Plate = {
+  gx: number
+  gy: number
+  label: string
+  correct: boolean
+  taken: boolean
+  /** Entry animation, 0→1. */
+  pop: number
+  /** Seconds held, 0→`PLATE_ARM`. */
+  charge: number
+}
+
+/** Half-width of a plate, in cells. Matches what `render.drawPlate` draws. */
+export const PLATE_HALF_W = 4.2
+/** Half-height of a plate, in cells. */
+export const PLATE_HALF_H = 3.4
+
+/**
+ * Seconds a plate must be held before it answers.
+ *
+ * Must stay above the time it takes to drive across one — `railSpeed` is 25
+ * cells per second at level one, so a crossing is 8.4/25 = 0.34s. There is a
+ * test that walks the whole ladder and holds this to it.
+ */
+export const PLATE_ARM = 0.55
+
+/**
+ * Where the plates sit, as fractions of the arena.
+ *
+ * Distinct rows and distinct columns, every pair separated by more than a plate,
+ * and none of them in the middle band of the screen where the prompt card is.
+ * Index order is fixed; which *label* lands on which plate is shuffled by the
+ * caller, so there is no learnable "the answer is always the low one".
+ */
+export const PLATE_SPOTS: ReadonlyArray<readonly [number, number]> = [
+  [0.22, 0.18],
+  [0.78, 0.62],
+  [0.5, 0.86],
+]
+
+/** Lay out up to three plates on an arena `gw` x `gh` cells (rail included). */
+export function layoutPlates(
+  gw: number,
+  gh: number,
+  labels: ReadonlyArray<{ label: string; correct: boolean }>,
+): Plate[] {
+  return labels.slice(0, PLATE_SPOTS.length).map((l, i) => {
+    const [fx, fy] = PLATE_SPOTS[i] as readonly [number, number]
+    return { gx: gw * fx, gy: gh * fy, label: l.label, correct: l.correct, taken: false, pop: 0, charge: 0 }
+  })
+}
+
+/** Is the player standing on this plate? */
+export function onPlate(p: Plate, px: number, py: number): boolean {
+  return Math.abs(p.gx - px) < PLATE_HALF_W && Math.abs(p.gy - py) < PLATE_HALF_H
+}
+
+/**
+ * Advance every plate's hold and return the index of the one just answered, or
+ * -1.
+ *
+ * Leaving a plate empties it outright rather than draining it. A child crossing
+ * two plates on the way to a third must not be able to bank two half-holds into
+ * an answer they never chose, and "it empties when you step off" is a rule a
+ * ten-year-old can see happening.
+ */
+export function holdPlates(plates: Plate[], px: number, py: number, dt: number): number {
+  let answered = -1
+  for (let i = 0; i < plates.length; i++) {
+    const p = plates[i] as Plate
+    if (p.taken) continue
+    p.pop = Math.min(1, p.pop + dt * 3.2)
+    if (onPlate(p, px, py)) {
+      p.charge += dt
+      if (p.charge >= PLATE_ARM && answered < 0) answered = i
+    } else {
+      p.charge = 0
+    }
+  }
+  return answered
+}

--- a/dynawalla/games/claim/src/game/render.ts
+++ b/dynawalla/games/claim/src/game/render.ts
@@ -5,6 +5,7 @@
 // smoothing off, so a fully claimed arena costs exactly the same as an empty
 // one. Nothing per-cell happens in the draw loop.
 
+import { clamp } from "./exact.ts"
 import { VOID, type Grid } from "./grid.ts"
 import { batchColour, css, INK, mix, type LevelInk, type Rgb } from "./palette.ts"
 import type { Particles } from "./particles.ts"
@@ -564,24 +565,36 @@ export class Renderer {
   }
 
   /** A revive-gate answer plate. Big enough to hit at speed with a thumb. */
-  drawPlate(gx: number, gy: number, label: string, pop: number, time: number): void {
+  /**
+   * `hold` is 0→1 as the player stands on the plate. It is drawn as a tide
+   * rising up the plate, because "arriving is not answering" has to be
+   * something a child *sees* happening rather than something they are told: you
+   * stop on the one you mean and it fills, you drive over it and it does not.
+   */
+  drawPlate(gx: number, gy: number, label: string, pop: number, time: number, hold = 0): void {
     const ctx = this.ctx
     const cs = this.cs
     const p = this.gridToPx(gx, gy)
     const k = 0.35 + 0.65 * pop
-    const bob = Math.sin(time * 2.4 + gx * 0.4) * cs * 0.5
+    const t = clamp(hold, 0, 1)
+    const bob = Math.sin(time * 2.4 + gx * 0.4) * cs * 0.5 * (1 - t)
     const w = cs * 8.4 * k
     const h = cs * 5.4 * k
     ctx.save()
     ctx.translate(p.x, p.y + bob)
+    ctx.scale(1 + t * 0.06, 1 + t * 0.06)
     ctx.globalCompositeOperation = "lighter"
-    ctx.fillStyle = css(INK.yellow, 0.16)
+    ctx.fillStyle = css(INK.yellow, 0.16 + t * 0.3)
     ctx.fillRect(-w * 0.62, -h * 0.72, w * 1.24, h * 1.44)
     ctx.globalCompositeOperation = "source-over"
     ctx.fillStyle = css(INK.paper)
     ctx.fillRect(-w / 2, -h / 2, w, h)
+    if (t > 0) {
+      ctx.fillStyle = css(INK.yellow, 0.34 + t * 0.4)
+      ctx.fillRect(-w / 2, h / 2 - h * t, w, h * t)
+    }
     ctx.strokeStyle = css(INK.yellow)
-    ctx.lineWidth = Math.max(2, cs * 0.34)
+    ctx.lineWidth = Math.max(2, cs * (0.34 + t * 0.5))
     ctx.strokeRect(-w / 2, -h / 2, w, h)
     ctx.fillStyle = css(INK.bone)
     ctx.textAlign = "center"

--- a/dynawalla/games/claim/test/claim.test.ts
+++ b/dynawalla/games/claim/test/claim.test.ts
@@ -237,6 +237,40 @@ test("a question the level cannot use falls back to the ladder", () => {
   assert.equal(goalFromQuestion(levelAt(9), 7200, huge).target, 6480)
 })
 
+test("KNOWN GAP: an ordinary arithmetic answer can never be this game's goal", () => {
+  // Not a fix — a pin on a hole, so that the next person to read `goalFromQuestion`
+  // does not mistake it for a working seam.
+  //
+  // A goal must be a whole number of cells of a 7200-cell plane and at least
+  // `total/20` = 360 of them, because a seven-cell goal is not a game. Every
+  // answer a two-digit skill produces is under 200, so **no question from an
+  // arithmetic curriculum ever becomes the goal** — the fraction the child works
+  // is always the hardcoded LADDER's, and the host's question is spent on the
+  // gate instead.
+  //
+  // Widening the threshold does not fix it. The blocker is the representation:
+  // CLAIM's own `covers.skills` are fraction skills whose answers are fractions
+  // ("3/4"), and `Number("3/4")` is not an integer, so those are rejected before
+  // the threshold is even reached. Only an answer that is *literally a count of
+  // cells* can drive the goal, and nothing in the curriculum graph produces one.
+  //
+  // Closing it needs a decision this game cannot make on its own — either a
+  // generator whose answers are areas of 7200, or a documented mapping from a
+  // small answer onto the plane (answer-as-percent, answer-as-blocks) that the
+  // goal card would have to teach. Both are design work, not a threshold tweak.
+  for (const answer of [7, 63, 99, 198, 359]) {
+    const g = goalFromQuestion(levelAt(1), 7200, { id: "q", prompt: "27 + 35", answer: String(answer) })
+    assert.equal(g.questionId, null, `${answer} became a goal — has the mapping landed?`)
+    assert.equal(g.target, 3600, "the ladder's own fraction is what the child actually works")
+  }
+  // And a fraction-shaped answer, which is what this pack's declared skills
+  // produce, is rejected before any threshold applies.
+  assert.equal(
+    goalFromQuestion(levelAt(3), 7200, { id: "q", prompt: "6/8 in lowest terms", answer: "3/4" }).questionId,
+    null,
+  )
+})
+
 test("every level's own ladder goal is inside its own share window", () => {
   for (let i = 1; i <= 60; i++) {
     const l = levelAt(i)

--- a/dynawalla/games/claim/test/domstub.ts
+++ b/dynawalla/games/claim/test/domstub.ts
@@ -1,0 +1,159 @@
+// Just enough browser to run the real game in `node --test`.
+//
+// CLAIM's only report used to be reachable from `die()` alone, and the test that
+// pinned it counted `host.report(` calls in the source because "the game class
+// needs a DOM". That is true, and it is also why the reporting hole survived:
+// nothing could ever *play* the game and look at what came out. This is the
+// smallest stub that lets `tick()`/`hold()` drive the actual loop — same update,
+// same collision, same claim rule, same gate.
+//
+// Nothing here is asserted on. It exists so the assertions can be about the
+// game.
+
+type Any = Record<string, unknown>
+
+const rect = { x: 0, y: 0, width: 1024, height: 768, top: 0, left: 0, right: 1024, bottom: 768 }
+
+function ctx2d(): Any {
+  const store: Any = {}
+  return new Proxy(store, {
+    get(t, k) {
+      if (k === "canvas") return { width: 1024, height: 768 }
+      if (k === "measureText") return () => ({ width: 12 })
+      if (k === "createLinearGradient" || k === "createRadialGradient" || k === "createPattern")
+        return () => ({ addColorStop: () => {} })
+      if (k === "createImageData" || k === "getImageData")
+        return (w: number, h: number) => ({
+          width: w,
+          height: h,
+          data: new Uint8ClampedArray(Math.max(4, w * h * 4)),
+        })
+      if (k in t) return t[k as string]
+      return () => undefined
+    },
+    set(t, k, v) {
+      t[k as string] = v
+      return true
+    },
+  }) as unknown as Any
+}
+
+function el(tag = "div"): Any {
+  const style = new Proxy({} as Any, {
+    get: (t, k) => (k === "setProperty" || k === "removeProperty" ? () => {} : (t[k as string] ?? "")),
+    set: (t, k, v) => {
+      t[k as string] = v
+      return true
+    },
+  })
+  const node: Any = {
+    tagName: tag.toUpperCase(),
+    className: "",
+    innerHTML: "",
+    textContent: "",
+    tabIndex: 0,
+    style,
+    dataset: {},
+    children: [] as Any[],
+    width: 1024,
+    height: 768,
+    clientWidth: 1024,
+    clientHeight: 768,
+    offsetWidth: 1024,
+    offsetHeight: 768,
+    classList: { add: () => {}, remove: () => {}, toggle: () => {}, contains: () => false },
+    appendChild(c: Any) {
+      ;(node.children as Any[]).push(c)
+      return c
+    },
+    insertBefore(c: Any) {
+      ;(node.children as Any[]).push(c)
+      return c
+    },
+    removeChild() {},
+    remove() {},
+    append() {},
+    focus() {},
+    blur() {},
+    click() {},
+    addEventListener() {},
+    removeEventListener() {},
+    setAttribute() {},
+    removeAttribute() {},
+    getAttribute: () => null,
+    setPointerCapture() {},
+    releasePointerCapture() {},
+    // The HUD builds itself with `innerHTML` and then reaches for the pieces.
+    // A stub that answers `null` makes the game crash on its first frame, so
+    // every selector gets a stable element of its own.
+    querySelector(sel: string) {
+      const cache = node._q as Record<string, Any>
+      return (cache[sel] ??= el("div"))
+    },
+    querySelectorAll: () => [],
+    _q: {} as Record<string, Any>,
+    closest: () => null,
+    contains: () => false,
+    getBoundingClientRect: () => rect,
+    getContext: () => ctx2d(),
+    toDataURL: () => "",
+  }
+  return node
+}
+
+let installed = false
+
+/** Install once. Returns a detached element to mount the game into. */
+export function stubDom(): Any {
+  const g = globalThis as unknown as Any
+  if (!installed) {
+    installed = true
+    const body = el("body")
+    g.document = {
+      createElement: (t: string) => el(t),
+      createElementNS: (_ns: string, t: string) => el(t),
+      createTextNode: () => el("#text"),
+      getElementById: () => null,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      body,
+      documentElement: el("html"),
+      head: el("head"),
+      fonts: { ready: Promise.resolve(), load: () => Promise.resolve(), add: () => {} },
+      visibilityState: "visible",
+      hidden: false,
+    }
+    g.Path2D = class {
+      moveTo() {}
+      lineTo() {}
+      arc() {}
+      rect() {}
+      closePath() {}
+addPath() {}
+    }
+    g.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    g.requestAnimationFrame = () => 1
+    g.cancelAnimationFrame = () => {}
+    g.matchMedia = () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+    })
+    g.getComputedStyle = () => ({ getPropertyValue: () => "0px" })
+    g.devicePixelRatio = 2
+    g.innerWidth = 1024
+    g.innerHeight = 768
+    g.addEventListener = () => {}
+    g.removeEventListener = () => {}
+    g.window = g
+  }
+  return el("div")
+}

--- a/dynawalla/games/claim/test/plates.test.ts
+++ b/dynawalla/games/claim/test/plates.test.ts
@@ -1,0 +1,187 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { ARENAS, makeGrid, pickArena } from "../src/game/grid.ts"
+import { levelAt } from "../src/game/levels.ts"
+import {
+  PLATE_ARM,
+  PLATE_HALF_H,
+  PLATE_HALF_W,
+  holdPlates,
+  layoutPlates,
+  onPlate,
+  type Plate,
+} from "../src/game/plates.ts"
+
+const LABELS = [
+  { label: "4500", correct: true },
+  { label: "3600", correct: false },
+  { label: "5040", correct: false },
+]
+
+/** Every arena the game can be played on, rail included. */
+const GRIDS = ARENAS.map((a) => makeGrid(a))
+
+// ---------------------------------------------------------------------------
+// The plate row. This is the defect: three answers on one line, in a game where
+// the player travels along lines.
+// ---------------------------------------------------------------------------
+
+test("no two plates share a row or a column", () => {
+  for (const g of GRIDS) {
+    const ps = layoutPlates(g.w, g.h, LABELS)
+    assert.equal(ps.length, 3)
+    for (let i = 0; i < ps.length; i++) {
+      for (let j = i + 1; j < ps.length; j++) {
+        const a = ps[i] as Plate
+        const b = ps[j] as Plate
+        assert.ok(
+          Math.abs(a.gx - b.gx) > PLATE_HALF_W * 2,
+          `${g.w}x${g.h}: plates ${i} and ${j} are ${Math.abs(a.gx - b.gx).toFixed(1)} cells apart in x`,
+        )
+        assert.ok(
+          Math.abs(a.gy - b.gy) > PLATE_HALF_H * 2,
+          `${g.w}x${g.h}: plates ${i} and ${j} share a row (${a.gy.toFixed(1)} vs ${b.gy.toFixed(1)})`,
+        )
+      }
+    }
+  }
+})
+
+test("a plate is never off the arena, on the rail, or under the prompt card", () => {
+  for (const g of GRIDS) {
+    for (const p of layoutPlates(g.w, g.h, LABELS)) {
+      assert.ok(p.gx - PLATE_HALF_W > 1 && p.gx + PLATE_HALF_W < g.w - 1, `${g.w}x${g.h}: ${p.label} off the side`)
+      assert.ok(p.gy - PLATE_HALF_H > 1 && p.gy + PLATE_HALF_H < g.h - 1, `${g.w}x${g.h}: ${p.label} off the top/bottom`)
+      // The prompt is a DOM card centred over the canvas. A plate behind it is
+      // a candidate a child cannot read — which is what the middle plate was,
+      // sitting at exactly `h * 0.5`.
+      assert.ok(
+        Math.abs(p.gy - g.h / 2) > PLATE_HALF_H,
+        `${g.w}x${g.h}: ${p.label} sits under the prompt card`,
+      )
+    }
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Arriving is not answering.
+// ---------------------------------------------------------------------------
+
+/**
+ * Drive the player in a straight line, one axis at a time, exactly as
+ * `movePlayer` does: constant cells per second, no acceleration.
+ *
+ * Returns every plate index that answered along the way.
+ */
+function drive(
+  plates: Plate[],
+  from: [number, number],
+  to: [number, number],
+  cellsPerSecond: number,
+): number[] {
+  const dt = 1 / 60
+  const dist = Math.hypot(to[0] - from[0], to[1] - from[1])
+  const steps = Math.ceil((dist / cellsPerSecond) * 60)
+  const answered: number[] = []
+  for (let s = 0; s <= steps; s++) {
+    const k = s / steps
+    const px = from[0] + (to[0] - from[0]) * k
+    const py = from[1] + (to[1] - from[1]) * k
+    const i = holdPlates(plates, px, py, dt)
+    if (i >= 0) {
+      answered.push(i)
+      ;(plates[i] as Plate).taken = true
+    }
+  }
+  return answered
+}
+
+test("driving across a plate never answers with it, at any speed the ladder reaches", () => {
+  // The old rule answered on contact. On a 120-wide arena the plates sat at
+  // x=30, 60 and 90 on the same row, so a child who worked out the answer, saw
+  // it on the right-hand plate and drove right was recorded as having chosen
+  // whichever plate they crossed first.
+  for (const g of GRIDS) {
+    for (const li of [1, 2, 5, 9, 20, 40, 60]) {
+      const speed = levelAt(li).railSpeed
+      for (const p of layoutPlates(g.w, g.h, LABELS)) {
+        const ps = layoutPlates(g.w, g.h, LABELS)
+        // Straight through the middle of it, both ways, both axes.
+        const runs: Array<[[number, number], [number, number]]> = [
+          [[0.5, p.gy], [g.w - 0.5, p.gy]],
+          [[g.w - 0.5, p.gy], [0.5, p.gy]],
+          [[p.gx, 0.5], [p.gx, g.h - 0.5]],
+          [[p.gx, g.h - 0.5], [p.gx, 0.5]],
+        ]
+        for (const [a, b] of runs) {
+          for (const q of ps) {
+            q.charge = 0
+            q.taken = false
+          }
+          const hits = drive(ps, a, b, speed)
+          assert.deepEqual(
+            hits,
+            [],
+            `${g.w}x${g.h} level ${li} (${speed} c/s): driving ${a} → ${b} answered with ` +
+              hits.map((i) => (ps[i] as Plate).label).join(","),
+          )
+        }
+      }
+    }
+  }
+})
+
+test("the hold is longer than the crossing, with room to spare, on every level", () => {
+  // The invariant the test above is a consequence of. `railSpeed` is the fast
+  // one — `cutSpeed` is slower and the player is never cutting at the gate.
+  for (let i = 1; i <= 60; i++) {
+    const speed = levelAt(i).railSpeed
+    const crossing = Math.max(PLATE_HALF_W * 2, PLATE_HALF_H * 2) / speed
+    assert.ok(
+      PLATE_ARM > crossing * 1.3,
+      `level ${i}: crossing a plate takes ${crossing.toFixed(2)}s and the hold is only ${PLATE_ARM}s`,
+    )
+  }
+})
+
+test("standing on the plate you meant does answer with it, well inside the gate clock", () => {
+  const g = makeGrid(pickArena(96 / 75))
+  const ps = layoutPlates(g.w, g.h, LABELS)
+  const want = ps.findIndex((p) => p.correct)
+  const target = ps[want] as Plate
+  let held = 0
+  let answered = -1
+  for (let s = 0; s < 600 && answered < 0; s++) {
+    held += 1 / 60
+    answered = holdPlates(ps, target.gx, target.gy, 1 / 60)
+  }
+  assert.equal(answered, want, "the plate under the player is the one that answers")
+  assert.equal((ps[answered] as Plate).correct, true)
+  assert.ok(held < 1, `it took ${held.toFixed(2)}s to answer a plate you are standing on`)
+  assert.ok(held < 7, "the gate ring closes at seven seconds")
+})
+
+test("stepping off empties a plate rather than banking it", () => {
+  const g = makeGrid(pickArena(96 / 75))
+  const ps = layoutPlates(g.w, g.h, LABELS)
+  const p = ps[0] as Plate
+  // Nearly there...
+  for (let s = 0; s < 30; s++) holdPlates(ps, p.gx, p.gy, 1 / 60)
+  assert.ok(p.charge > 0.4)
+  // ...and away. Two near-misses must not add up to an answer.
+  holdPlates(ps, p.gx + PLATE_HALF_W + 1, p.gy, 1 / 60)
+  assert.equal(p.charge, 0)
+  for (let s = 0; s < 30; s++) {
+    assert.equal(holdPlates(ps, p.gx, p.gy, 1 / 60), -1, "a second half-crossing answered")
+  }
+})
+
+test("the hit box is what the plate looks like, not something smaller", () => {
+  const g = makeGrid(pickArena(96 / 75))
+  const p = (layoutPlates(g.w, g.h, LABELS)[0] as Plate)
+  assert.equal(onPlate(p, p.gx, p.gy), true)
+  assert.equal(onPlate(p, p.gx + PLATE_HALF_W * 0.9, p.gy + PLATE_HALF_H * 0.9), true)
+  assert.equal(onPlate(p, p.gx + PLATE_HALF_W + 0.01, p.gy), false)
+  assert.equal(onPlate(p, p.gx, p.gy + PLATE_HALF_H + 0.01), false)
+})

--- a/dynawalla/games/claim/test/report.test.ts
+++ b/dynawalla/games/claim/test/report.test.ts
@@ -1,0 +1,225 @@
+// WHAT THE GAME TELLS THE HOST.
+//
+// CLAIM had exactly one `host.report`, inside `finishGate`, and the only route
+// to it was `die() -> openGate()`. **Every answer the game had ever reported was
+// preceded by a crash.** A child who cleared level after level without dying was,
+// to an adaptive controller reading that stream, a child who had answered
+// nothing — and the sample it did get was drawn entirely from the moment a run
+// fell apart.
+//
+// So this file plays the actual game, through the same `tick()`/`hold()` seam QA
+// uses, on the smallest browser stub that will hold it up.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { stubDom } from "./domstub.ts"
+
+stubDom()
+
+
+const { mount } = await import("../src/game/index.ts")
+const { createStubHost } = await import("../src/stubHost.ts")
+const { PLATE_ARM, PLATE_SPOTS } = await import("../src/game/plates.ts")
+
+/**
+ * A stub-host seed whose level one can be cleared by the straight-cut routine at
+ * the bottom of this file without the drifter ever catching the line.
+ *
+ * The game is deterministic given the host's question stream (`startLevel`
+ * re-seeds from the first question id), so this is a *replay*, not a fixture —
+ * change the arena, the hunter or the claim rule and this run changes with it.
+ */
+const CLEAN_RUN = "both"
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+type Harness = {
+  game: {
+    tick(dt: number): void
+    hold(x: number, y: number): void
+    stats(): Record<string, number | string>
+  }
+  reports: Report[]
+  unmount(): void
+}
+
+function start(seed: string | number): Harness {
+  const el = stubDom()
+  const reports: Report[] = []
+  const host = createStubHost({
+    total: 7200,
+    seed,
+    onReport: (r: Report) => reports.push(r),
+  })
+  const handle = mount(el as unknown as HTMLElement, host)
+  const game = (el as unknown as { __claim: Harness["game"] }).__claim
+  return { game, reports, unmount: handle.unmount }
+}
+
+/** Run `seconds` of real frames at 60Hz. */
+function run(h: Harness, seconds: number): void {
+  for (let i = 0; i < Math.round(seconds * 60); i++) h.game.tick(1 / 60)
+}
+
+/**
+ * Sit through the clear card until the gate is actually up.
+ *
+ * Not a fixed wait: the gate ring is seven seconds and every frame spent
+ * waiting is a frame the child does not have to answer in, which is exactly the
+ * kind of accounting this file exists to keep honest.
+ */
+function runToGate(h: Harness): void {
+  const G = h.game as unknown as { phase: string }
+  for (let i = 0; i < 900 && G.phase !== "gate"; i++) h.game.tick(1 / 60)
+  assert.equal(G.phase, "gate", "no gate ever opened")
+}
+
+test("the game runs headlessly at all — the stub holds up", () => {
+  const h = start("smoke")
+  run(h, 2)
+  const s = h.game.stats()
+  assert.equal(s.total, 7200)
+  assert.ok(Number(s.level) >= 1)
+  h.unmount()
+})
+
+// ---------------------------------------------------------------------------
+// The hole.
+// ---------------------------------------------------------------------------
+
+test("clearing a level opens a gate, so a run that never dies can still answer", () => {
+  const h = start(CLEAN_RUN)
+  // Skip the intro card, then take the whole plane: with no hunter able to
+  // reach it, the first closed loop claims everything and clears the level.
+  run(h, 2)
+  clearALevel(h)
+  assert.equal(Number(h.game.stats().lives), 3, "nobody died getting here")
+
+  // The clear card, then the vault.
+  runToGate(h)
+  const plates = platesOf(h)
+  assert.equal(plates.length, 3, "a level clear must put a question up")
+
+  // Drive onto the right one and hold it.
+  const want = plates.find((p) => p.correct)
+  assert.ok(want, "one plate must be the answer")
+  driveTo(h, want.gx, want.gy)
+  run(h, PLATE_ARM + 0.4)
+
+  assert.equal(h.reports.length, 1, `expected one report, got ${JSON.stringify(h.reports)}`)
+  const r = h.reports[0] as Report
+  assert.equal(r.correct, true, "a correct answer, reported, with no death anywhere in the run")
+  assert.equal(r.answered, want.label, "exact in, exact out")
+  assert.equal(Number(h.game.stats().lives), 3, "and it cost nothing")
+  h.unmount()
+})
+
+test("the vault answers with the plate you held, not the ones you drove over", () => {
+  // The defect: three plates on one row, answered on contact. Reaching the far
+  // one meant crossing the near ones, and the first box entered took the answer.
+  const h = start(CLEAN_RUN)
+  run(h, 2)
+  clearALevel(h)
+  runToGate(h)
+  const plates = platesOf(h)
+  assert.equal(plates.length, 3)
+  const want = plates.find((p) => p.correct)
+  assert.ok(want)
+
+  // Go straight over a wrong one on the way — the gate ring is seven seconds,
+  // so this is one detour, not a tour. `plates.test.ts` walks every plate on
+  // every arena at every speed the ladder reaches.
+  const [px, py] = playerAt(h)
+  const wrong = plates
+    .filter((p) => !p.correct)
+    .sort((a, b) => Math.hypot(a.gx - px, a.gy - py) - Math.hypot(b.gx - px, b.gy - py))[0]
+  assert.ok(wrong)
+  driveTo(h, wrong.gx, wrong.gy)
+  driveTo(h, wrong.gx + 7, wrong.gy)
+  assert.equal(h.reports.length, 0, `driving over a plate answered: ${JSON.stringify(h.reports)}`)
+  assert.equal(wrong.charge, 0, "leaving a plate must empty it")
+
+  driveTo(h, want.gx, want.gy)
+  run(h, PLATE_ARM + 0.4)
+  assert.equal(h.reports.length, 1, `expected the held plate to answer: ${JSON.stringify(h.reports)}`)
+  assert.equal((h.reports[0] as Report).correct, true)
+  assert.equal((h.reports[0] as Report).answered, want.label)
+  h.unmount()
+})
+
+test("a vault nobody touched is not reported as a wrong answer", () => {
+  // The trap in adding a second question surface: a bonus that opens after
+  // every level, reported as failed whenever a child ignores it, would hand the
+  // adaptive controller a stream of failures the game manufactured itself.
+  const h = start(CLEAN_RUN)
+  run(h, 2)
+  clearALevel(h)
+  runToGate(h)
+  run(h, 8) // the ring closes with nobody on a plate
+  assert.deepEqual(h.reports, [], "not answering is not answering wrong")
+  assert.ok(Number(h.game.stats().level) >= 2, "and the vault must not stall the ladder")
+  h.unmount()
+})
+
+test("the plates are never all on one line", () => {
+  // Pinned here as well as in `plates.test.ts` because this is the arrangement
+  // the running game actually builds.
+  const h = start(CLEAN_RUN)
+  run(h, 2)
+  clearALevel(h)
+  runToGate(h)
+  const ps = platesOf(h)
+  const rows = new Set(ps.map((p) => Math.round(p.gy)))
+  const cols = new Set(ps.map((p) => Math.round(p.gx)))
+  assert.equal(rows.size, 3, "three answers on one row is the bug")
+  assert.equal(cols.size, 3)
+  assert.equal(PLATE_SPOTS.length, 3)
+  h.unmount()
+})
+
+/* ------------------------------- driving --------------------------------- */
+
+type P = { gx: number; gy: number; label: string; correct: boolean; charge: number }
+
+function platesOf(h: Harness): P[] {
+  return (h.game as unknown as { plates: P[] }).plates
+}
+
+function playerAt(h: Harness): [number, number] {
+  const g = h.game as unknown as { cx: number; cy: number }
+  return [g.cx + 0.5, g.cy + 0.5]
+}
+
+/** Steer to a cell the way a thumb would: one axis, then the other. */
+function driveTo(h: Harness, tx: number, ty: number): void {
+  for (const axis of ["x", "y"] as const) {
+    for (let i = 0; i < 600; i++) {
+      const [px, py] = playerAt(h)
+      const d = axis === "x" ? tx - px : ty - py
+      if (Math.abs(d) < 0.75) break
+      if (axis === "x") h.game.hold(Math.sign(d), 0)
+      else h.game.hold(0, Math.sign(d))
+      h.game.tick(1 / 60)
+    }
+  }
+  h.game.hold(0, 0)
+}
+
+/**
+ * Play a level the way it is meant to be played: straight cuts, rail to rail,
+ * working across the plane a few columns at a time until the meter reaches the
+ * band. No cheat seam, no forced state — `closeCut` decides, exactly as it does
+ * on a tablet.
+ */
+function clearALevel(h: Harness): void {
+  const G = h.game as unknown as { g: { w: number; h: number }; phase: string }
+  for (let pass = 0; pass < 40; pass++) {
+    if (G.phase !== "play") return
+    const x = 3 + pass * 3
+    if (x > G.g.w - 3) return
+    driveTo(h, x, pass % 2 === 0 ? 0 : G.g.h - 1)
+    driveTo(h, x, pass % 2 === 0 ? G.g.h - 1 : 0)
+    run(h, 0.3)
+  }
+}

--- a/dynawalla/games/runner/README.md
+++ b/dynawalla/games/runner/README.md
@@ -46,9 +46,12 @@ voltage with 2.6 seconds of invulnerability — and your surge reset to
 ×1, which is the real price. Miss it and the run ends. Recharges are unlimited
 and the question gets harder each time; nothing is bought and nothing is scarce.
 
-`difficulty` is a hint to the host, not a demand: it climbs with distance and
-surge, and **drops hard when a child is actually struggling** (below 60% over the
-last handful of gates buys 2.2 levels of relief). See `src/game/pacing.ts`.
+`difficulty` is a hint to the host, not a demand: it climbs **one step per four
+gates read correctly** — never on distance, never on how long you stayed alive —
+plus a little for a hot surge, and it **drops hard when a child is actually
+struggling** (below 60% over the last handful of gates buys 2.2 levels of
+relief). Escalation is on achievement; surviving is not an achievement. See
+`src/game/pacing.ts`.
 
 ## What makes it readable at 60 units per second
 
@@ -91,11 +94,22 @@ read.
 - A character the atlas does not know renders as `?`, never as nothing. Silently
   skipping the glyph turns `3/4` into `34`, which is not an unreadable answer —
   it is a different and wrong one.
-- The **reading window is the difficulty knob**, not the speed: 3.4s at the start,
-  compressing toward a **hard floor of 1.55 seconds** that nothing can push
-  through. Reduced motion adds another half-second.
-- Hazards are suppressed within thirty metres of a gate. Dodging while reading is
-  not difficulty, it is noise.
+- The **reading window is the difficulty knob**, not the speed: 5.4s at the start,
+  compressing toward a **hard floor of 3.2 seconds** that nothing can push
+  through — and the floor is checked against what the *draw distance* can
+  actually deliver on the smallest tier at full speed, because a gate cannot
+  spawn past the far plane and the clamp used to quietly hand back less than the
+  floor promised. Reduced motion adds another half-second. This pack covers
+  `subtract-across-zero`, and `docs/EXPERIENCE_DESIGN.md` instruments two-digit
+  regrouping at p50 6s; a gate cycle — read it, then run the corridor — is about
+  5.3 seconds, which is the number that has to answer to that table.
+- **Nothing to dodge ever arrives while a gate is being read.** A hazard spawns
+  at the horizon and is airborne for five to seven seconds, so keeping that
+  promise means projecting the gate cycle forward to where the hazard will land,
+  not comparing its spawn point to a gate's current position — which is what the
+  guard used to do, and why roughly two hazards landed in every reading window.
+  Everything to dodge lives in the corridor between gates, which is why the
+  corridor is nearly two seconds wide.
 
 ## Endless
 

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -30,7 +30,9 @@ import { Shake, HitStop, FlashBus, Springy, clamp, clamp01, lerp, approach, ease
 import {
   V_START, V_TERMINAL, V_REDUCED_CAP, VOLT_MAX, COST_WRONG_GATE, COST_HAZARD,
   GAIN_GATE, GAIN_SPARK, GAIN_GRAZE, VOLT_BLEED, CHAIN_PER_SURGE, SURGE_MAX,
-  STUMBLE_TIME, CLEAN_READ_SHARE, REVIVE_GRACE, speedAt, readWindow, breather, beatTime, difficultyFor,
+  STUMBLE_TIME, CLEAN_READ_SHARE, REVIVE_GRACE,
+  speedAt, readWindow, breather, beatTime, difficultyFor,
+  gateDistance, hazardLandsOnRead,
 } from "./pacing.ts";
 
 type Phase = "idle" | "running" | "dying" | "revive" | "over";
@@ -479,14 +481,14 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
 
   /* --------------------------------- gates ------------------------------ */
 
-  const difficulty = (): number => difficultyFor(travel, surge, stats.gates, stats.gatesRight);
+  const difficulty = (): number => difficultyFor(surge, stats.gates, stats.gatesRight);
 
   function requestGate(): void {
     if (activeGate) return;
     const q = pendingQuestion ?? host.next({ difficulty: difficulty() });
     pendingQuestion = null;
     const w = readWindow(travel, reduced());
-    const dist = clamp(speed * w, 68, tiers.settings.far * 0.84);
+    const dist = gateDistance(speed, w, tiers.settings.far);
     const g = ents.spawnGate(q, dist, dist / Math.max(1, speed), rng);
     if (!g) {
       pendingQuestion = q;
@@ -612,11 +614,44 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     return r < 0.38 ? "pylon" : r < 0.62 ? "lowbar" : r < 0.8 ? "pit" : "sweeper";
   }
 
+  /**
+   * Sparks strung across all three lanes.
+   *
+   * What a reading corridor gets instead of a pylon. It is not silence — the
+   * causeway still lights up and there is still something to collect — but it
+   * asks for nothing: whichever lane the child has read their way into, the
+   * sparks are already there, so the corridor cannot pull them out of it.
+   */
+  function readingArch(spawnZ: number): void {
+    if (!rng.chance(0.55)) return;
+    for (let l = 0; l < 3; l++) ents.spawnSpark(laneX(l), 1.3, spawnZ + (l === 1 ? 3 : 0));
+  }
+
   function emitBeat(): void {
     const spawnZ = tiers.settings.far * 0.88;
     // Never put a hazard inside the reading window of a gate: the child would
     // be dodging while reading, which is not difficulty, it is noise.
-    if (activeGate && Math.abs(-spawnZ - activeGate.z) < 30) return;
+    //
+    // A hazard emitted here does not arrive here — it is five to seven seconds
+    // downrange, further out than the gate that is up right now, so the only
+    // way to keep this promise is to ask where the gate cycle *will be* when it
+    // lands. Comparing the spawn point to a live gate's position (what this used
+    // to do) compares two numbers that are never close, and blocks nothing.
+    if (
+      hazardLandsOnRead({
+        dist: spawnZ,
+        elapsed,
+        travel,
+        speed,
+        far: tiers.settings.far,
+        reduced: reduced(),
+        gateEndsIn: activeGate ? Math.max(0, -activeGate.z) / Math.max(1, speed) : null,
+        cooldown: gateCooldown,
+      })
+    ) {
+      readingArch(spawnZ);
+      return;
+    }
 
     const roll = rng.next();
     const hazardChance = clamp(0.42 + travel / 9000, 0.42, 0.78);

--- a/dynawalla/games/runner/src/game/pacing.test.ts
+++ b/dynawalla/games/runner/src/game/pacing.test.ts
@@ -1,11 +1,117 @@
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
   speedAt, readWindow, breather, beatTime, difficultyFor,
-  READ_WINDOW_FLOOR, V_START, V_TERMINAL, V_REDUCED_CAP,
+  gateDistance, deliveredWindow, hazardLandsOnRead,
+  READ_WINDOW_FLOOR, DELIVERED_WINDOW_FLOOR, DODGE_CORRIDOR_FLOOR,
+  V_SURGE_BOOST_MAX, GATES_PER_STEP,
+  V_START, V_TERMINAL, V_REDUCED_CAP,
   COST_WRONG_GATE, COST_HAZARD, GAIN_GATE, VOLT_BLEED, VOLT_MAX,
 } from "./pacing.ts";
 import { Rng } from "./rng.ts";
+
+/* ------------------------- the spawn loop, headless ------------------------ */
+
+/**
+ * A replay of `mount.ts`'s gate/hazard scheduling with no WebGL under it.
+ *
+ * It is deliberately written from the *geometry* — gates and hazards are z
+ * coordinates that scroll toward the player at the live speed, exactly as
+ * `Entities.update` moves them — and not from any of the pacing functions'
+ * own arithmetic. A hazard counts as arriving during a read when its z crosses
+ * the answer plane on a frame where a gate is up. If the guard were to start
+ * lying, this measurement would not follow it.
+ */
+const clampN = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v);
+const approachN = (v: number, t: number, rate: number, dt: number) =>
+  v + (t - v) * (1 - Math.exp(-rate * dt));
+
+type Sim = {
+  gates: number;
+  arrivalsWhileReading: number;
+  arrivals: number;
+  readingDuty: number;
+  minDelivered: number;
+};
+
+function replay(opts: { until: number; from?: number; far: number; guard?: boolean }): Sim {
+  const { until, from = 0, far, guard = true } = opts;
+  const rng = new Rng(1234);
+  const dt = 1 / 60;
+  const spawnZ = far * 0.88;
+  let elapsed = 0, travel = 0, speed = V_START;
+  let gate: { z: number } | null = null;
+  let gateCooldown = 0.75;
+  let nextBeatAt = 70;
+  const hazards: number[] = [];
+  let gates = 0, hit = 0, arrivals = 0, reading = 0, live = 0;
+  let minDelivered = Infinity;
+
+  while (elapsed < until) {
+    elapsed += dt;
+    speed = approachN(speed, speedAt(elapsed, false), 1.6, dt);
+    const scroll = speed * dt;
+    travel += scroll;
+
+    if (gate) gate.z += scroll;
+    for (let i = 0; i < hazards.length; i++) {
+      const was = hazards[i] as number;
+      hazards[i] = was + scroll;
+      if (was < 0 && (hazards[i] as number) >= 0 && elapsed >= from) {
+        arrivals++;
+        if (gate) hit++;
+      }
+    }
+    for (let i = hazards.length - 1; i >= 0; i--) if ((hazards[i] as number) > 26) hazards.splice(i, 1);
+
+    if (elapsed >= from) {
+      live += dt;
+      if (gate) reading += dt;
+    }
+
+    if (gate && gate.z >= 0) {
+      gate = null;
+      gateCooldown = breather(travel);
+      if (elapsed >= from) gates++;
+    }
+    if (!gate) {
+      gateCooldown -= dt;
+      if (gateCooldown <= 0) {
+        const dist = gateDistance(speed, readWindow(travel, false), far);
+        gate = { z: -dist };
+        minDelivered = Math.min(minDelivered, dist / speed);
+      }
+    }
+
+    if (travel >= nextBeatAt) {
+      nextBeatAt = travel + speed * beatTime(travel);
+      const blocked =
+        guard &&
+        hazardLandsOnRead({
+          dist: spawnZ,
+          elapsed,
+          travel,
+          speed,
+          far,
+          reduced: false,
+          gateEndsIn: gate ? Math.max(0, -gate.z) / Math.max(1, speed) : null,
+          cooldown: gateCooldown,
+        });
+      if (!blocked && rng.next() < clampN(0.42 + travel / 9000, 0.42, 0.78)) hazards.push(-spawnZ);
+    }
+  }
+  return {
+    gates,
+    arrivalsWhileReading: hit,
+    arrivals,
+    readingDuty: reading / live,
+    minDelivered,
+  };
+}
+
+/** Every draw distance in `tiers.ts`, smallest first. */
+const FARS = [300, 380, 440, 520];
 
 /* --------------------------------- pacing --------------------------------- */
 
@@ -32,6 +138,142 @@ test("reduced motion caps speed without stopping the world", () => {
     assert.ok(v <= V_REDUCED_CAP, `reduced motion hit ${v} u/s`);
     assert.ok(v > 20, "reduced motion must still be a runner, not a slideshow");
   }
+});
+
+test("nothing to dodge arrives while a gate is being read", () => {
+  // The promise in `emitBeat`. It was written as a comment over a comparison
+  // between a hazard's spawn z (-334) and a gate's live z (never past -102), so
+  // it never fired once: measured on origin/main this was 1.47 hazards per
+  // reading window in the first ninety seconds and 2.03 from ninety seconds on,
+  // identical to the numbers with the guard deleted entirely.
+  for (const far of FARS) {
+    const early = replay({ until: 90, far });
+    const late = replay({ until: 300, from: 90, far });
+    for (const [phase, r] of [["first 90s", early], ["90s-300s", late]] as const) {
+      assert.ok(r.gates > 8, `${far}/${phase}: only ${r.gates} gates, nothing was measured`);
+      const per = r.arrivalsWhileReading / r.gates;
+      assert.ok(
+        per <= 0.02,
+        `far=${far} ${phase}: ${per.toFixed(2)} hazards arrive per reading window ` +
+          `(${r.arrivalsWhileReading} across ${r.gates} gates)`,
+      );
+    }
+  }
+});
+
+test("and the guard is actually wired into the beat that spawns them", () => {
+  // The test above replays the loop rather than running `mount.ts`, which needs
+  // a WebGL context. So it would still pass if `emitBeat` simply stopped
+  // consulting the guard — which is *exactly* the shape of the bug being fixed
+  // here: a promise written as a comment over a call that does nothing. The
+  // count of places that decide whether a hazard spawns is the thing worth
+  // pinning, so it is pinned.
+  const src = readFileSync(new URL("./mount.ts", import.meta.url), "utf8");
+  const beat = src.slice(src.indexOf("function emitBeat("), src.indexOf("/* ------------------------------ collisions"));
+  assert.ok(beat.length > 200, "emitBeat has moved; this test needs re-aiming");
+  assert.ok(
+    beat.includes("hazardLandsOnRead("),
+    "emitBeat must ask whether the hazard lands on a read before spawning one",
+  );
+  const call = beat.indexOf("hazardLandsOnRead(");
+  const spawn = beat.indexOf("ents.spawnHazard(");
+  assert.ok(spawn > call, "the question has to be asked before the hazard exists");
+  assert.equal(
+    (src.match(/ents\.spawnHazard\(/g) ?? []).length,
+    (beat.match(/ents\.spawnHazard\(/g) ?? []).length,
+    "every hazard in the game must come from the beat the guard covers",
+  );
+});
+
+test("the corridor between gates is where the runner is still a runner", () => {
+  // Relief comes from space and time. If the fix above were "delete the
+  // hazards", this is what would notice: a run must still be dense with things
+  // to dodge, they just all live between the gates now.
+  for (const far of FARS) {
+    const late = replay({ until: 300, from: 90, far });
+    const perGate = late.arrivals / late.gates;
+    assert.ok(perGate > 0.9, `far=${far}: only ${perGate.toFixed(2)} hazards per gate cycle — the world is empty`);
+    assert.ok(
+      late.readingDuty > 0.45 && late.readingDuty < 0.75,
+      `far=${far}: reading is ${(late.readingDuty * 100).toFixed(0)}% of the clock — ` +
+        "at 88% there is no corridor to put a pylon in, and at 40% it is not a maths game",
+    );
+  }
+});
+
+test("the reading window the child gets survives the draw distance", () => {
+  // `readWindow` is a wish; a gate cannot spawn past the far plane. On the
+  // smallest tier at full speed the clamp is what actually decides, so the
+  // floor has to hold there or the promise is decoration.
+  for (const far of FARS) {
+    for (let speed = V_START; speed <= V_TERMINAL * V_SURGE_BOOST_MAX + 0.01; speed += 0.5) {
+      for (const travel of [0, 2600, 20000, 1e6]) {
+        const w = deliveredWindow(travel, speed, far, false);
+        assert.ok(
+          w >= DELIVERED_WINDOW_FLOOR - 1e-9,
+          `far=${far} speed=${speed.toFixed(1)} travel=${travel}: only ${w.toFixed(2)}s to read`,
+        );
+      }
+    }
+    const late = replay({ until: 300, far });
+    assert.ok(
+      late.minDelivered >= DELIVERED_WINDOW_FLOOR - 1e-9,
+      `far=${far}: a real run handed out a ${late.minDelivered.toFixed(2)}s window`,
+    );
+  }
+  // And a gate is never spawned somewhere it cannot be drawn.
+  for (const far of FARS) {
+    assert.ok(gateDistance(1e6, 1e6, far) <= far, "a gate spawned beyond the far plane is invisible");
+    assert.ok(gateDistance(0, 0, far) >= 68, "a gate on top of the player is not a question");
+  }
+});
+
+test("the reading window answers to the cadence table, not to vibes", () => {
+  // docs/EXPERIENCE_DESIGN.md: two-digit regrouping is instrumented at p50 6s /
+  // p90 14s, and this pack's own pack.json claims
+  // `dw.add.regroup.subtract-across-zero`. Three shown candidates is cheaper
+  // than producing an answer cold — it is not four times cheaper, which is what
+  // a 1.55s window assumed.
+  assert.ok(READ_WINDOW_FLOOR >= 3, `a ${READ_WINDOW_FLOOR}s window is a coin toss with three faces`);
+  assert.ok(readWindow(0, false) > 5, "the first gates must be generous");
+  // The whole cycle — read it, then run the corridor — is the unit a child
+  // actually spends on one question, and it should land near that 6s p50.
+  const cycle = READ_WINDOW_FLOOR + DODGE_CORRIDOR_FLOOR;
+  assert.ok(cycle >= 4.5 && cycle <= 9, `${cycle}s per question is outside the cadence table`);
+});
+
+test("a hazard is only held back when it would actually land on a read", () => {
+  // The projection on its own, in a steady state: deep into a run the speed
+  // curve is flat, so a hazard's flight time is just distance over speed and
+  // the answer can be worked out by hand.
+  const base = {
+    elapsed: 2000, travel: 200000, speed: V_TERMINAL,
+    far: 380, reduced: false, cooldown: 0,
+  };
+  const w = deliveredWindow(base.travel, base.speed, base.far, false); // ~3.2s
+  const b = breather(base.travel); // ~1.9s
+  const unit = V_TERMINAL; // one second of flight, in world units
+
+  // A gate resolving in 1s. Reading now..1s, corridor 1..1+b, then w again.
+  const at = (seconds: number, gateEndsIn: number | null, cooldown = 0) =>
+    hazardLandsOnRead({ ...base, cooldown, gateEndsIn, dist: seconds * unit });
+  assert.equal(at(0.5, 1), true, "landing inside the live gate's own window");
+  assert.equal(at(1 + b * 0.5, 1), false, "landing in the middle of the corridor");
+  assert.equal(at(1 + b + w * 0.5, 1), true, "landing inside the next gate's window");
+  assert.equal(at(1 + b + w + b * 0.5, 1), false, "and the corridor after that is open");
+
+  // Nothing up yet, next gate requested in 1.5s.
+  assert.equal(at(0.7, null, 1.5), false);
+  assert.equal(at(1.5 + w * 0.5, null, 1.5), true);
+
+  // Six seconds downrange — a whole cycle out — is still answered honestly.
+  const cycle = w + b;
+  assert.equal(at(1 + b + cycle + w * 0.5, 1), true, "two cycles out, mid-read");
+  assert.equal(at(1 + b + cycle * 2 + w + b * 0.5, 1), false, "three cycles out, corridor");
+
+  // Degenerate input must terminate rather than spin.
+  assert.equal(typeof hazardLandsOnRead({ ...base, gateEndsIn: null, dist: 1e9 }), "boolean");
+  assert.equal(typeof hazardLandsOnRead({ ...base, gateEndsIn: null, dist: 0 }), "boolean");
 });
 
 test("the reading window shrinks but never below its floor", () => {
@@ -69,18 +311,39 @@ test("a twenty-minute run keeps escalating rather than plateauing into nothing",
 
 /* ------------------------------- difficulty ------------------------------- */
 
-test("difficulty climbs with distance and is clamped", () => {
-  assert.ok(difficultyFor(0, 1, 0, 0) < difficultyFor(5000, 1, 0, 0));
-  assert.ok(difficultyFor(1e9, 9, 100, 100) <= 12);
-  assert.ok(difficultyFor(0, 1, 100, 0) >= 0, "difficulty must never go negative");
+test("difficulty climbs on answers read correctly, and is clamped", () => {
+  assert.ok(difficultyFor(1, 8, 0) < difficultyFor(1, 8, 8));
+  assert.ok(difficultyFor(1, 100, 20) < difficultyFor(1, 100, 60));
+  assert.ok(difficultyFor(9, 100, 100) <= 12);
+  assert.ok(difficultyFor(1, 100, 0) >= 0, "difficulty must never go negative");
+  // A step is worth a handful of gates, not a whole session and not one gate.
+  assert.ok(GATES_PER_STEP >= 3 && GATES_PER_STEP <= 8);
+});
+
+test("surviving is not an achievement: distance alone never raises the maths", () => {
+  // The bug this replaces: `1 + travel/900` handed a child a harder question
+  // every fifteen seconds of *staying alive*, so a player who answered nothing
+  // correctly and merely dodged well was escalated at anyway. Nothing in the
+  // signature may be a proxy for run length — a run is a number of gates and a
+  // number of them right, and only the second one is an achievement.
+  assert.equal(difficultyFor.length, 3, "difficultyFor must not take a distance again");
+  const src = readFileSync(new URL("./mount.ts", import.meta.url), "utf8");
+  const call = /const difficulty = \(\)[^\n]*/.exec(src)?.[0] ?? "";
+  assert.ok(call.includes("difficultyFor("), "the difficulty hint has moved; re-aim this test");
+  assert.ok(!call.includes("travel"), `distance is back in the difficulty hint: ${call}`);
+  const noneRight = [0, 4, 20, 60, 200].map((gates) => difficultyFor(1, gates, 0));
+  const first = noneRight[0] as number;
+  for (const d of noneRight) {
+    assert.ok(d <= first, `a child answering nothing right was escalated to ${d}`);
+  }
 });
 
 test("a child who is drowning gets relief, not more escalation", () => {
-  const struggling = difficultyFor(4000, 1, 10, 4); // 40% right
-  const cruising = difficultyFor(4000, 1, 10, 10);
+  const struggling = difficultyFor(1, 10, 4); // 40% right
+  const cruising = difficultyFor(1, 10, 10);
   assert.ok(struggling < cruising - 1.5, "a bad patch must visibly ease the questions");
   // Fewer than four answered is not evidence of anything; do not punish it.
-  assert.equal(difficultyFor(4000, 1, 3, 0), difficultyFor(4000, 1, 0, 0));
+  assert.equal(difficultyFor(1, 3, 0), difficultyFor(1, 0, 0));
 });
 
 /* --------------------------------- economy -------------------------------- */

--- a/dynawalla/games/runner/src/game/pacing.ts
+++ b/dynawalla/games/runner/src/game/pacing.ts
@@ -77,18 +77,159 @@ export function speedAt(elapsed: number, reduced: boolean): number {
  * Seconds between a gate becoming visible and reaching the answer plane.
  *
  * This — not speed — is the real difficulty knob: the run gets harder because
- * the time you have to read compresses. The 1.55s floor is a hard promise. A
- * gate that arrives faster than a child can read it is not difficulty.
+ * the time you have to read compresses. The floor is a hard promise. A gate
+ * that arrives faster than a child can read it is not difficulty.
+ *
+ * The floor used to be 1.55s. This pack covers `dw.add.regroup.subtract-across-zero`
+ * — `5,001 − 2,798` is on its own skill list — and `docs/EXPERIENCE_DESIGN.md`
+ * instruments two-digit regrouping at **p50 6s / p90 14s**. 1.55s was not a
+ * reading window, it was a coin toss with three faces, and the honest read of a
+ * child's answer at that speed is "they guessed". Picking one of three shown
+ * candidates is cheaper than producing an answer cold, but it is not four times
+ * cheaper.
+ *
+ * 3.2s is what the *geometry* can actually deliver at terminal velocity on the
+ * smallest tier (see `deliveredWindow`), so it is the largest number that is not
+ * a lie. The gate cycle as a whole — window plus dodge corridor — lands near the
+ * 6s p50; the corridor is where the runner is a runner.
  */
-export const READ_WINDOW_FLOOR = 1.55;
+export const READ_WINDOW_FLOOR = 3.2;
 export function readWindow(travel: number, reduced: boolean): number {
-  const w = READ_WINDOW_FLOOR + 1.85 * Math.exp(-Math.max(0, travel) / 2600);
+  const w = READ_WINDOW_FLOOR + 2.2 * Math.exp(-Math.max(0, travel) / 2600);
   return reduced ? w + 0.5 : w;
 }
 
-/** Quiet seconds after a gate resolves before the next one is scheduled. */
+/**
+ * The dodge corridor: seconds after a gate resolves before the next is scheduled.
+ *
+ * This is not dead air, it is the *other half of the game*. Hazards are only
+ * allowed to arrive here (see `readingOverlaps`), so if this collapses the
+ * runner has nowhere to put a pylon and either the reading gets trampled or the
+ * world goes quiet. At 0.22s the reading window occupied 88% of the wall clock,
+ * which is exactly why the no-hazards-while-reading guard could never have been
+ * honoured. Space and time, not less feedback.
+ */
+export const DODGE_CORRIDOR_FLOOR = 1.9;
 export function breather(travel: number): number {
-  return 0.22 + 0.34 * Math.exp(-Math.max(0, travel) / 2200);
+  return DODGE_CORRIDOR_FLOOR + 1.0 * Math.exp(-Math.max(0, travel) / 2200);
+}
+
+/* --------------------------- gate geometry ---------------------------- */
+
+/** Nearest a gate may spawn — closer than this and it is on top of you. */
+export const GATE_MIN_DIST = 68;
+/** Share of the draw distance a gate may spawn at. Past it, nothing is drawn. */
+export const GATE_FAR_SHARE = 0.84;
+/** Ceiling on the surge speed bonus applied in `mount.ts`. */
+export const V_SURGE_BOOST_MAX = 1.2;
+
+const clampN = (v: number, lo: number, hi: number): number => (v < lo ? lo : v > hi ? hi : v);
+
+/** Where a gate is spawned, in units ahead, for a wanted reading window. */
+export function gateDistance(speed: number, window: number, far: number): number {
+  return clampN(speed * window, GATE_MIN_DIST, far * GATE_FAR_SHARE);
+}
+
+/**
+ * The reading window the child actually gets, after the draw distance has had
+ * its say.
+ *
+ * `readWindow` is a *wish*; a gate cannot be spawned beyond the far plane, so at
+ * high speed on a low tier the clamp quietly hands back less. This is the number
+ * that is promised, and there is a test that walks every tier at every speed the
+ * game can reach — including the surge bonus — and holds it to the floor.
+ */
+export const DELIVERED_WINDOW_FLOOR = 3.1;
+export function deliveredWindow(travel: number, speed: number, far: number, reduced: boolean): number {
+  return gateDistance(speed, readWindow(travel, reduced), far) / Math.max(1, speed);
+}
+
+/* ------------------------- the reading corridor ------------------------ */
+
+/**
+ * Seconds of margin either side of a hazard's predicted landing.
+ *
+ * The projection below is the game's own loop, so it is close — but it does not
+ * know about the surge speed bonus arriving mid-flight or a stumble slowing the
+ * world down, and a hazard is in the air for six seconds or more. This buys a
+ * reading window that nothing leaks into, at the cost of a hazard here and there
+ * at the very edge of a corridor.
+ */
+export const HAZARD_LEAD_SLOP = 0.3;
+
+/** How the world will be scheduled while a hazard is in the air. */
+export type FlightState = {
+  /** Units ahead the hazard is being spawned. */
+  dist: number;
+  elapsed: number;
+  travel: number;
+  /** Live forward speed, which is not exactly `speedAt` — surge, stumble. */
+  speed: number;
+  /** Draw distance of the current quality tier. */
+  far: number;
+  reduced: boolean;
+  /** Seconds until the live gate reaches the answer plane, null when none is up. */
+  gateEndsIn: number | null;
+  /** Seconds until the next gate is requested. */
+  cooldown: number;
+};
+
+/**
+ * Would a hazard spawned now be crossing the answer plane while a gate is being
+ * read?
+ *
+ * This is the promise `emitBeat` has always made in a comment and never kept.
+ * The old test compared a hazard's *spawn* z against a live gate's *current* z —
+ * −334 against something never past −102 — so the branch was unreachable and
+ * roughly two hazards landed in every reading window from ninety seconds on.
+ *
+ * The two quantities that are actually comparable are *arrival times*, and
+ * getting them needs a projection rather than a division: a hazard spawns at the
+ * far plane, further out than any gate, so it is airborne for one to three whole
+ * gate cycles, and both the world speed and the cycle length move while it
+ * flies. So this runs the same loop `step()` runs — accelerate, scroll, resolve
+ * the gate, wait out the corridor, spawn the next — forward until the hazard
+ * lands, and answers with what the child will be doing when it gets there.
+ *
+ * ~500 iterations of arithmetic, once per hazard beat. It is not a frame cost.
+ */
+export function hazardLandsOnRead(s: FlightState): boolean {
+  const step = 1 / 30;
+  const base = Math.max(1, speedAt(s.elapsed, s.reduced));
+  // Carry whatever the live speed is doing that the curve does not know about.
+  const ratio = clampN(s.speed / base, 0.4, 1.6);
+  let t = 0;
+  let travel = s.travel;
+  let z = -Math.max(0, s.dist);
+  let gz: number | null = s.gateEndsIn !== null ? -s.gateEndsIn * Math.max(1, s.speed) : null;
+  let cd = s.cooldown;
+  let landed = -1;
+  let lastRead = -1e9;
+
+  for (let i = 0; i < 1600; i++) {
+    const v = speedAt(s.elapsed + t, s.reduced) * ratio;
+    const d = v * step;
+    z += d;
+    travel += d;
+    if (gz !== null) {
+      gz += d;
+      if (gz >= 0) {
+        gz = null;
+        cd = breather(travel);
+      }
+    } else {
+      cd -= step;
+      if (cd <= 0) gz = -gateDistance(v, readWindow(travel, s.reduced), s.far);
+    }
+    t += step;
+    if (gz !== null) lastRead = t;
+    if (z >= 0) {
+      if (landed < 0) landed = t;
+      if (lastRead >= landed - HAZARD_LEAD_SLOP) return true;
+      if (t > landed + HAZARD_LEAD_SLOP) return false;
+    }
+  }
+  return false;
 }
 
 /** Seconds between hazard beats. Keeps rhythm constant as the world speeds up. */
@@ -96,18 +237,30 @@ export function beatTime(travel: number): number {
   return 0.62 + 0.55 * Math.exp(-Math.max(0, travel) / 2400);
 }
 
+/** Correct gates per step of difficulty. */
+export const GATES_PER_STEP = 4;
+
 /**
  * Difficulty hint handed to the host.
  *
- * Distance pushes it up, a hot surge pushes it up a little more, and a genuinely
- * bad patch pulls it down hard. The host owns real adaptivity; this only makes
- * sure the game never keeps escalating at a child who is drowning.
+ * **Escalation is on achievement, not on survival.** It used to be `1 +
+ * travel/900` — a step every fifteen seconds of *staying alive*, which handed
+ * harder subtraction to a child who had answered nothing right and merely
+ * dodged well. `docs/EXPERIENCE_DESIGN.md` bans exactly that: "escalation is on
+ * difficulty and repair, never run length." Every game in the fleet that paces
+ * well already does this — `siege` steps on a wave clear, `serpent` per nine
+ * correct eats, `stack` on a finished floor.
+ *
+ * So the ramp is the count of gates read correctly. A hot surge still adds a
+ * little on top, and a genuinely bad patch still pulls it down hard: the host
+ * owns real adaptivity, this only makes sure the game never escalates at a child
+ * who is drowning.
  */
-export function difficultyFor(travel: number, surge: number, gates: number, right: number): number {
-  const fromDistance = 1 + Math.max(0, travel) / 900;
+export function difficultyFor(surge: number, gates: number, right: number): number {
+  const fromRight = 1 + Math.max(0, right) / GATES_PER_STEP;
   const fromSurge = (surge - 1) * 0.25;
   const acc = gates >= 4 ? right / gates : 1;
   const relief = acc < 0.6 ? 2.2 : acc < 0.78 ? 1.1 : 0;
-  const d = fromDistance + fromSurge - relief;
+  const d = fromRight + fromSurge - relief;
   return d < 0 ? 0 : d > 12 ? 12 : d;
 }


### PR DESCRIPTION
Two Phase-0 defects from the adaptation audit, same class: **the child does the maths correctly and the game marks them wrong anyway.**

## RUNNER — the guard that promised to protect reading never fired

`emitBeat` has always carried this comment:

> Never put a hazard inside the reading window of a gate: the child would be dodging while reading, which is not difficulty, it is noise.

over this test:

```ts
if (activeGate && Math.abs(-spawnZ - activeGate.z) < 30) return;
```

`-spawnZ` is a hazard's **spawn** z (−334 on a mid tier). `activeGate.z` is a gate's **current** z, which starts at −(speed × window) and climbs to 0 — never past −102. The two are never within 30 units, so the branch is unreachable.

Measured before touching anything, with a headless replay of the spawn loop (geometry only — gates and hazards are z coordinates scrolled at the live speed, exactly as `Entities.update` moves them; a hazard counts as arriving during a read when it crosses the answer plane on a frame where a gate is up):

| | first 90 s | 90 s → 300 s |
|---|---|---|
| with the guard | 1.47 | **2.03** |
| with the guard deleted | 1.47 | **2.03** |

Identical, on every tier. Exactly the audit's number.

### What replaces it

The comparable quantities are **arrival times**, and a division does not get them: a hazard spawns at the horizon, further out than any gate, and is in the air for one to three whole gate cycles while both the world speed and the cycle length move. `hazardLandsOnRead` runs the same loop `step()` runs — accelerate, scroll, resolve the gate, wait out the corridor, spawn the next — forward until the hazard lands, and answers with what the child will be doing when it gets there. ~500 iterations of arithmetic once per hazard beat.

After: **0.000 hazards per reading window on all four tiers**, early and late.

### The cadence had to move with it, or nothing would spawn at all

A 1.55 s window against a 0.22 s breather is **88% of the wall clock spent reading**. There is nowhere to put a pylon, which is very likely why the guard was written dead rather than fixed. Relief here is space and time, not less feedback:

| | before | after |
|---|---|---|
| reading window floor | 1.55 s | **3.2 s** (5.4 s at the start) |
| dodge corridor floor | 0.22 s | **1.9 s** |
| reading share of the clock | 88% | **63–65%** |
| hazards arriving per gate cycle | 1.5 | **1.5** (all in the corridor now) |
| gates per minute, late | ~32 | ~11.4 |

The world is not quieter — the same density of things to dodge now lands in the corridor instead of on top of the arithmetic. A reading corridor gets a spark arch strung across **all three lanes**, so it still lights up and still pays, and it cannot pull a child out of the lane they read their way into.

Fewer gates per minute is the deliberate half of the trade. 32 gates a minute at 1.55 s each was fake throughput; the honest read of an answer at that speed is "they guessed". `docs/EXPERIENCE_DESIGN.md` instruments two-digit regrouping at **p50 6 s / p90 14 s**, and this pack's `pack.json` claims `dw.add.regroup.subtract-across-zero`. A whole gate cycle — read it, then run the corridor — is now ~5.3 s.

**3.2 s and not more** because that is what the geometry can deliver. A gate cannot spawn past the far plane, so `clamp(speed * w, 68, far * 0.84)` was quietly handing back less than the floor promised on a small tier at speed. `deliveredWindow` is now the promised number and a test walks every tier at every speed the game can reach, surge bonus included. **I cannot get to the 6 s p50 without a redesign** — at terminal velocity on the lowest tier the far plane caps the window at 3.18 s. Closing that needs the prompt to arrive before the gate does (a HUD pre-read, then the candidates), which is a real design change and not in this PR.

### Escalation moved off survival

`1 + travel / 900` was a step every fifteen seconds of *staying alive*: a child who answered nothing correctly and merely dodged well got harder subtraction for it. EXPERIENCE_DESIGN bans it outright ("escalation is on difficulty and repair, never run length"), and the fleet already agrees — siege on a wave clear, serpent per nine correct eats, stack on a finished floor. It is now **one step per four gates read correctly**. The accuracy relief branch is unchanged.

## CLAIM — three answers on one line, in a game that travels along lines

Confirmed, and the mechanism is worse than "ambiguous": the plates sat at `gy = h * 0.5` with `gx` at `w/4`, `w/2`, `3w/4`, and `updateGate` answered on **contact** (`|Δx| < 4.2 && |Δy| < 3.4`). The player moves one cell at a time along rows and columns. To reach the plate on the right you drive along the middle row *through* the other two, and the first box entered takes the answer. A child who computed 4500, saw it on the right-hand plate and drove right was recorded as answering whatever was in the middle. The centre row is also exactly where the prompt card is drawn, so the middle candidate was sitting behind it.

Two rules now, both in `src/game/plates.ts` where they can be proved instead of played:

1. **No two plates share a row or a column**, none of them in the middle band, on every one of the six arenas.
2. **Arriving is not answering.** A plate fills while you stand on it and empties the instant you leave. `PLATE_ARM` (0.55 s) is longer than the time to cross one at any `railSpeed` the ladder reaches (worst case 8.4/25 = 0.34 s), with a test that walks all 60 levels. It is drawn as a tide rising up the plate — the rule has to be something a child *sees*.

### CLAIM could not see success

There was one `host.report`, in `finishGate`, reachable only from `die() -> openGate()`. **Every answer the game ever reported was preceded by a crash.** A child who cleared level after level without dying had, to an adaptive controller, answered nothing — and the sample it did get was drawn entirely from the moment a run fell apart.

Clearing a level now opens the same three plates as a **vault**: hold the right one for score, lose nothing if you do not, next level either way. Still exactly one `host.report` (the existing invariant test still passes). A vault nobody touched is **not reported** — a bonus a child ignored is not a wrong answer, and posting one would feed the controller a stream of failures the game manufactured itself. The revive gate's timeout still reports, because the ring closing there costs a life.

`test/report.test.ts` plays the actual game — same update, same collision, same claim rule, same gate — through the `tick()`/`hold()` seam, on a ~150-line browser stub. The reporting hole survived this long partly because the test pinning it counted `host.report(` calls in the source, on the grounds that "the game class needs a DOM".

### Known gap: `goalFromQuestion` — reported, not fixed

`raw >= total/20` = 360 on a 7200-cell arena, so no two-digit answer can ever become the goal, and the fraction the child works is always the hardcoded LADDER's. **Widening the threshold does not fix it.** The blocker is the representation: this pack's own `covers.skills` are fraction skills whose answers are fractions (`"3/4"`), rejected as non-integers before the threshold is reached. Only an answer that is *literally a count of cells of 7200* can drive the goal, and nothing in the curriculum graph produces one — the skills CLAIM declares have no generator bindings at all yet.

Closing it needs a decision this game cannot make alone: either a generator whose answers are areas of 7200, or a documented mapping from a small answer onto the plane (answer-as-percent, answer-as-blocks) that the goal card would have to teach. Both are design work. There is a test named `KNOWN GAP: an ordinary arithmetic answer can never be this game's goal` that pins the behaviour and says all of this, so the next reader does not mistake `goalFromQuestion` for a working seam. **Not half-fixed.**

## Verification

Every fix was deleted and the suite re-run. Exact failures:

| fix removed | failure |
|---|---|
| `hazardLandsOnRead` returns false | `far=300 first 90s: 2.85 hazards arrive per reading window (37 across 13 gates)` |
| the call deleted from `emitBeat` | `emitBeat must ask whether the hazard lands on a read before spawning one` |
| window/corridor back to 1.55/0.22 | `far=300: only 0.00 hazards per gate cycle — the world is empty` · `far=300 speed=27.0 travel=2600: only 2.52s to read` · `a 1.55s window is a coin toss with three faces` |
| escalation back on distance | `a bad patch must visibly ease the questions` |
| `travel` passed back into the hint | `distance is back in the difficulty hint: const difficulty = (): number => difficultyFor(surge, stats.gates, stats.gatesRight, travel);` |
| plates back on one row | `62x122: plates 0 and 1 share a row (61.0 vs 61.0)` · `62x122: 4500 sits under the prompt card` |
| answer on contact instead of on hold | `62x122 level 1 (25 c/s): driving 0.5,21.96 → 61.5,21.96 answered with 4500` |
| the vault removed | `no gate ever opened` (×3) |

Both suites run 5× clean — runner 73/73, claim 70/70 — plus `tsc --noEmit` and `build:pack` on both. Nothing outside `dynawalla/games/runner/` and `dynawalla/games/claim/` is touched.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
