### PR TITLE
fix(dynawalla/game-chrome): the hold must not ask the context what the game wants

### DIFF
--- a/dynawalla/packs/shared/game-chrome/audioHold.test.ts
+++ b/dynawalla/packs/shared/game-chrome/audioHold.test.ts
@@ -231,6 +231,79 @@ test(
   },
 )
 
+/** A context whose two operations settle at different speeds, either way round. */
+function skewed(suspendTicks: number, resumeTicks: number) {
+  return class Skewed {
+    state: "running" | "suspended" | "closed" = "running"
+    async resume(): Promise<void> {
+      for (let i = 0; i < resumeTicks; i++) await Promise.resolve()
+      if (this.state !== "closed") this.state = "running"
+    }
+    async suspend(): Promise<void> {
+      for (let i = 0; i < suspendTicks; i++) await Promise.resolve()
+      if (this.state !== "closed") this.state = "suspended"
+    }
+    async close(): Promise<void> {
+      this.state = "closed"
+    }
+  }
+}
+
+/** Install a skewed constructor, run, put the world back. */
+async function withSkew(
+  Ctor: ReturnType<typeof skewed>,
+  fn: (ctx: { state: string }) => Promise<void>,
+): Promise<void> {
+  const g = globalThis as Globals
+  const prev = g.AudioContext
+  g.AudioContext = Ctor
+  installAudioHold()
+  try {
+    await fn(new (g.AudioContext as new () => { state: string })())
+  } finally {
+    g.AudioContext = prev
+    forgetAudioContexts()
+  }
+}
+
+test("a second read opened before the first read's resume lands is still silent", async () => {
+  // A child taps PLAY and taps "?" again in the same second, which they do
+  // constantly. A resume is slower than a suspend on a real device — it has to
+  // re-acquire the output — so the second read begins while the first read's
+  // resume is still in the air. Deciding what the game wants by looking at the
+  // context at that instant reads the not-yet-undone silence as "this game does
+  // not want sound", holds nothing, and the resume lands: the game plays for
+  // the whole of the second read.
+  await withSkew(skewed(1, 6), async (ctx) => {
+    holdAudio()
+    await settle()
+    assert.equal(ctx.state, "suspended")
+    releaseAudio()
+    holdAudio()
+    for (let i = 0; i < 4; i++) await settle()
+    assert.equal(ctx.state, "suspended", "the game played through the second read")
+    releaseAudio()
+    for (let i = 0; i < 4; i++) await settle()
+    assert.equal(ctx.state, "running", "and never came back")
+  })
+})
+
+test("a game pausing itself in the same frame the manual opens stays paused after it", async () => {
+  // The other direction. A suspend can be slower than a resume, and a game that
+  // pauses itself as the sheet goes up — its own pause screen, a phone call —
+  // is still "running" for a moment afterwards. Believing that reading switches
+  // a self-paused game back on when the manual closes.
+  await withSkew(skewed(6, 1), async (ctx) => {
+    const c = ctx as unknown as { suspend(): Promise<void> }
+    void c.suspend()
+    holdAudio()
+    for (let i = 0; i < 4; i++) await settle()
+    releaseAudio()
+    for (let i = 0; i < 4; i++) await settle()
+    assert.equal(ctx.state, "suspended", "closing the manual restarted a self-paused game")
+  })
+})
+
 test(
   "a context that existed BEFORE the wrap is not held — and that is the known limit",
   withAudio(async () => {

--- a/dynawalla/packs/shared/game-chrome/audioHold.ts
+++ b/dynawalla/packs/shared/game-chrome/audioHold.ts
@@ -182,8 +182,17 @@ export function holdAudio(): void {
   depth += 1
   if (depth > 1) return
   for (const rec of held) {
-    rec.wanted = rec.ctx.state === "running"
-    if (rec.wanted) run(rec, rec.nativeSuspend)
+    // `wanted` is NOT re-derived from `ctx.state` here. It is already the
+    // game's intent — the shims above maintain it on every call — and
+    // `ctx.state` is a racing observation: it does not settle until whatever is
+    // on the tail lands. Reading it got this wrong in both directions. A second
+    // read taken while the first read's own resume was still in flight saw
+    // "suspended", concluded the game did not want sound, suspended nothing and
+    // let the resume land — the game played through the whole second read. And
+    // a hold taken in the same frame as the game's own `suspend()` saw
+    // "running", concluded the game DID want sound, and switched a
+    // self-paused game back on when the manual closed.
+    if (rec.wanted || rec.ctx.state === "running") run(rec, rec.nativeSuspend)
   }
 }
 

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -26,10 +26,8 @@ export {
   type InstructionsSpec,
   type Section,
 } from "./instructions.ts"
-export {
-  installAudioHold,
-  holdAudio,
-  releaseAudio,
-  isAudioHeld,
-  forgetAudioContexts,
-} from "./audioHold.ts"
+// `forgetAudioContexts` is deliberately NOT re-exported. It drops the registry
+// and zeroes the depth, so a game that reached for it would silently defeat the
+// hold for the whole pack. It stays importable from `./audioHold.ts` by the
+// tests that need it and by nothing else.
+export { installAudioHold, holdAudio, releaseAudio, isAudioHeld } from "./audioHold.ts"

--- a/dynawalla/packs/shared/game-chrome/instructions.test.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.test.ts
@@ -662,15 +662,50 @@ test("a tap INSIDE the sheet does not dismiss it", () => {
   r.restore()
 })
 
-test("but the sheet's own pointers still get through — it must stay draggable", async () => {
-  // A swallow that ate the sheet's own gestures would take the drag dismissal,
-  // the PLAY button and tap-to-close with it.
+test("the sheet's own gestures are never stopped, or it could not be dragged or dismissed", () => {
+  // `stopPropagation` in capture stops an event reaching its own target's
+  // listeners as well, so stopping a sheet node would take the drag dismissal
+  // and the PLAY button with it.
+  //
+  // The rig reports `reachedGame` — "the event was not stopped" — and for a
+  // sheet node those are the same fact, which is the honest and uncomfortable
+  // shape of this: letting the sheet keep its own gestures means the game hears
+  // them too. Closing that would mean moving the drag and PLAY into this
+  // capture handler the way Escape and the background tap already are. It is
+  // survivable where the key swallow's equivalent is not, because a gesture on
+  // the sheet is a gesture on a 46rem panel the game cannot see under.
   const r = rig()
   r.ui.open()
   const grab = r.root.find("dwc-grab")
   const close = r.root.find("dwc-close")
   assert.equal(r.pointer("pointerdown", grab).reachedGame, true, "the grab handle was deafened")
   assert.equal(r.pointer("pointerup", close).reachedGame, true, "PLAY was deafened")
+  r.ui.destroy()
+  r.restore()
+})
+
+test("the rest of the dismissing tap does not land on the game either", () => {
+  // The background tap closes on `pointerdown`, so its `pointerup` and `click`
+  // arrive with the sheet already shut and every `guide.isOpen` guard already
+  // false. Most games act on release, which is exactly the edge this swallow
+  // exists for.
+  const r = rig()
+  r.ui.open()
+  const scrim = r.root.find("dwc-scrim")
+  const canvas = new El("canvas")
+  r.pointer("pointerdown", scrim)
+  assert.equal(r.ui.isOpen, false)
+  for (const t of ["pointermove", "pointerup", "mouseup", "click"]) r.pointer(t, canvas)
+  assert.deepEqual(
+    r.gameSawPointers,
+    [],
+    `the game was hit by ${r.gameSawPointers.join(",")} on the way out of the manual`,
+  )
+  // ...and the NEXT gesture is the child playing again. A gate stuck shut is
+  // the same bug as a gate stuck open.
+  r.pointer("pointerdown", canvas)
+  r.pointer("pointerup", canvas)
+  assert.deepEqual(r.gameSawPointers, ["pointerdown", "pointerup"], "the game was starved after one tap")
   r.ui.destroy()
   r.restore()
 })

--- a/dynawalla/packs/shared/game-chrome/instructions.ts
+++ b/dynawalla/packs/shared/game-chrome/instructions.ts
@@ -500,7 +500,38 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     "dblclick",
   ] as const
 
+  // A background tap dismisses on `pointerdown`, which hides the scrim
+  // synchronously — so the `pointerup`, `mouseup` and `click` of that SAME tap
+  // hit-test to the game, arrive with the sheet already closed, and fire it.
+  // That is the defect this swallow exists for, moved from the down edge to the
+  // up edge, and release is the more dangerous edge of the two.
+  //
+  // So the rest of the dismissing gesture is eaten. It clears on the next
+  // `pointerdown`, which is a new gesture and must never be starved.
+  const GESTURE_TAIL = new Set([
+    "pointermove",
+    "pointerup",
+    "pointercancel",
+    "mousemove",
+    "mouseup",
+    "touchmove",
+    "touchend",
+    "touchcancel",
+    "click",
+    "dblclick",
+  ])
+  let eatTail = false
+
   const swallowPointer = (e: Event): void => {
+    if (eatTail) {
+      if (e.type === "pointerdown" || e.type === "mousedown" || e.type === "touchstart") {
+        eatTail = false
+      } else if (GESTURE_TAIL.has(e.type)) {
+        e.stopPropagation()
+        if (e.type === "click" || e.type === "dblclick") eatTail = false
+        return
+      }
+    }
     // The tap that OPENS the manual is a tap on one of ours, so the rule below
     // would let it through to the game as well — and opening the rules cost a
     // move. The help control is handled in both directions: its gestures never
@@ -524,7 +555,10 @@ export function createInstructions(root: HTMLElement, spec: InstructionsSpec): I
     if (e.target === scrim) {
       if (!open) return
       e.stopPropagation()
-      if (e.type === "pointerdown") doClose()
+      if (e.type === "pointerdown") {
+        eatTail = true
+        doClose()
+      }
       return
     }
     if (ours.has(e.target)) return


### PR DESCRIPTION
Follow-up to #681, which merged through the queue while I was reviewing it. Three defects, all in `dynawalla/packs/shared/game-chrome/`. **No file under `dynawalla/games/` is edited.**

## 1. `holdAudio()` threw away the intent it already had (the real one)

`rec.wanted` **is** the game's intent — the `resume`/`suspend` shims maintain it on every call. `holdAudio()` was discarding it and re-deriving it from `ctx.state`, which is a *racing observation*: it does not settle until whatever is on the tail lands. `run()` serialises the operations; nothing serialised that read against them.

Wrong in both directions, and both are ordinary child behaviour:

- **The game plays through the second read.** A child taps PLAY and taps `?` again in the same second. A resume is slower than a suspend on a device — it has to re-acquire the output — so read #2 begins with read #1's resume still in the air. The state read saw the not-yet-undone silence, concluded the game did not want sound, held nothing, and the resume landed. That is precisely the reported defect, reintroduced by the fix for it.
- **A self-paused game is switched back on.** A game pausing itself in the same frame the sheet goes up is still `"running"` for a moment. The state read believed it, and closing the manual resumed it — falsifying the invariant `audioHold.ts` states in its own header.

Fixed by trusting `rec.wanted` and only falling back to `ctx.state` as an extra reason to silence, never as a reason to make noise.

## 2. The rest of the dismissing tap was still hitting the game

A background tap closes on `pointerdown`, which hides the scrim synchronously — so its `pointerup`, `mouseup` and `click` arrive with the sheet already shut and every `guide.isOpen` guard already `false`. That is the defect the swallow exists for, moved from the down edge to the up edge, and release is the more dangerous edge, as the swallow's own comment argues. The tail of that gesture is now eaten, and clears on the next `pointerdown` so the child's next move is never starved.

## 3. `forgetAudioContexts` was on the public surface

It drops the registry and zeroes the depth. A game reaching for it would silently defeat the hold for the whole pack. It stays importable from `./audioHold.ts` by the tests and by nothing else.

Also: the "sheet's own gestures" test now says what it actually asserts. For a sheet node, "not stopped" and "the game heard it" are the same fact — letting the sheet keep its own gestures means the game hears them too. The test states that residual hole instead of claiming a modality it does not prove. Closing it would mean moving the drag and PLAY into the capture handler the way Escape and the background tap already are.

## Proof

54 tests, suite run 5× clean, `tsc --noEmit` clean, all 27 game suites green.

Each fix verified by restoring the bug:

| restored | failure |
|---|---|
| `rec.wanted = rec.ctx.state === "running"` | `the game played through the second read` **and** `closing the manual restarted a self-paused game` |
| the gesture-tail swallow deleted | `the game was hit by pointermove,pointerup,mouseup,click on the way out of the manual` |
| `eatTail` never cleared | `the game was starved after one tap` |

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
