### PR TITLE
dynawalla/curriculum: the ceiling — the tables, the quotients, and arithmetic below zero

### DIFF
--- a/dynawalla/packs/shared/curriculum/CHANGELOG.md
+++ b/dynawalla/packs/shared/curriculum/CHANGELOG.md
@@ -9,6 +9,69 @@ installed pack until that pack is rebuilt and republished.
 
 ## 0.1.0 — Unreleased
 
+### The ceiling: the tables, the quotients, and arithmetic below zero
+
+The graph reached `4,003 − 87` and stopped. `mul` had no fact rows at all, `div`
+had no floor under long division, and there was no integer arithmetic anywhere —
+so the program's stated span, "`0 + 1` to `48,826 × 82,726`", was missing its top
+two thirds. `48,826 × 82,726` was not merely unauthored: `multidigit-mul` capped
+the multiplier at three digits, so no parameter object could describe it.
+
+- **A new family, `gen.arith.times-table`.** The tables and their inverses, `0 × 1`
+  through `144 ÷ 12`, drawn uniformly from an enumerated closed set. Multiplication
+  and division are one family because `48 ÷ 6` is `6 × 8` read backwards, exactly as
+  `15 − 8` is `8 + 7` read backwards in `gen.arith.number-facts`.
+  `gen.arith.multidigit-mul` is bounded by a digit count and cannot express "the
+  tables to five"; its walkthrough at one digit by one digit announces a partial
+  product and then announces it again as the answer.
+- **Three fact rows.** `dw.mul.facts.tables-within-five`,
+  `dw.mul.facts.tables-to-twelve` and `dw.div.facts.division-facts`, from −1.20 up
+  to 0.15, sitting between the hardest addition fact (−1.25) and the first written
+  multiplication (0.25). Each declares `closedFactSet` — the reconciliation with
+  CG-10 that the addition floor established, applied to the content the old `mul.ts`
+  said the floor forbade outright.
+- **A new family, `gen.arith.signed-int`, and a seventh domain, `int`.** Four rows:
+  `3 − 9` as the on-ramp, then adding, subtracting and multiplying signed numbers.
+  Levels are bounded by magnitude and capped at twenty, because past twenty this is
+  column arithmetic wearing a sign and column arithmetic has a family; what these
+  rows teach is which way the answer points.
+- **`AnswerSchema.integer.signed`, and `answer:integer-signed`.** The first answers
+  in this program that go below zero. A separate renderer id rather than a flag,
+  because a digit keypad handed `(−7) + 4` is not the blank card CG-8 usually
+  catches — it is a card that looks answerable and marks a correct child wrong.
+  CG-8 reads it through the new `answerRendererIdFor(schema)`.
+- **`multidigit-mul` reaches five digits by five**, and a new row,
+  `dw.mul.multidigit.long-multiplication`, whose top level is `48,826 × 82,726`.
+  No existing level's output moves, so `familyRev` does not turn over.
+- **Two CG-10 blockers cleared by widening, not by argument.**
+  `dw.mul.scale.times-power-of-ten` L0 went from 90 problems to 1,800 and
+  `dw.div.whole.divide-exact` L0 from 720 to 7,200. Both were bounded by a digit
+  count that nothing about the content asked to be small, which is precisely the
+  case `closedFactSet` must not be used for.
+- **`PromptTemplateDeclaration.operator`, and `promptOperator(key)`.** The glyph
+  every question is written with, as data the curriculum owns. It exists because
+  the only thing that draws a question today — `dynawalla-app/src/packs/items.ts` —
+  picks the operator with `promptKey.endsWith(".sub") ? "−" : "+"`, so every
+  template that is not a subtraction is drawn as an **addition**. `7 × 8` would
+  reach a child as `7 + 8`.
+- **`OPERATOR_BLOCKED_TEMPLATES` and `SIGNED_BLOCKED_SKILLS`** join
+  `CG10_BLOCKED_LEVELS` in `promotionBlockers.ts`, each asserted against what the
+  graph measures rather than maintained by hand. The first is why the
+  multiplication and division rows are still `draft` after their generators, their
+  fact floors and their variant spaces were all finished; `render/prompts.test.ts`
+  found two entries a human reading of the list had missed
+  (`dw.prompt.missing-operand.sub-unknown` is a subtraction whose key ends
+  `".sub-unknown"`, so the host draws it with a plus too).
+- **`fluencyTarget.p50Ms` on eight more rows**, each with the reason on it. The
+  host takes the wider of the cadence table's p90 and 2.5× this median, and the
+  table was measured on column addition: `47 × 23` is two digits wide and would
+  otherwise climb only under 14 s, which is narrower than the work.
+- **`generators/shared/uniformity.ts`.** χ² over a closed set, in exact rationals,
+  with the tail bound squared so no square root ever happens. The closure tests
+  cannot see a generator that reaches all 121 facts and asks for `2 × 2` twenty
+  times as often as `9 × 8`.
+
+
 ### The floor: `gen.arith.number-facts`, and a ladder that starts at `0 + 1`
 
 The easiest thing this library could give a child was `plus(2, 2, 0)` — a

--- a/dynawalla/packs/shared/curriculum/README.md
+++ b/dynawalla/packs/shared/curriculum/README.md
@@ -36,6 +36,8 @@ npm run snapshots:update    # rewrite the CG-16 output hashes
 | `src/rng/` | Seeded integer-only PRNG (FNV-1a + mulberry32) and the FNV-1a-64 used for output hashes. |
 | `src/types/` | `SkillNode`, `Exercise`, `AnswerSchema`, `PromptSpec`, the generator contract, the mal-rule contract. |
 | `src/generators/numberFacts/` | `gen.arith.number-facts` — the recalled facts, `0 + 1` through `15 − 8`, drawn uniformly from an enumerated closed set. |
+| `src/generators/timesTable/` | `gen.arith.times-table` — the tables and their inverses, `0 × 1` through `144 ÷ 12`, drawn uniformly from an enumerated closed set. |
+| `src/generators/signedInt/` | `gen.arith.signed-int` — arithmetic below zero. The first answers in this package that carry a minus. |
 | `src/generators/columnOp/` | `gen.arith.column-op` — the column algorithm, add and subtract, with exact regrouping control including across zeros. |
 | `src/malrules/` | Sixteen executable buggy procedures, and the classifier. |
 | `src/board/` | Reading a column item back out of the public prompt contract, and the **counting-board contrast pair**. |
@@ -111,7 +113,11 @@ Implementation notes where the document and the code differ, all deliberate:
   does not exist. That is a *sharper* claim than the floor, not a waiver, and it
   is pinned from the other side by `numberFacts.test.ts`, which enumerates each
   level's set from the level's stated rules and asserts the generator reaches
-  every member of it and nothing else.
+  every member of it and nothing else. The same reconciliation is what makes the
+  times tables and the signed-integer rows possible: there are 121 multiplications
+  in the tables to twelve and no 122nd. `uniformity.ts` adds the check the closure
+  cannot make — that the draw over the closed set is *flat*, by χ² in exact
+  rationals.
 - **CG-12** also checks the *declaration* half of the mal-rule contract: every id in
   a node's `misconceptions` resolves in the registry and belongs to the family the
   node binds, and every diagnosis the node's own items emit as a distractor is

--- a/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
@@ -291,12 +291,72 @@ test("sweep: the checker agrees with its own output, and rejects every distracto
   }
 });
 
-test("sweep: no answer is negative, and no fraction answer has a zero denominator", () => {
+/**
+ * Negativity, and the one place in this sweep where an absolute claim became a
+ * conditional one.
+ *
+ * This test asserted that **no** answer in the graph is below zero, and that was
+ * true of every item the program had until integers arrived. The claim worth
+ * making now is the one a renderer depends on: an answer is below zero only where
+ * the item's own schema says it may be, because `AnswerSchema.integer.signed` is
+ * what tells an entry surface to offer a minus key. An item that answers `−3`
+ * behind an unsigned schema is a card a child cannot answer correctly, and it
+ * would reach them looking perfectly ordinary.
+ *
+ * The converse is **not** asserted, and the reason is worth writing down because
+ * the obvious symmetric test is wrong. `(−7) × (−4)` and `7 − (−4)` are signed
+ * items whose answers are all positive, and two levels of the graph are entirely
+ * made of them. If those levels dropped the flag, the keypad would lose its minus
+ * key on exactly the levels where the answer is never negative — which tells a
+ * child the sign of the answer before they have worked it out, the same leak
+ * `answerDigits` exists to avoid. So the flag is a property of the **node**, and
+ * that is what is checked instead: all of a node's levels or none of them.
+ */
+test("sweep: an answer is negative only where its schema says it may be", () => {
+  const signedByNode = new Map<string, Set<boolean>>();
+  let negativeItems = 0;
+
+  for (const level of LEVELS) {
+    for (const exercise of level.exercises) {
+      const signed = exercise.schema.kind === "integer" && exercise.schema.signed === true;
+      const seen = signedByNode.get(level.nodeId) ?? new Set<boolean>();
+      seen.add(signed);
+      signedByNode.set(level.nodeId, seen);
+
+      const answer = exercise.answer.canonical;
+      if (answer.kind !== "integer" && answer.kind !== "columnAlgorithm") continue;
+      if (answer.value.n >= 0n) continue;
+      negativeItems += 1;
+      assert.ok(
+        signed,
+        `${exercise.exerciseId}: answers ${String(answer.value.n)} behind a schema that does not declare it signed — ` +
+          `a keypad with no minus key would draw this card and mark a correct child wrong`,
+      );
+    }
+  }
+
+  for (const [nodeId, seen] of signedByNode) {
+    assert.equal(
+      seen.size,
+      1,
+      `${nodeId} declares a signed answer schema on some of its levels and not others: the keypad would gain and ` +
+        `lose its minus key as a child climbs, which says what sign the answer has before they have found it`,
+    );
+  }
+
+  const signedNodes = [...signedByNode].filter(([, seen]) => seen.has(true)).map(([id]) => id);
+  // A vacuity guard. Every assertion above passes on a graph with no signed item
+  // in it, which is what this file measured before integers existed.
+  assert.ok(negativeItems > 0, "no item in the whole graph answers below zero");
+  process.stdout.write(
+    `# signed answers: ${String(signedNodes.length)} node(s) declare a signed schema, ` +
+      `${String(negativeItems)} item(s) answer below zero\n`,
+  );
+});
+
+test("sweep: no fraction answer has a zero denominator", () => {
   for (const exercise of ALL_ITEMS) {
     const answer = exercise.answer.canonical;
-    if (answer.kind === "integer" || answer.kind === "columnAlgorithm") {
-      assert.ok(answer.value.n >= 0n, `${exercise.exerciseId}: negative answer`);
-    }
     if (answer.kind === "fraction") {
       assert.ok(answer.den > 0n, `${exercise.exerciseId}: non-positive denominator`);
       assert.ok(answer.num >= 0n, `${exercise.exerciseId}: negative numerator`);

--- a/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/params.ts
@@ -34,12 +34,23 @@ export type MultidigitMulParams =
     };
 
 export const MAX_MULTIPLICAND_DIGITS = 5;
-export const MAX_MULTIPLIER_DIGITS = 3;
+/**
+ * Five, raised from three.
+ *
+ * The program's stated ceiling is `48,826 × 82,726`, and at a three-digit
+ * multiplier that item was not merely unauthored — it was **unstatable**, because
+ * no parameter object could describe it. Nothing else changes: `generate` reads
+ * `multiplierDigits` in a loop and drew a four-digit multiplier correctly the whole
+ * time, so no existing level's output moves and `familyRev` does not turn over.
+ * The bound stays a bound rather than becoming `Infinity` because a level table is
+ * a place a typo lands, and a twelve-digit multiplier is a typo and not a lesson.
+ */
+export const MAX_MULTIPLIER_DIGITS = 5;
 export const MAX_POWER = 4;
 
 export const multidigitMulParamSchema: ParamSchema<MultidigitMulParams> = {
   describe:
-    "{ shape: 'general', digits: 2..5, multiplierDigits: 1..3, carries: boolean } | " +
+    "{ shape: 'general', digits: 2..5, multiplierDigits: 1..5, carries: boolean } | " +
     "{ shape: 'power-of-ten', digits: 2..5, maxPower: 1..4 }",
 
   validate(raw: unknown): ParamResult<MultidigitMulParams> {

--- a/dynawalla/packs/shared/curriculum/src/generators/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/registry.ts
@@ -14,7 +14,9 @@ import { missingOperandFamily } from "./missingOperand/family.ts";
 import { multidigitMulFamily } from "./multidigitMul/family.ts";
 import { numberFactsFamily } from "./numberFacts/family.ts";
 import { placeValueFamily } from "./placeValue/family.ts";
+import { signedIntFamily } from "./signedInt/family.ts";
 import { roundEstimateFamily } from "./roundEstimate/family.ts";
+import { timesTableFamily } from "./timesTable/family.ts";
 
 export const generatorFamilies: readonly AnyGeneratorFamily[] = [
   erase(numberFactsFamily),
@@ -27,6 +29,8 @@ export const generatorFamilies: readonly AnyGeneratorFamily[] = [
   erase(fracEquivalenceFamily),
   erase(fracArithFamily),
   erase(missingOperandFamily),
+  erase(timesTableFamily),
+  erase(signedIntFamily),
 ];
 
 export function familyById(

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/uniformity.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/uniformity.ts
@@ -1,0 +1,87 @@
+/**
+ * Is a draw over a closed set uniform? Measured, in exact rationals.
+ *
+ * ## Why a family that enumerates still has to prove this
+ *
+ * `rng.pick` is unbiased and `factSet` is a list, so a uniform draw ought to be
+ * automatic. It is not, and the failure is quiet: the moment a family draws its
+ * operands *separately* rather than picking a member of an enumerated set — which
+ * is what every other generator in this package does, for good reasons — the
+ * distribution over problems stops being flat. Drawing `b` from `2..20` and then
+ * `a` from `1..b−1` covers exactly the same forty-five pairs `3 − 9` needs and
+ * gives the pairs with a small `b` nineteen times the weight of the pairs with a
+ * large one. Every closure test still passes: every member is reached, and no
+ * member outside the set ever is.
+ *
+ * A child would meet that as a level that keeps asking `1 − 2`. So the family
+ * tests measure the shape of the draw as well as its support.
+ *
+ * ## The statistic, and the bound
+ *
+ * `χ² = Σ (Oᵢ − E)² / E` with `E = N / k`, computed as a `Rational` over BigInt —
+ * `E` is very often not an integer and rounding it would put the whole test's
+ * verdict at the mercy of the rounding.
+ *
+ * The bound is the normal approximation to the upper tail, `df + z·√(2·df)`,
+ * with `z` taken well past the 0.999 point and a constant added so that it is also
+ * safe at the small degrees of freedom where the approximation is worst:
+ *
+ *     χ² < df + 3.5·√(2·df) + 6
+ *
+ * At df = 8 that is 28.0 against a true 0.1% point of 26.1; at df = 35, 70.3
+ * against 66.6; at df = 120, 180.2 against 173.6. Loose on purpose in the safe
+ * direction — this is looking for a draw that is *wrong*, not for one that is
+ * unlucky, and it is looking at a **deterministic** sample: the seeds are fixed, so
+ * a pass is a pass on every machine for ever and a failure reproduces exactly.
+ *
+ * The square root never happens. `χ² − df − 6 < 3.5·√(2·df)` is squared into
+ * `(2·(χ² − df − 6))² < 98·df`, which is exact in rationals, after the trivial
+ * case where the left side is already negative.
+ */
+
+import { add, cmp, div, mul, rational, sub } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+
+export type UniformityResult = {
+  /** The statistic, exactly. */
+  readonly chiSquare: Rational;
+  /** `k − 1`, where `k` is the number of cells the draw could land in. */
+  readonly degreesOfFreedom: number;
+  /** How many cells were never drawn at all. Named separately: it is the loud failure. */
+  readonly empty: number;
+  readonly uniform: boolean;
+};
+
+/**
+ * `counts` is one observed count per cell of the closed set, including the zeros.
+ * A cell missing from the array is a cell the caller forgot, not a cell that was
+ * never drawn, so callers build the array from the *set* and not from the draw.
+ */
+export function chiSquareUniform(counts: readonly number[]): UniformityResult {
+  const cells = counts.length;
+  if (cells < 2) throw new RangeError(`chiSquareUniform: ${String(cells)} cell(s) is not a distribution`);
+  const total = counts.reduce((sum, count) => sum + count, 0);
+  if (total <= 0) throw new RangeError("chiSquareUniform: nothing was drawn");
+
+  // E = N/k, exactly. Σ (O − E)²/E = (k/N)·Σ (O − E)².
+  const expected = rational(BigInt(total), BigInt(cells));
+  let statistic = rational(0n);
+  for (const count of counts) {
+    const deviation = sub(rational(BigInt(count)), expected);
+    statistic = add(statistic, div(mul(deviation, deviation), expected));
+  }
+
+  const df = cells - 1;
+  const slack = sub(statistic, rational(BigInt(df + 6)));
+  // Below the constant already: no tail to approximate.
+  const uniform =
+    cmp(slack, rational(0n)) <= 0 ||
+    cmp(mul(mul(rational(2n), slack), mul(rational(2n), slack)), rational(BigInt(98 * df))) < 0;
+
+  return {
+    chiSquare: statistic,
+    degreesOfFreedom: df,
+    empty: counts.filter((count) => count === 0).length,
+    uniform,
+  };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/signedInt/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/signedInt/constants.ts
@@ -1,0 +1,130 @@
+/**
+ * `gen.arith.signed-int` constants — ids, locale keys and every difficulty
+ * coefficient, in one place.
+ *
+ * CURRICULUM.md pins the shape of the difficulty function:
+ *
+ *   b = b_skill
+ *     + 0.55·regroupings
+ *     + 0.30·(maxDigits − 2)
+ *     + 0.25·zeroBorrowThrough
+ *     + 0.20·noAnchor
+ *     − 0.35·specialCase
+ *     + repOffset + formOffset
+ *
+ * None of the place-value terms mean anything here, because **none of the
+ * difficulty of signed arithmetic is in the arithmetic**. `(−7) + 4` is `7 − 4`
+ * with a decision on the front, and a child who can do the second and not the
+ * first has a sign problem rather than a subtraction problem. So the slots are
+ * spent on where the minus signs are, and each substitution is a falsifiable
+ * claim:
+ *
+ * - **`0.20` where the first operand is negative** takes the `noAnchor` slot at
+ *   its documented size. It is the smallest of the three placements because the
+ *   minus is read once, at the front, before anything else happens.
+ * - **`0.35` where the *second* operand is negative** is larger than for the
+ *   first, and that ordering is the claim. `7 + (−4)` and `7 − (−4)` put two signs
+ *   next to each other, which is where the over-generalised "two negatives make a
+ *   positive" fires; the same child reads `(−7) + 4` correctly far more often.
+ * - **`0.45` where both are** is not `0.20 + 0.35`. The two placements do not
+ *   compound: a child holding the sign rule gets `(−7) + (−4)` from the same one
+ *   move that gets them `7 + (−4)`, and scoring it as the sum of two independent
+ *   difficulties would put it above every item in the program.
+ * - **`0.15·subtraction`** is `gen.arith.number-facts`'s coefficient unchanged,
+ *   for the same phenomenon at a different range, and **`0.10·multiplication`**
+ *   is below it deliberately. Multiplying signs is a *rule* — count the minuses —
+ *   where subtracting them is a transformation the child has to perform first.
+ *   Every curriculum that orders the two teaches multiplication of integers after
+ *   subtraction and reports it as the easier of the two.
+ * - **`0.05` per unit of magnitude** above ten is `number-facts`'s range
+ *   coefficient, and it is small for the same reason: `(−7) + 4` and `(−17) + 14`
+ *   are not far apart, and a coefficient large enough to separate them would put
+ *   arithmetic size above sign placement, which is the wrong ordering for
+ *   everything this family teaches.
+ *
+ * Every coefficient is an exact rational. `0.35` as a float would make `b` — and
+ * therefore `P̂` — platform-dependent in the last bits.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const SIGNED_INT_FAMILY = familyId("gen.arith.signed-int");
+
+/**
+ * Bump whenever generated output changes for any seed. CG-16 keys its committed
+ * output hashes on this value.
+ */
+export const SIGNED_INT_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const SIGNED_INT_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_ADD = locKey("dw.prompt.signed-int.add");
+export const PROMPT_KEY_SUB = locKey("dw.prompt.signed-int.sub");
+export const PROMPT_KEY_MUL = locKey("dw.prompt.signed-int.mul");
+
+export const SOLUTION_KEY_READ = locKey("dw.solution.signed-int.read");
+/** `3 − 9`: three steps down to zero, and six more past it. */
+export const SOLUTION_KEY_PAST_ZERO = locKey("dw.solution.signed-int.past-zero");
+/** Subtracting a number is adding its opposite. The rung the rest turns on. */
+export const SOLUTION_KEY_ADD_THE_OPPOSITE = locKey("dw.solution.signed-int.add-the-opposite");
+/** Signs alike: add the sizes, keep the sign. */
+export const SOLUTION_KEY_SAME_SIGNS = locKey("dw.solution.signed-int.same-signs");
+/** Signs unlike: take the smaller size from the larger, keep the larger's sign. */
+export const SOLUTION_KEY_DIFFERENT_SIGNS = locKey("dw.solution.signed-int.different-signs");
+/** Multiply the sizes; the number of minus signs decides the sign. */
+export const SOLUTION_KEY_SIGN_RULE = locKey("dw.solution.signed-int.sign-rule");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.signed-int.result");
+
+/**
+ * Every locale key this family can emit. The i18n gate reads this rather than
+ * grepping, so a new template that nobody translated fails loudly.
+ */
+export const SIGNED_INT_LOC_KEYS = [
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  PROMPT_KEY_MUL,
+  SOLUTION_KEY_READ,
+  SOLUTION_KEY_PAST_ZERO,
+  SOLUTION_KEY_ADD_THE_OPPOSITE,
+  SOLUTION_KEY_SAME_SIGNS,
+  SOLUTION_KEY_DIFFERENT_SIGNS,
+  SOLUTION_KEY_SIGN_RULE,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+/** Prompt slot names. Stable: they are part of the translated template. */
+export const SLOT_FIRST = "first";
+export const SLOT_SECOND = "second";
+export const SLOT_ANSWER = "answer";
+/** How far past zero `3 − 9` goes, once zero has been reached. */
+export const SLOT_PAST = "past";
+/** The opposite of the second operand — what a subtraction becomes an addition of. */
+export const SLOT_OPPOSITE = "opposite";
+/** The two magnitudes, in the order the strategy names them. */
+export const SLOT_LARGER = "larger";
+export const SLOT_SMALLER = "smaller";
+/** The product of the magnitudes, before the sign is decided. */
+export const SLOT_SIZE = "size";
+/** How many minus signs are on the card. A count: the template's plural turns on it. */
+export const SLOT_NEGATIVES = "negatives";
+
+/** 0.05 per unit of magnitude above ten. */
+export const COEFF_MAGNITUDE_OVER_ROOT = rational(5n, 100n);
+/** 0.15 for subtraction — `gen.arith.number-facts`'s coefficient, unchanged. */
+export const COEFF_SUBTRACTION = rational(15n, 100n);
+/** 0.10 for multiplication: a rule to apply, not a transformation to perform. */
+export const COEFF_MULTIPLICATION = rational(10n, 100n);
+/** 0.20 when the first operand carries the minus. */
+export const COEFF_FIRST_NEGATIVE = rational(20n, 100n);
+/** 0.35 when the second does, and two signs end up side by side. */
+export const COEFF_SECOND_NEGATIVE = rational(35n, 100n);
+/** 0.45 when both do. Not the sum of the two above — see the note at the top. */
+export const COEFF_BOTH_NEGATIVE = rational(45n, 100n);
+
+/** The magnitude every level is measured against — within ten, as everywhere else. */
+export const ROOT_MAGNITUDE = 10;
+
+/** Free entry is the only form; the offset is stated so the contract is total. */
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/signedInt/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/signedInt/family.ts
@@ -1,0 +1,301 @@
+/**
+ * `gen.arith.signed-int` — arithmetic below zero. The pre-algebra on-ramp.
+ *
+ * ## What is new here, and it is one thing
+ *
+ * Every answer in this program before now was at or above zero, and every gate,
+ * sweep and renderer declaration quietly assumed it. This family is the first that
+ * cannot, so it carries the first `AnswerSchema.integer.signed`, and that flag is
+ * not decoration: a keypad with no minus key on `(−7) + 4` draws a card that looks
+ * answerable and marks a correct child wrong, which is worse than the blank screen
+ * CG-8 usually catches. `answer:integer-signed` is a separate renderer id for
+ * exactly that reason.
+ *
+ * ## What it does not do
+ *
+ * **No number line.** The number line is the right representation for integers and
+ * it is not declared here, because nothing in this repository draws a
+ * representation. A row whose question is a picture nobody draws is a blank card,
+ * and `−3` is a complete question written as numerals; a line would have been a
+ * scaffold, not the content. `REP_NUMBER_LINE` is registered and unimplemented, and
+ * the day it is drawn these rows gain it as `optional` without a new id.
+ *
+ * **No division.** `(−48) ÷ 6` follows the same sign rule as the multiplication
+ * here and would need an exact-division draw to avoid posing a fraction by
+ * accident. It is a row this family can carry the day someone wants it, not a gap
+ * in what it teaches.
+ *
+ * **No mal-rules.** The evidence base for sign errors is real — the
+ * over-generalised "two negatives make a positive" applied to an addition is the
+ * one every teacher can name — but this program's rule is that a mal-rule is a
+ * *documented* buggy procedure with a citation behind it, and `README.md` forbids
+ * inventing one outright. The rows declare `misconceptions: []`, the items carry
+ * no distractors, and a wrong answer routes to the worked example. That is the
+ * honest outcome, and the rung it routes to is the one that names the rule.
+ */
+
+import { mul as ratMul, rational, add as ratAdd, sub as ratSub, eq as ratEq } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { countSlot, numberSlot } from "../shared/slots.ts";
+import {
+  COEFF_BOTH_NEGATIVE,
+  COEFF_FIRST_NEGATIVE,
+  COEFF_MAGNITUDE_OVER_ROOT,
+  COEFF_MULTIPLICATION,
+  COEFF_SECOND_NEGATIVE,
+  COEFF_SUBTRACTION,
+  FORM_OFFSET_FREE_ENTRY,
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_MUL,
+  PROMPT_KEY_SUB,
+  ROOT_MAGNITUDE,
+  SIGNED_INT_FAMILY,
+  SIGNED_INT_FAMILY_REV,
+  SIGNED_INT_FORMS,
+  SLOT_ANSWER,
+  SLOT_FIRST,
+  SLOT_LARGER,
+  SLOT_NEGATIVES,
+  SLOT_OPPOSITE,
+  SLOT_PAST,
+  SLOT_SECOND,
+  SLOT_SIZE,
+  SLOT_SMALLER,
+  SOLUTION_KEY_ADD_THE_OPPOSITE,
+  SOLUTION_KEY_DIFFERENT_SIGNS,
+  SOLUTION_KEY_PAST_ZERO,
+  SOLUTION_KEY_READ,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SAME_SIGNS,
+  SOLUTION_KEY_SIGN_RULE,
+} from "./constants.ts";
+import { pairSet } from "./pairs.ts";
+import type { Pair } from "./pairs.ts";
+import { signedIntParamSchema } from "./params.ts";
+import type { SignedIntParams } from "./params.ts";
+
+const PROMPT_KEYS = {
+  add: PROMPT_KEY_ADD,
+  sub: PROMPT_KEY_SUB,
+  mul: PROMPT_KEY_MUL,
+} as const;
+
+/** `|n|`, on a plain number. */
+function magnitude(value: number): number {
+  return value < 0 ? -value : value;
+}
+
+/**
+ * The answer field's width, which is the *level's* width and never this item's.
+ *
+ * The sign is not a digit — `−144` is three digits and a minus — so the width is
+ * read off the largest magnitude the level can reach and the schema's `signed`
+ * flag carries the rest. A field cut to this item would say how big the answer is,
+ * and on a level whose answers straddle zero it would also say which side of it.
+ */
+function answerDigits(params: SignedIntParams): number {
+  const widest = params.op === "mul" ? params.maxMagnitude * params.maxMagnitude : 2 * params.maxMagnitude;
+  return String(widest).length;
+}
+
+function schemaFor(params: SignedIntParams): AnswerSchema {
+  return { kind: "integer", digits: answerDigits(params), decimalPlaces: 0, signed: true };
+}
+
+/** The exact answer, in integers. The item's whole arithmetic, in one place. */
+function resultOf(op: SignedIntParams["op"], pair: Pair): number {
+  switch (op) {
+    case "add":
+      return pair.first + pair.second;
+    case "sub":
+      return pair.first - pair.second;
+    case "mul":
+      return pair.first * pair.second;
+  }
+}
+
+/**
+ * The hint ladder. Read the item, name the move, state the answer — with a fourth
+ * rung on subtraction, because subtraction has two moves.
+ *
+ * The middle rungs are the strategy and never a restatement of the arithmetic:
+ *
+ * - **`3 − 9`** counts down to zero and then past it. Not "add the opposite":
+ *   a child meeting a negative answer for the first time has no opposite to add
+ *   yet, and the thing they need is that the count carries on below zero.
+ * - **Every other subtraction** turns into an addition first — `7 − (−4)` is
+ *   `7 + 4` — and then takes the addition rung it became. Two rungs, because that
+ *   is two moves, and a ladder that did both in one step would hide the move the
+ *   row exists to teach.
+ * - **Addition** splits on whether the signs agree. Alike: add the sizes, keep the
+ *   sign. Unlike: take the smaller size from the larger and keep the larger's sign.
+ * - **Multiplication** multiplies the sizes and then counts the minus signs. One
+ *   rung, one key, and the count is a `count` slot so the template's plural turns
+ *   on it: "one minus sign" and "two minus signs" are one sentence in English and
+ *   two in several launch locales.
+ */
+function solutionFor(params: SignedIntParams, pair: Pair): SolutionStep[] {
+  const answer = resultOf(params.op, pair);
+  const read: SolutionStep = {
+    key: SOLUTION_KEY_READ,
+    slots: {
+      [SLOT_FIRST]: numberSlot(BigInt(pair.first)),
+      [SLOT_SECOND]: numberSlot(BigInt(pair.second)),
+    },
+  };
+  const result: SolutionStep = {
+    key: SOLUTION_KEY_RESULT,
+    slots: { [SLOT_ANSWER]: numberSlot(BigInt(answer)) },
+  };
+
+  if (params.op === "mul") {
+    const negatives = (pair.first < 0 ? 1 : 0) + (pair.second < 0 ? 1 : 0);
+    return [
+      read,
+      {
+        key: SOLUTION_KEY_SIGN_RULE,
+        slots: {
+          [SLOT_SIZE]: numberSlot(BigInt(magnitude(pair.first) * magnitude(pair.second))),
+          [SLOT_NEGATIVES]: countSlot(negatives),
+        },
+      },
+      result,
+    ];
+  }
+
+  if (params.op === "sub" && params.negatives === "none") {
+    return [
+      read,
+      {
+        key: SOLUTION_KEY_PAST_ZERO,
+        slots: {
+          [SLOT_FIRST]: numberSlot(BigInt(pair.first)),
+          [SLOT_PAST]: countSlot(pair.second - pair.first),
+        },
+      },
+      result,
+    ];
+  }
+
+  // From here the item is an addition, either because it was one or because the
+  // rung above turned it into one. `addend` is what is really being added.
+  const addend = params.op === "sub" ? -pair.second : pair.second;
+  const steps: SolutionStep[] = [read];
+  if (params.op === "sub") {
+    steps.push({
+      key: SOLUTION_KEY_ADD_THE_OPPOSITE,
+      slots: {
+        [SLOT_SECOND]: numberSlot(BigInt(pair.second)),
+        [SLOT_OPPOSITE]: numberSlot(BigInt(addend)),
+      },
+    });
+  }
+
+  // The two sizes, always larger first — on both rungs, and not only on the one
+  // that subtracts them. "Add the larger and the smaller" is the same sentence
+  // whichever order the card wrote them in, and a slot called `larger` that
+  // sometimes holds the smaller is a template waiting to be translated wrongly.
+  const bigger = magnitude(pair.first) >= magnitude(addend) ? magnitude(pair.first) : magnitude(addend);
+  const smaller = magnitude(pair.first) >= magnitude(addend) ? magnitude(addend) : magnitude(pair.first);
+  steps.push({
+    key: pair.first < 0 === addend < 0 ? SOLUTION_KEY_SAME_SIGNS : SOLUTION_KEY_DIFFERENT_SIGNS,
+    slots: {
+      [SLOT_LARGER]: numberSlot(BigInt(bigger)),
+      [SLOT_SMALLER]: numberSlot(BigInt(smaller)),
+    },
+  });
+
+  steps.push(result);
+  return steps;
+}
+
+export const signedIntFamily: GeneratorFamily<SignedIntParams> = {
+  family: SIGNED_INT_FAMILY,
+  familyRev: SIGNED_INT_FAMILY_REV,
+  paramSchema: signedIntParamSchema,
+  forms: SIGNED_INT_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: SignedIntParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: SignedIntParams): Rational {
+    let b = ratMul(COEFF_MAGNITUDE_OVER_ROOT, rational(BigInt(params.maxMagnitude - ROOT_MAGNITUDE)));
+    if (params.op === "sub") b = ratAdd(b, COEFF_SUBTRACTION);
+    if (params.op === "mul") b = ratAdd(b, COEFF_MULTIPLICATION);
+    if (params.negatives === "first") b = ratAdd(b, COEFF_FIRST_NEGATIVE);
+    if (params.negatives === "second") b = ratAdd(b, COEFF_SECOND_NEGATIVE);
+    if (params.negatives === "both") b = ratAdd(b, COEFF_BOTH_NEGATIVE);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<SignedIntParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(SIGNED_INT_FAMILY, SIGNED_INT_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+    const form = chooseForm(forms, SIGNED_INT_FORMS, rng);
+
+    const pairs = pairSet(params);
+    if (pairs.length === 0) {
+      // The schema rejects every combination that empties the set, so reaching
+      // here is a disagreement between the validator and the enumeration — the one
+      // bug class a family of this shape is most likely to have.
+      throw new InfeasibleLevelError(`no pair satisfies the parameters of ${exerciseId}`);
+    }
+    const pair = rng.pick(pairs);
+    const answer = resultOf(params.op, pair);
+
+    // Integer arithmetic and exact rational arithmetic agree, asserted on every
+    // call. This is where a sign error in the family itself would be caught, and it
+    // is worth the two multiplications: an answer whose sign is wrong is wrong
+    // identically on every device and no test that re-ran `resultOf` would see it.
+    const left = rational(BigInt(pair.first));
+    const right = rational(BigInt(pair.second));
+    const exact =
+      params.op === "add" ? ratAdd(left, right) : params.op === "sub" ? ratSub(left, right) : ratMul(left, right);
+    if (!ratEq(exact, rational(BigInt(answer)))) {
+      throw new InfeasibleLevelError(`signed arithmetic disagreed with exact arithmetic on ${exerciseId}`);
+    }
+
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: SIGNED_INT_FAMILY,
+      familyRev: SIGNED_INT_FAMILY_REV,
+      form,
+      prompt: {
+        key: PROMPT_KEYS[params.op],
+        slots: {
+          [SLOT_FIRST]: numberSlot(BigInt(pair.first)),
+          [SLOT_SECOND]: numberSlot(BigInt(pair.second)),
+        },
+      },
+      schema: schemaFor(params),
+      answer: { canonical: { kind: "integer", value: rational(BigInt(answer)) }, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, pair),
+    };
+
+    return { ...base, distractors: distractorsFor(SIGNED_INT_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/signedInt/pairs.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/signedInt/pairs.ts
@@ -1,0 +1,69 @@
+/**
+ * The pairs a level draws from, enumerated.
+ *
+ * Same reasoning as `numberFacts/facts.ts` and `timesTable/facts.ts`: a level here
+ * is bounded by a magnitude, so its problem space is a written-down list rather
+ * than a number estimated from observed collisions, and a test can compare against
+ * it in both directions. The largest list is four hundred entries.
+ *
+ * Two shapes, and the second is the reason this is a file and not two `nextInt`
+ * calls:
+ *
+ * - **`first`, `second` and `both`** are the rectangle `1..m × 1..m` with the
+ *   minus signs written on. A magnitude of zero is excluded everywhere, because a
+ *   zero has no sign: `(−0) + 4` is a card with a lie on it, and `0 × (−7)` is an
+ *   item whose answer is right whatever the child believes about signs.
+ * - **`none`** — the on-ramp, `3 − 9` — is the *triangle* `a < b`, because the
+ *   whole content of the level is that the answer lands below zero and an item
+ *   where it does not is an item from another family. Two independent draws with a
+ *   rejection would give a stream whose length depends on what it rejected, and
+ *   drawing `b` first and then `a` under it would not be uniform: the pairs with a
+ *   large `b` would be spread thin and the pairs with `b = 2` would come up as
+ *   often as the whole of `b = 20`. `signedInt.test.ts` measures that with a χ².
+ *
+ * Ordering is a plain nested loop and never a sort, so the list is byte-stable on
+ * every platform (CG-16) without a comparator to get wrong.
+ */
+
+import type { SignedIntParams } from "./params.ts";
+
+/** One item: `first op second`, both signed as the level's placement says. */
+export type Pair = {
+  readonly first: number;
+  readonly second: number;
+};
+
+/**
+ * Every pair this parameter set admits, in a fixed order.
+ *
+ * Never memoised. A cache keyed on a parameter object is a key-order assumption
+ * waiting to happen.
+ */
+export function pairSet(params: SignedIntParams): Pair[] {
+  const { maxMagnitude: m, negatives } = params;
+  const out: Pair[] = [];
+
+  if (negatives === "none") {
+    // `a − b` with `a < b`, so the answer is strictly below zero on every item.
+    for (let first = 1; first < m; first++) {
+      for (let second = first + 1; second <= m; second++) {
+        out.push({ first, second });
+      }
+    }
+    return out;
+  }
+
+  const firstSign = negatives === "first" || negatives === "both" ? -1 : 1;
+  const secondSign = negatives === "second" || negatives === "both" ? -1 : 1;
+  for (let a = 1; a <= m; a++) {
+    for (let b = 1; b <= m; b++) {
+      out.push({ first: firstSign * a, second: secondSign * b });
+    }
+  }
+  return out;
+}
+
+/** How many problems the level has. What a curriculum row declares and CG-10 checks. */
+export function pairSetSize(params: SignedIntParams): number {
+  return pairSet(params).length;
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/signedInt/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/signedInt/params.ts
@@ -1,0 +1,66 @@
+/**
+ * `gen.arith.signed-int` parameters and their validator.
+ *
+ * Two things a level names, and neither of them is a digit count.
+ *
+ * **`negatives` — where the minus signs are.** Not how many: `(−7) + 4` and
+ * `7 + (−4)` both have one, and they are not the same item to a child. The whole
+ * difficulty of this family is in that placement, so a level that let the draw
+ * decide would serve a mixture of two skills and could measure neither. It is the
+ * same decision `gen.arith.multidigit-mul` makes about `carries`.
+ *
+ * **`maxMagnitude` — how big the numbers are, capped at twenty.** The cap is the
+ * content, not a limitation waiting to be lifted: past twenty, `(−47) + 23` is
+ * column arithmetic wearing a sign, and column arithmetic already has a family.
+ * What this one teaches is which way the answer points, and it teaches it on
+ * numbers a child can hold in their head so that nothing else can be the reason
+ * they got it wrong. That cap is also why every level here declares
+ * `closedFactSet`: bounded by magnitude, a level of this family is a fixed and
+ * countable set of problems in exactly the sense `add-within-ten` is.
+ *
+ * `none` is subtraction only, and it is the on-ramp: `3 − 9`, written with no
+ * minus sign anywhere and answered with one. For addition and multiplication a
+ * level with no negative operand is not signed arithmetic at all — it is a fact
+ * from another family with this family's name on the mastery record.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type SignedOp = "add" | "sub" | "mul";
+export const SIGNED_OPS: readonly SignedOp[] = ["add", "sub", "mul"];
+
+/** Which operands carry a minus sign. */
+export type SignPlacement = "none" | "first" | "second" | "both";
+export const SIGN_PLACEMENTS: readonly SignPlacement[] = ["none", "first", "second", "both"];
+
+export type SignedIntParams = {
+  readonly op: SignedOp;
+  /** Both magnitudes are drawn from `1..maxMagnitude`. Never zero — see below. */
+  readonly maxMagnitude: number;
+  readonly negatives: SignPlacement;
+};
+
+/** Below five, a level is a dozen items and a child sees each of them twice a run. */
+export const MIN_MAGNITUDE = 5;
+/** Past twenty this stops being about the sign. See the note at the top. */
+export const MAX_MAGNITUDE = 20;
+
+export const signedIntParamSchema: ParamSchema<SignedIntParams> = {
+  describe: "{ op: 'add'|'sub'|'mul', maxMagnitude: 5..20, negatives: 'none'|'first'|'second'|'both' }",
+
+  validate(raw: unknown): ParamResult<SignedIntParams> {
+    const read = reader(raw);
+    const op = read.choice<SignedOp>("op", SIGNED_OPS);
+    const maxMagnitude = read.int("maxMagnitude", MIN_MAGNITUDE, MAX_MAGNITUDE);
+    const negatives = read.choice<SignPlacement>("negatives", SIGN_PLACEMENTS);
+
+    if (read.clean() && negatives === "none" && op !== "sub") {
+      read.reject(
+        "negatives",
+        `${op} with no negative operand has no negative anywhere in it and is not signed arithmetic`,
+      );
+    }
+    return read.finish({ op, maxMagnitude, negatives });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/signedInt/signedInt.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/signedInt/signedInt.test.ts
@@ -1,0 +1,456 @@
+/**
+ * `gen.arith.signed-int`, held to what a generator binding has to prove before a
+ * row may be served to a child — and to one thing no other family in this package
+ * has ever had to prove, which is that the sign is right.
+ *
+ * 1. **Every stated answer is correct, checked in the inverse direction.** Never
+ *    by re-running the generator's own expression. An addition is checked by
+ *    taking the second operand back off the answer, a subtraction by adding it
+ *    back on, and a multiplication by *dividing* — three operations the family
+ *    never performs.
+ * 2. **The eight sign cases are named individually.** A property test over four
+ *    hundred pairs passes if the family gets seven of the eight rules right and
+ *    one of them backwards on a case the level table happens not to reach. The
+ *    cases are written out with their answers, and each is looked up in the
+ *    generator's own output rather than computed here.
+ * 3. **The set is closed, exactly, and the draw over it is uniform** by χ². The
+ *    uniformity is not decoration on this family: the on-ramp level draws from a
+ *    *triangle*, and the obvious two-draw implementation of a triangle is
+ *    lopsided by a factor of nineteen while passing every closure check.
+ * 4. **Every item declares a signed answer schema**, and the set of skills that do
+ *    is exactly `SIGNED_BLOCKED_SKILLS`. A signed answer behind an unsigned schema
+ *    is a card drawn with a keypad that cannot express its answer.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  add as ratAdd,
+  cmp as ratCmp,
+  div as ratDiv,
+  eq as ratEq,
+  rational,
+  sub as ratSub,
+  toString as ratToString,
+} from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { skillId } from "../../types/ids.ts";
+import { schemaDefect } from "../../types/answer.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { serializeExercise } from "../../serialize.ts";
+import { allNodes } from "../../graph/graph.ts";
+import { SIGNED_BLOCKED_SKILLS } from "../../graph/promotionBlockers.ts";
+import { answerRendererIdFor, findRenderer } from "../../render/registry.ts";
+import { chiSquareUniform } from "../shared/uniformity.ts";
+import { signedIntFamily } from "./family.ts";
+import { pairSet } from "./pairs.ts";
+import { signedIntParamSchema } from "./params.ts";
+import type { SignedIntParams, SignedOp, SignPlacement } from "./params.ts";
+import {
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_MUL,
+  PROMPT_KEY_SUB,
+  SIGNED_INT_FAMILY,
+  SLOT_FIRST,
+  SLOT_SECOND,
+  SOLUTION_KEY_ADD_THE_OPPOSITE,
+  SOLUTION_KEY_DIFFERENT_SIGNS,
+  SOLUTION_KEY_PAST_ZERO,
+  SOLUTION_KEY_SAME_SIGNS,
+  SOLUTION_KEY_SIGN_RULE,
+} from "./constants.ts";
+
+const SKILL = skillId("dw.int.arith.add-signed");
+const FORMS = ["free-entry"];
+
+/** Enough draws that a set of four hundred is collected several times over. */
+const SEEDS = 6000;
+
+function params(op: SignedOp, maxMagnitude: number, negatives: SignPlacement): SignedIntParams {
+  return { op, maxMagnitude, negatives };
+}
+
+function generate(p: SignedIntParams, seed: number, level = 0): Exercise {
+  return signedIntFamily.generate({ skillId: SKILL, level, seed, params: p, forms: FORMS });
+}
+
+function operands(exercise: Exercise): { first: Rational; second: Rational } {
+  const first = exercise.prompt.slots[SLOT_FIRST];
+  const second = exercise.prompt.slots[SLOT_SECOND];
+  assert.ok(first !== undefined && first.kind === "number", exercise.exerciseId);
+  assert.ok(second !== undefined && second.kind === "number", exercise.exerciseId);
+  return { first: first.value, second: second.value };
+}
+
+function answerOf(exercise: Exercise): Rational {
+  const answer = exercise.answer.canonical;
+  assert.equal(answer.kind, "integer", exercise.exerciseId);
+  return answer.kind === "integer" ? answer.value : rational(0n);
+}
+
+const BOUND_LEVELS = allNodes
+  .filter((node) => node.generator.family === SIGNED_INT_FAMILY)
+  .flatMap((node) =>
+    node.generator.params.map((raw, level) => {
+      const validated = signedIntParamSchema.validate(raw);
+      assert.ok(validated.ok, `${node.id} L${String(level)} params rejected`);
+      return {
+        label: `${node.id} L${String(level)}`,
+        node,
+        level,
+        params: validated.ok ? validated.value : params("sub", 10, "none"),
+        declared: node.generator.closedFactSet?.[level],
+      };
+    }),
+  );
+
+test("the graph binds this family, and every bound level declares its closed set", () => {
+  assert.ok(BOUND_LEVELS.length >= 12, `only ${String(BOUND_LEVELS.length)} bound level(s)`);
+  for (const bound of BOUND_LEVELS) {
+    assert.ok(bound.declared !== undefined, `${bound.label} declares no closedFactSet`);
+  }
+  // All three operations, or a row is bound that the family cannot distinguish.
+  const ops = new Set(BOUND_LEVELS.map((bound) => bound.params.op));
+  assert.deepEqual([...ops].sort(), ["add", "mul", "sub"]);
+  process.stdout.write(`# signed-int: ${String(BOUND_LEVELS.length)} bound level(s)\n`);
+});
+
+test("every stated answer is correct, re-derived from the prompt by the inverse operation", () => {
+  let checked = 0;
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+      const answer = answerOf(exercise);
+
+      // Each of these is the operation the generator did *not* do, so a sign
+      // dropped in one direction cannot be dropped identically in the other.
+      const rebuilt =
+        bound.params.op === "add"
+          ? ratSub(answer, second)
+          : bound.params.op === "sub"
+            ? ratAdd(answer, second)
+            : ratDiv(answer, second);
+      assert.ok(
+        ratEq(rebuilt, first),
+        `${exercise.exerciseId}: ${ratToString(first)} ${bound.params.op} ${ratToString(second)} gave ` +
+          `${ratToString(answer)}, which does not come back to ${ratToString(first)}`,
+      );
+      checked += 1;
+    }
+  }
+  process.stdout.write(`# signed-int: ${String(checked)} answers re-derived by the inverse\n`);
+});
+
+/**
+ * The eight rules, named, with the item each one is about.
+ *
+ * Each row is `[op, first, second, answer]`, and the item is **found in the
+ * generator's output** rather than computed here: the level that could pose it is
+ * drawn until the pair comes up, and its stated answer is compared with this
+ * table. A test that computed the expected answer with the same rule the family
+ * uses would agree with a family that had the rule backwards.
+ */
+const SIGN_CASES: readonly (readonly [SignedOp, SignPlacement, number, number, number])[] = [
+  // The on-ramp: no minus on the card, one in the answer.
+  ["sub", "none", 3, 9, -6],
+  // Addition. Unlike signs take the smaller size from the larger and keep the
+  // larger's sign; like signs add the sizes and keep it.
+  ["add", "first", -7, 4, -3],
+  ["add", "first", -4, 7, 3],
+  ["add", "second", 7, -4, 3],
+  ["add", "both", -7, -4, -11],
+  // Subtraction. The second row is the one the whole domain turns on.
+  ["sub", "first", -7, 4, -11],
+  ["sub", "second", 7, -4, 11],
+  ["sub", "both", -7, -4, -3],
+  // Multiplication: count the minus signs.
+  ["mul", "first", -6, 8, -48],
+  ["mul", "both", -6, -8, 48],
+];
+
+test("the eight sign rules are right, each on an item the generator actually drew", () => {
+  for (const [op, negatives, first, second, expected] of SIGN_CASES) {
+    const magnitude = Math.max(Math.abs(first), Math.abs(second));
+    const level = params(op, Math.max(magnitude, 10), negatives);
+    let found: Exercise | undefined;
+    for (let seed = 1; seed <= SEEDS && found === undefined; seed++) {
+      const exercise = generate(level, seed);
+      const drawn = operands(exercise);
+      if (drawn.first.n === BigInt(first) && drawn.second.n === BigInt(second)) found = exercise;
+    }
+    assert.ok(
+      found !== undefined,
+      `no seed under ${String(SEEDS)} draws ${String(first)} ${op} ${String(second)} on a ${negatives} level`,
+    );
+    assert.equal(
+      ratToString(answerOf(found)),
+      String(expected),
+      `${String(first)} ${op} ${String(second)} is ${String(expected)} and the item says ${ratToString(answerOf(found))}`,
+    );
+  }
+  process.stdout.write(`# signed-int: ${String(SIGN_CASES.length)} named sign case(s) checked\n`);
+});
+
+test("every item is inside the band its level declares, and every operand has a sign", () => {
+  for (const bound of BOUND_LEVELS) {
+    const { maxMagnitude, negatives, op } = bound.params;
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+
+      // Zero has no sign, so a signed item never has one as an operand: `(−0) + 4`
+      // is a card with a lie on it and `0 × (−7)` is right whatever the child
+      // believes about signs.
+      assert.notEqual(first.n, 0n, `${exercise.exerciseId}: a zero operand`);
+      assert.notEqual(second.n, 0n, `${exercise.exerciseId}: a zero operand`);
+      const firstSize = first.n < 0n ? -first.n : first.n;
+      const secondSize = second.n < 0n ? -second.n : second.n;
+      assert.ok(firstSize <= BigInt(maxMagnitude), `${exercise.exerciseId}: first operand above the level`);
+      assert.ok(secondSize <= BigInt(maxMagnitude), `${exercise.exerciseId}: second operand above the level`);
+
+      // The placement is the level's declaration and never the draw's accident.
+      const wantFirstNegative = negatives === "first" || negatives === "both";
+      const wantSecondNegative = negatives === "second" || negatives === "both";
+      assert.equal(first.n < 0n, wantFirstNegative, `${exercise.exerciseId}: the first sign is not the level's`);
+      assert.equal(second.n < 0n, wantSecondNegative, `${exercise.exerciseId}: the second sign is not the level's`);
+      if (negatives === "none") {
+        // The whole content of the on-ramp: the answer is strictly below zero.
+        assert.ok(op === "sub" && ratCmp(answerOf(exercise), rational(0n)) < 0, exercise.exerciseId);
+      }
+
+      assert.equal(schemaDefect(exercise.schema), null, exercise.exerciseId);
+      assert.ok(exercise.schema.kind === "integer" && exercise.schema.signed === true, exercise.exerciseId);
+      const size = answerOf(exercise).n < 0n ? -answerOf(exercise).n : answerOf(exercise).n;
+      assert.ok(
+        size.toString().length <= (exercise.schema.kind === "integer" ? exercise.schema.digits : 0),
+        `${exercise.exerciseId}: the answer does not fit the field`,
+      );
+    }
+  }
+});
+
+/**
+ * The closure, against an enumeration written here and not imported.
+ *
+ * `pairSet` is the generator's own list, so asserting the generator against it
+ * would prove only that the family calls the function it calls.
+ */
+function independentSet(p: SignedIntParams): Set<string> {
+  const out = new Set<string>();
+  const firstSign = p.negatives === "first" || p.negatives === "both" ? -1 : 1;
+  const secondSign = p.negatives === "second" || p.negatives === "both" ? -1 : 1;
+  for (let a = 1; a <= p.maxMagnitude; a++) {
+    for (let b = 1; b <= p.maxMagnitude; b++) {
+      // The on-ramp is the triangle where the answer lands below zero, and nothing
+      // else; every other placement is the whole rectangle with signs written on.
+      if (p.negatives === "none" && a >= b) continue;
+      out.add(`${String(firstSign * a)}|${String(secondSign * b)}`);
+    }
+  }
+  return out;
+}
+
+test("the set is closed, the generator reaches exactly it, and the draw is uniform", () => {
+  const lines: string[] = [];
+  for (const bound of BOUND_LEVELS) {
+    const expected = independentSet(bound.params);
+    assert.equal(
+      pairSet(bound.params).length,
+      expected.size,
+      `${bound.label}: pairSet has ${String(pairSet(bound.params).length)} pairs, the rules give ${String(expected.size)}`,
+    );
+    assert.equal(
+      bound.declared,
+      expected.size,
+      `${bound.label}: the row declares ${String(bound.declared)} and the mathematics has ${String(expected.size)}`,
+    );
+
+    const counts = new Map<string, number>([...expected].map((pair) => [pair, 0]));
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const { first, second } = operands(generate(bound.params, seed, bound.level));
+      const key = `${first.n.toString()}|${second.n.toString()}`;
+      assert.ok(counts.has(key), `${bound.label}: the generator reached ${key}, which is outside the closed set`);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const missing = [...counts].filter(([, count]) => count === 0).map(([pair]) => pair);
+    assert.deepEqual(missing.sort(), [], `${bound.label}: the generator never reached a pair in the closed set`);
+
+    const uniformity = chiSquareUniform([...counts.values()]);
+    assert.ok(
+      uniformity.uniform,
+      `${bound.label}: the draw is not uniform over its own set — χ² = ${ratToString(uniformity.chiSquare)} ` +
+        `on ${String(uniformity.degreesOfFreedom)} degrees of freedom`,
+    );
+    lines.push(
+      `#   ${bound.label}: ${String(expected.size)} pairs, all reached in ${String(SEEDS)} seeds, ` +
+        `χ² ≈ ${String(Number(uniformity.chiSquare.n) / Number(uniformity.chiSquare.d))} on ${String(uniformity.degreesOfFreedom)} df`,
+    );
+  }
+  process.stdout.write(`# closed signed sets:\n${lines.join("\n")}\n`);
+});
+
+test("the walkthrough names the move, and the move is the one the item needs", () => {
+  const seen = new Set<string>();
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= 600; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+      const steps = exercise.solution;
+      const last = steps[steps.length - 1];
+      assert.ok(last !== undefined);
+      const stated = last.slots["answer"];
+      assert.ok(stated !== undefined && stated.kind === "number", exercise.exerciseId);
+      assert.ok(ratEq(stated.value, answerOf(exercise)), `${exercise.exerciseId}: the ladder ends elsewhere`);
+
+      for (const step of steps) seen.add(String(step.key));
+
+      if (bound.params.op === "sub" && bound.params.negatives === "none") {
+        assert.equal(steps.length, 3, exercise.exerciseId);
+        const past = steps[1]?.slots["past"];
+        assert.equal(steps[1]?.key, SOLUTION_KEY_PAST_ZERO, exercise.exerciseId);
+        assert.ok(past !== undefined && past.kind === "count", exercise.exerciseId);
+        // Down to zero, then `past` further — and `past` is exactly how far below
+        // zero the answer lands.
+        assert.equal(BigInt(past.value), -answerOf(exercise).n, exercise.exerciseId);
+        continue;
+      }
+
+      if (bound.params.op === "sub") {
+        // Four rungs, because subtraction is two moves and a ladder that did both
+        // in one step would hide the one the row exists to teach.
+        assert.equal(steps.length, 4, exercise.exerciseId);
+        assert.equal(steps[1]?.key, SOLUTION_KEY_ADD_THE_OPPOSITE, exercise.exerciseId);
+        const opposite = steps[1]?.slots["opposite"];
+        assert.ok(opposite !== undefined && opposite.kind === "number", exercise.exerciseId);
+        assert.equal(opposite.value.n, -second.n, `${exercise.exerciseId}: the opposite is not the opposite`);
+        continue;
+      }
+
+      if (bound.params.op === "mul") {
+        assert.equal(steps[1]?.key, SOLUTION_KEY_SIGN_RULE, exercise.exerciseId);
+        const negatives = steps[1]?.slots["negatives"];
+        const size = steps[1]?.slots["size"];
+        assert.ok(negatives !== undefined && negatives.kind === "count", exercise.exerciseId);
+        assert.ok(size !== undefined && size.kind === "number", exercise.exerciseId);
+        assert.equal(negatives.value, (first.n < 0n ? 1 : 0) + (second.n < 0n ? 1 : 0), exercise.exerciseId);
+        // The size is the answer with the sign taken off, always.
+        const answer = answerOf(exercise).n;
+        assert.equal(size.value.n, answer < 0n ? -answer : answer, exercise.exerciseId);
+        assert.equal(negatives.value % 2 === 1, answer < 0n, `${exercise.exerciseId}: the sign rule is backwards`);
+        continue;
+      }
+
+      // Addition: the rung is decided by whether the signs agree, and nothing else.
+      const alike = first.n < 0n === second.n < 0n;
+      assert.equal(
+        steps[1]?.key,
+        alike ? SOLUTION_KEY_SAME_SIGNS : SOLUTION_KEY_DIFFERENT_SIGNS,
+        `${exercise.exerciseId}: the wrong strategy rung for these signs`,
+      );
+      const larger = steps[1]?.slots["larger"];
+      const smaller = steps[1]?.slots["smaller"];
+      assert.ok(larger !== undefined && larger.kind === "number", exercise.exerciseId);
+      assert.ok(smaller !== undefined && smaller.kind === "number", exercise.exerciseId);
+      assert.ok(larger.value.n >= smaller.value.n, `${exercise.exerciseId}: the sizes are named the wrong way round`);
+    }
+  }
+  // Every rung the family can emit is emitted by the level table the graph has.
+  // A rung nobody reaches is a translated string nobody needs and an untested path.
+  for (const key of [
+    SOLUTION_KEY_PAST_ZERO,
+    SOLUTION_KEY_ADD_THE_OPPOSITE,
+    SOLUTION_KEY_SAME_SIGNS,
+    SOLUTION_KEY_DIFFERENT_SIGNS,
+    SOLUTION_KEY_SIGN_RULE,
+  ]) {
+    assert.ok(seen.has(String(key)), `no level in the graph ever emits ${key}`);
+  }
+});
+
+test("the rows that answer below zero are exactly the ones promotionBlockers.ts names", () => {
+  const signedSkills = new Set<string>();
+  for (const bound of BOUND_LEVELS) {
+    const schema = signedIntFamily.answerSchema(bound.params, "free-entry");
+    if (schema.kind === "integer" && schema.signed === true) signedSkills.add(String(bound.node.id));
+    // The whole point of the flag: CG-8 asks for a *different* renderer, and that
+    // renderer is not built. A gate reading only `schema.kind` would let these rows
+    // through behind the unsigned keypad.
+    assert.equal(answerRendererIdFor(schema), "answer:integer-signed", bound.label);
+  }
+  assert.deepEqual([...signedSkills].sort(), [...SIGNED_BLOCKED_SKILLS].sort());
+
+  const declared = findRenderer("answer:integer-signed");
+  assert.ok(declared !== undefined, "the signed entry has no renderer declaration at all");
+  assert.equal(
+    declared.implemented,
+    false,
+    "answer:integer-signed is implemented — strike these rows off SIGNED_BLOCKED_SKILLS and promote them",
+  );
+  // And every one of those rows is still draft, which is what the blocker means.
+  for (const id of SIGNED_BLOCKED_SKILLS) {
+    const node = allNodes.find((candidate) => String(candidate.id) === id);
+    assert.ok(node !== undefined, `${id} is named as blocked and is not in the graph`);
+    assert.equal(node.status, "draft", `${id} is ${node.status} behind an entry surface that cannot write its answer`);
+  }
+});
+
+test("the parameter schema rejects a level with no negative in it", () => {
+  const reject = (raw: unknown, pattern: RegExp): void => {
+    const result = signedIntParamSchema.validate(raw);
+    assert.equal(result.ok, false, `expected a rejection of ${JSON.stringify(raw)}`);
+    if (!result.ok) {
+      assert.match(result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; "), pattern);
+    }
+  };
+
+  assert.equal(signedIntParamSchema.validate(params("sub", 10, "none")).ok, true);
+  reject(params("add", 10, "none"), /is not signed arithmetic/);
+  reject(params("mul", 10, "none"), /is not signed arithmetic/);
+  reject({ op: "div", maxMagnitude: 10, negatives: "first" }, /op must be one of/);
+  reject({ op: "add", maxMagnitude: 21, negatives: "first" }, /maxMagnitude must be 5/);
+  reject({ op: "add", maxMagnitude: 4, negatives: "first" }, /maxMagnitude must be 5/);
+  reject({ op: "add", maxMagnitude: 10, negatives: "left" }, /negatives must be one of/);
+});
+
+test("the difficulty contribution is exact, ordered, and never a float", () => {
+  const offset = (p: SignedIntParams): Rational => signedIntFamily.difficultyOffset(p);
+
+  assert.equal(ratToString(offset(params("add", 10, "first"))), "1/5");
+  assert.equal(ratToString(offset(params("sub", 10, "none"))), "3/20");
+  assert.equal(ratToString(offset(params("mul", 12, "both"))), "13/20");
+
+  // The ordering the coefficients claim, stated as comparisons rather than as
+  // numbers so that a coefficient change has to keep the ordering or fail here.
+  const at = (op: SignedOp, negatives: SignPlacement): Rational => offset(params(op, 10, negatives));
+  assert.equal(ratCmp(at("add", "second"), at("add", "first")), 1, "a minus in the middle is not above a minus in front");
+  assert.equal(ratCmp(at("add", "both"), at("add", "second")), 1);
+  // And both placements together are below their sum: the two do not compound.
+  assert.ok(ratCmp(at("add", "both"), ratAdd(at("add", "first"), at("add", "second"))) < 0);
+  assert.equal(ratCmp(at("sub", "first"), at("add", "first")), 1, "subtraction is not above addition");
+  assert.equal(ratCmp(at("sub", "first"), at("mul", "first")), 1, "multiplication is not below subtraction");
+});
+
+test("the same seed produces the identical item, and different seeds do not all agree", () => {
+  const p = params("sub", 20, "both");
+  const first = serializeExercise(generate(p, 11));
+  assert.equal(serializeExercise(generate(p, 11)), first);
+  assert.equal(serializeExercise(generate(p, 11)), first);
+
+  const distinct = new Set(Array.from({ length: 50 }, (_unused, i) => serializeExercise(generate(p, i + 1))));
+  assert.ok(distinct.size > 40, `50 seeds produced only ${String(distinct.size)} distinct items`);
+});
+
+test("the prompt is a spec with typed slots, and the sign rides on the value", () => {
+  const sum = generate(params("add", 10, "first"), 3);
+  assert.equal(sum.prompt.key, PROMPT_KEY_ADD);
+  assert.deepEqual(Object.keys(sum.prompt.slots).sort(), [SLOT_FIRST, SLOT_SECOND].sort());
+  // The minus is part of the number, not a separate slot and not a character in a
+  // template: a renderer writes `(−7)` from the value, and a translator never sees
+  // a sign to move.
+  assert.ok(operands(sum).first.n < 0n);
+  assert.equal(generate(params("sub", 10, "first"), 3).prompt.key, PROMPT_KEY_SUB);
+  assert.equal(generate(params("mul", 10, "first"), 3).prompt.key, PROMPT_KEY_MUL);
+});

--- a/dynawalla/packs/shared/curriculum/src/generators/timesTable/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/timesTable/constants.ts
@@ -1,0 +1,114 @@
+/**
+ * `gen.arith.times-table` constants — ids, locale keys and every difficulty
+ * coefficient, in one place.
+ *
+ * CURRICULUM.md pins the shape of the difficulty function:
+ *
+ *   b = b_skill
+ *     + 0.55·regroupings
+ *     + 0.30·(maxDigits − 2)
+ *     + 0.25·zeroBorrowThrough
+ *     + 0.20·noAnchor
+ *     − 0.35·specialCase
+ *     + repOffset + formOffset
+ *
+ * A times-table fact has no columns and no regrouping, so the same three slots
+ * `gen.arith.number-facts` spends on value-bounded facts are spent here on the
+ * three parameters that make one table fact harder than another. Each
+ * substitution is a falsifiable claim, stated:
+ *
+ * - **`0.15` per factor above the root's two** spends the `noAnchor` slot, and it
+ *   is three times the coefficient `number-facts` uses per unit of range. That is
+ *   the claim, and it is the whole shape of this family: one more in a sum is one
+ *   more count, and one more in a factor is **a whole further table** — the step
+ *   from the five times table to the six times table is not the step from `4 + 5`
+ *   to `4 + 6`. Ten steps from two to twelve then span 1.50 logits, which is about
+ *   the span the addition ladder takes from `3 + 5` to `4,003 − 87`.
+ * - **`0.15·division`** reuses `number-facts`'s subtraction coefficient unchanged,
+ *   because it is the same phenomenon: the inverse direction of a fact a child
+ *   has, at the same range. `48 ÷ 6` is `6 × 8` read backwards exactly as `15 − 8`
+ *   is `8 + 7` read backwards, and claiming a different number for it would be two
+ *   answers to one question.
+ * - **`−0.10·includeTrivial`** is `number-facts`'s `includeZero` coefficient, for
+ *   the same reason and with the same reading: not a claim that `0 × 4` is a tenth
+ *   of a logit below `2 × 4`, but that *admitting* the zero and identity facts to a
+ *   level lowers that level's expected difficulty a little, because they are a
+ *   minority of a set that is otherwise unchanged.
+ *
+ * Every coefficient is an exact rational. `0.15` as a float would make `b` — and
+ * therefore `P̂` — platform-dependent in the last bits.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const TIMES_TABLE_FAMILY = familyId("gen.arith.times-table");
+
+/**
+ * Bump whenever generated output changes for any seed. CG-16 keys its committed
+ * output hashes on this value.
+ */
+export const TIMES_TABLE_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const TIMES_TABLE_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_MUL = locKey("dw.prompt.times-table.mul");
+export const PROMPT_KEY_DIV = locKey("dw.prompt.times-table.div");
+
+export const SOLUTION_KEY_READ = locKey("dw.solution.times-table.read");
+/** Count in steps of the larger factor, the smaller factor's many times. */
+export const SOLUTION_KEY_SKIP_COUNT = locKey("dw.solution.times-table.skip-count");
+/** Any number of nothings is nothing. */
+export const SOLUTION_KEY_TIMES_ZERO = locKey("dw.solution.times-table.times-zero");
+/** One of something is that something. */
+export const SOLUTION_KEY_TIMES_ONE = locKey("dw.solution.times-table.times-one");
+/** `48 ÷ 6` as "what do you multiply 6 by to reach 48?". */
+export const SOLUTION_KEY_MISSING_FACTOR = locKey("dw.solution.times-table.missing-factor");
+/** Nothing shared between any number of hands leaves each hand with nothing. */
+export const SOLUTION_KEY_ZERO_SHARED = locKey("dw.solution.times-table.zero-shared");
+/** Sharing between one leaves the whole. */
+export const SOLUTION_KEY_DIVIDE_BY_ONE = locKey("dw.solution.times-table.divide-by-one");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.times-table.result");
+
+/**
+ * Every locale key this family can emit. The i18n gate reads this rather than
+ * grepping, so a new template that nobody translated fails loudly.
+ */
+export const TIMES_TABLE_LOC_KEYS = [
+  PROMPT_KEY_MUL,
+  PROMPT_KEY_DIV,
+  SOLUTION_KEY_READ,
+  SOLUTION_KEY_SKIP_COUNT,
+  SOLUTION_KEY_TIMES_ZERO,
+  SOLUTION_KEY_TIMES_ONE,
+  SOLUTION_KEY_MISSING_FACTOR,
+  SOLUTION_KEY_ZERO_SHARED,
+  SOLUTION_KEY_DIVIDE_BY_ONE,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+/** Prompt slot names. Stable: they are part of the translated template. */
+export const SLOT_FIRST = "first";
+export const SLOT_SECOND = "second";
+export const SLOT_DIVIDEND = "dividend";
+export const SLOT_DIVISOR = "divisor";
+export const SLOT_ANSWER = "answer";
+/** The factor counted in, and how many of those steps are taken. */
+export const SLOT_STEP = "step";
+export const SLOT_TIMES = "times";
+/** The other factor, on the two facts where one of them decides the answer. */
+export const SLOT_OTHER = "other";
+
+/** 0.15 per factor above the root's two — a whole further table each time. */
+export const COEFF_FACTOR_OVER_ROOT = rational(15n, 100n);
+/** 0.15 for the inverse direction — `number-facts`'s subtraction coefficient. */
+export const COEFF_DIVISION = rational(15n, 100n);
+/** −0.10 when the zero and identity facts are in the set. */
+export const COEFF_INCLUDE_TRIVIAL = rational(-10n, 100n);
+
+/** The table every level is measured against — the twos, the first one taught. */
+export const ROOT_MAX_FACTOR = 2;
+
+/** Free entry is the only form; the offset is stated so the contract is total. */
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/timesTable/facts.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/timesTable/facts.ts
@@ -1,0 +1,94 @@
+/**
+ * The table a level draws from, enumerated.
+ *
+ * ## Why this family enumerates
+ *
+ * The same reason `numberFacts/facts.ts` gives, and one more.
+ *
+ * The reason it shares: "the tables to five" is **thirty-five problems in the
+ * world** — not thirty-five this generator happens to reach. Enumerating them and
+ * picking one uniformly makes the level's variant space a list a test can compare
+ * against in both directions, rather than a number estimated from observed
+ * collisions.
+ *
+ * The reason it does not share: a table is a *rectangle* with one corner missing,
+ * so two independent draws would very nearly do. Very nearly is the problem. The
+ * corner is `0 × 0`, and a rejection loop around it is a stream whose length
+ * depends on what it rejected; the division set is a different rectangle again
+ * (the divisor is never zero, whatever `includeTrivial` says, because dividing by
+ * nothing is not a question with a wrong answer — it is not a question). One
+ * enumeration states both shapes once, where they can be read.
+ *
+ * ## Which facts are in, and the two that are not
+ *
+ * `0 × 4`, `4 × 1`, `0 ÷ 4` and `4 ÷ 1` are all facts and all in, on any level
+ * that asks for them. The zero property and the identity property are content —
+ * CCSS 3.OA.B.5 — and they are also the rung a child who has slid all the way
+ * down this strand lands on. Nothing about them is made harder to look more
+ * respectable.
+ *
+ * Two draws are excluded and only two:
+ *
+ * - **`0 × 0`.** Both operands decided by the same rule, with nothing on either
+ *   side to reason from. `numberFacts` excludes `0 + 0` for the same reason.
+ * - **any divisor of zero.** `12 ÷ 0` has no answer and `0 ÷ 0` has every answer;
+ *   an item whose answer does not exist is not a hard item, it is a broken one.
+ *
+ * Ordering is a plain nested loop and never a sort, so the list is byte-stable on
+ * every platform (CG-16) without a comparator to get wrong.
+ */
+
+import type { TimesTableParams } from "./params.ts";
+
+/**
+ * One fact. `first op second`, with the result the child writes.
+ *
+ * For `div` the pair is the written problem — `first` is the dividend and
+ * `second` the divisor — so that a `Fact` is always "what is on the card", and
+ * the two ops can share every consumer.
+ */
+export type Fact = {
+  readonly first: number;
+  readonly second: number;
+  readonly result: number;
+};
+
+/**
+ * Every fact this parameter set admits, in a fixed order.
+ *
+ * Never memoised. A cache keyed on a parameter object is a key-order assumption
+ * waiting to happen, and the largest list here is 169 entries.
+ */
+export function factSet(params: TimesTableParams): Fact[] {
+  const { op, maxFactor, includeTrivial } = params;
+  const out: Fact[] = [];
+  const low = includeTrivial ? 0 : 2;
+
+  if (op === "mul") {
+    for (let first = low; first <= maxFactor; first++) {
+      for (let second = low; second <= maxFactor; second++) {
+        // The one excluded draw: nothing times nothing.
+        if (first === 0 && second === 0) continue;
+        out.push({ first, second, result: first * second });
+      }
+    }
+    return out;
+  }
+
+  // The quotient runs over the level's factors and the divisor runs over the same
+  // factors from one upward, so the dividend is a product of the table and never
+  // an accident. `low` is 0 on a trivial level, which admits `0 ÷ n`; the divisor
+  // starts at `max(low, 1)`, because dividing by nothing is not a question.
+  const divisorLow = low < 1 ? 1 : low;
+  for (let quotient = low; quotient <= maxFactor; quotient++) {
+    for (let divisor = divisorLow; divisor <= maxFactor; divisor++) {
+      out.push({ first: quotient * divisor, second: divisor, result: quotient });
+    }
+  }
+  return out;
+}
+
+/** How many facts the level has. What a curriculum row declares and CG-10 checks. */
+export function factSetSize(params: TimesTableParams): number {
+  return factSet(params).length;
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/timesTable/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/timesTable/family.ts
@@ -1,0 +1,267 @@
+/**
+ * `gen.arith.times-table` — the multiplication tables and their inverses, from
+ * `0 × 1` to `144 ÷ 12`.
+ *
+ * ## Why this is not `gen.arith.multidigit-mul` with smaller parameters
+ *
+ * The same argument `gen.arith.number-facts` makes against `gen.arith.column-op`,
+ * and it lands harder here. `multidigit-mul` is bounded by a **digit count** and
+ * its smallest legal multiplicand is two digits wide; there is no parameter in it
+ * that means "the tables to five", because a digit count cannot say which table.
+ * Its worked solution is a walk over partial products and its three mal-rules are
+ * all bugs in that walk — run at one digit by one digit, the walkthrough for
+ * `6 × 8` announces a single partial product and then announces it again as the
+ * answer, and every mal-rule's `applies()` is false.
+ *
+ * What a child does with `6 × 8` is recall it, and failing that, count in sixes.
+ * That is the hint ladder here, and it is the whole reason the family exists.
+ *
+ * ## Why multiplication and division are one family
+ *
+ * `48 ÷ 6` is not a procedure at this size; it is `6 × 8` read backwards, and the
+ * strategy rung says so in as many words. One family means one closed set, one
+ * enumeration and one uniformity argument covering both directions, and it means
+ * a level table cannot accidentally claim a division level reaching facts its
+ * multiplication sibling does not have. `gen.arith.long-div` owns division the
+ * moment it stops being recall and becomes a column procedure, which is exactly
+ * where `divisorDigits` starts to mean something.
+ *
+ * ## No mal-rules, on purpose
+ *
+ * Every buggy procedure in `malrules/` is a bug in a written algorithm.
+ * CURRICULUM.md names `mis.mul.makes-bigger` for this domain, and it is a real and
+ * well-evidenced belief — but its home is an item where multiplying *can* make a
+ * number smaller, which is a fraction or a decimal, and a whole-number table never
+ * poses one. The documented error at this size is a retrieval slip: the
+ * neighbouring fact, or a skip-count that lost a step. Shipping either as a
+ * distractor would be a bug this program invented rather than one it has evidence
+ * for, which `README.md` forbids outright. The rows declare `misconceptions: []`
+ * and a wrong answer routes to the worked example, which is the honest outcome.
+ *
+ * ## No array picture
+ *
+ * The array model is the right representation for `6 × 8` and it is not declared
+ * here, because nothing in this repository draws a representation and a card whose
+ * question is a picture nobody draws is a blank card. `REP_GEAR_TRAIN` and an
+ * array both wait on the same pack renderer. The numerals are a complete question
+ * without them; a picture would have been a scaffold, not the content.
+ */
+
+import { eq as ratEq, mul as ratMul, mul, rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { add as ratAdd } from "../../math/rational.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { countSlot, numberSlot } from "../shared/slots.ts";
+import {
+  COEFF_DIVISION,
+  COEFF_FACTOR_OVER_ROOT,
+  COEFF_INCLUDE_TRIVIAL,
+  FORM_OFFSET_FREE_ENTRY,
+  PROMPT_KEY_DIV,
+  PROMPT_KEY_MUL,
+  ROOT_MAX_FACTOR,
+  SLOT_ANSWER,
+  SLOT_DIVIDEND,
+  SLOT_DIVISOR,
+  SLOT_FIRST,
+  SLOT_OTHER,
+  SLOT_SECOND,
+  SLOT_STEP,
+  SLOT_TIMES,
+  SOLUTION_KEY_DIVIDE_BY_ONE,
+  SOLUTION_KEY_MISSING_FACTOR,
+  SOLUTION_KEY_READ,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SKIP_COUNT,
+  SOLUTION_KEY_TIMES_ONE,
+  SOLUTION_KEY_TIMES_ZERO,
+  SOLUTION_KEY_ZERO_SHARED,
+  TIMES_TABLE_FAMILY,
+  TIMES_TABLE_FAMILY_REV,
+  TIMES_TABLE_FORMS,
+} from "./constants.ts";
+import { factSet } from "./facts.ts";
+import type { Fact } from "./facts.ts";
+import { timesTableParamSchema } from "./params.ts";
+import type { TimesTableParams } from "./params.ts";
+
+/**
+ * The answer field's width, which is the *level's* width and never this item's.
+ *
+ * Sizing the field to the answer would tell a child how many digits it has
+ * (ARCHITECTURE L3), and on the twelve times table that is most of the question:
+ * a two-cell field on `12 × 9` rules out 108 before the child has thought about it.
+ * The widest product a level can reach is `maxFactor²`; the widest quotient is
+ * `maxFactor`, because the level draws the quotient and multiplies back.
+ */
+function answerDigits(params: TimesTableParams): number {
+  const widest = params.op === "mul" ? params.maxFactor * params.maxFactor : params.maxFactor;
+  return String(widest).length;
+}
+
+function schemaFor(params: TimesTableParams): AnswerSchema {
+  return { kind: "integer", digits: answerDigits(params), decimalPlaces: 0 };
+}
+
+function promptSlots(params: TimesTableParams, fact: Fact): Readonly<Record<string, PromptSlot>> {
+  return params.op === "mul"
+    ? { [SLOT_FIRST]: numberSlot(BigInt(fact.first)), [SLOT_SECOND]: numberSlot(BigInt(fact.second)) }
+    : { [SLOT_DIVIDEND]: numberSlot(BigInt(fact.first)), [SLOT_DIVISOR]: numberSlot(BigInt(fact.second)) };
+}
+
+/**
+ * The hint ladder: read the fact, apply the strategy, state the answer.
+ *
+ * The middle rung is the strategy, not a restatement of the arithmetic.
+ *
+ * For multiplication it is skip counting **in steps of the larger factor**, taken
+ * the smaller factor's many times: `3 × 8` is three eights and not eight threes,
+ * because a child who counts in threes eight times has eight chances to lose the
+ * thread. That is the same decision `number-facts` makes when it counts on from
+ * the larger addend, and for the same reason.
+ *
+ * For division it is the missing factor, in as many words: `48 ÷ 6` is "what do
+ * you multiply six by to reach forty-eight". A repeated-subtraction rung would be
+ * the other correct reading and is the slower habit; the strategy this row is
+ * teaching is that the table is the answer.
+ *
+ * The four facts decided by one operand alone get their own rung each, because
+ * counting in steps of nothing, and counting in steps of anything exactly once,
+ * are both nonsense dressed as a strategy.
+ */
+function solutionFor(params: TimesTableParams, fact: Fact): SolutionStep[] {
+  const read: SolutionStep = { key: SOLUTION_KEY_READ, slots: promptSlots(params, fact) };
+  const result: SolutionStep = {
+    key: SOLUTION_KEY_RESULT,
+    slots: { [SLOT_ANSWER]: numberSlot(BigInt(fact.result)) },
+  };
+
+  if (params.op === "mul") {
+    if (fact.first === 0 || fact.second === 0) {
+      const other = fact.first === 0 ? fact.second : fact.first;
+      return [read, { key: SOLUTION_KEY_TIMES_ZERO, slots: { [SLOT_OTHER]: numberSlot(BigInt(other)) } }, result];
+    }
+    if (fact.first === 1 || fact.second === 1) {
+      const other = fact.first === 1 ? fact.second : fact.first;
+      return [read, { key: SOLUTION_KEY_TIMES_ONE, slots: { [SLOT_OTHER]: numberSlot(BigInt(other)) } }, result];
+    }
+    const step = fact.first > fact.second ? fact.first : fact.second;
+    const times = fact.first > fact.second ? fact.second : fact.first;
+    return [
+      read,
+      {
+        key: SOLUTION_KEY_SKIP_COUNT,
+        slots: { [SLOT_STEP]: numberSlot(BigInt(step)), [SLOT_TIMES]: countSlot(times) },
+      },
+      result,
+    ];
+  }
+
+  if (fact.first === 0) {
+    return [read, { key: SOLUTION_KEY_ZERO_SHARED, slots: { [SLOT_DIVISOR]: numberSlot(BigInt(fact.second)) } }, result];
+  }
+  if (fact.second === 1) {
+    return [
+      read,
+      { key: SOLUTION_KEY_DIVIDE_BY_ONE, slots: { [SLOT_DIVIDEND]: numberSlot(BigInt(fact.first)) } },
+      result,
+    ];
+  }
+  return [
+    read,
+    {
+      key: SOLUTION_KEY_MISSING_FACTOR,
+      slots: {
+        [SLOT_DIVISOR]: numberSlot(BigInt(fact.second)),
+        [SLOT_DIVIDEND]: numberSlot(BigInt(fact.first)),
+      },
+    },
+    result,
+  ];
+}
+
+export const timesTableFamily: GeneratorFamily<TimesTableParams> = {
+  family: TIMES_TABLE_FAMILY,
+  familyRev: TIMES_TABLE_FAMILY_REV,
+  paramSchema: timesTableParamSchema,
+  forms: TIMES_TABLE_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: TimesTableParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: TimesTableParams): Rational {
+    let b = mul(COEFF_FACTOR_OVER_ROOT, rational(BigInt(params.maxFactor - ROOT_MAX_FACTOR)));
+    if (params.op === "div") b = ratAdd(b, COEFF_DIVISION);
+    if (params.includeTrivial) b = ratAdd(b, COEFF_INCLUDE_TRIVIAL);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<TimesTableParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(TIMES_TABLE_FAMILY, TIMES_TABLE_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+    const form = chooseForm(forms, TIMES_TABLE_FORMS, rng);
+
+    const facts = factSet(params);
+    if (facts.length === 0) {
+      // The schema rejects every combination that empties the table, so reaching
+      // here is a disagreement between the validator and the enumeration — the one
+      // bug class a family of this shape is most likely to have.
+      throw new InfeasibleLevelError(`no fact satisfies the parameters of ${exerciseId}`);
+    }
+    const fact = rng.pick(facts);
+
+    // The enumeration and exact rational arithmetic agree, asserted on every call.
+    // `facts.ts` computes the result while it builds the pair, so this is the one
+    // place the two derivations meet — and both readings are checked in the
+    // *multiplicative* direction, which for a division item is the inverse of what
+    // the child is asked. A quotient that did not multiply back would be a card
+    // with a wrong answer on it, and it would be wrong identically on every device.
+    const product = ratMul(
+      rational(BigInt(params.op === "mul" ? fact.first : fact.result)),
+      rational(BigInt(fact.second)),
+    );
+    const stated = rational(BigInt(params.op === "mul" ? fact.result : fact.first));
+    if (!ratEq(product, stated)) {
+      throw new InfeasibleLevelError(`the table disagreed with exact arithmetic on ${exerciseId}`);
+    }
+
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: TIMES_TABLE_FAMILY,
+      familyRev: TIMES_TABLE_FAMILY_REV,
+      form,
+      prompt: {
+        key: params.op === "mul" ? PROMPT_KEY_MUL : PROMPT_KEY_DIV,
+        slots: promptSlots(params, fact),
+      },
+      schema: schemaFor(params),
+      answer: { canonical: { kind: "integer", value: rational(BigInt(fact.result)) }, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, fact),
+    };
+
+    return { ...base, distractors: distractorsFor(TIMES_TABLE_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/timesTable/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/timesTable/params.ts
@@ -1,0 +1,82 @@
+/**
+ * `gen.arith.times-table` parameters and their validator.
+ *
+ * A table fact is bounded by a **factor**, not by a digit count and not by a
+ * value. "Multiply a one-digit number by a one-digit number" is `9 × 8` as readily
+ * as `2 × 3`, and there is no total that means "the tables up to five" — `4 × 3`
+ * and `12 × 1` reach the same twelve and are not the same content. `maxFactor` is
+ * therefore the one quantity a level table names, and it is the same quantity for
+ * both directions: `6 × 8` and `48 ÷ 6` are the same fact read two ways, exactly
+ * as `7 + 8` and `15 − 8` are in `gen.arith.number-facts`.
+ *
+ * The validator rejects the two combinations that would make a level either empty
+ * of content or two skills at once, so `generate()` can treat a thin fact set as a
+ * bug rather than as input it has to guess about.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type TimesTableOp = "mul" | "div";
+
+export const TIMES_TABLE_OPS: readonly TimesTableOp[] = ["mul", "div"];
+
+export type TimesTableParams = {
+  readonly op: TimesTableOp;
+  /**
+   * The largest factor the level reaches. For `mul` both factors are drawn up to
+   * it; for `div` the divisor and the quotient are, which makes the dividend as
+   * large as `maxFactor²`.
+   */
+  readonly maxFactor: number;
+  /**
+   * Admit the facts that are decided by one operand alone: `0 × n`, `n × 1`,
+   * `0 ÷ n` and `n ÷ 1`.
+   */
+  readonly includeTrivial: boolean;
+};
+
+/** The twos: the first table taught, and the smallest level worth posing. */
+export const MIN_MAX_FACTOR = 2;
+/** England mandates the tables to 12 × 12 by Y4, and nothing needs 13. */
+export const MAX_MAX_FACTOR = 12;
+/**
+ * Below this, a level with the trivial facts taken out has fewer than nine
+ * problems in it — `{2,3} × {2,3}` is four — and a level of four items is a
+ * flashcard, not a rung.
+ */
+export const MIN_UNTRIVIAL_FACTOR = 4;
+/**
+ * The zero and identity facts belong at the bottom of the ladder. A twelve times
+ * table that also draws `0 × 11` is two skills sharing one mastery record: the
+ * child who knows the zero property and not the twelves reads as half-fluent at
+ * both.
+ */
+export const MAX_TRIVIAL_FACTOR = 5;
+
+export const timesTableParamSchema: ParamSchema<TimesTableParams> = {
+  describe: "{ op: 'mul'|'div', maxFactor: 2..12, includeTrivial: boolean }",
+
+  validate(raw: unknown): ParamResult<TimesTableParams> {
+    const read = reader(raw);
+    const op = read.choice<TimesTableOp>("op", TIMES_TABLE_OPS);
+    const maxFactor = read.int("maxFactor", MIN_MAX_FACTOR, MAX_MAX_FACTOR);
+    const includeTrivial = read.boolean("includeTrivial");
+
+    if (read.clean()) {
+      if (!includeTrivial && maxFactor < MIN_UNTRIVIAL_FACTOR) {
+        read.reject(
+          "maxFactor",
+          `a level without the trivial facts needs factors to at least ${String(MIN_UNTRIVIAL_FACTOR)}`,
+        );
+      }
+      if (includeTrivial && maxFactor > MAX_TRIVIAL_FACTOR) {
+        read.reject(
+          "includeTrivial",
+          `the zero and identity facts belong below the ${String(MAX_TRIVIAL_FACTOR)} times table`,
+        );
+      }
+    }
+    return read.finish({ op, maxFactor, includeTrivial });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/timesTable/timesTable.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/timesTable/timesTable.test.ts
@@ -1,0 +1,466 @@
+/**
+ * `gen.arith.times-table`, held to what a generator binding has to prove before a
+ * row may be served to a child.
+ *
+ * The whole-graph sweep in `../families.property.test.ts` already runs every level
+ * of every row for schema defects, determinism, checker agreement and timing. What
+ * it cannot do is know what *this* family claims, and the claims are the point:
+ *
+ * 1. **Every stated answer is correct, checked in the other direction.** Never by
+ *    re-running `first * second`, which is what the generator did — that would be
+ *    the same expression twice and would agree with any consistent bug in it. A
+ *    multiplication is checked by **repeated addition** of exact rationals, which
+ *    is what multiplication means and shares no code with it; a division is checked
+ *    by multiplying the quotient back.
+ * 2. **The table is closed, and the closure is exact in both directions.** The
+ *    generator reaches every fact the level admits and never one it does not, and
+ *    it is asserted against an enumeration written here rather than against
+ *    `factSet` itself. This is what `GeneratorBinding.closedFactSet` and CG-10's
+ *    substituted check rest on.
+ * 3. **The draw is uniform over that set**, by χ². The closure test cannot see a
+ *    generator that reaches all 121 facts and asks for `2 × 2` twenty times as
+ *    often as `9 × 8`, and a child would meet that as a level that will not stop
+ *    asking the easy ones.
+ * 4. **Every item is inside the band the row declares.** No factor above the
+ *    level's ceiling, no trivial fact on a level that excludes them, and — the one
+ *    that has no equivalent in any other family here — **never a divisor of zero**.
+ * 5. **`48,826 × 82,726` is expressible**, which is a claim about `multidigit-mul`
+ *    and is asserted at the bottom of this file because this is the change that
+ *    made it true.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  add as ratAdd,
+  cmp as ratCmp,
+  eq as ratEq,
+  mul as ratMul,
+  rational,
+  toString as ratToString,
+} from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { skillId } from "../../types/ids.ts";
+import { schemaDefect } from "../../types/answer.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { serializeExercise } from "../../serialize.ts";
+import { allNodes } from "../../graph/graph.ts";
+import { chiSquareUniform } from "../shared/uniformity.ts";
+import { multidigitMulFamily } from "../multidigitMul/family.ts";
+import { multidigitMulParamSchema } from "../multidigitMul/params.ts";
+import { timesTableFamily } from "./family.ts";
+import { factSet } from "./facts.ts";
+import { timesTableParamSchema } from "./params.ts";
+import type { TimesTableParams } from "./params.ts";
+import {
+  PROMPT_KEY_DIV,
+  PROMPT_KEY_MUL,
+  SLOT_DIVIDEND,
+  SLOT_DIVISOR,
+  SLOT_FIRST,
+  SLOT_SECOND,
+  SOLUTION_KEY_MISSING_FACTOR,
+  SOLUTION_KEY_SKIP_COUNT,
+  TIMES_TABLE_FAMILY,
+} from "./constants.ts";
+
+const SKILL = skillId("dw.mul.facts.tables-within-five");
+const FORMS = ["free-entry"];
+
+/** Enough draws that a set of 121 is collected several times over. */
+const SEEDS = 4000;
+
+function params(op: "mul" | "div", maxFactor: number, includeTrivial = false): TimesTableParams {
+  return { op, maxFactor, includeTrivial };
+}
+
+function generate(p: TimesTableParams, seed: number, level = 0): Exercise {
+  return timesTableFamily.generate({ skillId: SKILL, level, seed, params: p, forms: FORMS });
+}
+
+/** The written operands, read back out of the public prompt contract. */
+function operands(exercise: Exercise): { first: Rational; second: Rational } {
+  const mul = exercise.prompt.key === PROMPT_KEY_MUL;
+  const first = exercise.prompt.slots[mul ? SLOT_FIRST : SLOT_DIVIDEND];
+  const second = exercise.prompt.slots[mul ? SLOT_SECOND : SLOT_DIVISOR];
+  assert.ok(first !== undefined && first.kind === "number", exercise.exerciseId);
+  assert.ok(second !== undefined && second.kind === "number", exercise.exerciseId);
+  return { first: first.value, second: second.value };
+}
+
+function answerOf(exercise: Exercise): Rational {
+  const answer = exercise.answer.canonical;
+  assert.equal(answer.kind, "integer", exercise.exerciseId);
+  return answer.kind === "integer" ? answer.value : rational(0n);
+}
+
+/** Every level bound by a `gen.arith.times-table` row, with its declared size. */
+const BOUND_LEVELS = allNodes
+  .filter((node) => node.generator.family === TIMES_TABLE_FAMILY)
+  .flatMap((node) =>
+    node.generator.params.map((raw, level) => {
+      const validated = timesTableParamSchema.validate(raw);
+      assert.ok(validated.ok, `${node.id} L${String(level)} params rejected`);
+      return {
+        label: `${node.id} L${String(level)}`,
+        node,
+        level,
+        params: validated.ok ? validated.value : params("mul", 2, true),
+        declared: node.generator.closedFactSet?.[level],
+      };
+    }),
+  );
+
+test("the graph binds this family, and every bound level declares its closed set", () => {
+  assert.ok(BOUND_LEVELS.length >= 10, `only ${String(BOUND_LEVELS.length)} bound level(s)`);
+  // Both directions of the binding, and the second is the one that matters: a
+  // family bound by nothing is dead code, and a level without `closedFactSet`
+  // falls back to CG-10's floor of 975, which no table can reach.
+  for (const bound of BOUND_LEVELS) {
+    assert.ok(bound.declared !== undefined, `${bound.label} declares no closedFactSet`);
+  }
+  const domains = new Set(BOUND_LEVELS.map((bound) => bound.node.domain));
+  assert.deepEqual([...domains].sort(), ["div", "mul"], "one family, both directions, or the sharing is a claim only");
+  process.stdout.write(`# times-table: ${String(BOUND_LEVELS.length)} bound level(s)\n`);
+});
+
+test("every stated answer is correct, re-derived from the prompt and never by multiplying again", () => {
+  let checked = 0;
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+      const answer = answerOf(exercise);
+
+      if (bound.params.op === "mul") {
+        // Repeated addition: `first` added to itself `second` times. That is what
+        // multiplication *is*, and it shares no line of code with the `*` the
+        // generator used, so a consistent bug in one cannot hide in the other.
+        let summed = rational(0n);
+        for (let i = 0; i < Number(second.n); i++) summed = ratAdd(summed, first);
+        assert.ok(
+          ratEq(summed, answer),
+          `${exercise.exerciseId}: ${ratToString(first)} added ${ratToString(second)} times is ` +
+            `${ratToString(summed)}, not ${ratToString(answer)}`,
+        );
+      } else {
+        // The quotient multiplied back is the dividend, and the divisor is never
+        // zero — the two facts that make a division item well posed.
+        assert.notEqual(second.n, 0n, `${exercise.exerciseId}: a divisor of zero`);
+        assert.ok(
+          ratEq(ratMul(answer, second), first),
+          `${exercise.exerciseId}: ${ratToString(answer)} × ${ratToString(second)} is not ${ratToString(first)}`,
+        );
+      }
+      checked += 1;
+    }
+  }
+  process.stdout.write(`# times-table: ${String(checked)} answers re-derived\n`);
+});
+
+test("every item is inside the band its level declares, and none is degenerate", () => {
+  for (const bound of BOUND_LEVELS) {
+    const { maxFactor, includeTrivial, op } = bound.params;
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const first = Number(operands(exercise).first.n);
+      const second = Number(operands(exercise).second.n);
+      const answer = Number(answerOf(exercise).n);
+
+      if (op === "mul") {
+        assert.ok(first <= maxFactor && second <= maxFactor, `${exercise.exerciseId}: a factor above the level`);
+        assert.ok(first >= 0 && second >= 0, `${exercise.exerciseId}: a negative factor`);
+        // The one draw this family excludes, named so a widening cannot let it back
+        // in unnoticed: nothing times nothing has no side to reason from.
+        assert.ok(first + second > 0, `${exercise.exerciseId}: both factors are zero`);
+        if (!includeTrivial) {
+          assert.ok(first >= 2 && second >= 2, `${exercise.exerciseId}: a trivial factor on a level without them`);
+        }
+      } else {
+        assert.ok(second >= 1, `${exercise.exerciseId}: a divisor of zero`);
+        assert.ok(second <= maxFactor && answer <= maxFactor, `${exercise.exerciseId}: outside the level's table`);
+        assert.ok(first <= maxFactor * maxFactor, `${exercise.exerciseId}: a dividend outside the table`);
+        if (!includeTrivial) {
+          assert.ok(second >= 2 && answer >= 2, `${exercise.exerciseId}: a trivial quotient on a level without them`);
+        }
+      }
+
+      // The answer field is the level's width, never this item's: a field cut to
+      // fit would say how many digits the answer has, which on `12 × 9` rules out
+      // 108 before the child has thought about it.
+      assert.equal(schemaDefect(exercise.schema), null, exercise.exerciseId);
+      assert.ok(
+        String(answer).length <= (exercise.schema.kind === "integer" ? exercise.schema.digits : 0),
+        `${exercise.exerciseId}: the answer does not fit the field`,
+      );
+      assert.equal(exercise.schema.kind === "integer" ? exercise.schema.signed : true, undefined, exercise.exerciseId);
+    }
+  }
+});
+
+/**
+ * The closure, against an enumeration written here and not imported.
+ *
+ * `factSet` is the generator's own list, so asserting the generator against it
+ * would prove only that the family calls the function it calls. This walks every
+ * pair of numbers a level could conceivably involve and decides membership from
+ * the level's *stated* rules, then compares the two sets whole.
+ */
+function independentSet(p: TimesTableParams): Set<string> {
+  const out = new Set<string>();
+  const low = p.includeTrivial ? 0 : 2;
+  for (let a = 0; a <= 12; a++) {
+    for (let b = 0; b <= 12; b++) {
+      if (a < low || b < low || a > p.maxFactor || b > p.maxFactor) continue;
+      if (p.op === "mul") {
+        if (a === 0 && b === 0) continue;
+        out.add(`${String(a)}x${String(b)}`);
+        continue;
+      }
+      // `a` is the quotient and `b` the divisor; the written problem is `ab ÷ b`.
+      if (b === 0) continue;
+      out.add(`${String(a * b)}/${String(b)}`);
+    }
+  }
+  return out;
+}
+
+test("the table is closed, the generator reaches exactly it, and the draw is uniform", () => {
+  const lines: string[] = [];
+  for (const bound of BOUND_LEVELS) {
+    const expected = independentSet(bound.params);
+    assert.equal(
+      factSet(bound.params).length,
+      expected.size,
+      `${bound.label}: factSet has ${String(factSet(bound.params).length)} facts, the rules give ${String(expected.size)}`,
+    );
+    assert.equal(
+      bound.declared,
+      expected.size,
+      `${bound.label}: the row declares a closed set of ${String(bound.declared)} and the mathematics has ${String(expected.size)}`,
+    );
+
+    const counts = new Map<string, number>([...expected].map((fact) => [fact, 0]));
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      const { first, second } = operands(exercise);
+      const key =
+        bound.params.op === "mul"
+          ? `${first.n.toString()}x${second.n.toString()}`
+          : `${first.n.toString()}/${second.n.toString()}`;
+      assert.ok(counts.has(key), `${bound.label}: the generator reached ${key}, which is outside the closed set`);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+
+    const observed = [...counts.values()];
+    const missing = [...counts].filter(([, count]) => count === 0).map(([fact]) => fact);
+    assert.deepEqual(missing.sort(), [], `${bound.label}: the generator never reached a fact in the closed set`);
+
+    const uniformity = chiSquareUniform(observed);
+    assert.ok(
+      uniformity.uniform,
+      `${bound.label}: the draw is not uniform over its own set — χ² = ${ratToString(uniformity.chiSquare)} ` +
+        `on ${String(uniformity.degreesOfFreedom)} degrees of freedom`,
+    );
+    lines.push(
+      `#   ${bound.label}: ${String(expected.size)} facts, all reached in ${String(SEEDS)} seeds, ` +
+        `χ² ≈ ${String(Number(uniformity.chiSquare.n) / Number(uniformity.chiSquare.d))} on ${String(uniformity.degreesOfFreedom)} df`,
+    );
+  }
+  process.stdout.write(`# closed tables:\n${lines.join("\n")}\n`);
+});
+
+test("the root of the strand is reachable: 0 x 1, 1 x n, 0 ÷ n and n ÷ 1 are all drawn", () => {
+  // The graph's own level 0, not a fixture written here. A row edited to start at
+  // `2 × 2` — by dropping `includeTrivial`, which is one word — has to fail this,
+  // and a test carrying its own parameters would go on passing while the strand's
+  // bottom rung quietly moved up.
+  const rowLevel = (id: string, level: number): TimesTableParams => {
+    const bound = BOUND_LEVELS.find((candidate) => String(candidate.node.id) === id && candidate.level === level);
+    assert.ok(bound !== undefined, `the graph has no level ${String(level)} of ${id}`);
+    return bound.params;
+  };
+
+  const drawn = new Set<string>();
+  for (let seed = 1; seed <= 200; seed++) {
+    const { first, second } = operands(generate(rowLevel("dw.mul.facts.tables-within-five", 0), seed));
+    drawn.add(`${first.n.toString()}x${second.n.toString()}`);
+  }
+  for (const fact of ["0x1", "1x0", "1x1", "0x2", "2x0", "1x2", "2x1", "2x2"]) {
+    assert.ok(drawn.has(fact), `the root level never draws ${fact}`);
+  }
+  assert.ok(!drawn.has("0x0"), "the root level draws a question with nothing on either side");
+
+  const drawnDiv = new Set<string>();
+  for (let seed = 1; seed <= 400; seed++) {
+    const { first, second } = operands(generate(rowLevel("dw.div.facts.division-facts", 0), seed, 0));
+    drawnDiv.add(`${first.n.toString()}/${second.n.toString()}`);
+  }
+  for (const fact of ["0/1", "0/5", "3/1", "5/1", "25/5"]) {
+    assert.ok(drawnDiv.has(fact), `the entry division level never draws ${fact}`);
+  }
+  // Every divisor of zero, on every level. The one item whose answer does not
+  // exist, and the reason the division enumeration is not a plain rectangle.
+  for (const bound of BOUND_LEVELS) {
+    if (bound.params.op !== "div") continue;
+    for (const fact of factSet(bound.params)) {
+      assert.notEqual(fact.second, 0, `${bound.label}: the closed set contains a division by zero`);
+    }
+  }
+});
+
+test("the walkthrough's strategy rung is the strategy, and its last rung is the answer", () => {
+  let skipCounts = 0;
+  let missingFactors = 0;
+  for (const bound of BOUND_LEVELS) {
+    for (let seed = 1; seed <= 400; seed++) {
+      const exercise = generate(bound.params, seed, bound.level);
+      assert.equal(exercise.solution.length, 3, exercise.exerciseId);
+      const middle = exercise.solution[1];
+      const last = exercise.solution[2];
+      assert.ok(middle !== undefined && last !== undefined);
+
+      const stated = last.slots["answer"];
+      assert.ok(stated !== undefined && stated.kind === "number", exercise.exerciseId);
+      assert.ok(ratEq(stated.value, answerOf(exercise)), `${exercise.exerciseId}: the ladder ends elsewhere`);
+
+      const { first, second } = operands(exercise);
+      if (middle.key === SOLUTION_KEY_SKIP_COUNT) {
+        // Count in steps of the *larger* factor. Counting in threes eight times is
+        // eight chances to lose the thread, and a rung that taught it would be
+        // teaching the slower habit in the right place.
+        const step = middle.slots["step"];
+        const times = middle.slots["times"];
+        assert.ok(step !== undefined && step.kind === "number", exercise.exerciseId);
+        assert.ok(times !== undefined && times.kind === "count", exercise.exerciseId);
+        assert.ok(step.value.n >= BigInt(times.value), `${exercise.exerciseId}: counts in steps of the smaller factor`);
+        assert.ok(
+          ratEq(ratMul(step.value, rational(BigInt(times.value))), answerOf(exercise)),
+          exercise.exerciseId,
+        );
+        assert.equal(step.value.n * BigInt(times.value), first.n * second.n, exercise.exerciseId);
+        skipCounts += 1;
+        continue;
+      }
+      if (middle.key === SOLUTION_KEY_MISSING_FACTOR) {
+        const divisor = middle.slots["divisor"];
+        const dividend = middle.slots["dividend"];
+        assert.ok(divisor !== undefined && divisor.kind === "number", exercise.exerciseId);
+        assert.ok(dividend !== undefined && dividend.kind === "number", exercise.exerciseId);
+        assert.ok(ratEq(divisor.value, second) && ratEq(dividend.value, first), exercise.exerciseId);
+        missingFactors += 1;
+      }
+    }
+  }
+  assert.ok(skipCounts > 0 && missingFactors > 0, "one of the two strategies never fires");
+  process.stdout.write(
+    `# times-table: ${String(skipCounts)} skip-count rung(s), ${String(missingFactors)} missing-factor rung(s)\n`,
+  );
+});
+
+test("the parameter schema rejects the combinations that would be two skills or a flashcard", () => {
+  const reject = (raw: unknown, pattern: RegExp): void => {
+    const result = timesTableParamSchema.validate(raw);
+    assert.equal(result.ok, false, `expected a rejection of ${JSON.stringify(raw)}`);
+    if (!result.ok) {
+      assert.match(result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; "), pattern);
+    }
+  };
+
+  assert.equal(timesTableParamSchema.validate(params("mul", 2, true)).ok, true);
+  assert.equal(timesTableParamSchema.validate(params("div", 12)).ok, true);
+
+  reject(params("mul", 3), /needs factors to at least 4/);
+  reject(params("div", 12, true), /belong below the 5 times table/);
+  reject({ op: "plus", maxFactor: 5, includeTrivial: true }, /op must be one of/);
+  reject({ op: "mul", maxFactor: 13, includeTrivial: false }, /maxFactor must be 2/);
+  reject({ op: "mul", maxFactor: 1, includeTrivial: true }, /maxFactor must be 2/);
+  reject({ op: "mul", maxFactor: 5 }, /includeTrivial must be a boolean/);
+});
+
+test("the difficulty contribution is exact, ordered, and never a float", () => {
+  const offset = (p: TimesTableParams): Rational => timesTableFamily.difficultyOffset(p);
+
+  // Hundredths of a logit, exactly. A float `0.15` would make the last bits of
+  // every `b` in this family platform-dependent.
+  assert.equal(ratToString(offset(params("mul", 2, true))), "-1/10");
+  assert.equal(ratToString(offset(params("mul", 2))), "0");
+  assert.equal(ratToString(offset(params("mul", 12))), "3/2");
+  assert.equal(ratToString(offset(params("div", 12))), "33/20");
+
+  // The ordering the coefficients claim: the inverse direction is harder at the
+  // same range, and a whole further table is harder than admitting the trivial
+  // facts is easy.
+  assert.equal(ratCmp(offset(params("div", 9)), offset(params("mul", 9))), 1);
+  assert.equal(ratCmp(offset(params("mul", 6)), offset(params("mul", 5))), 1);
+  assert.equal(ratCmp(offset(params("mul", 5, true)), offset(params("mul", 5))), -1);
+});
+
+test("the same seed produces the identical item, and different seeds do not all agree", () => {
+  const p = params("mul", 12);
+  const first = serializeExercise(generate(p, 7));
+  assert.equal(serializeExercise(generate(p, 7)), first);
+  assert.equal(serializeExercise(generate(p, 7)), first);
+
+  const distinct = new Set(Array.from({ length: 50 }, (_unused, i) => serializeExercise(generate(p, i + 1))));
+  assert.ok(distinct.size > 20, `50 seeds produced only ${String(distinct.size)} distinct items`);
+});
+
+test("the prompt is a spec with typed slots, never a rendered sentence", () => {
+  const product = generate(params("mul", 12), 3);
+  assert.equal(product.prompt.key, PROMPT_KEY_MUL);
+  assert.deepEqual(Object.keys(product.prompt.slots).sort(), [SLOT_FIRST, SLOT_SECOND].sort());
+
+  const quotient = generate(params("div", 12), 3);
+  assert.equal(quotient.prompt.key, PROMPT_KEY_DIV);
+  assert.deepEqual(Object.keys(quotient.prompt.slots).sort(), [SLOT_DIVIDEND, SLOT_DIVISOR].sort());
+});
+
+/**
+ * The program's stated ceiling, asserted as an item rather than as an intention.
+ *
+ * `48,826 × 82,726` was not merely unauthored before this change: `multidigitMul`
+ * capped `multiplierDigits` at three, so no parameter object could describe it and
+ * the schema rejected the level table outright. This checks the three things that
+ * had to become true — the parameters validate, the level draws items of that
+ * shape, and the product is exact at a size where a double would have stopped
+ * being one (`48,826 × 82,726` is 4,039,179,676, comfortably inside a double, but
+ * the level's widest is `99,999 × 99,999` and a product of that size is exactly
+ * where a program that reached for floats would begin to be quietly wrong).
+ */
+test("48,826 × 82,726 is expressible, and the widest level's products are exact", () => {
+  const wide = { shape: "general" as const, digits: 5, multiplierDigits: 5, carries: true };
+  const validated = multidigitMulParamSchema.validate(wide);
+  assert.ok(validated.ok, "a five-by-five multiplication is not a legal level");
+
+  const top = allNodes.find((node) => String(node.id) === "dw.mul.multidigit.long-multiplication");
+  assert.ok(top !== undefined, "the graph has no long-multiplication row");
+  assert.deepEqual(top.generator.params[top.generator.params.length - 1], wide, "its top level is not five by five");
+
+  let widest = 0n;
+  for (let seed = 1; seed <= 500; seed++) {
+    const exercise = multidigitMulFamily.generate({
+      skillId: top.id,
+      level: 2,
+      seed,
+      params: validated.ok ? validated.value : wide,
+      forms: ["free-entry"],
+    });
+    const slots = exercise.prompt.slots;
+    const a = slots["top"];
+    const b = slots["bottom"];
+    assert.ok(a !== undefined && a.kind === "number" && b !== undefined && b.kind === "number");
+    assert.equal(a.value.n.toString().length, 5, exercise.exerciseId);
+    assert.equal(b.value.n.toString().length, 5, exercise.exerciseId);
+    const answer = exercise.answer.canonical;
+    assert.equal(answer.kind, "integer");
+    if (answer.kind === "integer") {
+      assert.ok(ratEq(ratMul(a.value, b.value), answer.value), `${exercise.exerciseId}: the product is not exact`);
+      if (answer.value.n > widest) widest = answer.value.n;
+    }
+  }
+  // The founder's number, as arithmetic this package can do exactly.
+  assert.equal((48826n * 82726n).toString(), "4039179676");
+  process.stdout.write(`# long multiplication: widest product drawn in 500 seeds is ${widest.toString()}\n`);
+});

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
@@ -60,8 +60,18 @@ const CAP_ADD_CARRY = capabilityTag("cap.arith.add-carry");
  */
 const CAP_SUMS_WITHIN_TEN = capabilityTag("cap.arith.sums-within-ten");
 const CAP_DIFFERENCES_WITHIN_TEN = capabilityTag("cap.arith.differences-within-ten");
-const CAP_SUMS_ACROSS_TEN = capabilityTag("cap.arith.sums-across-ten");
-const CAP_DIFFERENCES_ACROSS_TEN = capabilityTag("cap.arith.differences-across-ten");
+/**
+ * Exported, unlike its three siblings, because the multiplicative strand consumes
+ * it: a carry out of a single-digit multiplication pass is a sum across ten, and
+ * `dw.mul.multidigit.times-one-digit` says so rather than implying it.
+ */
+export const CAP_SUMS_ACROSS_TEN = capabilityTag("cap.arith.sums-across-ten");
+/**
+ * Exported for the same reason as its sibling above: the integer strand consumes
+ * it. `3 − 9` is answered by taking three from nine and writing a minus in front,
+ * and a child without the difference cannot reach the sign.
+ */
+export const CAP_DIFFERENCES_ACROSS_TEN = capabilityTag("cap.arith.differences-across-ten");
 
 /** Written out so the fact level tables below read as tables. */
 function fact(

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/div.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/div.ts
@@ -1,18 +1,27 @@
 /**
- * Domain `div` — division, with the remainder taken seriously.
+ * Domain `div` — division, from `0 ÷ 1` to a four-digit quotient over a two-digit
+ * divisor, with the remainder taken seriously.
  *
- * `draft`, for the reason `ns.ts` states: the generator is complete and the app
- * cannot draw the question. See `render/prompts.ts`. One level here needs a second
- * thing before it can go active — `dw.div.whole.divide-exact` L0 is under CG-10's
- * variant-space floor. See `promotionBlockers.ts`.
+ * Two clusters and two generator families, on the shape `add` and `mul` both take:
+ * `facts` binds `gen.arith.times-table` and holds the recalled quotients, `whole`
+ * binds `gen.arith.long-div` and holds the algorithm. A long division is a
+ * sequence of table facts and subtractions, so the procedure rows consume the fact
+ * row and CG-6 names the missing edge if anyone cuts it.
  *
- * The four rows are the four things a remainder can be asked to be: nothing (the
- * division comes out even), the answer itself, the fraction part of a mixed number,
- * and the thing a dropped zero in the quotient hides.
+ * The four `whole` rows are the four things a remainder can be asked to be:
+ * nothing (the division comes out even), the answer itself, the fraction part of a
+ * mixed number, and the thing a dropped zero in the quotient hides.
  *
  * `mis.div.divisor-must-be-smaller` is named in CURRICULUM.md and is deliberately
  * absent — `malrules/longDiv.ts` says why: its home is an item where the divisor is
  * the larger number, and whole-number long division never poses one.
+ *
+ * **Every row here is still `draft`, and CG-10 is no longer the reason.**
+ * `divide-exact` L0 was under the variant-space floor and has been widened past it;
+ * what remains is that nothing draws a division *question*. The shipped host writes
+ * every item it does not recognise with a plus sign, so `1,548 ÷ 6` would reach a
+ * child as `1,548 + 6`. `promotionBlockers.ts` names the templates, and
+ * `render/prompts.ts` carries the operator each one is written with.
  */
 
 import { rational } from "../../math/rational.ts";
@@ -22,16 +31,29 @@ import {
   LONG_DIV_FAMILY,
   LONG_DIV_FAMILY_REV,
 } from "../../generators/longDiv/constants.ts";
+import {
+  FORM_FREE_ENTRY as TABLE_FORM,
+  TIMES_TABLE_FAMILY,
+  TIMES_TABLE_FAMILY_REV,
+} from "../../generators/timesTable/constants.ts";
+import type { TimesTableParams } from "../../generators/timesTable/params.ts";
 import { MIS_QUOTIENT_ZERO_SKIPPED, MIS_REMAINDER_DROPPED } from "../../malrules/longDiv.ts";
-import { CAP_MUL_ONE_DIGIT } from "./mul.ts";
+import { CAP_MUL_ONE_DIGIT, CAP_TABLES_TO_TWELVE, SKILL_TABLES_TO_TWELVE, SKILL_TIMES_ONE_DIGIT } from "./mul.ts";
 import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
 import type { SkillNode } from "../../types/skill.ts";
 
 export const CAP_DIV_EXACT = capabilityTag("cap.div.exact");
 export const CAP_DIV_REMAINDER = capabilityTag("cap.div.remainder");
+/** Recalled quotients — `48 ÷ 6` — which every column of a long division is. */
+export const CAP_DIVISION_FACTS = capabilityTag("cap.div.facts");
 
 function b(hundredths: bigint) {
   return rational(hundredths, 100n);
+}
+
+/** Written out so the fact level table below reads as a table. */
+function quotients(maxFactor: number, includeTrivial = false): TimesTableParams {
+  return { op: "div", maxFactor, includeTrivial };
 }
 
 function divide(
@@ -44,14 +66,94 @@ function divide(
   return { task, quotientDigits, divisorDigits, exact, quotientZeros };
 }
 
+export const SKILL_DIVISION_FACTS = skillId("dw.div.facts.division-facts");
 export const SKILL_DIVIDE_EXACT = skillId("dw.div.whole.divide-exact");
 export const SKILL_DIVIDE_REMAINDER = skillId("dw.div.whole.find-the-remainder");
 export const SKILL_QUOTIENT_AND_REMAINDER = skillId("dw.div.whole.quotient-and-remainder");
 export const SKILL_ZERO_IN_QUOTIENT = skillId("dw.div.whole.zero-in-the-quotient");
 
+/**
+ * The bottom of the division strand: the quotients a child recalls.
+ *
+ * A separate row from `dw.mul.facts.tables-to-twelve` and not a level of it, for
+ * the reason `dw.add.facts.subtract-within-ten` is separate from its addition
+ * sibling: a child fluent in the tables is routinely not fluent in the quotients,
+ * and one mastery record for both would report a fluency the child does not have
+ * in the direction that is actually failing. It binds the same family and draws
+ * from the same closed set read backwards, which is what makes "the same fact two
+ * ways" a fact about the code rather than a claim in a comment.
+ *
+ * Level 0 admits the facts one operand decides — `0 ÷ 7`, `7 ÷ 1` — and the levels
+ * above it do not. They are the rung a child who has slid all the way down this
+ * strand lands on.
+ */
+const divisionFacts: SkillNode = {
+  id: SKILL_DIVISION_FACTS,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.div.facts.division-facts.title"),
+  learnerGoal: locKey("dw.skill.div.facts.division-facts.goal"),
+  domain: "div",
+  cluster: "facts",
+  bigIdeas: [
+    locKey("dw.idea.division.sharing-and-grouping"),
+    locKey("dw.idea.equality.undoing-runs-both-ways"),
+  ],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 1, strategic: 2, adaptive: 1 },
+  classification: "fluency",
+  /**
+   * Ten seconds, one above the tables it inverts.
+   *
+   * A child answers `48 ÷ 6` by searching the six times table for forty-eight,
+   * which is the strategy the walkthrough teaches and it is a search rather than a
+   * recall until the fact is over-learned. The cadence table would give this
+   * one-digit-answer item a six-second window and refuse to promote the method.
+   */
+  fluencyTarget: { p50Ms: 10000 },
+  prereqs: [{ kind: "requires", to: SKILL_TABLES_TO_TWELVE }],
+  // Above the tables it inverts and below the first long division, so the strand
+  // is one climb: `48 ÷ 6` at −0.55 to −0.15, then `516 ÷ 4` at 0.20.
+  difficulty: { b: b(-105n), levels: [b(-55n), b(-15n), b(15n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: TIMES_TABLE_FAMILY,
+    familyRev: TIMES_TABLE_FAMILY_REV,
+    params: [quotients(5, true), quotients(9), quotients(12)],
+    forms: [TABLE_FORM],
+    minVariants: 26,
+    // 6 × 5, then 8², then 11² — `factSetSize` of each level, pinned from the
+    // other side by `timesTable.test.ts`, which enumerates each set independently.
+    closedFactSet: [30, 64, 121],
+    consumes: [CAP_TABLES_TO_TWELVE],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_DIVISION_FACTS],
+  standards: { ccss: ["3.OA.C.7", "3.OA.B.6"] },
+};
+
 const divideExact: SkillNode = {
   id: SKILL_DIVIDE_EXACT,
-  rev: 1,
+  /**
+   * rev 2: a wider entry level, and the two prerequisites it always had.
+   *
+   * L0 was a two-digit quotient over a one-digit divisor — ninety quotients times
+   * eight divisors is 720 problems, against CG-10's floor of 975, and the row could
+   * not be promoted while that was its entry level. It is not a closed fact set:
+   * the bound is a digit count that nothing about the content asks to be two, which
+   * is exactly the case `GeneratorBinding.closedFactSet` forbids declaring. So the
+   * level was widened to a three-digit quotient, which is the resolution the gate
+   * was asking for and 7,200 problems instead.
+   *
+   * The prerequisites are the mathematics: every column of a long division picks a
+   * quotient digit out of a times table and then multiplies it back.
+   */
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.div.whole.divide-exact.title"),
   learnerGoal: locKey("dw.skill.div.whole.divide-exact.goal"),
@@ -62,9 +164,23 @@ const divideExact: SkillNode = {
   strandRole: "spine",
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
   classification: "procedural",
+  /**
+   * Eighteen seconds, kept as authored, and now with a reason on it.
+   *
+   * The host takes the wider of the cadence table's p90 at the item's width and
+   * 2.5× this median. A three-digit quotient over a one-digit divisor is three
+   * table searches, three multiplications back and three subtractions; the table,
+   * measured on column addition, would give the four-digit dividend a 40 s window
+   * and the three-digit one 27 s. Eighteen widens both to 45 s. It is the row's
+   * median across four levels whose hardest is a four-digit quotient over a
+   * two-digit divisor, where every column is a *guess* at the quotient digit.
+   */
   fluencyTarget: { p50Ms: 18000 },
-  prereqs: [],
-  difficulty: { b: b(-40n), levels: [b(-10n), b(20n), b(75n), b(105n)] },
+  prereqs: [
+    { kind: "requires", to: SKILL_DIVISION_FACTS },
+    { kind: "requires", to: SKILL_TIMES_ONE_DIGIT },
+  ],
+  difficulty: { b: b(-40n), levels: [b(20n), b(50n), b(75n), b(105n)] },
   // Nothing is left over, so there is nothing to drop; the interior-zero rule needs
   // a quotient wide enough to hide one, which the last level of this row provides.
   misconceptions: [MIS_QUOTIENT_ZERO_SKIPPED],
@@ -73,14 +189,14 @@ const divideExact: SkillNode = {
     family: LONG_DIV_FAMILY,
     familyRev: LONG_DIV_FAMILY_REV,
     params: [
-      divide("quotient", 2, 1, true),
       divide("quotient", 3, 1, true),
+      divide("quotient", 4, 1, true),
       divide("quotient", 3, 2, true),
       divide("quotient", 4, 2, true),
     ],
     forms: [DIV_FORM],
     minVariants: 80,
-    consumes: [CAP_MUL_ONE_DIGIT],
+    consumes: [CAP_DIVISION_FACTS, CAP_MUL_ONE_DIGIT],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [CAP_DIV_EXACT],
@@ -100,6 +216,10 @@ const findTheRemainder: SkillNode = {
   strandRole: "bridge",
   proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
   classification: "conceptual",
+  // The same procedure as its prerequisite, so the same median. What is different
+  // is the question, not the work: the child divides and then reports what is
+  // over instead of what came out.
+  fluencyTarget: { p50Ms: 18000 },
   prereqs: [{ kind: "requires", to: SKILL_DIVIDE_EXACT }],
   difficulty: { b: b(-40n), levels: [b(15n), b(45n), b(100n)] },
   misconceptions: [MIS_REMAINDER_DROPPED],
@@ -137,6 +257,9 @@ const quotientAndRemainder: SkillNode = {
   strandRole: "bridge",
   proficiency: { conceptual: 3, procedural: 3, strategic: 2, adaptive: 2 },
   classification: "conceptual",
+  // Twenty: the division, and then a mixed number to write. The extra two seconds
+  // are the writing, which on this row is part of the answer and not overhead.
+  fluencyTarget: { p50Ms: 20000 },
   prereqs: [{ kind: "requires", to: SKILL_DIVIDE_REMAINDER }],
   difficulty: { b: b(-40n), levels: [b(15n), b(45n), b(100n)] },
   misconceptions: [MIS_REMAINDER_DROPPED, MIS_QUOTIENT_ZERO_SKIPPED],
@@ -176,6 +299,9 @@ const zeroInTheQuotient: SkillNode = {
   strandRole: "fluency",
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 2 },
   classification: "procedural",
+  // Twenty: the column where the partial dividend is smaller than the divisor is
+  // the one a child stops at, and stopping to think there is the skill.
+  fluencyTarget: { p50Ms: 20000 },
   prereqs: [{ kind: "requires", to: SKILL_DIVIDE_EXACT }],
   difficulty: { b: b(-40n), levels: [b(55n), b(85n), b(140n)] },
   misconceptions: [MIS_QUOTIENT_ZERO_SKIPPED],
@@ -198,6 +324,7 @@ const zeroInTheQuotient: SkillNode = {
 };
 
 export const divDomainNodes: readonly SkillNode[] = [
+  divisionFacts,
   divideExact,
   findTheRemainder,
   quotientAndRemainder,

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/int.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/int.ts
@@ -1,0 +1,293 @@
+/**
+ * Domain `int` — the integers. Arithmetic below zero, and the pre-algebra on-ramp.
+ *
+ * ## Why this is a seventh domain and not a cluster of `ns` or `add`
+ *
+ * The alternative was `dw.ns.integer.*` for the ordering and `dw.add.integer.*`
+ * for the arithmetic, and it was rejected because it puts one idea under two
+ * mastery namespaces. What a child is learning across all four rows below is a
+ * single thing — that a number carries a direction, and that every operation they
+ * have has a rule for it — and a scheduler that can see "this child is shaky on
+ * integers" needs those rows to share a domain rather than to be scattered across
+ * the two domains that own the *unsigned* versions of the same operations.
+ *
+ * `ns` is number sense and place value: how a numeral is built. `add` and `mul`
+ * are the written algorithms. Neither is what this is.
+ *
+ * **`int` is deliberately absent from `V1_DOMAIN_BANDS`**, the table CG-15 reads.
+ * CURRICULUM.md names integers in the V2 cut list, and a coverage matrix that
+ * demanded an integer skill in grade 3 would be a gate everybody learns to ignore.
+ * The rows exist because the program's stated span reaches pre-algebra and the
+ * on-ramp has to be built before it can be climbed; they are not V1 coverage and
+ * the matrix does not pretend they are.
+ *
+ * ## What is here and what is not
+ *
+ * Four rows: past zero, adding, subtracting, multiplying. Two things a reader
+ * might look for are missing on purpose.
+ *
+ * **Ordering and the number line.** "Which is greater, `−7` or `−3`?" is real
+ * content and a genuine misconception magnet, and locating an integer on a number
+ * line is how it is taught. Neither is here, because a comparison row would bind
+ * `gen.number.compare-order`, whose answer schema is a closed choice that no
+ * renderer draws, and a number-line row would be **a card whose question is a
+ * picture nobody draws** — a blank. `REP_NUMBER_LINE` is registered and
+ * unimplemented; the day a pack draws it, an ordering row is one PR and it is the
+ * right first PR into this domain.
+ *
+ * **Division.** Same sign rule as the multiplication row, and it needs an exact
+ * division so the item does not pose a fraction by accident. A row this family can
+ * carry, not a gap in what it teaches.
+ *
+ * ## Every level here declares `closedFactSet`, and why that is honest
+ *
+ * A level of `gen.arith.signed-int` is bounded by a magnitude, and the bound *is*
+ * the content: what the row teaches is which way the answer points, and it teaches
+ * it on numbers small enough that nothing else can be the reason a child got it
+ * wrong. There are exactly forty-five subtractions within ten that land below zero
+ * and there is no forty-sixth, in precisely the sense there are thirty-six
+ * additions within ten. See `GeneratorBinding.closedFactSet`: the substituted
+ * check is sharper than the floor, not a waiver of it — the gate fails if the
+ * generator ever reaches a problem the row says does not exist, and
+ * `signedInt.test.ts` pins each set from the other side by enumerating it
+ * independently.
+ *
+ * ## Status
+ *
+ * All four rows are `draft`, and unlike most of this graph the blocker is
+ * specific rather than the standing "no renderer exists" note. Two things:
+ *
+ *   1. the answer goes below zero, and `answer:integer-signed` is not built. A
+ *      digit keypad with no minus key on `(−7) + 4` is not a blank card — it is a
+ *      card that looks answerable and marks a correct child wrong;
+ *   2. the multiplication row's question is drawn with a `×`, which the shipped
+ *      host writes as a `+`. See `promotionBlockers.ts`.
+ */
+
+import { rational } from "../../math/rational.ts";
+import {
+  FORM_FREE_ENTRY as SIGNED_FORM,
+  SIGNED_INT_FAMILY,
+  SIGNED_INT_FAMILY_REV,
+} from "../../generators/signedInt/constants.ts";
+import type { SignedIntParams, SignPlacement } from "../../generators/signedInt/params.ts";
+import { CAP_DIFFERENCES_ACROSS_TEN, SKILL_SUBTRACT_ACROSS_TEN } from "./add.ts";
+import { CAP_TABLES_TO_TWELVE, SKILL_TABLES_TO_TWELVE } from "./mul.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+/** A number can be below zero, and the count carries on down there. */
+export const CAP_BELOW_ZERO = capabilityTag("cap.int.below-zero");
+/** The two sign rules for addition: signs alike, signs unlike. */
+export const CAP_SIGNED_SUM = capabilityTag("cap.int.signed-sum");
+
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+/** Written out so the level tables below read as tables. */
+function signed(op: SignedIntParams["op"], maxMagnitude: number, negatives: SignPlacement): SignedIntParams {
+  return { op, maxMagnitude, negatives };
+}
+
+export const SKILL_PAST_ZERO = skillId("dw.int.arith.subtract-past-zero");
+export const SKILL_ADD_SIGNED = skillId("dw.int.arith.add-signed");
+export const SKILL_SUBTRACT_SIGNED = skillId("dw.int.arith.subtract-signed");
+export const SKILL_MULTIPLY_SIGNED = skillId("dw.int.arith.multiply-signed");
+
+/**
+ * The on-ramp: `3 − 9`.
+ *
+ * Not a minus sign anywhere on the card, and the answer has one. That is the whole
+ * row, and it is a separate mastery key from every row above it because the thing
+ * a child does not yet have is not a rule for signs — it is the fact that the count
+ * does not stop at zero. A child who answers `6` here is not misapplying a sign
+ * rule; they are subtracting the only way subtraction has ever worked for them,
+ * smaller from larger, which is `mis.add.smaller-from-larger` arriving in the one
+ * place it is nearly right.
+ */
+const subtractPastZero: SkillNode = {
+  id: SKILL_PAST_ZERO,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.int.arith.subtract-past-zero.title"),
+  learnerGoal: locKey("dw.skill.int.arith.subtract-past-zero.goal"),
+  domain: "int",
+  cluster: "arith",
+  bigIdeas: [locKey("dw.idea.number.the-count-goes-below-zero")],
+  gradeBand: { earliest: 5, nominal: 6, latest: 7 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 1, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  /**
+   * Ten seconds. The arithmetic is a within-twenty difference the child already
+   * has and the cadence table would give the item six; what the extra four seconds
+   * pay for is the decision, which is the entire content of the row. A window cut
+   * to the arithmetic would promote only the children who had stopped thinking
+   * about the sign.
+   */
+  fluencyTarget: { p50Ms: 10000 },
+  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_ACROSS_TEN }],
+  difficulty: { b: b(125n), levels: [b(140n), b(165n), b(190n)] },
+  misconceptions: [],
+  // The number line belongs here and is not claimed. See the note at the top.
+  representations: { required: [], optional: [] },
+  generator: {
+    family: SIGNED_INT_FAMILY,
+    familyRev: SIGNED_INT_FAMILY_REV,
+    params: [signed("sub", 10, "none"), signed("sub", 15, "none"), signed("sub", 20, "none")],
+    forms: [SIGNED_FORM],
+    minVariants: 40,
+    // m(m−1)/2 at ten, fifteen and twenty: the triangle `a < b`, which is every
+    // subtraction within the bound that lands below zero and no other.
+    closedFactSet: [45, 105, 190],
+    consumes: [CAP_DIFFERENCES_ACROSS_TEN],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_BELOW_ZERO],
+  standards: { ccss: ["6.NS.C.5", "7.NS.A.1"] },
+};
+
+const addSigned: SkillNode = {
+  id: SKILL_ADD_SIGNED,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.int.arith.add-signed.title"),
+  learnerGoal: locKey("dw.skill.int.arith.add-signed.goal"),
+  domain: "int",
+  cluster: "arith",
+  bigIdeas: [
+    locKey("dw.idea.number.the-count-goes-below-zero"),
+    locKey("dw.idea.number.a-number-carries-a-direction"),
+  ],
+  gradeBand: { earliest: 6, nominal: 6, latest: 7 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  // Twelve. Two more than the row below it, for the second decision: the sizes
+  // have to be compared before either of them is used.
+  fluencyTarget: { p50Ms: 12000 },
+  prereqs: [{ kind: "requires", to: SKILL_PAST_ZERO }],
+  difficulty: { b: b(140n), levels: [b(160n), b(185n), b(235n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: SIGNED_INT_FAMILY,
+    familyRev: SIGNED_INT_FAMILY_REV,
+    // The minus on the front, then the minus in the middle, then both. The order
+    // is the difficulty coefficients' order and it is the claim they make: two
+    // signs side by side is harder to read than one at the start.
+    params: [signed("add", 10, "first"), signed("add", 12, "second"), signed("add", 20, "both")],
+    forms: [SIGNED_FORM],
+    minVariants: 90,
+    closedFactSet: [100, 144, 400],
+    consumes: [CAP_BELOW_ZERO, CAP_DIFFERENCES_ACROSS_TEN],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_SIGNED_SUM],
+  standards: { ccss: ["7.NS.A.1"] },
+};
+
+/**
+ * Subtracting a signed number, which is the row the whole domain turns on.
+ *
+ * `7 − (−4)` is where "two negatives make a positive" is *correct*, and it is the
+ * same sentence that makes `(−7) + (−4) = 11` on the row below. Separate mastery
+ * keys, because a child can hold the rule for one and not the other and a single
+ * record would average the two into a number that describes neither.
+ */
+const subtractSigned: SkillNode = {
+  id: SKILL_SUBTRACT_SIGNED,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.int.arith.subtract-signed.title"),
+  learnerGoal: locKey("dw.skill.int.arith.subtract-signed.goal"),
+  domain: "int",
+  cluster: "arith",
+  bigIdeas: [
+    locKey("dw.idea.number.a-number-carries-a-direction"),
+    locKey("dw.idea.equality.undoing-runs-both-ways"),
+  ],
+  gradeBand: { earliest: 6, nominal: 6, latest: 7 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 3, adaptive: 2 },
+  classification: "conceptual",
+  // Fourteen: the item becomes an addition first and is then the row below it.
+  // Two moves, and the median is the two of them.
+  fluencyTarget: { p50Ms: 14000 },
+  prereqs: [{ kind: "requires", to: SKILL_ADD_SIGNED }],
+  difficulty: { b: b(155n), levels: [b(190n), b(215n), b(265n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: SIGNED_INT_FAMILY,
+    familyRev: SIGNED_INT_FAMILY_REV,
+    params: [signed("sub", 10, "first"), signed("sub", 12, "second"), signed("sub", 20, "both")],
+    forms: [SIGNED_FORM],
+    minVariants: 90,
+    closedFactSet: [100, 144, 400],
+    consumes: [CAP_SIGNED_SUM],
+  },
+  probes: [
+    { level: 1, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [],
+  standards: { ccss: ["7.NS.A.1"] },
+};
+
+const multiplySigned: SkillNode = {
+  id: SKILL_MULTIPLY_SIGNED,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.int.arith.multiply-signed.title"),
+  learnerGoal: locKey("dw.skill.int.arith.multiply-signed.goal"),
+  domain: "int",
+  cluster: "arith",
+  bigIdeas: [
+    locKey("dw.idea.number.a-number-carries-a-direction"),
+    locKey("dw.idea.multiplication.equal-groups"),
+  ],
+  gradeBand: { earliest: 6, nominal: 7, latest: 7 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 2, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  // Twelve: a table fact, and then one decision that is a rule rather than a
+  // comparison. Below its subtraction sibling on purpose — see the coefficients.
+  fluencyTarget: { p50Ms: 12000 },
+  prereqs: [
+    { kind: "requires", to: SKILL_ADD_SIGNED },
+    { kind: "requires", to: SKILL_TABLES_TO_TWELVE },
+  ],
+  difficulty: { b: b(170n), levels: [b(195n), b(225n), b(235n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: SIGNED_INT_FAMILY,
+    familyRev: SIGNED_INT_FAMILY_REV,
+    params: [signed("mul", 9, "first"), signed("mul", 12, "second"), signed("mul", 12, "both")],
+    forms: [SIGNED_FORM],
+    minVariants: 72,
+    closedFactSet: [81, 144, 144],
+    consumes: [CAP_SIGNED_SUM, CAP_TABLES_TO_TWELVE],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [],
+  standards: { ccss: ["7.NS.A.2"] },
+};
+
+export const intDomainNodes: readonly SkillNode[] = [
+  subtractPastZero,
+  addSigned,
+  subtractSigned,
+  multiplySigned,
+];

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/mul.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/mul.ts
@@ -1,18 +1,33 @@
 /**
- * Domain `mul` — multiplication.
+ * Domain `mul` — multiplication, from `0 × 1` to `48,826 × 82,726`.
  *
- * `draft`, for the reason `ns.ts` states at length: the generator is complete and
- * the app cannot draw the question. See `render/prompts.ts`. One level here needs a
- * second thing before it can go active — `dw.mul.scale.times-power-of-ten` L0 is
- * under CG-10's variant-space floor. See `promotionBlockers.ts`.
+ * Two clusters and two generator families, in one ladder, on the same shape the
+ * `add` domain took: `facts` binds `gen.arith.times-table` and holds the recalled
+ * tables a child needs before any written multiplication means anything, and
+ * `multidigit` binds `gen.arith.multidigit-mul` and holds the algorithm. The
+ * capability tags below are what make that a mechanical fact rather than an
+ * editorial ordering — `472 × 6` *is* `2 × 6` and `7 × 6` inside a procedure, so
+ * the column rows consume the fact rows and CG-6 names the missing edge if anyone
+ * cuts one.
  *
- * **What is missing from this domain, and why.** CURRICULUM.md gives `mul` ten
- * fact-recall skills, and there are none here. Times-table facts have at most 144
- * distinct problems in the world; CG-10's variant-space floor is 975, derived from
- * a 40-item practice run repeating no more than one item in fifty. A fact family
- * cannot satisfy it and no amount of generator work will change that — the floor
- * and the content are in genuine conflict, and the resolution belongs with whoever
- * owns CG-10, not in a generator that games the estimator.
+ * **The fact rows were the hole this domain shipped with.** CURRICULUM.md gives
+ * `mul` ten fact-recall skills and there were none, on the argument that a table
+ * has at most 144 problems in the world and CG-10's floor is 975 — so the floor and
+ * the content were in conflict and the conflict was left open. That reconciliation
+ * arrived with the addition floor: `GeneratorBinding.closedFactSet` replaces the
+ * floor for a level whose problem space is closed, with a *sharper* check in its
+ * place (the gate fails when the generator reaches a problem the row says does not
+ * exist). There are one hundred and twenty-one multiplications in the tables to
+ * twelve, there is no hundred-and-twenty-second, and a floor derived from a model
+ * of generators that do not close was never a statement about them.
+ *
+ * **Every row here is still `draft`, and the blocker is not CG-10 any more.** It is
+ * that nothing draws a multiplication *question*. That is not the standing
+ * "no renderer exists" note the rest of the graph carries: the shipped host grew a
+ * partial one, and it writes every item it cannot recognise with a plus sign. See
+ * `promotionBlockers.ts` — `OPERATOR_BLOCKED_TEMPLATES` names the templates it
+ * would mis-draw, and `render/prompts.ts` now carries the operator each template
+ * is written with so that the fix is a lookup rather than a second guess.
  */
 
 import { rational } from "../../math/rational.ts";
@@ -23,18 +38,43 @@ import {
   MULTIDIGIT_MUL_FAMILY_REV,
 } from "../../generators/multidigitMul/constants.ts";
 import {
+  FORM_FREE_ENTRY as TABLE_FORM,
+  TIMES_TABLE_FAMILY,
+  TIMES_TABLE_FAMILY_REV,
+} from "../../generators/timesTable/constants.ts";
+import type { TimesTableParams } from "../../generators/timesTable/params.ts";
+import {
   MIS_CARRY_ADDED_BEFORE_MULTIPLYING,
   MIS_FORGOT_THE_SHIFT,
   MIS_PARTIAL_PRODUCT_MISALIGNED,
 } from "../../malrules/multidigitMul.ts";
+import { CAP_SUMS_ACROSS_TEN, SKILL_ADD_ACROSS_TEN } from "./add.ts";
 import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
 import type { SkillNode } from "../../types/skill.ts";
 
 export const CAP_MUL_ONE_DIGIT = capabilityTag("cap.mul.by-one-digit");
 export const CAP_MUL_MULTIDIGIT = capabilityTag("cap.mul.multidigit");
 
+/**
+ * The two fact capabilities, and why they are not decoration.
+ *
+ * A single-digit pass of the written algorithm is a table fact and a carry: the
+ * units column of `472 × 6` is `2 × 6`, and the tens column is `7 × 6` plus what
+ * came out of the units. So `dw.mul.multidigit.*` does not merely *follow* the
+ * tables in some editorial ordering — it consumes them, and CG-6 fails on a graph
+ * that forgets to say so. The split at five is where the tables stop being the
+ * small ones a second grader meets and start being the ones England mandates by Y4.
+ */
+export const CAP_TABLES_WITHIN_FIVE = capabilityTag("cap.mul.tables-within-five");
+export const CAP_TABLES_TO_TWELVE = capabilityTag("cap.mul.tables-to-twelve");
+
 function b(hundredths: bigint) {
   return rational(hundredths, 100n);
+}
+
+/** Written out so the fact level tables below read as tables. */
+function table(maxFactor: number, includeTrivial = false): TimesTableParams {
+  return { op: "mul", maxFactor, includeTrivial };
 }
 
 function times(digits: number, multiplierDigits: number, carries: boolean): MultidigitMulParams {
@@ -45,13 +85,149 @@ function powerOfTen(digits: number, maxPower: number): MultidigitMulParams {
   return { shape: "power-of-ten", digits, maxPower };
 }
 
+export const SKILL_TABLES_WITHIN_FIVE = skillId("dw.mul.facts.tables-within-five");
+export const SKILL_TABLES_TO_TWELVE = skillId("dw.mul.facts.tables-to-twelve");
 export const SKILL_TIMES_POWER_OF_TEN = skillId("dw.mul.scale.times-power-of-ten");
 export const SKILL_TIMES_ONE_DIGIT = skillId("dw.mul.multidigit.times-one-digit");
 export const SKILL_TIMES_TWO_DIGIT = skillId("dw.mul.multidigit.times-two-digit");
+export const SKILL_LONG_MULTIPLICATION = skillId("dw.mul.multidigit.long-multiplication");
+
+/**
+ * ## The two fact rows: the bottom of the multiplicative strand
+ *
+ * Before these, the easiest thing this domain could offer was `472 × 6` — a
+ * three-digit carrying multiplication — and there was nothing underneath it at
+ * all. A child who cannot recall `7 × 6` cannot do that item however well they
+ * align, and had nowhere to go.
+ *
+ * **Why two rows and not one.** A child fluent in the tables to five is routinely
+ * not fluent in the sevens and the eights, and one mastery record for both would
+ * report a fluency the child does not have in exactly the tables that are failing.
+ * The split is also where the two frameworks disagree: Singapore teaches ×2, ×5
+ * and ×10 at P2, CCSS puts all of the tables to ten at grade 3, and England
+ * mandates to 12 × 12 by Y4. Splitting at five is what lets one graph serve all
+ * three without a grade appearing anywhere except as a label.
+ *
+ * **`closedFactSet` is what makes them possible.** See `GeneratorBinding` for the
+ * argument; the short form is that there are one hundred and twenty-one
+ * multiplications in the tables to twelve and no hundred-and-twenty-second, and a
+ * variant-space floor derived from a model of generators that do not close was
+ * never a statement about a closed one. The numbers below are `factSetSize` of
+ * each level's parameters, and `timesTable.test.ts` enumerates each set
+ * independently and asserts the generator reaches every member of it and nothing
+ * outside it.
+ */
+const tablesWithinFive: SkillNode = {
+  id: SKILL_TABLES_WITHIN_FIVE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.mul.facts.tables-within-five.title"),
+  learnerGoal: locKey("dw.skill.mul.facts.tables-within-five.goal"),
+  domain: "mul",
+  cluster: "facts",
+  bigIdeas: [locKey("dw.idea.multiplication.equal-groups")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 1, strategic: 2, adaptive: 1 },
+  classification: "fluency",
+  /**
+   * Eight seconds, two above the addition facts' six, and the two extra seconds
+   * are the skip count. A child at this row who has not yet memorised `4 × 3`
+   * reaches it by counting four, eight, twelve — which is the strategy the
+   * walkthrough teaches and the strategy the row is *for*. Timing them at the
+   * cadence table's one-digit p90 of six seconds would classify the entire
+   * intended method as too slow to climb.
+   */
+  fluencyTarget: { p50Ms: 8000 },
+  // Repeated addition is what a first table fact is: `3 × 4` is four and four and
+  // four, and the skip count that replaces it crosses ten on its second step.
+  prereqs: [{ kind: "requires", to: SKILL_ADD_ACROSS_TEN }],
+  // Placed so the strand is continuous rather than parallel: `2 × 2` at −1.20 sits
+  // just above the hardest addition fact (`15 − 8`, at −1.25) and just below the
+  // easiest column sum (`43 + 25`, at −0.90), and the top of this row is under the
+  // easiest written multiplication. A table fact must be below every item that
+  // *uses* table facts, which `ladder.test.ts` asserts across the whole strand.
+  difficulty: { b: b(-110n), levels: [b(-120n), b(-105n), b(-75n), b(-65n)] },
+  misconceptions: [],
+  // The array model belongs here and is not claimed: nothing in this repository
+  // draws a representation, and a row that declared one `required` today would be
+  // a curriculum row the app cannot draw. It is not `optional` either, because
+  // this family does not emit a rep spec at all — see `timesTable/family.ts`.
+  representations: { required: [], optional: [] },
+  generator: {
+    family: TIMES_TABLE_FAMILY,
+    familyRev: TIMES_TABLE_FAMILY_REV,
+    // The twos, the threes, the whole of the tables to five, and then the same
+    // range with the zero and identity facts taken away.
+    params: [table(2, true), table(3, true), table(5, true), table(5)],
+    forms: [TABLE_FORM],
+    // Eight: level 0's whole set. `minVariants` counts distinct items *in a
+    // sample*, so on a closed set it can never assert more than the sample makes
+    // reachable; the assertion that matters is the closure test.
+    minVariants: 8,
+    closedFactSet: [8, 15, 35, 16],
+    consumes: [CAP_SUMS_ACROSS_TEN],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 3, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_TABLES_WITHIN_FIVE],
+  standards: { ccss: ["3.OA.A.1", "3.OA.B.5", "3.OA.C.7"], sg: ["P2-MD-1"] },
+};
+
+const tablesToTwelve: SkillNode = {
+  id: SKILL_TABLES_TO_TWELVE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.mul.facts.tables-to-twelve.title"),
+  learnerGoal: locKey("dw.skill.mul.facts.tables-to-twelve.goal"),
+  domain: "mul",
+  cluster: "facts",
+  bigIdeas: [locKey("dw.idea.multiplication.equal-groups")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 1, procedural: 1, strategic: 2, adaptive: 1 },
+  classification: "fluency",
+  // Nine, one above its sibling: the same skip count, over more steps of a larger
+  // number. Nothing in the cadence table reaches a one-digit question that takes
+  // this long, which is the whole reason the field is read at all.
+  fluencyTarget: { p50Ms: 9000 },
+  prereqs: [{ kind: "requires", to: SKILL_TABLES_WITHIN_FIVE }],
+  difficulty: { b: b(-135n), levels: [b(-60n), b(-30n), b(15n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: TIMES_TABLE_FAMILY,
+    familyRev: TIMES_TABLE_FAMILY_REV,
+    params: [table(7), table(9), table(12)],
+    forms: [TABLE_FORM],
+    minVariants: 32,
+    closedFactSet: [36, 64, 121],
+    consumes: [CAP_TABLES_WITHIN_FIVE],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_TABLES_TO_TWELVE],
+  standards: { ccss: ["3.OA.C.7"], uk: ["Y4-MD-1"] },
+};
 
 const timesPowerOfTen: SkillNode = {
   id: SKILL_TIMES_POWER_OF_TEN,
-  rev: 1,
+  /**
+   * rev 2: the level table starts a digit wider and reaches a power further.
+   *
+   * `powerOfTen(2, 1)` was two-digit multiplicands times ten — ninety problems in
+   * the world, against CG-10's floor of 975, and the row could not be promoted
+   * while it was the entry level. It is not a closed fact set: the bound is a digit
+   * count that could be widened at any time and nothing about the content asks for
+   * it to be ninety, which is exactly the case `GeneratorBinding.closedFactSet`
+   * forbids declaring. So the level was widened instead, which is the resolution
+   * the gate was asking for. `472 × 100` is the same skill `47 × 100` was.
+   */
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.mul.scale.times-power-of-ten.title"),
   learnerGoal: locKey("dw.skill.mul.scale.times-power-of-ten.goal"),
@@ -62,8 +238,8 @@ const timesPowerOfTen: SkillNode = {
   strandRole: "bridge",
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
   classification: "conceptual",
-  prereqs: [],
-  difficulty: { b: b(-40n), levels: [b(-75n), b(-45n), b(-15n)] },
+  prereqs: [{ kind: "requires", to: SKILL_TABLES_WITHIN_FIVE }],
+  difficulty: { b: b(-40n), levels: [b(-45n), b(-15n), b(15n)] },
   // `47 × 100` answered as `47`: the zeros that move the product up two places
   // were never written. Same root cause as the missing placeholder zero in
   // `47 × 23` — both are `mis.mul.shift-not-applied` — but a different rule and a
@@ -76,10 +252,10 @@ const timesPowerOfTen: SkillNode = {
   generator: {
     family: MULTIDIGIT_MUL_FAMILY,
     familyRev: MULTIDIGIT_MUL_FAMILY_REV,
-    params: [powerOfTen(2, 1), powerOfTen(3, 2), powerOfTen(4, 3)],
+    params: [powerOfTen(3, 2), powerOfTen(4, 3), powerOfTen(5, 4)],
     forms: [MUL_FORM],
     minVariants: 60,
-    consumes: [],
+    consumes: [CAP_TABLES_WITHIN_FIVE],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [],
@@ -88,7 +264,14 @@ const timesPowerOfTen: SkillNode = {
 
 const timesOneDigit: SkillNode = {
   id: SKILL_TIMES_ONE_DIGIT,
-  rev: 1,
+  /**
+   * rev 2: gained the two prerequisites it always had and never declared. Each
+   * single-digit pass of `472 × 6` is a table fact, and the carry out of it is a
+   * sum across ten — so a child without either cannot do this row however well
+   * they set it out. Before the fact rows existed there was nothing to declare;
+   * the row sat at the bottom of its own domain with no floor under it.
+   */
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.mul.multidigit.times-one-digit.title"),
   learnerGoal: locKey("dw.skill.mul.multidigit.times-one-digit.goal"),
@@ -99,8 +282,24 @@ const timesOneDigit: SkillNode = {
   strandRole: "spine",
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
   classification: "procedural",
+  /**
+   * Fifteen seconds, kept as authored, and now with a reason on it.
+   *
+   * The number is read by the host's climb rule, which takes the wider of the
+   * cadence table's p90 at the item's width and 2.5× this median. The table was
+   * measured on column *addition*, where a three-digit item is three sums; a
+   * three-digit multiplication is three products, three carries and three sums,
+   * and the table's 27 s window at that width would refuse to promote a child who
+   * did the whole of `472 × 6` correctly in half a minute. Fifteen seconds is the
+   * row's median across its three levels — L2 is a five-digit multiplicand, where
+   * the table already dominates — so the declared number binds only at width three,
+   * where it widens 27 s to 37.5 s.
+   */
   fluencyTarget: { p50Ms: 15000 },
-  prereqs: [],
+  prereqs: [
+    { kind: "requires", to: SKILL_TABLES_TO_TWELVE },
+    { kind: "requires", to: SKILL_ADD_ACROSS_TEN },
+  ],
   difficulty: { b: b(-30n), levels: [b(25n), b(55n), b(85n)] },
   misconceptions: [MIS_CARRY_ADDED_BEFORE_MULTIPLYING],
   representations: { required: [], optional: [] },
@@ -110,7 +309,7 @@ const timesOneDigit: SkillNode = {
     params: [times(3, 1, true), times(4, 1, true), times(5, 1, true)],
     forms: [MUL_FORM],
     minVariants: 80,
-    consumes: [],
+    consumes: [CAP_TABLES_TO_TWELVE, CAP_SUMS_ACROSS_TEN],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [CAP_MUL_ONE_DIGIT],
@@ -130,6 +329,17 @@ const timesTwoDigit: SkillNode = {
   strandRole: "spine",
   proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
   classification: "procedural",
+  /**
+   * Twenty-five seconds, and this row is the one the field exists for.
+   *
+   * `47 × 23` is two digits wide, and the cadence table — measured on two-digit
+   * column *addition* — gives a two-digit item a 14 s window. The item is two
+   * partial products, four table facts, four carries and a three-digit sum. A
+   * child who writes all of that correctly in twenty seconds is fluent and would
+   * never climb: the window would be narrower than the work. Declaring 25 s widens
+   * it to 62.5 s, which is the slow tail of a 25 s median rather than a target.
+   */
+  fluencyTarget: { p50Ms: 25000 },
   prereqs: [
     { kind: "requires", to: SKILL_TIMES_ONE_DIGIT },
     { kind: "supports", to: SKILL_TIMES_POWER_OF_TEN },
@@ -150,4 +360,72 @@ const timesTwoDigit: SkillNode = {
   standards: { ccss: ["5.NBT.B.5"], uk: ["Y5-MD-1"] },
 };
 
-export const mulDomainNodes: readonly SkillNode[] = [timesPowerOfTen, timesOneDigit, timesTwoDigit];
+/**
+ * The top of the domain: every partial product, at the widths the program says it
+ * reaches.
+ *
+ * A separate row from `times-two-digit` and not three more levels of it, because
+ * what a child is doing changes: at two partial products the sum at the bottom is
+ * an addition they already have, and at five it is a five-addend column addition
+ * that is its own source of error. The row's own name is the mathematics — long
+ * multiplication is every digit of the multiplier against every digit of the
+ * multiplicand — and not a width, so widening it later is a level and not a new id.
+ *
+ * **`48,826 × 82,726` is level 2 of this row.** That number is the program's stated
+ * ceiling, and before this row the widest multiplication in the graph was three
+ * digits by three: the parameter schema itself stopped at a three-digit multiplier,
+ * so the item was not expressible at all rather than merely unauthored.
+ */
+const longMultiplication: SkillNode = {
+  id: SKILL_LONG_MULTIPLICATION,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.mul.multidigit.long-multiplication.title"),
+  learnerGoal: locKey("dw.skill.mul.multidigit.long-multiplication.goal"),
+  domain: "mul",
+  cluster: "multidigit",
+  bigIdeas: [
+    locKey("dw.idea.place-value.regroup"),
+    locKey("dw.idea.multiplication.partial-products"),
+  ],
+  gradeBand: { earliest: 5, nominal: 5, latest: 5 },
+  strandRole: "fluency",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  /**
+   * Seventy-five seconds, measured against L1 — a five-digit multiplicand and a
+   * four-digit multiplier — which is the row's middle level and its median item.
+   *
+   * This is far outside the cadence table, which stops meaning anything above four
+   * digits: at width five it reads 53 s, and `48,826 × 82,726` is five partial
+   * products of five digits each and then a five-addend sum. The declared median
+   * widens the window to 187 s. That is not a target and nothing paces a child at
+   * it; it is the number that stops a correct answer to the hardest item in the
+   * program from being classified as a slow one.
+   */
+  fluencyTarget: { p50Ms: 75000 },
+  prereqs: [{ kind: "requires", to: SKILL_TIMES_TWO_DIGIT }],
+  difficulty: { b: b(-30n), levels: [b(165n), b(250n), b(305n)] },
+  misconceptions: [MIS_PARTIAL_PRODUCT_MISALIGNED],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MULTIDIGIT_MUL_FAMILY,
+    familyRev: MULTIDIGIT_MUL_FAMILY_REV,
+    params: [times(4, 3, true), times(5, 4, true), times(5, 5, true)],
+    forms: [MUL_FORM],
+    minVariants: 80,
+    consumes: [CAP_MUL_MULTIDIGIT],
+  },
+  probes: [{ level: 2, seed: 48826, purpose: "promotion" }],
+  provides: [],
+  standards: { ccss: ["5.NBT.B.5"] },
+};
+
+export const mulDomainNodes: readonly SkillNode[] = [
+  tablesWithinFive,
+  tablesToTwelve,
+  timesPowerOfTen,
+  timesOneDigit,
+  timesTwoDigit,
+  longMultiplication,
+];

--- a/dynawalla/packs/shared/curriculum/src/graph/graph.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/graph.ts
@@ -5,10 +5,15 @@
  * from it and from every coverage count, so the graph can never become a wish list
  * (CG-7).
  *
- * Six domains are represented here and one of them has active rows. `add` binds
+ * Seven domains are represented here and one of them has active rows. `add` binds
  * `gen.arith.column-op` and `gen.arith.number-facts`, which between them are the
- * whole arithmetic ladder from `0 + 1` upward; every other row is a complete,
+ * whole additive ladder from `0 + 1` upward; every other row is a complete,
  * property-tested generator waiting on the statement renderer PR-2.13 lands.
+ *
+ * The seventh domain is `int`, which CURRICULUM.md's V1 table does not have and
+ * which CG-15's band table deliberately does not expect. It is the pre-algebra
+ * on-ramp and it is out of V1 scope; `domains/int.ts` says why it is a domain of
+ * its own rather than a cluster of two existing ones.
  *
  * Note that "waiting on a renderer" is true of the active rows too — CG-8 warns on
  * all of them and fails under `--strict-renderers`. What distinguishes an active
@@ -31,6 +36,7 @@ import { addDomainNodes } from "./domains/add.ts";
 import { algDomainNodes } from "./domains/alg.ts";
 import { divDomainNodes } from "./domains/div.ts";
 import { fracDomainNodes } from "./domains/frac.ts";
+import { intDomainNodes } from "./domains/int.ts";
 import { mulDomainNodes } from "./domains/mul.ts";
 import { nsDomainNodes } from "./domains/ns.ts";
 
@@ -41,6 +47,7 @@ export const allNodes: readonly SkillNode[] = [
   ...divDomainNodes,
   ...fracDomainNodes,
   ...algDomainNodes,
+  ...intDomainNodes,
 ];
 
 export function activeNodes(nodes: readonly SkillNode[] = allNodes): SkillNode[] {

--- a/dynawalla/packs/shared/curriculum/src/graph/ladder.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/ladder.test.ts
@@ -20,6 +20,15 @@ import test from "node:test";
 
 import { activeNodes, allNodes } from "./graph.ts";
 import {
+  SKILL_LONG_MULTIPLICATION,
+  SKILL_TABLES_TO_TWELVE,
+  SKILL_TABLES_WITHIN_FIVE,
+  SKILL_TIMES_ONE_DIGIT,
+  SKILL_TIMES_TWO_DIGIT,
+} from "./domains/mul.ts";
+import { SKILL_DIVIDE_EXACT, SKILL_DIVISION_FACTS } from "./domains/div.ts";
+import { SKILL_ADD_SIGNED, SKILL_MULTIPLY_SIGNED, SKILL_PAST_ZERO } from "./domains/int.ts";
+import {
   SKILL_ADD_ACROSS_TEN,
   SKILL_ADD_MULTIDIGIT,
   SKILL_ADD_NO_REGROUP,
@@ -123,10 +132,17 @@ test("the bottom rung is a number fact, and it is well below the column work", (
   );
   assert.equal(ratToString(easiest.b), "-3", "the root rung is not where the level table puts it");
 
-  // Every fact item is below every column item, with no overlap. The two families
-  // are a ladder and not two ladders side by side.
-  const factLevels = ACTIVE.filter((node) => node.cluster === "facts").flatMap((node) => node.difficulty.levels);
-  const columnLevels = ACTIVE.filter((node) => node.cluster !== "facts").flatMap((node) => node.difficulty.levels);
+  // Every addition fact is below every column item, with no overlap. The two
+  // families are a ladder and not two ladders side by side.
+  //
+  // Scoped to `add` since the multiplicative strand arrived. `dw.mul.facts.*` is
+  // also a `facts` cluster and it sits *above* two-digit column addition, which is
+  // correct — a times-table fact is grade-3 content and `43 + 25` is grade 1 — and
+  // would break an unscoped reading of this claim. The claim was always about the
+  // additive ladder; the multiplicative one has its own assertion below.
+  const additive = ACTIVE.filter((node) => node.domain === "add");
+  const factLevels = additive.filter((node) => node.cluster === "facts").flatMap((node) => node.difficulty.levels);
+  const columnLevels = additive.filter((node) => node.cluster !== "facts").flatMap((node) => node.difficulty.levels);
   assert.ok(factLevels.length >= 14 && columnLevels.length >= 13);
   const hardestFact = factLevels.reduce((high, current) => (cmp(current, high) > 0 ? current : high));
   const easiestColumn = columnLevels.reduce((low, current) => (cmp(current, low) < 0 ? current : low));
@@ -147,4 +163,89 @@ test("the fact rows are active, because a draft floor is not a floor", () => {
     assert.ok(node !== undefined, `${id} is missing from the graph`);
     assert.equal(node.status, "active", `${id} is ${node.status}: a controller walking activeNodes() cannot reach it`);
   }
+});
+
+/**
+ * The strands above the addition spine, asserted over the **whole** graph rather
+ * than over the active part of it.
+ *
+ * Every row named here is `draft` — see `promotionBlockers.ts` — so an assertion
+ * scoped to `activeNodes()` would pass on an empty set and go on passing after
+ * they are promoted with the edges cut. The claim is about the mathematics, which
+ * does not wait for a renderer.
+ */
+const ALL_BY_ID = new Map<string, (typeof allNodes)[number]>(allNodes.map((node) => [String(node.id), node]));
+
+/** Everything `id` transitively requires, across the whole graph. */
+function requiresAll(id: SkillId): Set<string> {
+  const seen = new Set<string>();
+  const stack = [String(id)];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined) continue;
+    for (const edge of ALL_BY_ID.get(current)?.prereqs ?? []) {
+      if (!ORDERING_KINDS.includes(edge.kind)) continue;
+      if (seen.has(String(edge.to))) continue;
+      seen.add(String(edge.to));
+      stack.push(String(edge.to));
+    }
+  }
+  return seen;
+}
+
+test("the multiplicative strand climbs from the tables, and the tables climb from the facts", () => {
+  const requires = (from: SkillId, to: SkillId): void => {
+    assert.ok(requiresAll(from).has(String(to)), `${from} should sit above ${to} and does not`);
+  };
+
+  // The mathematics, in edges. A single-digit pass of a written multiplication is
+  // a table fact and a carry; a long division picks its quotient digits out of a
+  // table; a table fact is reached by skip counting, which crosses ten.
+  requires(SKILL_TABLES_WITHIN_FIVE, SKILL_ADD_ACROSS_TEN);
+  requires(SKILL_TABLES_TO_TWELVE, SKILL_TABLES_WITHIN_FIVE);
+  requires(SKILL_TIMES_ONE_DIGIT, SKILL_TABLES_TO_TWELVE);
+  requires(SKILL_TIMES_TWO_DIGIT, SKILL_TIMES_ONE_DIGIT);
+  requires(SKILL_LONG_MULTIPLICATION, SKILL_TIMES_TWO_DIGIT);
+  requires(SKILL_DIVISION_FACTS, SKILL_TABLES_TO_TWELVE);
+  requires(SKILL_DIVIDE_EXACT, SKILL_DIVISION_FACTS);
+  // And the whole strand still stands on the floor the addition rows are.
+  requires(SKILL_LONG_MULTIPLICATION, SKILL_ADD_WITHIN_TEN);
+  requires(SKILL_DIVIDE_EXACT, SKILL_ADD_WITHIN_TEN);
+
+  // The integer strand, which is where pre-algebra starts.
+  requires(SKILL_PAST_ZERO, SKILL_SUBTRACT_ACROSS_TEN);
+  requires(SKILL_ADD_SIGNED, SKILL_PAST_ZERO);
+  requires(SKILL_MULTIPLY_SIGNED, SKILL_TABLES_TO_TWELVE);
+});
+
+test("every table fact is below every written multiplication, and the strands do not overlap", () => {
+  const levelsOf = (id: SkillId): readonly { readonly n: bigint; readonly d: bigint }[] =>
+    ALL_BY_ID.get(String(id))?.difficulty.levels ?? [];
+  const hardest = (ids: readonly SkillId[]) =>
+    ids.flatMap(levelsOf).reduce((high, current) => (cmp(current, high) > 0 ? current : high));
+  const easiest = (ids: readonly SkillId[]) =>
+    ids.flatMap(levelsOf).reduce((low, current) => (cmp(current, low) < 0 ? current : low));
+
+  const tables = hardest([SKILL_TABLES_WITHIN_FIVE, SKILL_TABLES_TO_TWELVE]);
+  const written = easiest([SKILL_TIMES_ONE_DIGIT, SKILL_TIMES_TWO_DIGIT, SKILL_LONG_MULTIPLICATION]);
+  assert.ok(
+    cmp(tables, written) < 0,
+    `the hardest table fact ${ratToString(tables)} is not below the easiest written multiplication ${ratToString(written)}`,
+  );
+
+  // And the top of the arithmetic spine is the top of this strand: the hardest
+  // item in `add`, `mul` and `div` together is `48,826 × 82,726`. Not the hardest
+  // in the graph — `dw.frac.*` reaches further and should, since a fraction row is
+  // grade-5 content standing on all of this — so the claim is scoped to the three
+  // whole-number domains rather than overstated.
+  const spine = allNodes
+    .filter((node) => ["add", "mul", "div"].includes(node.domain))
+    .flatMap((node) => node.difficulty.levels.map((b) => ({ node, b })));
+  const highest = spine.reduce((high, current) => (cmp(current.b, high.b) > 0 ? current : high));
+  assert.equal(
+    String(highest.node.id),
+    String(SKILL_LONG_MULTIPLICATION),
+    `the hardest whole-number item belongs to ${highest.node.id} at ${ratToString(highest.b)}`,
+  );
+  assert.equal(highest.b, ALL_BY_ID.get(String(SKILL_LONG_MULTIPLICATION))?.difficulty.levels[2]);
 });

--- a/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
@@ -8,21 +8,31 @@
  * curriculum item today, so promoting a row buys an answer entry on a child's
  * screen with no question above it (CG-8, `render/prompts.ts`).
  *
- * Eighteen of them wait on a **second** thing, and it is not a field flip. CG-10
- * requires an estimated variant space of 975 — a 40-item practice run repeating no
- * more than one item in fifty — and the levels named below do not clear it. Some
- * are genuinely short of problems in the world: `dw.alg.equality.missing-addend` L0
- * draws both operands from 1..9, so its true space is exactly 81 items, and no
- * generator work changes that. Others would clear the floor with a wider draw.
- * Either way the row needs a widened generator, a reconciliation with whoever owns
- * CG-10, or both — and a promotion PR planned as "flip `status`" would fail the
- * gate on the first run.
+ * Three further blockers are named below, and each is a different kind of thing.
  *
- * The list is here rather than in a comment beside each `minVariants` because a
- * comment cannot be checked. `families.property.test.ts` measures the sub-floor set
- * over the whole graph and asserts it equals this list **in both directions**: a
- * level that slips under the floor is named here or the sweep fails, and a
- * generator widened past it must be struck off or the sweep fails too.
+ * **CG-10**, the variant-space floor. It requires an estimated space of 975 — a
+ * 40-item practice run repeating no more than one item in fifty — and the levels
+ * in `CG10_BLOCKED_LEVELS` do not clear it. Some are genuinely short of problems in
+ * the world: `dw.alg.equality.missing-addend` L0 draws both operands from 1..9, so
+ * its true space is exactly 81 items and no generator work changes that. Others
+ * would clear the floor with a wider draw, and two of them now have one — see the
+ * note under the list.
+ *
+ * **The operator**, in `OPERATOR_BLOCKED_TEMPLATES`, and this one is not a gap in
+ * the curriculum at all. It is a defect in the only thing that draws a question
+ * today, and it is why the multiplication and division rows are still draft after
+ * their generators, their fact floors and their variant spaces were all finished.
+ *
+ * **The sign**, in `SIGNED_BLOCKED_SKILLS`. The integer rows answer below zero and
+ * `answer:integer-signed` is not built.
+ *
+ * The lists are here rather than in a comment beside each row because a comment
+ * cannot be checked. `families.property.test.ts` measures the sub-floor set over
+ * the whole graph and asserts it equals `CG10_BLOCKED_LEVELS` **in both
+ * directions**: a level that slips under the floor is named here or the sweep
+ * fails, and a generator widened past it must be struck off or the sweep fails
+ * too. The other two lists are asserted the same way, against the prompt registry
+ * and against the schemas the graph's own items emit.
  *
  * Labels are `<skill id> L<level>`, the same form the sweep prints.
  */
@@ -30,8 +40,6 @@
 export const CG10_BLOCKED_LEVELS: readonly string[] = [
   "dw.ns.place.digit-in-place L0",
   "dw.ns.round.whole-numbers L0",
-  "dw.mul.scale.times-power-of-ten L0",
-  "dw.div.whole.divide-exact L0",
   "dw.frac.equivalence.build-equivalent L0",
   "dw.frac.equivalence.build-equivalent L1",
   "dw.frac.equivalence.build-equivalent L2",
@@ -57,7 +65,99 @@ export const CG10_BLOCKED_LEVELS: readonly string[] = [
   "dw.alg.equality.missing-factor L0",
 ];
 
-/** The skills above, deduplicated — 18 of the graph's 30 draft rows. */
+/**
+ * Two levels came off this list, and neither by argument.
+ *
+ * `dw.mul.scale.times-power-of-ten L0` was `47 × 100` — ninety multiplicands times
+ * one power, ninety problems — and is now three digits by two powers, which is
+ * 1,800. `dw.div.whole.divide-exact L0` was a two-digit quotient over a one-digit
+ * divisor, 720 problems, and is now a three-digit quotient, which is 7,200. Both
+ * were bounded by a digit count that nothing about the content asked to be small,
+ * which is precisely the case `GeneratorBinding.closedFactSet` must not be used
+ * for. A level that could be widened and simply has not been is a level that gets
+ * widened.
+ *
+ * The fact rows added alongside them are the other case and take the other route:
+ * there are 121 multiplications in the tables to twelve and no 122nd, so they
+ * declare `closedFactSet` and are measured against it. Nothing on this list moved
+ * because the floor was argued down.
+ */
+
+/** The skills above, deduplicated. */
 export const CG10_BLOCKED_SKILLS: readonly string[] = [
   ...new Set(CG10_BLOCKED_LEVELS.map((label) => label.slice(0, label.lastIndexOf(" ")))),
+];
+
+/**
+ * Prompt templates the shipped renderer draws with the wrong operator.
+ *
+ * ## The defect, precisely
+ *
+ * `dynawalla-app/src/packs/items.ts` is the only thing in this repository that
+ * turns an `Exercise` into something a child reads, and `packs/shared/game-host`
+ * passes its `prompt` string to a game unchanged. It picks the operator with
+ * `promptKey.endsWith(".sub") ? "−" : "+"`, so **every template that is not a
+ * subtraction is drawn as an addition**. `7 × 8` reaches the child as `7 + 8`,
+ * with 56 as the answer they must give.
+ *
+ * That is correct for the four templates active today, which is why nothing has
+ * caught it: the host's own `items.test.ts` asserts `operator === "+"` for every
+ * skill whose id does not contain "subtract", so it passes on a multiplication row
+ * and passes *wrongly*.
+ *
+ * ## Why this list, and why here
+ *
+ * Promoting a row named below would put a wrong question in front of a child. Not
+ * a blank card, which is what CG-8 usually protects against and what a reviewer
+ * would notice in a minute — a card that reads fine, is answerable, and marks the
+ * right answer wrong. So this is a harder blocker than "no renderer exists", and
+ * it belongs somewhere a promotion PR reads first.
+ *
+ * The fix is small and is not in this package's power: read `promptOperator(key)`
+ * from `render/prompts.ts`, which now carries the glyph for every template, and
+ * put it in `Item.operator` — a field `packs/sdk/src/protocol.ts` has typed as
+ * `"+" | "-" | "×" | "÷" | "<" | ">" | "="` since it was written. When that lands,
+ * every entry below is struck off and the rows above them are a `status` flip.
+ *
+ * `render/prompts.test.ts` asserts this list equals the set of registered
+ * templates whose operator is neither `+` nor `−`, in both directions, so it
+ * cannot go stale as families are added.
+ */
+export const OPERATOR_BLOCKED_TEMPLATES: readonly string[] = [
+  "dw.prompt.frac-arith.mul",
+  "dw.prompt.frac-arith.mul-whole",
+  "dw.prompt.long-div.quotient",
+  "dw.prompt.long-div.quotient-remainder",
+  "dw.prompt.long-div.remainder",
+  "dw.prompt.missing-operand.mul-unknown",
+  // These two are subtractions and are drawn with a plus, which is the same
+  // defect arriving by a different route: the host tests `endsWith(".sub")` and
+  // these keys end `".sub-unknown"`. Found by `render/prompts.test.ts` rather
+  // than by reading — the list was authored from the non-additive families and
+  // missed the two additive-family templates whose *names* the rule mis-parses.
+  "dw.prompt.missing-operand.sub-unknown",
+  "dw.prompt.missing-operand.sub-unknown-minuend",
+  "dw.prompt.multidigit-mul.product",
+  "dw.prompt.signed-int.mul",
+  "dw.prompt.times-table.div",
+  "dw.prompt.times-table.mul",
+];
+
+/**
+ * Skills whose answers go below zero, which no built entry surface can express.
+ *
+ * A digit keypad handed `(−7) + 4` is not a blank card. It is a card that looks
+ * answerable, and every key the child can press produces a positive number — so
+ * the only thing they can do is be wrong. `render/registry.ts` declares
+ * `answer:integer-signed` as a renderer distinct from `answer:integer` for exactly
+ * this reason, and CG-8 tells the two apart through `answerRendererIdFor`.
+ *
+ * `signedInt.test.ts` asserts this list equals the set of skills in the graph
+ * whose bound levels emit a signed schema, in both directions.
+ */
+export const SIGNED_BLOCKED_SKILLS: readonly string[] = [
+  "dw.int.arith.add-signed",
+  "dw.int.arith.multiply-signed",
+  "dw.int.arith.subtract-past-zero",
+  "dw.int.arith.subtract-signed",
 ];

--- a/dynawalla/packs/shared/curriculum/src/index.ts
+++ b/dynawalla/packs/shared/curriculum/src/index.ts
@@ -27,6 +27,7 @@ export { addDomainNodes } from "./graph/domains/add.ts";
 export { algDomainNodes } from "./graph/domains/alg.ts";
 export { divDomainNodes } from "./graph/domains/div.ts";
 export { fracDomainNodes } from "./graph/domains/frac.ts";
+export { intDomainNodes } from "./graph/domains/int.ts";
 export { mulDomainNodes } from "./graph/domains/mul.ts";
 export { nsDomainNodes } from "./graph/domains/ns.ts";
 
@@ -62,6 +63,28 @@ export {
   NUMBER_FACTS_FORMS,
   NUMBER_FACTS_LOC_KEYS,
 } from "./generators/numberFacts/constants.ts";
+export { timesTableFamily } from "./generators/timesTable/family.ts";
+export { timesTableParamSchema } from "./generators/timesTable/params.ts";
+export type { TimesTableParams } from "./generators/timesTable/params.ts";
+export { factSet as timesTableSet, factSetSize as timesTableSetSize } from "./generators/timesTable/facts.ts";
+// Named rather than `export *`: three families now define a `PROMPT_KEY_MUL`.
+export {
+  TIMES_TABLE_FAMILY,
+  TIMES_TABLE_FAMILY_REV,
+  TIMES_TABLE_FORMS,
+  TIMES_TABLE_LOC_KEYS,
+} from "./generators/timesTable/constants.ts";
+export { signedIntFamily } from "./generators/signedInt/family.ts";
+export { signedIntParamSchema } from "./generators/signedInt/params.ts";
+export type { SignedIntParams, SignedOp, SignPlacement } from "./generators/signedInt/params.ts";
+export { pairSet, pairSetSize } from "./generators/signedInt/pairs.ts";
+export type { Pair } from "./generators/signedInt/pairs.ts";
+export {
+  SIGNED_INT_FAMILY,
+  SIGNED_INT_FAMILY_REV,
+  SIGNED_INT_FORMS,
+  SIGNED_INT_LOC_KEYS,
+} from "./generators/signedInt/constants.ts";
 export { multidigitMulFamily } from "./generators/multidigitMul/family.ts";
 export { multidigitMulParamSchema } from "./generators/multidigitMul/params.ts";
 export type { MultidigitMulParams } from "./generators/multidigitMul/params.ts";
@@ -104,9 +127,15 @@ export {
 export { placeValueMalRules, MIS_DIGIT_FOR_VALUE } from "./malrules/placeValue.ts";
 export { MIS_WHOLE_NUMBER_BIAS } from "./malrules/roots.ts";
 
-export { answerRendererId, findRenderer, rendererRegistry, repRendererId } from "./render/registry.ts";
-export { findPromptTemplate, promptRegistry } from "./render/prompts.ts";
-export type { PromptTemplateDeclaration } from "./render/prompts.ts";
+export {
+  answerRendererId,
+  answerRendererIdFor,
+  findRenderer,
+  rendererRegistry,
+  repRendererId,
+} from "./render/registry.ts";
+export { findPromptTemplate, promptOperator, promptRegistry } from "./render/prompts.ts";
+export type { PromptOperator, PromptTemplateDeclaration } from "./render/prompts.ts";
 export type { RendererDeclaration } from "./render/registry.ts";
 export {
   balanceLowerPan,

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The prompt registry, and the operator a question is written with.
+ *
+ * ## Why this file exists
+ *
+ * `dynawalla-app/src/packs/items.ts` is the only thing in this repository that
+ * turns an `Exercise` into a string a child reads, and `packs/shared/game-host`
+ * hands that string to a game unchanged. It picks the operator like this:
+ *
+ * ```ts
+ * export function isSubtraction(promptKey: string): boolean {
+ *   return promptKey === PROMPT_KEY_SUB || promptKey.endsWith(".sub")
+ * }
+ * // …
+ * prompt: `${top} ${subtract ? MINUS : "+"} ${bottom}`,
+ * ```
+ *
+ * So every template that is not a subtraction is drawn as an **addition**. That is
+ * right for the four templates the graph has active and wrong for ten others, and
+ * the failure it produces is the worst shape this program has: `7 × 8` reaches the
+ * child as `7 + 8`, reads perfectly, is answerable, and marks 15 wrong.
+ *
+ * The rule is reproduced here — not imported, because this package cannot import
+ * the app — and asserted against what the curriculum actually declares. The list
+ * it disagrees on is `OPERATOR_BLOCKED_TEMPLATES`, which is what stops the
+ * multiplication and division rows being promoted, and this is what keeps that
+ * list from going stale in either direction.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { allNodes } from "../graph/graph.ts";
+import { OPERATOR_BLOCKED_TEMPLATES } from "../graph/promotionBlockers.ts";
+import { familyById } from "../generators/registry.ts";
+import { findPromptTemplate, promptOperator, promptRegistry } from "./prompts.ts";
+import type { PromptOperator } from "./prompts.ts";
+
+/**
+ * The shipped renderer's rule, transcribed from
+ * `dynawalla-app/src/packs/items.ts`. Reproduced rather than imported: the
+ * curriculum cannot depend on the app, and a transcription that drifts from the
+ * original is caught by the next person to read either file — where a test that
+ * skipped the question entirely is caught by nobody.
+ */
+function operatorTheHostWouldDraw(promptKey: string): "+" | "−" {
+  return promptKey.endsWith(".sub") ? "−" : "+";
+}
+
+test("every registered template declares the operator its question is written with", () => {
+  const glyphs = new Map<PromptOperator, number>();
+  for (const entry of promptRegistry) {
+    const operator = promptOperator(String(entry.id));
+    assert.ok(operator !== null, `${entry.id} declares no operator`);
+    glyphs.set(operator, (glyphs.get(operator) ?? 0) + 1);
+    // The declaration and the key have to agree where the key says anything at
+    // all, or the table is a second source of truth that can drift from the first.
+    if (String(entry.id).endsWith(".add")) assert.equal(operator, "+", entry.id);
+    if (String(entry.id).endsWith(".sub")) assert.equal(operator, "−", entry.id);
+    if (String(entry.id).endsWith(".mul")) assert.equal(operator, "×", entry.id);
+    if (String(entry.id).endsWith(".div")) assert.equal(operator, "÷", entry.id);
+  }
+  assert.ok((glyphs.get("×") ?? 0) >= 4, "no multiplication template in a program that teaches multiplication");
+  assert.ok((glyphs.get("÷") ?? 0) >= 4, "no division template in a program that teaches division");
+  process.stdout.write(
+    `# prompt operators: ${[...glyphs].map(([glyph, count]) => `${glyph}×${String(count)}`).join(" ")}\n`,
+  );
+});
+
+test("an unregistered key has no operator, and the answer is null rather than a plus", () => {
+  // The default matters more than it looks. A renderer that cannot tell what
+  // operator a question uses must draw nothing and say so; a lookup that fell back
+  // to `"+"` would reproduce the defect this table exists to retire, one layer
+  // further in and harder to see.
+  assert.equal(promptOperator("dw.prompt.nothing.at-all"), null);
+  assert.equal(findPromptTemplate("dw.prompt.nothing.at-all" as never), undefined);
+});
+
+test("the templates the shipped renderer would mis-draw are exactly the blocked list", () => {
+  const misdrawn = promptRegistry
+    .filter((entry) => entry.operator !== "none")
+    .filter((entry) => operatorTheHostWouldDraw(String(entry.id)) !== entry.operator)
+    .map((entry) => String(entry.id))
+    .sort();
+
+  assert.deepEqual(
+    misdrawn,
+    [...OPERATOR_BLOCKED_TEMPLATES].sort(),
+    "promotionBlockers.ts and the registry disagree about which questions are drawn with the wrong sign",
+  );
+
+  // And the rule is right on everything else, so the list above is a list of
+  // defects rather than a list of everything the renderer draws. `none` is
+  // excluded from both halves: a question that is not a binary operation is drawn
+  // by a different path entirely, and the host's plus sign is not an answer to it.
+  const blocked = new Set(misdrawn);
+  for (const entry of promptRegistry) {
+    if (entry.operator === "none" || blocked.has(String(entry.id))) continue;
+    assert.equal(operatorTheHostWouldDraw(String(entry.id)), entry.operator, entry.id);
+  }
+  process.stdout.write(
+    `# operator blocker: ${String(misdrawn.length)} of ${String(promptRegistry.length)} templates would be drawn ` +
+      `with the wrong sign\n`,
+  );
+});
+
+test("no active row emits a template the shipped renderer would mis-draw", () => {
+  // The claim the blocker list is *for*, checked against the graph rather than
+  // against the list. Promoting a row named in `OPERATOR_BLOCKED_TEMPLATES` puts a
+  // wrong question in front of a child — not a blank card, which a reviewer would
+  // see in a minute, but a card that reads fine and marks the right answer wrong.
+  const blocked = new Set(OPERATOR_BLOCKED_TEMPLATES);
+  for (const node of allNodes) {
+    if (node.status !== "active") continue;
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined, `${node.id} binds an unregistered family`);
+    node.generator.params.forEach((raw, level) => {
+      const validated = family.paramSchema.validate(raw);
+      if (!validated.ok) return;
+      for (let seed = 1; seed <= 40; seed++) {
+        const key = String(
+          family.generate({
+            skillId: node.id,
+            level,
+            seed,
+            params: validated.value,
+            forms: node.generator.forms,
+          }).prompt.key,
+        );
+        assert.ok(
+          !blocked.has(key),
+          `${node.id} L${String(level)} is active and emits ${key}, which the shipped renderer draws with a plus ` +
+            `sign — a child would be asked the wrong question and marked wrong for answering the right one`,
+        );
+      }
+    });
+  }
+});
+
+test("every template a bound level can emit is registered, and nothing is registered that none emits", () => {
+  // Both directions, over the *whole* graph including drafts, because a draft row
+  // is exactly where an unregistered template would sit unnoticed until the day
+  // somebody promotes it.
+  const emitted = new Set<string>();
+  for (const node of allNodes) {
+    if (node.status === "deprecated") continue;
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined, `${node.id} binds an unregistered family`);
+    node.generator.params.forEach((raw, level) => {
+      const validated = family.paramSchema.validate(raw);
+      assert.ok(validated.ok, `${node.id} L${String(level)} params rejected`);
+      if (!validated.ok) return;
+      for (let seed = 1; seed <= 60; seed++) {
+        emitted.add(
+          String(
+            family.generate({
+              skillId: node.id,
+              level,
+              seed,
+              params: validated.value,
+              forms: node.generator.forms,
+            }).prompt.key,
+          ),
+        );
+      }
+    });
+  }
+
+  const declared = promptRegistry.map((entry) => String(entry.id));
+  assert.deepEqual(
+    [...emitted].filter((key) => !declared.includes(key)).sort(),
+    [],
+    "a bound level emits a prompt template nobody registered",
+  );
+  assert.deepEqual(
+    declared.filter((key) => !emitted.has(key)).sort(),
+    [],
+    "a prompt template is registered that no bound level emits",
+  );
+  assert.equal(new Set(declared).size, declared.length, "a prompt template is declared twice");
+});

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.ts
@@ -39,11 +39,46 @@
 import type { FamilyId, LocKey } from "../types/ids.ts";
 import { familyId, locKey } from "../types/ids.ts";
 
+/**
+ * The operator glyph a template's question is written with, or `none` for a
+ * question that is not a binary operation at all.
+ *
+ * ## Why this is on the declaration and not left to the renderer
+ *
+ * Because the renderer got it wrong, in the shipped product, in the way this
+ * program keeps meeting: silently and in the child's favour of nobody.
+ *
+ * `dynawalla-app/src/packs/items.ts` builds the string a game shows a child, and
+ * it decides the operator like this:
+ *
+ * ```ts
+ * export function isSubtraction(promptKey: string): boolean {
+ *   return promptKey === PROMPT_KEY_SUB || promptKey.endsWith(".sub")
+ * }
+ * // …
+ * prompt: `${top} ${subtract ? MINUS : "+"} ${bottom}`,
+ * ```
+ *
+ * Every template that is not a subtraction is drawn as an **addition**. That is
+ * correct for the four templates the graph has active today and wrong for eleven
+ * of the rest: `dw.prompt.times-table.mul` would reach a child as `7 + 8` with 56
+ * as the answer. `packs/sdk/src/protocol.ts` has carried `"×"` and `"÷"` in
+ * `Item.operator` the whole time; what was missing was anywhere to look them up.
+ *
+ * This is that place. It is data the curriculum owns — which glyph a question is
+ * written with is a fact about the question — and `promptOperator()` below is the
+ * lookup a renderer needs. `promotionBlockers.ts` lists the templates that are
+ * mis-drawn until one uses it.
+ */
+export type PromptOperator = "+" | "−" | "×" | "÷" | "none";
+
 export type PromptTemplateDeclaration = {
   /** The `LocKey` a family writes into `Exercise.prompt.key`. */
   readonly id: LocKey;
   /** The family that emits it. Lets the gate report a family, not just a key. */
   readonly family: FamilyId;
+  /** The glyph this question is written with. See `PromptOperator`. */
+  readonly operator: PromptOperator;
   /** The PR that owns landing the renderer. Required — an unowned entry is noise. */
   readonly owner: string;
   readonly implemented: boolean;
@@ -61,6 +96,8 @@ const LONG_DIV = familyId("gen.arith.long-div");
 const FRAC_EQUIVALENCE = familyId("gen.frac.equivalence-simplify");
 const FRAC_ARITH = familyId("gen.frac.arith");
 const MISSING_OPERAND = familyId("gen.arith.missing-operand");
+const TIMES_TABLE = familyId("gen.arith.times-table");
+const SIGNED_INT = familyId("gen.arith.signed-int");
 
 /**
  * Every prompt template every registered family can emit.
@@ -80,77 +117,97 @@ const MISSING_OPERAND = familyId("gen.arith.missing-operand");
 export const promptRegistry: readonly PromptTemplateDeclaration[] = [
   // The bottom of the ladder. Two numbers and an operator, which is the smallest
   // question this program can ask and the first one a five-year-old sees.
-  { id: locKey("dw.prompt.number-facts.add"), family: NUMBER_FACTS, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.number-facts.sub"), family: NUMBER_FACTS, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.number-facts.add"), operator: "+", family: NUMBER_FACTS, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.number-facts.sub"), operator: "−", family: NUMBER_FACTS, owner: "PR-2.13", implemented: false },
 
-  { id: locKey("dw.prompt.column-op.sub"), family: COLUMN_OP, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.column-op.add"), family: COLUMN_OP, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.column-op.sub"), operator: "−", family: COLUMN_OP, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.column-op.add"), operator: "+", family: COLUMN_OP, owner: "PR-2.13", implemented: false },
 
-  { id: locKey("dw.prompt.place-value.digit-value"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.place-value.digit-in-place"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.place-value.total-in-place"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.place-value.digit-value"), operator: "none", family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.place-value.digit-in-place"), operator: "none", family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.place-value.total-in-place"), operator: "none", family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
 
-  { id: locKey("dw.prompt.compare-order.greater"), family: COMPARE_ORDER, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.compare-order.lesser"), family: COMPARE_ORDER, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.compare-order.greater"), operator: "none", family: COMPARE_ORDER, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.compare-order.lesser"), operator: "none", family: COMPARE_ORDER, owner: "PR-2.13", implemented: false },
 
-  { id: locKey("dw.prompt.round-estimate.round"), family: ROUND_ESTIMATE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.round-estimate.round"), operator: "none", family: ROUND_ESTIMATE, owner: "PR-2.13", implemented: false },
 
-  { id: locKey("dw.prompt.multidigit-mul.product"), family: MULTIDIGIT_MUL, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.multidigit-mul.product"), operator: "×", family: MULTIDIGIT_MUL, owner: "PR-2.13", implemented: false },
 
-  { id: locKey("dw.prompt.long-div.quotient"), family: LONG_DIV, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.long-div.remainder"), family: LONG_DIV, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.long-div.quotient"), operator: "÷", family: LONG_DIV, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.long-div.remainder"), operator: "÷", family: LONG_DIV, owner: "PR-2.13", implemented: false },
   {
     id: locKey("dw.prompt.long-div.quotient-remainder"),
+    operator: "÷",
     family: LONG_DIV,
     owner: "PR-2.13",
     implemented: false,
   },
 
-  { id: locKey("dw.prompt.frac-equivalence.simplify"), family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.frac-equivalence.build"), family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.frac-equivalence.to-mixed"), family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-equivalence.simplify"), operator: "none", family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-equivalence.build"), operator: "none", family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-equivalence.to-mixed"), operator: "none", family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
   {
     id: locKey("dw.prompt.frac-equivalence.to-improper"),
+    operator: "none",
     family: FRAC_EQUIVALENCE,
     owner: "PR-2.13",
     implemented: false,
   },
 
-  { id: locKey("dw.prompt.frac-arith.add"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.frac-arith.sub"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.frac-arith.mul"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
-  { id: locKey("dw.prompt.frac-arith.mul-whole"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.add"), operator: "+", family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.sub"), operator: "−", family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.mul"), operator: "×", family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.mul-whole"), operator: "×", family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
 
   {
     id: locKey("dw.prompt.missing-operand.add-unknown"),
+    operator: "+",
     family: MISSING_OPERAND,
     owner: "PR-2.13",
     implemented: false,
   },
   {
     id: locKey("dw.prompt.missing-operand.sub-unknown"),
+    operator: "−",
     family: MISSING_OPERAND,
     owner: "PR-2.13",
     implemented: false,
   },
   {
     id: locKey("dw.prompt.missing-operand.sub-unknown-minuend"),
+    operator: "−",
     family: MISSING_OPERAND,
     owner: "PR-2.13",
     implemented: false,
   },
   {
     id: locKey("dw.prompt.missing-operand.mul-unknown"),
+    operator: "×",
     family: MISSING_OPERAND,
     owner: "PR-2.13",
     implemented: false,
   },
   {
     id: locKey("dw.prompt.missing-operand.both-sides"),
+    operator: "none",
     family: MISSING_OPERAND,
     owner: "PR-2.13",
     implemented: false,
   },
+
+  // The tables and their inverses. Neither glyph has ever been drawn by anything
+  // in this repository, and the second is the one a game would meet first.
+  { id: locKey("dw.prompt.times-table.mul"), operator: "×", family: TIMES_TABLE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.times-table.div"), operator: "÷", family: TIMES_TABLE, owner: "PR-2.13", implemented: false },
+
+  // Signed arithmetic. The `+` and `−` here are the same glyphs the additive
+  // families use and the *operands* are what differ — `(−7) + 4` is an addition
+  // however it reads — so a renderer that draws these correctly still needs
+  // `answer:integer-signed` before the card is answerable.
+  { id: locKey("dw.prompt.signed-int.add"), operator: "+", family: SIGNED_INT, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.signed-int.sub"), operator: "−", family: SIGNED_INT, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.signed-int.mul"), operator: "×", family: SIGNED_INT, owner: "PR-2.13", implemented: false },
 ];
 
 export function findPromptTemplate(
@@ -158,4 +215,20 @@ export function findPromptTemplate(
   registry: readonly PromptTemplateDeclaration[] = promptRegistry,
 ): PromptTemplateDeclaration | undefined {
   return registry.find((entry) => entry.id === key);
+}
+
+/**
+ * The glyph this question is written with, or `null` for a key nothing declares.
+ *
+ * The lookup a renderer needs, so that "which operator is this" is a table read
+ * rather than a guess from the shape of the key. `null` and not `"+"` on an
+ * unknown key, deliberately: a renderer that cannot tell must draw nothing and say
+ * so, because the alternative is the defect this function exists to retire — a
+ * multiplication served to a child with a plus sign in the middle of it.
+ */
+export function promptOperator(
+  key: string,
+  registry: readonly PromptTemplateDeclaration[] = promptRegistry,
+): PromptOperator | null {
+  return registry.find((entry) => String(entry.id) === key)?.operator ?? null;
 }

--- a/dynawalla/packs/shared/curriculum/src/render/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/registry.ts
@@ -39,7 +39,7 @@
  * the three rules above exist to prevent.
  */
 
-import type { AnswerSchemaKind } from "../types/answer.ts";
+import type { AnswerSchema, AnswerSchemaKind } from "../types/answer.ts";
 import type { RepId } from "../types/ids.ts";
 
 export type RendererDeclaration = {
@@ -62,6 +62,18 @@ const PACK = "PR-4.16 — a pack renderer, ADR-0022";
 
 export const rendererRegistry: readonly RendererDeclaration[] = [
   { id: "answer:integer", kind: "answerSchema", owner: PACK, implemented: false },
+  /**
+   * The signed integer entry, and it is a **separate renderer** rather than a flag
+   * on the one above.
+   *
+   * A pack that implements `answer:integer` implements a digit keypad, and a digit
+   * keypad handed `(−7) + 4` draws a card a child cannot answer: every key they can
+   * press produces a positive number. That is not the blank screen CG-8 usually
+   * catches, it is worse — the card looks answerable and marks a correct child
+   * wrong. Two ids means the gate can tell the two apart, and a pack that has only
+   * built the unsigned keypad cannot accidentally satisfy the signed rows.
+   */
+  { id: "answer:integer-signed", kind: "answerSchema", owner: PACK, implemented: false },
   { id: "answer:columnAlgorithm", kind: "answerSchema", owner: PACK, implemented: false },
   { id: "answer:fraction", kind: "answerSchema", owner: PACK, implemented: false },
   { id: "answer:choice", kind: "answerSchema", owner: PACK, implemented: false },
@@ -82,6 +94,19 @@ export const rendererRegistry: readonly RendererDeclaration[] = [
 
 export function answerRendererId(kind: AnswerSchemaKind): string {
   return `answer:${kind}`;
+}
+
+/**
+ * The renderer a *schema* needs, which is not always the one its kind names.
+ *
+ * `answerRendererId` takes a kind and is kept as it was, because a caller holding
+ * only a kind is asking a narrower question and gets a narrower answer. CG-8 holds
+ * the whole schema and must ask the wider one: a signed integer entry is a
+ * different widget from an unsigned one, not the same widget in a different mood.
+ */
+export function answerRendererIdFor(schema: AnswerSchema): string {
+  if (schema.kind === "integer" && schema.signed === true) return "answer:integer-signed";
+  return answerRendererId(schema.kind);
 }
 
 export function repRendererId(rep: RepId): string {

--- a/dynawalla/packs/shared/curriculum/src/serialize.ts
+++ b/dynawalla/packs/shared/curriculum/src/serialize.ts
@@ -54,8 +54,12 @@ function step(value: SolutionStep): string {
  */
 function schema(value: AnswerSchema): string {
   switch (value.kind) {
+    // The sign is appended rather than written as a third positional field, so
+    // every hash committed before integers existed is byte-identical after them.
+    // A snapshot that turned over on a field no existing level sets would have
+    // been a diff nobody could review for the one thing it is there to catch.
     case "integer":
-      return `integer(${String(value.digits)},${String(value.decimalPlaces)})`;
+      return `integer(${String(value.digits)},${String(value.decimalPlaces)}${value.signed === true ? ",signed" : ""})`;
     case "columnAlgorithm":
       return `columnAlgorithm(${String(value.cols)},${value.marks},${String(value.decimalPlaces)})`;
     case "fraction":

--- a/dynawalla/packs/shared/curriculum/src/types/answer.ts
+++ b/dynawalla/packs/shared/curriculum/src/types/answer.ts
@@ -60,7 +60,33 @@ export type FractionEquivalence =
   | "any-equivalent";
 
 export type AnswerSchema =
-  | { readonly kind: "integer"; readonly digits: number; readonly decimalPlaces: number }
+  | {
+      readonly kind: "integer";
+      readonly digits: number;
+      readonly decimalPlaces: number;
+      /**
+       * The answer may be below zero, and the surface must offer a way to write
+       * that. Absent means it may not, which is every skill the program had before
+       * integers arrived.
+       *
+       * On the schema and not inferred from the item, for the reason `equivalence`
+       * and `options` are on the schema: a renderer receives the schema and nothing
+       * else. `EntryModel.init`, `.keys` and `.value` take a schema, so "does this
+       * keypad have a minus key" has to be answerable from here or it is not
+       * answerable where it is needed — and a keypad with no minus key on
+       * `(−7) + 4` is a card a child cannot answer correctly however well they
+       * understand it.
+       *
+       * `digits` counts digit cells and never the sign: `−144` is three digits and
+       * a minus, not four.
+       *
+       * It is also what makes the sweep's "no answer is negative" invariant
+       * checkable instead of absolute. That assertion held over every item in the
+       * graph until this field existed; now it holds over every item whose schema
+       * does not say otherwise, which is the claim actually worth making.
+       */
+      readonly signed?: boolean;
+    }
   | {
       readonly kind: "columnAlgorithm";
       readonly cols: number;

--- a/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
@@ -307,7 +307,7 @@ test("CG-8: strict mode rejects a prompt template that is declared but not imple
   const renderers = rendererRegistry.map(drawn);
   const unbuilt = promptRegistry.map(drawn).map((entry) =>
     entry.id === "dw.prompt.column-op.sub"
-      ? { id: entry.id, family: entry.family, owner: entry.owner, implemented: false }
+      ? { id: entry.id, family: entry.family, operator: entry.operator, owner: entry.owner, implemented: false }
       : entry,
   );
   assert.equal(

--- a/dynawalla/packs/shared/curriculum/src/validate/gates/bindingGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates/bindingGates.ts
@@ -6,7 +6,7 @@
 
 import { activeNodes } from "../../graph/graph.ts";
 import { familyById } from "../../generators/registry.ts";
-import { answerRendererId, findRenderer, repRendererId } from "../../render/registry.ts";
+import { answerRendererIdFor, findRenderer, repRendererId } from "../../render/registry.ts";
 import { findPromptTemplate } from "../../render/prompts.ts";
 import type { FamilyId } from "../../types/ids.ts";
 import type { LevelSample, ValidationContext } from "../context.ts";
@@ -223,7 +223,15 @@ export function cg8(context: ValidationContext, samples: readonly LevelSample[])
       if (!validated.ok) return; // CG-7 owns this failure.
       for (const form of node.generator.forms) {
         const schema = family.answerSchema(validated.value, form);
-        requireRenderer(answerRendererId(schema.kind), node.id, `L${String(level)} ${form} answer schema "${schema.kind}"`);
+        // `answerRendererIdFor` and not `answerRendererId(schema.kind)`: a signed
+        // integer entry is a different widget from an unsigned one, and a gate
+        // that read only the kind would let a row whose answers go below zero be
+        // drawn by a keypad with no minus key.
+        requireRenderer(
+          answerRendererIdFor(schema),
+          node.id,
+          `L${String(level)} ${form} answer schema "${answerRendererIdFor(schema).slice("answer:".length)}"`,
+        );
       }
     });
 


### PR DESCRIPTION
The graph reached `4,003 − 87` and stopped. `mul` had 0 active / 3 draft rows and
no fact recall at all, `div` had no floor under long division, and there was no
integer arithmetic anywhere. `48,826 × 82,726` was not merely unauthored —
`multidigit-mul` capped the multiplier at three digits, so no parameter object
could describe it.

Two new generator families, eight new rows, two CG-10 blockers cleared, and one
defect found on the way that is the reason nothing is promoted.

## What is here

**`gen.arith.times-table`** — the tables and their inverses, `0 × 1` through
`144 ÷ 12`, drawn uniformly from an enumerated closed set. One family for both
directions because `48 ÷ 6` is `6 × 8` read backwards, exactly as `15 − 8` is
`8 + 7` read backwards in `gen.arith.number-facts`. Three rows bind it:
`dw.mul.facts.tables-within-five`, `dw.mul.facts.tables-to-twelve`,
`dw.div.facts.division-facts`. Each declares `closedFactSet` — the reconciliation
with CG-10 that PR #655 established, applied to the content the old `mul.ts` said
the floor forbade outright.

**`gen.arith.signed-int`**, in a seventh domain, `int`. `3 − 9` as the on-ramp,
then adding, subtracting and multiplying signed numbers. Bounded by magnitude and
capped at twenty: past twenty this is column arithmetic wearing a sign, and column
arithmetic has a family. These are the first answers in the program that carry a
minus, so `AnswerSchema.integer` gains `signed` and the registry gains
`answer:integer-signed` — a separate renderer id rather than a flag, because a
digit keypad handed `(−7) + 4` is not the blank card CG-8 usually catches; it is a
card that looks answerable and marks a correct child wrong.

**`dw.mul.multidigit.long-multiplication`**, whose top level is `48,826 × 82,726`.
`MAX_MULTIPLIER_DIGITS` goes 3 → 5; no existing level's output moves, so
`familyRev` does not turn over and no committed hash changes.

**Two CG-10 blockers cleared by widening, not by argument.**
`dw.mul.scale.times-power-of-ten` L0 from 90 problems to 1,800 and
`dw.div.whole.divide-exact` L0 from 720 to 7,200. Both were bounded by a digit
count that nothing about the content asked to be small, which is precisely the
case `closedFactSet` must not be used for.

## Why nothing is promoted to `active`

`dynawalla-app/src/packs/items.ts` is the only thing in the repository that turns
an `Exercise` into a string a child reads, and `packs/shared/game-host` passes it
to a game unchanged. It picks the operator with

```ts
promptKey.endsWith(".sub") ? MINUS : "+"
```

so **every template that is not a subtraction is drawn as an addition**. Promoting
`dw.mul.facts.tables-to-twelve` today would put `7 + 8` in front of a child with
56 as the required answer. Not a blank card — a card that reads fine, is
answerable, and marks the right answer wrong. The host's own `items.test.ts`
asserts `operator === "+"` for every skill whose id does not contain "subtract",
so it passes on a multiplication row and passes *wrongly*.

This PR ships the data that fix needs — `PromptTemplateDeclaration.operator` and
`promptOperator(key)`, the glyph for all 32 templates — and names the twelve
templates the shipped renderer mis-draws in `OPERATOR_BLOCKED_TEMPLATES`, asserted
against the registry in both directions. `render/prompts.test.ts` found two that a
human reading of the list had missed: `dw.prompt.missing-operand.sub-unknown` is a
subtraction whose key ends `".sub-unknown"`, so the rule draws it with a plus too.

Once `items.ts` reads `promptOperator` into `Item.operator` — a field
`packs/sdk/src/protocol.ts` has typed `"+" | "-" | "×" | "÷" | "<" | ">" | "="`
since it was written — every mul and div row here is a `status` flip. `int` needs
`answer:integer-signed` as well.

## Gates

`npm test` 206/206, five consecutive runs. `npm run tsc` clean. `npm run check`
OK — CG-1 through CG-22 unchanged in status, no new failures, no snapshot churn
(CG-16 walks active rows and the active set did not change). `dynawalla-app`
238/238 and typecheck clean against the new graph.

Claude-Session: https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
