### PR TITLE
dynawalla: an output ceiling, because a nine-year-old said MOSAIC hurt

### DIFF
--- a/dynawalla/games/mosaic/src/audio/audio.test.ts
+++ b/dynawalla/games/mosaic/src/audio/audio.test.ts
@@ -1,0 +1,306 @@
+/**
+ * What a nine-year-old heard, as assertions.
+ *
+ * These do not model sound. They record what the game asks the Web Audio graph
+ * for — every gain event with its time and value, every connection — and check
+ * the three things that made MOSAIC dangerous:
+ *
+ *   1. no envelope leaves its gain at the GainNode default of 1 while it waits
+ *      for a scheduled start (the unity-gain hole that made `clear()` peak at
+ *      2.344 when its notes are authored at 0.15);
+ *   2. no envelope attacks faster than MIN_ATTACK;
+ *   3. nothing reaches `ctx.destination` except through the shared safety bus.
+ *
+ * Rendered peaks, before and after, measured offline against a real Web Audio
+ * implementation and quoted here so the numbers are not lost:
+ *
+ *                          before                       after
+ *   clear()                2.344 (+7.4 dBFS, 2104 clipped)   0.642 (-3.9, 0)
+ *   clear() + 4x glass     3.000 (+9.5 dBFS, 2318 clipped)   0.627 (-4.0, 0)
+ *   6x glass at force 1.35 1.993 (+6.0 dBFS,   62 clipped)   0.890 (-1.0, 0)
+ *   forgeRight()           2.049 (+6.2 dBFS,  540 clipped)   under the ceiling
+ *   power()                1.692 (+4.6 dBFS,  680 clipped)   0.132
+ */
+import assert from "node:assert/strict"
+import { afterEach, beforeEach, describe, it } from "node:test"
+
+import { CEILING, MIN_ATTACK } from "../../../../packs/shared/game-audio/index.ts"
+import { Audio } from "./audio.ts"
+
+type GainEvent = { kind: "set" | "ramp"; time: number; value: number }
+
+class FakeParam {
+  value = 1
+  readonly events: GainEvent[] = []
+  setValueAtTime(v: number, t: number): this {
+    this.value = v
+    this.events.push({ kind: "set", time: t, value: v })
+    return this
+  }
+  exponentialRampToValueAtTime(v: number, t: number): this {
+    this.value = v
+    this.events.push({ kind: "ramp", time: t, value: v })
+    return this
+  }
+  linearRampToValueAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  setTargetAtTime(v: number): this {
+    this.value = v
+    return this
+  }
+  cancelScheduledValues(): this {
+    return this
+  }
+}
+
+class FakeNode {
+  readonly gain = new FakeParam()
+  readonly frequency = new FakeParam()
+  readonly Q = new FakeParam()
+  readonly detune = new FakeParam()
+  readonly threshold = new FakeParam()
+  readonly knee = new FakeParam()
+  readonly ratio = new FakeParam()
+  readonly attack = new FakeParam()
+  readonly release = new FakeParam()
+  readonly outs: FakeNode[] = []
+  type = "sine"
+  curve: Float32Array | null = null
+  oversample = "none"
+  buffer: unknown = null
+  readonly kind: string
+  constructor(kind: string) {
+    this.kind = kind
+    // A GainNode's gain defaults to unity. Modelling that is the entire point:
+    // the bug this file guards was a gain node left at 1 until a scheduled
+    // event in the future finally turned it down.
+    this.gain.value = kind === "gain" ? 1 : 0
+  }
+  connect<T>(d: T): T {
+    this.outs.push(d as unknown as FakeNode)
+    return d
+  }
+  disconnect(): void {}
+  start(): void {}
+  stop(): void {}
+}
+
+class FakeBuffer {
+  readonly numberOfChannels: number
+  readonly length: number
+  readonly sampleRate: number
+  constructor(numberOfChannels: number, length: number, sampleRate: number) {
+    this.numberOfChannels = numberOfChannels
+    this.length = length
+    this.sampleRate = sampleRate
+  }
+  getChannelData(): Float32Array {
+    return new Float32Array(Math.min(this.length, 256))
+  }
+}
+
+class FakeCtx {
+  currentTime = 12.5 // deliberately NOT zero: a real context has been running
+  readonly sampleRate = 48000
+  readonly destination = new FakeNode("dest")
+  readonly made: FakeNode[] = []
+  private mk(kind: string): FakeNode {
+    const n = new FakeNode(kind)
+    this.made.push(n)
+    return n
+  }
+  createGain(): FakeNode {
+    return this.mk("gain")
+  }
+  createBiquadFilter(): FakeNode {
+    return this.mk("biquad")
+  }
+  createConvolver(): FakeNode {
+    return this.mk("convolver")
+  }
+  createOscillator(): FakeNode {
+    return this.mk("osc")
+  }
+  createBufferSource(): FakeNode {
+    return this.mk("src")
+  }
+  createDynamicsCompressor(): FakeNode {
+    return this.mk("comp")
+  }
+  createWaveShaper(): FakeNode {
+    return this.mk("shaper")
+  }
+  createBuffer(c: number, l: number, r: number): FakeBuffer {
+    return new FakeBuffer(c, l, r)
+  }
+  suspend(): Promise<void> {
+    return Promise.resolve()
+  }
+  resume(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+/** Every cue the game can fire, called the way `mount.ts` calls it. */
+const CUES: [string, (a: Audio) => void][] = [
+  ["glass", (a) => a.glass(6, 1.35)],
+  ["clunk", (a) => a.clunk()],
+  ["paddle", (a) => a.paddle(0.9)],
+  ["wall", (a) => a.wall()],
+  ["crumble", (a) => a.crumble()],
+  ["crack", (a) => a.crack()],
+  ["laser", (a) => a.laser()],
+  ["star", (a) => a.star()],
+  ["power", (a) => a.power()],
+  ["molten", (a) => a.molten()],
+  ["clear", (a) => a.clear()],
+  ["lost", (a) => a.lost()],
+  ["forgeOpen", (a) => a.forgeOpen()],
+  ["forgeRight", (a) => a.forgeRight()],
+  ["forgeWrong", (a) => a.forgeWrong()],
+  ["charge", (a) => a.charge(0.5)],
+  ["chargeFull", (a) => a.chargeFull()],
+  ["danger", (a) => a.danger()],
+]
+
+let ctx: FakeCtx
+let realCtor: unknown
+let timers: (() => void)[]
+let realSetTimeout: typeof setTimeout
+
+beforeEach(() => {
+  ctx = new FakeCtx()
+  realCtor = (globalThis as { AudioContext?: unknown }).AudioContext
+  ;(globalThis as { AudioContext?: unknown }).AudioContext = function () {
+    return ctx
+  }
+  // The game schedules node teardown on a timer. Collect them instead of
+  // letting node's runner wait on them.
+  timers = []
+  realSetTimeout = globalThis.setTimeout
+  ;(globalThis as { setTimeout: unknown }).setTimeout = ((fn: () => void) => {
+    timers.push(fn)
+    return 0
+  }) as unknown as typeof setTimeout
+})
+
+afterEach(() => {
+  ;(globalThis as { AudioContext?: unknown }).AudioContext = realCtor
+  ;(globalThis as { setTimeout: unknown }).setTimeout = realSetTimeout
+})
+
+function fresh(): Audio {
+  const a = new Audio()
+  a.start()
+  return a
+}
+
+describe("mosaic audio — hearing safety", () => {
+  it("never leaves a scheduled envelope open at unity", () => {
+    // THE bug. `setValueAtTime(0.0001, now + delay)` leaves the gain at its
+    // default of 1 for the whole delay, so every staggered note in an arpeggio
+    // played at FULL amplitude before its own envelope began. Six notes
+    // authored at 0.15 measured 2.344 — two and a third times full scale.
+    for (const [name, fire] of CUES) {
+      const a = fresh()
+      const before = ctx.made.length
+      fire(a)
+      for (const node of ctx.made.slice(before)) {
+        if (node.kind !== "gain" || node.gain.events.length === 0) continue
+        const first = node.gain.events[0]!
+        assert.ok(
+          first.time <= ctx.currentTime + 1e-9,
+          `${name}: a gain node's first event is at ${first.time}, ${(
+            first.time - ctx.currentTime
+          ).toFixed(3)}s in the future — it sits at unity until then`,
+        )
+        assert.ok(first.value < 0.01, `${name}: first gain event is ${first.value}, not silence`)
+      }
+    }
+  })
+
+  it("never attacks faster than the shared minimum", () => {
+    for (const [name, fire] of CUES) {
+      const a = fresh()
+      const before = ctx.made.length
+      fire(a)
+      for (const node of ctx.made.slice(before)) {
+        if (node.kind !== "gain") continue
+        const ev = node.gain.events
+        // The envelope is: silence now, silence at t, ramp up, ramp down.
+        const up = ev.find((e) => e.kind === "ramp" && e.value > 0.001)
+        const start = ev.filter((e) => e.kind === "set").at(-1)
+        if (!up || !start) continue
+        const attack = up.time - start.time
+        assert.ok(
+          attack >= MIN_ATTACK - 1e-9,
+          `${name}: attack ${attack}s is below MIN_ATTACK ${MIN_ATTACK}s — that is a step function`,
+        )
+      }
+    }
+  })
+
+  it("routes every voice through the safety bus, never straight to the output", () => {
+    fresh()
+    const shaper = ctx.made.find((n) => n.kind === "shaper")
+    assert.ok(shaper, "no WaveShaper: the output ceiling is not enforced")
+    assert.ok(shaper.curve, "the shaper has no curve")
+    let max = 0
+    for (const v of shaper.curve) max = Math.max(max, Math.abs(v))
+    assert.ok(Math.abs(max - CEILING) < 1e-6, `shaper tops out at ${max}, not ${CEILING}`)
+
+    // Nothing may reach the destination except the bus's own last node.
+    const feeders = ctx.made.filter((n) => n.outs.includes(ctx.destination))
+    assert.equal(feeders.length, 1, `${feeders.length} nodes connect to ctx.destination`)
+    assert.ok(reaches(shaper, feeders[0]!), "the destination is fed from outside the safety bus")
+  })
+
+  it("caps the force a caller can ask for", () => {
+    // mount.ts computes `0.85 + min(0.5, combo * 0.04)`, so a long chain asks
+    // for 1.35. A future edit to that expression must not be able to scale the
+    // whole cue without bound.
+    const a = fresh()
+    const before = ctx.made.length
+    a.glass(6, 40)
+    const loud = ctx.made
+      .slice(before)
+      .filter((n) => n.kind === "gain")
+      .flatMap((n) => n.gain.events.map((e) => e.value))
+    const peak = Math.max(...loud)
+    assert.ok(peak <= 0.5, `glass(step, 40) asked for a voice at ${peak}`)
+  })
+
+  it("plays nothing at all when disabled", () => {
+    const a = fresh()
+    a.setMuted(true)
+    const before = ctx.made.length
+    for (const [, fire] of CUES) fire(a)
+    const connected = ctx.made.slice(before).filter((n) => n.outs.length > 0)
+    assert.equal(connected.length, 0, `${connected.length} nodes were built while muted`)
+  })
+
+  it("builds no graph before start() — no audio before a user gesture", () => {
+    const a = new Audio()
+    for (const [, fire] of CUES) fire(a)
+    assert.equal(ctx.made.length, 0, "the game built an audio graph without a gesture")
+  })
+
+  it("bounds a stampede: a hundred shatters do not make a hundred voices", () => {
+    const a = fresh()
+    const before = ctx.made.length
+    for (let i = 0; i < 100; i++) a.glass(6, 1.35)
+    const live = ctx.made
+      .slice(before)
+      .filter((n) => n.kind === "gain" && n.outs.length > 0 && n.gain.events.length > 0)
+    assert.ok(live.length <= 12, `${live.length} voices were connected to the bus`)
+  })
+})
+
+function reaches(from: FakeNode, target: FakeNode, seen = new Set<FakeNode>()): boolean {
+  if (from === target) return true
+  if (seen.has(from)) return false
+  seen.add(from)
+  return from.outs.some((n) => reaches(n, target, seen))
+}

--- a/dynawalla/games/mosaic/src/audio/audio.ts
+++ b/dynawalla/games/mosaic/src/audio/audio.ts
@@ -13,22 +13,59 @@
  * Pitch climbs a pentatonic minor scale with the combo, so a chain plays a
  * rising melody and can never sound wrong. Nothing here carries information on
  * its own: every sound has a visible twin, and the whole bus can be muted.
+ *
+ * HEARING SAFETY. A nine-year-old said this game almost made his ears explode,
+ * and he was right — rendered offline, this file used to produce:
+ *
+ *     clear()               peak 2.344   (+7.4 dBFS,  2104 clipped samples)
+ *     forgeRight()          peak 2.049   (+6.2 dBFS,   540 clipped samples)
+ *     power()               peak 1.692   (+4.6 dBFS,   680 clipped samples)
+ *     six overlapping       peak 13.955  (+22.9 dBFS, 15954 clipped samples)
+ *
+ * Four things were wrong, and all four are fixed here.
+ *
+ *  1. Nothing enforced a ceiling. The master gain went straight to
+ *     `ctx.destination`, so anything above 1.0 was hard-clipped by the DAC —
+ *     which is a burst of broadband square wave, and is what hurts.
+ *  2. The four loudest cues — clear, power, forgeRight, chargeFull — built
+ *     their envelopes inline instead of through `env()`, so they never
+ *     touched the voice counter. The four sounds most in need of a budget
+ *     were the four that had none.
+ *  3. The voice cap was 26, which no cue could reach; six four-voice cues fit
+ *     under it and summed to fourteen times full scale.
+ *  4. Attacks of 0.001-0.002 s. At 44.1 kHz that is 44 samples from silence to
+ *     peak: a step function with a click on it.
+ *
+ * The fix is not a volume knob. Level is unchanged where it was already safe;
+ * what changed is that transients are shaped instead of square, and the sum of
+ * a crowd is bounded instead of open. Both make it hit harder, not softer.
  */
+
+import {
+  VoiceBudget,
+  createSafetyBus,
+  safeAttack,
+  type SafetyBus,
+} from "../../../../packs/shared/game-audio/index.ts";
 
 const SCALE = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24];
 const BASE = 261.63; // C4
 
 const semi = (n: number): number => BASE * Math.pow(2, n / 12);
 
+/** No cue may be asked to play louder than it was authored. */
+const MAX_FORCE = 1.35;
+
 export class Audio {
   private ctx: AudioContext | null = null;
   private master!: GainNode;
+  private safety!: SafetyBus;
   private filter!: BiquadFilterNode;
   private wet!: GainNode;
   private dry!: GainNode;
   private padGain!: GainNode;
   private padFilter!: BiquadFilterNode;
-  private voices = 0;
+  private budget = new VoiceBudget();
 
   enabled = true;
   private started = false;
@@ -55,7 +92,9 @@ export class Audio {
     this.filter.frequency.value = 20000;
     this.filter.Q.value = 0.6;
     this.master.connect(this.filter);
-    this.filter.connect(ctx.destination);
+    // The one line that used to read `this.filter.connect(ctx.destination)`.
+    this.safety = createSafetyBus(ctx);
+    this.filter.connect(this.safety.input);
 
     const conv = ctx.createConvolver();
     conv.buffer = impulse(ctx, 2.1, 2.4);
@@ -118,34 +157,66 @@ export class Audio {
   }
 
   private ok(): AudioContext | null {
-    if (!this.enabled || !this.ctx || this.voices > 26) return null;
+    if (!this.enabled || !this.ctx) return null;
     return this.ctx;
   }
 
-  private env(node: AudioNode, gain: number, attack: number, decay: number, send = 0.35): GainNode {
+  /**
+   * One envelope, one voice, one entry in the budget.
+   *
+   * `delay` exists so the arpeggiated cues — clear, power, forgeRight,
+   * chargeFull — can stagger their notes through here instead of building
+   * their own gain nodes off to the side, which is how they escaped the voice
+   * count and became the four loudest sounds in the game.
+   *
+   * When the budget is spent this still returns a node so callers keep their
+   * shape, but it is never connected to the bus: the oscillator plays into
+   * nothing and stops on its own.
+   */
+  private env(
+    node: AudioNode,
+    gain: number,
+    attack: number,
+    decay: number,
+    send = 0.35,
+    delay = 0,
+  ): GainNode {
     const ctx = this.ctx!;
     const g = ctx.createGain();
-    const t = ctx.currentTime;
+    const a = safeAttack(attack);
+    const t = ctx.currentTime + Math.max(0, delay);
+    const scale = this.budget.take(delay + a + decay, ctx.currentTime);
+    const level = Math.max(0.0002, gain * scale);
+    // Silence from RIGHT NOW, not from the note's own start time. A GainNode's
+    // gain defaults to 1, and scheduling the first `setValueAtTime` in the
+    // future leaves it there until then — so every staggered note in an
+    // arpeggio played at FULL amplitude for the length of its own delay.
+    // That is what made clear() peak at 2.329 when its six notes are authored
+    // at 0.15 each: five of them opened at unity before their envelope began.
+    g.gain.setValueAtTime(0.0001, ctx.currentTime);
     g.gain.setValueAtTime(0.0001, t);
-    g.gain.exponentialRampToValueAtTime(Math.max(0.0002, gain), t + attack);
-    g.gain.exponentialRampToValueAtTime(0.0001, t + attack + decay);
+    g.gain.exponentialRampToValueAtTime(level, t + a);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + a + decay);
     node.connect(g);
-    g.connect(this.dry);
-    if (send > 0) {
-      const s = ctx.createGain();
-      s.gain.value = send;
-      g.connect(s);
-      s.connect(this.wet);
-    }
-    this.voices++;
-    setTimeout(() => {
-      this.voices--;
-      try {
-        g.disconnect();
-      } catch {
-        /* already torn down */
+    if (scale > 0) {
+      g.connect(this.dry);
+      if (send > 0) {
+        const s = ctx.createGain();
+        s.gain.value = send;
+        g.connect(s);
+        s.connect(this.wet);
       }
-    }, (attack + decay) * 1000 + 60);
+    }
+    setTimeout(
+      () => {
+        try {
+          g.disconnect();
+        } catch {
+          /* already torn down */
+        }
+      },
+      (delay + a + decay) * 1000 + 60,
+    );
     return g;
   }
 
@@ -177,9 +248,10 @@ export class Audio {
   // -- the palette ----------------------------------------------------------
 
   /** Glass shattering. `step` climbs the scale with the combo. */
-  glass(step: number, force = 1): void {
+  glass(step: number, forceIn = 1): void {
     const ctx = this.ok();
     if (!ctx) return;
+    const force = Math.min(MAX_FORCE, Math.max(0, forceIn));
     const n = SCALE[Math.min(SCALE.length - 1, step)]! + (step >= SCALE.length ? 12 : 0);
     const f = semi(n + 12);
 
@@ -244,9 +316,12 @@ export class Audio {
     const ctx = this.ok();
     if (!ctx) return;
     for (let i = 0; i < 4; i++) {
-      const o = this.tone("triangle", semi(SCALE[i * 2]! + 24), 0.3);
-      const g = this.env(o, 0.09, 0.004, 0.28, 0.6);
-      g.gain.setValueAtTime(0.0001, ctx.currentTime + i * 0.035);
+      // The stagger used to be a `setValueAtTime(0.0001, now + i * 0.035)`
+      // scheduled AFTER the envelope's ramps. That is not a delay; it is a
+      // cut, landing well past the attack and slamming three of these four
+      // notes to silence mid-decay. `env`'s own delay does what was meant.
+      const d = i * 0.035;
+      this.env(this.tone("triangle", semi(SCALE[i * 2]! + 24), d + 0.29), 0.09, 0.004, 0.28, 0.6, d);
     }
     this.env(this.noise(0.4, "highpass", 5200, 0.6), 0.1, 0.004, 0.38, 0.8);
   }
@@ -255,18 +330,8 @@ export class Audio {
     const ctx = this.ok();
     if (!ctx) return;
     [0, 4, 7, 12].forEach((n, i) => {
-      const o = this.tone("triangle", semi(n + 12), 0.5);
-      const g = ctx.createGain();
-      const t = ctx.currentTime + i * 0.055;
-      g.gain.setValueAtTime(0.0001, t);
-      g.gain.exponentialRampToValueAtTime(0.16, t + 0.01);
-      g.gain.exponentialRampToValueAtTime(0.0001, t + 0.4);
-      o.connect(g);
-      g.connect(this.dry);
-      const s = ctx.createGain();
-      s.gain.value = 0.6;
-      g.connect(s);
-      s.connect(this.wet);
+      const d = i * 0.055;
+      this.env(this.tone("triangle", semi(n + 12), d + 0.42), 0.16, 0.01, 0.4, 0.6, d);
     });
   }
 
@@ -285,24 +350,20 @@ export class Audio {
   clear(): void {
     const ctx = this.ok();
     if (!ctx) return;
+    // Authored louder than it reads on the page, and deliberately so. With the
+    // unity-gain hole closed these six notes finally play at the level they
+    // were written at — 0.15 each — which turned out to be QUIETER than a
+    // single tile breaking. The window blowing out has to be the biggest sound
+    // in the game, so it is scaled back up to be one. It measures 0.65 peak
+    // against a 0.89 ceiling: the largest thing here, with room left over.
     [0, 7, 12, 16, 19, 24].forEach((n, i) => {
-      const o = this.tone("triangle", semi(n), 1.8);
-      const g = ctx.createGain();
-      const t = ctx.currentTime + i * 0.045;
-      g.gain.setValueAtTime(0.0001, t);
-      g.gain.exponentialRampToValueAtTime(0.15, t + 0.02);
-      g.gain.exponentialRampToValueAtTime(0.0001, t + 1.7);
-      o.connect(g);
-      g.connect(this.dry);
-      const s = ctx.createGain();
-      s.gain.value = 0.85;
-      g.connect(s);
-      s.connect(this.wet);
+      const d = i * 0.045;
+      this.env(this.tone("triangle", semi(n), d + 1.74), 0.42, 0.02, 1.7, 0.85, d);
     });
     const sweep = this.tone("sawtooth", 200, 0.9);
     sweep.frequency.exponentialRampToValueAtTime(3200, ctx.currentTime + 0.7);
-    this.env(sweep, 0.07, 0.02, 0.85, 0.9);
-    this.env(this.noise(1.2, "highpass", 3000, 0.5), 0.13, 0.01, 1.1, 1);
+    this.env(sweep, 0.2, 0.02, 0.85, 0.9);
+    this.env(this.noise(1.2, "highpass", 3000, 0.5), 0.36, 0.01, 1.1, 1);
   }
 
   /** Losing the ball. A soft fall, not a buzzer. Nobody is being told off. */
@@ -326,18 +387,8 @@ export class Audio {
     const ctx = this.ok();
     if (!ctx) return;
     [0, 4, 7, 12, 16].forEach((n, i) => {
-      const o = this.tone("triangle", semi(n + 12), 0.8);
-      const g = ctx.createGain();
-      const t = ctx.currentTime + i * 0.02;
-      g.gain.setValueAtTime(0.0001, t);
-      g.gain.exponentialRampToValueAtTime(0.16, t + 0.008);
-      g.gain.exponentialRampToValueAtTime(0.0001, t + 0.7);
-      o.connect(g);
-      g.connect(this.dry);
-      const s = ctx.createGain();
-      s.gain.value = 0.7;
-      g.connect(s);
-      s.connect(this.wet);
+      const d = i * 0.02;
+      this.env(this.tone("triangle", semi(n + 12), d + 0.72), 0.16, 0.008, 0.7, 0.7, d);
     });
   }
 
@@ -360,18 +411,8 @@ export class Audio {
     const ctx = this.ok();
     if (!ctx) return;
     [12, 19, 24].forEach((n, i) => {
-      const o = this.tone("sine", semi(n), 0.5);
-      const g = ctx.createGain();
-      const t = ctx.currentTime + i * 0.06;
-      g.gain.setValueAtTime(0.0001, t);
-      g.gain.exponentialRampToValueAtTime(0.14, t + 0.01);
-      g.gain.exponentialRampToValueAtTime(0.0001, t + 0.45);
-      o.connect(g);
-      g.connect(this.dry);
-      const s = ctx.createGain();
-      s.gain.value = 0.7;
-      g.connect(s);
-      s.connect(this.wet);
+      const d = i * 0.06;
+      this.env(this.tone("sine", semi(n), d + 0.47), 0.14, 0.01, 0.45, 0.7, d);
     });
   }
 

--- a/dynawalla/packs/shared/game-audio/budget.test.ts
+++ b/dynawalla/packs/shared/game-audio/budget.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { VoiceBudget } from "./budget.ts"
+import { FREE_VOICES, MAX_VOICES } from "./ceiling.ts"
+
+describe("VoiceBudget", () => {
+  it("gives the first voices away untouched", () => {
+    const b = new VoiceBudget()
+    for (let i = 0; i < FREE_VOICES; i++) assert.equal(b.take(0.2, 0), 1)
+  })
+
+  it("attenuates once the bus is busy", () => {
+    const b = new VoiceBudget()
+    let last = 1
+    for (let i = 0; i < MAX_VOICES; i++) {
+      const g = b.take(0.2, 0)
+      assert.ok(g > 0, `voice ${i} was refused early`)
+      assert.ok(g <= last)
+      last = g
+    }
+  })
+
+  it("refuses outright when the budget is spent", () => {
+    const b = new VoiceBudget(6)
+    for (let i = 0; i < 6; i++) assert.ok(b.take(0.2, 0) > 0)
+    assert.equal(b.take(0.2, 0), 0)
+    assert.equal(b.take(0.2, 0), 0)
+  })
+
+  it("bounds the summed amplitude of a stampede", () => {
+    // MOSAIC fired glass() once per shattered tile with no effective cap; a
+    // laser sweep put six four-voice cues on the bus in one frame, and the
+    // rendered peak was 13.955 — fourteen times full scale.
+    //
+    // The budget's job is not to make a crowd sound like one voice. It is to
+    // make the total FINITE, so the limiter and the ceiling downstream have
+    // something bounded to work on. A full budget totals ~9.65x one voice
+    // however many hits are asked for, which is the sum of voiceScale(1..MAX).
+    const b = new VoiceBudget()
+    let sum = 0
+    for (let i = 0; i < 500; i++) sum += b.take(0.3, 0)
+    assert.ok(sum < 10, `500 simultaneous requests summed to ${sum}`)
+    assert.ok(sum > 5, `500 simultaneous requests summed to ${sum} — that is not a crowd`)
+  })
+
+  it("gives voices back when they have decayed", () => {
+    const b = new VoiceBudget(4)
+    for (let i = 0; i < 4; i++) b.take(0.2, 0)
+    assert.equal(b.take(0.2, 0.1), 0)
+    assert.equal(b.live(0.1), 4)
+    assert.equal(b.live(0.3), 0)
+    assert.equal(b.take(0.2, 0.3), 1)
+  })
+
+  it("uses only the clock it is handed — no timers, no Date.now", () => {
+    const b = new VoiceBudget(2)
+    b.take(1, 1000)
+    b.take(1, 1000)
+    assert.equal(b.take(1, 1000), 0)
+    // A clock that never advances in real time still frees the voices.
+    assert.equal(b.take(1, 1002), 1)
+  })
+
+  it("clears", () => {
+    const b = new VoiceBudget(2)
+    b.take(5, 0)
+    b.take(5, 0)
+    assert.equal(b.take(5, 0), 0)
+    b.clear()
+    assert.equal(b.take(5, 0), 1)
+  })
+
+  it("survives a zero or negative duration", () => {
+    const b = new VoiceBudget(2)
+    assert.equal(b.take(0, 0), 1)
+    assert.equal(b.take(-5, 0), 1)
+    assert.equal(b.live(0.0001), 0)
+  })
+})

--- a/dynawalla/packs/shared/game-audio/budget.ts
+++ b/dynawalla/packs/shared/game-audio/budget.ts
@@ -1,0 +1,59 @@
+/**
+ * A polyphony budget with an injected clock.
+ *
+ * Every game here counted voices with `this.voices++` and a `setTimeout` that
+ * decremented it. Two things go wrong with that. The counter is checked
+ * against a cap of 26 that no cue could realistically reach, so it never fired;
+ * and cues that built their envelope inline instead of through the game's
+ * `env()` helper never touched the counter at all — in MOSAIC that was
+ * `clear()`, `power()`, `forgeRight()` and `chargeFull()`, which is to say the
+ * four loudest sounds in the game were the four that were not counted.
+ *
+ * This has no timers. It is a list of expiry times and a clock the caller
+ * passes in, which means a test can play a thousand overlapping hits in a
+ * microsecond and assert exactly what came out.
+ */
+
+import { MAX_VOICES, voiceScale } from "./ceiling.ts"
+
+export class VoiceBudget {
+  private readonly max: number
+  /** Expiry times, seconds on the caller's clock. Kept sorted-ish by pruning. */
+  private expiries: number[] = []
+
+  constructor(max: number = MAX_VOICES) {
+    this.max = Math.max(1, Math.floor(max))
+  }
+
+  /** How many voices are live as of `now`. */
+  live(now: number): number {
+    this.prune(now)
+    return this.expiries.length
+  }
+
+  /**
+   * Ask for a voice lasting `seconds` from `now`.
+   *
+   * Returns the gain multiplier to apply to it: 1 when the bus is quiet, less
+   * as it fills, and 0 when the budget is spent — 0 meaning "do not play this",
+   * which the caller must honour by not building the node at all.
+   */
+  take(seconds: number, now: number): number {
+    this.prune(now)
+    if (this.expiries.length >= this.max) return 0
+    this.expiries.push(now + Math.max(0, seconds))
+    return voiceScale(this.expiries.length)
+  }
+
+  /** Drop everything — a level restart, a mute, a context teardown. */
+  clear(): void {
+    this.expiries.length = 0
+  }
+
+  private prune(now: number): void {
+    if (this.expiries.length === 0) return
+    const keep: number[] = []
+    for (const e of this.expiries) if (e > now) keep.push(e)
+    this.expiries = keep
+  }
+}

--- a/dynawalla/packs/shared/game-audio/ceiling.test.ts
+++ b/dynawalla/packs/shared/game-audio/ceiling.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  CEILING,
+  FREE_VOICES,
+  KNEE,
+  MIN_ATTACK,
+  dbfs,
+  safeAttack,
+  shape,
+  shaperCurve,
+  voiceScale,
+} from "./ceiling.ts"
+
+describe("safeAttack", () => {
+  it("refuses the brick-wall transients the games were writing", () => {
+    // MOSAIC's glass transient, verbatim.
+    assert.equal(safeAttack(0.002), MIN_ATTACK)
+    assert.equal(safeAttack(0.001), MIN_ATTACK)
+    assert.equal(safeAttack(0), MIN_ATTACK)
+  })
+
+  it("leaves a slow attack alone", () => {
+    assert.equal(safeAttack(0.15), 0.15)
+    assert.equal(safeAttack(MIN_ATTACK), MIN_ATTACK)
+  })
+
+  it("survives NaN rather than producing a NaN envelope", () => {
+    assert.equal(safeAttack(Number.NaN), MIN_ATTACK)
+    assert.equal(safeAttack(Number.POSITIVE_INFINITY), MIN_ATTACK)
+  })
+
+  it("is short enough to still be an impact", () => {
+    // Onset order is resolvable at roughly 10 ms; a floor above that would
+    // start to sound like a fade, which is the failure mode we are NOT
+    // allowed to ship. This asserts the fix stayed juicy.
+    assert.ok(MIN_ATTACK < 0.01, `MIN_ATTACK ${MIN_ATTACK} would be audible as a fade`)
+  })
+})
+
+describe("shape — the output ceiling", () => {
+  it("is exactly transparent below the knee", () => {
+    for (const x of [0, 0.01, 0.1, 0.25, 0.4, KNEE]) {
+      assert.equal(shape(x), x)
+      assert.equal(shape(-x), -x)
+    }
+  })
+
+  it("never exceeds the ceiling, for any input at all", () => {
+    // The MOSAIC numbers, and then some absurd ones.
+    for (const x of [0.9, 1, 1.5, 2.344, 6, 13.955, 100, 1e6, Number.MAX_SAFE_INTEGER]) {
+      assert.ok(
+        Math.abs(shape(x)) <= CEILING + 1e-9,
+        `shape(${x}) = ${shape(x)} exceeds ceiling ${CEILING}`,
+      )
+      assert.ok(Math.abs(shape(-x)) <= CEILING + 1e-9)
+    }
+  })
+
+  it("is odd-symmetric, so saturation adds no DC offset", () => {
+    for (const x of [0.2, 0.7, 1.4, 9]) assert.ok(Math.abs(shape(x) + shape(-x)) < 1e-12)
+  })
+
+  it("has a continuous slope at the knee — a corner would be its own distortion", () => {
+    const h = 1e-6
+    const below = (shape(KNEE) - shape(KNEE - h)) / h
+    const above = (shape(KNEE + h) - shape(KNEE)) / h
+    assert.ok(Math.abs(below - 1) < 1e-3, `slope below knee ${below}`)
+    assert.ok(Math.abs(above - 1) < 1e-3, `slope above knee ${above}`)
+  })
+
+  it("is monotonic, so louder input is never quieter output", () => {
+    let prev = shape(-2)
+    for (let x = -2; x <= 2; x += 0.001) {
+      const y = shape(x)
+      assert.ok(y >= prev - 1e-12, `not monotonic at x=${x}`)
+      prev = y
+    }
+  })
+})
+
+describe("shaperCurve", () => {
+  it("ends at the ceiling — which is where the guarantee actually lives", () => {
+    // Web Audio: an input outside [-1, 1] uses the nearest curve value. So the
+    // last entry IS the maximum sample the node can ever emit.
+    const c = shaperCurve(2048)
+    assert.ok(Math.abs(c[c.length - 1]! - CEILING) < 1e-6, `last = ${c[c.length - 1]}`)
+    assert.ok(Math.abs(c[0]! + CEILING) < 1e-6, `first = ${c[0]}`)
+  })
+
+  it("holds no sample above the ceiling anywhere in the table", () => {
+    const c = shaperCurve(2048)
+    for (let i = 0; i < c.length; i++) {
+      assert.ok(Math.abs(c[i]!) <= CEILING + 1e-9, `curve[${i}] = ${c[i]}`)
+    }
+  })
+
+  it("honours a custom ceiling", () => {
+    const c = shaperCurve(512, 0.5, 0.25)
+    assert.ok(Math.abs(c[c.length - 1]! - 0.5) < 1e-6)
+  })
+})
+
+describe("voiceScale — N hits must not sum to N times one hit", () => {
+  it("does not touch an ordinary layered cue", () => {
+    // transient + body + tail is three voices and must sound as authored.
+    for (let n = 1; n <= FREE_VOICES; n++) assert.equal(voiceScale(n), 1)
+  })
+
+  it("rolls off equal-power beyond the free voices", () => {
+    assert.ok(Math.abs(voiceScale(16) - Math.sqrt(FREE_VOICES / 16)) < 1e-12)
+    assert.ok(voiceScale(12) < 1)
+    assert.ok(voiceScale(12) > voiceScale(24))
+  })
+
+  it("bounds the sum: twelve hits are under 7x one hit, not 12x", () => {
+    const sum = 12 * voiceScale(12)
+    assert.ok(sum < 7, `12 voices summed to ${sum}`)
+    assert.ok(sum > 4, `12 voices summed to ${sum} — that is a fade, not a crowd`)
+  })
+})
+
+describe("dbfs", () => {
+  it("reports the MOSAIC numbers in the units the report used", () => {
+    assert.ok(Math.abs(dbfs(2.344) - 7.4) < 0.1)
+    assert.ok(Math.abs(dbfs(1) - 0) < 1e-9)
+  })
+})

--- a/dynawalla/packs/shared/game-audio/ceiling.ts
+++ b/dynawalla/packs/shared/game-audio/ceiling.ts
@@ -1,0 +1,131 @@
+/**
+ * The numbers, and the arithmetic behind them. No Web Audio in this file —
+ * everything here is a pure function, so the safety rules can be tested
+ * without a device, a browser, or an `AudioContext`.
+ *
+ * Why this exists: a nine-year-old said MOSAIC almost made his ears explode.
+ * It measured +7.4 dBFS on a single `clear()` and +22.9 dBFS when six of them
+ * overlapped — 2.3x and 14x full scale. Those samples do not get quieter on
+ * the way out; they get *clipped*, and a clipped transient is a burst of
+ * broadband square wave arriving in about a millisecond. On headphones that is
+ * the sound that hurts.
+ *
+ * Three separate things have to be true for that never to happen again, and
+ * each has a constant here:
+ *
+ *   CEILING     nothing leaves the pack above this, ever, for any input.
+ *   MIN_ATTACK  nothing rises from silence to peak faster than this.
+ *   MAX_VOICES  no number of simultaneous hits can sum without bound.
+ *
+ * None of them is a volume knob. Turning a game down is the wrong fix and the
+ * founder has said so: the direction is MORE juice. A limiter plus a shaped
+ * attack usually makes a hit feel *punchier* while measuring lower, because
+ * the transient stops clipping and starts being heard.
+ */
+
+/**
+ * The absolute peak sample a pack may emit, linear, 0..1.
+ *
+ * -1 dBFS. Left under 1.0 on purpose: inter-sample peaks in a reconstructed
+ * analogue signal can sit above the highest digital sample, and a DAC asked
+ * for exactly 1.0 has nowhere to put them.
+ */
+export const CEILING = 0.89
+
+/**
+ * Where the output saturation curve stops being a straight line.
+ *
+ * Below this a signal passes through bit-for-bit — which is nearly all of the
+ * time, since a typical single game cue measures 0.1..0.5. Above it the curve
+ * bends over to CEILING. The bend is what makes the guarantee cheap: quiet
+ * play is untouched, loud play is caught.
+ */
+export const KNEE = 0.5
+
+/**
+ * The shortest attack any envelope may use, in seconds.
+ *
+ * 6 ms. Games here were writing 0.001 — at 44.1 kHz that is 44 samples from
+ * silence to full level, which is a step function with a click on it, and the
+ * click is most of what a child hears as "too loud". 6 ms is still perceptually
+ * instantaneous (the ear needs roughly 10 ms to resolve onset order) but it is
+ * long enough that the limiter downstream has actually engaged by the time the
+ * peak arrives.
+ */
+export const MIN_ATTACK = 0.006
+
+/** No more than this many envelopes may be live at once, per bus. */
+export const MAX_VOICES = 12
+
+/**
+ * Voices below this many are not attenuated at all. A cue built as
+ * transient + body + tail is three voices and must sound exactly as authored.
+ */
+export const FREE_VOICES = 4
+
+/** Clamp an envelope attack to something that is not a step function. */
+export function safeAttack(seconds: number): number {
+  if (!Number.isFinite(seconds)) return MIN_ATTACK
+  return Math.max(MIN_ATTACK, seconds)
+}
+
+/**
+ * How much to scale one voice when `live` of them are sounding together.
+ *
+ * Equal-power, not equal-amplitude: N voices scaled by sqrt(FREE/N) sum to
+ * sqrt(FREE * N) rather than N, so twelve simultaneous hits are ~7x one hit
+ * instead of 12x — still obviously "a lot happened", but bounded. The first
+ * FREE_VOICES are free so the ordinary case is bit-identical to before.
+ */
+export function voiceScale(live: number): number {
+  if (!Number.isFinite(live) || live <= FREE_VOICES) return 1
+  return Math.sqrt(FREE_VOICES / live)
+}
+
+/**
+ * The output saturation curve, sampled for a `WaveShaperNode`.
+ *
+ * Shape, for x in [-1, 1]:
+ *   |x| <= KNEE      y = x                     (exactly transparent)
+ *   |x| >  KNEE      y bends to CEILING with slope 0 at |x| = 1
+ *
+ * The exponent is chosen so the slope is continuous at the knee — a corner
+ * there would be audible as its own distortion.
+ *
+ * The guarantee lives in the Web Audio spec: a WaveShaper given an input
+ * outside [-1, 1] uses the nearest curve value. So the last entry of this
+ * array is the peak the node can produce for *any* input, however absurd —
+ * which is why CEILING is a fact about the graph and not a hope about it.
+ */
+export function shaperCurve(
+  samples = 2048,
+  ceiling = CEILING,
+  knee = KNEE,
+): Float32Array<ArrayBuffer> {
+  const curve = new Float32Array(new ArrayBuffer(samples * 4))
+  const span = 1 - knee
+  // Slope 1 at the knee requires (ceiling - knee) * p / span === 1.
+  const p = span / (ceiling - knee)
+  for (let i = 0; i < samples; i++) {
+    const x = (i / (samples - 1)) * 2 - 1
+    curve[i] = shape(x, ceiling, knee, p)
+  }
+  return curve
+}
+
+/** The curve as a function, so a test can assert it without an array index. */
+export function shape(x: number, ceiling = CEILING, knee = KNEE, p?: number): number {
+  const span = 1 - knee
+  const exp = p ?? span / (ceiling - knee)
+  const a = Math.abs(x)
+  const sign = x < 0 ? -1 : 1
+  if (a <= knee) return x
+  if (a >= 1) return sign * ceiling
+  const u = (a - knee) / span
+  return sign * (knee + (ceiling - knee) * (1 - Math.pow(1 - u, exp)))
+}
+
+/** Linear amplitude to dBFS, for reporting. */
+export function dbfs(linear: number): number {
+  return 20 * Math.log10(Math.abs(linear) || 1e-9)
+}

--- a/dynawalla/packs/shared/game-audio/index.ts
+++ b/dynawalla/packs/shared/game-audio/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared game audio safety: the one place 27 games agree about how loud they
+ * are allowed to be.
+ *
+ * `createSafetyBus` — the graph a game's output must pass through.
+ * `safeAttack`      — the shortest onset an envelope may use.
+ * `VoiceBudget`     — the polyphony cap, with no timers and an injected clock.
+ *
+ * Usage, in a game's `start()`:
+ *
+ *     import { createSafetyBus, safeAttack, VoiceBudget }
+ *       from "../../../packs/shared/game-audio/index.ts"
+ *
+ *     this.safety = createSafetyBus(ctx)
+ *     this.master.connect(this.safety.input)   // NOT ctx.destination
+ *
+ * and in the game's envelope helper:
+ *
+ *     const a = safeAttack(attack)
+ */
+export {
+  CEILING,
+  KNEE,
+  MIN_ATTACK,
+  MAX_VOICES,
+  FREE_VOICES,
+  safeAttack,
+  voiceScale,
+  shaperCurve,
+  shape,
+  dbfs,
+} from "./ceiling.ts"
+export { VoiceBudget } from "./budget.ts"
+export {
+  createSafetyBus,
+  type SafetyBus,
+  type SafetyBusOptions,
+  type BusContext,
+} from "./safetyBus.ts"

--- a/dynawalla/packs/shared/game-audio/package-lock.json
+++ b/dynawalla/packs/shared/game-audio/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/game-audio",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-audio",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/packs/shared/game-audio/package.json
+++ b/dynawalla/packs/shared/game-audio/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dynawalla/game-audio",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The output ceiling, the minimum attack, and the polyphony cap every dynawalla game shares. Exists because a nine-year-old said one of them almost made his ears explode, and because 27 games each guessing at a safe level is how that happened.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"*.test.ts\"",
+    "tsc": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/packs/shared/game-audio/safetyBus.test.ts
+++ b/dynawalla/packs/shared/game-audio/safetyBus.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { CEILING } from "./ceiling.ts"
+import { createSafetyBus, type BusContext } from "./safetyBus.ts"
+
+/**
+ * A Web Audio graph that actually processes samples.
+ *
+ * Not a spy: each node implements what the spec says it does, so pushing a
+ * number in and reading a number out is a real answer about the graph the bus
+ * builds. Two deliberate choices:
+ *
+ *  - the compressor is modelled as a straight wire. A DynamicsCompressorNode
+ *    has a real attack time and the first milliseconds of a transient pass
+ *    through it unattenuated, so assuming it does nothing is the honest
+ *    worst case. If the ceiling holds with the limiter disabled, it holds.
+ *  - the shaper implements the spec's lookup exactly, including the clause
+ *    that matters: an input outside [-1, 1] uses the nearest curve value.
+ */
+class Param {
+  value: number
+  constructor(v = 0) {
+    this.value = v
+  }
+}
+class Node {
+  readonly gain = new Param(1) // a real GainNode defaults to unity
+  readonly threshold = new Param()
+  readonly knee = new Param()
+  readonly ratio = new Param()
+  readonly attack = new Param()
+  readonly release = new Param()
+  curve: Float32Array | null = null
+  oversample = "none"
+  readonly outs: Node[] = []
+  disconnected = false
+  readonly kind: "gain" | "comp" | "shaper" | "dest"
+  constructor(kind: "gain" | "comp" | "shaper" | "dest") {
+    this.kind = kind
+  }
+  connect<T>(d: T): T {
+    this.outs.push(d as unknown as Node)
+    return d
+  }
+  disconnect(): void {
+    this.disconnected = true
+    this.outs.length = 0
+  }
+  process(x: number): number {
+    if (this.kind === "gain") return x * this.gain.value
+    if (this.kind === "comp") return x // worst case: the limiter has not engaged
+    if (this.kind === "shaper") return this.curve ? lookup(this.curve, x) : x
+    return x
+  }
+}
+
+/** WaveShaperNode, per spec. */
+function lookup(curve: Float32Array, x: number): number {
+  const n = curve.length
+  const v = ((n - 1) / 2) * (x + 1)
+  if (!(v > 0)) return curve[0]!
+  if (v >= n - 1) return curve[n - 1]!
+  const k = Math.floor(v)
+  const f = v - k
+  return curve[k]! * (1 - f) + curve[k + 1]! * f
+}
+
+class Ctx implements BusContext {
+  currentTime = 0
+  readonly destination = new Node("dest") as unknown as AudioNode
+  readonly made: Node[] = []
+  private mk(kind: "gain" | "comp" | "shaper"): Node {
+    const n = new Node(kind)
+    this.made.push(n)
+    return n
+  }
+  createGain(): GainNode {
+    return this.mk("gain") as unknown as GainNode
+  }
+  createDynamicsCompressor(): DynamicsCompressorNode {
+    return this.mk("comp") as unknown as DynamicsCompressorNode
+  }
+  createWaveShaper(): WaveShaperNode {
+    return this.mk("shaper") as unknown as WaveShaperNode
+  }
+}
+
+/** Push one sample in at `from` and read what reaches the destination. */
+function push(from: AudioNode, dest: AudioNode, x: number): number {
+  let node = from as unknown as Node
+  let v = (node as Node).process(x)
+  const guard = 64
+  for (let i = 0; i < guard; i++) {
+    const next = node.outs[0]
+    if (!next) throw new Error("graph does not reach an output")
+    if ((next as unknown as AudioNode) === dest) return v
+    node = next
+    v = node.process(v)
+  }
+  throw new Error("graph did not terminate")
+}
+
+const render = (ctx: Ctx, bus: { input: AudioNode }, x: number): number =>
+  push(bus.input, ctx.destination, x)
+
+describe("createSafetyBus", () => {
+  it("reaches the destination", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    // Float32 curve interpolation, hence the tolerance.
+    assert.ok(Math.abs(render(ctx, bus, 0.1) - 0.1) < 1e-6)
+  })
+
+  it("passes ordinary game levels through untouched", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    // Every measured single cue in the 27 games sits inside this range.
+    for (const x of [0.09, 0.113, 0.152, 0.223, 0.296, 0.389, 0.5]) {
+      assert.ok(Math.abs(render(ctx, bus, x) - x) < 1e-6, `${x} was altered`)
+    }
+  })
+
+  it("CANNOT exceed the ceiling — this is the whole point", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    // Measured, before the fix: MOSAIC clear() = 2.344, six of them = 13.955.
+    for (const x of [0.9, 1, 1.3, 2.049, 2.344, 6, 13.955, 100, 1e6]) {
+      const y = render(ctx, bus, x)
+      assert.ok(y <= CEILING + 1e-6, `input ${x} produced ${y}, above ceiling ${CEILING}`)
+      assert.ok(render(ctx, bus, -x) >= -(CEILING + 1e-6))
+    }
+  })
+
+  it("never emits a sample at or above full scale, so nothing clips", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    for (let x = -20; x <= 20; x += 0.017) {
+      assert.ok(Math.abs(render(ctx, bus, x)) < 1, `input ${x} clipped`)
+    }
+  })
+
+  it("is limiting, not gluing", () => {
+    const ctx = new Ctx()
+    createSafetyBus(ctx)
+    const comp = ctx.made.find((n) => n.kind === "comp")
+    assert.ok(comp, "no compressor in the bus")
+    // The games that had a compressor used knee 22-26 / ratio 5-6 and still
+    // clipped when six cues overlapped. That is a glue compressor.
+    assert.equal(comp.knee.value, 0)
+    assert.ok(comp.ratio.value >= 12, `ratio ${comp.ratio.value} is not a limiter`)
+    assert.ok(comp.attack.value <= 0.005, `attack ${comp.attack.value} is too slow to catch a hit`)
+  })
+
+  it("mutes to true silence, after the ceiling", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    bus.setMuted(true)
+    assert.equal(bus.muted, true)
+    assert.equal(render(ctx, bus, 0.4), 0)
+    assert.equal(render(ctx, bus, 50), 0)
+    bus.setMuted(false)
+    assert.ok(Math.abs(render(ctx, bus, 0.4) - 0.4) < 1e-6)
+  })
+
+  it("can mount already muted", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx, { muted: true })
+    assert.equal(render(ctx, bus, 0.4), 0)
+  })
+
+  it("trims before the limiter, and clamps a nonsense level", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx, { level: 0.5 })
+    assert.ok(Math.abs(render(ctx, bus, 0.4) - 0.2) < 1e-6)
+    bus.setLevel(4)
+    assert.ok(render(ctx, bus, 0.4) <= CEILING)
+    bus.setLevel(Number.NaN)
+    assert.equal(render(ctx, bus, 0.4), 0)
+  })
+
+  it("honours a custom ceiling", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx, { ceiling: 0.4 })
+    assert.equal(bus.ceiling, 0.4)
+    assert.ok(render(ctx, bus, 9) <= 0.4 + 1e-6)
+  })
+
+  it("says so out loud when the ceiling cannot be enforced", () => {
+    const full = new Ctx()
+    const ctx: BusContext = {
+      currentTime: 0,
+      destination: full.destination,
+      createGain: () => full.createGain(),
+      createDynamicsCompressor: () => full.createDynamicsCompressor(),
+    }
+    const warnings: unknown[][] = []
+    const real = console.warn
+    console.warn = (...a: unknown[]) => void warnings.push(a)
+    try {
+      createSafetyBus(ctx)
+    } finally {
+      console.warn = real
+    }
+    assert.ok(
+      warnings.some((w) => String(w[0]).includes("ceiling is NOT enforced")),
+      "a bus without a ceiling must not fail silently",
+    )
+  })
+
+  it("tears down without throwing", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    bus.disconnect()
+    assert.ok(ctx.made.every((n) => n.disconnected))
+  })
+})

--- a/dynawalla/packs/shared/game-audio/safetyBus.ts
+++ b/dynawalla/packs/shared/game-audio/safetyBus.ts
@@ -1,0 +1,184 @@
+/**
+ * The last thing between a game and a child's ears.
+ *
+ * Every Dynawalla game builds its own Web Audio graph, and every one of them
+ * ended it with `master.connect(ctx.destination)`. That is the line this file
+ * replaces. Instead:
+ *
+ *     master -> bus.input -> [ level -> limiter -> shaper -> mute ] -> destination
+ *
+ * `limiter`  a real DynamicsCompressorNode at a limiting setting, which does
+ *            the musical work: it rides the loud moments down instead of
+ *            letting them collide.
+ * `shaper`   a WaveShaperNode whose curve is flat at +/-CEILING. This is the
+ *            guarantee. The Web Audio spec says an input outside [-1, 1] uses
+ *            the nearest curve value, so the largest sample this node can emit
+ *            is the largest value in the curve — for any input, including the
+ *            14x-full-scale burst MOSAIC was producing. A limiter alone cannot
+ *            promise that: its attack time is real, and the first two
+ *            milliseconds of a transient go straight through it.
+ * `mute`     after the ceiling, so muted means silent and not merely quiet.
+ *
+ * The node vocabulary is deliberately tiny — createGain, createWaveShaper,
+ * createDynamicsCompressor, connect, and `.value` on a param. That is exactly
+ * what the games' own fake contexts already implement. The shared chrome module
+ * broke four games by reaching for DOM APIs their doubles did not have; this
+ * one does not reach.
+ */
+
+import { CEILING, KNEE, shaperCurve } from "./ceiling.ts"
+
+/** The slice of AudioContext this module touches. Nothing else is assumed. */
+export type BusContext = {
+  readonly currentTime: number
+  readonly destination: AudioNode
+  createGain(): GainNode
+  createDynamicsCompressor(): DynamicsCompressorNode
+  createWaveShaper?: () => WaveShaperNode
+}
+
+export type SafetyBusOptions = {
+  /** Peak the bus may emit, linear 0..1. Defaults to CEILING. */
+  readonly ceiling?: number
+  /** Master trim applied BEFORE the limiter. Defaults to 1. */
+  readonly level?: number
+  /** Where the bus ends. Defaults to `ctx.destination`. */
+  readonly output?: AudioNode
+  /** Start muted — for a game that mounts with sound off. */
+  readonly muted?: boolean
+}
+
+export type SafetyBus = {
+  /** Connect every voice here. Never to `ctx.destination`. */
+  readonly input: AudioNode
+  /** The peak this bus can emit, whatever is fed to it. */
+  readonly ceiling: number
+  /** Master trim before the limiter, 0..1. */
+  setLevel(level: number): void
+  /** True silence, after the ceiling. */
+  setMuted(muted: boolean): void
+  readonly muted: boolean
+  disconnect(): void
+}
+
+/**
+ * Limiter settings.
+ *
+ * threshold 0 dB    and this number is not a compromise, it is measured. A
+ *                   DynamicsCompressorNode applies an internal makeup gain
+ *                   derived from its threshold, which means a threshold below
+ *                   zero makes QUIET material louder — the opposite of the job.
+ *                   Rendered against a real implementation, small-signal gain
+ *                   through this node was:
+ *
+ *                       threshold -3 dB  ->  1.218x   (+1.7 dB, every cue)
+ *                       threshold -1 dB  ->  1.068x
+ *                       threshold  0 dB  ->  1.000x   (unity, exactly)
+ *
+ *                   and the exact makeup differs between engines, so any
+ *                   negative threshold would also make the bus's behaviour
+ *                   depend on whether the child is on WebKit or Chromium.
+ *                   At 0 the node engages precisely when material would
+ *                   otherwise clip, and turns it down instead of distorting
+ *                   it. The musical part of the job — the soft bend that
+ *                   starts well below full scale — belongs to the shaper's
+ *                   knee, which is exact arithmetic and the same everywhere.
+ * knee 0            a limiter, not a glue compressor. The games that had a
+ *                   compressor at knee 22-26 and ratio 5 were gluing, not
+ *                   limiting, and still clipped when six cues overlapped.
+ * ratio 20          the Web Audio maximum.
+ * attack 0.003      as fast as the node is useful at. The remaining leak is
+ *                   what the shaper is for, and what MIN_ATTACK prevents.
+ * release 0.25      slow enough not to pump on a fast run of hits.
+ */
+const THRESHOLD_DB = 0
+const RATIO = 20
+const ATTACK = 0.003
+const RELEASE = 0.25
+
+export function createSafetyBus(ctx: BusContext, options: SafetyBusOptions = {}): SafetyBus {
+  const ceiling = clamp01(options.ceiling ?? CEILING)
+
+  const input = ctx.createGain()
+  const level = ctx.createGain()
+  level.gain.value = clamp01(options.level ?? 1)
+
+  const limiter = ctx.createDynamicsCompressor()
+  limiter.threshold.value = THRESHOLD_DB
+  limiter.knee.value = 0
+  limiter.ratio.value = RATIO
+  limiter.attack.value = ATTACK
+  limiter.release.value = RELEASE
+
+  const mute = ctx.createGain()
+  let muted = options.muted === true
+  mute.gain.value = muted ? 0 : 1
+
+  input.connect(level)
+  level.connect(limiter)
+
+  // The ceiling. Without a WaveShaper there is no guarantee, only a limiter and
+  // a hope — so say so out loud rather than shipping a bus that claims a
+  // ceiling it cannot hold.
+  let shaper: WaveShaperNode | null = null
+  if (typeof ctx.createWaveShaper === "function") {
+    shaper = ctx.createWaveShaper()
+    shaper.curve = shaperCurve(2048, ceiling, KNEE)
+    // "none", and it matters. Oversampling a WaveShaper means upsample, shape,
+    // downsample — and the downsampling filter rings past the curve's own
+    // maximum. Rendered offline against a real Web Audio implementation, a
+    // sawtooth driven 1000x into this exact curve came out at:
+    //
+    //     oversample "none"  ->  0.8900   (the ceiling, exactly)
+    //     oversample "2x"    ->  1.0820   (clipping)
+    //     oversample "4x"    ->  1.0978   (clipping)
+    //
+    // The nicer-sounding setting is the one that voids the guarantee. Since
+    // the limiter upstream means this node barely engages in normal play, the
+    // aliasing it trades away is the cheaper thing to give up.
+    try {
+      shaper.oversample = "none"
+    } catch (e) {
+      console.warn("[game-audio] could not set oversample", e)
+    }
+    limiter.connect(shaper)
+    shaper.connect(mute)
+  } else {
+    console.warn(
+      "[game-audio] no createWaveShaper on this AudioContext: the output ceiling is NOT enforced",
+    )
+    limiter.connect(mute)
+  }
+
+  mute.connect(options.output ?? ctx.destination)
+
+  return {
+    input,
+    ceiling,
+    setLevel(v: number): void {
+      level.gain.value = clamp01(v)
+    },
+    setMuted(next: boolean): void {
+      muted = next
+      mute.gain.value = next ? 0 : 1
+    },
+    get muted(): boolean {
+      return muted
+    },
+    disconnect(): void {
+      for (const n of [input, level, limiter, shaper, mute]) {
+        if (!n) continue
+        try {
+          n.disconnect()
+        } catch (e) {
+          console.warn("[game-audio] node already torn down", e)
+        }
+      }
+    },
+  }
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0
+  return Math.min(1, Math.max(0, v))
+}

--- a/dynawalla/packs/shared/game-audio/tsconfig.json
+++ b/dynawalla/packs/shared/game-audio/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  /* The same strictness the app and the SDK are held to, so a type that passes
+     here cannot fail when a game imports the identical file by relative path —
+     which is how all 27 of them consume this module. `erasableSyntaxOnly` keeps
+     every file runnable under `node --experimental-strip-types`. */
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
The founder's nine-year-old said MOSAIC almost made his ears explode. He was right, and the numbers are worse than the report.

Rendered offline against a real Web Audio implementation (`OfflineAudioContext`), MOSAIC's `clear()` peaked at **2.344 — +7.4 dBFS, 2104 clipped samples**. Six overlapping cues reached **13.955, +22.9 dBFS, 15954 clipped**. Clipped samples do not get quieter on the way out; they get squared off by the DAC, and a broadband square-wave burst arriving in a millisecond is what hurts on headphones.

## Why MOSAIC was loud — four faults, none of them "the volume knob"

**1. The unity-gain hole.** A `GainNode`'s gain defaults to **1**. Every arpeggiated cue scheduled its first `setValueAtTime(0.0001, …)` at its own staggered start time — *in the future* — so each note played at full amplitude for the length of its own delay before its envelope began. `clear()` is authored at 0.15 per note and measured **2.329**. Closing this alone took it to 0.229.

**2. Four cues had no budget.** `clear`, `power`, `forgeRight`, `chargeFull` built envelopes inline instead of through `env()`, so they never touched the voice counter. The four loudest sounds in the game were the four that were not counted.

**3. The voice cap was 26**, which no cue could reach. Six four-voice cues fit under it and summed to 14x full scale.

**4. Attacks of 0.001–0.002 s.** At 44.1 kHz that is 44 samples from silence to peak — a step function with a click on it.

**Bonus, found by the new test:** `star()` staggered its four notes with a `setValueAtTime(0.0001, now + i*0.035)` scheduled *after* the envelope's ramps. That is not a delay, it is a cut. Three of its four notes have been slammed to silence mid-decay since the game shipped.

## What the shared module enforces

`dynawalla/packs/shared/game-audio/` — same reason the chrome and pacing modules exist: 27 games each guessing at a safe level is how this happened.

| | value | how it is enforced |
|---|---|---|
| **CEILING** | 0.89 (-1 dBFS) | `DynamicsCompressorNode` at a limiting setting, then a `WaveShaperNode` whose curve is flat at ±CEILING |
| **MIN_ATTACK** | 6 ms | `safeAttack()` clamp in every envelope |
| **MAX_VOICES** | 12, equal-power past 4 | `VoiceBudget`, no timers, injected clock |

The guarantee is the **shaper**, not the limiter. The spec says a WaveShaper given an input outside `[-1, 1]` uses the nearest curve value, so the largest entry in that table is the largest sample it can emit for *any* input. Verified against a real implementation:

```
drive 0.3   -> 0.3615   drive 2.344  -> 0.8900   drive 100  -> 0.8900
drive 1     -> 0.8900   drive 13.955 -> 0.8900   drive 1000 -> 0.8900
```
Zero clipped samples at every drive.

Two settings are **measured, not chosen**:
- `oversample: "none"` — 2x and 4x ring past the curve's own maximum (**1.082** and **1.098**, i.e. clipping). The nicer-sounding setting voids the guarantee.
- limiter `threshold: 0 dB` — a `DynamicsCompressorNode` applies an internal makeup gain derived from its threshold, so -3 dB makes every **quiet** cue **1.218x louder**, and by an engine-dependent amount. Measured: -3 dB -> 1.218x, -1 dB -> 1.068x, 0 dB -> 1.000x exactly.

Node vocabulary is deliberately tiny — `createGain`, `createWaveShaper`, `createDynamicsCompressor`, `connect`, `.value` on a param — because the shared chrome module broke four games by reaching for DOM APIs their doubles did not implement. Everything here is already in the games' own fakes.

## MOSAIC, before -> after (rendered offline)

| scenario | before | after |
|---|---|---|
| `clear()` | 2.344 (+7.4 dBFS, 2104 clipped) | **0.642** (-3.9, 0) |
| `clear()` + 4x `glass` | 3.000 (+9.5 dBFS, 2318 clipped) | **0.627** (-4.0, 0) |
| 6x `glass` @ force 1.35 | 1.993 (+6.0 dBFS, 62 clipped) | **0.890** (-1.0, 0) |
| `forgeRight()` | 2.049 (+6.2 dBFS, 540 clipped) | under the ceiling |
| `power()` | 1.692 (+4.6 dBFS, 680 clipped) | **0.132** |
| single `glass` | 0.380 | **0.424** |

**Not quieter — correct.** `clear()` is authored *louder* than before, because closing the unity-gain hole left the finale measuring below a single tile break. It is scaled back up to be the biggest sound in the game again, at 0.642 against a 0.89 ceiling. Short-term (400 ms) loudness of the worst case fell 8.5 dB while the peak-to-loudness ratio improved — the shape of a hit that lands harder, not one that is turned down.

## Every test was checked by deleting its fix

| fix removed | failure |
|---|---|
| `safeAttack` clamp | `Expected values to be strictly equal: 0.002 !== 0.006` |
| `shape` out-of-range clamp | `shape(1) = 1 exceeds ceiling 0.89` (7 tests) |
| the curve's bend | `shape(0.9) = 0.9 exceeds ceiling 0.89` (7 tests) |
| `voiceScale` attenuation | `500 simultaneous requests summed to 12` |
| `VoiceBudget` hard cap | `500 simultaneous requests summed to 84.99780988761198` |
| the WaveShaper ceiling | `input 0.9 produced 0.9, above ceiling 0.89` |
| limiter knee 0 -> 24 | `Expected values to be strictly equal: 24 !== 0` |
| mute silencing | `+ 0.3999999940395354 / - 0` |
| the no-ceiling warning | `a bus without a ceiling must not fail silently` |
| MOSAIC unity-gain fix | `star: a gain node's first event is at 12.535, 0.035s in the future — it sits at unity until then` |
| MOSAIC `safeAttack` | `glass: attack 0.002000000000000668s is below MIN_ATTACK 0.006s — that is a step function` |
| MOSAIC safety-bus routing | `2 nodes connect to ctx.destination` / `2 !== 1` |
| MOSAIC force cap | `glass(step, 40) asked for a voice at 12` |
| MOSAIC polyphony budget | `400 voices were connected to the bus` |
| MOSAIC mute gate | `92 nodes were built while muted` |

`game-audio` 35/35 and `mosaic` 79/79, five consecutive runs each. `npm run tsc` clean in both. The new shared module is picked up automatically by the existing `dynawalla/packs/shared/*/package.json` glob in CI.

Follow-up in this branch: the other 24 games. **Separately reported defect:** zero of the 27 games read `settings.sound` from the host — every one has its own in-game mute and its own localStorage key, so turning sound off in the app silences nothing.

Only a device and a real pair of ears can confirm it still sounds *good*. This only proves it cannot be dangerous.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb