### PR TITLE
fix(dynawalla-app): delete the tap guard, reuse dw-locked, and make the CSS regression guard actually guard

### DIFF
--- a/dynawalla/dynawalla-app/index.html
+++ b/dynawalla/dynawalla-app/index.html
@@ -4,12 +4,15 @@
     <meta charset="UTF-8" />
     <!-- viewport-fit=cover is what makes env(safe-area-inset-*) report real
          values on notched iPhones; the --safe-* tokens are dead without it. -->
-    <!-- user-scalable=no and maximum-scale=1 are what actually stop iOS
-         double-tap-to-zoom. Without them a double tap inside a game scales and
-         pans the HOST document, and the catalog behind the pack slides into
-         view at the top. Every pack entry already sets both; the frame around
-         them did not. `touch-action: manipulation` does NOT cover this — it
-         removes the click delay and still permits pinch and double-tap. -->
+    <!-- user-scalable=no and maximum-scale=1 are the FIRST line against iOS
+         double-tap-to-zoom, not the whole of it: WKWebView respects them by
+         default (Safari has ignored them since iOS 10), and they have still
+         been reported not to hold on a real iPhone. What a double tap inside a
+         game actually scales is this document — an iframe has no viewport of
+         its own — and what makes that visible is the page being scrollable
+         behind the stage. See src/app/zoom.ts; nothing there depends on this
+         line, and `resetViewportScale` restores this exact string, which a
+         test pins. -->
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"

--- a/dynawalla/dynawalla-app/src/app/zoom.test.ts
+++ b/dynawalla/dynawalla-app/src/app/zoom.test.ts
@@ -1,17 +1,17 @@
-// The zoom guard, asserted rather than described.
+// The document lock and the scale watchdog, asserted rather than described.
 //
-// What can be proved here: the state machine that decides a double tap, that
-// the listener is on the right target with the one option that makes
-// `preventDefault` work at all, that the scroll lock adds and removes the class
-// it says it does and hands the offset back, and that the two strings this
-// module duplicates from files TypeScript never reads — the viewport meta in
-// `index.html` and the class name in `index.css` — still match.
+// What can be proved here: that the lock adds and removes the class it says it
+// does, counts its holders, and hands the scroll offset back; that the pinch
+// listeners are on the right target with the one option that makes
+// `preventDefault` work at all; and that the two strings this module duplicates
+// from files TypeScript never reads — the viewport meta in `index.html` and the
+// class name in `index.css` — still match.
 //
 // What CANNOT be proved here, and is stated in the PR rather than hidden:
 // whether WebKit on a real iPhone honours any of it. Nobody in this repository
 // has an iPhone in CI. In particular a tap that lands inside a pack's iframe is
-// dispatched in the child realm and never reaches these listeners, so no test
-// in this file can stand in for one.
+// dispatched in the child realm and never reaches this document at all, so no
+// test in this file can stand in for one.
 
 import { test } from "node:test"
 import assert from "node:assert/strict"
@@ -20,111 +20,109 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import {
-  createTapGuard,
-  DOUBLE_TAP_MS,
-  installZoomGuard,
+  createDocumentLock,
+  installPinchGuard,
+  LOCKED_CLASS,
   resetViewportScale,
-  STAGED_CLASS,
-  stageDocument,
-  TAP_SLOP_PX,
   VIEWPORT_CONTENT,
   watchScale,
   type GuardTarget,
   type Listener,
-  type TouchEventLike,
 } from "./zoom.ts"
 
 const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const appRoot = path.resolve(srcRoot, "..")
 
-// ── the state machine ────────────────────────────────────────────────────────
+// ── the document lock ────────────────────────────────────────────────────────
 
-/** A one-finger touch that went down and came up at the same point. */
-function tap(guard: ReturnType<typeof createTapGuard>, at: number, x = 100, y = 100): boolean {
-  guard.start(1, { x, y }, at)
-  return guard.end({ x, y }, at + 20)
+function docHarness(scrollY = 0) {
+  const classes = new Set<string>()
+  const scrolls: number[] = []
+  const doc = {
+    documentElement: {
+      classList: {
+        add: (token: string) => classes.add(token),
+        remove: (token: string) => classes.delete(token),
+      },
+    },
+  }
+  const win = { scrollY, scrollTo: (_x: number, y: number) => scrolls.push(y) }
+  return { doc, win, classes, scrolls }
 }
 
-test("a single tap is never suppressed", () => {
-  const guard = createTapGuard()
-  assert.equal(tap(guard, 0), false)
+test("locking freezes the document and releasing gives the scroll back where it was", () => {
+  const lock = createDocumentLock()
+  const { doc, win, classes, scrolls } = docHarness(742)
+
+  const release = lock.acquire(doc, win)
+  assert.ok(classes.has(LOCKED_CLASS), "the document must be locked while a pack is up")
+  assert.deepEqual(scrolls, [], "nothing may scroll on the way in")
+
+  release()
+  assert.equal(classes.has(LOCKED_CLASS), false, "the lock must not outlive the pack")
+  // `overflow: hidden` clamps the offset to zero, so a child who scrolled to
+  // the bottom of the catalogue and played a game would come back to the top.
+  assert.deepEqual(scrolls, [742])
 })
 
-test("the second tap of a double tap is suppressed", () => {
-  const guard = createTapGuard()
-  assert.equal(tap(guard, 0), false)
-  assert.equal(tap(guard, 100), true)
+test("releasing twice restores the scroll once", () => {
+  // React StrictMode runs an effect's cleanup twice on the first mount.
+  const lock = createDocumentLock()
+  const { doc, win, scrolls } = docHarness(120)
+  const release = lock.acquire(doc, win)
+  release()
+  release()
+  assert.deepEqual(scrolls, [120])
+  assert.equal(lock.holders(), 0, "a double release must not drive the count negative")
 })
 
-test("two taps further apart in time than the gesture window are two taps", () => {
-  const guard = createTapGuard()
-  assert.equal(tap(guard, 0), false)
-  // The first tap ended at 20, so this lands one millisecond outside.
-  assert.equal(tap(guard, DOUBLE_TAP_MS + 2), false)
+test("a second holder keeps the lock when the first lets go", () => {
+  // The day-pass sheet opens over a running game. The sheet closing must not
+  // hand the scroll back to a pack that is still on the stage.
+  const lock = createDocumentLock()
+  const { doc, win, classes, scrolls } = docHarness(310)
+
+  const stage = lock.acquire(doc, win)
+  const sheet = lock.acquire(doc, win)
+  assert.equal(lock.holders(), 2)
+
+  sheet()
+  assert.ok(classes.has(LOCKED_CLASS), "one holder left is still a holder")
+  assert.deepEqual(scrolls, [], "the scroll may not come back while a game is up")
+
+  stage()
+  assert.equal(classes.has(LOCKED_CLASS), false)
+  assert.deepEqual(scrolls, [310])
 })
 
-test("two taps in different places are two taps", () => {
-  const guard = createTapGuard()
-  assert.equal(tap(guard, 0, 100, 100), false)
-  assert.equal(tap(guard, 100, 100, 100 + TAP_SLOP_PX + 1), false)
+test("the offset restored is the one the page really had, not the clamped zero", () => {
+  // The second holder arrives while the document is already locked, so its
+  // `scrollY` is whatever `overflow: hidden` clamped it to. Reading that one
+  // would silently discard the child's place in the catalogue.
+  const lock = createDocumentLock()
+  const first = docHarness(880)
+  const clamped = { scrollY: 0, scrollTo: (_x: number, y: number) => first.scrolls.push(y) }
+
+  const stage = lock.acquire(first.doc, first.win)
+  const sheet = lock.acquire(first.doc, clamped)
+  sheet()
+  stage()
+
+  assert.deepEqual(first.scrolls, [880])
 })
 
-test("a scroll is not a tap, and does not become half of a double tap", () => {
-  const guard = createTapGuard()
-  // A finger that went down and travelled: a flick of the catalogue, a
-  // joystick, a swipe. Suppressing the touchend at the end of one of these is
-  // the bug that froze the catalogue last time.
-  guard.start(1, { x: 100, y: 400 }, 0)
-  assert.equal(guard.end({ x: 100, y: 40 }, 200), false)
-  // And the tap that follows it is a first tap, not a second.
-  assert.equal(tap(guard, 260, 100, 40), false)
+test("locking again after a full release captures the new offset", () => {
+  const lock = createDocumentLock()
+  const a = docHarness(50)
+  lock.acquire(a.doc, a.win)()
+  const b = docHarness(900)
+  lock.acquire(b.doc, b.win)()
+
+  assert.deepEqual(a.scrolls, [50])
+  assert.deepEqual(b.scrolls, [900])
 })
 
-test("a tap that drifts within the slop is still a tap", () => {
-  const guard = createTapGuard()
-  guard.start(1, { x: 100, y: 100 }, 0)
-  assert.equal(guard.end({ x: 100, y: 100 + TAP_SLOP_PX - 1 }, 20), false)
-  assert.equal(tap(guard, 100), true)
-})
-
-test("a two-finger gesture is never counted as taps", () => {
-  const guard = createTapGuard()
-  // Pinch: two fingers down, two fingers up, in the same place and well inside
-  // the window. Counted naively that is a double tap.
-  guard.start(1, { x: 100, y: 100 }, 0)
-  guard.start(2, { x: 140, y: 100 }, 10)
-  assert.equal(guard.end({ x: 140, y: 100 }, 60), false)
-  assert.equal(guard.end({ x: 100, y: 100 }, 70), false)
-  // The next single tap opens a fresh pair rather than closing one.
-  assert.equal(tap(guard, 100), false)
-})
-
-test("a pinch that follows a tap does not close a pair with it", () => {
-  // The case the finger count is actually there for. One real tap, and then a
-  // second finger arrives near it — a child steadying a tablet, or starting a
-  // pinch. Without the count the pinch's first lift lands inside the window and
-  // inside the slop, and gets swallowed as if it were the second tap.
-  const guard = createTapGuard()
-  assert.equal(tap(guard, 0), false)
-
-  guard.start(2, { x: 110, y: 105 }, 60)
-  assert.equal(guard.end({ x: 110, y: 105 }, 120), false)
-})
-
-test("a third tap opens a new pair rather than closing the second", () => {
-  const guard = createTapGuard()
-  assert.equal(tap(guard, 0), false)
-  assert.equal(tap(guard, 100), true)
-  assert.equal(tap(guard, 200), false)
-  assert.equal(tap(guard, 300), true)
-})
-
-test("a touchend with no touchstart is ignored", () => {
-  const guard = createTapGuard()
-  assert.equal(guard.end({ x: 1, y: 1 }, 0), false)
-})
-
-// ── the listener ─────────────────────────────────────────────────────────────
+// ── the pinch guard ──────────────────────────────────────────────────────────
 
 type Registration = { type: string; listener: Listener; options: unknown }
 
@@ -143,78 +141,31 @@ function targetHarness() {
   return { target, registered, removed, fire }
 }
 
-function touch(x: number, y: number, at: number, fingers = 1) {
-  let prevented = 0
-  const event: TouchEventLike = {
-    touches: { length: fingers },
-    changedTouches: { length: 1, 0: { clientX: x, clientY: y } },
-    timeStamp: at,
-    preventDefault: () => {
-      prevented += 1
-    },
-  }
-  return { event, prevented: () => prevented }
-}
+const GESTURES = ["gesturestart", "gesturechange", "gestureend"]
 
-test("touchend is registered non-passive, which is the whole fix", () => {
+test("the gesture listeners are registered non-passive, which is the whole point", () => {
   // A passive listener's preventDefault() is ignored and logs nothing. iOS
   // treats window touch listeners as passive unless told otherwise, so
   // `{ passive: false }` is the difference between this working and this being
   // decoration.
   const { target, registered } = targetHarness()
-  installZoomGuard(target)
+  installPinchGuard(target)
 
-  const end = registered.find((entry) => entry.type === "touchend")
-  assert.ok(end, "touchend must be registered")
-  assert.deepEqual(end.options, { passive: false })
-
-  for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
-    const entry = registered.find((r) => r.type === type)
-    assert.ok(entry, `${type} must be registered`)
-    assert.deepEqual(entry.options, { passive: false })
+  assert.deepEqual(
+    registered.map((entry) => entry.type).sort(),
+    [...GESTURES].sort(),
+    "exactly the three WebKit gesture events, and nothing else",
+  )
+  for (const entry of registered) {
+    assert.deepEqual(entry.options, { passive: false }, `${entry.type} must be non-passive`)
   }
 })
 
-test("the guard prevents the second tap and nothing else", () => {
+test("every gesture event is prevented", () => {
   const { target, fire } = targetHarness()
-  installZoomGuard(target)
+  installPinchGuard(target)
 
-  const first = touch(50, 50, 0)
-  fire("touchstart", first.event)
-  fire("touchend", touch(50, 50, 20).event)
-  assert.equal(first.prevented(), 0)
-
-  fire("touchstart", touch(50, 50, 100).event)
-  const second = touch(50, 50, 120)
-  fire("touchend", second.event)
-  assert.equal(second.prevented(), 1)
-})
-
-test("a lone tap on the catalogue is left alone", () => {
-  const { target, fire } = targetHarness()
-  installZoomGuard(target)
-
-  fire("touchstart", touch(50, 50, 0).event)
-  const end = touch(50, 50, 20)
-  fire("touchend", end.event)
-  assert.equal(end.prevented(), 0)
-})
-
-test("a scroll of the catalogue is left alone", () => {
-  const { target, fire } = targetHarness()
-  installZoomGuard(target)
-
-  fire("touchstart", touch(50, 500, 0).event)
-  const end = touch(50, 80, 300)
-  fire("touchend", end.event)
-  assert.equal(end.prevented(), 0)
-})
-
-test("the WebKit gesture events are all prevented", () => {
-  const { target, fire } = targetHarness()
-  installZoomGuard(target)
-
-  for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+  for (const type of GESTURES) {
     let prevented = 0
     fire(type, {
       preventDefault: () => {
@@ -227,7 +178,7 @@ test("the WebKit gesture events are all prevented", () => {
 
 test("disposing removes every listener it added, once", () => {
   const { target, registered, removed } = targetHarness()
-  const dispose = installZoomGuard(target)
+  const dispose = installPinchGuard(target)
   dispose()
   dispose()
 
@@ -240,49 +191,9 @@ test("disposing removes every listener it added, once", () => {
   }
 })
 
-// ── the scroll lock ──────────────────────────────────────────────────────────
-
-function docHarness(scrollY = 0) {
-  const classes = new Set<string>()
-  const scrolls: number[] = []
-  const doc = {
-    documentElement: {
-      classList: {
-        add: (token: string) => classes.add(token),
-        remove: (token: string) => classes.delete(token),
-      },
-    },
-  }
-  const win = { scrollY, scrollTo: (_x: number, y: number) => scrolls.push(y) }
-  return { doc, win, classes, scrolls }
-}
-
-test("staging locks the document and releasing gives the scroll back where it was", () => {
-  const { doc, win, classes, scrolls } = docHarness(742)
-
-  const release = stageDocument(doc, win)
-  assert.ok(classes.has(STAGED_CLASS), "the document must be locked while a pack is up")
-
-  release()
-  assert.equal(classes.has(STAGED_CLASS), false, "the lock must not outlive the pack")
-  // `overflow: hidden` clamps the offset to zero, so a child who scrolled to
-  // the bottom of the catalogue and played a game would come back to the top.
-  assert.deepEqual(scrolls, [742])
-})
-
-test("releasing twice restores the scroll once", () => {
-  // React StrictMode runs an effect's cleanup twice on the first mount.
-  const { doc, win, scrolls } = docHarness(120)
-  const release = stageDocument(doc, win)
-  release()
-  release()
-  assert.deepEqual(scrolls, [120])
-})
-
 // ── the scale watchdog ───────────────────────────────────────────────────────
 
-test("resetting the scale ends on the canonical viewport, via a different string", () => {
-  // Writing the same string back is a no-op and WebKit never re-evaluates.
+function metaHarness() {
   const written: string[] = []
   const meta = {
     get content() {
@@ -292,20 +203,23 @@ test("resetting the scale ends on the canonical viewport, via a different string
       written.push(value)
     },
   }
+  return { meta, written }
+}
+
+test("resetting the scale ends on the canonical viewport, via a different string", () => {
+  // Writing the same string back is a no-op and WebKit never re-evaluates.
+  const { meta, written } = metaHarness()
   resetViewportScale(meta)
   assert.equal(written.length, 2)
   assert.notEqual(written[0], written[1])
   assert.equal(written[1], VIEWPORT_CONTENT)
+  // The intermediate value must be the STRICTER of the two: a frame painted
+  // while it is live must not be scalable in either direction.
+  assert.match(written[0] ?? "", /minimum-scale=1/)
 })
 
 test("the watchdog fires only when the page has actually scaled", () => {
-  const written: string[] = []
-  const meta = { content: "" }
-  Object.defineProperty(meta, "content", {
-    get: () => written[written.length - 1] ?? "",
-    set: (value: string) => written.push(value),
-  })
-
+  const { meta, written } = metaHarness()
   const subscription: { fn: (() => void) | null } = { fn: null }
   const viewport = {
     scale: 1,
@@ -333,7 +247,30 @@ test("the watchdog fires only when the page has actually scaled", () => {
   assert.equal(subscription.fn, null)
 })
 
-// ── the strings this module duplicates ───────────────────────────────────────
+test("a missing viewport meta is loud, not silent", () => {
+  // House rule: every catch is visible. Without the meta this whole module is
+  // inert and nothing else in the app would say so.
+  const said: unknown[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args[0])
+  try {
+    const dispose = watchScale(
+      {
+        scale: 3,
+        addEventListener: () => assert.fail("must not subscribe with nothing to write back"),
+        removeEventListener: () => {},
+      },
+      null,
+    )
+    dispose()
+  } finally {
+    console.error = real
+  }
+  assert.equal(said.length, 1)
+  assert.match(String(said[0]), /viewport meta/)
+})
+
+// ── the files this module duplicates strings from ────────────────────────────
 
 test("index.html still carries the viewport this module writes back", () => {
   // `resetViewportScale` restores VIEWPORT_CONTENT verbatim. If the meta in
@@ -346,38 +283,78 @@ test("index.html still carries the viewport this module writes back", () => {
   assert.equal(match[1] ?? "", VIEWPORT_CONTENT)
 })
 
-test("the stylesheet is cut for the class the stage actually sets", () => {
+/**
+ * Every innermost rule in a stylesheet, comments stripped.
+ *
+ * `[^{}]*` cannot cross a brace, so each match runs from just after the
+ * previous `}` (or `{`, inside `@layer`) to the next `}` with no nesting in
+ * between — which is exactly the set of real declaration blocks. An earlier
+ * version of this anchored on `(^|\})` and consumed the closing brace, so it
+ * returned every OTHER rule and its coverage flipped with the parity of
+ * anything added above. The sanity assertions below exist so that failure mode
+ * cannot come back quietly.
+ */
+function rulesOf(css: string): { selector: string; body: string }[] {
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, "")
+  return [...clean.matchAll(/([^{}]*)\{([^{}]*)\}/g)].map((match) => ({
+    selector: (match[1] ?? "").trim(),
+    body: match[2] ?? "",
+  }))
+}
+
+test("the stylesheet is cut for the class the lock actually sets", () => {
   const indexCss = fs.readFileSync(path.join(srcRoot, "index.css"), "utf8")
-  assert.match(indexCss, new RegExp(`html\\.${STAGED_CLASS}\\s*,`))
-  assert.match(indexCss, new RegExp(`html\\.${STAGED_CLASS} body\\s*\\{\\s*overflow: hidden;`))
+  const rules = rulesOf(indexCss)
+
+  const lock = rules.find((rule) => rule.selector.includes(`html.${LOCKED_CLASS}`))
+  assert.ok(lock, `index.css must carry a rule for .${LOCKED_CLASS}`)
+  assert.match(lock.body, /overflow:\s*hidden/)
+  // Both, not just html: body is the taller box and is what actually scrolls.
+  assert.match(lock.selector, new RegExp(`html\\.${LOCKED_CLASS} body`))
 })
 
-test("the document lock is scoped to the stage and never applied to html outright", () => {
+test("the document lock is scoped to the class and never applied to html outright", () => {
   // An earlier attempt at this put the lock on `body` unconditionally and
   // stopped the catalogue scrolling entirely. `overflow-x: hidden` on html/body
   // is deliberate and stays; a bare `overflow` on either is the regression.
   const indexCss = fs.readFileSync(path.join(srcRoot, "index.css"), "utf8")
-  const rules = indexCss.matchAll(/(^|\})([^{}]*)\{([^{}]*)\}/g)
+  const rules = rulesOf(indexCss)
+
+  // The walker must actually be seeing the rules it is being asked about. A
+  // parser that silently returns half the file is a test that reports green on
+  // the very edit it exists to stop.
+  assert.ok(
+    rules.some((rule) => rule.selector === "body"),
+    "the walker must find the base `body` rule",
+  )
+  assert.ok(
+    rules.some((rule) => /overflow-x:\s*hidden/.test(rule.body)),
+    "the walker must find the `html, body { overflow-x }` rule",
+  )
+
+  const bare = /(^|,)\s*(html|body)\s*(,|$)/m
   for (const rule of rules) {
-    const selector = (rule[2] ?? "").replace(/\/\*[\s\S]*?\*\//g, "").trim()
-    const body = rule[3] ?? ""
-    if (!/(^|,)\s*(html|body)\s*(,|$)/m.test(selector)) continue
+    if (!bare.test(rule.selector)) continue
     assert.doesNotMatch(
-      body,
+      rule.body,
       /(^|;)\s*overflow\s*:/,
-      `an unscoped \`overflow\` on \`${selector}\` freezes the catalogue`,
+      `an unscoped \`overflow\` on \`${rule.selector}\` freezes the catalogue`,
     )
   }
 })
 
-test("the stage is what turns the lock on", () => {
+test("the stage is what takes the lock", () => {
   // A source assertion, and a weak one — it proves the call is written, not
   // that React runs it. It is here because the whole fix is inert if the wiring
   // is deleted, and there is no DOM in this test runner to render Stage.tsx in.
   const stage = fs.readFileSync(path.join(srcRoot, "packs/Stage.tsx"), "utf8")
   assert.ok(
-    stage.includes("stageDocument(document, window)"),
-    "Stage.tsx must call stageDocument(document, window) while a pack is mounted",
+    stage.includes("documentLock.acquire(document, window)"),
+    "Stage.tsx must take the document lock while a pack is mounted",
+  )
+  assert.ok(
+    /useLayoutEffect\(\(\) => \{[^}]*documentLock\.acquire/s.test(stage),
+    "the lock must be taken in the layout phase, or the scroll restore lands a frame late",
   )
   const main = fs.readFileSync(path.join(srcRoot, "main.tsx"), "utf8")
   assert.ok(

--- a/dynawalla/dynawalla-app/src/app/zoom.ts
+++ b/dynawalla/dynawalla-app/src/app/zoom.ts
@@ -9,38 +9,55 @@
 //   1. Page scale is a property of the TOP-LEVEL page. A pack runs in a
 //      sandboxed, opaque-origin iframe, but an iframe has no viewport and no
 //      scale of its own; the gesture recogniser lives on the WKWebView. So a
-//      double tap on a game canvas scales the host document.
+//      double tap on a game canvas scales the HOST document.
 //   2. On iOS a `position: fixed` element is laid out against the LAYOUT
 //      viewport, and WebKit does not reposition it continuously while a pan is
 //      in flight. The stage is `fixed inset-0`. The ONLY way anything behind it
 //      can come into view is for the document to be taller than the layout
 //      viewport and to scroll. A catalogue of game cards always is.
 //
-// Fact 2 is the one this app fully owns, and it is a necessary condition: take
-// the document's scroll away while a game is up and there is nothing behind the
-// stage to pan to, whether or not the scale changed. That is `stageDocument`.
+// Fact 2 is the one this app owns outright, and it is a necessary condition:
+// take the document's scroll away while a game is up and there is nothing
+// behind the stage to pan to, whether or not the scale changed. That is the
+// document lock, and it is the fix.
 //
 // ── What this file cannot do ─────────────────────────────────────────────────
-// The tap guard below sees `touchstart`/`touchend` on the HOST document only.
 // Touch events raised inside a cross-origin iframe are dispatched in the child
 // realm and never cross the boundary — `window.parent` is not even readable
-// from there. So the guard covers the exit chevron, the day-pass sheet and the
-// catalogue, and it does NOT cover a tap that lands on a game. Preventing that
-// one at source belongs to the pack document, which means the pack SDK, not
-// here. `resetViewportScale` is the only lever in this file that reaches across
-// the boundary at all, and it is a recovery rather than a prevention: it undoes
-// a scale change after the fact instead of stopping the gesture.
+// from there. So nothing here can see, let alone prevent, the tap that starts
+// this. Preventing it at source belongs to the pack document, which means the
+// pack SDK. `resetViewportScale` is the only lever in this file that reaches
+// across the boundary at all, and it is a recovery rather than a prevention: it
+// undoes a scale change after the fact instead of stopping the gesture.
+//
+// A `touchend` double-tap guard on the host window was written, tested and then
+// deleted. It could only ever cover host chrome — the exit chevron, the sheets,
+// the catalogue — where `touch-action: manipulation` on `body` already disables
+// double-tap zoom per spec, and where `preventDefault()` on the second
+// `touchend` also cancels the compatibility `click`. That is a parent tapping
+// "Erase everything" twice in place, as that control is designed to be used,
+// and the second press doing nothing. A guard whose only reachable surface is
+// the one where it costs an activation is not worth its own code.
 //
 // ── Why the viewport meta is not enough on its own ───────────────────────────
 // `user-scalable=no, maximum-scale=1` is respected by WKWebView by default
 // (unlike Safari, which has ignored it since iOS 10 —
 // `WKWebViewConfiguration.ignoresViewportScaleLimits` is false unless someone
 // sets it, and wry does not). It is kept, it is the first line, and it is
-// asserted against `index.html` by the tests. It has been reported not to hold
-// on a real iPhone, which is why none of what follows depends on it.
+// pinned to `index.html` by a test. It has been reported not to hold on a real
+// iPhone, which is why nothing here depends on it.
 
-/** On `<html>` for exactly as long as a pack is on the stage. */
-export const STAGED_CLASS = "dw-staged"
+/**
+ * On `<html>` for as long as anything is covering the page.
+ *
+ * The class already existed, cut for the sheets, which want the same thing for
+ * the same reason: a scrim is `position: fixed`, so a drag on it scrolls
+ * whatever is behind it. The stage is the only caller today — the sheets have
+ * yet to be wired to `documentLock` — but there is one class and one rule, and
+ * the lock counts its holders so that when they are, a sheet closing over a
+ * running game does not unlock the page under it.
+ */
+export const LOCKED_CLASS = "dw-locked"
 
 /**
  * The canonical viewport, duplicated from `index.html` because a string in a
@@ -50,99 +67,66 @@ export const STAGED_CLASS = "dw-staged"
 export const VIEWPORT_CONTENT =
   "width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
 
-/** The window WebKit joins two taps into one gesture in. */
-export const DOUBLE_TAP_MS = 350
+// ── the document lock ────────────────────────────────────────────────────────
 
-/**
- * How far a finger may travel and still have been a tap.
- *
- * Generous on purpose: this is a seven-year-old's finger on a game, not a
- * mouse. Too small and a slightly smeared double tap is not caught; too large
- * and a short flick of the catalogue is mistaken for one, which is why the
- * guard also checks the distance the finger travelled WITHIN each tap and
- * treats anything that moved as a drag rather than as a tap.
- */
-export const TAP_SLOP_PX = 30
+export type ClassList = { add(token: string): void; remove(token: string): void }
+export type LockDocument = { readonly documentElement: { readonly classList: ClassList } }
+export type LockWindow = { readonly scrollY: number; scrollTo(x: number, y: number): void }
 
-export type Point = { readonly x: number; readonly y: number }
-
-function far(a: Point, b: Point): boolean {
-  return Math.hypot(a.x - b.x, a.y - b.y) > TAP_SLOP_PX
-}
-
-export type TapGuard = {
-  /** `touchstart`. `fingers` is `event.touches.length`. */
-  start(fingers: number, point: Point, at: number): void
-  /** `touchend`. True when this is the second tap of a double tap. */
-  end(point: Point, at: number): boolean
+export type DocumentLock = {
+  /** Take the lock. Returns the release, which is idempotent. */
+  acquire(doc: LockDocument, win: LockWindow): () => void
+  /** Test seam: how many holders there are right now. */
+  holders(): number
 }
 
 /**
- * The classic double-tap guard, as a pure state machine.
+ * Take the host document's scroll away while something is covering it, and give
+ * it back — at the same offset — when the last holder lets go.
  *
- * A tap is one finger that went down and came up in the same place. A double
- * tap is two of those, close together in time and in space. Everything else —
- * a scroll, a flick, a two-finger anything, a long press that drifted — is not
- * a tap and clears the pair, because the alternative is a guard that swallows
- * the tap at the end of a scroll.
+ * Counted, not a boolean: the stage and a sheet can both be up, and a sheet
+ * closing must not hand the scroll back to a game that is still running. The
+ * offset restored is the one captured when the FIRST holder took the lock,
+ * because that is the last moment the page was really scrolled.
+ *
+ * Restoring it is not a nicety: `overflow: hidden` clamps the offset to zero, so
+ * without this a child who scrolled to the bottom of the catalogue, played a
+ * game and came back would be at the top.
  */
-export function createTapGuard(): TapGuard {
-  let down: { point: Point; at: number } | null = null
-  let multi = false
-  let previous: { point: Point; at: number } | null = null
+export function createDocumentLock(): DocumentLock {
+  let held = 0
+  let restore: { win: LockWindow; offset: number } | null = null
+  let root: LockDocument | null = null
 
   return {
-    start(fingers, point, at) {
-      if (fingers > 1) {
-        // A pinch is not two taps, and neither half of it may be counted.
-        multi = true
-        down = null
-        previous = null
-        return
+    holders: () => held,
+    acquire(doc, win) {
+      if (held === 0) {
+        root = doc
+        restore = { win, offset: win.scrollY }
+        doc.documentElement.classList.add(LOCKED_CLASS)
       }
-      multi = false
-      down = { point, at }
-    },
+      held += 1
 
-    end(point, at) {
-      const from = down
-      down = null
-      if (multi || from === null) {
-        previous = null
-        return false
+      let released = false
+      return () => {
+        if (released) return
+        released = true
+        held -= 1
+        if (held > 0) return
+        root?.documentElement.classList.remove(LOCKED_CLASS)
+        restore?.win.scrollTo(0, restore.offset)
+        root = null
+        restore = null
       }
-      // It moved: a scroll, a swipe, a joystick. Not a tap, and it ends any
-      // pair in progress so the finger lifting is never the second of one.
-      if (far(from.point, point)) {
-        previous = null
-        return false
-      }
-
-      const first = previous
-      if (first !== null && at - first.at <= DOUBLE_TAP_MS && !far(first.point, point)) {
-        // The pair is spent. A third tap opens a new one rather than pairing
-        // with the second, which is what makes a child drumming on a button
-        // cost one suppressed click per two taps and not every tap after the
-        // first.
-        previous = null
-        return true
-      }
-
-      previous = { point, at }
-      return false
     },
   }
 }
 
-type TouchPoint = { readonly clientX: number; readonly clientY: number }
+/** The one lock the app actually uses. */
+export const documentLock = createDocumentLock()
 
-/** The parts of a `TouchEvent` this file uses. Narrow so it can be faked. */
-export type TouchEventLike = {
-  readonly touches: { readonly length: number }
-  readonly changedTouches: { readonly length: number; readonly [index: number]: TouchPoint }
-  readonly timeStamp: number
-  preventDefault(): void
-}
+// ── the pinch guard ──────────────────────────────────────────────────────────
 
 export type Listener = (event: never) => void
 
@@ -152,57 +136,34 @@ export type GuardTarget = {
 }
 
 /**
- * Register the guard on the host document. Returns a disposer.
+ * Refuse WebKit's pinch on the host document. Returns a disposer.
  *
- * `touchend` MUST be registered non-passive: a passive listener's
- * `preventDefault()` is ignored, and iOS defaults touch listeners on the window
- * to passive. That single option is the whole difference between this working
- * and this being decoration, so there is a test for it.
+ * `gesturestart`/`gesturechange`/`gestureend` are WebKit's own, non-standard,
+ * and TWO-FINGER: they are pinch, and they are NOT double tap. They are here
+ * because the invariant is "the host page never scales", not because they cover
+ * the bug this file is named for — nobody should read them as doing that. Like
+ * everything else here they stop at the iframe boundary.
  *
- * `gesturestart`/`gesturechange`/`gestureend` are WebKit's own, non-standard
- * and two-finger only: they are pinch, NOT double tap. They are here because
- * the invariant is "the host page never scales", not "the host page never
- * double-tap-zooms" — but nobody should expect them to fire for a double tap.
+ * Registered non-passive, because a passive listener's `preventDefault()` is
+ * ignored and reports nothing. That option is the whole difference between this
+ * working and this being decoration, so there is a test for it.
  */
-export function installZoomGuard(
-  target: GuardTarget,
-  guard: TapGuard = createTapGuard(),
-): () => void {
-  const onStart = (event: TouchEventLike) => {
-    const touch = event.changedTouches[0]
-    if (!touch) return
-    guard.start(event.touches.length, { x: touch.clientX, y: touch.clientY }, event.timeStamp)
-  }
-
-  const onEnd = (event: TouchEventLike) => {
-    const touch = event.changedTouches[0]
-    if (!touch) return
-    if (guard.end({ x: touch.clientX, y: touch.clientY }, event.timeStamp)) event.preventDefault()
-  }
-
+export function installPinchGuard(target: GuardTarget): () => void {
   const onGesture = (event: { preventDefault(): void }) => event.preventDefault()
+  const types = ["gesturestart", "gesturechange", "gestureend"]
+  const options = { passive: false }
 
-  const registered: [string, Listener, unknown][] = [
-    ["touchstart", onStart as Listener, { passive: true }],
-    ["touchend", onEnd as Listener, { passive: false }],
-    ["gesturestart", onGesture as Listener, { passive: false }],
-    ["gesturechange", onGesture as Listener, { passive: false }],
-    ["gestureend", onGesture as Listener, { passive: false }],
-  ]
-
-  for (const [type, listener, options] of registered) {
-    target.addEventListener(type, listener, options)
-  }
+  for (const type of types) target.addEventListener(type, onGesture as Listener, options)
 
   let disposed = false
   return () => {
     if (disposed) return
     disposed = true
-    for (const [type, listener, options] of registered) {
-      target.removeEventListener(type, listener, options)
-    }
+    for (const type of types) target.removeEventListener(type, onGesture as Listener, options)
   }
 }
+
+// ── the scale watchdog ───────────────────────────────────────────────────────
 
 /**
  * Put the page back to scale 1.
@@ -210,9 +171,9 @@ export function installZoomGuard(
  * There is no API for this. Rewriting the viewport meta makes WebKit
  * re-evaluate it and clamp the current scale to the limits it finds, and
  * writing the SAME string is a no-op — so it goes out via a value that differs
- * textually while describing exactly the same viewport, then back to the
- * canonical one. Both strings pin minimum = initial = maximum = 1, so there is
- * no intermediate viewport a frame could be painted at.
+ * textually first. The intermediate string is the STRICTER of the two: it adds
+ * `minimum-scale=1`, so for the frame it is live the page cannot be scaled in
+ * either direction, and the canonical string is then restored verbatim.
  *
  * UNVERIFIED on a device. This is the only thing in this file that can undo a
  * zoom which began inside a pack's iframe, and it is a recovery: the scale
@@ -235,15 +196,21 @@ const SCALE_TOLERANCE = 0.01
 /**
  * Watch the visual viewport and undo any scale the page acquires.
  *
- * `visualViewport` is a property of the top-level page, so this sees a zoom
- * that a pack's iframe caused even though it never sees the touch that caused
- * it. Returns a disposer.
+ * `visualViewport` is a property of the top-level page, so this sees a zoom a
+ * pack's iframe caused even though it never sees the touch that caused it.
+ * Returns a disposer.
  */
 export function watchScale(
   viewport: VisualViewportLike,
   meta: { content: string } | null,
 ): () => void {
-  if (!meta) return () => {}
+  if (!meta) {
+    // The viewport meta is what stops the page scaling in the first place, and
+    // without it there is nothing to write back either. Loud, because the whole
+    // of this file is then inert and nothing else would say so.
+    console.error("[zoom] no viewport meta: the page can scale and nothing can undo it")
+    return () => {}
+  }
   const onResize = () => {
     if (Math.abs(viewport.scale - 1) > SCALE_TOLERANCE) resetViewportScale(meta)
   }
@@ -251,43 +218,11 @@ export function watchScale(
   return () => viewport.removeEventListener("resize", onResize)
 }
 
-export type ClassList = { add(token: string): void; remove(token: string): void }
-export type StageDocument = { readonly documentElement: { readonly classList: ClassList } }
-export type StageWindow = { readonly scrollY: number; scrollTo(x: number, y: number): void }
-
-/**
- * Take the host document's scroll away for as long as a pack is on the stage,
- * and give it back — at the same offset — when the pack leaves.
- *
- * This is the fix, not a hardening of it: with nothing to scroll, a scaled and
- * panned page has nowhere to pan to, so the catalogue behind the stage cannot
- * come into view even if the zoom itself happens.
- *
- * Scoped to a class that only exists while a game is running. `overflow:
- * hidden` on `html` unconditionally froze the catalogue once already; this is
- * why it is a class and not a rule.
- *
- * Restoring `scrollY` is not a nicety: `overflow: hidden` clamps the offset to
- * zero, so without this a child who scrolled to the bottom of the catalogue,
- * played a game and came back would be at the top.
- */
-export function stageDocument(doc: StageDocument, win: StageWindow): () => void {
-  const offset = win.scrollY
-  doc.documentElement.classList.add(STAGED_CLASS)
-  let released = false
-  return () => {
-    if (released) return
-    released = true
-    doc.documentElement.classList.remove(STAGED_CLASS)
-    win.scrollTo(0, offset)
-  }
-}
-
 // Applied at module load, like the theme: the host page must never scale, and
-// there is no screen on which that is not true. Nothing here touches the pack
-// iframe — see the note at the top of the file.
+// there is no screen on which that is not true. Nothing here reaches into the
+// pack iframe — see the note at the top of the file.
 if (typeof window !== "undefined" && typeof document !== "undefined") {
-  installZoomGuard(window as unknown as GuardTarget)
+  installPinchGuard(window as unknown as GuardTarget)
   const viewport = (window as unknown as { visualViewport?: VisualViewportLike }).visualViewport
   if (viewport) watchScale(viewport, document.querySelector<HTMLMetaElement>('meta[name="viewport"]'))
 }

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -20,9 +20,11 @@
     /* Keeps the WebView's own chrome — overscroll glow, form controls,
        scrollbars — in the theme the app is actually painting. */
     color-scheme: light;
-    /* On iOS the rubber-band belongs to the scrolling VIEWPORT, not to body.
-       Set on body alone the document still bounces, which is how the catalog
-       slides into view above a running game. */
+    /* On iOS the rubber-band belongs to the scrolling VIEWPORT, not to body;
+       set on body alone the document still bounces at the ends of the
+       catalogue. It is NOT what let the catalogue surface above a running
+       game — that was the document being scrollable at all, which `dw-locked`
+       below now takes away for as long as a pack is up. */
     overscroll-behavior: none;
     /* WebKit inflates text in a narrow column when a page is rotated or
        zoomed. It is a document behaviour and this is not a document; left on,
@@ -105,26 +107,6 @@
     overflow-x: hidden;
   }
 
-  /* While a pack is on the stage the host document has nowhere to go.
-   *
-   * The stage is `position: fixed; inset: 0`, and on iOS a fixed element is
-   * laid out against the LAYOUT viewport and is not repositioned continuously
-   * while a pan is in flight. So the only way the catalogue behind a running
-   * game can come into view is for the document to be TALLER than that
-   * viewport and to scroll — which is exactly what the pan after a double-tap
-   * zoom does, and a grid of game cards is always taller. Take the scroll away
-   * and there is nothing behind the stage to reach, whether or not the scale
-   * changed.
-   *
-   * A class, never a bare `html` rule: the catalogue has to scroll, and
-   * locking the document unconditionally froze it once already. `zoom.ts`
-   * adds this for exactly as long as a pack is mounted and restores the
-   * scroll offset on the way out. */
-  html.dw-staged,
-  html.dw-staged body {
-    overflow: hidden;
-  }
-
   /* A mouse user genuinely needs a scrollbar — but they need the one their
      desktop draws, which is an overlay thumb on nothing, not a painted grey
      channel down the edge of the page. Thumb only, in the theme's own violet,
@@ -193,10 +175,25 @@
     scroll-padding-block: calc(var(--safe-top) + 5.5rem) calc(var(--safe-bottom) + 5.5rem);
   }
 
-  /* While a sheet is up, the page behind it must not scroll. The scrim is
-     `position: fixed`, so a drag on it was still scrolling the catalogue
-     underneath and the sheet closed onto a different offset — the surface
-     you came back to was not the one you left. */
+  /* While anything is covering the page, the page behind it must not scroll.
+   *
+   * One rule, because it is one fact, and it is written for two callers even
+   * though only the stage takes it today. A sheet's scrim is `position:
+   * fixed`, so a drag on it was still scrolling the catalogue underneath and
+   * the sheet closed onto a different offset — the surface you came back to
+   * was not the one you left; that is what this class was cut for, and the
+   * sheets have yet to be wired to `documentLock`. A running pack's stage is
+   * `fixed` too, and on iOS a fixed element is laid out against the LAYOUT
+   * and is not repositioned continuously while a pan is in flight: the only
+   * way the catalogue behind a game can come into view is for the document to
+   * be TALLER than that viewport and to scroll, which is exactly what the pan
+   * after a double-tap zoom does. Take the scroll away and there is nothing
+   * behind the stage to reach, whether or not the scale changed.
+   *
+   * A class, never a bare `html` rule: the catalogue has to scroll, and
+   * locking the document unconditionally froze it once already. `zoom.ts`
+   * counts the holders, adds this while there is at least one, and hands the
+   * scroll offset back when the last one lets go. */
   html.dw-locked,
   html.dw-locked body {
     overflow: hidden;

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -15,14 +15,14 @@
 // navigation that nothing navigates to. What is launched is app state, and
 // leaving it is one action.
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useState } from "react"
 import { create } from "zustand"
 
 import type { Settings } from "../../../packs/sdk/src/index.ts"
 import { BUILD_VERSION, hapticPorts } from "../app/platform.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
-import { stageDocument } from "../app/zoom.ts"
+import { documentLock } from "../app/zoom.ts"
 import { PassSheet } from "../pass/PassSheet.tsx"
 import { usePass } from "../pass/store.ts"
 import { useProfiles } from "../profiles/store.ts"
@@ -272,9 +272,14 @@ export function PackStage() {
   // a pack scales the HOST page — the iframe has no viewport of its own — and
   // the pan that follows is what slides the catalogue into view above the
   // stage. It can only slide if there is something to scroll. See zoom.ts.
-  useEffect(() => {
+  //
+  // `useLayoutEffect`, not `useEffect`: the release restores the scroll offset,
+  // and in the passive phase that lands after the browser has already painted a
+  // frame of the catalogue clamped at zero — a visible jump on the way out of
+  // every game.
+  useLayoutEffect(() => {
     if (packId === null) return
-    return stageDocument(document, window)
+    return documentLock.acquire(document, window)
   }, [packId])
 
   // Escape leaves, on every platform that has a keyboard. A game that takes the


### PR DESCRIPTION
Three findings from the adversarial pass, all real.

THE TAP GUARD IS GONE. `preventDefault()` on the second `touchend` also cancels
the compatibility `click`, and the guard's window is 350ms and 30px with no
requirement that the two taps be on the same element. Its only reachable
surface was host chrome — where `touch-action: manipulation` on `body` already
disables double-tap zoom per spec — and on that surface it broke a parent
tapping "Erase everything" twice in place, which is exactly how that control is
designed to be used; also `addProfile` pressed twice, and a correction between
two cells of a segmented control 20px apart. A guard whose only reachable
surface is the one where it costs an activation is not worth its own code. The
pinch guard stays: gesture events carry no click.

ONE LOCK CLASS, COUNTED. #669 already cut `html.dw-locked { overflow: hidden }`
for the sheets and nothing wires it yet; this added a byte-identical
`dw-staged` beside it. Now there is one class, one rule, and a counted lock, so
that when the sheets are wired a sheet closing over a running game does not
unlock the page under it. The restored offset is the one captured by the FIRST
holder — a second holder arriving while the document is already locked reads
the clamped zero, and using that would throw away the child's place in the
catalogue.

THE CSS REGRESSION GUARD DID NOT GUARD. Its rule walker anchored on `(^|\})`
and so consumed each closing brace, returning every OTHER rule; it never saw
the base `body` block, which is precisely where the frozen-catalogue regression
it names would land. Proven: `overflow: hidden` added to `body` passed green.
Fixed, and it now asserts that the walker actually found the two rules it is
being asked about, so a parser that silently returns half the file fails
instead of reporting green.

Also: the lock is taken in `useLayoutEffect`, not `useEffect` — the release
restores the scroll offset, and in the passive phase that lands after a painted
frame of the catalogue clamped at zero. A missing viewport meta is now logged
rather than swallowed. The `minimum-scale` comment was backwards about which of
the two writes is the strict one. And `index.html` and `index.css` no longer
carry two older, competing explanations of the same bug.

Twenty mutations this round, every one caught — including the three the review
proved the old CSS test slept through, and one that breaks the walker itself.

Follow-up to #677, which merged before this self-review landed.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb