### PR TITLE
release(dynawalla): 0.3.4 — trebuchet's search cannot freeze, and TRUE DRAW has two gestures

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Cut immediately: 0.3.3 ships a trebuchet that can hang.

## Trebuchet (#702) — replaces the flawed fix that shipped in 0.3.3

0.3.3 contained the first version of the empty-rack fix, and its author's own self-review found it broken **after it had been merged**. It bisected the difficulty axis on a premise asserted in a docstring and never measured — that answer magnitude rises with the ladder.

**It does not.** Division rungs return single-digit *quotients* and sit **above** the placeable multiplication rungs, so a single probe there excludes the whole band permanently. It also had three exits that returned without moving, which froze the search — measured at **11,552 `host.next()` calls and climbing**, phase stuck.

Replaced with a direction-fixed sweep in sub-rung steps with wrapping: provably visits every rung, cannot freeze, exclude or oscillate. Wave 1 now costs **2** curriculum items, down from 140.

## TRUE DRAW (#701)

Two gestures, a bag, and a timeout that is nobody's mistake.

Previously **one of the two verdicts was expressed by doing nothing** — a timeout settled as a hold, so saying "keep" meant sitting out the entire window. That punished the fast player on every TRUE slate, and left the ladder with **no latency measurement for half of all answers**, which is a large part of why 25 fast correct answers in a row did not move the founder off the bottom rung.

## Process note

I enqueued #698 while its author was still verifying, which is how the flawed search reached 0.3.3. That was my error, not the agent's — it flagged the risk explicitly in its report.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb