### PR TITLE
fix(dynawalla): the host can now see a frame with no game in it, and FUSE stops surviving on two accidents

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/frame.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.test.ts
@@ -7,10 +7,24 @@
 // `allow-same-origin` back in would be invisible in every other test in this
 // repository. This is the one that fails.
 
+import { readFileSync } from "node:fs"
 import { test, type TestContext } from "node:test"
 import assert from "node:assert/strict"
 
-import { mountPack } from "./frame.ts"
+import {
+  describeFault,
+  fillsWindow,
+  LIVENESS,
+  MIN_FILL,
+  mountPack,
+  newWatch,
+  step,
+  stillWatching,
+  type LivenessFault,
+  type LivenessLimits,
+  type Observation,
+  type Watch,
+} from "./frame.ts"
 import type { HostServices } from "./bridge.ts"
 import type { Capability, Connect, Settings } from "../../../packs/sdk/src/index.ts"
 
@@ -54,7 +68,19 @@ type Harness = {
   children: unknown[]
   listeners: Map<string, Set<(event: unknown) => void>>
   removed: boolean
+  /** Faults the host reported, in order. */
+  faults: LivenessFault[]
+  /** The box the frame reports from here on. */
+  setBox(width: number, height: number): void
   fire(event: { source: unknown; data: unknown }): void
+}
+
+/** How a mount may be varied. Everything omitted behaves like a healthy app. */
+type HarnessOptions = {
+  readonly granted?: readonly Capability[]
+  /** The frame's box. Defaults to a 820x1180 tablet, which is what it is. */
+  readonly box?: { readonly width: number; readonly height: number }
+  readonly liveness?: Partial<LivenessLimits>
 }
 
 /**
@@ -71,12 +97,18 @@ type Harness = {
  * `dispose()` is idempotent (there is a test for it), so tests may still call it
  * themselves where the call is the thing being asserted.
  */
-function harness(t: TestContext, granted: readonly Capability[] = ["items"]): Harness {
+function harness(t: TestContext, options: HarnessOptions = {}): Harness {
+  const granted = options.granted ?? ["items"]
   const posted: Posted[] = []
   const children: unknown[] = []
+  const faults: LivenessFault[] = []
   const listeners = new Map<string, Set<(event: unknown) => void>>()
   const attributes = new Map<string, string>()
   const state = { removed: false }
+  // A real frame, in a real app, on a real tablet. The liveness watch measures
+  // this, so a fake that reported nothing would make every liveness assertion
+  // below vacuous.
+  const box = { width: options.box?.width ?? 820, height: options.box?.height ?? 1180 }
 
   const contentWindow = {
     postMessage: (data: unknown, targetOrigin: string, transfer: readonly MessagePort[] = []) => {
@@ -86,6 +118,8 @@ function harness(t: TestContext, granted: readonly Capability[] = ["items"]): Ha
 
   const frame: Record<string, unknown> = {
     contentWindow,
+    isConnected: true,
+    getBoundingClientRect: () => ({ ...box }),
     setAttribute: (name: string, value: string) => attributes.set(name, value),
     getAttribute: (name: string) => attributes.get(name) ?? null,
     addEventListener: () => {},
@@ -94,8 +128,10 @@ function harness(t: TestContext, granted: readonly Capability[] = ["items"]): Ha
     },
   }
 
-  const doc = { createElement: () => frame } as unknown as Document
+  const doc = { createElement: () => frame, visibilityState: "visible" } as unknown as Document
   const win = {
+    innerWidth: 820,
+    innerHeight: 1180,
     addEventListener: (type: string, listener: (event: unknown) => void) => {
       const set = listeners.get(type) ?? new Set()
       set.add(listener)
@@ -120,6 +156,8 @@ function harness(t: TestContext, granted: readonly Capability[] = ["items"]): Ha
     title: "Abacus Tower",
     document: doc,
     window: win,
+    onFault: (fault) => faults.push(fault),
+    ...(options.liveness ? { liveness: options.liveness } : {}),
   })
   t.after(() => mounted.dispose())
 
@@ -129,6 +167,11 @@ function harness(t: TestContext, granted: readonly Capability[] = ["items"]): Ha
     posted,
     children,
     listeners,
+    faults,
+    setBox: (width, height) => {
+      box.width = width
+      box.height = height
+    },
     get removed() {
       return state.removed
     },
@@ -194,7 +237,7 @@ test("a ready from anywhere but this frame is ignored", (t) => {
 })
 
 test("the handshake transfers exactly one port and states the grant set", (t) => {
-  const test = harness(t, ["items", "haptics"])
+  const test = harness(t, { granted: ["items", "haptics"] })
   shake(test)
   assert.equal(test.mounted.connected(), true)
   assert.equal(test.posted.length, 1)
@@ -222,7 +265,7 @@ test("a second ready does not hand out a second port", (t) => {
 })
 
 test("traffic on the port reaches the bridge and comes back", async (t) => {
-  const test = harness(t, ["items"])
+  const test = harness(t, { granted: ["items"] })
   shake(test)
   const packPort = test.posted[0]?.transfer[0]
   assert.ok(packPort)
@@ -280,4 +323,469 @@ test("mounting twice makes two independent packs — StrictMode does exactly thi
   assert.equal(second.mounted.connected(), true)
   assert.equal(second.removed, false)
   second.mounted.dispose()
+})
+
+/* -------------------------------------------------------------------------- */
+/* Liveness: noticing that a pack is showing a child nothing.                  */
+/*                                                                            */
+/* VOLTA shipped blank on both platforms and the only net was the handshake    */
+/* timeout, which a pack that connects and then draws nothing sails past.      */
+/* These are the two faults the host can observe for itself, and most of what  */
+/* is below is the other half of the job: proving the watch stays quiet in     */
+/* every situation where a working pack legitimately measures zero or says     */
+/* nothing. A false "this pack is broken" is worse than the silence.           */
+/* -------------------------------------------------------------------------- */
+
+/** A healthy tablet: visible, measurable, filling the window, and it has spoken. */
+const HEALTHY: Observation = {
+  visible: true,
+  measurable: true,
+  width: 820,
+  height: 1180,
+  windowWidth: 820,
+  windowHeight: 1180,
+  messages: 1,
+}
+
+/**
+ * Run a sequence of observations through the watch and collect everything said.
+ *
+ * `dtMs` defaults to the real poll interval, so a count of observations is a
+ * duration and the thresholds under test are the shipped ones.
+ */
+function watchThrough(
+  observations: readonly Observation[],
+  asksForItems = true,
+  limits: LivenessLimits = LIVENESS,
+): { readonly said: readonly LivenessFault[]; readonly watch: Watch } {
+  let watch = newWatch()
+  const said: LivenessFault[] = []
+  for (const observation of observations) {
+    const result = step(watch, observation, limits.pollMs, asksForItems, limits)
+    watch = result.watch
+    said.push(...result.faults)
+  }
+  return { said, watch }
+}
+
+/** `count` copies of one observation. */
+const held = (observation: Observation, count: number): Observation[] =>
+  Array.from({ length: count }, () => observation)
+
+/** Enough ticks to pass a threshold twice over. */
+const ticksFor = (ms: number): number => Math.ceil((ms / LIVENESS.pollMs) * 2)
+
+test("a working pack is never accused, and stops being watched almost at once", () => {
+  const run = watchThrough(held(HEALTHY, ticksFor(LIVENESS.muteAfterMs)))
+  assert.equal(run.said.length, 0, `a healthy pack was accused of ${run.said.join(", ")}`)
+  // And the poll stops: the watch has its answer after one measurement, so a
+  // child's forty-minute session does not carry a timer that can never fire.
+  assert.equal(
+    stillWatching(run.watch, HEALTHY.messages, true),
+    false,
+    "the host kept polling a pack it had already cleared",
+  )
+})
+
+test("a frame with no box is reported, once, after five seconds of being visible", () => {
+  const blank: Observation = { ...HEALTHY, width: 820, height: 0 }
+  // One tick short of the threshold: still nothing said.
+  const early = watchThrough(held(blank, LIVENESS.blankAfterMs / LIVENESS.pollMs - 1))
+  assert.equal(early.said.length, 0, "the watch accused a frame before its grace ran out")
+
+  const run = watchThrough(held(blank, ticksFor(LIVENESS.blankAfterMs)))
+  assert.deepEqual(run.said, ["no-room"], "a frame measuring 820x0 was not reported exactly once")
+  assert.equal(stillWatching(run.watch, blank.messages, true), false)
+})
+
+test("the shape the host's own chain actually breaks into is reported", () => {
+  // 300x150 is not a guess. `Stage.tsx` wraps the frame in a `fixed; inset: 0`
+  // div, and `.pack-frame` / `.pack-frame-host` take their whole box from it by
+  // percentage. Taking that one declaration away was tried in a browser against
+  // the real `packs.css`: the frame does not become 0x0, it becomes 300x150 —
+  // an iframe's intrinsic default, which is what a replaced element falls back to
+  // when a percentage has nothing to resolve against.
+  //
+  // This is the case a check written against zero would have watched go past, and
+  // it is the most likely way this failure ever happens.
+  const defaulted: Observation = { ...HEALTHY, width: 300, height: 150 }
+  assert.equal(fillsWindow(defaulted), false, "a 300x150 iframe counts as filling a tablet")
+  const run = watchThrough(held(defaulted, ticksFor(LIVENESS.blankAfterMs)))
+  assert.deepEqual(run.said, ["no-room"], "the measured failure shape went unreported")
+})
+
+test("either axis counts — a frame the window's height but a sliver wide shows no game", () => {
+  for (const box of [
+    { width: 0, height: 1180 },
+    { width: 820, height: 0 },
+    { width: 0, height: 0 },
+    { width: 300, height: 150 },
+    { width: 820, height: 1180 * MIN_FILL - 1 },
+    { width: 820 * MIN_FILL - 1, height: 1180 },
+  ]) {
+    const run = watchThrough(held({ ...HEALTHY, ...box }, ticksFor(LIVENESS.blankAfterMs)))
+    assert.deepEqual(run.said, ["no-room"], `${box.width}x${box.height} was not reported`)
+  }
+})
+
+test("a small window is not a fault — the yardstick is the window, not a floor", () => {
+  // The false positive a fixed pixel floor would have shipped. A desktop user who
+  // drags the window down to a strip, a phone in split view, a WebView that has
+  // not finished sizing: in every one the frame still fills what it was given, and
+  // a pack drawn into all of a small window is a small game, not a broken one.
+  for (const [name, w, h] of [
+    ["a 320x568 phone", 320, 568],
+    ["a window dragged to a strip", 400, 180],
+    ["a single row of pixels", 900, 2],
+  ] as const) {
+    const small: Observation = {
+      ...HEALTHY,
+      width: w,
+      height: h,
+      windowWidth: w,
+      windowHeight: h,
+    }
+    assert.equal(fillsWindow(small), true, `${name}: a frame filling its window read as too small`)
+    const run = watchThrough(held(small, ticksFor(LIVENESS.muteAfterMs)))
+    assert.equal(run.said.length, 0, `${name}: reported ${run.said.join(", ")}`)
+  }
+})
+
+test("exactly at the threshold is not a fault; a pixel under it is", () => {
+  const at: Observation = { ...HEALTHY, width: 820 * MIN_FILL, height: 1180 * MIN_FILL }
+  assert.equal(fillsWindow(at), true, "the threshold is exclusive where it should be inclusive")
+  assert.equal(fillsWindow({ ...at, height: at.height - 1 }), false)
+})
+
+test("one full measurement, ever, settles it — a stage animating in is not broken", () => {
+  // The frame is zero for four seconds and then has a box. This is a stage
+  // transitioning in, a frame measured before first layout, and a tab that has
+  // just come back; all three had to be safe before this could ship at all.
+  const collapsed: Observation = { ...HEALTHY, height: 0 }
+  const run = watchThrough([
+    ...held(collapsed, (LIVENESS.blankAfterMs / LIVENESS.pollMs) - 4),
+    ...held(HEALTHY, ticksFor(LIVENESS.blankAfterMs)),
+  ])
+  assert.equal(run.said.length, 0, `an animating stage was accused of ${run.said.join(", ")}`)
+  assert.equal(run.watch.everFilled, true)
+})
+
+test("a frame that had a box and then lost it is the host's doing, not the pack's", () => {
+  // The other half of the latch, and the reason it is a latch rather than a
+  // first-few-seconds grace. A pack's stage either has a box or it does not, and
+  // which one is settled at mount; a frame going to zero *after* a minute of
+  // being fine is the host — a sheet, a rotation, a route change, a teardown —
+  // and blaming the pack for it would fire on every game a child ever leaves.
+  const run = watchThrough([
+    ...held(HEALTHY, 40),
+    ...held({ ...HEALTHY, height: 0 }, ticksFor(LIVENESS.blankAfterMs) * 4),
+  ])
+  assert.equal(run.said.length, 0, `a pack the host put away was accused of ${run.said.join(", ")}`)
+})
+
+test("time spent hidden or unmeasurable is not counted, however long it lasts", () => {
+  const cases: Array<[string, Observation]> = [
+    // A backgrounded tab. Layout may be stale and rAF is stopped; nothing
+    // measured here is evidence about the pack.
+    ["a backgrounded app", { ...HEALTHY, visible: false, width: 0, height: 0, messages: 0 }],
+    // The host hid the frame itself: a sheet over a paused pack, a teardown in
+    // flight, an ancestor with `display: none`.
+    ["a frame the host hid", { ...HEALTHY, measurable: false, width: 0, height: 0, messages: 0 }],
+  ]
+  for (const [name, observation] of cases) {
+    const run = watchThrough(held(observation, ticksFor(LIVENESS.muteAfterMs)))
+    assert.equal(run.said.length, 0, `${name}: reported ${run.said.join(", ")}`)
+    assert.equal(run.watch.visibleMs, 0, `${name}: unusable time was counted against the pack`)
+  }
+})
+
+test("a hidden app that comes back is judged on what it does afterwards, not before", () => {
+  const hiddenBlank: Observation = { ...HEALTHY, visible: false, height: 0, messages: 0 }
+  const visibleBlank: Observation = { ...HEALTHY, height: 0, messages: 0 }
+  const run = watchThrough([
+    ...held(hiddenBlank, 400),
+    ...held(visibleBlank, ticksFor(LIVENESS.blankAfterMs)),
+  ])
+  assert.deepEqual(run.said, ["no-room"])
+  // The five seconds were the visible ones, not the hundred spent hidden.
+  assert.ok(
+    run.watch.visibleMs < 400 * LIVENESS.pollMs,
+    "hidden time was charged to the pack after all",
+  )
+})
+
+test("a pack that spoke once is never called mute, however long it then idles", () => {
+  // Measured in a framed pack: 129 messages in the first 1.3 seconds and 13 more
+  // across the next five, whether anyone was playing or not. A gap in traffic is
+  // an idle child as often as a dead pack, so only never-having-spoken counts.
+  const idle: Observation = { ...HEALTHY, messages: 129 }
+  const run = watchThrough(held(idle, ticksFor(LIVENESS.muteAfterMs) * 4))
+  assert.equal(run.said.length, 0, `an idle pack was accused of ${run.said.join(", ")}`)
+})
+
+test("a pack that took its port and never used it is reported, once, after 30s", () => {
+  const mute: Observation = { ...HEALTHY, messages: 0 }
+  const early = watchThrough(held(mute, LIVENESS.muteAfterMs / LIVENESS.pollMs - 1))
+  assert.equal(early.said.length, 0, "the watch accused a pack that was still starting up")
+
+  const run = watchThrough(held(mute, ticksFor(LIVENESS.muteAfterMs)))
+  assert.deepEqual(run.said, ["never-spoke"])
+})
+
+test("a pack that was not granted items is not expected to ask for one", () => {
+  const mute: Observation = { ...HEALTHY, messages: 0 }
+  const run = watchThrough(held(mute, ticksFor(LIVENESS.muteAfterMs) * 4), false)
+  assert.equal(run.said.length, 0, `a pack with no items grant was accused of ${run.said.join(", ")}`)
+  assert.equal(stillWatching(run.watch, 0, false), false, "it is still being polled for nothing")
+})
+
+test("a pack that is both blank and mute is told about both, and each once", () => {
+  const dead: Observation = { ...HEALTHY, width: 820, height: 0, messages: 0 }
+  const run = watchThrough(held(dead, ticksFor(LIVENESS.muteAfterMs)))
+  assert.deepEqual(run.said, ["no-room", "never-spoke"])
+  assert.deepEqual(run.watch.said, ["no-room", "never-spoke"])
+})
+
+test("what is said names the pack, the measurement, and the lie it contradicts", () => {
+  const blank = describeFault("dynawalla.fuse", "no-room", { ...HEALTHY, width: 300, height: 150 })
+  assert.match(blank, /dynawalla\.fuse/)
+  assert.match(blank, /300x150/, "the message does not say what was measured")
+  assert.match(blank, /820x1180/, "the message does not say what it was measured against")
+
+  const mute = describeFault("dynawalla.fuse", "never-spoke", { ...HEALTHY, messages: 0 })
+  assert.match(mute, /dynawalla\.fuse/)
+  // The whole reason this fault is worth reporting: every game's entry answers a
+  // failed start by drawing "<GAME> runs inside Dynawalla", which is the
+  // standalone message. When the host sees this fault it knows that is false.
+  assert.match(mute, /runs\s+inside Dynawalla/)
+  assert.match(mute, /false/)
+})
+
+/* -------------------------------------------------------------------------- */
+/* Why the box is worth watching at all: the host's own stylesheet.            */
+/* -------------------------------------------------------------------------- */
+
+/** The declarations of one rule in the real `packs.css`. */
+function packsCssRule(selector: string): Map<string, string> {
+  const css = readFileSync(new URL("./packs.css", import.meta.url), "utf8")
+  // Comments first: `packs.css` is mostly prose, and a selector inside a comment
+  // is not a rule.
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, "")
+  const rule = new RegExp(`${selector.replace(".", "\\.")}\\s*\\{([^}]*)\\}`).exec(source)
+  assert.ok(rule, `packs.css has no ${selector} rule; this test is measuring the wrong element`)
+  const declarations = new Map<string, string>()
+  for (const part of (rule[1] ?? "").split(";")) {
+    const colon = part.indexOf(":")
+    if (colon < 0) continue
+    declarations.set(part.slice(0, colon).trim(), part.slice(colon + 1).trim())
+  }
+  return declarations
+}
+
+/** Every way a box can be given a size of its own, in one place. */
+const OWN_SIZE = [
+  "height",
+  "block-size",
+  "min-height",
+  "min-block-size",
+  "width",
+  "min-width",
+  "min-inline-size",
+  "aspect-ratio",
+]
+
+test("the frame's box is entirely its ancestor's, which is why it is watched", () => {
+  // The precondition the `no-room` fault exists for, read out of the real
+  // stylesheet rather than restated. `.pack-frame` is 100% of `.pack-frame-host`,
+  // which is 100% of the `fixed; inset: 0` div in `Stage.tsx`. Nothing in the
+  // chain has a size of its own, so the whole app is one edit away from handing a
+  // child a 300x150 iframe where a game should be.
+  //
+  // If this ever fails because the frame was given a real size, the fault is less
+  // necessary than it is today — and that is worth knowing deliberately rather
+  // than by a test quietly going green.
+  for (const selector of [".pack-frame", ".pack-frame-host"]) {
+    const rule = packsCssRule(selector)
+    assert.equal(rule.get("block-size"), "100%", `${selector} no longer sizes by percentage`)
+    assert.equal(rule.get("inline-size"), "100%", `${selector} no longer sizes by percentage`)
+    for (const property of OWN_SIZE) {
+      if (property === "block-size") continue
+      // `.pack-frame-host` sets `min-inline-size: 0`, which takes a size away
+      // rather than giving one.
+      if (property === "min-inline-size" && rule.get(property) === "0") continue
+      assert.equal(rule.get(property), undefined, `${selector} now has its own ${property}`)
+    }
+  }
+})
+
+/**
+ * An iframe's intrinsic size — what a replaced element falls back to when its
+ * percentage has nothing to resolve against. Not a choice of this codebase's:
+ * measured in a browser at exactly this, against this stylesheet.
+ */
+const IFRAME_DEFAULT = { width: 300, height: 150 }
+
+/**
+ * The used box of the frame, given the box of the ancestor `Stage.tsx` wraps it in.
+ *
+ * Resolved from what `packs.css` actually declares, down the real chain
+ * `.pack-frame-host` -> `.pack-frame`, rather than from what the file is
+ * remembered to say. A deliberately tiny slice of CSS and only the slice the
+ * frame's box depends on: a percentage of the containing block, an explicit
+ * length, or — when the ancestor's own box is gone and the percentage cannot
+ * resolve — the replaced element's intrinsic default.
+ *
+ * `null` for the ancestor is the failure: a stage div with no box of its own,
+ * which is what removing `fixed; inset: 0` from `Stage.tsx` produces.
+ */
+function frameBox(
+  ancestor: { width: number; height: number } | null,
+): { width: number; height: number } {
+  if (ancestor === null) return { ...IFRAME_DEFAULT }
+  let box = { ...ancestor }
+  for (const selector of [".pack-frame-host", ".pack-frame"]) {
+    const rule = packsCssRule(selector)
+    const resolve = (declared: string | undefined, against: number, intrinsic: number): number => {
+      if (declared === undefined) return intrinsic
+      if (declared.endsWith("%")) return (against * Number.parseFloat(declared)) / 100
+      if (declared.endsWith("px")) return Number.parseFloat(declared)
+      return intrinsic
+    }
+    box = {
+      width: resolve(rule.get("inline-size"), box.width, IFRAME_DEFAULT.width),
+      height: resolve(rule.get("block-size"), box.height, IFRAME_DEFAULT.height),
+    }
+  }
+  return box
+}
+
+test("the box the host's chain hands the frame, in both states, is what the watch judges", () => {
+  // The arithmetic joined to the fault. The frame's box IS the stage div's, so the
+  // failure is one edit away in `Stage.tsx` or in one rule here — and both
+  // directions are asserted, because a check that fires on a healthy 820x1180
+  // frame is worse than no check at all.
+  const window = { windowWidth: 820, windowHeight: 1180 }
+  const healthy = frameBox({ width: 820, height: 1180 })
+  assert.deepEqual(healthy, { width: 820, height: 1180 }, "the frame no longer fills its ancestor")
+
+  const broken = frameBox(null)
+  // The measurement, pinned. If this ever stops being 300x150 the threshold above
+  // was derived against a shape that no longer happens.
+  assert.deepEqual(broken, IFRAME_DEFAULT, "a boxless ancestor no longer defaults the frame")
+
+  const good = watchThrough(held({ ...HEALTHY, ...healthy, ...window }, ticksFor(LIVENESS.blankAfterMs)))
+  assert.equal(good.said.length, 0, `a full-size frame was accused of ${good.said.join(", ")}`)
+
+  const bad = watchThrough(held({ ...HEALTHY, ...broken, ...window }, ticksFor(LIVENESS.blankAfterMs)))
+  assert.deepEqual(bad.said, ["no-room"], "a defaulted frame went unreported")
+})
+
+/* -------------------------------------------------------------------------- */
+/* The same two faults, through the real mount.                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Short clocks, so the suite does not wait out half a minute of real time.
+ *
+ * Only ONE fault is armed at a time. Both thresholds live on the same visible
+ * clock, so a test that shortened both would be racing its own assertion against
+ * the second fault arriving — the exact shape of flake this file's `until`
+ * helper was written to avoid.
+ */
+const WATCH_BOX: Partial<LivenessLimits> = { pollMs: 4, blankAfterMs: 24, muteAfterMs: 3_600_000 }
+const WATCH_MUTE: Partial<LivenessLimits> = { pollMs: 4, blankAfterMs: 3_600_000, muteAfterMs: 40 }
+
+test("the watch starts at the handshake, not before it", async (t) => {
+  // A pack that never says `ready` is the handshake timeout's business, and
+  // accusing it of silence as well would be two messages about one failure.
+  t.mock.method(console, "error", () => {})
+  const test = harness(t, { box: { width: 0, height: 0 }, liveness: { pollMs: 4, blankAfterMs: 24, muteAfterMs: 40 } })
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  assert.equal(test.faults.length, 0, `an unconnected pack was accused of ${test.faults.join(", ")}`)
+})
+
+test("a mounted pack whose frame has no box is reported through the real mount", async (t) => {
+  const said: string[] = []
+  t.mock.method(console, "error", (message: string) => said.push(message))
+  const test = harness(t, { box: { width: 820, height: 0 }, liveness: WATCH_BOX })
+  shake(test)
+
+  await until(() => test.faults.includes("no-room"))
+  assert.deepEqual(test.faults, ["no-room"])
+  assert.deepEqual(test.mounted.faults(), ["no-room"])
+  // Once. A 250ms poll over a forty-minute session would otherwise be ten
+  // thousand copies of the same line, which is a log nobody reads.
+  await new Promise((resolve) => setTimeout(resolve, 60))
+  assert.deepEqual(test.faults, ["no-room"], "the fault was repeated")
+  assert.equal(said.length, 1, "the fault was not said out loud exactly once")
+  assert.match(said[0] ?? "", /820x0/)
+})
+
+test("a frame that gains a box before the grace runs out is never reported", async (t) => {
+  t.mock.method(console, "error", () => {})
+  const test = harness(t, { box: { width: 820, height: 0 }, liveness: WATCH_BOX })
+  shake(test)
+  await new Promise((resolve) => setTimeout(resolve, 8))
+  test.setBox(820, 1180)
+
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  assert.equal(test.faults.length, 0, `reported ${test.faults.join(", ")}`)
+})
+
+test("a pack that uses its port is never called mute; one that does not, is", async (t) => {
+  t.mock.method(console, "error", () => {})
+  const talker = harness(t, { liveness: WATCH_MUTE })
+  shake(talker)
+  const port = talker.posted[0]?.transfer[0]
+  assert.ok(port)
+  t.after(() => port.close())
+  port.start()
+  port.postMessage({ id: 1, method: "items.next", params: {} })
+
+  const mute = harness(t, { liveness: WATCH_MUTE })
+  shake(mute)
+
+  await until(() => mute.faults.includes("never-spoke"))
+  assert.deepEqual(mute.faults, ["never-spoke"], "a pack that never spoke was not reported")
+  assert.equal(
+    talker.faults.length,
+    0,
+    `a pack that used its port was accused of ${talker.faults.join(", ")}`,
+  )
+})
+
+test("disposing stops the watch, and clears its timer", async (t) => {
+  // Two claims, and the second is the expensive one.
+  //
+  // "A disposed pack is not accused" passes with the interval still running,
+  // because `tick` also returns early once `disposed` is set — so asserting only
+  // that would prove nothing about the teardown. What has to be asserted is the
+  // handle: a repeating timer nobody cleared keeps node's event loop alive, and
+  // this file's own harness note is about the fifteen minutes of runner time the
+  // last leaked handle here cost.
+  const started: unknown[] = []
+  const stopped: unknown[] = []
+  const reallySet = globalThis.setInterval
+  const reallyClear = globalThis.clearInterval
+  t.mock.method(globalThis, "setInterval", ((...args: Parameters<typeof globalThis.setInterval>) => {
+    const id = reallySet(...args)
+    started.push(id)
+    return id
+  }) as typeof globalThis.setInterval)
+  t.mock.method(globalThis, "clearInterval", ((id: Parameters<typeof globalThis.clearInterval>[0]) => {
+    stopped.push(id)
+    reallyClear(id)
+  }) as typeof globalThis.clearInterval)
+  t.mock.method(console, "error", () => {})
+
+  const test = harness(t, { box: { width: 0, height: 0 }, liveness: WATCH_BOX })
+  shake(test)
+  assert.equal(started.length, 1, "the handshake started no liveness watch at all")
+
+  test.mounted.dispose()
+  assert.equal(stopped.length, 1, "dispose cleared no interval")
+  assert.equal(stopped[0], started[0], "dispose cleared some other interval")
+
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  assert.equal(test.faults.length, 0, `a disposed pack was accused of ${test.faults.join(", ")}`)
 })

--- a/dynawalla/dynawalla-app/src/packs/frame.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.ts
@@ -34,6 +34,255 @@ import { createBridge } from "./bridge.ts"
 /** A pack that has not said `ready` by now is not going to. */
 const HANDSHAKE_TIMEOUT_MS = 20_000
 
+/* ------------------------------- liveness --------------------------------- */
+//
+// Everything below exists because VOLTA shipped in 0.3.1 completely blank on
+// iOS and Android and nothing here noticed. It never threw: it mounted, said
+// `ready`, took its port, warmed its question pool, built a WebGL context and a
+// HUD, and drew all of it into a box 820 pixels wide and zero tall. The
+// handshake timeout above is the right net for a pack that dies before
+// `connect()` — and it was the only net there was.
+//
+// ── What the host can and cannot see ────────────────────────────────────────
+//
+// The frame is sandboxed without `allow-same-origin`, so its document is
+// unreadable: there is no way to ask a pack how big its stage is, what it
+// painted, or whether it painted. Exactly two channels cross the boundary.
+//
+//   1. **The frame element's own box.** Ours, in our document, measurable.
+//   2. **The port.** Every message a pack sends arrives at `bridge.handle`.
+//
+// Both were measured against a real framed pack (`games/merge`, built, framed on
+// an opaque origin at 820x1180, driven through a run) with its stage
+// deliberately collapsed the way VOLTA's was:
+//
+//   * the frame element measured **820x1180** — healthy — while the stage inside
+//     it measured **820x0**;
+//   * the port carried **129 messages in the first 1.3 seconds** and 13 more
+//     across the next five, whether the game was visible or not.
+//
+// So neither channel separates a blank pack from a playing one, and **nothing
+// here could have caught VOLTA.** That collapse happened one document deeper
+// than the host can reach, and catching it needs the pack to measure its own
+// stage and say so — which is what `makeStage` and the stage-collapse error in
+// `games/runner` and `games/merge` now do, in the only place the measurement
+// exists.
+//
+// What the box *does* catch is the host's own copy of that bug, one level up,
+// which was completely unwatched. That is not hypothetical either: taking
+// `fixed; inset: 0` off the stage div in `Stage.tsx` was tried in a browser
+// against the real `packs.css`, and the frame comes out **300x150** — an iframe
+// with nothing to resolve its percentages against. Which is why the threshold
+// below is a share of the window rather than zero.
+//
+// What the two channels *do* catch is stated narrowly, and each fault below says
+// which real failure it is the net for. Neither is routed to `onError`: that
+// replaces the pack with a curtain and ends a child's run, and a false
+// "this pack is broken" is worse than the silence it replaces. They are said out
+// loud, once, and offered on `MountedPack.faults()`.
+
+/** A way a connected pack can be failing that the host can actually observe. */
+export type LivenessFault =
+  /**
+   * The frame is nowhere near filling the window it was given, so whatever the
+   * pack draws, the child is not seeing a game.
+   *
+   * This is the *host's* copy of the bug that blanked VOLTA, and it is the same
+   * shape: `.pack-frame` gets its box from `block-size: 100%` against
+   * `.pack-frame-host`, which gets one the same way from the `fixed; inset: 0`
+   * div in `Stage.tsx`, and everything a pack draws is inside it. One edit
+   * anywhere up that chain and the percentages resolve against nothing.
+   *
+   * The threshold is a *share of the window* rather than zero, and that is a
+   * measurement rather than a preference. Taking `fixed; inset: 0` off the stage
+   * div was tried in a real browser against the real `packs.css`: the frame does
+   * not go to zero, it goes to **300x150** — an iframe's intrinsic default size,
+   * which is what a replaced element falls back to when a percentage has nothing
+   * to resolve against. A check written against zero would have watched the most
+   * likely form of this failure go past.
+   *
+   * Half the window on either axis, because a window is the only honest
+   * yardstick here. An absolute floor would accuse a desktop user who made their
+   * window short; a share cannot, since a frame that fills a small window still
+   * fills it. And `Stage.tsx` deliberately puts no bar above or below the frame
+   * ("a bar above the frame is a bar that resizes the game every time the safe
+   * area changes"), so half a window is an enormous amount of slack for any host
+   * chrome that might one day be added — but not enough to hide a 150px strip.
+   */
+  | "no-room"
+  /**
+   * The pack took its port and then never used it.
+   *
+   * All twenty-eight shipping games do the same three things in the same order:
+   * `createGameHost()`, `await warm()`, then mount. `warm()` is `items.next`, so
+   * every one of them speaks within milliseconds of the handshake — measured at
+   * **11ms** in a real framed pack. A pack that was granted `items` and has said
+   * nothing at all after half a minute of being on screen never reached its game
+   * loop.
+   *
+   * This is the fault that contradicts `renderNoHost()`. Every game's entry
+   * catches a failure on the way up and draws "<GAME> runs inside Dynawalla" —
+   * the standalone message — so a pack that crashed while starting tells a child
+   * there is no host, and tells a developer the wrong thing. When the host sees
+   * this fault it knows that message is false: the pack connected to it. It
+   * catches a failure at or before `warm()`; a crash in `mount()` happens after
+   * the warm burst and is invisible here.
+   */
+  | "never-spoke"
+
+/**
+ * The share of the window on each axis a framed pack has to reach.
+ *
+ * See `"no-room"`. Not zero, because the measured failure is 300x150 rather than
+ * 0x0; and a share rather than a floor, because a small window is not a fault.
+ */
+export const MIN_FILL = 0.5
+
+/** The two clocks the faults above are judged against. */
+export type LivenessLimits = {
+  /** How often the frame is measured. */
+  readonly pollMs: number
+  /** Visible time a frame gets to fill the window it was given. */
+  readonly blankAfterMs: number
+  /** Visible time a pack granted `items` gets to ask for one. */
+  readonly muteAfterMs: number
+}
+
+export const LIVENESS: LivenessLimits = {
+  pollMs: 250,
+  // Generous, because the cost of being wrong is an accusation. A stage that is
+  // animating in, a frame measured before first layout and a frame in a tab that
+  // has just come back can all measure small or nothing for a moment; five
+  // seconds of *visible* time is far past any of them, and one full measurement
+  // at any point settles the question forever.
+  blankAfterMs: 5_000,
+  // Thirty seconds is roughly three thousand times the fleet's measured
+  // handshake-to-`items.next` latency. Nothing that starts at all takes it.
+  muteAfterMs: 30_000,
+}
+
+/** One measurement of the two things that cross the boundary. */
+export type Observation = {
+  /** Whether the host document was visible over the interval just elapsed. */
+  readonly visible: boolean
+  /**
+   * Whether the frame's box means anything right now.
+   *
+   * False when the host window has no box of its own, when the frame is not in
+   * the document, or when the host has hidden it — a sheet over a paused pack, a
+   * teardown in flight. A measurement the host caused is not a pack's fault, and
+   * the watch neither accuses on it nor counts the time.
+   */
+  readonly measurable: boolean
+  readonly width: number
+  readonly height: number
+  /** The window the frame is supposed to fill. The only honest yardstick. */
+  readonly windowWidth: number
+  readonly windowHeight: number
+  /** Messages received from the pack since the port was transferred. */
+  readonly messages: number
+}
+
+/** What the watch carries between observations. */
+export type Watch = {
+  /** Visible, measurable time since the handshake. */
+  readonly visibleMs: number
+  /** Set by the first measurement that filled the window, and never cleared. */
+  readonly everFilled: boolean
+  /** Faults already said. Each is said once. */
+  readonly said: readonly LivenessFault[]
+}
+
+export const newWatch = (): Watch => ({ visibleMs: 0, everFilled: false, said: [] })
+
+/** Whether a frame this size is showing a game in a window that size. */
+export function fillsWindow(observation: Observation): boolean {
+  return (
+    observation.width >= observation.windowWidth * MIN_FILL &&
+    observation.height >= observation.windowHeight * MIN_FILL
+  )
+}
+
+/**
+ * Fold one observation into the watch, and report anything newly wrong.
+ *
+ * A pure reducer, so the whole judgement — including every reason it should
+ * stay quiet — is testable as a sequence of observations rather than as a
+ * timing race against a browser.
+ *
+ * `asksForItems` is whether the pack was granted `items`. A pack that never
+ * asked for questions is not expected to request any, and "never-spoke" is not
+ * a fault it can commit.
+ */
+export function step(
+  watch: Watch,
+  observation: Observation,
+  dtMs: number,
+  asksForItems: boolean,
+  limits: LivenessLimits = LIVENESS,
+): { readonly watch: Watch; readonly faults: readonly LivenessFault[] } {
+  const usable = observation.visible && observation.measurable
+  const filled = usable && fillsWindow(observation)
+  const next: Watch = {
+    visibleMs: usable ? watch.visibleMs + dtMs : watch.visibleMs,
+    everFilled: watch.everFilled || filled,
+    said: watch.said,
+  }
+
+  const faults: LivenessFault[] = []
+  const say = (fault: LivenessFault) => {
+    if (!next.said.includes(fault)) faults.push(fault)
+  }
+  // A frame that has never once filled the window, after five seconds of being
+  // visible in a window that itself has a size.
+  if (usable && !next.everFilled && next.visibleMs >= limits.blankAfterMs) say("no-room")
+  // Silence, and only silence. One message at any point in the pack's life
+  // clears this forever — an idle child produces exactly as little traffic as a
+  // crashed pack, so a *gap* in traffic is not evidence of anything.
+  if (asksForItems && observation.messages === 0 && next.visibleMs >= limits.muteAfterMs) {
+    say("never-spoke")
+  }
+
+  return {
+    watch: faults.length === 0 ? next : { ...next, said: [...next.said, ...faults] },
+    faults,
+  }
+}
+
+/**
+ * Whether anything is still worth watching for.
+ *
+ * The box latches on its first full measurement and silence latches on the pack's
+ * first message, so a healthy pack stops being polled within a second of starting
+ * rather than for the length of a child's run.
+ */
+export function stillWatching(watch: Watch, messages: number, asksForItems: boolean): boolean {
+  const room = !watch.everFilled && !watch.said.includes("no-room")
+  const mute = asksForItems && messages === 0 && !watch.said.includes("never-spoke")
+  return room || mute
+}
+
+/** What is written to the console. Says what was measured, and what to go read. */
+export function describeFault(
+  packId: string,
+  fault: LivenessFault,
+  observation: Observation,
+): string {
+  const size = (w: number, h: number) => `${String(Math.round(w))}x${String(Math.round(h))}`
+  return fault === "no-room"
+    ? `[packs] ${packId} is framed at ${size(observation.width, observation.height)} in a ` +
+        `${size(observation.windowWidth, observation.windowHeight)} window. The pack may be ` +
+        `running perfectly; the child is not seeing a game. The frame's box comes from ` +
+        `.pack-frame -> .pack-frame-host -> the fixed, inset:0 div in Stage.tsx, and something ` +
+        `in that chain has stopped giving it one — 300x150 is an iframe with nothing to resolve ` +
+        `its percentages against.`
+    : `[packs] ${packId} took its port and has not sent one message since. Every game asks for ` +
+        `an item before it mounts, so this pack did not get that far. If it is showing "runs ` +
+        `inside Dynawalla", that message is false — it is connected to this host.`
+}
+
+/* -------------------------------------------------------------------------- */
+
 export type MountOptions = {
   readonly container: HTMLElement
   readonly packId: string
@@ -45,9 +294,19 @@ export type MountOptions = {
   /** The frame's accessible name. A pack is a region of the app, not a picture. */
   readonly title: string
   readonly onError?: (reason: string) => void
+  /**
+   * Told when the host can see for itself that this pack is showing nothing.
+   *
+   * Deliberately not `onError`: that draws a curtain over the pack and ends the
+   * run, and neither fault is certain enough to spend a child's session on. The
+   * faults are always written to the console whether this is given or not.
+   */
+  readonly onFault?: (fault: LivenessFault, message: string) => void
   /** Injected in tests. Defaults to the real document. */
   readonly document?: Document
   readonly window?: Window
+  /** Injected in tests, so a suite does not wait out half a minute. */
+  readonly liveness?: Partial<LivenessLimits>
 }
 
 export type MountedPack = {
@@ -55,6 +314,8 @@ export type MountedPack = {
   readonly bridge: Bridge
   /** True once the pack has completed the handshake. */
   readonly connected: () => boolean
+  /** What the host has observed to be wrong with this pack. Usually empty. */
+  readonly faults: () => readonly LivenessFault[]
   send(event: HostEventName, data?: unknown): void
   pushSettings(settings: Settings): void
   dispose(): void
@@ -95,6 +356,60 @@ export function mountPack(options: MountOptions): MountedPack {
   let disposed = false
   let timer: ReturnType<typeof setTimeout> | null = null
 
+  /* ------------------------------ liveness ------------------------------- */
+
+  const limits: LivenessLimits = { ...LIVENESS, ...options.liveness }
+  // A pack that did not ask for questions cannot be guilty of never asking.
+  const asksForItems = options.granted.includes("items")
+  let watch = newWatch()
+  let messages = 0
+  let poll: ReturnType<typeof setInterval> | null = null
+
+  /**
+   * Read the two channels that cross the boundary.
+   *
+   * Every "cannot tell" here is a false positive that was not shipped. The frame
+   * is measured only while the host document is visible, the host window has a
+   * box of its own, the frame is still in the document, and nothing above the
+   * frame has hidden it — a sheet over a paused pack, a teardown in flight, a
+   * stage collapsed by the app rather than by the pack.
+   */
+  const observe = (): Observation => {
+    const box = frame.getBoundingClientRect()
+    // `checkVisibility` walks ancestors, which is the whole reason for using it
+    // over the frame's own computed style; a host that hid the frame's *parent*
+    // has hidden the frame. Optional-called because a fake frame in a test has
+    // no layout at all, and "no opinion" must read as visible rather than hidden.
+    const shown = frame.checkVisibility?.() !== false
+    return {
+      visible: doc.visibilityState !== "hidden",
+      measurable: shown && frame.isConnected !== false && win.innerWidth >= 1 && win.innerHeight >= 1,
+      width: box.width,
+      height: box.height,
+      windowWidth: win.innerWidth,
+      windowHeight: win.innerHeight,
+      messages,
+    }
+  }
+
+  const tick = () => {
+    if (disposed) return
+    const observation = observe()
+    const result = step(watch, observation, limits.pollMs, asksForItems, limits)
+    watch = result.watch
+    for (const fault of result.faults) {
+      const message = describeFault(options.packId, fault, observation)
+      // Loud, always. This is the whole point: the last time a pack showed a
+      // child nothing, the only thing that noticed was the founder.
+      console.error(message)
+      options.onFault?.(fault, message)
+    }
+    if (!stillWatching(watch, messages, asksForItems) && poll !== null) {
+      clearInterval(poll)
+      poll = null
+    }
+  }
+
   const onReady = (event: MessageEvent) => {
     // The only thing that authenticates this message is the frame it came from.
     // `event.origin` is `"null"` for a sandboxed frame and is worth nothing.
@@ -110,11 +425,20 @@ export function mountPack(options: MountOptions): MountedPack {
 
     channel = new MessageChannel()
     channel.port1.onmessage = (message: MessageEvent) => {
+      // Counted before it is validated. "Did the pack use its port" is a
+      // different question from "was the message any good", and a pack sending
+      // garbage has at least reached the code that sends.
+      messages += 1
       void bridge.handle(message.data).then((response) => {
         if (response !== null && !disposed) channel?.port1.postMessage(response)
       })
     }
     channel.port1.start()
+
+    // The watch starts at the handshake, not at mount: before the port is
+    // transferred the pack has no way to speak, and the timeout below is already
+    // the net for that.
+    poll = setInterval(tick, limits.pollMs)
 
     const connect: Connect = {
       event: "connect",
@@ -152,6 +476,7 @@ export function mountPack(options: MountOptions): MountedPack {
     element: frame,
     bridge,
     connected: () => connected,
+    faults: () => watch.said,
     send,
     pushSettings: (settings) => send("settings", settings),
     dispose: () => {
@@ -159,6 +484,8 @@ export function mountPack(options: MountOptions): MountedPack {
       disposed = true
       if (timer !== null) clearTimeout(timer)
       timer = null
+      if (poll !== null) clearInterval(poll)
+      poll = null
       // Tell the pack first, so it can stop its own loop before its port dies.
       if (connected) channel?.port1.postMessage({ event: "dispose" })
       win.removeEventListener("message", onReady)

--- a/dynawalla/games/merge/README.md
+++ b/dynawalla/games/merge/README.md
@@ -144,6 +144,29 @@ viewport. The plasma, the well walls and the sparks still bleed to the edges.
 How to play is the shared `createInstructions` panel, reachable during a run,
 not just before it.
 
+### The stage belongs to the host
+
+The canvas is `position: absolute; inset: 0`, so the element the host hands to
+`mount()` is the only node with a size of its own — and the host *document*
+decides what that size is. `makeStage` therefore branches on the **computed**
+position and writes one only when nobody has positioned the element at all.
+
+It used to read `el.style.position`, which is the *inline* declaration and is
+empty for an element positioned from a stylesheet. `pack.html` gives `#root` its
+entire box with `position: fixed; inset: 0` and nothing else, so the fallback
+always fired, the inline `relative` won the cascade, and the insets stopped
+meaning anything. Measured in a framed pack: `#root` **820x0**. `games/runner`
+shipped that same line to two app stores as a black screen; FUSE survived it on
+two accidents — no `overflow: hidden` on the stage, so the canvas painted
+outside the collapsed box instead of being clipped, and an
+`el.clientHeight || window.innerHeight` whose `||` swallowed the zero. Neither
+was a decision, and either is one ordinary edit from being removed.
+
+The measurement is now honest and `resize()` says so out loud, once, when the
+stage comes back under two pixels on either axis. `layout.test.ts` reads the real
+`#root` rule out of `pack.html` and resolves the two-declaration cascade the bug
+lived in, so the fix cannot be undone quietly.
+
 ## Structure
 
 ```

--- a/dynawalla/games/merge/src/layout.test.ts
+++ b/dynawalla/games/merge/src/layout.test.ts
@@ -1,8 +1,9 @@
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { hitsHostChrome, safeRect } from "../../../packs/shared/game-chrome/index.ts";
 import { COLS, ROWS } from "./core/rules.ts";
-import { cellCenter, colAt, computeLayout } from "./layout.ts";
+import { cellCenter, colAt, computeLayout, makeStage, type StageEl } from "./layout.ts";
 
 /** every viewport the game is expected to survive */
 const SIZES: [string, number, number][] = [
@@ -251,4 +252,138 @@ test("the incoming strip stays inside the safe area once it has moved clear", ()
       b.x < l.wellX + l.wellW && l.wellX < b.x + b.w && b.y < l.wellY + l.wellH && l.wellY < b.y + b.h;
     assert.equal(onWell, false, `${name}: the incoming strip covers the well`);
   }
+});
+
+/* -------------------------------------------------------------------------- */
+/* The stage.                                                                 */
+/*                                                                            */
+/* `games/runner` shipped to two app stores completely blank because           */
+/* `el.style.position = el.style.position || "relative"` read the INLINE       */
+/* position — empty for an element positioned from a stylesheet — and so       */
+/* always fired, overwriting `#app { position: fixed; inset: 0 }` and taking   */
+/* the insets with it. FUSE carried the identical line against the identical   */
+/* shape of `pack.html`, and its stage measured 820x0 in a framed pack too. It */
+/* played anyway, on two accidents: no `overflow: hidden` on the stage, and an */
+/* `el.clientHeight || window.innerHeight` whose `||` caught the zero.         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * What `pack.html` declares about the element the pack mounts into.
+ *
+ * Read out of the real file rather than restated here, because the defect this
+ * section pins is exactly a disagreement between that file and this game's code:
+ * the only box `#root` has comes from the stylesheet, and any inline `position`
+ * the game writes wins over it.
+ */
+function packStageRule(): Map<string, string> {
+  const html = readFileSync(new URL("../pack.html", import.meta.url), "utf8");
+  const rule = /#root\s*\{([^}]*)\}/.exec(html);
+  assert.ok(rule, "pack.html has no #root rule; this test is measuring the wrong element");
+  const decls = new Map<string, string>();
+  for (const part of (rule[1] ?? "").split(";")) {
+    const colon = part.indexOf(":");
+    if (colon < 0) continue;
+    decls.set(part.slice(0, colon).trim(), part.slice(colon + 1).trim());
+  }
+  return decls;
+}
+
+/**
+ * The used height of the stage in CSS pixels, on a `viewportH`-tall surface.
+ *
+ * A deliberately tiny slice of CSS, and only the slice FUSE's layout depends on:
+ * the canvas is `position: absolute; inset: 0`, so the stage has no in-flow
+ * content and `height: auto` resolves to zero. It gets a height from exactly two
+ * places — an explicit `height`, or being out of flow with both `top` and
+ * `bottom` pinned. Inline declarations beat the stylesheet, which is the whole
+ * mechanism of the bug.
+ */
+function stageHeight(
+  sheet: Map<string, string>,
+  inline: Map<string, string>,
+  viewportH: number,
+): number {
+  const used = (prop: string): string | undefined => inline.get(prop) ?? sheet.get(prop);
+  const height = used("height");
+  if (height === "100%") return viewportH;
+  if (height !== undefined && height.endsWith("px")) return Number.parseFloat(height);
+
+  const position = used("position") ?? "static";
+  const inset = used("inset");
+  const top = used("top") ?? inset;
+  const bottom = used("bottom") ?? inset;
+  const outOfFlow = position === "fixed" || position === "absolute";
+  if (outOfFlow && top === "0" && bottom === "0") return viewportH;
+  // In flow, height auto, and nothing in flow inside it.
+  return 0;
+}
+
+test("the pack's stage is sized only by being out of flow", () => {
+  // The precondition that makes the rest of this section mean anything. If
+  // pack.html ever gives #root a height of its own, an inline `position` stops
+  // being able to collapse it and these tests are measuring a bug that is gone.
+  const sheet = packStageRule();
+  assert.equal(sheet.get("height"), undefined, "#root now has a height; re-derive this section");
+  assert.equal(sheet.get("position"), "fixed");
+  assert.equal(sheet.get("inset"), "0");
+  assert.equal(stageHeight(sheet, new Map(), 1180), 1180, "#root has no box even untouched");
+});
+
+test("an inline position on the stage collapses the whole game to nothing", () => {
+  // The failure, stated. Measured in a framed pack before the fix: #root 820x0,
+  // canvas 820x1180 painting *outside* it, and the only reason a child saw
+  // anything at all.
+  const sheet = packStageRule();
+  assert.equal(stageHeight(sheet, new Map([["position", "relative"]]), 1180), 0);
+  assert.equal(stageHeight(sheet, new Map([["position", "static"]]), 1180), 0);
+});
+
+test("makeStage leaves a stage the document has already positioned alone", () => {
+  const sheet = packStageRule();
+  // What a browser computes for #root at the moment `mount` runs.
+  const computed = sheet.get("position") ?? "static";
+  const el: StageEl = { style: { position: "" } };
+  makeStage(el, computed);
+
+  const inline = new Map<string, string>();
+  if (el.style.position !== "") inline.set("position", el.style.position);
+  assert.equal(
+    stageHeight(sheet, inline, 1180),
+    1180,
+    `makeStage wrote position:${el.style.position} over the document's ${computed}`,
+  );
+});
+
+test("makeStage still positions a stage nobody else has", () => {
+  // A host that hands over a plain in-flow div — and `index.html`'s `#root`
+  // before it had a rule of its own — still needs the canvas to have something to
+  // be absolute against.
+  const el: StageEl = { style: { position: "" } };
+  makeStage(el, "static");
+  assert.equal(el.style.position, "relative");
+});
+
+test("makeStage never overwrites any position the document computed", () => {
+  for (const computed of ["relative", "absolute", "fixed", "sticky"]) {
+    const el: StageEl = { style: { position: "" } };
+    makeStage(el, computed);
+    assert.equal(el.style.position, "", `makeStage overwrote a computed ${computed}`);
+  }
+});
+
+test("a collapsed stage is not a survivable state for this game any more", () => {
+  // The second accident, pinned. `resize()` used `el.clientHeight ||
+  // window.innerHeight`, which turned a stage with no box into a full-window
+  // canvas — so the game kept playing and the collapse was invisible to
+  // everybody, including the author of the line that caused it. The layout is now
+  // computed from the stage's real box, and a zero box produces a layout that
+  // visibly has nothing in it rather than a plausible full-screen one.
+  const collapsed = computeLayout(1, 1, 2, safeRect(1, 1));
+  const real = computeLayout(820, 1180, 2, safeRect(820, 1180));
+  assert.notEqual(
+    collapsed.cell,
+    real.cell,
+    "a 1x1 stage laid out the same as a real one; the collapse is still invisible",
+  );
+  assert.ok(collapsed.boardW <= 1 + COLS * 18, "a 1x1 stage produced a full-size board");
 });

--- a/dynawalla/games/merge/src/layout.ts
+++ b/dynawalla/games/merge/src/layout.ts
@@ -25,6 +25,57 @@ import { COLS, ROWS } from "./core/rules.ts";
  * still bleed to the edges, which is the point of `cover`.
  */
 
+/* --------------------------------- the stage ------------------------------- */
+
+/**
+ * Just enough of an element for `makeStage`: the inline style it writes.
+ *
+ * Structural rather than `HTMLElement` so a test can hand it an object literal
+ * and read back exactly what was written, with no cast and no DOM.
+ */
+export type StageEl = {
+  style: { position: string };
+};
+
+/**
+ * Take the host's element over as FUSE's stage.
+ *
+ * The canvas is `position: absolute; inset: 0`, so the stage is the only node in
+ * the tree with a size of its own — and it is the host *document* that decides
+ * what that size is. This function's whole job is to not take that away.
+ *
+ * **What it replaces shipped a black screen in a sibling game.** The line was
+ *
+ *     el.style.position = el.style.position || "relative";
+ *
+ * and `el.style.position` reads the *inline* declaration, which is empty for an
+ * element positioned from a stylesheet. `pack.html` says
+ * `#root { position: fixed; inset: 0 }`, so the fallback always fired and wrote
+ * an inline `relative` that won the cascade — taking the `inset: 0` with it,
+ * because insets do nothing to a relatively positioned box. The stage fell back
+ * to `height: auto` with nothing but an absolutely positioned canvas inside it.
+ * Measured in a framed pack before this fix: `#root` **820x0**.
+ *
+ * `games/runner` shipped exactly this to two app stores. FUSE did not, and it is
+ * worth saying why it did not, because neither reason was a decision:
+ *
+ *   * it never writes `overflow: hidden` on the stage, so the canvas paints
+ *     *outside* the collapsed box rather than being clipped to nothing;
+ *   * `resize()` sized that canvas with `el.clientHeight || window.innerHeight`,
+ *     and the `||` swallowed the zero.
+ *
+ * Two accidents, either of which an ordinary edit removes. So: branch on the
+ * *computed* position, never the inline one, and write one only when nobody has
+ * positioned the element at all.
+ *
+ * Invisible in `npm run dev` for the same reason it was there: `index.html`
+ * gives `#root` a position too, and the dev harness is full-size either way.
+ * Only the entry a child runs collapses.
+ */
+export function makeStage(el: StageEl, computedPosition: string): void {
+  if (computedPosition === "static") el.style.position = "relative";
+}
+
 export type Layout = {
   w: number;
   h: number;

--- a/dynawalla/games/merge/src/mount.ts
+++ b/dynawalla/games/merge/src/mount.ts
@@ -3,7 +3,7 @@ import type { Host, FocusableHost } from "./contract.ts";
 import { Game } from "./game.ts";
 import { Renderer } from "./render.ts";
 import { bindInput } from "./input.ts";
-import { computeLayout, type Layout } from "./layout.ts";
+import { computeLayout, makeStage, type Layout } from "./layout.ts";
 
 export type MountOptions = {
   seed?: string;
@@ -31,7 +31,11 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
     "aria-label",
     "FUSE. Drop numbered chips into the well. Touching chips that add up to the key number fuse.",
   );
-  el.style.position = el.style.position || "relative";
+  // The computed position, not the inline one — see `makeStage`. This is the only
+  // place the game asks the browser where the host has put it, and reading it off
+  // `el.style` instead is what made a sibling game a black screen on two app
+  // stores.
+  makeStage(el, getComputedStyle(el).position);
   el.appendChild(canvas);
 
   // How to play, on the shared surface every Dynawalla game uses. Nobody can
@@ -118,9 +122,24 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
   let acc = 0;
   const frameTimes: number[] = [];
 
+  /** Said once. A collapsed stage would otherwise say it on every resize. */
+  let saidCollapsed = false;
   const resize = () => {
-    const w = Math.max(1, el.clientWidth || window.innerWidth);
-    const h = Math.max(1, el.clientHeight || window.innerHeight);
+    // `el.clientHeight || window.innerHeight` was here, and the `||` is one of the
+    // two accidents that kept this game alive while `makeStage`'s predecessor was
+    // collapsing its stage to 820x0: a stage with no box quietly rendered at
+    // window size, so an honest measurement was never available to anybody. Now
+    // the measurement is honest and a missing stage is said out loud instead.
+    if (!saidCollapsed && (el.clientWidth < 2 || el.clientHeight < 2)) {
+      saidCollapsed = true;
+      console.error(
+        `[fuse] the stage measures ${String(el.clientWidth)}x${String(el.clientHeight)}. ` +
+          `The canvas is position:absolute inside it, so nothing this game draws has a size. ` +
+          `The host's element needs a box of its own — see makeStage in layout.ts.`,
+      );
+    }
+    const w = Math.max(1, el.clientWidth);
+    const h = Math.max(1, el.clientHeight);
     const dpr = Math.min(2, window.devicePixelRatio || 1);
     canvas.width = Math.round(w * dpr);
     canvas.height = Math.round(h * dpr);


### PR DESCRIPTION
VOLTA shipped blank on both platforms and the only net the host had was a
20-second handshake timeout, which a pack that connects and *then* draws nothing
sails straight past. Two things here, and the second one is the honest half.

── FUSE had the same line, and it was live sooner than it looked ────────────

`games/merge` carried `el.style.position = el.style.position || "relative"`
against the same shape of `pack.html`. Reproduced before touching it: built
`dist-pack`, framed it on an opaque origin in a headless browser at 820x1180
behind a stub host that answers the real protocol, and drove a run. `#root`
measured **820x0**, inline `position: relative` over the stylesheet's `fixed`,
canvas 820x1180 painting outside the collapsed box. It played anyway — score 90
— on the two accidents already known: no `overflow: hidden` on the stage, and an
`el.clientHeight || window.innerHeight` whose `||` ate the zero.

`makeStage` now branches on the **computed** position, as `runner` does. And the
second accident is gone with it: `resize()` measures the stage honestly and says
so once when it comes back under two pixels, because a silent fallback to window
size is why nobody could see this for the whole life of the bug. After: `#root`
820x1180, inline position empty, FUSE plays (score 100), and the standalone
workbench is unchanged at 1024x768 with nothing on the console. Injecting the
collapse into the framed pack afterwards produces exactly:

    [fuse] the stage measures 820x0. The canvas is position:absolute inside it,
    so nothing this game draws has a size. …

── the host's liveness watch, and what it honestly cannot do ───────────────

**It would not have caught VOLTA, and nothing on the host side could have.**
That is measured, not assumed. Across the sandbox boundary the host has exactly
two channels, and in the framed blank pack above both read healthy: the frame
element measured **820x1180** while the stage inside it measured 820x0, and the
port carried **129 messages in the first 1.3 seconds** and 13 more over the next
five, whether the game was visible or not. A blank pack's traffic is a playing
pack's traffic. The measurement that catches that collapse only exists inside
the pack, which is where `makeStage` and the stage error now live for FUSE.
**VOLTA is not fixed by this commit and cannot be**: `games/runner` still carries
the line, its repair is in an open PR rather than in this tree, and the module
note in `frame.ts` now says so rather than implying otherwise.

What *was* completely unwatched is the host's own copy of the same bug, one
level up. `.pack-frame` takes its whole box from `.pack-frame-host`, which takes
its whole box from the `fixed; inset: 0` div in `Stage.tsx`; nothing in the chain
has a size of its own. Taking that one declaration off, in a browser, against
the real `packs.css`: the frame does not go to 0x0, it goes to **300x150** — an
iframe's intrinsic default, what a replaced element falls back to when a
percentage has nothing to resolve against. A check written against zero, which
is what I wrote first, would have watched the likely form of this go past. So
the fault is *a share of the window*, half on either axis: an absolute floor
would accuse a desktop user who dragged their window to a strip, and a share
cannot, because a frame that fills a small window still fills it.

The second fault is silence. All twenty-seven games do `createGameHost()`,
`await warm()`, then mount — `warm()` is `items.next`, measured on the wire at
**11ms** after the handshake. A pack granted `items` that has sent nothing after
thirty seconds of being on screen never got that far. This is the one that
contradicts `renderNoHost()`: a pack that crashed on the way up draws "<GAME>
runs inside Dynawalla", and when the host sees this fault it knows that sentence
is false. Both faults are said out loud once and offered on
`MountedPack.faults()`; neither is routed to `onError`, which draws a curtain and
ends a child's run. And neither has a consumer in a release build yet — `Stage.tsx`
does not pass `onFault` and this app has no console-to-native bridge, so on a
device these lines reach a WebInspector session and nowhere else. That makes this
a dev-loop instrument today rather than the thing that would have told somebody
other than the founder; the module note says that plainly, and wiring a consumer
belongs to `Stage.tsx`, which is not this diff.

Ruling out false positives is most of the code and most of the tests. The
judgement is a pure reducer over observations, so every reason to stay quiet is a
sequence rather than a race: time spent hidden or unmeasurable is not counted at
all; one full measurement ever latches the frame clean forever, which covers a
stage animating in, a frame measured before first layout, and a frame the host
later hides behind a sheet or tears down; a *gap* in traffic is never evidence,
because an idle child produces exactly as little as a dead pack; and a pack that
was not granted `items` cannot be guilty of not asking for one.

Deleting each part, in turn:

    ✖ the shape the host's own chain actually breaks into is reported
      AssertionError: a 300x150 iframe counts as filling a tablet
    ✖ a small window is not a fault — the yardstick is the window, not a floor
      AssertionError: a window dragged to a strip: a frame filling its window read as too small
    ✖ time spent hidden or unmeasurable is not counted, however long it lasts
      AssertionError: a backgrounded app: reported no-room, never-spoke
    ✖ a frame that had a box and then lost it is the host's doing, not the pack's
      AssertionError: a pack the host put away was accused of no-room
    ✖ a pack that spoke once is never called mute, however long it then idles
      AssertionError: an idle pack was accused of never-spoke
    ✖ a pack that uses its port is never called mute; one that does not, is
      AssertionError: a pack that used its port was accused of never-spoke
    ✖ disposing stops the watch, and clears its timer
      AssertionError: dispose cleared no interval
    ✖ a frame with no box is reported, once, after five seconds of being visible
      AssertionError: a frame measuring 820x0 was not reported exactly once
    ✖ makeStage leaves a stage the document has already positioned alone
      AssertionError: makeStage wrote position:relative over the document's fixed
    ✖ makeStage still positions a stage nobody else has
      AssertionError: Expected values to be strictly equal

Nothing string-matches source. `frame.test.ts` reads the real rules out of
`packs.css` and resolves the two-step percentage chain to both its outcomes;
`layout.test.ts` reads the real `#root` rule out of `pack.html` and resolves the
two-declaration cascade the bug lives in — deleting either rule fails them with
"this test is measuring the wrong element".

── what still needs a device, and what needs somebody else's file ──────────

Neither iOS nor Android has been touched here. What is proven is the layout, the
arithmetic and the protocol traffic, in a real browser against the built pack.

`renderNoHost()` itself is not fixed and cannot be from here: the call sites are
in twenty-eight game entries, and the message a child sees is drawn entirely
inside the pack document. A real fix is one shared change plus one line per game
— `renderNoHost` needs to take the error, and to say "this game could not start"
when a host connected and something after that threw, keeping the standalone
wording only for `PackError("no_host")`. The host's `never-spoke` fault is the
half of that which was available here.

Verified on Node 24: `dynawalla-app` 314 tests and `games/merge` 79, five
consecutive runs each, plus lint, `tsc` on all three projects, both app builds,
both FUSE builds, and `npm run packs -- merge`. An adversarial pass over the diff found the two
claims corrected above, a tautological assertion (`frameBox` short-circuited the
null case it was supposed to resolve — it now goes through the real declarations),
a miscount, a `[fuse]` line that could fire once on a momentarily zero-size
window, and a leaked-interval regression that failed slowly instead of fast. All
five are fixed here.

Claude-Session: https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb

