### PR TITLE
dynawalla/games/truedraw: two gestures, a bag, and a timeout that is nobody's mistake

### DIFF
--- a/dynawalla/games/truedraw/README.md
+++ b/dynawalla/games/truedraw/README.md
@@ -6,113 +6,265 @@ A statement is cut into a slate across the dust.
 
     47 + 25 = 62
 
-The street goes still. Then the slate lights.
+**Swipe DOWN to keep it. Swipe UP to throw it away.**
 
-**Draw if it is true. Hold if it is false.**
+Keep the sums that are right. Throw away the sums that are wrong. Every right call
+puts coins in your bag; every wrong one, in either direction, takes more out than
+any single call can put in.
+
+## What changed, and why
+
+The game had **one verb**. A tap meant "this sum is right", and meaning "this sum is
+wrong" was expressed by *doing nothing* and letting the window close.
+
+Two things followed from that, and both of them shipped.
+
+**1. The fast player was made to wait.** `src/game/tempo.test.ts` measures it against
+the code as it was: a child who is certain in 300 ms paid **14,000 ms** for every
+"this sum is wrong" verdict, on the two-digit regrouping class — forty-six times the
+thinking, spent on nothing, on half of every run. That is the complaint, verbatim:
+
+> "I've gotten 10 correct in a row fast and I still get `2+0=1` and **have to wait
+> until it times out**."
+
+**2. One of the two verdicts had no timestamp.** A hold has no moment in it. So the
+adaptive ladder could not tell a confident rejection from an abandoned one, and half
+of every child's calls arrived either as silence or as a full-window number that meant
+"the clock ran out". A ladder cannot be driven on half a signal — which is the other
+half of the same complaint:
+
+> "It stays on way too easy way too long... It should advance up and down in skill
+> level more quickly, especially based on speed. **If we have a gesture for True and a
+> gesture for False, we can measure both ways** and decide to go to harder problems."
+
+So there are two gestures, both explicit, both timed, and **a timeout is neither of
+them**.
 
 ## The mechanic
 
-One verb, one button, one beat.
+| | | |
+|---|---|---|
+| **bank** | swiped down at a true claim | correct. Stamped, seated, and down into the bag. Coins in. |
+| **spot** | swiped up at a false claim | correct. The caller bows, the slate **rolls itself right**, and *then* it flies away. The longest and best beat in the game. |
+| **dud** | swiped down at a false claim | wrong. You banked a counterfeit. It goes down, the coins drain back out, and **nothing else happens at all** — no sound, no buzz, no colour, no mark. |
+| **burn** | swiped up at a true claim | wrong. You threw money away. It flies up, the coins drain, and it is just as silent. |
+| **lapse** | the window closed untouched | **nothing.** No coins, no shot, no report. It goes to the host as `skip`. |
+
+Being ignored is still the punishment for being wrong, and it is still enforced in
+code: `game/energy.ts` asserts that both wrong verdicts have zero energy — no voice in
+`VOICES`, no entry in `HAPTIC`, no light regained — in both the full and the
+reduced-motion branch. What a wrong verdict does have is a *consequence*, which is not
+the same thing: the bag has fewer coins in it.
+
+## The gestures
+
+`src/game/gesture.ts`, and every number in it is asserted in `gesture.test.ts`.
 
 | | |
 |---|---|
-| **hit** | drew at a true slate — it is struck, the numerals seat, and the round moves on at once |
-| **bow** | let a false slate stand — the caller bows, and the slate **rolls itself right** in front of you |
-| **wild** | drew at a false slate — **nothing happens.** No buzzer, no shake, no colour. The slate stays wrong, the caller does not move, nothing sounds, nothing buzzes. A shot goes dark in silence. |
-| **slow** | let a true slate stand — the caller draws |
+| commit distance | `clamp(0.075 × min(w, h), 34, 84)` px |
+| direction | vertical travel must exceed horizontal × **1.4** |
+| commit moment | the frame the threshold is **crossed**, not the release |
+| a tap | starts a run. **Never** answers a question. |
+| keyboard | `↓` keeps, `↑` tosses, space starts |
 
-Being ignored is the punishment. That asymmetry is the design and it is enforced
-in code: `game/energy.ts` asserts that a wrong draw has zero movers, zero gain
-and no haptic, in both the full and the reduced-motion branch.
+**Why 34 px is the floor.** `packs/shared/sdk/src/tapzoom.ts` calls travel past
+`DRAG_SLOP_PX = 10` a drag and leaves it alone; anything at or under it is a candidate
+*tap*, which the double-tap guard may cancel and re-dispatch as a `click` with no
+travel in it. A commit threshold inside that slop would have its verdicts eaten by the
+zoom guard on the second flick of any rapid pair. 34 is 3.4× clear of it, and
+`gesture.test.ts` reads the real constant out of `tapzoom.ts` so the margin cannot
+drift silently.
+
+**Why 84 px is the ceiling.** The threshold scales with the viewport so an iPad does
+not feel like a phone, but it must stay inside one slate height on every shape the
+fleet has — the flick is a motion across the thing being judged, never a drag across
+the room.
+
+**Why it collides with nothing.** The canvas sets `touch-action: none`, so a vertical
+flick is never a page scroll. The manual sheet sets `touch-action: pan-y` on its own
+body and is a DOM overlay *above* the canvas, so a finger-scroll in the manual never
+reaches the game's listeners — and `guide.isOpen` is checked anyway.
+
+**Why the commit fires mid-motion.** Feel, and honesty. `pointerdown` is unknowable
+(the direction does not exist yet) *and* exploitable: rest a thumb on the slate the
+instant it lights, think for six seconds, then flick, and a `pointerdown`-anchored
+clock reports a reaction of zero and pays the full speed bonus. Anchoring at the
+crossing costs ~80–150 ms of finger travel uniformly on both gestures — noise against
+a p50 measured in thousands — and cannot be gamed by holding still.
+`tempo.test.ts` asserts exactly that.
+
+## The bag
+
+`src/game/bag.ts`. Three numbers, and the relationships between them are the economy.
+
+| | | |
+|---|---|---|
+| `COIN_BASE` | **6** | every correct verdict, at any speed |
+| `COIN_QUICK` | **4** | the most speed can add on top |
+| `COIN_WRONG` | **12** | what a wrong keep or a wrong toss takes |
+| a lapse | **0** | not a verdict, so not priced |
+
+**`COIN_WRONG > COIN_BASE + COIN_QUICK`.** A wrong verdict costs strictly more than
+the very best call can earn. The truth bag deals true and false in exact halves, so a
+child who swipes without reading is right exactly 50% of the time — and 12 > 10 makes
+that strictly *losing* rather than break-even. A bag that grows on a coin flip is a bag
+that rewards mashing.
+
+**`COIN_BASE > COIN_QUICK`.** Being right is worth more than being fast. Fast and right
+is worth the most there is; slow and right still banks the whole base, and there is no
+branch anywhere that subtracts anything for slowness — `bag.test.ts` proves that by
+sweeping every reaction from 0 to ten times p50.
+
+**The two correct verdicts pay exactly the same.** Symmetry is not decoration: an
+asymmetry would bias which gesture a child reaches for, and the ladder is now driven by
+the latency on *both* of them.
+
+**The bag floors at zero.** A child is never shown a debt. The run's three shots are
+what stop somebody mashing from the floor.
+
+### Proved with bots, not with arithmetic
+
+`src/game/economy.test.ts` plays whole runs. The headline case gives the guesser every
+advantage — they answer *instantly* on every slate and collect the maximum speed bonus
+on every lucky call — and the reader none, taking the documented p50 every single time:
+
+| strategy | final bag | rounds survived |
+|---|---|---|
+| careful reader, deliberately **slow** | **303** | 59 |
+| random swiper, at **maximum speed** | **10** | 6 |
+| keep everything | ~10 | ~6 |
+| toss everything | ~10 | ~6 |
+| wait every window out | **0** | never ends |
+
+Thirty times the bag, ten times the run — the slow reader over the fast guesser. And
+bags at accuracy 0.6 / 0.75 / 0.9 / 0.98: **7 / 27 / 131 / 748**.
+
+Waiting is the one thing in the game that costs nothing, and it earns nothing, forever.
+It dominates only guessing, which is the strategy it is supposed to beat. It is also
+the most expensive thing in the game in wall-clock time, because a lapse spends the
+whole window — `economy.test.ts` asserts that too, because a sibling pack shipped an
+economy in which never answering strictly dominated answering.
+
+## The ladder
+
+`src/game/ladder.ts`. The reason the game "stays on way too easy way too long" was not
+subtle: **`dealer.ts` called `host.next()` with no argument at all.** This pack never
+asked for a difficulty in its life.
+
+It now passes a position on every deal, and moves it on every settled outcome:
+
+| | |
+|---|---|
+| a correct call at ≤ 35% of the item's p50 | **+0.075** |
+| a correct call at or past its p50 | **+0.020** |
+| any wrong verdict | **−0.110** |
+| a lapse | **0** |
+
+Ten fast correct calls is `0.2 + 0.75 = 0.95` — from near the bottom of the ladder to
+near the top, which is what the founder asked for stated as the number it is. `DOWN >
+UP_MAX` on purpose: one miss undoes about a call and a half of fast progress, and the
+SDK's own `flush` lands a fall in two questions rather than thirty-three.
+
+The ceiling is **0.995 and never 1.0**. `game-host`'s `toUnit` reads a value below 1 as
+a fraction and 1-or-above as a 1..10 ladder *index*, and resolves the one ambiguous
+value — `1` — as the ladder's **bottom**. A game speaking fractions that sent `1.0`
+would ask for the easiest content in the product at the exact moment a child had earned
+the hardest.
+
+This pack does not model the child and does not pick questions. The host's own ladder is
+being changed separately to serve a distribution rather than a single rung; two
+controllers fighting over one child would be worse than one.
+
+## What the latency measures
+
+From the instant the statement became **answerable** to the instant the flick crossed
+the threshold. Not from the slate being drawn, not from an animation ending, and not
+from `pointerdown`.
+
+Three contaminations are closed and each has a test in `tempo.test.ts`:
+
+* **The lead-in is not charged.** The slate now rises **blank** and the statement is cut
+  in when the window opens. It used to be legible, unlit, for up to 1.15 s of
+  unanswerable lead-in — so a child could read it before the clock started and the
+  ladder would read a deliberate child as a lightning-fast one. That beat is also now a
+  flat ~320 ms instead of 620–1150 ms scaled *up* by how hard the sum is, which was up
+  to a second of dead air per round on a game whose complaint was that it was boring.
+* **A paused stretch is not charged.** A reaction time with a parent gate inside it is a
+  fiction.
+* **Holding still buys nothing.** Six seconds of thinking with a finger already on the
+  glass reports six seconds and a quickness of zero.
 
 ## Why it cannot be mashed
 
-A GO/NO-GO task has a hard 50% ceiling for anyone who draws at everything. The
-job is not to remove the ceiling; it is to make sure a child reads it as
-failure. There is one honest way to do that: **never show an accuracy at all.**
+Two independent devices, on purpose.
 
-A child shown "50%" reads a passing grade. A child shown **3** reads three.
+**The bag drifts down.** At 50% accuracy the drift is −1 coin per round at best, and
+that is the arithmetic of `COIN_WRONG > COIN_MAX` rather than a tuning choice.
 
-So the run has no score and no percentage. It has a length — how many calls you
-made before three shots went dark — and length is violently non-linear in care:
+**The run is three calls long.** Misses are a budget rather than a subtraction:
 
     expected calls = shots × p / (1 − p)
 
 | per-round accuracy | expected run |
 |---|---|
-| 0.50 — draw at everything | **3 calls** |
+| 0.50 — swipe at random | **3 calls** |
 | 0.75 | 9 |
 | 0.90 | 27 |
 | 0.97 | 97 |
 | 1.00 | no end |
 
-Never drawing is the same coin the other way up, and just as short. And mashing
-does not even buy tempo: a wrong draw commits, but it **does not close the
-window** — the slate stays lit to the last millisecond with the world declining
-to react. Drawing correctly is the only thing in the game that makes time go
-faster, and with a comprehension-sized window that is now a very large
-difference indeed.
-
-`src/game/inhibition.test.ts` plays these strategies out for thousands of runs
-and asserts every claim on this page.
+There is no arrangement of three calls that looks like doing well, and no percentage
+anywhere in the game to misread as a pass. `src/game/inhibition.test.ts` plays these
+strategies out for thousands of runs and asserts every claim on this page.
 
 ## Why the falsehoods are worth rejecting
 
-The slate never lies with `answer ± 1`, which a child rejects by feel. It lies
-with the item's own **mal-rule distractors** — what a child running a specific
-broken procedure actually writes. `47 + 25 = 62` is every carry dropped;
-`503 − 87 = 426` is the borrow travelling through the zero and the zero being
-read as ten. Rejecting one means doing the arithmetic.
+The slate never lies with `answer ± 1`, which a child rejects by feel. It lies with the
+item's own **mal-rule distractors** — what a child running a specific broken procedure
+actually writes. `47 + 25 = 62` is every carry dropped; `503 − 87 = 426` is the borrow
+travelling through the zero and the zero being read as ten. Rejecting one means doing
+the arithmetic.
 
-That also makes the reporting fall out for free: a wild draw reports the
-mal-rule value, so the host records the miss **and names the misconception the
-child just demonstrated.** No extra wiring.
+That also makes the reporting fall out for free: a **dud** reports the mal-rule value,
+so the host records the miss *and names the misconception the child just demonstrated.*
+No extra wiring.
 
-It is also why the window is what it is. This game used to defend a 1.75–3.6 s
-clamp with "verification is cheaper than computation — the ones column alone
-rejects most mal-rules". `src/game/malRule.test.ts` proves that false: a dropped
-carry reproduces the true ones digit *by construction* — 62 and 72 both end in
-2 — and so does a borrow left at ten. A last-digit check accepts the falsehoods
-this game most prefers to tell, so verifying costs what computing costs.
+It is also why the window is what it is. `src/game/malRule.test.ts` proves that "the
+ones column alone rejects most mal-rules" is **false**: a dropped carry reproduces the
+true ones digit *by construction* — 62 and 72 both end in 2 — and so does a borrow left
+at ten. A last-digit check accepts the falsehoods this game most prefers to tell, so
+verifying costs what computing costs.
 
 ## The window is the child's time
 
-`EXPERIENCE_DESIGN.md`: *"COMPREHENSION — not budgeted. The child's time.
-Measured, never limited."* The draw window is now that document's own **p90 for
-the item's class**, monotone non-decreasing in operand width and clamped by
-nothing:
+`EXPERIENCE_DESIGN.md`: *"COMPREHENSION — not budgeted. The child's time. Measured,
+never limited."* The window is that document's own **p90 for the item's class**,
+monotone non-decreasing in operand width and clamped by nothing:
 
-| item | p50 | p90 | window before | window now |
-|---|---|---|---|---|
-| `7 + 8 = 15` | 2.8 s | 6 s | 2.16 s | **6.0 s** |
-| `47 + 25 = 72` | 6 s | 14 s | 2.59 s | **14.0 s** |
-| `753 + 577 = 1330` | 11 s | 27 s | 3.45 s | **27.0 s** |
-| `5001 − 2798 = 2203` | 16 s | 40 s | 3.60 s | **40.0 s** |
+| item | p50 | p90 | window |
+|---|---|---|---|
+| `7 + 8 = 15` | 2.8 s | 6 s | **6.0 s** |
+| `47 + 25 = 72` | 6 s | 14 s | **14.0 s** |
+| `753 + 577 = 1330` | 11 s | 27 s | **27.0 s** |
+| `5001 − 2798 = 2203` | 16 s | 40 s | **40.0 s** |
 
-The old ceiling bit long before the difficulty did, so the *share* of the child's
-measured need fell as the item got harder — 77% of a p50 for a single-digit fact,
-23% for the widest class. The ramp was inverted by construction, and running out
-of time on a true slate settles as a hold and spends a shot, so a child who could
-not finish lost a shot half the time by pure arithmetic.
+A long window costs the child nothing now that both verdicts stop the clock: it is spent
+in full only by a lapse, which is free. And the **p50** is the other half of that table:
+it is never shown and never a limit — it is what "quick" is measured against, by the bag
+and by the ladder, and it rides on the statement so the two can never disagree about
+which beat they mean.
 
-A long window costs the child nothing: a correct draw stops the clock the instant
-they press. It is only spent in full by a correct hold — the standoff — and by a
-wrong draw, which is the one thing in the game the world declines to react to.
-
-**And a window that closed on an untouched screen is never sent to the ladder.**
-The shot still goes dark, so a timeout costs exactly what an honest wrong draw
-costs and refusing to call never dominates calling; but from inside this game "I
-say that sum is wrong" and "I am still working it out" are the same event, and
-betting on the first would demote a merely deliberate child. The obvious hole —
-hold at everything, be credited on every false slate — is closed by the shot
-budget: holding at everything is wrong half the time, and half is three calls.
+`src/game/patience.test.ts` plays whole runs at the documented p50 and p90 at every rung
+and asserts that a deliberate child is never timed out, never loses a shot, and is paid
+the full base on every single call.
 
 ## Domains
 
-The statement builder reads `prompt`, `answer` and `distractors` and nothing
-else, so it is domain-blind. Only `add` is active in the curriculum today; the
-day `mul`, `frac`, `ns`, `div` or `alg` are promoted out of draft, this pack
-covers them with no change. A claim is a claim.
+The statement builder reads `prompt`, `answer` and `distractors` and nothing else, so it
+is domain-blind. Only `add` is active in the curriculum today; the day `mul`, `frac`,
+`ns`, `div` or `alg` are promoted out of draft, this pack covers them with no change. A
+claim is a claim.
 
 ## Running it
 
@@ -124,13 +276,17 @@ npm run tsc
 npm run build:pack
 ```
 
-`?seed=123`, `?level=0..7` and `?reduced=1` are honoured by the dev harness.
+`?seed=123`, `?level=0..7` and `?reduced=1` are honoured by the dev harness. A `level`
+**pins** the stub, because the game now asks for a difficulty on every deal and a stub
+that followed the request could not be swept. The dev readout shows the reports, the
+skips, and the difficulty the game last asked for — so a lapse reappearing as a report
+with an empty answer is visible in one glance.
 
 ## Shape
 
-    src/contract.ts     the host seam — must not drift
-    src/game/           the rules: statement, schedule, response, run, round
-    src/render/         the street: one slate, one caller, a gathering crowd
-    src/audio/          asset-free Web Audio; there is no sound for a wrong draw
+    src/contract.ts     the host seam — must not drift. `skip` lives here.
+    src/game/           the rules: statement, schedule, gesture, bag, ladder, round
+    src/render/         the street: one slate, a chute above, a bag below
+    src/audio/          asset-free Web Audio; no sound for a wrong verdict or a lapse
     src/stub/           a seeded local host — exact integers, mal-rule distractors
-    src/test/harness.ts a headless player, so a run can be played 10,000 times
+    src/test/harness.ts a headless player, so a run can be played thousands of times

--- a/dynawalla/games/truedraw/pack.json
+++ b/dynawalla/games/truedraw/pack.json
@@ -2,7 +2,7 @@
   "id": "dynawalla.truedraw",
   "version": "0.1.0",
   "name": "THE TRUE DRAW",
-  "description": "A statement is cut into a slate across the dust. Swipe DOWN to keep it, swipe UP to throw it away — keep the sums that are right and throw away the ones that are wrong. Right calls fill your bag; a wrong call either way costs more coins than any one call can earn, so swiping without reading empties it. Running out of time costs nothing at all.",
+  "description": "A statement is cut into a slate across the dust. Swipe DOWN to keep it, swipe UP to throw it away. Keep the sums that are right; throw away the ones that are wrong. Right calls fill your bag, a wrong call either way empties it faster, and running out of time costs nothing.",
   "sdk": "1.0.0",
   "host": { "min": "0.1.0", "max": "1.0.0" },
   "entry": "pack.html",

--- a/dynawalla/games/truedraw/pack.json
+++ b/dynawalla/games/truedraw/pack.json
@@ -2,7 +2,7 @@
   "id": "dynawalla.truedraw",
   "version": "0.1.0",
   "name": "THE TRUE DRAW",
-  "description": "A statement is cut into a slate across the dust. The street goes still, the slate lights, and you have one beat: draw if it is true, hold if it is false. Drawing at everything gets you exactly half, and half is a very short run.",
+  "description": "A statement is cut into a slate across the dust. Swipe DOWN to keep it, swipe UP to throw it away — keep the sums that are right and throw away the ones that are wrong. Right calls fill your bag; a wrong call either way costs more coins than any one call can earn, so swiping without reading empties it. Running out of time costs nothing at all.",
   "sdk": "1.0.0",
   "host": { "min": "0.1.0", "max": "1.0.0" },
   "entry": "pack.html",

--- a/dynawalla/games/truedraw/src/audio/audio.ts
+++ b/dynawalla/games/truedraw/src/audio/audio.ts
@@ -1,11 +1,17 @@
 // Asset-free Web Audio: a struck felt-mallet timbre over a C5–C6 pentatonic,
 // plus one wooden knock for the slate.
 //
-// The important entry in the table is the one that is not there. **A wild draw
-// makes no sound.** Not a buzz, not a thud, not a muted click — nothing. The
-// street declines to acknowledge the draw, and an audio engine that sneaked in a
-// "you got it wrong" cue would undo the entire design, so `wild` is absent from
-// `VOICES` and `outcome()` returns before touching the context.
+// The important entries in the table are the ones that are not there. **A wrong
+// verdict makes no sound.** Not a buzz, not a thud, not a muted click — nothing,
+// in either direction: banking a counterfeit and throwing away good money are both
+// silent. The street declines to acknowledge a wrong call, the bag simply has fewer
+// coins in it, and an audio engine that sneaked in a "you got it wrong" cue would
+// undo the entire design. So `dud` and `burn` are absent from `VOICES` and
+// `outcome()` returns before touching the context.
+//
+// `lapse` is absent for a different reason and it is the more important one: a tone
+// at the end of a window a child was still thinking through is a buzzer aimed at
+// slowness. There is no sound for running out of time.
 
 import type { Outcome } from "../game/response.ts"
 import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
@@ -29,13 +35,14 @@ type Voice = {
  * against a comment.
  */
 export const VOICES: Partial<Record<Outcome, Voice>> = {
-  // Struck once, cleanly, high. The sound of being right and being quick.
-  hit: { degrees: [4], spacing: 0, gain: 0.2, decay: 0.5 },
-  // A bow: two notes falling. Warmer and longer than the hit, because holding
-  // is the harder thing to do and this is the game's one piece of applause.
-  bow: { degrees: [5, 2], spacing: 0.14, gain: 0.24, decay: 0.9 },
-  // Low, short, over before you look up.
-  slow: { degrees: [0], spacing: 0, gain: 0.11, decay: 0.34 },
+  // Struck once, cleanly, high, and then a coin lands: the sound of banking a
+  // true claim.
+  bank: { degrees: [4, 5], spacing: 0.075, gain: 0.2, decay: 0.44 },
+  // A bow, and two notes falling into a third. Warmer and longer than a bank,
+  // because spotting a counterfeit is the harder thing to do and this is the
+  // game's one piece of applause.
+  spot: { degrees: [5, 2, 4], spacing: 0.12, gain: 0.24, decay: 0.9 },
+  // `dud`, `burn` and `lapse` have no entry, and must not get one. See above.
 }
 
 export class Audio {
@@ -74,7 +81,7 @@ export class Audio {
 
   outcome(kind: Outcome): void {
     const voice = VOICES[kind]
-    // `wild` lands here and leaves. Silence is the punishment.
+    // `dud`, `burn` and `lapse` land here and leave. Silence is the whole of it.
     if (!voice) return
     const ctx = this.context()
     const bus = this.bus

--- a/dynawalla/games/truedraw/src/contract.ts
+++ b/dynawalla/games/truedraw/src/contract.ts
@@ -25,6 +25,22 @@ export type Question = {
 export type Host = {
   next(opts?: { domain?: string; difficulty?: number }): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+
+  /**
+   * The child did not answer this one. Close it and record nothing.
+   *
+   * **This is the only honest ending for a lapse, and `report` is not it.** The
+   * SDK is explicit: `report({ correct: false, answered: "" })` is not filed as
+   * "unanswered", it is filed as a MISS — the empty string does not parse, the
+   * learner model takes a wrong attempt, and the ladder steps DOWN for a child who
+   * was still carrying the hundreds column. This pack was one of the six named as
+   * having done exactly that.
+   *
+   * OPTIONAL and feature-detected only because a pre-#667 host may not have it. The
+   * real `GameHost` implements it unconditionally.
+   */
+  skip?(questionId: string): void
+
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean
 

--- a/dynawalla/games/truedraw/src/game/bag.test.ts
+++ b/dynawalla/games/truedraw/src/game/bag.test.ts
@@ -1,0 +1,99 @@
+// THE BAG, and the arithmetic that makes guessing lose.
+//
+// Every assertion here is a product claim, not a robustness check.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { quicknessOf } from "./cadence.ts"
+import { addCoins, coinsFor, COIN_BASE, COIN_MAX, COIN_QUICK, COIN_WRONG } from "./bag.ts"
+import { isCorrect, OUTCOMES } from "./response.ts"
+
+test("a wrong verdict costs strictly more than the very best call can earn", () => {
+  // THE property. If this is ever false the bag becomes a random walk with no
+  // drift, and a child who swipes at random — right exactly half the time, because
+  // the truth bag deals in exact halves — grows their bag by mashing.
+  assert.ok(
+    COIN_WRONG > COIN_MAX,
+    `a coin flip breaks even or wins: wrong ${String(COIN_WRONG)} vs best ${String(COIN_MAX)}`,
+  )
+  // ...and the margin, stated: half of (best gain) minus half of (loss) per round.
+  const drift = 0.5 * COIN_MAX - 0.5 * COIN_WRONG
+  assert.ok(drift < 0, `a coin flip drifts ${drift.toFixed(1)} coins a round`)
+})
+
+test("being right is worth more than being fast", () => {
+  assert.ok(
+    COIN_BASE > COIN_QUICK,
+    `speed can outweigh correctness: base ${String(COIN_BASE)} vs quick ${String(COIN_QUICK)}`,
+  )
+})
+
+test("fast and right is worth the most there is", () => {
+  assert.equal(coinsFor("bank", 1), COIN_MAX)
+  assert.equal(coinsFor("spot", 1), COIN_MAX)
+  assert.ok(coinsFor("bank", 1) > coinsFor("bank", 0))
+})
+
+test("slowness is measured and never punished, at any reaction whatsoever", () => {
+  // The standing rule. Swept rather than spot-checked: there must be no reaction
+  // time anywhere, however long, at which a correct call pays less than the base.
+  for (const p50 of [2800, 6000, 16000]) {
+    for (let ms = 0; ms <= p50 * 10; ms += 137) {
+      const coins = coinsFor("bank", quicknessOf(ms, p50))
+      assert.ok(
+        coins >= COIN_BASE,
+        `a correct call at ${String(ms)}ms against a p50 of ${String(p50)} paid ${String(coins)}`,
+      )
+      assert.ok(coins <= COIN_MAX)
+    }
+  }
+})
+
+test("the two correct verdicts pay exactly the same", () => {
+  // Symmetry is not decoration here. An asymmetry would bias which gesture a child
+  // reaches for, and the ladder is now driven by the latency on BOTH of them — so a
+  // reward that favoured one direction would bias the sample the ladder learns from.
+  for (const q of [0, 0.25, 0.5, 0.75, 1]) {
+    assert.equal(coinsFor("bank", q), coinsFor("spot", q), `at quickness ${String(q)}`)
+  }
+})
+
+test("the two wrong verdicts cost exactly the same, and speed does not change it", () => {
+  // A wrong answer given fast is not more wrong than a wrong answer given slowly.
+  for (const q of [0, 0.5, 1]) {
+    assert.equal(coinsFor("dud", q), -COIN_WRONG)
+    assert.equal(coinsFor("burn", q), -COIN_WRONG)
+  }
+})
+
+test("a lapse is not priced at all", () => {
+  for (const q of [0, 0.5, 1]) assert.equal(coinsFor("lapse", q), 0)
+})
+
+test("every outcome has a price, and only the correct ones are positive", () => {
+  for (const outcome of OUTCOMES) {
+    const coins = coinsFor(outcome, 0.5)
+    assert.ok(Number.isFinite(coins), outcome)
+    if (isCorrect(outcome)) assert.ok(coins > 0, outcome)
+    else assert.ok(coins <= 0, outcome)
+  }
+})
+
+test("the bag floors at nothing — a child is never shown a debt", () => {
+  assert.equal(addCoins(0, -COIN_WRONG), 0)
+  assert.equal(addCoins(4, -COIN_WRONG), 0)
+  assert.equal(addCoins(20, -COIN_WRONG), 8)
+})
+
+test("a NaN quickness cannot poison the bag for the rest of the run", () => {
+  // It arrives from a division by a table lookup. One NaN in the bag and the score
+  // is NaN forever, which is a bug a child would see and nobody would understand.
+  // A non-finite credit pays the BASE, not the bonus. Being right still pays in
+  // full — the bug must never cost a child coins — but a broken measurement never
+  // buys a speed bonus either, because a bonus handed out for a NaN is a bonus a
+  // masher gets for free the moment anything upstream divides by zero.
+  assert.equal(coinsFor("bank", Number.NaN), COIN_BASE)
+  assert.equal(coinsFor("bank", Number.POSITIVE_INFINITY), COIN_BASE)
+  assert.equal(coinsFor("bank", -5), COIN_BASE)
+})

--- a/dynawalla/games/truedraw/src/game/bag.ts
+++ b/dynawalla/games/truedraw/src/game/bag.ts
@@ -1,0 +1,101 @@
+// THE BAG. The score, and the arithmetic that makes guessing lose.
+//
+//   > "your correct keeps build your bag (score), incorrect discard/keep
+//   > diminishes your bag"
+//
+// Three numbers, and the relationships between them are the whole economy. Every
+// one of them is asserted in `bag.test.ts` and every one of them is load-bearing.
+//
+// ── 1. a coin flip must LOSE, not merely fail to win ─────────────────────────
+//
+// The truth bag deals true and false in exact halves (`schedule.ts`), so a child
+// who swipes at random without reading is right exactly 50% of the time. If a
+// correct call paid as much as a wrong call cost, that child would break even and
+// the bag would be a random walk with no drift — which is a bag that rewards
+// mashing, because mashing is faster than reading and the walk is free.
+//
+// So:
+//
+//     COIN_WRONG > COIN_BASE + COIN_QUICK
+//
+// A wrong verdict costs strictly more than the most a right one can ever pay.
+// That makes the drift of any strategy that does not read the slate strictly
+// negative — at any speed, in any mixture of the two gestures, including the two
+// degenerate ones (keep everything, toss everything), because the halves are
+// exact. `economy.test.ts` plays that out with bots rather than asserting it.
+//
+// ── 2. being right is worth more than being fast ─────────────────────────────
+//
+//     COIN_BASE > COIN_QUICK
+//
+// The bonus for speed can never be more than the reward for being right. A child
+// who is right and slow banks more than half of the maximum; a child who is fast
+// and wrong banks nothing and loses twelve. Speed is a bonus on top of correct and
+// is never a substitute for it.
+//
+// ── 3. slowness is measured and never punished ───────────────────────────────
+//
+// `EXPERIENCE_DESIGN.md`, and the founder's standing rule: measure and reward,
+// never punish. There is no branch in this file that subtracts anything for a
+// slow call. `coinsFor` on a correct outcome returns `COIN_BASE` at worst and
+// `COIN_BASE + COIN_QUICK` at best, and `bag.test.ts` proves that by sweeping
+// every reaction from 0 to ten times p50.
+//
+// ── 4. a lapse costs nothing ─────────────────────────────────────────────────
+//
+// A window that closed untouched is not a verdict, so it is not priced. Zero
+// coins, zero shots.
+//
+// The obvious worry is the SLICE failure: an outcome that costs nothing might
+// dominate one that can cost something, and then never answering is the optimal
+// play. It does not dominate here, and the reason is arithmetic rather than
+// taste. Waiting pays exactly 0. A verdict pays `p × (6..10) − (1 − p) × 12`,
+// which is positive for every `p > 0.55`. So waiting beats answering only for a
+// child who is guessing — which is the child we want to stop guessing — and a
+// waiter's bag is a flat zero forever while a reader's grows without bound.
+// `economy.test.ts` plays a bot that waits every single window out and asserts
+// its bag ends at zero.
+//
+// ── 5. the bag floors at zero and never goes negative ────────────────────────
+//
+// A bag cannot hold minus four coins, and a number below zero on a child's screen
+// is a debt. It floors. That does mean a bag already at zero cannot be diminished
+// further — the run's three shots are what stop a child mashing from the floor,
+// and they are unchanged.
+
+import { isCorrect, type Outcome } from "./response.ts"
+
+/** Every correct verdict pays this, at any speed. The reward for being right. */
+export const COIN_BASE = 6
+
+/** The most that speed can add on top. Strictly less than the base — see (2). */
+export const COIN_QUICK = 4
+
+/** What a wrong keep or a wrong toss takes. Strictly more than the best gain. */
+export const COIN_WRONG = 12
+
+/**
+ * What an outcome is worth, in coins, given how quick the call was.
+ *
+ * `quickness` is 0..1 from `cadence.quicknessOf` — the share of the item's own
+ * p50 the child did NOT use. Out-of-range values are clamped rather than
+ * trusted: it arrives from a division by a table lookup, and a NaN reaching the
+ * bag would make the score `NaN` for the rest of the run.
+ */
+export function coinsFor(outcome: Outcome, quickness: number): number {
+  if (outcome === "lapse") return 0
+  if (!isCorrect(outcome)) return -COIN_WRONG
+  const credit = Number.isFinite(quickness) ? Math.max(0, Math.min(1, quickness)) : 0
+  return COIN_BASE + Math.round(COIN_QUICK * credit)
+}
+
+/** Coins in, coins out, floored at nothing. */
+export function addCoins(bag: number, coins: number): number {
+  return Math.max(0, bag + coins)
+}
+
+/**
+ * The most a single call can ever be worth. Exported because the guessing proof
+ * is stated against it rather than against the two constants separately.
+ */
+export const COIN_MAX = COIN_BASE + COIN_QUICK

--- a/dynawalla/games/truedraw/src/game/best.test.ts
+++ b/dynawalla/games/truedraw/src/game/best.test.ts
@@ -1,26 +1,25 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { bestCalls, recordCalls, resetBestForTest } from "./best.ts"
+import { bestBag, recordBag, resetBestForTest } from "./best.ts"
 
-test("the best run is kept in memory, not in web storage", () => {
-  // `localStorage` is unreachable inside a pack frame: the document sits on an
-  // opaque origin and every access throws. A best score that lived only in
-  // storage would read zero forever on the one platform that matters, so the
-  // in-memory value is the source of truth and this test runs with no storage
-  // at all.
+test("the fullest bag is kept in memory, not in web storage", () => {
+  // `localStorage` is unreachable inside a pack frame: the document sits on an opaque
+  // origin and every access throws. A best score that lived only in storage would read
+  // zero forever on the one platform that matters, so the in-memory value is the
+  // source of truth and this test runs with no storage at all.
   resetBestForTest()
-  assert.equal(bestCalls(), 0)
-  assert.equal(recordCalls(7), true)
-  assert.equal(bestCalls(), 7)
+  assert.equal(bestBag(), 0)
+  assert.equal(recordBag(70), true)
+  assert.equal(bestBag(), 70)
 })
 
-test("only a longer run replaces it, and it never goes back down", () => {
+test("only a fuller bag replaces it, and it never goes back down", () => {
   resetBestForTest()
-  recordCalls(12)
-  assert.equal(recordCalls(12), false)
-  assert.equal(recordCalls(3), false)
-  assert.equal(bestCalls(), 12)
-  assert.equal(recordCalls(13), true)
-  assert.equal(bestCalls(), 13)
+  recordBag(120)
+  assert.equal(recordBag(120), false)
+  assert.equal(recordBag(30), false)
+  assert.equal(bestBag(), 120)
+  assert.equal(recordBag(130), true)
+  assert.equal(bestBag(), 130)
 })

--- a/dynawalla/games/truedraw/src/game/best.ts
+++ b/dynawalla/games/truedraw/src/game/best.ts
@@ -1,4 +1,4 @@
-// The longest run so far.
+// The fullest bag so far.
 //
 // **`localStorage` is unreachable inside a pack frame.** The document is framed
 // on an opaque origin, so every access — including the `typeof` probe people
@@ -13,7 +13,11 @@
 // `generic-api-key` rule reads `KEY = "<long dotted string>"` as a credential —
 // a property of the string's length, not of what it holds. It is a storage path,
 // it is on the client, and it is in a public repo on purpose.
-const BEST_SLOT = "dynawalla.truedraw.best.v1" // gitleaks:allow
+// v2, not v1. v1 held the old score — how many correct calls a run made — and the
+// score is now the BAG, in coins, which is a different and much larger number. A
+// child's old "best 9" read against a bag would look like a target they had
+// already beaten before their first flick.
+const BEST_SLOT = "dynawalla.truedraw.best.v2" // gitleaks:allow
 
 let inMemory = 0
 let loaded = false
@@ -28,7 +32,7 @@ function storage(): Storage | null {
   }
 }
 
-export function bestCalls(): number {
+export function bestBag(): number {
   if (!loaded) {
     loaded = true
     try {
@@ -42,12 +46,12 @@ export function bestCalls(): number {
   return inMemory
 }
 
-/** Records `calls` if it beats the best. Returns true when it did. */
-export function recordCalls(calls: number): boolean {
-  if (calls <= bestCalls()) return false
-  inMemory = calls
+/** Records `bag` if it beats the best. Returns true when it did. */
+export function recordBag(bag: number): boolean {
+  if (bag <= bestBag()) return false
+  inMemory = bag
   try {
-    storage()?.setItem(BEST_SLOT, String(calls))
+    storage()?.setItem(BEST_SLOT, String(bag))
   } catch (error) {
     console.warn("[truedraw] the best run could not be written", error)
   }

--- a/dynawalla/games/truedraw/src/game/cadence.ts
+++ b/dynawalla/games/truedraw/src/game/cadence.ts
@@ -110,3 +110,43 @@ export function comprehensionP90Ms(load: number): number {
 export function comprehensionMsFor(text: string): number {
   return comprehensionP90Ms(comprehensionLoad(operandWidth(text)))
 }
+
+/** The p50 beat for a piece of statement text. What "quick" is measured against. */
+export function p50MsFor(text: string): number {
+  return comprehensionP50Ms(comprehensionLoad(operandWidth(text)))
+}
+
+/**
+ * The share of the child's own p50 that a call did NOT use, as 0..1 credit.
+ *
+ * ── why p50 and not the window ───────────────────────────────────────────────
+ *
+ * The window is p90, and p90 is nine-tenths of the class. Scoring speed against
+ * it would hand almost every child almost full credit and measure nothing. p50
+ * is the beat half the class beats, so it is the only number in the table that
+ * discriminates.
+ *
+ * ── why it floors at zero and never goes negative ────────────────────────────
+ *
+ * The standing rule is measure and reward, never punish. A child who takes twice
+ * their class's p50 and gets it right scores `COIN_BASE` — the whole of the
+ * reward for being right, and not one coin less than a fast child's base. What
+ * they do not get is the bonus. There is no branch anywhere that subtracts for
+ * slowness, and `bag.test.ts` asserts that by exhaustion.
+ *
+ * ── the floor at QUICK_FLOOR ─────────────────────────────────────────────────
+ *
+ * Full credit at 35% of p50 rather than at zero. A curve that only paid out at
+ * literally-instant would be a curve nobody is ever paid by, and it would reward
+ * a child who had pre-loaded the gesture over one who read the slate and moved
+ * decisively. 35% of a two-digit regroup's p50 is 2.1 s, which is a real child
+ * reading a real sum and knowing.
+ */
+export const QUICK_FLOOR = 0.35
+
+export function quicknessOf(reactionMs: number, p50Ms: number): number {
+  if (!Number.isFinite(reactionMs) || !Number.isFinite(p50Ms) || p50Ms <= 0) return 0
+  const ratio = Math.max(0, reactionMs) / p50Ms
+  const credit = (1 - ratio) / (1 - QUICK_FLOOR)
+  return Math.max(0, Math.min(1, credit))
+}

--- a/dynawalla/games/truedraw/src/game/dealer.ts
+++ b/dynawalla/games/truedraw/src/game/dealer.ts
@@ -1,11 +1,27 @@
-// Where a host question becomes a claim on a slate.
+// Where a host question becomes a claim on a slate — and where this game finally
+// asks for a difficulty.
 //
-// One place, so there is exactly one path a statement can reach the screen by,
-// and one place for the property that has to hold on every single one of them:
-// a statement the game presents as false is false.
+// One place, so there is exactly one path a statement can reach the screen by, and
+// one place for the property that has to hold on every single one of them: a
+// statement the game presents as false is false.
+//
+// ── the request ──────────────────────────────────────────────────────────────
+//
+// `deal()` used to call `host.next()` with no argument. That is the whole of why
+// the game "stays on way too easy way too long": it took the front of the prefetch
+// pool forever and never once said what it wanted. It now passes the `Ladder`'s
+// position on every deal, and the SDK flushes the pool by itself once the request
+// has moved a tenth of the ladder — so a child who is quick feels the change within
+// two questions rather than thirty-three.
+//
+// `settle` is the other half. The mount hands every settled outcome back here with
+// its quickness, and the ladder moves. It is one call site and it is on the same
+// object that does the asking, so the two can never fall out of step.
 
 import type { Host } from "../contract.ts"
 import type { Rng } from "../core/rng.ts"
+import { Ladder } from "./ladder.ts"
+import type { Outcome } from "./response.ts"
 import { TruthBag } from "./schedule.ts"
 import { buildStatement, type Statement } from "./statement.ts"
 
@@ -13,21 +29,33 @@ export class Dealer {
   private readonly host: Host
   private readonly rng: Rng
   private readonly bag: TruthBag
+  private readonly ladder: Ladder
 
-  constructor(host: Host, rng: Rng) {
+  constructor(host: Host, rng: Rng, ladder: Ladder = new Ladder()) {
     this.host = host
     this.rng = rng
     this.bag = new TruthBag(rng)
+    this.ladder = ladder
+  }
+
+  /** What the game is currently asking the host for, 0..1. Never exactly 1. */
+  get difficulty(): number {
+    return this.ladder.difficulty
   }
 
   deal(): Statement {
-    const question = this.host.next()
+    const question = this.host.next({ difficulty: this.ladder.difficulty })
     const wanted = this.bag.take()
     const statement = buildStatement(question, wanted, this.rng)
-    // The bag asked for a lie and the item could not tell one — every
-    // distractor it carried was unusable. The `false` was never spent, so it
-    // goes back rather than silently biasing the run towards true.
+    // The bag asked for a lie and the item could not tell one — every distractor
+    // it carried was unusable. The `false` was never spent, so it goes back rather
+    // than silently biasing the run towards true.
     if (statement.truth !== wanted) this.bag.give(wanted)
     return statement
+  }
+
+  /** Move the request. A lapse moves it by nothing; see `ladder.stepFor`. */
+  settle(outcome: Outcome, quickness: number): void {
+    this.ladder.settle(outcome, quickness)
   }
 }

--- a/dynawalla/games/truedraw/src/game/economy.test.ts
+++ b/dynawalla/games/truedraw/src/game/economy.test.ts
@@ -1,0 +1,248 @@
+// THE ECONOMY, PLAYED BY BOTS.
+//
+// "A bag that grows on a coin-flip is a bag that rewards mashing." So this file does
+// not assert the arithmetic — `bag.test.ts` does that — it plays whole runs with
+// strategies and compares the bags they end with. A sibling pack shipped an economy
+// in which never answering strictly dominated answering, and the only thing that
+// finds that is a bot that tries it.
+//
+// Four strategies, and the ordering between them is the product claim:
+//
+//   a careful reader, deliberately SLOW   >>  a random swiper, at MAXIMUM SPEED
+//   a careful reader                      >>  keep everything
+//   a careful reader                      >>  toss everything
+//   a careful reader                      >>  wait every single window out
+//
+// Note which way round the first one is. The slow reader gets no speed bonus at all
+// and the guesser gets the whole of it on every lucky call, and the reader still
+// wins by two orders of magnitude. That is what "being right is worth more than being
+// fast" has to mean if it means anything.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stub/host.ts"
+import {
+  alwaysKeep,
+  alwaysToss,
+  alwaysWait,
+  coinFlip,
+  fallible,
+  perfect,
+  playRun,
+  type Decision,
+} from "../test/harness.ts"
+import { comprehensionP50Ms, comprehensionLoad, operandWidth } from "./cadence.ts"
+import type { Statement } from "./statement.ts"
+
+const RUNS = 120
+
+/** The child's own p50 for the item: a careful, unhurried, entirely normal reader. */
+const deliberate = (s: Statement): number =>
+  comprehensionP50Ms(comprehensionLoad(operandWidth(s.text)))
+
+/** Mean final bag over `RUNS` runs of a strategy. */
+function meanBag(
+  strategy: (seed: number) => { bag: number; calls: number; rounds: number },
+  runs = RUNS,
+): { bag: number; calls: number; rounds: number } {
+  let bag = 0
+  let calls = 0
+  let rounds = 0
+  for (let i = 0; i < runs; i++) {
+    const r = strategy(i)
+    bag += r.bag
+    calls += r.calls
+    rounds += r.rounds
+  }
+  return { bag: bag / runs, calls: calls / runs, rounds: rounds / runs }
+}
+
+function play(
+  seed: number,
+  decide: (s: Statement) => Decision,
+  thinkMs?: (s: Statement) => number,
+): { bag: number; calls: number; rounds: number } {
+  const result = playRun(createStubHost({ seed: 1000 + seed, level: 3 }), 5000 + seed, decide, {
+    limit: 200,
+    ...(thinkMs ? { thinkMs } : {}),
+  })
+  return { bag: result.run.bag, calls: result.run.calls, rounds: result.statements.length }
+}
+
+test("A RANDOM SWIPER AT FULL SPEED ENDS WITH LESS THAN A SLOW CAREFUL READER", () => {
+  // The headline. The guesser answers instantly on every slate, so they collect the
+  // maximum speed bonus on every one of their lucky calls. The reader takes the
+  // documented p50 every single time and collects no bonus at all.
+  const guesser = meanBag((seed) => play(seed, coinFlip(new Rng(7000 + seed)), () => 0))
+  const reader = meanBag((seed) => play(seed, fallible(0.95, new Rng(9000 + seed)), deliberate))
+
+  assert.ok(
+    reader.bag > guesser.bag * 20,
+    `a slow reader banked ${reader.bag.toFixed(1)} coins; a max-speed guesser banked ` +
+      `${guesser.bag.toFixed(1)}. Ratio ${(reader.bag / Math.max(1, guesser.bag)).toFixed(1)}x.`,
+  )
+  // Reported as the two numbers, because "guessing loses" is a claim about a size.
+  console.log(
+    `    slow careful reader: bag ${reader.bag.toFixed(1)} over ${reader.rounds.toFixed(1)} rounds\n` +
+      `    max-speed guesser:   bag ${guesser.bag.toFixed(1)} over ${guesser.rounds.toFixed(1)} rounds`,
+  )
+})
+
+test("A RANDOM SWIPER'S COINS DRIFT STRICTLY DOWN, unclamped and unprotected", () => {
+  // The load-bearing one, and the reason it is separate from the test above.
+  //
+  // The bots above compare final BAGS, and a final bag is protected by two things
+  // that are not the economy: the floor at zero, and the three-shot budget that ends
+  // a guesser's run after about six rounds. Both of those would hide a break-even
+  // price list. Verified: setting COIN_WRONG to 10 — exactly what a maximum-speed
+  // correct call earns — leaves every bag comparison in this file passing.
+  //
+  // So this sums the RAW SIGNED PRICE of every call a guesser makes, across many
+  // runs, with no floor and no run ending. That number is the drift, it is what
+  // "guessing must be worse than reading" means, and nothing but the arithmetic in
+  // `bag.ts` can make it negative.
+  let coins = 0
+  let calls = 0
+  for (let seed = 0; seed < 250; seed++) {
+    const result = playRun(
+      createStubHost({ seed: 30_000 + seed, level: 3 }),
+      31_000 + seed,
+      coinFlip(new Rng(32_000 + seed)),
+      { limit: 200, thinkMs: () => 0 },
+    )
+    for (const event of result.events) {
+      if (event.kind !== "settled") continue
+      coins += event.coins
+      calls += 1
+    }
+  }
+  assert.ok(calls > 800, `only ${String(calls)} calls sampled`)
+  const drift = coins / calls
+  assert.ok(
+    drift < -0.5,
+    `a maximum-speed random swiper drifts ${drift.toFixed(2)} coins a call — the honest number is ` +
+      `about −1; at or above zero ` +
+      `the bag is a free random walk and mashing pays`,
+  )
+  console.log(`    guesser drift: ${drift.toFixed(2)} coins per call over ${String(calls)} calls`)
+})
+
+test("a careful reader's coins drift strongly UP, by the same measure", () => {
+  // The counterweight. The test above would also pass if correct calls paid nothing.
+  let coins = 0
+  let calls = 0
+  for (let seed = 0; seed < 120; seed++) {
+    const result = playRun(
+      createStubHost({ seed: 40_000 + seed, level: 3 }),
+      41_000 + seed,
+      fallible(0.95, new Rng(42_000 + seed)),
+      { limit: 120, thinkMs: deliberate },
+    )
+    for (const event of result.events) {
+      if (event.kind !== "settled") continue
+      coins += event.coins
+      calls += 1
+    }
+  }
+  const drift = coins / calls
+  assert.ok(drift > 4.5, `a careful reader drifts only ${drift.toFixed(2)} coins a call`)
+  console.log(`    reader drift:  ${drift.toFixed(2)} coins per call over ${String(calls)} calls`)
+})
+
+test("a random swiper's bag hovers at nothing, whatever the seed", () => {
+  // Not "grows slowly" — does not grow. The drift per round is negative, and the run
+  // ends after three wrong verdicts, which for a coin flip is about six rounds.
+  const guesser = meanBag((seed) => play(seed, coinFlip(new Rng(2000 + seed)), () => 0))
+  assert.ok(guesser.bag < 40, `a guesser averaged a bag of ${guesser.bag.toFixed(1)}`)
+  assert.ok(guesser.rounds < 12, `a guesser lasted ${guesser.rounds.toFixed(1)} rounds`)
+})
+
+test("keeping everything and tossing everything are both losing, and equally so", () => {
+  // The two degenerate swipers. The truth bag deals in exact halves, so neither can
+  // beat 50%, and 50% loses coins by construction.
+  const keeper = meanBag((seed) => play(seed, alwaysKeep, () => 0))
+  const tosser = meanBag((seed) => play(seed, alwaysToss, () => 0))
+  const reader = meanBag((seed) => play(seed, fallible(0.95, new Rng(4000 + seed)), deliberate))
+  for (const [name, bot] of [
+    ["keep everything", keeper],
+    ["toss everything", tosser],
+  ] as const) {
+    assert.ok(
+      reader.bag > bot.bag * 20,
+      `${name} banked ${bot.bag.toFixed(1)} against the reader's ${reader.bag.toFixed(1)}`,
+    )
+    assert.ok(bot.rounds < 12, `${name} lasted ${bot.rounds.toFixed(1)} rounds`)
+  }
+  // And the economy does not favour one gesture over the other.
+  assert.ok(
+    Math.abs(keeper.bag - tosser.bag) < Math.max(6, keeper.bag * 0.6),
+    `one direction pays better: keep ${keeper.bag.toFixed(1)} vs toss ${tosser.bag.toFixed(1)}`,
+  )
+})
+
+test("WAITING EVERY WINDOW OUT EARNS EXACTLY NOTHING — it does not dominate answering", () => {
+  // The SLICE failure, checked for. A lapse costs nothing, so the worry is that
+  // never answering is the optimal play. It earns zero, forever, and a reader earns
+  // hundreds — so it dominates nothing except guessing, which is the one strategy it
+  // is supposed to beat.
+  const waiter = meanBag((seed) => play(seed, alwaysWait), 60)
+  const reader = meanBag((seed) => play(seed, fallible(0.95, new Rng(6000 + seed)), deliberate))
+  assert.equal(waiter.bag, 0, `a waiter banked ${waiter.bag.toFixed(1)} coins`)
+  assert.equal(waiter.calls, 0)
+  assert.ok(reader.bag > 300, `a reader only banked ${reader.bag.toFixed(1)}`)
+})
+
+test("waiting is the most expensive thing in the game in wall-clock time", () => {
+  // It is free in coins and it is not free in minutes: a lapse spends the whole
+  // window, which is the largest single cost any round can incur. So per minute of
+  // play, waiting is the worst play available to anybody who can read at all.
+  const waiter = playRun(createStubHost({ seed: 77, level: 5 }), 78, alwaysWait, { limit: 30 })
+  const reader = playRun(createStubHost({ seed: 77, level: 5 }), 78, perfect, {
+    limit: 30,
+    thinkMs: deliberate,
+  })
+  const spent = (r: typeof waiter): number =>
+    r.events.reduce((sum, e) => sum + (e.kind === "settled" ? e.reactionMs : 0), 0)
+  assert.ok(
+    spent(waiter) > spent(reader) * 1.8,
+    `waiting spent ${String(spent(waiter))}ms and reading spent ${String(spent(reader))}ms`,
+  )
+})
+
+test("accuracy pays superlinearly: a better reader banks disproportionately more", () => {
+  // Not "10% better accuracy, 10% more coins". The run length is negative-binomial in
+  // accuracy AND the per-round drift rises with it, so the two multiply.
+  const bags = [0.6, 0.75, 0.9, 0.98].map((p) =>
+    meanBag((seed) => play(seed, fallible(p, new Rng(11_000 + seed)), deliberate), 80).bag,
+  )
+  for (let i = 1; i < bags.length; i++) {
+    assert.ok(
+      (bags[i] ?? 0) > (bags[i - 1] ?? 0),
+      `bags did not rise with accuracy: ${bags.map((b) => b.toFixed(1)).join(" → ")}`,
+    )
+  }
+  assert.ok(
+    (bags[3] ?? 0) / Math.max(1, bags[0] ?? 0) > 8,
+    `0.98 accuracy is only ${((bags[3] ?? 0) / Math.max(1, bags[0] ?? 1)).toFixed(1)}x a 0.6 bag`,
+  )
+  console.log(`    bags at p=0.6/0.75/0.9/0.98: ${bags.map((b) => b.toFixed(0)).join(" / ")}`)
+})
+
+test("fast AND right is the best there is — speed still pays, on top of correct", () => {
+  // The other side of it. Correctness dominates speed, but a fast correct player must
+  // still out-earn a slow correct one, or the bonus is decoration.
+  const fast = meanBag((seed) => play(seed, perfect, () => 200), 120)
+  const slow = meanBag((seed) => play(seed, perfect, deliberate), 120)
+  assert.ok(
+    fast.bag > slow.bag,
+    `speed bought nothing: fast ${fast.bag.toFixed(1)} vs slow ${slow.bag.toFixed(1)}`,
+  )
+  // ...and never more than two thirds again as much, because the base is the bigger
+  // half of every coin.
+  assert.ok(
+    fast.bag < slow.bag * 1.7,
+    `speed is worth ${(fast.bag / slow.bag).toFixed(2)}x, which is more than being right`,
+  )
+})

--- a/dynawalla/games/truedraw/src/game/energy.test.ts
+++ b/dynawalla/games/truedraw/src/game/energy.test.ts
@@ -3,44 +3,70 @@ import { test } from "node:test"
 
 import { VOICES } from "../audio/audio.ts"
 import { energy, HAPTIC, MOVERS, TIMINGS } from "./energy.ts"
+import { OUTCOMES } from "./response.ts"
 import { TIMING, TIMING_REDUCED } from "./round.ts"
 
-test("a wrong draw has no reaction at all — no motion, no sound, no motor", () => {
+test("a wrong verdict has no reaction at all — in either direction", () => {
+  // The bag losing coins is the ledger telling the truth, not a reaction to the
+  // child. Nothing sounds, nothing buzzes, nothing flashes, the caller does not move.
   for (const timing of TIMINGS) {
-    assert.equal(energy("wild", timing), 0)
+    assert.equal(energy("dud", timing), 0)
+    assert.equal(energy("burn", timing), 0)
   }
-  assert.equal(MOVERS.wild, 0)
-  assert.equal(VOICES.wild, undefined, "there is no wild voice and there must not be one")
-  assert.equal(HAPTIC.wild, null, "a motor pulse is a buzzer you can feel")
+  assert.equal(VOICES.dud, undefined, "there is no dud voice and there must not be one")
+  assert.equal(VOICES.burn, undefined, "there is no burn voice and there must not be one")
+  assert.equal(HAPTIC.dud, null, "a motor pulse is a buzzer you can feel")
+  assert.equal(HAPTIC.burn, null)
+})
+
+test("a lapse is the quietest thing in the game, because it is not a failure", () => {
+  // A tone or a buzz at the end of a window a child was still thinking through is a
+  // buzzer aimed at slowness, which is the one thing this product will not do.
+  for (const timing of TIMINGS) assert.equal(energy("lapse", timing), 0)
+  assert.equal(VOICES.lapse, undefined)
+  assert.equal(HAPTIC.lapse, null)
 })
 
 test("being wrong is never more interesting than being right", () => {
-  // energy(SLIP) < energy(SEAT), from EXPERIENCE_DESIGN.md, checked against the
-  // real durations and gains rather than against a comment about them.
+  // energy(SLIP) < energy(SEAT), from EXPERIENCE_DESIGN.md, checked against the real
+  // durations and gains rather than against a comment about them.
   for (const timing of TIMINGS) {
-    assert.ok(energy("slow", timing) < energy("hit", timing))
-    assert.ok(energy("wild", timing) < energy("hit", timing))
+    for (const wrong of ["dud", "burn", "lapse"] as const) {
+      assert.ok(energy(wrong, timing) < energy("bank", timing), wrong)
+      assert.ok(energy(wrong, timing) < energy("spot", timing), wrong)
+    }
   }
 })
 
-test("the correct hold is the biggest moment in the game", () => {
+test("spotting a counterfeit is the biggest moment in the game", () => {
   for (const timing of TIMINGS) {
-    assert.ok(energy("bow", timing) > energy("hit", timing))
-    assert.ok(energy("bow", timing) > energy("slow", timing))
+    assert.ok(energy("spot", timing) > energy("bank", timing))
   }
+  assert.ok(MOVERS.spot > MOVERS.bank)
 })
 
 test("reduced motion is a branch, not a deletion", () => {
-  for (const kind of ["hit", "bow", "slow"] as const) {
+  for (const kind of ["bank", "spot"] as const) {
     assert.ok(TIMING_REDUCED.verdict[kind] > 0, kind)
     assert.ok(TIMING_REDUCED.verdict[kind] < TIMING.verdict[kind], kind)
   }
-  // The one that cannot shrink: there is no motion in being ignored to reduce.
-  assert.equal(TIMING_REDUCED.verdict.wild, TIMING.verdict.wild)
+  // The ones that cannot shrink: there is no motion in a silent loss to reduce.
+  assert.equal(TIMING_REDUCED.verdict.dud, TIMING.verdict.dud)
+  assert.equal(TIMING_REDUCED.verdict.burn, TIMING.verdict.burn)
 })
 
-test("nothing sounds at the cue", () => {
-  // A haptic or a distinct tone at the go signal would let a child play the
-  // flash by feel and never read the slate. The cue is a light change.
-  assert.equal(Object.values(HAPTIC).filter((h) => h !== null).length, 3)
+test("only the two correct verdicts buzz, and nothing buzzes at the cue", () => {
+  // A haptic when the statement is cut in would let a child play the beat by feel and
+  // never read the slate.
+  const buzzing = OUTCOMES.filter((o) => HAPTIC[o] !== null)
+  assert.deepEqual(buzzing, ["bank", "spot"], `${buzzing.join(",")} buzz`)
+})
+
+test("every outcome has a mover count and a duration — no table is left short", () => {
+  for (const outcome of OUTCOMES) {
+    assert.equal(typeof MOVERS[outcome], "number", outcome)
+    for (const timing of TIMINGS) {
+      assert.ok(timing.verdict[outcome] > 0, `${outcome} has no beat`)
+    }
+  }
 })

--- a/dynawalla/games/truedraw/src/game/energy.ts
+++ b/dynawalla/games/truedraw/src/game/energy.ts
@@ -1,14 +1,18 @@
 // The reaction budget, as a number a test can compare.
 //
-// `EXPERIENCE_DESIGN.md` sets one invariant on feedback and it is not a matter
-// of taste: **being wrong must never be more interesting than being right.**
-// Written as `energy(SLIP) < energy(SEAT)`, where energy is the product of how
-// long a reaction runs, how many things move, and how loud it is.
+// `EXPERIENCE_DESIGN.md` sets one invariant on feedback and it is not a matter of
+// taste: **being wrong must never be more interesting than being right.** Written
+// as `energy(SLIP) < energy(SEAT)`, where energy is the product of how long a
+// reaction runs, how many things move, and how loud it is.
 //
-// This game states it stronger, because restraint is the whole design here: the
-// wrong *draw* — the mash — has energy exactly zero. Nothing moves, nothing
-// sounds, nothing lights. There is no dial to creep upward later, because there
-// is no term in the product that is non-zero.
+// This game still states it stronger, and the bag did not weaken it. A wrong
+// verdict now has a consequence — coins leave — but a consequence is not a
+// reaction: nothing sounds, nothing buzzes, no colour flashes, the caller does not
+// move and the slate is not marked. The coins draining is the ledger telling the
+// truth, and it is the ONLY thing that happens.
+//
+// So `gain` is zero for `dud` and for `burn`, and therefore their energy is
+// exactly zero in both timing branches, with no dial to creep upward later.
 
 import { VOICES } from "../audio/audio.ts"
 import type { Outcome } from "./response.ts"
@@ -16,30 +20,44 @@ import { TIMING, TIMING_REDUCED, type Timing } from "./round.ts"
 
 /** How many things on screen move during each verdict. Counted, not guessed. */
 export const MOVERS: Record<Outcome, number> = {
-  // The strike mark, and the numerals seating into the recess.
-  hit: 2,
-  // The caller bowing, and the wrong numeral rolling over into the right one.
-  bow: 2,
-  // Nothing. The slate does not change, the caller does not move.
-  wild: 0,
-  // The caller draws. One thing.
-  slow: 1,
+  // The stamp, the numerals seating, and the slate going down into the bag.
+  bank: 3,
+  // The caller bowing, the wrong numeral rolling over into the right one, and the
+  // slate flying away. The biggest moment in the game.
+  spot: 4,
+  // The slate goes down and the coins come back out. Two, and no more: no mark,
+  // no colour, no caller.
+  dud: 2,
+  // The slate goes up and the coins come back out.
+  burn: 2,
+  // The slate sinks. One thing, and it is the same thing an empty street does.
+  lapse: 1,
 }
 
 /**
  * The named haptic cue per outcome, or `null` for none.
  *
- * `wild` is `null`, and that is not an oversight to be tidied up later. A motor
- * pulse on a wrong draw is a buzzer you can feel: it tells a masher that
- * *something* registered, which is exactly the acknowledgement the design
- * withholds. Nothing fires on the cue either — a haptic at the go signal would
- * let a child play the flash by feel without ever reading the slate.
+ * Both wrong verdicts are `null`, and that is not an oversight to be tidied up
+ * later. A motor pulse on a wrong answer is a buzzer you can feel: it tells a
+ * masher that *something* registered, which is exactly the acknowledgement the
+ * design withholds. The bag emptying is the feedback and it is legible without a
+ * buzz.
+ *
+ * Nothing fires when the statement is cut in either — a haptic at that moment
+ * would let a child play the beat by feel without ever reading the slate.
+ *
+ * `lapse` is `null` too: buzzing at a child for still thinking is the single most
+ * hostile thing this game could do.
  */
-export const HAPTIC: Record<Outcome, "light" | "medium" | "heavy" | "success" | "failure" | null> = {
-  hit: "light",
-  bow: "success",
-  wild: null,
-  slow: "medium",
+export const HAPTIC: Record<
+  Outcome,
+  "light" | "medium" | "heavy" | "success" | "failure" | null
+> = {
+  bank: "light",
+  spot: "success",
+  dud: null,
+  burn: null,
+  lapse: null,
 }
 
 export function energy(outcome: Outcome, timing: Timing = TIMING): number {

--- a/dynawalla/games/truedraw/src/game/gesture.test.ts
+++ b/dynawalla/games/truedraw/src/game/gesture.test.ts
@@ -1,0 +1,207 @@
+// The two gestures. Every threshold in `gesture.ts` is a number a six-year-old
+// either lands or does not, so every one of them is asserted here — including the
+// two that are properties of OTHER modules in this repository and would otherwise
+// drift silently.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+import {
+  commitDistance,
+  COMMIT_MAX_PX,
+  COMMIT_MIN_PX,
+  DOMINANCE,
+  Gesture,
+  SDK_DRAG_SLOP_PX,
+  TAP_SLOP_PX,
+} from "./gesture.ts"
+
+const flick = (g: Gesture, dx: number, dy: number, steps = 6): (string | null)[] => {
+  const out: (string | null)[] = []
+  g.begin(200, 400)
+  for (let i = 1; i <= steps; i++) {
+    out.push(g.move(200 + (dx * i) / steps, 400 + (dy * i) / steps))
+  }
+  return out
+}
+
+test("down is keep and up is toss, and nothing else is either", () => {
+  const commit = commitDistance(390, 844)
+  let g = new Gesture(commit)
+  assert.ok(flick(g, 0, commit + 4).includes("keep"), "a downward flick did not keep")
+  g = new Gesture(commit)
+  assert.ok(flick(g, 0, -(commit + 4)).includes("toss"), "an upward flick did not toss")
+})
+
+test("a flick commits exactly once, however long the finger keeps travelling", () => {
+  // A pointermove stream is 120 Hz. A recogniser that fired on every frame past the
+  // threshold would settle twenty verdicts out of one flick — nineteen of them
+  // against slates that no longer exist.
+  const g = new Gesture(40)
+  const calls = flick(g, 0, 600, 60).filter((c) => c !== null)
+  assert.deepEqual(calls, ["keep"], `one flick produced ${String(calls.length)} verdicts`)
+})
+
+test("a travel short of the threshold is not a verdict", () => {
+  const commit = commitDistance(390, 844)
+  const g = new Gesture(commit)
+  assert.deepEqual(
+    flick(g, 0, commit - 2).filter((c) => c !== null),
+    [],
+    "a flick that stopped short still answered the question",
+  )
+  assert.equal(g.end(), "drag", "a long-but-short-of-commit travel is not a tap either")
+})
+
+test("a horizontal drag is never a verdict, and neither is a 45-degree one", () => {
+  const commit = 40
+  for (const [dx, dy] of [
+    [300, 0],
+    [-300, 0],
+    // Exactly diagonal: dy is not 1.4x dx, so it means nothing.
+    [200, 200],
+    [200, -200],
+    [-200, 240],
+  ] as const) {
+    const g = new Gesture(commit)
+    assert.deepEqual(
+      flick(g, dx, dy, 20).filter((c) => c !== null),
+      [],
+      `${String(dx)},${String(dy)} was read as a verdict`,
+    )
+  }
+})
+
+test("a steep diagonal still commits — a child's flick is never plumb", () => {
+  const g = new Gesture(40)
+  assert.ok(flick(g, 20, 120, 12).includes("keep"), "a realistic thumb arc was rejected")
+})
+
+test("DOMINANCE is the line, exactly", () => {
+  // Just inside and just outside, so the constant is the thing being tested rather
+  // than a comfortable margin around it.
+  const commit = 50
+  const inside = new Gesture(commit)
+  assert.ok(flick(inside, 30, 30 * DOMINANCE + 22, 12).includes("keep"))
+  const outside = new Gesture(commit)
+  assert.deepEqual(
+    flick(outside, 60, 60 * DOMINANCE - 1, 12).filter((c) => c !== null),
+    [],
+  )
+})
+
+test("a tap is a tap, and a tap is never an answer", () => {
+  const g = new Gesture(commitDistance(390, 844))
+  g.begin(100, 200)
+  assert.equal(g.move(103, 204), null)
+  assert.equal(g.end(), "tap")
+})
+
+test("a scrub that never committed is a drag, not a tap", () => {
+  const g = new Gesture(200)
+  g.begin(100, 200)
+  g.move(100, 260)
+  assert.equal(g.end(), "drag", "a 60px scrub would have started a run as a tap")
+})
+
+test("the commit distance clears the SDK's drag slop by a wide margin", () => {
+  // `packs/shared/sdk/src/tapzoom.ts` treats travel past DRAG_SLOP_PX as a drag and
+  // leaves it entirely alone; anything at or under it is a candidate TAP, which the
+  // guard may cancel and re-dispatch as a click with no travel in it at all. A
+  // commit threshold inside that slop would have its verdicts eaten by the zoom
+  // guard on the second flick of any rapid pair.
+  assert.ok(
+    COMMIT_MIN_PX >= SDK_DRAG_SLOP_PX * 3,
+    `${String(COMMIT_MIN_PX)}px is not clear of the SDK's ${String(SDK_DRAG_SLOP_PX)}px slop`,
+  )
+  for (const [w, h] of [
+    [320, 568],
+    [390, 844],
+    [768, 1024],
+    [1024, 768],
+    [844, 390],
+    [568, 320],
+    [1366, 1024],
+  ] as const) {
+    const commit = commitDistance(w, h)
+    assert.ok(
+      commit > SDK_DRAG_SLOP_PX * 3,
+      `${String(w)}×${String(h)}: ${commit.toFixed(1)}px is inside the SDK's slop`,
+    )
+    assert.ok(commit >= COMMIT_MIN_PX && commit <= COMMIT_MAX_PX, `${String(w)}×${String(h)}`)
+  }
+})
+
+test("the SDK's drag slop has not moved out from under us", () => {
+  // `gesture.ts` restates a number that lives in another package. If that package
+  // raises it, the margin above is a fiction and this is the test that says so.
+  const source = readFileSync(
+    fileURLToPath(new URL("../../../../packs/sdk/src/tapzoom.ts", import.meta.url)),
+    "utf8",
+  )
+  const found = /export const DRAG_SLOP_PX = (\d+)/.exec(source)?.[1]
+  assert.equal(
+    Number(found),
+    SDK_DRAG_SLOP_PX,
+    `the SDK's DRAG_SLOP_PX is now ${String(found)}; gesture.ts still says ${String(SDK_DRAG_SLOP_PX)}`,
+  )
+})
+
+test("the commit distance is reachable on the smallest phone and bounded on the biggest tablet", () => {
+  assert.equal(commitDistance(320, 568), COMMIT_MIN_PX, "the small phone is not at the floor")
+  assert.equal(commitDistance(1366, 2000), COMMIT_MAX_PX, "the big tablet is not at the ceiling")
+  // And it is always a fraction of a slate height, so the flick is a motion across
+  // the thing being judged rather than a drag across the room. The slate is
+  // `min(area.w * 0.88, 640) * 0.3` tall.
+  for (const [w, h] of [
+    [320, 568],
+    [390, 844],
+    [768, 1024],
+    [1024, 1366],
+  ] as const) {
+    const slateH = Math.min(w * 0.88, 640) * 0.3
+    assert.ok(
+      commitDistance(w, h) <= slateH * 1.35,
+      `${String(w)}×${String(h)}: a ${commitDistance(w, h).toFixed(0)}px flick against a ${slateH.toFixed(0)}px slate`,
+    )
+  }
+})
+
+test("a cancel owes nothing — the system taking the gesture is not a verdict", () => {
+  const g = new Gesture(40)
+  g.begin(100, 200)
+  g.move(100, 230)
+  g.cancel()
+  assert.equal(g.down, false)
+  assert.equal(g.move(100, 600), null, "a cancelled gesture still committed")
+})
+
+test("the live drag is clamped, so the slate can never be dragged off the world", () => {
+  const g = new Gesture(50)
+  g.begin(100, 200)
+  g.move(100, 5000)
+  assert.equal(g.pull, 1)
+  g.begin(100, 200)
+  g.move(100, -5000)
+  assert.equal(g.pull, 1)
+})
+
+test("the heading lights up before the verdict fires, which is the whole affordance", () => {
+  const g = new Gesture(80)
+  g.begin(100, 400)
+  g.move(100, 420)
+  assert.equal(g.heading, "keep", "the child gets no hint which way they are going")
+  assert.equal(g.pull > 0 && g.pull < 1, true)
+  g.begin(100, 400)
+  g.move(100, 380)
+  assert.equal(g.heading, "toss")
+})
+
+test("TAP_SLOP_PX is small enough that a tap cannot become a heading", () => {
+  const g = new Gesture(80)
+  g.begin(100, 400)
+  g.move(100, 400 + TAP_SLOP_PX)
+  assert.equal(g.heading, null, "a tap's wander showed a direction")
+})

--- a/dynawalla/games/truedraw/src/game/gesture.ts
+++ b/dynawalla/games/truedraw/src/game/gesture.ts
@@ -1,0 +1,192 @@
+// The two gestures, as a state machine with no DOM in it.
+//
+//   swipe DOWN  →  keep  ("this claim is true", into the bag)
+//   swipe UP    →  toss  ("this claim is false", thrown away)
+//
+// Split out from `mount.ts` so the thresholds — which are the difference between
+// a gesture a six-year-old lands every time and one that eats their answer — can
+// be driven exactly rather than approximated through a fake PointerEvent.
+//
+// ── COMMIT_MIN_PX = 34, and why not less ─────────────────────────────────────
+//
+// Three numbers already in this repository bound it from below.
+//
+//   * `packs/shared/sdk/src/tapzoom.ts` calls anything past `DRAG_SLOP_PX = 10` a
+//     drag rather than a tap. That module cancels the second tap of a zoom-shaped
+//     chain and re-dispatches its `click`; a *drag* it leaves entirely alone. So a
+//     committed swipe must be comfortably past 10 px, and at 34 it is 3.4× clear.
+//     A swipe under that slop would be seen by the guard as a tap, could be
+//     cancelled as half of a double tap, and would arrive at the canvas as a
+//     re-dispatched click with no travel in it at all.
+//   * A resting thumb wanders a few pixels between `pointerdown` and
+//     `pointerup`. 34 px is past any of that, so a child who means to tap never
+//     accidentally banks a counterfeit.
+//   * 34 CSS px is 34 pt on iOS, just under the 44 pt minimum touch target. A
+//     flick that travels less than one target height is not a flick.
+//
+// ── COMMIT_MAX_PX = 84, and why there is a ceiling at all ────────────────────
+//
+// The threshold scales with the viewport so an iPad does not feel like a phone,
+// but it must never exceed what a thumb can travel in one motion without the hand
+// moving. On a 1366 px iPad the unclamped fraction is 102 px; clamped it is 84.
+// The slate itself is `min(area.w × 0.88, 640)` wide and 0.3 of that tall, so 84
+// px is well inside one slate height on every shape the fleet has — the gesture
+// is always a flick across the thing being judged, never a drag across the room.
+//
+// ── the fraction between them ────────────────────────────────────────────────
+//
+// 7.5% of the SHORTER side, not of the height. In landscape on a phone the height
+// is the short side and a height-based threshold would be tiny; in portrait on an
+// iPad the width is the short side and a height-based one would be enormous. The
+// shorter side is the one bounded by the hand in both orientations.
+//
+// ── DOMINANCE = 1.4, and what it defends ─────────────────────────────────────
+//
+// A vertical travel only commits if it is 1.4× the horizontal travel. A diagonal
+// drag is not a verdict, and neither is a horizontal one: the host owns horizontal
+// gestures on its own surfaces, and a child who drags sideways across a canvas has
+// not said anything about arithmetic. Making that ambiguous would spend a shot.
+//
+// ── COMMIT ON CROSSING, NOT ON RELEASE ──────────────────────────────────────
+//
+// The verdict fires the instant the threshold is crossed, mid-motion, and the
+// timestamp taken there is the reported latency. Two reasons, and the second is
+// the one that matters.
+//
+//   1. Feel. A card you have thrown is gone before your hand stops.
+//   2. Honesty. The alternative anchors — `pointerdown`, or the end of the
+//      release animation — are both wrong. `pointerdown` is unknowable (the
+//      direction does not exist yet) and would be *exploitable*: rest a finger on
+//      the slate at the moment it lights, think for six seconds, then flick, and
+//      a `pointerdown`-anchored clock would report a reaction of zero and hand out
+//      the full speed bonus. Anchoring at the crossing costs the ~80–150 ms of
+//      finger travel, uniformly, on both gestures — noise against a p50 measured
+//      in thousands — and cannot be gamed by holding still.
+
+import type { Call } from "./response.ts"
+
+/** Share of the shorter viewport side a swipe must travel to commit. */
+export const COMMIT_FRACTION = 0.075
+
+export const COMMIT_MIN_PX = 34
+export const COMMIT_MAX_PX = 84
+
+/** How much more vertical than horizontal a travel must be to mean anything. */
+export const DOMINANCE = 1.4
+
+/**
+ * The SDK's own drag threshold, restated here as the floor it is.
+ *
+ * `COMMIT_MIN_PX` must stay above it. Imported as a number rather than from the
+ * SDK because this package does not depend on the SDK — but `gesture.test.ts`
+ * reads the real constant out of `tapzoom.ts` and fails if the two drift.
+ */
+export const SDK_DRAG_SLOP_PX = 10
+
+/** How far a pointer may wander and still be a tap rather than a scrub. */
+export const TAP_SLOP_PX = 10
+
+export function commitDistance(w: number, h: number): number {
+  const short = Math.max(1, Math.min(w, h))
+  return Math.max(COMMIT_MIN_PX, Math.min(COMMIT_MAX_PX, COMMIT_FRACTION * short))
+}
+
+/** How a completed pointer sequence ended. */
+export type Release = "tap" | "drag"
+
+/**
+ * One pointer at a time, with the commit fired exactly once per sequence.
+ *
+ * The "exactly once" is not decoration. A `pointermove` stream on a real device
+ * arrives at 120 Hz, and a finger that keeps travelling after the threshold would
+ * otherwise commit a verdict on every frame — twenty duds from one flick.
+ */
+export class Gesture {
+  private readonly commit: number
+  private active = false
+  private fired = false
+  private startX = 0
+  private startY = 0
+  private x = 0
+  private y = 0
+
+  constructor(commitPx: number) {
+    this.commit = commitPx
+  }
+
+  get down(): boolean {
+    return this.active
+  }
+
+  /** How far the live pointer has travelled vertically. Down is positive. */
+  get dy(): number {
+    return this.active ? this.y - this.startY : 0
+  }
+
+  /** 0..1 towards a commit, for the renderer. Clamped, so the slate cannot fly off. */
+  get pull(): number {
+    return Math.max(0, Math.min(1, Math.abs(this.dy) / this.commit))
+  }
+
+  /**
+   * The call this travel is heading towards, or null while it means nothing yet.
+   *
+   * It lights as soon as the travel is past a tap's wander and vertical enough to be
+   * unambiguous — deliberately much earlier than the commit. That is the affordance:
+   * the child sees which way they are going while they can still change their mind,
+   * which is why the controls do not have to be explained twice.
+   */
+  get heading(): Call | null {
+    if (!this.active) return null
+    const dy = this.dy
+    if (Math.abs(dy) <= TAP_SLOP_PX) return null
+    if (Math.abs(dy) <= Math.abs(this.x - this.startX) * DOMINANCE) return null
+    return dy > 0 ? "keep" : "toss"
+  }
+
+  begin(x: number, y: number): void {
+    this.active = true
+    this.fired = false
+    this.startX = x
+    this.startY = y
+    this.x = x
+    this.y = y
+  }
+
+  /** The call, the one frame it crosses. Null on every other frame. */
+  move(x: number, y: number): Call | null {
+    if (!this.active || this.fired) {
+      this.x = x
+      this.y = y
+      return null
+    }
+    this.x = x
+    this.y = y
+    const dy = y - this.startY
+    const dx = x - this.startX
+    if (Math.abs(dy) < this.commit) return null
+    // A diagonal is not a verdict. Checked after the distance so a long
+    // horizontal scrub cannot commit by accumulating a little vertical drift.
+    if (Math.abs(dy) <= Math.abs(dx) * DOMINANCE) return null
+    this.fired = true
+    return dy > 0 ? "keep" : "toss"
+  }
+
+  /**
+   * The pointer lifted. Says whether the sequence was a tap, so `mount.ts` can
+   * use one to start a run — and never to answer a question.
+   */
+  end(): Release {
+    const travelled = Math.hypot(this.x - this.startX, this.y - this.startY)
+    const release: Release = !this.fired && travelled <= TAP_SLOP_PX ? "tap" : "drag"
+    this.active = false
+    this.fired = false
+    return release
+  }
+
+  /** The system took the gesture away. Nothing committed, nothing is owed. */
+  cancel(): void {
+    this.active = false
+    this.fired = false
+  }
+}

--- a/dynawalla/games/truedraw/src/game/inhibition.test.ts
+++ b/dynawalla/games/truedraw/src/game/inhibition.test.ts
@@ -1,9 +1,13 @@
-// The 50% mashing ceiling, measured.
+// The 50% ceiling, measured.
 //
-// Everything else in this pack is a rendering choice. This file is the product
-// claim: that a child who draws at everything is right exactly half the time,
-// that half is not a passing grade but a three-call run, and that reading the
-// slate is worth nine times as much game.
+// This is the file the whole format rests on. A two-choice task has a hard 50%
+// ceiling for anyone who does not read, and that is not a flaw to be patched — it is
+// the measurement. The job is to make sure that ceiling reads as failure. It now does
+// so twice: the bag drifts DOWN on a coin flip (`economy.test.ts`) and the run is
+// three calls long (here).
+//
+// What this file also has to hold, and what #657 put here, is that the slate lies with
+// values a child cannot reject by feel.
 
 import assert from "node:assert/strict"
 import { test } from "node:test"
@@ -11,7 +15,7 @@ import { test } from "node:test"
 import { sameValue } from "../core/exact.ts"
 import { Rng } from "../core/rng.ts"
 import { createStubHost } from "../stub/host.ts"
-import { alwaysDraw, alwaysHold, fallible, perfect, playRun } from "../test/harness.ts"
+import { alwaysKeep, alwaysToss, coinFlip, fallible, perfect, playRun } from "../test/harness.ts"
 import { Dealer } from "./dealer.ts"
 import { isCorrect, outcomeOf } from "./response.ts"
 
@@ -23,33 +27,30 @@ function stream(seed: number) {
   return Array.from({ length: ROUNDS }, () => dealer.deal())
 }
 
-test("drawing at everything is right exactly half the time", () => {
+test("keeping everything is right exactly half the time", () => {
   for (const seed of [1, 77, 4242]) {
     const statements = stream(seed)
-    const correct = statements.filter((s) => isCorrect(outcomeOf("draw", s.truth))).length
+    const correct = statements.filter((s) => isCorrect(outcomeOf("keep", s.truth))).length
     const rate = correct / statements.length
-    assert.ok(
-      Math.abs(rate - 0.5) < 0.01,
-      `seed ${String(seed)}: a masher scored ${rate.toFixed(4)}`,
-    )
+    assert.ok(Math.abs(rate - 0.5) < 0.01, `seed ${String(seed)}: a keeper scored ${rate.toFixed(4)}`)
   }
 })
 
-test("never drawing is the same coin, the other way up", () => {
+test("tossing everything is the same coin, the other way up", () => {
   const statements = stream(9)
-  const correct = statements.filter((s) => isCorrect(outcomeOf("hold", s.truth))).length
+  const correct = statements.filter((s) => isCorrect(outcomeOf("toss", s.truth))).length
   assert.ok(Math.abs(correct / statements.length - 0.5) < 0.01)
 })
 
 test("no strategy that ignores the slate can beat half", () => {
-  // Any fixed call is right on exactly the statements whose truth matches it,
-  // and the bag deals those in halves. There is no timing trick, no rhythm and
-  // no tell to find, because the truth is not a function of anything the child
-  // can see before reading.
+  // Any fixed gesture is right on exactly the statements whose truth matches it, and
+  // the bag deals those in halves. There is no timing trick, no rhythm and no tell to
+  // find, because the truth is not a function of anything the child can see before
+  // reading.
   const statements = stream(31)
-  const drew = statements.filter((s) => s.truth).length
-  const held = statements.length - drew
-  assert.ok(Math.max(drew, held) / statements.length <= 0.51)
+  const keep = statements.filter((s) => s.truth).length
+  const toss = statements.length - keep
+  assert.ok(Math.max(keep, toss) / statements.length <= 0.51)
 })
 
 test("true and false stay balanced all the way through a run, not just on average", () => {
@@ -75,9 +76,10 @@ test("not one statement presented as false is actually true", () => {
 })
 
 test("the slate lies with values a child actually writes", () => {
-  // Every falsehood on the slate came out of the item's own distractor list,
-  // which is mal-rule output. Nothing here is `answer + 1` noise a child can
-  // reject by feel without doing the arithmetic.
+  // Every falsehood on the slate came out of the item's own distractor list, which is
+  // mal-rule output. Nothing here is `answer + 1` noise a child can reject by feel
+  // without doing the arithmetic. #657 proved the ones-column shortcut does not work
+  // against these values and nothing in this rework may reintroduce one.
   const host = createStubHost({ seed: 606 })
   const dealer = new Dealer(host, new Rng(607))
   let checked = 0
@@ -85,8 +87,6 @@ test("the slate lies with values a child actually writes", () => {
     const statement = dealer.deal()
     if (statement.truth) continue
     checked++
-    // `expression` is `a + b`; recompute the operands from it and confirm the
-    // claim is a value the item offered rather than something invented here.
     assert.notEqual(statement.claimed, statement.answer)
     assert.ok(Number.isInteger(Number(statement.claimed)))
   }
@@ -94,45 +94,51 @@ test("the slate lies with values a child actually writes", () => {
 })
 
 /** Mean calls per run over `n` runs of a strategy. */
-function meanCalls(
-  strategy: (seed: number) => number,
-  n: number,
-): number {
+function meanCalls(strategy: (seed: number) => number, n: number): number {
   let total = 0
   for (let i = 0; i < n; i++) total += strategy(i)
   return total / n
 }
 
-test("a masher's whole run is three calls long", () => {
-  // This is the number that makes the ceiling read as failure. Not "50%" — a
-  // child reads that as a pass. Three.
+test("a guesser's whole run is three calls long", () => {
+  // The number that makes the ceiling read as failure. Not "50%" — a child reads that
+  // as a pass. Three.
   const mean = meanCalls(
-    (seed) => playRun(createStubHost({ seed: 1000 + seed }), 2000 + seed, alwaysDraw).run.calls,
-    1200,
+    (seed) =>
+      playRun(createStubHost({ seed: 1000 + seed }), 2000 + seed, coinFlip(new Rng(seed))).run
+        .calls,
+    600,
   )
-  assert.ok(mean > 2.3 && mean < 3.8, `a masher averaged ${mean.toFixed(2)} calls`)
+  assert.ok(mean > 2.3 && mean < 3.8, `a guesser averaged ${mean.toFixed(2)} calls`)
 })
 
-test("refusing to play is exactly as short", () => {
-  const mean = meanCalls(
-    (seed) => playRun(createStubHost({ seed: 3000 + seed }), 4000 + seed, alwaysHold).run.calls,
-    1200,
-  )
-  assert.ok(mean > 2.3 && mean < 3.8, `never drawing averaged ${mean.toFixed(2)} calls`)
+test("keeping everything and tossing everything are exactly as short", () => {
+  for (const [name, bot] of [
+    ["keep everything", alwaysKeep],
+    ["toss everything", alwaysToss],
+  ] as const) {
+    const mean = meanCalls(
+      (seed) => playRun(createStubHost({ seed: 3000 + seed }), 4000 + seed, bot).run.calls,
+      600,
+    )
+    assert.ok(mean > 2.3 && mean < 3.8, `${name} averaged ${mean.toFixed(2)} calls`)
+  }
 })
 
 test("reading the slate is worth nine times the game", () => {
-  const masher = meanCalls(
-    (seed) => playRun(createStubHost({ seed: 5000 + seed }), 6000 + seed, alwaysDraw).run.calls,
-    600,
+  const guesser = meanCalls(
+    (seed) =>
+      playRun(createStubHost({ seed: 5000 + seed }), 6000 + seed, coinFlip(new Rng(seed))).run
+        .calls,
+    300,
   )
   const careful = meanCalls((seed) => {
     const rng = new Rng(7000 + seed)
     return playRun(createStubHost({ seed: 8000 + seed }), 9000 + seed, fallible(0.9, rng), {
       limit: 600,
     }).run.calls
-  }, 600)
-  assert.ok(careful / masher >= 6, `${careful.toFixed(1)} vs ${masher.toFixed(1)} calls`)
+  }, 300)
+  assert.ok(careful / guesser >= 6, `${careful.toFixed(1)} vs ${guesser.toFixed(1)} calls`)
 })
 
 test("a child who reads every slate is never stopped at all", () => {
@@ -141,10 +147,14 @@ test("a child who reads every slate is never stopped at all", () => {
   assert.equal(result.run.over, false)
 })
 
-test("mashing does not even buy tempo", () => {
-  // A wrong draw does not close the window, so a masher sits through every
-  // window in full. Per statement presented, they get strictly less game.
-  const masher = playRun(createStubHost({ seed: 41 }), 42, alwaysDraw, { limit: 60 })
+test("a guesser gets FEWER slates than a reader, not more", () => {
+  // The old design enforced this by refusing to close the window on a wrong draw. It
+  // is now enforced by the run: a guesser is off the street in six rounds. Mashing has
+  // never bought tempo in this game and it still does not.
+  const guesser = playRun(createStubHost({ seed: 41 }), 42, coinFlip(new Rng(3)), { limit: 60 })
   const reader = playRun(createStubHost({ seed: 41 }), 42, perfect, { limit: 60 })
-  assert.ok(masher.statements.length < reader.statements.length)
+  assert.ok(
+    guesser.statements.length < reader.statements.length,
+    `${String(guesser.statements.length)} vs ${String(reader.statements.length)} slates`,
+  )
 })

--- a/dynawalla/games/truedraw/src/game/ladder.test.ts
+++ b/dynawalla/games/truedraw/src/game/ladder.test.ts
@@ -1,0 +1,116 @@
+// What this game asks for, and how fast it moves.
+//
+// The founder's complaint, quantified:
+//
+//   > "I've gotten 10 correct in a row fast and I still get `2+0=1`... I did 20 in a
+//   > row max speed and got `2+1=3`. 25 in a row max speed and I get `2+0=1`."
+//
+// So the numbers here are asserted against exactly that: ten fast correct calls, and
+// where on the ladder they land you.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { CEILING, DOWN, Ladder, START, stepFor, UP_MAX, UP_MIN } from "./ladder.ts"
+import { OUTCOMES } from "./response.ts"
+
+test("ten correct calls at full speed walk from the bottom to near the top", () => {
+  const ladder = new Ladder()
+  assert.equal(ladder.difficulty, START)
+  for (let i = 0; i < 10; i++) ladder.settle("bank", 1)
+  assert.ok(
+    ladder.difficulty >= 0.9,
+    `ten fast correct calls only reached ${ladder.difficulty.toFixed(3)}`,
+  )
+})
+
+test("twenty-five at full speed are long since at the ceiling", () => {
+  const ladder = new Ladder()
+  for (let i = 0; i < 25; i++) ladder.settle("spot", 1)
+  assert.equal(ladder.difficulty, CEILING)
+})
+
+test("speed is the signal: fast and right climbs far faster than slow and right", () => {
+  const fast = new Ladder()
+  const slow = new Ladder()
+  for (let i = 0; i < 10; i++) {
+    fast.settle("bank", 1)
+    slow.settle("bank", 0)
+  }
+  assert.ok(
+    fast.difficulty - START > (slow.difficulty - START) * 3,
+    `fast climbed ${(fast.difficulty - START).toFixed(3)}, slow ${(slow.difficulty - START).toFixed(3)}`,
+  )
+  // ...but a correct-and-slow call still climbs. Being right is never a demotion.
+  assert.ok(slow.difficulty > START, "a correct but deliberate child was not moved up")
+})
+
+test("you fall faster than you climb", () => {
+  assert.ok(DOWN > UP_MAX, `a miss (${String(DOWN)}) costs less than a fast hit gains`)
+  const ladder = new Ladder(0.6)
+  ladder.settle("bank", 1)
+  const climbed = ladder.difficulty
+  ladder.settle("dud", 1)
+  assert.ok(ladder.difficulty < 0.6, `one miss left the child at ${ladder.difficulty.toFixed(3)}`)
+  assert.ok(climbed - ladder.difficulty > UP_MAX)
+})
+
+test("a wrong verdict costs the same whichever direction it was", () => {
+  assert.equal(stepFor("dud", 1), stepFor("burn", 1))
+  assert.equal(stepFor("dud", 0), stepFor("dud", 1), "a fast wrong answer was priced differently")
+})
+
+test("A LAPSE MOVES NOTHING — a child who ran out of time told us nothing", () => {
+  // The same rule `skip` states: no outcome, no verdict, no movement. Betting either
+  // way on a window that closed untouched is a guess about a child, and this module
+  // does not guess.
+  for (const q of [0, 0.5, 1]) assert.equal(stepFor("lapse", q), 0)
+  const ladder = new Ladder(0.5)
+  for (let i = 0; i < 30; i++) ladder.settle("lapse", 1)
+  assert.equal(ladder.difficulty, 0.5)
+})
+
+test("the request is NEVER exactly 1, which the SDK would read as the ladder's BOTTOM", () => {
+  // `game-host`'s `toUnit`: below 1 is a fraction, at or above 1 is a 1..10 ladder
+  // index, and the one ambiguous value — 1 — resolves as the ladder's bottom because
+  // five of the six index-scale games send it on their opening question. A game
+  // speaking fractions that sent 1.0 would ask for the EASIEST content in the
+  // product at the exact moment a child had earned the hardest.
+  assert.ok(CEILING < 1)
+  const ladder = new Ladder()
+  for (let i = 0; i < 200; i++) ladder.settle("bank", 1)
+  assert.ok(ladder.difficulty < 1, `the game asked for ${String(ladder.difficulty)}`)
+  assert.equal(ladder.difficulty, CEILING)
+})
+
+test("the request never goes below zero either", () => {
+  const ladder = new Ladder()
+  for (let i = 0; i < 200; i++) ladder.settle("burn", 0)
+  assert.equal(ladder.difficulty, 0)
+})
+
+test("every outcome has a step, and only a miss is negative", () => {
+  for (const outcome of OUTCOMES) {
+    const step = stepFor(outcome, 0.5)
+    assert.ok(Number.isFinite(step), outcome)
+  }
+  assert.ok(stepFor("bank", 0) >= UP_MIN)
+  assert.ok(stepFor("spot", 1) <= UP_MAX)
+})
+
+test("a NaN quickness cannot strand the ladder", () => {
+  const ladder = new Ladder()
+  ladder.settle("bank", Number.NaN)
+  assert.ok(Number.isFinite(ladder.difficulty))
+  assert.equal(ladder.difficulty, START + UP_MIN)
+})
+
+test("a finished run does not send the child back to the bottom", () => {
+  // A child who reached rung eight can do rung eight. Handing them `1 + 0 = 1` again
+  // because a run ended is the exact complaint this module answers.
+  const ladder = new Ladder()
+  for (let i = 0; i < 8; i++) ladder.settle("bank", 1)
+  const reached = ladder.difficulty
+  ladder.reset()
+  assert.equal(ladder.difficulty, reached)
+})

--- a/dynawalla/games/truedraw/src/game/ladder.ts
+++ b/dynawalla/games/truedraw/src/game/ladder.ts
@@ -1,0 +1,131 @@
+// What this game ASKS FOR next.
+//
+// ── the defect ───────────────────────────────────────────────────────────────
+//
+//   > "It stays on way too easy way too long to be fun for more advanced people.
+//   > `1+0=0` (False) is fine to start but I don't want to see that 3 times out of
+//   > the first 20 and see the same easy stuff for dozens of rounds. It should
+//   > advance up and down in skill level more quickly, especially based on speed."
+//
+// The reason it stayed easy was not subtle. `dealer.ts` called `host.next()` with
+// **no argument at all**. This pack never asked for a difficulty in its life, so
+// it got the front of the prefetch pool forever, at whatever rung the pool was
+// stocked at. Nothing here was adaptive; nothing here was even trying to be.
+//
+// This module is that request, and only that. It does not select questions, does
+// not know what a skill is, and does not model the child — a separate change to
+// the host is making its ladder serve a distribution rather than a single rung and
+// calibrate faster, and duplicating that here would give a child two controllers
+// fighting. What lives here is one number and how this game moves it.
+//
+// ── SPEED IS THE SIGNAL, and it could not be before ─────────────────────────
+//
+// The founder's own observation is the design:
+//
+//   > "If we have a gesture for True and a gesture for False, we can measure both
+//   > ways and decide to go to harder problems."
+//
+// With one verb, one of the two verdicts had no moment in it, so half of every
+// child's calls carried either no latency or a full-window timestamp that meant
+// "the clock ran out", not "they were sure". A ladder cannot be driven on
+// half a signal. With two gestures every call has an honest reaction time, so the
+// step up is a FUNCTION of it: fast and right moves nearly four times as far as
+// slow and right.
+//
+// ── the numbers ──────────────────────────────────────────────────────────────
+//
+// Positions are on the SDK's 0..1 fraction scale.
+//
+//   UP_MAX  0.075   a correct call at or under 35% of the item's p50
+//   UP_MIN  0.020   a correct call at or past its p50 — still up, just slower
+//   DOWN    0.110   any wrong verdict, at any speed
+//
+// Ten fast correct calls from the start position is `0.2 + 10 × 0.075 = 0.95`, so
+// the founder's "10 correct in a row fast" walks the child from near the bottom of
+// the ladder to near the top of it — which is what he asked for, stated as the
+// number it is. Ten correct-but-deliberate calls is `0.2 + 0.2 = 0.4`, a real move
+// and a much gentler one.
+//
+// `DOWN > UP_MAX` on purpose: one wrong verdict undoes roughly a call and a half of
+// fast progress. Falling faster than you climb is what keeps a child who has been
+// pushed too high from staying there, and the SDK's `flush` exists precisely so a
+// fall lands in two questions rather than thirty-three.
+//
+// A `lapse` moves the ladder by exactly nothing. A child who ran out of time has
+// told us nothing about what they know, and `skip`'s own contract says the same.
+//
+// ── CEILING = 0.995, which is not a rounding artefact ───────────────────────
+//
+// `game-host`'s `toUnit` reads a value below 1 as a fraction and a value at or
+// above 1 as a 1..10 ladder INDEX. That makes exactly one number ambiguous — `1` —
+// and it is resolved as the ladder's BOTTOM, because five of the six games that
+// speak the index scale send `1` on their opening question. So a game speaking
+// fractions that ever sends exactly `1.0` does not ask for the hardest content in
+// the product; it asks for the easiest, silently, at the moment the child has
+// earned the opposite. This game never sends it.
+
+import { isCorrect, type Outcome } from "./response.ts"
+
+/** Where a run starts. Low, because a child who is quick leaves it in seconds. */
+export const START = 0.2
+
+/** A correct call at or past the item's own p50. Still a step up. */
+export const UP_MIN = 0.02
+
+/** A correct call at or under `QUICK_FLOOR` of the item's p50. */
+export const UP_MAX = 0.075
+
+/** Any wrong verdict. Bigger than `UP_MAX`: you fall faster than you climb. */
+export const DOWN = 0.11
+
+/** The top this game will ever ask for. See the note above — never 1.0. */
+export const CEILING = 0.995
+
+export const FLOOR = 0
+
+/**
+ * How far one settled outcome moves the request.
+ *
+ * `quickness` is `cadence.quicknessOf` — 0..1, the share of the item's p50 the
+ * child did not use. It scales the step UP and is ignored on the way down: a
+ * wrong answer given fast is not more wrong than a wrong answer given slowly, and
+ * pricing it that way would punish a child for being decisive.
+ */
+export function stepFor(outcome: Outcome, quickness: number): number {
+  if (outcome === "lapse") return 0
+  if (!isCorrect(outcome)) return -DOWN
+  const credit = Number.isFinite(quickness) ? Math.max(0, Math.min(1, quickness)) : 0
+  return UP_MIN + (UP_MAX - UP_MIN) * credit
+}
+
+/** The one number, and the only thing that moves it. */
+export class Ladder {
+  private at: number
+
+  constructor(start: number = START) {
+    this.at = clamp(start)
+  }
+
+  /** What to ask the host for. Always a legal fraction, never exactly 1. */
+  get difficulty(): number {
+    return this.at
+  }
+
+  settle(outcome: Outcome, quickness: number): number {
+    this.at = clamp(this.at + stepFor(outcome, quickness))
+    return this.at
+  }
+
+  /** A new run starts where the last one left off; the child did not get worse. */
+  reset(): void {
+    // Deliberately NOT back to START. A child who reached rung eight and then ran
+    // out of shots is a child who can do rung eight; handing them `1 + 0 = 1`
+    // again because a run ended is the exact complaint this module answers. What a
+    // finished run costs is the run, not the standing.
+  }
+}
+
+function clamp(value: number): number {
+  if (!Number.isFinite(value)) return START
+  return Math.max(FLOOR, Math.min(CEILING, value))
+}

--- a/dynawalla/games/truedraw/src/game/patience.test.ts
+++ b/dynawalla/games/truedraw/src/game/patience.test.ts
@@ -9,17 +9,24 @@
 // short. They take the number of milliseconds the *repo* says the item costs,
 // and then the run reports what the game did about it.
 //
-// The failure this catches is the one the audit found: the window was capped at
-// 3.6 s, running out of time on a TRUE slate settles as a hold, and a hold is a
-// miss — so a child working at the documented p50 lost a shot on every true
-// slate, and the bag deals true slates in exact halves. Half their shots gone by
-// arithmetic, regardless of what they knew.
+// The failure this catches is the one the audit found: the window was capped at 3.6 s,
+// running out of time on a TRUE slate settled as a hold, and a hold was a miss — so a
+// child working at the documented p50 lost a shot on every true slate, and the bag
+// deals true slates in exact halves. Half their shots gone by arithmetic, regardless
+// of what they knew.
+//
+// Two things have changed under it and neither weakens it. Running out of time is now a
+// LAPSE, which spends no shot — so the worst case is milder. But the window is still
+// the item's p90 and a child at p50 must still LAND THE CALL, because a lapse earns no
+// coins and a child who can do the sum should be paid for it. So the assertion is the
+// same one: at every rung, a deliberate child answers every slate.
 
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { createStubHost } from "../stub/host.ts"
 import { perfect, playRun } from "../test/harness.ts"
+import { COIN_BASE } from "./bag.ts"
 import { comprehensionLoad, comprehensionP50Ms, comprehensionP90Ms, operandWidth } from "./cadence.ts"
 import type { Statement } from "./statement.ts"
 
@@ -42,13 +49,14 @@ test("a child working at the documented p50 is never timed out, at any rung", ()
       limit: 60,
       thinkMs: p50,
     })
-    const timedOut = result.outcomes.filter((o) => o === "slow").length
+    const timedOut = result.outcomes.filter((o) => o === "lapse").length
     assert.equal(
       timedOut,
       0,
       `level ${String(level)}: ${String(timedOut)} of ${String(result.outcomes.length)} calls were lost to the clock`,
     )
     assert.equal(result.run.shots, 3, `level ${String(level)}: shots spent by a child who was right`)
+    assert.ok(result.run.bag > 0, `level ${String(level)}: a correct deliberate child earned nothing`)
   }
 })
 
@@ -60,7 +68,7 @@ test("even the slowest tenth of the class lands the call", () => {
       limit: 40,
       thinkMs: (s) => p90(s) - 40,
     })
-    const timedOut = result.outcomes.filter((o) => o === "slow").length
+    const timedOut = result.outcomes.filter((o) => o === "lapse").length
     assert.equal(timedOut, 0, `level ${String(level)}: the slowest tenth lost ${String(timedOut)} calls`)
   }
 })
@@ -97,4 +105,36 @@ test("a run at p50 is long, which is the whole point of the format", () => {
   })
   assert.equal(result.run.over, false)
   assert.ok(result.run.calls >= 120, `only ${String(result.run.calls)} calls`)
+})
+
+test("a deliberate child is paid the full base on every single call", () => {
+  // The standing rule: measure and reward, never punish. A child working at their own
+  // class's p50 collects no speed bonus and every coin of the base, at every rung.
+  for (const level of LEVELS) {
+    const result = playRun(createStubHost({ seed: 3900 + level, level }), 3400 + level, perfect, {
+      limit: 30,
+      thinkMs: p50,
+    })
+    const calls = result.outcomes.filter((o) => o === "bank" || o === "spot").length
+    assert.ok(calls > 20, `level ${String(level)}: only ${String(calls)} calls`)
+    assert.equal(
+      result.run.bag,
+      calls * COIN_BASE,
+      `level ${String(level)}: a p50 child was paid ${String(result.run.bag)} for ${String(calls)} calls`,
+    )
+  }
+})
+
+test("a lapse never costs a deliberate child anything", () => {
+  // Even the child who cannot finish inside p90 — the tenth the table says exists —
+  // pays nothing for it. No shot, no coin, and nothing reported.
+  const result = playRun(createStubHost({ seed: 4900, level: 7 }), 4400, perfect, {
+    limit: 12,
+    thinkMs: (s) => s.windowMs * 3,
+  })
+  assert.ok(result.outcomes.length > 8, `only ${String(result.outcomes.length)} rounds`)
+  assert.ok(result.outcomes.every((o) => o === "lapse"))
+  assert.equal(result.run.shots, 3, "a shot was spent on a child who was still thinking")
+  assert.equal(result.run.bag, 0)
+  assert.equal(result.run.over, false)
 })

--- a/dynawalla/games/truedraw/src/game/response.test.ts
+++ b/dynawalla/games/truedraw/src/game/response.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { isCorrect, outcomeOf, reportsToCurriculum, responseFor } from "./response.ts"
+import { coinsFor } from "./bag.ts"
+import {
+  isCorrect,
+  isMiss,
+  isVerdict,
+  outcomeOf,
+  OUTCOMES,
+  reportsToCurriculum,
+  responseFor,
+} from "./response.ts"
 import { applyOutcome, newRun, SHOTS } from "./run.ts"
 import type { Statement } from "./statement.ts"
 
@@ -13,73 +22,100 @@ function statement(over: Partial<Statement> = {}): Statement {
     answer: "72",
     truth: false,
     text: "47 + 25 = 62",
-    windowMs: 2100,
-    stillMs: 900,
+    windowMs: 14000,
+    stillMs: 320,
+    p50Ms: 6000,
     ...over,
   }
 }
 
-test("the four outcomes are the two calls against the two truths", () => {
-  assert.equal(outcomeOf("draw", true), "hit")
-  assert.equal(outcomeOf("draw", false), "wild")
-  assert.equal(outcomeOf("hold", false), "bow")
-  assert.equal(outcomeOf("hold", true), "slow")
+test("the four verdicts are the two gestures against the two truths", () => {
+  assert.equal(outcomeOf("keep", true), "bank")
+  assert.equal(outcomeOf("keep", false), "dud")
+  assert.equal(outcomeOf("toss", false), "spot")
+  assert.equal(outcomeOf("toss", true), "burn")
 })
 
-test("drawing and holding are each right exactly half the time", () => {
+test("each gesture is right exactly half the time", () => {
   const outcomes = [
-    outcomeOf("draw", true),
-    outcomeOf("draw", false),
-    outcomeOf("hold", true),
-    outcomeOf("hold", false),
+    outcomeOf("keep", true),
+    outcomeOf("keep", false),
+    outcomeOf("toss", true),
+    outcomeOf("toss", false),
   ]
   assert.equal(outcomes.filter(isCorrect).length, 2)
 })
 
-test("a wrong draw reports the mal-rule value, so the misconception routes", () => {
+test("a lapse is not a verdict, and the four gestures are", () => {
+  for (const outcome of OUTCOMES) {
+    assert.equal(isVerdict(outcome), outcome !== "lapse", outcome)
+  }
+})
+
+test("keeping a counterfeit reports the mal-rule value, so the misconception routes", () => {
   const s = statement()
-  // The child said "62". 62 is the carry-dropped output, the host records a
-  // miss and names the diagnosis. This is the format's best property.
-  assert.equal(responseFor("wild", s), "62")
+  // The child said "62". 62 is the carry-dropped output, the host records a miss and
+  // names the diagnosis. This is the format's best property.
+  assert.equal(responseFor("dud", s), "62")
 })
 
-test("a correct draw reports the value it claimed, which is the answer", () => {
+test("banking a true claim reports the value it claimed, which is the answer", () => {
   const s = statement({ claimed: "72", truth: true })
-  assert.equal(responseFor("hit", s), "72")
+  assert.equal(responseFor("bank", s), "72")
 })
 
-test("a correct hold is credited rather than recorded as a miss", () => {
-  // A child who correctly rejects a mal-rule value has done the thing this
-  // game measures. Reporting the claimed value instead would demote them down
-  // the ladder for playing perfectly.
-  assert.equal(responseFor("bow", statement()), "72")
+test("spotting a counterfeit is credited rather than recorded as a miss", () => {
+  // A child who correctly rejects a mal-rule value has done the thing this game
+  // measures. Reporting the claimed value instead would demote them down the ladder
+  // for playing perfectly.
+  assert.equal(responseFor("spot", statement()), "72")
 })
 
-test("letting a true statement stand reports nothing the host can parse", () => {
-  const s = statement({ claimed: "72", truth: true })
-  // Unparseable, so nothing is recorded. Refusing a true sentence is not a
-  // misconception with a name.
-  assert.equal(responseFor("slow", s), "")
+test("THROWING AWAY A TRUE CLAIM IS NOW REPORTED, AND THAT IS THE POINT", () => {
+  // This is the outcome the second gesture created. Under one verb, "I say that sum
+  // is wrong" was expressed by letting the window run out — indistinguishable from
+  // "I am still working it out" — so it could not be reported at all and half of the
+  // child's evidence never reached the ladder. A swipe up is unambiguous, so it is
+  // sent, as the wrong answer it is.
+  assert.equal(reportsToCurriculum("burn"), true)
+  assert.equal(isCorrect("burn"), false)
+  // With no mal-rule to name: "I do not believe 47 + 25 = 72" is not a broken
+  // procedure with an output. The host files a miss, which is what it was.
+  assert.equal(responseFor("burn", statement({ claimed: "72", truth: true })), "")
 })
 
-test("a window that closed on an untouched screen is not sent to the ladder", () => {
-  // The three outcomes somebody performed are evidence. `slow` is the window
-  // closing with nothing touched, and from inside this game "I say that is
-  // wrong" and "I am still working it out" are the same event. Sending it as a
-  // wrong answer bets on the first and demotes a merely deliberate child.
-  assert.equal(reportsToCurriculum("hit"), true)
-  assert.equal(reportsToCurriculum("bow"), true)
-  assert.equal(reportsToCurriculum("wild"), true)
-  assert.equal(reportsToCurriculum("slow"), false)
+test("A LAPSE IS NEVER REPORTED — it is skipped", () => {
+  // The three verdicts somebody performed are evidence. A window closing on an
+  // untouched screen is not, and `report({ correct: false, answered: "" })` is NOT
+  // how you say so: the SDK is explicit that the empty string fails to parse and is
+  // filed as a MISS, stepping the ladder down for a child who was merely deliberate.
+  // `mount.ts` calls `host.skip` instead, and `wiring.test.ts` holds that.
+  assert.equal(reportsToCurriculum("bank"), true)
+  assert.equal(reportsToCurriculum("spot"), true)
+  assert.equal(reportsToCurriculum("dud"), true)
+  assert.equal(reportsToCurriculum("burn"), true)
+  assert.equal(reportsToCurriculum("lapse"), false)
 })
 
-test("the shot still goes dark — a timeout costs exactly what a wrong draw costs", () => {
-  // Suppressing the report must not quietly make not-answering free. Inside the
-  // run a hold is a call like any other: `wild` and `slow` are both misses and
-  // both spend one of three shots, so refusing to call never dominates calling.
-  assert.equal(isCorrect("wild"), false)
-  assert.equal(isCorrect("slow"), false)
-  const budget = applyOutcome(applyOutcome(newRun(), "slow"), "wild")
-  assert.equal(budget.shots, SHOTS - 2, "one shot each, no discount for silence")
+test("a lapse costs neither a shot nor a coin", () => {
+  // A window that closed untouched is not a mistake. The two wrong VERDICTS spend a
+  // shot; a lapse spends nothing, in either currency.
+  assert.equal(isMiss("dud"), true)
+  assert.equal(isMiss("burn"), true)
+  assert.equal(isMiss("lapse"), false)
+  const after = applyOutcome(newRun(), "lapse", coinsFor("lapse", 1))
+  assert.equal(after.shots, SHOTS, "a lapse spent a shot")
+  assert.equal(after.bag, 0)
+  assert.equal(after.lapses, 1)
+  assert.equal(after.over, false)
+})
+
+test("both wrong verdicts spend a shot, so refusing to read never pays", () => {
+  const budget = applyOutcome(
+    applyOutcome(newRun(), "burn", coinsFor("burn", 1)),
+    "dud",
+    coinsFor("dud", 1),
+  )
+  assert.equal(budget.shots, SHOTS - 2, "one shot each, in both directions")
   assert.equal(budget.calls, 0)
 })

--- a/dynawalla/games/truedraw/src/game/response.ts
+++ b/dynawalla/games/truedraw/src/game/response.ts
@@ -1,91 +1,129 @@
 // What the child said, and what the host is told they said.
 //
-// Four outcomes, and the asymmetry between them is the design:
+// ── the change that this file exists to record ───────────────────────────────
 //
-//   hit   drew on a true statement    — the slate is struck and the claim seats
-//   bow   held on a false statement   — the caller bows, the slate corrects itself
-//   wild  drew on a false statement   — nothing happens at all
-//   slow  held on a true statement    — the caller draws
+// This game used to have ONE verb. A tap meant "that sum is right"; meaning "that
+// sum is wrong" was expressed by DOING NOTHING and waiting the window out. Two
+// things follow from that, and both of them were shipping:
 //
-// `wild` is the one that matters. A wrong draw is not buzzed, not shaken, not
-// flashed red. The world simply does not acknowledge it: the slate stays wrong,
-// the caller does not move, no sound plays. A shot goes dark and the round ends
-// in the same silence it began in. Being ignored is the punishment.
+//   1. A child who was certain in 300 ms still sat through the entire window on
+//      every false slate. Measured, on the widest class: 14,000 ms of waiting for
+//      a verdict they had reached in 300. "I've gotten 10 correct in a row fast
+//      and I still get `2+0=1` and have to wait until it times out."
+//
+//   2. There was NO LATENCY FOR ONE OF THE TWO VERDICTS. A hold has no moment in
+//      it. So the adaptive ladder could never tell a confident rejection from an
+//      abandoned one, and half of every child's evidence arrived as either
+//      silence or a full-window timestamp that meant nothing.
+//
+// Both are the same defect: a verdict expressed by absence is a verdict with no
+// timestamp and no end. So there are now TWO GESTURES and they are symmetric:
+//
+//   swipe DOWN  keep   — "this claim is true", the slate goes into the bag
+//   swipe UP    toss   — "this claim is false", the slate is thrown away
+//
+// and a window that closes untouched is NEITHER. It is a `lapse`: not a verdict,
+// not a miss, not evidence. It is reported with `skip`, which is the SDK's third
+// ending — closed on the host, recorded against nobody.
+//
+// ── the five outcomes ────────────────────────────────────────────────────────
+//
+//   bank   kept a true claim      — correct. Coins into the bag.
+//   spot   tossed a false claim   — correct. Coins into the bag, and the slate
+//                                   rolls itself right on the way out, which is
+//                                   the best thing in the game.
+//   dud    kept a false claim     — wrong. You banked a counterfeit: coins leave.
+//   burn   tossed a true claim    — wrong. You threw money away: coins leave.
+//   lapse  the window closed      — nothing. No coins, no shot, no report.
 
 import type { Statement } from "./statement.ts"
 
-export type Call = "draw" | "hold"
-export type Outcome = "hit" | "bow" | "wild" | "slow"
+/** The two gestures, as the two things they mean. */
+export type Call = "keep" | "toss"
+
+export type Outcome = "bank" | "spot" | "dud" | "burn" | "lapse"
+
+/** Every outcome, in one place, so a table over them cannot be left short. */
+export const OUTCOMES: readonly Outcome[] = ["bank", "spot", "dud", "burn", "lapse"]
 
 export function outcomeOf(call: Call, truth: boolean): Outcome {
-  if (call === "draw") return truth ? "hit" : "wild"
-  return truth ? "slow" : "bow"
+  if (call === "keep") return truth ? "bank" : "dud"
+  return truth ? "burn" : "spot"
 }
 
 export function isCorrect(outcome: Outcome): boolean {
-  return outcome === "hit" || outcome === "bow"
+  return outcome === "bank" || outcome === "spot"
+}
+
+/**
+ * Whether the child performed this at all.
+ *
+ * Four of the five are gestures. `lapse` is the window closing with the screen
+ * untouched, and it is the only one nobody did.
+ */
+export function isVerdict(outcome: Outcome): boolean {
+  return outcome !== "lapse"
+}
+
+/** A wrong verdict — a gesture that was performed and was wrong. Never a lapse. */
+export function isMiss(outcome: Outcome): boolean {
+  return outcome === "dud" || outcome === "burn"
+}
+
+/**
+ * Whether this outcome is evidence about the child, fit to send to the ladder.
+ *
+ * **Four of the five now are, and that is the point of the second gesture.**
+ *
+ * Before, the outcome that meant "I say that sum is wrong" was indistinguishable
+ * from "I am still working it out", because both of them were the window closing
+ * on an untouched screen. It could not be reported — betting on the first reading
+ * would demote a child who was merely deliberate — so half of the evidence the
+ * ladder needed simply was not sent.
+ *
+ * A swipe up removes the ambiguity completely. A child who swiped up performed
+ * something, at a moment, meaning one thing. So `burn` — a swipe up at a true
+ * claim — is a wrong answer and is reported as one, with an honest latency on it.
+ *
+ * `lapse` is the only survivor of the old asymmetry and it is now the honest
+ * shape of it: the child said nothing, so nothing is claimed about them. It goes
+ * across as `skip` rather than as a report — see `mount.ts`. An empty `answered`
+ * on `report` does NOT mean "unanswered": the SDK documents that the empty string
+ * fails to parse and is filed as a MISS, which steps the ladder down for a child
+ * who was still carrying the hundreds column.
+ */
+export function reportsToCurriculum(outcome: Outcome): boolean {
+  return isVerdict(outcome)
 }
 
 /**
  * The response reported to the host, which is the only judge.
  *
- * The host records value-answers, so a classification has to be expressed as
- * one. Each mapping below is the honest reading of what the child asserted:
- *
- *   hit  — "the answer is 72", and it is. Recorded correct.
- *   wild — "the answer is 62". Recorded wrong, **and diagnosed**: 62 is the
- *          carry-dropped mal-rule, so drawing at a false slate routes the exact
+ *   bank — "the answer is 72", and it is. Recorded correct.
+ *   dud  — "the answer is 62". Recorded wrong, **and diagnosed**: 62 is the
+ *          carry-dropped mal-rule, so keeping a false slate routes the exact
  *          misconception the child just demonstrated. This is the single best
  *          property of the format and it comes for free.
- *   bow  — "the answer is not 62". A correct rejection of a mal-rule value is
+ *   spot — "the answer is not 62". A correct rejection of a mal-rule value is
  *          the thing this game is measuring, and it is credited: the answer is
- *          reported. That is a slightly generous reading of the evidence, and it
+ *          reported. That is a slightly generous reading of the evidence and it
  *          is the deliberate one — the alternative records a child who played
- *          perfectly as having missed, which would demote them down the ladder
- *          for being right.
- *   slow — "the answer is not 72", and it is. Nothing a child could have written
- *          expresses that, so nothing is: the empty response is unparseable and
- *          no mal-rule is named. Refusing a true sentence is not a misconception
- *          with a name — and, per `reportsToCurriculum`, it is not sent at all.
+ *          perfectly as having missed.
+ *   burn — "the answer is not 72", and it is. A wrong verdict, performed, with a
+ *          timestamp. There is no mal-rule to name — "I do not believe
+ *          47 + 25 = 72" is not a broken procedure with an output — so the value
+ *          is empty and the host files a miss, which is exactly what it was.
+ *   lapse — never reaches `report` at all. It reaches `skip`.
  */
-/**
- * Whether this outcome is evidence about the child, fit to send to the ladder.
- *
- * Three of the four are. `slow` is not, and this is the one asymmetry in the
- * file that is about the child rather than about the street.
- *
- * `slow` is the only outcome nobody performed. A `hit`, a `bow` and a `wild` are
- * all things a child *did* — a press, at a moment, meaning something. A `slow`
- * is the window closing with the screen untouched, and there is no way from
- * inside this game to tell "I say that sum is wrong" apart from "I am still
- * working it out". Reporting it as a wrong answer bets on the first reading and
- * demotes the child down the ladder when the second is true. A child who was
- * still computing is not a child who does not know the skill, and the ladder is
- * the one place that mistake compounds: it would feed them easier items, which
- * is precisely the wrong medicine for somebody who is merely deliberate.
- *
- * The shot still goes dark — inside the run a hold is a call like any other, and
- * a timeout costs exactly what an honest wrong draw costs, never less. What
- * changes is only what crosses the wire.
- *
- * The obvious hole — hold at everything, be reported correct on every false
- * slate and reported not at all on every true one — is closed by the shot
- * budget, not by the wire: holding at everything is wrong half the time, and
- * half is three calls (`run.ts`). A passive holder gets about six rounds before
- * the street clears, every time, forever.
- */
-export function reportsToCurriculum(outcome: Outcome): boolean {
-  return outcome !== "slow"
-}
-
 export function responseFor(outcome: Outcome, statement: Statement): string {
   switch (outcome) {
-    case "hit":
-    case "wild":
+    case "bank":
+    case "dud":
       return statement.claimed
-    case "bow":
+    case "spot":
       return statement.answer
-    case "slow":
+    case "burn":
+    case "lapse":
       return ""
   }
 }

--- a/dynawalla/games/truedraw/src/game/round.test.ts
+++ b/dynawalla/games/truedraw/src/game/round.test.ts
@@ -2,12 +2,12 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { createStubHost } from "../stub/host.ts"
-import { alwaysDraw, alwaysHold, perfect, playRun } from "../test/harness.ts"
+import { alwaysKeep, alwaysWait, perfect, playRun } from "../test/harness.ts"
 import { isCorrect } from "./response.ts"
-import { Round, TIMING, TIMING_REDUCED } from "./round.ts"
+import { exitOf, Round, TIMING, TIMING_REDUCED } from "./round.ts"
 import type { Statement } from "./statement.ts"
 
-function fixed(truth: boolean, windowMs = 2000, stillMs = 800): () => Statement {
+function fixed(truth: boolean, windowMs = 2000, stillMs = 320): () => Statement {
   return () => ({
     questionId: "q",
     expression: "47 + 25",
@@ -17,7 +17,16 @@ function fixed(truth: boolean, windowMs = 2000, stillMs = 800): () => Statement 
     text: `47 + 25 = ${truth ? "72" : "62"}`,
     windowMs,
     stillMs,
+    p50Ms: 6000,
   })
+}
+
+/** Wind a fresh round forward to the open window. */
+function atCall(deal: () => Statement, timing = TIMING): Round {
+  const round = new Round(deal, timing)
+  round.tap()
+  round.advance(timing.raise + 320)
+  return round
 }
 
 test("a run is idle until the first tap, and the first tap is the start", () => {
@@ -25,102 +34,119 @@ test("a run is idle until the first tap, and the first tap is the start", () => 
   assert.equal(round.phase, "idle")
   round.advance(5000)
   assert.equal(round.phase, "idle", "nothing happens on its own")
-  const events = round.press()
+  const events = round.tap()
   assert.equal(events[0]?.kind, "begin")
   assert.equal(round.phase, "raise")
 })
 
-test("the phases run raise, still, call — and the cue is the only signal", () => {
+test("the phases run raise, still, call — and the statement is cut in at the call", () => {
   const round = new Round(fixed(true))
-  round.press()
+  round.tap()
   assert.equal(round.phase, "raise")
   round.advance(TIMING.raise)
   assert.equal(round.phase, "still")
-  const events = round.advance(800)
+  const events = round.advance(320)
   assert.equal(round.phase, "call")
   assert.equal(events.filter((e) => e.kind === "cue").length, 1)
 })
 
-test("a press before the slate lights is a flinch: counted, and ignored", () => {
+test("a flick before the statement is cut in is a flinch: counted, and ignored", () => {
   const round = new Round(fixed(false))
-  round.press()
-  const events = round.press()
+  round.tap()
+  assert.deepEqual(round.verdict("keep"), [], "a verdict landed on a blank slate")
+  const events = round.tap()
   assert.equal(events[0]?.kind, "flinch")
   assert.equal(round.run.flinches, 1)
   assert.equal(round.run.shots, 3)
   assert.equal(round.phase, "raise", "the round is not advanced by a flinch")
 })
 
-test("drawing at a true slate settles at once — the only thing that hurries the game", () => {
-  const round = new Round(fixed(true))
-  round.press()
-  round.advance(TIMING.raise + 800)
-  assert.equal(round.phase, "call")
-  round.advance(200)
-  const events = round.press()
-  const settled = events.find((e) => e.kind === "settled")
-  assert.equal(settled?.kind === "settled" && settled.outcome, "hit")
-  assert.equal(round.phase, "verdict")
-  assert.ok(settled?.kind === "settled" && settled.reactionMs <= 220)
+test("BOTH verdicts settle at once — nothing makes a child wait for a call they made", () => {
+  // THE fix. Under one verb, only the "true" verdict ended the round; saying a sum
+  // was wrong meant sitting through the whole window, every time. Now either flick
+  // ends it in the same beat.
+  for (const [truth, call, expected] of [
+    [true, "keep", "bank"],
+    [false, "toss", "spot"],
+    [false, "keep", "dud"],
+    [true, "toss", "burn"],
+  ] as const) {
+    const round = atCall(fixed(truth, 14000))
+    round.advance(300)
+    const events = round.verdict(call)
+    const settled = events.find((e) => e.kind === "settled")
+    assert.equal(settled?.kind === "settled" && settled.outcome, expected)
+    assert.equal(round.phase, "verdict", `${expected} did not stop the clock`)
+    assert.ok(
+      settled?.kind === "settled" && settled.reactionMs <= 340,
+      `${expected} reported ${String(settled?.kind === "settled" ? settled.reactionMs : -1)}ms against a 14000ms window`,
+    )
+  }
 })
 
-test("drawing at a false slate buys no time at all", () => {
-  // The press is spent, the world does not react, and the window still runs to
-  // the last millisecond. Mashing gets the slowest possible game.
-  const round = new Round(fixed(false, 2000))
-  round.press()
-  round.advance(TIMING.raise + 800)
-  assert.equal(round.phase, "call")
+test("one flick per round — the second is ignored", () => {
+  const round = atCall(fixed(true))
   round.advance(100)
-  assert.deepEqual(round.press(), [], "nothing happens")
-  assert.equal(round.phase, "call", "and the clock does not move on")
-  round.advance(400)
-  assert.equal(round.phase, "call")
-  const events = round.advance(1600)
-  const settled = events.find((e) => e.kind === "settled")
-  assert.equal(settled?.kind === "settled" && settled.outcome, "wild")
-  assert.equal(round.run.shots, 2)
-})
-
-test("letting a false slate stand is the bow", () => {
-  const round = new Round(fixed(false, 2000))
-  round.press()
-  round.advance(TIMING.raise + 800)
-  const events = round.advance(2000)
-  const settled = events.find((e) => e.kind === "settled")
-  assert.equal(settled?.kind === "settled" && settled.outcome, "bow")
-  assert.equal(round.run.calls, 1)
+  round.verdict("keep")
+  assert.deepEqual(round.verdict("toss"), [], "a second flick answered the same slate")
   assert.equal(round.run.shots, 3)
 })
 
-test("letting a true slate stand costs a shot", () => {
-  const round = new Round(fixed(true, 2000))
-  round.press()
-  round.advance(TIMING.raise + 800)
+test("the window closing untouched is a LAPSE, not a wrong answer", () => {
+  const round = atCall(fixed(true, 2000))
   const events = round.advance(2000)
   const settled = events.find((e) => e.kind === "settled")
-  assert.equal(settled?.kind === "settled" && settled.outcome, "slow")
-  assert.equal(round.run.shots, 2)
+  assert.equal(settled?.kind === "settled" && settled.outcome, "lapse")
+  assert.equal(round.run.shots, 3, "a lapse spent a shot")
+  assert.equal(round.run.bag, 0)
+  assert.equal(round.run.lapses, 1)
+  // And it reports the whole window as its reaction — the only honest thing to say
+  // about a window nobody touched — which is never sent to the ladder.
+  assert.equal(settled?.kind === "settled" && settled.reactionMs, 2000)
+})
+
+test("a lapse on a FALSE slate is also just a lapse", () => {
+  // Under one verb this was the correct answer, and a child had to wait for it. It is
+  // now nothing at all, and a child who knows the answer says so in 300ms instead.
+  const round = atCall(fixed(false, 2000))
+  const events = round.advance(2000)
+  const settled = events.find((e) => e.kind === "settled")
+  assert.equal(settled?.kind === "settled" && settled.outcome, "lapse")
+  assert.equal(round.run.calls, 0, "a lapse was credited as a correct call")
+})
+
+test("the slate leaves in the direction it was thrown", () => {
+  assert.equal(exitOf("bank"), 1, "a kept slate must go down, into the bag")
+  assert.equal(exitOf("dud"), 1, "a kept counterfeit goes down too — you kept it")
+  assert.equal(exitOf("spot"), -1, "a thrown slate must go up")
+  assert.equal(exitOf("burn"), -1)
+  assert.equal(exitOf("lapse"), 1, "an untouched slate sinks")
 })
 
 test("a long frame gap is spent phase by phase, never skipped", () => {
-  // A backgrounded tab hands back one enormous delta. The machine must not owe
-  // the child a round it never played.
   const round = new Round(fixed(false, 2000))
-  round.press()
+  round.tap()
   const events = round.advance(20_000)
   assert.ok(events.some((e) => e.kind === "cue"))
   assert.ok(events.some((e) => e.kind === "settled"))
 })
 
-test("three misses end the run and the street stays cleared", () => {
+test("three wrong verdicts end the run and the street stays cleared", () => {
   const host = createStubHost({ seed: 5 })
-  const result = playRun(host, 11, alwaysHold, { limit: 200 })
+  const result = playRun(host, 11, alwaysKeep, { limit: 200 })
   assert.equal(result.finished, true)
   assert.equal(result.run.over, true)
   assert.equal(result.run.shots, 0)
   assert.equal(result.events.filter((e) => e.kind === "over").length, 1)
   assert.equal(result.run.calls, result.outcomes.filter(isCorrect).length)
+})
+
+test("a run of nothing but lapses never ends, and never earns", () => {
+  const result = playRun(createStubHost({ seed: 8 }), 9, alwaysWait, { limit: 40 })
+  assert.equal(result.finished, false, "waiting ended a run")
+  assert.equal(result.run.shots, 3)
+  assert.equal(result.run.bag, 0, `a waiter banked ${String(result.run.bag)} coins`)
+  assert.ok(result.outcomes.every((o) => o === "lapse"))
 })
 
 test("a perfect player is never stopped", () => {
@@ -133,12 +159,11 @@ test("a perfect player is never stopped", () => {
 
 test("reduced motion changes what is drawn, never what is timed", () => {
   const host = createStubHost({ seed: 7 })
-  const a = playRun(host, 21, alwaysDraw, { timing: TIMING })
-  const b = playRun(createStubHost({ seed: 7 }), 21, alwaysDraw, { timing: TIMING_REDUCED })
-  // Same seed, same questions, same truth schedule, same calls: the motion
-  // preference is a rendering branch and touches no rule.
+  const a = playRun(host, 21, alwaysKeep, { timing: TIMING })
+  const b = playRun(createStubHost({ seed: 7 }), 21, alwaysKeep, { timing: TIMING_REDUCED })
   assert.deepEqual(a.outcomes, b.outcomes)
   assert.equal(a.run.calls, b.run.calls)
+  assert.equal(a.run.bag, b.run.bag)
   assert.deepEqual(
     a.statements.map((s) => s.text),
     b.statements.map((s) => s.text),
@@ -147,52 +172,53 @@ test("reduced motion changes what is drawn, never what is timed", () => {
 
 // ---------------------------------------------------------------------------
 // The sheet. The host can put something over the frame — a transition, a parent
-// gate — and sends `pause` with the pack still mounted and its rAF still
-// running. This game calls transition every tenth call, so it is not a corner.
+// gate — and sends `pause` with the pack still mounted and its rAF still running.
+// This game calls transition every tenth call, so it is not a corner.
 // ---------------------------------------------------------------------------
 
 test("a paused round does not run its clock behind the sheet", () => {
   const round = new Round(fixed(true))
-  round.press()
+  round.tap()
   round.advance(TIMING.raise)
   assert.equal(round.phase, "still")
 
   round.pause()
   assert.equal(round.paused, true)
-  // Far more than enough to cross `still` and the whole draw window.
   round.advance(60_000)
   assert.equal(round.phase, "still", "the clock ran behind the sheet")
 
   round.resume()
   assert.equal(round.paused, false)
-  round.advance(800)
+  round.advance(320)
   assert.equal(round.phase, "call", "the clock did not restart on resume")
 })
 
-test("a true slate cannot cost a shot while the sheet is up", () => {
-  // The bug this guards, exactly: an unpaused draw window opens and closes
-  // behind the sheet, settles as a hold, and a *true* statement takes one of
-  // the child's three shots for a slate they were never shown. A reward that
-  // costs a life is the worst outcome this game has.
-  const round = new Round(fixed(true))
-  round.press()
-  round.advance(TIMING.raise)
+test("a slate cannot lapse while the sheet is up", () => {
+  // The bug this guards: an unpaused window opens and closes behind the sheet and
+  // the host is handed a `skip` for a question the child was never shown, burning it.
+  const round = atCall(fixed(true))
   round.pause()
-  const before = round.run.shots
-
   round.advance(60_000)
-
-  assert.equal(round.run.shots, before, "a shot was spent behind the sheet")
-  assert.equal(round.phase, "still", "the round advanced while paused")
+  assert.equal(round.run.lapses, 0, "a question was skipped behind the sheet")
+  assert.equal(round.phase, "call", "the round advanced while paused")
 })
 
-test("a tap on the sheet is a tap on the sheet — not a draw, not a flinch", () => {
-  const round = new Round(fixed(false))
-  round.press()
-  round.advance(TIMING.raise)
+test("a flick on the sheet is a flick on the sheet — not a verdict, not a flinch", () => {
+  const round = atCall(fixed(false))
   round.pause()
   const flinches = round.run.flinches
-  const events = round.press()
-  assert.equal(events.length, 0, "a press was handled while paused")
-  assert.equal(round.run.flinches, flinches, "a paused press was counted as a flinch")
+  assert.deepEqual(round.verdict("toss"), [], "a verdict was handled while paused")
+  assert.deepEqual(round.tap(), [], "a tap was handled while paused")
+  assert.equal(round.run.flinches, flinches, "a paused touch was counted as a flinch")
+})
+
+test("answerable is exactly when a flick means something", () => {
+  const round = new Round(fixed(true))
+  assert.equal(round.answerable, false, "an idle street is answerable")
+  round.tap()
+  assert.equal(round.answerable, false, "a blank slate is answerable")
+  round.advance(TIMING.raise + 320)
+  assert.equal(round.answerable, true)
+  round.verdict("keep")
+  assert.equal(round.answerable, false, "an answered slate is still answerable")
 })

--- a/dynawalla/games/truedraw/src/game/round.ts
+++ b/dynawalla/games/truedraw/src/game/round.ts
@@ -1,42 +1,65 @@
 // The round, as a clock.
 //
-//   RAISE    the slate comes up out of the dust, blank
-//   STILL    the statement is cut into it, unlit. Nothing else moves.
-//   CALL     the slate lights. The window is open. One press is your call.
+//   RAISE    an EMPTY slate comes up out of the dust
+//   STILL    it stands blank, ~320 ms. Nothing to read, nothing to answer.
+//   CALL     the statement is cut in, lit. The window is open. One flick is your
+//            call, and either flick ends the round the instant it commits.
 //   VERDICT  what the street does about it
-//   CLEAR    the slate goes back down
+//   CLEAR    the slate leaves — DOWNWARD if you kept it, UPWARD if you threw it
 //
-// Two rules in here carry the whole feel.
+// Two rules in here carry the whole feel, and both of them are new.
 //
-// **A wrong draw does not stop the clock.** Drawing at a true slate commits
-// instantly and the round moves on — that is the reward for reading, and it is
-// the only thing in the game that makes time go faster. Drawing at a *false*
-// slate commits too, but the window still runs out to the last millisecond,
-// with nothing on screen changing. A masher therefore gets no tempo out of
-// mashing: they get the slowest possible game, sitting through a window they
-// already spent, watching a slate that does not care.
+// **EITHER VERDICT STOPS THE CLOCK.** This is the fix. There used to be one verb,
+// so one of the two verdicts was expressed by letting the window run out — and a
+// child who was certain in 300 ms sat through the rest of it, every time, on half
+// of all slates. Measured on the widest class before this change: 300 ms of
+// thinking, 14,000 ms of waiting. Now a flick in either direction settles at once
+// and the next slate comes up. Nothing in this game makes a child wait for a
+// verdict they have already reached.
 //
-// **Nothing escalates.** The window is a function of the statement and of
-// nothing else — not of how long the run has lasted. `EXPERIENCE_DESIGN.md`
-// bans escalation on run length and a creeping timer is that ban's exact
-// target. A long run here is longer, never faster.
+// **A TIMEOUT IS NOT A VERDICT.** The window closing on an untouched screen is a
+// `lapse`. It costs no coins and no shot, and it is reported to the host with
+// `skip` rather than with `report` — see `response.ts` and `mount.ts`. It is not a
+// wrong answer, because nobody answered.
+//
+// **Nothing escalates.** The window is a function of the statement and of nothing
+// else — not of how long the run has lasted. `EXPERIENCE_DESIGN.md` bans escalation
+// on run length and a creeping timer is that ban's exact target. A long run here is
+// longer, never faster.
 //
 // The machine is driven by elapsed milliseconds rather than by frames, so
 // `round.test.ts` plays whole runs with no canvas, no rAF and no clock.
 
+import { coinsFor } from "./bag.ts"
+import { quicknessOf } from "./cadence.ts"
 import { applyFlinch, applyOutcome, newRun, type Run } from "./run.ts"
-import { isCorrect, outcomeOf, type Outcome } from "./response.ts"
+import { isCorrect, outcomeOf, type Call, type Outcome } from "./response.ts"
 import type { Statement } from "./statement.ts"
 
 export type Phase = "idle" | "raise" | "still" | "call" | "verdict" | "clear" | "over"
 
 export type RoundEvent =
   | { kind: "present"; statement: Statement }
-  /** The slate lit. This is the go signal and the only cue there is. */
+  /** The statement was cut in. The window is open from this instant. */
   | { kind: "cue"; statement: Statement }
-  /** A press before the slate lit. Counted, and otherwise ignored. */
+  /** A touch on a blank slate. Counted, and otherwise ignored. */
   | { kind: "flinch" }
-  | { kind: "settled"; outcome: Outcome; statement: Statement; reactionMs: number }
+  | {
+      kind: "settled"
+      outcome: Outcome
+      statement: Statement
+      /**
+       * Milliseconds from the statement becoming answerable to the flick
+       * committing. Never from the slate being drawn, never from an animation
+       * ending. A `lapse` reports the whole window, which is the one honest thing
+       * to say about a window nobody touched — and it is never sent to the ladder.
+       */
+      reactionMs: number
+      /** 0..1 share of the item's p50 the child did not use. */
+      quickness: number
+      /** Coins this call was worth. Negative on a wrong verdict, zero on a lapse. */
+      coins: number
+    }
   | { kind: "over"; run: Run }
   | { kind: "begin" }
 
@@ -52,15 +75,20 @@ export const TIMING: Timing = {
   raise: 220,
   clear: 200,
   verdict: {
-    // Struck, seated, gone. The correct draw is the fast one.
-    hit: 520,
-    // The bow, and the slate rolling itself right. The longest thing in the
-    // game, because it is the best thing in the game.
-    bow: 940,
-    // Nothing happens. The beat exists so the silence is legible as silence
-    // rather than as a dropped frame.
-    wild: 620,
-    slow: 640,
+    // Stamped, seated, and gone into the bag.
+    bank: 500,
+    // The bow, and the slate rolling itself right before it flies away. The
+    // longest thing in the game, because it is the best thing in the game.
+    spot: 940,
+    // You banked a counterfeit. It goes down like a bank and the coins drain
+    // back out. No sound, no buzz, no colour — the loss is the whole of it.
+    dud: 560,
+    // You threw a good slate away. It flies up and the coins drain. Also silent.
+    burn: 560,
+    // Nobody said anything. The slate just sinks. The shortest beat there is,
+    // because there is nothing to show and a child who is still thinking should
+    // not be made to watch a reaction to their not answering.
+    lapse: 300,
   },
   overLock: 900,
 }
@@ -69,16 +97,22 @@ export const TIMING_REDUCED: Timing = {
   raise: 110,
   clear: 100,
   verdict: {
-    hit: 300,
+    bank: 300,
     // Still the longest, still the payoff: a cross-fade from the wrong numeral
     // to the right one instead of a roll. A branch, not a degradation.
-    bow: 520,
-    // Unchanged, and it is the one that could not change: there is no motion in
-    // being ignored to reduce.
-    wild: 620,
-    slow: 360,
+    spot: 520,
+    // Unchanged, and they are the ones that could not change: there is no motion
+    // in a silent loss to reduce.
+    dud: 560,
+    burn: 560,
+    lapse: 300,
   },
   overLock: 900,
+}
+
+/** Which way the slate leaves. `+1` is down, into the bag; `-1` is up, away. */
+export function exitOf(outcome: Outcome | null): 1 | -1 {
+  return outcome === "spot" || outcome === "burn" ? -1 : 1
 }
 
 export class Round {
@@ -117,6 +151,11 @@ export class Round {
     return this.phaseName === "verdict" || this.phaseName === "clear" ? this.lastOutcome : null
   }
 
+  /** Whether a flick would mean anything right now. */
+  get answerable(): boolean {
+    return !this.stopped && this.phaseName === "call" && this.committed === null
+  }
+
   get paused(): boolean {
     return this.stopped
   }
@@ -127,11 +166,10 @@ export class Round {
    * This matters more here than in any other pack, and it is not hypothetical:
    * this game calls `transition` on every tenth call, the SDK documents that a
    * transition may put a sheet over the frame, and the host then sends `pause`
-   * while leaving the pack mounted and running. Without this, a 1750–3600 ms
-   * draw window would open and close behind that sheet, settle as a hold, and —
-   * if the statement happened to be true — take one of the child's three shots
-   * for a slate they were never shown. A reward that costs a life is the worst
-   * bug this game could have.
+   * while leaving the pack mounted and running. Without this a window would open
+   * and close behind that sheet and settle — as a lapse now rather than as a lost
+   * shot, which is already much less bad, but it would still hand the host a
+   * `skip` for a slate the child was never shown and burn the question.
    */
   pause(): void {
     this.stopped = true
@@ -186,32 +224,43 @@ export class Round {
     return events
   }
 
-  /** One press. Returns whatever it caused, which is often nothing. */
-  press(): RoundEvent[] {
-    // A tap that lands on a sheet is a tap on the sheet. It is not a draw, and
-    // it is not even a flinch.
+  /**
+   * One flick, in one of the two directions. Both settle at once.
+   *
+   * The reaction reported is `elapsed` at this instant, and `elapsed` in the
+   * `call` phase is measured from the moment the statement was cut into the slate
+   * — which is the moment it became both legible and answerable. Before this
+   * change the slate carried the statement, unlit, throughout `still`, so a child
+   * could read it for up to 1.15 s before the clock started. See `stillFor`.
+   */
+  verdict(call: Call): RoundEvent[] {
+    if (this.stopped) return []
+    if (this.phaseName !== "call") return []
+    if (this.committed !== null) return []
+    const statement = this.current
+    if (!statement) return []
+    this.reaction = this.elapsed
+    return this.settle(outcomeOf(call, statement.truth))
+  }
+
+  /**
+   * A tap: a touch that did not travel far enough to mean anything.
+   *
+   * It is never a verdict. On an empty street it starts the run; on a lit slate it
+   * is a flinch, which costs nothing and is counted. A tap that answered a
+   * question would put the whole game back where it started — a child who taps
+   * would be voting "true" without knowing they had voted.
+   */
+  tap(): RoundEvent[] {
     if (this.stopped) return []
     switch (this.phaseName) {
       case "raise":
-      case "still": {
+      case "still":
+      case "call": {
         this.state = applyFlinch(this.state)
         return [{ kind: "flinch" }]
       }
-      case "call": {
-        if (this.committed !== null) return []
-        const statement = this.current
-        if (!statement) return []
-        this.reaction = this.elapsed
-        const outcome = outcomeOf("draw", statement.truth)
-        this.committed = outcome
-        // A true draw stops the clock. A wild one does not: the window runs its
-        // full length with the world declining to react.
-        if (outcome === "hit") return this.settle(outcome)
-        return []
-      }
       case "idle": {
-        // Nothing on the street but the caller and three loaded shots. The
-        // first tap is the start button, which is why there is not one.
         return this.begin()
       }
       case "over": {
@@ -235,7 +284,7 @@ export class Round {
     const statement = this.current
     switch (this.phaseName) {
       case "raise": {
-        this.enter("still", statement ? statement.stillMs : 900)
+        this.enter("still", statement ? statement.stillMs : 320)
         return []
       }
       case "still": {
@@ -243,11 +292,9 @@ export class Round {
         return statement ? [{ kind: "cue", statement }] : []
       }
       case "call": {
-        // Either a wild draw that has been sitting on the clock, or no press at
-        // all — which is a hold, and a hold is a call like any other.
-        const outcome = this.committed ?? outcomeOf("hold", statement ? statement.truth : true)
-        if (this.committed === null) this.reaction = this.duration
-        return this.settle(outcome)
+        // Nobody flicked. That is not a verdict — it is a lapse.
+        this.reaction = this.duration
+        return this.settle("lapse")
       }
       case "verdict": {
         this.enter("clear", this.timing.clear)
@@ -269,17 +316,13 @@ export class Round {
     const statement = this.current
     this.lastOutcome = outcome
     this.committed = outcome
-    this.state = applyOutcome(this.state, outcome)
+    const reactionMs = Math.round(this.reaction)
+    const quickness = quicknessOf(reactionMs, statement?.p50Ms ?? 0)
+    const coins = coinsFor(outcome, quickness)
+    this.state = applyOutcome(this.state, outcome, coins)
     this.enter("verdict", this.timing.verdict[outcome])
     if (!statement) return []
-    return [
-      {
-        kind: "settled",
-        outcome,
-        statement,
-        reactionMs: Math.round(this.reaction),
-      },
-    ]
+    return [{ kind: "settled", outcome, statement, reactionMs, quickness, coins }]
   }
 
   private enter(phase: Phase, duration: number): void {

--- a/dynawalla/games/truedraw/src/game/run.test.ts
+++ b/dynawalla/games/truedraw/src/game/run.test.ts
@@ -1,48 +1,67 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
+import { COIN_WRONG, coinsFor } from "./bag.ts"
 import { applyFlinch, applyOutcome, crowdOf, expectedCalls, newRun, SHOTS } from "./run.ts"
 
-test("a run starts loaded and empty", () => {
+const settle = (run: ReturnType<typeof newRun>, kind: Parameters<typeof coinsFor>[0], q = 1) =>
+  applyOutcome(run, kind, coinsFor(kind, q))
+
+test("a run starts loaded, empty, and with an empty bag", () => {
   const run = newRun()
   assert.equal(run.shots, SHOTS)
   assert.equal(run.calls, 0)
+  assert.equal(run.bag, 0)
   assert.equal(run.over, false)
 })
 
-test("a correct call adds to the tally and costs nothing", () => {
+test("a correct call fills the bag and costs nothing", () => {
   let run = newRun()
-  run = applyOutcome(run, "hit")
-  run = applyOutcome(run, "bow")
+  run = settle(run, "bank")
+  run = settle(run, "spot")
   assert.equal(run.calls, 2)
   assert.equal(run.shots, SHOTS)
+  assert.equal(run.bag, coinsFor("bank", 1) * 2)
 })
 
-test("a miss spends a shot and never takes back a call", () => {
-  let run = applyOutcome(applyOutcome(newRun(), "hit"), "hit")
-  run = applyOutcome(run, "wild")
-  assert.equal(run.calls, 2, "the tally only ever rises")
+test("a wrong verdict spends a shot, empties coins, and never takes back a call", () => {
+  let run = newRun()
+  for (let i = 0; i < 4; i++) run = settle(run, "bank")
+  const before = run.bag
+  run = settle(run, "dud")
+  assert.equal(run.calls, 4, "the tally only ever rises")
   assert.equal(run.shots, SHOTS - 1)
-  assert.equal(run.wild, 1)
+  assert.equal(run.dud, 1)
+  assert.equal(run.bag, before - COIN_WRONG)
 })
 
-test("three misses clear the street, in any mixture", () => {
+test("three wrong verdicts clear the street, in any mixture", () => {
   for (const kinds of [
-    ["wild", "wild", "wild"],
-    ["slow", "slow", "slow"],
-    ["wild", "slow", "wild"],
+    ["dud", "dud", "dud"],
+    ["burn", "burn", "burn"],
+    ["dud", "burn", "dud"],
   ] as const) {
     let run = newRun()
-    for (const kind of kinds) run = applyOutcome(run, kind)
+    for (const kind of kinds) run = settle(run, kind)
     assert.equal(run.over, true, kinds.join("/"))
     assert.equal(run.shots, 0)
   }
 })
 
+test("no number of lapses can end a run", () => {
+  // A child who is thinking is not a child who is failing. Thirty windows closing
+  // untouched costs three shots' worth of nothing.
+  let run = newRun()
+  for (let i = 0; i < 30; i++) run = settle(run, "lapse")
+  assert.equal(run.over, false)
+  assert.equal(run.shots, SHOTS)
+  assert.equal(run.lapses, 30)
+})
+
 test("a finished run absorbs anything else that arrives", () => {
   let run = newRun()
-  for (const kind of ["wild", "wild", "wild"] as const) run = applyOutcome(run, kind)
-  const frozen = applyOutcome(applyFlinch(run), "hit")
+  for (const kind of ["dud", "dud", "dud"] as const) run = settle(run, kind)
+  const frozen = settle(applyFlinch(run), "bank")
   assert.deepEqual(frozen, run)
 })
 
@@ -51,13 +70,14 @@ test("a flinch is counted and costs nothing", () => {
   assert.equal(run.flinches, 2)
   assert.equal(run.shots, SHOTS)
   assert.equal(run.calls, 0)
+  assert.equal(run.bag, 0)
 })
 
 test("the crowd is the tally, capped, and never smaller than it was", () => {
   let run = newRun()
   let last = 0
   for (let i = 0; i < 40; i++) {
-    run = applyOutcome(run, "hit")
+    run = settle(run, "bank")
     const crowd = crowdOf(run)
     assert.ok(crowd >= last)
     last = crowd
@@ -65,10 +85,15 @@ test("the crowd is the tally, capped, and never smaller than it was", () => {
   assert.equal(crowdOf(run), 14)
 })
 
-test("half right is a three-call run — the whole design in one number", () => {
-  // Drawing at everything is right exactly half the time, and half is not a
-  // grade here: it is a length. There is no arrangement of three calls that
-  // looks like doing well.
+test("the bag never shows a debt, however badly it goes", () => {
+  let run = newRun()
+  run = settle(run, "bank")
+  run = settle(run, "dud")
+  assert.equal(run.bag, 0, `a bag of ${String(run.bag)} coins`)
+  assert.ok(run.bag >= 0)
+})
+
+test("half right is a three-call run — the older half of the design, unchanged", () => {
   assert.equal(expectedCalls(0.5), 3)
   assert.equal(expectedCalls(0.75), 9)
   assert.ok(Math.abs(expectedCalls(0.9) - 27) < 1e-9)
@@ -77,8 +102,6 @@ test("half right is a three-call run — the whole design in one number", () => 
 })
 
 test("run length climbs faster than accuracy does", () => {
-  // The gap between a masher and a careful player is not ten percent. It is
-  // nine times the run.
   let previous = -1
   for (const p of [0.5, 0.6, 0.7, 0.8, 0.9, 0.95]) {
     const calls = expectedCalls(p)

--- a/dynawalla/games/truedraw/src/game/run.ts
+++ b/dynawalla/games/truedraw/src/game/run.ts
@@ -1,41 +1,43 @@
-// The run, and why half right is a failure.
+// The run: a bag of coins, and three shots to fill it with.
 //
-// This is the module the whole design rests on. A GO/NO-GO task has a hard 50%
-// ceiling for anyone who ignores the statement and just draws — that is not a
-// flaw to be patched, it is the measurement. The job here is to make sure that
-// ceiling *reads* as failure to a seven-year-old, and there is exactly one
-// honest way to do it: **never show an accuracy at all.**
+// There are two quantities and they do different jobs.
 //
-// A child shown "50%" reads a passing grade. A child shown a tally of three
-// reads what it is.
+// **The bag** is the score, and it is what the founder asked for: correct keeps
+// build it, a wrong keep or a wrong toss diminishes it. Its arithmetic lives in
+// `bag.ts` and the single property that matters is `COIN_WRONG > COIN_MAX` — a
+// coin flip loses coins, so the bag cannot be grown by mashing.
 //
-// So the run has no score and no percentage. It has a **length**: how many calls
-// you made before three shots went dark. And the length of a run is violently
-// non-linear in how carefully you play, because misses are a budget rather than
-// a subtraction:
+// **The shots** are the run's length, and they are unchanged. Three wrong verdicts
+// and the street clears. This is the older half of the design and it is kept
+// because it is the part that is violently non-linear in care:
 //
 //     expected calls = shots × p / (1 − p)
 //
-//        p = 0.50  (draw at everything)  →   3 calls
-//        p = 0.75                        →   9 calls
-//        p = 0.90                        →  27 calls
-//        p = 0.97                        →  97 calls
-//        p = 1.00                        →  no end
+//        p = 0.50  (swipe at random)  →   3 calls
+//        p = 0.75                     →   9 calls
+//        p = 0.90                     →  27 calls
+//        p = 0.97                     →  97 calls
+//        p = 1.00                     →  no end
 //
-// A masher's whole run is three calls long. There is no arrangement of three
-// that looks like doing well, no number on the slate to misread, and nothing to
-// argue with: the street empties before a crowd ever gathers. The same is true
-// of the other degenerate strategy — never drawing is also exactly half, and
-// also three calls.
+// A guesser therefore loses twice over: their bag drifts down at 2 coins a round
+// AND their run is three calls long, so there is no arrangement of it that looks
+// like doing well. Belt and braces, deliberately — the bag is a number a child
+// might argue with and the empty street is not.
 //
-// Nothing here ever *subtracts*. A miss spends a shot; it does not take back a
-// call you made. Construction never regresses (`P-04`) — the pull is "my run was
-// getting long", never "my score is at risk".
+// A LAPSE COSTS NEITHER. A window that closed untouched is not a verdict: no
+// coins, no shot. It is the one thing in the game that is free, and it is free
+// because a child who was still working the hundreds column has not made a
+// mistake. What it costs is the window, which is the most wall-clock any single
+// round can spend — so per minute of play, waiting is the worst thing available to
+// anybody who can read at all.
+//
+// Nothing here ever takes back a CALL. The bag can fall; the tally of correct
+// calls, and therefore the crowd, only ever rises.
 
-import type { Outcome } from "./response.ts"
-import { isCorrect } from "./response.ts"
+import { addCoins } from "./bag.ts"
+import { isCorrect, isMiss, type Outcome } from "./response.ts"
 
-/** Misses a run survives. Three, as in the original. */
+/** Wrong verdicts a run survives. Three, as in the original. */
 export const SHOTS = 3
 
 /** Witnesses that can stand in the haze. Past this the crowd is a crowd. */
@@ -44,43 +46,60 @@ export const CROWD_MAX = 14
 export type Run = {
   /** Shots left. At zero the street clears. */
   readonly shots: number
-  /** Correct calls made. This is the tally, and it is the only one. */
+  /** Correct calls made. Never goes down. */
   readonly calls: number
-  /** Drew at a false slate. */
-  readonly wild: number
-  /** Let a true slate stand. */
-  readonly slow: number
-  /** Pressed before the slate lit. Ignored, and counted anyway. */
+  /** Coins in the bag. This is the score. It can go down; it floors at zero. */
+  readonly bag: number
+  /** Kept a false claim — banked a counterfeit. */
+  readonly dud: number
+  /** Tossed a true claim — threw money away. */
+  readonly burn: number
+  /** Windows that closed untouched. Counted, and charged for nothing. */
+  readonly lapses: number
+  /** Touched the slate before the statement was cut in. Ignored, counted anyway. */
   readonly flinches: number
   readonly over: boolean
 }
 
 export function newRun(): Run {
-  return { shots: SHOTS, calls: 0, wild: 0, slow: 0, flinches: 0, over: false }
+  return { shots: SHOTS, calls: 0, bag: 0, dud: 0, burn: 0, lapses: 0, flinches: 0, over: false }
 }
 
-export function applyOutcome(run: Run, outcome: Outcome): Run {
+/**
+ * Settle one outcome, worth `coins`.
+ *
+ * `coins` is passed in rather than computed here because it depends on the item's
+ * p50 and on how quick the call was, and neither is a property of the run.
+ * `bag.ts` owns the price list; this owns the ledger.
+ */
+export function applyOutcome(run: Run, outcome: Outcome, coins: number): Run {
   if (run.over) return run
-  if (isCorrect(outcome)) {
-    return { ...run, calls: run.calls + 1 }
+  const bag = addCoins(run.bag, coins)
+  if (outcome === "lapse") {
+    // Not a verdict. Not a miss. Not priced.
+    return { ...run, bag, lapses: run.lapses + 1 }
   }
-  const shots = run.shots - 1
+  if (isCorrect(outcome)) {
+    return { ...run, bag, calls: run.calls + 1 }
+  }
+  const shots = run.shots - (isMiss(outcome) ? 1 : 0)
   return {
     ...run,
+    bag,
     shots,
-    wild: run.wild + (outcome === "wild" ? 1 : 0),
-    slow: run.slow + (outcome === "slow" ? 1 : 0),
+    dud: run.dud + (outcome === "dud" ? 1 : 0),
+    burn: run.burn + (outcome === "burn" ? 1 : 0),
     over: shots <= 0,
   }
 }
 
-/** A press before the slate lit. It costs nothing and is never hidden. */
+/** Touched the slate before there was anything on it. Costs nothing, never hidden. */
 export function applyFlinch(run: Run): Run {
   if (run.over) return run
   return { ...run, flinches: run.flinches + 1 }
 }
 
-/** Witnesses currently standing. One per call, and it never goes back down. */
+/** Witnesses standing. One per correct call, and it never goes back down. */
 export function crowdOf(run: Run): number {
   return Math.min(CROWD_MAX, run.calls)
 }
@@ -90,7 +109,7 @@ export function crowdOf(run: Run): number {
  * number of successes before the `shots`-th failure.
  *
  * Exported because it is the design claim, and a claim in a comment is not
- * checked. `run.test.ts` asserts the 0.5 case is 3 and that a simulated masher
+ * checked. `run.test.ts` asserts the 0.5 case is 3 and that a simulated guesser
  * lands on it.
  */
 export function expectedCalls(p: number, shots: number = SHOTS): number {

--- a/dynawalla/games/truedraw/src/game/statement.test.ts
+++ b/dynawalla/games/truedraw/src/game/statement.test.ts
@@ -132,10 +132,33 @@ test("a short statement comes at you faster than a long one", () => {
   assert.ok(quick < slow - 800, `${String(quick)}ms vs ${String(slow)}ms`)
 })
 
-test("the stillness before the cue is jittered but bounded", () => {
+test("the beat before the statement is short, jittered, and NOT a function of the item", () => {
+  // It used to be 620–1150ms and to scale UP with the digit count — dead air, more of
+  // it the harder the sum, on a game whose complaint was that it was boring. It is now
+  // a flat ~320ms because the slate is BLANK for all of it: the statement is cut in
+  // when the window opens, so there is nothing to read during the lead-in and nothing
+  // for it to be proportional to.
   const rng = new Rng(17)
-  for (let i = 0; i < 500; i++) {
-    const still = stillFor("4003 − 87 = 3916", rng)
-    assert.ok(still >= 450 && still <= 1400, String(still))
+  const seen = new Set<number>()
+  for (const text of ["7 + 8 = 15", "4003 − 87 = 3916", "5001 − 2798 = 2203"]) {
+    for (let i = 0; i < 400; i++) {
+      const still = stillFor(text, rng)
+      assert.ok(still >= 250 && still <= 410, `${text}: ${String(still)}ms`)
+      seen.add(still)
+    }
   }
+  // The jitter is real: a fixed lead would let a child pre-load the flick and stop
+  // reading, and pre-loading is the one way left to fake a fast call.
+  assert.ok(seen.size > 40, `only ${String(seen.size)} distinct lead-ins`)
+})
+
+test("the item's own p50 rides on the statement, so the bag and the ladder agree", () => {
+  const s = buildStatement(question(), true, new Rng(9))
+  assert.equal(s.p50Ms, CADENCE.regroup.p50, `two-digit regrouping got a p50 of ${String(s.p50Ms)}`)
+  const wide = buildStatement(
+    question({ prompt: "5001 − 2798", answer: "2203", distractors: ["3313"] }),
+    true,
+    new Rng(9),
+  )
+  assert.ok(wide.p50Ms > s.p50Ms, "a harder item did not get a longer beat")
 })

--- a/dynawalla/games/truedraw/src/game/statement.ts
+++ b/dynawalla/games/truedraw/src/game/statement.ts
@@ -22,8 +22,8 @@
 // `distractors` and nothing else, so the day `mul`, `frac` or `alg` are promoted
 // out of draft this game covers them with no change: a claim is a claim.
 
-import { comprehensionMsFor } from "./cadence.ts"
-import { canonicalNumeral, digitCount, sameValue } from "../core/exact.ts"
+import { comprehensionMsFor, p50MsFor } from "./cadence.ts"
+import { canonicalNumeral, sameValue } from "../core/exact.ts"
 import type { Rng } from "../core/rng.ts"
 import type { Question } from "../contract.ts"
 
@@ -40,10 +40,16 @@ export type Statement = {
   truth: boolean
   /** "47 + 25 = 62" */
   text: string
-  /** How long the draw window stays open once the slate lights, in ms. */
+  /** How long the window stays open once the statement is cut in, in ms. */
   windowMs: number
-  /** How long the street stays still before the slate lights, in ms. */
+  /** How long the empty slate stands before the statement is cut into it, in ms. */
   stillMs: number
+  /**
+   * The item's own p50 from `cadence.ts`. Not a limit and never shown: it is what
+   * "quick" is measured against, by the bag and by the ladder, and it is carried
+   * on the statement so those two can never disagree about which beat they mean.
+   */
+  p50Ms: number
 }
 
 /**
@@ -84,12 +90,33 @@ export function windowFor(text: string): number {
   return comprehensionMsFor(text)
 }
 
-export function stillFor(text: string, rng: Rng): number {
-  const d = digitCount(text)
-  const base = Math.max(620, Math.min(1150, 420 + 80 * d))
-  // A fixed lead would let a child pre-load the press and stop reading. The
-  // jitter is small enough to stay a beat and large enough to defeat that.
-  return Math.round(base + rng.range(-140, 180))
+/**
+ * The beat before the statement is cut in — and the slate is BLANK for all of it.
+ *
+ * It used to scale with the digit count, 620–1150 ms, because the statement was
+ * legible during it: the slate came up already engraved and unlit, and the light
+ * was the go signal of a GO/NO-GO task. That structure is gone, and it took two
+ * things with it.
+ *
+ *   1. **The free thinking time.** A child could read `47 + 25 = 62` for a whole
+ *      second before the window opened, then answer in 40 ms. Every latency this
+ *      game measures would have that second silently subtracted out of it, and the
+ *      ladder would read a deliberate child as a lightning-fast one. With two
+ *      gestures the reaction time is the signal that drives the difficulty, so a
+ *      lead-in the child can think during is a lead-in that corrupts it. The
+ *      statement now appears when the window opens, and `p50Ms` is measured from
+ *      there.
+ *
+ *   2. **The dead air.** Up to 1.15 s per round of a slate you may not answer,
+ *      scaled UP by how hard the sum is, on a game whose complaint was that it was
+ *      boring. It is now a flat ~320 ms: enough for the eye to land on the slate,
+ *      not enough to read anything, and not a function of the item at all.
+ *
+ * The jitter stays. A fixed lead would let a child pre-load the flick and stop
+ * reading, and pre-loading is the one way left to fake a fast call.
+ */
+export function stillFor(_text: string, rng: Rng): number {
+  return Math.round(320 + rng.range(-70, 90))
 }
 
 /**
@@ -148,6 +175,7 @@ export function buildStatement(question: Question, wantTruth: boolean, rng: Rng)
     text,
     windowMs: windowFor(text),
     stillMs: stillFor(text, rng),
+    p50Ms: p50MsFor(text),
   }
 }
 

--- a/dynawalla/games/truedraw/src/game/tempo.test.ts
+++ b/dynawalla/games/truedraw/src/game/tempo.test.ts
@@ -1,0 +1,200 @@
+// THE DEFECT, PLAYED. "I still get `2+0=1` and have to wait until it times out."
+//
+// This file exists to hold one number, and it is the number the whole rework was
+// commissioned by. Under one verb, a child who was certain in 300 milliseconds paid
+// the ENTIRE window for every verdict they expressed by waiting — because waiting
+// was how one of the two verdicts was expressed.
+//
+// The old machine is reconstructed here rather than described, so the size of the
+// hole is a measurement and not a claim, and so the fix is compared against the
+// thing it replaced instead of against a comment about it.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost } from "../stub/host.ts"
+import { perfect, playRun } from "../test/harness.ts"
+import { comprehensionMsFor } from "./cadence.ts"
+import { Round, TIMING } from "./round.ts"
+import type { Statement } from "./statement.ts"
+
+/** A child who is certain, fast, on every slate. */
+const CERTAIN_MS = 300
+
+function statement(truth: boolean, windowMs: number): Statement {
+  return {
+    questionId: "q",
+    expression: "47 + 25",
+    claimed: truth ? "72" : "62",
+    answer: "72",
+    truth,
+    text: `47 + 25 = ${truth ? "72" : "62"}`,
+    windowMs,
+    stillMs: 320,
+    p50Ms: 6000,
+  }
+}
+
+/**
+ * THE OLD MACHINE, in eleven lines.
+ *
+ * One verb. A press meant "true". Saying "false" was letting the window run out, so
+ * the cost of a false verdict was, unavoidably and by construction, `windowMs`.
+ * There was no other way to say it.
+ */
+function oldVerdictCostMs(truth: boolean, windowMs: number, certainAtMs: number): number {
+  return truth ? certainAtMs : windowMs
+}
+
+test("under one verb, a certain child paid the whole window on half of all slates", () => {
+  // The two-digit regrouping class. `cadence.ts` gives it a p90 of 14 s, which is the
+  // window — correctly, because a window is the child's time. What was wrong was
+  // having to SPEND it to say one of the two things.
+  const window = comprehensionMsFor("47 + 25 = 62")
+  assert.equal(window, 14000)
+  assert.equal(oldVerdictCostMs(true, window, CERTAIN_MS), CERTAIN_MS)
+  assert.equal(
+    oldVerdictCostMs(false, window, CERTAIN_MS),
+    14000,
+    "the old machine did not make a certain child wait",
+  )
+  // Forty-six times the thinking, spent on nothing, on half of every run.
+  assert.ok(oldVerdictCostMs(false, window, CERTAIN_MS) / CERTAIN_MS > 45)
+})
+
+test("NOW: a certain child pays what they thought, whichever verdict it is", () => {
+  const window = comprehensionMsFor("753 + 577 = 1330")
+  assert.ok(window >= 14000, `the window shrank to ${String(window)}ms — #657 must not be undone`)
+  for (const [truth, call] of [
+    [true, "keep"],
+    [false, "toss"],
+  ] as const) {
+    const round = new Round(() => statement(truth, window), TIMING)
+    round.tap()
+    round.advance(TIMING.raise + 320)
+    assert.equal(round.phase, "call")
+    round.advance(CERTAIN_MS)
+    const events = round.verdict(call)
+    const settled = events.find((e) => e.kind === "settled")
+    assert.ok(settled?.kind === "settled")
+    assert.ok(
+      settled.reactionMs <= CERTAIN_MS + 40,
+      `${call} cost ${String(settled.reactionMs)}ms of a ${String(window)}ms window`,
+    )
+    // ...and it is 1/45th of what the same verdict used to cost.
+    assert.ok(settled.reactionMs * 40 < oldVerdictCostMs(truth, window, CERTAIN_MS) || truth)
+  }
+})
+
+test("a fast perfect run gets MANY more slates per unit of wall clock than the old one", () => {
+  // The founder's actual experience, as throughput. A certain child playing the new
+  // machine spends `CERTAIN_MS` per round; the old one spent `CERTAIN_MS` on true
+  // slates and the whole window on false ones, and the bag deals those in halves.
+  const result = playRun(createStubHost({ seed: 31, level: 4 }), 32, perfect, {
+    limit: 60,
+    thinkMs: () => CERTAIN_MS,
+  })
+  const settled = result.events.filter((e) => e.kind === "settled")
+  assert.ok(settled.length > 40, `only ${String(settled.length)} rounds`)
+
+  let now = 0
+  let then = 0
+  for (const e of settled) {
+    if (e.kind !== "settled") continue
+    now += e.reactionMs
+    then += oldVerdictCostMs(e.statement.truth, e.statement.windowMs, CERTAIN_MS)
+  }
+  assert.ok(
+    then / now > 10,
+    `the wait is only ${(then / now).toFixed(1)}x shorter (${String(then)}ms → ${String(now)}ms)`,
+  )
+  // And not one of those rounds is a lapse: a certain child never runs out of time.
+  assert.equal(result.outcomes.filter((o) => o === "lapse").length, 0)
+})
+
+test("NEITHER verdict now costs more than the other — the asymmetry is gone", () => {
+  // The deeper defect. It was not that waiting was slow; it was that ONE OF THE TWO
+  // VERDICTS HAD NO TIMESTAMP, so the ladder could not read half of a child's calls.
+  // Symmetry here is what makes the speed signal usable.
+  const window = 14000
+  const costs: Record<string, number> = {}
+  for (const [truth, call] of [
+    [true, "keep"],
+    [false, "toss"],
+    [false, "keep"],
+    [true, "toss"],
+  ] as const) {
+    const round = new Round(() => statement(truth, window), TIMING)
+    round.tap()
+    round.advance(TIMING.raise + 320)
+    round.advance(1234)
+    const settled = round.verdict(call).find((e) => e.kind === "settled")
+    assert.ok(settled?.kind === "settled")
+    costs[settled.outcome] = settled.reactionMs
+  }
+  const values = Object.values(costs)
+  assert.equal(values.length, 4, `only ${String(values.length)} distinct outcomes reached a verdict`)
+  for (const v of values) {
+    assert.ok(
+      Math.abs(v - 1234) <= 40,
+      `one verdict reported ${String(v)}ms where the others reported ~1234ms: ${JSON.stringify(costs)}`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// WHAT THE LATENCY MEASURES. Three anchors are wrong and one is right, and two
+// sibling packs shipped the wrong ones.
+// ---------------------------------------------------------------------------
+
+test("the clock starts when the statement becomes ANSWERABLE, not when the slate is drawn", () => {
+  // The slate rises and stands blank for ~320 ms before the statement is cut in. Not
+  // one millisecond of that is charged to the child — and, just as importantly, the
+  // statement is not legible during it, so no free thinking time is subtracted out of
+  // the measurement either. `statement.stillFor` is where that is enforced.
+  const window = 8000
+  const round = new Round(() => statement(true, window), TIMING)
+  round.tap()
+  // The whole of raise and still, plus a long pause on top.
+  round.advance(TIMING.raise)
+  round.advance(320)
+  assert.equal(round.phase, "call")
+  round.advance(500)
+  const settled = round.verdict("keep").find((e) => e.kind === "settled")
+  assert.ok(settled?.kind === "settled")
+  assert.equal(
+    settled.reactionMs,
+    500,
+    "the lead-in was charged to the child, or the window opened before the statement did",
+  )
+})
+
+test("a paused stretch is not charged either", () => {
+  // The host puts a sheet over the frame. Whatever the child was doing, they were not
+  // reading a slate, and a reaction time with a parent gate inside it is a fiction.
+  const round = new Round(() => statement(true, 8000), TIMING)
+  round.tap()
+  round.advance(TIMING.raise + 320)
+  round.advance(200)
+  round.pause()
+  round.advance(30_000)
+  round.resume()
+  round.advance(100)
+  const settled = round.verdict("keep").find((e) => e.kind === "settled")
+  assert.ok(settled?.kind === "settled")
+  assert.equal(settled.reactionMs, 300, "the sheet was charged to the child")
+})
+
+test("holding a finger still does not buy a speed bonus", () => {
+  // The exploit a `pointerdown`-anchored clock would have: rest a thumb on the slate
+  // the instant it lights, think for six seconds, then flick. The commit is what is
+  // timed, so this reports six seconds.
+  const round = new Round(() => statement(true, 14000), TIMING)
+  round.tap()
+  round.advance(TIMING.raise + 320)
+  round.advance(6000)
+  const settled = round.verdict("keep").find((e) => e.kind === "settled")
+  assert.ok(settled?.kind === "settled")
+  assert.equal(settled.reactionMs, 6000)
+  assert.equal(settled.quickness, 0, "a six-second call was paid a speed bonus")
+})

--- a/dynawalla/games/truedraw/src/game/wiring.test.ts
+++ b/dynawalla/games/truedraw/src/game/wiring.test.ts
@@ -1,15 +1,18 @@
-// The seam, guarded at the source.
+// The seams, guarded at the source.
 //
-// `cadence.ts` and `reportsToCurriculum` are pure and heavily tested, and
-// neither fact is worth anything if `mount.ts` stops calling them. This file
-// reads the mount as text — a blunt instrument, used deliberately: the
-// alternative is a DOM, a canvas and a rAF harness to assert two call sites.
+// `cadence.ts`, `ladder.ts`, `gesture.ts` and `reportsToCurriculum` are pure and
+// heavily tested, and none of that is worth anything if `mount.ts` stops calling them.
+// This file reads the mount as text — a blunt instrument, used deliberately: the
+// alternative is a DOM, a canvas and a rAF harness to assert a handful of call sites.
 // Every assertion below names the regression it exists to catch.
 
 import assert from "node:assert/strict"
 import { test } from "node:test"
 import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
+
+import { createStubHost } from "../stub/host.ts"
+import { alwaysWait, perfect, playRun } from "../test/harness.ts"
 
 const read = (relative: string): string =>
   readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8")
@@ -27,23 +30,35 @@ const strip = (source: string): string =>
 
 const MOUNT = strip(read("../mount.ts"))
 const STATEMENT = strip(read("./statement.ts"))
+const DEALER = strip(read("./dealer.ts"))
 
 const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1
 
-test("a window that closed on an untouched screen is never sent to the ladder", () => {
-  // The regression: the guard is dropped and `slow` goes back across the wire as
-  // a wrong answer, demoting a child who was merely deliberate.
+test("A LAPSE GOES TO host.skip AND NEVER TO host.report", () => {
+  // The regression this exists for is not hypothetical: this pack was one of the six
+  // named in the SDK as having reported timeouts as `{ correct: false, answered: "" }`,
+  // which is filed as a MISS and steps the ladder DOWN for a child who was still
+  // thinking. There is exactly one `report` and exactly one `skip`, and the `skip` is
+  // in the else of the guard.
   assert.equal(count(MOUNT, "host.report("), 1, "a new report call appeared in mount.ts")
+  assert.equal(count(MOUNT, "host.skip?.("), 1, "the skip call is gone or duplicated")
   assert.ok(MOUNT.includes("reportsToCurriculum(event.outcome)"), "the report is unguarded again")
   const settled = MOUNT.slice(MOUNT.indexOf('case "settled"'))
   const guard = settled.indexOf("reportsToCurriculum(")
-  const call = settled.indexOf("host.report(")
-  assert.ok(guard !== -1 && guard < call, "the report is no longer behind the guard")
+  const report = settled.indexOf("host.report(")
+  const skip = settled.indexOf("host.skip?.(")
+  assert.ok(guard !== -1 && guard < report, "the report is no longer behind the guard")
+  assert.ok(report < skip, "the skip is not in the else branch of the guard")
+  // And nothing reports an empty string on purpose, which is the shape of the bug.
+  assert.ok(
+    !/answered:\s*""/.test(MOUNT),
+    "mount.ts reports a literal empty answer, which the host files as a miss",
+  )
 })
 
 test("the window comes from the cadence table, with nothing clamping it", () => {
   // The regression: the ceiling comes back — 3600, or any other number — because
-  // fourteen seconds "feels slow". It is the number the repo measured.
+  // fourteen seconds "feels slow". It is the number the repo measured. #657.
   assert.ok(STATEMENT.includes("comprehensionMsFor(text)"), "windowFor stopped asking cadence.ts")
   assert.ok(!/1300\s*\+\s*215/.test(STATEMENT), "the old linear window is back")
   assert.ok(!/Math\.min\(3600/.test(STATEMENT), "the old upper clamp is back")
@@ -51,4 +66,99 @@ test("the window comes from the cadence table, with nothing clamping it", () => 
   const body = fn.slice(0, fn.indexOf("\n}"))
   assert.ok(!body.includes("Math.min"), "something is capping the comprehension window again")
   assert.ok(!body.includes("Math.max"), "something is flooring the comprehension window again")
+})
+
+test("THE GAME ASKS FOR A DIFFICULTY on every deal", () => {
+  // The regression is the state this pack shipped in: `host.next()` with no argument,
+  // forever, so nothing about the stream was adaptive and "it stays on way too easy way
+  // too long" was true by construction.
+  assert.ok(
+    /host\.next\(\{\s*difficulty:/.test(DEALER),
+    "dealer.ts is back to calling host.next() with no request",
+  )
+  assert.equal(count(DEALER, "this.host.next("), 1, "there is more than one way to deal a question")
+  assert.ok(DEALER.includes("this.ladder.settle("), "the ladder is no longer moved by an outcome")
+})
+
+test("the ladder is moved by every settled outcome, from the one place", () => {
+  assert.ok(MOUNT.includes("dealer.settle(event.outcome, event.quickness)"), "the ladder is unwired")
+  assert.equal(count(MOUNT, "dealer.settle("), 1)
+})
+
+test("the verdict fires on the move, not on the release", () => {
+  // The regression: somebody "tidies" the recogniser so a swipe commits at
+  // `pointerup`. It would still work and it would feel dead, and the reported latency
+  // would include however long the finger loitered after crossing.
+  const moveFn = MOUNT.slice(MOUNT.indexOf("const move ="), MOUNT.indexOf("const up ="))
+  assert.ok(moveFn.includes("round.verdict(call)"), "the verdict left the move handler")
+  const upFn = MOUNT.slice(MOUNT.indexOf("const up ="), MOUNT.indexOf("const cancel ="))
+  assert.ok(!upFn.includes("round.verdict("), "a verdict is now being fired on release")
+  assert.ok(upFn.includes("round.tap()"), "a tap no longer starts a run")
+})
+
+test("a tap is never a verdict, anywhere in the mount", () => {
+  // The one thing that would silently put the game back where it started: a child who
+  // taps would be voting "keep" without knowing they had voted.
+  assert.ok(!/tap\(\)[^\n]*verdict/.test(MOUNT))
+  const keys = MOUNT.slice(MOUNT.indexOf("const key ="))
+  assert.ok(keys.includes('"ArrowDown"'), "the keyboard cannot keep")
+  assert.ok(keys.includes('"ArrowUp"'), "the keyboard cannot toss")
+})
+
+// ---------------------------------------------------------------------------
+// And the same two claims played rather than read, through the stub host.
+// ---------------------------------------------------------------------------
+
+test("a lapse reaches skip and never reaches report, end to end", () => {
+  const reports: string[] = []
+  const skips: string[] = []
+  const host = createStubHost({
+    seed: 5,
+    onReport: (r) => reports.push(`${r.questionId}:${String(r.correct)}:${r.answered}`),
+    onSkip: (id) => skips.push(id),
+  })
+  // The harness drives the round machine, and the mount's reporting is the thing under
+  // test — so the reporting rule is applied here exactly as `mount.ts` applies it.
+  const result = playRun(host, 6, alwaysWait, { limit: 20 })
+  for (const event of result.events) {
+    if (event.kind !== "settled") continue
+    if (event.outcome === "lapse") skips.push(event.statement.questionId)
+    else reports.push(event.statement.questionId)
+  }
+  assert.ok(skips.length > 15, `only ${String(skips.length)} lapses in twenty rounds`)
+  assert.equal(reports.length, 0, `a lapse was reported: ${reports.join(",")}`)
+})
+
+test("a fast correct player drags the request up the ladder, question by question", () => {
+  // The end-to-end version of the founder's complaint. A stub with no `level` follows
+  // whatever the game asks for, so this is the whole loop: deal, settle, ask higher.
+  const asked: number[] = []
+  const host = createStubHost({ seed: 21, onNext: (d) => asked.push(d) })
+  playRun(host, 22, perfect, { limit: 30, thinkMs: () => 150 })
+  assert.ok(asked.length > 25, `only ${String(asked.length)} deals`)
+  const first = asked[0] ?? -1
+  const last = asked.at(-1) ?? -1
+  assert.ok(first < 0.3, `the first request was already ${first.toFixed(3)}`)
+  assert.ok(last > 0.9, `after thirty fast correct calls the game asked for ${last.toFixed(3)}`)
+  assert.ok(asked.every((d) => d >= 0 && d < 1), "a request left the legal 0..1 range")
+  // Ten fast calls in, and it has already moved a long way. This is the number the
+  // founder asked for.
+  assert.ok(
+    (asked[10] ?? 0) > 0.85,
+    `after ten fast correct calls the game was still asking for ${(asked[10] ?? 0).toFixed(3)}`,
+  )
+})
+
+test("a wrong verdict drags it back down within a question or two", () => {
+  const asked: number[] = []
+  const host = createStubHost({ seed: 23, onNext: (d) => asked.push(d) })
+  // Right eight times fast, then wrong three times.
+  let n = 0
+  playRun(host, 24, (s) => (n++ < 8 ? (s.truth ? "keep" : "toss") : s.truth ? "toss" : "keep"), {
+    limit: 20,
+    thinkMs: () => 150,
+  })
+  const peak = Math.max(...asked)
+  const end = asked.at(-1) ?? 1
+  assert.ok(end < peak, `the request never came back down from ${peak.toFixed(3)}`)
 })

--- a/dynawalla/games/truedraw/src/main.ts
+++ b/dynawalla/games/truedraw/src/main.ts
@@ -14,18 +14,34 @@ const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefine
 
 let answered = 0
 let correct = 0
+let skipped = 0
+let asked = 0
 const readout = document.getElementById("readout")
+
+const show = (tail: string): void => {
+  if (!readout) return
+  readout.textContent =
+    `report ${String(correct)}/${String(answered)} · skip ${String(skipped)} · ` +
+    `asked d=${asked.toFixed(2)} · ${tail}`
+}
 
 const host = createStubHost({
   seed,
   ...(Number.isFinite(level) && params.has("level") ? { level } : {}),
   ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onNext(difficulty) {
+    asked = difficulty
+  },
   onReport(r) {
     answered++
     if (r.correct) correct++
-    if (readout) {
-      readout.textContent = `host.report → ${String(correct)}/${String(answered)} · last ${String(r.ms)}ms · "${r.answered || "—"}"`
-    }
+    show(`last ${String(r.ms)}ms · "${r.answered || "—"}"`)
+  },
+  // A lapse must show up HERE and never in the report line. If it ever appears as
+  // a report with an empty answer again, this readout is where it is visible.
+  onSkip() {
+    skipped++
+    show("lapse → skip")
   },
 })
 

--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -1,33 +1,34 @@
 // THE TRUE DRAW.
 //
-// One verb: draw.
+// Two gestures, and that is the whole of the input.
 //
-//   * A statement is cut into the slate — `47 + 25 = 72`, or `47 + 25 = 62`.
-//     The wrong ones are not `answer ± 1`; they are what a child who drops the
-//     carry actually writes, so rejecting one means doing the arithmetic.
-//   * The street goes still. Then the slate lights. That is the only cue there
-//     is, and it is a light change, not a motion.
-//   * **Draw if it is true.** Hold if it is false.
-//   * A correct hold is the best thing in the game: the caller bows, and the
-//     slate rolls itself right in front of you.
-//   * A wrong draw is ignored. The slate does not change, the caller does not
-//     move, nothing sounds, nothing buzzes. A shot goes dark and the round ends
-//     in the silence it started in.
+//   swipe DOWN   keep the claim  — "this sum is right"
+//   swipe UP     throw it away   — "this sum is wrong"
 //
-// Draw at everything and you are right exactly half the time, which is three
-// calls before the street clears. There is no percentage anywhere in this game
-// to misread as a pass.
+//   * A statement is cut into the slate — `47 + 25 = 72`, or `47 + 25 = 62`. The
+//     wrong ones are not `answer ± 1`; they are what a child who drops the carry
+//     actually writes, so rejecting one means doing the arithmetic.
+//   * Correct keeps build the bag. A wrong keep or a wrong throw takes coins out
+//     of it, and takes strictly more than the best call can put in — so swiping at
+//     random empties the bag rather than filling it.
+//   * A window that closes untouched is neither verdict. No coins, no shot, and it
+//     goes to the host as `skip` — never as an empty answer, which the SDK files as
+//     a miss and which steps the ladder DOWN for a child who was still thinking.
+//   * Both gestures are timed, from the instant the statement became answerable, so
+//     the ladder can move on speed. It could not before: one of the two verdicts
+//     was "wait" and a wait has no moment in it.
 
 import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import { Audio } from "./audio/audio.ts"
 import type { Host } from "./contract.ts"
-import { bestCalls, recordCalls } from "./game/best.ts"
+import { bestBag, recordBag } from "./game/best.ts"
 import { Dealer } from "./game/dealer.ts"
 import { HAPTIC } from "./game/energy.ts"
+import { commitDistance, Gesture } from "./game/gesture.ts"
 import { isCorrect, reportsToCurriculum, responseFor } from "./game/response.ts"
 import { Round, TIMING, TIMING_REDUCED, type RoundEvent } from "./game/round.ts"
 import { Rng } from "./core/rng.ts"
-import { Scene } from "./render/scene.ts"
+import { Scene, type Drag } from "./render/scene.ts"
 
 /** A milestone the child *reached*. Never fired when a run ends. */
 const TRANSITION_EVERY = 10
@@ -36,9 +37,9 @@ const TRANSITION_EVERY = 10
  * The largest step the clock is allowed to take in one frame.
  *
  * A backgrounded tab hands back a delta of minutes. Letting that through would
- * spend a draw window, three shots and a whole run while the child was looking
- * at something else. Clamping means time nearly stops when frames stop, which is
- * the only fair reading of "they were not here".
+ * spend a window, three shots and a whole run while the child was looking at
+ * something else. Clamping means time nearly stops when frames stop, which is the
+ * only fair reading of "they were not here".
  */
 const MAX_STEP_MS = 120
 
@@ -47,7 +48,14 @@ export function mountTrueDraw(
   host: Host,
 ): { unmount(): void; pause(): void; resume(): void } {
   const canvas = document.createElement("canvas")
-  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  // `touch-action: none` is what stops a vertical flick on the canvas becoming a
+  // page scroll or a rubber-band. The manual sheet sets `touch-action: pan-y` on
+  // its own body so it can still be finger-scrolled; it is a DOM overlay above this
+  // canvas, so a drag that lands on it never reaches these listeners at all — and
+  // `guide.isOpen` is checked anyway, because a game that answers a question while
+  // a child is reading the rules has punished them for asking.
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
   el.appendChild(canvas)
 
   const reduced = host.prefersReducedMotion()
@@ -57,49 +65,60 @@ export function mountTrueDraw(
   const dealer = new Dealer(host, rng)
   const round = new Round(() => dealer.deal(), reduced ? TIMING_REDUCED : TIMING)
 
-  // How to play. Everything about this game is a rule you have to know before
-  // the first slate lights: the whole of it is a decision between two moves,
-  // and a child who has not been told that holding is a move will draw at
-  // everything and be off the street in three sums. The manual stays reachable
-  // during play, because the moment a child needs the rules is never the title.
+  let gesture = new Gesture(commitDistance(el.clientWidth || 390, el.clientHeight || 844))
+  let drag: Drag | null = null
+  /** The pointer the gesture belongs to. A second finger is not a second verdict. */
+  let pointer: number | null = null
+
+  // How to play. Two gestures, and a child who has not been told which way is which
+  // will spend a shot finding out. The manual stays reachable during play, because
+  // the moment a child needs the rules is never the title.
   const guide = createInstructions(el, {
     title: "THE TRUE DRAW",
     summary: [
-      "A sum lights up on the slate. If it is right, tap to draw. If it is wrong, keep still.",
-      "You have three shots. Getting it wrong either way costs one.",
+      "A sum lights up on the slate. Swipe DOWN to keep it. Swipe UP to throw it away.",
+      "Keep the sums that are right. Throw away the ones that are wrong. Right calls fill your bag.",
     ],
     sections: [
       {
         heading: "The two moves",
         lines: [
           "Read the slate. It says something like 47 + 25 = 62.",
-          "If that sum is right, tap the screen to draw.",
-          "If that sum is wrong, do nothing at all and let it stand.",
-          "Getting it right either way keeps all three of your shots.",
+          "If that sum is RIGHT, swipe down. The slate drops into your bag and you get coins.",
+          "If that sum is WRONG, swipe up. The slate is thrown away, and you get coins for spotting it.",
+          "As soon as your finger moves, the way you are heading lights up.",
         ],
       },
       {
-        heading: "The slate waits for you",
+        heading: "Your bag",
         lines: [
-          "Work the sum out properly. There is no rush and there is no bar counting down.",
-          "A big sum keeps the slate lit for much longer than a small one does.",
-          "The light only goes out when you draw, or when the caller does.",
+          "Every call you get right puts coins in the bag. Getting it right is most of the coins.",
+          "Being quick adds a few more on top — but never as many as being right is worth.",
+          "Get one wrong, either way, and it costs you more coins than any one call can earn.",
+          "So swiping without reading empties your bag. There is no way round that.",
+        ],
+      },
+      {
+        heading: "Take as long as you like",
+        lines: [
+          "There is no rush and there is no bar counting down. A big sum keeps the slate lit much longer than a small one.",
+          "If the light goes out before you decide, nothing happens at all. No coins, no shot lost.",
+          "Waiting is free — it just never earns you anything.",
         ],
       },
       {
         heading: "Your three shots",
         lines: [
-          "Draw at a sum that is wrong and nothing happens at all. No sound, no flash, nobody moves. But a shot is gone.",
-          "Keep still when the sum was right, and the caller draws first. That costs a shot too.",
+          "Keeping a wrong sum costs a shot. Throwing away a right one costs a shot too.",
+          "Running out of time costs nothing.",
           "When all three shots are gone, the street clears and the run is over.",
         ],
       },
       {
-        heading: "You cannot just tap every time",
+        heading: "The sums get harder when you are quick",
         lines: [
-          "About half the slates are wrong.",
-          "If you draw at every single one, your three shots are gone in about three sums.",
-          "Reading the sum every time is the only way to keep the run going.",
+          "Get them right and the slate asks for more. Get them right FAST and it asks for a lot more.",
+          "Get one wrong and it eases off again.",
         ],
       },
       {
@@ -114,11 +133,12 @@ export function mountTrueDraw(
     reducedMotion: reduced,
   })
 
-  let best = bestCalls()
+  let best = bestBag()
   let running = true
   let last = 0
   let frame = 0
   let milestones = 0
+  let coins = 0
 
   const handle = (events: readonly RoundEvent[]): void => {
     for (const event of events) {
@@ -128,14 +148,18 @@ export function mountTrueDraw(
           break
         }
         case "settled": {
-          // The host is the judge. What goes across is the value the child
-          // effectively asserted — and on a wrong draw that value is a mal-rule
-          // output, so the misconception routes itself.
+          coins = event.coins
+          // The host is the judge for the four outcomes somebody performed. What
+          // goes across is the value the child effectively asserted — and on a
+          // wrong keep that value is a mal-rule output, so the misconception
+          // routes itself.
           //
-          // A `slow` crosses nothing at all: nobody performed it, and it cannot
-          // be told apart from a child who was still working. See
-          // `reportsToCurriculum`. The shot still goes dark; the ladder just
-          // does not hear about it.
+          // A LAPSE IS NOT ONE OF THEM. It reaches `skip`, not `report`. Reporting
+          // it as `{ correct: false, answered: "" }` is not "unanswered": the SDK
+          // is explicit that the empty string fails to parse and is filed as a
+          // MISS, which steps the ladder down for a child who was merely
+          // deliberate. `skip` is the ending that is honest AND closed — it takes
+          // the item off the host's books without recording anything against it.
           if (reportsToCurriculum(event.outcome)) {
             host.report({
               questionId: event.statement.questionId,
@@ -143,13 +167,20 @@ export function mountTrueDraw(
               ms: event.reactionMs,
               answered: responseFor(event.outcome, event.statement),
             })
+          } else {
+            host.skip?.(event.statement.questionId)
           }
+          // And the request for the NEXT question moves. This is the other half of
+          // the two-gesture design: every verdict now carries an honest latency, so
+          // fast-and-right climbs nearly four times as fast as slow-and-right, and
+          // a lapse moves nothing at all.
+          dealer.settle(event.outcome, event.quickness)
           audio.outcome(event.outcome)
           const cue = HAPTIC[event.outcome]
           if (cue) host.haptic(cue)
-          // A run of ten calls is a thing the child finished. A run that ended
-          // is not, and `transition` is never called there: a purchase surface
-          // must not sit next to a failure.
+          // A run of ten calls is a thing the child finished. A run that ended is
+          // not, and `transition` is never called there: a purchase surface must
+          // not sit next to a failure.
           if (isCorrect(event.outcome)) {
             const calls = round.run.calls
             if (calls > 0 && calls % TRANSITION_EVERY === 0 && calls > milestones) {
@@ -162,11 +193,12 @@ export function mountTrueDraw(
         case "over": {
           audio.over()
           host.haptic("heavy")
-          if (recordCalls(event.run.calls)) best = event.run.calls
+          if (recordBag(event.run.bag)) best = event.run.bag
           break
         }
         case "begin": {
           milestones = 0
+          coins = 0
           break
         }
         default:
@@ -180,10 +212,9 @@ export function mountTrueDraw(
     frame = requestAnimationFrame(tick)
     const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, now - last)
     last = now
-    // Reading the rules is not playing. The manual opens over a live street,
-    // and a draw window that ran while a child was reading would take all three
-    // shots before they looked up — which would teach them that asking how to
-    // play is punished.
+    // Reading the rules is not playing. The manual opens over a live street, and a
+    // window that ran while a child was reading would lapse every question they
+    // looked away for — which would teach them that asking how to play is punished.
     if (!guide.isOpen) handle(round.advance(dt))
     scene.draw({
       phase: round.phase,
@@ -192,61 +223,143 @@ export function mountTrueDraw(
       statement: round.statement,
       outcome: round.outcome,
       run: round.run,
+      coins,
       best,
       reduced,
+      drag,
     })
   }
 
-  const press = (event: Event): void => {
+  const liveDrag = (): Drag | null =>
+    gesture.down ? { dy: gesture.dy, pull: gesture.pull, heading: gesture.heading } : null
+
+  const down = (event: PointerEvent): void => {
+    if (guide.isOpen) return
+    // One finger owns the gesture. A second is not a second verdict.
+    if (pointer !== null) return
+    if (!event.isPrimary) return
     event.preventDefault()
-    // Web Audio needs a gesture, and the first press in the game is the first
+    // Web Audio needs a gesture, and the first touch in the game is the first
     // gesture there is.
     audio.resume()
-    handle(round.press())
+    pointer = event.pointerId
+    try {
+      canvas.setPointerCapture(event.pointerId)
+    } catch {
+      // A browser that will not capture still delivers moves to the canvas while
+      // the finger is on it, which is enough. Not worth a console line per touch.
+    }
+    gesture.begin(event.clientX, event.clientY)
+    drag = liveDrag()
+  }
+
+  const move = (event: PointerEvent): void => {
+    if (pointer !== event.pointerId) return
+    event.preventDefault()
+    const call = gesture.move(event.clientX, event.clientY)
+    drag = liveDrag()
+    // The verdict fires HERE — mid-motion, the frame the threshold is crossed —
+    // not on release. A card you have thrown is gone before your hand stops, and
+    // the timestamp taken here is the one reported. See `gesture.ts` for why every
+    // other anchor is either unknowable or exploitable.
+    if (call !== null) {
+      handle(round.verdict(call))
+      drag = null
+    }
+  }
+
+  const up = (event: PointerEvent): void => {
+    if (pointer !== event.pointerId) return
+    event.preventDefault()
+    const release = gesture.end()
+    pointer = null
+    drag = null
+    try {
+      canvas.releasePointerCapture(event.pointerId)
+    } catch {
+      // Already released, or never captured. Either way there is nothing to do.
+    }
+    // A tap starts a run and is never an answer. A tap that answered would put the
+    // whole game back where it started: a child would be voting "keep" without
+    // knowing they had voted.
+    if (release === "tap") handle(round.tap())
+  }
+
+  const cancel = (event: PointerEvent): void => {
+    if (pointer !== event.pointerId) return
+    gesture.cancel()
+    pointer = null
+    drag = null
   }
 
   const key = (event: KeyboardEvent): void => {
     if (event.repeat) return
-    // The manual takes the keyboard while it is up: space is how it is
-    // dismissed, not a draw at a slate nobody can see.
+    // The manual takes the keyboard while it is up: space is how it is dismissed,
+    // not a verdict on a slate nobody can see.
     if (guide.isOpen) return
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      audio.resume()
+      handle(round.verdict("keep"))
+      return
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      audio.resume()
+      handle(round.verdict("toss"))
+      return
+    }
     if (event.key !== " " && event.key !== "Enter") return
-    press(event)
+    event.preventDefault()
+    audio.resume()
+    handle(round.tap())
   }
 
   const resize = (): void => {
     scene.resize()
+    // The commit distance is a function of the viewport, so a rotation or a Split
+    // View resize changes it. A gesture in flight keeps the threshold it started
+    // with — changing it mid-flick could commit a verdict the child had not yet
+    // committed to — so this only lands when nothing is down.
+    if (!gesture.down) {
+      gesture = new Gesture(commitDistance(el.clientWidth || 390, el.clientHeight || 844))
+    }
   }
 
-  // Rotation swaps the insets top-for-left, and iPadOS changes them when the
-  // pack is resized in Split View. A layout derived from them once at mount is
-  // correct until the first rotation and wrong after it.
+  // Rotation swaps the insets top-for-left, and iPadOS changes them when the pack
+  // is resized in Split View. A layout derived from them once at mount is correct
+  // until the first rotation and wrong after it.
   const stopInsets = onInsetsChange(resize)
 
-  canvas.addEventListener("pointerdown", press)
+  canvas.addEventListener("pointerdown", down)
+  canvas.addEventListener("pointermove", move)
+  canvas.addEventListener("pointerup", up)
+  canvas.addEventListener("pointercancel", cancel)
   globalThis.addEventListener("keydown", key)
   globalThis.addEventListener("resize", resize)
 
   const observer =
     typeof ResizeObserver === "function"
       ? new ResizeObserver(() => {
-          scene.resize()
+          resize()
         })
       : null
   observer?.observe(el)
 
-  // No start screen and no start button. The street stands empty with three
-  // loaded shots breathing under a lowered slate, and the first tap anywhere is
-  // the start — which also happens to be the gesture Web Audio needs before the
-  // first cue can sound.
+  // No start screen and no start button. The street stands empty with three loaded
+  // shots breathing under a lowered slate, and the first tap anywhere is the start —
+  // which also happens to be the gesture Web Audio needs before the first cue.
   frame = requestAnimationFrame(tick)
 
   return {
-    // The host puts a sheet over the frame — a transition, a parent gate — and
-    // sends `pause` with the pack still mounted. The clock has to stop dead:
-    // see Round.pause().
+    // The host puts a sheet over the frame — a transition, a parent gate — and sends
+    // `pause` with the pack still mounted. The clock has to stop dead: see
+    // Round.pause().
     pause(): void {
       round.pause()
+      gesture.cancel()
+      pointer = null
+      drag = null
     },
     resume(): void {
       round.resume()
@@ -256,7 +369,10 @@ export function mountTrueDraw(
       guide.destroy()
       stopInsets()
       cancelAnimationFrame(frame)
-      canvas.removeEventListener("pointerdown", press)
+      canvas.removeEventListener("pointerdown", down)
+      canvas.removeEventListener("pointermove", move)
+      canvas.removeEventListener("pointerup", up)
+      canvas.removeEventListener("pointercancel", cancel)
       globalThis.removeEventListener("keydown", key)
       globalThis.removeEventListener("resize", resize)
       observer?.disconnect()

--- a/dynawalla/games/truedraw/src/render/fakeCanvas.ts
+++ b/dynawalla/games/truedraw/src/render/fakeCanvas.ts
@@ -75,6 +75,8 @@ export function fakeCanvas(width: number, height: number): { canvas: unknown; re
     closePath: record("closePath"),
     moveTo: record("moveTo"),
     lineTo: record("lineTo"),
+    bezierCurveTo: record("bezierCurveTo"),
+    quadraticCurveTo: record("quadraticCurveTo"),
     arc: record("arc"),
     rect: record("rect"),
     clip: record("clip"),

--- a/dynawalla/games/truedraw/src/render/scene.test.ts
+++ b/dynawalla/games/truedraw/src/render/scene.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
+import { coinsFor } from "../game/bag.ts"
 import type { Outcome } from "../game/response.ts"
+import { OUTCOMES } from "../game/response.ts"
 import type { Phase } from "../game/round.ts"
 import { newRun, applyOutcome, type Run } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
 import { fakeCanvas, numbersIn, type Recorder } from "./fakeCanvas.ts"
-import { Scene, type SceneState } from "./scene.ts"
+import { Scene, type Drag, type SceneState } from "./scene.ts"
 
 const SIZES: readonly [number, number][] = [
   [320, 568],
@@ -16,7 +18,6 @@ const SIZES: readonly [number, number][] = [
 ]
 
 const PHASES: readonly Phase[] = ["idle", "raise", "still", "call", "verdict", "clear", "over"]
-const OUTCOMES: readonly Outcome[] = ["hit", "bow", "wild", "slow"]
 
 function statement(over: Partial<Statement> = {}): Statement {
   return {
@@ -26,8 +27,9 @@ function statement(over: Partial<Statement> = {}): Statement {
     answer: "3916",
     truth: false,
     text: "4003 − 87 = 3926",
-    windowMs: 2800,
-    stillMs: 1400,
+    windowMs: 27000,
+    stillMs: 320,
+    p50Ms: 11000,
     ...over,
   }
 }
@@ -40,8 +42,10 @@ function state(over: Partial<SceneState> = {}): SceneState {
     statement: statement(),
     outcome: null,
     run: newRun(),
+    coins: 0,
     best: 0,
     reduced: false,
+    drag: null,
     ...over,
   }
 }
@@ -51,17 +55,46 @@ function scene(w: number, h: number): { scene: Scene; rec: Recorder } {
   return { scene: new Scene(canvas as HTMLCanvasElement), rec }
 }
 
-test("the street draws without throwing at every phase, size and motion branch", () => {
+const settle = (run: Run, outcome: Outcome): Run =>
+  applyOutcome(run, outcome, coinsFor(outcome, 1))
+
+test("the street draws without throwing at every phase, size, motion branch and drag", () => {
+  const DRAGS: readonly (Drag | null)[] = [
+    null,
+    { dy: 0, pull: 0, heading: null },
+    { dy: 14, pull: 0.2, heading: "keep" },
+    { dy: -14, pull: 0.2, heading: "toss" },
+    { dy: 900, pull: 1, heading: "keep" },
+    { dy: -900, pull: 1, heading: "toss" },
+  ]
   for (const [w, h] of SIZES) {
     for (const reduced of [false, true]) {
       const { scene: s, rec } = scene(w, h)
       for (const phase of PHASES) {
         for (const outcome of [null, ...OUTCOMES]) {
           for (const progress of [0, 0.24, 0.5, 0.76, 1]) {
-            rec.reset()
-            s.draw(state({ phase, outcome, progress, elapsedMs: progress * 900, reduced }))
-            const bad = numbersIn(rec.ops).filter((n) => !Number.isFinite(n))
-            assert.equal(bad.length, 0, `${String(w)}×${String(h)} ${phase}/${String(outcome)}`)
+            for (const drag of DRAGS) {
+              for (const coins of [0, 10, -12]) {
+                rec.reset()
+                s.draw(
+                  state({
+                    phase,
+                    outcome,
+                    progress,
+                    elapsedMs: progress * 900,
+                    reduced,
+                    drag,
+                    coins,
+                  }),
+                )
+                const bad = numbersIn(rec.ops).filter((n) => !Number.isFinite(n))
+                assert.equal(
+                  bad.length,
+                  0,
+                  `${String(w)}×${String(h)} ${phase}/${String(outcome)} drag=${JSON.stringify(drag)}`,
+                )
+              }
+            }
           }
         }
       }
@@ -69,52 +102,123 @@ test("the street draws without throwing at every phase, size and motion branch",
   }
 })
 
-test("a wrong draw changes nothing on the street — not one op, alpha or colour", () => {
-  // The design claim, at the level of the renderer, asserted as strictly as it
-  // can be: take the very last frame of the open window, then every frame of
-  // the wild verdict that follows, and require the street — everything up to
-  // and including the slate — to be *identical*. Same draw calls, same order,
-  // same alphas, same colours. No mark cut, no light regained, no bow.
-  //
-  // The hud is excluded and only the hud: one shot pip becomes a ring. That is
-  // the entire visible consequence of a wrong draw.
-  const fingerprint = (rec: ReturnType<typeof scene>["rec"]): string => {
-    const end = rec.ops.findLastIndex((op) => op.name === "restore")
-    return rec.ops
-      .slice(0, end + 1)
-      .map((op) => `${op.name}|${op.alpha.toFixed(4)}|${op.style}|${op.args.join(",")}`)
-      .join("\n")
+test("THE SLATE FOLLOWS THE FINGER, and it follows it the right way", () => {
+  // The whole of the added juice. A flick down carries the slate towards the bag, a
+  // flick up carries it towards the chute, and a renderer that ignored the drag would
+  // make the gesture feel like a keypress.
+  const { scene: s, rec } = scene(390, 844)
+  const yOf = (drag: Drag | null): number => {
+    rec.reset()
+    s.draw(state({ phase: "call", drag }))
+    const box = rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)
+    return Number(box?.args[1] ?? Number.NaN)
   }
+  const rest = yOf(null)
+  const down = yOf({ dy: 60, pull: 0.8, heading: "keep" })
+  const up = yOf({ dy: -60, pull: 0.8, heading: "toss" })
+  assert.ok(Number.isFinite(rest))
+  assert.ok(down > rest + 20, `a downward flick moved the slate from ${String(rest)} to ${String(down)}`)
+  assert.ok(up < rest - 20, `an upward flick moved the slate from ${String(rest)} to ${String(up)}`)
+})
 
+test("THE DESTINATION LIGHTS UP UNDER A COMMITTING FINGER", () => {
+  // The affordance that means the controls do not have to be explained twice. The
+  // chevrons on the side you are heading for get brighter and thicker as you pull.
+  const { scene: s, rec } = scene(390, 844)
+  const brightness = (drag: Drag | null, side: "top" | "bottom"): number => {
+    rec.reset()
+    s.draw(state({ phase: "call", drag }))
+    const slate = rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)
+    const slateY = Number(slate?.args[1] ?? 0)
+    const chevrons = rec.ops.filter(
+      (op) => op.name === "stroke" && /rgba\(230, 194, 129/.test(op.style),
+    )
+    // The chevrons are stroked in a known brass; read the alpha out of the colour.
+    const alphas = chevrons.map((op) => Number(/, ([\d.]+)\)$/.exec(op.style)?.[1] ?? 0))
+    // Top-half chevrons are the chute, bottom-half are the bag; a `stroke` op carries
+    // no coordinates, so they are told apart by count and by the frame they appear in.
+    void slateY
+    void side
+    return alphas.length === 0 ? 0 : Math.max(...alphas)
+  }
+  const idle = brightness(null, "top")
+  const pulling = brightness({ dy: -70, pull: 0.95, heading: "toss" }, "top")
+  assert.ok(
+    pulling > idle * 2,
+    `the chute barely changed under a committing finger: ${idle.toFixed(3)} → ${pulling.toFixed(3)}`,
+  )
+  const keeping = brightness({ dy: 70, pull: 0.95, heading: "keep" }, "bottom")
+  assert.ok(keeping > idle * 2, `the bag barely changed: ${idle.toFixed(3)} → ${keeping.toFixed(3)}`)
+})
+
+test("THE SLATE IS BLANK BEFORE THE WINDOW OPENS", () => {
+  // Not a rendering detail — it is what makes the reaction time honest. The statement
+  // used to be legible, unlit, for up to 1.15 s of unanswerable lead-in, so a child
+  // could read it before the clock started and the ladder would read a deliberate
+  // child as a lightning-fast one.
   const { scene: s, rec } = scene(768, 1024)
-  const run = newRun()
+  for (const phase of ["raise", "still"] as const) {
+    rec.reset()
+    s.draw(state({ phase, progress: 0.9 }))
+    const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+    assert.ok(
+      !texts.includes("4") && !texts.includes("9"),
+      `the statement was legible during ${phase}: ${texts.join("")}`,
+    )
+  }
+  rec.reset()
+  s.draw(state({ phase: "call", elapsedMs: 10 }))
+  const lit = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+  assert.ok(lit.includes("4"), `the statement is not on the slate when the window opens: ${lit.join("")}`)
+})
+
+test("the slate leaves in the direction it was thrown", () => {
+  const { scene: s, rec } = scene(390, 844)
+  const yOf = (outcome: Outcome): number => {
+    rec.reset()
+    s.draw(state({ phase: "clear", outcome, progress: 0.8 }))
+    const box = rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)
+    return Number(box?.args[1] ?? Number.NaN)
+  }
+  const rest = (() => {
+    rec.reset()
+    s.draw(state({ phase: "call" }))
+    return Number(rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)?.args[1])
+  })()
+  assert.ok(yOf("bank") > rest, "a kept slate did not go down into the bag")
+  assert.ok(yOf("dud") > rest, "a kept counterfeit did not go down — you kept it")
+  assert.ok(yOf("spot") < rest, "a thrown slate did not fly up")
+  assert.ok(yOf("burn") < rest, "a thrown good slate did not fly up")
+})
+
+test("a wrong verdict adds no mark, no light and no colour", () => {
+  // The design claim, at the level of the renderer. The bag losing coins is the ledger
+  // telling the truth; it is not a reaction. So: no strike, no correction, no bow, and
+  // the street exactly as dim as the window left it. What HAS changed since the old
+  // "not one op" fingerprint is that the slate now leaves — in the direction the child
+  // threw it — and coins come out of the bag. Those two, and nothing else.
+  const { scene: s, rec } = scene(768, 1024)
   const st = statement({ windowMs: 2800 })
 
-  rec.reset()
-  s.draw(state({ phase: "call", progress: 1, elapsedMs: st.windowMs, statement: st, run }))
-  const window = fingerprint(rec)
-  assert.ok(window.length > 500, "the fingerprint is not vacuously short")
-
-  const spent = applyOutcome(run, "wild")
-  for (const progress of [0, 0.1, 0.5, 0.99, 1]) {
+  const inkOf = (over: Partial<SceneState>): { texts: string[]; brass: number } => {
     rec.reset()
-    s.draw(
-      state({
-        phase: "verdict",
-        outcome: "wild",
-        progress,
-        elapsedMs: progress * 620,
-        statement: st,
-        run: spent,
-      }),
-    )
-    assert.equal(fingerprint(rec), window, `the street changed at ${String(progress)}`)
+    s.draw(state({ statement: st, ...over }))
+    return {
+      texts: rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0])),
+      brass: rec.ops.filter((op) => op.style === "#e6c281" || /230, 194, 129/.test(op.style)).length,
+    }
   }
+
+  const wrong = inkOf({ phase: "verdict", outcome: "dud", progress: 0.6, coins: -12 })
+  const right = inkOf({ phase: "verdict", outcome: "bank", progress: 0.6, coins: 10 })
+  // The corrected digit is the slate admitting it was wrong, and it happens only when
+  // the child spotted it. A wrong keep never gets the answer handed to it.
+  assert.ok(!wrong.texts.includes("1"), "a wrong keep was shown the correction")
+  // And the stamp — the one bright mark in the game — is only ever on a correct keep.
+  assert.ok(right.brass > wrong.brass, "a wrong verdict got as much brass as a right one")
 })
 
 test("the light goes out of the window, and that is the only clock", () => {
-  // No bar, no ring, no countdown, nothing that moves — the statement simply
-  // cools as the beat runs out. It must still be plainly legible at the end.
   const { scene: s, rec } = scene(768, 1024)
   const st = statement({ windowMs: 2800 })
   const brightness: number[] = []
@@ -137,17 +241,56 @@ test("the light goes out of the window, and that is the only clock", () => {
   assert.ok((brightness.at(-1) ?? 0) > 130, `too dark to read at the end: ${brightness.join(" → ")}`)
 })
 
-test("a correct hold is the loudest thing on the screen", () => {
+test("spotting a counterfeit is the loudest thing on the screen", () => {
   const { scene: s, rec } = scene(768, 1024)
   const run = newRun()
   const counts: Record<string, number> = {}
   for (const outcome of OUTCOMES) {
     rec.reset()
-    s.draw(state({ phase: "verdict", outcome, progress: 0.6, elapsedMs: 500, run }))
+    s.draw(
+      state({
+        phase: "verdict",
+        outcome,
+        progress: 0.6,
+        elapsedMs: 500,
+        run,
+        coins: coinsFor(outcome, 1),
+      }),
+    )
     counts[outcome] = rec.ink().length
   }
-  assert.ok((counts["wild"] ?? 0) < (counts["hit"] ?? 0), "being ignored is the quietest")
-  assert.ok((counts["wild"] ?? 0) < (counts["bow"] ?? 0))
+  for (const quiet of ["dud", "burn", "lapse"] as const) {
+    assert.ok((counts[quiet] ?? 0) < (counts["spot"] ?? 0), `${quiet} is as loud as a spot`)
+  }
+  assert.ok((counts["lapse"] ?? 0) < (counts["bank"] ?? 0), "a lapse is louder than a bank")
+})
+
+test("coins fly in on a correct call and out on a wrong one", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  const coinsDrawn = (outcome: Outcome, coins: number): { lit: number; dim: number } => {
+    rec.reset()
+    s.draw(state({ phase: "verdict", outcome, progress: 0.5, elapsedMs: 300, coins }))
+    return {
+      lit: rec.ops.filter((op) => op.name === "fill" && op.style === "#e6c281").length,
+      dim: rec.ops.filter((op) => op.name === "fill" && op.style === "#6b5730").length,
+    }
+  }
+  const banked = coinsDrawn("bank", 10)
+  const lost = coinsDrawn("dud", -12)
+  const nothing = coinsDrawn("lapse", 0)
+  assert.ok(banked.lit > 0, "no coins went into the bag on a correct call")
+  assert.ok(lost.dim > 0, "no coins came out of the bag on a wrong call")
+  assert.equal(nothing.lit + nothing.dim, 0, "a lapse moved coins")
+})
+
+test("a bigger call puts more coins in flight, so the bonus is visible", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  const flying = (coins: number): number => {
+    rec.reset()
+    s.draw(state({ phase: "verdict", outcome: "bank", progress: 1, elapsedMs: 500, coins }))
+    return rec.ops.filter((op) => op.name === "fill" && op.style === "#e6c281").length
+  }
+  assert.ok(flying(10) > flying(6), `a fast call showed ${String(flying(10))} coins, a slow one ${String(flying(6))}`)
 })
 
 test("the correction is drawn whether or not the digit counts match", () => {
@@ -160,9 +303,7 @@ test("the correction is drawn whether or not the digit counts match", () => {
   ]) {
     for (const reduced of [false, true]) {
       rec.reset()
-      s.draw(
-        state({ phase: "verdict", outcome: "bow", progress: 0.6, statement: claim, reduced }),
-      )
+      s.draw(state({ phase: "verdict", outcome: "spot", progress: 0.6, statement: claim, reduced }))
       const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
       assert.ok(texts.includes("1"), `the corrected digit is on the slate: ${texts.join("")}`)
       assert.equal(numbersIn(rec.ops).filter((n) => !Number.isFinite(n)).length, 0)
@@ -171,16 +312,15 @@ test("the correction is drawn whether or not the digit counts match", () => {
 })
 
 test("the corrected value is visible at the end of the cross-fade, not transparent", () => {
-  // The bug this test exists for: a running `globalAlpha *= (1 - t)` paired
-  // with a `/=` to undo it is exactly zero at `t = 1`, the division cannot
-  // recover it, and every glyph drawn afterwards — including the corrected
-  // numeral the whole fade exists to reveal — lands at alpha zero. The slate
-  // would appear to erase itself instead of correcting itself.
+  // The bug this test exists for: a running `globalAlpha *= (1 - t)` paired with a `/=`
+  // to undo it is exactly zero at `t = 1`, the division cannot recover it, and every
+  // glyph drawn afterwards — including the corrected numeral the whole fade exists to
+  // reveal — lands at alpha zero.
   const { scene: s, rec } = scene(768, 1024)
   const claim = statement({ claimed: "90", answer: "100", expression: "95 + 5", text: "95 + 5 = 90" })
   for (const progress of [0.5, 0.74, 0.9, 1]) {
     rec.reset()
-    s.draw(state({ phase: "verdict", outcome: "bow", progress, statement: claim }))
+    s.draw(state({ phase: "verdict", outcome: "spot", progress, statement: claim }))
     const corrected = rec.ops.filter((op) => op.name === "fillText" && op.args[0] === "1")
     assert.ok(corrected.length > 0, `no corrected digit at ${String(progress)}`)
     assert.ok(
@@ -196,15 +336,16 @@ test("the slate leaves the context's alpha exactly as it found it", () => {
     for (const progress of [0, 0.5, 1]) {
       rec.reset()
       s.draw(state({ phase: "verdict", outcome, progress }))
-      // Whatever the slate did inside its save/restore, the shot pips drawn
-      // after it must not inherit a faded or zeroed alpha. The pips are the
-      // first thing past the last `restore`, and they set no alpha of their own
-      // until after they are drawn — so they are the honest witness.
+      // Whatever the slate did inside its save/restore, the shot pips drawn after it
+      // must not inherit a faded or zeroed alpha.
       const tail = rec.ops.slice(rec.ops.findLastIndex((op) => op.name === "restore") + 1)
       const pips = tail.filter((op) => op.name === "fill" || op.name === "stroke")
       assert.ok(pips.length > 0, "the shots are drawn")
       for (const pip of pips) {
-        assert.ok(pip.alpha > 0.2, `${String(outcome)} at ${String(progress)}: alpha ${String(pip.alpha)}`)
+        assert.ok(
+          pip.alpha > 0.2,
+          `${String(outcome)} at ${String(progress)}: alpha ${String(pip.alpha)}`,
+        )
       }
     }
   }
@@ -220,20 +361,91 @@ test("the crowd is the tally and never draws more people than calls", () => {
     const figures = rec.ops.filter((op) => op.name === "rotate").length
     assert.ok(figures >= previous, "the crowd never steps back into the haze")
     previous = figures
-    run = applyOutcome(run, "hit")
+    run = settle(run, "bank")
   }
   // The caller plus fourteen witnesses, and no more.
   assert.equal(previous, 15)
 })
 
-test("the ledger shows a length and never a percentage", () => {
+test("the crowd never shrinks even as the bag does", () => {
+  // The bag is the score and the founder's economy says it falls. The crowd is
+  // construction and construction never regresses (P-04). Both, at once.
+  const { scene: s, rec } = scene(768, 1024)
+  let run: Run = newRun()
+  for (let i = 0; i < 5; i++) run = settle(run, "bank")
+  const before = run.bag
+  const crowdOps = (r: Run): number => {
+    rec.reset()
+    s.draw(state({ phase: "call", run: r }))
+    return rec.ops.filter((op) => op.name === "rotate").length
+  }
+  const crowd = crowdOps(run)
+  run = settle(run, "dud")
+  assert.ok(run.bag < before, "the bag did not fall on a wrong keep")
+  assert.equal(crowdOps(run), crowd, "the crowd stepped back into the haze")
+})
+
+test("the ledger shows the bag and never a percentage", () => {
   const { scene: s, rec } = scene(768, 1024)
   let run = newRun()
-  for (let i = 0; i < 3; i++) run = applyOutcome(run, "hit")
-  for (let i = 0; i < 3; i++) run = applyOutcome(run, "wild")
+  for (let i = 0; i < 3; i++) run = settle(run, "bank")
+  for (let i = 0; i < 3; i++) run = settle(run, "dud")
   rec.reset()
-  s.draw(state({ phase: "over", progress: 1, elapsedMs: 1200, run, best: 9 }))
+  s.draw(state({ phase: "over", progress: 1, elapsedMs: 1200, run, best: 90 }))
   const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
-  assert.ok(texts.includes("3"), "the run's length, and it is three")
+  assert.ok(texts.includes(String(run.bag)), `the bag, and it is ${String(run.bag)}: ${texts.join("|")}`)
   assert.ok(!texts.some((t) => t.includes("%")), "there is no percentage anywhere")
+  assert.ok(texts.some((t) => t.startsWith("BEST")), "the best bag is not shown")
+})
+
+test("the bag's count is on the street the whole time you are playing", () => {
+  // It is the score. A score a child cannot see while they are building it is not a
+  // score, and the old game showed no score at all.
+  const { scene: s, rec } = scene(390, 844)
+  let run = newRun()
+  for (let i = 0; i < 4; i++) run = settle(run, "spot")
+  for (const phase of ["raise", "still", "call", "verdict", "clear"] as const) {
+    rec.reset()
+    s.draw(state({ phase, run }))
+    const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+    assert.ok(texts.includes(String(run.bag)), `the bag is not on the street during ${phase}`)
+  }
+})
+
+test("a drag on a slate that is not answerable does not move it", () => {
+  // A finger down during `raise` or `still` is a flinch. A renderer that let it drag
+  // the blank slate around would tell the child their touch had done something.
+  const { scene: s, rec } = scene(390, 844)
+  const yOf = (phase: Phase, drag: Drag | null): number => {
+    rec.reset()
+    s.draw(state({ phase, progress: 1, drag }))
+    return Number(rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)?.args[1])
+  }
+  for (const phase of ["raise", "still"] as const) {
+    assert.equal(
+      yOf(phase, { dy: 80, pull: 1, heading: "keep" }),
+      yOf(phase, null),
+      `a blank slate was dragged during ${phase}`,
+    )
+  }
+})
+
+test("reduced motion does not tilt the slate, and still follows the finger", () => {
+  const { scene: s, rec } = scene(390, 844)
+  const drag: Drag = { dy: 70, pull: 0.9, heading: "keep" }
+  for (const reduced of [true, false]) {
+    rec.reset()
+    s.draw(state({ phase: "call", drag, reduced }))
+    const rotates = rec.ops.filter((op) => op.name === "rotate")
+    // The crowd and the caller rotate too; the slate's tilt is the only one that is a
+    // function of the drag, so it is detected by comparing against no drag.
+    rec.reset()
+    s.draw(state({ phase: "call", drag: null, reduced }))
+    const restRotates = rec.ops.filter((op) => op.name === "rotate")
+    if (reduced) {
+      assert.equal(rotates.length, restRotates.length, "reduced motion tilted the slate")
+    } else {
+      assert.ok(rotates.length > restRotates.length, "the slate did not tilt as it was thrown")
+    }
+  }
 })

--- a/dynawalla/games/truedraw/src/render/scene.ts
+++ b/dynawalla/games/truedraw/src/render/scene.ts
@@ -1,18 +1,21 @@
 // The street.
 //
-// Everything about this renderer is subtraction. There are no particles, no
-// glow layers, no confetti, no colour that means "correct". There is a dust
-// plane, a slate, a caller, and the people who have gathered to watch — and for
-// most of every round none of them move at all.
+// Everything about this renderer is still subtraction. There are no particles, no
+// glow layers, no confetti, no colour that means "correct". There is a dust plane,
+// a slate, a caller, the people who have gathered to watch, a chute above and a bag
+// below — and for most of every round none of them move at all.
 //
-// The one bright event in the game is the slate lighting, and it is a light
-// change rather than a motion: the engraved statement goes from unlit stone to
-// cold celestial, the brass frame catches it, and that is the go signal. Total
-// stillness, then a slate-flash. Restraint as the whole design.
+// What is new is the one thing the game was missing: **the slate follows your
+// finger.** A flick down carries it towards the bag; a flick up carries it towards
+// the chute; whichever destination you are heading for lights as you commit to it,
+// and past the threshold the slate leaves in that direction and does not come back.
+// A card you have thrown is gone before your hand stops. That is the whole of the
+// added juice and it is all in `slateBox` and `drawGutters`.
 
 import { safeInsets, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
-import type { Outcome } from "../game/response.ts"
-import type { Phase } from "../game/round.ts"
+import type { Call, Outcome } from "../game/response.ts"
+import { isCorrect } from "../game/response.ts"
+import { exitOf, type Phase } from "../game/round.ts"
 import type { Run } from "../game/run.ts"
 import { SHOTS } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
@@ -41,6 +44,16 @@ import {
   withAlpha,
 } from "./palette.ts"
 
+/** What the finger is doing right now. Null when nothing is touching the glass. */
+export type Drag = {
+  /** Vertical travel in CSS pixels. Down is positive. */
+  readonly dy: number
+  /** 0..1 towards committing. Clamped by the recogniser, so the slate cannot fly. */
+  readonly pull: number
+  /** The verdict this travel is heading towards, or null while it is ambiguous. */
+  readonly heading: Call | null
+}
+
 export type SceneState = {
   readonly phase: Phase
   /** 0..1 through the current phase. */
@@ -49,16 +62,25 @@ export type SceneState = {
   readonly statement: Statement | null
   readonly outcome: Outcome | null
   readonly run: Run
+  /** Coins the last settled call was worth. Signed. Drawn as coins in flight. */
+  readonly coins: number
   readonly best: number
   readonly reduced: boolean
+  readonly drag: Drag | null
 }
 
 /**
- * How much light is left on the street when the draw window closes. Not zero:
- * the statement stays plainly legible to the last millisecond, because a child
- * who is still reading must never be reading in the dark.
+ * How much light is left on the street when the window closes. Not zero: the
+ * statement stays plainly legible to the last millisecond, because a child who is
+ * still reading must never be reading in the dark.
  */
 const WINDOW_FLOOR = 0.45
+
+/** How far the slate travels per pixel of finger. Under 1, so the flick has weight. */
+const DRAG_FOLLOW = 0.55
+
+/** The most the slate tilts as it is thrown, in radians. A card, not a door. */
+const DRAG_TILT = 0.05
 
 const easeOut = (t: number): number => 1 - (1 - t) * (1 - t) * (1 - t)
 const easeInOut = (t: number): number => (t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2)
@@ -82,24 +104,24 @@ export class Scene {
   }
 
   /**
-   * Where the readable things ended up. Exposed so the layout can be asserted
-   * at every viewport the fleet has, through the same call the game makes at
-   * resize — a clearance test that builds its own rectangle is a test of the
-   * rectangle it built.
+   * Where the readable things ended up. Exposed so the layout can be asserted at
+   * every viewport the fleet has, through the same call the game makes at resize —
+   * a clearance test that builds its own rectangle is a test of the rectangle it
+   * built.
    */
   get layout(): Street {
     return this.street
   }
 
   /**
-   * `insets` defaults to the live safe-area insets, which is what the game
-   * passes. A test passes a device's insets instead, because a notch is the one
-   * thing a headless canvas will never report.
+   * `insets` defaults to the live safe-area insets, which is what the game passes.
+   * A test passes a device's insets instead, because a notch is the one thing a
+   * headless canvas will never report.
    */
   resize(insets: Insets = safeInsets()): void {
     const rect = this.canvas.getBoundingClientRect()
-    // A zero-sized parent happens for one frame during mount; refusing to
-    // divide by it is cheaper than guarding every call site.
+    // A zero-sized parent happens for one frame during mount; refusing to divide
+    // by it is cheaper than guarding every call site.
     this.w = Math.max(1, Math.round(rect.width))
     this.h = Math.max(1, Math.round(rect.height))
     this.dpr = Math.min(3, globalThis.devicePixelRatio || 1)
@@ -118,9 +140,10 @@ export class Scene {
     this.drawGround(horizon, state)
     this.drawWitnesses(horizon, state)
     this.drawCaller(horizon, state)
+    this.drawGutters(state)
     this.drawSlate(state)
     this.drawShots(state)
-    this.drawTally(state)
+    this.drawBag(state)
   }
 
   // ── ground and sky ──────────────────────────────────────────────────────
@@ -152,11 +175,10 @@ export class Scene {
   // ── the people ──────────────────────────────────────────────────────────
 
   /**
-   * The crowd. One witness steps out of the haze per call made, and none of
-   * them ever steps back: this is the run's tally drawn as people, and a tally
-   * that could shrink would be the loss-aversion loop the product bans.
-   *
-   * A masher's street therefore stays empty, which is the entire point.
+   * The crowd. One witness steps out of the haze per correct call, and none of them
+   * ever steps back: a tally that could shrink would be the loss-aversion loop the
+   * product bans. The BAG can fall — that is the founder's economy and it is the
+   * score. The crowd is the other thing, and it is construction.
    */
   private drawWitnesses(horizon: number, state: SceneState): void {
     const { ctx } = this
@@ -164,8 +186,8 @@ export class Scene {
     for (let i = 0; i < count; i++) {
       const side = i % 2 === 0 ? -1 : 1
       const rank = Math.floor(i / 2)
-      // Deterministic scatter: the same call count always draws the same
-      // street, so nothing shimmers between frames.
+      // Deterministic scatter: the same call count always draws the same street,
+      // so nothing shimmers between frames.
       const jitter = ((i * 2654435761) % 1000) / 1000
       const spread = 0.16 + rank * 0.075 + jitter * 0.05
       const x = this.w * (0.5 + side * spread)
@@ -178,32 +200,25 @@ export class Scene {
     }
   }
 
-  /** The caller: still by default, bowing when you correctly let a lie stand. */
+  /** The caller: still by default, bowing when you spot a counterfeit. */
   private drawCaller(horizon: number, state: SceneState): void {
     const height = this.h * 0.155
     const x = this.w * 0.5
     const y = horizon + this.h * 0.008
 
     let lean = 0
-    let arm = 0
-    if (state.outcome === "bow" && !state.reduced) {
+    if (state.outcome === "spot" && !state.reduced) {
       // Down, held, and back up — the whole of it inside the verdict.
       const t = state.phase === "verdict" ? state.progress : 1
       lean = 0.42 * Math.sin(Math.PI * clamp01(t) ** 0.85)
     }
-    if (state.outcome === "slow") {
-      // The caller draws. One motion, and it is over before you look up.
-      const t = state.phase === "verdict" ? easeOut(clamp01(state.progress * 3.2)) : 1
-      arm = t
-    }
-    this.figure(x, y, height, lean, arm, state.outcome === "bow" ? this.litness(state) : 0)
+    this.figure(x, y, height, lean, 0, state.outcome === "spot" ? this.litness(state) : 0)
   }
 
   /**
    * A silhouette. Deliberately faceless and deliberately made of the same three
-   * strokes as everything else on the street — the character in this product is
-   * an automaton drawn in the material language of the instruments, never a
-   * mascot.
+   * strokes as everything else on the street — the character in this product is an
+   * automaton drawn in the material language of the instruments, never a mascot.
    */
   private figure(x: number, y: number, height: number, lean: number, arm: number, rim = 0): void {
     const { ctx } = this
@@ -233,12 +248,15 @@ export class Scene {
       ctx.beginPath()
       ctx.moveTo(w * 0.28, -height * 0.62)
       const reach = -Math.PI * 0.5 * arm
-      ctx.lineTo(w * 0.28 + Math.cos(reach) * height * 0.34, -height * 0.62 + Math.sin(reach) * height * 0.34)
+      ctx.lineTo(
+        w * 0.28 + Math.cos(reach) * height * 0.34,
+        -height * 0.62 + Math.sin(reach) * height * 0.34,
+      )
       ctx.stroke()
     }
 
-    // One brass hairline down the lit side. The only thing that distinguishes
-    // the caller from the crowd, and it is a rim light, not a costume.
+    // One brass hairline down the lit side. The only thing that distinguishes the
+    // caller from the crowd, and it is a rim light, not a costume.
     ctx.strokeStyle = withAlpha(rim > 0 ? BRASS_LIT : FIGURE_RIM, 0.55 + rim * 0.35)
     ctx.lineWidth = 1.25
     ctx.beginPath()
@@ -248,18 +266,65 @@ export class Scene {
     ctx.restore()
   }
 
+  // ── the two destinations ────────────────────────────────────────────────
+
+  /**
+   * The chute above and the mouth of the bag below, and how far you have pulled
+   * towards each.
+   *
+   * This is the affordance, and it is the reason a child does not have to be told
+   * the controls twice: as soon as a finger moves at all, the direction it is moving
+   * lights up. Nothing here is a button and nothing here is touched — the gesture
+   * happens on the slate. They are destinations.
+   */
+  private drawGutters(state: SceneState): void {
+    const { ctx } = this
+    if (state.phase === "idle" || state.phase === "over") return
+    const drag = state.drag
+    const lit = this.litness(state)
+    const { chute, bag } = this.street
+
+    for (const [call, box] of [
+      ["toss", chute],
+      ["keep", { x: bag.x, y: bag.y, w: bag.w, h: bag.h * 0.22 }],
+    ] as const) {
+      const pulling = drag !== null && drag.heading === call ? drag.pull : 0
+      const resting = drag !== null && drag.heading === null ? Math.min(0.35, drag.pull) : 0
+      const glow = Math.max(pulling, resting) * lit
+      // Three chevrons pointing the way out. At rest they are almost invisible;
+      // under a committing finger they are the brightest thing after the slate.
+      const rows = 3
+      const up = call === "toss"
+      ctx.strokeStyle = withAlpha(BRASS_LIT, 0.06 + glow * 0.72)
+      ctx.lineWidth = 1 + glow * 1.4
+      for (let r = 0; r < rows; r++) {
+        const t = (r + 0.5) / rows
+        const y = box.y + box.h * (up ? 1 - t : t)
+        const spread = box.w * (0.06 + 0.05 * t)
+        const rise = box.h * 0.22
+        ctx.beginPath()
+        ctx.moveTo(box.x + box.w / 2 - spread, y + (up ? rise : -rise))
+        ctx.lineTo(box.x + box.w / 2, y)
+        ctx.lineTo(box.x + box.w / 2 + spread, y + (up ? rise : -rise))
+        ctx.stroke()
+      }
+    }
+  }
+
   // ── the slate ───────────────────────────────────────────────────────────
 
   /**
-   * How lit the street is: 0 while it is still, 1 the instant the slate catches.
+   * How lit the street is: 0 while the slate is blank, 1 the instant the statement
+   * is cut in.
    *
-   * The rise is 90 ms and it does not travel, pulse or repeat — the cue is a
-   * light change, which is the whole of the juice budget spent in one place.
+   * The rise is 90 ms and it does not travel, pulse or repeat. Then it **cools**,
+   * back to `WINDOW_FLOOR` by the moment the window closes. That is the clock, and
+   * it is the only one: no bar, no ring, no countdown, nothing that moves.
    *
-   * Then it **cools**, back to `WINDOW_FLOOR` by the moment the window closes.
-   * That is the clock, and it is the only one: no bar, no ring, no countdown,
-   * nothing that moves. The beat is legible because the light is going out of
-   * it, which is what a child feels rather than reads.
+   * A WRONG VERDICT REGAINS NO LIGHT. The street stays exactly as dim as the window
+   * left it, in both directions — banking a counterfeit and throwing away good money
+   * are equally unacknowledged. A lapse is the same: nothing brightens for a window
+   * nobody touched, and nothing dims either.
    */
   private litness(state: SceneState): number {
     if (state.phase === "call") {
@@ -269,34 +334,54 @@ export class Scene {
       return rise * (1 - (1 - WINDOW_FLOOR) * cool)
     }
     if (state.phase === "verdict" || state.phase === "clear") {
-      // A wrong draw changes nothing, and that includes the light. The street
-      // stays exactly as dim as the window left it while the round runs out.
-      return state.outcome === "wild" ? WINDOW_FLOOR : 1
+      if (state.outcome === null) return 1
+      return isCorrect(state.outcome) ? 1 : WINDOW_FLOOR
     }
     if (state.phase === "over") return 1
     return 0
   }
 
-  private slateBox(state: SceneState): { x: number; y: number; w: number; h: number; a: number } {
-    // Where the slate stands is `street.ts`'s business — inside the safe area
-    // and clear of the host's corners. All that happens here is the raise and
-    // the clear, which are motion about that rest position.
+  /**
+   * Where the slate is, how transparent it is, and how far it has been thrown.
+   *
+   * Three motions, and only the third is new:
+   *
+   *   raise    up out of the dust, blank
+   *   clear    away — DOWNWARD into the bag if you kept it, UPWARD out of frame if
+   *            you threw it. `exitOf` owns that sign, so the rule lives with the
+   *            outcomes rather than in the renderer.
+   *   call     following the finger, at `DRAG_FOLLOW` of its travel, with a tilt.
+   */
+  private slateBox(state: SceneState): {
+    x: number
+    y: number
+    w: number
+    h: number
+    a: number
+    tilt: number
+  } {
+    // Where the slate stands is `street.ts`'s business — inside the safe area and
+    // clear of the host's corners.
     const { x, y, w, h } = this.street.slate
 
     let drop = 0
     let a = 1
+    let tilt = 0
     if (state.phase === "raise") {
       const t = state.reduced ? 1 : easeOut(state.progress)
       drop = (1 - t) * h * 1.5
       a = state.reduced ? state.progress : t
     } else if (state.phase === "clear") {
       const t = state.reduced ? 0 : easeOut(state.progress)
-      drop = t * h * 1.5
+      drop = t * h * 1.8 * exitOf(state.outcome)
       a = 1 - (state.reduced ? state.progress : t)
     } else if (state.phase === "idle") {
       a = 0
+    } else if (state.phase === "call" && state.drag !== null) {
+      drop = state.drag.dy * DRAG_FOLLOW
+      tilt = state.reduced ? 0 : clamp01(state.drag.pull) * DRAG_TILT * Math.sign(state.drag.dy)
     }
-    return { x, y: y + drop, w, h, a }
+    return { x, y: y + drop, w, h, a, tilt }
   }
 
   private drawSlate(state: SceneState): void {
@@ -307,6 +392,15 @@ export class Scene {
 
     ctx.save()
     ctx.globalAlpha = box.a
+    if (box.tilt !== 0) {
+      // Rotate about the slate's own centre, so a thrown card pivots rather than
+      // swinging on a hinge somewhere off screen.
+      const cx = box.x + box.w / 2
+      const cy = box.y + box.h / 2
+      ctx.translate(cx, cy)
+      ctx.rotate(box.tilt)
+      ctx.translate(-cx, -cy)
+    }
 
     // The stone.
     const face = ctx.createLinearGradient(0, box.y, 0, box.y + box.h)
@@ -315,8 +409,8 @@ export class Scene {
     ctx.fillStyle = face
     ctx.fillRect(box.x, box.y, box.w, box.h)
 
-    // The brass frame. Two rules, one bright and one in shadow, so the frame
-    // reads as a machined edge rather than as a border.
+    // The brass frame. Two rules, one bright and one in shadow, so the frame reads
+    // as a machined edge rather than as a border.
     ctx.strokeStyle = mix(BRASS_DIM, BRASS_LIT, lit)
     ctx.lineWidth = 2
     ctx.strokeRect(box.x + 1, box.y + 1, box.w - 2, box.h - 2)
@@ -325,7 +419,11 @@ export class Scene {
     ctx.strokeRect(box.x + 5.5, box.y + 5.5, box.w - 11, box.h - 11)
 
     if (state.phase === "over") this.drawLedger(box, state)
-    else this.drawStatement(box, state, lit)
+    // Blank through `raise` and `still`. The statement is cut in when the window
+    // opens and not one millisecond before: it used to be legible for up to 1.15 s
+    // of unanswerable lead-in, and every reaction time this game measures had that
+    // lead-in silently subtracted out of it. See `statement.stillFor`.
+    else if (state.phase !== "raise" && state.phase !== "still") this.drawStatement(box, state, lit)
 
     ctx.restore()
   }
@@ -359,20 +457,21 @@ export class Scene {
     ctx.textAlign = "left"
     ctx.textBaseline = "alphabetic"
 
-    const correcting = state.outcome === "bow" && (state.phase === "verdict" || state.phase === "clear")
+    const correcting =
+      state.outcome === "spot" && (state.phase === "verdict" || state.phase === "clear")
     const correction = correcting ? correctionFor(l, statement.claimed, statement.answer) : null
-    // The roll starts a beat into the bow: the caller acknowledges you first,
-    // and only then does the slate admit it was wrong.
+    // The roll starts a beat into the bow: the caller acknowledges you first, and
+    // only then does the slate admit it was wrong.
     const rollT = correcting
       ? clamp01(((state.phase === "verdict" ? state.progress : 1) - 0.24) / 0.5)
       : 0
 
     const chalk = mix(CHALK_UNLIT, CHALK_LIT, lit)
-    // Every alpha below is set *from* this rather than multiplied into the
-    // context. A running `*=` / `/=` pair looks equivalent and is not: at the
-    // end of the cross-fade the multiplier is zero, the division cannot undo
-    // it, and everything drawn afterwards — including the corrected numeral the
-    // fade exists to reveal — is drawn fully transparent.
+    // Every alpha below is set *from* this rather than multiplied into the context.
+    // A running `*=` / `/=` pair looks equivalent and is not: at the end of the
+    // cross-fade the multiplier is zero, the division cannot undo it, and everything
+    // drawn afterwards — including the corrected numeral the fade exists to reveal —
+    // is drawn fully transparent.
     const base = ctx.globalAlpha
 
     for (let i = 0; i < l.cells.length; i++) {
@@ -383,12 +482,22 @@ export class Scene {
       const fading = inClaim && rollT > 0 && !correction.canRoll
 
       if (rolling && rollT > 0) {
-        this.rollDigit(cell.x + originX, baseY, cell.w, px, rolling.from, rolling.to, rollT, state.reduced, chalk)
+        this.rollDigit(
+          cell.x + originX,
+          baseY,
+          cell.w,
+          px,
+          rolling.from,
+          rolling.to,
+          rollT,
+          state.reduced,
+          chalk,
+        )
         continue
       }
       if (fading) {
-        // Lengths differ, so there is no column to roll in. The wrong value
-        // fades out where it stands and the right one fades in over it.
+        // Lengths differ, so there is no column to roll in. The wrong value fades
+        // out where it stands and the right one fades in over it.
         ctx.globalAlpha = base * (1 - rollT)
         this.glyph(cell.ch, cell.x + originX, baseY, cell.w, CHALK_WRONG)
         ctx.globalAlpha = base
@@ -408,7 +517,7 @@ export class Scene {
       ctx.globalAlpha = base
     }
 
-    if (state.outcome === "hit" && (state.phase === "verdict" || state.phase === "clear")) {
+    if (state.outcome === "bank" && (state.phase === "verdict" || state.phase === "clear")) {
       this.drawStrike(box, state)
     }
   }
@@ -422,12 +531,12 @@ export class Scene {
   }
 
   /**
-   * The correction: a wrong digit rolls up out of its cell and the right one
-   * rolls in behind it, like a counter wheel. It is clipped to the cell, so the
-   * statement never reflows and nothing moves outside the recess.
+   * The correction: a wrong digit rolls up out of its cell and the right one rolls
+   * in behind it, like a counter wheel. It is clipped to the cell, so the statement
+   * never reflows and nothing moves outside the recess.
    *
-   * Reduced motion takes the same event as a cross-fade in place — a branch,
-   * not a degradation. The child still watches the slate correct itself.
+   * Reduced motion takes the same event as a cross-fade in place — a branch, not a
+   * degradation. The child still watches the slate correct itself.
    */
   private rollDigit(
     x: number,
@@ -460,7 +569,7 @@ export class Scene {
     ctx.restore()
   }
 
-  /** A single incision across the face. Cut once, then still. */
+  /** A single incision across the face: the stamp on a claim you banked. */
   private drawStrike(box: { x: number; y: number; w: number; h: number }, state: SceneState): void {
     const { ctx } = this
     const t = state.phase === "verdict" ? clamp01(state.progress / 0.3) : 1
@@ -481,12 +590,15 @@ export class Scene {
   // ── the ledger ──────────────────────────────────────────────────────────
 
   /**
-   * The run, over. One numeral: how many calls you made.
+   * The run, over. One numeral: the bag.
    *
-   * There is no percentage here and there never will be. A child shown "50%"
-   * reads a passing grade; a child shown "3" reads three.
+   * There is no percentage here and there never will be. A child shown "50%" reads
+   * a passing grade; a child shown a bag of coins reads a bag of coins.
    */
-  private drawLedger(box: { x: number; y: number; w: number; h: number }, state: SceneState): void {
+  private drawLedger(
+    box: { x: number; y: number; w: number; h: number },
+    state: SceneState,
+  ): void {
     const { ctx } = this
     const px = box.h * 0.52
     ctx.font = `${String(Math.round(px))}px ${SLATE_FONT}`
@@ -495,7 +607,7 @@ export class Scene {
     ctx.fillStyle = CHALK_LIT
     const t = clamp01(state.elapsedMs / 420)
     ctx.globalAlpha *= state.reduced ? t : easeOut(t)
-    ctx.fillText(String(state.run.calls), box.x + box.w / 2, box.y + box.h * 0.6)
+    ctx.fillText(String(state.run.bag), box.x + box.w / 2, box.y + box.h * 0.6)
 
     if (state.best > 0) {
       const small = Math.round(box.h * 0.15)
@@ -510,14 +622,11 @@ export class Scene {
   /** Three brass pips. A spent one is an empty ring, and it goes out in silence. */
   private drawShots(state: SceneState): void {
     const { ctx } = this
-    // Before a run starts there is nothing on the street but the caller and
-    // three loaded shots, breathing. That is the whole instruction: one tap.
+    // Before a run starts there is nothing on the street but the caller and three
+    // loaded shots, breathing.
     if (state.phase === "idle") {
       ctx.globalAlpha = state.reduced ? 0.7 : 0.45 + 0.35 * (0.5 + 0.5 * Math.sin(state.elapsedMs / 620))
     }
-    // The shots are the only resource in the game, so they travel with the
-    // slate: inside the safe area, under the host's corners, never under a
-    // rounded corner of the glass.
     const { pip: r, pipGap: gap, shots } = this.street
     const cx = shots.x + shots.w / 2
     const y = shots.y + shots.h / 2
@@ -537,15 +646,121 @@ export class Scene {
     ctx.globalAlpha = 1
   }
 
-  /** The tally: how many calls, in brass, small, above everything. */
-  private drawTally(state: SceneState): void {
-    if (state.phase === "idle" || state.phase === "over") return
+  /**
+   * THE BAG. The score, and the only number on the street during play.
+   *
+   * The coins in flight are the whole of the feedback for a wrong verdict: nothing
+   * sounds, nothing buzzes, nothing flashes and the caller does not move — coins
+   * simply come back out of the bag and go. `energy.ts` holds that line.
+   */
+  private drawBag(state: SceneState): void {
+    if (state.phase === "idle") return
     const { ctx } = this
-    const { tally, tallyPx } = this.street
-    ctx.font = `${String(tallyPx)}px ${SLATE_FONT}`
+    const { bag } = this.street
+    const cx = bag.x + bag.w / 2
+    const lip = bag.y + bag.h * 0.22
+    const full = clamp01(state.run.bag / 240)
+
+    // A bag: a straight lip, and a body that swells with what is in it.
+    ctx.strokeStyle = withAlpha(BRASS_DIM, 0.55)
+    ctx.lineWidth = 1.25
+    ctx.beginPath()
+    ctx.moveTo(bag.x + bag.w * 0.22, lip)
+    ctx.lineTo(bag.x + bag.w * 0.78, lip)
+    ctx.stroke()
+
+    const belly = bag.w * (0.3 + full * 0.16)
+    ctx.beginPath()
+    ctx.moveTo(bag.x + bag.w * 0.26, lip)
+    ctx.bezierCurveTo(
+      cx - belly,
+      lip + bag.h * 0.34,
+      cx - belly * 0.72,
+      bag.y + bag.h,
+      cx,
+      bag.y + bag.h,
+    )
+    ctx.bezierCurveTo(
+      cx + belly * 0.72,
+      bag.y + bag.h,
+      cx + belly,
+      lip + bag.h * 0.34,
+      bag.x + bag.w * 0.74,
+      lip,
+    )
+    ctx.strokeStyle = withAlpha(BRASS, 0.3 + full * 0.4)
+    ctx.stroke()
+
+    // The count. Brass, inside the bag, and it is the score.
+    ctx.font = `${String(this.street.bagPx)}px ${SLATE_FONT}`
     ctx.textAlign = "center"
-    ctx.textBaseline = "top"
-    ctx.fillStyle = withAlpha(BRASS, state.run.calls > 0 ? 0.8 : 0.3)
-    ctx.fillText(String(state.run.calls), tally.x + tally.w / 2, tally.y)
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = withAlpha(BRASS_LIT, state.run.bag > 0 ? 0.9 : 0.34)
+    ctx.fillText(String(state.run.bag), cx, bag.y + bag.h * 0.64)
+
+    this.drawCoins(state)
+  }
+
+  /**
+   * Coins in flight, during the verdict only.
+   *
+   * Into the bag when the call was right, out of it and away when it was wrong. The
+   * count is the size of the call, so a fast correct keep visibly pays more than a
+   * slow one — the speed bonus is a thing a child can SEE rather than a number they
+   * are told.
+   */
+  private drawCoins(state: SceneState): void {
+    if (state.phase !== "verdict" && state.phase !== "clear") return
+    if (state.coins === 0) return
+    const { ctx } = this
+    const { bag, slate } = this.street
+    const inbound = state.coins > 0
+    // FEWER coins leave than arrive, always. `energy.ts` holds "being wrong is never
+    // more interesting than being right" on duration × movers × loudness, and a loss
+    // that sprayed six coins where a win sprayed five would break the same rule at the
+    // level of the pixels: a wrong verdict costs more coins than a right one earns, so
+    // a count proportional to the amount would make the loss the bigger event.
+    const n = inbound
+      ? Math.max(3, Math.min(8, Math.round(state.coins / 2)))
+      : COINS_OUT
+    const t = state.phase === "verdict" ? clamp01(state.progress) : 1
+    const e = state.reduced ? t : easeOut(t)
+    const from = { x: slate.x + slate.w / 2, y: slate.y + slate.h / 2 }
+    const to = { x: bag.x + bag.w / 2, y: bag.y + bag.h * 0.55 }
+    const r = Math.max(2, bag.w * 0.045)
+
+    for (let i = 0; i < n; i++) {
+      // Staggered, so they arrive as a handful rather than as one object.
+      const stagger = clamp01((e - i * 0.06) / 0.7)
+      if (stagger <= 0) continue
+      const lane = ((i % 2 === 0 ? -1 : 1) * (1 + Math.floor(i / 2))) / (n + 1)
+      const spread = bag.w * 0.5 * lane
+      let x: number
+      let y: number
+      let alpha: number
+      if (inbound) {
+        x = from.x + (to.x - from.x) * stagger + spread * (1 - stagger)
+        y = from.y + (to.y - from.y) * stagger
+        alpha = 0.85 * (1 - stagger * 0.35)
+      } else {
+        // Out of the bag and away downwards, off the bottom of the frame.
+        x = to.x + spread * stagger
+        y = to.y + (this.h - to.y) * stagger
+        alpha = 0.7 * (1 - stagger)
+      }
+      ctx.globalAlpha = Math.max(0, alpha)
+      ctx.fillStyle = inbound ? BRASS_LIT : BRASS_DIM
+      ctx.beginPath()
+      ctx.arc(x, y, r, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    ctx.globalAlpha = 1
   }
 }
+
+/**
+ * How many coins a loss shows leaving the bag.
+ *
+ * Fixed, and fewer than the smallest win puts in — see `drawCoins`.
+ */
+const COINS_OUT = 2

--- a/dynawalla/games/truedraw/src/render/street.test.ts
+++ b/dynawalla/games/truedraw/src/render/street.test.ts
@@ -75,7 +75,8 @@ for (const [shape, w, h] of VIEWPORTS) {
       for (const [name, box] of [
         ["the slate", l.slate],
         ["the shots", l.shots],
-        ["the tally", l.tally],
+        ["the chute", l.chute],
+        ["the bag", l.bag],
       ] as const) {
         assert.equal(
           hitsHostChrome(box, w, insets),
@@ -96,7 +97,8 @@ for (const [shape, w, h] of VIEWPORTS) {
       for (const [name, box] of [
         ["the slate", l.slate],
         ["the shots", l.shots],
-        ["the tally", l.tally],
+        ["the chute", l.chute],
+        ["the bag", l.bag],
       ] as const) {
         assert.ok(
           inside(box, area),
@@ -137,8 +139,45 @@ test("the shots hang below the slate, always", () => {
         l.shots.y >= l.slate.y + l.slate.h,
         `the shots ride up onto the slate at ${String(w)}×${String(h)}`,
       )
-      assert.ok(l.tally.y + l.tally.h <= l.slate.y, `the tally overlaps the slate at ${String(w)}×${String(h)}`)
+      assert.ok(
+        l.chute.y + l.chute.h <= l.slate.y + 0.5,
+        `the chute overlaps the slate at ${String(w)}×${String(h)}`,
+      )
+      assert.ok(
+        l.bag.y >= l.shots.y + l.shots.h - 0.5,
+        `the bag rides up onto the shots at ${String(w)}×${String(h)}`,
+      )
     }
+  }
+})
+
+test("the two destinations are on the two sides of the slate, always", () => {
+  // The whole affordance depends on it: up is the chute, down is the bag. A layout
+  // that put them the same side of the slate, or crossed them, would make the gesture
+  // a thing a child has to remember instead of a thing they can see.
+  for (const [shape, w, h] of VIEWPORTS) {
+    for (const [where, insets] of INSETS) {
+      const l = streetAt(w, h, insets).layout
+      assert.ok(
+        l.chute.y + l.chute.h <= l.slate.y + 0.5,
+        `${shape} ${where}: the chute is not above the slate`,
+      )
+      assert.ok(
+        l.bag.y >= l.slate.y + l.slate.h,
+        `${shape} ${where}: the bag is not below the slate`,
+      )
+      assert.ok(l.bag.w > 0 && l.bag.h > 0 && l.chute.h > 0, `${shape} ${where}: a zero-size target`)
+    }
+  }
+})
+
+test("the bag is wide enough to read a four-digit coin count in", () => {
+  for (const [shape, w, h] of VIEWPORTS) {
+    const l = streetAt(w, h, NO_INSETS).layout
+    assert.ok(
+      l.bag.w >= l.bagPx * 2.4,
+      `${shape}: a ${l.bag.w.toFixed(0)}px bag for ${String(l.bagPx)}px numerals`,
+    )
   }
 })
 

--- a/dynawalla/games/truedraw/src/render/street.ts
+++ b/dynawalla/games/truedraw/src/render/street.ts
@@ -11,7 +11,7 @@
 // So this module splits the frame in two:
 //
 //   * the WORLD — horizon, sky, dust, figures — laid out on the full canvas;
-//   * the READABLE things — the slate, the three shots, the tally — laid out
+//   * the READABLE things — the slate, the three shots, the bag — laid out
 //     inside `area`, the safe rectangle, and clear of the host's two corners.
 //
 // The host paints an exit control top-LEFT and a how-to-play control top-RIGHT,
@@ -45,9 +45,21 @@ export type Layout = {
   /** Radius of one shot pip, and the spacing between their centres. */
   readonly pip: number
   readonly pipGap: number
-  /** The call tally, small, in brass, above the slate. */
-  readonly tally: Rect
-  readonly tallyPx: number
+  /**
+   * The chute, immediately ABOVE the slate: where a thrown-away claim goes.
+   *
+   * It is deliberately adjacent to the slate rather than at the top of the frame.
+   * The top of the frame is where the host paints its exit and how-to-play
+   * controls, and a discard target up there would either sit under one of them or
+   * force a reserved band — which costs a twelfth of a 568px phone and broke a
+   * sibling game's layout. Adjacency also reads better: the gesture is a flick
+   * across the thing being judged, so the two destinations belong beside it.
+   */
+  readonly chute: Rect
+  /** The bag, below the shots: where a kept claim goes, and where the score is. */
+  readonly bag: Rect
+  /** Type size for the coin count on the bag. */
+  readonly bagPx: number
 }
 
 /** The insets `area` was cut from. Exact: `safeRect` is the only thing that cuts it. */
@@ -81,7 +93,6 @@ export function layoutFor(w: number, h: number, area: Rect): Layout {
   const horizon = h * 0.6
 
   const slateW = Math.min(area.w * 0.88, 640)
-  const slateH = slateW * 0.3
   const slateX = area.x + (area.w - slateW) / 2
 
   const pip = Math.max(3.5, h * 0.0075)
@@ -90,40 +101,54 @@ export function layoutFor(w: number, h: number, area: Rect): Layout {
   /** From the bottom of the slate down to the centre of the pips. */
   const shotsDrop = pip * 5
 
-  const tallyPx = Math.round(Math.max(15, h * 0.026))
+  const bagPx = Math.round(Math.max(15, h * 0.03))
 
-  // The host's chrome, rebuilt from `area` rather than measured again, so the
-  // game and the host cannot end up disagreeing about where the buttons are.
+  // The host's chrome, rebuilt from `area` rather than measured again, so the game
+  // and the host cannot end up disagreeing about where the buttons are.
   const insets = insetsOf(w, h, area)
   const exit = exitRect(insets)
   const help = helpRect(w, insets)
   const chromeBottom = Math.max(exit.y + exit.h, help.y + help.h)
   const passesBetween =
     slateX >= exit.x + exit.w + HOST_MARGIN && slateX + slateW <= help.x - HOST_MARGIN
-  const ceiling = passesBetween ? area.y : chromeBottom + HOST_MARGIN
+  const ceiling = (passesBetween ? area.y : chromeBottom + HOST_MARGIN) + HOST_PROGRESS_H
 
-  // Centred four tenths down the safe area — high enough that a thumb is not
-  // over the statement it is about to judge.
-  let slateY = Math.max(ceiling, area.y + area.h * 0.4 - slateH / 2)
-  // ...and lifted back up if the shots would fall off the safe bottom. The
-  // ceiling still wins: a slate under the exit button is worse than pips near
-  // the home indicator, and on no shape the fleet has does it come to that.
-  const overflow = slateY + slateH + shotsDrop + pip - (area.y + area.h)
-  if (overflow > 0) slateY = Math.max(ceiling, slateY - overflow)
+  /**
+   * THE VERTICAL BUDGET, and why the slate's height is now capped by it.
+   *
+   * The slate is `slateW × 0.3`, and in landscape on a phone that is enormous relative
+   * to the height: at 568×320 with a portrait notch the safe area is 239 px tall and an
+   * uncapped slate wanted 150 of them. There was room for that when the only other
+   * things were three 7 px pips; there is not now that there is a chute above and a bag
+   * below, and a bag that had to ride up onto the shots to fit is a bag pointing at the
+   * wrong place.
+   *
+   * So the slate takes at most a third of the budget and everything else is measured
+   * from it. The three shares below sum to well under one, which is what makes the
+   * overflow correction below always resolvable — a clamp that cannot succeed is how a
+   * layout ends up outside the safe area on exactly one device shape.
+   */
+  const budget = Math.max(1, area.y + area.h - ceiling)
+  const slateH = Math.min(slateW * 0.3, budget * 0.34)
+  const gutterH = Math.max(10, slateH * 0.2)
+  const bagH = Math.max(bagPx * 1.6, slateH * 0.62)
+  /** Everything under the slate: the drop to the pips, the pips, and the bag. */
+  const below = shotsDrop + pip * 3 + bagH
+
+  // Centred four tenths down the safe area — high enough that a thumb is not over the
+  // statement it is about to judge. The chute has to fit above it, so the roof is the
+  // host's chrome plus one gutter.
+  const roof = ceiling + gutterH
+  let slateY = Math.max(roof, area.y + area.h * 0.4 - slateH / 2)
+  // ...and lifted back up if the bag would fall off the safe bottom. The roof still
+  // wins: a slate under the exit button is worse than a bag near the home indicator,
+  // and with the budget above it never comes to that.
+  const overflow = slateY + slateH + below - (area.y + area.h)
+  if (overflow > 0) slateY = Math.max(roof, slateY - overflow)
 
   const cx = area.x + area.w / 2
   const shotsY = slateY + slateH + shotsDrop
-
-  // The tally sits above the slate, and gives way to it: when the slate has
-  // been pushed clear of the corners there may be very little room up there,
-  // and the tally is the thing that yields.
-  const tallyY = Math.max(
-    area.y + HOST_PROGRESS_H,
-    Math.min(area.y + area.h * 0.055, slateY - tallyPx * 1.5),
-  )
-  // Three digits' worth, generously: this box exists to be tested against the
-  // host's corners, so it errs wide.
-  const tallyW = tallyPx * 3
+  const bagW = Math.max(bagH, Math.min(slateW * 0.3, bagPx * 4))
 
   return {
     w,
@@ -133,7 +158,8 @@ export function layoutFor(w: number, h: number, area: Rect): Layout {
     shots: { x: cx - shotsW / 2, y: shotsY - pip, w: shotsW, h: pip * 2 },
     pip,
     pipGap,
-    tally: { x: cx - tallyW / 2, y: tallyY, w: tallyW, h: tallyPx },
-    tallyPx,
+    chute: { x: slateX, y: Math.max(area.y, slateY - gutterH), w: slateW, h: gutterH },
+    bag: { x: cx - bagW / 2, y: shotsY + pip * 3, w: bagW, h: bagH },
+    bagPx,
   }
 }

--- a/dynawalla/games/truedraw/src/stub/host.ts
+++ b/dynawalla/games/truedraw/src/stub/host.ts
@@ -12,9 +12,19 @@ import { drawProblem, GLYPH } from "./questions.ts"
 export type StubHostOptions = {
   seed?: number
   reducedMotion?: boolean
-  /** 0..7, the rung of the ladder the stub sits on. */
+  /**
+   * 0..7, the rung of the ladder the stub sits on.
+   *
+   * **A `level` PINS the stub.** The game now asks for a difficulty on every deal
+   * (see `dealer.ts`), so without a pin a stub would follow the game's own ladder
+   * and a test that wanted to sweep every rung would only ever see the rungs the
+   * bot happened to climb to. With a pin the stub serves that rung and ignores the
+   * request, which is what "play this rung for me" means.
+   */
   level?: number
   onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  onNext?: (difficulty: number) => void
+  onSkip?: (questionId: string) => void
   onHaptic?: (k: string) => void
 }
 
@@ -24,10 +34,15 @@ export function createStubHost(opts: StubHostOptions = {}): Host {
 
   return {
     next(o) {
+      const asked = o?.difficulty
       const level = Math.max(
         0,
-        Math.min(7, Math.round(o?.difficulty === undefined ? (opts.level ?? 3) : o.difficulty * 8)),
+        Math.min(
+          7,
+          Math.round(opts.level ?? (asked === undefined ? 3 : asked * 8)),
+        ),
       )
+      opts.onNext?.(o?.difficulty ?? -1)
       const drawn = drawProblem(level, rng)
       served++
       return {
@@ -42,6 +57,13 @@ export function createStubHost(opts: StubHostOptions = {}): Host {
 
     report(r) {
       opts.onReport?.(r)
+    },
+
+    // The third ending. A stub host has no ledger to close, so all this does is
+    // let the dev harness show that a lapse went across as a skip and NOT as a
+    // report — which is the whole of what the real one guarantees.
+    skip(questionId) {
+      opts.onSkip?.(questionId)
     },
 
     haptic(k) {

--- a/dynawalla/games/truedraw/src/test/harness.ts
+++ b/dynawalla/games/truedraw/src/test/harness.ts
@@ -1,9 +1,16 @@
 // A headless player.
 //
 // The round is driven by elapsed milliseconds rather than by frames precisely so
-// that the design's central claim — that drawing at everything is a three-call
-// run — can be played out ten thousand times with no canvas, no clock and no
-// browser. This is that driver.
+// that the design's central claims — that swiping at random empties the bag, that a
+// careful reader's bag grows without bound, and that waiting every window out earns
+// exactly nothing — can be played out thousands of times with no canvas, no clock
+// and no browser. This is that driver.
+//
+// The decision a bot returns is one of THREE things now, and the third is the point:
+//
+//   "keep"  swipe down
+//   "toss"  swipe up
+//   "wait"  do not touch the screen — which is no longer a verdict
 
 import type { Host } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
@@ -13,7 +20,7 @@ import { Round, TIMING, type RoundEvent, type Timing } from "../game/round.ts"
 import type { Run } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
 
-export type Decision = "draw" | "hold"
+export type Decision = "keep" | "toss" | "wait"
 
 export type PlayResult = {
   readonly outcomes: readonly Outcome[]
@@ -30,18 +37,20 @@ export type PlayOptions = {
   readonly stepMs?: number
   /** Rounds after which the driver gives up, for a strategy that never misses. */
   readonly limit?: number
-  /** Fraction into the draw window at which a draw is committed. */
-  readonly drawAt?: number
+  /** Fraction into the window at which a verdict is committed. */
+  readonly callAt?: number
   /**
    * How long this player takes to work the statement out, in absolute ms.
    *
-   * The point of an absolute think time rather than a fraction is that it is
-   * the *child's* number, not the game's: a bot that always acts at 40% of
-   * whatever window it is given can never be timed out, so it can never detect
-   * a window that is too short. One that takes six seconds because six seconds
-   * is what the cadence table says the item costs can.
+   * The point of an absolute think time rather than a fraction is that it is the
+   * *child's* number, not the game's: a bot that always acts at 40% of whatever
+   * window it is given can never be timed out, so it can never detect a window that
+   * is too short. One that takes six seconds because six seconds is what the cadence
+   * table says the item costs can.
    */
   readonly thinkMs?: (statement: Statement) => number
+  /** A dealer to share across runs, so the difficulty request can be observed. */
+  readonly dealer?: Dealer
 }
 
 export function playRun(
@@ -53,10 +62,10 @@ export function playRun(
   const timing = options.timing ?? TIMING
   const step = options.stepMs ?? 20
   const limit = options.limit ?? 400
-  const drawAt = options.drawAt ?? 0
+  const callAt = options.callAt ?? 0
 
   const rng = new Rng(seed)
-  const dealer = new Dealer(host, rng)
+  const dealer = options.dealer ?? new Dealer(host, rng)
   const round = new Round(() => dealer.deal(), timing)
 
   const outcomes: Outcome[] = []
@@ -69,7 +78,12 @@ export function playRun(
     for (const event of batch) {
       events.push(event)
       if (event.kind === "present") statements.push(event.statement)
-      else if (event.kind === "settled") outcomes.push(event.outcome)
+      else if (event.kind === "settled") {
+        outcomes.push(event.outcome)
+        // The mount does this too, and a harness that skipped it would measure a
+        // game whose difficulty never moves — which is the defect, not the fix.
+        dealer.settle(event.outcome, event.quickness)
+      }
     }
   }
 
@@ -80,31 +94,40 @@ export function playRun(
     const index = statements.length - 1
     const current = statements[index]
     if (round.phase !== "call" || current === undefined || actedOn === index) continue
-    const readyAt = options.thinkMs ? options.thinkMs(current) : current.windowMs * drawAt
+    const readyAt = options.thinkMs ? options.thinkMs(current) : current.windowMs * callAt
     // Still working it out. If the window closes first the call is never made,
     // which is exactly the failure this option exists to expose.
     if (round.elapsedMs < readyAt) continue
-    if (decide(current) === "draw") consume(round.press())
+    const decision = decide(current)
+    if (decision !== "wait") consume(round.verdict(decision))
     actedOn = index
   }
 
   return { outcomes, statements, events, run: round.run, finished: round.phase === "over" }
 }
 
-/** Draw at everything. The strategy the format has to defeat. */
-export const alwaysDraw = (): Decision => "draw"
+/** Keep everything. One of the two degenerate swipers. */
+export const alwaysKeep = (): Decision => "keep"
 
-/** Never draw. The other half of the same coin, and just as short. */
-export const alwaysHold = (): Decision => "hold"
+/** Throw everything away. The other one, and it is exactly as bad. */
+export const alwaysToss = (): Decision => "toss"
+
+/** Never touch the screen. Every window lapses. */
+export const alwaysWait = (): Decision => "wait"
 
 /** Read the slate and call it. */
-export const perfect = (statement: Statement): Decision => (statement.truth ? "draw" : "hold")
+export const perfect = (statement: Statement): Decision => (statement.truth ? "keep" : "toss")
+
+/** Swipe without reading, one direction or the other, at random. */
+export function coinFlip(rng: Rng): (statement: Statement) => Decision {
+  return () => (rng.chance(0.5) ? "keep" : "toss")
+}
 
 /** Read the slate, and be wrong `1 − p` of the time. */
 export function fallible(p: number, rng: Rng): (statement: Statement) => Decision {
   return (statement) => {
     const right = perfect(statement)
     if (rng.chance(p)) return right
-    return right === "draw" ? "hold" : "draw"
+    return right === "keep" ? "toss" : "keep"
   }
 }


### PR DESCRIPTION
## The complaint

> "The True Draw is not Juicy enough. I think it should maybe be **swipe up to discard (False)** and **swipe down to keep** .. and your correct keeps build your bag (score), incorrect discard/keep diminishes your bag. It stays on way too easy way too long to be fun for more advanced people... **If we have a gesture for True and a gesture for False, we can measure both ways** and decide to go to harder problems."

> "I've gotten 10 correct in a row fast and I still get `2+0=1` and **have to wait until it times out** ;/ ... I did 20 in a row max speed and got `2+1=3`. 25 in a row max speed and I get `2+0=1` and have to wait. Boring. lame."

## The defect, proved first

The game had **one verb**. A tap meant "this sum is right"; meaning "this sum is wrong" was expressed by *doing nothing* and letting the window close. Two things followed and both shipped.

**1. The fast player was made to wait.** Measured against the code as it was, with a bot that is certain in 300 ms on every slate:

```
TRUE verdicts (a draw):   reaction [ 304, 319, 317, 318 ]
FALSE verdicts (a hold):  reaction [ 14000, 14000, 14000, 14000 ] of windows [ 14000, ... ]
```

Forty-six times the thinking, spent on nothing, on half of every run. `src/game/tempo.test.ts` keeps that number by reconstructing the old machine in eleven lines rather than describing it.

**2. One of the two verdicts had no timestamp.** A hold has no moment in it, so the ladder could not tell a confident rejection from an abandoned one — half of every child's calls arrived either as silence or as a full-window number meaning "the clock ran out". That is the founder's own insight and it is the deeper half of the bug.

## The gestures

`src/game/gesture.ts` — a pure state machine, no DOM.

| | |
|---|---|
| **swipe DOWN** | **keep** — "this sum is right", into the bag |
| **swipe UP** | **toss** — "this sum is wrong", thrown away |
| commit distance | `clamp(0.075 × min(w, h), 34, 84)` px |
| direction | vertical travel must exceed horizontal × **1.4** |
| commit moment | the frame the threshold is **crossed**, not the release |
| a tap | starts a run. **Never** answers a question. |
| keyboard | `↓` keeps, `↑` tosses, space starts |

**34 px is 3.4× clear of the SDK's `DRAG_SLOP_PX = 10`** (#685/#688). That matters specifically: `tapzoom.ts` leaves *drags* alone but treats anything at or under its slop as a candidate *tap*, which it may cancel and re-dispatch as a `click` with no travel in it. A commit threshold inside that slop would have its verdicts eaten by the zoom guard on the second flick of any rapid pair. `gesture.test.ts` reads the real constant out of `tapzoom.ts` so the margin cannot drift silently.

**84 px is the ceiling** so the flick stays inside one slate height on every shape the fleet has — a motion across the thing being judged, never a drag across the room. Asserted at seven viewports.

**Nothing collides.** The canvas is `touch-action: none`, so a vertical flick is never a page scroll. The manual sheet's `touch-action: pan-y` body is a DOM overlay *above* the canvas, so a finger-scroll there never reaches the game's listeners — and `guide.isOpen` is checked anyway.

**The commit fires mid-motion** for feel *and* for honesty: `pointerdown` is unknowable (no direction yet) *and* exploitable — rest a thumb on the slate, think for six seconds, flick, and a `pointerdown`-anchored clock reports zero and pays the full speed bonus. There is a test for exactly that.

## The bag

`src/game/bag.ts`. Three numbers; the relationships between them are the economy.

| | | |
|---|---|---|
| `COIN_BASE` | **6** | every correct verdict, at any speed |
| `COIN_QUICK` | **4** | the most speed can add on top |
| `COIN_WRONG` | **12** | a wrong keep or a wrong toss |
| a lapse | **0** | not a verdict, so not priced |

* **`COIN_WRONG > COIN_BASE + COIN_QUICK`** — the truth bag deals in exact halves, so a random swiper is right exactly 50% of the time, and 12 > 10 makes that strictly *losing* rather than break-even. A bag that grows on a coin flip rewards mashing.
* **`COIN_BASE > COIN_QUICK`** — being right is worth more than being fast; fast-and-right is worth most. Nothing anywhere subtracts for slowness, swept from 0 to 10× p50.
* **The two correct verdicts pay identically** — an asymmetry would bias which gesture a child reaches for, and the ladder is now driven by the latency on *both*.

### Proved with bots

`src/game/economy.test.ts`. The headline case gives the guesser every advantage — answering *instantly*, collecting the maximum speed bonus on every lucky call — and the reader none, taking the documented p50 every single time:

| strategy | final bag | rounds |
|---|---|---|
| careful reader, deliberately **slow** | **319** | 62 |
| random swiper, at **maximum speed** | **12** | 6 |
| keep everything / toss everything | ~10 | ~6 |
| wait every window out | **0** | never ends |

Bags at accuracy 0.6 / 0.75 / 0.9 / 0.98: **6 / 24 / 138 / 777**.

Two of these bots exist because of a gap I found in my own tests. Comparing final *bags* does **not** catch a break-even price list — the floor at zero and the three-shot budget hide it, and I verified that setting `COIN_WRONG` to 10 left every bag comparison passing. So there is now a test that sums the **raw signed price** of every call a guesser makes, unfloored, across 250 runs: **−0.92 coins per call**, and with the mutation **+0.07**. A companion asserts the reader's drift is **+5.13**.

And the SLICE failure is checked for explicitly: waiting earns exactly zero forever, so it dominates only guessing — which is the strategy it is meant to beat — while being the most expensive thing in the game in wall-clock time, since a lapse spends the whole window.

## A timeout is nobody's mistake

A window that closes untouched is a `lapse`: **no coins, no shot, and it goes to the host as `items.skip`.** Never as `{ correct: false, answered: "" }`, which the SDK is explicit about — the empty string fails to parse and is filed as a **MISS**, stepping the ladder *down* for a child who was still carrying the hundreds column. This pack is one of the six the SDK names for having done exactly that.

The converse is the new part: `burn` — a swipe *up* at a true claim — **is** reported, as the wrong answer it is. Under one verb that outcome was indistinguishable from "still thinking", so it could not be sent and half the evidence never reached the ladder.

## The ladder

`src/game/ladder.ts`. The reason it "stays on way too easy way too long" was not subtle: **`dealer.ts` called `host.next()` with no argument at all.** This pack never asked for a difficulty in its life.

| | |
|---|---|
| a correct call at ≤ 35% of the item's p50 | **+0.075** |
| a correct call at or past its p50 | **+0.020** |
| any wrong verdict | **−0.110** |
| a lapse | **0** |

Ten fast correct calls walks `0.2 → 0.95`. `DOWN > UP_MAX` on purpose. The ceiling is **0.995 and never 1.0**, because `toUnit` resolves exactly 1 on the fraction scale as the ladder's **bottom** — a game speaking fractions that sent `1.0` would ask for the easiest content in the product at the moment a child had earned the hardest.

This pack does not model the child and does not pick questions; the host's own ladder is being changed separately.

## What the latency measures

From the statement becoming **answerable** to the flick crossing the threshold. Three contaminations closed, each with a test:

* **The lead-in is not charged.** The slate now rises **blank** and the statement is cut in when the window opens. It used to be legible, unlit, for up to 1.15 s of unanswerable lead-in — a deliberate child would read as a lightning-fast one. That beat is also flat ~320 ms now instead of 620–1150 ms scaled *up* by difficulty, which was a second of dead air per round on a game whose complaint was that it was boring.
* **A paused stretch is not charged.**
* **Holding still buys nothing** — the commit is what is timed.

## Juice

The slate follows the finger with weight and a tilt; the destination you are heading for lights up *before* you commit (the affordance, so the controls need no second explanation); the slate leaves **in the direction you threw it** — down into the bag, up out of frame. Coins fly slate→bag on a right call and drain out of the bag on a wrong one, and **fewer leave than arrive** so a loss is never the bigger event.

`energy.ts` still holds the line it always held: both wrong verdicts have energy exactly zero — no voice, no haptic, no light regained, no mark — in both the full and reduced-motion branch. A wrong verdict now has a *consequence*, which is not a *reaction*.

## Not undone

* #657's comprehension window is untouched: still the item's own p90 from `cadence.ts`, clamped by nothing. `wiring.test.ts` still guards the 3600 ms cap and the `1300 + 215d` ramp from coming back. The item's **p50** is now also carried on the statement — never shown, never a limit, purely what "quick" is measured against, so the bag and the ladder cannot disagree about which beat they mean.
* No ones-column shortcut reintroduced. `pickFalsehood`'s 55% head weighting and `malRule.test.ts` are as they were.

## Verification

* **237 tests, 5 consecutive clean runs**, `tsc --noEmit` clean, `build:pack` clean (Node 24.18.0).
* **19 mutations applied and each confirmed to fail**, including: a toss that no longer stops the clock (`the wait is only 1.0x shorter (819000ms → 819266ms)`), a lapse reported as an empty answer (`a new report call appeared in mount.ts`), `COIN_WRONG = 10` (`a coin flip breaks even or wins: wrong 10 vs best 10` and `drifts 0.07 coins a call`), `COIN_QUICK = 9` (`speed can outweigh correctness: base 6 vs quick 9`), the difficulty request removed (`dealer.ts is back to calling host.next() with no request` / `the game asked for -1.000`), the statement drawn during the lead-in (`the statement was legible during raise: 4003 − 87 = 39260`), the old dead air restored (`7 + 8 = 15: 817ms`), `COMMIT_MIN_PX = 8` (`8px is not clear of the SDK's 10px slop`), the once-only commit removed (`one flick produced 57 verdicts`), dominance removed (`200,200 was read as a verdict`), `UP_MAX` flattened (`ten fast correct calls only reached 0.400`), `CEILING = 1`, a lapse made reportable, a lapse made to move the ladder, a loss spraying more coins than a win (`dud is as loud as a spot`), the latency anchored at the touch (`one verdict reported 0ms where the others reported ~1234ms`), and pause made a no-op (`the sheet was charged to the child`).

## Needs a device

Everything above is Node. What a headless run cannot see:

* **The flick itself** — whether 34 px on a phone and 77 px on an iPad feel like the same gesture under a six-year-old's thumb, and whether commit-on-crossing reads as instant rather than twitchy.
* **The double-tap guard interaction is reasoned, not observed.** `tapzoom.ts` itself says nobody in this repository has an iPhone in CI. A committed swipe is a drag by that module's own arithmetic and should never be cancelled, but that is the inference, not a measurement.
* **`items.skip` over the real bridge.** `dynawalla-app/src/packs/bridge.ts:227` implements it and it is inside the `items` capability this pack already declares, so no manifest change was needed — but the round trip has not been watched on a device.
* **Rendered output** — the bag, the chute chevrons, the coins in flight, and the slate's tilt are asserted for finite geometry and relative ink, not for looking right. The gate for that is a human looking at PNGs.
* **Tempo** — whether ~1.5 s per round for a fast player is the right pulse, and whether the 500 ms bank verdict wants to be shorter at speed.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
