### PR TITLE
dynawalla/packs: a minimum age on every pack, and a floor with no ceiling

### DIFF
--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -65,6 +65,19 @@ export const strings = {
     nothing: "No game here matches that.",
     /** The band a game is written for, on its card. */
     grades: "Grades {{from}}–{{to}}",
+    /**
+     * The youngest age a game's *hands* are written for, on its card.
+     *
+     * A template rather than a bare `${age}+` in the JSX, and it is the only
+     * reason this two-character string is in here at all: `+` is a suffix in
+     * English and is not universally one. It leads in Arabic ordering, several
+     * locales set it off with a space, and a locale that wants "from 8" or
+     * "8 years and up" can only say so if the whole phrase is theirs to
+     * rewrite. Cost: one line in each of the five locale bundles.
+     *
+     * A floor and never a range — see `minAge` in the pack schema.
+     */
+    minAge: "{{age}}+",
 
     /**
      * The subjects, derived from skill ids at runtime (`catalog/domains.ts`).

--- a/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
+++ b/dynawalla/dynawalla-app/src/catalog/Catalog.tsx
@@ -1,22 +1,15 @@
 import { useId, useMemo, useState } from "react"
 
-import { fill, strings } from "../app/strings.ts"
+import { strings } from "../app/strings.ts"
 import type { Row } from "../shell/surfaces.ts"
 import { chipsFor, domainName, domainsOf, type DomainId } from "./domains.ts"
+import { gradeLabel, minAgeLabel } from "./labels.ts"
 import { PackArt } from "./PackArt.tsx"
 
 type PackRow = Extract<Row, { kind: "pack" }>
 
 /** Case- and accent-insensitive enough for a child hunting for "serpent". */
 const folded = (text: string): string => text.toLocaleLowerCase()
-
-/** The band a game is written for, or nothing at all — never "Grades ?–?". */
-function gradeLabel(grades: readonly [number, number] | null): string | null {
-  if (grades === null) return null
-  const [from, to] = grades
-  if (!Number.isFinite(from) || !Number.isFinite(to)) return null
-  return fill(strings.catalog.grades, { from, to })
-}
 
 /**
  * One game, as a card.
@@ -37,6 +30,7 @@ function gradeLabel(grades: readonly [number, number] | null): string | null {
  */
 function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
   const grades = gradeLabel(row.grades)
+  const age = minAgeLabel(row.minAge)
   const domains = domainsOf(row.skills)
   // Lead with the subject the child actually filtered by. Taking `domains[0]`
   // instead meant a card answering a Multiplication filter labelled itself
@@ -107,6 +101,20 @@ function Card({ row, active }: { row: PackRow; active: DomainId | null }) {
             </span>
           ))}
           {grades ? <span className="numeral text-ink-muted text-[0.6875rem]">{grades}</span> : null}
+          {/* Beside the grade band, in the same type as the version and the
+              "Play" word, because it is the same class of thing: small print
+              about who the game is for. It is NOT a badge — no border, no
+              fill, no colour of its own — and it must never become one. A
+              loud `8+` on a five-year-old's screen reads as a refusal, and
+              this is guidance.
+
+              It is here rather than on the title line, which is where it was
+              asked for, and the reason is measured rather than aesthetic: the
+              10.5rem column above is sized to exactly the 142px COUNTERWEIGHT
+              needs at 15px, with no slack at all. Any sibling on that line
+              takes width from the title and brings back "COUNTERPOI / SE",
+              which has already reached a screen once. */}
+          {age ? <span className="numeral text-ink-muted text-[0.6875rem]">{age}</span> : null}
           <span className="numeral text-ink-muted text-[0.6875rem]">
             {row.resting ? strings.packs.tomorrow : strings.packs.play}
           </span>

--- a/dynawalla/dynawalla-app/src/catalog/catalog.test.ts
+++ b/dynawalla/dynawalla-app/src/catalog/catalog.test.ts
@@ -17,7 +17,9 @@ import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { fill, strings } from "../app/strings.ts"
 import { ART_HUES, DRAWN_PACKS, artOf, hashOf, hueClass, isMotifKey, rngFrom } from "./art.ts"
+import { gradeLabel, minAgeLabel } from "./labels.ts"
 import { MOTIF_KEYS, shapesOf, type Shape } from "./motifs.ts"
 import { DOMAIN_IDS, chipsFor, domainOfSkill, domainsOf } from "./domains.ts"
 
@@ -212,4 +214,67 @@ test("the generator is seeded, spread and engine-independent", () => {
   for (const value of draws) assert.ok(value >= 0 && value < 1)
   const mean = draws.reduce((total, value) => total + value, 0) / draws.length
   assert.ok(Math.abs(mean - 0.5) < 0.06, `the generator is biased: mean ${mean}`)
+})
+
+/* ── The card's small print ───────────────────────────────────────────────── */
+
+test("a minimum age is drawn as a floor and never as a range", () => {
+  // The founder's instruction was an "and up" scheme and explicitly NOT a
+  // range: every game's mathematics adapts upward without bound, so a `6–10`
+  // on a card would promise a ceiling the product does not have.
+  assert.equal(minAgeLabel(5), "5+")
+  assert.equal(minAgeLabel(8), "8+")
+  for (const age of [5, 6, 7, 8, 9]) {
+    const label = minAgeLabel(age)
+    assert.ok(label, `no label for ${age}`)
+    assert.ok(!/[–—-]/.test(label), `${label} reads as a range`)
+    assert.ok(label.includes(String(age)), `${label} does not name the age`)
+  }
+})
+
+test("the age template keeps its slot, so a translation cannot empty the label", () => {
+  // `fill` leaves an unknown slot in place rather than blanking it, so a
+  // translation that drops `{{age}}` prints a literal `{{age}}` — visible, and
+  // a bug report. A translation that drops the NUMBER, though, would render a
+  // bare `+` and look like a rendering fault instead. This is what catches it.
+  assert.match(strings.catalog.minAge, /\{\{age\}\}/, "the age slot is gone")
+  assert.equal(fill(strings.catalog.minAge, { age: 42 }).includes("42"), true)
+})
+
+test("an unstated age is drawn as nothing, never as a guess or a placeholder", () => {
+  // A pack record written before this field existed is on a device today, and
+  // `minAge` is optional in the schema for exactly that reason.
+  assert.equal(minAgeLabel(null), null)
+  for (const nonsense of [0, -3, 7.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(minAgeLabel(nonsense), null, `${nonsense} reached a card`)
+  }
+})
+
+test("a grade band with a hole in it is drawn as nothing rather than as Grades ?–?", () => {
+  assert.equal(gradeLabel([1, 4]), "Grades 1–4")
+  assert.equal(gradeLabel(null), null)
+  assert.equal(gradeLabel([Number.NaN, 4]), null)
+  assert.equal(gradeLabel([1, Number.POSITIVE_INFINITY]), null)
+})
+
+test("every shipped game states a minimum age, and the catalogue can label it", () => {
+  // The fleet rule itself is enforced in `packs/sdk/src/fleet.test.ts`, which
+  // is the suite the `dynawalla/games/**` CI filter actually runs. This is the
+  // other half: that what the packs declare is something this catalogue can
+  // draw. A number the schema accepts but `minAgeLabel` rejects would ship a
+  // fleet of cards with a silent hole where the age should be.
+  const ages = fs
+    .readdirSync(gamesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(gamesRoot, entry.name, "pack.json"))
+    .filter((file) => fs.existsSync(file))
+    .map((file) => JSON.parse(fs.readFileSync(file, "utf8")) as { id: string; minAge?: number })
+
+  assert.ok(ages.length > 20, `expected the catalogue, found ${ages.length} packs`)
+  const undrawable = ages.filter((pack) => minAgeLabel(pack.minAge ?? null) === null)
+  assert.deepEqual(
+    undrawable.map((pack) => pack.id),
+    [],
+    "games whose minAge the catalogue cannot draw",
+  )
 })

--- a/dynawalla/dynawalla-app/src/catalog/labels.ts
+++ b/dynawalla/dynawalla-app/src/catalog/labels.ts
@@ -1,0 +1,38 @@
+// The small print on a game's card, as pure functions.
+//
+// Here rather than inside `Catalog.tsx` for one reason: `.tsx` cannot be tested
+// in this runner. Node's type stripper does not read JSX and there is no DOM,
+// so anything living in the component is held only by `tsc` — and "Grades ?–?"
+// and "NaN+" are both type-correct. These are the two lines a parent reads to
+// decide whether a game is for their child, so they are worth an assertion.
+//
+// The shared rule in both: **a fact that is missing is drawn as nothing, never
+// as a guess and never as a placeholder.** A pack record written before either
+// field existed is on a device today.
+
+import { fill, strings } from "../app/strings.ts"
+
+/** The band a game is written for, or nothing at all — never "Grades ?–?". */
+export function gradeLabel(grades: readonly [number, number] | null): string | null {
+  if (grades === null) return null
+  const [from, to] = grades
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null
+  return fill(strings.catalog.grades, { from, to })
+}
+
+/**
+ * The youngest age the game's *hands* are written for, or nothing at all.
+ *
+ * A floor, drawn "and up": `8+`, never `6–10`. There is no ceiling to draw
+ * because every game's mathematics adapts upward without bound, so a range
+ * would print a promise the product does not make.
+ *
+ * **Guidance, not a gate.** Nothing reads this to lock, hide, dim or reorder a
+ * pack — it is one more piece of small print in the same type as the version,
+ * and a five-year-old's parent seeing `8+` is being told the game may be
+ * frustrating, not that it is shut.
+ */
+export function minAgeLabel(minAge: number | null): string | null {
+  if (minAge === null || !Number.isInteger(minAge) || minAge <= 0) return null
+  return fill(strings.catalog.minAge, { age: minAge })
+}

--- a/dynawalla/dynawalla-app/src/packs/library.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/library.test.ts
@@ -9,7 +9,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { HOST_SUPPORTS, hostProfile, readLibrary } from "./library.ts"
+import { HOST_SUPPORTS, cardFacts, hostProfile, readLibrary } from "./library.ts"
 import type { InstalledPackRow, PackNative } from "./native.ts"
 
 const manifest = (over: Record<string, unknown> = {}) => ({
@@ -111,4 +111,37 @@ test("this build supports every capability the SDK defines", () => {
     [...HOST_SUPPORTS].sort(),
     ["audio", "haptics", "items", "items.reveal", "learner.read", "milestones", "storage"],
   )
+})
+
+test("the card's facts carry the minimum age, and carry its absence as absence", async () => {
+  // `libraryStore` persists this projection and `useHost` lays it back over the
+  // stored record. It is one function precisely so those two cannot disagree,
+  // and this is what holds the manifest end of it: a field dropped here reaches
+  // the catalogue as a card with a silent hole in its small print, with every
+  // type still correct on both sides.
+  const stated = await readLibrary({
+    native: nativeWith([rowFor(manifest({ minAge: 8 }))]),
+    host: hostProfile("0.1.0"),
+  })
+  const withAge = stated.entries[0]
+  assert.ok(withAge)
+  assert.deepEqual(cardFacts(withAge), {
+    description: "Chips that add to the key number fuse.",
+    skills: ["dw.add.regroup.add-multidigit"],
+    grades: [1, 4],
+    minAge: 8,
+  })
+
+  const silent = await readLibrary({
+    native: nativeWith([rowFor(manifest())]),
+    host: hostProfile("0.1.0"),
+  })
+  const withoutAge = silent.entries[0]
+  assert.ok(withoutAge)
+  const facts = cardFacts(withoutAge)
+  // Absent, not present-and-undefined. The persisted record and the type
+  // checker both treat those as different things, and a stored `undefined`
+  // would be written into a family's localStorage forever.
+  assert.equal("minAge" in facts, false, "an unstated age was stored as undefined")
+  assert.deepEqual(Object.keys(facts).sort(), ["description", "grades", "skills"])
 })

--- a/dynawalla/dynawalla-app/src/packs/library.ts
+++ b/dynawalla/dynawalla-app/src/packs/library.ts
@@ -62,6 +62,37 @@ export type LibraryDeps = {
 }
 
 /**
+ * Everything the front door needs to draw a card, lifted off one manifest.
+ *
+ * One function with two callers, and the duplication it replaces is why it
+ * exists: `libraryStore` copies these onto the persisted record and `useHost`
+ * copies them back over it, and the two lists have to agree field for field
+ * forever. They were two hand-written object literals, so the failure mode of
+ * adding a field was a card that drew it after a fresh install and lost it on
+ * the next launch — or the reverse — with every type still correct.
+ */
+export type PackCardFacts = {
+  readonly description: string
+  readonly skills: readonly string[]
+  readonly grades: readonly [number, number]
+  /** Absent, not `undefined`: `exactOptionalPropertyTypes` is on. */
+  readonly minAge?: number
+}
+
+export function cardFacts(entry: LibraryEntry): PackCardFacts {
+  return {
+    description: entry.description,
+    skills: entry.manifest.covers.skills,
+    grades: entry.manifest.covers.grades,
+    // Spread rather than assigned, so a pack that states no minimum age leaves
+    // the key off entirely. The catalogue draws an unstated age as nothing at
+    // all, and an explicit `undefined` is a different thing from an absent key
+    // to both the persisted record and the type checker.
+    ...(entry.manifest.minAge === undefined ? {} : { minAge: entry.manifest.minAge }),
+  }
+}
+
+/**
  * Read the pack root and decide what may run.
  *
  * Pure over its dependencies so the whole decision — a damaged manifest, a pack

--- a/dynawalla/dynawalla-app/src/packs/libraryStore.ts
+++ b/dynawalla/dynawalla-app/src/packs/libraryStore.ts
@@ -11,7 +11,7 @@
 import { create } from "zustand"
 
 import { BUILD_VERSION, isNative } from "../app/platform.ts"
-import { hostProfile, readLibrary, type LibraryEntry, type LibraryProblem } from "./library.ts"
+import { cardFacts, hostProfile, readLibrary, type LibraryEntry, type LibraryProblem } from "./library.ts"
 import { tauriNative } from "./native.ts"
 import { usePacks } from "./registry.ts"
 
@@ -55,10 +55,11 @@ export const useLibrary = create<LibraryState>()((set) => ({
           installedAt: Date.now(),
           // What the catalogue draws a card from. Written here, from the same
           // manifest the version came from, so the record and the card cannot
-          // disagree about what a pack is.
-          description: entry.description,
-          skills: entry.manifest.covers.skills,
-          grades: entry.manifest.covers.grades,
+          // disagree about what a pack is. `cardFacts` is shared with
+          // `useHost`, which writes the same fields back over this record —
+          // two hand-written copies of one list is how a field goes missing on
+          // one side of a launch.
+          ...cardFacts(entry),
         })
       }
       const live = new Set(entries.map((entry) => entry.manifest.id))

--- a/dynawalla/dynawalla-app/src/packs/registry.ts
+++ b/dynawalla/dynawalla-app/src/packs/registry.ts
@@ -47,6 +47,13 @@ export interface InstalledPack {
   readonly skills?: readonly string[]
   /** `covers.grades` — inclusive band, `[1, 4]` is grades one to four. */
   readonly grades?: readonly [number, number]
+  /**
+   * `minAge` — the youngest age the game's *hands* are written for, drawn as
+   * `8+`. A floor with no ceiling, and guidance rather than a gate: nothing
+   * anywhere reads this to lock, hide, dim or reorder a pack. Absent means the
+   * pack did not state one, which the card draws as nothing at all.
+   */
+  readonly minAge?: number
 }
 
 export interface RegistryState {

--- a/dynawalla/dynawalla-app/src/shell/surfaces.test.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.test.ts
@@ -320,3 +320,70 @@ test("diagnostics are off until a parent turns them on", () => {
     "the storage breakdown is the point of the mode",
   )
 })
+
+test("a pack's minimum age reaches the card, and an unstated one stays unstated", () => {
+  // The wire from the manifest to the small print: `libraryStore` copies
+  // `manifest.minAge` onto the record, and this is where it becomes something
+  // the catalogue can draw. Everything either side of this hop is typed; this
+  // hop is a hand-written object literal, which is where a field goes missing.
+  const rows = rowsOf("packs", {
+    ...coldHost,
+    packs: [
+      {
+        id: "inc.corpora.pack.stated",
+        name: "Stated",
+        version: "1.0.0",
+        bytes: 1024,
+        sha256: "",
+        installedAt: 0,
+        minAge: 8,
+      },
+      {
+        id: "inc.corpora.pack.silent",
+        name: "Silent",
+        version: "1.0.0",
+        bytes: 1024,
+        sha256: "",
+        installedAt: 0,
+      },
+    ],
+  }).filter((row) => row.kind === "pack")
+
+  assert.equal(rows.length, 2)
+  assert.equal(rows.find((row) => row.name === "Stated")?.minAge, 8)
+  // `null`, not `undefined`: a record written before this field existed is on
+  // a device today, and the card draws nothing rather than guessing.
+  assert.equal(rows.find((row) => row.name === "Silent")?.minAge, null)
+})
+
+test("a minimum age is guidance and never a gate", () => {
+  // The whole product decision in one assertion. A game labelled for older
+  // hands is not locked, not hidden, not dimmed, not sorted away and not
+  // resting: the row is identical to every other row except for two extra
+  // characters of small print, and pressing it launches the pack.
+  const { calls, actions } = recorder()
+  const rows = surfaceOf(
+    "packs",
+    {
+      ...coldHost,
+      packs: [
+        {
+          id: "inc.corpora.pack.oldest",
+          name: "Oldest",
+          version: "1.0.0",
+          bytes: 1024,
+          sha256: "",
+          installedAt: 0,
+          minAge: 18,
+        },
+      ],
+    },
+    actions,
+  ).flatMap((section) => [...section.rows])
+
+  const pack = rows.find((row) => row.kind === "pack")
+  assert.ok(pack?.kind === "pack", "the oldest-labelled game left the front door")
+  assert.equal(pack.resting, false, "an age label must not rest a game")
+  pack.play()
+  assert.deepEqual(calls, ["launchPack"], "the oldest-labelled game did not open")
+})

--- a/dynawalla/dynawalla-app/src/shell/surfaces.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.ts
@@ -101,6 +101,17 @@ export type Row =
       readonly skills: readonly string[]
       /** Inclusive grade band, or `null` when the record predates it. */
       readonly grades: readonly [number, number] | null
+      /**
+       * The youngest age the game's *hands* are written for, or `null` when
+       * the pack did not say.
+       *
+       * **Guidance, never a gate.** It is carried here so the card can print
+       * `8+` beside the grade band, and for no other reason: nothing in this
+       * model or downstream of it filters, sorts, dims or locks on it. A
+       * five-year-old's parent seeing `8+` is being told the game may be
+       * frustrating — the game still opens, at full strength, on a press.
+       */
+      readonly minAge: number | null
       /** Launches it onto the stage. Never null: an unplayable pack is not a row. */
       readonly play: () => void
       /**
@@ -257,6 +268,7 @@ function packsSurface(view: HostView, act: HostActions): readonly Section[] {
           description: pack.description ?? "",
           skills: pack.skills ?? [],
           grades: pack.grades ?? null,
+          minAge: pack.minAge ?? null,
           play: () => act.launchPack(pack.id),
           resting: view.resting.includes(pack.id),
         }),

--- a/dynawalla/dynawalla-app/src/shell/useHost.ts
+++ b/dynawalla/dynawalla-app/src/shell/useHost.ts
@@ -13,6 +13,7 @@ import { storageBreakdown, storageBytes } from "../app/profile.ts"
 import { recordFor, worldFor } from "../app/stores.ts"
 import { eraseEverything } from "../app/erase.ts"
 import { useThemeStore } from "../app/theme.ts"
+import { cardFacts } from "../packs/library.ts"
 import { useLibrary } from "../packs/libraryStore.ts"
 import { usePacks, type InstalledPack } from "../packs/registry.ts"
 import { useLaunch } from "../packs/Stage.tsx"
@@ -112,9 +113,10 @@ function useDescribedPacks(): readonly InstalledPack[] {
       if (!entry) return pack
       return {
         ...pack,
-        description: entry.description,
-        skills: entry.manifest.covers.skills,
-        grades: entry.manifest.covers.grades,
+        // The same projection `libraryStore` persists, so the card a child
+        // sees before the library has been read and the card they see after
+        // cannot describe the pack differently.
+        ...cardFacts(entry),
       }
     })
   }, [packs, entries])

--- a/dynawalla/games/arena/pack.json
+++ b/dynawalla/games/arena/pack.json
@@ -11,6 +11,7 @@
     "skills": ["dw.ns.compare.whole-numbers"],
     "grades": [1, 4]
   },
+  "minAge": 8,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/balance/pack.json
+++ b/dynawalla/games/balance/pack.json
@@ -27,6 +27,7 @@
       5
     ]
   },
+  "minAge": 6,
   "locales": [
     "en"
   ],

--- a/dynawalla/games/beam/pack.json
+++ b/dynawalla/games/beam/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 8,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/claim/pack.json
+++ b/dynawalla/games/claim/pack.json
@@ -25,6 +25,7 @@
       5
     ]
   },
+  "minAge": 8,
   "locales": [
     "en"
   ],

--- a/dynawalla/games/coil/pack.json
+++ b/dynawalla/games/coil/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 6,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/colossus/pack.json
+++ b/dynawalla/games/colossus/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 5,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/counterweight/pack.json
+++ b/dynawalla/games/counterweight/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/forge/pack.json
+++ b/dynawalla/games/forge/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 5,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/foundry/pack.json
+++ b/dynawalla/games/foundry/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 6,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/guilty/pack.json
+++ b/dynawalla/games/guilty/pack.json
@@ -29,6 +29,7 @@
       5
     ]
   },
+  "minAge": 8,
   "locales": [
     "en"
   ],

--- a/dynawalla/games/horde/pack.json
+++ b/dynawalla/games/horde/pack.json
@@ -31,6 +31,7 @@
       5
     ]
   },
+  "minAge": 8,
   "locales": [
     "en"
   ],

--- a/dynawalla/games/lattice/pack.json
+++ b/dynawalla/games/lattice/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 8,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/merge-idle/pack.json
+++ b/dynawalla/games/merge-idle/pack.json
@@ -20,6 +20,7 @@
     ],
     "grades": [1, 5]
   },
+  "minAge": 5,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/merge/pack.json
+++ b/dynawalla/games/merge/pack.json
@@ -16,6 +16,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 6,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/mosaic/pack.json
+++ b/dynawalla/games/mosaic/pack.json
@@ -17,6 +17,7 @@
     ],
     "grades": [2, 5]
   },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/polarity/pack.json
+++ b/dynawalla/games/polarity/pack.json
@@ -17,6 +17,7 @@
     ],
     "grades": [1, 5]
   },
+  "minAge": 9,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/pulse/pack.json
+++ b/dynawalla/games/pulse/pack.json
@@ -16,6 +16,7 @@
     ],
     "grades": [3, 5]
   },
+  "minAge": 9,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/rhythm/pack.json
+++ b/dynawalla/games/rhythm/pack.json
@@ -18,6 +18,7 @@
     ],
     "grades": [3, 5]
   },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/runner/pack.json
+++ b/dynawalla/games/runner/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/serpent/pack.json
+++ b/dynawalla/games/serpent/pack.json
@@ -20,6 +20,7 @@
     ],
     "grades": [1, 5]
   },
+  "minAge": 8,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/siege/pack.json
+++ b/dynawalla/games/siege/pack.json
@@ -16,6 +16,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 5,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/skyledger/pack.json
+++ b/dynawalla/games/skyledger/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/slice/pack.json
+++ b/dynawalla/games/slice/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/stack/pack.json
+++ b/dynawalla/games/stack/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 9,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/street/pack.json
+++ b/dynawalla/games/street/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 5,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/trebuchet/pack.json
+++ b/dynawalla/games/trebuchet/pack.json
@@ -16,6 +16,7 @@
     ],
     "grades": [1, 3]
   },
+  "minAge": 6,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/games/truedraw/pack.json
+++ b/dynawalla/games/truedraw/pack.json
@@ -19,6 +19,7 @@
     ],
     "grades": [1, 4]
   },
+  "minAge": 6,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }

--- a/dynawalla/packs/README.md
+++ b/dynawalla/packs/README.md
@@ -49,6 +49,7 @@ hold at a thousand packs, so it holds at two.
   "entry": "pack.html",
   "capabilities": ["items", "items.reveal", "haptics"],
   "covers": { "skills": ["dw.add.regroup.subtract-multidigit"], "grades": [1, 4] },
+  "minAge": 7,
   "locales": ["en"],
   "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
 }
@@ -56,6 +57,31 @@ hold at a thousand packs, so it holds at two.
 
 `assets.files`, `assets.bytes` and the integrity digest are **generated**. They
 are facts about built output, and a hand-maintained copy of a fact goes stale.
+
+### `minAge` — the one judgement a builder cannot make
+
+Every game must state one, and `packs/sdk/src/fleet.test.ts` fails the build if a
+new directory arrives without it. It is a **floor with no ceiling**: `7` is drawn
+as `7+`, and there is no `maxAge` — the parser rejects one — because every game's
+mathematics adapts upward without bound and a range would print a ceiling the
+product does not have.
+
+**Judge it by motor and attention demand, never by the arithmetic.** The maths
+adapts down to single-digit facts in every pack, so it is never what stops a
+five-year-old; what stops them is a 60 ms timing window, two thumbs on two
+independent sticks, or steering away from something while computing. Roughly:
+
+| | what the hands must do |
+| --- | --- |
+| 5 | discrete taps on large targets, self-paced, nothing moving against the child |
+| 6 | one forgiving continuous gesture (a drag, a free aim), or a soft budget, no dual task |
+| 7 | steer or survive while a question is live, or a window around 200–400 ms, or small targets |
+| 8 | two simultaneous continuous axes, or sustained dodge-plus-compute, or a window under 250 ms |
+| 9 | all of it at once: precision timing, dual task, and fine discrimination between numerals |
+
+**It is guidance, not a gate.** Nothing anywhere reads this field to lock, hide,
+dim or reorder a pack. A five-year-old's parent seeing `8+` is being told the
+game may be frustrating; the game still opens, at full strength, on a press.
 
 ### Where the output goes
 

--- a/dynawalla/packs/authoring.mjs
+++ b/dynawalla/packs/authoring.mjs
@@ -1,0 +1,66 @@
+// `pack.json` (what an author writes) → `manifest.json` (what a device reads).
+//
+// Extracted out of `build.mjs` for one reason: it is the only part of the
+// pipeline that is a pure function, and it is the part where a field goes
+// missing. Everything else in that script is filesystem work whose failure is
+// loud — a build that does not produce a file stops. A field silently dropped
+// here produces twenty-seven perfectly valid manifests that simply do not say
+// the thing, and the first sign of it is a catalogue whose small print is
+// blank. `packs/sdk/src/fleet.test.ts` covers this function directly.
+//
+// The rule about what belongs here has not changed: **generated fields are
+// facts about built output** (`assets`, `download`), and everything else is
+// carried across from what the author wrote. A hand-maintained copy of a fact
+// goes stale; a builder-invented judgement is worse, because nobody made it.
+
+/**
+ * The fields carried from `pack.json`, in the order the schema documents them.
+ *
+ * A list, not a spread of the whole source object: `pack.json` also holds
+ * `build` — the vite config and output directory — which is instruction to the
+ * builder and has no business on a device.
+ *
+ * `optional: true` means omitted when the author did not write it, never
+ * emitted as `null`. The schema distinguishes "unstated" from "stated as
+ * nothing", and `minAge` is the field where that distinction is visible to a
+ * parent: an unstated age draws as nothing at all rather than as a guess.
+ *
+ * `minAge` is optional in the SCHEMA — a manifest written before the field
+ * existed is on a device today — but required of every pack in THIS
+ * repository, which `fleet.test.ts` enforces. It is carried, never defaulted:
+ * how hard a game is on a pair of five-year-old hands is the one judgement a
+ * builder cannot make, and inventing a number here would put a claim on a card
+ * that nobody made.
+ */
+export const CARRIED = Object.freeze([
+  { field: "id" },
+  { field: "version" },
+  { field: "name" },
+  { field: "description" },
+  { field: "nameLocalized", optional: true },
+  { field: "descriptionLocalized", optional: true },
+  { field: "sdk" },
+  { field: "host" },
+  { field: "entry" },
+  { field: "capabilities" },
+  { field: "covers" },
+  { field: "minAge", optional: true },
+  { field: "locales" },
+])
+
+/**
+ * @param {Record<string, unknown>} source  the parsed `pack.json`
+ * @param {{ files: number, bytes: number }} assets  measured, about the built directory
+ * @param {{ bytes: number, sha256: string }} download  measured, about the archive
+ */
+export function manifestFrom(source, assets, download) {
+  /** @type {Record<string, unknown>} */
+  const manifest = { schema: 1 }
+  for (const { field, optional } of CARRIED) {
+    if (optional && source[field] === undefined) continue
+    manifest[field] = source[field]
+  }
+  manifest.assets = assets
+  manifest.download = download
+  return manifest
+}

--- a/dynawalla/packs/build.mjs
+++ b/dynawalla/packs/build.mjs
@@ -37,6 +37,8 @@ import fs from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { manifestFrom } from "./authoring.mjs"
+
 const here = path.dirname(fileURLToPath(import.meta.url))
 const root = path.resolve(here, "..")
 const GAMES = path.join(root, "games")
@@ -133,29 +135,17 @@ function buildOne(pack) {
   // build for a reason nobody would guess.
   const content = walk(staged)
   const contentBytes = bytesOf(staged, content)
-  const manifest = {
-    schema: 1,
-    id: source.id,
-    version: source.version,
-    name: source.name,
-    description: source.description,
-    ...(source.nameLocalized ? { nameLocalized: source.nameLocalized } : {}),
-    ...(source.descriptionLocalized ? { descriptionLocalized: source.descriptionLocalized } : {}),
-    sdk: source.sdk,
-    host: source.host,
-    entry: source.entry,
-    capabilities: source.capabilities,
-    covers: source.covers,
-    locales: source.locales,
-    assets: {
+  const manifest = manifestFrom(
+    source,
+    {
       files: content.length + 1,
       bytes: Math.ceil((contentBytes + 4096) / 1024) * 1024,
     },
-    download: {
+    {
       bytes: Math.max(1, contentBytes),
       sha256: digestOf(staged, content),
     },
-  }
+  )
   fs.writeFileSync(path.join(staged, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
 
   // The gate. Not advisory: a pack that does not pass does not ship, and the

--- a/dynawalla/packs/sdk/README.md
+++ b/dynawalla/packs/sdk/README.md
@@ -63,6 +63,7 @@ Two consequences worth planning around:
   "entry": "index.html",
   "capabilities": ["items", "haptics"],
   "covers": { "skills": ["add.2digit.regroup"], "grades": [1, 3] },
+  "minAge": 6,
   "locales": ["en", "es"],
   "assets": { "files": 42, "bytes": 3000000 },
   "download": {
@@ -87,6 +88,13 @@ Notes that are not obvious from the shape:
   produces two different hashes for one version number and is unresolvable from
   the device.
 - `covers` is how the host routes a skill to a pack that can teach it.
+- `minAge` is optional, an integer in 3–18, and a **floor with no ceiling** —
+  `6` is drawn as `6+`. There is no `maxAge` and the parser rejects one: every
+  game's mathematics adapts upward without bound, so a range would print a
+  promise the product does not make. It is a claim about **motor and attention
+  demand, not about arithmetic** — the maths adapts down to single-digit facts
+  in every pack, so it is never the limiting factor. **Guidance, never a
+  gate:** nothing in the host reads it to lock, hide, dim or reorder a pack.
 
 ---
 

--- a/dynawalla/packs/sdk/bin/dw-pack.mjs
+++ b/dynawalla/packs/sdk/bin/dw-pack.mjs
@@ -130,6 +130,7 @@ function check(dir) {
   console.log(`  sdk          ${manifest.sdk} (this SDK is ${SDK_VERSION})`)
   console.log(`  capabilities ${manifest.capabilities.join(", ") || "none"}`)
   console.log(`  covers       ${manifest.covers.skills.length} skills, grades ${manifest.covers.grades.join("–")}`)
+  console.log(`  min age      ${manifest.minAge === undefined ? "unstated" : `${manifest.minAge}+`}`)
   console.log(`  on disk      ${files.length} files, ${bytes} bytes`)
 }
 

--- a/dynawalla/packs/sdk/example/manifest.json
+++ b/dynawalla/packs/sdk/example/manifest.json
@@ -9,6 +9,7 @@
   "entry": "index.html",
   "capabilities": ["items", "haptics"],
   "covers": { "skills": ["sub.4digit.zero"], "grades": [2, 4] },
+  "minAge": 5,
   "locales": ["en"],
   "assets": { "files": 4, "bytes": 32768 },
   "download": {

--- a/dynawalla/packs/sdk/src/fleet.test.ts
+++ b/dynawalla/packs/sdk/src/fleet.test.ts
@@ -1,0 +1,138 @@
+// The one thing about a pack that no builder can measure: how hard it is on a
+// pair of five-year-old hands.
+//
+// `minAge` is OPTIONAL in the schema, and has to be — a manifest written before
+// the field existed is on a device today, and refusing it there would uninstall
+// working games. That optionality is the hazard this file closes: the schema
+// will happily accept a new pack that says nothing, and a card with no age on
+// it is indistinguishable from a card whose author forgot.
+//
+// So the rule is split in two:
+//
+//   * the SCHEMA says "an integer in 3–18, or nothing" — `manifest.test.ts`,
+//   * this repository's FLEET says "every game states one" — here.
+//
+// **Why this file is in the SDK and not in the app.** The app's catalogue test
+// already globs this same directory, but the app's CI filter is
+// `^dynawalla/(dynawalla-app|curriculum|engine)/`, so adding `games/twentyeight/`
+// does not run it. `dynawalla_packs` is `^dynawalla/(games|packs)/`, and the
+// SDK's `npm test` is the first thing that job runs. A guard that does not run
+// on the change it guards against is not a guard.
+//
+// Discovery is a glob, matching `packs/build.mjs`: adding the thousandth pack
+// is adding a directory, and there is no register to forget to edit.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { MIN_AGE_CEILING, MIN_AGE_FLOOR, parseManifest } from "./manifest.ts"
+// @ts-expect-error — a plain .mjs pipeline module with no type declarations.
+import { manifestFrom } from "../../authoring.mjs"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const gamesRoot = path.resolve(here, "../../../games")
+
+type PackSource = { readonly id?: unknown; readonly minAge?: unknown }
+
+/** Every `games/<name>/pack.json`, as `[directory, parsed]`. */
+function fleet(): readonly (readonly [string, PackSource])[] {
+  const out: (readonly [string, PackSource])[] = []
+  for (const entry of fs.readdirSync(gamesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const file = path.join(gamesRoot, entry.name, "pack.json")
+    if (!fs.existsSync(file)) continue
+    out.push([entry.name, JSON.parse(fs.readFileSync(file, "utf8")) as PackSource])
+  }
+  return out.sort((a, b) => (a[0] < b[0] ? -1 : 1))
+}
+
+test("the glob still finds the fleet", () => {
+  // Without this, every assertion below passes on an empty list the day the
+  // games move, and the file goes on reporting green forever.
+  assert.ok(fleet().length > 20, `expected the fleet, found ${fleet().length} pack.json files`)
+})
+
+test("every shipped game states the youngest age its hands are written for", () => {
+  // A new game arrives as a new directory. It must not be able to arrive
+  // without an answer to "can a five-year-old work this?", because the schema
+  // will accept the silence and the card will simply print nothing.
+  const silent = fleet()
+    .filter(([, source]) => source.minAge === undefined)
+    .map(([name]) => name)
+  assert.deepEqual(
+    silent,
+    [],
+    'games with no "minAge" in pack.json — add one, justified by motor and attention demand, never by the arithmetic (the maths adapts down to single digits in every pack)',
+  )
+})
+
+test("every stated minimum age is an integer inside the schema's bounds", () => {
+  for (const [name, source] of fleet()) {
+    const age = source.minAge
+    assert.equal(typeof age, "number", `${name}: minAge is ${JSON.stringify(age)}, not a number`)
+    assert.ok(Number.isInteger(age), `${name}: minAge ${String(age)} is not a whole year`)
+    assert.ok(
+      typeof age === "number" && age >= MIN_AGE_FLOOR && age <= MIN_AGE_CEILING,
+      `${name}: minAge ${String(age)} is outside ${MIN_AGE_FLOOR}–${MIN_AGE_CEILING}`,
+    )
+  }
+})
+
+test("no game declares an age ceiling — the label is a floor and says so", () => {
+  // The founder's instruction was an "and up" scheme and explicitly NOT a
+  // range. Every game's mathematics adapts upward without bound, so a `6–10`
+  // on a card would be a promise the product does not make. The schema refuses
+  // these fields; this is what stops one being introduced under another name.
+  for (const [name, source] of fleet()) {
+    for (const field of ["maxAge", "ageRange", "ages", "ageBand"]) {
+      assert.equal(
+        (source as Record<string, unknown>)[field],
+        undefined,
+        `${name} declares "${field}" — there is no ceiling in this schema`,
+      )
+    }
+  }
+})
+
+test("the fleet spreads across the ladder rather than labelling everything the same", () => {
+  // A label every game shares carries no information, and a parent choosing
+  // between twenty-seven cards that all read "5+" has been told nothing. This
+  // is the guard against a future bulk edit that flattens the judgement.
+  const ages = new Set(fleet().map(([, source]) => source.minAge))
+  assert.ok(ages.size >= 3, `every game claims one of ${ages.size} ages — that is not guidance`)
+})
+
+/* ── The builder's projection ─────────────────────────────────────────────── */
+
+test("the builder carries a stated minimum age onto the manifest a device reads", () => {
+  // The one place a field is dropped without anything going red: `build.mjs`
+  // would still produce twenty-seven schema-valid manifests, and the only
+  // symptom would be a catalogue whose small print is blank. Every other
+  // assertion in this file is about `pack.json`, which is the wrong end.
+  const assets = { files: 4, bytes: 32768 }
+  const download = { bytes: 8192, sha256: "a".repeat(64) }
+
+  for (const [name, source] of fleet()) {
+    const manifest = manifestFrom(source, assets, download)
+    assert.equal(manifest["minAge"], source.minAge, `${name}: the builder lost its minAge`)
+    // …and the result is something the schema will actually take, so a fleet
+    // value the parser rejects fails here rather than at the build's gate.
+    const parsed = parseManifest(manifest)
+    assert.equal(parsed.ok, true, parsed.ok ? "" : `${name}: ${parsed.problems.join("; ")}`)
+  }
+})
+
+test("the builder omits an unstated age rather than writing it as null", () => {
+  // `null` and `7.5` both reach a card as garbage, and `undefined` survives
+  // `JSON.stringify` as an absent key only by accident of the serialiser. The
+  // schema distinguishes "unstated" from "stated as nothing" and so must this.
+  const [, sample] = fleet()[0] ?? []
+  assert.ok(sample, "no pack to build a fixture from")
+  const { minAge: _dropped, ...silent } = sample as Record<string, unknown>
+  const manifest = manifestFrom(silent, { files: 4, bytes: 32768 }, { bytes: 8192, sha256: "a".repeat(64) })
+  assert.equal("minAge" in manifest, false, "an unstated age was written into the manifest")
+  assert.equal(parseManifest(manifest).ok, true)
+})

--- a/dynawalla/packs/sdk/src/manifest.test.ts
+++ b/dynawalla/packs/sdk/src/manifest.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict"
 
 import {
   MAX_INSTALLED_BYTES,
+  MIN_AGE_CEILING,
+  MIN_AGE_FLOOR,
   isSafeRelativePath,
   localizedDescription,
   localizedName,
@@ -171,4 +173,61 @@ test("localisation falls back by base tag and then to the plain field", () => {
   assert.equal(localizedName(manifest, "fr"), "Abacus Tower", "fallback")
   assert.equal(localizedDescription(manifest, "fr"), "Carry beads up the tower.")
   assert.equal(localizedName(valid() as unknown as PackManifest, "es"), "Abacus Tower")
+})
+
+/* ── minAge — a floor, drawn as "and up" ──────────────────────────────────── */
+
+test("minAge is optional, so a manifest written before it existed still parses", () => {
+  const draft = valid() as unknown as Record<string, unknown>
+  assert.equal("minAge" in draft, false, "the fixture was supposed to omit it")
+  const result = parseManifest(draft)
+  assert.equal(result.ok, true, result.ok ? "" : result.problems.join("; "))
+  assert.equal(result.ok ? result.manifest.minAge : 0, undefined, "absent must stay absent")
+})
+
+test("a stated minAge survives parsing as the integer it was written as", () => {
+  for (const age of [MIN_AGE_FLOOR, 5, 8, MIN_AGE_CEILING]) {
+    const result = parseManifest({ ...valid(), minAge: age })
+    assert.equal(result.ok, true, result.ok ? "" : result.problems.join("; "))
+    assert.equal(result.ok ? result.manifest.minAge : -1, age)
+  }
+})
+
+test("the three shapes an author reaches for instead of an integer are all refused", () => {
+  // Each of these renders on a parent's screen as garbage rather than failing:
+  // "8+" becomes "8++", [6, 10] becomes "6,10+", 7.5 becomes "7.5+".
+  for (const wrong of ["8+", "8", [6, 10], 7.5, null, Number.NaN, true]) {
+    assert.ok(
+      problemsFor((draft) => {
+        draft["minAge"] = wrong
+      }).some((p) => p.includes("minAge")),
+      `${JSON.stringify(wrong)} was accepted as a minimum age`,
+    )
+  }
+})
+
+test("minAge is bounded on both sides, because a label outside them means nothing", () => {
+  for (const wrong of [MIN_AGE_FLOOR - 1, 0, -5, MIN_AGE_CEILING + 1, 99]) {
+    assert.ok(
+      problemsFor((draft) => {
+        draft["minAge"] = wrong
+      }).some((p) => p.includes("minAge")),
+      `${wrong} was accepted as a minimum age`,
+    )
+  }
+})
+
+test("there is no age ceiling in this schema, and asking for one is an error", () => {
+  // The founder's instruction was an "and up" scheme and explicitly NOT a
+  // range: every game's mathematics adapts upward without bound, so a `6–10`
+  // would promise a ceiling the product does not have. A pack author who
+  // writes one must be told, not quietly ignored.
+  for (const field of ["maxAge", "ageRange"]) {
+    assert.ok(
+      problemsFor((draft) => {
+        draft[field] = field === "maxAge" ? 10 : [6, 10]
+      }).some((p) => p.includes("and up")),
+      `${field} was silently accepted`,
+    )
+  }
 })

--- a/dynawalla/packs/sdk/src/manifest.ts
+++ b/dynawalla/packs/sdk/src/manifest.ts
@@ -41,6 +41,17 @@ export const MAX_DOWNLOAD_BYTES = 256 * 1024 * 1024
 
 export const MAX_FILES = 20_000
 
+/**
+ * The bounds on `minAge`.
+ *
+ * A floor with no ceiling, so the numbers stay inside what a *label* can mean:
+ * below three there is no child holding the tablet, and past eighteen the word
+ * "minimum age" has stopped describing a learner. A pack that wants to say
+ * "anyone" omits the field.
+ */
+export const MIN_AGE_FLOOR = 3
+export const MIN_AGE_CEILING = 18
+
 export type PackManifest = {
   readonly schema: number
   readonly id: string
@@ -63,6 +74,26 @@ export type PackManifest = {
     /** Inclusive school-grade band. `[1, 3]` is grades one to three. */
     readonly grades: readonly [number, number]
   }
+  /**
+   * The youngest age the game's **hands** are written for. Guidance, never a
+   * gate.
+   *
+   * A floor and no ceiling — `8` means "eight and up", drawn as `8+`. There is
+   * deliberately no `maxAge`: every game's mathematics adapts upward without
+   * bound, so a range would promise a ceiling the product does not have.
+   *
+   * It is a claim about **motor and attention demand, not about arithmetic**.
+   * The maths adapts down to single-digit facts in every pack, so it is never
+   * the limiting factor; what a five-year-old cannot do is hold a precise
+   * timing window or steer two axes while computing. A parent reading `8+` on
+   * a five-year-old's screen is being told the game may be frustrating, and
+   * nothing in the host reads this field to lock, hide, dim or reorder a pack.
+   *
+   * Optional because a manifest written before this field existed is on disk
+   * today. Absent means unstated, which the catalogue draws as nothing at all
+   * — never as a guess.
+   */
+  readonly minAge?: number
   /** BCP-47 tags the pack renders. `en` is required. */
   readonly locales: readonly string[]
   readonly assets: { readonly files: number; readonly bytes: number }
@@ -230,6 +261,24 @@ export function parseManifest(input: unknown): ManifestResult {
     ) {
       fail("covers.grades must be an inclusive [low, high] band within 0–12")
     }
+  }
+
+  // Absent is allowed and means unstated. Present-but-wrong is not: `"8+"`,
+  // `[6, 10]` and `7.5` are the three shapes an author reaches for, and each
+  // would otherwise reach a parent's screen as `NaN+`, `6,10+` or `7.5+`.
+  const minAge = input["minAge"]
+  if (
+    minAge !== undefined &&
+    (typeof minAge !== "number" ||
+      !Number.isInteger(minAge) ||
+      minAge < MIN_AGE_FLOOR ||
+      minAge > MIN_AGE_CEILING)
+  ) {
+    fail(`minAge must be an integer in ${MIN_AGE_FLOOR}–${MIN_AGE_CEILING} when present`)
+  }
+  // There is no `maxAge` and there never will be: the label is "and up".
+  if (input["maxAge"] !== undefined || input["ageRange"] !== undefined) {
+    fail("there is no age ceiling in this schema — minAge is a floor, drawn as \"and up\"")
   }
 
   const locales = stringArray(input["locales"])


### PR DESCRIPTION
Twenty-seven cards said what a game teaches and nothing about whether a child can work it.

This adds an optional `minAge` to the pack manifest, sets it on all 27 games, and draws it in the catalogue's small print as `8+`.

## The scheme: a floor, and no ceiling

`8+`, never `6–10`. Every game's mathematics adapts upward without bound, so a range would print a ceiling the product does not have. The parser **rejects `maxAge` and `ageRange` by name** rather than ignoring them, and the fleet test refuses them in `pack.json` too — the next author to reach for a range gets told, not quietly overruled.

**Guidance, never a gate.** Nothing reads this field to lock, hide, dim, rest or reorder a pack. `surfaces.test.ts` asserts it against an 18-labelled pack: the row is not resting, and pressing it launches the game.

## The numbers, and why each one

Judged by **motor and attention demand, never by the arithmetic** — every pack's maths adapts down to single-digit facts, so it is never the limiting factor. Nine agents read the input path, timing constants, target sizes and threat model of three games each; nothing was played. The rubric:

| | what the hands must do |
| --- | --- |
| 5 | discrete taps on large targets, self-paced, nothing moving against the child |
| 6 | one forgiving continuous gesture, or a soft budget, no dual task |
| 7 | steer or survive while a question is live, or a 200–400 ms window, or small targets |
| 8 | two simultaneous continuous axes, or sustained dodge-plus-compute, or a window under 250 ms |
| 9 | all of it: precision timing **and** dual task **and** fine numeral discrimination |

| game | age | the motor demand that sets it |
| --- | --- | --- |
| `colossus` | 5 | Select-then-confirm tapping on 56 px slabs (`render/layout.ts:43`) and a ≥58 px STRIKE pill; one `pointerdown` listener in the whole pack, no timer, no lives. |
| `forge` | 5 | Tap 1-of-4 ingots sized never below ~62 px (`game/layout.ts:154, 205-211`); no per-question clock exists anywhere in `src/`. |
| `merge-idle` | 5 | The answer act is a tap on a ~50 px DOM chip (`ui/hud.ts:113-118`); zero hits for `timer|deadline|expire` across the pack, and `TapGuard` is explicitly a state machine, not a timeout. |
| `siege` | 5 | Four `clamp(54px,…,100px)` buttons (`ui/styles.css:459`), no answer deadline; the only clock is a 7 s intermission the child can ignore. |
| `street` | 5 | Taps on rects floored at `MIN_TOUCH = 44` (`render/scene.ts:132,177`); `waits(phase)` is true for both input phases and `advance` returns early — elapsed time cannot accumulate while thinking. |
| `balance` | 6 | Drag a 34 px-floor weight onto a pan (`layout.ts:97`); the 260 ms in `game.ts:858` is a tap-vs-drag discriminator, not a correctness window. Nothing moves against the child. |
| `coil` | 6 | Discrete taps, fully untimed — but adjacent links can be 15 px apart (`render/layout.ts:148`) and are told apart by shape, plus a repeat-tap-same-target gesture. |
| `foundry` | 6 | Motorically trivial (the screen is two half-screen pedals, `mount.ts:365`) but not self-paced: `slapPeriodFor()` × `SLAP_COUNT = 3` gives 3.15–9.6 s per fall (`game/bout.ts:49,119-123`). |
| `merge` | 6 | One-axis drag with a landing ghost; the answering tap is protected (the well rises on drop count, `game.ts:775-777`, not a clock). Docked from 5 for a 9 s `RES_LIMIT` and an 18 px worst-case cell (`layout.ts:200`). |
| `trebuchet` | 6 | Drag a dial at 0.42 gain with snap-to-metre and `+`/`−` buttons as a discrete fallback; `ramAdvances(phase)` proves the ram moves on shots, not seconds (`sim/world.ts:285-296`). |
| `truedraw` | 6 | One whole-canvas tap — `press` ignores coordinates (`mount.ts:200-206`). The load is response inhibition against a 6 s-plus window (`game/cadence.ts:38-44`), not motor skill. |
| `counterweight` | 7 | A multi-tap plan of up to ~25 blows executed at a metered ≥220 ms cadence (`RESONANCE_MS = 220`, `game/strain.ts:38`) inside a clock falling 13 s → 7.6 s (`game/bout.ts:67,91`); one reflexive extra tap shears the beam. |
| `mosaic` | 7 | The paddle must stay under a live, losable ball while the question is up — `cam.timeScaleTarget = 0.12` slows it 8× but `stepForge` runs in real time (`game/forge.ts:110`), and there are no lives (`game/sim.ts:642-649`). |
| `rhythm` | 7 | The field is deliberately cleared for the answer (`core.ts:457`), but the tap must still land within ±205 ms of a moving downbeat (`game/judge.ts:20-25`). |
| `runner` | 7 | Swipe-commit a lane under a 3.1 s deadline while running (`game/pacing.ts:96,143`), needing 42% of the window already spent in-lane; mitigated by very large numerals and a hazard-free reading corridor. |
| `skyledger` | 7 | Fine rotary arc-drag on a ~29 px radial band (`render/astrolabe.ts:59-66`, `render/sky.ts:75-77`), one detent per digit, while several stars fall on 9–21 s deadlines (`game/game.ts:72-74,340`). |
| `slice` | 7 | Swipe strokes across 28 px-floor lanterns that drift and bob (`render/hud.ts:238-240`) with bombs in play; held at 7 because the answering moment is genuinely protected (`director.quiet`, `mount.ts:1320`). |
| `arena` | 8 | Sustained floating-joystick evasion under live predation, and **steering is the answering act** — you pilot into the sphere (`sim/world.ts:1718-1721`); the resonance goes inert but the spheres keep drifting. |
| `beam` | 8 | Lane defence and a divisibility judgement are live at once: automata keep descending during the sum, each floor breach costs an anchor, and the run ends at zero (`mount.ts:699-717`, `sim/director.ts:71-72`). |
| `claim` | 8 | Qix-style continuous steering under pursuit while estimating what fraction of the plane you have enclosed — the fraction work happens mid-cut with hunters loose (`game/index.ts:645-648`). |
| `guilty` | 8 | Hold a laterally-swinging ~42 px husk under a continuously-steered ship and stay still for 0.11 s to fire (`game/ship.ts:69-76`, `core/config.ts:28`), while the formation descends and, from wave 10, shoots back. |
| `horde` | 8 | Sustained two-axis evasion, and the answer is a steering act into a 40 px orb orbiting at 0.42 rad/s (`game/game.ts:1459-1474`); 0.15× bullet-time only partly protects it, and a wrong orb spawns nine enemies on top of you. |
| `lattice` | 8 | Literal twin-stick: two independent continuous 2D sticks tracked per-`pointerId` (`mount.ts:345-378`). No threat and no fail state, but two thumbs on two axes is the barrier. |
| `serpent` | 8 | Free-aim piloting plus dodge plus compute against a **~6 px bite core** and 11–13 px numerals (`game/tuning.ts:50-58`, `render/scene.ts:185,327`), with no inert moment anywhere. |
| `polarity` | 9 | Layered: a 190 ms tap-vs-drag flip window (`input/input.ts:24-25`), sign-matching under fire, a 1.15-unit danmaku hitbox, and a weaving 5.4-unit answer orb that must be reached while the shmup runs. |
| `pulse` | 9 | Sub-100 ms judgement (`game/judge.ts:15-19`) between candidates only 119–238 ms apart, while a live drum groove keeps costing health, with ~7 px stacked fraction numerals (`render/scene.ts:823-828`). |
| `stack` | 9 | A ~70 ms perfect window at floor 0 falling to ~13 ms (`game/tuning.ts:22-24,37-39`), and the same tap must be true twice — correct value **and** aligned (`game/sim.ts:328`). |

**Where this exceeds `ADAPTATION_AUDIT_2026-07.md`.** That audit found ten games fail a five-year-old on motor demand: `beam`, `claim`, `counterweight`, `mosaic`, `polarity`, `rhythm`, `serpent`, `slice`, `trebuchet`, `truedraw`. Every one of those is ≥6 here, so nothing contradicts it. But six more are also above 5 — `arena`, `guilty`, `horde`, `lattice` at 8 and `pulse`, `stack` at 9 — and that is deliberate. The audit's question was *"could a controller relax this?"*, not *"can a five-year-old do it today?"*; it is scoped to adaptivity and its own Honest Limits says nothing was in front of a child. A 13 ms perfect window and a two-stick control scheme are not five-year-old motor tasks under any reading of that document.

## How it is surfaced

Beside the grade band in the card's small print, in the same type as the version and the "Play" word — `numeral text-ink-muted text-[0.6875rem]`, no border, no fill, no colour. Not a badge: a loud `8+` on a five-year-old's screen reads as a refusal.

It is **not** on the title line, which is where it was asked for, and the reason is measured rather than aesthetic. The grid column's 10.5rem is documented as sized to exactly the 142 px `COUNTERWEIGHT` needs at 15px, with zero slack; any sibling on that line takes width from the title and brings back "COUNTERPOI / SE", which has reached a screen once already.

## Localisation cost

One template: `strings.catalog.minAge: "{{age}}+"` → **five translations** when the locale bundles land in PR-1.6. It is a template rather than a bare `` `${age}+` `` in the JSX because `+` is a suffix in English and is not universally one — it leads in Arabic ordering, several locales set it off with a space, and a locale that wants "from 8" or "8 years and up" can only say so if the whole phrase is theirs. A test asserts the `{{age}}` slot survives, so a translation cannot silently render a bare `+`.

## Two things factored out

Both are places a field goes missing with every type still correct:

- **`packs/authoring.mjs`** — the `pack.json` → `manifest.json` projection, lifted out of `build.mjs`. It is the only pure function in that script and the only one whose failure is silent: a dropped field still produces 27 schema-valid manifests and one blank line of small print. Now covered directly.
- **`library.ts`'s `cardFacts()`** — `libraryStore` and `useHost` each held a hand-written copy of the same field list. They must agree forever, and a field added to one gives a card that draws it after an install and loses it on the next launch.

## Every test, with the fix deleted

Fourteen mutations, each reverted after. Exact failures:

| # | fix removed | test that failed | message |
| --- | --- | --- | --- |
| 1 | `parseManifest`'s `minAge` validation | `the three shapes an author reaches for instead of an integer are all refused` | `expected this manifest to be rejected` / `true !== false` |
| 2 | same | `minAge is bounded on both sides, because a label outside them means nothing` | `expected this manifest to be rejected` / `true !== false` |
| 3 | the `maxAge`/`ageRange` rejection | `there is no age ceiling in this schema, and asking for one is an error` | `expected this manifest to be rejected` / `true !== false` |
| 4 | `minAge` deleted from `games/coil/pack.json` | `every shipped game states the youngest age its hands are written for` | ``games with no "minAge" in pack.json — add one, justified by motor and attention demand, never by the arithmetic (the maths adapts down to single digits in every pack)`` |
| 5 | same | `every stated minimum age is an integer inside the schema's bounds` | `coil: minAge is undefined, not a number` |
| 6 | `minAge` removed from `authoring.mjs`'s carried list | `the builder carries a stated minimum age onto the manifest a device reads` | `arena: the builder lost its minAge` |
| 7 | `authoring.mjs` emits an unstated age instead of omitting it | `the builder omits an unstated age rather than writing it as null` | `an unstated age was written into the manifest` |
| 8 | every `pack.json` flattened to `minAge: 5` | `the fleet spreads across the ladder rather than labelling everything the same` | `every game claims one of 1 ages — that is not guidance` |
| 9 | `surfaces.ts` stops putting `minAge` on the pack row | `a pack's minimum age reaches the card, and an unstated one stays unstated` | `Expected values to be strictly equal: null !== 8` |
| 10 | `resting` made to depend on `minAge` (i.e. the label becomes a gate) | `a minimum age is guidance and never a gate` | `an age label must not rest a game` / `true !== false` |
| 11 | `cardFacts` stops carrying `minAge` | `the card's facts carry the minimum age, and carry its absence as absence` | `Expected values to be strictly deep-equal` (`minAge: 8` missing) |
| 12 | `cardFacts` assigns instead of spreading | same | `an unstated age was stored as undefined` / `true !== false` |
| 13 | `minAgeLabel` prints a range | `a minimum age is drawn as a floor and never as a range` | `Expected values to be strictly equal: '5–9' !== '5+'` |
| 14 | `minAgeLabel` stops rejecting nonsense | `an unstated age is drawn as nothing, never as a guess or a placeholder` | `0 reached a card` / `'0+' !== null` |
| 15 | `strings.catalog.minAge` loses its `{{age}}` slot | `a minimum age is drawn as a floor and never as a range` + `the age template keeps its slot…` | `Expected values to be strictly equal: '+' !== '5+'` |
| 16 | `minAge` deleted from `games/stack/pack.json` | `every shipped game states a minimum age, and the catalogue can label it` | `games whose minAge the catalogue cannot draw` |

**Honest gap:** the JSX that renders the label cannot be tested in this runner — Node's type stripper does not read JSX and there is no DOM, which is why the label logic was moved into `catalog/labels.ts`. That boundary is the same one `surfaces.test.ts` already documents.

## Verified

- `packs/sdk`: 66 tests, `dynawalla-app`: 246 tests — **both green 5× in a row**.
- `tsc` clean in both packages (all three app projects), `eslint` clean.
- `npm run packs colossus` end-to-end: builds, generates the manifest, and `dw-pack check` prints `min age      5+`.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
