### PR TITLE
dynawalla/games/arena: absorb the exact number, and mean every line of the ribbon

### DIFF
--- a/dynawalla/games/arena/README.md
+++ b/dynawalla/games/arena/README.md
@@ -11,7 +11,7 @@ you, and anything larger will hurt.**
 ```bash
 npm install
 npm run dev      # http://127.0.0.1:5188/
-npm test         # 24 tests, Node's native runner, zero dependencies
+npm test         # 71 tests, Node's native runner, zero dependencies
 npm run tsc      # typecheck
 npm run build:pack   # the installable pack; `../../packs && node build.mjs arena` checks and stages it
 ```
@@ -274,6 +274,17 @@ the supply**, which is the only honest place for it:
 - **`VOID_MAX_FRACTION`** — the 11%-of-mass mercy on a void used to clamp the
   DAMAGE while the label said something else. It now clamps the **label**: same
   hit to the unit, and `24 − 5 = 19` becomes a sentence the game can print.
+
+- **`EXHAUST_SHARE` / `EXHAUST_GRAIN`** — the surge trail is a **ledger**, not a
+  rate. It used to be 26 motes a second worth 3.5% of you each against a burn of
+  11% a second, which was only survivable because eating it back was throttled
+  by the saturation this pass deleted. Measured on the exact-absorption branch
+  before the fix, holding surge one second in five: 42,287 at one minute,
+  28,074,058 at two, 4,268,470,964 at four. The water now gets exactly the mass
+  actually taken off you and a fixed share of it, so boosting still costs
+  something when you turn round and hoover your own trail back up. `main` had a
+  milder version of the same hole — the same bot reached 124,408 at five minutes
+  against roughly 1,300 for a player who never boosted.
 
 A rival is rationed by the world rather than by a constant — at most 26, a
 respawn timer, and only edible below `mass / 1.06`, so a kill can never more

--- a/dynawalla/games/arena/README.md
+++ b/dynawalla/games/arena/README.md
@@ -240,33 +240,48 @@ test that flies a run and a host emitting ten-digit answers.
 
 ## Tuning notes for whoever comes next
 
-Three constants are the entire difficulty curve, and all three were fitted by
-simulating complete twenty-minute runs rather than by looking at the screen:
+**Absorption is exact and is not a tuning knob.** Eat a `4`, gain 4 — at every
+mass, forever, and the same for a rival and for the number a void wears. It did
+not used to be: absorption saturated at a seventh of you, so a `4` at mass 10
+was worth `+1`, and the running equation printed `10 + 1 = 11` under a numeral
+a child had just read as 4. That is a true sentence about a game the child
+cannot see, and a maths product may not ship one. `absorbGain` and `devourGain`
+are the identity and there is nowhere left in either to put a multiplier.
+
+Everything that used to be done by shrinking the gain is now done by **metering
+the supply**, which is the only honest place for it:
 
 - **`FOOD_A` / `FOOD_B`** — mote value scales as `A × mass^B`, *not* as a
   fraction of mass. A fraction compounds, and compounding turns a twenty-minute
-  climb into a ninety-second explosion followed by nothing.
-- **`ABSORB_K` / `ABSORB_SOFT`** — absorption saturates, capping any single mote
-  at a seventh of you, and past `ABSORB_SOFT` the cap itself tightens as
-  `√mass`. Without the cap, the sliver of the near-tie band just below your mass
-  is a free doubling; a child finds it in ninety seconds. Without the tightening
-  the same band is a *fixed fraction* of you, which is an exponential by a
-  slower road — measured at 273 → 3,330,895 → 1,301,388,804 in three hundred
-  seconds, which is a legibility failure before it is a balance one.
-- **`DEVOUR_K`** — the same idea, far more generously, for eating a rival: your
-  own size is worth about a third of you, **at every size**. It deliberately
-  does *not* get the `√mass` tightening, and the asymmetry is the point: the
-  near-tie mote is a supply the game manufactures on purpose, and a rival is
-  not — there are at most 26, they respawn on a timer, and one is only edible
-  below `mass / 1.06`. Measured with a bot that hunts nothing else for twenty
-  minutes, tightening it changed the peak from 34,456 to 11,442 — both five
-  digits, neither an explosion — so it bought no safety and cost the genre its
-  payoff moment. `sim.test.ts` flies that bot as a regression.
+  climb into a ninety-second explosion followed by nothing. `A` fell from 0.40
+  to 0.16 when absorption went exact, because the same table of numbers now
+  feeds a player two to six times faster; the constant moved to keep the CURVE
+  where it already was.
+- **`WALL_RATE`** — one mote in seven is drawn at or above your mass. That band
+  is the declared skill (3,418 against 3,481) so it keeps full frequency at
+  every size — but a wall is never food. A wall is otherwise a *prize with a
+  delay on it*: grow five per cent and the 1.05× you swam around thirty seconds
+  ago is a free hundred-per-cent breakfast, forever, because the field
+  manufactures walls forever. Measured with walls left flippable and absorption
+  exact: a struggling run passed 100,000 inside the first minute. Outgrow a
+  wall now and it **bursts into crumbs** on the ordinary food scale — the
+  genre's best moment kept, as an event rather than a jackpot.
+- **`PRIZE_RATE` / `PRIZE_RATE_EXP` / `PRIZE_RATE_MAX`** — a number *just under*
+  your own is a literal doubling, so it is rationed, and the ration falls as
+  `mass^-0.85`: exactly fast enough that its contribution stays a fixed share of
+  a curve whose other half goes as `√mass`. Flatten the taper and the same
+  twenty-minute run of perfect play finishes at 5,745,335 instead of 255,153.
+- **`VOID_MAX_FRACTION`** — the 11%-of-mass mercy on a void used to clamp the
+  DAMAGE while the label said something else. It now clamps the **label**: same
+  hit to the unit, and `24 − 5 = 19` becomes a sentence the game can print.
 
-A mote's printed number is a **size**, not an addend. A fish that swallows a
-fish nearly its own size does not double, and the floating number that pops on
-absorb is the size you actually gained. The comparison — which is the
-mathematics — is exact and honest; the economy is a separate, tuned layer.
+A rival is rationed by the world rather than by a constant — at most 26, a
+respawn timer, and only edible below `mass / 1.06`, so a kill can never more
+than 1.94× you — which is what made it safe to make exact. Measured against a
+bot that hunts nothing else for twenty minutes while answering perfectly, over
+three seeds: saturating peaked at 97,715 / 139,611 / 156,320, exact peaks at
+125,210 / 701,405 / 230,764. Six digits at the top of the strongest possible
+play, which is the legibility contract. `sim.test.ts` flies that bot.
 
 `src/sim/sim.test.ts` runs a full twenty-minute headless game and asserts on
 the *shape* of the result rather than on a number: the first minute must be a

--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -1,72 +1,65 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, FLOOR_MASS } from "./world.ts"
+import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, FLOOR_MASS, MK_FOOD, MK_VOID, MK_SHED } from "./world.ts"
 import { Rng } from "../core/rng.ts"
 import { DEPTHS, depthFor, overdrive } from "./depths.ts"
 import { specFor } from "../core/tier.ts"
 import { createStubHost } from "../host/stubHost.ts"
 import type { Host, Question } from "../contract.ts"
 
-test("absorption saturates, and saturates harder as you grow", () => {
-  for (const mass of [10, 60, 500, 4000, 90000, 3_000_000]) {
-    let peak = 0
-    for (let v = 1; v <= mass; v = Math.max(v + 1, Math.round(v * 1.05))) {
-      const g = absorbGain(v, mass)
-      assert.ok(g >= 1, "a swallow always gives at least one")
-      assert.ok(Number.isInteger(g))
-      assert.ok(g <= v + 1, `gain ${g} exceeded the mote's own value ${v}`)
-      peak = Math.max(peak, g)
-    }
-    // mass/(1+K) with K = 6, plus a rounding unit.
-    assert.ok(peak <= mass / 7 + 1, `peak gain ${peak} broke the cap at mass ${mass}`)
+/**
+ * Absorption is the identity. Eat a `4`, gain 4 — at every mass, forever.
+ *
+ * This test used to assert the opposite ("absorption saturates, and saturates
+ * harder as you grow"), and the reversal is the founder's:
+ *
+ *   "it would seem more intuitive to me to absorb the exact number? ... is that
+ *    not how most games like this work?"
+ *
+ * The old curve made a `4` at mass 10 worth `+1`, so the running equation
+ * printed `10 + 1 = 11` under a numeral a child had just read as 4. In a maths
+ * product that is not a balance choice, it is a false sentence on screen.
+ *
+ * There is no free parameter left in here to get wrong, which is the point:
+ * anything that ever wants to scale a swallow has to be argued about somewhere
+ * else, because this function has nowhere to put it.
+ */
+test("absorption is exact, at every mass, with nothing left to tune", () => {
+  for (const v of [1, 2, 3, 4, 7, 40, 999, 3418, 1_000_000, 2_147_483_646]) {
+    assert.equal(absorbGain(v), v, `a mote wearing ${v} was not worth ${v}`)
   }
-
-  // The early game must stay explosive: below the soft point the curve is
-  // within a few per cent of the flat-K one it replaced.
-  //
-  // This assertion used to read `absorbGain(10, 10) >= 10 / 7 * 0.92` and could
-  // never have passed, against either curve. `absorbGain` returns an INTEGER,
-  // and at the smallest mass in the game the rounding quantum is the whole
-  // quantity under test: the flat-K curve it names as its reference is
-  // round(10 / 7) = 1, not 1.43, so it was comparing a rounded number against
-  // an unrounded target and failing on the rounding rather than on the nerf it
-  // meant to catch. The property is real; it just has to be stated against the
-  // reference put through the same rounding, over the mass range the claim
-  // actually covers — the tens to low hundreds, which is the first two minutes.
-  const flatK = (value: number, mass: number): number =>
-    Math.max(1, Math.round(value / (1 + (6 * value) / Math.max(1, mass))))
-  for (const m of [10, 20, 40, 80, 120]) {
-    assert.ok(
-      absorbGain(m, m) >= flatK(m, m) * 0.92,
-      `the first minute was nerfed at mass ${m}: ${absorbGain(m, m)} vs ${flatK(m, m)}`,
-    )
-  }
-
-  // …and the late game must stop being an exponential. A near-tie is a fixed
-  // fraction of you only until it isn't; past that the fraction itself falls.
-  const frac = (m: number): number => absorbGain(Math.round(m * 0.98), m) / m
-  assert.ok(frac(1e4) < frac(1e2), "the near-tie fraction must fall with mass")
-  assert.ok(frac(1e7) < frac(1e4) * 0.5, "…and keep falling, or a bot finds the exponential")
+  // Nothing at or below nothing is worth anything, and nothing is ever handed
+  // back for a negative — a void is a LOSS and it is applied in `collide`.
+  assert.equal(absorbGain(0), 0)
+  assert.equal(absorbGain(-9), 0)
+  // Still an integer, because it lands between the ribbon's integer terms.
+  for (const v of [1, 5, 12345]) assert.ok(Number.isInteger(absorbGain(v)))
 })
 
 /**
- * The kill curve is deliberately mass-INVARIANT, unlike the mote curve, and the
- * asymmetry is asserted here rather than left to a comment. See DEVOUR_K in
- * world.ts: the near-tie mote is a manufactured, continuous supply and the
- * rival is not, so the sqrt(mass) tightening belongs on one and not the other.
+ * And so is the kill. See `devourGain` in world.ts for why this one could
+ * honestly have gone either way and did not: a rival carries a drawn numeral
+ * (`gfx.ts` labels every core big enough to hold one), so `400 + 84 = 484`
+ * under a core reading 300 is the same false sentence by another route.
+ *
+ * What keeps it safe is that a rival is a RATIONED supply where a mote is not:
+ * MAX_RIVALS of them, a respawn timer, and the `mass > m * 1.06` rule, which
+ * together mean a kill can never more than 1.94x you.
  */
-test("devouring a rival is generous but still bounded", () => {
-  for (const mass of [10, 500, 90000]) {
-    const equal = devourGain(mass, mass)
-    assert.ok(equal > mass * 0.22, "eating your own size should feel enormous")
-    assert.ok(equal <= mass * 0.32 + 1, "…but it may never approach a doubling")
-    // Monotonic in the prey's size.
-    let prev = 0
-    for (let m = 1; m <= mass * 3; m = Math.max(m + 1, Math.round(m * 1.1))) {
-      const g = devourGain(m, mass)
-      assert.ok(g >= prev, "gain must never fall as prey grows")
-      prev = g
-    }
+test("devouring a rival is exact, and a kill can never more than double you", () => {
+  for (const m of [1, 4, 500, 90_000, 3_000_000]) {
+    assert.equal(devourGain(m), m, `a rival of ${m} was not worth ${m}`)
+  }
+  assert.equal(devourGain(0), 0)
+  assert.equal(devourGain(-3), 0)
+  // The bound is the collision rule's, not the curve's: you may only swallow a
+  // rival strictly below `mass / 1.06`, so the most a kill can pay is 1/1.06.
+  for (const mass of [10, 500, 90_000]) {
+    const biggestLegal = Math.ceil(mass / 1.06) - 1
+    assert.ok(
+      mass + devourGain(biggestLegal) < mass * 1.95,
+      `a legal kill at mass ${mass} paid ${devourGain(biggestLegal)} — more than a doubling`,
+    )
   }
 })
 
@@ -214,6 +207,13 @@ test("a twenty-minute run escalates without trivialising the arena", () => {
   assert.ok(massAtOneMinute > 60, `no escalation in the first minute: ${Math.round(massAtOneMinute)}`)
   assert.ok(massAtOneMinute < 30_000, `first minute detonated: ${Math.round(massAtOneMinute)}`)
   assert.ok(peak > 400, `run never escalated; peak mass was only ${Math.round(peak)}`)
+  // The legibility contract, at the other end. This bot answers every question
+  // correctly AND eats everything it can reach, which is the strongest line of
+  // play in the game, and after twenty minutes of it the player's own core must
+  // still be a number a seven-year-old can read. It is also the only assertion
+  // that holds the prize taper honest: with `prizeRate` flattened to its
+  // ceiling the same run reaches 5,745,335.
+  assert.ok(peak < 1e6, `twenty minutes of perfect play reached ${Math.round(peak)} — that is not a readable number`)
 
   // The ladder is still live after twenty minutes: something out there can
   // still eat you, and the board is still populated.
@@ -472,10 +472,12 @@ function fly(
   accuracy: number,
   seed: number,
   onFrame?: (f: number) => void,
+  beforeFrame?: (f: number) => void,
 ): void {
   const coin = new Rng(seed)
   let target = -1
   for (let f = 0; f < 60 * seconds; f++) {
+    beforeFrame?.(f)
     const res = world.resonance
     if (res.active && res.phase === 2) {
       if (target < 0) target = coin.f() < accuracy ? res.correctSlot : (res.correctSlot + 1 + coin.int(0, 2)) % 4
@@ -559,20 +561,43 @@ test("a run opens sparse and fills up only as the world is earned", () => {
  * seed-dependent and the property is not.
  */
 test("the numbers a child reads stay in a workable range for a long time", () => {
-  const world = new World(createStubHost({ seed: 4 }), specFor("mid"), 0xbeef)
-  const at: Record<number, number> = {}
+  // Four seeds and a median, where this used to be one seed and a number.
+  //
+  // The change is forced by exact absorption and it makes the test stronger,
+  // not looser. A single early kill is now worth up to 94% of you rather than
+  // 25%, so ONE seed's fifteen-second mass is a coin flip on whether a rival
+  // wandered into range — measured across five seeds after this pass: 131, 67,
+  // 62, 52, 47. Asserting the band on the median keeps the property the test
+  // names, and the per-seed ceiling below keeps a single run from hiding a
+  // detonation inside a lucky median.
   const marks = [15, 30, 60, 120, 300]
-  fly(world, 300, 0.3, 9, (f) => {
-    const t = (f + 1) / 60
-    for (const m of marks) if (Math.abs(t - m) < 1 / 120) at[m] = world.mass
-  })
+  const runs: Record<number, number>[] = []
+  for (const [host, world, coin] of [[4, 0xbeef, 9], [6, 31337, 11], [15, 606, 4], [21, 1234, 3]] as const) {
+    const w = new World(createStubHost({ seed: host }), specFor("mid"), world)
+    const at: Record<number, number> = {}
+    fly(w, 300, 0.3, coin, (f) => {
+      const t = (f + 1) / 60
+      for (const m of marks) if (Math.abs(t - m) < 1 / 120) at[m] = w.mass
+    })
+    runs.push(at)
+  }
+  const median = (m: number): number => {
+    const xs = runs.map((r) => r[m] as number).sort((a, b) => a - b)
+    return ((xs[1] as number) + (xs[2] as number)) / 2
+  }
+  const worst = (m: number): number => Math.max(...runs.map((r) => r[m] as number))
 
-  assert.ok((at[15] as number) < 100, `mass was already ${Math.round(at[15] as number)} after fifteen seconds`)
-  assert.ok((at[30] as number) < 200, `mass was already ${Math.round(at[30] as number)} after half a minute`)
-  assert.ok((at[60] as number) < 600, `mass was already ${Math.round(at[60] as number)} after one minute`)
+  assert.ok(median(15) < 100, `mass was already ${Math.round(median(15))} after fifteen seconds`)
+  assert.ok(median(30) < 200, `mass was already ${Math.round(median(30))} after half a minute`)
+  assert.ok(median(60) < 600, `mass was already ${Math.round(median(60))} after one minute`)
+  // No single run may be an order of magnitude out of band either. Every
+  // economy bug this file has caught was two or more orders out, not one.
+  assert.ok(worst(15) < 300, `a run reached ${Math.round(worst(15))} in fifteen seconds`)
+  assert.ok(worst(30) < 900, `a run reached ${Math.round(worst(30))} in half a minute`)
+  assert.ok(worst(60) < 2500, `a run reached ${Math.round(worst(60))} in one minute`)
   // …and it must still be a climb, not a stall. A game where nothing grows is
   // not calmer, it is dead.
-  assert.ok((at[300] as number) > (at[30] as number) * 3, "five minutes of play went nowhere")
+  assert.ok(median(300) > median(30) * 3, "five minutes of play went nowhere")
 })
 
 /**
@@ -770,6 +795,357 @@ test("the running equation is always true, and never fires for a change of nothi
     })
     assert.ok(lines > 40, `only ${lines} equations in seven minutes — the ribbon is barely alive`)
   }
+})
+
+/**
+ * The founder's sketch, run as arithmetic:
+ *
+ *     10 + 4 = 14
+ *     14 + 10 = 24
+ *     24 - 5 = 19
+ *
+ * Three swallows, three lines, and every term is the number that was drawn on
+ * the thing the player touched. Before this pass the first line came out as
+ * `10 + 1 = 11`, because absorption saturated and a `4` at mass 10 was worth
+ * one; the third came out as `24 - 2 = 22`, because a void's damage was clamped
+ * to 11% of mass while its label was not.
+ *
+ * Deterministic on purpose. The soak below covers the run; this covers the
+ * sentence, and it is the one a child actually reads.
+ */
+test("the ribbon prints the founder's three lines, exactly", () => {
+  const world = new World(createStubHost({ seed: 44 }), specFor("mid"), 1010)
+  const swallow = (value: number, kind: number): void => {
+    // One thing in the water, right next to the player, and nothing else.
+    world.malive.fill(0)
+    world.ralive.fill(0)
+    world.mwall.fill(0)
+    world.moteCount = 0
+    world.rivalCount = 0
+    world.stingGrace = 0
+    world.mx[0] = world.px
+    world.my[0] = world.py
+    world.mvx[0] = 0
+    world.mvy[0] = 0
+    world.mval[0] = value
+    world.mr[0] = radiusForValue(value)
+    world.mkind[0] = kind
+    world.mflip[0] = 1
+    world.malive[0] = 1
+    world.moteCount = 1
+    const seq = world.eqSeq
+    for (let f = 0; f < 12 && world.eqSeq === seq; f++) {
+      world.aimX = world.px
+      world.aimY = world.py
+      world.step(1 / 60)
+    }
+    assert.notEqual(world.eqSeq, seq, `the ${value} was never touched`)
+  }
+
+  swallow(4, MK_FOOD)
+  assert.deepEqual([world.eqA, world.eqD, world.eqC], [10, 4, 14], `got ${world.eqA} + ${world.eqD} = ${world.eqC}`)
+  swallow(10, MK_FOOD)
+  assert.deepEqual([world.eqA, world.eqD, world.eqC], [14, 10, 24], `got ${world.eqA} + ${world.eqD} = ${world.eqC}`)
+  swallow(-5, MK_VOID)
+  assert.deepEqual([world.eqA, world.eqD, world.eqC], [24, -5, 19], `got ${world.eqA} − ${-world.eqD} = ${world.eqC}`)
+  assert.equal(world.mass, 19, `the ribbon says 19 and the simulation says ${world.mass}`)
+})
+
+/**
+ * …and the same claim over a long seeded run, asserted line by line rather than
+ * in shape: the ribbon's arithmetic must be IDENTICAL to the simulation's, not
+ * merely plausible against it.
+ *
+ * Two things are checked on every single change:
+ *
+ *   * the printed answer is the player's actual number — `eqC` is `mass`,
+ *     rounded, at the end of the frame that produced it, and `eqA + eqD` is
+ *     `eqC` exactly; and
+ *   * the printed CHANGE is the number that was drawn on the thing eaten. Each
+ *     absorb event is paired back to the specific mote index it came from (by
+ *     the position the event carries, which nothing rewrites once the mote is
+ *     dead) and the gain is compared against that mote's own `mval`.
+ *
+ * The pairing is what makes this a test of the arithmetic rather than of the
+ * bookkeeping. A saturating curve passes every internal-consistency check ever
+ * written — `10 + 1 = 11` is a perfectly true sentence — and fails this.
+ */
+test("the ribbon's arithmetic is the simulation's arithmetic, line for line", () => {
+  for (const seed of [1, 4242]) {
+    const world = new World(createStubHost({ seed }), specFor("mid"), seed * 7)
+    const preVal = new Int32Array(world.mval.length)
+    const preAlive = new Uint8Array(world.malive.length)
+    let seq = world.eqSeq
+    let lines = 0
+    let paired = 0
+    let tBefore = 0
+
+    fly(
+      world,
+      420,
+      0.6,
+      seed,
+      () => {
+        // Every numeral that left the water this frame, with the number it was
+        // wearing when the frame began. `maintain` refills a freed slot inside
+        // the same step, so "gone" has to mean reborn as well as dead.
+        const consumed: number[] = []
+        for (let i = 0; i < preAlive.length; i++) {
+          if (!preAlive[i]) continue
+          if (world.malive[i] && (world.mborn[i] as number) <= tBefore && world.mval[i] === preVal[i]) continue
+          consumed.push(preVal[i] as number)
+        }
+        for (let e = 0; e < world.eventLen; e++) {
+          const ev = world.events[e] as { kind: string; x: number; y: number; a: number }
+          if (ev.kind !== "absorb") continue
+          // Full coverage, one-to-one: the gain must be spent against a numeral
+          // that actually left, and no two absorbs may claim the same one.
+          const at = consumed.indexOf(ev.a)
+          assert.ok(
+            at >= 0,
+            `the arena grew by ${ev.a} and nothing wearing ${ev.a} left the water: [${consumed.join(",")}]`,
+          )
+          consumed.splice(at, 1)
+          paired++
+          // …and where the slot was not recycled, pin the absorb to the exact
+          // mote index by the position the event carries, which nothing
+          // rewrites once the mote is dead.
+          for (let i = 0; i < preAlive.length; i++) {
+            if (!preAlive[i] || world.malive[i]) continue
+            if (world.mx[i] !== ev.x || world.my[i] !== ev.y) continue
+            assert.equal(
+              ev.a,
+              preVal[i],
+              `the arena swallowed a numeral reading ${preVal[i]} and grew by ${ev.a}`,
+            )
+            break
+          }
+        }
+        if (world.eqSeq === seq) return
+        seq = world.eqSeq
+        lines++
+        assert.equal(
+          world.eqA + world.eqD,
+          world.eqC,
+          `the ribbon printed ${world.eqA} ${world.eqD < 0 ? "−" : "+"} ${Math.abs(world.eqD)} = ${world.eqC}`,
+        )
+        assert.equal(
+          world.eqC,
+          Math.round(world.mass),
+          `the ribbon answered ${world.eqC} while the player's own number was ${Math.round(world.mass)}`,
+        )
+      },
+      () => {
+        preVal.set(world.mval)
+        preAlive.set(world.malive)
+        tBefore = world.time
+      },
+    )
+
+    assert.ok(lines > 200, `only ${lines} equations in seven minutes — the ribbon is barely alive`)
+    assert.ok(paired > 300, `only ${paired} absorbs were traced back to a numeral — the pairing proved nothing`)
+  }
+})
+
+/**
+ * THE WALL RULE, which is what pays for exact absorption.
+ *
+ * A number born bigger than you is there to be read and avoided. It is not a
+ * deposit that matures into a free doubling the moment you grow past it — and
+ * with absorption exact, that is precisely what letting it flip would be. See
+ * WALL_RATE in world.ts: measured with the walls left flippable, a struggling
+ * run passed 100,000 inside the first minute.
+ */
+test("a wall is never food, and outgrowing one bursts it into crumbs", () => {
+  const world = new World(createStubHost({ seed: 61 }), specFor("mid"), 3003)
+  const place = (value: number, wall: number, dx: number): void => {
+    world.malive.fill(0)
+    world.mwall.fill(0)
+    world.moteCount = 0
+    world.mx[0] = world.px + dx
+    world.my[0] = world.py
+    world.mvx[0] = 0
+    world.mvy[0] = 0
+    world.mval[0] = value
+    world.mr[0] = radiusForValue(value)
+    world.mkind[0] = MK_FOOD
+    world.mflip[0] = wall ? 0 : 1
+    world.mwall[0] = wall
+    world.malive[0] = 1
+    world.moteCount = 1
+  }
+  const collide = (world as unknown as { collide(dt: number): void }).collide.bind(world)
+
+  // Sitting inside the player, worth half of it, and it may not be eaten. This
+  // is the guard in `collide`, exercised on its own: a wall can be outgrown
+  // MID-FRAME, several absorbs deep, and reach the collision test edible.
+  world.mass = 100
+  world.ralive.fill(0)
+  world.rivalCount = 0
+  place(50, 1, 0)
+  collide(1 / 60)
+  // It may sting — it is still a wall, and touching one costs you — but it may
+  // never PAY. Growing past a wall mid-frame is the one way one can reach the
+  // collision test looking edible.
+  assert.ok(world.mass <= 100, `a wall worth 50 was swallowed at mass 100 -> ${world.mass}`)
+
+  // …and the same mote, not marked a wall, IS eaten for exactly its number.
+  // Without this the assertion above passes for any reason at all.
+  world.mass = 100
+  world.stingGrace = 0
+  place(50, 0, 0)
+  collide(1 / 60)
+  assert.equal(world.mass, 150, `an ordinary 50 at mass 100 was worth ${world.mass - 100}`)
+
+  // Outgrow one and it comes apart: it is gone, it left crumbs on the food
+  // scale, and it paid nothing.
+  world.mass = 100
+  place(50, 1, 400)
+  const before = world.mass
+  world.aimX = world.px
+  world.aimY = world.py
+  world.step(1 / 60)
+  // Asserted on the whole field, not on slot 0: `maintain` tops the population
+  // back up inside the same step and hands the freed slot straight out again.
+  for (let i = 0; i < world.malive.length; i++) {
+    assert.ok(
+      !(world.malive[i] && world.mwall[i] && world.mval[i] === 50),
+      "an outgrown wall is still sitting there",
+    )
+  }
+  assert.equal(world.mass, before, `bursting a wall paid ${world.mass - before}`)
+  let shards = 0
+  let biggest = 0
+  for (let i = 0; i < world.malive.length; i++) {
+    if (!world.malive[i] || world.mkind[i] !== MK_SHED) continue
+    shards++
+    biggest = Math.max(biggest, world.mval[i] as number)
+  }
+  assert.ok(shards >= 4, `a burst wall left ${shards} crumbs`)
+  assert.ok(biggest < 50 * 0.25, `a crumb of ${biggest} carries a quarter of the wall — the doubling came back`)
+  assert.ok(
+    world.events.slice(0, world.eventLen).some((e) => (e as { kind: string }).kind === "flip"),
+    "the wall came apart in silence — the genre's best moment is not being played",
+  )
+})
+
+/**
+ * THE SPAWN TABLE, asserted directly rather than through a run.
+ *
+ * Every property here is load-bearing for exact absorption and every one of
+ * them is a coin-flip away from being invisible in a seeded soak, so they are
+ * read off `rollValue` itself, tens of thousands of draws at a time.
+ *
+ *   * a WALL is never below your mass — if it were it would be food, and food
+ *     worth all of you is the exponential this whole pass exists to remove;
+ *   * a PRIZE always is, or it is not a prize at all, just a wall that got
+ *     rounded up by `tidyValue`;
+ *   * a VOID never wears a number bigger than 11% of you, which is the mercy
+ *     that used to live on the damage and now has to live on the label, because
+ *     the label is what gets subtracted; and
+ *   * the prize is RATIONED, and the ration falls with mass. That last one is
+ *     the difference between a twenty-minute run finishing at 222,742 and at
+ *     5,745,335.
+ */
+test("the spawn table cannot hand out a wall you can eat, or a void that outweighs its number", () => {
+  const prizeFrac: Record<number, number> = {}
+  // 43,910 and 43,960 are not decoration. `tidyValue` rounds past a thousand to
+  // three significant figures, so at those masses the raw draw at the very edge
+  // of each band rounds ACROSS the player's own mass — a wall down to 43,900
+  // and a prize up to 44,000 — which is how a wall becomes edible and a prize
+  // becomes a wall. Round masses like 40,000 land exactly on the step and hide
+  // it. The draw count rises with mass because the prize ration falls with it,
+  // and a band nobody drew from is a band nobody tested.
+  for (const mass of [10, 40, 137, 1237, 43_910, 43_960]) {
+    const draws = mass > 1000 ? 900_000 : 40_000
+    const world = new World(createStubHost({ seed: 71 }), specFor("mid"), 9090)
+    // The opening band carries no voids at all, so the run is nudged past it
+    // first — otherwise the void assertions below are being skipped rather than
+    // passed. The depth is a ratchet, so setting the mass afterwards keeps it.
+    fly(world, 200, 0.5, 5)
+    assert.ok(world.voidRate > 0, "the field still has no voids in it — the void assertions are vacuous")
+    world.mass = mass
+    const roll = (world as unknown as { rollValue(): { v: number; kind: number; wall: number } }).rollValue.bind(world)
+    let voids = 0
+    let walls = 0
+    let prizes = 0
+    let food = 0
+    for (let n = 0; n < draws; n++) {
+      const { v, kind, wall } = roll()
+      if (kind === MK_VOID) {
+        voids++
+        assert.ok(v < 0, `a void wearing ${v} is not a loss`)
+        assert.ok(
+          -v <= Math.max(1, Math.round(mass * 0.11)),
+          `a void wearing ${-v} at mass ${mass} takes ${((-v / mass) * 100).toFixed(0)}% in one touch`,
+        )
+        continue
+      }
+      if (wall) {
+        walls++
+        assert.ok(v >= mass, `a wall wearing ${v} is edible at mass ${mass}`)
+        continue
+      }
+      assert.ok(v < mass, `an ordinary mote wearing ${v} is not edible at mass ${mass}`)
+      if (v > mass * 0.5) prizes++
+      else food++
+    }
+    assert.ok(voids > 0 && walls > 0 && food > 0, `mass ${mass}: ${voids} voids, ${walls} walls, ${food} crumbs`)
+    // The walls keep their full share at every size — the reading is the point
+    // and it may not thin out with the economy.
+    assert.ok(walls / draws > 0.09, `mass ${mass}: only ${walls} walls in ${draws} — the field has nothing to flee`)
+    // …and the prize never does, at any size.
+    assert.ok(prizes / draws <= 0.006, `mass ${mass}: ${prizes} free doublings in ${draws} draws`)
+    assert.ok(prizes > 0, `mass ${mass}: not one prize in ${draws} draws — the prize assertions are vacuous`)
+    prizeFrac[mass] = prizes / draws
+  }
+
+  // Rationed, and the ration FALLS — this is the anti-exponential, and it is
+  // the only place it is stated as a property rather than as a measured run.
+  assert.ok(
+    (prizeFrac[43_910] as number) < (prizeFrac[137] as number) * 0.25,
+    `the prize ration barely tapered: ${prizeFrac[137]} at mass 137, ${prizeFrac[43_910]} at 43,910`,
+  )
+  assert.ok(
+    (prizeFrac[1237] as number) < (prizeFrac[10] as number) * 0.6,
+    `the prize ration barely tapered: ${prizeFrac[10]} at mass 10, ${prizeFrac[1237]} at 1,237`,
+  )
+})
+
+/**
+ * A Resonance sphere is recycled from whatever mote happened to be nearest, and
+ * that mote may well have been a wall. If the flag comes with it, `stepMotes`
+ * sees a wall it has outgrown and BURSTS the answer out of the water in front
+ * of the child mid-question.
+ */
+test("a Resonance sphere is never still carrying a wall's flag", () => {
+  const world = new World(createStubHost({ seed: 23 }), specFor("mid"), 8123)
+  // Spheres are recycled through `freeMote`, which hands back a DEAD slot with
+  // whatever it was last carrying. Waiting for a run to happen to seat a sphere
+  // on a dead wall is waiting on a coin: every slot that is free at the moment
+  // the beat opens is poisoned here instead, which is the same state the game
+  // reaches on its own and reaches it every time.
+  let opened = 0
+  for (let f = 0; f < 60 * 300; f++) {
+    world.aimX = world.px
+    world.aimY = world.py
+    const res = world.resonance
+    if (!res.active) for (let i = 0; i < world.malive.length; i++) if (!world.malive[i]) world.mwall[i] = 1
+    world.step(1 / 60)
+    if (!res.active || res.phase < 1 || res.phase > 2) continue
+    opened++
+    for (let sl = 0; sl < 4; sl++) {
+      const i = res.spheres[sl] as number
+      assert.ok(i >= 0, "a Resonance opened without four spheres")
+      // Aliveness is the assertion that matters: a sphere carrying the flag is
+      // burst by `stepMotes` and the answer disappears out of the water in
+      // front of the child. The flag alone would only be read in the frames
+      // where the bug had not fired yet.
+      assert.equal(world.malive[i], 1, "an answer sphere vanished while the question was still open")
+      assert.equal(world.mwall[i], 0, "an answer sphere is flagged as a wall — it can burst mid-question")
+    }
+  }
+  assert.ok(opened > 60, `only ${opened} frames of open Resonance in five minutes — nothing was checked`)
 })
 
 /**

--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -473,11 +473,13 @@ function fly(
   seed: number,
   onFrame?: (f: number) => void,
   beforeFrame?: (f: number) => void,
+  surgeDuty = 0,
 ): void {
   const coin = new Rng(seed)
   let target = -1
   for (let f = 0; f < 60 * seconds; f++) {
     beforeFrame?.(f)
+    if (surgeDuty > 0) world.surging = (f / 60) % 1 < surgeDuty
     const res = world.resonance
     if (res.active && res.phase === 2) {
       if (target < 0) target = coin.f() < accuracy ? res.correctSlot : (res.correctSlot + 1 + coin.int(0, 2)) % 4
@@ -1075,8 +1077,11 @@ test("the spawn table cannot hand out a wall you can eat, or a void that outweig
       if (kind === MK_VOID) {
         voids++
         assert.ok(v < 0, `a void wearing ${v} is not a loss`)
+        // Stated as a bound, not re-derived from the constant: a test that
+        // recomputes `Math.round(mass * VOID_MAX_FRACTION)` passes for every
+        // value of VOID_MAX_FRACTION and pins nothing.
         assert.ok(
-          -v <= Math.max(1, Math.round(mass * 0.11)),
+          -v <= Math.max(1, mass * 0.12),
           `a void wearing ${-v} at mass ${mass} takes ${((-v / mass) * 100).toFixed(0)}% in one touch`,
         )
         continue
@@ -1087,7 +1092,11 @@ test("the spawn table cannot hand out a wall you can eat, or a void that outweig
         continue
       }
       assert.ok(v < mass, `an ordinary mote wearing ${v} is not edible at mass ${mass}`)
-      if (v > mass * 0.5) prizes++
+      // 0.85, not 0.5. The prize band is [0.90M, M-1] and the mid band is
+      // capped at 0.55M, so this discriminates the two whatever FOOD_A is —
+      // at 0.5 it only worked because today's FOOD_A leaves the mid band far
+      // below its own ceiling.
+      if (v >= mass * 0.85) prizes++
       else food++
     }
     assert.ok(voids > 0 && walls > 0 && food > 0, `mass ${mass}: ${voids} voids, ${walls} walls, ${food} crumbs`)
@@ -1146,6 +1155,155 @@ test("a Resonance sphere is never still carrying a wall's flag", () => {
     }
   }
   assert.ok(opened > 60, `only ${opened} frames of open Resonance in five minutes — nothing was checked`)
+})
+
+/**
+ * THE EXHAUST, and the hole this test exists to close.
+ *
+ * `surging` was never set to `true` anywhere in this file. Not in `fly`, not in
+ * the twenty-minute soak, not in the kill-hunting bot — every regression this
+ * suite has ever run flew a child who could not press the boost. So the largest
+ * term in the whole economy was untested, and the moment absorption went exact
+ * it became a mass printer: the trail used to lay down 26 motes a second worth
+ * 3.5% of the player each, against a burn of 11% a second, and the only thing
+ * that made that survivable was the saturation this pass deleted. Measured on
+ * the branch before the fix, holding surge one second in five: 42,287 at one
+ * minute, 28,074,058 at two, 4,268,470,964 at four, against 1,913 / 10,483 /
+ * 51,909 on main.
+ *
+ * The exhaust is a ledger now — a fixed share of the mass actually taken off
+ * you, and not one unit more — so the property is simple and total: **surging
+ * may never pay.** Turn round and hoover up every crumb of your own trail and
+ * you are still down on the deal.
+ */
+test("holding the surge always costs mass, even if you eat your own trail", () => {
+  // Head straight back down the trail every other half-second, which is the
+  // hoover: the exhaust is ejected backwards at 150 u/s into a pull field that
+  // reaches 3.4 radii and pulls at up to 260, so turning round collects it.
+  const hoover = (surgeDuty: number, seconds: number): World => {
+    const world = new World(createStubHost({ seed: 33 }), specFor("mid"), 777)
+    let seq = world.eqSeq
+    for (let f = 0; f < 60 * seconds; f++) {
+      const t = f / 60
+      world.surging = (t % 1) < surgeDuty
+      const back = Math.floor(t * 2) % 2 === 1
+      const sp = Math.hypot(world.pvx, world.pvy) || 1
+      world.aimX = world.px + (back ? -world.pvx / sp : world.pvx / sp) * 900 + Math.cos(t) * 40
+      world.aimY = world.py + (back ? -world.pvy / sp : world.pvy / sp) * 900 + Math.sin(t) * 40
+      world.step(1 / 60)
+      assert.ok(Number.isFinite(world.mass), `mass went non-finite at frame ${f}`)
+      // The ribbon has to survive the one thing that moves mass by a fraction
+      // sixty times a second. `stepPlayer` burns before `collide` notes, so the
+      // printed answer is still the player's number at the end of the frame —
+      // asserted rather than assumed, because nothing else in this file ever
+      // had the surge on.
+      if (world.eqSeq !== seq) {
+        seq = world.eqSeq
+        assert.equal(world.eqA + world.eqD, world.eqC, "the ribbon printed a false sum under a surge")
+        assert.equal(
+          world.eqC,
+          Math.round(world.mass),
+          `the ribbon answered ${world.eqC} while the surging player's number was ${Math.round(world.mass)}`,
+        )
+      }
+    }
+    return world
+  }
+
+  // A player who never answers and never eats anything but their own exhaust
+  // must go DOWN. This is the printer, stated as an assertion.
+  const burned = hoover(1, 120)
+  assert.ok(
+    burned.mass < 10,
+    `two minutes of held surge left the player at ${Math.round(burned.mass)} — the exhaust is paying for itself`,
+  )
+  assert.ok(burned.mass >= FLOOR_MASS, "…but it may never take a child below the floor")
+
+  // …and the same at a realistic duty cycle, against the same player not
+  // surging at all. Without this the assertion above passes for a game in which
+  // nobody grows, and the bot above eats a little of the ordinary field too.
+  const idle = hoover(0, 120)
+  assert.ok(
+    burned.mass < idle.mass,
+    `surging the whole time (${Math.round(burned.mass)}) beat never surging (${Math.round(idle.mass)})`,
+  )
+
+  // The trail is real and it is on the field: a surge lays down numerals a
+  // child can see and a rival can steal, which is the whole point of paying in
+  // mass rather than in a bar.
+  const world = new World(createStubHost({ seed: 34 }), specFor("mid"), 90210)
+  world.mass = 4000
+  let shed = 0
+  for (let f = 0; f < 60; f++) {
+    world.surging = true
+    world.aimX = world.px + 2000
+    world.aimY = world.py
+    world.step(1 / 60)
+    for (let e = 0; e < world.eventLen; e++) void world.events[e]
+  }
+  for (let i = 0; i < world.malive.length; i++) if (world.malive[i] && world.mkind[i] === MK_SHED) shed++
+  assert.ok(shed >= 6, `a second of surge at mass 4,000 laid down only ${shed} numerals`)
+
+  // The ledger, measured against the burn, in isolation. The field is wiped
+  // every frame so that nothing but the exhaust can be MK_SHED and nothing but
+  // the burn can move the player's mass; every free slot is poisoned with a
+  // dead wall's flag, because `freeMote` hands those straight back and a crumb
+  // that reads as a wall is burst by `stepMotes` the same frame — or, when the
+  // burst queue is full, stings the player with their own exhaust.
+  const solo = new World(createStubHost({ seed: 36 }), specFor("mid"), 61616)
+  solo.mass = 20_000
+  solo.ralive.fill(0)
+  solo.rivalCount = 0
+  const before = solo.mass
+  let laid = 0
+  let bursts = 0
+  for (let f = 0; f < 240; f++) {
+    for (let i = 0; i < solo.malive.length; i++) {
+      solo.malive[i] = 0
+      solo.mwall[i] = 1
+    }
+    solo.moteCount = 0
+    solo.surging = true
+    solo.aimX = solo.px + 60_000
+    solo.aimY = solo.py
+    solo.step(1 / 60)
+    for (let e = 0; e < solo.eventLen; e++) if ((solo.events[e] as { kind: string }).kind === "flip") bursts++
+    for (let i = 0; i < solo.malive.length; i++) {
+      if (!solo.malive[i] || solo.mkind[i] !== MK_SHED) continue
+      assert.equal(solo.mwall[i], 0, "a crumb of exhaust is flagged as a wall")
+      laid += solo.mval[i] as number
+    }
+  }
+  const burnt = before - solo.mass
+  assert.equal(bursts, 0, `${bursts} crumbs of exhaust were burst as walls the frame they were laid`)
+  assert.ok(laid > burnt * 0.2, `four seconds of surge burned ${Math.round(burnt)} and laid down only ${laid}`)
+  assert.ok(
+    laid < burnt * 0.85,
+    `the trail (${laid}) is worth as much as the surge cost (${Math.round(burnt)}) — boosting is free`,
+  )
+
+  // Finally, an ordinary player who boosts: the ribbon must stay true through
+  // the one thing that moves mass by a fraction sixty times a second, and the
+  // climb must stay inside the same band a player who never boosts gets.
+  const boosting = new World(createStubHost({ seed: 35 }), specFor("mid"), 5150)
+  let seq = boosting.eqSeq
+  let lines = 0
+  fly(boosting, 300, 0.6, 12, () => {
+    if (boosting.eqSeq === seq) return
+    seq = boosting.eqSeq
+    lines++
+    assert.equal(boosting.eqA + boosting.eqD, boosting.eqC, "the ribbon printed a false sum under a surge")
+    assert.equal(
+      boosting.eqC,
+      Math.round(boosting.mass),
+      `the ribbon answered ${boosting.eqC} while the surging player's number was ${Math.round(boosting.mass)}`,
+    )
+  }, undefined, 0.4)
+  assert.ok(lines > 150, `only ${lines} equations in five minutes of boosting — nothing was checked`)
+  assert.ok(
+    boosting.mass < 40_000,
+    `five minutes of a boosting player reached ${Math.round(boosting.mass)} — the trail is paying for itself`,
+  )
 })
 
 /**

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -182,90 +182,175 @@ const GRID_COLS = 62
  *
  * Both numbers matter and they do different jobs.
  *
- *   FOOD_A 0.62 -> 0.30 scales the whole curve down. Because the field's own
- *   size scales with the player, the eat RATE goes as M^-0.35 and the gain per
- *   mote as M^FOOD_B, so dM/dt is proportional to M^(FOOD_B - 0.35) and the
- *   solution is a power of t. Halving A slows the clock on the whole climb.
+ *   FOOD_A scales the whole curve down. Because the field's own size scales
+ *   with the player, the eat RATE goes as M^-0.35 and the gain per mote as
+ *   M^FOOD_B, so dM/dt is proportional to M^(FOOD_B - 0.35) and the solution is
+ *   a power of t. A slows the clock on the whole climb without touching shape.
  *
- *   FOOD_B 0.60 -> 0.46 is the shape, and it is the one that decides whether
- *   the twelfth minute is still a maths game. At 0.60, dM/dt goes as M^0.25 and
- *   mass runs as t^(4/3) — super-linear, so the run accelerates away from the
- *   curriculum forever. At 0.46 the exponent is 0.11 and mass runs as t^1.12:
- *   very nearly linear, which is a climb a child can stay inside.
+ *   FOOD_B is the shape, and it is the one that decides whether the twelfth
+ *   minute is still a maths game. At 0.60, dM/dt goes as M^0.25 and mass runs
+ *   as t^(4/3) — super-linear, so the run accelerates away from the curriculum
+ *   forever. At 0.50 the exponent is 0.15 and mass runs as t^1.18: very nearly
+ *   linear, which is a climb a child can stay inside.
  *
- * Measured after: 2 digits for the first half-minute, 3 digits for the next
- * several minutes, 4 digits past ten. See `sim.test.ts`, which asserts the
- * bands rather than the numbers.
+ * A moved 0.62 -> 0.40 when the curve was first refitted and 0.40 -> 0.16 when
+ * absorption was made exact, and the second cut is not a second opinion about
+ * pace: a mote used to be worth `v / (1 + 6v/M)` and is now worth `v`, so the
+ * same table of numbers feeds a player two to six times faster than it did.
+ * The constant fell to keep the CURVE where it already was. Measured, mid tier,
+ * four seeds, median, at 15s / 60s / 2min / 5min / 10min / 20min:
+ *
+ *   struggling      before  47 / 300 / 752 / 1,294 / 1,261 / 1,241
+ *                   after   65 / 352 / 441 /   683 / 1,700 / 1,853
+ *   answering well  before  47 / 1,044 / 11,422 / 42,909 / 130,137 / 258,477
+ *                   after   65 /   742 /  2,703 / 28,709 / 103,960 / 255,153
+ *
+ * — the same bands, in the same minutes, with the arithmetic on screen true.
+ * See `sim.test.ts`, which asserts the bands rather than the numbers.
  */
-const FOOD_A = 0.40
+const FOOD_A = 0.16
 const FOOD_B = 0.50
 
 /**
- * How much of a mote actually becomes you.
+ * How much of a mote becomes you: ALL of it. Eat a `4`, gain exactly 4.
  *
- * A mote's printed number is a SIZE — the thing you compare against your own
- * size, which is the entire mathematics of this game and is exact. It is not
- * an addend: a fish that swallows a fish nearly its own size does not double.
- * Absorption saturates, and the cap `mass / (1 + ABSORB_K)` means no single
- * mote can ever be worth more than a seventh of you.
+ * This function used to saturate. A mote's number was treated as a SIZE and not
+ * as an addend — a fish that swallows a fish nearly its own size does not double
+ * — so swallowing a `4` at mass 10 was worth `+1`, and the running equation
+ * printed `10 + 1 = 11` under a numeral a child had just watched read `4`. The
+ * founder's ruling, and it is the right one twice over:
  *
- * Without this, the sliver of the near-tie band that sits just below your mass
- * is a free doubling, a child finds it in ninety seconds, and a twenty-minute
- * climb becomes an exponential explosion. Measured: it did, every run.
+ *   "it would seem more intuitive to me to absorb the exact number? ... is that
+ *    not how most games like this work?"
+ *
+ * In the genre you absorb what you ate. And in THIS product a maths game may not
+ * put an equation on screen that is not the one it performed: `10 + 4` has to
+ * be `14`, and the only way to make the ribbon true is to make the simulation
+ * do what the ribbon says. Absorption is now the identity, forever, and nothing
+ * may be added to it.
+ *
+ * The saturation was not decoration — it was the only thing holding the economy
+ * down, because it is the near-tie mote (worth ~M) that compounds. That job has
+ * moved to `NEAR_PRIZE` below, where it belongs: not "you get less than you
+ * ate", but "there is less of it to eat". Metering the SUPPLY is honest;
+ * metering the ARITHMETIC is not.
+ *
+ * `Math.round` is defensive only. `mval` is an Int32Array, so every value that
+ * reaches here is already an integer, and it must stay one: the ribbon's terms
+ * are integers and this is the number that lands between them.
  */
-const ABSORB_K = 6
-
-/**
- * …and the mass at which that saturation itself starts to tighten.
- *
- * A constant K makes every near-tie worth a FIXED FRACTION of you, and a fixed
- * fraction repeated is an exponential. Measured with a bot that simply always
- * chased the largest thing it could still swallow — which is the obvious
- * strategy in this genre and a child will find it — mass went 273 → 3,330,895
- * → 1,301,388,804 across three hundred seconds. That is not a balance problem
- * so much as a *legibility* problem: the entire premise of the game is telling
- * 3,418 from 3,481, and it cannot survive the player's own core reading
- * 1,301,388,804.
- *
- * So K grows as sqrt(mass) past this point, which turns dM/dt ∝ M into
- * dM/dt ∝ sqrt(M): polynomial, not exponential, and a twenty-minute run of the
- * strongest possible play now finishes in five or six digits instead of ten.
- * Below SOFT it is within a hair of the old curve, so the first two minutes —
- * the part that has to feel like an explosion — are untouched.
- */
-const ABSORB_SOFT = 900
-
-export function absorbGain(value: number, mass: number): number {
+export function absorbGain(value: number): number {
   if (value <= 0) return 0
-  const k = ABSORB_K * Math.sqrt(1 + Math.max(0, mass) / ABSORB_SOFT)
-  return Math.max(1, Math.round(value / (1 + (k * value) / Math.max(1, mass))))
+  return Math.round(value)
 }
 
 /**
- * Swallowing a rival is the payoff moment of the whole genre, so it saturates
- * far more generously: taking down something your own size is worth about a
- * third of you, at every size, forever. It still saturates, because uncapped it
- * is a doubling, and a doubling that repeats is the same explosion by another
- * route — measured at 216 kills and eight orders of magnitude in a twenty-
- * minute run.
+ * PLACEHOLDER
  *
- * It deliberately does NOT get the sqrt(mass) tightening ABSORB_SOFT applies,
- * and the asymmetry is the point. The near-tie *mote* is an exploit because the
- * game manufactures a continuous supply of them: about one mote in seven is
- * drawn from a band straddling your own mass, on purpose, because that is where
- * the place-value comparison lives. A *rival* is not a supply. There are at most
- * MAX_RIVALS of them, they respawn on a timer, and one is only edible below
- * `mass / 1.06`, so kills are rate-limited by the world rather than by the
- * curve. Measured with a bot that hunts nothing but the largest legally edible
- * rival for twenty minutes: flat K peaks at 34,456 and a tightened K at 11,442
- * — both five digits, neither an explosion. The tightening bought no safety and
- * cost the genre its payoff moment, so it is not taken.
+ * About one mote in twelve is drawn from a band straddling your own mass,
+ * because telling 3,418 from 3,481 at speed IS the declared skill and the band
+ * is where that reading happens. Most of it is a wall. The sliver below your
+ * mass is the prize, and a prize worth ~M added exactly is a DOUBLING: repeat
+ * it and mass is exponential in the number of motes eaten, with no polynomial
+ * anywhere to save it. Measured, with absorption made exact and this band left
+ * alone: 27,494,014 at two minutes against 12,738 before, and 189,893,983 by
+ * twenty. Eight digits on the player's own core ends the game the pack is for.
+ *
+ * So the prize gets rarer exactly as fast as it gets bigger. The edible sliver
+ * is `NEAR_PRIZE / sqrt(mass)` of the band, which makes its contribution to
+ * growth `p * M ∝ sqrt(M)` — the same shape as the crumb economy, which is what
+ * keeps the whole curve polynomial. At mass 10 roughly a quarter of the near-tie
+ * band is edible; at mass 10,000, one in four hundred.
+ *
+ * What does NOT change is how often the band appears. The READING is the
+ * pedagogy and it keeps its full frequency; what tapers is how often the answer
+ * to "can I eat this?" is yes. That asymmetry is also the honest picture of the
+ * genre: the bigger you are, the less there is anywhere near your size that is
+ * beneath you.
  */
-const DEVOUR_K = 2.6
+const FOOD_MIN = 1
+const PRIZE_RATE = 0.8
+const PRIZE_RATE_EXP = 0.85
+const PRIZE_RATE_MAX = 0.005
 
-export function devourGain(rivalMass: number, mass: number): number {
+/**
+ * THE WALLS, and why they are not a bank account.
+ *
+ * One mote in seven is drawn at or above your own mass. That band is where the
+ * declared skill lives — telling 3,418 from 3,481 at speed, deciding in half a
+ * second whether the thing in front of you is beneath you — and a growth arena
+ * with nothing in it to flee is a screensaver. So it keeps its full frequency,
+ * at every size, forever.
+ *
+ * What it does NOT keep is the right to become a meal. A wall is only a prize
+ * with a delay on it: grow five per cent and the 1.05x you swam around thirty
+ * seconds ago is a hundred-per-cent breakfast, free, at no risk, available
+ * continuously because the field manufactures walls forever. Under the old
+ * saturating curve that was worth a seventh of you and nobody noticed. With
+ * absorption exact it is the single largest term in the economy and it is a
+ * repeated doubling — it is most of the 100,000-in-sixty-seconds measured
+ * above.
+ *
+ * So a wall stays a wall for as long as it lives, and when you finally outgrow
+ * it, it comes apart: it bursts into crumbs on the ordinary food scale, which
+ * you can then eat, each one worth exactly what it says. The genre's best
+ * moment — watching the world turn into food underneath you — is kept, and it
+ * is kept as an event rather than as a jackpot.
+ */
+const WALL_RATE = 0.14
+/** Of the walls, how many are the near-tie rather than the far threat. */
+const WALL_NEAR_SHARE = 0.57
+/** Crumbs a burst wall leaves behind, and the food scales each is worth. */
+const WALL_SHARDS = 4
+const WALL_SHARD_SCALE = 0.8
+
+/**
+ * The most a void may be worth, as a fraction of your mass.
+ *
+ * This used to be a clamp on the DAMAGE — `min(mass * 0.11, |v|)` — which meant
+ * a void wearing `−40` could take 11 off you, and the ribbon then printed
+ * `100 − 11 = 89` under a numeral that plainly said 40. Same lie as the mote,
+ * so it gets the same fix: the cap moves onto the LABEL, the loss is exactly
+ * the label, and the hit a child actually takes is unchanged to the unit.
+ */
+const VOID_MAX_FRACTION = 0.11
+
+/**
+ * Swallowing a rival is worth exactly the rival, and this was the one call in
+ * the pass that could honestly have gone either way.
+ *
+ * It used to saturate at `DEVOUR_K = 2.6` — something your own size was worth
+ * about a third of you — and the argument for keeping that was that a rival is
+ * "a creature you burst", not a labelled quantity you add. That argument does
+ * not survive looking at the screen. `gfx.ts` draws `Math.round(rmass[k])` on
+ * every core big enough to carry a numeral, so a rival IS a number in the
+ * water, read the same way and against the same law of radius; eat the one
+ * wearing `300` at mass 400 and the old code put `400 + 84 = 484` in the ribbon
+ * under a numeral that plainly said 300. That is the founder's complaint word
+ * for word, applied to a core instead of a mote, and there is no principled
+ * place to stop it at the mote.
+ *
+ * What made it *safe* to make exact is the thing the old comment already had
+ * right, and it is the same thing that governs the mote economy after this
+ * pass: a rival is a rationed supply and a mote is not. There are at most
+ * MAX_RIVALS of them, they respawn on a timer, and one is only edible below
+ * `mass / 1.06` — so a kill can never more than 1.94x you and the world, not
+ * an arithmetic fudge, decides how often you get one.
+ *
+ * Measured against the bot that hunts nothing but the largest legally edible
+ * rival for twenty minutes, answering every question correctly, over three
+ * seeds: saturating peaked at 97,715 / 139,611 / 156,320; exact peaks at
+ * 125,210 / 701,405 / 230,764. Six digits at the very top of the strongest
+ * possible play, which is the legibility contract this file has always held —
+ * and 1.3x to 5x the old numbers, which is what an honest doubling costs.
+ *
+ * Rival-versus-rival is now conserving: the winner becomes exactly the two of
+ * them. That is also the honest picture, and the size recycler still caps any
+ * core at RIVAL_MAX_RATIO of the player, so it cannot fill the screen.
+ */
+export function devourGain(rivalMass: number): number {
   if (rivalMass <= 0) return 0
-  return Math.max(1, Math.round(rivalMass / (1 + (DEVOUR_K * rivalMass) / Math.max(1, mass))))
+  return Math.round(rivalMass)
 }
 const MAX_RIVALS = 26
 const MAX_EVENTS = 96
@@ -515,6 +600,12 @@ export class World {
   readonly mphase = new Float32Array(MAX_MOTES)
   /** 0 = threat, 1 = edible. Animated, so the flip is a visible event. */
   readonly mflip = new Float32Array(MAX_MOTES)
+  /**
+   * Born at or above the player's mass, and therefore never food. See WALL_RATE.
+   * A wall keeps its number and its menace for as long as it lives; outgrowing
+   * one bursts it into crumbs rather than handing you a free doubling.
+   */
+  readonly mwall = new Uint8Array(MAX_MOTES)
   readonly mborn = new Float32Array(MAX_MOTES)
   moteCount = 0
 
@@ -891,13 +982,20 @@ export class World {
    * It turns eating numbers into arithmetic that is visible and reviewable
    * instead of implicit.
    *
-   * **It shows the TRUE change, and that is not always the number printed on
-   * the thing you ate.** A mote's label is a SIZE — the quantity you compare
-   * against your own, which is the whole mathematics of this game and is exact
-   * — and absorption saturates, so swallowing a `4` at mass 10 is worth +1, not
-   * +4. A ribbon reading "10 + 4 = 14" would print a sum the game did not
-   * perform, and a maths product may not do that at any price. So it prints
-   * "10 + 1 = 11".
+   * **It shows the TRUE change, and the true change is now the number printed
+   * on the thing you ate.** This comment used to say the opposite, and it was
+   * right about the rule and wrong about the fix: absorption saturated, so a
+   * `4` at mass 10 was worth +1, and the ribbon printed "10 + 1 = 11" — a true
+   * sentence about a game that had done something a child could not see. The
+   * founder's ruling reversed it. `absorbGain` is the identity, `devourGain` is
+   * the identity, a void costs exactly the number it wears, and the ribbon now
+   * reads "10 + 4 = 14" because that is what happened.
+   *
+   * This function still rounds, because mass is a float and the ribbon's terms
+   * are integers — the Resonance reward and the rupture are the only two things
+   * left that move mass by a non-integer. Both ends are rounded, the middle is
+   * DERIVED, and `sim.test.ts` walks a seeded run pairing every absorb back to
+   * the numeral it came from.
    *
    * Both ends are rounded and the middle is derived, never the other way round,
    * so `eqA + eqD === eqC` holds exactly however the floats fell. A change that
@@ -928,6 +1026,7 @@ export class World {
     this.moteCount = 0
     this.rivalCount = 0
     this.malive.fill(0)
+    this.mwall.fill(0)
     this.ralive.fill(0)
     this.resonance.active = false
     this.resonance.phase = 0
@@ -1039,46 +1138,103 @@ export class World {
    * cent of a 340-mote field turned APEX into forty overlapping five-digit
    * numbers, which is not tension, it is noise. Ten per cent reads.
    */
-  private rollValue(): { v: number; kind: number } {
+  private rollValue(): { v: number; kind: number; wall: number } {
     const M = this.mass
     const r = this.rng
+    // The climb is metered by how much food the water carries, NOT by handing a
+    // child less than the number they ate. `growth` used to multiply the GAIN,
+    // which is the one thing in this file that may not be scaled by anything:
+    // it made `10 + 4 = 12` on top of the saturation's `10 + 4 = 11`. It now
+    // scales the crumb SCALE and the near-tie prize rate instead, which is the
+    // same brake on the same curve and does exactly what the old comment said
+    // it was for — a struggling child stays in two and three figures — while
+    // leaving every printed number exact.
+    const g = this.growth
     if (r.chance(this.voidRate)) {
-      const mag = Math.max(2, tidyValue(FOOD_A * Math.pow(M, FOOD_B) * r.range(1.0, 3.0)))
-      return { v: -mag, kind: MK_VOID }
+      // A void costs EXACTLY the number it wears; see the sting in `collide`.
+      // So the label carries the mercy that the loss used to: it is capped at
+      // the same 11% of your mass the damage was clamped to, which leaves the
+      // hit identical and makes `24 − 5 = 19` a sentence the game can print.
+      const mag = Math.min(
+        Math.max(1, Math.round(M * VOID_MAX_FRACTION)),
+        Math.max(2, tidyValue(FOOD_A * Math.pow(M, FOOD_B) * r.range(1.0, 3.0))),
+      )
+      return { v: -mag, kind: MK_VOID, wall: 0 }
     }
-    const scale = Math.max(2, FOOD_A * Math.pow(M, FOOD_B))
-    const roll = r.f()
-    if (roll < 0.62) {
+    // THE PRIZE. A number just under your own, swallowed whole, worth all of
+    // you — the bravest thing in the game and now, with absorption exact, a
+    // literal doubling. It is rationed; see PRIZE_RATE.
+    if (r.chance(this.prizeRate)) {
+      const hi = Math.max(1, Math.round(M) - 1)
+      const lo = Math.max(1, Math.min(hi, Math.round(M * 0.90)))
+      // Tidied DOWN, never up. `tidyValue` rounds to three significant figures,
+      // and rounding 3,996 up to 4,000 at mass 4,000 would turn the prize into
+      // the wall it was drawn NOT to be.
+      return { v: Math.min(hi, tidyValue(r.int(lo, hi))), kind: MK_FOOD, wall: 0 }
+    }
+
+    // THE WALLS. Everything at or above your own mass. Full frequency, because
+    // this is where the reading is — 3,418 against 3,481 — and a field with
+    // nothing in it to flee is not this game. They are never food; see `mwall`.
+    if (r.chance(WALL_RATE)) {
+      if (r.f() < WALL_NEAR_SHARE) {
+        const lo = Math.max(2, Math.round(M) + 1)
+        const hi = Math.max(lo + 2, Math.round(M * 1.32))
+        return { v: Math.max(lo, tidyValue(r.int(lo, hi))), kind: MK_FOOD, wall: 1 }
+      }
+      const lo = Math.max(2, Math.round(M * 1.5))
+      const hi = Math.max(lo + 2, Math.round(M * 3.1))
+      return { v: Math.max(lo, tidyValue(r.int(lo, hi))), kind: MK_FOOD, wall: 1 }
+    }
+
+    const scale = Math.max(FOOD_MIN, FOOD_A * Math.pow(M, FOOD_B) * g)
+    if (r.f() < 0.72) {
       // Crumbs — where almost all of your food comes from. Their value grows
       // with the square-ish root of your mass, so a crumb is a fifth of you at
       // the start and a rounding error when you are enormous. That single
       // choice is what makes the climb last.
-      return { v: tidyValue(r.int(1, Math.max(2, Math.round(scale)))), kind: MK_FOOD }
+      return { v: tidyValue(r.int(1, Math.max(1, Math.round(scale)))), kind: MK_FOOD, wall: 0 }
     }
-    if (roll < 0.86) {
-      const lo = Math.max(1, Math.round(scale * 0.8))
-      const hi = Math.max(lo + 1, Math.round(scale * 2.6))
-      return { v: tidyValue(r.int(lo, Math.min(hi, Math.max(2, Math.round(M * 0.55))))), kind: MK_FOOD }
-    }
-    if (roll < 0.94) {
-      // The near-tie band, deliberately skewed *above* you. Most of it is a
-      // wall; the sliver below your mass is worth nearly doubling, and taking
-      // it is the bravest thing in the game. It has to be rare or it is the
-      // only thing anyone does.
-      const lo = Math.max(1, Math.round(M * 0.95))
-      const hi = Math.max(lo + 2, Math.round(M * 1.32))
-      return { v: tidyValue(r.int(lo, hi)), kind: MK_FOOD }
-    }
-    const lo = Math.max(2, Math.round(M * 1.5))
-    const hi = Math.max(lo + 2, Math.round(M * 3.1))
-    return { v: tidyValue(r.int(lo, hi)), kind: MK_FOOD }
+    const lo = Math.max(1, Math.round(scale * 0.8))
+    const hi = Math.max(lo + 1, Math.round(scale * 2.6))
+    return { v: tidyValue(r.int(lo, Math.min(hi, Math.max(2, Math.round(M * 0.55))))), kind: MK_FOOD, wall: 0 }
+  }
+
+  /**
+   * How often the water offers a number just under your own.
+   *
+   * This one rate is what makes exact absorption survivable, and it replaces
+   * the saturation that used to do the same job by lying about arithmetic.
+   *
+   * A prize is worth ALL OF YOU: swallow one and you double, exactly, and the
+   * ribbon prints the doubling. Repeat that at a fixed frequency and mass is
+   * exponential in the number of motes eaten, with no polynomial anywhere to
+   * catch it. Measured, with absorption made exact and the old flat 8% band
+   * left alone: a struggling run passed 100,000 inside the first minute and a
+   * well-answered one reached 27 million by the second — against 300 and
+   * 11,422 before. Eight digits on the player's own core is the end of the
+   * product the pack exists for.
+   *
+   * So the prize gets rarer exactly as fast as it gets bigger. Its contribution
+   * to growth is `rate * M`; the crumb economy's goes as `sqrt(M)`; holding the
+   * ratio fixed at every size — which is what "the same curve" actually means —
+   * needs `rate ∝ M^-0.85` once the eat rate's own `M^-0.35` is folded in. The
+   * ceiling is what keeps the opening explosive: for the first half-minute the
+   * cap binds and doubling is a thing that happens to you often.
+   *
+   * It is scaled by `growth`, so a child who is struggling meets fewer of them.
+   * That is the same brake the old code applied by shrinking the gain, moved
+   * onto the supply, where it does not have to lie to work.
+   */
+  private get prizeRate(): number {
+    return Math.min(PRIZE_RATE_MAX, (PRIZE_RATE * this.growth) / Math.pow(Math.max(1, this.mass), PRIZE_RATE_EXP))
   }
 
   private spawnMote(anywhere: boolean): number {
     const i = this.freeMote()
     if (i < 0) return -1
     const r = this.rng
-    const { v, kind } = this.rollValue()
+    const { v, kind, wall } = this.rollValue()
     let x: number
     let y: number
     if (anywhere) {
@@ -1128,7 +1284,8 @@ export class World {
     this.mkind[i] = kind
     this.malive[i] = 1
     this.mphase[i] = r.range(0, Math.PI * 2)
-    this.mflip[i] = kind === MK_VOID ? 0 : Math.abs(v) < this.mass ? 1 : 0
+    this.mwall[i] = wall
+    this.mflip[i] = kind === MK_VOID || wall ? 0 : Math.abs(v) < this.mass ? 1 : 0
     this.mborn[i] = this.time
     this.moteCount++
     return i
@@ -1151,6 +1308,7 @@ export class World {
       this.mr[i] = radiusForValue(per)
       this.mkind[i] = kind
       this.malive[i] = 1
+      this.mwall[i] = 0
       this.mphase[i] = this.rng.range(0, Math.PI * 2)
       this.mflip[i] = per < this.mass ? 1 : 0
       this.mborn[i] = this.time
@@ -1175,8 +1333,9 @@ export class World {
     let m: number
     // The plankton tier matters twice over. It is the fantasy — once you are
     // the board, most of the board is beneath your notice — and it is the brake
-    // on the kill economy, because absorption saturates and something a
-    // twentieth your size is worth a twentieth of you however many you eat.
+    // on the kill economy: a kill is worth exactly the rival now, so a quarter
+    // of every board being worth a twentieth of you is what stops "hunt the
+    // easiest thing on screen" being the whole game.
     if (roll < 0.26) m = Math.max(4, this.mass * r.range(0.03, 0.20))
     else if (roll < 0.48) m = Math.max(4, this.mass * r.range(0.30, 0.70))
     else if (roll < 0.78) m = this.mass * r.range(0.80, 1.18)
@@ -1434,7 +1593,19 @@ export class World {
       // The flip. When you grow past a mote it stops being a threat, and that
       // conversion is animated rather than swapped, because watching the world
       // turn into food is the reward the whole genre is built on.
-      if (this.mkind[i] !== MK_VOID && this.mkind[i] !== MK_ANSWER) {
+      //
+      // A WALL does not flip — it BURSTS. See WALL_RATE: a number born above
+      // you is not a deposit you collect later at a hundred per cent interest,
+      // and with absorption exact that is precisely what flipping one would be.
+      // Outgrow it and it comes apart into crumbs on the ordinary food scale,
+      // which is the same moment with the same sound and an economy behind it.
+      // Queued rather than burst in place, because bursting allocates motes and
+      // `freeMote` may hand back an index this loop has not reached yet.
+      if (this.mwall[i]) {
+        if (Math.abs(this.mval[i] as number) < M && this.burstLen < this.burstQ.length) {
+          this.burstQ[this.burstLen++] = i
+        }
+      } else if (this.mkind[i] !== MK_VOID && this.mkind[i] !== MK_ANSWER) {
         const want = Math.abs(this.mval[i] as number) < M ? 1 : 0
         const cur = this.mflip[i] as number
         if (want === 1 && cur < 0.5) {
@@ -1443,7 +1614,28 @@ export class World {
         this.mflip[i] = cur + (want - cur) * Math.min(1, dt * 7)
       }
     }
+
+    for (let q = 0; q < this.burstLen; q++) {
+      const i = this.burstQ[q] as number
+      if (!this.malive[i] || !this.mwall[i]) continue
+      const x = this.mx[i] as number
+      const y = this.my[i] as number
+      this.emit("flip", x, y, this.mr[i] as number, this.mval[i] as number)
+      this.malive[i] = 0
+      this.mwall[i] = 0
+      this.moteCount--
+      // On the FOOD scale, not on the wall's own. The wall's number was a size
+      // to be read, never an addend, and shards that carried a share of it would
+      // put the doubling straight back into the economy through the side door.
+      const scale = Math.max(FOOD_MIN, FOOD_A * Math.pow(M, FOOD_B) * this.growth)
+      this.scatter(x, y, Math.round(scale * WALL_SHARD_SCALE * WALL_SHARDS), WALL_SHARDS, 130, MK_SHED)
+    }
+    this.burstLen = 0
   }
+
+  /** Walls outgrown this frame, waiting to come apart. Preallocated; see above. */
+  private readonly burstQ = new Int32Array(24)
+  private burstLen = 0
 
   private stepRivals(dt: number): void {
     const frame = (this.time * 60) | 0
@@ -1727,7 +1919,10 @@ export class World {
       if (v < 0) {
         if (d > pr + mr * 0.2) return
         if (this.stingGrace > 0) return
-        const loss = this.damage(Math.min(this.mass * 0.11, Math.abs(v)))
+        // Exactly the number it wears. The cap that used to live here now lives
+        // on the label (VOID_MAX_FRACTION), so this is the same hit and a true
+        // sentence instead of a false one.
+        const loss = this.damage(Math.abs(v))
         this.combo = 0
         this.malive[i] = 0
         this.moteCount--
@@ -1739,11 +1934,23 @@ export class World {
         return
       }
 
-      if (v < this.mass) {
+      // `!this.mwall[i]` is load-bearing in both directions. A wall you have
+      // just outgrown is bursting this frame but has not burst yet — mass can
+      // rise mid-`collide`, several absorbs deep — and without the guard it
+      // would be swallowed for its whole number, which is the free doubling the
+      // wall rule exists to remove. The sting branch then has to survive a
+      // NEGATIVE `over` for the same reason: `0.035 + over * 0.09` goes below
+      // zero, `damage` is handed a negative loss, and a negative loss PAYS the
+      // player. That is the exact shape of the rupture bug that once printed six
+      // orders of magnitude of free mass.
+      if (v < this.mass && !this.mwall[i]) {
         // Absorb once the mote is meaningfully inside you — the little bit of
         // required overlap is what makes a near-miss feel like a near-miss.
         if (d > pr - mr * 0.35) return
-        const gain = Math.max(1, Math.round(absorbGain(v, this.mass) * this.growth))
+        // Exactly the mote's own number. Nothing scales this — not the breath,
+        // not the depth, not a combo. The instant anything multiplies this line
+        // the ribbon above it stops being true.
+        const gain = absorbGain(v)
         const before = this.mass
         this.mass += gain
         this.note(before)
@@ -1761,7 +1968,7 @@ export class World {
         // rival — but a dense field at a flat 19% ground a run to the floor
         // without a single rupture, which read as the game cheating.
         if (d > pr * 0.55 + mr * 0.45) return
-        const over = v / Math.max(1, this.mass) - 1
+        const over = Math.max(0, v / Math.max(1, this.mass) - 1)
         const rate = Math.min(0.13, 0.035 + over * 0.09)
         const loss = this.damage(Math.min(this.mass * rate, Math.max(1, v * 0.34)))
         this.combo = 0
@@ -1787,12 +1994,15 @@ export class World {
       this.grid.query(rxk, ryk, rr + 40, (i) => {
         if (!this.malive[i]) return
         if (this.mkind[i] === MK_ANSWER) return
+        // A wall is not food for anybody. Rivals get the same rule the player
+        // does, or a rival simply farms the doubling the player cannot.
+        if (this.mwall[i]) return
         const v = this.mval[i] as number
         if (v < 0 || v >= m) return
         const dx = (this.mx[i] as number) - rxk
         const dy = (this.my[i] as number) - ryk
         if (Math.hypot(dx, dy) > rr - (this.mr[i] as number) * 0.35) return
-        this.rmass[k] = m + absorbGain(v, m)
+        this.rmass[k] = m + absorbGain(v)
         this.malive[i] = 0
         this.moteCount--
       })
@@ -1812,7 +2022,7 @@ export class World {
           if (this.mass > m * 1.06 && d < pr - rr * 0.5) {
             // You ate a rival. This is the payoff moment of the genre.
             const before = this.mass
-            this.mass += devourGain(m, this.mass)
+            this.mass += devourGain(m)
             this.note(before)
             this.combo++
             this.killRival(k, false)
@@ -1834,10 +2044,10 @@ export class World {
           const dd = Math.hypot(ddx, ddy)
           if (dd > Math.max(rr, rr2)) continue
           if (m > m2 * 1.06 && dd < rr - rr2 * 0.72) {
-            this.rmass[k] = m + devourGain(m2, m)
+            this.rmass[k] = m + devourGain(m2)
             this.killRival(j, true)
           } else if (m2 > m * 1.06 && dd < rr2 - rr * 0.72) {
-            this.rmass[j] = m2 + devourGain(m, m2)
+            this.rmass[j] = m2 + devourGain(m)
             this.killRival(k, true)
             break
           }
@@ -2087,6 +2297,8 @@ export class World {
       // deliberately switched off so the answer is the only thing that decides.
       this.mr[i] = Math.max(this.playerRTrue * 0.82, 54)
       this.mkind[i] = MK_ANSWER
+      // A sphere is never a wall, whatever the mote it was recycled from was.
+      this.mwall[i] = 0
       this.mflip[i] = 1
       this.mphase[i] = a
       this.mborn[i] = this.time

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -230,9 +230,9 @@ const FOOD_B = 0.50
  * may be added to it.
  *
  * The saturation was not decoration — it was the only thing holding the economy
- * down, because it is the near-tie mote (worth ~M) that compounds. That job has
- * moved to `NEAR_PRIZE` below, where it belongs: not "you get less than you
- * ate", but "there is less of it to eat". Metering the SUPPLY is honest;
+ * down, because it is the mote worth ~M that compounds. That job has moved to
+ * `PRIZE_RATE` and `WALL_RATE` below, where it belongs: not "you get less than
+ * you ate", but "there is less of it to eat". Metering the SUPPLY is honest;
  * metering the ARITHMETIC is not.
  *
  * `Math.round` is defensive only. `mval` is an Int32Array, so every value that
@@ -245,28 +245,33 @@ export function absorbGain(value: number): number {
 }
 
 /**
- * PLACEHOLDER
+ * THE PRIZE — a number just under your own — and its ration.
  *
- * About one mote in twelve is drawn from a band straddling your own mass,
- * because telling 3,418 from 3,481 at speed IS the declared skill and the band
- * is where that reading happens. Most of it is a wall. The sliver below your
- * mass is the prize, and a prize worth ~M added exactly is a DOUBLING: repeat
- * it and mass is exponential in the number of motes eaten, with no polynomial
- * anywhere to save it. Measured, with absorption made exact and this band left
- * alone: 27,494,014 at two minutes against 12,738 before, and 189,893,983 by
- * twenty. Eight digits on the player's own core ends the game the pack is for.
+ * Swallowing one is a literal doubling now that absorption is exact, which
+ * makes it the biggest single event in the mote economy and the one that can
+ * end the game. A doubling repeated at a fixed frequency is exponential in the
+ * number of motes eaten, with no polynomial anywhere to save it: measured, with
+ * absorption made exact and the old flat 8% near-tie band left alone,
+ * 27,494,014 at two minutes against 12,738 before, and 189,893,983 by twenty.
+ * Eight digits on the player's own core ends the product the pack is for.
  *
- * So the prize gets rarer exactly as fast as it gets bigger. The edible sliver
- * is `NEAR_PRIZE / sqrt(mass)` of the band, which makes its contribution to
- * growth `p * M ∝ sqrt(M)` — the same shape as the crumb economy, which is what
- * keeps the whole curve polynomial. At mass 10 roughly a quarter of the near-tie
- * band is edible; at mass 10,000, one in four hundred.
+ * So the prize is drawn on its own roll, and the roll gets rarer exactly as
+ * fast as the prize gets bigger. Its contribution to growth is `rate * M`; the
+ * crumb economy's goes as `sqrt(M)`; holding the ratio fixed at every size —
+ * which is what "the same curve" actually means — needs `rate ∝ M^-0.85` once
+ * the eat rate's own `M^-0.35` is folded in. PRIZE_RATE_MAX is a ceiling on top
+ * of that, and it binds up to about mass 300, so the whole early game meets a
+ * prize about one mote in two hundred and the twelfth minute almost never does.
  *
- * What does NOT change is how often the band appears. The READING is the
- * pedagogy and it keeps its full frequency; what tapers is how often the answer
- * to "can I eat this?" is yes. That asymmetry is also the honest picture of the
- * genre: the bigger you are, the less there is anywhere near your size that is
- * beneath you.
+ * The RATE is scaled by `growth`, so a child who is struggling meets fewer of
+ * them. That is the same brake the old code applied by shrinking the gain,
+ * moved onto the supply, where it does not have to lie to work.
+ *
+ * What does NOT taper is the READING. The wall band below keeps its full
+ * frequency at every size, so "is that one bigger than me?" is asked exactly as
+ * often as it always was; what gets rarer is how often the answer is yes. That
+ * asymmetry is also the honest picture of the genre — the bigger you are, the
+ * less there is anywhere near your size that is beneath you.
  */
 const FOOD_MIN = 1
 const PRIZE_RATE = 0.8
@@ -303,6 +308,19 @@ const WALL_NEAR_SHARE = 0.57
 /** Crumbs a burst wall leaves behind, and the food scales each is worth. */
 const WALL_SHARDS = 4
 const WALL_SHARD_SCALE = 0.8
+
+/**
+ * How much of the mass a surge actually burns reaches the water behind you, and
+ * how coarsely it is chopped. See `stepPlayer`.
+ *
+ * SHARE is the only reason holding the boost still costs anything: recover
+ * every crumb of your own trail and you are still down 45% of what you spent.
+ * GRAIN is presentation — it is chosen so a surge at any size lays down roughly
+ * the same twenty-odd numerals a second it always did, because the trail is the
+ * one place a child SEES what speed costs.
+ */
+const EXHAUST_SHARE = 0.55
+const EXHAUST_GRAIN = 0.0024
 
 /**
  * The most a void may be worth, as a fraction of your mass.
@@ -344,9 +362,11 @@ const VOID_MAX_FRACTION = 0.11
  * possible play, which is the legibility contract this file has always held —
  * and 1.3x to 5x the old numbers, which is what an honest doubling costs.
  *
- * Rival-versus-rival is now conserving: the winner becomes exactly the two of
- * them. That is also the honest picture, and the size recycler still caps any
- * core at RIVAL_MAX_RATIO of the player, so it cannot fill the screen.
+ * Rival-versus-rival now moves the whole loser into the winner rather than a
+ * third of it. Not conserving — `killRival(j, true)` still scatters 22% of the
+ * loser as edible crumbs on top, so a collision leaves 1.22x the two of them —
+ * but the size recycler caps any core at RIVAL_MAX_RATIO of the player, so it
+ * cannot run away and it cannot fill the screen.
  */
 export function devourGain(rivalMass: number): number {
   if (rivalMass <= 0) return 0
@@ -992,8 +1012,8 @@ export class World {
    * reads "10 + 4 = 14" because that is what happened.
    *
    * This function still rounds, because mass is a float and the ribbon's terms
-   * are integers — the Resonance reward and the rupture are the only two things
-   * left that move mass by a non-integer. Both ends are rounded, the middle is
+   * are integers — the Resonance reward, the rupture and the surge burn all move
+   * mass by a fraction. Both ends are rounded, the middle is
    * DERIVED, and `sim.test.ts` walks a seeded run pairing every absorb back to
    * the numeral it came from.
    *
@@ -1027,6 +1047,7 @@ export class World {
     this.rivalCount = 0
     this.malive.fill(0)
     this.mwall.fill(0)
+    this.exhaust = 0
     this.ralive.fill(0)
     this.resonance.active = false
     this.resonance.phase = 0
@@ -1201,30 +1222,10 @@ export class World {
   }
 
   /**
-   * How often the water offers a number just under your own.
-   *
-   * This one rate is what makes exact absorption survivable, and it replaces
-   * the saturation that used to do the same job by lying about arithmetic.
-   *
-   * A prize is worth ALL OF YOU: swallow one and you double, exactly, and the
-   * ribbon prints the doubling. Repeat that at a fixed frequency and mass is
-   * exponential in the number of motes eaten, with no polynomial anywhere to
-   * catch it. Measured, with absorption made exact and the old flat 8% band
-   * left alone: a struggling run passed 100,000 inside the first minute and a
-   * well-answered one reached 27 million by the second — against 300 and
-   * 11,422 before. Eight digits on the player's own core is the end of the
-   * product the pack exists for.
-   *
-   * So the prize gets rarer exactly as fast as it gets bigger. Its contribution
-   * to growth is `rate * M`; the crumb economy's goes as `sqrt(M)`; holding the
-   * ratio fixed at every size — which is what "the same curve" actually means —
-   * needs `rate ∝ M^-0.85` once the eat rate's own `M^-0.35` is folded in. The
-   * ceiling is what keeps the opening explosive: for the first half-minute the
-   * cap binds and doubling is a thing that happens to you often.
-   *
-   * It is scaled by `growth`, so a child who is struggling meets fewer of them.
-   * That is the same brake the old code applied by shrinking the gain, moved
-   * onto the supply, where it does not have to lie to work.
+   * How often the water offers a number just under your own. See PRIZE_RATE:
+   * this is the single rate that makes exact absorption survivable, and it
+   * replaces the saturation that used to do the same job by lying about
+   * arithmetic.
    */
   private get prizeRate(): number {
     return Math.min(PRIZE_RATE_MAX, (PRIZE_RATE * this.growth) / Math.pow(Math.max(1, this.mass), PRIZE_RATE_EXP))
@@ -1508,24 +1509,55 @@ export class World {
       // `false`: surge burn is a continuous drain, not an event. Left on the
       // ledger it would rewrite the ribbon sixty times a second with
       // "1503 - 1 = 1502" and bury every real piece of arithmetic.
-      const paid = this.damage(burn, false) > burn * 0.5
+      const spent = this.damage(burn, false)
       const sp = Math.hypot(this.pvx, this.pvy)
-      if (paid && sp > 1 && this.rng.chance(Math.min(1, dt * 26))) {
-        const i = this.freeMote()
-        if (i >= 0) {
-          const v = Math.max(1, Math.round(this.mass * 0.035))
-          this.mx[i] = this.px - (this.pvx / sp) * r
-          this.my[i] = this.py - (this.pvy / sp) * r
-          this.mvx[i] = -(this.pvx / sp) * 150 + this.rng.sym(60)
-          this.mvy[i] = -(this.pvy / sp) * 150 + this.rng.sym(60)
-          this.mval[i] = v
-          this.mr[i] = radiusForValue(v)
-          this.mkind[i] = MK_SHED
-          this.malive[i] = 1
-          this.mphase[i] = this.rng.range(0, 6.28)
-          this.mflip[i] = 1
-          this.mborn[i] = this.time
-          this.moteCount++
+
+      // THE EXHAUST IS A LEDGER, not a rate, and under exact absorption that is
+      // the difference between a mechanic and a mass printer.
+      //
+      // It used to be a rate: 26 motes a second, each worth 3.5% of the player,
+      // against a burn of 11% of the player a second. Nine tenths of your mass
+      // hit the water every second for a ninth of your mass paid, and the only
+      // reason the arena survived it was that eating it back was throttled — by
+      // the saturation this pass deleted (a factor of 3 to 8) and by the
+      // `growth` multiplier this pass moved onto the supply. With both gone the
+      // exhaust is ejected at 150 u/s straight into the player's own pull field,
+      // which reaches 3.4 radii and pulls at up to 260 u/s. Measured on a bot
+      // holding surge one second in five: 42,287 at one minute, 28,074,058 at
+      // two, 4,268,470,964 at four. It is the largest term in the game by five
+      // orders of magnitude and it is invisible to a bot that never surges.
+      //
+      // So the water gets exactly the mass that was actually taken off you, and
+      // a fixed share of it: `EXHAUST_SHARE` is what makes surging still COST
+      // something when you turn around and hoover your own trail back up. The
+      // rest is gone. Nothing anywhere claims the trail adds up to the burn —
+      // what is claimed, and what now holds, is that every numeral in it is
+      // worth exactly what it says.
+      this.exhaust = Math.min(this.exhaust + spent * EXHAUST_SHARE, this.mass * 0.05 + 4)
+      if (sp > 1) {
+        const v = Math.max(1, Math.round(this.mass * EXHAUST_GRAIN))
+        if (this.exhaust >= v) {
+          const i = this.freeMote()
+          if (i >= 0) {
+            this.exhaust -= v
+            this.mx[i] = this.px - (this.pvx / sp) * r
+            this.my[i] = this.py - (this.pvy / sp) * r
+            this.mvx[i] = -(this.pvx / sp) * 150 + this.rng.sym(60)
+            this.mvy[i] = -(this.pvy / sp) * 150 + this.rng.sym(60)
+            this.mval[i] = v
+            this.mr[i] = radiusForValue(v)
+            this.mkind[i] = MK_SHED
+            this.malive[i] = 1
+            // A recycled slot may still be carrying a dead wall's flag, and a
+            // shed crumb that reads as a wall is burst by `stepMotes` the same
+            // frame — or, if the burst queue is full, stings the player with
+            // their own exhaust.
+            this.mwall[i] = 0
+            this.mphase[i] = this.rng.range(0, 6.28)
+            this.mflip[i] = 1
+            this.mborn[i] = this.time
+            this.moteCount++
+          }
         }
       }
     }
@@ -1636,6 +1668,8 @@ export class World {
   /** Walls outgrown this frame, waiting to come apart. Preallocated; see above. */
   private readonly burstQ = new Int32Array(24)
   private burstLen = 0
+  /** Mass burned by the surge and not yet laid down as exhaust. See EXHAUST_SHARE. */
+  private exhaust = 0
 
   private stepRivals(dt: number): void {
     const frame = (this.time * 60) | 0


### PR DESCRIPTION
The running equation printed `10 + 1 = 11` when a child ate a mote labelled 4.
`absorbGain` saturated — a mote's number was treated as a SIZE, not an addend —
so the sentence on screen was true about a game the child could not see. The
founder's ruling:

> "it would seem more intuitive to me to absorb the exact number? ... is that not how most games like this work?"

Right on both counts, and for this product the second one binds: **a maths game
may not print an equation that is not the one it performed.**

## What is exact now

- `absorbGain` is the identity. Eat a 4, gain 4, at every mass, forever.
- `devourGain` is the identity too. **The screen decided this one.** `gfx.ts`
  draws a numeral on every core big enough to carry one, so `400 + 84 = 484`
  under a core reading 300 is the same false sentence by another route. What
  made it *safe* is that a rival is a rationed supply — 26 of them, a respawn
  timer, only edible below `mass / 1.06`, so a kill can never more than 1.94x
  you. Measured against the kill-hunting bot over three seeds: saturating peaked
  at 97,715 / 139,611 / 156,320, exact peaks at 125,210 / 701,405 / 230,764 —
  six digits, which is the legibility contract.
- A void costs exactly the number it wears. The 11%-of-mass mercy moved off the
  damage and onto the **label**: identical hit, and `24 − 5 = 19` becomes a
  sentence the game can print.
- `growth` came off the **gain** and onto the **supply**. Handing a child less
  than they ate was the same lie a second time.

## What pays for it

Saturation was load-bearing. Its job moved to the spawn table, because the thing
that compounds is a mote worth ~M.

- **Walls keep full frequency** — one mote in seven at or above your mass, which
  is where 3,418-against-3,481 lives — but a wall is never food. A wall is
  otherwise *a prize with a delay on it*: grow 5% and the 1.05x from thirty
  seconds ago is a free doubling, forever, because the field manufactures walls
  forever. Measured with walls left flippable and absorption exact: a struggling
  run passed 100,000 inside the first minute; a well-answered one reached 27
  million by the second. Outgrow a wall now and it **bursts into crumbs** —
  the genre's best moment kept, as an event rather than a jackpot.
- **The prize is rationed**, and the ration falls as `mass^-0.85` — exactly fast
  enough to stay a fixed share of a curve whose other half goes as `sqrt(mass)`.
  Flatten the taper and twenty minutes of perfect play finishes at 5,745,335
  instead of 255,153.
- **The surge exhaust is a ledger, not a rate.** Found in self-review, and it
  was the biggest term in the game. It shed 26 motes a second worth 3.5% of the
  player each against a burn of 11% a second; the only thing that made that
  survivable was the saturation this pass deletes. Holding surge one second in
  five reached 4,268,470,964 at four minutes. `main` has a milder version of the
  same hole (124,408 at five minutes against ~1,300 for a player who never
  boosts). Nothing caught it because **`world.surging` was never `true` anywhere
  in the test suite.**
- `FOOD_A` 0.40 → 0.16, because the same table of numbers now feeds a player two
  to six times faster. The constant moved to keep the curve where it was.

## The curve

Mid tier, four seeds, median, at 15s / 60s / 2m / 5m / 10m / 20m:

| | 15s | 60s | 2m | 5m | 10m | 20m |
|---|---|---|---|---|---|---|
| struggling, before | 47 | 300 | 752 | 1,294 | 1,261 | 1,241 |
| struggling, after | 65 | 352 | 441 | 683 | 1,700 | 1,853 |
| answering well, before | 47 | 1,044 | 11,422 | 42,909 | 130,137 | 258,477 |
| answering well, after | 65 | 742 | 2,703 | 28,709 | 103,960 | 255,153 |

Worst rival against the width of a phone held tall: 0.68–0.77x, against
0.69–0.75x before. The hard bound is 1.

## Tests

Seventeen mutants were built and **every one is caught**. The three that were
not, on first check, are why the spawn-table test, the legibility bound on the
twenty-minute run, and the whole surge test exist at all.

- `the ribbon prints the founder's three lines, exactly` — 10+4=14, 14+10=24,
  24−5=19, deterministic. Restore the old curve: `got 10 + 1 = 11`.
- `the ribbon's arithmetic is the simulation's arithmetic, line for line` — a
  seeded run pairing **every** absorb one-to-one back to the numeral it came
  from, plus `eqC === round(mass)` on every change. Restore the old curve:
  `the arena grew by 1 and nothing wearing 1 left the water: [2,9]`.
- `the spawn table cannot hand out a wall you can eat, or a void that outweighs
  its number` — read off `rollValue`, at masses chosen so `tidyValue` rounds
  *across* the player's own mass, which round masses hide.
- `a wall is never food, and outgrowing one bursts it into crumbs`.
- `holding the surge always costs mass, even if you eat your own trail`.
- `a Resonance sphere is never still carrying a wall's flag` — spheres come from
  `freeMote`, so the test poisons every free slot rather than waiting on a coin.

`the numbers a child reads stay in a workable range` now runs four seeds and
asserts the band on the median plus a per-seed ceiling: an early kill is worth
up to 94% of you rather than 25%, so one seed's fifteen-second mass had become a
coin flip on whether a rival wandered into range.

71 tests, run 5x green. `tsc` clean, `build:pack` clean.

## Only a device can confirm

The wall band no longer flips into food, so the "husk collapses into a disc"
moment now comes from bursting rather than from morphing, and it fires on a
`"flip"` event at the same place with the same sound. It reads right in the
simulation; it wants one look on glass.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb