### PR TITLE
fix(dynawalla/packs/sdk): a double tap in a pack cannot scale the page, and does not cost a tap

### DIFF
--- a/dynawalla/packs/sdk/README.md
+++ b/dynawalla/packs/sdk/README.md
@@ -192,6 +192,20 @@ the colour scheme, and it follows the host — re-read it on the `settings` even
 - **Nothing by colour alone**, a keyboard path to everything, child-sized
   targets, and 320 px with no horizontal overflow.
 
+### Double-tap zoom is handled for you
+
+A pack is framed, and an iframe has no viewport of its own — so a double tap
+inside your game scales the **host** page, and neither your `<meta viewport>`
+nor your `touch-action: none` stops it. `connect()` installs a guard for this
+before it does anything else, in `tapzoom.ts`. Your game does not call it, does
+not configure it, and cannot forget it.
+
+What that costs you: nothing, on purpose. The guard cancels the second and later
+taps of a rapid chain — which is the only way to stop the zoom — and then
+re-dispatches the `click` the cancellation swallowed, so a control bound to
+`click` still fires on every tap. Read `tapzoom.ts` before you build anything
+that depends on the exact ordering of `touchend` and `click`.
+
 ---
 
 ## Developing a pack

--- a/dynawalla/packs/sdk/src/guest.test.ts
+++ b/dynawalla/packs/sdk/src/guest.test.ts
@@ -325,3 +325,27 @@ test("a difficulty request is on the wire, and only the fields that were named",
   assert.deepEqual(seen[2], { id: 3, method: "items.next", params: { skillId: "add.1" } })
   host.dispose()
 })
+
+test("connecting installs the tap guard on the pack document", async (t) => {
+  // The one wire that makes this automatic. If `connect()` stops calling
+  // `installTapZoomGuard`, twenty-seven packs silently get their double-tap
+  // zoom back and every test in `tapzoom.test.ts` still passes.
+  const bound: string[] = []
+  const document = {
+    addEventListener: (type: string) => {
+      bound.push(type)
+    },
+    removeEventListener: () => {},
+  }
+  ;(globalThis as { document?: unknown }).document = document
+  t.after(() => {
+    delete (globalThis as { document?: unknown }).document
+    cleanup()
+  })
+
+  const { client } = withFakeFrame()
+  const host = await client
+  assert.ok(bound.includes("touchend"), `no touchend guard on the pack document: ${bound.join(", ")}`)
+  assert.ok(bound.includes("touchstart"))
+  host.dispose()
+})

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -33,6 +33,7 @@ import type {
   TransitionKind,
 } from "./protocol.ts"
 import { isConnect, isResponse, PROTOCOL_VERSION } from "./protocol.ts"
+import { installTapZoomGuard } from "./tapzoom.ts"
 
 export class PackError extends Error {
   readonly code: string
@@ -145,6 +146,11 @@ const DEFAULT_TIMEOUT_MS = 15_000
  */
 export function connect(options: { timeoutMs?: number } = {}): Promise<HostClient> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  // Before the handshake, not after it. A pack draws a loading state while it
+  // waits for a port, and a child tapping at that is exactly as able to zoom
+  // the host as one tapping at a running game. See `tapzoom.ts` for why this
+  // belongs to the pack and cannot belong to the host.
+  installTapZoomGuard()
   return new Promise<HostClient>((resolve, reject) => {
     if (typeof window === "undefined" || window.parent === window) {
       reject(new PackError("no_host", "this document is not framed by a Dynawalla host"))

--- a/dynawalla/packs/sdk/src/index.ts
+++ b/dynawalla/packs/sdk/src/index.ts
@@ -68,3 +68,15 @@ export type { HostRange, Semver } from "./semver.ts"
 
 export { PackError, connect } from "./guest.ts"
 export type { HostClient, ItemRequest } from "./guest.ts"
+
+// `connect()` installs the guard itself — a pack never has to call this. It is
+// exported so the host and the dev harness can install the same one, and so a
+// pack that runs unframed on purpose still has a way to.
+export {
+  DOUBLE_TAP_MS,
+  DOUBLE_TAP_SLOP_PX,
+  DRAG_SLOP_PX,
+  TapZoomGuard,
+  installTapZoomGuard,
+} from "./tapzoom.ts"
+export type { GuardTouch, GuardTouchEvent, TapGuardOptions, TapGuardTarget } from "./tapzoom.ts"

--- a/dynawalla/packs/sdk/src/tapzoom.test.ts
+++ b/dynawalla/packs/sdk/src/tapzoom.test.ts
@@ -1,0 +1,461 @@
+// The tap guard, driven through the exact sequences a finger emits.
+//
+// The `click` half is dispatched for real: the targets are Node's own
+// `EventTarget` and the guard's default synthesiser builds a real event object
+// through `globalThis.MouseEvent`, shimmed below because Node has no DOM. So
+// "the child got their tap" is asserted by a listener firing, not by a spy on
+// an intention.
+//
+// The sequence that matters most is `rapid taps on one spot` — the invariant a
+// game depends on, and the one the host's deleted guard broke.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  DOUBLE_TAP_MS,
+  DOUBLE_TAP_SLOP_PX,
+  DRAG_SLOP_PX,
+  TapZoomGuard,
+  installTapZoomGuard,
+} from "./tapzoom.ts"
+import type { GuardTouch } from "./tapzoom.ts"
+
+/* ------------------------------------------------------------ the DOM shims */
+
+class FakeMouseEvent extends Event {
+  readonly clientX: number
+  readonly clientY: number
+  constructor(type: string, init: { clientX?: number; clientY?: number; bubbles?: boolean } = {}) {
+    super(type, init)
+    this.clientX = init.clientX ?? 0
+    this.clientY = init.clientY ?? 0
+  }
+}
+;(globalThis as { MouseEvent?: unknown }).MouseEvent = FakeMouseEvent
+
+/**
+ * The compatibility click the platform fires when a `touchend` was NOT
+ * cancelled. Modelled here so that "one click per tap" can be counted across
+ * both branches — the tap that kept the platform's click and the tap whose
+ * click the guard had to put back. Its own class, so the two are told apart by
+ * which code path built them rather than by a flag a test could set wrongly.
+ */
+class NativeClickEvent extends FakeMouseEvent {}
+
+/** A node a touch can land on, and a click can be delivered to. */
+class FakeNode extends EventTarget {
+  readonly clicks: FakeMouseEvent[] = []
+  constructor() {
+    super()
+    this.addEventListener("click", (event) => this.clicks.push(event as FakeMouseEvent))
+  }
+  /** Clicks the guard re-dispatched, as opposed to the ones the platform fired. */
+  get restored(): FakeMouseEvent[] {
+    return this.clicks.filter((c) => !(c instanceof NativeClickEvent))
+  }
+}
+
+type Bound = { type: string; listener: (event: never) => void; options?: { capture?: boolean; passive?: boolean } }
+
+/** Stands in for the pack document the guard installs on. */
+class FakeDocument {
+  readonly bound: Bound[] = []
+  addEventListener(
+    type: string,
+    listener: (event: never) => void,
+    options?: { capture?: boolean; passive?: boolean },
+  ): void {
+    this.bound.push(options === undefined ? { type, listener } : { type, listener, options })
+  }
+  removeEventListener(type: string, listener: (event: never) => void): void {
+    const index = this.bound.findIndex((b) => b.type === type && b.listener === listener)
+    if (index >= 0) this.bound.splice(index, 1)
+  }
+  /** Deliver an event to every listener bound for `type`, capture-phase style. */
+  emit(type: string, event: unknown): void {
+    for (const entry of [...this.bound]) {
+      if (entry.type === type) (entry.listener as (event: unknown) => void)(event)
+    }
+  }
+}
+
+type FakeTouchEvent = {
+  touches: GuardTouch[]
+  changedTouches: GuardTouch[]
+  cancelable: boolean
+  prevented: boolean
+  preventDefault: () => void
+}
+
+function touchEvent(
+  touch: GuardTouch | GuardTouch[],
+  options: { remaining?: number; cancelable?: boolean } = {},
+): FakeTouchEvent {
+  const remaining = options.remaining ?? 0
+  const event: FakeTouchEvent = {
+    // `touches` is what is STILL down, so on a lift it excludes this finger and
+    // on a press it includes it. The guard reads its length and nothing else,
+    // so a filler point is honest enough.
+    touches: Array.from({ length: remaining }, () => ({ clientX: 0, clientY: 0 })),
+    changedTouches: Array.isArray(touch) ? touch : [touch],
+    cancelable: options.cancelable ?? true,
+    prevented: false,
+    preventDefault: () => {
+      event.prevented = true
+    },
+  }
+  return event
+}
+
+/** Let the queued microtask that carries the re-dispatched click run. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+type Guarded = {
+  doc: FakeDocument
+  advance: (ms: number) => void
+  press: (x: number, y: number, node?: FakeNode, downCount?: number) => void
+  drag: (x: number, y: number, node?: FakeNode) => void
+  /** Returns whether the lift's default action was cancelled. */
+  lift: (x: number, y: number, node?: FakeNode, remaining?: number) => boolean
+  tap: (x: number, y: number, node?: FakeNode) => boolean
+}
+
+/**
+ * A guarded document with a controllable clock.
+ *
+ * `tap` drives the whole sequence — press, lift — and returns whether the lift
+ * was cancelled, which is the thing the zoom hangs on.
+ */
+function guarded(): Guarded {
+  const doc = new FakeDocument()
+  let clock = 1_000
+  installTapZoomGuard(doc, { now: () => clock })
+
+  const press = (x: number, y: number, node?: FakeNode, downCount = 1): void => {
+    doc.emit("touchstart", touchEvent({ clientX: x, clientY: y, target: node }, { remaining: downCount }))
+  }
+  const lift = (x: number, y: number, node?: FakeNode, remaining = 0): boolean => {
+    const event = touchEvent({ clientX: x, clientY: y, target: node }, { remaining })
+    doc.emit("touchend", event)
+    // What a browser does next, and the whole reason the guard has to give a
+    // click back: an uncancelled `touchend` is followed by the compatibility
+    // `click`, and a cancelled one is not.
+    if (!event.prevented && node) {
+      node.dispatchEvent(new NativeClickEvent("click", { clientX: x, clientY: y, bubbles: true }))
+    }
+    return event.prevented
+  }
+  return {
+    doc,
+    press,
+    lift,
+    advance: (ms) => {
+      clock += ms
+    },
+    drag: (x, y, node) => {
+      doc.emit("touchmove", touchEvent({ clientX: x, clientY: y, target: node }, { remaining: 1 }))
+    },
+    tap: (x, y, node) => {
+      press(x, y, node)
+      return lift(x, y, node)
+    },
+  }
+}
+
+/* ------------------------------------------------- the sequence that matters */
+
+test("rapid deliberate tapping on one spot delivers every tap to the game", async () => {
+  // FOUNDRY's pedals, COLOSSUS's strikes, STACK's commit. Eight presses on the
+  // same pixel, 80ms apart — indistinguishable from a double tap by geometry,
+  // and the child must lose none of them.
+  const g = guarded()
+  const pedal = new FakeNode()
+  const touchends: number[] = []
+  g.doc.addEventListener("touchend", (() => touchends.push(1)) as (event: never) => void)
+
+  for (let i = 0; i < 8; i++) {
+    g.tap(200, 300, pedal)
+    g.advance(80)
+  }
+  await flush()
+
+  assert.equal(pedal.clicks.length, 8, "every tap must produce exactly one click")
+  assert.equal(pedal.restored.length, 7, "one platform click, and seven the guard put back")
+  assert.equal(touchends.length, 8, "the game's own touchend listener must see every tap")
+})
+
+test("a rapid chain is one click per tap however each tap was handled", async () => {
+  // The first tap keeps its real click; every later one is cancelled and
+  // re-dispatched. Both branches are exercised here, and the count is the same
+  // either way — which is the whole point.
+  const g = guarded()
+  const node = new FakeNode()
+
+  const first = g.tap(50, 50, node)
+  g.advance(100)
+  const second = g.tap(50, 50, node)
+  g.advance(100)
+  const third = g.tap(50, 50, node)
+  await flush()
+
+  assert.equal(first, false, "the first tap of a chain is never cancelled")
+  assert.equal(second, true, "the second tap is the zoom, and is cancelled")
+  assert.equal(third, true, "and so is the third, so no untouched pair is left")
+  assert.equal(node.clicks.length, 3, "three taps, three clicks")
+  assert.deepEqual(
+    node.restored.map((c) => [c.clientX, c.clientY]),
+    [
+      [50, 50],
+      [50, 50],
+    ],
+    "the two cancelled taps got their clicks back, at the coordinates the finger was at",
+  )
+})
+
+test("the restored click lands after the touchend it belongs to", async () => {
+  // Dispatched from inside the `touchend` handler it would arrive BEFORE the
+  // game's own `touchend` listener — the guard installs in the capture phase,
+  // so it runs first — and a game whose state machine reads `pointerup` then
+  // `click` would see them inverted. MERGE IDLE's `TapGuard` is exactly such a
+  // machine.
+  const g = guarded()
+  const node = new FakeNode()
+  const log: string[] = []
+  g.doc.addEventListener("touchend", (() => log.push("touchend")) as (event: never) => void)
+  node.addEventListener("click", () => log.push("click"))
+
+  g.tap(40, 40, node)
+  g.advance(100)
+  g.tap(40, 40, node)
+  await flush()
+
+  assert.deepEqual(log, ["touchend", "click", "touchend", "click"])
+})
+
+test("a correction between two controls 20px apart reaches both controls", async () => {
+  // The objection that killed the host's guard in #678: two cells of a
+  // segmented control, tapped in sequence, well inside the double-tap slop.
+  const g = guarded()
+  const left = new FakeNode()
+  const right = new FakeNode()
+
+  g.tap(100, 100, left)
+  g.advance(120)
+  const prevented = g.tap(120, 100, right)
+  await flush()
+
+  assert.equal(prevented, true, "20px apart is a zoom by shape and must be cancelled")
+  assert.equal(left.clicks.length, 1, "the first tap kept the platform's own click")
+  assert.equal(left.restored.length, 0)
+  assert.deepEqual(
+    right.restored.map((c) => [c.clientX, c.clientY]),
+    [[120, 100]],
+    "and the second was re-delivered to the cell it was actually on",
+  )
+})
+
+/* ------------------------------------------------------- what must not zoom */
+
+test("a second tap inside the window and the slop is cancelled", () => {
+  // Literal milliseconds and pixels on purpose. Written against the exported
+  // constants, this test would follow them wherever they moved — a window
+  // narrowed to 40ms would read as green while the zoom came back.
+  const g = guarded()
+  assert.equal(g.tap(10, 10), false)
+  g.advance(300)
+  assert.equal(g.tap(10, 10), true, "300ms later on the same pixel is a double tap")
+
+  const h = guarded()
+  assert.equal(h.tap(10, 10), false)
+  h.advance(120)
+  assert.equal(h.tap(35, 10), true, "and so is 25px away")
+
+  assert.ok(DOUBLE_TAP_MS >= 300 && DOUBLE_TAP_SLOP_PX >= 25, "the constants the numbers above assume")
+})
+
+test("gesture events are cancelled, and are pinch rather than double tap", () => {
+  const g = guarded()
+  for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+    const event = touchEvent({ clientX: 0, clientY: 0 })
+    g.doc.emit(type, event)
+    assert.equal(event.prevented, true, `${type} must not scale the page`)
+  }
+})
+
+/* ---------------------------------------------------- what must not be eaten */
+
+test("two taps a second apart are both left alone", () => {
+  const g = guarded()
+  assert.equal(g.tap(10, 10), false)
+  g.advance(1_000)
+  assert.equal(g.tap(10, 10), false, "past the window this is a new gesture, not a zoom")
+})
+
+test("two taps further apart than the slop are both left alone", () => {
+  const g = guarded()
+  assert.equal(g.tap(10, 10), false)
+  g.advance(50)
+  assert.equal(g.tap(200, 10), false)
+})
+
+test("a finger-scroll of the manual sheet is never cancelled", async () => {
+  // `packs/shared/game-chrome` sets `touch-action: pan-y` on the manual body so
+  // it can be scrolled. Two short flicks, ending 15px apart and 60ms apart —
+  // close enough in both to be a double tap if the guard failed to notice that
+  // the finger travelled. A cancelled `touchend` there would not stop the
+  // scroll, but it WOULD fire a click into the manual that the child never made.
+  const g = guarded()
+  const sheet = new FakeNode()
+  g.press(100, 400, sheet)
+  g.drag(100, 380, sheet)
+  g.drag(100, 340, sheet)
+  assert.equal(g.lift(100, 340, sheet), false, "a drag is not a tap")
+  g.advance(60)
+  g.press(100, 340, sheet)
+  g.drag(100, 330, sheet)
+  g.drag(100, 325, sheet)
+  assert.equal(g.lift(100, 325, sheet), false, "and a second flick is not the second half of one")
+  await flush()
+  assert.equal(sheet.restored.length, 0, "and no click was invented on the way past")
+})
+
+test("a jitter inside the drag slop is still a tap", () => {
+  const g = guarded()
+  g.press(10, 10)
+  g.drag(18, 10)
+  assert.equal(g.lift(18, 10), false, "first of the chain")
+  g.advance(60)
+  assert.equal(g.tap(10, 10), true, "an 8px shake is a finger, not a swipe")
+  assert.ok(DRAG_SLOP_PX >= 8, "the slop the number above assumes")
+})
+
+test("a pinch is not a tap and clears the chain", () => {
+  const g = guarded()
+  assert.equal(g.tap(100, 100), false)
+  g.advance(40)
+  // Second finger down, then both up, one at a time.
+  g.press(100, 100, undefined, 1)
+  g.press(140, 100, undefined, 2)
+  assert.equal(g.lift(140, 100, undefined, 1), false, "a lift with a finger still down is not a tap")
+  assert.equal(g.lift(100, 100, undefined, 0), false, "and the finger left over is not one either")
+  g.advance(40)
+  assert.equal(g.tap(100, 100), false, "the pinch cleared the history behind it")
+})
+
+test("two fingers lifting in one touchend are not a tap", () => {
+  // The sequence that has no lift with a finger still down to catch it: iOS
+  // reports both fingers in one `touchend`, `touches` is empty, and the only
+  // thing that knows this was never a tap is the second `touchstart`.
+  const g = guarded()
+  assert.equal(g.tap(100, 100), false)
+  g.advance(40)
+  g.press(100, 100, undefined, 1)
+  g.press(140, 100, undefined, 2)
+  const event = touchEvent([{ clientX: 100, clientY: 100 }, { clientX: 140, clientY: 100 }], { remaining: 0 })
+  g.doc.emit("touchend", event)
+  assert.equal(event.prevented, false, "a pinch release is not the second half of a double tap")
+})
+
+test("a cancelled touch clears the chain", () => {
+  const g = guarded()
+  assert.equal(g.tap(10, 10), false)
+  g.advance(40)
+  g.doc.emit("touchcancel", touchEvent({ clientX: 10, clientY: 10 }))
+  assert.equal(g.tap(10, 10), false, "the system took the gesture, so nothing pairs with it")
+})
+
+test("a non-cancelable touchend is left alone and costs no click", async () => {
+  const g = guarded()
+  const node = new FakeNode()
+  g.tap(10, 10, node)
+  g.advance(40)
+  g.press(10, 10, node)
+  const event = touchEvent({ clientX: 10, clientY: 10, target: node }, { cancelable: false })
+  g.doc.emit("touchend", event)
+  await flush()
+  assert.equal(event.prevented, false)
+  assert.equal(node.restored.length, 0, "nothing was swallowed, so nothing is re-dispatched")
+})
+
+/* ------------------------------------------------------------ how it is wired */
+
+test("touchend is non-passive and in the capture phase", () => {
+  // A device-only failure: a passive `touchend` makes `preventDefault()` a
+  // silent no-op and the zoom comes straight back, with every behavioural test
+  // above still green. And a bubble-phase listener never sees a tap on a game
+  // that calls `stopPropagation()` on its own `touchend`, which several do.
+  const doc = new FakeDocument()
+  installTapZoomGuard(doc)
+  const wiring = new Map(doc.bound.map((b) => [b.type, b.options] as const))
+
+  assert.deepEqual(wiring.get("touchend"), { capture: true, passive: false })
+  assert.deepEqual(wiring.get("touchstart"), { capture: true, passive: true })
+  assert.deepEqual(wiring.get("touchmove"), { capture: true, passive: true })
+  assert.deepEqual(wiring.get("touchcancel"), { capture: true, passive: true })
+  for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+    assert.deepEqual(wiring.get(type), { capture: true, passive: false }, `${type} must be cancellable`)
+  }
+  assert.equal(wiring.size, 7, "four touch events and three gesture events, and nothing silently dropped")
+})
+
+test("installing twice binds one guard, not two", async () => {
+  const doc = new FakeDocument()
+  const node = new FakeNode()
+  installTapZoomGuard(doc, { now: () => 0 })
+  installTapZoomGuard(doc, { now: () => 0 })
+  const bound = doc.bound.length
+
+  doc.emit("touchstart", touchEvent({ clientX: 5, clientY: 5, target: node }, { remaining: 1 }))
+  doc.emit("touchend", touchEvent({ clientX: 5, clientY: 5, target: node }))
+  doc.emit("touchstart", touchEvent({ clientX: 5, clientY: 5, target: node }, { remaining: 1 }))
+  doc.emit("touchend", touchEvent({ clientX: 5, clientY: 5, target: node }))
+  await flush()
+
+  assert.equal(bound, 7, "seven listeners, once")
+  assert.equal(node.clicks.length, 1, "one re-dispatched click, not two")
+})
+
+test("the disposer unbinds, and a target can then be guarded again", () => {
+  const doc = new FakeDocument()
+  const dispose = installTapZoomGuard(doc, { now: () => 0 })
+  assert.equal(doc.bound.length, 7)
+  dispose()
+  assert.equal(doc.bound.length, 0)
+  installTapZoomGuard(doc, { now: () => 0 })
+  assert.equal(doc.bound.length, 7, "the target is no longer marked as guarded")
+})
+
+test("no document, and no MouseEvent, are both survivable", async () => {
+  assert.doesNotThrow(() => installTapZoomGuard(undefined)())
+  assert.doesNotThrow(() => installTapZoomGuard(null)())
+  assert.doesNotThrow(() => installTapZoomGuard({} as unknown as FakeDocument)())
+
+  const saved = (globalThis as { MouseEvent?: unknown }).MouseEvent
+  delete (globalThis as { MouseEvent?: unknown }).MouseEvent
+  try {
+    const g = guarded()
+    const node = new FakeNode()
+    g.tap(1, 1, node)
+    g.advance(30)
+    assert.equal(g.tap(1, 1, node), true, "the zoom is still cancelled")
+    await flush()
+    assert.equal(node.restored.length, 0, "and nothing threw inside a touch handler")
+  } finally {
+    ;(globalThis as { MouseEvent?: unknown }).MouseEvent = saved
+  }
+})
+
+/* ------------------------------------------------------ the machine on its own */
+
+test("the state machine reads a lift with fingers still down as no tap at all", () => {
+  const guard = new TapZoomGuard()
+  guard.start(0, 0, 1)
+  assert.equal(guard.end(0, 0, 0, 0), false)
+  guard.start(0, 0, 1)
+  assert.equal(guard.end(10, 0, 0, 1), false, "a finger is still down: not a completed tap")
+  guard.start(0, 0, 1)
+  assert.equal(guard.end(20, 0, 0, 0), false, "and the chain behind it was cleared")
+})

--- a/dynawalla/packs/sdk/src/tapzoom.test.ts
+++ b/dynawalla/packs/sdk/src/tapzoom.test.ts
@@ -41,14 +41,33 @@ class FakeMouseEvent extends Event {
  * click the guard had to put back. Its own class, so the two are told apart by
  * which code path built them rather than by a flag a test could set wrongly.
  */
-class NativeClickEvent extends FakeMouseEvent {}
+class NativeClickEvent extends FakeMouseEvent {
+  constructor(type: string, init: { clientX?: number; clientY?: number; bubbles?: boolean } = {}) {
+    super(type, init)
+    // The guard tells the platform's clicks from its own by exactly this, so
+    // the fake has to carry it. A constructed `Event` is never trusted.
+    Object.defineProperty(this, "isTrusted", { value: true })
+  }
+}
 
 /** A node a touch can land on, and a click can be delivered to. */
 class FakeNode extends EventTarget {
   readonly clicks: FakeMouseEvent[] = []
-  constructor() {
+  readonly doc: FakeDocument | undefined
+  constructor(doc?: FakeDocument) {
     super()
+    this.doc = doc
     this.addEventListener("click", (event) => this.clicks.push(event as FakeMouseEvent))
+  }
+  /**
+   * Every click here bubbles, and the guard is listening at the document — its
+   * OWN re-dispatch included, which is the case that matters: a watcher that
+   * counted its own work would starve the next tap in a chain.
+   */
+  override dispatchEvent(event: Event): boolean {
+    const result = super.dispatchEvent(event)
+    this.doc?.emit(event.type, event)
+    return result
   }
   /** Clicks the guard re-dispatched, as opposed to the ones the platform fired. */
   get restored(): FakeMouseEvent[] {
@@ -108,7 +127,7 @@ function touchEvent(
   return event
 }
 
-/** Let the queued microtask that carries the re-dispatched click run. */
+/** Let the task that carries the re-dispatched click run. */
 function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
@@ -116,6 +135,12 @@ function flush(): Promise<void> {
 type Guarded = {
   doc: FakeDocument
   advance: (ms: number) => void
+  /**
+   * Model an engine that raises the compatibility `click` even though the tap
+   * was cancelled — which is what the Touch Events spec actually permits, since
+   * it only promises suppression for a cancelled `touchstart`.
+   */
+  leaky: (on: boolean) => void
   press: (x: number, y: number, node?: FakeNode, downCount?: number) => void
   drag: (x: number, y: number, node?: FakeNode) => void
   /** Returns whether the lift's default action was cancelled. */
@@ -132,6 +157,7 @@ type Guarded = {
 function guarded(): Guarded {
   const doc = new FakeDocument()
   let clock = 1_000
+  let leaky = false
   installTapZoomGuard(doc, { now: () => clock })
 
   const press = (x: number, y: number, node?: FakeNode, downCount = 1): void => {
@@ -142,8 +168,9 @@ function guarded(): Guarded {
     doc.emit("touchend", event)
     // What a browser does next, and the whole reason the guard has to give a
     // click back: an uncancelled `touchend` is followed by the compatibility
-    // `click`, and a cancelled one is not.
-    if (!event.prevented && node) {
+    // `click`. A cancelled one is not — unless the engine does not honour that,
+    // which is what `leaky` is.
+    if ((!event.prevented || leaky) && node) {
       node.dispatchEvent(new NativeClickEvent("click", { clientX: x, clientY: y, bubbles: true }))
     }
     return event.prevented
@@ -154,6 +181,9 @@ function guarded(): Guarded {
     lift,
     advance: (ms) => {
       clock += ms
+    },
+    leaky: (on) => {
+      leaky = on
     },
     drag: (x, y, node) => {
       doc.emit("touchmove", touchEvent({ clientX: x, clientY: y, target: node }, { remaining: 1 }))
@@ -172,7 +202,7 @@ test("rapid deliberate tapping on one spot delivers every tap to the game", asyn
   // same pixel, 80ms apart — indistinguishable from a double tap by geometry,
   // and the child must lose none of them.
   const g = guarded()
-  const pedal = new FakeNode()
+  const pedal = new FakeNode(g.doc)
   const touchends: number[] = []
   g.doc.addEventListener("touchend", (() => touchends.push(1)) as (event: never) => void)
 
@@ -192,7 +222,7 @@ test("a rapid chain is one click per tap however each tap was handled", async ()
   // re-dispatched. Both branches are exercised here, and the count is the same
   // either way — which is the whole point.
   const g = guarded()
-  const node = new FakeNode()
+  const node = new FakeNode(g.doc)
 
   const first = g.tap(50, 50, node)
   g.advance(100)
@@ -215,6 +245,49 @@ test("a rapid chain is one click per tap however each tap was handled", async ()
   )
 })
 
+test("an engine that raises the click anyway does not double it", async () => {
+  // The Touch Events spec only promises that cancelling `touchstart` suppresses
+  // the compatibility mouse events. If an engine raises the `click` after a
+  // cancelled `touchend`, a naive re-dispatch gives the control TWO — a second
+  // answer submitted, a second revive spent. The guard counts instead of
+  // assuming, and keeps the platform's own, which is the one carrying user
+  // activation.
+  const g = guarded()
+  g.leaky(true)
+  const node = new FakeNode(g.doc)
+
+  g.tap(60, 60, node)
+  g.advance(90)
+  assert.equal(g.tap(60, 60, node), true, "still cancelled, so the page still cannot scale")
+  await flush()
+
+  assert.equal(node.clicks.length, 2, "two taps, two clicks — not three")
+  assert.equal(node.restored.length, 0, "and none of them invented")
+})
+
+test("the restored click waits a task, so a leaked platform click gets there first", async () => {
+  // Why a task and not a microtask. A browser dispatches the compatibility
+  // click in the same input turn as the `touchend`, but AFTER the microtask
+  // checkpoint that follows the `touchend` handlers — so a restore queued as a
+  // microtask would run first, see nothing, dispatch, and then be joined by the
+  // platform's own. Modelled by putting the leaked click in a microtask.
+  const g = guarded()
+  const node = new FakeNode(g.doc)
+  g.tap(70, 70, node)
+  g.advance(90)
+  g.press(70, 70, node)
+  const event = touchEvent({ clientX: 70, clientY: 70, target: node })
+  g.doc.emit("touchend", event)
+  assert.equal(event.prevented, true)
+  queueMicrotask(() => {
+    node.dispatchEvent(new NativeClickEvent("click", { clientX: 70, clientY: 70, bubbles: true }))
+  })
+  await flush()
+
+  assert.equal(node.clicks.length, 2, "two taps, two clicks")
+  assert.equal(node.restored.length, 0, "the platform's own was allowed to win the race")
+})
+
 test("the restored click lands after the touchend it belongs to", async () => {
   // Dispatched from inside the `touchend` handler it would arrive BEFORE the
   // game's own `touchend` listener — the guard installs in the capture phase,
@@ -222,7 +295,7 @@ test("the restored click lands after the touchend it belongs to", async () => {
   // `click` would see them inverted. MERGE IDLE's `TapGuard` is exactly such a
   // machine.
   const g = guarded()
-  const node = new FakeNode()
+  const node = new FakeNode(g.doc)
   const log: string[] = []
   g.doc.addEventListener("touchend", (() => log.push("touchend")) as (event: never) => void)
   node.addEventListener("click", () => log.push("click"))
@@ -239,8 +312,8 @@ test("a correction between two controls 20px apart reaches both controls", async
   // The objection that killed the host's guard in #678: two cells of a
   // segmented control, tapped in sequence, well inside the double-tap slop.
   const g = guarded()
-  const left = new FakeNode()
-  const right = new FakeNode()
+  const left = new FakeNode(g.doc)
+  const right = new FakeNode(g.doc)
 
   g.tap(100, 100, left)
   g.advance(120)
@@ -308,7 +381,7 @@ test("a finger-scroll of the manual sheet is never cancelled", async () => {
   // the finger travelled. A cancelled `touchend` there would not stop the
   // scroll, but it WOULD fire a click into the manual that the child never made.
   const g = guarded()
-  const sheet = new FakeNode()
+  const sheet = new FakeNode(g.doc)
   g.press(100, 400, sheet)
   g.drag(100, 380, sheet)
   g.drag(100, 340, sheet)
@@ -369,7 +442,7 @@ test("a cancelled touch clears the chain", () => {
 
 test("a non-cancelable touchend is left alone and costs no click", async () => {
   const g = guarded()
-  const node = new FakeNode()
+  const node = new FakeNode(g.doc)
   g.tap(10, 10, node)
   g.advance(40)
   g.press(10, 10, node)
@@ -395,15 +468,16 @@ test("touchend is non-passive and in the capture phase", () => {
   assert.deepEqual(wiring.get("touchstart"), { capture: true, passive: true })
   assert.deepEqual(wiring.get("touchmove"), { capture: true, passive: true })
   assert.deepEqual(wiring.get("touchcancel"), { capture: true, passive: true })
+  assert.deepEqual(wiring.get("click"), { capture: true, passive: true }, "the click watcher never interferes")
   for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
     assert.deepEqual(wiring.get(type), { capture: true, passive: false }, `${type} must be cancellable`)
   }
-  assert.equal(wiring.size, 7, "four touch events and three gesture events, and nothing silently dropped")
+  assert.equal(wiring.size, 8, "four touch events, a click watcher and three gesture events")
 })
 
 test("installing twice binds one guard, not two", async () => {
   const doc = new FakeDocument()
-  const node = new FakeNode()
+  const node = new FakeNode(doc)
   installTapZoomGuard(doc, { now: () => 0 })
   installTapZoomGuard(doc, { now: () => 0 })
   const bound = doc.bound.length
@@ -414,18 +488,18 @@ test("installing twice binds one guard, not two", async () => {
   doc.emit("touchend", touchEvent({ clientX: 5, clientY: 5, target: node }))
   await flush()
 
-  assert.equal(bound, 7, "seven listeners, once")
+  assert.equal(bound, 8, "eight listeners, once")
   assert.equal(node.clicks.length, 1, "one re-dispatched click, not two")
 })
 
 test("the disposer unbinds, and a target can then be guarded again", () => {
   const doc = new FakeDocument()
   const dispose = installTapZoomGuard(doc, { now: () => 0 })
-  assert.equal(doc.bound.length, 7)
+  assert.equal(doc.bound.length, 8)
   dispose()
   assert.equal(doc.bound.length, 0)
   installTapZoomGuard(doc, { now: () => 0 })
-  assert.equal(doc.bound.length, 7, "the target is no longer marked as guarded")
+  assert.equal(doc.bound.length, 8, "the target is no longer marked as guarded")
 })
 
 test("no document, and no MouseEvent, are both survivable", async () => {
@@ -437,7 +511,7 @@ test("no document, and no MouseEvent, are both survivable", async () => {
   delete (globalThis as { MouseEvent?: unknown }).MouseEvent
   try {
     const g = guarded()
-    const node = new FakeNode()
+    const node = new FakeNode(g.doc)
     g.tap(1, 1, node)
     g.advance(30)
     assert.equal(g.tap(1, 1, node), true, "the zoom is still cancelled")

--- a/dynawalla/packs/sdk/src/tapzoom.ts
+++ b/dynawalla/packs/sdk/src/tapzoom.ts
@@ -56,10 +56,21 @@
 // A geometric test cannot separate those from a zoom: a child tapping the same
 // pedal twice in 120ms IS two taps close in time and space. So this does not
 // try. It cancels the tap's default action and then RE-DISPATCHES the `click`
-// the cancellation swallowed, at the same coordinates on the same target, one
-// microtask later so it still lands after the `touchend` it belongs to. The
+// the cancellation swallowed, at the same coordinates on the same target, in a
+// task of its own so it still lands after the `touchend` it belongs to. The
 // zoom is a default action of the touch and does not come back; the activation
 // is not a default action of the touch and does.
+//
+// A task rather than a microtask, and counted rather than assumed. That
+// cancelling `touchend` suppresses the compatibility `click` is engine
+// behaviour this repository cannot observe — the Touch Events spec only
+// promises it for `touchstart` — and an engine that fired the click anyway
+// would give a control TWO. So the guard watches for a trusted `click` and
+// re-dispatches only if none arrived: a microtask would run before the
+// compatibility click and see nothing, a task runs after it. Either way exactly
+// one click reaches the control, and where the platform's own survived, the
+// platform's own is the one that is kept — it is the one carrying user
+// activation.
 //
 // The accounting that follows from that: the FIRST tap of any chain is never
 // cancelled, and every later tap is cancelled and re-clicked. One `click` per
@@ -236,6 +247,8 @@ export function installTapZoomGuard(
   const now = options.now ?? Date.now
   const click = options.click ?? dispatchClick
   const guard = new TapZoomGuard()
+  /** Clicks the platform raised by itself. The re-dispatched ones are not trusted. */
+  let trustedClicks = 0
 
   const onStart = (event: GuardTouchEvent) => {
     const touch = first(event.changedTouches)
@@ -255,15 +268,23 @@ export function installTapZoomGuard(
     if (!guard.end(now(), touch.clientX, touch.clientY, count(event.touches))) return
     if (event.cancelable === false || typeof event.preventDefault !== "function") return
     event.preventDefault()
-    // After the `touchend` finishes dispatching, so the game sees its own
-    // listeners run in the order it wrote them and the click lands where the
-    // real one would have.
+    // After the whole input turn, so the game sees its own listeners run in the
+    // order it wrote them, and so a compatibility click the engine raised in
+    // spite of the cancellation has already been counted.
     const { clientX, clientY } = touch
     const node = touch.target
-    queueMicrotask(() => click(node, clientX, clientY))
+    const seen = trustedClicks
+    setTimeout(() => {
+      if (trustedClicks !== seen) return
+      click(node, clientX, clientY)
+    }, 0)
   }
 
   const onCancel = () => guard.cancel()
+
+  const onClick = (event: { isTrusted?: boolean }) => {
+    if (event.isTrusted !== false) trustedClicks += 1
+  }
 
   // Pinch is a different gesture and this is not the fix for it — it is here
   // because the invariant is "a pack never scales the page", and because
@@ -283,6 +304,10 @@ export function installTapZoomGuard(
     ["touchmove", onMove as (event: never) => void, { capture: true, passive: true }],
     ["touchend", onEnd as (event: never) => void, { capture: true, passive: false }],
     ["touchcancel", onCancel as (event: never) => void, { capture: true, passive: true }],
+    // Watching, never interfering: it cancels nothing and stops nothing, it
+    // only counts, so a control that legitimately receives a click still
+    // receives it.
+    ["click", onClick as (event: never) => void, { capture: true, passive: true }],
     ["gesturestart", onGesture as (event: never) => void, { capture: true, passive: false }],
     ["gesturechange", onGesture as (event: never) => void, { capture: true, passive: false }],
     ["gestureend", onGesture as (event: never) => void, { capture: true, passive: false }],

--- a/dynawalla/packs/sdk/src/tapzoom.ts
+++ b/dynawalla/packs/sdk/src/tapzoom.ts
@@ -1,0 +1,328 @@
+// A double tap inside a pack must never scale the page it is framed by.
+//
+// ── What actually happens on an iPhone ───────────────────────────────────────
+//
+// A pack runs in a sandboxed, opaque-origin iframe. An iframe has no viewport
+// and no page scale of its own: WebKit's double-tap-to-zoom recogniser lives on
+// the WKWebView and page scale is a property of the TOP-LEVEL document. So a
+// double tap on a game canvas scales the HOST. #677 removed the visible half of
+// that — while a pack is mounted the host document cannot scroll, so the
+// catalogue can no longer surface from behind a `fixed inset-0` stage — and
+// left the other half standing: the page still SCALES, and the game visibly
+// zooms under the child's finger mid-play.
+//
+// The host cannot fix that half. Touch events raised inside a cross-origin
+// iframe are dispatched in the child realm and never cross the boundary; the
+// host cannot see, let alone cancel, the tap that causes this. Prevention
+// belongs to the pack document, which is this file — one place, and not a
+// paragraph in twenty-seven games' entry files that a twenty-eighth will forget.
+//
+// ── Why the packs' own `touch-action: none` is not already enough ────────────
+//
+// Twenty-six of the twenty-seven shipping packs set `touch-action: none` on
+// `html, body` and most set it again on the canvas, and the zoom was still
+// reported from a device. So whatever `touch-action` does here, it does not
+// reach the gesture that scales the top-level page.
+//
+// The likely reason, and it is reasoning rather than an observation: WebKit
+// decides whether a tap may become a zoom in the UI process, against a
+// touch-action region the web process publishes for the MAIN FRAME's scrolling
+// tree. `touch-action` composes over an element's ancestors only up to its own
+// document's root — the chain stops at the frame boundary — so a region
+// computed inside an opaque-origin child has to be merged into the main frame's
+// to have any effect on a main-frame gesture, and evidently is not. Each pack's
+// `<meta name="viewport" content="user-scalable=no">` is dead for the same
+// reason: a subframe has no viewport for it to describe.
+//
+// `preventDefault()` on a touch event is a different mechanism, not a stronger
+// dose of the same one. It marks the touch sequence itself as handled, and that
+// verdict is what the UI process waits for before it lets a gesture recogniser
+// fire — which is why cancelling the second `touchend` was the way every
+// pre-`touch-action` library stopped double-tap zoom on iOS. Unverified on a
+// device: nobody in this repository has an iPhone in CI. What is proven below
+// is the state machine, the listener wiring and the click accounting, in Node.
+//
+// ── The part that would be easy to get wrong ─────────────────────────────────
+//
+// `preventDefault()` on `touchend` also cancels the compatibility `click` for
+// that tap. #678 deleted a guard from the HOST for exactly this: it ate the
+// second press of "Erase everything", a second `addProfile`, and a correction
+// between two cells of a segmented control 20px apart. Inside a pack the same
+// cost lands on RUNNER's revive lanes, MERGE IDLE's chips, STACK's answer
+// choices and game-chrome's help button — all bound to `click` — and on
+// FOUNDRY's pedals, COLOSSUS's strikes and STACK's commit, which are rapid by
+// design and must not lose a beat.
+//
+// A geometric test cannot separate those from a zoom: a child tapping the same
+// pedal twice in 120ms IS two taps close in time and space. So this does not
+// try. It cancels the tap's default action and then RE-DISPATCHES the `click`
+// the cancellation swallowed, at the same coordinates on the same target, one
+// microtask later so it still lands after the `touchend` it belongs to. The
+// zoom is a default action of the touch and does not come back; the activation
+// is not a default action of the touch and does.
+//
+// The accounting that follows from that: the FIRST tap of any chain is never
+// cancelled, and every later tap is cancelled and re-clicked. One `click` per
+// tap, always, whichever branch a tap took — which is the invariant the tests
+// assert, because it is the one a game depends on.
+//
+// What a re-dispatched `click` does NOT carry is user activation: it is
+// untrusted, so it cannot resume an `AudioContext` or enter fullscreen. That is
+// why the first tap is left alone rather than cancelled for symmetry — a pack
+// unlocks its audio on the first touch of a session, and that one is real.
+
+/** How long after a tap a second tap can still be read as a double tap. */
+export const DOUBLE_TAP_MS = 350
+
+/**
+ * How far apart two taps may be and still be one zoom gesture.
+ *
+ * Deliberately loose. WebKit's own slop is generous, an over-wide guard costs
+ * only a re-dispatched `click` — which the child cannot tell from the real one
+ * — and an under-wide one costs a zoom.
+ */
+export const DOUBLE_TAP_SLOP_PX = 30
+
+/**
+ * How far a finger may travel within one touch and still count as a tap.
+ *
+ * Past this the sequence is a drag: a swipe on a canvas, or the manual sheet
+ * being finger-scrolled. A drag is never cancelled and never becomes the first
+ * half of a pair.
+ */
+export const DRAG_SLOP_PX = 10
+
+/**
+ * The tap bookkeeping, with no DOM in it.
+ *
+ * Split out so the sequences that matter — a rapid chain on one spot, a pinch,
+ * a scroll, a tap after a long pause — can be driven exactly rather than
+ * approximated through a fake event object.
+ */
+export class TapZoomGuard {
+  /** A single-finger sequence that is still a candidate tap. */
+  private alive = false
+  private startX = 0
+  private startY = 0
+  /** The last completed single-finger tap, whatever happened to it. */
+  private last: { t: number; x: number; y: number } | null = null
+
+  /**
+   * A finger went down. `touchCount` is how many are down INCLUDING this one.
+   *
+   * A second finger is a pinch, not a tap: it ends the candidate and clears the
+   * history, because WebKit will not read a tap either side of a pinch as a
+   * double tap and neither should this.
+   */
+  start(x: number, y: number, touchCount: number): void {
+    if (touchCount !== 1) {
+      this.alive = false
+      this.last = null
+      return
+    }
+    this.alive = true
+    this.startX = x
+    this.startY = y
+  }
+
+  /** The finger moved. Past `DRAG_SLOP_PX` this sequence is no longer a tap. */
+  move(x: number, y: number): void {
+    if (!this.alive) return
+    if (distance(x, y, this.startX, this.startY) > DRAG_SLOP_PX) this.alive = false
+  }
+
+  /**
+   * A finger lifted. `remaining` is how many are still down.
+   *
+   * Returns true when this lift is the second-or-later tap of a zoom-shaped
+   * chain and its default action must be cancelled.
+   */
+  end(t: number, x: number, y: number, remaining: number): boolean {
+    const wasTap = this.alive && remaining === 0
+    this.alive = false
+    if (!wasTap) {
+      // A drag, or a finger lifting out of a pinch. Not a tap, so it is neither
+      // cancelled nor remembered — but it does not erase what came before it
+      // either: over-suppressing costs a re-dispatched click, under-suppressing
+      // costs a zoom.
+      if (remaining !== 0) this.last = null
+      return false
+    }
+    const previous = this.last
+    this.last = { t, x, y }
+    if (previous === null) return false
+    const elapsed = t - previous.t
+    if (elapsed < 0 || elapsed > DOUBLE_TAP_MS) return false
+    return distance(x, y, previous.x, previous.y) <= DOUBLE_TAP_SLOP_PX
+  }
+
+  /** The system took the gesture away. Nothing is pending and nothing is owed. */
+  cancel(): void {
+    this.alive = false
+    this.last = null
+  }
+}
+
+function distance(ax: number, ay: number, bx: number, by: number): number {
+  return Math.hypot(ax - bx, ay - by)
+}
+
+/* -------------------------------------------------------------------------- */
+
+/** One finger, as much of it as this module reads. */
+export type GuardTouch = {
+  readonly clientX: number
+  readonly clientY: number
+  readonly target?: unknown
+}
+
+/** A touch event, as much of it as this module reads. */
+export type GuardTouchEvent = {
+  readonly touches?: ArrayLike<GuardTouch>
+  readonly changedTouches?: ArrayLike<GuardTouch>
+  readonly cancelable?: boolean
+  preventDefault?: () => void
+}
+
+type ListenerOptions = { capture?: boolean; passive?: boolean }
+
+/**
+ * Just enough of an `EventTarget` to install on.
+ *
+ * The listener's parameter is `never` on purpose: every handler is assignable
+ * to it, so a real `Document` and a plain object in a Node test are both
+ * assignable to this type without dragging the DOM's event hierarchy into a
+ * module the tests have to drive with no DOM at all.
+ */
+export type TapGuardTarget = {
+  addEventListener(type: string, listener: (event: never) => void, options?: ListenerOptions): void
+  removeEventListener(type: string, listener: (event: never) => void, options?: ListenerOptions): void
+}
+
+export type TapGuardOptions = {
+  /** The clock. Injected so a test can place taps in time exactly. */
+  readonly now?: () => number
+  /**
+   * Dispatch the `click` that cancelling a tap swallowed.
+   *
+   * Defaults to a real `MouseEvent` on the touch's own target, and no-ops where
+   * there is no `MouseEvent` to construct — which is every Node test that does
+   * not shim one, and which must not throw inside a touch handler.
+   */
+  readonly click?: (target: unknown, x: number, y: number) => void
+}
+
+/** Targets already guarded, so a second `connect()` cannot double-install. */
+const installed = new WeakSet<object>()
+
+/**
+ * Stop a double tap in this pack from scaling the page, without costing a tap.
+ *
+ * Installed by `connect()`, so every pack has it and no pack has to remember
+ * it. Idempotent per target, and a no-op where there is no document — a pack's
+ * modules are imported by Node tests too.
+ *
+ * Returns a disposer. Nothing in a pack calls it: the guard's lifetime is the
+ * frame's, and the frame is torn down whole.
+ */
+export function installTapZoomGuard(
+  target: TapGuardTarget | null | undefined = defaultTarget(),
+  options: TapGuardOptions = {},
+): () => void {
+  if (!target || typeof target.addEventListener !== "function") return () => {}
+  if (installed.has(target)) return () => {}
+  installed.add(target)
+
+  const now = options.now ?? Date.now
+  const click = options.click ?? dispatchClick
+  const guard = new TapZoomGuard()
+
+  const onStart = (event: GuardTouchEvent) => {
+    const touch = first(event.changedTouches)
+    if (!touch) return
+    guard.start(touch.clientX, touch.clientY, count(event.touches))
+  }
+
+  const onMove = (event: GuardTouchEvent) => {
+    const touch = first(event.changedTouches)
+    if (!touch) return
+    guard.move(touch.clientX, touch.clientY)
+  }
+
+  const onEnd = (event: GuardTouchEvent) => {
+    const touch = first(event.changedTouches)
+    if (!touch) return
+    if (!guard.end(now(), touch.clientX, touch.clientY, count(event.touches))) return
+    if (event.cancelable === false || typeof event.preventDefault !== "function") return
+    event.preventDefault()
+    // After the `touchend` finishes dispatching, so the game sees its own
+    // listeners run in the order it wrote them and the click lands where the
+    // real one would have.
+    const { clientX, clientY } = touch
+    const node = touch.target
+    queueMicrotask(() => click(node, clientX, clientY))
+  }
+
+  const onCancel = () => guard.cancel()
+
+  // Pinch is a different gesture and this is not the fix for it — it is here
+  // because the invariant is "a pack never scales the page", and because
+  // WebKit's `gesture*` events carry no click, so cancelling them costs
+  // nothing. Nobody should read these three lines as covering a double tap.
+  const onGesture = (event: GuardTouchEvent) => {
+    if (typeof event.preventDefault === "function") event.preventDefault()
+  }
+
+  // Capture, so a game that calls `stopPropagation()` on its own `touchend` —
+  // several do — cannot hide the tap from the guard. Passive everywhere the
+  // guard never cancels, so the manual sheet's `touch-action: pan-y` finger
+  // scroll and every canvas drag keep their fast path; `touchend` alone is
+  // non-passive, which is the one place `preventDefault()` has to be allowed.
+  const bind: [string, (event: never) => void, ListenerOptions][] = [
+    ["touchstart", onStart as (event: never) => void, { capture: true, passive: true }],
+    ["touchmove", onMove as (event: never) => void, { capture: true, passive: true }],
+    ["touchend", onEnd as (event: never) => void, { capture: true, passive: false }],
+    ["touchcancel", onCancel as (event: never) => void, { capture: true, passive: true }],
+    ["gesturestart", onGesture as (event: never) => void, { capture: true, passive: false }],
+    ["gesturechange", onGesture as (event: never) => void, { capture: true, passive: false }],
+    ["gestureend", onGesture as (event: never) => void, { capture: true, passive: false }],
+  ]
+  for (const [type, listener, listenerOptions] of bind) {
+    target.addEventListener(type, listener, listenerOptions)
+  }
+
+  return () => {
+    for (const [type, listener] of bind) target.removeEventListener(type, listener, { capture: true })
+    installed.delete(target)
+  }
+}
+
+function defaultTarget(): TapGuardTarget | undefined {
+  return (globalThis as { document?: TapGuardTarget }).document
+}
+
+function first(list: ArrayLike<GuardTouch> | undefined): GuardTouch | undefined {
+  if (!list || list.length === 0) return undefined
+  return list[0]
+}
+
+function count(list: ArrayLike<GuardTouch> | undefined): number {
+  return list ? list.length : 0
+}
+
+function dispatchClick(target: unknown, x: number, y: number): void {
+  const Ctor = (globalThis as { MouseEvent?: typeof MouseEvent }).MouseEvent
+  if (!Ctor) return
+  const node = target as { dispatchEvent?: (event: object) => boolean } | null
+  if (!node || typeof node.dispatchEvent !== "function") return
+  node.dispatchEvent(
+    new Ctor("click", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      detail: 1,
+      clientX: x,
+      clientY: y,
+    }),
+  )
+}


### PR DESCRIPTION
The founder, on iPhone: *"the double tap still bleeds through to the stage and
makes the zoom thing happen that shows the catalog behind the game."*

#677 removed the visible half — with `<html>` scroll locked while a pack is
mounted, the catalogue can no longer surface from behind a `fixed inset-0`
stage — and named the half it could not reach. This is that half: the page can
still SCALE, and the game zooms under the child's finger mid-play.

## Why the host cannot do it

Touch events raised inside a cross-origin iframe are dispatched in the child
realm and never cross the boundary. The host cannot see, let alone cancel, the
tap. So the guard is installed by `connect()`, which every pack passes through
on its way to a host — one place, no per-game change, and nothing a
twenty-eighth game can forget. Verified in a real pack bundle: COLOSSUS's
`build:pack` output contains it.

## Why the packs' own `touch-action: none` is not already enough

Twenty-six of the twenty-seven set it on `html, body` and most set it again on
the canvas, and the zoom was still reported from a device. So whatever
`touch-action` does here, it does not reach the gesture that scales the
top-level page.

The likely reason — **reasoning, not an observation**: WebKit decides whether a
tap may become a zoom in the UI process, against a touch-action region the web
process publishes for the MAIN FRAME's scrolling tree. `touch-action` composes
over an element's ancestors only up to its own document's root; the chain stops
at the frame boundary, so a region computed inside an opaque-origin child would
have to be merged into the main frame's to affect a main-frame gesture, and
evidently is not. Each pack's `<meta name="viewport" content="user-scalable=no">`
is dead for the same reason: a subframe has no viewport for it to describe.

`preventDefault()` is a different mechanism rather than a stronger dose of the
same one. It marks the touch sequence itself as handled, and that verdict is
what the UI process waits for before it lets a gesture recogniser fire — which
is why cancelling the second `touchend` was how every pre-`touch-action` library
stopped double-tap zoom on iOS.

## The part that would be easy to get wrong

`preventDefault()` on `touchend` also cancels the compatibility `click`. #678
deleted a guard from the HOST for exactly that: it ate the second press of
"Erase everything", a second `addProfile`, and a correction between two cells of
a segmented control 20px apart. Inside a pack the same cost lands on RUNNER's
revive lanes, MERGE IDLE's chips, STACK's answer choices and game-chrome's help
button — all bound to `click` — and on FOUNDRY's pedals, COLOSSUS's strikes and
STACK's commit, which are rapid by design and must not lose a beat.

No geometric test separates those from a zoom: a child tapping one pedal twice
in 120ms **is** two taps close in time and space. So this does not try. It
cancels the tap's default action and then **re-dispatches the `click` the
cancellation swallowed**, at the same coordinates on the same target, in a task
of its own so it still lands after the `touchend` it belongs to. The zoom is a
default action of the touch and does not come back; the activation is not a
default action of the touch and does.

**Counted, not assumed.** That cancelling a `touchend` suppresses the
compatibility `click` is engine behaviour nobody here can observe — the Touch
Events spec only promises it for `touchstart` — and an engine that raised the
click anyway would hand a control TWO: a second answer submitted, a second
revive spent, on Android, where this bug does not even occur. So a capture-phase
`click` listener that cancels nothing and stops nothing tallies **trusted**
clicks; the restore reads the tally when it cancels and re-dispatches only if it
has not moved. Exactly one click reaches the control either way, and where the
platform's own survived, the platform's own is kept — it is the one carrying
user activation. This is also why the restore is a task and not a microtask: a
browser raises the compatibility click in the same input turn but *after* the
microtask checkpoint, so a microtask restore would run first, see nothing,
dispatch, and then be joined by the platform's own.

The accounting that follows: the FIRST tap of any chain is never cancelled, and
every later tap is cancelled and re-clicked. **One `click` per tap, always,
whichever branch a tap took.** That is the headline test — eight presses on one
pixel 80ms apart produce eight clicks and eight `touchend`s — because it is the
invariant a game depends on.

The first tap is left real rather than cancelled for symmetry because a
re-dispatched click is untrusted and carries no user activation, and a pack
unlocks its `AudioContext` on the first touch of a session.

## What is deliberately not touched

- A sequence that travels more than 10px is a **drag**: never cancelled, and
  never half of a pair. `packs/shared/game-chrome` sets `touch-action: pan-y` on
  the manual body so it can be finger-scrolled, and that was a shipped bug once
  already. Two short flicks ending 15px and 60ms apart are covered by test.
- Pointer events are untouched, so drag-to-dismiss on the manual sheet is
  untouched.
- `touchstart`, `touchmove` and `touchcancel` are bound **passive**, so no drag
  loses its fast path. `touchend` alone is non-passive, and both facts are
  pinned by a test: a passive `touchend` makes `preventDefault()` a silent no-op
  on a device with every behavioural test still green.
- Everything binds in the **capture** phase, because several games call
  `stopPropagation()` on their own `touchend`.
- No CSS is injected and no `touch-action` is changed.

`gesturestart`/`gesturechange`/`gestureend` are cancelled too. They are WebKit's
own, they are two-finger, and they are pinch and **not** double tap — they are
here because the invariant is "a pack never scales the page", and nobody should
read them as covering the reported bug.

## Unverified

Nobody in this repository has an iPhone in CI. **That `preventDefault()` on a
`touchend` inside an opaque-origin subframe reaches WebKit's main-frame gesture
recogniser is reasoned from the platform and is not observed.** So is the
explanation above for why `touch-action` does not.

What IS proven, in Node: the state machine, the listener wiring, the ordering
and the click accounting — against real `EventTarget`s with a real dispatch, and
with the platform's own compatibility click modelled, so "the child got their
tap" is a listener firing rather than a spy on an intention.

## Every test was checked by deleting what it covers

Twenty-six mutations, every one caught. Five survived a draft and forced better
tests: a drag that is not detected, a two-finger release that arrives as one
`touchend`, a drag slop that a self-referential test slid along with, a click
dispatched inside the `touchend` instead of after it, and — only after the fake
DOM was taught that a click bubbles to the document — a click watcher that
counted its own re-dispatch and so starved the next tap in a chain.

```
M1  no preventDefault on the second tap
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      one platform click, and seven the guard put back
      0 !== 7
M2  no click put back
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      every tap must produce exactly one click
      1 !== 8
M3  touchend bound passive
  not ok - touchend is non-passive and in the capture phase
      Expected values to be strictly deep-equal:
      + actual - expected
M4  touchend bound in the bubble phase
  not ok - touchend is non-passive and in the capture phase
      Expected values to be strictly deep-equal:
      + actual - expected
M5  no time window
  not ok - two taps a second apart are both left alone
      past the window this is a new gesture, not a zoom
      true !== false
M6  no distance window
  not ok - two taps further apart than the slop are both left alone
      Expected values to be strictly equal:
      true !== false
M7  a drag is not detected
  not ok - a finger-scroll of the manual sheet is never cancelled
      and a second flick is not the second half of one
      true !== false
M8  a second finger is treated as a tap
  not ok - two fingers lifting in one touchend are not a tap
      a pinch release is not the second half of a double tap
      true !== false
M9  touchcancel does not clear the chain
  not ok - a cancelled touch clears the chain
      the system took the gesture, so nothing pairs with it
      true !== false
M10 connect() stops installing the guard
  not ok - connecting installs the tap guard on the pack document

M11 no idempotence
  not ok - installing twice binds one guard, not two
      eight listeners, once
      16 !== 8
M12 a lift with fingers still down keeps the chain
  not ok - the state machine reads a lift with fingers still down as no tap at all
      and the chain behind it was cleared
      true !== false
M13 the first tap of a chain is cancelled too
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      one platform click, and seven the guard put back
      8 !== 7
M14 a non-cancelable touchend is cancelled anyway
  not ok - a non-cancelable touchend is left alone and costs no click
      Expected values to be strictly equal:
      true !== false
M15 no MouseEvent guard
  not ok - no document, and no MouseEvent, are both survivable

M16 the drag slop swallows a jitter
  not ok - a jitter inside the drag slop is still a tap
      an 8px shake is a finger, not a swipe
      false !== true
M17 the disposer does not unbind
  not ok - the disposer unbinds, and a target can then be guarded again
      Expected values to be strictly equal:
      8 !== 0
M18 the guard is never bound at all
  not ok - connecting installs the tap guard on the pack document
      one platform click, and seven the guard put back
      0 !== 7
M19 the gesture handler does nothing
  not ok - gesture events are cancelled, and are pinch rather than double tap
      gesturestart must not scale the page
      false !== true
M21 the time window is narrowed to 40ms
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      one platform click, and seven the guard put back
      0 !== 7
M22 the distance window is narrowed to 4px
  not ok - a correction between two controls 20px apart reaches both controls
      20px apart is a zoom by shape and must be cancelled
      false !== true
M20 the click is dispatched inside the touchend instead of after it
  not ok - an engine that raises the click anyway does not double it
      two taps, two clicks — not three
      3 !== 2
M23 the restore is queued as a microtask, racing the platform
  not ok - the restored click waits a task, so a leaked platform click gets there first
      two taps, two clicks
      3 !== 2
M24 the restore ignores the click count
  not ok - an engine that raises the click anyway does not double it
      two taps, two clicks — not three
      3 !== 2
M25 the click watcher counts nothing
  not ok - an engine that raises the click anyway does not double it
      two taps, two clicks — not three
      3 !== 2
M26 the click watcher counts the guard's own re-dispatch too
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      every tap must produce exactly one click
      2 !== 8
```

88 tests, five consecutive clean runs. `npm run tsc` clean, `packs/shared/game-host`
(the SDK's other consumer) tests and typecheck clean, and COLOSSUS's pack bundle
builds with the guard in it.

Follow-up to #677 and #678.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
