### PR TITLE
fix(dynawalla/games/runner): VOLTA was one inline CSS declaration wide of a black screen

### DIFF
--- a/dynawalla/games/runner/README.md
+++ b/dynawalla/games/runner/README.md
@@ -103,6 +103,30 @@ read.
   `subtract-across-zero`, and `docs/EXPERIENCE_DESIGN.md` instruments two-digit
   regrouping at p50 6s; a gate cycle — read it, then run the corridor — is about
   5.3 seconds, which is the number that has to answer to that table.
+- **The sum arrives a corridor before the gate does.** The far plane caps the time
+  between a gate becoming visible and reaching the answer plane at 3.20s at p50
+  however the pacing is tuned, which is half of that 6s. So the next question is
+  drawn as soon as the last one resolves and its prompt goes on the HUD three
+  tenths of a second later — the crossing keeps that much of the corridor, so a
+  new sum is never part of the verdict on the old one. A child then has 4.80s at
+  p50 with a question instead of 3.20s. Two things this deliberately is not: it is
+  **not** a hazard-free window (pylons live in the corridor, and the window in
+  which nothing can hit you is still the gate's own), and it is **not** 6s. The
+  last second has to come from the low tier's draw distance or from terminal
+  velocity, and both of those are decisions about frame rate and feel rather than
+  about reading. `pacing.test.ts` pins the number as a band so neither shrinking
+  the pre-read nor quietly reaching the target goes unnoticed.
+- **The host's element is the only thing on screen with a size.** The canvas and
+  every HUD layer are `position:absolute; inset:0` inside it, so a stage with no
+  box is the whole game gone. `pack.html` gives `#app` its box with
+  `position: fixed; inset: 0` and nothing else — no width, no height — and VOLTA
+  shipped one line that wrote an inline `position: relative` over it. That won the
+  cascade, took the insets with it, collapsed the stage to 820x0 and the canvas to
+  one CSS pixel tall, and put a child in front of black glass on iOS and Android
+  alike. It never showed in `npm run dev`, where `index.html` also gives `#game`
+  `width/height: 100%` and a percentage height survives the overwrite. `makeStage`
+  branches on the *computed* position now, and `resize()` says so out loud if the
+  stage ever measures nothing again.
 - **Nothing to dodge ever arrives while a gate is being read.** A hazard spawns
   at the horizon and is airborne for five to seven seconds, so keeping that
   promise means projecting the gate cycle forward to where the hazard will land,

--- a/dynawalla/games/runner/src/game/chrome.test.ts
+++ b/dynawalla/games/runner/src/game/chrome.test.ts
@@ -18,6 +18,7 @@
  * margin and every `hitsHostChrome` assertion trips.
  */
 
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
@@ -27,7 +28,15 @@ import {
   safeRect,
   type Insets,
 } from "../../../../packs/shared/game-chrome/index.ts";
-import { hudEdge, ndcFrame, readoutRect, READOUT_CLEAR } from "./chrome.ts";
+import {
+  hudEdge,
+  makeStage,
+  ndcFrame,
+  readoutRect,
+  READOUT_CLEAR,
+  STAGE_BG,
+  type StageEl,
+} from "./chrome.ts";
 import { BAND, FULL_FRAME, payoffEdge, popupEdge, readBand } from "./readband.ts";
 import { INK, TRACK } from "./glyphs.ts";
 
@@ -233,5 +242,113 @@ test("the payoff and the score popups honour the same frame", () => {
       assert.ok(ndcToPx(popupEdge(f.edge), w) <= w - insets.right, "a popup can reach the cutout");
       assert.ok(h > 0);
     }
+  }
+});
+
+/* ------------------------------- the stage -------------------------------- */
+
+/**
+ * What `pack.html` declares about the element the pack mounts into.
+ *
+ * Read out of the real file rather than restated here, because the defect this
+ * section pins is exactly a disagreement between that file and this game's code:
+ * the only box `#app` has comes from the stylesheet, and any inline `position`
+ * the game writes wins over it.
+ */
+function packStageRule(): Map<string, string> {
+  const html = readFileSync(new URL("../../pack.html", import.meta.url), "utf8");
+  const rule = /#app\s*\{([^}]*)\}/.exec(html);
+  assert.ok(rule, "pack.html has no #app rule; this test is measuring the wrong element");
+  const decls = new Map<string, string>();
+  for (const part of (rule[1] ?? "").split(";")) {
+    const colon = part.indexOf(":");
+    if (colon < 0) continue;
+    decls.set(part.slice(0, colon).trim(), part.slice(colon + 1).trim());
+  }
+  return decls;
+}
+
+/**
+ * The used height of the stage in CSS pixels, on a `viewportH`-tall surface.
+ *
+ * A deliberately tiny slice of CSS, and only the slice VOLTA's layout depends
+ * on: every child of the stage is `position:absolute; inset:0`, so the stage has
+ * no in-flow content and `height: auto` resolves to zero. It gets a height from
+ * exactly two places — an explicit `height`, or being out of flow with both
+ * `top` and `bottom` pinned. Inline declarations beat the stylesheet, which is
+ * the whole mechanism of the bug.
+ */
+function stageHeight(
+  sheet: Map<string, string>,
+  inline: Map<string, string>,
+  viewportH: number,
+): number {
+  const used = (prop: string): string | undefined => inline.get(prop) ?? sheet.get(prop);
+  const height = used("height");
+  if (height === "100%") return viewportH;
+  if (height !== undefined && height.endsWith("px")) return Number.parseFloat(height);
+
+  const position = used("position") ?? "static";
+  const inset = used("inset");
+  const top = used("top") ?? inset;
+  const bottom = used("bottom") ?? inset;
+  const outOfFlow = position === "fixed" || position === "absolute";
+  if (outOfFlow && top === "0" && bottom === "0") return viewportH;
+  // In flow, height auto, and nothing in flow inside it.
+  return 0;
+}
+
+test("the pack's stage is sized only by being out of flow", () => {
+  // The precondition that makes the rest of this section mean anything. If
+  // pack.html ever gives #app a height of its own, an inline `position` stops
+  // being able to collapse it and these tests are measuring a bug that is gone.
+  const sheet = packStageRule();
+  assert.equal(sheet.get("height"), undefined, "#app now has a height; re-derive this section");
+  assert.equal(stageHeight(sheet, new Map(), 1180), 1180, "#app has no box even untouched");
+});
+
+test("an inline position on the stage collapses the whole game to nothing", () => {
+  // The failure, stated. `el.style.position = el.style.position || "relative"`
+  // read the INLINE position, which is empty for an element positioned from a
+  // stylesheet, so it always fired — and took `inset: 0` with it. Measured in a
+  // framed pack before the fix: #app 820x0, canvas style height 1px, black glass
+  // and nothing else, on iOS and Android alike.
+  const sheet = packStageRule();
+  assert.equal(stageHeight(sheet, new Map([["position", "relative"]]), 1180), 0);
+  assert.equal(stageHeight(sheet, new Map([["position", "static"]]), 1180), 0);
+});
+
+test("makeStage leaves a stage the document has already positioned alone", () => {
+  const sheet = packStageRule();
+  // What a browser computes for #app at the moment `mountRunner` runs.
+  const computed = sheet.get("position") ?? "static";
+  const el: StageEl = { style: { position: "", overflow: "", touchAction: "", background: "" } };
+  makeStage(el, computed);
+
+  const inline = new Map<string, string>();
+  if (el.style.position !== "") inline.set("position", el.style.position);
+  assert.equal(
+    stageHeight(sheet, inline, 1180),
+    1180,
+    `makeStage wrote position:${el.style.position} over the document's ${computed}`,
+  );
+});
+
+test("makeStage still positions a stage nobody else has", () => {
+  // A host that hands over a plain in-flow div — the dev harness before its own
+  // stylesheet existed, and any future host — still needs the canvas and the HUD
+  // to have something to be absolute against.
+  const el: StageEl = { style: { position: "", overflow: "", touchAction: "", background: "" } };
+  makeStage(el, "static");
+  assert.equal(el.style.position, "relative");
+});
+
+test("makeStage takes the rest of the stage either way", () => {
+  for (const computed of ["static", "relative", "absolute", "fixed", "sticky"]) {
+    const el: StageEl = { style: { position: "", overflow: "", touchAction: "", background: "" } };
+    makeStage(el, computed);
+    assert.equal(el.style.overflow, "hidden", computed);
+    assert.equal(el.style.touchAction, "none", computed);
+    assert.equal(el.style.background, STAGE_BG, computed);
   }
 });

--- a/dynawalla/games/runner/src/game/chrome.ts
+++ b/dynawalla/games/runner/src/game/chrome.ts
@@ -33,6 +33,58 @@ import {
 } from "../../../../packs/shared/game-chrome/index.ts";
 import { BAND, type Frame } from "./readband.ts";
 
+/* --------------------------------- the stage ------------------------------ */
+
+/** The colour of an empty causeway, so a resize never flashes white. */
+export const STAGE_BG = "#04060f";
+
+/**
+ * Just enough of an element for `makeStage`: the inline style it writes.
+ *
+ * Structural rather than `HTMLElement` so a test can hand it an object literal
+ * and read back exactly what was written, with no cast and no DOM.
+ */
+export type StageEl = {
+  style: { position: string; overflow: string; touchAction: string; background: string };
+};
+
+/**
+ * Take the host's element over as VOLTA's stage.
+ *
+ * Everything this game draws — the WebGL canvas and every HUD layer — is
+ * `position:absolute; inset:0`, so the stage is the only node in the tree that
+ * has a size of its own, and it is the host *document* that decides what that
+ * size is. This function's whole job is to not take that away.
+ *
+ * **What it replaces shipped a black screen on every device.** The line was
+ *
+ *     el.style.position = el.style.position || "relative";
+ *
+ * and `el.style.position` reads the *inline* declaration, which is empty for an
+ * element positioned from a stylesheet. `pack.html` says
+ * `#app { position: fixed; inset: 0 }`, so the fallback always fired and wrote
+ * an inline `relative` that won the cascade — taking the `inset: 0` with it,
+ * because insets do nothing to a relatively positioned box. The stage fell back
+ * to `height: auto` with nothing but absolutely positioned children inside it,
+ * measured 820x0, and the canvas came out one CSS pixel tall. Measured in a
+ * framed pack: `#app` 820x0, canvas `style="width:820px;height:1px"`.
+ *
+ * It was invisible in `npm run dev` for one reason. `index.html` gives `#game`
+ * `width:100%; height:100%` as well as a position, and a percentage height still
+ * resolves against `body` once the position is overwritten — so the dev harness
+ * is full-size and the pack entry, which has only `inset: 0` to give it a box, is
+ * not. Only the thing a child runs collapses.
+ *
+ * So: branch on the *computed* position, never the inline one, and write one only
+ * when nobody has positioned the element at all.
+ */
+export function makeStage(el: StageEl, computedPosition: string): void {
+  if (computedPosition === "static") el.style.position = "relative";
+  el.style.overflow = "hidden";
+  el.style.touchAction = "none";
+  el.style.background = STAGE_BG;
+}
+
 /** Clear air between the bottom of a host control and the readout under it. */
 const GAP = 6;
 

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -18,7 +18,7 @@ import { Rng } from "./rng.ts";
 import { biomeAt, biomeLength } from "./biomes.ts";
 import { detectTier, TierController, type TierName } from "./tiers.ts";
 import { buildHud, groupDigits, ringCircumference } from "./hud.ts";
-import { ndcFrame } from "./chrome.ts";
+import { makeStage, ndcFrame } from "./chrome.ts";
 import type { Frame } from "./readband.ts";
 import {
   createInstructions,
@@ -30,7 +30,7 @@ import { Shake, HitStop, FlashBus, Springy, clamp, clamp01, lerp, approach, ease
 import {
   V_START, V_TERMINAL, V_REDUCED_CAP, VOLT_MAX, COST_WRONG_GATE, COST_HAZARD,
   GAIN_GATE, GAIN_SPARK, GAIN_GRAZE, VOLT_BLEED, CHAIN_PER_SURGE, SURGE_MAX,
-  STUMBLE_TIME, CLEAN_READ_SHARE, REVIVE_GRACE,
+  STUMBLE_TIME, CLEAN_READ_SHARE, REVIVE_GRACE, RESOLVE_HOLD,
   speedAt, readWindow, breather, beatTime, difficultyFor,
   gateDistance, hazardLandsOnRead,
 } from "./pacing.ts";
@@ -72,10 +72,10 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
   /* ------------------------------ chrome -------------------------------- */
 
   const params = new URLSearchParams(location.search);
-  el.style.position = el.style.position || "relative";
-  el.style.overflow = "hidden";
-  el.style.touchAction = "none";
-  el.style.background = "#04060f";
+  // The computed position, not the inline one — see `makeStage`. This is the only
+  // place the game asks the browser where the host has put it, and getting it
+  // from `el.style` instead is what made the pack a black screen.
+  makeStage(el, getComputedStyle(el).position);
 
   const canvas = document.createElement("canvas");
   canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none;";
@@ -163,6 +163,8 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
   let nextBeatAt = 60;
   let activeGate: Gate | null = null;
   let pendingQuestion: Question | null = null;
+  /** Whether `pendingQuestion`'s sum is already the one on the HUD. */
+  let promptShown = false;
   let reviveQ: Question | null = null;
   let reviveTimer = 0;
   let reviveLimit = 7;
@@ -270,8 +272,22 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
    * game that reads them once at mount is correct until the first rotation.
    */
   let frameNdc: Frame = ndcFrame(1, 1, safeInsets());
+  /** Said once. A collapsed stage would otherwise say it on every resize. */
+  let saidCollapsed = false;
   function resize(): void {
     const r = el.getBoundingClientRect();
+    // A stage with no box is the whole game gone, and `Math.max(1, ...)` below
+    // turns it into a plausible-looking 1px canvas rather than an error. Say it:
+    // the last time this happened it was a black screen on two platforms that
+    // nothing in the repository noticed.
+    if (!saidCollapsed && (r.width < 2 || r.height < 2)) {
+      saidCollapsed = true;
+      console.error(
+        `[runner] the stage measures ${String(Math.round(r.width))}x${String(Math.round(r.height))}. ` +
+          `The canvas and every HUD layer are position:absolute inside it, so nothing this game ` +
+          `draws has a size. The host's element needs a box of its own — see makeStage in chrome.ts.`,
+      );
+    }
     vw = Math.max(1, Math.round(r.width));
     vh = Math.max(1, Math.round(r.height));
     frameNdc = ndcFrame(vw, vh, safeInsets());
@@ -433,6 +449,7 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     nextBeatAt = 70;
     activeGate = null;
     pendingQuestion = null;
+    promptShown = false;
     reviveLimit = 7;
     lowVoltWarned = false;
     stats.distance = 0; stats.score = 0; stats.gates = 0; stats.gatesRight = 0;
@@ -483,19 +500,55 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
 
   const difficulty = (): number => difficultyFor(surge, stats.gates, stats.gatesRight);
 
+  /**
+   * Put the next sum on the HUD now, during the dodge corridor, before the gate
+   * that carries the three candidates exists.
+   *
+   * The reason is arithmetic, not polish. A gate cannot spawn past the far plane,
+   * so the time between one becoming visible and reaching the answer plane is
+   * 3.20s at p50 however the pacing is tuned (`deliveredWindow`), and
+   * `docs/EXPERIENCE_DESIGN.md` instruments a two-digit regroup at p50 6s. The
+   * game was asking for the whole computation in half the time the product says
+   * it takes. Showing the sum a corridor early is the part of that gap that costs
+   * nothing: `comprehensionWindow` measures 4.80s at p50 instead of 3.20s.
+   *
+   * It is not a hazard-free window and this must not turn into one — pylons live
+   * in the corridor, which is what #665 built it for. This is time a child *may*
+   * spend computing while they run; the window in which nothing can hit them is
+   * still the gate's own.
+   *
+   * Idempotent: once a question is pending, `requestGate` is the only thing that
+   * consumes it.
+   */
+  function preRead(): void {
+    if (activeGate || pendingQuestion) return;
+    const q = host.next({ difficulty: difficulty() });
+    pendingQuestion = q;
+    promptShown = true;
+    setPrompt(q.prompt);
+  }
+
   function requestGate(): void {
     if (activeGate) return;
+    // A pre-read question is already the sum on the HUD; punching the prompt
+    // again would be a second announcement of a question the child has been
+    // reading for a second and a half.
+    const announced = pendingQuestion !== null && promptShown;
     const q = pendingQuestion ?? host.next({ difficulty: difficulty() });
     pendingQuestion = null;
     const w = readWindow(travel, reduced());
     const dist = gateDistance(speed, w, tiers.settings.far);
     const g = ents.spawnGate(q, dist, dist / Math.max(1, speed), rng);
     if (!g) {
+      // Held for the next attempt, prompt and all: `promptShown` is deliberately
+      // left alone so a pre-read sum is not announced twice when the gate that
+      // was going to carry it could not be spawned.
       pendingQuestion = q;
       return;
     }
     activeGate = g;
-    setPrompt(q.prompt);
+    if (!announced) setPrompt(q.prompt);
+    promptShown = false;
     audio.uiTick();
   }
 
@@ -1046,6 +1099,13 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
       }
       if (!activeGate) {
         gateCooldown -= dt;
+        // The corridor opens with the answer the child just gave still on the
+        // HUD, and hands them the next sum for the rest of it. Compared against
+        // `breather(travel)` rather than a saved corridor length so the two
+        // corridors that are shorter than a corridor — the 0.75s at the start of
+        // a run and the 1.1s after a hazard — pre-read immediately, which is what
+        // a child picking themselves up wants anyway.
+        if (gateCooldown <= breather(travel) - RESOLVE_HOLD) preRead();
         if (gateCooldown <= 0) requestGate();
       }
 

--- a/dynawalla/games/runner/src/game/pacing.test.ts
+++ b/dynawalla/games/runner/src/game/pacing.test.ts
@@ -3,8 +3,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   speedAt, readWindow, breather, beatTime, difficultyFor,
-  gateDistance, deliveredWindow, hazardLandsOnRead,
+  gateDistance, deliveredWindow, comprehensionWindow, hazardLandsOnRead,
   READ_WINDOW_FLOOR, DELIVERED_WINDOW_FLOOR, DODGE_CORRIDOR_FLOOR,
+  COMPREHENSION_FLOOR, RESOLVE_HOLD,
   V_SURGE_BOOST_MAX, GATES_PER_STEP,
   V_START, V_TERMINAL, V_REDUCED_CAP,
   COST_WRONG_GATE, COST_HAZARD, GAIN_GATE, VOLT_BLEED, VOLT_MAX,
@@ -33,6 +34,11 @@ type Sim = {
   arrivals: number;
   readingDuty: number;
   minDelivered: number;
+  /**
+   * The shortest time any gate's sum spent on the HUD before that gate reached
+   * the answer plane — the pre-read corridor plus the gate's own window.
+   */
+  minComprehension: number;
 };
 
 function replay(opts: { until: number; from?: number; far: number; guard?: boolean }): Sim {
@@ -47,6 +53,9 @@ function replay(opts: { until: number; from?: number; far: number; guard?: boole
   const hazards: number[] = [];
   let gates = 0, hit = 0, arrivals = 0, reading = 0, live = 0;
   let minDelivered = Infinity;
+  let minComprehension = Infinity;
+  /** `elapsed` when the sum for the *next* gate went on the HUD, or null. */
+  let promptAt: number | null = null;
 
   while (elapsed < until) {
     elapsed += dt;
@@ -73,14 +82,22 @@ function replay(opts: { until: number; from?: number; far: number; guard?: boole
     if (gate && gate.z >= 0) {
       gate = null;
       gateCooldown = breather(travel);
-      if (elapsed >= from) gates++;
+      if (elapsed >= from) {
+        gates++;
+        if (promptAt !== null) minComprehension = Math.min(minComprehension, elapsed - promptAt);
+      }
+      promptAt = null;
     }
     if (!gate) {
       gateCooldown -= dt;
+      // `preRead()`: the next sum goes on the HUD partway through the corridor.
+      if (promptAt === null && gateCooldown <= breather(travel) - RESOLVE_HOLD) promptAt = elapsed;
       if (gateCooldown <= 0) {
         const dist = gateDistance(speed, readWindow(travel, false), far);
         gate = { z: -dist };
         minDelivered = Math.min(minDelivered, dist / speed);
+        // A corridor shorter than the hold hands the sum over with the gate.
+        if (promptAt === null) promptAt = elapsed;
       }
     }
 
@@ -107,6 +124,7 @@ function replay(opts: { until: number; from?: number; far: number; guard?: boole
     arrivals,
     readingDuty: reading / live,
     minDelivered,
+    minComprehension,
   };
 }
 
@@ -240,6 +258,86 @@ test("the reading window answers to the cadence table, not to vibes", () => {
   // actually spends on one question, and it should land near that 6s p50.
   const cycle = READ_WINDOW_FLOOR + DODGE_CORRIDOR_FLOOR;
   assert.ok(cycle >= 4.5 && cycle <= 9, `${cycle}s per question is outside the cadence table`);
+});
+
+test("the child has the sum before the gate that carries the answers", () => {
+  // The pre-read. `deliveredWindow` is capped by the far plane at 3.20s at p50
+  // however the pacing is tuned, and EXPERIENCE_DESIGN instruments a two-digit
+  // regroup at p50 6s — so the sum goes on the HUD a corridor early and the
+  // corridor becomes reading time too. This asserts the *combined* number, which
+  // is the one a child experiences.
+  for (const far of FARS) {
+    for (let speed = V_START; speed <= V_TERMINAL * V_SURGE_BOOST_MAX + 0.01; speed += 0.5) {
+      for (const travel of [0, 2600, 20000, 1e6]) {
+        for (const reduced of [false, true]) {
+          const c = comprehensionWindow(travel, speed, far, reduced);
+          assert.ok(
+            c >= COMPREHENSION_FLOOR - 1e-9,
+            `far=${far} speed=${speed.toFixed(1)} travel=${travel} reduced=${String(reduced)}: ` +
+              `only ${c.toFixed(2)}s with the question`,
+          );
+          // And it is genuinely more than the gate alone gives, everywhere. A
+          // pre-read that collapses to the gate's own window is the bug back.
+          assert.ok(
+            c >= deliveredWindow(travel, speed, far, reduced) + DODGE_CORRIDOR_FLOOR - RESOLVE_HOLD - 1e-9,
+            `far=${far} speed=${speed.toFixed(1)}: the pre-read added nothing`,
+          );
+        }
+      }
+    }
+  }
+  // Measured through the real scheduling loop rather than from the formula, with
+  // the pre-read wired in exactly where `mount.ts` puts it.
+  for (const far of FARS) {
+    const late = replay({ until: 300, from: 90, far });
+    assert.ok(late.gates > 8, `far=${far}: only ${late.gates} gates, nothing was measured`);
+    assert.ok(
+      late.minComprehension >= COMPREHENSION_FLOOR - 1e-9,
+      `far=${far}: a real run gave a child ${late.minComprehension.toFixed(2)}s with a question`,
+    );
+    // The hazard-free part is untouched — that is the promise the pre-read must
+    // not be allowed to quietly absorb, because pylons live in the corridor.
+    assert.ok(
+      late.minDelivered >= DELIVERED_WINDOW_FLOOR - 1e-9,
+      `far=${far}: the gate's own window fell to ${late.minDelivered.toFixed(2)}s`,
+    );
+  }
+});
+
+test("and the pre-read is wired into the corridor, not just available", () => {
+  // Same reason as the hazard guard below: the replay above is a model of the
+  // loop, so it would still pass if `mount.ts` never called `preRead`. What is
+  // pinned is that the corridor branch calls it, that it runs before the gate is
+  // requested, and that the prompt is announced once rather than twice.
+  const src = readFileSync(new URL("./mount.ts", import.meta.url), "utf8");
+  const loop = src.slice(src.indexOf("if (!activeGate) {"), src.indexOf("if (travel >= nextBeatAt)"));
+  assert.ok(loop.length > 80, "the corridor branch has moved; this test needs re-aiming");
+  assert.ok(loop.includes("preRead()"), "the corridor must hand the child the next sum");
+  assert.ok(
+    loop.indexOf("preRead()") < loop.indexOf("requestGate()"),
+    "the sum has to be on the HUD before the gate carrying its answers is spawned",
+  );
+  assert.ok(loop.includes("RESOLVE_HOLD"), "the corridor must still open with the answer just given");
+  // One announcement per question: `requestGate` re-punches the prompt only when
+  // the question was not pre-read.
+  const req = src.slice(src.indexOf("function requestGate("), src.indexOf("function resolveGate("));
+  assert.ok(req.includes("if (!announced) setPrompt("), "a pre-read sum must not be announced twice");
+});
+
+test("the pre-read is still short of the cadence table, and that is written down", () => {
+  // EXPERIENCE_DESIGN wants p50 6s. The pre-read reaches 4.79-4.80s and cannot
+  // reach further: `readWindow` already sits at the largest floor the far plane
+  // can honour, so the remaining second has to come from the low tier's draw
+  // distance or from terminal velocity, and both of those are decisions about
+  // frame rate and feel rather than about reading. Pinned as a band so that
+  // shrinking the pre-read fails here, and so does reaching the target without
+  // updating the note in `pacing.ts` and the README.
+  const late = replay({ until: 300, from: 90, far: 300 });
+  assert.ok(
+    late.minComprehension >= COMPREHENSION_FLOOR && late.minComprehension < 6.0,
+    `the worst comprehension window is now ${late.minComprehension.toFixed(2)}s — ` +
+      "if that is 6s or more, the cadence table is met and the caveats should go",
+  );
 });
 
 test("a hazard is only held back when it would actually land on a read", () => {

--- a/dynawalla/games/runner/src/game/pacing.ts
+++ b/dynawalla/games/runner/src/game/pacing.ts
@@ -114,6 +114,22 @@ export function breather(travel: number): number {
   return DODGE_CORRIDOR_FLOOR + 1.0 * Math.exp(-Math.max(0, travel) / 2200);
 }
 
+/**
+ * How long the corridor still belongs to the gate that just resolved.
+ *
+ * The next sum goes on the HUD during the corridor, not when the gate carrying
+ * its candidates appears — that is the pre-read `comprehensionWindow` measures.
+ * But swapping it in on the very frame the child crosses the answer plane makes
+ * the new question part of the verdict on the old one, and the crossing is
+ * already the busiest frame in the game.
+ *
+ * 0.3s: eighteen frames, enough that the swap is plainly a separate event from
+ * the crossing, and a sixth of the corridor rather than a quarter of it. Every
+ * tenth of a second here is a tenth taken off the pre-read, which is the whole
+ * reason the pre-read exists, so it is not rounded up for comfort.
+ */
+export const RESOLVE_HOLD = 0.3;
+
 /* --------------------------- gate geometry ---------------------------- */
 
 /** Nearest a gate may spawn — closer than this and it is on top of you. */
@@ -142,6 +158,40 @@ export function gateDistance(speed: number, window: number, far: number): number
 export const DELIVERED_WINDOW_FLOOR = 3.1;
 export function deliveredWindow(travel: number, speed: number, far: number, reduced: boolean): number {
   return gateDistance(speed, readWindow(travel, reduced), far) / Math.max(1, speed);
+}
+
+/**
+ * The whole time a child has with a question: the dodge corridor the prompt is
+ * *already on the HUD* for, plus the gate's own hazard-free window.
+ *
+ * **Why this number exists.** `deliveredWindow` is the time between a gate
+ * becoming visible and reaching the answer plane, and it is capped by the far
+ * plane: measured across a ten-minute run at every tier, with and without the
+ * surge speed bonus, it is 3.19s at worst and 3.20s at p50.
+ * `docs/EXPERIENCE_DESIGN.md` instruments two-digit regrouping at p50 6s, so
+ * VOLTA was asking for a two-digit regroup in slightly over half the time the
+ * product says one takes.
+ *
+ * The geometry cannot give more. `readWindow` already sits at the largest floor
+ * the far plane can honour (3.2s — raise it and `gateDistance` clamps it back
+ * down, which is the exact lie #665 removed), so a longer hazard-free window
+ * needs the low tier's draw distance or the terminal velocity to move, and both
+ * of those are decisions about frame rate and feel rather than about reading.
+ *
+ * What is free is *when the child is told the sum*. The question is drawn a
+ * corridor early and its prompt goes on the HUD then, so the corridor is reading
+ * time too: measured through the real scheduling loop, 4.79s at worst and 4.80s
+ * at p50, up from 3.19s and 3.20s.
+ *
+ * **This is not the same promise as `deliveredWindow` and must not be read as
+ * one.** Hazards live in the corridor — that is what #665 built it for — so the
+ * pre-read is time a child *may* use to compute, while dodging, and the window
+ * in which nothing can hit them is still `deliveredWindow`. It is still short of
+ * 6s p50 and the reason is written down above.
+ */
+export const COMPREHENSION_FLOOR = 4.7;
+export function comprehensionWindow(travel: number, speed: number, far: number, reduced: boolean): number {
+  return Math.max(0, breather(travel) - RESOLVE_HOLD) + deliveredWindow(travel, speed, far, reduced);
 }
 
 /* ------------------------- the reading corridor ------------------------ */


### PR DESCRIPTION
VOLTA did not load on iOS or Android. It was never a device problem, a
bundling problem or a throw: the pack mounted cleanly, handshook with the host,
warmed its question pool, built its WebGL context and its HUD, and then drew all
of it into a box 820 pixels wide and **zero pixels tall**.

    el.style.position = el.style.position || "relative";

`el.style.position` is the *inline* declaration, and it is empty for an element
positioned from a stylesheet — so the fallback always fired. `pack.html` gives
`#app` its entire box with `position: fixed; inset: 0` and nothing else: no
width, no height. An inline `relative` beats that rule, and insets do nothing to
a relatively positioned box, so the stage fell back to `height: auto` with
nothing but absolutely positioned children in it. Measured in a framed pack
before the fix: `#app` 820x0, canvas `style="width:820px;height:1px"`,
`#04060f` from edge to edge and nothing else.

Both platforms, because it is CSS. Never in `npm run dev`, because `index.html`
gives `#game` `width:100%; height:100%` as well as a position and a percentage
height still resolves once the position is overwritten — the dev harness is
full-size and the only entry a child ever runs is the one that collapses.

`makeStage` branches on the **computed** position instead, and writes one only
when nobody has positioned the element at all. `resize()` also now says out loud
once when the stage measures under two pixels on either axis, because
`Math.max(1, ...)` turns a missing stage into a plausible-looking 1px canvas and
that is how this shipped.

Proof, and the failure with the fix deleted. `chrome.test.ts` reads the real
`#app` rule out of `pack.html`, resolves the two-declaration cascade the bug
lives in, and asserts the stage still has a box after `makeStage` has run.
Reverting `makeStage` to the old expression:

    ✖ makeStage leaves a stage the document has already positioned alone
      AssertionError: makeStage wrote position:relative over the document's fixed
      0 !== 1180

Verified in a headless browser as well, on the built `dist-pack`, framed in an
opaque-origin iframe by a stub host that answers `items.next`/`items.reveal` the
way the app's bridge does — 820x0 and a black frame before, 820x1180 and a
playable causeway after, plus a run driven to a live gate. Neither device has
been touched by anybody here: what is proven is the layout and the arithmetic,
and what is inferred is that iOS and Android had no third cause.

**Two findings for other people's files, not touched here.**

`games/merge` (FUSE) has the identical line, against the identical shape of
`pack.html` (`#root { position: fixed; inset: 0 }`, canvas `position:absolute`),
and its stage measures 820x0 in a framed pack for exactly the same reason. It is
the only other instance in the fleet. **It is not broken**, and that was measured
rather than assumed: FUSE renders and plays, because it never writes
`overflow: hidden` on the stage — so the canvas paints outside the collapsed box
instead of being clipped to nothing — and because it sizes that canvas with
`el.clientHeight || window.innerHeight`, whose `||` happens to catch the zero.
Latent, not live: one `overflow: hidden` or one honest measurement away from
being this bug. Not touched here, and nobody should read this commit as having
fixed it or as saying it needs no attention.

And the host cannot see this class of failure at all. `packs/frame.ts` has a
20s handshake timeout that catches a pack which never posts `ready`, which is
the right net for a pack that throws before `connect()`. After the port is
transferred there is no liveness check of any kind, so a pack that connects and
then renders nothing is indistinguishable from a working one — which is exactly
the gap this bug lived in for its whole life. Relatedly, every game's entry
catches a mount throw and calls `renderNoHost()`, which draws "VOLTA runs inside
Dynawalla" — a pack that crashed while mounting tells a child there is no host
when there is one.

── the reading window, since the file was open ──────────────────────────────

#665 left `deliveredWindow` measuring a promise it could not keep. The far
plane caps the time between a gate becoming visible and reaching the answer
plane; measured across a ten-minute run at every tier, with and without the
surge speed bonus, that is 3.19s at worst and 3.20s at p50.
`docs/EXPERIENCE_DESIGN.md` instruments a two-digit regroup at p50 6s, and this
pack covers `subtract-across-zero`. VOLTA was asking for the whole computation
in slightly over half the time the product says one takes.

The geometry cannot give more: `readWindow` already sits at the largest floor
the far plane can honour, and raising it makes `gateDistance` clamp it back
down, which is the exact lie #665 removed. What is free is *when the child is
told the sum*. The next question is now drawn as soon as the last one resolves
and its prompt goes on the HUD `RESOLVE_HOLD` = 0.3s later — the crossing keeps
that much of the corridor so a new sum is never part of the verdict on the old
one. `comprehensionWindow` measures 4.79s at worst and 4.80s at p50, up from
3.19s and 3.20s.

It is deliberately **not** a hazard-free window. Pylons live in the corridor;
that is what #665 built the corridor for. The window in which nothing can hit a
child is still `deliveredWindow`, and `minDelivered` is asserted unchanged in
the same test. And it is **not** 6s: the last second has to come from the low
tier's draw distance or from terminal velocity, and both are decisions about
frame rate and feel rather than about reading. That is pinned as a band, so
shrinking the pre-read fails and so does reaching the target without updating
the note.

Removing each fix, in turn:

    ✖ and the pre-read is wired into the corridor, not just available
      AssertionError: the corridor must hand the child the next sum
    ✖ the child has the sum before the gate that carries the answers
      AssertionError: far=300 speed=27.0: the pre-read added nothing
    ✖ and the pre-read is wired into the corridor, not just available
      AssertionError: a pre-read sum must not be announced twice

81 tests, five consecutive runs, plus `npm run tsc`, both builds, and
`dw-pack check` on the staged pack.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb