### PR TITLE
COUNTERPOISE — the far right weight was always the answer, and the weights fritzed out on iOS

### DIFF
--- a/dynawalla/games/balance/src/adapter.ts
+++ b/dynawalla/games/balance/src/adapter.ts
@@ -10,9 +10,11 @@
 
 import type { Question } from "./contract.ts";
 import type { Frac } from "./frac.ts";
-import { frac, parseFrac, toNumber, isPositive } from "./frac.ts";
+import { frac, parseFrac, toKey, toNumber, isPositive } from "./frac.ts";
 import type { FixedItem, PuzzleSpec, Side } from "./puzzle.ts";
-import { PAN_PEG } from "./puzzle.ts";
+import { MOVEMENTS, PAN_PEG } from "./puzzle.ts";
+import { makeRng, seedFromString } from "./rng.ts";
+import type { Rng } from "./rng.ts";
 
 export type QuestionWithSpec = Question & { spec?: PuzzleSpec };
 
@@ -80,33 +82,156 @@ function tokenizeSide(sideText: string): Term[] {
   return out;
 }
 
-function rackFor(answer: Frac, distractors: readonly string[]): Frac[] {
+/** How many weights the rack offers. Nine, as it always did. */
+const RACK_SIZE = 9;
+
+/**
+ * The rack the child chooses from — and the one defect in this game that made
+ * arithmetic optional.
+ *
+ * The old version did three things, each of which on its own gives the answer
+ * away:
+ *
+ *   1. It threw away any distractor whose magnitude exceeded 30. Every real
+ *      mal-rule output for a two-digit sum is a two-digit number, so for
+ *      `57 + 40` the host's plausible wrong answers were all discarded.
+ *   2. It padded the remainder with 1, 2, 3, … from the bottom.
+ *   3. It sorted the result ascending.
+ *
+ * Together those produced, verbatim, what the founder played:
+ *
+ *     19 + 70  →  1 2 3 4 5 6 7 8 89
+ *     69 + 20  →  1 2 3 4 5 6 7 8 89
+ *     57 + 40  →  1 2 3 4 5 6 7 8 97
+ *
+ * The answer was the only two-digit weight on the rack and it was always the
+ * last one. A child does not need to add to win that; they need to notice which
+ * brass disc is bigger than the others, and then drag the far right one, every
+ * board, forever. Measured against the old code, a bot that drags the rightmost
+ * weight and nothing else scored 100%.
+ *
+ * So: every distractor the host sends is kept (they are mal-rule outputs — that
+ * is the whole point of them), the padding is drawn from the answer's own
+ * neighbourhood rather than from 1, and the order is shuffled.
+ *
+ * **And the answer's rank is drawn too.** Shuffling fixes where the disc sits
+ * on the rail; it does nothing about where the *number* sits once a child reads
+ * the nine of them in order. An earlier pass at this padded symmetrically and
+ * then forced at least two weights above and two below, which is a rule that
+ * puts the answer in the middle — measured, rank 3, 4 or 5 held it 81.5% of the
+ * time and "take the middle one" scored 32.6% against a 11.1% baseline. So the
+ * rank is chosen first, uniformly, and the two sides are filled to match it.
+ * There is one place that cannot be honoured and it is arithmetic rather than a
+ * leak: an answer of 1 has nothing that can go below it.
+ *
+ * Deterministic given the question id, so a board looks the same if it is
+ * rebuilt (a resize does that) and a test can pin it.
+ */
+function rackFor(answer: Frac, distractors: readonly string[], rng: Rng): Frac[] {
+  if (answer.d !== 1) return fractionRack(answer, distractors, rng);
+
   const negative = !isPositive(answer);
-  if (answer.d !== 1) {
-    return [
-      frac(1, 4),
-      frac(1, 3),
-      frac(1, 2),
-      frac(2, 3),
-      frac(3, 4),
-      frac(1),
-      frac(5, 4),
-      frac(3, 2),
-    ];
-  }
   const mag = Math.abs(answer.n);
-  const set = new Set<number>([mag]);
+
+  // The neighbourhood the padding is drawn from. A ±35% band, never narrower
+  // than ±4, keeps every weight the same size of number as the answer, so no
+  // single disc is conspicuous whatever order they end up in.
+  const spread = Math.max(4, Math.min(40, Math.round(mag * 0.35)));
+
+  // The host's own wrong answers, split by which side of the answer they fall.
+  // No magnitude filter: a distractor for `57 + 40` is 87 or 107, and dropping
+  // those was what left the answer standing alone in the first place.
+  const below = new Set<number>();
+  const above = new Set<number>();
   for (const d of distractors) {
+    if (below.size + above.size >= RACK_SIZE - 1) break;
     const f = parseFrac(d);
-    if (f && f.d === 1 && Math.abs(f.n) > 0 && Math.abs(f.n) <= 30) set.add(Math.abs(f.n));
+    if (!f || f.d !== 1) continue;
+    const v = Math.abs(f.n);
+    if (v <= 0 || v === mag || v > mag * 4 + 30) continue;
+    (v < mag ? below : above).add(v);
   }
-  let v = 1;
-  while (set.size < 9 && v <= 30) {
-    set.add(v);
-    v++;
-  }
-  const vals = [...set].sort((a, b) => a - b);
+
+  // How many weights read lighter than the answer — which is the answer's rank
+  // once a child sorts them in their head. Uniform over the whole rack, then
+  // clamped to what the distractors already committed to and to what the number
+  // line can supply.
+  const roomBelow = Math.max(below.size, Math.min(mag - 1, spread));
+  let nBelow = rng.int(0, RACK_SIZE - 1);
+  nBelow = Math.min(Math.max(nBelow, below.size), RACK_SIZE - 1 - above.size);
+  nBelow = Math.min(nBelow, roomBelow);
+
+  fillSide(below, nBelow, Math.max(1, mag - spread), mag - 1, -1, mag, rng);
+  fillSide(above, RACK_SIZE - 1 - nBelow, mag + 1, mag + spread, 1, mag, rng);
+
+  const vals = rng.shuffle([mag, ...below, ...above]);
   return vals.map((n) => frac(negative ? -n : n));
+}
+
+/**
+ * Fill one side of the answer to exactly `want` distinct values.
+ *
+ * Random draws inside the band first, then a deterministic walk outward if the
+ * band did not have enough distinct integers in it — the walk is what makes
+ * this total, and `above` is always satisfiable because there is no ceiling on
+ * the number line. `below` is capped by the caller at `mag - 1`, which is the
+ * most values that can exist under the answer at all.
+ */
+function fillSide(
+  into: Set<number>,
+  want: number,
+  lo: number,
+  hi: number,
+  outward: 1 | -1,
+  skip: number,
+  rng: Rng,
+): void {
+  if (hi < lo) return;
+  let guard = 0;
+  while (into.size < want && guard++ < 400) {
+    const v = rng.int(lo, hi);
+    if (v >= 1 && v !== skip) into.add(v);
+  }
+  let v = outward > 0 ? hi + 1 : lo - 1;
+  while (into.size < want && v >= 1 && guard++ < 2000) {
+    if (v !== skip) into.add(v);
+    v += outward;
+  }
+}
+
+/**
+ * The fractional rack. It used to be one frozen list in one frozen order, which
+ * did not always contain the answer — `5/6` was unreachable and the board was
+ * unsolvable. Now the answer is always on it, the family it belongs to fills
+ * the rest, and it is shuffled like every other rack.
+ */
+function fractionRack(answer: Frac, distractors: readonly string[], rng: Rng): Frac[] {
+  const seen = new Set<string>();
+  const out: Frac[] = [];
+  const push = (f: Frac): void => {
+    if (f.n === 0) return;
+    const k = toKey(f);
+    if (seen.has(k)) return;
+    seen.add(k);
+    out.push(f);
+  };
+  const sign = isPositive(answer) ? 1 : -1;
+  push(answer);
+  for (const d of distractors) {
+    if (out.length >= RACK_SIZE) break;
+    const f = parseFrac(d);
+    if (f && f.d !== 1) push(frac(sign * Math.abs(f.n), f.d));
+  }
+  // Siblings in the answer's own family, then the standard halves and quarters.
+  const den = answer.d;
+  for (let n = 1; out.length < RACK_SIZE && n <= den * 2 + 2; n++) {
+    push(frac(sign * n, den));
+  }
+  for (const f of [frac(1, 4), frac(1, 3), frac(1, 2), frac(2, 3), frac(3, 4), frac(1), frac(5, 4), frac(3, 2)]) {
+    if (out.length >= RACK_SIZE) break;
+    push(frac(sign * f.n, f.d));
+  }
+  return rng.shuffle(out);
 }
 
 /**
@@ -114,10 +239,14 @@ function rackFor(answer: Frac, distractors: readonly string[]): Frac[] {
  * returns a solvable spec, because the answer is taken from the contract and
  * the missing side is simply "whatever is left".
  */
-export function specFromQuestion(q: Question, index: number): PuzzleSpec {
+export function specFromQuestion(q: Question): PuzzleSpec {
   const withSpec = q as QuestionWithSpec;
   if (withSpec.spec) return withSpec.spec;
 
+  // Seeded from the question id, not from a counter: the same question rebuilds
+  // to the same board (a resize does that), and two questions never share a
+  // rack order just because they arrived in the same position in the run.
+  const rng = makeRng(seedFromString(q.id));
   const answer = parseFrac(q.answer) ?? frac(1);
   const eq = q.prompt.indexOf("=");
   const leftText = eq >= 0 ? q.prompt.slice(0, eq) : q.prompt;
@@ -142,20 +271,31 @@ export function specFromQuestion(q: Question, index: number): PuzzleSpec {
   const kind: PuzzleSpec["kind"] = l.crate || r.crate ? "declare" : "fill";
   const fillSide: Side = l.fill ?? r.fill ?? 1;
 
+  // The movement is the child's place on the *host's* ladder, not a count of
+  // how many boards have gone by. It used to be `Math.floor(index / 5)`: a
+  // hand-written staircase that advanced every five questions whether the
+  // mathematics got harder or not, so the plinth announced a new movement on a
+  // schedule and told the child nothing. `q.difficulty` is a 0..1 position on
+  // the host's whole ladder, which is exactly what the engraving means.
+  const movement = Math.max(
+    0,
+    Math.min(MOVEMENTS.length - 1, Math.floor((q.difficulty || 0) * MOVEMENTS.length)),
+  );
+
   return {
     id: q.id,
     kind,
     mode: "pans",
     fixed,
     answer,
-    rack: rackFor(answer, q.distractors),
+    rack: rackFor(answer, q.distractors, rng),
     fillSide: kind === "fill" ? fillSide : null,
     hangSlot: null,
     prompt: q.prompt,
     domain: q.domain,
     difficulty: q.difficulty,
-    movement: Math.floor(index / 5),
-    movementName: "",
+    movement,
+    movementName: MOVEMENTS[movement],
   };
 }
 

--- a/dynawalla/games/balance/src/balance.test.ts
+++ b/dynawalla/games/balance/src/balance.test.ts
@@ -261,7 +261,6 @@ test("a board can be built from a foreign question with no spec attached", () =>
       domain: "add-sub",
       difficulty: 0.2,
     },
-    0,
   );
   assert.equal(spec.kind, "fill");
   assert.equal(spec.fixed.length, 2);
@@ -277,7 +276,6 @@ test("a board can be built from a foreign question with no spec attached", () =>
       domain: "equations",
       difficulty: 0.5,
     },
-    1,
   );
   assert.equal(eq2.kind, "declare");
   assert.equal(eq2.fixed.filter((f) => f.kind === "crate").length, 3);
@@ -292,7 +290,6 @@ test("a board can be built from a foreign question with no spec attached", () =>
       domain: "fractions",
       difficulty: 0.6,
     },
-    2,
   );
   assert.ok(solveWithAnswer(fr));
 });

--- a/dynawalla/games/balance/src/contract.ts
+++ b/dynawalla/games/balance/src/contract.ts
@@ -11,8 +11,22 @@ export type Question = {
   difficulty: number; // 0..1
 };
 
+/**
+ * What the game asks for when it pulls a question. Every field is optional and
+ * a host that ignores all of them behaves exactly as it did before this type
+ * existed. Structurally identical to `DifficultyRequest` in
+ * `packs/shared/game-host`, which is what the real host implements.
+ */
+export type DifficultyRequest = {
+  readonly domain?: string;
+  /** 0..1 position on the host's whole ladder. */
+  readonly difficulty?: number;
+  /** A standing ceiling on the stream, same scale. */
+  readonly maxDifficulty?: number;
+};
+
 export type Host = {
-  next(): Question; // pull the next question
+  next(request?: DifficultyRequest): Question; // pull the next question
   report(r: {
     questionId: string;
     correct: boolean;
@@ -21,6 +35,11 @@ export type Host = {
   }): void;
   haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
   prefersReducedMotion(): boolean;
+  /**
+   * Optional host extension: put a floor under the stream that never falls
+   * again. Feature-detected, because a stub or an older host has no such thing.
+   */
+  raiseFloor?(difficulty: number): void;
 };
 
 export type Mounted = { unmount(): void };

--- a/dynawalla/games/balance/src/fairness.test.ts
+++ b/dynawalla/games/balance/src/fairness.test.ts
@@ -1,0 +1,528 @@
+// The three things a child found before anybody else did.
+//
+// COUNTERPOISE shipped with a rack that gave the answer away, a hardcoded seed
+// that replayed one run forever, and no idea who was playing. Each of those is
+// a bot in here: if the bot scores, the game does not need arithmetic.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import type { Question } from "./contract.ts";
+import { toKey } from "./frac.ts";
+import type { Frac } from "./frac.ts";
+import { specFromQuestion } from "./adapter.ts";
+import { PAN_PEG, netTorque, verdictFor, counts } from "./puzzle.ts";
+import { makeRng, freshSeed } from "./rng.ts";
+import { makeStubHost } from "./stubHost.ts";
+import { puzzleAt } from "./generate.ts";
+import { makePacing, afterBoard, request, onTheWire, FLOOR } from "./pacing.ts";
+import { toUnit } from "../../../packs/shared/game-host/index.ts";
+
+const RACK = 9;
+/** A bot picking blind out of a nine-weight rack. */
+const CHANCE = 1 / RACK;
+/** Comfortably above chance, comfortably below "it works". */
+const NO_BETTER_THAN_CHANCE = 0.2;
+
+/**
+ * Questions shaped like the ones the real host actually sends.
+ *
+ * Not the local ladder: the shipped pack never runs it. `pack.ts` mounts the
+ * shared game-host, which hands over a prompt, a canonical answer and whatever
+ * mal-rule wrong answers the curriculum produced, and `specFromQuestion` turns
+ * that into a board. That path is where the founder's `1 2 3 4 5 6 7 8 97` came
+ * from, so that is the path under test.
+ *
+ * A third of the questions carry no distractors at all, because `item.choices`
+ * is optional and a rack of `1..8 + 89` is what an empty one produced.
+ */
+function hostQuestions(count: number, seed = 0xc0ffee): Question[] {
+  const rng = makeRng(seed);
+  const out: Question[] = [];
+  for (let i = 0; i < count; i++) {
+    const a = rng.int(1, 60);
+    const b = rng.int(1, 60);
+    const sum = a + b;
+    // Real column-addition mal-rules: dropped the carry, carried twice, off by
+    // one, wrote the digits down side by side.
+    const mals = [sum - 10, sum + 10, sum - 1, a * 10 + b].filter((v) => v > 0 && v !== sum);
+    const ds = rng.chance(0.34) ? [] : rng.shuffle(mals).slice(0, rng.int(1, 3)).map(String);
+    out.push({
+      id: `q-${seed.toString(36)}-${i}`,
+      prompt: `${a} + ${b}`,
+      answer: String(sum),
+      distractors: ds,
+      domain: "add-sub",
+      difficulty: rng.next(),
+    });
+  }
+  return out;
+}
+
+function scoreBot(pick: (rack: readonly Frac[]) => Frac, qs: readonly Question[]): number {
+  let hits = 0;
+  for (const q of qs) {
+    const spec = specFromQuestion(q);
+    if (toKey(pick(spec.rack)) === toKey(spec.answer)) hits++;
+  }
+  return hits / qs.length;
+}
+
+const median = (xs: readonly number[]): number => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+};
+
+// -------------------------------------------------------------- the exploit
+
+test("the rightmost-weight bot cannot beat chance", () => {
+  // The founder's exact strategy, verbatim: "just drag the far right one".
+  // Against the shipped code this scored 1.00 on every board with a two-digit
+  // answer, because the rack was built by sorting a set whose only large member
+  // was the answer.
+  const qs = hostQuestions(600);
+  const score = scoreBot((rack) => rack[rack.length - 1], qs);
+  assert.ok(
+    score < NO_BETTER_THAN_CHANCE,
+    `the rightmost weight is the answer ${(score * 100).toFixed(1)}% of the time ` +
+      `(chance is ${(CHANCE * 100).toFixed(1)}%) — the game is solvable without arithmetic`,
+  );
+});
+
+test("nor can the biggest-weight, smallest-weight or odd-one-out bots", () => {
+  const qs = hostQuestions(600, 0xbeef);
+  const bots: [string, (r: readonly Frac[]) => Frac][] = [
+    ["leftmost", (r) => r[0]],
+    ["biggest", (r) => r.reduce((a, b) => (b.n > a.n ? b : a))],
+    ["smallest", (r) => r.reduce((a, b) => (b.n < a.n ? b : a))],
+    [
+      // Sort the nine discs by the number stamped on them and take the middle
+      // one. This is the bot that catches a rack padded symmetrically around
+      // the answer, which is what the first attempt at this fix produced.
+      "middle by value",
+      (r) => [...r].sort((a, b) => a.n - b.n)[Math.floor(r.length / 2)],
+    ],
+    [
+      // "Which one of these is not like the others" — the strategy a child finds
+      // about four seconds after "rightmost" stops working.
+      "odd one out",
+      (r) => {
+        const m = median(r.map((f) => f.n));
+        return r.reduce((a, b) => (Math.abs(b.n - m) > Math.abs(a.n - m) ? b : a));
+      },
+    ],
+  ];
+  for (const [name, pick] of bots) {
+    const score = scoreBot(pick, qs);
+    assert.ok(
+      score < NO_BETTER_THAN_CHANCE,
+      `the "${name}" bot scores ${(score * 100).toFixed(1)}% (chance is ${(CHANCE * 100).toFixed(1)}%)`,
+    );
+  }
+});
+
+test("the answer has no position on the rack", () => {
+  const qs = hostQuestions(900, 0xd15ea5e);
+  const atSlot = new Array<number>(RACK).fill(0);
+  let counted = 0;
+  for (const q of qs) {
+    const spec = specFromQuestion(q);
+    const i = spec.rack.findIndex((r) => toKey(r) === toKey(spec.answer));
+    assert.ok(i >= 0, `${q.prompt}: the answer is not on the rack at all`);
+    if (spec.rack.length !== RACK) continue;
+    atSlot[i]++;
+    counted++;
+  }
+  assert.ok(counted > 500, `expected real coverage, got ${counted}`);
+  for (let i = 0; i < RACK; i++) {
+    const share = atSlot[i] / counted;
+    assert.ok(
+      share > 0.04 && share < 0.2,
+      `slot ${i} holds the answer ${(share * 100).toFixed(1)}% of the time ` +
+        `(even would be ${(CHANCE * 100).toFixed(1)}%): ${atSlot.join(",")}`,
+    );
+  }
+});
+
+test("the weights are mixed, on both question paths", () => {
+  // Asked for by name: "we want the weights to be shuffled and variable …
+  // mixed, shuffled, randomized".
+  //
+  // It is worth being clear about what this does and does not buy, because
+  // once the answer's *rank* is uniform a sorted rail is no longer a leak on
+  // its own — every positional bot above still scores at chance against one.
+  // What a sorted rail does is collapse two cues into one: work out that the
+  // answer is the third smallest and you have also been told it is the third
+  // disc. And nine numerals laid out in order read as a number line, which is
+  // a different piece of furniture from a rack of brass.
+  const sorted = (xs: readonly number[]): boolean =>
+    xs.every((v, i) => i === 0 || v >= xs[i - 1]) ||
+    xs.every((v, i) => i === 0 || v <= xs[i - 1]);
+
+  let inOrder = 0;
+  const qs = hostQuestions(900, 0x5b1f);
+  for (const q of qs) if (sorted(specFromQuestion(q).rack.map((f) => f.n))) inOrder++;
+  assert.equal(inOrder, 0, `${inOrder} of ${qs.length} host racks are laid out in order`);
+
+  // And the local ladder, which the standalone shell plays.
+  let ladderInOrder = 0;
+  for (let i = 0; i < 250; i++) {
+    if (sorted(puzzleAt(i, 0xa11ce).rack.map((f) => f.n / f.d))) ladderInOrder++;
+  }
+  assert.ok(
+    ladderInOrder <= 2,
+    `${ladderInOrder} of 250 ladder racks are laid out in order`,
+  );
+});
+
+test("the answer never stands apart from the field it is hiding in", () => {
+  // The other half of the leak, and the half shuffling alone does not fix. In
+  // `1 2 3 4 5 6 7 8 97` the answer is legible from across the room wherever it
+  // sits, because there is a gap of 89 between it and the nearest other weight.
+  // A weight is only a real alternative if it is near enough to be mistaken for
+  // the answer — and the answer has to be bracketed, or "the outer one" works.
+  const qs = hostQuestions(400, 0x5a1ad);
+  for (const q of qs) {
+    const spec = specFromQuestion(q);
+    const answer = Math.abs(Number(q.answer));
+    const vals = spec.rack.map((f) => Math.abs(f.n));
+    const gap = Math.min(...vals.filter((v) => v !== answer).map((v) => Math.abs(v - answer)));
+    assert.ok(
+      gap <= Math.max(2, answer * 0.25),
+      `${q.prompt} = ${answer}: the nearest other weight is ${gap} away, so nothing on ` +
+        `the rack is a real alternative (rack ${spec.rack.map(toKey).join(" ")})`,
+    );
+  }
+});
+
+test("the answer has no rank either, once the weights are read in order", () => {
+  // Position on the rail is one leak; position in the *number order* is the
+  // other, and shuffling does nothing about it. An earlier pass at this padded
+  // symmetrically and then forced two weights above and two below, which reads
+  // as fair and is not: it puts the answer in the middle by construction, and
+  // "sort them in your head and take the fifth" scored 32.6% against a 11.1%
+  // baseline.
+  const qs = hostQuestions(1200, 0x4a4a4a);
+  const atRank = new Array<number>(RACK).fill(0);
+  let counted = 0;
+  for (const q of qs) {
+    const spec = specFromQuestion(q);
+    if (spec.rack.length !== RACK) continue;
+    const order = spec.rack.map((f) => Math.abs(f.n)).sort((a, b) => a - b);
+    atRank[order.indexOf(Math.abs(Number(q.answer)))]++;
+    counted++;
+  }
+  assert.ok(counted > 900, `expected real coverage, got ${counted}`);
+  for (let i = 0; i < RACK; i++) {
+    const share = atRank[i] / counted;
+    assert.ok(
+      share > 0.03 && share < 0.2,
+      `rank ${i} holds the answer ${(share * 100).toFixed(1)}% of the time ` +
+        `(even would be ${(CHANCE * 100).toFixed(1)}%): ${atRank.join(",")}`,
+    );
+  }
+});
+
+test("the founder's three boards, rebuilt", () => {
+  // Regression, spelled out. These are the exact prompts from the report and
+  // the exact rack the old code produced for them.
+  const played: [string, string][] = [
+    ["19 + 70", "89"],
+    ["69 + 20", "89"],
+    ["57 + 40", "97"],
+  ];
+  for (const [prompt, answer] of played) {
+    const spec = specFromQuestion({
+      id: `founder-${prompt}`,
+      prompt,
+      answer,
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0.3,
+    });
+    const rack = spec.rack.map(toKey);
+    assert.notDeepEqual(
+      rack,
+      ["1", "2", "3", "4", "5", "6", "7", "8", answer],
+      `${prompt} still builds the rack that was reported`,
+    );
+    assert.ok(rack.includes(answer), `${prompt}: the answer must still be reachable`);
+    // Not "the answer is not last" — with nine weights that is true 8 times in
+    // 9 by luck, and three boards cannot tell luck from a fix. The two tests
+    // above measure position over hundreds of boards. What this one adds is the
+    // thing a single board can show: the answer is no longer conspicuous.
+    const near = rack
+      .map(Number)
+      .filter((v) => v !== Number(answer) && Math.abs(v - Number(answer)) <= Number(answer) * 0.3);
+    assert.ok(
+      near.length >= 4,
+      `${prompt}: only ${near.length} weights are anywhere near ${answer} (rack ${rack.join(" ")})`,
+    );
+  }
+});
+
+test("a rebuilt board looks the same — a resize must not reshuffle the rack", () => {
+  const q: Question = {
+    id: "stable-1",
+    prompt: "24 + 13",
+    answer: "37",
+    distractors: ["27", "47"],
+    domain: "add-sub",
+    difficulty: 0.3,
+  };
+  assert.deepEqual(
+    specFromQuestion(q).rack.map(toKey),
+    specFromQuestion(q).rack.map(toKey),
+  );
+  const other = specFromQuestion({ ...q, id: "stable-2" }).rack.map(toKey);
+  assert.notDeepEqual(
+    specFromQuestion(q).rack.map(toKey),
+    other,
+    "two different questions share a rack order",
+  );
+});
+
+// ------------------------------------------------- what a wrong pick costs
+
+test("no wrong pick is free, now that every weight is near the answer", () => {
+  // The rack rewrite moved half of all wrong answers onto a path that recorded
+  // nothing. With padding drawn from `1, 2, 3, …` a too-light pick left a
+  // remainder the rack could still make, so the child went on placing and
+  // eventually overshot into `wrong()`. With padding drawn from the answer's
+  // own band, a too-light pick leaves a remainder smaller than the smallest
+  // disc — which is the `deadEnd` branch, written for a genuinely stuck child
+  // and free by design.
+  //
+  // Free would mean: four guesses, a gem, a ladder climb, and a floor raised
+  // under a child who was guessing. So both endings count now.
+  const qs = hostQuestions(400, 0x105e);
+  let ended = 0;
+  let free = 0;
+  let picks = 0;
+  for (const q of qs) {
+    const spec = specFromQuestion(q);
+    if (spec.kind !== "fill" || spec.fillSide === null) continue;
+    const start = Math.sign(netTorque(spec, [], null).n);
+    for (const weight of spec.rack) {
+      if (toKey(weight) === toKey(spec.answer)) continue;
+      picks++;
+      const placed = [{ id: "x", side: spec.fillSide, peg: PAN_PEG, value: weight }];
+      const v = verdictFor(spec, placed, null, start);
+      if (v === "continue") continue;
+      ended++;
+      if (!counts(v)) free++;
+    }
+  }
+  assert.ok(picks > 1000, `expected real coverage, got ${picks}`);
+  assert.ok(
+    ended / picks > 0.9,
+    `only ${((ended / picks) * 100).toFixed(1)}% of wrong picks end the attempt — ` +
+      `if most of them are 'continue' this test is not measuring anything`,
+  );
+  assert.equal(
+    free,
+    0,
+    `${free} of ${ended} wrong picks that ended a board were recorded as nothing`,
+  );
+  // And the right weight is still right.
+  for (const q of qs.slice(0, 40)) {
+    const spec = specFromQuestion(q);
+    if (spec.kind !== "fill" || spec.fillSide === null) continue;
+    const start = Math.sign(netTorque(spec, [], null).n);
+    const placed = [{ id: "x", side: spec.fillSide, peg: PAN_PEG, value: spec.answer }];
+    assert.equal(verdictFor(spec, placed, null, start), "solved", q.prompt);
+  }
+});
+
+test("the game records the dish tipping, not just the beam swinging past", () => {
+  // `spill()` lives in `Game`, which needs a canvas. The classifier either side
+  // of it is measured above; this is the one line that joins them.
+  const src = readFileSync(new URL("./game.ts", import.meta.url), "utf8");
+  const spill = /private spill\(\): void \{[\s\S]*?\n  \}/.exec(src);
+  assert.ok(spill, "game.ts no longer has a spill path");
+  assert.match(
+    spill[0],
+    /this\.errors\+\+/,
+    "a spill is not recorded against the child, so a guessed board still earns a gem",
+  );
+  assert.match(spill[0], /this\.report\(false\)/, "a spill is never reported to the host");
+});
+
+// ------------------------------------------------------------- the same run
+
+test("two sittings are not the same run", () => {
+  const opening = (host: ReturnType<typeof makeStubHost>): string => {
+    const out: string[] = [];
+    for (let i = 0; i < 10; i++) out.push(host.next().prompt);
+    return out.join(" | ");
+  };
+  const runs = Array.from({ length: 12 }, () => opening(makeStubHost()));
+  const distinct = new Set(runs);
+  assert.ok(
+    distinct.size >= 11,
+    `12 fresh sittings produced only ${distinct.size} distinct runs — a child ` +
+      `coming back gets the boards they already did:\n  ${[...distinct].join("\n  ")}`,
+  );
+
+  // And specifically not *the* run: the shipped default seed.
+  const legacy = opening(makeStubHost({ seed: 0x5eed1e }));
+  assert.ok(
+    runs.filter((r) => r === legacy).length <= 1,
+    "fresh sittings still replay the hardcoded 0x5eed1e run",
+  );
+});
+
+test("a seed still pins a run exactly, because that is what a seed is for", () => {
+  const run = (): string[] => {
+    const h = makeStubHost({ seed: 4242 });
+    return Array.from({ length: 8 }, () => h.next().prompt);
+  };
+  assert.deepEqual(run(), run());
+  assert.notDeepEqual(run(), Array.from({ length: 8 }, () => makeStubHost({ seed: 99 }).next().prompt));
+});
+
+test("freshSeed does not repeat", () => {
+  const seeds = new Set(Array.from({ length: 2000 }, () => freshSeed()));
+  assert.ok(seeds.size > 1900, `freshSeed collided ${2000 - seeds.size} times in 2000`);
+});
+
+// ---------------------------------------------------------------- the ramp
+
+test("a brand new child is asked for the very bottom of the ladder", () => {
+  const p = makePacing();
+  assert.equal(p.level, FLOOR);
+  const r = request(p);
+  assert.ok(r.difficulty <= 0.02, `opening request is ${r.difficulty}`);
+  assert.ok(r.maxDifficulty <= 0.15, `opening ceiling is ${r.maxDifficulty}`);
+});
+
+test("the opening board is small numbers, not two-digit column addition", () => {
+  // The founder's first three boards were 19+70, 69+20, 57+40.
+  for (const seed of [1, 7, 4242, 0x5eed1e, 99991]) {
+    const host = makeStubHost({ seed });
+    const q = host.next(request(makePacing()));
+    const numerals = (q.prompt.match(/\d+/g) ?? []).map(Number);
+    assert.ok(numerals.length > 0, `no numbers in "${q.prompt}"`);
+    assert.ok(
+      Math.max(...numerals) <= 10,
+      `seed ${seed}: the opening board is "${q.prompt}" — nothing on it may be above 10`,
+    );
+  }
+});
+
+test("a host that is asked for a rung serves that rung, not the next one along", () => {
+  // Without this the two tests below are vacuous: a host that ignores the
+  // request entirely and just counts up still starts at the bottom and still
+  // gets harder, so they would pass against the bug they exist to catch. A
+  // counter cannot go *back down*, and that is what is asserted.
+  const host = makeStubHost({ seed: 5 });
+  const hard = host.next({ difficulty: 0.9 });
+  const easy = host.next({ difficulty: 0.0 });
+  assert.ok(
+    easy.difficulty < hard.difficulty,
+    `asked for 0.0 straight after 0.9 and got something harder ` +
+      `(${easy.difficulty} vs ${hard.difficulty}) — the request is being ignored`,
+  );
+  const again = host.next({ difficulty: 0.9 });
+  assert.ok(again.difficulty > easy.difficulty, "and it cannot climb back");
+  // Two questions at the same rung are not the same question.
+  const a = makeStubHost({ seed: 5 });
+  const ids = new Set(Array.from({ length: 6 }, () => a.next({ difficulty: 0.3 }).id));
+  assert.equal(ids.size, 6, "the same rung served the same board six times");
+});
+
+test("the game asks the host for a rung — the wire is actually connected", () => {
+  // `Game` needs a canvas, a ResizeObserver and a rAF loop, none of which exist
+  // in Node, so the one line that joins the pacing to the host is checked where
+  // it is written. Everything either side of it is unit tested above.
+  const src = readFileSync(new URL("./game.ts", import.meta.url), "utf8");
+  const call = /this\.host\.next\(([^)]*)\)/.exec(src);
+  assert.ok(call, "game.ts no longer calls host.next at all");
+  assert.match(
+    call[1],
+    /request\(/,
+    `game.ts calls host.next(${call[1]}) — it must pass a difficulty request`,
+  );
+  assert.match(src, /this\.host\.raiseFloor\?\./, "the floor is never reported to the host");
+});
+
+test("every number this game puts on the wire survives the host's own reader", () => {
+  // Not a re-implementation: this is `toUnit` out of `packs/shared/game-host`,
+  // the function the shipped host actually reads a difficulty with. It serves
+  // two scales at once —
+  //
+  //     value < 1   →  a fraction of the ladder, used as is
+  //     value >= 1  →  a ladder index, (value − 1) / 9
+  //
+  // — so `toUnit(1)` is 0. This game speaks fractions, where 1 is the top, and
+  // `maxDifficulty` is a *standing* ceiling: one request carrying a literal 1
+  // pins the ceiling at 0 for the rest of the session and serves the easiest
+  // content in the product to the child who was doing best.
+  let p = makePacing();
+  for (let board = 0; board <= 60; board++) {
+    const r = request(p);
+    const askedFor = toUnit(r.difficulty);
+    const ceiling = toUnit(r.maxDifficulty);
+    assert.ok(
+      askedFor !== null && Math.abs(askedFor - r.difficulty) < 1e-9,
+      `board ${board}: asked for ${r.difficulty}, the host reads ${askedFor}`,
+    );
+    assert.ok(
+      ceiling !== null && ceiling >= askedFor,
+      `board ${board}: ceiling ${r.maxDifficulty} reads as ${ceiling}, below the ` +
+        `requested ${askedFor} — the stream is now pinned to the bottom`,
+    );
+    assert.ok(toUnit(onTheWire(p.floor))! >= 0, "the floor is unreadable");
+    p = afterBoard(p, 0);
+  }
+  // And the top of the ladder is still actually reachable.
+  assert.ok(toUnit(request(p).difficulty)! > 0.99, "the ladder cannot be finished");
+});
+
+test("the ladder climbs on clean solves and steps back down on wrong ones", () => {
+  const host = makeStubHost({ seed: 777 });
+  let p = makePacing();
+  const rungs: number[] = [];
+  for (let i = 0; i < 14; i++) {
+    host.next(request(p));
+    rungs.push(host.index);
+    p = afterBoard(p, 0);
+  }
+  assert.ok(
+    rungs[13] > rungs[0] + 6,
+    `fourteen clean boards moved the rung ${rungs[0]} → ${rungs[13]}: ${rungs.join(",")}`,
+  );
+  assert.ok(rungs.every((r, i) => i === 0 || r >= rungs[i - 1]), `it went backwards: ${rungs}`);
+
+  const high = p.level;
+  for (let i = 0; i < 4; i++) p = afterBoard(p, 2);
+  assert.ok(p.level < high, `four struggled boards did not ease the ladder: ${high} → ${p.level}`);
+  assert.ok(p.level >= p.floor, "it fell through its own floor");
+});
+
+test("a rung owned four boards running becomes a floor the host is told about", () => {
+  const host = makeStubHost({ seed: 31337 });
+  let p = makePacing();
+  for (let i = 0; i < 8; i++) {
+    host.next(request(p));
+    p = afterBoard(p, 0);
+    if (p.streak >= 4) host.raiseFloor?.(p.floor);
+  }
+  assert.ok(p.floor > 0, "eight clean boards raised no floor at all");
+  assert.ok(host.floor > 0, "the host was never told");
+  // Now fall apart completely. The floor holds.
+  for (let i = 0; i < 12; i++) p = afterBoard(p, 3);
+  assert.ok(p.level >= p.floor, `${p.level} fell below the floor ${p.floor}`);
+  assert.equal(p.floor, host.floor);
+});
+
+test("the ladder is bounded at both ends whatever it is fed", () => {
+  let p = makePacing();
+  for (let i = 0; i < 500; i++) p = afterBoard(p, 0);
+  assert.equal(p.level, 1);
+  assert.ok(request(p).maxDifficulty <= 1);
+  let q = makePacing();
+  for (let i = 0; i < 500; i++) q = afterBoard(q, 5);
+  assert.equal(q.level, FLOOR);
+});

--- a/dynawalla/games/balance/src/game.ts
+++ b/dynawalla/games/balance/src/game.ts
@@ -18,14 +18,16 @@ import {
   isBalanced,
   isPinned,
   minWeightsFor,
-  rackCanMake,
   remainingFor,
+  verdictFor,
+  counts,
 } from "./puzzle.ts";
 import {
   createInstructions,
   type Instructions,
 } from "../../../packs/shared/game-chrome/index.ts";
 import { specFromQuestion } from "./adapter.ts";
+import { makePacing, afterBoard, request, onTheWire, type Pacing } from "./pacing.ts";
 import { layoutForViewport, armDistance, beamPoint, rackSlot } from "./layout.ts";
 import type { Layout } from "./layout.ts";
 import {
@@ -78,7 +80,6 @@ export class Game {
   private bodies: Body[] = [];
   private declared: Frac | null = null;
   private startNetSign = 0;
-  private questionIndex = 0;
   private questionStart = 0;
   private errors = 0;
   private reported = false;
@@ -95,6 +96,9 @@ export class Game {
 
   solvedTotal = 0;
   gems = 0;
+  private pacing: Pacing = makePacing();
+  /** The deepest movement reached, so the plinth announces each one once. */
+  private peakMovement = -1;
 
   private drag: Body | null = null;
   private dragFromRack = -1;
@@ -247,9 +251,11 @@ export class Game {
   }
 
   private loadNext(first = false): void {
-    const q = this.host.next();
-    this.spec = specFromQuestion(q, this.questionIndex);
-    this.questionIndex++;
+    // Ask for a board this child can actually get onto. See `pacing.ts` — with
+    // no request at all the host chose from its whole ladder, and the opening
+    // board of a fresh install was two-digit column addition.
+    const q = this.host.next(request(this.pacing));
+    this.spec = specFromQuestion(q);
     this.declared = null;
     this.errors = 0;
     this.reported = false;
@@ -534,24 +540,25 @@ export class Game {
   private checkAfterPlacement(b: Body): void {
     if (this.phase === "solved") return;
     const placed = this.placed();
-    if (isBalanced(this.spec, placed, this.declared)) {
-      this.solve();
-      return;
+    switch (verdictFor(this.spec, placed, this.declared, this.startNetSign)) {
+      case "solved":
+        this.solve();
+        return;
+      case "overshot":
+        // Too far. The beam has already swung past level and hit its stop; the
+        // dish tips and hands the weight back.
+        this.wrong(b);
+        return;
+      case "deadEnd":
+        // What is left cannot be made from the rack. The dish tips and gives
+        // everything back — the presentation has not changed, and it is still
+        // the gentlest ending in the game. What changed is that it is now
+        // recorded; see `counts` in puzzle.ts for the measurement.
+        this.spill();
+        return;
+      case "continue":
+        return;
     }
-    const netNow = Math.sign(toNumber(this.net()));
-    const crossed = this.startNetSign !== 0 && netNow !== 0 && netNow !== this.startNetSign;
-    if (this.spec.kind === "hang" || crossed) {
-      // Too far. The beam has already swung past level and hit its stop; the
-      // dish tips and hands the weight back.
-      this.wrong(b);
-      return;
-    }
-    // Dead end: what is left cannot be made from the rack (1/3 placed when 1/2
-    // was wanted, and there is no 1/6). The child is not wrong, they are stuck,
-    // and being stuck with no way out is how a puzzle game loses a ten-year-old.
-    // The dish simply tips and gives everything back.
-    const left = remainingFor(this.spec, placed);
-    if (left && !rackCanMake(this.spec.rack, left)) this.spill();
   }
 
   /** Tip the dish: every weight the player put in comes back to the rack. */
@@ -566,6 +573,10 @@ export class Game {
       any = true;
     }
     if (!any) return;
+    if (counts("deadEnd")) {
+      this.errors++;
+      this.report(false);
+    }
     this.audio.chain(5);
     this.cam.addTrauma(0.14);
     this.host.haptic("medium");
@@ -721,9 +732,28 @@ export class Game {
   private advance(): void {
     this.solvedTotal++;
     if (this.errors === 0) this.gems++;
-    const prevMovement = this.spec.movement;
+    // The board is over, so the ladder moves before the next one is pulled.
+    const before = this.pacing;
+    this.pacing = afterBoard(before, this.errors);
+    if (this.pacing.floor > before.floor) {
+      // Feature-detected: the shared host has it, the stub has it, an older
+      // host does not and simply keeps serving what it is asked for. Through
+      // `onTheWire` like every other number this game sends — see `pacing.ts`
+      // for what a literal 1 does to a standing ceiling.
+      this.host.raiseFloor?.(onTheWire(this.pacing.floor));
+    }
     this.loadNext();
-    if (this.spec.movement !== prevMovement || this.solvedTotal === 1) {
+    // Once, on the way up, and never again.
+    //
+    // The test used to be `movement !== prevMovement`, which was safe only
+    // while the movement was `Math.floor(index / 5)` and could not go down.
+    // It is now the child's place on the host's ladder, which moves both ways
+    // — so a child hovering either side of a boundary would get the plinth and
+    // the fanfare every second or third board. A movement is an arrival, and
+    // you only arrive somewhere once.
+    const arrived = this.spec.movement > this.peakMovement;
+    if (arrived) this.peakMovement = this.spec.movement;
+    if (arrived || this.solvedTotal === 1) {
       this.banner = {
         text: this.spec.movementName,
         sub: `MOVEMENT ${ROMAN[Math.min(this.spec.movement, ROMAN.length - 1)]}`,

--- a/dynawalla/games/balance/src/generate.ts
+++ b/dynawalla/games/balance/src/generate.ts
@@ -14,22 +14,11 @@
 import type { Frac } from "./frac.ts";
 import { frac, toKey, toNumber, add, sub, mulInt, isZero, isPositive } from "./frac.ts";
 import type { FixedItem, PuzzleSpec, Side } from "./puzzle.ts";
-import { PAN_PEG } from "./puzzle.ts";
+import { MOVEMENTS, PAN_PEG } from "./puzzle.ts";
 import { makeRng } from "./rng.ts";
 import type { Rng } from "./rng.ts";
 
-export const MOVEMENTS: readonly string[] = [
-  "First Light",
-  "Both Dishes",
-  "The Sealed Crate",
-  "Identical Crates",
-  "The Arm",
-  "Crates Facing Crates",
-  "Lift",
-  "Halves and Quarters",
-  "The Long Arm",
-  "Sealed and Split",
-];
+export { MOVEMENTS } from "./puzzle.ts";
 export const PUZZLES_PER_MOVEMENT = 5;
 
 type Draft = {
@@ -111,8 +100,19 @@ function buildPrompt(
   return `${l} = ${r}`;
 }
 
-const INT_RACK = (hi: number): Frac[] =>
-  Array.from({ length: hi }, (_, i) => frac(i + 1));
+/**
+ * Every rack in this file is shuffled before it is handed over.
+ *
+ * A rack in ascending order is a rack whose answer has a *position*, and on a
+ * board where the answer is much larger or much smaller than everything else
+ * offered — which is most `declare` boards, where the mal-rules are `c − b` and
+ * `c + b` and the answer is the little `x` — that position is the same one
+ * every time. The child learns the position instead of the arithmetic. Nothing
+ * downstream depends on the order: the rack is addressed by `findIndex` on
+ * value everywhere it is used.
+ */
+const INT_RACK = (hi: number, rng: Rng): Frac[] =>
+  rng.shuffle(Array.from({ length: hi }, (_, i) => frac(i + 1)));
 
 /** Rack for a single-answer puzzle: the answer, real mal-rule outputs, and filler. */
 function answerRack(answer: Frac, mals: number[], rng: Rng, size = 9): Frac[] {
@@ -124,7 +124,7 @@ function answerRack(answer: Frac, mals: number[], rng: Rng, size = 9): Frac[] {
     const near = Math.max(1, a + rng.int(-5, 7));
     if (Number.isInteger(near)) set.add(near);
   }
-  return [...set].sort((x, y) => x - y).map((n) => frac(n));
+  return rng.shuffle([...set]).map((n) => frac(n));
 }
 
 // ---------------------------------------------------------------- generators
@@ -137,7 +137,7 @@ function genFillSimple(rng: Rng, hi: number): Draft {
     mode: "pans",
     fixed,
     answer: frac(target),
-    rack: INT_RACK(Math.max(9, Math.min(12, hi))),
+    rack: INT_RACK(Math.max(9, Math.min(12, hi)), rng),
     fillSide: 1,
     hangSlot: null,
     prompt: buildPrompt(fixed, "pans", 1, null),
@@ -160,7 +160,7 @@ function genFillBoth(rng: Rng, hi: number): Draft {
     mode: "pans",
     fixed,
     answer: frac(need),
-    rack: INT_RACK(12),
+    rack: INT_RACK(12, rng),
     fillSide,
     hangSlot: null,
     prompt: buildPrompt(fixed, "pans", fillSide, null),
@@ -303,7 +303,7 @@ function genBalloon(rng: Rng, hi: number): Draft {
     fixed,
     answer: frac(-x),
     // The rack holds balloons: every value lifts.
-    rack: Array.from({ length: 9 }, (_, i) => frac(-(i + 1))),
+    rack: rng.shuffle(Array.from({ length: 9 }, (_, i) => frac(-(i + 1)))),
     fillSide: heavy,
     hangSlot: null,
     prompt: buildPrompt(fixed, "pans", heavy, null),
@@ -338,7 +338,7 @@ function genFraction(rng: Rng): Draft {
     mode: "pans",
     fixed,
     answer,
-    rack: FRACTION_RACK,
+    rack: rng.shuffle(FRACTION_RACK),
     fillSide: 1,
     hangSlot: null,
     prompt: buildPrompt(fixed, "pans", 1, null),
@@ -363,7 +363,7 @@ function genDeclareFraction(rng: Rng): Draft {
     mode: "pans",
     fixed,
     answer: x,
-    rack: FRACTION_RACK.slice(),
+    rack: rng.shuffle(FRACTION_RACK),
     fillSide: null,
     hangSlot: null,
     prompt: buildPrompt(fixed, "pans", null, null),

--- a/dynawalla/games/balance/src/main.ts
+++ b/dynawalla/games/balance/src/main.ts
@@ -4,9 +4,14 @@
 
 import { mount } from "./game.ts";
 import { makeStubHost } from "./stubHost.ts";
+import { freshSeed } from "./rng.ts";
 
 const params = new URLSearchParams(location.search);
-const seed = Number(params.get("seed") ?? "") || 0x5eed1e;
+// A fresh run every sitting. `?seed=` pins one, which is what the playtest
+// harness and every bug report should use; the hardcoded `0x5eed1e` that used
+// to be here meant a child who came back got the same boards in the same order,
+// forever.
+const seed = Number(params.get("seed") ?? "") || freshSeed();
 const start = Number(params.get("start") ?? "") || 0;
 const reduced = params.get("reduced") === "1";
 

--- a/dynawalla/games/balance/src/pacing.ts
+++ b/dynawalla/games/balance/src/pacing.ts
@@ -1,0 +1,121 @@
+// What COUNTERPOISE asks the host for next.
+//
+// The game used to call `next()` with nothing in it, which meant the host chose
+// from its whole ladder with no idea who was playing. A child opening the game
+// for the first time was handed `19 + 70`, then `69 + 20`, then `57 + 40` —
+// two-digit column addition on board one, on an apparatus whose entire first
+// lesson is "the flat arm is the equals sign". The maths was in the way of the
+// idea.
+//
+// So this file holds one number: where on the host's 0..1 ladder the next board
+// should come from. It starts at the very bottom (the curriculum floor is
+// `0 + 1`), climbs while boards are being solved first try, and steps back down
+// when they are not.
+//
+// **There is no clock in here and there must never be one.** COUNTERPOISE is
+// one of the untimed games and that is deliberate: a child can stand and think
+// at a balance for as long as they like. Pacing here means *what is asked*,
+// never *how fast*. `errors` is the only input, and an error in this game is
+// not a buzzer — it is the beam swinging the way you made it swing.
+
+/** The bottom of the ladder. `0 + 1`, and a child can start there twice. */
+export const FLOOR = 0;
+
+/** Nothing above this is asked for. The host clamps anyway; be explicit. */
+export const CEILING = 1;
+
+/**
+ * How far above the request the host may still serve.
+ *
+ * `next({ maxDifficulty })` is a standing ceiling on the stream, and it is the
+ * part that actually stops the opening board being `19 + 70`: a request alone
+ * is answered from whatever is nearest in a pool of up to sixty-four questions,
+ * and "nearest" on a cold pool can be a long way off.
+ */
+export const HEADROOM = 0.12;
+
+/** Clean solves in a row before the ladder starts moving in bigger steps. */
+const WARMED_UP = 2;
+
+const STEP_FIRST = 0.02;
+const STEP_WARMED = 0.05;
+const STEP_DOWN = 0.035;
+
+/** Clean solves in a row that justify never going below here again. */
+export const FLOOR_AFTER = 4;
+
+export type Pacing = {
+  /** 0..1 on the host's whole ladder. */
+  readonly level: number;
+  /** Never falls. Raised by a run of clean solves. */
+  readonly floor: number;
+  /** Consecutive boards solved with no wrong weight at all. */
+  readonly streak: number;
+};
+
+export function makePacing(level = FLOOR): Pacing {
+  return { level: clamp(level), floor: FLOOR, streak: 0 };
+}
+
+const clamp = (v: number): number => (v < FLOOR ? FLOOR : v > CEILING ? CEILING : v);
+
+/**
+ * One board is over. `errors` is how many wrong weights the child hung on it
+ * before the beam went level — zero means they read the board and knew.
+ *
+ * Down is gentler than up on a warmed-up child and steeper than the first
+ * climb, which is the asymmetry that keeps a struggling child near the rung
+ * they can do instead of oscillating across it.
+ */
+export function afterBoard(p: Pacing, errors: number): Pacing {
+  if (errors > 0) {
+    const drop = STEP_DOWN * Math.min(3, errors);
+    return { level: Math.max(p.floor, clamp(p.level - drop)), floor: p.floor, streak: 0 };
+  }
+  const streak = p.streak + 1;
+  const step = streak >= WARMED_UP ? STEP_WARMED : STEP_FIRST;
+  const level = clamp(p.level + step);
+  // A rung reached by four clean boards in a row is a rung this child owns. The
+  // floor goes under it — one board below, so a wobble is still allowed — and
+  // never comes back down.
+  const floor =
+    streak >= FLOOR_AFTER ? Math.max(p.floor, clamp(level - STEP_WARMED * 2)) : p.floor;
+  return { level: Math.max(floor, level), floor, streak };
+}
+
+/**
+ * The largest number this game may put on the wire, and why it is not 1.
+ *
+ * `packs/shared/game-host` reads a difficulty through `toUnit`, which has to
+ * serve two scales that are both already in production:
+ *
+ *     value < 1   →  a fraction of the ladder, used as is
+ *     value >= 1  →  a ladder index, (value − 1) / 9
+ *
+ * so **`toUnit(1)` is 0** — the one ambiguous value, deliberately resolved
+ * downward because five of the six ladder games send `1` on their opening
+ * question. This game speaks the fraction scale, where 1 means the top, so
+ * sending a literal 1 asks for the bottom.
+ *
+ * That is not a rounding error, it is a trap door. `maxDifficulty` is a
+ * *standing* ceiling: a `maxDifficulty: 1` is stored as `ceiling = 0`, the
+ * target is then clamped to it, the prefetch pool is flushed, and every
+ * question from then on comes from the very bottom of the curriculum — for a
+ * child who had just answered nineteen boards in a row correctly, with no way
+ * back, because every later request carries the same 1.
+ *
+ * So nothing this file emits is ever exactly 1. The gap is far below one rung
+ * of anything (the host's own ladder is ten wide), so the top of the ladder is
+ * still reachable.
+ */
+export const MAX_ON_THE_WIRE = 0.999;
+
+/** Any 0..1 ladder position, made safe to hand to the host. */
+export function onTheWire(v: number): number {
+  return Math.min(MAX_ON_THE_WIRE, clamp(v));
+}
+
+/** The request `next()` is called with. */
+export function request(p: Pacing): { difficulty: number; maxDifficulty: number } {
+  return { difficulty: onTheWire(p.level), maxDifficulty: onTheWire(p.level + HEADROOM) };
+}

--- a/dynawalla/games/balance/src/puzzle.ts
+++ b/dynawalla/games/balance/src/puzzle.ts
@@ -52,6 +52,27 @@ export type PuzzleSpec = {
 
 export const PAN_PEG = 3; // pans always hang at the same distance, so peg cancels out
 
+/**
+ * The names engraved on the plinth as the apparatus changes.
+ *
+ * They live here rather than in `generate.ts` because both the local ladder and
+ * the real host need them, and `generate.ts` is the whole standalone question
+ * generator — importing it from the adapter would pull the entire local ladder
+ * into the shipped pack bundle to read ten strings.
+ */
+export const MOVEMENTS: readonly string[] = [
+  "First Light",
+  "Both Dishes",
+  "The Sealed Crate",
+  "Identical Crates",
+  "The Arm",
+  "Crates Facing Crates",
+  "Lift",
+  "Halves and Quarters",
+  "The Long Arm",
+  "Sealed and Split",
+];
+
 function lcm(a: number, b: number): number {
   let x = a;
   let y = b;
@@ -160,6 +181,66 @@ export function rackCanMake(rack: readonly Frac[], target: Frac): boolean {
     }
   }
   return ok[goal];
+}
+
+/**
+ * How an attempt ended, once a weight has landed.
+ *
+ * `continue` is the only one that is not an ending: more brass is still on its
+ * way to a solution.
+ */
+export type Verdict = "solved" | "overshot" | "deadEnd" | "continue";
+
+/**
+ * Read the board after a weight lands.
+ *
+ * Extracted from the game so it can be measured. The classification itself is
+ * unchanged; what changed is `counts` below.
+ */
+export function verdictFor(
+  spec: PuzzleSpec,
+  placed: readonly PlacedItem[],
+  declared: Frac | null,
+  startNetSign: number,
+): Verdict {
+  if (isBalanced(spec, placed, declared)) return "solved";
+  const net = Math.sign(toNumberSign(netTorque(spec, placed, declared)));
+  const crossed = startNetSign !== 0 && net !== 0 && net !== startNetSign;
+  if (spec.kind === "hang" || crossed) return "overshot";
+  const left = remainingFor(spec, placed);
+  if (left && !rackCanMake(spec.rack, left)) return "deadEnd";
+  return "continue";
+}
+
+/**
+ * Whether an ending is recorded against the child.
+ *
+ * **`deadEnd` used to be free, and that is now a lie.** The dish tipping and
+ * handing everything back was written for a genuine dead end: a third placed
+ * when a half was wanted and no sixth on the rack. Being stuck with no way out
+ * is how a puzzle game loses a ten-year-old, so it cost nothing.
+ *
+ * Then the rack stopped padding from `1, 2, 3, …`. Every weight is now within a
+ * band of the answer, so a pick that is merely *too light* leaves a remainder
+ * smaller than the smallest disc on the rail and lands here. Measured over two
+ * thousand host-shaped boards, 8131 of 16085 wrong picks reached `deadEnd` and
+ * 7954 reached `overshot` — so half of every wrong answer in the game would
+ * have been recorded as nothing at all: no error, no report, and a *gem* and a
+ * ladder-climb at the end of a board that took four guesses. The controller in
+ * `pacing.ts` reads errors, so that half would have pushed a floor under a
+ * child who was guessing.
+ *
+ * Too light and too heavy are the same mistake seen from two sides. Both count.
+ * Neither is announced any more loudly than it was: the beam still just swings
+ * the way you made it swing.
+ */
+export function counts(v: Verdict): boolean {
+  return v === "overshot" || v === "deadEnd";
+}
+
+/** `Math.sign` of a rational, without leaving the exact domain to get it. */
+function toNumberSign(f: Frac): number {
+  return f.n === 0 ? 0 : f.n < 0 ? -1 : 1;
 }
 
 /** What still has to go into the dish for the beam to level. */

--- a/dynawalla/games/balance/src/rng.ts
+++ b/dynawalla/games/balance/src/rng.ts
@@ -16,6 +16,33 @@ export type Rng = {
   chance(p: number): boolean;
 };
 
+/**
+ * A seed for *this* sitting.
+ *
+ * The standalone shell used to hardcode `0x5eed1e`, so every session — every
+ * time a child came back — replayed the same run in the same order. A seed is
+ * for reproducing a run on purpose (`?seed=`, and every test in this package
+ * passes one); it is not a default.
+ *
+ * `Date.now()` alone repeats across two tabs opened in the same millisecond, so
+ * it is mixed with a random draw.
+ */
+export function freshSeed(): number {
+  const t = Date.now() >>> 0;
+  const r = Math.floor(Math.random() * 0x100000000) >>> 0;
+  return ((t ^ Math.imul(r, 0x9e3779b1)) >>> 0) || 1;
+}
+
+/** A stable 32-bit seed for a string — a question id, usually. */
+export function seedFromString(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h || 1;
+}
+
 export function makeRng(seed: number): Rng {
   let a = seed >>> 0;
   const next = (): number => {

--- a/dynawalla/games/balance/src/sim.test.ts
+++ b/dynawalla/games/balance/src/sim.test.ts
@@ -1,0 +1,161 @@
+// "On iOS 0.3.0 the animation doesn't work — the weights just go nuts and fritz
+// out and drift off. The example weights when a problem comes up."
+//
+// The example weights are the `fixed` items: the statement of the problem,
+// dropped in from above by `loadNext` and then held on their seats by a spring.
+// The spring was integrated with a step the spring is not stable at. Nothing
+// about this is specific to iOS — iOS is simply where a frame first took longer
+// than 32 ms.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { frac } from "./frac.ts";
+import { makeBody, stepBody, launch, toss, MAX_BODY_DT } from "./sim.ts";
+import type { Body } from "./sim.ts";
+
+/** The largest dt the frame loop will ever hand the simulation. */
+const LOOP_CLAMP = 1 / 20;
+
+function seated(tx: number, ty: number): Body {
+  return makeBody({ value: frac(5), state: "seated", x: 0, y: 0, tx, ty, trot: 0 });
+}
+
+test("a seated weight springs home at every frame rate the loop can deliver", () => {
+  // 31 fps is the analytic stability limit of the seat spring (k = 1000,
+  // c = 46): 1000·dt² + 92·dt − 4 < 0 ⟹ dt < 0.0322 s. The loop clamps dt at
+  // 1/20 = 0.05, so every rate from 31 fps down to the clamp used to be
+  // exponential runaway. A thermal downclock to 30 fps was enough.
+  for (const fps of [120, 90, 60, 45, 40, 35, 30, 25, 20]) {
+    const dt = 1 / fps;
+    const b = seated(100, 100);
+    for (let i = 0; i < 600; i++) stepBody(b, dt);
+    assert.ok(
+      Number.isFinite(b.x) && Number.isFinite(b.y),
+      `at ${fps} fps a seated weight left the number line: x=${b.x} y=${b.y}`,
+    );
+    assert.ok(
+      Math.hypot(b.x - 100, b.y - 100) < 1,
+      `at ${fps} fps a seated weight settled at (${b.x.toExponential(2)}, ` +
+        `${b.y.toExponential(2)}) instead of its seat at (100, 100)`,
+    );
+  }
+});
+
+test("no step the frame loop can produce makes a weight drift off", () => {
+  // A sweep rather than a handful of rates: the loop's dt is whatever the
+  // device gives it, clamped, and there must be no hole anywhere under that.
+  let worst = 0;
+  let worstDt = 0;
+  for (let i = 0; i <= 200; i++) {
+    const dt = (1 / 144) + (LOOP_CLAMP - 1 / 144) * (i / 200);
+    const b = seated(-240, 380);
+    for (let k = 0; k < 400; k++) stepBody(b, dt);
+    const err = Math.hypot(b.x + 240, b.y - 380);
+    if (!(err <= worst)) {
+      worst = err;
+      worstDt = dt;
+    }
+  }
+  assert.ok(
+    worst < 1,
+    `the worst frame time in the loop's range (dt=${worstDt.toFixed(4)}, ` +
+      `${(1 / worstDt).toFixed(1)} fps) left the weight ${worst.toExponential(3)} px ` +
+      `from its seat`,
+  );
+});
+
+test("one stalled frame does not destroy the board", () => {
+  // What actually happens on a WebView resume: sixty good frames, one long one,
+  // then sixty more. Before substepping the single 50 ms frame put the pile at
+  // ~1e5 px and every frame after it made that worse, so the weights never came
+  // back — which is the "drift off" in the report.
+  const b = seated(200, 150);
+  for (let i = 0; i < 60; i++) stepBody(b, 1 / 60);
+  stepBody(b, LOOP_CLAMP);
+  for (let i = 0; i < 120; i++) stepBody(b, 1 / 60);
+  assert.ok(
+    Math.hypot(b.x - 200, b.y - 150) < 1,
+    `after one stalled frame the weight is at (${b.x.toExponential(2)}, ${b.y.toExponential(2)})`,
+  );
+});
+
+test("the moving dish still jostles the pile — the fix is not a freeze", () => {
+  // Substepping must not have turned the spring into a teleport: a seat that
+  // moves has to be chased, visibly, over several frames.
+  const b = seated(0, 0);
+  for (let i = 0; i < 30; i++) stepBody(b, 1 / 60);
+  b.tx = 120;
+  const trail: number[] = [];
+  for (let i = 0; i < 10; i++) {
+    stepBody(b, 1 / 60);
+    trail.push(b.x);
+  }
+  assert.ok(trail[0] > 0.5, "the weight did not start moving toward the new seat");
+  assert.ok(trail[0] < 110, `the weight teleported: ${trail[0]} of 120 in one frame`);
+  assert.ok(trail[9] > trail[0], "it stopped chasing the seat");
+  assert.ok(Math.abs(trail[9] - 120) < 12, `it never got there: ${trail[9]}`);
+});
+
+test("a body never carries a NaN forward", () => {
+  // A NaN is permanent and it draws as nothing, so a weight that is part of the
+  // statement of the problem silently vanishes. Both reachable divides:
+  const zeroDur = makeBody({ value: frac(3), x: 0, y: 0 });
+  launch(zeroDur, 50, 50, 0, 10);
+  for (let i = 0; i < 30; i++) stepBody(zeroDur, 1 / 60);
+  assert.ok(
+    Number.isFinite(zeroDur.x) && Number.isFinite(zeroDur.y),
+    `a zero-duration flight produced (${zeroDur.x}, ${zeroDur.y})`,
+  );
+
+  const zeroToss = makeBody({ value: frac(3), x: 10, y: 10 });
+  toss(zeroToss, 90, 90, 0);
+  // Asserted on the velocity, before a step: `settle` would otherwise mask this
+  // by cleaning up afterwards, and a test the guard alone can satisfy proves
+  // nothing about the divide that produced the Infinity.
+  assert.ok(
+    Number.isFinite(zeroToss.vx) && Number.isFinite(zeroToss.vy),
+    `a zero-duration toss set the velocity to (${zeroToss.vx}, ${zeroToss.vy})`,
+  );
+  for (let i = 0; i < 30; i++) stepBody(zeroToss, 1 / 60);
+  assert.ok(
+    Number.isFinite(zeroToss.x) && Number.isFinite(zeroToss.y),
+    `a zero-duration toss produced (${zeroToss.x}, ${zeroToss.y})`,
+  );
+
+  // And a body that has already been poisoned from outside — a seat measured on
+  // a zero-sized canvas — is put back rather than lost.
+  const poisoned = seated(64, 64);
+  poisoned.x = NaN;
+  poisoned.vy = Infinity;
+  stepBody(poisoned, 1 / 60);
+  assert.ok(Number.isFinite(poisoned.x), "a poisoned body stayed poisoned");
+  assert.equal(poisoned.x, 64);
+  assert.equal(poisoned.y, 64);
+});
+
+test("a nonsense dt is ignored rather than integrated", () => {
+  // The first frame after a resume can deliver a zero, a negative, or a NaN.
+  const b = seated(30, 30);
+  b.x = 10;
+  b.y = 10;
+  for (const dt of [0, -1 / 60, NaN, Infinity]) stepBody(b, dt);
+  assert.ok(Number.isFinite(b.x) && Number.isFinite(b.y), `(${b.x}, ${b.y})`);
+});
+
+test("the substep is inside the spring's stability limit, with margin", () => {
+  // The number this whole file is about. If somebody raises MAX_BODY_DT past
+  // 0.0322 the tests above go red, but this says why in one line.
+  const K = 1000;
+  const C = 46;
+  // The root of K·dt² + 2C·dt − 4 = 0, which is the condition documented on
+  // MAX_BODY_DT. An earlier version of this line solved K·dt² + C·dt − 4 and
+  // got 0.0443 — itself a divergent step, so the "one line that says why" said
+  // the wrong number while the assertion still passed.
+  const limit = (-C + Math.sqrt(C * C + 4 * K)) / K;
+  assert.ok(Math.abs(limit - 0.0322) < 0.0005, `the stability limit moved: ${limit}`);
+  assert.ok(
+    MAX_BODY_DT < limit / 2,
+    `MAX_BODY_DT ${MAX_BODY_DT} has no margin under the ${limit.toFixed(4)}s limit`,
+  );
+});

--- a/dynawalla/games/balance/src/sim.ts
+++ b/dynawalla/games/balance/src/sim.ts
@@ -235,7 +235,97 @@ export type BodyEvents = {
   onArriveRack?: (b: Body) => void;
 };
 
+/**
+ * The largest step the seat spring survives, and why this constant exists.
+ *
+ * A seated body is pulled home by a stiff spring integrated with semi-implicit
+ * Euler at k = 1000, c = 46. Writing the step as a matrix on (velocity, error):
+ *
+ *     [ 1 − c·dt         −k·dt      ]
+ *     [ dt·(1 − c·dt)   1 − k·dt²   ]
+ *
+ * its eigenvalues sit inside the unit circle only while
+ *
+ *     1000·dt² + 92·dt − 4 < 0     ⟹     dt < 0.0322 s
+ *
+ * — thirty-one frames a second. The frame loop clamped dt at 1/20 and handed
+ * 0.05 straight in, which is 1.55× past that limit, so **every value between
+ * 31 fps and the clamp is exponential runaway** rather than a spring. Measured
+ * on the unfixed integrator, 400 steps from a 141 px displacement:
+ *
+ *     dt = 1/60  →  x = 100      (home)
+ *     dt = 1/30  →  x = −2.10e21
+ *     dt = 1/20  →  x = −1.21e204
+ *
+ * That is the reported "the weights go nuts and fritz out and drift off": one
+ * stalled frame — a WebView resume, a GC pause, a thermal downclock to 30 fps —
+ * and the seated pile is at 1e21 px and never comes back, because nothing in
+ * the old code could pull it home again.
+ *
+ * The fix is not a tighter clamp on dt (that drops simulated time and still
+ * leaves 30 fps devices broken). It is substepping: whatever the frame took,
+ * the integrator only ever advances in slices this size, so the spring is
+ * unconditionally inside its stability region. 1/120 keeps a 3.9× margin.
+ */
+export const MAX_BODY_DT = 1 / 120;
+
+/**
+ * A ceiling on substeps so a pathological dt costs a bounded amount of work.
+ * Sixteen covers 0.133 s, well past the 1/20 the frame loop clamps to; beyond
+ * that the simulation runs slow rather than unstable, which is the right way
+ * round for a game a child is holding.
+ */
+const MAX_SUBSTEPS = 16;
+
+/**
+ * Advance one body. Substeps so the seat spring is stable at any frame rate.
+ *
+ * See `MAX_BODY_DT`. `stepBodyOnce` is the old body of this function, unchanged
+ * except that it is now only ever called with a step it is stable at.
+ */
 export function stepBody(b: Body, dt: number, ev: BodyEvents = {}): void {
+  if (!(dt > 0)) return;
+  let steps = Math.ceil(dt / MAX_BODY_DT);
+  if (!Number.isFinite(steps) || steps > MAX_SUBSTEPS) steps = MAX_SUBSTEPS;
+  const h = Math.min(MAX_BODY_DT, dt / steps);
+  for (let i = 0; i < steps; i++) stepBodyOnce(b, h, ev);
+  settle(b);
+}
+
+/**
+ * Last line of defence: a body whose numbers have stopped being numbers.
+ *
+ * A single NaN is permanent — every later frame propagates it — and it draws as
+ * nothing, so a weight that was part of the *statement of the problem* silently
+ * vanishes. Divides that can reach here at all: `t / b.dur` in the fly arc and
+ * the two `/ dur` in `toss` (both now floored), plus anything a caller writes
+ * into `tx`/`ty` from a layout measured on a zero-sized canvas. Rather than
+ * hunt every producer forever, a body that has left the number line is put back
+ * on its seat, at rest.
+ */
+function settle(b: Body): void {
+  if (
+    Number.isFinite(b.x) &&
+    Number.isFinite(b.y) &&
+    Number.isFinite(b.vx) &&
+    Number.isFinite(b.vy) &&
+    Number.isFinite(b.rot) &&
+    Number.isFinite(b.sq)
+  ) {
+    return;
+  }
+  b.x = Number.isFinite(b.tx) ? b.tx : 0;
+  b.y = Number.isFinite(b.ty) ? b.ty : 0;
+  b.vx = 0;
+  b.vy = 0;
+  b.rot = Number.isFinite(b.trot) ? b.trot : 0;
+  b.rotVel = 0;
+  b.sq = 0;
+  b.sqVel = 0;
+  if (b.state === "fly") b.state = "seated";
+}
+
+function stepBodyOnce(b: Body, dt: number, ev: BodyEvents): void {
   // squash-and-stretch spring, always running
   b.sqVel += -b.sq * 360 * dt;
   b.sqVel *= Math.exp(-11 * dt);
@@ -304,7 +394,9 @@ export function launch(
   b.fy = b.y;
   b.tx = toX;
   b.ty = toY;
-  b.dur = dur;
+  // `t / b.dur` is the arc parameter: a zero duration makes it 0/0 and the body
+  // is at NaN for the rest of the run.
+  b.dur = Math.max(1e-3, dur);
   b.arc = arc;
   b.t = 0;
   b.state = "fly";
@@ -319,10 +411,16 @@ export function toss(
   dur: number,
   gravity = 1750,
 ): void {
-  b.vx = (toX - b.x) / dur;
-  b.vy = (toY - b.y) / dur - 0.5 * gravity * dur;
+  const d = Math.max(1e-3, dur);
+  // Recorded even though the ballistic path does not read them: `settle` puts a
+  // body that has gone non-finite back on `tx`/`ty`, and without these it would
+  // put an ejecting weight back in the dish rather than on the rack rail.
+  b.tx = toX;
+  b.ty = toY;
+  b.vx = (toX - b.x) / d;
+  b.vy = (toY - b.y) / d - 0.5 * gravity * d;
   b.rotVel = (Math.random() < 0.5 ? -1 : 1) * (5 + Math.random() * 6);
   b.t = 0;
-  b.dur = dur;
+  b.dur = d;
   b.state = "eject";
 }

--- a/dynawalla/games/balance/src/stubHost.ts
+++ b/dynawalla/games/balance/src/stubHost.ts
@@ -1,10 +1,23 @@
 // The local stub Host. Seeded, exact, deterministic, and it attaches the full
 // board so the standalone build plays the real ladder. Delete when the shared
 // curriculum package lands; `specFromQuestion` already covers the fallback.
+//
+// Two things changed here after the game was played end to end.
+//
+// **The seed is no longer a constant.** It defaulted to `0x5eed1e`, so every
+// session — every time a child came back — replayed the identical run in the
+// identical order. A seed reproduces a run *on purpose*: `?seed=` in the shell
+// and every test in this package pass one. Nobody asked for the default.
+//
+// **It answers a difficulty request.** The rung used to be a counter that went
+// up by one per question no matter who was playing. It is now a position on the
+// same 0..1 ladder the real host speaks, so the standalone shell and the
+// shipped pack adapt the same way and the pacing has somewhere to be tested.
 
-import type { Host, Question } from "./contract.ts";
+import type { DifficultyRequest, Host, Question } from "./contract.ts";
 import { toKey } from "./frac.ts";
-import { puzzleAt, distractorsAt } from "./generate.ts";
+import { puzzleAt, distractorsAt, MOVEMENTS, PUZZLES_PER_MOVEMENT } from "./generate.ts";
+import { freshSeed } from "./rng.ts";
 import type { QuestionWithSpec } from "./adapter.ts";
 
 export type StubReport = {
@@ -16,8 +29,21 @@ export type StubReport = {
 
 export type StubHost = Host & {
   reports: StubReport[];
+  /** The rung the next question will be drawn from. */
   index: number;
+  /** The floor `raiseFloor` has pushed under the stream, 0..1. */
+  floor: number;
 };
+
+/** How many rungs the local ladder has. Difficulty 1 is the last one. */
+export const LADDER_RUNGS = MOVEMENTS.length * PUZZLES_PER_MOVEMENT;
+
+/** A 0..1 ladder position as a rung of the local ladder. */
+export function rungFor(difficulty: number): number {
+  if (!Number.isFinite(difficulty)) return 0;
+  const d = difficulty < 0 ? 0 : difficulty > 1 ? 1 : difficulty;
+  return Math.round(d * (LADDER_RUNGS - 1));
+}
 
 export function makeStubHost(opts?: {
   seed?: number;
@@ -25,31 +51,50 @@ export function makeStubHost(opts?: {
   reducedMotion?: boolean;
   onReport?: (r: StubReport) => void;
 }): StubHost {
-  const seed = opts?.seed ?? 0x5eed1e;
+  const seed = opts?.seed ?? freshSeed();
   let index = opts?.startIndex ?? 0;
+  let served = 0;
+  let floor = 0;
   const reports: StubReport[] = [];
+  // The rung says *which* board; the draw keeps two questions at the same rung
+  // from being the same question, which a difficulty that holds still would
+  // otherwise guarantee.
+  const drawSeed = (): number => (seed ^ Math.imul(served + 1, 0x85ebca6b)) >>> 0;
   const host: StubHost = {
     get index() {
       return index;
     },
+    get floor() {
+      return floor;
+    },
     reports,
-    next(): Question {
-      const spec = puzzleAt(index, seed);
+    next(request?: DifficultyRequest): Question {
+      const d = request?.difficulty;
+      const asked = typeof d === "number" && Number.isFinite(d);
+      if (asked) index = rungFor(Math.max(d as number, floor));
+      const s = drawSeed();
+      const spec = puzzleAt(index, s);
       const q: QuestionWithSpec = {
         id: spec.id,
         prompt: spec.prompt,
         answer: toKey(spec.answer),
-        distractors: distractorsAt(index, seed),
+        distractors: distractorsAt(index, s),
         domain: spec.domain,
         difficulty: spec.difficulty,
         spec,
       };
-      index++;
+      served++;
+      // With no request at all this is the counter it always was.
+      if (!asked) index++;
       return q;
     },
     report(r) {
       reports.push(r);
       opts?.onReport?.(r);
+    },
+    raiseFloor(difficulty: number) {
+      if (!Number.isFinite(difficulty)) return;
+      floor = Math.max(floor, Math.min(1, Math.max(0, difficulty)));
     },
     haptic() {
       // The real host routes to tauri-plugin-haptics. In a browser we try the


### PR DESCRIPTION
COUNTERPOISE was solvable without arithmetic. A bot that drags the rightmost disc every board and nothing else scored **97.2%**. It now scores **9.9%**, against an 11.1% baseline.

## What was wrong

**The rack gave the answer away.** `rackFor` in `src/adapter.ts` threw away every distractor above magnitude 30, padded from `1, 2, 3, …`, and sorted ascending. For any two-digit answer that produces, verbatim, what was played:

```
19 + 70  ->  1 2 3 4 5 6 7 8 89
69 + 20  ->  1 2 3 4 5 6 7 8 89
57 + 40  ->  1 2 3 4 5 6 7 8 97
```

One two-digit weight, always last. Not a question — a spot-the-odd-one-out.

**Every session was the same run.** `main.ts:9` and `stubHost.ts:28` both defaulted to `0x5eed1e`.

**The game never told the host who was playing.** `next()` took no argument, so a fresh install opened on two-digit column addition.

**The weights fritzed out on iOS.** The seat spring in `src/sim.ts` (k = 1000, c = 46) under semi-implicit Euler is stable only while `1000·dt² + 92·dt < 4` — dt < 0.0322 s, 31 fps. The frame loop clamped dt at 1/20 and fed 0.05 straight in.

## What changed

| | before | after |
|---|---|---|
| rightmost-weight bot | **97.2%** | 9.9% |
| biggest-weight bot | 97.3% | 0.0% |
| middle-by-value bot | 32.6%\* | 5.4% |
| answer's slot on the rail | slot 8, 88.5% of the time | 8–14% per slot |
| opening board | `19 + 70` | `3 = □` |
| `2 + 3` rack | `1 2 3 4 5 6 7 8 23` | `2 3 8 9 7 6 1 5 4` |
| seated weight at 30 fps, 400 steps | `x = -2.1e21` | home, ±1 px |

\* measured against the *first* attempt at this fix, which padded symmetrically and forced two weights either side — a rule that puts the answer in the middle by construction. Caught in self-review; the answer's rank among the nine numbers is now drawn uniformly, and there is a bot in the suite for that heuristic too.

- **Rack** — distractors kept whatever their size (they are mal-rule outputs), padding drawn from the answer's own ±35% band, rail shuffled, rank drawn uniformly.
- **Seed** — `freshSeed()` per sitting. `?seed=` still pins a run and every test passes one.
- **Difficulty** — drives the wire from #659: `next({ difficulty, maxDifficulty })` and `raiseFloor`, from the curriculum floor upward on clean solves. Nothing emitted is ever exactly `1` — `toUnit` reads `1` as a *ladder index* and returns 0, and `maxDifficulty` is a standing ceiling, so one such request would have pinned the strongest player in the product to the easiest content in it for the rest of the session. The test importing the real `toUnit` catches it.
- **Physics** — substep at 1/120 (3.9× margin under the stability limit), rather than clamping dt harder, which would drop simulated time and still leave 30 fps devices broken. Finite-guards on both reachable divides.
- **A wrong pick is no longer free** — a consequence of the rack change, found in review. With padding in the answer's band, a too-light weight leaves a remainder the rack cannot make: the `deadEnd` branch, written for a genuinely stuck child and deliberately uncounted. 8131 of 16085 wrong picks landed there, so half of every wrong answer would have been recorded as nothing, and a board guessed four times would still have earned a gem and raised the floor under a guessing child. Both endings count now. The presentation is unchanged — the dish tips and hands everything back.

**No timer was added.** This is one of the games the pacing audit called well-paced *because* it has no clock.

## Verification

68 tests, run 5×, plus `tsc`, `build` and `build:pack`. Every fix was deleted and the test confirmed red before it was put back — including three defects the deletion pass found in my own tests (one vacuous request test, one masked by a NaN guard, and the shuffle assertion that stopped being load-bearing once rank was uniform).

```
substepping removed  -> at 30 fps a seated weight settled at (-1.58e+31, -1.58e+31)
                        instead of its seat at (100, 100)
original rackFor     -> the rightmost weight is the answer 97.2% of the time
                        (chance is 11.1%) - the game is solvable without arithmetic
rank forced to 4     -> the "middle by value" bot scores 99.8% (chance is 11.1%)
hardcoded seed       -> 12 fresh sittings produced only 1 distinct runs
maxDifficulty = 1    -> board 19: ceiling 1 reads as 0, below the requested 0.92
                        - the stream is now pinned to the bottom
dead end free again  -> 1592 of 3196 wrong picks that ended a board were
                        recorded as nothing
```

## Needs a device

Nobody here can run iOS. The integrator divergence is arithmetic and is proven in Node at every frame time the loop can produce — that part needs no device. What is *reasoned* rather than proven is that iOS 0.3.0 is where the long frame came from; a WebView resume, a GC pause or a thermal downclock to 30 fps all reach it, and the 1/20 clamp guarantees 0.05 is reachable whenever a frame exceeds 50 ms. Worth one playthrough on hardware to confirm the weights now settle.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb