### PR TITLE
fix(dynawalla/games): the last two games through the audio ceiling

### DIFF
--- a/dynawalla/games/arena/src/feel/audio.ts
+++ b/dynawalla/games/arena/src/feel/audio.ts
@@ -10,6 +10,8 @@
  * Sound never carries information alone: every cue here has a visual twin.
  */
 
+import { createSafetyBus, type SafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 type Voice = { stop(at: number): void }
 
 const NOTES = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24] // minor pentatonic + octaves
@@ -17,6 +19,16 @@ const NOTES = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24] // minor pentatonic + oct
 export class Audio {
   private ctx: AudioContext | null = null
   private master!: GainNode
+  /**
+   * The shared ceiling every pack's output passes through.
+   *
+   * ARENA measured 1.409 peak with 636 clipped samples on six simultaneous cues
+   * — it was one of the two games the fleet audio pass could not route because
+   * this file was being edited at the time. The bus is a `WaveShaperNode`, so
+   * the largest entry in its curve is the largest sample that can be emitted
+   * for any input; the limiter in front of it is comfort, not the guarantee.
+   */
+  private safety!: SafetyBus
   private tone!: BiquadFilterNode
   private comp!: DynamicsCompressorNode
   private wetSend!: GainNode
@@ -103,7 +115,9 @@ export class Audio {
     wetGain.connect(this.tone)
     this.tone.connect(this.comp)
     this.comp.connect(this.master)
-    this.master.connect(ctx.destination)
+    // The one line that used to read `this.master.connect(ctx.destination)`.
+    this.safety = createSafetyBus(ctx)
+    this.master.connect(this.safety.input)
 
     const nb = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate)
     const nd = nb.getChannelData(0)

--- a/dynawalla/games/claim/src/game/audio.ts
+++ b/dynawalla/games/claim/src/game/audio.ts
@@ -5,6 +5,8 @@
 // is disableable and never carries information on its own: everything you can
 // hear, you can also see.
 
+import { createSafetyBus, type SafetyBus } from "../../../../packs/shared/game-audio/index.ts"
+
 const A4 = 440
 /** Pentatonic minor degrees in semitones — nothing here can sound wrong. */
 const SCALE = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24]
@@ -16,6 +18,14 @@ function hz(semitonesFromA4: number): number {
 export class Audio {
   private ctx: AudioContext | null = null
   private master: GainNode | null = null
+  /**
+   * The shared ceiling every pack's output passes through.
+   *
+   * CLAIM was one of the two games the fleet audio pass could not route, because
+   * this file was being edited at the time. The bus is a `WaveShaperNode`, so the
+   * largest entry in its curve is the largest sample emittable for any input.
+   */
+  private safety: SafetyBus | null = null
   private noiseBuf: AudioBuffer | null = null
   private tensionOsc: OscillatorNode | null = null
   private tensionGain: GainNode | null = null
@@ -35,7 +45,9 @@ export class Audio {
     const ctx = new Ctor()
     const master = ctx.createGain()
     master.gain.value = 0.55
-    master.connect(ctx.destination)
+    // The one line that used to read `master.connect(ctx.destination)`.
+    this.safety = createSafetyBus(ctx)
+    master.connect(this.safety.input)
     this.ctx = ctx
     this.master = master
 

--- a/dynawalla/packs/shared/game-audio/routing.test.ts
+++ b/dynawalla/packs/shared/game-audio/routing.test.ts
@@ -30,7 +30,9 @@ const GAMES = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "g
  * `arena` and `claim` are here because they were being edited by other agents
  * at the time this landed, not because there is anything different about them.
  */
-const NOT_YET_ROUTED = new Set(["arena", "claim"])
+// Empty, and it must stay that way: the assertion below fails when a game on
+// this list no longer needs to be, so a stale exception cannot rot here.
+const NOT_YET_ROUTED = new Set<string>([])
 
 /** Files that are allowed to mention `.destination`: they are not real graphs. */
 const isDouble = (p: string): boolean => p.includes("fake") || p.endsWith(".test.ts")


### PR DESCRIPTION
The fleet audio pass (#676, #680) routed 25 of 27 games through the shared `WaveShaperNode` ceiling and had to skip **`arena`** and **`claim`** — both files were being edited by other agents at the time. They were recorded on `routing.test.ts`'s `NOT_YET_ROUTED` list rather than left silent.

ARENA measured **1.409 peak with 636 clipped samples** on six simultaneous cues — one of the eighteen of twenty-five measurable games that clipped.

One line each, the same shape the other 25 use. **`NOT_YET_ROUTED` is now empty**, so the gate covers every game with no exceptions.

## Proof the gate bites

Un-routed arena and ran the gate:

```
✖ arena
  AssertionError: arena connects to the audio output without passing the shared ceiling:
    arena/src/feel/audio.ts:119  this.master.connect(ctx.destination)
```

## Verification

arena 71/71, claim 78/78, game-audio 79/79 — three consecutive runs each, `tsc` clean on both games, **on Node 24.18.0 to match CI** (Node 22's type stripping does not link-check named exports, which bit an earlier PR).

## Not verified

**Nothing was heard.** The ceiling is a proof about peak samples, not about whether these two games still sound good — the same honest gap the original audio pass recorded.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb