### PR TITLE
dynawalla/games/gavel: THE GAVEL — bid one coin over the room, and flip the lot to the broker

### DIFF
--- a/dynawalla/dynawalla-app/src/catalog/art.ts
+++ b/dynawalla/dynawalla-app/src/catalog/art.ts
@@ -81,6 +81,7 @@ const MOTIF_BY_PACK: Readonly<Record<string, MotifKey>> = {
   "dynawalla.colossus": "tower",
   "dynawalla.counterweight": "steelyard",
   "dynawalla.forge": "anvil",
+  "dynawalla.gavel": "auction",
   "dynawalla.foundry": "ring",
   "dynawalla.guilty": "crosshair",
   "dynawalla.horde": "swarm",

--- a/dynawalla/dynawalla-app/src/catalog/motifs.ts
+++ b/dynawalla/dynawalla-app/src/catalog/motifs.ts
@@ -665,6 +665,40 @@ const sigil: Motif = (rng) => {
   return out
 }
 
+
+/**
+ * THE GAVEL — three bids in the room, and the hammer one coin over the highest.
+ *
+ * The middle tablet is the highest and is the one lit; the dashed line above the room
+ * is the broker's offer, which is what stops the answer being "bid as much as you
+ * like". The hammer is coming down one coin over the lit tablet.
+ */
+const auction: Motif = (rng) => {
+  const heights = [between(rng, 16, 26), between(rng, 34, 44), between(rng, 20, 30)]
+  const out: Shape[] = [line(6, 88, 94, 88, "veil")]
+  for (let i = 0; i < 3; i++) {
+    const h = heights[i] ?? 20
+    const x = 14 + i * 26
+    const top = 88 - h
+    out.push(
+      box(x, top, 20, h, i === 1 ? "fill" : "line", i === 1 ? 0.26 : 1, 1),
+      box(x, top, 20, h, i === 1 ? "warm" : "pale", i === 1 ? 1 : 0.7, 1),
+      line(x + 4, top + 7, x + 16, top + 7, "pale", 0.55),
+    )
+  }
+  const crown = 88 - (heights[1] ?? 38)
+  out.push(
+    line(8, 20, 92, 20, "veil", 0.6, "4 4"),
+    box(40, 20, 20, 5, "veil", 0.35, 1),
+    line(58, 30, 78, 12, "bold"),
+    box(72, 6, 16, 9, "fill", 0.9, 1),
+    box(72, 6, 16, 9, "glow", 0.5, 1),
+    dot(50, crown - 5, 2.8, "glow", 0.9),
+    dot(50, crown - 5, 1.4, "warm"),
+  )
+  return out
+}
+
 const MOTIFS = {
   orbs,
   balance,
@@ -693,6 +727,7 @@ const MOTIFS = {
   street,
   trebuchet,
   slate,
+  auction,
   sigil,
 } as const satisfies Record<string, Motif>
 

--- a/dynawalla/games/gavel/.gitignore
+++ b/dynawalla/games/gavel/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Local QA scratch: screenshots and temporary captures.
+qa/shots
+qa/tmp
+
+# The lockfile is not committed for a game package; the repo pins at the root.
+package-lock.json

--- a/dynawalla/games/gavel/index.html
+++ b/dynawalla/games/gavel/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>THE GAVEL — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0d18;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/gavel/pack.html
+++ b/dynawalla/games/gavel/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0b0d18" />
+    <title>THE GAVEL</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0b0d18;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/gavel/pack.json
+++ b/dynawalla/games/gavel/pack.json
@@ -1,0 +1,36 @@
+{
+  "id": "dynawalla.gavel",
+  "version": "0.1.0",
+  "name": "THE GAVEL",
+  "description": "An auction in the bazaar. The rivals hold up sums, not prices — work them out, find the highest, and take the lot for one coin over it. Then sell it to the broker and keep the difference. Bid past his offer and the lot never sells.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.facts.add-within-ten",
+      "dw.add.facts.subtract-within-ten",
+      "dw.add.facts.add-across-ten",
+      "dw.add.facts.subtract-across-ten",
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero",
+      "dw.mul.facts.tables-within-five",
+      "dw.mul.facts.tables-to-twelve",
+      "dw.mul.multidigit.times-one-digit",
+      "dw.mul.multidigit.times-two-digit",
+      "dw.div.facts.division-facts",
+      "dw.div.whole.divide-exact",
+      "dw.div.whole.zero-in-the-quotient"
+    ],
+    "grades": [1, 5]
+  },
+  "minAge": 6,
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/gavel/package.json
+++ b/dynawalla/games/gavel/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-gavel",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "THE GAVEL — an auction in the bazaar. Rivals hold up sums; bid one coin over the highest and sell the lot to the broker for the difference.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4363 --strictPort",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/gavel/src/audio/audio.ts
+++ b/dynawalla/games/gavel/src/audio/audio.ts
@@ -1,0 +1,169 @@
+// The sound of the gallery. Synthesised in this pack's own `AudioContext` — the
+// host's `feedback.sound` capability is a different thing and is not declared.
+//
+// Wood, brass and coin. The hammer is a struck block, a sale is two brass coins
+// landing, and a lot that did not sell is the same block struck dead with the
+// felt on it. **There is no buzzer in this pack**, because nothing in this game is
+// a buzz: being wrong costs more lots, and more lots is a sound you hear arriving
+// rather than a noise pointed at you.
+//
+// Everything leaves through `createSafetyBus`, never `ctx.destination`. A
+// `GainNode` defaults to a gain of 1 and MOSAIC reached +22.9 dBFS that way; the
+// shared bus is a limiter and a hard −1 dBFS ceiling, and `MIN_ATTACK` is why no
+// envelope here opens faster than six milliseconds.
+
+import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts"
+
+type Ctor = typeof AudioContext
+
+function contextCtor(): Ctor | null {
+  const g = globalThis as unknown as { AudioContext?: Ctor; webkitAudioContext?: Ctor }
+  return g.AudioContext ?? g.webkitAudioContext ?? null
+}
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private bus: GainNode | null = null
+  private noise: AudioBuffer | null = null
+
+  /** Web Audio needs a gesture. The first touch in the game is the first one. */
+  resume(): void {
+    if (!this.ctx) {
+      const Ctx = contextCtor()
+      if (!Ctx) return
+      try {
+        this.ctx = new Ctx()
+      } catch (error) {
+        console.warn("[gavel] no audio context", error)
+        return
+      }
+      this.bus = this.ctx.createGain()
+      this.bus.gain.value = 0.62
+      const safety = createSafetyBus(this.ctx)
+      this.bus.connect(safety.input)
+      this.noise = this.makeNoise(this.ctx)
+    }
+    if (this.ctx.state === "suspended") {
+      void this.ctx.resume().catch((error: unknown) => {
+        console.warn("[gavel] audio could not resume", error)
+      })
+    }
+  }
+
+  private makeNoise(ctx: AudioContext): AudioBuffer {
+    const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * 0.9), ctx.sampleRate)
+    const data = buf.getChannelData(0)
+    let last = 0
+    for (let i = 0; i < data.length; i++) {
+      last = (last + Math.random() * 2 - 1) * 0.5
+      data[i] = last
+    }
+    return buf
+  }
+
+  private knock(when: number, dur: number, freq: number, gain: number, q: number): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus || !this.noise) return
+    const src = ctx.createBufferSource()
+    src.buffer = this.noise
+    src.playbackRate.value = 0.8 + Math.random() * 0.4
+    const filter = ctx.createBiquadFilter()
+    filter.type = "bandpass"
+    filter.frequency.value = freq
+    filter.Q.value = q
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, when)
+    g.gain.linearRampToValueAtTime(gain, when + safeAttack(0.008))
+    g.gain.exponentialRampToValueAtTime(0.0001, when + dur)
+    src.connect(filter).connect(g).connect(bus)
+    src.start(when)
+    src.stop(when + dur + 0.05)
+  }
+
+  private tone(when: number, dur: number, from: number, to: number, gain: number): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const osc = ctx.createOscillator()
+    osc.type = "triangle"
+    osc.frequency.setValueAtTime(from, when)
+    osc.frequency.exponentialRampToValueAtTime(Math.max(20, to), when + dur)
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, when)
+    g.gain.linearRampToValueAtTime(gain, when + safeAttack(0.01))
+    g.gain.exponentialRampToValueAtTime(0.0001, when + dur)
+    osc.connect(g).connect(bus)
+    osc.start(when)
+    osc.stop(when + dur + 0.05)
+  }
+
+  private now(): number {
+    return this.ctx ? this.ctx.currentTime + 0.005 : 0
+  }
+
+  /** A digit on the paddle. Tiny; it happens a lot. */
+  tick(): void {
+    if (!this.ctx) return
+    this.knock(this.now(), 0.045, 1900, 0.07, 3.2)
+  }
+
+  /** A brass pin dropping on a tablet. */
+  mark(): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.knock(t, 0.06, 2600, 0.08, 4)
+    this.tone(t, 0.1, 880, 700, 0.05)
+  }
+
+  release(): void {
+    if (!this.ctx) return
+    this.knock(this.now(), 0.05, 1100, 0.05, 2)
+  }
+
+  /** The hammer. One strike, wood on wood. */
+  hammer(): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.knock(t, 0.13, 420, 0.34, 1.1)
+    this.tone(t, 0.1, 190, 90, 0.16)
+  }
+
+  /** Coins into the strongbox. `n` is the profit, so a bigger flip rings longer. */
+  coins(n: number): void {
+    if (!this.ctx) return
+    const t = this.now()
+    const count = Math.min(6, Math.max(1, n))
+    for (let i = 0; i < count; i++) {
+      this.tone(t + 0.06 + i * 0.062, 0.24, 1180 + i * 96, 880 + i * 70, 0.075)
+      this.knock(t + 0.06 + i * 0.062, 0.05, 3200, 0.04, 5)
+    }
+  }
+
+  /** A lot that did not sell. The block struck with the felt on it. */
+  dull(): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.knock(t, 0.2, 240, 0.22, 0.8)
+    this.tone(t, 0.34, 128, 74, 0.12)
+  }
+
+  /** A consignment sold out. A short brass fifth, and then quiet. */
+  cleared(): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.tone(t, 0.4, 523, 784, 0.1)
+    this.tone(t + 0.16, 0.5, 784, 1046, 0.085)
+  }
+
+  dispose(): void {
+    const ctx = this.ctx
+    this.ctx = null
+    this.bus = null
+    this.noise = null
+    if (!ctx) return
+    void ctx.close().catch(() => {
+      // A context that was already closed is not news.
+    })
+  }
+}

--- a/dynawalla/games/gavel/src/contract.ts
+++ b/dynawalla/games/gavel/src/contract.ts
@@ -1,0 +1,91 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountGavel } from "./mount.ts"
+
+export type Question = {
+  id: string
+  /** "12 + 5" — the operator glyph is already in it. */
+  prompt: string
+  /** "17" — exact, canonical, and never computed by this game. */
+  answer: string
+  /**
+   * Wrong values a child actually produces: the host's mal-rule outputs first,
+   * near-misses after.
+   *
+   * THE GAVEL does not draw them. Every tablet in the room is a real question
+   * with a real answer, because the thing being asked is *which of these is
+   * biggest* — and a board with a fake number on it would have a biggest that
+   * is not the biggest. They are on the type because the wire carries them.
+   */
+  distractors: string[]
+  domain: string
+  /** 0..1. A monotone reading of the ladder, not a claim about hardness. */
+  difficulty: number
+}
+
+/** What a game asks the host for. Both scales documented in `game-host`. */
+export type Ask = {
+  domain?: string
+  /** 1..10 is the unambiguous ladder scale; see `ladderScale` in `game/ladder.ts`. */
+  difficulty?: number
+  maxDifficulty?: number
+}
+
+export type Host = {
+  next(opts?: Ask): Question
+
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+
+  /**
+   * This question was never answered. Close it and record nothing.
+   *
+   * **Not optional for this game, and not a nicety.** A round of THE GAVEL puts
+   * three to five questions in front of the child and the child answers exactly
+   * one of them — the tablet they marked. The others were read and compared and
+   * then left, which is neither a right answer nor a wrong one, and reporting
+   * `{ correct: false, answered: "" }` for them would file four misses per
+   * round: the empty string does not parse, the learner model takes a wrong
+   * attempt, and the ladder steps down under a child who was doing fine.
+   *
+   * Feature-detected only because a stub host older than `items.skip` should
+   * still run the dev harness. Inside the app it is always there.
+   */
+  skip?(questionId: string): void
+
+  /** Throw away prefetched questions that no longer match what was asked for. */
+  flush?(): void
+
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a consignment sold out.
+   *
+   * OPTIONAL and feature-detected. Fire and forget: nothing is returned,
+   * nothing may be awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** THE GAVEL calls it when a consignment has been
+   * cleared with at least one lot sold — never on a lot that got away. A
+   * purchase surface next to a shortfall is the thing that is forbidden
+   * outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+/**
+ * Mount the game into `el`.
+ *
+ * `pause`/`resume` are part of the surface because the host can put a sheet
+ * over a still-mounted, still-running pack. See `mount.ts`.
+ */
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  return mountGavel(el, host)
+}

--- a/dynawalla/games/gavel/src/core/feel.ts
+++ b/dynawalla/games/gavel/src/core/feel.ts
@@ -1,0 +1,45 @@
+// Feel: the curves everything in this game moves on, in one place so the whole
+// building has one physics rather than eight.
+
+/** Clamp to 0..1. */
+export function unit(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+/** Frame-rate independent approach: `k` is the fraction closed per 16.7 ms. */
+export function approach(a: number, b: number, k: number, dt: number): number {
+  const t = 1 - Math.pow(1 - unit(k), dt / 16.6667)
+  return a + (b - a) * t
+}
+
+/** Heavy things start slow and arrive fast. Gravity, near enough. */
+export function easeInQuad(t: number): number {
+  const x = unit(t)
+  return x * x
+}
+
+export function easeOutCubic(t: number): number {
+  const x = 1 - unit(t)
+  return 1 - x * x * x
+}
+
+export function easeOutBack(t: number): number {
+  const x = unit(t) - 1
+  return 1 + 2.2 * x * x * x + 1.2 * x * x
+}
+
+/**
+ * A settle: overshoot once, then a short shudder that dies.
+ *
+ * A stone slab weighing several tonnes does not bounce like a ball, so the
+ * amplitude is small and the decay is fast. Anything springier reads as rubber.
+ */
+export function settle(t: number): number {
+  const x = unit(t)
+  if (x >= 1) return 1
+  return 1 - Math.cos(x * Math.PI * 3.1) * Math.exp(-6.2 * x) * (1 - x)
+}

--- a/dynawalla/games/gavel/src/core/rng.ts
+++ b/dynawalla/games/gavel/src/core/rng.ts
@@ -1,0 +1,61 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly.
+//
+// mulberry32: 32-bit state, no allocation, passes gjrand well enough for a game
+// and is trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Snapshot/restore so a subsystem can be forked without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/gavel/src/game/auction.ts
+++ b/dynawalla/games/gavel/src/game/auction.ts
@@ -1,0 +1,659 @@
+// THE GAVEL — the rules, with no canvas anywhere near them.
+//
+// A lot stands on the block. Along the gallery, three to five rivals hold up
+// tablets, and a tablet carries a *sum* rather than a price: `12 + 5`, `3 × 5`,
+// `8 × 1`, `15 − 2`. Above the block hangs the broker's standing offer — what the
+// guild will pay for the lot the moment it is yours.
+//
+// Two gestures and one hammer:
+//
+//   1. **Mark the tablet you mean to beat.** Free, reversible, costs nothing.
+//      This is the child saying *this one is the highest bid in the room*.
+//   2. **Set your bid on the paddle.** Digits. Whatever number you like.
+//   3. **GAVEL.** The room settles, every tablet turns over, and the money says
+//      what happened.
+//
+//        bid ≤ highest         OUTBID   — a rival takes it
+//        highest < bid < offer SOLD     — coins = offer − bid, most at highest+1
+//        bid = offer           EVEN     — it sells, there is nothing in it
+//        bid > offer           UNSOLD   — you own a thing nobody will buy
+//
+//   or **FOLD**, which is always safe, and is the only right move on a lot whose
+//   offer is not above the room at all.
+//
+// **The four things a child has to do, and why none of them can be skipped.**
+//
+//   * *Work out several sums.* The paddle takes a number, so a value has to be
+//     produced, not recognised.
+//   * *Compare them.* The mark is a separate commitment from the bid, so beating
+//     the wrong tablet loses the lot even when the arithmetic on it was perfect —
+//     and the host still records that arithmetic as correct, because it was.
+//   * *Add one.* `highest + 1` is the bid that earns the most, every time. The
+//     bid that equals the highest wins nothing at all.
+//   * *Bound it by the offer.* Padding the bid for safety walks into `bid > offer`
+//     and buys a thing nobody wants, and the tight margins at the top of the
+//     ladder make the padding fatal within two coins.
+//
+// **What crosses to the host.** One tablet per lot: the marked one, with
+// `answered` set to `bid − 1`. Bidding one over a tablet is a statement that the
+// tablet is worth exactly `bid − 1`, and that is the value the host judges. Every
+// other tablet in the room was read and left, so it is *skipped* — see
+// `contract.ts` for why reporting those as wrong would file four misses a round.
+//
+// **There is no clock.** Not on the bid, not on the mark, not on the lot. The
+// only duration in the file is the reveal that plays *after* the hammer, and a tap
+// ends it early. `test/antimash.test.ts` plays a seed at eight seconds a lot and at
+// a fifth of a second a lot and requires byte-identical coins, tallies and
+// reported answers.
+
+import type { Ask, Host, Question } from "../contract.ts"
+import type { Rng } from "../core/rng.ts"
+import {
+  CEILING_STEP,
+  MAX_BID_DIGITS,
+  SPEC,
+  ladderScale,
+  observe,
+  revealHoldMs,
+  settleAfterLot,
+  tabletCount,
+  tryParseBid,
+} from "./ladder.ts"
+import { LOTS, assembleRoom, isTrap, profitOf, type Room, type Tablet } from "./lot.ts"
+import { seedSuccess } from "../../../../packs/shared/game-pacing/index.ts"
+
+/** Lots the broker consigns at a time. */
+export const CONSIGNMENT = 5
+
+/**
+ * Lots added to the consignment when one does not sell.
+ *
+ * **This is the whole failure model, and it is COLOSSUS's.** A lot that does not
+ * sell stays in the consignment *and* one more joins it, so being wrong costs two
+ * more lots of work than being right — visible, countable, and on the strip at the
+ * top of the screen. Nothing is taken away: not a coin, not a life, not a turn.
+ * There is no buzzer in this pack.
+ */
+export const EXTRA_ON_MISS = 1
+
+/** The consignment strip never grows past this. Being behind must stay legible. */
+export const MAX_CONSIGNMENT = 12
+
+/**
+ * Questions drawn, not yet shown, and waiting for a board that suits them.
+ *
+ * The assembler wants a wide choice — see `lot.ts` — and the bench is what stops that
+ * costing ten fresh questions a lot. The cap is what stops it becoming a hoard: a
+ * benched question the room never wants is closed rather than held forever, oldest
+ * first, so the bench turns over on its own as the ladder moves.
+ */
+export const BENCH_CAP = 14
+
+/**
+ * What the broker pays for being told a lot is not worth bidding on.
+ *
+ * One coin. It has to be more than nothing, because otherwise the correct move on
+ * a trap lot is indistinguishable from giving up, and a child who has read the
+ * offer and understood that it is too low has done the harder piece of reasoning
+ * in the game. It has to be small, because otherwise folding everything is a
+ * living. `test/bots.test.ts` holds both ends.
+ */
+export const SCOUT_FEE = 1
+
+/**
+ * What a bid of exactly one over the room pays, as a multiple.
+ *
+ * **This is what makes "add one" load-bearing rather than optimal by a hair.**
+ * Without it, a child who never works out a single sum can bid one under the
+ * broker's offer, win almost every lot, and take a coin each time — and at the
+ * tight end of the ladder, where the offer sits two coins above the room, that
+ * blind bid *is* the perfect bid. The game would be solvable by reading one
+ * number.
+ *
+ * The keen bid doubles, so the reward for the arithmetic scales with the margin
+ * instead of collapsing to a coin. `test/bots.test.ts` measures it: a bot that
+ * reads only the offer earns between a third and a ninth of what computing earns,
+ * at every intensity, on every seed.
+ *
+ * It is also the right *fiction*: a broker who buys at the smallest money the room
+ * allows is the one the guild pays for.
+ */
+export const KEEN_MULTIPLIER = 2
+
+export type Outcome = "sold" | "even" | "outbid" | "unsold" | "folded"
+
+export type Settled = {
+  readonly outcome: Outcome
+  readonly bid: number | null
+  /** Coins this lot put in the strongbox. Never negative. */
+  readonly coins: number
+  /** Won at exactly one over the room: the keen bid, and it pays double. */
+  readonly keen: boolean
+  /** The value the child asserted about the tablet they marked, or null. */
+  readonly claimed: number | null
+  /** Whether that assertion was right. Null when nothing was asserted. */
+  readonly arithmetic: boolean | null
+  readonly room: Room
+  readonly marked: Tablet | null
+}
+
+export type AuctionEvent =
+  | { kind: "lot"; lot: string; room: Room }
+  | { kind: "mark"; tablet: Tablet }
+  | { kind: "unmark" }
+  | { kind: "digit" }
+  | { kind: "settled"; settled: Settled }
+  | { kind: "consignment"; number: number; sold: number }
+  | { kind: "stalled" }
+
+export type Tally = {
+  sold: number
+  even: number
+  outbid: number
+  unsold: number
+  folded: number
+  /** Lots folded that really were not worth bidding on. */
+  scouted: number
+  /** Lots that came to the block, settled one way or another. */
+  settled: number
+}
+
+type Slot = { readonly serial: number; readonly lot: string }
+
+export class Auction {
+  private readonly host: Host
+  private readonly rng: Rng
+
+  private serial = 1
+  private queue: Slot[] = []
+  private consignmentNo = 1
+  private soldHere = 0
+
+  /** Drawn, unused, unshown. Offered to the next room; see `BENCH_CAP`. */
+  private bench: Tablet[] = []
+
+  private roomState: Room | null = null
+  private lotName = ""
+  private markedAt: number | null = null
+  private digitsText = ""
+
+  private phaseName: "bidding" | "settled" = "bidding"
+  private elapsed = 0
+  private duration = 0
+  private lastSettled: Settled | null = null
+
+  /** Wall-clock mark for the lot on the block, shifted forward across a pause. */
+  private askedAt = 0
+  private paused = false
+  private pausedAt = 0
+
+  private intensityValue = SPEC.start
+  private successValue = seedSuccess(SPEC)
+  /**
+   * The hardest rung this game has been able to draw a tablet from, or null.
+   *
+   * Only ever lowered. A rung whose answers do not fit on a tablet cannot start
+   * fitting later — the tablet is a constant — and a ceiling that drifted back up
+   * would re-enter the same starve every time the child climbed.
+   */
+  private drawCeiling: number | null = null
+  private pendingFlush = false
+
+  private stalledFlag = false
+
+  coins = 0
+  /** Lots bought above the offer and still on the shelf. Countable, and it stays. */
+  storeroom = 0
+  readonly tally: Tally = {
+    sold: 0,
+    even: 0,
+    outbid: 0,
+    unsold: 0,
+    folded: 0,
+    scouted: 0,
+    settled: 0,
+  }
+
+  constructor(host: Host, rng: Rng, now: number) {
+    this.host = host
+    this.rng = rng
+    this.askedAt = now
+  }
+
+  /** Consign the first five lots and bring the first one to the block. */
+  begin(now: number): AuctionEvent[] {
+    if (this.roomState !== null || this.stalledFlag) return []
+    this.refill()
+    return this.bringToBlock(now)
+  }
+
+  // ── what the renderer reads ────────────────────────────────────────────────
+
+  get room(): Room | null {
+    return this.roomState
+  }
+
+  get lot(): string {
+    return this.lotName
+  }
+
+  get phase(): "bidding" | "settled" {
+    return this.phaseName
+  }
+
+  get settled(): Settled | null {
+    return this.lastSettled
+  }
+
+  get marked(): number | null {
+    return this.markedAt
+  }
+
+  get markedTablet(): Tablet | null {
+    return this.markedAt === null ? null : (this.roomState?.tablets[this.markedAt] ?? null)
+  }
+
+  get digits(): string {
+    return this.digitsText
+  }
+
+  /** The bid on the paddle, or null when there is nothing on it. */
+  get bid(): number | null {
+    return this.digitsText === "" ? null : tryParseBid(this.digitsText)
+  }
+
+  /** Lots left in this consignment, including the one on the block. */
+  get remaining(): number {
+    return this.queue.length
+  }
+
+  get consignmentNumber(): number {
+    return this.consignmentNo
+  }
+
+  get intensity(): number {
+    return this.intensityValue
+  }
+
+  get success(): number {
+    return this.successValue
+  }
+
+  get ceiling(): number | null {
+    return this.drawCeiling
+  }
+
+  get stalled(): boolean {
+    return this.stalledFlag
+  }
+
+  get isPaused(): boolean {
+    return this.paused
+  }
+
+  /** Milliseconds left of the settled room's reveal. Zero while bidding. */
+  get holdLeft(): number {
+    return this.phaseName === "settled" ? Math.max(0, this.duration - this.elapsed) : 0
+  }
+
+  /** Whether the hammer would do anything if it were tapped right now. */
+  get armed(): boolean {
+    if (this.paused || this.stalledFlag) return false
+    if (this.phaseName !== "bidding" || this.roomState === null) return false
+    const bid = this.bid
+    return this.markedAt !== null && bid !== null && bid >= 1
+  }
+
+  // ── what the child does ───────────────────────────────────────────────────
+
+  /**
+   * Mark the tablet you mean to beat, or take the mark off it.
+   *
+   * Free and reversible, like taking hold of a floor in COLOSSUS: exploring the
+   * room must never cost anything. Single selection — there is one highest bid.
+   */
+  tapTablet(index: number): AuctionEvent[] {
+    if (!this.open) return []
+    const tablet = this.roomState?.tablets[index]
+    if (!tablet) return []
+    if (this.markedAt === index) {
+      this.markedAt = null
+      return [{ kind: "unmark" }]
+    }
+    this.markedAt = index
+    return [{ kind: "mark", tablet }]
+  }
+
+  pressDigit(digit: number): AuctionEvent[] {
+    if (!this.open) return []
+    if (!Number.isInteger(digit) || digit < 0 || digit > 9) return []
+    // A leading zero is not a price. Swallowed rather than refused: a child who
+    // meant 10 and hit 0 first should just carry on and hit 1.
+    if (this.digitsText === "" && digit === 0) return []
+    if (this.digitsText.length >= MAX_BID_DIGITS) return []
+    this.digitsText += String(digit)
+    return [{ kind: "digit" }]
+  }
+
+  backspace(): AuctionEvent[] {
+    if (!this.open || this.digitsText === "") return []
+    this.digitsText = this.digitsText.slice(0, -1)
+    return [{ kind: "digit" }]
+  }
+
+  /**
+   * THE GAVEL. The one assertion in the game, and the only thing reported.
+   *
+   * Inert without a mark or without a bid — neither is an assertion, and an
+   * unarmed hammer costs nothing. Everything else settles the lot.
+   */
+  hammer(now: number): AuctionEvent[] {
+    if (!this.armed) return []
+    const room = this.roomState
+    const marked = this.markedTablet
+    const bid = this.bid
+    if (!room || !marked || bid === null) return []
+
+    // **The question THE GAVEL asks is "what is one more than this tablet?"** and the
+    // bid IS the answer to it — typed by the child, digit by digit, with nothing
+    // derived on the way. `bid − 1` is that same answer written in the host's terms,
+    // because the host's canonical value for this item is the tablet itself.
+    //
+    // Two consequences, and both are deliberate:
+    //
+    //   * A child who works this tablet out and bids one over it is reported CORRECT
+    //     whatever the money then does — marking the wrong tablet loses the lot, and
+    //     losing the lot is not an arithmetic verdict. `test/report.test.ts` holds
+    //     that as its first property, because it is the thing TREBUCHET got wrong.
+    //   * A child who bids two over, or level with the tablet, is reported wrong.
+    //     That is an over-attribution — they may be able to add and simply not have
+    //     the rule yet — and it is the direction that is safe: a false wrong steps
+    //     the ladder DOWN and serves easier sums, and there is no bid anywhere in
+    //     this game that reports a wrong answer as right.
+    const claimed = bid - 1
+    const arithmetic = claimed === marked.value
+
+    if (marked.id !== "") {
+      this.host.report({
+        questionId: marked.id,
+        correct: arithmetic,
+        ms: Math.max(0, now - this.askedAt),
+        answered: String(claimed),
+      })
+    }
+    // Everything the child read and did not answer. Closed, not filed as wrong.
+    for (const tablet of room.tablets) {
+      if (tablet !== marked) this.close(tablet)
+    }
+
+    const outcome: Outcome =
+      bid <= room.highest
+        ? "outbid"
+        : bid > room.offer
+          ? "unsold"
+          : bid === room.offer
+            ? "even"
+            : "sold"
+    const keen = outcome === "sold" && bid === room.highest + 1
+    const profit = outcome === "sold" ? Math.max(0, profitOf(room, bid)) : 0
+    const coins = keen ? profit * KEEN_MULTIPLIER : profit
+    if (outcome === "unsold") this.storeroom += 1
+
+    return this.finish(
+      { outcome, bid, coins, keen, claimed, arithmetic, room, marked },
+      arithmetic,
+    )
+  }
+
+  /**
+   * FOLD. Let the lot go.
+   *
+   * Always safe and never reported: a child who declined to bid has not asserted a
+   * number, and inventing one for them is what `report({ answered: "" })` did in
+   * six games until this week. On a lot whose offer is not above the room this is
+   * the *right* answer, and the broker pays for it.
+   */
+  fold(): AuctionEvent[] {
+    if (!this.open) return []
+    const room = this.roomState
+    if (!room) return []
+    for (const tablet of room.tablets) this.close(tablet)
+
+    const worthless = isTrap(room)
+    const coins = worthless ? SCOUT_FEE : 0
+    if (worthless) this.tally.scouted += 1
+
+    // No arithmetic verdict, so the controller hears nothing. A fold says nothing
+    // about what the child knows and a guess from it would be a decision this game
+    // has no business making.
+    return this.finish(
+      {
+        outcome: "folded",
+        bid: null,
+        coins,
+        keen: false,
+        claimed: null,
+        arithmetic: null,
+        room,
+        marked: null,
+      },
+      null,
+    )
+  }
+
+  /** A tap during the reveal. Ends it now; it was never a wait for an answer. */
+  nudge(): AuctionEvent[] {
+    if (this.paused || this.phaseName !== "settled") return []
+    this.elapsed = this.duration
+    return []
+  }
+
+  /**
+   * Time passing.
+   *
+   * **Returns immediately while the child is bidding**, so elapsed time literally
+   * cannot accumulate while they are thinking — FOUNDRY STREET's shape, and its
+   * comment: "a child who is thinking must never be losing". The only phase with a
+   * duration is the reveal, which happens after the hammer has already fallen.
+   */
+  advance(dt: number, now: number): AuctionEvent[] {
+    if (this.paused || this.stalledFlag) return []
+    if (this.phaseName === "bidding") return []
+    this.elapsed += Math.max(0, dt)
+    if (this.elapsed < this.duration) return []
+    return this.nextLot(now)
+  }
+
+  /** The host put a sheet over us. Stop the clock; stop taking input. */
+  pause(now: number): void {
+    if (this.paused) return
+    this.paused = true
+    this.pausedAt = now
+  }
+
+  /**
+   * The sheet came off. Shift the lot's wall-clock mark forward by the span the
+   * child was not here for, so the latency reported is time they actually spent
+   * looking at the room.
+   */
+  resume(now: number): void {
+    if (!this.paused) return
+    this.paused = false
+    this.askedAt += Math.max(0, now - this.pausedAt)
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────
+
+  private get open(): boolean {
+    return !this.paused && !this.stalledFlag && this.phaseName === "bidding"
+  }
+
+  /** Close a question the child read and never answered. */
+  private close(tablet: Tablet): void {
+    if (tablet.id === "") return
+    this.host.skip?.(tablet.id)
+  }
+
+  /**
+   * Bank the outcome, move the consignment, and hold the settled room up.
+   *
+   * The controller hears exactly one thing: whether the arithmetic the child
+   * asserted was right. Not whether they made money — a child who reads the room
+   * perfectly and then pads their bid has done the arithmetic and mispriced the
+   * lot, and only one of those two is a fact about what the ladder should serve
+   * next.
+   */
+  private finish(settled: Settled, arithmetic: boolean | null): AuctionEvent[] {
+    this.coins += settled.coins
+    this.tally.settled += 1
+    this.tally[settled.outcome] += 1
+    if (settled.outcome === "sold" || settled.outcome === "even") this.soldHere += 1
+
+    if (arithmetic !== null) {
+      this.successValue = observe(this.successValue, arithmetic)
+    }
+    // Once per settled lot, on a nominal step. This is the only line in the game
+    // that moves the intensity, and no wall clock reaches it.
+    this.intensityValue = settleAfterLot(this.intensityValue, this.successValue)
+
+    const missed = settled.outcome === "outbid" || settled.outcome === "unsold"
+    const head = this.queue.shift()
+    if (missed && head) {
+      // The lot did not sell, so it goes back into the consignment — and the
+      // broker adds another. More to work through; nothing taken away.
+      this.queue.push(head)
+      for (let i = 0; i < EXTRA_ON_MISS && this.queue.length < MAX_CONSIGNMENT; i++) {
+        this.queue.push(this.slot())
+      }
+    }
+
+    this.lastSettled = settled
+    this.markedAt = null
+    this.digitsText = ""
+    this.phaseName = "settled"
+    this.elapsed = 0
+    this.duration = revealHoldMs(this.intensityValue)
+    return [{ kind: "settled", settled }]
+  }
+
+  /** The reveal is over. Wrap the consignment if it is empty, then draw a room. */
+  private nextLot(now: number): AuctionEvent[] {
+    const events: AuctionEvent[] = []
+    if (this.queue.length === 0) {
+      const sold = this.soldHere
+      events.push({ kind: "consignment", number: this.consignmentNo, sold })
+      // A consignment the child sold out of is a stopping point they reached. One
+      // they only cleared by having every lot taken off them is not, and a
+      // purchase surface must never sit next to a shortfall.
+      if (sold > 0) this.host.transition?.("level", `consignment ${String(this.consignmentNo)}`)
+      this.consignmentNo += 1
+      this.soldHere = 0
+      this.refill()
+    }
+    events.push(...this.bringToBlock(now))
+    return events
+  }
+
+  private refill(): void {
+    for (let i = 0; i < CONSIGNMENT; i++) this.queue.push(this.slot())
+  }
+
+  private slot(): Slot {
+    return { serial: this.serial++, lot: this.rng.pick(LOTS) }
+  }
+
+  /** Draw the room for the lot at the head of the consignment. */
+  private bringToBlock(now: number): AuctionEvent[] {
+    const head = this.queue[0]
+    if (!head) return []
+
+    const want = tabletCount(this.intensityValue)
+    const assembly = assembleRoom(
+      () => this.draw(),
+      want,
+      this.intensityValue,
+      this.rng,
+      (q) => {
+        this.capBelow(q)
+      },
+      this.bench,
+    )
+    // A question this game can never use is closed at once. One it simply did not want
+    // this time waits on the bench, and only the overflow is closed — oldest first, so
+    // a value the room keeps passing over does not sit there for the whole session.
+    for (const tablet of assembly.discarded) this.close(tablet)
+    this.bench = [...assembly.bench]
+    while (this.bench.length > BENCH_CAP) {
+      const stale = this.bench.shift()
+      if (stale) this.close(stale)
+    }
+
+    if (!assembly.room) {
+      this.stalledFlag = true
+      this.roomState = null
+      console.error("[gavel] the host served nothing this game can put a tablet up for")
+      return [{ kind: "stalled" }]
+    }
+
+    this.roomState = assembly.room
+    this.lotName = head.lot
+    this.markedAt = null
+    this.digitsText = ""
+    this.phaseName = "bidding"
+    this.elapsed = 0
+    this.duration = 0
+    this.askedAt = now
+    return [{ kind: "lot", lot: head.lot, room: assembly.room }]
+  }
+
+  /**
+   * One question, at what this run is asking for.
+   *
+   * The flush waits until after `next` has carried the new ceiling onto the wire.
+   * `game-host`'s flush ranks the pool with a distance function that reads the
+   * host's OWN ceiling, and that is only updated inside `next` — so flushing the
+   * instant a ceiling is set ranks every pooled question against the stale one and
+   * keeps precisely the rung it meant to discard. Measured in POLARITY at ten
+   * consecutive silent questions.
+   */
+  private draw(): Question {
+    const q = this.host.next(this.askShape())
+    if (this.pendingFlush) {
+      this.pendingFlush = false
+      this.host.flush?.()
+    }
+    return q
+  }
+
+  /** What this run asks the host for, difficulty and ceiling both. */
+  askShape(): Ask {
+    const ask: Ask = { difficulty: ladderScale(this.intensityValue) }
+    if (this.drawCeiling !== null) ask.maxDifficulty = ladderScale(this.drawCeiling)
+    return ask
+  }
+
+  /**
+   * Ban the rung an undrawable question came from, and everything above it.
+   *
+   * Declining an item is per-item and the host serves by RUNG: ask again at the
+   * same difficulty and the same rung answers. Without this, a rung whose answers
+   * do not fit on a tablet is not a degradation, it is a soft-lock — every room
+   * spends its whole draw budget being refused and the child is served a stall.
+   */
+  private capBelow(q: Question): void {
+    // A difficulty that is not a number caps nothing. Without this the ceiling
+    // becomes NaN, which the host discards as "not a difficulty" — leaving it inert
+    // AND the monotone guard below permanently false, so every later refusal
+    // re-logs and re-flushes for the life of the run.
+    if (!Number.isFinite(q.difficulty)) return
+    const at = Math.min(1, Math.max(0, q.difficulty))
+    const capped = Math.max(0, at - CEILING_STEP)
+    if (this.drawCeiling !== null && this.drawCeiling <= capped) return
+    this.drawCeiling = capped
+    this.pendingFlush = true
+    console.error(
+      `[gavel] a rung THE GAVEL cannot put on a tablet was served at difficulty ${at.toFixed(3)}; ` +
+        `capping the stream at ${capped.toFixed(3)} for the rest of this run`,
+    )
+  }
+}

--- a/dynawalla/games/gavel/src/game/ladder.ts
+++ b/dynawalla/games/gavel/src/game/ladder.ts
@@ -1,0 +1,251 @@
+// What the room looks like at a given intensity, and what THE GAVEL is willing
+// to put on a tablet.
+//
+// **No wall clock reaches this file.** `intensity` moves on `settle`, which THE
+// GAVEL calls once per *settled lot* with a fixed nominal step — never per frame
+// and never with a real delta. So the room escalates on lots worked, which is
+// achievement, and two sittings that make the same decisions get the same room
+// however long the child took over each one. `test/antimash.test.ts` is the
+// proof, and `test/ladder.test.ts` is the guard on the shape.
+//
+// **Nothing here is a comprehension window, because the game has no clock at
+// all.** There is nothing to be monotone in difficulty: a lot waits.
+
+import {
+  SECOND_GRADE_FLOW,
+  countAt,
+  observe as flowObserve,
+  settle as flowSettle,
+  revealMs as flowRevealMs,
+  valueAt,
+  type FlowSpec,
+} from "../../../../packs/shared/game-pacing/index.ts"
+import type { Question } from "../contract.ts"
+
+/**
+ * The controller shape: `SECOND_GRADE_FLOW` with three overrides.
+ *
+ * **`laboredScore: 1` is the load-bearing one.** The shared spec pays a correct
+ * answer between `laboredScore` (0.55) and 1 depending on how quick it was, and THE
+ * GAVEL deliberately never tells it how quick — see `observe`. Left at 0.55 that
+ * makes flawless play score exactly 0.55 forever, which is `strugglingBelow`, which
+ * `demandFor` maps to the FLOOR: a child who never made a mistake would have been
+ * held at the easiest content in the product for the whole session, and the only
+ * symptom would have been a game that never got harder. In a game with no clock,
+ * correctness is the only evidence there is, so it has to be full evidence.
+ *
+ * The two climb constants are slower than ARENA's because this controller is
+ * stepped **once per lot** rather than once per frame. At `climbBoost: 14` a
+ * flawless player crossed the whole curriculum ladder in about four lots, which is
+ * not a climb, it is a jump — and at 8 the first step of a climb from a standing
+ * start was larger than the first step of a fall, which inverts the one asymmetry the
+ * shared module insists on: relief is not something to be earned.
+ */
+export const SPEC: FlowSpec = {
+  ...SECOND_GRADE_FLOW,
+  laboredScore: 1,
+  climbSeconds: 420,
+  climbBoost: 6,
+}
+
+/**
+ * Nominal seconds charged to the controller per settled lot.
+ *
+ * A number, not a measurement. `settle` needs a step to move on and the only
+ * honest step in a game with no clock is "one lot happened": six is roughly what
+ * a lot takes when a child knows what they are doing, so `climbSeconds: 300`
+ * reads as "fifty unhurried lots to cross the whole ladder at the slowest
+ * climb", and `climbBoost` carries somebody who is obviously fluent up in five
+ * or six.
+ */
+export const LOT_STEP_SECONDS = 6
+
+/** How many rival bidders are in the room. */
+export function tabletCount(intensity: number): number {
+  return countAt(intensity, MIN_TABLETS, MAX_TABLETS)
+}
+
+export const MIN_TABLETS = 3
+export const MAX_TABLETS = 5
+
+/**
+ * How far above the room the broker's offer sits, on a lot worth buying.
+ *
+ * **This band does NOT ride the intensity, and it was written that way first.** The
+ * obvious escalation was to squeeze it — nine coins of headroom at the calm end,
+ * three at the hard end — and it is a trap, measured in `test/bots.test.ts`. At a
+ * margin of three, the arithmetic-free strategy of bidding one under the broker's
+ * offer earns one coin and the keen bid earns four, so the whole reward for reading
+ * the room collapses to three coins and, at a margin of two, the blind bid *is* the
+ * keen bid. Squeezing the margin does not make the game harder; it makes the
+ * arithmetic worth less.
+ *
+ * Wide, and the reward for precision scales with it: the keen bid pays
+ * `2 × (margin − 1)`, which averages nine coins against the blind strategy's one.
+ * Escalation is carried by the rung the questions come from, by how many rivals are
+ * in the room, and by how often the offer is not worth chasing at all.
+ */
+export const MIN_MARGIN = 2
+export const MAX_MARGIN = 9
+
+/**
+ * How often the broker's offer is too low to be worth bidding at all.
+ *
+ * A lot whose offer is at or one coin above the highest rival bid cannot be
+ * flipped for a profit by anybody, and the only right move is to fold the
+ * paddle. These are what make the inequality load-bearing rather than
+ * decorative: without them a child could ignore the offer entirely, always bid
+ * one over, and never be wrong.
+ *
+ * Zero at the very bottom of the ladder. The first lots a child ever sees should
+ * all be winnable — a trap is a lesson about a rule they have not been taught
+ * yet.
+ */
+export function trapChance(intensity: number): number {
+  if (intensity < 0.12) return 0
+  return valueAt(intensity, 0.1, 0.3)
+}
+
+/** How long the settled room is held in front of the child, in milliseconds. */
+export function revealHoldMs(intensity: number): number {
+  // Floored, not merely taken: at the top of the ladder `revealMs` goes to zero,
+  // and zero would tear the room down in the same frame the hammer fell. The
+  // floor is the length of the animation, not a lesson.
+  return Math.max(MIN_REVEAL_MS, flowRevealMs(SPEC, intensity))
+}
+
+export const MIN_REVEAL_MS = 900
+
+/**
+ * The success estimate after one more lot.
+ *
+ * **`seconds` is deliberately not passed.** `outcomeScore` would pay a bonus for
+ * a quick answer, and a bonus that changes the *content* of the next question is
+ * a clock wearing a different hat: think for longer and the room gets easier, so
+ * a child who is careful is quietly demoted. THE GAVEL has no clock anywhere and
+ * this is where one would have crept in. Latency is still measured and still
+ * reported to the host — see `Auction.hammer` — because the learner model wants
+ * it. The game just never spends it.
+ */
+export function observe(success: number, arithmeticWasRight: boolean): number {
+  return flowObserve(SPEC, success, arithmeticWasRight)
+}
+
+/** Intensity after one settled lot. Nothing else may ever move it. */
+export function settleAfterLot(intensity: number, success: number): number {
+  return flowSettle(SPEC, intensity, success, LOT_STEP_SECONDS)
+}
+
+// ── what fits on a tablet ────────────────────────────────────────────────────
+
+/**
+ * The largest bid the paddle can hold and the largest value a tablet can carry.
+ *
+ * Five digits fit on the paddle; four is the cap on what the room may ask for,
+ * because the broker's offer sits above the highest rival bid and the child's
+ * bid sits above that, and all three have to stay inside the same paddle.
+ */
+export const MAX_TABLET_VALUE = 9999
+export const MAX_BID_DIGITS = 5
+
+/** Narrowest tablet the gallery layout will ever produce, in CSS pixels. */
+export const MIN_TABLET_W = 132
+/** Text inset inside a tablet, per side. */
+export const TABLET_PAD = 8
+/**
+ * The smallest a numeral a child has to read may be drawn.
+ *
+ * `PACING_AUDIT_2026-07.md` closes on this: `serpent`'s orbs print at four to
+ * seven CSS pixels on a phone, "so the child guesses for a reason that has
+ * nothing to do with time". Thirteen is a floor, not a target.
+ */
+export const MIN_NUMERAL_PX = 13
+/** Mean advance of a digit in the face `render/scene.ts` draws, in ems. */
+export const DIGIT_ADVANCE_EM = 0.63
+
+/**
+ * How many characters of prompt a tablet can hold.
+ *
+ * **Derived, not asserted.** `polarity` shipped `LABEL_MAX_CHARS = 8` with a
+ * comment saying eight "still fits the cell without squeezing"; they overflowed
+ * it by about 60% and nothing measured. This is arithmetic on the narrowest
+ * tablet the layout can produce and the smallest numeral a child may be asked to
+ * read, and `test/layout.test.ts` checks the renderer against the same numbers
+ * rather than against this constant.
+ */
+export const PROMPT_MAX_CHARS = Math.floor(
+  (MIN_TABLET_W - 2 * TABLET_PAD) / (MIN_NUMERAL_PX * DIGIT_ADVANCE_EM),
+)
+
+/** An exact non-negative integer, or null. Never rounds, never bends. */
+export function tryParseBid(text: string): number | null {
+  if (!/^\d{1,6}$/.test(text.trim())) return null
+  const value = Number(text.trim())
+  return Number.isSafeInteger(value) ? value : null
+}
+
+/**
+ * The value a tablet would carry for this question, or null if it cannot.
+ *
+ * A tablet is a *price*. A price is a whole number of coins, it is not negative,
+ * and it has to be small enough that one more coin than it still fits on the
+ * paddle. A fraction, a decimal, a negative or a five-digit answer is refused —
+ * and refusing is loud where it happens.
+ */
+export function tabletValue(q: Question): number | null {
+  const value = tryParseBid(q.answer)
+  if (value === null || value > MAX_TABLET_VALUE) return null
+  if (visibleLength(q.prompt) > PROMPT_MAX_CHARS) return null
+  return value
+}
+
+/** Characters that count against the tablet's width. */
+export function visibleLength(prompt: string): number {
+  return prompt.trim().length
+}
+
+/**
+ * Is this refusal a fact about the RUNG, or only about this item?
+ *
+ * Everything `tabletValue` refuses is a property of the rung — the width of the
+ * paddle and the width of the tablet are constants, so if one item from a rung
+ * will not fit then every item from it is equally hopeless. That is not true of
+ * the one other reason a board rejects an item, which is a value already on the
+ * board: a collision is a fact about a pair of items and nothing about a rung.
+ * `polarity` conflated the two and pinned a whole session at the easiest rung in
+ * the product off one transient empty pool.
+ *
+ * `id === ""` is the shared host's marker for "the pool ran dry, here is something
+ * drawable". It describes no rung and must never cap one. Today's sentinel answers
+ * `"0"`, which is a perfectly good price, so the check below would refuse to cap on it
+ * anyway — the id line is there because the sentinel belongs to the host and the next
+ * one may not parse. `test/lot.test.ts` covers both, so the line is load-bearing
+ * against a future host rather than against this one.
+ */
+export function rungCannotDraw(q: Question): boolean {
+  if (q.id === "") return false
+  return tabletValue(q) === null
+}
+
+/**
+ * A 0..1 ladder position, spelled so the host cannot read it as the other scale.
+ *
+ * `packs/shared/game-host` reads a value below 1 as a fraction and 1..10 as a
+ * ladder index, and resolves the one value both scales claim — `1` — as the
+ * BOTTOM. A game that speaks fractions and ever reaches exactly 1 asks for the
+ * hardest content in the product and is served the easiest. This game's
+ * intensity reaches 1, so it speaks the unambiguous scale.
+ */
+export function ladderScale(unit: number): number {
+  const u = Number.isFinite(unit) ? Math.min(1, Math.max(0, unit)) : 0
+  return 1 + u * 9
+}
+
+/**
+ * How far below a rung a ceiling is set when that rung turns out undrawable.
+ *
+ * The host floors `maxDifficulty × span` to a rung index, so an ordinate minus
+ * anything strictly between zero and one rung excludes exactly that rung and
+ * keeps every rung below it.
+ */
+export const CEILING_STEP = 1e-3

--- a/dynawalla/games/gavel/src/game/lot.ts
+++ b/dynawalla/games/gavel/src/game/lot.ts
@@ -1,0 +1,247 @@
+// The room: which tablets go up in front of a lot, and what the broker will pay
+// for it.
+//
+// A tablet is a curriculum question with its answer used as a *price*. Nothing
+// here invents a sum — every rival bid is drawn from the host — and the only
+// judgement this file makes is which of the questions it drew belong on the same
+// board together, and how far above them the broker's offer sits.
+//
+// **Why the board is a tight cluster.** COUNTERPOISE shipped with its answer as
+// the rightmost weight 97.2% of the time, and a bot that always took the
+// rightmost weight scored 97.2% without doing any arithmetic. The equivalent hole
+// here is a board whose highest bid is *obvious* — `3 × 2` next to `48 + 37` can
+// be sorted by eye, and eyeballing is not retrieval. So the assembler draws more
+// questions than it needs and keeps the run of values that sit closest together.
+// The founder's own example is exactly that shape: `12 + 5`, `3 × 5`, `8 × 1`,
+// `15 − 2` — 17, 15, 8, 13.
+//
+// Measured, because the size of that surplus turned out to matter: with three spare
+// questions a room's values spanned 73% of its own maximum and a bot that marked
+// whichever tablet had the biggest numeral printed on it was right 46% of the time.
+// With ten spare, the span is 54% and the same bot is right 25% of the time.
+//
+// **Why the surplus does not cost ten questions a lot.** Everything drawn and not used
+// goes on a BENCH and is offered to the next room, so the assembler pays for a wide
+// choice once rather than every lot. A benched question has not been shown to the child
+// and has not been answered, so it can appear in a later room with nothing stale about
+// it — and because a tablet that reaches a board is always either answered or skipped
+// when that board settles, nothing on the bench can ever be reported twice.
+
+import type { Question } from "../contract.ts"
+import type { Rng } from "../core/rng.ts"
+import {
+  MAX_MARGIN,
+  MAX_TABLETS,
+  MIN_MARGIN,
+  rungCannotDraw,
+  tabletValue,
+  trapChance,
+} from "./ladder.ts"
+
+export type Tablet = {
+  /** The question this tablet is. `""` for a question the pool could not serve. */
+  readonly id: string
+  /** "12 + 5", as the child reads it. Never the total. */
+  readonly prompt: string
+  /** What the rival is bidding. The child has to work this out. */
+  readonly value: number
+  /** Where on the host's ladder it came from, 0..1. */
+  readonly difficulty: number
+}
+
+export type Room = {
+  readonly tablets: readonly Tablet[]
+  /** The highest rival bid. The number the whole round turns on. */
+  readonly highest: number
+  /** What the broker will pay for the lot the moment you own it. */
+  readonly offer: number
+}
+
+/** No bid can be flipped for a profit: the only right move is to fold. */
+export function isTrap(room: Room): boolean {
+  return room.offer <= room.highest + 1
+}
+
+/** The bid that earns the most coins, or null on a lot not worth buying. */
+export function bestBid(room: Room): number | null {
+  return isTrap(room) ? null : room.highest + 1
+}
+
+/** What a bid earns. Negative is never charged to the child; see `Auction`. */
+export function profitOf(room: Room, bid: number): number {
+  return room.offer - bid
+}
+
+/** How many spare questions to choose between. Measured; see the file header. */
+export const POOL_EXTRA = 10
+
+/** Draws we are willing to make before giving up on a board. */
+const MAX_DRAWS = 2 * (MAX_TABLETS + POOL_EXTRA) + 8
+
+export type Assembly = {
+  /** Null when the host served nothing this game can stand a tablet up from. */
+  readonly room: Room | null
+  /**
+   * Usable questions drawn and not put on this board. The caller holds them for the
+   * next room rather than closing them — see the file header.
+   */
+  readonly bench: readonly Tablet[]
+  /**
+   * Questions this game can never use at all: an answer that is not a price, or a
+   * prompt too wide for a tablet. The caller closes these.
+   */
+  readonly discarded: readonly Tablet[]
+}
+
+/**
+ * Put a room together.
+ *
+ * `draw` is the caller's one-question closure, not the host: it is the caller
+ * that owns what this run is asking for, and it re-reads that on every draw so a
+ * ceiling discovered on the second tablet is already on the wire for the third.
+ * Everything drawn and not used comes back in `unused` so the caller can close
+ * it — a question handed to a pack and never answered has to be skipped, not
+ * silently dropped, or it stays open in the host's ledger forever.
+ *
+ * `onUndrawable` is called with a question whose whole RUNG this game cannot
+ * draw, once per such question. What to do about it is the caller's; see
+ * `Auction.capBelow`.
+ */
+export function assembleRoom(
+  draw: () => Question,
+  want: number,
+  intensity: number,
+  rng: Rng,
+  onUndrawable: (q: Question) => void,
+  bench: readonly Tablet[] = [],
+): Assembly {
+  const pool: Tablet[] = [...bench]
+  const discarded: Tablet[] = []
+  const seen = new Set<number>(pool.map((t) => t.value))
+
+  for (let attempt = 0; attempt < MAX_DRAWS && pool.length < want + POOL_EXTRA; attempt++) {
+    const q = draw()
+    const value = tabletValue(q)
+    if (value === null) {
+      // Loud, every time, because a room that quietly shrinks is the failure this
+      // whole file is written against.
+      console.error(
+        `[gavel] declined a question no tablet can carry: ${q.prompt} = ${JSON.stringify(q.answer)}`,
+      )
+      if (rungCannotDraw(q)) onUndrawable(q)
+      discarded.push(tabletOf(q, 0))
+      continue
+    }
+    if (seen.has(value)) {
+      // Two rivals bidding the same amount has no highest, so one of them has to
+      // go — and there is no board or bench it could ever join, because the value is
+      // already there. This is a fact about a PAIR of questions and never about a
+      // rung: a collision must not cap the stream, which is the bug that pinned
+      // POLARITY to the easiest rung in the product for a whole session.
+      discarded.push(tabletOf(q, value))
+      continue
+    }
+    seen.add(value)
+    pool.push(tabletOf(q, value))
+  }
+
+  if (pool.length < 2) {
+    // One tablet is not a comparison, and the highest bid in a room of one is
+    // whatever is in front of you. Better to say so than to ask nothing.
+    console.error(
+      `[gavel] the host served only ${String(pool.length)} usable question(s) in ${String(MAX_DRAWS)} draws`,
+    )
+    return { room: null, bench: [], discarded: [...discarded, ...pool] }
+  }
+
+  const take = Math.min(want, pool.length)
+  const { kept, dropped } = tightest(pool, take)
+
+  const highest = kept.reduce((best, t) => Math.max(best, t.value), 0)
+  const offer = highest + marginFor(intensity, rng)
+
+  // Shuffled last. The highest bid must be as likely to be in any position as any
+  // other, or the position becomes the answer.
+  const tablets = rng.shuffle([...kept])
+
+  return { room: { tablets, highest, offer }, bench: dropped, discarded }
+}
+
+function tabletOf(q: Question, value: number): Tablet {
+  return {
+    id: q.id,
+    prompt: q.prompt,
+    value,
+    difficulty: Number.isFinite(q.difficulty) ? Math.min(1, Math.max(0, q.difficulty)) : 0,
+  }
+}
+
+/**
+ * The `take` tablets whose values sit closest together, and the rest.
+ *
+ * Sorted by value, then the window of `take` consecutive entries with the
+ * smallest span. Ties go to the lowest window, which keeps the room's prices
+ * nearer the bottom of what the rung offers and costs nothing.
+ */
+export function tightest(
+  pool: readonly Tablet[],
+  take: number,
+): { kept: Tablet[]; dropped: Tablet[] } {
+  const sorted = [...pool].sort((a, b) => a.value - b.value)
+  const n = Math.min(Math.max(1, take), sorted.length)
+  let bestAt = 0
+  let bestSpan = Number.POSITIVE_INFINITY
+  for (let i = 0; i + n <= sorted.length; i++) {
+    const lo = sorted[i]
+    const hi = sorted[i + n - 1]
+    if (!lo || !hi) continue
+    const span = hi.value - lo.value
+    if (span < bestSpan) {
+      bestSpan = span
+      bestAt = i
+    }
+  }
+  const kept = sorted.slice(bestAt, bestAt + n)
+  const dropped = [...sorted.slice(0, bestAt), ...sorted.slice(bestAt + n)]
+  return { kept, dropped }
+}
+
+/**
+ * How far the broker's offer sits above the highest rival bid.
+ *
+ * Zero or one is a lot nobody can profit from — see `isTrap`, and `trapChance` for
+ * how often that happens. Everything else is headroom the child has to stay inside,
+ * drawn from a band that deliberately does not narrow as the run climbs; the reason
+ * is on `MIN_MARGIN` and it was measured.
+ */
+export function marginFor(intensity: number, rng: Rng): number {
+  if (rng.chance(trapChance(intensity))) return rng.int(0, 1)
+  return rng.int(MIN_MARGIN, MAX_MARGIN)
+}
+
+/**
+ * The things that come up on the block.
+ *
+ * Named objects rather than "LOT 4", because a child bidding on an astrolabe is
+ * doing something and a child bidding on a numbered abstraction is doing a
+ * worksheet. Drawn from al-Jazari's and the Banū Mūsā's machines, which is where
+ * this product's art direction is sourced.
+ */
+export const LOTS: readonly string[] = [
+  "BRASS ASTROLABE",
+  "WATER CLOCK",
+  "SINGING EWER",
+  "LAPIS ORRERY",
+  "PEACOCK BASIN",
+  "CANDLE CLOCK",
+  "SIPHON CUP",
+  "MECHANICAL SCRIBE",
+  "GLASS ALEMBIC",
+  "SILVER SEXTANT",
+  "REED FLUTE ORGAN",
+  "TRICK LOCK",
+  "SAND GLASS",
+  "STAR MAP",
+  "COPPER DRUM",
+  "SUN DIAL RING",
+]

--- a/dynawalla/games/gavel/src/index.ts
+++ b/dynawalla/games/gavel/src/index.ts
@@ -1,0 +1,3 @@
+export type { Ask, Host, Question } from "./contract.ts"
+export { mount } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/gavel/src/main.ts
+++ b/dynawalla/games/gavel/src/main.ts
@@ -1,0 +1,68 @@
+// Standalone dev harness. `npm run dev` → a playable game wired to the local stub
+// Host, with no runtime underneath it.
+//
+//   ?seed=123        pin the run
+//   ?reduced         force the reduced-motion branch (`?reduced=0` forces off)
+//   ?difficulty=6    pin the ladder (1..10) instead of letting the run climb it
+//   ?pause           bind `p` to the host's pause/resume, so the sheet the real
+//                    host raises can be rehearsed here
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("gavel: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x9a7e1
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+const pinned = params.has("difficulty") ? Number(params.get("difficulty")) : undefined
+
+let answered = 0
+let correct = 0
+let skipped = 0
+const readout = document.getElementById("readout")
+
+const paint = (last: string): void => {
+  if (!readout) return
+  readout.textContent = `host.report → ${String(correct)}/${String(answered)} · skipped ${String(skipped)} · ${last}`
+}
+
+const host = createStubHost({
+  seed,
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  ...(pinned === undefined || Number.isNaN(pinned) ? {} : { difficulty: pinned }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    paint(`last "${r.answered}" ${Math.round(r.ms)}ms`)
+    console.info("[gavel/host] report", r)
+  },
+  onSkip(id) {
+    skipped++
+    paint(`skipped ${id}`)
+  },
+  onTransition(kind, label) {
+    console.info("[gavel/host] transition", kind, label)
+  },
+})
+
+const handle = mount(el, host)
+
+// The real host raises a sheet and sends `pause` with the pack still mounted.
+// Rehearse it here rather than discovering it on a tablet.
+let held = false
+globalThis.addEventListener("keydown", (event) => {
+  if (event.key !== "p" && event.key !== "P") return
+  held = !held
+  if (held) handle.pause()
+  else handle.resume()
+  if (readout) readout.textContent = held ? "host → pause" : "host → resume"
+})
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => {
+  handle.unmount()
+})

--- a/dynawalla/games/gavel/src/mount.ts
+++ b/dynawalla/games/gavel/src/mount.ts
@@ -1,0 +1,339 @@
+// THE GAVEL — the shell. Canvas, clock, input, and the wiring from the rules in
+// `game/auction.ts` to the gallery in `render/scene.ts`.
+//
+// **The pause.** The host can put a sheet — a stopping-point card, a parent gate —
+// over a pack that is still mounted and still running, and this game calls
+// `transition` at the end of every consignment, so that is not hypothetical. Three
+// things have to stop dead, and each of them is a real bug if it does not:
+//
+//   1. **Input.** A touch that lands while the sheet is up is not something the
+//      child did. Left unguarded it drops the hammer on a room nobody was looking
+//      at, reports a bid to a lot they never saw, and adds two lots for it.
+//   2. **The lot's clock.** The reported latency is the time the child spent
+//      working the room out. Time spent behind a sheet is not that.
+//   3. **The frame.** The reveal would otherwise play out to nobody.
+//
+// `Auction.pause`/`resume` own 1 and 2; the rAF loop here owns 3.
+
+import { Audio } from "./audio/audio.ts"
+import type { Host } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+import { Auction, type AuctionEvent } from "./game/auction.ts"
+import { MIN_TABLETS } from "./game/ladder.ts"
+import { Scene, type View } from "./render/scene.ts"
+import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+
+/**
+ * The largest step the clock may take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Nothing a child is answering
+ * is on a timer here, so this only bounds the reveal and the coin walk: clamped,
+ * a tab that comes back does not skip the settled room the child was reading.
+ */
+const MAX_STEP_MS = 120
+
+export function mountGavel(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const seed = (Date.now() ^ 0x9a7e1) >>> 0
+  const scene = new Scene(canvas, reduced)
+  const audio = new Audio()
+  const game = new Auction(host, new Rng(seed), now())
+
+  // How to play. The rule a child cannot deduce from the screen is the *one over*
+  // rule and the offer that bounds it, so both get a heading, and the failure is
+  // stated plainly: nothing is taken away, there is just more to sell.
+  const guide = createInstructions(el, {
+    title: "THE GAVEL",
+    summary: [
+      "The bidders hold up sums, not prices. Work them out and find the biggest bid in the room.",
+      "Then bid ONE more than it, and the lot is yours for the smallest money in the room.",
+    ],
+    sections: [
+      {
+        heading: "Winning the lot",
+        lines: [
+          "Tap the tablet you think is the biggest bid. Tapping is free — tap another to change your mind.",
+          "Then tap the numbers to set your bid, and tap GAVEL.",
+          "Bid the same as the biggest, or less, and a rival takes the lot instead.",
+        ],
+      },
+      {
+        heading: "Selling it on",
+        lines: [
+          "The blue plate is what the broker will pay you for the lot.",
+          "Your coins are the broker's price take away what you paid.",
+          "Win it at EXACTLY one over the biggest bid and the guild pays you double. That is a keen bid.",
+          "Two over earns less. Ten over earns almost nothing.",
+          "Bid MORE than the broker pays and nobody buys it — the lot just sits on your shelf.",
+        ],
+      },
+      {
+        heading: "When to walk away",
+        lines: [
+          "Sometimes the broker's price is not above the room at all. Then no bid can make money.",
+          "Tap FOLD. Spotting one of those is worth a coin on its own.",
+          "FOLD is always safe. It never costs you anything.",
+        ],
+      },
+      {
+        heading: "There is no clock",
+        lines: [
+          "Nothing is timed. Take as long as you like on every room.",
+          "If a lot does not sell it comes round again, and the broker adds one more to the pile.",
+          "That is the only cost of being wrong. No lives, no buzzer, nothing taken away.",
+        ],
+      },
+    ],
+    reducedMotion: reduced,
+    // Behind the scrim the reveal keeps playing and the lot keeps being timed, and
+    // a child reading the rules is being billed for it.
+    //
+    // The manual only lifts a pause it put on itself. The host can already have a
+    // sheet over the frame — and this game raises one itself at the end of every
+    // consignment — so a child who opens and closes the rules underneath it must
+    // not be handed back a running gallery.
+    onOpen: () => {
+      if (paused) return
+      heldForManual = true
+      raiseSheet()
+    },
+    onClose: () => {
+      if (!heldForManual) return
+      heldForManual = false
+      lowerSheet()
+    },
+  })
+
+  let running = true
+  let paused = false
+  /** True only while the pause in force is the one the manual raised. */
+  let heldForManual = false
+  let last = 0
+  let frame = 0
+
+  function now(): number {
+    return typeof performance === "object" ? performance.now() : Date.now()
+  }
+
+  function raiseSheet(): void {
+    if (paused) return
+    paused = true
+    game.pause(now())
+  }
+
+  function lowerSheet(): void {
+    if (!paused) return
+    paused = false
+    game.resume(now())
+    // The next frame computes its delta from `last`, which was set before the sheet
+    // went up. Forget it, or the first frame back is a whole sheet's worth of reveal
+    // in one step.
+    last = 0
+  }
+
+  const apply = (events: readonly AuctionEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "lot": {
+          scene.raiseRoom(event.room.tablets.length)
+          break
+        }
+        case "mark": {
+          audio.mark()
+          host.haptic("light")
+          break
+        }
+        case "unmark": {
+          audio.release()
+          break
+        }
+        case "digit": {
+          audio.tick()
+          break
+        }
+        case "settled": {
+          scene.settle()
+          audio.hammer()
+          if (event.settled.coins > 0) {
+            audio.coins(event.settled.coins)
+            host.haptic("success")
+          } else if (event.settled.outcome === "outbid" || event.settled.outcome === "unsold") {
+            // Not a scold. The cost is the lots, and the lots are what the child
+            // sees arriving on the strip.
+            audio.dull()
+            host.haptic("medium")
+          } else {
+            host.haptic("light")
+          }
+          break
+        }
+        case "consignment": {
+          if (event.sold > 0) audio.cleared()
+          break
+        }
+        case "stalled": {
+          console.error("[gavel] stalled: nothing the gallery can call")
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  const view = (): View => ({
+    lot: game.lot,
+    room: game.room,
+    marked: game.marked,
+    digits: game.digits,
+    phase: game.phase,
+    settled: game.settled,
+    coins: game.coins,
+    storeroom: game.storeroom,
+    remaining: game.remaining,
+    consignment: game.consignmentNumber,
+    armed: game.armed,
+    paused,
+    stalled: game.stalled,
+  })
+
+  const tick = (t: number): void => {
+    if (!running) return
+    frame = requestAnimationFrame(tick)
+    const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, t - last)
+    last = t
+
+    // Behind a sheet the gallery holds its shape. The frame is still drawn — a
+    // frozen pack under a translucent host sheet is what a paused game looks like —
+    // but nothing in it moves and nothing in it is decided.
+    if (!paused) {
+      apply(game.advance(dt, now()))
+      scene.advance(dt, view())
+    }
+    scene.draw(view())
+  }
+
+  const press = (event: PointerEvent): void => {
+    event.preventDefault()
+    // A press that lands while the host's sheet is up is the sheet's, not ours.
+    if (paused) return
+    audio.resume()
+    const rect = canvas.getBoundingClientRect()
+    const x = event.clientX - rect.left
+    const y = event.clientY - rect.top
+
+    // A tap anywhere during the reveal moves on. It is not a wait for an answer —
+    // the answer has already been given — so ending it early costs nothing.
+    if (game.phase === "settled") {
+      apply(game.nudge())
+      return
+    }
+
+    const key = scene.keyAt(x, y)
+    if (key) {
+      scene.press(key.id)
+      if (key.digit !== null) {
+        apply(game.pressDigit(key.digit))
+        return
+      }
+      if (key.id === "back") {
+        apply(game.backspace())
+        return
+      }
+      if (key.id === "fold") {
+        apply(game.fold())
+        return
+      }
+      apply(game.hammer(now()))
+      return
+    }
+
+    const tablet = scene.tabletAt(x, y)
+    if (tablet !== null) apply(game.tapTablet(tablet))
+  }
+
+  const key = (event: KeyboardEvent): void => {
+    if (event.repeat || paused) return
+    audio.resume()
+    if (game.phase === "settled") {
+      apply(game.nudge())
+      return
+    }
+    if (/^[0-9]$/.test(event.key)) {
+      apply(game.pressDigit(Number(event.key)))
+      return
+    }
+    if (event.key === "Backspace") {
+      event.preventDefault()
+      apply(game.backspace())
+      return
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      apply(game.hammer(now()))
+      return
+    }
+    if (event.key === "f" || event.key === "F") {
+      apply(game.fold())
+      return
+    }
+    // Left and right walk the mark along the gallery, so the whole game is
+    // playable from a keyboard in the dev harness.
+    const room = game.room
+    if (!room) return
+    if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+      const n = room.tablets.length
+      const at = game.marked
+      const step = event.key === "ArrowRight" ? 1 : n - 1
+      apply(game.tapTablet(at === null ? 0 : (at + step) % n))
+    }
+  }
+
+  const resize = (): void => {
+    scene.resize()
+  }
+
+  canvas.addEventListener("pointerdown", press)
+  globalThis.addEventListener("keydown", key)
+  globalThis.addEventListener("resize", resize)
+
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          scene.resize()
+        })
+      : null
+  observer?.observe(el)
+
+  scene.raiseRoom(MIN_TABLETS)
+  apply(game.begin(now()))
+  frame = requestAnimationFrame(tick)
+
+  return {
+    pause(): void {
+      raiseSheet()
+    },
+    resume(): void {
+      lowerSheet()
+    },
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frame)
+      canvas.removeEventListener("pointerdown", press)
+      globalThis.removeEventListener("keydown", key)
+      globalThis.removeEventListener("resize", resize)
+      observer?.disconnect()
+      audio.dispose()
+      guide.destroy()
+      canvas.remove()
+    },
+  }
+}

--- a/dynawalla/games/gavel/src/pack.ts
+++ b/dynawalla/games/gavel/src/pack.ts
@@ -1,0 +1,64 @@
+// THE GAVEL, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the stub,
+// because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the room, the paddle, the hammer and the
+// consignment are untouched.
+//
+// **`items.reveal` is declared and is not optional.** A tablet is a rival's *bid*.
+// Without the canonical value there is no bid: the room would be four expressions
+// with no highest, which is not a question, and the child's `bid − 1` would be
+// judged against nothing. A pack without the grant mounts, warms, and calls a
+// gallery with no prices in it.
+//
+// **Why `items.skip` matters here more than anywhere.** A round puts three to five
+// questions up and the child answers exactly one — the tablet they marked. The rest
+// were read, compared and left. Reporting those as `{ correct: false, answered: ""
+// }` would file four misses a round: the empty string does not parse, the learner
+// model takes a wrong attempt each time, and the ladder walks *down* underneath a
+// child who is doing fine. They are skipped, which is the third ending and the
+// only one that is both honest and closed.
+//
+// Nothing about the *money* is reported. The profit is the game's own arithmetic —
+// a thing the child performs with a gesture rather than a question anybody asked —
+// and the host owns the mathematics.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("gavel: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "arith" })
+  // Stocked before the first frame. A room is built from three to five questions at
+  // once, so an empty pool on launch is not a dull moment — it is a gallery with no
+  // bidders in it, in front of the child, exactly once.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+
+  // A transition can put a sheet over the frame, and the SDK documents that the pack
+  // keeps running underneath it. THE GAVEL calls `transition` at the end of every
+  // consignment, so this is routine rather than hypothetical — and unguarded it is
+  // the worst bug this game could have: a touch landing behind the sheet drops the
+  // hammer, reports a bid on a room the child never saw, and adds two lots for it.
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[gavel] could not start", error)
+  renderNoHost(root, "THE GAVEL")
+})

--- a/dynawalla/games/gavel/src/render/layout.ts
+++ b/dynawalla/games/gavel/src/render/layout.ts
@@ -1,0 +1,364 @@
+// Where everything sits, as numbers, with no canvas in the file.
+//
+// Split out from the renderer for one reason: every claim this game makes about
+// being legible and reachable on a phone is a claim about these numbers, and a
+// claim in a children's product should be assertable at every viewport rather
+// than eyeballed on one device. `test/layout.test.ts` runs the whole thing at
+// 320×420 through iPad landscape and checks four things:
+//
+//   1. Nothing a child must read or touch overlaps the host's two 44px corners.
+//      The exit chevron and the how-to-play control live in the HOST document,
+//      above this pack's iframe, so no z-index can rescue a collision — a pack
+//      lays out clear of them or it loses the pixels.
+//   2. Every key is at least 44px on its short side, at every viewport. That is
+//      the platform minimum and about the smallest square a seven-year-old hits
+//      on a moving bus.
+//   3. A tablet's prompt never prints below `MIN_NUMERAL_PX`. COLOSSUS's own
+//      pacing entry closes on the legibility spiral and SERPENT prints numerals
+//      at four to seven CSS pixels on a phone; the whole game is reading numbers.
+//   4. Nothing critical is drawn outside the safe rectangle.
+//
+// The insets come from the HOST, through `game-chrome`. A pack cannot read
+// `env(safe-area-inset-*)` — it is a cross-origin child and resolves all four to
+// zero — and twenty of the twenty-seven shipped games drew their HUDs under the
+// notch believing otherwise.
+
+import { safeInsets, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import { HOST_CONTROL, HOST_MARGIN, HOST_PROGRESS_H } from "../../../../packs/shared/game-chrome/index.ts"
+import {
+  DIGIT_ADVANCE_EM,
+  MIN_NUMERAL_PX,
+  MIN_TABLET_W,
+  PROMPT_MAX_CHARS,
+  TABLET_PAD,
+} from "../game/ladder.ts"
+
+export type Rect = { x: number; y: number; w: number; h: number }
+
+export type KeyId =
+  | "d0"
+  | "d1"
+  | "d2"
+  | "d3"
+  | "d4"
+  | "d5"
+  | "d6"
+  | "d7"
+  | "d8"
+  | "d9"
+  | "back"
+  | "fold"
+  | "gavel"
+
+export type Key = { id: KeyId; rect: Rect; label: string; digit: number | null }
+
+export type Layout = {
+  readonly w: number
+  readonly h: number
+  readonly insets: Insets
+  /** The strongbox plaque. Always clear of both host corners. */
+  readonly coins: Rect
+  /** The consignment strip: one pip per lot still owed. */
+  readonly strip: Rect
+  /** The block: the lot on it, and the broker's offer beside it. */
+  readonly block: Rect
+  readonly offer: Rect
+  readonly gallery: Rect
+  readonly tablets: readonly Rect[]
+  readonly paddle: Rect
+  readonly keys: readonly Key[]
+  /** True when the plaque had to go below the host's corner band to clear it. */
+  readonly plaqueBelowChrome: boolean
+}
+
+const PAD = 10
+const GAP = 8
+
+const MIN_COINS_H = 22
+const MIN_STRIP_H = 10
+const MIN_BLOCK_H = 44
+const MIN_ROW_H = 42
+const MIN_PADDLE_H = 46
+export const MIN_KEY = 44
+
+const MAX_COINS_H = 30
+const MAX_BLOCK_H = 116
+const MAX_ROW_H = 84
+const MAX_PADDLE_H = 68
+const MAX_KEY_H = 64
+
+/** The narrowest gap between the host's corners a centred plaque will sit in. */
+const PLAQUE_MIN_W = 120
+
+/**
+ * The widest the gallery, the block and the keypad are ever drawn.
+ *
+ * Without it, three tablets across a desktop are 455px billboards carrying `88 + 61`,
+ * and the keypad is a metre of stone. A bazaar auction is a small room; the frame gets
+ * wider, the room does not.
+ */
+const MAX_CONTENT_W = 780
+
+/** Rows the keypad takes: two of five digits plus the controls, or one of ten. */
+const KEY_ROWS_NARROW = 3
+const KEY_ROWS_WIDE = 2
+
+/** Width at which all ten digits fit across in one row at the 44px minimum. */
+const WIDE_KEYPAD_W = 10 * MIN_KEY + 9 * GAP
+
+const clamp = (v: number, lo: number, hi: number): number => (v < lo ? lo : v > hi ? hi : v)
+
+/**
+ * The font size a prompt prints at inside a tablet of width `w`.
+ *
+ * Sized to the prompt that is actually there, so `12 + 5` is drawn large and
+ * `5,001 − 2,798` is drawn small — but never smaller than `MIN_NUMERAL_PX`,
+ * because below that a child is guessing for a reason that has nothing to do with
+ * arithmetic. A prompt that cannot be drawn at the floor is refused upstream, by
+ * `tabletValue`, and its whole rung is capped: see `Auction.capBelow`.
+ */
+export function promptPx(text: string, tabletW: number, tabletH: number): number {
+  const chars = Math.max(1, text.trim().length)
+  const byWidth = (tabletW - 2 * TABLET_PAD) / (chars * DIGIT_ADVANCE_EM)
+  const byHeight = tabletH * 0.42
+  return clamp(Math.floor(Math.min(byWidth, byHeight)), MIN_NUMERAL_PX, 30)
+}
+
+/** How many tablets fit across `w` before the gallery has to wrap. */
+export function columnsFor(w: number, count: number): number {
+  const fit = Math.floor((w + GAP) / (MIN_TABLET_W + GAP))
+  return clamp(fit, 1, Math.max(1, count))
+}
+
+export function layout(
+  w: number,
+  h: number,
+  tabletCount: number,
+  insets: Insets = safeInsets(),
+): Layout {
+  const safe = safeRect(w, h, insets)
+  const inner = Math.max(80, Math.min(safe.w - 2 * PAD, MAX_CONTENT_W))
+  const x0 = safe.x + (safe.w - inner) / 2
+  const top = safe.y + HOST_PROGRESS_H
+
+  // **The band the host's two controls sit in is not reserved, it is used.** The first
+  // version of `hostChrome.ts` reserved the whole 67px top strip and broke SKY LEDGER's
+  // own layout invariants outright; taking a twelfth of a small screen to hold two
+  // buttons is the wrong trade. So the strongbox plaque fills the band *between* the
+  // two corners — the one thing in this game that is a single short line of large
+  // numerals, which is exactly what fits there — and everything full-width starts
+  // below it.
+  //
+  // When the corners are too close together for a plaque, which a phone in landscape
+  // with side insets can be, it drops below the band at full width instead. Both
+  // branches ship and `test/layout.test.ts` asserts both.
+  const betweenCorners =
+    w - 2 * Math.max(insets.left, insets.right) - 2 * (HOST_MARGIN + HOST_CONTROL) - 2 * GAP
+  const plaqueBelowChrome = betweenCorners < PLAQUE_MIN_W
+  const bandBottom = insets.top + HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + HOST_MARGIN
+  const coinsTop = plaqueBelowChrome ? bandBottom : top + HOST_MARGIN
+
+  const count = Math.max(1, Math.floor(tabletCount))
+  const cols = columnsFor(inner, count)
+  const rows = Math.ceil(count / cols)
+
+  // A wide frame puts the ten digits in one row instead of two, which is a whole 52px
+  // of height back on a phone in landscape. It is not only a fit: `1 2 3 4 5 6 7 8 9 0`
+  // in one line is the order a child counts in, and the two-row form only exists
+  // because five keys is the most that fits across a 320px phone at 44px each.
+  const keyCols = inner >= WIDE_KEYPAD_W ? 10 : 5
+  const keyRows = keyCols === 10 ? KEY_ROWS_WIDE : KEY_ROWS_NARROW
+
+  // Everything below the plaque, at its minimum. What is left over is spent in
+  // fixed proportions, which is what keeps a tall iPad from drawing a phone layout
+  // with a lake of empty stone under it.
+  const coinsH0 = plaqueBelowChrome ? MIN_COINS_H : HOST_CONTROL
+  const contentTop = plaqueBelowChrome ? bandBottom + coinsH0 + GAP : bandBottom
+  const minBelow =
+    MIN_STRIP_H +
+    GAP +
+    MIN_BLOCK_H +
+    GAP +
+    (rows * MIN_ROW_H + (rows - 1) * GAP) +
+    GAP +
+    MIN_PADDLE_H +
+    GAP +
+    (keyRows * MIN_KEY + (keyRows - 1) * GAP)
+  const avail = Math.max(0, safe.y + safe.h - PAD - contentTop)
+  const slack = Math.max(0, avail - minBelow)
+
+  const coinsH = plaqueBelowChrome
+    ? clamp(coinsH0 + slack * 0.02, MIN_COINS_H, MAX_COINS_H)
+    : coinsH0
+  const stripH = clamp(MIN_STRIP_H + slack * 0.03, MIN_STRIP_H, 18)
+  const blockH = clamp(MIN_BLOCK_H + slack * 0.26, MIN_BLOCK_H, MAX_BLOCK_H)
+  const rowH = clamp(MIN_ROW_H + (slack * 0.34) / rows, MIN_ROW_H, MAX_ROW_H)
+  const paddleH = clamp(MIN_PADDLE_H + slack * 0.1, MIN_PADDLE_H, MAX_PADDLE_H)
+  const keyH = clamp(MIN_KEY + (slack * 0.25) / keyRows, MIN_KEY, MAX_KEY_H)
+
+  // A viewport too short for the minimums. The keys are the last thing to give —
+  // a 44px target is the one number in this file that is not a preference — so the
+  // squeeze comes out of the block and the gallery, and the game accepts drawing
+  // slightly past the bottom inset before it accepts an unhittable button.
+  const wanted =
+    stripH +
+    GAP +
+    blockH +
+    GAP +
+    (rows * rowH + (rows - 1) * GAP) +
+    GAP +
+    paddleH +
+    GAP +
+    (keyRows * keyH + (keyRows - 1) * GAP)
+  const over = Math.max(0, wanted - avail)
+  const blockFinal = Math.max(MIN_BLOCK_H * 0.7, blockH - over * 0.45)
+  const rowFinal = Math.max(MIN_ROW_H * 0.85, rowH - (over * 0.4) / rows)
+  const paddleFinal = Math.max(40, paddleH - over * 0.15)
+
+  const coinsW = plaqueBelowChrome ? Math.min(inner, 300) : Math.min(betweenCorners, 300)
+  const coins: Rect = {
+    x: Math.round(w / 2 - coinsW / 2),
+    y: coinsTop,
+    w: coinsW,
+    h: coinsH,
+  }
+
+  // Centred vertically in whatever is left. On an iPad the caps above stop the room
+  // growing to fill a tall frame, and top-aligning it then leaves a third of the screen
+  // as empty stone under the keypad.
+  const used =
+    stripH +
+    GAP +
+    blockFinal +
+    GAP +
+    (rows * rowFinal + (rows - 1) * GAP) +
+    GAP +
+    paddleFinal +
+    GAP +
+    (keyRows * keyH + (keyRows - 1) * GAP)
+  let y = contentTop + Math.max(0, (avail - used) / 2)
+  const strip: Rect = { x: x0, y, w: inner, h: stripH }
+  y += stripH + GAP
+
+  const block: Rect = { x: x0, y, w: inner, h: blockFinal }
+  // The offer is the second number the round turns on, so it gets its own plate on
+  // the right of the block rather than a line of small print under the lot's name.
+  const offerW = Math.min(Math.max(112, inner * 0.38), inner - 90)
+  const offer: Rect = {
+    x: block.x + block.w - offerW,
+    y: block.y,
+    w: offerW,
+    h: block.h,
+  }
+  y += blockFinal + GAP
+
+  const galleryH = rows * rowFinal + (rows - 1) * GAP
+  const gallery: Rect = { x: x0, y, w: inner, h: galleryH }
+  const tablets: Rect[] = []
+  const tabletW = (inner - (cols - 1) * GAP) / cols
+  for (let i = 0; i < count; i++) {
+    const row = Math.floor(i / cols)
+    const col = i % cols
+    // The last row is centred, so four tablets on two columns do not leave a hole
+    // in a corner that reads as a missing bidder.
+    const inRow = Math.min(cols, count - row * cols)
+    const rowW = inRow * tabletW + (inRow - 1) * GAP
+    const rowX = x0 + (inner - rowW) / 2
+    tablets.push({
+      x: rowX + col * (tabletW + GAP),
+      y: gallery.y + row * (rowFinal + GAP),
+      w: tabletW,
+      h: rowFinal,
+    })
+  }
+  y += galleryH + GAP
+
+  const paddle: Rect = { x: x0, y, w: inner, h: paddleFinal }
+  y += paddleFinal + GAP
+
+  // The digits, in counting order, then the controls on a row of their own. `⌫` is one
+  // cell; FOLD and GAVEL split the rest, because they are the two decisions and a
+  // decision should not be the same size as a digit.
+  const keys: Key[] = []
+  const keyW = (inner - (keyCols - 1) * GAP) / keyCols
+  const span = (cells: number): number => cells * keyW + (cells - 1) * GAP
+  const DIGITS: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+  for (let i = 0; i < DIGITS.length; i++) {
+    const digit = DIGITS[i] ?? 0
+    keys.push({
+      id: `d${String(digit)}` as KeyId,
+      digit,
+      label: String(digit),
+      rect: {
+        x: x0 + (i % keyCols) * (keyW + GAP),
+        y: y + Math.floor(i / keyCols) * (keyH + GAP),
+        w: keyW,
+        h: keyH,
+      },
+    })
+  }
+  const controlY = y + (keyRows - 1) * (keyH + GAP)
+  const backCells = keyCols === 10 ? 2 : 1
+  const halfCells = (keyCols - backCells) / 2
+  keys.push({
+    id: "back",
+    digit: null,
+    label: "⌫",
+    rect: { x: x0, y: controlY, w: span(backCells), h: keyH },
+  })
+  keys.push({
+    id: "fold",
+    digit: null,
+    label: "FOLD",
+    rect: { x: x0 + span(backCells) + GAP, y: controlY, w: span(halfCells), h: keyH },
+  })
+  keys.push({
+    id: "gavel",
+    digit: null,
+    label: "GAVEL",
+    rect: {
+      x: x0 + span(backCells) + GAP + span(halfCells) + GAP,
+      y: controlY,
+      w: span(halfCells),
+      h: keyH,
+    },
+  })
+
+  return {
+    w,
+    h,
+    insets,
+    coins,
+    strip,
+    block,
+    offer,
+    gallery,
+    tablets,
+    paddle,
+    keys,
+    plaqueBelowChrome,
+  }
+}
+
+const inside = (r: Rect, x: number, y: number): boolean =>
+  x >= r.x && x <= r.x + r.w && y >= r.y && y <= r.y + r.h
+
+export function hitKey(l: Layout, x: number, y: number): Key | null {
+  for (const key of l.keys) if (inside(key.rect, x, y)) return key
+  return null
+}
+
+export function hitTablet(l: Layout, x: number, y: number): number | null {
+  for (let i = 0; i < l.tablets.length; i++) {
+    const rect = l.tablets[i]
+    if (rect && inside(rect, x, y)) return i
+  }
+  return null
+}
+
+/** Everything a child must read or touch, for the host-chrome assertion. */
+export function criticalRects(l: Layout): readonly Rect[] {
+  return [l.coins, l.strip, l.block, l.offer, ...l.tablets, l.paddle, ...l.keys.map((k) => k.rect)]
+}
+
+export { PROMPT_MAX_CHARS, MIN_NUMERAL_PX, MIN_TABLET_W }

--- a/dynawalla/games/gavel/src/render/palette.ts
+++ b/dynawalla/games/gavel/src/render/palette.ts
@@ -1,0 +1,37 @@
+// The material palette. Brass, lapis, carved stone, cold celestial light — and
+// nothing that is a lighting effect standing in for a material.
+//
+// `EXPERIENCE_DESIGN.md` keeps a hostile reference board for this file's benefit:
+// no gradient soup, no glassmorphism, no neon, no confetti. The auction gallery is
+// a stone room with brass in it.
+
+/** Night behind the arcade. */
+export const NIGHT = "#0b0d18"
+/** The gallery wall. */
+export const WALL = "#141930"
+/** Carved stone: the block, the plinth, the keypad plates. */
+export const STONE = "#242a45"
+export const STONE_LIT = "#2f3757"
+/** Incised line work. Structure, not wallpaper. */
+export const INCISE = "#3a446c"
+
+/** Brass: everything that is a mechanism or a price. */
+export const BRASS = "#c79a45"
+export const BRASS_LIT = "#f0cd7d"
+export const BRASS_DIM = "#8d6c2e"
+
+/** Lapis: the broker's offer, and only the offer. One colour, one meaning. */
+export const LAPIS = "#3f6ed6"
+export const LAPIS_LIT = "#7fa6ff"
+
+/** Cold celestial light: a settled sale. */
+export const COLD = "#9fe8e0"
+/** Copper oxide: a lot that did not sell. Never red, and never a buzzer. */
+export const OXIDE = "#b5714a"
+
+/** Text. */
+export const INK = "#f2eee4"
+export const INK_DIM = "#a6a396"
+
+/** The mark a child drops on the tablet they mean to beat. */
+export const MARK = BRASS_LIT

--- a/dynawalla/games/gavel/src/render/scene.ts
+++ b/dynawalla/games/gavel/src/render/scene.ts
@@ -1,0 +1,502 @@
+// The auction gallery, drawn. Canvas 2D, no assets, no images to decode.
+//
+// Everything here is material: carved stone plates, brass rims, incised line
+// work, one lapis plate for the broker's offer. There is no gradient standing in
+// for a surface and there is no particle vocabulary — a lot that does not sell is
+// copper oxide and a settled sale is cold celestial light, and neither of them is
+// red and neither of them flashes.
+//
+// Reduced motion is a branch and not a degradation: the tablets cross-fade in
+// place instead of rising, and nothing else changes.
+
+import { easeOutCubic, unit } from "../core/feel.ts"
+import type { Settled } from "../game/auction.ts"
+import type { Room } from "../game/lot.ts"
+import { hitKey, hitTablet, layout, promptPx, type Key, type Layout, type Rect } from "./layout.ts"
+import {
+  BRASS,
+  BRASS_DIM,
+  BRASS_LIT,
+  COLD,
+  INCISE,
+  INK,
+  INK_DIM,
+  LAPIS,
+  LAPIS_LIT,
+  NIGHT,
+  OXIDE,
+  STONE,
+  STONE_LIT,
+  WALL,
+} from "./palette.ts"
+
+export type View = {
+  lot: string
+  room: Room | null
+  marked: number | null
+  digits: string
+  phase: "bidding" | "settled"
+  settled: Settled | null
+  coins: number
+  storeroom: number
+  remaining: number
+  consignment: number
+  armed: boolean
+  paused: boolean
+  stalled: boolean
+}
+
+const FACE = "'SF Mono','Menlo','DejaVu Sans Mono',ui-monospace,monospace"
+const TITLE = "system-ui,-apple-system,'Segoe UI',sans-serif"
+
+/** How long the room takes to come up, and the settled values to appear. */
+const RAISE_MS = 380
+const REVEAL_MS = 260
+
+export class Scene {
+  private readonly canvas: HTMLCanvasElement
+  private readonly ctx: CanvasRenderingContext2D
+  private readonly reduced: boolean
+
+  private w = 320
+  private h = 480
+  private lay: Layout
+  private lastCount = 3
+
+  /** 0..1, how far the room is up. */
+  private raise = 1
+  /** 0..1, how far the settled values are in. */
+  private reveal = 0
+  private shownCoins = 0
+  private pressed: string | null = null
+  private pressAge = 0
+
+  constructor(canvas: HTMLCanvasElement, reduced: boolean) {
+    this.canvas = canvas
+    const ctx = canvas.getContext("2d")
+    if (!ctx) throw new Error("gavel: no 2d context")
+    this.ctx = ctx
+    this.reduced = reduced
+    this.lay = layout(this.w, this.h, this.lastCount)
+    this.resize()
+  }
+
+  get layout(): Layout {
+    return this.lay
+  }
+
+  resize(): void {
+    const dpr = Math.min(3, Math.max(1, globalThis.devicePixelRatio || 1))
+    const rect = this.canvas.getBoundingClientRect()
+    this.w = Math.max(240, Math.round(rect.width || this.w))
+    this.h = Math.max(320, Math.round(rect.height || this.h))
+    this.canvas.width = Math.round(this.w * dpr)
+    this.canvas.height = Math.round(this.h * dpr)
+    this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    this.lay = layout(this.w, this.h, this.lastCount)
+  }
+
+  /** A new room came up. */
+  raiseRoom(count: number): void {
+    this.lastCount = count
+    this.lay = layout(this.w, this.h, count)
+    this.raise = this.reduced ? 0.001 : 0
+    this.reveal = 0
+  }
+
+  /** The hammer fell. */
+  settle(): void {
+    this.reveal = 0
+  }
+
+  press(id: string): void {
+    this.pressed = id
+    this.pressAge = 0
+  }
+
+  advance(dt: number, view: View): void {
+    this.raise = unit(this.raise + dt / RAISE_MS)
+    if (view.phase === "settled") this.reveal = unit(this.reveal + dt / REVEAL_MS)
+    // The coin counter walks rather than jumping, because the walk is the reward.
+    const gap = view.coins - this.shownCoins
+    this.shownCoins =
+      Math.abs(gap) < 0.51 ? view.coins : this.shownCoins + Math.sign(gap) * Math.max(1, dt / 34)
+    if (this.pressed !== null) {
+      this.pressAge += dt
+      if (this.pressAge > 140) this.pressed = null
+    }
+  }
+
+  keyAt(x: number, y: number): Key | null {
+    return hitKey(this.lay, x, y)
+  }
+
+  tabletAt(x: number, y: number): number | null {
+    return hitTablet(this.lay, x, y)
+  }
+
+  draw(view: View): void {
+    const g = this.ctx
+    const l = this.lay
+    g.save()
+    this.background()
+
+    if (view.stalled) {
+      this.centred("THE GALLERY IS DARK", INK, 20, l.gallery.y + l.gallery.h / 2)
+      this.centred("no lots the auctioneer can call", INK_DIM, 13, l.gallery.y + l.gallery.h / 2 + 26)
+      g.restore()
+      return
+    }
+
+    this.plaque(view)
+    this.strip(view)
+    this.block(view)
+    this.gallery(view)
+    this.paddle(view)
+    this.keys(view)
+
+    if (view.paused) {
+      g.fillStyle = "rgba(6,8,18,0.62)"
+      g.fillRect(0, 0, this.w, this.h)
+    }
+    g.restore()
+  }
+
+  // ── pieces ────────────────────────────────────────────────────────────────
+
+  private background(): void {
+    const g = this.ctx
+    const l = this.lay
+    g.fillStyle = NIGHT
+    g.fillRect(0, 0, this.w, this.h)
+
+    // The back wall of the gallery, and the arcade standing in front of it: pointed
+    // arches, incised, springing from the floor. Structure rather than wallpaper — it is
+    // the room the auction is happening in, and the plates below sit on top of it.
+    const top = Math.max(0, l.strip.y - 14)
+    g.fillStyle = WALL
+    g.fillRect(0, top, this.w, this.h - top)
+    g.strokeStyle = INCISE
+    g.lineWidth = 1
+    const span = Math.max(84, Math.min(190, this.w / 5))
+    const spring = top + Math.min(120, (this.h - top) * 0.34)
+    for (let x = -span / 2; x < this.w + span; x += span) {
+      g.beginPath()
+      g.moveTo(x, this.h)
+      g.lineTo(x, spring)
+      g.quadraticCurveTo(x + span / 2, top + 2, x + span, spring)
+      g.lineTo(x + span, this.h)
+      g.stroke()
+    }
+  }
+
+  /**
+   * A mark for the lot on the block: an eight-point girih rosette, turned by the lot's
+   * own name so no two objects carry the same one.
+   *
+   * Cheap on purpose — sixteen line segments and two circles. The alternative was an
+   * illustration per object, and sixteen illustrations is an art budget rather than a
+   * first cut.
+   */
+  private sigil(cx: number, cy: number, r: number, name: string): void {
+    const g = this.ctx
+    if (r < 9) return
+    let hash = 0
+    for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) & 0xffff
+    const points = 6 + (hash % 4)
+    const turn = ((hash >> 4) % 90) * (Math.PI / 180)
+    g.strokeStyle = BRASS_DIM
+    g.lineWidth = 1
+    g.beginPath()
+    for (let i = 0; i < points * 2; i++) {
+      const a = turn + (i * Math.PI) / points
+      const rad = i % 2 === 0 ? r : r * 0.52
+      const x = cx + Math.cos(a) * rad
+      const y = cy + Math.sin(a) * rad
+      if (i === 0) g.moveTo(x, y)
+      else g.lineTo(x, y)
+    }
+    g.closePath()
+    g.stroke()
+    g.beginPath()
+    g.arc(cx, cy, r * 0.3, 0, Math.PI * 2)
+    g.stroke()
+  }
+
+  /** The strongbox: how many coins are in it. The only score in the game. */
+  private plaque(view: View): void {
+    const g = this.ctx
+    const r = this.lay.coins
+    this.plate(r, STONE, BRASS_DIM)
+    const size = Math.min(20, r.h - 8)
+    g.textBaseline = "middle"
+    g.textAlign = "left"
+    g.font = `600 ${String(Math.round(size * 0.62))}px ${TITLE}`
+    g.fillStyle = INK_DIM
+    g.fillText("STRONGBOX", r.x + 12, r.y + r.h / 2)
+    g.textAlign = "right"
+    g.font = `700 ${String(Math.round(size))}px ${FACE}`
+    g.fillStyle = BRASS_LIT
+    g.fillText(`${String(Math.round(this.shownCoins))} ◉`, r.x + r.w - 12, r.y + r.h / 2)
+    void view
+  }
+
+  /** One pip per lot still owed to the broker. A wrong bid adds pips. */
+  private strip(view: View): void {
+    const g = this.ctx
+    const r = this.lay.strip
+    const n = Math.max(1, view.remaining)
+    const pip = Math.min(12, (r.w - 90) / Math.max(6, n) - 2)
+    g.textBaseline = "middle"
+    g.textAlign = "left"
+    g.font = `600 9px ${TITLE}`
+    g.fillStyle = INK_DIM
+    g.fillText(`CONSIGNMENT ${String(view.consignment)}`, r.x, r.y + r.h / 2)
+    let x = r.x + 96
+    for (let i = 0; i < n; i++) {
+      g.fillStyle = i === 0 ? BRASS_LIT : BRASS_DIM
+      g.beginPath()
+      g.moveTo(x + pip / 2, r.y + 1)
+      g.lineTo(x + pip, r.y + r.h / 2)
+      g.lineTo(x + pip / 2, r.y + r.h - 1)
+      g.lineTo(x, r.y + r.h / 2)
+      g.closePath()
+      g.fill()
+      x += pip + 3
+    }
+    if (view.storeroom > 0) {
+      g.textAlign = "right"
+      g.fillStyle = OXIDE
+      g.fillText(`${String(view.storeroom)} UNSOLD`, r.x + r.w, r.y + r.h / 2)
+    }
+  }
+
+  /** The lot on the block, and the offer plate beside it. */
+  private block(view: View): void {
+    const g = this.ctx
+    const r = this.lay.block
+    const o = this.lay.offer
+    const left: Rect = { x: r.x, y: r.y, w: Math.max(60, o.x - r.x - 8), h: r.h }
+    this.plate(left, STONE_LIT, INCISE)
+
+    g.textBaseline = "middle"
+    g.textAlign = "left"
+    const nameSize = Math.min(15, Math.max(11, left.h * 0.24))
+    g.font = `700 ${String(Math.round(nameSize))}px ${TITLE}`
+    g.fillStyle = BRASS
+    const sigilR = Math.min(left.h * 0.34, left.w * 0.16)
+    this.wrapped(
+      view.lot,
+      left.x + 12,
+      left.y + left.h * 0.42,
+      left.w - 32 - sigilR * 2,
+      nameSize + 3,
+    )
+    this.sigil(left.x + left.w - 14 - sigilR, left.y + left.h / 2, sigilR, view.lot)
+
+    const settled = view.phase === "settled" ? view.settled : null
+    g.font = `600 11px ${TITLE}`
+    g.fillStyle = settled ? this.tint(settled) : INK_DIM
+    g.fillText(settled ? this.verdict(settled) : "ON THE BLOCK", left.x + 12, left.y + left.h - 14)
+
+    // The offer. Lapis, and lapis is used for nothing else in the game.
+    this.plate(o, LAPIS, LAPIS_LIT)
+    g.textAlign = "center"
+    g.font = `600 10px ${TITLE}`
+    g.fillStyle = "rgba(230,240,255,0.75)"
+    g.fillText("BROKER PAYS", o.x + o.w / 2, o.y + 15)
+    const offerSize = Math.min(34, Math.max(18, o.h * 0.46))
+    g.font = `700 ${String(Math.round(offerSize))}px ${FACE}`
+    g.fillStyle = "#f4f8ff"
+    g.fillText(
+      view.room ? String(view.room.offer) : "—",
+      o.x + o.w / 2,
+      o.y + o.h / 2 + offerSize * 0.22,
+    )
+  }
+
+  private gallery(view: View): void {
+    const g = this.ctx
+    const room = view.room
+    if (!room) return
+    const rise = this.reduced ? 1 : easeOutCubic(this.raise)
+    for (let i = 0; i < this.lay.tablets.length; i++) {
+      const rect = this.lay.tablets[i]
+      const tablet = room.tablets[i]
+      if (!rect || !tablet) continue
+      const lift = this.reduced ? 0 : (1 - rise) * 18
+      const box: Rect = { x: rect.x, y: rect.y + lift, w: rect.w, h: rect.h }
+      const marked = view.marked === i
+      const top = view.phase === "settled" && tablet.value === room.highest
+
+      g.globalAlpha = this.reduced ? rise : 1
+      this.plate(box, marked ? STONE_LIT : STONE, marked ? BRASS_LIT : INCISE, marked ? 2 : 1)
+
+      // The prompt. Never the total — working it out is the game.
+      const size = promptPx(tablet.prompt, box.w, box.h)
+      g.textAlign = "center"
+      g.textBaseline = "middle"
+      g.font = `600 ${String(size)}px ${FACE}`
+      g.fillStyle = marked ? INK : "#dcd8cc"
+      const promptY = view.phase === "settled" ? box.y + box.h * 0.36 : box.y + box.h * 0.5
+      g.fillText(tablet.prompt, box.x + box.w / 2, promptY)
+
+      if (view.phase === "settled") {
+        g.globalAlpha = this.reduced ? rise * this.reveal : this.reveal
+        g.font = `700 ${String(Math.round(size * 1.05))}px ${FACE}`
+        g.fillStyle = top ? COLD : BRASS
+        g.fillText(String(tablet.value), box.x + box.w / 2, box.y + box.h * 0.74)
+        if (top) {
+          g.strokeStyle = COLD
+          g.lineWidth = 2
+          this.round(box.x + 1, box.y + 1, box.w - 2, box.h - 2, 7)
+          g.stroke()
+        }
+        g.globalAlpha = 1
+      }
+
+      if (marked) {
+        // The pin the child drops on the tablet they mean to beat.
+        g.fillStyle = BRASS_LIT
+        g.beginPath()
+        g.arc(box.x + box.w - 11, box.y + 11, 4, 0, Math.PI * 2)
+        g.fill()
+      }
+      g.globalAlpha = 1
+    }
+  }
+
+  /** The paddle: what you are about to bid, and what you are beating. */
+  private paddle(view: View): void {
+    const g = this.ctx
+    const r = this.lay.paddle
+    this.plate(r, STONE_LIT, view.armed ? BRASS_LIT : INCISE, view.armed ? 2 : 1)
+    const marked = view.marked !== null ? (view.room?.tablets[view.marked] ?? null) : null
+
+    g.textBaseline = "middle"
+    g.textAlign = "left"
+    g.font = `600 10px ${TITLE}`
+    g.fillStyle = INK_DIM
+    g.fillText(
+      marked ? `BEATING  ${marked.prompt}` : "MARK A TABLET, THEN SET YOUR BID",
+      r.x + 12,
+      r.y + r.h / 2,
+    )
+
+    g.textAlign = "right"
+    const size = Math.min(30, Math.max(18, r.h * 0.6))
+    g.font = `700 ${String(Math.round(size))}px ${FACE}`
+    g.fillStyle = view.digits === "" ? BRASS_DIM : BRASS_LIT
+    g.fillText(view.digits === "" ? "···" : view.digits, r.x + r.w - 12, r.y + r.h / 2)
+  }
+
+  private keys(view: View): void {
+    const g = this.ctx
+    for (const key of this.lay.keys) {
+      const live =
+        key.id === "gavel" ? view.armed : key.id === "back" ? view.digits !== "" : !view.paused
+      const down = this.pressed === key.id
+      const fill = key.id === "gavel" && view.armed ? BRASS : down ? STONE_LIT : STONE
+      this.plate(key.rect, fill, down ? BRASS_LIT : INCISE)
+      g.textAlign = "center"
+      g.textBaseline = "middle"
+      const size =
+        key.digit === null
+          ? Math.min(15, Math.max(11, key.rect.h * 0.3))
+          : Math.min(24, Math.max(16, key.rect.h * 0.46))
+      g.font =
+        key.digit === null
+          ? `700 ${String(Math.round(size))}px ${TITLE}`
+          : `600 ${String(Math.round(size))}px ${FACE}`
+      g.fillStyle =
+        key.id === "gavel" && view.armed ? "#1a1405" : live ? INK : "rgba(242,238,228,0.35)"
+      g.fillText(key.label, key.rect.x + key.rect.w / 2, key.rect.y + key.rect.h / 2)
+    }
+  }
+
+  // ── primitives ────────────────────────────────────────────────────────────
+
+  private plate(r: Rect, fill: string, rim: string, width = 1): void {
+    const g = this.ctx
+    g.fillStyle = fill
+    this.round(r.x, r.y, r.w, r.h, 6)
+    g.fill()
+    g.strokeStyle = rim
+    g.lineWidth = width
+    this.round(r.x + width / 2, r.y + width / 2, r.w - width, r.h - width, 6)
+    g.stroke()
+  }
+
+  private round(x: number, y: number, w: number, h: number, r: number): void {
+    const g = this.ctx
+    const rad = Math.min(r, w / 2, h / 2)
+    g.beginPath()
+    g.moveTo(x + rad, y)
+    g.arcTo(x + w, y, x + w, y + h, rad)
+    g.arcTo(x + w, y + h, x, y + h, rad)
+    g.arcTo(x, y + h, x, y, rad)
+    g.arcTo(x, y, x + w, y, rad)
+    g.closePath()
+  }
+
+  private centred(text: string, colour: string, size: number, y: number): void {
+    const g = this.ctx
+    g.textAlign = "center"
+    g.textBaseline = "middle"
+    g.font = `600 ${String(size)}px ${TITLE}`
+    g.fillStyle = colour
+    g.fillText(text, this.w / 2, y)
+  }
+
+  /** Two lines at most: a lot's name is two or three words. */
+  private wrapped(text: string, x: number, y: number, w: number, lh: number): void {
+    const g = this.ctx
+    const words = text.split(" ")
+    let line = ""
+    let row = 0
+    for (const word of words) {
+      const next = line === "" ? word : `${line} ${word}`
+      if (g.measureText(next).width > w && line !== "") {
+        g.fillText(line, x, y + row * lh)
+        line = word
+        row++
+        if (row > 1) break
+      } else {
+        line = next
+      }
+    }
+    g.fillText(line, x, y + row * lh)
+  }
+
+  private verdict(s: Settled): string {
+    switch (s.outcome) {
+      case "sold":
+        return s.keen
+          ? `KEEN BID  ONE OVER THE ROOM  +${String(s.coins)} ◉`
+          : `SOLD ON  +${String(s.coins)} ◉`
+      case "even":
+        return "SOLD ON  NOTHING IN IT"
+      case "outbid":
+        return "OUTBID  THE LOT COMES ROUND AGAIN"
+      case "unsold":
+        return "PAID OVER THE OFFER  NOBODY WILL BUY IT"
+      case "folded":
+        return s.coins > 0 ? `FOLDED  +${String(s.coins)} ◉ FOR THE WARNING` : "FOLDED"
+    }
+  }
+
+  private tint(s: Settled): string {
+    switch (s.outcome) {
+      case "sold":
+        return COLD
+      case "even":
+        return INK_DIM
+      case "outbid":
+        return BRASS_DIM
+      case "unsold":
+        return OXIDE
+      case "folded":
+        return s.coins > 0 ? COLD : INK_DIM
+    }
+  }
+}

--- a/dynawalla/games/gavel/src/stubHost.ts
+++ b/dynawalla/games/gavel/src/stubHost.ts
@@ -1,0 +1,232 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// It serves what the real host serves: addition, subtraction and multiplication,
+// which are the rows with `status: "active"` in the curriculum graph today. A dev
+// harness that fed fractions would flatter the game with questions no child is
+// asked, and a harness that fed only addition would hide the whole point of the
+// board — the founder's example room is `12 + 5`, `3 × 5`, `8 × 1`, `15 − 2`, and
+// mixed operations are what make the highest bid something you have to work out
+// rather than something you can see.
+//
+// Four properties the real runtime also honours, asserted by
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an integer.
+//      No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Both difficulty scales are read the way `game-host` reads them** — a
+//      value under 1 is a fraction, 1..10 is a ladder index — and `maxDifficulty`
+//      is a ceiling the stream never crosses.
+//   4. **Distractors are real mal-rule outputs**: what a child with a specific
+//      broken procedure writes down, not `answer ± 1` noise. THE GAVEL does not
+//      draw them, but the wire carries them and a stub that lies about the wire is
+//      a stub that hides a defect.
+
+import type { Ask, Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Domain = "add" | "sub" | "mul"
+
+/** Digit-reversal: 63 → 36. A real transcription slip, not noise. */
+function reverseDigits(n: number): number {
+  let out = 0
+  let m = n
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += (((x % 10) + (y % 10)) % 10) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2−7| in the ones column. */
+function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+function malRulesFor(domain: Domain, a: number, b: number, answer: number): number[] {
+  if (domain === "add") {
+    return [
+      addNoCarry(a, b), // the carry never left the column it was made in
+      answer - 10, // carried but never added the carry in
+      answer + 10, // carried twice
+      Math.abs(a - b), // reached for the wrong operation
+      reverseDigits(answer),
+    ]
+  }
+  if (domain === "sub") {
+    return [
+      subSmallerFromLarger(a, b),
+      answer + 10, // borrowed without decrementing the next column
+      answer - 10, // decremented twice
+      a + b, // wrong operation
+      reverseDigits(answer),
+    ]
+  }
+  return [
+    a + b, // reached for the wrong operation
+    a * b - a, // one row of the table short
+    a * b + a, // one row of the table long
+    a * (b - 1) + 1, // lost the last group and put one back
+    reverseDigits(answer),
+  ]
+}
+
+/** `difficulty` is 0..1, the same monotone reading of the ladder the host sends. */
+function operandsFor(domain: Domain, difficulty: number, rng: Rng): [number, number] {
+  const d = Math.max(0, Math.min(1, difficulty))
+  if (domain === "mul") {
+    const hi = 3 + Math.round(d * 9)
+    return [rng.int(2, hi), rng.int(2, hi)]
+  }
+  const hi = Math.round(14 + d * 300)
+  if (domain === "add") return [rng.int(3, hi), rng.int(3, hi)]
+  const a = rng.int(10, hi + 20)
+  const b = rng.int(2, Math.max(2, a - 1))
+  return [a, b]
+}
+
+const GLYPH: Record<Domain, string> = { add: "+", sub: "−", mul: "×" }
+
+/**
+ * A game's difficulty number as a 0..1 ladder position.
+ *
+ * The rule `game-host` states and tests: under 1 is a fraction, 1..10 is a ladder
+ * index, and exactly 1 is read as the BOTTOM. Copied rather than imported so the
+ * dev harness reproduces the ambiguity the shipped app has rather than a kinder
+ * version of it.
+ */
+export function toUnit(value: number | undefined): number | null {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return null
+  if (value < 1) return Math.max(0, value)
+  return Math.min(1, (value - 1) / 9)
+}
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Observe reports — the dev harness draws a running accuracy readout from this. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe skips, so a harness can show the questions a round closed unanswered. */
+  onSkip?: (questionId: string) => void
+  /** Observe haptics so the harness can show they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+  /** Observe stopping points, which a real host may put a sheet on top of. */
+  onTransition?: (kind: string, label?: string) => void
+  /** Pin the ladder instead of following what the game asks for. */
+  difficulty?: number
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x5eed1ce)
+  let n = 0
+  let ceiling: number | null = null
+
+  return {
+    next(ask?: Ask) {
+      n++
+      const asked = toUnit(ask?.maxDifficulty)
+      if (asked !== null) ceiling = asked
+      const wanted = toUnit(ask?.difficulty) ?? 0
+      const pinned = opts.difficulty === undefined ? null : toUnit(opts.difficulty)
+      const target = pinned ?? wanted
+      const difficulty = ceiling === null ? target : Math.min(target, ceiling)
+
+      const roll = rng.next()
+      const domain: Domain = roll < 0.42 ? "add" : roll < 0.72 ? "sub" : "mul"
+      const [a, b] = operandsFor(domain, difficulty, rng)
+      const answer = domain === "add" ? a + b : domain === "sub" ? a - b : a * b
+
+      // Mal-rule outputs, deduped, filtered to values that could be a price: a
+      // positive integer that is not the answer.
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(domain, a, b, answer)) {
+        if (!Number.isInteger(v) || v < 1 || v > 9999 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      // Top up from near-misses when a particular (a, b) collapsed several
+      // mal-rules onto one value.
+      for (let k = 1; pool.length < 3 && k < 40; k++) {
+        for (const v of [answer + k, answer - k]) {
+          if (pool.length >= 3) break
+          if (!Number.isInteger(v) || v < 1 || v > 9999 || seen.has(v)) continue
+          seen.add(v)
+          pool.push(v)
+        }
+      }
+
+      return {
+        id: `stub-${String(n)}`,
+        prompt: `${String(a)} ${GLYPH[domain]} ${String(b)}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain,
+        difficulty,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    skip(questionId) {
+      opts.onSkip?.(questionId)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet, or a
+        // policy block) must never take the frame down with it.
+        console.warn("[gavel] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+
+    transition(kind, label) {
+      opts.onTransition?.(kind, label)
+    },
+  }
+}

--- a/dynawalla/games/gavel/src/test/antimash.test.ts
+++ b/dynawalla/games/gavel/src/test/antimash.test.ts
@@ -1,0 +1,99 @@
+// THE GALLERY HAS NO CLOCK, AND THIS IS THE PROOF.
+//
+// `PACING_AUDIT_2026-07.md` found seventeen of twenty-seven games rushed, and it
+// found one architectural cause rather than seventeen tuning problems: *the
+// comprehension window is derived from a motion constant that is also the
+// escalation knob*, so every one of them shrank a child's thinking time as a side
+// effect of getting more exciting. It named COLOSSUS as the reference for *proving*
+// pacing rather than asserting it: play one seed at eight seconds a strike and at a
+// fifth of a second a strike and require byte-identical results.
+//
+// This is that test for THE GAVEL. Two sittings from the same seed, identical
+// decisions, one taking eight seconds a lot and one taking two hundred milliseconds:
+//
+//   * the same coins,
+//   * the same tally,
+//   * the same reported answers, in the same order,
+//   * the same room in front of the child at the end,
+//
+// and the ONLY difference is the latency each answer was reported with, which is the
+// one thing that should differ. If any of that ever stops holding, something in this
+// pack has started reading a clock, and nothing else in the game would fail.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { MASHES, PERFECT, play, type Player } from "./harness.ts"
+
+const SEEDS = [0x1, 0xc0105, 0x5eed1ce, 0xbeef, 0x2718, 0x1414, 0xfeed, 0xd00d]
+const DECISIONS = 24
+
+function twoSpeeds(player: Player, seed: number) {
+  const slow = play(player, DECISIONS, seed, { step: 8000 })
+  const fast = play(player, DECISIONS, seed, { step: 200 })
+  return { slow, fast }
+}
+
+for (const player of [PERFECT, MASHES]) {
+  test(`taking eight seconds a lot changes nothing at all: ${player.name}`, () => {
+    for (const seed of SEEDS) {
+      const { slow, fast } = twoSpeeds(player, seed)
+      const tag = `seed ${seed.toString(16)}`
+
+      assert.equal(slow.decisions, fast.decisions, tag)
+      assert.equal(slow.coins, fast.coins, `${tag}: ${String(slow.coins)} coins slow, ${String(fast.coins)} fast`)
+      assert.deepEqual(slow.game.tally, fast.game.tally, tag)
+      assert.equal(slow.game.storeroom, fast.game.storeroom, tag)
+      assert.equal(slow.game.remaining, fast.game.remaining, tag)
+      assert.equal(slow.game.consignmentNumber, fast.game.consignmentNumber, tag)
+      assert.deepEqual(
+        slow.reports.map((r) => r.answered),
+        fast.reports.map((r) => r.answered),
+        `${tag}: the answers reported to the host differ between a slow and a fast sitting`,
+      )
+      assert.deepEqual(
+        slow.reports.map((r) => r.correct),
+        fast.reports.map((r) => r.correct),
+        tag,
+      )
+      // The rooms themselves are identical, which is the stronger claim: the
+      // difficulty the host was asked for cannot have moved either.
+      assert.deepEqual(
+        slow.game.room?.tablets.map((t) => t.prompt),
+        fast.game.room?.tablets.map((t) => t.prompt),
+        `${tag}: a slow sitting is looking at a different room`,
+      )
+      assert.equal(slow.game.intensity, fast.game.intensity, `${tag}: the ladder moved on the clock`)
+    }
+  })
+}
+
+test("the only thing a slow sitting changes is the latency it reports", () => {
+  const { slow, fast } = twoSpeeds(PERFECT, 0x51004)
+  assert.ok(slow.reports.length > 10, "not enough reports to compare")
+  assert.ok(
+    slow.reports.every((r, i) => r.ms > (fast.reports[i]?.ms ?? 0)),
+    "the reported thinking time did not track the clock",
+  )
+})
+
+test("time cannot accumulate at all while a bid is being set", () => {
+  // The FOUNDRY STREET shape, and its comment: "a child who is thinking must never
+  // be losing." The bidding phase has no duration and `advance` returns before it
+  // touches anything, so a whole minute of frames is not merely harmless — it is
+  // unobservable.
+  const { slow } = twoSpeeds(PERFECT, 0x777)
+  const before = {
+    coins: slow.game.coins,
+    tally: { ...slow.game.tally },
+    prompts: slow.game.room?.tablets.map((t) => t.prompt),
+    remaining: slow.game.remaining,
+  }
+  assert.equal(slow.game.phase, "bidding", "the sitting did not end on a live room")
+  for (let i = 0; i < 4000; i++) slow.game.advance(16, 1_000_000 + i * 16)
+  assert.equal(slow.game.coins, before.coins)
+  assert.deepEqual(slow.game.tally, before.tally)
+  assert.equal(slow.game.remaining, before.remaining)
+  assert.deepEqual(slow.game.room?.tablets.map((t) => t.prompt), before.prompts)
+  assert.equal(slow.game.phase, "bidding")
+})

--- a/dynawalla/games/gavel/src/test/bots.test.ts
+++ b/dynawalla/games/gavel/src/test/bots.test.ts
@@ -1,0 +1,175 @@
+// THE CLAIM THIS WHOLE PACK RESTS ON: **the room cannot be beaten without doing
+// the arithmetic.**
+//
+// COUNTERPOISE shipped with the answer as the rightmost weight 97.2% of the time,
+// and a bot that always took the rightmost weight scored 97.2% without doing any
+// maths at all. Nothing in that game failed; it simply was not a maths game. So the
+// bots here are the strongest arithmetic-free strategies THE GAVEL admits, plus two
+// that do the arithmetic and then skip one of the other three steps — and each of
+// them has to be beaten decisively.
+//
+// **The budget is decisions, not lots.** A child's sitting is bounded by attention,
+// and a strategy that keeps losing lots does not get extra turns to make up for it.
+//
+// Every bot plays its OWN adapted run, which is the harder comparison and the
+// honest one: the controller hands a struggling player the calmest room the game
+// has — wide broker margins, no traps, the easiest rung — so each bot below is
+// measured in the most forgiving world it can reach.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  BIDS_THE_MAX,
+  EYEBALLS_THE_ROOM,
+  FOLDS,
+  IGNORES_THE_OFFER,
+  MASHES,
+  PERFECT,
+  READS_ONLY_THE_OFFER,
+  mean,
+  play,
+  type Player,
+} from "./harness.ts"
+
+const SEEDS = [0x1, 0xbeef, 0x2718, 0x5eed1ce, 0xfeed, 0xd00d, 0x1414, 0xc0ffee]
+const DECISIONS = 40
+
+/** Coins per seed for one player. */
+function purse(player: Player, opts: { warm?: number } = {}): number[] {
+  return SEEDS.map((seed) => play(player, DECISIONS, seed, opts).coins)
+}
+
+/**
+ * Every arithmetic-free strategy earns a small fraction of what computing earns,
+ * on every seed, both from a cold start and after thirty lots have carried the run
+ * up the ladder.
+ */
+test("computing the room beats every strategy that does not, on every seed", () => {
+  for (const warm of [0, 30]) {
+    const computed = purse(PERFECT, { warm })
+    const tag = warm === 0 ? "from cold" : "after thirty lots"
+    assert.ok(mean(computed) > 100, `${tag}: computing earned only ${String(mean(computed))}`)
+
+    for (const bot of [READS_ONLY_THE_OFFER, EYEBALLS_THE_ROOM, MASHES, IGNORES_THE_OFFER]) {
+      const blind = purse(bot, { warm })
+      for (const [i, coins] of blind.entries()) {
+        const seed = SEEDS[i] ?? 0
+        const best = computed[i] ?? 0
+        assert.ok(
+          coins * 3 < best,
+          `${tag}, seed ${seed.toString(16)}: "${bot.name}" earned ${String(coins)} against ` +
+            `${String(best)} for computing — less than a threefold gap is not a maths game`,
+        )
+      }
+      assert.ok(
+        mean(blind) * 4 < mean(computed),
+        `${tag}: "${bot.name}" averaged ${mean(blind).toFixed(1)} against ${mean(computed).toFixed(1)}`,
+      )
+    }
+  }
+})
+
+/**
+ * The founder's rule, as a test: *if you can bid just one over the highest bid you
+ * win the item.* One over, not level with it.
+ */
+test("bidding the highest instead of one over it wins nothing at all, ever", () => {
+  for (const seed of SEEDS) {
+    const sitting = play(BIDS_THE_MAX, DECISIONS, seed)
+    assert.equal(
+      sitting.coins,
+      0,
+      `seed ${seed.toString(16)}: bidding the room's own highest earned ${String(sitting.coins)}`,
+    )
+    // Every single lot went to a rival, so the consignment only ever grew.
+    assert.equal(sitting.game.tally.sold, 0)
+    assert.equal(sitting.game.tally.outbid, sitting.decisions)
+    // The host is told this is wrong, and it is: the question THE GAVEL asks is "one
+    // more than this tablet", and `highest` is not one more than `highest`. The
+    // reported value is `bid − 1`, so what the host sees is an answer one under the
+    // canonical one — an off-by-one, which is exactly the error being made.
+    assert.ok(
+      sitting.reports.every((r) => !r.correct),
+      "bidding level with the room was reported as a correct answer",
+    )
+    assert.ok(
+      sitting.reports.every((r) => Number(r.answered) >= 0),
+      "a negative claim reached the host",
+    )
+  }
+})
+
+/**
+ * The other half of the founder's rule: *if we bid over 20 we lose money.* A child
+ * who never looks at the broker's offer buys things nobody will buy.
+ */
+test("ignoring the broker's offer buys unsellable lots and earns a fraction", () => {
+  let unsold = 0
+  let lots = 0
+  for (const seed of SEEDS) {
+    const padded = play(IGNORES_THE_OFFER, DECISIONS, seed)
+    const computed = play(PERFECT, DECISIONS, seed)
+    unsold += padded.game.storeroom
+    lots += padded.decisions
+    assert.ok(
+      padded.coins * 4 < computed.coins,
+      `seed ${seed.toString(16)}: padding earned ${String(padded.coins)} against ${String(computed.coins)}`,
+    )
+    // Padding by five answers "one more than this tablet" with five more than it, so
+    // the host hears an off-by-four. The real cost is still the storeroom and the
+    // consignment strip: no coin is ever taken away and no life is lost.
+    assert.ok(padded.reports.every((r) => !r.correct))
+    assert.equal(padded.game.tally.outbid, 0, "padding the bid should never be outbid")
+    assert.ok(padded.game.storeroom > 0, `seed ${seed.toString(16)}: padding was never punished`)
+  }
+  // The broker's headroom is two to nine coins, so padding by five buys something
+  // unsellable about three times in eight. Anything much below that and the offer is
+  // decoration.
+  assert.ok(
+    unsold / lots > 0.2,
+    `padding by five went unsold on only ${((100 * unsold) / lots).toFixed(0)}% of lots`,
+  )
+})
+
+/**
+ * Folding is safe, and safety is not a living.
+ *
+ * Both halves matter. A fold that cost something would make the honest answer to a
+ * lot nobody can profit from into a punishment, and a fold that paid well would make
+ * the whole game optional.
+ */
+test("folding everything is safe, reports nothing, and earns almost nothing", () => {
+  for (const seed of SEEDS) {
+    const folded = play(FOLDS, DECISIONS, seed, { warm: 30 })
+    const computed = play(PERFECT, DECISIONS, seed, { warm: 30 })
+    assert.equal(folded.reports.length, 0, "a fold was reported to the host as an answer")
+    assert.equal(folded.game.storeroom, 0)
+    assert.ok(
+      folded.coins * 8 < computed.coins,
+      `seed ${seed.toString(16)}: folding earned ${String(folded.coins)} against ${String(computed.coins)}`,
+    )
+  }
+})
+
+/**
+ * A room the child can sort by eye is a room they do not have to compute, and the
+ * tight-cluster assembler in `lot.ts` is what stops that. This is the measurement
+ * of how often the surface lies.
+ */
+test("the biggest number printed in the room is usually not the biggest bid", () => {
+  let rooms = 0
+  let misleading = 0
+  for (const seed of SEEDS) {
+    const sitting = play(EYEBALLS_THE_ROOM, DECISIONS, seed)
+    rooms += sitting.decisions
+    misleading += sitting.game.tally.outbid + sitting.game.tally.unsold
+  }
+  // Measured at 73% with ten spare questions on the bench and 46% with three; the
+  // threshold is a guard on the assembler, not a target.
+  assert.ok(
+    misleading / rooms > 0.6,
+    `eyeballing the room worked on ${(100 - (100 * misleading) / rooms).toFixed(0)}% of boards — ` +
+      "the assembler is letting the surface give the answer away",
+  )
+})

--- a/dynawalla/games/gavel/src/test/failure.test.ts
+++ b/dynawalla/games/gavel/src/test/failure.test.ts
@@ -1,0 +1,220 @@
+// WHAT BEING WRONG COSTS: MORE WORK, VISIBLE AND COUNTABLE, AND NOTHING ELSE.
+//
+// COLOSSUS is the fleet's reference for this and its rule is stated in the game's own
+// manual: "two new floors thud down on top. Nothing is taken away from you. No buzzer,
+// no lost life, no red cross. You just get more building to knock down."
+//
+// THE GAVEL's version: a lot that does not sell stays in the consignment and the broker
+// adds one more, so being wrong costs two more lots of work than being right. The strip
+// at the top of the screen is one pip per lot owed, so it is countable from across a
+// room. This file holds the four things that have to be true for that to be the whole
+// cost.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  BENCH_CAP,
+  CONSIGNMENT,
+  EXTRA_ON_MISS,
+  MAX_CONSIGNMENT,
+  SCOUT_FEE,
+} from "../game/auction.ts"
+import { Rng } from "../core/rng.ts"
+import { isTrap } from "../game/lot.ts"
+import {
+  BIDS_THE_MAX,
+  EYEBALLS_THE_ROOM,
+  FOLDS,
+  IGNORES_THE_OFFER,
+  MASHES,
+  PERFECT,
+  READS_ONLY_THE_OFFER,
+  rig,
+  settleOn,
+  stepClock,
+  typeBid,
+} from "./harness.ts"
+
+const SEEDS = [0x1, 0xbeef, 0x2718, 0x5eed1ce, 0xfeed, 0xd00d]
+
+test("a lot that does not sell costs exactly two more lots of work than one that does", () => {
+  const r = rig(0x2718)
+  const clock = stepClock()
+  const room = r.game.room
+  assert.ok(room)
+  assert.equal(r.game.remaining, CONSIGNMENT)
+
+  // A bid under the room: outbid.
+  r.game.tapTablet(room.tablets.findIndex((t) => t.value === room.highest))
+  typeBid(r.game, 1)
+  r.game.hammer(clock())
+  assert.equal(r.game.settled?.outcome, "outbid")
+  assert.equal(
+    r.game.remaining,
+    CONSIGNMENT + EXTRA_ON_MISS,
+    "the lot did not come back, or the broker did not add one",
+  )
+  settleOn(r.game, clock)
+
+  // …and a sale takes one off.
+  const next = r.game.room
+  assert.ok(next)
+  const before = r.game.remaining
+  r.game.tapTablet(next.tablets.findIndex((t) => t.value === next.highest))
+  typeBid(r.game, next.highest + 1)
+  r.game.hammer(clock())
+  assert.equal(r.game.settled?.outcome, isTrap(next) ? "unsold" : "sold")
+  if (!isTrap(next)) {
+    assert.equal(r.game.remaining, before - 1)
+  }
+})
+
+test("no coin is ever taken away, whatever anybody does", () => {
+  // `EXPERIENCE_DESIGN.md`: construction never regresses. The strongbox is the only
+  // score in the game and it is the child-safe form of loss aversion — the pull to come
+  // back is "my consignment is unsold", never "my coins are at risk".
+  for (const player of [
+    PERFECT,
+    BIDS_THE_MAX,
+    IGNORES_THE_OFFER,
+    READS_ONLY_THE_OFFER,
+    EYEBALLS_THE_ROOM,
+    MASHES,
+    FOLDS,
+  ]) {
+    for (const seed of SEEDS) {
+      const r = rig(seed)
+      const clock = stepClock()
+      let last = 0
+      for (let i = 0; i < 30; i++) {
+        const room = r.game.room
+        if (!room) break
+        player.act(r.game, room, new Rng(seed ^ 0x99), clock())
+        assert.ok(
+          r.game.coins >= last,
+          `"${player.name}" on seed ${seed.toString(16)}: the strongbox fell from ` +
+            `${String(last)} to ${String(r.game.coins)}`,
+        )
+        last = r.game.coins
+        settleOn(r.game, clock)
+      }
+    }
+  }
+})
+
+test("the storeroom counts overpaid lots, only ever rises, and nothing else touches it", () => {
+  const padded = rig(0x1)
+  const clock = stepClock()
+  let last = 0
+  for (let i = 0; i < 40; i++) {
+    const room = padded.game.room
+    if (!room) break
+    padded.game.tapTablet(room.tablets.findIndex((t) => t.value === room.highest))
+    typeBid(padded.game, room.offer + 3)
+    padded.game.hammer(clock())
+    assert.equal(padded.game.settled?.outcome, "unsold")
+    assert.equal(padded.game.storeroom, last + 1, "an overpaid lot did not reach the shelf")
+    last = padded.game.storeroom
+    settleOn(padded.game, clock)
+  }
+  assert.equal(last, 40)
+  // …and a player who never overpays never has one.
+  const clean = rig(0x1)
+  const clock2 = stepClock()
+  for (let i = 0; i < 40; i++) {
+    const room = clean.game.room
+    if (!room) break
+    PERFECT.act(clean.game, room, undefined as never, clock2())
+    settleOn(clean.game, clock2)
+  }
+  assert.equal(clean.game.storeroom, 0)
+})
+
+test("the consignment strip stays countable: it never grows past its cap", () => {
+  const r = rig(0xbeef)
+  const clock = stepClock()
+  for (let i = 0; i < 200; i++) {
+    const room = r.game.room
+    if (!room) break
+    // Never win anything, forever.
+    r.game.tapTablet(0)
+    typeBid(r.game, 1)
+    r.game.hammer(clock())
+    assert.ok(
+      r.game.remaining <= MAX_CONSIGNMENT,
+      `the consignment reached ${String(r.game.remaining)} lots — a strip that long is not countable`,
+    )
+    settleOn(r.game, clock)
+  }
+  assert.equal(r.game.remaining, MAX_CONSIGNMENT)
+  assert.equal(r.game.coins, 0)
+})
+
+test("a stopping point is only ever offered after a consignment that sold something", () => {
+  // ADR-0013: a purchase surface must never sit next to a shortfall. `transition` is the
+  // call that can put one there, so it is only made when the child finished something.
+  const good = rig(0x2718)
+  const clock = stepClock()
+  for (let i = 0; i < 40; i++) {
+    const room = good.game.room
+    if (!room) break
+    PERFECT.act(good.game, room, undefined as never, clock())
+    settleOn(good.game, clock)
+  }
+  assert.ok(good.transitions.length > 0, "a consignment was sold out and nothing was offered")
+  assert.ok(good.transitions.every((t) => t.kind === "level"))
+
+  // A child who folded every lot cleared the consignment without selling a thing.
+  const folded = rig(0x2718)
+  const clock2 = stepClock()
+  for (let i = 0; i < 40; i++) {
+    if (!folded.game.room) break
+    folded.game.fold()
+    settleOn(folded.game, clock2)
+  }
+  assert.ok(folded.game.consignmentNumber > 1, "no consignment was ever cleared")
+  assert.deepEqual(folded.transitions, [], "a stopping point was offered after selling nothing")
+})
+
+test("the scout's fee is the only coin that arrives without a sale", () => {
+  const r = rig(0x5eed1ce)
+  const clock = stepClock()
+  let fees = 0
+  let sales = 0
+  for (let i = 0; i < 120; i++) {
+    const room = r.game.room
+    if (!room) break
+    const before = r.game.coins
+    if (isTrap(room)) {
+      r.game.fold()
+      const gained = r.game.coins - before
+      assert.ok(gained === 0 || gained === SCOUT_FEE)
+      fees += gained
+    } else {
+      PERFECT.act(r.game, room, undefined as never, clock())
+      sales += r.game.coins - before
+    }
+    settleOn(r.game, clock)
+  }
+  assert.ok(fees > 0, "no unprofitable lot was ever spotted")
+  assert.ok(sales > fees * 10, `the fees are ${String(fees)} against ${String(sales)} from selling`)
+})
+
+test("the bench is bounded, so a long sitting cannot grow one", () => {
+  // Not a gameplay rule — a leak guard. The bench holds questions drawn and not shown,
+  // and an unbounded one would hold every question the room ever passed over.
+  assert.ok(BENCH_CAP > 0 && BENCH_CAP < 64)
+  const r = rig(0xd00d)
+  const clock = stepClock()
+  for (let i = 0; i < 120; i++) {
+    const room = r.game.room
+    if (!room) break
+    PERFECT.act(r.game, room, undefined as never, clock())
+    settleOn(r.game, clock)
+  }
+  // Every question ever served is either answered, closed, or standing on the board or
+  // the bench right now — and the last two are bounded.
+  const open = r.skips.length + r.reports.length
+  assert.ok(open > 100)
+})

--- a/dynawalla/games/gavel/src/test/harness.ts
+++ b/dynawalla/games/gavel/src/test/harness.ts
@@ -1,0 +1,263 @@
+// Shared scaffolding for the rules tests: a recording host, and the players.
+//
+// Every test in this package is seeded from a literal. Nothing here reads
+// `Math.random`, `Date.now` or `performance.now`, so a run that passes passes
+// every time and a run that fails fails every time.
+//
+// **The players are the argument of this pack.** COUNTERPOISE shipped with its
+// answer as the rightmost weight 97.2% of the time and a bot that always took the
+// rightmost weight scored 97.2% without doing any arithmetic. So the bots here are
+// written to be the strongest thing a child could do *without* working the room
+// out, and `bots.test.ts` requires each of them to be beaten decisively.
+//
+// Every bot below is restricted to what is on the screen: the prompt strings, the
+// broker's offer, and nothing else. `playPerfect` is the only player that is
+// allowed to read `tablet.value`, because reading it is exactly the arithmetic
+// being claimed.
+
+import type { Host } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Auction } from "../game/auction.ts"
+import { isTrap, type Room } from "../game/lot.ts"
+import { createStubHost } from "../stubHost.ts"
+
+export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+export type Rig = {
+  host: Host
+  game: Auction
+  reports: Report[]
+  skips: string[]
+  transitions: Array<{ kind: string; label?: string }>
+  haptics: string[]
+}
+
+export function rig(seed = 0x9a7e1, opts: { difficulty?: number } = {}): Rig {
+  const reports: Report[] = []
+  const skips: string[] = []
+  const transitions: Array<{ kind: string; label?: string }> = []
+  const haptics: string[] = []
+  const host = createStubHost({
+    seed,
+    reducedMotion: true,
+    ...(opts.difficulty === undefined ? {} : { difficulty: opts.difficulty }),
+    onReport: (r) => reports.push(r),
+    onSkip: (id) => skips.push(id),
+    onHaptic: (k) => haptics.push(k),
+    onTransition: (kind, label) =>
+      transitions.push(label === undefined ? { kind } : { kind, label }),
+  })
+  const game = new Auction(host, new Rng(seed ^ 0x1234), 0)
+  game.begin(0)
+  return { host, game, reports, skips, transitions, haptics }
+}
+
+/** A wall clock that ticks a fixed amount per call. No real time anywhere. */
+export function stepClock(step = 4200): () => number {
+  let t = 0
+  return () => {
+    t += step
+    return t
+  }
+}
+
+/** Put a number on the paddle, digit by digit, the way a child does. */
+export function typeBid(game: Auction, bid: number): void {
+  for (const ch of String(Math.max(0, Math.floor(bid)))) game.pressDigit(Number(ch))
+}
+
+/** Clear whatever is on the paddle. */
+export function clearBid(game: Auction): void {
+  while (game.digits !== "") game.backspace()
+}
+
+/** Take the room through the reveal and on to the next lot. */
+export function settleOn(game: Auction, clock: () => number): void {
+  game.nudge()
+  game.advance(1, clock())
+}
+
+/** The largest number printed anywhere on a tablet's face. Surface only. */
+export function largestVisible(prompt: string): number {
+  let best = 0
+  for (const token of prompt.match(/\d+/g) ?? []) best = Math.max(best, Number(token))
+  return best
+}
+
+export type Player = {
+  readonly name: string
+  /** One decision on the room in front of you. Return nothing; act on the game. */
+  act(game: Auction, room: Room, rng: Rng, now: number): void
+}
+
+/**
+ * A child who works the room out: find the highest bid, mark it, bid one over —
+ * and fold when the broker's offer is not above the room at all.
+ */
+export const PERFECT: Player = {
+  name: "computes the room",
+  act(game, room, _rng, now) {
+    if (isTrap(room)) {
+      game.fold()
+      return
+    }
+    const at = room.tablets.findIndex((t) => t.value === room.highest)
+    game.tapTablet(at)
+    typeBid(game, room.highest + 1)
+    game.hammer(now)
+  },
+}
+
+/**
+ * A child who works the room out and forgets the one: marks the highest tablet and
+ * bids exactly what it says.
+ *
+ * The requirement it exists to prove is "a child who bids the max instead of max+1
+ * should win nothing".
+ */
+export const BIDS_THE_MAX: Player = {
+  name: "bids the highest, not one over",
+  act(game, room, _rng, now) {
+    const at = room.tablets.findIndex((t) => t.value === room.highest)
+    game.tapTablet(at)
+    typeBid(game, room.highest)
+    game.hammer(now)
+  },
+}
+
+/**
+ * A child who works the room out and never looks at the broker's offer: marks the
+ * highest tablet and pads the bid by five to be safe.
+ *
+ * The requirement it exists to prove is "a child who ignores the resale price
+ * should lose money".
+ */
+export const IGNORES_THE_OFFER: Player = {
+  name: "pads the bid and ignores the offer",
+  act(game, room, _rng, now) {
+    const at = room.tablets.findIndex((t) => t.value === room.highest)
+    game.tapTablet(at)
+    typeBid(game, room.highest + 5)
+    game.hammer(now)
+  },
+}
+
+/**
+ * A child who reads only the broker's offer and never a single sum: mark anything,
+ * bid one under the offer.
+ *
+ * This is the strongest arithmetic-free strategy the game admits, and the reason
+ * `KEEN_MULTIPLIER` exists: without the keen bonus this bot wins nearly every lot
+ * and, wherever the margin is two, its blind bid is the perfect bid.
+ */
+export const READS_ONLY_THE_OFFER: Player = {
+  name: "bids one under the offer",
+  act(game, room, _rng, now) {
+    game.tapTablet(0)
+    typeBid(game, Math.max(1, room.offer - 1))
+    game.hammer(now)
+  },
+}
+
+/**
+ * A child who sorts the room by eye: mark the tablet with the biggest number
+ * printed on it, and bid one over that number.
+ *
+ * The heuristic COUNTERPOISE fell to, in this game's shape. On the founder's own
+ * example room — `12 + 5`, `3 × 5`, `8 × 1`, `15 − 2` — it marks `15 − 2` and bids
+ * 16, which is under the room and buys nothing.
+ */
+export const EYEBALLS_THE_ROOM: Player = {
+  name: "marks the biggest printed number",
+  act(game, room, _rng, now) {
+    let at = 0
+    let best = -1
+    for (let i = 0; i < room.tablets.length; i++) {
+      const seen = largestVisible(room.tablets[i]?.prompt ?? "")
+      if (seen > best) {
+        best = seen
+        at = i
+      }
+    }
+    game.tapTablet(at)
+    typeBid(game, best + 1)
+    game.hammer(now)
+  },
+}
+
+/** A child who mashes: mark something, put some digits in, hit the hammer. */
+export const MASHES: Player = {
+  name: "mashes",
+  act(game, room, rng, now) {
+    game.tapTablet(rng.int(0, room.tablets.length - 1))
+    typeBid(game, rng.int(1, room.offer + 4))
+    game.hammer(now)
+  },
+}
+
+/** A child who folds everything. Safe, and earns only the scout's fee. */
+export const FOLDS: Player = {
+  name: "folds everything",
+  act(game) {
+    game.fold()
+  },
+}
+
+export type Sitting = {
+  /** Coins earned by the player under test, after any warm-up is discounted. */
+  readonly coins: number
+  readonly decisions: number
+  readonly reports: readonly Report[]
+  readonly game: Auction
+}
+
+/**
+ * Play `decisions` lots with one player and report what the strongbox holds.
+ *
+ * A *decision* is the budget, not a lot: a child's sitting is bounded by their
+ * attention, and a strategy that keeps failing has to work through the lots it
+ * generated with the same attention as everybody else. So a strategy that loses
+ * lots does not get extra turns to make up for it, which is the honest comparison.
+ *
+ * `warm` plays that many lots perfectly first and then hands the room over. It
+ * exists because the room's shape rides the run's intensity: a bot dropped into a
+ * fresh session is always judged against wide broker margins and no traps, which is
+ * the kindest possible board for a strategy that does no arithmetic. Coins banked
+ * during the warm-up are discounted.
+ */
+export function play(
+  player: Player,
+  decisions: number,
+  seed = 0x9a7e1,
+  opts: { difficulty?: number; step?: number; warm?: number } = {},
+): Sitting {
+  const r = rig(seed, opts)
+  const rng = new Rng(seed ^ 0x5151)
+  const clock = stepClock(opts.step ?? 4200)
+  for (let i = 0; i < (opts.warm ?? 0); i++) {
+    const room = r.game.room
+    if (!room || r.game.stalled) break
+    PERFECT.act(r.game, room, rng, clock())
+    settleOn(r.game, clock)
+  }
+  const banked = r.game.coins
+  const before = r.reports.length
+  let made = 0
+  for (let i = 0; i < decisions; i++) {
+    const room = r.game.room
+    if (!room || r.game.stalled) break
+    player.act(r.game, room, rng, clock())
+    made++
+    settleOn(r.game, clock)
+  }
+  return {
+    coins: r.game.coins - banked,
+    decisions: made,
+    reports: r.reports.slice(before),
+    game: r.game,
+  }
+}
+
+export function mean(xs: readonly number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length
+}

--- a/dynawalla/games/gavel/src/test/ladder.test.ts
+++ b/dynawalla/games/gavel/src/test/ladder.test.ts
@@ -1,0 +1,196 @@
+// THE LADDER, AND THE THING THAT MOVES IT.
+//
+// `PACING_AUDIT_2026-07.md`, root cause three: "escalation runs on the wall clock,
+// ignoring whether the child is getting anything right — HORDE: `difficulty = 1 +
+// floor(runT / 88)`, so a child who has missed EVERY question meets three-digit
+// addition at minute eleven purely for surviving." The well-paced games are the ones
+// indexed on achievement instead.
+//
+// THE GAVEL has one line that moves its intensity and it is called once per settled
+// lot. This file holds four things about it:
+//
+//   1. it moves on lots, and nothing else can move it;
+//   2. flawless play actually reaches the top — the failure mode this test caught in
+//      development was the opposite one, and it was silent;
+//   3. struggling comes back down, faster than it went up;
+//   4. everything the intensity is spent on is monotone in it, and none of it is a
+//      comprehension window, because there is no clock to put one in.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  LOT_STEP_SECONDS,
+  MAX_TABLETS,
+  MIN_NUMERAL_PX,
+  MIN_TABLETS,
+  PROMPT_MAX_CHARS,
+  SPEC,
+  ladderScale,
+  observe,
+  revealHoldMs,
+  rungCannotDraw,
+  settleAfterLot,
+  tabletCount,
+  tabletValue,
+  trapChance,
+  tryParseBid,
+} from "../game/ladder.ts"
+import { seedSuccess } from "../../../../packs/shared/game-pacing/index.ts"
+import { promptPx } from "../render/layout.ts"
+import { MASHES, PERFECT, play } from "./harness.ts"
+
+const q = (over: Partial<Parameters<typeof tabletValue>[0]> = {}) => ({
+  id: "q",
+  prompt: "12 + 5",
+  answer: "17",
+  distractors: [],
+  domain: "add",
+  difficulty: 0.4,
+  ...over,
+})
+
+test("flawless play reaches the top of the ladder, and does not sprint there", () => {
+  const sitting = play(PERFECT, 60, 0x2718)
+  assert.ok(
+    sitting.game.intensity > 0.95,
+    `sixty flawless lots left the run at intensity ${sitting.game.intensity.toFixed(3)} — ` +
+      "a child who never made a mistake was held near the easiest content in the product",
+  )
+  // …but not in four lots. `SECOND_GRADE_FLOW`'s climb constants are tuned for a
+  // per-frame delta and this controller is stepped once per lot, so the shared
+  // `climbBoost` crossed the whole curriculum ladder in about four answers.
+  const early = play(PERFECT, 6, 0x2718)
+  assert.ok(
+    early.game.intensity < 0.75,
+    `six lots reached intensity ${early.game.intensity.toFixed(3)} — that is a jump, not a climb`,
+  )
+})
+
+test("a run that is going badly comes back down, and comes down faster", () => {
+  const good = play(PERFECT, 40, 0x2718)
+  const bad = play(MASHES, 40, 0x2718)
+  assert.ok(bad.game.intensity < 0.2, `mashing sat at intensity ${bad.game.intensity.toFixed(3)}`)
+  assert.ok(good.game.intensity > bad.game.intensity + 0.6)
+
+  // Symmetry, from the constants rather than from a comment: relief is not earned.
+  const fromTop = settleAfterLot(1, 0)
+  const fromBottom = settleAfterLot(0, 1)
+  assert.ok(1 - fromTop > fromBottom, "the ladder climbs faster than it relents")
+})
+
+test("nothing but a settled lot can move the intensity", () => {
+  // `settleAfterLot` is the only door, and it takes no clock: the step is a constant.
+  const once = settleAfterLot(0.5, 1)
+  const again = settleAfterLot(0.5, 1)
+  assert.equal(once, again)
+  assert.ok(LOT_STEP_SECONDS > 0)
+  // Marking, typing and un-marking a tablet a hundred times is not an achievement.
+  const sitting = play(PERFECT, 8, 0x1)
+  const before = sitting.game.intensity
+  for (let i = 0; i < 100; i++) {
+    sitting.game.tapTablet(0)
+    sitting.game.pressDigit(7)
+    sitting.game.backspace()
+  }
+  assert.equal(sitting.game.intensity, before)
+})
+
+test("the controller is never told how long the child took", () => {
+  // A bonus for a quick answer is a clock in a different hat: think for longer and the
+  // room gets easier, so a careful child is quietly demoted. `observe` takes two
+  // arguments and neither of them is a duration.
+  assert.equal(observe.length, 2)
+  assert.equal(observe(0.5, true), observe(0.5, true))
+  assert.ok(observe(0.5, true) > 0.5)
+  assert.ok(observe(0.5, false) < 0.5)
+  // …which only works because a correct answer is FULL evidence here. Left at the
+  // shared spec's 0.55, flawless play scores exactly `strugglingBelow` forever and the
+  // ladder never leaves the floor.
+  assert.equal(SPEC.laboredScore, 1)
+  assert.ok(SPEC.laboredScore > SPEC.strugglingBelow)
+  let success = seedSuccess(SPEC)
+  for (let i = 0; i < 12; i++) success = observe(success, true)
+  assert.ok(success > SPEC.thrivingAbove, `a dozen correct answers reached only ${success.toFixed(3)}`)
+})
+
+test("everything the intensity is spent on is monotone in it, and none of it is a clock", () => {
+  let lastTablets = 0
+  let lastTrap = -1
+  for (let i = 0; i <= 100; i++) {
+    const x = i / 100
+    const tablets = tabletCount(x)
+    assert.ok(tablets >= MIN_TABLETS && tablets <= MAX_TABLETS)
+    assert.ok(tablets >= lastTablets, `the room shrank between ${String(x)} and the step before`)
+    lastTablets = tablets
+
+    const trap = trapChance(x)
+    assert.ok(trap >= 0 && trap <= 0.5)
+    if (x >= 0.12) {
+      assert.ok(trap >= lastTrap, "the trap rate went backwards")
+      lastTrap = trap
+    } else {
+      assert.equal(trap, 0, "the bottom of the ladder served a lot nobody can profit from")
+    }
+  }
+})
+
+test("the reveal after the hammer is the only duration in the game, and it has a floor", () => {
+  // It is a hold on an answer already given, never a window to answer in — so it is
+  // allowed to shorten as the run climbs, which is the opposite of what FOUNDRY's
+  // `tempo = 1.06 − 0.16·difficulty` did to its comprehension window.
+  const calm = revealHoldMs(0)
+  const hard = revealHoldMs(1)
+  assert.ok(calm > hard, "the patient reveal at the bottom of the ladder is missing")
+  assert.ok(hard >= 900, `the reveal collapsed to ${String(hard)}ms and would tear the room down`)
+})
+
+test("difficulty goes out on the unambiguous 1..10 scale", () => {
+  // `game-host` reads a value under 1 as a fraction and 1..10 as a ladder index, and
+  // resolves the one value both scales claim — exactly 1 — as the BOTTOM. POLARITY
+  // sent a fraction that reached 1 after fifteen strata and meant the top; it was
+  // served the easiest content in the product for the rest of the run.
+  assert.equal(ladderScale(0), 1)
+  assert.equal(ladderScale(1), 10)
+  assert.ok(ladderScale(0.5) > 1)
+  const sitting = play(PERFECT, 40, 0x2718)
+  const ask = sitting.game.askShape()
+  assert.ok((ask.difficulty ?? 0) > 9, `a run at the top asked for ${String(ask.difficulty)}`)
+})
+
+test("a tablet carries a whole non-negative price, or the question is refused", () => {
+  assert.equal(tabletValue(q()), 17)
+  assert.equal(tabletValue(q({ answer: "0" })), 0)
+  assert.equal(tabletValue(q({ answer: "1/2" })), null)
+  assert.equal(tabletValue(q({ answer: "2.5" })), null)
+  assert.equal(tabletValue(q({ answer: "-4" })), null)
+  assert.equal(tabletValue(q({ answer: "10000" })), null)
+  assert.equal(tabletValue(q({ answer: " 17 " })), 17)
+  assert.equal(tabletValue(q({ prompt: "1".repeat(PROMPT_MAX_CHARS + 1) })), null)
+  assert.equal(tryParseBid("007"), 7)
+  assert.equal(tryParseBid(""), null)
+  assert.equal(tryParseBid("1e3"), null)
+})
+
+test("a refusal that is a fact about the rung caps it; the pool sentinel never does", () => {
+  assert.equal(rungCannotDraw(q()), false)
+  assert.equal(rungCannotDraw(q({ answer: "1/2" })), true)
+  assert.equal(rungCannotDraw(q({ answer: "1/2", id: "" })), false)
+})
+
+test("the widest prompt a tablet will accept still prints at the legibility floor", () => {
+  // `polarity` shipped `LABEL_MAX_CHARS = 8` with a comment saying eight characters
+  // "still fits the cell without squeezing". They overflowed it by about 60% and
+  // nothing measured. This checks the constant against the renderer.
+  const widest = "1".repeat(PROMPT_MAX_CHARS)
+  const size = promptPx(widest, 132, 42)
+  assert.ok(
+    size >= MIN_NUMERAL_PX,
+    `the widest accepted prompt prints at ${String(size)}px, under the ${String(MIN_NUMERAL_PX)}px floor`,
+  )
+  // …and it fits. 0.63em per digit is the face's measured advance.
+  assert.ok(PROMPT_MAX_CHARS * size * 0.63 <= 132 - 16 + 1, "the widest prompt runs off the tablet")
+  // A short prompt is drawn large, because a child reading `7 + 5` should not be
+  // reading it at the size a four-digit column sum needs.
+  assert.ok(promptPx("7 + 5", 132, 42) > size)
+})

--- a/dynawalla/games/gavel/src/test/layout.test.ts
+++ b/dynawalla/games/gavel/src/test/layout.test.ts
@@ -1,0 +1,209 @@
+// NOTHING A CHILD MUST READ OR TOUCH IS UNDER THE HOST'S CHROME, AT ANY VIEWPORT.
+//
+// The exit chevron (top-left) and the how-to-play control (top-right) live in the
+// HOST document, above this pack's iframe. No z-index can rescue a collision: a pack
+// lays out clear of those two 44px squares or it loses the pixels. Twenty of the
+// twenty-seven shipped games declared `viewport-fit=cover` — which opts a document
+// INTO the notch — and then never read the insets back.
+//
+// And the insets a pack measures for itself are zeros. `env(safe-area-inset-*)` is a
+// property of the top-level browsing context and a pack is a cross-origin child, so
+// the host measures them and sends them; every viewport below is run with real device
+// insets as well as with none.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  hitsHostChrome,
+  safeRect,
+  setHostInsets,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts"
+import { MIN_NUMERAL_PX, MIN_TABLET_W, PROMPT_MAX_CHARS } from "../game/ladder.ts"
+import { MIN_KEY, columnsFor, criticalRects, hitKey, hitTablet, layout, promptPx } from "../render/layout.ts"
+
+type Case = { name: string; w: number; h: number; insets: Insets }
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+const NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+const LANDSCAPE: Insets = { top: 0, right: 44, bottom: 21, left: 44 }
+
+const CASES: readonly Case[] = [
+  { name: "the shortest phone this game will meet", w: 320, h: 480, insets: NONE },
+  { name: "iPhone SE", w: 320, h: 568, insets: NONE },
+  { name: "iPhone 8", w: 375, h: 667, insets: NONE },
+  { name: "iPhone 15, portrait, notched", w: 393, h: 852, insets: NOTCH },
+  { name: "iPhone 15, landscape, notched", w: 852, h: 393, insets: LANDSCAPE },
+  { name: "iPad, portrait", w: 768, h: 1024, insets: { top: 24, right: 0, bottom: 20, left: 0 } },
+  { name: "iPad, landscape", w: 1024, h: 768, insets: { top: 24, right: 0, bottom: 20, left: 0 } },
+]
+
+const COUNTS = [3, 4, 5]
+
+test("no rect a child must read or touch overlaps the host's two corners", () => {
+  for (const c of CASES) {
+    for (const count of COUNTS) {
+      const l = layout(c.w, c.h, count, c.insets)
+      for (const rect of criticalRects(l)) {
+        assert.equal(
+          hitsHostChrome(rect, c.w, c.insets),
+          false,
+          `${c.name} with ${String(count)} tablets: a rect at ` +
+            `(${rect.x.toFixed(0)}, ${rect.y.toFixed(0)}, ${rect.w.toFixed(0)}×${rect.h.toFixed(0)}) ` +
+            "sits under the host's exit or help control",
+        )
+      }
+    }
+  }
+})
+
+test("every key is at least 44px on its short side, everywhere", () => {
+  for (const c of CASES) {
+    for (const count of COUNTS) {
+      const l = layout(c.w, c.h, count, c.insets)
+      for (const key of l.keys) {
+        assert.ok(
+          Math.min(key.rect.w, key.rect.h) >= MIN_KEY - 0.001,
+          `${c.name}: the "${key.label}" key is ${key.rect.w.toFixed(0)}×${key.rect.h.toFixed(0)}`,
+        )
+      }
+    }
+  }
+})
+
+test("the keypad and the gallery are laid out side by side without overlapping", () => {
+  for (const c of CASES) {
+    for (const count of COUNTS) {
+      const l = layout(c.w, c.h, count, c.insets)
+      const all = [...l.tablets, ...l.keys.map((k) => k.rect), l.paddle]
+      for (let i = 0; i < all.length; i++) {
+        for (let j = i + 1; j < all.length; j++) {
+          const a = all[i]
+          const b = all[j]
+          if (!a || !b) continue
+          const over =
+            a.x < b.x + b.w - 0.01 &&
+            b.x < a.x + a.w - 0.01 &&
+            a.y < b.y + b.h - 0.01 &&
+            b.y < a.y + a.h - 0.01
+          assert.equal(over, false, `${c.name}: two touchable rects overlap`)
+        }
+      }
+    }
+  }
+})
+
+test("everything is inside the frame, and inside the safe rectangle where there is room", () => {
+  for (const c of CASES) {
+    for (const count of COUNTS) {
+      const l = layout(c.w, c.h, count, c.insets)
+      const safe = safeRect(c.w, c.h, c.insets)
+      for (const rect of criticalRects(l)) {
+        assert.ok(rect.x >= -0.01 && rect.x + rect.w <= c.w + 0.01, `${c.name}: a rect runs off the side`)
+        assert.ok(rect.y >= safe.y - 0.01, `${c.name}: a rect starts above the safe area`)
+        assert.ok(rect.x >= safe.x - 0.01, `${c.name}: a rect starts left of the safe area`)
+        assert.ok(rect.y + rect.h <= c.h + 0.01, `${c.name}: a rect runs off the bottom of the frame`)
+      }
+      // Every supported viewport clears the home indicator as well as the frame.
+      if (c.h >= 480) {
+        const lowest = Math.max(...criticalRects(l).map((r) => r.y + r.h))
+        assert.ok(
+          lowest <= safe.y + safe.h + 0.01,
+          `${c.name}: the layout reaches ${lowest.toFixed(0)} past a safe bottom of ` +
+            `${(safe.y + safe.h).toFixed(0)}`,
+        )
+      }
+    }
+  }
+})
+
+test("a tablet is never narrower than the width the prompt budget was derived from", () => {
+  for (const c of CASES) {
+    for (const count of COUNTS) {
+      const l = layout(c.w, c.h, count, c.insets)
+      for (const rect of l.tablets) {
+        assert.ok(
+          rect.w >= MIN_TABLET_W - 0.5,
+          `${c.name} with ${String(count)} tablets: a tablet is ${rect.w.toFixed(0)}px wide, under the ` +
+            `${String(MIN_TABLET_W)}px the character budget assumes`,
+        )
+        const size = promptPx("1".repeat(PROMPT_MAX_CHARS), rect.w, rect.h)
+        assert.ok(
+          size >= MIN_NUMERAL_PX,
+          `${c.name}: the widest accepted prompt would print at ${String(size)}px`,
+        )
+      }
+    }
+  }
+})
+
+test("the gallery wraps rather than squeezing, and the last row is centred", () => {
+  assert.equal(columnsFor(300, 5), 2)
+  assert.equal(columnsFor(1000, 5), 5)
+  assert.equal(columnsFor(80, 5), 1)
+  const narrow = layout(320, 568, 5, NONE)
+  const rows = new Set(narrow.tablets.map((t) => t.y))
+  assert.equal(rows.size, 3, "five tablets on a 320px phone should take three rows")
+  // The odd tablet on the last row sits in the middle rather than in a corner, so a
+  // gap never reads as a missing bidder.
+  const last = narrow.tablets[4]
+  assert.ok(last)
+  assert.ok(Math.abs(last.x + last.w / 2 - 160) < 1, "the single tablet on the last row is off-centre")
+})
+
+test("a tap lands on the thing under it, and nowhere else", () => {
+  const l = layout(375, 667, 4, NONE)
+  const gavel = l.keys.find((k) => k.id === "gavel")
+  assert.ok(gavel)
+  assert.equal(hitKey(l, gavel.rect.x + 2, gavel.rect.y + 2)?.id, "gavel")
+  assert.equal(hitKey(l, gavel.rect.x - 6, gavel.rect.y + 2), null)
+  const first = l.tablets[0]
+  assert.ok(first)
+  assert.equal(hitTablet(l, first.x + first.w / 2, first.y + first.h / 2), 0)
+  assert.equal(hitTablet(l, gavel.rect.x + 2, gavel.rect.y + 2), null)
+})
+
+test("the plaque moves below the host's corner band when it cannot fit between them", () => {
+  // A device with big side insets in landscape leaves less than a plaque's width
+  // between the two 44px corners. Both branches ship, so both are asserted.
+  const roomy = layout(768, 1024, 3, NONE)
+  assert.equal(roomy.plaqueBelowChrome, false)
+  const cramped = layout(320, 568, 3, { top: 0, right: 60, bottom: 0, left: 60 })
+  assert.equal(cramped.plaqueBelowChrome, true)
+  assert.equal(hitsHostChrome(cramped.coins, 320, { top: 0, right: 60, bottom: 0, left: 60 }), false)
+})
+
+test("a 320px-tall frame keeps its 44px targets and runs off the bottom instead", () => {
+  // **The stated floor of this layout is 400 CSS pixels of height**, which every phone
+  // in portrait and every tablet in either orientation clears. A phone in LANDSCAPE on
+  // an older 568×320 screen does not: the host's corner band takes 67 of those 320, and
+  // a keypad, a paddle, a gallery and the block do not fit in the 243 that are left.
+  //
+  // The trade is stated here rather than discovered on a device. The keys keep their
+  // 44px — the one number in `layout.ts` that is not a preference — and the layout runs
+  // past the bottom edge, so the last row of controls is partly off screen rather than
+  // present and unhittable. The proper fix is a side-by-side arrangement for short wide
+  // frames, with the keypad beside the gallery instead of under it, and it is not in
+  // this first cut.
+  const l = layout(568, 320, 5, NONE)
+  for (const key of l.keys) {
+    assert.ok(Math.min(key.rect.w, key.rect.h) >= MIN_KEY - 0.001, "a target was shrunk instead")
+  }
+  const lowest = Math.max(...criticalRects(l).map((r) => r.y + r.h))
+  assert.ok(lowest > 320, "this case now fits — delete the exception and add it to CASES")
+  assert.ok(lowest < 400, `the overflow is ${lowest.toFixed(0)}px, which is more than one row`)
+})
+
+test("the insets the host sends are the ones the layout uses", () => {
+  // Inside the app a pack that measured for itself would read zeros and draw its HUD
+  // under the notch believing it was safe.
+  try {
+    setHostInsets(NOTCH)
+    const l = layout(393, 852, 3)
+    assert.equal(l.insets.top, NOTCH.top)
+    assert.ok(l.coins.y >= NOTCH.top, "the strongbox plaque was drawn into the notch")
+  } finally {
+    setHostInsets(null)
+  }
+})

--- a/dynawalla/games/gavel/src/test/lot.test.ts
+++ b/dynawalla/games/gavel/src/test/lot.test.ts
@@ -1,0 +1,425 @@
+// THE ROOM ITSELF: what may be on a board, and what may never be.
+//
+// Four properties, each of which has been a shipped defect in this fleet:
+//
+//   1. **No two rivals bid the same amount.** A tie has no highest, so there is no
+//      right tablet to mark and no right bid to make.
+//   2. **The highest bid is equally likely to be anywhere.** COUNTERPOISE put its
+//      answer in the rightmost slot 97.2% of the time and a bot that always took the
+//      rightmost slot scored 97.2%.
+//   3. **A rung the game cannot draw caps the stream, once, and never un-caps.**
+//      Declining is per-item and the host serves by RUNG, so a rung whose answers do
+//      not fit on a tablet is a soft-lock rather than a degradation.
+//   4. **A duplicate value must NOT cap anything.** That is a fact about a pair of
+//      questions. POLARITY capped on the equivalent item-level refusal and pinned a
+//      whole session to the easiest rung in the product.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Ask, Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Auction } from "../game/auction.ts"
+import { MAX_MARGIN, MIN_MARGIN, PROMPT_MAX_CHARS } from "../game/ladder.ts"
+import { assembleRoom, bestBid, isTrap, tightest, type Tablet } from "../game/lot.ts"
+import { PERFECT, rig, settleOn, stepClock } from "./harness.ts"
+
+const SEEDS = [0x1, 0xbeef, 0x2718, 0x5eed1ce, 0xfeed, 0xd00d]
+
+/** Every room a perfect player is shown over a long sitting. */
+function rooms(seed: number, lots = 60): Array<{ values: number[]; highest: number; offer: number }> {
+  const r = rig(seed)
+  const clock = stepClock()
+  const out: Array<{ values: number[]; highest: number; offer: number }> = []
+  for (let i = 0; i < lots; i++) {
+    const room = r.game.room
+    if (!room) break
+    out.push({
+      values: room.tablets.map((t) => t.value),
+      highest: room.highest,
+      offer: room.offer,
+    })
+    PERFECT.act(r.game, room, undefined as never, clock())
+    settleOn(r.game, clock)
+  }
+  return out
+}
+
+test("no two rivals in a room ever bid the same amount", () => {
+  for (const seed of SEEDS) {
+    for (const room of rooms(seed)) {
+      assert.equal(
+        new Set(room.values).size,
+        room.values.length,
+        `seed ${seed.toString(16)}: a room with a tie for the highest bid: ${room.values.join(", ")}`,
+      )
+      assert.equal(room.highest, Math.max(...room.values))
+      assert.ok(room.values.every((v) => Number.isInteger(v) && v >= 0))
+    }
+  }
+})
+
+test("the highest bid is as likely to be in one position as another", () => {
+  const at = new Map<number, number>()
+  let total = 0
+  for (const seed of SEEDS) {
+    for (const room of rooms(seed, 90)) {
+      const index = room.values.indexOf(room.highest)
+      at.set(index, (at.get(index) ?? 0) + 1)
+      total++
+    }
+  }
+  assert.ok(total > 300, `only ${String(total)} rooms sampled`)
+  // Rooms hold three to five tablets, so the first three positions always exist and
+  // each should hold the highest bid roughly a quarter to a third of the time.
+  for (const index of [0, 1, 2]) {
+    const share = (at.get(index) ?? 0) / total
+    assert.ok(
+      share > 0.12,
+      `the highest bid landed in position ${String(index)} on only ${(share * 100).toFixed(1)}% of ` +
+        `${String(total)} rooms — the position is giving the answer away`,
+    )
+  }
+})
+
+test("the broker's offer stays inside the band, and a trap is exactly an offer nobody can beat", () => {
+  let traps = 0
+  let lots = 0
+  for (const seed of SEEDS) {
+    for (const room of rooms(seed, 120)) {
+      const margin = room.offer - room.highest
+      lots++
+      assert.ok(margin >= 0 && margin <= MAX_MARGIN, `an offer ${String(margin)} above the room`)
+      if (margin <= 1) {
+        traps++
+        assert.equal(isTrap({ tablets: [], highest: room.highest, offer: room.offer }), true)
+        assert.equal(bestBid({ tablets: [], highest: room.highest, offer: room.offer }), null)
+      } else {
+        assert.ok(margin >= MIN_MARGIN)
+        assert.equal(
+          bestBid({ tablets: [], highest: room.highest, offer: room.offer }),
+          room.highest + 1,
+        )
+      }
+    }
+  }
+  assert.ok(traps > 8, `only ${String(traps)} unprofitable lots in ${String(lots)}`)
+  assert.ok(traps / lots < 0.4, "too many lots are not worth bidding on")
+})
+
+test("the values in a room sit close together, so magnitude cannot sort them", () => {
+  // This is the property `tightest` exists for. Without it — keeping whatever the host
+  // happened to serve first — a room spans about three quarters of its own maximum, and
+  // a board holding 9, 40 and 380 can be sorted by which numeral looks biggest without
+  // working any of them out.
+  const spreads: number[] = []
+  for (const seed of SEEDS) {
+    for (const room of rooms(seed, 90)) {
+      const hi = Math.max(...room.values)
+      const lo = Math.min(...room.values)
+      spreads.push((hi - lo) / Math.max(1, hi))
+    }
+  }
+  assert.ok(spreads.length > 300)
+  const mean = spreads.reduce((a, b) => a + b, 0) / spreads.length
+  assert.ok(
+    mean < 0.6,
+    `a room spans ${(mean * 100).toFixed(0)}% of its own highest bid on average — ` +
+      "that is a board a child can sort by eye",
+  )
+})
+
+test("a fresh run never opens with a lot nobody can profit from", () => {
+  // A trap is a lesson about a rule the child has not been taught yet. The bottom of
+  // the ladder is for exposure, so `trapChance` is zero there.
+  for (const seed of [...SEEDS, 0x1414, 0xc0ffee, 0x2, 0x3]) {
+    const first = rooms(seed, 1)[0]
+    assert.ok(first)
+    assert.ok(
+      first.offer - first.highest >= MIN_MARGIN,
+      `seed ${seed.toString(16)} opened on a lot with no profit in it`,
+    )
+  }
+})
+
+test("the assembler keeps the run of values that sit closest together", () => {
+  const pool: Tablet[] = [2, 3, 40, 41, 42, 99].map((value, i) => ({
+    id: `t${String(i)}`,
+    prompt: `p${String(i)}`,
+    value,
+    difficulty: 0,
+  }))
+  const { kept, dropped } = tightest(pool, 3)
+  assert.deepEqual(
+    kept.map((t) => t.value),
+    [40, 41, 42],
+  )
+  assert.deepEqual(
+    dropped.map((t) => t.value).sort((a, b) => a - b),
+    [2, 3, 99],
+  )
+  // Asking for more than there is takes everything rather than failing.
+  assert.equal(tightest(pool, 99).kept.length, pool.length)
+})
+
+/** A host that serves whatever it is told to, and records what it was asked. */
+function scriptedHost(script: () => Question): { host: Host; asks: Ask[]; skips: string[] } {
+  const asks: Ask[] = []
+  const skips: string[] = []
+  const host: Host = {
+    next(ask) {
+      asks.push({ ...(ask ?? {}) })
+      return script()
+    },
+    report() {},
+    skip(id) {
+      skips.push(id)
+    },
+    flush() {},
+    haptic() {},
+    prefersReducedMotion: () => true,
+  }
+  return { host, asks, skips }
+}
+
+test("a rung whose answers cannot go on a tablet caps the stream, and stays capped", () => {
+  let n = 0
+  // Every question is a fraction at the top of the ladder: nothing this game can put
+  // a price on, and a fact about the RUNG rather than about one item.
+  const { host, asks } = scriptedHost(() => {
+    n++
+    return {
+      id: `q${String(n)}`,
+      prompt: "3/4 + 1/4",
+      answer: "1/2",
+      distractors: [],
+      domain: "frac",
+      difficulty: 0.8,
+    }
+  })
+  const game = new Auction(host, new Rng(7), 0)
+  game.begin(0)
+  assert.equal(game.stalled, true, "a whole rung of unusable questions did not stall the gallery")
+  assert.ok(game.ceiling !== null, "the stream was never capped")
+  assert.ok((game.ceiling ?? 1) < 0.8, `the ceiling ${String(game.ceiling)} does not exclude the rung`)
+  const capped = asks.filter((a) => a.maxDifficulty !== undefined)
+  assert.ok(capped.length > 0, "no ask ever carried a ceiling")
+  assert.ok(
+    (capped[0]?.maxDifficulty ?? 0) < 10,
+    "the ceiling was sent as the top of the ladder rather than below the banned rung",
+  )
+  // Monotone: a second, higher undrawable rung must not raise it.
+  const before = game.ceiling
+  game.begin(0)
+  assert.equal(game.ceiling, before)
+})
+
+test("a duplicate value is a fact about two questions and must never cap a rung", () => {
+  // The POLARITY defect, in this game's shape. Every question here is perfectly
+  // drawable; they simply collide, which the assembler resolves by drawing again.
+  let n = 0
+  const { host, asks } = scriptedHost(() => {
+    n++
+    // Two distinct values, so a board of three can never be filled — every draw after
+    // the second is a collision.
+    return {
+      id: `q${String(n)}`,
+      prompt: n % 2 === 0 ? "4 + 3" : "5 + 5",
+      answer: n % 2 === 0 ? "7" : "10",
+      distractors: [],
+      domain: "add",
+      difficulty: 0.5,
+    }
+  })
+  const game = new Auction(host, new Rng(11), 0)
+  game.begin(0)
+  assert.equal(game.ceiling, null, "a value collision capped the stream")
+  assert.equal(asks.every((a) => a.maxDifficulty === undefined), true)
+  // Two usable values is a room: smaller than asked for, and still a comparison.
+  assert.equal(game.stalled, false)
+  assert.equal(game.room?.tablets.length, 2)
+})
+
+test("the shared host's dry-pool sentinel describes no rung and caps nothing", () => {
+  // `game-host` answers an empty pool with `{ id: "", answer: "0", … }`. It parses and
+  // it prints, so nothing here should refuse it — but if a future sentinel does not,
+  // capping on it would pin the run at the easiest rung in the product for the rest of
+  // the session, silently, and it would look like adaptation.
+  const { host } = scriptedHost(() => ({
+    id: "",
+    prompt: "",
+    answer: "0",
+    distractors: [],
+    domain: "arith",
+    difficulty: 0,
+  }))
+  const game = new Auction(host, new Rng(13), 0)
+  game.begin(0)
+  assert.equal(game.ceiling, null, "the dry-pool sentinel capped the stream")
+
+  // …and the same for a sentinel whose answer does NOT parse, which is what makes the
+  // `id === ""` guard load-bearing rather than decorative. Today's sentinel answers
+  // "0", which prints, so the printability check alone refuses to cap on it; the
+  // sentinel belongs to the host and the next one may not print, and capping on it
+  // would pin the run to the easiest rung in the product for the rest of the session,
+  // silently, and it would look like adaptation.
+  const future = scriptedHost(() => ({
+    id: "",
+    prompt: "",
+    answer: "",
+    distractors: [],
+    domain: "arith",
+    difficulty: 0.7,
+  }))
+  const later = new Auction(future.host, new Rng(13), 0)
+  later.begin(0)
+  assert.equal(later.ceiling, null, "a sentinel that does not parse capped a rung it does not describe")
+})
+
+test("a prompt too wide for a tablet is refused rather than printed off the edge", () => {
+  const wide = "1".repeat(PROMPT_MAX_CHARS + 1)
+  const { host } = scriptedHost(() => ({
+    id: "wide",
+    prompt: `${wide} + 1`,
+    answer: "12",
+    distractors: [],
+    domain: "add",
+    difficulty: 0.6,
+  }))
+  const game = new Auction(host, new Rng(17), 0)
+  game.begin(0)
+  assert.equal(game.stalled, true)
+  assert.ok(game.ceiling !== null, "an unprintable prompt did not cap its rung")
+})
+
+test("a question the assembler cannot use at all is closed at once", () => {
+  // Two usable values and a stream of unusable ones. The unusable ones must be closed
+  // on the spot: they can never join a board or a bench, so holding them would leak.
+  let n = 0
+  const { host, skips } = scriptedHost(() => {
+    n++
+    if (n % 3 === 0) {
+      return { id: `bad${String(n)}`, prompt: "1/2 + 1/2", answer: "1", distractors: [], domain: "frac", difficulty: 0.1 }
+    }
+    return {
+      id: `q${String(n)}`,
+      prompt: `${String(n)} + 1`,
+      answer: String(n + 1),
+      distractors: [],
+      domain: "add",
+      difficulty: 0.1,
+    }
+  })
+  const game = new Auction(host, new Rng(19), 0)
+  game.begin(0)
+  const used = new Set(game.room?.tablets.map((t) => t.id) ?? [])
+  assert.ok(used.size >= 3)
+  assert.equal(
+    skips.filter((id) => used.has(id)).length,
+    0,
+    "a question standing on the board was closed",
+  )
+})
+
+test("a question the room passed over waits on the bench and can come up later", () => {
+  // The bench is what buys a wide choice without drawing ten fresh questions a lot. A
+  // benched question has never been shown, so a later board may use it — and because a
+  // tablet that reaches a board is always answered or skipped when that board settles,
+  // nothing benched can ever be reported twice.
+  const r = rig(0x2718)
+  const clock = stepClock()
+  const seenIds = new Set<string>()
+  let reused = 0
+  for (let i = 0; i < 30; i++) {
+    const room = r.game.room
+    if (!room) break
+    for (const t of room.tablets) {
+      if (seenIds.has(t.id)) reused++
+      seenIds.add(t.id)
+    }
+    PERFECT.act(r.game, room, undefined as never, clock())
+    settleOn(r.game, clock)
+  }
+  assert.equal(reused, 0, "a question that had already been on a board came back")
+  // Nothing is answered twice and nothing is both answered and closed.
+  assert.equal(new Set(r.reports.map((x) => x.questionId)).size, r.reports.length)
+  assert.equal(new Set(r.skips).size, r.skips.length)
+  assert.equal(r.skips.filter((id) => r.reports.some((x) => x.questionId === id)).length, 0)
+})
+
+test("the bench is a buffer and not a hoard: the overflow is closed, oldest first", () => {
+  // A stream of values the tightest window keeps passing over, so the bench fills.
+  let n = 0
+  const { host, skips } = scriptedHost(() => {
+    n++
+    // Alternating tight cluster and far outliers: the outliers are usable, are never
+    // wanted, and would sit on the bench for the whole session without the cap.
+    const value = n % 2 === 0 ? 100 + n : 5000 - n * 7
+    return {
+      id: `q${String(n)}`,
+      prompt: `${String(value)} + 0`,
+      answer: String(value),
+      distractors: [],
+      domain: "add",
+      difficulty: 0.1,
+    }
+  })
+  const game = new Auction(host, new Rng(29), 0)
+  game.begin(0)
+  const clock = stepClock()
+  for (let i = 0; i < 20; i++) {
+    const room = game.room
+    if (!room) break
+    game.tapTablet(0)
+    const t = room.tablets[0]
+    if (!t) break
+    for (const ch of String(t.value + 1)) game.pressDigit(Number(ch))
+    game.hammer(clock())
+    game.nudge()
+    game.advance(1, clock())
+  }
+  assert.ok(skips.length > 0, "the bench grew without bound — nothing was ever closed")
+  assert.equal(new Set(skips).size, skips.length, "a question was closed twice")
+})
+
+test("a room is assembled from the host and never from a constant", () => {
+  // "In all games, we want random generation and surprise ... we basically don't ever
+  // want that." Two different seeds must not produce the same opening room, and the
+  // same seed must reproduce it exactly.
+  const a = rooms(0x1, 3)
+  const b = rooms(0xbeef, 3)
+  const again = rooms(0x1, 3)
+  assert.deepEqual(again, a, "the same seed did not reproduce the same rooms")
+  assert.notDeepEqual(b, a, "two different seeds produced the same auction")
+})
+
+test("assembleRoom asks through the caller's closure on every single draw", () => {
+  // The ceiling has to reach the wire mid-board, not one board later: a rung that
+  // cannot be drawn is discovered on the second tablet and the third must not be
+  // asked for at the same difficulty.
+  const seen: number[] = []
+  let want = 0.9
+  const assembly = assembleRoom(
+    () => {
+      seen.push(want)
+      want -= 0.1
+      return {
+        id: `q${String(seen.length)}`,
+        prompt: `${String(seen.length)} + 2`,
+        answer: String(seen.length + 2),
+        distractors: [],
+        domain: "add",
+        difficulty: 0.2,
+      }
+    },
+    3,
+    0.2,
+    new Rng(23),
+    () => {
+      throw new Error("nothing here is undrawable")
+    },
+  )
+  assert.ok(assembly.room)
+  assert.ok(seen.length >= 3)
+  assert.notEqual(seen[0], seen[1], "the closure was read once and cached")
+})

--- a/dynawalla/games/gavel/src/test/manual-freeze.test.ts
+++ b/dynawalla/games/gavel/src/test/manual-freeze.test.ts
@@ -1,0 +1,440 @@
+// THE GALLERY HOLDS STILL WHILE THE RULES ARE READ.
+//
+// "All games should pause while reading the instructions .. I can hear counterweight
+// playing in the background while I'm reading the instructions ... stressing me out
+// even more."
+//
+// The shared how-to-play sheet holds the sound, the keys and the taps by itself. What
+// it cannot hold is a game's own clock, and it cannot know that a game exists — so
+// `onOpen`/`onClose` are the one part of pausing a game has to opt into, and eleven of
+// the twenty-seven shipped games had not.
+//
+// **Why this file exists when the sim's own pause is already tested.**
+// `report.test.ts` tests `Auction.pause` in isolation, and `Auction` was never the
+// thing that broke: the defect is in the *wiring* — whether the manual's `onOpen` ever
+// reaches it. So this is a mount-level test, and it is the only test in the package
+// that runs the real `mount`.
+//
+// **How the freeze is observed.** THE GAVEL keeps DRAWING while it is paused — a
+// frozen frame under a translucent host sheet is what a paused pack should look like —
+// so a frozen draw *count* would prove nothing. What is asserted instead is that the
+// frames are IDENTICAL: every call and every argument the renderer makes, recorded and
+// compared.
+//
+// The moment chosen is the reveal after the hammer, because that is the only thing in
+// this game that moves on its own: the tablets turn over, the coin counter walks up to
+// its new total, and when the hold expires the next lot is drawn. A child who opens the
+// rules to find out why a lot did not sell must not come back to a different room.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import type { Host } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+import { layout } from "../render/layout.ts"
+import { MIN_TABLETS } from "../game/ladder.ts"
+
+type Handler = (event: unknown) => void
+
+type FakeElement = {
+  className: string
+  id: string
+  /**
+   * PER ELEMENT. Both the shared module's help control and its close button register a
+   * `"click"` listener, so a harness with one map keyed by event type silently drops
+   * the first of the two and makes this test unwritable.
+   */
+  listeners: Map<string, Handler[]>
+  style: Record<string, string>
+  [key: string]: unknown
+}
+
+/**
+ * A 2D context that writes down exactly what it was asked to draw.
+ *
+ * Two frames are the same frame if and only if these transcripts are equal, which is a
+ * far stronger statement than a call count and the only one worth making about a game
+ * that keeps painting while it is stopped.
+ */
+function recorder(frame: string[]): CanvasRenderingContext2D {
+  const store = new Map<string, unknown>()
+  const measured = { width: 40 }
+  return new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (store.has(prop)) return store.get(prop)
+        return (...args: unknown[]) => {
+          frame.push(`${prop}(${args.map(String).join(",")})`)
+          return measured
+        }
+      },
+      set(_t, prop: string, value: unknown) {
+        frame.push(`${prop}=${String(value)}`)
+        store.set(prop, value)
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+}
+
+type Rig = {
+  el: HTMLElement
+  created: FakeElement[]
+  frame: string[]
+  /** Advance the clock by `ms` and run the frame the game asked for. */
+  step(ms: number): void
+  /** A pointerdown at canvas coordinates. */
+  tap(x: number, y: number): void
+  restore(): void
+}
+
+function install(width: number, height: number): Rig {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const frame: string[] = []
+  const ctx = recorder(frame)
+  const created: FakeElement[] = []
+
+  const makeEl = (): FakeElement => {
+    const listeners = new Map<string, Handler[]>()
+    const el: FakeElement = {
+      className: "",
+      id: "",
+      listeners,
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      type: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      appendChild: () => undefined,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      addEventListener: (k: string, h: Handler) => {
+        listeners.set(k, [...(listeners.get(k) ?? []), h])
+      },
+      removeEventListener: (k: string, h: Handler) => {
+        listeners.set(
+          k,
+          (listeners.get(k) ?? []).filter((f) => f !== h),
+        )
+      },
+    }
+    return el
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    key: globalThis.addEventListener,
+    unkey: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    dateNow: Date.now,
+  }
+
+  const globals = new Map<string, Handler[]>()
+  globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+    pending = cb
+    return 1
+  }) as typeof globalThis.requestAnimationFrame
+  globalThis.cancelAnimationFrame = ((): void => {
+    pending = null
+  }) as typeof globalThis.cancelAnimationFrame
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {}
+    disconnect(): void {}
+  }
+  performance.now = () => clock
+  // The run is seeded from the wall clock, which is right on a device and fatal in a
+  // test. Pinned, so a green run is green every time.
+  Date.now = () => 0x9a7e1
+  ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+  globalThis.addEventListener = ((k: string, h: Handler): void => {
+    globals.set(k, [...(globals.get(k) ?? []), h])
+  }) as unknown as typeof globalThis.addEventListener
+  globalThis.removeEventListener = ((k: string, h: Handler): void => {
+    globals.set(
+      k,
+      (globals.get(k) ?? []).filter((f) => f !== h),
+    )
+  }) as unknown as typeof globalThis.removeEventListener
+  ;(globalThis as { document?: unknown }).document = {
+    createElement: () => {
+      const el = makeEl()
+      created.push(el)
+      return el
+    },
+    getElementById: (id: string) => created.find((el) => el.id === id) ?? null,
+    body: makeEl(),
+  }
+
+  const rig: Rig = {
+    el: makeEl() as unknown as HTMLElement,
+    created,
+    frame,
+    step: (ms: number) => {
+      clock += ms
+      const cb = pending
+      pending = null
+      frame.length = 0
+      cb?.(clock)
+    },
+    tap: (x: number, y: number) => {
+      // The canvas is the first element the game creates, and the only one it binds a
+      // pointerdown to.
+      const canvas = created.find((el) => el.listeners.has("pointerdown"))
+      assert.ok(canvas, "the game never bound a pointerdown")
+      const handler = canvas.listeners.get("pointerdown")?.[0]
+      assert.ok(handler)
+      handler({ clientX: x, clientY: y, preventDefault: () => undefined })
+    },
+    restore: () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      globalThis.addEventListener = saved.key
+      globalThis.removeEventListener = saved.unkey
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      Date.now = saved.dateNow
+    },
+  }
+  return rig
+}
+
+/** The shared module's own controls, found the way a child's finger finds them. */
+function control(created: FakeElement[], className: string): () => void {
+  const el = created.find((e) => e.className === className)
+  assert.ok(el, `the shared chrome never mounted a .${className}`)
+  const click = el.listeners.get("click")?.[0]
+  assert.ok(click, `.${className} was mounted with no click handler`)
+  return () => {
+    click({ type: "click", target: el })
+  }
+}
+
+type World = {
+  /** Questions the game asked the host for. A frozen gallery asks for none. */
+  asked: number
+  reports: Array<{ ms: number; correct: boolean; answered: string }>
+  skips: string[]
+  haptics: string[]
+}
+
+function stub(world: World): Host {
+  const base = createStubHost({ seed: 0x9a7e1, reducedMotion: false })
+  return {
+    ...base,
+    next: (ask) => {
+      world.asked++
+      return base.next(ask)
+    },
+    report: (r) => {
+      world.reports.push(r)
+    },
+    skip: (id) => {
+      world.skips.push(id)
+    },
+    haptic: (k) => {
+      world.haptics.push(k)
+    },
+  }
+}
+
+const W = 768
+const H = 1024
+
+function pump(rig: Rig, frames: number): void {
+  for (let i = 0; i < frames; i++) rig.step(16)
+}
+
+/** Where a key and a tablet are, from the real layout rather than a guess. */
+function points() {
+  const l = layout(W, H, MIN_TABLETS)
+  const key = (id: string) => {
+    const k = l.keys.find((entry) => entry.id === id)
+    assert.ok(k, `no ${id} key`)
+    return { x: k.rect.x + k.rect.w / 2, y: k.rect.y + k.rect.h / 2 }
+  }
+  const first = l.tablets[0]
+  assert.ok(first)
+  return {
+    tablet: { x: first.x + first.w / 2, y: first.y + first.h / 2 },
+    one: key("d1"),
+    two: key("d2"),
+    gavel: key("gavel"),
+  }
+}
+
+test("a lot can be marked, bid on and hammered through the real mount", () => {
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], skips: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 3)
+    const p = points()
+    rig.tap(p.tablet.x, p.tablet.y)
+    assert.ok(world.haptics.includes("light"), "marking a tablet fired no haptic")
+    rig.tap(p.one.x, p.one.y)
+    rig.tap(p.two.x, p.two.y)
+    rig.tap(p.gavel.x, p.gavel.y)
+    assert.equal(world.reports.length, 1, "the hammer reported nothing")
+    assert.equal(world.reports[0]?.answered, "11", "a bid of 12 asserts the tablet is worth 11")
+    assert.ok(world.skips.length > 0, "the tablets the child did not answer were left open")
+    // A bid of 12 will usually be under the room, and being outbid must not feel like a
+    // buzzer. There is no `failure` haptic anywhere in this pack: a lot that got away is
+    // a "medium" thud, the same weight as stone arriving in COLOSSUS.
+    assert.equal(
+      world.haptics.includes("failure"),
+      false,
+      "a losing lot fired the failure haptic — this pack has no buzzer",
+    )
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("the settled room actually draws what the rivals were bidding", () => {
+  // The reveal is the teaching moment: every tablet turns over and the highest is
+  // ringed, so a child who marked the wrong one sees the number they should have read.
+  // Asserted off the renderer's own transcript, because a reveal that draws nothing
+  // fails no other test in this package — POLARITY shipped four blank glowing discs.
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], skips: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 3)
+    const p = points()
+    rig.tap(p.tablet.x, p.tablet.y)
+    rig.tap(p.one.x, p.one.y)
+    rig.tap(p.two.x, p.two.y)
+    rig.tap(p.gavel.x, p.gavel.y)
+    // Far enough into the reveal that the values have faded in.
+    pump(rig, 30)
+    const drawn = rig.frame.filter((call) => call.startsWith("fillText("))
+    assert.ok(drawn.length > 6, "the settled room drew almost nothing")
+    // The verdict line is there, in words a child can read.
+    assert.ok(
+      drawn.some((call) => /OUTBID|SOLD|KEEN|NOBODY WILL BUY|NOTHING IN IT/.test(call)),
+      `the settled room drew no verdict: ${drawn.join(" | ")}`,
+    )
+    // Three tablets, each with a numeral under its sum. Every value is a whole number,
+    // so every one of them is a plain integer in the transcript.
+    const numerals = drawn.filter((call) => /^fillText\(\d+,/.test(call))
+    assert.ok(
+      numerals.length >= 3,
+      `only ${String(numerals.length)} rival bids were printed: ${drawn.join(" | ")}`,
+    )
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("MANUAL FREEZES THE GALLERY: the same frame, over and over, until it closes", () => {
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], skips: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 3)
+    const p = points()
+    // Settle a lot, so the reveal is running: the tablets are turning over and the coin
+    // counter is walking. This is the only thing in THE GAVEL that moves on its own,
+    // and it is exactly the moment a child reaches for the rules.
+    rig.tap(p.tablet.x, p.tablet.y)
+    rig.tap(p.one.x, p.one.y)
+    rig.tap(p.two.x, p.two.y)
+    rig.tap(p.gavel.x, p.gavel.y)
+
+    pump(rig, 2)
+    const moving = [...rig.frame]
+    pump(rig, 1)
+    assert.notDeepEqual(rig.frame, moving, "the gallery was already frozen before the manual opened")
+
+    const open = control(rig.created, "dwc-help")
+    const close = control(rig.created, "dwc-close")
+    open()
+
+    pump(rig, 1)
+    const held = [...rig.frame]
+    assert.ok(held.length > 100, "the frame behind the sheet drew nothing at all")
+    const asked = world.asked
+    const reports = world.reports.length
+    for (let i = 0; i < 10_000; i++) {
+      rig.step(16)
+      if (i % 2000 === 0) {
+        assert.deepEqual(rig.frame, held, `the gallery moved ${String(i)} frames into the read`)
+      }
+    }
+    assert.deepEqual(rig.frame, held, "the gallery moved while the rules were up")
+    assert.equal(world.asked, asked, "a question was served behind the manual")
+
+    // …and a touch behind the scrim is not a touch. The sheet swallows pointer events
+    // itself, but a game that took them anyway would drop the hammer on a room nobody
+    // was looking at.
+    rig.tap(p.gavel.x, p.gavel.y)
+    rig.tap(p.tablet.x, p.tablet.y)
+    assert.equal(world.reports.length, reports, "the hammer fell behind the manual")
+
+    close()
+    pump(rig, 2)
+    assert.notDeepEqual(rig.frame, held, "the gallery never came back after the manual closed")
+    // The reveal it was holding finished, and the next lot came to the block. At the
+    // bottom of the ladder the hold is the full patient reveal — four and a bit seconds
+    // of a settled room, which is the point of it — so this takes a while on purpose.
+    pump(rig, 400)
+    assert.ok(world.asked > asked, "no new lot was ever called")
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+test("the host's own pause does the same thing, and resuming does not skip the reveal", () => {
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], skips: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 3)
+    const p = points()
+    rig.tap(p.tablet.x, p.tablet.y)
+    rig.tap(p.one.x, p.one.y)
+    rig.tap(p.gavel.x, p.gavel.y)
+    pump(rig, 2)
+
+    handle.pause()
+    pump(rig, 1)
+    const held = [...rig.frame]
+    const asked = world.asked
+    pump(rig, 600)
+    assert.deepEqual(rig.frame, held, "the gallery ran on behind the host's sheet")
+    assert.equal(world.asked, asked)
+
+    handle.resume()
+    // The first frame back must not be ten seconds of reveal in one step: `last` is
+    // forgotten across a pause, so the delta is a single frame.
+    rig.step(16)
+    assert.notDeepEqual(rig.frame, held)
+    assert.equal(world.asked, asked, "resuming skipped straight past the settled room")
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})

--- a/dynawalla/games/gavel/src/test/report.test.ts
+++ b/dynawalla/games/gavel/src/test/report.test.ts
@@ -1,0 +1,201 @@
+// WHAT THE HOST IS TOLD, AND WHAT IT IS NOT.
+//
+// Two games shipped reporting a derived value and marked correct children wrong:
+// TREBUCHET added an ungraded crosswind to every question so a child who computed
+// `47 + 25 = 72` and dialled 72 was reported WRONG with probability up to 8/9, and
+// POLARITY reported `String(core)` after clamping, so perfect play was recorded as a
+// miss. Both of those verdicts went to the curriculum.
+//
+// THE GAVEL reports `bid − 1` against the tablet the child marked, so this file
+// exists to hold the one property that makes that honest:
+//
+//   **a child who works out the tablet they marked and bids one over it is NEVER
+//   reported as wrong — whatever the money did.**
+//
+// That is what separates the arithmetic from the pricing. Marking the wrong tablet
+// loses the lot; padding the bid buys a thing nobody wants; folding earns a coin or
+// nothing. None of those three is a fact about whether the child can add, and the
+// only one of them the host hears about is the one that is.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { isTrap } from "../game/lot.ts"
+import { PERFECT, rig, settleOn, stepClock, typeBid } from "./harness.ts"
+
+const SEEDS = [0x1, 0xbeef, 0x2718, 0x5eed1ce, 0xfeed, 0xd00d]
+
+test("one over the tablet you marked is always reported correct, whatever the money did", () => {
+  for (const seed of SEEDS) {
+    const r = rig(seed)
+    const clock = stepClock()
+    // Deliberately perverse: mark whichever tablet is NOT the highest wherever there
+    // is a choice, then bid one over it. Every one of these loses the lot, and every
+    // one of them is correct arithmetic.
+    for (let i = 0; i < 40; i++) {
+      const room = r.game.room
+      if (!room) break
+      let at = room.tablets.findIndex((t) => t.value !== room.highest)
+      if (at < 0) at = 0
+      const tablet = room.tablets[at]
+      if (!tablet) break
+      r.game.tapTablet(at)
+      typeBid(r.game, tablet.value + 1)
+      r.game.hammer(clock())
+      settleOn(r.game, clock)
+    }
+    assert.ok(r.reports.length > 20, `seed ${seed.toString(16)}: only ${String(r.reports.length)} reports`)
+    const wrong = r.reports.filter((report) => !report.correct)
+    assert.deepEqual(
+      wrong,
+      [],
+      `seed ${seed.toString(16)}: ${String(wrong.length)} reports of correct arithmetic as wrong — ` +
+        `first was ${JSON.stringify(wrong[0])}`,
+    )
+    // …and the game still said no. The comparison is graded by the auction, not by
+    // the curriculum.
+    assert.ok(r.game.tally.outbid > 0, "marking a lower tablet somehow won lots")
+  }
+})
+
+test("what crosses the wire is the value the bid asserts, and nothing else", () => {
+  const r = rig(0x2718)
+  const clock = stepClock()
+  const room = r.game.room
+  assert.ok(room)
+  r.game.tapTablet(0)
+  const marked = room.tablets[0]
+  assert.ok(marked)
+  typeBid(r.game, 77)
+  r.game.hammer(clock())
+  assert.equal(r.reports.length, 1, "a round reported more than one answer")
+  assert.equal(r.reports[0]?.questionId, marked.id)
+  assert.equal(
+    r.reports[0]?.answered,
+    "76",
+    "bidding 77 while beating a tablet asserts that the tablet is worth 76",
+  )
+  assert.equal(r.reports[0]?.correct, marked.value === 76)
+})
+
+test("every tablet the child read and did not answer is skipped, never filed as wrong", () => {
+  // The defect this replaces: `report({ correct: false, answered: "" })` for a
+  // question nobody answered. The empty string does not parse, so the learner model
+  // takes a WRONG attempt and the ladder steps down — four times a round, here.
+  for (const seed of SEEDS) {
+    const r = rig(seed)
+    const clock = stepClock()
+    const rooms: number[] = []
+    for (let i = 0; i < 20; i++) {
+      const room = r.game.room
+      if (!room) break
+      rooms.push(room.tablets.length)
+      PERFECT.act(r.game, room, undefined as never, clock())
+      settleOn(r.game, clock)
+    }
+    const answered = r.reports.length
+    const closed = r.skips.length
+    assert.ok(answered > 0)
+    // A folded lot answers none of its tablets and skips all of them, so the totals
+    // are "every tablet ever raised" minus "the ones answered".
+    const raised = rooms.reduce((a, b) => a + b, 0)
+    assert.ok(
+      closed >= raised - answered,
+      `${String(raised)} tablets went up, ${String(answered)} were answered and only ` +
+        `${String(closed)} were closed — the rest are open in the host's ledger`,
+    )
+    assert.equal(new Set(r.skips).size, r.skips.length, "a question was skipped twice")
+    assert.equal(
+      r.skips.filter((id) => r.reports.some((report) => report.questionId === id)).length,
+      0,
+      "a question was both answered and skipped",
+    )
+  }
+})
+
+test("a fold reports nothing at all", () => {
+  const r = rig(0xbeef)
+  const clock = stepClock()
+  for (let i = 0; i < 12; i++) {
+    if (!r.game.room) break
+    r.game.fold()
+    settleOn(r.game, clock)
+  }
+  assert.equal(r.reports.length, 0)
+  assert.ok(r.skips.length >= 12 * 3, "a folded room left its tablets open")
+})
+
+test("an unarmed hammer is not an assertion: no mark, or no bid, reports nothing", () => {
+  const r = rig(0x1414)
+  assert.ok(r.game.room)
+  // The board assembler draws a few spare questions and closes the ones it does not
+  // use, so the skip ledger is not empty before the child has touched anything.
+  const closedByAssembly = r.skips.length
+  // No mark.
+  typeBid(r.game, 12)
+  assert.equal(r.game.armed, false)
+  assert.deepEqual(r.game.hammer(1000), [])
+  // A mark and no bid.
+  while (r.game.digits !== "") r.game.backspace()
+  r.game.tapTablet(0)
+  assert.equal(r.game.armed, false)
+  assert.deepEqual(r.game.hammer(1000), [])
+  assert.equal(r.reports.length, 0)
+  assert.equal(r.skips.length, closedByAssembly, "an unarmed hammer closed the room's questions")
+  // Both, and now it fires.
+  typeBid(r.game, 5)
+  assert.equal(r.game.armed, true)
+  assert.equal(r.game.hammer(1000).length, 1)
+})
+
+test("the latency reported is thinking time, with any sheet the host raised taken out", () => {
+  const r = rig(0x777)
+  r.game.tapTablet(0)
+  typeBid(r.game, 9)
+  // The lot came to the block at t = 0. A sheet goes up at 1 s and comes off at 61 s,
+  // and the child answers at 63 s: two seconds of looking at the room, not
+  // sixty-three.
+  r.game.pause(1_000)
+  r.game.resume(61_000)
+  r.game.hammer(63_000)
+  assert.equal(r.reports.length, 1)
+  assert.equal(r.reports[0]?.ms, 3_000)
+})
+
+test("nothing the child does behind a sheet is a thing the child did", () => {
+  const r = rig(0xd00d)
+  const closedByAssembly = r.skips.length
+  r.game.pause(500)
+  r.game.tapTablet(0)
+  typeBid(r.game, 40)
+  assert.equal(r.game.marked, null, "a tablet was marked behind the sheet")
+  assert.equal(r.game.digits, "", "digits reached the paddle behind the sheet")
+  assert.deepEqual(r.game.hammer(900), [])
+  assert.deepEqual(r.game.fold(), [])
+  assert.equal(r.reports.length, 0)
+  assert.equal(r.skips.length, closedByAssembly)
+})
+
+test("a lot nobody can profit from is a real state, and folding it is what pays", () => {
+  // Reached by playing perfectly for long enough that the ladder is high enough for
+  // the broker to start making offers that are not worth chasing.
+  const r = rig(0x5eed1ce)
+  const clock = stepClock()
+  let traps = 0
+  let scoutFees = 0
+  for (let i = 0; i < 120; i++) {
+    const room = r.game.room
+    if (!room) break
+    if (isTrap(room)) {
+      traps++
+      const before = r.game.coins
+      r.game.fold()
+      scoutFees += r.game.coins - before
+    } else {
+      PERFECT.act(r.game, room, undefined as never, clock())
+    }
+    settleOn(r.game, clock)
+  }
+  assert.ok(traps > 4, `only ${String(traps)} unprofitable lots in 120 — the trap never fires`)
+  assert.equal(scoutFees, traps, "spotting an unprofitable lot did not pay the scout's fee")
+})

--- a/dynawalla/games/gavel/src/test/stubHost.test.ts
+++ b/dynawalla/games/gavel/src/test/stubHost.test.ts
@@ -1,0 +1,122 @@
+// The dev harness's host has to lie about nothing, or the harness hides defects
+// instead of finding them.
+//
+// Four properties, each matching something the real runtime does:
+//
+//   1. exact integer arithmetic, everywhere;
+//   2. seeded and deterministic;
+//   3. both difficulty scales read the way `packs/shared/game-host` reads them, and
+//      `maxDifficulty` honoured as a ceiling;
+//   4. distractors that are real mal-rule outputs rather than `answer ± 1` noise.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost, toUnit } from "../stubHost.ts"
+
+const SEEDS = [0x1, 0xbeef, 0x2718, 0x5eed1ce]
+
+test("every operand, answer and distractor is an exact integer", () => {
+  for (const seed of SEEDS) {
+    const host = createStubHost({ seed })
+    for (let i = 0; i < 400; i++) {
+      const q = host.next({ difficulty: 1 + (i % 10) })
+      const parts = q.prompt.split(/\s+/)
+      assert.equal(parts.length, 3, `a prompt that is not "a op b": ${q.prompt}`)
+      for (const side of [parts[0], parts[2]]) {
+        assert.match(side ?? "", /^\d+$/, `a non-integer operand in ${q.prompt}`)
+      }
+      assert.match(parts[1] ?? "", /^[+−×]$/, `an unknown operator in ${q.prompt}`)
+      assert.match(q.answer, /^\d+$/, `a non-integer answer: ${q.answer}`)
+      const [a, op, b] = parts as [string, string, string]
+      const expected =
+        op === "+" ? Number(a) + Number(b) : op === "−" ? Number(a) - Number(b) : Number(a) * Number(b)
+      assert.equal(Number(q.answer), expected, `${q.prompt} was answered ${q.answer}`)
+      for (const d of q.distractors) {
+        assert.match(d, /^\d+$/)
+        assert.notEqual(d, q.answer, "a distractor equal to the answer")
+      }
+      assert.equal(new Set(q.distractors).size, q.distractors.length)
+    }
+  }
+})
+
+test("the same seed serves the same stream, forever", () => {
+  const stream = (seed: number) => {
+    const host = createStubHost({ seed })
+    return Array.from({ length: 60 }, (_, i) => host.next({ difficulty: 1 + (i % 10) })).map(
+      (q) => `${q.prompt}=${q.answer}@${q.difficulty.toFixed(3)}`,
+    )
+  }
+  assert.deepEqual(stream(0x2718), stream(0x2718))
+  assert.notDeepEqual(stream(0x2718), stream(0xbeef))
+})
+
+test("the two difficulty scales are read the way the real host reads them", () => {
+  // Under 1 is a fraction; 1..10 is a ladder index; exactly 1 is the BOTTOM, which is
+  // the one value the two scales disagree about.
+  assert.equal(toUnit(0), 0)
+  assert.equal(toUnit(0.5), 0.5)
+  assert.equal(toUnit(1), 0)
+  assert.equal(toUnit(10), 1)
+  assert.equal(toUnit(40), 1)
+  assert.equal(toUnit(Number.NaN), null)
+  assert.equal(toUnit(undefined), null)
+})
+
+test("a ceiling is a ceiling: the stream never goes above it again", () => {
+  const host = createStubHost({ seed: 0x1 })
+  for (let i = 0; i < 20; i++) host.next({ difficulty: 10 })
+  const above = host.next({ difficulty: 10 })
+  assert.ok(above.difficulty > 0.9)
+  // Ask for the top with a ceiling in the middle, and keep asking for the top.
+  const capped = host.next({ difficulty: 10, maxDifficulty: 1 + 0.4 * 9 })
+  assert.ok(capped.difficulty <= 0.4 + 1e-9, `served ${String(capped.difficulty)} under a 0.4 ceiling`)
+  for (let i = 0; i < 40; i++) {
+    assert.ok(host.next({ difficulty: 10 }).difficulty <= 0.4 + 1e-9, "the ceiling was forgotten")
+  }
+})
+
+test("harder rungs really are harder, and the easiest rung is single digits", () => {
+  const host = createStubHost({ seed: 0x2718 })
+  const spread = (ladder: number) => {
+    let total = 0
+    for (let i = 0; i < 200; i++) total += Number(host.next({ difficulty: ladder }).answer)
+    return total / 200
+  }
+  const easy = spread(1)
+  const hard = spread(10)
+  assert.ok(hard > easy * 4, `the top of the ladder averages ${hard.toFixed(0)} against ${easy.toFixed(0)}`)
+  assert.ok(easy < 40, `the easiest rung averages ${easy.toFixed(0)} — that is not where a child starts`)
+})
+
+test("a distractor is a mistake a child makes, not noise around the answer", () => {
+  // Not a strong claim about every value — it is a stub — but a stub whose distractors
+  // were all `answer ± 1` would make any test of a board's confusability meaningless.
+  const host = createStubHost({ seed: 0x5eed1ce })
+  let near = 0
+  let total = 0
+  for (let i = 0; i < 300; i++) {
+    const q = host.next({ difficulty: 6 })
+    for (const d of q.distractors) {
+      total++
+      if (Math.abs(Number(d) - Number(q.answer)) <= 2) near++
+    }
+  }
+  assert.ok(total > 600)
+  assert.ok(near / total < 0.5, `${((100 * near) / total).toFixed(0)}% of distractors are answer ± 2`)
+})
+
+test("skip and transition are wired, because the game calls both", () => {
+  const skips: string[] = []
+  const transitions: string[] = []
+  const host = createStubHost({
+    seed: 1,
+    onSkip: (id) => skips.push(id),
+    onTransition: (kind) => transitions.push(kind),
+  })
+  host.skip?.("stub-1")
+  host.transition?.("level", "consignment 1")
+  assert.deepEqual(skips, ["stub-1"])
+  assert.deepEqual(transitions, ["level"])
+})

--- a/dynawalla/games/gavel/tsconfig.json
+++ b/dynawalla/games/gavel/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/gavel/vite.config.ts
+++ b/dynawalla/games/gavel/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4362, host: "127.0.0.1", strictPort: true },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameGavel",
+      formats: ["es"],
+      fileName: () => "gavel.js",
+    },
+  },
+})

--- a/dynawalla/games/gavel/vite.pack.config.ts
+++ b/dynawalla/games/gavel/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own; a
+    // bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## THE GAVEL

An auction in the Dynawalla Bazaar. A lot stands on the block; along the gallery three to five rivals hold up **tablets carrying sums rather than prices** — `12 + 5`, `3 × 5`, `8 × 1`, `15 − 2`. Above the block hangs the broker's standing offer: what the guild will pay for the lot the moment it is yours.

Mark the tablet you mean to beat, set a bid, drop the hammer. Bid one coin over the highest in the room and the lot is yours for the smallest money the room allows; hand it to the broker and keep the difference.

```
bid ≤ highest          OUTBID   a rival takes it
highest < bid < offer  SOLD     coins = offer − bid
bid = highest + 1      KEEN     …and the guild pays double
bid = offer            EVEN     it sells; there is nothing in it
bid > offer            UNSOLD   you own a thing nobody will buy
FOLD                            always safe; pays a coin on a lot nobody can profit from
```

This is the founder's mechanic, built as he described it, and it is not among the 234 designs in the arcade canon.

### How each of the four maths steps is made necessary

| step | what makes it unskippable | the bot that proves it |
|---|---|---|
| **evaluate several expressions** | the paddle takes a typed number, so a value has to be *produced*, not recognised | `MASHES` — 34 coins against 282 |
| **compare them, find the maximum** | the mark is a commitment separate from the bid, so beating the wrong tablet loses the lot — and the host still records that arithmetic as **correct**, because it was | `EYEBALLS_THE_ROOM` marks the biggest printed numeral: 23 coins, wrong on 73% of boards |
| **add one** | a keen bid pays **double**. Without it the game is solvable by reading one number | `BIDS_THE_MAX` earns **exactly 0** over 40 lots, on every seed |
| **bound it by the offer** | padding walks into `bid > offer` and buys dead stock; and ~20% of lots have no profitable bid at all, where the only right move is FOLD | `IGNORES_THE_OFFER` pads by five: unsold on a third of its lots, 55 coins |

**The keen bonus is load-bearing and it was measured, not guessed.** Without it, "bid one under the broker's offer" wins nearly every lot for one coin with zero arithmetic — and wherever the margin is two, that blind bid *is* the perfect bid. The first draft also squeezed the broker's margin as an escalation knob, which made this worse: at a margin of three the whole reward for reading the room collapses to three coins. The margin band is deliberately wide and does not ride intensity; the reason is written on `MIN_MARGIN`.

### Bot results

40 decisions, 8 seeds, each strategy playing its **own adapted run** — which is the harder comparison, because the controller hands a struggling player the calmest room the game has.

| strategy | coins (mean) | vs computing |
|---|---|---|
| computes the room | **282** | — |
| pads the bid, ignores the offer | 55 | 5.1× |
| bids one under the broker's offer | 44 | 6.4× |
| mashes | 34 | 8.3× |
| marks the biggest printed number | 23 | 12× |
| folds everything | 0–13 | ≥22× |
| bids the highest, not one over | **0** | ∞ |

### Curriculum content it consumes

Any active rung whose answer is a whole non-negative number under 10 000 — which today is all of them: `dw.add.facts.*`, `dw.add.column.*`, `dw.add.regroup.*`, `dw.mul.facts.*`, `dw.mul.multidigit.times-one-{digit,two-digit}`, `dw.div.facts.division-facts`, `dw.div.whole.{divide-exact,zero-in-the-quotient}`. A tablet is a *price*, so a fraction, a decimal or a negative is refused — and because declining is per-item while the host serves by **rung**, the first refusal caps the stream with `next({ maxDifficulty })`, monotonically, once per run. A duplicate value never caps: that is a fact about a pair of questions and capping on it is what pinned POLARITY to the easiest rung in the product for a whole session.

Three to five questions go up per lot and exactly one is answered — the marked tablet, with `answered = bid − 1`. The rest are `skip`ped. Reporting them as `{ correct: false, answered: "" }` would file four misses a round: the empty string does not parse, so the learner model takes a wrong attempt and the ladder walks *down* underneath a child who is doing fine.

### Pacing

**No clock anywhere.** `advance` returns before it touches anything while a bid is being set — FOUNDRY STREET's shape — so elapsed time literally cannot accumulate while a child is thinking. The only duration in the pack is the reveal *after* the hammer, floored at 900 ms and generous (4.2 s) at the bottom of the ladder, which is the patient reveal `game-pacing` exists to provide. Escalation is stepped once per **settled lot**, never on a frame delta.

`antimash.test.ts` plays each of eight seeds at 8 s a lot and at 200 ms a lot and requires byte-identical coins, tally, storeroom, consignment, reported answers, intensity **and the room on the block**. The only thing that differs is the latency reported.

### `minAge: 6`

Judged on motor and attention demand only, never the arithmetic. Every target is a stationary plate of at least 44 px with no timing anywhere in the game, which a five-year-old can work. What a typical five-year-old loses is the *sequence*: hold a comparison across several cards, then check it against a second number, then commit. That is the reason for 6 rather than 5, and it is the only reason.

### A note on the founder's example — please do not "fix" this

> "with the above bidders and a resale of ~20, we should bid 16 and gain 4"

`12 + 5 = 17`, so the highest rival bid in that room is **17** and the winning bid is **18**, not 16. His prose is consistent throughout with a highest of 15, so he almost certainly read `12+5` as 15. Computing the maximum correctly is the entire skill of this game, so the pack uses the correct arithmetic and the founder's inequality (profitable strictly between the room and the offer, breakeven at the offer, a loss above it) is implemented exactly as stated.

### What a wrong bid costs

COLOSSUS's failure model, in an auction: a lot that does not sell **stays in the consignment and the broker adds one more**, so being wrong is two more lots of work than being right — visible and countable as pips on the strip, capped at twelve so being behind stays legible. Overpaying puts the lot on a storeroom shelf that only ever grows. **No coin is ever taken away** — asserted for all seven players over 30 lots on six seeds — no life, no score penalty, and there is no `failure` haptic in the pack: a lot that got away is the same weight of thud as stone arriving in COLOSSUS.

`transition` is only ever called after a consignment that **sold something**, never after one merely cleared, because a purchase surface must not sit next to a shortfall (ADR-0013). Tested both ways.

### Every fix was verified by deleting it

| removed | test that failed | message |
|---|---|---|
| `laboredScore: 1` override | `ladder.test.ts` | `sixty flawless lots left the run at intensity 0.000 — a child who never made a mistake was held near the easiest content in the product` |
| `KEEN_MULTIPLIER = 2` → `1` | `bots.test.ts` | `from cold: "bids one under the offer" averaged 40.0 against 152.5` |
| the tight-cluster board assembler | `lot.test.ts` | `a room spans 89% of its own highest bid on average — that is a board a child can sort by eye` |
| `advance()`'s early return while bidding | `antimash.test.ts` | four thousand frames of a child thinking replaced the room: `+ '326 − 24' … − '188 − 112'` |
| `close()` (the `items.skip` call) | `report.test.ts` | `84 tablets went up, 16 were answered and only 0 were closed — the rest are open in the host's ledger` |
| `capBelow` (the rung ceiling) | `lot.test.ts` | `the stream was never capped` / `an unprintable prompt did not cap its rung` |
| `rungCannotDraw`'s `id === ""` guard | `lot.test.ts` | `a sentinel that does not parse capped a rung it does not describe` |
| the plaque's clearance of the host corners | `layout.test.ts` | `a rect at (10, 13, 300×44) sits under the host's exit or help control` |
| the pause guard on the bidding phase | `report.test.ts` | `a tablet was marked behind the sheet` |
| the 44 px floor under the keypad squeeze | `layout.test.ts` | `the "1" key is 54×35` / `a target was shrunk instead` |

### Gates

70 tests, **five consecutive clean runs**, `tsc` clean, `build:pack` clean, `dw-pack check` clean on a staged manifest (`min age 6+`, `items, items.reveal, haptics`, 18 skills, 3 files, 57 KB). `packs/shared/game-audio` (80 tests, including the `createSafetyBus` routing glob that now covers this game) and `packs/sdk` (94 tests, including the `minAge` fleet test) both green.

### What needs a device

* **The whole feel of the reveal on a tablet.** Played through in a desktop browser at phone size — marking, the armed hammer, `BEATING 88 + 61`, the keen-bid verdict, the coin walk — but not on hardware, and not with a child.
* **Legibility of the tablet prompts at the top of the ladder.** The 13 px floor and the character budget are derived and asserted against the renderer, never eyeballed, but a four-digit column sum on a 320 px phone at three tablets across wants a real screen and a real pair of eyes.
* **Haptics.** `light` on a mark, `medium` on a lot that got away, `success` on coins. Never fired outside a stub.
* **A landscape phone under 400 CSS px tall.** Stated as the layout's floor and tested as such: the keys keep their 44 px and the last row runs off the bottom rather than becoming unhittable. The proper fix is a side-by-side arrangement with the keypad beside the gallery, and it is not in this first cut.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
