### PR TITLE
dynawalla: the Sound setting silences the games, because today it silences nothing

### DIFF
--- a/dynawalla/packs/shared/game-audio/index.ts
+++ b/dynawalla/packs/shared/game-audio/index.ts
@@ -17,6 +17,11 @@
  * and in the game's envelope helper:
  *
  *     const a = safeAttack(attack)
+ *
+ * A game does not have to do anything else to honour the app's Sound setting.
+ * `game-host` publishes it through `setHostSound`, every live bus follows it,
+ * and a bus the app has closed cannot be reopened by the game's own mute
+ * button. See `sound.ts`.
  */
 export {
   CEILING,
@@ -37,3 +42,4 @@ export {
   type SafetyBusOptions,
   type BusContext,
 } from "./safetyBus.ts"
+export { setHostSound, hostSoundAllowed, onHostSound, resetHostSound } from "./sound.ts"

--- a/dynawalla/packs/shared/game-audio/safetyBus.ts
+++ b/dynawalla/packs/shared/game-audio/safetyBus.ts
@@ -18,6 +18,10 @@
  *            promise that: its attack time is real, and the first two
  *            milliseconds of a transient go straight through it.
  * `mute`     after the ceiling, so muted means silent and not merely quiet.
+ *            It answers to two independent owners: the app's Sound setting
+ *            (`sound.ts`) and the game's own mute button. Either one closes it;
+ *            only both open it, which is what makes the app setting
+ *            authoritative without any game having to know it exists.
  *
  * The node vocabulary is deliberately tiny — createGain, createWaveShaper,
  * createDynamicsCompressor, connect, and `.value` on a param. That is exactly
@@ -27,6 +31,7 @@
  */
 
 import { CEILING, KNEE, shaperCurve } from "./ceiling.ts"
+import { hostSoundAllowed, onHostSound } from "./sound.ts"
 
 /** The slice of AudioContext this module touches. Nothing else is assumed. */
 export type BusContext = {
@@ -55,10 +60,75 @@ export type SafetyBus = {
   readonly ceiling: number
   /** Master trim before the limiter, 0..1. */
   setLevel(level: number): void
-  /** True silence, after the ceiling. */
+  /**
+   * The GAME's mute button. True silence, after the ceiling.
+   *
+   * It cannot open a gate the app has closed. A game calling `setMuted(false)`
+   * while the app's Sound setting is off records the game's own preference and
+   * changes nothing audible — the bus stays shut until the parent turns Sound
+   * back on, at which point the game's preference is the one that applies.
+   */
   setMuted(muted: boolean): void
+  /**
+   * Whether this bus is silent — the honest reading, not the game's opinion.
+   *
+   * True when the app has turned Sound off OR the game muted itself. A game
+   * that toggles with `setMuted(!bus.muted)` therefore still cannot make noise
+   * against the app setting; the worst it can do is record `false` for later.
+   */
   readonly muted: boolean
+  /** What the game last asked for, ignoring the app setting. */
+  readonly gameMuted: boolean
+  /** Whether the app is allowing sound, ignoring what the game asked for. */
+  readonly hostAllows: boolean
   disconnect(): void
+}
+
+/**
+ * How long the gate takes to open or close, in seconds.
+ *
+ * Not zero. A gain stepped from 1 to 0 in one sample is a discontinuity, and a
+ * discontinuity is a click — a broadband transient, which is precisely the kind
+ * of sound this module exists to stop a child hearing. 12 ms is far below the
+ * ~100 ms at which a delay becomes perceptible as lag, and far above the point
+ * at which the step stops clicking.
+ *
+ * Only used where the context's `AudioParam` implements scheduling. The games'
+ * own fake contexts mostly implement `.value` and nothing else, and the shared
+ * chrome module has already broken four games by assuming otherwise, so the
+ * fallback below is a plain assignment and is equally complete — just abrupt.
+ */
+const GATE_FADE = 0.012
+
+/** A scheduling `AudioParam`, if this context happens to have one. */
+type Schedulable = {
+  value: number
+  cancelScheduledValues?: (when: number) => unknown
+  setValueAtTime?: (value: number, when: number) => unknown
+  linearRampToValueAtTime?: (value: number, when: number) => unknown
+}
+
+/** Move a gain to `target`, smoothly where the context can and bluntly where it cannot. */
+function slew(param: Schedulable, target: number, now: number): void {
+  if (
+    typeof param.cancelScheduledValues === "function" &&
+    typeof param.setValueAtTime === "function" &&
+    typeof param.linearRampToValueAtTime === "function" &&
+    Number.isFinite(now)
+  ) {
+    try {
+      // A linear ramp interpolates from the previous event, so there has to be
+      // one: cancel whatever is pending, pin the value we are actually at, then
+      // ramp. Without the pin, a second toggle inside the fade jumps.
+      param.cancelScheduledValues(now)
+      param.setValueAtTime(param.value, now)
+      param.linearRampToValueAtTime(target, now + GATE_FADE)
+      return
+    } catch (error) {
+      console.warn("[game-audio] could not schedule the mute gate; stepping instead", error)
+    }
+  }
+  param.value = target
 }
 
 /**
@@ -110,9 +180,23 @@ export function createSafetyBus(ctx: BusContext, options: SafetyBusOptions = {})
   limiter.attack.value = ATTACK
   limiter.release.value = RELEASE
 
+  // Two owners, one gate. `gameMuted` is the game's own button; `hostAllows`
+  // is the app's Sound setting, which this bus follows for as long as it lives.
   const mute = ctx.createGain()
-  let muted = options.muted === true
-  mute.gain.value = muted ? 0 : 1
+  let gameMuted = options.muted === true
+  let hostAllows = hostSoundAllowed()
+  const open = (): boolean => hostAllows && !gameMuted
+  // Assigned rather than slewed: at construction there is nothing playing to
+  // click, and a ramp would leave the first 12 ms of a game that mounts muted
+  // audible.
+  mute.gain.value = open() ? 1 : 0
+  const gate = (): void => {
+    slew(mute.gain as unknown as Schedulable, open() ? 1 : 0, ctx.currentTime)
+  }
+  const unfollow = onHostSound((on) => {
+    hostAllows = on
+    gate()
+  })
 
   input.connect(level)
   level.connect(limiter)
@@ -159,13 +243,20 @@ export function createSafetyBus(ctx: BusContext, options: SafetyBusOptions = {})
       level.gain.value = clamp01(v)
     },
     setMuted(next: boolean): void {
-      muted = next
-      mute.gain.value = next ? 0 : 1
+      gameMuted = next
+      gate()
     },
     get muted(): boolean {
-      return muted
+      return !open()
+    },
+    get gameMuted(): boolean {
+      return gameMuted
+    },
+    get hostAllows(): boolean {
+      return hostAllows
     },
     disconnect(): void {
+      unfollow()
       for (const n of [input, level, limiter, shaper, mute]) {
         if (!n) continue
         try {

--- a/dynawalla/packs/shared/game-audio/sound.test.ts
+++ b/dynawalla/packs/shared/game-audio/sound.test.ts
@@ -1,0 +1,340 @@
+/**
+ * The app's Sound setting, held to meaning something.
+ *
+ * The graph here processes samples the same way `safetyBus.test.ts` does — push
+ * a number into `bus.input`, read what arrives at the destination — because the
+ * only claim worth testing is "no sound comes out", and the only honest way to
+ * test that claim is to look at what comes out.
+ *
+ * Two contexts, deliberately. `Ctx` has `.value` and nothing else, which is
+ * what most of the 27 games' own fake contexts implement and therefore the
+ * shape the bus must never assume its way out of. `SchedulingCtx` implements
+ * the three automation methods a real `AudioParam` has, which is the branch a
+ * child on a device actually hears.
+ */
+import assert from "node:assert/strict"
+import { beforeEach, describe, it } from "node:test"
+
+import { createSafetyBus, type BusContext } from "./safetyBus.ts"
+import { hostSoundAllowed, onHostSound, resetHostSound, setHostSound } from "./sound.ts"
+
+// ─── A graph that processes samples ──────────────────────────────────────────
+
+class Param {
+  value: number
+  constructor(v = 0) {
+    this.value = v
+  }
+}
+
+/** An `AudioParam` with the automation a real one has, and a clock to read it against. */
+class SchedParam extends Param {
+  /** Ramps scheduled but not yet arrived: [target, when]. */
+  private pending: [number, number][] = []
+  private readonly clock: { currentTime: number }
+  constructor(clock: { currentTime: number }, v = 0) {
+    super(v)
+    this.clock = clock
+  }
+  cancelScheduledValues(when: number): void {
+    this.pending = this.pending.filter(([, at]) => at < when)
+  }
+  setValueAtTime(value: number, when: number): void {
+    this.pending.push([value, when])
+  }
+  linearRampToValueAtTime(value: number, when: number): void {
+    this.pending.push([value, when])
+  }
+  /** The last event whose time has arrived wins. Enough to see a ramp land. */
+  settle(): number {
+    for (const [value, at] of this.pending) if (at <= this.clock.currentTime) this.value = value
+    this.pending = this.pending.filter(([, at]) => at > this.clock.currentTime)
+    return this.value
+  }
+}
+
+class Node {
+  readonly gain: Param
+  readonly threshold = new Param()
+  readonly knee = new Param()
+  readonly ratio = new Param()
+  readonly attack = new Param()
+  readonly release = new Param()
+  curve: Float32Array | null = null
+  oversample = "none"
+  readonly outs: Node[] = []
+  readonly kind: "gain" | "comp" | "shaper" | "dest"
+  constructor(kind: "gain" | "comp" | "shaper" | "dest", gain: Param) {
+    this.kind = kind
+    this.gain = gain
+  }
+  connect<T>(d: T): T {
+    this.outs.push(d as unknown as Node)
+    return d
+  }
+  disconnect(): void {
+    this.outs.length = 0
+  }
+  process(x: number): number {
+    if (this.kind === "gain") {
+      const g = this.gain
+      return x * (g instanceof SchedParam ? g.settle() : g.value)
+    }
+    if (this.kind === "comp") return x
+    if (this.kind === "shaper") return this.curve ? lookup(this.curve, x) : x
+    return x
+  }
+}
+
+/** WaveShaperNode, per spec: outside [-1,1] uses the nearest curve value. */
+function lookup(curve: Float32Array, x: number): number {
+  const n = curve.length
+  const v = ((n - 1) / 2) * (x + 1)
+  if (!(v > 0)) return curve[0]!
+  if (v >= n - 1) return curve[n - 1]!
+  const k = Math.floor(v)
+  const f = v - k
+  return curve[k]! * (1 - f) + curve[k + 1]! * f
+}
+
+class Ctx implements BusContext {
+  currentTime = 0
+  readonly destination = new Node("dest", new Param(1)) as unknown as AudioNode
+  /** Whether gains get scheduling methods. Off = the games' own fake shape. */
+  protected scheduling = false
+  private mk(kind: "gain" | "comp" | "shaper"): Node {
+    const gain =
+      this.scheduling && kind === "gain" ? new SchedParam(this, 1) : new Param(kind === "gain" ? 1 : 0)
+    return new Node(kind, gain)
+  }
+  createGain(): GainNode {
+    return this.mk("gain") as unknown as GainNode
+  }
+  createDynamicsCompressor(): DynamicsCompressorNode {
+    return this.mk("comp") as unknown as DynamicsCompressorNode
+  }
+  createWaveShaper(): WaveShaperNode {
+    return this.mk("shaper") as unknown as WaveShaperNode
+  }
+}
+
+class SchedulingCtx extends Ctx {
+  constructor() {
+    super()
+    this.scheduling = true
+  }
+}
+
+/** Push one sample in at `bus.input` and read what reaches the destination. */
+function render(ctx: Ctx, bus: { input: AudioNode }, x: number): number {
+  let node = bus.input as unknown as Node
+  let v = node.process(x)
+  for (let i = 0; i < 64; i++) {
+    const next = node.outs[0]
+    if (!next) throw new Error("graph does not reach an output")
+    if ((next as unknown as AudioNode) === ctx.destination) return v
+    node = next
+    v = node.process(v)
+  }
+  throw new Error("graph did not terminate")
+}
+
+const SAMPLE = 0.4
+
+beforeEach(() => resetHostSound())
+
+// ─── The setting itself ──────────────────────────────────────────────────────
+
+describe("the published Sound setting", () => {
+  it("allows sound until a host says otherwise", () => {
+    assert.equal(hostSoundAllowed(), true)
+  })
+
+  it("only `false` silences — an older host that omits the field must not", () => {
+    setHostSound(undefined)
+    assert.equal(hostSoundAllowed(), true)
+    setHostSound(null)
+    assert.equal(hostSoundAllowed(), true)
+    setHostSound(false)
+    assert.equal(hostSoundAllowed(), false)
+  })
+
+  it("tells its followers, and stops when they leave", () => {
+    const seen: boolean[] = []
+    const off = onHostSound((on) => void seen.push(on))
+    setHostSound(false)
+    setHostSound(true)
+    off()
+    setHostSound(false)
+    assert.deepEqual(seen, [false, true])
+  })
+
+  it("says so out loud when a follower throws, and still tells the rest", () => {
+    const seen: boolean[] = []
+    onHostSound(() => {
+      throw new Error("this bus is broken")
+    })
+    onHostSound((on) => void seen.push(on))
+    const said: string[] = []
+    const real = console.error
+    console.error = (...a: unknown[]) => void said.push(a.map(String).join(" "))
+    try {
+      setHostSound(false)
+    } finally {
+      console.error = real
+    }
+    assert.deepEqual(seen, [false], "a throwing bus swallowed the setting for the others")
+    assert.ok(
+      said.some((s) => s.includes("refused the app's sound setting")),
+      "a bus that could not be silenced failed silently",
+    )
+  })
+})
+
+// ─── What the child hears ────────────────────────────────────────────────────
+
+describe("the app's Sound setting reaches the bus", () => {
+  it("THE DEFECT: a bus built while Sound is off used to make noise", () => {
+    setHostSound(false)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "a game mounted with Sound off is audible")
+    assert.equal(render(ctx, bus, 50), 0, "not even a huge input gets through")
+  })
+
+  it("THE DEFECT, LIVE: turning Sound off mid-session silences a running game", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    assert.ok(Math.abs(render(ctx, bus, SAMPLE) - SAMPLE) < 1e-6, "sound on, but nothing came out")
+
+    setHostSound(false)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "Sound was turned off and the game kept playing")
+
+    setHostSound(true)
+    assert.ok(
+      Math.abs(render(ctx, bus, SAMPLE) - SAMPLE) < 1e-6,
+      "the gate stuck shut: Sound came back on and the game stayed silent",
+    )
+  })
+
+  it("catches a cue that was already scheduled, not merely the next one", () => {
+    // A game's own mute button usually means "stop making new voices", which
+    // leaves the half-second tail of the cue that fired a moment ago ringing
+    // out. This gate is downstream of every voice, so the cue in flight — the
+    // one whose oscillator is already started and connected — is silenced too.
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    const voice = new Node("gain", new Param(1))
+    voice.connect(bus.input as unknown as Node)
+    const throughVoice = (x: number): number => render(ctx, { input: voice as unknown as AudioNode }, x)
+
+    assert.ok(Math.abs(throughVoice(SAMPLE) - SAMPLE) < 1e-6)
+    setHostSound(false)
+    assert.equal(throughVoice(SAMPLE), 0, "a cue already in flight survived the mute")
+  })
+
+  it("gates every bus in the pack, not just the last one made", () => {
+    const a = new Ctx()
+    const b = new Ctx()
+    const busA = createSafetyBus(a)
+    const busB = createSafetyBus(b)
+    setHostSound(false)
+    assert.equal(render(a, busA, SAMPLE), 0)
+    assert.equal(render(b, busB, SAMPLE), 0)
+  })
+
+  it("stops following once the bus is torn down", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    bus.disconnect()
+    // The graph is gone; what matters is that the setting no longer reaches a
+    // closure holding a dead bus alive.
+    setHostSound(false)
+    assert.equal(bus.hostAllows, true, "a disconnected bus is still following the setting")
+  })
+})
+
+// ─── Who wins ────────────────────────────────────────────────────────────────
+
+describe("the app setting is authoritative; the game's button is a convenience", () => {
+  it("a game cannot unmute itself out of an app-level mute", () => {
+    setHostSound(false)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    bus.setMuted(false)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "the game's mute button overrode the parent")
+    assert.equal(bus.muted, true, "the bus reported itself audible while silent")
+    assert.equal(bus.gameMuted, false, "the game's own preference was not recorded")
+  })
+
+  it("a game toggling with `!bus.muted` still cannot make noise", () => {
+    setHostSound(false)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    // The idiom every in-game mute button uses.
+    for (let i = 0; i < 4; i++) {
+      bus.setMuted(!bus.muted)
+      assert.equal(render(ctx, bus, SAMPLE), 0, `toggle ${String(i)} produced sound`)
+    }
+  })
+
+  it("the game's preference applies again the moment the app allows sound", () => {
+    setHostSound(false)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    bus.setMuted(false)
+    setHostSound(true)
+    assert.ok(Math.abs(render(ctx, bus, SAMPLE) - SAMPLE) < 1e-6)
+
+    bus.setMuted(true)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "the game's own mute stopped working")
+    // And the app turning Sound off and on again must not undo the game's mute.
+    setHostSound(false)
+    setHostSound(true)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "the app's setting forgot the game had muted itself")
+  })
+
+  it("reports the two owners separately", () => {
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    bus.setMuted(true)
+    assert.equal(bus.gameMuted, true)
+    assert.equal(bus.hostAllows, true)
+    setHostSound(false)
+    assert.equal(bus.hostAllows, false)
+  })
+})
+
+// ─── How the gate moves ──────────────────────────────────────────────────────
+
+describe("the gate on a real AudioParam", () => {
+  it("ramps rather than stepping, because a step from 1 to 0 is a click", () => {
+    const ctx = new SchedulingCtx()
+    const bus = createSafetyBus(ctx)
+    assert.ok(Math.abs(render(ctx, bus, SAMPLE) - SAMPLE) < 1e-6)
+
+    setHostSound(false)
+    // Nothing has arrived yet: this is a ramp, not an assignment.
+    assert.ok(render(ctx, bus, SAMPLE) > 0, "the gate stepped instead of ramping")
+    // 12 ms later it is shut, which is well inside "immediate" for a human.
+    ctx.currentTime += 0.05
+    assert.equal(render(ctx, bus, SAMPLE), 0, "the ramp never arrived")
+  })
+
+  it("mounts muted with no fade in, so a game with Sound off is silent at sample zero", () => {
+    setHostSound(false)
+    const ctx = new SchedulingCtx()
+    const bus = createSafetyBus(ctx)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "the first 12 ms of a Sound-off game were audible")
+  })
+
+  it("falls back to a step where the context has no automation", () => {
+    // The shape most of the 27 games' own fake contexts implement. Blunt, but
+    // complete — and the alternative is a shared module breaking their suites,
+    // which has happened here before.
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    setHostSound(false)
+    assert.equal(render(ctx, bus, SAMPLE), 0, "a value-only AudioParam was never gated")
+  })
+})

--- a/dynawalla/packs/shared/game-audio/sound.ts
+++ b/dynawalla/packs/shared/game-audio/sound.ts
@@ -1,0 +1,109 @@
+/**
+ * The app's Sound setting, as a fact every safety bus obeys.
+ *
+ * **The defect this closes.** Dynawalla's Settings screen has a Sound switch.
+ * It is wired to a store, the store is serialised onto the wire as
+ * `Settings.sound`, and the host pushes it to a running pack whenever it
+ * changes. Then nothing read it. `game-host` consumed `safeArea` and
+ * `reducedMotion` off that same object and walked past `sound`; not one of the
+ * 27 games read it either — every one of them shipped its own mute button and
+ * its own localStorage key. A parent turning Sound off silenced nothing. That
+ * is a lie told by a switch, and it is the one control a parent reaches for
+ * when a game is too loud.
+ *
+ * **Why it lives here and not in each game.** Every game's output is required
+ * to pass through `createSafetyBus` (see `routing.test.ts`). That is one
+ * chokepoint for 27 graphs, so the setting is applied once, here, and no game
+ * has to remember anything. A game written next year inherits it by connecting
+ * to the bus, which it already has to do.
+ *
+ * **Why a gain gate and not `AudioContext.suspend()`.** Suspending is the more
+ * total-sounding answer and it is the wrong one:
+ *
+ *  - *It can refuse to come back.* Resuming a context requires user activation
+ *    on WebKit. The gesture that flips this setting happens in the app's
+ *    document; the pack is a cross-origin iframe and does not receive it. A
+ *    context suspended from that gesture may sit suspended until the child next
+ *    touches the game — and if the game's own code only calls `resume()` on
+ *    start-up, never. A gate stuck shut is the same bug wearing a hat.
+ *  - *It is not ours to own.* The host already suspends and resumes for pause,
+ *    and the manual-pause work in `game-chrome` will too. Two owners of one
+ *    context flag is how "unpause left it silent" gets written.
+ *  - *It glitches.* A suspended context stops its clock; every envelope
+ *    scheduled against `currentTime` resumes where it left off, which is a
+ *    smear rather than silence.
+ *
+ * A gain node placed after the ceiling has none of those problems, and it is
+ * *more* complete than the alternative people reach for first. A game's own
+ * mute button typically means "stop making new voices", which leaves the
+ * half-second decay of the cue that fired a moment ago ringing out. Muting the
+ * bus catches that too: everything already scheduled is upstream of the gate,
+ * so it is silenced mid-flight.
+ */
+
+/**
+ * Whether the app is currently allowing sound.
+ *
+ * `true` until a host says otherwise. A game opened in the dev harness, or in a
+ * browser tab with no host at all, has to make noise — the failure mode of the
+ * other default is a silent game and nobody knowing why.
+ */
+let allowed = true
+
+type Sink = (allowed: boolean) => void
+
+/** Live buses. Each removes itself on `disconnect()`. */
+const sinks = new Set<Sink>()
+
+/**
+ * Publish the app's Sound setting.
+ *
+ * `game-host` calls this at attach and again on every `settings` event, which
+ * is what makes the switch work *during* a session rather than only at launch.
+ *
+ * `undefined` and `null` mean allow: a host too old to send the field is not a
+ * reason to silence a game.
+ */
+export function setHostSound(on: boolean | undefined | null): void {
+  const next = on !== false
+  if (next === allowed) return
+  allowed = next
+  // A copy, so a sink that disconnects its bus from inside the callback cannot
+  // mutate the set being iterated.
+  for (const sink of [...sinks]) {
+    try {
+      sink(next)
+    } catch (error) {
+      // Loud. A bus that could not be gated is a bus that is still making
+      // noise after a parent asked it not to, and that must never be quiet.
+      console.error("[game-audio] a bus refused the app's sound setting", error)
+    }
+  }
+}
+
+/** Whether the app is allowing sound right now. */
+export function hostSoundAllowed(): boolean {
+  return allowed
+}
+
+/**
+ * Follow the setting. Returns an unsubscribe; call it when the bus is torn
+ * down or the closure outlives the graph it was gating.
+ */
+export function onHostSound(sink: Sink): () => void {
+  sinks.add(sink)
+  return () => {
+    sinks.delete(sink)
+  }
+}
+
+/**
+ * Forget the published setting and every subscriber.
+ *
+ * For tests. Module state that survives between test files is how a suite
+ * starts passing for the wrong reason.
+ */
+export function resetHostSound(): void {
+  allowed = true
+  sinks.clear()
+}

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -61,6 +61,7 @@
 
 import type { Capability, HostClient, Item, TransitionKind } from "../../sdk/src/index.ts"
 import { setHostInsets } from "../game-chrome/insets.ts"
+import { setHostSound } from "../game-audio/index.ts"
 import { connect } from "../../sdk/src/index.ts"
 
 /** The shape both games declare locally. Kept structurally identical. */
@@ -428,8 +429,23 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   // `env(safe-area-inset-*)` belongs to the top-level browsing context, so it
   // reads zeros. The host measures and sends them; publish them to game-chrome
   // here, once, so every pack gets it without each game remembering to.
-  setHostInsets(client.settings.safeArea)
-  client.on("settings", () => setHostInsets(client.settings.safeArea))
+  //
+  // The app's Sound setting travels on the same object and had the same
+  // problem, worse: nothing read it at all. A parent turned Sound off and all
+  // 27 games kept playing, because each one owned a mute button and none of
+  // them owned the setting. Published here it reaches every game's safety bus
+  // at once, and no game has to be edited to obey it.
+  //
+  // Both are re-published on every `settings` event, not only at attach. The
+  // host pushes one whenever the store changes, which is the whole point: a
+  // switch that only takes effect at launch is a switch a parent flips while a
+  // game is loud and watches do nothing.
+  const publish = (): void => {
+    setHostInsets(client.settings.safeArea)
+    setHostSound(client.settings.sound)
+  }
+  publish()
+  client.on("settings", publish)
   const domain = options.domain ?? "arith"
   const autoFlush = options.autoFlush ?? true
   const granted = new Set<Capability>(client.granted)

--- a/dynawalla/packs/shared/game-host/sound.test.ts
+++ b/dynawalla/packs/shared/game-host/sound.test.ts
@@ -1,0 +1,262 @@
+/**
+ * The wire from the app's Sound switch to a silent game.
+ *
+ * `attachGameHost` already read `safeArea` and `reducedMotion` off
+ * `client.settings` and walked past `sound`. Nothing else read it either: all
+ * 27 games shipped their own mute button and their own localStorage key, so a
+ * parent turning Sound off in Settings silenced nothing at all.
+ *
+ * These tests run the whole path a device runs: a host client whose settings
+ * say what the app's store says, a pack attaching to it, and a game's audio
+ * graph built through the shared safety bus. What is asserted is what leaves
+ * the graph, because "is it silent" is not a question a spy can answer.
+ */
+import assert from "node:assert/strict"
+import { beforeEach, describe, it } from "node:test"
+
+import type { HostClient, HostEventName, Settings } from "../../sdk/src/index.ts"
+import { createSafetyBus, resetHostSound, type BusContext } from "../game-audio/index.ts"
+import { setHostInsets, safeInsets } from "../game-chrome/insets.ts"
+import { attachGameHost } from "./index.ts"
+
+// ─── The smallest host that can change its mind ──────────────────────────────
+
+const BASE: Settings = {
+  locale: "en",
+  reducedMotion: false,
+  quality: "high",
+  textScale: 1,
+  colorScheme: "light",
+  sound: true,
+  haptics: true,
+}
+
+type Stub = {
+  readonly client: HostClient
+  /** What the app's Settings screen just did. Pushes a `settings` event, as the real host does. */
+  push(next: Partial<Settings>): void
+  setSound(on: boolean): void
+}
+
+/**
+ * A client that behaves like the SDK's guest on the one axis under test:
+ * `settings` is live, and a `settings` event follows every change to it.
+ */
+function stubClient(initial: Partial<Settings> = {}): Stub {
+  let settings: Settings = { ...BASE, ...initial }
+  const listeners = new Map<HostEventName, Set<(data: unknown) => void>>()
+  const client: HostClient = {
+    packId: "dynawalla.test",
+    hostVersion: "0.1.0",
+    granted: [],
+    get settings() {
+      return settings
+    },
+    can: () => false,
+    nextItem: () => Promise.resolve(null),
+    answer: () => Promise.reject(new Error("not used")),
+    skip: () => Promise.resolve(),
+    reveal: () => Promise.resolve(""),
+    learnerSummary: () => Promise.resolve({ skills: [] }),
+    haptic: () => Promise.resolve(),
+    sound: () => Promise.resolve(),
+    milestone: () => Promise.resolve(),
+    storage: {
+      get: () => Promise.resolve(null),
+      set: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      keys: () => Promise.resolve([]),
+    },
+    progress: () => Promise.resolve(),
+    end: () => Promise.resolve(),
+    transition: () => Promise.resolve(),
+    on: (event, listener) => {
+      const set = listeners.get(event) ?? new Set()
+      set.add(listener)
+      listeners.set(event, set)
+      return () => void set.delete(listener)
+    },
+    dispose: () => {},
+  }
+  const push = (next: Partial<Settings>): void => {
+    settings = { ...settings, ...next }
+    for (const listener of listeners.get("settings") ?? []) listener(settings)
+  }
+  return { client, push, setSound: (on: boolean) => push({ sound: on }) }
+}
+
+// ─── A graph that processes samples ──────────────────────────────────────────
+
+class Param {
+  value: number
+  constructor(v = 0) {
+    this.value = v
+  }
+}
+class Node {
+  readonly gain = new Param(1)
+  readonly threshold = new Param()
+  readonly knee = new Param()
+  readonly ratio = new Param()
+  readonly attack = new Param()
+  readonly release = new Param()
+  curve: Float32Array | null = null
+  oversample = "none"
+  readonly outs: Node[] = []
+  readonly kind: "gain" | "comp" | "shaper" | "dest"
+  constructor(kind: "gain" | "comp" | "shaper" | "dest") {
+    this.kind = kind
+  }
+  connect<T>(d: T): T {
+    this.outs.push(d as unknown as Node)
+    return d
+  }
+  disconnect(): void {
+    this.outs.length = 0
+  }
+  process(x: number): number {
+    if (this.kind === "gain") return x * this.gain.value
+    if (this.kind === "shaper") return this.curve ? lookup(this.curve, x) : x
+    return x
+  }
+}
+function lookup(curve: Float32Array, x: number): number {
+  const n = curve.length
+  const v = ((n - 1) / 2) * (x + 1)
+  if (!(v > 0)) return curve[0]!
+  if (v >= n - 1) return curve[n - 1]!
+  const k = Math.floor(v)
+  const f = v - k
+  return curve[k]! * (1 - f) + curve[k + 1]! * f
+}
+class Ctx implements BusContext {
+  currentTime = 0
+  readonly destination = new Node("dest") as unknown as AudioNode
+  createGain(): GainNode {
+    return new Node("gain") as unknown as GainNode
+  }
+  createDynamicsCompressor(): DynamicsCompressorNode {
+    return new Node("comp") as unknown as DynamicsCompressorNode
+  }
+  createWaveShaper(): WaveShaperNode {
+    return new Node("shaper") as unknown as WaveShaperNode
+  }
+}
+
+/** What a game sounds like: one cue pushed through its bus to the speaker. */
+function heard(ctx: Ctx, bus: { input: AudioNode }, x = 0.4): number {
+  let node = bus.input as unknown as Node
+  let v = node.process(x)
+  for (let i = 0; i < 64; i++) {
+    const next = node.outs[0]
+    if (!next) throw new Error("graph does not reach an output")
+    if ((next as unknown as AudioNode) === ctx.destination) return v
+    node = next
+    v = node.process(v)
+  }
+  throw new Error("graph did not terminate")
+}
+
+const CUE = 0.4
+
+// The setting is module state in game-audio; a test that inherits the previous
+// test's answer is a test that passes for the wrong reason.
+beforeEach(() => {
+  resetHostSound()
+  setHostInsets(null)
+})
+
+describe("the app's Sound setting silences the game", () => {
+  it("THE DEFECT: a game launched with Sound off is silent", () => {
+    const stub = stubClient({ sound: false })
+    attachGameHost(stub.client)
+
+    // Exactly what a game does in `start()`, after the gesture.
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    assert.equal(
+      heard(ctx, bus, CUE),
+      0,
+      "the parent turned Sound off before launch and the game played anyway",
+    )
+  })
+
+  it("THE DEFECT, LIVE: the switch works during a session, in both directions", () => {
+    const stub = stubClient({ sound: true })
+    attachGameHost(stub.client)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+
+    assert.ok(Math.abs(heard(ctx, bus, CUE) - CUE) < 1e-6, "Sound is on and the game is silent")
+
+    stub.setSound(false)
+    assert.equal(heard(ctx, bus, CUE), 0, "Sound was switched off mid-game and nothing happened")
+
+    stub.setSound(true)
+    assert.ok(
+      Math.abs(heard(ctx, bus, CUE) - CUE) < 1e-6,
+      "the gate stuck shut: Sound came back and the game did not",
+    )
+  })
+
+  it("keeps publishing the insets it always published", () => {
+    // The settings handler grew a second job, and the two were folded into one
+    // listener. The first job has to survive that — a shared handler that
+    // quietly replaced the other is exactly the regression this repo has
+    // shipped before, so this reads the insets back out of game-chrome rather
+    // than trusting that the call was made.
+    const stub = stubClient({ safeArea: { top: 47, right: 0, bottom: 34, left: 0 } })
+    attachGameHost(stub.client)
+    assert.deepEqual(safeInsets(), { top: 47, right: 0, bottom: 34, left: 0 })
+
+    stub.push({ safeArea: { top: 0, right: 21, bottom: 21, left: 0 } })
+    assert.deepEqual(
+      safeInsets(),
+      { top: 0, right: 21, bottom: 21, left: 0 },
+      "rotating the tablet no longer moves the safe area",
+    )
+  })
+
+  it("a host too old to send the field does not silence the game", () => {
+    const { sound: _omitted, ...older } = BASE
+    const stub = stubClient()
+    const legacy: HostClient = { ...stub.client, settings: older as Settings }
+    attachGameHost(legacy)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+    assert.ok(
+      Math.abs(heard(ctx, bus, CUE) - CUE) < 1e-6,
+      "an older host with no `sound` field silenced a game it never asked to silence",
+    )
+  })
+
+  it("a game's own mute button cannot override the parent", () => {
+    const stub = stubClient({ sound: false })
+    attachGameHost(stub.client)
+    const ctx = new Ctx()
+    const bus = createSafetyBus(ctx)
+
+    bus.setMuted(false) // the child pressed the in-game speaker icon
+    assert.equal(heard(ctx, bus, CUE), 0, "the in-game button unmuted past the app setting")
+
+    stub.setSound(true)
+    assert.ok(
+      Math.abs(heard(ctx, bus, CUE) - CUE) < 1e-6,
+      "the child's own preference was lost when Sound came back",
+    )
+  })
+
+  it("silences every bus in the pack at once", () => {
+    // Several games build more than one: music and effects on separate buses.
+    const stub = stubClient({ sound: true })
+    attachGameHost(stub.client)
+    const music = new Ctx()
+    const sfx = new Ctx()
+    const musicBus = createSafetyBus(music)
+    const sfxBus = createSafetyBus(sfx)
+
+    stub.setSound(false)
+    assert.equal(heard(music, musicBus, CUE), 0, "the music bus kept playing")
+    assert.equal(heard(sfx, sfxBus, CUE), 0, "the effects bus kept playing")
+  })
+})


### PR DESCRIPTION
A parent turns Sound off in the Dynawalla Settings screen and every game keeps
playing. The switch is real all the way to the pack: `Settings.sound` is on the
wire, `services.ts` fills it in, `PackFrame` pushes a `settings` event whenever
the store changes. Nothing on the pack side read it. `packs/shared/game-host`
consumed `safeArea` and `reducedMotion` off that same object and walked past
`sound`, and no game read it either — all 27 ship their own mute button and
their own localStorage key.

A switch that does nothing is worse than a missing one, and it matters now: the
founder's nine-year-old said MOSAIC almost made his ears explode, and this is
the one control a parent reaches for.

## The mechanism

`packs/shared/game-audio/sound.ts` holds the app's setting as module state and
a set of followers. `attachGameHost` publishes it — at attach and again on
every `settings` event, folded into the same handler that already re-publishes
the insets — and `createSafetyBus` follows it for the life of the bus.

That is one chokepoint for 27 audio graphs, and **no game file is touched**. A
game inherits the behaviour by connecting to the bus, which it already has to.

### Why a gain gate and not `AudioContext.suspend()`

Suspending sounds more total and is the wrong answer:

* **It can refuse to come back.** Resuming needs user activation on WebKit. The
  gesture that flips this setting happens in the *app's* document; the pack is a
  cross-origin iframe and never receives it. A context suspended from that
  gesture can sit suspended until the child next touches the game — and if the
  game only calls `resume()` on start-up, forever. A gate stuck shut is the same
  bug wearing a hat, and this repo has shipped that exact failure.
* **It is not ours to own.** The host already suspends and resumes for pause,
  and the manual-pause work landing in `game-chrome` will too. Two owners of one
  context flag is how "unpause left it silent" gets written.
* **It glitches.** A suspended context stops its clock, so every envelope
  scheduled against `currentTime` resumes where it left off — a smear.

### Does it catch cues already scheduled? Yes — that is the point

A game's own mute button means "stop making new voices", which leaves the tail
of the cue that fired a moment ago ringing out. This gate is downstream of every
voice and after the ceiling, so a cue whose oscillator is already started and
connected is silenced mid-flight. Tested directly (`catches a cue that was
already scheduled, not merely the next one`).

The gate moves over 12 ms rather than in one sample: a gain stepped from 1 to 0
is a discontinuity, and a discontinuity is a click — precisely the sound this
module exists to prevent. Where the context has no automation (which is what
most games' own fake contexts implement) it falls back to a plain assignment:
blunt, equally silent, and it does not break their suites the way the shared
chrome module once broke four games by assuming APIs their doubles lacked.

## How this relates to the in-game mute buttons

The app setting is **authoritative**; a game's button is a convenience *within*
an unmuted session.

* `setMuted(false)` while Sound is off records the game's preference and changes
  nothing audible.
* `bus.muted` reports the honest reading — silent or not — so the
  `setMuted(!bus.muted)` idiom every in-game button uses still cannot make noise
  against the parent. Tested over four toggles.
* When Sound comes back, the game's own preference is the one that applies, and
  an app-level off/on cycle does not undo a game's own mute.

No game's button was changed; those files are locked.

## Which games are covered — plainly

The gate covers **whatever is routed through the safety bus**, and no more.

* On `main` today that is **mosaic only**. PR #676 landed the bus; #680, which
  routes the other games, is still **open**.
* Once #680 lands: **25 of 27**.
* **`arena` and `claim` are NOT covered.** Both still connect straight to
  `ctx.destination` and are on #680's `NOT_YET_ROUTED` list. They will be
  covered the moment they are routed — this change needs nothing further.

This is a gate on the chokepoint, not fleet coverage by itself.

## Proof

Nine of the new tests fail with the fix deleted. Two deletions, run separately:

**Delete the host wiring** (`setHostSound(client.settings.sound)` and its
import) — 4 of 6 in `game-host/sound.test.ts`:

```
✖ THE DEFECT: a game launched with Sound off is silent
  AssertionError: the parent turned Sound off before launch and the game played anyway
✖ THE DEFECT, LIVE: the switch works during a session, in both directions
  AssertionError: Sound was switched off mid-game and nothing happened
✖ a game's own mute button cannot override the parent
  AssertionError: the in-game button unmuted past the app setting
✖ silences every bus in the pack at once
  AssertionError: the music bus kept playing
```

The other two (`keeps publishing the insets it always published`, `a host too
old to send the field does not silence the game`) correctly still pass — they do
not depend on the wiring.

**Delete the bus's subscription** (`hostAllows` pinned true, `onHostSound`
dropped) — 10 in `game-audio/sound.test.ts`:

```
✖ THE DEFECT: a bus built while Sound is off used to make noise
  AssertionError: a game mounted with Sound off is audible
✖ THE DEFECT, LIVE: turning Sound off mid-session silences a running game
  AssertionError: Sound was turned off and the game kept playing
✖ catches a cue that was already scheduled, not merely the next one
  AssertionError: a cue already in flight survived the mute
✖ gates every bus in the pack, not just the last one made
✖ a game cannot unmute itself out of an app-level mute
  AssertionError: the game's mute button overrode the parent
✖ a game toggling with `!bus.muted` still cannot make noise
  AssertionError: toggle 1 produced sound
✖ reports the two owners separately
✖ ramps rather than stepping, because a step from 1 to 0 is a click
  AssertionError: the ramp never arrived
✖ mounts muted with no fade in, so a game with Sound off is silent at sample zero
  AssertionError: the first 12 ms of a Sound-off game were audible
✖ falls back to a step where the context has no automation
  AssertionError: a value-only AudioParam was never gated
```

The tests are not spies: both files build the bus's real graph and push samples
through it to the destination, so "silent" means a zero came out.

## Verified

* `game-audio` 51 pass / `game-host` 31 pass, **five consecutive runs each**.
* `tsc --noEmit` clean in both, plus `game-chrome` (29) and `game-pacing` (20).
* `mosaic` (79) and `trebuchet` (166) suites green — the two games that reach
  the bus and the host respectively.
* `trebuchet` `build:pack` builds, so the new cross-module import bundles.

## What only a device can confirm

* That the 12 ms fade is inaudible as lag and audibly removes the click. The
  ramp branch is asserted against a modelled `AudioParam`; a real
  `linearRampToValueAtTime` on WebKit is not.
* That nothing survives the gate on a real device — a game that connects around
  the bus would, and `arena`/`claim` currently do.
* Any interaction with the host's own cue player, which has its own
  `if (current.sound)` guard on the app side and is untouched here.