### PR TITLE
release(dynawalla): 0.3.2 — DEEPSWARM's answers are reachable

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
One line in `tauri.conf.json`. Cut immediately after DEEPSWARM landed, per the founder's request for ruthless patch releases rather than batching.

## DEEPSWARM (#693) — every complaint, two root causes

**The answers were unreachable by construction.** The orbs were recomputed from the player's *current* position every frame. Measured with a perfect stick: **172.0px at t=0, 159.8px at 0.5s, and 159.8px at every sample forever.** Closing on the 12.3px velocity lead alone needed 2,200 px/s against a base speed of 205. **Every CORE timed out, always.** Now: struck at 0.77s.

**The inversion was a coordinate-system sign**, not a `-dy` — input reports CSS pixels (+y down), both vertex shaders project +y up. One conversion fixes pointer, touch and keyboard, and **three unreported symptoms were the same bug**: the joystick ring drew at the reflected height, damage numbers were spat downward, and the **Warden's health arc drew underneath it**.

Which answers the founder's last question: **the rift was never the route.** Every weapon damages a Warden normally. It *read* invulnerable because its bar was below it, its damage numbers flew into the floor, and OVERCHARGE — earned from a **correct CORE answer** — was unobtainable because of the unreachable orbs.

**Question variety was arithmetic.** horde spoke the host's *integer* scale: 1–10 across 59 rungs at a stride of 6.5, so **50 of 60 rungs were unnameable** — including both easy no-regroup rungs *and all of carrying*. Now 46 of 60.

## Ten games stop playing behind the manual (#691, #692)

Two findings worth the note:

- **`serpent` measured latency on the wall clock.** Freezing the sim did nothing — **a three-minute read put a 180,000 ms answer on a child's record.** With the ladder now steering on latency, that is a competent child permanently classified as slow.
- **MONUMENT's manual says "Waiting never costs you anything"** while `sim.dither` compounded behind the sheet to its 1.9× ceiling.

## ARENA absorbs the exact number (#690)

`10 + 4 = 14` because that is what happens. Rivals too — the screen draws `Math.round(rmass[k])`, so eating a core reading 300 at mass 400 printed `400 + 84 = 484`.

Self-review found a live exploit **that also exists in 0.3.1**: the surge exhaust could be re-eaten, reaching **4,268,470,964 at four minutes** — invisible because `world.surging` was never `true` anywhere in the test suite.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb