### PR TITLE
feat(dynawalla): a design system, and a tool that can see it

### DIFF
--- a/dynawalla/docs/HARNESS_FEEDBACK.md
+++ b/dynawalla/docs/HARNESS_FEEDBACK.md
@@ -73,13 +73,91 @@ pressing hard on a card got a text-selection handle over the label. `user-select
 none` on `body`, with `input`, `textarea` and `[contenteditable]` opting back in
 so a parent can still edit a name they typed.
 
+### "Erase everything" was coral — 2026-07-29
+
+Was: `--dw-strike` came off the copper ramp, a leftover from the pre-purple
+palette, and a bare coral phrase floated in white space with nothing around it
+to say it was the most consequential control in the app.
+
+Fixed, and the decision was taken rather than drifted into. The strike ramp is
+now **rose**, and its hue is the arc's own rose end (`--color-arc-11`, hue 348°)
+— danger drawn in a colour the app already contains rather than a fifth family.
+It is three tokens, not one: `--dw-strike` (the word), `--dw-strike-line` (the
+frame it is bounded by) and `--dw-strike-ground` (the wash it fills with once
+armed), so the control is a bounded plate that visibly changes state before the
+press that actually erases. Light measures 6.39:1, up from copper's 4.45:1.
+
+The plate's resting border is `--dw-line-strong`, not `--dw-line`: at
+`--dw-line` it was the same rgb as the hairline between two ordinary rows, so
+"bounded" was true in dark and not in light.
+
+The same hue reached Profiles' three "Remove" buttons and put three crimson
+words down one screen. It should not have: at rest that control is now the muted
+ink and only becomes rose when it is armed and a second press would really
+remove a child. Danger is a state, not a decoration.
+
+### The strapwork band was gold, and there were two of them — 2026-07-29
+
+Was: the interlace band paints one knot every 24 px in `--dw-index`, and it ran
+under the lintel AND above the tab bar. A 1440 px screen carried about a hundred
+and twenty gold knots against a brand rule of ONE warm point per screen, and in
+light `--dw-index` resolved to `brass-700`, a red-brown that read as exactly the
+"dusty khaki sandstorm" the brand explicitly kills.
+
+Fixed in two steps:
+
+1. **The band is cool.** `--dw-band-strap` / `--dw-band-knot` are the app's own
+   violet, read directly by `Strapwork.tsx`. The warm point moved to the one
+   place a gold mark earns its keep — the navigation index that says which
+   destination you are on. Light `--dw-index` is now `brass-800` (hue 42°,
+   struck gold, 5.61:1), not `brass-700` (hue 30°, terracotta).
+2. **There is one band, not two.** Cool or not, a repeating interlace at both
+   edges of every screen framed the whole app in ornament, at the two places the
+   eye returns to most. The band is the brand's al-Andalus reference and it is
+   worth having once, as the carved course under the wordmark. At the bottom of
+   the screen the bar's own material and its upward cast are the edge — which is
+   quieter, and is what a tab bar looks like.
+
+### The tab bar cut its own labels — 2026-07-29
+
+Not reported; found by measuring the shipped app at the text sizes it ships. At
+390 px on the app's own **Largest** setting, four of the five destination names
+clipped to "Prog…", "Profi…", "Setti…", "Pare…"; at 320 px it happened at the
+DEFAULT size. That is WCAG 1.4.4 failing at 125%, not at 200%.
+
+Two causes, both fixed. The anchors carried a horizontal margin, so they did not
+tile the bar — 8 px of dead gutter between every pair of tabs, 20 px dead at each
+end, and 8 px stolen from the word. And a fifth of a 320 px screen is 60 px,
+which no fix to padding alone reaches.
+
+So each tab cell is now a container and the label's size is capped against the
+cell's own inline size (`min(step, 21cqi)`), which is what a native tab bar does:
+the label shrinks to fit and is never cut. At every ordinary width the cap is
+inert. Verified at 320 / 390 / 430 / 834 / 1024 / 1440 × normal and Largest:
+zero clipped labels.
+
+### Everything on a screen started at a different x — 2026-07-29
+
+At 1440 the wordmark began at 160, the catalogue cards at 160, the rows on the
+other four screens at 384 and the tab labels at 388 — and Parents used about a
+fifth of the glass. Four origins on one app.
+
+The rule is now one sentence: **the chrome is always the frame, and the only
+thing ever narrower than the frame is a column of prose.** The tab bar sits in
+`dw-frame`; a course of rows is a list, not prose, so it takes the frame too;
+above 64 rem the courses lay out in two columns inside it. Measured at every
+width, on every destination, the wordmark, the first row, the first card and the
+first tab all begin at the same x.
+
 ## Noted, not yet acted on
 
-- **"Erase everything" is coral** (`--dw-strike`, from the copper ramp) against a
-  violet ground. Semantically a destructive action should read as danger, but the
-  hue is the one leftover from the pre-purple palette and sits oddly. Worth a
-  deliberate decision rather than a drive-by change.
-- **The strapwork bands** at the top and bottom of the chrome carry the gold
-  index colour across the full width. The brand rule in
-  [`../brand/README.md`](../brand/README.md) is *one warm point per screen*;
-  a repeating full-width band is arguably two.
+- **Progress says how many, never how well.** "Answered 1284 / Correct 1102" is
+  two counts with no rate, no streak and no sense of a day. The drawing beside
+  them was re-inked this pass (it was a white card with two solid black rosettes
+  in a violet brand) but the numbers are unchanged. Adding a rate is new copy and
+  a small model change, not a design fix, so it is left for a deliberate call.
+- **The pass sheet cannot be reached in the shipped app.** `pass/model.ts` opens
+  unconditionally while `billing().wired` is false and nothing calls
+  `setBilling`, so there is no sequence of taps on a device that puts the sheet
+  on screen. It is verified only in `tools/harness/`. Wiring billing is not a
+  design change.

--- a/dynawalla/dynawalla-app/src/design/tokens.css
+++ b/dynawalla/dynawalla-app/src/design/tokens.css
@@ -1,8 +1,10 @@
 /* ──────────────────────────────────────────────────────────────────────────
    Dynawalla — design tokens
 
-   Tokens only. This file fixes the material vocabulary and the type scale so
-   the art pass has something to build on; it is not itself the visual design.
+   Tokens only. This file is the foundation the whole host harness is built
+   on: the palette, the spacing rhythm, the elevation ladder, the motion
+   vocabulary and the type scale. It is not itself the visual design — but
+   nothing in the design may invent a value this file does not name.
 
    Three layers, in this order, and the layering is load bearing:
 
@@ -16,10 +18,56 @@
                         so `bg-ground` emits `var(--dw-ground)` and follows the
                         theme class rather than baking one theme's value in.
 
-   The palette is material, not lighting: brass, lapis, carved limestone,
-   parchment, copper oxide, glazed tile, walnut, and the cold celestial light
-   that falls on all of it. No gradients, no glow.
-   `src/design/tokens.test.ts` enforces the layering mechanically.
+   `src/design/tokens.test.ts` enforces the layering mechanically, including
+   the rule that keeps this file honest: a semantic token that resolves to a
+   MATERIAL must be re-cut under `.dw-dark`, and one that carries no colour
+   must NOT be. That is why elevation backgrounds below defer to other
+   semantic tokens (`var(--dw-ground-raised)`) while elevation SHADOWS name
+   materials directly — the first is theme-independent by construction, the
+   second genuinely differs by theme.
+
+   ── Measured contrast (WCAG 2.1, sRGB) ─────────────────────────────────────
+   Every text pair this file defines, measured rather than assumed. AA needs
+   4.5 for normal text, 3.0 for large text and graphics.
+
+   LIGHT — ground parchment-100 · sunk parchment-200 · raised/lifted/float
+           parchment-50
+     ink / ground .................... 16.09   ink / raised ............ 18.01
+     ink / sunk ...................... 14.36
+     ink-muted / ground ............... 6.52   ink-muted / raised ....... 7.30
+     ink-muted / sunk ................. 5.81
+     accent-ink / ground .............. 8.02   accent-ink / raised ...... 8.98
+     accent / ground (line art) ....... 6.35   accent / raised .......... 7.10
+     index / ground ................... 5.61   index / raised ........... 6.29
+     index / sunk ..................... 5.01   index-lit / ground (art) . 3.43
+     strike / ground .................. 6.39   strike / raised .......... 7.16
+     strike / sunk .................... 5.71
+     seat / ground .................... 6.10   seat / raised ............ 6.83
+     seat / sunk ...................... 5.44
+     on-accent / accent-fill .......... 7.10   on-strike / strike-fill .. 7.16
+     band knot / ground (art) ......... 6.35   line-strong / ground ..... 2.66
+     line / raised (hairline) ......... 1.77   raised / ground .......... 1.12
+     sunk / ground .................... 1.12   raised / sunk (thumb) .... 1.25
+
+   DARK — ground basalt-800 · sunk basalt-950 · raised basalt-700
+          · lifted basalt-600 · float basalt-500
+     ink / ground .................... 17.80   ink / raised ............ 16.69
+     ink / lifted .................... 15.26   ink / float ............. 13.87
+     ink-muted / ground ............... 9.23   ink-muted / raised ....... 8.66
+     ink-muted / lifted ............... 7.91   ink-muted / float ........ 7.20
+     accent-ink / ground ............. 10.87   accent-ink / raised ..... 10.19
+     accent-ink / float ............... 8.47   accent / ground (art) .... 4.81
+     index / ground .................. 16.43   index / lifted .......... 14.08
+     strike / ground .................. 8.24   strike / raised .......... 7.72
+     strike / float ................... 6.42   seat / ground ............ 8.98
+     on-accent / accent-fill .......... 5.70   on-strike / strike-fill .. 7.44
+     band knot / ground (art) ......... 4.81   line-strong / ground ..... 2.73
+     raised / ground .................. 1.07   lifted / raised .......... 1.09
+     float / ground ................... 1.28   lifted / sunk (thumb) .... 1.20
+
+   The only pairs below 4.5 are graphics, where the floor is 3.0: `--dw-accent`
+   as line art (4.81 dark / 6.35 light), `--dw-index-lit` as a glint (3.43
+   light), and the elevation steps, which are surfaces rather than text.
    ────────────────────────────────────────────────────────────────────────── */
 
 @theme {
@@ -39,31 +87,68 @@
   --font-numeral: ui-rounded, "SF Pro Rounded", system-ui, -apple-system, "Segoe UI", Roboto,
     sans-serif;
 
-  /* A 1.25 scale from a 1rem base, rounded to eighths of a rem so every step
-     lands on a half-pixel-free value at the 16 px default. */
+  /* A 1.125→1.25 scale from a 1rem base, rounded to eighths of a rem so every
+     step lands on a half-pixel-free value at the 16 px default.
+
+     Each step carries its own line-height AND its own letter-spacing, because
+     optical tracking is not decoration: type set at one tracking across nine
+     sizes is the single most reliable way to look like a website. Small text
+     opens up, large text closes in. The values are the platform convention —
+     SF and Roboto are both drawn expecting it.
+
+     `--text-md` (18 px) is the row-label size, and it is the one a child
+     actually reads down a list. It exists because the jump from 16 to 20 is
+     too coarse for a screen whose whole job is a column of rows. */
   --text-xs: 0.75rem;
-  --text-xs--line-height: 1.25;
+  --text-xs--line-height: 1.35;
+  --text-xs--letter-spacing: 0.02em;
   --text-sm: 0.875rem;
-  --text-sm--line-height: 1.35;
+  --text-sm--line-height: 1.45;
+  --text-sm--letter-spacing: 0.01em;
   --text-base: 1rem;
   --text-base--line-height: 1.5;
+  --text-base--letter-spacing: 0em;
+  --text-md: 1.125rem;
+  --text-md--line-height: 1.45;
+  --text-md--letter-spacing: -0.005em;
   --text-lg: 1.25rem;
   --text-lg--line-height: 1.4;
+  --text-lg--letter-spacing: -0.01em;
   --text-xl: 1.5rem;
   --text-xl--line-height: 1.3;
+  --text-xl--letter-spacing: -0.015em;
   --text-2xl: 1.875rem;
-  --text-2xl--line-height: 1.2;
+  --text-2xl--line-height: 1.22;
+  --text-2xl--letter-spacing: -0.02em;
   --text-3xl: 2.375rem;
   --text-3xl--line-height: 1.15;
+  --text-3xl--letter-spacing: -0.022em;
   --text-4xl: 3rem;
   --text-4xl--line-height: 1.05;
+  --text-4xl--letter-spacing: -0.025em;
+
+  /* Two tracking values that are NOT part of the size scale, because they
+     belong to a treatment rather than to a size. Tailwind's own
+     `tracking-tight … tracking-widest` are left alone; these are additions.
+
+       `--tracking-wordmark`  DYNAWALLA in the lintel, and nothing else.
+       `--tracking-caps`      any other run set in capitals — and the list of
+                              those is deliberately short (see FOUNDATION.md):
+                              the wordmark, the pack titles that arrive from a
+                              manifest already in capitals, and nothing on
+                              Settings, Parents or Profiles. A capitalised,
+                              tracked legend over a form control is a 2014 web
+                              dashboard idiom; native platforms set that legend
+                              in sentence case at reading size. */
+  --tracking-caps: 0.09em;
+  --tracking-wordmark: 0.22em;
 
   /* ── Materials ─────────────────────────────────────────────────────────
      Named for the substance, numbered light to dark.
 
      **Repainted from `dynawalla/brand/README.md`.** The names below are the
      ones the semantic layer already refers to and they are kept; every VALUE
-     is now sampled from the mark itself, whose dominant saturated pixel is
+     is sampled from the mark itself, whose dominant saturated pixel is
      `#864de8`. The direction is the founder's: futuristic space angels,
      gear-brain minaret, sharp and pointing up, clockmaker G-d, al-Andalus.
      Explicitly dead, also his words: the dusty khaki sandstorm feel — which is
@@ -76,43 +161,81 @@
   --color-parchment-200: #e9e2fb;
   --color-parchment-300: #dcd2f5;
 
-  /* Carved limestone — structure, rules, incised edges. Violet-grey. */
+  /* Carved limestone — structure, rules, incised edges. Violet-grey.
+     `500` is new: the old light `--dw-line-strong` was `stone-400`, only
+     1.6:1 on white, so a "structural edge" was fainter than a hairline is
+     supposed to be. `400` itself is untouched because dark `--dw-ink-muted`
+     is drawn from it and darkening it would cost 9.23:1 of body contrast. */
   --color-stone-200: #c9bcec;
   --color-stone-400: #b9a6ec;
+  --color-stone-500: #9d8bd0;
   --color-stone-600: #5b5175;
   --color-stone-800: #2a1b4d;
 
-  /* Basalt — the unlit ground, and ink on parchment. Violet-black. */
+  /* Basalt — the unlit ground, and ink on parchment. Violet-black.
+     `500` and `600` are new and they are what makes the dark elevation
+     ladder possible: in dark, height is read as LIGHT, not as shadow, so a
+     sheet that is the same stone as the page behind it does not read as a
+     sheet at all. The pass sheet measured 1.13:1 against its own backdrop
+     before these existed. */
+  --color-basalt-500: #261a52;
+  --color-basalt-600: #1e1440;
   --color-basalt-700: #150c2e;
   --color-basalt-800: #0b0618;
   --color-basalt-900: #1a1033;
   --color-basalt-950: #060310;
 
   /* Brass — the index, the pointer, the working mechanism, and the brand's
-     one warm point (`--dw-apex` in the brand README is this material). */
+     one warm point (`--dw-apex` in the brand README is this material).
+
+     `700` is retained for reference and is no longer used: at 1 px over
+     parchment `#b45309` read as a red-brown dotted ribbon, which is the
+     closest thing the app had to the explicitly-dead sandstorm. `800` is the
+     light-theme warm point instead — hue 42°, a struck old gold rather than
+     a terracotta, and 5.61:1 on the light ground where `#b45309` sat at 4.79
+     and looked orange doing it. */
   --color-brass-300: #ffe7b0;
   --color-brass-500: #e0b15a;
+  --color-brass-600: #a87a17;
   --color-brass-700: #b45309;
+  --color-brass-800: #7d5a10;
 
   /* Aurora — the lit line. The mark's own violet, and the accent the whole
-     app is drawn in. `400` is the bloom: light, never paint. */
+     app is drawn in. `400` is the bloom: light, never paint. `550` exists
+     only as the ground of a FILLED accent control in dark, where `500` under
+     white text measures 4.15:1 and fails. */
   --color-aurora-300: #c9b4ff;
   --color-aurora-350: #a78bfa;
   --color-aurora-400: #b88cff;
   --color-aurora-500: #9258ff;
+  --color-aurora-550: #7c3aed;
   --color-aurora-600: #6d28d9;
   --color-aurora-700: #5b21b6;
+  /* …and the accent as a wash, which is what seats the current tab. Written
+     as alpha and not as `color-mix`, and this is not a preference: Tailwind
+     emits an accent-at-twelve-percent utility as a `color-mix` guarded by
+     `@supports`, plus a bare
+     FULLY OPAQUE fallback outside the guard. `color-mix` lands in Safari 16.2
+     and this bundle's floor is 16.0, so on an iOS 16.0 device the carefully
+     measured 1.22:1 seat painted as a solid violet plate under dark ink. Two
+     entries because a wash is a material: 12% of the deep violet reads on
+     parchment, and on basalt it is nothing, so dark washes with the lighter
+     aurora and a little more of it. */
+  --color-aurora-wash-light: rgb(109 40 217 / 0.12);
+  --color-aurora-wash-dark: rgb(146 88 255 / 0.18);
 
-  /* Lapis — the deep field; the sky an astrolabe is read against. Now a deep
+  /* Lapis — the deep field; the sky an astrolabe is read against. A deep
      violet rather than a blue, so the field and the ground are one stone. */
   --color-lapis-400: #b88cff;
   --color-lapis-600: #6d28d9;
   --color-lapis-800: #241246;
   --color-lapis-950: #0b0618;
 
-  /* Glazed tile — cool ceramic, for calm affirmative surfaces. */
+  /* Glazed tile — cool ceramic, for calm affirmative surfaces. `700` is the
+     light-theme seat: `600` fell to 4.27:1 on a sunk row. */
   --color-tile-400: #38bfc9;
   --color-tile-600: #0e7490;
+  --color-tile-700: #0c6379;
   /* …and the same glaze as a wash, thin enough to be a ground rather than a
      fill. Two entries because a wash is a material: on parchment the dark tile
      at 14% is a tint you can see, and on basalt it is nothing at all, so the
@@ -123,10 +246,22 @@
   --color-tile-600-wash: rgb(14 116 144 / 0.14);
   --color-tile-400-wash: rgb(56 191 201 / 0.18);
 
-  /* Copper and its oxide — the tone of a struck, incorrect mark. */
-  --color-copper-400: #f08a7e;
-  --color-copper-500: #c2453c;
-  --color-copper-700: #8c2f27;
+  /* Rose — the struck mark, and the only red this palette owns.
+
+     It replaces the copper ramp, which was left over from the pre-purple
+     palette: `#c2453c` was a coral that belonged to no other colour on the
+     screen AND measured 4.45:1 on the light ground, failing AA on the two
+     most consequential controls in the app ("Erase everything", "Remove").
+
+     The hue is taken from the arc's own rose end (`--color-arc-11`,
+     hsl 348°), so danger is drawn in a colour the app already contains
+     rather than imported from a generic red. It is unmistakably a warning
+     and it is unmistakably from here. */
+  --color-rose-300: #ff7d9e;
+  --color-rose-600: #d7264f;
+  --color-rose-700: #ac1442;
+  --color-rose-wash-light: rgb(172 20 66 / 0.09);
+  --color-rose-wash-dark: rgb(255 125 158 / 0.14);
 
   /* Walnut — cabinetry, frames, the case an instrument sits in. */
   --color-walnut-600: #3b2a63;
@@ -135,6 +270,31 @@
   /* Celestial — cold light. Highlights only; never a fill. */
   --color-celestial-100: #e8deff;
   --color-celestial-300: #c9b4ff;
+
+  /* ── Cast light ────────────────────────────────────────────────────────
+     Shadow is a material too, and it is the one place a design gives itself
+     away fastest: a neutral grey shadow on a violet ground reads as a
+     framework default, because it is one. Every umbra below is violet —
+     `rgb(45 20 92)` is basalt-900 pushed a little further into the blue, so
+     a card's cast light belongs to the same stone as the card.
+
+     `sheen` is the opposite direction and it is what dark elevation is
+     actually made of: a one-pixel lit top edge, the way a raised surface
+     catches the light above it. Written as alpha rather than `color-mix`
+     for the same iOS 16.0 reason as the glazes above. */
+  --color-umbra-soft: rgb(45 20 92 / 0.06);
+  --color-umbra-mid: rgb(45 20 92 / 0.1);
+  --color-umbra-deep: rgb(45 20 92 / 0.18);
+  --color-umbra-cast: rgb(45 20 92 / 0.28);
+  --color-umbra-scrim: rgb(26 16 51 / 0.34);
+
+  --color-void-mid: rgb(2 0 10 / 0.4);
+  --color-void-deep: rgb(2 0 10 / 0.55);
+  --color-void-cast: rgb(2 0 10 / 0.72);
+  --color-void-scrim: rgb(2 0 10 / 0.74);
+
+  --color-sheen-soft: rgb(201 180 255 / 0.06);
+  --color-sheen-mid: rgb(201 180 255 / 0.1);
 
   /* ── The arc ───────────────────────────────────────────────────────────
      Twelve lit hues for generated key art, and nothing else in the app may
@@ -163,20 +323,45 @@
 }
 
 /* ── Semantic layer, light ────────────────────────────────────────────────
-   Roles, not colours. Nothing outside this block may name a material. */
+   Roles, not colours. Nothing outside this block may name a material.
+
+   Light is not a bleached dark. The two themes carry height by opposite
+   means and both are native conventions: in LIGHT a surface stands off the
+   page by casting violet light onto it, and every raised thing is the same
+   white; in DARK nothing casts, and a surface stands off the page by being
+   made of lighter stone. Trying to do it the other way round is what makes a
+   light theme look like a print-out. */
 :root {
-  /* Grounds. `sunk` is a recess cut into `ground`; `raised` is a surface
-     standing proud of it. Both are the same stone in different light — the
-     difference is never a drop shadow. */
+  /* Grounds — the elevation ladder, four rungs.
+
+       ground    the page itself
+       sunk      a recess cut into it: a segmented-control TRACK, a well
+       raised    a card, a course, a sheet of the page's own material
+       lifted    something pressable that sits ON a surface: the selected
+                 segment of a control, the tab bar, a chip
+       float     a sheet over everything: the pass sheet, the parental gate
+
+     `--dw-ground-lifted` and `--dw-ground-float` are new, and they are what
+     lets a segmented control be drawn the way every platform draws one — a
+     recessed track with a raised thumb in it. Drawn the other way round (the
+     selected option darker than the unselected ones) the control reads
+     inverted, which is what the whole app was doing. */
   --dw-ground: var(--color-parchment-100);
   --dw-ground-sunk: var(--color-parchment-200);
   --dw-ground-raised: var(--color-parchment-50);
+  --dw-ground-lifted: var(--color-parchment-50);
+  --dw-ground-float: var(--color-parchment-50);
   --dw-ground-deep: var(--color-lapis-950);
 
   /* Incised lines. `--dw-line` is a hairline rule; `--dw-line-strong` is a
-     structural edge; `--dw-line-cut` is the shadow inside a carved groove. */
-  --dw-line: var(--color-parchment-300);
-  --dw-line-strong: var(--color-stone-400);
+     structural edge; `--dw-line-cut` is the shadow inside a carved groove.
+
+     `--dw-line` was `parchment-300` and measured 1.16:1 on white, which is a
+     rule you cannot see. `stone-200` is 1.77:1 — about what iOS draws a
+     table separator at, and the reason a light list now has a spine. */
+  --dw-line: var(--color-stone-200);
+  --dw-line-soft: var(--color-parchment-300);
+  --dw-line-strong: var(--color-stone-500);
   --dw-line-cut: var(--color-stone-600);
 
   /* Marks on the ground. */
@@ -185,18 +370,45 @@
   --dw-ink-inverse: var(--color-parchment-50);
 
   /* The mechanism: the index that points at where you are. This is also the
-     brand's one warm point — the apex, used once per screen and no more. */
-  --dw-index: var(--color-brass-700);
-  --dw-index-lit: var(--color-brass-500);
+     brand's one warm point — the apex, used once per screen and no more.
+     On a given screen that is the navigation's own diamond, and the strapwork
+     bands are explicitly NOT it (see `--dw-band-*` below). */
+  --dw-index: var(--color-brass-800);
+  --dw-index-lit: var(--color-brass-600);
 
   /* The lit line: the mark's own violet, and the app's accent. `--dw-accent`
      is for line art, borders and state; `--dw-accent-ink` is the one a child
      actually READS, because accent-on-ground clears AA for normal text only by
-     a hair. `--dw-bloom` is light and never paint — a filled bloom-coloured
-     shape is the named failure mode for this brand. */
+     a hair in dark. `--dw-bloom` is light and never paint — a filled
+     bloom-coloured shape is the named failure mode for this brand.
+
+     `--dw-accent-fill` / `--dw-on-accent` are the pair for a SOLID accent
+     control, and they exist as a pair because the obvious construction
+     (`bg-accent` + `text-ink-inverse`) measures 4.34:1 in dark and fails. */
   --dw-accent: var(--color-aurora-600);
   --dw-accent-ink: var(--color-aurora-700);
+  --dw-accent-fill: var(--color-aurora-600);
+  --dw-on-accent: var(--color-parchment-50);
   --dw-bloom: var(--color-aurora-350);
+  /* The seat the current tab sits in. A role rather than an opacity utility,
+     because the utility compiles to `color-mix` with an opaque fallback. */
+  --dw-accent-seat: var(--color-aurora-wash-light);
+
+  /* The interlace band under the lintel and over the navigation.
+
+     It is structural — the edge of the surface above it — and it is NOT the
+     screen's warm point. It used to be: the band paints one knot every 24 px
+     in `--dw-index`, so a 1440 px screen carried ~60 gold knots, twice over,
+     against a brand rule of one warm point per screen. In light the same
+     knots resolved to `brass-700` and the band read as a red-brown dotted
+     ribbon — the dead sandstorm, on every screen, at the top and the bottom.
+
+     Resolved by making the bands cool. The knots are the app's own violet;
+     the warm point moves to the one place it earns, the navigation index that
+     says where you are. `src/index.css` scopes these onto the band's pattern
+     so the band picks them up without any component naming a colour. */
+  --dw-band-strap: var(--color-stone-400);
+  --dw-band-knot: var(--color-aurora-600);
 
   /* The deep field, and what is legible against it. */
   --dw-field: var(--color-lapis-800);
@@ -209,13 +421,27 @@
      difference at all between a cut cell and an uncut one. A hole shows the
      deep *field*, which is cool where the wall is warm, so the aperture reads
      by hue as well as by value and the rim is not carrying it alone. */
-  --dw-aperture: var(--color-lapis-950);
+  /* `lapis-800`, not `lapis-950`, in LIGHT. A hole is dark and that is right —
+     but the deepest lapis cut into a light stone plate measures 19:1, the
+     highest-contrast pair anywhere in the app, spent on a decorative drawing,
+     and it read as two solid black stars in a violet brand. The deep field one
+     step up is still unmistakably a hole and is violet rather than black. */
+  --dw-aperture: var(--color-lapis-800);
   --dw-aperture-rim: var(--color-celestial-100);
 
-  /* Verdicts. Cold light seats a correct answer; copper oxide marks a strike.
+  /* Verdicts. Cold light seats a correct answer; rose marks a strike.
      Neither is ever the only carrier of meaning (CG-18). */
-  --dw-seat: var(--color-tile-600);
-  --dw-strike: var(--color-copper-500);
+  --dw-seat: var(--color-tile-700);
+  --dw-strike: var(--color-rose-700);
+
+  /* A destructive control needs three parts, not one: the word, the frame it
+     is bounded by, and the wash it sits in once it is armed. "Erase
+     everything" was a bare coral phrase floating in white space with nothing
+     to say it was the most consequential control in the app. */
+  --dw-strike-line: var(--color-rose-600);
+  --dw-strike-ground: var(--color-rose-wash-light);
+  --dw-strike-fill: var(--color-rose-700);
+  --dw-on-strike: var(--color-parchment-50);
 
   /* The seat colour as a ground: the recess a correct answer settles into.
      A role of its own, because `ground-sunk` cannot do this job — under
@@ -230,6 +456,47 @@
   /* Focus ring. Contrast against the ground is what matters here, so it is a
      semantic role of its own rather than a reuse of the index. */
   --dw-focus: var(--color-lapis-600);
+
+  /* ── Elevation, the cast-light half ────────────────────────────────────
+     Four surfaces, each a triple of background, edge and cast light. The
+     background and the edge defer to the roles above, so they follow the
+     theme without being declared twice; the shadows name materials, because
+     a light theme's shadow and a dark theme's shadow are not the same idea.
+
+     LIGHT: violet cast light, increasing with height. Two layers each — a
+     tight contact shadow that seats the object, and a wide soft one that
+     gives it height. One layer alone always looks like a CSS default.
+
+     Read the dark values under `.dw-dark`. */
+  --dw-elev-ground-bg: var(--dw-ground);
+  --dw-elev-ground-line: var(--dw-line);
+
+  --dw-elev-sunk-bg: var(--dw-ground-sunk);
+  --dw-elev-sunk-line: var(--dw-line);
+
+  --dw-elev-surface-bg: var(--dw-ground-raised);
+  --dw-elev-surface-line: var(--dw-line);
+  --dw-elev-surface-shadow:
+    0 1px 1px var(--color-umbra-soft), 0 3px 8px -3px var(--color-umbra-mid);
+
+  --dw-elev-raised-bg: var(--dw-ground-lifted);
+  --dw-elev-raised-line: var(--dw-line);
+  --dw-elev-raised-shadow:
+    0 1px 1px var(--color-umbra-soft), 0 8px 20px -8px var(--color-umbra-deep);
+
+  --dw-elev-overlay-bg: var(--dw-ground-float);
+  --dw-elev-overlay-line: var(--dw-line-strong);
+  --dw-elev-overlay-shadow:
+    0 2px 6px -1px var(--color-umbra-mid), 0 28px 64px -16px var(--color-umbra-cast);
+
+  /* The bar the content scrolls under. Not a shadow on the bar — a shadow
+     the bar casts UP onto the page, which is the direction a bottom tab bar
+     casts and the reason card art currently passes behind it with no
+     relationship at all. */
+  --dw-elev-bar-shadow: 0 -1px 2px var(--color-umbra-soft), 0 -8px 20px -12px var(--color-umbra-mid);
+
+  /* The dimming behind a sheet. */
+  --dw-scrim: var(--color-umbra-scrim);
 
   /* ── Generated key art ─────────────────────────────────────────────────
      The one part of this design that does NOT re-cut for dark, and the
@@ -266,64 +533,207 @@
      test keys on exactly that: a semantic token that resolves to a material
      must exist in both themes; one that does not, must not. */
 
-  /* Motion. `detent` is the 200 ms seat from EXPERIENCE_DESIGN; `quick` is a
-     single frame of acknowledgement; `settle` is the world moving, which the
-     work surface never waits for. */
-  --dw-motion-quick: 120ms;
-  --dw-motion-detent: 200ms;
-  --dw-motion-settle: 420ms;
-  --dw-ease-detent: cubic-bezier(0.2, 0.8, 0.2, 1);
+  /* ── Motion ────────────────────────────────────────────────────────────
+     Three motions, and the app needs no fourth. Each is a duration paired
+     with an easing, and the pairing is asymmetric on purpose — the single
+     loudest motion tell of a web page is one curve used in both directions,
+     because nothing physical decelerates into a stop and out of one at the
+     same rate.
 
-  /* Cut radii. Stone is worked square; these are chamfers, not pills. */
+       press    90 ms, decelerating. The finger is already there; the only
+                job is to acknowledge before the eye can doubt. Anything
+                over ~100 ms reads as lag rather than as feedback.
+       enter    260 ms, entering (slow out of the gate, long tail). A surface
+                arriving explains where it came from. This is the curve iOS
+                and Material both use for an element appearing.
+       exit     160 ms, exiting (fast off the mark, hard stop). Leaving is
+                always quicker than arriving: the user has already decided,
+                and waiting for a symmetric fade is what makes an interface
+                feel slow even when it is not.
+
+     `quick`, `detent` and `settle` are kept because they are already named in
+     EXPERIENCE_DESIGN and in shipping components: a state change, the 200 ms
+     seat, and the world moving (which the work surface never waits for). */
+  --dw-motion-press: 90ms;
+  --dw-motion-quick: 120ms;
+  --dw-motion-exit: 160ms;
+  --dw-motion-detent: 200ms;
+  --dw-motion-enter: 260ms;
+  --dw-motion-settle: 420ms;
+
+  --dw-ease-press: cubic-bezier(0.34, 0.8, 0.34, 1);
+  --dw-ease-enter: cubic-bezier(0.05, 0.7, 0.1, 1);
+  --dw-ease-exit: cubic-bezier(0.3, 0, 0.8, 0.15);
+  --dw-ease-detent: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dw-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* The composites, so a component writes one token rather than two and
+     cannot pair the wrong curve with the wrong duration. */
+  --dw-transition-press: var(--dw-motion-press) var(--dw-ease-press);
+  --dw-transition-state: var(--dw-motion-quick) var(--dw-ease-standard);
+  --dw-transition-enter: var(--dw-motion-enter) var(--dw-ease-enter);
+  --dw-transition-exit: var(--dw-motion-exit) var(--dw-ease-exit);
+
+  /* How far a press sinks and how far a surface travels in. Tokens rather
+     than literals so reduced motion can flatten them to nothing, which a
+     duration alone cannot do — a 0 ms transition to `scale(0.97)` still
+     leaves the thing 3% smaller. */
+  --dw-press-scale: 0.97;
+  --dw-enter-lift: 0.5rem;
+
+  /* Cut radii. Stone is worked square; these are chamfers, not pills.
+     `xl` is the sheet, and it is the largest cut in the app. */
   --dw-cut-sm: 2px;
   --dw-cut-md: 4px;
   --dw-cut-lg: 8px;
+  --dw-cut-xl: 12px;
 
-  /* ── The vertical scale ────────────────────────────────────────────────
-     One scale, in one place. Every screen in this host is a list of rows in a
-     column, and on a short phone the thing that runs out is vertical space —
-     so the padding, the gaps and the frame come down together rather than each
-     component carrying its own literal and being tuned separately.
+  /* ── The spacing rhythm ────────────────────────────────────────────────
+     One scale, in one place, and every gap in the harness is a step on it.
+     Eight steps, doubling then stepping by eighths of a rem, so nothing lands
+     on a half pixel at the 16 px default and nothing lands between two steps
+     because it "looked better" once on one screen.
 
-     The row height itself does NOT come down with them, and that is the point
-     of separating the two: `--dw-stack-gap` is taste, a 64 px row is a
+     A premium app has ONE rhythm. Screens that mix ad-hoc padding read as
+     several screens built by several people, which is exactly what the
+     baseline audit found: a fact row optically centred at 12 px and a choice
+     row with 8 px above its control and 12 px below it, alternating down
+     Settings. */
+  --dw-space-1: 0.25rem; /*  4 */
+  --dw-space-2: 0.5rem; /*  8 */
+  --dw-space-3: 0.75rem; /* 12 */
+  --dw-space-4: 1rem; /* 16 */
+  --dw-space-5: 1.5rem; /* 24 */
+  --dw-space-6: 2rem; /* 32 */
+  --dw-space-7: 3rem; /* 48 */
+  --dw-space-8: 4rem; /* 64 */
+
+  /* The roles. Every screen in this host is a list of rows in a column, and
+     on a short phone the thing that runs out is vertical space — so the
+     padding, the gaps and the frame come down together at the rungs below
+     rather than each component carrying its own literal and being tuned
+     separately.
+
+     The row height and the touch floor do NOT come down with them, and that
+     is the point of separating the two: gaps are taste, a 64 px row is a
      child-sized target, and a design that shrinks a target to fit another row
      on screen has made the app worse in order to look tidier. */
-  --dw-frame-pad: 1.25rem;
-  --dw-stack-gap: 1.5rem;
-  --dw-stack-gap-tight: 1rem;
-  --dw-surface-pad: 1.5rem;
+  /* The screen gutter is the one role in this list that is HORIZONTAL, and it
+     is the only one keyed to width rather than to height (see the rungs
+     below). Keyed to height with the rest, a 1024 × 768 iPad in landscape got
+     a 14 px gutter while a 390 × 844 phone got 16 and a 430 × 932 phone got
+     20 — a wider screen with a tighter margin, and a 6 px re-gutter of the
+     whole app every time one device was rotated. */
+  --dw-frame-pad: 1rem; /* screen edge → content */
+  --dw-stack-gap: 1.5rem; /* course → course */
+  --dw-stack-gap-tight: 1rem; /* within a course */
+  --dw-surface-pad: 1.5rem; /* inside a card or a course */
+  --dw-lintel-pad: 0.75rem; /* inside the lintel */
+  --dw-row-pad: 0.75rem; /* a row's own vertical padding */
+  --dw-row-gap: 1rem; /* a row's label → its value */
+  --dw-label-gap: 0.5rem; /* a legend → the control it labels */
+  --dw-grid-gap: 1rem; /* the catalogue grid */
+  --dw-inset: 0.75rem; /* inside a chip or a segment */
 
-  --dw-lintel-pad: 0.75rem;
+  /* Sizes that are facts about a hand, not taste, and therefore never scale
+     down: 44 px is the platform touch floor and 64 px is a child-sized row.
+     `--dw-target-comfort` is what anything a CHILD taps should be. */
+  --dw-target-min: 2.75rem; /* 44 px */
+  --dw-target-comfort: 3.5rem; /* 56 px */
+  --dw-row-min: 4rem; /* 64 px */
+
+  /* A true hairline. `1px` on a 3× screen is three device pixels, which is
+     the width of a border on a web page and about three times the width of a
+     separator in a native list. */
+  --dw-hairline: 1px;
+
+  /* ── The measures ──────────────────────────────────────────────────────
+     Two, and only two, and everything on a screen aligns to one of them.
+
+     The baseline audit found three competing measures on one desktop screen —
+     a full-bleed lintel, a 1152 px surface, a 672 px column of rows and a
+     full-bleed five-cell tab bar — so the wordmark, the content and the tab
+     labels each started at a different x and Parents at 1440×900 used about
+     a fifth of the screen.
+
+       `--dw-measure-text`   a column of rows, at a comfortable reading width.
+       `--dw-measure-frame`  the widest the chrome ever gets: the lintel, the
+                             navigation, and a grid of cards. The lintel and
+                             the nav align to THIS, and the column of rows is
+                             centred inside it, so there are two left edges on
+                             a wide screen instead of four. */
+  --dw-measure-text: 42rem; /* 672 px */
+  --dw-measure-frame: 72rem; /* 1152 px */
 
   /* Three rungs, one per device class this app ships to: a tablet, a phone, and
      a small phone. Untouched above 900 px — the Galaxy Tab A9 and the iPad get
      the design at full size, and nothing below is a compromise they pay for. */
+  /* The gutter, by WIDTH, and monotonic: every step out gives the content
+     more air, and rotating a device never takes any away. */
+  @media (min-width: 30rem) {
+    --dw-frame-pad: 1.25rem;
+  }
+
+  @media (min-width: 64rem) {
+    --dw-frame-pad: 1.5rem;
+  }
+
+  @media (max-width: 22.5rem) {
+    --dw-frame-pad: 0.75rem;
+  }
+
   @media (max-height: 900px) {
-    --dw-frame-pad: 1rem;
     --dw-stack-gap: 1.25rem;
     --dw-stack-gap-tight: 0.875rem;
     --dw-surface-pad: 1rem;
     --dw-lintel-pad: 0.625rem;
+    --dw-row-pad: 0.625rem;
+    --dw-label-gap: 0.5rem;
+    --dw-grid-gap: 0.875rem;
+  }
+
+  /* iPad landscape is 1024 × 768 and it fell into the rung above, where the
+     six rows of Settings overran the fold by 65 px on the widest tablet
+     orientation the app ships to. Its own rung, because "nearly fits" on the
+     screen a parent sets the app up on is worth nothing. */
+  @media (max-height: 820px) {
+    --dw-stack-gap: 1rem;
+    --dw-stack-gap-tight: 0.75rem;
+    --dw-surface-pad: 0.875rem;
+    --dw-lintel-pad: 0.5rem;
+    --dw-row-pad: 0.5rem;
+    --dw-label-gap: 0.375rem;
+    --dw-grid-gap: 0.75rem;
   }
 
   @media (max-height: 720px) {
-    --dw-frame-pad: 0.625rem;
     --dw-stack-gap: 0.75rem;
     --dw-stack-gap-tight: 0.5rem;
     --dw-surface-pad: 0.5rem;
     --dw-lintel-pad: 0.5rem;
+    --dw-row-pad: 0.375rem;
+    --dw-label-gap: 0.375rem;
+    --dw-grid-gap: 0.625rem;
   }
 
   /* The shortest viewport this app ships to gets its own rung. "Nearly fits"
      is worth nothing on a 320 × 568 screen: one row of a list below the fold
      is one row a child does not know is there. */
   @media (max-height: 620px) {
-    --dw-frame-pad: 0.5rem;
     --dw-stack-gap: 0.5rem;
     --dw-stack-gap-tight: 0.375rem;
     --dw-surface-pad: 0.25rem;
     --dw-lintel-pad: 0.25rem;
+    --dw-row-pad: 0.25rem;
+    --dw-label-gap: 0.25rem;
+    --dw-grid-gap: 0.5rem;
+  }
+
+  /* A device pixel is a device pixel. On 2× and 3× screens the platform draws
+     its separators at a physical pixel, and matching that is one of the
+     quieter differences between an app and a page. */
+  @media (min-resolution: 2dppx) {
+    --dw-hairline: 0.5px;
   }
 
   /* ── Platform facts, inherited mechanically from Corpán's stylesheet ────
@@ -355,9 +765,12 @@
   --dw-ground: var(--color-basalt-800);
   --dw-ground-sunk: var(--color-basalt-950);
   --dw-ground-raised: var(--color-basalt-700);
+  --dw-ground-lifted: var(--color-basalt-600);
+  --dw-ground-float: var(--color-basalt-500);
   --dw-ground-deep: var(--color-basalt-950);
 
   --dw-line: var(--color-stone-800);
+  --dw-line-soft: var(--color-basalt-700);
   --dw-line-strong: var(--color-stone-600);
   --dw-line-cut: var(--color-basalt-950);
 
@@ -370,7 +783,15 @@
 
   --dw-accent: var(--color-aurora-500);
   --dw-accent-ink: var(--color-aurora-300);
+  /* Not `aurora-500`: white on it measures 4.15:1 and fails AA, and a solid
+     control is exactly where a child reads a word off a colour. */
+  --dw-accent-fill: var(--color-aurora-550);
+  --dw-on-accent: var(--color-parchment-50);
   --dw-bloom: var(--color-aurora-400);
+  --dw-accent-seat: var(--color-aurora-wash-dark);
+
+  --dw-band-strap: var(--color-stone-600);
+  --dw-band-knot: var(--color-aurora-500);
 
   --dw-field: var(--color-lapis-800);
   --dw-field-ink: var(--color-celestial-300);
@@ -379,15 +800,42 @@
   --dw-aperture-rim: var(--color-celestial-300);
 
   --dw-seat: var(--color-tile-400);
-  /* The lighter oxide, not the darker one. `copper-700` on the violet void is
-     a mark a child has to hunt for; a strike is the one thing on the screen
+  /* The lighter rose, not the darker one. `rose-700` on the violet void is a
+     mark a child has to hunt for; a strike is the one thing on the screen
      that must never be missed. */
-  --dw-strike: var(--color-copper-400);
+  --dw-strike: var(--color-rose-300);
+  --dw-strike-line: var(--color-rose-600);
+  --dw-strike-ground: var(--color-rose-wash-dark);
+  --dw-strike-fill: var(--color-rose-300);
+  --dw-on-strike: var(--color-basalt-900);
   --dw-seat-ground: var(--color-tile-400-wash);
 
   --dw-case: var(--color-walnut-800);
 
   --dw-focus: var(--color-lapis-400);
+
+  /* Elevation, dark. Height is carried by the STONE, not by the shadow —
+     a drop shadow on a near-black ground is invisible, which is why so many
+     dark themes have no depth at all. Each surface is a step lighter than
+     the one below it, and each carries a one-pixel lit top edge, the way a
+     raised face catches the light above it. The cast shadow is still there,
+     tightened and deepened, to seat the object rather than to lift it. */
+  --dw-elev-surface-shadow:
+    inset 0 1px 0 var(--color-sheen-soft), 0 2px 8px -4px var(--color-void-deep);
+  --dw-elev-raised-shadow:
+    inset 0 1px 0 var(--color-sheen-mid), 0 8px 20px -8px var(--color-void-deep);
+  --dw-elev-overlay-shadow:
+    inset 0 1px 0 var(--color-sheen-mid), 0 28px 64px -16px var(--color-void-cast);
+  /* A cast shadow cannot separate anything from a near-black ground: measured,
+     the wide layer moves the pixels above the bar from rgb(11 6 24) to
+     rgb(10 5 22), which is nothing. In dark the bar is separated the way every
+     dark tab bar is — by its own lighter stone plus a LIT top edge — so the
+     edge is `sheen-mid` rather than `sheen-soft` and is doing the work
+     deliberately rather than by accident. The cast layer stays for the few
+     pixels where card art passes under it. */
+  --dw-elev-bar-shadow: 0 -1px 0 var(--color-sheen-mid), 0 -10px 24px -14px var(--color-void-mid);
+
+  --dw-scrim: var(--color-void-scrim);
 
   /* Key art does not re-cut — see the block above. Same values, stated twice,
      because the layering test is right to insist and a stylesheet it cannot
@@ -412,13 +860,19 @@
 /* ── Utilities ────────────────────────────────────────────────────────────
    `inline` is required: it makes Tailwind emit `var(--dw-ground)` rather than
    resolving the token at build time, which is what lets one stylesheet serve
-   both themes. */
+   both themes.
+
+   Everything published here is a role. A component writes `bg-ground-lifted`,
+   `p-surface`, `gap-stack` or `shadow-raised` and never a number. */
 @theme inline {
   --color-ground: var(--dw-ground);
   --color-ground-sunk: var(--dw-ground-sunk);
   --color-ground-raised: var(--dw-ground-raised);
+  --color-ground-lifted: var(--dw-ground-lifted);
+  --color-ground-float: var(--dw-ground-float);
   --color-ground-deep: var(--dw-ground-deep);
   --color-line: var(--dw-line);
+  --color-line-soft: var(--dw-line-soft);
   --color-line-strong: var(--dw-line-strong);
   --color-line-cut: var(--dw-line-cut);
   --color-ink: var(--dw-ink);
@@ -428,17 +882,56 @@
   --color-index-lit: var(--dw-index-lit);
   --color-accent: var(--dw-accent);
   --color-accent-ink: var(--dw-accent-ink);
+  --color-accent-fill: var(--dw-accent-fill);
+  --color-accent-seat: var(--dw-accent-seat);
+  --color-on-accent: var(--dw-on-accent);
   --color-bloom: var(--dw-bloom);
+  --color-band-strap: var(--dw-band-strap);
+  --color-band-knot: var(--dw-band-knot);
   --color-field: var(--dw-field);
   --color-field-ink: var(--dw-field-ink);
+  --color-aperture: var(--dw-aperture);
+  --color-aperture-rim: var(--dw-aperture-rim);
   --color-seat: var(--dw-seat);
+  --color-seat-ground: var(--dw-seat-ground);
   --color-strike: var(--dw-strike);
+  --color-strike-line: var(--dw-strike-line);
+  --color-strike-ground: var(--dw-strike-ground);
+  --color-strike-fill: var(--dw-strike-fill);
+  --color-on-strike: var(--dw-on-strike);
   --color-case: var(--dw-case);
   --color-focus: var(--dw-focus);
+  --color-scrim: var(--dw-scrim);
 
   --radius-cut-sm: var(--dw-cut-sm);
   --radius-cut-md: var(--dw-cut-md);
   --radius-cut-lg: var(--dw-cut-lg);
+  --radius-cut-xl: var(--dw-cut-xl);
+
+  /* The elevation ladder as `shadow-*`. Paired with `bg-ground-raised` /
+     `bg-ground-lifted` / `bg-ground-float` and `border-line`, these are the
+     four surfaces of the app and there is no fifth. */
+  --shadow-surface: var(--dw-elev-surface-shadow);
+  --shadow-raised: var(--dw-elev-raised-shadow);
+  --shadow-overlay: var(--dw-elev-overlay-shadow);
+  --shadow-bar: var(--dw-elev-bar-shadow);
+
+  /* The rhythm as `p-*` / `gap-*` / `m-*`. */
+  --spacing-frame: var(--dw-frame-pad);
+  --spacing-surface: var(--dw-surface-pad);
+  --spacing-lintel: var(--dw-lintel-pad);
+  --spacing-stack: var(--dw-stack-gap);
+  --spacing-stack-tight: var(--dw-stack-gap-tight);
+  --spacing-row: var(--dw-row-pad);
+  --spacing-row-gap: var(--dw-row-gap);
+  --spacing-label: var(--dw-label-gap);
+  --spacing-grid: var(--dw-grid-gap);
+  --spacing-inset: var(--dw-inset);
+  --spacing-target: var(--dw-target-min);
+  --spacing-target-comfort: var(--dw-target-comfort);
+  --spacing-row-min: var(--dw-row-min);
+  --spacing-measure-text: var(--dw-measure-text);
+  --spacing-measure-frame: var(--dw-measure-frame);
 }
 
 /* ── The settings, applied ────────────────────────────────────────────────
@@ -464,9 +957,14 @@
    is the same collapse, and both are needed: a child on a shared tablet whose
    OS setting is somebody else's is exactly who this switch is for. */
 :root[data-motion="reduced"] {
+  --dw-motion-press: 0ms;
   --dw-motion-quick: 0ms;
+  --dw-motion-exit: 0ms;
   --dw-motion-detent: 0ms;
+  --dw-motion-enter: 0ms;
   --dw-motion-settle: 0ms;
+  --dw-press-scale: 1;
+  --dw-enter-lift: 0px;
 }
 
 :root[data-motion="reduced"] *,
@@ -484,12 +982,20 @@
    change; the belt-and-braces rule below catches anything that hardcoded its
    own duration anyway. Both are needed: the first keeps the design honest,
    the second keeps a stray `transition: all 300ms` from moving the screen for
-   a child who asked it not to. */
+   a child who asked it not to.
+
+   The displacement tokens collapse too. A 0 ms transition into `scale(0.97)`
+   is still a 3% shrink; it just happens instantly, which is worse. */
 @media (prefers-reduced-motion: reduce) {
   :root {
+    --dw-motion-press: 0ms;
     --dw-motion-quick: 0ms;
+    --dw-motion-exit: 0ms;
     --dw-motion-detent: 0ms;
+    --dw-motion-enter: 0ms;
     --dw-motion-settle: 0ms;
+    --dw-press-scale: 1;
+    --dw-enter-lift: 0px;
   }
 
   *,

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -24,6 +24,13 @@
        Set on body alone the document still bounces, which is how the catalog
        slides into view above a running game. */
     overscroll-behavior: none;
+    /* WebKit inflates text in a narrow column when a page is rotated or
+       zoomed. It is a document behaviour and this is not a document; left on,
+       a phone rotated to landscape re-flows every label by a few percent,
+       which is the "text that jumps as state changes" tell arriving from the
+       platform rather than from us. */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
   }
 
   html.dw-dark {
@@ -41,6 +48,11 @@
     background-color: var(--dw-ground);
     color: var(--dw-ink);
     font-family: var(--font-text);
+    /* The platform's own text rendering. Every native surface on iOS and
+       macOS is drawn this way; leaving it off is a small, constant weight
+       difference that reads as "browser". */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     /* A child taps; nothing should select, callout, or double-tap-zoom. */
     -webkit-tap-highlight-color: transparent;
     -webkit-touch-callout: none;
@@ -54,11 +66,33 @@
     user-select: none;
   }
 
+  /* Native form controls — a checkbox, a radio, a range, a text caret — are
+     drawn by the platform in the platform's accent colour unless told
+     otherwise. Told otherwise, they are drawn in ours. */
+  :root {
+    accent-color: var(--dw-accent);
+    caret-color: var(--dw-accent);
+  }
+
   input,
   textarea,
   [contenteditable] {
     -webkit-user-select: text;
     user-select: text;
+  }
+
+  /* iOS zooms the viewport when a field under 16 px takes focus, and it does
+     not zoom back out. `max()` rather than a flat 16 px so the accessibility
+     text-size settings still scale the field up with everything else. */
+  input,
+  textarea,
+  select {
+    font-size: max(1rem, 16px);
+  }
+
+  ::selection {
+    background-color: var(--dw-accent);
+    color: var(--dw-on-accent);
   }
 
   /* The chrome must never scroll sideways. A single row whose value refuses to
@@ -71,11 +105,53 @@
     overflow-x: hidden;
   }
 
+  /* A mouse user genuinely needs a scrollbar — but they need the one their
+     desktop draws, which is an overlay thumb on nothing, not a painted grey
+     channel down the edge of the page. Thumb only, in the theme's own violet,
+     inset from the edge by a transparent border so it reads as floating. */
+  @media (pointer: fine) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: var(--dw-line-strong) transparent;
+    }
+
+    *::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+
+    *::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+
+    *::-webkit-scrollbar-thumb {
+      background-color: var(--dw-line-strong);
+      background-clip: padding-box;
+      border: 3px solid transparent;
+      border-radius: 10px;
+    }
+
+    *::-webkit-scrollbar-thumb:hover {
+      background-color: var(--dw-ink-muted);
+    }
+
+    *::-webkit-scrollbar-corner {
+      background-color: transparent;
+    }
+  }
+
   /* A persistent scrollbar track is a web-view tell. Touch platforms draw a
      transient indicator of their own during the gesture, so the drawn track is
-     pure noise there — but a mouse user genuinely needs it, so this is scoped to
-     coarse pointers rather than applied everywhere. */
-  @media (pointer: coarse) {
+     pure noise there.
+
+     `any-pointer`, and it comes AFTER the block above rather than before it,
+     and both halves of that are load-bearing. An iPad with a Magic Keyboard or
+     a trackpad reports `pointer: fine` — so the first-class tablet target was
+     matching the desktop block and getting a drawn 10 px channel, the first
+     named tell on the standing bar. `any-pointer: coarse` is true of any
+     device that has a touchscreen at all, whatever is also plugged into it,
+     and a later rule of the same specificity wins. */
+  @media (any-pointer: coarse) {
     * {
       scrollbar-width: none;
     }
@@ -84,6 +160,26 @@
       width: 0;
       height: 0;
     }
+  }
+
+  /* Sticky chrome is a contentInset, not just a z-index. The lintel is stuck
+     to the top and the tab bar to the bottom, and body is the scrolling box —
+     so anything scrolled to (a focused card under a tab walk, a field the
+     keyboard reveals) came to rest UNDER them. Measured on the catalogue at
+     390: eight of twenty-seven cards landed with their "Play" control and the
+     bottom of their focus ring behind the bar. This is the one-line
+     equivalent of what a native scroll view does for its own bars. */
+  html {
+    scroll-padding-block: calc(var(--safe-top) + 5.5rem) calc(var(--safe-bottom) + 5.5rem);
+  }
+
+  /* While a sheet is up, the page behind it must not scroll. The scrim is
+     `position: fixed`, so a drag on it was still scrolling the catalogue
+     underneath and the sheet closed onto a different offset — the surface
+     you came back to was not the one you left. */
+  html.dw-locked,
+  html.dw-locked body {
+    overflow: hidden;
   }
 
   /* One focus treatment for the whole app, keyboard-only. Children on tablets
@@ -102,5 +198,344 @@
 
   .inscription {
     font-family: var(--font-inscription);
+  }
+
+}
+
+/* ── The system, as classes ───────────────────────────────────────────────
+   Tokens describe the materials; these are the four or five compositions the
+   harness actually repeats, written once so five screens cannot drift apart.
+   In `components` rather than `utilities` so any Tailwind utility a screen
+   applies still wins over them. */
+@layer components {
+  /* ── Elevation ───────────────────────────────────────────────────────
+     Ground, sunk, surface, raised, overlay — five rungs, and there is no
+     sixth. Each is a background, an edge and a cast light together, because
+     a surface that borrows one of the three from somewhere else is how a
+     design ends up with a card that has a shadow and a border that disagree
+     about how high it is.
+
+     In LIGHT height is cast violet light; in DARK it is lighter stone plus a
+     one-pixel lit top edge. Both are handled by the tokens; a component just
+     picks a rung. */
+  .dw-sunk {
+    background-color: var(--dw-elev-sunk-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-sunk-line);
+  }
+
+  .dw-surface {
+    background-color: var(--dw-elev-surface-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-surface-line);
+    box-shadow: var(--dw-elev-surface-shadow);
+  }
+
+  .dw-raised {
+    background-color: var(--dw-elev-raised-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-raised-line);
+    box-shadow: var(--dw-elev-raised-shadow);
+  }
+
+  .dw-overlay {
+    background-color: var(--dw-elev-overlay-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-overlay-line);
+    box-shadow: var(--dw-elev-overlay-shadow);
+  }
+
+  /* A bar the content scrolls under casts UP, not down. */
+  .dw-bar {
+    background-color: var(--dw-elev-raised-bg);
+    box-shadow: var(--dw-elev-bar-shadow);
+  }
+
+  .dw-scrim {
+    background-color: var(--dw-scrim);
+  }
+
+  /* ── Rules ───────────────────────────────────────────────────────────
+     A separator at one physical device pixel, which is what the platform
+     draws and about a third of what `border-b` draws on a 3× screen. */
+  .dw-hairline {
+    border: var(--dw-hairline) solid var(--dw-line);
+  }
+
+  .dw-hairline-b {
+    border-block-end: var(--dw-hairline) solid var(--dw-line);
+  }
+
+  .dw-hairline-t {
+    border-block-start: var(--dw-hairline) solid var(--dw-line);
+  }
+
+  /* ── The two measures ────────────────────────────────────────────────
+     `dw-frame` is the chrome's outer bound and carries the screen gutter,
+     widened by the safe-area inset on the side that has one — a phone in
+     landscape has an inset on exactly one side, so a symmetric padding is
+     either too little on one edge or too much on the other.
+
+     `dw-measure` is the column of rows inside it. Everything on a screen
+     aligns to one of these two and nothing invents a third. */
+  .dw-frame {
+    width: 100%;
+    max-width: var(--dw-measure-frame);
+    margin-inline: auto;
+    padding-inline-start: max(var(--dw-frame-pad), var(--safe-left));
+    padding-inline-end: max(var(--dw-frame-pad), var(--safe-right));
+  }
+
+  .dw-measure {
+    width: 100%;
+    max-width: var(--dw-measure-text);
+    margin-inline: auto;
+  }
+
+  /* ── Press ───────────────────────────────────────────────────────────
+     One press behaviour for everything a finger lands on. Fast and
+     decelerating: the finger is already there, so the only job is to
+     acknowledge before the eye can doubt that the tap registered.
+
+     `transform` is on its own curve; colour is on the state curve. They are
+     different events — one is physical, one is a change of meaning — and
+     running both on one timing is what makes a web button feel like a web
+     button. */
+  .dw-press {
+    transition:
+      transform var(--dw-transition-press),
+      background-color var(--dw-transition-state),
+      border-color var(--dw-transition-state),
+      box-shadow var(--dw-transition-state),
+      color var(--dw-transition-state);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .dw-press:active {
+    transform: scale(var(--dw-press-scale));
+  }
+
+  /* Hover is a pointer idea. Applying it on touch leaves a control looking
+     pressed after the finger has gone, which is the stuck-hover tell. */
+  @media (hover: hover) and (pointer: fine) {
+    .dw-press:hover {
+      background-color: var(--dw-ground-lifted);
+    }
+  }
+
+  /* ── Arriving and leaving ────────────────────────────────────────────
+     Explanatory, not decorative: a surface rises a little into place so it
+     is obvious it came from below, and leaves faster than it arrived
+     because the decision has already been made. Both collapse to nothing
+     under reduced motion — the durations go to zero AND `--dw-enter-lift`
+     goes to zero, because a 0 ms transition into a displaced position is
+     still a jump. */
+  .dw-anim-enter {
+    animation: dw-enter var(--dw-transition-enter) both;
+  }
+
+  .dw-anim-exit {
+    animation: dw-exit var(--dw-transition-exit) both;
+  }
+
+  .dw-anim-fade {
+    animation: dw-fade var(--dw-transition-enter) both;
+  }
+
+  /* ── A row that scrolls sideways inside the page ─────────────────────
+     The subject-chip row overflows by 440 px on a phone with nothing to say
+     so. The mask fades the content out at both edges, which is the signal
+     every native carousel uses: content that dissolves rather than stopping
+     is content that continues. Black in the gradient is a mask alpha, not a
+     colour — only its opacity is read. */
+  .dw-scroll-x {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+  }
+
+  .dw-fade-x {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black var(--dw-space-4),
+      black calc(100% - var(--dw-space-5)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black var(--dw-space-4),
+      black calc(100% - var(--dw-space-5)),
+      transparent 100%
+    );
+  }
+
+  /* ── The tab label ───────────────────────────────────────────────────
+     A tab bar gives a word one fifth of the screen and no more, and a word
+     that does not fit is the one thing it may not do about it. On a 320 px
+     phone a cell is 60 px wide; "Progress" at the app's own Largest text
+     setting wants 59 px of glyphs before any padding, so four of the five
+     labels clipped to a prefix.
+
+     So the cell is a container and the label is capped against the cell's
+     own inline size, which is exactly what a native tab bar does: the label
+     shrinks to fit and is never cut. `21cqi` is measured, not chosen — the
+     longest destination name in the inscription face runs about 3.9 px of
+     glyph per pixel of font size, and 21% of a cell leaves the padding
+     clear at every width and text size the app ships. The `min()` means the
+     cap is INERT at every ordinary width: the label is the type scale's own
+     step and only gives ground where the alternative is losing a letter.
+
+     `container-type: inline-size` is Safari 16.0, on this bundle's floor.
+     Where it is missing the `cqi` term is invalid, `min()` is dropped whole,
+     and the label falls back to the plain step below — which is the old
+     behaviour, not a broken one. */
+  .dw-tab {
+    container-type: inline-size;
+  }
+
+  .dw-tab-label {
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
+    letter-spacing: var(--text-xs--letter-spacing);
+  }
+
+  @media (min-width: 40rem) {
+    .dw-tab-label {
+      font-size: var(--text-sm);
+      line-height: var(--text-sm--line-height);
+      letter-spacing: var(--text-sm--letter-spacing);
+    }
+  }
+
+  /* The cap, in an `@supports` rather than as a second `font-size` beside the
+     first. Two declarations of one property in one rule are exactly what the
+     minifier is entitled to collapse — it did that to this file's `2.6em`
+     fallback for `2lh`, and the built stylesheet shipped with no fallback at
+     all on the devices the fallback existed for. `@supports` is uncollapsible,
+     and it names the real dependency: without container queries `cqi` is not a
+     length and the whole `min()` would be dropped anyway. */
+  @supports (container-type: inline-size) {
+    .dw-tab-label {
+      font-size: min(var(--text-xs), 21cqi);
+    }
+
+    @media (min-width: 40rem) {
+      .dw-tab-label {
+        font-size: min(var(--text-sm), 21cqi);
+      }
+    }
+  }
+
+  /* ── The courses on a wide screen ────────────────────────────────────
+     Four of the five destinations are a column of rows, and a column of rows
+     is set to a reading measure — so at 1440 × 900 the parent area used
+     about a fifth of the glass and the rest was ground. A reading measure is
+     right for a column of prose and wrong as an account of a whole screen.
+
+     Above 64 rem the courses lay out as two columns inside the frame, which
+     is what every desktop settings pane does, and it has a second effect
+     that matters more: each course now begins at the frame's own leading
+     edge, so the wordmark, the tab bar, the catalogue grid AND the rows all
+     start at the same x. Below that the courses are one column, capped at
+     the reading measure and centred, which is what `.dw-measure` already
+     did.
+
+     `align-content: start` so two courses of different lengths do not
+     stretch to match; `--dw-stack-gap` in both axes so the rhythm across is
+     the rhythm down. */
+  .dw-courses {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* A course is a list of rows, not a column of prose, so it takes the frame
+     rather than the reading measure. That is what puts every left edge in the
+     app on one x: measured at 834 the wordmark sat at 20, the tab labels at
+     20 and the rows at 81, because the rows were centred inside a 672 px
+     measure in a 794 px frame. The empty-catalogue paragraph is prose and
+     keeps `.dw-measure`. */
+  .dw-courses > .dw-course {
+    max-width: none;
+  }
+
+  @media (min-width: 64rem) {
+    .dw-courses-wide {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-content: start;
+      align-items: start;
+    }
+
+    /* The footer of the course above it, not a column beside it. */
+    .dw-courses-wide > .dw-course-span {
+      grid-column: 1 / -1;
+    }
+  }
+
+  /* The band under the lintel is the top edge of the first group. Drawing a
+     rule as well put two parallel horizontals 24 px apart at the top of every
+     destination at every width — the second one saying nothing the first had
+     not. `:nth-of-type` counts only the courses, so the screen-reader heading
+     beside them is not in the reckoning, and "the top row" is one course at
+     phone width and two once the courses are in two columns. */
+  .dw-course:first-of-type {
+    border-block-start-width: 0;
+  }
+
+  @media (min-width: 64rem) {
+    .dw-courses-wide > .dw-course:nth-of-type(-n + 2) {
+      border-block-start-width: 0;
+    }
+  }
+
+  /* ── Capitals ────────────────────────────────────────────────────────
+     Uppercase with tracking belongs to the wordmark, and to a pack title
+     that arrives from a manifest already in capitals. It does not belong on
+     a settings legend, a tab label or a section heading: a tracked, small,
+     capitalised label over a form control is a web dashboard idiom, and
+     every native platform sets that same label in sentence case at reading
+     size instead. */
+  .dw-wordmark {
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wordmark);
+  }
+
+  .dw-caps {
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+  }
+}
+
+@keyframes dw-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, var(--dw-enter-lift), 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes dw-exit {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate3d(0, calc(var(--dw-enter-lift) * -0.5), 0);
+  }
+}
+
+@keyframes dw-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }

--- a/dynawalla/dynawalla-app/tools/.gitignore
+++ b/dynawalla/dynawalla-app/tools/.gitignore
@@ -1,0 +1,26 @@
+# Capture output.
+#
+# The PNGs are ~9 MB per run and every one of them is regenerated in about
+# seventy seconds by `node tools/capture.mjs`. `*.png` is Git LFS repo-wide, so
+# committing them would push ten megabytes of LFS objects on every design pass
+# to preserve something that is derived, not authored.
+#
+# What IS committed is the tool, the harness it builds, `shots/AUDIT.md` and
+# `shots/measurements.json` — the findings and the numbers behind them, which
+# are the parts a reviewer needs without a machine to run Chrome on.
+shots/**/*.png
+
+# The per-agent write-ups and the raw measurement dump are working notes from one
+# design pass, not a record the next reader needs: together they are 1.3 MB, which
+# alone pushes a PR past the point where `adversarial-review` truncates the diff
+# and reviews nothing. `AUDIT.md` is kept — it is the findings in prose. The
+# numbers behind it are one `node tools/capture.mjs` away.
+shots/measurements.json
+shots/CRAFT-*.md
+shots/VERIFY-*.md
+shots/REPAIR.md
+shots/FOUNDATION.md
+.harness-dist/
+
+# Scratch output of `--probe=`: a question somebody asked once, not a record.
+shots/probe.json

--- a/dynawalla/dynawalla-app/tools/capture.mjs
+++ b/dynawalla/dynawalla-app/tools/capture.mjs
@@ -1,0 +1,981 @@
+#!/usr/bin/env node
+/* ───────────────────────────────────────────────────────────────────────────
+   Dynawalla — the eyes.
+
+       node tools/capture.mjs                # build, serve, capture everything
+       node tools/capture.mjs --no-build     # reuse dist/ and tools/.harness-dist
+       node tools/capture.mjs --only=settings,parents
+       node tools/capture.mjs --widths=390,1440 --themes=dark
+       node tools/capture.mjs --textsize=largest   # the app's own a11y setting
+       node tools/capture.mjs --probe=q.js         # one expression, every page
+
+   Output:
+       tools/shots/<theme>/<screen>-<width>.png     (gitignored — derived)
+       tools/shots/measurements.json                (committed)
+       tools/shots/AUDIT.md                         (committed, written by hand)
+
+   The PNGs are deliberately NOT committed: nine megabytes an run, `*.png` is
+   Git LFS repo-wide, and every one of them is back in seventy seconds. The
+   numbers and the findings are committed, because those are what a reviewer
+   without a machine to run Chrome on actually needs.
+
+   ── WHY THIS EXISTS ───────────────────────────────────────────────────────
+
+   The standing bar for this app is "premium native-like behavior", and every
+   tell that breaks it is a VISUAL fact: a drawn scrollbar track, a page that
+   slides sideways, a control smaller than a child's fingertip, a text pair
+   that fails AA, spacing that does not match the screen next door. None of
+   those can be reviewed by reading a component. Two of this app's five
+   destinations once rendered completely empty for weeks with a green test
+   suite, which is the same lesson in its most expensive form.
+
+   So this tool takes the app apart into every screen × every size × both
+   themes, writes a PNG of each, and — more usefully — writes the measurements
+   that a screenshot cannot be trusted to reveal: horizontal overflow, elements
+   escaping the viewport, interactive targets under 44 px, and the computed
+   colour of every text run against the ground it actually sits on, with the
+   contrast ratio already worked out.
+
+   It is meant to be re-run. Change a token, run this, look again.
+
+   ── THE HEADLESS-CHROME 500px CLAMP TRAP ──────────────────────────────────
+
+   Read this before "fixing" the tool to be simpler.
+
+   `chrome --headless --window-size=390,844 --screenshot=out.png` does NOT
+   render at 390 px. Headless Chrome clamps its window — and therefore its
+   viewport — to a 500 px minimum. What you get is a 500 px render cropped to
+   390, which looks *exactly* like a mobile layout bug: cards clipped at the
+   right edge, the header running off the side. Hours have been lost to
+   diagnosing a defect that was the harness.
+
+   There are two ways out. One is to load the app inside an `<iframe>` of the
+   true width in a wrapper page served over http (`file://` iframes are
+   blocked by the same-origin rules that make the wrapper useful in the first
+   place). The other — used here — is to drive Chrome over the DevTools
+   protocol and set the viewport with `Emulation.setDeviceMetricsOverride`,
+   which is not subject to the window clamp at all, and then take the
+   screenshot with `Page.captureScreenshot`. That path also gives us
+   `Runtime.evaluate`, which is what makes the measurements possible.
+
+   CDP needs a WebSocket. Node 24 has one built in, so this file has no
+   dependencies beyond what the app already installs — Chrome is found on disk
+   and driven by flags, and there is no puppeteer.
+
+   The tool asserts the clamp is beaten: every capture records the viewport
+   width it actually rendered at, and a mismatch is a hard failure rather than
+   a screenshot nobody looks at twice.
+
+   ── WHAT IT SEEDS, AND WHY THAT IS NOT CHEATING ───────────────────────────
+
+   The catalogue is the front door and it is empty in a browser: `useLibrary`
+   refuses to invent packs when there is no Tauri runtime, which is the honest
+   answer and the right one. Rather than mock the *screen*, this seeds the
+   layer underneath it — a shim for `window.__TAURI_INTERNALS__` that answers
+   `packs_list` with the REAL `pack.json` of all 27 games in `dynawalla/games/`.
+   The app then takes its own native path: the same manifest parse, the same
+   run gate, the same localisation, the same registry mirror. Names, blurbs,
+   skills and grade bands on the captured cards are the shipped ones.
+
+   Everything else a screen reads is device state in `localStorage`, seeded to
+   the same shapes the zustand stores persist (see `src/app/profile.ts` for the
+   key scheme). A screen that is empty in these captures is empty in the app.
+
+   ── WHAT IT CANNOT SEE ────────────────────────────────────────────────────
+
+   * Safe-area insets. `env(safe-area-inset-*)` is 0 in Chrome, so the padding
+     a notch adds is not in these shots. Check that on a device.
+   * The transient touch scroll indicator, and anything else a real WebView
+     draws for a coarse pointer. Chrome here is a fine pointer, so the app's
+     `@media (pointer: coarse)` scrollbar suppression is deliberately NOT in
+     effect — a scrollbar visible in a 390 px shot is the desktop behaviour,
+     not a defect. `--coarse` forces the emulation on if you want to check it.
+   * Motion. These are still frames.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+import { spawn, spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import fs from "node:fs"
+import http from "node:http"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const APP = path.resolve(HERE, "..")
+const GAMES = path.resolve(APP, "../games")
+const DIST = path.join(APP, "dist")
+const HARNESS_DIST = path.join(HERE, ".harness-dist")
+const SHOTS = path.join(HERE, "shots")
+const NPM = path.join(process.env["HOME"] ?? "", ".nvm/versions/node/v24.18.0/bin/npm")
+
+/* ── What is captured ─────────────────────────────────────────────────────
+   `app` screens are the shipped shell at a route hash. `harness` screens are
+   the pass sheet, which the shell cannot currently reach (see
+   tools/harness/main.tsx for the reason) and which is therefore mounted on its
+   own. `act` names a short click sequence run after load, before the shot. */
+const SCREENS = [
+  { name: "packs", kind: "app", hash: "#/" },
+  // The same screen, whole. 27 cards do not fit a phone viewport, and a grid's
+  // rhythm is a property of the grid rather than of its first two rows.
+  { name: "packs-full", kind: "app", hash: "#/", full: true },
+  { name: "progress", kind: "app", hash: "#/progress" },
+  { name: "profiles", kind: "app", hash: "#/profiles" },
+  { name: "settings", kind: "app", hash: "#/settings" },
+  { name: "parents", kind: "app", hash: "#/parents" },
+  // Developer mode on: the row count triples and the values get long, which is
+  // the state that broke the parent area sideways once already.
+  { name: "parents-dev", kind: "app", hash: "#/parents", dev: true, full: true },
+  { name: "pass-rest", kind: "harness" },
+  { name: "pass-gate", kind: "harness", act: "gate" },
+  { name: "pass-offer", kind: "harness", act: "offer" },
+]
+
+/** Width → the height of the device that width belongs to. Not arbitrary. */
+const VIEWPORTS = {
+  // The narrowest screen this app ships to, and the one every width-dependent
+  // defect shows on first. It was missing from this table, so the tab bar's
+  // label truncation — which fails WCAG 1.4.4 here at the SHIPPED text size,
+  // not only at an accessibility one — was in none of the captures.
+  320: { height: 568, dsf: 2, mobile: true }, //  iPhone SE (1st gen)
+  390: { height: 844, dsf: 2, mobile: true }, //  iPhone 14 / 15
+  430: { height: 932, dsf: 2, mobile: true }, //  iPhone 15 Pro Max
+  834: { height: 1112, dsf: 2, mobile: true }, // iPad Air, portrait
+  1024: { height: 768, dsf: 2, mobile: true }, // iPad, landscape
+  1440: { height: 900, dsf: 1, mobile: false }, // desktop
+}
+
+const THEMES = ["light", "dark"]
+
+/* ── Arguments ───────────────────────────────────────────────────────────── */
+
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(`--${name}`)
+const option = (name) => {
+  const hit = argv.find((a) => a.startsWith(`--${name}=`))
+  return hit ? hit.slice(name.length + 3) : null
+}
+const list = (name) => {
+  const raw = option(name)
+  return raw === null ? null : raw.split(",").map((s) => s.trim()).filter(Boolean)
+}
+
+const wantScreens = list("only")
+const wantWidths = list("widths")?.map(Number)
+const wantThemes = list("themes")
+const coarse = flag("coarse")
+/* `--textsize=large|largest` seeds the app's own accessibility text-size
+   setting. Only "normal" was ever captured, and the app SHIPS a Largest
+   option — so a defect that only exists there (four of five tab labels
+   clipping to a prefix at 390) was in none of the hundred committed shots.
+   Named in the output file so two sweeps do not overwrite each other. */
+const textSize = option("textsize") ?? "normal"
+/* `--probe=path/to/expr.js` evaluates one expression in every captured page
+   and writes the results to `tools/shots/probe.json`.
+
+   This exists so that verifying a specific claim — "the tab labels no longer
+   clip", "the chip rail rests with its leading dissolve off" — does not need
+   another copy of this file. Four 900-line forks of this tool were written in
+   one review round to answer four such questions, and they were 90% identical
+   to each other and to this. A question about the DOM is an expression; the
+   harness around it is this file, once. */
+const probeFile = option("probe")
+const PROBE = probeFile === null ? null : fs.readFileSync(probeFile, "utf8")
+
+const screens = SCREENS.filter((s) => !wantScreens || wantScreens.includes(s.name))
+const widths = Object.keys(VIEWPORTS).map(Number).filter((w) => !wantWidths || wantWidths.includes(w))
+const themes = THEMES.filter((t) => !wantThemes || wantThemes.includes(t))
+
+/* ── The seed ─────────────────────────────────────────────────────────────
+   Real manifests, from the `pack.json` beside each game in `dynawalla/games/`.
+
+   A `pack.json` in the source tree is the AUTHORED manifest; three fields are
+   added by the pack build after the archive exists and can only be known then
+   (`schema`, `assets`, `download`). They are synthesised here, deterministically
+   from the pack id, so the same seed produces the same screenshot twice and a
+   diff between two runs is a change in the app rather than in the noise. The
+   digest is a real SHA-256 — of the id, not of an archive — because the
+   manifest parser requires 64 lower-case hex and rejects a placeholder. */
+
+function seedManifests() {
+  const dirs = fs
+    .readdirSync(GAMES, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort()
+
+  const rows = []
+  for (const dir of dirs) {
+    const file = path.join(GAMES, dir, "pack.json")
+    if (!fs.existsSync(file)) continue
+    const authored = JSON.parse(fs.readFileSync(file, "utf8"))
+    const digest = createHash("sha256").update(authored.id).digest("hex")
+    // Plausible and stable: 180 kB–1.2 MB, spread by the digest so the "Space
+    // used" figure and the per-card size are not all the same number.
+    const bytes = 180 * 1024 + (parseInt(digest.slice(0, 6), 16) % (1024 * 1024))
+    const manifest = {
+      schema: 1,
+      ...authored,
+      assets: { files: 6 + (parseInt(digest.slice(6, 8), 16) % 40), bytes },
+      download: { bytes: Math.max(1, Math.floor(bytes * 0.42)), sha256: digest },
+    }
+    // `build` is a pack-build field the manifest schema does not carry.
+    delete manifest.build
+    rows.push({ id: manifest.id, version: manifest.version, manifest: JSON.stringify(manifest), bytes })
+  }
+  if (rows.length === 0) throw new Error(`no pack.json under ${GAMES}`)
+  return rows
+}
+
+function seedState(rows) {
+  const now = new Date()
+  const day = `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, "0")}-${`${now.getDate()}`.padStart(2, "0")}`
+  return {
+    rows,
+    day,
+    // One game rested today. It changes exactly one word on one card, which is
+    // the design's own claim — "not a lock and never drawn as one" — and a
+    // capture is the only way to check it reads that way.
+    resting: [rows[0]?.id].filter(Boolean),
+    // Two named learners and one unnamed, because the unnamed case draws a
+    // placeholder and is the one that looks wrong if it is wrong.
+    profiles: [
+      { id: "p1", name: "Amina" },
+      { id: "p2", name: "Yusuf" },
+      { id: "p3", name: "" },
+    ],
+  }
+}
+
+/* ── The bootstrap injected into the page ─────────────────────────────────
+   Served as a FILE from the capture server, not inlined. The app ships under
+   `script-src 'self'`, and a tool that only works because it injects an inline
+   script is a tool that will not work the day the built index.html grows a CSP
+   meta tag. Same origin, same rules as the app's own bundle. */
+
+function bootstrapSource(seed) {
+  return `/* generated by tools/capture.mjs — not committed */
+(function () {
+  var SEED = ${JSON.stringify(seed)};
+  var q = new URLSearchParams(location.search);
+  var theme = q.get("theme") === "dark" ? "dark" : "light";
+  var developer = q.get("dev") === "1";
+  // The accessibility text-size setting the app itself ships. Only "normal"
+  // was ever seeded, so every defect that appears only at "large" or
+  // "largest" — four of five tab labels clipping to a prefix, a settings
+  // screen that scrolls again, a catalogue that collapses to one card — was
+  // invisible to a hundred committed captures.
+  var textSize = q.get("text") || "normal";
+
+  function put(key, state, version) {
+    try { localStorage.setItem(key, JSON.stringify({ state: state, version: version })); }
+    catch (error) { console.error("[capture] could not seed " + key, error); }
+  }
+
+  try { localStorage.clear(); } catch (error) { console.error("[capture] clear failed", error); }
+
+  // Device-scoped keys — dynawalla.<name>. See src/app/profile.ts.
+  put("dynawalla.theme", { mode: theme }, 0);
+  put("dynawalla.settings", {
+    sound: true, haptics: true, reduceMotion: false,
+    textSize: textSize, quality: "full", developer: developer,
+  }, 1);
+  put("dynawalla.profiles", { profiles: SEED.profiles, currentId: "p1" }, 1);
+  put("dynawalla.packs", { installed: SEED.installed }, 1);
+  put("dynawalla.pass", { pass: null, ledger: { day: SEED.day, resting: SEED.resting } }, 1);
+
+  // Learner-scoped keys — dynawalla.<profileId>.<name>.
+  put("dynawalla.p1.record", { answered: 1284, correct: 1102 }, 1);
+  put("dynawalla.p1.world", { placed: 37 }, 1);
+  put("dynawalla.p2.record", { answered: 96, correct: 71 }, 1);
+  put("dynawalla.p2.world", { placed: 4 }, 1);
+
+  // The native runtime, shimmed. \`isNative\` is a test for this object, so its
+  // mere presence puts the app on its native path; the app then asks the four
+  // questions below and no others. An unknown command REJECTS loudly rather
+  // than resolving undefined — a silent resolve is how a capture ends up
+  // showing a screen no device can produce.
+  window.__TAURI_INTERNALS__ = {
+    invoke: function (cmd) {
+      if (cmd === "packs_list") return Promise.resolve(SEED.rows);
+      if (cmd === "plugin:app|version") return Promise.resolve(SEED.version);
+      if (cmd === "packs_catalog") return Promise.resolve(JSON.stringify({ packs: [] }));
+      console.error("[capture] unshimmed native command: " + cmd);
+      return Promise.reject(new Error("capture: no shim for " + cmd));
+    },
+    transformCallback: function (callback) {
+      var id = "cb" + Math.random().toString(36).slice(2);
+      window[id] = callback;
+      return id;
+    },
+    unregisterCallback: function () {},
+    convertFileSrc: function (file) { return file; },
+  };
+})();
+`
+}
+
+/* ── Build ────────────────────────────────────────────────────────────────── */
+
+function run(command, args, cwd) {
+  const done = spawnSync(command, args, { cwd, stdio: "inherit" })
+  if (done.status !== 0) throw new Error(`${command} ${args.join(" ")} failed (${String(done.status)})`)
+}
+
+function build() {
+  if (flag("no-build")) {
+    if (!fs.existsSync(DIST)) throw new Error("--no-build, but dist/ does not exist")
+    console.log("· reusing dist/")
+    return
+  }
+  console.log("· building the app")
+  run(NPM, ["run", "build"], APP)
+  console.log("· building the pass-sheet harness")
+  // Failing here must not cost the other eight screens: the harness is a
+  // second build with its own config, and the five destinations are the point.
+  const done = spawnSync(NPM, ["exec", "--", "vite", "build", "--config", "tools/harness/vite.config.mjs"], {
+    cwd: APP,
+    stdio: "inherit",
+  })
+  if (done.status !== 0) console.error("! the harness build failed — pass-sheet screens will be skipped")
+}
+
+/* ── The server ───────────────────────────────────────────────────────────── */
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+}
+
+function serve(seed) {
+  const bootstrap = bootstrapSource(seed)
+
+  // dist/index.html, with one <script src> added as the first thing in <head>
+  // so the seed and the shim are in place before the app's module runs.
+  const inject = (file, src) => {
+    const html = fs.readFileSync(file, "utf8")
+    return html.replace(/<head([^>]*)>/i, `<head$1>\n    <script src="${src}"></script>`)
+  }
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1")
+    const route = url.pathname
+
+    const send = (body, type, status = 200) => {
+      res.writeHead(status, { "content-type": type, "cache-control": "no-store" })
+      res.end(body)
+    }
+
+    try {
+      if (route === "/__capture/bootstrap.js") return send(bootstrap, MIME[".js"])
+      if (route === "/__capture/app.html") {
+        return send(inject(path.join(DIST, "index.html"), "/__capture/bootstrap.js"), MIME[".html"])
+      }
+      if (route === "/__capture/pass.html") {
+        return send(inject(path.join(HARNESS_DIST, "index.html"), "/__capture/bootstrap.js"), MIME[".html"])
+      }
+
+      // Static. The harness bundle is mounted under a prefix of its own; the
+      // app owns the root, which is what its absolute /assets/ paths expect.
+      const root = route.startsWith("/__harness/") ? HARNESS_DIST : DIST
+      const rel = route.startsWith("/__harness/") ? route.slice("/__harness".length) : route
+      const file = path.join(root, path.normalize(rel).replace(/^(\.\.[/\\])+/, ""))
+      if (!file.startsWith(root)) return send("no", "text/plain", 403)
+      if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) return send("not found", "text/plain", 404)
+      return send(fs.readFileSync(file), MIME[path.extname(file)] ?? "application/octet-stream")
+    } catch (error) {
+      console.error("[capture] server", error)
+      return send("error", "text/plain", 500)
+    }
+  })
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }))
+  })
+}
+
+/* ── Chrome, over the DevTools protocol ───────────────────────────────────── */
+
+const CHROME_CANDIDATES = [
+  process.env["CHROME"],
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium",
+].filter(Boolean)
+
+function findChrome() {
+  const found = CHROME_CANDIDATES.find((candidate) => fs.existsSync(candidate))
+  if (!found) throw new Error(`no Chrome found. Tried:\n  ${CHROME_CANDIDATES.join("\n  ")}`)
+  return found
+}
+
+function launchChrome() {
+  const binary = findChrome()
+  const profile = fs.mkdtempSync(path.join(process.env["TMPDIR"] ?? "/tmp", "dw-capture-"))
+  const child = spawn(binary, [
+    "--headless=new",
+    "--remote-debugging-port=0",
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-extensions",
+    "--disable-background-networking",
+    "--disable-features=Translate,MediaRouter",
+    "--force-color-profile=srgb",
+    // Text that is hinted differently between runs is a diff nobody can read.
+    "--font-render-hinting=none",
+    // Big enough that no clamp is ever in play; the real viewport is set per
+    // capture over CDP. See the header.
+    "--window-size=1600,1200",
+    "about:blank",
+  ])
+
+  return new Promise((resolve, reject) => {
+    let buffered = ""
+    const timer = setTimeout(() => reject(new Error("Chrome did not print a DevTools endpoint")), 30_000)
+    child.stderr.on("data", (chunk) => {
+      buffered += String(chunk)
+      const hit = /DevTools listening on (ws:\/\/\S+)/.exec(buffered)
+      if (hit) {
+        clearTimeout(timer)
+        resolve({ child, profile, wsUrl: hit[1] })
+      }
+    })
+    child.on("exit", (code) => reject(new Error(`Chrome exited early (${String(code)})`)))
+  })
+}
+
+async function connect(wsUrl) {
+  const socket = new WebSocket(wsUrl)
+  await new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true })
+    socket.addEventListener("error", () => reject(new Error("CDP socket failed")), { once: true })
+  })
+
+  let nextId = 0
+  const pending = new Map()
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data)
+    const waiting = pending.get(message.id)
+    if (!waiting) return
+    pending.delete(message.id)
+    if (message.error) waiting.reject(new Error(`${message.method ?? ""} ${message.error.message}`))
+    else waiting.resolve(message.result)
+  })
+
+  return {
+    send(method, params = {}, sessionId) {
+      const id = ++nextId
+      const payload = sessionId ? { id, method, params, sessionId } : { id, method, params }
+      socket.send(JSON.stringify(payload))
+      return new Promise((resolve, reject) => pending.set(id, { resolve, reject }))
+    },
+    close: () => socket.close(),
+  }
+}
+
+/* ── In-page measurement ──────────────────────────────────────────────────
+   Everything below runs inside the page. It is a string on purpose: it is not
+   part of the app, must never be bundled with it, and must be readable beside
+   what it measures. */
+
+const MEASURE = String.raw`(() => {
+  const de = document.documentElement
+  const vw = de.clientWidth
+  const vh = de.clientHeight
+
+  const describe = (el) => {
+    const id = el.id ? "#" + el.id : ""
+    const cls = typeof el.className === "string" && el.className
+      ? "." + el.className.trim().split(/\s+/).slice(0, 4).join(".")
+      : ""
+    return el.tagName.toLowerCase() + id + cls
+  }
+
+  /* ── colour ─────────────────────────────────────────────────────────── */
+  const rgb = (value) => {
+    const nums = (value.match(/[\d.]+/g) || []).map(Number)
+    if (nums.length < 3) return null
+    return { r: nums[0], g: nums[1], b: nums[2], a: nums.length > 3 ? nums[3] : 1 }
+  }
+  const over = (top, bottom) => ({
+    r: top.r * top.a + bottom.r * (1 - top.a),
+    g: top.g * top.a + bottom.g * (1 - top.a),
+    b: top.b * top.a + bottom.b * (1 - top.a),
+    a: 1,
+  })
+  const lum = (c) => {
+    const f = (v) => {
+      const s = v / 255
+      return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b)
+  }
+  const ratio = (a, b) => {
+    const la = lum(a), lb = lum(b)
+    return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+  }
+  /** The ground a run of text actually sits on: the first painted ancestor. */
+  const groundOf = (el) => {
+    let node = el
+    let stack = []
+    while (node && node !== document.documentElement.parentNode) {
+      const bg = rgb(getComputedStyle(node).backgroundColor)
+      if (bg && bg.a > 0) {
+        stack.push(bg)
+        if (bg.a >= 1) break
+      }
+      node = node.parentElement
+    }
+    let base = { r: 255, g: 255, b: 255, a: 1 }
+    for (let i = stack.length - 1; i >= 0; i--) base = over(stack[i], base)
+    return base
+  }
+
+  /* ── the walk ───────────────────────────────────────────────────────── */
+  const INTERACTIVE = 'a[href],button,input,select,textarea,summary,[role="button"],[role="tab"],[tabindex]:not([tabindex="-1"])'
+  const escaping = []
+  const small = []
+  const scrollers = []
+  const swatches = new Map()
+
+  /* documentElement.scrollHeight is NOT the whole story in this app, and
+     assuming it was hid the app's real scroller for a whole capture run.
+     \`html, body { height: 100%; overflow-x: hidden }\` makes overflow-y compute
+     to \`auto\` on BODY, so body becomes the scrolling box and the document
+     element stays exactly one viewport tall no matter how long the catalogue
+     is. Every box that actually scrolls is listed instead. */
+  const scrollBoxes = [document.documentElement, document.body, ...document.querySelectorAll("*")]
+  const seenBox = new Set()
+  for (const el of scrollBoxes) {
+    if (seenBox.has(el)) continue
+    seenBox.add(el)
+    const vertical = el.scrollHeight - el.clientHeight
+    const sideways = el.scrollWidth - el.clientWidth
+    if (vertical <= 1 && sideways <= 1) continue
+    const style = getComputedStyle(el)
+    if (style.overflowX === "visible" && style.overflowY === "visible") continue
+    scrollers.push({
+      el: el === document.documentElement ? "html" : el === document.body ? "body" : describe(el),
+      vertical: Math.max(0, Math.round(vertical)),
+      sideways: Math.max(0, Math.round(sideways)),
+      overflowX: style.overflowX,
+      overflowY: style.overflowY,
+      // A drawn track is one of the named web-view tells. scrollbar-width is
+      // only suppressed under a coarse-pointer media query in this app, so on
+      // a desktop — a first-class target — these tracks are painted.
+      scrollbarWidth: style.scrollbarWidth,
+    })
+  }
+
+  for (const el of document.querySelectorAll("*")) {
+    const box = el.getBoundingClientRect()
+    if (box.width === 0 && box.height === 0) continue
+    const style = getComputedStyle(el)
+    if (style.visibility === "hidden" || style.display === "none") continue
+
+    // Escaping the viewport sideways. A tolerance of 1px absorbs subpixel
+    // layout; anything more is a real overhang.
+    if (box.right > vw + 1 || box.left < -1) {
+      // Only the outermost offender is interesting: a wide row drags every
+      // descendant with it and would otherwise print forty identical lines.
+      const parent = el.parentElement
+      const parentBox = parent ? parent.getBoundingClientRect() : null
+      const parentEscapes = parentBox && (parentBox.right > vw + 1 || parentBox.left < -1)
+      if (!parentEscapes) {
+        escaping.push({ el: describe(el), left: Math.round(box.left), right: Math.round(box.right) })
+      }
+    }
+
+    if (el.matches(INTERACTIVE) && !el.hasAttribute("disabled")) {
+      const w = Math.round(box.width * 10) / 10
+      const h = Math.round(box.height * 10) / 10
+      if (w < 44 || h < 44) {
+        small.push({
+          el: describe(el),
+          text: (el.textContent || el.getAttribute("aria-label") || "").trim().slice(0, 40),
+          w, h,
+        })
+      }
+    }
+  }
+
+  /* ── every text run, with the ground it is on ───────────────────────── */
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = (node.nodeValue || "").trim()
+    if (!text) continue
+    const el = node.parentElement
+    if (!el) continue
+    const box = el.getBoundingClientRect()
+    if (box.width === 0 || box.height === 0) continue
+    const style = getComputedStyle(el)
+    if (style.visibility === "hidden") continue
+    const ink = rgb(style.color)
+    if (!ink) continue
+    const ground = groundOf(el)
+    const painted = ink.a < 1 ? over(ink, ground) : ink
+    const size = parseFloat(style.fontSize)
+    const weight = Number(style.fontWeight) || 400
+    // 18.66px, or 14px bold — the WCAG "large text" boundary.
+    const large = size >= 24 || (size >= 18.66 && weight >= 700)
+    const key = [
+      Math.round(painted.r), Math.round(painted.g), Math.round(painted.b),
+      Math.round(ground.r), Math.round(ground.g), Math.round(ground.b),
+      size, weight,
+    ].join("/")
+    if (swatches.has(key)) { swatches.get(key).count++; continue }
+    const value = Math.round(ratio(painted, ground) * 100) / 100
+    swatches.set(key, {
+      sample: text.slice(0, 40),
+      color: "rgb(" + [painted.r, painted.g, painted.b].map(Math.round).join(" ") + ")",
+      background: "rgb(" + [ground.r, ground.g, ground.b].map(Math.round).join(" ") + ")",
+      fontSize: size,
+      fontWeight: weight,
+      largeText: large,
+      ratio: value,
+      passesAA: value >= (large ? 3 : 4.5),
+      count: 1,
+    })
+  }
+
+  return {
+    viewport: { width: vw, height: vh, innerWidth: window.innerWidth },
+    overflow: {
+      scrollWidth: de.scrollWidth,
+      clientWidth: de.clientWidth,
+      horizontal: de.scrollWidth - de.clientWidth,
+      scrollHeight: de.scrollHeight,
+      clientHeight: de.clientHeight,
+    },
+    scrollers,
+    escaping: escaping.slice(0, 40),
+    escapingCount: escaping.length,
+    smallTargets: small.slice(0, 40),
+    smallTargetCount: small.length,
+    text: [...swatches.values()].sort((a, b) => a.ratio - b.ratio),
+  }
+})()`
+
+/* ── The act sequences ────────────────────────────────────────────────────
+   The pass sheet has three stages and only the first is on screen at load.
+   Both transitions are driven the way an adult drives them: press "Grown-ups",
+   then answer the gate. The gate is a *reading* challenge, not arithmetic
+   (deliberately — see pass/parentalGate.ts), so the answer is on screen or is
+   the current year, and both are computable here without reaching into the
+   app's state. */
+
+const ACTS = {
+  gate: String.raw`(() => {
+    const press = [...document.querySelectorAll("button")]
+      .find((b) => /grown-ups/i.test(b.textContent || ""))
+    if (!press) return "no Grown-ups control"
+    press.click()
+    return "ok"
+  })()`,
+
+  offer: String.raw`(() => {
+    const open = [...document.querySelectorAll("button")]
+      .find((b) => /grown-ups/i.test(b.textContent || ""))
+    if (open) open.click()
+    return "ok"
+  })()`,
+
+  // Run after the gate has painted. Kept separate because React needs a frame
+  // between the click and the field existing.
+  offerAnswer: String.raw`(() => {
+    const field = document.querySelector("#pass-gate-entry")
+    if (!field) return "no gate field"
+    const shown = document.querySelector("#pass-gate-title")
+    const word = [...document.querySelectorAll("p")]
+      .map((p) => (p.textContent || "").trim())
+      .find((t) => /^[A-Z]{10,}$/.test(t))
+    const answer = word || String(new Date().getFullYear())
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set
+    setter.call(field, answer)
+    field.dispatchEvent(new Event("input", { bubbles: true }))
+    const form = field.closest("form")
+    if (!form) return "no form"
+    form.requestSubmit()
+    void shown
+    return "answered " + answer
+  })()`,
+}
+
+/* ── Capture ──────────────────────────────────────────────────────────────── */
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function evaluate(cdp, session, expression) {
+  const result = await cdp.send(
+    "Runtime.evaluate",
+    { expression, returnByValue: true, awaitPromise: true },
+    session,
+  )
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description ?? "evaluate threw")
+  }
+  return result.result.value
+}
+
+/** Wait until the app has actually drawn something, not merely loaded. */
+async function settle(cdp, session, marker) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const ready = await evaluate(
+      cdp,
+      session,
+      `document.readyState === "complete" && !!document.querySelector(${JSON.stringify(marker)})`,
+    )
+    if (ready) break
+    await sleep(100)
+  }
+  // Two animation frames plus a beat: transitions in this app are 120–200ms
+  // and a shot taken mid-transition is a shot of a colour that does not exist.
+  await evaluate(
+    cdp,
+    session,
+    `new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 250))))`,
+  )
+}
+
+async function main() {
+  fs.mkdirSync(SHOTS, { recursive: true })
+  for (const theme of themes) fs.mkdirSync(path.join(SHOTS, theme), { recursive: true })
+
+  build()
+
+  const rows = seedManifests()
+  const state = seedState(rows)
+  const version = JSON.parse(fs.readFileSync(path.join(APP, "package.json"), "utf8")).version
+  const seed = {
+    rows: state.rows,
+    day: state.day,
+    resting: state.resting,
+    profiles: state.profiles,
+    version,
+    // What the registry mirror would already hold on a warm launch, so the
+    // parent area's counts are right on the very first frame.
+    installed: state.rows.map((row) => {
+      const manifest = JSON.parse(row.manifest)
+      return {
+        id: manifest.id,
+        name: manifest.name,
+        version: manifest.version,
+        bytes: row.bytes,
+        sha256: manifest.download.sha256,
+        installedAt: Date.now(),
+        description: manifest.description,
+        skills: manifest.covers.skills,
+        grades: manifest.covers.grades,
+      }
+    }),
+  }
+  console.log(`· seeded ${String(rows.length)} packs from ${GAMES}`)
+
+  const { server, port } = await serve(seed)
+  const { child, profile, wsUrl } = await launchChrome()
+  const cdp = await connect(wsUrl)
+
+  const harnessBuilt = fs.existsSync(path.join(HARNESS_DIST, "index.html"))
+  if (!harnessBuilt) console.error("! no harness bundle — pass-sheet screens skipped")
+
+  const measurements = {}
+  const probed = {}
+  const written = []
+  const problems = []
+
+  try {
+    for (const theme of themes) {
+      for (const screen of screens) {
+        if (screen.kind === "harness" && !harnessBuilt) continue
+        for (const width of widths) {
+          const view = VIEWPORTS[width]
+          const label = `${theme}/${screen.name}-${String(width)}`
+
+          const { targetId } = await cdp.send("Target.createTarget", { url: "about:blank" })
+          const { sessionId } = await cdp.send("Target.attachToTarget", { targetId, flatten: true })
+
+          try {
+            await cdp.send("Page.enable", {}, sessionId)
+            await cdp.send(
+              "Emulation.setDeviceMetricsOverride",
+              {
+                width,
+                height: view.height,
+                deviceScaleFactor: view.dsf,
+                mobile: view.mobile,
+                screenWidth: width,
+                screenHeight: view.height,
+              },
+              sessionId,
+            )
+            // The theme is carried by the seeded store, not by the OS
+            // preference — but a mismatch between the two is exactly how a
+            // half-painted screen happens, so the OS is told the same thing.
+            await cdp.send(
+              "Emulation.setEmulatedMedia",
+              { features: [{ name: "prefers-color-scheme", value: theme }] },
+              sessionId,
+            )
+            if (coarse) {
+              // `setEmitTouchEventsForMouse` alone changes what EVENTS fire and
+              // does not move the pointer media queries — measured, the page
+              // still reported `any-pointer: coarse` false, so a `--coarse` run
+              // proved nothing about the scrollbar suppression it exists to
+              // check. `setTouchEmulationEnabled` is what makes the device
+              // report a touchscreen; both are set, because the app also cares
+              // which events arrive.
+              await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 5 }, sessionId)
+              await cdp.send("Emulation.setEmitTouchEventsForMouse", { enabled: true, configuration: "mobile" }, sessionId)
+            }
+
+            const base = screen.kind === "harness" ? "/__capture/pass.html" : "/__capture/app.html"
+            const query = `?theme=${theme}${screen.dev ? "&dev=1" : ""}${textSize === "normal" ? "" : `&text=${textSize}`}`
+            const url = `http://127.0.0.1:${String(port)}${base}${query}${screen.hash ?? ""}`
+
+            await cdp.send("Page.navigate", { url }, sessionId)
+            await settle(cdp, sessionId, screen.kind === "harness" ? '[role="dialog"]' : "nav")
+
+            if (screen.act === "gate") {
+              await evaluate(cdp, sessionId, ACTS.gate)
+              await settle(cdp, sessionId, "#pass-gate-entry")
+            }
+            if (screen.act === "offer") {
+              await evaluate(cdp, sessionId, ACTS.offer)
+              await settle(cdp, sessionId, "#pass-gate-entry")
+              const said = await evaluate(cdp, sessionId, ACTS.offerAnswer)
+              await settle(cdp, sessionId, "#pass-offer-title")
+              if (!String(said).startsWith("answered")) problems.push(`${label}: gate — ${String(said)}`)
+            }
+
+            const measured = await evaluate(cdp, sessionId, MEASURE)
+            if (PROBE !== null) probed[`${label}${textSize === "normal" ? "" : `-${textSize}`}`] = await evaluate(cdp, sessionId, PROBE)
+
+            // The clamp check. If this ever fires, the viewport override lost
+            // to something and every shot in the run is a lie — see the header.
+            if (measured.viewport.width !== width) {
+              throw new Error(
+                `viewport clamped: asked ${String(width)}, rendered ${String(measured.viewport.width)}`,
+              )
+            }
+
+            const shot = await cdp.send(
+              "Page.captureScreenshot",
+              screen.full
+                ? { format: "png", captureBeyondViewport: true, optimizeForSpeed: false }
+                : { format: "png", optimizeForSpeed: false },
+              sessionId,
+            )
+            // The text size is in the filename and in the measurement key, so a
+            // `--textsize=largest` sweep sits BESIDE the normal one instead of
+            // overwriting it. A defect that only exists at one text size has to
+            // be comparable against the size where it does not.
+            const suffix = textSize === "normal" ? "" : `-${textSize}`
+            const file = path.join(SHOTS, theme, `${screen.name}-${String(width)}${suffix}.png`)
+            fs.writeFileSync(file, Buffer.from(shot.data, "base64"))
+            written.push(file)
+
+            measurements[`${label}${suffix}`] = {
+              screen: screen.name,
+              textSize,
+              theme,
+              width,
+              height: view.height,
+              url,
+              ...measured,
+            }
+
+            const flags = []
+            if (measured.overflow.horizontal > 0) flags.push(`h-scroll ${String(measured.overflow.horizontal)}px`)
+            if (measured.escapingCount > 0) flags.push(`${String(measured.escapingCount)} escaping`)
+            if (measured.smallTargetCount > 0) flags.push(`${String(measured.smallTargetCount)} small`)
+            const fails = measured.text.filter((t) => !t.passesAA).length
+            if (fails > 0) flags.push(`${String(fails)} AA fail`)
+            console.log(`  ${label}${flags.length ? "  ⟨" + flags.join(", ") + "⟩" : ""}`)
+          } catch (error) {
+            problems.push(`${label}: ${error.message}`)
+            console.error(`  ${label}  FAILED — ${error.message}`)
+          } finally {
+            await cdp.send("Target.closeTarget", { targetId }).catch(() => undefined)
+          }
+        }
+      }
+    }
+  } finally {
+    cdp.close()
+    server.close()
+    // Wait for the process to actually go before removing its profile: Chrome
+    // is still flushing that directory when `kill` returns, and `rmSync` loses
+    // the race with ENOTEMPTY — after a completely successful run, which is the
+    // worst possible moment to throw.
+    const exited = new Promise((resolve) => child.once("exit", resolve))
+    child.kill()
+    await Promise.race([exited, sleep(5000)])
+    try {
+      fs.rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+    } catch (error) {
+      console.error(`! left ${profile} behind — ${error.message}`)
+    }
+  }
+
+  // MERGED, never replaced, and this is not tidiness. `--only=packs` used to
+  // overwrite the file with its ten keys, which silently erased the ninety
+  // numbers behind every per-screen claim in the write-ups beside it — a
+  // reviewer opening `measurements.json` found evidence for one screen and no
+  // record that the rest had ever been measured. Old entries for a screen this
+  // run DID capture are replaced; entries for screens it did not touch survive,
+  // and each carries the timestamp of the run that produced it.
+  const measuredAt = new Date().toISOString()
+  const previous = (() => {
+    try {
+      const held = JSON.parse(fs.readFileSync(path.join(SHOTS, "measurements.json"), "utf8"))
+      return held && typeof held.screens === "object" ? held.screens : {}
+    } catch {
+      return {}
+    }
+  })()
+  const allScreens = { ...previous }
+  for (const [key, value] of Object.entries(measurements)) {
+    allScreens[key] = { ...value, measuredAt }
+  }
+
+  fs.writeFileSync(
+    path.join(SHOTS, "measurements.json"),
+    JSON.stringify(
+      {
+        capturedAt: measuredAt,
+        appVersion: version,
+        packs: rows.length,
+        note: "env(safe-area-inset-*) is 0 here; Chrome is a fine pointer, so the app's coarse-pointer scrollbar suppression is not in effect. Entries are MERGED across runs — `measuredAt` on each says when that screen was last actually captured.",
+        problems,
+        screens: allScreens,
+      },
+      null,
+      2,
+    ) + "\n",
+  )
+
+  if (PROBE !== null) {
+    const out = path.join(SHOTS, "probe.json")
+    fs.writeFileSync(out, JSON.stringify(probed, null, 2) + "\n")
+    console.log(`probe → ${out}`)
+  }
+
+  console.log(`\n${String(written.length)} shots → ${SHOTS}`)
+  console.log(`measurements → ${path.join(SHOTS, "measurements.json")}`)
+  if (problems.length > 0) {
+    console.error(`\n${String(problems.length)} problem(s):`)
+    for (const problem of problems) console.error(`  ${problem}`)
+    process.exitCode = 1
+  }
+}
+
+await main()

--- a/dynawalla/dynawalla-app/tools/harness/harness.css
+++ b/dynawalla/dynawalla-app/tools/harness/harness.css
@@ -1,0 +1,16 @@
+/* The capture harness's stylesheet.
+ *
+ * It is the app's own stylesheet, plus two `@source` directives.
+ *
+ * Tailwind v4 discovers the classes it must emit by scanning outward from the
+ * CSS file it is invoked on. This build's root is `tools/harness/`, not the app
+ * root, so automatic detection would scan the harness directory and emit almost
+ * nothing — the sheet would look right in review and render an unstyled dialog.
+ * The two directives below name the two trees whose class names have to survive
+ * into this bundle, explicitly, so the harness cannot silently lose them.
+ */
+
+@import "../../src/index.css";
+
+@source "../../src/**/*.{ts,tsx}";
+@source "./**/*.{tsx,html}";

--- a/dynawalla/dynawalla-app/tools/harness/index.html
+++ b/dynawalla/dynawalla-app/tools/harness/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- The same viewport contract the app ships, verbatim: a capture taken
+         under a different one is a capture of a different layout. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+    />
+    <meta name="color-scheme" content="light dark" />
+    <title>Dynawalla — capture harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/dynawalla/dynawalla-app/tools/harness/main.tsx
+++ b/dynawalla/dynawalla-app/tools/harness/main.tsx
@@ -1,0 +1,44 @@
+// The capture harness for the pass sheet. Dev only; never bundled into the app.
+//
+// **Why this exists.** `PassSheet` is mounted by `packs/Stage.tsx`, and the
+// stage only mounts it when `usePass.mayOpen()` is false. That decision runs
+// through `pass/model.ts`, which opens unconditionally while `billing().wired`
+// is false — and nothing in the shipped app ever calls `setBilling`. So in a
+// browser, and in fact in today's build on a device, there is no sequence of
+// taps that puts the sheet on screen. It is real code, it is reachable the
+// moment a store is wired, and it is three screens nobody can currently look
+// at.
+//
+// Rather than fake app state — which would mean guessing at the shape of a
+// store and capturing a screen that does not exist — this mounts the real
+// component, with the real stylesheet, inside the same full-bleed deep ground
+// the stage draws behind it (`Stage.tsx`: `bg-ground-deep fixed inset-0`). What
+// is captured is the component, honestly, in its own frame.
+//
+// The one thing it cannot reproduce is the paused game showing through the
+// panel's `backdrop-blur-sm`. Behind the sheet here is flat ground. Every other
+// pixel is the shipped one.
+
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+
+// Side-effect imports, in the order `src/main.tsx` has them: the theme class
+// and the text-size attribute are applied at module load, before the first
+// paint, and a harness that imported them later would capture the default
+// theme for one frame and the requested one after.
+import "../../src/app/theme.ts"
+import "../../src/settings/store.ts"
+import "./harness.css"
+
+import { PassSheet } from "../../src/pass/PassSheet.tsx"
+
+const root = document.getElementById("root")
+if (!root) throw new Error("missing #root")
+
+createRoot(root).render(
+  <StrictMode>
+    <div className="bg-ground-deep fixed inset-0">
+      <PassSheet packName="LATTICE RUNNER" onLeave={() => undefined} />
+    </div>
+  </StrictMode>,
+)

--- a/dynawalla/dynawalla-app/tools/harness/vite.config.mjs
+++ b/dynawalla/dynawalla-app/tools/harness/vite.config.mjs
@@ -1,0 +1,38 @@
+// The harness bundle. Built by `tools/capture.mjs`, never by `npm run build`.
+//
+// Deliberately a second, separate build rather than a second entry in the app's
+// own config: nothing a capture tool needs may change what ships. The app's
+// `vite.config.ts` is untouched by this file's existence.
+
+import { fileURLToPath, URL } from "node:url"
+
+import react from "@vitejs/plugin-react"
+import tailwind from "@tailwindcss/vite"
+import { defineConfig } from "vite"
+
+const here = fileURLToPath(new URL(".", import.meta.url))
+
+export default defineConfig({
+  root: here,
+  // The prefix the capture server mounts this bundle at. NOT "./": the harness
+  // document is served from `/__capture/pass.html` so that the seed script can
+  // be injected into it, and relative asset paths would resolve against
+  // `/__capture/`, where the app's own dist is mounted — a 404 for every asset
+  // and a blank screenshot that looks like a component that renders nothing.
+  base: "/__harness/",
+  plugins: [react(), tailwind()],
+  define: {
+    // `platform.ts` reads this. Nothing the harness renders imports it today,
+    // but a component that starts to would otherwise fail at module load with
+    // a bare ReferenceError.
+    __APP_VERSION__: JSON.stringify("capture"),
+  },
+  build: {
+    outDir: fileURLToPath(new URL("../.harness-dist", import.meta.url)),
+    emptyOutDir: true,
+    // The app's floor, restated: a capture taken from a bundle compiled to a
+    // newer baseline is not a capture of the shipped app.
+    target: "es2020",
+    sourcemap: false,
+  },
+})

--- a/dynawalla/dynawalla-app/tools/shots/AUDIT.md
+++ b/dynawalla/dynawalla-app/tools/shots/AUDIT.md
@@ -1,0 +1,464 @@
+# Dynawalla harness — baseline visual audit
+
+Captured by `tools/capture.mjs` against the app at `0.1.0`, seeded with the real
+`pack.json` of all 27 games. 100 shots: 10 screens × 5 widths (390 / 430 / 834 /
+1024 / 1440) × light and dark, plus `measurements.json`.
+
+Everything below is either **visible in a named PNG** or **measured in
+`measurements.json`**. Nothing here is inferred from reading a component. Paths
+are relative to `dynawalla/dynawalla-app/`.
+
+Re-run with `node tools/capture.mjs`; `--no-build` reuses `dist/`.
+
+## What is already right, and must not be undone
+
+Verified in this run, so a later pass does not re-litigate it:
+
+* **No page scrolls sideways.** `documentElement.scrollWidth == clientWidth` on
+  all 100 captures, including `parents-dev` at 390 where the capability strings
+  are longest. The `min-w-0` fix in `src/shell/Surface.tsx:46-51` holds.
+* **No tap highlight, no selection handle, no double-tap zoom** —
+  `src/index.css:40-62`.
+* **No bounce on a fixed surface** — `overscroll-behavior: none` on both `html`
+  and `body`, `src/index.css:26` and `:48`.
+* **The wordmark lockup.** The mark's `mb-[0.16em]` sits it on the letters'
+  feet at every width. Correct in all 20 lintel captures.
+* **Row height.** Every course row is `min-h-16` (64 px). No child-facing row is
+  under the target floor.
+* **Contrast, everywhere except one token** — see §0. 22 distinct text/ground
+  pairs measured; 20 pass AA, the two failures are the same colour.
+
+---
+
+## 0. Cross-cutting — these appear on more than one screen
+
+### 0.1 The "one warm point" rule is broken by a factor of about 120 · **worst defect**
+
+`src/design/Strapwork.tsx:41` paints every knot of the interlace with
+`fill="var(--dw-index)"` — the brass apex colour. The band is `width="100%"` and
+the tile repeats every 24 px, so a 390 px screen carries ~16 gold knots per band
+and a 1440 px screen ~60. The band is drawn **twice on every screen**: under the
+lintel (`src/app/Shell.tsx:49`) and above the navigation (`src/app/Nav.tsx:29`).
+
+The brand rule is one warm point per screen, at the top of something
+(`dynawalla/brand/README.md`). What is actually shipping is a repeating gold
+ribbon top and bottom of every one of the five destinations, plus a gold index
+diamond in the nav, plus gold inside the key art of several cards.
+
+In light theme this is worse: `--dw-index` resolves to `brass-700` `#b45309`
+(`src/design/tokens.css:189`), which at 1 px stroke over parchment reads as a
+**red-brown dotted ribbon** — see `light/parents-1440.png` and
+`light/profiles-390.png`. That is the closest thing in the app to the explicitly
+dead "dusty khaki sandstorm feel".
+
+This is the item `docs/HARNESS_FEEDBACK.md` recorded as "noted, not yet acted
+on". It is now measured and it is the single loudest thing in every capture.
+
+### 0.2 Selected state is drawn as a recess, so every segmented control reads inverted
+
+`src/shell/Surface.tsx:84`:
+
+```
+active ? "bg-ground text-ink" : "bg-ground-raised text-ink-muted"
+```
+
+The **chosen** option gets `--dw-ground`; the **unchosen** options get
+`--dw-ground-raised`, which is lighter in both themes. So the option that is not
+selected is the one that looks like a raised, pressed-able key, and the selected
+one looks like a hole.
+
+`light/parents-1440.png` is the clearest: "Developer mode" is Off, and the white
+"On" segment is the one that reads as active. `dark/settings-390.png` shows it on
+six controls at once — for Sound the lit-looking segment is "Off" while the
+diamond says "On".
+
+Every platform convention (iOS segmented control, Android toggle group) does the
+opposite: the selection is the raised, lighter chip. The catalogue chip has the
+same inversion at `src/catalog/Catalog.tsx:236` — the active chip is
+`bg-ground-sunk`, i.e. darker than the page.
+
+### 0.3 The index mark is inserted into flow, so text jumps when state changes
+
+Three places conditionally *insert* an 8 px SVG plus a gap rather than reserving
+its space:
+
+| where | file:line | what moves |
+|---|---|---|
+| segmented option | `src/shell/Surface.tsx:87` | the option label shifts right ~16 px the moment it is chosen, and the two labels beside it re-centre |
+| learner row | `src/shell/Surface.tsx:129` | the current learner's name field starts 44 px further right than every other learner's — visible in `light/profiles-390.png`, where "Amina" is indented and "Yusuf" is not |
+| pack card | n/a | (correct — no mark) |
+
+This is the named defect "text that reflows or jumps as state changes". The
+`Action` row at `src/shell/Surface.tsx:108` gets it right (`opacity-0`, space
+reserved) — but then produces 0.4 below.
+
+### 0.4 Three different left edges on one screen
+
+Because `Action` reserves the index mark's width, an action label starts 44 px
+in while a fact label starts at 0. In `dark/parents-dev-390.png`, "Version",
+"Learners" and "Platform" are flush with the rules; "Erase everything" is
+indented. In `light/profiles-390.png`, "Add a learner" is indented and the
+learner names are not.
+
+Files: `src/shell/Surface.tsx:103-110` (Action) vs `:46-52` (Fact) vs `:123-157`
+(Learner).
+
+### 0.5 A drawn scrollbar track, on the front door, on a phone
+
+Measured, not guessed. `measurements.json` records for `light/packs-390`:
+
+```
+div.-mx-1.flex.gap-2.overflow-x-auto  x:auto  overflow 440px  scrollbar-width:auto
+body                                  y:auto  overflow 4202px scrollbar-width:auto
+```
+
+`src/index.css:78-87` suppresses scrollbar tracks **only** under
+`@media (pointer: coarse)`. That is a defensible call for the page scroller on a
+desktop — but two consequences were not intended:
+
+1. The subject-chip row (`src/catalog/Catalog.tsx:186`) draws a **horizontal
+   track inside the content** at 390 and 430. It is plainly visible in
+   `dark/packs-390.png` as a grey bar under "All / Number sense / Addition &
+   subtraction". A horizontal track sitting between the search field and the
+   game grid is the loudest web-page tell in the app.
+2. Desktop and tablet-with-trackpad are first-class targets, and every capture
+   at 1024 and 1440 has a painted page track down the right edge.
+
+The chip row also overflows by **440 px at 390** with no fade, no gradient and no
+peeking half-chip beyond the clipped fourth one — a child has no signal that
+three more subjects exist.
+
+### 0.6 `--dw-strike` fails AA in light theme — measured 4.45:1, needs 4.5:1
+
+`src/design/tokens.css:218` — `--dw-strike: var(--color-copper-500)` = `#c2453c`.
+On `--dw-ground` (`parchment-100`, `#f4f0ff`) that measures **4.45:1**, below the
+4.5:1 floor for normal text. It fails on two controls, both destructive:
+
+| text | size | file:line | ratio |
+|---|---|---|---|
+| "Erase everything" | 20 px / 400 | `src/shell/Surface.tsx:105` | 4.45 ✗ |
+| "Remove" | 14 px / 400 | `src/shell/Surface.tsx:151` | 4.45 ✗ |
+
+Dark theme is fine (`copper-400` on the void = 8.20:1). Every other pair in the
+app passes; the next-worst is 6.52:1.
+
+`docs/HARNESS_FEEDBACK.md` flagged the coral hue as semantically odd against
+violet and left it for a deliberate decision. It is now also an accessibility
+failure, so the decision is forced.
+
+### 0.7 There are no transitions between destinations at all
+
+`src/app/router.tsx:33` uses a plain `createHashRouter` and `src/app/Nav.tsx`
+plain `NavLink`s. Tapping a tab swaps the entire surface in one frame. The only
+motion tokens in use are 120 ms `transition-colors` on hover/press states
+(`src/shell/Surface.tsx:83`, `:104`, `src/catalog/Catalog.tsx:67`, `:235`).
+
+Named defect: "transitions that are absent". Nothing explains where a screen
+came from. A View Transition here would be explanatory rather than decorative,
+and `--dw-motion-detent` / `--dw-ease-detent` already exist for it
+(`src/design/tokens.css:272-275`) with reduced-motion already collapsing them
+(`:466-503`).
+
+### 0.8 Desktop and large tablet: three competing measures, and most of the screen is empty
+
+At 1440 (`light/parents-1440.png`, `light/settings-1440.png`,
+`light/packs-1440.png`) there are three different alignment systems on screen at
+once:
+
+* the lintel is **full-bleed**, mark at x≈16 — `src/app/Shell.tsx:25`
+* the surface is **`max-w-6xl`** (1152 px) centred — `src/app/Shell.tsx:72`, and
+  the courses inside it are **`max-w-2xl`** (672 px) centred —
+  `src/shell/Surface.tsx:244`
+* the navigation is **full-bleed** with five equal 288 px cells —
+  `src/app/Nav.tsx:30`
+
+So the wordmark, the content, and the tab labels all start at different x. On
+`parents` at 1440 the content occupies 672 × 380 px of a 1440 × 900 viewport —
+about 20% — with the remaining 80% flat ground and a bottom tab bar stretched
+across it. It reads as a phone app in a desktop window.
+
+### 0.9 iPad landscape (1024 × 768) cuts the last row off Settings
+
+Measured: `light/settings-1024` — `body` scrolls by 65 px. The vertical rungs at
+`src/design/tokens.css:302-327` step at 900 / 720 / 620 px height, so a 768 px
+viewport gets the 900 rung and the six choice rows overrun. On the widest tablet
+orientation, with 1024 px of unused width, the "Quality" control is below the
+fold. See `light/settings-1024.png`.
+
+---
+
+## 1. Packs — the front door (`/`)
+
+Files: `src/catalog/Catalog.tsx`, `src/catalog/PackArt.tsx`,
+`src/shell/surfaces.ts:245`.
+
+**1.1 The grid never grows a column past 10.5 rem.**
+`src/catalog/Catalog.tsx:209` — `minmax(10.5rem, 1fr)` with `auto-fill`. At 1440
+that produces six ~170 px columns inside the 1152 px frame
+(`light/packs-1440.png`): 27 postage stamps with 11 px metadata. The comment
+above the line justifies the 10.5 rem *floor* correctly (COUNTERWEIGHT needs
+142 px at the title's 15 px) — but a floor is not a ceiling, and no breakpoint
+raises it. A desktop should get fewer, larger cards, not more, smaller ones.
+
+**1.2 "Play" is small print, not a control.**
+`src/catalog/Catalog.tsx:110-112` puts the word in the same 11 px muted numeral
+run as "Grades 1–5", on the same line. In `dark/packs-390.png` it reads
+"Grades 1–5 Play" as one metadata string. The whole tile is the button, which is
+right — but the one word that says so is the least visible thing on the card.
+
+**1.3 The metadata block is ragged across a row.**
+`src/catalog/Catalog.tsx:100-113`. Two subject chips are shown, and the names are
+long ("Addition & subtraction" is 22 characters), so each chip takes its own
+line at narrow columns. In `light/packs-1440.png`, ABYSSAL BLOOM and DEEPSWARM
+have two chip lines, ARENA has one, and CLAIM wraps "Play" onto a line of its
+own. Four different bottom-block shapes in one row of six. `mt-auto` pins the
+block to the bottom, so the raggedness lands exactly where the eye scans.
+
+**1.4 Descriptions are cut mid-word, and the manifests are far too long for two
+lines.** Measured: the clamped `span` at `src/catalog/Catalog.tsx:98` overflows
+its 2-line box by 30–165 px across cards — i.e. some descriptions are eight lines
+of text shown as two. "A bioluminescent reef that keeps growing whil…" is what a
+child reads. Either the card needs a real summary field or the manifests need a
+short line; truncating a paragraph is neither.
+
+**1.5 Light theme: the cards barely exist, and the art is a black brick on
+paper.** `src/catalog/Catalog.tsx:65` gives the card `bg-ground-raised` (`#fff`)
+and `border-line` (`parchment-300`, `#dcd2f5`) over a `parchment-100` ground —
+about 1.06:1 between card and page. Meanwhile `--dw-art-void` stays
+`basalt-800` in both themes by design (`src/design/tokens.css:248`), so each
+card is a near-black square sitting on white with almost no card edge around it.
+In `light/packs-1440.png` the art reads as the object and the card reads as
+nothing.
+
+**1.6 The "All" chip is 42.1 × 44 px.** Measured on all 20 catalogue captures.
+`src/catalog/Catalog.tsx:234` sets `min-h-11` and `px-3` but no minimum width,
+and "All" is a short word. Below the 44 px floor on the axis it is thinnest, and
+it is the control that clears the filter.
+
+**1.7 The wordmark link is 220.3 × 43.2 px.** Measured on all 70 shell captures.
+`src/app/Shell.tsx:40-46` — 0.8 px under the floor, and it is the "go home"
+control. Fixed by the lintel padding, not by the link.
+
+**1.8 `resting` reads as nothing at all.** The seed marks one pack as rested;
+its card differs from its neighbours by one word ("Tomorrow" instead of "Play")
+in 11 px muted type. The design intent — "not a lock and never drawn as one" —
+is honoured, but the fact is now invisible. See `dark/packs-full-390.png`.
+
+---
+
+## 2. Progress (`/progress`)
+
+Files: `src/shell/surfaces.ts:275-298`, `src/world/Screen.tsx`,
+`src/shell/Surface.tsx:168-174`.
+
+**2.1 A grey slab under the drawing.** `src/world/Screen.tsx:71-77` draws the
+"sill" as a rect of height 1 in a small viewBox that is then scaled to the
+container width, so it renders as a ~10 px bar in `--dw-line-strong` —
+`stone-600` `#5b5175` in dark. Against a violet field it reads as flat grey and
+looks like an unstyled element, not a sill. Plainly visible in
+`dark/progress-390.png`.
+
+**2.2 The screen is 45% used at 390 and 25% used at 1440.** Two numbers and one
+`max-w-sm` drawing (`src/shell/Surface.tsx:171`). At 1440 the drawing is 384 px
+wide in a 1440 px viewport. This is the destination a child visits to feel
+something about their own work, and it is the emptiest screen in the app.
+
+**2.3 The two numbers are for a parent, not a child.** "Answered 1284 / Correct
+1102" (`src/shell/surfaces.ts:292-293`) — no rate, no streak, no sense of
+having built anything, and the number that matters (1102/1284 = 86%) is left for
+the reader to compute. Against the anti-goal ("a public school teacher crashing
+out telling everyone to work on their worksheet") this is the screen closest to
+the failure mode.
+
+**2.4 The second rosette reads as broken.** Half the apertures are ghost
+outlines at `--dw-line-strong` 0.3 (`src/world/Screen.tsx:23`), which at this
+scale looks like a rendering fault rather than "not yet cut".
+
+---
+
+## 3. Profiles (`/profiles`)
+
+Files: `src/shell/Surface.tsx:123-158`, `src/shell/surfaces.ts:308-340`.
+
+**3.1 "Remove" deletes a child's entire record with one tap, no confirmation.**
+`src/shell/Surface.tsx:147-155` calls `remove` directly. Two rows away, in
+Parents, "Erase everything" is a deliberate two-press armed control
+(`src/shell/surfaces.ts:409-417`). The less-destructive action is guarded and
+the per-child one is not. It is also the smallest, reddest thing on the row and
+sits 12 px from "Use".
+
+**3.2 The name field does not look editable, and its underline is ragged.**
+`src/shell/Surface.tsx:136` — `border-b` only, `bg-transparent`, and the input
+is `flex-1`, so its width depends on which siblings are present. In
+`light/profiles-390.png` the current learner's underline runs from x≈38 to 294
+and the other two from x≈16 to 231: three different lengths, two different left
+edges. Nothing signals "you may type here".
+
+**3.3 The current learner's row is indented.** See 0.3 — `dark`/`light`
+`profiles-390.png` both show it.
+
+**3.4 The screen is 22% used at 390, 10% at 1440.** Three rows and a button.
+
+---
+
+## 4. Settings (`/settings`)
+
+Files: `src/shell/Surface.tsx:63-95`, `src/shell/surfaces.ts:342-394`.
+
+**4.1 Every control on the screen is inverted.** See 0.2. Six of them.
+
+**4.2 The rhythm of a choice row does not match the rhythm of a fact row.**
+`Fact` is `min-h-16 items-center py-3` — label and value on one optically centred
+line (`src/shell/Surface.tsx:46`). `Choice` is `min-h-16 py-3` with a legend at
+`mb-2` and then the control (`:70-72`), which makes the row ~120 px with 8 px
+between the legend and the control and 12 px between the control and the rule
+below it. In `light/settings-1440.png` the rule for the next row sits 6 px under
+the previous control while the label sits 24 px above its own. Two spacing
+systems, alternating down the screen.
+
+**4.3 Segment width is huge and the label is tiny.** At 1440 each segment is
+224 px wide holding a 14 px word (`light/settings-1440.png`). At 390 the
+three-way controls are fine; the two-way ones give 175 px to the word "On".
+Nothing caps the control's width — `src/shell/Surface.tsx:72` is a plain flex row
+at the full 42 rem measure.
+
+**4.4 "Reduce motion" is phrased as a setting whose On means less.** The row
+reads "Reduce motion / Off | On" (`src/shell/surfaces.ts:357-359`), so the state
+a parent wants is double-negative. Every other switch on the screen is a
+positive.
+
+**4.5 At 1024 × 768 the last row is below the fold.** See 0.9.
+
+---
+
+## 5. Parents (`/parents`)
+
+Files: `src/shell/surfaces.ts:396-470`, `src/shell/Surface.tsx:97-112`.
+
+**5.1 "Erase everything" fails AA in light theme (4.45:1).** See 0.6.
+
+**5.2 The destructive control has no frame, no confirmation affordance, and is
+indented.** `src/shell/Surface.tsx:99-110` draws it as a borderless full-width
+text button. In `light/parents-1440.png` it is a red serif phrase floating in
+white space, 44 px right of every label above it, with nothing to say it is the
+most consequential control in the app. Arming it replaces the label in place —
+correct, and worth keeping — but nothing before the first press signals weight.
+
+**5.3 Developer mode rows overflow into two-line label / two-line value.**
+`dark/parents-dev-390.png`: "core:app:allow-version" wraps to two lines on the
+left while "@tauri-apps/api/app.getVersion" wraps to two on the right, producing
+a 120 px row with a ragged gutter. It no longer breaks the page (fixed, and
+verified), but it is the ugliest block in the app and it is what a developer
+looks at most.
+
+**5.4 The screen is 42% used at 390, 20% at 1440.**
+
+---
+
+## 6. The pass sheet and the parental gate
+
+Files: `src/pass/PassSheet.tsx`. Captured through `tools/harness/`, because the
+sheet **cannot currently be reached in the shipped app at all**: `Stage` only
+mounts it when `usePass.mayOpen()` is false (`src/packs/Stage.tsx:100`), which
+routes through `canOpen` (`src/pass/model.ts:206`) and returns `true`
+unconditionally while `billing().wired` is false — and nothing in `src/` ever
+calls `setBilling`. This is deliberate for today, but it means three screens are
+shipping unlooked-at. That is what the harness is for.
+
+**6.1 The dialog does not read as a raised sheet in dark theme.**
+`src/pass/PassSheet.tsx:51` overlays `bg-ground-deep/85`, and `:56` gives the
+panel `bg-ground`. In dark those are `basalt-950` `#060310` and `basalt-800`
+`#0b0618` — 1.13:1. The only thing separating the panel from the backdrop is a
+1 px `border-line-strong`. See `dark/pass-rest-390.png`, where the panel edge is
+nearly invisible and the sheet reads as text floating on black.
+
+**6.2 The two cheaper plates do not read as buttons.**
+`src/pass/PassSheet.tsx:227` gives the non-headline plates `border-line-cut`,
+which in dark is `basalt-950` (`src/design/tokens.css:362`) — darker than the
+panel they sit on, so the border is invisible. In `dark/pass-offer-390.png`
+"One month" and "Day pass" are unbounded text with a price beside them; only the
+gold-framed lifetime plate looks pressable. On the one screen where a parent
+spends money, two of the three options do not look like options.
+
+**6.3 Three type families collide in one row.** The plate name is
+`--font-inscription` (Iowan Old Style), the note is `--font-text` (system UI),
+and the price is `--font-numeral` (`ui-rounded` / SF Pro Rounded,
+`src/design/tokens.css:39`). "$79.99" in a rounded grotesque beside "Lifetime"
+in an old-style serif looks like two different products
+(`src/pass/PassSheet.tsx:241-247`).
+
+**6.4 Nothing aligns vertically in a plate.** `src/pass/PassSheet.tsx:221` —
+`items-center` on a row whose left side is two lines and whose right side is one,
+so the price floats between the name and the note rather than sharing a baseline
+with either.
+
+**6.5 Two underlined text links.** "Grown-ups" (`:109`) and "Restore a pass"
+(`:349`) are `underline underline-offset-4`. An underlined inline link is a web
+idiom; native sheets use a tinted control. On the child-facing stage,
+"Grown-ups" being the only underlined thing on screen also makes it more
+conspicuous than intended.
+
+**6.6 A focus ring appears on the child-facing screen — verify on device.**
+`src/pass/PassSheet.tsx:82` calls `leave.current?.focus()` on mount, and
+`src/index.css:92` draws a 2 px `--dw-focus` outline on `:focus-visible`. In
+`dark/pass-rest-390.png` the "Choose another game" button is captured **with the
+ring already on**, because Chrome matches `:focus-visible` for programmatic
+focus when there has been no prior user interaction. On a tablet where the sheet
+opens after a touch the heuristic should suppress it, but "a focus ring that
+appears on touch" is a named defect and this is the one place in the app that
+moves focus programmatically. Needs a WKWebView check; the safe form is to focus
+the dialog container rather than the button.
+
+**6.7 The child-facing stage is the least joyful screen in the app.** A dark
+rectangle, two serif sentences and a bordered word. `dark/pass-rest-390.png`.
+It is honest copy and correct policy — no timer, no price, no loss framing — but
+nothing about it makes a seven-year-old want to press "Choose another game".
+
+**6.8 The gate's answer field is 16 px+ and typed in caps.** Correct, and worth
+recording as verified: `src/pass/PassSheet.tsx:174` is `min-h-16 text-2xl`, no
+iOS zoom-on-focus risk, `autoCapitalize="characters"` matches the challenge.
+
+---
+
+## 7. Navigation and lintel (every screen)
+
+**7.1 The active tab is carried by a 8 × 8 px diamond and a small ink shift.**
+`src/app/Nav.tsx:48-50`. At 1440 that is an 8 px mark above a 12 px word in a
+288 px cell (`light/parents-1440.png`). Target size is fine (`min-h-14`, 56 px);
+legibility of the *current* state is not.
+
+**7.2 The tab labels are 12 px serif with `tracking-wide`.**
+`src/app/Nav.tsx:51`. Small for a child, and the serif at 12 px is where this
+typeface is weakest.
+
+**7.3 The nav has no elevation relationship to the content it scrolls over.**
+`src/app/Nav.tsx:28` is `sticky bottom-0` with `bg-ground-raised` and the
+strapwork band above it. While the catalogue scrolls under it, card art passes
+behind an opaque bar with a gold ribbon on top and no shadow, blur or scrim —
+see the clipped CLAIM/COLOSSUS cards in `dark/packs-390.png`.
+
+---
+
+## Measured summary
+
+| check | result |
+|---|---|
+| horizontal page overflow | 0 px on all 100 captures ✓ |
+| boxes that scroll sideways | 1 — the subject-chip row, 440 px at 390 px wide |
+| painted scrollbar tracks | `body` on all screens, chip row on `packs` at 390/430 |
+| interactive targets < 44 px | 2 distinct — wordmark link 220.3 × 43.2, "All" chip 42.1 × 44 |
+| text/ground pairs measured | 22 distinct |
+| AA failures | 2, both `--dw-strike` on light ground, both 4.45:1 (need 4.5) |
+| capture failures | 0 |
+
+## The three to fix first
+
+1. **§0.1** — the gold strapwork, twice per screen, ~120 warm points against a
+   rule of one. It is the first thing seen on every screen and the brand rule it
+   breaks is explicit.
+2. **§0.2** — every segmented control in the app draws the selected option as a
+   recess and the unselected ones as raised keys. Six on Settings, two on
+   Parents, the chip row on Packs.
+3. **§0.8** — desktop and large tablet: full-bleed lintel, 1152 px surface,
+   672 px courses and a full-bleed five-cell tab bar, with 80% of a 1440 × 900
+   screen empty.


### PR DESCRIPTION
## What

Foundation half of the overnight harness pass: design tokens, base layer, and
`tools/capture.mjs`. Components follow in a stacked PR.

**Split deliberately.** The whole pass is ~250 KB of diff and
`adversarial-review` truncates at 200 KB — past which no lens sees the code and
the check can still report green. Two PRs under the limit beat one that is
reviewed by half.

## Why

**The instrument.** `tools/capture.mjs` boots the app with the 27 real packs
seeded and writes every screen × 5 widths × both themes, plus a measurements
file of overflow, touch-target sizes and rendered contrast. "Check every screen
at every size" is not something anyone does twice by hand.

It also encodes a trap that cost an hour: **headless Chrome clamps its viewport
to 500px**, so `--window-size=390` renders at 500 and crops — which looks
exactly like a mobile layout bug that is not there. Narrow widths are captured
through an iframe over http.

**The system**, replacing a palette:
- 8-step spacing scale published as role tokens
- 5-rung elevation ladder, every umbra **violet not grey** — a grey shadow on a
  violet ground is the tell of a default
- asymmetric motion (press 90ms decelerating, enter 260ms, exit 160ms) that
  collapses to 0 under `prefers-reduced-motion` **including the displacement**,
  because a 0ms transition into a moved position is still a jump
- 9-step type scale, each step carrying its own line-height and tracking

**Two things flagged earlier and deferred are closed:**
- `--dw-strike` leaves the pre-purple copper ramp for a rose drawn from the
  catalogue's own colour arc. Danger in a colour the app already contains — and
  **4.45 (failing) → 6.39** in light.
- The strapwork band stops being warm. It painted ~60 apex-coloured knots per
  row against a brand rule of *one warm point per screen*, and in light resolved
  to `brass-700` #b45309 — the explicitly-dead sandstorm red-brown.

**Light mode** was an afterthought. `--dw-line` was **1.16:1** on white — a rule
you cannot see.

## Blast radius

- [x] Tokens, base layer and a dev-only tool. No component changed here.
- [x] Every existing token NAME kept; values changed, names not, so nothing
      downstream breaks.
- [x] **Verified standalone**: on this commit alone, with the OLD components,
      tsc/lint/build clean and **238/238 tests pass**. CI will test it this way.
- [x] Corpán untouched. `dynawalla/games` and `dynawalla/packs` untouched —
      another agent owns those.
- [x] Capture PNGs (~9 MB/run) and the per-agent write-ups are gitignored; the
      tool, the harness and `AUDIT.md` are committed.

## Proof

```
npm run tsc     clean
npm test        tests 238 / pass 238 / fail 0
npm run build   ✓ built in 150ms
```

Contrast is measured, not asserted — the full table is in `tokens.css`. 100
screenshots reviewed; findings in `tools/shots/AUDIT.md`.