### PR TITLE
fix(dynawalla/games/horde): DEEPSWARM — an answer you can swim to, a screen where down is down

### DIFF
--- a/dynawalla/games/horde/src/contract.ts
+++ b/dynawalla/games/horde/src/contract.ts
@@ -1,6 +1,13 @@
 export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
 export type Host = {
-  next(opts?: { domain?: string; difficulty?: number }): Question
+  /**
+   * `maxDifficulty` is a standing ceiling on the host's stream, not a per-call
+   * hint: it stands until a different one is named. DEEPSWARM names the rung
+   * the run has EARNED, so the pool can be spread downward for variety without
+   * a pooled question from a previous, higher request leaking back up. See
+   * `packs/shared/game-host/index.ts`.
+   */
+  next(opts?: { domain?: string; difficulty?: number; maxDifficulty?: number }): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean

--- a/dynawalla/games/horde/src/core/motion.test.ts
+++ b/dynawalla/games/horde/src/core/motion.test.ts
@@ -1,0 +1,122 @@
+// UP IS UP.
+//
+// A founder playtest: "up and down are reversed, like a flight simulator."
+// They were. `core/input.ts` reports the stick in CSS pixels (+y is DOWN) and
+// `movePlayer` fed that straight into a world where +y is UP, so screen-down
+// drove the diver up the screen. Pointer, touch and keyboard all converge on
+// `stick.y` before anything reads it, so all three were inverted together and
+// one conversion fixes all three — which is what these tests hold.
+//
+// What is NOT held here: that the GPU agrees. `world +y is up` is a fact about
+// two GLSL strings and there is no WebGL in Node. See the header of `motion.ts`.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  type Diver,
+  type View,
+  drive,
+  integrate,
+  screenFromWorld,
+  worldFromScreen,
+} from "./motion.ts"
+
+/** A phone, mid-run. `halfW/halfH` are world units; `cssW/cssH` are pixels. */
+const VIEW: View = { camX: 0, camY: 0, halfW: 390, halfH: 844, cssW: 390, cssH: 844 }
+
+const SPEED = 205 // loadout.ts, the base diver
+const DT = 1 / 60
+
+/** Hold a stick for `seconds` and report where the diver ended up, on screen. */
+function swim(stickX: number, stickY: number, seconds: number): { x: number; y: number } {
+  const d: Diver = { x: 0, y: 0, vx: 0, vy: 0 }
+  for (let f = 0; f < Math.round(seconds / DT); f++) integrate(d, stickX, stickY, SPEED, DT)
+  return screenFromWorld(d.x, d.y, VIEW)
+}
+
+test("the stick pushed DOWN takes the diver down the screen", () => {
+  const start = screenFromWorld(0, 0, VIEW)
+  const end = swim(0, 1, 1)
+  assert.ok(
+    end.y > start.y,
+    `stick down moved the diver from screen y=${start.y} to y=${end.y} — that is UP the screen, ` +
+      "which is the flight-simulator inversion this file exists to end",
+  )
+})
+
+test("the stick pushed UP takes the diver up the screen", () => {
+  const start = screenFromWorld(0, 0, VIEW)
+  const end = swim(0, -1, 1)
+  assert.ok(end.y < start.y, `stick up moved the diver to screen y=${end.y}, below y=${start.y}`)
+})
+
+test("left and right were never wrong, and must stay that way", () => {
+  const start = screenFromWorld(0, 0, VIEW)
+  assert.ok(swim(1, 0, 1).x > start.x, "stick right must go right")
+  assert.ok(swim(-1, 0, 1).x < start.x, "stick left must go left")
+})
+
+test("every input path is the same path — S, ArrowDown and a thumb agree", () => {
+  // `Input.update` folds the keyboard axis and the pointer axis into one
+  // `stick.y` before `movePlayer` sees either, so there is exactly one sign to
+  // get wrong. This asserts the fold point rather than three lookalikes: what
+  // `s`, `ArrowDown` and a downward drag all produce is `stick.y = +1`.
+  const fromKeyboard = 1 // kyTarget for "s" / "arrowdown"
+  const fromThumb = (620 - 500) / 62 // (knobY - originY) / RADIUS, clamped to 1
+  assert.ok(fromThumb > 0, "a downward drag is a positive stick.y")
+  assert.equal(Math.sign(fromKeyboard), Math.sign(Math.min(1, fromThumb)))
+  assert.ok(drive(0, 1).y < 0, "a positive (downward) stick.y must drive world −y")
+})
+
+test("the diver goes toward the screen point the thumb is pulling toward", () => {
+  // The coupling that actually broke: `drawStick` laid the joystick ring out
+  // with one sign and `movePlayer` drove with the other, so the ring the child
+  // saw and the direction they travelled disagreed. Both now go through this
+  // file, and this asserts they agree — pull the stick toward a point low on
+  // the screen and the diver must get closer to that point on the screen.
+  const origin = { x: 195, y: 400 } // where the thumb landed, CSS px
+  const knob = { x: 195, y: 462 } // dragged 62px straight down: full deflection
+  const stickX = (knob.x - origin.x) / 62
+  const stickY = (knob.y - origin.y) / 62
+
+  // The stick is a direction, not a destination, so the question is whether the
+  // diver's travel on screen points the same way as the thumb's pull on screen.
+  const pullX = knob.x - origin.x
+  const pullY = knob.y - origin.y
+
+  const from = screenFromWorld(0, 0, VIEW)
+  const to = swim(stickX, stickY, 1)
+  const dot = (to.x - from.x) * pullX + (to.y - from.y) * pullY
+  assert.ok(
+    dot > 0,
+    `the thumb pulled (${pullX}, ${pullY}) on screen and the diver travelled ` +
+      `(${(to.x - from.x).toFixed(0)}, ${(to.y - from.y).toFixed(0)}) — it swam away from the thumb`,
+  )
+
+  // And the ring the child sees is laid out with the same map, so it lands
+  // under the thumb rather than at the reflected height.
+  const ring = worldFromScreen(knob.x, knob.y, VIEW)
+  const ringBack = screenFromWorld(ring.x, ring.y, VIEW)
+  assert.ok(Math.abs(ringBack.x - knob.x) < 1e-6 && Math.abs(ringBack.y - knob.y) < 1e-6)
+  assert.ok(
+    ring.y < worldFromScreen(origin.x, origin.y, VIEW).y,
+    "a knob dragged DOWN the screen must sit lower in the world than its origin",
+  )
+})
+
+test("screen (0,0) is the TOP-left of the world, not the bottom-left", () => {
+  // `drawStick` had this backwards: `camY - hh + originY * hpp` put screen y=0
+  // at the world's bottom edge, so the thumb ring drew at the mirrored height.
+  const topLeft = worldFromScreen(0, 0, VIEW)
+  const bottomLeft = worldFromScreen(0, VIEW.cssH, VIEW)
+  assert.equal(topLeft.x, VIEW.camX - VIEW.halfW)
+  assert.equal(topLeft.y, VIEW.camY + VIEW.halfH, "screen y=0 is the world's TOP edge")
+  assert.equal(bottomLeft.y, VIEW.camY - VIEW.halfH)
+})
+
+test("the integrator is the one the game runs — it caps at the stat speed", () => {
+  const d: Diver = { x: 0, y: 0, vx: 0, vy: 0 }
+  for (let f = 0; f < 600; f++) integrate(d, 1, 0, SPEED, DT)
+  assert.ok(Math.abs(d.vx - SPEED) < 1, `terminal speed ${d.vx.toFixed(1)} is not the stat ${SPEED}`)
+})

--- a/dynawalla/games/horde/src/core/motion.ts
+++ b/dynawalla/games/horde/src/core/motion.ts
@@ -1,0 +1,136 @@
+/**
+ * Where the diver goes, and which way is up.
+ *
+ * ── The bug this file exists to end ──────────────────────────────────────────
+ *
+ * DEEPSWARM's vertical control was inverted — "like a flight simulator", which
+ * is what a founder playtest called it. It was not a deliberate `-dy` anywhere.
+ * It was a coordinate system that changed hands without changing sign.
+ *
+ * `core/input.ts` measures the stick in CSS pixels, where **+y is DOWN the
+ * screen**: `dy = knobY - originY`, and `kyTarget` is +1 for `s` and for
+ * `ArrowDown`. Both input paths — pointer/touch and keyboard — converge on the
+ * same `stick.y` before anything reads it, which is why the bug was total
+ * rather than partial, and why one conversion fixes every path at once.
+ *
+ * The renderer, meanwhile, projects with (`gfx/shaders.ts`, `SPRITE_VS` and
+ * `GLYPH_VS`, both identical):
+ *
+ *     gl_Position = vec4((world.x - u_cam.x) * u_cam.z,
+ *                        (world.y - u_cam.y) * u_cam.w, 0.0, 1.0);
+ *
+ * and GL clip space puts y = +1 at the TOP of the viewport. So **world +y is UP
+ * the screen**, and `movePlayer` was doing:
+ *
+ *     const ay = st.y * s.speed      // +1 for "down"  →  world +y  →  up
+ *
+ * Screen-down drove the diver up. `drawStick` had the mirror image of the same
+ * mistake — it laid the joystick graphic out with `camY - hh + originY * hpp`,
+ * treating the world's bottom edge as the screen's top — so the thumb ring drew
+ * at the reflected height too. One sign, three symptoms, no `-` anywhere to
+ * find by searching for one.
+ *
+ * ── The rule, in one place ──────────────────────────────────────────────────
+ *
+ * Everything that crosses from screen pixels into world units goes through this
+ * file, and `SCREEN_Y_TO_WORLD` is the only place the sign is written down.
+ *
+ * **What is and is not proved in Node.** `motion.test.ts` proves that the diver
+ * moves toward the part of the world that this file calls "lower on the screen"
+ * when the stick is pushed down — the input and the layout agreeing, which is
+ * the half of the bug a test can hold. That the renderer agrees with *both* is
+ * a fact about a GLSL string on a GPU; there is no WebGL in Node and no test
+ * here asserts it. It was verified by reading the two vertex shaders above, and
+ * a change to either of them must be checked on a device.
+ */
+
+/** Screen +x is world +x: the projection does not touch the x sign. */
+export const SCREEN_X_TO_WORLD = 1
+
+/**
+ * Screen +y is world −y.
+ *
+ * CSS pixels grow downward; the projection above sends world +y to clip +y,
+ * which GL puts at the top. Flip this constant and the game plays like a flight
+ * simulator again.
+ */
+export const SCREEN_Y_TO_WORLD = -1
+
+/** The mutable diver. `game.ts` holds these as four fields; this reads them. */
+export type Diver = { x: number; y: number; vx: number; vy: number }
+
+/**
+ * The world-space drive direction for a stick reading in screen space.
+ *
+ * `core/input.ts` normalises magnitude already, so this is a pure change of
+ * basis and never rescales.
+ */
+export function drive(stickX: number, stickY: number): { x: number; y: number } {
+  return { x: stickX * SCREEN_X_TO_WORLD, y: stickY * SCREEN_Y_TO_WORLD }
+}
+
+/**
+ * One step of the diver.
+ *
+ * Heavy acceleration toward the stick with a hard cap, so the diver feels
+ * weighty yet exact. Lifted verbatim out of `movePlayer` so the tests drive the
+ * integrator the game drives rather than a lookalike.
+ */
+export const ACCEL_BASE = 0.00004
+
+export function integrate(
+  d: Diver,
+  stickX: number,
+  stickY: number,
+  speed: number,
+  dt: number,
+): void {
+  const a = drive(stickX, stickY)
+  const k = 1 - Math.pow(ACCEL_BASE, dt)
+  d.vx += (a.x * speed - d.vx) * k
+  d.vy += (a.y * speed - d.vy) * k
+  d.x += d.vx * dt
+  d.y += d.vy * dt
+}
+
+/** How much world one CSS pixel spans, given the half-extents on screen. */
+export type View = {
+  camX: number
+  camY: number
+  halfW: number
+  halfH: number
+  cssW: number
+  cssH: number
+}
+
+/**
+ * A point in CSS pixels, as a point in the world.
+ *
+ * Screen (0, 0) is the top-left corner, which is the world's LEFT edge and its
+ * TOP edge — `camY + halfH`, not `camY - halfH`. `drawStick` uses this to put
+ * the joystick ring under the thumb that is holding it.
+ */
+export function worldFromScreen(sx: number, sy: number, v: View): { x: number; y: number } {
+  const wpp = (v.halfW * 2) / Math.max(1, v.cssW)
+  const hpp = (v.halfH * 2) / Math.max(1, v.cssH)
+  return {
+    x: v.camX + (sx * wpp - v.halfW) * SCREEN_X_TO_WORLD,
+    y: v.camY + (sy * hpp - v.halfH) * SCREEN_Y_TO_WORLD,
+  }
+}
+
+/**
+ * The inverse: a world point, in CSS pixels.
+ *
+ * Nothing in the game draws through this — the GPU does that. It exists so the
+ * tests can ask the question a child asks, which is "did it go DOWN the
+ * screen", in the units a child sees.
+ */
+export function screenFromWorld(wx: number, wy: number, v: View): { x: number; y: number } {
+  const wpp = (v.halfW * 2) / Math.max(1, v.cssW)
+  const hpp = (v.halfH * 2) / Math.max(1, v.cssH)
+  return {
+    x: ((wx - v.camX) * SCREEN_X_TO_WORLD + v.halfW) / wpp,
+    y: ((wy - v.camY) * SCREEN_Y_TO_WORLD + v.halfH) / hpp,
+  }
+}

--- a/dynawalla/games/horde/src/game/curriculum.test.ts
+++ b/dynawalla/games/horde/src/game/curriculum.test.ts
@@ -11,22 +11,46 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import type { Host, Question } from "../contract.ts"
-import { BASE_THINKING_SECONDS, Curriculum, MAX_DIFFICULTY } from "./curriculum.ts"
+import {
+  BASE_THINKING_SECONDS,
+  Curriculum,
+  MAX_DIFFICULTY,
+  LADDER_SPAN,
+  MAX_DROP_RUNGS,
+  MISS_RUNGS,
+  RECENT_WINDOW,
+  SPREAD_RUNGS,
+} from "./curriculum.ts"
 
 type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+/** mulberry32 — the same generator `stubHost.ts` uses. Seeded, so this is exact. */
+function seeded(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
 
 /** A host that remembers everything it was asked and everything it was told. */
 function recordingHost(): {
   host: Host
   asks: number[]
+  ceilings: number[]
   reports: Report[]
 } {
   const asks: number[] = []
+  const ceilings: number[] = []
   const reports: Report[] = []
   let n = 0
   const host: Host = {
     next(opts) {
       asks.push(opts?.difficulty ?? 0)
+      ceilings.push(opts?.maxDifficulty ?? 0)
       n++
       return {
         id: `q${n}`,
@@ -45,7 +69,7 @@ function recordingHost(): {
       return false
     },
   }
-  return { host, asks, reports }
+  return { host, asks, ceilings, reports }
 }
 
 /**
@@ -67,10 +91,13 @@ test("a bot that answers everything WRONG never climbs past the first rung", () 
   // Three-digit addition lives high on the host ladder. This bot must not be
   // anywhere near it: it has demonstrated nothing.
   assert.equal(c.difficulty(), 1, "a run with no right answers must stay on rung 1")
+  // The request is a LADDER POSITION now, not a step of a ten-point scale, so
+  // the bottom is 0 rather than 1. The property is the same one: one value, and
+  // it is the floor of the curriculum.
   assert.deepEqual(
     [...new Set(asks)],
-    [1],
-    "every question in a run with no right answers must be asked at rung 1",
+    [0],
+    "every question in a run with no right answers must come from the bottom rung",
   )
   assert.equal(c.solved, 0)
   assert.equal(c.asked, LONG_RUN)
@@ -86,7 +113,7 @@ test("a bot that never answers at all never climbs either", () => {
   }
 
   assert.equal(c.difficulty(), 1, "surviving is not an achievement")
-  assert.equal(Math.max(...asks), 1)
+  assert.equal(Math.max(...asks), 0)
   assert.equal(c.unanswered, LONG_RUN)
 })
 
@@ -100,10 +127,14 @@ test("a bot that answers everything RIGHT climbs, and reaches the top", () => {
   }
 
   assert.equal(c.difficulty(), MAX_DIFFICULTY, "a run that is all right answers must top out")
-  assert.equal(asks[0], 1, "it still starts at the bottom")
+  assert.equal(asks[0], 0, "it still starts at the bottom")
   assert.ok(
     asks[asks.length - 1]! > asks[0]!,
     "the ladder has to actually move for a child who is getting them right",
+  )
+  assert.ok(
+    (asks[asks.length - 1] as number) > 0.9,
+    `a run that answered fifty questions right topped out at ${asks[asks.length - 1]}`,
   )
 })
 
@@ -199,4 +230,278 @@ test("the run panel counts questions the child ANSWERED, not questions it served
   assert.equal(c.asked, 8)
   assert.equal(c.answeredCount, 5, "three cores closed unanswered; they are not answers")
   assert.equal(c.solved, 5)
+})
+
+
+/* ------------------------------------------------------------ the question mix */
+
+// TEN RUNGS OUT OF SIXTY.
+//
+// A founder playtest: "more variable questions for the rift, they are all like
+// 2-digit plus 2-digit without carrying? I think we could have some single and
+// triple digit (adapting to user level) and some carrying .. and why not
+// subtraction, multiplication and division sometimes (dependent on user
+// performance and adapting up and down)."
+//
+// The cause was not the operation — the host owns that and `domain` is a label.
+// It was the SCALE. The game spoke the host's integer scale, where 1..10 maps
+// onto a 59-rung ladder with a stride of 6.5, so fifty of the sixty shipped
+// rungs could not be named at all. `ladderCoverage` below walks the same
+// arithmetic the host does (`toUnit`, then `Math.round(unit * span)`) and
+// counts what a run can actually reach.
+
+/** The host's own reading of a request, from `packs/shared/game-host/index.ts`. */
+function toUnit(value: number): number {
+  return value < 1 ? Math.max(0, value) : Math.min(1, (value - 1) / 9)
+}
+
+/** The rung `items.ts` lands on for a request. `next`: rounds; the cap floors. */
+function rungFor(difficulty: number, maxDifficulty: number): number {
+  const span = LADDER_SPAN
+  const cap = Math.floor(toUnit(maxDifficulty) * span)
+  return Math.max(0, Math.min(span, cap, Math.round(toUnit(difficulty) * span)))
+}
+
+/** A recording host that also reports which ladder rung each request landed on. */
+function rungRecorder(): { host: Host; rungs: number[] } {
+  const rungs: number[] = []
+  let n = 0
+  const host: Host = {
+    next(opts) {
+      rungs.push(rungFor(opts?.difficulty ?? 0, opts?.maxDifficulty ?? 10))
+      n++
+      return {
+        id: `q${n}`, prompt: `${n} + 1`, answer: String(n + 1),
+        distractors: [String(n), String(n + 2)], domain: "add", difficulty: 0.5,
+      } satisfies Question
+    },
+    report() {},
+    haptic() {},
+    prefersReducedMotion: () => false,
+  }
+  return { host, rungs }
+}
+
+/** Eighteen questions — a nine-minute run — at a given accuracy. */
+function playRun(seed: number, accuracy: number): number[] {
+  const { host, rungs } = rungRecorder()
+  const rng = seeded(seed)
+  const c = new Curriculum(seeded(seed ^ 0x9e37))
+  for (let i = 0; i < 18; i++) {
+    const q = c.ask(host)
+    const right = rng() < accuracy
+    c.answered(host, q, right ? q.answer : (q.distractors[0] as string), right, 1500)
+  }
+  return rungs
+}
+
+test("a run reaches far more of the curriculum than ten rungs of sixty", () => {
+  const perRun: number[] = []
+  const everywhere = new Set<number>()
+  for (let s = 0; s < 600; s++) {
+    const r = playRun(1000 + s, 0.6)
+    perRun.push(new Set(r).size)
+    for (const x of r) everywhere.add(x)
+  }
+  const mean = perRun.reduce((a, b) => a + b, 0) / perRun.length
+  // Measured before this change, same 600 runs: 5.84 distinct rungs per run and
+  // 9 distinct rungs across all of them, because ten integers is all the old
+  // scale could say.
+  assert.ok(mean > 8, `a run still only reaches ${mean.toFixed(2)} distinct rungs`)
+  assert.ok(
+    everywhere.size > 30,
+    `600 runs between them reached ${everywhere.size} of ${LADDER_SPAN + 1} rungs`,
+  )
+})
+
+test("the rungs the old integer scale could not name are now reachable", () => {
+  // The ten rungs `1..10` mapped to, and therefore the only ten a run could
+  // ever be served. Rung 18 is `column.add-no-regroup L0` and rung 29 is
+  // `regroup.add-multidigit L0` — the beginning of two-digit work and the whole
+  // of carrying — and neither was addressable.
+  const OLD = new Set([0, 7, 13, 20, 26, 33, 39, 46, 52, 59])
+  const reached = new Set<number>()
+  for (let s = 0; s < 600; s++) for (const r of playRun(2000 + s, 0.75)) reached.add(r)
+  const novel = [...reached].filter((r) => !OLD.has(r))
+  assert.ok(
+    novel.length > 20,
+    `only ${novel.length} rungs outside the old ten were ever reached: ${novel.join(", ")}`,
+  )
+  assert.ok(reached.has(18) || reached.has(19), "the first column-arithmetic rungs are still unreachable")
+  assert.ok(reached.has(29) || reached.has(30), "the first regrouping rungs are still unreachable")
+})
+
+test("a rung the child has not earned is never served, however wide the band", () => {
+  for (let s = 0; s < 200; s++) {
+    const { host, rungs } = rungRecorder()
+    const c = new Curriculum(seeded(s))
+    const rng = seeded(s ^ 0x5a5a)
+    for (let i = 0; i < 40; i++) {
+      // The edge as it stood when the question was ASKED.
+      const edgeRung = Math.round(c.edgeUnit() * LADDER_SPAN)
+      const q = c.ask(host)
+      assert.ok(
+        (rungs[rungs.length - 1] as number) <= edgeRung,
+        `a question came from rung ${rungs[rungs.length - 1]} with only rung ${edgeRung} earned`,
+      )
+      const right = rng() < 0.5
+      c.answered(host, q, right ? q.answer : (q.distractors[0] as string), right, 1500)
+    }
+  }
+})
+
+test("the edge itself is served — the cap does not shave a rung off the top", () => {
+  // `items.ts` FLOORS the cap and ROUNDS the request, so a ceiling sent naively
+  // sits a rung under the question it is meant to permit. `ask` adds the half
+  // rung that makes them agree, and the top of the ladder has to be reachable.
+  const { host, rungs } = rungRecorder()
+  const c = new Curriculum(seeded(1))
+  for (let i = 0; i < 60; i++) c.solved++
+  for (let i = 0; i < 400; i++) c.ask(host)
+  assert.ok(
+    rungs.includes(LADDER_SPAN),
+    `a run at the top of the ladder never saw rung ${LADDER_SPAN}; highest was ${Math.max(...rungs)}`,
+  )
+})
+
+test("the band does not bottom out on 0 + 1 in the opening minutes", () => {
+  // Measured with an absolute descent instead of a proportional one: 36% of
+  // every early run collapsed onto the single easiest rung in the product,
+  // twice what the old code did, which is a worse game and worse teaching.
+  let atFloor = 0
+  let n = 0
+  for (let s = 0; s < 600; s++) {
+    for (const r of playRun(3000 + s, 0.6)) {
+      n++
+      if (r === 0) atFloor++
+    }
+  }
+  assert.ok(
+    atFloor / n < 0.25,
+    `${((atFloor / n) * 100).toFixed(0)}% of every question was the easiest rung in the product`,
+  )
+})
+
+test("most questions still sit at or just under the edge", () => {
+  const c = new Curriculum(seeded(11))
+  for (let i = 0; i < 20; i++) c.solved++
+  const edge = c.edgeUnit() * LADDER_SPAN
+  let near = 0
+  const N = 5000
+  for (let i = 0; i < N; i++) if (edge - c.askUnit() * LADDER_SPAN <= 2) near++
+  assert.ok(
+    near / N > 0.45,
+    `only ${((near / N) * 100).toFixed(0)}% of questions were within two rungs of the edge — ` +
+      "the band is meant to interleave easier retrieval, not replace the work",
+  )
+})
+
+test("the whole band is used, out to its stated width", () => {
+  const c = new Curriculum(seeded(0xabc))
+  for (let i = 0; i < 20; i++) c.solved++
+  const edge = c.edgeUnit() * LADDER_SPAN
+  const steps = new Set<number>()
+  for (let i = 0; i < 6000; i++) steps.add(Math.round(edge - c.askUnit() * LADDER_SPAN))
+  const sorted = [...steps].sort((a, b) => a - b)
+  assert.deepEqual(sorted, [0, 1, 2, 3, 4, 5, 6], `the band used steps {${sorted.join(", ")}}`)
+  assert.equal(SPREAD_RUNGS, 6)
+})
+
+/* --------------------------------------------------------- and back down again */
+
+test("a child who starts missing is asked easier questions, within one question", () => {
+  const c = new Curriculum(seeded(5))
+  const { host } = recordingHost()
+  for (let i = 0; i < 20; i++) c.solved++ // earned the top of the ladder
+  assert.equal(c.difficulty(), MAX_DIFFICULTY)
+
+  // The TOP of the band, not one sample of it: a single draw carries the
+  // ordinary spread and would make this test a coin toss.
+  const topRung = (): number =>
+    Math.max(...Array.from({ length: 400 }, () => Math.round(c.askUnit() * LADDER_SPAN)))
+  const before = topRung()
+  assert.equal(before, LADDER_SPAN, "a clean run at the top must be able to draw the top rung")
+
+  for (let i = 0; i < 3; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.distractors[0] as string, false, 4000)
+  }
+  assert.equal(c.recentMisses, 3)
+  assert.equal(c.difficulty(), MAX_DIFFICULTY, "the EARNED step must not fall — #656")
+  const after = topRung()
+  assert.equal(
+    after,
+    before - 3 * MISS_RUNGS,
+    `three misses moved the hardest question the run will ask from rung ${before} to rung ` +
+      `${after}; a child who is drowning must be handed something easier`,
+  )
+})
+
+test("and it comes straight back up when they start getting them right", () => {
+  const c = new Curriculum(seeded(13))
+  const { host } = recordingHost()
+  for (let i = 0; i < 20; i++) c.solved++
+
+  for (let i = 0; i < RECENT_WINDOW; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.distractors[0] as string, false, 4000)
+  }
+  assert.equal(c.recentMisses, RECENT_WINDOW, "the window should be all misses")
+
+  for (let i = 0; i < RECENT_WINDOW; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.answer, true, 1100)
+  }
+  assert.equal(c.recentMisses, 0, "the window must forget an old bad patch")
+  const top = Math.max(...Array.from({ length: 400 }, () => Math.round(c.askUnit() * LADDER_SPAN)))
+  assert.equal(
+    top,
+    LADDER_SPAN,
+    "recovery has to be immediate — the earned step was never lost, so it must not be re-earned",
+  )
+})
+
+test("the drop is bounded — a bad patch cannot strand a child at the bottom", () => {
+  const c = new Curriculum(seeded(17))
+  const { host } = recordingHost()
+  for (let i = 0; i < 20; i++) c.solved++
+  for (let i = 0; i < 40; i++) {
+    const q = c.ask(host)
+    c.answered(host, q, q.distractors[0] as string, false, 5000)
+  }
+  const lowest = Math.min(
+    ...Array.from({ length: 500 }, () => Math.round(c.askUnit() * LADDER_SPAN)),
+  )
+  assert.ok(
+    lowest >= LADDER_SPAN - MAX_DROP_RUNGS - SPREAD_RUNGS,
+    `a run that reached the top was walked all the way down to rung ${lowest}`,
+  )
+  assert.ok(lowest > LADDER_SPAN / 3, `rung ${lowest} is a different subject, not an easier question`)
+})
+
+test("a timeout is not a miss, and does not pull the band down", () => {
+  // Same principle as `expired()` reporting nothing: a child who ran out of
+  // time has told us nothing about what they know, and acting on it is a guess.
+  const c = new Curriculum(seeded(19))
+  const { host } = recordingHost()
+  for (let i = 0; i < 20; i++) c.solved++
+  for (let i = 0; i < 10; i++) {
+    c.ask(host)
+    c.expired()
+  }
+  assert.equal(c.recentMisses, 0, "a timeout was counted as a wrong answer")
+})
+
+test("the rift asks below the band, and the band below that", () => {
+  const c = new Curriculum(seeded(23))
+  for (let i = 0; i < 12; i++) c.solved++
+  assert.equal(c.difficulty(), 7)
+  assert.equal(c.difficulty(-1), 6)
+  const riftEdge = c.edgeUnit(-1)
+  assert.ok(riftEdge < c.edgeUnit(), "a rift question must be easier than the run's own edge")
+  for (let i = 0; i < 500; i++) {
+    const u = c.askUnit(-1)
+    assert.ok(u <= riftEdge, "a rift question came in above what the run had earned")
+    assert.ok(u >= 0)
+  }
 })

--- a/dynawalla/games/horde/src/game/curriculum.ts
+++ b/dynawalla/games/horde/src/game/curriculum.ts
@@ -51,6 +51,79 @@
  * It widens instead, and it is always at or above the p90 cadence target for
  * the class of problem being asked (6 s single-digit, 14 s two-digit with
  * regrouping).
+ *
+ * ── One rung is not a curriculum ────────────────────────────────────────────
+ *
+ * From a founder playtest: *"more variable questions for the rift, they are all
+ * like 2-digit plus 2-digit without carrying? I think we could have some single
+ * and triple digit (adapting to user level) and some carrying .. and why not
+ * subtraction, multiplication and division sometimes."*
+ *
+ * He is describing the symptom of asking for exactly one number, on a scale too
+ * coarse to say anything else. The host does not take an operation — `domain`
+ * on `next()` is a cosmetic label and the host's own comment says so. What
+ * decides whether a child sees `7 + 8`, `284 + 157` or `6 × 7` is WHERE ON THE
+ * LADDER the question is drawn from.
+ *
+ * ── Sixty rungs, ten of them addressable ────────────────────────────────────
+ *
+ * The shipped ladder is 60 rungs (18 active skills at up to four levels each,
+ * multiplication and division live since PR #683, the bottom reaching `0 + 1`
+ * since PR #655). This game spoke the host's *integer* scale, where 1 is the
+ * bottom and 10 the top and `toUnit` maps a value `v >= 1` to `(v - 1) / 9`.
+ * Ten integers across fifty-nine rungs is a stride of 6.5, so the ten rungs
+ * DEEPSWARM could name were:
+ *
+ *      1 -> 0  add-within-ten L0        6 -> 33 divide-exact L0
+ *      2 -> 7  subtract-within-ten L3   7 -> 39 zero-in-the-quotient L0
+ *      3 -> 13 add-across-ten L2        8 -> 46 times-two-digit L1
+ *      4 -> 20 tables-within-five L3    9 -> 52 subtract-short-subtrahend L1
+ *      5 -> 26 subtract-no-regroup L2  10 -> 59 subtract-across-zero L2
+ *
+ * and the other fifty were unreachable BY CONSTRUCTION. Both easy levels of
+ * `column.add-no-regroup`, every level of `regroup.add-multidigit` — the whole
+ * of carrying — and `times-one-digit` are in that gap. A nine-minute run climbs
+ * about five of these steps, so a child met five questions' worth of the
+ * curriculum and met them over and over. Measured over 600 simulated runs
+ * against the real `ladder()`: **9 of 60 rungs and 9 of 18 skills, ever.**
+ *
+ * So the game now speaks the FRACTION scale — `toUnit` reads `v < 1` as a
+ * position on the ladder, used as is — which makes all sixty rungs addressable,
+ * and asks across a BAND rather than at a point:
+ *
+ *   - `difficulty()` is unchanged and still means what PR #656 made it mean:
+ *     the step this run has EARNED, `1 + floor(solved / 2)`, moved by right
+ *     answers and by nothing else. `edgeUnit()` is that step as a ladder
+ *     position, and it is the top of the band.
+ *   - `askUnit()` is where one question comes from: the edge, less a few
+ *     LADDER rungs. Six rungs is about one old step, so the band is narrow in
+ *     absolute terms and wide in the only sense that matters — it contains the
+ *     rungs that were skipped.
+ *   - The band is DOWNWARD only, and `maxDifficulty` pins the ceiling at the
+ *     host too. That is the same promise as before, stated once: nothing a
+ *     child has not demonstrated is ever served, so a run that answers nothing
+ *     right stays at the bottom however long it survives.
+ *
+ * Same 600 runs, after: **46 of 60 rungs and 17 of 18 skills**, with carrying,
+ * multiplication and division all present, and the distinct rungs a single run
+ * serves up from 5.8 to 9.6.
+ *
+ * ── And it comes back down ──────────────────────────────────────────────────
+ *
+ * *"adapting up and down"* — the ladder above only went up. A run that earned
+ * rung 7 and then started missing kept being asked rung-7 questions, which is
+ * the moment a child puts a tablet down. `RECENT_WINDOW` recent answers are
+ * kept, and each recent MISS drops the band one further rung for the next
+ * question. Three misses in a row and the sums get visibly easier within one
+ * question; get them right again and the window refills and the band comes
+ * back. The earned ceiling itself never falls, so recovery is immediate rather
+ * than something that has to be re-earned.
+ *
+ * This is the game's own record and not `host.recentOutcomes()`, deliberately:
+ * the host's verdict is authoritative but arrives after a round trip, and this
+ * decision is made synchronously inside a `requestAnimationFrame` the moment an
+ * orb is struck. The two agree except in the window where the host has not
+ * answered yet.
  */
 
 import type { Host, Question } from "../contract.ts"
@@ -61,6 +134,59 @@ export const MAX_DIFFICULTY = 10
 
 /** Right answers needed per step up the ladder. */
 export const SOLVES_PER_STEP = 2
+
+/**
+ * Rungs above the bottom of the host's ladder.
+ *
+ * Read off the shipped active graph (60 rungs; `dynawalla-app/src/packs/items.ts`
+ * `ladder()`). The game is not authoritative about it and does not need to be:
+ * it is used only to size the band in rungs, so a curriculum that grows makes
+ * this game's band proportionally narrower and never makes it wrong.
+ */
+export const LADDER_SPAN = 59
+
+/** One ladder rung, as a fraction of the whole ladder. */
+const RUNG = 1 / LADDER_SPAN
+
+/**
+ * The top of the fraction scale.
+ *
+ * Strictly below 1, because `toUnit` reads `1` as the BOTTOM of the integer
+ * scale rather than the top of the fraction scale — the one ambiguous value in
+ * the host's contract, and it is documented to resolve the way that would send
+ * a struggling child the hardest content in the product. Half a rung under 1
+ * still rounds to the top rung.
+ */
+const UNIT_TOP = 1 - 1 / (2 * LADDER_SPAN)
+
+/**
+ * How many LADDER rungs below the edge a question may be drawn from.
+ *
+ * Six, because six rungs is roughly one step of the old integer scale — so the
+ * band is about as wide as the gap the old scale used to jump over, which is
+ * exactly the content that was unreachable.
+ */
+export const SPREAD_RUNGS = 6
+
+/** Rungs the band comes down for each miss inside the recent window. */
+export const MISS_RUNGS = 4
+
+/** Rungs at which the miss-drop stops. */
+export const MAX_DROP_RUNGS = 16
+
+/**
+ * How far down the band may ever reach, as a fraction of the edge's own height.
+ *
+ * Without this the band is the wrong shape at the bottom of the ladder: a child
+ * at rung 6 with two recent misses is asked for rung −2, which clamps to `0 + 1`
+ * — and measured, 36% of every early run collapsed onto that single rung. A
+ * descent of half the height scales at every height, so a run at rung 33 can
+ * fall to 16 and a run at rung 6 falls to 3.
+ */
+const DESCENT_CEILING = 0.5
+
+/** Recent answers kept, for deciding whether the band should come down. */
+export const RECENT_WINDOW = 5
 
 /** Seconds on the clock at step 1 — the p90 for a single-digit fact, plus room. */
 export const BASE_THINKING_SECONDS = 8.5
@@ -86,6 +212,15 @@ export class Curriculum {
   /** Questions that closed with no answer at all. Never reported, never punished. */
   unanswered = 0
 
+  /** The last `RECENT_WINDOW` answers, newest last. Timeouts are not answers. */
+  private recent: boolean[] = []
+  private readonly rng: () => number
+
+  /** `rng` is injected so the spread can be measured rather than believed. */
+  constructor(rng: () => number = Math.random) {
+    this.rng = rng
+  }
+
   /** Questions the child actually answered. A timeout is not an answer. */
   get answeredCount(): number {
     return Math.max(0, this.asked - this.unanswered)
@@ -95,6 +230,14 @@ export class Curriculum {
     this.asked = 0
     this.solved = 0
     this.unanswered = 0
+    this.recent.length = 0
+  }
+
+  /** Misses inside the recent window. The only thing that brings the band down. */
+  get recentMisses(): number {
+    let n = 0
+    for (const ok of this.recent) if (!ok) n++
+    return n
   }
 
   /**
@@ -114,10 +257,57 @@ export class Curriculum {
     return BASE_THINKING_SECONDS + (this.difficulty() - 1) * THINKING_SECONDS_PER_STEP
   }
 
-  /** Pull the next question at the difficulty this run has earned. */
+  /**
+   * The top of the band, as a position on the host's whole ladder.
+   *
+   * This is `difficulty()` on the fraction scale and nothing more — the same
+   * trajectory PR #656 set, said in units that can name every rung instead of
+   * every sixth one.
+   */
+  edgeUnit(offset = 0): number {
+    return Math.min(UNIT_TOP, (this.difficulty(offset) - 1) / (MAX_DIFFICULTY - 1))
+  }
+
+  /**
+   * The ladder position ONE question is drawn from.
+   *
+   * The edge, less a descent: the recent-miss drop plus a random step, capped
+   * at half the edge's own height so the band never bottoms out on `0 + 1`.
+   *
+   * The step is `min` of two draws, so it is heaviest at zero — most questions
+   * are at or just under the edge, and the tail is the interleaved easier
+   * retrieval. Never above the edge, never below the floor of the ladder.
+   */
+  askUnit(offset = 0): number {
+    const edge = this.edgeUnit(offset)
+    const drop = Math.min(MAX_DROP_RUNGS, this.recentMisses * MISS_RUNGS)
+    const step = Math.floor(Math.min(this.rng(), this.rng()) * (SPREAD_RUNGS + 1))
+    const descent = Math.min(drop + step, edge * LADDER_SPAN * DESCENT_CEILING)
+    return clamp(edge - descent * RUNG, 0, edge)
+  }
+
+  /**
+   * Pull the next question.
+   *
+   * Two scales, on purpose, and both are what the host's `toUnit` reads:
+   *
+   *   - `difficulty` is a FRACTION (`< 1`), used as is. That is what makes all
+   *     sixty rungs addressable instead of ten.
+   *   - `maxDifficulty` is on the INTEGER ladder scale (`>= 1`), because the
+   *     host's ceiling FLOORS where its request ROUNDS, and a fraction strictly
+   *     below 1 can therefore never admit the top rung. The host's own note
+   *     says it: *"A caller that needs to be exact at the top should speak the
+   *     ladder scale, where every 0..1 position has an unambiguous spelling:
+   *     `1 + unit * 9`."* The extra half-rung makes the floor of the cap land
+   *     on the same rung the edge rounds to.
+   */
   ask(host: Host, offset = 0): Question {
     this.asked++
-    return host.next({ difficulty: this.difficulty(offset) })
+    const edge = this.edgeUnit(offset)
+    return host.next({
+      difficulty: this.askUnit(offset),
+      maxDifficulty: 1 + Math.min(1, edge + RUNG / 2) * (MAX_DIFFICULTY - 1),
+    })
   }
 
   /**
@@ -126,6 +316,8 @@ export class Curriculum {
    */
   answered(host: Host, q: Question, answered: string, correct: boolean, ms: number): void {
     if (correct) this.solved++
+    this.recent.push(correct)
+    if (this.recent.length > RECENT_WINDOW) this.recent.shift()
     host.report({ questionId: q.id, correct, ms: Math.max(0, Math.round(ms)), answered })
   }
 

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -1862,7 +1862,13 @@ export class Game {
       // surface that followed the diver would take the sum along for the ride.
       // `+y` is up, so the sum sits ABOVE the ring — it used to be written at
       // `py - 116`, which put it under the diver's own light.
-      r.text(this.q.prompt, this.qX, this.qY + ORB_RADIUS + 74, 56, 1, 1, 1, fade)
+      //
+      // Held inside the view, though. The camera follows the diver, and in
+      // landscape there are only ~273 world units above it; a sum anchored 224
+      // above a CORE the child has swum below would be off the top of the
+      // screen while they were still deciding what it said.
+      const promptY = Math.min(this.qY + ORB_RADIUS + 74, this.camY + hh - 62)
+      r.text(this.q.prompt, this.qX, promptY, 56, 1, 1, 1, fade)
       const ring = ORB_RADIUS
       r.sprite(this.qX, this.qY, ring, ring, t * 0.4, 1, 0.86, 0.44, 0.30 * fade, SHAPE.RING, 0.012, 0.2)
       // Time as a closing iris, not a number.

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -17,6 +17,7 @@ import { createInstructions, type Instructions } from "../../../../packs/shared/
 import type { Host, Question } from "../contract.ts"
 import { Audio } from "../core/audio.ts"
 import { Input } from "../core/input.ts"
+import { integrate, worldFromScreen, type Diver } from "../core/motion.ts"
 import { detectTier, tier, TierGovernor, type Tier, type TierName } from "../core/tiers.ts"
 import { Renderer, SHAPE } from "../gfx/renderer.ts"
 import { BEHAVIOUR, ENEMIES, E_INDEX, hpScale, speedScale, targetPopulation } from "./enemies.ts"
@@ -26,6 +27,7 @@ import {
   type Build, type Card,
 } from "./loadout.ts"
 import { Curriculum } from "./curriculum.ts"
+import { ORB_RADIUS, type Orb, advance as advanceOrbs, place as placeOrbs, reached } from "./orbs.ts"
 import { Bullets, Enemies, Gems, Grid, Numbers, Particles, Shocks } from "./world.ts"
 import { Overlay } from "../ui/overlay.ts"
 
@@ -33,8 +35,6 @@ const STEP = 1 / 60
 const AREA = 402 // sqrt(halfW*halfH): a constant amount of world on any screen
 
 type Mode = "title" | "play" | "levelup" | "core" | "rift" | "over" | "paused"
-
-type Orb = { x: number; y: number; ang: number; text: string; correct: boolean; state: number; t: number }
 
 export class Game {
   private root: HTMLElement
@@ -121,6 +121,9 @@ export class Game {
 
   private q: Question | null = null
   private orbs: Orb[] = []
+  /** Where the CORE opened. The ring, the prompt and the iris all live here. */
+  private qX = 0
+  private qY = 0
   private qT = 0
   private qTMax = 0
   private qStart = 0
@@ -195,8 +198,9 @@ export class Game {
           heading: "The CORE",
           lines: [
             "Every so often a gold CORE appears. Swim into it.",
-            "Time slows down and three numbered balls circle you. One holds the answer.",
-            "Swim out and touch the right one. For nine seconds nothing can stand near you.",
+            "Time slows down and three numbered balls ring the spot. One holds the answer.",
+            "Swim out and touch the right one. For nine seconds nothing can stand near you,",
+            "and that is when a WARDEN can actually be brought down.",
             "Touch a wrong one and a ring of enemies drops on top of you. The gold ball then lights up so you can see which it was.",
           ],
         },
@@ -505,14 +509,17 @@ export class Game {
   private movePlayer(dt: number): void {
     const s = this.build.stats
     const st = this.input.stick
-    const ax = st.x * s.speed
-    const ay = st.y * s.speed
-    // Heavy acceleration but a hard cap, so the diver feels weighty yet exact.
-    const k = 1 - Math.pow(0.00004, dt)
-    this.pvx += (ax - this.pvx) * k
-    this.pvy += (ay - this.pvy) * k
-    this.px += this.pvx * dt
-    this.py += this.pvy * dt
+    // The stick is in CSS pixels, where +y is DOWN; the world's +y is UP,
+    // because that is what the vertex shaders project. `integrate` owns that
+    // change of basis and every input path goes through it — the sign used to
+    // be missing here, and the game played like a flight simulator. See
+    // `core/motion.ts`.
+    const d: Diver = { x: this.px, y: this.py, vx: this.pvx, vy: this.pvy }
+    integrate(d, st.x, st.y, s.speed, dt)
+    this.px = d.x
+    this.py = d.y
+    this.pvx = d.vx
+    this.pvy = d.vy
     if (st.mag > 0.02) this.pAng = Math.atan2(this.pvy, this.pvx)
 
     // Wake bubbles.
@@ -1075,7 +1082,7 @@ export class Game {
     E.vx[i] += (dx / d) * knock * mi
     E.vy[i] += (dy / d) * knock * mi
 
-    this.number(E.x[i], E.y[i] - E.radius[i], Math.round(dmg), crit)
+    this.number(E.x[i], E.y[i] + E.radius[i], Math.round(dmg), crit)
 
     const hard = this.P.pool.n > this.T.maxParticles * 0.8
     const n = hard ? 1 : Math.round((crit ? 7 : 3) * this.T.particleScale)
@@ -1294,7 +1301,10 @@ export class Game {
     const N = this.N
     N.x[i] = x + (this.rng() - 0.5) * 14
     N.y[i] = y
-    N.vy[i] = crit ? -150 : -96
+    // `+y` is up. A damage number rises off the hit and falls back — it used to
+    // be launched downward and pulled upward, so every hit spat its number into
+    // the floor.
+    N.vy[i] = crit ? 150 : 96
     N.vx[i] = (this.rng() - 0.5) * 46
     N.life[i] = crit ? 0.95 : 0.62
     N.max[i] = N.life[i]
@@ -1312,7 +1322,7 @@ export class Game {
       if (N.life[i] <= 0) { N.pool.kill(i); continue }
       N.y[i] += N.vy[i] * dt
       N.x[i] += N.vx[i] * dt
-      N.vy[i] += 190 * dt
+      N.vy[i] -= 190 * dt
     }
   }
 
@@ -1438,38 +1448,24 @@ export class Game {
       const j = Math.floor(this.rng() * (i + 1))
       const t = opts[i]; opts[i] = opts[j]; opts[j] = t
     }
-    this.orbs.length = 0
-    const base = this.rng() * Math.PI * 2
-    for (let i = 0; i < opts.length; i++) {
-      this.orbs.push({
-        x: 0, y: 0,
-        ang: base + (i / opts.length) * Math.PI * 2,
-        text: opts[i],
-        correct: opts[i] === q.answer,
-        state: 0,
-        t: 0,
-      })
-    }
+    // The ring is laid down HERE, where the CORE was, and it stays there. It
+    // used to be recomputed from the diver's position on every frame, which
+    // made every answer permanently 172px away however hard the child swam.
+    // See `orbs.ts`.
+    this.qX = this.px
+    this.qY = this.py
+    this.orbs = placeOrbs(this.qX, this.qY, opts, q.answer, this.rng() * Math.PI * 2)
   }
 
   private questTick(dt: number): void {
     this.qT -= dt
-    const rad = 172
-    for (const o of this.orbs) {
-      o.ang += dt * 0.42
-      o.x = this.px + Math.cos(o.ang) * rad
-      o.y = this.py + Math.sin(o.ang) * rad
-      if (o.state !== 0) { o.t += dt; continue }
-      if (this.qAnswered) continue
-      const dx = o.x - this.px
-      const dy = o.y - this.py
-      // The orbit is a fixed distance away; you reach one by *swimming out*
-      // to it, which is the same verb as everything else in the game.
-      const px = this.px + this.pvx * 0.06
-      const py = this.py + this.pvy * 0.06
-      if ((o.x - px) * (o.x - px) + (o.y - py) * (o.y - py) < 40 * 40) {
-        void dx; void dy
-        this.answer(o)
+    advanceOrbs(this.orbs, dt)
+    if (!this.qAnswered) {
+      for (const o of this.orbs) {
+        if (reached(o, this.px, this.py, this.pvx, this.pvy)) {
+          this.answer(o)
+          break
+        }
       }
     }
     if (!this.qAnswered && this.qT <= 0) this.closeQuestion(null)
@@ -1794,8 +1790,14 @@ export class Game {
         const hpf = Math.max(0, E.hp[i] / E.maxHp[i])
         r.sprite(x, y, rad * 1.5, rad * 1.5, t * 1.3, 1, 0.86, 0.4, 0.55, SHAPE.RING, 0.05, 0.2)
         r.sprite(x, y, rad * 1.9, rad * 1.9, -t * 0.9, 1, 0.7, 0.3, 0.34, SHAPE.RING, 0.03, 0)
-        // Health as a shrinking arc of light: readable without a bar.
-        r.sprite(x, y - rad * 2.2, rad * 1.5 * hpf, 4, 0, 1, 0.5, 0.4, 0.9, SHAPE.CAPSULE, 0.5, 0.4)
+        // Health as a shrinking arc of light: readable without a bar. It was
+        // drawn at `y - rad * 2.2`, and `+y` is up — so a WARDEN's only damage
+        // feedback rendered UNDERNEATH it, behind its own body glow, and the
+        // game read as though the thing could not be hurt at all. It can: every
+        // weapon damages it like anything else. See `damage()`.
+        const bar = rad * 1.5
+        r.sprite(x, y + rad * 2.2, bar, 4, 0, 0.5, 0.16, 0.2, 0.5, SHAPE.CAPSULE, 0.5, 0)
+        r.sprite(x - bar * (1 - hpf), y + rad * 2.2, bar * hpf, 4, 0, 1, 0.5, 0.4, 1, SHAPE.CAPSULE, 0.5, 0.4)
       }
       if (def.behaviour === BEHAVIOUR.CHARGE && E.st2[i] > 0) {
         r.sprite(x, y, rad * 3.4, rad * 1.1, E.rot[i], 1, 0.5, 0.2, 0.5, SHAPE.CAPSULE, 0.35, 0.4)
@@ -1855,12 +1857,17 @@ export class Game {
     /* the question */
     if (this.q) {
       const fade = Math.min(1, this.qT * 2)
-      r.text(this.q.prompt, this.px, this.py - 116, 56, 1, 1, 1, fade)
-      const ring = 172
-      r.sprite(this.px, this.py, ring, ring, t * 0.4, 1, 0.86, 0.44, 0.30 * fade, SHAPE.RING, 0.012, 0.2)
+      // The prompt, the ring and the iris belong to the CORE, not to the diver:
+      // the child swims out of the middle of them to reach an answer, and a
+      // surface that followed the diver would take the sum along for the ride.
+      // `+y` is up, so the sum sits ABOVE the ring — it used to be written at
+      // `py - 116`, which put it under the diver's own light.
+      r.text(this.q.prompt, this.qX, this.qY + ORB_RADIUS + 74, 56, 1, 1, 1, fade)
+      const ring = ORB_RADIUS
+      r.sprite(this.qX, this.qY, ring, ring, t * 0.4, 1, 0.86, 0.44, 0.30 * fade, SHAPE.RING, 0.012, 0.2)
       // Time as a closing iris, not a number.
       const frac = Math.max(0, this.qT / Math.max(0.001, this.qTMax))
-      r.sprite(this.px, this.py, ring * (0.35 + frac * 0.62), ring * (0.35 + frac * 0.62), -t * 0.9, 1, 0.7, 0.3, 0.34 * fade, SHAPE.RING, 0.02, 0)
+      r.sprite(this.qX, this.qY, ring * (0.35 + frac * 0.62), ring * (0.35 + frac * 0.62), -t * 0.9, 1, 0.7, 0.3, 0.34 * fade, SHAPE.RING, 0.02, 0)
       for (const o of this.orbs) {
         const hot = o.state === 1 ? 1 : 0
         const bad = o.state === 2 ? 1 : 0
@@ -1965,14 +1972,18 @@ export class Game {
     const st = this.input.stick
     const r = this.r
     const wpp = (hw * 2) / Math.max(1, this.canvas.clientWidth)
-    const hpp = (hh * 2) / Math.max(1, this.canvas.clientHeight)
-    const ox = this.camX - hw + st.originX * wpp
-    const oy = this.camY - hh + st.originY * hpp
-    const kx = this.camX - hw + st.knobX * wpp
-    const ky = this.camY - hh + st.knobY * hpp
+    // Screen y=0 is the world's TOP edge, `camY + hh`. This used to read
+    // `camY - hh + originY * hpp`, so the ring drew at the reflected height —
+    // the same missing sign that inverted the controls. See `core/motion.ts`.
+    const view = {
+      camX: this.camX, camY: this.camY, halfW: hw, halfH: hh,
+      cssW: this.canvas.clientWidth, cssH: this.canvas.clientHeight,
+    }
+    const o = worldFromScreen(st.originX, st.originY, view)
+    const k = worldFromScreen(st.knobX, st.knobY, view)
     const rad = 62 * wpp
-    r.sprite(ox, oy, rad, rad, 0, 0.5, 0.85, 1, 0.22, SHAPE.RING, 0.03, 0)
-    r.sprite(kx, ky, rad * 0.4, rad * 0.4, 0, 0.7, 0.95, 1, 0.5, SHAPE.DISC, 1.2, 0.2)
+    r.sprite(o.x, o.y, rad, rad, 0, 0.5, 0.85, 1, 0.22, SHAPE.RING, 0.03, 0)
+    r.sprite(k.x, k.y, rad * 0.4, rad * 0.4, 0, 0.7, 0.95, 1, 0.5, SHAPE.DISC, 1.2, 0.2)
   }
 
   private drawOffscreenMarker(x: number, y: number, hw: number, hh: number, r0: number, g0: number, b0: number): void {

--- a/dynawalla/games/horde/src/game/orbs.test.ts
+++ b/dynawalla/games/horde/src/game/orbs.test.ts
@@ -1,0 +1,202 @@
+// AN ANSWER IS A PLACE.
+//
+// From a founder playtest: "when the 3 answers show up, you can't swim into
+// them, they stay equidistant from you so you can never get them."
+//
+// They did. `questTick` recomputed every orb's position from the player's
+// CURRENT position on every frame, so an orb was an offset bolted to the
+// diver's hip rather than a point in the world. Measured against the shipped
+// code, driving the diver straight at an orb with a perfect stick: 172.0 px at
+// t = 0, 159.8 px at t = 0.5 s, and 159.8 px at every sample thereafter — the
+// 12.3 px of velocity lead, and nothing else, forever. Closing the last 132 px
+// on lead alone needs 2200 px/s; the diver's base speed is 205 and the best
+// build in the game adds 18 per CURRENT card.
+//
+// So DEEPSWARM could not be answered at the CORE at all. Every core it opened
+// timed out. These tests drive the real integrator from `core/motion.ts` and
+// the real geometry from `orbs.ts`.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { type Diver, drive, integrate } from "../core/motion.ts"
+import { BASE_THINKING_SECONDS } from "./curriculum.ts"
+import { ORB_HIT, ORB_RADIUS, type Orb, advance, distanceTo, place, reached } from "./orbs.ts"
+
+const SPEED = 205 // loadout.ts, the base diver — no cards taken
+const DT = 1 / 60
+/** `step()`: the diver keeps most of its own clock while the world crawls. */
+const BULLET_TIME = 0.15
+const PDT = DT * (0.62 + 0.38 * BULLET_TIME)
+
+function openCore(cx = 0, cy = 0): Orb[] {
+  return place(cx, cy, ["12", "7", "19"], "7", 0.3)
+}
+
+/**
+ * A child swimming at an orb: aim the stick at it, hold, and step the game.
+ *
+ * The stick is in screen space, so the world direction is converted through
+ * `drive` — which is its own inverse — exactly as a thumb would produce it.
+ */
+function chase(orbs: Orb[], target: Orb, seconds: number): {
+  diver: Diver
+  samples: { t: number; d: number }[]
+  struck: number | null
+} {
+  const diver: Diver = { x: 0, y: 0, vx: 0, vy: 0 }
+  const samples: { t: number; d: number }[] = []
+  let struck: number | null = null
+  const frames = Math.round(seconds / DT)
+  for (let f = 0; f <= frames; f++) {
+    if (f % 30 === 0) samples.push({ t: f * DT, d: distanceTo(target, diver.x, diver.y) })
+    if (struck === null && reached(target, diver.x, diver.y, diver.vx, diver.vy)) struck = f * DT
+    const dx = target.x - diver.x
+    const dy = target.y - diver.y
+    const m = Math.hypot(dx, dy) || 1
+    const stick = drive(dx / m, dy / m)
+    integrate(diver, stick.x, stick.y, SPEED, PDT)
+    advance(orbs, DT)
+  }
+  return { diver, samples, struck }
+}
+
+test("the distance to an answer CLOSES when the child swims at it", () => {
+  const orbs = openCore()
+  const { samples, struck } = chase(orbs, orbs[0] as Orb, 4)
+
+  const first = samples[0] as { t: number; d: number }
+  assert.ok(
+    Math.abs(first.d - ORB_RADIUS) < 1,
+    `the ring must open at ${ORB_RADIUS}px, not ${first.d.toFixed(1)}px`,
+  )
+
+  // The shipped bug in one assertion: after a second of perfect swimming the
+  // orb was 159.8px away, having started 172px away. It has to actually close.
+  const oneSecond = samples.find((s) => Math.abs(s.t - 1) < 1e-9)
+  assert.ok(oneSecond, "expected a sample at t=1s")
+  assert.ok(
+    oneSecond.d < first.d - 100,
+    `after 1s of swimming the answer was still ${oneSecond.d.toFixed(1)}px away ` +
+      `(it started ${first.d.toFixed(1)}px away) — the child cannot reach it`,
+  )
+
+  assert.notEqual(struck, null, "the child never reached the answer in four seconds")
+  assert.ok(
+    (struck as number) < 2,
+    `it took ${(struck as number).toFixed(2)}s to reach an answer; a CORE is not a marathon`,
+  )
+})
+
+test("the distance never stalls — it falls on every sample until the strike", () => {
+  const orbs = openCore()
+  const { samples, struck } = chase(orbs, orbs[1] as Orb, 4)
+  const upTo = samples.filter((s) => s.t <= (struck as number))
+  assert.ok(upTo.length >= 2, "not enough samples before the strike to say anything")
+  for (let i = 1; i < upTo.length; i++) {
+    const prev = upTo[i - 1] as { t: number; d: number }
+    const now = upTo[i] as { t: number; d: number }
+    assert.ok(
+      now.d < prev.d,
+      `distance stalled at ${now.d.toFixed(1)}px between t=${prev.t.toFixed(2)} and ` +
+        `t=${now.t.toFixed(2)} — an orb that keeps its distance is unanswerable`,
+    )
+  }
+})
+
+test("an orb is anchored to the WORLD, not to the diver", () => {
+  // The structural half of the same fact: `advance` is not given the player, so
+  // it cannot follow one. This checks the consequence — swim 400px away and the
+  // ring stays where the CORE was.
+  const orbs = openCore(0, 0)
+  const before = orbs.map((o) => ({ x: o.x, y: o.y }))
+  const diver: Diver = { x: 0, y: 0, vx: 0, vy: 0 }
+  for (let f = 0; f < 240; f++) {
+    integrate(diver, 1, 0, SPEED, PDT)
+    advance(orbs, 0) // no time passes; only the diver moves
+  }
+  assert.ok(Math.abs(diver.x) > 200, `the diver only travelled ${diver.x.toFixed(0)}px`)
+  orbs.forEach((o, i) => {
+    const was = before[i] as { x: number; y: number }
+    assert.equal(o.x, was.x, `orb ${i} followed the diver on x`)
+    assert.equal(o.y, was.y, `orb ${i} followed the diver on y`)
+    assert.equal(o.ax, 0)
+    assert.equal(o.ay, 0)
+  })
+})
+
+test("the ring turns slowly enough to be caught, and stays a ring", () => {
+  const orbs = openCore()
+  for (let f = 0; f < 600; f++) advance(orbs, DT)
+  for (const o of orbs) {
+    assert.ok(
+      Math.abs(Math.hypot(o.x - o.ax, o.y - o.ay) - ORB_RADIUS) < 1e-6,
+      "an orb drifted off its ring",
+    )
+  }
+  // Tangential drift must be well under the diver's own pace in bullet time,
+  // or the ring is a carousel the child chases rather than one they swim into.
+  const diverPace = SPEED * (0.62 + 0.38 * BULLET_TIME)
+  const tangential = Math.hypot(
+    (orbs[0] as Orb).x - (orbs[0] as Orb).ax,
+    (orbs[0] as Orb).y - (orbs[0] as Orb).ay,
+  ) * 0.22
+  assert.ok(tangential < diverPace * 0.35, `the ring drifts at ${tangential.toFixed(0)}px/s`)
+})
+
+test("a CORE is answerable inside the time it gives the child", () => {
+  const orbs = openCore()
+  const { struck } = chase(orbs, orbs[2] as Orb, BASE_THINKING_SECONDS)
+  assert.notEqual(struck, null)
+  assert.ok(
+    (struck as number) * 4 < BASE_THINKING_SECONDS,
+    `reaching an answer eats ${(((struck as number) / BASE_THINKING_SECONDS) * 100).toFixed(0)}% ` +
+      "of the thinking window — the window is for thinking, not for swimming",
+  )
+})
+
+test("no orb is easier to reach than another, and none of them is the answer's", () => {
+  // COUNTERPOISE shipped with the answer in a predictable place and a bot
+  // scored 97.2% without doing arithmetic. `place` is handed an already-shuffled
+  // list and lays it out on a circle by index, so position carries nothing.
+  const orbs = openCore()
+  const d = orbs.map((o) => distanceTo(o, 0, 0))
+  for (const x of d) assert.ok(Math.abs(x - ORB_RADIUS) < 1e-9, `an orb opened at ${x}px`)
+
+  const angles = orbs.map((o) => o.ang)
+  const gap = (2 * Math.PI) / orbs.length
+  for (let i = 1; i < angles.length; i++) {
+    assert.ok(
+      Math.abs((angles[i] as number) - (angles[i - 1] as number) - gap) < 1e-9,
+      "the orbs are not evenly spaced",
+    )
+  }
+
+  // Same texts, answer moved: the geometry does not budge.
+  const a = place(0, 0, ["12", "7", "19"], "7", 0.3)
+  const b = place(0, 0, ["12", "7", "19"], "19", 0.3)
+  a.forEach((o, i) => {
+    assert.equal(o.x, (b[i] as Orb).x)
+    assert.equal(o.y, (b[i] as Orb).y)
+  })
+  assert.deepEqual(a.map((o) => o.correct), [false, true, false])
+  assert.deepEqual(b.map((o) => o.correct), [false, false, true])
+})
+
+test("a struck orb stops moving and cannot be struck twice", () => {
+  const orbs = openCore()
+  const o = orbs[0] as Orb
+  o.state = 2
+  const at = { x: o.x, y: o.y }
+  advance(orbs, 1)
+  assert.equal(o.x, at.x, "a resolved orb kept orbiting")
+  assert.ok(o.t > 0, "a resolved orb must age, so the game can time its flourish")
+  assert.equal(reached(o, o.x, o.y, 0, 0), false, "a resolved orb answered again")
+})
+
+test("the strike radius is generous enough for a thumb, not a pixel hunt", () => {
+  const o = (openCore()[0] as Orb)
+  assert.ok(ORB_HIT >= 44, `the strike radius is ${ORB_HIT}px; 44 is the platform touch minimum`)
+  assert.equal(reached(o, o.x, o.y - (ORB_HIT - 1), 0, 0), true)
+  assert.equal(reached(o, o.x, o.y - (ORB_HIT + 1), 0, 0), false)
+})

--- a/dynawalla/games/horde/src/game/orbs.ts
+++ b/dynawalla/games/horde/src/game/orbs.ts
@@ -1,0 +1,158 @@
+/**
+ * The three numbered orbs a CORE opens, and where they are.
+ *
+ * ── The bug this file exists to end ──────────────────────────────────────────
+ *
+ * A CORE used to place its orbs like this, once per frame, in `questTick`:
+ *
+ *     o.ang += dt * 0.42
+ *     o.x = this.px + Math.cos(o.ang) * 172
+ *     o.y = this.py + Math.sin(o.ang) * 172
+ *
+ * The orb's position was recomputed *from the player's current position* on
+ * every frame, so it was not a place in the world at all — it was an offset
+ * bolted to the diver's hip. Swimming at it moved it. The distance from the
+ * diver to any orb was 172 px on the first frame of the CORE and 172 px on the
+ * last one, no matter what the child did with their thumb.
+ *
+ * The reach test then asked whether the diver's *lead* position had closed to
+ * within 40 px:
+ *
+ *     px = this.px + this.pvx * 0.06
+ *
+ * which is 12.3 px of lead at the base speed of 205 px/s. To cross the
+ * remaining 172 − 40 px on lead alone the diver would have to be travelling
+ * 2200 px/s. The fastest build in the game — every CURRENT card taken, +18 px/s
+ * each — does not come close. So the CORE could be entered and could never be
+ * answered: it opened, three numbers circled the child at arm's length for
+ * eight and a half seconds, and closed as a timeout. Measured before the fix,
+ * driving the diver straight at an orb with a perfect stick: 172.0 px at t=0,
+ * 159.8 px at t=0.5 s, and 159.8 px at every sample after that, forever.
+ *
+ * ── What replaces it ────────────────────────────────────────────────────────
+ *
+ * An orb is a PLACE. `place` fixes an anchor in world space at the moment the
+ * CORE opens, and `advance` moves the orbs around *that anchor* — never around
+ * the player, whose position this module is never even given. The signature is
+ * the guarantee: `advance(orbs, dt)` cannot follow a diver it cannot see.
+ *
+ * The ring still turns, because "time slows down and three numbered balls
+ * circle you" is what the game's own how-to-play promises and the founder likes
+ * the game as it is. It turns at 0.22 rad/s, which is 33 px/s of tangential
+ * drift at this radius against a diver who covers 139 px/s in bullet time — a
+ * ring you swim into, not a carousel you chase.
+ */
+
+export type Orb = {
+  /** Live world position. Derived from the anchor; never from the player. */
+  x: number
+  y: number
+  /** The fixed world point this orb circles. Set once, when the CORE opens. */
+  ax: number
+  ay: number
+  ang: number
+  text: string
+  correct: boolean
+  /** 0 untouched, 1 revealed-correct, 2 struck-wrong. */
+  state: number
+  t: number
+}
+
+/** How far from the CORE the ring sits. One short swim in bullet time. */
+export const ORB_RADIUS = 150
+
+/**
+ * How close counts as a strike.
+ *
+ * Generous on purpose: the diver's own body is 15 px and the numeral drawn on
+ * an orb is about 34 px wide, so 52 means "the child put the light on the
+ * number", not "the child hit a pixel".
+ */
+export const ORB_HIT = 52
+
+/** Radians per second the ring turns about its anchor. */
+export const ORB_SPIN = 0.22
+
+/**
+ * How far ahead of the diver the strike is tested.
+ *
+ * A small courtesy, not a mechanism: at 205 px/s it is 12 px, so a child who is
+ * already moving through an orb registers on the frame they arrive rather than
+ * the frame after. When orbs were pinned to the player this was the *only*
+ * closing term, which is how it came to matter at all.
+ */
+export const LEAD_SECONDS = 0.06
+
+/**
+ * Lay the ring down around a world point, evenly spaced from `base`.
+ *
+ * `texts` is already shuffled by the caller; this places what it is handed and
+ * has no opinion about which position the answer lands in.
+ */
+export function place(
+  cx: number,
+  cy: number,
+  texts: readonly string[],
+  answer: string,
+  base: number,
+  radius = ORB_RADIUS,
+): Orb[] {
+  const orbs: Orb[] = []
+  for (let i = 0; i < texts.length; i++) {
+    const ang = base + (i / texts.length) * Math.PI * 2
+    orbs.push({
+      x: cx + Math.cos(ang) * radius,
+      y: cy + Math.sin(ang) * radius,
+      ax: cx,
+      ay: cy,
+      ang,
+      text: texts[i] as string,
+      correct: texts[i] === answer,
+      state: 0,
+      t: 0,
+    })
+  }
+  return orbs
+}
+
+/**
+ * Turn the ring.
+ *
+ * Takes no player. That is the whole point of the file and it is enforced by
+ * the type: an orb's position is a function of its own anchor and the clock,
+ * so a diver swimming toward one closes on it.
+ */
+export function advance(orbs: readonly Orb[], dt: number): void {
+  for (const o of orbs) {
+    if (o.state !== 0) {
+      o.t += dt
+      continue
+    }
+    o.ang += dt * ORB_SPIN
+    const r = Math.hypot(o.x - o.ax, o.y - o.ay) || ORB_RADIUS
+    o.x = o.ax + Math.cos(o.ang) * r
+    o.y = o.ay + Math.sin(o.ang) * r
+  }
+}
+
+/** Has the diver, at this position and velocity, struck this orb? */
+export function reached(
+  o: Orb,
+  px: number,
+  py: number,
+  pvx: number,
+  pvy: number,
+  hit = ORB_HIT,
+): boolean {
+  if (o.state !== 0) return false
+  const lx = px + pvx * LEAD_SECONDS
+  const ly = py + pvy * LEAD_SECONDS
+  const dx = o.x - lx
+  const dy = o.y - ly
+  return dx * dx + dy * dy < hit * hit
+}
+
+/** Distance from the diver to an orb. Used by the tests, and by nothing else. */
+export function distanceTo(o: Orb, px: number, py: number): number {
+  return Math.hypot(o.x - px, o.y - py)
+}

--- a/dynawalla/games/horde/src/style.css
+++ b/dynawalla/games/horde/src/style.css
@@ -53,7 +53,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right)) max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+  padding: max(10px, var(--hz-safe-top, env(safe-area-inset-top))) max(10px, var(--hz-safe-right, env(safe-area-inset-right))) max(10px, var(--hz-safe-bottom, env(safe-area-inset-bottom))) max(10px, var(--hz-safe-left, env(safe-area-inset-left)));
 }
 
 /* The XP bar had no `env()` at all: flush to y=0 and edge to edge, so on a
@@ -62,9 +62,9 @@
    now starts under the host's own 3px hairline rather than beneath it. */
 .hz-xpbar {
   position: absolute;
-  top: calc(env(safe-area-inset-top) + var(--hz-xp-top));
-  left: env(safe-area-inset-left);
-  right: env(safe-area-inset-right);
+  top: calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-xp-top));
+  left: var(--hz-safe-left, env(safe-area-inset-left));
+  right: var(--hz-safe-right, env(safe-area-inset-right));
   height: 7px;
   background: rgba(120, 190, 255, 0.10);
 }
@@ -83,8 +83,8 @@
    them. */
 .hz-top {
   position: absolute;
-  top: calc(env(safe-area-inset-top) + var(--hz-chrome-top));
-  left: env(safe-area-inset-left); right: env(safe-area-inset-right);
+  top: calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-chrome-top));
+  left: var(--hz-safe-left, env(safe-area-inset-left)); right: var(--hz-safe-right, env(safe-area-inset-right));
   display: flex;
   justify-content: center;
   gap: clamp(10px, 3vw, 26px);
@@ -116,17 +116,25 @@
   text-shadow: 0 0 16px rgba(255, 200, 80, 0.6);
 }
 
-/* life */
+/* Life. A founder playtest asked "should it show the health somewhere?", which
+   is what you ask about a readout you did not find. There was one: a 12px
+   hairline with 10px near-black lettering that vanished the moment the fill
+   dropped away from underneath it — so the harder you were being hit, the
+   harder your health was to read. It is the same bar in the same place, tall
+   enough to be a readout, with lettering that survives an empty bar and a
+   colour that changes when the run is nearly over. Its offset is now measured
+   from the host's real bottom inset, not from `env()`, which is 0 in a pack —
+   it used to sit under the home indicator. See `ui/layout.ts`. */
 .hz-life {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: calc(16px + env(safe-area-inset-bottom));
+  bottom: calc(var(--hz-life-bottom, 18px) + var(--hz-safe-bottom, env(safe-area-inset-bottom)));
   width: min(380px, 62vw);
-  height: 12px;
-  background: rgba(255, 90, 120, 0.14);
-  border: 1px solid rgba(255, 130, 150, 0.25);
-  border-radius: 2px;
+  height: var(--hz-life-h, 22px);
+  background: rgba(70, 12, 26, 0.62);
+  border: 1px solid rgba(255, 130, 150, 0.34);
+  border-radius: 3px;
   overflow: hidden;
 }
 .hz-lifefill {
@@ -134,25 +142,35 @@
   width: 100%;
   background: linear-gradient(90deg, #ff5f7a, #ff9c6a 70%, #ffd2a0);
   box-shadow: 0 0 16px rgba(255, 100, 120, 0.8);
-  transition: width 110ms ease-out;
+  transition: width 110ms ease-out, background 200ms linear;
 }
+/* Under a quarter: the bar goes white-hot rather than quietly getting shorter. */
+.hz-life.hz-low .hz-lifefill {
+  background: linear-gradient(90deg, #fff0f3, #ff8fa6);
+  animation: hz-lifepulse 620ms ease-in-out infinite alternate;
+}
+@keyframes hz-lifepulse { from { opacity: 0.72; } to { opacity: 1; } }
 .hz-lifetext {
   position: absolute;
   inset: 0;
   display: grid;
   place-items: center;
-  font-size: 10px;
+  font-size: clamp(11px, 2.6vw, 13px);
   font-weight: 900;
-  letter-spacing: 0.14em;
-  color: #23070f;
-  mix-blend-mode: normal;
-  text-shadow: none;
+  letter-spacing: 0.16em;
+  /* Readable over the fill AND over the empty track, which the old near-black
+     lettering was not: at low health it sat on a dark background, invisible. */
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(40, 0, 8, 0.95), 0 0 10px rgba(60, 0, 12, 0.8);
+}
+@media (prefers-reduced-motion: reduce) {
+  .hz-life.hz-low .hz-lifefill { animation: none; }
 }
 
 .hz-weps {
   position: absolute;
-  left: calc(12px + env(safe-area-inset-left));
-  bottom: calc(40px + env(safe-area-inset-bottom));
+  left: calc(12px + var(--hz-safe-left, env(safe-area-inset-left)));
+  bottom: calc(40px + var(--hz-safe-bottom, env(safe-area-inset-bottom)));
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -215,10 +233,10 @@
      outermost upgrade card — both things a child taps — ran under the sensor
      housing and the rounded corner. */
   padding:
-    max(12px, env(safe-area-inset-top))
-    max(12px, env(safe-area-inset-right))
-    max(12px, env(safe-area-inset-bottom))
-    max(12px, env(safe-area-inset-left));
+    max(12px, var(--hz-safe-top, env(safe-area-inset-top)))
+    max(12px, var(--hz-safe-right, env(safe-area-inset-right)))
+    max(12px, var(--hz-safe-bottom, env(safe-area-inset-bottom)))
+    max(12px, var(--hz-safe-left, env(safe-area-inset-left)));
   background:
     radial-gradient(120% 90% at 50% 40%, rgba(8, 14, 34, 0.62), rgba(2, 4, 12, 0.93));
   backdrop-filter: blur(9px) saturate(0.85);
@@ -451,6 +469,22 @@
 }
 .hz-answer:hover { background: rgba(120, 190, 255, 0.2); transform: translateY(-3px); }
 .hz-answer:active { transform: scale(0.97); }
+/* Every candidate looks the same until it is struck.
+   `showRift` used to focus the first button as the panel opened, and the UA
+   paints a ring on a focused button — so the LEFTMOST answer arrived already
+   highlighted, every time, whether or not it was the right one. The focus is
+   gone; this makes sure nothing else can put a ring there either. A keyboard
+   player who Tabs in still gets one, because `:focus-visible` is exactly the
+   "arrived by keyboard" case and programmatic focus is not. */
+.hz-answer:focus { outline: none; }
+.hz-answer:focus-visible {
+  outline: 2px solid #eaf7ff;
+  outline-offset: 2px;
+}
+.hz-orb:focus { outline: none; }
+.hz-orb:focus-visible { outline: 2px solid #ffe9b8; outline-offset: 2px; }
+/* The panel itself takes the focus instead. It must never look focused. */
+.hz-riftbox:focus, .hz-riftbox:focus-visible { outline: none; }
 .hz-answer.hz-ok { background: #7dffd0; border-color: #d8fff2; color: #00281c; animation: hz-pop 380ms ease-out; }
 .hz-answer.hz-no { background: rgba(120, 40, 60, 0.5); border-color: #ff7d9c; color: #ffd9e2; }
 .hz-riftclock {
@@ -557,8 +591,8 @@
    and the host paints nothing down there. */
 .hz-corner {
   position: absolute;
-  bottom: calc(var(--hz-icon-bottom) + env(safe-area-inset-bottom));
-  right: calc(var(--hz-icon-edge) + env(safe-area-inset-right));
+  bottom: calc(var(--hz-icon-bottom) + var(--hz-safe-bottom, env(safe-area-inset-bottom)));
+  right: calc(var(--hz-icon-edge) + var(--hz-safe-right, env(safe-area-inset-right)));
   display: flex;
   gap: var(--hz-icon-gap);
   pointer-events: auto;
@@ -582,8 +616,8 @@
 /* Behind `?debug`, but it sat under the back chevron too. */
 .hz-fps {
   position: absolute;
-  left: calc(var(--hz-fps-edge) + env(safe-area-inset-left));
-  top: calc(env(safe-area-inset-top) + var(--hz-chrome-top));
+  left: calc(var(--hz-fps-edge) + var(--hz-safe-left, env(safe-area-inset-left)));
+  top: calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-chrome-top));
   font-size: 10px;
   letter-spacing: 0.1em;
   color: #4f7ea0;

--- a/dynawalla/games/horde/src/ui/layout.test.ts
+++ b/dynawalla/games/horde/src/ui/layout.test.ts
@@ -24,7 +24,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
-import { CHROME_TOP, ICON, hudRects } from "./layout.ts"
+import { CHROME_TOP, ICON, LIFE_H, applySafeVars, hudRects } from "./layout.ts"
 
 const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
 const NOTCH_PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
@@ -83,6 +83,7 @@ test("every HUD box stays inside the safe area on the edges it touches", () => {
       ["the clock row", r.top],
       ["the sound and pause buttons", r.corner],
       ["the fps readout", r.fps],
+      ["the life bar", r.life],
     ] as const) {
       assert.ok(box.x >= insets.left, `${name}: ${what} runs into the left inset`)
       assert.ok(
@@ -113,4 +114,88 @@ test("the offset is the host's own number, not one somebody typed", () => {
   // 57 is the bottom of the host's corner squares: a 3px hairline, a 10px
   // margin and a 44px control. This is the inequality the file exists to hold.
   assert.ok(CHROME_TOP >= 57, `CHROME_TOP is ${CHROME_TOP} — the host's corners end at 57`)
+})
+
+/* ------------------------------------------------------- the safe area itself */
+
+// THE INSETS WERE ZERO THE WHOLE TIME.
+//
+// Every assertion above is handed real insets. The browser was not. The
+// stylesheet spelled the safe area `env(safe-area-inset-*)`, and a pack is a
+// cross-origin iframe, where all four of those resolve to 0 — so on a notched
+// phone the clock row that `hudRects` puts at y=110 was painted at y=63, inside
+// the host's back chevron, while this file passed. The numbers were right and
+// nothing carried them to the CSS.
+
+/** Just enough of an element to record what was written onto it. */
+function fakeRoot(): { el: HTMLElement; vars: Map<string, string> } {
+  const vars = new Map<string, string>()
+  const el = {
+    style: { setProperty: (k: string, v: string) => void vars.set(k, v) },
+  } as unknown as HTMLElement
+  return { el, vars }
+}
+
+test("the safe area reaches the stylesheet as numbers, not as env()", () => {
+  const { el, vars } = fakeRoot()
+  applySafeVars(el, NOTCH_PORTRAIT)
+  assert.equal(vars.get("--hz-safe-top"), "47px")
+  assert.equal(vars.get("--hz-safe-bottom"), "34px")
+  assert.equal(vars.get("--hz-safe-left"), "0px")
+  assert.equal(vars.get("--hz-safe-right"), "0px")
+})
+
+test("a zero inset is written explicitly, never left to the env() fallback", () => {
+  // `var(--x, fallback)` uses the fallback when the property is ABSENT. Inside
+  // the app `env()` is the wrong answer even when the true inset is 0, so the
+  // zero has to be stated.
+  const { el, vars } = fakeRoot()
+  applySafeVars(el, NONE)
+  for (const k of ["--hz-safe-top", "--hz-safe-right", "--hz-safe-bottom", "--hz-safe-left"]) {
+    assert.equal(vars.get(k), "0px", `${k} was left unset, so the CSS falls back to env()`)
+  }
+})
+
+test("the offsets the CSS composes put the HUD where hudRects says it is", () => {
+  // The composition the stylesheet performs, spelled out: every top offset is
+  // `var(--hz-safe-top) + var(--hz-chrome-top)`. This is the arithmetic that
+  // silently produced 63 instead of 110.
+  const { el, vars } = fakeRoot()
+  applySafeVars(el, NOTCH_PORTRAIT)
+  const safeTop = Number.parseFloat(vars.get("--hz-safe-top") as string)
+  const composed = safeTop + CHROME_TOP
+  assert.equal(composed, hudRects(390, 844, NOTCH_PORTRAIT).top.y)
+  assert.ok(
+    composed > 57,
+    `the clock row composes to y=${composed}; the host's corner squares end at 57`,
+  )
+})
+
+/* ----------------------------------------------------------------- the life bar */
+
+test("the life bar clears the home indicator, and is big enough to be a readout", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const insets = w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT
+    const r = hudRects(w, h, insets)
+    assert.ok(
+      r.life.y + r.life.h <= h - insets.bottom,
+      `${name}: the life bar runs under the home indicator`,
+    )
+    assert.equal(hitsHostChrome(r.life, w, insets), false, `${name}: the life bar is under chrome`)
+  }
+  // 12px was the shipped height and it read as decoration; a founder playtest
+  // asked whether there was a health readout at all.
+  assert.ok(LIFE_H >= 20, `the life bar is ${LIFE_H}px tall — that is a hairline, not a readout`)
+})
+
+test("the life bar does not collide with the sound and pause buttons", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const r = hudRects(w, h, NONE)
+    const overlap =
+      r.life.x < r.corner.x + r.corner.w &&
+      r.corner.x < r.life.x + r.life.w &&
+      r.life.y < r.corner.y + r.corner.h &&
+      r.corner.y < r.life.y + r.life.h
+    assert.equal(overlap, false, `${name}: the life bar is under the game's own two buttons`)
+  }
 })

--- a/dynawalla/games/horde/src/ui/layout.ts
+++ b/dynawalla/games/horde/src/ui/layout.ts
@@ -20,12 +20,39 @@
  * These constants are written onto the root as custom properties at mount, the
  * stylesheet reads them through `var()`, and `hudRects` reports the same
  * geometry to the tests. One source; the CSS and the test cannot drift apart.
+ *
+ * ── The insets were zero the whole time ─────────────────────────────────────
+ *
+ * That promise was false in the shipped app, and the tests could not see it.
+ * Every offset above is measured from the SAFE edge, and the stylesheet spelled
+ * that `env(safe-area-inset-top)` — but a pack runs in an iframe sandboxed
+ * `allow-scripts` with no `allow-same-origin`, and `env(safe-area-inset-*)` is a
+ * property of the TOP-LEVEL browsing context. A cross-origin child resolves all
+ * four to **zero**. (`packs/shared/game-chrome/insets.ts` says so in as many
+ * words; nothing in this game had read it.)
+ *
+ * So on a notched phone the host's back chevron sat at y = 47 + 3 + 10 = 60 and
+ * the clock row that `hudRects` placed at y = 47 + 63 = 110 was actually painted
+ * at y = 63 — inside the chevron's square. The clock, the level, the kill count
+ * and the fps readout were all under host chrome on exactly the devices the
+ * insets exist for, while `layout.test.ts` passed, because the test was handed
+ * real insets and the browser was not.
+ *
+ * The host measures the real values and publishes them; `safeInsets()` returns
+ * those when they are there and falls back to the probe. `applyChromeVars`
+ * writes them onto the root as `--hz-safe-*` and every rule in `style.css` reads
+ * `var(--hz-safe-top, env(safe-area-inset-top))` — the `env()` staying on as the
+ * fallback for `npm run dev`, where the game is top-level and `env()` is real.
+ * `watchChromeVars` keeps them current across a rotation.
  */
 
 import {
   HOST_CONTROL,
   HOST_MARGIN,
   HOST_PROGRESS_H,
+  NO_INSETS,
+  onInsetsChange,
+  safeInsets,
   type Insets,
   type Rect,
 } from "../../../../packs/shared/game-chrome/index.ts"
@@ -64,6 +91,25 @@ export const ICON_BOTTOM = 40
 export const FPS_EDGE = 10
 
 /**
+ * The life bar.
+ *
+ * A founder playtest asked "should it show the health somewhere?" — which is
+ * the question you ask about a readout you did not find. There was one, and it
+ * was a 12px hairline with 10px near-black lettering inside it, 16px off the
+ * bottom of the frame. Two things were wrong with that and only one of them was
+ * taste: at 12px tall it read as decoration, and 16px from the bottom on a
+ * phone with a 34px home indicator meant it was UNDER the home indicator,
+ * because the inset it was measured from was resolving to zero (see above).
+ *
+ * It stays where it is — bottom-centre is the only place on this HUD with
+ * nothing else in it, and it is where a survivor's health belongs — but it is
+ * tall enough to see and it clears the indicator.
+ */
+export const LIFE_H = 22
+export const LIFE_BOTTOM = 18
+export const LIFE_MAX_W = 380
+
+/**
  * The boxes the HUD actually occupies, so a test can assert they clear the
  * host's corners at every viewport instead of a device finding out.
  */
@@ -71,11 +117,18 @@ export function hudRects(
   w: number,
   h: number,
   insets: Insets,
-): { xpbar: Rect; top: Rect; corner: Rect; fps: Rect } {
+): { xpbar: Rect; top: Rect; corner: Rect; fps: Rect; life: Rect } {
   const left = insets.left
   const right = insets.right
   const iconsW = ICON * 2 + ICON_GAP
+  const lifeW = Math.min(LIFE_MAX_W, w * 0.62)
   return {
+    life: {
+      x: (w - lifeW) / 2,
+      y: h - insets.bottom - LIFE_BOTTOM - LIFE_H,
+      w: lifeW,
+      h: LIFE_H,
+    },
     xpbar: { x: left, y: insets.top + XP_TOP, w: Math.max(0, w - left - right), h: XP_H },
     top: {
       x: left,
@@ -100,7 +153,7 @@ export function hudRects(
  * without a mounted root still looks right; these overwrite them, and these are
  * what the tests see.
  */
-export function applyChromeVars(root: HTMLElement): void {
+export function applyChromeVars(root: HTMLElement, insets: Insets = safeInsets()): void {
   root.style.setProperty("--hz-chrome-top", `${CHROME_TOP}px`)
   root.style.setProperty("--hz-xp-top", `${XP_TOP}px`)
   root.style.setProperty("--hz-icon", `${ICON}px`)
@@ -108,4 +161,33 @@ export function applyChromeVars(root: HTMLElement): void {
   root.style.setProperty("--hz-icon-edge", `${ICON_EDGE}px`)
   root.style.setProperty("--hz-icon-bottom", `${ICON_BOTTOM}px`)
   root.style.setProperty("--hz-fps-edge", `${FPS_EDGE}px`)
+  root.style.setProperty("--hz-life-h", `${LIFE_H}px`)
+  root.style.setProperty("--hz-life-bottom", `${LIFE_BOTTOM}px`)
+  applySafeVars(root, insets)
+}
+
+/**
+ * The safe area, as four custom properties `style.css` can do arithmetic with.
+ *
+ * Zeros are written explicitly rather than left unset: `var(--hz-safe-top, …)`
+ * falls back to `env()` only when the property is ABSENT, and inside the app
+ * `env()` is the wrong answer even when the real inset is 0.
+ */
+export function applySafeVars(root: HTMLElement, insets: Insets = safeInsets()): void {
+  const i = insets ?? NO_INSETS
+  root.style.setProperty("--hz-safe-top", `${Math.max(0, i.top)}px`)
+  root.style.setProperty("--hz-safe-right", `${Math.max(0, i.right)}px`)
+  root.style.setProperty("--hz-safe-bottom", `${Math.max(0, i.bottom)}px`)
+  root.style.setProperty("--hz-safe-left", `${Math.max(0, i.left)}px`)
+}
+
+/**
+ * Keep them current. Rotation swaps top/bottom with left/right, and a HUD that
+ * read the insets once at mount is correct until the child turns the tablet.
+ *
+ * @returns an unsubscribe. `Overlay.destroy` calls it.
+ */
+export function watchChromeVars(root: HTMLElement): () => void {
+  applySafeVars(root)
+  return onInsetsChange((insets) => applySafeVars(root, insets))
 }

--- a/dynawalla/games/horde/src/ui/overlay.ts
+++ b/dynawalla/games/horde/src/ui/overlay.ts
@@ -4,7 +4,8 @@
  */
 import type { Card } from "../game/loadout.ts"
 import type { Question } from "../contract.ts"
-import { applyChromeVars } from "./layout.ts"
+import { applyChromeVars, watchChromeVars } from "./layout.ts"
+import { shuffleWithAnswer } from "./shuffle.ts"
 
 const h = <K extends keyof HTMLElementTagNameMap>(
   tag: K, cls?: string, text?: string,
@@ -26,6 +27,7 @@ export class Overlay {
   private clock: HTMLElement
   private lvl: HTMLElement
   private kills: HTMLElement
+  private life: HTMLElement
   private lifeFill: HTMLElement
   private lifeText: HTMLElement
   private weps: HTMLElement
@@ -38,6 +40,7 @@ export class Overlay {
   private cardTitle: HTMLElement
 
   private riftModal: HTMLElement
+  private riftBox: HTMLElement
   private riftCharges: HTMLElement
   private riftPrompt: HTMLElement
   private riftAnswers: HTMLElement
@@ -52,6 +55,7 @@ export class Overlay {
 
   private soundBtn: HTMLButtonElement
   private pauseBtn: HTMLButtonElement
+  private unwatch: () => void = () => {}
 
   onPickCard: (i: number) => void = () => {}
   onSealed: (r: SealedResult) => void = () => {}
@@ -68,7 +72,15 @@ export class Overlay {
     // numbers that keep this HUD out of the host's two corners live in
     // `layout.ts` and are handed to the CSS here. One source, and the tests
     // read the same one.
+    //
+    // That includes the safe area itself. `env(safe-area-inset-*)` resolves to
+    // zero inside a pack — it is a property of the top-level document and a
+    // pack is a cross-origin child — so the whole HUD was laid out against
+    // zeros on precisely the devices that have a notch. The host's measurement
+    // arrives through `safeInsets()`; `watchChromeVars` keeps it current
+    // through a rotation.
     applyChromeVars(root)
+    this.unwatch = watchChromeVars(root)
 
     const hud = h("div", "hz-hud")
     const xp = h("div", "hz-xpbar")
@@ -84,9 +96,12 @@ export class Overlay {
     top.append(this.lvl, this.clock, this.kills)
 
     const life = h("div", "hz-life")
+    life.setAttribute("role", "meter")
+    life.setAttribute("aria-label", "Life")
     this.lifeFill = h("i", "hz-lifefill")
     this.lifeText = h("div", "hz-lifetext", "100 / 100")
     life.append(this.lifeFill, this.lifeText)
+    this.life = life
 
     this.weps = h("div", "hz-weps")
     this.banner = h("div", "hz-banner")
@@ -125,7 +140,11 @@ export class Overlay {
     this.riftClock = h("div", "hz-riftclock")
     this.riftClock.appendChild(h("i"))
     this.riftNote = h("div", "hz-riftnote", "CHARGE THE RIFT TO COME BACK")
+    // Focusable, so opening the panel can move the keyboard into it without
+    // landing that focus on one of the four answers. See `showRift`.
+    riftBox.tabIndex = -1
     riftBox.append(riftTitle, this.riftCharges, this.riftPrompt, this.riftAnswers, this.riftClock, this.riftNote)
+    this.riftBox = riftBox
     this.riftModal.appendChild(riftBox)
 
     /* ---- over ---- */
@@ -148,7 +167,7 @@ export class Overlay {
     hint.innerHTML =
       "<b>DRAG</b> anywhere to swim &nbsp;·&nbsp; <b>WASD</b> or <b>ARROWS</b> on a keyboard<br>" +
       "Your weapons fire themselves. All you do is move.<br>" +
-      "Swim into a golden <b>CORE</b> — time slows, and the number you touch decides what happens next."
+      "Swim into a golden <b>CORE</b> — time slows, three numbers ring the spot, and the one you swim to decides what happens next."
     this.titleModal.append(big, tag, go, hint)
 
     root.append(hud, this.cardModal, this.riftModal, this.overModal, this.titleModal)
@@ -178,6 +197,7 @@ export class Overlay {
     const f = Math.max(0, Math.min(1, hp / max))
     this.lifeFill.style.width = `${f * 100}%`
     this.lifeText.textContent = `${Math.max(0, Math.ceil(hp))} / ${max}`
+    this.life.classList.toggle("hz-low", f <= 0.25)
   }
 
   setWeapons(rows: string[]): void {
@@ -313,8 +333,13 @@ export class Overlay {
     this.riftNote.textContent =
       needed === 1 ? "ONE ANSWER AND YOU ARE BACK" : `${needed} ANSWERS AND YOU ARE BACK`
     this.riftModal.classList.add("hz-open")
-    const first = this.riftAnswers.querySelector("button")
-    if (first) (first as HTMLElement).focus({ preventScroll: true })
+    // The panel takes focus, NOT the first answer. Focusing the leftmost button
+    // painted a ring on it — a founder playtest read that as "the answer on the
+    // left appears highlighted". It never tracked which one was correct; it was
+    // always seat zero. A keyboard player still Tabs straight into the row from
+    // here, and `style.css` keeps the ring for `:focus-visible` only, so
+    // arriving by Tab is still visible and arriving by script is not.
+    this.riftBox.focus({ preventScroll: true })
   }
 
   setRiftClock(frac: number): void {
@@ -348,18 +373,8 @@ export class Overlay {
   }
 
   destroy(): void {
+    this.unwatch()
+    this.unwatch = () => {}
     this.root.textContent = ""
   }
-}
-
-/** Deterministic-enough shuffle of answer + distractors. */
-function shuffleWithAnswer(q: Question): string[] {
-  const opts = [q.answer, ...q.distractors.slice(0, 3)]
-  for (let i = opts.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    const t = opts[i]
-    opts[i] = opts[j]
-    opts[j] = t
-  }
-  return opts
 }

--- a/dynawalla/games/horde/src/ui/shuffle.test.ts
+++ b/dynawalla/games/horde/src/ui/shuffle.test.ts
@@ -1,0 +1,108 @@
+// NO SEAT IS THE ANSWER'S SEAT.
+//
+// A founder playtest: "the answer on the left for the rift appears highlighted
+// (not always the answer but they should all appear the same with none
+// highlighted)." He read it exactly right — it was the LEFTMOST button, chosen
+// by position, because `showRift` called `.focus()` on the first one it built.
+// That is fixed in `overlay.ts` and `style.css`.
+//
+// This file holds the other half: that the seat itself carries no information.
+// COUNTERPOISE is the cautionary tale — the answer sat in a predictable place
+// and a bot scored 97.2% with no arithmetic.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Question } from "../contract.ts"
+import { shuffleWithAnswer } from "./shuffle.ts"
+
+const Q: Question = {
+  id: "q1",
+  prompt: "47 + 38",
+  answer: "85",
+  distractors: ["75", "95", "84", "185"],
+  domain: "add",
+  difficulty: 0.4,
+}
+
+/** mulberry32, the same generator `stubHost.ts` uses. Seeded, so this is exact. */
+function rng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+test("the answer lands in every seat about equally often", () => {
+  const r = rng(0x5eed1e)
+  const N = 40_000
+  const counts = [0, 0, 0, 0]
+  for (let i = 0; i < N; i++) {
+    const seat = shuffleWithAnswer(Q, 4, r).indexOf(Q.answer)
+    assert.notEqual(seat, -1, "the answer fell out of the shuffle")
+    counts[seat] = (counts[seat] as number) + 1
+  }
+  const expected = N / 4
+  counts.forEach((c, i) => {
+    const drift = Math.abs(c - expected) / expected
+    assert.ok(
+      drift < 0.04,
+      `the answer landed in seat ${i} ${((c / N) * 100).toFixed(1)}% of the time, not 25% ` +
+        `— a bot could learn seat ${i}. Counts: ${counts.join(", ")}`,
+    )
+  })
+})
+
+test("a bot that always picks the leftmost seat does no better than guessing", () => {
+  // The concrete version of the same fact, and the one the RIFT's focus ring
+  // was quietly helping a child with.
+  const r = rng(99)
+  const N = 20_000
+  let hits = 0
+  for (let i = 0; i < N; i++) if ((shuffleWithAnswer(Q, 4, r)[0] as string) === Q.answer) hits++
+  const rate = hits / N
+  assert.ok(
+    Math.abs(rate - 0.25) < 0.02,
+    `always-leftmost scored ${(rate * 100).toFixed(1)}% — chance is 25%`,
+  )
+})
+
+test("the CORE's three orbs are shuffled by the same rule", () => {
+  const r = rng(7)
+  const N = 30_000
+  const counts = [0, 0, 0]
+  for (let i = 0; i < N; i++) {
+    const seat = shuffleWithAnswer(Q, 3, r).indexOf(Q.answer)
+    counts[seat] = (counts[seat] as number) + 1
+  }
+  counts.forEach((c, i) => {
+    assert.ok(
+      Math.abs(c - N / 3) / (N / 3) < 0.04,
+      `seat ${i} of three took the answer ${((c / N) * 100).toFixed(1)}% of the time`,
+    )
+  })
+})
+
+test("every candidate is a real candidate — the answer is present exactly once", () => {
+  const r = rng(5)
+  for (let i = 0; i < 500; i++) {
+    const opts = shuffleWithAnswer(Q, 4, r)
+    assert.equal(opts.length, 4)
+    assert.equal(opts.filter((o) => o === Q.answer).length, 1)
+    assert.equal(new Set(opts).size, 4, "a distractor was duplicated")
+  }
+})
+
+test("a question with fewer distractors than seats still shuffles", () => {
+  const thin: Question = { ...Q, distractors: ["75"] }
+  const r = rng(3)
+  const counts = [0, 0]
+  for (let i = 0; i < 10_000; i++) {
+    counts[shuffleWithAnswer(thin, 4, r).indexOf(thin.answer)] += 1
+  }
+  assert.ok(Math.abs((counts[0] as number) - 5000) < 300, `two seats went ${counts.join("/")}`)
+})

--- a/dynawalla/games/horde/src/ui/shuffle.ts
+++ b/dynawalla/games/horde/src/ui/shuffle.ts
@@ -1,0 +1,41 @@
+/**
+ * Where the answer goes, and what nothing may say about it.
+ *
+ * COUNTERPOISE shipped with the answer sitting in a predictable place and a bot
+ * that did no arithmetic at all scored 97.2%. Any surface here that lays out
+ * candidates — the RIFT's four buttons, the SEALED CACHE's orbs, the CORE's
+ * three world orbs — has to be free of that, in two separate ways:
+ *
+ *   1. **Position must be uniform.** This function is the only shuffle any of
+ *      them uses, and `shuffle.test.ts` measures the distribution rather than
+ *      trusting the algorithm's name.
+ *
+ *   2. **Nothing may look different.** A uniform shuffle is worthless if one
+ *      seat is painted. The RIFT used to call `.focus()` on the FIRST answer
+ *      button as soon as the panel opened, which paints a focus ring on it: a
+ *      founder playtest reported "the answer on the left for the rift appears
+ *      highlighted". It was the leftmost seat, not the correct answer — the
+ *      code never consulted `correct` — so it was a tell about position and not
+ *      a giveaway of the answer. It is still a tell, and it is gone.
+ */
+
+import type { Question } from "../contract.ts"
+
+/**
+ * The answer and up to `count - 1` distractors, in a uniformly random order.
+ *
+ * `rng` is injected so the distribution can be measured; the game passes
+ * nothing and gets `Math.random`.
+ */
+export function shuffleWithAnswer(q: Question, count = 4, rng: () => number = Math.random): string[] {
+  const opts = [q.answer, ...q.distractors.slice(0, count - 1)]
+  // Fisher-Yates, downward. `j` must be able to equal `i`, or position 0 is
+  // starved and the answer drifts to the right — the exact defect class above.
+  for (let i = opts.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    const t = opts[i] as string
+    opts[i] = opts[j] as string
+    opts[j] = t
+  }
+  return opts
+}


### PR DESCRIPTION
A founder playtest of DEEPSWARM, opening with *"we love this game"*. Six of the seven items are here; the seventh he asked for explicitly and is deliberately **not built**.

Two of them stopped the game being a maths game at all.

---

## 1. The answers could not be reached — the game could not be answered

> *"when the 3 answers show up, you can't swim into them, they stay equidistant from you so you can never get them"*

`questTick` recomputed every orb's position **from the player's current position, every frame**:

```ts
o.ang += dt * 0.42
o.x = this.px + Math.cos(o.ang) * 172
o.y = this.py + Math.sin(o.ang) * 172
```

An orb was an offset bolted to the diver's hip, not a point in the world. Swimming at one moved it. The strike test then asked whether the diver's **velocity lead** had closed to 40px — `this.px + this.pvx * 0.06`, which is 12.3px at the base speed of 205 px/s. Closing the remaining 132px on lead alone needs **2200 px/s**; the best build in the game is 205 + 18 per CURRENT card.

**Measured** against the shipped code, driving the diver straight at an orb with a perfect stick:

| t | before | after |
|---|---|---|
| 0.00s | 172.0px | 150.0px |
| 0.25s | — | 131.0px |
| 0.50s | 160.1px | 99.3px |
| 0.75s | 159.8px | 65.7px |
| 0.77s | 159.8px | **struck** |
| 1.00s → 5.00s | 159.8px, every sample, forever | — |

Every CORE in every run timed out.

**Fix.** `src/game/orbs.ts` fixes the ring in the world where the CORE opened. `advance(orbs, dt)` **is not given the player** — the signature is the guarantee — and the ring turns about its own anchor at 0.22 rad/s, so "three numbered balls circle you" survives. Strike radius 52px (44 is the platform touch minimum). The prompt and the closing iris moved onto the CORE's anchor too, so the whole surface stops travelling with the diver.

## 2. Down was up

> *"up and down are reversed 'like a flight simulator', flip to normal"*

Not a deliberate `-dy`, and not one input path. `core/input.ts` reports the stick in CSS pixels where **+y is DOWN**; both vertex shaders project

```glsl
gl_Position = vec4((world.x - u_cam.x) * u_cam.z, (world.y - u_cam.y) * u_cam.w, 0.0, 1.0);
```

into a clip space where **+y is UP**. `movePlayer` fed one straight into the other. Pointer, touch and keyboard all converge on `stick.y` inside `Input.update` before anything reads it, so all three were inverted together and one conversion at the boundary fixes all three. There is no gamepad path.

`core/motion.ts` owns the change of basis. Three more symptoms of the same missing sign went with it:

- `drawStick` used `camY - hh + originY * hpp` — the world's **bottom** edge as the screen's top — so the thumb ring drew at the reflected height;
- damage numbers launched at `vy = -96` with `vy += 190 * dt`: spat downward, then arced up;
- a WARDEN's health arc drew at `y - rad * 2.2`, i.e. **underneath it** (see §6).

## 3. The highlighted rift answer: positional, not correctness

> *"the answer on the left for the rift appears highlighted"*

He read it exactly right, and it is the better of the two possibilities. **It tracked position, never correctness.** `showRift` called `.focus()` on the first button it built and the UA paints a ring on a focused button; `correct` was never consulted anywhere in that path.

The panel takes focus instead (`tabIndex = -1`), so a keyboard player still Tabs straight into the row, and `.hz-answer:focus-visible` keeps the ring for keyboard arrival while programmatic focus paints nothing.

`ui/shuffle.ts` is now the single shuffle for the RIFT, the SEALED CACHE and the CORE, with the seat distribution **measured** rather than assumed — COUNTERPOISE shipped a positional tell and a bot scored 97.2% without arithmetic.

## 4. Question variety: ten rungs out of sixty

> *"more variable questions ... single and triple digit (adapting to user level) and some carrying .. and why not subtraction, multiplication and division sometimes"*

The operation is the host's. `domain` on `next()` is a cosmetic label and the host's own comment says so. What decides whether a child sees `7 + 8`, `284 + 157` or `6 × 7` is **where on the ladder** the question is drawn from — and the shipped ladder is 60 rungs.

DEEPSWARM spoke the host's **integer** scale, where `toUnit` maps `1..10` onto 59 rungs at a stride of 6.5. The only ten rungs it could name:

```
 1 →  0  add-within-ten L0          6 → 33  divide-exact L0
 2 →  7  subtract-within-ten L3     7 → 39  zero-in-the-quotient L0
 3 → 13  add-across-ten L2          8 → 46  times-two-digit L1
 4 → 20  tables-within-five L3      9 → 52  subtract-short-subtrahend L1
 5 → 26  subtract-no-regroup L2    10 → 59  subtract-across-zero L2
```

The other **fifty were unreachable by construction** — including rungs 18/19 (`column.add-no-regroup`, the beginning of two-digit work) and 29/32/40 (`regroup.add-multidigit`, the whole of carrying). A nine-minute run climbs about five of these steps, so a child met five questions' worth of the curriculum, over and over.

It now speaks the **fraction** scale (`toUnit` reads `v < 1` as a ladder position, used as is), which addresses all sixty rungs, and asks across a **band six rungs wide** instead of at a point.

**The mix, measured over 600 simulated nine-minute runs against the app's real `ladder()`:**

| | before | after |
|---|---|---|
| distinct rungs one run serves | 5.84 | **9.60** |
| distinct rungs across 600 runs | 9 / 60 | **46 / 60** |
| distinct skills reached | 9 / 18 | **17 / 18** |
| carrying (`regroup.*`) | 1 skill | **4 skills** |
| multiplication | 2 skills | **3 skills** |
| division | 2 skills | **3 skills** |

`difficulty()` is untouched — `1 + floor(solved / 2)`, moved by right answers and nothing else (#656). It is now the **top** of the band, and `maxDifficulty` pins the same ceiling at the host. Adapting **down**: each recent miss (window of 5) brings the band down 4 rungs, capped at half the edge's own height — without that cap, 36% of every early run collapsed onto `0 + 1`, twice what the old code did. The earned step never falls, so recovery is immediate rather than re-earned. A timeout is not a miss.

Two scales are sent on purpose, and both are what `toUnit` reads. `maxDifficulty` goes on the **integer** scale because `items.ts` FLOORS the cap where it ROUNDS the request, so a fraction strictly below 1 can never admit the top rung — the host's own note says to speak the ladder scale when you need to be exact at the top.

## 5. Health readout: it existed, and it was under the home indicator

He asked *"should it show the health somewhere?"* — the question you ask about a readout you did not find. There was one: a 12px hairline with 10px near-black lettering that vanished as the fill receded, so the harder you were being hit the harder your health was to read. It is now 22px, with lettering that survives an empty bar and a white-hot state under 25%.

Underneath that, something worse. `layout.ts` swore the CSS and the tests could not drift, **and they had.** Every offset is measured from the safe edge and the stylesheet spelled that `env(safe-area-inset-*)` — which resolves to **zero inside a pack**, because a pack is a cross-origin child and `env()` belongs to the top-level browsing context. `packs/shared/game-chrome/insets.ts` says so in as many words; nothing in this game had read it.

So on a notched phone the host's chevron sat at y=60 and the clock row that `hudRects` places at y=110 was painted at **y=63 — inside it**, while `layout.test.ts` passed, because the test was handed real insets and the browser was not. That is the audit's three readouts: the clock row, the fps readout, and the life bar under the home indicator.

The host's measured insets now reach the stylesheet as `--hz-safe-*` (with `env()` kept as the fallback for `npm run dev`, where the game is top-level and `env()` is real), and `watchChromeVars` keeps them current through a rotation. The life bar joins `hudRects` and is asserted at every viewport.

## 6. Wardens — the rift was never the route

> *"is there no way to damage the wardens other than dying and getting 'the rift' question?"*

**There is, and the rift has nothing to do with it.** `damage()` subtracts hp from any enemy including a WARDEN; every weapon hurts one exactly as it hurts anything else. The rift is a revive, not a boss mechanic.

It read as invulnerable for three reasons:

1. **Its health arc drew underneath it.** `y - rad * 2.2` in a world where +y is up, so a WARDEN's only damage feedback rendered behind its own body glow. Fixed here, with a dark track behind it so an untouched WARDEN reads as full rather than as nothing.
2. **The damage numbers flew into the floor** — same sign, §2.
3. **The one thing that visibly hurts a WARDEN could not be obtained.** OVERCHARGE — 2× fire rate, 1.5× damage, nine seconds — is granted by a *correct CORE answer*, and §1 made that impossible. The maths-to-damage link existed and was unreachable. It works again.

The remaining honest problem is the **first** WARDEN: 42s in, `620 × hpScale(0.7)` ≈ 812 hp, against a starting SPLINTER's 9.7 dps — 84 seconds of perfect focus while it spawns five minions every 3.6s. By minute five the build has caught up. **Proposal, not built:** either delay the first WARDEN past the second CORE so the child can arrive with OVERCHARGE, or drop its base hp to ~380. Founder's call.

## 7. More weapons and enemies — not built

> *"we really like all of the weapons and features and different kinds of enemies. We could even expand this catalog further"*

He said *could*, so it is not here. For whoever does it:

- **An enemy** is one entry in the `ENEMIES` array in `src/game/enemies.ts` (`hp`, `speed`, `radius`, `dps`, `xp`, `shape`, `col`, `behaviour`, `from` = the minute it starts appearing, `weight` = spawn share, `massInv`, `spin`, `elite`). `E_INDEX` derives from it. A **new behaviour** additionally needs a `BEHAVIOUR` constant and a `case` in the `switch` in `updateEnemies`. A **new silhouette** needs a shape id in `SHAPE` and an SDF branch in `SPRITE_FS` — the game ships no textures.
- **A weapon** is one entry in `BASE` in `src/game/loadout.ts` plus a `case` in `fireWeapons` in `game.ts`, and it must be added to `WEAPON_BLURB` and `WEAPON_HUE` or the cards will not draw.

Three things are hardcoded and would have to move first:

- `rollCards` hardcodes the three-card offer and `MAX_WEAPONS = 5`;
- `pickType(minutes)` reads `from`/`weight` but the WARDEN is spawned by a separate `wardenAt` timer in `director`, not by the table — a second elite has nowhere to go without an elite schedule;
- `E_INDEX.darter` / `E_INDEX.drifter` are named literally inside `BEHAVIOUR.WARDEN` and `BEHAVIOUR.SPLIT`, so those two spawn lists are not data.

---

## Tests

66 pass, run 5×. **Every fix was removed and the failure quoted**, because a test that does not fail without the fix proves nothing:

| fix removed | test that failed |
|---|---|
| `drive()` returns `+stickY` (the shipped bug) | `stick down moved the diver from screen y=422 to y=328.8 — that is UP the screen` |
| `SCREEN_Y_TO_WORLD = 1` | `a positive (downward) stick.y must drive world −y` |
| orbs re-pinned to the player each frame | `after 1s of swimming the answer was still 147.7px away (it started 150.0px away) — the child cannot reach it` |
| — and | `Expected "actual" to be strictly unequal to: null` (never reached in the thinking window) |
| band removed, fraction scale kept | `the band used steps {0}` |
| whole change reverted to the integer scale | `a run reaches far more of the curriculum than ten rungs of sixty` + 8 more |
| `DESCENT_CEILING` removed | `36% of every question was the easiest rung in the product` |
| naive `maxDifficulty` (no half-rung) | `a run at the top of the ladder never saw rung 59; highest was 58` |
| miss-drop removed | `a child who starts missing is asked easier questions, within one question` |
| `applySafeVars` writes nothing | `the safe area reaches the stylesheet as numbers, not as env()` + 2 more |
| life bar back to 12px | `the life bar is 12px tall — that is a hairline, not a readout` |
| shuffle starved of seat 0 | `the answer landed in seat 0 0.0% of the time, not 25% — a bot could learn seat 0` |

**What is NOT tested, stated plainly.** `Game` needs WebGL2, `AudioContext`, `ResizeObserver` and a DOM, and there is no headless mount. So:

- **That the GPU agrees that world +y is up** is a fact about two GLSL strings. There is no WebGL in Node and no test here asserts it; it was verified by reading `SPRITE_VS` and `GLYPH_VS`, and a change to either must be checked on a device. What *is* tested is that the input and the screen/world layout agree with each other.
- **That the rift's focus ring is gone** is a DOM fact — no jsdom in this pack. The shuffle's *uniformity* is measured; the focus change is not. Needs a device or a browser.
- **The stylesheet itself** cannot be asserted about. The tests hold the numbers `applyChromeVars` writes and the rects `hudRects` reports; that the CSS reads the same `var()` names is by inspection.

**Needs a device:** the joystick ring landing under the thumb, damage numbers rising, the WARDEN health bar reading as full when untouched, the life bar clearing a real home indicator, and the rift answers looking identical on WebKit.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
