### PR TITLE
fix(dynawalla/games/trebuchet): the search walks the ladder, because the ladder is not sorted by answer size

### DIFF
--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -169,38 +169,57 @@ function newGame(answers: number[], wave: number): ReturnType<typeof installDom>
 }
 
 /**
- * A host that behaves like the shipped one: the answers it serves depend on the
- * difficulty the game asks for, and the game cannot see the mapping.
+ * The shape of the shipped ladder, rung by rung.
  *
- * The numbers are the measured ladder. `ladder()` over the shipped 66 rungs, at
- * the difficulties `waveConfig` asks for, returns `dw.add.facts.subtract-within-ten`
- * (answers 0-9) at the bottom, two-digit answers in the middle, and
- * `dw.add.column.subtract-no-regroup` / `dw.mul.scale.times-power-of-ten`
- * (answers in the thousands and the millions) above it. Only the middle fits on a
- * 122-metre field.
+ * Not invented: this is the measured `ladder()` over the 66 active rungs, banded by
+ * the magnitude of the answers each returns. The two things it exists to preserve
+ * are the two that break a naive search:
  *
- * `lagPulls` models the other half of the real host: the question pool is refilled
- * ASYNCHRONOUSLY, so the first few `next()` calls after a difficulty change still
- * return the old rung. A game that retried inside one synchronous call would never
- * see the new questions at all.
+ *   - **Magnitude is NOT monotonic.** Division rungs return single-digit QUOTIENTS
+ *     and they sit ABOVE placeable multiplication-table rungs. Measured:
+ *     0.323 placeable (8..81), 0.338 quotients (0..5), 0.415 placeable (6..110),
+ *     0.508 quotients (2..12), 0.538 hundreds of thousands. A search that treats a
+ *     "too small" verdict as a floor excludes the placeable band and never returns.
+ *   - **Only a narrow middle fits on 122 metres.** Everything below is single-digit
+ *     facts; everything above is column arithmetic in the thousands and scaling in
+ *     the millions.
  */
-function ladderHost(lagPulls = 0, startDifficulty = 0.04): { host: Host; asks: number[] } {
+const RUNGS: Array<{ upto: number; lo: number; hi: number }> = [
+  { upto: 0.246, lo: 0, hi: 9 }, // add/sub facts within ten
+  { upto: 0.33, lo: 8, hi: 81 }, // tables — placeable
+  { upto: 0.354, lo: 0, hi: 5 }, // division facts — small, and ABOVE a placeable rung
+  { upto: 0.43, lo: 6, hi: 110 }, // tables — placeable
+  { upto: 0.523, lo: 2, hi: 12 }, // division facts — small again, higher still
+  { upto: 0.75, lo: 2000, hi: 5400 }, // column arithmetic
+  { upto: 1.01, lo: 1_000_000, hi: 9_000_000 }, // times a power of ten
+]
+
+/**
+ * A host that behaves like the shipped one.
+ *
+ * Faithful in the four ways that decide whether the search is correct:
+ *
+ *   - the answers depend on the rung, and the game cannot see the mapping;
+ *   - the ladder is quantised — a request lands on `round(d * 65)`, so many distinct
+ *     requests are the same rung, exactly as in `items.ts`;
+ *   - the difficulty reported back is the ORDINATE OF THE RUNG SERVED, not the
+ *     number that was asked for, which is what the app actually returns;
+ *   - `lagPulls` models the asynchronous pool: the first calls after a change still
+ *     return the old rung, so a game that retried inside one synchronous call would
+ *     never see the new questions.
+ */
+function ladderHost(
+  lagPulls = 0,
+  opts: { start?: number; rungs?: typeof RUNGS; nonInteger?: boolean } = {},
+): { host: Host; asks: number[]; served: number[] } {
+  const table = opts.rungs ?? RUNGS
   const asks: number[] = []
+  const served: number[] = []
+  const span = 65
   let n = 0
-  // The resting rung, which is near the bottom — so the very first questions a
-  // wave sees are the ones that do not fit, exactly as they do on the device.
-  let difficulty = startDifficulty
+  let difficulty = opts.start ?? 0.04
   let pending: number | null = null
   let lag = 0
-  const answerFor = (d: number): number => {
-    n++
-    // Below the field, on the field, then far above it — monotonic in magnitude,
-    // which is what makes the game's search converge.
-    if (d < 0.22) return n % 10
-    if (d < 0.58) return 14 + ((n * 7) % 100)
-    if (d < 0.75) return 2000 + ((n * 137) % 4000)
-    return 1_000_000 + n
-  }
   const host: Host & { setDifficulty?: (d: number) => void } = {
     next: (): Question => {
       if (pending !== null) {
@@ -210,14 +229,23 @@ function ladderHost(lagPulls = 0, startDifficulty = 0.04): { host: Host; asks: n
           pending = null
         }
       }
-      const a = answerFor(difficulty)
+      n++
+      // The app's own quantisation: a 0..1 request picks a whole rung.
+      const index = Math.max(0, Math.min(span, Math.round(difficulty * span)))
+      const ordinate = index / span
+      const band = table.find((b) => ordinate < b.upto) ?? table[table.length - 1]
+      const spread = band.hi - band.lo + 1
+      const a = band.lo + ((n * 7) % spread)
+      served.push(ordinate)
       return {
         id: `q${n}`,
         prompt: `? = ${a}`,
-        answer: String(a),
+        // A rung of fractions is a rung this game can never place, and it must not
+        // be able to stop the search either.
+        answer: opts.nonInteger ? `${String(a)}.5` : String(a),
         distractors: [String(a + 11), String(a + 23)],
         domain: 'add-sub',
-        difficulty,
+        difficulty: ordinate,
       }
     },
     report: () => undefined,
@@ -226,10 +254,14 @@ function ladderHost(lagPulls = 0, startDifficulty = 0.04): { host: Host; asks: n
     setDifficulty: (d: number) => {
       asks.push(d)
       pending = d
-      lag = lagPulls
+      // Only a big move restarts the wait. `game-host` flushes and refills its pool
+      // when a request moves by `FLUSH_BAND` (0.1) or more and otherwise just retargets
+      // it, so a search stepping by a fraction of a rung does NOT keep resetting the
+      // refill — and a test that assumed it did would demand the impossible.
+      if (Math.abs(d - difficulty) >= 0.1) lag = lagPulls
     },
   }
-  return { host, asks }
+  return { host, asks, served }
 }
 
 /* ------------------------------------------------------------------ tests */
@@ -284,7 +316,14 @@ test('the fire button is never lit over an empty rack', () => {
   // the moment is the easy part: what has to hold is that the button and the
   // machine never disagree, in any phase, on any wave.
   const dom = installDom()
-  const { host } = ladderHost()
+  // A ladder whose placeable band is nowhere near where the first search starts, so
+  // the game genuinely opens with an empty rack and has to go looking.
+  const { host } = ladderHost(0, {
+    rungs: [
+      { upto: 0.8, lo: 0, hi: 9 },
+      { upto: 1.01, lo: 20, hi: 90 },
+    ],
+  })
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   game.manualDrive()
 
@@ -295,7 +334,7 @@ test('the fire button is never lit over an empty rack', () => {
   assert.equal(game.fireArmed(), false, 'the fire button is lit over an empty rack')
 
   let armedFrames = 0
-  for (let i = 0; i < 900; i++) {
+  for (let i = 0; i < 3000; i++) {
     game.stepFrames(1)
     if (game.fireArmed()) {
       armedFrames++
@@ -326,8 +365,74 @@ test('the search for a placeable rung survives a pool that refills late', () => 
   )
   assert.notEqual(game.currentAnswer(), -1)
   assert.ok(asks.length > 1, 'the game never asked for a different rung')
+  const a = game.currentAnswer()
+  assert.ok(a >= 14 && a <= 118, `${a} does not fit on the field`)
+})
+
+test('a ladder whose difficulty does not track answer size is still searched', () => {
+  // The premise a bisection would need, and the one the real ladder breaks. Division
+  // rungs return single-digit quotients and sit ABOVE placeable multiplication
+  // rungs, so "the answers here are too small" is not evidence that the band is
+  // higher up. A search that treated it as a floor would raise its bound past the
+  // placeable band at 0.246-0.43 and search only the region where nothing fits —
+  // turning the fix for a blank screen into a blank screen.
+  //
+  // Started deliberately on the HIGHER of the two small-quotient rungs (0.5), which
+  // is the exact probe that would poison a bisection.
+  const dom = installDom()
+  const { host } = ladderHost(0, { start: 0.5 })
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  game.jumpToWave(9) // difficulty 0.616 — above the band, below the millions
+
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim', 3000),
+    'a non-monotonic ladder was never searched successfully',
+  )
+  const a = game.currentAnswer()
+  assert.ok(a >= 14 && a <= 118, `${a} does not fit on the field`)
+})
+
+test('a rung that yields no verdict at all does not stop the search', () => {
+  // Every probe must move. A rung of non-integer answers is unplaceable and says
+  // nothing about direction — nothing is too big, nothing is too small — and a probe
+  // that drew no conclusion used to leave the difficulty untouched. The next probe
+  // then re-asked nothing, because a difficulty already stated is not re-stated, and
+  // re-read the identical stream: a search that has silently finished, with a dark
+  // button on an empty field. Standing still is the one outcome not allowed.
+  const dom = installDom()
+  const fractions = [{ upto: 1.01, lo: 20, hi: 90 }]
+  const { host, asks } = ladderHost(0, { rungs: fractions, nonInteger: true })
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  for (let i = 0; i < 300; i++) game.stepFrames(1)
+
+  assert.equal(game.currentPhase, 'stocking', 'fractions cannot stand on the field')
+  // The point: it kept looking. A frozen search asks once and never again.
+  assert.ok(asks.length > 8, `the search stopped after ${asks.length} asks`)
+  const unique = new Set(asks)
+  assert.ok(unique.size > 8, `the search re-asked the same rung: ${unique.size} distinct`)
+})
+
+test('the search walks the whole ladder rather than excluding parts of it', () => {
+  // A band that exists only at the very top, reached from the very bottom. Nothing
+  // may be ruled out on the way: the walk steps by less than one rung and wraps, so
+  // every rung is visited whatever shape the ladder has.
+  const dom = installDom()
+  const topOnly = [
+    { upto: 0.9, lo: 2, hi: 6 },
+    { upto: 1.01, lo: 30, hi: 90 },
+  ]
+  const { host } = ladderHost(0, { start: 0.0, rungs: topOnly })
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim', 6000),
+    'a band at the top of the ladder was never reached from the bottom',
+  )
   const found = game.stockedDifficulty()
-  assert.ok(found !== null && found >= 0.22 && found < 0.58, `settled on an unplaceable rung ${found}`)
+  assert.ok(found !== null && found >= 0.9, `settled at ${found}, which is not where the band is`)
 })
 
 test('a wave that cannot be stocked at all says so out loud', () => {
@@ -359,7 +464,7 @@ test('a wave that cannot be stocked at all says so out loud', () => {
   try {
     const game = new TrebuchetGame(dom.el, host, 0xb01de)
     game.manualDrive()
-    for (let i = 0; i < 700; i++) game.stepFrames(1) // ~11 s of frames
+    for (let i = 0; i < 1300; i++) game.stepFrames(1) // ~22 s: past a full pass of the ladder
     assert.equal(game.currentPhase, 'stocking')
     assert.equal(game.fireArmed(), false, 'the button is lit on a field with no keeps')
   } finally {
@@ -375,44 +480,62 @@ test('a rung far above the field is searched downward, not only upward', () => {
   // returns millions, and neither can put a keep on 122 metres of field. So the
   // same blank screen and dead button waited for anyone who got that far. The
   // search has to move both ways.
+  // A ladder whose only placeable rungs are BELOW where the first search starts, and
+  // where everything above them is in the thousands. The opening probe therefore
+  // reads "too big" and the sweep has to go down to find the field.
   const dom = installDom()
-  const { host } = ladderHost()
+  const { host } = ladderHost(0, {
+    rungs: [
+      { upto: 0.14, lo: 20, hi: 90 },
+      { upto: 1.01, lo: 2000, hi: 9000 },
+    ],
+  })
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   game.manualDrive()
-  // Jumped before a single frame runs, so nothing has been found yet and the wave's
-  // own difficulty — 0.832, the millions — is genuinely where the search starts.
-  game.jumpToWave(12)
-  assert.equal(game.stockedDifficulty(), null, 'a band was already known; nothing is being searched')
-  assert.equal(game.currentPhase, 'stocking', 'a wave in the millions claimed to be playable')
+  const opening: string = game.currentPhase
+  assert.equal(opening, 'stocking', 'a rung in the thousands claimed to be playable')
 
   assert.ok(
-    runUntil(game, () => game.currentPhase === 'aim', 2400),
+    runUntil(game, () => game.currentPhase === 'aim', 3000),
     'a wave above the field never came back down to it',
   )
   const answer = game.currentAnswer()
   assert.notEqual(answer, -1, 'there is no question on the screen')
   assert.ok(answer >= 14 && answer <= 118, `${answer} does not fit on the field`)
   const found = game.stockedDifficulty()
-  assert.ok(found !== null && found < 0.832, `the search never came down from 0.832 (settled ${found})`)
+  assert.ok(found !== null && found < 0.14, `the search never came down to the band (settled ${found})`)
 })
 
-test('a wave configured above the field does not drag the game back off it', () => {
-  // Once a band is known it is kept. `waveConfig` keeps raising the arithmetic it
-  // asks for — 0.83 by wave 12 — and honouring that would walk the stream straight
-  // back out of the window the dial can express. The wave's escalation is wind, the
-  // wall, the ram and the keeps; the arithmetic stops at the width of the field.
+test('the arithmetic creeps up with the waves and never off the field', () => {
+  // `waveConfig` keeps raising the difficulty it asks for — 0.83 by wave 12 — and
+  // honouring that walks the stream straight out of the window the dial can express,
+  // which is how waves 6 upward went blank. But pinning it forever would mean a
+  // twenty-wave run of the same two-digit sums.
+  //
+  // So each wave asks for one notch above the rung that last worked, and a notch
+  // that does not fit is not adopted. The result has to be both: it moves, and it
+  // never leaves the field.
   const dom = installDom()
   const { host } = ladderHost()
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   game.manualDrive()
   assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'wave 1 never stocked')
-  const band = game.stockedDifficulty()
+  const first = game.stockedDifficulty()
+  assert.ok(first !== null)
 
-  game.jumpToWave(12)
-  assert.ok(runUntil(game, () => game.currentPhase === 'aim', 2400), 'wave 12 never stocked')
-  assert.equal(game.stockedDifficulty(), band, 'the band found at wave 1 was thrown away')
-  const answer = game.currentAnswer()
-  assert.ok(answer >= 14 && answer <= 118, `${answer} does not fit on the field`)
+  const bands: number[] = []
+  for (let w = 2; w <= 12; w++) {
+    game.jumpToWave(w)
+    assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${w} never stocked`)
+    const a = game.currentAnswer()
+    assert.ok(a >= 14 && a <= 118, `wave ${w} put ${a} on a 122-metre field`)
+    const band = game.stockedDifficulty()
+    assert.ok(band !== null)
+    bands.push(band)
+  }
+  assert.ok(bands[bands.length - 1] > first, 'the arithmetic never got any harder across 12 waves')
+  // ...and it did not run away up the ladder either: every wave stayed placeable,
+  // which is asserted above, wave by wave.
 })
 
 test('a bullseye stays a bullseye when the dial is nudged mid-flight', () => {

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -121,6 +121,37 @@ const DIAL_MAX = FIELD_MAX
 const PLACEABLE_LO = DIAL_MIN + 6
 const PLACEABLE_HI = DIAL_MAX - 4
 
+/**
+ * One step of the search for a placeable rung, as a fraction of the ladder.
+ *
+ * Smaller than one rung on the shipped 66-rung ladder (1/65 = 0.0154), so the walk
+ * cannot stride over a narrow band of placeable rungs, and it wraps — so a full
+ * pass visits all of them.
+ */
+const PROBE_STEP = 0.012
+/**
+ * How much harder each new wave asks for than the rung that last worked.
+ *
+ * About one rung. This is the game's arithmetic escalation, and it is deliberately
+ * this small: the field is 122 metres, so the questions cannot climb into the
+ * thousands however long the child plays. Wind, the wall, the ram, the extra keeps
+ * and the loft lever are where a later wave gets harder.
+ */
+const ESCALATE = 0.016
+/** Probes before the search is called stalled and says so. A full pass is ~84. */
+const PROBE_LIMIT = 100
+/**
+ * Where the FIRST search starts, before anything is known.
+ *
+ * A guess, and only a guess — correctness does not depend on it, because the sweep
+ * visits every rung either way. But `waveConfig(1).difficulty` is 0.04, the very
+ * bottom of the ladder, which is the worst possible opening bid for a game that
+ * needs two-digit answers: it cost 13 probes and 140 curriculum items to walk up out
+ * of the single-digit facts. On the shipped ladder the two-digit region is around
+ * 0.20-0.38, so starting in the middle of it usually stocks on the first probe.
+ */
+const PROBE_START = 0.28
+
 const PAL: Palette = {
   dust: C.dust,
   debris: [C.stone, C.stoneLit, '#0d1222'],
@@ -194,20 +225,22 @@ export class TrebuchetGame {
   /** The distractor pools that came with the rack, kept for the tower layout. */
   private pools: number[][] = []
   /**
-   * The difficulty last known to return answers this field can hold, and the
-   * bisection state used to find it. `stockD` survives the wave so the search
-   * runs once a run; the bounds are re-opened per wave.
+   * The difficulty last known to return answers this field can hold. It survives
+   * the wave, so the search runs once a run and every later wave starts from a rung
+   * that is known to work.
    */
   private stockD: number | null = null
+  /** The rung being probed now. */
   private probeD = 0
-  private probeLo = 0
-  private probeHi = 1
   /** The last difficulty actually stated to the host, so it is not re-stated. */
   private askedD: number | null = null
+  /** Probes spent on this wave. */
+  private probes = 0
+  /** Which way this wave's search is sweeping: -1, +1, or 0 for not yet decided. */
+  private probeDir = 0
   /** Seconds waited in 'stocking' since the last probe. */
   private stockT = 0
-  /** Seconds this wave has spent unable to stock, and whether that was said. */
-  private stockStall = 0
+  /** Whether the stall was already reported for this wave. */
   private toldAboutStocking = false
 
   // shot
@@ -396,18 +429,37 @@ export class TrebuchetGame {
     // when it will not, the wave waits in 'stocking' and tries again on a later
     // frame, because the pool behind `host.next()` refills asynchronously and a
     // synchronous retry can only ever re-read the same drained pool.
+    //
+    // The previous wave is struck FIRST, before the search begins. A stocking gap
+    // between waves would otherwise leave the last wave's craters, ghosts, wall and
+    // ram sitting on a field with no keeps on it — the old wave's wreckage as the
+    // backdrop to the new wave's empty plaque.
     this.rack = []
     this.activeIdx = 0
     this.towers = []
+    this.craters = []
+    this.ghosts = []
+    this.wall = null
+    this.ram = null
+    this.parts.clear()
+    this.rings.clear()
+    this.hitsThisWave = 0
+    this.clearT = -1
     this.phase = 'stocking'
     this.phaseT = 0
     this.stockT = 0
-    this.stockStall = 0
-    this.probeD = this.stockD ?? cfg.difficulty
-    // A fresh bisection per wave, but seeded from the band already found, so the
-    // search happens once a run and not once a wave.
-    this.probeLo = 0
-    this.probeHi = 1
+    this.toldAboutStocking = false
+    this.probes = 0
+    this.probeDir = 0
+    // The loft lever appears mid-run and it moves mute, so the controls belong to
+    // the new wave from the first frame of it, stocked or not.
+    this.hud = hudLayout(this.w, this.h, this.hud.area, cfg.loft)
+    this.btns = this.hud.buttons
+    // Seeded from the band already found, nudged one notch harder: the arithmetic
+    // creeps upward as the child keeps clearing waves, and it can only ever creep
+    // onto a rung whose answers still fit, because a probe that does not fit is
+    // not adopted. `stockD` is the floor it falls back to.
+    this.probeD = this.stockD === null ? PROBE_START : Math.min(1, this.stockD + ESCALATE)
     if (!this.stock()) return
     this.layOutWave()
   }
@@ -415,19 +467,47 @@ export class TrebuchetGame {
   /**
    * Ask for a rung, and say whether the answers can stand on the field.
    *
-   * Everything about the request is a request: `setDifficulty` is a 0..1 position
-   * on a ladder whose arithmetic the pack cannot see, so the only way to find out
-   * whether a rung's answers fit in `PLACEABLE_LO..PLACEABLE_HI` is to ask and
-   * look. When they do not, the answers that came back say which way to move —
-   * all too small means ask harder, all too large means ask easier — and answer
-   * magnitude rises with the ladder, so a bisection converges on the band in a
-   * handful of probes instead of sweeping 66 rungs blind.
+   * `setDifficulty` is a 0..1 position on a ladder whose arithmetic the pack cannot
+   * see, so the only way to find out whether a rung's answers fit in
+   * `PLACEABLE_LO..PLACEABLE_HI` is to ask and look.
    *
-   * The difficulty that worked is remembered in `stockD` for every later wave.
-   * The arithmetic therefore stops climbing at the width of the field, which is
-   * honest: a 122-metre field cannot pose a question whose answer is 5400. The
-   * wave's own escalation — wind, the wall, the ram, more keeps, less ammunition,
-   * the loft lever — is untouched and is where TREBUCHET gets harder.
+   * **This walks; it does not bisect, and the difference is the whole correctness
+   * argument.** Bisecting assumes answer magnitude rises with the ladder. It does
+   * not. Measured over all 66 shipped rungs:
+   *
+   *     0.323  PLACEABLE  8..81      dw.mul.facts.tables-to-twelve L1
+   *     0.338      -       0..5      dw.div.facts.division-facts L0
+   *     0.415  PLACEABLE  6..110     dw.mul.facts.tables-to-twelve L2
+   *     0.508      -       2..12     dw.div.facts.division-facts L2
+   *     0.538      -       311710..989670000
+   *
+   * Division rungs return single-digit QUOTIENTS and they sit above placeable
+   * multiplication rungs. A bisection that read "too small" at 0.508 would raise
+   * its floor above the entire placeable band at 0.246-0.415 and never come back —
+   * so the fix for a blank screen would have been a blank screen.
+   *
+   * So the answers choose a DIRECTION, once, and after that the walk sweeps that
+   * way in steps smaller than one rung, wrapping at the ends. Two properties come
+   * out of that, and both are needed:
+   *
+   *   - **It cannot oscillate.** Steering on every verdict looks smarter and is not.
+   *     Walking down from the millions reaches the small-quotient rungs at 0.43-0.523,
+   *     reads "too small", turns around, reads "too big", and paces across that one
+   *     boundary forever with the placeable band a few rungs below it. Fixing the
+   *     direction for the wave is what makes the band reachable.
+   *   - **It cannot exclude anything.** A monotonic sweep with wrapping visits every
+   *     rung on the ladder within `1 / PROBE_STEP` probes, whatever shape the ladder
+   *     has, so no verdict can put the band out of reach.
+   *
+   * And it always steps, on every outcome — a rung of non-integer answers, of
+   * unparseable answers, of no answers at all. A probe that changed nothing would
+   * re-ask nothing (see `askedD`) and re-read the same stream forever, which is a
+   * search that has silently stopped: the same dark button on the same empty field
+   * this whole change exists to remove.
+   *
+   * Success does not depend on the direction being right. A wave is stocked when a
+   * pull actually YIELDS placeable answers, so a wrong or stale verdict costs probes
+   * and can never cost correctness.
    */
   private stock(): boolean {
     const cfg = this.cfg
@@ -439,16 +519,17 @@ export class TrebuchetGame {
       this.askedD = this.probeD
       anyHost.setDifficulty?.(this.probeD)
     }
+    this.probes++
 
-    // A small draw, not a drained pool: this may be one probe of several, and
-    // every question pulled is a curriculum item spent.
+    // A small draw, not a drained pool. Every question pulled is a curriculum item
+    // the host records as served, and this may be one probe of many.
     const { boulders, pools, seen } = pullQuestions(
       () => this.host.next(),
       cfg.ammo,
       MIN_GAP,
       PLACEABLE_LO,
       PLACEABLE_HI,
-      32,
+      cfg.ammo + 8,
     )
     if (boulders.length > 0) {
       this.rack = boulders
@@ -457,22 +538,20 @@ export class TrebuchetGame {
       return true
     }
 
-    // Nothing placeable. Steer — but only on questions that came from the rung
-    // that was asked for. Anything else is the pool's previous contents, and
-    // reading it would move the search on evidence about a rung already left.
-    const fresh = seen.filter((s) => Math.abs(s.difficulty - this.probeD) <= 0.08)
-    if (fresh.length === 0) return false
-
-    const tooSmall = fresh.filter((s) => s.answer < PLACEABLE_LO).length
-    const tooBig = fresh.filter((s) => s.answer > PLACEABLE_HI).length
-    if (tooSmall === 0 && tooBig === 0) return false
-    if (tooSmall >= tooBig) {
-      this.probeLo = Math.max(this.probeLo, this.probeD)
-      this.probeD = Math.min(1, (this.probeD + this.probeHi) / 2)
-    } else {
-      this.probeHi = Math.min(this.probeHi, this.probeD)
-      this.probeD = Math.max(0, (this.probeLo + this.probeD) / 2)
+    // The direction is chosen once per wave, from the first probe that had an
+    // opinion, and then held. A rung of fractions or of nothing at all has no
+    // opinion and leaves the direction to be decided later — but still steps.
+    if (this.probeDir === 0) {
+      const tooBig = seen.filter((s) => s.answer > PLACEABLE_HI).length
+      const tooSmall = seen.filter((s) => s.answer < PLACEABLE_LO).length
+      if (tooBig > tooSmall) this.probeDir = -1
+      else if (tooSmall > 0) this.probeDir = 1
     }
+    // Wrapping, so the sweep cannot park itself against 0 or 1.
+    let next = this.probeD + (this.probeDir === 0 ? 1 : this.probeDir) * PROBE_STEP
+    if (next > 1) next -= 1
+    if (next < 0) next += 1
+    this.probeD = next
     return false
   }
 
@@ -1129,25 +1208,27 @@ export class TrebuchetGame {
 
     switch (this.phase) {
       case 'stocking': {
-        // Probe about six times a second. Each attempt asks for a different rung
-        // and gives the pool behind `host.next()` a frame or two to refill, which
-        // is the whole reason this is a phase and not a loop.
+        // Five probes a second. Each asks for a different rung and gives the pool
+        // behind `host.next()` a frame or two to refill, which is the whole reason
+        // this is a phase and not a loop. Past a full pass of the ladder the rate
+        // drops hard: the questions are real curriculum items, and a pack that
+        // cannot be served must not spend the host's whole budget saying so.
+        const stalled = this.probes >= PROBE_LIMIT
         this.stockT += rawDt
-        if (this.stockT >= 0.16) {
+        if (this.stockT >= (stalled ? 2 : 0.12)) {
           this.stockT = 0
           if (this.stock()) this.layOutWave()
         }
-        // Said out loud, once. A wave that cannot be stocked shows a field with no
-        // keeps and no equation, which is precisely the screen that was reported
-        // as "I can't see the problem and I can't fire" — so if it ever comes back
-        // it says so in the console instead of looking like a game that is merely
-        // slow. Five seconds is many times the handful of probes a search needs.
-        this.stockStall += rawDt
-        if (this.stockStall > 5 && !this.toldAboutStocking) {
+        // Said out loud, once per wave, and only if it is still true. A wave that
+        // cannot be stocked shows a field with no keeps and no equation, which is
+        // precisely the screen reported as "I can't see the problem and I can't
+        // fire" — so if it ever comes back it says so instead of passing for a game
+        // that is merely slow.
+        if (stalled && !this.toldAboutStocking && this.phase === 'stocking') {
           this.toldAboutStocking = true
           console.error(
-            `[trebuchet] wave ${String(this.wave)} cannot be stocked: no rung between ` +
-              `${String(this.probeLo)} and ${String(this.probeHi)} returns an answer in ` +
+            `[trebuchet] wave ${String(this.wave)} cannot be stocked: ${String(this.probes)} ` +
+              `probes across the whole difficulty range found no rung returning an answer in ` +
               `${String(PLACEABLE_LO)}..${String(PLACEABLE_HI)}, which is the only window a ` +
               `${String(FIELD_MAX)}-metre field can stand a keep on. The child is looking at an ` +
               `empty field.`,


### PR DESCRIPTION
Follow-up to #698, which merged while this revision was being verified. #698 is the
fix; this is the correction to its search. Re-verified on top of #699, which changed
the pool prefetch and the ladder's stride: the measured results are identical.

Self-review found the first cut of this fix could reproduce the very bug it fixes.
It bisected, and bisecting rests on a premise I asserted in a docstring and never
measured: that answer magnitude rises with the ladder. It does not. Every one of the
66 shipped rungs, by the size of the answers it returns:

    0.323  PLACEABLE  8..81       dw.mul.facts.tables-to-twelve L1
    0.338      -      0..5        dw.div.facts.division-facts L0
    0.415  PLACEABLE  6..110      dw.mul.facts.tables-to-twelve L2
    0.508      -      2..12       dw.div.facts.division-facts L2
    0.538      -      311710..989670000

Division rungs return single-digit QUOTIENTS and they sit ABOVE the placeable
multiplication rungs. A bisection reading "too small" at 0.508 raised its floor above
the entire placeable band at 0.246-0.43 and could never come back down — so on a
ladder one rung different from today's, the fix for a blank screen was a blank screen.

Three defects, all found by removing the fix's own assumptions rather than by
re-reading it:

  * **The bisection could exclude the answer.** Fixed by never bounding anything. The
    verdict now chooses a DIRECTION and the search sweeps that way in steps smaller
    than one rung, wrapping at the ends, so it visits every rung on the ladder
    whatever shape the ladder is.
  * **It could stop dead.** Three exits returned without moving `probeD`, and a probe
    that does not move re-asks nothing — a difficulty already stated is deliberately
    not re-stated — so it re-read the same stream forever. Measured on a rung of
    non-integer answers: one `setDifficulty`, then silence, phase stuck in 'stocking',
    and 11,552 `host.next()` calls and climbing. Every probe now steps, on every
    outcome, including outcomes with no opinion at all.
  * **Steering on every verdict oscillates.** Found while fixing the above: walking
    down from the millions reaches the small-quotient rungs at 0.43-0.523, reads "too
    small", turns round, reads "too big", and paces that one boundary forever with the
    placeable band a few rungs below. The direction is now chosen once per wave and
    held, which is what makes the band reachable.

Also from the review:

  * **The test double was shaped to flatter the fix.** `ladderHost`'s answers were
    monotonic in difficulty — the one property of the real ladder that does not hold —
    and its comment said so as if it were the reason the search worked. It is now a
    seven-band table taken from the measured `ladder()`, division rungs and all, and
    it quantises requests to `round(d * 65)` and reports back the ORDINATE OF THE RUNG
    SERVED rather than echoing the request, which is what `items.ts` actually does.
  * **The freshness gate is gone**, and with it the fragile 0.08 tolerance that was
    wider than every bisection step after the fourth. It is not needed: stocking
    succeeds when a pull actually YIELDS placeable answers, so a stale verdict costs
    probes and can never cost correctness. `seen` still carries each answer's rung,
    which is what picks the direction.
  * **The host is no longer hammered.** The draw per probe is `ammo + 8` instead of 32,
    the rate is 5/s instead of 6/s, and past a full pass of the ladder it drops to one
    probe every 2 s — a pack that cannot be served must not spend the host's whole
    budget saying so. `[pack] the question pool ran dry` was being printed 24-114
    times per launch; wave 1 now costs 2 items.
  * **The arithmetic escalates again.** Pinning the stream to the first rung that
    worked meant a twenty-wave run of identical sums — a product decision smuggled
    into a bug fix. Each wave now asks one notch above the rung that last worked, and
    a notch that does not fit is not adopted, so it climbs and can never climb off the
    field. Against the real ladder: 0.28 at wave 1 rising to 0.376 by wave 10, then
    holding at the top of the placeable band.
  * **The first guess is no longer the worst one.** `waveConfig(1).difficulty` is 0.04,
    the very bottom of the ladder, which cost 13 probes and 140 curriculum items to
    walk up out of the single-digit facts. The first search now opens at 0.28, in the
    two-digit region. It is only a guess — the sweep covers everything regardless —
    but it stocks wave 1 on the first probe: 140 items to 2, and 2.65 s to 0.9 s.
  * A stocking gap between waves left the previous wave's craters, ghosts, wall and ram
    on a field with no keeps. The old wave is now struck before the search starts, and
    the HUD is laid out for the new wave from its first frame.
  * The stall complaint now fires on probe count rather than wall-clock seconds, is
    checked only while still stocking so it cannot fire on the frame the field filled,
    and resets per wave.

Verified against the REAL ladder and the app's own rung selection, not the double:
all of waves 1-14 stock, every answer lands in 14..118, every answer has a keep, and
a search started at 0.544 — inside the non-monotonic region — still finds the field.
351 curriculum items across fourteen waves.

Each new mechanism removed in turn:

  * re-steer on every verdict (allow oscillation) — `wave 9 never stocked`
  * a no-verdict probe stands still — `the search stopped after 1 asks`
  * clamp instead of wrap — `the game never found a rung it could place`
  * `PROBE_STEP` strides over a narrow band — `a band at the top of the ladder was
    never reached from the bottom`
  * lay out the wave even when unstocked (the original bug) — 15 tests fail

177 tests, five consecutive runs, plus `npm run tsc`.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb