### PR TITLE
fix(dynawalla/packs/sdk): defend the leaked click at BOTH ends, and stop the drag failing open

### DIFF
--- a/dynawalla/packs/sdk/src/tapzoom.test.ts
+++ b/dynawalla/packs/sdk/src/tapzoom.test.ts
@@ -16,6 +16,7 @@ import {
   DOUBLE_TAP_MS,
   DOUBLE_TAP_SLOP_PX,
   DRAG_SLOP_PX,
+  LEAK_WINDOW_MS,
   TapZoomGuard,
   installTapZoomGuard,
 } from "./tapzoom.ts"
@@ -54,20 +55,37 @@ class NativeClickEvent extends FakeMouseEvent {
 class FakeNode extends EventTarget {
   readonly clicks: FakeMouseEvent[] = []
   readonly doc: FakeDocument | undefined
+  /** What `Element.isConnected` would say. Games replace their DOM constantly. */
+  connected = true
   constructor(doc?: FakeDocument) {
     super()
     this.doc = doc
     this.addEventListener("click", (event) => this.clicks.push(event as FakeMouseEvent))
   }
   /**
-   * Every click here bubbles, and the guard is listening at the document — its
-   * OWN re-dispatch included, which is the case that matters: a watcher that
-   * counted its own work would starve the next tap in a chain.
+   * The document sees it first and may stop it.
+   *
+   * The guard installs in the CAPTURE phase, which runs document-first, and it
+   * swallows a duplicate click by calling `stopImmediatePropagation()`. A fake
+   * that dispatched at the target first could never observe that, and the test
+   * for it would pass whether the guard swallowed or not.
    */
   override dispatchEvent(event: Event): boolean {
-    const result = super.dispatchEvent(event)
+    let stopped = false
+    const stop = event.stopImmediatePropagation.bind(event)
+    Object.defineProperty(event, "stopImmediatePropagation", {
+      configurable: true,
+      value: () => {
+        stopped = true
+        stop()
+      },
+    })
     this.doc?.emit(event.type, event)
-    return result
+    if (stopped) return !event.defaultPrevented
+    return super.dispatchEvent(event)
+  }
+  get isConnected(): boolean {
+    return this.connected
   }
   /** Clicks the guard re-dispatched, as opposed to the ones the platform fired. */
   get restored(): FakeMouseEvent[] {
@@ -263,6 +281,119 @@ test("an engine that raises the click anyway does not double it", async () => {
 
   assert.equal(node.clicks.length, 2, "two taps, two clicks — not three")
   assert.equal(node.restored.length, 0, "and none of them invented")
+})
+
+test("a platform click that leaks LATE, after the restore, is swallowed", async () => {
+  // The timing the first draft of this module did not defend. An engine that
+  // still runs a double-tap-to-zoom recogniser is the engine that may hold the
+  // compatibility click back to wait out the second tap — so the leak that
+  // matters arrives long after any `setTimeout(0)`, and a guard that only
+  // watched the early window would hand STACK's answer chip two `onChoose`
+  // calls from one tap.
+  const g = guarded()
+  const chip = new FakeNode(g.doc)
+  g.tap(90, 90, chip)
+  g.advance(90)
+  assert.equal(g.tap(90, 90, chip), true)
+  await flush()
+  assert.equal(chip.clicks.length, 2, "the restore has already been delivered")
+
+  // ...and now, 300ms later, the platform's own turns up anyway.
+  g.advance(300)
+  chip.dispatchEvent(new NativeClickEvent("click", { clientX: 90, clientY: 90, bubbles: true }))
+
+  assert.equal(chip.clicks.length, 2, "two taps, two clicks — the duplicate never reached the chip")
+})
+
+test("a leak after the window has closed is not swallowed", async () => {
+  // The swallow must expire, or a control that happens to sit where a tap was
+  // cancelled would go on losing clicks for the rest of the session.
+  const g = guarded()
+  const chip = new FakeNode(g.doc)
+  g.tap(90, 90, chip)
+  g.advance(90)
+  assert.equal(g.tap(90, 90, chip), true)
+  await flush()
+
+  g.advance(2_000)
+  chip.dispatchEvent(new NativeClickEvent("click", { clientX: 90, clientY: 90, bubbles: true }))
+  assert.equal(chip.clicks.length, 3, "a click this late belongs to somebody else")
+  assert.ok(LEAK_WINDOW_MS < 2_000, "the window the number above assumes")
+})
+
+test("a tap the guard did not cancel keeps its own click, debt or no debt", async () => {
+  // The debt has to be dropped the moment a tap comes through uncancelled, or
+  // the guard goes on swallowing at that coordinate and the child's next
+  // deliberate press does nothing at all.
+  const g = guarded()
+  const chip = new FakeNode(g.doc)
+  g.tap(90, 90, chip)
+  g.advance(90)
+  assert.equal(g.tap(90, 90, chip), true)
+  await flush()
+  assert.equal(chip.clicks.length, 2)
+
+  // Well past the double-tap window, so this one is a fresh gesture — and it is
+  // still inside the leak window of the tap before it.
+  g.advance(400)
+  assert.equal(g.tap(90, 90, chip), false, "a new gesture, not a zoom")
+  await flush()
+  assert.equal(chip.clicks.length, 3, "and its own click reached the chip")
+})
+
+test("a trusted click on another control does not eat the restore", async () => {
+  // The tally this replaced was global: any click anywhere satisfied the debt,
+  // so a click on an unrelated control landing in the window made the guard
+  // withhold the tap's own and the child's press vanished with no trace.
+  const g = guarded()
+  const chip = new FakeNode(g.doc)
+  const elsewhere = new FakeNode(g.doc)
+  g.tap(90, 90, chip)
+  g.advance(90)
+  assert.equal(g.tap(90, 90, chip), true)
+  elsewhere.dispatchEvent(new NativeClickEvent("click", { clientX: 400, clientY: 400, bubbles: true }))
+  await flush()
+
+  assert.equal(elsewhere.clicks.length, 1, "the unrelated click was neither eaten nor counted")
+  assert.equal(chip.restored.length, 1, "and the cancelled tap still got its own")
+})
+
+test("a first tap that drifted past the drag slop still arms the pair", () => {
+  // The guard failing OPEN on the one thing it exists to stop. This module
+  // calls 11px a drag; WebKit's double-tap slop is looser, so a first tap that
+  // drifted 11px is still half of a double tap to the gesture recogniser. If
+  // the guard forgets it, the second tap is not cancelled and the page scales.
+  const g = guarded()
+  g.press(100, 100)
+  g.drag(111, 100)
+  assert.equal(g.lift(111, 100), false, "a drag is still never cancelled itself")
+  g.advance(90)
+  assert.equal(g.tap(105, 100), true, "but the tap after it is")
+})
+
+test("a restore whose element has gone is delivered where the platform would have put it", async () => {
+  // STACK empties `choicesEl` and rebuilds every button, with the handler
+  // delegated on the container: a click on a button that has been replaced
+  // reaches nobody, and the child's tap disappears. The platform hit-tests
+  // afresh; where the touch's own target is gone, so does the guard.
+  const g = guarded()
+  const gone = new FakeNode(g.doc)
+  const replacement = new FakeNode(g.doc)
+  gone.connected = false
+  const saved = (globalThis as { document?: unknown }).document
+  ;(globalThis as { document?: unknown }).document = { elementFromPoint: () => replacement }
+  try {
+    g.tap(140, 140, gone)
+    g.advance(90)
+    assert.equal(g.tap(140, 140, gone), true)
+    await flush()
+  } finally {
+    if (saved === undefined) delete (globalThis as { document?: unknown }).document
+    else (globalThis as { document?: unknown }).document = saved
+  }
+
+  assert.equal(replacement.restored.length, 1, "the click went to what is actually there")
+  assert.equal(gone.restored.length, 0, "and not to the detached node")
 })
 
 test("the restored click waits a task, so a leaked platform click gets there first", async () => {
@@ -468,7 +599,9 @@ test("touchend is non-passive and in the capture phase", () => {
   assert.deepEqual(wiring.get("touchstart"), { capture: true, passive: true })
   assert.deepEqual(wiring.get("touchmove"), { capture: true, passive: true })
   assert.deepEqual(wiring.get("touchcancel"), { capture: true, passive: true })
-  assert.deepEqual(wiring.get("click"), { capture: true, passive: true }, "the click watcher never interferes")
+  // Non-passive because this listener DOES cancel — a duplicate click after a
+  // restore is swallowed there, and a passive listener could not.
+  assert.deepEqual(wiring.get("click"), { capture: true, passive: false })
   for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
     assert.deepEqual(wiring.get(type), { capture: true, passive: false }, `${type} must be cancellable`)
   }

--- a/dynawalla/packs/sdk/src/tapzoom.ts
+++ b/dynawalla/packs/sdk/src/tapzoom.ts
@@ -48,29 +48,41 @@
 // that tap. #678 deleted a guard from the HOST for exactly this: it ate the
 // second press of "Erase everything", a second `addProfile`, and a correction
 // between two cells of a segmented control 20px apart. Inside a pack the same
-// cost lands on RUNNER's revive lanes, MERGE IDLE's chips, STACK's answer
-// choices and game-chrome's help button — all bound to `click` — and on
-// FOUNDRY's pedals, COLOSSUS's strikes and STACK's commit, which are rapid by
-// design and must not lose a beat.
+// cost lands on RUNNER's revive lanes, MERGE IDLE's chips and actions, STACK's
+// answer choices and game-chrome's help and close buttons — every one of them
+// bound to `click`, and every one of them a control a child taps twice.
 //
-// A geometric test cannot separate those from a zoom: a child tapping the same
-// pedal twice in 120ms IS two taps close in time and space. So this does not
-// try. It cancels the tap's default action and then RE-DISPATCHES the `click`
-// the cancellation swallowed, at the same coordinates on the same target, in a
-// task of its own so it still lands after the `touchend` it belongs to. The
-// zoom is a default action of the touch and does not come back; the activation
-// is not a default action of the touch and does.
+// The games whose rapid input is famous are NOT on that list, and it is worth
+// saying which is which rather than guessing: FOUNDRY's pedals, COLOSSUS's
+// strikes and STACK's commit all act on `pointerdown`, which cancelling a
+// `touchend` does not touch. No game in this repository binds `touchend` at
+// all. So the tap that a naive guard would eat is an ANSWER, not a beat — which
+// is worse, not better.
 //
-// A task rather than a microtask, and counted rather than assumed. That
-// cancelling `touchend` suppresses the compatibility `click` is engine
-// behaviour this repository cannot observe — the Touch Events spec only
-// promises it for `touchstart` — and an engine that fired the click anyway
-// would give a control TWO. So the guard watches for a trusted `click` and
-// re-dispatches only if none arrived: a microtask would run before the
-// compatibility click and see nothing, a task runs after it. Either way exactly
-// one click reaches the control, and where the platform's own survived, the
-// platform's own is the one that is kept — it is the one carrying user
-// activation.
+// A geometric test cannot separate a deliberate double press from a zoom: a
+// child tapping the same chip twice in 120ms IS two taps close in time and
+// space. So this does not try. It cancels the tap's default action and then
+// RE-DISPATCHES the `click` the cancellation swallowed, at the same coordinates
+// on the same target, in a task of its own so it still lands after the
+// `touchend` it belongs to. The zoom is a default action of the touch and does
+// not come back; the activation is not a default action of the touch and does.
+//
+// Reconciled rather than assumed. That cancelling `touchend` suppresses the
+// compatibility `click` is engine behaviour this repository cannot observe —
+// the Touch Events spec only promises it for `touchstart` — and an engine that
+// raised the click anyway would give a control TWO: a second answer submitted,
+// a second revive spent.
+//
+// Watching for that leak in ONE direction is not enough, and the first draft of
+// this module got it wrong. An engine that still runs a double-tap-to-zoom
+// recogniser is, by construction, an engine that may hold the compatibility
+// click back to wait out the second tap — so the leak this defends against is
+// precisely the one that arrives LATE, long after any restore. So the guard
+// keeps a record of the tap it cancelled and reconciles both ends: a leak that
+// beats the restore cancels the restore, and a leak that follows one is
+// swallowed. Exactly one click reaches the control either way, and where the
+// platform's own survived it is the one that is kept — it is the one carrying
+// user activation.
 //
 // The accounting that follows from that: the FIRST tap of any chain is never
 // cancelled, and every later tap is cancelled and re-clicked. One `click` per
@@ -98,10 +110,21 @@ export const DOUBLE_TAP_SLOP_PX = 30
  * How far a finger may travel within one touch and still count as a tap.
  *
  * Past this the sequence is a drag: a swipe on a canvas, or the manual sheet
- * being finger-scrolled. A drag is never cancelled and never becomes the first
- * half of a pair.
+ * being finger-scrolled. A drag is never cancelled — but it IS remembered, and
+ * `TapZoomGuard.end` says why that is the difference between the guard holding
+ * and the guard failing open.
  */
 export const DRAG_SLOP_PX = 10
+
+/**
+ * How long a cancelled tap may still be reconciled against a platform click.
+ *
+ * Wide enough to cover the classic ~300ms compatibility-click delay, because
+ * that delay exists precisely to wait out a second tap — so the engine that
+ * still has a double-tap gesture to hold the click for is exactly the one this
+ * has to survive.
+ */
+export const LEAK_WINDOW_MS = 500
 
 /**
  * The tap bookkeeping, with no DOM in it.
@@ -113,9 +136,11 @@ export const DRAG_SLOP_PX = 10
 export class TapZoomGuard {
   /** A single-finger sequence that is still a candidate tap. */
   private alive = false
+  /** ...and one that began with a single finger, whether or not it stayed still. */
+  private single = false
   private startX = 0
   private startY = 0
-  /** The last completed single-finger tap, whatever happened to it. */
+  /** Where the last single-finger sequence ended, tap or drag. */
   private last: { t: number; x: number; y: number } | null = null
 
   /**
@@ -128,10 +153,12 @@ export class TapZoomGuard {
   start(x: number, y: number, touchCount: number): void {
     if (touchCount !== 1) {
       this.alive = false
+      this.single = false
       this.last = null
       return
     }
     this.alive = true
+    this.single = true
     this.startX = x
     this.startY = y
   }
@@ -150,13 +177,27 @@ export class TapZoomGuard {
    */
   end(t: number, x: number, y: number, remaining: number): boolean {
     const wasTap = this.alive && remaining === 0
+    const wasSingle = this.single && remaining === 0
     this.alive = false
     if (!wasTap) {
-      // A drag, or a finger lifting out of a pinch. Not a tap, so it is neither
-      // cancelled nor remembered — but it does not erase what came before it
-      // either: over-suppressing costs a re-dispatched click, under-suppressing
-      // costs a zoom.
-      if (remaining !== 0) this.last = null
+      if (!wasSingle) {
+        // A finger lifting out of a pinch. WebKit will not pair a tap across
+        // one either.
+        this.last = null
+        return false
+      }
+      // A single finger that travelled: a drag, so it is never cancelled — a
+      // drag does not zoom, and cancelling one would fire a click into the
+      // manual sheet the child never made.
+      //
+      // But it IS remembered. This module calls 11px a drag; WebKit's own
+      // double-tap slop is looser, so a first tap that drifted 11px is still
+      // half of a double tap to the gesture recogniser. Forgetting it would
+      // leave the SECOND tap uncancelled and the page would scale — the guard
+      // failing open on the one thing it exists to stop. Remembering it costs
+      // at worst a re-dispatched click after a real drag, which the child
+      // cannot tell from the real one.
+      this.last = { t, x, y }
       return false
     }
     const previous = this.last
@@ -170,12 +211,32 @@ export class TapZoomGuard {
   /** The system took the gesture away. Nothing is pending and nothing is owed. */
   cancel(): void {
     this.alive = false
+    this.single = false
     this.last = null
   }
 }
 
 function distance(ax: number, ay: number, bx: number, by: number): number {
   return Math.hypot(ax - bx, ay - by)
+}
+
+/** A cancelled tap, from the moment its click is owed until it is reconciled. */
+type OwedTap = {
+  readonly x: number
+  readonly y: number
+  readonly until: number
+  /** The platform's own arrived first, so the guard must not add another. */
+  satisfied: boolean
+  /** The guard already delivered this tap's click, so a later one is a duplicate. */
+  restored: boolean
+}
+
+/** Forget taps whose leak window has closed, so nothing is swallowed forever. */
+function prune(owed: OwedTap[], t: number): void {
+  for (let i = owed.length - 1; i >= 0; i--) {
+    const record = owed[i]
+    if (record && t > record.until) owed.splice(i, 1)
+  }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -193,6 +254,15 @@ export type GuardTouchEvent = {
   readonly changedTouches?: ArrayLike<GuardTouch>
   readonly cancelable?: boolean
   preventDefault?: () => void
+}
+
+/** A click, as much of it as this module reads. */
+export type GuardClickEvent = {
+  readonly isTrusted?: boolean
+  readonly clientX?: number
+  readonly clientY?: number
+  preventDefault?: () => void
+  stopImmediatePropagation?: () => void
 }
 
 type ListenerOptions = { capture?: boolean; passive?: boolean }
@@ -247,8 +317,18 @@ export function installTapZoomGuard(
   const now = options.now ?? Date.now
   const click = options.click ?? dispatchClick
   const guard = new TapZoomGuard()
-  /** Clicks the platform raised by itself. The re-dispatched ones are not trusted. */
-  let trustedClicks = 0
+  /**
+   * The cancelled taps that are owed a click, and how far each has got.
+   *
+   * Records rather than a tally, and matched on WHERE the click landed: a tally
+   * is satisfied by any click anywhere, so a click on an unrelated control
+   * arriving inside the window would make the guard withhold a tap's own and
+   * the child's press would vanish with no trace.
+   *
+   * A list rather than one slot because taps overlap: a chain puts a new tap in
+   * flight every 50-100ms while the last one is still inside its leak window.
+   */
+  const owed: OwedTap[] = []
 
   const onStart = (event: GuardTouchEvent) => {
     const touch = first(event.changedTouches)
@@ -265,25 +345,90 @@ export function installTapZoomGuard(
   const onEnd = (event: GuardTouchEvent) => {
     const touch = first(event.changedTouches)
     if (!touch) return
-    if (!guard.end(now(), touch.clientX, touch.clientY, count(event.touches))) return
+    const at = now()
+    if (!guard.end(at, touch.clientX, touch.clientY, count(event.touches))) {
+      // Nothing was cancelled, so nothing is owed and the click that follows is
+      // this tap's own. Dropping the records here is what keeps the guard from
+      // swallowing it.
+      owed.length = 0
+      return
+    }
     if (event.cancelable === false || typeof event.preventDefault !== "function") return
     event.preventDefault()
     // After the whole input turn, so the game sees its own listeners run in the
     // order it wrote them, and so a compatibility click the engine raised in
     // spite of the cancellation has already been counted.
+    //
+    // The target is the touch's OWN — `Touch.target` is where the finger went
+    // down — rather than whatever is under the coordinate when the restore
+    // runs. A tap moves less than 10px so the two agree, except in the one case
+    // where they must not: a game that swaps its DOM inside the `touchend`.
+    // There the platform's click hit-tests afresh and lands on whatever
+    // appeared underneath, which is a tap-through bug MERGE IDLE has already
+    // had to write a guard against.
     const { clientX, clientY } = touch
     const node = touch.target
-    const seen = trustedClicks
+    const record: OwedTap = {
+      x: clientX,
+      y: clientY,
+      until: at + LEAK_WINDOW_MS,
+      satisfied: false,
+      restored: false,
+    }
+    prune(owed, at)
+    owed.push(record)
     setTimeout(() => {
-      if (trustedClicks !== seen) return
+      // Keyed on the record, not on it still being the newest: a tap that has
+      // been overtaken is still a tap the child made and is still owed its
+      // click.
+      if (record.satisfied) return
+      record.restored = true
       click(node, clientX, clientY)
     }, 0)
   }
 
-  const onCancel = () => guard.cancel()
+  const onCancel = () => {
+    guard.cancel()
+    owed.length = 0
+  }
 
-  const onClick = (event: { isTrusted?: boolean }) => {
-    if (event.isTrusted !== false) trustedClicks += 1
+  /**
+   * Watch the platform's own clicks, and reconcile them with the guard's.
+   *
+   * The whole double-click defence is here, and it has to work at BOTH ends of
+   * the timing, because an engine that still runs a double-tap-to-zoom
+   * recogniser is by construction an engine that may hold the compatibility
+   * click back to wait out the second tap:
+   *
+   *   * the leak arrives BEFORE the restore — mark the tap satisfied and let
+   *     the platform's own through, since it is the one carrying user
+   *     activation and the guard's would only duplicate it;
+   *   * the leak arrives AFTER the restore — the guard already delivered this
+   *     tap's click, so this one is the duplicate and is swallowed.
+   *
+   * Matched on position and inside a window, so a trusted click that belongs to
+   * some other control is neither counted nor eaten. This is the only place the
+   * guard ever interferes with a click, and it only ever does so for a tap it
+   * cancelled itself.
+   */
+  const onClick = (event: GuardClickEvent) => {
+    if (event.isTrusted === false) return
+    prune(owed, now())
+    const x = event.clientX
+    const y = event.clientY
+    if (x === undefined || y === undefined) return
+    const index = owed.findIndex((r) => distance(x, y, r.x, r.y) <= DOUBLE_TAP_SLOP_PX)
+    const record = owed[index]
+    if (!record) return
+    // Reconciled either way, so it is taken off the list: whatever happens to
+    // the next click at this coordinate, it is not this tap's business.
+    owed.splice(index, 1)
+    if (!record.restored) {
+      record.satisfied = true
+      return
+    }
+    if (typeof event.preventDefault === "function") event.preventDefault()
+    if (typeof event.stopImmediatePropagation === "function") event.stopImmediatePropagation()
   }
 
   // Pinch is a different gesture and this is not the fix for it — it is here
@@ -294,20 +439,22 @@ export function installTapZoomGuard(
     if (typeof event.preventDefault === "function") event.preventDefault()
   }
 
-  // Capture, so a game that calls `stopPropagation()` on its own `touchend` —
-  // several do — cannot hide the tap from the guard. Passive everywhere the
-  // guard never cancels, so the manual sheet's `touch-action: pan-y` finger
-  // scroll and every canvas drag keep their fast path; `touchend` alone is
-  // non-passive, which is the one place `preventDefault()` has to be allowed.
+  // Capture, so that no listener a pack installs can hide a tap from the guard
+  // by calling `stopPropagation()`. No game in this repository does today; the
+  // guard is the last thing that should depend on that staying true.
+  //
+  // Passive everywhere the guard never cancels, so the manual sheet's
+  // `touch-action: pan-y` finger scroll and every canvas drag keep their fast
+  // path. `touchend` and `click` are the two that may cancel, and they are the
+  // two that are not passive.
   const bind: [string, (event: never) => void, ListenerOptions][] = [
     ["touchstart", onStart as (event: never) => void, { capture: true, passive: true }],
     ["touchmove", onMove as (event: never) => void, { capture: true, passive: true }],
     ["touchend", onEnd as (event: never) => void, { capture: true, passive: false }],
     ["touchcancel", onCancel as (event: never) => void, { capture: true, passive: true }],
-    // Watching, never interfering: it cancels nothing and stops nothing, it
-    // only counts, so a control that legitimately receives a click still
-    // receives it.
-    ["click", onClick as (event: never) => void, { capture: true, passive: true }],
+    // Non-passive: this is the one listener that may cancel, and it does so
+    // only for a duplicate of a click the guard itself already delivered.
+    ["click", onClick as (event: never) => void, { capture: true, passive: false }],
     ["gesturestart", onGesture as (event: never) => void, { capture: true, passive: false }],
     ["gesturechange", onGesture as (event: never) => void, { capture: true, passive: false }],
     ["gestureend", onGesture as (event: never) => void, { capture: true, passive: false }],
@@ -335,10 +482,27 @@ function count(list: ArrayLike<GuardTouch> | undefined): number {
   return list ? list.length : 0
 }
 
+function elementAt(x: number, y: number): { dispatchEvent?: (event: object) => boolean } | null {
+  const doc = (globalThis as { document?: { elementFromPoint?: (x: number, y: number) => unknown } }).document
+  if (!doc || typeof doc.elementFromPoint !== "function") return null
+  return (doc.elementFromPoint(x, y) as { dispatchEvent?: (event: object) => boolean } | null) ?? null
+}
+
 function dispatchClick(target: unknown, x: number, y: number): void {
   const Ctor = (globalThis as { MouseEvent?: typeof MouseEvent }).MouseEvent
   if (!Ctor) return
-  const node = target as { dispatchEvent?: (event: object) => boolean } | null
+  let node = target as { dispatchEvent?: (event: object) => boolean; isConnected?: boolean } | null
+  // The touch's own target while it is still in the document — a tap moved less
+  // than 11px, so hit-testing afresh would only find the same element, except
+  // where a game swapped its DOM inside the `touchend` and the platform's own
+  // click would land on whatever appeared underneath. That is a tap-through
+  // MERGE IDLE has already had to write a guard against.
+  //
+  // But when the element is GONE, keeping it drops the child's tap in silence:
+  // STACK rebuilds its answer chips and delegates the handler to the container,
+  // so a click on a replaced button reaches nobody. There the platform's
+  // behaviour is the better of the two, and the guard falls back to it.
+  if (node && node.isConnected === false) node = elementAt(x, y) ?? node
   if (!node || typeof node.dispatchEvent !== "function") return
   node.dispatchEvent(
     new Ctor("click", {


### PR DESCRIPTION
Self-review of #685, which merged before this pass finished. Three real defects,
one of them the thing the guard exists to prevent.

## The double-click defence watched the wrong end

#685 skipped the restore if a trusted click arrived before a `setTimeout(0)`.
But an engine that still runs a double-tap-to-zoom recogniser is, by
construction, an engine that may hold the compatibility click back to wait out
the second tap — the classic ~300 ms delay exists for exactly that. So the leak
this defends against is precisely the one that arrives **late**, and the counter
could not see it: STACK's answer chip takes the restore at t≈1 ms and the
platform's own at t≈300 ms, and one tap submits two answers. RUNNER's revive
lanes spend two revives.

Worse, both of #685's tests put the leak *before* the restore — one
synchronously, one in a microtask — so they asserted the property only in the
timing where it already held. That is the vacuous shape this repo keeps getting
burned by, and it was mine.

Now the guard keeps a **record of each cancelled tap** and reconciles both ends:

- a leak that beats the restore → the restore is cancelled, and the platform's
  own is allowed through, because it is the one carrying user activation;
- a leak that follows a restore → it is the duplicate, and it is swallowed.

The swallow is the only place this module ever interferes with a click, it only
ever fires for a tap the guard itself cancelled, and it expires.

## The tally was global

It was satisfied by any click anywhere, so a click on an unrelated control
landing inside the window made the guard withhold a tap's own — and the child's
press vanished with no trace. Records are now matched on **where** the click
landed, and there is a list of them rather than one slot, because a chain puts a
new tap in flight while the last one is still inside its leak window.

## The drag failed open on the zoom itself

A first tap that travelled 11 px was neither cancelled nor **remembered**, so the
second tap had nothing to pair with and was not cancelled either. The page
scales — the whole bug this exists to stop, reachable by a child whose finger
drifts, which is most of them.

This module calls 11 px a drag; WebKit's own double-tap slop is looser. A drag is
still never cancelled — the manual sheet's finger scroll is untouched — but it is
now remembered. Cost: at worst a re-dispatched click after a real drag, which the
child cannot tell from the real one.

## Two smaller ones

**A restore whose element has gone** is now delivered where the platform would
have put it. STACK empties `choicesEl` and rebuilds every button with the handler
delegated on the container, so a click on a replaced button reaches nobody. The
touch's own target is still preferred *while it is connected* — that is what
keeps the guard from re-creating the tap-through MERGE IDLE had to write a guard
against — and the hit test is the fallback, not the rule.

**The prose said things that are not true of this repository.** No game binds
`touchend`. FOUNDRY's pedals, COLOSSUS's strikes and STACK's commit — the three
#685 named as the click-accounting risk — all act on `pointerdown`, which
cancelling a `touchend` does not touch. The controls actually at risk are
RUNNER's revive lanes, MERGE IDLE's chips and actions, STACK's answer choices and
game-chrome's help and close buttons. The tap a naive guard eats is an **answer**,
not a beat, which is worse rather than better.

## The fake DOM was lying about the capture phase

It dispatched at the target and only then told the document. The guard swallows
in the **capture** phase, which runs document-first, so a fake in that order
could never observe a swallow — the swallow test would have passed whether the
guard swallowed or not. It now dispatches at the document first and honours
`stopImmediatePropagation()`.

## Still unverified

Unchanged from #685, and worth repeating: nobody here has an iPhone in CI. That
`preventDefault()` on a `touchend` inside an opaque-origin subframe reaches
WebKit's main-frame gesture recogniser is **reasoned from the platform, not
observed**, and so is the account of why `touch-action` does not. What is proven
in Node is the state machine, the listener wiring, the ordering, the leak
reconciliation at both ends, and the click accounting — with real `EventTarget`s,
real dispatch, and the platform's own compatibility click modelled.

## Every test checked by deleting what it covers

Thirty-two mutations, every one caught. Four of my own survived a first sweep and
were fixed rather than reported: a gesture mutation that silently landed on the
wrong function (so `M19` read green while the gesture guard was gutted), a
microtask swap that was not actually a swap, a leak-window test written against
the very constant it was guarding, and no test at all for dropping the debt when
a tap comes through uncancelled.

```
M1  no preventDefault on the second tap
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      one platform click, and seven the guard put back
      0 !== 7
M2  no click put back
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      every tap must produce exactly one click
      1 !== 8
M3  touchend bound passive
  not ok - touchend is non-passive and in the capture phase
      Expected values to be strictly deep-equal:
      + actual - expected
M4  touchend bound in the bubble phase
  not ok - touchend is non-passive and in the capture phase
      Expected values to be strictly deep-equal:
      + actual - expected
M5  no time window
  not ok - a tap the guard did not cancel keeps its own click, debt or no debt
      a new gesture, not a zoom
      true !== false
M6  no distance window
  not ok - two taps further apart than the slop are both left alone
      Expected values to be strictly equal:
      true !== false
M7  a drag is not detected
  not ok - a finger-scroll of the manual sheet is never cancelled
      and a second flick is not the second half of one
      true !== false
M8  a second finger is treated as a tap
  not ok - a pinch is not a tap and clears the chain
      the pinch cleared the history behind it
      true !== false
M9  touchcancel does not clear the chain
  not ok - a cancelled touch clears the chain
      the system took the gesture, so nothing pairs with it
      true !== false
M10 connect() stops installing the guard
  not ok - connecting installs the tap guard on the pack document
M11 no idempotence
  not ok - installing twice binds one guard, not two
      eight listeners, once
      16 !== 8
M12 a lift with fingers still down keeps the chain
  not ok - the state machine reads a lift with fingers still down as no tap at all
      and the chain behind it was cleared
      true !== false
M13 the first tap of a chain is cancelled too
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      one platform click, and seven the guard put back
      8 !== 7
M14 a non-cancelable touchend is cancelled anyway
  not ok - a non-cancelable touchend is left alone and costs no click
      Expected values to be strictly equal:
      true !== false
M15 no MouseEvent guard
  not ok - no document, and no MouseEvent, are both survivable
M16 the drag slop swallows a jitter
  not ok - a jitter inside the drag slop is still a tap
M17 the disposer does not unbind
  not ok - the disposer unbinds, and a target can then be guarded again
      Expected values to be strictly equal:
      8 !== 0
M18 the guard is never bound at all
  not ok - connecting installs the tap guard on the pack document
      one platform click, and seven the guard put back
      0 !== 7
M19 the gesture handler does nothing
  not ok - gesture events are cancelled, and are pinch rather than double tap
      gesturestart must not scale the page
      false !== true
M21 the time window is narrowed to 40ms
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      one platform click, and seven the guard put back
      0 !== 7
M22 the distance window is narrowed to 4px
  not ok - a first tap that drifted past the drag slop still arms the pair
      but the tap after it is
      false !== true
M20 the restore is dispatched inside the touchend instead of after it
  not ok - an engine that raises the click anyway does not double it
      and none of them invented
      1 !== 0
M23 the restore is queued as a microtask, racing the platform
  not ok - the restored click waits a task, so a leaked platform click gets there first
      the platform's own was allowed to win the race
      1 !== 0
M24 the restore ignores whether the platform already delivered
  not ok - an engine that raises the click anyway does not double it
      two taps, two clicks — not three
      3 !== 2
M25 a late leak is not swallowed
  not ok - a platform click that leaks LATE, after the restore, is swallowed
      two taps, two clicks — the duplicate never reached the chip
      3 !== 2
M26 the click watcher counts the guard's own re-dispatch too
  not ok - rapid deliberate tapping on one spot delivers every tap to the game
      every tap must produce exactly one click
      2 !== 8
M27 the leak window never expires
  not ok - a leak after the window has closed is not swallowed
      a click this late belongs to somebody else
      2 !== 3
M28 a click anywhere reconciles a cancelled tap
  not ok - a trusted click on another control does not eat the restore
      and the cancelled tap still got its own
      0 !== 1
M29 an uncancelled tap leaves the debt standing
  not ok - a tap the guard did not cancel keeps its own click, debt or no debt
      and its own click reached the chip
      2 !== 3
M30 a drag is forgotten, so the tap after it is not cancelled
  not ok - a first tap that drifted past the drag slop still arms the pair
      but the tap after it is
      false !== true
M31 a detached target is used anyway
  not ok - a restore whose element has gone is delivered where the platform would have put it
      the click went to what is actually there
      0 !== 1
M32 a live target is hit-tested afresh
  not ok - a restore whose element has gone is delivered where the platform would have put it
      the click went to what is actually there
      2 !== 1
```

94 tests, five consecutive clean runs. `npm run tsc` clean; `packs/shared/game-host`
25/25 and clean; the host's `boundary.test.ts` 8/8, which is what holds the SDK
entry point to re-exporting nothing but its own siblings.

Follow-up to #685.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
