### PR TITLE
dynawalla: the ladder was 64 questions behind the child, and it only ever served one rung

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -10,18 +10,30 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 
 import {
+  advanceStaircase,
+  ascentOf,
   cadenceFor,
   choicesFor,
   binaryOperator,
   climbRungs,
   climbWithinMs,
   createItemService,
+  DESCENT_RATIO,
+  descentOf,
   isQuick,
   itemPace,
   ladder,
   normalizeMinus,
+  openStaircase,
+  pickRung,
+  rungWeights,
+  SPREAD_ABOVE,
+  SPREAD_BELOW,
+  STEP_OPEN,
+  STEP_START,
+  STEP_TRACK,
 } from "./items.ts"
-import type { Rung } from "./items.ts"
+import type { Rung, Staircase } from "./items.ts"
 import type { PromptSlot } from "./curriculum.ts"
 import {
   activeNodes,
@@ -206,7 +218,18 @@ test("the ladder climbs on a fast correct answer and steps down on a wrong one",
     response: "definitely wrong",
     latencyMs: 200,
   })
-  assert.equal(service.position(), climbed - 1)
+  // Down, by the staircase's current stride rather than by a fixed rung — see
+  // `STEP_START`. The exact arithmetic is pinned on the pure functions below
+  // ("the staircase opens wide…"); what is asserted here is that the service
+  // composes them in the right direction and that a miss is never free.
+  const dropped = service.position()
+  assert.ok(dropped < climbed, `a miss left the child on rung ${String(dropped)}`)
+  assert.ok(
+    climbed - dropped <= STEP_START,
+    `one miss cost ${String(climbed - dropped)} rungs, and the opening stride is ${String(
+      STEP_START,
+    )}`,
+  )
 })
 
 test("a pack may ask for a skill it covers, and an unknown one is not an error", () => {
@@ -318,7 +341,17 @@ test("driving the difficulty moves the one ladder, so judging resumes from where
   const after = service.next({ packId: "dynawalla.stack" })
   assert.ok(after)
   assert.equal(service.position(), top)
-  assert.equal(after.difficulty, item.difficulty)
+  // Not the same ordinate: with the pack no longer naming a difficulty the host
+  // serves from its own spread around where it was left (`rungWeights`). What
+  // must hold is that it is still *there* — within the spread of the rung the
+  // pack drove it to, and not back at the bottom of the ladder.
+  const span = ladder().length - 1
+  const drove = item.difficulty ?? -1
+  const served = after.difficulty ?? -1
+  assert.ok(
+    served >= drove - (SPREAD_BELOW + 1) / span && served <= drove + SPREAD_ABOVE / span,
+    `the pack left the child at ${drove.toFixed(3)} and the host served ${served.toFixed(3)}`,
+  )
 
   service.judge({
     packId: "dynawalla.stack",
@@ -326,7 +359,13 @@ test("driving the difficulty moves the one ladder, so judging resumes from where
     response: "definitely wrong",
     latencyMs: 1000,
   })
-  assert.equal(service.position(), top - 1, "the ladder did not step down from the pack's position")
+  // Exactly the opening stride: nothing has been answered yet, so the staircase
+  // is still where `openStaircase` puts it.
+  assert.equal(
+    service.position(),
+    top - descentOf(openStaircase()),
+    "the ladder did not step down from the pack's position by the opening stride",
+  )
 })
 
 test("every rung on the ladder draws a question with numbers in it", () => {
@@ -713,6 +752,7 @@ test("the `5,001 − 2,798` rungs are reachable: answering them at the published
   assert.equal(service.position(), 0)
 
   for (let step = 0; step < rungs.length - 1; step++) {
+    const before = service.position()
     const item = service.next({ packId: "dynawalla.siege" })
     assert.ok(item)
     const width = widthOf(item.operands)
@@ -725,14 +765,14 @@ test("the `5,001 − 2,798` rungs are reachable: answering them at the published
       // answer this question correctly take at least this long.
       latencyMs: median,
     })
-    assert.equal(
-      service.position(),
-      step + 1,
+    assert.ok(
+      service.position() > before || before === rungs.length - 1,
       `${item.prompt} is ${String(width)} digits wide, its published median is ` +
         `${String(median)} ms, it was answered correctly in exactly that, and the ladder ` +
-        `did not move off rung ${String(step)}`,
+        `did not move off rung ${String(before)}`,
     )
   }
+  assert.equal(service.position(), rungs.length - 1, "the hardest node's top rung is unreachable")
 })
 
 test("a two-digit regrouping answered a millisecond past the median still climbs", () => {
@@ -743,7 +783,10 @@ test("a two-digit regrouping answered a millisecond past the median still climbs
   assert.ok(rungs.length > 1)
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
 
-  const item = service.next({ packId: "dynawalla.siege" })
+  // Named rather than drawn from the spread, so the item under test is the
+  // two-digit rung on every run and not four times in five — a named difficulty
+  // is a point, which is what `items.ts` says it is.
+  const item = service.next({ packId: "dynawalla.siege", difficulty: 0 })
   assert.ok(item)
   assert.equal(widthOf(item.operands), 2, `${item.prompt} is not the two-digit rung`)
   service.judge({
@@ -752,7 +795,14 @@ test("a two-digit regrouping answered a millisecond past the median still climbs
     response: service.reveal(item.id),
     latencyMs: 6_001,
   })
-  assert.equal(service.position(), 1, `${item.prompt} in 6,001 ms did not climb`)
+  assert.ok(service.position() > 0, `${item.prompt} in 6,001 ms did not climb`)
+  // And it is a *whole* stride, not a fraction of one: 6,001 ms is a millisecond
+  // into the second half of the expected band, not into the slow tail.
+  assert.equal(
+    climbRungs({ digits: 2, fluencyP50Ms: undefined, latencyMs: 6_001 }),
+    1,
+    "a millisecond past the two-digit median is being scored as the slow tail",
+  )
 })
 
 test("a child who answers every question correctly at its own published median reaches the top", () => {
@@ -914,7 +964,14 @@ test("a latency that is not a measurement promotes and says so", () => {
       response: service.reveal(item.id),
       latencyMs: Number.NaN,
     })
-    assert.equal(service.position(), 1, "a broken clock stopped a correct answer climbing")
+    assert.ok(service.position() > 0, "a broken clock stopped a correct answer climbing")
+    // And it is worth a whole stride, not a fraction: an unmeasurable clock is
+    // never a reason to pay a child less than the expected band.
+    assert.equal(
+      climbRungs({ digits: 1, fluencyP50Ms: undefined, latencyMs: Number.NaN }),
+      1,
+      "a broken clock is being scored as the slow tail",
+    )
   } finally {
     console.warn = realWarn
   }
@@ -934,7 +991,10 @@ test("a correct answer from the slow tail never costs a rung, never jumps one, a
   // and a slow answer worth a twentieth of a rung both leave `position()`
   // where it was after one answer. Only the third part below separates them,
   // and only the third part fails against the rule this replaced.
-  const rungs = ladder().filter((rung) => rung.node.id === "dw.add.facts.add-within-ten")
+  // The whole ladder, not one node's four rungs: with a stride that opens at
+  // `STEP_START` a filtered ladder is at its own ceiling within two answers, and
+  // a clamp is not a measurement of anything.
+  const rungs = ladder()
   assert.ok(rungs.length > 1)
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
   const first = service.next({ packId: "dynawalla.siege" })
@@ -946,7 +1006,7 @@ test("a correct answer from the slow tail never costs a rung, never jumps one, a
     latencyMs: 2_800,
   })
   const climbed = service.position()
-  assert.equal(climbed, 1)
+  assert.ok(climbed > 0)
 
   const second = service.next({ packId: "dynawalla.siege" })
   assert.ok(second)
@@ -957,7 +1017,25 @@ test("a correct answer from the slow tail never costs a rung, never jumps one, a
     // Five minutes on a single-digit fact. Nobody's p90.
     latencyMs: 300_000,
   })
-  assert.equal(service.position(), climbed, "one slow answer jumped a whole rung")
+  // Never costs a rung.
+  assert.ok(
+    service.position() >= climbed,
+    `a slow correct answer cost a rung: ${String(climbed)} → ${String(service.position())}`,
+  )
+  // Never jumps one, *relative to the stride it was taken at* — which is the
+  // claim that survives now that the search step is separate from what the
+  // answer was worth. A slow answer buys strictly less of the same stride than
+  // an expected-pace one, at every stride, so "slowly" cannot quietly become
+  // "immediately" however wide the search happens to be open.
+  for (const stair of [openStaircase(), { ...openStaircase(), step: STEP_TRACK }]) {
+    const slow = ascentOf(stair, climbRungs({ digits: 1, latencyMs: 300_000 }))
+    const expected = ascentOf(stair, climbRungs({ digits: 1, latencyMs: 2_800 }))
+    assert.ok(
+      slow < expected,
+      `a five-minute answer moved ${String(slow)} rungs and an on-median one ${String(expected)}`,
+    )
+    assert.ok(slow > 0, "a five-minute correct answer moved nothing at all")
+  }
 
   // And now the same answer, again and again. A child working at this pace all
   // afternoon is still working; a ladder that never moves for them is the
@@ -996,16 +1074,16 @@ test("no run of wrong answers can push a child below the easiest rung the curric
   assert.ok(service.next({ packId: "dynawalla.siege" }), "the floor is not serving questions")
 })
 
-test("an answer at the published median is worth exactly one rung, and a miss costs exactly one", () => {
-  // The descent rule is unchanged and is founder direction; what is checked here
-  // is that it composes with the climb rule rather than fighting it.
-  //
+test("an answer at the published median is worth a whole stride, and the bonus does not leak into it", () => {
   // Six answers, each taking exactly as long as the table says that class takes.
-  // Not quick, not slow: expected. Expected is one rung — the middle regime —
-  // and the fact that `high` is exactly 6 rather than something larger is the
-  // assertion that the speedcuber bonus does not leak into ordinary pace.
+  // Not quick, not slow: expected. Expected is worth exactly one stride — the
+  // middle regime — and the assertion is that six of them come to exactly the
+  // sum of the first six strides rather than to anything larger, which is what
+  // the speedcuber bonus leaking into ordinary pace would look like.
   const rungs = ladder()
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  let stair = openStaircase()
+  let expected = 0
   for (let i = 0; i < 6; i++) {
     const item = service.next({ packId: "dynawalla.siege" })
     assert.ok(item)
@@ -1015,9 +1093,10 @@ test("an answer at the published median is worth exactly one rung, and a miss co
       response: service.reveal(item.id),
       latencyMs: publishedP50Ms(widthOf(item.operands)),
     })
+    expected += ascentOf(stair, 1)
+    stair = advanceStaircase(stair, 1, 1)
   }
-  const high = service.position()
-  assert.equal(high, 6)
+  assert.equal(service.position(), Math.floor(expected))
   for (let i = 0; i < 3; i++) {
     const item = service.next({ packId: "dynawalla.siege" })
     assert.ok(item)
@@ -1027,8 +1106,152 @@ test("an answer at the published median is worth exactly one rung, and a miss co
       response: "definitely wrong",
       latencyMs: 1_000,
     })
+    expected -= descentOf(stair)
+    stair = advanceStaircase(stair, -1, null)
   }
-  assert.equal(service.position(), high - 3, "three misses did not cost exactly three rungs")
+  assert.equal(
+    service.position(),
+    Math.floor(expected),
+    "three misses did not cost exactly three strides",
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Calibration: find the level quickly, then track it gently.
+//
+// The founder's report, and the apparent contradiction in it:
+//
+//   "it's way too quick to go from 0+1 to 1269/9. We need to find the users level
+//    more gently!"
+//   "We need to sort of quickly find the players level .. maybe where they are
+//    getting 80%+ correct but slowly"
+//
+// The search is quick; the content does not lurch. See `STEP_START` in `items.ts`.
+
+test("the staircase opens wide, shrinks with every answer, and halves at a reversal", () => {
+  const open = openStaircase()
+  assert.equal(open.step, STEP_START, "the search does not open at the opening stride")
+  assert.equal(open.reversed, false)
+  assert.equal(open.lastDir, 0)
+
+  // Never wrong: the stride shrinks toward `STEP_OPEN` and stops there, because a
+  // child who has not been bracketed has not given the evidence that would let
+  // the search slow below the rate this file has always climbed at.
+  let straight = open
+  const strides: number[] = []
+  for (let i = 0; i < 40; i++) {
+    strides.push(straight.step)
+    straight = advanceStaircase(straight, 1, 1)
+  }
+  for (let i = 1; i < strides.length; i++) {
+    assert.ok(
+      (strides[i] as number) < (strides[i - 1] as number) + 1e-12,
+      `the stride grew at answer ${String(i)}: ${String(strides[i - 1])} → ${String(strides[i])}`,
+    )
+  }
+  // Converges on the floor from above and never goes under it: the decay is
+  // geometric, so it approaches rather than arrives, and the floor is the thing
+  // that must be exact in the direction that matters.
+  assert.ok(
+    straight.step >= STEP_OPEN,
+    `the stride fell under its floor: ${String(straight.step)} < ${String(STEP_OPEN)}`,
+  )
+  assert.ok(
+    straight.step - STEP_OPEN < 1e-4,
+    `forty right answers left the stride at ${String(straight.step)}, not ${String(STEP_OPEN)}`,
+  )
+  assert.equal(straight.reversed, false, "a child who was never wrong was treated as bracketed")
+
+  // A reversal is the moment the level is bracketed: an extra halving, and the
+  // stride's floor drops from `STEP_OPEN` to `STEP_TRACK`.
+  const before = advanceStaircase(advanceStaircase(open, 1, 1), 1, 1)
+  const after = advanceStaircase(before, -1, null)
+  assert.equal(after.reversed, true, "a direction change did not bracket the child")
+  assert.ok(
+    after.step < before.step / 2,
+    `a reversal took the stride from ${String(before.step)} to ${String(after.step)}, which is ` +
+      `not a halving on top of the per-answer decay`,
+  )
+  let settled = after
+  for (let i = 0; i < 40; i++) settled = advanceStaircase(settled, 1, 1)
+  assert.ok(
+    Math.abs(settled.step - STEP_TRACK) < 1e-6,
+    `a bracketed child's stride settled at ${String(settled.step)}, not ${String(STEP_TRACK)}`,
+  )
+})
+
+test("down is four times up once the child is bracketed, which is what 80% correct means", () => {
+  // Kaernbach's weighted up/down rule: a staircase converges on the proportion
+  // `p` correct when up:down is `(1 − p) : p`. The founder asked for "80%+
+  // correct", so the ratio is 1:4 and `DESCENT_RATIO` is that four. Asserted as
+  // the ratio rather than as two magnitudes, because the magnitudes are the
+  // child's own pace and the ratio is the thing that fixes the accuracy.
+  // Derived, not restated: `p / (1 − p)` at the accuracy the founder named. A
+  // test that compared `descentOf / ascentOf` to `DESCENT_RATIO` would pass at
+  // any value of `DESCENT_RATIO` at all, including the 1 this replaced.
+  // As the whole ratio `right : asked` rather than as 0.8, because `0.8 / (1 −
+  // 0.8)` is 4.000000000000001 and a test that is right about the mathematics and
+  // wrong about binary floats is a test somebody deletes.
+  const RIGHT = 4
+  const ASKED = 5
+  assert.equal(
+    DESCENT_RATIO,
+    RIGHT / (ASKED - RIGHT),
+    `a staircase with this ratio converges on ` +
+      `${((DESCENT_RATIO / (1 + DESCENT_RATIO)) * 100).toFixed(0)}% correct, not ` +
+      `${((RIGHT / ASKED) * 100).toFixed(0)}%`,
+  )
+  const settled: Staircase = { step: STEP_TRACK, lastDir: 1, reversed: true, pace: 1 }
+  assert.equal(descentOf(settled) / ascentOf(settled, 1), DESCENT_RATIO)
+  // And in a slower child's currency: a child whose correct answers are worth a
+  // quarter of a rung each falls a quarter as far, so the *ratio* — and with it
+  // the accuracy the search converges on — is the same for them.
+  const deliberate: Staircase = { ...settled, pace: 0.25 }
+  assert.equal(descentOf(deliberate) / ascentOf(deliberate, 0.25), DESCENT_RATIO)
+  assert.equal(descentOf(deliberate), descentOf(settled) / 4)
+
+  // Before the bracket closes it is symmetric. The first miss is the move that
+  // *closes* the bracket and must be the size of the moves that opened it —
+  // four times an opening stride of four rungs is sixteen, which is the lurch in
+  // the other direction.
+  const opening = openStaircase()
+  assert.equal(descentOf(opening), ascentOf(opening, 1))
+})
+
+test("a child who is right four times in five settles, and stays settled", () => {
+  // The founder's target, end to end: "maybe where they are getting 80%+
+  // correct". A staircase at the 1:4 ratio has zero expected drift at exactly
+  // 80%, so a child answering in that pattern must come to rest somewhere and
+  // stay there — not creep to the top, and not slide to the floor.
+  const rungs = ladder()
+  const top = rungs.length - 1
+  const walked: number[] = []
+  const service = createItemService({ profileId: "p80", record: noRecord, rungs })
+  for (let answered = 0; answered < 500; answered++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    // Right on four of every five, in a fixed pattern rather than at random, so
+    // the assertion is about the rule and not about a seed.
+    const right = answered % 5 !== 4
+    service.judge({
+      packId: "dynawalla.siege",
+      itemId: item.id,
+      response: right ? service.reveal(item.id) : "definitely wrong",
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+    walked.push(service.position())
+  }
+  const tail = walked.slice(400)
+  const low = Math.min(...tail)
+  const high = Math.max(...tail)
+  assert.ok(low > 0, `an 80%-correct child slid to rung ${String(low)}`)
+  assert.ok(high < top, `an 80%-correct child crept to the top (rung ${String(high)} of ${String(top)})`)
+  // Settled means the last hundred answers cover a handful of rungs, not the
+  // ladder. Anything wider is a walk, not a level.
+  assert.ok(
+    high - low <= 2 * (SPREAD_BELOW + SPREAD_ABOVE),
+    `an 80%-correct child's last hundred answers ranged over rungs ${String(low)}..${String(high)}`,
+  )
 })
 
 // ---------------------------------------------------------------------------
@@ -1144,10 +1367,25 @@ test("regime 1: a speedcuber does not walk every rung", () => {
     )} ms each — that is one rung per answer or worse, and a child who answers in a fifth of a ` +
       `second is not being told anything by this ladder`,
   )
+  // Bounded, and the bound is the two numbers it is made of: what one answer can
+  // be worth (2.5, the table's widest published p90/p50) times the widest the
+  // search ever opens (`STEP_START`). Not 2.5 alone — during calibration the
+  // stride is deliberately wider than one rung, which is the "quickly find the
+  // players level" half of the founder's report. What must not exist is an
+  // unbounded rate.
   assert.ok(
-    quick.answers >= Math.ceil(quick.top / 2.5),
-    `${String(quick.top)} rungs in ${String(quick.answers)} answers is more than 2.5 rungs an ` +
-      `answer, and 2.5 is the widest p90/p50 the cadence table publishes`,
+    quick.answers >= Math.ceil(quick.top / (2.5 * STEP_START)),
+    `${String(quick.top)} rungs in ${String(quick.answers)} answers is more than ` +
+      `${String(2.5 * STEP_START)} rungs an answer, which is the widest published p90/p50 ` +
+      `times the widest the search ever opens`,
+  )
+  // And once the search has settled — which for a child who is never wrong means
+  // a stride of `STEP_OPEN` — the rate is back inside 2.5 an answer, so the
+  // calibration boost is a boost and not a new baseline.
+  const settled: Staircase = { step: STEP_OPEN, lastDir: 1, reversed: false, pace: 2.5 }
+  assert.ok(
+    ascentOf(settled, climbRungs({ digits: 1, latencyMs: A_SPEEDCUBER_MS, quickRun: 99 })) <= 2.5,
+    "a settled speedcuber is still climbing more than the table's widest spread per answer",
   )
 })
 
@@ -1358,12 +1596,14 @@ test("the tail cannot underflow the floor or overflow the top", () => {
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
   const item = service.next({ packId: "dynawalla.siege" })
   assert.ok(item)
-  // One slow-and-right answer: some fraction of a rung, and still rung 0.
+  // One slow-and-right answer: some fraction of a rung, and still rung 0. Ten
+  // minutes rather than one, because the opening stride multiplies whatever the
+  // answer was worth and a minute times four rungs is no longer a fraction.
   service.judge({
     packId: "dynawalla.siege",
     itemId: item.id,
     response: service.reveal(item.id),
-    latencyMs: A_FULL_MINUTE_MS,
+    latencyMs: 10 * A_FULL_MINUTE_MS,
   })
   assert.equal(service.position(), 0)
   const missed = service.next({ packId: "dynawalla.siege" })
@@ -1376,42 +1616,54 @@ test("the tail cannot underflow the floor or overflow the top", () => {
   })
   assert.equal(service.position(), 0, "a fraction of a rung above the floor fell through it")
 
-  // At the top: quick answers pile up, then one miss must cost exactly one rung
-  // rather than being absorbed by banked credit.
+  // At the top: quick answers pile up, then one miss must cost the same as it
+  // would have cost the moment the top was reached. Credit above the top is not
+  // credit — it is clamped away — and a child who kept playing after arriving
+  // must not have bought themselves a free miss.
   const top = rungs.length - 1
-  for (let i = 0; i < 200 && service.position() < top; i++) {
-    const next = service.next({ packId: "dynawalla.siege" })
-    assert.ok(next)
-    service.judge({
+  /** Climbs to the top, answers `extra` more, misses once, and says where it is. */
+  const missAtTop = (profileId: string, extra: number): number => {
+    const at = createItemService({ profileId, record: noRecord, rungs })
+    for (let i = 0; i < 200 && at.position() < top; i++) {
+      const next = at.next({ packId: "dynawalla.siege" })
+      assert.ok(next)
+      at.judge({
+        packId: "dynawalla.siege",
+        itemId: next.id,
+        response: at.reveal(next.id),
+        latencyMs: A_SPEEDCUBER_MS,
+      })
+    }
+    assert.equal(at.position(), top, `${profileId} never reached the top`)
+    for (let i = 0; i < extra; i++) {
+      const next = at.next({ packId: "dynawalla.siege" })
+      assert.ok(next)
+      at.judge({
+        packId: "dynawalla.siege",
+        itemId: next.id,
+        response: at.reveal(next.id),
+        latencyMs: A_SPEEDCUBER_MS,
+      })
+    }
+    const missed = at.next({ packId: "dynawalla.siege" })
+    assert.ok(missed)
+    at.judge({
       packId: "dynawalla.siege",
-      itemId: next.id,
-      response: service.reveal(next.id),
-      latencyMs: A_SPEEDCUBER_MS,
+      itemId: missed.id,
+      response: "definitely wrong",
+      latencyMs: 1_000,
     })
+    return at.position()
   }
-  assert.equal(service.position(), top)
-  for (let i = 0; i < 5; i++) {
-    const next = service.next({ packId: "dynawalla.siege" })
-    assert.ok(next)
-    service.judge({
-      packId: "dynawalla.siege",
-      itemId: next.id,
-      response: service.reveal(next.id),
-      latencyMs: A_SPEEDCUBER_MS,
-    })
-  }
-  const missedAtTop = service.next({ packId: "dynawalla.siege" })
-  assert.ok(missedAtTop)
-  service.judge({
-    packId: "dynawalla.siege",
-    itemId: missedAtTop.id,
-    response: "definitely wrong",
-    latencyMs: 1_000,
-  })
+  const straightAway = missAtTop("top-0", 0)
+  const afterLingering = missAtTop("top-20", 20)
+  assert.ok(straightAway < top, "a miss at the top of the ladder cost nothing at all")
   assert.equal(
-    service.position(),
-    top - 1,
-    "five quick answers at the top banked credit that a miss then paid for",
+    afterLingering,
+    straightAway,
+    `twenty quick answers at the top banked credit that a miss then paid for: the child who ` +
+      `missed straight away fell to ${String(straightAway)} and the one who lingered to ` +
+      `${String(afterLingering)}`,
   )
 })
 
@@ -1424,4 +1676,218 @@ test("a latency past what the table has a class for is still classified, never u
   assert.ok(wide, "a six-digit item has no pace, so the fitted line stopped fitting")
   assert.ok(wide.tailMs > P90_WIDEST_PUBLISHED_MS, "a six-digit item is not slower than a 4-digit")
   assert.ok(rateAt(6, undefined, 600_000) < 0.2, "ten minutes on one question is not a rung")
+})
+
+// ---------------------------------------------------------------------------
+// A rung is served as a distribution, not as a point.
+//
+// "we don't have to be at one level only 'mixed triple and double' .. we could
+//  still throw in some single digit problems but it should change the
+//  probabilities of harder and easier problems more smoothly."
+//
+// See `rungWeights` in `items.ts` for the shape and the arithmetic behind the
+// two ratios.
+
+/** The kernel as a share of its own mass, which is what a child experiences. */
+function shares(centre: number, span: number): number[] {
+  const weights = rungWeights(centre, span)
+  const total = weights.reduce((a, b) => a + b, 0)
+  return weights.map((w) => w / total)
+}
+
+test("the spread is centred, asymmetric, and reaches both ways", () => {
+  const span = 40
+  const p = shares(20, span)
+  // Every rung inside the spread carries mass and every rung outside it carries
+  // none: the point of a truncated kernel is that a rung the child cannot do is
+  // not merely unlikely, it is absent.
+  for (let i = 0; i < p.length; i++) {
+    const offset = i - 20
+    const inside = offset >= -SPREAD_BELOW && offset <= SPREAD_ABOVE
+    assert.equal(
+      (p[i] as number) > 0,
+      inside,
+      `rung ${String(i)} (offset ${String(offset)}) has share ${String(p[i])}`,
+    )
+  }
+  // The mode is the centre, and it is not the majority — a rung that carried more
+  // than half the mass would be a point with a rumour of a spread around it.
+  const centre = p[20] as number
+  for (let i = 0; i < p.length; i++) {
+    if (i !== 20) assert.ok((p[i] as number) < centre, `rung ${String(i)} outweighs the centre`)
+  }
+  assert.ok(centre < 0.5, `the centre carries ${(centre * 100).toFixed(1)}% of the mass`)
+  // Monotone away from the centre in both directions, so there is no distance at
+  // which the shape changes its mind.
+  for (let d = 1; d < SPREAD_BELOW; d++) {
+    assert.ok((p[20 - d] as number) > (p[20 - d - 1] as number), `below is not monotone at ${String(d)}`)
+  }
+  for (let d = 1; d < SPREAD_ABOVE; d++) {
+    assert.ok((p[20 + d] as number) > (p[20 + d + 1] as number), `above is not monotone at ${String(d)}`)
+  }
+  // Easier is likelier than harder at the same distance. Being served a rung
+  // below your level is a fluency rep; being served one above it is being stuck.
+  for (let d = 1; d <= SPREAD_ABOVE; d++) {
+    assert.ok(
+      (p[20 - d] as number) > (p[20 + d] as number),
+      `offset −${String(d)} is not likelier than +${String(d)}`,
+    )
+  }
+})
+
+test("the spread puts about a fifth of questions above the child's rung, which is what 80% is made of", () => {
+  const p = shares(20, 40)
+  const below = p.slice(0, 20).reduce((a, b) => a + b, 0)
+  const above = p.slice(21).reduce((a, b) => a + b, 0)
+  // A fifth above: paired with near-perfect accuracy below the rung, ~90% at it
+  // and ~60% one above, this mix measures out at ~83% correct, which is the
+  // founder's "80%+ correct" arrived at from the content side while the staircase
+  // arrives at it from the search side.
+  assert.ok(above > 0.15 && above < 0.25, `${(above * 100).toFixed(1)}% of questions are harder`)
+  // A rung the child cannot do is rare: two above is a twentieth.
+  assert.ok((p[22] as number) < 0.07, `two rungs up is ${((p[22] as number) * 100).toFixed(1)}%`)
+  // And there are real easier questions in the stream — "we could still throw in
+  // some single digit problems".
+  assert.ok(below > 0.3, `only ${(below * 100).toFixed(1)}% of questions are easier`)
+
+  // Consecutive questions differ: the chance two independent draws land on the
+  // same rung is Σp², and a spread that fails this is a point in disguise.
+  const same = p.reduce((a, b) => a + b * b, 0)
+  assert.ok(same < 0.3, `two questions running land on the same rung ${(same * 100).toFixed(1)}% of the time`)
+})
+
+test("the spread reflects at the ends of the ladder rather than piling onto them", () => {
+  const span = 40
+  // At the floor there is nowhere below to go. Clipping would pile the whole
+  // downward tail onto rung 0 — which on `add-within-ten` L0 is a set of NINE
+  // items, and is why the founder believed the questions were hardcoded. The
+  // mass goes the only other way it can.
+  const floorShares = shares(0, span)
+  assert.ok(
+    (floorShares[0] as number) < 0.5,
+    `a child at the floor gets ${((floorShares[0] as number) * 100).toFixed(1)}% of their ` +
+      `questions from one rung`,
+  )
+  assert.ok(
+    (floorShares[3] as number) > 0,
+    "the spread at the floor does not reach the fourth rung, so the neighbours are unused",
+  )
+  // Nothing is lost and nothing is invented: the reflected kernel carries exactly
+  // the mass the untruncated one does.
+  const total = (centre: number) => rungWeights(centre, span).reduce((a, b) => a + b, 0)
+  assert.ok(Math.abs(total(0) - total(20)) < 1e-12, "mass is not conserved at the floor")
+  assert.ok(Math.abs(total(span) - total(20)) < 1e-12, "mass is not conserved at the top")
+  // And at the top it reflects downward, so a child at the hardest rung the
+  // product has still gets a mixed stream rather than that rung forever.
+  const topShares = shares(span, span)
+  assert.ok((topShares[span] as number) < 0.5, "a child at the top is served one rung")
+  assert.ok((topShares[span - 3] as number) > 0, "the spread at the top does not reach downward")
+
+  // A ladder narrower than the kernel still normalises rather than leaving a
+  // hole: reflection is iterated, so `-3` on a two-rung ladder comes back inside.
+  for (let narrow = 0; narrow <= 4; narrow++) {
+    const weights = rungWeights(0, narrow)
+    assert.equal(weights.length, narrow + 1)
+    assert.ok(
+      weights.reduce((a, b) => a + b, 0) > 0,
+      `a ${String(narrow + 1)}-rung ladder has no weight anywhere`,
+    )
+    for (const w of weights) assert.ok(Number.isFinite(w) && w >= 0, "a weight is not a weight")
+  }
+})
+
+test("pickRung is a draw from those weights and cannot fall off either end", () => {
+  const span = 30
+  const counts = new Array<number>(span + 1).fill(0)
+  const draws = 20_000
+  for (let i = 0; i < draws; i++) {
+    const rung = pickRung(15, span, i / draws)
+    assert.ok(rung >= 0 && rung <= span, `pickRung returned ${String(rung)}`)
+    counts[rung] = (counts[rung] as number) + 1
+  }
+  // Sweeping the unit interval reproduces the weights it was built from.
+  const p = shares(15, span)
+  for (let i = 0; i <= span; i++) {
+    assert.ok(
+      Math.abs((counts[i] as number) / draws - (p[i] as number)) < 0.005,
+      `rung ${String(i)} drew ${String(counts[i])} of ${String(draws)}, expected share ${String(p[i])}`,
+    )
+  }
+  // The ends of the stream, which is where an off-by-one lives.
+  assert.ok(pickRung(0, span, 0) >= 0)
+  assert.ok(pickRung(span, span, 1) <= span)
+  assert.ok(pickRung(0, 0, 0.999) === 0, "a one-rung ladder served something other than its rung")
+})
+
+test("a beginner sees far more than nine distinct questions, without any closed set being inflated", () => {
+  // The founder: "I've gotten 10 correct in a row fast and I still get 2+0=1".
+  // `dw.add.facts.add-within-ten` L0 declares `closedFactSet: [9, …]` — nine
+  // items, honestly, and CG-10 exists so that a small honest set is not dressed
+  // up as a generator. So the fix is not to inflate it; it is that a child on the
+  // bottom rung is served its neighbours too.
+  const rungs = ladder()
+  const service = createItemService({ profileId: "beginner", record: noRecord, rungs })
+  const prompts = new Set<string>()
+  const skills = new Set<string>()
+  // Twenty questions with no answers at all, so the ladder never moves and this
+  // is purely what the spread does for a child standing on rung 0.
+  for (let i = 0; i < 20; i++) {
+    const item = service.next({ packId: "dynawalla.truedraw" })
+    assert.ok(item)
+    prompts.add(item.prompt)
+    skills.add(`${item.skillId}#${String(item.level)}`)
+  }
+  // The threshold is not taste: it is the size of the bottom rung's own declared
+  // closed set, read off the curriculum. Serving one rung, *however* well, cannot
+  // produce more distinct questions than the rung has in it — so exceeding it is
+  // proof that the neighbours were reached, and it is a number that cannot be
+  // satisfied by any amount of shuffling.
+  const bottom = rungs.find((rung) => rung.node.id === "dw.add.facts.add-within-ten")?.node.generator
+    .closedFactSet?.[0]
+  assert.ok(typeof bottom === "number" && bottom > 0, "the bottom rung declares no closed set")
+  assert.ok(
+    prompts.size > bottom,
+    `twenty questions at the floor drew ${String(prompts.size)} distinct prompts and the bottom ` +
+      `rung's closed set holds ${String(bottom)} — so nothing outside it was served: ` +
+      `${[...prompts].join(", ")}`,
+  )
+  assert.ok(
+    skills.size >= 3,
+    `twenty questions at the floor came from ${String(skills.size)} rung(s): ` +
+      `${[...skills].join(", ")} — the floor is still a point`,
+  )
+  // And they are all still first-grade facts, not a stretch into column
+  // arithmetic: the spread is narrow, it is only not a point.
+  for (const key of skills) assert.match(key, /^dw\.add\.facts\./, `the floor reached ${key}`)
+})
+
+test("the stream a child is served stays inside the spread of where the ladder stands", () => {
+  // The guard that the mixing cannot quietly become "any rung at all". Over a
+  // long session with a child who is right four times in five, every question
+  // must have come from within the kernel of the position at the time.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-spread", record: noRecord, rungs })
+  let worstBelow = 0
+  let worstAbove = 0
+  for (let answered = 0; answered < 400; answered++) {
+    const centre = service.position()
+    const item = service.next({ packId: "dynawalla.truedraw" })
+    assert.ok(item)
+    const served = Math.round((item.difficulty ?? 0) * span)
+    worstBelow = Math.max(worstBelow, centre - served)
+    worstAbove = Math.max(worstAbove, served - centre)
+    const right = answered % 5 !== 4
+    service.judge({
+      packId: "dynawalla.truedraw",
+      itemId: item.id,
+      response: right ? service.reveal(item.id) : "definitely wrong",
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+  }
+  assert.ok(worstAbove <= SPREAD_ABOVE, `a question came ${String(worstAbove)} rungs above the child`)
+  assert.ok(worstBelow <= SPREAD_BELOW, `a question came ${String(worstBelow)} rungs below the child`)
+  // And it really did use the width, rather than serving the centre forever.
+  assert.equal(worstAbove, SPREAD_ABOVE, "the spread never once reached its own ceiling")
+  assert.equal(worstBelow, SPREAD_BELOW, "the spread never once reached its own floor")
 })

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -169,6 +169,263 @@ const CADENCE_SPREAD_DEN = 2
  */
 const CHOICE_COUNT = 4
 
+/**
+ * ## Why a rung is served as a distribution and not as a point
+ *
+ * The founder, having played it:
+ *
+ * > "we don't have to be at one level only 'mixed triple and double' .. we could
+ * > still throw in some single digit problems but it should change the
+ * > probabilities of harder and easier problems more smoothly."
+ *
+ * Until this note the ladder served `rungs[Math.floor(progress)]` and nothing
+ * else. Two consequences, and both of them are what he was reporting:
+ *
+ *   * Every question in a sitting came from one rung, so on a rung whose fact
+ *     set is closed and small — `add-within-ten` L0 has **nine** items in it —
+ *     the same sum came round every few questions and the content looked
+ *     hardcoded. It is not hardcoded; it is a nine-item set served nine times.
+ *   * The rung's ordinate moved in whole steps, so the content *lurched*: a
+ *     child was on `0 + 2` and then, in one step, on nothing but the next rung.
+ *     There was no such thing as "mostly this, sometimes one either side".
+ *
+ * **The kernel.** A two-sided geometric weight over the offset from the rung the
+ * ladder is standing on: the centre weighs 1, each rung below weighs
+ * `BELOW_RATIO` times the one above it, each rung above weighs `ABOVE_RATIO`
+ * times the one below it, truncated at `SPREAD_BELOW` and `SPREAD_ABOVE`.
+ * Geometric because the weights then compose — two rungs away is exactly "one
+ * rung away, twice" — and there is no distance at which the shape changes its
+ * mind. Asymmetric because *easier than you can do* and *harder than you can do*
+ * are not the same event: the first is a fluency rep, the second is a child stuck.
+ *
+ * **What the numbers are, and where they come from.** They are not taste; they
+ * are the founder's accuracy target read as a mix. With the constants below the
+ * kernel is
+ *
+ * | offset | −3   | −2   | −1   | 0    | +1   | +2   |
+ * |--------|------|------|------|------|------|------|
+ * | weight | .125 | .25  | .5   | 1    | .35  | .1225|
+ * | share  | 5.2% | 10.4%| 20.9%| 41.7%| 14.6%| 5.1% |
+ *
+ * so **20% of questions are above the rung the child is standing on** and 5% are
+ * two above. Against the accuracy a child plausibly has at each offset — near
+ * everything below level, ~90% at level, ~60% one above, ~30% two above — that
+ * mix measures out at **83% correct**, which is the "80%+ correct but slowly"
+ * the founder asked the calibration to find. The distribution and the staircase
+ * are therefore aiming at the same number from two directions, which is the only
+ * reason it is safe to run them at once.
+ *
+ * Two more properties it has to have, and does:
+ *
+ *   * **Consecutive questions differ.** The chance two draws land on the same
+ *     rung is `Σ p²` = 25.5%, so three questions in four move.
+ *   * **A rung the child cannot do is rare.** Two above is 5%, three above is
+ *     not served at all.
+ *
+ * **Reflected at the ends, not clipped.** At the bottom of the ladder there is
+ * nowhere below to go, and clipping would pile 78% of a beginner's questions
+ * onto rung 0 — nine items — which is the exact defect this exists to fix. So
+ * the mass that falls off an end is *reflected back inward*: at rung 0 the
+ * kernel becomes 43% / 36% / 16% / 5% over rungs 0..3, which is `add-within-ten`
+ * L0 and L1 and `subtract-within-ten` L0 and L1 — about sixty distinct items
+ * rather than nine, with nothing inflated and no closed set relabelled. That is
+ * the answer to a small honest fact set: **reach the neighbours**, never pretend
+ * the set is bigger than it is (CG-10 exists to stop exactly that pretence).
+ */
+export const SPREAD_BELOW = 3
+export const SPREAD_ABOVE = 2
+export const BELOW_RATIO = 0.5
+export const ABOVE_RATIO = 0.35
+
+/**
+ * The weight of every rung on the ladder for a child standing on `centre`.
+ *
+ * Length `span + 1` — one weight per rung — summing to the untruncated kernel's
+ * total, because mass that falls off an end is reflected inward rather than
+ * dropped. Reflection is iterated, so a ladder narrower than the kernel (a test
+ * with two rungs in it) still gets a normalisable set of weights instead of a
+ * hole.
+ *
+ * Exported because a distribution asserted by sampling it is a distribution
+ * asserted at whatever confidence the sample happened to have. `items.test.ts`
+ * reads the weights.
+ */
+export function rungWeights(centre: number, span: number): readonly number[] {
+  const width = Math.max(0, Math.floor(span)) + 1
+  const weights = new Array<number>(width).fill(0)
+  const from = Math.max(0, Math.min(width - 1, Math.round(centre)))
+  for (let offset = -SPREAD_BELOW; offset <= SPREAD_ABOVE; offset++) {
+    const weight =
+      offset === 0 ? 1 : offset < 0 ? BELOW_RATIO ** -offset : ABOVE_RATIO ** offset
+    // Reflect at both ends rather than clip. `-1` reflects to `1`, and on a
+    // two-rung ladder `-3` reflects to `3` and then back to `1`, so the loop
+    // runs until the index is inside — bounded, because each pass strictly
+    // reduces the overshoot.
+    let index = from + offset
+    for (let guard = 0; guard < 64 && (index < 0 || index > width - 1); guard++) {
+      if (index < 0) index = -index
+      if (index > width - 1) index = 2 * (width - 1) - index
+    }
+    if (index < 0 || index > width - 1) index = from
+    weights[index] = (weights[index] as number) + weight
+  }
+  return weights
+}
+
+/** `Rng` emits uint32 rather than a float, so a unit draw is spelled out once. */
+const UINT32_RANGE = 2 ** 32
+
+/** One rung drawn from `rungWeights`. Deterministic in the stream it is given. */
+export function pickRung(centre: number, span: number, unit: number): number {
+  const weights = rungWeights(centre, span)
+  let total = 0
+  for (const weight of weights) total += weight
+  if (total <= 0) return Math.max(0, Math.min(weights.length - 1, Math.round(centre)))
+  // `unit` is clamped rather than trusted: a stream that returns exactly 1 must
+  // land on the last rung with weight, not past the end of the array.
+  let cut = Math.min(0.999_999_999, Math.max(0, unit)) * total
+  for (let index = 0; index < weights.length; index++) {
+    cut -= weights[index] as number
+    if (cut < 0) return index
+  }
+  return weights.length - 1
+}
+
+/**
+ * ## Finding a child's level quickly, then tracking it gently
+ *
+ * The founder, in the same report:
+ *
+ * > "right now the true draw is almost impossible to progress beyond 0+2 level.
+ * > We need to sort of quickly find the players level .. maybe where they are
+ * > getting 80%+ correct but slowly .. go down on a wrong answer, go up on a
+ * > right answer"
+ *
+ * and, one paragraph earlier, the apparent opposite:
+ *
+ * > "it's way too quick to go from 0+1 to 1269/9. We need to find the users
+ * > level more gently!"
+ *
+ * They are the same request. The *search* must be quick and the *content* must
+ * not lurch. What was shipped was the reverse of both: a fixed ±1 rung, which is
+ * a slow search, married to a single-rung stream and a 64-deep question queue in
+ * `packs/shared/game-host`, which is what turned the search into a teleport once
+ * the queue finally turned over. The queue is fixed there; the search is fixed
+ * here.
+ *
+ * **The shape: a weighted staircase with a decaying step.** Standard psychophysics,
+ * and it is the right standard because the problem is literally threshold
+ * estimation — find the difficulty at which this child is right 80% of the time.
+ *
+ *   * **The stride shrinks.** It opens at `STEP_START` rungs, multiplies by
+ *     `STEP_DECAY` after every answer, and is *halved again at every reversal* —
+ *     every time the child's direction changes, because a reversal is the moment
+ *     their level got bracketed. Large strides early are the "quickly find the
+ *     level"; the shrinking is the "more gently".
+ *   * **The floor of the stride depends on the evidence.** While no reversal has
+ *     happened the stride bottoms out at `STEP_OPEN` = 1 — which is exactly the
+ *     rate this file shipped with, so **a child who is never wrong is never
+ *     slower than they were before**, and the 87-answer property for a slow
+ *     perfect child is preserved by construction rather than by tuning. Once
+ *     bracketed it bottoms out at `STEP_TRACK`, a quarter of a rung, which is
+ *     what makes the tracking gentle.
+ *   * **Down is four times up.** Kaernbach's weighted up/down rule: a staircase
+ *     converges on the proportion `p` correct when the step ratio is
+ *     `up : down = (1 − p) : p`. For the founder's 80% that ratio is **1:4**, and
+ *     `DESCENT_RATIO` is that four. It is not a punishment and it is not tuned;
+ *     it is the arithmetic of the number he asked for. At the tracking floor it
+ *     comes out as +0.25 of a rung for a right answer and −1 for a wrong one —
+ *     so a miss costs precisely the one rung it always cost, and only the reward
+ *     changed.
+ *   * **In the child's own currency.** The descent is scaled by `pace`, a running
+ *     mean of what this child's correct answers have actually been worth
+ *     (`climbRungs`, unchanged — quick, expected and tail regimes all still
+ *     apply, and they now scale the stride instead of being the whole of it). A
+ *     child worth 0.4 of a rung an answer falls 0.4 × 4 × step, not 1 × 4 × step.
+ *     Without this the ratio is 1:4 only for a child answering at the median and
+ *     nearer 1:10 for a deliberate one, which would park every slow child several
+ *     rungs below the fast child who knows exactly as much.
+ *   * **The first miss is symmetric.** Before any reversal the descent weight is
+ *     1, not 4: the first wrong answer is the move that *closes* the bracket, and
+ *     it should be the same size as the moves that opened it. Multiplying an
+ *     opening stride of four rungs by four would throw a child sixteen rungs down
+ *     for one slip, which is the lurch in the other direction.
+ *
+ * **A guesser still cannot climb.** One tap in four on a four-slab grid: their
+ * expected move once bracketed is `¼(+0.25) − ¾(4 × 0.25) = −0.69` rungs an
+ * answer, against `¼(+1) − ¾(1) = −0.5` under the rule this replaces. The
+ * speedcuber bonus is still gated behind `QUICK_RUN_FOR_BONUS` consecutive quick
+ * *correct* answers, which a guesser reaches one time in 4⁶. `items.test.ts`
+ * runs the bot.
+ */
+export const STEP_START = 4
+export const STEP_OPEN = 1
+export const STEP_TRACK = 0.25
+export const STEP_DECAY = 0.72
+export const REVERSAL_DECAY = 0.5
+export const DESCENT_RATIO = 4
+
+/**
+ * How fast `pace` forgets. A quarter, so five answers carry ~76% of the weight:
+ * long enough that one unusually fast tap does not redefine a child's currency,
+ * short enough that a child who has warmed up is measured warm.
+ */
+export const PACE_ALPHA = 0.25
+
+/**
+ * The smallest currency a child can be charged a miss in.
+ *
+ * A pace of zero would make a miss free, which is the one thing a staircase may
+ * never be — it is exactly what a guesser would need in order to climb. A tenth
+ * of a rung is under the pace of a child answering at ten times an item's own
+ * p90, so it binds on nobody the tail regime can measure and it closes the hole.
+ */
+export const PACE_FLOOR = 0.1
+
+/** Where the search is: the stride, the direction, and the child's own currency. */
+export type Staircase = {
+  /** Rungs, before the regime multiplier. Never below the current floor. */
+  readonly step: number
+  /** `+1`, `-1`, or `0` before the first answer. */
+  readonly lastDir: 0 | 1 | -1
+  /** Whether the child's direction has ever changed — i.e. whether they are bracketed. */
+  readonly reversed: boolean
+  /** Running mean of what this child's correct answers have been worth, in rungs. */
+  readonly pace: number
+}
+
+export function openStaircase(): Staircase {
+  return { step: STEP_START, lastDir: 0, reversed: false, pace: 1 }
+}
+
+/** How far this correct answer moves the centre, given what it was worth. */
+export function ascentOf(stair: Staircase, gain: number): number {
+  return gain * stair.step
+}
+
+/**
+ * How far this wrong answer moves the centre.
+ *
+ * Symmetric with the ascent until the bracket closes, then `DESCENT_RATIO` times
+ * it — in the child's own currency, so the 1:4 that produces 80% correct holds
+ * for a deliberate child as well as a quick one.
+ */
+export function descentOf(stair: Staircase): number {
+  const weight = stair.reversed ? DESCENT_RATIO : 1
+  return weight * stair.step * Math.max(PACE_FLOOR, stair.pace)
+}
+
+/** The search after one answer in `dir`, worth `gain` rungs if it was correct. */
+export function advanceStaircase(stair: Staircase, dir: 1 | -1, gain: number | null): Staircase {
+  const isReversal = stair.lastDir !== 0 && dir !== stair.lastDir
+  const reversed = stair.reversed || isReversal
+  const floor = reversed ? STEP_TRACK : STEP_OPEN
+  const base = isReversal ? stair.step * REVERSAL_DECAY : stair.step
+  const step = Math.max(floor, floor + (base - floor) * STEP_DECAY)
+  const pace = gain === null ? stair.pace : stair.pace + PACE_ALPHA * (gain - stair.pace)
+  return { step, lastDir: dir, reversed, pace }
+}
+
 export type Rung = {
   readonly node: SkillNode
   readonly family: AnyGeneratorFamily
@@ -731,6 +988,14 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
    */
   let progress = 0
   /**
+   * The search for where the child is: stride, direction, and their own currency.
+   *
+   * Session-scoped, like `progress`, and for the same reason — it is a search,
+   * and a search that opens mid-stride is a search that has evidence it does not
+   * have. See the note on `STEP_START`.
+   */
+  let stair = openStaircase()
+  /**
    * Consecutive quick, correct answers. Reset by anything else — see
    * `QUICK_RUN_FOR_BONUS` for why a single one earns nothing.
    */
@@ -824,9 +1089,9 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       // not two: a pack that drives the difficulty and then stops driving it
       // resumes from where it left the child, and `judge` keeps climbing and
       // stepping down from there.
+      const span = Math.max(0, rungs.length - 1)
       let index = Math.floor(progress)
       if (difficulty !== undefined || maxDifficulty !== undefined) {
-        const span = Math.max(0, rungs.length - 1)
         const asked = difficulty === undefined ? index / Math.max(1, span) : difficulty
         // The request rounds to the nearest rung — a pack asking for 0.5 wants the
         // middle and not the rung below it. The **ceiling floors**, and the two are
@@ -846,12 +1111,41 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         progress = index + (progress - Math.floor(progress))
       }
 
-      const rung = wanted ?? rungAt(index)
+      sequence += 1
+
+      // The rung is drawn from a spread centred on the one the ladder is
+      // standing on — see `rungWeights` for the shape and why it is not a point.
+      // Seeded off (profile, pack, sequence) like everything else here, so the
+      // same learner on two devices sees the same mix and not merely the same
+      // centre; and re-clamped under `maxDifficulty` afterwards, because a
+      // ceiling the spread could reach over is not a ceiling.
+      //
+      // **Only when the centre is the host's own.** A `difficulty` the pack
+      // named is honoured as the point the SDK documents it to be, and the
+      // reason is not caution, it is four shipped games: `counterweight` pins
+      // `maxDifficulty` *equal* to its request, `polarity` and `balance` and
+      // `horde` pin a ceiling to what they can physically draw, and PR 694 exists
+      // because polarity was handed a rung it could not render. Smearing the
+      // host's kernel over a request like that overrides a pack's own model with
+      // no way for the pack to say no. What the child's *level* is, is the
+      // host's business and gets the spread; what a game's dramaturgy wants for
+      // the next chip is the game's, and it already varies on its own terms. A
+      // pack opting into a spread around its own request is one SDK field and is
+      // named here rather than guessed at.
+      let drawn = index
+      if (difficulty === undefined) {
+        const spread = createRng(seedFrom(deps.profileId, packId, String(sequence), "rung"))
+        drawn = pickRung(index, span, spread.nextUint32() / UINT32_RANGE)
+        if (maxDifficulty !== undefined) {
+          drawn = Math.min(drawn, Math.max(0, Math.floor(maxDifficulty * span)))
+        }
+      }
+
+      const rung = wanted ?? rungAt(drawn)
       if (!rung) return null
       // Where the rung that was actually used sits, so the pack is told what it
       // got and not what it asked for. A pack comparing the two is how a
       // clamped request becomes visible on the pack's side.
-      const span = Math.max(0, rungs.length - 1)
       const used = rungs.indexOf(rung)
       const ordinate = span === 0 ? 0 : Math.max(0, Math.min(1, used / span))
       if (span === 0 && difficulty !== undefined && !toldAboutFlatLadder) {
@@ -863,7 +1157,6 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         )
       }
 
-      sequence += 1
       const seed = seedFrom(deps.profileId, packId, String(sequence))
       let exercise: Exercise
       try {
@@ -992,15 +1285,22 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       if (!served.answered) {
         served.answered = true
         deps.record({ packId, correct: verdict.correct })
-        // The ladder moves on what actually happened. Up on every correct
-        // answer — by more than a rung when it was quick for this question, by
-        // a fraction of one when it came from the item's slow tail — and down
-        // one rung on any miss. Slow is not wrong: it is the same direction,
+        // The ladder moves on what actually happened, and how far is the
+        // staircase's stride times what this answer was worth. Up on every
+        // correct answer — by more than a rung when it was quick for this
+        // question, by a fraction of one when it came from the item's slow tail
+        // — and down on any miss. Slow is not wrong: it is the same direction,
         // taken at the child's own speed. Wrong is the only thing that
-        // descends, which is what stops a guesser.
-        if (verdict.correct) progress = progress + climbFor(served, latencyMs)
-        else {
-          progress = progress - 1
+        // descends, which is what stops a guesser. See `STEP_START` for why the
+        // stride opens wide and shrinks, and `DESCENT_RATIO` for why down is
+        // four times up once the child's level has been bracketed.
+        if (verdict.correct) {
+          const gain = climbFor(served, latencyMs)
+          progress = progress + ascentOf(stair, gain)
+          stair = advanceStaircase(stair, 1, gain)
+        } else {
+          progress = progress - descentOf(stair)
+          stair = advanceStaircase(stair, -1, null)
           // A miss ends the run, however fast it was. Speed on a wrong answer
           // is not evidence of anything at all — it is what guessing looks
           // like — and the speedcuber's rate has to be earned again.

--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -51,6 +51,14 @@ type Fake = {
   answerFails: boolean
   /** Make `skip` reject, as an older host with no such method would. */
   skipFails: boolean
+  /**
+   * The rung the fake's own ladder is standing on, which a test may move.
+   *
+   * The real host's position moves on every answer, and a fake that stands still
+   * forever cannot show the defect this exists for: a pool stocked at rung 0
+   * being served to a child the ladder has already carried to rung 25.
+   */
+  standing: number
 }
 
 /**
@@ -73,6 +81,7 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
     verdict: true,
     answerFails: false,
     skipFails: false,
+    standing: RESTING_RUNG,
     asks,
     answers,
     skips,
@@ -87,7 +96,7 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
         asks.push(ask)
         const span = Math.max(1, rungs - 1)
         const cap = ask.maxDifficulty === undefined ? 1 : ask.maxDifficulty
-        const wanted = ask.difficulty === undefined ? RESTING_RUNG / span : ask.difficulty
+        const wanted = ask.difficulty === undefined ? fake.standing / span : ask.difficulty
         const index = Math.max(
           0,
           Math.min(rungs - 1, Math.round(Math.min(wanted, cap) * span)),
@@ -297,29 +306,123 @@ async function questionsUntilEasy(mounted: ReturnType<typeof attachGameHost>): P
   return Number.POSITIVE_INFINITY
 }
 
-test("without a flush the change lands a whole pool later; with one it lands next question", async () => {
-  // Both start from a *full* pool — `warm` awaits the floor and tops up in the
-  // background, and it is the topped-up sixty-four that a real game meets.
-  const stale = attachGameHost(fakeHost().client, { autoFlush: false })
-  await stale.warm()
-  await settle()
-  const before = await questionsUntilEasy(stale)
-  stale.dispose()
+test("a difficulty change lands next question, and the pool is re-stocked for it", async () => {
+  // Both arms start from a *full* pool — `warm` awaits the floor and tops up in
+  // the background, and it is the topped-up sixty-four that a real game meets.
+  //
+  // This test used to read "without a flush the change lands a whole pool later",
+  // and the reason it no longer can is worth stating: the pool used to be
+  // refilled in batches of thirty-two, when it drained past `POOL_FLOOR`, so
+  // between batches there was nothing stocked at the new difficulty for the
+  // *search* to find and the flush was the only thing that could help. It is
+  // topped up one question at a time now — for a different reason, see `fresh` in
+  // `index.ts` — so the search alone lands a change within a question or two even
+  // with `autoFlush` off. What the flush still does, and what is asserted here,
+  // is discard the sixty-four questions the child will now never see, so the pool
+  // in front of them is stocked for where they are rather than where they were.
+  const measure = async (autoFlush: boolean) => {
+    const fake = fakeHost()
+    const mounted = attachGameHost(fake.client, { autoFlush })
+    await mounted.warm()
+    await settle()
+    const asked = fake.asks.length
+    const questions = await questionsUntilEasy(mounted)
+    await settle()
+    const stocked = fake.asks.length - asked
+    mounted.dispose()
+    return { questions, stocked }
+  }
+  const stale = await measure(false)
+  const fresh = await measure(true)
 
-  const fresh = attachGameHost(fakeHost().client)
-  await fresh.warm()
-  await settle()
-  const after = await questionsUntilEasy(fresh)
-  fresh.dispose()
-
-  console.log(`[measured] questions until a difficulty change lands: ${String(before)} → ${String(after)}`)
+  console.log(
+    `[measured] questions until a difficulty change lands: ` +
+      `${String(stale.questions)} → ${String(fresh.questions)}; questions re-stocked for it: ` +
+      `${String(stale.stocked)} → ${String(fresh.stocked)}`,
+  )
 
   assert.ok(
-    before >= POOL_FLOOR,
-    `a stale pool should hold the old difficulty for at least ${String(POOL_FLOOR)} questions, not ${String(before)}`,
+    fresh.questions <= 2,
+    `a flushed pool should follow within 2 questions, not ${String(fresh.questions)}`,
   )
-  assert.ok(after <= 2, `a flushed pool should follow within 2 questions, not ${String(after)}`)
-  assert.ok(after < before, `flushing changed nothing: ${String(after)} vs ${String(before)}`)
+  // A pool that was only searched grows back by the handful of questions that
+  // were taken out of it. A pool that was flushed is trimmed to `FLUSH_KEEP` and
+  // has to be refetched, which is most of `POOL_TARGET`.
+  assert.ok(
+    fresh.stocked > POOL_FLOOR,
+    `a flush should re-stock more than ${String(POOL_FLOOR)} questions for the new difficulty, ` +
+      `not ${String(fresh.stocked)}`,
+  )
+  assert.ok(
+    stale.stocked < POOL_FLOOR,
+    `with autoFlush off nothing should be discarded, so nothing much should be re-stocked; ` +
+      `${String(stale.stocked)} questions were`,
+  )
+})
+
+test("a game that drives no difficulty at all still gets the host's current rung", async () => {
+  // THE test for the founder's report. TRUE DRAW calls `host.next()` with no
+  // arguments — it has no difficulty model of its own and does not want one — so
+  // `target` is never set, and the flush used to return early on exactly that.
+  // The pool it was handed at `warm()` was therefore stocked at whatever rung the
+  // ladder stood on before the child answered anything, and stayed in front of
+  // the child for the whole depth of the pool, permanently:
+  //
+  //   "I've gotten 10 correct in a row fast and I still get 2+0=1 ... 25 in a
+  //    row max speed and I get 2+0=1"
+  //
+  // Here the host's ladder starts at the bottom and is carried to the top, which
+  // is what twenty-five correct answers do to it. The question is how many
+  // questions a child has to answer before they see it.
+  // The measured depth on the code this replaces, on this same fake, was **65
+  // questions** — `POOL_FLOOR` awaited by `warm()` plus the top-up to
+  // `POOL_TARGET` on the first hand-out, and then never refreshed. It is not
+  // reproducible from here by flipping `autoFlush`, because three separate things
+  // had to change to fix it and that option only disables one: the pool is now
+  // *aimed* at the host's own position (`fresh`), *searched* against that aim,
+  // and topped up one question at a time so the aim is current. Delete any one of
+  // them and this test fails — measured at 65, 65 and 34 respectively.
+  const fake = fakeHost()
+  fake.standing = 0
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  await settle()
+  // The ladder moves, exactly as `items.ts` moves it on a correct answer. The
+  // game is told nothing and asks for nothing.
+  fake.standing = RUNGS - 1
+  const asked = fake.asks.length
+  let served = Number.POSITIVE_INFINITY
+  for (let n = 1; n <= 400; n++) {
+    const q = mounted.host.next()
+    if (q.difficulty >= 0.9) {
+      served = n
+      break
+    }
+    await settle(3)
+  }
+  await settle()
+  // Searched *and* discarded. Finding the one fresh question in a pool of
+  // sixty-four stale ones is what makes the next question right; throwing the
+  // sixty-four away is what makes the question after that right too, and it is a
+  // separate mechanism (`maybeFlush` from `take`) with a separate failure mode. A
+  // pool that was only searched grows back by the handful taken out of it.
+  const stocked = fake.asks.length - asked
+  mounted.dispose()
+  console.log(
+    `[measured] questions a game driving no difficulty serves before it sees the host's own ` +
+      `rung: ${String(served)} (was 65); questions re-stocked for it: ${String(stocked)}`,
+  )
+  assert.ok(
+    served <= 8,
+    `a game that drives nothing waited ${String(served)} questions for the ladder it is standing ` +
+      `on; the pool is aimed at the host's own position now, so it should be a handful`,
+  )
+  assert.ok(
+    stocked > POOL_FLOOR,
+    `the stale pool was searched but never discarded: only ${String(stocked)} questions were ` +
+      `re-stocked for the rung the child is now on, so most of what is queued in front of them ` +
+      `is still the rung they left`,
+  )
 })
 
 test("flush never empties the pool, so a flushed question is still reportable", async () => {

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -51,7 +51,34 @@
 //   3. The pool is *flushed* when the request moves, because a pool of
 //      thirty-two to sixty-four questions is otherwise a thirty-two question
 //      delay between a decision and its effect. Measured: 34 questions without,
-//      2 with.
+//      2 with. (The 34 was also half caused by the batched refill described
+//      below; with the pool topped up one question at a time the *search* alone
+//      lands a change in two, and the flush's remaining job is to stop the pool
+//      accumulating sixty-four questions the child will never be served.)
+//
+// ── The pool also goes stale when the HOST moves, not only when the game asks ──
+//
+// Part 3 above was written for a game that drives its own difficulty, and it
+// checked `target === null` and returned. Every game that does *not* drive one —
+// TRUE DRAW calls `host.next()` with no arguments at all — therefore had no
+// flush of any kind, and the delay was the full depth of the pool, permanently.
+//
+// What that cost, measured on the shipped code: `warm()` awaits `POOL_FLOOR`
+// questions before the first frame and the first `take()` tops the pool up to
+// `POOL_TARGET`, so **the first sixty-four questions of a session are all drawn
+// from wherever the host's ladder stood before the child answered anything** —
+// rung zero. The founder's report is both halves of this one bug:
+//
+//   "I've gotten 10 correct in a row fast and I still get 2+0=1 ... 25 in a row
+//    max speed and I get 2+0=1"          — the queue in front of him was 64 deep
+//   "it's way too quick to go from 0+1 to 1269/9"
+//                        — and when it finally turned over, it turned over whole
+//
+// So the aim the pool is stocked and searched against is now `target ?? fresh`,
+// where `fresh` is the ordinate of the most recent item the host actually handed
+// over. A game that drives difficulty is unaffected — its own request still wins
+// — and a game that drives nothing now discards a pool the ladder has walked
+// away from instead of feeding a child their own past.
 //
 // What this module does NOT do is decide anything. It does not read the
 // outcomes it records, it has no opinion about whether a child is struggling,
@@ -314,6 +341,17 @@ const SESSION_ITEMS = 40
 const FLUSH_BAND = 0.1
 
 /**
+ * The same, when the thing that moved is the host's ladder rather than a request.
+ *
+ * Three hundredths, which on the sixty-six-rung ladder that ships is two rungs —
+ * inside the width of the spread `items.ts` serves from, so a pool is refreshed
+ * before the child can notice it has gone stale, and not so tight that it churns.
+ * Only reached once per question (from `take`), never per frame, and still behind
+ * `FLUSH_COOLDOWN_MS`.
+ */
+const HOST_FLUSH_BAND = 0.03
+
+/**
  * The shortest gap between two automatic flushes.
  *
  * runner recomputes its difficulty continuously and asks on every gate; without
@@ -469,6 +507,16 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   let ceiling: number | null = null
   /** A floor that only ever rises. siege drives this. */
   let floor = 0
+  /**
+   * The ordinate of the most recent item the host handed over.
+   *
+   * The freshest reading available of where the host's own ladder is standing —
+   * every refill fetches at the host's current position, so the last arrival is
+   * at most one round trip old. It is what the pool is aimed at when the game
+   * does not aim it itself; see the note at the top of this file for what it
+   * cost to have no aim at all.
+   */
+  let fresh: number | null = null
   /** The difficulty the pool was last stocked for. */
   let filledFor: number | null = null
   let lastFlush = 0
@@ -548,7 +596,13 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
             console.error("[pack] items.reveal was not granted; questions cannot be placed")
             break
           }
-          pool.push({ question: questionFrom(item, canonical, domain), skillId: item.skillId })
+          const question = questionFrom(item, canonical, domain)
+          // The freshest reading of where the host stands, taken on arrival
+          // rather than on hand-out: a question that is still in the pool has
+          // already told us something, and waiting until a child sees it is
+          // waiting the length of the pool.
+          fresh = question.difficulty
+          pool.push({ question, skillId: item.skillId })
         }
       } catch (error) {
         console.error("[pack] could not fill the question pool", error)
@@ -558,9 +612,19 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     })()
   }
 
+  /**
+   * What the pool should be stocked and searched against, or `null` for
+   * "whatever is in it".
+   *
+   * The game's own request when it makes one, and otherwise where the host's
+   * ladder actually is. A `null` here means neither is known, which happens only
+   * before the first item has ever arrived.
+   */
+  const aim = (): number | null => target ?? fresh
+
   /** How wrong a pooled question is for what the game is asking for now. */
   const distance = (entry: Pooled): number => {
-    const want = target ?? ceiling ?? entry.question.difficulty
+    const want = aim() ?? ceiling ?? entry.question.difficulty
     const over = ceiling !== null && entry.question.difficulty > ceiling + EPS
     // A question above a stated ceiling is never the answer while anything else
     // exists, and is still an answer when nothing else does.
@@ -569,8 +633,8 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
 
   const flushNow = () => {
     lastFlush = Date.now()
-    filledFor = target
-    if (target !== null && pool.length > FLUSH_KEEP) {
+    filledFor = aim()
+    if (aim() !== null && pool.length > FLUSH_KEEP) {
       // A focused value survives a flush whatever its difficulty. `focus`
       // outranks difficulty when a question is handed out — FUSE's chip has to
       // be able to say its own number — so a flush that threw those away would
@@ -590,9 +654,18 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   }
 
   const maybeFlush = () => {
-    if (!autoFlush || target === null) return
-    const moved = filledFor === null ? 1 : Math.abs(target - filledFor)
-    if (moved < FLUSH_BAND) return
+    const want = aim()
+    if (!autoFlush || want === null) return
+    const moved = filledFor === null ? 1 : Math.abs(want - filledFor)
+    // A game's request is a coarse intent that can jitter frame to frame, so it
+    // has to move a tenth of the ladder to be worth discarding a pool for. The
+    // host's own position is not an intent — it is where the child is — and it
+    // moves in whole rungs, so it gets a tighter band. Without the tighter one a
+    // sixty-six-rung ladder has to be walked almost seven rungs before the queue
+    // in front of a child is refreshed, which is more than the whole width of the
+    // spread the host serves from.
+    const band = target === null ? HOST_FLUSH_BAND : FLUSH_BAND
+    if (moved < band) return
     if (moved < FLUSH_URGENT && Date.now() - lastFlush < FLUSH_COOLDOWN_MS) return
     flushNow()
   }
@@ -615,10 +688,21 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   const take = (request?: DifficultyRequest): Question => {
     lastAsk = Date.now()
     applyRequest(request)
+    // Once per question, whether or not the game said anything. `applyRequest`
+    // returns early when there is no request, and that early return is exactly
+    // what left a game driving no difficulty with no flush at all.
+    maybeFlush()
     const label = request?.domain ?? domain
 
     const hand = (entry: Pooled): Question => {
-      if (pool.length < POOL_FLOOR) fill()
+      // Topped up on every hand-out rather than in batches of thirty-two when the
+      // pool drains past `POOL_FLOOR`. Same number of fetches over a session, and
+      // it is what makes `fresh` actually fresh: refilling in batches meant the
+      // host was not asked anything at all for thirty-two questions at a time, so
+      // there was no reading of where its ladder had got to and nothing for
+      // `maybeFlush` to act on. `fill` is idempotent while one is in flight and
+      // stops at `POOL_TARGET`, so this is one round trip per question.
+      fill()
       const question = label === entry.question.domain
         ? entry.question
         : { ...entry.question, domain: label }
@@ -659,6 +743,13 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
 
     // The question closest to what was asked for. Ties go to the front of the
     // pool, so with no difficulty request this is exactly the FIFO it was.
+    //
+    // Deliberately still `target` and not `aim()`: searching the pool against the
+    // host's own position as well was tried, and it changes the order every one of
+    // the twenty-seven games is served in while making no measurable difference to
+    // the staleness it was meant to fix (2 questions either way — the flush and
+    // the per-question top-up already do it). A behaviour change to shared code
+    // that no test can distinguish is a behaviour change nobody asked for.
     if ((target !== null || ceiling !== null) && pool.length > 0) {
       let best = 0
       let score = distance(pool[0] as Pooled)
@@ -809,7 +900,9 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
         if (item === null) break
         const canonical = canReveal ? await client.reveal(item.id) : ""
         if (canonical === "") break
-        pool.push({ question: questionFrom(item, canonical, domain), skillId: item.skillId })
+        const question = questionFrom(item, canonical, domain)
+        fresh = question.difficulty
+        pool.push({ question, skillId: item.skillId })
       }
       fill()
     },


### PR DESCRIPTION
The founder played THE TRUE DRAW and reported two things that read as opposites. They are one bug, and the number is **65**.

## Why 25 fast correct answers did not move him

`packs/shared/game-host` prefetches questions. `warm()` awaits `POOL_FLOOR` before the first frame and the first hand-out tops the pool to `POOL_TARGET`, so **the first sixty-four questions of a session were all generated at the rung the ladder stood on before the child answered anything** — rung zero. The flush that exists to prevent exactly this checked `target === null` and returned, and TRUE DRAW calls `host.next()` with no arguments at all.

So the ladder *did* climb on his twenty-five answers. The queue in front of him was sixty-four items of `0 + 2` deep — and when it finally turned over it turned over whole, which is the *"way too quick to go from 0+1 to 1269/9"* in the same report. One mechanism, both complaints.

None of the three suspects in the brief was the cause. The six-quick gate, the `latencyMs` contamination and the generous verify-game window are all real and each costs a rung here and there. This cost sixty-four questions, every session, permanently.

Measured on the fake host, for a game that drives no difficulty: **65 → 2 questions.**

## What changed

**A rung is served as a distribution.** A two-sided geometric kernel centred on the rung the ladder stands on — ratio 1/2 down, 0.35 up, truncated at −3/+2 — giving shares 5/10/21/42/15/5. Twenty per cent of questions land above the child's rung, five per cent two above; against the accuracy a child plausibly has at each offset the mix measures out at ~83% correct. At the ends it **reflects** rather than clips, because clipping piles 80% of a beginner's questions onto rung 0, and `dw.add.facts.add-within-ten` L0 declares a closed set of **nine items**. Thirty questions at the floor drew 9 distinct prompts before and draw **26** now, with nothing inflated and no closed set relabelled.

**Calibration is a weighted staircase with a decaying stride.** Opens at 4 rungs, ×0.72 per answer, halved again at every reversal; floor of 1 rung while unbracketed (the rate this file always climbed at) and 0.25 once bracketed. **Down is four times up** once bracketed — Kaernbach's rule, `up:down = (1−p):p`, so 80% correct *is* 1:4. At the tracking floor that is +0.25 for a right answer and −1 for a wrong one: the miss costs exactly the rung it always cost, and only the reward changed. Scaled by a running mean of what that child's answers are worth, so the ratio holds for a deliberate child too.

**The pool is aimed at the host's own position**, `maybeFlush` runs once per question, and the pool is topped up one question at a time rather than in batches of thirty-two.

## Simulated, 66-rung ladder, 200 answers

| child | @10 | @25 | @50 | @200 | acc | rungs seen (last 100) | distinct prompts /30 | answers to bracket |
|---|---|---|---|---|---|---|---|---|
| beginner (true rung 2) | 3 | 2 | 2 | 3 | 79% | 0..4 | 26 | 1 |
| 80%-correct child (true rung 20) | 20 | 19 | 21 | 20 | 81% | 17..22 | 29 | 8 |
| fast-perfect adult | 30 | 65 | 65 | 65 | 100% | 62..65 | 29 | — |
| slow-perfect child | 5 | 9 | 17 | 65 | 100% | 46..65 | 25 | — |
| guesser (1 tap in 4) | 0 | 0 | 0 | 0 | 25% | 0..3 | 19 | — |

## Nothing regressed

Everything is still relative to the item — no rung became unreachable. Slow-perfect reaches the top in **126** answers against 139 on main; fast-perfect **24** against 29; median-perfect **55** against 65. The guesser bot stays on rung 0, expected move −0.69 rungs an answer against −0.5 before. `fluencyTarget.p50Ms` still only widens a window, asserted graph-wide.

A `difficulty` a pack names is still honoured as a point, not smeared: `counterweight` pins `maxDifficulty` *equal* to its request and `polarity`/`balance`/`horde` pin a ceiling to what they can draw — PR #694 exists because polarity was handed a rung it could not render.

## Verification

301 app tests + 32 game-host tests, five runs each, all green. `tsc` and `eslint` clean. All 27 packs build.

Every fix was deleted and the failure quoted:

| fix removed | test that fails | message |
|---|---|---|
| serve a point, not a spread | beginner distinct prompts | `twenty questions at the floor drew 9 distinct prompts and the bottom rung's closed set holds 9 — so nothing outside it was served` |
| clip instead of reflect | spread reflects at the ends | `a child at the floor gets 79.9% of their questions from one rung` |
| ±1 rung instead of the stride | 80%-correct child settles | `an 80%-correct child crept to the top (rung 65 of 65)` |
| the stride never shrinks | guesser / staircase / settles | `a guesser reached rung 40 of 65 along the way`; `forty right answers left the stride at 4, not 1` |
| `DESCENT_RATIO` back to 1 | down is four times up | `a staircase with this ratio converges on 50% correct, not 80%` |
| reflection not iterated | narrow-ladder normalisation | `a 1-rung ladder has no weight anywhere` |
| pool not aimed at the host | game driving no difficulty | measured **65**, asserted ≤ 8 |
| batched refill of 32 | same, plus the older flush test | measured **34** |
| `maybeFlush` not called from `take` | same | `only 2 questions were re-stocked for the rung the child is now on` |
| `maybeFlush` bails on `target === null` | same | `only 2 questions were re-stocked` |

The `DESCENT_RATIO` test derives 4 from `right : asked` = 4 : 5 rather than comparing the constant to itself, which would have passed at any value including the 1 it replaces.

## Not verified

Not run on a device — the numbers above are simulated against the real shipped ladder and the real curriculum generators, not measured on a child. The secondary TRUE DRAW finding is diagnosed but not fixed here (it is under `dynawalla/games/**`, which this branch does not touch): a correct *hold* on a false slate reports `ms = windowMs`, 1,750–3,600 ms, so about half of that game's correct answers are never "quick" and the six-consecutive-quick speedcuber bonus is close to unreachable in it. It costs a fast child rate, never a demotion.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb