### PR TITLE
fix(dynawalla/packs/shared/game-host): a timed-out question can finally be closed as one

### DIFF
--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -43,10 +43,14 @@ type Fake = {
   readonly asks: Ask[]
   /** Every `answer` call, in order. */
   readonly answers: { itemId: string; response: string }[]
+  /** Every `items.skip` call, in order. */
+  readonly skips: string[]
   /** The host's verdict on the next answer, whatever the pack claims. */
   verdict: boolean
   /** Make `answer` reject, to prove the pack's own belief still survives. */
   answerFails: boolean
+  /** Make `skip` reject, as an older host with no such method would. */
+  skipFails: boolean
 }
 
 /**
@@ -61,14 +65,17 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
   const rungs = options.rungs ?? RUNGS
   const asks: Ask[] = []
   const answers: { itemId: string; response: string }[] = []
+  const skips: string[] = []
   const canonicals = new Map<string, string>()
   let sequence = 0
 
   const fake: Fake = {
     verdict: true,
     answerFails: false,
+    skipFails: false,
     asks,
     answers,
+    skips,
     client: {
       packId: "dynawalla.test",
       hostVersion: "0.1.0",
@@ -117,7 +124,13 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
           advance: fake.verdict,
         } satisfies Judgement)
       },
-      skip: () => Promise.resolve(),
+      skip: (itemId) => {
+        skips.push(itemId)
+        // What an older host — one shipped before `items.skip` existed — would
+        // do with the call, so the adapter is held to surviving it.
+        if (fake.skipFails) return Promise.reject(new Error("unknown method: items.skip"))
+        return Promise.resolve()
+      },
       reveal: (itemId) => Promise.resolve(canonicals.get(itemId) ?? ""),
       learnerSummary: () => Promise.resolve({ skills: [] }),
       haptic: () => Promise.resolve(),
@@ -381,6 +394,195 @@ test("an outcome is recorded once, and only for a question this module served", 
   mounted.host.report({ questionId: "", correct: true, ms: 100, answered: "4" })
   await settle()
   assert.equal(mounted.host.recentOutcomes().length, 1)
+  mounted.dispose()
+})
+
+// ─── A question that was never answered ──────────────────────────────────────
+//
+// A timeout is not a wrong answer. Six games used to report one as
+// `{ correct: false, answered: "" }`, which this adapter forwarded to
+// `items.answer` as an empty response — and an empty response does not parse,
+// so the host filed a miss and stepped the child's ladder down for not having
+// finished in time. Those games now say nothing at all, which is honest and
+// leaves the item open. `skip` is the ending that is honest *and* closed.
+
+test("a question the child never answered is closed on the host, and closed as a skip", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  const q = mounted.host.next()
+  mounted.host.skip(q.id)
+  await settle()
+
+  assert.deepEqual(fake.skips, [q.id], `items.skip was not reached: ${JSON.stringify(fake.skips)}`)
+  // And emphatically not through the method that records a wrong attempt. This
+  // is the line the whole fix exists for: an empty response *is* a miss.
+  assert.deepEqual(
+    fake.answers,
+    [],
+    `a skip reached items.answer as ${JSON.stringify(fake.answers)}, which is a recorded miss`,
+  )
+  mounted.dispose()
+})
+
+test("a skip is an absence of evidence: no outcome, no verdict, no progress", async () => {
+  const fake = fakeHost()
+  const outcomes: unknown[] = []
+  const progress: number[] = []
+  const mounted = attachGameHost(fake.client, {
+    onOutcome: (o) => outcomes.push(o),
+    onProgress: (f) => progress.push(f),
+  })
+  await mounted.warm()
+
+  const skipped = mounted.host.next()
+  mounted.host.skip(skipped.id)
+  await settle()
+
+  assert.deepEqual(outcomes, [], "a skip produced an outcome a pacing controller would read")
+  assert.deepEqual(
+    mounted.host.recentOutcomes(),
+    [],
+    "a skip is in recentOutcomes, where a controller will count it against the child",
+  )
+  assert.deepEqual(progress, [], "a skip advanced the session progress, which counts answers")
+
+  // An answered question, immediately after, still does all three — the skip
+  // suppressed the record of itself and nothing else.
+  const answered = mounted.host.next()
+  mounted.host.report({ questionId: answered.id, correct: true, ms: 400, answered: "7" })
+  await settle()
+  assert.equal(mounted.host.recentOutcomes().length, 1, "a real answer stopped being recorded")
+  assert.equal(progress.length, 1, "a real answer stopped advancing progress")
+  mounted.dispose()
+})
+
+test("skipping is final: an answer reported afterwards is not recorded either", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  const q = mounted.host.next()
+  mounted.host.skip(q.id)
+  // A late strike, a queued input, a second code path in the game. Whatever it
+  // is, the item is closed, and reopening it is how a timeout becomes a miss by
+  // another route.
+  mounted.host.report({ questionId: q.id, correct: false, ms: 9000, answered: "" })
+  await settle()
+
+  assert.deepEqual(
+    fake.answers,
+    [],
+    `an answer after a skip reached the host: ${JSON.stringify(fake.answers)}`,
+  )
+  assert.deepEqual(mounted.host.recentOutcomes(), [], "an answer after a skip was recorded")
+  mounted.dispose()
+})
+
+test("and the other way round: a skip after an answer does not close it twice", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  const q = mounted.host.next()
+  mounted.host.report({ questionId: q.id, correct: true, ms: 400, answered: "7" })
+  mounted.host.skip(q.id)
+  // Ids this module never served, and the id the dry pool hands out.
+  mounted.host.skip("never-served")
+  mounted.host.skip("")
+  await settle()
+
+  assert.equal(mounted.host.recentOutcomes().length, 1, "the answer was lost")
+  assert.deepEqual(fake.skips, [], `unserved ids reached the wire: ${JSON.stringify(fake.skips)}`)
+  mounted.dispose()
+})
+
+test("a skipped question does not come straight back, with or without a flush", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  const skipped = mounted.host.next()
+  mounted.host.skip(skipped.id)
+  await settle()
+
+  const later: string[] = []
+  for (let i = 0; i < 30; i++) {
+    later.push(mounted.host.next().id)
+    if (i === 4) mounted.host.flush()
+    if (i % 6 === 0) await settle(2)
+  }
+  assert.ok(
+    !later.includes(skipped.id),
+    `the question that just timed out was served again at position ${String(later.indexOf(skipped.id) + 1)}`,
+  )
+  mounted.dispose()
+})
+
+test("a skip asks for nothing: it does not move the difficulty or flush the pool", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  await settle()
+  fake.asks.length = 0
+
+  for (let i = 0; i < 6; i++) {
+    const q = mounted.host.next()
+    mounted.host.skip(q.id)
+    await settle(2)
+  }
+
+  // A child who ran out of time has told us nothing about what they know, so
+  // this module says nothing about it either. Anything else would be this
+  // module deciding a difficulty, which is a controller's job and not its own.
+  assert.equal(
+    fake.asks.every((ask) => ask.difficulty === undefined && ask.maxDifficulty === undefined),
+    true,
+    `skipping put a difficulty on the wire: ${JSON.stringify(fake.asks.slice(0, 4))}`,
+  )
+  mounted.dispose()
+})
+
+test("a host that cannot take a skip says so once, and the item is still not recorded", async () => {
+  const fake = fakeHost()
+  fake.skipFails = true
+  const mounted = attachGameHost(fake.client)
+  const said = await withConsole(async () => {
+    await mounted.warm()
+    const first = mounted.host.next()
+    mounted.host.skip(first.id)
+    // The same failure again, and again: a game with a per-gate timer produces
+    // one of these a second, and a message printed a thousand times is not read.
+    for (let i = 0; i < 5; i++) {
+      const q = mounted.host.next()
+      mounted.host.skip(q.id)
+    }
+    await settle()
+    mounted.host.report({ questionId: first.id, correct: false, ms: 9000, answered: "" })
+    await settle()
+  })
+
+  const complaints = said.filter((line) => line.includes("could not be closed"))
+  assert.equal(complaints.length, 1, `said ${String(complaints.length)} times: ${said.join(" | ")}`)
+  // The half of the fix that does not need the host: the item is gone from this
+  // module's ledger, so nothing can turn it into a wrong attempt afterwards.
+  assert.deepEqual(fake.answers, [], "a failed skip left the item answerable, so it became a miss")
+  assert.deepEqual(mounted.host.recentOutcomes(), [], "a failed skip still produced an outcome")
+  mounted.dispose()
+})
+
+test("a pack that never skips never touches the skip wire", async () => {
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  for (let i = 0; i < 10; i++) {
+    const q = mounted.host.next({ difficulty: 4 })
+    mounted.host.report({ questionId: q.id, correct: true, ms: 300, answered: q.answer })
+    await settle(2)
+  }
+  assert.deepEqual(fake.skips, [], "the twenty-seven packs that never skip started skipping")
+  assert.equal(fake.answers.length, 10)
   mounted.dispose()
 })
 

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -25,6 +25,10 @@
 // this module did not serve, is dropped. A pack that double-reports a chip
 // would otherwise inflate a child's record, and the record only ever rises.
 //
+// **A question can also be closed unanswered.** `skip` is the other ending, and
+// it is not a quiet synonym for a wrong answer — see the method for what it
+// costs and what it deliberately does not touch.
+//
 // ── The difficulty wire ──────────────────────────────────────────────────────
 //
 // This module used to be a one-way pipe. `next()` took no arguments, so the ten
@@ -184,6 +188,44 @@ export type GameHost = {
    */
   next(request?: DifficultyRequest): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  /**
+   * The child did not answer this one. Close it and record nothing.
+   *
+   * **Why it has to be here.** `report` is the only other ending, and it
+   * forwards `answered` to `items.answer` — so a timeout reported as
+   * `{ correct: false, answered: "" }` is not filed as "unanswered", it is
+   * filed as a MISS: the empty string does not parse, the learner model takes
+   * a wrong attempt, and the ladder steps down. beam, rhythm, horde, pulse,
+   * truedraw and trebuchet all did exactly that until this week. They now say
+   * nothing instead, which is honest but leaves the item open at both ends.
+   * This is the third option, and the only one that is both honest and closed.
+   *
+   * **What it does.** Drops the pack-side record of the question — which is
+   * what stops a later `report` on the same id from reaching the host at all —
+   * and calls the SDK's `items.skip`, which marks the item closed in the
+   * host's ledger so that nothing arriving afterwards can be recorded against
+   * it either.
+   *
+   * **What it deliberately does not do.** It does not produce an `Outcome`, so
+   * a pacing controller reading `recentOutcomes` never sees a skip as a wrong
+   * answer — it sees an absence, which is what it is. It does not advance the
+   * session progress fraction, because that counts answered questions. It does
+   * not move the difficulty, request one, or flush: a child who ran out of time
+   * has told us nothing about what they know, and a module that guessed from
+   * that would be deciding something, which this module does not do.
+   *
+   * **It does not put the question back.** A skipped question was already taken
+   * out of the prefetch pool when it was handed over and is not returned to it,
+   * so the next `next()` is a new question. Being handed the same sum again the
+   * instant the timer runs out reads as nagging, and a child who was still
+   * carrying the hundreds column does not need to be asked twice.
+   *
+   * Once per item, like `report`: an id that was never served, or that has
+   * already been answered or skipped, is dropped. Skipping is final — an answer
+   * reported after a skip is not recorded, and neither is a skip after an
+   * answer.
+   */
+  skip(questionId: string): void
   haptic(kind: HapticKind): void
   prefersReducedMotion(): boolean
   /** Optional host extension FUSE feature-detects: bias the stream by value. */
@@ -402,6 +444,8 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   let lastServed: Question | null = null
   let lastAsk = Date.now()
   let reported = 0
+  /** Whether a failed `items.skip` has already been said out loud. */
+  let skipFailed = false
 
   /** The difficulty the game is asking for, 0..1, or null for "whatever". */
   let target: number | null = null
@@ -670,6 +714,29 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
             land(correct, false)
           },
         )
+    },
+
+    skip: (questionId) => {
+      const origin = served.get(questionId)
+      if (questionId === "" || origin === undefined) return
+      // Deleted first, and this is the half of the fix that works even when the
+      // host cannot be reached: with the entry gone, a `report` on this id can
+      // no longer produce an `items.answer` call, so nothing about this
+      // question can turn into a wrong attempt afterwards.
+      served.delete(questionId)
+      void client.skip(questionId).catch((error: unknown) => {
+        if (skipFailed) return
+        skipFailed = true
+        // Loud, once. The consequence is small and worth stating precisely: the
+        // item stays open in the host's ledger until it is evicted, and an open
+        // item costs a child nothing — it is never re-served, never recorded,
+        // and never moves the ladder on its own.
+        console.error(
+          "[pack] an unanswered question could not be closed on the host; it is left open " +
+            "rather than recorded, which costs the child nothing",
+          error,
+        )
+      })
     },
 
     haptic: (kind) => {


### PR DESCRIPTION
A timeout is not a wrong answer. Six games — beam, rhythm, horde, pulse, truedraw, trebuchet — used to report an expiry as `{ correct: false, answered: "" }`, and because this adapter discards the game's `correct` and forwards `answered` to `items.answer`, where an empty string does not parse, **the host recorded a miss and stepped the child's ladder down for not having answered in time.**

Those games were fixed to say nothing instead. That is strictly better, but it leaves the item open at both ends: the SDK has had `items.skip` all along and the game-facing `Host` did not surface it, so a game's `skip` reached nothing.

## What an abandoned item actually costs

Read before fixing, because the honest answer changes the size of the fix.

**On the host it costs very little.** In `dynawalla-app/src/packs/items.ts` the ledger is a 512-entry FIFO with eviction, so an unanswered item does not leak. Ids are unique per `sequence`, so it is never re-served. `deps.record` is called only from `judge`, and `position` moves only in `judge` or on an explicit difficulty request — so an abandoned item never touches the learner record and never moves the ladder. `practised` is added at serve time, so the learner summary already counted it the moment the question was drawn.

The one thing left open is a **window**: the item stays `answered: false` until eviction, so anything that reports that id later — a late strike, a queued input, a second code path — is still recorded, and still steps the ladder. `items.skip` closes exactly that window.

**On the pack side it costs more than it looks.** `served` is pruned only by `report`, so **every abandoned item holds a `served` entry for the entire life of the mount**. A game with a per-gate timer leaks one per expiry. That is the real, unbounded cost, and it is on this side of the wire.

## The surface

```ts
skip(questionId: string): void
```

Present on `GameHost` always, so a feature-detecting game (`host.skip?.(id)`, which is how beam already declares it) finds it. Synchronous, fire and forget.

- `client.skip` on the wire, never `client.answer`.
- The `served` entry is dropped **first** — the half of the fix that works with no host at all: with the entry gone, a later `report` on that id cannot produce an `items.answer` call.
- **No `Outcome`.** A pacing controller reading `recentOutcomes` sees an absence, not a wrong answer.
- **No progress tick** — that fraction counts answered questions.
- **No difficulty and no flush.** A child who ran out of time has told us nothing about what they know.
- Once per item, like `report`: unserved, already-answered, already-skipped and the dry-pool `""` are all dropped.
- A host too old to have the method complains once per mount, not once per gate, and the item is still not recorded.

## Pool and `flush()`

A served question is spliced out of the pool when it is handed over and `skip` does not put it back, so the sum that just timed out is not the next one asked — verified across 30 subsequent draws with a `flush()` in the middle. `skip` itself never flushes and never sets a target, so the pool is exactly as it was.

## Every test earned against a mutant

Removing the method entirely fails all seven with `mounted.host.skip is not a function`. Each new test additionally has a mutant that **only it** catches:

| mutant | test that catches it | failure |
| --- | --- | --- |
| skip = the old `report(correct:false, answered:"")` | closed as a skip | `items.skip was not reached: []` |
| calls the wire, no `served.delete` | skipping is final | `an answer after a skip reached the host: [{"itemId":"i1","response":""}]` |
| deletes, never calls the wire | closed as a skip | `items.skip was not reached: []` |
| files an `Outcome` anyway | absence of evidence | `a skip produced an outcome a pacing controller would read` |
| puts the question back in the pool | does not come straight back | `the question that just timed out was served again at position 1` |
| treats a timeout as "struggling" and drives the wire | asks for nothing | `skipping put a difficulty on the wire: [{"difficulty":0.6}, …]` |
| complains on every failure | says so once | `said 6 times: … 6 !== 1` |
| no guard on unserved ids | does not close it twice | `unserved ids reached the wire: ["i1","never-served",""]` |

## Compatibility

Twenty-seven packs mount on this module and **none of them names the `GameHost` type** — they assign `mounted.host` to their own local `Host`, so an added member is structurally invisible. beam (declares `skip?`) and horde (declares nothing of the kind) both `tsc --noEmit` clean. A test asserts a pack that never skips never touches the skip wire.

`game-host` 25/25 and `sdk` 54/54, five consecutive runs each. `tsc --noEmit` clean on both. CI picks this up through the `dynawalla/packs/shared/*/package.json` glob.

## Not verified without a device

The end-to-end path through the real `PackFrame` → bridge → `services.skip` → `items.skip` was read, not run: the bridge case, the capability entry and the ledger write are all present on `main`, but nothing here exercises a real `MessagePort`. And no game calls `skip` yet — beam, rhythm and horde are all still on the "say nothing" fallback, which is now upgradeable one game at a time.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb