### PR TITLE
fix(dynawalla/games/pulse): a 15px answer behind a bloom halo is not an answer

### DIFF
--- a/dynawalla/games/pulse/src/audio/clock.ts
+++ b/dynawalla/games/pulse/src/audio/clock.ts
@@ -1,0 +1,132 @@
+/**
+ * One clock, and it is the audio one.
+ *
+ * **The bug this exists for.** "On chromebook the timing seems to be a little
+ * bit off for the music and the visual. It must be 100% in sync to work."
+ *
+ * `AudioContext.currentTime` is not a continuous reading of the audio hardware.
+ * It is the timestamp of the last render block the audio thread finished and
+ * published to the main thread, so it advances in STEPS the size of the output
+ * callback and holds still in between — 128 frames (2.7 ms) where the browser
+ * can manage it, and 480 or 960 frames (10–20 ms) on a device whose audio stack
+ * cannot, which describes a Chromebook exactly. Read it at an arbitrary moment
+ * and the answer is uniformly 0..q too small.
+ *
+ * The old code read it raw, twice, for two different purposes:
+ *
+ *   - the picture, once per frame, off `now() - outputLatency`
+ *   - the judgment, at every tap, off `now() - performance.now()`
+ *
+ * Each read carried its own independent 0..q error, so the same tap could be
+ * judged up to a full callback early, at random, and the amount depended
+ * entirely on how big that device's audio callback happened to be. On a machine
+ * with a 20 ms callback that is a third of the ±55 ms PERFECT window, spent on
+ * nothing, and it is invisible on a Mac and obvious on a Chromebook. That is not
+ * "two clocks drifting" in the textbook sense — it is worse, because a drift is
+ * at least consistent.
+ *
+ * **The fix.** Keep ONE model of the transport: `audioTime = perfTime + offset`.
+ * `performance.now()` supplies resolution and smoothness; the audio clock
+ * supplies truth and is the only thing `offset` is ever derived from — it stays
+ * the master, and nothing here can make the transport run at a rate the audio
+ * hardware is not running at.
+ *
+ * `offset` is estimated as the running MAXIMUM of `currentTime - perfNow`,
+ * which is the trick that recovers what the quantisation threw away: because
+ * `currentTime` is only ever rounded DOWN, the largest sample in a short window
+ * is the one taken closest to a block boundary, and it is the least wrong. It is
+ * then allowed to fall back slowly, so a genuine difference in rate between the
+ * two clocks (crystal drift, a resampled output device) is tracked rather than
+ * latched, and it re-anchors outright when the two disagree by more than a
+ * pause's worth — which is exactly what a suspended context looks like.
+ */
+
+/**
+ * How fast `offset` may fall, in seconds per second.
+ *
+ * Real drift between an audio clock and `performance.now()` is on the order of
+ * 100 ppm — two crystals, both good. 500 ppm tracks that five times over, and
+ * it is also what sets the residual error between two lucky samples: at 500 ppm
+ * the model gives away half a millisecond a second, so a boundary-aligned
+ * sample every couple of seconds is enough to hold it under a millisecond.
+ * Faster and the residual grows; slower and a genuine rate difference takes
+ * minutes to track out.
+ */
+const DRIFT_PER_SEC = 0.0005;
+
+/**
+ * Disagreement above which the model is wrong rather than stale, and is thrown
+ * away and rebuilt from the current reading.
+ *
+ * A suspended `AudioContext` freezes `currentTime` while `performance.now()`
+ * keeps running, so every pause produces exactly this and it must snap back the
+ * instant the context resumes rather than bleed off at the drift rate.
+ */
+const RESYNC_SEC = 0.2;
+
+export type ClockSources = {
+  /** The master. `AudioContext.currentTime`, in seconds. */
+  audio: () => number;
+  /** The interpolator. `performance.now() / 1000`. */
+  perf: () => number;
+};
+
+export class TransportClock {
+  private readonly src: ClockSources;
+  private offset: number | null = null;
+  private lastPerf = 0;
+  /** Widest gap seen between a raw reading and the model, for the perf overlay. */
+  private worstRawError = 0;
+
+  constructor(src: ClockSources) {
+    this.src = src;
+  }
+
+  /**
+   * Re-anchor on the master and return the current offset. Cheap, and called
+   * from every read, so there is no "remember to pump it once a frame" rule to
+   * get wrong.
+   */
+  private sync(): number {
+    const p = this.src.perf();
+    const raw = this.src.audio() - p;
+    const prev = this.offset;
+    if (prev === null || raw > prev || prev - raw > RESYNC_SEC) {
+      this.offset = raw;
+    } else {
+      const dt = Math.max(0, p - this.lastPerf);
+      this.offset = Math.max(raw, prev - DRIFT_PER_SEC * dt);
+      const err = this.offset - raw;
+      if (err > this.worstRawError) this.worstRawError = err;
+    }
+    this.lastPerf = p;
+    return this.offset;
+  }
+
+  /** Audio-clock time, now, at `performance.now()`'s resolution. */
+  now(): number {
+    return this.src.perf() + this.sync();
+  }
+
+  /**
+   * Audio-clock time of a moment stamped on the `performance.now()` timeline —
+   * a pointer or key event, whose `timeStamp` is exactly that.
+   *
+   * The whole point of routing input through the same model: a tap and the
+   * picture it was aimed at are converted by one function, so they cannot
+   * disagree by a quantisation error that only one of them paid.
+   */
+  timeAtPerf(perfSec: number): number {
+    return perfSec + this.sync();
+  }
+
+  /**
+   * How far the raw `currentTime` reading is currently lagging the model — i.e.
+   * how much error every direct read of `currentTime` would be carrying. Zero
+   * on a device whose audio clock is genuinely continuous; the size of the
+   * output callback on one whose is not.
+   */
+  quantisationError(): number {
+    return this.worstRawError;
+  }
+}

--- a/dynawalla/games/pulse/src/audio/engine.ts
+++ b/dynawalla/games/pulse/src/audio/engine.ts
@@ -19,6 +19,8 @@
  * which is how a real band tells you that you dropped it.
  */
 
+import { TransportClock } from "./clock.ts";
+
 export type Engine = {
   ctx: AudioContext;
   drumBus: GainNode;
@@ -29,8 +31,21 @@ export type Engine = {
   master: GainNode;
   analyser: AnalyserNode;
   noise: AudioBuffer;
-  /** Current audio-clock time, in seconds. */
+  /**
+   * Current audio-clock time, in seconds — smoothed. See `audio/clock.ts`: the
+   * raw `currentTime` advances in output-callback steps and is 0..q too small
+   * at any moment you happen to read it.
+   */
   now(): number;
+  /**
+   * Audio-clock time of a moment stamped on the `performance.now()` timeline.
+   * The ONLY supported way to turn an input event into transport time.
+   */
+  timeAtPerf(perfSec: number): number;
+  /** Raw `ctx.currentTime`. Diagnostics only — never schedule or judge off it. */
+  rawNow(): number;
+  /** How much error a raw `currentTime` read is currently carrying, in seconds. */
+  clockError(): number;
   /** Output latency in seconds — how far ahead of the speaker the clock runs. */
   latency(): number;
   wave: Float32Array;
@@ -149,6 +164,13 @@ export function createEngine(): Engine {
   let isMuted = false;
   let prevGain = 0.9;
 
+  // The transport. Everything above this line makes sound; this is the only
+  // thing that says WHEN, and there is deliberately exactly one of it.
+  const clock = new TransportClock({
+    audio: () => ctx.currentTime,
+    perf: () => performance.now() / 1000,
+  });
+
   return {
     ctx,
     drumBus,
@@ -161,7 +183,10 @@ export function createEngine(): Engine {
     noise,
     wave,
     spectrum,
-    now: () => ctx.currentTime,
+    now: () => clock.now(),
+    timeAtPerf: (perfSec) => clock.timeAtPerf(perfSec),
+    rawNow: () => ctx.currentTime,
+    clockError: () => clock.quantisationError(),
     latency: () => {
       const c = ctx as AudioContext & { outputLatency?: number };
       const out = typeof c.outputLatency === "number" && c.outputLatency > 0 ? c.outputLatency : 0;

--- a/dynawalla/games/pulse/src/dev/fakeAudio.ts
+++ b/dynawalla/games/pulse/src/dev/fakeAudio.ts
@@ -100,8 +100,45 @@ class FakeBuffer {
 }
 
 export class FakeAudioContext {
-  /** The one clock. Tests move it; the game only ever reads it. */
-  currentTime = 0
+  /**
+   * The TRUE audio position — what the hardware is actually playing. Tests move
+   * this; the game can never see it, exactly like on a device.
+   */
+  private trueTime = 0
+
+  /**
+   * Size of the output callback, in seconds. `currentTime` advances in steps of
+   * it and holds still in between, which is what a real `AudioContext` does:
+   * the value published to the main thread is the timestamp of the last render
+   * block the audio thread finished.
+   *
+   * 0 means "a perfect, continuous clock", which is what the older tests want
+   * and what no real device has. 0.02 is a Chromebook-shaped 960-frame callback
+   * at 48 kHz; 0.00267 is the 128-frame quantum a healthy desktop manages.
+   */
+  quantumSec = 0
+
+  /** What the GAME sees. Rounded down to the last completed block, always. */
+  get currentTime(): number {
+    if (this.quantumSec <= 0) return this.trueTime
+    return Math.floor(this.trueTime / this.quantumSec + 1e-9) * this.quantumSec
+  }
+
+  /** Assignment sets the true position — `ctx.currentTime += dt` still works. */
+  set currentTime(v: number) {
+    this.trueTime = v
+  }
+
+  /** The true position, for a test to assert against. Never visible to the game. */
+  get truthTime(): number {
+    return this.trueTime
+  }
+
+  /** Move the true position forward without a read-modify-write of a rounded value. */
+  advance(seconds: number): void {
+    this.trueTime += seconds
+  }
+
   readonly sampleRate = 48000
   state: "running" | "suspended" | "closed" = "running"
   readonly baseLatency = 0.008
@@ -147,6 +184,32 @@ export class FakeAudioContext {
   close(): Promise<void> {
     this.state = "closed"
     return Promise.resolve()
+  }
+}
+
+/**
+ * A hand-driven `performance.now()`.
+ *
+ * The transport is a model of `audioTime = perfTime + offset` (see
+ * `audio/clock.ts`), so a test that moves the audio clock and leaves
+ * `performance.now()` running at real wall-clock speed is testing two
+ * unrelated timelines. Both have to be driven together, which means owning
+ * this one too.
+ *
+ * Returns a handle; the global is replaced for the rest of the process, so this
+ * belongs in a test file that does nothing else.
+ */
+export function installFakeNow(): { set(ms: number): void; advance(ms: number): void } {
+  let ms = 0
+  const g = globalThis as unknown as { performance: { now(): number } }
+  g.performance = { now: () => ms }
+  return {
+    set(v) {
+      ms = v
+    },
+    advance(v) {
+      ms += v
+    },
   }
 }
 

--- a/dynawalla/games/pulse/src/game/gate.test.ts
+++ b/dynawalla/games/pulse/src/game/gate.test.ts
@@ -165,3 +165,68 @@ test("the fraction stub host also always gives a real choice", () => {
     assert.equal(g.candidates.filter((c) => c.correct).length, 1, `${g.prompt} correct-count`);
   }
 });
+
+// --------------------------------------------------- the gap, in real pixels
+//
+// The unit tests above are about values. This one is about the screen, because
+// `minGapDenom` is a display constraint and a display constraint asserted in
+// bar-fractions is not asserted at all: the old call site passed the constant
+// 12 at every viewport and every viewport overlapped.
+
+test("no two candidates of a real gate overlap on a real screen", async () => {
+  const { computeLayout, gateFitFor } = await import("../render/layout.ts");
+  const { NO_INSETS, safeRect } = await import(
+    "../../../../packs/shared/game-chrome/index.ts"
+  );
+
+  const viewports: Array<[number, number, string]> = [
+    [320, 568, "320×568"],
+    [390, 844, "390×844"],
+    [412, 915, "412×915"],
+    [768, 1024, "768×1024"],
+    [1024, 768, "1024×768"],
+    [844, 390, "844×390"],
+  ];
+
+  for (const [w, h, name] of viewports) {
+    for (const lanes of [1, 2, 3]) {
+      const l = computeLayout(w, h, lanes, safeRect(w, h, NO_INSETS));
+      const fit = gateFitFor(l);
+      const diameter = l.gateR * 2;
+      const host = createStubHost({ seed: `overlap-${name}-${lanes}` });
+      const r = rng();
+      let worstPx = Infinity;
+      let worstAt = "";
+      let sawFour = 0;
+
+      for (let i = 0; i < 1200; i++) {
+        // Sweep the whole difficulty ramp: the crowded gates live at the top of
+        // it, where the denominators get big.
+        host.setFloor((i % 100) / 100);
+        const g = buildGate(host.next(), r, fit);
+        if (g.candidates.length >= 3) sawFour++;
+        for (let k = 1; k < g.candidates.length; k++) {
+          const px = (g.candidates[k]!.pos - g.candidates[k - 1]!.pos) * l.runLen;
+          if (px < worstPx) {
+            worstPx = px;
+            worstAt = `${g.prompt} → ${g.candidates.map((c) => c.label).join(" ")}`;
+          }
+        }
+        assert.ok(
+          g.candidates.length <= fit.maxCandidates,
+          `${name}: ${g.candidates.length} candidates where ${fit.maxCandidates} fit`,
+        );
+      }
+
+      assert.ok(
+        worstPx >= diameter,
+        `${name}/${lanes} lanes: the closest two candidates were ${worstPx.toFixed(1)} px ` +
+          `apart and are ${diameter.toFixed(1)} px across — overlapping by ` +
+          `${(diameter - worstPx).toFixed(1)} px. [${worstAt}]`,
+      );
+      // Guards the shape of the sweep: a fit so tight that every gate collapsed
+      // to two candidates would pass the line above and mean nothing.
+      assert.ok(sawFour > 0 || fit.maxCandidates === 2, `${name}: swept only pairs`);
+    }
+  }
+});

--- a/dynawalla/games/pulse/src/game/gate.ts
+++ b/dynawalla/games/pulse/src/game/gate.ts
@@ -45,6 +45,13 @@ export type BuiltGate = {
  */
 export type GateFit = { maxCandidates: number; minGapDenom: number };
 
+/**
+ * The fallback for a caller that has no viewport to measure — a unit test, a
+ * tool. NOT what the game plays with: `Run` is handed a fit computed from the
+ * live layout by `render/layout.ts`'s `gateFitFor`, because a twelfth of a bar
+ * is 33 px on a 390 px phone and a candidate is 74 px across, and this constant
+ * arriving unchanged at the only call site is exactly the bug that shipped.
+ */
 export const DEFAULT_FIT: GateFit = { maxCandidates: 4, minGapDenom: 12 };
 
 function farEnough(v: Rat, kept: Rat[], minGap: Rat): boolean {

--- a/dynawalla/games/pulse/src/game/run.test.ts
+++ b/dynawalla/games/pulse/src/game/run.test.ts
@@ -21,7 +21,7 @@ import { installFakeAudio } from "../dev/fakeAudio.ts";
 const audio = installFakeAudio();
 
 // After the fake is installed, so `createEngine()` finds it.
-const { GATE_READ_SEC, Run } = await import("./run.ts");
+const { GATE_READ_SEC, Run, candidatesForStage } = await import("./run.ts");
 const { gatesToClear, stageAt } = await import("./stages.ts");
 
 import type { Host } from "../contract.ts";
@@ -60,6 +60,8 @@ type Rig = {
   readingWindows: number[];
   /** Every `gateResolved` outcome, in order. */
   outcomes: string[];
+  /** How many candidates each gate carried, in order, with its stage. */
+  gateShapes: Array<{ stage: number; candidates: number; wrong: number }>;
   play(seconds: number): void;
   dispose(): void;
 };
@@ -73,6 +75,7 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
   const stages: number[] = [];
   const readingWindows: number[] = [];
   const outcomes: string[] = [];
+  const gateShapes: Array<{ stage: number; candidates: number; wrong: number }> = [];
   let n = 0;
 
   const host: Host = {
@@ -94,6 +97,11 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
     miss() {},
     stray() {},
     gateOpen(built) {
+      gateShapes.push({
+        stage: run.stageIndex,
+        candidates: built.candidates.length,
+        wrong: built.candidates.filter((c) => !c.correct).length,
+      });
       // The window a child gets to read this question: from the moment it is
       // on screen to the moment the right answer crosses the strike line.
       const target = run.notes
@@ -115,6 +123,11 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
   };
 
   const run = new Run({ host, fx, seed: "bots", startStage });
+  // A screen with room to spare, so what these runs measure is the STAGE's
+  // ceiling on how many numbers a child is shown, not the phone's. `Run`
+  // defaults to the smallest phone's answer until a layout tells it otherwise,
+  // and a rig that left it there would be testing that default forever.
+  run.setGateFit({ maxCandidates: 4, minGapDenom: 4 });
   const ctx = audio.latest();
   run.start();
 
@@ -163,6 +176,7 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
     stages,
     readingWindows,
     outcomes,
+    gateShapes,
     play(seconds) {
       const steps = Math.round(seconds / 0.02);
       for (let i = 0; i < steps; i++) step();
@@ -328,4 +342,100 @@ test("every gate served is resolved exactly once, even at the top of the loop", 
     `${seen} gates were served but only ${expired} ever resolved — the rest were ` +
       `overwritten in the slot while still live`,
   );
+});
+
+// --------------------------------------------------------------- the opening
+//
+// "starts too hard too ... it should start easy (and more sparse maybe with
+// wrong answers)".
+//
+// The first fraction gate a child ever saw carried four candidates — one right
+// and THREE wrong — because the single call site passed `maxCandidates: 4` and
+// nothing about it ever moved. The rhythm escalated; the arithmetic did not.
+// That is ARENA's defect in another costume: the opening frame was already
+// carrying the twentieth minute's density.
+
+test("the first question a child ever sees is sparse", () => {
+  const r = rig("never");
+  // Long enough to reach the first two gate bars of stage 0 and no further:
+  // nothing has been cleared, so nothing escalates.
+  r.play(90);
+  const shapes = [...r.gateShapes];
+  r.dispose();
+
+  assert.ok(shapes.length > 0, "no gate opened at all; this test measured nothing");
+  const first = shapes[0]!;
+  assert.equal(first.stage, 0, "the first gate must belong to the first stage");
+  assert.equal(
+    first.wrong,
+    1,
+    `the first question a child is ever asked put ${first.wrong} wrong answers on the ` +
+      `screen at once`,
+  );
+  for (const s of shapes) {
+    assert.equal(s.stage, 0, "a bot that answers nothing must not escalate");
+    assert.ok(
+      s.candidates <= 2,
+      `stage 0 served ${s.candidates} candidates; the opening is meant to be sparse`,
+    );
+    assert.ok(s.candidates >= 2, "and never a single unmissable target");
+  }
+});
+
+test("density is part of the escalation, not a constant", () => {
+  // Stated once as a rule, so the shape is not only inferable from a bot that
+  // happens to reach stage 4.
+  assert.equal(candidatesForStage(0), 2);
+  assert.ok(
+    candidatesForStage(0) < candidatesForStage(12),
+    "a child deep in the run must be asked to discriminate between more numbers " +
+      "than a child on their first bar",
+  );
+  let prev = 0;
+  for (let i = 0; i < 30; i++) {
+    const n = candidatesForStage(i);
+    assert.ok(n >= prev, `stage ${i} is sparser than stage ${i - 1}`);
+    assert.ok(n >= 2 && n <= 4, `stage ${i} wants ${n} candidates`);
+    prev = n;
+  }
+});
+
+test("a child who is climbing IS given more to discriminate between", () => {
+  // The other half of the rule: sparse must not mean permanently sparse, or
+  // the fix for "starts too hard" has quietly capped the whole game. Compared
+  // against the opening rather than against a constant, because how many of the
+  // host's distractors actually survive the spacing is the host's business.
+  const opening = rig("never");
+  opening.play(90);
+  const openWidest = Math.max(...opening.gateShapes.map((s) => s.candidates));
+  opening.dispose();
+
+  const deep = rig("right", 6);
+  deep.play(120);
+  const shapes = [...deep.gateShapes];
+  deep.dispose();
+
+  assert.ok(shapes.length > 0, "no gate opened deep in the run");
+  const widest = Math.max(...shapes.map((s) => s.candidates));
+  assert.ok(
+    widest > openWidest,
+    `stage 6 offered at most ${widest} candidates and the opening offered ${openWidest}; ` +
+      `the game has been flattened, not made gentle`,
+  );
+});
+
+test("the viewport can hold the count down, but never below a real choice", () => {
+  // A phone too small for four orbs must be given fewer, and a stage that wants
+  // fewer must not be talked into more by a big screen. The run ANDs the two.
+  const r = rig("right", 8);
+  r.run.setGateFit({ maxCandidates: 2, minGapDenom: 3 });
+  assert.equal(r.run.gateFit().maxCandidates, 2, "the screen's ceiling must bind");
+  assert.equal(r.run.gateFit().minGapDenom, 3, "and its spacing must be used verbatim");
+  r.run.setGateFit({ maxCandidates: 4, minGapDenom: 6 });
+  assert.equal(
+    r.run.gateFit().maxCandidates,
+    candidatesForStage(r.run.stageIndex),
+    "with room to spare the stage decides",
+  );
+  r.dispose();
 });

--- a/dynawalla/games/pulse/src/game/run.ts
+++ b/dynawalla/games/pulse/src/game/run.ts
@@ -5,12 +5,18 @@
  * every visible consequence is announced through `Fx` so the renderer and the juice
  * layer stay replaceable and this file stays testable.
  *
- * Two clocks, and the distinction matters:
- *   - `engine.now()` is when a sound will be *scheduled*.
- *   - `heard()` is `now() - outputLatency`: what the player is hearing this instant.
- * Notes are drawn against `heard()` and input is timestamped against `heard()`, so
- * the picture, the sound and the judgment agree even on a laptop with 40 ms of
- * Bluetooth latency.
+ * ONE clock, read three ways, and the distinction matters:
+ *   - `engine.now()` is the transport — when a sound will be *scheduled*.
+ *   - `heard()` is `now() - outputLatency`: what the player is hearing this instant,
+ *     and the only thing a judgment is ever measured against.
+ *   - `shown()` is `heard() + visualLead`: what the frame being drawn will be
+ *     showing by the time it reaches the glass.
+ *
+ * All three come from `audio/clock.ts`, which is slaved to `AudioContext.currentTime`
+ * and interpolated by `performance.now()`. Audio is the master; the picture is derived
+ * from it and compensated for the display; nothing anywhere runs on a second clock.
+ * That is what makes the picture, the sound and the judgment agree on a laptop with
+ * 40 ms of Bluetooth latency AND on a Chromebook with a 20 ms output callback.
  */
 
 import type { Host } from "../contract.ts";
@@ -28,7 +34,7 @@ import {
   type LayerId,
 } from "../audio/music.ts";
 import { barNotes, BEATS_PER_BAR, laneVoices, type ChartNote } from "./chart.ts";
-import { buildGate, DEFAULT_FIT, type BuiltGate } from "./gate.ts";
+import { buildGate, type BuiltGate, type GateFit } from "./gate.ts";
 import { classify, multiplierFor, NoteQueue, WINDOWS, type Judgment, type LiveNote } from "./judge.ts";
 import { gatesToClear, stageAt, type StageSpec } from "./stages.ts";
 import { makeRng, hashSeed, type Rng } from "../rng.ts";
@@ -77,6 +83,40 @@ export type RunOptions = {
  * tempo, which is the entire point.
  */
 export const GATE_READ_SEC = 6;
+
+/**
+ * How many numbers ride toward the line at once, by stage.
+ *
+ * The first gate a child ever saw carried FOUR candidates — one right, three
+ * wrong — at twenty seconds in, because the only call site passed
+ * `maxCandidates: 4` and nothing about it moved. That is the ARENA defect in
+ * another costume: the opening frame was already carrying the twentieth
+ * minute's density. "starts too hard too ... it should start easy (and more
+ * sparse maybe with wrong answers)".
+ *
+ * So the count is part of the escalation, like the subdivision and the tempo
+ * are. One wrong turning to begin with, and because a candidate's POSITION is
+ * its value, one wrong turning is already a real question: the child still has
+ * to strike at the right moment in the bar, not pick the surviving option.
+ * Three by the time they are on triplets, four once they are past sixteenths.
+ *
+ * This is a ceiling, not a quota. The viewport ANDs its own ceiling on top —
+ * see `gateFitFor` — and a small phone may hold the count down further.
+ */
+export function candidatesForStage(stageIndex: number): number {
+  if (stageIndex <= 1) return 2;
+  if (stageIndex <= 3) return 3;
+  return 4;
+}
+
+/**
+ * What to assume before anyone has said how big the screen is.
+ *
+ * Deliberately the smallest phone's answer rather than `DEFAULT_FIT`: a run
+ * whose first gate is built before `setGateFit` arrives should serve something
+ * legible everywhere, not something legible only on a tablet.
+ */
+const SAFE_FIT: GateFit = { maxCandidates: 2, minGapDenom: 3 };
 
 const HEALTH = {
   miss: -0.05,
@@ -129,6 +169,12 @@ export class Run {
   layers = new Set<LayerId>(["bass"]);
   gate: ActiveGate | null = null;
   gateStreak = 0;
+  /**
+   * What the SCREEN can hold. Pushed in by whoever owns the layout — see
+   * `setGateFit` — because the gap between two candidates is a number of pixels
+   * and this file has never seen a pixel.
+   */
+  private viewportFit: GateFit = SAFE_FIT;
   overdriveUntilBar = -1;
   bar = 0;
   running = false;
@@ -172,13 +218,40 @@ export class Run {
     return this.timeline.spbAtBeat(this.timeline.beatOfBar(this.bar)) * BEATS_PER_BAR;
   }
 
+  /**
+   * How far ahead of `heard()` the picture is drawn, in seconds.
+   *
+   * A frame is not seen when it is drawn. `requestAnimationFrame` runs at the
+   * start of a frame and what it paints reaches the glass a frame later, so a
+   * playfield positioned at "the music as it sounds right now" is on screen
+   * showing where the music WAS — by 16 ms on a display keeping 60 Hz and by
+   * twice that on one that is not. Audio latency was compensated and this was
+   * not, which is why the two agreed on a fast machine and visibly did not on a
+   * slower one.
+   *
+   * Owned by whoever drives the frame loop, because only it knows the frame
+   * period and how long ago the vsync was. Zero in a headless run, which is
+   * correct: nothing is being presented.
+   */
+  visualLeadSec = 0;
+
   /** Audio time of the sound reaching the player's ears right now. */
   heard(): number {
     return this.engine.now() - this.engine.latency();
   }
 
+  /**
+   * Audio time the frame being drawn RIGHT NOW will represent when it is seen.
+   *
+   * The picture is derived from the audio clock and pushed forward by the
+   * display's own latency — never the reverse, and never a second clock.
+   */
+  shown(): number {
+    return this.heard() + this.visualLeadSec;
+  }
+
   nowBeat(): number {
-    return this.timeline.beatAt(this.heard());
+    return this.timeline.beatAt(this.shown());
   }
 
   /**
@@ -340,7 +413,7 @@ export class Run {
     }
 
     const q = this.host.next();
-    const built = buildGate(q, this.rng, { ...DEFAULT_FIT, maxCandidates: 4 });
+    const built = buildGate(q, this.rng, this.gateFit());
     this.gatesSeen++;
     const beat0 = this.timeline.beatOfBar(bar);
     for (const c of built.candidates) {
@@ -362,6 +435,25 @@ export class Run {
       resolved: false,
     };
     this.fx.gateOpen(built);
+  }
+
+  /**
+   * Tell the run what the screen can hold. Call it on mount and on every
+   * resize; a rotation changes both numbers.
+   */
+  setGateFit(fit: GateFit): void {
+    this.viewportFit = fit;
+  }
+
+  /** The screen's ceiling and the stage's ceiling, whichever binds harder. */
+  gateFit(): GateFit {
+    return {
+      minGapDenom: this.viewportFit.minGapDenom,
+      maxCandidates: Math.max(
+        2,
+        Math.min(this.viewportFit.maxCandidates, candidatesForStage(this.stageIndex)),
+      ),
+    };
   }
 
   private setStage(index: number, atBeat: number): void {
@@ -406,9 +498,19 @@ export class Run {
     else this.onHit(note, judgment, delta);
   }
 
+  /**
+   * A tap's moment, in transport time.
+   *
+   * This used to derive its own audio/`performance.now()` offset on the spot,
+   * from a raw `currentTime` read — a second, independent, quantised estimate
+   * of the same thing the picture was using, carrying up to a full output
+   * callback of random error that the picture did not carry. One model now
+   * answers both. See `audio/clock.ts`.
+   */
   private perfToHeard(perfMs: number): number {
-    const offset = this.engine.now() - performance.now() / 1000;
-    return perfMs / 1000 + offset - this.engine.latency() - this.calibrationMs / 1000;
+    return (
+      this.engine.timeAtPerf(perfMs / 1000) - this.engine.latency() - this.calibrationMs / 1000
+    );
   }
 
   private onHit(note: LiveNote, judgment: Judgment, delta: number): void {

--- a/dynawalla/games/pulse/src/game/sync.test.ts
+++ b/dynawalla/games/pulse/src/game/sync.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Audio and picture, on a device whose audio clock is coarse.
+ *
+ * "On chromebook the timing seems to be a little bit off for the music and the
+ * visual. It must be 100% in sync to work."
+ *
+ * `AudioContext.currentTime` is published to the main thread once per output
+ * callback and holds still in between, so any read of it is uniformly 0..q too
+ * small. `q` is a property of the device's audio stack — 2.7 ms where a browser
+ * manages a 128-frame quantum, 10-20 ms where it does not. The old code read it
+ * raw and INDEPENDENTLY for two things: where to draw the notes, once a frame,
+ * and what moment a tap happened at, on every tap. Two reads, two independent
+ * errors, no relationship between them.
+ *
+ * These play the real transport through `FakeAudioContext` with a coarse
+ * quantum and a hand-driven `performance.now()`, and the bot strikes on what it
+ * can SEE — `run.nowBeat()`, the same number the renderer positions notes from —
+ * rather than on a note's private schedule time. That is the whole point: a
+ * child aims at the picture, so the picture is what the judge has to agree with.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { installFakeAudio, installFakeNow } from "../dev/fakeAudio.ts";
+
+const nowClock = installFakeNow();
+const audio = installFakeAudio();
+
+const { Run } = await import("./run.ts");
+const { BEATS_PER_BAR } = await import("./chart.ts");
+const { TransportClock } = await import("../audio/clock.ts");
+const { WINDOWS } = await import("./judge.ts");
+
+import type { Host } from "../contract.ts";
+import type { Fx } from "./run.ts";
+
+/** A 960-frame output callback at 48 kHz. Chromebook-shaped, and legal. */
+const COARSE_QUANTUM = 0.02;
+const FRAME_SEC = 1 / 60;
+
+const question = (n: number) => ({
+  id: `q${n}`,
+  prompt: `1/2 + 1/4 (${n})`,
+  answer: "3/4",
+  distractors: ["1/4", "1/2", "1/8"],
+  domain: "fractions",
+  difficulty: 0.5,
+});
+
+const silentFx = (): Fx => ({
+  hit() {},
+  miss() {},
+  stray() {},
+  gateOpen() {},
+  gateResolved() {},
+  bar() {},
+  stageChanged() {},
+  drop() {},
+  stumble() {},
+  overdrive() {},
+  layerEarned() {},
+});
+
+const host = (): Host => {
+  let n = 0;
+  return {
+    next: () => question(++n),
+    report() {},
+    haptic() {},
+    prefersReducedMotion: () => true,
+  };
+};
+
+// ------------------------------------------------------------------- the model
+
+test("the transport recovers what a coarse audio callback throws away", () => {
+  // A clock the game cannot see, and the rounded-down one it can.
+  let truth = 0;
+  let perf = 0;
+  const visible = (): number => Math.floor(truth / COARSE_QUANTUM + 1e-9) * COARSE_QUANTUM;
+  const clock = new TransportClock({ audio: visible, perf: () => perf });
+
+  let worstModel = 0;
+  let worstRaw = 0;
+  // Frames deliberately NOT in phase with the callback: a test that samples on
+  // the quantum boundary measures nothing. The first second is warm-up and is
+  // not scored — the estimator cannot know where the boundary is until it has
+  // seen one, and a run has a title screen and a count-in before a note lands.
+  for (let i = 0; i < 360; i++) {
+    const jitter = ((i * 7919) % 1000) / 1000000; // sub-millisecond, deterministic
+    truth += FRAME_SEC + jitter;
+    perf += FRAME_SEC + jitter;
+    const model = Math.abs(clock.now() - truth);
+    const raw = Math.abs(visible() - truth);
+    if (i < 60) continue;
+    worstModel = Math.max(worstModel, model);
+    worstRaw = Math.max(worstRaw, raw);
+  }
+
+  // Proves the harness is exercising the defect rather than a perfect clock.
+  assert.ok(
+    worstRaw > COARSE_QUANTUM * 0.75,
+    `the raw reading was only ${(worstRaw * 1000).toFixed(2)} ms out — the coarse ` +
+      `clock is not being simulated and this test proves nothing`,
+  );
+  assert.ok(
+    worstModel < 0.0025,
+    `the transport was ${(worstModel * 1000).toFixed(2)} ms out against a raw ` +
+      `${(worstRaw * 1000).toFixed(2)} ms; the model must not inherit the quantisation`,
+  );
+});
+
+test("a suspended context does not leave the transport running ahead", () => {
+  // Pause suspends the AudioContext, which freezes `currentTime` while
+  // `performance.now()` keeps going. Bleeding that off at the drift rate would
+  // take minutes; it has to re-anchor.
+  let audioT = 0;
+  let perf = 0;
+  const clock = new TransportClock({ audio: () => audioT, perf: () => perf });
+  for (let i = 0; i < 60; i++) {
+    audioT += FRAME_SEC;
+    perf += FRAME_SEC;
+    clock.now();
+  }
+  // Two seconds of pause: the audio clock stands still.
+  perf += 2;
+  clock.now();
+  for (let i = 0; i < 10; i++) {
+    audioT += FRAME_SEC;
+    perf += FRAME_SEC;
+    clock.now();
+  }
+  assert.ok(
+    Math.abs(clock.now() - audioT) < 0.01,
+    `after a 2 s pause the transport was ${((clock.now() - audioT) * 1000).toFixed(0)} ms ` +
+      `ahead of the audio clock`,
+  );
+});
+
+// --------------------------------------------------------------- the whole game
+
+test("a strike aimed at the drawn line is judged there, on a coarse clock", () => {
+  /**
+   * The player model: watch the field, and tap when the note is on the line.
+   *
+   * The tap does NOT happen at the same instant the frame was drawn — a pointer
+   * event arrives when a thumb arrives, at some arbitrary phase inside the
+   * frame, and that is the whole difficulty. A test that strikes in the same
+   * tick as it looks would have BOTH reads land on the same rounded
+   * `currentTime` and the two errors would cancel, which is how a broken
+   * transport passes a lazy test.
+   */
+  const TAP_PHASE_SEC = 0.005;
+
+  const deltas: number[] = [];
+  const grades: string[] = [];
+  const fx = silentFx();
+  fx.hit = (_n, judgment, delta) => {
+    deltas.push(delta);
+    grades.push(judgment);
+  };
+
+  nowClock.set(0);
+  const run = new Run({ host: host(), fx, seed: "sync" });
+  const ctx = audio.latest();
+  ctx.currentTime = 0;
+  ctx.quantumSec = COARSE_QUANTUM;
+  run.start();
+
+  const struck = new Set<number>();
+  for (let frame = 0; frame < 60 * 60; frame++) {
+    ctx.advance(FRAME_SEC);
+    nowClock.advance(FRAME_SEC * 1000);
+    run.update();
+    const beat = run.nowBeat();
+    const wanted = run.notes
+      .all()
+      .filter((n) => n.judged === null && !struck.has(n.id) && !n.gate)
+      .filter((n) => (n.beat - beat) / BEATS_PER_BAR <= 0);
+    if (wanted.length === 0) continue;
+    // The thumb lands part-way through the frame it decided on.
+    ctx.advance(TAP_PHASE_SEC);
+    nowClock.advance(TAP_PHASE_SEC * 1000);
+    for (const n of wanted) {
+      struck.add(n.id);
+      run.input(n.lane, performance.now());
+    }
+  }
+  run.dispose();
+
+  assert.ok(deltas.length > 60, `only ${deltas.length} notes were struck; nothing was measured`);
+
+  // Everything a strike can honestly be off by: the note crossed the line at
+  // some point inside the frame that noticed, and the thumb landed at a fixed
+  // phase after it. One frame, and no more. Anything wider than that came out
+  // of the clock rather than out of the play.
+  const spread = Math.max(...deltas) - Math.min(...deltas);
+  assert.ok(
+    spread <= FRAME_SEC * 1.25,
+    `strikes aimed at the same drawn position were judged across a ` +
+      `${(spread * 1000).toFixed(1)} ms band on a ${COARSE_QUANTUM * 1000} ms audio ` +
+      `callback; one 60 Hz frame is ${(FRAME_SEC * 1000).toFixed(1)} ms and the rest is ` +
+      `the audio clock's quantisation leaking into the judgment`,
+  );
+  assert.deepEqual(
+    [...new Set(grades)],
+    ["perfect"],
+    `a player dead on the drawn line was graded ${[...new Set(grades)].join("/")}`,
+  );
+});
+
+test("the picture is pushed forward to meet the display, not left behind it", () => {
+  nowClock.set(0);
+  const run = new Run({ host: host(), fx: silentFx(), seed: "lead" });
+  const ctx = audio.latest();
+  ctx.currentTime = 0;
+  ctx.quantumSec = 0;
+  run.start();
+  for (let i = 0; i < 120; i++) {
+    ctx.advance(FRAME_SEC);
+    nowClock.advance(FRAME_SEC * 1000);
+    run.update();
+  }
+
+  const heard = run.heard();
+  assert.equal(run.shown(), heard, "with nothing being presented the lead must be zero");
+
+  run.visualLeadSec = FRAME_SEC;
+  assert.ok(
+    Math.abs(run.shown() - (heard + FRAME_SEC)) < 1e-9,
+    "the drawn moment must lead the heard moment by exactly the display's latency",
+  );
+  const drawn = run.nowBeat();
+  run.visualLeadSec = 0;
+  const behind = run.nowBeat();
+  assert.ok(
+    drawn > behind,
+    "compensating the display must move the field FORWARD in the music, not back",
+  );
+  // And it is bounded: a frame of lead is a small fraction of a beat, never a
+  // shortcut for scrolling the field faster.
+  assert.ok(drawn - behind < 0.2, `a frame of lead moved the field ${drawn - behind} beats`);
+  run.dispose();
+});
+
+test("transport time advances by what actually elapsed, not by a whole callback", () => {
+  /**
+   * The structural claim, and the one a same-instant test cannot make.
+   *
+   * Read the transport, let five milliseconds pass, read it again. The
+   * difference must be five milliseconds. Read raw, `currentTime` has either
+   * not moved at all or has jumped a whole callback, so the interval between a
+   * frame and the tap aimed at it is reported as 0 ms or 20 ms and never as the
+   * 5 ms it was — which is precisely the error the judge then scores.
+   */
+  const GAP_SEC = 0.005;
+  nowClock.set(0);
+  const run = new Run({ host: host(), fx: silentFx(), seed: "one-clock" });
+  const ctx = audio.latest();
+  ctx.currentTime = 0;
+  ctx.quantumSec = COARSE_QUANTUM;
+  run.start();
+  for (let i = 0; i < 90; i++) {
+    ctx.advance(FRAME_SEC);
+    nowClock.advance(FRAME_SEC * 1000);
+    run.update();
+  }
+
+  let worst = 0;
+  for (let i = 0; i < 200; i++) {
+    const before = run.heard();
+    ctx.advance(GAP_SEC);
+    nowClock.advance(GAP_SEC * 1000);
+    const after = run.engine.timeAtPerf(performance.now() / 1000) - run.engine.latency();
+    worst = Math.max(worst, Math.abs(after - before - GAP_SEC));
+  }
+  run.dispose();
+
+  assert.ok(
+    worst < 0.0015,
+    `${GAP_SEC * 1000} ms between the frame and the tap aimed at it was reported as far ` +
+      `as ${((worst + GAP_SEC) * 1000).toFixed(1)} ms — off by ${(worst * 1000).toFixed(1)} ms, ` +
+      `which is the output callback, not the play`,
+  );
+  assert.ok(WINDOWS.perfect > 0);
+});

--- a/dynawalla/games/pulse/src/mount.ts
+++ b/dynawalla/games/pulse/src/mount.ts
@@ -15,6 +15,7 @@ import { Run, type Fx } from "./game/run.ts";
 import { bindInput } from "./input.ts";
 import { createSurfaces } from "./render/canvas.ts";
 import { drawButtons, drawPause, drawPerf, drawTitle, hitButton } from "./render/chrome.ts";
+import { gateFitFor } from "./render/layout.ts";
 import { Scene } from "./render/scene.ts";
 import { loadSettings, prefersReducedMotion, saveSettings } from "./settings.ts";
 
@@ -134,7 +135,9 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
     },
     stageChanged(stage, index) {
       scene.stageCardShow(stage, index);
-      scene.resize(stage.lanes);
+      // The lane count changes with the stage, which changes the field, which
+      // changes what a bar is worth in pixels. Re-fit rather than resize.
+      relayout();
     },
     drop() {
       scene.dropFlash();
@@ -210,7 +213,7 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
         run.input(lane, perfMs);
       },
       tap(x, y) {
-        const b = hitButton(x, y, scene.layout.area, scene.layout.compact);
+        const b = hitButton(x, y, scene.layout.area, scene.layout.compact, surfaces.h);
         if (!b) return false;
         if (b === "mute") {
           settings.muted = !settings.muted;
@@ -238,8 +241,22 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
   };
   document.addEventListener("visibilitychange", onVisibility);
 
+  /**
+   * Re-lay the field AND tell the run what the new frame can hold.
+   *
+   * These two must not come apart. `gateFitFor` is the only thing that knows
+   * both how wide a bar is in pixels and how wide a candidate is, and a gate is
+   * built from whatever the run last heard — so a rotation that relaid the
+   * playfield without re-fitting the gate would go on spacing candidates for
+   * the old screen. Every path that resizes goes through here.
+   */
+  const relayout = (): void => {
+    scene.resize(run.stage.lanes);
+    run.setGateFit(gateFitFor(scene.layout));
+  };
+
   const ro = new ResizeObserver(() => {
-    if (surfaces.resize()) scene.resize(run.stage.lanes);
+    if (surfaces.resize()) relayout();
   });
   ro.observe(el);
 
@@ -249,13 +266,13 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
    * Split View. The canvas size may not change at all across some of those, so
    * `ResizeObserver` alone would leave the field laid out against stale numbers.
    */
-  const stopInsets = onInsetsChange(() => scene.resize(run.stage.lanes));
+  const stopInsets = onInsetsChange(relayout);
   window.addEventListener("resize", onWindowResize);
   function onWindowResize(): void {
-    if (surfaces.resize()) scene.resize(run.stage.lanes);
+    if (surfaces.resize()) relayout();
   }
 
-  scene.resize(run.stage.lanes);
+  relayout();
 
   /**
    * When a harness drives the loop itself, `requestAnimationFrame` stops touching the
@@ -263,6 +280,13 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
    * one enormous frame into the middle of a measured burst.
    */
   let externalDriver = false;
+
+  /**
+   * The `requestAnimationFrame` timestamp of the frame being drawn, or null
+   * when a harness is driving the loop by hand — in which case nothing is being
+   * presented and there is no display latency to compensate.
+   */
+  let vsyncMs: number | null = null;
 
   const step = (raw: number): void => {
     const dt = Math.min(0.05, Math.max(0, raw / 1000));
@@ -285,8 +309,29 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
     // exactly like a tab switch.
     if (guide.isOpen && phase === "playing") setPaused(true);
 
-    if (surfaces.resize()) scene.resize(run.stage.lanes);
-    if (scene.layout.laneCount !== run.stage.lanes) scene.resize(run.stage.lanes);
+    if (surfaces.resize()) relayout();
+    if (scene.layout.laneCount !== run.stage.lanes) relayout();
+
+    /**
+     * Point the picture at the moment it will actually be SEEN.
+     *
+     * `vsyncMs` is the timestamp `requestAnimationFrame` handed us: the start of
+     * the frame being composed. What we paint from here lands on the glass at
+     * the next one, so the music the playfield should be showing is the music of
+     * `vsync + one frame`, not the music of the instant we happen to read the
+     * audio clock — which is later still, since this callback has been running
+     * for a while by now.
+     *
+     * Compensating audio latency and not this is what made the game agree with
+     * itself on a fast machine and not on a slow one: on a 60 Hz display it is
+     * ~16 ms of lag and on a Chromebook dropping to 30 fps it is ~33 ms, and
+     * neither of them was anywhere in the model. The frame period is measured
+     * rather than assumed, so a 120 Hz iPad gets its own answer, and it is
+     * clamped so one stalled frame cannot fling the field forward.
+     */
+    const periodMs = Math.min(34, Math.max(6, raw || 16.7));
+    const leadMs = vsyncMs === null ? 0 : vsyncMs + periodMs - performance.now();
+    run.visualLeadSec = Math.max(0, Math.min(0.05, leadMs / 1000));
 
     run.engine.sample();
     const { ctx, w, h } = surfaces;
@@ -327,12 +372,21 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
           notes: run.notes.all().length,
           latencyMs: run.engine.latency(),
           calibrationMs: run.calibrationMs,
+          visualLeadMs: run.visualLeadSec * 1000,
+          clockErrorMs: run.engine.clockError() * 1000,
         });
       }
     }
 
     ctx.globalCompositeOperation = "lighter";
-    drawButtons(ctx, scene.layout.area, scene.layout.compact, settings.muted, phase === "paused");
+    drawButtons(
+      ctx,
+      scene.layout.area,
+      scene.layout.compact,
+      surfaces.h,
+      settings.muted,
+      phase === "paused",
+    );
   };
 
   const frame = (t: number): void => {
@@ -340,7 +394,9 @@ export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): 
     const raw = t - last;
     last = t;
     if (externalDriver) return;
+    vsyncMs = t;
     step(raw);
+    vsyncMs = null;
   };
   raf = requestAnimationFrame(frame);
 

--- a/dynawalla/games/pulse/src/render/chrome.ts
+++ b/dynawalla/games/pulse/src/render/chrome.ts
@@ -16,8 +16,38 @@ import { neon } from "./text.ts";
 
 export type ChromeButton = "mute" | "pause";
 
-const BTN = { size: 34, gap: 10, margin: 16 };
-const BTN_COMPACT = { size: 30, gap: 8, margin: 12 };
+/**
+ * The platform minimum touch target, and the floor for anything a child taps.
+ *
+ * These two squares were 30 px on a phone and 34 px on a tablet. A 30 px square
+ * is not a control a seven-year-old hits; it is a control an adult hits on the
+ * third try. Nothing about this game needs them small, so they are 44 px
+ * everywhere, which is what `HOST_CONTROL` already promises for the host's own
+ * two corners.
+ */
+export const MIN_TOUCH = 44;
+
+/**
+ * How much of the bottom edge belongs to the system rather than to us.
+ *
+ * `safeRect` subtracts `env(safe-area-inset-bottom)`, and on iOS that is the
+ * home indicator and it is honest. On Android it is not enough: the value the
+ * WebView reports describes the DISPLAY CUTOUT, while the thing that eats a tap
+ * is the gesture-navigation handle — a strip along the bottom edge that the
+ * system claims for the swipe-up-to-home gesture and that reports a bottom
+ * inset of ZERO on plenty of devices. That is the shape of the bug the founder
+ * hit: both controls were drawn inside the safe rect, correctly, and still
+ * could not be touched.
+ *
+ * So the bottom of a control is held clear of the raw canvas edge by this much
+ * *as well as* clear of the reported inset, whichever binds harder. 24 CSS px
+ * is the Android gesture handle's own height; the button margin sits on top of
+ * it, so the real clearance is 36-40 px.
+ */
+export const GESTURE_STRIP = 24;
+
+const BTN = { size: MIN_TOUCH, gap: 10, margin: 16 };
+const BTN_COMPACT = { size: MIN_TOUCH, gap: 8, margin: 12 };
 
 function metrics(compact: boolean): typeof BTN {
   return compact ? BTN_COMPACT : BTN;
@@ -26,28 +56,42 @@ function metrics(compact: boolean): typeof BTN {
 /**
  * Pause and mute, bottom-right.
  *
- * `area` is the safe rect and is REQUIRED, for the same reason it is required on
- * `computeLayout`: measured from the raw canvas these two buttons sit in the home
- * indicator's strip on every modern phone, where a swipe up is the system's gesture
- * and not ours. Optional, a caller that forgets it compiles and the bug only exists
- * on hardware. `hitButton` reads the same rect, so the touch target can never drift
- * away from the drawn square.
+ * `area` is the safe rect and `canvasH` is the raw canvas height. BOTH are
+ * REQUIRED, for the same reason `area` is required on `computeLayout`: measured
+ * from the raw canvas alone these two buttons sit in the home indicator's
+ * strip, and measured from the safe rect alone they sit in Android's gesture
+ * strip — which the safe rect does not describe. Optional, a caller that
+ * forgets one compiles and the bug only exists on hardware.
+ *
+ * `hitButton` reads the same rect, so the touch target can never drift away
+ * from the drawn square.
  */
 export function buttonRect(
   i: number,
   area: Rect,
   compact: boolean,
+  canvasH: number,
 ): { x: number; y: number; s: number } {
   const m = metrics(compact);
   const s = m.size;
   const x = area.x + area.w - m.margin - s - i * (s + m.gap);
-  const y = area.y + area.h - m.margin - s;
+  // The lower of "the safe rect's floor" and "the canvas floor minus the strip
+  // the system swipes in". Clamped so a viewport too short to honour either
+  // still puts the button on screen rather than above it.
+  const floor = Math.min(area.y + area.h, canvasH - GESTURE_STRIP);
+  const y = Math.max(area.y, floor - m.margin - s);
   return { x, y, s };
 }
 
-export function hitButton(x: number, y: number, area: Rect, compact: boolean): ChromeButton | null {
+export function hitButton(
+  x: number,
+  y: number,
+  area: Rect,
+  compact: boolean,
+  canvasH: number,
+): ChromeButton | null {
   for (let i = 0; i < 2; i++) {
-    const r = buttonRect(i, area, compact);
+    const r = buttonRect(i, area, compact, canvasH);
     const pad = 6;
     if (x >= r.x - pad && x <= r.x + r.s + pad && y >= r.y - pad && y <= r.y + r.s + pad) {
       return i === 0 ? "pause" : "mute";
@@ -60,11 +104,12 @@ export function drawButtons(
   ctx: CanvasRenderingContext2D,
   area: Rect,
   compact: boolean,
+  canvasH: number,
   muted: boolean,
   paused: boolean,
 ): void {
   const draw = (i: number, fn: (x: number, y: number, s: number) => void, ink: Ink, on: boolean): void => {
-    const r = buttonRect(i, area, compact);
+    const r = buttonRect(i, area, compact, canvasH);
     const c = INK[ink];
     ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${on ? 0.5 : 0.24})`;
     ctx.lineWidth = 1;
@@ -233,6 +278,10 @@ export type PerfStats = {
   notes: number;
   latencyMs: number;
   calibrationMs: number;
+  /** How far ahead of the audio the picture is drawn to meet the display. */
+  visualLeadMs: number;
+  /** How much error a raw `AudioContext.currentTime` read would be carrying. */
+  clockErrorMs: number;
 };
 
 export function drawPerf(ctx: CanvasRenderingContext2D, area: Rect, s: PerfStats): void {
@@ -242,6 +291,7 @@ export function drawPerf(ctx: CanvasRenderingContext2D, area: Rect, s: PerfStats
     `draw ${s.drawMs.toFixed(2)} ms`,
     `parts ${s.particles}  notes ${s.notes}`,
     `latency ${(s.latencyMs * 1000).toFixed(1)} ms  cal ${s.calibrationMs.toFixed(0)} ms`,
+    `lead ${s.visualLeadMs.toFixed(1)} ms  clock err ${s.clockErrorMs.toFixed(1)} ms`,
   ];
   // Developer overlay (`?perf`), tucked under the host's help button rather
   // than behind it.

--- a/dynawalla/games/pulse/src/render/layout.test.ts
+++ b/dynawalla/games/pulse/src/render/layout.test.ts
@@ -24,10 +24,12 @@ import {
   type Insets,
   type Rect,
 } from "../../../../packs/shared/game-chrome/index.ts";
-import { buttonRect } from "./chrome.ts";
+import { GESTURE_STRIP, MIN_TOUCH, buttonRect, hitButton } from "./chrome.ts";
 import {
+  GATE_LABEL_MIN,
   comboBox,
   computeLayout,
+  gateFitFor,
   healthBox,
   laneAtPoint,
   multBox,
@@ -160,7 +162,7 @@ function readables(l: Layout): Array<[string, Rect]> {
 /** Pulse's own two buttons, as squares. */
 function ownButtons(l: Layout): Array<[string, Rect]> {
   return [0, 1].map((i) => {
-    const r = buttonRect(i, l.area, l.compact);
+    const r = buttonRect(i, l.area, l.compact, l.h);
     const box: Rect = { x: r.x, y: r.y, w: r.s, h: r.s };
     return [i === 0 ? "pause button" : "mute button", box] as [string, Rect];
   });
@@ -275,7 +277,8 @@ test("the layout follows the insets rather than reading them once", () => {
     "the score must sit lower once there is a notch above it",
   );
   assert.ok(
-    buttonRect(0, upright.area, upright.compact).y < buttonRect(0, flat.area, flat.compact).y,
+    buttonRect(0, upright.area, upright.compact, 844).y <
+      buttonRect(0, flat.area, flat.compact, 844).y,
     "the buttons must sit higher once there is a home indicator below them",
   );
 });
@@ -285,8 +288,163 @@ test("the touch target of pulse's own buttons is the square it draws", () => {
   // cannot leave the tappable squares behind at the old place.
   const l = computeLayout(390, 844, 3, safeRect(390, 844, NOTCHED_PORTRAIT));
   for (const i of [0, 1]) {
-    const r = buttonRect(i, l.area, l.compact);
+    const r = buttonRect(i, l.area, l.compact, 844);
     assert.ok(r.y + r.s <= l.area.y + l.area.h, `button ${i} is in the home indicator`);
     assert.ok(r.x + r.s <= l.area.x + l.area.w, `button ${i} is past the safe edge`);
   }
 });
+
+// ------------------------------------------------------- the answer, readable
+//
+// "Cant see the answers (when you are tasked with performing arithmetic), too
+// blurry ... the answers should be very clear".
+//
+// Two separate defects wore that one sentence. The number on a gate candidate
+// was derived from the orb — `gateR * 0.62 * 0.84` — which is 15.1 px on a
+// 390 px phone and 15.1 px on a 320 px one; and `minGapDenom` was hardcoded to
+// 12 at its only call site, so two candidates a twelfth of the bar apart were
+// 34.0 px apart on that same phone while being 57.8 px across. They physically
+// overlapped, by 24 px, and the measured minimum gap over 5000 real gates was
+// exactly 1/12 — so the worst case was the ordinary case.
+
+/**
+ * Where a child is actually asked to read a moving number, including a device
+ * whose bottom inset is ZERO while its gesture strip is not. Kept separate from
+ * `VIEWPORTS` above deliberately: that list is about the host's chrome, this
+ * one is about hands and eyes.
+ */
+const READING_VIEWPORTS: Array<[number, number, Insets, string]> = [
+  [320, 568, NO_INSETS, "320×568 small phone"],
+  [390, 844, NOTCHED_PORTRAIT, "390×844 notched phone"],
+  [412, 915, NO_INSETS, "412×915 android, no reported bottom inset"],
+  [412, 915, { top: 24, right: 0, bottom: 24, left: 0 }, "412×915 android, gesture insets"],
+  [768, 1024, NO_INSETS, "768×1024 tablet"],
+  [1024, 768, NO_INSETS, "1024×768 tablet landscape"],
+  [844, 390, NOTCHED_LANDSCAPE, "844×390 phone landscape"],
+];
+
+for (const [w, h, insets, name] of READING_VIEWPORTS) {
+  test(`a gate candidate's number is big enough to read at ${name}`, () => {
+    for (const lanes of [1, 2, 3]) {
+      const l = computeLayout(w, h, lanes, safeRect(w, h, insets));
+      assert.ok(
+        l.gateLabelSize >= GATE_LABEL_MIN,
+        `${name}/${lanes} lanes: the answer is drawn at ${l.gateLabelSize.toFixed(1)} px, ` +
+          `below the ${GATE_LABEL_MIN} px floor`,
+      );
+      // And the ring it lives in has to hold it, or the fit is a lie that the
+      // renderer silently shrinks its way out of.
+      assert.ok(
+        l.gateR * 2 >= l.gateLabelSize * 2.36,
+        `${name}/${lanes} lanes: a stacked fraction of ${l.gateLabelSize.toFixed(1)} px needs ` +
+          `${(l.gateLabelSize * 2.36).toFixed(1)} px and the orb is ${(l.gateR * 2).toFixed(1)}`,
+      );
+    }
+  });
+
+  test(`two gate candidates cannot overlap at ${name}`, () => {
+    for (const lanes of [1, 2, 3]) {
+      const l = computeLayout(w, h, lanes, safeRect(w, h, insets));
+      const fit = gateFitFor(l);
+      const diameter = l.gateR * 2;
+
+      // The positional path: the closest two candidates the gate will ever
+      // admit are exactly `minGapDenom` apart.
+      const closest = l.runLen / fit.minGapDenom;
+      assert.ok(
+        closest >= diameter,
+        `${name}/${lanes} lanes: candidates 1/${fit.minGapDenom} of a bar apart are ` +
+          `${closest.toFixed(1)} px apart and ${diameter.toFixed(1)} px across — they overlap ` +
+          `by ${(diameter - closest).toFixed(1)} px`,
+      );
+
+      // The flat fallback, which spaces `n` candidates at 1/(n+1) of the bar
+      // and is reached in ordinary play whenever the host serves column
+      // arithmetic. It obeys the same geometry or it is a second way to ship
+      // the same defect.
+      const flat = l.runLen / (fit.maxCandidates + 1);
+      assert.ok(
+        flat >= diameter,
+        `${name}/${lanes} lanes: ${fit.maxCandidates} evenly spaced candidates sit ` +
+          `${flat.toFixed(1)} px apart and are ${diameter.toFixed(1)} px across`,
+      );
+
+      assert.ok(fit.maxCandidates >= 2, "a gate is never a single unmissable target");
+      assert.ok(fit.minGapDenom >= 2);
+    }
+  });
+}
+
+// ------------------------------------------------- the two controls, tappable
+//
+// "On Android, the pause button and the mute button are at the bottom and
+// actually conflict with the safe area and can't be touched."
+//
+// They were 30 px squares sitting 12 px above the bottom of the safe rect. Two
+// things were wrong and only one of them is about the safe rect: 30 px is under
+// the 44 px minimum touch target, and the safe rect does not describe Android's
+// gesture strip at all — plenty of devices report `safe-area-inset-bottom: 0`
+// and still swallow a tap in the bottom 24 px. So the zero-inset Android case
+// is in this list on purpose; it is the case that broke.
+
+for (const [w, h, insets, name] of READING_VIEWPORTS) {
+  test(`pause and mute can be touched at ${name}`, () => {
+    const area = safeRect(w, h, insets);
+    const l = computeLayout(w, h, 3, area);
+    for (const i of [0, 1]) {
+      const which = i === 0 ? "pause" : "mute";
+      const r = buttonRect(i, l.area, l.compact, h);
+
+      assert.ok(
+        r.s >= MIN_TOUCH,
+        `${name}: ${which} is ${r.s} px; ${MIN_TOUCH} px is the minimum touch target`,
+      );
+
+      // Inside the safe rect — the notch, the home indicator, the rounded
+      // corners.
+      assert.ok(
+        r.x >= area.x - 0.5 &&
+          r.y >= area.y - 0.5 &&
+          r.x + r.s <= area.x + area.w + 0.5 &&
+          r.y + r.s <= area.y + area.h + 0.5,
+        `${name}: ${which} at x ${r.x.toFixed(0)}..${(r.x + r.s).toFixed(0)}, ` +
+          `y ${r.y.toFixed(0)}..${(r.y + r.s).toFixed(0)} is outside the safe rect ` +
+          `${span(area)}`,
+      );
+
+      // …AND clear of the system's gesture strip, measured from the raw canvas,
+      // which is the part the safe rect cannot tell us about.
+      assert.ok(
+        r.y + r.s <= h - GESTURE_STRIP,
+        `${name}: ${which} reaches y ${(r.y + r.s).toFixed(0)} of ${h}, inside the ` +
+          `${GESTURE_STRIP} px the system swipes in`,
+      );
+
+      // The hit test agrees with the square that was drawn, at its centre and
+      // at every corner.
+      const cx = r.x + r.s / 2;
+      const cy = r.y + r.s / 2;
+      assert.equal(hitButton(cx, cy, l.area, l.compact, h), which, `${name}: ${which} centre`);
+      for (const [dx, dy] of [
+        [1, 1],
+        [r.s - 1, 1],
+        [1, r.s - 1],
+        [r.s - 1, r.s - 1],
+      ]) {
+        assert.equal(
+          hitButton(r.x + dx!, r.y + dy!, l.area, l.compact, h),
+          which,
+          `${name}: ${which} corner ${dx},${dy}`,
+        );
+      }
+    }
+
+    // And they are two controls, not one square drawn twice.
+    const a = buttonRect(0, l.area, l.compact, h);
+    const b = buttonRect(1, l.area, l.compact, h);
+    assert.ok(
+      a.x >= b.x + b.s || b.x >= a.x + a.s,
+      `${name}: pause and mute overlap each other`,
+    );
+  });
+}

--- a/dynawalla/games/pulse/src/render/layout.ts
+++ b/dynawalla/games/pulse/src/render/layout.ts
@@ -49,6 +49,36 @@ const COMBO_PUNCH = 1.28;
 
 const UMAX = 1.06;
 
+/**
+ * The smallest a gate candidate's number may ever be drawn, in CSS px.
+ *
+ * It used to be derived from the note: `gateR * 0.62 * 0.84`, which on a 390 px
+ * phone is **15.1 px** for a stacked fraction and 17.9 px for a plain numeral —
+ * drawn additively, mid-scroll, over a bloom halo a third of the glyph's own
+ * size. The founder's report is exact: "Cant see the answers ... too blurry".
+ *
+ * So the dependency is inverted. The number gets a floor a child can read on a
+ * moving bus, and the ring is sized to hold it. 22 px is the smallest numeral
+ * that survives the phosphor bloom this game is made of; below that the halo is
+ * wider than the strokes and a 3 reads as an 8.
+ */
+export const GATE_LABEL_MIN = 22;
+/** …and a ceiling, so a tablet does not hand a child a dinner plate. */
+export const GATE_LABEL_MAX = 40;
+
+/**
+ * A stacked fraction reaches ±1.18·size vertically, so a ring of 1.4·size in
+ * radius holds one with a little air. Plain numerals are shrunk to fit the same
+ * ring by the renderer, which measures them.
+ */
+const GATE_RING_PER_LABEL = 1.4;
+
+/** The type size of a gate candidate's number at this viewport. */
+export function gateLabelSizeFor(w: number, h: number): number {
+  const short = Math.min(w, h);
+  return Math.max(GATE_LABEL_MIN, Math.min(GATE_LABEL_MAX, short * 0.068));
+}
+
 /** A left/right/centre anchored line of text: `x` is the anchored edge. */
 export type Anchor = { x: number; cy: number; size: number };
 
@@ -84,6 +114,12 @@ export type Layout = {
   /** Drawn radius of an ordinary note, and of a gate note (which carries a label). */
   noteR: number;
   gateR: number;
+  /**
+   * Type size of the number a gate candidate carries. THE most important
+   * readable in the game — it is the answer — so it is a first-class layout
+   * value with a floor, and `gateR` is derived from it rather than the reverse.
+   */
+  gateLabelSize: number;
   hud: Hud;
   pt(u: number, v: number, out?: { x: number; y: number }): { x: number; y: number };
   laneV(lane: number): number;
@@ -160,7 +196,12 @@ export function computeLayout(w: number, h: number, laneCount: number, area: Rec
     );
     const lanePitch = fieldThickness / lanes;
     const noteR = Math.min(lanePitch * 0.3, compact ? 17 : 24);
-    const gateR = noteR * (compact ? 1.7 : 2.0);
+    const gateLabelSize = Math.min(
+      gateLabelSizeFor(w, h),
+      // Never taller than the field it rides in, whatever the viewport says.
+      (fieldThickness * 0.46) / GATE_RING_PER_LABEL,
+    );
+    const gateR = gateLabelSize * GATE_RING_PER_LABEL;
     const strikeX = area.x + Math.max(72, Math.min(160, area.w * 0.19));
     // The trailing margin is at least a gate note's radius, so a note one whole
     // bar out is drawn complete rather than clipped by the safe edge.
@@ -178,6 +219,7 @@ export function computeLayout(w: number, h: number, laneCount: number, area: Rec
       area,
       noteR,
       gateR,
+      gateLabelSize,
       hud: {
         pad,
         score,
@@ -217,7 +259,11 @@ export function computeLayout(w: number, h: number, laneCount: number, area: Rec
   const strikeY = area.y + area.h * 0.775;
   const lanePitch = fieldThickness / lanes;
   const noteR = Math.min(lanePitch * 0.3, compact ? 17 : 24);
-  const gateR = noteR * (compact ? 1.7 : 2.0);
+  const gateLabelSize = Math.min(
+    gateLabelSizeFor(w, h),
+    (fieldThickness * 0.46) / GATE_RING_PER_LABEL,
+  );
+  const gateR = gateLabelSize * GATE_RING_PER_LABEL;
   // A note at uMax is the first frame a child could read it. Its own radius has
   // to clear the question above it, which in turn clears the host's corners.
   const runTop = promptBottom + gateR + CHROME_GAP;
@@ -238,6 +284,7 @@ export function computeLayout(w: number, h: number, laneCount: number, area: Rec
     area,
     noteR,
     gateR,
+    gateLabelSize,
     hud: {
       pad,
       score,
@@ -333,6 +380,42 @@ export function promptBox(l: Layout, textW: number): Rect {
 export function comboBox(l: Layout, textW: number): Rect {
   const c = l.hud.combo;
   return textRect(c.cx, c.cy, textW * COMBO_PUNCH, c.size * COMBO_PUNCH, "centre");
+}
+
+// ------------------------------------------------------------------ the gate
+//
+// `GateFit` in `game/gate.ts` documents `minGapDenom` as "a *display*
+// constraint, not a mathematical one, so it is passed in rather than fixed: a
+// 1372 px landscape bar can hold four orbs a twelfth apart, and a 544 px phone
+// bar cannot". It was then passed in as the constant 12 from one call site and
+// never varied. So the constraint said "a twelfth" on every viewport, and a
+// twelfth of a 390 px phone's bar is 34.0 px between two candidates that are
+// 57.8 px across: they OVERLAPPED, by 24 px, in ordinary play — and the
+// measured minimum gap over 5000 real gates was exactly 1/12, so the bad case
+// was the normal case. At 320 px they overlapped by 36 px of a 58 px orb.
+//
+// A gap is a number of pixels. Turning it back into a fraction of the bar is
+// this function's whole job, and it is the only place that knows both numbers.
+
+/** Clear air between two candidate rings, as a fraction of one ring's diameter. */
+const GATE_BREATH = 1.18;
+
+/**
+ * How far apart candidates must sit and how many of them fit, at THIS viewport.
+ *
+ * The caller ANDs this with whatever the stage allows: the fit says what the
+ * screen can hold, the stage says what the child should be asked for.
+ */
+export function gateFitFor(l: Layout): { maxCandidates: number; minGapDenom: number } {
+  const needPx = l.gateR * 2 * GATE_BREATH;
+  // The largest number of equal parts the bar divides into where one part is
+  // still wider than a candidate needs. Never below 2 — the bar has to hold at
+  // least the answer and one wrong turning.
+  const denom = Math.max(2, Math.floor(l.runLen / needPx));
+  // The flat fallback in `buildGate` spaces n candidates at 1/(n+1) of the bar,
+  // so it obeys the same gap only while n + 1 <= denom. Capped at 4, which is
+  // as many numbers as a child reads while a bar goes past.
+  return { maxCandidates: Math.max(2, Math.min(4, denom - 1)), minGapDenom: denom };
 }
 
 /** The box a note occupies on screen. Gate notes are drawn larger and carry a label. */

--- a/dynawalla/games/pulse/src/render/scene.ts
+++ b/dynawalla/games/pulse/src/render/scene.ts
@@ -38,7 +38,7 @@ import {
 } from "./layout.ts";
 import { BG_RGB, INK, JUDGE_INK, laneInk, rgb, type Ink } from "./palette.ts";
 import { KIND_MOTE, KIND_SHARD, Particles, Ripples } from "./particles.ts";
-import { fraction, fractionBar, measure, neon, setFont } from "./text.ts";
+import { fraction, measure, neon, setFont } from "./text.ts";
 
 type Popup = {
   x: number;
@@ -810,36 +810,66 @@ export class Scene {
 
       const rr = (isGate ? l.gateR : r) * scale;
       if (toTrail) {
+        // The trail buffer is half-resolution and smeared on purpose, and a
+        // gate note's job is to be READ. Its glow still goes in — the smear is
+        // what makes it a light source — but the number never does, so the one
+        // thing the child has to decode is never drawn through the blur.
         glow(ctx, ink, p.x, p.y, rr * 2.1, alpha * (isGate ? 0.5 : 0.34));
         continue;
       }
 
       glow(ctx, ink, p.x, p.y, rr * 1.6, alpha * 0.42);
+
+      if (isGate) {
+        /**
+         * A dark plate under the number, in `source-over`.
+         *
+         * Everything in this scene is additive light, which means a white
+         * numeral lands ON TOP of whatever the tunnel, the spectrum, the trail
+         * bloom and three other candidates' halos have already put there — and
+         * additive light only ever gets brighter, so contrast at the glyph goes
+         * to zero exactly where it is needed. Punching the plate out first
+         * gives the number something to be light AGAINST. It is the same trick
+         * an oscilloscope's graticule mask uses, and it keeps the neon.
+         */
+        ctx.globalCompositeOperation = "source-over";
+        ctx.fillStyle = `rgba(4,5,10,${(0.82 * alpha).toFixed(3)})`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, rr * 0.9, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.globalCompositeOperation = "lighter";
+      }
+
       const c = INK[ink];
       ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${alpha.toFixed(3)})`;
       ctx.lineWidth = isGate ? 2.5 : n.accent ? 2.4 : 1.8;
-      shape(ctx, n.div, p.x, p.y, rr, isGate);
 
-      if (isGate) {
-        const g = n.gate!;
-        const m = FRACTION_TOKEN.exec(g.label);
-        const inner = rr * 0.62;
-        if (m) {
-          fraction(ctx, Number(m[1]), Number(m[2]), p.x, p.y - inner * 0.06, inner * 0.84, "white", alpha);
-          fractionBar(
-            ctx,
-            Number(m[1]),
-            Number(m[2]),
-            p.x - rr * 0.72,
-            p.y + rr * (l.compact ? 0.72 : 0.78),
-            rr * 1.44,
-            l.compact ? 5 : 7,
-            "violet",
-            alpha * 0.9,
-          );
-        } else {
-          neon(ctx, g.label, p.x, p.y, inner, "white", { alpha });
-        }
+      if (!isGate) {
+        shape(ctx, n.div, p.x, p.y, rr);
+        continue;
+      }
+
+      const g = n.gate!;
+      const m = FRACTION_TOKEN.exec(g.label);
+      // The ring IS the second representation, and it costs no footprint: the
+      // circle is cut into `d` arcs with `n` of them lit, so the orb says what
+      // its number says without using colour and without a strip hanging off
+      // the bottom of it that the next candidate then has to dodge.
+      gateRing(ctx, p.x, p.y, rr, m ? Number(m[2]) : 0, m ? Number(m[1]) : 0, ink, alpha);
+
+      // The layout owns this size and gives it a floor; the ring was built to
+      // hold it. `scale` follows the pop animation so the number grows with its
+      // orb instead of rattling around inside it.
+      const want = l.gateLabelSize * scale;
+      const room = rr * 1.5;
+      if (m) {
+        const size = fitSize(ctx, [m[1]!, m[2]!], want, room);
+        fraction(ctx, Number(m[1]), Number(m[2]), p.x, p.y, size, "white", alpha);
+      } else {
+        const size = fitSize(ctx, [g.label], want, room);
+        // Bloom held down hard: at these sizes the halo stroke is a third of
+        // the glyph, and that halo is what "too blurry" was made of.
+        neon(ctx, g.label, p.x, p.y, size, "white", { alpha, bloom: 0.35 });
       }
     }
   }
@@ -1000,17 +1030,75 @@ export class Scene {
 
 // ------------------------------------------------------------------ helpers
 
-/** Subdivision shape. Positive div = per-beat; negative = |n| across the bar. */
-function shape(ctx: CanvasRenderingContext2D, div: number, x: number, y: number, r: number, gate: boolean): void {
-  if (gate) {
+/**
+ * The largest type size at which every one of `parts` fits inside `maxWidth`.
+ *
+ * The layout hands down a size a child can read; a three-digit answer or a
+ * denominator of 12 still has to live inside the ring. Measured rather than
+ * guessed, because the display font is whatever the platform actually resolved.
+ */
+export function fitSize(
+  ctx: CanvasRenderingContext2D,
+  parts: readonly string[],
+  want: number,
+  maxWidth: number,
+): number {
+  let widest = 0;
+  for (const p of parts) widest = Math.max(widest, measure(ctx, p, want));
+  if (widest <= maxWidth || widest <= 0) return want;
+  return want * (maxWidth / widest);
+}
+
+/**
+ * A gate candidate's orb: a ring cut into `d` arcs with `n` of them lit.
+ *
+ * Two representations of the same value, in one mark and one footprint — the
+ * number in the middle and the portion around the outside. `d = 0` (a label
+ * that is not a fraction, which is what the live `add` ladder serves) falls
+ * back to the plain double ring.
+ */
+function gateRing(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  d: number,
+  n: number,
+  ink: Ink,
+  alpha: number,
+): void {
+  const c = INK[ink];
+  ctx.beginPath();
+  ctx.arc(x, y, r * 0.82, 0, Math.PI * 2);
+  ctx.stroke();
+  if (!Number.isFinite(d) || d < 1 || d > 16 || n < 0) {
     ctx.beginPath();
     ctx.arc(x, y, r, 0, Math.PI * 2);
     ctx.stroke();
-    ctx.beginPath();
-    ctx.arc(x, y, r * 0.84, 0, Math.PI * 2);
-    ctx.stroke();
     return;
   }
+  const gap = Math.min(0.16, 1.1 / d);
+  const step = (Math.PI * 2) / d;
+  for (let i = 0; i < d; i++) {
+    const lit = i < n;
+    const a0 = -Math.PI / 2 + i * step + gap / 2;
+    const a1 = a0 + step - gap;
+    ctx.beginPath();
+    ctx.arc(x, y, r, a0, a1);
+    ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${((lit ? 1 : 0.22) * alpha).toFixed(3)})`;
+    ctx.lineWidth = lit ? 4 : 2;
+    ctx.stroke();
+  }
+}
+
+/**
+ * Subdivision shape. Positive div = per-beat; negative = |n| across the bar.
+ *
+ * Gate candidates do NOT come through here — they are drawn by `gateRing`,
+ * which says the same thing about their value that the number in the middle
+ * does.
+ */
+function shape(ctx: CanvasRenderingContext2D, div: number, x: number, y: number, r: number): void {
   if (div < 0) {
     // Polyrhythm: a ring with |div| spokes — you can count the beam.
     const n = -div;

--- a/dynawalla/games/pulse/src/stubHost.ts
+++ b/dynawalla/games/pulse/src/stubHost.ts
@@ -5,8 +5,11 @@
  * here except through `Host`.
  *
  * Every answer is a fraction strictly inside `(0, 1]` because in PULSE a value IS a
- * position inside one bar. Candidates are kept at least 1/12 of a bar apart so four
- * of them are legible side by side at 390px wide.
+ * position inside one bar. Distractors are kept at least 1/12 of a bar apart so the
+ * set handed over is not degenerate — but a twelfth is NOT a legibility guarantee and
+ * this file must not pretend to make one: at 390 px it is 33 px between candidates
+ * that are 74 px across. What the child actually sees is spaced by `gateFitFor`,
+ * which knows the viewport. This is a producer's hint; `buildGate` is the enforcer.
  */
 
 import type { Host, Question } from "./contract.ts";


### PR DESCRIPTION
Four defects the founder reported from real play on three devices. Each was measured before it was fixed, and each test was verified by deleting its fix.

## 1. The answers were illegible

Two separate causes wore one sentence of report.

**The numeral.** A gate candidate's number was derived from the orb it sits in — `gateR * 0.62 * 0.84` — and `gateR` is capped at `noteR * 1.7` with `noteR` capped at 17 px on any compact viewport. So the number was **15.1 px on a 320 px phone and 15.1 px on a 390 px one**, drawn additively, mid-scroll, under a `neon` bloom stroke of `size * 0.34` — a halo a third of the glyph's own size. That is what "too blurry" is made of.

**The spacing.** `gate.ts` documents `minGapDenom` as "a *display* constraint, not a mathematical one, so it is passed in rather than fixed: a 1372 px landscape bar can hold four orbs a twelfth apart, and a 544 px phone bar cannot". It was then passed in as the constant `12` from its one call site and never varied. The audit's lead was correct. Measured:

| viewport | numeral (before) | gap at 1/12 | candidate diameter | overlap |
|---|---|---|---|---|
| 320×568 | 15.1 px | 22.1 px | 57.8 px | **35.7 px** |
| 390×844 | 15.1 px | 34.0 px | 57.8 px | **23.8 px** |
| 768×1024 | 25.0 px | 46.1 px | 96.0 px | **49.9 px** |
| 844×390 | 15.1 px | 48.1 px | 57.8 px | **9.7 px** |

And the constraint binds in ordinary play: sweeping 5000 gates from the stub host, **the minimum observed gap was exactly 1/12** — the worst case was the normal case. Candidates overlapped on every viewport the game supports, including tablets.

**The fix** inverts the dependency: the numeral gets a floor (`GATE_LABEL_MIN = 22`, scaling to 40 on a tablet) and the ring is sized to hold it; `gateFitFor(layout)` turns a required pixel gap back into a fraction of the bar, because it is the only thing that knows both how wide a bar is in pixels and how wide a candidate is. The label also gets a punched-out dark plate in `source-over` before the additive pass — additive light only ever gets brighter, so contrast at the glyph was going to zero — and its bloom is held down.

| viewport | numeral after | gap after | diameter | clear air |
|---|---|---|---|---|
| 320×568 | **22.0 px** | 87.7 px | 61.6 px | +26.1 px |
| 390×844 | **26.5 px** | 100.0 px | 74.3 px | +25.7 px |
| 412×915 | **28.0 px** | 101.8 px | 78.4 px | +23.4 px |
| 768×1024 | **40.0 px** | 136.3 px | 112.0 px | +24.3 px |
| 1024×768 | **40.0 px** | 134.3 px | 112.0 px | +22.3 px |
| 844×390 | **26.5 px** | 94.7 px | 74.3 px | +20.5 px |

The pie-slice glyph that used to hang below the orb is gone; the ring itself is now cut into `d` arcs with `n` lit, so the second representation costs no footprint for the next candidate to dodge.

## 2. It started too hard

`#656` and `#662` were read first and are untouched: stage advance still requires cleared gates, `GATE_READ_SEC` is still 6 and still tempo-independent.

What remained was the opening state. Same shape as ARENA: the only call site passed `maxCandidates: 4`, unconditionally, so **the first question a child ever saw carried 4 candidates — 1 right and 3 wrong — at ~20 s in, on stage 0.** Measured opening, before and after:

```
before   bar 7  stage 0  4 candidates, 3 wrong
after    bar 7  stage 0  2 candidates, 1 wrong
```

`candidatesForStage` makes the count part of the escalation (2 → 3 → 4), and the viewport ANDs its own ceiling on top. One wrong turning is still a real question here, because a candidate's *position* is its value — the child strikes at a moment, they do not pick the surviving option. A test asserts the widest gate deep in the run is strictly wider than the opening's, so "gentle" cannot quietly become "flattened".

## 3. Audio and picture disagreed on a Chromebook

For a rhythm game this is correctness. The investigation found the visual was *already* derived from `AudioContext.currentTime` and compensated by `outputLatency` — the textbook two-independent-clocks bug was not there. Two real ones were.

**`currentTime` is not continuous.** It is the timestamp of the last render block the audio thread published to the main thread, so it advances in steps the size of the output callback and holds still in between: 2.7 ms where a browser manages a 128-frame quantum, 10–20 ms where it does not, which describes a Chromebook. Any read is uniformly 0..q too small. The old code read it raw and **independently twice** — once a frame for the picture, and again inside `perfToHeard` on every tap, which re-derived its own audio/`performance.now()` offset. Two reads, two unrelated errors, and the magnitude of both is a property of the device. On a 20 ms callback that is a third of the ±55 ms PERFECT window.

**Display latency was never compensated at all.** `requestAnimationFrame` runs at the start of a frame and what it paints reaches the glass a frame later, so a field positioned at "the music as it sounds right now" is on screen showing where the music *was* — 16 ms at 60 Hz, ~33 ms on a display that is not keeping up. Audio latency was compensated and this was not, which is exactly why it looked fine on fast hardware.

**The fix** is one model: `audioTime = perfTime + offset`, with `offset` estimated as the running maximum of `currentTime - perfNow` (the trick that recovers what rounding-down threw away), decaying at 500 ppm so genuine rate drift is tracked, and re-anchoring outright when a suspended context freezes the audio clock. Audio stays the master; the picture is derived from it and pushed forward by the measured frame period; input goes through the same function.

Measured headlessly through the real transport with `dev/fakeAudio.ts` extended to simulate a coarse output callback, plus a hand-driven `performance.now()`:

| measurement (20 ms callback) | before | after |
|---|---|---|
| error in a raw `currentTime` read | 19.9 ms | — |
| error in the transport's answer | 19.9 ms | **2.3 ms** (1.0 ms typical) |
| 5 ms between a frame and the tap aimed at it, as reported | up to **20.0 ms** (15.0 ms error) | **< 1.5 ms** |
| judged-delta band for strikes aimed at the same drawn position | **31.4 ms** | **16.7 ms** — one 60 Hz frame, all it can honestly be |

`?perf` now shows `lead` and `clock err` so the two numbers are visible on the device that has the problem.

## 4. Pause and mute could not be touched on Android

Two things were wrong and only one is about the safe rect. The buttons were **30 px** squares (34 on a tablet) — under the 44 px minimum touch target — sitting 12 px above the bottom of the safe rect. And the safe rect does not describe Android's gesture strip: `env(safe-area-inset-bottom)` reports the *display cutout*, while the thing that eats a tap is the gesture-navigation handle, and plenty of Android devices report a bottom inset of **0** while still claiming the bottom ~24 px. Both controls were drawn correctly inside the safe rect and still could not be pressed.

Both are 44 px now, and their bottom edge is held clear of the *raw canvas* edge by `GESTURE_STRIP` as well as clear of the reported inset, whichever binds harder:

| viewport | drawn | hit target | inside safe rect | clearance from canvas bottom |
|---|---|---|---|---|
| 320×568 no insets | 44 px | 56 px | yes | 36 px |
| 390×844 notched | 44 px | 56 px | yes | 46 px |
| **412×915 android, bottom inset 0** | 44 px | 56 px | yes | **36 px** |
| 412×915 android, gesture insets | 44 px | 56 px | yes | 36 px |
| 768×1024 tablet | 44 px | 56 px | yes | 40 px |
| 844×390 landscape | 44 px | 56 px | yes | 36 px |

The test asserts size, containment in the safe rect, clearance from the gesture strip, and that `hitButton` agrees with the drawn square at its centre and all four corners — at every viewport above, **including the zero-bottom-inset Android case, which is the one that broke**.

## Removed-fix verification

Seven authors shipped vacuous tests here in the last day, so every assertion was checked by deleting its fix. Exact messages:

**1. numeral floor deleted** (`gateR`/label back to the old derivation)
```
not ok 38 - a gate candidate's number is big enough to read at 320×568 small phone
  error: '320×568 small phone/1 lanes: the answer is drawn at 15.1 px, below the 22 px floor'
not ok 40 - a gate candidate's number is big enough to read at 390×844 notched phone
  error: '390×844 notched phone/1 lanes: the answer is drawn at 15.1 px, below the 22 px floor'
```

**2. per-viewport `GateFit` deleted** (back to the hardcoded 4 / 12)
```
not ok 39 - two gate candidates cannot overlap at 320×568 small phone
  error: '320×568 small phone/1 lanes: candidates 1/12 of a bar apart are 21.9 px apart
          and 61.6 px across — they overlap by 39.7 px'
not ok 41 - two gate candidates cannot overlap at 390×844 notched phone
  error: '390×844 notched phone/1 lanes: candidates 1/12 of a bar apart are 33.3 px apart
          and 74.3 px across — they overlap by 40.9 px'
not ok 9 - no two candidates of a real gate overlap on a real screen
  error: '320×568/1 lanes: the closest two candidates were 21.9 px apart and are 61.6 px
          across — overlapping by 39.7 px. [3/4 − 1/6 → 1/2 7/12 2/3 5/6]'
```

**3. touch-target + gesture-strip fix deleted**
```
not ok 52 - pause and mute can be touched at 320×568 small phone
  error: '320×568 small phone: pause is 30 px; 44 px is the minimum touch target'
not ok 54 - pause and mute can be touched at 412×915 android, no reported bottom inset
  error: '412×915 android, no reported bottom inset: pause is 30 px; 44 px is the minimum touch target'
```

**4. opening-density fix deleted** (`candidatesForStage` always 4)
```
not ok 10 - the first question a child ever sees is sparse
  error: the first question a child is ever asked put 2 wrong answers on the screen at once
         2 !== 1
not ok 11 - density is part of the escalation, not a constant
  error: 4 !== 2
not ok 12 - a child who is climbing IS given more to discriminate between
```
(3 wrong before the viewport fit was also introduced; 2 with it, and the assertion is 1.)

**5. one-clock fix deleted** (`engine.now()` reads `ctx.currentTime` raw, input re-derives its own offset)
```
not ok 3 - a strike aimed at the drawn line is judged there, on a coarse clock
  error: "strikes aimed at the same drawn position were judged across a 31.4 ms band on a
          20 ms audio callback; one 60 Hz frame is 16.7 ms and the rest is the audio clock's
          quantisation leaking into the judgment"
not ok 5 - transport time advances by what actually elapsed, not by a whole callback
  error: '5 ms between the frame and the tap aimed at it was reported as far as 20.0 ms —
          off by 15.0 ms, which is the output callback, not the play'
```

**6. visual-lead compensation deleted** (`shown()` returns `heard()`)
```
not ok 4 - the picture is pushed forward to meet the display, not left behind it
  error: "the drawn moment must lead the heard moment by exactly the display's latency"
```

An earlier draft of test 5 was itself vacuous — it compared the picture and a tap *at the same instant*, so both reads landed on the same rounded `currentTime` and the two errors cancelled. It passed with the fix deleted. It now advances the clock between the two reads, which is what a pointer event actually does.

## Verification

- `npm test` **5×: 129 tests, 129 pass, 0 fail** every run
- `npm run tsc` clean
- `npm run build:pack` clean, 90.95 kB
- `pack.json` deliberately not staged

## Where the next contributor adds odd time signatures and randomised openings

This did not build the founder's "more types of sounds and beats and even odd time signatures … more random what you start with", but it touched the layer, so:

- **Time signatures** — `BEATS_PER_BAR` in `game/chart.ts` is a module constant assumed by `Timeline`, `gridSlots`, `Placer` and the gate's `pos → beat` mapping. Making it per-stage means moving it onto `StageSpec` and threading it through those five; `stages.ts` already carries `poly: { lane, perBar }` for 3-over-4 and 5-over-4, which is the same idea one level down and is the natural place to generalise from. `layout.ts` needs nothing — the field is one *bar*, whatever a bar is.
- **Randomised openings** — `stages.ts` is a frozen `STAGES` array plus `stageAt(index)` for the endless loop. A fresh opening is a seeded permutation of the early entries, or a `stageAt(0)` that picks from several stage-0 variants; the run seed (`Run.seed`) already reaches `barNotes` and would carry it with no new plumbing. Note that `phraseCache` in `chart.ts` is keyed on `runSeed|stageId|phrase`, so variants must differ in `id` or they will share cached bars.
- **New voices** — `audio/voices.ts` and the `LAYER_ORDER` progression in `audio/music.ts`; layers are earned per correct gate in `Run.earnLayer`.

## What only a device can confirm

- Whether 22 px is genuinely enough on a real 320 px phone in a lit room. The floor is a judgement call backed by geometry, not by a child.
- The actual size of the Chromebook's output callback, and whether the residual ~1 ms model error is below the perceptual floor there. The harness simulates 20 ms; the real number is visible on device via `?perf` (`clock err`).
- Whether `GESTURE_STRIP = 24` clears the specific Android device's gesture zone. It is the handle's nominal height and the effective clearance is 36–40 px, but gesture insets vary by OEM and this is the one number here that a device could still disprove.
- That the dark plate behind the numeral reads as intended rather than as a hole in the neon.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb