### PR TITLE
dynawalla: a slow, correct child climbs — slowly

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -12,9 +12,12 @@ import assert from "node:assert/strict"
 import {
   cadenceFor,
   choicesFor,
+  climbRungs,
   climbWithinMs,
   createItemService,
+  isQuick,
   isSubtraction,
+  itemPace,
   ladder,
 } from "./items.ts"
 import type { PromptSlot } from "./curriculum.ts"
@@ -641,10 +644,16 @@ test("a latency that is not a measurement promotes and says so", () => {
   )
 })
 
-test("a correct answer from the slow tail of its own item holds the rung, and never costs one", () => {
-  // The intent the constant was reaching for, kept: a child who took far longer
-  // than the ninth of ten children on this question does not climb — and does
-  // not fall either. Being slow is not being wrong.
+test("a correct answer from the slow tail never costs a rung, never jumps one, and enough of them promote", () => {
+  // This test used to be called "…holds the rung", and holding is the thing the
+  // founder ruled out: "if the person is 100% right but slow, we could still
+  // slowly move up." So the claim is now three-part, and the middle part is
+  // what stops "slowly" from quietly becoming "immediately".
+  //
+  // Note what the old version could not tell apart: a slow answer worth zero
+  // and a slow answer worth a twentieth of a rung both leave `position()`
+  // where it was after one answer. Only the third part below separates them,
+  // and only the third part fails against the rule this replaced.
   const rungs = ladder().filter((rung) => rung.node.id === "dw.add.facts.add-within-ten")
   assert.ok(rungs.length > 1)
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
@@ -668,7 +677,26 @@ test("a correct answer from the slow tail of its own item holds the rung, and ne
     // Five minutes on a single-digit fact. Nobody's p90.
     latencyMs: 300_000,
   })
-  assert.equal(service.position(), climbed, "a slow correct answer moved the ladder")
+  assert.equal(service.position(), climbed, "one slow answer jumped a whole rung")
+
+  // And now the same answer, again and again. A child working at this pace all
+  // afternoon is still working; a ladder that never moves for them is the
+  // product telling them they are not.
+  for (let i = 0; i < 60; i++) {
+    const next = service.next({ packId: "dynawalla.siege" })
+    assert.ok(next)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: next.id,
+      response: service.reveal(next.id),
+      latencyMs: 300_000,
+    })
+  }
+  assert.ok(
+    service.position() > climbed,
+    `sixty correct answers in a row left the child on rung ${String(service.position())}, ` +
+      `where one answer had already put them — slow and right is still right`,
+  )
 })
 
 test("no run of wrong answers can push a child below the easiest rung the curriculum has", () => {
@@ -688,9 +716,14 @@ test("no run of wrong answers can push a child below the easiest rung the curric
   assert.ok(service.next({ packId: "dynawalla.siege" }), "the floor is not serving questions")
 })
 
-test("climbing and stepping down are one rung each and meet in the middle", () => {
+test("an answer at the published median is worth exactly one rung, and a miss costs exactly one", () => {
   // The descent rule is unchanged and is founder direction; what is checked here
-  // is that it composes with the new climb rule rather than fighting it.
+  // is that it composes with the climb rule rather than fighting it.
+  //
+  // Six answers, each taking exactly as long as the table says that class takes.
+  // Not quick, not slow: expected. Expected is one rung — the middle regime —
+  // and the fact that `high` is exactly 6 rather than something larger is the
+  // assertion that the speedcuber bonus does not leak into ordinary pace.
   const rungs = ladder()
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
   for (let i = 0; i < 6; i++) {
@@ -716,4 +749,399 @@ test("climbing and stepping down are one rung each and meet in the middle", () =
     })
   }
   assert.equal(service.position(), high - 3, "three misses did not cost exactly three rungs")
+})
+
+// ---------------------------------------------------------------------------
+// The three regimes.
+//
+// Founder ruling, verbatim: "if it takes a long time to get the right answer
+// then we should tend to stay at the same level .. if the person is 100% right
+// but slow, we could still slowly move up. But, a speedcuber should move up very
+// fast." Holding was therefore wrong, and this block is that sentence as three
+// tests plus the two things the mechanism must not break — a guesser, and the
+// floor.
+//
+// The published p90 column, read off `docs/EXPERIENCE_DESIGN.md` by hand like
+// the p50 column above. Nothing below calls `itemPace` or `climbRungs` to decide
+// what it expects.
+//
+// | class                     | p50    | p90  |
+// |---------------------------|--------|------|
+// | single-digit fact         |  2.8 s |  6 s |
+// | two-digit with regrouping |    6 s | 14 s |
+// | three-digit               |   11 s | 27 s |
+// | the `5,001 − 2,798` class |   16 s | 40 s |
+const P90_WIDEST_PUBLISHED_MS = 40_000
+
+/**
+ * A latency that is in the slow tail of *every* rung that ships, by hand.
+ *
+ * The widest published p90 is 40 s. The most generous median any node in the
+ * graph declares is `dw.div.*` at 18 s, and a declared median widens to 45 s.
+ * A minute is past both, so one minute per question is the slow tail of every
+ * question in the product — including `0 + 3` — without this test re-deriving
+ * the window from the code under test.
+ */
+const A_FULL_MINUTE_MS = 60_000
+
+/**
+ * A latency that is quick for every rung that ships, by hand.
+ *
+ * The narrowest published median is 2.8 s and a declared median can only widen
+ * it, so the quickest any item's quick mark can be is a fraction of 2.8 s. Two
+ * hundred milliseconds is under any fraction of it that a human clock could
+ * report — a child who has the fact and does not compute it.
+ */
+const A_SPEEDCUBER_MS = 200
+
+/** Answers correctly at a fixed pace until the top, or until it gives up. */
+function runChild(latencyMs: number, limit: number) {
+  const rungs = ladder()
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  const top = rungs.length - 1
+  let answers = 0
+  while (answers < limit && service.position() < top) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs,
+    })
+    answers += 1
+  }
+  return { rung: service.position(), top, answers, elapsedMs: answers * latencyMs }
+}
+
+test("regime 2: a child who is right every single time and slow every single time still climbs", () => {
+  // THE test. Before this rule, a correct answer past the item's p90 held the
+  // rung, so this child — one minute a question, never once wrong — sat on rung
+  // 0 for as long as they played and the product had nothing to say about it.
+  // "if the person is 100% right but slow, we could still slowly move up."
+  const slow = runChild(A_FULL_MINUTE_MS, 400)
+  assert.ok(
+    slow.rung > 0,
+    `four hundred correct answers in a row left the child on rung ${String(slow.rung)} of ` +
+      `${String(slow.top)}. Being unhurried is not being wrong, and this is the child the ` +
+      `product exists for`,
+  )
+  // And they get all the way there, given the afternoon.
+  assert.equal(
+    slow.rung,
+    slow.top,
+    `the slow child stalled at rung ${String(slow.rung)} of ${String(slow.top)} after ` +
+      `${String(slow.answers)} correct answers`,
+  )
+})
+
+test("regime 1 beats regime 2: the same ladder, quick, takes far fewer answers than slow", () => {
+  // "slowly" is the load-bearing word in the ruling — slow-and-correct must
+  // climb, and must not climb at the pace of a child who has the fact. A rule
+  // that promoted everyone equally would pass the test above and fail the
+  // product.
+  const quick = runChild(A_SPEEDCUBER_MS, 400)
+  const slow = runChild(A_FULL_MINUTE_MS, 400)
+  assert.equal(quick.rung, quick.top)
+  assert.equal(slow.rung, slow.top)
+  assert.ok(
+    quick.answers * 4 < slow.answers,
+    `the speedcuber took ${String(quick.answers)} answers to the top and the slow child took ` +
+      `${String(slow.answers)} — those are not different speeds`,
+  )
+})
+
+test("regime 1: a speedcuber does not walk every rung", () => {
+  // "a speedcuber should move up very fast." Two-sided: more than one rung per
+  // answer, and not an unbounded number of them — the cap is the table's own
+  // p90/p50 spread, 40/16 = 2.5 at its widest row.
+  const quick = runChild(A_SPEEDCUBER_MS, 400)
+  assert.equal(quick.rung, quick.top)
+  assert.ok(
+    quick.answers < quick.top,
+    `${String(quick.top)} rungs took ${String(quick.answers)} answers at ${String(
+      A_SPEEDCUBER_MS,
+    )} ms each — that is one rung per answer or worse, and a child who answers in a fifth of a ` +
+      `second is not being told anything by this ladder`,
+  )
+  assert.ok(
+    quick.answers >= Math.ceil(quick.top / 2.5),
+    `${String(quick.top)} rungs in ${String(quick.answers)} answers is more than 2.5 rungs an ` +
+      `answer, and 2.5 is the widest p90/p50 the cadence table publishes`,
+  )
+})
+
+/** The rate for a single answer, with no run of quick answers behind it. */
+function rateAt(digits: number, fluencyP50Ms: number | undefined, latencyMs: number): number {
+  return climbRungs({ digits, fluencyP50Ms, latencyMs })
+}
+
+/** The rate for a child who has already been quick often enough to earn it. */
+function sustainedRateAt(
+  digits: number,
+  fluencyP50Ms: number | undefined,
+  latencyMs: number,
+): number {
+  return climbRungs({ digits, fluencyP50Ms, latencyMs, quickRun: 99 })
+}
+
+test("regime 3: the climb rate decays with lateness, and is never zero", () => {
+  // Read against the published single-digit row — p50 2.8 s, p90 6 s — on a node
+  // that declares no fluency target of its own, so the numbers below are the
+  // table's and nothing else's.
+  assert.equal(rateAt(1, undefined, 6_000), 1, "the p90 itself is a whole rung")
+  assert.equal(rateAt(1, undefined, 12_000), 0.5, "twice the p90 is half a rung")
+  assert.equal(rateAt(1, undefined, 60_000), 0.1, "ten times the p90 is a tenth of a rung")
+
+  // A child at ten times the expected time is not demonstrating what a child at
+  // one and a half times is, and a step function would say they were.
+  let previous = Infinity
+  for (const late of [6_001, 9_000, 12_000, 24_000, 60_000, 600_000]) {
+    const rate = rateAt(1, undefined, late)
+    assert.ok(rate < previous, `${String(late)} ms was not worth less than the answer before it`)
+    assert.ok(rate > 0, `${String(late)} ms was worth nothing at all — that is a hold`)
+    previous = rate
+  }
+})
+
+test("the expected band is one rung, and its edges are the item's own", () => {
+  // The middle regime, at both of its boundaries, in published numbers. The
+  // quick mark of a single-digit fact is 2.8 s compressed by the table's widest
+  // spread — 2,800 × 2/5 = 1,120 ms — and its tail is the published p90.
+  assert.equal(sustainedRateAt(1, undefined, 1_120), 1)
+  assert.equal(sustainedRateAt(1, undefined, 2_800), 1)
+  assert.equal(sustainedRateAt(1, undefined, 6_000), 1)
+  assert.ok(sustainedRateAt(1, undefined, 1_119) > 1, "a millisecond inside the mark is not quick")
+  assert.ok(sustainedRateAt(1, undefined, 6_001) < 1, "a millisecond into the tail is a whole rung")
+
+  // And the run is counted at the same mark that pays, which is the seam a
+  // rewrite would most easily get wrong: an answer that counts toward the run
+  // but is not worth the bonus, or the reverse, would let a child be quick
+  // forever and never earn it.
+  assert.equal(isQuick(1, undefined, 1_119), true)
+  assert.equal(isQuick(1, undefined, 1_120), false)
+  assert.equal(isQuick(1, undefined, 2_800), false, "the published median is not quick")
+  assert.equal(isQuick(1, undefined, Number.NaN), false, "a broken clock is not evidence of speed")
+
+  // Every rung on the shipped ladder has the same shape: quick < median < tail,
+  // and answering at the pace the table publishes for that width is never a
+  // demotion-by-slowness — it is worth a whole rung or better, on every rung,
+  // which is the invariant the constant this replaced violated on half of them.
+  for (const rung of ladder()) {
+    const service = createItemService({ profileId: "p1", record: noRecord, rungs: [rung] })
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    const width = widthOf(item.operands)
+    const declared = rung.node.fluencyTarget?.p50Ms
+    const pace = itemPace(width, declared)
+    assert.ok(pace, `${rung.node.id} has no pace at all`)
+    assert.ok(
+      pace.quickMs < pace.medianMs && pace.medianMs < pace.tailMs,
+      `${rung.node.id} paces at ${JSON.stringify(pace)}`,
+    )
+    assert.ok(
+      rateAt(width, declared, publishedP50Ms(width)) >= 1,
+      `${rung.node.id} draws ${item.prompt} and treats ${String(publishedP50Ms(width))} ms — ` +
+        `the published median for a ${String(width)}-digit item — as less than a whole rung`,
+    )
+  }
+})
+
+test("a declared fluency target only ever widens the pace, at both ends", () => {
+  // The pre-existing guard, extended to the quick mark. `dw.mul.*` declares a
+  // 15 s median and `dw.div.*` an 18 s one: read through the column model alone,
+  // a two-digit multiplication would be "slow" at 14 s and "quick" at 2.4 s. A
+  // node's own data must be able to move both marks outward and neither inward.
+  for (const node of allNodes) {
+    const declared = node.fluencyTarget?.p50Ms
+    if (declared === undefined) continue
+    for (let width = 1; width <= 6; width++) {
+      const table = itemPace(width, undefined)
+      const paced = itemPace(width, declared)
+      assert.ok(paced && table, `${node.id} at ${String(width)} digits has no pace`)
+      assert.ok(
+        paced.quickMs >= table.quickMs,
+        `${node.id} declares ${String(declared)} ms and that NARROWED the quick mark at ` +
+          `${String(width)} digits, from ${String(table.quickMs)} to ${String(paced.quickMs)}`,
+      )
+      assert.ok(paced.tailMs >= table.tailMs, `${node.id} narrowed the tail at ${String(width)}`)
+      // And a child answering in exactly the time the node itself declares is
+      // never in the tail: a node's own median cannot make its own items slow.
+      assert.ok(
+        rateAt(width, declared, declared) >= 1,
+        `${node.id} declares ${String(declared)} ms and then treats an answer taking exactly ` +
+          `that long as slow, at ${String(width)} digits`,
+      )
+      // Both marks, stated as what a child experiences rather than as one
+      // number being no smaller than another — which two marks derived from the
+      // same expression will always satisfy, whether or not the declared median
+      // is read at all. The spread is the table's widest published p90/p50,
+      // 40/16, so two fifths of a declared median is as quick as its own tail is
+      // slow.
+      // Annotated because `assert.ok` is an assertion signature, and a `const`
+      // inferred after one in the same block trips TS7022.
+      const asQuickAsDeclaredAllows: number = Math.floor((declared * 2) / 5) - 1
+      assert.ok(
+        sustainedRateAt(width, declared, asQuickAsDeclaredAllows) > 1,
+        `${node.id} declares a ${String(declared)} ms median, and an answer in ` +
+          `${String(asQuickAsDeclaredAllows)} ms — under two fifths of it — is not quick to it ` +
+          `at ${String(width)} digits. A node's own data cannot make its own items harder to be ` +
+          `quick at than the table's`,
+      )
+      assert.ok(
+        rateAt(width, declared, Math.floor((declared * 5) / 2)) >= 1,
+        `${node.id} declares a ${String(declared)} ms median and puts two and a half times it ` +
+          `in the slow tail at ${String(width)} digits`,
+      )
+    }
+  }
+})
+
+/**
+ * A child touching one of the four slabs at random, instantly, for a whole
+ * session. Seeded, so the same guesser guesses the same way on every run.
+ */
+function guessSession(seed0: number, answers: number) {
+  const rungs = ladder()
+  const service = createItemService({ profileId: `guesser-${String(seed0)}`, record: noRecord, rungs })
+  let seed = seed0
+  // The high bits: the low bits of a linear congruential stream have a period
+  // of four, which for a four-slab grid is not a guesser, it is a metronome.
+  const pick = (n: number) => {
+    seed = (seed * 1_103_515_245 + 12_345) & 0x7fff_ffff
+    return Math.floor(seed / 65_536) % n
+  }
+  let highest = 0
+  let lucky = 0
+  let sum = 0
+  for (let i = 0; i < answers; i++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    const choices = item.choices ?? []
+    assert.equal(choices.length, 4, "the grid is not four slabs and the arithmetic is wrong")
+    const guess = choices[pick(choices.length)]
+    assert.ok(guess)
+    if (guess.text === service.reveal(item.id)) lucky += 1
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      // Instantly. A guesser is quick by definition — they are not computing.
+      response: guess.id,
+      latencyMs: 1,
+    })
+    highest = Math.max(highest, service.position())
+    sum += service.position()
+  }
+  return { top: rungs.length - 1, finished: service.position(), highest, lucky, mean: sum / answers }
+}
+
+test("a guesser does not climb, however fast the guessing is", () => {
+  // A closed list is four slabs, so a child touching one at random is right one
+  // time in four and wrong three. A miss costs a whole rung, so the only way
+  // guessing pays is if a lucky tap can be worth more than a rung — which is
+  // exactly what the speedcuber's rate is, and exactly why it is not handed out
+  // for one quick answer. See `QUICK_RUN_FOR_BONUS`: with no run required, this
+  // guesser reached rung 26 of 35.
+  //
+  // Six sessions, six hundred questions each. One session is a coin-toss story;
+  // the drift is the claim.
+  let worstFinish = 0
+  let worstReach = 0
+  let top = 0
+  for (const seed of [13, 7_932, 15_851, 23_770, 31_689, 39_608]) {
+    const run = guessSession(seed, 600)
+    top = run.top
+    assert.ok(run.lucky > 0, "the guesser never once guessed right, so this proves nothing")
+    assert.ok(
+      run.mean < 2,
+      `a guesser spent 600 questions an average of ${run.mean.toFixed(2)} rungs up the ladder`,
+    )
+    worstFinish = Math.max(worstFinish, run.finished)
+    worstReach = Math.max(worstReach, run.highest)
+  }
+  assert.ok(
+    worstFinish <= top / 8,
+    `guessing at random finished as high as rung ${String(worstFinish)} of ${String(top)}`,
+  )
+  assert.ok(
+    worstReach <= top / 4,
+    `a guesser reached rung ${String(worstReach)} of ${String(top)} along the way — luck is ` +
+      `buying real progress, and the speedcuber's rate is what a guesser is spending`,
+  )
+})
+
+test("the tail cannot underflow the floor or overflow the top", () => {
+  // The clamps, against the fractional carry specifically: a child sitting on a
+  // fraction of a rung above the floor is still not allowed below it, and a
+  // child at the top does not bank credit they could spend on a miss.
+  const rungs = ladder()
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  const item = service.next({ packId: "dynawalla.siege" })
+  assert.ok(item)
+  // One slow-and-right answer: some fraction of a rung, and still rung 0.
+  service.judge({
+    packId: "dynawalla.siege",
+    itemId: item.id,
+    response: service.reveal(item.id),
+    latencyMs: A_FULL_MINUTE_MS,
+  })
+  assert.equal(service.position(), 0)
+  const missed = service.next({ packId: "dynawalla.siege" })
+  assert.ok(missed)
+  service.judge({
+    packId: "dynawalla.siege",
+    itemId: missed.id,
+    response: "definitely wrong",
+    latencyMs: 1_000,
+  })
+  assert.equal(service.position(), 0, "a fraction of a rung above the floor fell through it")
+
+  // At the top: quick answers pile up, then one miss must cost exactly one rung
+  // rather than being absorbed by banked credit.
+  const top = rungs.length - 1
+  for (let i = 0; i < 200 && service.position() < top; i++) {
+    const next = service.next({ packId: "dynawalla.siege" })
+    assert.ok(next)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: next.id,
+      response: service.reveal(next.id),
+      latencyMs: A_SPEEDCUBER_MS,
+    })
+  }
+  assert.equal(service.position(), top)
+  for (let i = 0; i < 5; i++) {
+    const next = service.next({ packId: "dynawalla.siege" })
+    assert.ok(next)
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: next.id,
+      response: service.reveal(next.id),
+      latencyMs: A_SPEEDCUBER_MS,
+    })
+  }
+  const missedAtTop = service.next({ packId: "dynawalla.siege" })
+  assert.ok(missedAtTop)
+  service.judge({
+    packId: "dynawalla.siege",
+    itemId: missedAtTop.id,
+    response: "definitely wrong",
+    latencyMs: 1_000,
+  })
+  assert.equal(
+    service.position(),
+    top - 1,
+    "five quick answers at the top banked credit that a miss then paid for",
+  )
+})
+
+test("a latency past what the table has a class for is still classified, never unbounded", () => {
+  // Six digits is off the end of the published table, and the fitted line is
+  // what says how long it should take. What must not happen is a wide item
+  // becoming unclassifiable and every answer on it — including a guessed one —
+  // being worth a whole rung by default.
+  const wide = itemPace(6, undefined)
+  assert.ok(wide, "a six-digit item has no pace, so the fitted line stopped fitting")
+  assert.ok(wide.tailMs > P90_WIDEST_PUBLISHED_MS, "a six-digit item is not slower than a 4-digit")
+  assert.ok(rateAt(6, undefined, 600_000) < 0.2, "ten minutes on one question is not a rung")
 })

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -23,10 +23,10 @@
 // **What a rung is.** The curriculum ships one generator family so far
 // (`gen.arith.column-op`) bound to four active skills at four levels each. The
 // rungs are those bindings, sorted by the difficulty the node itself declares,
-// and the ladder walks them: a correct answer that was not from the slow tail of
-// *that item* climbs, a wrong one steps down. "Not slow for that item" is read
-// off the cadence table in `docs/EXPERIENCE_DESIGN.md` — see the `CADENCE_*`
-// note below, and what it says about the constant it replaced.
+// and the ladder walks them: a correct answer climbs, a wrong one steps down.
+// How *far* a correct answer climbs is how quick it was for *that item* — read
+// off the cadence table in `docs/EXPERIENCE_DESIGN.md`, never off a constant.
+// See `climbRungs` below for the three regimes and why none of them is a hold.
 // That is not the FSRS scheduler (ADR-0008) — it is the smallest honest
 // thing that makes a pack's stream get harder — and it is confined to this file
 // so replacing it does not touch the boundary.
@@ -110,8 +110,22 @@ const CADENCE_COLUMN_P90_PER_DIGIT_MS = 13_000
  * The table's widest p90/p50 spread, as a ratio so it multiplies exactly.
  *
  * 6/2.8, 14/6, 27/11 and 40/16 are 2.14, 2.33, 2.45 and 2.50. The largest is
- * taken, because every use of it below is "widen a declared median into a slow
- * tail" and a narrow guess there is the punitive direction.
+ * taken, because the first use of it below is "widen a declared median into a
+ * slow tail" and a narrow guess there is the punitive direction.
+ *
+ * It has three uses, and they are the same number on purpose:
+ *
+ *   * A declared `fluencyTarget.p50Ms` becomes a tail at `p50 × 5/2`.
+ *   * The **quick mark** of an item is its median compressed by the same
+ *     ratio, `p50 × 2/5` — the mirror image of the tail. An item's expected
+ *     band is therefore the stretch between them, and "quick" and "slow" are
+ *     the same distance from the middle rather than two independent opinions.
+ *   * The **most rungs one answer can be worth**, so an unbelievably small
+ *     latency cannot buy an unbounded climb. 5/2 is under three, and three is
+ *     the number of wrong slabs on a four-option grid, so a guesser's expected
+ *     move stays negative. Necessary and *not* sufficient — see
+ *     `QUICK_RUN_FOR_BONUS`, which is what actually keeps a guesser off the
+ *     ladder, and `items.test.ts`, which runs one.
  */
 const CADENCE_SPREAD_NUM = 5
 const CADENCE_SPREAD_DEN = 2
@@ -337,13 +351,13 @@ export function cadenceFor(digits: number): { p50Ms: number; p90Ms: number } | n
 }
 
 /**
- * How long an answer to *this* item may take and still climb the ladder — or
- * `null` when nothing about the item says.
+ * How long an answer to *this* item may take and still be worth a whole rung —
+ * or `null` when nothing about the item says.
  *
  * The item's own p90. A child at the p90 is not slow; a child at the p90 is the
- * ninth of ten children who answered it, and the tenth still keeps the rung they
- * are on. What the rule refuses to promote is a correct answer from the slow
- * tail *of that question*, which is the only thing "quick" ever meant.
+ * ninth of ten children who answered it, and the tenth climbs too, by the
+ * fraction `climbRungs` gives them. Nothing here is a ceiling on a child's
+ * progress; it is the width of the band worth exactly one rung.
  *
  * Two inputs, and the wider of them wins:
  *
@@ -364,13 +378,166 @@ export function cadenceFor(digits: number): { p50Ms: number; p90Ms: number } | n
  * to hold a child down.
  */
 export function climbWithinMs(digits: number, fluencyP50Ms: number | undefined): number | null {
+  return itemPace(digits, fluencyP50Ms)?.tailMs ?? null
+}
+
+/**
+ * The three landmarks on *this* item's clock, or `null` when it has none.
+ *
+ * `quickMs < medianMs < tailMs`, always, and every one of them is read off the
+ * item — the cadence table at the width the child saw, widened (never narrowed)
+ * by a `fluencyTarget.p50Ms` the node declares. There is no absolute number
+ * here and there must never be one: the whole defect this replaced was a single
+ * constant applied to every question in the product.
+ *
+ * The tail is the p90 of the class. The quick mark is the median compressed by
+ * the same ratio the tail stretches it by, so an item's "expected" band is
+ * symmetric about its own median in log terms rather than being two unrelated
+ * judgements.
+ */
+export function itemPace(
+  digits: number,
+  fluencyP50Ms: number | undefined,
+): { quickMs: number; medianMs: number; tailMs: number } | null {
   const table = cadenceFor(digits)
   const declared =
     fluencyP50Ms === undefined || !Number.isFinite(fluencyP50Ms) || fluencyP50Ms <= 0
       ? null
-      : Math.round((fluencyP50Ms * CADENCE_SPREAD_NUM) / CADENCE_SPREAD_DEN)
+      : fluencyP50Ms
   if (table === null && declared === null) return null
-  return Math.max(table?.p90Ms ?? 0, declared ?? 0)
+  const medianMs = Math.max(table?.p50Ms ?? 0, declared ?? 0)
+  const tailMs = Math.max(
+    table?.p90Ms ?? 0,
+    declared === null ? 0 : Math.round((declared * CADENCE_SPREAD_NUM) / CADENCE_SPREAD_DEN),
+  )
+  return {
+    quickMs: (medianMs * CADENCE_SPREAD_DEN) / CADENCE_SPREAD_NUM,
+    medianMs,
+    tailMs,
+  }
+}
+
+/**
+ * How many consecutive quick, correct answers earn the speedcuber's rate.
+ *
+ * Not a duration — the rule that everything be relative to the item's own
+ * expected time is about *times*, and this is a count of answers. It exists
+ * because being quick is the one signal a child can produce without knowing any
+ * mathematics: a random tap on a four-slab grid is instant, and one tap in four
+ * is right.
+ *
+ * The arithmetic. A guesser on a closed list of `CHOICE_COUNT` is right one
+ * time in four and wrong three, so their expected move per answer is
+ * `bonus/4 − 3/4`. At a bonus of one rung — the rule this replaced, which had
+ * no bonus at all — that is −0.5 a question and a guesser sits on the floor. At
+ * the full 2.5 for any single quick answer it is −0.09, which is not a drift,
+ * it is noise. That is not a hypothetical: the simulated guesser in
+ * `items.test.ts` reached **rung 26 of 35** the first time this rule was
+ * written without a run, having answered nothing correctly except by luck.
+ *
+ * Requiring a run of `n` costs a guesser about 4ⁿ questions per bonus. The
+ * number below was measured rather than reasoned: sixty seeded sessions of four
+ * hundred random taps each, against the shipped ladder, at every run length.
+ *
+ * | run | furthest a guesser got | where they finished |
+ * |-----|------------------------|---------------------|
+ * | 1   | 35 of 35 (the top)     | 25                  |
+ * | 3   | 22                     | 6                   |
+ * | 4   | 10                     | 3                   |
+ * | 5   | 11                     | 3                   |
+ * | 6   | 8                      | 3                   |
+ * | — the same guesser under the *old* rule, with no bonus at all: 8, and 3.    |
+ *
+ * Six is where a guesser stops being able to tell the difference: their whole
+ * trajectory is the one they had before the speedcuber existed. A child who
+ * actually is quick pays six questions for it once and then keeps it for as
+ * long as they keep being quick, which on a 36-rung ladder costs them about two
+ * answers out of seventeen.
+ *
+ * "Sustained fast-correct evidence" is the founder's phrase for this, and a run
+ * is the smallest honest reading of it. Anything but a quick correct answer — a
+ * miss, or a correct one at ordinary pace — resets the run to zero.
+ */
+const QUICK_RUN_FOR_BONUS = 6
+
+/**
+ * ## How far one correct answer climbs
+ *
+ * In rungs, and never zero. The founder's ruling, in his words:
+ *
+ * > "if it takes a long time to get the right answer then we should tend to
+ * > stay at the same level .. if the person is 100% right but slow, we could
+ * > still slowly move up. But, a speedcuber should move up very fast."
+ *
+ * Three regimes, each relative to the item's own clock (`itemPace`):
+ *
+ *   * **Quick** — under the quick mark. `quickMs / latencyMs` rungs, so a child
+ *     answering twice as fast as the mark takes two rungs at a time, capped at
+ *     the table's own spread — but only once `quickRun` says they have done it
+ *     `QUICK_RUN_FOR_BONUS` times running. A speedcuber does not walk every
+ *     rung; a lucky tap is not a speedcuber.
+ *   * **Expected** — between the quick mark and the tail. Exactly one rung.
+ *     This is the great majority of answers, and it is the pace the table was
+ *     measured at.
+ *   * **Tail** — past the item's p90. `tailMs / latencyMs` rungs: a fraction,
+ *     decaying as the answer gets later, and **positive at every latency**. Ten
+ *     slow-but-right answers still promote; the tenth of ten children is not
+ *     demonstrating what the first is, and they are not stuck either.
+ *
+ * The decay is what the ruling asks for and a step function is not. Holding a
+ * rung — which is what this rule did until the ruling — meant a child who is
+ * correct all afternoon and unhurried never moved, and that child is the one
+ * the product exists for. A flat fraction instead would have said a child at
+ * ten times the expected time is doing the same thing as one at one and a half,
+ * and they are not.
+ *
+ * Two ways to reach a plain one-rung climb by default, and the caller says so
+ * on the console for both: an item whose class is not knowable, and a latency
+ * that is not a measurement. Neither is ever a reason to hold a child down.
+ *
+ * **What a contaminated clock costs.** `judge` documents that some packs time
+ * from when a question was drawn rather than from when it became answerable,
+ * inflating every latency by a second or two. Read against the three regimes,
+ * that inflation can deny a genuinely quick child the speedcuber's rate — the
+ * quick mark of a single-digit fact is around a second, and a second of
+ * contamination is all of it. It cannot demote anybody: the middle regime is
+ * still a whole rung, and the tail is still positive. The cost of a bad clock
+ * is a slower climb, never a fall, and that is the direction it has to fail in.
+ *
+ * A wrong answer never reaches here. The descent is one rung, at any speed.
+ */
+export function climbRungs(input: {
+  /** Width of the widest operand as drawn. 0 when the prompt held no numerals. */
+  readonly digits: number
+  /** `fluencyTarget.p50Ms` from the node, when it declares one. */
+  readonly fluencyP50Ms?: number | undefined
+  readonly latencyMs: number
+  /**
+   * How many quick, correct answers came immediately before this one. Zero
+   * unless the caller is tracking a run, which the ladder is.
+   */
+  readonly quickRun?: number
+}): number {
+  const pace = itemPace(input.digits, input.fluencyP50Ms)
+  if (pace === null) return 1
+  const { latencyMs } = input
+  if (!Number.isFinite(latencyMs) || latencyMs < 0) return 1
+  if (latencyMs > pace.tailMs) return pace.tailMs / latencyMs
+  if (latencyMs >= pace.quickMs) return 1
+  if ((input.quickRun ?? 0) + 1 < QUICK_RUN_FOR_BONUS) return 1
+  return Math.min(CADENCE_SPREAD_NUM / CADENCE_SPREAD_DEN, pace.quickMs / latencyMs)
+}
+
+/** Whether an answer this quick counts toward the run, whatever it is worth. */
+export function isQuick(
+  digits: number,
+  fluencyP50Ms: number | undefined,
+  latencyMs: number,
+): boolean {
+  const pace = itemPace(digits, fluencyP50Ms)
+  if (pace === null) return false
+  if (!Number.isFinite(latencyMs) || latencyMs < 0) return false
+  return latencyMs < pace.quickMs
 }
 
 type Served = {
@@ -467,7 +634,24 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
   const ledger = new Map<string, Served>()
   const order: string[] = []
   const practised = new Set<string>()
-  let position = 0
+  /**
+   * Where the child is, in rungs, carried as a real number.
+   *
+   * The rung they are standing on is the whole part of it; the fraction is
+   * credit earned toward the next one. That fraction is the entire mechanism
+   * behind "correct but slow still climbs, slowly" — a tail answer is worth
+   * less than a rung, and enough of them are worth one. Carrying it as one
+   * number rather than as an integer plus a counter means the two directions
+   * cannot disagree: a step down is `− 1` whatever the fraction was, and
+   * `Math.floor(x − 1) === Math.floor(x) − 1` for every x, so a miss always
+   * costs exactly one rung and never one and a bit.
+   */
+  let progress = 0
+  /**
+   * Consecutive quick, correct answers. Reset by anything else — see
+   * `QUICK_RUN_FOR_BONUS` for why a single one earns nothing.
+   */
+  let quickRun = 0
   let sequence = 0
   /** A ladder with one rung answers every difficulty the same. Said once. */
   let toldAboutFlatLadder = false
@@ -489,40 +673,49 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
   }
 
   /**
-   * Whether a correct answer was quick enough for *this* item to climb.
+   * How far this correct answer climbs, with the two "we cannot tell" cases
+   * said out loud.
    *
-   * Everything that is not a clear "no" is a yes, and every yes-by-default says
-   * so on the console once per skill. Two ways to reach one:
+   * `climbRungs` already returns a whole rung for both of them — this is where
+   * they become a line on the console rather than a silent default:
    *
    *   * The item's class is not knowable — no numerals in the prompt and no
    *     `fluencyTarget` on the node. A future family will hit this the day it
    *     lands, and it must arrive as a line in the log rather than as a child
-   *     who answers correctly all afternoon and never moves.
-   *   * The latency is not a measurement. `NaN <= anything` is `false`, so a
+   *     whose rate is being guessed at.
+   *   * The latency is not a measurement. Arithmetic on `NaN` is `NaN`, so a
    *     pack reporting a bad clock would otherwise pin a child to the bottom of
    *     the ladder in total silence — the exact shape of this bug, one layer
    *     down.
    */
-  const climbs = (served: Served, latencyMs: number): boolean => {
-    const within = climbWithinMs(served.digits, served.rung.node.fluencyTarget?.p50Ms)
-    if (within === null) {
+  const climbFor = (served: Served, latencyMs: number): number => {
+    const declared = served.rung.node.fluencyTarget?.p50Ms
+    const gained = climbRungs({
+      digits: served.digits,
+      fluencyP50Ms: declared,
+      latencyMs,
+      quickRun,
+    })
+    // Counted after it is spent, so the sixth quick answer in a row is the
+    // first one that pays. A correct answer at ordinary pace ends the run —
+    // being quick six times running is the claim, not being right six times.
+    quickRun = isQuick(served.digits, declared, latencyMs) ? quickRun + 1 : 0
+    if (itemPace(served.digits, declared) === null) {
       sayOnce(
         served.rung.node.id,
         `[packs] ${served.rung.node.id} draws a prompt with no numerals in it and declares no ` +
           `fluencyTarget, so how long it should take is unknown — every correct answer on it ` +
-          `climbs. Give the node a fluencyTarget.p50Ms to pace it.`,
+          `climbs one rung. Give the node a fluencyTarget.p50Ms to pace it.`,
       )
-      return true
-    }
-    if (!Number.isFinite(latencyMs) || latencyMs < 0) {
+    } else if (!Number.isFinite(latencyMs) || latencyMs < 0) {
       sayOnce(
         `latency:${served.rung.node.id}`,
         `[packs] ${served.rung.node.id} was answered with a latency of ${String(latencyMs)}, ` +
-          `which is not a measurement — the answer climbs, and the pack's clock needs fixing.`,
+          `which is not a measurement — the answer climbs one rung, and the pack's clock needs ` +
+          `fixing.`,
       )
-      return true
     }
-    return latencyMs <= within
+    return gained
   }
 
   const rungAt = (index: number): Rung | null => {
@@ -532,7 +725,9 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
   }
 
   return {
-    position: () => position,
+    /** The rung being stood on: the whole part of `progress`, never a fraction.
+        A pack asked for a rung index and a half-climbed one is not one. */
+    position: () => Math.floor(progress),
 
     next: ({ packId, skillId, difficulty, maxDifficulty }) => {
       // A pack may name a skill it covers. It is a request, not an instruction:
@@ -546,14 +741,18 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       // not two: a pack that drives the difficulty and then stops driving it
       // resumes from where it left the child, and `judge` keeps climbing and
       // stepping down from there.
-      let index = position
+      let index = Math.floor(progress)
       if (difficulty !== undefined || maxDifficulty !== undefined) {
         const span = Math.max(0, rungs.length - 1)
-        const asked = difficulty === undefined ? position / Math.max(1, span) : difficulty
+        const asked = difficulty === undefined ? index / Math.max(1, span) : difficulty
         const cap = maxDifficulty === undefined ? 1 : maxDifficulty
-        index = Math.round(Math.min(asked, cap) * span)
-        position = Math.max(0, Math.min(span, index))
-        index = position
+        index = Math.max(0, Math.min(span, Math.round(Math.min(asked, cap) * span)))
+        // The rung the pack named, carrying the credit already earned toward
+        // the next one. Overwriting the whole number would let a game that
+        // drives difficulty on every question quietly delete the fraction a
+        // slow-and-correct child had banked, over and over, and that child
+        // would never move — which is the bug this rule was rewritten to end.
+        progress = index + (progress - Math.floor(progress))
       }
 
       const rung = wanted ?? rungAt(index)
@@ -670,17 +869,24 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       if (!served.answered) {
         served.answered = true
         deps.record({ packId, correct: verdict.correct })
-        // The ladder moves on what actually happened. Up when it was right and
-        // not from the slow tail *of this question*, down on any miss — a child
-        // who is guessing does not climb, and a child who is struggling is not
-        // held there. A correct answer past the item's own p90 holds the rung:
-        // it is neither a promotion nor a demotion, and it is never a penalty.
-        if (verdict.correct && climbs(served, latencyMs)) position = position + 1
-        else if (!verdict.correct) position = position - 1
+        // The ladder moves on what actually happened. Up on every correct
+        // answer — by more than a rung when it was quick for this question, by
+        // a fraction of one when it came from the item's slow tail — and down
+        // one rung on any miss. Slow is not wrong: it is the same direction,
+        // taken at the child's own speed. Wrong is the only thing that
+        // descends, which is what stops a guesser.
+        if (verdict.correct) progress = progress + climbFor(served, latencyMs)
+        else {
+          progress = progress - 1
+          // A miss ends the run, however fast it was. Speed on a wrong answer
+          // is not evidence of anything at all — it is what guessing looks
+          // like — and the speedcuber's rate has to be earned again.
+          quickRun = 0
+        }
         // One clamp for both directions, and the floor is written as a floor:
         // no sequence of answers can put a child below the easiest rung the
         // curriculum has, and none can put them past the hardest.
-        position = Math.max(0, Math.min(Math.max(0, rungs.length - 1), position))
+        progress = Math.max(0, Math.min(Math.max(0, rungs.length - 1), progress))
       }
 
       return {


### PR DESCRIPTION
The ladder held the rung for a correct answer past the item's own p90. Founder ruling: holding is wrong.

> "if it takes a long time to get the right answer then we should tend to stay at the same level .. if the person is 100% right but slow, we could still slowly move up. But, a speedcuber should move up very fast."

## Three regimes

Everything is relative to the item's own clock. `itemPace(digits, fluencyP50Ms)` publishes three landmarks off the cadence table in `docs/EXPERIENCE_DESIGN.md`, widened — never narrowed — by a node's declared `fluencyTarget.p50Ms`. The quick mark is the median compressed by the same ratio the tail stretches it by, so "quick" and "slow" are the same distance from the middle rather than two independent opinions.

| regime | latency | rungs |
|---|---|---|
| **quick** | under the quick mark | `quickMs / latencyMs`, capped at the table's widest p90/p50 (5/2), after six quick correct answers running |
| **expected** | between the mark and the tail | exactly 1 |
| **tail** | past the item's p90 | `tailMs / latencyMs` — decaying with lateness, positive at every latency |

Wrong is unchanged: one rung down, at any speed.

The mechanism is a fractional position: the rung is the whole part, the fraction is credit toward the next one. `Math.floor(x − 1) === Math.floor(x) − 1` for every x, so a miss always costs exactly one rung and never one and a bit.

## What it does to children

Simulated against the shipped 36-rung ladder, always correct:

| child | before | after |
|---|---|---|
| 60 s on every question | rung **0** after 2,000 answers (33 h) | the **top**, in 87 answers |
| 200 ms on every question | the top in 35 answers — walks every rung | the top in **17** |
| at the published median for each item | the top in 35 | the top in 35 (unchanged) |

## The guesser

The speedcuber's rate is the one signal a child can produce without knowing any mathematics, and the first draft of this let a simulated random-tapper reach **rung 26 of 35**. A run of six quick correct answers costs a guesser about 4^6 questions per bonus; over sixty seeded 400-question sessions they end up exactly where the rule with no bonus at all put them (furthest reached 8, finishing 3 — identical to `origin/main`). A guesser is now in `items.test.ts`, six seeds × 600 questions.

## Verification

Every test was checked by deleting the fix. Eight mutations, all caught:

| mutation | first failure |
|---|---|
| the slow tail earns nothing (the hold) | `four hundred correct answers in a row left the child on rung 0 of 35` |
| the speedcuber's rate removed | `35 rungs took 35 answers at 200 ms each — that is one rung per answer or worse` |
| the run gate removed | `a guesser spent 600 questions an average of 7.27 rungs up the ladder` |
| the clamps removed | `the ladder went to -1` / `a fraction of a rung above the floor fell through it` |
| a declared target no longer widens the quick mark | `dw.ns.place.digit-in-place declares a 8000 ms median, and an answer in 3199 ms — under two fifths of it — is not quick to it` |
| a declared target no longer widens the tail | `dw.add.facts.add-within-ten declares a 6000 ms median and climbs only under 6000 ms` |
| the quick mark moved to the median | the published-median-is-one-rung equality |
| the fraction rounded away | `sixty correct answers in a row left the child on rung 1, where one answer had already put them` |

Two of those eight were caught by nothing before this PR — the quick-mark widening guard needed a claim about what a child experiences, because two marks derived from the same expression always satisfy `a >= b`.

Audit of the ladder tests that were already here: one asserted the reversed behaviour in its name (`…holds the rung`) and could not tell a slow answer worth zero from one worth a twentieth of a rung — rewritten into a three-part claim whose third part is what fails under the old rule. `climbing and stepping down are one rung each` was renamed to what it actually pins (an answer at the published median is worth exactly one rung), which is now the assertion that the speedcuber bonus does not leak into ordinary pace. The pre-existing p50 widening guard over every node in the graph is untouched and still green.

`npm test` (247 tests) run 5×, plus `lint`, `tsc` and `build`. Nothing outside `dynawalla/dynawalla-app/` is touched.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb