### PR TITLE
dynawalla/games/counterweight: THE STEELYARD — the window belongs to the weight, not to the Turk

### DIFF
--- a/dynawalla/games/counterweight/README.md
+++ b/dynawalla/games/counterweight/README.md
@@ -1,9 +1,11 @@
-# THE COUNTERWEIGHT
+# THE STEELYARD
 
 > His pan carries the sum and never its total. Yours carries a number you steer
 > with place-value counterweights. Hold exactly one notch ahead.
 
-An arm-wrestle across a steelyard beam. Rank 30, S tier, in
+An arm-wrestle across a steelyard beam. The directory is still `counterweight`;
+the game is **THE STEELYARD**, renamed away from `games/balance`'s COUNTERPOISE,
+which it was being confused with. Rank 30, S tier, in
 [`docs/catalog/ARCADE_CANON.md`](../../docs/catalog/ARCADE_CANON.md), after
 *Arm Wrestling* (1985). The canon entry calls it **the most unmashable design in
 the catalogue**, which is a claim about behaviour, so
@@ -69,7 +71,7 @@ costs 13. Strain bleeds out at 6 a second and the beam shears at 34.
 |---|---|
 | Hits everything as fast as a thumb moves | Shears in about a fifth of a second, every round, forever |
 | Hits one plate fast | Same |
-| Hits one plate slowly, under the resonance window | Never shears — and never gets anywhere either: the window is thirteen seconds, a pan only travels so far in ones, and nothing about walking it lands on the one notch |
+| Hits one plate slowly, under the resonance window | Never shears — and never gets anywhere either: a pan only travels so far in ones, and nothing about walking it lands on the one notch |
 | Hunts by watching which way the beam leans | Every probe needs the beam to stop ringing first, and the window runs out |
 | Does the arithmetic | Ten deliberate blows, a quarter-second apart, peaks at about a third of the shear limit |
 
@@ -78,13 +80,62 @@ That last row is the one that makes the rest mean anything, so
 over and shears the beam never, while every masher, every hammer on every one of
 the eight faces, and the beam-watcher put over **zero**.
 
-Two more pressures keep the round live without being mashable:
+Two more pressures keep the round live without being mashable — and neither of
+them charges a child for thinking:
 
