### PR TITLE
fix(dynawalla/host): "quick" is a property of the question, not a number

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -9,8 +9,23 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { createItemService, ladder, choicesFor, isSubtraction } from "./items.ts"
-import { familyById, FORM_FREE_ENTRY, activeNodes } from "./curriculum.ts"
+import {
+  cadenceFor,
+  choicesFor,
+  climbWithinMs,
+  createItemService,
+  isSubtraction,
+  ladder,
+} from "./items.ts"
+import type { PromptSlot } from "./curriculum.ts"
+import {
+  activeNodes,
+  allNodes,
+  familyById,
+  FORM_FREE_ENTRY,
+  SLOT_BOTTOM,
+  SLOT_TOP,
+} from "./curriculum.ts"
 
 const noRecord = () => {}
 
@@ -369,4 +384,336 @@ test("isSubtraction reads every active family's key, not one family's constant",
     const key = String(rung.node.generator.family)
     assert.ok(key.length > 0)
   }
+})
+
+// ---------------------------------------------------------------------------
+// The ladder's climb rule, against the cadence table it is supposed to obey.
+//
+// Every millisecond quoted below is read off `docs/EXPERIENCE_DESIGN.md` by hand
+// and written out as a literal. Nothing here calls `cadenceFor` or
+// `climbWithinMs` to decide what it expects — a test that asks the fix what the
+// answer is and then agrees with it measures nothing, and this repo has shipped
+// several of those.
+//
+// | class                     | p50    | p90  |
+// |---------------------------|--------|------|
+// | single-digit fact         |  2.8 s |  6 s |
+// | two-digit with regrouping |    6 s | 14 s |
+// | three-digit               |   11 s | 27 s |
+// | the `5,001 − 2,798` class |   16 s | 40 s |
+const P50_BY_WIDTH: Readonly<Record<number, number>> = { 1: 2_800, 2: 6_000, 3: 11_000, 4: 16_000 }
+/** The widest published median. Beyond four digits the table says nothing. */
+const P50_WIDEST_PUBLISHED_MS = 16_000
+
+const ACROSS_ZERO = "dw.add.regroup.subtract-across-zero"
+
+function widthOf(operands: readonly string[]): number {
+  let widest = 0
+  for (const operand of operands) {
+    const digits = operand.replace(/[^0-9]/g, "").length
+    if (digits > widest) widest = digits
+  }
+  return widest
+}
+
+/** What the table says the median is for an item that wide. */
+function publishedP50Ms(width: number): number {
+  return P50_BY_WIDTH[width] ?? P50_WIDEST_PUBLISHED_MS
+}
+
+test("the `5,001 − 2,798` rungs are reachable: answering them at the published median climbs", () => {
+  // The three levels of the hardest node that ships, on their own ladder so the
+  // climb is observable rather than clamped at the top of the full one.
+  const rungs = ladder().filter((rung) => rung.node.id === ACROSS_ZERO)
+  assert.equal(rungs.length, 3, "the across-zero node no longer has three rungs")
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  assert.equal(service.position(), 0)
+
+  for (let step = 0; step < rungs.length - 1; step++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    const width = widthOf(item.operands)
+    const median = publishedP50Ms(width)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      // Exactly the median. Not "fast" — expected. Half of the children who
+      // answer this question correctly take at least this long.
+      latencyMs: median,
+    })
+    assert.equal(
+      service.position(),
+      step + 1,
+      `${item.prompt} is ${String(width)} digits wide, its published median is ` +
+        `${String(median)} ms, it was answered correctly in exactly that, and the ladder ` +
+        `did not move off rung ${String(step)}`,
+    )
+  }
+})
+
+test("a two-digit regrouping answered a millisecond past the median still climbs", () => {
+  // The median is the median: half of the children answering at the expected
+  // pace are on the slow side of it. A gate cut at 6,000 ms sent every one of
+  // them back down the ladder for being average.
+  const rungs = ladder().filter((rung) => rung.node.id === "dw.add.regroup.subtract-multidigit")
+  assert.ok(rungs.length > 1)
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+
+  const item = service.next({ packId: "dynawalla.siege" })
+  assert.ok(item)
+  assert.equal(widthOf(item.operands), 2, `${item.prompt} is not the two-digit rung`)
+  service.judge({
+    packId: "dynawalla.siege",
+    itemId: item.id,
+    response: service.reveal(item.id),
+    latencyMs: 6_001,
+  })
+  assert.equal(service.position(), 1, `${item.prompt} in 6,001 ms did not climb`)
+})
+
+test("a child who answers every question correctly at its own published median reaches the top", () => {
+  // End to end over the shipped ladder. This is the founder's sentence as a
+  // test: "if they are just crushing double digits for a nice little while then
+  // the triple digits come in."
+  const rungs = ladder()
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  const top = rungs.length - 1
+
+  const seen: string[] = []
+  for (let answered = 0; answered < 200 && service.position() < top; answered++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    const before = service.position()
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+    if (service.position() === before) seen.push(`${item.prompt} (rung ${String(before)})`)
+  }
+  assert.equal(
+    service.position(),
+    top,
+    `the ladder stalled at rung ${String(service.position())} of ${String(top)}; ` +
+      `these questions were answered correctly at their published median and did not climb: ` +
+      `${seen.slice(0, 5).join(", ")}`,
+  )
+})
+
+test("no rung's climb window is narrower than that rung's own expected time", () => {
+  // The invariant the defect violated, held over every rung in the shipped
+  // ladder rather than over the four the table names.
+  for (const rung of ladder()) {
+    const service = createItemService({ profileId: "p1", record: noRecord, rungs: [rung] })
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item, `${rung.node.id}#L${String(rung.level)} served nothing`)
+    const width = widthOf(item.operands)
+    const window = climbWithinMs(width, rung.node.fluencyTarget?.p50Ms)
+    assert.ok(window !== null, `${item.prompt} has no climb window at all`)
+    assert.ok(
+      window > publishedP50Ms(width),
+      `${rung.node.id}#L${String(rung.level)} draws ${item.prompt}, ${String(width)} digits ` +
+        `wide, whose published median is ${String(publishedP50Ms(width))} ms — and it climbs ` +
+        `only under ${String(window)} ms`,
+    )
+    // And a node that declares its own median may only widen the window, never
+    // narrow it. `dw.mul.*` declares 15 s and `dw.div.*` 18 s; those rows are
+    // draft today and this is the guard that stops the same defect arriving
+    // with them.
+    const declared = rung.node.fluencyTarget?.p50Ms
+    if (declared !== undefined) {
+      assert.ok(
+        window > declared,
+        `${rung.node.id} declares a ${String(declared)} ms median and climbs only under ` +
+          `${String(window)} ms`,
+      )
+    }
+  }
+})
+
+test("every node in the graph, draft included, gets a window wider than its declared median", () => {
+  for (const node of allNodes) {
+    const declared = node.fluencyTarget?.p50Ms
+    if (declared === undefined) continue
+    for (let width = 1; width <= 6; width++) {
+      const window = climbWithinMs(width, declared)
+      assert.ok(window !== null && window > declared, `${node.id} at ${String(width)} digits`)
+    }
+  }
+})
+
+test("the cadence table is the only thing the climb window is derived from", () => {
+  // The four published rows, restated as the assertion that the two lines in
+  // `items.ts` actually pass through them.
+  assert.deepEqual(cadenceFor(1), { p50Ms: 2_800, p90Ms: 6_000 })
+  assert.deepEqual(cadenceFor(2), { p50Ms: 6_000, p90Ms: 14_000 })
+  assert.deepEqual(cadenceFor(3), { p50Ms: 11_000, p90Ms: 27_000 })
+  assert.deepEqual(cadenceFor(4), { p50Ms: 16_000, p90Ms: 40_000 })
+  // A width that is not a width is not a class, and is never silently "easy".
+  assert.equal(cadenceFor(0), null)
+  assert.equal(cadenceFor(-1), null)
+  assert.equal(climbWithinMs(0, undefined), null)
+})
+
+test("an unclassifiable item promotes and says so, rather than pinning a child in silence", () => {
+  // A prompt with no numerals in it, on a node that declares no fluency target.
+  // No family ships one today; the next one might, and the failure mode must be
+  // a line in the log rather than a child who answers correctly all afternoon
+  // and never moves.
+  const base = ladder().find((rung) => rung.node.id === ACROSS_ZERO)
+  assert.ok(base)
+  assert.equal(base.node.fluencyTarget, undefined, "the chosen node now declares a median")
+
+  const wordless = {
+    ...base,
+    family: {
+      ...base.family,
+      generate: (request: Parameters<typeof base.family.generate>[0]) => {
+        const exercise = base.family.generate(request)
+        return {
+          ...exercise,
+          prompt: {
+            key: exercise.prompt.key,
+            slots: {
+              [SLOT_TOP]: { kind: "term", key: "dw.term.the-larger" } as unknown as PromptSlot,
+              [SLOT_BOTTOM]: { kind: "term", key: "dw.term.the-smaller" } as unknown as PromptSlot,
+            },
+          },
+        }
+      },
+    },
+  } as typeof base
+
+  const warnings: string[] = []
+  const realWarn = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "))
+  try {
+    const service = createItemService({
+      profileId: "p1",
+      record: noRecord,
+      rungs: [wordless, wordless],
+    })
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    assert.equal(widthOf(item.operands), 0, `${item.prompt} still has numerals in it`)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      // Four minutes. Unclassifiable must mean generous, not punitive.
+      latencyMs: 240_000,
+    })
+    assert.equal(service.position(), 1, "an unclassifiable item refused to promote")
+  } finally {
+    console.warn = realWarn
+  }
+  assert.ok(
+    warnings.some((line) => line.includes(ACROSS_ZERO) && line.includes("fluencyTarget")),
+    `nothing was said about it: ${JSON.stringify(warnings)}`,
+  )
+})
+
+test("a latency that is not a measurement promotes and says so", () => {
+  // `NaN <= 40000` is `false`. A pack with a broken clock would otherwise pin a
+  // child to the bottom rung with nothing on the console at all.
+  const warnings: string[] = []
+  const realWarn = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "))
+  try {
+    const service = createItemService({ profileId: "p1", record: noRecord })
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: Number.NaN,
+    })
+    assert.equal(service.position(), 1, "a broken clock stopped a correct answer climbing")
+  } finally {
+    console.warn = realWarn
+  }
+  assert.ok(
+    warnings.some((line) => line.includes("not a measurement")),
+    `nothing was said about it: ${JSON.stringify(warnings)}`,
+  )
+})
+
+test("a correct answer from the slow tail of its own item holds the rung, and never costs one", () => {
+  // The intent the constant was reaching for, kept: a child who took far longer
+  // than the ninth of ten children on this question does not climb — and does
+  // not fall either. Being slow is not being wrong.
+  const rungs = ladder().filter((rung) => rung.node.id === "dw.add.facts.add-within-ten")
+  assert.ok(rungs.length > 1)
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  const first = service.next({ packId: "dynawalla.siege" })
+  assert.ok(first)
+  service.judge({
+    packId: "dynawalla.siege",
+    itemId: first.id,
+    response: service.reveal(first.id),
+    latencyMs: 2_800,
+  })
+  const climbed = service.position()
+  assert.equal(climbed, 1)
+
+  const second = service.next({ packId: "dynawalla.siege" })
+  assert.ok(second)
+  service.judge({
+    packId: "dynawalla.siege",
+    itemId: second.id,
+    response: service.reveal(second.id),
+    // Five minutes on a single-digit fact. Nobody's p90.
+    latencyMs: 300_000,
+  })
+  assert.equal(service.position(), climbed, "a slow correct answer moved the ladder")
+})
+
+test("no run of wrong answers can push a child below the easiest rung the curriculum has", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  for (let i = 0; i < 30; i++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item, `the floor stopped serving questions after ${String(i)} misses`)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: "definitely wrong",
+      latencyMs: 1_000,
+    })
+    assert.ok(service.position() >= 0, `the ladder went to ${String(service.position())}`)
+  }
+  assert.equal(service.position(), 0)
+  assert.ok(service.next({ packId: "dynawalla.siege" }), "the floor is not serving questions")
+})
+
+test("climbing and stepping down are one rung each and meet in the middle", () => {
+  // The descent rule is unchanged and is founder direction; what is checked here
+  // is that it composes with the new climb rule rather than fighting it.
+  const rungs = ladder()
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  for (let i = 0; i < 6; i++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+  }
+  const high = service.position()
+  assert.equal(high, 6)
+  for (let i = 0; i < 3; i++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: "definitely wrong",
+      latencyMs: 1_000,
+    })
+  }
+  assert.equal(service.position(), high - 3, "three misses did not cost exactly three rungs")
 })

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -23,8 +23,11 @@
 // **What a rung is.** The curriculum ships one generator family so far
 // (`gen.arith.column-op`) bound to four active skills at four levels each. The
 // rungs are those bindings, sorted by the difficulty the node itself declares,
-// and the ladder walks them: a fast correct answer climbs, a wrong one steps
-// down. That is not the FSRS scheduler (ADR-0008) — it is the smallest honest
+// and the ladder walks them: a correct answer that was not from the slow tail of
+// *that item* climbs, a wrong one steps down. "Not slow for that item" is read
+// off the cadence table in `docs/EXPERIENCE_DESIGN.md` — see the `CADENCE_*`
+// note below, and what it says about the constant it replaced.
+// That is not the FSRS scheduler (ADR-0008) — it is the smallest honest
 // thing that makes a pack's stream get harder — and it is confined to this file
 // so replacing it does not touch the boundary.
 
@@ -60,8 +63,58 @@ const MINUS = "−"
 /** Items kept addressable for `judge` and `reveal`. Oldest evicted first. */
 const LEDGER_LIMIT = 512
 
-/** Faster than this and the ladder climbs. Half the slowest node's p50. */
-const QUICK_MS = 6_000
+/**
+ * ## How long a question is *expected* to take
+ *
+ * `EXPERIENCE_DESIGN.md` publishes a cadence table — instrumented p50/p90, never
+ * shown to a child:
+ *
+ * | class | p50 | p90 |
+ * |---|---|---|
+ * | single-digit fact | 2.8 s | 6 s |
+ * | two-digit with regrouping | 6 s | 14 s |
+ * | three-digit | 11 s | 27 s |
+ * | the `5,001 − 2,798` class | 16 s | 40 s |
+ *
+ * Two straight lines fit all four rows exactly, in the width of the widest
+ * operand — which is also how the table names its own classes:
+ *
+ *     p50 = 2.8 s                             at one digit
+ *         = 6 s  + 5 s  × (digits − 2)        from two digits up
+ *     p90 = 6 s                               at one digit
+ *         = 14 s + 13 s × (digits − 2)        from two digits up
+ *
+ * Check: three digits → 6+5 = 11 s and 14+13 = 27 s; four → 16 s and 40 s. The
+ * constants below are those two lines and nothing else, so the table stays the
+ * source of truth and this file holds no opinion of its own about how long a
+ * child should take.
+ *
+ * **Why this is here at all.** Until this note, the ladder climbed on
+ * `correct && latencyMs <= 6000` — one constant for every question in the
+ * product. Against the table above, six seconds is the *median* of a two-digit
+ * regrouping item, so half of the children answering at the expected pace never
+ * climbed; and it is well under the median of the `5,001 − 2,798` class, so the
+ * three rungs of `dw.add.regroup.subtract-across-zero` — the hardest content
+ * that ships — were not hard, they were **unreachable**. The doc's own line for
+ * this row reads "COMPREHENSION — not budgeted. The child's time. Measured,
+ * never limited," and a constant threshold budgeted it.
+ */
+const CADENCE_FACT_P50_MS = 2_800
+const CADENCE_FACT_P90_MS = 6_000
+const CADENCE_COLUMN_P50_MS = 6_000
+const CADENCE_COLUMN_P50_PER_DIGIT_MS = 5_000
+const CADENCE_COLUMN_P90_MS = 14_000
+const CADENCE_COLUMN_P90_PER_DIGIT_MS = 13_000
+
+/**
+ * The table's widest p90/p50 spread, as a ratio so it multiplies exactly.
+ *
+ * 6/2.8, 14/6, 27/11 and 40/16 are 2.14, 2.33, 2.45 and 2.50. The largest is
+ * taken, because every use of it below is "widen a declared median into a slow
+ * tail" and a narrow guess there is the punitive direction.
+ */
+const CADENCE_SPREAD_NUM = 5
+const CADENCE_SPREAD_DEN = 2
 
 /**
  * Options on a closed list: the canonical answer and three wrong ones.
@@ -254,11 +307,79 @@ export function choicesFor(exercise: Exercise, places: number): readonly ItemCho
   return texts.map((text, index) => ({ id: `c${String(index)}`, text }))
 }
 
+/**
+ * How wide the widest operand is, in digits, as a child reads it.
+ *
+ * Digit characters only, so `12.5` is three and `4,003` would be four however it
+ * is punctuated. Zero means the prompt has no numerals in it — a fraction card
+ * or a worded term — and zero is *not* a width: it is "this file cannot tell",
+ * and the caller must treat it as such rather than as "easy".
+ */
+export function widestOperandDigits(operands: readonly string[]): number {
+  let widest = 0
+  for (const operand of operands) {
+    let digits = 0
+    for (const ch of operand) if (ch >= "0" && ch <= "9") digits += 1
+    if (digits > widest) widest = digits
+  }
+  return widest
+}
+
+/** The cadence table read at a width, or `null` when there is no width to read. */
+export function cadenceFor(digits: number): { p50Ms: number; p90Ms: number } | null {
+  if (!Number.isInteger(digits) || digits < 1) return null
+  if (digits === 1) return { p50Ms: CADENCE_FACT_P50_MS, p90Ms: CADENCE_FACT_P90_MS }
+  const over = digits - 2
+  return {
+    p50Ms: CADENCE_COLUMN_P50_MS + CADENCE_COLUMN_P50_PER_DIGIT_MS * over,
+    p90Ms: CADENCE_COLUMN_P90_MS + CADENCE_COLUMN_P90_PER_DIGIT_MS * over,
+  }
+}
+
+/**
+ * How long an answer to *this* item may take and still climb the ladder — or
+ * `null` when nothing about the item says.
+ *
+ * The item's own p90. A child at the p90 is not slow; a child at the p90 is the
+ * ninth of ten children who answered it, and the tenth still keeps the rung they
+ * are on. What the rule refuses to promote is a correct answer from the slow
+ * tail *of that question*, which is the only thing "quick" ever meant.
+ *
+ * Two inputs, and the wider of them wins:
+ *
+ *   * **The cadence table**, at the width of the widest operand.
+ *   * **`fluencyTarget.p50Ms`**, when the curriculum node declares one, widened
+ *     by the table's own spread. This is not decoration. `gen.arith.column-op`
+ *     is the addition ladder the table was measured on; `dw.mul.*` declares a
+ *     15 s median and `dw.div.*` an 18 s one, and a two-digit multiplication
+ *     read only through the column model would get a 14 s window around a 15 s
+ *     median — the same defect, in a domain that has not gone active yet. Taking
+ *     the **max** makes authored data able only to widen the window and never to
+ *     narrow it, which `items.test.ts` asserts over every node in the graph.
+ *
+ * `null` — a prompt with no numerals on a node that declares no target — means
+ * the item's class is not knowable here. The caller promotes anyway and says so
+ * out loud. A ladder that quietly declines to move is exactly the silent blank
+ * this codebase keeps shipping, and "we could not classify it" is never a reason
+ * to hold a child down.
+ */
+export function climbWithinMs(digits: number, fluencyP50Ms: number | undefined): number | null {
+  const table = cadenceFor(digits)
+  const declared =
+    fluencyP50Ms === undefined || !Number.isFinite(fluencyP50Ms) || fluencyP50Ms <= 0
+      ? null
+      : Math.round((fluencyP50Ms * CADENCE_SPREAD_NUM) / CADENCE_SPREAD_DEN)
+  if (table === null && declared === null) return null
+  return Math.max(table?.p90Ms ?? 0, declared ?? 0)
+}
+
 type Served = {
   readonly exercise: Exercise
   readonly rung: Rung
   readonly places: number
   readonly choices: readonly ItemChoice[]
+  /** Width of the widest operand as drawn. 0 when the prompt held no numerals. */
+  readonly digits: number
   answered: boolean
 }
 
@@ -294,6 +415,37 @@ export type ItemService = {
     packId: string
     itemId: string
     response: string
+    /**
+     * ## What `latencyMs` is, and what it is not
+     *
+     * **There is no contract.** This is a finding, not a description. The SDK
+     * declares `answer({ itemId, response, latencyMs })` with no doc comment on
+     * the field, `bridge.ts` only clamps it to ten minutes and rejects a
+     * negative, and every pack decides for itself what interval it names. What
+     * has actually been observed in the shipped games: latency timed from when
+     * a question was *drawn* rather than from when it became *answerable*, and
+     * latency timed to a projectile's *impact* rather than to the child's
+     * commit — the second inflating every answer in that game by the two to
+     * three seconds of the arc (`games/trebuchet/src/game.test.ts` pins the fix
+     * from the pack's side).
+     *
+     * That is why the rule below is written to be robust to a couple of seconds
+     * of contamination rather than exact. The p90 of an item is roughly twice
+     * its p50; a game whose clock starts early by two seconds spends about a
+     * seventh of that head-room on a two-digit item and less on anything
+     * harder, so it costs a child a rung occasionally and never systematically.
+     * A rule cut at the p50 — which is what a flat 6 s was for two-digit
+     * regrouping — has no head-room at all, and contamination there is the
+     * difference between climbing and not.
+     *
+     * `EXPERIENCE_DESIGN.md` says what the contract *should* be, and nothing
+     * implements it yet: `timeToFirstKeyMs` and `timeToCommitMs` recorded
+     * separately, because a long first key is retrieval difficulty and a long
+     * key-to-commit is execution difficulty. "Corpán conflates them into one
+     * `latencyMs`; we will not" — and the SDK, today, does. Splitting the field
+     * is a protocol change across `packs/sdk` and every game, so it is named
+     * here rather than done here.
+     */
     latencyMs: number
   }): Judgement
   reveal(itemId: string): string
@@ -319,6 +471,13 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
   let sequence = 0
   /** A ladder with one rung answers every difficulty the same. Said once. */
   let toldAboutFlatLadder = false
+  /** Warnings that would otherwise fire on every single answer. */
+  const said = new Set<string>()
+  const sayOnce = (key: string, message: string) => {
+    if (said.has(key)) return
+    said.add(key)
+    console.warn(message)
+  }
 
   const remember = (id: string, served: Served) => {
     ledger.set(id, served)
@@ -327,6 +486,43 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       const evicted = order.shift()
       if (evicted !== undefined) ledger.delete(evicted)
     }
+  }
+
+  /**
+   * Whether a correct answer was quick enough for *this* item to climb.
+   *
+   * Everything that is not a clear "no" is a yes, and every yes-by-default says
+   * so on the console once per skill. Two ways to reach one:
+   *
+   *   * The item's class is not knowable — no numerals in the prompt and no
+   *     `fluencyTarget` on the node. A future family will hit this the day it
+   *     lands, and it must arrive as a line in the log rather than as a child
+   *     who answers correctly all afternoon and never moves.
+   *   * The latency is not a measurement. `NaN <= anything` is `false`, so a
+   *     pack reporting a bad clock would otherwise pin a child to the bottom of
+   *     the ladder in total silence — the exact shape of this bug, one layer
+   *     down.
+   */
+  const climbs = (served: Served, latencyMs: number): boolean => {
+    const within = climbWithinMs(served.digits, served.rung.node.fluencyTarget?.p50Ms)
+    if (within === null) {
+      sayOnce(
+        served.rung.node.id,
+        `[packs] ${served.rung.node.id} draws a prompt with no numerals in it and declares no ` +
+          `fluencyTarget, so how long it should take is unknown — every correct answer on it ` +
+          `climbs. Give the node a fluencyTarget.p50Ms to pace it.`,
+      )
+      return true
+    }
+    if (!Number.isFinite(latencyMs) || latencyMs < 0) {
+      sayOnce(
+        `latency:${served.rung.node.id}`,
+        `[packs] ${served.rung.node.id} was answered with a latency of ${String(latencyMs)}, ` +
+          `which is not a measurement — the answer climbs, and the pack's clock needs fixing.`,
+      )
+      return true
+    }
+    return latencyMs <= within
   }
 
   const rungAt = (index: number): Rung | null => {
@@ -412,7 +608,18 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       const places = decimalPlacesOf(exercise)
       const choices = choicesFor(exercise, places)
       const id = `${exercise.exerciseId}#${String(sequence)}`
-      remember(id, { exercise, rung, places, choices, answered: false })
+      // Measured here rather than in `judge`, off the strings a child actually
+      // read: the operands are already in hand, and the width of the question as
+      // drawn is the only reading of "how hard is this item" that cannot drift
+      // from what was on the screen.
+      remember(id, {
+        exercise,
+        rung,
+        places,
+        choices,
+        digits: widestOperandDigits([top, bottom]),
+        answered: false,
+      })
       practised.add(rung.node.id)
 
       const subtract = isSubtraction(exercise.prompt.key)
@@ -463,11 +670,17 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       if (!served.answered) {
         served.answered = true
         deps.record({ packId, correct: verdict.correct })
-        // The ladder moves on what actually happened. Up only when it was both
-        // right and quick, down on any miss — a child who is guessing does not
-        // climb, and a child who is struggling is not held there.
-        if (verdict.correct && latencyMs <= QUICK_MS) position = Math.min(rungs.length - 1, position + 1)
-        else if (!verdict.correct) position = Math.max(0, position - 1)
+        // The ladder moves on what actually happened. Up when it was right and
+        // not from the slow tail *of this question*, down on any miss — a child
+        // who is guessing does not climb, and a child who is struggling is not
+        // held there. A correct answer past the item's own p90 holds the rung:
+        // it is neither a promotion nor a demotion, and it is never a penalty.
+        if (verdict.correct && climbs(served, latencyMs)) position = position + 1
+        else if (!verdict.correct) position = position - 1
+        // One clamp for both directions, and the floor is written as a floor:
+        // no sequence of answers can put a child below the easiest rung the
+        // curriculum has, and none can put them past the hardest.
+        position = Math.max(0, Math.min(Math.max(0, rungs.length - 1), position))
       }
 
       return {


### PR DESCRIPTION
The ladder climbed on `verdict.correct && latencyMs <= 6_000` — one constant for every question the product can ask. Read against the cadence table in `docs/EXPERIENCE_DESIGN.md`, that constant is not a threshold, it is a ceiling on the curriculum.

| class | p50 | p90 |
|---|---|---|
| single-digit fact | 2.8 s | 6 s |
| two-digit with regrouping | 6 s | 14 s |
| three-digit | 11 s | 27 s |
| the `5,001 − 2,798` class | 16 s | 40 s |

Six seconds is the **median** of a two-digit regrouping item, so half the children answering at the expected pace never climbed. It is well under the median of every three-digit item and of the `5,001 − 2,798` class.

**18 of the ladder's 36 rungs could not be climbed** by a child answering correctly at the pace the product itself expects. A simulated child answering every question correctly at its own published median stalled on rung 16 of 35, at `545 + 130`, and stayed there forever. The doc's own row for this reads *"COMPREHENSION — not budgeted. The child's time. Measured, never limited"* — and a constant budgeted it.

## The new rule, in plain terms

**A correct answer climbs unless it came from the slow tail of that particular question.**

The window is the item's own p90. Two straight lines fit all four published rows exactly, in the width of the widest operand — which is how the table names its own classes:

```
p50 = 2.8 s                      at one digit
    = 6 s  + 5 s  × (digits − 2) from two digits up
p90 = 6 s                        at one digit
    = 14 s + 13 s × (digits − 2) from two digits up
```

Where a curriculum node declares `fluencyTarget.p50Ms`, that median widened by the table's own spread is taken as well, and the **wider** of the two wins — authored data can only widen the window, never narrow it. Not decoration: `dw.mul.*` declares a 15 s median and `dw.div.*` an 18 s one, and read through the column model alone a two-digit multiplication would get a 14 s window around a 15 s median. The same defect, waiting for those rows to go active. A test holds the invariant over every node in the graph, draft included.

### Reachability, before and after

| rungs | before (`≤ 6 s`) | after |
|---|---|---|
| 0–15 (1- and 2-digit facts and columns) | reachable | reachable |
| 16–19, 22–35 (every 3-, 4-, 5- and 6-digit rung, incl. all three `subtract-across-zero` rungs) | **unreachable at the published median** | reachable |
| total unreachable at the median | **18 / 36** | **0 / 36** |

## What is deliberately unchanged

- A wrong answer steps down, at any speed. Founder direction, kept in shape.
- A correct answer past the item's p90 **holds** the rung — neither promotion nor demotion. Being slow is not being wrong.
- A guesser still does not climb: a guess is wrong, and wrong descends.

Climb and descent now share one clamp, so no run of answers in either direction can leave the ladder. Removing that clamp drives it to −1, and a test says so.

## Nothing here fails silently

This repo has shipped three silent-blank failures in one night; this change adds no fourth.

- An item whose class cannot be determined — no numerals in the prompt, no declared median — **promotes**, and says so on the console.
- A latency that is not a measurement **promotes**, and says so. `NaN <= 40000` is `false`, so a pack with a broken clock would have pinned a child to the bottom rung with nothing in the log at all.

Both are once-per-skill, never per answer.

## What `latencyMs` actually measures: there is no contract

Stated as a finding, not a description. The SDK declares `answer({ itemId, response, latencyMs })` with **no doc comment on the field**; `bridge.ts` only clamps it to ten minutes and rejects a negative; every pack decides for itself what interval it names. Observed in shipped games: latency timed from when a question was *drawn* rather than when it became *answerable*, and latency timed to a projectile's *impact* rather than to the child's commit.

That finding is written at the call site, with why a p90 window survives it: the p90 of an item is roughly twice its p50, so a clock that starts two seconds early spends about a seventh of the head-room on a two-digit item and less on anything harder — it costs a rung occasionally, never systematically. A rule cut at the p50 (which is what a flat 6 s was for two-digit regrouping) has no head-room at all, and contamination there is the difference between climbing and not.

`EXPERIENCE_DESIGN.md` says what the contract *should* be — `timeToFirstKeyMs` and `timeToCommitMs` recorded separately, *"Corpán conflates them into one `latencyMs`; we will not"* — and the SDK today does exactly that. Splitting the field is a protocol change across `packs/sdk` and every game, so it is named here rather than done here.

## Every test was run with the fix deleted

Eleven new tests. Every millisecond in them is read off the doc by hand and written as a literal; none of them asks the code under test what the answer should be. Exact failure messages from the removed-fix runs:

| mutation | failure |
|---|---|
| old constant restored | `400 − 155 is 3 digits wide, its published median is 11000 ms, it was answered correctly in exactly that, and the ladder did not move off rung 0` |
| old constant restored | `86 − 77 in 6,001 ms did not climb` |
| old constant restored | `the ladder stalled at rung 16 of 35; these questions were answered correctly at their published median and did not climb: 125 + 540 (rung 16), …` |
| window cut at p50 not p90 | `dw.add.regroup.add-short-addend#L0 draws 5593 + 51, 4 digits wide, whose published median is 16000 ms — and it climbs only under 16000 ms` |
| declared-median term dropped | `dw.add.facts.add-within-ten declares a 6000 ms median and climbs only under 6000 ms` |
| declared-median term dropped | `dw.ns.place.digit-in-place at 1 digits` |
| p90 per-digit slope changed | `Expected values to be strictly deep-equal` (the four published rows) |
| unknown class refused | `an unclassifiable item refused to promote` |
| unknown class / bad clock, warnings removed | `nothing was said about it: []` |
| clamp removed | `the ladder went to -1` |
| descent made two rungs | `three misses did not cost exactly three rungs` |
| speed gate removed entirely | `a slow correct answer moved the ladder` |

## Verification

- `npm run tsc`, `npm run lint` clean.
- 238 tests, **five consecutive runs**, all green.
- The two pre-existing ladder tests were audited: `"the ladder climbs on a fast correct answer…"` already had its `"0"`-as-wrong-answer bug fixed and is guarded (it fails when descent is made two rungs); `"driving the difficulty moves the one ladder…"` uses a genuinely unparseable response. Both hold.

## Not verified

- No device or in-app run — this is pure host logic with no DOM, no Tauri and no frame.
- Nothing outside `dynawalla/dynawalla-app/` is touched. `dynawalla/games/**` and `dynawalla/packs/**` are read-only in this change, so the per-game latency contamination named above is reported, not fixed.
- The straight-line fit is exact on all four published rows; widths of 5 and 6 digits extrapolate beyond what the table publishes, and the tests only claim those are at least as wide as the widest published median.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb