### PR TITLE
fix(dynawalla/games/truedraw): a latch the manual eats, a drag that outlives its slate, and three tests that could not fail

### DIFF
--- a/dynawalla/games/truedraw/README.md
+++ b/dynawalla/games/truedraw/README.md
@@ -285,6 +285,7 @@ with an empty answer is visible in one glance.
 ## Shape
 
     src/contract.ts     the host seam — must not drift. `skip` lives here.
+    src/game/report.ts  the ONE place a settled round crosses the wire
     src/game/           the rules: statement, schedule, gesture, bag, ladder, round
     src/render/         the street: one slate, a chute above, a bag below
     src/audio/          asset-free Web Audio; no sound for a wrong verdict or a lapse

--- a/dynawalla/games/truedraw/src/game/gesture.test.ts
+++ b/dynawalla/games/truedraw/src/game/gesture.test.ts
@@ -179,13 +179,16 @@ test("a cancel owes nothing — the system taking the gesture is not a verdict",
 })
 
 test("the live drag is clamped, so the slate can never be dragged off the world", () => {
+  // Driven with a travel the DOMINANCE rule refuses to commit — a huge horizontal
+  // component — because a committed gesture has no live drag at all by design, and a
+  // clamp is only interesting while the finger is still deciding.
   const g = new Gesture(50)
-  g.begin(100, 200)
-  g.move(100, 5000)
-  assert.equal(g.pull, 1)
-  g.begin(100, 200)
-  g.move(100, -5000)
-  assert.equal(g.pull, 1)
+  for (const dy of [5000, -5000]) {
+    g.begin(100, 200)
+    g.move(100 + 20_000, 200 + dy)
+    assert.equal(g.committed, false, "the guard travel committed after all")
+    assert.equal(g.pull, 1, `a pull of ${String(g.pull)} would throw the slate off the world`)
+  }
 })
 
 test("the heading lights up before the verdict fires, which is the whole affordance", () => {

--- a/dynawalla/games/truedraw/src/game/gesture.ts
+++ b/dynawalla/games/truedraw/src/game/gesture.ts
@@ -11,7 +11,7 @@
 //
 // Three numbers already in this repository bound it from below.
 //
-//   * `packs/shared/sdk/src/tapzoom.ts` calls anything past `DRAG_SLOP_PX = 10` a
+//   * `dynawalla/packs/sdk/src/tapzoom.ts` calls travel past `DRAG_SLOP_PX = 10` a
 //     drag rather than a tap. That module cancels the second tap of a zoom-shaped
 //     chain and re-dispatches its `click`; a *drag* it leaves entirely alone. So a
 //     committed swipe must be comfortably past 10 px, and at 34 it is 3.4× clear.
@@ -118,9 +118,30 @@ export class Gesture {
     return this.active
   }
 
-  /** How far the live pointer has travelled vertically. Down is positive. */
+  /** Whether this sequence has already produced its one verdict. */
+  get committed(): boolean {
+    return this.fired
+  }
+
+  /**
+   * ── the three accessors below are THE LIVE DRAG, and they go neutral the
+   *    instant a verdict commits ──────────────────────────────────────────────
+   *
+   * Not a nicety. A finger does not stop when it crosses the threshold: it keeps
+   * travelling and then it RESTS on the glass, and `move` keeps recording `x`/`y`
+   * for all of it. If these kept reporting that travel, the renderer would be
+   * handed a large drag on a slate that had already been answered — and, because
+   * the pointer is only cleared on release, that same drag would still be there
+   * 1.2 s later when the NEXT slate came up. A child who flicks down and rests
+   * their thumb would watch the following statement render 165 px below its rest
+   * position with the bag lit, unreadable and unanswerable until they lifted.
+   *
+   * `pull` is clamped and `dy` deliberately is not — the renderer wants the real
+   * travel so the slate has weight — which is exactly why the guard has to live
+   * here, on the concept, rather than at the one call site that reads it today.
+   */
   get dy(): number {
-    return this.active ? this.y - this.startY : 0
+    return this.active && !this.fired ? this.y - this.startY : 0
   }
 
   /** 0..1 towards a commit, for the renderer. Clamped, so the slate cannot fly off. */
@@ -137,7 +158,7 @@ export class Gesture {
    * which is why the controls do not have to be explained twice.
    */
   get heading(): Call | null {
-    if (!this.active) return null
+    if (!this.active || this.fired) return null
     const dy = this.dy
     if (Math.abs(dy) <= TAP_SLOP_PX) return null
     if (Math.abs(dy) <= Math.abs(this.x - this.startX) * DOMINANCE) return null

--- a/dynawalla/games/truedraw/src/game/ladder.test.ts
+++ b/dynawalla/games/truedraw/src/game/ladder.test.ts
@@ -11,6 +11,10 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stub/host.ts"
+import { perfect, playRun } from "../test/harness.ts"
+import { Dealer } from "./dealer.ts"
 import { CEILING, DOWN, Ladder, START, stepFor, UP_MAX, UP_MIN } from "./ladder.ts"
 import { OUTCOMES } from "./response.ts"
 
@@ -105,12 +109,42 @@ test("a NaN quickness cannot strand the ladder", () => {
   assert.equal(ladder.difficulty, START + UP_MIN)
 })
 
-test("a finished run does not send the child back to the bottom", () => {
+test("A FINISHED RUN DOES NOT SEND THE CHILD BACK TO THE BOTTOM", () => {
   // A child who reached rung eight can do rung eight. Handing them `1 + 0 = 1` again
   // because a run ended is the exact complaint this module answers.
+  //
+  // This used to assert that a no-op `reset()` was a no-op, which is a thing that
+  // cannot fail — an empty method body is always empty. So it is now asserted where
+  // it is actually observable: two whole runs through ONE dealer, which is what a
+  // mount has, watching what the host is asked for on the first question of the
+  // second run.
+  const asked: number[] = []
+  const host = createStubHost({ seed: 88, onNext: (d) => asked.push(d) })
+  const dealer = new Dealer(host, new Rng(89))
+
+  playRun(host, 90, perfect, { limit: 12, thinkMs: () => 120, dealer })
+  const reached = asked.at(-1) ?? -1
+  assert.ok(reached > 0.7, `twelve fast correct calls only reached ${reached.toFixed(3)}`)
+
+  const before = asked.length
+  playRun(host, 91, perfect, { limit: 3, thinkMs: () => 120, dealer })
+  const firstOfSecondRun = asked[before] ?? -1
+  assert.ok(
+    firstOfSecondRun >= reached,
+    `a new run asked for ${firstOfSecondRun.toFixed(3)} after the last one ended at ${reached.toFixed(3)}`,
+  )
+  assert.ok(firstOfSecondRun > 0.7, "the second run opened near the bottom of the ladder")
+})
+
+test("...but three wrong verdicts in a first run DO leave the child near the floor", () => {
+  // The honest other half, stated rather than hidden. `START` is 0.2 and `DOWN` is
+  // 0.11, so a run that ends on three wrong verdicts leaves the standing request at
+  // zero: the easiest content the curriculum has. That is deliberate — a child who
+  // got their first three calls wrong should be met at the bottom — but it is a real
+  // consequence of `DOWN > START / 2` and it should not be a surprise to whoever
+  // changes either constant.
   const ladder = new Ladder()
-  for (let i = 0; i < 8; i++) ladder.settle("bank", 1)
-  const reached = ladder.difficulty
-  ladder.reset()
-  assert.equal(ladder.difficulty, reached)
+  for (let i = 0; i < 3; i++) ladder.settle("dud", 0)
+  assert.equal(ladder.difficulty, 0)
+  assert.ok(DOWN * 3 > START, "the arithmetic this test describes no longer holds")
 })

--- a/dynawalla/games/truedraw/src/game/ladder.ts
+++ b/dynawalla/games/truedraw/src/game/ladder.ts
@@ -98,7 +98,20 @@ export function stepFor(outcome: Outcome, quickness: number): number {
   return UP_MIN + (UP_MAX - UP_MIN) * credit
 }
 
-/** The one number, and the only thing that moves it. */
+/**
+ * The one number, and the only thing that moves it.
+ *
+ * **A run ending does not touch it, and there is no method that could.** A child
+ * who reached rung eight and then ran out of shots is a child who can do rung
+ * eight; handing them `1 + 0 = 1` again because a run ended is the exact complaint
+ * this module answers. What a finished run costs is the run, not the standing —
+ * `mount.ts` builds one `Dealer`, and therefore one of these, per mount.
+ *
+ * There used to be a no-op `reset()` here to say so. It said nothing: an empty
+ * method body cannot be wrong, so the test for it could not fail. The standing is
+ * now asserted where it is observable, by playing two runs through one dealer —
+ * see `ladder.test.ts`.
+ */
 export class Ladder {
   private at: number
 
@@ -114,14 +127,6 @@ export class Ladder {
   settle(outcome: Outcome, quickness: number): number {
     this.at = clamp(this.at + stepFor(outcome, quickness))
     return this.at
-  }
-
-  /** A new run starts where the last one left off; the child did not get worse. */
-  reset(): void {
-    // Deliberately NOT back to START. A child who reached rung eight and then ran
-    // out of shots is a child who can do rung eight; handing them `1 + 0 = 1`
-    // again because a run ended is the exact complaint this module answers. What a
-    // finished run costs is the run, not the standing.
   }
 }
 

--- a/dynawalla/games/truedraw/src/game/report.ts
+++ b/dynawalla/games/truedraw/src/game/report.ts
@@ -1,0 +1,51 @@
+// The one place a settled round crosses the wire.
+//
+// It is a module rather than four lines inside `mount.ts` for a reason that is not
+// tidiness: **the branch in here is the single most consequential line in the pack,
+// and inside the mount it could not be tested against a host.** A harness that
+// drives `Round` never touches a `Host`, so the only guard on the routing was a
+// source-text assertion that `mount.ts` still contained the right shape — which is
+// a test of the spelling, not of the behaviour. Out here it takes a `Host` and can
+// be played against a stub for a whole run.
+//
+// ── the branch ───────────────────────────────────────────────────────────────
+//
+// Four of the five outcomes are things the child DID: a flick, at a moment, meaning
+// one thing. They go to `report`, with the value the child effectively asserted —
+// and on a wrong keep that value is the item's own mal-rule output, so the
+// misconception routes itself with no extra wiring.
+//
+// The fifth is `lapse`: the window closed on an untouched screen. It goes to
+// `skip`, and the reason it must not go to `report` is stated by the SDK itself:
+// `report({ correct: false, answered: "" })` is NOT filed as "unanswered". The
+// empty string fails to parse, the learner model takes a wrong attempt, and the
+// ladder steps DOWN — for a child who was still carrying the hundreds column. This
+// pack is one of the six the SDK names for having done exactly that.
+//
+// `skip` is feature-detected because a host shipped before it existed does not have
+// it. On such a host the item is left open, which is worse than closed and much
+// better than recorded as a miss.
+
+import type { Host } from "../contract.ts"
+import { isCorrect, reportsToCurriculum, responseFor, type Outcome } from "./response.ts"
+import type { Statement } from "./statement.ts"
+
+export type Settled = {
+  readonly outcome: Outcome
+  readonly statement: Statement
+  readonly reactionMs: number
+}
+
+export function reportSettled(host: Host, event: Settled): void {
+  const questionId = event.statement.questionId
+  if (reportsToCurriculum(event.outcome)) {
+    host.report({
+      questionId,
+      correct: isCorrect(event.outcome),
+      ms: event.reactionMs,
+      answered: responseFor(event.outcome, event.statement),
+    })
+    return
+  }
+  host.skip?.(questionId)
+}

--- a/dynawalla/games/truedraw/src/game/round.ts
+++ b/dynawalla/games/truedraw/src/game/round.ts
@@ -36,6 +36,28 @@ import { applyFlinch, applyOutcome, newRun, type Run } from "./run.ts"
 import { isCorrect, outcomeOf, type Call, type Outcome } from "./response.ts"
 import type { Statement } from "./statement.ts"
 
+/**
+ * The largest step the clock is allowed to take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Letting that through would
+ * spend a window, three shots and a whole run while the child was looking at
+ * something else, so it is clamped.
+ *
+ * **It was 120 ms, and 120 ms was a bias rather than a guard.** A device that
+ * drops to 5 fps produces real 200 ms frames, and clamping those makes `elapsed`
+ * accrue 120 ms for every 200 ms the child actually spent — so every reaction
+ * time on a slow phone was under-reported by about 40%, and the child collected a
+ * systematic speed bonus and a faster ladder climb for owning a worse device.
+ * Now that reaction time drives both the bag and the difficulty, that is not a
+ * rounding error.
+ *
+ * 400 ms is above any frame a running app produces — 2.5 fps — and far below the
+ * seconds-to-minutes a suspended one hands back. Jank is charged to the child,
+ * because during jank the child was there; suspension is not, because they were
+ * not.
+ */
+export const MAX_STEP_MS = 400
+
 export type Phase = "idle" | "raise" | "still" | "call" | "verdict" | "clear" | "over"
 
 export type RoundEvent =

--- a/dynawalla/games/truedraw/src/game/tempo.test.ts
+++ b/dynawalla/games/truedraw/src/game/tempo.test.ts
@@ -15,7 +15,7 @@ import { test } from "node:test"
 import { createStubHost } from "../stub/host.ts"
 import { perfect, playRun } from "../test/harness.ts"
 import { comprehensionMsFor } from "./cadence.ts"
-import { Round, TIMING } from "./round.ts"
+import { MAX_STEP_MS, Round, TIMING } from "./round.ts"
 import type { Statement } from "./statement.ts"
 
 /** A child who is certain, fast, on every slate. */
@@ -81,8 +81,16 @@ test("NOW: a certain child pays what they thought, whichever verdict it is", () 
       settled.reactionMs <= CERTAIN_MS + 40,
       `${call} cost ${String(settled.reactionMs)}ms of a ${String(window)}ms window`,
     )
-    // ...and it is 1/45th of what the same verdict used to cost.
-    assert.ok(settled.reactionMs * 40 < oldVerdictCostMs(truth, window, CERTAIN_MS) || truth)
+    // ...and for the verdict that used to be expressed by waiting, it is a fortieth
+    // of what it used to cost. Asserted only on that half of the pair: the `|| truth`
+    // escape hatch this line used to carry made the other half tautological, which is
+    // worse than not asserting it.
+    if (!truth) {
+      assert.ok(
+        settled.reactionMs * 40 < oldVerdictCostMs(truth, window, CERTAIN_MS),
+        `a toss costs ${String(settled.reactionMs)}ms against the old ${String(oldVerdictCostMs(truth, window, CERTAIN_MS))}ms`,
+      )
+    }
   }
 })
 
@@ -146,6 +154,28 @@ test("NEITHER verdict now costs more than the other — the asymmetry is gone", 
 // WHAT THE LATENCY MEASURES. Three anchors are wrong and one is right, and two
 // sibling packs shipped the wrong ones.
 // ---------------------------------------------------------------------------
+
+test("a frame a slow phone actually produces is charged to the child", () => {
+  // `MAX_STEP_MS` was 120, which is below a real frame on a device dropping to 5 fps —
+  // so `elapsed` accrued 120ms for every 200ms the child actually spent, every reaction
+  // time on a slow phone was under-reported by about 40%, and the child collected a
+  // systematic speed bonus and a faster ladder climb for owning a worse device. Now
+  // that the reaction time drives both the bag and the difficulty, that is a bias and
+  // not a rounding error.
+  assert.ok(
+    MAX_STEP_MS >= 250,
+    `MAX_STEP_MS is ${String(MAX_STEP_MS)}ms, which clamps frames a running app produces`,
+  )
+  // Jank is charged; suspension is not. A round driven in 200ms lumps reports the real
+  // elapsed time.
+  const round = new Round(() => statement(true, 14000), TIMING)
+  round.tap()
+  round.advance(TIMING.raise + 320)
+  for (let i = 0; i < 10; i++) round.advance(Math.min(MAX_STEP_MS, 200))
+  const settled = round.verdict("keep").find((e) => e.kind === "settled")
+  assert.ok(settled?.kind === "settled")
+  assert.equal(settled.reactionMs, 2000, "a janky two seconds was not charged in full")
+})
 
 test("the clock starts when the statement becomes ANSWERABLE, not when the slate is drawn", () => {
   // The slate rises and stands blank for ~320 ms before the statement is cut in. Not

--- a/dynawalla/games/truedraw/src/game/wiring.test.ts
+++ b/dynawalla/games/truedraw/src/game/wiring.test.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url"
 
 import { createStubHost } from "../stub/host.ts"
 import { alwaysWait, perfect, playRun } from "../test/harness.ts"
+import { reportSettled } from "./report.ts"
 
 const read = (relative: string): string =>
   readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8")
@@ -29,31 +30,50 @@ const strip = (source: string): string =>
     .join("\n")
 
 const MOUNT = strip(read("../mount.ts"))
+const REPORT = strip(read("./report.ts"))
 const STATEMENT = strip(read("./statement.ts"))
 const DEALER = strip(read("./dealer.ts"))
 
 const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1
 
-test("A LAPSE GOES TO host.skip AND NEVER TO host.report", () => {
-  // The regression this exists for is not hypothetical: this pack was one of the six
-  // named in the SDK as having reported timeouts as `{ correct: false, answered: "" }`,
-  // which is filed as a MISS and steps the ladder DOWN for a child who was still
-  // thinking. There is exactly one `report` and exactly one `skip`, and the `skip` is
-  // in the else of the guard.
-  assert.equal(count(MOUNT, "host.report("), 1, "a new report call appeared in mount.ts")
-  assert.equal(count(MOUNT, "host.skip?.("), 1, "the skip call is gone or duplicated")
-  assert.ok(MOUNT.includes("reportsToCurriculum(event.outcome)"), "the report is unguarded again")
-  const settled = MOUNT.slice(MOUNT.indexOf('case "settled"'))
-  const guard = settled.indexOf("reportsToCurriculum(")
-  const report = settled.indexOf("host.report(")
-  const skip = settled.indexOf("host.skip?.(")
-  assert.ok(guard !== -1 && guard < report, "the report is no longer behind the guard")
-  assert.ok(report < skip, "the skip is not in the else branch of the guard")
-  // And nothing reports an empty string on purpose, which is the shape of the bug.
+test("there is exactly ONE place a settled round crosses the wire", () => {
+  // The behaviour is proved against a host further down. What this guards is that a
+  // SECOND path does not appear later — a "quick" report added inline in the mount
+  // would bypass the branch entirely and nothing about it would look wrong.
+  assert.equal(count(MOUNT, "host.report("), 0, "mount.ts reports directly again")
+  assert.equal(count(MOUNT, "host.skip"), 0, "mount.ts skips directly again")
+  assert.equal(count(MOUNT, "reportSettled(host, event)"), 1, "the one seam is gone or doubled")
+  assert.equal(count(REPORT, "host.report("), 1, "report.ts grew a second report call")
+  assert.equal(count(REPORT, "host.skip?.("), 1, "report.ts grew a second skip call")
+  assert.ok(REPORT.includes("reportsToCurriculum(event.outcome)"), "the report is unguarded")
+  // And nothing reports a literal empty answer on purpose, which is the shape of the
+  // bug: the SDK files the empty string as a MISS, not as "unanswered".
+  assert.ok(!/answered:\s*""/.test(REPORT + MOUNT), "a literal empty answer is being reported")
+})
+
+test("THE POINTER LATCH HAS A GUARANTEED RELEASE, and pointerup is not one", () => {
+  // The regression, and it is the worst one this rework could ship. The mount latches
+  // one pointer id so a second finger cannot be a second verdict. `game-chrome`'s
+  // manual installs its pointer swallower as a CAPTURE-phase listener on `globalThis`
+  // and stops every event not aimed at its own nodes while it is open — so a finger
+  // resting on the glass when a child taps how-to-play never delivers its `pointerup`
+  // to this canvas. Without another way out, the latch is held forever and the game
+  // goes permanently deaf to touch.
+  assert.ok(MOUNT.includes("const releasePointer ="), "the single release path is gone")
   assert.ok(
-    !/answered:\s*""/.test(MOUNT),
-    "mount.ts reports a literal empty answer, which the host files as a miss",
+    MOUNT.includes('canvas.addEventListener("lostpointercapture"'),
+    "a lost capture no longer clears the latch",
   )
+  const tick = MOUNT.slice(MOUNT.indexOf("const tick ="), MOUNT.indexOf("const liveDrag ="))
+  assert.ok(
+    /guide\.isOpen[\s\S]{0,200}releasePointer\(\)/.test(tick),
+    "the frame loop no longer releases the latch while the manual is open",
+  )
+  const pause = MOUNT.slice(MOUNT.indexOf("pause(): void {"))
+  assert.ok(pause.includes("releasePointer()"), "pause no longer clears the latch")
+  // And the manual is checked before a touch is accepted at all.
+  const downFn = MOUNT.slice(MOUNT.indexOf("const down ="), MOUNT.indexOf("const move ="))
+  assert.ok(downFn.includes("guide.isOpen"), "a touch behind the sheet is accepted as a gesture")
 })
 
 test("the window comes from the cadence table, with nothing clamping it", () => {
@@ -109,24 +129,79 @@ test("a tap is never a verdict, anywhere in the mount", () => {
 // And the same two claims played rather than read, through the stub host.
 // ---------------------------------------------------------------------------
 
-test("a lapse reaches skip and never reaches report, end to end", () => {
+/**
+ * Every settled event of a run, routed through the REAL `reportSettled` into a real
+ * stub host — which is the whole reason that branch lives in `report.ts` and not
+ * inside `mount.ts`.
+ *
+ * The previous version of this test built the same two arrays and then filled them
+ * from its own `if (event.outcome === "lapse")`, because a harness that drives
+ * `Round` never touches a `Host`. It therefore asserted its own `if` and passed with
+ * the entire routing block deleted from the mount. It was vacuous.
+ */
+function routeRun(
+  seed: number,
+  decide: Parameters<typeof playRun>[2],
+  options: Parameters<typeof playRun>[3] = {},
+): { reports: string[]; skips: string[]; outcomes: readonly string[] } {
   const reports: string[] = []
   const skips: string[] = []
   const host = createStubHost({
-    seed: 5,
-    onReport: (r) => reports.push(`${r.questionId}:${String(r.correct)}:${r.answered}`),
+    seed,
+    onReport: (r) => reports.push(`${r.questionId}|${String(r.correct)}|${r.answered}`),
     onSkip: (id) => skips.push(id),
   })
-  // The harness drives the round machine, and the mount's reporting is the thing under
-  // test — so the reporting rule is applied here exactly as `mount.ts` applies it.
-  const result = playRun(host, 6, alwaysWait, { limit: 20 })
+  const result = playRun(host, seed + 1, decide, options)
   for (const event of result.events) {
-    if (event.kind !== "settled") continue
-    if (event.outcome === "lapse") skips.push(event.statement.questionId)
-    else reports.push(event.statement.questionId)
+    if (event.kind === "settled") reportSettled(host, event)
   }
-  assert.ok(skips.length > 15, `only ${String(skips.length)} lapses in twenty rounds`)
-  assert.equal(reports.length, 0, `a lapse was reported: ${reports.join(",")}`)
+  return { reports, skips, outcomes: result.outcomes }
+}
+
+test("A LAPSE REACHES skip AND NEVER REACHES report — through the real host seam", () => {
+  const { reports, skips, outcomes } = routeRun(5, alwaysWait, { limit: 20 })
+  assert.ok(outcomes.every((o) => o === "lapse"))
+  assert.ok(skips.length > 15, `only ${String(skips.length)} lapses reached items.skip`)
+  assert.equal(reports.length, 0, `a lapse was reported: ${reports.join(", ")}`)
+})
+
+test("and every performed verdict reaches report, with the value the child asserted", () => {
+  // The counterweight: the test above would also pass if `reportSettled` did nothing
+  // at all.
+  const { reports, skips } = routeRun(15, perfect, { limit: 20, thinkMs: () => 200 })
+  assert.ok(reports.length > 15, `only ${String(reports.length)} verdicts reached items.answer`)
+  assert.equal(skips.length, 0, `a performed verdict was skipped: ${skips.join(", ")}`)
+  // Every one of them is judged correct and carries a parseable numeral — never the
+  // empty string, which is the shape of the bug this whole seam exists for.
+  for (const line of reports) {
+    const [, correct, answered] = line.split("|")
+    assert.equal(correct, "true", line)
+    assert.ok(answered !== undefined && answered.length > 0 && /^\d+$/.test(answered), line)
+  }
+})
+
+test("a wrong keep reaches report as a miss carrying the mal-rule value", () => {
+  // The format's best property, through the seam: the host records the miss AND names
+  // the misconception the child just demonstrated.
+  const { reports } = routeRun(25, () => "keep", { limit: 20, thinkMs: () => 200 })
+  const misses = reports.filter((line) => line.split("|")[1] === "false")
+  assert.ok(misses.length > 0, "a keep-everything bot produced no misses")
+  for (const line of misses) {
+    const answered = line.split("|")[2]
+    assert.ok(answered !== undefined && /^\d+$/.test(answered), `no mal-rule value on ${line}`)
+  }
+})
+
+test("a wrong toss reaches report as a miss with no misconception invented for it", () => {
+  // "I do not believe 47 + 25 = 72" is not a broken procedure with an output, so
+  // nothing is named. It is still a miss and it is still sent — which is exactly what
+  // the second gesture bought.
+  const { reports } = routeRun(35, () => "toss", { limit: 20, thinkMs: () => 200 })
+  const misses = reports.filter((line) => line.split("|")[1] === "false")
+  assert.ok(misses.length > 0, "a toss-everything bot produced no misses")
+  for (const line of misses) {
+    assert.equal(line.split("|")[2], "", `a mal-rule was invented for a burn: ${line}`)
+  }
 })
 
 test("a fast correct player drags the request up the ladder, question by question", () => {

--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -25,23 +25,14 @@ import { bestBag, recordBag } from "./game/best.ts"
 import { Dealer } from "./game/dealer.ts"
 import { HAPTIC } from "./game/energy.ts"
 import { commitDistance, Gesture } from "./game/gesture.ts"
-import { isCorrect, reportsToCurriculum, responseFor } from "./game/response.ts"
-import { Round, TIMING, TIMING_REDUCED, type RoundEvent } from "./game/round.ts"
+import { reportSettled } from "./game/report.ts"
+import { isCorrect } from "./game/response.ts"
+import { MAX_STEP_MS, Round, TIMING, TIMING_REDUCED, type RoundEvent } from "./game/round.ts"
 import { Rng } from "./core/rng.ts"
 import { Scene, type Drag } from "./render/scene.ts"
 
 /** A milestone the child *reached*. Never fired when a run ends. */
 const TRANSITION_EVERY = 10
-
-/**
- * The largest step the clock is allowed to take in one frame.
- *
- * A backgrounded tab hands back a delta of minutes. Letting that through would
- * spend a window, three shots and a whole run while the child was looking at
- * something else. Clamping means time nearly stops when frames stop, which is the
- * only fair reading of "they were not here".
- */
-const MAX_STEP_MS = 120
 
 export function mountTrueDraw(
   el: HTMLElement,
@@ -149,27 +140,11 @@ export function mountTrueDraw(
         }
         case "settled": {
           coins = event.coins
-          // The host is the judge for the four outcomes somebody performed. What
-          // goes across is the value the child effectively asserted — and on a
-          // wrong keep that value is a mal-rule output, so the misconception
-          // routes itself.
-          //
-          // A LAPSE IS NOT ONE OF THEM. It reaches `skip`, not `report`. Reporting
-          // it as `{ correct: false, answered: "" }` is not "unanswered": the SDK
-          // is explicit that the empty string fails to parse and is filed as a
-          // MISS, which steps the ladder down for a child who was merely
-          // deliberate. `skip` is the ending that is honest AND closed — it takes
-          // the item off the host's books without recording anything against it.
-          if (reportsToCurriculum(event.outcome)) {
-            host.report({
-              questionId: event.statement.questionId,
-              correct: isCorrect(event.outcome),
-              ms: event.reactionMs,
-              answered: responseFor(event.outcome, event.statement),
-            })
-          } else {
-            host.skip?.(event.statement.questionId)
-          }
+          // Four of the five outcomes go to `report`; a lapse goes to `skip`.
+          // `report.ts` owns that branch and is tested against a host for a whole
+          // run — it is the most consequential line in the pack and it is not a
+          // line this file is able to prove anything about.
+          reportSettled(host, event)
           // And the request for the NEXT question moves. This is the other half of
           // the two-gesture design: every verdict now carries an honest latency, so
           // fast-and-right climbs nearly four times as fast as slow-and-right, and
@@ -215,7 +190,14 @@ export function mountTrueDraw(
     // Reading the rules is not playing. The manual opens over a live street, and a
     // window that ran while a child was reading would lapse every question they
     // looked away for — which would teach them that asking how to play is punished.
-    if (!guide.isOpen) handle(round.advance(dt))
+    if (guide.isOpen) {
+      // The manual swallows every pointer event aimed at the game, including the
+      // release. A latch held across that is a latch held forever — see
+      // `releasePointer`.
+      releasePointer()
+    } else {
+      handle(round.advance(dt))
+    }
     scene.draw({
       phase: round.phase,
       progress: round.progress,
@@ -227,6 +209,12 @@ export function mountTrueDraw(
       best,
       reduced,
       drag,
+      // The slate goes blank behind the sheet. It is blurred and dimmed by the
+      // manual's own scrim, but "mostly illegible" is the wrong standard for a
+      // file that argues at length against giving a child readable, unanswerable
+      // thinking time — the whole reason the statement is not drawn during the
+      // lead-in. The clock is stopped, so nothing is lost by hiding it.
+      masked: guide.isOpen,
     })
   }
 
@@ -285,11 +273,58 @@ export function mountTrueDraw(
     if (release === "tap") handle(round.tap())
   }
 
-  const cancel = (event: PointerEvent): void => {
-    if (pointer !== event.pointerId) return
+  /**
+   * Forget whatever finger we thought was down. Idempotent, and the ONE way out.
+   *
+   * ── why this is not just `cancel`'s body ─────────────────────────────────────
+   *
+   * The mount latches one pointer id so that a second finger cannot be a second
+   * verdict, and a latch needs a guaranteed release. `pointerup` is not one.
+   * `packs/shared/game-chrome/instructions.ts` installs its pointer swallower as a
+   * CAPTURE-phase listener on `globalThis` and calls `stopPropagation()` on every
+   * event whose target is not one of its own nodes while the sheet is open — so
+   * while the manual is up, `pointerup` never reaches this canvas at all. That
+   * module documents the trade deliberately: "a game holding a drag when the sheet
+   * opens does not get the release that ends it."
+   *
+   * Which is a real sequence and not a corner: a child holds the phone with one
+   * finger resting mid-flick on the glass and taps how-to-play with the other. The
+   * release is swallowed, the latch is never cleared, and from then on EVERY
+   * `pointerdown` returns at the `pointer !== null` guard. The game goes
+   * permanently deaf to touch — no verdict, no tap to start — and `resize` stops
+   * rebuilding the commit distance too, because that is gated on `!gesture.down`.
+   * Keyboard would still work, which on an iPad is no help at all.
+   *
+   * So the latch is released from three more places than `pointerup`: a cancel, a
+   * lost capture, and the frame loop the moment the manual is open.
+   */
+  const releasePointer = (): void => {
+    if (pointer !== null) {
+      try {
+        canvas.releasePointerCapture(pointer)
+      } catch {
+        // Already released, or never captured. Either way there is nothing to do.
+      }
+    }
     gesture.cancel()
     pointer = null
     drag = null
+  }
+
+  const cancel = (event: PointerEvent): void => {
+    if (pointer !== event.pointerId) return
+    releasePointer()
+  }
+
+  /**
+   * The browser took the capture away — the element moved, a system gesture won,
+   * the sheet went up. Whatever the reason, this sequence is over as far as we can
+   * tell, and holding the latch on the strength of a `pointerup` that may never
+   * arrive is how the game goes deaf.
+   */
+  const lostCapture = (event: PointerEvent): void => {
+    if (pointer !== event.pointerId) return
+    releasePointer()
   }
 
   const key = (event: KeyboardEvent): void => {
@@ -335,6 +370,7 @@ export function mountTrueDraw(
   canvas.addEventListener("pointermove", move)
   canvas.addEventListener("pointerup", up)
   canvas.addEventListener("pointercancel", cancel)
+  canvas.addEventListener("lostpointercapture", lostCapture)
   globalThis.addEventListener("keydown", key)
   globalThis.addEventListener("resize", resize)
 
@@ -357,9 +393,7 @@ export function mountTrueDraw(
     // Round.pause().
     pause(): void {
       round.pause()
-      gesture.cancel()
-      pointer = null
-      drag = null
+      releasePointer()
     },
     resume(): void {
       round.resume()
@@ -373,6 +407,7 @@ export function mountTrueDraw(
       canvas.removeEventListener("pointermove", move)
       canvas.removeEventListener("pointerup", up)
       canvas.removeEventListener("pointercancel", cancel)
+      canvas.removeEventListener("lostpointercapture", lostCapture)
       globalThis.removeEventListener("keydown", key)
       globalThis.removeEventListener("resize", resize)
       observer?.disconnect()

--- a/dynawalla/games/truedraw/src/render/scene.test.ts
+++ b/dynawalla/games/truedraw/src/render/scene.test.ts
@@ -8,6 +8,7 @@ import type { Phase } from "../game/round.ts"
 import { newRun, applyOutcome, type Run } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
 import { fakeCanvas, numbersIn, type Recorder } from "./fakeCanvas.ts"
+import { Gesture } from "../game/gesture.ts"
 import { Scene, type Drag, type SceneState } from "./scene.ts"
 
 const SIZES: readonly [number, number][] = [
@@ -75,24 +76,27 @@ test("the street draws without throwing at every phase, size, motion branch and 
           for (const progress of [0, 0.24, 0.5, 0.76, 1]) {
             for (const drag of DRAGS) {
               for (const coins of [0, 10, -12]) {
-                rec.reset()
-                s.draw(
-                  state({
-                    phase,
-                    outcome,
-                    progress,
-                    elapsedMs: progress * 900,
-                    reduced,
-                    drag,
-                    coins,
-                  }),
-                )
-                const bad = numbersIn(rec.ops).filter((n) => !Number.isFinite(n))
-                assert.equal(
-                  bad.length,
-                  0,
-                  `${String(w)}×${String(h)} ${phase}/${String(outcome)} drag=${JSON.stringify(drag)}`,
-                )
+                for (const masked of [false, true]) {
+                  rec.reset()
+                  s.draw(
+                    state({
+                      phase,
+                      outcome,
+                      progress,
+                      elapsedMs: progress * 900,
+                      reduced,
+                      drag,
+                      coins,
+                      masked,
+                    }),
+                  )
+                  const bad = numbersIn(rec.ops).filter((n) => !Number.isFinite(n))
+                  assert.equal(
+                    bad.length,
+                    0,
+                    `${String(w)}×${String(h)} ${phase}/${String(outcome)} drag=${JSON.stringify(drag)}`,
+                  )
+                }
               }
             }
           }
@@ -121,34 +125,125 @@ test("THE SLATE FOLLOWS THE FINGER, and it follows it the right way", () => {
   assert.ok(up < rest - 20, `an upward flick moved the slate from ${String(rest)} to ${String(up)}`)
 })
 
-test("THE DESTINATION LIGHTS UP UNDER A COMMITTING FINGER", () => {
-  // The affordance that means the controls do not have to be explained twice. The
-  // chevrons on the side you are heading for get brighter and thicker as you pull.
+/**
+ * The brightness of the chevrons ABOVE the slate and BELOW it, told apart by where
+ * they were actually drawn.
+ *
+ * The previous version of this took a `side` argument and then `void side`, returning
+ * the max alpha over every chevron in the frame — so its two calls computed the
+ * identical number and swapping the chute and the bag in `drawGutters` left it
+ * passing. A `stroke` op carries no coordinates, so each one is attributed to the y
+ * of the most recent `moveTo` before it, which does.
+ */
+function gutterGlow(
+  s: Scene,
+  rec: Recorder,
+  drag: Drag | null,
+): { above: number; below: number } {
+  rec.reset()
+  s.draw(state({ phase: "call", drag }))
+  // The STATIC layout, not the drawn slate: under a drag the slate moves and the
+  // gutters do not, so attributing chevrons to where the slate currently is would
+  // reclassify them the moment a finger pulled. `chute` is above the slate's rest
+  // position and `bag` is below it, by construction and by `street.test.ts`.
+  const { chute, bag } = s.layout
+  let cursorY = Number.NaN
+  let above = 0
+  let below = 0
+  for (const op of rec.ops) {
+    if (op.name === "moveTo") cursorY = Number(op.args[1])
+    if (op.name !== "stroke") continue
+    const alpha = Number(/rgba\(230, 194, 129, ([\d.]+)\)/.exec(op.style)?.[1] ?? Number.NaN)
+    if (!Number.isFinite(alpha) || !Number.isFinite(cursorY)) continue
+    // A chevron's `moveTo` is one of its two feet, so the band is widened by the
+    // chevron's own rise rather than being the box exactly.
+    const rise = chute.h
+    if (cursorY <= chute.y + chute.h + rise) above = Math.max(above, alpha)
+    else if (cursorY >= bag.y - rise) below = Math.max(below, alpha)
+  }
+  return { above, below }
+}
+
+test("THE DESTINATION LIGHTS UP UNDER A COMMITTING FINGER — the RIGHT one", () => {
+  // The affordance that means the controls do not have to be explained twice, and the
+  // direction is half of it: pulling UP must light the chute above the slate and pulling
+  // DOWN must light the bag below it. Getting that backwards would teach a child the
+  // wrong gesture and would cost them a shot every time they believed it.
   const { scene: s, rec } = scene(390, 844)
-  const brightness = (drag: Drag | null, side: "top" | "bottom"): number => {
+  const idle = gutterGlow(s, rec, null)
+  const up = gutterGlow(s, rec, { dy: -70, pull: 0.95, heading: "toss" })
+  const down = gutterGlow(s, rec, { dy: 70, pull: 0.95, heading: "keep" })
+
+  assert.ok(idle.above > 0 && idle.below > 0, "the gutters are not drawn at rest at all")
+  assert.ok(
+    up.above > idle.above * 2,
+    `pulling up barely lit the chute: ${idle.above.toFixed(3)} → ${up.above.toFixed(3)}`,
+  )
+  assert.ok(
+    down.below > idle.below * 2,
+    `pulling down barely lit the bag: ${idle.below.toFixed(3)} → ${down.below.toFixed(3)}`,
+  )
+  // ...and the OTHER side stays where it was. This is the assertion the old version
+  // could not make, and the one that catches the two being swapped.
+  assert.ok(
+    up.below < up.above,
+    `pulling up lit the bag as brightly as the chute: below ${up.below.toFixed(3)} vs above ${up.above.toFixed(3)}`,
+  )
+  assert.ok(
+    down.above < down.below,
+    `pulling down lit the chute as brightly as the bag: above ${down.above.toFixed(3)} vs below ${down.below.toFixed(3)}`,
+  )
+})
+
+test("A COMMITTED FLICK LEAVES NO LIVE DRAG BEHIND IT", () => {
+  // The bug this closes: a finger does not stop when it crosses the threshold, it keeps
+  // travelling and then RESTS. The recogniser's live-drag accessors go neutral the
+  // instant a verdict commits (`gesture.ts`), so a slate that has been answered — and,
+  // 1.2s later, the NEXT slate — is never handed a drag from a finger that is merely
+  // still down.
+  const g = new Gesture(50)
+  g.begin(100, 400)
+  assert.equal(g.move(100, 460), "keep")
+  // The finger travels on, and then rests.
+  g.move(100, 700)
+  g.move(100, 700)
+  assert.equal(g.committed, true)
+  assert.equal(g.dy, 0, "a committed gesture still reports travel")
+  assert.equal(g.pull, 0)
+  assert.equal(g.heading, null)
+  // And the renderer therefore draws the slate at rest.
+  const { scene: s, rec } = scene(390, 844)
+  const yOf = (drag: Drag | null): number => {
     rec.reset()
     s.draw(state({ phase: "call", drag }))
-    const slate = rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)
-    const slateY = Number(slate?.args[1] ?? 0)
-    const chevrons = rec.ops.filter(
-      (op) => op.name === "stroke" && /rgba\(230, 194, 129/.test(op.style),
+    return Number(
+      rec.ops.find((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40)
+        ?.args[1],
     )
-    // The chevrons are stroked in a known brass; read the alpha out of the colour.
-    const alphas = chevrons.map((op) => Number(/, ([\d.]+)\)$/.exec(op.style)?.[1] ?? 0))
-    // Top-half chevrons are the chute, bottom-half are the bag; a `stroke` op carries
-    // no coordinates, so they are told apart by count and by the frame they appear in.
-    void slateY
-    void side
-    return alphas.length === 0 ? 0 : Math.max(...alphas)
   }
-  const idle = brightness(null, "top")
-  const pulling = brightness({ dy: -70, pull: 0.95, heading: "toss" }, "top")
-  assert.ok(
-    pulling > idle * 2,
-    `the chute barely changed under a committing finger: ${idle.toFixed(3)} → ${pulling.toFixed(3)}`,
-  )
-  const keeping = brightness({ dy: 70, pull: 0.95, heading: "keep" }, "bottom")
-  assert.ok(keeping > idle * 2, `the bag barely changed: ${idle.toFixed(3)} → ${keeping.toFixed(3)}`)
+  const live: Drag | null = g.down ? { dy: g.dy, pull: g.pull, heading: g.heading } : null
+  assert.equal(yOf(live), yOf(null), "the slate was drawn thrown by a finger merely resting")
+})
+
+test("THE SLATE GOES BLANK BEHIND A SHEET", () => {
+  // Same rule as the lead-in. The manual dims and blurs the frame, but "mostly
+  // illegible" is the wrong standard for readable, unanswerable thinking time in a game
+  // whose reaction clock now drives both the bag and the difficulty.
+  const { scene: s, rec } = scene(768, 1024)
+  for (const phase of ["call", "verdict"] as const) {
+    rec.reset()
+    s.draw(state({ phase, masked: true }))
+    const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+    assert.ok(
+      !texts.includes("4") && !texts.includes("9"),
+      `the statement was legible behind the sheet during ${phase}: ${texts.join("")}`,
+    )
+    // The slate itself still stands — it is masked, not removed.
+    assert.ok(
+      rec.ops.some((op) => op.name === "fillRect" && Number(op.args[0]) > 1 && Number(op.args[3]) > 40),
+      `the slate vanished during ${phase}`,
+    )
+  }
 })
 
 test("THE SLATE IS BLANK BEFORE THE WINDOW OPENS", () => {

--- a/dynawalla/games/truedraw/src/render/scene.ts
+++ b/dynawalla/games/truedraw/src/render/scene.ts
@@ -17,7 +17,7 @@ import type { Call, Outcome } from "../game/response.ts"
 import { isCorrect } from "../game/response.ts"
 import { exitOf, type Phase } from "../game/round.ts"
 import type { Run } from "../game/run.ts"
-import { SHOTS } from "../game/run.ts"
+import { crowdOf, SHOTS } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
 import { correctionFor, digitCellWidth, layout, type Layout } from "./glyphs.ts"
 import { layoutFor, type Layout as Street } from "./street.ts"
@@ -67,6 +67,14 @@ export type SceneState = {
   readonly best: number
   readonly reduced: boolean
   readonly drag: Drag | null
+  /**
+   * The host or the manual has something over the frame. The slate stands, blank.
+   *
+   * Same rule as the lead-in: a statement a child can read but cannot answer is
+   * free thinking time that the reaction clock — which now drives both the bag and
+   * the difficulty — would have silently subtracted out of itself.
+   */
+  readonly masked?: boolean
 }
 
 /**
@@ -182,7 +190,7 @@ export class Scene {
    */
   private drawWitnesses(horizon: number, state: SceneState): void {
     const { ctx } = this
-    const count = Math.min(14, state.run.calls)
+    const count = crowdOf(state.run)
     for (let i = 0; i < count; i++) {
       const side = i % 2 === 0 ? -1 : 1
       const rank = Math.floor(i / 2)
@@ -423,7 +431,9 @@ export class Scene {
     // opens and not one millisecond before: it used to be legible for up to 1.15 s
     // of unanswerable lead-in, and every reaction time this game measures had that
     // lead-in silently subtracted out of it. See `statement.stillFor`.
-    else if (state.phase !== "raise" && state.phase !== "still") this.drawStatement(box, state, lit)
+    else if (state.phase !== "raise" && state.phase !== "still" && state.masked !== true) {
+      this.drawStatement(box, state, lit)
+    }
 
     ctx.restore()
   }


### PR DESCRIPTION
Follow-up to #701 (which merged out of the queue while I was still reviewing it). Self-review of the gesture rework found **one way to brick the pack** and **three tests that asserted their own `if`**.

## HIGH — the pointer latch could go deaf for the rest of the session

`src/mount.ts`. The mount latches one pointer id so a second finger cannot be a second verdict, and it was cleared in exactly three places: `pointerup`, `pointercancel`, `pause()`. **The in-pack manual eats all three.**

`packs/shared/game-chrome/instructions.ts` installs `swallowPointer` as a **capture-phase listener on `globalThis`** for `pointerdown/pointermove/pointerup/pointercancel`, and `stopPropagation()`s any event whose target is not one of its own nodes while the sheet is open. It documents the trade on purpose:

> "`pointerup` is swallowed along with the rest, which means a game holding a drag when the sheet opens does not get the release that ends it."

Repro — two fingers, which is how a child holds a phone:

1. Finger A down on the canvas mid-flick → `pointer = 1`, capture set.
2. Finger B taps how-to-play → the sheet opens. Finger A is still down.
3. Finger A lifts. `pointerup` is stopped in capture, so `up` never runs and `pointer` stays `1`.
4. Sheet closes. Every later `pointerdown` returns at `if (pointer !== null) return`.

**The game is permanently unresponsive to touch** — no verdict, no tap-to-start — until unmount or a host `pause()`/`resume()`. `resize()` also stops rebuilding the `Gesture`, since it is gated on `!gesture.down`, so every rotation from then on keeps a stale commit distance. Keyboard still works, which on an iPad is no help at all.

New in #701: `main`'s previous mount was a stateless `pointerdown`-only handler with no state to latch.

Fixed with one idempotent `releasePointer()`, called from `pointerup`, `pointercancel`, **`lostpointercapture`**, `pause()`, **and the frame loop the moment `guide.isOpen` is true.**

## MEDIUM — a committed flick left a live drag behind it

`src/game/gesture.ts`, `src/mount.ts`, `src/render/scene.ts`. `liveDrag()` was gated on `gesture.down`, not on whether the verdict had already fired. A finger does not stop when it crosses the threshold — it travels on and then **rests**, and `Gesture.move` keeps recording `x`/`y` for all of it. `pull` is clamped; `dy` deliberately is not, because the renderer wants real travel so the slate has weight — and `slateBox` uses the raw value.

So: child flicks down and rests their thumb, last `pointermove` at `dy ≈ 300`. `bank 500 + clear 200 + raise 220 + still ≈320 = 1240 ms` later the **next** slate enters `call` with that drag still live — rendered 165 px below rest with the bag chevrons at full brightness, off the bottom of a phone, unreadable, and unanswerable with that finger (the `Gesture` is still `fired`) until they lift. The round lapses.

Fixed on the concept rather than at the call site: `dy`, `pull` and `heading` are *the live drag* and go neutral the instant a verdict commits, so no future reader can reintroduce it.

## Three tests that could not fail

* **`wiring.test.ts`'s end-to-end lapse test tested nothing.** It built a stub host with `onReport`/`onSkip`, but `playRun` only drives `Round` and never touches a `Host` — so those arrays stayed empty and the test filled them from its own `if (event.outcome === "lapse")`. With `alwaysWait` every outcome is a lapse, so `reports.length === 0` followed from the bot plus the test's own branch. **It passed with the entire routing block deleted from `mount.ts`.**

  The branch is now `src/game/report.ts` — a module, because *inside the mount the most consequential line in the pack could not be tested against a host at all* — and four tests play whole runs through it: a lapse reaches `skip` and never `report`; every performed verdict reaches `report` with a parseable numeral; a wrong keep carries the mal-rule value; a wrong toss carries none.

* **`scene.test.ts`'s destination test was direction-blind.** The helper took `side: "top" | "bottom"` and then `void side`, returning the max alpha over *every* chevron in the frame — so both calls computed the identical number. **Swapping the chute and the bag in `drawGutters` left it passing**, which would have taught a child the wrong gesture and cost them a shot every time they believed it. It now attributes each `stroke` to the static layout band its preceding `moveTo` landed in (static, because under a drag the slate moves and the gutters do not) and asserts the *other* side stays dark.

* **`ladder.test.ts` asserted that an empty method body was empty.** `Ladder.reset()` had no statements and no production caller. `reset()` is deleted; the standing difficulty is now asserted where it is observable — two whole runs through one `Dealer`, checking what the host is asked for on the first question of the second run. Its honest other half is asserted too: `DOWN * 3 > START`, so three wrong verdicts in a *first* run do leave a child at the floor. That is deliberate, and it should not surprise whoever next changes either constant.

## Also

* **`MAX_STEP_MS` 120 → 400**, moved to `round.ts` where the clock lives. At 120 a device dropping to 5 fps produces real 200 ms frames, so `elapsed` accrued 120 ms for every 200 ms the child actually spent: every reaction time on a slow phone was under-reported by ~40%, and the child collected a systematic speed bonus **and** a faster ladder climb for owning a worse device. Now that latency drives both the bag and the difficulty that is a bias, not a rounding error. 400 ms is above any frame a *running* app produces (2.5 fps) and far below the seconds-to-minutes a suspended one hands back — jank is charged to the child because during jank they were there; suspension is not.
* **The slate goes blank behind a sheet.** The manual blurs 7 px and dims 66%, but "mostly illegible" is the wrong standard for readable, unanswerable thinking time in exactly the file that argues at length against that channel — it is why the statement is not drawn during the lead-in either. The clock is stopped, so nothing is lost.
* `tempo.test.ts:85` had `assert.ok(... || truth)`, which made half of one assertion tautological. Removed.
* `scene.ts` reads `crowdOf` from `run.ts` instead of a hardcoded `Math.min(14, …)`.
* `gesture.ts` cited `packs/shared/sdk/src/tapzoom.ts`; the real path is `dynawalla/packs/sdk/src/tapzoom.ts`.

## Verification

**245 tests, 5 consecutive clean runs**, `tsc --noEmit` clean, `build:pack` clean, `packs/sdk` 94/94 (Node 24.18.0).

**Each of the seven fixes deleted and confirmed to fail:**

| mutation | failure |
|---|---|
| the frame loop stops releasing the latch | `the frame loop no longer releases the latch while the manual is open` |
| `lostpointercapture` listener removed | `a lost capture no longer clears the latch` |
| live drag reports travel after commit | `a committed gesture still reports travel` / `300 !== 0` |
| a lapse reported as an empty answer | `report.ts grew a second report call` / `only 0 lapses reached items.skip` |
| the chute and the bag swapped | `pulling up barely lit the chute: 0.060 → 0.060` |
| the mask guard removed | `the statement was legible behind the sheet during call: 4003 − 87 = 39260` |
| `MAX_STEP_MS` back to 120 | `MAX_STEP_MS is 120ms, which clamps frames a running app produces` |

## Still needs a device

Unchanged from #701, plus: the two-finger manual sequence above is reasoned from `instructions.ts`'s own documented behaviour and closed in code, but it has not been reproduced on hardware. `lostpointercapture` firing when a cross-realm capture listener swallows the release is not something a Node harness can observe.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