-* **The clock.** The window closes and the beam is seated where it stands. The
-  whistle does not wait, and the load you had on the bar is the claim you made.
+* **The clock.** The window belongs to the weight, not to the Turk. See
+  [The window](#the-window).
 * **The sag.** A pan nobody is tending settles — one unit, then another. You
-  cannot find the notch early and sit on it. Any strike re-seats it, so this only
-  ever bites a player who has stopped playing.
+  cannot find the notch early and sit on it. Any strike re-seats it, and **it
+  does not run at all before your first blow of the round**, so it only ever
+  bites a player who has stopped playing rather than one who has not started.
+
+## The window
+
+The press window used to be `timingForBout()`: 13.0 s at the first Turk, 1.1 s
+less at every one after, down to a 7.6 s floor. The bout counter is also what
+escalates the arithmetic, so the child got less time exactly as the sums got
+harder — the defect `docs/PACING_AUDIT_2026-07.md` names in seventeen games, and
+this pack's own solver bot measured it: at the house cadence table's p90 for a
+two-digit regrouping the bot held **0 of 78 rounds**.
+
+[`game/window.ts`](src/game/window.ts) replaces it. The window is
+`comprehension(item) + motor(item)`, both pure functions of the weight on his
+pan, both monotone non-decreasing in its width, and **no bout number, elapsed
+time or speed may appear in either**.
+
+| item | comprehension | motor | window | was |
+|---|---|---|---|---|
+| `43 + 25` | 11.0 s | 3.5 s | **14.5 s** | 13.0 → 7.6 s |
+| `47 + 25` | 14.0 s | 3.5 s | **17.5 s** | 13.0 → 7.6 s |
+| `473 + 168` | 23.0 s | 5.25 s | **28.3 s** | 13.0 → 7.6 s |
+| `5,001 − 2,798` | 40.0 s | 7.0 s | **47.0 s** | 13.0 → 7.6 s |
+
+The comprehension term is the house cadence table's **p90**, not its p50: the
+window is where the whistle takes the round away, so it is sized for the child
+who is slow today. The motor term is the one the old window did not have at all
+— the plates the answer decomposes into, priced at `BASE_STRAIN / BLEED_PER_SEC`,
+the fastest cadence [`strain.ts`](src/game/strain.ts) lets a correct player
+sustain without shearing. At the top of the old ladder a p90 plan was 7.0 s of
+pure motor work inside a 7.6 s window.
+
+**The whistle takes nothing.** Running out of time is not a wrong answer: no
+ground moves, nothing is reported, and the item is closed with the host's `skip`
+rather than with a `report` that would file a miss and walk the ladder down on a
+child who was still carrying the hundreds column.
+
+## Escalation
+
+The Turk gets stronger by the arithmetic and by nothing else. There is no bout
+counter in any duration in the game.
+
+[`game/ladder.ts`](src/game/ladder.ts) names a rung on every single weight —
+`next({ difficulty, maxDifficulty })`. The opening rung is the bottom of the
+curriculum, which is what "it starts way too hard" was: the game used to ask for
+nothing and take whatever the scheduler had stocked. It climbs one rung per Turk
+put over — five net holds, achievement and never a clock — and comes back down
+one on a pinning. `raiseFloor` is deliberately not called: a permanent floor is
+exactly what would stop a struggling child getting easier work again.
 
 ## The beam
 
@@ -103,6 +154,11 @@ Place value is a thing you can hear here.
 the beam moving *is* the information; it is critically damped instead, so it
 travels to its reading and stops rather than ringing its way there. Same reading,
 same reach, same clock — every duration in `TIMING_REDUCED` is identical.
+
+Your load stays where you left it between rounds, which is what makes each round
+only the *difference*. The one exception is when the ladder moves out from under
+it: a pan sitting on 8,367 when the next weight is `43 + 25` is re-racked near
+the new magnitude rather than costing a whole calm round of unwinding.
 
 ## The arithmetic it is served
 
@@ -130,7 +186,7 @@ defeat.
 ```
 npm install
 npm run dev        # the standalone harness on :4327, stub host, no runtime needed
-npm test           # 78 cases: the rules, the strain, the beam, the mashers
+npm test           # 136 cases: the rules, the window, the ladder, the strain, the mashers
 npm run tsc
 npm run build:pack # the installable pack
 ```

--- a/dynawalla/games/counterweight/index.html
+++ b/dynawalla/games/counterweight/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <meta name="color-scheme" content="dark" />
-    <title>THE COUNTERWEIGHT — dev harness</title>
+    <title>THE STEELYARD — dev harness</title>
     <style>
       html,
       body {

--- a/dynawalla/games/counterweight/pack.html
+++ b/dynawalla/games/counterweight/pack.html
@@ -8,7 +8,7 @@
     />
     <meta name="color-scheme" content="dark" />
     <meta name="theme-color" content="#0a0b0e" />
-    <title>THE COUNTERWEIGHT</title>
+    <title>THE STEELYARD</title>
     <style>
       html,
       body {

--- a/dynawalla/games/counterweight/pack.json
+++ b/dynawalla/games/counterweight/pack.json
@@ -1,7 +1,7 @@
 {
   "id": "dynawalla.counterweight",
   "version": "0.1.0",
-  "name": "THE COUNTERWEIGHT",
+  "name": "THE STEELYARD",
   "description": "An arm-wrestle across a steelyard beam. His pan carries a column sum and never its total; yours carries a number you steer with place-value counterweights. Hold exactly one notch ahead and seat the beam — but steel struck in a rhythm shears.",
   "sdk": "1.0.0",
   "host": { "min": "0.1.0", "max": "1.0.0" },

--- a/dynawalla/games/counterweight/package.json
+++ b/dynawalla/games/counterweight/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "THE COUNTERWEIGHT — a steelyard arm-wrestle against the Iron Turk. His pan carries a column sum you must evaluate; yours carries a number you steer with place-value counterweights. Hold one notch ahead.",
+  "description": "THE STEELYARD — a steelyard arm-wrestle against the Iron Turk. His pan carries a column sum you must evaluate; yours carries a number you steer with place-value counterweights. Hold one notch ahead.",
   "engines": {
     "node": ">=22.12"
   },

--- a/dynawalla/games/counterweight/src/contract.ts
+++ b/dynawalla/games/counterweight/src/contract.ts
@@ -16,8 +16,33 @@ export type Question = {
 }
 
 export type Host = {
-  next(opts?: { domain?: string; difficulty?: number }): Question
+  /**
+   * `difficulty` is the rung the yard is asking for and `maxDifficulty` is the
+   * ceiling it wants the stream held under. Both on the host's ladder scale,
+   * where `1` is the bottom. See `game/ladder.ts` — the game names a rung on
+   * every single weight, because a game that names none gets whatever the
+   * scheduler had stocked, and on a fresh session that is how a child meets a
+   * borrow across a zero on their first round.
+   */
+  next(opts?: { domain?: string; difficulty?: number; maxDifficulty?: number }): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+
+  /**
+   * The child did not answer this one. Close it; record nothing.
+   *
+   * OPTIONAL and feature-detected, like `transition` — a host that predates it
+   * simply does not hear about the round, which is strictly better than what
+   * this game used to do.
+   *
+   * **Why it is not a `report`.** `report` forwards `answered` to the host's
+   * item ledger, so a whistle filed as `{ correct: false }` is not recorded as
+   * "unanswered" — it is a MISS, it takes a wrong attempt against the learner
+   * model, and it walks the ladder down. The child who ran out of time while
+   * carrying the hundreds column has told us nothing about what they know, and
+   * this is the ending that says nothing back.
+   */
+  skip?(questionId: string): void
+
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean
 

--- a/dynawalla/games/counterweight/src/game/bout.ts
+++ b/dynawalla/games/counterweight/src/game/bout.ts
@@ -1,4 +1,4 @@
-// THE COUNTERWEIGHT — the rules.
+// THE STEELYARD — the rules.
 //
 // A steelyard beam between you and the Iron Turk.
 //
@@ -14,17 +14,31 @@
 //   * Strike **SEAT** and the beam is judged. One notch ahead and he gives
 //     ground. Anything else and he takes it.
 //
-// Three pressures keep it live, and none of them is a mash:
+// Three pressures keep it live, and none of them is a mash — and none of them,
+// now, is allowed to charge a child for thinking:
 //
-//   1. **The clock.** The round has a window; when it runs out the beam is
-//      seated where it stands. The whistle does not wait.
-//   2. **The sag.** Leave the beam alone and your pan settles — one unit, then
-//      another. You cannot find the notch early and sit on it. Any strike
-//      re-seats the pan and the sag starts over, so this only bites a player who
-//      has stopped playing.
+//   1. **The clock.** The round has a window, and the window is a pure function
+//      of the weight on his pan — see `window.ts`. When it runs out the round is
+//      simply over: no verdict, no ground either way, nothing reported. A child
+//      who was still carrying the hundreds column has told us nothing about what
+//      they know, and a game that filed that as a wrong answer would be lying to
+//      the curriculum about them.
+//   2. **The sag.** Leave the beam alone *after you have moved it* and your pan
+//      settles — one unit, then another. You cannot find the notch early and sit
+//      on it. **It does not run before your first blow of the round**, which is
+//      the whole of the child's reading time: a pan that drained while they read
+//      his column made the arithmetic they had just done wrong by the time they
+//      reached the rack, and that is what "sometimes the timing is sort of
+//      impossible" was.
 //   3. **The strain.** Every strike rings the steel and strain does not bleed
 //      out as fast as a mash puts it in. See `strain.ts` — that module is the
 //      answer to "what stops a child hitting plates fast".
+//
+// **The Turk gets stronger by the arithmetic and by nothing else.** There is no
+// bout counter in any duration in this file. The window, the sag and the shear
+// limit are the same at the ninth Turk as at the first; what changes is the rung
+// the yard asks the host for — `ladder.ts` — which moves on Turks put over and
+// comes back down on a pinning.
 //
 // What crosses to the host is `load − 1`: the value the child's beam asserts his
 // column sum to be. Get the sum right and it is the canonical value. Drop a
@@ -32,8 +46,9 @@
 // extra wiring — the game never compares anything to an answer.
 
 import type { Question } from "../contract.ts"
-import { applyStrike, PILLAR_COOLDOWN_MS, type Place, type Strike } from "./places.ts"
+import { applyStrike, PILLAR_COOLDOWN_MS, strikesFor, type Place, type Strike } from "./places.ts"
 import { Strain } from "./strain.ts"
+import { MIN_PRESS_SECONDS, pressMsFor } from "./window.ts"
 
 /** How far the arm travels before somebody is over. */
 export const GROUND = 5
@@ -46,16 +61,25 @@ export type Phase =
   /** The verdict is showing. */
   | "settle"
 
-export type Verdict = "true" | "short" | "over" | "shear"
+export type Verdict =
+  | "true"
+  | "short"
+  | "over"
+  | "shear"
+  /** The whistle blew on a round nobody declared. Costs nothing, says nothing. */
+  | "expired"
 
+/**
+ * Everything with a duration except the press window, which is not here on
+ * purpose: it belongs to the item, it lives in `window.ts`, and a field for it
+ * in this record is how it would get a game constant folded back into it.
+ */
 export type Timing = {
   /** The weight coming down. */
   readonly hangMs: number
-  /** The window to find the notch and seat it. */
-  readonly pressMs: number
   /** The verdict beat. */
   readonly settleMs: number
-  /** Quiet time before the pan starts to settle. */
+  /** Quiet time, after the first blow of the round, before the pan settles. */
   readonly sagGraceMs: number
   /** How long each further unit of sag takes. */
   readonly sagPeriodMs: number
@@ -65,10 +89,12 @@ export type Timing = {
 
 export const TIMING: Timing = {
   hangMs: 760,
-  pressMs: 13000,
   settleMs: 1150,
-  sagGraceMs: 1500,
-  sagPeriodMs: 1300,
+  // Was 1500/1300, and tightening with every Turk. A child mid-execution is
+  // striking every third of a second, so this never fires on them; it fires on a
+  // pan that has been parked, which is the only thing it was ever for.
+  sagGraceMs: 3000,
+  sagPeriodMs: 1600,
   shearAt: 34,
 }
 
@@ -81,21 +107,18 @@ export const TIMING: Timing = {
 export const TIMING_REDUCED: Timing = TIMING
 
 /**
- * The Turk gets stronger. Never by making the arithmetic unfair — the host owns
- * the ladder — but by shortening the window, tightening the steel and grinding
- * harder.
+ * How far out of position the pan may be before the yard re-racks it.
+ *
+ * Your load staying where you left it is the good rule and it holds nearly
+ * always: consecutive weights of the same size are a handful of strikes apart.
+ * What it cannot survive is the ladder moving under it — a pan sitting on 8,367
+ * when the next weight is `43 + 25` costs a whole round of unwinding before any
+ * arithmetic happens, which is a calm round spent on nothing. So when the load
+ * is this many strikes worse than a fresh seed would be, the yard racks it back.
+ * Measured in strikes rather than in magnitude because strikes are the thing
+ * that costs the child time.
  */
-export function timingForBout(bout: number, base: Timing = TIMING): Timing {
-  const step = Math.max(0, bout - 1)
-  return {
-    hangMs: base.hangMs,
-    pressMs: Math.max(7600, base.pressMs - step * 1100),
-    settleMs: base.settleMs,
-    sagGraceMs: Math.max(900, base.sagGraceMs - step * 120),
-    sagPeriodMs: Math.max(750, base.sagPeriodMs - step * 110),
-    shearAt: Math.max(24, base.shearAt - step * 2),
-  }
-}
+export const RERACK_SLACK = 5
 
 export type Match = {
   /** Which Turk, one-based. */
@@ -104,6 +127,8 @@ export type Match = {
   arm: number
   /** Turks put over, this session. */
   won: number
+  /** Times pinned, this session. The relief half of the ladder. */
+  pinned: number
   /** Rounds seated exactly true, this session. */
   held: number
 }
@@ -123,6 +148,8 @@ export type Seat = {
 
 export type BoutEvent =
   | { kind: "hang"; question: Question; delta: number }
+  /** The yard racked the pan back — the ladder moved out from under it. */
+  | { kind: "rerack"; load: number }
   | { kind: "open" }
   | { kind: "strike"; strike: Strike; load: number; impulse: number }
   | { kind: "refused"; reason: "cooldown" | "phase" }
@@ -151,27 +178,33 @@ export function openingLoad(target: number): number {
  */
 export class Bout {
   private readonly deal: () => Question
-  private readonly base: Timing
   private phaseName: Phase = "hang"
   private elapsed = 0
   private duration: number
-  private state: Match = { bout: 1, arm: 0, won: 0, held: 0 }
+  private state: Match = { bout: 1, arm: 0, won: 0, pinned: 0, held: 0 }
   private current: Question | null = null
   private target = 0
   private loadValue = 0
   private lastSeat: Seat | null = null
   private strainMeter: Strain
-  private timing: Timing
+  private readonly timing: Timing
+  /** This round's window. Set from the item at `hang`, from nothing else ever. */
+  private pressWindowMs: number
   private readonly cooldowns = new Map<Place, number>()
   private sagIdleMs = 0
+  /**
+   * Whether the sag is live yet. False until the child's first blow of the
+   * round: reading his column is not "leaving the pan alone".
+   */
+  private sagArmed = false
   private stopped = false
   private started = false
   private seeded = false
 
   constructor(deal: () => Question, base: Timing = TIMING) {
     this.deal = deal
-    this.base = base
-    this.timing = timingForBout(1, this.base)
+    this.timing = base
+    this.pressWindowMs = MIN_PRESS_SECONDS * 1000
     this.strainMeter = new Strain({ shearAt: this.timing.shearAt })
     this.duration = this.timing.hangMs
   }
@@ -227,6 +260,17 @@ export class Bout {
 
   get timings(): Timing {
     return this.timing
+  }
+
+  /**
+   * This round's window, in milliseconds.
+   *
+   * A property of the weight on his pan and of nothing else — not of the Turk,
+   * not of the arm, not of how long anybody has been playing. `window.ts` is the
+   * only thing that can produce it.
+   */
+  get pressMs(): number {
+    return this.pressWindowMs
   }
 
   /** Whether this pillar is still swinging back. */
@@ -293,6 +337,9 @@ export class Bout {
     this.cooldowns.set(strike.place, PILLAR_COOLDOWN_MS)
     const impulse = this.strainMeter.strike()
     this.loadValue = applyStrike(this.loadValue, strike)
+    // The first blow of the round is what arms the sag. Before it, the child is
+    // reading his column, and reading is not neglect.
+    this.sagArmed = true
     this.sagIdleMs = 0
     const events: BoutEvent[] = [{ kind: "strike", strike, load: this.loadValue, impulse }]
     if (this.strainMeter.isSheared) events.push(...this.judge(false, "shear"))
@@ -315,12 +362,15 @@ export class Bout {
 
     if (this.phaseName === "press") {
       this.strainMeter.advance(dt)
-      // The pan settles under a load nobody is tending.
-      this.sagIdleMs += dt
-      while (this.sagIdleMs >= this.timing.sagGraceMs + this.timing.sagPeriodMs) {
-        this.sagIdleMs -= this.timing.sagPeriodMs
-        this.loadValue -= 1
-        events.push({ kind: "sag", load: this.loadValue })
+      // The pan settles under a load nobody is tending — but only once somebody
+      // has tended it. A round nobody has touched yet is a round being read.
+      if (this.sagArmed) {
+        this.sagIdleMs += dt
+        while (this.sagIdleMs >= this.timing.sagGraceMs + this.timing.sagPeriodMs) {
+          this.sagIdleMs -= this.timing.sagPeriodMs
+          this.loadValue -= 1
+          events.push({ kind: "sag", load: this.loadValue })
+        }
       }
     }
 
@@ -332,15 +382,23 @@ export class Bout {
     const over = this.elapsed - this.duration
     switch (this.phaseName) {
       case "hang": {
-        this.enter("press", this.timing.pressMs)
+        this.enter("press", this.pressWindowMs)
+        this.sagArmed = false
         this.sagIdleMs = 0
         events.push({ kind: "open" })
         break
       }
       case "press": {
-        // The whistle. The beam is judged where it stands — which is honest:
-        // that load is the claim the child had on the bar when time ran out.
-        events.push(...this.judge(false))
+        // The whistle. The round is **over**, not lost.
+        //
+        // It used to judge the beam where it stood, on the argument that the
+        // load was the claim the child had on the bar when time ran out. It is
+        // not. It is where they had got to, and marking it took ground off them
+        // *and* filed a wrong answer against a sum they were still working —
+        // which walks the host's ladder DOWN on a child who was doing the
+        // arithmetic. `mount.ts` closes the item with `skip` instead: an
+        // absence, which is what it is.
+        events.push(...this.expire())
         break
       }
       case "settle": {
@@ -349,13 +407,14 @@ export class Bout {
           this.state.won += 1
           this.state.bout += 1
           this.state.arm = 0
-          this.timing = timingForBout(this.state.bout, this.base)
           events.push({ kind: "won", bout })
         } else if (this.state.arm <= -GROUND) {
-          // Pinned. The Turk does not get stronger for it and nothing is taken
-          // away: the arm goes back to level and the same one squares up again.
-          // Stakes without loss — ADR-0009.
+          // Pinned. Nothing is taken away: the arm goes back to level and the
+          // same Turk squares up again. Stakes without loss — ADR-0009. What it
+          // does do is drop the rung the yard asks for, which is relief rather
+          // than punishment and is the only thing a pinning changes.
           this.state.arm = 0
+          this.state.pinned += 1
           events.push({ kind: "pinned", bout: this.state.bout })
         }
         events.push(...this.hang())
@@ -378,6 +437,12 @@ export class Bout {
       console.error("[counterweight] a question arrived with a non-integer answer", question.answer)
     }
     this.target = Number.isInteger(answer) ? answer : 0
+    // The window comes from the weight and from nothing else. Computed here, at
+    // the moment the item is known, so that by the time the phase machine needs
+    // it there is no other number it could have come from.
+    this.pressWindowMs = pressMsFor({ prompt: question.prompt, answer: this.target })
+
+    const events: BoutEvent[] = []
     // The very first weight of the session lands on an empty pan. Give it a
     // start within striking distance so the first round is arithmetic rather
     // than a hundred blows on the thousands pillar.
@@ -389,11 +454,47 @@ export class Bout {
     if (!this.seeded) {
       this.seeded = true
       this.loadValue = openingLoad(this.target)
+    } else {
+      const seat = openingLoad(this.target)
+      const fromHere = strikesFor(this.target + 1 - this.loadValue)
+      const fromSeat = strikesFor(this.target + 1 - seat)
+      // The ladder moved out from under the pan. Rack it back rather than spend
+      // the round unwinding the last one — the adaptation audit's one named
+      // defect in this pack.
+      if (fromHere > fromSeat + RERACK_SLACK) {
+        this.loadValue = seat
+        events.push({ kind: "rerack", load: this.loadValue })
+      }
     }
     this.strainMeter = new Strain({ shearAt: this.timing.shearAt })
+    this.sagArmed = false
     this.sagIdleMs = 0
     this.enter("hang", this.timing.hangMs)
-    return [{ kind: "hang", question, delta: this.target + 1 - this.loadValue }]
+    events.push({ kind: "hang", question, delta: this.target + 1 - this.loadValue })
+    return events
+  }
+
+  /**
+   * The whistle on a round nobody declared.
+   *
+   * No ground moves, no tally moves, nothing is reported. The only thing that
+   * happens is that the beat is spent showing the child that time went, and then
+   * the next weight comes down.
+   */
+  private expire(): BoutEvent[] {
+    const question = this.current
+    if (!question) return []
+    const seat: Seat = {
+      question,
+      verdict: "expired",
+      load: this.loadValue,
+      asserted: this.loadValue - 1,
+      ms: Math.max(0, Math.round(this.elapsed)),
+      declared: false,
+    }
+    this.lastSeat = seat
+    this.enter("settle", this.timing.settleMs)
+    return [{ kind: "seat", seat, arm: this.state.arm }]
   }
 
   private judge(declared: boolean, forced?: "shear"): BoutEvent[] {

--- a/dynawalla/games/counterweight/src/game/ladder.ts
+++ b/dynawalla/games/counterweight/src/game/ladder.ts
@@ -1,0 +1,69 @@
+// WHAT THE YARD ASKS FOR — the game's one difficulty knob.
+//
+// The game used to ask the host for nothing at all: `next({ domain: "add" })`,
+// take whatever comes off the front of the pool. So the opening round of a
+// session was whatever the scheduler happened to have stocked, which is how a
+// child could meet a four-digit borrow across a zero on their first weight. The
+// founder's word for it was "starts way too hard", and it was not a pacing
+// problem — it was the game never having said what it wanted.
+//
+// It says now. Two rules, and they are the whole module:
+//
+//   1. **The opening rung is the bottom one.** Every session starts on the
+//      easiest thing the curriculum will serve, with a ceiling that stops the
+//      stream drifting above it.
+//   2. **It moves on achievement, never on a clock.** A rung per Turk put over,
+//      which costs five net holds — the same shape `siege` uses, where the wave
+//      counter advances only on *clear*. Nothing in here reads elapsed time,
+//      and there is no counter that only goes up.
+//
+// **And it comes back down.** A pinning drops the rung by one. That asymmetry
+// is deliberate: `raiseFloor` is on the host and is not called here, because a
+// permanent floor is exactly the thing that would stop a struggling child ever
+// getting easier work again. A floor is the right primitive for a game whose
+// waves cannot be un-cleared. This one is an arm-wrestle, and an arm-wrestle
+// goes both ways.
+
+/** The scale the host reads: `1` is the bottom of the ladder, `10` the top. */
+export const OPENING_RUNG = 1
+export const TOP_RUNG = 10
+
+/** What the match has actually achieved. Both directions, both earned. */
+export type Record = {
+  /** Turks put over. */
+  readonly won: number
+  /** Times pinned. */
+  readonly pinned: number
+}
+
+/**
+ * The rung to ask for.
+ *
+ * `null` — nothing played yet — is the opening rung, which is what makes the
+ * very first `next()` of a session an explicit request for the easiest item in
+ * the product rather than a shrug.
+ */
+export function rungFor(record: Record | null | undefined): number {
+  if (!record) return OPENING_RUNG
+  const rung = OPENING_RUNG + record.won - record.pinned
+  return Math.max(OPENING_RUNG, Math.min(TOP_RUNG, rung))
+}
+
+export type Request = {
+  readonly domain: string
+  readonly difficulty: number
+  readonly maxDifficulty: number
+}
+
+/**
+ * The whole request, ceiling included.
+ *
+ * The ceiling is the same rung and not a rung above it. Without it the host is
+ * free to serve anything in the pool that is *near* the ask, and "near" at the
+ * bottom of the ladder is the difference between `43 + 25` and a borrow across a
+ * zero.
+ */
+export function requestFor(record: Record | null | undefined): Request {
+  const rung = rungFor(record)
+  return { domain: "add", difficulty: rung, maxDifficulty: rung }
+}

--- a/dynawalla/games/counterweight/src/game/window.ts
+++ b/dynawalla/games/counterweight/src/game/window.ts
@@ -1,0 +1,193 @@
+// THE PRESS WINDOW — how long the round may last.
+//
+// `docs/EXPERIENCE_DESIGN.md` states this as a prohibition rather than a target:
+//
+//     T=0→C COMPREHENSION | not budgeted | The child's time. Measured, never
+//     limited.
+//
+// A steelyard round cannot take that literally — the whistle has to blow or the
+// beam never gets judged. What it CAN hold, and what this module exists to
+// guarantee, is the invariant underneath it:
+//
+//     **The window is monotone non-decreasing in the item's difficulty, and a
+//     pure function of the item.**
+//
+// Nothing in this file may read a bout number, a Turk, an arm, an elapsed time
+// or a speed. That is the decoupling, stated structurally, and the reason the
+// defect this replaces cannot be written here again.
+//
+// ── What it replaces ────────────────────────────────────────────────────────
+//
+// The window used to be `timingForBout()`: 13.0 s at the first Turk, falling
+// 1.1 s per Turk to a 7.6 s floor. The bout counter is also what escalates the
+// arithmetic, so the two moved together in opposite directions — the child got
+// less time exactly as the sums got harder. Measured on this package's own
+// solver bot, a player who took the house table's own p90 thinking time for a
+// two-digit regrouping (14 s) held **0 of 78 rounds** and never put a Turk over.
+//
+// Worse, at the floor the game was arithmetically impossible on its own hardest
+// rung. A four-digit column sum decomposes into a median 13 strikes and a p90 of
+// 20 (max 27 measured over 400 draws), and `strain.ts` shears the beam if those
+// blows are struck faster than the steel can bleed — `BASE_STRAIN /
+// BLEED_PER_SEC`, one blow every third of a second. Twenty blows at the fastest
+// safe cadence is 7.0 s of pure motor work inside a 7.6 s window: 0.6 s left for
+// a sum whose own documented p90 is forty seconds. Twenty-seven blows did not
+// fit at all.
+//
+// ── What it is now ──────────────────────────────────────────────────────────
+//
+// Two terms, both functions of the item alone, both monotone in its width:
+//
+//   * **Comprehension.** The house cadence table's p90 — the time to actually do
+//     the arithmetic. Not the p50: the window is the point at which the whistle
+//     takes the round away, so it is sized for the child who is slow today.
+//   * **Motor.** The time to physically strike the plates the answer decomposes
+//     into, priced at the fastest cadence the steel tolerates indefinitely. This
+//     is the term the old window did not have at all, and it is why this game
+//     needs a longer window than a game where the answer is a tap.
+//
+// The sum is a ceiling nobody fluent ever touches — the round ends the moment
+// SEAT is struck — not a pace anybody is held to.
+
+import { BASE_STRAIN, BLEED_PER_SEC } from "./strain.ts"
+
+/**
+ * Seconds by column count, from `docs/EXPERIENCE_DESIGN.md`: index 1 is the
+ * single-digit fact's p90, index 2 and index 4 are the two rows the table names
+ * outright (6 s/14 s for two-digit regrouping, 16 s/40 s for the `5,001 − 2,798`
+ * class), and index 3 is between them. Strictly increasing, which is half of the
+ * invariant.
+ *
+ * The same table `beam` reads in `beam/src/sim/window.ts`. Duplicated rather
+ * than imported because a game pack is a standalone build with its own
+ * `package.json` and nothing here may reach into a sibling; the audit's proposed
+ * `packs/shared/pacing` is where these two eventually meet.
+ */
+const BY_COLUMNS = [6, 6, 11, 18, 32] as const
+
+/**
+ * What regrouping is worth on top, per column count.
+ *
+ * `11 + 3 = 14` is the two-digit-with-regrouping row exactly and `32 + 8 = 40`
+ * is the `5,001 − 2,798` row exactly. Each is small enough that
+ * `BY_COLUMNS[n] + REGROUPING[n] <= BY_COLUMNS[n + 1]`, which is the other half
+ * of the invariant and is asserted rather than assumed.
+ */
+const REGROUPING = [0, 0, 3, 5, 8] as const
+
+/**
+ * The fastest cadence the steel tolerates for ever.
+ *
+ * A blow outside the resonance window costs `BASE_STRAIN`; the beam bleeds
+ * `BLEED_PER_SEC`. Strike slower than this ratio and strain trends to zero
+ * however long the plan is; strike faster and it climbs until the beam shears.
+ * So this is not a comfort figure — it is the floor the game's own physics puts
+ * under a correct player's execution, and pricing the motor budget below it
+ * would be the game shearing children for doing the arithmetic right.
+ */
+export const SUSTAINABLE_STRIKE_SECONDS = BASE_STRAIN / BLEED_PER_SEC
+
+/**
+ * What one strike is budgeted at: the sustainable cadence with a little room for
+ * a child's hand finding the plate.
+ */
+export const STRIKE_SECONDS = 0.35
+
+/**
+ * Strikes budgeted per column.
+ *
+ * `places.ts` decomposes every delta into balanced base-ten, and
+ * `places.test.ts` proves no low place is ever struck more than five times. The
+ * top pillar can exceed it — nothing above it to borrow from — which is what the
+ * clamp on `MAX_PRESS_SECONDS` and the generous comprehension term at four
+ * columns cover between them.
+ */
+export const STRIKES_PER_COLUMN = 5
+
+/** Nothing is ever answerable for less than this, whatever the parser makes of it. */
+export const MIN_PRESS_SECONDS = 9
+
+/**
+ * Nor for more. Not a budget — a guard against a malformed prompt parsing as
+ * nine columns and leaving a round open for two minutes.
+ */
+export const MAX_PRESS_SECONDS = 52
+
+export type Item = {
+  /** As the child reads it: `473 + 168`. */
+  readonly prompt: string
+  /** The canonical value the host revealed. Never computed here. */
+  readonly answer: number
+}
+
+/**
+ * The widest column count in the item — the operands and the answer together.
+ *
+ * The answer counts twice over here. It is a column wider than either operand
+ * whenever the top place carries, and it is also the value the child's pan has
+ * to travel to, so it sets the motor cost as well as the reading cost.
+ */
+export function widestColumn(item: Item): number {
+  let widest = 1
+  for (const run of item.prompt.match(/\d+/g) ?? []) widest = Math.max(widest, run.length)
+  if (Number.isInteger(item.answer) && item.answer > 0) {
+    widest = Math.max(widest, String(Math.abs(item.answer)).length)
+  }
+  return widest
+}
+
+const OPERATOR = /^\s*(\d+)\s*([+\-−–])\s*(\d+)\s*$/
+
+/**
+ * Does this item need a carry or a borrow anywhere?
+ *
+ * A prompt this cannot parse reads as **true**, which is the longer window.
+ * Guessing in the child's favour is the only direction this function is allowed
+ * to be wrong in.
+ */
+export function needsRegrouping(prompt: string): boolean {
+  const m = OPERATOR.exec(prompt)
+  if (!m) return true
+  const a = Number(m[1])
+  const b = Number(m[3])
+  if (!Number.isSafeInteger(a) || !Number.isSafeInteger(b)) return true
+  const add = m[2] === "+"
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    if (add && (x % 10) + (y % 10) >= 10) return true
+    if (!add && x % 10 < y % 10) return true
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return false
+}
+
+/** Columns, clamped to the table. */
+function columnsOf(item: Item): number {
+  return Math.max(1, Math.min(BY_COLUMNS.length - 1, widestColumn(item)))
+}
+
+/** The arithmetic's own time, off the house table. Nothing else is in here. */
+export function comprehensionSeconds(item: Item): number {
+  const columns = columnsOf(item)
+  const base = BY_COLUMNS[columns] ?? MIN_PRESS_SECONDS
+  return base + (needsRegrouping(item.prompt) ? (REGROUPING[columns] ?? 0) : 0)
+}
+
+/** The time to strike the plates, at a cadence the steel survives. */
+export function motorSeconds(item: Item): number {
+  return columnsOf(item) * STRIKES_PER_COLUMN * STRIKE_SECONDS
+}
+
+/**
+ * The whole window for this item, in milliseconds.
+ *
+ * Monotone non-decreasing in both inputs — more columns is never less time, and
+ * needing to regroup is never less time than not needing to — and a function of
+ * the item alone.
+ */
+export function pressMsFor(item: Item): number {
+  const seconds = comprehensionSeconds(item) + motorSeconds(item)
+  return Math.round(Math.max(MIN_PRESS_SECONDS, Math.min(MAX_PRESS_SECONDS, seconds)) * 1000)
+}

--- a/dynawalla/games/counterweight/src/mount.ts
+++ b/dynawalla/games/counterweight/src/mount.ts
@@ -1,4 +1,4 @@
-// THE COUNTERWEIGHT.
+// THE STEELYARD.
 //
 // The wiring, and nothing else: the rules are in `game/bout.ts`, the physics in
 // `sim/beam.ts`, the yard in `render/scene.ts`. This file owns the frame, the
@@ -12,6 +12,7 @@ import { Audio } from "./audio.ts"
 import { Bout, type BoutEvent, TIMING, TIMING_REDUCED } from "./game/bout.ts"
 import { loadTally, recordTally } from "./game/best.ts"
 import { splitPrompt, type Column } from "./game/column.ts"
+import { requestFor } from "./game/ladder.ts"
 import type { Place } from "./game/places.ts"
 import { Beam, MAX_TILT, TUNING, TUNING_REDUCED } from "./sim/beam.ts"
 import { PALETTE } from "./render/palette.ts"
@@ -49,13 +50,30 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
   const scene = new Scene(canvas)
   const audio = new Audio()
   const beam = new Beam(reduced ? TUNING_REDUCED : TUNING)
-  const bout = new Bout(() => host.next({ domain: "add" }), reduced ? TIMING_REDUCED : TIMING)
+
+  /**
+   * The deal reads the match *at the moment the weight is hung*, which is why it
+   * goes through a mutable handle rather than closing over a rung.
+   *
+   * `Bout.hang()` runs inside the same event batch that carries the `won` or
+   * `pinned` that caused it, and it runs FIRST — so a rung updated from those
+   * events in `handle()` below would always be one round stale. Reading
+   * `bout.match` lazily is what makes the Turk who just went over the reason the
+   * next weight is heavier.
+   */
+  let table: Bout | null = null
+  const bout = new Bout(
+    () => host.next(requestFor(table?.match)),
+    reduced ? TIMING_REDUCED : TIMING,
+  )
+  table = bout
 
   const guide = createInstructions(el, {
-    title: "THE COUNTERWEIGHT",
+    title: "THE STEELYARD",
     summary: [
       "The Iron Turk's pan holds a sum. Work out its answer yourself — it is never shown.",
       "Load your pan to exactly one more than his answer, then press SEAT.",
+      "Take as long as you need to work it out. Nothing moves until you touch the rack.",
     ],
     sections: [
       {
@@ -64,6 +82,7 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
           "There are four pillars: thousands, hundreds, tens and ones.",
           "The top face of a pillar adds one of that size. The bottom face takes one off.",
           "Your load stays where you left it. Each round you only change the difference.",
+          "If his weights change size, the yard racks your pan back near them.",
         ],
       },
       {
@@ -89,8 +108,16 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
           "The beam is a bar of steel. Hit it again while it is still ringing and the ring grows.",
           "Ring it too hard and the beam shears, and the round is over.",
           "Leave a beat between blows and that never happens.",
-          "The window closes on its own. Whatever is on your pan then is your answer.",
-          "If you stop touching the rack your pan slowly settles. Any strike puts it back.",
+        ],
+      },
+      {
+        heading: "The whistle",
+        lines: [
+          "Each weight has its own window, and a bigger sum gets a longer one.",
+          "It is long enough to work the sum out and strike every plate it needs.",
+          "If it does run out, the round is simply over. No ground is lost.",
+          "Once you have started striking, a pan left alone slowly settles.",
+          "Any strike puts it back, and it never settles before your first blow.",
         ],
       },
     ],
@@ -157,7 +184,23 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
           audio.sag()
           break
         }
+        case "rerack": {
+          beam.aim(bout.margin)
+          audio.sag()
+          host.haptic("light")
+          scene.flash(PALETTE.brassDim, 200)
+          break
+        }
         case "seat": {
+          if (event.seat.verdict === "expired") {
+            // The whistle. Close the item and say nothing about it — not
+            // `report`, which would file a miss against a sum the child was
+            // still working and step the host's ladder down for it.
+            skip(event.seat.question.id)
+            beam.aim(bout.margin)
+            audio.sag()
+            break
+          }
           report(event.seat.question.id, event.seat.verdict === "true", event.seat.asserted)
           beam.aim(bout.margin)
           if (event.seat.verdict === "true") {
@@ -204,6 +247,19 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
           break
       }
     }
+  }
+
+  /**
+   * Close an item nobody answered.
+   *
+   * Shares the `reported` set with `report`, which is what makes the two endings
+   * mutually exclusive: an item that expired can never also be reported, and an
+   * item that was seated can never also be skipped.
+   */
+  const skip = (questionId: string): void => {
+    if (questionId === "" || reported.has(questionId)) return
+    reported.add(questionId)
+    host.skip?.(questionId)
   }
 
   const report = (questionId: string, correct: boolean, asserted: number): void => {

--- a/dynawalla/games/counterweight/src/pack.ts
+++ b/dynawalla/games/counterweight/src/pack.ts
@@ -1,4 +1,4 @@
-// THE COUNTERWEIGHT, as a Dynawalla pack.
+// THE STEELYARD, as a Dynawalla pack.
 //
 // The seam and nothing else. `mount` is handed the real host in place of the
 // stub, because the adapter presents the same synchronous surface `Host` in
@@ -58,5 +58,5 @@ async function start(el: HTMLElement): Promise<void> {
 
 void start(root).catch((error: unknown) => {
   console.error("[counterweight] could not start", error)
-  renderNoHost(root, "THE COUNTERWEIGHT")
+  renderNoHost(root, "THE STEELYARD")
 })

--- a/dynawalla/games/counterweight/src/render/scene.ts
+++ b/dynawalla/games/counterweight/src/render/scene.ts
@@ -38,12 +38,16 @@ const VERDICT_WORD: Record<Verdict, string> = {
   short: "UNDER",
   over: "OVER",
   shear: "SHEARED",
+  expired: "TIME",
 }
 
 const VERDICT_HUE: Record<Verdict, string> = {
   true: PALETTE.seat,
   short: PALETTE.ember,
   over: PALETTE.ember,
+  // Deliberately the dimmest brass in the palette and not the ember: a whistle
+  // is not a verdict, nothing was lost, and it must not read like a buzzer.
+  expired: PALETTE.brassDim,
   shear: PALETTE.strain,
 }
 
@@ -493,6 +497,13 @@ export class Scene {
     }
     if (showing.verdict === "shear") {
       ctx.fillText(compact ? "SHEARED" : "SHEARED — TOO MANY BLOWS", cx, cy)
+      return
+    }
+    if (showing.verdict === "expired") {
+      // No number. The pan's load was never a claim — the child never said it —
+      // and printing it as one would be the screen scoring a round the rules
+      // just decided not to score.
+      ctx.fillText(compact ? "TIME" : "TIME — NO GROUND LOST", cx, cy)
       return
     }
     // What the child claimed, never what the answer was. The number they put on

--- a/dynawalla/games/counterweight/src/stubHost.ts
+++ b/dynawalla/games/counterweight/src/stubHost.ts
@@ -23,7 +23,7 @@
 //      rule that would coincide with the correct procedure emits nothing at all.
 //      Never `answer ± 1`, and never a fixed offset off the answer.
 //
-// The third one earns its keep here. THE COUNTERWEIGHT never *places* a
+// The third one earns its keep here. THE STEELYARD never *places* a
 // distractor — there is nothing to choose between, only a beam to hold — but the
 // value the child's beam asserts is reported verbatim, so a child who drops a
 // carry seats their pan on the carry-dropped value and the Turk recognises it.
@@ -216,11 +216,34 @@ const GLYPH: Record<Op, string> = { add: "+", sub: "−" }
 /** The ladder's height, matching the host's `item.level / 8` normalisation. */
 const LEVELS = 8
 
+/**
+ * The host's rule for reading a difficulty, mirrored so the stub obeys the same
+ * wire the runtime does — `packs/shared/game-host`, `toUnit`:
+ *
+ *     value < 1   →  a fraction, used as is
+ *     value >= 1  →  a ladder index, `(value - 1) / 9`
+ *
+ * Without this the stub would ignore what the game asked for and the escalation
+ * tests would be measuring nothing.
+ */
+export function toUnit(value: number): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null
+  if (value < 1) return Math.max(0, value)
+  return Math.min(1, (value - 1) / 9)
+}
+
+/** A 0..1 rung as one of this stub's eight curriculum levels. */
+function levelForUnit(unit: number): number {
+  return Math.max(0, Math.min(LEVELS - 1, Math.round(unit * (LEVELS - 1))))
+}
+
 export type StubHostOptions = {
   seed?: number
   reducedMotion?: boolean
   /** Pin the ladder level instead of walking it. For tests and for capture runs. */
   level?: number
+  /** Observe skips, so a test can prove a whistle never reaches `report`. */
+  onSkip?: (questionId: string) => void
   /** Observe reports — the dev harness draws a running tally from this. */
   onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
   /** Observe haptics so the harness can show they fired on a device that has none. */
@@ -236,13 +259,24 @@ export function createStubHost(options: StubHostOptions = {}): Host {
   return {
     next(o) {
       served++
-      // A slow walk up the ladder, so a dev session sees two-digit sums first
-      // and four-digit borrows twenty rounds later — the shape of a real
-      // scheduler, without pretending to be one.
-      const level =
+      // What the game asked for wins, because that is the whole point of the
+      // request: the yard names a rung on every weight and this is what makes
+      // "the opening round is the easiest thing in the product" a claim a test
+      // can settle. Failing that — a caller that asks for nothing — a slow walk
+      // up the ladder, the shape of a real scheduler without pretending to be
+      // one.
+      const asked = o?.difficulty === undefined ? null : toUnit(o.difficulty)
+      const ceiling = o?.maxDifficulty === undefined ? null : toUnit(o.maxDifficulty)
+      const walked = Math.min(LEVELS - 1, Math.floor((served - 1) / 6))
+      let level =
         options.level !== undefined
           ? Math.max(0, Math.min(LEVELS - 1, Math.round(options.level)))
-          : Math.min(LEVELS - 1, Math.floor((served - 1) / 6))
+          : asked !== null
+            ? levelForUnit(asked)
+            : walked
+      if (options.level === undefined && ceiling !== null) {
+        level = Math.min(level, levelForUnit(ceiling))
+      }
       const op: Op = rng.chance(0.5) ? "add" : "sub"
       const [a, b] = operandsFor(op, level, rng)
       const answer = op === "add" ? a + b : a - b
@@ -269,6 +303,10 @@ export function createStubHost(options: StubHostOptions = {}): Host {
 
     report(r) {
       options.onReport?.(r)
+    },
+
+    skip(questionId) {
+      options.onSkip?.(questionId)
     },
 
     haptic(k) {

--- a/dynawalla/games/counterweight/src/test/bout.test.ts
+++ b/dynawalla/games/counterweight/src/test/bout.test.ts
@@ -4,14 +4,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import type { Question } from "../contract.ts"
-import {
-  Bout,
-  GROUND,
-  openingLoad,
-  TIMING,
-  type BoutEvent,
-  timingForBout,
-} from "../game/bout.ts"
+import { Bout, GROUND, openingLoad, RERACK_SLACK, TIMING, type BoutEvent } from "../game/bout.ts"
 import { planStrikes } from "../game/places.ts"
 
 function question(answer: number, id = "q1"): Question {
@@ -133,28 +126,51 @@ test("being pinned costs the arm and nothing else — no Turk, no tally, no puni
   // Stakes without loss: the same Turk squares back up, no harder than before.
   assert.equal(bout.match.bout, 1)
   assert.equal(bout.match.arm, 0)
-  assert.equal(bout.timings.pressMs, timingForBout(1).pressMs)
   // And a pin is never a stopping point: nothing here is a `won` event.
   assert.equal(events.filter((e) => e.kind === "won").length, 0)
 })
 
-test("the window running out seats the beam where it stands", () => {
-  // Sag is switched off for this one so the only thing under test is the
-  // whistle. The case just below covers what the pan does when it is left alone.
-  const bout = new Bout(fixed(500), { ...TIMING, sagGraceMs: 10 ** 9 })
+test("the window running out takes nothing — no verdict, no ground, no answer", () => {
+  // **A timeout is not a wrong answer.** It used to be: the beam was judged
+  // where it stood, which took a length of ground off a child who was still
+  // carrying the hundreds column and filed a miss against them with the host.
+  // Now the round is simply over.
+  const bout = new Bout(fixed(500))
   open(bout)
-  loadTo(bout, 501)
-  const events = bout.advance(TIMING.pressMs + 100)
+  // Deliberately NOT on the notch — the point is that being caught mid-sum
+  // costs nothing, not that a finished round is honoured.
+  loadTo(bout, 480)
+  const before = bout.match.arm
+  const events = bout.advance(bout.pressMs + 100)
   const seat = events.find((e) => e.kind === "seat")
   assert.ok(seat && seat.kind === "seat")
-  // Honest either way: they had it, so it counts.
-  assert.equal(seat.seat.verdict, "true")
+  assert.equal(seat.seat.verdict, "expired")
   assert.equal(seat.seat.declared, false, "the whistle was recorded as a declaration")
+  assert.equal(seat.arm, before, "the whistle moved the arm")
+  assert.equal(bout.match.arm, before)
+  assert.equal(bout.match.held, 0)
+})
+
+test("a whistle on a pan that happened to be right is still not a hold", () => {
+  // The old rule honoured this one, and honouring it is what made the losing
+  // case defensible. Both go: the child never said it.
+  const bout = new Bout(fixed(500))
+  open(bout)
+  loadTo(bout, 501)
+  const events = bout.advance(bout.pressMs + 100)
+  const seat = events.find((e) => e.kind === "seat")
+  assert.ok(seat && seat.kind === "seat")
+  assert.equal(seat.seat.verdict, "expired")
+  assert.equal(bout.match.arm, 0)
+  assert.equal(bout.match.held, 0)
 })
 
 test("a pan nobody is tending settles, and a strike re-seats it", () => {
   const bout = new Bout(fixed(500))
   open(bout)
+  // The sag is armed by the first blow, so a round has to be *started* before
+  // anything can be neglected. The case below is the one that matters.
+  bout.strike({ place: 1, dir: 1 })
   const before = bout.load
   bout.advance(TIMING.sagGraceMs + TIMING.sagPeriodMs * 3 + 20)
   assert.equal(bout.load, before - 3, "the pan did not settle under a load left alone")
@@ -163,6 +179,65 @@ test("a pan nobody is tending settles, and a strike re-seats it", () => {
   bout.strike({ place: 1, dir: 1 })
   bout.advance(TIMING.sagGraceMs - 10)
   assert.equal(bout.load, now + 1, "the sag did not start over after a strike")
+})
+
+test("the pan does not move while the child is reading his column", () => {
+  // **The defect the founder felt as "sometimes the timing is sort of
+  // impossible".** The sag used to run from the instant the window opened, at a
+  // grace of 1.5 s and a period that fell to 0.75 s — so a child taking the
+  // house table's own p90 for a two-digit regrouping (14 s) reached the rack
+  // with a pan nine units below where they had read it, and the sum they had
+  // just done in their head was wrong through no fault of theirs.
+  const bout = new Bout(fixed(500))
+  open(bout)
+  const read = bout.load
+  bout.advance(bout.pressMs - 50)
+  assert.equal(bout.load, read, "the pan drained while the child was still reading")
+})
+
+test("the ladder moving out from under the pan re-racks it", () => {
+  // The adaptation audit's one named defect in this pack: a pan sitting on a
+  // four-digit load when the next weight is two digits costs a whole calm round
+  // of unwinding before any arithmetic happens.
+  let big = true
+  const bout = new Bout(() => {
+    const q = question(big ? 8000 : 47)
+    big = false
+    return q
+  })
+  open(bout)
+  loadTo(bout, 8001)
+  bout.seatNow()
+  const events = bout.advance(TIMING.settleMs + TIMING.hangMs + 4)
+  const rerack = events.find((e) => e.kind === "rerack")
+  assert.ok(rerack && rerack.kind === "rerack", "the pan was left four digits out of position")
+  assert.equal(bout.load, openingLoad(47))
+  const hang = events.find((e) => e.kind === "hang")
+  assert.ok(hang && hang.kind === "hang")
+  assert.equal(hang.delta, 48 - bout.load, "the hang delta did not follow the re-rack")
+})
+
+test("a pan a few strikes out of position is left exactly where it was", () => {
+  // The good rule, and it has to keep holding: your load staying put is what
+  // makes each round only the *difference*. The re-rack is for a collapse, not
+  // for ordinary drift.
+  let first = true
+  const bout = new Bout(() => {
+    const q = question(first ? 500 : 512)
+    first = false
+    return q
+  })
+  open(bout)
+  loadTo(bout, 501)
+  bout.seatNow()
+  const events = bout.advance(TIMING.settleMs + TIMING.hangMs + 4)
+  assert.equal(
+    events.filter((e) => e.kind === "rerack").length,
+    0,
+    "the yard re-racked a pan that was a couple of strikes away",
+  )
+  assert.equal(bout.load, 501)
+  assert.ok(RERACK_SLACK >= 2, "the slack has to leave room for ordinary drift")
 })
 
 test("a pillar still swinging back refuses the next blow", () => {
@@ -198,17 +273,24 @@ test("shearing the steel ends the round on the blow that broke it", () => {
   assert.equal(bout.match.arm, -1)
 })
 
-test("the Turk tightens the window and the steel, and never the arithmetic", () => {
-  const one = timingForBout(1)
-  const five = timingForBout(5)
-  assert.ok(five.pressMs < one.pressMs)
-  assert.ok(five.shearAt < one.shearAt)
-  assert.ok(five.sagPeriodMs < one.sagPeriodMs)
-  // Floors, so it stops at hard rather than running off to impossible.
-  const far = timingForBout(40)
-  assert.ok(far.pressMs >= 7000)
-  assert.ok(far.shearAt >= 20)
-  assert.equal(far.pressMs, timingForBout(41).pressMs)
+test("the Turk never tightens a clock — the same weight gets the same window forever", () => {
+  // **The ratchet, and its absence.** `timingForBout` used to take 1.1 s off the
+  // press window per Turk, down to a 7.6 s floor, while the bout counter it read
+  // was also what escalated the arithmetic. Nothing left in this file may do
+  // that: put the same weight up at the ninth Turk as at the first and every
+  // duration has to come back identical.
+  const bout = new Bout(fixed(500))
+  open(bout)
+  const first = { press: bout.pressMs, ...bout.timings }
+  for (let turk = 0; turk < 9; turk++) {
+    for (let i = 0; i < GROUND; i++) {
+      loadTo(bout, 501)
+      bout.seatNow()
+      bout.advance(TIMING.settleMs + TIMING.hangMs + 4)
+    }
+  }
+  assert.ok(bout.match.won >= 9, `only ${bout.match.won} Turks went over`)
+  assert.deepEqual({ press: bout.pressMs, ...bout.timings }, first)
 })
 
 test("the first pan of a session starts a few strikes off, never on the answer", () => {

--- a/dynawalla/games/counterweight/src/test/harness.ts
+++ b/dynawalla/games/counterweight/src/test/harness.ts
@@ -6,6 +6,7 @@
 // description of mashing, it is a player, and it plays the shipping rules.
 
 import { Bout, type BoutEvent, type Timing, type Verdict } from "../game/bout.ts"
+import { requestFor } from "../game/ladder.ts"
 import { FACES, planStrikes, type Strike } from "../game/places.ts"
 import type { Question } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
@@ -32,6 +33,10 @@ export type Play = {
   readonly verdicts: Record<Verdict, number>
   readonly bestArm: number
   readonly reports: ReadonlyArray<{ correct: boolean; answered: string }>
+  /** The rung asked for on each weight, in order. The ladder, as played. */
+  readonly rungs: readonly number[]
+  /** Press windows served, in milliseconds, in order. */
+  readonly windows: readonly number[]
 }
 
 export type PlayOptions = {
@@ -51,29 +56,51 @@ export function play(strategy: Strategy, options: PlayOptions = {}): Play {
   })
   const rng = new Rng((options.seed ?? 0x51ee) ^ 0x2f19)
   const beam = new Beam(TUNING)
-  const deal = (): Question => host.next({ domain: "add" })
+  const rungs: number[] = []
+  // The same lazy read of the match that `mount.ts` does, and for the same
+  // reason: `hang()` runs before the `won` that caused it is ever seen.
+  let table: Bout | null = null
+  const deal = (): Question => {
+    const request = requestFor(table?.match)
+    rungs.push(request.difficulty)
+    return host.next(request)
+  }
   const bout = options.timing ? new Bout(deal, options.timing) : new Bout(deal)
+  table = bout
 
-  const verdicts: Record<Verdict, number> = { true: 0, short: 0, over: 0, shear: 0 }
+  const verdicts: Record<Verdict, number> = { true: 0, short: 0, over: 0, shear: 0, expired: 0 }
   const reports: Array<{ correct: boolean; answered: string }> = []
+  const windows: number[] = []
   let rounds = 0
   let bestArm = 0
   let windowMs = 0
 
   const absorb = (events: readonly BoutEvent[]): void => {
     for (const event of events) {
-      if (event.kind === "open") windowMs = 0
+      if (event.kind === "open") {
+        windowMs = 0
+        windows.push(bout.pressMs)
+      }
       if (event.kind === "strike") beam.hit(event.impulse, event.strike.dir)
-      if (event.kind === "hang" || event.kind === "strike" || event.kind === "sag") {
+      if (
+        event.kind === "hang" ||
+        event.kind === "rerack" ||
+        event.kind === "strike" ||
+        event.kind === "sag"
+      ) {
         beam.aim(bout.margin)
       }
       if (event.kind === "seat") {
         rounds += 1
         verdicts[event.seat.verdict] += 1
-        reports.push({
-          correct: event.seat.verdict === "true",
-          answered: String(event.seat.asserted),
-        })
+        // A whistle is not an answer, so it is not in `reports` — the same
+        // split `mount.ts` makes between `report` and `skip`.
+        if (event.seat.verdict !== "expired") {
+          reports.push({
+            correct: event.seat.verdict === "true",
+            answered: String(event.seat.asserted),
+          })
+        }
         beam.aim(bout.margin)
         bestArm = Math.max(bestArm, event.arm)
       }
@@ -94,7 +121,16 @@ export function play(strategy: Strategy, options: PlayOptions = {}): Play {
     }
   }
 
-  return { won: bout.match.won, held: bout.match.held, rounds, verdicts, bestArm, reports }
+  return {
+    won: bout.match.won,
+    held: bout.match.held,
+    rounds,
+    verdicts,
+    bestArm,
+    reports,
+    rungs,
+    windows,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -149,6 +185,51 @@ export function solver(thinkMs = 2400, gapMs = 280): Strategy {
       // The arithmetic, done: his column's value, plus the one notch, less what
       // is already on the pan.
       plan = planStrikes(Number(bout.question?.answer ?? 0) + 1 - bout.load)
+      since = gapMs
+    }
+    since += STEP
+    if (since < gapMs) return []
+    since = 0
+    const next = plan.shift()
+    if (next) return [next]
+    return ["seat"]
+  }
+}
+
+/**
+ * The same child, honestly modelled.
+ *
+ * `solver` re-reads the pan at the instant it starts striking, which no human
+ * does — it plans from the number in front of it *when the window opened*, works
+ * the sum out, and then strikes what it worked out. That one difference is the
+ * whole of the sag defect: a pan that drained while the child was thinking makes
+ * the arithmetic they just did wrong by the time they reach the rack, and they
+ * have no way of knowing it happened.
+ *
+ * Keep both. `solver` measures whether the window is long enough; this one
+ * measures whether the round is *honest*.
+ */
+export function patient(thinkMs = 6000, gapMs = 300): Strategy {
+  let plan: Strike[] = []
+  let planned = false
+  let read: number | null = null
+  let since = 0
+  let phase: string | null = null
+  return ({ bout, windowMs }) => {
+    if (bout.phase !== phase) {
+      phase = bout.phase
+      planned = false
+      plan = []
+      read = null
+      since = 0
+    }
+    if (bout.phase !== "press") return []
+    // The pan as it stood when the weight came down. Read once, like a child.
+    if (read === null) read = bout.load
+    if (windowMs < thinkMs) return []
+    if (!planned) {
+      planned = true
+      plan = planStrikes(Number(bout.question?.answer ?? 0) + 1 - read)
       since = gapMs
     }
     since += STEP

--- a/dynawalla/games/counterweight/src/test/ladder.test.ts
+++ b/dynawalla/games/counterweight/src/test/ladder.test.ts
@@ -1,0 +1,101 @@
+// **"It starts way too hard."**
+//
+// The game used to ask the host for nothing at all, so the opening round of a
+// session was whatever the scheduler had stocked. These cases hold the two rules
+// that replaced that: the opening rung is the bottom one, and the rung moves on
+// what the child *achieved*, in both directions.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { OPENING_RUNG, requestFor, rungFor, TOP_RUNG } from "../game/ladder.ts"
+import { GROUND } from "../game/bout.ts"
+import { play, solver } from "./harness.ts"
+import { createStubHost, toUnit } from "../stubHost.ts"
+
+test("the first weight of a session is the easiest thing the product has", () => {
+  // Nothing played yet, so there is nothing to justify anything harder.
+  const opening = requestFor(null)
+  assert.equal(opening.difficulty, OPENING_RUNG)
+  assert.equal(opening.maxDifficulty, OPENING_RUNG)
+  assert.equal(opening.domain, "add")
+  // On the host's wire, rung 1 is position zero: the bottom of the ladder, not
+  // the top. `toUnit`'s one ambiguous value, read the safe way.
+  assert.equal(toUnit(opening.difficulty), 0)
+  assert.equal(rungFor({ won: 0, pinned: 0 }), OPENING_RUNG)
+})
+
+test("a bottom-rung request actually serves two-digit sums without regrouping", () => {
+  // The request is only worth making if the other end honours it — and the stub
+  // honours it the way `packs/shared/game-host` does, through `toUnit`.
+  const host = createStubHost({ seed: 0x51ee, reducedMotion: true })
+  const request = requestFor(null)
+  for (let i = 0; i < 60; i++) {
+    const q = host.next(request)
+    const operands = (q.prompt.match(/\d+/g) ?? []).map(Number)
+    for (const n of operands) {
+      assert.ok(n < 100, `${q.prompt} is not a two-digit sum`)
+    }
+    assert.ok(Number(q.answer) < 100, `${q.prompt} carries into a third column`)
+  }
+})
+
+test("the rung climbs on Turks put over and on nothing else", () => {
+  // Achievement, not a clock. A Turk costs five net holds, so this counter
+  // cannot move without the child having actually been right five more times
+  // than they were wrong.
+  assert.equal(rungFor({ won: 0, pinned: 0 }), 1)
+  assert.equal(rungFor({ won: 3, pinned: 0 }), 4)
+  assert.equal(rungFor({ won: 40, pinned: 0 }), TOP_RUNG)
+  assert.equal(GROUND, 5, "a Turk stopped costing five net holds")
+})
+
+test("and it comes back down when a child is pinned", () => {
+  // The relief valve, and the reason `raiseFloor` is not called anywhere in this
+  // pack: a permanent floor is exactly what would stop a struggling child ever
+  // getting easier work again.
+  assert.equal(rungFor({ won: 4, pinned: 2 }), 3)
+  assert.equal(rungFor({ won: 0, pinned: 5 }), OPENING_RUNG, "the rung fell below the bottom")
+  assert.equal(requestFor({ won: 2, pinned: 1 }).maxDifficulty, 2)
+})
+
+test("the ceiling never lets the stream drift above what was earned", () => {
+  for (const record of [
+    { won: 0, pinned: 0 },
+    { won: 1, pinned: 0 },
+    { won: 6, pinned: 2 },
+    { won: 30, pinned: 0 },
+  ]) {
+    const request = requestFor(record)
+    assert.equal(request.maxDifficulty, request.difficulty)
+  }
+})
+
+test("a played session walks the rung up one Turk at a time, from the bottom", () => {
+  // End to end, through the shipping `Bout`: a bot that does the arithmetic
+  // starts on the easiest rung and earns each one after it.
+  const run = play(solver(2400, 350), { seed: 3, seconds: 400 })
+  assert.equal(run.rungs[0], OPENING_RUNG, "the session did not open on the bottom rung")
+  assert.ok(run.won >= 6, `a solver only put ${run.won} Turks over`)
+  assert.equal(Math.max(...run.rungs), Math.min(TOP_RUNG, 1 + run.won))
+  // Monotone here only because this bot is never pinned; what matters is that it
+  // never jumps.
+  for (let i = 1; i < run.rungs.length; i++) {
+    const step = (run.rungs[i] as number) - (run.rungs[i - 1] as number)
+    assert.ok(step >= 0 && step <= 1, `the rung jumped by ${step}`)
+  }
+})
+
+test("a player who never gets anything right is never dragged up the ladder", () => {
+  // The `horde` defect, which this pack must not grow: escalation on the wall
+  // clock hands three-digit addition to a child who has missed every question
+  // purely for still being in the room.
+  const run = play(() => [], { seed: 3, seconds: 900 })
+  assert.equal(run.won, 0)
+  assert.ok(run.rungs.length > 8, `only ${run.rungs.length} weights were hung`)
+  assert.deepEqual(
+    [...new Set(run.rungs)],
+    [OPENING_RUNG],
+    "fifteen minutes of not answering moved the ladder",
+  )
+})

--- a/dynawalla/games/counterweight/src/test/mash.test.ts
+++ b/dynawalla/games/counterweight/src/test/mash.test.ts
@@ -1,6 +1,7 @@
 // **The bar this game was designed against: no mashing strategy wins.**
 //
-// The canon entry calls THE COUNTERWEIGHT the most unmashable design in the
+// The canon entry calls THE STEELYARD (shipped as THE COUNTERWEIGHT) the most
+// unmashable design in the
 // catalogue, and that is a claim about behaviour, so it is settled by playing
 // rather than by reading the source. Every case below drives the shipping `Bout`
 // with a bot and counts what it got. The bots are in `harness.ts`.
@@ -23,7 +24,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { FACES } from "../game/places.ts"
-import { hammer, masher, play, prober, solver } from "./harness.ts"
+import { hammer, masher, patient, play, prober, solver } from "./harness.ts"
 
 /** Fixed, so this file has no unseeded randomness in it anywhere. */
 const SEEDS = Array.from({ length: 12 }, (_, i) => i * 7919 + 3)
@@ -109,4 +110,110 @@ test("what a wrong seat reports is a number the child put there, not noise", () 
     assert.match(report.answered, /^-?\d+$/, `"${report.answered}" is not a whole number`)
   }
   assert.ok(run.reports.length > 10)
+})
+
+// ---------------------------------------------------------------------------
+// **The other half of the bar: a child who is thinking must not be losing.**
+//
+// Everything above proves the game cannot be beaten without the arithmetic.
+// These prove it can be beaten *with* it, at the speeds real children do it at,
+// which is the half the pacing audit found missing. The founder's report was
+// "this one is stressful and rushed and sometimes the timing is sort of
+// impossible"; each case below is one of the reasons it was.
+// ---------------------------------------------------------------------------
+
+/** The house cadence table's p90 for two-digit-with-regrouping. */
+const P90_TWO_DIGIT_MS = 14000
+
+test("a child who thinks at the house table's own pace wins comfortably", () => {
+  // **The headline defect.** Measured on this bot before the change: at a nine
+  // second pause it held 45 of 96 rounds and put over 7 Turks in the time it
+  // now takes to put over 18; at the documented p90 it held 0 of 78 and never
+  // put over a single one. The window it was thinking against was falling from
+  // 13.0 s to 7.6 s while the sums climbed to four digits.
+  for (const think of [2400, 4200, 6000, 9000]) {
+    for (const seed of SEEDS.slice(0, 6)) {
+      const run = play(solver(think, 350), { seed, seconds: 400 })
+      assert.ok(
+        run.won >= 3,
+        `a ${think} ms thinker only put ${run.won} Turks over on seed ${seed}`,
+      )
+      assert.ok(
+        run.held / run.rounds > 0.9,
+        `a ${think} ms thinker held ${run.held} of ${run.rounds} on seed ${seed}`,
+      )
+      assert.equal(run.verdicts.shear, 0, `a ${think} ms thinker sheared on seed ${seed}`)
+    }
+  }
+})
+
+test("nothing moves under a child who has not touched the rack yet", () => {
+  // **"Sometimes the timing is sort of impossible."** The sag used to run from
+  // the instant the window opened, so a child taking the p90 for their sum
+  // arrived at the rack with a pan several units below the number they had done
+  // the arithmetic against — and no way of knowing. `patient` is the honest
+  // model of that child: it plans from the pan it read when the weight came
+  // down and never looks again. It has to be able to win.
+  for (const seed of SEEDS.slice(0, 6)) {
+    const run = play(patient(6000, 350), { seed, seconds: 400 })
+    assert.ok(run.won >= 3, `an honest thinker only put ${run.won} Turks over on seed ${seed}`)
+    assert.equal(
+      run.verdicts.short,
+      0,
+      `an honest thinker came up short ${run.verdicts.short} times on seed ${seed} — the pan moved under them`,
+    )
+  }
+})
+
+test("the window a weight gets never depends on how long anybody has been playing", () => {
+  // **The ratchet, gone.** The same seed played for one minute and for ten has
+  // to serve the same window for the same weight. A bout counter anywhere in the
+  // window would show up here as a second, shorter figure for a prompt that
+  // already had one.
+  const short = play(solver(2400, 350), { seed: 3, seconds: 90 })
+  const long = play(solver(2400, 350), { seed: 3, seconds: 600 })
+  assert.ok(long.rounds > short.rounds * 3, "the long run was not actually longer")
+  assert.ok(long.won >= 8, `only ${long.won} Turks went over in ten minutes`)
+  for (let i = 0; i < short.windows.length; i++) {
+    assert.equal(
+      long.windows[i],
+      short.windows[i],
+      `weight ${i} was served a different window in the longer session`,
+    )
+  }
+  // And the windows never trend down as the ladder climbs: the last quarter of a
+  // ten-minute session is the hardest content in the pack and must have the most
+  // time, not the least.
+  const quarter = Math.floor(long.windows.length / 4)
+  const opening = long.windows.slice(0, quarter)
+  const closing = long.windows.slice(-quarter)
+  const mean = (xs: readonly number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length
+  assert.ok(
+    mean(closing) > mean(opening),
+    `the window shrank from ${Math.round(mean(opening))} ms to ${Math.round(mean(closing))} ms as the maths got harder`,
+  )
+})
+
+test("running out of time costs nothing, and is never reported as an answer", () => {
+  // **A timeout is not a wrong answer.** A bot that sits on its hands for a
+  // quarter of an hour must reach the end of it with the arm where it started
+  // and with nothing filed against it — the whistle used to take a length of
+  // ground and report the pan's load as the child's answer.
+  const run = play(() => [], { seed: 3, seconds: 900 })
+  assert.ok(run.rounds > 15, `only ${run.rounds} rounds went by`)
+  assert.equal(run.verdicts.expired, run.rounds, "a round nobody touched was judged")
+  assert.deepEqual(run.reports, [], "a round nobody answered was reported as an answer")
+  assert.equal(run.bestArm, 0)
+  assert.equal(run.won, 0)
+})
+
+test("a slow thinker is never worse off than a fast one on the same seed", () => {
+  // The property that makes the window a ceiling rather than a pace: taking
+  // longer may cost throughput, and must never cost accuracy.
+  for (const seed of SEEDS.slice(0, 4)) {
+    const quick = play(solver(1200, 350), { seed, seconds: 400 })
+    const slow = play(solver(P90_TWO_DIGIT_MS / 2, 350), { seed, seconds: 400 })
+    assert.equal(quick.held, quick.rounds, `a fast solver missed one on seed ${seed}`)
+    assert.equal(slow.held, slow.rounds, `a slow solver missed one on seed ${seed}`)
+  }
 })

--- a/dynawalla/games/counterweight/src/test/mount.test.ts
+++ b/dynawalla/games/counterweight/src/test/mount.test.ts
@@ -22,6 +22,7 @@ import type { Host, Question } from "../contract.ts"
 import { openingLoad } from "../game/bout.ts"
 import { PLACES, planStrikes } from "../game/places.ts"
 import { viewLayout } from "../render/layout.ts"
+import { OPENING_RUNG } from "../game/ladder.ts"
 import { createStubHost } from "../stubHost.ts"
 
 type Listener = (event: unknown) => void
@@ -315,36 +316,75 @@ test("the reduced-motion branch plays the same match with no sparks", () => {
 test("a Turk going over is the only thing that ever reaches `transition`", () => {
   const counter = { calls: 0, text: [] as string[] }
   const stops: string[] = []
-  let rounds = 0
-  let held = 0
+  const reports: Array<{ correct: boolean }> = []
+  const skips: string[] = []
   withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames }) => {
     const stub = createStubHost({
       seed: 0x51ab,
       reducedMotion: true,
       onTransition: (kind) => stops.push(kind),
-      onReport: (r) => {
-        rounds += 1
-        if (r.correct) held += 1
-      },
+      onReport: (r) => reports.push(r),
+      onSkip: (id) => skips.push(id),
     })
     const handle = mount(host as unknown as HTMLElement, stub)
-    // No input at all: every round runs out of window and is lost. Dozens of
-    // failures, and not one of them may raise a purchase surface.
-    pump(frames, 20000)
+    // No input at all: every round runs out of window. Dozens of them, and not
+    // one may raise a purchase surface.
+    pump(frames, 30000)
     handle.unmount()
   })
-  assert.ok(rounds > 8, `only ${rounds} rounds went by`)
-  assert.equal(held, 0, "a match with no input somehow held a round")
+  // **Not one of them reached the curriculum as an answer.** A whistle reported
+  // as `{ correct: false }` is filed as a miss and walks the ladder down, on a
+  // child who was still working the sum.
+  assert.deepEqual(
+    reports,
+    [],
+    `${reports.length} rounds nobody answered were reported to the host as answers`,
+  )
+  assert.ok(skips.length > 8, `only ${skips.length} rounds went by`)
+  assert.equal(new Set(skips).size, skips.length, "an item was closed twice")
   assert.deepEqual(stops, [], "a stopping point was offered next to a failure")
+})
+
+test("the very first weight of a session is asked for at the bottom of the ladder", () => {
+  // **"It starts way too hard."** This is the call site the complaint was about:
+  // the game used to ask `next({ domain: "add" })` and take whatever the
+  // scheduler had stocked. `ladder.test.ts` proves the request is right; this
+  // proves the mount actually makes it.
+  const counter = { calls: 0, text: [] as string[] }
+  const asks: Array<{ difficulty?: number; maxDifficulty?: number } | undefined> = []
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames }) => {
+    const base = createStubHost({ seed: 0x51ab, reducedMotion: true })
+    const stub: Host = {
+      ...base,
+      next: (o) => {
+        asks.push(o)
+        return base.next(o)
+      },
+    }
+    const handle = mount(host as unknown as HTMLElement, stub)
+    pump(frames, 240)
+    handle.unmount()
+  })
+  assert.ok(asks.length > 0, "the game never asked for a question")
+  assert.equal(asks[0]?.difficulty, OPENING_RUNG, "the opening weight was not the easiest one")
+  assert.equal(asks[0]?.maxDifficulty, OPENING_RUNG, "the opening stream had no ceiling")
+  for (const ask of asks) {
+    assert.equal(ask?.difficulty, OPENING_RUNG, "the rung moved without a Turk going over")
+  }
 })
 
 test("the sheet stops the world, and lifting it gives the window back", () => {
   // The host's `pause`, exactly as the pack seam calls it. Both halves are under
   // test: the clock must stop, and a tap on the sheet must not reach the rack.
   const counter = { calls: 0, text: [] as string[] }
-  const reports: unknown[] = []
+  const closed: unknown[] = []
   withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, created }) => {
-    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
+    const stub = createStubHost({
+      seed: 0x51ab,
+      reducedMotion: true,
+      onReport: (r) => closed.push(r),
+      onSkip: (id) => closed.push(id),
+    })
     const handle = mount(host as unknown as HTMLElement, stub)
     let t = pump(frames, 120)
     const canvas = canvasOf(created)
@@ -352,10 +392,10 @@ test("the sheet stops the world, and lifting it gives the window back", () => {
     const up = canvas.listeners.get("pointerup")?.[0] as Listener
 
     handle.pause()
-    const seated = reports.length
-    // Thirty seconds behind the sheet — more than two whole windows.
-    t = pump(frames, 1800, t)
-    assert.equal(reports.length, seated, "rounds were seated behind the sheet")
+    const seated = closed.length
+    // A hundred seconds behind the sheet — more than two whole windows.
+    t = pump(frames, 6000, t)
+    assert.equal(closed.length, seated, "rounds were closed behind the sheet")
 
     // And presses on the sheet are presses on the sheet.
     for (const p of facePoints(768, 1024)) {
@@ -366,33 +406,38 @@ test("the sheet stops the world, and lifting it gives the window back", () => {
     down({ preventDefault() {}, clientX: lever.x, clientY: lever.y })
     up({})
     t = pump(frames, 60, t)
-    assert.equal(reports.length, seated, "the beam was seated through the sheet")
+    assert.equal(closed.length, seated, "the beam was seated through the sheet")
 
     handle.resume()
-    t = pump(frames, 1800, t)
-    assert.ok(reports.length > seated, "the world never came back")
+    t = pump(frames, 6000, t)
+    assert.ok(closed.length > seated, "the world never came back")
     handle.unmount()
   })
 })
 
 test("a backgrounded tab is the same as a sheet", () => {
   const counter = { calls: 0, text: [] as string[] }
-  const reports: unknown[] = []
+  const closed: unknown[] = []
   withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, doc }) => {
-    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
+    const stub = createStubHost({
+      seed: 0x51ab,
+      reducedMotion: true,
+      onReport: (r) => closed.push(r),
+      onSkip: (id) => closed.push(id),
+    })
     const handle = mount(host as unknown as HTMLElement, stub)
     let t = pump(frames, 120)
 
     doc.visibilityState = "hidden"
     for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
-    const seated = reports.length
-    t = pump(frames, 1800, t)
-    assert.equal(reports.length, seated, "the window closed while the tab was hidden")
+    const seated = closed.length
+    t = pump(frames, 6000, t)
+    assert.equal(closed.length, seated, "the window closed while the tab was hidden")
 
     doc.visibilityState = "visible"
     for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
-    t = pump(frames, 1800, t)
-    assert.ok(reports.length > seated, "the world never came back")
+    t = pump(frames, 6000, t)
+    assert.ok(closed.length > seated, "the world never came back")
     handle.unmount()
   })
 })
@@ -473,17 +518,25 @@ test("time behind the sheet is not billed to the child as thinking time", () => 
   const reports: Array<{ ms: number }> = []
   const SHEET_FRAMES = 1800
 
-  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, clock }) => {
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, clock, created }) => {
     const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
     const handle = mount(host as unknown as HTMLElement, stub)
+    const canvas = canvasOf(created)
+    const down = canvas.listeners.get("pointerdown")?.[0] as Listener
+    const up = canvas.listeners.get("pointerup")?.[0] as Listener
 
     // Into the window, then the sheet goes up for thirty seconds.
     let t = pump(frames, 90, 0, clock)
     handle.pause()
     t = pump(frames, SHEET_FRAMES, t, clock)
     handle.resume()
-    // And then the window runs its course.
-    t = pump(frames, 1400, t, clock)
+    t = pump(frames, 30, t, clock)
+    // And then the child seats the beam. A whistle is not reported at all any
+    // more, so the round has to be *declared* for there to be an `ms` to bill.
+    const lever = seatPoint(768, 1024)
+    down({ preventDefault() {}, clientX: lever.x, clientY: lever.y })
+    up({})
+    t = pump(frames, 30, t, clock)
     handle.unmount()
   })
 

--- a/dynawalla/games/counterweight/src/test/pause.test.ts
+++ b/dynawalla/games/counterweight/src/test/pause.test.ts
@@ -53,7 +53,7 @@ test("the clock does not run behind the sheet", () => {
 
   bout.resume()
   assert.equal(bout.paused, false)
-  bout.advance(TIMING.pressMs + 10)
+  bout.advance(bout.pressMs + 10)
   assert.equal(bout.phase, "settle", "the clock did not restart on resume")
 })
 
@@ -76,6 +76,9 @@ test("the pan does not settle behind the sheet either", () => {
   // The sag is a clock too, and a slow one. Left running behind a sheet it turns
   // a correct load into a wrong one without a single frame the child saw.
   const bout = opened()
+  // Armed first: the sag does not run before the child's first blow of the
+  // round, so a bout nobody has touched would pass this vacuously.
+  bout.strike({ place: 1, dir: 1 })
   const load = bout.load
   bout.pause()
   bout.advance(120_000)
@@ -111,7 +114,7 @@ test("a tap on the sheet is a tap on the sheet — not a blow, not a seat", () =
 test("resuming does not hand back a window that has already gone", () => {
   // A sheet raised with two seconds left leaves two seconds, not thirteen.
   const bout = opened()
-  bout.advance(TIMING.pressMs - 2000)
+  bout.advance(bout.pressMs - 2000)
   bout.pause()
   bout.advance(60_000)
   bout.resume()

--- a/dynawalla/games/counterweight/src/test/window.test.ts
+++ b/dynawalla/games/counterweight/src/test/window.test.ts
@@ -1,0 +1,188 @@
+// **The invariant, and the defect it replaces.**
+//
+// The press window used to be `timingForBout(bout)`: 13.0 s at the first Turk,
+// 1.1 s less at every one after, down to a 7.6 s floor. The bout counter is also
+// what escalates the arithmetic, so the child got less time exactly as the sums
+// got harder. Every case here is written so that putting a bout number, an
+// elapsed time or a speed back into the window fails it.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  comprehensionSeconds,
+  MAX_PRESS_SECONDS,
+  MIN_PRESS_SECONDS,
+  motorSeconds,
+  needsRegrouping,
+  pressMsFor,
+  STRIKE_SECONDS,
+  STRIKES_PER_COLUMN,
+  SUSTAINABLE_STRIKE_SECONDS,
+  widestColumn,
+} from "../game/window.ts"
+import { planStrikes, strikesFor } from "../game/places.ts"
+import { BASE_STRAIN, BLEED_PER_SEC, impulseFor, Strain } from "../game/strain.ts"
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stubHost.ts"
+
+/** Every column operation the seven live curriculum rows can produce. */
+function ladderItems(): Array<{ prompt: string; answer: number; level: number }> {
+  const out: Array<{ prompt: string; answer: number; level: number }> = []
+  for (let level = 0; level < 8; level++) {
+    const host = createStubHost({ seed: 0x51ee, level, reducedMotion: true })
+    for (let i = 0; i < 300; i++) {
+      const q = host.next({ domain: "add" })
+      out.push({ prompt: q.prompt, answer: Number(q.answer), level })
+    }
+  }
+  return out
+}
+
+test("the window is monotone non-decreasing in the item's width", () => {
+  // Half of the invariant, stated as directly as it can be: no wider sum ever
+  // gets less time than a narrower one, anywhere in the reachable range.
+  const rng = new Rng(0x7c31)
+  const byWidth = new Map<number, { min: number; max: number }>()
+  for (let i = 0; i < 6000; i++) {
+    const a = rng.int(1, 9999)
+    const b = rng.int(1, 9999)
+    const item = { prompt: `${a} + ${b}`, answer: a + b }
+    const ms = pressMsFor(item)
+    const w = widestColumn(item)
+    const seen = byWidth.get(w) ?? { min: Infinity, max: -Infinity }
+    byWidth.set(w, { min: Math.min(seen.min, ms), max: Math.max(seen.max, ms) })
+  }
+  const widths = [...byWidth.keys()].sort((x, y) => x - y)
+  assert.ok(widths.length >= 4, "the sample never reached four columns")
+  for (let i = 1; i < widths.length; i++) {
+    const lower = byWidth.get(widths[i - 1] as number)
+    const upper = byWidth.get(widths[i] as number)
+    assert.ok(lower && upper)
+    assert.ok(
+      upper.min >= lower.max,
+      `${widths[i]} columns can get ${upper.min} ms where ${widths[i - 1]} columns gets ${lower.max} ms`,
+    )
+  }
+})
+
+test("regrouping is never worth less time than not regrouping", () => {
+  // The other half. Same width, harder procedure, never a shorter window.
+  const rng = new Rng(0x2288)
+  let plain = 0
+  let carried = 0
+  for (let i = 0; i < 4000; i++) {
+    const a = rng.int(10, 99)
+    const b = rng.int(10, 99)
+    if (a + b >= 100) continue
+    const item = { prompt: `${a} + ${b}`, answer: a + b }
+    if (needsRegrouping(item.prompt)) carried = Math.max(carried, pressMsFor(item))
+    else plain = Math.max(plain, pressMsFor(item))
+  }
+  assert.ok(plain > 0 && carried > 0, "the sample missed one of the two cases")
+  assert.ok(carried >= plain, `a regrouping sum got ${carried} ms against ${plain} ms without`)
+})
+
+test("the window is a pure function of the item and of nothing else", () => {
+  // The structural claim. `pressMsFor` takes one argument; call it a thousand
+  // times, out of order, interleaved with other items, and it cannot drift —
+  // which is exactly what a bout counter, a run clock or a tempo would do.
+  const items = ladderItems()
+  const first = new Map<string, number>()
+  for (const item of items) {
+    const key = `${item.prompt}=${item.answer}`
+    const ms = pressMsFor(item)
+    const seen = first.get(key)
+    if (seen === undefined) first.set(key, ms)
+    else assert.equal(ms, seen, `${key} answered ${ms} ms after answering ${seen} ms`)
+  }
+  // And again, in reverse, after everything else has been through it.
+  for (const item of [...items].reverse()) {
+    assert.equal(pressMsFor(item), first.get(`${item.prompt}=${item.answer}`))
+  }
+})
+
+test("every item the curriculum can serve fits its window with the arithmetic still to do", () => {
+  // **The measured claim, and the one the pacing audit says the old window
+  // failed.** For every item on every live rung: the plates the answer needs,
+  // struck at a cadence the steel survives, must leave the child most of the
+  // window to think in.
+  const items = ladderItems()
+  let worst = { prompt: "", left: Infinity, level: -1 }
+  for (const item of items) {
+    // The pan starts a handful of strikes off in either direction; take the
+    // expensive side of the range the game can actually put a child in.
+    const strikes = Math.max(
+      strikesFor(item.answer + 1 - Math.round(item.answer * 0.9)),
+      strikesFor(item.answer + 1 - Math.round(item.answer * 1.1)),
+    )
+    const motor = strikes * STRIKE_SECONDS
+    const left = pressMsFor(item) / 1000 - motor
+    if (left < worst.left) worst = { prompt: item.prompt, left, level: item.level }
+  }
+  assert.ok(
+    worst.left >= 8,
+    `${worst.prompt} (rung ${worst.level}) leaves ${worst.left.toFixed(1)} s to do the arithmetic in`,
+  )
+})
+
+test("the motor budget is priced at a cadence the steel actually survives", () => {
+  // Not a comfort figure. A blow outside the resonance window costs
+  // `BASE_STRAIN` and the beam bleeds `BLEED_PER_SEC`, so anything faster than
+  // their ratio accumulates strain until the beam shears — which would mean the
+  // game shearing a child for executing a correct plan inside the window it gave
+  // them. Proved by playing it, not by reading the constants.
+  assert.ok(
+    STRIKE_SECONDS >= SUSTAINABLE_STRIKE_SECONDS,
+    `${STRIKE_SECONDS}s per strike is faster than the steel bleeds (${SUSTAINABLE_STRIKE_SECONDS}s)`,
+  )
+  assert.equal(SUSTAINABLE_STRIKE_SECONDS, BASE_STRAIN / BLEED_PER_SEC)
+  assert.equal(impulseFor(STRIKE_SECONDS * 1000), BASE_STRAIN)
+
+  // The longest plan this rack can be asked for, struck at the budgeted cadence.
+  // Found rather than asserted: five blows on each of the low places and
+  // whatever is left on the thousands pillar, which has nothing above it.
+  let longest = 0
+  for (let delta = -19999; delta <= 19999; delta++) {
+    longest = Math.max(longest, planStrikes(delta).length)
+  }
+  assert.ok(longest >= 20, `the worst plan is only ${longest} strikes`)
+  const steel = new Strain({ shearAt: 34 })
+  for (let i = 0; i < longest; i++) {
+    steel.strike()
+    steel.advance(STRIKE_SECONDS * 1000)
+    assert.equal(steel.isSheared, false, `the steel sheared on blow ${i + 1} of a correct plan`)
+  }
+})
+
+test("the pieces are each monotone, so nothing can cancel out inside the sum", () => {
+  const widths: Array<{ prompt: string; answer: number }> = [
+    { prompt: "3 + 4", answer: 7 },
+    { prompt: "43 + 25", answer: 68 },
+    { prompt: "473 + 168", answer: 641 },
+    { prompt: "6253 + 5710", answer: 11963 },
+  ]
+  for (let i = 1; i < widths.length; i++) {
+    const lower = widths[i - 1] as { prompt: string; answer: number }
+    const upper = widths[i] as { prompt: string; answer: number }
+    assert.ok(comprehensionSeconds(upper) >= comprehensionSeconds(lower))
+    assert.ok(motorSeconds(upper) >= motorSeconds(lower))
+  }
+  assert.ok(STRIKES_PER_COLUMN >= 5, "balanced base-ten can need five blows on a place")
+})
+
+test("a prompt this cannot read gets the longer window, never the shorter", () => {
+  // Guessing in the child's favour is the only direction this may be wrong in.
+  assert.equal(needsRegrouping("a bag of 47 marbles and one of 25"), true)
+  assert.equal(needsRegrouping("43 + 25"), false)
+  assert.equal(needsRegrouping("47 + 25"), true)
+  assert.equal(needsRegrouping("52 − 27"), true)
+  assert.equal(needsRegrouping("58 − 27"), false)
+})
+
+test("the clamps hold at both ends", () => {
+  assert.ok(pressMsFor({ prompt: "1 + 1", answer: 2 }) >= MIN_PRESS_SECONDS * 1000)
+  const absurd = { prompt: "123456789 + 987654321", answer: 1111111110 }
+  assert.ok(pressMsFor(absurd) <= MAX_PRESS_SECONDS * 1000)
+  assert.ok(MIN_PRESS_SECONDS < MAX_PRESS_SECONDS)
+})


### PR DESCRIPTION
> "this one is stressful and rushed and sometimes the timing is sort of impossible .. and it starts way too hard ... too fast, too hard"
> "names are too similar .. change one of their names"

The fleet-wide adaptation pass did not cover this pack. It does now.

## The name

THE COUNTERWEIGHT vs `games/balance`'s COUNTERPOISE is a real collision. This one becomes **THE STEELYARD** — the actual name of the single-beam balance the game is built on, the word the source already uses for its arena ("the yard in `render/scene.ts`"), and the name `dynawalla-app/src/catalog/motifs.ts` had *already* given this pack's catalogue art. The historical Steelyard was a Hanseatic trading compound, which sits inside the Bazaar frame. Checked against all 26 other display names — no collision. Directory stays `counterweight`; COUNTERPOISE untouched.

## What the ratchet was

`timingForBout(bout)`: `pressMs = max(7600, 13000 − (bout−1)×1100)`, plus a tightening sag and shear limit. The bout counter is also what escalates the arithmetic, so the window closed exactly as the sums got harder.

Measured on this pack's solver bot (400 s runs, 3 seeds), **before**:

| think | Turks over | held |
|---|---|---|
| 2.4 s | 30 | 162/170 (95%) |
| 6.0 s | 14 | 87/120 (73%) |
| 9.0 s | 7 | 45/96 (47%) |
| **14.0 s** (house p90, two-digit regrouping) | **0** | **0/78 (0%)** |

And at the 7.6 s floor it was arithmetically impossible. A four-digit sum decomposes into a median 13 strikes, p90 20, max 27 measured over 400 draws; `strain.ts` shears the beam above one blow per `BASE_STRAIN / BLEED_PER_SEC` = 0.333 s. Twenty blows at the fastest safe cadence is **7.0 s of pure motor work inside a 7.6 s window** — 0.6 s left for a sum whose own documented p90 is 40 s. Twenty-seven did not fit at all.

## What replaced it

`src/game/window.ts` — `comprehension(item) + motor(item)`, both pure functions of the weight on his pan, both monotone non-decreasing in its width. Nothing in the file may read a bout, an arm, an elapsed time or a speed.

| item | comprehension (house p90) | motor | window | was |
|---|---|---|---|---|
| `43 + 25` | 11.0 s | 3.50 s | **14.5 s** | 13.0 → 7.6 s |
| `47 + 25` | 14.0 s | 3.50 s | **17.5 s** | 13.0 → 7.6 s |
| `473 + 168` | 23.0 s | 5.25 s | **28.3 s** | 13.0 → 7.6 s |
| `5,001 − 2,798` | 40.0 s | 7.00 s | **47.0 s** | 13.0 → 7.6 s |

The motor term is the one the old window did not have at all, and it is priced at the cadence the game's own physics tolerates indefinitely — so the game can no longer shear a child for executing a correct plan inside the window it gave them.

**After**, same bot, same seeds:

| think | Turks over | held |
|---|---|---|
| 2.4 s | 33 | 174/174 (100%) |
| 6.0 s | 21 | 117/117 (100%) |
| 9.0 s | 18 | 92/92 (100%) |

Beam-hunting did **not** become viable on the longer windows: the prober still holds 1–2 of 78 and puts over zero, on every seed.

## Escalation, on achievement

`src/game/ladder.ts` names a rung on every weight — `next({ difficulty, maxDifficulty })`. It opens at the bottom of the curriculum, which is what "starts way too hard" was: the game used to call `next({ domain: "add" })` and take whatever the scheduler had stocked. It climbs one rung per Turk put over (five net holds — `siege`'s shape) and comes back **down** one on a pinning. `raiseFloor` is deliberately not called: a permanent floor is exactly what stops a struggling child getting easier work again.

Rungs asked for across a played 400 s session: `1,1,1,1,1,2,2,2,2,2,3,...,10`. A bot that answers nothing sits on rung 1 for fifteen minutes — the `horde` defect cannot appear here.

## The sag, and the whistle

- **The sag ran while the child was reading.** Grace 1.5 s, period falling to 0.75 s, from the instant the window opened — so a child taking the p90 for their sum arrived at the rack with a pan **nine units** below the number they had just done the arithmetic against, and no way to know. It is now armed by their first blow. Reading is not neglect. A new `patient` bot models this honestly (plans from the pan it read, never re-reads) and now holds 100%.
- **A timeout is not a wrong answer.** It used to take a length of ground *and* `report` the pan's load — which the host files as a miss and walks the ladder down for. It now closes the item with `skip(questionId)` (PR #667) and takes nothing. `arena`'s shape exactly.
- Plus the adaptation audit's one named defect in this pack: the pan is re-racked when the ladder moves its magnitude out from under it.

## The opening 30 seconds

Before: `86 − 32` on a 13.0 s window, then `55 − 34`, then `75 − 60` — with the pan sagging from 1.5 s in. After: the same class of item (explicitly requested at rung 1) on 14.5 s windows, nothing moving until the child touches the rack.

## Proof

136 cases, `npm test` run 5×, all green. **Every fix was deleted and the suite re-run:**

| deleted | fails | message |
|---|---|---|
| the per-item window (ratchet restored) | 4 | `the window shrank from 11219 ms to 7600 ms as the maths got harder` |
| the sag arming | 2 | `the pan drained while the child was still reading` · `an honest thinker only put 0 Turks over on seed 3` |
| `expire()` (whistle judges again) | 4 | `'short' !== 'expired'` · `a round nobody touched was judged` |
| `skip` in `mount` (reports instead) | 1 | `30 rounds nobody answered were reported to the host as answers` |
| the ladder request | 3 | `the opening weight was not the easiest one` |
| the re-rack | 1 | `the pan was left four digits out of position` |
| `STRIKE_SECONDS` floor | 1 | `0.2s per strike is faster than the steel bleeds (0.3333333333333333s)` |

The unmashability bar is unchanged: masher at eight speeds, hammer on all eight faces, and the beam-watcher still put over **zero** Turks across twelve seeds.

## Only a device can confirm

Whether 47 s reads as *calm* or as *dead air* on the hardest rung; whether the whistle showing `TIME — NO GROUND LOST` in dim brass is legible as "nothing happened" rather than as a loss; whether the re-rack flash reads as the yard helping rather than as the pan being taken away; and the one number no audit can supply — what multiple of the declared p90 a real 7–11 year old needs under mild arcade pressure.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb