### PR TITLE
fix(dynawalla/game-chrome): the manual silences the game, for every pack, by construction

### DIFF
--- a/dynawalla/packs/shared/game-chrome/audioHold.test.ts
+++ b/dynawalla/packs/shared/game-chrome/audioHold.test.ts
@@ -1,0 +1,249 @@
+// The hold, on its own, away from the sheet.
+//
+// `instructions.test.ts` proves the child-facing promise: open the manual and
+// the game goes quiet. This file proves the machinery underneath it, because
+// the interesting failures are the ones a screenshot cannot show — a context
+// created before the wrap, a context closed while held, two holds nested, the
+// webkit-prefixed constructor one game reads in preference to the standard one.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  installAudioHold,
+  holdAudio,
+  releaseAudio,
+  isAudioHeld,
+  forgetAudioContexts,
+} from "./audioHold.ts"
+
+class FakeAudioContext {
+  state: "running" | "suspended" | "closed" = "running"
+  suspends = 0
+  resumes = 0
+  args: unknown[]
+  constructor(...args: unknown[]) {
+    this.args = args
+  }
+  async resume(): Promise<void> {
+    this.resumes += 1
+    await Promise.resolve()
+    if (this.state !== "closed") this.state = "running"
+  }
+  async suspend(): Promise<void> {
+    this.suspends += 1
+    await Promise.resolve()
+    if (this.state !== "closed") this.state = "suspended"
+  }
+  async close(): Promise<void> {
+    this.state = "closed"
+  }
+}
+
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 8; i++) await Promise.resolve()
+}
+
+type Globals = Record<string, unknown>
+
+/** Install the hold over a fresh fake constructor, and put the world back after. */
+function withAudio(
+  fn: (make: () => FakeAudioContext) => Promise<void> | void,
+  name = "AudioContext",
+): () => Promise<void> {
+  return async () => {
+    const g = globalThis as Globals
+    const prev = g[name]
+    g[name] = FakeAudioContext
+    installAudioHold()
+    try {
+      await fn(() => new (g[name] as new () => FakeAudioContext)())
+    } finally {
+      g[name] = prev
+      forgetAudioContexts()
+    }
+  }
+}
+
+test(
+  "a context made after the wrap is suspended by a hold and restored by the release",
+  withAudio(async (make) => {
+    const ctx = make()
+    holdAudio()
+    await settle()
+    assert.equal(ctx.state, "suspended")
+    releaseAudio()
+    await settle()
+    assert.equal(ctx.state, "running")
+  }),
+)
+
+test(
+  "the hold nests: an inner release does not give the sound back early",
+  withAudio(async (make) => {
+    const ctx = make()
+    holdAudio()
+    // Settled BETWEEN the two, deliberately. A second hold that re-derives the
+    // game's intent from the context's state would read the silence the FIRST
+    // hold caused as "this game did not want sound", and never give it back.
+    await settle()
+    holdAudio()
+    await settle()
+    assert.equal(ctx.state, "suspended")
+    releaseAudio()
+    await settle()
+    assert.equal(ctx.state, "suspended", "the outer hold was ignored")
+    assert.equal(isAudioHeld(), true)
+    releaseAudio()
+    await settle()
+    assert.equal(ctx.state, "running")
+    assert.equal(isAudioHeld(), false)
+  }),
+)
+
+test(
+  "an unmatched release is not a licence to make noise",
+  withAudio(async (make) => {
+    const ctx = make()
+    await ctx.suspend()
+    releaseAudio()
+    releaseAudio()
+    await settle()
+    assert.equal(ctx.state, "suspended", "a stray release started a silent game")
+    assert.equal(isAudioHeld(), false)
+    // And it must not have driven the count below zero: a hold that has to
+    // climb back out of a hole is a hold that does nothing on the next read.
+    await ctx.resume()
+    holdAudio()
+    await settle()
+    assert.equal(isAudioHeld(), true, "the next read was not held")
+    assert.equal(ctx.state, "suspended", "the stray releases cost the next read its silence")
+    releaseAudio()
+    await settle()
+  }),
+)
+
+test(
+  "a context closed while held is not touched again",
+  withAudio(async (make) => {
+    // A pack can unmount mid-read: the host's exit chevron is in the host
+    // document and the swallow cannot reach it. Resuming a closed context
+    // throws in a real browser, which would be an unhandled rejection on the
+    // way out of the game.
+    const ctx = make()
+    holdAudio()
+    await settle()
+    await ctx.close()
+    const before = ctx.resumes
+    releaseAudio()
+    await settle()
+    assert.equal(ctx.resumes, before, "the hold resumed a closed context")
+    assert.equal(ctx.state, "closed")
+  }),
+)
+
+test(
+  "installing twice does not wrap the wrapper, and does not double-register",
+  withAudio(async (make) => {
+    // `createInstructions` installs at every mount and the module installs at
+    // import, so this runs more than once by design. A wrapper wrapped in a
+    // wrapper is a construct trap per layer, forever, for the life of the page.
+    const once = (globalThis as Globals).AudioContext
+    installAudioHold()
+    installAudioHold()
+    assert.equal((globalThis as Globals).AudioContext, once, "the wrapper was wrapped again")
+    const ctx = make()
+    holdAudio()
+    await settle()
+    assert.equal(ctx.suspends, 1, `the context was suspended ${ctx.suspends} times`)
+    releaseAudio()
+    await settle()
+    assert.equal(ctx.resumes, 1, `the context was resumed ${ctx.resumes} times`)
+  }),
+)
+
+test(
+  "the wrap is transparent: constructor arguments and instanceof survive it",
+  withAudio(async (make) => {
+    // `pulse` and `rhythm` both pass `{ latencyHint: "interactive" }`, and a
+    // timing game that silently lost its latency hint would be a worse bug than
+    // the one being fixed here.
+    const g = globalThis as Globals
+    const Ctor = g.AudioContext as new (o: unknown) => FakeAudioContext
+    const ctx = new Ctor({ latencyHint: "interactive" })
+    assert.deepEqual(ctx.args, [{ latencyHint: "interactive" }], "the options were dropped")
+    assert.ok(ctx instanceof FakeAudioContext, "the instance lost its prototype")
+    void make()
+  }),
+)
+
+test(
+  "the webkit-prefixed constructor is wrapped too",
+  withAudio(async (make) => {
+    // `rhythm` reads `webkitAudioContext ?? window.AudioContext` — the opposite
+    // order to every other game. Wrapping only the unprefixed name would hold
+    // twenty-six games and leave the twenty-seventh playing.
+    const ctx = make()
+    holdAudio()
+    await settle()
+    assert.equal(ctx.state, "suspended", "webkitAudioContext was never wrapped")
+    releaseAudio()
+    await settle()
+  }, "webkitAudioContext"),
+)
+
+test(
+  "a read shorter than a suspend still ends with the sound on",
+  async () => {
+    // `suspend()` and `resume()` are promises and a child can open and shut the
+    // sheet inside one frame. Issued in parallel, the resume can complete first
+    // and the late suspend then lands on a game that is being played — silence
+    // that never comes back, which is worse than the noise being fixed.
+    class SlowSuspend {
+      state: "running" | "suspended" | "closed" = "running"
+      async resume(): Promise<void> {
+        await Promise.resolve()
+        if (this.state !== "closed") this.state = "running"
+      }
+      async suspend(): Promise<void> {
+        for (let i = 0; i < 6; i++) await Promise.resolve()
+        if (this.state !== "closed") this.state = "suspended"
+      }
+      async close(): Promise<void> {
+        this.state = "closed"
+      }
+    }
+    const g = globalThis as Globals
+    const prev = g.AudioContext
+    g.AudioContext = SlowSuspend
+    installAudioHold()
+    try {
+      const ctx = new (g.AudioContext as new () => SlowSuspend)()
+      holdAudio()
+      releaseAudio()
+      await settle()
+      await settle()
+      assert.equal(ctx.state, "running", "the game came back mute after a quick look")
+    } finally {
+      g.AudioContext = prev
+      forgetAudioContexts()
+    }
+  },
+)
+
+test(
+  "a context that existed BEFORE the wrap is not held — and that is the known limit",
+  withAudio(async () => {
+    // Honest about the seam: the proxy can only see a `new` that goes through
+    // it. Today every one of the twenty-seven builds its context lazily, on the
+    // first sound, which is always after mount — so this case does not occur in
+    // the shipped packs. A game that constructs one at module scope, before
+    // `createInstructions` runs, would not be held, and would need its own line.
+    const raw = new FakeAudioContext()
+    holdAudio()
+    await settle()
+    assert.equal(raw.state, "running")
+    releaseAudio()
+    await settle()
+  }),
+)

