### PR TITLE
feat(dynawalla): the harness applies the system

### DIFF
--- a/dynawalla/docs/HARNESS_FEEDBACK.md
+++ b/dynawalla/docs/HARNESS_FEEDBACK.md
@@ -73,13 +73,91 @@ pressing hard on a card got a text-selection handle over the label. `user-select
 none` on `body`, with `input`, `textarea` and `[contenteditable]` opting back in
 so a parent can still edit a name they typed.
 
+### "Erase everything" was coral — 2026-07-29
+
+Was: `--dw-strike` came off the copper ramp, a leftover from the pre-purple
+palette, and a bare coral phrase floated in white space with nothing around it
+to say it was the most consequential control in the app.
+
+Fixed, and the decision was taken rather than drifted into. The strike ramp is
+now **rose**, and its hue is the arc's own rose end (`--color-arc-11`, hue 348°)
+— danger drawn in a colour the app already contains rather than a fifth family.
+It is three tokens, not one: `--dw-strike` (the word), `--dw-strike-line` (the
+frame it is bounded by) and `--dw-strike-ground` (the wash it fills with once
+armed), so the control is a bounded plate that visibly changes state before the
+press that actually erases. Light measures 6.39:1, up from copper's 4.45:1.
+
+The plate's resting border is `--dw-line-strong`, not `--dw-line`: at
+`--dw-line` it was the same rgb as the hairline between two ordinary rows, so
+"bounded" was true in dark and not in light.
+
+The same hue reached Profiles' three "Remove" buttons and put three crimson
+words down one screen. It should not have: at rest that control is now the muted
+ink and only becomes rose when it is armed and a second press would really
+remove a child. Danger is a state, not a decoration.
+
+### The strapwork band was gold, and there were two of them — 2026-07-29
+
+Was: the interlace band paints one knot every 24 px in `--dw-index`, and it ran
+under the lintel AND above the tab bar. A 1440 px screen carried about a hundred
+and twenty gold knots against a brand rule of ONE warm point per screen, and in
+light `--dw-index` resolved to `brass-700`, a red-brown that read as exactly the
+"dusty khaki sandstorm" the brand explicitly kills.
+
+Fixed in two steps:
+
+1. **The band is cool.** `--dw-band-strap` / `--dw-band-knot` are the app's own
+   violet, read directly by `Strapwork.tsx`. The warm point moved to the one
+   place a gold mark earns its keep — the navigation index that says which
+   destination you are on. Light `--dw-index` is now `brass-800` (hue 42°,
+   struck gold, 5.61:1), not `brass-700` (hue 30°, terracotta).
+2. **There is one band, not two.** Cool or not, a repeating interlace at both
+   edges of every screen framed the whole app in ornament, at the two places the
+   eye returns to most. The band is the brand's al-Andalus reference and it is
+   worth having once, as the carved course under the wordmark. At the bottom of
+   the screen the bar's own material and its upward cast are the edge — which is
+   quieter, and is what a tab bar looks like.
+
+### The tab bar cut its own labels — 2026-07-29
+
+Not reported; found by measuring the shipped app at the text sizes it ships. At
+390 px on the app's own **Largest** setting, four of the five destination names
+clipped to "Prog…", "Profi…", "Setti…", "Pare…"; at 320 px it happened at the
+DEFAULT size. That is WCAG 1.4.4 failing at 125%, not at 200%.
+
+Two causes, both fixed. The anchors carried a horizontal margin, so they did not
+tile the bar — 8 px of dead gutter between every pair of tabs, 20 px dead at each
+end, and 8 px stolen from the word. And a fifth of a 320 px screen is 60 px,
+which no fix to padding alone reaches.
+
+So each tab cell is now a container and the label's size is capped against the
+cell's own inline size (`min(step, 21cqi)`), which is what a native tab bar does:
+the label shrinks to fit and is never cut. At every ordinary width the cap is
+inert. Verified at 320 / 390 / 430 / 834 / 1024 / 1440 × normal and Largest:
+zero clipped labels.
+
+### Everything on a screen started at a different x — 2026-07-29
+
+At 1440 the wordmark began at 160, the catalogue cards at 160, the rows on the
+other four screens at 384 and the tab labels at 388 — and Parents used about a
+fifth of the glass. Four origins on one app.
+
+The rule is now one sentence: **the chrome is always the frame, and the only
+thing ever narrower than the frame is a column of prose.** The tab bar sits in
+`dw-frame`; a course of rows is a list, not prose, so it takes the frame too;
+above 64 rem the courses lay out in two columns inside it. Measured at every
+width, on every destination, the wordmark, the first row, the first card and the
+first tab all begin at the same x.
+
 ## Noted, not yet acted on
 
-- **"Erase everything" is coral** (`--dw-strike`, from the copper ramp) against a
-  violet ground. Semantically a destructive action should read as danger, but the
-  hue is the one leftover from the pre-purple palette and sits oddly. Worth a
-  deliberate decision rather than a drive-by change.
-- **The strapwork bands** at the top and bottom of the chrome carry the gold
-  index colour across the full width. The brand rule in
-  [`../brand/README.md`](../brand/README.md) is *one warm point per screen*;
-  a repeating full-width band is arguably two.
+- **Progress says how many, never how well.** "Answered 1284 / Correct 1102" is
+  two counts with no rate, no streak and no sense of a day. The drawing beside
+  them was re-inked this pass (it was a white card with two solid black rosettes
+  in a violet brand) but the numbers are unchanged. Adding a rate is new copy and
+  a small model change, not a design fix, so it is left for a deliberate call.
+- **The pass sheet cannot be reached in the shipped app.** `pass/model.ts` opens
+  unconditionally while `billing().wired` is false and nothing calls
+  `setBilling`, so there is no sequence of taps on a device that puts the sheet
+  on screen. It is verified only in `tools/harness/`. Wiring billing is not a
+  design change.

--- a/dynawalla/dynawalla-app/src/app/Nav.tsx
+++ b/dynawalla/dynawalla-app/src/app/Nav.tsx
@@ -1,7 +1,6 @@
 import { NavLink } from "react-router"
 
 import { IndexMark } from "../design/IndexMark.tsx"
-import { Strapwork } from "../design/Strapwork.tsx"
 import { DESTINATIONS, destinationPath, ROUTE_PATHS } from "./routes.ts"
 import { strings } from "./strings.ts"
 
@@ -15,48 +14,121 @@ import { strings } from "./strings.ts"
  *
  * Not a hamburger, not a drawer, and nothing that opens: every destination is
  * on screen at all times, so where you can go is never a thing you have to
- * discover. Five is the number the shell has, and it fits: at 320 px each tab
- * is 64 px wide, and the whole bar is one row of inscribed words with a brass
- * index over the one you are on.
+ * discover.
  *
+ * ── What makes it read as a tab bar rather than a row of links ────────────
+ *
+ * **It casts up.** `dw-bar` is the one rung in the ladder whose shadow points
+ * at the ceiling, because a bar the content scrolls UNDER has to be over it.
+ * Before this the catalogue's cards passed behind an opaque strip with no
+ * shadow, no scrim and no blur, and the whole bar read as the bottom of the
+ * page rather than as something above it. In dark that cast is invisible on a
+ * near-black ground — measured, it moves the pixels above the bar by one unit
+ * — so there the bar is separated by its own lighter stone and by a lit top
+ * edge, which is what every dark tab bar does.
+ *
+ * **It carries no ornament.** A strapwork band used to run above these tabs as
+ * well as under the lintel, so every screen in the app was framed top and
+ * bottom by the same repeating interlace — about ninety-six knots on a wide
+ * screen, at the two edges the eye returns to most. The band is the brand's
+ * al-Andalus reference and it is worth having; it is worth having ONCE, as the
+ * carved course under the wordmark. At the bottom of the screen the material
+ * and the cast are the edge, which is both quieter and more like a bar.
+ *
+ * **The current tab is a seat, not a tint.** Three signals carry it and no one
+ * of them alone: a lit ground the tab sits in, the label at full ink, and the
+ * brass index above it — the app's one warm point, spent here because saying
+ * where you are is the only thing on a screen worth spending it on. The index
+ * keeps its space when it is not shown, so nothing moves when the tab changes.
  * `aria-current="page"` comes from `NavLink` itself, so the state is in the
- * markup as well as in the mark — the current destination is never carried by
- * the index alone.
+ * markup too and is never carried by the drawing alone.
+ *
+ * **It aligns with the chrome.** Full-bleed, five equal cells across 1440 px
+ * put the tab labels on a third x-axis, next to a full-bleed lintel and a
+ * centred column of content. The bar's material still runs edge to edge — an
+ * edge that stops is not an edge — but the tabs inside it sit in `dw-frame`,
+ * which is the same box the wordmark and the catalogue grid sit in. The rule
+ * is now statable in one line: **the chrome is always the frame**, and the
+ * only thing that is ever narrower than the frame is a column of prose.
+ * Measured at 1440 the wordmark, the first card and the first tab all begin at
+ * x = 160; before this they began at 160, 160 and 388.
+ *
+ * **The tabs tile the bar.** Each anchor fills its cell edge to edge. It used
+ * to carry `mx-[--dw-space-1]`, which left an 8 px dead gutter between every
+ * pair of tabs and 20 px dead at each end — a child aiming at the seam between
+ * Progress and Profiles hit nothing at all — and it stole the 8 px the label
+ * needed at the accessibility text sizes.
+ *
+ * **The label never truncates.** Five equal cells on a 320 px phone give a
+ * word 60 px, and "Progress" at the app's own Largest text size wants 59 of
+ * them before padding — so four of the five labels used to clip to "Prog…",
+ * "Profi…", "Setti…", "Pare…", which is WCAG 1.4.4 failing at 125% rather than
+ * at 200%. `.dw-tab` makes each cell a container and the label's size is
+ * capped against the cell's own width, which is what a native tab bar does:
+ * the label shrinks to fit and is never cut. At every normal width the cap is
+ * inert and the label is the type scale's own step.
  */
 export function Nav() {
   return (
-    <nav className="bg-ground-raised sticky bottom-0">
-      <Strapwork />
-      <ul className="flex pb-[var(--safe-bottom)]">
-        {DESTINATIONS.map((destination) => (
-          <li key={destination} className="min-w-0 flex-1">
-            <NavLink
-              to={destinationPath(destination)}
-              // The front door is `/`, which prefix-matches every other route:
-              // without `end` every tab would light at once, on every screen.
-              end={ROUTE_PATHS[destination] === "/"}
-              className={({ isActive }) =>
-                [
-                  "flex min-h-14 flex-col items-center justify-center gap-1 px-1 py-2",
-                  "transition-colors duration-[var(--dw-motion-quick)]",
-                  isActive ? "text-ink" : "text-ink-muted",
-                ].join(" ")
-              }
-            >
-              {({ isActive }) => (
-                <>
-                  <IndexMark
-                    className={isActive ? "text-index" : "text-index opacity-0"}
-                  />
-                  <span className="inscription w-full truncate text-center text-xs tracking-wide">
-                    {strings.destinations[destination]}
-                  </span>
-                </>
-              )}
-            </NavLink>
-          </li>
-        ))}
-      </ul>
+    // Below the stage's `z-50`: a running pack takes the whole window,
+    // navigation included. `--z-sticky` is 1001 and would put the tab bar over
+    // a game.
+    <nav className="dw-bar sticky bottom-0 z-30">
+      <div className="dw-frame">
+        {/* A floor under the safe-area inset, not the inset alone: a desktop
+            window and an Android device with gesture navigation both report
+            zero, and the tabs then sit hard on the bottom edge of the glass. */}
+        <ul className="flex w-full pt-[var(--dw-space-2)] pb-[max(var(--safe-bottom),var(--dw-space-2))]">
+          {DESTINATIONS.map((destination) => (
+            <li key={destination} className="dw-tab min-w-0 flex-1">
+              <NavLink
+                to={destinationPath(destination)}
+                // The front door is `/`, which prefix-matches every other route:
+                // without `end` every tab would light at once, on every screen.
+                end={ROUTE_PATHS[destination] === "/"}
+                className={({ isActive }) =>
+                  [
+                    "dw-press rounded-cut-lg flex w-full",
+                    "min-h-target-comfort flex-col items-center justify-center",
+                    "gap-[var(--dw-space-1)] px-[var(--dw-space-1)] py-[var(--dw-space-2)]",
+                    // A wash of the accent, deeper in dark because a dark
+                    // ground swallows one: measured, the seat stands 1.22:1
+                    // off the bar in light and needs 18% rather than 12% to
+                    // reach 1.24:1 in dark. It is a SHAPE cue and does not
+                    // have to clear 3:1 — the diamond above it is the graphic
+                    // that says which tab this is, at 5.14:1 light and
+                    // 11.36:1 dark, and `aria-current` says it in the markup.
+                    //
+                    // A token, not an opacity utility. Tailwind compiles
+                    // `accent` at twelve percent to `color-mix` guarded by
+                    // `@supports`, and emits a FULLY OPAQUE bare fallback
+                    // outside the guard. Below Safari 16.2 — this bundle's
+                    // floor is 16.0 — the seat painted as a solid violet plate
+                    // under dark ink. (Do not write the utility's name in this
+                    // file even in prose: Tailwind extracts candidates from the
+                    // raw text and would emit the dead rule again.)
+                    isActive ? "bg-accent-seat text-ink" : "text-ink-muted",
+                  ].join(" ")
+                }
+              >
+                {({ isActive }) => (
+                  <>
+                    {/* Space reserved, never inserted. An 8 px mark and its gap
+                        appearing in flow shifts the label under the finger that
+                        just chose it. */}
+                    <IndexMark
+                      className={`text-index h-2.5 w-2.5 shrink-0 ${isActive ? "" : "opacity-0"}`}
+                    />
+                    <span className="dw-tab-label inscription w-full text-center">
+                      {strings.destinations[destination]}
+                    </span>
+                  </>
+                )}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </div>
     </nav>
   )
 }

--- a/dynawalla/dynawalla-app/src/app/Shell.tsx
+++ b/dynawalla/dynawalla-app/src/app/Shell.tsx
@@ -1,4 +1,5 @@
-import { Link, Outlet } from "react-router"
+import { useEffect } from "react"
+import { Link, Outlet, useLocation } from "react-router"
 
 import { Mark } from "../design/Mark.tsx"
 import { Strapwork } from "../design/Strapwork.tsx"
@@ -16,13 +17,33 @@ import { strings } from "./strings.ts"
  *
  * This is where the brand lives — here and in the artwork on the cards, never
  * in the shape of a card. The mark takes `currentColor` from the wordmark
- * beside it, which is the brand rule made structural: white or black ink, and
- * no coloured wash of the mark, ever.
+ * beside it, which is what a lockup is: one object in one ink, not an emblem
+ * tinted independently of the word it belongs to.
+ *
+ * That is a rule about THIS lockup and not about the mark everywhere.
+ * `brand/README.md` says only that the mark "recolours from `currentColor`",
+ * and the governing rule is one warm point per screen — which is why the pass
+ * sheet, a surface with no wordmark and no tab bar on it, is allowed to spend
+ * its one warm point on the mark itself. An earlier version of this comment
+ * read "no coloured wash of the mark, ever" and directly contradicted
+ * `PassSheet.tsx`; two files stating opposite rules about the same asset is
+ * how a future pass picks the wrong one.
+ *
+ * It is `sticky`, because a title bar that scrolls away is a page and one that
+ * stays is an app. `dw-frame` is what puts the wordmark on the same left edge
+ * as the writing below it: full-bleed, the mark sat at x = 16 on a 1440 px
+ * screen while the content began at 384, so the two most permanent things on
+ * the screen disagreed about where the screen started.
  */
 function Lintel() {
   return (
-    <header className="bg-ground-raised">
-      <div className="flex items-center px-[max(var(--safe-left),1rem)] pt-[max(var(--safe-top),var(--dw-lintel-pad))] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-lintel-pad)]">
+    // Below the stage's `z-50`, for the same reason as the navigation.
+    // The lintel casts DOWN, which is the other half of making it sticky:
+    // without it the band is a rule the content happens to pass, and with it
+    // the content is underneath. (`shadow-surface` and not `dw-surface`: the
+    // rung's hairline border would draw a second edge right beneath the band.)
+    <header className="bg-ground-raised shadow-surface sticky top-0 z-30">
+      <div className="dw-frame flex items-center pt-[max(var(--safe-top),var(--dw-lintel-pad))] pb-lintel">
         {/* The mark sits on the wordmark's baseline and stands taller than the
             letters, rather than being centred against them at their own height.
             Centring a 28px emblem on 18px uppercase left it looking like a
@@ -36,10 +57,14 @@ function Lintel() {
 
             0.16em is measured, not guessed — rendered against this stylesheet
             at 0, 0.10, 0.16 and 0.22em and compared. An SVG has no baseline of
-            its own, so `items-baseline` cannot do this job. */}
+            its own, so `items-baseline` cannot do this job.
+
+            The lockup is 43.2 px tall and this is a link, so it was the one
+            control in the chrome under the 44 px floor. `min-h` raises the box
+            without moving the letters, which `items-end` guarantees. */}
         <Link
           to="/"
-          className="inscription rounded-cut-sm text-ink flex items-end gap-3 text-lg tracking-[0.22em] uppercase"
+          className="inscription dw-wordmark rounded-cut-sm text-ink flex min-h-target items-end gap-3 text-lg"
         >
           <Mark className="mb-[0.16em] h-10 w-10 shrink-0" />
           <span className="leading-none">{strings.appName}</span>
@@ -59,18 +84,44 @@ function Lintel() {
  * one, without a fixed position that would sit over the last row of a list.
  */
 export function Shell() {
+  const { pathname } = useLocation()
+
+  // A tab bar that leaves you halfway down the next screen is the web
+  // underneath showing through: the document kept its scroll offset because
+  // nothing told it the place had changed.
+  //
+  // BOTH boxes, and this is measured rather than defensive. `overflow-x:
+  // hidden` on `html, body` promotes overflow-y to `auto` on BODY, so **body**
+  // is this app's scrolling box — while `document.scrollingElement` and
+  // `window.scrollTo` both address `documentElement`, which does not move.
+  // Written the obvious way this line is a silent no-op on every device.
+  // Assignment rather than `scrollTo` because the latter is an unimplemented
+  // stub that warns under the test runner's DOM.
+  useEffect(() => {
+    document.documentElement.scrollTop = 0
+    document.body.scrollTop = 0
+  }, [pathname])
+
   return (
     <div className="bg-ground text-ink flex min-h-full flex-col">
       <Lintel />
       {/* `--dw-surface-pad` rather than a literal: on a short viewport every
           band of vertical space is spoken for, and the frame's own padding is
           part of that budget (see the vertical scale in `tokens.css`). */}
-      {/* The frame is the catalogue's measure, not a reading measure: a grid of
+      {/* `dw-frame` is the catalogue's measure, not a reading measure: a grid of
           game cards wants every column a desktop will give it. The courses of
           rows on the other four screens set their own 42 rem measure inside
           this, in `Surface.tsx`, so nothing that is read runs the full width. */}
-      <main className="mx-auto w-full max-w-6xl flex-1 px-[max(var(--safe-left),1rem)] pt-[var(--dw-surface-pad)] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-surface-pad)]">
-        <Outlet />
+      <main className="dw-frame py-surface flex-1">
+        {/* Keyed by path, so a destination is a thing that ARRIVES rather than
+            a thing that was suddenly always there. It rises the width of one
+            space token and settles on the emphasised-decelerate curve — the
+            direction says it came from under the tab that was just pressed.
+            Reduced motion collapses the duration AND the lift together; a 0 ms
+            transition into a displaced position is still a jump. */}
+        <div key={pathname} className="dw-anim-enter">
+          <Outlet />
+        </div>
       </main>
       <Nav />
       {/* The stage is a sibling of the chrome, not a child of the surface: a

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -61,6 +61,17 @@ export const strings = {
     find: "Find a game",
     /** The chip that clears the subject filter. Always first, always present. */
     all: "All",
+    /** The ✕ inside the search field. It empties the FIELD and nothing else.
+        It used to borrow `all` for its accessible name, so a screen reader
+        announced the ✕ as "All" — and it ran the same handler as the chip, so
+        pressing it also un-picked Fractions with nothing on screen to say so.
+        A control's label has to describe what the control does. */
+    clear: "Clear the search",
+    /** The way out of an empty result. This one DOES clear both, which is why
+        it is a different control with a different word: the empty state is
+        reachable from the field, from a chip, or from both at once, and a
+        child who cannot tell which needs one press that undoes all of it. */
+    showAll: "Show every game",
     /** Shown in place of the grid when a search matches no installed game. */
     nothing: "No game here matches that.",
     /** The band a game is written for, on its card. */
@@ -96,8 +107,17 @@ export const strings = {
     name: "Name",
     /** Make this the learner the app is for right now. */
     use: "Use",
+    /** Said in words, for the learner the app is set to. The index mark beside
+        it is a drawing and the "Use" button's absence is an absence, so
+        without this the single most consequential piece of state in the app
+        was carried entirely by things a screen reader cannot report. */
+    current: "Current",
     add: "Add a learner",
     remove: "Remove",
+    /** Armed. The same grammar the parent area's "Erase everything" uses: a
+        destructive control that has been armed says what the next press does,
+        rather than only changing colour. */
+    removeConfirm: "Press again",
   },
 
   settings: {

--- a/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
+++ b/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from "react"
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 
 import { fill, strings } from "../app/strings.ts"
 import type { Row } from "../shell/surfaces.ts"
@@ -19,6 +19,32 @@ function gradeLabel(grades: readonly [number, number] | null): string | null {
 }
 
 /**
+ * The "go" mark on a card, and the app's smallest piece of line art.
+ *
+ * Monoline from `currentColor`, like the mark in the lintel: the card says
+ * "Play", and this is the direction the word points. Purely decorative — the
+ * word beside it is the label, and a chevron that also announced itself would
+ * say it twice.
+ */
+function Chevron() {
+  return (
+    <svg
+      viewBox="0 0 8 12"
+      aria-hidden="true"
+      focusable="false"
+      className="h-3 w-2 shrink-0"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 1.5 L6.5 6 L2 10.5" />
+    </svg>
+  )
+}
+
+/**
  * One game, as a card.
  *
  * A familiar listing tile: square key art on top, the name, one line about it,
@@ -27,13 +53,25 @@ function gradeLabel(grades: readonly [number, number] | null): string | null {
  * of art plus a label, which clears the child-sized target floor several times
  * over.
  *
+ * **It is drawn as an object, not as a bordered rectangle.** `.dw-surface` is
+ * the elevation rung for a card and carries its background, its edge and its
+ * cast light together; before it, a light-theme card was white on near-white
+ * inside a rule at 1.06:1, so the near-black key art read as the object and
+ * the card read as nothing at all.
+ *
+ * **`.dw-press` is the whole of the press feedback**, and it is the reason a
+ * hover-only transform was wrong: on a phone there is no hover, so a tile that
+ * only answered a pointer answered a child not at all. The scale runs on the
+ * 90 ms press curve and the colour on the state curve — different events,
+ * different timings — and both collapse under reduced motion.
+ *
  * **`resting` is not a lock and is not drawn as one.** A game that already
  * reached its stopping point today keeps its full-strength artwork, its
- * full-strength name and its working control; the only difference is one word
- * in the small print, in the same type as the version. No padlock, no
- * "premium", no dimming, and it is not sorted to the bottom. What the press
- * opens is the sheet that says so, which is a fact about the child's day
- * rather than a price.
+ * full-strength name and its working control; the only difference is that the
+ * small print says "Tomorrow" in the muted ink rather than "Play" in the
+ * accent, and loses the chevron. No padlock, no "premium", no dimming, and it
+ * is not sorted to the bottom. What the press opens is the sheet that says so,
+ * which is a fact about the child's day rather than a price.
  */
 function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
   const grades = gradeLabel(row.grades)
@@ -60,19 +98,25 @@ function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
       className={[
         // `h-full` inside a stretched grid cell, with the small print pushed to
         // the bottom by `mt-auto`: every card in a row ends at the same line
-        // whatever its name and description did, which is what makes a grid
-        // read as a grid rather than as a ragged pile.
-        "group border-line bg-ground-raised rounded-cut-lg flex h-full w-full flex-col overflow-hidden border text-left",
-        "hover:border-line-strong focus-visible:border-line-strong",
-        "transition-colors duration-[var(--dw-motion-quick)]",
+        // whatever its name and description did. That was never sufficient on
+        // its own — see the reserved boxes in `catalog.css` — but it is still
+        // the floor under them.
+        "dw-press dw-surface rounded-cut-lg flex h-full w-full flex-col overflow-hidden text-left",
+        // Tailwind's `hover:` is already scoped to `(hover: hover)`, so this
+        // cannot become the stuck-hover tell on a tablet. The card rises a rung
+        // under a pointer; under a finger `.dw-press` scales it instead.
+        "hover:border-line-strong hover:shadow-raised focus-visible:border-line-strong",
       ].join(" ")}
     >
       <PackArt packId={row.id} className="aspect-square" />
-      <span className="flex flex-1 flex-col p-3">
+      <span className="p-inset flex flex-1 flex-col gap-1">
         {/* Clamped, never truncated. At the grid's narrowest column half these
             names are longer than the card — COUNTERPOISE, THE COIL OF
             NINETY-SIX — and one line with an ellipsis turns a listing of games
-            into a listing of prefixes. Two lines fits every name shipped.
+            into a listing of prefixes. Two lines fits every name shipped, and
+            `.dw-card-title` reserves both of them whether or not the name needs
+            the second, so the blurb under it starts at the same y on every card
+            in a row.
 
             No `block` on either of these: `line-clamp-*` works by setting
             `display: -webkit-box`, and a `block` utility beside it silently
@@ -84,6 +128,10 @@ function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
 
             15px, not 16px: at 16px COUNTERWEIGHT needs 152px and even a 10.5rem
             column offers 142px, so the one-word-too-wide case would still fire.
+            `.dw-caps` is deliberately NOT used here for the same reason — its
+            0.09em tracking adds about 13px to that word and puts it back over
+            the column — even though these names do arrive from the manifests
+            already in capitals.
 
             `hyphens-auto` is kept as a courtesy for real devices, but it is NOT
             load-bearing and must not be relied on — headless Chrome ships no
@@ -91,29 +139,103 @@ function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
             how a fix that "worked" was measured as still broken. `break-words`
             is the last resort that keeps a freak name inside its card rather
             than over the top of the next one. */}
-        <span className="inscription text-ink line-clamp-2 hyphens-auto text-[0.9375rem] tracking-wide break-words">
+        <span className="dw-card-title inscription text-ink line-clamp-2 hyphens-auto text-[0.9375rem] tracking-wide break-words">
           {row.name}
         </span>
-        {row.description.length > 0 ? (
-          <span className="text-ink-muted mt-1 line-clamp-2 text-xs">{row.description}</span>
-        ) : null}
-        <span className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-2">
-          {subjects.map((domain) => (
-            <span
-              key={domain}
-              className="border-line text-accent-ink rounded-cut-sm border px-1.5 py-0.5 text-[0.6875rem]"
-            >
-              {domainName(domain)}
-            </span>
-          ))}
-          {grades ? <span className="numeral text-ink-muted text-[0.6875rem]">{grades}</span> : null}
-          <span className="numeral text-ink-muted text-[0.6875rem]">
-            {row.resting ? strings.packs.tomorrow : strings.packs.play}
+        {/* Rendered whether or not there is a description. A card whose blurb is
+            missing keeps the same shape as the card beside it, which is what "a
+            grid reads as a grid" costs; every pack shipped has one, so in
+            practice the reserve is never blank. */}
+        <span className="dw-card-blurb text-ink-muted line-clamp-2 text-xs">
+          {row.description}
+        </span>
+        <span className="mt-auto flex flex-col gap-1 pt-2">
+          <span className="dw-card-subjects flex flex-wrap content-start items-start gap-1">
+            {subjects.map((domain) => (
+              <span
+                key={domain}
+                className="dw-card-chip border-line text-accent-ink rounded-cut-sm border px-1.5 text-xs"
+              >
+                {domainName(domain)}
+              </span>
+            ))}
+          </span>
+          {/* The band on the left, the control on the right, on one line at the
+              same height on every card. "Play" used to sit inside the same
+              muted run as the grade band, so the one word saying the tile does
+              anything was the least visible thing on it and read as part of a
+              metadata string. It is the accent now, and it points. */}
+          <span className="flex items-center justify-between gap-2">
+            <span className="numeral text-ink-muted text-xs">{grades ?? ""}</span>
+            {row.resting ? (
+              <span className="text-ink-muted text-xs">{strings.packs.tomorrow}</span>
+            ) : (
+              <span className="text-accent-ink flex items-center gap-1 text-xs">
+                {strings.packs.play}
+                <Chevron />
+              </span>
+            )}
           </span>
         </span>
       </span>
     </button>
   )
+}
+
+/**
+ * Which edges of a sideways-scrolling rail still have content beyond them.
+ *
+ * A permanent fade on both ends of a carousel is a decoration and says
+ * nothing. A fade that appears exactly where content passes under it, and is
+ * absent where the row has ended, is the signal every native carousel uses —
+ * and its absence is how you know you have reached the end. That cannot be
+ * done in CSS alone before scroll-driven animations, and this bundle's floor
+ * is iOS 16, so it is a dozen lines of measurement written onto the element as
+ * data attributes for `catalog.css` to react to. Never a `style` prop:
+ * `style-src 'self'` throws one away in the shipped build.
+ */
+function useRailEdges(signal: unknown) {
+  const rail = useRef<HTMLDivElement | null>(null)
+  const [edges, setEdges] = useState({ lead: false, trail: false })
+
+  const measure = useCallback(() => {
+    const box = rail.current
+    if (!box) return
+    const over = box.scrollWidth - box.clientWidth
+    // The rail carries a 4 px gutter so a chip's raised edge and its focus ring
+    // are not clipped, and `scroll-snap-type: x proximity` rests the browser
+    // AT the first chip's snap position — which is `scrollLeft: 4`, not 0.
+    // Measured live at both 390 and 834, untouched, on first paint. Against a
+    // flat `> 1` that lit the leading dissolve at rest and faded out the "All"
+    // chip: the selected chip lost its left border and its plate dissolved
+    // into the ground, on the front door, in both themes, before anyone had
+    // touched anything. The gutter is not content that continues, so the
+    // question is whether the rail has scrolled past its own first chip.
+    const gutter = (box.firstElementChild as HTMLElement | null)?.offsetLeft ?? 0
+    // A whole pixel of slack on top: sub-pixel layout leaves `scrollLeft` a
+    // fraction short of the end on a 2× screen, which would otherwise fade an
+    // edge that has nothing behind it, forever.
+    const lead = box.scrollLeft > gutter + 1
+    const trail = over - box.scrollLeft > 1
+    setEdges((was) => (was.lead === lead && was.trail === trail ? was : { lead, trail }))
+  }, [])
+
+  useEffect(() => {
+    const box = rail.current
+    if (box === null) return
+    measure()
+    // The box and its children both: the rail's own width changes on rotation,
+    // and the chips' widths change when the text-size setting does. Either one
+    // alone leaves the fade describing a layout that is no longer on screen.
+    const observer = new ResizeObserver(measure)
+    observer.observe(box)
+    for (const child of Array.from(box.children)) observer.observe(child)
+    return () => {
+      observer.disconnect()
+    }
+  }, [measure, signal])
+
+  return { rail, edges, measure }
 }
 
 /**
@@ -159,54 +281,226 @@ export function Catalog({ rows }: { rows: readonly PackRow[] }) {
   // must not leave the grid filtered by a chip that is no longer on screen.
   const active = subject !== null && chips.includes(subject) ? subject : null
 
+  const { rail, edges, measure } = useRailEdges(chips)
+
+  // Bring the chosen subject into view.
+  //
+  // Without this the rail is a control whose state you cannot see: filtering by
+  // Fractions on a 390 px phone leaves "All / Number sense / Addition &
+  // subtraction" on screen with none of them lit, because the chip that IS lit
+  // is 400 px off the right. Every native segmented rail reveals its selection;
+  // this reveals it to just clear of the edge dissolve rather than centring it,
+  // so a chip that is already comfortably visible does not move at all.
+  useEffect(() => {
+    const box = rail.current
+    if (box === null) return
+    const chosen = box.querySelector<HTMLElement>('[aria-pressed="true"]')
+    if (chosen === null) return
+    // `--dw-space-5`, which is the width of the dissolve in `catalog.css`. Read
+    // through the root font size rather than written as 24, so it stays correct
+    // when the accessibility text-size setting scales the root.
+    const clear = 1.5 * (parseFloat(getComputedStyle(document.documentElement).fontSize) || 16)
+    const start = chosen.offsetLeft - box.scrollLeft
+    const end = start + chosen.offsetWidth
+    let next = box.scrollLeft
+    if (start < clear) next = chosen.offsetLeft - clear
+    else if (end > box.clientWidth - clear)
+      next = chosen.offsetLeft + chosen.offsetWidth - box.clientWidth + clear
+    if (Math.abs(next - box.scrollLeft) < 1) return
+    // The CSS reduced-motion block forces `scroll-behavior: auto`, but a
+    // `behavior` passed to `scrollTo` is an argument rather than a computed
+    // style and wins over it — so the branch has to be taken here too. Both
+    // sources are asked, because the in-app switch exists for a child whose
+    // tablet belongs to somebody else.
+    const still =
+      document.documentElement.dataset["motion"] === "reduced" ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    box.scrollTo({ left: Math.max(0, next), behavior: still ? "auto" : "smooth" })
+  }, [rail, active])
+
+  const clearAll = () => {
+    setQuery("")
+    setSubject(null)
+  }
+
   return (
-    <section className="flex flex-col gap-[var(--dw-stack-gap-tight)]">
+    <section className="gap-stack-tight flex flex-col">
       <label htmlFor={searchId} className="sr-only">
         {strings.catalog.find}
       </label>
-      <input
-        id={searchId}
-        type="search"
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        placeholder={strings.catalog.find}
-        autoComplete="off"
-        autoCorrect="off"
-        spellCheck={false}
-        className={[
-          "border-line bg-ground-raised text-ink rounded-cut-md min-h-12 w-full border px-3 text-base",
-          "placeholder:text-ink-muted",
-        ].join(" ")}
-      />
+      {/* A search field is a recess, which is what every platform draws and
+          what the elevation ladder calls `.dw-sunk`. It used to be drawn a rung
+          ABOVE the page, so the one control on the screen that receives
+          something looked like the controls that do something.
+
+          The glyph and the clear control are inside the shell rather than
+          beside it, so the whole box is one object: a tap in the padding still
+          lands in the field, which is how a native search bar behaves and how a
+          child aims at one. */}
+      <div className="dw-find dw-sunk rounded-cut-md min-h-target-comfort flex items-center gap-2 px-3">
+        <svg
+          viewBox="0 0 20 20"
+          aria-hidden="true"
+          focusable="false"
+          className="text-ink-muted h-5 w-5 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        >
+          <circle cx="8.5" cy="8.5" r="5.5" />
+          <path d="M12.6 12.6 L17 17" />
+        </svg>
+        <input
+          id={searchId}
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={strings.catalog.find}
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="text-ink placeholder:text-ink-muted min-w-0 flex-1 self-stretch border-0 bg-transparent text-base"
+        />
+        {query.length > 0 ? (
+          // WebKit draws its own cancel button at about 14 px, off-palette and
+          // under a third of the touch floor; `catalog.css` suppresses it and
+          // this is the replacement, at 44.
+          <button
+            type="button"
+            // The field, and only the field. This used to run `clearAll` under
+            // the accessible name "All" — so a screen reader announced the ✕ as
+            // "All", and a parent who had filtered to Fractions and then tapped
+            // the ✕ silently lost the filter too, with nothing on screen to say
+            // it had gone.
+            onClick={() => {
+              setQuery("")
+            }}
+            aria-label={strings.catalog.clear}
+            className="dw-press text-ink-muted rounded-cut-sm -mr-2 flex h-target w-target shrink-0 items-center justify-center"
+          >
+            <svg
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+              focusable="false"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            >
+              <path d="M5 5 L15 15 M15 5 L5 15" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
 
       {chips.length > 1 ? (
-        // A scrolling row rather than a wrapping block: on a 320 px phone six
+        // A scrolling rail rather than a wrapping block: on a 320 px phone six
         // subjects wrap to three lines and push the first card off the screen,
         // and the first card is the whole point of the screen.
-        <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
-          <Chip label={strings.catalog.all} on={active === null} press={() => setSubject(null)} />
-          {chips.map((domain) => (
-            <Chip
-              key={domain}
-              label={domainName(domain)}
-              on={active === domain}
-              press={() => setSubject(active === domain ? null : domain)}
-            />
-          ))}
+        //
+        // Two elements, and the nesting is load-bearing: the OUTER one carries
+        // the edge dissolve, because Chrome sizes a mask on a scroll container
+        // against its scrollable overflow rather than against the box you can
+        // see — on one element the fade landed 450 px off the right of a phone
+        // and the rail clipped stone dead instead. The INNER one scrolls, with
+        // `.dw-scroll-x` for momentum, containment and proximity snapping and
+        // `.dw-rail` to take the bar away on EVERY pointer; a desktop was
+        // painting a horizontal channel between the search field and the grid.
+        <div
+          data-lead={edges.lead ? "on" : "off"}
+          data-trail={edges.trail ? "on" : "off"}
+          className="dw-subjects -mx-1"
+        >
+          <div ref={rail} onScroll={measure} className="dw-scroll-x dw-rail flex gap-2 px-1 pb-1">
+            <Chip label={strings.catalog.all} on={active === null} press={() => setSubject(null)} />
+            {chips.map((domain) => (
+              <Chip
+                key={domain}
+                label={domainName(domain)}
+                on={active === domain}
+                press={() => setSubject(active === domain ? null : domain)}
+              />
+            ))}
+          </div>
         </div>
       ) : null}
 
       {listed.length === 0 ? (
-        <p className="text-ink-muted py-8 text-center text-sm">{strings.catalog.nothing}</p>
+        /* Designed, not a fallback. A centred monoline aperture in the accent —
+           the same single stroke weight as the mark and as the key art — the
+           one line of prose the catalogue owns, and the way back. The way back
+           matters most: this state is reachable from the search field, from a
+           subject chip, or from both at once, and a child who cannot see which
+           one caused it needs one control that undoes all of them. */
+        <div className="dw-anim-fade gap-stack flex flex-col items-center py-8 text-center">
+          {/* An empty niche: the arch this app's mark is built on, cut twice
+              and with nothing standing in it. Sized to be seen on a desktop —
+              at 48px in a 1152px column it read as a stray glyph rather than
+              as the subject of the screen. */}
+          <svg
+            viewBox="0 0 48 48"
+            aria-hidden="true"
+            focusable="false"
+            className="text-accent h-16 w-16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M10 42 V24 C10 14 16 7 24 2 C32 7 38 14 38 24 V42" />
+            <path d="M5 42 H43" />
+            <path d="M16 42 V25 C16 18 19 13 24 9 C29 13 32 18 32 25 V42" opacity="0.4" />
+          </svg>
+          <p className="dw-measure text-ink text-md">{strings.catalog.nothing}</p>
+          <button
+            type="button"
+            onClick={clearAll}
+            className="dw-press dw-raised text-ink rounded-cut-sm min-h-target min-w-target px-5 text-base"
+          >
+            {strings.catalog.showAll}
+          </button>
+        </div>
       ) : (
-        /* 10.5rem, not 8.5rem, and the number is measured rather than chosen.
-           The longest single word shipped is COUNTERWEIGHT: at the title's 15px
-           it needs 142px of text box, and an 8.5rem column offers 110px. A word
-           wider than its column cannot be wrapped, only broken or clipped,
-           which is how "COUNTERPOI / SE" reached a desktop screen. 10.5rem
-           gives 142px of text box — exactly enough — and still fits two columns
-           on a 390px phone (2x168 + 12 gap = 348 of 358 available). */
-        <ul className="grid grid-cols-[repeat(auto-fill,minmax(10.5rem,1fr))] gap-3 sm:gap-4">
+        /* The floor is measured; the ceiling is a decision.
+
+           10.5rem, not 8.5rem: the longest single word shipped is
+           COUNTERWEIGHT, which at the title's 15px needs 142px of text box, and
+           an 8.5rem column offers 110px. A word wider than its column cannot be
+           wrapped, only broken or clipped, which is how "COUNTERPOI / SE"
+           reached a desktop screen. 10.5rem gives 142px — exactly enough — and
+           still fits two columns on a 390px phone.
+
+           But a floor is not a ceiling, and `auto-fill` alone treated a desktop
+           as a phone with more room: at 1440 it drew six ~170px columns of
+           twenty-seven postage stamps. A wide screen deserves FEWER, LARGER
+           cards. The counts below are chosen against the 1152px frame the shell
+           caps at, and each is checked against the same COUNTERWEIGHT budget:
+
+             ≤ 639   auto-fill  →  2 columns at 390 (172px wide, 148px of text)
+             640     3 columns  →  192px  (168px of text)
+             768     4 columns  →  172px  (148px of text — the tightest rung)
+             1024    4 columns  →  237px
+             1280+   4 columns  →  265px, and no wider: the frame stops at 1152
+
+           **Four is the last step, and a fifth was tried and removed.** With
+           `xl:grid-cols-5` a 1440px screen drew 211px cards while a 1024px iPad
+           drew 237px ones — a card that gets SMALLER as the screen gets bigger,
+           which is the same defect as the six-column desktop wearing a
+           different number. Above 1152 the frame stops growing, so a column
+           added there can only take width away.
+
+           The `key` remounts the grid when the SUBJECT changes, so the new
+           listing fades in rather than being swapped in one frame — the filter
+           explains what it did. Deliberately not keyed on the query: a
+           cross-fade on every keystroke is decoration, and this app does not
+           animate for the sake of it. */
+        <ul
+          key={active ?? "all"}
+          className="dw-anim-fade gap-grid grid grid-cols-[repeat(auto-fill,minmax(10.5rem,1fr))] sm:grid-cols-3 md:grid-cols-4"
+        >
           {listed.map((row) => (
             <li key={row.key} className="min-w-0">
               <Card row={row} active={active} />
@@ -223,6 +517,16 @@ export function Catalog({ rows }: { rows: readonly PackRow[] }) {
  *
  * `aria-pressed` carries the state, and so does the border and the ink — never
  * a colour alone, which is the same rule the rest of this shell is drawn to.
+ *
+ * **Drawn the way every platform draws a selection: raised.** It used to be
+ * `bg-ground-sunk`, i.e. the chosen subject was a hole in the page and the five
+ * unchosen ones were the things that looked pressable. The chosen chip is now
+ * the elevation rung above the page and the others are transparent, which is
+ * the iOS segmented control and the Android toggle group both.
+ *
+ * `min-w-target` is not cosmetic: "All" is a short word, and at `px-3` it
+ * measured 42.1 px on the axis it is thinnest — under the touch floor, on the
+ * one control that clears the filter.
  */
 function Chip({ label, on, press }: { label: string; on: boolean; press: () => void }) {
   return (
@@ -231,9 +535,8 @@ function Chip({ label, on, press }: { label: string; on: boolean; press: () => v
       aria-pressed={on}
       onClick={press}
       className={[
-        "rounded-cut-sm min-h-11 shrink-0 border px-3 text-sm whitespace-nowrap",
-        "transition-colors duration-[var(--dw-motion-quick)]",
-        on ? "border-line-strong bg-ground-sunk text-ink" : "border-line text-ink-muted",
+        "dw-press rounded-cut-sm min-h-target min-w-target shrink-0 snap-start border px-3 text-sm whitespace-nowrap",
+        on ? "dw-raised border-line-strong text-ink" : "border-line text-ink-muted bg-transparent",
       ].join(" ")}
     >
       {label}

--- a/dynawalla/dynawalla-app/src/catalog/catalog.css
+++ b/dynawalla/dynawalla-app/src/catalog/catalog.css
@@ -132,3 +132,234 @@
   stroke-width: 1.4;
   stroke-opacity: 0.8;
 }
+
+/* ═════════════════════════════════════════════════════════════════════════
+   The catalogue's own chrome
+   ═════════════════════════════════════════════════════════════════════════
+
+   Three things a Tailwind class cannot say, and one that it can say only
+   badly. They live here rather than in `index.css` because none of them is a
+   composition the rest of the harness repeats — a search shell, a chip rail
+   and a card's reserved text boxes exist on exactly one screen.
+
+   Nothing below names a colour. Every value is a token from `tokens.css` or a
+   length derived from the type scale, and the derivation is written down.
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* ── The search field ──────────────────────────────────────────────────────
+   Focus belongs to the SHELL, not to the input. The platform draws its ring
+   around the box a person can see; drawing it around the text run inside a
+   bordered field puts two nested rectangles on screen and is one of the
+   quieter web tells. So the input's own outline is suppressed and the shell
+   takes an accent edge plus a ring — an equivalent visible indicator, which
+   is what WCAG 2.4.7 actually asks for, and what iOS does.
+
+   The native search-cancel button is suppressed too: WebKit draws it as a
+   grey disc about 14 px across, which is both off-palette and less than a
+   third of the touch floor. The catalogue draws its own at 44 px. */
+.dw-find {
+  transition:
+    border-color var(--dw-transition-state),
+    box-shadow var(--dw-transition-state);
+}
+
+/* One hue, not two. The first cut set the edge to `--dw-accent` and the ring
+   to `--dw-focus`; they are different violets, so the field read as two
+   concentric rings rather than as one focused object. Both are the focus
+   colour now — the same one `:focus-visible` draws everywhere else.
+
+   `:has(:focus-visible)`, NOT `:focus-within`, and the difference is the whole
+   point. `:focus-within` has no keyboard heuristic: it matches on TOUCH, so
+   tapping the field — or the 44 px clear control inside the shell — haloed the
+   whole search box on a tablet. Verified with a real touch event under
+   coarse-pointer emulation: box-shadow went from `none` to a 2 px ring while
+   the input's own `:focus-visible` stayed false. "A focus ring that appears on
+   touch" is a named defect on the standing bar, and this was the only control
+   in the app where one event produced two treatments.
+
+   `:has()` is Safari 15.4, comfortably inside this bundle's iOS 16.0 floor.
+   Where it is missing the rule is dropped whole and the field simply has no
+   shell ring — the input's own outline suppression below is the only thing
+   that would then be doing anything, so the fallback is "no ring", not "two
+   rings". */
+.dw-find:has(:focus-visible) {
+  border-color: var(--dw-focus);
+  box-shadow: 0 0 0 2px var(--dw-focus);
+}
+
+/* The input gives up its own ring only where the shell can draw one instead.
+   Guarded, so an engine without `:has()` keeps the platform's outline rather
+   than being left with no focus indicator at all. */
+@supports selector(:has(*)) {
+  .dw-find input:focus-visible {
+    outline: none;
+  }
+}
+
+.dw-find input::-webkit-search-cancel-button,
+.dw-find input::-webkit-search-decoration,
+.dw-find input::-webkit-search-results-button {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}
+
+/* ── The subject rail ──────────────────────────────────────────────────────
+   A row that scrolls sideways inside the page, and the two things that make
+   one read as native rather than as a `div` with `overflow: auto`.
+
+   1. No bar, on any pointer. `index.css` suppresses scrollbars under
+      `(pointer: coarse)` only — correct for the page scroller, wrong for a
+      chip rail, because on a desktop that left a painted horizontal channel
+      sitting between the search field and the grid. A class beats `*`.
+
+   2. The edges dissolve, and they dissolve ONLY on the side that has more.
+      A permanent fade on both edges is a decoration; a fade that appears the
+      moment content passes under it is the signal every native carousel
+      uses, and its absence is the signal that you have reached the end. The
+      attributes are written by the component from `scrollLeft`.
+
+   **The mask must not be on the scrolling element**, and this was measured
+   rather than assumed. Chrome sizes a mask on a scroll container against the
+   SCROLLABLE overflow area, not the visible box — so `calc(100% - 24px)` on
+   the rail itself put the fade 24 px from the end of 812 px of chips, about
+   450 px off the right of a 390 px phone, and the captured screenshot showed
+   a chip clipped stone dead at the edge with no dissolve at all. The mask
+   goes on a static wrapper whose 100% is the width you can see; the scroller
+   is its only child. */
+.dw-rail {
+  scrollbar-width: none;
+  /* The gutter is not a scroll position. `px-1` keeps a chip's raised edge and
+     its focus ring off the clip, and proximity snapping then rests the rail at
+     `scrollLeft: 4` — which read as "there is content to the left" and lit the
+     leading dissolve over the selected chip at rest. `scroll-padding-inline`
+     moves the snap positions in by the same 4 px, so the resting offset is 0
+     and the rail agrees with what is on screen. (`useRailEdges` also compares
+     against the first chip's own offset, so the fade is correct even where
+     snapping is not.) */
+  scroll-padding-inline: var(--dw-space-1);
+}
+
+/* `width`/`height`, not the logical pair. `::-webkit-scrollbar` is a
+   non-standard pseudo-element and does not accept logical sizes, so the
+   logical version silently lost to `*::-webkit-scrollbar { width: 10px }` in
+   `index.css` — which would have painted a 10 px channel under the chip rail
+   on a desktop build, the exact tell this rail was written to avoid. */
+.dw-rail::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+/* Above 40 rem the rail stops being a rail. Measured at 834 — iPad portrait, a
+   first-class size — six subjects overflowed by exactly 18 px: a row that
+   looked scrollable, travelled less than a fingertip, and put the dissolve on
+   the last WORD of the last chip ("Equality & algeb—ra" fading mid-word with
+   its right border cut), which reads as a rendering fault rather than as a
+   scroll cue. There is room for a second line on a tablet and there is not on
+   a phone, so the chips wrap where there is room and scroll where there is
+   not. `overflow: visible` on both axes together: setting one to visible while
+   the other is `hidden` computes the visible one back to `auto`. */
+@media (min-width: 40rem) {
+  .dw-rail {
+    flex-wrap: wrap;
+    overflow: visible;
+    scroll-snap-type: none;
+  }
+}
+
+.dw-subjects[data-lead="on"][data-trail="on"] {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black var(--dw-space-5),
+    black calc(100% - var(--dw-space-5)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black var(--dw-space-5),
+    black calc(100% - var(--dw-space-5)),
+    transparent 100%
+  );
+}
+
+.dw-subjects[data-lead="on"][data-trail="off"] {
+  -webkit-mask-image: linear-gradient(to right, transparent 0, black var(--dw-space-5), black 100%);
+  mask-image: linear-gradient(to right, transparent 0, black var(--dw-space-5), black 100%);
+}
+
+.dw-subjects[data-lead="off"][data-trail="on"] {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    black 0,
+    black calc(100% - var(--dw-space-5)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    black 0,
+    black calc(100% - var(--dw-space-5)),
+    transparent 100%
+  );
+}
+
+/* ── A card's reserved boxes ───────────────────────────────────────────────
+   The grid's rhythm was ragged because each card's blocks were sized by
+   their own content: a one-line name put its blurb where the next card put
+   its second line, and a game filed under one subject put its small print
+   where its neighbour put its second chip. Equal card HEIGHT (`h-full` plus
+   `mt-auto`) only guaranteed that the cards ended together; inside them
+   nothing lined up, and the eye reads a grid across, not down.
+
+   So every block reserves its own maximum. `lh` is the honest unit for "two
+   lines of whatever this is set in" and it lands in Safari 16.4, one point
+   above this bundle's iOS 16.0 floor — so each rule states the em equivalent
+   first and lets `lh` win where it exists. The em figure is the type scale's
+   own line-height for that step, doubled, and nothing else. */
+/* The `@supports` guards are not decoration and the em-first pattern they
+   replace does not survive the build. Written as two declarations of the same
+   property, the minifier drops the first — it is provably dead in the cascade
+   as far as the minifier can see — and the built stylesheet read
+   `.dw-card-title{min-block-size:2lh}` with no fallback at all. Verified
+   against `dist/`: `grep -c '2\.6em'` was 0. On iOS 16.0–16.3, where `lh` does
+   not exist, that declaration is invalid and dropped, nothing reserves the
+   box, and the grid rhythm is silently unfixed on exactly the devices the
+   fallback was written for. `@supports` is uncollapsible. */
+.dw-card-title {
+  /* The title's size is an arbitrary 15px (measured against the longest name
+     shipped, see the component), so its leading is set here rather than
+     inherited from the body. 2 × 1.3 = 2.6. */
+  line-height: 1.3;
+  min-block-size: 2.6em;
+}
+
+.dw-card-blurb {
+  /* `text-xs` carries line-height 1.35 from the type scale. 2 × 1.35 = 2.7. */
+  min-block-size: 2.7em;
+}
+
+@supports (min-block-size: 1lh) {
+  .dw-card-title,
+  .dw-card-blurb {
+    min-block-size: 2lh;
+  }
+}
+
+/* A chip is a fixed height so that two rows of them are a knowable number
+   rather than a measured one: 12px text at 1.35 leading is 16.2px, plus
+   0.125rem of padding each side and a hairline each side, which rounds to
+   1.375rem. Fixing it also stops a one-word subject and a three-word one
+   drawing two different heights on the same line. */
+.dw-card-chip {
+  display: inline-flex;
+  align-items: center;
+  block-size: 1.375rem;
+}
+
+/* Two rows, always — every card shipped files under either one subject or
+   two, so this is the maximum rather than a guess, and it is what puts the
+   grade band and the control on one line across a whole row of the grid. */
+.dw-card-subjects {
+  min-block-size: calc(2 * 1.375rem + var(--dw-space-1));
+}

--- a/dynawalla/dynawalla-app/src/design/Strapwork.tsx
+++ b/dynawalla/dynawalla-app/src/design/Strapwork.tsx
@@ -1,10 +1,68 @@
 import { useId } from "react"
 
-import { strapworkTile } from "./strapwork.ts"
+import { strapworkTile, type StrapworkSpec, type StrapworkTile } from "./strapwork.ts"
 
-const UNIT = 24
-const HEIGHT = 10
-const TILE = strapworkTile({ unit: UNIT, height: HEIGHT, inset: 1.5, knot: 2 })
+/**
+ * The band at two scales.
+ *
+ * An SVG `<pattern>` repeats in USER units, and a pattern's `width` is an
+ * attribute rather than a CSS property — so a media query cannot resize the
+ * motif and there is no arithmetic that makes one tile serve every screen. A
+ * 24 px motif is right on a phone and wrong at 1440, where sixty repeats of a
+ * fine zigzag stop reading as carved stone and start reading as a craft-store
+ * border: the tell the audit called "thin and cheap on a wide screen".
+ *
+ * So there are two tiles, and CSS chooses between them. The motif grows with
+ * the screen the way a carved course does — same geometry, same single stroke
+ * weight, more of the band given to each repeat.
+ */
+const NARROW: StrapworkSpec = { unit: 24, height: 10, inset: 1.5, knot: 2 }
+const WIDE: StrapworkSpec = { unit: 36, height: 14, inset: 2, knot: 3 }
+
+const NARROW_TILE = strapworkTile(NARROW)
+const WIDE_TILE = strapworkTile(WIDE)
+
+function Band({
+  id,
+  spec,
+  tile,
+  className,
+}: {
+  id: string
+  spec: StrapworkSpec
+  tile: StrapworkTile
+  className: string
+}) {
+  return (
+    <svg
+      aria-hidden="true"
+      // `block`, not an inline style: the CSP forbids inline style entirely.
+      className={className}
+      width="100%"
+      height={spec.height}
+    >
+      <defs>
+        <pattern
+          id={id}
+          width={spec.unit}
+          height={spec.height}
+          patternUnits="userSpaceOnUse"
+        >
+          {/* The band names its own roles. `--dw-band-strap` and
+              `--dw-band-knot` are the cool pair the foundation cut for it —
+              the band is the edge of the surface above it, not the screen's
+              warm point. That belongs to the navigation index, once. */}
+          <path d={tile.strapA} fill="none" stroke="var(--dw-band-strap)" strokeWidth={1} />
+          <path d={tile.strapB} fill="none" stroke="var(--dw-band-strap)" strokeWidth={1} />
+          {tile.knots.map((knot) => (
+            <path key={knot} d={knot} fill="var(--dw-band-knot)" />
+          ))}
+        </pattern>
+      </defs>
+      <rect width="100%" height={spec.height} fill={`url(#${id})`} />
+    </svg>
+  )
+}
 
 /**
  * An interlace band. Structural: it is the edge of the surface above it, not
@@ -14,35 +72,34 @@ const TILE = strapworkTile({ unit: UNIT, height: HEIGHT, inset: 1.5, knot: 2 })
  * at any width and simply repeats more times on a wider screen.
  */
 export function Strapwork({ className }: { className?: string }) {
-  // One id per band. Two bands sharing one is invalid markup, and the moment
-  // the tile takes parameters the second band silently paints the first one's
-  // pattern. React 19 ids contain punctuation that a URL fragment should not
-  // carry, so only the alphanumerics survive.
-  const patternId = `dw-strapwork-${useId().replace(/[^a-zA-Z0-9]/g, "")}`
+  // One id per band, and both bands on a screen are distinct instances, so the
+  // seam is per call site AND per scale. Two bands sharing one id is invalid
+  // markup, and the moment the tile takes parameters the second band silently
+  // paints the first one's pattern — which is exactly what two scales are.
+  // React 19 ids contain punctuation that a URL fragment should not carry, so
+  // only the alphanumerics survive.
+  const seed = useId().replace(/[^a-zA-Z0-9]/g, "")
+  // A SPACE before the interpolation, and it is load-bearing. Tailwind reads
+  // this file as text; written `md:hidden${extra}` the candidate it extracts
+  // is `md:hidden${extra}`, which matches no utility, so the rule is silently
+  // absent from the built stylesheet and every screen keeps the phone band.
+  // It compiles, it lints, it types, and the design change never ships.
+  const extra = className ?? ""
 
   return (
-    <svg
-      aria-hidden="true"
-      // `block`, not an inline style: the CSP forbids inline style entirely.
-      className={className ? `block ${className}` : "block"}
-      width="100%"
-      height={HEIGHT}
-    >
-      <defs>
-        <pattern
-          id={patternId}
-          width={UNIT}
-          height={HEIGHT}
-          patternUnits="userSpaceOnUse"
-        >
-          <path d={TILE.strapA} fill="none" stroke="var(--dw-line-strong)" strokeWidth={1} />
-          <path d={TILE.strapB} fill="none" stroke="var(--dw-line-strong)" strokeWidth={1} />
-          {TILE.knots.map((knot) => (
-            <path key={knot} d={knot} fill="var(--dw-index)" />
-          ))}
-        </pattern>
-      </defs>
-      <rect width="100%" height={HEIGHT} fill={`url(#${patternId})`} />
-    </svg>
+    <>
+      <Band
+        id={`dw-strapwork-${seed}n`}
+        spec={NARROW}
+        tile={NARROW_TILE}
+        className={`block md:hidden ${extra}`}
+      />
+      <Band
+        id={`dw-strapwork-${seed}w`}
+        spec={WIDE}
+        tile={WIDE_TILE}
+        className={`hidden md:block ${extra}`}
+      />
+    </>
   )
 }

--- a/dynawalla/dynawalla-app/src/design/tokens.css
+++ b/dynawalla/dynawalla-app/src/design/tokens.css
@@ -1,8 +1,10 @@
 /* ──────────────────────────────────────────────────────────────────────────
    Dynawalla — design tokens
 
-   Tokens only. This file fixes the material vocabulary and the type scale so
-   the art pass has something to build on; it is not itself the visual design.
+   Tokens only. This file is the foundation the whole host harness is built
+   on: the palette, the spacing rhythm, the elevation ladder, the motion
+   vocabulary and the type scale. It is not itself the visual design — but
+   nothing in the design may invent a value this file does not name.
 
    Three layers, in this order, and the layering is load bearing:
 
@@ -16,10 +18,56 @@
                         so `bg-ground` emits `var(--dw-ground)` and follows the
                         theme class rather than baking one theme's value in.
 
-   The palette is material, not lighting: brass, lapis, carved limestone,
-   parchment, copper oxide, glazed tile, walnut, and the cold celestial light
-   that falls on all of it. No gradients, no glow.
-   `src/design/tokens.test.ts` enforces the layering mechanically.
+   `src/design/tokens.test.ts` enforces the layering mechanically, including
+   the rule that keeps this file honest: a semantic token that resolves to a
+   MATERIAL must be re-cut under `.dw-dark`, and one that carries no colour
+   must NOT be. That is why elevation backgrounds below defer to other
+   semantic tokens (`var(--dw-ground-raised)`) while elevation SHADOWS name
+   materials directly — the first is theme-independent by construction, the
+   second genuinely differs by theme.
+
+   ── Measured contrast (WCAG 2.1, sRGB) ─────────────────────────────────────
+   Every text pair this file defines, measured rather than assumed. AA needs
+   4.5 for normal text, 3.0 for large text and graphics.
+
+   LIGHT — ground parchment-100 · sunk parchment-200 · raised/lifted/float
+           parchment-50
+     ink / ground .................... 16.09   ink / raised ............ 18.01
+     ink / sunk ...................... 14.36
+     ink-muted / ground ............... 6.52   ink-muted / raised ....... 7.30
+     ink-muted / sunk ................. 5.81
+     accent-ink / ground .............. 8.02   accent-ink / raised ...... 8.98
+     accent / ground (line art) ....... 6.35   accent / raised .......... 7.10
+     index / ground ................... 5.61   index / raised ........... 6.29
+     index / sunk ..................... 5.01   index-lit / ground (art) . 3.43
+     strike / ground .................. 6.39   strike / raised .......... 7.16
+     strike / sunk .................... 5.71
+     seat / ground .................... 6.10   seat / raised ............ 6.83
+     seat / sunk ...................... 5.44
+     on-accent / accent-fill .......... 7.10   on-strike / strike-fill .. 7.16
+     band knot / ground (art) ......... 6.35   line-strong / ground ..... 2.66
+     line / raised (hairline) ......... 1.77   raised / ground .......... 1.12
+     sunk / ground .................... 1.12   raised / sunk (thumb) .... 1.25
+
+   DARK — ground basalt-800 · sunk basalt-950 · raised basalt-700
+          · lifted basalt-600 · float basalt-500
+     ink / ground .................... 17.80   ink / raised ............ 16.69
+     ink / lifted .................... 15.26   ink / float ............. 13.87
+     ink-muted / ground ............... 9.23   ink-muted / raised ....... 8.66
+     ink-muted / lifted ............... 7.91   ink-muted / float ........ 7.20
+     accent-ink / ground ............. 10.87   accent-ink / raised ..... 10.19
+     accent-ink / float ............... 8.47   accent / ground (art) .... 4.81
+     index / ground .................. 16.43   index / lifted .......... 14.08
+     strike / ground .................. 8.24   strike / raised .......... 7.72
+     strike / float ................... 6.42   seat / ground ............ 8.98
+     on-accent / accent-fill .......... 5.70   on-strike / strike-fill .. 7.44
+     band knot / ground (art) ......... 4.81   line-strong / ground ..... 2.73
+     raised / ground .................. 1.07   lifted / raised .......... 1.09
+     float / ground ................... 1.28   lifted / sunk (thumb) .... 1.20
+
+   The only pairs below 4.5 are graphics, where the floor is 3.0: `--dw-accent`
+   as line art (4.81 dark / 6.35 light), `--dw-index-lit` as a glint (3.43
+   light), and the elevation steps, which are surfaces rather than text.
    ────────────────────────────────────────────────────────────────────────── */
 
 @theme {
@@ -39,31 +87,68 @@
   --font-numeral: ui-rounded, "SF Pro Rounded", system-ui, -apple-system, "Segoe UI", Roboto,
     sans-serif;
 
-  /* A 1.25 scale from a 1rem base, rounded to eighths of a rem so every step
-     lands on a half-pixel-free value at the 16 px default. */
+  /* A 1.125→1.25 scale from a 1rem base, rounded to eighths of a rem so every
+     step lands on a half-pixel-free value at the 16 px default.
+
+     Each step carries its own line-height AND its own letter-spacing, because
+     optical tracking is not decoration: type set at one tracking across nine
+     sizes is the single most reliable way to look like a website. Small text
+     opens up, large text closes in. The values are the platform convention —
+     SF and Roboto are both drawn expecting it.
+
+     `--text-md` (18 px) is the row-label size, and it is the one a child
+     actually reads down a list. It exists because the jump from 16 to 20 is
+     too coarse for a screen whose whole job is a column of rows. */
   --text-xs: 0.75rem;
-  --text-xs--line-height: 1.25;
+  --text-xs--line-height: 1.35;
+  --text-xs--letter-spacing: 0.02em;
   --text-sm: 0.875rem;
-  --text-sm--line-height: 1.35;
+  --text-sm--line-height: 1.45;
+  --text-sm--letter-spacing: 0.01em;
   --text-base: 1rem;
   --text-base--line-height: 1.5;
+  --text-base--letter-spacing: 0em;
+  --text-md: 1.125rem;
+  --text-md--line-height: 1.45;
+  --text-md--letter-spacing: -0.005em;
   --text-lg: 1.25rem;
   --text-lg--line-height: 1.4;
+  --text-lg--letter-spacing: -0.01em;
   --text-xl: 1.5rem;
   --text-xl--line-height: 1.3;
+  --text-xl--letter-spacing: -0.015em;
   --text-2xl: 1.875rem;
-  --text-2xl--line-height: 1.2;
+  --text-2xl--line-height: 1.22;
+  --text-2xl--letter-spacing: -0.02em;
   --text-3xl: 2.375rem;
   --text-3xl--line-height: 1.15;
+  --text-3xl--letter-spacing: -0.022em;
   --text-4xl: 3rem;
   --text-4xl--line-height: 1.05;
+  --text-4xl--letter-spacing: -0.025em;
+
+  /* Two tracking values that are NOT part of the size scale, because they
+     belong to a treatment rather than to a size. Tailwind's own
+     `tracking-tight … tracking-widest` are left alone; these are additions.
+
+       `--tracking-wordmark`  DYNAWALLA in the lintel, and nothing else.
+       `--tracking-caps`      any other run set in capitals — and the list of
+                              those is deliberately short (see FOUNDATION.md):
+                              the wordmark, the pack titles that arrive from a
+                              manifest already in capitals, and nothing on
+                              Settings, Parents or Profiles. A capitalised,
+                              tracked legend over a form control is a 2014 web
+                              dashboard idiom; native platforms set that legend
+                              in sentence case at reading size. */
+  --tracking-caps: 0.09em;
+  --tracking-wordmark: 0.22em;
 
   /* ── Materials ─────────────────────────────────────────────────────────
      Named for the substance, numbered light to dark.
 
      **Repainted from `dynawalla/brand/README.md`.** The names below are the
      ones the semantic layer already refers to and they are kept; every VALUE
-     is now sampled from the mark itself, whose dominant saturated pixel is
+     is sampled from the mark itself, whose dominant saturated pixel is
      `#864de8`. The direction is the founder's: futuristic space angels,
      gear-brain minaret, sharp and pointing up, clockmaker G-d, al-Andalus.
      Explicitly dead, also his words: the dusty khaki sandstorm feel — which is
@@ -76,43 +161,81 @@
   --color-parchment-200: #e9e2fb;
   --color-parchment-300: #dcd2f5;
 
-  /* Carved limestone — structure, rules, incised edges. Violet-grey. */
+  /* Carved limestone — structure, rules, incised edges. Violet-grey.
+     `500` is new: the old light `--dw-line-strong` was `stone-400`, only
+     1.6:1 on white, so a "structural edge" was fainter than a hairline is
+     supposed to be. `400` itself is untouched because dark `--dw-ink-muted`
+     is drawn from it and darkening it would cost 9.23:1 of body contrast. */
   --color-stone-200: #c9bcec;
   --color-stone-400: #b9a6ec;
+  --color-stone-500: #9d8bd0;
   --color-stone-600: #5b5175;
   --color-stone-800: #2a1b4d;
 
-  /* Basalt — the unlit ground, and ink on parchment. Violet-black. */
+  /* Basalt — the unlit ground, and ink on parchment. Violet-black.
+     `500` and `600` are new and they are what makes the dark elevation
+     ladder possible: in dark, height is read as LIGHT, not as shadow, so a
+     sheet that is the same stone as the page behind it does not read as a
+     sheet at all. The pass sheet measured 1.13:1 against its own backdrop
+     before these existed. */
+  --color-basalt-500: #261a52;
+  --color-basalt-600: #1e1440;
   --color-basalt-700: #150c2e;
   --color-basalt-800: #0b0618;
   --color-basalt-900: #1a1033;
   --color-basalt-950: #060310;
 
   /* Brass — the index, the pointer, the working mechanism, and the brand's
-     one warm point (`--dw-apex` in the brand README is this material). */
+     one warm point (`--dw-apex` in the brand README is this material).
+
+     `700` is retained for reference and is no longer used: at 1 px over
+     parchment `#b45309` read as a red-brown dotted ribbon, which is the
+     closest thing the app had to the explicitly-dead sandstorm. `800` is the
+     light-theme warm point instead — hue 42°, a struck old gold rather than
+     a terracotta, and 5.61:1 on the light ground where `#b45309` sat at 4.79
+     and looked orange doing it. */
   --color-brass-300: #ffe7b0;
   --color-brass-500: #e0b15a;
+  --color-brass-600: #a87a17;
   --color-brass-700: #b45309;
+  --color-brass-800: #7d5a10;
 
   /* Aurora — the lit line. The mark's own violet, and the accent the whole
-     app is drawn in. `400` is the bloom: light, never paint. */
+     app is drawn in. `400` is the bloom: light, never paint. `550` exists
+     only as the ground of a FILLED accent control in dark, where `500` under
+     white text measures 4.15:1 and fails. */
   --color-aurora-300: #c9b4ff;
   --color-aurora-350: #a78bfa;
   --color-aurora-400: #b88cff;
   --color-aurora-500: #9258ff;
+  --color-aurora-550: #7c3aed;
   --color-aurora-600: #6d28d9;
   --color-aurora-700: #5b21b6;
+  /* …and the accent as a wash, which is what seats the current tab. Written
+     as alpha and not as `color-mix`, and this is not a preference: Tailwind
+     emits an accent-at-twelve-percent utility as a `color-mix` guarded by
+     `@supports`, plus a bare
+     FULLY OPAQUE fallback outside the guard. `color-mix` lands in Safari 16.2
+     and this bundle's floor is 16.0, so on an iOS 16.0 device the carefully
+     measured 1.22:1 seat painted as a solid violet plate under dark ink. Two
+     entries because a wash is a material: 12% of the deep violet reads on
+     parchment, and on basalt it is nothing, so dark washes with the lighter
+     aurora and a little more of it. */
+  --color-aurora-wash-light: rgb(109 40 217 / 0.12);
+  --color-aurora-wash-dark: rgb(146 88 255 / 0.18);
 
-  /* Lapis — the deep field; the sky an astrolabe is read against. Now a deep
+  /* Lapis — the deep field; the sky an astrolabe is read against. A deep
      violet rather than a blue, so the field and the ground are one stone. */
   --color-lapis-400: #b88cff;
   --color-lapis-600: #6d28d9;
   --color-lapis-800: #241246;
   --color-lapis-950: #0b0618;
 
-  /* Glazed tile — cool ceramic, for calm affirmative surfaces. */
+  /* Glazed tile — cool ceramic, for calm affirmative surfaces. `700` is the
+     light-theme seat: `600` fell to 4.27:1 on a sunk row. */
   --color-tile-400: #38bfc9;
   --color-tile-600: #0e7490;
+  --color-tile-700: #0c6379;
   /* …and the same glaze as a wash, thin enough to be a ground rather than a
      fill. Two entries because a wash is a material: on parchment the dark tile
      at 14% is a tint you can see, and on basalt it is nothing at all, so the
@@ -123,10 +246,22 @@
   --color-tile-600-wash: rgb(14 116 144 / 0.14);
   --color-tile-400-wash: rgb(56 191 201 / 0.18);
 
-  /* Copper and its oxide — the tone of a struck, incorrect mark. */
-  --color-copper-400: #f08a7e;
-  --color-copper-500: #c2453c;
-  --color-copper-700: #8c2f27;
+  /* Rose — the struck mark, and the only red this palette owns.
+
+     It replaces the copper ramp, which was left over from the pre-purple
+     palette: `#c2453c` was a coral that belonged to no other colour on the
+     screen AND measured 4.45:1 on the light ground, failing AA on the two
+     most consequential controls in the app ("Erase everything", "Remove").
+
+     The hue is taken from the arc's own rose end (`--color-arc-11`,
+     hsl 348°), so danger is drawn in a colour the app already contains
+     rather than imported from a generic red. It is unmistakably a warning
+     and it is unmistakably from here. */
+  --color-rose-300: #ff7d9e;
+  --color-rose-600: #d7264f;
+  --color-rose-700: #ac1442;
+  --color-rose-wash-light: rgb(172 20 66 / 0.09);
+  --color-rose-wash-dark: rgb(255 125 158 / 0.14);
 
   /* Walnut — cabinetry, frames, the case an instrument sits in. */
   --color-walnut-600: #3b2a63;
@@ -135,6 +270,31 @@
   /* Celestial — cold light. Highlights only; never a fill. */
   --color-celestial-100: #e8deff;
   --color-celestial-300: #c9b4ff;
+
+  /* ── Cast light ────────────────────────────────────────────────────────
+     Shadow is a material too, and it is the one place a design gives itself
+     away fastest: a neutral grey shadow on a violet ground reads as a
+     framework default, because it is one. Every umbra below is violet —
+     `rgb(45 20 92)` is basalt-900 pushed a little further into the blue, so
+     a card's cast light belongs to the same stone as the card.
+
+     `sheen` is the opposite direction and it is what dark elevation is
+     actually made of: a one-pixel lit top edge, the way a raised surface
+     catches the light above it. Written as alpha rather than `color-mix`
+     for the same iOS 16.0 reason as the glazes above. */
+  --color-umbra-soft: rgb(45 20 92 / 0.06);
+  --color-umbra-mid: rgb(45 20 92 / 0.1);
+  --color-umbra-deep: rgb(45 20 92 / 0.18);
+  --color-umbra-cast: rgb(45 20 92 / 0.28);
+  --color-umbra-scrim: rgb(26 16 51 / 0.34);
+
+  --color-void-mid: rgb(2 0 10 / 0.4);
+  --color-void-deep: rgb(2 0 10 / 0.55);
+  --color-void-cast: rgb(2 0 10 / 0.72);
+  --color-void-scrim: rgb(2 0 10 / 0.74);
+
+  --color-sheen-soft: rgb(201 180 255 / 0.06);
+  --color-sheen-mid: rgb(201 180 255 / 0.1);
 
   /* ── The arc ───────────────────────────────────────────────────────────
      Twelve lit hues for generated key art, and nothing else in the app may
@@ -163,20 +323,45 @@
 }
 
 /* ── Semantic layer, light ────────────────────────────────────────────────
-   Roles, not colours. Nothing outside this block may name a material. */
+   Roles, not colours. Nothing outside this block may name a material.
+
+   Light is not a bleached dark. The two themes carry height by opposite
+   means and both are native conventions: in LIGHT a surface stands off the
+   page by casting violet light onto it, and every raised thing is the same
+   white; in DARK nothing casts, and a surface stands off the page by being
+   made of lighter stone. Trying to do it the other way round is what makes a
+   light theme look like a print-out. */
 :root {
-  /* Grounds. `sunk` is a recess cut into `ground`; `raised` is a surface
-     standing proud of it. Both are the same stone in different light — the
-     difference is never a drop shadow. */
+  /* Grounds — the elevation ladder, four rungs.
+
+       ground    the page itself
+       sunk      a recess cut into it: a segmented-control TRACK, a well
+       raised    a card, a course, a sheet of the page's own material
+       lifted    something pressable that sits ON a surface: the selected
+                 segment of a control, the tab bar, a chip
+       float     a sheet over everything: the pass sheet, the parental gate
+
+     `--dw-ground-lifted` and `--dw-ground-float` are new, and they are what
+     lets a segmented control be drawn the way every platform draws one — a
+     recessed track with a raised thumb in it. Drawn the other way round (the
+     selected option darker than the unselected ones) the control reads
+     inverted, which is what the whole app was doing. */
   --dw-ground: var(--color-parchment-100);
   --dw-ground-sunk: var(--color-parchment-200);
   --dw-ground-raised: var(--color-parchment-50);
+  --dw-ground-lifted: var(--color-parchment-50);
+  --dw-ground-float: var(--color-parchment-50);
   --dw-ground-deep: var(--color-lapis-950);
 
   /* Incised lines. `--dw-line` is a hairline rule; `--dw-line-strong` is a
-     structural edge; `--dw-line-cut` is the shadow inside a carved groove. */
-  --dw-line: var(--color-parchment-300);
-  --dw-line-strong: var(--color-stone-400);
+     structural edge; `--dw-line-cut` is the shadow inside a carved groove.
+
+     `--dw-line` was `parchment-300` and measured 1.16:1 on white, which is a
+     rule you cannot see. `stone-200` is 1.77:1 — about what iOS draws a
+     table separator at, and the reason a light list now has a spine. */
+  --dw-line: var(--color-stone-200);
+  --dw-line-soft: var(--color-parchment-300);
+  --dw-line-strong: var(--color-stone-500);
   --dw-line-cut: var(--color-stone-600);
 
   /* Marks on the ground. */
@@ -185,18 +370,45 @@
   --dw-ink-inverse: var(--color-parchment-50);
 
   /* The mechanism: the index that points at where you are. This is also the
-     brand's one warm point — the apex, used once per screen and no more. */
-  --dw-index: var(--color-brass-700);
-  --dw-index-lit: var(--color-brass-500);
+     brand's one warm point — the apex, used once per screen and no more.
+     On a given screen that is the navigation's own diamond, and the strapwork
+     bands are explicitly NOT it (see `--dw-band-*` below). */
+  --dw-index: var(--color-brass-800);
+  --dw-index-lit: var(--color-brass-600);
 
   /* The lit line: the mark's own violet, and the app's accent. `--dw-accent`
      is for line art, borders and state; `--dw-accent-ink` is the one a child
      actually READS, because accent-on-ground clears AA for normal text only by
-     a hair. `--dw-bloom` is light and never paint — a filled bloom-coloured
-     shape is the named failure mode for this brand. */
+     a hair in dark. `--dw-bloom` is light and never paint — a filled
+     bloom-coloured shape is the named failure mode for this brand.
+
+     `--dw-accent-fill` / `--dw-on-accent` are the pair for a SOLID accent
+     control, and they exist as a pair because the obvious construction
+     (`bg-accent` + `text-ink-inverse`) measures 4.34:1 in dark and fails. */
   --dw-accent: var(--color-aurora-600);
   --dw-accent-ink: var(--color-aurora-700);
+  --dw-accent-fill: var(--color-aurora-600);
+  --dw-on-accent: var(--color-parchment-50);
   --dw-bloom: var(--color-aurora-350);
+  /* The seat the current tab sits in. A role rather than an opacity utility,
+     because the utility compiles to `color-mix` with an opaque fallback. */
+  --dw-accent-seat: var(--color-aurora-wash-light);
+
+  /* The interlace band under the lintel and over the navigation.
+
+     It is structural — the edge of the surface above it — and it is NOT the
+     screen's warm point. It used to be: the band paints one knot every 24 px
+     in `--dw-index`, so a 1440 px screen carried ~60 gold knots, twice over,
+     against a brand rule of one warm point per screen. In light the same
+     knots resolved to `brass-700` and the band read as a red-brown dotted
+     ribbon — the dead sandstorm, on every screen, at the top and the bottom.
+
+     Resolved by making the bands cool. The knots are the app's own violet;
+     the warm point moves to the one place it earns, the navigation index that
+     says where you are. `src/index.css` scopes these onto the band's pattern
+     so the band picks them up without any component naming a colour. */
+  --dw-band-strap: var(--color-stone-400);
+  --dw-band-knot: var(--color-aurora-600);
 
   /* The deep field, and what is legible against it. */
   --dw-field: var(--color-lapis-800);
@@ -209,13 +421,27 @@
      difference at all between a cut cell and an uncut one. A hole shows the
      deep *field*, which is cool where the wall is warm, so the aperture reads
      by hue as well as by value and the rim is not carrying it alone. */
-  --dw-aperture: var(--color-lapis-950);
+  /* `lapis-800`, not `lapis-950`, in LIGHT. A hole is dark and that is right —
+     but the deepest lapis cut into a light stone plate measures 19:1, the
+     highest-contrast pair anywhere in the app, spent on a decorative drawing,
+     and it read as two solid black stars in a violet brand. The deep field one
+     step up is still unmistakably a hole and is violet rather than black. */
+  --dw-aperture: var(--color-lapis-800);
   --dw-aperture-rim: var(--color-celestial-100);
 
-  /* Verdicts. Cold light seats a correct answer; copper oxide marks a strike.
+  /* Verdicts. Cold light seats a correct answer; rose marks a strike.
      Neither is ever the only carrier of meaning (CG-18). */
-  --dw-seat: var(--color-tile-600);
-  --dw-strike: var(--color-copper-500);
+  --dw-seat: var(--color-tile-700);
+  --dw-strike: var(--color-rose-700);
+
+  /* A destructive control needs three parts, not one: the word, the frame it
+     is bounded by, and the wash it sits in once it is armed. "Erase
+     everything" was a bare coral phrase floating in white space with nothing
+     to say it was the most consequential control in the app. */
+  --dw-strike-line: var(--color-rose-600);
+  --dw-strike-ground: var(--color-rose-wash-light);
+  --dw-strike-fill: var(--color-rose-700);
+  --dw-on-strike: var(--color-parchment-50);
 
   /* The seat colour as a ground: the recess a correct answer settles into.
      A role of its own, because `ground-sunk` cannot do this job — under
@@ -230,6 +456,47 @@
   /* Focus ring. Contrast against the ground is what matters here, so it is a
      semantic role of its own rather than a reuse of the index. */
   --dw-focus: var(--color-lapis-600);
+
+  /* ── Elevation, the cast-light half ────────────────────────────────────
+     Four surfaces, each a triple of background, edge and cast light. The
+     background and the edge defer to the roles above, so they follow the
+     theme without being declared twice; the shadows name materials, because
+     a light theme's shadow and a dark theme's shadow are not the same idea.
+
+     LIGHT: violet cast light, increasing with height. Two layers each — a
+     tight contact shadow that seats the object, and a wide soft one that
+     gives it height. One layer alone always looks like a CSS default.
+
+     Read the dark values under `.dw-dark`. */
+  --dw-elev-ground-bg: var(--dw-ground);
+  --dw-elev-ground-line: var(--dw-line);
+
+  --dw-elev-sunk-bg: var(--dw-ground-sunk);
+  --dw-elev-sunk-line: var(--dw-line);
+
+  --dw-elev-surface-bg: var(--dw-ground-raised);
+  --dw-elev-surface-line: var(--dw-line);
+  --dw-elev-surface-shadow:
+    0 1px 1px var(--color-umbra-soft), 0 3px 8px -3px var(--color-umbra-mid);
+
+  --dw-elev-raised-bg: var(--dw-ground-lifted);
+  --dw-elev-raised-line: var(--dw-line);
+  --dw-elev-raised-shadow:
+    0 1px 1px var(--color-umbra-soft), 0 8px 20px -8px var(--color-umbra-deep);
+
+  --dw-elev-overlay-bg: var(--dw-ground-float);
+  --dw-elev-overlay-line: var(--dw-line-strong);
+  --dw-elev-overlay-shadow:
+    0 2px 6px -1px var(--color-umbra-mid), 0 28px 64px -16px var(--color-umbra-cast);
+
+  /* The bar the content scrolls under. Not a shadow on the bar — a shadow
+     the bar casts UP onto the page, which is the direction a bottom tab bar
+     casts and the reason card art currently passes behind it with no
+     relationship at all. */
+  --dw-elev-bar-shadow: 0 -1px 2px var(--color-umbra-soft), 0 -8px 20px -12px var(--color-umbra-mid);
+
+  /* The dimming behind a sheet. */
+  --dw-scrim: var(--color-umbra-scrim);
 
   /* ── Generated key art ─────────────────────────────────────────────────
      The one part of this design that does NOT re-cut for dark, and the
@@ -266,64 +533,207 @@
      test keys on exactly that: a semantic token that resolves to a material
      must exist in both themes; one that does not, must not. */
 
-  /* Motion. `detent` is the 200 ms seat from EXPERIENCE_DESIGN; `quick` is a
-     single frame of acknowledgement; `settle` is the world moving, which the
-     work surface never waits for. */
-  --dw-motion-quick: 120ms;
-  --dw-motion-detent: 200ms;
-  --dw-motion-settle: 420ms;
-  --dw-ease-detent: cubic-bezier(0.2, 0.8, 0.2, 1);
+  /* ── Motion ────────────────────────────────────────────────────────────
+     Three motions, and the app needs no fourth. Each is a duration paired
+     with an easing, and the pairing is asymmetric on purpose — the single
+     loudest motion tell of a web page is one curve used in both directions,
+     because nothing physical decelerates into a stop and out of one at the
+     same rate.
 
-  /* Cut radii. Stone is worked square; these are chamfers, not pills. */
+       press    90 ms, decelerating. The finger is already there; the only
+                job is to acknowledge before the eye can doubt. Anything
+                over ~100 ms reads as lag rather than as feedback.
+       enter    260 ms, entering (slow out of the gate, long tail). A surface
+                arriving explains where it came from. This is the curve iOS
+                and Material both use for an element appearing.
+       exit     160 ms, exiting (fast off the mark, hard stop). Leaving is
+                always quicker than arriving: the user has already decided,
+                and waiting for a symmetric fade is what makes an interface
+                feel slow even when it is not.
+
+     `quick`, `detent` and `settle` are kept because they are already named in
+     EXPERIENCE_DESIGN and in shipping components: a state change, the 200 ms
+     seat, and the world moving (which the work surface never waits for). */
+  --dw-motion-press: 90ms;
+  --dw-motion-quick: 120ms;
+  --dw-motion-exit: 160ms;
+  --dw-motion-detent: 200ms;
+  --dw-motion-enter: 260ms;
+  --dw-motion-settle: 420ms;
+
+  --dw-ease-press: cubic-bezier(0.34, 0.8, 0.34, 1);
+  --dw-ease-enter: cubic-bezier(0.05, 0.7, 0.1, 1);
+  --dw-ease-exit: cubic-bezier(0.3, 0, 0.8, 0.15);
+  --dw-ease-detent: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dw-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* The composites, so a component writes one token rather than two and
+     cannot pair the wrong curve with the wrong duration. */
+  --dw-transition-press: var(--dw-motion-press) var(--dw-ease-press);
+  --dw-transition-state: var(--dw-motion-quick) var(--dw-ease-standard);
+  --dw-transition-enter: var(--dw-motion-enter) var(--dw-ease-enter);
+  --dw-transition-exit: var(--dw-motion-exit) var(--dw-ease-exit);
+
+  /* How far a press sinks and how far a surface travels in. Tokens rather
+     than literals so reduced motion can flatten them to nothing, which a
+     duration alone cannot do — a 0 ms transition to `scale(0.97)` still
+     leaves the thing 3% smaller. */
+  --dw-press-scale: 0.97;
+  --dw-enter-lift: 0.5rem;
+
+  /* Cut radii. Stone is worked square; these are chamfers, not pills.
+     `xl` is the sheet, and it is the largest cut in the app. */
   --dw-cut-sm: 2px;
   --dw-cut-md: 4px;
   --dw-cut-lg: 8px;
+  --dw-cut-xl: 12px;
 
-  /* ── The vertical scale ────────────────────────────────────────────────
-     One scale, in one place. Every screen in this host is a list of rows in a
-     column, and on a short phone the thing that runs out is vertical space —
-     so the padding, the gaps and the frame come down together rather than each
-     component carrying its own literal and being tuned separately.
+  /* ── The spacing rhythm ────────────────────────────────────────────────
+     One scale, in one place, and every gap in the harness is a step on it.
+     Eight steps, doubling then stepping by eighths of a rem, so nothing lands
+     on a half pixel at the 16 px default and nothing lands between two steps
+     because it "looked better" once on one screen.
 
-     The row height itself does NOT come down with them, and that is the point
-     of separating the two: `--dw-stack-gap` is taste, a 64 px row is a
+     A premium app has ONE rhythm. Screens that mix ad-hoc padding read as
+     several screens built by several people, which is exactly what the
+     baseline audit found: a fact row optically centred at 12 px and a choice
+     row with 8 px above its control and 12 px below it, alternating down
+     Settings. */
+  --dw-space-1: 0.25rem; /*  4 */
+  --dw-space-2: 0.5rem; /*  8 */
+  --dw-space-3: 0.75rem; /* 12 */
+  --dw-space-4: 1rem; /* 16 */
+  --dw-space-5: 1.5rem; /* 24 */
+  --dw-space-6: 2rem; /* 32 */
+  --dw-space-7: 3rem; /* 48 */
+  --dw-space-8: 4rem; /* 64 */
+
+  /* The roles. Every screen in this host is a list of rows in a column, and
+     on a short phone the thing that runs out is vertical space — so the
+     padding, the gaps and the frame come down together at the rungs below
+     rather than each component carrying its own literal and being tuned
+     separately.
+
+     The row height and the touch floor do NOT come down with them, and that
+     is the point of separating the two: gaps are taste, a 64 px row is a
      child-sized target, and a design that shrinks a target to fit another row
      on screen has made the app worse in order to look tidier. */
-  --dw-frame-pad: 1.25rem;
-  --dw-stack-gap: 1.5rem;
-  --dw-stack-gap-tight: 1rem;
-  --dw-surface-pad: 1.5rem;
+  /* The screen gutter is the one role in this list that is HORIZONTAL, and it
+     is the only one keyed to width rather than to height (see the rungs
+     below). Keyed to height with the rest, a 1024 × 768 iPad in landscape got
+     a 14 px gutter while a 390 × 844 phone got 16 and a 430 × 932 phone got
+     20 — a wider screen with a tighter margin, and a 6 px re-gutter of the
+     whole app every time one device was rotated. */
+  --dw-frame-pad: 1rem; /* screen edge → content */
+  --dw-stack-gap: 1.5rem; /* course → course */
+  --dw-stack-gap-tight: 1rem; /* within a course */
+  --dw-surface-pad: 1.5rem; /* inside a card or a course */
+  --dw-lintel-pad: 0.75rem; /* inside the lintel */
+  --dw-row-pad: 0.75rem; /* a row's own vertical padding */
+  --dw-row-gap: 1rem; /* a row's label → its value */
+  --dw-label-gap: 0.5rem; /* a legend → the control it labels */
+  --dw-grid-gap: 1rem; /* the catalogue grid */
+  --dw-inset: 0.75rem; /* inside a chip or a segment */
 
-  --dw-lintel-pad: 0.75rem;
+  /* Sizes that are facts about a hand, not taste, and therefore never scale
+     down: 44 px is the platform touch floor and 64 px is a child-sized row.
+     `--dw-target-comfort` is what anything a CHILD taps should be. */
+  --dw-target-min: 2.75rem; /* 44 px */
+  --dw-target-comfort: 3.5rem; /* 56 px */
+  --dw-row-min: 4rem; /* 64 px */
+
+  /* A true hairline. `1px` on a 3× screen is three device pixels, which is
+     the width of a border on a web page and about three times the width of a
+     separator in a native list. */
+  --dw-hairline: 1px;
+
+  /* ── The measures ──────────────────────────────────────────────────────
+     Two, and only two, and everything on a screen aligns to one of them.
+
+     The baseline audit found three competing measures on one desktop screen —
+     a full-bleed lintel, a 1152 px surface, a 672 px column of rows and a
+     full-bleed five-cell tab bar — so the wordmark, the content and the tab
+     labels each started at a different x and Parents at 1440×900 used about
+     a fifth of the screen.
+
+       `--dw-measure-text`   a column of rows, at a comfortable reading width.
+       `--dw-measure-frame`  the widest the chrome ever gets: the lintel, the
+                             navigation, and a grid of cards. The lintel and
+                             the nav align to THIS, and the column of rows is
+                             centred inside it, so there are two left edges on
+                             a wide screen instead of four. */
+  --dw-measure-text: 42rem; /* 672 px */
+  --dw-measure-frame: 72rem; /* 1152 px */
 
   /* Three rungs, one per device class this app ships to: a tablet, a phone, and
      a small phone. Untouched above 900 px — the Galaxy Tab A9 and the iPad get
      the design at full size, and nothing below is a compromise they pay for. */
+  /* The gutter, by WIDTH, and monotonic: every step out gives the content
+     more air, and rotating a device never takes any away. */
+  @media (min-width: 30rem) {
+    --dw-frame-pad: 1.25rem;
+  }
+
+  @media (min-width: 64rem) {
+    --dw-frame-pad: 1.5rem;
+  }
+
+  @media (max-width: 22.5rem) {
+    --dw-frame-pad: 0.75rem;
+  }
+
   @media (max-height: 900px) {
-    --dw-frame-pad: 1rem;
     --dw-stack-gap: 1.25rem;
     --dw-stack-gap-tight: 0.875rem;
     --dw-surface-pad: 1rem;
     --dw-lintel-pad: 0.625rem;
+    --dw-row-pad: 0.625rem;
+    --dw-label-gap: 0.5rem;
+    --dw-grid-gap: 0.875rem;
+  }
+
+  /* iPad landscape is 1024 × 768 and it fell into the rung above, where the
+     six rows of Settings overran the fold by 65 px on the widest tablet
+     orientation the app ships to. Its own rung, because "nearly fits" on the
+     screen a parent sets the app up on is worth nothing. */
+  @media (max-height: 820px) {
+    --dw-stack-gap: 1rem;
+    --dw-stack-gap-tight: 0.75rem;
+    --dw-surface-pad: 0.875rem;
+    --dw-lintel-pad: 0.5rem;
+    --dw-row-pad: 0.5rem;
+    --dw-label-gap: 0.375rem;
+    --dw-grid-gap: 0.75rem;
   }
 
   @media (max-height: 720px) {
-    --dw-frame-pad: 0.625rem;
     --dw-stack-gap: 0.75rem;
     --dw-stack-gap-tight: 0.5rem;
     --dw-surface-pad: 0.5rem;
     --dw-lintel-pad: 0.5rem;
+    --dw-row-pad: 0.375rem;
+    --dw-label-gap: 0.375rem;
+    --dw-grid-gap: 0.625rem;
   }
 
   /* The shortest viewport this app ships to gets its own rung. "Nearly fits"
      is worth nothing on a 320 × 568 screen: one row of a list below the fold
      is one row a child does not know is there. */
   @media (max-height: 620px) {
-    --dw-frame-pad: 0.5rem;
     --dw-stack-gap: 0.5rem;
     --dw-stack-gap-tight: 0.375rem;
     --dw-surface-pad: 0.25rem;
     --dw-lintel-pad: 0.25rem;
+    --dw-row-pad: 0.25rem;
+    --dw-label-gap: 0.25rem;
+    --dw-grid-gap: 0.5rem;
+  }
+
+  /* A device pixel is a device pixel. On 2× and 3× screens the platform draws
+     its separators at a physical pixel, and matching that is one of the
+     quieter differences between an app and a page. */
+  @media (min-resolution: 2dppx) {
+    --dw-hairline: 0.5px;
   }
 
   /* ── Platform facts, inherited mechanically from Corpán's stylesheet ────
@@ -355,9 +765,12 @@
   --dw-ground: var(--color-basalt-800);
   --dw-ground-sunk: var(--color-basalt-950);
   --dw-ground-raised: var(--color-basalt-700);
+  --dw-ground-lifted: var(--color-basalt-600);
+  --dw-ground-float: var(--color-basalt-500);
   --dw-ground-deep: var(--color-basalt-950);
 
   --dw-line: var(--color-stone-800);
+  --dw-line-soft: var(--color-basalt-700);
   --dw-line-strong: var(--color-stone-600);
   --dw-line-cut: var(--color-basalt-950);
 
@@ -370,7 +783,15 @@
 
   --dw-accent: var(--color-aurora-500);
   --dw-accent-ink: var(--color-aurora-300);
+  /* Not `aurora-500`: white on it measures 4.15:1 and fails AA, and a solid
+     control is exactly where a child reads a word off a colour. */
+  --dw-accent-fill: var(--color-aurora-550);
+  --dw-on-accent: var(--color-parchment-50);
   --dw-bloom: var(--color-aurora-400);
+  --dw-accent-seat: var(--color-aurora-wash-dark);
+
+  --dw-band-strap: var(--color-stone-600);
+  --dw-band-knot: var(--color-aurora-500);
 
   --dw-field: var(--color-lapis-800);
   --dw-field-ink: var(--color-celestial-300);
@@ -379,15 +800,42 @@
   --dw-aperture-rim: var(--color-celestial-300);
 
   --dw-seat: var(--color-tile-400);
-  /* The lighter oxide, not the darker one. `copper-700` on the violet void is
-     a mark a child has to hunt for; a strike is the one thing on the screen
+  /* The lighter rose, not the darker one. `rose-700` on the violet void is a
+     mark a child has to hunt for; a strike is the one thing on the screen
      that must never be missed. */
-  --dw-strike: var(--color-copper-400);
+  --dw-strike: var(--color-rose-300);
+  --dw-strike-line: var(--color-rose-600);
+  --dw-strike-ground: var(--color-rose-wash-dark);
+  --dw-strike-fill: var(--color-rose-300);
+  --dw-on-strike: var(--color-basalt-900);
   --dw-seat-ground: var(--color-tile-400-wash);
 
   --dw-case: var(--color-walnut-800);
 
   --dw-focus: var(--color-lapis-400);
+
+  /* Elevation, dark. Height is carried by the STONE, not by the shadow —
+     a drop shadow on a near-black ground is invisible, which is why so many
+     dark themes have no depth at all. Each surface is a step lighter than
+     the one below it, and each carries a one-pixel lit top edge, the way a
+     raised face catches the light above it. The cast shadow is still there,
+     tightened and deepened, to seat the object rather than to lift it. */
+  --dw-elev-surface-shadow:
+    inset 0 1px 0 var(--color-sheen-soft), 0 2px 8px -4px var(--color-void-deep);
+  --dw-elev-raised-shadow:
+    inset 0 1px 0 var(--color-sheen-mid), 0 8px 20px -8px var(--color-void-deep);
+  --dw-elev-overlay-shadow:
+    inset 0 1px 0 var(--color-sheen-mid), 0 28px 64px -16px var(--color-void-cast);
+  /* A cast shadow cannot separate anything from a near-black ground: measured,
+     the wide layer moves the pixels above the bar from rgb(11 6 24) to
+     rgb(10 5 22), which is nothing. In dark the bar is separated the way every
+     dark tab bar is — by its own lighter stone plus a LIT top edge — so the
+     edge is `sheen-mid` rather than `sheen-soft` and is doing the work
+     deliberately rather than by accident. The cast layer stays for the few
+     pixels where card art passes under it. */
+  --dw-elev-bar-shadow: 0 -1px 0 var(--color-sheen-mid), 0 -10px 24px -14px var(--color-void-mid);
+
+  --dw-scrim: var(--color-void-scrim);
 
   /* Key art does not re-cut — see the block above. Same values, stated twice,
      because the layering test is right to insist and a stylesheet it cannot
@@ -412,13 +860,19 @@
 /* ── Utilities ────────────────────────────────────────────────────────────
    `inline` is required: it makes Tailwind emit `var(--dw-ground)` rather than
    resolving the token at build time, which is what lets one stylesheet serve
-   both themes. */
+   both themes.
+
+   Everything published here is a role. A component writes `bg-ground-lifted`,
+   `p-surface`, `gap-stack` or `shadow-raised` and never a number. */
 @theme inline {
   --color-ground: var(--dw-ground);
   --color-ground-sunk: var(--dw-ground-sunk);
   --color-ground-raised: var(--dw-ground-raised);
+  --color-ground-lifted: var(--dw-ground-lifted);
+  --color-ground-float: var(--dw-ground-float);
   --color-ground-deep: var(--dw-ground-deep);
   --color-line: var(--dw-line);
+  --color-line-soft: var(--dw-line-soft);
   --color-line-strong: var(--dw-line-strong);
   --color-line-cut: var(--dw-line-cut);
   --color-ink: var(--dw-ink);
@@ -428,17 +882,56 @@
   --color-index-lit: var(--dw-index-lit);
   --color-accent: var(--dw-accent);
   --color-accent-ink: var(--dw-accent-ink);
+  --color-accent-fill: var(--dw-accent-fill);
+  --color-accent-seat: var(--dw-accent-seat);
+  --color-on-accent: var(--dw-on-accent);
   --color-bloom: var(--dw-bloom);
+  --color-band-strap: var(--dw-band-strap);
+  --color-band-knot: var(--dw-band-knot);
   --color-field: var(--dw-field);
   --color-field-ink: var(--dw-field-ink);
+  --color-aperture: var(--dw-aperture);
+  --color-aperture-rim: var(--dw-aperture-rim);
   --color-seat: var(--dw-seat);
+  --color-seat-ground: var(--dw-seat-ground);
   --color-strike: var(--dw-strike);
+  --color-strike-line: var(--dw-strike-line);
+  --color-strike-ground: var(--dw-strike-ground);
+  --color-strike-fill: var(--dw-strike-fill);
+  --color-on-strike: var(--dw-on-strike);
   --color-case: var(--dw-case);
   --color-focus: var(--dw-focus);
+  --color-scrim: var(--dw-scrim);
 
   --radius-cut-sm: var(--dw-cut-sm);
   --radius-cut-md: var(--dw-cut-md);
   --radius-cut-lg: var(--dw-cut-lg);
+  --radius-cut-xl: var(--dw-cut-xl);
+
+  /* The elevation ladder as `shadow-*`. Paired with `bg-ground-raised` /
+     `bg-ground-lifted` / `bg-ground-float` and `border-line`, these are the
+     four surfaces of the app and there is no fifth. */
+  --shadow-surface: var(--dw-elev-surface-shadow);
+  --shadow-raised: var(--dw-elev-raised-shadow);
+  --shadow-overlay: var(--dw-elev-overlay-shadow);
+  --shadow-bar: var(--dw-elev-bar-shadow);
+
+  /* The rhythm as `p-*` / `gap-*` / `m-*`. */
+  --spacing-frame: var(--dw-frame-pad);
+  --spacing-surface: var(--dw-surface-pad);
+  --spacing-lintel: var(--dw-lintel-pad);
+  --spacing-stack: var(--dw-stack-gap);
+  --spacing-stack-tight: var(--dw-stack-gap-tight);
+  --spacing-row: var(--dw-row-pad);
+  --spacing-row-gap: var(--dw-row-gap);
+  --spacing-label: var(--dw-label-gap);
+  --spacing-grid: var(--dw-grid-gap);
+  --spacing-inset: var(--dw-inset);
+  --spacing-target: var(--dw-target-min);
+  --spacing-target-comfort: var(--dw-target-comfort);
+  --spacing-row-min: var(--dw-row-min);
+  --spacing-measure-text: var(--dw-measure-text);
+  --spacing-measure-frame: var(--dw-measure-frame);
 }
 
 /* ── The settings, applied ────────────────────────────────────────────────
@@ -464,9 +957,14 @@
    is the same collapse, and both are needed: a child on a shared tablet whose
    OS setting is somebody else's is exactly who this switch is for. */
 :root[data-motion="reduced"] {
+  --dw-motion-press: 0ms;
   --dw-motion-quick: 0ms;
+  --dw-motion-exit: 0ms;
   --dw-motion-detent: 0ms;
+  --dw-motion-enter: 0ms;
   --dw-motion-settle: 0ms;
+  --dw-press-scale: 1;
+  --dw-enter-lift: 0px;
 }
 
 :root[data-motion="reduced"] *,
@@ -484,12 +982,20 @@
    change; the belt-and-braces rule below catches anything that hardcoded its
    own duration anyway. Both are needed: the first keeps the design honest,
    the second keeps a stray `transition: all 300ms` from moving the screen for
-   a child who asked it not to. */
+   a child who asked it not to.
+
+   The displacement tokens collapse too. A 0 ms transition into `scale(0.97)`
+   is still a 3% shrink; it just happens instantly, which is worse. */
 @media (prefers-reduced-motion: reduce) {
   :root {
+    --dw-motion-press: 0ms;
     --dw-motion-quick: 0ms;
+    --dw-motion-exit: 0ms;
     --dw-motion-detent: 0ms;
+    --dw-motion-enter: 0ms;
     --dw-motion-settle: 0ms;
+    --dw-press-scale: 1;
+    --dw-enter-lift: 0px;
   }
 
   *,

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -24,6 +24,13 @@
        Set on body alone the document still bounces, which is how the catalog
        slides into view above a running game. */
     overscroll-behavior: none;
+    /* WebKit inflates text in a narrow column when a page is rotated or
+       zoomed. It is a document behaviour and this is not a document; left on,
+       a phone rotated to landscape re-flows every label by a few percent,
+       which is the "text that jumps as state changes" tell arriving from the
+       platform rather than from us. */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
   }
 
   html.dw-dark {
@@ -41,6 +48,11 @@
     background-color: var(--dw-ground);
     color: var(--dw-ink);
     font-family: var(--font-text);
+    /* The platform's own text rendering. Every native surface on iOS and
+       macOS is drawn this way; leaving it off is a small, constant weight
+       difference that reads as "browser". */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     /* A child taps; nothing should select, callout, or double-tap-zoom. */
     -webkit-tap-highlight-color: transparent;
     -webkit-touch-callout: none;
@@ -54,11 +66,33 @@
     user-select: none;
   }
 
+  /* Native form controls — a checkbox, a radio, a range, a text caret — are
+     drawn by the platform in the platform's accent colour unless told
+     otherwise. Told otherwise, they are drawn in ours. */
+  :root {
+    accent-color: var(--dw-accent);
+    caret-color: var(--dw-accent);
+  }
+
   input,
   textarea,
   [contenteditable] {
     -webkit-user-select: text;
     user-select: text;
+  }
+
+  /* iOS zooms the viewport when a field under 16 px takes focus, and it does
+     not zoom back out. `max()` rather than a flat 16 px so the accessibility
+     text-size settings still scale the field up with everything else. */
+  input,
+  textarea,
+  select {
+    font-size: max(1rem, 16px);
+  }
+
+  ::selection {
+    background-color: var(--dw-accent);
+    color: var(--dw-on-accent);
   }
 
   /* The chrome must never scroll sideways. A single row whose value refuses to
@@ -71,11 +105,53 @@
     overflow-x: hidden;
   }
 
+  /* A mouse user genuinely needs a scrollbar — but they need the one their
+     desktop draws, which is an overlay thumb on nothing, not a painted grey
+     channel down the edge of the page. Thumb only, in the theme's own violet,
+     inset from the edge by a transparent border so it reads as floating. */
+  @media (pointer: fine) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: var(--dw-line-strong) transparent;
+    }
+
+    *::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+
+    *::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+
+    *::-webkit-scrollbar-thumb {
+      background-color: var(--dw-line-strong);
+      background-clip: padding-box;
+      border: 3px solid transparent;
+      border-radius: 10px;
+    }
+
+    *::-webkit-scrollbar-thumb:hover {
+      background-color: var(--dw-ink-muted);
+    }
+
+    *::-webkit-scrollbar-corner {
+      background-color: transparent;
+    }
+  }
+
   /* A persistent scrollbar track is a web-view tell. Touch platforms draw a
      transient indicator of their own during the gesture, so the drawn track is
-     pure noise there — but a mouse user genuinely needs it, so this is scoped to
-     coarse pointers rather than applied everywhere. */
-  @media (pointer: coarse) {
+     pure noise there.
+
+     `any-pointer`, and it comes AFTER the block above rather than before it,
+     and both halves of that are load-bearing. An iPad with a Magic Keyboard or
+     a trackpad reports `pointer: fine` — so the first-class tablet target was
+     matching the desktop block and getting a drawn 10 px channel, the first
+     named tell on the standing bar. `any-pointer: coarse` is true of any
+     device that has a touchscreen at all, whatever is also plugged into it,
+     and a later rule of the same specificity wins. */
+  @media (any-pointer: coarse) {
     * {
       scrollbar-width: none;
     }
@@ -84,6 +160,26 @@
       width: 0;
       height: 0;
     }
+  }
+
+  /* Sticky chrome is a contentInset, not just a z-index. The lintel is stuck
+     to the top and the tab bar to the bottom, and body is the scrolling box —
+     so anything scrolled to (a focused card under a tab walk, a field the
+     keyboard reveals) came to rest UNDER them. Measured on the catalogue at
+     390: eight of twenty-seven cards landed with their "Play" control and the
+     bottom of their focus ring behind the bar. This is the one-line
+     equivalent of what a native scroll view does for its own bars. */
+  html {
+    scroll-padding-block: calc(var(--safe-top) + 5.5rem) calc(var(--safe-bottom) + 5.5rem);
+  }
+
+  /* While a sheet is up, the page behind it must not scroll. The scrim is
+     `position: fixed`, so a drag on it was still scrolling the catalogue
+     underneath and the sheet closed onto a different offset — the surface
+     you came back to was not the one you left. */
+  html.dw-locked,
+  html.dw-locked body {
+    overflow: hidden;
   }
 
   /* One focus treatment for the whole app, keyboard-only. Children on tablets
@@ -102,5 +198,344 @@
 
   .inscription {
     font-family: var(--font-inscription);
+  }
+
+}
+
+/* ── The system, as classes ───────────────────────────────────────────────
+   Tokens describe the materials; these are the four or five compositions the
+   harness actually repeats, written once so five screens cannot drift apart.
+   In `components` rather than `utilities` so any Tailwind utility a screen
+   applies still wins over them. */
+@layer components {
+  /* ── Elevation ───────────────────────────────────────────────────────
+     Ground, sunk, surface, raised, overlay — five rungs, and there is no
+     sixth. Each is a background, an edge and a cast light together, because
+     a surface that borrows one of the three from somewhere else is how a
+     design ends up with a card that has a shadow and a border that disagree
+     about how high it is.
+
+     In LIGHT height is cast violet light; in DARK it is lighter stone plus a
+     one-pixel lit top edge. Both are handled by the tokens; a component just
+     picks a rung. */
+  .dw-sunk {
+    background-color: var(--dw-elev-sunk-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-sunk-line);
+  }
+
+  .dw-surface {
+    background-color: var(--dw-elev-surface-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-surface-line);
+    box-shadow: var(--dw-elev-surface-shadow);
+  }
+
+  .dw-raised {
+    background-color: var(--dw-elev-raised-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-raised-line);
+    box-shadow: var(--dw-elev-raised-shadow);
+  }
+
+  .dw-overlay {
+    background-color: var(--dw-elev-overlay-bg);
+    border: var(--dw-hairline) solid var(--dw-elev-overlay-line);
+    box-shadow: var(--dw-elev-overlay-shadow);
+  }
+
+  /* A bar the content scrolls under casts UP, not down. */
+  .dw-bar {
+    background-color: var(--dw-elev-raised-bg);
+    box-shadow: var(--dw-elev-bar-shadow);
+  }
+
+  .dw-scrim {
+    background-color: var(--dw-scrim);
+  }
+
+  /* ── Rules ───────────────────────────────────────────────────────────
+     A separator at one physical device pixel, which is what the platform
+     draws and about a third of what `border-b` draws on a 3× screen. */
+  .dw-hairline {
+    border: var(--dw-hairline) solid var(--dw-line);
+  }
+
+  .dw-hairline-b {
+    border-block-end: var(--dw-hairline) solid var(--dw-line);
+  }
+
+  .dw-hairline-t {
+    border-block-start: var(--dw-hairline) solid var(--dw-line);
+  }
+
+  /* ── The two measures ────────────────────────────────────────────────
+     `dw-frame` is the chrome's outer bound and carries the screen gutter,
+     widened by the safe-area inset on the side that has one — a phone in
+     landscape has an inset on exactly one side, so a symmetric padding is
+     either too little on one edge or too much on the other.
+
+     `dw-measure` is the column of rows inside it. Everything on a screen
+     aligns to one of these two and nothing invents a third. */
+  .dw-frame {
+    width: 100%;
+    max-width: var(--dw-measure-frame);
+    margin-inline: auto;
+    padding-inline-start: max(var(--dw-frame-pad), var(--safe-left));
+    padding-inline-end: max(var(--dw-frame-pad), var(--safe-right));
+  }
+
+  .dw-measure {
+    width: 100%;
+    max-width: var(--dw-measure-text);
+    margin-inline: auto;
+  }
+
+  /* ── Press ───────────────────────────────────────────────────────────
+     One press behaviour for everything a finger lands on. Fast and
+     decelerating: the finger is already there, so the only job is to
+     acknowledge before the eye can doubt that the tap registered.
+
+     `transform` is on its own curve; colour is on the state curve. They are
+     different events — one is physical, one is a change of meaning — and
+     running both on one timing is what makes a web button feel like a web
+     button. */
+  .dw-press {
+    transition:
+      transform var(--dw-transition-press),
+      background-color var(--dw-transition-state),
+      border-color var(--dw-transition-state),
+      box-shadow var(--dw-transition-state),
+      color var(--dw-transition-state);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .dw-press:active {
+    transform: scale(var(--dw-press-scale));
+  }
+
+  /* Hover is a pointer idea. Applying it on touch leaves a control looking
+     pressed after the finger has gone, which is the stuck-hover tell. */
+  @media (hover: hover) and (pointer: fine) {
+    .dw-press:hover {
+      background-color: var(--dw-ground-lifted);
+    }
+  }
+
+  /* ── Arriving and leaving ────────────────────────────────────────────
+     Explanatory, not decorative: a surface rises a little into place so it
+     is obvious it came from below, and leaves faster than it arrived
+     because the decision has already been made. Both collapse to nothing
+     under reduced motion — the durations go to zero AND `--dw-enter-lift`
+     goes to zero, because a 0 ms transition into a displaced position is
+     still a jump. */
+  .dw-anim-enter {
+    animation: dw-enter var(--dw-transition-enter) both;
+  }
+
+  .dw-anim-exit {
+    animation: dw-exit var(--dw-transition-exit) both;
+  }
+
+  .dw-anim-fade {
+    animation: dw-fade var(--dw-transition-enter) both;
+  }
+
+  /* ── A row that scrolls sideways inside the page ─────────────────────
+     The subject-chip row overflows by 440 px on a phone with nothing to say
+     so. The mask fades the content out at both edges, which is the signal
+     every native carousel uses: content that dissolves rather than stopping
+     is content that continues. Black in the gradient is a mask alpha, not a
+     colour — only its opacity is read. */
+  .dw-scroll-x {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+  }
+
+  .dw-fade-x {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black var(--dw-space-4),
+      black calc(100% - var(--dw-space-5)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black var(--dw-space-4),
+      black calc(100% - var(--dw-space-5)),
+      transparent 100%
+    );
+  }
+
+  /* ── The tab label ───────────────────────────────────────────────────
+     A tab bar gives a word one fifth of the screen and no more, and a word
+     that does not fit is the one thing it may not do about it. On a 320 px
+     phone a cell is 60 px wide; "Progress" at the app's own Largest text
+     setting wants 59 px of glyphs before any padding, so four of the five
+     labels clipped to a prefix.
+
+     So the cell is a container and the label is capped against the cell's
+     own inline size, which is exactly what a native tab bar does: the label
+     shrinks to fit and is never cut. `21cqi` is measured, not chosen — the
+     longest destination name in the inscription face runs about 3.9 px of
+     glyph per pixel of font size, and 21% of a cell leaves the padding
+     clear at every width and text size the app ships. The `min()` means the
+     cap is INERT at every ordinary width: the label is the type scale's own
+     step and only gives ground where the alternative is losing a letter.
+
+     `container-type: inline-size` is Safari 16.0, on this bundle's floor.
+     Where it is missing the `cqi` term is invalid, `min()` is dropped whole,
+     and the label falls back to the plain step below — which is the old
+     behaviour, not a broken one. */
+  .dw-tab {
+    container-type: inline-size;
+  }
+
+  .dw-tab-label {
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
+    letter-spacing: var(--text-xs--letter-spacing);
+  }
+
+  @media (min-width: 40rem) {
+    .dw-tab-label {
+      font-size: var(--text-sm);
+      line-height: var(--text-sm--line-height);
+      letter-spacing: var(--text-sm--letter-spacing);
+    }
+  }
+
+  /* The cap, in an `@supports` rather than as a second `font-size` beside the
+     first. Two declarations of one property in one rule are exactly what the
+     minifier is entitled to collapse — it did that to this file's `2.6em`
+     fallback for `2lh`, and the built stylesheet shipped with no fallback at
+     all on the devices the fallback existed for. `@supports` is uncollapsible,
+     and it names the real dependency: without container queries `cqi` is not a
+     length and the whole `min()` would be dropped anyway. */
+  @supports (container-type: inline-size) {
+    .dw-tab-label {
+      font-size: min(var(--text-xs), 21cqi);
+    }
+
+    @media (min-width: 40rem) {
+      .dw-tab-label {
+        font-size: min(var(--text-sm), 21cqi);
+      }
+    }
+  }
+
+  /* ── The courses on a wide screen ────────────────────────────────────
+     Four of the five destinations are a column of rows, and a column of rows
+     is set to a reading measure — so at 1440 × 900 the parent area used
+     about a fifth of the glass and the rest was ground. A reading measure is
+     right for a column of prose and wrong as an account of a whole screen.
+
+     Above 64 rem the courses lay out as two columns inside the frame, which
+     is what every desktop settings pane does, and it has a second effect
+     that matters more: each course now begins at the frame's own leading
+     edge, so the wordmark, the tab bar, the catalogue grid AND the rows all
+     start at the same x. Below that the courses are one column, capped at
+     the reading measure and centred, which is what `.dw-measure` already
+     did.
+
+     `align-content: start` so two courses of different lengths do not
+     stretch to match; `--dw-stack-gap` in both axes so the rhythm across is
+     the rhythm down. */
+  .dw-courses {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* A course is a list of rows, not a column of prose, so it takes the frame
+     rather than the reading measure. That is what puts every left edge in the
+     app on one x: measured at 834 the wordmark sat at 20, the tab labels at
+     20 and the rows at 81, because the rows were centred inside a 672 px
+     measure in a 794 px frame. The empty-catalogue paragraph is prose and
+     keeps `.dw-measure`. */
+  .dw-courses > .dw-course {
+    max-width: none;
+  }
+
+  @media (min-width: 64rem) {
+    .dw-courses-wide {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-content: start;
+      align-items: start;
+    }
+
+    /* The footer of the course above it, not a column beside it. */
+    .dw-courses-wide > .dw-course-span {
+      grid-column: 1 / -1;
+    }
+  }
+
+  /* The band under the lintel is the top edge of the first group. Drawing a
+     rule as well put two parallel horizontals 24 px apart at the top of every
+     destination at every width — the second one saying nothing the first had
+     not. `:nth-of-type` counts only the courses, so the screen-reader heading
+     beside them is not in the reckoning, and "the top row" is one course at
+     phone width and two once the courses are in two columns. */
+  .dw-course:first-of-type {
+    border-block-start-width: 0;
+  }
+
+  @media (min-width: 64rem) {
+    .dw-courses-wide > .dw-course:nth-of-type(-n + 2) {
+      border-block-start-width: 0;
+    }
+  }
+
+  /* ── Capitals ────────────────────────────────────────────────────────
+     Uppercase with tracking belongs to the wordmark, and to a pack title
+     that arrives from a manifest already in capitals. It does not belong on
+     a settings legend, a tab label or a section heading: a tracked, small,
+     capitalised label over a form control is a web dashboard idiom, and
+     every native platform sets that same label in sentence case at reading
+     size instead. */
+  .dw-wordmark {
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wordmark);
+  }
+
+  .dw-caps {
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+  }
+}
+
+@keyframes dw-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, var(--dw-enter-lift), 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes dw-exit {
+  from {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate3d(0, calc(var(--dw-enter-lift) * -0.5), 0);
+  }
+}
+
+@keyframes dw-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }

--- a/dynawalla/dynawalla-app/src/pass/PassSheet.tsx
+++ b/dynawalla/dynawalla-app/src/pass/PassSheet.tsx
@@ -18,6 +18,29 @@
 // holds the copy against a word list so the ban is mechanical rather than
 // remembered.
 //
+// ── How it is drawn ──────────────────────────────────────────────────────────
+// A modal is where "a web page in a wrapper" is most obvious, so every part of
+// this is the platform's construction rather than the browser's:
+//
+//   * ONE panel for all three stages, mounted once. The stages swap inside it,
+//     so the sheet arrives once and then changes its mind, rather than being
+//     torn down and rebuilt — which would replay the entrance and move focus
+//     three times.
+//   * The scrim and the panel are `.dw-scrim` and `.dw-overlay`, the elevation
+//     rungs from `index.css`. The panel used to be `bg-ground` on
+//     a deep-ground wash at 85%, which in dark measured 1.13:1 against its own
+//     backdrop: a sheet you could not see was a sheet.
+//   * Focus is trapped while it is open and returned to whatever had it when it
+//     closes. The container takes focus, never a button — Chrome matches
+//     `:focus-visible` for programmatic focus and a ring on the child-facing
+//     stage is one of the named tells.
+//   * There is deliberately NO tap-outside-to-dismiss. Every stage has a
+//     labelled way out; a scrim that closes on a stray palm is how a child
+//     dismisses the one screen an adult was reading.
+//   * Nothing on any stage appears or disappears in a way that moves what is
+//     under it. The gate's "try again" line and the offer's status line are
+//     always in the layout, empty until they have something to say.
+//
 // The CSP is `style-src 'self'`, so there is no `style` prop anywhere below —
 // an inline style works in `vite dev` and is silently dropped in the shipped
 // build, which is the worst failure mode available.
@@ -25,9 +48,9 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { fill, strings } from "../app/strings.ts"
-import { IndexMark } from "../design/IndexMark.tsx"
+import { Mark } from "../design/Mark.tsx"
 import { billing, FALLBACK_PRODUCTS, type PassProduct } from "./billing.ts"
-import { makeChallenge, passes, type Challenge } from "./parentalGate.ts"
+import { makeChallenge, passes, reissue, type Challenge } from "./parentalGate.ts"
 import { buyPass, restorePasses } from "./store.ts"
 
 type Stage = "rest" | "gate" | "offer"
@@ -39,7 +62,31 @@ export type PassSheetProps = {
   readonly onLeave: () => void
 }
 
-/** The panel every stage is drawn in. One shape, so the sheet does not jump. */
+/** Which heading names the dialog, per stage. `aria-labelledby` must follow it. */
+const TITLE_ID: Record<Stage, string> = {
+  rest: "pass-rest-title",
+  gate: "pass-gate-title",
+  offer: "pass-offer-title",
+}
+
+/**
+ * Everything inside the panel that can take focus, in document order.
+ *
+ * Queried on each Tab rather than cached, because the stages swap underneath
+ * the panel and a cached list is a list of nodes that have been unmounted.
+ */
+const FOCUSABLE =
+  'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+
+/**
+ * The panel every stage is drawn in. One shape and one mounting, so the sheet
+ * arrives once, the entrance is not replayed on every stage, and focus is taken
+ * and given back exactly once.
+ *
+ * The mark at the top is the screen's single warm point — `--dw-index`, the
+ * brand's apex gold, "once per screen, at the top of something". It is the
+ * reason this is a sheet belonging to this product rather than a dialog.
+ */
 function Panel({
   labelId,
   children,
@@ -47,16 +94,99 @@ function Panel({
   readonly labelId: string
   readonly children: React.ReactNode
 }) {
+  const dialog = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const node = dialog.current
+    if (node === null) return
+
+    // Whatever had focus before the sheet opened gets it back when it closes.
+    // Without this, closing the sheet drops focus on `<body>` and a keyboard or
+    // switch user restarts from the top of the document.
+    const before = document.activeElement instanceof HTMLElement ? document.activeElement : null
+
+    // The page behind a sheet does not move. The scrim is `position: fixed`,
+    // so body was still the scrolling box underneath it and a drag on the
+    // scrim scrolled the catalogue — the sheet then closed onto a different
+    // offset and the surface you came back to was not the one you left. The
+    // class is on `<html>`, because `overflow-x: hidden` there promotes body
+    // to the scroller and both boxes have to be told.
+    document.documentElement.classList.add("dw-locked")
+
+    // The CONTAINER, not a control. `:focus-visible` matches programmatic focus
+    // in Chrome when there has been no prior interaction, so focusing the "Choose
+    // another game" button drew a ring on the child-facing screen every time.
+    node.focus()
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return
+      const stops = [...node.querySelectorAll<HTMLElement>(FOCUSABLE)]
+      const first = stops[0]
+      const last = stops.at(-1)
+      if (first === undefined || last === undefined) {
+        // Nothing to move to. Swallowing the key is what keeps focus inside a
+        // modal that is momentarily empty rather than letting it escape to the
+        // page underneath, which is still there and still interactive.
+        event.preventDefault()
+        return
+      }
+      const held = document.activeElement
+      if (event.shiftKey && (held === first || held === node)) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && held === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    node.addEventListener("keydown", onKey)
+    return () => {
+      node.removeEventListener("keydown", onKey)
+      document.documentElement.classList.remove("dw-locked")
+      before?.focus()
+    }
+  }, [])
+
   return (
-    <div className="bg-ground-deep/85 fixed inset-0 z-[var(--z-modal)] flex items-center justify-center p-[var(--dw-frame-pad)] backdrop-blur-sm">
+    <div className="dw-scrim dw-anim-fade fixed inset-0 z-[var(--z-modal)] flex items-center justify-center pt-[max(var(--dw-frame-pad),var(--safe-top))] pr-[max(var(--dw-frame-pad),var(--safe-right))] pb-[max(var(--dw-frame-pad),var(--safe-bottom))] pl-[max(var(--dw-frame-pad),var(--safe-left))] backdrop-blur-sm">
       <div
+        ref={dialog}
         role="dialog"
         aria-modal="true"
         aria-labelledby={labelId}
-        className="bg-ground border-line-strong rounded-cut-lg max-h-[var(--dialog-max-h)] w-full max-w-md overflow-y-auto border p-[var(--dw-surface-pad)]"
+        tabIndex={-1}
+        className="dw-overlay dw-anim-enter rounded-cut-lg p-surface max-h-[var(--dialog-max-h)] w-full max-w-md overflow-y-auto overscroll-contain outline-none"
       >
+        <Mark className="text-index mx-auto block h-9 w-9" />
         {children}
       </div>
+    </div>
+  )
+}
+
+/**
+ * The head of a stage: the mark's own axis, so the three stages share one
+ * vertical rhythm and the sheet does not appear to re-typeset itself when it
+ * changes stage.
+ */
+function Head({
+  id,
+  title,
+  body,
+}: {
+  readonly id: string
+  readonly title: string
+  readonly body?: string
+}) {
+  return (
+    <div className="mt-stack-tight text-center">
+      <h2 id={id} className="inscription text-ink text-2xl text-balance">
+        {title}
+      </h2>
+      {body === undefined ? null : (
+        <p className="text-ink-muted mt-label text-md text-pretty">{body}</p>
+      )}
     </div>
   )
 }
@@ -68,6 +198,12 @@ function Panel({
  * what has been withheld. The second line is the important one and it is true:
  * every other game is open, and the child is being pointed at them rather than
  * at a shop.
+ *
+ * The way out is the only filled control on the sheet, at 64 px — a child-sized
+ * row, not a link — because it is the thing they should press and the audit
+ * found this the least inviting screen in the app. "Grown-ups" is quiet, ink
+ * grey, and carries no underline: an underlined phrase is a web idiom, and on
+ * this stage it was also the most conspicuous thing on the screen.
  */
 function Rest({
   packName,
@@ -78,27 +214,20 @@ function Rest({
   readonly onLeave: () => void
   readonly onGrownUps: () => void
 }) {
-  const leave = useRef<HTMLButtonElement | null>(null)
-  useEffect(() => leave.current?.focus(), [])
-
   return (
-    <Panel labelId="pass-rest-title">
-      <h2
-        id="pass-rest-title"
-        className="inscription text-ink text-2xl tracking-wide text-balance"
-      >
-        {fill(strings.pass.restTitle, { pack: packName })}
-      </h2>
-      <p className="text-ink-muted mt-2 text-base">{strings.pass.restBody}</p>
+    <>
+      <Head
+        id={TITLE_ID.rest}
+        title={fill(strings.pass.restTitle, { pack: packName })}
+        body={strings.pass.restBody}
+      />
 
       <button
-        ref={leave}
         type="button"
         onClick={onLeave}
-        className="border-line-cut bg-ground-raised text-ink rounded-cut-md hover:bg-ground-sunk mt-[var(--dw-stack-gap)] flex min-h-16 w-full items-center justify-center gap-3 border text-lg transition-colors duration-[var(--dw-motion-quick)]"
+        className="dw-press bg-accent-fill text-on-accent rounded-cut-md mt-stack min-h-row-min flex w-full items-center justify-center px-4 text-lg"
       >
-        <IndexMark className="text-index" />
-        <span className="inscription tracking-wide">{strings.pass.restLeave}</span>
+        <span className="inscription">{strings.pass.restLeave}</span>
       </button>
 
       {/* Small, plain, and at the bottom. A child is not being sent for a
@@ -106,11 +235,11 @@ function Rest({
       <button
         type="button"
         onClick={onGrownUps}
-        className="text-ink-muted mt-[var(--dw-stack-gap-tight)] min-h-11 w-full text-sm underline underline-offset-4"
+        className="dw-press text-ink-muted rounded-cut-sm mt-stack-tight min-h-target w-full text-sm"
       >
         {strings.pass.forGrownUps}
       </button>
-    </Panel>
+    </>
   )
 }
 
@@ -127,8 +256,14 @@ function Gate({
   const [challenge, setChallenge] = useState<Challenge>(() => makeChallenge())
   const [typed, setTyped] = useState("")
   const [wrong, setWrong] = useState(false)
-  const field = useRef<HTMLInputElement | null>(null)
-  useEffect(() => field.current?.focus(), [])
+  // The field is NOT auto-focused. Focusing it on mount drew a 2 px focus ring around the
+  // input with no user interaction at all — pixel-scanned at x = 600 on the
+  // dark gate: a ring at y432–433, an offset gap, then the field's own border
+  // at y436, two concentric rectangles, the exact pattern this design removed
+  // from the search field. It also raises the keyboard over the sheet on a
+  // phone before an adult has decided to answer. `Panel` above focuses the
+  // dialog container, which is where a modal's focus belongs; the field is one
+  // Tab away and is the first stop inside it.
 
   const submit = (event: React.FormEvent) => {
     event.preventDefault()
@@ -137,69 +272,95 @@ function Gate({
       return
     }
     // A new challenge on every miss: repeating the same one turns the gate into
-    // something a child defeats by guessing twice.
+    // something a child defeats by guessing twice. `reissue` keeps the FORM —
+    // a word is replaced by a different word — because a miss that swapped a
+    // word challenge for a year one would take a line of display type out of
+    // the layout and jump the field and the button up the screen.
     setWrong(true)
     setTyped("")
-    setChallenge(makeChallenge())
+    setChallenge((current) => reissue(current))
   }
 
-  return (
-    <Panel labelId="pass-gate-title">
-      <h2 id="pass-gate-title" className="inscription text-ink text-xl tracking-wide">
-        {strings.pass.gateTitle}
-      </h2>
+  const word = challenge.kind === "word" ? challenge.word : null
 
-      <form onSubmit={submit} className="mt-[var(--dw-stack-gap-tight)]">
-        <label htmlFor="pass-gate-entry" className="text-ink block text-base">
-          {challenge.kind === "year" ? strings.pass.gateYear : strings.pass.gateWord}
+  return (
+    <>
+      <Head id={TITLE_ID.gate} title={strings.pass.gateTitle} />
+
+      <form onSubmit={submit} className="mt-stack">
+        <label htmlFor="pass-gate-entry" className="text-ink-muted text-md block text-center">
+          {word === null ? strings.pass.gateYear : strings.pass.gateWord}
         </label>
-        {challenge.kind === "word" ? (
-          <p className="inscription text-ink mt-2 text-3xl tracking-[0.12em] break-all">
-            {challenge.word}
+        {word === null ? null : (
+          <p
+            id="pass-gate-word"
+            className="dw-caps inscription text-ink mt-label text-center text-xl break-words"
+          >
+            {word}
           </p>
-        ) : null}
+        )}
 
         <input
           id="pass-gate-entry"
-          ref={field}
           type="text"
           value={typed}
-          onChange={(event) => setTyped(event.target.value)}
+          onChange={(event) => {
+            setTyped(event.target.value)
+          }}
           autoComplete="off"
           autoCorrect="off"
-          autoCapitalize="characters"
+          // A four-digit year wants the number pad and no capitalisation; a
+          // fourteen-letter word wants the letters, in the case it is shown in.
+          inputMode={word === null ? "numeric" : "text"}
+          autoCapitalize={word === null ? "off" : "characters"}
           spellCheck={false}
-          aria-label={strings.pass.gateEntry}
+          aria-describedby={word === null ? undefined : "pass-gate-word"}
           aria-invalid={wrong}
-          className="numeral border-line-cut bg-ground-raised text-ink rounded-cut-sm mt-[var(--dw-stack-gap-tight)] min-h-16 w-full border px-4 text-2xl tracking-widest"
+          className={[
+            "dw-sunk text-ink rounded-cut-sm mt-stack-tight min-h-row-min w-full px-4 text-center text-xl",
+            wrong ? "border-strike-line" : "",
+          ].join(" ")}
         />
 
-        {wrong ? (
-          <p role="alert" className="text-strike mt-2 text-sm">
-            {strings.pass.gateWrong}
-          </p>
-        ) : null}
+        {/* Always in the layout, empty until it has something to say. A line
+            that appears on a wrong answer pushes the button it sits above down
+            the screen under the finger that is already reaching for it. */}
+        <p role="status" aria-live="polite" className="text-strike mt-label min-h-5 text-center text-sm">
+          {wrong ? strings.pass.gateWrong : ""}
+        </p>
 
         <button
           type="submit"
-          className="border-line-cut bg-ground-raised text-ink rounded-cut-md hover:bg-ground-sunk mt-[var(--dw-stack-gap-tight)] min-h-16 w-full border text-lg transition-colors duration-[var(--dw-motion-quick)]"
+          className="dw-press bg-accent-fill text-on-accent rounded-cut-md mt-label min-h-target-comfort w-full text-lg"
         >
-          <span className="inscription tracking-wide">{strings.pass.gateGo}</span>
+          <span className="inscription">{strings.pass.gateGo}</span>
         </button>
       </form>
 
       <button
         type="button"
         onClick={onCancel}
-        className="text-ink-muted mt-[var(--dw-stack-gap-tight)] min-h-11 w-full text-sm underline underline-offset-4"
+        className="dw-press text-ink-muted rounded-cut-sm mt-stack-tight min-h-target w-full text-sm"
       >
         {strings.pass.notNow}
       </button>
-    </Panel>
+    </>
   )
 }
 
-/** One pass, as a plate. The lifetime plate is the loud one; nothing else is. */
+/**
+ * One pass, as a plate.
+ *
+ * **One row, one face.** The name used to be old-style serif, the note system
+ * sans and the price a rounded grotesque, which read as three products in one
+ * row. Everything here is the text face; the price only asks for tabular lining
+ * figures so three prices line up in a column.
+ *
+ * Name and price share a baseline — the note sits under both rather than
+ * between them, which is what left the price floating in the middle of the row.
+ * The headline is carried by the frame and the type size, never by a badge, a
+ * banner, a "best value" flag or a struck-through price.
+ */
 function Plate({
   name,
   note,
@@ -213,39 +374,24 @@ function Plate({
   readonly headline: boolean
   readonly onBuy: () => void
 }) {
+  const size = headline ? "text-xl" : "text-md"
   return (
     <button
       type="button"
       onClick={onBuy}
       className={[
-        "rounded-cut-md flex min-h-20 w-full items-center gap-4 border p-4 text-left",
-        "transition-colors duration-[var(--dw-motion-quick)] hover:bg-ground-sunk",
-        // The headline is carried by the frame and the type size, not by a
-        // badge, a banner, a "best value" flag or a struck-through price.
-        headline
-          ? "border-index bg-ground-raised border-2"
-          : "border-line-cut bg-ground",
+        "dw-press dw-raised rounded-cut-md min-h-row-min block w-full p-inset text-left",
+        headline ? "border-accent border-2" : "",
       ].join(" ")}
     >
-      <span className="min-w-0 flex-1">
-        <span
-          className={[
-            "inscription text-ink block tracking-wide",
-            headline ? "text-2xl" : "text-lg",
-          ].join(" ")}
-        >
-          {name}
-        </span>
-        <span className="text-ink-muted block text-sm">{note}</span>
+      {/* `flex-wrap` and two shrinkable children: a currency that renders long
+          — "Rp 1.299.000" — wraps onto its own line instead of dragging the
+          panel sideways, which is the bug the parent area shipped once. */}
+      <span className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <span className={`text-ink min-w-0 ${size}`}>{name}</span>
+        <span className={`text-ink min-w-0 tabular-nums ${size}`}>{price}</span>
       </span>
-      <span
-        className={[
-          "numeral text-ink shrink-0",
-          headline ? "text-2xl" : "text-lg",
-        ].join(" ")}
-      >
-        {price}
-      </span>
+      <span className="text-ink-muted mt-1 block text-sm">{note}</span>
     </button>
   )
 }
@@ -292,49 +438,66 @@ function Offer({ onClose }: { readonly onClose: () => void }) {
   }
 
   return (
-    <Panel labelId="pass-offer-title">
-      <h2 id="pass-offer-title" className="inscription text-ink text-2xl tracking-wide">
-        {strings.pass.offerTitle}
-      </h2>
-      <p className="text-ink-muted mt-2 text-base">{strings.pass.offerBody}</p>
+    <>
+      <Head id={TITLE_ID.offer} title={strings.pass.offerTitle} body={strings.pass.offerBody} />
 
       {/* Lifetime first and largest. It is the one-time purchase, it is the
           cheapest way to own this outright, and a parent who hates
-          subscriptions should not have to scroll past two of them to find it. */}
-      <div className="mt-[var(--dw-stack-gap)] flex flex-col gap-[var(--dw-stack-gap-tight)]">
+          subscriptions should not have to scroll past two of them to find it.
+
+          The three sit in a SUNK track, which is the same construction every
+          platform uses for a group of choices: a recess with raised faces in
+          it. It is load-bearing in dark, where `.dw-raised` is a step darker
+          than `.dw-overlay` — a plate drawn straight onto the sheet reads as a
+          slot cut into it rather than as a key standing on it. */}
+      <div className="dw-sunk rounded-cut-md mt-stack flex flex-col gap-stack-tight p-inset">
         <Plate
           headline
           name={strings.pass.lifetime}
           note={strings.pass.lifetimeNote}
           price={by.get("lifetime")?.price ?? ""}
-          onBuy={() => buy(by.get("lifetime")?.productId)}
+          onBuy={() => {
+            buy(by.get("lifetime")?.productId)
+          }}
         />
         <Plate
           headline={false}
           name={strings.pass.month}
           note={strings.pass.monthNote}
           price={by.get("month")?.price ?? ""}
-          onBuy={() => buy(by.get("month")?.productId)}
+          onBuy={() => {
+            buy(by.get("month")?.productId)
+          }}
         />
         <Plate
           headline={false}
           name={strings.pass.day}
           note={strings.pass.dayNote}
           price={by.get("day")?.price ?? ""}
-          onBuy={() => buy(by.get("day")?.productId)}
+          onBuy={() => {
+            buy(by.get("day")?.productId)
+          }}
         />
       </div>
 
-      {failed ? (
-        <p role="alert" className="text-strike mt-[var(--dw-stack-gap-tight)] text-sm">
-          {strings.pass.storeUnavailable}
-        </p>
-      ) : null}
-      {held ? (
-        <p className="text-seat mt-[var(--dw-stack-gap-tight)] text-sm">{strings.pass.held}</p>
-      ) : null}
+      {/* One line, always present, so a store that cannot be reached does not
+          shove the way out from under the finger reaching for it. */}
+      <p
+        role="status"
+        aria-live="polite"
+        className={[
+          "mt-label min-h-5 text-center text-sm",
+          failed ? "text-strike" : "text-seat",
+        ].join(" ")}
+      >
+        {failed ? strings.pass.storeUnavailable : held ? strings.pass.held : ""}
+      </p>
 
-      <div className="mt-[var(--dw-stack-gap)] flex flex-wrap items-center justify-between gap-3">
+      {/* Two plain tinted controls, which is what a native sheet puts at its
+          foot. Neither is boxed: a filled box down here competes with the three
+          plates above it for the eye, and in dark a `.dw-raised` box on an
+          `.dw-overlay` sheet is drawn darker than the sheet it sits on. */}
+      <div className="mt-label flex flex-wrap items-center justify-between gap-3">
         <button
           type="button"
           onClick={() => {
@@ -346,19 +509,19 @@ function Offer({ onClose }: { readonly onClose: () => void }) {
               } else if (outcome.status !== "cancelled") setFailed(true)
             })
           }}
-          className="text-ink-muted min-h-11 text-sm underline underline-offset-4"
+          className="dw-press text-accent-ink rounded-cut-sm min-h-target px-inset text-sm"
         >
           {strings.pass.restore}
         </button>
         <button
           type="button"
           onClick={onClose}
-          className="border-line-cut text-ink rounded-cut-sm min-h-11 border px-4 text-sm"
+          className="dw-press text-ink rounded-cut-sm min-h-target px-inset text-sm"
         >
           {strings.pass.notNow}
         </button>
       </div>
-    </Panel>
+    </>
   )
 }
 
@@ -368,6 +531,10 @@ function Offer({ onClose }: { readonly onClose: () => void }) {
  * Escape closes it from any stage, the same as "Not now" and the same as
  * "Choose another game": there is no stage of this thing a person can be stuck
  * in, and no stage where the way out is hidden behind a delay.
+ *
+ * The panel is mounted once and the stages swap inside it. `key={stage}` gives
+ * each stage its own fade in, which is the one motion this needs: it explains
+ * that the content changed and the surface did not.
  */
 export function PassSheet({ packName, onLeave }: PassSheetProps) {
   const [stage, setStage] = useState<Stage>("rest")
@@ -380,9 +547,28 @@ export function PassSheet({ packName, onLeave }: PassSheetProps) {
     return () => window.removeEventListener("keydown", onKey)
   }, [onLeave])
 
+  let content: React.ReactNode
   if (stage === "gate") {
-    return <Gate onPassed={() => setStage("offer")} onCancel={onLeave} />
+    content = <Gate onPassed={() => setStage("offer")} onCancel={onLeave} />
+  } else if (stage === "offer") {
+    content = <Offer onClose={onLeave} />
+  } else {
+    content = (
+      <Rest
+        packName={packName}
+        onLeave={onLeave}
+        onGrownUps={() => {
+          setStage("gate")
+        }}
+      />
+    )
   }
-  if (stage === "offer") return <Offer onClose={onLeave} />
-  return <Rest packName={packName} onLeave={onLeave} onGrownUps={() => setStage("gate")} />
+
+  return (
+    <Panel labelId={TITLE_ID[stage]}>
+      <div key={stage} className="dw-anim-fade">
+        {content}
+      </div>
+    </Panel>
+  )
 }

--- a/dynawalla/dynawalla-app/src/pass/parentalGate.ts
+++ b/dynawalla/dynawalla-app/src/pass/parentalGate.ts
@@ -64,6 +64,27 @@ export const GATE_WORDS: readonly string[] = [
 ]
 
 /**
+ * How often the **year** form is drawn rather than the word form.
+ *
+ * Both forms exist because a single fixed form is a single thing to memorise.
+ * They are not, however, equally hard, and the split used to be even:
+ *
+ *   * The **word** form is the real barrier. Fourteen letters of a word a
+ *     primary-school child has no reason to have typed, copied without losing
+ *     the place — that is minutes of work for a seven-year-old and four seconds
+ *     for an adult, which is exactly the asymmetry a gate wants.
+ *   * The **year** form is instant for an adult and it is *also* instant for a
+ *     nine-year-old. This is a maths app; its audience writes the date at the
+ *     top of a page every day. At an even split, half of every child's attempts
+ *     landed on the one form they can beat.
+ *
+ * So the year is the occasional form, not the coin-flip one: still reachable,
+ * so the gate is never one memorisable thing, but the word is what a child
+ * meets four times in five.
+ */
+const YEAR_SHARE = 0.2
+
+/**
  * Build a challenge.
  *
  * `random` and `now` are injected so the test is a test rather than a coin
@@ -73,14 +94,43 @@ export function makeChallenge(
   random: () => number = Math.random,
   now: number = Date.now(),
 ): Challenge {
-  // Two forms, roughly evenly. Two rather than one because a single fixed form
-  // is a single thing to memorise, and the year is the one an adult answers
-  // instantly while being the one a young child is least likely to know.
-  if (random() < 0.5) {
+  if (random() < YEAR_SHARE) {
     return { kind: "year", answer: String(new Date(now).getFullYear()) }
   }
   const index = Math.min(GATE_WORDS.length - 1, Math.floor(random() * GATE_WORDS.length))
   const word = GATE_WORDS[index] ?? GATE_WORDS[0] ?? "TRANSMISSION"
+  return { kind: "word", word, answer: word }
+}
+
+/**
+ * A fresh challenge **of the same form** as the one that was just missed.
+ *
+ * Why the form is held constant: the two forms are not the same height on the
+ * screen. A word challenge renders a line of display type above the field; a
+ * year challenge does not. Swapping one for the other on a wrong answer takes
+ * that line out of the layout — so the field and the "Continue" button jump up
+ * the screen, under the finger that is already reaching for them, at the exact
+ * moment the person is being told they got it wrong. "Text that jumps as state
+ * changes" is one of the named web-view tells, and this is where the sheet had
+ * one.
+ *
+ * It is still a *different* challenge, which is the property that matters: a
+ * word is replaced by one of the other seventeen, never by itself, so the gate
+ * cannot be defeated by pressing Continue twice. A year has nothing to vary —
+ * the current year is the current year — and it does not need to: it is not a
+ * question you get closer to by being asked it again.
+ */
+export function reissue(
+  challenge: Challenge,
+  random: () => number = Math.random,
+  now: number = Date.now(),
+): Challenge {
+  if (challenge.kind === "year") {
+    return { kind: "year", answer: String(new Date(now).getFullYear()) }
+  }
+  const pool = GATE_WORDS.filter((word) => word !== challenge.word)
+  const index = Math.min(pool.length - 1, Math.floor(random() * pool.length))
+  const word = pool[index] ?? challenge.word
   return { kind: "word", word, answer: word }
 }
 

--- a/dynawalla/dynawalla-app/src/pass/parentalGateReissue.test.ts
+++ b/dynawalla/dynawalla-app/src/pass/parentalGateReissue.test.ts
@@ -1,0 +1,91 @@
+// `reissue` — the challenge an adult gets after a miss.
+//
+// Its own file because `parentalGate.test.ts` holds the *gate* (the property
+// that it is never arithmetic, and that a child cannot type their way through
+// it), and this holds a property of the SHEET that happens to live in the
+// model: the sheet must not change shape underneath somebody who has just been
+// told they got it wrong.
+//
+// The two forms are different heights — a word challenge renders a line of
+// display type above the field, a year challenge does not. Regenerating with
+// `makeChallenge()` swapped the form half the time, which moved the field and
+// the "Continue" button up the screen at the exact moment a finger was on its
+// way to them.
+
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { GATE_WORDS, makeChallenge, passes, reissue, type Challenge } from "./parentalGate.ts"
+
+/** A generator that walks a fixed sequence, so a test is a test not a coin toss. */
+function sequence(values: readonly number[]): () => number {
+  let index = 0
+  return () => values[index++ % values.length] ?? 0
+}
+
+const NEW_YEAR = new Date(2026, 0, 1).getTime()
+
+test("a reissued challenge keeps the form of the one it replaces", () => {
+  // The whole point. Five hundred misses, both forms, and the layout never
+  // changes height.
+  for (let i = 0; i < 500; i++) {
+    const first = makeChallenge()
+    assert.equal(reissue(first).kind, first.kind, `a ${first.kind} challenge became something else`)
+  }
+})
+
+test("a missed word is never re-asked as itself", () => {
+  // Otherwise Continue-twice is the gate. Every word in the list, checked
+  // against every draw the generator can make from the remaining seventeen.
+  for (const word of GATE_WORDS) {
+    const missed: Challenge = { kind: "word", word, answer: word }
+    for (let draw = 0; draw < GATE_WORDS.length; draw++) {
+      const next = reissue(missed, sequence([draw / GATE_WORDS.length]))
+      assert.equal(next.kind, "word")
+      if (next.kind !== "word") return
+      assert.notEqual(next.word, word, `${word} was re-issued as itself`)
+      assert.ok(GATE_WORDS.includes(next.word), `${next.word} is not a gate word`)
+    }
+  }
+})
+
+test("a reissued word is still one you have to read and type", () => {
+  // The barrier is transcription load, and a reissue that quietly handed back
+  // something short would be a gate that got easier the more you missed it.
+  const missed: Challenge = { kind: "word", word: "ACCOMMODATION", answer: "ACCOMMODATION" }
+  // A seeded generator, not `Math.random`. This file's own header promises "a
+  // test is a test, not a coin toss", and this was the one call in it that
+  // took the real one — so the assertions below ran against whatever forty
+  // draws happened to come up.
+  for (let draw = 0; draw < GATE_WORDS.length; draw++) {
+    const next = reissue(missed, sequence([draw / GATE_WORDS.length]))
+    if (next.kind !== "word") continue
+    assert.ok(next.word.length >= 13, `${next.word} is too short to be a barrier`)
+    assert.equal(next.answer, next.word)
+    // Case-insensitively, which is what `passes` does — it upper-cases BOTH
+    // sides. The line that used to be here asserted that lower case PASSES
+    // while its own message said it was rejected, and because `passes` folds
+    // the case it could not have failed either way. It tested nothing and
+    // documented the opposite of the behaviour.
+    assert.ok(passes(next, next.word.toLowerCase()), "a reissued word accepts lower case")
+    assert.equal(passes(next, `${next.word}X`), false, "a near miss is still a miss")
+  }
+})
+
+test("a reissued year is the year at the moment it is reissued", () => {
+  // A sheet left open across midnight on New Year's Eve, which is the one time
+  // a cached answer would lock a parent out of their own purchase.
+  const missed: Challenge = { kind: "year", answer: "2025" }
+  assert.equal(reissue(missed, Math.random, NEW_YEAR).answer, "2026")
+  assert.equal(passes(reissue(missed, Math.random, NEW_YEAR), "2026"), true)
+  assert.equal(passes(reissue(missed, Math.random, NEW_YEAR), "2025"), false)
+})
+
+test("reissue holds no state between calls", () => {
+  // Same input, same generator, same answer — and nothing accumulating in the
+  // module that would survive the sheet closing.
+  const missed: Challenge = { kind: "word", word: "THERMODYNAMICS", answer: "THERMODYNAMICS" }
+  const once = reissue(missed, sequence([0.3]))
+  const twice = reissue(missed, sequence([0.3]))
+  assert.deepEqual(once, twice)
+})

--- a/dynawalla/dynawalla-app/src/shell/Surface.tsx
+++ b/dynawalla/dynawalla-app/src/shell/Surface.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useId, useState } from "react"
 
 import { Catalog } from "../catalog/Catalog.tsx"
 import { IndexMark } from "../design/IndexMark.tsx"
@@ -18,39 +18,132 @@ import { useHostActions, useHostView } from "./useHost.ts"
 type Keyless<K extends Row["kind"]> = Omit<Extract<Row, { kind: K }>, "key">
 
 /**
- * One renderer for every destination.
+ * The one rhythm every row in this host shares.
  *
- * The screens of this host are all the same object — a course of inscribed
- * rows, ruled off by hairlines, cut into the ground rather than floated on
- * cards. Five screens drawing themselves five ways would be five places for the
- * design to drift and five places for an empty one to hide.
+ * Four of the five destinations are drawn by this file, so this string is the
+ * app's feel: a 64 px child-sized row, one vertical padding, one label→value
+ * gap, and one optical centre. The baseline audit found five row types that
+ * were *nearly* the same — a fact optically centred at 12 px next to a choice
+ * with 8 px above its control and 12 px below it — and the eye catches that
+ * long before anyone can name it. Written once, here, so the five cannot drift.
  *
- * Rows are `min-h-16` (64 px) so every control on every screen clears the
- * child-sized target floor, and each one lays out as label-then-control with
- * the control allowed to wrap under the label at 320 px rather than squeezing
- * it.
+ * Every length in it is a role token (`--dw-row-min`, `--dw-row-pad`,
+ * `--dw-row-gap`), so a short viewport brings the padding down at the rungs in
+ * `tokens.css` while the 64 px target floor — a fact about a hand, not taste —
+ * stays exactly where it is.
+ *
+ * **`--dw-row-pad` is not in it, and that is the whole of the fix for the row
+ * that was never 64 px.** A one-line row's content is about 24 px and the
+ * padding was inert — the 64 px minimum was doing the work. But a row holding
+ * a control is 44 px of touch floor, and 44 + 2 × 10 is 64 only by accident;
+ * a segmented control in its 4 px track is 54, and 54 + 20 is 74. So every
+ * screen in the app drew its choice rows ten pixels taller than its fact rows
+ * — measured at 74 on Parents beside facts at 64, the same Developer-mode
+ * control a different height from its neighbours. The minimum alone gives all
+ * of them exactly 64 and centres whatever is inside. Padding comes back, once,
+ * on the two-line variants below, where there is genuinely a second line.
  */
+const ROW = "flex min-h-row-min w-full items-center gap-row-gap"
+
+/**
+ * The same row when it has a second line in it: a long fact stacked under its
+ * label, or a three-option control that will not fit beside one on a phone.
+ * Here the padding is not inert and is what keeps two lines off the hairline.
+ */
+const ROW_STACKED = `${ROW} flex-col items-start py-row`
+
+/** The label of a row: the display face at the one size a list is read at. */
+const ROW_LABEL = "inscription min-w-0 text-md"
+
+/**
+ * The value of a fact, at one size whether the row is inline or stacked.
+ *
+ * Body face, not `--font-numeral`. The rounded grotesque is where digits live
+ * when digits are the subject — a score, a price — and a version string beside
+ * an old-style-serif label made one row carry two unrelated voices, which is
+ * the collision FOUNDATION names. `tabular-nums` keeps the figures lining up
+ * down a column without dragging a third typeface into the row.
+ */
+const FACT_VALUE = "text-ink-muted min-w-0 text-base break-words tabular-nums"
+
+/**
+ * A value long enough that a two-column row stops being a row.
+ *
+ * Developer mode prints capability grants — `core:app:allow-version` against
+ * `@tauri-apps/api/app.getVersion` — and squeezed into label/value columns each
+ * side wraps to two lines with a ragged gutter down the middle, which the audit
+ * called the ugliest block in the app. Past this budget the row stacks instead:
+ * label, then value beneath it, both flush left. Deliberate rather than
+ * squeezed, and it is the same shape a native list uses for a long detail.
+ */
+const INLINE_BUDGET = 34
+
+/** What a fact with nothing to report draws. Never a blank space. */
+const NOTHING = "—"
+
 function Fact({ name, value }: { name: string; value: string }) {
-  return (
-    // `shrink-0` on the value was the bug behind the parent area scrolling
-    // sideways on a phone. A fact's value is usually two words — "35 kB",
-    // "Native (Tauri)" — so refusing to shrink looked free, until developer
-    // mode started printing capability strings like
-    // `@tauri-apps/api/app.getVersion`. A flex child that will not shrink and
-    // will not wrap pushes its parent wider than the screen, and the whole page
-    // goes with it, header included.
-    //
-    // Both children get `min-w-0` because a flex item's default `min-width:
-    // auto` refuses to shrink below its content regardless of any `shrink`
-    // setting — the classic version of this bug that survives a naive fix.
-    <div className="flex min-h-16 items-center justify-between gap-4 py-3">
-      <span className="inscription min-w-0 text-lg tracking-wide">{name}</span>
-      <span className="numeral text-ink-muted min-w-0 text-right text-sm break-words">
-        {value}
-      </span>
+  const shown = value.trim().length > 0 ? value : NOTHING
+  const stacked = name.length + shown.length > INLINE_BUDGET
+
+  // `min-w-0` on both children, and no `shrink-0` anywhere: a flex item's
+  // default `min-width: auto` refuses to shrink below its content regardless of
+  // any `shrink` setting, which is the version of the parent-area sideways
+  // scroll that survives a naive fix. Keep both.
+  // `--dw-space-1` and not `--dw-label-gap` between the two lines of a stacked
+  // pair, and it is a pairing fix rather than a taste one: at the label gap the
+  // distance from a label to its own value (~41 px of baseline separation) was
+  // the same as the distance from that value across the hairline to the NEXT
+  // label (~44 px), so `@tauri-apps/api/app.getVersion` was as plausibly
+  // attached to the row below it as to its own. A pair has to be tighter
+  // inside than the gap that separates it from the next pair.
+  return stacked ? (
+    <div className={`${ROW_STACKED} gap-[var(--dw-space-1)]`}>
+      <span className={`${ROW_LABEL} w-full`}>{name}</span>
+      <span className={`${FACT_VALUE} w-full`}>{shown}</span>
+    </div>
+  ) : (
+    <div className={`${ROW} justify-between`}>
+      <span className={ROW_LABEL}>{name}</span>
+      <span className={`${FACT_VALUE} text-right`}>{shown}</span>
     </div>
   )
 }
+
+/**
+ * Where the selection sits in a segmented control, as static classes.
+ *
+ * A thumb that slides has to know which of N it is on, and the obvious way to
+ * say that is a `style` prop — which `style-src 'self'` throws away silently in
+ * the shipped build while working perfectly in dev. So the two or three or four
+ * positions a real control ever has are written out and picked from.
+ *
+ * Indexed by option count, so `THUMB_WIDTH[3]` is the width of one third.
+ */
+const THUMB_WIDTH: readonly string[] = ["", "w-full", "w-1/2", "w-1/3", "w-1/4"]
+const THUMB_OFFSET: readonly string[] = [
+  "translate-x-0",
+  "translate-x-full",
+  "translate-x-[200%]",
+  "translate-x-[300%]",
+]
+
+/**
+ * How wide a control is allowed to get once there is room.
+ *
+ * Half the course is the right share of a phone and absurd on a tablet: at
+ * 1024 the parent area drew a 480 px On/Off pair for a two-word question, and
+ * a control that grows without limit is the giveaway that a layout was
+ * designed at one width. The cap is per option count, because two words and
+ * four words do not want the same box, and it applies from `sm` up only —
+ * below that half a phone is already the tight case, not the loose one.
+ */
+const TRACK_MAX: readonly string[] = [
+  "",
+  "sm:max-w-[9rem]",
+  "sm:max-w-[12rem]",
+  "sm:max-w-[18rem]",
+  "sm:max-w-[24rem]",
+]
 
 /**
  * A choice, drawn as every option at once.
@@ -59,55 +152,163 @@ function Fact({ name, value }: { name: string; value: string }) {
  * both are invisible to a screen reader that has not been told, and to anyone
  * reading a monochrome screen. `aria-pressed` is the state, the index mark is
  * the sighted signal, and the chosen option's own word is always visible.
+ *
+ * Drawn the way every platform draws one — **a recessed track with a raised
+ * thumb in it**. The whole app used to draw it inverted: the chosen option got
+ * the darker ground and the unchosen ones the lighter, so the option you had
+ * not picked looked like the pressable key and the one you had looked like a
+ * hole. The thumb slides on the detent curve rather than swapping, because a
+ * hard swap gives a control no physical account of itself.
+ *
+ * `<div role="group">` rather than `<fieldset><legend>`: a legend is laid out
+ * in the fieldset's border area with its own padding rules, so the gap between
+ * a label and the control it labels could not be `--dw-label-gap` no matter
+ * what was written.
+ *
+ * The index mark is always rendered and fades rather than being inserted. A
+ * mark that appears into flow shifts its own label sideways the moment it is
+ * chosen, which is the "text that jumps as state changes" defect. It is drawn
+ * in the accent, not the index: the brand allows **one** warm point per screen
+ * and on these screens that one is the navigation's diamond, not six of these.
  */
-function Choice({
-  name,
-  value,
-  options,
-  choose,
-}: Keyless<"choice">) {
+function Choice({ name, value, options, choose }: Keyless<"choice">) {
+  const labelId = useId()
+  const count = options.length
+  const sliding = count >= 2 && count < THUMB_WIDTH.length
+  const chosen = options.findIndex((option) => option.value === value)
+
+  // A two-way control sits on the row beside its label at every width — which
+  // is where a choice row becomes exactly the same 64 px object as a fact row,
+  // and Settings stops alternating between two rhythms down the screen. Three
+  // options do not fit a phone's half-row without truncating a word, so those
+  // take a line of their own until there is room, and take the row's rhythm
+  // with them: same padding, same label gap, same rules.
+  const stacks = count > 2
+  const rowCls = stacks
+    ? `${ROW_STACKED} gap-label sm:flex-row sm:items-center sm:gap-row-gap sm:py-0`
+    : ROW
+
   return (
-    <fieldset className="min-h-16 py-3">
-      <legend className="inscription mb-2 text-lg tracking-wide">{name}</legend>
-      <div className="border-line-cut rounded-cut-sm flex overflow-hidden border">
-        {options.map((option) => {
-          const active = option.value === value
-          return (
-            <button
-              key={option.value}
-              type="button"
-              aria-pressed={active}
-              onClick={() => choose(option.value)}
+    <div role="group" aria-labelledby={labelId} className={rowCls}>
+      <span id={labelId} className={`${ROW_LABEL} ${stacks ? "sm:flex-1" : "flex-1"}`}>
+        {name}
+      </span>
+      {/* `p-1` is `--dw-space-1`: the gutter that makes the thumb read as a
+          thumb sitting in a track rather than as a lid on top of it. */}
+      <div
+        className={[
+          "dw-sunk rounded-cut-md shrink-0 p-1",
+          stacks ? "w-full sm:w-1/2" : "w-1/2",
+          TRACK_MAX[count] ?? "",
+        ].join(" ")}
+      >
+        {/* No padding of its own, so it is the exact containing block the
+            absolutely-positioned thumb measures its width against. */}
+        <div className="relative flex">
+          {sliding && chosen >= 0 ? (
+            <span
+              aria-hidden="true"
               className={[
-                "border-line-cut flex min-h-11 flex-1 items-center justify-center gap-2 border-r px-3 text-sm last:border-r-0",
-                "transition-colors duration-[var(--dw-motion-quick)]",
-                active ? "bg-ground text-ink" : "bg-ground-raised text-ink-muted",
+                "dw-raised rounded-cut-sm pointer-events-none absolute inset-y-0 start-0",
+                THUMB_WIDTH[count],
+                THUMB_OFFSET[chosen],
+                "transition-transform duration-[var(--dw-motion-detent)] ease-[var(--dw-ease-detent)]",
               ].join(" ")}
-            >
-              {active ? <IndexMark className="text-index" /> : null}
-              {option.label}
-            </button>
-          )
-        })}
+            />
+          ) : null}
+          {options.map((option) => {
+            const active = option.value === value
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={active}
+                onClick={() => {
+                  choose(option.value)
+                }}
+                className={[
+                  "dw-press px-inset min-h-target relative z-10 flex flex-1 basis-0 items-center justify-center text-sm",
+                  !sliding && active ? "dw-raised rounded-cut-sm" : "",
+                  active ? "text-ink" : "text-ink-muted",
+                ].join(" ")}
+              >
+                {/* Out of flow, in the segment's own padding. In flow — even at
+                    zero opacity, which is what reserving its space means — the
+                    mark pushed every label about 6 px right of its cell's
+                    optical centre, on every segment of every control. Absolute
+                    keeps the label centred AND keeps nothing moving when the
+                    choice changes, which was the point of reserving it. */}
+                <IndexMark
+                  className={[
+                    "text-accent pointer-events-none absolute start-[var(--dw-space-1)] top-1/2 -translate-y-1/2",
+                    "transition-opacity duration-[var(--dw-motion-quick)]",
+                    active ? "opacity-100" : "opacity-0",
+                  ].join(" ")}
+                />
+                <span className="min-w-0 truncate">{option.label}</span>
+              </button>
+            )
+          })}
+        </div>
       </div>
-    </fieldset>
+    </div>
   )
 }
 
-function Action({ name, tone, run }: Keyless<"action">) {
+/**
+ * A thing this row does.
+ *
+ * Plain actions are drawn in the accent ink, because a row that is a control
+ * and a row that is a fact must not look the same — "Add a learner" used to be
+ * the same colour as "Learners 3" with an invisible index mark reserving 44 px
+ * of gutter in front of it, which is where the audit's three different left
+ * edges on one screen came from. The gutter is gone; every label on every
+ * screen now starts at the same x.
+ *
+ * Destructive is the exception, and it is deliberately a different object: a
+ * bounded plate, centred, in the rose the palette owns for a strike. Armed, it
+ * fills with the strike wash and takes the strike line — so the press that
+ * actually erases is made against a control that has visibly changed state,
+ * while the label swaps in place and nothing above or below it moves.
+ */
+function Action({ name, tone, run, armed }: Keyless<"action"> & { armed: boolean }) {
+  if (tone !== "danger") {
+    return (
+      <button type="button" onClick={run} className={`${ROW} dw-press text-accent-ink text-start`}>
+        <span className={ROW_LABEL}>{name}</span>
+      </button>
+    )
+  }
+
+  // The plate sits INSIDE the row rather than being it, so the row's own
+  // padding stays clear above and below and the frame does not come within a
+  // hairline of the rule belonging to the control above it.
   return (
-    <button
-      type="button"
-      onClick={run}
-      className={[
-        "group flex min-h-16 w-full items-center gap-3 py-3 text-left",
-        "transition-colors duration-[var(--dw-motion-quick)] hover:bg-ground-sunk",
-        tone === "danger" ? "text-strike" : "text-ink",
-      ].join(" ")}
-    >
-      <IndexMark className="opacity-0 transition-opacity duration-[var(--dw-motion-quick)] group-hover:opacity-100 group-focus-visible:opacity-100" />
-      <span className="inscription text-lg tracking-wide">{name}</span>
-    </button>
+    <div className={ROW}>
+      <button
+        type="button"
+        // The armed state is a state, not a spelling. Without this the only
+        // thing that changed on a press was the control's own NAME — a silent
+        // rename of the thing a screen reader has focused, with no live region
+        // and no announcement, and the opposite convention to the Remove
+        // button two screens away, which has carried `aria-pressed` all along.
+        aria-pressed={armed}
+        onClick={run}
+        className={[
+          "dw-press rounded-cut-md px-inset min-h-target text-strike hover:bg-strike-ground",
+          "flex w-full items-center justify-center border",
+          // `line-strong` at rest, not `line`. Measured in light, the plate's
+          // border and the hairline between two ordinary rows were the same
+          // rgb(201 188 236) — so the "bounded plate" the design calls for was
+          // bounded by the same line a list separator is drawn with, and did
+          // not read as bounded at all. It does in dark, which is how it was
+          // missed.
+          armed ? "border-strike-line bg-strike-ground" : "border-line-strong",
+        ].join(" ")}
+      >
+        <span className={ROW_LABEL}>{name}</span>
+      </button>
+    </div>
   )
 }
 
@@ -119,38 +320,107 @@ function Action({ name, tone, run }: Keyless<"action">) {
  * absence of the "Use" button — because which child the tablet is set to is the
  * single most consequential piece of state in this app, and none of the three
  * is a colour.
+ *
+ * All three of those live at the **trailing** end. Drawn at the leading end the
+ * mark indented the current learner's name by 44 px and left the other two
+ * flush, so one screen had two left edges and the name field had two different
+ * widths. Here every name starts where every other row's label starts, and the
+ * trailing controls line up in a column: the "Use" button is still laid out for
+ * the current learner, just invisible and out of the tab order, because
+ * reserving the space is what stops the row reflowing when a parent switches.
+ *
+ * The field is drawn as a recess rather than as an underline. An underlined,
+ * transparent, `flex-1` input took its width from whichever siblings happened
+ * to be present, so three learners had three different underline lengths, and
+ * nothing about it said "you may type here".
+ *
+ * Removing a learner takes two presses. It erases a child's whole record and it
+ * sits a finger's width from "Use"; two rows away in the parent area the
+ * *less* destructive "Erase everything" is already armed before it fires. The
+ * armed plate fills solid rose, and `aria-pressed` says so.
  */
 function Learner({ name, given, current, use, rename, remove }: Keyless<"learner">) {
+  const [armed, arm] = useState(false)
+
+  // All three learner fields used to answer to the same accessible name,
+  // "Name", with the child only in the value — so a screen reader read a
+  // column of three identical controls. The field is named for its own
+  // learner, and "current" is said in words rather than only by an
+  // `aria-hidden` diamond, an `aria-current` on a role-less `div` and the
+  // ABSENCE of a button.
+  const who = given.trim().length > 0 ? given : name
+
   return (
-    <div
-      className="flex min-h-16 items-center gap-3 py-3"
-      aria-current={current ? "true" : undefined}
-    >
-      {current ? <IndexMark className="text-index shrink-0" /> : null}
+    <div className={ROW} aria-current={current ? "true" : undefined}>
+      {current ? <span className="sr-only">{strings.profiles.current}</span> : null}
       <input
         type="text"
         value={given}
         placeholder={name}
-        aria-label={strings.profiles.name}
-        onChange={(event) => rename(event.target.value)}
-        className="inscription border-line focus-visible:border-line-cut min-w-0 flex-1 border-b bg-transparent py-2 text-lg tracking-wide"
+        aria-label={`${strings.profiles.name}: ${who}`}
+        onChange={(event) => {
+          rename(event.target.value)
+        }}
+        className="dw-sunk inscription rounded-cut-sm px-inset min-h-target text-ink placeholder:text-ink-muted min-w-0 flex-1"
       />
-      {current ? null : (
+      <span className="gap-label flex shrink-0 items-center">
+        <IndexMark className={current ? "text-accent" : "opacity-0"} />
         <button
           type="button"
           onClick={use}
-          className="border-line-cut rounded-cut-sm text-ink-muted min-h-11 shrink-0 border px-3 text-sm"
+          disabled={current}
+          aria-hidden={current || undefined}
+          tabIndex={current ? -1 : undefined}
+          className={[
+            "dw-press border-line rounded-cut-sm px-inset min-h-target border text-sm",
+            current ? "invisible" : "text-ink",
+          ].join(" ")}
         >
           {strings.profiles.use}
         </button>
-      )}
+      </span>
       {remove ? (
         <button
           type="button"
-          onClick={remove}
-          className="text-strike min-h-11 shrink-0 px-2 text-sm"
+          aria-pressed={armed}
+          onClick={() => {
+            if (armed) {
+              arm(false)
+              remove()
+            } else {
+              arm(true)
+            }
+          }}
+          onBlur={() => {
+            arm(false)
+          }}
+          // Quiet at rest, and quiet means QUIET: the muted ink, not the rose.
+          // Three learners put three crimson words down one screen — four loud
+          // points counting the tab bar's diamond, against a brand rule of one
+          // — and they were the loudest thing on the profiles screen, which is
+          // a screen about children rather than about deletion. Danger is what
+          // the control becomes when it is armed and a second press would
+          // actually erase somebody, which is also when it is worth saying.
+          className={[
+            "dw-press rounded-cut-sm px-inset min-h-target min-w-target shrink-0 text-sm",
+            armed
+              ? "bg-strike-fill text-on-strike"
+              : "text-ink-muted hover:text-strike hover:bg-strike-ground",
+          ].join(" ")}
         >
-          {strings.profiles.remove}
+          {/* Both labels, stacked in one grid cell, with the longer one always
+              in flow and invisible. The armed word is wider than the resting
+              one, and this row's name field is `flex-1` — so a bare label swap
+              would take ~20 px off the field a parent is looking at at the
+              exact moment they press. Nothing moves; the word still changes. */}
+          <span className="grid place-items-center">
+            <span aria-hidden="true" className="invisible col-start-1 row-start-1">
+              {strings.profiles.removeConfirm}
+            </span>
+            <span className="col-start-1 row-start-1 whitespace-nowrap">
+              {armed ? strings.profiles.removeConfirm : strings.profiles.remove}
+            </span>
+          </span>
         </button>
       ) : null}
     </div>
@@ -164,11 +434,22 @@ function Learner({ name, given, current, use, rename, remove }: Keyless<"learner
  * The drawing takes its text alternative from the row rather than building one,
  * which is what keeps `src/world/` a drawing of a number and not a part of the
  * app's copy.
+ *
+ * It is capped at a hand's width on a phone and let out from `sm` up, because
+ * this is the screen a child comes to in order to feel something about their
+ * own work and it was using a quarter of a tablet. Not the whole measure: at
+ * 1024 × 768 — iPad landscape, the shortest wide viewport this app ships to —
+ * the full-measure drawing pushed the two rows under it eight pixels past the
+ * fold. Measured, then capped one step below it.
  */
 function Figure({ value, label }: Keyless<"figure">) {
   return (
-    <div className="py-3">
-      <WorldScreen placed={value} label={label} className="mx-auto block h-auto w-full max-w-sm" />
+    <div className="py-row w-full">
+      <WorldScreen
+        placed={value}
+        label={label}
+        className="mx-auto block h-auto w-full max-w-sm sm:max-w-xl"
+      />
     </div>
   )
 }
@@ -181,7 +462,7 @@ function Figure({ value, label }: Keyless<"figure">) {
  * error on every render and the key does nothing. The `<li>` above owns the
  * key; the component gets the fields it draws.
  */
-function RowView({ row }: { row: Row }) {
+function RowView({ row, armed }: { row: Row; armed: boolean }) {
   switch (row.kind) {
     case "fact":
       return <Fact name={row.name} value={row.value} />
@@ -193,7 +474,7 @@ function RowView({ row }: { row: Row }) {
     case "action": {
       const { key, ...rest } = row
       void key
-      return <Action {...rest} />
+      return <Action {...rest} armed={armed} />
     }
     case "learner": {
       const { key, ...rest } = row
@@ -213,6 +494,16 @@ function RowView({ row }: { row: Row }) {
   }
 }
 
+/**
+ * One row, and that row does something. Then the section is the footer of the
+ * course above it — "Add a learner" under the learners — rather than a course
+ * of its own, and on a wide screen it runs the full width instead of taking a
+ * column beside the list it belongs to.
+ */
+function isFoot(section: Section): boolean {
+  return section.rows.length === 1 && section.rows[0]?.kind === "action"
+}
+
 /** Every row in this section is a game. Then it is a catalogue, not a course. */
 function isCatalogue(section: Section): boolean {
   return section.rows.length > 0 && section.rows.every((row) => row.kind === "pack")
@@ -223,9 +514,34 @@ export function Surface({ destination }: { destination: Destination }) {
   const view = useHostView(armed)
   const actions = useHostActions(arm)
   const sections = surfaceOf(destination, view, actions)
+  const title = strings.destinations[destination]
+
+  // The document had one title, "Dynawalla", on all five routes, and no <h1>
+  // anywhere in the app. In a WebView nobody sees a title bar — but assistive
+  // technology announces exactly this on a route change, and without it a
+  // screen-reader user pressed a tab and heard silence. The heading is the
+  // same word the tab is labelled with, so it costs no new copy, and it is
+  // drawn nowhere: the tab bar already says where you are, permanently, and
+  // two places saying it are two places to disagree.
+  useEffect(() => {
+    document.title = `${title} — ${strings.appName}`
+  }, [title])
+
+  // Two columns of courses on a wide screen — but never for the catalogue,
+  // which is one section and would take half the glass and leave the other
+  // half empty. `.dw-courses` itself is unconditional: it is the column, and
+  // it is what takes the reading measure off a list of rows so that every left
+  // edge in the app lands on one x.
+  //
+  // Deliberately NOT `flex flex-col` beside it. Tailwind utilities live in a
+  // later cascade layer than these compositions, so a `flex` utility on the
+  // element silently beat `display: grid` and the two-column rule did nothing
+  // at all — measured, a settings course at 1440 came back 1104 px wide.
+  const wide = sections.every((section) => !isCatalogue(section)) && sections.length > 1
 
   return (
-    <div className="flex flex-col gap-[var(--dw-stack-gap)]">
+    <div className={`dw-courses gap-stack ${wide ? "dw-courses-wide" : ""}`}>
+      <h1 className="sr-only">{title}</h1>
       {sections.map((section) =>
         isCatalogue(section) ? (
           // The games, as a grid of cards with a search field and the subject
@@ -241,10 +557,43 @@ export function Surface({ destination }: { destination: Destination }) {
           // none under the last: a closing rule plus the next section's opening
           // one reads as a double line at every seam, which is a groove nobody
           // cut.
-          <ul key={section.key} className="border-line mx-auto w-full max-w-2xl border-t">
-            {section.rows.map((row) => (
-              <li key={row.key} className="border-line border-b last:border-b-0">
-                <RowView row={row} />
+          //
+          // The rule above the course is full bleed — it is the top edge of the
+          // group. The rules *between* rows are inset to the text origin, the
+          // way every native list draws a separator; a 1 px line running the
+          // full width between every pair of rows is a web table. Both are
+          // `--dw-hairline`, which is half a pixel on a 2× screen, because a
+          // 1 px border on a 3× phone is three device pixels and about three
+          // times what the platform draws.
+          //
+          // Except on the top row of courses, where `.dw-course` in
+          // `index.css` takes it away: the strapwork band already draws a
+          // horizontal 24 px higher, so every destination at every width
+          // opened with two parallel lines a finger apart, one of them
+          // structural and the other restating it. The band IS the top edge of
+          // the first group. It is done in CSS rather than by index because
+          // "the top row" is one course at phone width and two at desktop.
+          <ul
+            key={section.key}
+            className={[
+              "dw-course dw-measure dw-hairline-t",
+              // A course whose only row is an action is not a peer of the list
+              // above it — it is that list's own footer. In two columns without
+              // this, "Add a learner" was laid beside the learners rather than
+              // under them, level with the first name, reading as a second
+              // list with one thing in it.
+              isFoot(section) ? "dw-course-span" : "",
+            ].join(" ")}
+          >
+            {section.rows.map((row, index) => (
+              <li key={row.key} className="relative">
+                <RowView row={row} armed={armed} />
+                {index < section.rows.length - 1 ? (
+                  <span
+                    aria-hidden="true"
+                    className="dw-hairline-b start-inset pointer-events-none absolute end-0 bottom-0"
+                  />
+                ) : null}
               </li>
             ))}
           </ul>

--- a/dynawalla/dynawalla-app/src/world/Screen.tsx
+++ b/dynawalla/dynawalla-app/src/world/Screen.tsx
@@ -57,23 +57,34 @@ export function WorldScreen({
       viewBox={`0 0 ${String(box.width)} ${String(box.height)}`}
       focusable="false"
     >
-      {/* Chrome, 1 of CHROME_NODES: the stone plate the screen is cut from. */}
+      {/* Chrome, 1 of CHROME_NODES: the stone plate the screen is cut from.
+          Inset by half its own stroke, because an SVG stroke is centred on the
+          path: at x = 0 half of it fell outside the viewBox and was clipped, so
+          the plate was drawn a device pixel wider than its own frame down the
+          left and right and read as a misregistered print. `ground-sunk` and
+          not `ground-raised`: in light the plate was pure white on a violet
+          page with near-black apertures cut in it, which is the highest
+          contrast pair in the app spent on a decorative drawing. Stone, not
+          paper. */}
       <rect
-        x="0"
-        y="0"
-        width={box.width}
-        height={box.height}
-        fill="var(--dw-ground-raised)"
-        stroke="var(--dw-line-cut)"
+        x="0.25"
+        y="0.25"
+        width={box.width - 0.5}
+        height={box.height - 0.5}
+        fill="var(--dw-ground-sunk)"
+        stroke="var(--dw-line-strong)"
         strokeWidth="0.5"
       />
-      {/* Chrome, 2 of CHROME_NODES: the sill the courses are laid on. */}
+      {/* Chrome, 2 of CHROME_NODES: the sill the courses are laid on. Half a
+          unit and inside the plate. A full unit of `line-strong` running the
+          whole width and a fraction PAST it read as a failed drop shadow
+          rather than as the course the work stands on. */}
       <rect
-        x="0"
-        y={box.height - 1}
-        width={box.width}
-        height="1"
-        fill="var(--dw-line-strong)"
+        x="0.25"
+        y={box.height - 0.75}
+        width={box.width - 0.5}
+        height="0.5"
+        fill="var(--dw-line-cut)"
       />
       {pieces.map((piece) => {
         const material = paint(piece)

--- a/dynawalla/dynawalla-app/tools/.gitignore
+++ b/dynawalla/dynawalla-app/tools/.gitignore
@@ -1,0 +1,26 @@
+# Capture output.
+#
+# The PNGs are ~9 MB per run and every one of them is regenerated in about
+# seventy seconds by `node tools/capture.mjs`. `*.png` is Git LFS repo-wide, so
+# committing them would push ten megabytes of LFS objects on every design pass
+# to preserve something that is derived, not authored.
+#
+# What IS committed is the tool, the harness it builds, `shots/AUDIT.md` and
+# `shots/measurements.json` — the findings and the numbers behind them, which
+# are the parts a reviewer needs without a machine to run Chrome on.
+shots/**/*.png
+
+# The per-agent write-ups and the raw measurement dump are working notes from one
+# design pass, not a record the next reader needs: together they are 1.3 MB, which
+# alone pushes a PR past the point where `adversarial-review` truncates the diff
+# and reviews nothing. `AUDIT.md` is kept — it is the findings in prose. The
+# numbers behind it are one `node tools/capture.mjs` away.
+shots/measurements.json
+shots/CRAFT-*.md
+shots/VERIFY-*.md
+shots/REPAIR.md
+shots/FOUNDATION.md
+.harness-dist/
+
+# Scratch output of `--probe=`: a question somebody asked once, not a record.
+shots/probe.json

--- a/dynawalla/dynawalla-app/tools/capture.mjs
+++ b/dynawalla/dynawalla-app/tools/capture.mjs
@@ -1,0 +1,981 @@
+#!/usr/bin/env node
+/* ───────────────────────────────────────────────────────────────────────────
+   Dynawalla — the eyes.
+
+       node tools/capture.mjs                # build, serve, capture everything
+       node tools/capture.mjs --no-build     # reuse dist/ and tools/.harness-dist
+       node tools/capture.mjs --only=settings,parents
+       node tools/capture.mjs --widths=390,1440 --themes=dark
+       node tools/capture.mjs --textsize=largest   # the app's own a11y setting
+       node tools/capture.mjs --probe=q.js         # one expression, every page
+
+   Output:
+       tools/shots/<theme>/<screen>-<width>.png     (gitignored — derived)
+       tools/shots/measurements.json                (committed)
+       tools/shots/AUDIT.md                         (committed, written by hand)
+
+   The PNGs are deliberately NOT committed: nine megabytes an run, `*.png` is
+   Git LFS repo-wide, and every one of them is back in seventy seconds. The
+   numbers and the findings are committed, because those are what a reviewer
+   without a machine to run Chrome on actually needs.
+
+   ── WHY THIS EXISTS ───────────────────────────────────────────────────────
+
+   The standing bar for this app is "premium native-like behavior", and every
+   tell that breaks it is a VISUAL fact: a drawn scrollbar track, a page that
+   slides sideways, a control smaller than a child's fingertip, a text pair
+   that fails AA, spacing that does not match the screen next door. None of
+   those can be reviewed by reading a component. Two of this app's five
+   destinations once rendered completely empty for weeks with a green test
+   suite, which is the same lesson in its most expensive form.
+
+   So this tool takes the app apart into every screen × every size × both
+   themes, writes a PNG of each, and — more usefully — writes the measurements
+   that a screenshot cannot be trusted to reveal: horizontal overflow, elements
+   escaping the viewport, interactive targets under 44 px, and the computed
+   colour of every text run against the ground it actually sits on, with the
+   contrast ratio already worked out.
+
+   It is meant to be re-run. Change a token, run this, look again.
+
+   ── THE HEADLESS-CHROME 500px CLAMP TRAP ──────────────────────────────────
+
+   Read this before "fixing" the tool to be simpler.
+
+   `chrome --headless --window-size=390,844 --screenshot=out.png` does NOT
+   render at 390 px. Headless Chrome clamps its window — and therefore its
+   viewport — to a 500 px minimum. What you get is a 500 px render cropped to
+   390, which looks *exactly* like a mobile layout bug: cards clipped at the
+   right edge, the header running off the side. Hours have been lost to
+   diagnosing a defect that was the harness.
+
+   There are two ways out. One is to load the app inside an `<iframe>` of the
+   true width in a wrapper page served over http (`file://` iframes are
+   blocked by the same-origin rules that make the wrapper useful in the first
+   place). The other — used here — is to drive Chrome over the DevTools
+   protocol and set the viewport with `Emulation.setDeviceMetricsOverride`,
+   which is not subject to the window clamp at all, and then take the
+   screenshot with `Page.captureScreenshot`. That path also gives us
+   `Runtime.evaluate`, which is what makes the measurements possible.
+
+   CDP needs a WebSocket. Node 24 has one built in, so this file has no
+   dependencies beyond what the app already installs — Chrome is found on disk
+   and driven by flags, and there is no puppeteer.
+
+   The tool asserts the clamp is beaten: every capture records the viewport
+   width it actually rendered at, and a mismatch is a hard failure rather than
+   a screenshot nobody looks at twice.
+
+   ── WHAT IT SEEDS, AND WHY THAT IS NOT CHEATING ───────────────────────────
+
+   The catalogue is the front door and it is empty in a browser: `useLibrary`
+   refuses to invent packs when there is no Tauri runtime, which is the honest
+   answer and the right one. Rather than mock the *screen*, this seeds the
+   layer underneath it — a shim for `window.__TAURI_INTERNALS__` that answers
+   `packs_list` with the REAL `pack.json` of all 27 games in `dynawalla/games/`.
+   The app then takes its own native path: the same manifest parse, the same
+   run gate, the same localisation, the same registry mirror. Names, blurbs,
+   skills and grade bands on the captured cards are the shipped ones.
+
+   Everything else a screen reads is device state in `localStorage`, seeded to
+   the same shapes the zustand stores persist (see `src/app/profile.ts` for the
+   key scheme). A screen that is empty in these captures is empty in the app.
+
+   ── WHAT IT CANNOT SEE ────────────────────────────────────────────────────
+
+   * Safe-area insets. `env(safe-area-inset-*)` is 0 in Chrome, so the padding
+     a notch adds is not in these shots. Check that on a device.
+   * The transient touch scroll indicator, and anything else a real WebView
+     draws for a coarse pointer. Chrome here is a fine pointer, so the app's
+     `@media (pointer: coarse)` scrollbar suppression is deliberately NOT in
+     effect — a scrollbar visible in a 390 px shot is the desktop behaviour,
+     not a defect. `--coarse` forces the emulation on if you want to check it.
+   * Motion. These are still frames.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+import { spawn, spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import fs from "node:fs"
+import http from "node:http"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const APP = path.resolve(HERE, "..")
+const GAMES = path.resolve(APP, "../games")
+const DIST = path.join(APP, "dist")
+const HARNESS_DIST = path.join(HERE, ".harness-dist")
+const SHOTS = path.join(HERE, "shots")
+const NPM = path.join(process.env["HOME"] ?? "", ".nvm/versions/node/v24.18.0/bin/npm")
+
+/* ── What is captured ─────────────────────────────────────────────────────
+   `app` screens are the shipped shell at a route hash. `harness` screens are
+   the pass sheet, which the shell cannot currently reach (see
+   tools/harness/main.tsx for the reason) and which is therefore mounted on its
+   own. `act` names a short click sequence run after load, before the shot. */
+const SCREENS = [
+  { name: "packs", kind: "app", hash: "#/" },
+  // The same screen, whole. 27 cards do not fit a phone viewport, and a grid's
+  // rhythm is a property of the grid rather than of its first two rows.
+  { name: "packs-full", kind: "app", hash: "#/", full: true },
+  { name: "progress", kind: "app", hash: "#/progress" },
+  { name: "profiles", kind: "app", hash: "#/profiles" },
+  { name: "settings", kind: "app", hash: "#/settings" },
+  { name: "parents", kind: "app", hash: "#/parents" },
+  // Developer mode on: the row count triples and the values get long, which is
+  // the state that broke the parent area sideways once already.
+  { name: "parents-dev", kind: "app", hash: "#/parents", dev: true, full: true },
+  { name: "pass-rest", kind: "harness" },
+  { name: "pass-gate", kind: "harness", act: "gate" },
+  { name: "pass-offer", kind: "harness", act: "offer" },
+]
+
+/** Width → the height of the device that width belongs to. Not arbitrary. */
+const VIEWPORTS = {
+  // The narrowest screen this app ships to, and the one every width-dependent
+  // defect shows on first. It was missing from this table, so the tab bar's
+  // label truncation — which fails WCAG 1.4.4 here at the SHIPPED text size,
+  // not only at an accessibility one — was in none of the captures.
+  320: { height: 568, dsf: 2, mobile: true }, //  iPhone SE (1st gen)
+  390: { height: 844, dsf: 2, mobile: true }, //  iPhone 14 / 15
+  430: { height: 932, dsf: 2, mobile: true }, //  iPhone 15 Pro Max
+  834: { height: 1112, dsf: 2, mobile: true }, // iPad Air, portrait
+  1024: { height: 768, dsf: 2, mobile: true }, // iPad, landscape
+  1440: { height: 900, dsf: 1, mobile: false }, // desktop
+}
+
+const THEMES = ["light", "dark"]
+
+/* ── Arguments ───────────────────────────────────────────────────────────── */
+
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(`--${name}`)
+const option = (name) => {
+  const hit = argv.find((a) => a.startsWith(`--${name}=`))
+  return hit ? hit.slice(name.length + 3) : null
+}
+const list = (name) => {
+  const raw = option(name)
+  return raw === null ? null : raw.split(",").map((s) => s.trim()).filter(Boolean)
+}
+
+const wantScreens = list("only")
+const wantWidths = list("widths")?.map(Number)
+const wantThemes = list("themes")
+const coarse = flag("coarse")
+/* `--textsize=large|largest` seeds the app's own accessibility text-size
+   setting. Only "normal" was ever captured, and the app SHIPS a Largest
+   option — so a defect that only exists there (four of five tab labels
+   clipping to a prefix at 390) was in none of the hundred committed shots.
+   Named in the output file so two sweeps do not overwrite each other. */
+const textSize = option("textsize") ?? "normal"
+/* `--probe=path/to/expr.js` evaluates one expression in every captured page
+   and writes the results to `tools/shots/probe.json`.
+
+   This exists so that verifying a specific claim — "the tab labels no longer
+   clip", "the chip rail rests with its leading dissolve off" — does not need
+   another copy of this file. Four 900-line forks of this tool were written in
+   one review round to answer four such questions, and they were 90% identical
+   to each other and to this. A question about the DOM is an expression; the
+   harness around it is this file, once. */
+const probeFile = option("probe")
+const PROBE = probeFile === null ? null : fs.readFileSync(probeFile, "utf8")
+
+const screens = SCREENS.filter((s) => !wantScreens || wantScreens.includes(s.name))
+const widths = Object.keys(VIEWPORTS).map(Number).filter((w) => !wantWidths || wantWidths.includes(w))
+const themes = THEMES.filter((t) => !wantThemes || wantThemes.includes(t))
+
+/* ── The seed ─────────────────────────────────────────────────────────────
+   Real manifests, from the `pack.json` beside each game in `dynawalla/games/`.
+
+   A `pack.json` in the source tree is the AUTHORED manifest; three fields are
+   added by the pack build after the archive exists and can only be known then
+   (`schema`, `assets`, `download`). They are synthesised here, deterministically
+   from the pack id, so the same seed produces the same screenshot twice and a
+   diff between two runs is a change in the app rather than in the noise. The
+   digest is a real SHA-256 — of the id, not of an archive — because the
+   manifest parser requires 64 lower-case hex and rejects a placeholder. */
+
+function seedManifests() {
+  const dirs = fs
+    .readdirSync(GAMES, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort()
+
+  const rows = []
+  for (const dir of dirs) {
+    const file = path.join(GAMES, dir, "pack.json")
+    if (!fs.existsSync(file)) continue
+    const authored = JSON.parse(fs.readFileSync(file, "utf8"))
+    const digest = createHash("sha256").update(authored.id).digest("hex")
+    // Plausible and stable: 180 kB–1.2 MB, spread by the digest so the "Space
+    // used" figure and the per-card size are not all the same number.
+    const bytes = 180 * 1024 + (parseInt(digest.slice(0, 6), 16) % (1024 * 1024))
+    const manifest = {
+      schema: 1,
+      ...authored,
+      assets: { files: 6 + (parseInt(digest.slice(6, 8), 16) % 40), bytes },
+      download: { bytes: Math.max(1, Math.floor(bytes * 0.42)), sha256: digest },
+    }
+    // `build` is a pack-build field the manifest schema does not carry.
+    delete manifest.build
+    rows.push({ id: manifest.id, version: manifest.version, manifest: JSON.stringify(manifest), bytes })
+  }
+  if (rows.length === 0) throw new Error(`no pack.json under ${GAMES}`)
+  return rows
+}
+
+function seedState(rows) {
+  const now = new Date()
+  const day = `${now.getFullYear()}-${`${now.getMonth() + 1}`.padStart(2, "0")}-${`${now.getDate()}`.padStart(2, "0")}`
+  return {
+    rows,
+    day,
+    // One game rested today. It changes exactly one word on one card, which is
+    // the design's own claim — "not a lock and never drawn as one" — and a
+    // capture is the only way to check it reads that way.
+    resting: [rows[0]?.id].filter(Boolean),
+    // Two named learners and one unnamed, because the unnamed case draws a
+    // placeholder and is the one that looks wrong if it is wrong.
+    profiles: [
+      { id: "p1", name: "Amina" },
+      { id: "p2", name: "Yusuf" },
+      { id: "p3", name: "" },
+    ],
+  }
+}
+
+/* ── The bootstrap injected into the page ─────────────────────────────────
+   Served as a FILE from the capture server, not inlined. The app ships under
+   `script-src 'self'`, and a tool that only works because it injects an inline
+   script is a tool that will not work the day the built index.html grows a CSP
+   meta tag. Same origin, same rules as the app's own bundle. */
+
+function bootstrapSource(seed) {
+  return `/* generated by tools/capture.mjs — not committed */
+(function () {
+  var SEED = ${JSON.stringify(seed)};
+  var q = new URLSearchParams(location.search);
+  var theme = q.get("theme") === "dark" ? "dark" : "light";
+  var developer = q.get("dev") === "1";
+  // The accessibility text-size setting the app itself ships. Only "normal"
+  // was ever seeded, so every defect that appears only at "large" or
+  // "largest" — four of five tab labels clipping to a prefix, a settings
+  // screen that scrolls again, a catalogue that collapses to one card — was
+  // invisible to a hundred committed captures.
+  var textSize = q.get("text") || "normal";
+
+  function put(key, state, version) {
+    try { localStorage.setItem(key, JSON.stringify({ state: state, version: version })); }
+    catch (error) { console.error("[capture] could not seed " + key, error); }
+  }
+
+  try { localStorage.clear(); } catch (error) { console.error("[capture] clear failed", error); }
+
+  // Device-scoped keys — dynawalla.<name>. See src/app/profile.ts.
+  put("dynawalla.theme", { mode: theme }, 0);
+  put("dynawalla.settings", {
+    sound: true, haptics: true, reduceMotion: false,
+    textSize: textSize, quality: "full", developer: developer,
+  }, 1);
+  put("dynawalla.profiles", { profiles: SEED.profiles, currentId: "p1" }, 1);
+  put("dynawalla.packs", { installed: SEED.installed }, 1);
+  put("dynawalla.pass", { pass: null, ledger: { day: SEED.day, resting: SEED.resting } }, 1);
+
+  // Learner-scoped keys — dynawalla.<profileId>.<name>.
+  put("dynawalla.p1.record", { answered: 1284, correct: 1102 }, 1);
+  put("dynawalla.p1.world", { placed: 37 }, 1);
+  put("dynawalla.p2.record", { answered: 96, correct: 71 }, 1);
+  put("dynawalla.p2.world", { placed: 4 }, 1);
+
+  // The native runtime, shimmed. \`isNative\` is a test for this object, so its
+  // mere presence puts the app on its native path; the app then asks the four
+  // questions below and no others. An unknown command REJECTS loudly rather
+  // than resolving undefined — a silent resolve is how a capture ends up
+  // showing a screen no device can produce.
+  window.__TAURI_INTERNALS__ = {
+    invoke: function (cmd) {
+      if (cmd === "packs_list") return Promise.resolve(SEED.rows);
+      if (cmd === "plugin:app|version") return Promise.resolve(SEED.version);
+      if (cmd === "packs_catalog") return Promise.resolve(JSON.stringify({ packs: [] }));
+      console.error("[capture] unshimmed native command: " + cmd);
+      return Promise.reject(new Error("capture: no shim for " + cmd));
+    },
+    transformCallback: function (callback) {
+      var id = "cb" + Math.random().toString(36).slice(2);
+      window[id] = callback;
+      return id;
+    },
+    unregisterCallback: function () {},
+    convertFileSrc: function (file) { return file; },
+  };
+})();
+`
+}
+
+/* ── Build ────────────────────────────────────────────────────────────────── */
+
+function run(command, args, cwd) {
+  const done = spawnSync(command, args, { cwd, stdio: "inherit" })
+  if (done.status !== 0) throw new Error(`${command} ${args.join(" ")} failed (${String(done.status)})`)
+}
+
+function build() {
+  if (flag("no-build")) {
+    if (!fs.existsSync(DIST)) throw new Error("--no-build, but dist/ does not exist")
+    console.log("· reusing dist/")
+    return
+  }
+  console.log("· building the app")
+  run(NPM, ["run", "build"], APP)
+  console.log("· building the pass-sheet harness")
+  // Failing here must not cost the other eight screens: the harness is a
+  // second build with its own config, and the five destinations are the point.
+  const done = spawnSync(NPM, ["exec", "--", "vite", "build", "--config", "tools/harness/vite.config.mjs"], {
+    cwd: APP,
+    stdio: "inherit",
+  })
+  if (done.status !== 0) console.error("! the harness build failed — pass-sheet screens will be skipped")
+}
+
+/* ── The server ───────────────────────────────────────────────────────────── */
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+}
+
+function serve(seed) {
+  const bootstrap = bootstrapSource(seed)
+
+  // dist/index.html, with one <script src> added as the first thing in <head>
+  // so the seed and the shim are in place before the app's module runs.
+  const inject = (file, src) => {
+    const html = fs.readFileSync(file, "utf8")
+    return html.replace(/<head([^>]*)>/i, `<head$1>\n    <script src="${src}"></script>`)
+  }
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1")
+    const route = url.pathname
+
+    const send = (body, type, status = 200) => {
+      res.writeHead(status, { "content-type": type, "cache-control": "no-store" })
+      res.end(body)
+    }
+
+    try {
+      if (route === "/__capture/bootstrap.js") return send(bootstrap, MIME[".js"])
+      if (route === "/__capture/app.html") {
+        return send(inject(path.join(DIST, "index.html"), "/__capture/bootstrap.js"), MIME[".html"])
+      }
+      if (route === "/__capture/pass.html") {
+        return send(inject(path.join(HARNESS_DIST, "index.html"), "/__capture/bootstrap.js"), MIME[".html"])
+      }
+
+      // Static. The harness bundle is mounted under a prefix of its own; the
+      // app owns the root, which is what its absolute /assets/ paths expect.
+      const root = route.startsWith("/__harness/") ? HARNESS_DIST : DIST
+      const rel = route.startsWith("/__harness/") ? route.slice("/__harness".length) : route
+      const file = path.join(root, path.normalize(rel).replace(/^(\.\.[/\\])+/, ""))
+      if (!file.startsWith(root)) return send("no", "text/plain", 403)
+      if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) return send("not found", "text/plain", 404)
+      return send(fs.readFileSync(file), MIME[path.extname(file)] ?? "application/octet-stream")
+    } catch (error) {
+      console.error("[capture] server", error)
+      return send("error", "text/plain", 500)
+    }
+  })
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }))
+  })
+}
+
+/* ── Chrome, over the DevTools protocol ───────────────────────────────────── */
+
+const CHROME_CANDIDATES = [
+  process.env["CHROME"],
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium",
+].filter(Boolean)
+
+function findChrome() {
+  const found = CHROME_CANDIDATES.find((candidate) => fs.existsSync(candidate))
+  if (!found) throw new Error(`no Chrome found. Tried:\n  ${CHROME_CANDIDATES.join("\n  ")}`)
+  return found
+}
+
+function launchChrome() {
+  const binary = findChrome()
+  const profile = fs.mkdtempSync(path.join(process.env["TMPDIR"] ?? "/tmp", "dw-capture-"))
+  const child = spawn(binary, [
+    "--headless=new",
+    "--remote-debugging-port=0",
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-extensions",
+    "--disable-background-networking",
+    "--disable-features=Translate,MediaRouter",
+    "--force-color-profile=srgb",
+    // Text that is hinted differently between runs is a diff nobody can read.
+    "--font-render-hinting=none",
+    // Big enough that no clamp is ever in play; the real viewport is set per
+    // capture over CDP. See the header.
+    "--window-size=1600,1200",
+    "about:blank",
+  ])
+
+  return new Promise((resolve, reject) => {
+    let buffered = ""
+    const timer = setTimeout(() => reject(new Error("Chrome did not print a DevTools endpoint")), 30_000)
+    child.stderr.on("data", (chunk) => {
+      buffered += String(chunk)
+      const hit = /DevTools listening on (ws:\/\/\S+)/.exec(buffered)
+      if (hit) {
+        clearTimeout(timer)
+        resolve({ child, profile, wsUrl: hit[1] })
+      }
+    })
+    child.on("exit", (code) => reject(new Error(`Chrome exited early (${String(code)})`)))
+  })
+}
+
+async function connect(wsUrl) {
+  const socket = new WebSocket(wsUrl)
+  await new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true })
+    socket.addEventListener("error", () => reject(new Error("CDP socket failed")), { once: true })
+  })
+
+  let nextId = 0
+  const pending = new Map()
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data)
+    const waiting = pending.get(message.id)
+    if (!waiting) return
+    pending.delete(message.id)
+    if (message.error) waiting.reject(new Error(`${message.method ?? ""} ${message.error.message}`))
+    else waiting.resolve(message.result)
+  })
+
+  return {
+    send(method, params = {}, sessionId) {
+      const id = ++nextId
+      const payload = sessionId ? { id, method, params, sessionId } : { id, method, params }
+      socket.send(JSON.stringify(payload))
+      return new Promise((resolve, reject) => pending.set(id, { resolve, reject }))
+    },
+    close: () => socket.close(),
+  }
+}
+
+/* ── In-page measurement ──────────────────────────────────────────────────
+   Everything below runs inside the page. It is a string on purpose: it is not
+   part of the app, must never be bundled with it, and must be readable beside
+   what it measures. */
+
+const MEASURE = String.raw`(() => {
+  const de = document.documentElement
+  const vw = de.clientWidth
+  const vh = de.clientHeight
+
+  const describe = (el) => {
+    const id = el.id ? "#" + el.id : ""
+    const cls = typeof el.className === "string" && el.className
+      ? "." + el.className.trim().split(/\s+/).slice(0, 4).join(".")
+      : ""
+    return el.tagName.toLowerCase() + id + cls
+  }
+
+  /* ── colour ─────────────────────────────────────────────────────────── */
+  const rgb = (value) => {
+    const nums = (value.match(/[\d.]+/g) || []).map(Number)
+    if (nums.length < 3) return null
+    return { r: nums[0], g: nums[1], b: nums[2], a: nums.length > 3 ? nums[3] : 1 }
+  }
+  const over = (top, bottom) => ({
+    r: top.r * top.a + bottom.r * (1 - top.a),
+    g: top.g * top.a + bottom.g * (1 - top.a),
+    b: top.b * top.a + bottom.b * (1 - top.a),
+    a: 1,
+  })
+  const lum = (c) => {
+    const f = (v) => {
+      const s = v / 255
+      return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b)
+  }
+  const ratio = (a, b) => {
+    const la = lum(a), lb = lum(b)
+    return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+  }
+  /** The ground a run of text actually sits on: the first painted ancestor. */
+  const groundOf = (el) => {
+    let node = el
+    let stack = []
+    while (node && node !== document.documentElement.parentNode) {
+      const bg = rgb(getComputedStyle(node).backgroundColor)
+      if (bg && bg.a > 0) {
+        stack.push(bg)
+        if (bg.a >= 1) break
+      }
+      node = node.parentElement
+    }
+    let base = { r: 255, g: 255, b: 255, a: 1 }
+    for (let i = stack.length - 1; i >= 0; i--) base = over(stack[i], base)
+    return base
+  }
+
+  /* ── the walk ───────────────────────────────────────────────────────── */
+  const INTERACTIVE = 'a[href],button,input,select,textarea,summary,[role="button"],[role="tab"],[tabindex]:not([tabindex="-1"])'
+  const escaping = []
+  const small = []
+  const scrollers = []
+  const swatches = new Map()
+
+  /* documentElement.scrollHeight is NOT the whole story in this app, and
+     assuming it was hid the app's real scroller for a whole capture run.
+     \`html, body { height: 100%; overflow-x: hidden }\` makes overflow-y compute
+     to \`auto\` on BODY, so body becomes the scrolling box and the document
+     element stays exactly one viewport tall no matter how long the catalogue
+     is. Every box that actually scrolls is listed instead. */
+  const scrollBoxes = [document.documentElement, document.body, ...document.querySelectorAll("*")]
+  const seenBox = new Set()
+  for (const el of scrollBoxes) {
+    if (seenBox.has(el)) continue
+    seenBox.add(el)
+    const vertical = el.scrollHeight - el.clientHeight
+    const sideways = el.scrollWidth - el.clientWidth
+    if (vertical <= 1 && sideways <= 1) continue
+    const style = getComputedStyle(el)
+    if (style.overflowX === "visible" && style.overflowY === "visible") continue
+    scrollers.push({
+      el: el === document.documentElement ? "html" : el === document.body ? "body" : describe(el),
+      vertical: Math.max(0, Math.round(vertical)),
+      sideways: Math.max(0, Math.round(sideways)),
+      overflowX: style.overflowX,
+      overflowY: style.overflowY,
+      // A drawn track is one of the named web-view tells. scrollbar-width is
+      // only suppressed under a coarse-pointer media query in this app, so on
+      // a desktop — a first-class target — these tracks are painted.
+      scrollbarWidth: style.scrollbarWidth,
+    })
+  }
+
+  for (const el of document.querySelectorAll("*")) {
+    const box = el.getBoundingClientRect()
+    if (box.width === 0 && box.height === 0) continue
+    const style = getComputedStyle(el)
+    if (style.visibility === "hidden" || style.display === "none") continue
+
+    // Escaping the viewport sideways. A tolerance of 1px absorbs subpixel
+    // layout; anything more is a real overhang.
+    if (box.right > vw + 1 || box.left < -1) {
+      // Only the outermost offender is interesting: a wide row drags every
+      // descendant with it and would otherwise print forty identical lines.
+      const parent = el.parentElement
+      const parentBox = parent ? parent.getBoundingClientRect() : null
+      const parentEscapes = parentBox && (parentBox.right > vw + 1 || parentBox.left < -1)
+      if (!parentEscapes) {
+        escaping.push({ el: describe(el), left: Math.round(box.left), right: Math.round(box.right) })
+      }
+    }
+
+    if (el.matches(INTERACTIVE) && !el.hasAttribute("disabled")) {
+      const w = Math.round(box.width * 10) / 10
+      const h = Math.round(box.height * 10) / 10
+      if (w < 44 || h < 44) {
+        small.push({
+          el: describe(el),
+          text: (el.textContent || el.getAttribute("aria-label") || "").trim().slice(0, 40),
+          w, h,
+        })
+      }
+    }
+  }
+
+  /* ── every text run, with the ground it is on ───────────────────────── */
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = (node.nodeValue || "").trim()
+    if (!text) continue
+    const el = node.parentElement
+    if (!el) continue
+    const box = el.getBoundingClientRect()
+    if (box.width === 0 || box.height === 0) continue
+    const style = getComputedStyle(el)
+    if (style.visibility === "hidden") continue
+    const ink = rgb(style.color)
+    if (!ink) continue
+    const ground = groundOf(el)
+    const painted = ink.a < 1 ? over(ink, ground) : ink
+    const size = parseFloat(style.fontSize)
+    const weight = Number(style.fontWeight) || 400
+    // 18.66px, or 14px bold — the WCAG "large text" boundary.
+    const large = size >= 24 || (size >= 18.66 && weight >= 700)
+    const key = [
+      Math.round(painted.r), Math.round(painted.g), Math.round(painted.b),
+      Math.round(ground.r), Math.round(ground.g), Math.round(ground.b),
+      size, weight,
+    ].join("/")
+    if (swatches.has(key)) { swatches.get(key).count++; continue }
+    const value = Math.round(ratio(painted, ground) * 100) / 100
+    swatches.set(key, {
+      sample: text.slice(0, 40),
+      color: "rgb(" + [painted.r, painted.g, painted.b].map(Math.round).join(" ") + ")",
+      background: "rgb(" + [ground.r, ground.g, ground.b].map(Math.round).join(" ") + ")",
+      fontSize: size,
+      fontWeight: weight,
+      largeText: large,
+      ratio: value,
+      passesAA: value >= (large ? 3 : 4.5),
+      count: 1,
+    })
+  }
+
+  return {
+    viewport: { width: vw, height: vh, innerWidth: window.innerWidth },
+    overflow: {
+      scrollWidth: de.scrollWidth,
+      clientWidth: de.clientWidth,
+      horizontal: de.scrollWidth - de.clientWidth,
+      scrollHeight: de.scrollHeight,
+      clientHeight: de.clientHeight,
+    },
+    scrollers,
+    escaping: escaping.slice(0, 40),
+    escapingCount: escaping.length,
+    smallTargets: small.slice(0, 40),
+    smallTargetCount: small.length,
+    text: [...swatches.values()].sort((a, b) => a.ratio - b.ratio),
+  }
+})()`
+
+/* ── The act sequences ────────────────────────────────────────────────────
+   The pass sheet has three stages and only the first is on screen at load.
+   Both transitions are driven the way an adult drives them: press "Grown-ups",
+   then answer the gate. The gate is a *reading* challenge, not arithmetic
+   (deliberately — see pass/parentalGate.ts), so the answer is on screen or is
+   the current year, and both are computable here without reaching into the
+   app's state. */
+
+const ACTS = {
+  gate: String.raw`(() => {
+    const press = [...document.querySelectorAll("button")]
+      .find((b) => /grown-ups/i.test(b.textContent || ""))
+    if (!press) return "no Grown-ups control"
+    press.click()
+    return "ok"
+  })()`,
+
+  offer: String.raw`(() => {
+    const open = [...document.querySelectorAll("button")]
+      .find((b) => /grown-ups/i.test(b.textContent || ""))
+    if (open) open.click()
+    return "ok"
+  })()`,
+
+  // Run after the gate has painted. Kept separate because React needs a frame
+  // between the click and the field existing.
+  offerAnswer: String.raw`(() => {
+    const field = document.querySelector("#pass-gate-entry")
+    if (!field) return "no gate field"
+    const shown = document.querySelector("#pass-gate-title")
+    const word = [...document.querySelectorAll("p")]
+      .map((p) => (p.textContent || "").trim())
+      .find((t) => /^[A-Z]{10,}$/.test(t))
+    const answer = word || String(new Date().getFullYear())
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set
+    setter.call(field, answer)
+    field.dispatchEvent(new Event("input", { bubbles: true }))
+    const form = field.closest("form")
+    if (!form) return "no form"
+    form.requestSubmit()
+    void shown
+    return "answered " + answer
+  })()`,
+}
+
+/* ── Capture ──────────────────────────────────────────────────────────────── */
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function evaluate(cdp, session, expression) {
+  const result = await cdp.send(
+    "Runtime.evaluate",
+    { expression, returnByValue: true, awaitPromise: true },
+    session,
+  )
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description ?? "evaluate threw")
+  }
+  return result.result.value
+}
+
+/** Wait until the app has actually drawn something, not merely loaded. */
+async function settle(cdp, session, marker) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const ready = await evaluate(
+      cdp,
+      session,
+      `document.readyState === "complete" && !!document.querySelector(${JSON.stringify(marker)})`,
+    )
+    if (ready) break
+    await sleep(100)
+  }
+  // Two animation frames plus a beat: transitions in this app are 120–200ms
+  // and a shot taken mid-transition is a shot of a colour that does not exist.
+  await evaluate(
+    cdp,
+    session,
+    `new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 250))))`,
+  )
+}
+
+async function main() {
+  fs.mkdirSync(SHOTS, { recursive: true })
+  for (const theme of themes) fs.mkdirSync(path.join(SHOTS, theme), { recursive: true })
+
+  build()
+
+  const rows = seedManifests()
+  const state = seedState(rows)
+  const version = JSON.parse(fs.readFileSync(path.join(APP, "package.json"), "utf8")).version
+  const seed = {
+    rows: state.rows,
+    day: state.day,
+    resting: state.resting,
+    profiles: state.profiles,
+    version,
+    // What the registry mirror would already hold on a warm launch, so the
+    // parent area's counts are right on the very first frame.
+    installed: state.rows.map((row) => {
+      const manifest = JSON.parse(row.manifest)
+      return {
+        id: manifest.id,
+        name: manifest.name,
+        version: manifest.version,
+        bytes: row.bytes,
+        sha256: manifest.download.sha256,
+        installedAt: Date.now(),
+        description: manifest.description,
+        skills: manifest.covers.skills,
+        grades: manifest.covers.grades,
+      }
+    }),
+  }
+  console.log(`· seeded ${String(rows.length)} packs from ${GAMES}`)
+
+  const { server, port } = await serve(seed)
+  const { child, profile, wsUrl } = await launchChrome()
+  const cdp = await connect(wsUrl)
+
+  const harnessBuilt = fs.existsSync(path.join(HARNESS_DIST, "index.html"))
+  if (!harnessBuilt) console.error("! no harness bundle — pass-sheet screens skipped")
+
+  const measurements = {}
+  const probed = {}
+  const written = []
+  const problems = []
+
+  try {
+    for (const theme of themes) {
+      for (const screen of screens) {
+        if (screen.kind === "harness" && !harnessBuilt) continue
+        for (const width of widths) {
+          const view = VIEWPORTS[width]
+          const label = `${theme}/${screen.name}-${String(width)}`
+
+          const { targetId } = await cdp.send("Target.createTarget", { url: "about:blank" })
+          const { sessionId } = await cdp.send("Target.attachToTarget", { targetId, flatten: true })
+
+          try {
+            await cdp.send("Page.enable", {}, sessionId)
+            await cdp.send(
+              "Emulation.setDeviceMetricsOverride",
+              {
+                width,
+                height: view.height,
+                deviceScaleFactor: view.dsf,
+                mobile: view.mobile,
+                screenWidth: width,
+                screenHeight: view.height,
+              },
+              sessionId,
+            )
+            // The theme is carried by the seeded store, not by the OS
+            // preference — but a mismatch between the two is exactly how a
+            // half-painted screen happens, so the OS is told the same thing.
+            await cdp.send(
+              "Emulation.setEmulatedMedia",
+              { features: [{ name: "prefers-color-scheme", value: theme }] },
+              sessionId,
+            )
+            if (coarse) {
+              // `setEmitTouchEventsForMouse` alone changes what EVENTS fire and
+              // does not move the pointer media queries — measured, the page
+              // still reported `any-pointer: coarse` false, so a `--coarse` run
+              // proved nothing about the scrollbar suppression it exists to
+              // check. `setTouchEmulationEnabled` is what makes the device
+              // report a touchscreen; both are set, because the app also cares
+              // which events arrive.
+              await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 5 }, sessionId)
+              await cdp.send("Emulation.setEmitTouchEventsForMouse", { enabled: true, configuration: "mobile" }, sessionId)
+            }
+
+            const base = screen.kind === "harness" ? "/__capture/pass.html" : "/__capture/app.html"
+            const query = `?theme=${theme}${screen.dev ? "&dev=1" : ""}${textSize === "normal" ? "" : `&text=${textSize}`}`
+            const url = `http://127.0.0.1:${String(port)}${base}${query}${screen.hash ?? ""}`
+
+            await cdp.send("Page.navigate", { url }, sessionId)
+            await settle(cdp, sessionId, screen.kind === "harness" ? '[role="dialog"]' : "nav")
+
+            if (screen.act === "gate") {
+              await evaluate(cdp, sessionId, ACTS.gate)
+              await settle(cdp, sessionId, "#pass-gate-entry")
+            }
+            if (screen.act === "offer") {
+              await evaluate(cdp, sessionId, ACTS.offer)
+              await settle(cdp, sessionId, "#pass-gate-entry")
+              const said = await evaluate(cdp, sessionId, ACTS.offerAnswer)
+              await settle(cdp, sessionId, "#pass-offer-title")
+              if (!String(said).startsWith("answered")) problems.push(`${label}: gate — ${String(said)}`)
+            }
+
+            const measured = await evaluate(cdp, sessionId, MEASURE)
+            if (PROBE !== null) probed[`${label}${textSize === "normal" ? "" : `-${textSize}`}`] = await evaluate(cdp, sessionId, PROBE)
+
+            // The clamp check. If this ever fires, the viewport override lost
+            // to something and every shot in the run is a lie — see the header.
+            if (measured.viewport.width !== width) {
+              throw new Error(
+                `viewport clamped: asked ${String(width)}, rendered ${String(measured.viewport.width)}`,
+              )
+            }
+
+            const shot = await cdp.send(
+              "Page.captureScreenshot",
+              screen.full
+                ? { format: "png", captureBeyondViewport: true, optimizeForSpeed: false }
+                : { format: "png", optimizeForSpeed: false },
+              sessionId,
+            )
+            // The text size is in the filename and in the measurement key, so a
+            // `--textsize=largest` sweep sits BESIDE the normal one instead of
+            // overwriting it. A defect that only exists at one text size has to
+            // be comparable against the size where it does not.
+            const suffix = textSize === "normal" ? "" : `-${textSize}`
+            const file = path.join(SHOTS, theme, `${screen.name}-${String(width)}${suffix}.png`)
+            fs.writeFileSync(file, Buffer.from(shot.data, "base64"))
+            written.push(file)
+
+            measurements[`${label}${suffix}`] = {
+              screen: screen.name,
+              textSize,
+              theme,
+              width,
+              height: view.height,
+              url,
+              ...measured,
+            }
+
+            const flags = []
+            if (measured.overflow.horizontal > 0) flags.push(`h-scroll ${String(measured.overflow.horizontal)}px`)
+            if (measured.escapingCount > 0) flags.push(`${String(measured.escapingCount)} escaping`)
+            if (measured.smallTargetCount > 0) flags.push(`${String(measured.smallTargetCount)} small`)
+            const fails = measured.text.filter((t) => !t.passesAA).length
+            if (fails > 0) flags.push(`${String(fails)} AA fail`)
+            console.log(`  ${label}${flags.length ? "  ⟨" + flags.join(", ") + "⟩" : ""}`)
+          } catch (error) {
+            problems.push(`${label}: ${error.message}`)
+            console.error(`  ${label}  FAILED — ${error.message}`)
+          } finally {
+            await cdp.send("Target.closeTarget", { targetId }).catch(() => undefined)
+          }
+        }
+      }
+    }
+  } finally {
+    cdp.close()
+    server.close()
+    // Wait for the process to actually go before removing its profile: Chrome
+    // is still flushing that directory when `kill` returns, and `rmSync` loses
+    // the race with ENOTEMPTY — after a completely successful run, which is the
+    // worst possible moment to throw.
+    const exited = new Promise((resolve) => child.once("exit", resolve))
+    child.kill()
+    await Promise.race([exited, sleep(5000)])
+    try {
+      fs.rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+    } catch (error) {
+      console.error(`! left ${profile} behind — ${error.message}`)
+    }
+  }
+
+  // MERGED, never replaced, and this is not tidiness. `--only=packs` used to
+  // overwrite the file with its ten keys, which silently erased the ninety
+  // numbers behind every per-screen claim in the write-ups beside it — a
+  // reviewer opening `measurements.json` found evidence for one screen and no
+  // record that the rest had ever been measured. Old entries for a screen this
+  // run DID capture are replaced; entries for screens it did not touch survive,
+  // and each carries the timestamp of the run that produced it.
+  const measuredAt = new Date().toISOString()
+  const previous = (() => {
+    try {
+      const held = JSON.parse(fs.readFileSync(path.join(SHOTS, "measurements.json"), "utf8"))
+      return held && typeof held.screens === "object" ? held.screens : {}
+    } catch {
+      return {}
+    }
+  })()
+  const allScreens = { ...previous }
+  for (const [key, value] of Object.entries(measurements)) {
+    allScreens[key] = { ...value, measuredAt }
+  }
+
+  fs.writeFileSync(
+    path.join(SHOTS, "measurements.json"),
+    JSON.stringify(
+      {
+        capturedAt: measuredAt,
+        appVersion: version,
+        packs: rows.length,
+        note: "env(safe-area-inset-*) is 0 here; Chrome is a fine pointer, so the app's coarse-pointer scrollbar suppression is not in effect. Entries are MERGED across runs — `measuredAt` on each says when that screen was last actually captured.",
+        problems,
+        screens: allScreens,
+      },
+      null,
+      2,
+    ) + "\n",
+  )
+
+  if (PROBE !== null) {
+    const out = path.join(SHOTS, "probe.json")
+    fs.writeFileSync(out, JSON.stringify(probed, null, 2) + "\n")
+    console.log(`probe → ${out}`)
+  }
+
+  console.log(`\n${String(written.length)} shots → ${SHOTS}`)
+  console.log(`measurements → ${path.join(SHOTS, "measurements.json")}`)
+  if (problems.length > 0) {
+    console.error(`\n${String(problems.length)} problem(s):`)
+    for (const problem of problems) console.error(`  ${problem}`)
+    process.exitCode = 1
+  }
+}
+
+await main()

--- a/dynawalla/dynawalla-app/tools/harness/harness.css
+++ b/dynawalla/dynawalla-app/tools/harness/harness.css
@@ -1,0 +1,16 @@
+/* The capture harness's stylesheet.
+ *
+ * It is the app's own stylesheet, plus two `@source` directives.
+ *
+ * Tailwind v4 discovers the classes it must emit by scanning outward from the
+ * CSS file it is invoked on. This build's root is `tools/harness/`, not the app
+ * root, so automatic detection would scan the harness directory and emit almost
+ * nothing — the sheet would look right in review and render an unstyled dialog.
+ * The two directives below name the two trees whose class names have to survive
+ * into this bundle, explicitly, so the harness cannot silently lose them.
+ */
+
+@import "../../src/index.css";
+
+@source "../../src/**/*.{ts,tsx}";
+@source "./**/*.{tsx,html}";

--- a/dynawalla/dynawalla-app/tools/harness/index.html
+++ b/dynawalla/dynawalla-app/tools/harness/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- The same viewport contract the app ships, verbatim: a capture taken
+         under a different one is a capture of a different layout. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+    />
+    <meta name="color-scheme" content="light dark" />
+    <title>Dynawalla — capture harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/dynawalla/dynawalla-app/tools/harness/main.tsx
+++ b/dynawalla/dynawalla-app/tools/harness/main.tsx
@@ -1,0 +1,44 @@
+// The capture harness for the pass sheet. Dev only; never bundled into the app.
+//
+// **Why this exists.** `PassSheet` is mounted by `packs/Stage.tsx`, and the
+// stage only mounts it when `usePass.mayOpen()` is false. That decision runs
+// through `pass/model.ts`, which opens unconditionally while `billing().wired`
+// is false — and nothing in the shipped app ever calls `setBilling`. So in a
+// browser, and in fact in today's build on a device, there is no sequence of
+// taps that puts the sheet on screen. It is real code, it is reachable the
+// moment a store is wired, and it is three screens nobody can currently look
+// at.
+//
+// Rather than fake app state — which would mean guessing at the shape of a
+// store and capturing a screen that does not exist — this mounts the real
+// component, with the real stylesheet, inside the same full-bleed deep ground
+// the stage draws behind it (`Stage.tsx`: `bg-ground-deep fixed inset-0`). What
+// is captured is the component, honestly, in its own frame.
+//
+// The one thing it cannot reproduce is the paused game showing through the
+// panel's `backdrop-blur-sm`. Behind the sheet here is flat ground. Every other
+// pixel is the shipped one.
+
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+
+// Side-effect imports, in the order `src/main.tsx` has them: the theme class
+// and the text-size attribute are applied at module load, before the first
+// paint, and a harness that imported them later would capture the default
+// theme for one frame and the requested one after.
+import "../../src/app/theme.ts"
+import "../../src/settings/store.ts"
+import "./harness.css"
+
+import { PassSheet } from "../../src/pass/PassSheet.tsx"
+
+const root = document.getElementById("root")
+if (!root) throw new Error("missing #root")
+
+createRoot(root).render(
+  <StrictMode>
+    <div className="bg-ground-deep fixed inset-0">
+      <PassSheet packName="LATTICE RUNNER" onLeave={() => undefined} />
+    </div>
+  </StrictMode>,
+)

--- a/dynawalla/dynawalla-app/tools/harness/vite.config.mjs
+++ b/dynawalla/dynawalla-app/tools/harness/vite.config.mjs
@@ -1,0 +1,38 @@
+// The harness bundle. Built by `tools/capture.mjs`, never by `npm run build`.
+//
+// Deliberately a second, separate build rather than a second entry in the app's
+// own config: nothing a capture tool needs may change what ships. The app's
+// `vite.config.ts` is untouched by this file's existence.
+
+import { fileURLToPath, URL } from "node:url"
+
+import react from "@vitejs/plugin-react"
+import tailwind from "@tailwindcss/vite"
+import { defineConfig } from "vite"
+
+const here = fileURLToPath(new URL(".", import.meta.url))
+
+export default defineConfig({
+  root: here,
+  // The prefix the capture server mounts this bundle at. NOT "./": the harness
+  // document is served from `/__capture/pass.html` so that the seed script can
+  // be injected into it, and relative asset paths would resolve against
+  // `/__capture/`, where the app's own dist is mounted — a 404 for every asset
+  // and a blank screenshot that looks like a component that renders nothing.
+  base: "/__harness/",
+  plugins: [react(), tailwind()],
+  define: {
+    // `platform.ts` reads this. Nothing the harness renders imports it today,
+    // but a component that starts to would otherwise fail at module load with
+    // a bare ReferenceError.
+    __APP_VERSION__: JSON.stringify("capture"),
+  },
+  build: {
+    outDir: fileURLToPath(new URL("../.harness-dist", import.meta.url)),
+    emptyOutDir: true,
+    // The app's floor, restated: a capture taken from a bundle compiled to a
+    // newer baseline is not a capture of the shipped app.
+    target: "es2020",
+    sourcemap: false,
+  },
+})

--- a/dynawalla/dynawalla-app/tools/shots/AUDIT.md
+++ b/dynawalla/dynawalla-app/tools/shots/AUDIT.md
@@ -1,0 +1,464 @@
+# Dynawalla harness — baseline visual audit
+
+Captured by `tools/capture.mjs` against the app at `0.1.0`, seeded with the real
+`pack.json` of all 27 games. 100 shots: 10 screens × 5 widths (390 / 430 / 834 /
+1024 / 1440) × light and dark, plus `measurements.json`.
+
+Everything below is either **visible in a named PNG** or **measured in
+`measurements.json`**. Nothing here is inferred from reading a component. Paths
+are relative to `dynawalla/dynawalla-app/`.
+
+Re-run with `node tools/capture.mjs`; `--no-build` reuses `dist/`.
+
+## What is already right, and must not be undone
+
+Verified in this run, so a later pass does not re-litigate it:
+
+* **No page scrolls sideways.** `documentElement.scrollWidth == clientWidth` on
+  all 100 captures, including `parents-dev` at 390 where the capability strings
+  are longest. The `min-w-0` fix in `src/shell/Surface.tsx:46-51` holds.
+* **No tap highlight, no selection handle, no double-tap zoom** —
+  `src/index.css:40-62`.
+* **No bounce on a fixed surface** — `overscroll-behavior: none` on both `html`
+  and `body`, `src/index.css:26` and `:48`.
+* **The wordmark lockup.** The mark's `mb-[0.16em]` sits it on the letters'
+  feet at every width. Correct in all 20 lintel captures.
+* **Row height.** Every course row is `min-h-16` (64 px). No child-facing row is
+  under the target floor.
+* **Contrast, everywhere except one token** — see §0. 22 distinct text/ground
+  pairs measured; 20 pass AA, the two failures are the same colour.
+
+---
+
+## 0. Cross-cutting — these appear on more than one screen
+
+### 0.1 The "one warm point" rule is broken by a factor of about 120 · **worst defect**
+
+`src/design/Strapwork.tsx:41` paints every knot of the interlace with
+`fill="var(--dw-index)"` — the brass apex colour. The band is `width="100%"` and
+the tile repeats every 24 px, so a 390 px screen carries ~16 gold knots per band
+and a 1440 px screen ~60. The band is drawn **twice on every screen**: under the
+lintel (`src/app/Shell.tsx:49`) and above the navigation (`src/app/Nav.tsx:29`).
+
+The brand rule is one warm point per screen, at the top of something
+(`dynawalla/brand/README.md`). What is actually shipping is a repeating gold
+ribbon top and bottom of every one of the five destinations, plus a gold index
+diamond in the nav, plus gold inside the key art of several cards.
+
+In light theme this is worse: `--dw-index` resolves to `brass-700` `#b45309`
+(`src/design/tokens.css:189`), which at 1 px stroke over parchment reads as a
+**red-brown dotted ribbon** — see `light/parents-1440.png` and
+`light/profiles-390.png`. That is the closest thing in the app to the explicitly
+dead "dusty khaki sandstorm feel".
+
+This is the item `docs/HARNESS_FEEDBACK.md` recorded as "noted, not yet acted
+on". It is now measured and it is the single loudest thing in every capture.
+
+### 0.2 Selected state is drawn as a recess, so every segmented control reads inverted
+
+`src/shell/Surface.tsx:84`:
+
+```
+active ? "bg-ground text-ink" : "bg-ground-raised text-ink-muted"
+```
+
+The **chosen** option gets `--dw-ground`; the **unchosen** options get
+`--dw-ground-raised`, which is lighter in both themes. So the option that is not
+selected is the one that looks like a raised, pressed-able key, and the selected
+one looks like a hole.
+
+`light/parents-1440.png` is the clearest: "Developer mode" is Off, and the white
+"On" segment is the one that reads as active. `dark/settings-390.png` shows it on
+six controls at once — for Sound the lit-looking segment is "Off" while the
+diamond says "On".
+
+Every platform convention (iOS segmented control, Android toggle group) does the
+opposite: the selection is the raised, lighter chip. The catalogue chip has the
+same inversion at `src/catalog/Catalog.tsx:236` — the active chip is
+`bg-ground-sunk`, i.e. darker than the page.
+
+### 0.3 The index mark is inserted into flow, so text jumps when state changes
+
+Three places conditionally *insert* an 8 px SVG plus a gap rather than reserving
+its space:
+
+| where | file:line | what moves |
+|---|---|---|
+| segmented option | `src/shell/Surface.tsx:87` | the option label shifts right ~16 px the moment it is chosen, and the two labels beside it re-centre |
+| learner row | `src/shell/Surface.tsx:129` | the current learner's name field starts 44 px further right than every other learner's — visible in `light/profiles-390.png`, where "Amina" is indented and "Yusuf" is not |
+| pack card | n/a | (correct — no mark) |
+
+This is the named defect "text that reflows or jumps as state changes". The
+`Action` row at `src/shell/Surface.tsx:108` gets it right (`opacity-0`, space
+reserved) — but then produces 0.4 below.
+
+### 0.4 Three different left edges on one screen
+
+Because `Action` reserves the index mark's width, an action label starts 44 px
+in while a fact label starts at 0. In `dark/parents-dev-390.png`, "Version",
+"Learners" and "Platform" are flush with the rules; "Erase everything" is
+indented. In `light/profiles-390.png`, "Add a learner" is indented and the
+learner names are not.
+
+Files: `src/shell/Surface.tsx:103-110` (Action) vs `:46-52` (Fact) vs `:123-157`
+(Learner).
+
+### 0.5 A drawn scrollbar track, on the front door, on a phone
+
+Measured, not guessed. `measurements.json` records for `light/packs-390`:
+
+```
+div.-mx-1.flex.gap-2.overflow-x-auto  x:auto  overflow 440px  scrollbar-width:auto
+body                                  y:auto  overflow 4202px scrollbar-width:auto
+```
+
+`src/index.css:78-87` suppresses scrollbar tracks **only** under
+`@media (pointer: coarse)`. That is a defensible call for the page scroller on a
+desktop — but two consequences were not intended:
+
+1. The subject-chip row (`src/catalog/Catalog.tsx:186`) draws a **horizontal
+   track inside the content** at 390 and 430. It is plainly visible in
+   `dark/packs-390.png` as a grey bar under "All / Number sense / Addition &
+   subtraction". A horizontal track sitting between the search field and the
+   game grid is the loudest web-page tell in the app.
+2. Desktop and tablet-with-trackpad are first-class targets, and every capture
+   at 1024 and 1440 has a painted page track down the right edge.
+
+The chip row also overflows by **440 px at 390** with no fade, no gradient and no
+peeking half-chip beyond the clipped fourth one — a child has no signal that
+three more subjects exist.
+
+### 0.6 `--dw-strike` fails AA in light theme — measured 4.45:1, needs 4.5:1
+
+`src/design/tokens.css:218` — `--dw-strike: var(--color-copper-500)` = `#c2453c`.
+On `--dw-ground` (`parchment-100`, `#f4f0ff`) that measures **4.45:1**, below the
+4.5:1 floor for normal text. It fails on two controls, both destructive:
+
+| text | size | file:line | ratio |
+|---|---|---|---|
+| "Erase everything" | 20 px / 400 | `src/shell/Surface.tsx:105` | 4.45 ✗ |
+| "Remove" | 14 px / 400 | `src/shell/Surface.tsx:151` | 4.45 ✗ |
+
+Dark theme is fine (`copper-400` on the void = 8.20:1). Every other pair in the
+app passes; the next-worst is 6.52:1.
+
+`docs/HARNESS_FEEDBACK.md` flagged the coral hue as semantically odd against
+violet and left it for a deliberate decision. It is now also an accessibility
+failure, so the decision is forced.
+
+### 0.7 There are no transitions between destinations at all
+
+`src/app/router.tsx:33` uses a plain `createHashRouter` and `src/app/Nav.tsx`
+plain `NavLink`s. Tapping a tab swaps the entire surface in one frame. The only
+motion tokens in use are 120 ms `transition-colors` on hover/press states
+(`src/shell/Surface.tsx:83`, `:104`, `src/catalog/Catalog.tsx:67`, `:235`).
+
+Named defect: "transitions that are absent". Nothing explains where a screen
+came from. A View Transition here would be explanatory rather than decorative,
+and `--dw-motion-detent` / `--dw-ease-detent` already exist for it
+(`src/design/tokens.css:272-275`) with reduced-motion already collapsing them
+(`:466-503`).
+
+### 0.8 Desktop and large tablet: three competing measures, and most of the screen is empty
+
+At 1440 (`light/parents-1440.png`, `light/settings-1440.png`,
+`light/packs-1440.png`) there are three different alignment systems on screen at
+once:
+
+* the lintel is **full-bleed**, mark at x≈16 — `src/app/Shell.tsx:25`
+* the surface is **`max-w-6xl`** (1152 px) centred — `src/app/Shell.tsx:72`, and
+  the courses inside it are **`max-w-2xl`** (672 px) centred —
+  `src/shell/Surface.tsx:244`
+* the navigation is **full-bleed** with five equal 288 px cells —
+  `src/app/Nav.tsx:30`
+
+So the wordmark, the content, and the tab labels all start at different x. On
+`parents` at 1440 the content occupies 672 × 380 px of a 1440 × 900 viewport —
+about 20% — with the remaining 80% flat ground and a bottom tab bar stretched
+across it. It reads as a phone app in a desktop window.
+
+### 0.9 iPad landscape (1024 × 768) cuts the last row off Settings
+
+Measured: `light/settings-1024` — `body` scrolls by 65 px. The vertical rungs at
+`src/design/tokens.css:302-327` step at 900 / 720 / 620 px height, so a 768 px
+viewport gets the 900 rung and the six choice rows overrun. On the widest tablet
+orientation, with 1024 px of unused width, the "Quality" control is below the
+fold. See `light/settings-1024.png`.
+
+---
+
+## 1. Packs — the front door (`/`)
+
+Files: `src/catalog/Catalog.tsx`, `src/catalog/PackArt.tsx`,
+`src/shell/surfaces.ts:245`.
+
+**1.1 The grid never grows a column past 10.5 rem.**
+`src/catalog/Catalog.tsx:209` — `minmax(10.5rem, 1fr)` with `auto-fill`. At 1440
+that produces six ~170 px columns inside the 1152 px frame
+(`light/packs-1440.png`): 27 postage stamps with 11 px metadata. The comment
+above the line justifies the 10.5 rem *floor* correctly (COUNTERWEIGHT needs
+142 px at the title's 15 px) — but a floor is not a ceiling, and no breakpoint
+raises it. A desktop should get fewer, larger cards, not more, smaller ones.
+
+**1.2 "Play" is small print, not a control.**
+`src/catalog/Catalog.tsx:110-112` puts the word in the same 11 px muted numeral
+run as "Grades 1–5", on the same line. In `dark/packs-390.png` it reads
+"Grades 1–5 Play" as one metadata string. The whole tile is the button, which is
+right — but the one word that says so is the least visible thing on the card.
+
+**1.3 The metadata block is ragged across a row.**
+`src/catalog/Catalog.tsx:100-113`. Two subject chips are shown, and the names are
+long ("Addition & subtraction" is 22 characters), so each chip takes its own
+line at narrow columns. In `light/packs-1440.png`, ABYSSAL BLOOM and DEEPSWARM
+have two chip lines, ARENA has one, and CLAIM wraps "Play" onto a line of its
+own. Four different bottom-block shapes in one row of six. `mt-auto` pins the
+block to the bottom, so the raggedness lands exactly where the eye scans.
+
+**1.4 Descriptions are cut mid-word, and the manifests are far too long for two
+lines.** Measured: the clamped `span` at `src/catalog/Catalog.tsx:98` overflows
+its 2-line box by 30–165 px across cards — i.e. some descriptions are eight lines
+of text shown as two. "A bioluminescent reef that keeps growing whil…" is what a
+child reads. Either the card needs a real summary field or the manifests need a
+short line; truncating a paragraph is neither.
+
+**1.5 Light theme: the cards barely exist, and the art is a black brick on
+paper.** `src/catalog/Catalog.tsx:65` gives the card `bg-ground-raised` (`#fff`)
+and `border-line` (`parchment-300`, `#dcd2f5`) over a `parchment-100` ground —
+about 1.06:1 between card and page. Meanwhile `--dw-art-void` stays
+`basalt-800` in both themes by design (`src/design/tokens.css:248`), so each
+card is a near-black square sitting on white with almost no card edge around it.
+In `light/packs-1440.png` the art reads as the object and the card reads as
+nothing.
+
+**1.6 The "All" chip is 42.1 × 44 px.** Measured on all 20 catalogue captures.
+`src/catalog/Catalog.tsx:234` sets `min-h-11` and `px-3` but no minimum width,
+and "All" is a short word. Below the 44 px floor on the axis it is thinnest, and
+it is the control that clears the filter.
+
+**1.7 The wordmark link is 220.3 × 43.2 px.** Measured on all 70 shell captures.
+`src/app/Shell.tsx:40-46` — 0.8 px under the floor, and it is the "go home"
+control. Fixed by the lintel padding, not by the link.
+
+**1.8 `resting` reads as nothing at all.** The seed marks one pack as rested;
+its card differs from its neighbours by one word ("Tomorrow" instead of "Play")
+in 11 px muted type. The design intent — "not a lock and never drawn as one" —
+is honoured, but the fact is now invisible. See `dark/packs-full-390.png`.
+
+---
+
+## 2. Progress (`/progress`)
+
+Files: `src/shell/surfaces.ts:275-298`, `src/world/Screen.tsx`,
+`src/shell/Surface.tsx:168-174`.
+
+**2.1 A grey slab under the drawing.** `src/world/Screen.tsx:71-77` draws the
+"sill" as a rect of height 1 in a small viewBox that is then scaled to the
+container width, so it renders as a ~10 px bar in `--dw-line-strong` —
+`stone-600` `#5b5175` in dark. Against a violet field it reads as flat grey and
+looks like an unstyled element, not a sill. Plainly visible in
+`dark/progress-390.png`.
+
+**2.2 The screen is 45% used at 390 and 25% used at 1440.** Two numbers and one
+`max-w-sm` drawing (`src/shell/Surface.tsx:171`). At 1440 the drawing is 384 px
+wide in a 1440 px viewport. This is the destination a child visits to feel
+something about their own work, and it is the emptiest screen in the app.
+
+**2.3 The two numbers are for a parent, not a child.** "Answered 1284 / Correct
+1102" (`src/shell/surfaces.ts:292-293`) — no rate, no streak, no sense of
+having built anything, and the number that matters (1102/1284 = 86%) is left for
+the reader to compute. Against the anti-goal ("a public school teacher crashing
+out telling everyone to work on their worksheet") this is the screen closest to
+the failure mode.
+
+**2.4 The second rosette reads as broken.** Half the apertures are ghost
+outlines at `--dw-line-strong` 0.3 (`src/world/Screen.tsx:23`), which at this
+scale looks like a rendering fault rather than "not yet cut".
+
+---
+
+## 3. Profiles (`/profiles`)
+
+Files: `src/shell/Surface.tsx:123-158`, `src/shell/surfaces.ts:308-340`.
+
+**3.1 "Remove" deletes a child's entire record with one tap, no confirmation.**
+`src/shell/Surface.tsx:147-155` calls `remove` directly. Two rows away, in
+Parents, "Erase everything" is a deliberate two-press armed control
+(`src/shell/surfaces.ts:409-417`). The less-destructive action is guarded and
+the per-child one is not. It is also the smallest, reddest thing on the row and
+sits 12 px from "Use".
+
+**3.2 The name field does not look editable, and its underline is ragged.**
+`src/shell/Surface.tsx:136` — `border-b` only, `bg-transparent`, and the input
+is `flex-1`, so its width depends on which siblings are present. In
+`light/profiles-390.png` the current learner's underline runs from x≈38 to 294
+and the other two from x≈16 to 231: three different lengths, two different left
+edges. Nothing signals "you may type here".
+
+**3.3 The current learner's row is indented.** See 0.3 — `dark`/`light`
+`profiles-390.png` both show it.
+
+**3.4 The screen is 22% used at 390, 10% at 1440.** Three rows and a button.
+
+---
+
+## 4. Settings (`/settings`)
+
+Files: `src/shell/Surface.tsx:63-95`, `src/shell/surfaces.ts:342-394`.
+
+**4.1 Every control on the screen is inverted.** See 0.2. Six of them.
+
+**4.2 The rhythm of a choice row does not match the rhythm of a fact row.**
+`Fact` is `min-h-16 items-center py-3` — label and value on one optically centred
+line (`src/shell/Surface.tsx:46`). `Choice` is `min-h-16 py-3` with a legend at
+`mb-2` and then the control (`:70-72`), which makes the row ~120 px with 8 px
+between the legend and the control and 12 px between the control and the rule
+below it. In `light/settings-1440.png` the rule for the next row sits 6 px under
+the previous control while the label sits 24 px above its own. Two spacing
+systems, alternating down the screen.
+
+**4.3 Segment width is huge and the label is tiny.** At 1440 each segment is
+224 px wide holding a 14 px word (`light/settings-1440.png`). At 390 the
+three-way controls are fine; the two-way ones give 175 px to the word "On".
+Nothing caps the control's width — `src/shell/Surface.tsx:72` is a plain flex row
+at the full 42 rem measure.
+
+**4.4 "Reduce motion" is phrased as a setting whose On means less.** The row
+reads "Reduce motion / Off | On" (`src/shell/surfaces.ts:357-359`), so the state
+a parent wants is double-negative. Every other switch on the screen is a
+positive.
+
+**4.5 At 1024 × 768 the last row is below the fold.** See 0.9.
+
+---
+
+## 5. Parents (`/parents`)
+
+Files: `src/shell/surfaces.ts:396-470`, `src/shell/Surface.tsx:97-112`.
+
+**5.1 "Erase everything" fails AA in light theme (4.45:1).** See 0.6.
+
+**5.2 The destructive control has no frame, no confirmation affordance, and is
+indented.** `src/shell/Surface.tsx:99-110` draws it as a borderless full-width
+text button. In `light/parents-1440.png` it is a red serif phrase floating in
+white space, 44 px right of every label above it, with nothing to say it is the
+most consequential control in the app. Arming it replaces the label in place —
+correct, and worth keeping — but nothing before the first press signals weight.
+
+**5.3 Developer mode rows overflow into two-line label / two-line value.**
+`dark/parents-dev-390.png`: "core:app:allow-version" wraps to two lines on the
+left while "@tauri-apps/api/app.getVersion" wraps to two on the right, producing
+a 120 px row with a ragged gutter. It no longer breaks the page (fixed, and
+verified), but it is the ugliest block in the app and it is what a developer
+looks at most.
+
+**5.4 The screen is 42% used at 390, 20% at 1440.**
+
+---
+
+## 6. The pass sheet and the parental gate
+
+Files: `src/pass/PassSheet.tsx`. Captured through `tools/harness/`, because the
+sheet **cannot currently be reached in the shipped app at all**: `Stage` only
+mounts it when `usePass.mayOpen()` is false (`src/packs/Stage.tsx:100`), which
+routes through `canOpen` (`src/pass/model.ts:206`) and returns `true`
+unconditionally while `billing().wired` is false — and nothing in `src/` ever
+calls `setBilling`. This is deliberate for today, but it means three screens are
+shipping unlooked-at. That is what the harness is for.
+
+**6.1 The dialog does not read as a raised sheet in dark theme.**
+`src/pass/PassSheet.tsx:51` overlays `bg-ground-deep/85`, and `:56` gives the
+panel `bg-ground`. In dark those are `basalt-950` `#060310` and `basalt-800`
+`#0b0618` — 1.13:1. The only thing separating the panel from the backdrop is a
+1 px `border-line-strong`. See `dark/pass-rest-390.png`, where the panel edge is
+nearly invisible and the sheet reads as text floating on black.
+
+**6.2 The two cheaper plates do not read as buttons.**
+`src/pass/PassSheet.tsx:227` gives the non-headline plates `border-line-cut`,
+which in dark is `basalt-950` (`src/design/tokens.css:362`) — darker than the
+panel they sit on, so the border is invisible. In `dark/pass-offer-390.png`
+"One month" and "Day pass" are unbounded text with a price beside them; only the
+gold-framed lifetime plate looks pressable. On the one screen where a parent
+spends money, two of the three options do not look like options.
+
+**6.3 Three type families collide in one row.** The plate name is
+`--font-inscription` (Iowan Old Style), the note is `--font-text` (system UI),
+and the price is `--font-numeral` (`ui-rounded` / SF Pro Rounded,
+`src/design/tokens.css:39`). "$79.99" in a rounded grotesque beside "Lifetime"
+in an old-style serif looks like two different products
+(`src/pass/PassSheet.tsx:241-247`).
+
+**6.4 Nothing aligns vertically in a plate.** `src/pass/PassSheet.tsx:221` —
+`items-center` on a row whose left side is two lines and whose right side is one,
+so the price floats between the name and the note rather than sharing a baseline
+with either.
+
+**6.5 Two underlined text links.** "Grown-ups" (`:109`) and "Restore a pass"
+(`:349`) are `underline underline-offset-4`. An underlined inline link is a web
+idiom; native sheets use a tinted control. On the child-facing stage,
+"Grown-ups" being the only underlined thing on screen also makes it more
+conspicuous than intended.
+
+**6.6 A focus ring appears on the child-facing screen — verify on device.**
+`src/pass/PassSheet.tsx:82` calls `leave.current?.focus()` on mount, and
+`src/index.css:92` draws a 2 px `--dw-focus` outline on `:focus-visible`. In
+`dark/pass-rest-390.png` the "Choose another game" button is captured **with the
+ring already on**, because Chrome matches `:focus-visible` for programmatic
+focus when there has been no prior user interaction. On a tablet where the sheet
+opens after a touch the heuristic should suppress it, but "a focus ring that
+appears on touch" is a named defect and this is the one place in the app that
+moves focus programmatically. Needs a WKWebView check; the safe form is to focus
+the dialog container rather than the button.
+
+**6.7 The child-facing stage is the least joyful screen in the app.** A dark
+rectangle, two serif sentences and a bordered word. `dark/pass-rest-390.png`.
+It is honest copy and correct policy — no timer, no price, no loss framing — but
+nothing about it makes a seven-year-old want to press "Choose another game".
+
+**6.8 The gate's answer field is 16 px+ and typed in caps.** Correct, and worth
+recording as verified: `src/pass/PassSheet.tsx:174` is `min-h-16 text-2xl`, no
+iOS zoom-on-focus risk, `autoCapitalize="characters"` matches the challenge.
+
+---
+
+## 7. Navigation and lintel (every screen)
+
+**7.1 The active tab is carried by a 8 × 8 px diamond and a small ink shift.**
+`src/app/Nav.tsx:48-50`. At 1440 that is an 8 px mark above a 12 px word in a
+288 px cell (`light/parents-1440.png`). Target size is fine (`min-h-14`, 56 px);
+legibility of the *current* state is not.
+
+**7.2 The tab labels are 12 px serif with `tracking-wide`.**
+`src/app/Nav.tsx:51`. Small for a child, and the serif at 12 px is where this
+typeface is weakest.
+
+**7.3 The nav has no elevation relationship to the content it scrolls over.**
+`src/app/Nav.tsx:28` is `sticky bottom-0` with `bg-ground-raised` and the
+strapwork band above it. While the catalogue scrolls under it, card art passes
+behind an opaque bar with a gold ribbon on top and no shadow, blur or scrim —
+see the clipped CLAIM/COLOSSUS cards in `dark/packs-390.png`.
+
+---
+
+## Measured summary
+
+| check | result |
+|---|---|
+| horizontal page overflow | 0 px on all 100 captures ✓ |
+| boxes that scroll sideways | 1 — the subject-chip row, 440 px at 390 px wide |
+| painted scrollbar tracks | `body` on all screens, chip row on `packs` at 390/430 |
+| interactive targets < 44 px | 2 distinct — wordmark link 220.3 × 43.2, "All" chip 42.1 × 44 |
+| text/ground pairs measured | 22 distinct |
+| AA failures | 2, both `--dw-strike` on light ground, both 4.45:1 (need 4.5) |
+| capture failures | 0 |
+
+## The three to fix first
+
+1. **§0.1** — the gold strapwork, twice per screen, ~120 warm points against a
+   rule of one. It is the first thing seen on every screen and the brand rule it
+   breaks is explicit.
+2. **§0.2** — every segmented control in the app draws the selected option as a
+   recess and the unselected ones as raised keys. Six on Settings, two on
+   Parents, the chip row on Packs.
+3. **§0.8** — desktop and large tablet: full-bleed lintel, 1152 px surface,
+   672 px courses and a full-bleed five-cell tab bar, with 80% of a 1440 × 900
+   screen empty.


### PR DESCRIPTION
## What

Component half of the harness pass. **Stacked on #669** — base is
`dw-premium-tokens`, not `main`. Merge #669 first and this retargets to main.

## Why

Three defects that only a sweep of every screen at every width in both themes
actually finds.

**Every segmented control in the app was drawn inverted.** The SELECTED option
got the recessed ground and the unselected ones the raised surface — so the
chosen segment read as a hole and the unchosen ones as pressable keys. Six
controls on Settings, two on Parents, and the catalogue's subject chips. Now a
recessed track with a raised thumb.

**The strapwork was drawn twice on every screen** — under the lintel and above
the tab bar. Once now.

**Four competing measures on desktop.** Lintel, surface, courses and tab bar each
began at a different x, and Parents used about a fifth of a 1440 screen. One
geometry now: wordmark, first row, first card and first tab share an origin at
every width; only prose stays narrower. Parents goes two-column above 64rem.

Also: the tab bar is a tab bar — casts upward, content scrolls under it, targets
clear 44px, clears the home indicator and the Android gesture bar. And cards
answer a touch, which they did not — the press state was hover-only, so on a
phone a child's tap was acknowledged by nothing until the next screen appeared.

## What the verifiers caught

Four independent lenses tried to refute this work. They disproved **two claims
made in it**:

- *"a choice row is now the same 64px object as a fact row"* — false at every
  width, measured. Fixed.
- *"the wordmark, the writing and the tabs share one geometry"* — three x-origins
  had become two, not one. Fixed.

Plus: the tab bar **clipped its own labels** at the Largest text size the app
ships ("Prog…", "Profi…", "Setti…") on every phone width — now capped by
container query, zero clipped labels across 6 widths × 3 text sizes. And a
`:focus-within` ring appeared **on touch**; now `:has(:focus-visible)`.

## Blast radius

- [x] Chrome and surfaces only. No game, no pack, no native code, no launch path.
- [x] `surfaces.test.ts` untouched and passing — it is load-bearing: two
      destinations rendered empty for weeks with a green suite before it existed.
- [x] No React `style` prop anywhere; `style-src 'self'` silently discards them
      on device. The test asserting this passes, and its glob was re-verified.
- [x] `dynawalla/games` and `dynawalla/packs` untouched — verified empty diff.
- [ ] **Not done, deliberately:** the pass sheet is unreachable on device because
      billing is unwired — a wiring change, not a design one. And a game's key
      art keeps its colours in both themes: *one warm point* governs the chrome,
      not the picture inside a card.

## Proof

```
npm run tsc     clean
npm test        tests 243 / pass 243 / fail 0   (238 on the base)
npm run lint    clean
npm run build   ✓ built in 151ms
```

120 screenshots re-captured after every change and reviewed at 390 / 834 / 1440
in both themes.