### PR TITLE
release(dynawalla): 0.3.3 — VOLTA was a black screen and trebuchet could not fire

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Both of the founder's blockers from 0.3.1. Cut immediately, not batched.

## VOLTA never threw (#697)

It mounted, handshook, warmed its question pool, built its WebGL context and its HUD — and drew all of it into a box **820px wide and 0px tall**.

```ts
el.style.position = el.style.position || "relative"
```

`el.style.position` reads the **inline** declaration, which is empty when a stylesheet positions the element — **so the fallback fired every single time.** `pack.html` gives `#app` `position: fixed; inset: 0` and no width or height; an inline `relative` wins that cascade, insets mean nothing to a relatively positioned box, and the stage collapsed to `height: auto` around absolutely positioned children.

Measured in headless Chromium against the real built pack in an opaque-origin iframe: before **820x0**, canvas `height:1px`; after **820x1180**, playable, driven to a live gate.

**Both platforms because it is CSS.** And **never in `npm run dev`** — the dev `index.html` also sets `#game` to 100%, and a percentage height survives the overwrite. The dev harness was full-size; only the entry a child runs collapsed. Third time this week a development environment was more forgiving than production.

`resize()` now shouts once if the stage measures under 2px on either axis. `Math.max(1, …)` had been turning a missing stage into a plausible 1px canvas — the same shape as every silent-blank failure this week.

Reading window also 3.20s → **4.80s p50** via a pre-read. Honestly **not** the 6s target: the far plane caps it and the last second must come from draw distance or terminal velocity, which are feel decisions rather than reading ones.

## Trebuchet (#698)

A keep stands at the answer, so the answer has to fit on the field.

## Known, not fixed here

- The host has **no liveness check after the handshake**, so a pack that connects and renders nothing is indistinguishable from a working one. That is how a blank game shipped. Separate PR in progress.
- `games/merge` (FUSE) carries the identical CSS line and survives on two accidents. Latent, one `overflow: hidden` from being VOLTA. Same PR.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb