### PR TITLE
dynawalla/games/arena: the answer clock was charging children for animation they could not answer inside

### DIFF
--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -868,3 +868,93 @@ test("a missed answer is completed patiently at the floor and skipped at the cei
   const calmHold = holdAfterMiss(0)
   assert.ok(calmHold > 2.5, `the reveal at the floor lasted only ${calmHold.toFixed(1)}s`)
 })
+
+/**
+ * THE LATENCY CONTRACT.
+ *
+ * Latency starts when the child can first READ AND ACT ON the question, and
+ * ends at the moment they COMMIT. Nothing else belongs in it.
+ *
+ * This is not pedantry. The difficulty controller separates "already knew it"
+ * from "worked it out" on response time alone, so anything that inflates the
+ * number — an opening animation, a projectile's flight, a settle — is a
+ * SYSTEMATIC error, not a noisy one. It never averages out, it looks like a
+ * plausible number, and its effect is to quietly refuse to promote the children
+ * who answered fastest. A sibling game was found reporting 2-3 seconds of
+ * boulder flight time as though it were thinking time.
+ *
+ * ARENA had two contaminants, both smaller and both real:
+ *
+ *   * a 0.55 s phase-1 ramp during which `resolveResonance` refuses to register
+ *     anything and the prompt is still fading up, and
+ *   * the traversal to a sphere, which is genuinely part of the act and so stays
+ *     in the reported number, but is not deliberation and so comes out of the
+ *     steering signal.
+ */
+test("thinking time excludes the opening ramp and the swim to the answer", () => {
+  const world = new World(createStubHost({ seed: 19 }), specFor("mid"), 4004)
+  const res = world.resonance
+
+  // Open one, and hold still through the whole ramp.
+  let opened = -1
+  for (let f = 0; f < 60 * 120 && !res.active; f++) {
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+    if (res.active) opened = world.time
+  }
+  assert.ok(opened > 0, "no Resonance ever opened")
+  assert.equal(res.phase, 1)
+
+  // The clock must NOT be running during the ramp.
+  const stampAtOpen = res.openedT
+  while (res.phase === 1) {
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+  }
+  assert.ok(
+    res.openedT > stampAtOpen,
+    "the clock started at the moment the beat opened — 0.55s of animation a child cannot answer inside is being charged to them",
+  )
+  assert.ok(
+    Math.abs(res.openedT - world.time) < 0.02,
+    `the clock started ${(world.time - res.openedT).toFixed(2)}s from the moment the question became answerable`,
+  )
+
+  // The traversal floor is real, matches how `stepPlayer` actually moves, and
+  // is what the controller subtracts.
+  assert.ok(res.reachSeconds > 0.3, `the swim to an answer was costed at ${res.reachSeconds}s`)
+  assert.ok(res.reachSeconds <= 1.4, `the swim was costed at ${res.reachSeconds}s — that is more than the traversal floor allows`)
+  assert.ok(
+    res.reachSeconds <= res.ringR / world.playerSpeed + 1e-6,
+    "the costed swim is longer than swimming it at the player's own speed would take",
+  )
+
+  // A child who answers the instant they can must be seen as instant. Swim
+  // straight at the correct sphere and check the controller was not handed
+  // something that looks laboured.
+  const i = res.spheres[res.correctSlot] as number
+  const t0 = world.time
+  for (let f = 0; f < 60 * 30 && res.phase === 2; f++) {
+    world.aimX = world.mx[i] as number
+    world.aimY = world.my[i] as number
+    world.step(1 / 60)
+  }
+  const wall = world.time - t0
+  assert.ok(wall > 0, "the sphere was never reached")
+  // Asserted on what the controller was HANDED, not on a subtraction this test
+  // performs itself — a test that redoes the arithmetic passes when the
+  // arithmetic is deleted from the simulation.
+  assert.ok(
+    res.thinkSeconds < 1,
+    `answering as fast as the game physically allows was scored as ${res.thinkSeconds.toFixed(2)}s of thinking`,
+  )
+  assert.ok(
+    res.thinkSeconds < wall - 0.2,
+    `the swim to the answer (${res.reachSeconds.toFixed(2)}s of a ${wall.toFixed(2)}s answer) is being charged as deliberation`,
+  )
+  // …and the host still gets the honest observable, ramp excluded but swim
+  // included, because swimming there is what the child did.
+  assert.ok(res.answerMs >= 0 && Number.isFinite(res.answerMs))
+})

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -404,6 +404,32 @@ export type Resonance = {
    */
   openedT: number
   /**
+   * Seconds the player cannot avoid spending TRAVELLING to an answer.
+   *
+   * In ARENA committing to an answer is swimming into a sphere, and the spheres
+   * sit `ringR` away, so the fastest possible answer still takes real time —
+   * measured between 0.62 s and 1.35 s depending on size, because `stepPlayer`
+   * floors the traversal speed at `ringR / 1.35`.
+   *
+   * That component is part of what a child DID, so it stays in the latency
+   * reported to the Host: `ms` is the honest observable, from the moment the
+   * question was readable to the moment it was committed. It is NOT part of what
+   * a child THOUGHT, so the difficulty controller — which is trying to tell
+   * "already knew it" from "worked it out" — subtracts it. Without that, the
+   * same three seconds of thinking scores as brisk at mass 10 and as laboured at
+   * mass 20,000, purely because the arena got bigger.
+   */
+  reachSeconds: number
+  /**
+   * Deliberation, in seconds, frozen at the moment of the answer — the number
+   * the difficulty controller was actually handed.
+   *
+   * Kept beside `answerMs` rather than derived from it because the two are
+   * deliberately different quantities, and a test that recomputes the
+   * subtraction itself is a test that passes when the subtraction is deleted.
+   */
+  thinkSeconds: number
+  /**
    * Milliseconds from opening to the answer being registered, frozen at the
    * moment of the answer. The harness used to recompute this from `openedAt`
    * on every frame of the 0.9 s resolve, so the metric it reported was the
@@ -537,6 +563,8 @@ export class World {
     correctSlot: 0,
     openedAt: 0,
     openedT: 0,
+    reachSeconds: 0,
+    thinkSeconds: 0,
     answerMs: 0,
     ringR: 0,
     chosen: -1,
@@ -734,6 +762,40 @@ export class World {
    */
   get revealSeconds(): number {
     return revealMs(FLOW, this.intensity) / 1000
+  }
+
+  /**
+   * The player's ordinary top speed, before any Resonance traversal floor and
+   * before the surge multiplier.
+   *
+   * Extracted so `openResonance` can compute the traversal floor from the same
+   * arithmetic `stepPlayer` uses. Two copies of this drifted apart once already.
+   */
+    // Agar's law: mass costs agility. Without this, growth has no downside and
+    // the whole genre collapses into a farming sim.
+    // Size buys momentum, not top speed denial: a leviathan crosses the water
+    // quickly and turns like a barge. Making size cost *agility* rather than
+    // *speed* is what keeps the twelfth minute from becoming a slow crawl
+    // across an empty screen, while still letting a minnow dance out of reach.
+    //
+    // The two numbers were tuned in world units, where 520 looks brisk. In
+    // SCREEN units they were the founder's "the character zips too fast it's
+    // hard to control": at the starting mass, 520 with an exponent of 0.30 was
+    // 1.13 screen-heights per second and 2.44 screen-WIDTHS per second on a
+    // phone held tall — the width of the glass crossed in 0.41 s, before the
+    // surge multiplier. Worse, it was the FASTEST the game ever was in screen
+    // terms. By mass 20,000 the same formula gives 0.12 screen-heights per
+    // second, a nine-fold swing, and it ran the wrong way round: hardest to
+    // control in the first ten seconds, sluggish by the twentieth minute.
+    //
+    // 520 -> 400 slows the opening. 0.30 -> 0.42 gives size more of its speed
+    // back, which flattens the swing to 3.7x and leaves Agar's law intact —
+    // mass still costs agility, below, which is where "majestic" actually comes
+    // from. Measured, with the wider opening view: 0.48 screen-heights per
+    // second at the start (was 1.13) and 0.13 at mass 20,000 (was 0.12).
+  get playerSpeed(): number {
+    const r = this.playerRTrue
+    return 400 * Math.pow(Math.max(18, r) / 28, 0.42)
   }
 
   /** The largest rival `k` may be before the world recycles it. */
@@ -1229,30 +1291,8 @@ export class World {
 
   private stepPlayer(dt: number): void {
     const r = this.playerRTrue
-    // Agar's law: mass costs agility. Without this, growth has no downside and
-    // the whole genre collapses into a farming sim.
-    // Size buys momentum, not top speed denial: a leviathan crosses the water
-    // quickly and turns like a barge. Making size cost *agility* rather than
-    // *speed* is what keeps the twelfth minute from becoming a slow crawl
-    // across an empty screen, while still letting a minnow dance out of reach.
-    //
-    // The two numbers were tuned in world units, where 520 looks brisk. In
-    // SCREEN units they were the founder's "the character zips too fast it's
-    // hard to control": at the starting mass, 520 with an exponent of 0.30 was
-    // 1.13 screen-heights per second and 2.44 screen-WIDTHS per second on a
-    // phone held tall — the width of the glass crossed in 0.41 s, before the
-    // surge multiplier. Worse, it was the FASTEST the game ever was in screen
-    // terms. By mass 20,000 the same formula gives 0.12 screen-heights per
-    // second, a nine-fold swing, and it ran the wrong way round: hardest to
-    // control in the first ten seconds, sluggish by the twentieth minute.
-    //
-    // 520 -> 400 slows the opening. 0.30 -> 0.42 gives size more of its speed
-    // back, which flattens the swing to 3.7x and leaves Agar's law intact —
-    // mass still costs agility, below, which is where "majestic" actually comes
-    // from. Measured, with the wider opening view: 0.48 screen-heights per
-    // second at the start (was 1.13) and 0.13 at mass 20,000 (was 0.12).
-    const base = 400
-    let speed = base * Math.pow(Math.max(18, r) / 28, 0.42)
+    // Agar's law, and the two constants behind it, live on `playerSpeed`.
+    let speed = this.playerSpeed
     // Inside a Resonance the arena is a fixed-size room however large you are.
     // Distance to a sphere grows with your radius while ordinary speed only
     // grows as r^0.30, so past a certain size the answer becomes physically
@@ -1886,7 +1926,25 @@ export class World {
       return
     }
     res.t += dt
-    if (res.phase === 1 && res.t > 0.55) res.phase = 2
+    if (res.phase === 1 && res.t > 0.55) {
+      res.phase = 2
+      // THE CLOCK STARTS HERE, and it used to start 0.55 s earlier.
+      //
+      // `openResonance` set both stamps at the moment the beat OPENED, which is
+      // the start of a 0.55 s ramp during which `resolveResonance` refuses to
+      // register anything (`res.phase !== 2`) and the prompt is still fading up
+      // in the HUD. Every latency this game has ever reported therefore carried
+      // 0.55 s of animation that no child could have answered inside.
+      //
+      // That was harmless while nothing read the number. It stopped being
+      // harmless the moment latency began deciding whether a player climbs: the
+      // inflation is SYSTEMATIC, not noisy, so it never averages out, and it
+      // reads as a plausible number while quietly refusing to promote children
+      // who answered instantly. Latency starts when the child can first read the
+      // question and act on it. Nothing else belongs in it.
+      res.openedAt = performance.now()
+      res.openedT = this.time
+    }
     if (res.phase === 2 && res.t > res.duration) {
       this.emit("resonance-fade", this.px, this.py, 0, 0)
       // A question that went unanswered comes back LATER, not on the usual
@@ -1995,12 +2053,19 @@ export class World {
     res.duration = this.resonanceSeconds
     res.question = q
     res.chosen = -1
+    // Provisional: both are re-stamped at the phase 1 -> 2 transition, when the
+    // question actually becomes answerable. These values exist only so a
+    // Resonance that is torn down mid-ramp does not carry a stale stamp.
     res.openedAt = performance.now()
     res.openedT = this.time
     this.resonanceCount++
 
     const ringR = Math.max(viewSpanFor(this.mass) * 0.30, this.playerRTrue * 3.4)
     res.ringR = ringR
+    // The traversal floor, computed the same way `stepPlayer` computes it, so
+    // the two cannot drift.
+    const travelSpeed = Math.max(this.playerSpeed, ringR / 1.35)
+    res.reachSeconds = ringR / Math.max(1, travelSpeed)
     const base = this.rng.range(0, Math.PI * 2)
     res.correctSlot = -1
     for (let s = 0; s < 4; s++) {
@@ -2045,8 +2110,16 @@ export class World {
     res.wasCorrect = correct
     const ms = Math.round(performance.now() - res.openedAt)
     res.answerMs = ms
-    /** Thinking time on the simulation clock — deterministic, and what steers. */
-    const took = Math.max(0, this.time - res.openedT)
+    /**
+     * THINKING time on the simulation clock: deterministic, and what steers.
+     *
+     * The wall clock is reported to the Host and never read here — a seeded run
+     * has to reproduce on a slow machine. The traversal floor comes off because
+     * swimming to a sphere is not deliberation, and leaving it in makes the
+     * signal a function of the player's size rather than of their fluency.
+     */
+    const took = Math.max(0, this.time - res.openedT - res.reachSeconds)
+    res.thinkSeconds = took
 
     try {
       this.host.report({

--- a/dynawalla/packs/shared/game-pacing/flow.ts
+++ b/dynawalla/packs/shared/game-pacing/flow.ts
@@ -54,6 +54,37 @@
  * (`intensity` and `success`); this module only ever computes the next value.
  * That keeps a sixty-times-a-second call path allocation-free and makes every
  * transition trivially testable.
+ *
+ * ---------------------------------------------------------------------------
+ * THE LATENCY CONTRACT — read this before passing `seconds` to `observe`.
+ * ---------------------------------------------------------------------------
+ *
+ * `seconds` is THINKING time:
+ *
+ *     it STARTS when the child can first read the question and act on it
+ *     it ENDS at the moment they commit to an answer
+ *     nothing else belongs in it
+ *
+ * Not when the question object was created. Not when an opening animation
+ * began. Not when a projectile landed, a card finished flipping, a token
+ * finished travelling, or a result finished settling.
+ *
+ * This is a contract rather than a suggestion because the controller separates
+ * "already knew it" from "worked it out" on this number alone, and those two
+ * want opposite things from the world. Contamination here is SYSTEMATIC, not
+ * noisy: it does not average out, it looks like a perfectly plausible number,
+ * and its effect is to quietly refuse to promote exactly the children who
+ * answered fastest. Two games in this catalogue were found charging children
+ * for animation they could not have answered inside — one for 0.55 s of an
+ * opening ramp, one for 2-3 seconds of a boulder's flight.
+ *
+ * If a game's act of answering unavoidably contains travel or animation, take
+ * it out of `seconds` before calling this, and leave it in whatever the game
+ * reports to its Host. What the Host wants is the honest observable; what this
+ * wants is deliberation.
+ *
+ * And use a clock the SIMULATION owns, not the wall clock, or a seeded run
+ * stops reproducing on a slower machine.
  */
 
 import { clamp01, uncurved, valueAt, type Curve } from "./curve.ts"


### PR DESCRIPTION

ARENA's difficulty controller separates "already knew it" from "worked it out"
on response time alone, and those two cases want opposite things from the world.
So the number had better mean what it says. It did not.

Two contaminants, both systematic rather than noisy — which is the dangerous
kind, because a systematic error never averages out, looks like a perfectly
plausible number, and its effect is to quietly refuse to promote exactly the
children who answered fastest.

**The opening ramp.** `openResonance` stamped the clock at the moment the beat
opened. `stepResonance` then spends 0.55 s in phase 1, during which
`resolveResonance` refuses to register anything and the prompt is still fading
up in the HUD. Every latency this game has ever reported carried 0.55 s that no
child could have answered inside. The stamps now land on the phase 1 -> 2
transition — the moment the question becomes readable and actionable.

**The swim.** Committing to an answer in ARENA means physically swimming into a
sphere `ringR` away, which is 0.62 s to 1.35 s depending on size. That is
genuinely part of what the child DID, so it stays in the `ms` reported to the
Host — the Host wants the honest observable. It is not part of what the child
THOUGHT, so the controller subtracts it. Left in, the same three seconds of
deliberation scored as brisk at mass 10 and as laboured at mass 20,000, purely
because the arena had got bigger.

`res.thinkSeconds` now records what the controller was actually handed, so the
test asserts on that rather than redoing the subtraction itself — a test that
recomputes the arithmetic is a test that passes when the arithmetic is deleted.
Both mutations were checked and both now fail:

    clock at the beat's opening  -> "0.55s of animation a child cannot answer
                                     inside is being charged to them"
    swim charged as thinking     -> "the swim to the answer (0.62s of a 0.58s
                                     answer) is being charged as deliberation"

`packs/shared/game-pacing/flow.ts` now states the contract for the other 26
games: latency starts when the child can first read the question and act on it,
ends at the moment of commitment, and nothing else belongs in it. If a game's
act of answering unavoidably contains travel or animation, take it out before
calling `observe` and leave it in what you report to the Host.

`playerSpeed` was extracted while doing this so `openResonance` computes the
traversal floor from the same arithmetic `stepPlayer` moves by. Two copies of
that expression had already drifted apart once.

65 arena tests and 20 pacing tests, five clean runs each.

Claude-Session: https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
