### PR TITLE
fix(dynawalla/games): the manual stops the game — six games that already knew how to pause

### DIFF
--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -158,6 +158,24 @@ export function mountBeam(el: HTMLElement, host: Host): {
       },
     ],
     reducedMotion: reduced,
+    // The hall keeps descending behind the scrim otherwise. A child opens the
+    // rules BECAUSE they are losing, and the automaton that was two thirds of
+    // the way down when they opened them lands on the floor while they read.
+    //
+    // The manual only lifts a pause it put on itself. The host can already have
+    // a sheet of its own over the frame — a parent gate, a stopping point — and
+    // a child who opens and closes the rules underneath it must not be handed
+    // back a running lattice.
+    onOpen: () => {
+      if (paused) return
+      heldForManual = true
+      setPaused(true)
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      setPaused(false)
+    },
   })
   const gov = new TierGovernor(detectTier())
   const feel = new Feel({ reducedMotion: reduced })
@@ -186,6 +204,8 @@ export function mountBeam(el: HTMLElement, host: Host): {
   let dpr = 1
   let running = true
   let paused = false
+  /** True only while the pause in force is the one the manual raised. */
+  let heldForManual = false
   let pausedAt = 0
   let over = false
   let overAt = 0

--- a/dynawalla/games/beam/src/test/manual-freeze.test.ts
+++ b/dynawalla/games/beam/src/test/manual-freeze.test.ts
@@ -1,0 +1,388 @@
+// THE HALL STOPS WHILE THE RULES ARE READ.
+//
+// "All games should pause while reading the instructions .. I can hear
+// counterweight playing in the background while I'm reading the instructions
+// ... stressing me out even more."
+//
+// The shared how-to-play sheet holds the sound, the keys and the taps by itself.
+// What it cannot hold is this game's simulation clock, and LATTICE RUNNER is the
+// worst case for that: a child opens the manual BECAUSE an automaton is two
+// thirds of the way down and they cannot see which beam divides it. Left
+// running, that automaton reaches the floor and puts a light out while the child
+// is reading why.
+//
+// So this drives the real button. It does NOT call `setPaused` — that path is
+// already covered in `loop.test.ts` and calling it here would prove only that a
+// function this file also wrote does what it says. It finds the `dwc-help`
+// control the shared module mounted, fires its own click handler, and watches
+// the world.
+//
+// Two observables, deliberately. The 2D context counts every call it is asked
+// for, so "nothing was drawn" is measured rather than asserted; and the host is
+// wrapped, so "nothing was decided" is measured too. A freeze that stopped the
+// pixels and not the mathematics would pass one and fail the other.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import type { Host } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Handler = (e: unknown) => void
+
+type FakeElement = {
+  className: string
+  id: string
+  /**
+   * PER ELEMENT, and that is the whole reason this file has its own harness.
+   *
+   * `loop.test.ts` keeps one listener map keyed by event type for every fake
+   * element in the document. Both the help control and the sheet's PLAY button
+   * register a `"click"` listener, so in that harness the second silently
+   * overwrites the first and there is no way to reach either of them on purpose.
+   */
+  listeners: Map<string, Handler[]>
+  style: Record<string, string>
+  [key: string]: unknown
+}
+
+type Rig = {
+  el: HTMLElement
+  created: FakeElement[]
+  /** Advance the clock by `ms` and run the frame the game asked for. */
+  step(ms: number): void
+  /**
+   * A key, dispatched the way a browser does it: to every `globalThis`
+   * listener in registration order, stopping the moment one of them calls
+   * `stopPropagation`. That is what puts the shared module's capture-phase
+   * swallow in front of the game's own handler, exactly as it is on a device.
+   */
+  press(key: string): void
+  restore(): void
+  counter: { calls: number }
+}
+
+/**
+ * A surface with no pixels that still counts the work.
+ *
+ * Every context method returns the context itself so gradient chains resolve
+ * without a real canvas, and every call bumps `counter.calls`. BEAM does not
+ * draw at all while it is paused — its frame callback returns before `draw` —
+ * so a frozen count is exactly the claim being made.
+ */
+function install(width: number, height: number, wallClock: number): Rig {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const counter = { calls: 0 }
+  const noop = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, prop) => (prop === "then" ? undefined : noop),
+    set: () => true,
+    apply: () => {
+      counter.calls++
+      return noop
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  const created: FakeElement[] = []
+  const makeEl = (): FakeElement => {
+    const listeners = new Map<string, Handler[]>()
+    const el: FakeElement = {
+      className: "",
+      id: "",
+      listeners,
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      type: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      appendChild: () => undefined,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => noop,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener: (k: string, h: Handler) => {
+        listeners.set(k, [...(listeners.get(k) ?? []), h])
+      },
+      removeEventListener: (k: string, h: Handler) => {
+        listeners.set(k, (listeners.get(k) ?? []).filter((f) => f !== h))
+      },
+    }
+    return el
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    key: globalThis.addEventListener,
+    unkey: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    dateNow: Date.now,
+    nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
+  }
+
+  const globals = new Map<string, Handler[]>()
+  globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+    pending = cb
+    return 1
+  }) as typeof globalThis.requestAnimationFrame
+  globalThis.cancelAnimationFrame = ((): void => {
+    pending = null
+  }) as typeof globalThis.cancelAnimationFrame
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {}
+    disconnect(): void {}
+  }
+  performance.now = () => clock
+  Date.now = () => wallClock
+  Object.defineProperty(globalThis, "navigator", {
+    value: { hardwareConcurrency: 12 },
+    configurable: true,
+    writable: true,
+  })
+  ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+  globalThis.addEventListener = ((k: string, h: Handler): void => {
+    globals.set(k, [...(globals.get(k) ?? []), h])
+  }) as unknown as typeof globalThis.addEventListener
+  globalThis.removeEventListener = ((k: string, h: Handler): void => {
+    globals.set(k, (globals.get(k) ?? []).filter((f) => f !== h))
+  }) as unknown as typeof globalThis.removeEventListener
+  ;(globalThis as { document?: unknown }).document = {
+    createElement: () => {
+      const el = makeEl()
+      created.push(el)
+      return el
+    },
+    getElementById: (id: string) => created.find((el) => el.id === id) ?? null,
+    body: makeEl(),
+  }
+
+  return {
+    el: makeEl() as unknown as HTMLElement,
+    created,
+    counter,
+    step: (ms: number) => {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+    press: (key: string) => {
+      let stopped = false
+      const event = {
+        key,
+        type: "keydown",
+        preventDefault: () => undefined,
+        stopPropagation: () => {
+          stopped = true
+        },
+      }
+      for (const h of globals.get("keydown") ?? []) {
+        if (stopped) break
+        h(event)
+      }
+    },
+    restore: () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      globalThis.addEventListener = saved.key
+      globalThis.removeEventListener = saved.unkey
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      Date.now = saved.dateNow
+      if (saved.nav) Object.defineProperty(globalThis, "navigator", saved.nav)
+    },
+  }
+}
+
+/** The shared module's own controls, found the way a child's finger finds them. */
+function control(created: FakeElement[], className: string): () => void {
+  const el = created.find((e) => e.className === className)
+  assert.ok(el, `the shared chrome never mounted a .${className}`)
+  const click = el.listeners.get("click")?.[0]
+  assert.ok(click, `.${className} was mounted with no click handler`)
+  return () => click({ type: "click", target: el })
+}
+
+type World = {
+  /** Every ending an item can have: answered, or run out. Both close a wave. */
+  resolved: string[]
+  /** Items the game asked the host for. A frozen game asks for nothing. */
+  asked: number
+  reports: Array<{ ms: number }>
+}
+
+function stub(world: World): Host {
+  const base = createStubHost({
+    seed: 0xbea3f,
+    reducedMotion: false,
+    onReport: (r) => {
+      world.reports.push(r)
+      world.resolved.push(r.questionId)
+    },
+    onSkip: (id) => world.resolved.push(id),
+  })
+  return {
+    ...base,
+    next: (o) => {
+      world.asked++
+      return base.next(o)
+    },
+  }
+}
+
+test("MANUAL FREEZES THE HALL: nothing descends, nothing draws, nothing is decided", () => {
+  const rig = install(768, 1024, 0x51ee)
+  const world: World = { resolved: [], asked: 0, reports: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    // Long enough that a wave is certainly in the air and one has been resolved.
+    for (let i = 0; i < 2400; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+    }
+    assert.ok(world.resolved.length > 0, "nothing happened before the manual was opened")
+
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+
+    open()
+    const resolved = world.resolved.length
+    const asked = world.asked
+    const drawn = rig.counter.calls
+
+    // Ninety-six seconds of reading, with the child mashing at the screen the
+    // whole time — which is what a five-year-old does with a wall of text.
+    for (let i = 0; i < 6000; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+      if (i % 11 === 0) rig.press("ArrowLeft")
+    }
+
+    assert.equal(
+      rig.counter.calls,
+      drawn,
+      `${rig.counter.calls - drawn} draw calls went out behind the manual`,
+    )
+    assert.equal(
+      world.resolved.length,
+      resolved,
+      "an item was resolved while the child was reading the rules",
+    )
+    assert.equal(world.asked, asked, "the hall asked for a new question behind the manual")
+
+    close()
+    for (let i = 0; i < 3000; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+    }
+    assert.ok(rig.counter.calls > drawn, "the hall never came back after the manual closed")
+    assert.ok(world.resolved.length > resolved, "the run did not resume when the manual closed")
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+
+  // And the read is not billed to the child. Every latency is bounded by the
+  // answering window, which is nowhere near the ninety-six seconds above.
+  for (const r of world.reports) {
+    assert.ok(r.ms < 60_000, `a report carried ${r.ms}ms — the manual leaked into the latency`)
+  }
+})
+
+test("THE MANUAL ONLY LIFTS ITS OWN PAUSE: closing it cannot restart a host-paused game", () => {
+  // The host puts a sheet over a still-mounted pack — a parent gate, a stopping
+  // point — and the child, stuck behind it, opens the rules and closes them
+  // again. Without the guard the game is handed back RUNNING underneath the
+  // host's own sheet, which is the defect the pause existed to prevent, now
+  // reachable by reading.
+  const rig = install(768, 1024, 0x51ef)
+  const world: World = { resolved: [], asked: 0, reports: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    for (let i = 0; i < 2400; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+    }
+    assert.ok(world.resolved.length > 0, "nothing happened before the host raised its sheet")
+
+    handle.setPaused(true)
+    const drawn = rig.counter.calls
+    const resolved = world.resolved.length
+    const asked = world.asked
+
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    open()
+    for (let i = 0; i < 1200; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+    }
+    close()
+    // Twenty seconds after the manual was put away, and the host has never
+    // lifted its sheet.
+    for (let i = 0; i < 1200; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+    }
+
+    assert.equal(rig.counter.calls, drawn, "the manual handed a host-paused game back to the loop")
+    assert.equal(world.resolved.length, resolved, "an item was resolved behind the host's sheet")
+    assert.equal(world.asked, asked, "a question was drawn behind the host's sheet")
+
+    // And the host's own resume still works: the pause was not double-counted.
+    handle.setPaused(false)
+    for (let i = 0; i < 3000; i++) {
+      rig.step(16)
+      if (i % 5 === 0) rig.press(" ")
+    }
+    assert.ok(rig.counter.calls > drawn, "the game never came back when the host lifted its sheet")
+    assert.ok(world.resolved.length > resolved, "the run never resumed")
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("opening and closing the manual repeatedly is not a stack of pauses", () => {
+  const rig = install(768, 1024, 0x51f0)
+  const world: World = { resolved: [], asked: 0, reports: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    for (let i = 0; i < 600; i++) rig.step(16)
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    for (let round = 0; round < 6; round++) {
+      open()
+      open() // already open: the module refuses, and `onOpen` must not run twice
+      const frozen = rig.counter.calls
+      for (let j = 0; j < 200; j++) rig.step(16)
+      assert.equal(rig.counter.calls, frozen, `read ${round} did not stop the hall`)
+      close()
+      close() // and a double close must not resume a game twice
+      for (let j = 0; j < 200; j++) rig.step(16)
+      assert.ok(rig.counter.calls > frozen, `read ${round} left the game stuck paused`)
+    }
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+  for (const r of world.reports) assert.ok(r.ms < 60_000)
+})

--- a/dynawalla/games/colossus/src/mount.ts
+++ b/dynawalla/games/colossus/src/mount.ts
@@ -92,18 +92,57 @@ export function mountColossus(
       },
     ],
     reducedMotion: reduced,
+    // Behind the scrim the slabs keep falling and the keystone keeps being
+    // timed, and a child reading the rules is being billed for it.
+    //
+    // The manual only lifts a pause it put on itself. The host can already have
+    // a sheet over the frame — and this game raises one itself, every time a
+    // tower comes down — so a child who opens and closes the rules underneath
+    // it must not be handed back a running building.
+    onOpen: () => {
+      if (paused) return
+      heldForManual = true
+      raiseSheet()
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      lowerSheet()
+    },
   })
 
   let best = bestStreak()
   let streak = 0
   let running = true
   let paused = false
+  /** True only while the pause in force is the one the manual raised. */
+  let heldForManual = false
   let last = 0
   let frame = 0
   let banner: Banner | null = null
 
   function now(): number {
     return typeof performance === "object" ? performance.now() : Date.now()
+  }
+
+  // The two halves of the pause, named so the host's `pause`/`resume` and the
+  // manual's `onOpen`/`onClose` go through the same door rather than each
+  // keeping their own flag. Both are idempotent: whichever asked second is a
+  // no-op, and nothing double-marks the keystone clock.
+  function raiseSheet(): void {
+    if (paused) return
+    paused = true
+    game.pause(now())
+  }
+
+  function lowerSheet(): void {
+    if (!paused) return
+    paused = false
+    game.resume(now())
+    // The next frame computes its delta from `last`, which was set before the
+    // sheet went up. Forget it, or the first frame back is a whole sheet's
+    // worth of gravity in one step.
+    last = 0
   }
 
   const apply = (events: readonly GameEvent[]): void => {
@@ -239,18 +278,10 @@ export function mountColossus(
 
   return {
     pause(): void {
-      if (paused) return
-      paused = true
-      game.pause(now())
+      raiseSheet()
     },
     resume(): void {
-      if (!paused) return
-      paused = false
-      game.resume(now())
-      // The next frame computes its delta from `last`, which was set before the
-      // sheet went up. Forget it, or the first frame back is a whole sheet's
-      // worth of gravity in one step.
-      last = 0
+      lowerSheet()
     },
     unmount(): void {
       running = false

--- a/dynawalla/games/colossus/src/test/manual-freeze.test.ts
+++ b/dynawalla/games/colossus/src/test/manual-freeze.test.ts
@@ -1,0 +1,433 @@
+// THE BUILDING HOLDS STILL WHILE THE RULES ARE READ.
+//
+// "All games should pause while reading the instructions .. I can hear
+// counterweight playing in the background while I'm reading the instructions
+// ... stressing me out even more."
+//
+// The shared how-to-play sheet holds the sound, the keys and the taps. It cannot
+// hold a game's own clock, and COLOSSUS has two that matter: the slab physics,
+// and the keystone's stopwatch. A child who opens the manual because a wrong
+// strike just made the tower taller is billed for every second they spend
+// reading why.
+//
+// **Why this file exists at all when `pause.test.ts` is right there.** That file
+// tests `Game.pause` in isolation, and `Game` was never the thing that was
+// broken — the defect is in the *wiring*: whether the manual's `onOpen` ever
+// reaches it. So this is a mount-level test. There was no mount-level harness in
+// this package before it; the one below is modelled on COUNTERWEIGHT's, which is
+// the same shape.
+//
+// **How the freeze is observed.** COLOSSUS deliberately keeps DRAWING while it
+// is paused — a frozen frame under a translucent host sheet is what a paused
+// pack should look like — so a frozen draw *count* would prove nothing here.
+// What is asserted instead is that the frames are IDENTICAL: every call and
+// every argument the renderer makes, recorded and compared. The giant breathes
+// on `Scene.time`, which only advances in `Scene.advance`, so a world that is
+// still moving produces a different frame and a frozen one repeats itself
+// exactly.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import type { Host } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+import { viewLayout } from "../render/layout.ts"
+
+type Handler = (event: unknown) => void
+
+type FakeElement = {
+  className: string
+  id: string
+  /**
+   * PER ELEMENT. Both the shared module's help control and its PLAY button
+   * register a `"click"` listener, so a harness with one map keyed by event
+   * type — which is what most of the packs' harnesses have — silently drops the
+   * first of the two and makes this test unwritable.
+   */
+  listeners: Map<string, Handler[]>
+  style: Record<string, string>
+  [key: string]: unknown
+}
+
+/**
+ * A 2D context that writes down exactly what it was asked to draw.
+ *
+ * Every call and every property assignment lands in `frame`, in order, with its
+ * arguments. Two frames are the same frame if and only if those transcripts are
+ * equal — which is a much stronger statement than a call count, and the only one
+ * worth making about a game that keeps painting while it is stopped.
+ */
+function recorder(frame: string[]): CanvasRenderingContext2D {
+  const store = new Map<string, unknown>()
+  const gradient = {
+    addColorStop(...args: unknown[]): void {
+      frame.push(`stop(${args.map(String).join(",")})`)
+    },
+  }
+  return new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (store.has(prop)) return store.get(prop)
+        return (...args: unknown[]) => {
+          frame.push(`${prop}(${args.map(String).join(",")})`)
+          return gradient
+        }
+      },
+      set(_t, prop: string, value: unknown) {
+        frame.push(`${prop}=${String(value)}`)
+        store.set(prop, value)
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+}
+
+type Rig = {
+  el: HTMLElement
+  created: FakeElement[]
+  /** The transcript of the most recent frame drawn. */
+  frame: string[]
+  /** Advance the clock by `ms` and run the frame the game asked for. */
+  step(ms: number): void
+  restore(): void
+}
+
+function install(width: number, height: number): Rig {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const frame: string[] = []
+  const ctx = recorder(frame)
+  const created: FakeElement[] = []
+
+  const makeEl = (): FakeElement => {
+    const listeners = new Map<string, Handler[]>()
+    const el: FakeElement = {
+      className: "",
+      id: "",
+      listeners,
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      type: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      appendChild: () => undefined,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      addEventListener: (k: string, h: Handler) => {
+        listeners.set(k, [...(listeners.get(k) ?? []), h])
+      },
+      removeEventListener: (k: string, h: Handler) => {
+        listeners.set(k, (listeners.get(k) ?? []).filter((f) => f !== h))
+      },
+    }
+    return el
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    key: globalThis.addEventListener,
+    unkey: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    dateNow: Date.now,
+  }
+
+  const globals = new Map<string, Handler[]>()
+  globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+    pending = cb
+    return 1
+  }) as typeof globalThis.requestAnimationFrame
+  globalThis.cancelAnimationFrame = ((): void => {
+    pending = null
+  }) as typeof globalThis.cancelAnimationFrame
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {}
+    disconnect(): void {}
+  }
+  performance.now = () => clock
+  // The tower's shape is seeded from the wall clock, which is right on a device
+  // and fatal in a test. Pinned, so a green run is green every time.
+  Date.now = () => 0x0c0105
+  ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+  globalThis.addEventListener = ((k: string, h: Handler): void => {
+    globals.set(k, [...(globals.get(k) ?? []), h])
+  }) as unknown as typeof globalThis.addEventListener
+  globalThis.removeEventListener = ((k: string, h: Handler): void => {
+    globals.set(k, (globals.get(k) ?? []).filter((f) => f !== h))
+  }) as unknown as typeof globalThis.removeEventListener
+  ;(globalThis as { document?: unknown }).document = {
+    createElement: () => {
+      const el = makeEl()
+      created.push(el)
+      return el
+    },
+    getElementById: (id: string) => created.find((el) => el.id === id) ?? null,
+    body: makeEl(),
+  }
+
+  const rig: Rig = {
+    el: makeEl() as unknown as HTMLElement,
+    created,
+    frame,
+    step: (ms: number) => {
+      clock += ms
+      const cb = pending
+      pending = null
+      frame.length = 0
+      cb?.(clock)
+    },
+    restore: () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      globalThis.addEventListener = saved.key
+      globalThis.removeEventListener = saved.unkey
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      Date.now = saved.dateNow
+    },
+  }
+  return rig
+}
+
+/** The shared module's own controls, found the way a child's finger finds them. */
+function control(created: FakeElement[], className: string): () => void {
+  const el = created.find((e) => e.className === className)
+  assert.ok(el, `the shared chrome never mounted a .${className}`)
+  const click = el.listeners.get("click")?.[0]
+  assert.ok(click, `.${className} was mounted with no click handler`)
+  return () => click({ type: "click", target: el })
+}
+
+type World = {
+  /** Keystones the game asked the host for. A frozen tower asks for nothing. */
+  asked: number
+  reports: Array<{ ms: number; correct: boolean }>
+  /**
+   * Every haptic the game fired. This is the cheapest honest proof that a
+   * press reached the rules: taking hold of a slab fires one, and nothing else
+   * on the screen does.
+   */
+  haptics: string[]
+}
+
+function stub(world: World): Host {
+  const base = createStubHost({ seed: 0xc0105, reducedMotion: false })
+  return {
+    ...base,
+    next: (o) => {
+      world.asked++
+      return base.next(o)
+    },
+    report: (r) => {
+      world.reports.push(r)
+    },
+    haptic: (k) => {
+      world.haptics.push(k)
+    },
+  }
+}
+
+const W = 768
+const H = 1024
+
+/** The strike pill, from the real layout rather than a guessed coordinate. */
+function strikePoint(): { x: number; y: number } {
+  const { strike } = viewLayout(W, H)
+  return { x: strike.x + strike.w / 2, y: strike.y + strike.h / 2 }
+}
+
+function pump(rig: Rig, frames: number): void {
+  for (let i = 0; i < frames; i++) rig.step(16)
+}
+
+test("MANUAL FREEZES THE BUILDING: the same frame, over and over, until it closes", () => {
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    // Past the opening drop, so the slabs are seated and the only thing still
+    // moving is the giant himself — which is the honest hard case, because a
+    // freeze that only stopped the falling stone would still pass here.
+    pump(rig, 300)
+    const moving = [...rig.frame]
+    pump(rig, 1)
+    assert.notDeepEqual(rig.frame, moving, "the yard was already frozen before the manual opened")
+
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    open()
+
+    // The first frame behind the sheet, and then a hundred and sixty seconds of
+    // reading — every one of which must be pixel-for-pixel the same frame.
+    pump(rig, 1)
+    const held = [...rig.frame]
+    assert.ok(held.length > 100, "the frame behind the sheet drew nothing at all")
+    const asked = world.asked
+    for (let i = 0; i < 10_000; i++) {
+      rig.step(16)
+      if (i % 1000 === 0) {
+        assert.deepEqual(rig.frame, held, `the building moved ${i} frames into the read`)
+      }
+    }
+    assert.deepEqual(rig.frame, held, "the building moved while the rules were up")
+    assert.equal(world.asked, asked, "a keystone was served behind the manual")
+
+    close()
+    pump(rig, 30)
+    assert.notDeepEqual(rig.frame, held, "the building never came back after the manual closed")
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("a press behind the manual is not a press, and the read is not thinking time", () => {
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    const canvas = rig.created[0]
+    assert.ok(canvas, "mount did not create a canvas")
+    const press = canvas.listeners.get("pointerdown")?.[0]
+    assert.ok(press, "the tower was never wired to anything")
+    const at = (x: number, y: number): void => {
+      press({ preventDefault: () => undefined, clientX: x, clientY: y })
+    }
+    /** Walk down the middle of the frame until a slab is taken hold of. */
+    const grabOne = (): boolean => {
+      const before = world.haptics.length
+      for (let y = 0; y < H; y += 6) {
+        at(W / 2, y)
+        if (world.haptics.length > before) return true
+      }
+      return false
+    }
+
+    pump(rig, 300)
+    // The positive control. Without this the "nothing happened" below would
+    // pass just as well for a sweep that misses the building entirely.
+    assert.ok(grabOne(), "the sweep never found a slab, so it proves nothing")
+
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    open()
+    // Two and a half minutes of reading, with a thumb on the glass throughout.
+    pump(rig, 9000)
+    pump(rig, 1)
+    const held = [...rig.frame]
+    const haptics = world.haptics.length
+    for (let y = 0; y < H; y += 6) at(W / 2, y)
+    at(strikePoint().x, strikePoint().y)
+    pump(rig, 1)
+
+    assert.equal(world.haptics.length, haptics, "a press behind the manual reached the tower")
+    // Length, not `deepEqual(world.reports, [])`. Node's `deepEqual` is typed
+    // `asserts actual is T`, so comparing against a bare `[]` narrows
+    // `world.reports` to `never[]` for the rest of the function — and the
+    // latency assertion at the bottom, the one with the teeth, then reads `.ms`
+    // off `never` and stops meaning anything.
+    assert.equal(
+      world.reports.length,
+      0,
+      `${world.reports.length} keystones were answered from behind the manual`,
+    )
+    assert.deepEqual(rig.frame, held, "the building changed under the manual")
+
+    close()
+    pump(rig, 30)
+    assert.ok(grabOne(), "the tower never came back after the manual closed")
+    at(strikePoint().x, strikePoint().y)
+    pump(rig, 5)
+
+    assert.ok(world.reports.length > 0, "the fist never landed after the manual closed")
+    const first = world.reports[0]
+    assert.ok(first)
+    // The keystone's stopwatch, which is a wall clock and keeps running behind
+    // any sheet. `Game.resume` shifts the mark; if the manual never reached it,
+    // the 144 seconds of reading are billed as a child staring at a sum.
+    assert.ok(
+      first.ms < 30_000,
+      `${Math.round(first.ms)} ms was billed for a keystone that had a 144 s manual over it`,
+    )
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("THE MANUAL ONLY LIFTS ITS OWN PAUSE: closing it cannot restart a host-paused game", () => {
+  // This game raises the host's sheet ITSELF, every time a tower comes down —
+  // `transition("level")` — so a child stuck behind a stopping-point card is
+  // exactly the child who opens the rules. Closing them must not hand the
+  // building back running underneath a sheet that is still up.
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 300)
+    handle.pause()
+    pump(rig, 1)
+    const held = [...rig.frame]
+
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    open()
+    pump(rig, 600)
+    close()
+    pump(rig, 600)
+
+    assert.deepEqual(rig.frame, held, "the manual handed a host-paused game back to the loop")
+
+    // And the host's own resume still works: nothing was double-counted.
+    handle.resume()
+    pump(rig, 30)
+    assert.notDeepEqual(rig.frame, held, "the game never came back when the host lifted its sheet")
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("opening and closing the manual repeatedly is not a stack of pauses", () => {
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 300)
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    for (let round = 0; round < 6; round++) {
+      open()
+      open() // already open: the module refuses, and `onOpen` must not run twice
+      pump(rig, 1)
+      const held = [...rig.frame]
+      pump(rig, 200)
+      assert.deepEqual(rig.frame, held, `read ${round} did not stop the building`)
+      close()
+      close() // and a double close must not resume a game twice
+      pump(rig, 30)
+      assert.notDeepEqual(rig.frame, held, `read ${round} left the game stuck paused`)
+    }
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})

--- a/dynawalla/games/counterweight/src/mount.ts
+++ b/dynawalla/games/counterweight/src/mount.ts
@@ -122,6 +122,25 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
       },
     ],
     reducedMotion: reduced,
+    // This is the game the complaint was about: "I can hear counterweight
+    // playing in the background while I'm reading the instructions." The sound
+    // is held for us; the press window is not, and a window that opens and
+    // whistles behind the scrim costs a round the child never saw.
+    //
+    // The manual only lifts a pause it put on itself. The host can already have
+    // a sheet over the frame, and the tab can already be in the background —
+    // a child who opens and closes the rules underneath either of those must
+    // not be handed back a running yard.
+    onOpen: () => {
+      if (sheeted) return
+      heldForManual = true
+      pauseAll()
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      resumeAll()
+    },
   })
 
   let tally = loadTally()
@@ -130,6 +149,8 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
   let last = 0
   /** Set by the host's `pause`. Blocks the clock *and* the input, separately. */
   let sheeted = false
+  /** True only while the pause in force is the one the manual raised. */
+  let heldForManual = false
   let column: Column | null = null
   let promptRaw = ""
   /**

--- a/dynawalla/games/counterweight/src/test/browser.ts
+++ b/dynawalla/games/counterweight/src/test/browser.ts
@@ -1,0 +1,220 @@
+// The browser THE STEELYARD is mounted into, headlessly.
+//
+// `tsc` proves the draw calls type-check and the vite build proves the modules
+// resolve. Neither proves that a frame *runs* — a stale property, a function
+// renamed in `render/` and not in `mount.ts`, a value read before it is
+// assigned: all compile, and all crash on the first frame in front of a child.
+//
+// So this is a canvas that records instead of painting, a document that builds
+// elements instead of nodes, and a clock the test drives by hand. It lives in
+// its own module because more than one test file needs it — `mount.test.ts`
+// drives whole matches through it, `manual-freeze.test.ts` drives the shared
+// how-to-play sheet — and two copies of a rig this size drift within a week.
+//
+// **Per-element listener maps.** Not one map keyed by event type for the whole
+// document. The shared chrome's help control and its PLAY button both register
+// a `"click"` listener, so a shared map silently keeps only the second and the
+// manual becomes unreachable from a test.
+
+export type Listener = (event: unknown) => void
+
+/** A 2D context that answers every call and records how much work it was asked for. */
+export function fakeContext(counter: {
+  calls: number
+  text: string[]
+}): CanvasRenderingContext2D {
+  const store = new Map<string, unknown>()
+  const noop = (name: string) =>
+    function (...args: unknown[]) {
+      counter.calls++
+      if (name === "fillText" && typeof args[0] === "string") counter.text.push(args[0])
+      // Gradients are the one call whose result is used, so everything returns
+      // something that can take a colour stop.
+      return { addColorStop() {} }
+    }
+  return new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (store.has(prop)) return store.get(prop)
+        return noop(prop)
+      },
+      set(_t, prop: string, value) {
+        store.set(prop, value)
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+}
+
+export type FakeElement = {
+  id: string
+  /** Set by the shared chrome on the controls it mounts. How a test finds them. */
+  className: string
+  style: Record<string, string>
+  width: number
+  height: number
+  listeners: Map<string, Listener[]>
+  appendChild(child: unknown): void
+  append(...children: unknown[]): void
+  setAttribute(name: string, value: string): void
+  focus(): void
+  remove(): void
+  addEventListener(type: string, fn: Listener): void
+  removeEventListener(type: string, fn: Listener): void
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
+  getContext(): CanvasRenderingContext2D
+  [key: string]: unknown
+}
+
+export function harness(size: { w: number; h: number }, counter: { calls: number; text: string[] }) {
+  const ctx = fakeContext(counter)
+  const make = (): FakeElement => {
+    const listeners = new Map<string, Listener[]>()
+    return {
+      id: "",
+      className: "",
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      listeners,
+      appendChild() {},
+      append() {},
+      setAttribute() {},
+      focus() {},
+      remove() {},
+      addEventListener(type, fn) {
+        const list = listeners.get(type) ?? []
+        list.push(fn)
+        listeners.set(type, list)
+      },
+      removeEventListener(type, fn) {
+        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
+      },
+      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
+      getContext: () => ctx,
+    }
+  }
+  const created: FakeElement[] = []
+  // The shared chrome adds two things this stub has to answer for: the
+  // safe-area probe, which looks itself up by id before making a second one,
+  // and the how-to-play panel, which builds a small tree of buttons and lists.
+  // Both are DOM the game now really does create, so the fake DOM grows to meet
+  // them rather than the game being asked to skip them under test.
+  const doc = {
+    visibilityState: "visible",
+    listeners: new Map<string, Listener[]>(),
+    body: { appendChild() {} },
+    activeElement: null,
+    createElement() {
+      const el = make()
+      created.push(el)
+      return el
+    },
+    getElementById(id: string): FakeElement | null {
+      return created.find((el) => el.id === id) ?? null
+    },
+    addEventListener(type: string, fn: Listener) {
+      const list = doc.listeners.get(type) ?? []
+      list.push(fn)
+      doc.listeners.set(type, list)
+    },
+    removeEventListener(type: string, fn: Listener) {
+      doc.listeners.set(type, (doc.listeners.get(type) ?? []).filter((f) => f !== fn))
+    },
+  }
+  return { host: make(), doc, created, ctx }
+}
+
+export type Clock = { now: number }
+export type Rig = ReturnType<typeof harness> & {
+  frames: Array<(t: number) => void>
+  /** The wall clock `mount.ts` bills latency against, under the test's control. */
+  clock: Clock
+}
+
+/**
+ * Install the browser globals `mount.ts` needs, run `body`, and take them back
+ * off again — including when `body` throws, which is the case these files exist
+ * to catch.
+ */
+export function withBrowser(
+  size: { w: number; h: number },
+  counter: { calls: number; text: string[] },
+  body: (rig: Rig) => void,
+): void {
+  const rig = harness(size, counter)
+  const g = globalThis as Record<string, unknown>
+  const saved = new Map<string, PropertyDescriptor | undefined>()
+  const set = (key: string, value: unknown) => {
+    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+  const frames: Array<(t: number) => void> = []
+  const clock: Clock = { now: 0 }
+  set("performance", { now: () => clock.now })
+  set("document", rig.doc)
+  set("devicePixelRatio", 2)
+  set("requestAnimationFrame", (fn: (t: number) => void) => {
+    frames.push(fn)
+    return frames.length
+  })
+  set("cancelAnimationFrame", () => {})
+  if (typeof g.addEventListener !== "function") set("addEventListener", () => {})
+  if (typeof g.removeEventListener !== "function") set("removeEventListener", () => {})
+
+  try {
+    body({ ...rig, frames, clock })
+  } finally {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+      else Reflect.deleteProperty(globalThis, key)
+    }
+  }
+}
+
+/**
+ * The listener a game registered on an element, proved to be there.
+ *
+ * `el.listeners.get("pointerdown")?.[0] as Listener` types the hole shut
+ * without ever looking into it: a game that stopped wiring its canvas hands
+ * back `undefined`, the cast calls it a `Listener`, and any `assert.ok` on the
+ * result is vacuously true — `tsc` says so, TS2774. Throwing here is the check.
+ */
+export function listenerOn(el: FakeElement, type: string): Listener {
+  const fn = el.listeners.get(type)?.[0]
+  if (!fn) throw new Error(`nothing was ever registered for "${type}"`)
+  return fn
+}
+
+/** The canvas is the first element `mount` creates. */
+export function canvasOf(created: FakeElement[]): FakeElement {
+  const el = created[0]
+  if (!el) throw new Error("mount did not create a canvas")
+  return el
+}
+
+/**
+ * Run `n` frames at 60 Hz, draining the rAF queue each time.
+ *
+ * The wall clock moves with the frames, because it does on a device — which is
+ * the whole point of the latency cases: a sheet held up for half a minute moves
+ * `performance.now()` by half a minute whether or not the game is running.
+ */
+export function pump(
+  frames: Array<(t: number) => void>,
+  n: number,
+  from = 0,
+  clock?: Clock,
+): number {
+  let t = from
+  for (let i = 0; i < n; i++) {
+    const next = frames.pop()
+    frames.length = 0
+    if (!next) break
+    t += 16.7
+    if (clock) clock.now = t
+    next(t)
+  }
+  return t
+}

--- a/dynawalla/games/counterweight/src/test/manual-freeze.test.ts
+++ b/dynawalla/games/counterweight/src/test/manual-freeze.test.ts
@@ -1,0 +1,318 @@
+// THE YARD STOPS WHILE THE RULES ARE READ.
+//
+// "All games should pause while reading the instructions .. I can hear
+// counterweight playing in the background while I'm reading the instructions
+// ... stressing me out even more."
+//
+// This is the game that was named. The shared how-to-play sheet holds the sound
+// itself now, and the keys and the taps with it — but it cannot hold a game's
+// own clock, and the clock is the part with teeth here. A press window that
+// opens, runs and whistles behind the scrim costs the child a weight they never
+// saw, and the sag drains their pan while they read.
+//
+// `mount.test.ts` already drives the host's `pause()` and a backgrounded tab.
+// Neither of those is this: the defect was that the manual reached NEITHER of
+// them. So this file never calls `pause()`. It finds the `dwc-help` control the
+// shared module mounted, fires its own click handler the way a finger does, and
+// watches the yard.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import type { Host } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+import { viewLayout } from "../render/layout.ts"
+import { canvasOf, listenerOn, pump, withBrowser, type FakeElement } from "./browser.ts"
+
+const W = 768
+const H = 1024
+
+/** Every face on the rack, from the real layout rather than a guessed point. */
+function facePoints(): Array<{ x: number; y: number }> {
+  return viewLayout(W, H).pillars.flatMap((pillar) =>
+    [pillar.up, pillar.down].map((r) => ({ x: r.x + r.w / 2, y: r.y + r.h / 2 })),
+  )
+}
+
+function seatPoint(): { x: number; y: number } {
+  const { seat } = viewLayout(W, H)
+  return { x: seat.x + seat.w / 2, y: seat.y + seat.h / 2 }
+}
+
+/** The shared module's own controls, found the way a child's finger finds them. */
+function control(created: FakeElement[], className: string): () => void {
+  const el = created.find((e) => e.className === className)
+  assert.ok(el, `the shared chrome never mounted a .${className}`)
+  const click = el.listeners.get("click")?.[0]
+  assert.ok(click, `.${className} was mounted with no click handler`)
+  return () => click({ type: "click", target: el })
+}
+
+type World = {
+  /**
+   * Every ending a weight can have — seated, or whistled. Both close an item,
+   * and a yard whose clock has stopped produces neither.
+   */
+  closed: unknown[]
+  /** Weights the game asked the host for. A frozen bout asks for nothing. */
+  asked: number
+  /** A strike that reached the rules fires one. Nothing else does. */
+  haptics: string[]
+  reports: Array<{ ms: number }>
+}
+
+function stub(world: World): Host {
+  const base = createStubHost({ seed: 0x51ab, reducedMotion: true })
+  return {
+    ...base,
+    next: (o) => {
+      world.asked++
+      return base.next(o)
+    },
+    report: (r) => {
+      world.reports.push(r)
+      world.closed.push(r)
+    },
+    skip: (id) => {
+      world.closed.push(id)
+    },
+    haptic: (k) => {
+      world.haptics.push(k)
+    },
+  }
+}
+
+const counter = () => ({ calls: 0, text: [] as string[] })
+
+/**
+ * Run the yard until a round has actually gone by.
+ *
+ * A fixed frame count would be a guess about the press window, and the window
+ * is deliberately a function of the sum. Waiting for the observable instead
+ * means the test says what it means: the world was demonstrably turning before
+ * anything was asked of it.
+ */
+function untilARoundGoesBy(
+  frames: Array<(t: number) => void>,
+  world: World,
+  from: number,
+  clock: { now: number },
+): number {
+  let t = from
+  for (let i = 0; i < 400 && world.closed.length === 0; i++) t = pump(frames, 100, t, clock)
+  assert.ok(world.closed.length > 0, "no round ever went by")
+  return t
+}
+
+test("MANUAL FREEZES THE YARD: no window opens, closes or whistles behind the rules", () => {
+  withBrowser({ w: W, h: H }, counter(), ({ host, frames, created, clock }) => {
+    const world: World = { closed: [], asked: 0, haptics: [], reports: [] }
+    const handle = mount(host as unknown as HTMLElement, stub(world))
+    let t = untilARoundGoesBy(frames, world, 0, clock)
+
+    const open = control(created, "dwc-help")
+    const close = control(created, "dwc-close")
+    open()
+
+    const closed = world.closed.length
+    const asked = world.asked
+    // A hundred seconds behind the scrim — more than two whole press windows,
+    // which is exactly what the child used to lose by reading.
+    t = pump(frames, 6000, t, clock)
+
+    assert.equal(
+      world.closed.length,
+      closed,
+      `${world.closed.length - closed} rounds were closed while the child was reading the rules`,
+    )
+    assert.equal(world.asked, asked, "a weight was hung behind the manual")
+
+    close()
+    t = pump(frames, 6000, t, clock)
+    assert.ok(world.closed.length > closed, "the yard never came back after the manual closed")
+    assert.ok(world.asked > asked, "no new weight was hung after the manual closed")
+    handle.unmount()
+  })
+})
+
+test("a blow struck behind the manual is not a blow", () => {
+  withBrowser({ w: W, h: H }, counter(), ({ host, frames, created, clock }) => {
+    const world: World = { closed: [], asked: 0, haptics: [], reports: [] }
+    const handle = mount(host as unknown as HTMLElement, stub(world))
+    const canvas = canvasOf(created)
+    // `listenerOn` throws if the rack was never wired to anything. An
+    // `assert.ok` on a `as Listener` cast could not: the cast makes it
+    // non-nullable before the assertion ever sees it.
+    const down = listenerOn(canvas, "pointerdown")
+    const up = listenerOn(canvas, "pointerup")
+    const hit = (p: { x: number; y: number }): void => {
+      down({ preventDefault: () => undefined, clientX: p.x, clientY: p.y })
+      up({})
+    }
+
+    let t = pump(frames, 120, 0, clock)
+    // The positive control. Without it, "nothing happened" below would pass
+    // just as well for a sweep that lands on no plate at all.
+    for (const p of facePoints()) {
+      hit(p)
+      t = pump(frames, 20, t, clock)
+    }
+    assert.ok(world.haptics.length > 0, "the sweep never struck a plate, so it proves nothing")
+
+    const open = control(created, "dwc-help")
+    const close = control(created, "dwc-close")
+    open()
+    const haptics = world.haptics.length
+    const closed = world.closed.length
+    // A child reading a manual still has a thumb on the glass. The shared
+    // module swallows the pointer before the game sees it on a device; this
+    // goes round the swallow and calls the game's own handler, which must
+    // refuse as well — belt and braces, because only one of the two is ours.
+    for (const p of facePoints()) {
+      hit(p)
+      t = pump(frames, 20, t, clock)
+    }
+    hit(seatPoint())
+    t = pump(frames, 60, t, clock)
+
+    assert.equal(world.haptics.length, haptics, "a blow behind the manual reached the rack")
+    assert.equal(world.closed.length, closed, "the beam was seated through the manual")
+
+    close()
+    t = pump(frames, 30, t, clock)
+    for (const p of facePoints()) {
+      hit(p)
+      t = pump(frames, 20, t, clock)
+    }
+    assert.ok(world.haptics.length > haptics, "the rack never came back after the manual closed")
+    handle.unmount()
+  })
+})
+
+test("the read is not billed to the child as thinking time", () => {
+  // Latency is measured against the wall clock, and the wall clock keeps
+  // running behind the manual. Unless `onOpen` reaches `pauseAll`, a child who
+  // spends half a minute in the rules is recorded as a child who spent half a
+  // minute failing to evaluate a column, and the fluency model reads it as
+  // difficulty.
+  const SHEET_FRAMES = 1800
+  withBrowser({ w: W, h: H }, counter(), ({ host, frames, created, clock }) => {
+    const world: World = { closed: [], asked: 0, haptics: [], reports: [] }
+    const handle = mount(host as unknown as HTMLElement, stub(world))
+    const canvas = canvasOf(created)
+    const down = listenerOn(canvas, "pointerdown")
+    const up = listenerOn(canvas, "pointerup")
+
+    // Into the window, then the rules for thirty seconds.
+    let t = pump(frames, 90, 0, clock)
+    const open = control(created, "dwc-help")
+    const close = control(created, "dwc-close")
+    open()
+    t = pump(frames, SHEET_FRAMES, t, clock)
+    close()
+    t = pump(frames, 30, t, clock)
+
+    // Then the child seats the beam. A whistle is not reported at all, so the
+    // round has to be *declared* for there to be an `ms` to bill.
+    const lever = seatPoint()
+    down({ preventDefault: () => undefined, clientX: lever.x, clientY: lever.y })
+    up({})
+    t = pump(frames, 30, t, clock)
+    handle.unmount()
+
+    assert.ok(world.reports.length > 0, "no round was ever seated")
+    const sheetMs = SHEET_FRAMES * 16.7
+    const first = world.reports[0]
+    assert.ok(first)
+    assert.ok(
+      first.ms < sheetMs,
+      `${Math.round(first.ms)} ms was billed for a round that had a ${Math.round(sheetMs)} ms manual over it`,
+    )
+  })
+})
+
+test("THE MANUAL ONLY LIFTS ITS OWN PAUSE: closing it cannot restart a host-paused game", () => {
+  // The host puts a sheet over a still-mounted pack — a parent gate, a stopping
+  // point, and this game raises one itself every time a Turk goes over. A child
+  // stuck behind it opens the rules and closes them again. Without the guard,
+  // the yard is handed back RUNNING underneath a sheet that is still up, and
+  // the next window opens and whistles where nobody can see it.
+  withBrowser({ w: W, h: H }, counter(), ({ host, frames, created, clock }) => {
+    const world: World = { closed: [], asked: 0, haptics: [], reports: [] }
+    const handle = mount(host as unknown as HTMLElement, stub(world))
+    let t = untilARoundGoesBy(frames, world, 0, clock)
+
+    handle.pause()
+    const closed = world.closed.length
+    const asked = world.asked
+
+    const open = control(created, "dwc-help")
+    const close = control(created, "dwc-close")
+    open()
+    t = pump(frames, 3000, t, clock)
+    close()
+    // Fifty more seconds after the manual is put away, and the host has never
+    // lifted its sheet.
+    t = pump(frames, 3000, t, clock)
+
+    assert.equal(world.closed.length, closed, "the manual handed a host-paused game back to the loop")
+    assert.equal(world.asked, asked, "a weight was hung behind the host's sheet")
+
+    // And the host's own resume still works: the pause was not double-counted.
+    handle.resume()
+    t = pump(frames, 6000, t, clock)
+    assert.ok(world.closed.length > closed, "the game never came back when the host lifted its sheet")
+    handle.unmount()
+  })
+})
+
+test("a backgrounded tab, read behind, and brought back is still stopped by the manual", () => {
+  // Both pauses are the same flag, so the order they arrive in matters. A tab
+  // hidden first must not let the manual's close resume the yard.
+  withBrowser({ w: W, h: H }, counter(), ({ host, frames, created, doc, clock }) => {
+    const world: World = { closed: [], asked: 0, haptics: [], reports: [] }
+    const handle = mount(host as unknown as HTMLElement, stub(world))
+    let t = untilARoundGoesBy(frames, world, 0, clock)
+
+    doc.visibilityState = "hidden"
+    for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
+    const closed = world.closed.length
+
+    const open = control(created, "dwc-help")
+    const close = control(created, "dwc-close")
+    open()
+    t = pump(frames, 1500, t, clock)
+    close()
+    t = pump(frames, 3000, t, clock)
+    assert.equal(world.closed.length, closed, "the manual resumed a backgrounded tab")
+
+    doc.visibilityState = "visible"
+    for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
+    t = pump(frames, 6000, t, clock)
+    assert.ok(world.closed.length > closed, "the yard never came back when the tab did")
+    handle.unmount()
+  })
+})
+
+test("opening and closing the manual repeatedly is not a stack of pauses", () => {
+  withBrowser({ w: W, h: H }, counter(), ({ host, frames, created, clock }) => {
+    const world: World = { closed: [], asked: 0, haptics: [], reports: [] }
+    const handle = mount(host as unknown as HTMLElement, stub(world))
+    let t = pump(frames, 300, 0, clock)
+    const open = control(created, "dwc-help")
+    const close = control(created, "dwc-close")
+    for (let round = 0; round < 6; round++) {
+      open()
+      open() // already open: the module refuses, and `onOpen` must not run twice
+      const asked = world.asked
+      t = pump(frames, 1200, t, clock)
+      assert.equal(world.asked, asked, `read ${round} did not stop the yard`)
+      close()
+      close() // and a double close must not resume a game twice
+      t = pump(frames, 1200, t, clock)
+      assert.ok(world.asked > asked, `read ${round} left the game stuck paused`)
+    }
+    handle.unmount()
+  })
+})

--- a/dynawalla/games/counterweight/src/test/mount.test.ts
+++ b/dynawalla/games/counterweight/src/test/mount.test.ts
@@ -5,11 +5,12 @@
 // renamed in `render/` and not in `mount.ts`, a value read before it is
 // assigned: all compile, and all crash on the first frame in front of a child.
 //
-// So this mounts the real game against a canvas that records instead of paints,
-// drives several hundred frames through weights hung, plates struck, beams
-// seated and Turks put over, and asserts that nothing threw and that the world
-// actually moved. It is not a rendering test — there are no pixels — it is a
-// test that the whole thing is wired to itself.
+// So this mounts the real game against `./browser.ts` — a canvas that records
+// instead of painting and a clock the test drives by hand — pushes several
+// hundred frames through weights hung, plates struck, beams seated and Turks
+// put over, and asserts that nothing threw and that the world actually moved.
+// It is not a rendering test — there are no pixels — it is a test that the
+// whole thing is wired to itself.
 //
 // It also drives the two pause paths the host can take: the sheet (`pause()`)
 // and a backgrounded tab (`visibilitychange`).
@@ -24,188 +25,7 @@ import { PLACES, planStrikes } from "../game/places.ts"
 import { viewLayout } from "../render/layout.ts"
 import { OPENING_RUNG } from "../game/ladder.ts"
 import { createStubHost } from "../stubHost.ts"
-
-type Listener = (event: unknown) => void
-
-/** A 2D context that answers every call and records how much work it was asked for. */
-function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderingContext2D {
-  const store = new Map<string, unknown>()
-  const noop = (name: string) =>
-    function (...args: unknown[]) {
-      counter.calls++
-      if (name === "fillText" && typeof args[0] === "string") counter.text.push(args[0])
-      // Gradients are the one call whose result is used, so everything returns
-      // something that can take a colour stop.
-      return { addColorStop() {} }
-    }
-  return new Proxy(
-    {},
-    {
-      get(_t, prop: string) {
-        if (store.has(prop)) return store.get(prop)
-        return noop(prop)
-      },
-      set(_t, prop: string, value) {
-        store.set(prop, value)
-        return true
-      },
-    },
-  ) as unknown as CanvasRenderingContext2D
-}
-
-type FakeElement = {
-  id: string
-  style: Record<string, string>
-  width: number
-  height: number
-  listeners: Map<string, Listener[]>
-  appendChild(child: unknown): void
-  append(...children: unknown[]): void
-  setAttribute(name: string, value: string): void
-  focus(): void
-  remove(): void
-  addEventListener(type: string, fn: Listener): void
-  removeEventListener(type: string, fn: Listener): void
-  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
-  getContext(): CanvasRenderingContext2D
-}
-
-function harness(size: { w: number; h: number }, counter: { calls: number; text: string[] }) {
-  const ctx = fakeContext(counter)
-  const make = (): FakeElement => {
-    const listeners = new Map<string, Listener[]>()
-    return {
-      id: "",
-      style: { cssText: "" },
-      width: 0,
-      height: 0,
-      listeners,
-      appendChild() {},
-      append() {},
-      setAttribute() {},
-      focus() {},
-      remove() {},
-      addEventListener(type, fn) {
-        const list = listeners.get(type) ?? []
-        list.push(fn)
-        listeners.set(type, list)
-      },
-      removeEventListener(type, fn) {
-        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
-      },
-      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
-      getContext: () => ctx,
-    }
-  }
-  const created: FakeElement[] = []
-  // The shared chrome adds two things this stub has to answer for: the
-  // safe-area probe, which looks itself up by id before making a second one,
-  // and the how-to-play panel, which builds a small tree of buttons and lists.
-  // Both are DOM the game now really does create, so the fake DOM grows to meet
-  // them rather than the game being asked to skip them under test.
-  const doc = {
-    visibilityState: "visible",
-    listeners: new Map<string, Listener[]>(),
-    body: { appendChild() {} },
-    activeElement: null,
-    createElement() {
-      const el = make()
-      created.push(el)
-      return el
-    },
-    getElementById(id: string): FakeElement | null {
-      return created.find((el) => el.id === id) ?? null
-    },
-    addEventListener(type: string, fn: Listener) {
-      const list = doc.listeners.get(type) ?? []
-      list.push(fn)
-      doc.listeners.set(type, list)
-    },
-    removeEventListener(type: string, fn: Listener) {
-      doc.listeners.set(type, (doc.listeners.get(type) ?? []).filter((f) => f !== fn))
-    },
-  }
-  return { host: make(), doc, created, ctx }
-}
-
-type Clock = { now: number }
-type Rig = ReturnType<typeof harness> & {
-  frames: Array<(t: number) => void>
-  /** The wall clock `mount.ts` bills latency against, under the test's control. */
-  clock: Clock
-}
-
-/**
- * Install the browser globals `mount.ts` needs, run `body`, and take them back
- * off again — including when `body` throws, which is the case this file exists
- * to catch.
- */
-function withBrowser(
-  size: { w: number; h: number },
-  counter: { calls: number; text: string[] },
-  body: (rig: Rig) => void,
-): void {
-  const rig = harness(size, counter)
-  const g = globalThis as Record<string, unknown>
-  const saved = new Map<string, PropertyDescriptor | undefined>()
-  const set = (key: string, value: unknown) => {
-    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
-    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
-  }
-  const frames: Array<(t: number) => void> = []
-  const clock: Clock = { now: 0 }
-  set("performance", { now: () => clock.now })
-  set("document", rig.doc)
-  set("devicePixelRatio", 2)
-  set("requestAnimationFrame", (fn: (t: number) => void) => {
-    frames.push(fn)
-    return frames.length
-  })
-  set("cancelAnimationFrame", () => {})
-  if (typeof g.addEventListener !== "function") set("addEventListener", () => {})
-  if (typeof g.removeEventListener !== "function") set("removeEventListener", () => {})
-
-  try {
-    body({ ...rig, frames, clock })
-  } finally {
-    for (const [key, descriptor] of saved) {
-      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
-      else Reflect.deleteProperty(globalThis, key)
-    }
-  }
-}
-
-/** The canvas is the second element `mount` creates: the root stand-in, then it. */
-function canvasOf(created: FakeElement[]): FakeElement {
-  const el = created[0]
-  if (!el) throw new Error("mount did not create a canvas")
-  return el
-}
-
-/**
- * Run `n` frames at 60 Hz, draining the rAF queue each time.
- *
- * The wall clock moves with the frames, because it does on a device — which is
- * the whole point of the latency case below: a sheet held up for half a minute
- * moves `performance.now()` by half a minute whether or not the game is running.
- */
-function pump(
-  frames: Array<(t: number) => void>,
-  n: number,
-  from = 0,
-  clock?: Clock,
-): number {
-  let t = from
-  for (let i = 0; i < n; i++) {
-    const next = frames.pop()
-    frames.length = 0
-    if (!next) break
-    t += 16.7
-    if (clock) clock.now = t
-    next(t)
-  }
-  return t
-}
+import { canvasOf, pump, withBrowser, type Listener } from "./browser.ts"
 
 /**
  * Every face on the rack, taken from the real layout rather than guessed. A

--- a/dynawalla/games/serpent/src/game/manual.test.ts
+++ b/dynawalla/games/serpent/src/game/manual.test.ts
@@ -1,0 +1,381 @@
+/**
+ * FROZEN BEHIND THE MANUAL.
+ *
+ * "All games should pause while reading the instructions .. I can hear
+ * counterweight playing in the background while I'm reading the instructions ...
+ * stressing me out even more."
+ *
+ * The shared how-to-play sheet holds sound, keys and taps for every game with no
+ * per-game line. What it cannot hold is a game's own simulation clock, and in
+ * this game that clock is a snake that keeps swimming, an arena that keeps
+ * shrinking and a wall that keeps closing in behind the scrim a child raised
+ * *because they were stuck*.
+ *
+ * So this file mounts the real game against a headless surface, reaches the
+ * shared module's own help button the way a finger does, and watches the world.
+ * Three things are proved, and each one fails if the `onOpen`/`onClose` pair in
+ * `mount.ts` is deleted:
+ *
+ *   1. The water stops. Not "a flag was set" — `world.time`, the head's
+ *      position and every orb hold exactly where they were, for three minutes
+ *      of frames.
+ *   2. It starts again on close, and does not teleport: the first frame after
+ *      the sheet carries a normal delta, not the whole read.
+ *   3. **A dive the CHILD paused stays paused.** They have their own pause verb
+ *      here. Opening the manual on top of their own pause and closing it must
+ *      not hand them back a moving snake.
+ *
+ * The fake elements below carry a listener map EACH, which is not tidiness: the
+ * help button and the PLAY button both register a `"click"`, so one shared map
+ * keyed by type silently drops the first and the test opens nothing.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/index.ts";
+import { mountSerpent } from "./mount.ts";
+import { createStubHost } from "../stub/host.ts";
+import type { Host } from "../contract.ts";
+
+type Handler = (e: unknown) => void;
+
+type FakeEl = {
+  className: string;
+  fire(type: string, event?: unknown): void;
+  has(type: string): boolean;
+  [key: string]: unknown;
+};
+
+function makeSurface(width = 768, height = 1024) {
+  const created: FakeEl[] = [];
+  const rect = { left: 0, top: 0, right: width, bottom: height, width, height, x: 0, y: 0 };
+
+  // Every method returns the context, so chained builder calls work; every
+  // property read is a callable. Nothing about pixels is asserted here.
+  const ctx: unknown = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "then") return undefined;
+        if (typeof prop === "symbol") return undefined;
+        return () => ctx;
+      },
+      set: () => true,
+    },
+  );
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>();
+    const el = {
+      style: {} as Record<string, unknown>,
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: 400,
+      appendChild: (c: unknown) => c,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? [];
+        list.push(h);
+        listeners.set(type, list);
+      },
+      removeEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? [];
+        const at = list.indexOf(h);
+        if (at >= 0) list.splice(at, 1);
+      },
+      has: (type: string) => (listeners.get(type) ?? []).length > 0,
+      fire(type: string, event: unknown = {}) {
+        for (const h of [...(listeners.get(type) ?? [])]) h(event);
+      },
+    } as unknown as FakeEl;
+    created.push(el);
+    return el;
+  };
+
+  const root = makeEl();
+  const globalKeys = new Map<string, Handler[]>();
+  let pending: ((t: number) => void) | null = null;
+  let clock = 0;
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    add: globalThis.addEventListener,
+    remove: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    win: (globalThis as { window?: unknown }).window,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    random: Math.random,
+  };
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb;
+      return 1;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null;
+    }) as typeof globalThis.cancelAnimationFrame;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    };
+    performance.now = () => clock;
+    // The arena is scattered with `Math.random` — where the orbs sit, which way
+    // the serpent is facing on the first frame. Left alone, this whole file is
+    // green four runs in five and has therefore proved nothing: the dive
+    // sometimes ends before the manual is ever opened. A pinned stream makes a
+    // failure reproducible from the failure message alone.
+    let bits = 0x9e3779b9;
+    Math.random = (): number => {
+      bits = (bits + 0x6d2b79f5) | 0;
+      let t = Math.imul(bits ^ (bits >>> 15), 1 | bits);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+    globalThis.addEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? [];
+      list.push(h);
+      globalKeys.set(type, list);
+    }) as unknown as typeof globalThis.addEventListener;
+    globalThis.removeEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? [];
+      const at = list.indexOf(h);
+      if (at >= 0) list.splice(at, 1);
+    }) as unknown as typeof globalThis.removeEventListener;
+    (globalThis as { document?: unknown }).document = {
+      createElement: (tag: string) => {
+        const el = makeEl();
+        el.tag = tag;
+        return el;
+      },
+      getElementById: () => null,
+      body: makeEl(),
+      hidden: false,
+      activeElement: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    };
+    (globalThis as { window?: unknown }).window = globalThis;
+    (globalThis as { innerWidth?: number }).innerWidth = width;
+    (globalThis as { innerHeight?: number }).innerHeight = height;
+    (globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2;
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf;
+      globalThis.cancelAnimationFrame = saved.caf;
+      (globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro;
+      performance.now = saved.now;
+      globalThis.addEventListener = saved.add;
+      globalThis.removeEventListener = saved.remove;
+      (globalThis as { document?: unknown }).document = saved.doc;
+      (globalThis as { window?: unknown }).window = saved.win;
+      (globalThis as { devicePixelRatio?: number | undefined }).devicePixelRatio = saved.dpr;
+      Math.random = saved.random;
+      forgetAudioContexts();
+    };
+  };
+
+  return {
+    root,
+    install,
+    step(ms: number): void {
+      clock += ms;
+      const cb = pending;
+      pending = null;
+      cb?.(clock);
+    },
+    now: () => clock,
+    key(type: string, event: unknown): void {
+      for (const h of [...(globalKeys.get(type) ?? [])]) h(event);
+    },
+    /** The shared module's own controls, found the way a finger finds them. */
+    help: () => created.find((e) => e.className === "dwc-help"),
+    closeButton: () => created.find((e) => e.className === "dwc-close"),
+    canvas: () => created.find((e) => e.tag === "canvas"),
+  };
+}
+
+function rig(): {
+  surface: ReturnType<typeof makeSurface>;
+  handle: ReturnType<typeof mountSerpent>;
+  stop(): void;
+} {
+  const surface = makeSurface();
+  const restore = surface.install();
+  const host: Host = createStubHost({ seed: "manual-freeze" });
+  const handle = mountSerpent(surface.root as unknown as HTMLElement, host);
+  return {
+    surface,
+    handle,
+    stop(): void {
+      handle.unmount();
+      restore();
+    },
+  };
+}
+
+/** Tap the middle of the water: in attract that is what starts a dive. */
+function tapCentre(surface: ReturnType<typeof makeSurface>): void {
+  const canvas = surface.canvas();
+  assert.ok(canvas, "the game mounted no canvas");
+  const event = {
+    pointerId: 1,
+    pointerType: "mouse",
+    isPrimary: true,
+    button: 0,
+    buttons: 1,
+    clientX: 384,
+    clientY: 512,
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined,
+  };
+  canvas.fire("pointerdown", event);
+  canvas.fire("pointerup", { ...event, buttons: 0 });
+}
+
+function openManual(surface: ReturnType<typeof makeSurface>): void {
+  const help = surface.help();
+  assert.ok(help, "the shared how-to-play button was never mounted");
+  help.fire("click", { target: help, type: "click" });
+}
+
+function closeManual(surface: ReturnType<typeof makeSurface>): void {
+  const button = surface.closeButton();
+  assert.ok(button, "the sheet has no PLAY button");
+  button.fire("click", { target: button, type: "click" });
+}
+
+/** Everything about the world a frame is allowed to change. */
+function snapshot(world: ReturnType<typeof mountSerpent>["world"]): string {
+  return JSON.stringify({
+    time: world.time,
+    runTime: world.runTime,
+    x: world.serpent.x,
+    y: world.serpent.y,
+    heading: world.serpent.heading,
+    segments: world.serpent.segments,
+    pathHead: world.serpent.pathHead,
+    bodyX: [...world.serpent.bodyX.slice(0, world.serpent.bodyCount)],
+    arenaR: world.arenaR,
+    score: world.score,
+    depth: world.depth,
+    combo: world.combo,
+    orbs: world.orbs.map((o) => [o.x, o.y, o.label]),
+  });
+}
+
+test("the water stops while the rules are up, and starts again when they go down", () => {
+  const { surface, handle, stop } = rig();
+  try {
+    for (let i = 0; i < 60; i++) surface.step(16);
+    tapCentre(surface);
+    for (let i = 0; i < 240; i++) surface.step(16);
+    assert.equal(handle.world.phase, "play", "the dive never started");
+
+    // The observable is live: a frame of play moves the world.
+    const before = snapshot(handle.world);
+    surface.step(16);
+    assert.notEqual(snapshot(handle.world), before, "the snake was not moving to begin with");
+
+    openManual(surface);
+    const held = snapshot(handle.world);
+    // Three minutes of frames behind the sheet — longer than any child reads,
+    // and long enough that a leak of even a hundredth of a second per frame
+    // would be unmissable.
+    for (let i = 0; i < 11_250; i++) surface.step(16);
+    assert.equal(snapshot(handle.world), held, "the world moved behind the manual");
+
+    closeManual(surface);
+    // And it does not teleport. One frame after the sheet must carry one
+    // frame's worth of world, not three minutes of it.
+    const timeAtClose = handle.world.time;
+    surface.step(16);
+    const firstStep = handle.world.time - timeAtClose;
+    assert.ok(firstStep > 0, "the water never started again");
+    assert.ok(
+      firstStep < 0.1,
+      `the first frame after the sheet carried ${firstStep.toFixed(3)}s of simulation`,
+    );
+
+    for (let i = 0; i < 120; i++) surface.step(16);
+    assert.ok(handle.world.time > timeAtClose + 1, "the world did not come back");
+  } finally {
+    stop();
+  }
+});
+
+test("a dive the CHILD paused is still paused when they close the rules", () => {
+  const { surface, handle, stop } = rig();
+  try {
+    for (let i = 0; i < 60; i++) surface.step(16);
+    tapCentre(surface);
+    for (let i = 0; i < 240; i++) surface.step(16);
+    assert.equal(handle.world.phase, "play");
+
+    // Their own pause verb. A child who stops the game, opens the manual to
+    // work out what the rule in the middle means, and closes it again has not
+    // asked to be dropped back into a moving arena.
+    surface.key("keydown", { code: "KeyP", key: "p", preventDefault: () => undefined });
+    surface.step(16);
+    assert.equal(handle.world.paused, true, "the pause key did nothing");
+
+    const held = snapshot(handle.world);
+    openManual(surface);
+    for (let i = 0; i < 600; i++) surface.step(16);
+    closeManual(surface);
+    for (let i = 0; i < 600; i++) surface.step(16);
+
+    assert.equal(handle.world.paused, true, "closing the manual lifted the child's own pause");
+    assert.equal(snapshot(handle.world), held, "the snake swam again after the rules closed");
+  } finally {
+    stop();
+  }
+});
+
+test("the manual is not thinking time: the answer clock is rebased across it", () => {
+  const { surface, handle, stop } = rig();
+  try {
+    for (let i = 0; i < 60; i++) surface.step(16);
+    tapCentre(surface);
+    for (let i = 0; i < 240; i++) surface.step(16);
+    assert.equal(handle.world.phase, "play");
+
+    const trial = handle.world.pending[0];
+    assert.ok(trial, "no question was live");
+    // How long the child has had this question so far. Everything after this is
+    // reading, and reading is not answering.
+    const spentBefore = surface.now() - trial.servedAtMs;
+
+    openManual(surface);
+    for (let i = 0; i < 11_250; i++) surface.step(16); // three minutes
+    closeManual(surface);
+
+    const spentAfter = surface.now() - trial.servedAtMs;
+    assert.ok(
+      Math.abs(spentAfter - spentBefore) < 50,
+      `the sheet put ${Math.round(spentAfter - spentBefore)}ms of reading on the child's record`,
+    );
+  } finally {
+    stop();
+  }
+});

--- a/dynawalla/games/serpent/src/game/manual.test.ts
+++ b/dynawalla/games/serpent/src/game/manual.test.ts
@@ -33,7 +33,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/index.ts";
+// From `audioHold.ts` directly, not the barrel: `index.ts` deliberately does
+// NOT re-export this, because a game that reached for it would defeat the hold
+// for the whole pack. Node 24 enforces that — Node 22's type stripping does
+// not, which is how the wrong import passed locally and failed in CI.
+import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/audioHold.ts";
 import { mountSerpent } from "./mount.ts";
 import { createStubHost } from "../stub/host.ts";
 import type { Host } from "../contract.ts";

--- a/dynawalla/games/serpent/src/game/mount.ts
+++ b/dynawalla/games/serpent/src/game/mount.ts
@@ -19,7 +19,7 @@ import { simDelta, updateCamera } from "./fx/camera.ts";
 import { createRenderer, type View } from "./render/scene.ts";
 import { hudLayout, soundTarget } from "./render/chrome.ts";
 import { drawHud } from "./render/hud.ts";
-import { confirmPressed, createWorld, stepWorld, type World } from "./world.ts";
+import { confirmPressed, createWorld, setPaused, stepWorld, type World } from "./world.ts";
 import { clamp } from "./num.ts";
 
 const FIXED = 1 / 120;
@@ -82,7 +82,7 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
 
   const onVisibility = (): void => {
     if (document.hidden) {
-      if (world.phase === "play") world.paused = true;
+      if (world.phase === "play") setPaused(world, true);
       audio.ambient(false);
       audio.setBoost(false);
     } else {
@@ -126,13 +126,13 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
 
     if (input.takeMute()) audio.setEnabled(!audio.enabled);
     if (input.takeDebug()) showDebug = !showDebug;
-    if (input.takePause() && world.phase === "play") world.paused = !world.paused;
+    if (input.takePause() && world.phase === "play") setPaused(world, !world.paused);
     if (input.takeConfirm()) {
       if (soundHit(lastTapX, lastTapY)) {
         audio.setEnabled(!audio.enabled);
         if (audio.enabled) audio.ambient(world.phase !== "attract");
       } else if (world.paused) {
-        world.paused = false;
+        setPaused(world, false);
       } else {
         audio.resume();
         confirmPressed(world);
@@ -181,6 +181,12 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
   // it changes — was never said anywhere. Watching a tail get shorter is not an
   // explanation. The manual stays reachable during a dive, because the moment a
   // child needs the rules is never the title screen.
+  //
+  // The water stops while it is up. It is the same pause the P key and the
+  // host's sheet take, and it lifts only what it put on — a child who paused
+  // the dive themselves, then opened the manual, must not find the snake
+  // swimming again because they closed it.
+  let heldForManual = false;
   const guide = createInstructions(el, {
     title: "SERPENT",
     summary: [
@@ -232,6 +238,16 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
       },
     ],
     reducedMotion: reduced,
+    onOpen: () => {
+      if (world.paused) return;
+      heldForManual = true;
+      setPaused(world, true);
+    },
+    onClose: () => {
+      if (!heldForManual) return;
+      heldForManual = false;
+      setPaused(world, false);
+    },
   });
 
   return {

--- a/dynawalla/games/serpent/src/game/world.ts
+++ b/dynawalla/games/serpent/src/game/world.ts
@@ -86,6 +86,13 @@ export type World = {
 
   phase: Phase;
   paused: boolean;
+  /**
+   * Wall clock at which the current pause began, or 0 when running.
+   *
+   * Only `setPaused` writes it. It exists because the answer clock below is
+   * wall clock, not simulation time.
+   */
+  pausedAt: number;
   reduced: boolean;
   time: number;
   runTime: number;
@@ -154,6 +161,7 @@ export function createWorld(host: Host, audio: Audio, reduced: boolean): World {
 
     phase: "attract",
     paused: false,
+    pausedAt: 0,
     reduced,
     time: 0,
     runTime: 0,
@@ -299,11 +307,43 @@ function beginMutation(w: World, q: Question): void {
   if (w.phase === "play") w.host.haptic("medium");
 }
 
+// -------------------------------------------------------------------- pause
+
+/**
+ * Stop the water, or start it again — and keep the answer clock honest across
+ * the gap.
+ *
+ * **Why this is a function and not `w.paused = true`.** Latency here is *wall*
+ * clock: a trial carries the `performance.now()` it was served at, and a bite
+ * bills the child `now − servedAt`. The simulation stopping does nothing to
+ * that. So a child who pauses — their own P key, the host's sheet, or the
+ * how-to-play manual they opened *because they were stuck* — and reads for two
+ * minutes comes back, eats one orb, and puts a 120,000ms answer on their record
+ * for a question they were never looking at. Reading the rules must not be
+ * evidence about a child.
+ *
+ * Every live trial's start therefore moves forward by exactly the length of the
+ * pause, so the gap is spent by nobody. Idempotent in both directions: a second
+ * pause does not move the mark and a resume of a running world is nothing.
+ */
+export function setPaused(w: World, paused: boolean): void {
+  if (w.paused === paused) return;
+  w.paused = paused;
+  if (paused) {
+    w.pausedAt = nowMs();
+    return;
+  }
+  const held = Math.max(0, nowMs() - w.pausedAt);
+  for (const p of w.pending) p.servedAtMs += held;
+  w.pausedAt = 0;
+}
+
 // --------------------------------------------------------------------- run
 
 export function resetRun(w: World, phase: Phase): void {
   w.phase = phase;
   w.paused = false;
+  w.pausedAt = 0;
   w.runTime = 0;
   w.depth = 1;
   w.score = 0;

--- a/dynawalla/games/skyledger/src/mount.ts
+++ b/dynawalla/games/skyledger/src/mount.ts
@@ -17,6 +17,13 @@
 // pack that registers a `pause()` and never wires it up is the exact bug this
 // comment exists to prevent.
 //
+// The game's own how-to-play sheet is the *other* thing that puts a scrim over
+// a running observatory, and it is the one a child raises deliberately, because
+// they are stuck. Stars falling behind the rules a child opened in order to
+// understand why they were falling is the whole defect. So the manual takes the
+// same pause — but only lifts one it put on itself, or a watch the host had
+// already stopped would come back running the moment the rules were closed.
+//
 // **Hitstop and timescale.** The escalation's channels arrive on the bloom
 // event. Hitstop is a global time-scale of exactly zero applied to the
 // simulation only: audio keeps ringing, input keeps being sampled, and the
@@ -64,44 +71,6 @@ export function mountSkyLedger(
   const scene = new Scene(canvas, reduced, seed)
   const audio = new Audio()
 
-  // How to play. SKY LEDGER shipped with no instructions at all: a child was
-  // shown a sky, a dial and the words "THE REGISTER IS EMPTY", and nothing told
-  // them the dial is how you name where to strike. The manual stays reachable
-  // during play, because the moment a child needs the rules is never the title.
-  const guide = createInstructions(el, {
-    title: "SKY LEDGER",
-    summary: [
-      "Trails fall out of the dark. Each one is heading for a place in the sky.",
-      "Turn the astrolabe to name that place — across, then up — and strike it.",
-    ],
-    sections: [
-      {
-        heading: "Naming a place",
-        lines: [
-          "The sky is a grid. Every place in it has two numbers: how far across, then how far up.",
-          "The astrolabe has one ring for each. Turn them until the pair matches the trail.",
-          "You are not pointing at the answer. You are saying it.",
-        ],
-      },
-      {
-        heading: "Chains",
-        lines: [
-          "Strike a second trail before the light fades and the two link.",
-          "Each link renews the light, so a chain is a rhythm rather than a race.",
-          "Nine links is the longest chain the sky will hold.",
-        ],
-      },
-      {
-        heading: "The watch",
-        lines: [
-          "There is no winning. The watch ends and the observatory writes down what you logged.",
-          "A longer chain is worth more than a faster one.",
-        ],
-      },
-    ],
-    reducedMotion: reduced,
-  })
-
   function now(): number {
     return typeof performance === "object" ? performance.now() : Date.now()
   }
@@ -111,6 +80,8 @@ export function mountSkyLedger(
 
   let running = true
   let paused = false
+  /** Did the manual put this pause on? Only then may closing it lift one. */
+  let heldForManual = false
   let last = 0
   let frame = 0
 
@@ -409,6 +380,94 @@ export function mountSkyLedger(
     typeof ResizeObserver === "function" ? new ResizeObserver(() => scene.resize()) : null
   observer?.observe(canvas)
 
+  // ── the pause ────────────────────────────────────────────────────────────
+  // One pair, reached from two places: the host, through the handle below, and
+  // the manual, through the callbacks under it.
+
+  const doPause = (): void => {
+    if (paused) return
+    paused = true
+    held = null
+    pointer = -1
+    game.pause(now())
+  }
+
+  const doResume = (): void => {
+    // The rules are still up. Whoever asked for this — the host taking its own
+    // sheet down over the top of the manual — the child is still reading, and
+    // the only thing allowed to start the sky again is the rules going down.
+    // Without this the host's resume hands back a running observatory behind a
+    // scrim, which is the whole defect wearing a different hat.
+    if (guide.isOpen) {
+      heldForManual = true
+      return
+    }
+    if (!paused) return
+    paused = false
+    // The next frame is a fresh one. Without this the delta carries the whole
+    // length of the sheet and the sky drops a watch's worth of stars in a
+    // single step the moment the child closes it.
+    last = 0
+    game.resume(now())
+  }
+
+  // ── how to play ──────────────────────────────────────────────────────────
+  //
+  // SKY LEDGER shipped with no instructions at all: a child was shown a sky, a
+  // dial and the words "THE REGISTER IS EMPTY", and nothing told them the dial
+  // is how you name where to strike. The manual stays reachable during play,
+  // because the moment a child needs the rules is never the title.
+  //
+  // Built after the loop rather than before it because it holds the loop:
+  // `onOpen` and `onClose` are the only part of pausing a game has to opt into,
+  // and they need the pair above.
+  const guide = createInstructions(el, {
+    title: "SKY LEDGER",
+    summary: [
+      "Trails fall out of the dark. Each one is heading for a place in the sky.",
+      "Turn the astrolabe to name that place — across, then up — and strike it.",
+    ],
+    sections: [
+      {
+        heading: "Naming a place",
+        lines: [
+          "The sky is a grid. Every place in it has two numbers: how far across, then how far up.",
+          "The astrolabe has one ring for each. Turn them until the pair matches the trail.",
+          "You are not pointing at the answer. You are saying it.",
+        ],
+      },
+      {
+        heading: "Chains",
+        lines: [
+          "Strike a second trail before the light fades and the two link.",
+          "Each link renews the light, so a chain is a rhythm rather than a race.",
+          "Nine links is the longest chain the sky will hold.",
+        ],
+      },
+      {
+        heading: "The watch",
+        lines: [
+          "There is no winning. The watch ends and the observatory writes down what you logged.",
+          "A longer chain is worth more than a faster one.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+    // The manual only lifts a pause it put on itself. A watch the host had
+    // already stopped — a stopping-point card, a parent gate — must not be
+    // handed back running because the child closed the rules.
+    onOpen: () => {
+      if (paused) return
+      heldForManual = true
+      doPause()
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      doResume()
+    },
+  })
+
   return {
     unmount(): void {
       running = false
@@ -424,18 +483,7 @@ export function mountSkyLedger(
       audio.close()
       canvas.remove()
     },
-    pause(): void {
-      if (paused) return
-      paused = true
-      held = null
-      pointer = -1
-      game.pause(now())
-    },
-    resume(): void {
-      if (!paused) return
-      paused = false
-      last = 0
-      game.resume(now())
-    },
+    pause: doPause,
+    resume: doResume,
   }
 }

--- a/dynawalla/games/skyledger/src/test/manual.test.ts
+++ b/dynawalla/games/skyledger/src/test/manual.test.ts
@@ -24,7 +24,11 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/index.ts"
+// From `audioHold.ts` directly, not the barrel: `index.ts` deliberately does
+// NOT re-export this, because a game that reached for it would defeat the hold
+// for the whole pack. Node 24 enforces that; Node 22 does not, which is how the
+// wrong import passed locally and failed in CI.
+import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/audioHold.ts"
 import { mountSkyLedger } from "../mount.ts"
 import { createStubHost } from "../stubHost.ts"
 

--- a/dynawalla/games/skyledger/src/test/manual.test.ts
+++ b/dynawalla/games/skyledger/src/test/manual.test.ts
@@ -1,0 +1,356 @@
+// FROZEN BEHIND THE MANUAL.
+//
+// "All games should pause while reading the instructions .. I can hear
+// counterweight playing in the background while I'm reading the instructions ...
+// stressing me out even more."
+//
+// `pause.test.ts` next door proves the *rules* stop when `Game.pause` is called.
+// It cannot prove that anything ever calls it, and the one surface that must —
+// the game's own how-to-play sheet, which a child raises precisely when they are
+// losing — is opt-in and was not wired. So this file is the wiring's gate: it
+// mounts the whole shell against a headless surface, reaches the shared module's
+// real help button the way a finger does, and watches the sky.
+//
+// **The observable is the host, not the canvas.** This game keeps DRAWING a
+// frozen frame while paused, on purpose, so a count of context calls would be
+// meaningless. What is unambiguously simulation is that a falling star pulls a
+// ledger line from the host when it is released and buzzes the motor when it
+// lands. Neither can happen if the sky is not moving.
+//
+// The fake elements below carry a listener map EACH, which is not tidiness: the
+// help button and the PLAY button both register a `"click"`, so one shared map
+// keyed by type silently drops the first and this test opens nothing.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/index.ts"
+import { mountSkyLedger } from "../mount.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Handler = (e: unknown) => void
+
+type FakeEl = {
+  className: string
+  tag?: string
+  fire(type: string, event?: unknown): void
+  [key: string]: unknown
+}
+
+function makeSurface(width = 768, height = 1024) {
+  const created: FakeEl[] = []
+  const rect = { left: 0, top: 0, right: width, bottom: height, width, height, x: 0, y: 0 }
+
+  const ctx: unknown = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "then") return undefined
+        if (typeof prop === "symbol") return undefined
+        return () => ctx
+      },
+      set: () => true,
+    },
+  )
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>()
+    const el = {
+      style: {} as Record<string, unknown>,
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: 400,
+      appendChild: (c: unknown) => c,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? []
+        list.push(h)
+        listeners.set(type, list)
+      },
+      removeEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? []
+        const at = list.indexOf(h)
+        if (at >= 0) list.splice(at, 1)
+      },
+      fire(type: string, event: unknown = {}) {
+        for (const h of [...(listeners.get(type) ?? [])]) h(event)
+      },
+    } as unknown as FakeEl
+    created.push(el)
+    return el
+  }
+
+  const root = makeEl()
+  const globalKeys = new Map<string, Handler[]>()
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    dateNow: Date.now,
+    add: globalThis.addEventListener,
+    remove: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+  }
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb
+      return 1
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    // The scene seeds itself from the wall clock, which is right on a tablet and
+    // fatal in a test: a suite that is green four runs in five has proved
+    // nothing.
+    Date.now = () => 0x5eed
+    globalThis.addEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? []
+      list.push(h)
+      globalKeys.set(type, list)
+    }) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? []
+      const at = list.indexOf(h)
+      if (at >= 0) list.splice(at, 1)
+    }) as unknown as typeof globalThis.removeEventListener
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: (tag: string) => {
+        const el = makeEl()
+        el.tag = tag
+        return el
+      },
+      getElementById: () => null,
+      body: makeEl(),
+      activeElement: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      Date.now = saved.dateNow
+      globalThis.addEventListener = saved.add
+      globalThis.removeEventListener = saved.remove
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      forgetAudioContexts()
+    }
+  }
+
+  return {
+    root,
+    install,
+    step(ms: number): void {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+    /** The shared module's own controls, found the way a finger finds them. */
+    help: () => created.find((e) => e.className === "dwc-help"),
+    closeButton: () => created.find((e) => e.className === "dwc-close"),
+  }
+}
+
+type Rig = {
+  surface: ReturnType<typeof makeSurface>
+  handle: ReturnType<typeof mountSkyLedger>
+  /** Ledger lines pulled from the host. Only a released star pulls one. */
+  served: () => number
+  haptics: string[]
+  reports: Array<{ ms: number }>
+  stop(): void
+}
+
+function rig(seed = 0x5c7ed6): Rig {
+  const surface = makeSurface()
+  const restore = surface.install()
+  const haptics: string[] = []
+  const reports: Array<{ ms: number }> = []
+  let served = 0
+  const stub = createStubHost({
+    seed,
+    reducedMotion: false,
+    onHaptic: (k) => haptics.push(k),
+    onReport: (r) => reports.push(r),
+  })
+  const host = {
+    ...stub,
+    next: (o?: { domain?: string; difficulty?: number }) => {
+      served++
+      return stub.next(o)
+    },
+  }
+  const handle = mountSkyLedger(surface.root as unknown as HTMLElement, host)
+  return {
+    surface,
+    handle,
+    served: () => served,
+    haptics,
+    reports,
+    stop(): void {
+      handle.unmount()
+      restore()
+    },
+  }
+}
+
+function openManual(surface: ReturnType<typeof makeSurface>): void {
+  const help = surface.help()
+  assert.ok(help, "the shared how-to-play button was never mounted")
+  help.fire("click", { target: help, type: "click" })
+}
+
+function closeManual(surface: ReturnType<typeof makeSurface>): void {
+  const button = surface.closeButton()
+  assert.ok(button, "the sheet has no PLAY button")
+  button.fire("click", { target: button, type: "click" })
+}
+
+test("the sky does not fall while the rules are up", () => {
+  const r = rig()
+  try {
+    // Twenty-four seconds of watch. Stars are released, fall, and land.
+    for (let i = 0; i < 1500; i++) r.surface.step(16)
+    const servedBefore = r.served()
+    const hapticsBefore = r.haptics.length
+    assert.ok(servedBefore > 1, `the sky never released a star (${servedBefore} served)`)
+    assert.ok(hapticsBefore > 0, "nothing ever landed, so there is nothing to freeze")
+
+    openManual(r.surface)
+    // Three minutes behind the sheet. A child reading the manual after a bad
+    // watch should not come back to a dark observatory.
+    for (let i = 0; i < 11_250; i++) r.surface.step(16)
+    assert.equal(r.served(), servedBefore, "the sky pulled a ledger line behind the manual")
+    assert.equal(r.haptics.length, hapticsBefore, "a star landed behind the manual")
+
+    closeManual(r.surface)
+    // And it does not teleport. The frame after the sheet is one frame, not
+    // three minutes: a burst of releases here would mean the sky dumped a whole
+    // read's worth of stars into the ground at once.
+    r.surface.step(16)
+    assert.ok(
+      r.served() - servedBefore <= 1,
+      `${r.served() - servedBefore} ledger lines were pulled in the first frame after the sheet`,
+    )
+
+    for (let i = 0; i < 1800; i++) r.surface.step(16)
+    assert.ok(r.served() > servedBefore, "the sky never started falling again")
+    assert.ok(r.haptics.length > hapticsBefore, "the watch did not come back")
+  } finally {
+    r.stop()
+  }
+})
+
+test("a watch the HOST already stopped is not restarted by closing the rules", () => {
+  // The host puts a sheet over a still-mounted pack — a stopping-point card, a
+  // parent gate, a day-pass offer — and this game raises one itself at the end
+  // of every watch. If the child then opens the manual on top of it and closes
+  // it, the observatory must not start running underneath the host's sheet.
+  const r = rig(0x40b)
+  try {
+    for (let i = 0; i < 1500; i++) r.surface.step(16)
+    assert.ok(r.served() > 1)
+
+    r.handle.pause()
+    const servedBefore = r.served()
+    const hapticsBefore = r.haptics.length
+
+    openManual(r.surface)
+    for (let i = 0; i < 1200; i++) r.surface.step(16)
+    closeManual(r.surface)
+    for (let i = 0; i < 6000; i++) r.surface.step(16)
+
+    assert.equal(r.served(), servedBefore, "closing the manual lifted the host's own pause")
+    assert.equal(r.haptics.length, hapticsBefore, "a star fell out from under the host's sheet")
+
+    // The host's pause is still the host's to lift, and lifting it works.
+    r.handle.resume()
+    for (let i = 0; i < 1800; i++) r.surface.step(16)
+    assert.ok(r.served() > servedBefore, "the host could not restart its own watch")
+  } finally {
+    r.stop()
+  }
+})
+
+test("the host lifting its own sheet does not start the sky behind the manual", () => {
+  // The other order, and the one that reintroduces the whole defect: the host
+  // pauses, the child opens the rules, and then the host takes ITS sheet down
+  // while the manual is still up. The sky must wait for the rules.
+  const r = rig(0x7e57)
+  try {
+    for (let i = 0; i < 1500; i++) r.surface.step(16)
+    assert.ok(r.served() > 1)
+
+    r.handle.pause()
+    openManual(r.surface)
+    const servedBefore = r.served()
+    const hapticsBefore = r.haptics.length
+
+    r.handle.resume()
+    for (let i = 0; i < 6000; i++) r.surface.step(16)
+    assert.equal(r.served(), servedBefore, "the sky fell behind the manual")
+    assert.equal(r.haptics.length, hapticsBefore, "a star landed behind the manual")
+
+    // And closing the rules is what hands it back, because by then the manual
+    // is the only thing still holding it.
+    closeManual(r.surface)
+    for (let i = 0; i < 1800; i++) r.surface.step(16)
+    assert.ok(r.served() > servedBefore, "the watch never came back when the rules went down")
+  } finally {
+    r.stop()
+  }
+})
+
+test("opening and closing the rules repeatedly is not a stack of pauses", () => {
+  const r = rig(0x1de)
+  try {
+    for (let i = 0; i < 1200; i++) r.surface.step(16)
+    for (let i = 0; i < 6; i++) {
+      openManual(r.surface)
+      for (let n = 0; n < 30; n++) r.surface.step(16)
+      closeManual(r.surface)
+      for (let n = 0; n < 30; n++) r.surface.step(16)
+    }
+    const servedBefore = r.served()
+    for (let i = 0; i < 1800; i++) r.surface.step(16)
+    assert.ok(r.served() > servedBefore, "the watch never came back after six reads")
+    // Nothing was billed to the child for the reading.
+    for (const report of r.reports) {
+      assert.ok(report.ms < 60_000, `a report carried ${report.ms}ms — the sheet leaked into it`)
+    }
+  } finally {
+    r.stop()
+  }
+})

--- a/dynawalla/games/street/src/manual.test.ts
+++ b/dynawalla/games/street/src/manual.test.ts
@@ -28,7 +28,11 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { forgetAudioContexts } from "../../../packs/shared/game-chrome/index.ts"
+// From `audioHold.ts` directly, not the barrel: `index.ts` deliberately does
+// NOT re-export this, because a game that reached for it would defeat the hold
+// for the whole pack. Node 24 enforces that; Node 22 does not, which is how the
+// wrong import passed locally and failed in CI.
+import { forgetAudioContexts } from "../../../packs/shared/game-chrome/audioHold.ts"
 import { mountStreet } from "./mount.ts"
 import { fakeCanvas } from "./render/fakeCanvas.ts"
 import { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/street/src/manual.test.ts
+++ b/dynawalla/games/street/src/manual.test.ts
@@ -1,0 +1,415 @@
+// FROZEN BEHIND THE MANUAL.
+//
+// "All games should pause while reading the instructions .. I can hear
+// counterweight playing in the background while I'm reading the instructions ...
+// stressing me out even more."
+//
+// `game/street.test.ts` next door proves the machine stops when `Street.pause`
+// is called. It cannot prove that anything ever calls it, and the surface that
+// must — the game's own how-to-play sheet, which a child raises exactly when the
+// street is beating them — is opt-in and was not wired. So this file is the
+// wiring's gate: it mounts the whole shell against a headless surface and
+// reaches the shared module's real help button the way a finger does.
+//
+// **Two observables, because one is not enough.** The street keeps DRAWING
+// while it is paused, so a count of context calls proves nothing. What proves
+// something is what is drawn: this scene is a pure function of the frame it is
+// handed, with no clock and no randomness of its own, so every drawing call and
+// every argument is recorded and the whole frame compared. A world that did not
+// move draws the identical picture, to the argument. Alongside it the host's own
+// record: the latency reported for a plate is measured on the machine's clock,
+// and three minutes of reading must not appear on a child's record as three
+// minutes of thinking.
+//
+// The fake elements below carry a listener map EACH, which is not tidiness: the
+// help button and the PLAY button both register a `"click"`, so one shared map
+// keyed by type silently drops the first and this test opens nothing.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { forgetAudioContexts } from "../../../packs/shared/game-chrome/index.ts"
+import { mountStreet } from "./mount.ts"
+import { fakeCanvas } from "./render/fakeCanvas.ts"
+import { createStubHost } from "./stubHost.ts"
+
+type Handler = (e: unknown) => void
+
+type FakeEl = {
+  className: string
+  tag?: string
+  fire(type: string, event?: unknown): void
+  [key: string]: unknown
+}
+
+const WIDTH = 768
+const HEIGHT = 1024
+
+function makeSurface() {
+  const created: FakeEl[] = []
+  const rect = {
+    left: 0,
+    top: 0,
+    right: WIDTH,
+    bottom: HEIGHT,
+    width: WIDTH,
+    height: HEIGHT,
+    x: 0,
+    y: 0,
+  }
+
+  // The recording context this package already has, the one `scene.test.ts`
+  // gates the renderer with. It keeps the receipt: every call, its arguments,
+  // the alpha and the style in force. That is what turns "the picture did not
+  // change" into an assertion instead of an impression.
+  const { canvas: recordingCanvas, rec } = fakeCanvas(WIDTH, HEIGHT)
+  const ctx = (recordingCanvas as { getContext(): unknown }).getContext()
+  const show = (v: unknown): string =>
+    typeof v === "number" && Number.isFinite(v) ? v.toFixed(4) : String(v)
+  const picture = (): string =>
+    rec.ops.map((op) => `${op.name}(${op.args.map(show).join(",")})@${op.alpha}/${op.style}`).join("|")
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>()
+    const el = {
+      style: {} as Record<string, unknown>,
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: 400,
+      appendChild: (c: unknown) => c,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? []
+        list.push(h)
+        listeners.set(type, list)
+      },
+      removeEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? []
+        const at = list.indexOf(h)
+        if (at >= 0) list.splice(at, 1)
+      },
+      fire(type: string, event: unknown = {}) {
+        for (const h of [...(listeners.get(type) ?? [])]) h(event)
+      },
+    } as unknown as FakeEl
+    created.push(el)
+    return el
+  }
+
+  const root = makeEl()
+  const globalKeys = new Map<string, Handler[]>()
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    dateNow: Date.now,
+    add: globalThis.addEventListener,
+    remove: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+  }
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb
+      return 1
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    // The wave order is seeded from the wall clock, which is right on a tablet
+    // and fatal in a test: a suite that is green four runs in five has proved
+    // nothing.
+    Date.now = () => 0x57ee7
+    globalThis.addEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? []
+      list.push(h)
+      globalKeys.set(type, list)
+    }) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? []
+      const at = list.indexOf(h)
+      if (at >= 0) list.splice(at, 1)
+    }) as unknown as typeof globalThis.removeEventListener
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: (tag: string) => {
+        const el = makeEl()
+        el.tag = tag
+        return el
+      },
+      getElementById: () => null,
+      body: makeEl(),
+      activeElement: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      Date.now = saved.dateNow
+      globalThis.addEventListener = saved.add
+      globalThis.removeEventListener = saved.remove
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      forgetAudioContexts()
+    }
+  }
+
+  const step = (ms: number): void => {
+    clock += ms
+    const cb = pending
+    pending = null
+    cb?.(clock)
+  }
+
+  return {
+    root,
+    install,
+    step,
+    /** Step one frame and hand back everything the street drew in it. */
+    frame(ms = 16): string {
+      rec.reset()
+      step(ms)
+      return picture()
+    },
+    canvas: () => created.find((e) => e.tag === "canvas"),
+    /** The shared module's own controls, found the way a finger finds them. */
+    help: () => created.find((e) => e.className === "dwc-help"),
+    closeButton: () => created.find((e) => e.className === "dwc-close"),
+  }
+}
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+function rig(seed = 0x57ee7): {
+  surface: ReturnType<typeof makeSurface>
+  handle: ReturnType<typeof mountStreet>
+  reports: Report[]
+  stop(): void
+} {
+  const surface = makeSurface()
+  const restore = surface.install()
+  const reports: Report[] = []
+  const host = createStubHost({ seed, reducedMotion: false, onReport: (r) => reports.push(r) })
+  const handle = mountStreet(surface.root as unknown as HTMLElement, host)
+  return {
+    surface,
+    handle,
+    reports,
+    stop(): void {
+      handle.unmount()
+      restore()
+    },
+  }
+}
+
+function openManual(surface: ReturnType<typeof makeSurface>): void {
+  const help = surface.help()
+  assert.ok(help, "the shared how-to-play button was never mounted")
+  help.fire("click", { target: help, type: "click" })
+}
+
+function closeManual(surface: ReturnType<typeof makeSurface>): void {
+  const button = surface.closeButton()
+  assert.ok(button, "the sheet has no PLAY button")
+  button.fire("click", { target: button, type: "click" })
+}
+
+/**
+ * Hit a rivet, without knowing where the rivets are.
+ *
+ * The layout is the scene's business and reproducing it here would be a second
+ * copy of it that could drift. A child's finger does not know either; it lands
+ * somewhere on the plate. So this walks the glass until something is struck.
+ */
+function tapAnyRivet(
+  surface: ReturnType<typeof makeSurface>,
+  reports: Report[],
+): Report | undefined {
+  const canvas = surface.canvas()
+  assert.ok(canvas, "the game mounted no canvas")
+  const before = reports.length
+  for (let y = 8; y < HEIGHT; y += 16) {
+    for (let x = 8; x < WIDTH; x += 16) {
+      canvas.fire("pointerdown", {
+        pointerId: 1,
+        button: 0,
+        clientX: x,
+        clientY: y,
+        preventDefault: () => undefined,
+      })
+      if (reports.length > before) return reports[reports.length - 1]
+    }
+  }
+  return undefined
+}
+
+test("the street does not move while the rules are up", () => {
+  const r = rig()
+  try {
+    // Five frames in, the shutter is on its way down: a phase driven by the
+    // clock, so the picture changes every frame.
+    const moving = new Set<string>()
+    for (let i = 0; i < 5; i++) moving.add(r.surface.frame())
+    assert.equal(moving.size, 5, "the street was not moving to begin with")
+
+    openManual(r.surface)
+    const held = r.surface.frame()
+    // Three minutes behind the sheet, sampled throughout. Every frame draws the
+    // identical picture, to the argument, because nothing underneath it moved.
+    for (let i = 0; i < 11_250; i++) {
+      if (i % 250 === 0) {
+        assert.equal(r.surface.frame(), held, `the street moved behind the manual (frame ${i})`)
+      } else {
+        r.surface.step(16)
+      }
+    }
+
+    closeManual(r.surface)
+    const after = new Set<string>()
+    for (let i = 0; i < 5; i++) after.add(r.surface.frame())
+    assert.equal(after.size, 5, "the shutter never came down again")
+    assert.ok(!after.has(held), "the street resumed on the same frame it froze on")
+
+    // And the sheet is not on the child's record. The latency for a plate is
+    // measured on the machine's own clock; three minutes of reading behind the
+    // scrim would be reported as three minutes of thinking.
+    for (let i = 0; i < 60; i++) r.surface.step(16)
+    const report = tapAnyRivet(r.surface, r.reports)
+    assert.ok(report, "no rivet could be struck after the sheet lifted")
+    assert.ok(
+      report.ms < 5_000,
+      `the plate was reported at ${report.ms}ms — the manual was billed to the child`,
+    )
+  } finally {
+    r.stop()
+  }
+})
+
+test("a street the HOST already stopped is not restarted by closing the rules", () => {
+  // The host puts a sheet over a still-mounted pack — this game asks for one
+  // itself on every finished block — and sends `pause`. A child who opens the
+  // manual on top of that and closes it must not set the street running
+  // underneath the host's own scrim.
+  const r = rig(0x40b)
+  try {
+    for (let i = 0; i < 3; i++) r.surface.frame()
+
+    r.handle.pause()
+    const held = r.surface.frame()
+
+    openManual(r.surface)
+    for (let i = 0; i < 600; i++) r.surface.step(16)
+    closeManual(r.surface)
+    for (let i = 0; i < 600; i++) {
+      if (i % 100 === 0) {
+        assert.equal(r.surface.frame(), held, "closing the manual lifted the host's own pause")
+      } else {
+        r.surface.step(16)
+      }
+    }
+
+    // The host's pause is still the host's to lift, and lifting it works.
+    r.handle.resume()
+    const after = new Set<string>()
+    for (let i = 0; i < 5; i++) after.add(r.surface.frame())
+    assert.equal(after.size, 5, "the host could not restart its own street")
+  } finally {
+    r.stop()
+  }
+})
+
+test("the host lifting its own sheet does not start the street behind the manual", () => {
+  // The other order, and the one that reintroduces the whole defect: the host
+  // pauses, the child opens the rules, and then the host takes ITS sheet down
+  // while the manual is still up. The street must wait for the rules.
+  const r = rig(0x7e57)
+  try {
+    for (let i = 0; i < 3; i++) r.surface.frame()
+    r.handle.pause()
+    openManual(r.surface)
+    const held = r.surface.frame()
+
+    r.handle.resume()
+    for (let i = 0; i < 600; i++) {
+      if (i % 100 === 0) {
+        assert.equal(r.surface.frame(), held, "the street ran behind the manual")
+      } else {
+        r.surface.step(16)
+      }
+    }
+
+    // And closing the rules is what hands it back, because by then the manual
+    // is the only thing still holding it.
+    closeManual(r.surface)
+    const after = new Set<string>()
+    for (let i = 0; i < 5; i++) after.add(r.surface.frame())
+    assert.equal(after.size, 5, "the street never came back when the rules went down")
+  } finally {
+    r.stop()
+  }
+})
+
+test("six reads cost the street nothing at all", () => {
+  // The sharpest form of the claim: a child who opens the rules six times and
+  // a child who never opens them are looking at the same street, to the
+  // argument, once you take the reading out. Same seed, same frames played.
+  const play = (reads: boolean): string => {
+    const r = rig(0x1de)
+    try {
+      for (let i = 0; i < 6; i++) {
+        if (reads) openManual(r.surface)
+        // Behind the sheet. These frames must buy the street nothing.
+        for (let n = 0; n < 3; n++) r.surface.step(16)
+        if (reads) closeManual(r.surface)
+        for (let n = 0; n < 3; n++) r.surface.step(16)
+      }
+      return r.surface.frame()
+    } finally {
+      r.stop()
+    }
+  }
+  // The control plays only the frames the reader had the sheet down for.
+  const straight = (): string => {
+    const r = rig(0x1de)
+    try {
+      for (let n = 0; n < 18; n++) r.surface.step(16)
+      return r.surface.frame()
+    } finally {
+      r.stop()
+    }
+  }
+  assert.equal(play(true), straight(), "the reading was billed to the street")
+  // And the control is not a frozen street either, or the equality above would
+  // be two still pictures agreeing about nothing.
+  assert.notEqual(play(false), straight(), "the street was not moving in either run")
+})

--- a/dynawalla/games/street/src/mount.ts
+++ b/dynawalla/games/street/src/mount.ts
@@ -45,12 +45,29 @@ export function mountStreet(
   const audio = new StreetAudio()
   const rng = new Rng((Date.now() ^ 0x57ee7) >>> 0)
 
+  const street = new Street({
+    rng,
+    timing: reduced ? TIMING_REDUCED : TIMING,
+    deal: () => {
+      const q = host.next({ domain: "add" })
+      return { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors }
+    },
+  })
+  street.setStreetWidth(scene.width)
+
+  /** Did the manual stop the street? Only then may closing it start again. */
+  let heldForManual = false
+
   // How to play. Nothing on the street says what a stud is, and nothing is
   // going to: primeness here is a wall you walk into, not a fact you are given.
   // But the two verbs are not discoverable — a child who does not know that a
   // stud is a claim about the number is tapping brass at random. The manual
   // stays reachable during play, because the moment a child needs the rules is
   // never the title.
+  //
+  // Built after the street rather than before it because it stops the street:
+  // `onOpen`/`onClose` below are the only part of pausing this game has to opt
+  // into, and they need something to pause.
   const guide = createInstructions(el, {
     title: "FOUNDRY STREET",
     summary: [
@@ -105,17 +122,20 @@ export function mountStreet(
       },
     ],
     reducedMotion: reduced,
-  })
-
-  const street = new Street({
-    rng,
-    timing: reduced ? TIMING_REDUCED : TIMING,
-    deal: () => {
-      const q = host.next({ domain: "add" })
-      return { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors }
+    // The manual only lifts a pause it put on itself. A street the host had
+    // already stopped — a transition sheet, a parent gate — must not be handed
+    // back running because the child closed the rules.
+    onOpen: () => {
+      if (street.paused) return
+      heldForManual = true
+      street.pause()
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      street.resume()
     },
   })
-  street.setStreetWidth(scene.width)
 
   let best = blocksCleared()
   let running = true
@@ -280,11 +300,21 @@ export function mountStreet(
   return {
     // The host puts a sheet over the frame — a transition, a parent gate — and
     // sends `pause` with the pack still mounted and its rAF still firing. The
-    // clock has to stop dead and input has to stop counting: see `Street`.
+    // clock has to stop dead and input has to stop counting: see `Street`. The
+    // game's own how-to-play sheet takes the same pause, above.
     pause(): void {
       street.pause()
     },
     resume(): void {
+      // The rules are still up. Whoever asked for this — the host taking its
+      // own sheet down over the top of the manual — the child is still reading,
+      // and the only thing allowed to start the street again is the rules going
+      // down. Without this the host's resume hands back a running street behind
+      // a scrim, which is the whole defect wearing a different hat.
+      if (guide.isOpen) {
+        heldForManual = true
+        return
+      }
       street.resume()
     },
     unmount(): void {


### PR DESCRIPTION
The founder, on QA: *"All games should pause while reading the instructions .. I can hear counterweight playing in the background while I'm reading the instructions ... stressing me out even more .. it's so stressful I don't even want to QA it."*

#681 held **sound, taps and keys** for all 27 games structurally, with no per-game change. What the shared module cannot reach is a game's own simulation clock — it has no idea what a game's loop is. That is what `onOpen`/`onClose` are for, and its docstring names them as the one deliberately opt-in part of pausing.

Eleven games still ran behind the sheet. **This PR is the six that already had a working pause.** The other five — the ones that had no pause concept at all and needed one built — are a separate PR, because "wire a callback to an existing door" and "build the door" are different diffs to review.

## What freezing meant, per game

None of these gets a new flag. Each is wired to the pause path it already had, so the host's sheet, the tab backgrounding, the child's own pause key and the manual all go through one door.

| game | composed with |
|---|---|
| BEAM | `setPaused(boolean)` — the same entry point the host uses |
| COLOSSUS | `pause`/`resume` lifted into `raiseSheet`/`lowerSheet`; the handle now just calls them |
| COUNTERWEIGHT | `pauseAll`/`resumeAll`, already shared with the `visibilitychange` handler |
| SKY LEDGER | `pause`/`resume` lifted into `doPause`/`doResume` |
| FOUNDRY STREET | `Street.pause()/resume()`, guarded on the existing `street.paused` getter |
| SERPENT | three scattered `world.paused = ...` writes replaced by one `setPaused(world, boolean)` |

## The manual only lifts a pause it put on itself

A game the host had already stopped must not be handed back running because a child closed the rules. In **SERPENT** this is sharper still: the child has their own pause key, so a child who pauses, opens the manual and closes it must not find the snake swimming again.

SKY LEDGER and FOUNDRY STREET also close the mirror hole — a host `resume` arriving *while the manual is up* transfers ownership to the manual instead of starting the game behind the scrim.

## The clock jump

SERPENT had a real one, and it was not the simulation. Its answer latency is **wall** clock: a trial carries the `performance.now()` it was served at, so freezing the sim did nothing to it and a three-minute read put a **180,000 ms** answer on a child's record for a question they were never looking at. `setPaused` now shifts every live trial's start forward by exactly the pause. This also fixes the child's own pause key, which had the same bug.

BEAM, COLOSSUS and COUNTERWEIGHT already rebased their marks; verified rather than assumed. FOUNDRY STREET's clock is an internal accumulator that stops with `advance`, so it rebases itself.

## How it was proved

**None of these six had a mount-level harness for this.** beam's `loop.test.ts` keys listeners by event type across *all* elements, so the help button's `"click"` is overwritten by PLAY's. Each game therefore gets a harness with **per-element listener maps**; the sheet is opened by finding `className === "dwc-help"` and invoking its own click handler, and is never faked by calling the game's pause directly.

Several of these deliberately keep **drawing** a frozen frame while paused, so a draw count proves nothing. The assertions are about the world: byte-identical recorded draw transcripts over thousands of frames, `host.next` never called, the ledger line never pulled, an identical world snapshot over 11,250 frames.

**Every test was checked by deleting the fix.** A sample of the verbatim failures:

```
serpent   not ok 1 - the water stops while the rules are up
            the world moved behind the manual
            + '{"time":161.28,"runTime":160.34,...,"score":861}'
            - '{"time":4.15,"runTime":3.21,...,"score":3}'
serpent   not ok 2 - a dive the CHILD paused is still paused when they close the rules
            closing the manual lifted the child's own pause
beam      not ok 1 - MANUAL FREEZES THE HALL
            1069973 draw calls went out behind the manual
colossus  not ok 2 - a press behind the manual is not a press
            a press behind the manual reached the tower  46 !== 1
counterweight not ok 1 - MANUAL FREEZES THE YARD
            6 rounds were closed while the child was reading the rules
skyledger not ok 3 - the host lifting its own sheet does not start the sky behind the manual
street    not ok 4 - six reads cost the street nothing at all
```

One flake was caught and fixed on the way: serpent's arena uses bare `Math.random`, and the harness was green four runs in five until the seed was pinned. That is why the suites are run five times.

## Verification

Suites run **5× each, all green**, independently of the authoring agents: beam 102, colossus 85, counterweight 142, skyledger 73, street 103, serpent 41. `npm run tsc` clean in all six. `npm run build:pack` clean in all six. The delete-the-fix check was re-run by the integrator, not taken on trust.

## Device-only
That the canvas visibly holds its last painted frame under the scrim rather than blanking, and that audio actually goes silent through the real `AudioContext` hold.

## Known, deliberate limit
If the host calls `pause()` *while* the manual already holds the pause, the host's call is a no-op and a later manual close resumes. The host's own sheet sits above the iframe, so the pack's PLAY button is not reachable by touch in that state. Left on the canonical shape rather than special-cased in six places.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
