### PR TITLE
fix(dynawalla/games/polarity): eight characters was never measured, and a rung it cannot draw is a Bearer that asks nothing

### DIFF
--- a/dynawalla/games/polarity/src/contract.ts
+++ b/dynawalla/games/polarity/src/contract.ts
@@ -16,11 +16,52 @@ export type Question = {
   difficulty: number; // 0..1
 };
 
+/**
+ * What POLARITY asks for when it asks for a question.
+ *
+ * Field-for-field a subset of `packs/shared/game-host`'s `DifficultyRequest`,
+ * which is the object the real host reads — so this stays assignable and the
+ * swap stays a one-line import change.
+ *
+ * **On the scale.** The host reads a value below 1 as a 0..1 fraction and a
+ * value from 1 to 10 as a ladder index, which makes exactly one number
+ * ambiguous — `1` — and it resolves it as the BOTTOM of the ladder. POLARITY
+ * reaches a difficulty of exactly 1 after fifteen strata and means the top, so
+ * it speaks the ladder scale on both fields; see `ladderScale` in `seal.ts`.
+ */
+export type Ask = {
+  domain?: string;
+  difficulty?: number;
+  /**
+   * A ceiling on the same scale. The stream never goes above it.
+   *
+   * This is how a pack that cannot DRAW a rung tells the host, instead of
+   * declining item after item from a rung the host will keep serving. Declining
+   * is per-item and the host serves by rung, so without this a level whose every
+   * item is unprintable is not a graceful degradation — it is a Seal Bearer that
+   * asks nothing, forever, and the child at the top of the ladder is the one it
+   * happens to.
+   */
+  maxDifficulty?: number;
+};
+
 export type Host = {
-  next(opts?: { domain?: string; difficulty?: number }): Question;
+  next(opts?: Ask): Question;
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void;
   prefersReducedMotion(): boolean;
+  /**
+   * Throw away questions prefetched at a difficulty the game has since moved
+   * off. Optional and feature-detected, exactly as `trebuchet` and `siege` do
+   * with their own host extensions: the stub host has no pool to flush and an
+   * older host may not have the method.
+   *
+   * A lowered ceiling needs it. The pool holds up to sixty-four questions and
+   * they were all drawn from the rung that has just been ruled out, so without
+   * a flush the ceiling takes sixty-four questions to arrive — which for a
+   * Bearer every twenty-six seconds is most of an afternoon.
+   */
+  flush?(): void;
 };
 
 export function mount(_el: HTMLElement, _host: Host): { unmount(): void } {

--- a/dynawalla/games/polarity/src/core/labels.test.ts
+++ b/dynawalla/games/polarity/src/core/labels.test.ts
@@ -4,12 +4,22 @@ import assert from "node:assert/strict";
 import {
   LABEL_ASPECT,
   LABEL_CAPACITY,
+  LABEL_CAP_RATIO,
+  LABEL_CELL_H,
+  LABEL_COLS,
+  LABEL_ROWS,
+  LABEL_EM,
   LABEL_FAULT,
+  LABEL_INK_W,
+  LABEL_MAX_CHARS,
+  LABEL_MIN_ADVANCE_CAPS,
+  LABEL_MIN_ADVANCE_EM,
   LabelBook,
   isPrintable,
+  labelAdvanceEm,
   labelText,
 } from "./labels.ts";
-import { BULLET, HALF_W } from "../game/constants.ts";
+import { BULLET, HALF_W, MAX_HALF_H, MIN_HALF_H, ORB_SPREAD } from "../game/constants.ts";
 import { orbValues } from "../game/seal.ts";
 import type { Question } from "../contract.ts";
 // The REAL stream. `ladder()`, `choicesFor()` and `answerText()` are the host's
@@ -195,16 +205,102 @@ test("a frame that wants too many numerals gets a question mark, not a swap", ()
 });
 
 test("a wide numeral still fits its own orb's lane", () => {
-  // Cells got wider so a four-digit answer keeps its glyph HEIGHT instead of
-  // being squeezed flat. That only helps if the wide quad still fits the slot an
-  // orb is given: four orbs share `(HALF_W - 12) * 2` of playfield, and the
-  // renderer boosts label size by 1.18 on a narrow phone.
-  const lane = ((HALF_W - 12) * 2) / 4;
+  // THE constraint on how long an answer POLARITY can print. Not the atlas and
+  // not the texture: four orbs share `ORB_SPREAD` of the hundred-unit playfield,
+  // the label drawn over one is `size * LABEL_ASPECT` wide, and the renderer
+  // boosts label size by 1.18 on a narrow phone. Two labels that overlap are
+  // worse than one that is condensed, so this is what `LABEL_ASPECT` is capped
+  // by — and through it, `LABEL_MAX_CHARS`.
+  const lane = ORB_SPREAD / 4;
   const widest = BULLET.orbR * 1.35 * LABEL_ASPECT * 1.18;
   assert.ok(
     widest < lane,
     `a numeral is ${widest.toFixed(1)} wide in a ${lane.toFixed(1)} lane — orbs would collide`,
   );
+  // And the outermost orb's numeral stays on the field. Its centre sits at
+  // three-eighths of the spread, and the ink is `LABEL_INK_W / (LABEL_CELL_H *
+  // LABEL_ASPECT)` of the quad.
+  const inkHalf = (widest * (LABEL_INK_W / (LABEL_CELL_H * LABEL_ASPECT))) / 2;
+  const edge = (ORB_SPREAD * 3) / 8 + inkHalf;
+  assert.ok(edge < HALF_W, `the outer numeral reaches ${edge.toFixed(1)} of ${String(HALF_W)}`);
+});
+
+test("the atlas is a whole number of texels wide on every tier, and fits a 2048 texture", () => {
+  // The shader addresses a tile as a fraction of `uGrid`, so a cell width the
+  // canvas has to round is a cell that samples its neighbour — a silent defect
+  // that reads as a font bug. And 2048 is the value WebGL guarantees for
+  // `MAX_TEXTURE_SIZE`, which is the ceiling on BOTH dimensions: the old atlas
+  // was 2048 × 768, already at it sideways, which is why the cell got its extra
+  // width from a squarer grid rather than from a bigger texture.
+  for (const cellPx of [96, 128]) {
+    const cellW = cellPx * LABEL_ASPECT;
+    assert.ok(Number.isInteger(cellW), `a ${String(cellPx)}px cell is ${String(cellW)} texels wide`);
+    const texW = LABEL_COLS * cellW;
+    const texH = LABEL_ROWS * cellPx;
+    assert.ok(texW <= 2048 && texH <= 2048, `the atlas is ${String(texW)} × ${String(texH)}`);
+  }
+});
+
+test("the longest numeral is derived from the lane, and is not a number somebody typed", () => {
+  // `LABEL_MAX_CHARS = 8` used to be a constant whose stated reason — that eight
+  // characters "still fits the cell without squeezing" — was false: eight at
+  // `LABEL_EM` measure about 365 design units against what was then a 232-unit
+  // box, so the widest numeral the old constant permitted was already squeezed
+  // to about 0.64 and nothing said so. The budget is the ratio now, and the
+  // character count falls out of it.
+  assert.ok(
+    labelAdvanceEm(LABEL_MAX_CHARS) >= LABEL_MIN_ADVANCE_EM,
+    `${String(LABEL_MAX_CHARS)} characters get ${labelAdvanceEm(LABEL_MAX_CHARS).toFixed(4)} em`,
+  );
+  assert.ok(
+    labelAdvanceEm(LABEL_MAX_CHARS + 1) < LABEL_MIN_ADVANCE_EM,
+    `${String(LABEL_MAX_CHARS + 1)} characters would also have fitted — the cap is not the geometry`,
+  );
+  // `48,826 × 82,726` is the program's stated ceiling and ten characters wide.
+  assert.ok(
+    LABEL_MAX_CHARS >= 10,
+    `the widest answer the curriculum reaches is ten characters and this game prints ${String(LABEL_MAX_CHARS)}`,
+  );
+});
+
+test("the longest numeral clears the canon's cap-height gate on every viewport", () => {
+  // `docs/catalog/arcade-canon.json`, on numerals carried by moving objects —
+  // which is exactly what an orb is: "minimum 22 rpx cap-height at the moment of
+  // decision … This is a hard gate, not a style note." One rpx is a thousand-
+  // and-eightieth of the short edge in physical pixels, so a length in rpx is
+  // `cssPx * 1080 / shortEdgeCss` and the device pixel ratio cancels out of it.
+  //
+  // Computed from POLARITY's own constants across the fleet rather than argued.
+  // Type size does NOT depend on how long the numeral is — that is the whole
+  // point of fitting a numeral to a box rather than shrinking it — so this holds
+  // at `LABEL_MAX_CHARS` exactly as it does at one digit.
+  const viewports = [
+    { w: 360, h: 640, what: "the narrowest phone, portrait" },
+    { w: 390, h: 844, what: "a tall phone, portrait" },
+    { w: 640, h: 360, what: "a phone, landscape" },
+    { w: 834, h: 1112, what: "a tablet, portrait" },
+    { w: 1112, h: 834, what: "a tablet, landscape" },
+  ];
+  for (const { w, h, what } of viewports) {
+    const halfH = Math.min(MAX_HALF_H, Math.max(MIN_HALF_H, (HALF_W * h) / w));
+    const scale = Math.min(w / (2 * HALF_W), h / (2 * halfH));
+    const boost = w < 520 ? 1.18 : 1;
+    const quadH = BULLET.orbR * 1.35 * boost * scale; // css px
+    const typePx = (LABEL_EM / LABEL_CELL_H) * quadH;
+    const rpx = (css: number): number => (css * 1080) / Math.min(w, h);
+    assert.ok(
+      rpx(typePx * LABEL_CAP_RATIO) >= 22,
+      `${what}: cap height is ${rpx(typePx * LABEL_CAP_RATIO).toFixed(1)} rpx, under the canon's 22`,
+    );
+    // And what LENGTH costs is advance, which is the floor `LABEL_MAX_CHARS` is
+    // derived from — restated here in the canon's own units so the two numbers
+    // can be read against each other.
+    const advanceRpx = rpx(labelAdvanceEm(LABEL_MAX_CHARS) * typePx);
+    assert.ok(
+      advanceRpx >= 22 * LABEL_MIN_ADVANCE_CAPS,
+      `${what}: a digit gets ${advanceRpx.toFixed(1)} rpx of width`,
+    );
+  }
 });
 
 test("the shipping grid is never asked for more numerals in a frame than it holds", () => {

--- a/dynawalla/games/polarity/src/core/labels.ts
+++ b/dynawalla/games/polarity/src/core/labels.ts
@@ -15,25 +15,36 @@
  * FOUR blank glowing discs in front of the child, with no error and no warning.
  * A child cannot choose between four unlabelled circles.
  *
- * So tiles are claimed on demand instead. Any finite integer prints, whatever
- * its magnitude, and a value that is somehow not one prints `?` — loud in the
- * console and visible on the field, because the one thing a numeral must never
- * be is absent.
+ * So tiles are claimed on demand instead. Any finite integer up to
+ * `LABEL_MAX_CHARS` prints, whatever its magnitude, and a value that is somehow
+ * not an integer prints `?` — loud in the console and visible on the field,
+ * because the one thing a numeral must never be is absent.
+ *
+ * **There is still a width, and it is now derived rather than typed.** A
+ * numeral cannot be narrower than half its own cap height and still be read, and
+ * the width it has is the orb's lane — see `LABEL_ASPECT` and
+ * `LABEL_MIN_ADVANCE_CAPS`. What that budget refuses, `seal.ts` turns into a
+ * ceiling on the whole stream rather than a refusal per item, because a rung
+ * whose every answer is too wide is a Seal Bearer that asks nothing.
  */
 
 import { MINUS } from "../math/signed.ts";
 
 /**
- * The grid. 48 cells: 47 claimable and one reserved.
+ * The grid. 49 cells: 48 claimable and one reserved.
  *
  * The playfield's entire numeric vocabulary in one frame is chaff at ±2…9,
  * charge at ±2…9, the float texts they leave behind (a subset of those), four
  * orbs and one lock — about two dozen distinct values, measured in
  * `labels.test.ts`. Twice that is headroom; more than that is texture nobody
  * looks at, and the cell has to stay big enough to read.
+ *
+ * It was 8 × 6 while the cell was 2:1. The cell is `LABEL_ASPECT`:1 now and the
+ * texture cannot grow sideways — see that constant — so the grid is squarer at
+ * the same claimable count.
  */
-export const LABEL_COLS = 8;
-export const LABEL_ROWS = 6;
+export const LABEL_COLS = 7;
+export const LABEL_ROWS = 7;
 export const LABEL_CAPACITY = LABEL_COLS * LABEL_ROWS;
 
 /**
@@ -49,21 +60,104 @@ export const LABEL_CAPACITY = LABEL_COLS * LABEL_ROWS;
 export const LABEL_FAULT_TILE = LABEL_CAPACITY - 1;
 
 /**
- * Cells are twice as wide as they are tall, so a four-digit answer gets ROOM
- * rather than being squeezed to a smear at the same height as a `7`. The quad
- * the shader draws is `size * LABEL_ASPECT` wide by `size` tall, and a short
- * numeral simply leaves transparent margin either side.
+ * Cells are wider than they are tall, so a long answer gets ROOM rather than
+ * being squeezed to a smear at the same height as a `7`. The quad the shader
+ * draws is `size * LABEL_ASPECT` wide by `size` tall, and a short numeral simply
+ * leaves transparent margin either side.
+ *
+ * **Why 2.25 and not more.** Not the texture: the atlas is `LABEL_COLS *
+ * cellPx * LABEL_ASPECT` wide, which at 2.25 and a 128px cell is 2016 — under
+ * 2048, the value WebGL guarantees for `MAX_TEXTURE_SIZE` and therefore the
+ * hard ceiling on this dimension. The binding constraint is the ORB'S LANE.
+ * Four orbs share `ORB_SPREAD` of the hundred-unit playfield, so each gets
+ * `ORB_SPREAD / 4`; the label drawn over one is `size * LABEL_ASPECT` wide, and
+ * two labels that overlap are worse than one that is condensed. See
+ * `labels.test.ts`, which holds the two numbers against each other.
  */
-export const LABEL_ASPECT = 2;
+export const LABEL_ASPECT = 2.25;
+
+/** The cell's height in design units. `atlas.ts` scales the real cell to this. */
+export const LABEL_CELL_H = 128;
+
+/** The numeral's type size in design units — its HEIGHT, whatever its length. */
+export const LABEL_EM = 76;
 
 /**
- * The longest numeral a tile is expected to hold. Evidence, not a guess: the
- * widest value the shipping ladder emits across 44,000 measured orbs is
- * `998232` — six characters — and the longest a mal-rule or near-miss
- * distractor pushes it to is seven. Eight leaves a character of headroom and
- * still fits the cell without squeezing.
+ * Total horizontal padding inside a cell, design units, so glyphs never clip.
+ *
+ * Ten a side, and the number it has to clear is the baked contrast rim: the
+ * painter strokes the numeral at `lineWidth 13` before filling it, which puts
+ * ink 6.5 design units outside the glyph outline. Ten leaves three and a half
+ * units of slack on top of that. It was 24 — a round number nothing derived —
+ * and the four units are the difference between ten characters and nine.
  */
-export const LABEL_MAX_CHARS = 8;
+export const LABEL_CELL_MARGIN = 20;
+
+/** The box a numeral is fitted into, design units wide. */
+export const LABEL_INK_W = LABEL_CELL_H * LABEL_ASPECT - LABEL_CELL_MARGIN;
+
+/**
+ * What one character gets, in ems of the numeral's own height, when a numeral
+ * of `chars` characters is fitted to the cell.
+ *
+ * This is the number that decides legibility, and it is font-independent:
+ * anything wider than the box is squeezed to exactly fill it (`atlas.ts`), so a
+ * long numeral's advance is the box divided by the character count whatever
+ * face the device resolves. Height never moves — every numeral on the field is
+ * drawn at the same `LABEL_EM`.
+ *
+ * For a numeral short enough not to be squeezed this is an upper bound: it gets
+ * the face's own advance, which is smaller.
+ */
+export function labelAdvanceEm(chars: number): number {
+  return LABEL_INK_W / (LABEL_EM * Math.max(1, chars));
+}
+
+/** Cap height as a fraction of the type size. Conservative for a geometric sans. */
+export const LABEL_CAP_RATIO = 0.7;
+
+/**
+ * How narrow a digit is allowed to get, as a fraction of its own cap height.
+ *
+ * A half. Condensed tabular faces bottom out at about 0.45 to 0.5 of cap
+ * height — below that the counters of `8`, `6` and `0` close and a child
+ * reading at speed is guessing — and an unsqueezed face runs about 0.85. So
+ * this is the narrow end of legible, deliberately, and it is stated against the
+ * cap height rather than in pixels because the one hard gate this program has
+ * for a numeral on a moving object is a cap-height gate:
+ * `docs/catalog/arcade-canon.json` demands 22 rpx "at the moment of decision".
+ * `labels.test.ts` computes the cap height across the fleet from these
+ * constants and holds it to that.
+ */
+export const LABEL_MIN_ADVANCE_CAPS = 0.5;
+
+/**
+ * The same floor in ems, which is the unit the cell is measured in.
+ *
+ * **What it replaces.** `LABEL_MAX_CHARS = 8`, whose stated reason was that
+ * eight "still fits the cell without squeezing". It does not: eight characters
+ * at `LABEL_EM` measure about 365 design units against what was then a 232-unit
+ * box, so the eight-character numeral the old constant permitted was already
+ * squeezed to roughly 0.64 of its natural width — 0.38 em of advance, 0.55 of
+ * cap height. Nothing measured that, nothing enforced it, and no shipped item
+ * ever reached it: the widest the ladder emitted was six characters. The budget
+ * is stated as the ratio it always really was, and the character count is
+ * derived from it rather than chosen.
+ */
+export const LABEL_MIN_ADVANCE_EM = LABEL_MIN_ADVANCE_CAPS * LABEL_CAP_RATIO;
+
+/**
+ * The longest numeral a tile will hold — DERIVED, not chosen.
+ *
+ * The largest `n` for which `labelAdvanceEm(n) >= LABEL_MIN_ADVANCE_EM`, which
+ * at the shipping geometry is ten — by a margin of less than one percent. Ten
+ * characters is `48,826 × 82,726`, the widest answer the curriculum reaches and
+ * the ceiling this whole program is aimed at, and it is reached because the
+ * geometry allows it and not because anything was rounded in its favour: a
+ * later change to the cell, the margin or the aspect moves this number, and
+ * `labels.test.ts` asserts both that ten fits and that eleven does not.
+ */
+export const LABEL_MAX_CHARS = Math.floor(LABEL_INK_W / (LABEL_EM * LABEL_MIN_ADVANCE_EM));
 
 /** What a tile with nothing legible to print shows. Never blank. */
 export const LABEL_FAULT = "?";
@@ -82,10 +176,18 @@ export function labelText(v: number): string {
  * a reason to say no — only a value that is not a finite integer, or one so
  * long the cell could not hold it legibly, is refused, and both are refused out
  * loud where they happen.
+ *
+ * **Why `maxChars` is a parameter.** The thing this refusal exists to protect
+ * against is a curriculum WIDER than the one that ships, and today's ships
+ * inside the budget with nothing to spare on either side — so a test that
+ * cannot narrow the budget cannot exercise the refusal, or the ceiling built on
+ * top of it in `seal.ts`, until the day the curriculum has already broken.
+ * `game/ask.test.ts` narrows it and plays the real ladder through the real
+ * host; nothing in the game passes anything but the default.
  */
-export function isPrintable(v: number): boolean {
+export function isPrintable(v: number, maxChars: number = LABEL_MAX_CHARS): boolean {
   if (!Number.isInteger(v)) return false;
-  return labelText(v).length <= LABEL_MAX_CHARS;
+  return labelText(v).length <= maxChars;
 }
 
 /**

--- a/dynawalla/games/polarity/src/game/ask.test.ts
+++ b/dynawalla/games/polarity/src/game/ask.test.ts
@@ -1,0 +1,317 @@
+/**
+ * What POLARITY asks the host for, and what happens at the rung it cannot draw.
+ *
+ * Two failures live here, and the second is the one this file exists for.
+ *
+ * **The scale.** The host reads a request below 1 as a 0..1 fraction and 1..10
+ * as a ladder index, and resolves `1` — the one value both scales claim — as the
+ * BOTTOM. POLARITY sent `clamp(0.14 + stratum * 0.06, 0, 1)`, which reaches
+ * exactly 1 at stratum 15, and meant the top. So the single number this game was
+ * guaranteed to reach was the number that meant the opposite of what it wanted.
+ *
+ * **The soft-lock.** A pack that cannot print an answer must not offer it, and
+ * this one declines correctly and loudly. But declining is per-ITEM and the host
+ * serves by RUNG: ask again at the same difficulty and the same rung answers. So
+ * a level whose every item is too wide is not a graceful degradation — the
+ * Bearer refuses six times, cracks open having asked nothing, and the next one
+ * does the same, forever, for the child who has climbed highest. That is what
+ * `NUMERAL_WIDTH_BLOCKED_LEVELS` recorded, and `next({ maxDifficulty })` is the
+ * seam that ends it.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Ask, Host, Question } from "../contract.ts";
+import { LABEL_MAX_CHARS } from "../core/labels.ts";
+import { tierByName } from "../core/tier.ts";
+import { askShape, ladderScale, launchBoss, stepBoss } from "./seal.ts";
+import { startRun } from "./sim.ts";
+import type { Enemy } from "./types.ts";
+import { makeWorld, type World } from "./world.ts";
+
+/**
+ * A host that serves by RUNG, which is the whole point.
+ *
+ * The clamp rules are transcribed from `createItemService.next` in
+ * `dynawalla-app/src/packs/items.ts` — the request **rounds** to the nearest
+ * rung because a pack asking for 0.5 wants the middle, the ceiling **floors**
+ * because "the stream never goes above it" and rounding a cap can only round it
+ * up — and the scale rule from `toUnit` in `packs/shared/game-host`. Reproduced
+ * rather than imported because a game may not depend on the app; a transcription
+ * that drifts is caught by the next person to read either file, where not
+ * testing the rung behaviour at all is caught by nobody.
+ */
+type RungHost = { host: Host; asked: Question[]; flushed: { count: number } };
+
+function rungHost(answers: readonly string[], opts: { reserve?: number } = {}): RungHost {
+  const asked: Question[] = [];
+  const span = Math.max(1, answers.length - 1);
+  const flushed = { count: 0 };
+  let target = 0;
+  let ceiling = 1;
+  let reserve = opts.reserve ?? 0;
+  let n = 0;
+
+  const toUnit = (value: number): number => {
+    if (value < 1) return Math.max(0, value);
+    return Math.min(1, (value - 1) / 9);
+  };
+
+  const host: Host = {
+    next: (ask?: Ask) => {
+      if (ask?.maxDifficulty !== undefined) ceiling = toUnit(ask.maxDifficulty);
+      if (ask?.difficulty !== undefined) target = toUnit(ask.difficulty);
+      const cap = Math.floor(ceiling * span);
+      let index = Math.max(0, Math.min(span, cap, Math.round(target * span)));
+      // The reserve a flush leaves behind. `packs/shared/game-host` keeps the
+      // eight pooled questions closest to the new request rather than emptying
+      // the pool — "an empty pool is not a pause, it is a question with no id" —
+      // and if every one of them is above the ceiling it hands one over anyway,
+      // because `distance` says an over-ceiling question "is still an answer
+      // when nothing else does". So a ceiling can be answered by a rung above
+      // it, for a couple of questions, and that is not hypothetical.
+      if (reserve > 0) {
+        reserve--;
+        index = span;
+      }
+      const answer = answers[index] as string;
+      n++;
+      const q: Question = {
+        id: `rung${String(index)}-${String(n)}`,
+        prompt: `rung ${String(index)}`,
+        answer,
+        // Near-misses, so a rung whose answer is too wide has wrongs that are
+        // too wide as well — which is what a real generator does.
+        distractors: [String(Number(answer) + 1), String(Number(answer) + 2)],
+        domain: "add-sub",
+        // What the host reports back: where the rung it ACTUALLY used sits.
+        difficulty: index / span,
+      };
+      asked.push(q);
+      return q;
+    },
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => true,
+    flush: () => {
+      flushed.count++;
+      reserve = opts.reserve ?? 0;
+    },
+  };
+  return { host, asked, flushed };
+}
+
+/**
+ * A ladder whose answers grow one character a rung, past what POLARITY prints.
+ *
+ * A power of ten rather than a row of nines, so that the near-miss distractors
+ * `rungHost` builds are the same width as the answer they miss. `999…9 + 1`
+ * carries into an extra character, which would make a rung undrawable for a
+ * second, different reason (its wrongs will not print, so it is not a question)
+ * and would confuse what these tests are measuring — the real generators do not
+ * do that: five digits times five digits is at most ten characters and its
+ * mal-rules are smaller, not larger.
+ */
+function widthLadder(): string[] {
+  const out: string[] = [];
+  for (let chars = 2; chars <= LABEL_MAX_CHARS + 8; chars++) {
+    out.push("1" + "0".repeat(chars - 1));
+  }
+  return out;
+}
+
+function world(host: Host): World {
+  const w = makeWorld(host, tierByName("low"), 0x50147);
+  startRun(w);
+  return w;
+}
+
+/**
+ * Run `count` Seal Bearers through the ask, one at a time.
+ *
+ * `bearerCount` is reset each time so `launchBoss` never rolls a Warden — the
+ * Warden asks the curriculum nothing by design (`stepWarden`), so one in the
+ * sample would be a Bearer that "asked nothing" for the right reason and would
+ * make the assertions below mean nothing.
+ */
+function runBearers(w: World, count: number): void {
+  for (let i = 0; i < count; i++) {
+    w.bearerCount = 0;
+    w.enemyN = 0;
+    launchBoss(w);
+    const e = w.enemies[w.enemyN - 1] as Enemy;
+    for (let f = 0; f < 400 && e.phase === 0; f++) {
+      w.t += 1 / 60;
+      stepBoss(w, e, 1 / 60, 1);
+    }
+    assert.notEqual(e.phase, 0, "a Bearer never got as far as asking");
+    w.bossActive = false;
+    w.seal.state = "idle";
+  }
+}
+
+test("the top of the ladder is asked for as the TOP of the ladder", () => {
+  // `toUnit` reads 1 as the bottom. A game that reaches exactly 1 and means the
+  // top has to say so on the unambiguous scale, and this is that scale: every
+  // 0..1 position has exactly one spelling in 1..10 and none of them is
+  // reachable by the fraction reading.
+  assert.equal(ladderScale(0), 1);
+  assert.equal(ladderScale(1), 10);
+  assert.equal(ladderScale(0.5), 5.5);
+
+  const w = world(rungHost(["1", "2"]).host);
+  // Stratum 15 is where `clamp(0.14 + stratum * 0.06, 0, 1)` pins at 1 — about
+  // seven and a half minutes of good play.
+  w.stratum = 15;
+  const ask = askShape(w);
+  assert.equal(ask.difficulty, 10, "the hardest content in the product was asked for as the easiest");
+  // And the round trip is exact, so nothing else in the request moved: the
+  // opening question still asks for 0.14 of the ladder, as it always did.
+  w.stratum = 0;
+  assert.ok(Math.abs((askShape(w).difficulty - 1) / 9 - 0.14) < 1e-12);
+});
+
+test("a rung POLARITY cannot draw is asked once, not forever", () => {
+  // THE soft-lock. The host is standing on a rung whose every answer is wider
+  // than the numeral cell, and it will keep standing there — that is what
+  // serving by rung means — until the pack says otherwise.
+  const errors: string[] = [];
+  const real = console.error;
+  console.error = (...a: unknown[]) => errors.push(String(a[0]));
+  let w: World;
+  let handle: ReturnType<typeof rungHost>;
+  try {
+    handle = rungHost(widthLadder());
+    w = world(handle.host);
+    w.stratum = 40; // far past the top: the game is asking for the hardest rung
+    runBearers(w, 6);
+  } finally {
+    console.error = real;
+  }
+
+  assert.ok(
+    w.stats.asked > 0,
+    "six Seal Bearers arrived and not one of them asked a question — the child at the top of " +
+      "the ladder was served silence",
+  );
+  // Everything it did ask, it could draw.
+  for (const q of handle.asked.slice(-4)) {
+    assert.ok(
+      q.answer.length <= LABEL_MAX_CHARS,
+      `it settled on "${q.answer}", which is ${String(q.answer.length)} characters`,
+    );
+  }
+  // And it settled on the WIDEST rung it can draw, not on the bottom.
+  const last = handle.asked[handle.asked.length - 1] as Question;
+  assert.equal(
+    last.answer.length,
+    LABEL_MAX_CHARS,
+    `it fell back to ${String(last.answer.length)} characters when it can print ${String(LABEL_MAX_CHARS)}`,
+  );
+  assert.ok(w.drawCeiling !== null, "nothing was capped, so the ceiling did nothing");
+  assert.match(errors.join("\n"), /capping the stream/);
+});
+
+test("the ceiling is learned once and costs one Bearer, not one per Bearer", () => {
+  const real = console.error;
+  console.error = () => {};
+  let w: World;
+  let handle: ReturnType<typeof rungHost>;
+  try {
+    handle = rungHost(widthLadder());
+    w = world(handle.host);
+    w.stratum = 40;
+    // Two Bearers to walk the ceiling down — the first starves, because eight
+    // rungs of overshoot is more than `MAX_ASK_TRIES`, and that is the honest
+    // cost of learning a ceiling from a refusal.
+    runBearers(w, 2);
+    const afterSettling = handle.asked.length;
+    const askedWhileSettling = w.stats.asked;
+    runBearers(w, 5);
+    // Five more Bearers, five more questions, five host calls. No re-learning
+    // and no second starve: this is the difference between a ceiling and a
+    // per-item refusal.
+    assert.equal(
+      w.stats.asked - askedWhileSettling,
+      5,
+      "a later Bearer had to rediscover the ceiling",
+    );
+    assert.equal(
+      handle.asked.length - afterSettling,
+      5,
+      `the host was asked ${String(handle.asked.length - afterSettling)} times for five questions`,
+    );
+  } finally {
+    console.error = real;
+  }
+  assert.ok(w.drawCeiling !== null);
+});
+
+test("the ceiling only ever falls, and the pool is flushed when it does", () => {
+  const real = console.error;
+  console.error = () => {};
+  let w: World;
+  let handle: ReturnType<typeof rungHost>;
+  try {
+    handle = rungHost(widthLadder());
+    w = world(handle.host);
+    w.stratum = 40;
+    runBearers(w, 2);
+    const settled = w.drawCeiling;
+    assert.ok(settled !== null);
+    // A run that drops back down the strata must not lift the ceiling: what
+    // POLARITY can draw is a property of POLARITY.
+    w.stratum = 1;
+    runBearers(w, 2);
+    assert.ok((w.drawCeiling as number) <= settled, "the ceiling rose again");
+    assert.ok(handle.flushed.count > 0, "a ceiling landed sixty-four questions late");
+  } finally {
+    console.error = real;
+  }
+});
+
+test("a host with no ceiling to give is not made worse by asking for one", () => {
+  // The whole shipping ladder fits inside the numeral budget, so `capBelow`
+  // never fires in production and the request is pure overhead — it must
+  // therefore be harmless. A host that ignores `maxDifficulty` entirely (an
+  // older one, or the stub) still serves, and nothing is capped.
+  const answers = ["7", "42", "137", "3916"];
+  const handle = rungHost(answers);
+  const w = world(handle.host);
+  w.stratum = 20;
+  runBearers(w, 4);
+  assert.equal(w.stats.asked, 4);
+  assert.equal(w.drawCeiling, null, "a ladder this game can draw entirely was still capped");
+  assert.equal(handle.flushed.count, 0, "the pool was thrown away for nothing");
+});
+
+test("a ceiling is never raised by the stale question that outlived it", () => {
+  // The guard inside `capBelow`, and the reason it is not belt-and-braces: a
+  // flush leaves a reserve of up to eight pooled questions so the pool is never
+  // empty, and when all of them are above the new ceiling the host hands one
+  // over anyway. Read naively, that question's difficulty is a fresh piece of
+  // evidence and the ceiling follows it back UP — and then the next refusal
+  // walks it down again, forever, one Bearer at a time.
+  const real = console.error;
+  console.error = () => {};
+  let w: World;
+  try {
+    const handle = rungHost(widthLadder(), { reserve: 3 });
+    w = world(handle.host);
+    w.stratum = 40;
+    runBearers(w, 3);
+    const settled = w.drawCeiling;
+    assert.ok(settled !== null, "nothing was capped, so this proves nothing");
+    for (let i = 0; i < 6; i++) {
+      runBearers(w, 1);
+      assert.ok(
+        (w.drawCeiling as number) <= settled,
+        `the ceiling climbed back to ${String(w.drawCeiling)} from ${String(settled)}`,
+      );
+    }
+    assert.ok(w.stats.asked > 0, "the run stopped asking questions altogether");
+  } finally {
+    console.error = real;
+  }
+});

--- a/dynawalla/games/polarity/src/game/ask.test.ts
+++ b/dynawalla/games/polarity/src/game/ask.test.ts
@@ -315,3 +315,100 @@ test("a ceiling is never raised by the stale question that outlived it", () => {
     console.error = real;
   }
 });
+
+/**
+ * The dry pool must not be mistaken for a rung this game cannot draw.
+ *
+ * `orbValues` says no for two reasons and only one of them is the rung's. An
+ * unprintable ANSWER is a rung fact — the numeral budget is a constant, so every
+ * item from that rung is equally undrawable. **Too few distractors is an ITEM
+ * fact**, and capping on it ended the session.
+ *
+ * `packs/shared/game-host` answers an empty pool with
+ * `{ id: "", prompt: "", answer: "0", distractors: [], difficulty: 0 }`. That
+ * answer parses and prints perfectly; it simply yields one value. So one
+ * transient empty pool read as "difficulty 0 cannot be drawn", pinned the
+ * ceiling at 0 where the monotone guard made it unraisable, and `startRun`
+ * deliberately does not reset it — so every question for the rest of the mount
+ * was the easiest rung in the product. That is worse than the soft-lock this
+ * file exists to fix, because it is silent and it looks like adaptation.
+ *
+ * The pool runs dry for reasons that have nothing to do with POLARITY:
+ * `createItemService.next` has four `return null` paths and `warm()` swallows a
+ * throw with a `break`.
+ */
+test("one dry pool does not pin the run to the bottom rung for the rest of the mount", () => {
+  const real = console.error;
+  console.error = () => {};
+  try {
+    const handle = rungHost(["12", "34", "56", "78", "90"]);
+    let dry = 1;
+    const host: Host = {
+      ...handle.host,
+      next: (ask?: Ask): Question => {
+        if (dry > 0) {
+          dry -= 1;
+          // Byte-for-byte the sentinel at game-host/index.ts:681-684.
+          return { id: "", prompt: "", answer: "0", distractors: [], domain: "add", difficulty: 0 };
+        }
+        return handle.host.next(ask);
+      },
+    };
+    const w = world(host);
+    w.stratum = 12;
+    runBearers(w, 1);
+
+    assert.equal(
+      w.drawCeiling,
+      null,
+      `a dry pool capped the stream at ${String(w.drawCeiling)} — every question after this is the easiest rung in the product`,
+    );
+
+    const before = handle.asked.length;
+    runBearers(w, 4);
+    const after = handle.asked.slice(before);
+    assert.ok(after.length > 0, "the run stopped asking after the dry Bearer");
+    assert.ok(
+      after.some((q) => q.difficulty > 0),
+      `every rung served after the dry pool was the bottom one: ${after.map((q) => q.difficulty.toFixed(3)).join(", ")}`,
+    );
+  } finally {
+    console.error = real;
+  }
+});
+
+/**
+ * A difficulty that is not a number caps nothing.
+ *
+ * `clamp` is NaN-transparent, so a NaN difficulty used to set `drawCeiling` to
+ * NaN — which `readScale` discards as "not a difficulty", leaving the ceiling
+ * inert AND `drawCeiling <= capped` permanently false, so every later refusal
+ * re-logged and re-flushed for the life of the run.
+ */
+test("a NaN difficulty is not a ceiling", () => {
+  const real = console.error;
+  console.error = () => {};
+  try {
+    const handle = rungHost(["12", "34"]);
+    const wide = "1".repeat(LABEL_MAX_CHARS + 4);
+    const host: Host = {
+      ...handle.host,
+      next: (): Question => ({
+        id: "nan",
+        prompt: "?",
+        answer: wide,
+        distractors: [`${wide}2`, `${wide}3`],
+        domain: "add",
+        difficulty: Number.NaN,
+      }),
+    };
+    const w = world(host);
+    runBearers(w, 1);
+    assert.ok(
+      w.drawCeiling === null || Number.isFinite(w.drawCeiling),
+      `the ceiling is ${String(w.drawCeiling)}, which readScale discards while the monotone guard treats it as set`,
+    );
+  } finally {
+    console.error = real;
+  }
+});

--- a/dynawalla/games/polarity/src/game/constants.ts
+++ b/dynawalla/games/polarity/src/game/constants.ts
@@ -73,6 +73,23 @@ export const BULLET = {
   lanceR: 2.5,
 } as const;
 
+/**
+ * How wide a Seal Bearer scatters its four orbs, in playfield units.
+ *
+ * The lane a numeral is drawn in is a quarter of this, and it is the ONLY thing
+ * that limits how long an answer POLARITY can print — not the atlas, which is a
+ * resolution, and not the texture size, which the cell already sits under. Four
+ * labels `BULLET.orbR * 1.35 * LABEL_ASPECT` wide have to fit here without
+ * touching, and `core/labels.test.ts` asserts they do.
+ *
+ * It was `(HALF_W - 12) * 2`. The extra four units are what a ten-character
+ * answer costs, and they are free: the outermost orb sits at three-eighths of
+ * this from the centre — 31.5 rather than 28.5 — so its numeral's far edge lands
+ * at 40 of the 50 units the field has, and the weave clamp at `HALF_W - r` is
+ * nowhere near it.
+ */
+export const ORB_SPREAD = (HALF_W - 8) * 2;
+
 // --- enemies ----------------------------------------------------------------
 /** Enemy kinds. Same shape and the same reason as `BK`. */
 export const EK = {

--- a/dynawalla/games/polarity/src/game/seal.test.ts
+++ b/dynawalla/games/polarity/src/game/seal.test.ts
@@ -318,7 +318,11 @@ test("an item with an answer this game cannot print is declined, not shown unlab
     console.error = real;
   }
   assert.ok(errors.length > 0, "an item was silently dropped — the whole failure mode, again");
-  assert.match(String(errors[0]?.[0]), /declined an item/);
+  const said = errors.map((line) => String(line[0])).join("\n");
+  assert.match(said, /declined an item/);
+  // And the rung it came from is named, not just the item — because refusing
+  // the same rung six times and then going quiet is the soft-lock.
+  assert.match(said, /capping the stream/);
 });
 
 test("a boss that could not ask does not sweep the playfield clean", () => {

--- a/dynawalla/games/polarity/src/game/seal.ts
+++ b/dynawalla/games/polarity/src/game/seal.ts
@@ -10,6 +10,7 @@ import {
   EK,
   ENEMY,
   HALF_W,
+  ORB_SPREAD,
   PACE,
   SCORE,
   polColor,
@@ -89,11 +90,43 @@ export function launchBoss(w: World): void {
 /**
  * How many items to refuse before giving up on this Bearer.
  *
- * Refusing is meant to be a rarity — the atlas prints any integer, so the only
- * thing left to refuse is an answer that is not one. A bound exists so a host
- * serving a whole domain this game cannot draw costs a bearer, not a hang.
+ * Refusing is meant to be a rarity — the atlas prints any integer up to
+ * `LABEL_MAX_CHARS`, so the only things left to refuse are an answer that is not
+ * an integer and an answer wider than the lane. A bound exists so a host serving
+ * a whole rung this game cannot draw costs a bearer, not a hang — and, since
+ * `capBelow`, costs it exactly once.
  */
 const MAX_ASK_TRIES = 6;
+
+/**
+ * A 0..1 ladder position, spelled so the host cannot read it as the other scale.
+ *
+ * `packs/shared/game-host` reads a value below 1 as a fraction and 1..10 as a
+ * ladder index, and resolves the one value both scales claim — `1` — as the
+ * BOTTOM, because six other games send exactly that on their opening question
+ * and meant the easiest content in the product.
+ *
+ * POLARITY sent a fraction, and its fraction is `clamp(0.14 + stratum * 0.06, 0,
+ * 1)`, which reaches exactly 1 at stratum 15 — about seven and a half minutes of
+ * good play — and meant the HARDEST content. So the one number this game was
+ * guaranteed to send eventually was the one number that meant the opposite of
+ * what it wanted: a child who had climbed fifteen strata was dropped to the
+ * bottom of the ladder and held there for the rest of the run. `game-host` names
+ * this game in the comment on that rule. It speaks the unambiguous scale now.
+ */
+export function ladderScale(unit: number): number {
+  return 1 + clamp(unit, 0, 1) * 9;
+}
+
+/**
+ * How far below a rung the ceiling is set when that rung turns out undrawable.
+ *
+ * The host floors `maxDifficulty * span` to a rung index, so an ordinate of
+ * `used / span` minus anything strictly between 0 and one rung excludes exactly
+ * that rung and keeps every rung below it. A thousandth is below one rung for
+ * any ladder shorter than a thousand rungs; the shipping one has sixty.
+ */
+const CEILING_STEP = 1e-3;
 
 /**
  * The values an item would put on the field: the answer first, then its wrongs.
@@ -105,30 +138,75 @@ const MAX_ASK_TRIES = 6;
  *   * fewer than two values, which is not a question. One orb on the field is
  *     the right answer by elimination; a child touching it is not retrieval, and
  *     reporting it as a correct answer inflates a record that only ever rises.
+ *
+ * `maxChars` exists for the same reason it exists on `isPrintable`: the refusal
+ * guards against a curriculum wider than the one that ships, and a test that
+ * cannot narrow the budget cannot reach it. Nothing in the game passes it.
  */
-export function orbValues(q: Question, orbCount: number): number[] | null {
+export function orbValues(q: Question, orbCount: number, maxChars?: number): number[] | null {
   const answer = tryParseInt(q.answer);
   // A value the game cannot print must never be offered. There is no third
   // option where it is offered and comes out blank.
-  if (answer === null || !isPrintable(answer)) return null;
+  if (answer === null || !isPrintable(answer, maxChars)) return null;
   const out = [answer];
   for (const d of q.distractors) {
     if (out.length >= orbCount) break;
     const v = tryParseInt(d);
     // A wrong answer that will not print is dropped, not drawn: three orbs a
     // child can read beat four where one is a blank disc.
-    if (v === null || !isPrintable(v) || out.includes(v)) continue;
+    if (v === null || !isPrintable(v, maxChars) || out.includes(v)) continue;
     out.push(v);
   }
   return out.length >= Math.min(2, orbCount) ? out : null;
 }
 
+/** What this run asks the host for, difficulty and ceiling both. */
+export function askShape(w: World): { difficulty: number; maxDifficulty?: number } {
+  const want = clamp(0.14 + w.stratum * 0.06, 0, 1);
+  const ask: { difficulty: number; maxDifficulty?: number } = {
+    difficulty: ladderScale(want),
+  };
+  if (w.drawCeiling !== null) ask.maxDifficulty = ladderScale(w.drawCeiling);
+  return ask;
+}
+
+/**
+ * Ban the rung an unprintable item came from, and everything above it.
+ *
+ * **This is the durable half of the numeral fix.** Widening the numeral moves
+ * the ceiling; this is what makes a ceiling safe. A pack that cannot draw a rung
+ * has to tell the host, because declining is per-item and the host serves by
+ * RUNG: ask again at the same difficulty and the same rung answers. Six refusals
+ * later the Bearer cracks open having asked nothing, the next one does the same,
+ * and the child at the top of the ladder is served silence — which is not a
+ * degradation, it is a soft-lock, and it is what `NUMERAL_WIDTH_BLOCKED_LEVELS`
+ * was recording.
+ *
+ * Monotone downwards and never raised again. A rung that could not be drawn once
+ * cannot be drawn later — the budget is a constant — and a ceiling that drifted
+ * back up would re-enter the same starve every time the child climbed.
+ */
+function capBelow(w: World, q: Question): void {
+  const at = clamp(q.difficulty, 0, 1);
+  const capped = Math.max(0, at - CEILING_STEP);
+  if (w.drawCeiling !== null && w.drawCeiling <= capped) return;
+  w.drawCeiling = capped;
+  console.error(
+    `[polarity] a rung POLARITY cannot draw was served at difficulty ${at.toFixed(3)}; ` +
+      `capping the stream at ${capped.toFixed(3)} for the rest of this run`,
+  );
+  // The pool was stocked from the rung that has just been ruled out, so without
+  // this the ceiling arrives sixty-four questions late.
+  w.host.flush?.();
+}
+
 /** Draw an item this game can actually put on the field, or nothing. */
 function drawAskable(w: World, orbCount: number): { q: Question; values: number[] } | null {
   for (let i = 0; i < MAX_ASK_TRIES; i++) {
-    const q = w.host.next({ difficulty: clamp(0.14 + w.stratum * 0.06, 0, 1) });
+    const q = w.host.next(askShape(w));
     const values = orbValues(q, orbCount);
     if (values) return { q, values };
+    capBelow(w, q);
     console.error(
       `[polarity] declined an item POLARITY cannot print: ${q.prompt} = ${JSON.stringify(q.answer)}`,
     );
@@ -160,8 +238,7 @@ function askQuestion(w: World, e: Enemy, orbCount: number): boolean {
     if (!o) continue;
     const b = addBullet(w);
     if (!b) continue;
-    const spread = (HALF_W - 12) * 2;
-    const tx = -spread / 2 + (spread * (i + 0.5)) / n;
+    const tx = -ORB_SPREAD / 2 + (ORB_SPREAD * (i + 0.5)) / n;
     b.x = e.x;
     b.y = e.y - e.r * 0.4;
     b.vx = (tx - e.x) * 0.55;

--- a/dynawalla/games/polarity/src/game/seal.ts
+++ b/dynawalla/games/polarity/src/game/seal.ts
@@ -187,26 +187,66 @@ export function askShape(w: World): { difficulty: number; maxDifficulty?: number
  * back up would re-enter the same starve every time the child climbed.
  */
 function capBelow(w: World, q: Question): void {
+  // A difficulty that is not a number caps nothing. `clamp` is NaN-transparent,
+  // so without this the ceiling becomes NaN — which `readScale` then discards as
+  // "not a difficulty", leaving the ceiling inert AND `drawCeiling <= capped`
+  // permanently false, so every later refusal re-logs and re-flushes forever.
+  if (!Number.isFinite(q.difficulty)) return;
   const at = clamp(q.difficulty, 0, 1);
   const capped = Math.max(0, at - CEILING_STEP);
   if (w.drawCeiling !== null && w.drawCeiling <= capped) return;
   w.drawCeiling = capped;
+  // The pool is still stocked from the rung just ruled out, but the flush waits
+  // until `askShape` has carried the new ceiling into `next()`. See
+  // `World.pendingFlush`.
+  w.pendingFlush = true;
   console.error(
     `[polarity] a rung POLARITY cannot draw was served at difficulty ${at.toFixed(3)}; ` +
       `capping the stream at ${capped.toFixed(3)} for the rest of this run`,
   );
-  // The pool was stocked from the rung that has just been ruled out, so without
-  // this the ceiling arrives sixty-four questions late.
-  w.host.flush?.();
+}
+
+/**
+ * Is this refusal a fact about the RUNG, or only about this item?
+ *
+ * `orbValues` says no for two reasons and only one of them is the rung's. An
+ * unprintable ANSWER is a property of the rung: the budget is a constant, so
+ * every item from that rung is equally undrawable. Too few distractors is a
+ * property of the ITEM, and capping on it was a session-ending bug — the host's
+ * dry-pool sentinel is `{ id: "", answer: "0", distractors: [] }`, which parses
+ * and prints perfectly and yields exactly one value. One transient empty pool
+ * therefore read as "difficulty 0 is undrawable", pinned the ceiling at 0 where
+ * the monotone guard made it unraisable, and `startRun` deliberately does not
+ * reset it — so every question for the rest of the mount was the easiest rung in
+ * the product. An id of `""` is the host's own marker for "this is not a served
+ * item"; nothing about it describes a rung.
+ *
+ * The `id === ""` line is belt-and-braces and is NOT load-bearing today: the
+ * sentinel's `answer: "0"` prints, so the printability check below already
+ * refuses to cap on it, and deleting the id line breaks no test. It stays
+ * because a sentinel is the host's to change and the next one may not print —
+ * at which point capping on it would silently pin the run again.
+ */
+function rungCannotDraw(q: Question): boolean {
+  if (q.id === "") return false;
+  const answer = tryParseInt(q.answer);
+  return answer === null || !isPrintable(answer);
 }
 
 /** Draw an item this game can actually put on the field, or nothing. */
 function drawAskable(w: World, orbCount: number): { q: Question; values: number[] } | null {
   for (let i = 0; i < MAX_ASK_TRIES; i++) {
     const q = w.host.next(askShape(w));
+    // `askShape` has just put the new ceiling on the wire, so the pool can now
+    // be ranked against it. Flushing inside `capBelow` ranked it against the old
+    // one and kept the banned rung.
+    if (w.pendingFlush) {
+      w.pendingFlush = false;
+      w.host.flush?.();
+    }
     const values = orbValues(q, orbCount);
     if (values) return { q, values };
-    capBelow(w, q);
+    if (rungCannotDraw(q)) capBelow(w, q);
     console.error(
       `[polarity] declined an item POLARITY cannot print: ${q.prompt} = ${JSON.stringify(q.answer)}`,
     );

--- a/dynawalla/games/polarity/src/game/sim.ts
+++ b/dynawalla/games/polarity/src/game/sim.ts
@@ -752,6 +752,10 @@ export function startRun(w: World): void {
   w.spawnAcc = 0;
   w.stratum = 0;
   w.bearerCount = 0;
+  // `w.drawCeiling` is deliberately NOT reset. What POLARITY can draw is a
+  // property of POLARITY's numeral cell, not of this run, so a rung that starved
+  // one run would starve the next one identically — and re-learning it costs a
+  // Bearer that asks nothing, every restart.
   w.bossActive = false;
   w.bank = 1;
   w.nextBearer = PACE.firstBearer;

--- a/dynawalla/games/polarity/src/game/world.ts
+++ b/dynawalla/games/polarity/src/game/world.ts
@@ -135,6 +135,18 @@ export type World = {
    * hardest question it can actually draw".
    */
   drawCeiling: number | null;
+  /**
+   * A ceiling was lowered and the host has not been told yet.
+   *
+   * The flush has to happen AFTER the new ceiling reaches the host, never
+   * before: `flushNow` ranks the pool with `distance()`, which reads the host's
+   * OWN `ceiling`, and that is only updated inside `next()`. Flushing first
+   * ranked every pooled question against the stale ceiling and therefore kept
+   * precisely the banned rung's questions it meant to discard — measured as ten
+   * consecutive Bearers asking nothing, about four and a half minutes of
+   * silence, before the pool drained on its own.
+   */
+  pendingFlush: boolean;
   bossActive: boolean;
   hush: number;
 
@@ -291,6 +303,7 @@ export function makeWorld(host: Host, tier: Tier, seed: number): World {
     bearerCount: 0,
     stratum: 0,
     drawCeiling: null,
+    pendingFlush: false,
     bossActive: false,
     hush: 0,
     seal: { serial: 0, state: "idle", q: null, askedAt: 0, answered: "" },

--- a/dynawalla/games/polarity/src/game/world.ts
+++ b/dynawalla/games/polarity/src/game/world.ts
@@ -126,6 +126,15 @@ export type World = {
   nextBearer: number;
   bearerCount: number;
   stratum: number;
+  /**
+   * The highest ladder position this run will accept, 0..1, or null for none.
+   *
+   * Set the first time the host serves a rung whose answers POLARITY cannot
+   * print, and only ever lowered after that — see `capBelow` in `seal.ts`. It is
+   * what turns "declines every item this rung offers, forever" into "asks the
+   * hardest question it can actually draw".
+   */
+  drawCeiling: number | null;
   bossActive: boolean;
   hush: number;
 
@@ -281,6 +290,7 @@ export function makeWorld(host: Host, tier: Tier, seed: number): World {
     nextBearer: 0,
     bearerCount: 0,
     stratum: 0,
+    drawCeiling: null,
     bossActive: false,
     hush: 0,
     seal: { serial: 0, state: "idle", q: null, askedAt: 0, answered: "" },

--- a/dynawalla/games/polarity/src/pack.ts
+++ b/dynawalla/games/polarity/src/pack.ts
@@ -21,8 +21,16 @@
 // nothing declined an item outside the range, the renderer simply skipped the
 // numeral, and 89.9% of the orb values this pack requests across the shipping
 // ladder came out as blank glowing discs. Tiles are claimed on demand now
-// (`core/labels.ts`) and any integer prints; `askQuestion` refuses anything it
-// cannot print, out loud, rather than dropping it on the field unlabelled.
+// (`core/labels.ts`) and `askQuestion` refuses anything it cannot print, out
+// loud, rather than dropping it on the field unlabelled.
+//
+// There IS a real limit and it is stated where it can be checked: a numeral is
+// drawn in the lane its orb gets, four orbs share `ORB_SPREAD` of a hundred-unit
+// field, and a character narrower than half its own cap height is not a numeral.
+// That comes out at ten characters — `48,826 × 82,726`, the widest answer the
+// curriculum reaches. Past it, POLARITY caps its own stream with
+// `next({ maxDifficulty })` rather than declining item after item from a rung
+// the host has no reason to stop serving.
 //
 // There are no signed-integer rows in the graph yet; when there are, they belong
 // here.

--- a/dynawalla/games/polarity/src/render/atlas.ts
+++ b/dynawalla/games/polarity/src/render/atlas.ts
@@ -1,8 +1,16 @@
 import { CanvasTexture, LinearFilter, SRGBColorSpace, Texture } from "three";
-import { LABEL_ASPECT, LABEL_COLS, LABEL_ROWS, LabelBook } from "../core/labels.ts";
+import {
+  LABEL_ASPECT,
+  LABEL_CELL_H,
+  LABEL_COLS,
+  LABEL_EM,
+  LABEL_INK_W,
+  LABEL_ROWS,
+  LabelBook,
+} from "../core/labels.ts";
 
 const FACE =
-  '900 76px ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", ' +
+  `900 ${String(LABEL_EM)}px ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", ` +
   '"Nimbus Sans", Inter, system-ui, sans-serif';
 
 /**
@@ -16,6 +24,11 @@ const FACE =
  * Cells are `LABEL_ASPECT` times wider than they are tall. A long answer gets
  * width, not a horizontal squeeze: every numeral on the field is drawn at the
  * same glyph HEIGHT, which is the thing a child reads at speed.
+ *
+ * `cellPx` is the HEIGHT. The width is `cellPx * LABEL_ASPECT`, and both tiers
+ * are chosen so that product is a whole number of texels — the shader addresses
+ * a tile as a fraction of `uGrid`, so a cell width the canvas has to round is a
+ * cell whose neighbour bleeds into it.
  */
 export class LabelAtlas {
   readonly book: LabelBook;
@@ -33,6 +46,16 @@ export class LabelAtlas {
     this.book = new LabelBook(LABEL_COLS * LABEL_ROWS);
     this.cellH = cellPx;
     this.cellW = cellPx * LABEL_ASPECT;
+    // Loud, because the failure is silent and looks like a font bug: the shader
+    // addresses a tile as `col / uGrid.x` of the texture, so if `cellPx *
+    // LABEL_ASPECT` is not a whole number the canvas rounds its width and every
+    // column after the first samples a sliver of its neighbour's numeral.
+    if (!Number.isInteger(this.cellW)) {
+      console.error(
+        `[polarity] a ${String(cellPx)}px cell at aspect ${String(LABEL_ASPECT)} is ` +
+          `${String(this.cellW)} texels wide, which is not a whole number — tiles will bleed`,
+      );
+    }
     this.canvas = document.createElement("canvas");
     this.canvas.width = this.cols * this.cellW;
     this.canvas.height = this.rows * this.cellH;
@@ -86,13 +109,13 @@ export class LabelAtlas {
     g.clearRect(x, y, this.cellW, this.cellH);
     g.save();
     g.translate(x + this.cellW / 2, y + this.cellH / 2);
-    g.scale(this.cellH / 128, this.cellH / 128);
+    g.scale(this.cellH / LABEL_CELL_H, this.cellH / LABEL_CELL_H);
     g.font = FACE;
-    // The cell is 256 units wide in this space. Squeeze only what genuinely
-    // overflows it — which the shipping curriculum never does.
+    // Fitted, not clipped. Everything past `LABEL_INK_W` is squeezed to exactly
+    // fill the box, which is what makes `labelAdvanceEm` true whatever face the
+    // device resolved — the box is ours and the advance is not.
     const w = g.measureText(s).width;
-    const maxW = 128 * LABEL_ASPECT - 24;
-    if (w > maxW) g.scale(maxW / w, 1);
+    if (w > LABEL_INK_W) g.scale(LABEL_INK_W / w, 1);
 
     // dark contrast rim first, then the solid face
     g.lineJoin = "round";

--- a/dynawalla/games/polarity/src/render/renderer.ts
+++ b/dynawalla/games/polarity/src/render/renderer.ts
@@ -153,8 +153,8 @@ export class Renderer {
     this.gl.autoClear = true;
 
     // Cell HEIGHT, and the same as the tile size the baked atlas used: the cell
-    // got wider, not shorter, so a numeral has exactly the texels it always had
-    // and a four-digit answer is drawn wide rather than crushed.
+    // has only ever got wider, never shorter, so a numeral has exactly the
+    // texels it always had and a long answer is drawn wide rather than crushed.
     this.atlas = new LabelAtlas(tier.name === "low" ? 96 : 128);
 
     this.uBack = {

--- a/dynawalla/games/polarity/src/stubHost.ts
+++ b/dynawalla/games/polarity/src/stubHost.ts
@@ -13,7 +13,7 @@
  * Difficulty is adaptive (up on fast + correct, down on wrong), which is what
  * the real host does, so swapping it in changes nothing about how this feels.
  */
-import type { Host, Question } from "./contract.ts";
+import type { Ask, Host, Question } from "./contract.ts";
 import { makeRng, type Rng } from "./core/rng.ts";
 import { MINUS, fmtInt } from "./math/signed.ts";
 
@@ -226,6 +226,22 @@ export function chooseDistractors(answer: number, wrong: number[], rng: Rng): st
   return rng.shuffle(out).map(fmtInt);
 }
 
+/**
+ * A game's difficulty number as a 0..1 ladder position.
+ *
+ * Transcribed from `toUnit` in `packs/shared/game-host/index.ts` — a value below
+ * 1 is a fraction, 1..10 is a ladder index, and `1` is read as the BOTTOM. The
+ * stub cannot import the real host (this file exists so POLARITY runs with no
+ * host at all), and a stub that read the request on a different scale from the
+ * shipping host would be a dev harness that agrees with nothing — which is
+ * precisely how the blank-orb defect survived a whole build.
+ */
+export function toUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 1) return Math.max(0, value);
+  return Math.min(1, (value - 1) / 9);
+}
+
 export type StubOpts = {
   seed?: number;
   /** starting difficulty 0..1 */
@@ -237,10 +253,16 @@ export type StubOpts = {
 export function makeStubHost(opts: StubOpts = {}): Host & { difficulty(): number } {
   const rng = makeRng(opts.seed ?? 0x50147);
   let hard = Math.min(1, Math.max(0, opts.difficulty ?? 0.18));
+  /** A standing ceiling, 0..1. Stands until the game names a different one. */
+  let ceiling = 1;
   let n = 0;
 
-  const build = (want?: { domain?: string; difficulty?: number }): Question => {
-    const d = Math.min(1, Math.max(0, want?.difficulty ?? hard));
+  const build = (want?: Ask): Question => {
+    // The ceiling is a hard cap and the request is a wish, same as the real
+    // service: `maxDifficulty` floors, `difficulty` does not.
+    if (want?.maxDifficulty !== undefined) ceiling = toUnit(want.maxDifficulty);
+    const asked = want?.difficulty === undefined ? hard : toUnit(want.difficulty);
+    const d = Math.min(1, Math.max(0, Math.min(asked, ceiling)));
     const table = d < 0.3 ? EASY : d < 0.68 ? MID : HARD;
     const pinned = want?.domain ? BY_DOMAIN[want.domain] : undefined;
     let b: Built | null = null;

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/mul.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/mul.ts
@@ -30,16 +30,22 @@
  * `promptOperator(key)` out of `render/prompts.ts` now, which is why those four
  * rows are a `status` flip and nothing else — no generator here changed.
  *
- * **The other two are held by something no gate had ever needed to check: how wide
- * a numeral a game can print.** `dw.mul.scale.times-power-of-ten` and
- * `dw.mul.multidigit.long-multiplication` reach nine and ten characters, and
- * `games/polarity` refuses an answer past eight — its own sweep of the shipping
- * ladder went red on `544,080,000` the moment they went active, which is that gate
- * working. See `NUMERAL_WIDTH_BLOCKED_LEVELS` in `promotionBlockers.ts`: the rows
- * are right and the ceiling is the program's stated one. What is missing is on the
- * pack's side, and `packs/sdk` already has the seam — a pack that can print eight
- * characters caps its stream with `next({ maxDifficulty })` and gets the part of
- * the ladder it can draw.
+ * **The other two were held by something no gate had ever needed to check: how
+ * wide a numeral a game can print**, and they are active now too.
+ * `dw.mul.scale.times-power-of-ten` and `dw.mul.multidigit.long-multiplication`
+ * reach nine and ten characters; `games/polarity` refused an answer past eight,
+ * and its own sweep of the shipping ladder went red on `544,080,000` the moment
+ * they were first promoted — which is that gate working. The rows were never
+ * wrong and the ceiling is the program's stated one, so the fix was the pack's:
+ * POLARITY's numeral budget is derived from the lane an orb is drawn in rather
+ * than typed, which puts it at ten characters, and it caps its own stream with
+ * `next({ maxDifficulty })` when it meets a rung it cannot draw instead of
+ * declining item after item from a rung the host will keep serving. Both are a
+ * `status` flip here and nothing else.
+ *
+ * `SHIPPED_NUMERAL_MAX_CHARS` in `promotionBlockers.ts` still holds the whole
+ * graph to what the narrowest pack prints, in both directions, so the row that
+ * reaches eleven characters is stopped by a test rather than by a child.
  */
 
 import { rational } from "../../math/rational.ts";
@@ -240,7 +246,7 @@ const timesPowerOfTen: SkillNode = {
    * the gate was asking for. `472 × 100` is the same skill `47 × 100` was.
    */
   rev: 2,
-  status: "draft",
+  status: "active",
   title: locKey("dw.skill.mul.scale.times-power-of-ten.title"),
   learnerGoal: locKey("dw.skill.mul.scale.times-power-of-ten.goal"),
   domain: "mul",
@@ -391,7 +397,7 @@ const timesTwoDigit: SkillNode = {
 const longMultiplication: SkillNode = {
   id: SKILL_LONG_MULTIPLICATION,
   rev: 1,
-  status: "draft",
+  status: "active",
   title: locKey("dw.skill.mul.multidigit.long-multiplication.title"),
   learnerGoal: locKey("dw.skill.mul.multidigit.long-multiplication.goal"),
   domain: "mul",

--- a/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
@@ -140,58 +140,63 @@ export const MISSTATED_QUESTION_TEMPLATES: readonly string[] = [
 /**
  * The longest numeral a shipped game will put in front of a child, in characters.
  *
- * Read off `games/polarity/src/core/labels.ts`, which is the narrowest budget any
- * pack in this repository declares and the only one that is a hard refusal rather
- * than a layout squeeze: `isPrintable(v)` is false past eight characters, and
- * `orbValues` returns `null` for an item whose *answer* will not print. The number
- * is not arbitrary there — the game's numeral cell is twice as wide as it is tall
- * and the constant was measured over 44,000 orbs of the ladder as it then was.
+ * Read off `games/polarity/src/core/labels.ts`, which is still the only pack in
+ * this repository that refuses an answer outright rather than squeezing a layout
+ * — `isPrintable(v)` is false past this, and `orbValues` returns `null` for an
+ * item whose *answer* will not print, so the item is never offered.
  *
- * It is written down here because a curriculum row is only reachable if something
- * can draw its answer, and until this pass no row in the graph came close to the
- * limit. `48,826 × 82,726` is ten characters.
+ * **It was eight, and eight was not measured.** The constant's stated reason was
+ * that eight characters "still fits the cell without squeezing"; they did not,
+ * by about 60%, and nothing checked. POLARITY derives the number now, from the
+ * thing that actually limits it: four answer orbs share a fixed slice of a
+ * hundred-unit playfield, the numeral drawn over one is as wide as its lane
+ * allows and no wider, and a character may not be narrower than half its own cap
+ * height. That comes out at ten — which is `48,826 × 82,726`, the program's
+ * stated ceiling, reached with less than one percent of margin rather than by
+ * rounding in its favour.
+ *
+ * It is written down here because a curriculum row is only reachable if
+ * something can draw its answer. Eleven characters is a row that ships to a
+ * child who is served nothing.
  */
-export const SHIPPED_NUMERAL_MAX_CHARS = 8;
+export const SHIPPED_NUMERAL_MAX_CHARS = 10;
 
 /**
- * Levels whose answers are wider than any shipped game will print.
+ * Levels whose answers are wider than any shipped game will print. **Empty.**
  *
- * ## What this costs, precisely
+ * ## What it recorded, and what cleared it
  *
- * A pack that cannot print an answer must not offer it, and `games/polarity` gets
- * that right: it declines the item and says so on the console. But declining is
- * per-item and the host serves by *rung* — ask again at the same difficulty and the
- * same rung answers — so a level where every item is too wide is not a graceful
- * degradation. It is a Seal Bearer that asks nothing, forever, and the child at the
- * top of the ladder is the one it happens to. Measured over 60 seeds a level:
+ * `dw.mul.scale.times-power-of-ten L2` and `dw.mul.multidigit.long-multiplication`
+ * L1 and L2 reach nine and ten characters, and the pack refused past eight.
+ * Refusing is per-item and the host serves by *rung* — ask again at the same
+ * difficulty and the same rung answers — so a level where every item is too wide
+ * was not a graceful degradation. It was a Seal Bearer that asks nothing,
+ * forever, and the child at the top of the ladder was the one it happened to.
+ * Measured over 60 seeds a level, at the time it was recorded:
  *
  * | level | items too wide | widest |
  * |---|---|---|
- * | `dw.mul.scale.times-power-of-ten L2` | 21/60 | `544,080,000` — 9 |
- * | `dw.mul.multidigit.long-multiplication L1` | 50/60 | `799,204,497` — 9 |
- * | `dw.mul.multidigit.long-multiplication L2` | **60/60** | `2,367,541,946` — 10 |
+ * | `dw.mul.scale.times-power-of-ten L2` | 18/60 | `546,270,000` — 9 |
+ * | `dw.mul.multidigit.long-multiplication L1` | 51/60 | `263,502,180` — 9 |
+ * | `dw.mul.multidigit.long-multiplication L2` | **60/60** | `1,042,977,861` — 10 |
  *
- * ## Why this is the pack's to clear and not the curriculum's
+ * Nothing was ever wrong with the rows, and the fix was the pack's, in two parts:
+ * the numeral budget is derived from the orb's lane rather than typed, which puts
+ * it at ten characters; and POLARITY caps its own stream with
+ * `next({ maxDifficulty })` the first time a rung refuses to print, which is what
+ * makes any ceiling — this one or the next one — safe rather than silent.
  *
- * Nothing is wrong with the rows. `48,826 × 82,726` is the program's stated ceiling
- * and `docs/` has said so since before the generator existed; a graph that trimmed
- * its own content to a texture atlas would be the tail wagging the dog. What is
- * missing is on the other side, and `packs/sdk` already has the seam for it:
- * `next({ maxDifficulty })` is "a ceiling on the same scale, the stream never goes
- * above it", and polarity does not pass one. A pack that can print eight characters
- * says so, and gets the part of the ladder it can draw.
+ * ## Why the empty list stays
  *
- * So this blocker clears when a pack either widens its numeral or caps its stream —
- * and the row is a `status` flip after it, exactly like the operator was.
- * `render/prompts.test.ts` asserts this list equals the levels whose answers exceed
- * `SHIPPED_NUMERAL_MAX_CHARS`, in both directions, so widening one and forgetting
- * the other fails.
+ * Because it is asserted in BOTH directions. `render/prompts.test.ts` measures
+ * every bound level of every non-deprecated row against
+ * `SHIPPED_NUMERAL_MAX_CHARS` and requires the result to equal this list, so the
+ * day a row reaches eleven characters it is named here by a failing build rather
+ * than by a child being served silence. A deleted list would have to be
+ * rediscovered the same way the first one was: by promoting the rows and
+ * watching a pack's sweep go red.
  */
-export const NUMERAL_WIDTH_BLOCKED_LEVELS: readonly string[] = [
-  "dw.mul.multidigit.long-multiplication L1",
-  "dw.mul.multidigit.long-multiplication L2",
-  "dw.mul.scale.times-power-of-ten L2",
-];
+export const NUMERAL_WIDTH_BLOCKED_LEVELS: readonly string[] = [];
 
 /** The skills above, deduplicated — the rows that stay draft because of it. */
 export const NUMERAL_WIDTH_BLOCKED_SKILLS: readonly string[] = [

--- a/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
+++ b/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
@@ -60,6 +60,12 @@
     "gen.arith.long-div@1|dw.div.whole.divide-exact|L3": "b521e068909c39d4",
     "gen.arith.long-div@1|dw.div.whole.zero-in-the-quotient|L0": "6c1692e3a2713b86",
     "gen.arith.long-div@1|dw.div.whole.zero-in-the-quotient|L1": "c48fc1f14698b531",
-    "gen.arith.long-div@1|dw.div.whole.zero-in-the-quotient|L2": "b3708b4205c519fc"
+    "gen.arith.long-div@1|dw.div.whole.zero-in-the-quotient|L2": "b3708b4205c519fc",
+    "gen.arith.multidigit-mul@1|dw.mul.scale.times-power-of-ten|L0": "66b5e4e61b33da75",
+    "gen.arith.multidigit-mul@1|dw.mul.scale.times-power-of-ten|L1": "0307112bb78b72d3",
+    "gen.arith.multidigit-mul@1|dw.mul.scale.times-power-of-ten|L2": "918cca675d399fa1",
+    "gen.arith.multidigit-mul@1|dw.mul.multidigit.long-multiplication|L0": "106e1eebe68d83db",
+    "gen.arith.multidigit-mul@1|dw.mul.multidigit.long-multiplication|L1": "bc9af04dca377856",
+    "gen.arith.multidigit-mul@1|dw.mul.multidigit.long-multiplication|L2": "1239bfc39b12417f"
   }
 }


### PR DESCRIPTION
## What

Make a ten-character answer drawable on a POLARITY orb, cap the stream at what
the pack can draw instead of declining item by item, and promote the last two
multiplication rows — which puts `48,826 × 82,726` in front of a child.

## The real width constraint, which is not the atlas

PR #683 recorded that POLARITY's numeral cell "holds eight characters". It does
not hold eight; it *permits* eight, and the reason written next to the constant
was false:

```ts
/**
 * … Eight leaves a character of headroom and
 * still fits the cell without squeezing.
 */
export const LABEL_MAX_CHARS = 8;
```

`atlas.ts` has always **fitted** rather than clipped — `if (w > maxW) g.scale(maxW / w, 1)`
— so nothing overflows a cell and nothing ever refuses for want of texels. Eight
characters at the 76-unit type size measure about **365** design units against a
**232**-unit box, so the widest numeral the old constant allowed was already
squeezed to roughly **0.64** of its natural width. Nothing measured that and
nothing enforced it. No shipped item ever reached it either: the widest answer
the ladder emitted was six characters.

The texture is not the constraint either, though it is genuinely out of room
sideways: the atlas was 2048 × 768 and 2048 is the WebGL-guaranteed
`MAX_TEXTURE_SIZE` floor. But a cell is a *sampling resolution*, and the label's
size on screen has nothing to do with it.

**The constraint is the orb's lane.** Four orbs share `(HALF_W − 12) × 2 = 76` of
the hundred-unit playfield, so each gets 19 units; the label drawn over one is
`orbR × 1.35 × LABEL_ASPECT × boost` = 17.2 units wide on a narrow phone. Two
labels that overlap are worse than one that is condensed, so that 19 units is the
whole budget, and the on-screen condensation of an *n*-character numeral works out
to exactly

```
advance / em  =  (LABEL_CELL_H · LABEL_ASPECT − margin) / (LABEL_EM · n)
```

— font-independent, because anything wider than the box is squeezed to fill it
exactly. Eight characters is simply where that ratio, at the old aspect and
margin, happened to land on 0.38 em.

## What changed

**The budget is derived, not typed.** `LABEL_MIN_ADVANCE_CAPS = 0.5` — a digit may
not be narrower than half its own cap height, which is where condensed tabular
faces bottom out — and `LABEL_MAX_CHARS` falls out of the geometry at **ten**,
with less than one percent of margin. `labels.test.ts` asserts both that ten fits
and that eleven does not, so a later change to the cell, the margin or the aspect
moves the number rather than silently keeping it.

**The width it needed came from geometry, not from lowering a bar:**

- `LABEL_ASPECT` 2 → 2.25, and the grid 8 × 6 → **7 × 7** so the texture *shrinks*
  sideways: 2016 × 896 against the 2048 ceiling, at the same 48 claimable cells.
  A new guard shouts if `cellPx * LABEL_ASPECT` is ever not a whole number of
  texels — the shader addresses a tile as a fraction of `uGrid`, so a rounded cell
  width is a numeral sampling a sliver of its neighbour, and it reads as a font bug.
- `LABEL_CELL_MARGIN` 24 → **20**. The number it has to clear is the baked contrast
  rim, which puts ink 6.5 design units outside the outline (`lineWidth 13`); 24 was
  a round number nothing derived, and the four units are the difference between ten
  characters and nine.
- `ORB_SPREAD` `(HALF_W − 12) × 2` → `(HALF_W − 8) × 2`. The outermost orb moves from
  28.5 to 31.5 and its numeral's far edge lands at 40 of the 50 units the field has,
  nowhere near the weave clamp at `HALF_W − r`.

**Type size does not move.** `LABEL_EM / LABEL_CELL_H` is unchanged, so every numeral
is drawn at the height it always was and only the advance changes with length. Across
five viewports the test computes cap height from the constants and holds it to the
arcade canon's hard gate for numerals on moving objects — 22 rpx "at the moment of
decision" — which it clears at 29–39 rpx everywhere. `games/beam`'s 15 css px
candidate floor is cleared in portrait (17–20 px); the landscape phone reads 14.2 px
and always has, which this PR does not change and does not claim to.

Short numerals get *better*, not worse: up to five characters they are now drawn
undistorted where they used to start squeezing at six.

**`maxDifficulty`, which is the durable fix.** `next({ difficulty, maxDifficulty })`
has existed on `GameHost` since #659 and POLARITY passed neither. It does now, and
the mechanism does not need to know anything about the curriculum: when
`drawAskable` meets an item it cannot print, `capBelow` sets the ceiling to that
item's own reported ladder ordinate minus a thousandth — which is strictly inside
one rung on any ladder shorter than a thousand rungs, so the host's `floor(cap × span)`
excludes exactly that rung — and calls `host.flush?.()`, because the pool holds up to
sixty-four questions all drawn from the rung that was just ruled out.

Monotone downwards, never raised, and not reset by `startRun`: what POLARITY can draw
is a property of POLARITY, so re-learning it would cost a starved Bearer every restart.

**A third defect, at the same call site.** `game-host`'s `toUnit` reads a value below 1
as a fraction and 1..10 as a ladder index, and resolves the one value both scales claim
— `1` — as the **BOTTOM**, because six other games send it on their opening question.
POLARITY sent `clamp(0.14 + stratum * 0.06, 0, 1)`, which pins at exactly 1 from
stratum 15 — about seven and a half minutes of good play — and meant the **top**. So a
child who had climbed fifteen strata was dropped to the easiest content in the product
and held there for the rest of the run. `game-host` names this game in the comment on
that rule. It sends `1 + unit × 9` now, on both fields.

The stub host learned the same scale and the same ceiling, transcribed with a comment:
a dev harness that reads the request differently from the shipping host is how the
blank-orb defect survived a whole build.

## Measured, 60 seeds a level, before and after

Answers wider than the budget, over the whole promoted ladder (66 rungs). Only the
three levels that were ever wide are shown; nothing else on the ladder exceeds six
characters.

| level | seen | too wide @ 8 | too wide @ 10 | **declined** @ 10 | widest |
|---|---|---|---|---|---|
| `dw.mul.scale.times-power-of-ten L2` | 60 | 17/60 | **0/60** | **0/60** | `635,560,000` — 9 |
| `dw.mul.multidigit.long-multiplication L1` | 60 | 52/60 | **0/60** | **0/60** | `105,342,552` — 9 |
| `dw.mul.multidigit.long-multiplication L2` | 60 | **60/60** | **0/60** | **0/60** | `1,234,138,608` — 10 |

`declined` is `orbValues()` returning `null` — the pack's own refusal, including
distractors. Extended to **1,000 seeds a level**: still 0 declined, widest answer
`1,234,138,608` and widest distractor `1,234,138,609`, both ten. Eleven is not
reachable by construction — five digits by five digits is at most ten characters,
and the mal-rules are smaller than the product, not larger.

#683 measured 21/60, 50/60 and 60/60 on the same levels; the small differences are
the seed derivation (`seedFrom` here, raw indices there) and not the content.

## `48,826 × 82,726`, end to end

Through the real `createItemService`, at `difficulty: 1`, forty items — every one
drawn by `orbValues`, every orb given a real tile by `LabelBook`, every canonical
answer fed back through `judge`:

```
rungs: 66
  dw.mul.multidigit.long-multiplication L2  "42539 × 12532" = 533098748
      orbs [533098748, 533098749, 533098747, 553007]   correct=true
  dw.mul.multidigit.long-multiplication L2  "31457 × 55613" = 1749418141
      orbs [1749418141, 629140, 1749418140, 1749418142] correct=true
  dw.mul.multidigit.long-multiplication L2  "75513 × 63536" = 4797793968
      orbs [4797793968, 1736799, 4797793969, 4797793967] correct=true
drawn 40/40   judged correct 40/40

48,826 × 82,726 = 4039179676 -> "4039179676" (10 chars)
a real ten-character item off the top rung: "36536 × 69356" = 2533990816 at difficulty 1
```

`48,826 × 82,726` is exactly the shape of `long-multiplication` L2 — five digits by
five — its product is ten characters, and ten characters is what POLARITY prints.

## Rows promoted

- `dw.mul.scale.times-power-of-ten` (draft → active)
- `dw.mul.multidigit.long-multiplication` (draft → active)

A `status` flip and nothing else: no generator, level table or parameter changed.
`NUMERAL_WIDTH_BLOCKED_LEVELS` is now empty and `SHIPPED_NUMERAL_MAX_CHARS` is 10.
The empty list stays rather than being deleted, because `render/prompts.test.ts`
asserts it in **both** directions — the day a row reaches eleven characters it is
named by a failing build rather than rediscovered by promoting rows and watching a
pack's sweep go red, which is how the first one was found.

## Removed-fix verification

Every test was checked by deleting the fix it covers.

Narrow `ORB_SPREAD` back to `(HALF_W − 12) × 2`:

```
✖ a wide numeral still fits its own orb's lane
  a numeral is 19.4 wide in a 19.0 lane — orbs would collide
```

Type `LABEL_MAX_CHARS = 8` back in (three failures, the first over the real,
promoted ladder — the symptom #683 saw in CI):

```
✖ not one orb the shipping curriculum can put on the field comes out blank
  dw.mul.scale.times-power-of-ten L2 produced an item with no drawable answer
✖ every value the ladder emits survives a round trip through a printed numeral
✖ the longest numeral is derived from the lane, and is not a number somebody typed
  9 characters would also have fitted — the cap is not the geometry
```

Shrink `LABEL_EM` (the constant that sets type size):

```
✖ the longest numeral clears the canon's cap-height gate on every viewport
  a phone, landscape: cap height is 18.8 rpx, under the canon's 22
```

Send the raw fraction again instead of `ladderScale` (four failures):

```
✖ the top of the ladder is asked for as the TOP of the ladder
  the hardest content in the product was asked for as the easiest
  1 !== 10
```

Delete `capBelow` — **the soft-lock, reproduced**:

```
✖ a rung POLARITY cannot draw is asked once, not forever
  six Seal Bearers arrived and not one of them asked a question — the child at
  the top of the ladder was served silence
✖ the ceiling is learned once and costs one Bearer, not one per Bearer
  a later Bearer had to rediscover the ceiling
✖ the ceiling only ever falls, and the pool is flushed when it does
✖ an item with an answer this game cannot print is declined, not shown unlabelled
```

Drop the `host.flush?.()`:

```
✖ the ceiling only ever falls, and the pool is flushed when it does
  a ceiling landed sixty-four questions late
```

Drop the monotone guard inside `capBelow` — exercised by the reserve a real flush
leaves, which `game-host` documents as still answerable above a ceiling "when
nothing else does":

```
✖ a ceiling is never raised by the stale question that outlived it
  the run stopped asking questions altogether
```

Cap on every ask rather than only on a refusal:

```
✖ a rung POLARITY cannot draw is asked once, not forever
  it fell back to 6 characters when it can print 10
✖ a host with no ceiling to give is not made worse by asking for one
  a ladder this game can draw entirely was still capped
```

Revert `SHIPPED_NUMERAL_MAX_CHARS` to 8, and separately to 9:

```
✖ the levels whose answers are too wide to print are exactly the ones promotionBlockers.ts names
  + ['dw.mul.multidigit.long-multiplication L1',
  +  'dw.mul.multidigit.long-multiplication L2',
  +  'dw.mul.scale.times-power-of-ten L2']
  - []

✖ the levels whose answers are too wide to print are exactly the ones promotionBlockers.ts names
  + ['dw.mul.multidigit.long-multiplication L2']
  - []
```

## Suites, five runs each

```
polarity   ×5:  ℹ tests 60  ℹ pass 60  ℹ fail 0
curriculum ×5:  ℹ tests 208 ℹ pass 208 ℹ fail 0   |  npm run check: OK
app        ×5:  ℹ tests 292 ℹ pass 292 ℹ fail 0
```

**Every game in the tree**, because the ladder moved under all of them:

```
arena 65   balance 68   beam 99    claim 78    coil 109   colossus 81
counterweight 136  forge 79   foundry 93  guilty 36   horde 29   lattice 94
merge-idle 175  merge 73   mosaic 79   polarity 60  pulse 129  rhythm 70
runner 73  serpent 38  siege 29   skyledger 69  slice 114  stack 36
street 99  trebuchet 166  truedraw 154        — 0 failures
```

`packs/sdk`: 88 pass. Typecheck clean on polarity (both projects), curriculum and
the app; `npm run lint` clean; `build:pack` clean.

## Blast radius

**Areas touched:** dynawalla (`games/polarity/`, `packs/shared/curriculum/`)

- [x] Every touched path is covered by a `ci.yml` area filter — `dynawalla/games/`
      by `dynawalla_packs`, `dynawalla/packs/shared/curriculum/` by
      `dynawalla_curriculum` and `dynawalla_packs`. Observed on this PR:
      `dynawalla-app`, `dynawalla-curriculum` (ubuntu **and** macos) and
      `dynawalla-packs` all ran, and the app's 292 tests — which sweep the ladder —
      are green in CI as well as five times locally.
- [x] **Outside the stated file list, deliberately and minimally:**
      `packs/shared/curriculum/src/snapshots/generators.json`. CG-16 requires a
      committed determinism hash per active (skill, level), so the six new hashes
      are a mandatory consequence of the two `status` flips — `npm run check` is
      FAILED without them. Produced by `npm run snapshots:update`, no generator
      touched. Nothing under `games/arena|balance|beam|colossus|counterweight|merge-idle|serpent|siege|skyledger|slice|stack|street`,
      `packs/sdk/` or `dynawalla-app/` was modified.
- [x] **Pack back-compat.** No published pack zip changed, no catalog entry touched,
      no `minAppVersion` moved. `Item`, `Judgement` and the `packs/sdk` protocol are
      unchanged — `ItemRequest.maxDifficulty` and `GameHost.flush` both already
      existed and are used here for the first time by this game.
      `packs/shared/game-host` is untouched. POLARITY's local `Host` type gained
      `Ask.maxDifficulty` and an **optional** `flush?()`, which keeps it structurally
      assignable from `GameHost` and feature-detected exactly as `trebuchet` and
      `siege` do with theirs.
- [x] **Native integrity.** N/A — no Rust touched.
- [x] **Strings.** N/A — no locale strings. The two promoted rows' `locKey`s already
      exist and are unchanged.
- [x] **Curriculum.** No skill id renamed or reused. No grade change. No generator,
      parameter or difficulty coefficient changed. Every operand and answer stays an
      exact `Rational`. Two rows promoted; both have passing generator bindings and
      `npm run check` is OK.
- [x] **Secrets.** None.

## Not verified without a device

The atlas paints on a real `<canvas>`, so the one thing argued rather than seen is
**whether a ten-character numeral reads at speed on a tablet**. Everything about it
is computed here — 0.35 em of advance, ~20 css px of type, 39 rpx of cap height on a
reference phone — and it clears the only floor this repository states for a numeral
on a moving object by a wide margin. But 0.35 em is condensed, it is the narrowest
numeral this game has ever drawn, and a child reading `2,533,990,816` off a moving
orb in a bullet field is the test.

If a playtest says it is too tight, the next lever is identified and costed: the orbs
already weave ±5.5 units vertically with independent phase, so giving the four of them
a deterministic ±6.5-unit stagger would put alternate labels on disjoint bands and
**double** the lane — enough to draw ten characters completely undistorted. It is a
change to how a child threads the orb field, which wants a tablet and a child rather
than a patch, so it is named here rather than done here.

Also unseen: the widened cell in the GL layer (the quad is `iSize * uAspect` and only
`uAspect` moved), and the promoted rows' pacing — `long-multiplication` declares a
75 s median and POLARITY's orb hold is `max(4.6, 7.5 − bearers × 0.35)` seconds, so the
top rung is almost certainly unfinishable inside one Bearer. That is the fleet-wide
timing finding #683 recorded as still open, same owner, and it is not made worse here.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
