### PR TITLE
release(dynawalla): 0.3.1 — the night the games stopped rushing children

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
One line in `tauri.conf.json`. Thirty-eight commits since 0.3.0, from two fleet audits and a founder playtest.

## Games that marked a correct child wrong

- **trebuchet** — the crosswind scored a right answer **wrong up to 8 times in 9** by wave 16, and sent that verdict to the curriculum.
- **polarity** — four blank glowing discs for **100% of level-1+ items**; 89.9% of every answer option ever offered had no number on it. It also reported `"20"` for an answer of 3916.
- **beam** — its CORE was killed on the frame it was born, **every wave since the function was written**. The prompt was legible for **zero** seconds, not 1.3.

## Timing that could not be met

- **THE STEELYARD** (was COUNTERWEIGHT) — 7.6s for a four-digit sum whose motor plan alone costs 7.0s. Its solver bot scored **0 of 78** at the house's own expected pace.
- **claim** — 7s to read, compute *and drive*, of which the drive alone measured 5.52s.
- **SLICE** — a bot that never answered outscored one that answered correctly. **Zero answers landed in a 300-second run.**

## The ladder was capped

A hardcoded 6-second promotion rule made **18 of 36 rungs unreachable**. A child answering everything correctly at its own published median stalled permanently at rung 16. A slow, perfect child needed **33 hours** to leave rung 0 — they now reach the top in 87 minutes.

## The wire was dead

`GameHost.next()` ignored its argument in production. **Eight games had been passing a difficulty request into nothing since they shipped.** It now carries difficulty, domain and a flush; nine games adapt with no edit at all.

## The curriculum grew at both ends

`0 + 1` exists, trivial identities included. Multiplication and division are authored, seven rows active — **43 rungs to 60**.

## Audio

MOSAIC peaked at **+22.9 dBFS with 15,954 clipped samples**. A `GainNode` defaults to 1, and every arpeggiated cue sat at unity for the length of its own stagger. **18 of 25 measurable games clipped.** Every cue now measures under a WaveShaper ceiling with zero clipped samples — and the Sound setting silences them for the first time.

## Chrome

The manual is a bottom sheet that cannot collide with the exit control, holds every pack's audio by construction, and its scrim finally stops taps that were reaching the game underneath. Real iOS haptics via the Taptic Engine. Every pack declares a minimum age.

## What this build is for

Nothing above has been in front of a child. The device-only questions: does MOSAIC still hurt on headphones, do the haptics fire, does COUNTERPOISE still let you drag the far-right weight, and does the double-tap still expose the catalogue.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb