### PR TITLE
feat(dynawalla): real haptics on iOS — the cues were a silent no-op on the whole platform

### DIFF
--- a/corpan/plugins/tauri-plugin-haptics/CHANGELOG.md
+++ b/corpan/plugins/tauri-plugin-haptics/CHANGELOG.md
@@ -11,6 +11,16 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+### Added
+- Two new `impact(style)` values, `selection` and `error`. Purely additive:
+  no existing style, command, argument type or permission changed, and Corpán
+  sends neither string. `selection` is `UISelectionFeedbackGenerator`
+  (`selectionChanged()`) on iOS and the shortest still-felt one-shot on
+  Android; `error` is `UINotificationFeedbackGenerator.error` on iOS and a
+  heavier, slower waveform than `warning` on Android. Added for Dynawalla,
+  which had no native haptics at all — it drove `navigator.vibrate`, which
+  does not exist in iOS WKWebView.
+
 ## [0.1.0] - 2026-06-16
 
 ### Added

--- a/corpan/plugins/tauri-plugin-haptics/android/src/main/java/com/corpora/haptics/HapticsPlugin.kt
+++ b/corpan/plugins/tauri-plugin-haptics/android/src/main/java/com/corpora/haptics/HapticsPlugin.kt
@@ -62,10 +62,15 @@ class HapticsPlugin(private val activity: Activity) : Plugin(activity) {
             // reveal haptic goes unfelt. A duration + amplitude one-shot is
             // reliably felt across devices.
             when (args.style) {
+                // Android has no selection generator; the nearest honest
+                // equivalent is the shortest one-shot that is still felt.
+                "selection" -> strongOneShot(vib, ms = 12L, amplitude = 90)
                 "light" -> strongOneShot(vib, ms = 18L, amplitude = 110)
                 "heavy" -> strongOneShot(vib, ms = 55L, amplitude = 255)
                 "success" -> waveform(vib, longArrayOf(0, 35, 60, 55))
                 "warning" -> waveform(vib, longArrayOf(0, 45, 80, 70))
+                // Heavier and slower than "warning": a refusal, not a caution.
+                "error" -> waveform(vib, longArrayOf(0, 55, 45, 90))
                 // "medium" and any unknown value
                 else -> strongOneShot(vib, ms = 32L, amplitude = 190)
             }

--- a/corpan/plugins/tauri-plugin-haptics/ios/Sources/HapticsPlugin.swift
+++ b/corpan/plugins/tauri-plugin-haptics/ios/Sources/HapticsPlugin.swift
@@ -5,9 +5,17 @@ import WebKit
 /// Native haptic feedback plugin for iOS.
 ///
 /// Fire-and-forget. `impact(style:)` maps:
-///   light/medium/heavy → UIImpactFeedbackGenerator
-///   success/warning     → UINotificationFeedbackGenerator
+///   light/medium/heavy    → UIImpactFeedbackGenerator
+///   selection             → UISelectionFeedbackGenerator
+///   success/warning/error → UINotificationFeedbackGenerator
 /// All generator work happens on the main thread (UIKit requirement).
+///
+/// Adding a style is additive by construction: an unknown string already falls
+/// back to `.medium`, so a caller that sends one of these to an older build
+/// feels a medium impact rather than an error. That is also the trap — a
+/// misspelled style is INDISTINGUISHABLE from a working one at runtime, which
+/// is why Dynawalla's `haptics.test.ts` parses this file and asserts every
+/// style it sends appears here as an explicit case.
 class HapticsPlugin: Plugin {
     @objc func impact(_ invoke: Invoke) throws {
         let args = try invoke.parseArgs(ImpactArgs.self)
@@ -24,6 +32,18 @@ class HapticsPlugin: Plugin {
                 let gen = UIImpactFeedbackGenerator(style: .heavy)
                 gen.prepare()
                 gen.impactOccurred()
+            case "selection":
+                // `UISelectionFeedbackGenerator` is not a small impact — it is
+                // the OS's own "a value changed under your finger" cue, tuned
+                // to stay crisp when it repeats at speed instead of turning to
+                // mush the way a stream of light impacts does.
+                let gen = UISelectionFeedbackGenerator()
+                gen.prepare()
+                gen.selectionChanged()
+            case "error":
+                let gen = UINotificationFeedbackGenerator()
+                gen.prepare()
+                gen.notificationOccurred(.error)
             case "success":
                 let gen = UINotificationFeedbackGenerator()
                 gen.prepare()

--- a/corpan/plugins/tauri-plugin-haptics/src/models.rs
+++ b/corpan/plugins/tauri-plugin-haptics/src/models.rs
@@ -2,8 +2,12 @@ use serde::{Deserialize, Serialize};
 
 /// Arguments for the `impact` command.
 ///
-/// `style` is one of: "light", "medium", "heavy", "success", "warning".
-/// Unknown values are treated as "medium" by the native side.
+/// `style` is one of: "selection", "light", "medium", "heavy", "success",
+/// "warning", "error".
+///
+/// Unknown values are treated as "medium" by the native side — deliberately, so
+/// a pack cannot make the app fail by asking for a feel it does not have. The
+/// cost is that a typo is silent, so callers pin their style set with a test.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImpactArgs {

--- a/dynawalla/dynawalla-app/README.md
+++ b/dynawalla/dynawalla-app/README.md
@@ -95,9 +95,11 @@ narrow it later without breaking installed clients.
 | Grant | Command | Why |
 |---|---|---|
 | `core:app:allow-version` | `getVersion()` | The settings screen shows the installed build — the first thing a parent reporting a problem is asked for. |
+| `haptics:allow-impact` | `invoke("plugin:haptics\|impact")` | Real haptics. `navigator.vibrate` is `undefined` in iOS WKWebView, so the WebView-only implementation this app shipped first was a silent no-op on every iPhone and iPad. |
 
-That is the whole list. No plugin is registered and no `<plugin>:default` grant
-exists (ADR-0005 point 4, acceptance item `X-07`). The CSP is non-null, has no
+That is the whole list. One plugin is registered — `tauri-plugin-haptics`,
+shared with Corpán — and no `<plugin>:default` grant exists (ADR-0005 point 4,
+acceptance item `X-07`). The CSP is non-null, has no
 wildcard, admits no remote origin, and admits no inline style — which is why no
 component may set a `style` attribute; a test holds those two together.
 

--- a/dynawalla/dynawalla-app/src-tauri/Cargo.lock
+++ b/dynawalla/dynawalla-app/src-tauri/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-haptics",
  "zip",
 ]
 
@@ -3328,6 +3329,34 @@ dependencies = [
  "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-haptics"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/dynawalla/dynawalla-app/src-tauri/Cargo.toml
+++ b/dynawalla/dynawalla-app/src-tauri/Cargo.toml
@@ -34,6 +34,16 @@ sha2 = "0.10"
 # to a public repository.
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
+# Haptics. A path dependency on Corpán's plugin rather than a copy: the Swift
+# and Kotlin in it are the only thing that makes a haptic real on iOS, where
+# `navigator.vibrate` does not exist at all (it is `undefined` in WKWebView, so
+# a WebView-only implementation is a silent no-op on the entire platform and
+# looks perfectly fine in a desktop browser).
+#
+# Shared, so it is shared carefully: Dynawalla added two style values to it and
+# changed none. See `corpan/plugins/tauri-plugin-haptics/CHANGELOG.md`.
+tauri-plugin-haptics = { path = "../../../corpan/plugins/tauri-plugin-haptics" }
+
 [profile.release]
 opt-level = "z"   # Size, not speed: this is a mobile binary.
 lto = true

--- a/dynawalla/dynawalla-app/src-tauri/capabilities/default.json
+++ b/dynawalla/dynawalla-app/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Least privilege for the main window: one command, app.version, read on the settings screen. Every grant names a single command — never <plugin>:default (ADR-0005, X-07). Adding a grant here means an app can do something it could not do before, and a shipped app cannot narrow permissions without breaking installed clients, so this file only ever grows for a reason recorded in README.md.",
+  "description": "Least privilege for the main window: app.version, read on the settings screen, and one haptic command. Every grant names a single command — never <plugin>:default (ADR-0005, X-07). Adding a grant here means an app can do something it could not do before, and a shipped app cannot narrow permissions without breaking installed clients, so this file only ever grows for a reason recorded in README.md.",
   "windows": ["main"],
-  "permissions": ["core:app:allow-version"]
+  "permissions": ["core:app:allow-version", "haptics:allow-impact"]
 }

--- a/dynawalla/dynawalla-app/src-tauri/src/lib.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/lib.rs
@@ -24,6 +24,11 @@ mod packs;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        // The one plugin. Registering it is half the wiring — without the
+        // matching `haptics:allow-impact` grant in `capabilities/default.json`
+        // the ACL denies the invoke at runtime and nothing at build time says
+        // so. `src/packs/haptics.test.ts` asserts the two move together.
+        .plugin(tauri_plugin_haptics::init())
         // Packs that ship with this build are installed before the first window
         // exists, so the front door is never empty on a first launch and a
         // `npm run tauri dev` session always has the freshly built ones.

--- a/dynawalla/dynawalla-app/src/app/permissions.ts
+++ b/dynawalla/dynawalla-app/src/app/permissions.ts
@@ -84,6 +84,12 @@ export const NATIVE_CALLS: readonly NativeCall[] = [
   {
     module: "@tauri-apps/api/core",
     fn: "invoke",
+    permission: "haptics:allow-impact",
+    why: "Real haptics. `navigator.vibrate` does not exist in iOS WKWebView, so a WebView-only implementation is a silent no-op on every iPhone and iPad; the plugin reaches UIImpactFeedbackGenerator and friends. One command, never haptics:default.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "invoke",
     permission: null,
     command: "packs_list",
     why: "The pack runtime reads what is installed. Packs are the product; the shell is what installs and serves them.",

--- a/dynawalla/dynawalla-app/src/app/platform.ts
+++ b/dynawalla/dynawalla-app/src/app/platform.ts
@@ -12,6 +12,9 @@
 // build if the three ever disagree.
 
 import { getVersion } from "@tauri-apps/api/app"
+import { invoke } from "@tauri-apps/api/core"
+
+import type { HapticPorts, HapticStyle } from "../packs/haptics.ts"
 
 declare const __APP_VERSION__: string
 
@@ -32,4 +35,30 @@ export const isNative = typeof window !== "undefined" && "__TAURI_INTERNALS__" i
 export async function appVersion(): Promise<string> {
   if (!isNative) return BUILD_VERSION
   return await getVersion()
+}
+
+/**
+ * The two haptic back-ends this device actually has.
+ *
+ * Built once, at module load, because both answers are properties of the build
+ * and the platform rather than of the moment: whether Tauri injected its IPC,
+ * and whether this WebView implements `navigator.vibrate`. The second is the
+ * one that matters — it is `undefined` in WKWebView, so on iOS the web port is
+ * `null` and the native one is the only thing that will ever fire.
+ *
+ * The invoke is written out here rather than in `packs/haptics.ts` for the
+ * usual reason: that module decides *what* a cue should feel like, and this one
+ * is the only file allowed to reach the bridge. The command name and payload
+ * shape are the plugin's: a single `args` struct, because Tauri maps the JS
+ * payload keys onto the Rust function's parameters and `impact` takes one
+ * parameter called `args`.
+ */
+export const hapticPorts: HapticPorts = {
+  native: isNative
+    ? (style: HapticStyle) => invoke("plugin:haptics|impact", { args: { style } })
+    : null,
+  web:
+    typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
+      ? navigator.vibrate.bind(navigator)
+      : null,
 }

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useState } from "react"
 import { create } from "zustand"
 
 import type { Settings } from "../../../packs/sdk/src/index.ts"
-import { BUILD_VERSION } from "../app/platform.ts"
+import { BUILD_VERSION, hapticPorts } from "../app/platform.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { PassSheet } from "../pass/PassSheet.tsx"
@@ -112,6 +112,10 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
       createServices({
         profileId,
         settings: forPack,
+        // Resolved once at load, not per launch: whether this build has a
+        // native bridge and whether this WebView has `navigator.vibrate` are
+        // facts about the device, and neither can change while a child plays.
+        haptics: hapticPorts,
         onProgress: setProgress,
         onEnd: () => onLeave(),
         onMilestone: (name) => console.info(`[packs] ${packId} reached ${name}`),

--- a/dynawalla/dynawalla-app/src/packs/haptics.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/haptics.test.ts
@@ -1,0 +1,196 @@
+// The cue table, checked against the native code that has to answer it.
+//
+// This exists because of a specific, shipped bug: the app asked for haptics
+// with `navigator.vibrate`, which is `undefined` in iOS WKWebView, so every cue
+// on every iPhone and iPad was a silent no-op — no error, no log, nothing to
+// notice except that the app felt dead. A haptic has no return value anyone
+// checks, so there is no runtime signal at all. The only things that can catch
+// a regression here are the two below: read the native sources and prove the
+// styles exist, and read the wiring and prove the grant, the registration and
+// the dependency all agree.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { fireHaptic, HAPTIC_PATTERN, HAPTIC_STYLE, type HapticPorts, type HapticStyle } from "./haptics.ts"
+import type { HapticCue } from "../../../packs/sdk/src/index.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const tauriRoot = path.resolve(here, "../../src-tauri")
+const plugin = path.resolve(here, "../../../../corpan/plugins/tauri-plugin-haptics")
+
+const CUES: readonly HapticCue[] = ["tick", "seat", "settle", "refuse"]
+
+/** A recorder standing in for the two device back-ends. */
+function ports(
+  overrides: { native?: HapticPorts["native"]; web?: HapticPorts["web"] } = {},
+): { ports: HapticPorts; styles: HapticStyle[]; patterns: (number | number[])[] } {
+  const styles: HapticStyle[] = []
+  const patterns: (number | number[])[] = []
+  return {
+    styles,
+    patterns,
+    ports: {
+      native:
+        overrides.native === undefined
+          ? (style) => {
+              styles.push(style)
+              return Promise.resolve()
+            }
+          : overrides.native,
+      web:
+        overrides.web === undefined
+          ? (pattern) => {
+              patterns.push(pattern)
+              return true
+            }
+          : overrides.web,
+    },
+  }
+}
+
+test("every cue has a style and a fallback pattern", () => {
+  for (const cue of CUES) {
+    assert.ok(HAPTIC_STYLE[cue], `${cue} has no native style`)
+    assert.ok(HAPTIC_PATTERN[cue] !== undefined, `${cue} has no fallback pattern`)
+  }
+  assert.deepEqual(Object.keys(HAPTIC_STYLE).sort(), [...CUES].sort())
+})
+
+test("the mapping is the one that was reasoned about", () => {
+  // Pinned, because every one of these is a judgement that can be quietly
+  // undone by someone who reads "duration" and reaches for the nearest impact.
+  assert.equal(HAPTIC_STYLE.tick, "selection")
+  assert.equal(HAPTIC_STYLE.seat, "medium")
+  assert.equal(HAPTIC_STYLE.settle, "success")
+  assert.equal(HAPTIC_STYLE.refuse, "error")
+
+  // A refusal is not a caution, and a placement is not a refusal. Distinctness
+  // is the property that survives someone retuning the individual choices.
+  assert.equal(new Set(Object.values(HAPTIC_STYLE)).size, CUES.length)
+})
+
+test("every style is an explicit case in the iOS plugin", () => {
+  // THE trap. `HapticsPlugin.swift` ends its switch with `default:` → medium
+  // impact, on purpose, so a pack cannot crash the app by asking for a feel
+  // that does not exist. The cost is that a style this app sends and the
+  // plugin does not implement is INDISTINGUISHABLE at runtime from one that
+  // works: a `tick` would silently feel like a medium thump forever. Nothing
+  // else in this repository compiles Swift, so this reads it.
+  const swift = fs.readFileSync(path.join(plugin, "ios/Sources/HapticsPlugin.swift"), "utf8")
+  for (const style of new Set(Object.values(HAPTIC_STYLE))) {
+    assert.match(
+      swift,
+      new RegExp(`case "${style}":`),
+      `iOS falls through to a medium impact for "${style}" — it has no case`,
+    )
+  }
+  // And the generators are the ones the mapping claims, not three impacts.
+  assert.match(swift, /UISelectionFeedbackGenerator\(\)[\s\S]*selectionChanged\(\)/)
+  assert.match(swift, /notificationOccurred\(\.error\)/)
+  assert.match(swift, /notificationOccurred\(\.success\)/)
+})
+
+test("every style is an explicit branch in the Android plugin", () => {
+  // Same trap, other platform: Kotlin's `when` has an `else ->` that means
+  // medium. Android is where these cues did work, so a silent downgrade here
+  // is a regression rather than a gap.
+  const kotlin = fs.readFileSync(
+    path.join(plugin, "android/src/main/java/com/corpora/haptics/HapticsPlugin.kt"),
+    "utf8",
+  )
+  for (const style of new Set(Object.values(HAPTIC_STYLE))) {
+    if (style === "medium") continue // Android's `else ->` branch IS medium, by name.
+    assert.match(
+      kotlin,
+      new RegExp(`"${style}" ->`),
+      `Android falls through to medium for "${style}" — it has no branch`,
+    )
+  }
+})
+
+test("a cue reaches the native plugin, not the vibrator, when both exist", () => {
+  // Android has both. The plugin is the better path there — it reaches
+  // amplitude-controlled effects `navigator.vibrate` cannot express — and it
+  // is the ONLY path on iOS, so "native wins" has to hold unconditionally.
+  const { ports: p, styles, patterns } = ports()
+  for (const cue of CUES) fireHaptic(cue, p)
+  assert.deepEqual(styles, ["selection", "medium", "success", "error"])
+  assert.deepEqual(patterns, [], "the web fallback fired as well as the plugin")
+})
+
+test("without a native bridge the cue falls back to the vibrator", () => {
+  // `npm run dev` in a browser, and the pack SDK's standalone harness.
+  const { ports: p, patterns } = ports({ native: null })
+  for (const cue of CUES) fireHaptic(cue, p)
+  assert.deepEqual(patterns, [8, 18, [12, 40, 12], [40, 30, 60]])
+})
+
+test("a rejected invoke falls back rather than disappearing", async () => {
+  // The shape of a missing capability grant: `invoke` rejects. A cue that ends
+  // in an unhandled rejection is both a lost haptic and console noise on the
+  // answer path.
+  const { ports: p, patterns } = ports({ native: () => Promise.reject(new Error("denied")) })
+  fireHaptic("refuse", p)
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.deepEqual(patterns, [[40, 30, 60]])
+})
+
+test("a synchronously throwing bridge falls back too", () => {
+  // `invoke` throws rather than rejecting when Tauri's internals are absent.
+  const { ports: p, patterns } = ports({
+    native: () => {
+      throw new TypeError("__TAURI_INTERNALS__ is undefined")
+    },
+  })
+  fireHaptic("tick", p)
+  assert.deepEqual(patterns, [8])
+})
+
+test("a device with neither back-end is silent, not broken", () => {
+  // Desktop. A missing motor is not an error a child should hear about.
+  const p: HapticPorts = { native: null, web: null }
+  for (const cue of CUES) assert.doesNotThrow(() => fireHaptic(cue, p))
+})
+
+test("a throwing vibrator does not reach the pack", () => {
+  const { ports: p } = ports({
+    native: null,
+    web: () => {
+      throw new Error("blocked before a gesture")
+    },
+  })
+  assert.doesNotThrow(() => fireHaptic("tick", p))
+})
+
+test("the grant, the plugin registration and the dependency all agree", () => {
+  // Three files, and any two of them agreeing is not enough:
+  //   - registered in Rust but ungranted → the ACL denies the invoke at
+  //     runtime, and the fallback hides it (silently, on iOS, forever);
+  //   - granted but not registered → the command does not exist;
+  //   - either, without the Cargo dependency → it does not compile.
+  // Nothing in CI compiles this crate, so this is the check that runs.
+  const capability = JSON.parse(
+    fs.readFileSync(path.join(tauriRoot, "capabilities/default.json"), "utf8"),
+  ) as { permissions: string[] }
+  const libRs = fs.readFileSync(path.join(tauriRoot, "src/lib.rs"), "utf8")
+  const cargo = fs.readFileSync(path.join(tauriRoot, "Cargo.toml"), "utf8")
+
+  assert.ok(
+    capability.permissions.includes("haptics:allow-impact"),
+    "capabilities/default.json does not grant haptics:allow-impact",
+  )
+  assert.match(libRs, /\.plugin\(tauri_plugin_haptics::init\(\)\)/)
+  assert.match(cargo, /^tauri-plugin-haptics = \{ path = "(.+)" \}$/m)
+
+  // And the path resolves to the crate, rather than to a directory that used
+  // to hold it. A relocation would fail the Rust build — which no CI job runs.
+  const dep = /^tauri-plugin-haptics = \{ path = "(.+)" \}$/m.exec(cargo)?.[1] ?? ""
+  assert.ok(
+    fs.existsSync(path.resolve(tauriRoot, dep, "Cargo.toml")),
+    `the plugin path dependency "${dep}" does not point at a crate`,
+  )
+})

--- a/dynawalla/dynawalla-app/src/packs/haptics.ts
+++ b/dynawalla/dynawalla-app/src/packs/haptics.ts
@@ -1,0 +1,124 @@
+// The four named cues, turned into something a hand can actually feel.
+//
+// ## What was wrong
+//
+// This app asked for haptics with `navigator.vibrate`. That API does not exist
+// in iOS Safari or in WKWebView — not "fails", not "returns false": the
+// property is `undefined`, so the guard `navigator.vibrate && ...` was simply
+// false on every iPhone and iPad and every cue was a silent no-op. What a child
+// on iOS felt was the *sound*. It worked on Android, and it worked in a desktop
+// browser, which is exactly why nobody caught it.
+//
+// ## Why a duration was the wrong unit
+//
+// `navigator.vibrate(8)` says "run the motor for eight milliseconds". That is
+// an Android idiom and it is the whole vocabulary of the API. iOS has no such
+// control and never will: Taptic Engine feedback is exposed only as *named
+// semantic events* through `UIImpactFeedbackGenerator`,
+// `UISelectionFeedbackGenerator` and `UINotificationFeedbackGenerator`. A
+// duration cannot be translated into one; a meaning can. So the durations below
+// are kept strictly as the web fallback, and the cue → style table is what the
+// native path uses.
+//
+// ## The mapping, and why each one
+//
+// - `tick` → `selection`. The OS's own "a value changed under your finger"
+//   cue. It is not a small impact — it is tuned to stay legible when it repeats
+//   at speed, which is the entire life of a tick (a digit entered, a value
+//   scrubbed). A stream of light impacts turns to mush; this does not.
+// - `seat` → `medium`. A piece arriving where it belongs is a collision, so it
+//   wants an impact generator rather than a notification. `light` is lost
+//   underneath a finger already in motion, `heavy` reads as something going
+//   wrong; medium is the confirming thunk of a thing landing home.
+// - `settle` → `success`. The end of an action that went well, which is the
+//   literal contract of `UINotificationFeedbackGenerator.success`. Note the old
+//   web pattern here was `[12, 40, 12]` — a two-beat "ta-dum", already the
+//   shape of the iOS success rhythm, invented by hand.
+// - `refuse` → `error`. The canonical rejection. `warning` is the softer
+//   "careful" pattern and is what a near-miss would use; a refusal is a
+//   "no", and it should not feel like a caution.
+//
+// ## The trap this file is shaped around
+//
+// The plugin treats an unknown style as `medium` on both platforms, on purpose
+// (a pack must not be able to fail the app by asking for a feel that does not
+// exist). The cost is that a misspelled style is INDISTINGUISHABLE at runtime
+// from a working one — no error, no log, just the wrong feel forever.
+// `haptics.test.ts` therefore reads the plugin's Swift and Kotlin sources and
+// asserts every style named below is an explicit case in both.
+
+import type { HapticCue } from "../../../packs/sdk/src/index.ts"
+
+/** The styles `tauri-plugin-haptics` names. Not every style it accepts. */
+export type HapticStyle = "selection" | "medium" | "success" | "error"
+
+/** Cue → native feedback style. The reasoning is in the header. */
+export const HAPTIC_STYLE: Readonly<Record<HapticCue, HapticStyle>> = {
+  tick: "selection",
+  seat: "medium",
+  settle: "success",
+  refuse: "error",
+}
+
+/**
+ * The web fallback, in milliseconds.
+ *
+ * Reached on Android's WebView before the plugin answers, and in a plain
+ * browser (`npm run dev`, or the pack SDK's standalone harness) where there is
+ * no IPC at all. Unchanged from what this app shipped, because on the one
+ * platform where it ever did anything it was already right.
+ */
+export const HAPTIC_PATTERN: Readonly<Record<HapticCue, number | readonly number[]>> = {
+  tick: 8,
+  seat: 18,
+  settle: [12, 40, 12],
+  refuse: [40, 30, 60],
+}
+
+/**
+ * The two ways a cue can reach hardware, as a port.
+ *
+ * A port rather than a direct `invoke` import so the decision — which cue, which
+ * style, which path, and whether the settings toggle allows any of it — is
+ * testable in Node with no WebView, no device and no Tauri, exactly as
+ * `native.ts` does it for the pack runtime.
+ */
+export type HapticPorts = {
+  /** The native plugin. `null` when this build is not running under Tauri. */
+  readonly native: ((style: HapticStyle) => Promise<unknown>) | null
+  /** `navigator.vibrate`, bound. `null` where the platform lacks it — iOS. */
+  readonly web: ((pattern: number | number[]) => unknown) | null
+}
+
+/**
+ * Fire one cue. Never throws, never returns a promise anyone can await.
+ *
+ * Native first, because it is the only path that does anything on iOS and the
+ * better path on Android (the plugin drives amplitude-controlled effects that
+ * `navigator.vibrate` cannot reach). The web path is the fallback, and it is
+ * also the fallback for a *rejected* invoke — a missing capability grant, an
+ * older shell — rather than a dead end.
+ *
+ * The failure of a haptic is never surfaced to a child, and it is not an error
+ * in the log either: a device with no vibration motor is not a fault, and this
+ * is called on the answer path where noise would be constant.
+ */
+export function fireHaptic(cue: HapticCue, ports: HapticPorts): void {
+  const fallback = () => {
+    if (!ports.web) return
+    try {
+      ports.web(HAPTIC_PATTERN[cue] as number | number[])
+    } catch {
+      /* no motor, or a WebView that refuses before a gesture — not a fault */
+    }
+  }
+  if (ports.native) {
+    try {
+      void ports.native(HAPTIC_STYLE[cue]).catch(fallback)
+    } catch {
+      fallback()
+    }
+    return
+  }
+  fallback()
+}

--- a/dynawalla/dynawalla-app/src/packs/services.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.test.ts
@@ -1,0 +1,121 @@
+// The settings gate, attacked.
+//
+// `settings.haptics` is a switch a parent can reach, and a switch that only
+// silences one of two platforms is not a switch. There is exactly one line
+// enforcing it — `if (current.haptics)` in `services.ts` — so these tests are
+// the only thing that keeps it there, and they check both back-ends
+// independently: a gate that stops the plugin but not the vibrator would be
+// silent on iOS and buzzing on Android, which is precisely the class of split
+// this change exists to end.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { createServices } from "./services.ts"
+import type { HapticPorts, HapticStyle } from "./haptics.ts"
+import type { HapticCue, Settings } from "../../../packs/sdk/src/index.ts"
+
+const CUES: readonly HapticCue[] = ["tick", "seat", "settle", "refuse"]
+
+/** Which pack asked. Carried by every host call; irrelevant to the gate. */
+const PACK = "dw.test"
+
+const SETTINGS = (haptics: boolean): Settings => ({
+  locale: "en",
+  reducedMotion: false,
+  quality: "high",
+  textScale: 1,
+  colorScheme: "light",
+  sound: true,
+  haptics,
+  safeArea: { top: 0, right: 0, bottom: 0, left: 0 },
+})
+
+function recorder(): { ports: HapticPorts; fired: (HapticStyle | number | number[])[] } {
+  const fired: (HapticStyle | number | number[])[] = []
+  return {
+    fired,
+    ports: {
+      native: (style) => {
+        fired.push(style)
+        return Promise.resolve()
+      },
+      web: (pattern) => {
+        fired.push(pattern)
+        return true
+      },
+    },
+  }
+}
+
+/** A fresh session. `profileId` is unique per test so no storage is shared. */
+function session(profileId: string, haptics: boolean) {
+  const { ports, fired } = recorder()
+  const launch = createServices({ profileId, settings: SETTINGS(haptics), haptics: ports })
+  return { launch, fired }
+}
+
+test("haptics on: every cue reaches a back-end", async () => {
+  const { launch, fired } = session("p-on", true)
+  for (const cue of CUES) await launch.services.haptic({ packId: PACK, cue })
+  assert.deepEqual(fired, ["selection", "medium", "success", "error"])
+})
+
+test("haptics off: no cue reaches either back-end", async () => {
+  const { launch, fired } = session("p-off", false)
+  for (const cue of CUES) await launch.services.haptic({ packId: PACK, cue })
+  assert.deepEqual(fired, [], "the settings toggle did not silence the haptics")
+})
+
+test("the toggle silences a pack that is already running", async () => {
+  // `push` replaces the settings of a mounted pack without remounting it. A
+  // gate reading the launch-time settings would keep buzzing until the child
+  // quit the game — which is what a parent turning it off is trying to stop.
+  const { launch, fired } = session("p-mid", true)
+  await launch.services.haptic({ packId: PACK, cue: "tick" })
+  assert.deepEqual(fired, ["selection"])
+
+  launch.push(SETTINGS(false))
+  for (const cue of CUES) await launch.services.haptic({ packId: PACK, cue })
+  assert.deepEqual(fired, ["selection"], "a cue fired after haptics were turned off")
+})
+
+test("the toggle turns them back on without a remount", async () => {
+  const { launch, fired } = session("p-back", false)
+  await launch.services.haptic({ packId: PACK, cue: "refuse" })
+  assert.deepEqual(fired, [])
+
+  launch.push(SETTINGS(true))
+  await launch.services.haptic({ packId: PACK, cue: "refuse" })
+  assert.deepEqual(fired, ["error"])
+})
+
+test("haptics off silences the vibrator too, not just the plugin", async () => {
+  // The gate has to sit above the choice of back-end. One that sat below it
+  // would silence iOS and leave Android buzzing.
+  const fired: (number | number[])[] = []
+  const ports: HapticPorts = {
+    native: null,
+    web: (pattern) => {
+      fired.push(pattern)
+      return true
+    },
+  }
+  const launch = createServices({ profileId: "p-web", settings: SETTINGS(false), haptics: ports })
+  for (const cue of CUES) await launch.services.haptic({ packId: PACK, cue })
+  assert.deepEqual(fired, [])
+
+  launch.push(SETTINGS(true))
+  await launch.services.haptic({ packId: PACK, cue: "seat" })
+  assert.deepEqual(fired, [18])
+})
+
+test("the settings a pack is told about report the toggle honestly", async () => {
+  // A pack may draw its own affordance from `settings.haptics`. If the host
+  // silenced cues but still reported `true`, the pack would show a control
+  // that does nothing.
+  const { launch } = session("p-report", false)
+  assert.equal((await launch.services.settings()).haptics, false)
+  launch.push(SETTINGS(true))
+  assert.equal((await launch.services.settings()).haptics, true)
+})

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -11,13 +11,13 @@
 // child who played.
 
 import type {
-  HapticCue,
   Item,
   Settings,
   SoundCue,
   TransitionKind,
 } from "../../../packs/sdk/src/index.ts"
 import type { HostServices } from "./bridge.ts"
+import { fireHaptic, type HapticPorts } from "./haptics.ts"
 import { createItemService, type ItemService } from "./items.ts"
 import { report } from "./host.ts"
 import { packStorageFor } from "./storage.ts"
@@ -93,21 +93,6 @@ export function packSettings(input: SettingsInput): Settings {
   }
 }
 
-/**
- * The named haptics, as durations.
- *
- * Named rather than parameterised so a pack cannot invent a waveform: four
- * cues, four patterns, and a device with no vibration motor simply does
- * nothing. `navigator.vibrate` is a no-op on iOS Safari and on desktop, which
- * is correct — a missing motor is not an error a child should hear about.
- */
-const HAPTIC_PATTERN: Readonly<Record<HapticCue, number | readonly number[]>> = {
-  tick: 8,
-  seat: 18,
-  settle: [12, 40, 12],
-  refuse: [40, 30, 60],
-}
-
 /** Frequency and length for each named cue. The host owns the palette. */
 const SOUND_CUE: Readonly<Record<SoundCue, { hz: number; ms: number }>> = {
   tick: { hz: 880, ms: 40 },
@@ -156,6 +141,16 @@ export type ServicesDeps = {
   readonly profileId: string
   /** The device facts at launch. `push` replaces them without a remount. */
   readonly settings: Settings
+  /**
+   * Where a haptic cue goes: the device's real back-ends in production
+   * (`app/platform.ts`), a recorder in a test.
+   *
+   * Required rather than optional-with-a-default, deliberately. A defaulted
+   * port would make "nobody wired the haptics" compile, run, and feel exactly
+   * like a device with no motor — which is the bug this whole change exists to
+   * fix, reintroduced one layer up. The compiler asks instead.
+   */
+  readonly haptics: HapticPorts
   readonly onProgress?: (fraction: number) => void
   readonly onEnd?: (reason: "finished" | "quit") => void
   readonly onMilestone?: (name: string) => void
@@ -191,6 +186,7 @@ export function createServices(deps: ServicesDeps): LaunchServices {
   const items = createItemService({ profileId: deps.profileId, record: report })
   const store = packStorageFor(deps.profileId)
   const audio: Audio = { context: null }
+  const haptics = deps.haptics
   let current = deps.settings
 
   const keysOf = (packId: string): string[] =>
@@ -206,14 +202,19 @@ export function createServices(deps: ServicesDeps): LaunchServices {
     reveal: (input) => Promise.resolve(items.reveal(input.itemId)),
     learnerSummary: () => Promise.resolve(items.summary()),
 
+    /**
+     * The settings toggle is enforced HERE, on `current`, and nowhere else.
+     *
+     * `current` rather than `deps.settings` because `push` replaces the
+     * settings of a *running* pack without remounting it: a parent who turns
+     * haptics off mid-game has turned them off, and reading the launch-time
+     * value would keep buzzing until the child quit. There is no second gate
+     * further down — `fireHaptic` has no opinion about settings, so this line
+     * is the only thing standing between a cue and the motor, on either
+     * platform, and it is what `services.test.ts` attacks.
+     */
     haptic: (input) => {
-      if (current.haptics && typeof navigator !== "undefined" && navigator.vibrate) {
-        try {
-          navigator.vibrate(HAPTIC_PATTERN[input.cue] as number | number[])
-        } catch (error) {
-          console.error("[packs] a haptic cue failed", error)
-        }
-      }
+      if (current.haptics) fireHaptic(input.cue, haptics)
       return Promise.resolve()
     },
     sound: (input) => {


### PR DESCRIPTION
## The finding

`services.ts` implemented the `feedback.haptic` capability with **`navigator.vibrate`**. That API is `undefined` in iOS Safari and WKWebView — not failing, *absent* — so the guard `navigator.vibrate && ...` was false on every iPhone and iPad and all four cues did nothing. What a child on iOS felt was the *sound*. It worked on Android, and it worked in a desktop browser, which is why it survived. `src-tauri/Cargo.toml` declared zero Tauri plugins.

## What this does

Wires `corpan/plugins/tauri-plugin-haptics` into `dynawalla-app/src-tauri` and routes the host service through it, keeping `navigator.vibrate` as the fallback for desktop and for a plain browser.

The durations were the wrong unit. `vibrate(8)` says "run the motor for eight milliseconds" — the whole vocabulary of the Android API, and meaningless on iOS, where feedback is exposed only as named semantic events. The durations stay as the web fallback; the cues gain a real mapping.

| Cue | iOS | Why |
|---|---|---|
| `tick` | `UISelectionFeedbackGenerator.selectionChanged()` | Not a small impact — the OS's own "a value changed under your finger" cue, tuned to stay legible when it repeats at speed. A stream of light impacts turns to mush; this is the entire life of a tick. |
| `seat` | `UIImpactFeedbackGenerator(.medium)` | A piece landing where it belongs is a collision, so an impact rather than a notification. `light` is lost under a moving finger; `heavy` reads as something going wrong. |
| `settle` | `UINotificationFeedbackGenerator.success` | The end of an action that went well, which is that generator's literal contract. The web pattern it replaces, `[12, 40, 12]`, was already a hand-rolled two-beat of exactly that shape. |
| `refuse` | `UINotificationFeedbackGenerator.error` | A refusal is not a caution. `warning` is the softer "careful" pattern and is what a near-miss would use. |

## Corpán

Touched, minimally and additively. The plugin gains two style values, `selection` and `error`, and **changes none**: no existing `case`/`when` branch, no Rust type, no command signature, no permission. Corpán sends neither string, and both platforms already treat an unknown style as `medium`, so an older caller is unaffected by construction. Changelog entry added.

## The trap this is shaped around

That `medium` fallback is deliberate — a pack must not be able to fail the app by asking for a feel that does not exist — and it is exactly why a mistake here is invisible: a style the plugin does not implement is **indistinguishable at runtime** from one that works. No error, no log, just the wrong feel forever. So `haptics.test.ts` reads the plugin's Swift and Kotlin sources and asserts every style sent is an explicit case in both, and asserts the capability grant, the `.plugin()` registration and the Cargo path dependency all agree — any two of the three agreeing is either a runtime ACL denial (hidden by the fallback) or a build failure.

The settings toggle is enforced on one line, *above* the choice of back-end, and against the pushed settings rather than the launch-time ones: a parent turning haptics off mid-game has turned them off.

## Verified

- `npm test` — 255 pass, 0 fail. `npm run tsc`, `npm run lint`, `npm run build` clean.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — both crates.
- `cargo check` for the host, `aarch64-apple-ios` and `aarch64-linux-android`.
- The Swift really compiles: proved by breaking it deliberately, which surfaced `error: value of type 'UISelectionFeedbackGenerator' has no member 'selectionChangedTYPO'` through cargo, and by finding `UISelectionFeedbackGenerator` in the built `libtauri-plugin-haptics.a`.
- No `[workspace]` anywhere; `links =` values still unique.

Every test was checked by deleting the fix. Eleven mutations, each one failing the test that claims to cover it — messages in the review thread.

## NOT verified

- **No device build was run.** Nobody here can. That the four cues *feel* right on real hardware, and that the plugin fires at all on a physical iPhone or iPad, is unconfirmed by anything in this PR.
- **The Kotlin was not compiled.** No NDK and no `kotlinc` on this machine, and Dynawalla has no Android target yet. The change is two `when` branches; the risk is small but it is not zero, and Corpán compiles the same file.
- `ios-native.yml` is path-gated on `corpan/plugins/**` and will build the plugin's Swift for `aarch64-apple-ios` on this PR — it is **advisory, not required**, so read it by hand.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb