### PR TITLE
fix(dynawalla/games/trebuchet): a keep stands at the answer, so the answer has to fit on the field

### DIFF
--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -161,10 +161,259 @@ function newGame(answers: number[], wave: number): ReturnType<typeof installDom>
   game.manualDrive()
   game.jumpToWave(wave)
   assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the wave never became playable')
+  // A wave that is "playable" with nothing in the rack is the bug this guard
+  // exists for: `phase` reached 'aim' happily with no boulder and no question,
+  // and every assertion below it read -1 and passed anyway.
+  assert.notEqual(game.currentAnswer(), -1, 'the wave became playable with an empty rack')
   return { ...dom, game, reports }
 }
 
+/**
+ * A host that behaves like the shipped one: the answers it serves depend on the
+ * difficulty the game asks for, and the game cannot see the mapping.
+ *
+ * The numbers are the measured ladder. `ladder()` over the shipped 66 rungs, at
+ * the difficulties `waveConfig` asks for, returns `dw.add.facts.subtract-within-ten`
+ * (answers 0-9) at the bottom, two-digit answers in the middle, and
+ * `dw.add.column.subtract-no-regroup` / `dw.mul.scale.times-power-of-ten`
+ * (answers in the thousands and the millions) above it. Only the middle fits on a
+ * 122-metre field.
+ *
+ * `lagPulls` models the other half of the real host: the question pool is refilled
+ * ASYNCHRONOUSLY, so the first few `next()` calls after a difficulty change still
+ * return the old rung. A game that retried inside one synchronous call would never
+ * see the new questions at all.
+ */
+function ladderHost(lagPulls = 0, startDifficulty = 0.04): { host: Host; asks: number[] } {
+  const asks: number[] = []
+  let n = 0
+  // The resting rung, which is near the bottom — so the very first questions a
+  // wave sees are the ones that do not fit, exactly as they do on the device.
+  let difficulty = startDifficulty
+  let pending: number | null = null
+  let lag = 0
+  const answerFor = (d: number): number => {
+    n++
+    // Below the field, on the field, then far above it — monotonic in magnitude,
+    // which is what makes the game's search converge.
+    if (d < 0.22) return n % 10
+    if (d < 0.58) return 14 + ((n * 7) % 100)
+    if (d < 0.75) return 2000 + ((n * 137) % 4000)
+    return 1_000_000 + n
+  }
+  const host: Host & { setDifficulty?: (d: number) => void } = {
+    next: (): Question => {
+      if (pending !== null) {
+        if (lag > 0) lag--
+        else {
+          difficulty = pending
+          pending = null
+        }
+      }
+      const a = answerFor(difficulty)
+      return {
+        id: `q${n}`,
+        prompt: `? = ${a}`,
+        answer: String(a),
+        distractors: [String(a + 11), String(a + 23)],
+        domain: 'add-sub',
+        difficulty,
+      }
+    },
+    report: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => true,
+    setDifficulty: (d: number) => {
+      asks.push(d)
+      pending = d
+      lag = lagPulls
+    },
+  }
+  return { host, asks }
+}
+
 /* ------------------------------------------------------------------ tests */
+
+test('the fire button throws a boulder', () => {
+  // The control a child actually presses, pressed the way she presses it. Every
+  // test in this file used to reach `fireNow()` instead — the harness door — so
+  // `pressBtn`'s `case 'fire'` had no coverage at all, and a fire button that did
+  // nothing was invisible to all 166 of them.
+  const { game, canvas } = newGame([42, 60, 78, 96], 2)
+  assert.equal(game.currentPhase, 'aim')
+  assert.equal(game.fireArmed(), true, 'the button is not offering itself')
+
+  tap(canvas, 'fire')
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'flight'),
+    'tapping fire did not put a boulder in the air',
+  )
+})
+
+test('a stream the field cannot hold still becomes a playable wave', () => {
+  // The founder's bug. TREBUCHET stands a keep at the answer in METRES, so it can
+  // only ask a question whose answer fits on 122 metres of field — and the ladder
+  // it was asking for at wave 1 serves differences within ten. Every answer was
+  // dropped, the rack came back empty, and an empty rack has no equation to draw
+  // and no boulder to throw: the child saw no question and the fire button did
+  // nothing. Both symptoms, one cause.
+  const dom = installDom()
+  const { host } = ladderHost()
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the wave never became playable')
+  const answer = game.currentAnswer()
+  assert.notEqual(answer, -1, 'there is no question on the screen')
+  assert.ok(game.towerRanges().includes(answer), 'the answer has no keep to knock down')
+
+  // And it is playable through the real control, not just internally consistent.
+  game.aimAt(answer)
+  tap(dom.canvas, 'fire')
+  assert.ok(runUntil(game, () => game.currentPhase === 'flight'), 'the shot never left')
+})
+
+test('the fire button is never lit over an empty rack', () => {
+  // The other half of the report: the button did not merely fail, it *invited* the
+  // press. `canFire` was `phase === 'aim' || phase === 'intro'` and phase reached
+  // 'aim' with an empty rack, so the button drew lit and pulsing while `fire()`
+  // returned on its second line for want of a boulder. A control that lies about
+  // being ready is worse than one that is plainly dark.
+  //
+  // Asserted as an invariant over a whole run rather than at one moment, because
+  // the moment is the easy part: what has to hold is that the button and the
+  // machine never disagree, in any phase, on any wave.
+  const dom = installDom()
+  const { host } = ladderHost()
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+
+  // Read into a local: asserting on the getter itself narrows its type for the
+  // rest of the function, and the loop below has to be free to see any phase.
+  const opening: string = game.currentPhase
+  assert.equal(opening, 'stocking', 'the wave claimed to be playable')
+  assert.equal(game.fireArmed(), false, 'the fire button is lit over an empty rack')
+
+  let armedFrames = 0
+  for (let i = 0; i < 900; i++) {
+    game.stepFrames(1)
+    if (game.fireArmed()) {
+      armedFrames++
+      assert.notEqual(game.currentAnswer(), -1, `frame ${i}: the button is lit with no boulder`)
+    }
+    if (game.currentPhase === 'aim' && game.currentAnswer() > 0) {
+      game.aimAt(game.currentAnswer())
+      tap(dom.canvas, 'fire')
+    }
+  }
+  assert.ok(armedFrames > 0, 'the button was never armed at all, so nothing was proved')
+})
+
+test('the search for a placeable rung survives a pool that refills late', () => {
+  // The reason stocking is a phase and not a loop. The real host refills its
+  // question pool asynchronously, so the questions that answer a difficulty change
+  // arrive several `next()` calls later. A synchronous retry re-reads the drained
+  // pool for as long as it is willing to spin and concludes, wrongly, that there
+  // is nothing playable anywhere on the ladder.
+  const dom = installDom()
+  const { host, asks } = ladderHost(40)
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim', 2400),
+    'the game never found a rung it could place',
+  )
+  assert.notEqual(game.currentAnswer(), -1)
+  assert.ok(asks.length > 1, 'the game never asked for a different rung')
+  const found = game.stockedDifficulty()
+  assert.ok(found !== null && found >= 0.22 && found < 0.58, `settled on an unplaceable rung ${found}`)
+})
+
+test('a wave that cannot be stocked at all says so out loud', () => {
+  // The one case the search cannot rescue: a ladder with no rung whose answers fit
+  // on 122 metres. The screen then looks exactly like the reported bug — an empty
+  // field, no equation, a dark fire button — so it must not be a silent one.
+  const dom = installDom()
+  let n = 0
+  const host: Host = {
+    next: (): Question => {
+      n++
+      // Nothing this field can hold, at any difficulty.
+      return {
+        id: `q${n}`,
+        prompt: '? = 9000',
+        answer: '9000',
+        distractors: [],
+        domain: 'add-sub',
+        difficulty: 0.5,
+      }
+    },
+    report: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => true,
+  }
+  const said: string[] = []
+  const realError = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(' '))
+  try {
+    const game = new TrebuchetGame(dom.el, host, 0xb01de)
+    game.manualDrive()
+    for (let i = 0; i < 700; i++) game.stepFrames(1) // ~11 s of frames
+    assert.equal(game.currentPhase, 'stocking')
+    assert.equal(game.fireArmed(), false, 'the button is lit on a field with no keeps')
+  } finally {
+    console.error = realError
+  }
+  assert.equal(said.length, 1, `expected exactly one complaint, got ${said.length}`)
+  assert.match(said[0], /cannot be stocked/)
+})
+
+test('a rung far above the field is searched downward, not only upward', () => {
+  // The top end was broken too, and for longer than the bottom: wave 6 asked for a
+  // difficulty that returns four-digit column subtraction and wave 7 one that
+  // returns millions, and neither can put a keep on 122 metres of field. So the
+  // same blank screen and dead button waited for anyone who got that far. The
+  // search has to move both ways.
+  const dom = installDom()
+  const { host } = ladderHost()
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  // Jumped before a single frame runs, so nothing has been found yet and the wave's
+  // own difficulty — 0.832, the millions — is genuinely where the search starts.
+  game.jumpToWave(12)
+  assert.equal(game.stockedDifficulty(), null, 'a band was already known; nothing is being searched')
+  assert.equal(game.currentPhase, 'stocking', 'a wave in the millions claimed to be playable')
+
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim', 2400),
+    'a wave above the field never came back down to it',
+  )
+  const answer = game.currentAnswer()
+  assert.notEqual(answer, -1, 'there is no question on the screen')
+  assert.ok(answer >= 14 && answer <= 118, `${answer} does not fit on the field`)
+  const found = game.stockedDifficulty()
+  assert.ok(found !== null && found < 0.832, `the search never came down from 0.832 (settled ${found})`)
+})
+
+test('a wave configured above the field does not drag the game back off it', () => {
+  // Once a band is known it is kept. `waveConfig` keeps raising the arithmetic it
+  // asks for — 0.83 by wave 12 — and honouring that would walk the stream straight
+  // back out of the window the dial can express. The wave's escalation is wind, the
+  // wall, the ram and the keeps; the arithmetic stops at the width of the field.
+  const dom = installDom()
+  const { host } = ladderHost()
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'wave 1 never stocked')
+  const band = game.stockedDifficulty()
+
+  game.jumpToWave(12)
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim', 2400), 'wave 12 never stocked')
+  assert.equal(game.stockedDifficulty(), band, 'the band found at wave 1 was thrown away')
+  const answer = game.currentAnswer()
+  assert.ok(answer >= 14 && answer <= 118, `${answer} does not fit on the field`)
+})
 
 test('a bullseye stays a bullseye when the dial is nudged mid-flight', () => {
   // Wave 8: wind up to ±5, and the +/- buttons are not phase-gated, so a child

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -91,6 +91,36 @@ const MIN_GAP = 8
 const DIAL_MIN = 8
 const DIAL_MAX = FIELD_MAX
 
+/**
+ * The window of answers this game can physically ask about.
+ *
+ * A keep stands at its own answer in METRES, on a field 122 metres long, and the
+ * blast is wide enough that two keeps must be `MIN_GAP` apart to be distinct
+ * targets. So the answer to every question TREBUCHET poses has to be an integer
+ * in this window — that is not a tuning choice, it is what "the range dial is the
+ * answer" costs.
+ *
+ * Nothing about the question stream guarantees it. The host hands out rungs off a
+ * single cross-domain ladder addressed by a 0..1 difficulty, and a pack cannot
+ * see what arithmetic sits on a rung before it asks. Measured against the shipped
+ * 66-rung ladder, the difficulties this game used to ask for returned:
+ *
+ *     wave 1  d=0.040  dw.add.facts.subtract-within-ten   answers 0-4     0/12 placeable
+ *     wave 2  d=0.112  dw.add.facts.subtract-within-ten   answers 1-9     0/12
+ *     wave 3  d=0.184  dw.add.facts.subtract-across-ten   answers 2-9     0/12
+ *     wave 5  d=0.328  dw.mul.facts.tables-to-twelve      answers 8-81    9/12
+ *     wave 6  d=0.400  dw.add.column.subtract-no-regroup  answers to 5400 0/12
+ *     wave 7  d=0.472  dw.mul.scale.times-power-of-ten    answers in the millions
+ *
+ * Waves 1-3 and 6 upward could not put a single keep on the field, so the rack
+ * came back empty, the equation plaque had nothing to draw and the fire button
+ * had no boulder to throw. That is the whole of the bug this window exists to
+ * make impossible: the game now FINDS a rung it can place instead of assuming it
+ * was handed one.
+ */
+const PLACEABLE_LO = DIAL_MIN + 6
+const PLACEABLE_HI = DIAL_MAX - 4
+
 const PAL: Palette = {
   dust: C.dust,
   debris: [C.stone, C.stoneLit, '#0d1222'],
@@ -161,8 +191,27 @@ export class TrebuchetGame {
   private dialPop = 1
   private aimEmphasis = 0
 
+  /** The distractor pools that came with the rack, kept for the tower layout. */
+  private pools: number[][] = []
+  /**
+   * The difficulty last known to return answers this field can hold, and the
+   * bisection state used to find it. `stockD` survives the wave so the search
+   * runs once a run; the bounds are re-opened per wave.
+   */
+  private stockD: number | null = null
+  private probeD = 0
+  private probeLo = 0
+  private probeHi = 1
+  /** The last difficulty actually stated to the host, so it is not re-stated. */
+  private askedD: number | null = null
+  /** Seconds waited in 'stocking' since the last probe. */
+  private stockT = 0
+  /** Seconds this wave has spent unable to stock, and whether that was said. */
+  private stockStall = 0
+  private toldAboutStocking = false
+
   // shot
-  private phase: Phase = 'intro'
+  private phase: Phase = 'stocking'
   private phaseT = 0
   private shot: Solved | null = null
   private shotT = 0
@@ -340,26 +389,107 @@ export class TrebuchetGame {
       setDifficulty?: (d: number) => void
       setDistractorCount?: (k: number) => void
     }
-    anyHost.setDifficulty?.(cfg.difficulty)
     anyHost.setDistractorCount?.(Math.max(2, cfg.extraTowers + 1))
 
-    const { boulders, pools } = pullQuestions(
+    // The wave is not laid out until there is something to shoot at. `stock()`
+    // asks for a rung and reports whether what came back will fit on the field;
+    // when it will not, the wave waits in 'stocking' and tries again on a later
+    // frame, because the pool behind `host.next()` refills asynchronously and a
+    // synchronous retry can only ever re-read the same drained pool.
+    this.rack = []
+    this.activeIdx = 0
+    this.towers = []
+    this.phase = 'stocking'
+    this.phaseT = 0
+    this.stockT = 0
+    this.stockStall = 0
+    this.probeD = this.stockD ?? cfg.difficulty
+    // A fresh bisection per wave, but seeded from the band already found, so the
+    // search happens once a run and not once a wave.
+    this.probeLo = 0
+    this.probeHi = 1
+    if (!this.stock()) return
+    this.layOutWave()
+  }
+
+  /**
+   * Ask for a rung, and say whether the answers can stand on the field.
+   *
+   * Everything about the request is a request: `setDifficulty` is a 0..1 position
+   * on a ladder whose arithmetic the pack cannot see, so the only way to find out
+   * whether a rung's answers fit in `PLACEABLE_LO..PLACEABLE_HI` is to ask and
+   * look. When they do not, the answers that came back say which way to move —
+   * all too small means ask harder, all too large means ask easier — and answer
+   * magnitude rises with the ladder, so a bisection converges on the band in a
+   * handful of probes instead of sweeping 66 rungs blind.
+   *
+   * The difficulty that worked is remembered in `stockD` for every later wave.
+   * The arithmetic therefore stops climbing at the width of the field, which is
+   * honest: a 122-metre field cannot pose a question whose answer is 5400. The
+   * wave's own escalation — wind, the wall, the ram, more keeps, less ammunition,
+   * the loft lever — is untouched and is where TREBUCHET gets harder.
+   */
+  private stock(): boolean {
+    const cfg = this.cfg
+    const anyHost = this.host as Host & { setDifficulty?: (d: number) => void }
+    // Only when it has actually moved. Re-stating a difficulty makes the host
+    // flush and refill its pool, so asking again for what was already asked keeps
+    // the pool permanently empty — the search would outrun the questions.
+    if (this.askedD !== this.probeD) {
+      this.askedD = this.probeD
+      anyHost.setDifficulty?.(this.probeD)
+    }
+
+    // A small draw, not a drained pool: this may be one probe of several, and
+    // every question pulled is a curriculum item spent.
+    const { boulders, pools, seen } = pullQuestions(
       () => this.host.next(),
       cfg.ammo,
       MIN_GAP,
-      DIAL_MIN + 6,
-      DIAL_MAX - 4,
+      PLACEABLE_LO,
+      PLACEABLE_HI,
+      32,
     )
-    this.rack = boulders
-    this.activeIdx = 0
+    if (boulders.length > 0) {
+      this.rack = boulders
+      this.pools = pools
+      this.stockD = this.probeD
+      return true
+    }
+
+    // Nothing placeable. Steer — but only on questions that came from the rung
+    // that was asked for. Anything else is the pool's previous contents, and
+    // reading it would move the search on evidence about a rung already left.
+    const fresh = seen.filter((s) => Math.abs(s.difficulty - this.probeD) <= 0.08)
+    if (fresh.length === 0) return false
+
+    const tooSmall = fresh.filter((s) => s.answer < PLACEABLE_LO).length
+    const tooBig = fresh.filter((s) => s.answer > PLACEABLE_HI).length
+    if (tooSmall === 0 && tooBig === 0) return false
+    if (tooSmall >= tooBig) {
+      this.probeLo = Math.max(this.probeLo, this.probeD)
+      this.probeD = Math.min(1, (this.probeD + this.probeHi) / 2)
+    } else {
+      this.probeHi = Math.min(this.probeHi, this.probeD)
+      this.probeD = Math.max(0, (this.probeLo + this.probeD) / 2)
+    }
+    return false
+  }
+
+  /** Build the field around the rack `stock()` filled. */
+  private layOutWave(): void {
+    const cfg = this.cfg
+    const boulders = this.rack
+    const pools = this.pools
+    const n = this.wave
 
     const values = layoutTowerValues(
       boulders.map((b) => b.answer),
       pools,
       cfg.extraTowers,
       MIN_GAP,
-      DIAL_MIN + 6,
-      DIAL_MAX - 4,
+      PLACEABLE_LO,
+      PLACEABLE_HI,
       this.rng,
     )
     this.towers = values.map((v, i) => buildTower(i, v, this.rng, cfg.volley && i % 2 === 0))
@@ -580,7 +710,15 @@ export class TrebuchetGame {
       clearHits: this.hitsThisWave,
       clearOf: this.rack.length,
       dialPop: this.dialPop,
-      canFire: this.phase === 'aim' || this.phase === 'intro',
+      // A lit, pulsing fire button over an empty rack was half of the bug: the
+      // control advertised itself as ready and `fire()` returned on the very next
+      // line for want of a boulder. The phase fix is what actually closes that —
+      // 'aim' is now unreachable without ammunition — so these two clauses are
+      // belt-and-braces and NO test reaches them: removing them leaves the suite
+      // green, which is stated here rather than dressed up as coverage. They stay
+      // because the exact failure was a control that lied about being ready, and
+      // `fire()`'s own guard should not be the only thing that knows.
+      canFire: (this.phase === 'aim' || this.phase === 'intro') && b !== null && !b.spent,
     }
   }
 
@@ -990,6 +1128,33 @@ export class TrebuchetGame {
     }
 
     switch (this.phase) {
+      case 'stocking': {
+        // Probe about six times a second. Each attempt asks for a different rung
+        // and gives the pool behind `host.next()` a frame or two to refill, which
+        // is the whole reason this is a phase and not a loop.
+        this.stockT += rawDt
+        if (this.stockT >= 0.16) {
+          this.stockT = 0
+          if (this.stock()) this.layOutWave()
+        }
+        // Said out loud, once. A wave that cannot be stocked shows a field with no
+        // keeps and no equation, which is precisely the screen that was reported
+        // as "I can't see the problem and I can't fire" — so if it ever comes back
+        // it says so in the console instead of looking like a game that is merely
+        // slow. Five seconds is many times the handful of probes a search needs.
+        this.stockStall += rawDt
+        if (this.stockStall > 5 && !this.toldAboutStocking) {
+          this.toldAboutStocking = true
+          console.error(
+            `[trebuchet] wave ${String(this.wave)} cannot be stocked: no rung between ` +
+              `${String(this.probeLo)} and ${String(this.probeHi)} returns an answer in ` +
+              `${String(PLACEABLE_LO)}..${String(PLACEABLE_HI)}, which is the only window a ` +
+              `${String(FIELD_MAX)}-metre field can stand a keep on. The child is looking at an ` +
+              `empty field.`,
+          )
+        }
+        break
+      }
       case 'intro':
         if (this.phaseT > 0.9) {
           this.phase = 'aim'
@@ -1436,5 +1601,19 @@ export class TrebuchetGame {
 
   currentWind(): number {
     return this.wind
+  }
+
+  /**
+   * Exactly the `canFire` the renderer is handed — read off the real `hudState()`
+   * rather than recomputed, so a test asserting the button is dark is asserting
+   * about the button a child is looking at.
+   */
+  fireArmed(): boolean {
+    return this.hudState().canFire
+  }
+
+  /** The difficulty the game last found it could place answers from. */
+  stockedDifficulty(): number | null {
+    return this.stockD
   }
 }

--- a/dynawalla/games/trebuchet/src/sim/world.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
+import type { Question } from '../contract.ts'
 import { makeRng } from '../core/rng.ts'
 import { createStubHost } from '../stubHost.ts'
 import { heightAtX, LAUNCH_H } from './ballistics.ts'
@@ -56,6 +57,39 @@ test('a wave never hands you two boulders whose keeps would overlap', () => {
   }
 })
 
+test('a rejected answer is reported with the rung it came from', () => {
+  // `seen` is how the game finds a rung whose answers fit on the field, and the
+  // difficulty beside each answer is what stops it steering on the stale contents
+  // of a pool that has not turned over yet. An answer without its rung is a
+  // rejection the game cannot act on — which is how a blank plaque and a dead fire
+  // button survived for a whole release.
+  let n = 0
+  const stream = (answer: number, difficulty: number): Question => {
+    n++
+    return {
+      id: `q${n}`,
+      prompt: `? = ${answer}`,
+      answer: String(answer),
+      distractors: [],
+      domain: 'add-sub',
+      difficulty,
+    }
+  }
+  // Four answers far below the field, served off rung 0.04.
+  const low = pullQuestions(() => stream(3, 0.04), 2, MIN_GAP, 14, 118, 4)
+  assert.equal(low.boulders.length, 0, 'a difference within ten cannot stand on the field')
+  assert.equal(low.seen.length, 4, 'the rejections were thrown away')
+  for (const s of low.seen) {
+    assert.equal(s.answer, 3)
+    assert.equal(s.difficulty, 0.04, 'the rung that produced the answer was lost')
+  }
+
+  // And an answer that fits is kept, with the draw bounded by `maxPulls`.
+  const ok = pullQuestions(() => stream(20 + n * 9, 0.5), 2, MIN_GAP, 14, 118, 8)
+  assert.equal(ok.boulders.length, 2)
+  assert.ok(ok.seen.length <= 8, `the draw ran past maxPulls: ${ok.seen.length}`)
+})
+
 test('escalation is monotonic where it should be and bounded everywhere', () => {
   let prevDiff = -1
   for (let w = 1; w <= 60; w++) {
@@ -86,6 +120,7 @@ test('the ram does not roll while the child is working the sum out', () => {
   // The how-to-play panel promises "there is no clock, nothing happens until you
   // fire", and EXPERIENCE_DESIGN.md does not budget comprehension at all. Those
   // are the two phases in which the child is reading and dialling.
+  assert.equal(ramAdvances('stocking'), false, 'there is not even a question yet')
   assert.equal(ramAdvances('intro'), false, 'the wave has only just been laid out')
   assert.equal(ramAdvances('aim'), false, 'she is working it out')
   assert.equal(ramAdvances('impact'), false, 'the hit-stop holds everything still')

--- a/dynawalla/games/trebuchet/src/sim/world.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.ts
@@ -279,7 +279,22 @@ export type Ghost = { pts: Array<{ x: number; y: number }>; landing: number; age
  * rather than against `string` — under which renaming a phase would silently
  * put the ram back on the child's thinking time with every test still green.
  */
-export type Phase = 'intro' | 'aim' | 'windup' | 'flight' | 'impact' | 'settle' | 'clear'
+export type Phase =
+  /**
+   * No boulder can be loaded yet, because nothing the question stream has
+   * offered will fit on the field. The game is looking for a rung it can place —
+   * see `stock()` — and it is emphatically NOT 'aim': a child cannot aim at a
+   * question that is not there, and calling it 'aim' is what lit the fire button
+   * over an empty rack.
+   */
+  | 'stocking'
+  | 'intro'
+  | 'aim'
+  | 'windup'
+  | 'flight'
+  | 'impact'
+  | 'settle'
+  | 'clear'
 
 /**
  * Does the ram roll during this phase?
@@ -294,7 +309,9 @@ export type Phase = 'intro' | 'aim' | 'windup' | 'flight' | 'impact' | 'settle' 
  * hit-stop, where everything else is.
  */
 export function ramAdvances(phase: Phase): boolean {
-  return phase !== 'intro' && phase !== 'aim' && phase !== 'impact'
+  return (
+    phase !== 'stocking' && phase !== 'intro' && phase !== 'aim' && phase !== 'impact'
+  )
 }
 
 /** A battering ram: pure pressure. No number on it — read the ground to lead it. */
@@ -341,24 +358,55 @@ export function layoutTowerValues(
 
 export type Boulder = { q: Question; answer: number; spent: boolean; hit: boolean }
 
-/** Pull `n` questions whose answers can all stand apart on the same field. */
+/**
+ * Pull up to `n` questions whose answers can all stand apart on the same field.
+ *
+ * **`seen` is not diagnostics — the game steers on it.** A keep stands at its own
+ * answer in metres, so this game can only ask a question whose answer fits on a
+ * 122-metre field: everything outside `lo..hi` is unplaceable and is dropped
+ * here. When the question stream is aimed at the wrong rung, EVERY answer is
+ * dropped and the rack comes back empty — which used to leave a child with a
+ * blank plaque and a fire button that did nothing. So the answers that were
+ * rejected are handed back with the ones that were kept, and `stock()` in
+ * `game.ts` reads them to work out which way to move the difficulty it asks for.
+ * A rejection nobody can see is a rejection nobody can correct.
+ *
+ * Each rejected answer is reported WITH the difficulty of the question it came
+ * from. That pairing is what makes the search safe: the pool on the other side of
+ * `next` is refilled asynchronously, so the first answers after a difficulty
+ * change are still the old rung's, and a search that steered on them would read
+ * "still too easy" about a request it had already made and stride straight past
+ * the band. The caller compares the difficulty it asked for against the
+ * difficulty it was served and only steers on evidence about the right rung.
+ *
+ * `maxPulls` bounds the draw. A stocking attempt that drained the pool dry would
+ * spend hundreds of curriculum items to learn one bit about a rung; a small draw,
+ * repeated on later frames, learns the same thing and lets the pool keep up.
+ */
 export function pullQuestions(
   next: () => Question,
   n: number,
   minGap: number,
   lo: number,
   hi: number,
-): { boulders: Boulder[]; pools: number[][] } {
+  maxPulls = 200,
+): {
+  boulders: Boulder[]
+  pools: number[][]
+  seen: Array<{ answer: number; difficulty: number }>
+} {
   const boulders: Boulder[] = []
   const pools: number[][] = []
+  const seen: Array<{ answer: number; difficulty: number }> = []
   let guard = 0
-  while (boulders.length < n && guard++ < 200) {
+  while (boulders.length < n && guard++ < maxPulls) {
     const q = next()
     const a = Number(q.answer)
+    if (Number.isFinite(a)) seen.push({ answer: a, difficulty: q.difficulty })
     if (!Number.isInteger(a) || a < lo || a > hi) continue
     if (boulders.some((b) => Math.abs(b.answer - a) < minGap)) continue
     boulders.push({ q, answer: a, spent: false, hit: false })
     pools.push(q.distractors.map(Number).filter(Number.isInteger))
   }
-  return { boulders, pools }
+  return { boulders, pools, seen }
 }


### PR DESCRIPTION
"trebuchet is broken. I can't see the problem and I can't fire. the fire
button does not work."

Both symptoms, one cause, and it is not either of the two PRs that landed in
0.3.1. The rack was empty.

An empty rack is invisible twice over. `hudState()` draws `equation: b ? b.q.prompt
: ''`, so with no boulder loaded the equation plaque has nothing to write — there is
no problem on the screen to see. And `fire()` returns on its second line, `if (!b ||
b.spent) return`, so the button does nothing. Worse, `canFire` was `phase === 'aim'
|| phase === 'intro'` and phase reached 'aim' happily with an empty rack, so the
button drew LIT AND PULSING over a machine with nothing to throw. The founder was
looking at a game that advertised itself as ready and was not.

**Why the rack was empty.** A keep stands at its own answer in METRES, on a field
122 metres long, and two keeps must be `MIN_GAP` apart to be distinct targets. So
this game can only pose a question whose answer is an integer in 14..118. That is
not tuning, it is what "the range dial is the answer" costs. `pullQuestions`
enforced it by dropping every answer outside the window — and dropped all of them.

The host addresses one cross-domain ladder by a 0..1 difficulty, and a pack cannot
see what arithmetic sits on a rung before it asks. Driving the shipped 66-rung
`ladder()` at the difficulties `waveConfig` asks for, with the app's own rung
selection and the real generators:

    wave 1  d=0.040  dw.add.facts.subtract-within-ten   answers 4,4,3,4,0,2,2,0...   0/12 placeable
    wave 2  d=0.112  dw.add.facts.subtract-within-ten   answers 3,1,1,1,3,8,8,8...   0/12
    wave 3  d=0.184  dw.add.facts.subtract-across-ten   answers 2,8,6,8,5,7,8,8...   0/12
    wave 4  d=0.256  dw.mul.facts.tables-within-five    answers 0,0,10,4,15,0...     1/12
    wave 5  d=0.328  dw.mul.facts.tables-to-twelve      answers 45,12,56,24,12...    9/12
    wave 6  d=0.400  dw.add.column.subtract-no-regroup  answers 2030,3033,140,2527   0/12
    wave 7  d=0.472  dw.mul.scale.times-power-of-ten    answers 4510000, 309600...   0/12

Wave 1 could not put a single keep on the field. Nor could 2, 3, or anything from 6
upward. Wave 5 was the only playable wave in the game.

The bottom of that table is a 0.3.1 regression and the top of it never worked.
#655 ("the ladder now starts at 0 + 1", landed the same day) put four fact rows
under the ladder so a five-year-old has a floor — which is right, and which moved
rungs 0-12 to single-digit answers. Before it, the easiest rung was `plus(2,2,0)`
and wave 1 got two-digit sums by luck. The 4-digit and 7-digit rungs above wave 6
were always unplaceable; nobody had got that far.

**The fix: find a rung this field can hold, instead of assuming one was handed
over.** A wave is no longer laid out until it has ammunition. `startWave` sets a new
'stocking' phase and `stock()` asks for a rung and reports whether the answers fit;
when they do not, the wave waits and probes again on a later frame. It is a phase
and not a loop because the pool behind `host.next()` refills ASYNCHRONOUSLY — a
synchronous retry can only re-read the pool its own difficulty change just flushed,
which is why 200 pulls in one call learned nothing.

Three things make the search converge rather than thrash:

  * **It steers on the rejected answers.** `pullQuestions` now returns what it threw
    away, so "all too small" means ask harder and "all too large" means ask easier.
    Answer magnitude rises with the ladder, so a bisection finds the band in a
    handful of probes instead of sweeping 66 rungs blind.
  * **It only steers on questions from the rung it asked for.** Each answer comes
    back with its own difficulty. The first answers after a change are still the old
    rung's, and steering on them reads "still too easy" about a request already made
    and strides straight past the band.
  * **It does not re-state a difficulty it has already stated.** Re-stating one makes
    the host flush and refill, so asking again for what was already asked keeps the
    pool permanently empty and the search outruns the questions.

The difficulty that worked is kept for later waves, so the search runs once a run.
The arithmetic therefore stops climbing at the width of the field, which is honest —
122 metres cannot pose a question whose answer is 5400 — and the wave's real
escalation (wind, the wall, the ram, more keeps, less ammunition, the loft lever) is
untouched. Against the real ladder the game now settles on d=0.28 and opens with
answer 73 and keeps at 73/84/94.

And if a ladder ever has no placeable rung at all, it says so once on `console.error`
naming the window, instead of showing the same silent empty field.

**Why 166 tests missed it.** Two holes, both in the mount-level test that #654 added
for exactly this class of bug:

  * `recordingHost` serves `[42, 60, 78, 96]` — four answers hand-picked inside the
    window. No test ever modelled a host whose answers this game cannot place, which
    is every host it actually ships against.
  * **The fire button was never pressed.** The suite taps `plus` through the real
    listener but reaches fire through `game.fireNow()`, the harness door. `pressBtn`'s
    `case 'fire'` had no coverage at all, so a dead fire button was invisible to all
    of them. There is now a test that taps the real control and asserts a boulder
    leaves.

`newGame` also asserted only that phase reached 'aim', which an empty rack satisfies;
it now asserts there is a question too, so the helper cannot certify a blank wave as
playable again.

Verified by removing each fix in turn:

  * no 'stocking' phase (lay out whatever came back) — 6 failures, first is
    `there is no question on the screen`, and `the wave claimed to be playable
    + 'intro' - 'stocking'`
  * no bisection (probe the wave's difficulty and never move) — 5 failures,
    `the wave never became playable`, `the game never found a rung it could place`,
    `a wave above the field never came back down to it`
  * steer on all answers including the stale pool — `the search for a placeable rung
    survives a pool that refills late`: `the game never found a rung it could place`
  * re-state the difficulty on every probe — same test, same failure
  * no stall complaint — `expected exactly one complaint, got 0`

The two `canFire` clauses are the exception and are labelled as such in the source:
removing them leaves the suite green, because the phase fix already makes 'aim'
unreachable without ammunition. They stay as belt-and-braces on the exact reported
symptom rather than being dressed up as covered.

174 tests, five consecutive runs, plus `npm run tsc`.

**Not this pack, and worth a look.** `game-chrome` was cleared: the manual's scrim is
`hidden` when closed and its capture-phase pointer swallow is gated on `open` ("a gate
stuck shut is the same bug as a gate stuck open"), so it eats nothing during play.
But `pack.json` declares `covers.skills` of four add/sub column skills, the app's
`next()` accepts a `skillId` to honour it, and `game-host`'s `askShape()` never sends
one — so a pack cannot restrict the maths it receives, and this one is served
`dw.mul.scale.times-power-of-ten`. That is shared, affects every pack, and is left
alone here.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb