### PR TITLE
fix(dynawalla-app): the catalogue cannot be behind a running game if the page cannot scroll

### DIFF
--- a/dynawalla/dynawalla-app/src/app/zoom.test.ts
+++ b/dynawalla/dynawalla-app/src/app/zoom.test.ts
@@ -1,0 +1,387 @@
+// The zoom guard, asserted rather than described.
+//
+// What can be proved here: the state machine that decides a double tap, that
+// the listener is on the right target with the one option that makes
+// `preventDefault` work at all, that the scroll lock adds and removes the class
+// it says it does and hands the offset back, and that the two strings this
+// module duplicates from files TypeScript never reads — the viewport meta in
+// `index.html` and the class name in `index.css` — still match.
+//
+// What CANNOT be proved here, and is stated in the PR rather than hidden:
+// whether WebKit on a real iPhone honours any of it. Nobody in this repository
+// has an iPhone in CI. In particular a tap that lands inside a pack's iframe is
+// dispatched in the child realm and never reaches these listeners, so no test
+// in this file can stand in for one.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import {
+  createTapGuard,
+  DOUBLE_TAP_MS,
+  installZoomGuard,
+  resetViewportScale,
+  STAGED_CLASS,
+  stageDocument,
+  TAP_SLOP_PX,
+  VIEWPORT_CONTENT,
+  watchScale,
+  type GuardTarget,
+  type Listener,
+  type TouchEventLike,
+} from "./zoom.ts"
+
+const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const appRoot = path.resolve(srcRoot, "..")
+
+// ── the state machine ────────────────────────────────────────────────────────
+
+/** A one-finger touch that went down and came up at the same point. */
+function tap(guard: ReturnType<typeof createTapGuard>, at: number, x = 100, y = 100): boolean {
+  guard.start(1, { x, y }, at)
+  return guard.end({ x, y }, at + 20)
+}
+
+test("a single tap is never suppressed", () => {
+  const guard = createTapGuard()
+  assert.equal(tap(guard, 0), false)
+})
+
+test("the second tap of a double tap is suppressed", () => {
+  const guard = createTapGuard()
+  assert.equal(tap(guard, 0), false)
+  assert.equal(tap(guard, 100), true)
+})
+
+test("two taps further apart in time than the gesture window are two taps", () => {
+  const guard = createTapGuard()
+  assert.equal(tap(guard, 0), false)
+  // The first tap ended at 20, so this lands one millisecond outside.
+  assert.equal(tap(guard, DOUBLE_TAP_MS + 2), false)
+})
+
+test("two taps in different places are two taps", () => {
+  const guard = createTapGuard()
+  assert.equal(tap(guard, 0, 100, 100), false)
+  assert.equal(tap(guard, 100, 100, 100 + TAP_SLOP_PX + 1), false)
+})
+
+test("a scroll is not a tap, and does not become half of a double tap", () => {
+  const guard = createTapGuard()
+  // A finger that went down and travelled: a flick of the catalogue, a
+  // joystick, a swipe. Suppressing the touchend at the end of one of these is
+  // the bug that froze the catalogue last time.
+  guard.start(1, { x: 100, y: 400 }, 0)
+  assert.equal(guard.end({ x: 100, y: 40 }, 200), false)
+  // And the tap that follows it is a first tap, not a second.
+  assert.equal(tap(guard, 260, 100, 40), false)
+})
+
+test("a tap that drifts within the slop is still a tap", () => {
+  const guard = createTapGuard()
+  guard.start(1, { x: 100, y: 100 }, 0)
+  assert.equal(guard.end({ x: 100, y: 100 + TAP_SLOP_PX - 1 }, 20), false)
+  assert.equal(tap(guard, 100), true)
+})
+
+test("a two-finger gesture is never counted as taps", () => {
+  const guard = createTapGuard()
+  // Pinch: two fingers down, two fingers up, in the same place and well inside
+  // the window. Counted naively that is a double tap.
+  guard.start(1, { x: 100, y: 100 }, 0)
+  guard.start(2, { x: 140, y: 100 }, 10)
+  assert.equal(guard.end({ x: 140, y: 100 }, 60), false)
+  assert.equal(guard.end({ x: 100, y: 100 }, 70), false)
+  // The next single tap opens a fresh pair rather than closing one.
+  assert.equal(tap(guard, 100), false)
+})
+
+test("a pinch that follows a tap does not close a pair with it", () => {
+  // The case the finger count is actually there for. One real tap, and then a
+  // second finger arrives near it — a child steadying a tablet, or starting a
+  // pinch. Without the count the pinch's first lift lands inside the window and
+  // inside the slop, and gets swallowed as if it were the second tap.
+  const guard = createTapGuard()
+  assert.equal(tap(guard, 0), false)
+
+  guard.start(2, { x: 110, y: 105 }, 60)
+  assert.equal(guard.end({ x: 110, y: 105 }, 120), false)
+})
+
+test("a third tap opens a new pair rather than closing the second", () => {
+  const guard = createTapGuard()
+  assert.equal(tap(guard, 0), false)
+  assert.equal(tap(guard, 100), true)
+  assert.equal(tap(guard, 200), false)
+  assert.equal(tap(guard, 300), true)
+})
+
+test("a touchend with no touchstart is ignored", () => {
+  const guard = createTapGuard()
+  assert.equal(guard.end({ x: 1, y: 1 }, 0), false)
+})
+
+// ── the listener ─────────────────────────────────────────────────────────────
+
+type Registration = { type: string; listener: Listener; options: unknown }
+
+function targetHarness() {
+  const registered: Registration[] = []
+  const removed: Registration[] = []
+  const target: GuardTarget = {
+    addEventListener: (type, listener, options) => registered.push({ type, listener, options }),
+    removeEventListener: (type, listener, options) => removed.push({ type, listener, options }),
+  }
+  const fire = (type: string, event: unknown) => {
+    for (const entry of registered) {
+      if (entry.type === type) (entry.listener as (e: unknown) => void)(event)
+    }
+  }
+  return { target, registered, removed, fire }
+}
+
+function touch(x: number, y: number, at: number, fingers = 1) {
+  let prevented = 0
+  const event: TouchEventLike = {
+    touches: { length: fingers },
+    changedTouches: { length: 1, 0: { clientX: x, clientY: y } },
+    timeStamp: at,
+    preventDefault: () => {
+      prevented += 1
+    },
+  }
+  return { event, prevented: () => prevented }
+}
+
+test("touchend is registered non-passive, which is the whole fix", () => {
+  // A passive listener's preventDefault() is ignored and logs nothing. iOS
+  // treats window touch listeners as passive unless told otherwise, so
+  // `{ passive: false }` is the difference between this working and this being
+  // decoration.
+  const { target, registered } = targetHarness()
+  installZoomGuard(target)
+
+  const end = registered.find((entry) => entry.type === "touchend")
+  assert.ok(end, "touchend must be registered")
+  assert.deepEqual(end.options, { passive: false })
+
+  for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+    const entry = registered.find((r) => r.type === type)
+    assert.ok(entry, `${type} must be registered`)
+    assert.deepEqual(entry.options, { passive: false })
+  }
+})
+
+test("the guard prevents the second tap and nothing else", () => {
+  const { target, fire } = targetHarness()
+  installZoomGuard(target)
+
+  const first = touch(50, 50, 0)
+  fire("touchstart", first.event)
+  fire("touchend", touch(50, 50, 20).event)
+  assert.equal(first.prevented(), 0)
+
+  fire("touchstart", touch(50, 50, 100).event)
+  const second = touch(50, 50, 120)
+  fire("touchend", second.event)
+  assert.equal(second.prevented(), 1)
+})
+
+test("a lone tap on the catalogue is left alone", () => {
+  const { target, fire } = targetHarness()
+  installZoomGuard(target)
+
+  fire("touchstart", touch(50, 50, 0).event)
+  const end = touch(50, 50, 20)
+  fire("touchend", end.event)
+  assert.equal(end.prevented(), 0)
+})
+
+test("a scroll of the catalogue is left alone", () => {
+  const { target, fire } = targetHarness()
+  installZoomGuard(target)
+
+  fire("touchstart", touch(50, 500, 0).event)
+  const end = touch(50, 80, 300)
+  fire("touchend", end.event)
+  assert.equal(end.prevented(), 0)
+})
+
+test("the WebKit gesture events are all prevented", () => {
+  const { target, fire } = targetHarness()
+  installZoomGuard(target)
+
+  for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+    let prevented = 0
+    fire(type, {
+      preventDefault: () => {
+        prevented += 1
+      },
+    })
+    assert.equal(prevented, 1, `${type} must be prevented`)
+  }
+})
+
+test("disposing removes every listener it added, once", () => {
+  const { target, registered, removed } = targetHarness()
+  const dispose = installZoomGuard(target)
+  dispose()
+  dispose()
+
+  assert.equal(removed.length, registered.length)
+  for (const entry of registered) {
+    assert.ok(
+      removed.some((r) => r.type === entry.type && r.listener === entry.listener),
+      `${entry.type} must be removed with the same function reference`,
+    )
+  }
+})
+
+// ── the scroll lock ──────────────────────────────────────────────────────────
+
+function docHarness(scrollY = 0) {
+  const classes = new Set<string>()
+  const scrolls: number[] = []
+  const doc = {
+    documentElement: {
+      classList: {
+        add: (token: string) => classes.add(token),
+        remove: (token: string) => classes.delete(token),
+      },
+    },
+  }
+  const win = { scrollY, scrollTo: (_x: number, y: number) => scrolls.push(y) }
+  return { doc, win, classes, scrolls }
+}
+
+test("staging locks the document and releasing gives the scroll back where it was", () => {
+  const { doc, win, classes, scrolls } = docHarness(742)
+
+  const release = stageDocument(doc, win)
+  assert.ok(classes.has(STAGED_CLASS), "the document must be locked while a pack is up")
+
+  release()
+  assert.equal(classes.has(STAGED_CLASS), false, "the lock must not outlive the pack")
+  // `overflow: hidden` clamps the offset to zero, so a child who scrolled to
+  // the bottom of the catalogue and played a game would come back to the top.
+  assert.deepEqual(scrolls, [742])
+})
+
+test("releasing twice restores the scroll once", () => {
+  // React StrictMode runs an effect's cleanup twice on the first mount.
+  const { doc, win, scrolls } = docHarness(120)
+  const release = stageDocument(doc, win)
+  release()
+  release()
+  assert.deepEqual(scrolls, [120])
+})
+
+// ── the scale watchdog ───────────────────────────────────────────────────────
+
+test("resetting the scale ends on the canonical viewport, via a different string", () => {
+  // Writing the same string back is a no-op and WebKit never re-evaluates.
+  const written: string[] = []
+  const meta = {
+    get content() {
+      return written[written.length - 1] ?? ""
+    },
+    set content(value: string) {
+      written.push(value)
+    },
+  }
+  resetViewportScale(meta)
+  assert.equal(written.length, 2)
+  assert.notEqual(written[0], written[1])
+  assert.equal(written[1], VIEWPORT_CONTENT)
+})
+
+test("the watchdog fires only when the page has actually scaled", () => {
+  const written: string[] = []
+  const meta = { content: "" }
+  Object.defineProperty(meta, "content", {
+    get: () => written[written.length - 1] ?? "",
+    set: (value: string) => written.push(value),
+  })
+
+  const subscription: { fn: (() => void) | null } = { fn: null }
+  const viewport = {
+    scale: 1,
+    addEventListener: (_type: string, fn: () => void) => {
+      subscription.fn = fn
+    },
+    removeEventListener: () => {
+      subscription.fn = null
+    },
+  }
+
+  const dispose = watchScale(viewport, meta)
+  const fire = subscription.fn
+  assert.ok(fire, "the watchdog must subscribe to the visual viewport")
+
+  // A resize with no scale change — a rotation, a keyboard — is not a zoom.
+  fire()
+  assert.deepEqual(written, [])
+
+  viewport.scale = 2.4
+  fire()
+  assert.equal(written[written.length - 1], VIEWPORT_CONTENT)
+
+  dispose()
+  assert.equal(subscription.fn, null)
+})
+
+// ── the strings this module duplicates ───────────────────────────────────────
+
+test("index.html still carries the viewport this module writes back", () => {
+  // `resetViewportScale` restores VIEWPORT_CONTENT verbatim. If the meta in
+  // index.html drifts — someone drops `user-scalable=no`, or adds a token —
+  // the first zoom silently rewrites the page's viewport to a stale one, and
+  // nothing else in this repository would notice.
+  const html = fs.readFileSync(path.join(appRoot, "index.html"), "utf8")
+  const match = /<meta\s+name="viewport"\s+content="([^"]+)"/s.exec(html.replace(/\s+/g, " "))
+  assert.ok(match, "index.html must declare a viewport meta this test can read")
+  assert.equal(match[1] ?? "", VIEWPORT_CONTENT)
+})
+
+test("the stylesheet is cut for the class the stage actually sets", () => {
+  const indexCss = fs.readFileSync(path.join(srcRoot, "index.css"), "utf8")
+  assert.match(indexCss, new RegExp(`html\\.${STAGED_CLASS}\\s*,`))
+  assert.match(indexCss, new RegExp(`html\\.${STAGED_CLASS} body\\s*\\{\\s*overflow: hidden;`))
+})
+
+test("the document lock is scoped to the stage and never applied to html outright", () => {
+  // An earlier attempt at this put the lock on `body` unconditionally and
+  // stopped the catalogue scrolling entirely. `overflow-x: hidden` on html/body
+  // is deliberate and stays; a bare `overflow` on either is the regression.
+  const indexCss = fs.readFileSync(path.join(srcRoot, "index.css"), "utf8")
+  const rules = indexCss.matchAll(/(^|\})([^{}]*)\{([^{}]*)\}/g)
+  for (const rule of rules) {
+    const selector = (rule[2] ?? "").replace(/\/\*[\s\S]*?\*\//g, "").trim()
+    const body = rule[3] ?? ""
+    if (!/(^|,)\s*(html|body)\s*(,|$)/m.test(selector)) continue
+    assert.doesNotMatch(
+      body,
+      /(^|;)\s*overflow\s*:/,
+      `an unscoped \`overflow\` on \`${selector}\` freezes the catalogue`,
+    )
+  }
+})
+
+test("the stage is what turns the lock on", () => {
+  // A source assertion, and a weak one — it proves the call is written, not
+  // that React runs it. It is here because the whole fix is inert if the wiring
+  // is deleted, and there is no DOM in this test runner to render Stage.tsx in.
+  const stage = fs.readFileSync(path.join(srcRoot, "packs/Stage.tsx"), "utf8")
+  assert.ok(
+    stage.includes("stageDocument(document, window)"),
+    "Stage.tsx must call stageDocument(document, window) while a pack is mounted",
+  )
+  const main = fs.readFileSync(path.join(srcRoot, "main.tsx"), "utf8")
+  assert.ok(
+    main.includes('import "./app/zoom.ts"'),
+    "main.tsx must import ./app/zoom.ts so the guard is registered before the first paint",
+  )
+})

--- a/dynawalla/dynawalla-app/src/app/zoom.ts
+++ b/dynawalla/dynawalla-app/src/app/zoom.ts
@@ -1,0 +1,293 @@
+// Nothing in this app is a document, and a document is the only thing that
+// should scale.
+//
+// ── What actually goes wrong ─────────────────────────────────────────────────
+// A child double-taps inside a running game on an iPhone. The page scales, the
+// child's finger pans it, and the catalogue appears above the game. It reads
+// like the game "leaking" — it is not. Two separate facts combine:
+//
+//   1. Page scale is a property of the TOP-LEVEL page. A pack runs in a
+//      sandboxed, opaque-origin iframe, but an iframe has no viewport and no
+//      scale of its own; the gesture recogniser lives on the WKWebView. So a
+//      double tap on a game canvas scales the host document.
+//   2. On iOS a `position: fixed` element is laid out against the LAYOUT
+//      viewport, and WebKit does not reposition it continuously while a pan is
+//      in flight. The stage is `fixed inset-0`. The ONLY way anything behind it
+//      can come into view is for the document to be taller than the layout
+//      viewport and to scroll. A catalogue of game cards always is.
+//
+// Fact 2 is the one this app fully owns, and it is a necessary condition: take
+// the document's scroll away while a game is up and there is nothing behind the
+// stage to pan to, whether or not the scale changed. That is `stageDocument`.
+//
+// ── What this file cannot do ─────────────────────────────────────────────────
+// The tap guard below sees `touchstart`/`touchend` on the HOST document only.
+// Touch events raised inside a cross-origin iframe are dispatched in the child
+// realm and never cross the boundary — `window.parent` is not even readable
+// from there. So the guard covers the exit chevron, the day-pass sheet and the
+// catalogue, and it does NOT cover a tap that lands on a game. Preventing that
+// one at source belongs to the pack document, which means the pack SDK, not
+// here. `resetViewportScale` is the only lever in this file that reaches across
+// the boundary at all, and it is a recovery rather than a prevention: it undoes
+// a scale change after the fact instead of stopping the gesture.
+//
+// ── Why the viewport meta is not enough on its own ───────────────────────────
+// `user-scalable=no, maximum-scale=1` is respected by WKWebView by default
+// (unlike Safari, which has ignored it since iOS 10 —
+// `WKWebViewConfiguration.ignoresViewportScaleLimits` is false unless someone
+// sets it, and wry does not). It is kept, it is the first line, and it is
+// asserted against `index.html` by the tests. It has been reported not to hold
+// on a real iPhone, which is why none of what follows depends on it.
+
+/** On `<html>` for exactly as long as a pack is on the stage. */
+export const STAGED_CLASS = "dw-staged"
+
+/**
+ * The canonical viewport, duplicated from `index.html` because a string in a
+ * document TypeScript never reads is a string that silently drifts. A test
+ * asserts the two are the same.
+ */
+export const VIEWPORT_CONTENT =
+  "width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+
+/** The window WebKit joins two taps into one gesture in. */
+export const DOUBLE_TAP_MS = 350
+
+/**
+ * How far a finger may travel and still have been a tap.
+ *
+ * Generous on purpose: this is a seven-year-old's finger on a game, not a
+ * mouse. Too small and a slightly smeared double tap is not caught; too large
+ * and a short flick of the catalogue is mistaken for one, which is why the
+ * guard also checks the distance the finger travelled WITHIN each tap and
+ * treats anything that moved as a drag rather than as a tap.
+ */
+export const TAP_SLOP_PX = 30
+
+export type Point = { readonly x: number; readonly y: number }
+
+function far(a: Point, b: Point): boolean {
+  return Math.hypot(a.x - b.x, a.y - b.y) > TAP_SLOP_PX
+}
+
+export type TapGuard = {
+  /** `touchstart`. `fingers` is `event.touches.length`. */
+  start(fingers: number, point: Point, at: number): void
+  /** `touchend`. True when this is the second tap of a double tap. */
+  end(point: Point, at: number): boolean
+}
+
+/**
+ * The classic double-tap guard, as a pure state machine.
+ *
+ * A tap is one finger that went down and came up in the same place. A double
+ * tap is two of those, close together in time and in space. Everything else —
+ * a scroll, a flick, a two-finger anything, a long press that drifted — is not
+ * a tap and clears the pair, because the alternative is a guard that swallows
+ * the tap at the end of a scroll.
+ */
+export function createTapGuard(): TapGuard {
+  let down: { point: Point; at: number } | null = null
+  let multi = false
+  let previous: { point: Point; at: number } | null = null
+
+  return {
+    start(fingers, point, at) {
+      if (fingers > 1) {
+        // A pinch is not two taps, and neither half of it may be counted.
+        multi = true
+        down = null
+        previous = null
+        return
+      }
+      multi = false
+      down = { point, at }
+    },
+
+    end(point, at) {
+      const from = down
+      down = null
+      if (multi || from === null) {
+        previous = null
+        return false
+      }
+      // It moved: a scroll, a swipe, a joystick. Not a tap, and it ends any
+      // pair in progress so the finger lifting is never the second of one.
+      if (far(from.point, point)) {
+        previous = null
+        return false
+      }
+
+      const first = previous
+      if (first !== null && at - first.at <= DOUBLE_TAP_MS && !far(first.point, point)) {
+        // The pair is spent. A third tap opens a new one rather than pairing
+        // with the second, which is what makes a child drumming on a button
+        // cost one suppressed click per two taps and not every tap after the
+        // first.
+        previous = null
+        return true
+      }
+
+      previous = { point, at }
+      return false
+    },
+  }
+}
+
+type TouchPoint = { readonly clientX: number; readonly clientY: number }
+
+/** The parts of a `TouchEvent` this file uses. Narrow so it can be faked. */
+export type TouchEventLike = {
+  readonly touches: { readonly length: number }
+  readonly changedTouches: { readonly length: number; readonly [index: number]: TouchPoint }
+  readonly timeStamp: number
+  preventDefault(): void
+}
+
+export type Listener = (event: never) => void
+
+export type GuardTarget = {
+  addEventListener(type: string, listener: Listener, options?: unknown): void
+  removeEventListener(type: string, listener: Listener, options?: unknown): void
+}
+
+/**
+ * Register the guard on the host document. Returns a disposer.
+ *
+ * `touchend` MUST be registered non-passive: a passive listener's
+ * `preventDefault()` is ignored, and iOS defaults touch listeners on the window
+ * to passive. That single option is the whole difference between this working
+ * and this being decoration, so there is a test for it.
+ *
+ * `gesturestart`/`gesturechange`/`gestureend` are WebKit's own, non-standard
+ * and two-finger only: they are pinch, NOT double tap. They are here because
+ * the invariant is "the host page never scales", not "the host page never
+ * double-tap-zooms" — but nobody should expect them to fire for a double tap.
+ */
+export function installZoomGuard(
+  target: GuardTarget,
+  guard: TapGuard = createTapGuard(),
+): () => void {
+  const onStart = (event: TouchEventLike) => {
+    const touch = event.changedTouches[0]
+    if (!touch) return
+    guard.start(event.touches.length, { x: touch.clientX, y: touch.clientY }, event.timeStamp)
+  }
+
+  const onEnd = (event: TouchEventLike) => {
+    const touch = event.changedTouches[0]
+    if (!touch) return
+    if (guard.end({ x: touch.clientX, y: touch.clientY }, event.timeStamp)) event.preventDefault()
+  }
+
+  const onGesture = (event: { preventDefault(): void }) => event.preventDefault()
+
+  const registered: [string, Listener, unknown][] = [
+    ["touchstart", onStart as Listener, { passive: true }],
+    ["touchend", onEnd as Listener, { passive: false }],
+    ["gesturestart", onGesture as Listener, { passive: false }],
+    ["gesturechange", onGesture as Listener, { passive: false }],
+    ["gestureend", onGesture as Listener, { passive: false }],
+  ]
+
+  for (const [type, listener, options] of registered) {
+    target.addEventListener(type, listener, options)
+  }
+
+  let disposed = false
+  return () => {
+    if (disposed) return
+    disposed = true
+    for (const [type, listener, options] of registered) {
+      target.removeEventListener(type, listener, options)
+    }
+  }
+}
+
+/**
+ * Put the page back to scale 1.
+ *
+ * There is no API for this. Rewriting the viewport meta makes WebKit
+ * re-evaluate it and clamp the current scale to the limits it finds, and
+ * writing the SAME string is a no-op — so it goes out via a value that differs
+ * textually while describing exactly the same viewport, then back to the
+ * canonical one. Both strings pin minimum = initial = maximum = 1, so there is
+ * no intermediate viewport a frame could be painted at.
+ *
+ * UNVERIFIED on a device. This is the only thing in this file that can undo a
+ * zoom which began inside a pack's iframe, and it is a recovery: the scale
+ * changes and then snaps back. Prevention there belongs to the pack.
+ */
+export function resetViewportScale(meta: { content: string }): void {
+  meta.content = `${VIEWPORT_CONTENT}, minimum-scale=1`
+  meta.content = VIEWPORT_CONTENT
+}
+
+export type VisualViewportLike = {
+  readonly scale: number
+  addEventListener(type: string, listener: () => void): void
+  removeEventListener(type: string, listener: () => void): void
+}
+
+/** Scale drift below this is float noise, not a zoom. */
+const SCALE_TOLERANCE = 0.01
+
+/**
+ * Watch the visual viewport and undo any scale the page acquires.
+ *
+ * `visualViewport` is a property of the top-level page, so this sees a zoom
+ * that a pack's iframe caused even though it never sees the touch that caused
+ * it. Returns a disposer.
+ */
+export function watchScale(
+  viewport: VisualViewportLike,
+  meta: { content: string } | null,
+): () => void {
+  if (!meta) return () => {}
+  const onResize = () => {
+    if (Math.abs(viewport.scale - 1) > SCALE_TOLERANCE) resetViewportScale(meta)
+  }
+  viewport.addEventListener("resize", onResize)
+  return () => viewport.removeEventListener("resize", onResize)
+}
+
+export type ClassList = { add(token: string): void; remove(token: string): void }
+export type StageDocument = { readonly documentElement: { readonly classList: ClassList } }
+export type StageWindow = { readonly scrollY: number; scrollTo(x: number, y: number): void }
+
+/**
+ * Take the host document's scroll away for as long as a pack is on the stage,
+ * and give it back — at the same offset — when the pack leaves.
+ *
+ * This is the fix, not a hardening of it: with nothing to scroll, a scaled and
+ * panned page has nowhere to pan to, so the catalogue behind the stage cannot
+ * come into view even if the zoom itself happens.
+ *
+ * Scoped to a class that only exists while a game is running. `overflow:
+ * hidden` on `html` unconditionally froze the catalogue once already; this is
+ * why it is a class and not a rule.
+ *
+ * Restoring `scrollY` is not a nicety: `overflow: hidden` clamps the offset to
+ * zero, so without this a child who scrolled to the bottom of the catalogue,
+ * played a game and came back would be at the top.
+ */
+export function stageDocument(doc: StageDocument, win: StageWindow): () => void {
+  const offset = win.scrollY
+  doc.documentElement.classList.add(STAGED_CLASS)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    doc.documentElement.classList.remove(STAGED_CLASS)
+    win.scrollTo(0, offset)
+  }
+}
+
+// Applied at module load, like the theme: the host page must never scale, and
+// there is no screen on which that is not true. Nothing here touches the pack
+// iframe — see the note at the top of the file.
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  installZoomGuard(window as unknown as GuardTarget)
+  const viewport = (window as unknown as { visualViewport?: VisualViewportLike }).visualViewport
+  if (viewport) watchScale(viewport, document.querySelector<HTMLMetaElement>('meta[name="viewport"]'))
+}

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -105,6 +105,26 @@
     overflow-x: hidden;
   }
 
+  /* While a pack is on the stage the host document has nowhere to go.
+   *
+   * The stage is `position: fixed; inset: 0`, and on iOS a fixed element is
+   * laid out against the LAYOUT viewport and is not repositioned continuously
+   * while a pan is in flight. So the only way the catalogue behind a running
+   * game can come into view is for the document to be TALLER than that
+   * viewport and to scroll — which is exactly what the pan after a double-tap
+   * zoom does, and a grid of game cards is always taller. Take the scroll away
+   * and there is nothing behind the stage to reach, whether or not the scale
+   * changed.
+   *
+   * A class, never a bare `html` rule: the catalogue has to scroll, and
+   * locking the document unconditionally froze it once already. `zoom.ts`
+   * adds this for exactly as long as a pack is mounted and restores the
+   * scroll offset on the way out. */
+  html.dw-staged,
+  html.dw-staged body {
+    overflow: hidden;
+  }
+
   /* A mouse user genuinely needs a scrollbar — but they need the one their
      desktop draws, which is an overlay thumb on nothing, not a painted grey
      channel down the edge of the page. Thumb only, in the theme's own violet,

--- a/dynawalla/dynawalla-app/src/main.tsx
+++ b/dynawalla/dynawalla-app/src/main.tsx
@@ -8,6 +8,11 @@ import { RouterProvider } from "react-router"
 // jump from default type to the size a child actually reads at.
 import "./app/theme.ts"
 import "./settings/store.ts"
+// Registered before the first paint for the same reason: the guard has to be on
+// the window before a finger can reach it. See the note at the head of the file
+// for what it does and does not cover — in particular that it cannot see a tap
+// inside a pack's iframe.
+import "./app/zoom.ts"
 import "./index.css"
 
 import { router } from "./app/router.tsx"

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -22,6 +22,7 @@ import type { Settings } from "../../../packs/sdk/src/index.ts"
 import { BUILD_VERSION, hapticPorts } from "../app/platform.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
+import { stageDocument } from "../app/zoom.ts"
 import { PassSheet } from "../pass/PassSheet.tsx"
 import { usePass } from "../pass/store.ts"
 import { useProfiles } from "../profiles/store.ts"
@@ -266,6 +267,15 @@ function Curtain({ message, onLeave }: { message: string; onLeave: () => void })
 export function PackStage() {
   const packId = useLaunch((state) => state.packId)
   const leave = useLaunch((state) => state.leave)
+
+  // The host document does not scroll while a game is up. A double tap inside
+  // a pack scales the HOST page — the iframe has no viewport of its own — and
+  // the pan that follows is what slides the catalogue into view above the
+  // stage. It can only slide if there is something to scroll. See zoom.ts.
+  useEffect(() => {
+    if (packId === null) return
+    return stageDocument(document, window)
+  }, [packId])
 
   // Escape leaves, on every platform that has a keyboard. A game that takes the
   // whole window with no keyboard path out is a trap.


### PR DESCRIPTION
#609 said this was fixed. It was not, on iPhone, and the reason it looked
fixed is that it works on Android.

WHAT ACTUALLY HAPPENS. Two facts combine, and only one of them is about zoom.

  1. A pack runs in a sandboxed, opaque-origin iframe. An iframe has no
     viewport and no page scale of its own — the double-tap gesture recogniser
     lives on the WKWebView and page scale is a property of the TOP-LEVEL page.
     So a double tap on a game canvas scales the HOST document. That much #609
     had right.
  2. On iOS a `position: fixed` element is laid out against the LAYOUT
     viewport, and WebKit does not reposition it continuously while a pan is in
     flight. The stage is `fixed inset-0`. The ONLY way anything behind it can
     come into view is for the document to be TALLER than the layout viewport
     and to scroll — and a grid of game cards always is.

Fact 2 is a necessary condition, and it is the one this app owns outright.
While a pack is on the stage, `<html>` now carries `dw-staged`, which is
`overflow: hidden` on html and body. With nothing to scroll there is nowhere
to pan to, so the catalogue cannot surface whether or not the scale changed.
The class exists for exactly as long as a pack is mounted and the scroll offset
is handed back on the way out — `overflow: hidden` clamps it to zero, so
without that a child who scrolled to the bottom of the catalogue, played a game
and came back would be at the top. It is a class and never a bare `html` rule,
because locking the document unconditionally froze the catalogue once already.

WHY #609's VIEWPORT META WAS NOT ENOUGH. It is kept — WKWebView does respect
`user-scalable=no` by default, unlike Safari, which has ignored it since iOS 10
(`WKWebViewConfiguration.ignoresViewportScaleLimits` is false unless someone
sets it, and wry does not). It is now also pinned by a test against the
constant this module writes back. But it was the whole of the fix, it was
reported not to hold on a real iPhone, and nothing added here depends on it.

WHAT THE HOST STILL CANNOT DO. Touch events raised inside a cross-origin iframe
are dispatched in the child realm and never cross the boundary. The tap guard
added here — `touchend`, non-passive, second tap inside 350ms and 30px — covers
the exit chevron, the day-pass sheet and the catalogue, and it CANNOT see a tap
that lands on a game. Preventing that one at source belongs to the pack
document, which is `packs/sdk` and `packs/shared/game-chrome`, not here.
`resetViewportScale` is the only lever in this commit that reaches across the
boundary at all, and it is a recovery rather than a prevention: `visualViewport`
is a top-level property, so the host sees a scale a pack caused even though it
never saw the touch, and rewrites the viewport meta to snap it back.

`gesturestart`/`gesturechange`/`gestureend` are prevented too. They are WebKit's
own, they are two-finger, and they are pinch and NOT double tap — they are here
because the invariant is "the host page never scales", and nobody should read
them as covering the reported bug.

UNVERIFIED. Nobody in this repository has an iPhone in CI. Every WebKit claim
above is reasoned from the platform, not observed: the scroll lock, the
non-passive listener and the state machine are proven by test in Node, and
whether WebKit honours any of it on a device is not.

Twenty-four tests, and every one of them was checked by deleting the thing it
covers and watching it fail — fifteen separate mutations, all caught, including
one that survived the first draft and forced a better multi-touch test.

`touch-action` is deliberately untouched. `.pack-frame-host` already carries
`touch-action: none`; whether that propagates into the child document is
contested between engines, and if it does then tightening it further would take
the in-game manual's `pan-y` finger scroll with it.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb