### PR TITLE
fix(dynawalla/games): four games with no pause at all, and the dither that made reading cost money

### DIFF
--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -166,7 +166,16 @@ export function mountGame(el: HTMLElement, host: Host): { unmount(): void } {
   return new Game(el, host).handle()
 }
 
-class Game {
+/**
+ * Exported for the mount-level test in `pause.test.ts`, and for nothing else.
+ *
+ * `mountGame` is the entry point every caller uses and the handle it returns is
+ * `{ unmount }`, because the host contract has no slot for a pause and inventing
+ * a public one to make a test easier would be inventing a public surface. A test
+ * that has to read the pause flag therefore needs the instance, and the instance
+ * is only reachable if the class has a name outside this module.
+ */
+export class Game {
   private s: State
   private rng: Rng
   private rnd: () => number
@@ -182,6 +191,16 @@ class Game {
   private raf = 0
   private last = 0
   private running = true
+  /** True while the reef is frozen: nothing steps, nothing draws. */
+  private paused = false
+  /**
+   * The manual only lifts a pause it put on itself. Nothing else pauses this
+   * game today, but the day something does — a host sheet, a parent gate — a
+   * child closing the rules underneath it must not be handed back a running reef.
+   */
+  private heldForManual = false
+  /** `performance.now()` when the freeze began, so resume can rebase off it. */
+  private pausedAt = 0
   private ro: ResizeObserver | null = null
   private saveMs = 0
   private fpsSamples: number[] = []
@@ -259,7 +278,24 @@ class Game {
     if (this.s.vents.length === 0) this.addVent()
     if (polyps(this.s.board).length === 0) this.seedShelf()
 
-    this.guide = createInstructions(el, INSTRUCTIONS(this.s.reduceMotion))
+    this.guide = createInstructions(el, {
+      ...INSTRUCTIONS(this.s.reduceMotion),
+      // The reef is the one genre where "it kept running while I read" is not
+      // only noise: vents cough polyps onto the shelf on a timer, a cold vent
+      // warms back up on a timer, a swell rises on a timer, and `askedAt` is the
+      // thinking time this game reports to the learner model. All of it moves
+      // with nobody's hands on the glass, so all of it has to stop.
+      onOpen: () => {
+        if (this.paused) return
+        this.heldForManual = true
+        this.setPaused(true)
+      },
+      onClose: () => {
+        if (!this.heldForManual) return
+        this.heldForManual = false
+        this.setPaused(false)
+      },
+    })
 
     this.bindInput()
     this.observeSize()
@@ -286,6 +322,74 @@ class Game {
     this.audio.close()
     this.renderer.destroy()
     this.hud.destroy()
+  }
+
+  /**
+   * Stop the reef dead, or start it again.
+   *
+   * **Frozen means frozen.** The frame callback keeps being scheduled — it has
+   * to, or there would be nothing left to resume with — but it steps nothing and
+   * draws nothing. Every moving part of this game lives inside `update()` and
+   * `drawFrame()`: essence accrual, polyp ages, the merge cascade queue, each
+   * vent's emit timer and cold timer, the swell, the sonar ping, the long-press
+   * dissolve timer, the drag spring, particles, shockwaves, floaters and the
+   * autosave. One `return` above them takes all of them, and the canvas holds
+   * its last painted frame underneath the sheet.
+   *
+   * **The idle question, decided.** An idle game banks wall-clock time, so
+   * "reading is free production" and "reading costs you two minutes" are both
+   * live possibilities and it would be negligent to pick one by accident. This
+   * game credits away-time through exactly one surface: `offlineHaul`, capped at
+   * eight hours, discounted to 55%, and collected by answering a tide gate. That
+   * is deliberate — essence in ABYSSAL BLOOM is never handed over without either
+   * a merge or a question. Silently topping up `essence` for the seconds a sheet
+   * was up would be the only path in the game that pays for neither, and because
+   * the hold is measured with `performance.now()` it would also pay out real
+   * *backgrounded* time — a child who opens the manual and puts the tablet down
+   * for an hour would come back an hour richer with the tide gate bypassed. So
+   * the read is outside of time: nothing accrues, and nothing decays either. No
+   * vent cools down for free, no swell arrives, no timer runs out. A child is
+   * returned the reef they left, to the polyp.
+   *
+   * The one thing that must NOT be left alone is a wall-clock mark, because
+   * every one of them leaps forward the instant the clock is looked at again.
+   */
+  private setPaused(on: boolean): void {
+    if (on === this.paused) return
+    this.paused = on
+    if (on) {
+      this.pausedAt = performance.now()
+      // A drag in flight never gets its release: the shared sheet swallows
+      // `pointerup` along with every other pointer event. Left standing, the
+      // long-press dissolve timer would carry on counting from behind the
+      // manual and take the polyp out from under a finger that is no longer
+      // there. Sound is already held by the sheet, so this is silent.
+      if (this.s.drag.active) this.cancelDrag()
+      return
+    }
+    // Every wall-clock mark moves forward by exactly the time the sheet was up.
+    // `Math.min(now, ...)` covers a mark that was set DURING the hold — the tide
+    // gate re-asks on a 520ms `setTimeout` — which must not be shifted into the
+    // future and reported as negative thinking time.
+    const now = performance.now()
+    const held = now - this.pausedAt
+    for (const v of this.s.vents) {
+      v.askedAt = Math.min(now, v.askedAt + held)
+      v.hintAt += held
+      if (v.coldUntil > 0) v.coldUntil += held
+    }
+    const t = this.s.tide
+    if (t.askedAt > 0) t.askedAt = Math.min(now, t.askedAt + held)
+    for (const c of this.cascades) c.at += held
+    // `last` is the frame delta's other end. Without this the resumed frame
+    // computes a delta the length of the read; it would be clamped to 50ms, but
+    // 50ms of free reef is still 50ms nobody played.
+    this.last = now
+    // Re-stamp `lastSeen`. `offlineHaul` measures from the last write, so
+    // without this a read would be banked as away-time on the next launch and
+    // the manual would become a way to farm the tide — the exact leak the
+    // paragraph above refuses to open from the other end.
+    this.save()
   }
 
   private observeSize(): void {
@@ -1116,6 +1220,13 @@ class Game {
   private frame = (now: number): void => {
     if (!this.running) return
     this.raf = requestAnimationFrame(this.frame)
+    if (this.paused) {
+      // Nothing steps and nothing is drawn. `last` still tracks so that a
+      // resume — or a rotation that relayouts underneath the sheet — cannot
+      // land one enormous frame.
+      this.last = now
+      return
+    }
     const realDt = Math.min(0.05, Math.max(0.0001, (now - this.last) / 1000))
     this.last = now
 

--- a/dynawalla/games/merge-idle/src/pause.test.ts
+++ b/dynawalla/games/merge-idle/src/pause.test.ts
@@ -1,0 +1,598 @@
+/**
+ * The reef stops while the rules are up.
+ *
+ * "All games should pause while reading the instructions .. I can hear
+ * counterweight playing in the background while I'm reading the instructions ...
+ * stressing me out even more."
+ *
+ * Sound, keys and taps are held by the shared sheet for every game. A game's own
+ * simulation clock is the one thing it cannot reach, and ABYSSAL BLOOM is the
+ * genre where that clock is the *subject*: essence accrues with nobody's hands
+ * on the glass, vents cough polyps out on a timer, a choked vent warms back up
+ * on a timer, and a swell rises on a timer. All of it ran behind the manual.
+ *
+ * **The idle question was decided deliberately, not by accident.** A read is
+ * outside of time: nothing accrues and nothing decays. See `setPaused` in
+ * `game.ts` for why crediting the read would have been a second, unquestioned
+ * path to essence — and, because the hold is measured on the wall clock, a way
+ * to farm backgrounded time past the tide gate that exists to charge for it.
+ *
+ * **This is a mount-level test, on purpose.** ABYSSAL BLOOM had no headless
+ * harness: every one of its existing tests proves a pure function or a layout
+ * number and not one of them constructs the game. A pause test written against a
+ * pure function would prove nothing about the wiring, which is the only thing
+ * here that can be wrong. So this file builds the harness — a fake document, a
+ * fake `requestAnimationFrame`, a fake `performance.now`/`Date.now`, a fake
+ * `ResizeObserver`, and a 2d context that counts every call made through it.
+ *
+ * **Removing the fix fails this file.** Delete the `onOpen`/`onClose` pair in
+ * `game.ts` and the reef keeps blooming behind the sheet; delete the `if
+ * (this.paused)` guard in `frame` and it blooms regardless of the flag; delete
+ * the wall-clock rebasing and a read is billed to the child as thinking time,
+ * or banked as away-time the next launch pays out.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { Game } from './game.ts'
+import { makeStubHost } from './stubHost.ts'
+import { useSaveSlot } from './core/save.ts'
+
+type Handler = (e: unknown) => void
+
+/** A fake element. Every one carries its OWN listener map — see `control`. */
+type FakeEl = {
+  className: string
+  listeners: Map<string, Handler[]>
+  children: FakeEl[]
+} & Record<string, unknown>
+
+type Save = {
+  essence: number
+  magnitude: number
+  cols: number
+  rows: number
+  cells: Array<[number, number]>
+  vents: Array<{ tier: number }>
+  lastSeen: number
+}
+
+type Harness = {
+  root: HTMLElement
+  install(): () => void
+  /** a frame delivered, and the clock moved with it */
+  step(ms: number): void
+  /** the clock moved with NO frame — a backgrounded app */
+  advance(ms: number): void
+  now(): number
+  made: FakeEl[]
+  draws(): number
+  /** every save the reef has written, newest last */
+  saves: Save[]
+  /** dispatch a key the way a browser would, honouring `stopPropagation` */
+  press(key: string): void
+}
+
+/** A fixed instant, so a run seeded from the calendar is the same run every time. */
+const DAY0 = 1_780_000_000_000
+const T0 = 1000
+
+function harness(w = 820, h = 1180): Harness {
+  const made: FakeEl[] = []
+  const saves: Save[] = []
+  let drawCalls = 0
+  const rect = { left: 0, top: 0, width: w, height: h, right: w, bottom: h, x: 0, y: 0 }
+
+  // Counts every call made through it and returns itself, so chains like
+  // `createLinearGradient(...).addColorStop(...)` survive with no real canvas.
+  const ctx: unknown = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, prop) => {
+      if (prop === 'then') return undefined
+      // Any coercion of a context value yields 0, so a real comparison in the
+      // renderer — `measureText(label).width <= maxW` — reaches a decision
+      // instead of throwing on an object with no primitive form.
+      if (prop === Symbol.toPrimitive) return () => 0
+      return ctx
+    },
+    set: () => true,
+    apply: () => {
+      drawCalls++
+      return ctx
+    },
+  })
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>()
+    const children: FakeEl[] = []
+    const style: Record<string, unknown> = {
+      cssText: '',
+      setProperty(k: string, v: string) {
+        style[k] = v
+      },
+      removeProperty(k: string) {
+        delete style[k]
+      },
+    }
+    const classes = new Set<string>()
+    const el: FakeEl = {
+      className: '',
+      listeners,
+      children,
+      style,
+      classList: {
+        add: (c: string) => classes.add(c),
+        remove: (c: string) => classes.delete(c),
+        toggle: (c: string, on?: boolean) => {
+          const want = on ?? !classes.has(c)
+          if (want) classes.add(c)
+          else classes.delete(c)
+          return want
+        },
+        contains: (c: string) => classes.has(c),
+      },
+      textContent: '',
+      id: '',
+      type: '',
+      hidden: false,
+      disabled: false,
+      dataset: {},
+      tabIndex: 0,
+      scrollTop: 0,
+      width: 0,
+      height: 0,
+      offsetWidth: 100,
+      offsetHeight: 40,
+      clientWidth: w,
+      clientHeight: h,
+      appendChild: (c: FakeEl) => {
+        children.push(c)
+        return c
+      },
+      append: (...cs: FakeEl[]) => {
+        children.push(...cs)
+      },
+      replaceChildren: (...cs: FakeEl[]) => {
+        children.length = 0
+        children.push(...cs)
+      },
+      remove: () => undefined,
+      querySelectorAll: () => [],
+      focus: () => undefined,
+      animate: () => ({ onfinish: null }),
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      addEventListener: (k: string, fn: Handler) => {
+        const list = listeners.get(k) ?? []
+        list.push(fn)
+        listeners.set(k, list)
+      },
+      removeEventListener: (k: string, fn: Handler) => {
+        listeners.set(k, (listeners.get(k) ?? []).filter((x) => x !== fn))
+      },
+      get firstElementChild(): FakeEl | null {
+        return children[0] ?? null
+      },
+      get lastElementChild(): FakeEl | null {
+        return children[children.length - 1] ?? null
+      },
+    }
+    made.push(el)
+    return el
+  }
+
+  // A QUEUE, not a slot. The HUD schedules its own `requestAnimationFrame`
+  // for a toast fade, and a harness that kept only the newest callback
+  // silently dropped the GAME's frame the first time a toast appeared —
+  // the loop stopped five seconds in and every assertion after that was
+  // measuring a game that had quietly died.
+  let pending: Array<(t: number) => void> = []
+  let clock = T0
+
+  // A LIST per type, not one handler per type. The shared how-to-play surface
+  // registers a capture-phase swallow for `keydown` on top of the game's own
+  // `keydown`, and a map that kept only the last one would quietly delete half
+  // the wiring this file is here to test.
+  const globals = new Map<string, Handler[]>()
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    dateNow: Date.now,
+    add: globalThis.addEventListener,
+    rm: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    win: (globalThis as { window?: unknown }).window,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    nav: Object.getOwnPropertyDescriptor(globalThis, 'navigator'),
+  }
+
+  const root = makeEl()
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending.push(cb)
+      return pending.length
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = []
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    // Tied to the same clock rather than frozen: `lastSeen` is what `offlineHaul`
+    // measures from, so a `Date.now` that never moves would make the one thing
+    // this game banks unobservable. It still starts at a fixed instant, which is
+    // what the run's seed is drawn from.
+    Date.now = () => DAY0 + (clock - T0)
+    globalThis.addEventListener = ((k: string, fn: Handler): void => {
+      const list = globals.get(k) ?? []
+      list.push(fn)
+      globals.set(k, list)
+    }) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = ((k: string, fn: Handler): void => {
+      globals.set(k, (globals.get(k) ?? []).filter((x) => x !== fn))
+    }) as unknown as typeof globalThis.removeEventListener
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: () => makeEl(),
+      createElementNS: () => makeEl(),
+      createTextNode: () => makeEl(),
+      getElementById: () => null,
+      body: makeEl(),
+      head: makeEl(),
+      hidden: false,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }
+    ;(globalThis as { window?: unknown }).window = globalThis
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { hardwareConcurrency: 8 },
+      configurable: true,
+      writable: true,
+    })
+    // The reef's save is a seam precisely so a pack frame with no `localStorage`
+    // still remembers. Here it is the best observable the game has: it carries
+    // the essence, the shelf and the wall-clock stamp `offlineHaul` measures from.
+    useSaveSlot({
+      read: () => null,
+      write: (value) => {
+        saves.push(JSON.parse(value) as Save)
+      },
+    })
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      Date.now = saved.dateNow
+      globalThis.addEventListener = saved.add
+      globalThis.removeEventListener = saved.rm
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      ;(globalThis as { window?: unknown }).window = saved.win
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      if (saved.nav) Object.defineProperty(globalThis, 'navigator', saved.nav)
+    }
+  }
+
+  return {
+    root: root as unknown as HTMLElement,
+    install,
+    step: (ms: number): void => {
+      clock += ms
+      const due = pending
+      pending = []
+      for (const cb of due) cb(clock)
+    },
+    advance: (ms: number): void => {
+      clock += ms
+    },
+    now: () => clock,
+    made,
+    draws: () => drawCalls,
+    saves,
+    press: (key: string): void => {
+      // Capture order and `stopPropagation` are honoured, because that is the
+      // whole mechanism by which the shared sheet keeps keys off the game: a
+      // dispatcher that called every handler regardless would quietly make the
+      // sheet look modal when it was not.
+      let stopped = false
+      const e = {
+        key,
+        type: 'keydown',
+        preventDefault: () => undefined,
+        stopPropagation: () => {
+          stopped = true
+        },
+      }
+      for (const fn of [...(globals.get('keydown') ?? [])]) {
+        if (stopped) return
+        fn(e)
+      }
+    },
+  }
+}
+
+/** The shared sheet's controls, found the way a finger finds them. */
+function control(h: Harness, cls: string): FakeEl {
+  const found = h.made.filter((el) => el.className === cls)
+  assert.equal(found.length, 1, `expected exactly one .${cls}, found ${found.length}`)
+  return found[0] as FakeEl
+}
+
+function click(el: FakeEl): void {
+  const list = el.listeners.get('click') ?? []
+  assert.ok(list.length > 0, `.${el.className} has no click listener`)
+  for (const fn of list) fn({ type: 'click', target: el })
+}
+
+/** Everything the reef persists that is SIMULATION — `lastSeen` is not. */
+function reef(s: Save): unknown {
+  return {
+    essence: s.essence,
+    magnitude: s.magnitude,
+    cols: s.cols,
+    rows: s.rows,
+    cells: s.cells,
+    vents: s.vents,
+  }
+}
+
+const last = (h: Harness): Save => {
+  assert.ok(h.saves.length > 0, 'the reef never saved — the observable proves nothing')
+  return h.saves[h.saves.length - 1] as Save
+}
+
+/** Long enough for the autosave (every 4s) to have fired several times. */
+const WARM = 1500
+
+test('nothing on the reef advances while the manual is open', () => {
+  const h = harness()
+  const restore = h.install()
+  const handle = new Game(h.root, makeStubHost({ seed: 0xab1e })).handle()
+  try {
+    for (let i = 0; i < WARM; i++) h.step(16)
+
+    // The reef has to actually be blooming, or "nothing advanced" is vacuous.
+    assert.ok(h.saves.length >= 3, `only ${h.saves.length} autosaves in the warm-up`)
+    assert.ok(last(h).essence > 0, 'no essence ever accrued — the observable proves nothing')
+    assert.ok(h.draws() > 0, 'nothing ever drew — the counter proves nothing')
+
+    // Line the observable up with the sheet: pump until the reef autosaves, then
+    // open the manual in the same breath. The last save is now the reef the
+    // sheet went up over, to the polyp — not one up to four seconds stale.
+    const settled = h.saves.length
+    while (h.saves.length === settled) h.step(16)
+
+    click(control(h, 'dwc-help'))
+
+    const before = reef(last(h))
+    const savesBefore = h.saves.length
+    const drawsBefore = h.draws()
+
+    // Two full minutes of a child reading. At this rate that is a visible pile
+    // of essence and about twenty-four polyps coughed onto the shelf.
+    for (let i = 0; i < 7500; i++) h.step(16)
+
+    assert.equal(h.saves.length, savesBefore, 'the autosave ran behind the sheet')
+    assert.equal(h.draws(), drawsBefore, `${h.draws() - drawsBefore} draw calls behind the sheet`)
+    assert.deepEqual(reef(last(h)), before, 'the reef bloomed behind the sheet')
+
+    click(control(h, 'dwc-close'))
+
+    // The reef is handed back exactly as it was left — to the polyp, and to the
+    // unit of essence. This is the "a read is outside of time" claim, stated.
+    assert.deepEqual(reef(last(h)), before, 'closing the manual paid out the read')
+
+    for (let i = 0; i < 400; i++) h.step(16)
+    assert.notDeepEqual(reef(last(h)), before, 'the reef never restarted after the manual closed')
+    assert.ok(h.draws() > drawsBefore, 'nothing drew again after the manual closed')
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test('a read costs the child nothing and gives them nothing — the resume does not jump', () => {
+  // The strongest form of both claims at once: the same seed, the same number of
+  // LIVE frames, one run interrupted by two minutes of reading and one not. If
+  // anything accrued behind the sheet the interrupted reef is richer; if any
+  // wall-clock mark leapt on resume it is richer by a different amount. Only an
+  // exact freeze makes these equal.
+  const play = (readAt: number | null): unknown => {
+    const h = harness()
+    const restore = h.install()
+    const handle = new Game(h.root, makeStubHost({ seed: 0xab1e })).handle()
+    try {
+      for (let i = 0; i < 3000; i++) {
+        if (readAt !== null && i === readAt) {
+          click(control(h, 'dwc-help'))
+          for (let k = 0; k < 7500; k++) h.step(16)
+          click(control(h, 'dwc-close'))
+        }
+        h.step(16)
+      }
+      // Sampled from the save `unmount` writes, not from the last autosave: the
+      // resume writes one of its own, so the two runs would otherwise be read at
+      // different instants and disagree about a reef that is in fact identical.
+      handle.unmount()
+      return reef(last(h))
+    } finally {
+      restore()
+    }
+  }
+
+  assert.deepEqual(play(1500), play(null))
+})
+
+test('the read is not banked as away-time the next launch pays out', () => {
+  // `offlineHaul` measures from `lastSeen`, and it is the ONE surface that pays
+  // for time the child was not playing — capped, discounted, and collected by
+  // answering a tide gate. If a read left `lastSeen` two minutes stale, the
+  // manual would become a way to farm that gate: open the rules, put the tablet
+  // down, come back rich. The refusal has to hold from both ends.
+  const h = harness()
+  const restore = h.install()
+  const handle = new Game(h.root, makeStubHost({ seed: 0xab1e })).handle()
+  try {
+    for (let i = 0; i < WARM; i++) h.step(16)
+
+    click(control(h, 'dwc-help'))
+    for (let i = 0; i < 7500; i++) h.step(16)
+    click(control(h, 'dwc-close'))
+
+    const stale = Date.now() - last(h).lastSeen
+    assert.ok(stale < 2000, `the read left ${Math.round(stale / 1000)}s bankable as away-time`)
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test('the read is not charged to the child as thinking time', () => {
+  // `askedAt` is a `performance.now()` mark and it is what ABYSSAL BLOOM reports
+  // as how long a child took over a vent's sum. Left alone across a two-minute
+  // read it turns a child who was shown a sheet into a child who could not
+  // answer, and the learner model believes it.
+  const h = harness()
+  const restore = h.install()
+  const reports: number[] = []
+  const handle = new Game(
+    h.root,
+    makeStubHost({ seed: 0xab1e, onReport: (r) => reports.push(r.ms) }),
+  ).handle()
+  try {
+    for (let i = 0; i < 600; i++) h.step(16) // 9.6s of genuine thinking
+
+    click(control(h, 'dwc-help'))
+    for (let i = 0; i < 7500; i++) h.step(16) // two minutes of reading
+    click(control(h, 'dwc-close'))
+
+    // Walk the cursor over the shelf posting whatever it finds into vent 1. The
+    // shelf is seeded from the run's own RNG, so which cell holds a polyp is not
+    // this test's business — only that something gets posted and reported.
+    outer: for (let row = 0; row < 6; row++) {
+      for (let col = 0; col < 5; col++) {
+        h.press(' ')
+        h.press('1')
+        if (reports.length > 0) break outer
+        h.press('ArrowRight')
+      }
+      for (let col = 0; col < 5; col++) h.press('ArrowLeft')
+      h.press('ArrowDown')
+    }
+
+    assert.ok(reports.length > 0, 'nothing was ever posted into a vent — the test proved nothing')
+    const ms = reports[0] as number
+    assert.ok(ms >= 0, `thinking time went negative: ${ms}ms`)
+    assert.ok(ms < 20_000, `the sheet's two minutes were billed to the child: ${ms}ms`)
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test('reads taken through a backgrounded app never accumulate into free reef', () => {
+  // The manual is up and the child switches apps. `requestAnimationFrame` stops
+  // dead; `performance.now()` does not. Whatever `last` held is now stale, and
+  // the first frame after the sheet closes carries all of it — capped at 50ms by
+  // the loop, so one read is 34ms of reef nobody played. That is invisible; a
+  // session's worth of reads is not, and a child who keeps checking the rules is
+  // the child this whole surface exists for.
+  const play = (reads: boolean): unknown => {
+    const h = harness()
+    const restore = h.install()
+    const handle = new Game(h.root, makeStubHost({ seed: 0xab1e })).handle()
+    try {
+      for (let i = 0; i < 3000; i++) {
+        if (reads && i > 0 && i % 100 === 0) {
+          click(control(h, 'dwc-help'))
+          h.advance(3000) // away, with no frames at all
+          click(control(h, 'dwc-close'))
+        }
+        h.step(16)
+      }
+      // From `unmount`'s save, for the same reason as above.
+      handle.unmount()
+      return reef(last(h))
+    } finally {
+      restore()
+    }
+  }
+
+  assert.deepEqual(play(true), play(false), 'coming back from the background bloomed the reef')
+})
+
+test('the manual only lifts a pause it put on itself', () => {
+  // Nothing else pauses ABYSSAL BLOOM today. The day something does — a host
+  // sheet over the frame, a parent gate — a child who opens and closes the rules
+  // underneath it must not be handed back a running reef. Reaching past the type
+  // is the only way to stand in for that second pause, and the guard is worth
+  // proving before the second pause exists rather than after.
+  const h = harness()
+  const restore = h.install()
+  const game = new Game(h.root, makeStubHost({ seed: 0xab1e }))
+  const handle = game.handle()
+  const priv = game as unknown as { paused: boolean; heldForManual: boolean }
+  try {
+    for (let i = 0; i < WARM; i++) h.step(16)
+
+    // The control, so this test cannot pass by the whole feature being absent:
+    // with nobody else holding the clock, the manual takes it and gives it back.
+    click(control(h, 'dwc-help'))
+    assert.equal(priv.paused, true, 'the manual did not stop the reef at all')
+    assert.equal(priv.heldForManual, true, 'the manual did not record its own hold')
+    click(control(h, 'dwc-close'))
+    assert.equal(priv.paused, false, 'the manual did not start the reef again')
+
+    priv.paused = true // somebody else stopped the clock
+    click(control(h, 'dwc-help'))
+    assert.equal(priv.heldForManual, false, 'the manual claimed a pause it did not put on')
+
+    const before = reef(last(h))
+    const drawsBefore = h.draws()
+    click(control(h, 'dwc-close'))
+    for (let i = 0; i < 600; i++) h.step(16)
+
+    assert.deepEqual(reef(last(h)), before, "closing the rules resumed somebody else's pause")
+    assert.equal(h.draws(), drawsBefore, 'closing the rules resumed drawing under another pause')
+    priv.paused = false
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test('opening and closing the manual repeatedly never double-pauses or double-resumes', () => {
+  const h = harness()
+  const restore = h.install()
+  const game = new Game(h.root, makeStubHost({ seed: 0xab1e }))
+  const handle = game.handle()
+  const priv = game as unknown as { paused: boolean; heldForManual: boolean }
+  try {
+    for (let i = 0; i < 400; i++) h.step(16)
+    for (let n = 0; n < 8; n++) {
+      click(control(h, 'dwc-help'))
+      click(control(h, 'dwc-help')) // `open` is documented safe when already open
+      assert.equal(priv.paused, true, 'the manual did not stop the reef')
+      for (let i = 0; i < 30; i++) h.step(16)
+      click(control(h, 'dwc-close'))
+      click(control(h, 'dwc-close'))
+      assert.equal(priv.paused, false, 'the manual did not start the reef again')
+      assert.equal(priv.heldForManual, false, 'the hold outlived the sheet')
+      for (let i = 0; i < 30; i++) h.step(16)
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})

--- a/dynawalla/games/siege/package.json
+++ b/dynawalla/games/siege/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "preview": "vite preview --port 4187",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",
+    "test": "node --experimental-transform-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",
     "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {

--- a/dynawalla/games/siege/src/mount.ts
+++ b/dynawalla/games/siege/src/mount.ts
@@ -83,6 +83,16 @@ export class Siege {
   private raf = 0;
   private lastT = 0;
   private destroyed = false;
+  /** True while the siege is frozen: the wave does not march and nothing draws. */
+  private paused = false;
+  /**
+   * The manual only lifts a pause it put on itself. Nothing else pauses SIEGE
+   * today, but the day something does — a host sheet, a parent gate — a child
+   * closing the rules underneath it must not be handed back a running wave.
+   */
+  private heldForManual = false;
+  /** `performance.now()` when the freeze began, so resume can rebase off it. */
+  private pausedAt = 0;
 
   private q: Question | null = null;
   private order: number[] = [0, 1, 2, 3];
@@ -209,6 +219,21 @@ export class Siege {
         },
       ],
       reducedMotion: this.cam.reducedMotion,
+      // A child opens the rules BECAUSE the wave is winning, and the wave is
+      // what keeps walking while they read: the spawner keeps releasing, the
+      // march keeps advancing, and every enemy that reaches the forge takes a
+      // life the child was never shown losing. The overcharge window is worse
+      // still — it is a countdown, and it would expire behind the sheet.
+      onOpen: () => {
+        if (this.paused) return;
+        this.heldForManual = true;
+        this.setPaused(true);
+      },
+      onClose: () => {
+        if (!this.heldForManual) return;
+        this.heldForManual = false;
+        this.setPaused(false);
+      },
     });
 
     this.nextQuestion();
@@ -241,6 +266,48 @@ export class Siege {
     if ((globalThis as unknown as { __siege?: unknown }).__siege === this) {
       delete (globalThis as unknown as { __siege?: unknown }).__siege;
     }
+  }
+
+  /**
+   * Stop the siege dead, or start it again.
+   *
+   * **Frozen means frozen.** The frame callback keeps being scheduled — it has
+   * to, or there would be nothing left to resume with — but it steps nothing and
+   * draws nothing. Everything that moves in SIEGE is downstream of this one
+   * function: `clock.advance` (and with it `clock.wall`, which the cold anvil
+   * and every canvas animation are measured against), `step()` (the wave
+   * spawner, the enemy march, tower fire, the intermission countdown, the leak
+   * that costs a life), the particles, the camera, the build hint, and the
+   * overcharge window's own countdown. One `return` above them takes all of
+   * them, and the canvas holds its last painted frame underneath the sheet.
+   *
+   * `coldUntil` deliberately needs no rebasing: it is measured against
+   * `clock.wall`, which is a simulation accumulator this function has already
+   * stopped. Only marks taken from the real clock have to move.
+   */
+  private setPaused(on: boolean): void {
+    if (on === this.paused) return;
+    this.paused = on;
+    if (on) {
+      this.pausedAt = performance.now();
+      return;
+    }
+    // `askedAt` is the child's thinking time, and it is the one mark here taken
+    // from the wall clock. Without the shift the next `report` would carry the
+    // sheet's seconds, and the learner model would read a child who was shown
+    // nothing as a child who could not answer.
+    //
+    // `Math.min(now, ...)` covers a mark that was set DURING the hold: a correct
+    // answer re-asks on a 190ms `setTimeout` and the focus overlay closes on a
+    // 260ms one, and a timer that fires behind the sheet must not be shifted
+    // into the future and reported as negative thinking time.
+    const now = performance.now();
+    const held = now - this.pausedAt;
+    this.askedAt = Math.min(now, this.askedAt + held);
+    // The frame delta's other end. Without this the resumed frame measures the
+    // whole read; `Clock.advance` would clamp it to 50ms, but `worstFrame` is
+    // read raw by the playtest harness and would report the sheet as a stall.
+    this.lastT = now;
   }
 
   private onResize = (): void => this.resize();
@@ -428,6 +495,13 @@ export class Siege {
   private frame = (now: number): void => {
     if (this.destroyed) return;
     this.raf = requestAnimationFrame(this.frame);
+    if (this.paused) {
+      // Nothing steps and nothing is drawn. `lastT` still tracks so that a
+      // resume — or a rotation that resizes underneath the sheet — cannot land
+      // one enormous frame, and so `worstFrame` stays a measure of the game.
+      this.lastT = now;
+      return;
+    }
     const raw = (now - this.lastT) / 1000;
     this.lastT = now;
 

--- a/dynawalla/games/siege/src/pause.test.ts
+++ b/dynawalla/games/siege/src/pause.test.ts
@@ -1,0 +1,510 @@
+/**
+ * The siege stops while the rules are up.
+ *
+ * "All games should pause while reading the instructions .. I can hear
+ * counterweight playing in the background while I'm reading the instructions ...
+ * stressing me out even more."
+ *
+ * Sound, keys and taps are held by the shared sheet for every game. A game's own
+ * simulation clock is the one thing it cannot reach, and in SIEGE that clock is
+ * the whole stake: the spawner keeps releasing, the wave keeps marching, and
+ * every enemy that walks into the forge takes a life off a child who is reading
+ * why they are losing. The overcharge window is a countdown and would expire
+ * behind the sheet.
+ *
+ * **This is a mount-level test, on purpose.** SIEGE had no headless harness at
+ * all — `siege.test.ts` proves pure functions and `ui/chrome.test.ts` proves
+ * layout arithmetic, and neither of them ever constructs the game. A pause test
+ * written against a pure function would prove nothing about the wiring, which is
+ * the only thing here that can be wrong. So this file builds the harness: a fake
+ * document, a fake `requestAnimationFrame`, a fake `performance.now`, a fake
+ * `ResizeObserver`, and a 2d context that counts every call made through it.
+ *
+ * **Why `package.json` now runs `--experimental-transform-types`.** It is a
+ * superset of `--experimental-strip-types` and it is what this file needs to
+ * exist: `render/particles.ts` declares `const enum PKind`, which strip-only
+ * mode refuses outright, so importing `mount.ts` from a test was impossible
+ * before. The alternative was to demote the `const enum` to a const object,
+ * which would put a property lookup into the hottest loop in the game to satisfy
+ * a test runner. The flag changes nothing that ships.
+ *
+ * **Removing the fix fails this file.** Delete the `onOpen`/`onClose` pair in
+ * `mount.ts` and the wave marches on behind the sheet; delete the `if
+ * (this.paused)` guard in `frame` and it marches on regardless of the flag;
+ * delete the `lastT`/`askedAt` rebasing and the resumed run diverges from the
+ * uninterrupted one.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Siege } from "./mount.ts";
+import { createStubHost } from "./stubHost.ts";
+import type { State } from "./game/state.ts";
+
+type Handler = (e: unknown) => void;
+
+/** A fake element. Every one carries its OWN listener map — see `helpButton`. */
+type FakeEl = {
+  className: string;
+  listeners: Map<string, Handler[]>;
+  children: FakeEl[];
+} & Record<string, unknown>;
+
+type Harness = {
+  root: HTMLElement;
+  install(): () => void;
+  step(ms: number): void;
+  advance(ms: number): void;
+  now(): number;
+  /** every element the run has made, in creation order */
+  made: FakeEl[];
+  /** calls made through any 2d context — the "did anything draw?" counter */
+  draws(): number;
+};
+
+function harness(w = 820, h = 1180): Harness {
+  const made: FakeEl[] = [];
+  let drawCalls = 0;
+  const rect = { left: 0, top: 0, width: w, height: h, right: w, bottom: h, x: 0, y: 0 };
+
+  // Counts every call made through it and returns itself, so chains like
+  // `createRadialGradient(...).addColorStop(...)` survive with no real canvas.
+  const ctx: unknown = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, prop) => {
+      if (prop === "then") return undefined;
+      // Any coercion of a context value yields 0, so a real comparison in the
+      // renderer — `measureText(label).width <= maxW` — reaches a decision
+      // instead of throwing on an object with no primitive form.
+      if (prop === Symbol.toPrimitive) return () => 0;
+      return ctx;
+    },
+    set: () => true,
+    apply: () => {
+      drawCalls++;
+      return ctx;
+    },
+  });
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>();
+    const children: FakeEl[] = [];
+    const style: Record<string, unknown> = {
+      cssText: "",
+      setProperty(k: string, v: string) {
+        style[k] = v;
+      },
+      removeProperty(k: string) {
+        delete style[k];
+      },
+    };
+    const classes = new Set<string>();
+    const el: FakeEl = {
+      className: "",
+      listeners,
+      children,
+      style,
+      classList: {
+        add: (c: string) => classes.add(c),
+        remove: (c: string) => classes.delete(c),
+        toggle: (c: string, on?: boolean) => {
+          const want = on ?? !classes.has(c);
+          if (want) classes.add(c);
+          else classes.delete(c);
+          return want;
+        },
+        contains: (c: string) => classes.has(c),
+      },
+      textContent: "",
+      id: "",
+      type: "",
+      hidden: false,
+      disabled: false,
+      tabIndex: 0,
+      scrollTop: 0,
+      width: 0,
+      height: 0,
+      offsetWidth: 100,
+      offsetHeight: 40,
+      clientWidth: w,
+      clientHeight: h,
+      appendChild: (c: FakeEl) => {
+        children.push(c);
+        return c;
+      },
+      append: (...cs: FakeEl[]) => {
+        children.push(...cs);
+      },
+      replaceChildren: (...cs: FakeEl[]) => {
+        children.length = 0;
+        children.push(...cs);
+      },
+      remove: () => undefined,
+      querySelectorAll: () => [],
+      focus: () => undefined,
+      animate: () => ({ onfinish: null }),
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      addEventListener: (k: string, fn: Handler) => {
+        const list = listeners.get(k) ?? [];
+        list.push(fn);
+        listeners.set(k, list);
+      },
+      removeEventListener: (k: string, fn: Handler) => {
+        const list = (listeners.get(k) ?? []).filter((x) => x !== fn);
+        listeners.set(k, list);
+      },
+      get firstElementChild(): FakeEl | null {
+        return children[0] ?? null;
+      },
+    };
+    made.push(el);
+    return el;
+  };
+
+  // A QUEUE, not a slot. The HUD schedules its own `requestAnimationFrame`
+  // for a toast fade, and a harness that kept only the newest callback
+  // silently dropped the GAME's frame the first time a toast appeared —
+  // the loop stopped five seconds in and every assertion after that was
+  // measuring a game that had quietly died.
+  let pending: Array<(t: number) => void> = [];
+  let clock = 1000;
+
+  const globals = new Map<string, Handler[]>();
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    dateNow: Date.now,
+    add: globalThis.addEventListener,
+    rm: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    win: (globalThis as { window?: unknown }).window,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+  };
+
+  const root = makeEl();
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending.push(cb);
+      return pending.length;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = [];
+    }) as typeof globalThis.cancelAnimationFrame;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    };
+    performance.now = () => clock;
+    // Pinned: SIEGE seeds its run from the calendar day, and a suite whose seed
+    // depends on when it runs is a suite that goes red for no reason.
+    Date.now = () => 1_780_000_000_000;
+    // A LIST per type, not one handler per type. The shared how-to-play surface
+    // registers a capture-phase swallow for `keydown` on top of the game's own
+    // `keydown`, and a map that kept only the last one would quietly delete half
+    // the wiring this file is here to test.
+    globalThis.addEventListener = ((k: string, fn: Handler): void => {
+      const list = globals.get(k) ?? [];
+      list.push(fn);
+      globals.set(k, list);
+    }) as unknown as typeof globalThis.addEventListener;
+    globalThis.removeEventListener = ((k: string, fn: Handler): void => {
+      globals.set(k, (globals.get(k) ?? []).filter((x) => x !== fn));
+    }) as unknown as typeof globalThis.removeEventListener;
+    (globalThis as { document?: unknown }).document = {
+      createElement: () => makeEl(),
+      createElementNS: () => makeEl(),
+      createTextNode: () => makeEl(),
+      getElementById: () => null,
+      body: makeEl(),
+      head: makeEl(),
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    };
+    (globalThis as { window?: unknown }).window = globalThis;
+    (globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2;
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf;
+      globalThis.cancelAnimationFrame = saved.caf;
+      (globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro;
+      performance.now = saved.now;
+      Date.now = saved.dateNow;
+      globalThis.addEventListener = saved.add;
+      globalThis.removeEventListener = saved.rm;
+      (globalThis as { document?: unknown }).document = saved.doc;
+      (globalThis as { window?: unknown }).window = saved.win;
+      (globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr;
+    };
+  };
+
+  return {
+    root: root as unknown as HTMLElement,
+    install,
+    step: (ms: number): void => {
+      clock += ms;
+      const due = pending;
+      pending = [];
+      for (const cb of due) cb(clock);
+    },
+    // Time passing with no frame delivered — which is exactly what a phone does
+    // when the app goes to the background with the manual up: `rAF` stops, the
+    // wall clock does not.
+    advance: (ms: number): void => {
+      clock += ms;
+    },
+    now: () => clock,
+    made,
+    draws: () => drawCalls,
+  };
+}
+
+/** The shared sheet's help control, found the way a finger finds it. */
+function control(h: Harness, cls: string): FakeEl {
+  const found = h.made.filter((el) => el.className === cls);
+  assert.equal(found.length, 1, `expected exactly one .${cls}, found ${found.length}`);
+  return found[0] as FakeEl;
+}
+
+function click(el: FakeEl): void {
+  const list = el.listeners.get("click") ?? [];
+  assert.ok(list.length > 0, `.${el.className} has no click listener`);
+  for (const fn of list) fn({ type: "click", target: el });
+}
+
+/**
+ * Everything about the run that is SIMULATION, and nothing that is not.
+ *
+ * `fps` and `worstFrame` are instrumentation about the harness's own pumping and
+ * are deliberately excluded; every other field here is something a child would
+ * see change, and every one of them must be identical between a run that was
+ * interrupted by the manual and a run that was not.
+ */
+function sim(s: State): unknown {
+  return {
+    wave: s.wave,
+    phase: s.phase,
+    coreHp: s.coreHp,
+    embers: s.embers,
+    overcharge: s.overcharge,
+    hpRemaining: s.hpRemaining,
+    intermissionT: s.intermissionT,
+    towers: s.towers.map((t) => ({ kind: t.kind, level: t.level, plotId: t.plotId })),
+    stats: { ...s.stats },
+    enemies: s.enemies.map((e) => ({
+      kind: e.kind,
+      alive: e.alive,
+      hp: e.hp,
+      s: e.s,
+      x: e.x,
+      y: e.y,
+    })),
+  };
+}
+
+function live(count: State): number {
+  let n = 0;
+  for (const e of count.enemies) if (e.alive) n++;
+  return n;
+}
+
+/** Frames enough for the first waves to release and start walking. */
+const WARM = 900;
+
+test("nothing in the siege advances while the manual is open", () => {
+  const h = harness();
+  const restore = h.install();
+  const game = new Siege(h.root, createStubHost({ seed: 0x51e6 }));
+  try {
+    for (let i = 0; i < WARM; i++) h.step(16);
+
+    // The run has to actually be running, or "nothing advanced" is vacuous.
+    assert.ok(live(game.live) > 0, "no enemy ever walked — the warm-up proved nothing");
+    assert.ok(h.draws() > 0, "nothing ever drew — the counter proves nothing");
+
+    click(control(h, "dwc-help"));
+
+    const before = sim(game.live);
+    const drawsBefore = h.draws();
+
+    // Two full minutes of a child reading. A wave is thirty seconds.
+    for (let i = 0; i < 7500; i++) h.step(16);
+
+    assert.deepEqual(sim(game.live), before, "the siege advanced behind the sheet");
+    assert.equal(h.draws(), drawsBefore, `${h.draws() - drawsBefore} draw calls behind the sheet`);
+
+    click(control(h, "dwc-close"));
+
+    for (let i = 0; i < 120; i++) h.step(16);
+    assert.notDeepEqual(sim(game.live), before, "the siege never restarted after the manual closed");
+    assert.ok(h.draws() > drawsBefore, "nothing drew again after the manual closed");
+  } finally {
+    game.destroy();
+    restore();
+  }
+});
+
+test("a read costs the child nothing and gives them nothing — the resume does not jump", () => {
+  // The strongest form of both claims at once: the same seed, the same number of
+  // LIVE frames, one run interrupted by two minutes of reading and one not. If
+  // anything advanced behind the sheet the interrupted run is ahead; if any
+  // wall-clock mark leapt on resume it is ahead by a different amount. Only an
+  // exact freeze makes these equal.
+  const play = (readAt: number | null): unknown => {
+    const h = harness();
+    const restore = h.install();
+    const game = new Siege(h.root, createStubHost({ seed: 0x51e6 }));
+    try {
+      for (let i = 0; i < 1800; i++) {
+        if (readAt !== null && i === readAt) {
+          click(control(h, "dwc-help"));
+          for (let k = 0; k < 7500; k++) h.step(16);
+          click(control(h, "dwc-close"));
+        }
+        h.step(16);
+      }
+      return sim(game.live);
+    } finally {
+      game.destroy();
+      restore();
+    }
+  };
+
+  assert.deepEqual(play(900), play(null));
+});
+
+test("the read is not charged to the child as thinking time", () => {
+  // `askedAt` is a `performance.now()` mark and the only thing SIEGE reports
+  // about how long a child took. Left alone across a two-minute read it turns a
+  // child who was shown a sheet into a child who could not answer, and the
+  // learner model believes it.
+  const h = harness();
+  const restore = h.install();
+  const reports: number[] = [];
+  const game = new Siege(
+    h.root,
+    createStubHost({ seed: 0x51e6, onReport: (r) => reports.push(r.ms) }),
+  );
+  try {
+    for (let i = 0; i < 600; i++) h.step(16); // 9.6s of genuine thinking
+
+    click(control(h, "dwc-help"));
+    for (let i = 0; i < 7500; i++) h.step(16); // two minutes of reading
+    click(control(h, "dwc-close"));
+
+    assert.equal(game.autoAnswer(), true, "the anvil would not take an answer after the read");
+    assert.equal(reports.length, 1, "the answer was not reported");
+    const ms = reports[0] as number;
+    assert.ok(ms >= 0, `thinking time went negative: ${ms}ms`);
+    assert.ok(ms < 20_000, `the sheet's two minutes were billed to the child: ${ms}ms`);
+  } finally {
+    game.destroy();
+    restore();
+  }
+});
+
+test("a read through a backgrounded app does not land one enormous frame", () => {
+  // The manual is up and the child switches apps. `requestAnimationFrame` stops
+  // dead; `performance.now()` does not. Whatever `lastT` held is now two minutes
+  // stale, and the first frame after the sheet closes carries all of it.
+  const play = (background: boolean): { sim: unknown; worst: number } => {
+    const h = harness();
+    const restore = h.install();
+    const game = new Siege(h.root, createStubHost({ seed: 0x51e6 }));
+    try {
+      for (let i = 0; i < 1200; i++) {
+        if (i === 600 && background) {
+          click(control(h, "dwc-help"));
+          h.advance(120_000); // away, with no frames at all
+          click(control(h, "dwc-close"));
+        }
+        h.step(16);
+      }
+      return { sim: sim(game.live), worst: game.worstFrame };
+    } finally {
+      game.destroy();
+      restore();
+    }
+  };
+
+  const away = play(true);
+  const straight = play(false);
+  assert.deepEqual(away.sim, straight.sim, "coming back from the background moved the siege");
+  assert.ok(
+    away.worst < 1,
+    `the frame after the sheet measured ${Math.round(away.worst * 1000)}ms of siege`,
+  );
+});
+
+test("the manual only lifts a pause it put on itself", () => {
+  // Nothing else pauses SIEGE today. The day something does — a host sheet over
+  // the frame, a parent gate — a child who opens and closes the rules underneath
+  // it must not be handed back a running wave. Reaching past the type is the
+  // only way to stand in for that second pause, and the guard is worth proving
+  // before the second pause exists rather than after.
+  const h = harness();
+  const restore = h.install();
+  const game = new Siege(h.root, createStubHost({ seed: 0x51e6 }));
+  const priv = game as unknown as { paused: boolean; heldForManual: boolean };
+  try {
+    for (let i = 0; i < WARM; i++) h.step(16);
+
+    // The control, so this test cannot pass by the whole feature being absent:
+    // with nobody else holding the clock, the manual takes it and gives it back.
+    click(control(h, "dwc-help"));
+    assert.equal(priv.paused, true, "the manual did not stop the clock at all");
+    assert.equal(priv.heldForManual, true, "the manual did not record its own hold");
+    click(control(h, "dwc-close"));
+    assert.equal(priv.paused, false, "the manual did not start the clock again");
+
+    priv.paused = true; // somebody else stopped the clock
+    click(control(h, "dwc-help"));
+    assert.equal(priv.heldForManual, false, "the manual claimed a pause it did not put on");
+
+    const before = sim(game.live);
+    const drawsBefore = h.draws();
+    click(control(h, "dwc-close"));
+    for (let i = 0; i < 600; i++) h.step(16);
+
+    assert.deepEqual(sim(game.live), before, "closing the rules resumed somebody else's pause");
+    assert.equal(h.draws(), drawsBefore, "closing the rules resumed drawing under another pause");
+  } finally {
+    priv.paused = false;
+    game.destroy();
+    restore();
+  }
+});
+
+test("opening and closing the manual repeatedly never double-pauses or double-resumes", () => {
+  const h = harness();
+  const restore = h.install();
+  const game = new Siege(h.root, createStubHost({ seed: 0x51e6 }));
+  const priv = game as unknown as { paused: boolean; heldForManual: boolean };
+  const help = () => control(h, "dwc-help");
+  const close = () => control(h, "dwc-close");
+  try {
+    for (let i = 0; i < 400; i++) h.step(16);
+    for (let n = 0; n < 8; n++) {
+      click(help());
+      click(help()); // `open` is documented safe to call when already open
+      assert.equal(priv.paused, true, "the manual did not stop the clock");
+      for (let i = 0; i < 30; i++) h.step(16);
+      click(close());
+      click(close());
+      assert.equal(priv.paused, false, "the manual did not start the clock again");
+      assert.equal(priv.heldForManual, false, "the hold outlived the sheet");
+      for (let i = 0; i < 30; i++) h.step(16);
+    }
+    assert.equal(game.live.phase === "defeat", false, "eight reads lost the run");
+  } finally {
+    game.destroy();
+    restore();
+  }
+});

--- a/dynawalla/games/slice/src/contract.ts
+++ b/dynawalla/games/slice/src/contract.ts
@@ -36,6 +36,20 @@ export type Host = {
   transition?(kind: "level" | "run" | "boss", label?: string): void
 }
 
-export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): {
+  unmount(): void
+  /**
+   * Stop the market's clock, or start it again.
+   *
+   * The host can put a sheet over a still-mounted pack — a purchase surface, a
+   * parent gate — and the SDK documents that the pack keeps running underneath
+   * it. Here that means bombs arriving and a live question's window draining
+   * behind something the child cannot see through. Idempotent both ways.
+   */
+  setPaused(paused: boolean): void
+} {
   return mountSlice(el, host)
 }

--- a/dynawalla/games/slice/src/core/feel.ts
+++ b/dynawalla/games/slice/src/core/feel.ts
@@ -160,6 +160,22 @@ export class Feel {
     return this.flashColor
   }
 
+  /**
+   * Move every wall-clock mark forward by `ms`, because the game was stopped
+   * for that long and did not experience it.
+   *
+   * `hitstopMs` is a countdown against real elapsed time and is untouched — it
+   * was never spent while nothing was advancing. `slowUntil` and `lastFlashAt`
+   * are absolute, so without this a slow-motion in progress when the manual
+   * opened would be over the instant the child closed it, and the first flash
+   * back would ignore the rate limit.
+   */
+  shift(ms: number): void {
+    this.slowUntil += ms
+    this.lastFlashAt += ms
+    this.nowMs += ms
+  }
+
   reset(): void {
     this.trauma = 0
     this.kickX = 0

--- a/dynawalla/games/slice/src/mount.ts
+++ b/dynawalla/games/slice/src/mount.ts
@@ -105,7 +105,10 @@ type Slash = {
 
 const CHAIN_WINDOW = 0.75 // seconds; a cut inside this extends the chain
 
-export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
+export function mountSlice(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; setPaused(paused: boolean): void } {
   // ── surface ──────────────────────────────────────────────────────────────
   const root = document.createElement("div")
   root.style.cssText =
@@ -122,6 +125,22 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
 
   // ── systems ──────────────────────────────────────────────────────────────
   const reduced = host.prefersReducedMotion()
+
+  // ── the clock, and who is allowed to stop it ──────────────────────────────
+  //
+  // THE SPLIT had no pause at all. The host can put a sheet over a still-mounted
+  // pack, and the child can open the manual mid-run, and underneath either one
+  // the market kept throwing: bombs kept arriving, a live question's window kept
+  // draining, and a child who opened the rules *because they were stuck* was
+  // charged the reading time and sometimes lost the lamp while reading about it.
+  //
+  // Declared here rather than beside the loop because `createInstructions` below
+  // closes over them, and a `let` is in its temporal dead zone until this line.
+  let paused = false
+  let pausedAt = 0
+  // The manual only lifts a pause it put on itself. A game the host had already
+  // paused must not be handed back running because a child closed the rules.
+  let heldForManual = false
 
   // How to play. THE SPLIT shipped with none: a child was handed a screen of
   // flying gourds and had to infer from nothing that a swipe cuts, that a cut
@@ -172,6 +191,19 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       },
     ],
     reducedMotion: reduced,
+    // The one part of pausing the shared sheet cannot do for us: sound, keys and
+    // taps are already held over there, but nothing outside this file knows what
+    // this game's clock is.
+    onOpen: () => {
+      if (paused) return
+      heldForManual = true
+      setPaused(true)
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      setPaused(false)
+    },
   })
 
   const gov = new TierGovernor(detectTier())
@@ -1223,6 +1255,10 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function onDown(e: PointerEvent): void {
+    // A host sheet is not the manual: the shared module's pointer swallow only
+    // covers its own scrim, so the game has to refuse the touch itself. A tap
+    // behind a paywall must not start a blade, and must not restart the run.
+    if (paused) return
     void audio.start()
     if (over && performance.now() - overAt > 550) {
       restart()
@@ -1244,6 +1280,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function onMove(e: PointerEvent): void {
+    if (paused) return
     const b = blades.get(e.pointerId)
     if (!b) return
     const r = canvas.getBoundingClientRect()
@@ -1280,6 +1317,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   canvas.addEventListener("contextmenu", (e) => e.preventDefault())
 
   function onKey(e: KeyboardEvent): void {
+    if (paused) return
     if (e.key === "m" || e.key === "M") audio.setEnabled(!audio.enabled)
     if (e.key === "p" || e.key === "P") showPerf = !showPerf
     if ((e.key === "Enter" || e.key === " ") && over) restart()
@@ -1288,7 +1326,9 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
 
   function onVisibility(): void {
     if (document.hidden) audio.suspend()
-    else audio.resume()
+    // Coming back to a paused game must not bring the sound back with it: the
+    // sheet is still up, and the whole complaint was hearing the game behind it.
+    else if (!paused) audio.resume()
   }
   document.addEventListener("visibilitychange", onVisibility)
 
@@ -2006,6 +2046,15 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   function frame(nowMs: number): void {
     if (!running) return
     raf = requestAnimationFrame(frame)
+    if (paused) {
+      // Nothing steps, nothing resolves and nothing is drawn: the canvas holds
+      // its last frame, which is exactly what belongs under the scrim. `last`
+      // still tracks the real clock so the resume cannot land one enormous
+      // frame — a minute behind the manual would otherwise arrive as a minute
+      // of gravity in a single step.
+      last = nowMs
+      return
+    }
     const rawDt = Math.min(64, nowMs - last)
     last = nowMs
     if (gov.sample(rawDt)) resize()
@@ -2030,6 +2079,53 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     draw(nowMs)
   }
   raf = requestAnimationFrame(frame)
+
+  /**
+   * Stop or start the market's clock.
+   *
+   * Idempotent in both directions: two pauses are one pause, and resuming a
+   * running game is nothing. The host calls this around its own sheets, and the
+   * manual calls it around itself.
+   */
+  function setPaused(on: boolean): void {
+    if (on === paused) return
+    paused = on
+    if (on) {
+      pausedAt = performance.now()
+      // A finger that was mid-stroke when the sheet came up will never get its
+      // `pointerup` — the shared module swallows it — so the ribbons are ended
+      // here rather than left hanging for the length of the read.
+      for (const b of blades.values()) b.end()
+      audio.suspend()
+      return
+    }
+    // Every wall-clock mark moves forward by exactly the time the game was
+    // stopped. This is the whole difference between "the game froze" and "the
+    // game skipped": without it, a three-minute read makes the live question
+    // expire on the first frame back, every bomb's fuse tick at once, and the
+    // next `report` bills the child three minutes of thinking time they spent
+    // reading the rules.
+    //
+    // The shift is UNIFORM, which is what keeps every comparison between two
+    // marks — `b.bornAt >= waveBornCut`, `nowMs > b.cuttableAt` — answering the
+    // same way it did before the pause.
+    const held = performance.now() - pausedAt
+    overAt += held
+    liveQAt += held
+    waveBornCut += held
+    for (const b of world.bodies) {
+      b.bornAt += held
+      b.cuttableAt += held
+      b.nextFuseAt += held
+    }
+    // Hitstop and slow-motion are wall-clock too, over in `feel`.
+    feel.shift(held)
+    // Blade ribbons are deliberately NOT shifted. A stroke from before the read
+    // has expired, and bringing it back would hand the child a live blade they
+    // are not touching.
+    last = performance.now()
+    audio.resume()
+  }
 
   // Diagnostics, opt-in via `?debug` on the harness URL. Not attached in normal
   // play, so nothing leaks into the host page. This is what the automated
@@ -2096,6 +2192,8 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   return {
+    setPaused,
+
     unmount(): void {
       running = false
       guide.destroy()

--- a/dynawalla/games/slice/src/pack.ts
+++ b/dynawalla/games/slice/src/pack.ts
@@ -32,6 +32,18 @@ async function start(el: HTMLElement): Promise<void> {
 
   const handle = mount(el, mounted.host as unknown as Host)
 
+  // The host can put a sheet over a still-mounted pack — a purchase surface, a
+  // parent gate — and this game's answering window IS the lanterns' fall. A
+  // question left running behind a sheet expires against a child who was never
+  // shown it, and the bombs keep coming while they cannot reach the blade. The
+  // clock stops dead instead.
+  mounted.client.on("pause", () => {
+    handle.setPaused(true)
+  })
+  mounted.client.on("resume", () => {
+    handle.setPaused(false)
+  })
+
   // The host tells a pack before its port dies, so the rAF loop and the audio
   // context are torn down before the frame is, rather than a frame or two
   // after it.

--- a/dynawalla/games/slice/src/test/manual.test.ts
+++ b/dynawalla/games/slice/src/test/manual.test.ts
@@ -1,0 +1,548 @@
+// The market stops while the rules are up.
+//
+// "I can hear counterweight playing in the background while I'm reading the
+// instructions ... stressing me out even more." THE SPLIT had the same defect
+// and worse than most: the answering window IS the lanterns' fall, so a child
+// who opened the manual *because they were stuck* watched the question they were
+// stuck on expire behind the scrim, and a bomb could take a lamp while they read
+// about bombs.
+//
+// `wiring.test.ts` reads `mount.ts` as text and says so; this file does not. It
+// mounts the real game against a fake surface, drives the real frame loop on a
+// virtual clock, reaches the shared how-to-play sheet through its OWN help
+// button — the same click a child makes — and watches whether the world moved.
+//
+// Three independent observables, because one is a flag and a flag can lie:
+//
+//   1. `draws`  — every call into the 2D context. Zero while frozen.
+//   2. `elapsed` — the director's own clock, which is what decides when the next
+//      gourd is thrown. This is simulation, not rendering.
+//   3. the bodies' positions, straight out of the debug surface.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Handler = (e: unknown) => void
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+type Target = { x: number; y: number; r: number; kind: number; text: string; correct: boolean }
+type Dbg = {
+  stats(): Record<string, number | string>
+  targets(): Target[]
+}
+
+const B_SIGIL = 1
+const B_MOTE = 2
+
+/**
+ * A surface with no pixels, but one that counts.
+ *
+ * Every element gets its OWN listener map. A single map keyed by event type is
+ * the trap here: the shared sheet's help button and its PLAY button both
+ * register a `"click"`, so a shared map would leave the second overwriting the
+ * first and a test that "opened the manual" would in fact be closing it.
+ */
+function surface(width: number, height: number, cores = 12) {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const made: FakeEl[] = []
+  const globals = new Map<string, Handler[]>()
+  let draws = 0
+
+  const ctx = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, prop) => {
+      if (prop === "then") return undefined
+      // `measureText().width` must be a NUMBER. Through a bare proxy it is a
+      // proxy, every glyph atlas is sized `NaN × NaN`, every body lands at NaN
+      // and "the world did not move" becomes unfalsifiable — NaN never equals
+      // itself, so the assertion could not fail even if the game ran.
+      if (prop === "measureText") {
+        return (t: string) => {
+          draws++
+          return { width: String(t).length * 42, actualBoundingBoxAscent: 40, actualBoundingBoxDescent: 12 }
+        }
+      }
+      return ctx
+    },
+    set: () => true,
+    apply: () => {
+      draws++
+      return ctx
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  type FakeEl = {
+    className: string
+    listeners: Map<string, Handler[]>
+    fire(type: string, e?: unknown): void
+    [k: string]: unknown
+  }
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>()
+    const el: FakeEl = {
+      style: {} as Record<string, string>,
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: height,
+      clientWidth: width,
+      clientHeight: height,
+      listeners,
+      appendChild: () => undefined,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener: (k: string, h: Handler) => {
+        const list = listeners.get(k) ?? []
+        list.push(h)
+        listeners.set(k, list)
+      },
+      removeEventListener: (k: string, h: Handler) => {
+        const list = listeners.get(k) ?? []
+        const at = list.indexOf(h)
+        if (at >= 0) list.splice(at, 1)
+      },
+      fire: (k: string, e?: unknown) => {
+        for (const h of [...(listeners.get(k) ?? [])]) h(e ?? {})
+      },
+    }
+    made.push(el)
+    return el
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 1000
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    add: globalThis.addEventListener,
+    remove: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    loc: (globalThis as { location?: unknown }).location,
+    ls: (globalThis as { localStorage?: unknown }).localStorage,
+    dateNow: Date.now,
+    nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
+  }
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb
+      return 1
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    Date.now = () => 0x51ce51ce
+    Object.defineProperty(globalThis, "navigator", {
+      value: { hardwareConcurrency: cores },
+      configurable: true,
+      writable: true,
+    })
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+    // `?debug` is what publishes `globalThis.__slice`, and that surface is how
+    // this file sees the simulation at all.
+    ;(globalThis as { location?: unknown }).location = { search: "?debug" }
+    const store = new Map<string, string>()
+    ;(globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    }
+    globalThis.addEventListener = ((k: string, h: Handler): void => {
+      const list = globals.get(k) ?? []
+      list.push(h)
+      globals.set(k, list)
+    }) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = ((k: string, h: Handler): void => {
+      const list = globals.get(k) ?? []
+      const at = list.indexOf(h)
+      if (at >= 0) list.splice(at, 1)
+    }) as unknown as typeof globalThis.removeEventListener
+    const body = makeEl()
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: () => makeEl(),
+      getElementById: () => null,
+      body,
+      hidden: false,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      Date.now = saved.dateNow
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      globalThis.addEventListener = saved.add
+      globalThis.removeEventListener = saved.remove
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      ;(globalThis as { location?: unknown }).location = saved.loc
+      ;(globalThis as { localStorage?: unknown }).localStorage = saved.ls
+      if (saved.nav) Object.defineProperty(globalThis, "navigator", saved.nav)
+      delete (globalThis as { __slice?: unknown }).__slice
+    }
+  }
+
+  return {
+    el: makeEl(),
+    install,
+    made,
+    globals,
+    drawsSoFar: () => draws,
+    now: () => clock,
+    step: (ms: number): void => {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+  }
+}
+
+type Surface = ReturnType<typeof surface>
+
+/** The shared sheet's own controls, found the way a finger finds them. */
+function control(s: Surface, cls: string): { fire(type: string, e?: unknown): void } {
+  const el = s.made.find((e) => e.className === cls)
+  assert.ok(el, `no ${cls} in the mounted tree — the shared sheet did not mount`)
+  return el as unknown as { fire(type: string, e?: unknown): void }
+}
+
+const openManual = (s: Surface): void => control(s, "dwc-help").fire("click")
+const closeManual = (s: Surface): void => control(s, "dwc-close").fire("click")
+
+function dbg(): Dbg {
+  const d = (globalThis as { __slice?: Dbg }).__slice
+  assert.ok(d, "the debug surface is missing — mount did not see ?debug")
+  return d
+}
+
+/** Everything this file calls "the world". */
+function snapshot(s: Surface): string {
+  const st = dbg().stats()
+  return JSON.stringify({
+    draws: s.drawsSoFar(),
+    elapsed: st.elapsed,
+    bodies: st.bodies,
+    heat: st.heat,
+    score: st.score,
+    lamps: st.lamps,
+    particles: st.particles,
+    chunks: st.chunks,
+    targets: dbg()
+      .targets()
+      .map((t) => [t.x, t.y, t.kind, t.text]),
+  })
+}
+
+function begin(opts: { seed?: number; onReport?: (r: Report) => void } = {}) {
+  const s = surface(768, 1024)
+  const restore = s.install()
+  const nexts: number[] = []
+  const base = createStubHost({ seed: opts.seed ?? 0x51ce, reducedMotion: false, onReport: opts.onReport })
+  const host = {
+    ...base,
+    next: (o?: { domain?: string; difficulty?: number }) => {
+      nexts.push(1)
+      return base.next(o)
+    },
+  }
+  const handle = mount(s.el as unknown as HTMLElement, host)
+  return { s, handle, restore, nextCount: () => nexts.length }
+}
+
+/** A swipe straight through a point, fast enough to be a cut and not a drag. */
+function swipe(s: Surface, x: number, y: number): void {
+  const canvas = s.made.find((e) => e.listeners.has("pointerdown"))
+  assert.ok(canvas, "the canvas never bound a pointerdown")
+  const t = s.now()
+  const ev = (cx: number, cy: number, ts: number) => ({
+    pointerId: 1,
+    button: 0,
+    clientX: cx,
+    clientY: cy,
+    timeStamp: ts,
+    preventDefault: () => undefined,
+  })
+  canvas.fire("pointerdown", ev(x - 120, y, t))
+  canvas.fire("pointermove", ev(x - 40, y, t + 8))
+  canvas.fire("pointermove", ev(x + 40, y, t + 16))
+  canvas.fire("pointermove", ev(x + 120, y, t + 24))
+  canvas.fire("pointerup", ev(x + 120, y, t + 24))
+}
+
+test("THE MARKET STOPS: nothing advances while the manual is up", () => {
+  const { s, handle, restore } = begin({ seed: 0xf00d })
+  try {
+    for (let i = 0; i < 900; i++) s.step(16)
+    const before = snapshot(s)
+    assert.ok(dbg().targets().length > 0, "nothing was in the air before the manual opened")
+
+    openManual(s)
+    // Three minutes of a child reading, at sixty frames a second.
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    assert.equal(snapshot(s), before, "the market kept running behind the manual")
+
+    closeManual(s)
+    for (let i = 0; i < 240; i++) s.step(16)
+    assert.notEqual(snapshot(s), before, "the market never came back after the manual closed")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the manual does not serve the child a question they never saw", () => {
+  const { s, handle, restore, nextCount } = begin({ seed: 0xbeef })
+  try {
+    for (let i = 0; i < 900; i++) s.step(16)
+    const before = nextCount()
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    assert.equal(nextCount(), before, "the director drew questions from the host behind the sheet")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("closing the manual does not hand the loop one enormous frame", () => {
+  // `last` has to keep tracking the real clock across the read, or the first
+  // frame back is `now − last` — three minutes of gravity in a single step. The
+  // loop's 64ms clamp catches the worst of it, which is exactly why this needs
+  // asserting rather than eyeballing: the bug survives the clamp as a visible
+  // four-frame lurch of everything in the air, not as a crash.
+  //
+  // Measured as how far the gourds actually moved, because the director's clock
+  // is only published to a tenth of a second and a frame is well under that.
+  const key = (t: Target): string => `${t.kind}:${t.text}:${t.r.toFixed(4)}`
+  const travel = (): number => {
+    const before = new Map(dbg().targets().map((t) => [key(t), t]))
+    s.step(16)
+    let most = 0
+    for (const t of dbg().targets()) {
+      const was = before.get(key(t))
+      if (!was) continue
+      most = Math.max(most, Math.hypot(t.x - was.x, t.y - was.y))
+    }
+    return most
+  }
+
+  const { s, handle, restore } = begin({ seed: 0xc0ffee })
+  try {
+    for (let i = 0; i < 900; i++) s.step(16)
+    const ordinary = travel()
+    assert.ok(ordinary > 0, "nothing was moving before the manual opened, so this measures nothing")
+
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    closeManual(s)
+
+    const firstBack = travel()
+    assert.ok(
+      firstBack <= ordinary * 1.6,
+      `the first frame back moved the market ${firstBack.toFixed(1)}px against an ordinary ${ordinary.toFixed(1)}px`,
+    )
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("THE READ IS NOT BILLED: a question survives the manual, and costs nothing", () => {
+  // The wall-clock half of the fix. `liveQAt` is a `performance.now()` mark and
+  // the answering window is a countdown; a manual left up for three minutes must
+  // not expire the question, and the latency handed to the curriculum must be
+  // the child's thinking, not their reading.
+  const reports: Report[] = []
+  const { s, handle, restore } = begin({ seed: 0x5161, onReport: (r) => reports.push(r) })
+  try {
+    let sliced = false
+    for (let i = 0; i < 4000 && !sliced; i++) {
+      s.step(16)
+      const sigil = dbg()
+        .targets()
+        .find((t) => t.kind === B_SIGIL)
+      if (sigil) {
+        swipe(s, sigil.x, sigil.y)
+        s.step(16)
+        sliced = dbg().targets().some((t) => t.kind === B_MOTE)
+      }
+    }
+    assert.ok(sliced, "never managed to open a sigil, so this test proved nothing")
+
+    // Let the read-lock lapse so the candidates are cuttable.
+    for (let i = 0; i < 60; i++) s.step(16)
+    const liveBefore = String(dbg().stats().liveQ)
+    assert.ok(liveBefore.length > 0, "no question was live after the sigil opened")
+    const motesBefore = dbg().targets().filter((t) => t.kind === B_MOTE).length
+
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    closeManual(s)
+
+    assert.equal(String(dbg().stats().liveQ), liveBefore, "the question expired behind the manual")
+    assert.equal(
+      dbg().targets().filter((t) => t.kind === B_MOTE).length,
+      motesBefore,
+      "candidates went away while the child was reading",
+    )
+
+    const mote = dbg()
+      .targets()
+      .find((t) => t.kind === B_MOTE)
+    assert.ok(mote, "the candidates vanished across the pause")
+    const n = reports.length
+    swipe(s, mote.x, mote.y)
+    s.step(16)
+    assert.equal(reports.length, n + 1, "cutting a candidate after the manual reported nothing")
+    const r = reports[reports.length - 1] as Report
+    assert.ok(
+      r.ms < 60_000,
+      `the read was billed to the child: ${r.ms}ms of "thinking" for a question answered at once`,
+    )
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the read-lock survives the manual — a candidate is not cuttable on the way back", () => {
+  // `cuttableAt` is the other wall-clock mark, and it is the one the manual
+  // says out loud: "You cannot cut them straight away. You get a moment to read
+  // them first." Unshifted, three minutes of reading burns the lock, and the
+  // stroke a child makes as they close the sheet answers a question they have
+  // not looked at yet.
+  const reports: Report[] = []
+  const { s, handle, restore } = begin({ seed: 0x5161, onReport: (r) => reports.push(r) })
+  try {
+    let motes: Target[] = []
+    for (let i = 0; i < 4000 && motes.length === 0; i++) {
+      s.step(16)
+      const sigil = dbg()
+        .targets()
+        .find((t) => t.kind === B_SIGIL)
+      if (sigil) {
+        swipe(s, sigil.x, sigil.y)
+        s.step(16)
+        motes = dbg().targets().filter((t) => t.kind === B_MOTE)
+      }
+    }
+    assert.ok(motes.length > 0, "never managed to open a sigil, so this test proved nothing")
+
+    // Straight into the manual, inside the 420ms lock.
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    closeManual(s)
+
+    const n = reports.length
+    const mote = dbg()
+      .targets()
+      .find((t) => t.kind === B_MOTE)
+    assert.ok(mote, "the candidates vanished across the pause")
+    swipe(s, mote.x, mote.y)
+    s.step(16)
+    assert.equal(reports.length, n, "the read-lock was spent on the manual — the first stroke back answered")
+
+    // And the lock does still lapse, on the game's own time.
+    for (let i = 0; i < 60; i++) s.step(16)
+    const m2 = dbg()
+      .targets()
+      .find((t) => t.kind === B_MOTE)
+    assert.ok(m2, "the candidates fell away before the lock lapsed")
+    swipe(s, m2.x, m2.y)
+    s.step(16)
+    assert.equal(reports.length, n + 1, "the lock never lapsed — the candidates are permanently uncuttable")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the manual only lifts a pause it put on itself", () => {
+  // The host puts a sheet over a still-mounted pack — a purchase surface, a
+  // parent gate — and the child, behind it, closes the how-to-play they had
+  // open. The game must stay stopped: the host is still holding it.
+  const { s, handle, restore } = begin({ seed: 0x9001 })
+  try {
+    for (let i = 0; i < 600; i++) s.step(16)
+    handle.setPaused(true)
+    const held = snapshot(s)
+
+    openManual(s)
+    for (let i = 0; i < 600; i++) s.step(16)
+    closeManual(s)
+    for (let i = 0; i < 1200; i++) s.step(16)
+    assert.equal(snapshot(s), held, "closing the rules handed the game back while the host held it")
+
+    handle.setPaused(false)
+    for (let i = 0; i < 240; i++) s.step(16)
+    assert.notEqual(snapshot(s), held, "the host could not get its own game back")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("pausing twice is one pause, and resuming a running game is nothing", () => {
+  const { s, handle, restore } = begin({ seed: 0x1d3a })
+  try {
+    handle.setPaused(false)
+    for (let i = 0; i < 600; i++) s.step(16)
+    handle.setPaused(true)
+    handle.setPaused(true)
+    const held = snapshot(s)
+    for (let i = 0; i < 3000; i++) s.step(16)
+    assert.equal(snapshot(s), held, "a doubled pause let the market through")
+    handle.setPaused(false)
+    handle.setPaused(false)
+    for (let i = 0; i < 240; i++) s.step(16)
+    assert.notEqual(snapshot(s), held, "a doubled resume left the market stopped")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the manual can be opened and closed all run without the game drifting", () => {
+  const { s, handle, restore } = begin({ seed: 0x2b2b })
+  try {
+    for (let i = 0; i < 40; i++) {
+      for (let k = 0; k < 30; k++) s.step(16)
+      openManual(s)
+      for (let k = 0; k < 30; k++) s.step(16)
+      closeManual(s)
+    }
+    const st = dbg().stats()
+    assert.ok(Number(st.elapsed) > 0, "forty opens and closes left the game never having run")
+    assert.ok(Number(st.lamps) >= 0)
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})

--- a/dynawalla/games/stack/src/audio/audio.ts
+++ b/dynawalla/games/stack/src/audio/audio.ts
@@ -95,6 +95,17 @@ export class Audio {
     if (this.ctx && this.ctx.state === "suspended") void this.ctx.resume();
   }
 
+  /**
+   * Stop the graph dead while the game is stopped.
+   *
+   * The shared how-to-play sheet already holds every context the pack owns, so
+   * this is not for the manual — it is for a sheet the HOST raises over a still
+   * mounted pack, which nothing else in this package would silence.
+   */
+  suspend(): void {
+    if (this.ctx && this.ctx.state === "running") void this.ctx.suspend();
+  }
+
   dispose(): void {
     try {
       void this.ctx?.close();

--- a/dynawalla/games/stack/src/contract.ts
+++ b/dynawalla/games/stack/src/contract.ts
@@ -26,6 +26,21 @@ export type Host = {
    */
   transition?(kind: "level" | "run" | "boss", label?: string): void
 }
-export type Mount = (el: HTMLElement, host: Host) => { unmount(): void }
+export type Mount = (
+  el: HTMLElement,
+  host: Host,
+) => {
+  unmount(): void
+  /**
+   * Stop the monument's clock, or start it again.
+   *
+   * The host can put a sheet over a still-mounted pack — a purchase surface, a
+   * parent gate — and the SDK documents that the pack keeps running underneath
+   * it. Here that means the sweep still sweeping, the slot still turning over
+   * and `dither` still compounding behind something the child cannot reach
+   * through. Idempotent both ways.
+   */
+  setPaused(paused: boolean): void
+}
 
 export { mount } from "./game/mount.ts";

--- a/dynawalla/games/stack/src/game/manual.test.ts
+++ b/dynawalla/games/stack/src/game/manual.test.ts
@@ -1,0 +1,554 @@
+// The monument stops while the rules are up.
+//
+// "I can hear counterweight playing in the background while I'm reading the
+// instructions ... stressing me out even more." MONUMENT was worse than noisy.
+// Its manual ends with the words "Waiting never costs you anything", and behind
+// that very sheet the sweep kept sweeping, the value on the stone kept turning
+// over, and `dither` — the impatience penalty that makes the stone FASTER every
+// three idle cycles — kept compounding. Reading the rules was charged as
+// dithering. Three minutes of a child being careful took the sweep from 1.00 to
+// its 1.90 ceiling.
+//
+// So this file mounts the real `mount()` — three, WebGL, HUD and all — against a
+// stubbed drawing context, drives the real frame loop on a virtual clock,
+// reaches the shared how-to-play sheet through its OWN help button, and watches
+// the simulation directly through the game's `?dev=1` handle.
+//
+// What is NOT covered here: pixels. The GL stub records calls and returns
+// plausible constants; it does not rasterise. "The canvas visibly holds its last
+// frame under the scrim" is a device claim, not this file's.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "./mount.ts"
+import type { Sim } from "./sim.ts"
+import { createStubHost } from "../host/stub.ts"
+
+type Handler = (e: unknown) => void
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+type Dev = { sim: Sim; tap: (ts?: number) => void; latency: () => number }
+
+/**
+ * Enough WebGL2 for three to construct, compile, link and draw.
+ *
+ * Everything unknown becomes either an enum constant (ALL_CAPS) or a no-op
+ * function, resolved on first touch. The handful of calls three actually reads a
+ * value back from are answered explicitly — `getParameter(VERSION)` in
+ * particular must be a string, or `WebGLState` dies on `glVersion.indexOf`.
+ */
+function makeGl(count: () => void, draw: () => void): WebGL2RenderingContext {
+  const obj = (): Record<string, unknown> => ({})
+  const target: Record<string, unknown> = {}
+  let next = 0x1000
+  const fixed: Record<string, unknown> = {
+    canvas: null,
+    drawingBufferWidth: 768,
+    drawingBufferHeight: 1024,
+    getParameter: (p: number) => {
+      if (p === target.VERSION) return "WebGL 2.0 (stub)"
+      if (p === target.SHADING_LANGUAGE_VERSION) return "WebGL GLSL ES 3.00 (stub)"
+      if (p === target.VENDOR || p === target.RENDERER) return "stub"
+      if (
+        p === target.MAX_TEXTURE_SIZE ||
+        p === target.MAX_CUBE_MAP_TEXTURE_SIZE ||
+        p === target.MAX_RENDERBUFFER_SIZE ||
+        p === target.MAX_3D_TEXTURE_SIZE ||
+        p === target.MAX_ARRAY_TEXTURE_LAYERS
+      ) {
+        return 4096
+      }
+      if (p === target.MAX_VIEWPORT_DIMS || p === target.VIEWPORT || p === target.SCISSOR_BOX) {
+        return [0, 0, 4096, 4096]
+      }
+      if (p === target.MAX_SAMPLES) return 4
+      return 16
+    },
+    getExtension: () => null,
+    getSupportedExtensions: () => [],
+    getShaderPrecisionFormat: () => ({ precision: 23, rangeMin: 127, rangeMax: 127 }),
+    createShader: obj,
+    createProgram: obj,
+    createBuffer: obj,
+    createTexture: obj,
+    createFramebuffer: obj,
+    createRenderbuffer: obj,
+    createVertexArray: obj,
+    getShaderParameter: () => true,
+    getProgramParameter: () => true,
+    getShaderInfoLog: () => "",
+    getProgramInfoLog: () => "",
+    getActiveAttrib: () => ({ name: "a", type: 0, size: 1 }),
+    getActiveUniform: () => ({ name: "u", type: 0, size: 1 }),
+    getUniformLocation: obj,
+    getAttribLocation: () => 0,
+    getError: () => 0,
+    checkFramebufferStatus: () => 0x8cd5,
+    isContextLost: () => false,
+  }
+  const DRAWS = new Set(["drawArrays", "drawElements", "drawArraysInstanced", "drawElementsInstanced", "clear"])
+  for (const [k, v] of Object.entries(fixed)) {
+    target[k] = typeof v === "function" ? (...a: unknown[]) => {
+      count()
+      return (v as (...x: unknown[]) => unknown)(...a)
+    } : v
+  }
+  return new Proxy(target, {
+    get(t, p) {
+      if (p in t) return t[p as string]
+      if (typeof p === "symbol") return undefined
+      const name = String(p)
+      if (/^[A-Z0-9_]+$/.test(name)) {
+        t[name] = next++
+        return t[name]
+      }
+      const isDraw = DRAWS.has(name)
+      t[name] = () => {
+        count()
+        if (isDraw) draw()
+      }
+      return t[name]
+    },
+  }) as unknown as WebGL2RenderingContext
+}
+
+/**
+ * A DOM with no layout.
+ *
+ * Every element gets its OWN listener map. A single map keyed by event type is
+ * the trap here: the shared sheet's help button and its PLAY button both
+ * register a `"click"`, so a shared map would leave the second overwriting the
+ * first and a test that "opened the manual" would in fact be closing it.
+ */
+function surface(width: number, height: number) {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const made: FakeEl[] = []
+  let calls = 0
+  let draws = 0
+  const gl = makeGl(
+    () => {
+      calls++
+    },
+    () => {
+      draws++
+    },
+  )
+
+  const ctx2d = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, prop) => {
+      if (prop === "then") return undefined
+      if (prop === "measureText") {
+        return (t: string) => {
+          calls++
+          return { width: String(t).length * 40, actualBoundingBoxAscent: 40, actualBoundingBoxDescent: 12 }
+        }
+      }
+      return ctx2d
+    },
+    set: () => true,
+    apply: () => {
+      calls++
+      return ctx2d
+    },
+  }) as unknown as CanvasRenderingContext2D
+
+  type FakeEl = {
+    className: string
+    listeners: Map<string, Handler[]>
+    fire(type: string, e?: unknown): void
+    [k: string]: unknown
+  }
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>()
+    const classes = new Set<string>()
+    // The HUD writes its palette through CSS custom properties, so `style` has
+    // to be a CSSStyleDeclaration and not a bag of named fields — the shared
+    // sheet's own idiom is plain assignment, and both have to work on one object.
+    const vars = new Map<string, string>()
+    const el: FakeEl = {
+      style: {
+        setProperty: (k: string, v: string) => void vars.set(k, v),
+        getPropertyValue: (k: string) => vars.get(k) ?? "",
+        removeProperty: (k: string) => void vars.delete(k),
+      } as unknown as Record<string, string>,
+      dataset: {} as Record<string, string>,
+      children: [] as unknown[],
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      innerHTML: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: height,
+      clientWidth: width,
+      clientHeight: height,
+      listeners,
+      classList: {
+        add: (c: string) => void classes.add(c),
+        remove: (c: string) => void classes.delete(c),
+        toggle: (c: string, on?: boolean) => void (on ?? !classes.has(c) ? classes.add(c) : classes.delete(c)),
+        contains: (c: string) => classes.has(c),
+      },
+      appendChild: (c: unknown) => c,
+      append: () => undefined,
+      remove: () => undefined,
+      replaceChildren: () => undefined,
+      focus: () => undefined,
+      blur: () => undefined,
+      closest: () => null,
+      querySelector: () => makeEl(),
+      querySelectorAll: () => [],
+      animate: () => ({ cancel: () => undefined, finish: () => undefined }),
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: (kind: string) => (kind === "2d" ? ctx2d : gl),
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener: (k: string, h: Handler) => {
+        const list = listeners.get(k) ?? []
+        list.push(h)
+        listeners.set(k, list)
+      },
+      removeEventListener: (k: string, h: Handler) => {
+        const list = listeners.get(k) ?? []
+        const at = list.indexOf(h)
+        if (at >= 0) list.splice(at, 1)
+      },
+      fire: (k: string, e?: unknown) => {
+        for (const h of [...(listeners.get(k) ?? [])]) h(e ?? {})
+      },
+    }
+    made.push(el)
+    return el
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 1000
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    add: globalThis.addEventListener,
+    remove: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    win: (globalThis as { window?: unknown }).window,
+    loc: (globalThis as { location?: unknown }).location,
+    nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
+  }
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb
+      return 1
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    Object.defineProperty(globalThis, "navigator", {
+      value: { hardwareConcurrency: 8, deviceMemory: 8 },
+      configurable: true,
+      writable: true,
+    })
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 1
+    // `?dev=1` is what publishes `window.__monument`, and that handle — which
+    // carries the live `Sim` — is how this file sees the simulation at all.
+    ;(globalThis as { location?: unknown }).location = { search: "?dev=1" }
+    globalThis.addEventListener = (() => undefined) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = (() => undefined) as unknown as typeof globalThis.removeEventListener
+    const body = makeEl()
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: () => makeEl(),
+      getElementById: () => null,
+      body,
+      hidden: false,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }
+    ;(globalThis as { window?: unknown }).window = globalThis
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      globalThis.addEventListener = saved.add
+      globalThis.removeEventListener = saved.remove
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      ;(globalThis as { window?: unknown }).window = saved.win
+      ;(globalThis as { location?: unknown }).location = saved.loc
+      if (saved.nav) Object.defineProperty(globalThis, "navigator", saved.nav)
+      delete (globalThis as { __monument?: unknown }).__monument
+    }
+  }
+
+  return {
+    el: makeEl(),
+    install,
+    made,
+    calls: () => calls,
+    draws: () => draws,
+    step: (ms: number): void => {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+  }
+}
+
+type Surface = ReturnType<typeof surface>
+
+function control(s: Surface, cls: string): { fire(type: string, e?: unknown): void } {
+  const el = s.made.find((e) => e.className === cls)
+  assert.ok(el, `no ${cls} in the mounted tree — the shared sheet did not mount`)
+  return el as unknown as { fire(type: string, e?: unknown): void }
+}
+
+const openManual = (s: Surface): void => control(s, "dwc-help").fire("click")
+const closeManual = (s: Surface): void => control(s, "dwc-close").fire("click")
+
+function dev(): Dev {
+  const d = (globalThis as { __monument?: Dev }).__monument
+  assert.ok(d, "the dev handle is missing — mount did not see ?dev=1")
+  return d
+}
+
+/** Everything this file calls "the monument". */
+function snapshot(s: Surface): string {
+  const sim = dev().sim
+  return JSON.stringify({
+    calls: s.calls(),
+    draws: s.draws(),
+    sweep: sim.sweep,
+    dir: sim.dir,
+    slot: sim.slot,
+    dither: sim.dither,
+    cyclesIdle: sim.cyclesIdle,
+    holdLeft: sim.holdLeft,
+    swayT: sim.swayT,
+    floor: sim.floor,
+    phase: sim.phase,
+    questionAt: sim.questionAt,
+    prompt: sim.question.prompt,
+  })
+}
+
+function begin(opts: { onReport?: (r: Report) => void } = {}) {
+  const s = surface(768, 1024)
+  const restore = s.install()
+  const host = createStubHost({ seed: 0x51ab, onReport: opts.onReport })
+  const handle = mount(s.el as unknown as HTMLElement, host)
+  return { s, handle, restore }
+}
+
+test("THE SWEEP STOPS: nothing advances while the manual is up", () => {
+  const { s, handle, restore } = begin()
+  try {
+    for (let i = 0; i < 300; i++) s.step(16)
+    const before = snapshot(s)
+    assert.ok(s.draws() > 0, "nothing was ever drawn, so a frozen draw count proves nothing")
+    assert.notEqual(dev().sim.sweep, 0, "the sweep never moved before the manual opened")
+
+    openManual(s)
+    // Three minutes of a child reading, at sixty frames a second.
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    assert.equal(snapshot(s), before, "the monument kept running behind the manual")
+
+    closeManual(s)
+    for (let i = 0; i < 120; i++) s.step(16)
+    assert.notEqual(snapshot(s), before, "the monument never came back after the manual closed")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("WAITING IS FREE, INCLUDING READING: the dither does not compound behind the sheet", () => {
+  // The exact contradiction this fix exists to end. The last line of MONUMENT's
+  // own manual is "Waiting never costs you anything", and `dither` is the one
+  // mechanism in the game that makes waiting cost something: three idle cycles
+  // and the stone gets 16% faster, up to a 1.9× ceiling. Three minutes behind
+  // the sheet is more than enough idle cycles to hit that ceiling.
+  const { s, handle, restore } = begin()
+  try {
+    for (let i = 0; i < 300; i++) s.step(16)
+    const sim = dev().sim
+    assert.equal(sim.dither, 1, "the run started already dithering")
+    const idleBefore = sim.cyclesIdle
+
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    assert.equal(sim.dither, 1, `three minutes of reading pushed the stone to ${sim.dither}× speed`)
+    assert.equal(sim.cyclesIdle, idleBefore, "the child was billed idle cycles for reading the rules")
+
+    // And the penalty is still armed — this test must not be passing because
+    // dithering was quietly removed.
+    closeManual(s)
+    for (let i = 0; i < 3600; i++) s.step(16)
+    assert.ok(sim.dither > 1, "dithering no longer happens at all, so the assertion above is vacuous")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("THE READ IS NOT BILLED: a stone set after the manual costs the reading time", () => {
+  // `ms` on every report is `(clock − questionAt) × 1000`, and `clock` is the
+  // loop's own accumulator. Freezing the loop is what keeps that honest: a
+  // three-minute read must not reach the curriculum as three minutes of a child
+  // failing to answer.
+  const reports: Report[] = []
+  const { s, handle, restore } = begin({ onReport: (r) => reports.push(r) })
+  try {
+    for (let i = 0; i < 300; i++) s.step(16)
+    const askedAt = dev().sim.questionAt
+
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    closeManual(s)
+    assert.equal(dev().sim.questionAt, askedAt, "the question was re-stamped across the pause")
+
+    const n = reports.length
+    dev().tap()
+    for (let i = 0; i < 30; i++) s.step(16)
+    assert.equal(reports.length, n + 1, "setting a stone after the manual reported nothing")
+    const r = reports[reports.length - 1] as Report
+    assert.ok(
+      r.ms < 60_000,
+      `the read was billed to the child: ${r.ms}ms of "thinking" for a stone set at once`,
+    )
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("closing the manual does not hand the loop one enormous frame", () => {
+  // `last` has to keep tracking the real clock while the game is stopped, or
+  // the first frame back is `now − last` — the whole length of the read. The
+  // loop's 0.05s clamp catches the worst of it, which is exactly why this needs
+  // asserting rather than eyeballing: the bug survives the clamp as a visible
+  // three-frame lurch, not as a crash.
+  const { s, handle, restore } = begin()
+  try {
+    for (let i = 0; i < 300; i++) s.step(16)
+    const a = dev().sim.swayT
+    s.step(16)
+    const ordinary = dev().sim.swayT - a
+
+    openManual(s)
+    for (let i = 0; i < 11_250; i++) s.step(16)
+    closeManual(s)
+
+    const b = dev().sim.swayT
+    s.step(16)
+    const firstBack = dev().sim.swayT - b
+    assert.ok(
+      firstBack <= ordinary * 1.5,
+      `the first frame back carried ${(firstBack * 1000).toFixed(1)}ms against an ordinary ${(ordinary * 1000).toFixed(1)}ms`,
+    )
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("a tap cannot set a stone while the game is stopped", () => {
+  const { s, handle, restore } = begin()
+  try {
+    for (let i = 0; i < 300; i++) s.step(16)
+    const placed = dev().sim.placed
+    handle.setPaused(true)
+    for (let i = 0; i < 40; i++) {
+      dev().tap()
+      s.step(16)
+    }
+    assert.equal(dev().sim.placed, placed, "forty taps behind a host sheet set forty stones")
+    handle.setPaused(false)
+    for (let i = 0; i < 30; i++) s.step(16)
+    dev().tap()
+    for (let i = 0; i < 30; i++) s.step(16)
+    assert.equal(dev().sim.placed, placed + 1, "the tap never came back")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the manual only lifts a pause it put on itself", () => {
+  // The host puts a sheet over a still-mounted pack — a purchase surface, a
+  // parent gate — and the child, behind it, closes the how-to-play they had
+  // open. The game must stay stopped: the host is still holding it.
+  const { s, handle, restore } = begin()
+  try {
+    for (let i = 0; i < 300; i++) s.step(16)
+    handle.setPaused(true)
+    const held = snapshot(s)
+
+    openManual(s)
+    for (let i = 0; i < 600; i++) s.step(16)
+    closeManual(s)
+    for (let i = 0; i < 1200; i++) s.step(16)
+    assert.equal(snapshot(s), held, "closing the rules handed the game back while the host held it")
+
+    handle.setPaused(false)
+    for (let i = 0; i < 120; i++) s.step(16)
+    assert.notEqual(snapshot(s), held, "the host could not get its own game back")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("pausing twice is one pause, and resuming a running game is nothing", () => {
+  const { s, handle, restore } = begin()
+  try {
+    handle.setPaused(false)
+    for (let i = 0; i < 300; i++) s.step(16)
+    handle.setPaused(true)
+    handle.setPaused(true)
+    const held = snapshot(s)
+    for (let i = 0; i < 3000; i++) s.step(16)
+    assert.equal(snapshot(s), held, "a doubled pause let the sweep through")
+    handle.setPaused(false)
+    handle.setPaused(false)
+    for (let i = 0; i < 120; i++) s.step(16)
+    assert.notEqual(snapshot(s), held, "a doubled resume left the monument stopped")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("the manual can be opened and closed all run without the game drifting", () => {
+  const { s, handle, restore } = begin()
+  try {
+    for (let i = 0; i < 40; i++) {
+      for (let k = 0; k < 20; k++) s.step(16)
+      openManual(s)
+      for (let k = 0; k < 20; k++) s.step(16)
+      closeManual(s)
+      if (i % 4 === 0) dev().tap()
+    }
+    assert.ok(dev().sim.swayT > 0, "forty opens and closes left the game never having run")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})

--- a/dynawalla/games/stack/src/game/mount.ts
+++ b/dynawalla/games/stack/src/game/mount.ts
@@ -51,7 +51,10 @@ const ACTION_SCREEN_Y = 0.33;
 const HOVER = T.SLAB_H * 1.15;
 const DROP_MS = 88;
 
-export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; setPaused(paused: boolean): void } {
   const reduced = host.prefersReducedMotion();
   let raf = 0;
   let running = true;
@@ -200,6 +203,9 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
         if (sim.reviveQ) hud.showRevive(sim.reviveQ.prompt, sim.reviveChoices);
       },
       onChoose: (v) => {
+        // The revive panel is real DOM sitting under whatever the host raised.
+        // Answering it behind a sheet reports an item the child never saw.
+        if (paused) return;
         const answer = sim.reviveQ?.answer ?? "";
         hud.markChoice(v, answer);
         const ok = sim.answerRevive(v, clock);
@@ -226,6 +232,21 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     },
     reduced,
   );
+
+  /* ── the clock, and who is allowed to stop it ───────────────────────────
+   *
+   * MONUMENT had no pause of any kind. Behind the manual the sweep kept
+   * sweeping, the slot kept turning over — and worse, `dither` kept compounding,
+   * so the sheet that says "Waiting never costs you anything" was itself making
+   * the stone faster while it was open. Behind a host sheet the same, with no
+   * scrim of ours to catch the tap.
+   *
+   * Declared above `createInstructions` because the sheet closes over them.
+   */
+  let paused = false;
+  // The manual only lifts a pause it put on itself. A game the host had already
+  // paused must not be handed back running because a child closed the rules.
+  let heldForManual = false;
 
   // How to play. MONUMENT asks for two judgements in one tap — is this the
   // right value, and is it over the tower — and shipped saying only "Tap to set
@@ -270,6 +291,18 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       },
     ],
     reducedMotion: reduced,
+    // The one part of pausing the shared sheet cannot do for us. It holds the
+    // sound, the keys and the taps; it has no idea the sweep exists.
+    onOpen: () => {
+      if (paused) return;
+      heldForManual = true;
+      setPaused(true);
+    },
+    onClose: () => {
+      if (!heldForManual) return;
+      heldForManual = false;
+      setPaused(false);
+    },
   });
 
   /* ── palette blending ───────────────────────────────────────────────── */
@@ -693,6 +726,10 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
   let lastLatency = 0;
 
   function tap(evTs?: number): void {
+    // A host sheet is not the manual: the shared module's pointer swallow only
+    // covers its own scrim, so the game has to refuse the tap itself. A touch
+    // landing behind a paywall must not set a stone the child never aimed.
+    if (paused) return;
     audio.resume();
     if (sim.phase !== "sweep") return;
     if (drop.active) return;
@@ -740,6 +777,7 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     tap(e.timeStamp);
   };
   const onKey = (e: KeyboardEvent): void => {
+    if (paused) return;
     if (e.code === "Space" || e.code === "Enter" || e.code === "ArrowDown" || e.code === "KeyR") {
       e.preventDefault();
       if (sim.phase !== "sweep" && collapseAt < 0) restart();
@@ -799,6 +837,17 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
   function frame(now: number): void {
     if (!running) return;
     raf = requestAnimationFrame(frame);
+    if (paused) {
+      // Nothing steps, nothing renders: the WebGL front buffer holds its last
+      // frame, which is exactly what belongs under the scrim. `last` still
+      // tracks the real clock so the resume cannot arrive as one enormous
+      // frame — and `clock` does not advance at all, which is what keeps
+      // `questionAt`, `collapseAt` and the reported latency honest without any
+      // rebasing: they are all measured in this clock, and this clock did not
+      // pass.
+      last = now;
+      return;
+    }
     let real = (now - last) / 1000;
     last = now;
     if (real > 0.05) real = 0.05; // a tab restore must not teleport the sim
@@ -1154,9 +1203,38 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     };
   }
 
+  /* ── the pause ──────────────────────────────────────────────────────── */
+
+  /**
+   * Stop the monument's clock, or start it again.
+   *
+   * Idempotent in both directions: two pauses are one pause, and resuming a
+   * running game is nothing. The host calls this around its own sheets, and the
+   * manual calls it around itself.
+   *
+   * There is nothing to rebase on the way back. Everything MONUMENT measures —
+   * `questionAt`, `collapseAt`, the `ms` on every report — is measured against
+   * `clock`, which is an accumulator this loop advances and therefore did not
+   * advance while stopped. The single wall-clock value in the loop is `last`,
+   * and its whole job is to be reset here so the first frame back is one frame
+   * and not the length of the read.
+   */
+  function setPaused(on: boolean): void {
+    if (on === paused) return;
+    paused = on;
+    if (on) {
+      audio.suspend();
+      return;
+    }
+    last = performance.now();
+    audio.resume();
+  }
+
   /* ── teardown ───────────────────────────────────────────────────────── */
 
   return {
+    setPaused,
+
     unmount(): void {
       running = false;
       cancelAnimationFrame(raf);

--- a/dynawalla/games/stack/src/pack.ts
+++ b/dynawalla/games/stack/src/pack.ts
@@ -29,6 +29,18 @@ async function start(el: HTMLElement): Promise<void> {
 
   const game = mount(el, mounted.host as unknown as Host);
 
+  // The host can put a sheet over a still-mounted pack — a purchase surface, a
+  // parent gate — and MONUMENT's whole promise is that waiting is free. Behind
+  // a sheet it is not: the sweep keeps sweeping, the value on the stone keeps
+  // turning over, and the dither keeps making it faster. The clock stops dead
+  // instead.
+  mounted.client.on("pause", () => {
+    game.setPaused(true);
+  });
+  mounted.client.on("resume", () => {
+    game.setPaused(false);
+  });
+
   // The host tells a pack before its port dies, so the rAF loop stops and the
   // WebGL context is released before the frame is torn down rather than a
   // frame or two after it.


### PR DESCRIPTION
The other half of the how-to-play freeze. Sibling: #691.

#681 held **sound, taps and keys** for all 27 games structurally. `onOpen`/`onClose` are the only part of pausing a game has to opt into, because the shared module has no idea what a game's loop is.

The six games in #691 already had a pause to compose with. **These four had none** — no `pause`, no `resume`, no `setPaused`, no visibility handler. So the pause is built here, and the manual was not the only thing missing it: the host has been able to put a sheet over a still-mounted pack all along, and in these four the game simply kept playing under it.

## MONUMENT was breaking a promise it makes in writing

The last line of its own manual is **"Waiting never costs you anything."** Behind the sheet the sweep kept sweeping and `sim.dither` kept compounding — every three slot cycles, up to the `DITHER_MAX = 1.9` ceiling — so three minutes of reading the rules handed the child back a stone moving at 1.9×. Verbatim, from the test that now guards it:

```
three minutes of reading pushed the stone to 1.9x speed
1.9 !== 1
```

## ABYSSAL BLOOM is an idle game, so freezing it is a decision

**It freezes and credits nothing.** Away-time in this game is paid for through exactly one surface — `offlineHaul`, capped at 8h, discounted to 55%, collected by *answering a tide gate* — and essence is never handed over without a merge or a question. Crediting the hold would be the only path that pays for neither. And because the hold is measured with `performance.now()`, crediting it would pay out real **backgrounded** time: open the manual, put the tablet down for an hour, come back an hour richer with the gate bypassed. Resume also re-stamps `lastSeen`, so a read is not bankable as away-time on the next launch either — without that, `the read left 124s bankable as away-time`.

## Host wiring

THE SPLIT and MONUMENT expose `setPaused` on the mount handle, type it in `contract.ts`, and wire it to the SDK's `pause`/`resume` host events in `pack.ts` — the same shape BEAM already uses. ABYSSAL BLOOM and SIEGE keep the flag internal: their contracts have no slot and nothing invents a public surface here. *(Follow-up worth doing separately: give those two the same host wiring.)*

## Wall-clock marks rebased on resume

The most likely bug to introduce is a game that leaps forward when it unfreezes. Every `performance.now()` in these files was enumerated and decided:

- **THE SPLIT** — `overAt`, `liveQAt`, `waveBornCut`, and per body `bornAt`, `cuttableAt`, `nextFuseAt`; plus a new `Feel.shift(ms)` for the slow-motion marks. Deliberately **not** shifted: blade ribbon timestamps. A stroke from before the read has expired, and restoring it hands the child a live blade they are not touching; blades are `end()`ed on pause because the swallowed `pointerup` never arrives.
- **ABYSSAL BLOOM** — `askedAt` (clamped), `hintAt`, `coldUntil`, the tide gate, every queued cascade. Pausing also **cancels an in-flight drag**: the sheet swallows `pointerup`, so the 620 ms long-press dissolve would otherwise resume counting and eat the polyp under a finger that had already left.
- **SIEGE** — `askedAt` and `lastT`. `coldUntil` is measured against `clock.wall`, which the guard already stops.
- **MONUMENT** — none, and that is the point: every mark is measured against `clock`, an accumulator the loop advances, so freezing the loop freezes them.

## How it was proved

**None of the four had a mount-level harness.** THE SPLIT's `wiring.test.ts` reads `mount.ts` as *text*. Four real ones were built, with **per-element listener maps** — the help button and the PLAY button both register a `"click"`, and a single event-keyed map loses the first. MONUMENT's needed a WebGL2 stub good enough for three.js to compile, link and draw.

Delete-the-fix, verbatim:

```
merge-idle  not ok - nothing on the reef advances while the manual is open
            the manual did not stop the reef at all / false !== true
merge-idle  not ok - the read is not banked as away-time the next launch pays out
siege       not ok - nothing in the siege advances while the manual is open
            + coreHp: 2  / - coreHp: 20     (18 of 20 lives lost while reading)
slice       not ok - THE MARKET STOPS: nothing advances while the manual is up
            + '{"draws":11805717,"elapsed":194.1,"bodies":14}'
            - '{"draws":649253,"elapsed":14.4,"bodies":6}'
slice       not ok - the director drew questions from the host behind the sheet  41 !== 2
stack       not ok - WAITING IS FREE, INCLUDING READING: the dither does not compound  1.9 !== 1
```

**One vacuous test was caught during authoring and rewritten**: THE SPLIT's resume test passed with the `last` resets deleted, because the 64 ms delta clamp hid the jump. It now measures per-frame body displacement, and fails as `the first frame back moved the market 71.6px against an ordinary 25.1px`.

## One infrastructure change
`siege`'s test script moves from `--experimental-strip-types` to `--experimental-transform-types`. `render/particles.ts` has a `const enum`, which strip-only mode refuses, so `mount.ts` could not be imported from a test at all. It is a superset flag; nothing that ships changes, and `npm run tsc` is unaffected.

## Verification
Suites run **5× each, all green**, independently of the authoring agent: merge-idle 182, siege 35, slice 122, stack 44. `npm run tsc` and `npm run build:pack` clean in all four. The delete-the-fix check was re-run by the integrator, not taken on trust.

## Device-only
That the canvas visibly holds its last painted frame under the scrim rather than blanking; that audio actually goes silent through the real `AudioContext` hold (MONUMENT's GL stub records calls, it does not rasterise); and that a rotation *while the manual is up* comes back correctly laid out.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