--- a/dynawalla/packs/shared/game-chrome/audioHold.ts
+++ b/dynawalla/packs/shared/game-chrome/audioHold.ts
@@ -1,0 +1,214 @@
+/**
+ * Silence, held. Every `AudioContext` a pack ever makes, stopped together.
+ *
+ * **Why this exists.** The report was: "All games should pause while reading the
+ * instructions .. I can hear counterweight playing in the background while I'm
+ * reading the instructions ... stressing me out even more .. it's so stressful I
+ * don't even want to QA it."
+ *
+ * A child opens the rules BECAUSE they are overwhelmed. That is the single worst
+ * moment in the whole product for the game to keep shouting at them.
+ *
+ * **Why it is here and not in the games.** Pausing had already been fixed per
+ * game — #642 for VOLTA and MOSAIC, then trebuchet, coil, foundry and guilty
+ * one at a time — and eleven of the twenty-seven still had no gating at all.
+ * Every per-game fix is a fix the twenty-eighth pack will not get. So the hold
+ * lives at the seam every game already goes through, and a game gets it by
+ * existing rather than by remembering.
+ *
+ * **How it reaches a game that never calls us.** Every one of the twenty-seven
+ * audio modules resolves its constructor lazily, inside the method that makes
+ * the context:
+ *
+ *     const Ctx = globalThis.AudioContext ?? globalThis.webkitAudioContext
+ *     const ctx = new Ctx()
+ *
+ * — none of them cache it at module scope. So replacing that global with a
+ * `Proxy` whose `construct` trap registers the instance catches all of them,
+ * with no import and no line of wiring on their side. The proxy forwards
+ * everything else, so `instanceof`, statics and the prototype are unchanged.
+ *
+ * **Holding, not stopping once.** A single `suspend()` on open would be undone
+ * by the game itself: every pack calls `audio.resume()` on any gesture, because
+ * Web Audio needs one, and taps still reach some games from behind the scrim.
+ * So while the hold is on, a context's own `resume()` records the intent and
+ * returns — it does not restart the sound. The intent is honoured on release,
+ * which is why a game that asked for sound during the read is not left mute
+ * afterwards.
+ *
+ * **What a game that was already silent gets.** Nothing. Whether a context is
+ * resumed on release is decided by whether the GAME wanted it running, never by
+ * whether we suspended it, so a game paused by its own pause screen, by a phone
+ * call, or by the host putting a sheet over the frame comes back exactly as it
+ * was.
+ *
+ * **What suspend does to a note in flight.** It freezes the graph: the context
+ * clock stops, so an oscillator holds where it is and every scheduled envelope
+ * point holds with it. On resume the note continues from that instant rather
+ * than jumping — nothing is skipped forward. Two honest costs. The cut is a
+ * discontinuity, so a loud sustained voice can click going down; and a game
+ * whose simulation keeps running while the manual is up will schedule new
+ * sounds against a frozen `currentTime`, which then all land in the same
+ * instant when the clock starts again. That second one is a real argument for
+ * `onOpen` in the games that make sound without input — it is not an argument
+ * for leaving the sound on.
+ */
+
+type Held = {
+  ctx: AudioContext
+  /** Bound before we shadow them, so the shadows can still reach the real ones. */
+  nativeResume: () => Promise<void>
+  nativeSuspend: () => Promise<void>
+  /** Does the GAME want sound? Not "did we suspend it" — that is a different question. */
+  wanted: boolean
+  /**
+   * Serialises this context's suspend/resume calls.
+   *
+   * `suspend()` and `resume()` are promises and a child can open and close the
+   * sheet faster than either settles. Firing them in parallel lets a resume
+   * that was issued second complete first, leaving a game that is being played
+   * with its sound off — the failure that is worse than the one being fixed.
+   */
+  tail: Promise<void>
+}
+
+const held: Held[] = []
+/** Proxies we made, so installing twice does not wrap a wrapper. */
+const wrappers = new WeakSet<object>()
+let depth = 0
+
+const run = (rec: Held, op: () => Promise<void>): Promise<void> => {
+  rec.tail = rec.tail.then(op).catch((error: unknown) => {
+    // Loud, never silent. A hold that failed means either a game shouting over
+    // the manual or a game that came back mute, and both are worth a line in
+    // the console.
+    console.warn("[game-chrome] audio hold could not change state", error)
+  })
+  return rec.tail
+}
+
+function register(ctx: AudioContext): void {
+  if (held.some((r) => r.ctx === ctx)) return
+  const rec: Held = {
+    ctx,
+    nativeResume: ctx.resume.bind(ctx),
+    nativeSuspend: ctx.suspend.bind(ctx),
+    wanted: ctx.state === "running",
+    tail: Promise.resolve(),
+  }
+  held.push(rec)
+
+  // Own properties shadowing the prototype's. Plain assignment, the same idiom
+  // the games' own code uses — no `defineProperty`, no descriptor games.
+  ctx.resume = (): Promise<void> => {
+    rec.wanted = true
+    if (depth > 0) return Promise.resolve()
+    return run(rec, rec.nativeResume)
+  }
+  ctx.suspend = (): Promise<void> => {
+    rec.wanted = false
+    if (depth > 0) return Promise.resolve()
+    return run(rec, rec.nativeSuspend)
+  }
+  // Forgetting a closed context is not tidiness. `resume()` on a closed context
+  // rejects, and a pack torn down mid-read would take an unhandled rejection
+  // with it on the way out of the game.
+  const nativeClose = ctx.close.bind(ctx)
+  ctx.close = (): Promise<void> => {
+    const at = held.indexOf(rec)
+    if (at >= 0) held.splice(at, 1)
+    return nativeClose()
+  }
+
+  // Born during a read. The first gesture in a game is often the tap that opens
+  // the rules, so the context may not exist until after the sheet is up.
+  if (depth > 0 && ctx.state === "running") run(rec, rec.nativeSuspend)
+}
+
+function wrap(Ctor: unknown): unknown {
+  if (typeof Ctor !== "function") return Ctor
+  if (wrappers.has(Ctor)) return Ctor
+  const proxy = new Proxy(Ctor as new (...args: never[]) => AudioContext, {
+    construct(target, args, newTarget): object {
+      const ctx = Reflect.construct(target, args, newTarget) as AudioContext
+      try {
+        register(ctx)
+      } catch (error) {
+        console.warn("[game-chrome] could not hold this audio context", error)
+      }
+      return ctx
+    },
+  })
+  wrappers.add(proxy)
+  return proxy
+}
+
+/**
+ * Wrap the audio constructors so every context a game makes is holdable.
+ *
+ * Idempotent, and safe where there is no Web Audio at all — a headless test rig
+ * or a WebView with the API switched off simply has nothing to wrap.
+ *
+ * Both names are wrapped. `rhythm` reads `webkitAudioContext ?? AudioContext`
+ * and everyone else reads them the other way round, so wrapping one of the two
+ * would hold twenty-six games and not the twenty-seventh.
+ */
+export function installAudioHold(): void {
+  const g = globalThis as Record<string, unknown>
+  for (const name of ["AudioContext", "webkitAudioContext"]) {
+    const Ctor = g[name]
+    if (typeof Ctor !== "function") continue
+    const wrapped = wrap(Ctor)
+    if (wrapped === Ctor) continue
+    try {
+      g[name] = wrapped
+    } catch (error) {
+      // Loud, never silent: from here the manual cannot silence this game and
+      // that is exactly the defect this module exists to close.
+      console.warn(`[game-chrome] ${name} could not be wrapped; the manual will not mute audio`, error)
+    }
+  }
+}
+
+// As early as the module graph allows. Every game imports the manual, and every
+// game builds its context lazily on first sound, so in practice the wrap is in
+// place long before the first `new AudioContext()`. `createInstructions` calls
+// this again at mount, which is what covers a bundle that evaluates a game's
+// audio module first.
+installAudioHold()
+
+/** Silence everything, and keep it silent until the matching `releaseAudio()`. */
+export function holdAudio(): void {
+  depth += 1
+  if (depth > 1) return
+  for (const rec of held) {
+    rec.wanted = rec.ctx.state === "running"
+    if (rec.wanted) run(rec, rec.nativeSuspend)
+  }
+}
+
+/** Give back exactly the sound the game had, and nothing it did not. */
+export function releaseAudio(): void {
+  if (depth === 0) return
+  depth -= 1
+  if (depth > 0) return
+  for (const rec of held) {
+    if (rec.wanted) run(rec, rec.nativeResume)
+  }
+}
+
+/** True while the manual — or anything else — is holding the sound down. */
+export function isAudioHeld(): boolean {
+  return depth > 0
+}
+
+/**
+ * Drop every registered context and clear the hold.
+ *
+ * For tests only: the registry is process-global, so one test's context would
+ * otherwise be suspended by the next test's manual.
+ */
+export function forgetAudioContexts(): void {
+  held.length = 0
+  depth = 0
+}

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -5,6 +5,8 @@
  * `insets`      — the safe rectangle, as numbers a canvas can lay out against.
  * `hostChrome`  — where the HOST draws over the game, so nothing is covered.
  * `instructions`— one "how to play" surface, populated per game.
+ * `audioHold`   — the pack's sound, stopped while that surface is up. Mounting
+ *                 the manual arms it; no game imports it or calls it.
  */
 export { safeInsets, setHostInsets, onInsetsChange, safeRect, NO_INSETS, type Insets } from "./insets.ts"
 export {
@@ -24,3 +26,10 @@ export {
   type InstructionsSpec,
   type Section,
 } from "./instructions.ts"
+export {
+  installAudioHold,
+  holdAudio,
+  releaseAudio,
+  isAudioHeld,
+  forgetAudioContexts,
+} from "./audioHold.ts"

--- a/dynawalla/packs/shared/game-chrome/instructions.test.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.test.ts
@@ -24,6 +24,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { createInstructions, sheetTop, type InstructionsSpec } from "./instructions.ts"
+import { forgetAudioContexts } from "./audioHold.ts"
 import { setHostInsets, type Insets } from "./insets.ts"
 import { exitRect, helpRect, HOST_CONTROL } from "./hostChrome.ts"
 
@@ -127,13 +128,49 @@ const doc = {
   body: new El("body"),
 }
 
+/**
+ * A game's `AudioContext`, with only the three methods this module touches.
+ *
+ * State flips when the promise settles, not when the call is made, because that
+ * is what a real context does — and a test whose fake flips synchronously would
+ * pass with a `suspend()` that is never awaited by anything.
+ */
+class FakeAudioContext {
+  state: "running" | "suspended" | "closed" = "running"
+  resumed = 0
+  suspended = 0
+  async resume(): Promise<void> {
+    this.resumed += 1
+    await Promise.resolve()
+    if (this.state !== "closed") this.state = "running"
+  }
+  async suspend(): Promise<void> {
+    this.suspended += 1
+    await Promise.resolve()
+    if (this.state !== "closed") this.state = "suspended"
+  }
+  async close(): Promise<void> {
+    this.state = "closed"
+  }
+}
+
+/** Let every queued suspend/resume settle. The hold serialises them per context. */
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 8; i++) await Promise.resolve()
+}
+
 /** Key listeners registered on `globalThis`, and the games that share them. */
 type Rig = {
   root: El
   ui: ReturnType<typeof createInstructions>
   /** Dispatch a key the way a browser would: capture listeners, then the game. */
   key(type: "keydown" | "keyup", key: string): { reachedGame: boolean; defaultPrevented: boolean }
+  /** The same, for a pointer. `target` is what the browser would hit. */
+  pointer(type: string, target: El): { reachedGame: boolean }
+  /** A context the GAME made, through whatever `globalThis.AudioContext` is now. */
+  gameAudio(): FakeAudioContext
   gameSawKeys: string[]
+  gameSawPointers: string[]
   restore(): void
 }
 
@@ -145,9 +182,12 @@ function rig(spec?: Partial<InstructionsSpec>): Rig {
   // Mutation testing caught it; nothing else would have.
   const capture = new Map<string, Listener[]>()
   const gameSawKeys: string[] = []
+  const gameSawPointers: string[] = []
 
   const prevDoc = (globalThis as { document?: unknown }).document
   const prevCS = (globalThis as { getComputedStyle?: unknown }).getComputedStyle
+  const prevAC = (globalThis as { AudioContext?: unknown }).AudioContext
+  ;(globalThis as { AudioContext?: unknown }).AudioContext = FakeAudioContext
   ;(globalThis as { document?: unknown }).document = doc
   ;(globalThis as { getComputedStyle?: unknown }).getComputedStyle = () => ({
     paddingTop: "0px",
@@ -164,16 +204,14 @@ function rig(spec?: Partial<InstructionsSpec>): Rig {
     fn: Listener,
     useCapture?: boolean,
   ) => {
-    if (t.startsWith("key") && useCapture === true) {
-      capture.set(t, [...(capture.get(t) ?? []), fn])
-    }
+    if (useCapture === true) capture.set(t, [...(capture.get(t) ?? []), fn])
   }
   ;(globalThis as { removeEventListener: unknown }).removeEventListener = (
     t: string,
     fn: Listener,
     useCapture?: boolean,
   ) => {
-    if (t.startsWith("key") && useCapture === true) {
+    if (useCapture === true) {
       capture.set(t, (capture.get(t) ?? []).filter((f) => f !== fn))
     }
   }
@@ -190,6 +228,31 @@ function rig(spec?: Partial<InstructionsSpec>): Rig {
     root,
     ui,
     gameSawKeys,
+    gameSawPointers,
+    gameAudio() {
+      const Ctor = (globalThis as unknown as { AudioContext?: new () => FakeAudioContext })
+        .AudioContext
+      if (!Ctor) throw new Error("no AudioContext on globalThis")
+      return new Ctor()
+    },
+    pointer(type, target) {
+      let stopped = false
+      const e = {
+        type,
+        target,
+        currentTarget: null,
+        preventDefault() {},
+        stopPropagation() {
+          stopped = true
+        },
+      }
+      for (const fn of [...(capture.get(type) ?? [])]) fn(e)
+      // Every game binds its own pointer handlers — on its canvas, its root or
+      // `globalThis`. A capture listener on `globalThis` runs before all three,
+      // so stopping there is what does or does not reach the game.
+      if (!stopped) gameSawPointers.push(type)
+      return { reachedGame: !stopped }
+    },
     key(type, key) {
       let stopped = false
       let defaultPrevented = false
@@ -214,6 +277,8 @@ function rig(spec?: Partial<InstructionsSpec>): Rig {
       ;(globalThis as { removeEventListener: unknown }).removeEventListener = realRemove
       ;(globalThis as { document?: unknown }).document = prevDoc
       ;(globalThis as { getComputedStyle?: unknown }).getComputedStyle = prevCS
+      ;(globalThis as { AudioContext?: unknown }).AudioContext = prevAC
+      forgetAudioContexts()
     },
   }
 }
@@ -441,6 +506,219 @@ test("close fires onClose so the game can resume, and open/close are idempotent"
   r.ui.close()
   r.ui.close()
   assert.equal(closes, 1, "onClose fired for a close that did not happen")
+  r.ui.destroy()
+  r.restore()
+})
+
+// --- the game must not be playing behind the manual -------------------------
+//
+// The report, verbatim: "All games should pause while reading the instructions
+// .. I can hear counterweight playing in the background while I'm reading the
+// instructions ... stressing me out even more .. it's so stressful I don't even
+// want to QA it."
+//
+// A child opens the rules BECAUSE they are overwhelmed. Getting shouted at by
+// the game while they read is the worst moment in the product to be loud.
+//
+// This had been fixed per game — #642 for VOLTA and MOSAIC, then trebuchet,
+// coil, foundry and guilty one at a time. Eleven of the twenty-seven had no
+// gating at all, and the twenty-eighth pack would have shipped without it too.
+// So it is fixed HERE, where a game cannot forget it.
+
+test("the game's sound stops while the manual is open", async () => {
+  const r = rig()
+  const ctx = r.gameAudio()
+  assert.equal(ctx.state, "running")
+  r.ui.open()
+  await settle()
+  assert.equal(ctx.state, "suspended", "the game is still making noise behind the manual")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("and starts again when the manual closes", async () => {
+  const r = rig()
+  const ctx = r.gameAudio()
+  r.ui.open()
+  await settle()
+  r.ui.close()
+  await settle()
+  assert.equal(ctx.state, "running", "the game came back silent")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("a game that was ALREADY silent is not switched on by closing the manual", async () => {
+  // A game paused on its own — its own pause screen, a phone call, the host
+  // putting a sheet over the frame — must come back exactly as it was. Closing
+  // the manual is not permission to make noise.
+  const r = rig()
+  const ctx = r.gameAudio()
+  await ctx.suspend()
+  assert.equal(ctx.state, "suspended")
+  r.ui.open()
+  await settle()
+  r.ui.close()
+  await settle()
+  assert.equal(ctx.state, "suspended", "closing the manual restarted a game that was paused")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the game cannot resume its own sound from behind the manual", async () => {
+  // Every game calls `audio.resume()` on any gesture, because Web Audio needs
+  // one. A tap on the scrim still reaches those handlers in some games, and a
+  // one-shot suspend would be undone by the first such tap. The hold has to
+  // OUTLAST the open sheet, not fire once at the start of it.
+  const r = rig()
+  const ctx = r.gameAudio()
+  r.ui.open()
+  await settle()
+  void ctx.resume()
+  await settle()
+  assert.equal(ctx.state, "suspended", "the game resumed itself while the manual was up")
+  // ...and the intent is not thrown away: it wanted sound, so it gets sound.
+  r.ui.close()
+  await settle()
+  assert.equal(ctx.state, "running", "the game's own resume was swallowed for good")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("a context the game creates DURING the read is born silent", async () => {
+  // Nothing says the context exists before the sheet does. A child who opens
+  // the rules before ever touching the game leaves the first gesture — and so
+  // the first `new AudioContext()` — until after the sheet is up.
+  const r = rig()
+  r.ui.open()
+  await settle()
+  const ctx = r.gameAudio()
+  await settle()
+  assert.equal(ctx.state, "suspended", "a context made behind the manual started playing")
+  r.ui.close()
+  await settle()
+  assert.equal(ctx.state, "running")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("unmounting while the manual is open does not leave the hold on", async () => {
+  const r = rig()
+  const ctx = r.gameAudio()
+  r.ui.open()
+  await settle()
+  r.ui.destroy()
+  await settle()
+  assert.equal(ctx.state, "running", "the pack was torn down with its audio still held")
+  r.restore()
+})
+
+test("the game sees no taps while the manual is open", async () => {
+  // The scrim covers the game visually, but a pointer event on the scrim still
+  // bubbles to whatever the game bound on its root or on `globalThis`. So the
+  // sheet only LOOKED modal: tapping the background to dismiss it also fired a
+  // shot, a shear or a swipe underneath. This is the same hole the key swallow
+  // was written for, on the other input.
+  const r = rig()
+  r.ui.open()
+  // The scrim is `inset:0`, so a tap "on the game" IS a tap on the scrim. The
+  // canvas stands in for the rarer case of a game node that outranks it.
+  const scrim = r.root.find("dwc-scrim")
+  const canvas = new El("canvas")
+  for (const t of ["pointermove", "pointerup", "touchstart", "mousedown", "wheel"]) {
+    r.pointer(t, scrim)
+    r.pointer(t, canvas)
+  }
+  assert.deepEqual(
+    r.gameSawPointers,
+    [],
+    `the game saw ${r.gameSawPointers.join(",")} behind the manual`,
+  )
+  assert.equal(r.ui.isOpen, true, "the manual dismissed itself on a move")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("a tap on the background closes the manual — and the game does not feel it", () => {
+  // Both halves matter. Tap-to-dismiss is how most children close a sheet, and
+  // it used to fire a shot on the way out.
+  const r = rig()
+  r.ui.open()
+  const scrim = r.root.find("dwc-scrim")
+  assert.equal(r.pointer("pointerdown", scrim).reachedGame, false, "the dismissing tap hit the game")
+  assert.equal(r.ui.isOpen, false, "a tap on the background did not close the manual")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("a tap INSIDE the sheet does not dismiss it", () => {
+  // A child reading the manual touches it. Being thrown out of the rules
+  // mid-read is worse than having to find the button.
+  const r = rig()
+  r.ui.open()
+  r.pointer("pointerdown", r.root.find("dwc-body"))
+  assert.equal(r.ui.isOpen, true, "touching the manual closed it")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("but the sheet's own pointers still get through — it must stay draggable", async () => {
+  // A swallow that ate the sheet's own gestures would take the drag dismissal,
+  // the PLAY button and tap-to-close with it.
+  const r = rig()
+  r.ui.open()
+  const grab = r.root.find("dwc-grab")
+  const close = r.root.find("dwc-close")
+  assert.equal(r.pointer("pointerdown", grab).reachedGame, true, "the grab handle was deafened")
+  assert.equal(r.pointer("pointerup", close).reachedGame, true, "PLAY was deafened")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("and nothing is swallowed once the manual is closed", async () => {
+  // A gate stuck shut is the same bug as a gate stuck open. A game whose taps
+  // stopped working after one read is worse than one that was noisy for ten
+  // seconds.
+  const r = rig()
+  const scrim = r.root.find("dwc-scrim")
+  r.ui.open()
+  r.ui.close()
+  for (const t of ["pointerdown", "pointerup", "touchstart"]) r.pointer(t, scrim)
+  assert.deepEqual(
+    r.gameSawPointers,
+    ["pointerdown", "pointerup", "touchstart"],
+    "the game was starved of input after the manual closed",
+  )
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the tap that OPENS the manual does not also fire the game underneath", async () => {
+  // The help control is a pack element sitting over the playfield. Its tap
+  // bubbled straight into the game, so opening the rules cost a move.
+  const r = rig()
+  const help = r.root.find("dwc-help")
+  assert.equal(r.pointer("pointerdown", help).reachedGame, false, "opening the rules fired the game")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("onOpen fires so a game can freeze its loop, exactly once per open", () => {
+  // Sound is stopped for every game by construction. A game's SIMULATION cannot
+  // be — the module has no idea what a game's loop is — so `onOpen` is the pair
+  // to `onClose` for games that need to stop the clock as well as the noise.
+  let opens = 0
+  let closes = 0
+  const r = rig({ onOpen: () => (opens += 1), onClose: () => (closes += 1) })
+  r.ui.open()
+  r.ui.open()
+  assert.equal(opens, 1, "onOpen fired for an open that did not happen")
+  assert.equal(closes, 0, "onClose fired before anything closed")
+  r.ui.close()
+  r.ui.close()
+  assert.equal(closes, 1)
+  r.ui.open()
+  assert.equal(opens, 2, "the second read never told the game")
   r.ui.destroy()
   r.restore()
 })

--- a/dynawalla/packs/shared/game-chrome/instructions.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.ts
@@ -34,10 +34,29 @@
  * A sheet rises from the bottom and is capped so its top edge can never reach
  * the host's corners. The clearance is arithmetic, not judgement, and
  * `sheetTop()` exposes it so a test can assert it at any viewport.
+ *
+ * **The game stops while the sheet is up, and it is not the game's job to
+ * remember.** "I can hear counterweight playing in the background while I'm
+ * reading the instructions ... it's so stressful I don't even want to QA it."
+ * Pausing had been fixed per game five times by then and eleven of the
+ * twenty-seven still had none, so it is fixed here instead, on all three of the
+ * ways a game keeps running behind a scrim:
+ *
+ *   - **sound** — `audioHold` suspends every `AudioContext` the pack owns and
+ *     holds it suspended. No import, no callback, no line in the game.
+ *   - **keys** — the capture-phase swallow, below. Already here.
+ *   - **taps** — the same swallow, for pointers. A scrim covers the game to the
+ *     eye but a pointer event on it still bubbles to whatever the game bound on
+ *     its root or on `globalThis`, so the sheet only LOOKED modal.
+ *
+ * What cannot be done from here is a game's own simulation clock: this module
+ * has no idea what a game's loop is. That is what `onOpen`/`onClose` are for,
+ * and they are the only part of pausing a game still has to opt into.
  */
 
 import { safeInsets, onInsetsChange, type Insets } from "./insets.ts"
 import { HOST_CONTROL, HOST_MARGIN, HOST_PROGRESS_H } from "./hostChrome.ts"
+import { installAudioHold, holdAudio, releaseAudio } from "./audioHold.ts"
 
 export type Section = { heading: string; lines: readonly string[] }
 
@@ -48,7 +67,19 @@ export type InstructionsSpec = {
   readonly summary: readonly string[]
   /** The manual. Omit for a game whose summary really is the whole rule set. */
   readonly sections?: readonly Section[]
-  /** Called when the panel closes, so a game can resume. */
+  /**
+   * Called when the panel opens, so a game can stop its clock.
+   *
+   * Sound, keys and taps are already held for you and need nothing here — this
+   * is only for a simulation that would otherwise keep advancing behind the
+   * scrim: a wall that keeps rising, a runner that keeps running, a timer that
+   * keeps counting down while a child reads why they lost.
+   *
+   * Opt-in, and opt-in is how the noise defect happened, so it is deliberately
+   * NOT the mechanism for anything that could be done without it.
+   */
+  readonly onOpen?: () => void
+  /** Called when the panel closes, so a game can resume. The pair to `onOpen`. */
   readonly onClose?: () => void
   /** Skip the entrance transition. Pass `host.prefersReducedMotion()`. */
   readonly reducedMotion?: boolean
@@ -186,22 +217,38 @@ function styleSheet(reduced: boolean): string {
  * child reliably hits, and the platform floor.
  */
 export function createInstructions(root: HTMLElement, spec: InstructionsSpec): Instructions {
+  // Mounting the manual is what arms the audio hold. It is idempotent and it
+  // runs at import too; doing it here as well is what covers a bundle that
+  // evaluated a game's audio module before this one.
+  installAudioHold()
+
+  // Identity, not DOM traversal. The pointer swallow has to answer "is this
+  // event ours?" and the twenty-seven games mount against hand-rolled fake
+  // elements with no `contains`, no `closest` and no `parentNode` — the same
+  // trap that `style.setProperty` and `classList` fell into. A Set of the nodes
+  // this module made needs nothing from the DOM at all.
+  const ours = new Set<unknown>()
+  const mine = <T>(el: T): T => {
+    ours.add(el)
+    return el
+  }
+
   const reduced = spec.reducedMotion === true
   const style = document.createElement("style")
   style.textContent = styleSheet(reduced)
   root.appendChild(style)
 
-  const help = document.createElement("button")
+  const help = mine(document.createElement("button"))
   help.type = "button"
   help.className = "dwc-help"
   help.textContent = "?"
   help.setAttribute("aria-label", `How to play ${spec.title}`)
 
-  const scrim = document.createElement("div")
+  const scrim = mine(document.createElement("div"))
   scrim.className = "dwc-scrim"
   scrim.hidden = true
 
-  const sheet = document.createElement("div")
+  const sheet = mine(document.createElement("div"))
   sheet.className = "dwc-sheet"
   // State goes on `className`, never `classList`. The 27 games mount against
   // hand-rolled fake elements that expose `className` and nothing else, so a
@@ -217,46 +264,46 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
   sheet.setAttribute("aria-label", `How to play ${spec.title}`)
   sheet.tabIndex = -1
 
-  const grab = document.createElement("div")
+  const grab = mine(document.createElement("div"))
   grab.className = "dwc-grab"
   // It is a control: it dismisses the sheet by drag. Announce it as one rather
   // than leaving a silent div a screen reader walks straight past.
   grab.setAttribute("role", "button")
   grab.setAttribute("aria-label", "Close how to play")
   grab.tabIndex = 0
-  const pill = document.createElement("div")
+  const pill = mine(document.createElement("div"))
   pill.className = "dwc-pill"
   grab.appendChild(pill)
 
-  const head = document.createElement("div")
+  const head = mine(document.createElement("div"))
   head.className = "dwc-head"
-  const h = document.createElement("h2")
+  const h = mine(document.createElement("h2"))
   h.className = "dwc-title"
   h.textContent = spec.title
   head.appendChild(h)
 
-  const body = document.createElement("div")
+  const body = mine(document.createElement("div"))
   body.className = "dwc-body"
 
-  const sum = document.createElement("div")
+  const sum = mine(document.createElement("div"))
   sum.className = "dwc-sum"
   for (const line of spec.summary) {
-    const p = document.createElement("p")
+    const p = mine(document.createElement("p"))
     p.textContent = line
     sum.appendChild(p)
   }
   body.appendChild(sum)
 
   for (const sec of spec.sections ?? []) {
-    const wrap = document.createElement("section")
+    const wrap = mine(document.createElement("section"))
     wrap.className = "dwc-sec"
-    const sh = document.createElement("h3")
+    const sh = mine(document.createElement("h3"))
     sh.className = "dwc-h"
     sh.textContent = sec.heading
-    const ul = document.createElement("ul")
+    const ul = mine(document.createElement("ul"))
     ul.className = "dwc-l"
     for (const line of sec.lines) {
-      const li = document.createElement("li")
+      const li = mine(document.createElement("li"))
       li.textContent = line
       ul.appendChild(li)
     }
@@ -264,9 +311,9 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     body.appendChild(wrap)
   }
 
-  const foot = document.createElement("div")
+  const foot = mine(document.createElement("div"))
   foot.className = "dwc-foot"
-  const close = document.createElement("button")
+  const close = mine(document.createElement("button"))
   close.type = "button"
   close.className = "dwc-close"
   close.textContent = "PLAY"
@@ -305,6 +352,9 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
   const doOpen = (): void => {
     if (open) return
     open = true
+    // Before anything is drawn. The sheet takes 380ms to arrive and a child
+    // should not hear the game for those 380ms.
+    holdAudio()
     restore = (document.activeElement as HTMLElement) ?? null
     place()
     sheetClass()
@@ -314,6 +364,7 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     help.setAttribute("aria-expanded", "true")
     body.scrollTop = 0
     sheet.focus()
+    spec.onOpen?.()
   }
 
   const doClose = (): void => {
@@ -327,14 +378,8 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     help.setAttribute("aria-expanded", "false")
     restore?.focus?.()
     restore = null
+    releaseAudio()
     spec.onClose?.()
-  }
-
-  // A tap on the scrim closes; a tap inside the sheet must not. Children tap
-  // the background constantly and being thrown out of the rules mid-read is
-  // worse than having to find the button.
-  const onScrim = (e: Event): void => {
-    if (e.target === scrim) doClose()
   }
 
   // ---- drag to dismiss -----------------------------------------------------
@@ -418,10 +463,81 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
   globalThis.addEventListener("keydown", swallow, true)
   globalThis.addEventListener("keyup", swallow, true)
 
+  // The same swallow, for the other input.
+  //
+  // The scrim covers the game to the eye, but a pointer event that lands on it
+  // still travels to whatever the game bound on its canvas, its root or
+  // `globalThis` — so the sheet only LOOKED modal. Tapping the background to
+  // dismiss the manual also fired a shot, a shear or a swipe underneath it, and
+  // in the eleven games with no gating of their own that is the whole of what
+  // "the game keeps playing while I read" means for touch.
+  //
+  // Ours pass and everything else stops. `stopPropagation` in capture prevents
+  // an event reaching its own target's listeners too, so stopping one of our
+  // nodes would take the drag dismissal, PLAY and tap-to-close with it.
+  //
+  // `pointerup` is swallowed along with the rest, which means a game holding a
+  // drag when the sheet opens does not get the release that ends it. That is the
+  // same trade the key swallow already makes with `keyup`, and it is the right
+  // way round: letting "up" through would fire every game that acts on release,
+  // which is most of them, and the drag can only have been started by a finger
+  // that is about to be lifted anyway.
+  const POINTERS = [
+    "pointerdown",
+    "pointermove",
+    "pointerup",
+    "pointercancel",
+    "mousedown",
+    "mousemove",
+    "mouseup",
+    "touchstart",
+    "touchmove",
+    "touchend",
+    "touchcancel",
+    "wheel",
+    "contextmenu",
+    "click",
+    "dblclick",
+  ] as const
+
+  const swallowPointer = (e: Event): void => {
+    // The tap that OPENS the manual is a tap on one of ours, so the rule below
+    // would let it through to the game as well — and opening the rules cost a
+    // move. The help control is handled in both directions: its gestures never
+    // reach the game, and its `click`, which is what actually opens the sheet,
+    // is left alone whether the sheet is up or not.
+    if (e.target === help) {
+      if (e.type !== "click" && e.type !== "dblclick") e.stopPropagation()
+      return
+    }
+    // The scrim IS the background. It is `inset:0`, so a tap "on the game" is a
+    // tap on the scrim, and letting our own elements through unconditionally
+    // would have let every one of those reach the game — which is the whole
+    // defect, not an edge of it.
+    //
+    // So closing on a background tap is done HERE, in capture, for the same
+    // reason Escape is: a bubble listener on the scrim could only run if the
+    // event were allowed to travel, and allowing it to travel is what feeds the
+    // game. Children tap the background constantly, and a tap inside the sheet
+    // must still not dismiss it — being thrown out of the rules mid-read is
+    // worse than having to find the button.
+    if (e.target === scrim) {
+      if (!open) return
+      e.stopPropagation()
+      if (e.type === "pointerdown") doClose()
+      return
+    }
+    if (ours.has(e.target)) return
+    if (open) e.stopPropagation()
+    // Closed, and not one of ours: the game is being played and must hear every
+    // one of them. A gate stuck shut is the same bug as a gate stuck open.
+  }
+
+  for (const t of POINTERS) globalThis.addEventListener(t, swallowPointer, true)
+
   const draggers = [grab, head]
   help.addEventListener("click", doOpen)
   close.addEventListener("click", doClose)
-  scrim.addEventListener("pointerdown", onScrim)
   for (const el of draggers) {
     el.addEventListener("pointerdown", onDown)
     el.addEventListener("pointermove", onMove)
@@ -436,12 +552,18 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
       return open
     },
     destroy(): void {
+      // A pack torn down mid-read must not leave the sound held: the hold is
+      // process-wide and nothing would ever come back to lift it.
+      if (open) {
+        open = false
+        releaseAudio()
+      }
       stopInsets()
       globalThis.removeEventListener("keydown", swallow, true)
       globalThis.removeEventListener("keyup", swallow, true)
+      for (const t of POINTERS) globalThis.removeEventListener(t, swallowPointer, true)
       help.removeEventListener("click", doOpen)
       close.removeEventListener("click", doClose)
-      scrim.removeEventListener("pointerdown", onScrim)
       for (const el of draggers) {
         el.removeEventListener("pointerdown", onDown)
         el.removeEventListener("pointermove", onMove)


### PR DESCRIPTION
> "All games should pause while reading the instructions .. I can hear counterweight playing in the background while I'm reading the instructions ... stressing me out even more .. it's so stressful I don't even want to QA it."

A child opens the rules BECAUSE they are overwhelmed. Getting shouted at by the game while they read is the worst moment in the product to be loud.

Pausing had been fixed **per game five times** — #642 for VOLTA and MOSAIC, then trebuchet, coil, foundry and guilty one at a time — and eleven of the twenty-seven still had none. Every per-game fix is a fix the twenty-eighth pack will not get, so this moves it into the seam every game already goes through.

Only `dynawalla/packs/shared/game-chrome/` is touched. **No file under `dynawalla/games/` is edited.**

## The mechanism

**Sound — every game, no change on their side.** `audioHold.ts` replaces `AudioContext` *and* `webkitAudioContext` with a `Proxy` whose `construct` trap registers the instance. All twenty-seven audio modules resolve their constructor lazily, inside the method that makes the context (`globalThis.AudioContext ?? globalThis.webkitAudioContext`) — none caches it at module scope — so the wrap reaches every one of them with no import, no callback and no line of wiring. `rhythm` reads the prefixed name *first*, which is why both are wrapped.

It **holds**, it does not fire once. Every pack calls `audio.resume()` on any gesture because Web Audio needs one, so a single `suspend()` would be undone by the first tap. While held, a context's own `resume()` records the intent and returns; the intent is honoured on release, so a game that asked for sound during the read is not left mute.

Whether a context is resumed on release is decided by **whether the game wanted it running**, never by whether we suspended it — so a game already paused by its own pause screen, a phone call, or the host putting a sheet over the frame comes back exactly as it was.

Calls are **serialised per context**. `suspend()` and `resume()` are promises and a child can open and shut the sheet inside a frame; in parallel the resume can complete first and the late suspend then lands on a game that is being played — permanent silence, worse than the noise.

**Taps — every game, no change on their side.** The scrim is `inset:0`, so a tap "on the game" *is* a tap on the scrim, and it still travelled to whatever the game bound on its canvas, its root or `globalThis`. The sheet only *looked* modal: dismissing it fired a shot or a shear underneath. A capture-phase pointer swallow now mirrors the key swallow, and tap-to-close moved into it for the same reason Escape lives there — a bubble listener on the scrim can only run if the event is allowed to travel, and allowing it to travel is what feeds the game. The tap that opens the manual no longer fires the game either.

Membership is a `Set` of the nodes this module made — **not** `contains`, `closest` or `parentNode`, which the games' hand-rolled fake elements do not have. That is the trap `style.setProperty` and `classList` each fell into, and this file's whole history is that trap.

**Clock — opt-in, and labelled as such.** `onOpen` joins `onClose` for a simulation that would keep advancing. Opt-in is how the noise defect happened, so it is deliberately not the mechanism for anything that could be done without it.

## Coverage, honestly

**Sound, taps and keys: all 27 games, today, with zero changes.** Nothing to dispatch.

**Simulation clock: 16 of 27 already freeze their loop** and need nothing — arena, claim, coil, forge, foundry, guilty, horde, lattice, merge, mosaic, polarity, pulse, rhythm, runner, trebuchet, truedraw.

**11 still simulate behind the sheet** and would each need one `onOpen`/`onClose` pair: **balance, beam, colossus, counterweight, merge-idle, serpent, siege, skyledger, slice, stack, street**. Those files are held by other agents right now, so this PR does not touch them. For most, the audible half of the complaint — including COUNTERWEIGHT, the game in the report — is fixed by the audio hold alone; what remains is a wall that keeps rising or a timer that keeps counting while a child reads.

## Audio mid-note

`suspend()` freezes the graph: the context clock stops, an oscillator holds where it is and every scheduled envelope point holds with it, so on resume the note continues from that instant rather than jumping. Two honest costs, both documented in the module:

- the cut is a discontinuity, so a loud sustained voice (COUNTERWEIGHT's bowed drone is the obvious one) **can click going down**;
- a game whose simulation keeps running schedules new sounds against a **frozen `currentTime`**, which then all land in the same instant when the clock restarts. That is a real argument for `onOpen` in the eleven above — not an argument for leaving the sound on.

## Proving it

The gap was proven first, against the unmodified module: `the game is still making noise behind the manual` (`'running'` ≠ `'suspended'`) and `the game saw pointerdown,pointermove,pointerup,touchstart,mousedown,wheel behind the manual`.

51 tests, suite run 5× clean, `tsc --noEmit` clean, and **all 27 game suites re-run green** (1 971 tests) plus `tsc` on counterweight, rhythm and mosaic.

Every test was verified by deleting the guard it covers — 17 mutations, 17 failures:

| deleted | first failure |
|---|---|
| `holdAudio()` in `doOpen` | `the game is still making noise behind the manual` |
| `releaseAudio()` in `doClose` | `the game came back silent` |
| the hold outlasting the game's `resume()` | `the game resumed itself while the manual was up` |
| `wanted` read from state → hardcoded true | `closing the manual restarted a game that was paused` |
| suspend for a context born during a read | `a context made behind the manual started playing` |
| `destroy` lifting the hold | `the pack was torn down with its audio still held` |
| the nesting guard | `the outer hold was ignored` |
| the pointer swallow | `the game saw pointermove,pointerup,… behind the manual` |
| the scrim branch's `stopPropagation` | `the dismissing tap hit the game` |
| the help-control branch | `opening the rules fired the game` |
| `spec.onOpen?.()` | `onOpen fired for an open that did not happen` |
| `webkitAudioContext` from the wrap list | `webkitAudioContext was never wrapped` |
| per-context serialisation | `the game came back mute after a quick look` |
| the double-wrap guard | `the wrapper was wrapped again` |
| the unmatched-release guard | `the next read was not held` |
| forgetting a closed context | `the hold resumed a closed context` |
| `holdAudio` reading state at each nested hold | `the outer hold was ignored` |

Three tests survived their mutation on the first pass and were rewritten until they did not; one piece of genuinely dead code (a redundant prune) was deleted rather than left untested.

## Only a device can confirm

- whether the drone's cut is audible as a click on real hardware, and whether it is worth a fade;
- how big the scheduled-event pile-up sounds on release in the eleven games that keep simulating;
- that `globalThis.AudioContext` is writable in WKWebView and Android WebView — the assignment is in a `try` and warns loudly if it is not, but nothing here proves it succeeds;
- that a game holding a pointer capture when the sheet opens recovers cleanly. `pointerup` is swallowed with the rest, which is the same trade the key swallow already makes with `keyup`.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
