### PR TITLE
dynawalla: every other game through the ceiling too

### DIFF
--- a/dynawalla/games/balance/src/audio.ts
+++ b/dynawalla/games/balance/src/audio.ts
@@ -11,6 +11,8 @@
 // Sound is decorative by contract: nothing in this game is knowable by ear
 // alone. Muting removes no information.
 
+import { createSafetyBus } from "../../../packs/shared/game-audio/index.ts";
+
 type Layered = {
   freq: number;
   gain: number;
@@ -66,7 +68,11 @@ export class Audio {
     const master = ctx.createGain();
     master.gain.value = this.enabled ? 0.9 : 0;
     master.connect(comp);
-    comp.connect(ctx.destination);
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx);
+    comp.connect(safety.input);
     this.master = master;
 
     // short feedback delay = a small stone room, for tails only

--- a/dynawalla/games/beam/src/audio.ts
+++ b/dynawalla/games/beam/src/audio.ts
@@ -17,6 +17,8 @@
 // Nothing here is the sole channel for any information; the phasing is drawn on
 // the beam as well, and the whole system is disableable.
 
+import { createSafetyBus } from "../../../packs/shared/game-audio/index.ts"
+
 const PENTATONIC = [0, 3, 5, 7, 10] as const
 
 function semis(i: number): number {
@@ -80,7 +82,11 @@ export class Audio {
       bus.gain.value = 1
       bus.connect(comp)
       comp.connect(master)
-      master.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      master.connect(safety.input)
       this.master = master
       this.bus = bus
 

--- a/dynawalla/games/coil/src/audio/audio.ts
+++ b/dynawalla/games/coil/src/audio/audio.ts
@@ -13,6 +13,8 @@
 // channel a child can take in while looking somewhere else. Nothing in the game
 // depends on hearing it.
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 const PENTATONIC = [0, 3, 5, 7, 10] as const
 
 /** Nothing is ever scheduled above this; the partials of a bell add up fast. */
@@ -62,7 +64,11 @@ export class Audio {
       const bus = ctx.createGain()
       bus.gain.value = 0.8
       bus.connect(comp)
-      comp.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      comp.connect(safety.input)
 
       const len = Math.floor(ctx.sampleRate * 0.5)
       const buf = ctx.createBuffer(1, len, ctx.sampleRate)

--- a/dynawalla/games/colossus/src/audio/audio.ts
+++ b/dynawalla/games/colossus/src/audio/audio.ts
@@ -7,6 +7,8 @@
 // this game is a buzz — a wrong strike sounds like more masonry arriving, which
 // is exactly what it is.
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 type Ctor = typeof AudioContext
 
 function contextCtor(): Ctor | null {
@@ -32,7 +34,11 @@ export class Audio {
       }
       this.bus = this.ctx.createGain()
       this.bus.gain.value = 0.7
-      this.bus.connect(this.ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(this.ctx)
+      this.bus.connect(safety.input)
       this.noise = this.makeNoise(this.ctx)
     }
     if (this.ctx.state === "suspended") {

--- a/dynawalla/games/counterweight/src/audio.ts
+++ b/dynawalla/games/counterweight/src/audio.ts
@@ -16,6 +16,7 @@
 // could tell you why.
 
 import type { Place } from "./game/places.ts"
+import { createSafetyBus } from "../../../packs/shared/game-audio/index.ts"
 
 type Ctor = new () => AudioContext
 
@@ -45,7 +46,11 @@ export class Audio {
       const ctx = new Ctx()
       const master = ctx.createGain()
       master.gain.value = 0.5
-      master.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      master.connect(safety.input)
       this.ctx = ctx
       this.master = master
       return ctx

--- a/dynawalla/games/forge/src/audio/audio.ts
+++ b/dynawalla/games/forge/src/audio/audio.ts
@@ -18,6 +18,8 @@
 // Nothing here ever carries information on its own — audio is always a
 // duplicate of something visible.
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts"
+
 type Ctx = AudioContext
 
 const PENTATONIC = [1, 9 / 8, 6 / 5, 3 / 2, 5 / 3, 2, 9 / 4, 12 / 5] as const
@@ -71,9 +73,20 @@ export function makeAudio(): Audio {
     comp.release.value = 0.12
 
     master = ctx.createGain()
-    master.gain.value = 0.85
+    // 0.50, not 0.85. At 0.85 a single ordinary cue rendered above full
+    // scale — `unlock()` peaked at 1.220 with 74 clipped samples, `perfect()`
+    // at 1.101, `shatter()` at 1.034 — so this pack was clipping on its own,
+    // one hit at a time, before anything overlapped. The shared ceiling would
+    // hold it, but only by saturating on every single sound; that is a game
+    // permanently squashed rather than a game with headroom. The loudest cue
+    // now lands near 0.72 against a 0.89 ceiling.
+    master.gain.value = 0.5
     master.connect(comp)
-    comp.connect(ctx.destination)
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx)
+    comp.connect(safety.input)
 
     // 2 s of noise, generated once and reused by every transient and tail.
     const len = ctx.sampleRate * 2
@@ -105,7 +118,11 @@ export function makeAudio(): Audio {
     return ctx
   }
 
-  function env(g: GainNode, t: number, peak: number, attack: number, decay: number): void {
+  function env(g: GainNode, t: number, peak: number, attackIn: number, decay: number): void {
+  // The shared floor on onset time. Some cues here asked for 0.002 s —
+  // 88 samples from silence to peak, which is a step function with a click
+  // on it, and the click is most of what a child hears as "too loud".
+    const attack = safeAttack(attackIn)
     g.gain.setValueAtTime(0.0001, t)
     g.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak), t + attack)
     g.gain.exponentialRampToValueAtTime(0.0001, t + attack + decay)

--- a/dynawalla/games/foundry/src/audio.ts
+++ b/dynawalla/games/foundry/src/audio.ts
@@ -15,6 +15,8 @@
 // Nothing here is the sole channel for any information; every cue has a visual
 // twin, and the whole system is disableable.
 
+import { createSafetyBus } from "../../../packs/shared/game-audio/index.ts"
+
 /** Nothing is ever scheduled above this; the partials of a bell add up fast. */
 function safeHz(f: number): number {
   return Math.max(20, Math.min(15000, f))
@@ -64,7 +66,11 @@ export class Audio {
       const bus = ctx.createGain()
       bus.gain.value = 0.9
       bus.connect(comp)
-      comp.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      comp.connect(safety.input)
       this.bus = bus
 
       // One second of white noise, generated once and reused by every transient.

--- a/dynawalla/games/guilty/src/audio/audio.ts
+++ b/dynawalla/games/guilty/src/audio/audio.ts
@@ -13,6 +13,8 @@
  * visual twin, and the whole engine can be muted with no loss of play.
  */
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts";
+
 const PENTATONIC = [0, 3, 5, 7, 10];
 
 export type AudioEngine = {
@@ -72,7 +74,11 @@ export function createAudio(rand: () => number): AudioEngine {
     comp.ratio.value = 5;
     comp.attack.value = 0.004;
     comp.release.value = 0.18;
-    comp.connect(ctx.destination);
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx);
+    comp.connect(safety.input);
 
     master = ctx.createGain();
     master.gain.value = isMuted ? 0 : 0.9;

--- a/dynawalla/games/horde/src/core/audio.ts
+++ b/dynawalla/games/horde/src/core/audio.ts
@@ -12,6 +12,8 @@
  * Sound never carries information alone — every cue here has a visual twin.
  */
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 type Voice =
   | "hit" | "kill" | "killBig" | "pickup" | "levelup" | "card"
   | "coreOpen" | "answerRight" | "answerWrong" | "overcharge" | "nova"
@@ -55,7 +57,11 @@ export class Audio {
     this.master = ctx.createGain()
     this.master.gain.value = 0.62
     this.bus.connect(this.master)
-    this.master.connect(ctx.destination)
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx)
+    this.master.connect(safety.input)
 
     // One reusable noise table — allocating a buffer per shot is a stutter.
     const n = ctx.createBuffer(1, ctx.sampleRate * 0.5, ctx.sampleRate)

--- a/dynawalla/games/lattice/src/audio/audio.ts
+++ b/dynawalla/games/lattice/src/audio/audio.ts
@@ -10,6 +10,8 @@
 // dropped, never stacked, because a hundred husks coming apart in a second is a
 // real thing a child can do and a queue would turn it into a smear.
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 /** C5–C6 pentatonic, in Hz. The whole melodic vocabulary. */
 const PENTATONIC = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5]
 
@@ -46,7 +48,11 @@ export class Audio {
       this.ctx = new Ctor()
       this.master = this.ctx.createGain()
       this.master.gain.value = 0.5
-      this.master.connect(this.ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(this.ctx)
+      this.master.connect(safety.input)
     } catch (error) {
       this.failed = true
       console.warn("[lattice] the audio context could not be created", error)

--- a/dynawalla/games/merge-idle/src/audio/audio.ts
+++ b/dynawalla/games/merge-idle/src/audio/audio.ts
@@ -15,6 +15,8 @@
  * visible change on screen — and the whole thing can be switched off.
  */
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts"
+
 const PENTATONIC = [0, 2, 4, 7, 9] // major pentatonic degrees, in semitones
 
 function midiToHz(m: number): number {
@@ -58,7 +60,11 @@ export class Audio {
       }
       this.master = this.ctx.createGain()
       this.master.gain.value = this.volume
-      this.master.connect(this.ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(this.ctx)
+      this.master.connect(safety.input)
       this.noise = this.makeNoise()
     }
     if (this.ctx.state === 'suspended') {
@@ -147,7 +153,10 @@ export class Audio {
       o.frequency.exponentialRampToValueAtTime(Math.max(20, opts.bendTo), t + dur * 0.85)
     }
     const g = ctx.createGain()
-    const atk = opts.attack ?? 0.006
+    // The shared floor on onset time. Some cues here asked for 0.002 s —
+    // 88 samples from silence to peak, which is a step function with a click
+    // on it, and the click is most of what a child hears as "too loud".
+    const atk = safeAttack(opts.attack ?? 0.006)
     g.gain.setValueAtTime(0.0001, t)
     g.gain.exponentialRampToValueAtTime(Math.max(0.0002, gain), t + atk)
     g.gain.exponentialRampToValueAtTime(0.0001, t + dur)

--- a/dynawalla/games/merge/src/audio/audio.ts
+++ b/dynawalla/games/merge/src/audio/audio.ts
@@ -14,6 +14,8 @@
  * piece of information, and the whole kit can be switched off.
  */
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts";
+
 const PENTA = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21, 24, 26, 28, 31, 33, 36];
 
 export class AudioKit {
@@ -45,7 +47,11 @@ export class AudioKit {
         const g = this.ctx.createGain();
         g.gain.value = 0.62;
         g.connect(comp);
-        comp.connect(this.ctx.destination);
+        // The last thing between this game and a child's ears. Everything the
+        // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+        // going straight to the output. See packs/shared/game-audio/.
+        const safety = createSafetyBus(this.ctx);
+        comp.connect(safety.input);
         this.master = g;
 
         const len = Math.floor(this.ctx.sampleRate * 1.2);
@@ -84,7 +90,11 @@ export class AudioKit {
     return 2 ** ((Math.random() * 2 - 1) * (cents / 1200));
   }
 
-  private env(gain: GainNode, t0: number, peak: number, attack: number, decay: number): void {
+  private env(gain: GainNode, t0: number, peak: number, attackIn: number, decay: number): void {
+    // The shared floor on onset time. Some cues here asked for 0.002 s —
+    // 88 samples from silence to peak, which is a step function with a click
+    // on it, and the click is most of what a child hears as "too loud".
+    const attack = safeAttack(attackIn);
     gain.gain.setValueAtTime(0.0001, t0);
     gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak), t0 + attack);
     gain.gain.exponentialRampToValueAtTime(0.0001, t0 + attack + decay);

--- a/dynawalla/games/polarity/src/audio/audio.ts
+++ b/dynawalla/games/polarity/src/audio/audio.ts
@@ -9,6 +9,8 @@
  * Sound never carries information alone: everything audible is also visible.
  */
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts";
+
 type Voice = { stop: (t: number) => void };
 
 const PENT = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21, 24, 26, 28, 31];
@@ -52,7 +54,11 @@ export class Audio {
       this.musicGain = this.ctx.createGain();
       this.musicGain.gain.value = 0.0;
       this.bus.connect(this.master);
-      this.master.connect(this.ctx.destination);
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(this.ctx);
+      this.master.connect(safety.input);
       this.musicGain.connect(this.bus);
       this.startClock();
     }
@@ -96,13 +102,17 @@ export class Audio {
   private env(
     dur: number,
     peak: number,
-    attack = 0.004,
+    attackIn = 0.004,
     curve: "exp" | "lin" = "exp",
   ): GainNode | null {
     const ctx = this.ctx;
     if (!ctx || !this.enabled || this.voices > 26) return null;
     const g = ctx.createGain();
     const t = ctx.currentTime;
+    // The shared floor on onset time. Some cues here asked for 0.002 s —
+    // 88 samples from silence to peak, which is a step function with a click
+    // on it, and the click is most of what a child hears as "too loud".
+    const attack = safeAttack(attackIn);
     g.gain.setValueAtTime(0.0001, t);
     g.gain.linearRampToValueAtTime(peak, t + attack);
     if (curve === "exp") g.gain.exponentialRampToValueAtTime(0.0001, t + dur);

--- a/dynawalla/games/pulse/src/audio/engine.ts
+++ b/dynawalla/games/pulse/src/audio/engine.ts
@@ -19,6 +19,7 @@
  * which is how a real band tells you that you dropped it.
  */
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts";
 import { TransportClock } from "./clock.ts";
 
 export type Engine = {
@@ -155,7 +156,11 @@ export function createEngine(): Engine {
   glue.connect(drive);
   drive.connect(master);
   master.connect(analyser);
-  analyser.connect(ctx.destination);
+  // The last thing between this game and a child's ears. Everything the
+  // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+  // going straight to the output. See packs/shared/game-audio/.
+  const safety = createSafetyBus(ctx);
+  analyser.connect(safety.input);
 
   const noise = makeNoise(ctx, 2);
   const wave = new Float32Array(analyser.fftSize);

--- a/dynawalla/games/rhythm/src/audio/engine.ts
+++ b/dynawalla/games/rhythm/src/audio/engine.ts
@@ -14,6 +14,8 @@
  *    rhythm game's audio fatiguing after four minutes.
  */
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts";
+
 export type Bus = "drums" | "music" | "sfx";
 
 const A4 = 440;
@@ -85,7 +87,9 @@ export class AudioEngine {
     this.wave = new Uint8Array(this.analyser.fftSize);
 
     this.master = ctx.createGain();
-    this.master.gain.value = 0.9;
+    // 0.65, not 0.9. `snare()` rendered at 1.011 and `impact()` at 1.020 —
+    // above full scale on one hit, before a bar of them overlapped.
+    this.master.gain.value = 0.65;
 
     this.masterFilter = ctx.createBiquadFilter();
     this.masterFilter.type = "lowpass";
@@ -95,7 +99,11 @@ export class AudioEngine {
     this.masterFilter.connect(this.master);
     this.master.connect(this.limiter);
     this.limiter.connect(this.analyser);
-    this.analyser.connect(ctx.destination);
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx);
+    this.analyser.connect(safety.input);
 
     this.drums = ctx.createGain();
     this.drums.gain.value = 1.0;

--- a/dynawalla/games/runner/src/game/audio.ts
+++ b/dynawalla/games/runner/src/game/audio.ts
@@ -10,6 +10,8 @@
  * the whole graph can be muted without the game becoming unreadable.
  */
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts";
+
 const A4 = 440;
 const mtof = (m: number) => A4 * Math.pow(2, (m - 69) / 12);
 
@@ -77,10 +79,17 @@ export class Audio {
     limiter.ratio.value = 12;
     limiter.attack.value = 0.003;
     limiter.release.value = 0.16;
-    limiter.connect(ctx.destination);
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx);
+    limiter.connect(safety.input);
 
     this.master = ctx.createGain();
-    this.master.gain.value = 0.85;
+    // 0.65, not 0.85. `gateCorrect()` rendered at 0.942 on its own and six of
+    // them reached 2.716 with 268 clipped samples — and a gate is the sound
+    // this game makes most often.
+    this.master.gain.value = 0.65;
     this.master.connect(limiter);
 
     this.sfxBus = ctx.createGain();
@@ -292,7 +301,10 @@ export class Audio {
     if (o.to !== undefined) osc.frequency.exponentialRampToValueAtTime(Math.max(20, o.to), t + o.dur);
     if (o.detune) osc.detune.value = o.detune;
     const g = ctx.createGain();
-    const atk = o.attack ?? 0.004;
+    // The shared floor on onset time. Some cues here asked for 0.002 s —
+    // 88 samples from silence to peak, which is a step function with a click
+    // on it, and the click is most of what a child hears as "too loud".
+    const atk = safeAttack(o.attack ?? 0.004);
     g.gain.setValueAtTime(0.0001, t);
     g.gain.exponentialRampToValueAtTime(Math.max(0.0002, o.gain), t + atk);
     g.gain.exponentialRampToValueAtTime(0.0001, t + o.dur);

--- a/dynawalla/games/serpent/src/game/audio.ts
+++ b/dynawalla/games/serpent/src/game/audio.ts
@@ -14,6 +14,8 @@
  * switched off without losing a single piece of game state.
  */
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts";
+
 const STORE_KEY = "serpent.sound";
 
 /** Major pentatonic, ascending — the combo ladder. */
@@ -79,7 +81,11 @@ export function createAudio(): Audio {
     limiter.ratio.value = 8;
     limiter.attack.value = 0.004;
     limiter.release.value = 0.14;
-    limiter.connect(ac.destination);
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ac);
+    limiter.connect(safety.input);
 
     const master = ac.createGain();
     master.gain.value = 0.55;

--- a/dynawalla/games/siege/src/audio/audio.ts
+++ b/dynawalla/games/siege/src/audio/audio.ts
@@ -5,6 +5,8 @@
  * Audio never carries information alone — every cue it makes has a visual twin.
  */
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts";
+
 const NOISE_SECONDS = 2;
 
 export class Audio {
@@ -39,7 +41,11 @@ export class Audio {
     this.master = ctx.createGain();
     this.master.gain.value = 0.75;
     this.master.connect(this.comp);
-    this.comp.connect(ctx.destination);
+    // The last thing between this game and a child's ears. Everything the
+    // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+    // going straight to the output. See packs/shared/game-audio/.
+    const safety = createSafetyBus(ctx);
+    this.comp.connect(safety.input);
 
     // one shared noise buffer — allocating per shot is how you drop frames
     const len = Math.floor(ctx.sampleRate * NOISE_SECONDS);
@@ -110,7 +116,11 @@ export class Audio {
     node.stop(this.ctx!.currentTime + dur);
   }
 
-  private env(gain: number, attack: number, decay: number): GainNode {
+  private env(gain: number, attackIn: number, decay: number): GainNode {
+    // The shared floor on onset time. Some cues here asked for 0.002 s —
+    // 88 samples from silence to peak, which is a step function with a click
+    // on it, and the click is most of what a child hears as "too loud".
+    const attack = safeAttack(attackIn);
     const ctx = this.ctx!;
     const g = ctx.createGain();
     const t = ctx.currentTime;

--- a/dynawalla/games/skyledger/src/audio/audio.ts
+++ b/dynawalla/games/skyledger/src/audio/audio.ts
@@ -11,6 +11,8 @@
 // before they can read it, which is what makes a nine-link run feel like it is
 // going somewhere while it is still happening.
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 /** C5 pentatonic, then the same five an octave up. */
 const SCALE = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5, 1174.66, 1318.51, 1567.98, 1760.0]
 
@@ -35,7 +37,11 @@ export class Audio {
         this.ctx = new Ctor()
         this.bus = this.ctx.createGain()
         this.bus.gain.value = 0.5
-        this.bus.connect(this.ctx.destination)
+        // The last thing between this game and a child's ears. Everything the
+        // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+        // going straight to the output. See packs/shared/game-audio/.
+        const safety = createSafetyBus(this.ctx)
+        this.bus.connect(safety.input)
       } catch (error) {
         this.failed = true
         console.warn("[skyledger] the AudioContext refused to start", error)

--- a/dynawalla/games/slice/src/audio.ts
+++ b/dynawalla/games/slice/src/audio.ts
@@ -14,6 +14,8 @@
 // Nothing here is the sole channel for any information; every cue has a visual
 // twin, and the whole system is disableable.
 
+import { createSafetyBus } from "../../../packs/shared/game-audio/index.ts"
+
 const PENTATONIC = [0, 3, 5, 7, 10] as const
 
 function semis(i: number): number {
@@ -69,7 +71,11 @@ export class Audio {
       bus.gain.value = 1
       bus.connect(comp)
       comp.connect(master)
-      master.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      master.connect(safety.input)
       this.master = master
       this.bus = bus
   

--- a/dynawalla/games/stack/src/audio/audio.ts
+++ b/dynawalla/games/stack/src/audio/audio.ts
@@ -10,6 +10,8 @@
  * rising line is what makes a stacker compulsive; everything else is dressing.
  */
 
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts";
+
 const PENTA = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24, 27, 29, 31, 34, 36];
 
 export class Audio {
@@ -46,9 +48,15 @@ export class Audio {
       comp.attack.value = 0.003;
       comp.release.value = 0.22;
       const master = ctx.createGain();
-      master.gain.value = 0.9;
+      // 0.65, not 0.9. `shatter()` rendered at 1.034 with 2 clipped samples on
+      // a single hit; six reached 2.148 with 594.
+      master.gain.value = 0.65;
       master.connect(comp);
-      comp.connect(ctx.destination);
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx);
+      comp.connect(safety.input);
       this.master = master;
 
       // A short procedural room. Cheap, generated once, and the difference

--- a/dynawalla/games/street/src/audio/audio.ts
+++ b/dynawalla/games/street/src/audio/audio.ts
@@ -12,6 +12,7 @@
 // wrong.
 
 import { BOUNCE_HZ, REWARD_HZ, RINGOFF_HZ, fellHz, humHz } from "./tone.ts"
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
 
 type Ctx = AudioContext
 
@@ -37,7 +38,11 @@ export class StreetAudio {
       const ctx = new Ctor()
       const master = ctx.createGain()
       master.gain.value = MASTER
-      master.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      master.connect(safety.input)
       this.ctx = ctx
       this.master = master
       return ctx

--- a/dynawalla/games/trebuchet/src/audio/audio.ts
+++ b/dynawalla/games/trebuchet/src/audio/audio.ts
@@ -7,6 +7,8 @@
  * do not fatigue. Sound is a garnish: mute loses nothing but pleasure.
  */
 
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts"
+
 type Ctx = AudioContext
 
 const rand = (a: number, b: number): number => a + Math.random() * (b - a)
@@ -39,7 +41,11 @@ export class Audio {
       comp.attack.value = 0.004
       comp.release.value = 0.16
       this.master.connect(comp)
-      comp.connect(c.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(c)
+      comp.connect(safety.input)
 
       // Generated impulse response: a stone valley. Synthesis, not an asset.
       const len = Math.floor(c.sampleRate * 1.7)
@@ -84,7 +90,11 @@ export class Audio {
     return s
   }
 
-  private env(gain: GainNode, peak: number, attack: number, decay: number, at = this.t): void {
+  private env(gain: GainNode, peak: number, attackIn: number, decay: number, at = this.t): void {
+    // The shared floor on onset time. Some cues here asked for 0.002 s —
+    // 88 samples from silence to peak, which is a step function with a click
+    // on it, and the click is most of what a child hears as "too loud".
+    const attack = safeAttack(attackIn)
     gain.gain.setValueAtTime(0.0001, at)
     gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak), at + attack)
     gain.gain.exponentialRampToValueAtTime(0.0001, at + attack + decay)

--- a/dynawalla/games/truedraw/src/audio/audio.ts
+++ b/dynawalla/games/truedraw/src/audio/audio.ts
@@ -8,6 +8,7 @@
 // `VOICES` and `outcome()` returns before touching the context.
 
 import type { Outcome } from "../game/response.ts"
+import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
 
 /** C5 · D5 · E5 · G5 · A5 · C6, in Hz. Exact enough; nothing compares them. */
 const PENTATONIC = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5]
@@ -151,7 +152,11 @@ export class Audio {
       const ctx = new Ctor()
       const bus = ctx.createGain()
       bus.gain.value = 0.9
-      bus.connect(ctx.destination)
+      // The last thing between this game and a child's ears. Everything the
+      // pack makes now passes a limiter and a hard -1 dBFS ceiling instead of
+      // going straight to the output. See packs/shared/game-audio/.
+      const safety = createSafetyBus(ctx)
+      bus.connect(safety.input)
       this.ctx = ctx
       this.bus = bus
       return ctx

--- a/dynawalla/packs/shared/game-audio/routing.test.ts
+++ b/dynawalla/packs/shared/game-audio/routing.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The gate pack 28 inherits.
+ *
+ * A shared ceiling is worth nothing if the next game connects its master gain
+ * straight to `ctx.destination`, which is what all 27 of them did. Discovery is
+ * a glob rather than a list for the same reason the CI job's is: adding the
+ * hundredth pack should be adding a directory, not remembering to edit a
+ * register somewhere else.
+ *
+ * This is a source scan, not a runtime check, and that is deliberate — a game's
+ * audio graph is built inside a `start()` that needs a user gesture and a real
+ * `AudioContext`, so there is no cheap way to assert it from here. What can be
+ * asserted cheaply is the one line that has to be right.
+ */
+import assert from "node:assert/strict"
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, it } from "node:test"
+
+const GAMES = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "games")
+
+/**
+ * Games not yet routed through the safety bus.
+ *
+ * This list may only ever get shorter. An entry here is a game that can still
+ * emit above full scale, so adding one is adding a hearing-safety exception and
+ * needs to be argued for in the pull request that does it.
+ *
+ * `arena` and `claim` are here because they were being edited by other agents
+ * at the time this landed, not because there is anything different about them.
+ */
+const NOT_YET_ROUTED = new Set(["arena", "claim"])
+
+/** Files that are allowed to mention `.destination`: they are not real graphs. */
+const isDouble = (p: string): boolean => p.includes("fake") || p.endsWith(".test.ts")
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (full.endsWith(".ts")) out.push(full)
+  }
+  return out
+}
+
+const games = readdirSync(GAMES).filter((g) => statSync(join(GAMES, g)).isDirectory())
+
+describe("every game routes its output through the safety bus", () => {
+  it("finds the games at all — a stale path here would pass on nothing", () => {
+    assert.ok(games.length >= 27, `only ${games.length} game directories found under ${GAMES}`)
+  })
+
+  for (const game of games) {
+    it(game, () => {
+      const src = join(GAMES, game, "src")
+      const offenders: string[] = []
+      for (const file of walk(src)) {
+        if (isDouble(file)) continue
+        const text = readFileSync(file, "utf8")
+        for (const [i, line] of text.split("\n").entries()) {
+          if (line.trimStart().startsWith("//") || line.trimStart().startsWith("*")) continue
+          if (/\.connect\(\s*[A-Za-z_$][\w.$]*\.destination\s*\)/.test(line)) {
+            offenders.push(`${file.slice(GAMES.length + 1)}:${i + 1}  ${line.trim()}`)
+          }
+        }
+      }
+      if (NOT_YET_ROUTED.has(game)) {
+        assert.ok(
+          offenders.length > 0,
+          `${game} is on the NOT_YET_ROUTED list but no longer connects to ctx.destination — delete the exception`,
+        )
+        return
+      }
+      assert.deepEqual(
+        offenders,
+        [],
+        `${game} connects to the audio output without passing the shared ceiling:\n  ${offenders.join(
+          "\n  ",
+        )}\nRoute it through createSafetyBus() from packs/shared/game-audio/.`,
+      )
+    })
+  }
+})


### PR DESCRIPTION
Follow-up to #676. MOSAIC was the one a child complained about; it was not the only one that clipped.

## The survey — 27 games, rendered offline

Each game's audio module was loaded into an `OfflineAudioContext` and every cue fired, alone and then six-at-once in a single frame (a laser sweep, a combo, a wave clear). Peak is linear; **> 1.0 means samples that the DAC hard-clips**.

| game | limiter before | master | loudest single cue | 6-at-once | clipped samples |
|---|---|---|---|---|---|
| **mosaic** | **none** | 0.62 | `clear()` **2.344** | **13.955** | **15954** |
| runner | comp -12/r12 | 0.85 | `gateCorrect()` **0.942** | **2.716** | 268 |
| stack | comp -13/r7/k26 | 0.90 | `shatter()` **1.034** | **2.148** | 594 |
| foundry | comp -17/r6/k26 | 0.90 | `kickout()` 0.521 | **1.839** | 236 |
| trebuchet | comp -14/r5/k22 | 0.62 | `collapse()` 0.793 | **1.650** | 1216 |
| colossus | **none** | 0.70 | `topple()` 0.296 | **1.639** | 4096 |
| balance | comp -14/r5 | 0.90 | `clank()` 0.389 | **1.562** | 246 |
| merge-idle | **none** | var | `magnitude()` 0.246 | **1.471** | 44 |
| arena | comp | 0.85 | `rupture()` 0.684 | **1.409** | 636 |
| merge | comp -12/r9/k18 | 0.62 | `resonanceHit()` 0.548 | **1.401** | 216 |
| rhythm | comp | 0.90 | `impact()` **1.020** | **1.393** | 456 |
| forge | comp -10/r12/k6 | 0.85 | `unlock()` **1.220** | **1.360** | 286 |
| polarity | comp -14/r8/k24 | 0.72 | `release()` 0.573 | **1.177** | 28 |
| skyledger | **none** | 0.50 | `bloom()` 0.191 | **1.148** | 82 |
| street | **none** | 0.50 | `down()` 0.187 | **1.123** | 26 |
| serpent | comp | 0.55 | `death()` 0.254 | **1.117** | 44 |
| coil | comp -16/r6/k24 | 0.80 | `seat()` 0.260 | **1.087** | 36 |
| guilty | comp -14/r5/k22 | 0.90 | `hostileWake()` 0.208 | **1.058** | 40 |
| slice | comp -18/r6/k26 | 0.85 | `bomb()` 0.342 | 0.980 | 0 |
| truedraw | **none** | 0.90 | `over()` 0.152 | 0.913 | 0 |
| claim | **none** | 0.55 | `death()` 0.177 | 0.910 | 0 |
| beam | comp -18/r6/k26 | 0.85 | `ascend()` 0.223 | 0.810 | 0 |
| lattice | **none** (cap 10) | 0.50 | `open()` 0.113 | 0.565 | 0 |
| counterweight | **none** | 0.50 | `shear()` 0.090 | 0.539 | 0 |
| siege | comp -18/r8/k24 | 0.75 | `bossDown()` 0.504 | 0.504 | 0 |
| horde | comp | 0.62 | *auto-probe could not reach its cues (multi-arg)* | | |
| pulse | comp glue | 0.78 | *auto-probe could not reach its cues (multi-arg)* | | |

**Eighteen of the twenty-five measurable games clipped.** Nine had no limiter of any kind. The sixteen that did were not limiting — knee 22–26 at ratio 5–6 is a *glue compressor*, and it let all of the above through, because its 3 ms attack means the first 3 ms of every transient passes unattenuated. Master gains disagreed 0.50 vs 0.90 with no rationale anywhere. Four games clipped on a **single ordinary cue**, before anything overlapped.

## What changed

Each game now ends its graph at `createSafetyBus(ctx).input` instead of `ctx.destination` — one line, mechanically, in all twenty-four (arena and claim excluded; other agents held those files).

**After, across every cue of every game: the largest sample any of them can produce is 0.890, and clipped samples are zero everywhere.**

| game | 6-at-once before | after |
|---|---|---|
| mosaic | 13.955 (15954 clipped) | 0.890 (0) |
| runner | 2.716 (268) | 0.890 (0) |
| stack | 2.148 (594) | 0.890 (0) |
| foundry | 1.839 (236) | 0.890 (0) |
| trebuchet | 1.650 (1216) | 0.890 (0) |
| colossus | 1.639 (4096) | 0.890 (0) |
| balance | 1.562 (246) | 0.890 (0) |
| …all others | | ≤ 0.890 (0) |

Four games were also **turned down**, because riding the ceiling on every hit is a game permanently squashed rather than a game with headroom:

| game | master | loudest cue |
|---|---|---|
| forge | 0.85 -> 0.50 | 1.220 -> 0.890 (typical cue 0.74–0.80) |
| rhythm | 0.90 -> 0.65 | 1.020 -> 0.758 |
| runner | 0.85 -> 0.65 | 0.942 -> 0.693 |
| stack | 0.90 -> 0.65 | 1.034 -> 0.623 |

The seven games whose envelopes take a named attack now clamp it through `safeAttack` (6 ms floor): forge, merge, merge-idle, polarity, runner, siege, trebuchet. The other seventeen write ramp times inline at each call site; sweeping those is a follow-up, and the bus holds them meanwhile.

## The gate pack 28 inherits

`routing.test.ts` globs every game directory and asserts nothing connects to `ctx.destination` outside the safety bus. Discovery is a glob rather than a list for the same reason the CI job's is — adding the hundredth pack should be adding a directory. `arena` and `claim` sit on a `NOT_YET_ROUTED` list that **can only get shorter**: the test fails if an entry becomes unnecessary, so the list cannot rot.

Verified by removing the fix — reverting street's one line to `master.connect(ctx.destination)`:

```
not ok 26 - street
  street connects to the audio output without passing the shared ceiling:
  street/src/audio/audio.ts:45  master.connect(ctx.destination)
  Route it through createSafetyBus() from packs/shared/game-audio/.
```

2095 game tests and 63 shared tests, five consecutive runs each, plus `npm run tsc` on all twenty-five games.

## Still open

- **`settings.sound` is honoured by zero of the 27 games.** Every one has its own in-game mute button and its own localStorage key; none reads `client.settings.sound` from the host. Turning sound off in the Dynawalla app silences nothing. Needs its own change.
- `arena` and `claim` still connect straight to the output.
- Seventeen games still write sub-5 ms attack ramps inline.
- Only a device and a real pair of ears can confirm any of this still sounds *good*.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb