### PR TITLE
fix(dynawalla): #704 left a comment saying VOLTA was fixed, and a test that could not fail

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/frame.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.test.ts
@@ -632,31 +632,43 @@ const IFRAME_DEFAULT = { width: 300, height: 150 }
  * `.pack-frame-host` -> `.pack-frame`, rather than from what the file is
  * remembered to say. A deliberately tiny slice of CSS and only the slice the
  * frame's box depends on: a percentage of the containing block, an explicit
- * length, or — when the ancestor's own box is gone and the percentage cannot
- * resolve — the replaced element's intrinsic default.
+ * length, or — when the containing block has no definite size of its own and the
+ * percentage therefore cannot resolve — the replaced element's intrinsic default.
  *
- * `null` for the ancestor is the failure: a stage div with no box of its own,
- * which is what removing `fixed; inset: 0` from `Stage.tsx` produces.
+ * `null` on an axis is a containing block with no definite size on that axis,
+ * which is what taking `fixed; inset: 0` off the stage div produces. It is passed
+ * *through the real declarations* rather than short-circuited, so this returns
+ * 300x150 only because `packs.css` really does size both boxes by percentage.
  */
-function frameBox(
-  ancestor: { width: number; height: number } | null,
-): { width: number; height: number } {
-  if (ancestor === null) return { ...IFRAME_DEFAULT }
-  let box = { ...ancestor }
+function frameBox(ancestor: {
+  width: number | null
+  height: number | null
+}): { width: number; height: number } {
+  const resolve = (
+    declared: string | undefined,
+    against: number | null,
+    intrinsic: number,
+  ): number | null => {
+    if (declared === undefined) return null
+    if (declared.endsWith("px")) return Number.parseFloat(declared)
+    if (!declared.endsWith("%")) return null
+    // A percentage of an indefinite containing block does not resolve. For an
+    // iframe — a replaced element — what is left is its intrinsic size.
+    return against === null ? intrinsic : (against * Number.parseFloat(declared)) / 100
+  }
+
+  let box: { width: number | null; height: number | null } = { ...ancestor }
   for (const selector of [".pack-frame-host", ".pack-frame"]) {
     const rule = packsCssRule(selector)
-    const resolve = (declared: string | undefined, against: number, intrinsic: number): number => {
-      if (declared === undefined) return intrinsic
-      if (declared.endsWith("%")) return (against * Number.parseFloat(declared)) / 100
-      if (declared.endsWith("px")) return Number.parseFloat(declared)
-      return intrinsic
-    }
     box = {
       width: resolve(rule.get("inline-size"), box.width, IFRAME_DEFAULT.width),
       height: resolve(rule.get("block-size"), box.height, IFRAME_DEFAULT.height),
     }
   }
-  return box
+  return {
+    width: box.width ?? IFRAME_DEFAULT.width,
+    height: box.height ?? IFRAME_DEFAULT.height,
+  }
 }
 
 test("the box the host's chain hands the frame, in both states, is what the watch judges", () => {
@@ -668,10 +680,13 @@ test("the box the host's chain hands the frame, in both states, is what the watc
   const healthy = frameBox({ width: 820, height: 1180 })
   assert.deepEqual(healthy, { width: 820, height: 1180 }, "the frame no longer fills its ancestor")
 
-  const broken = frameBox(null)
-  // The measurement, pinned. If this ever stops being 300x150 the threshold above
-  // was derived against a shape that no longer happens.
+  const broken = frameBox({ width: null, height: null })
+  // The measurement, pinned, and reached through the real declarations rather than
+  // asserted about a constant: a percentage of an indefinite box does not resolve,
+  // and what an iframe is left with is 300x150. If this ever stops being that, the
+  // threshold above was derived against a shape that no longer happens.
   assert.deepEqual(broken, IFRAME_DEFAULT, "a boxless ancestor no longer defaults the frame")
+  assert.equal(fillsWindow({ ...HEALTHY, ...broken, ...window }), false)
 
   const good = watchThrough(held({ ...HEALTHY, ...healthy, ...window }, ticksFor(LIVENESS.blankAfterMs)))
   assert.equal(good.said.length, 0, `a full-size frame was accused of ${good.said.join(", ")}`)
@@ -776,6 +791,12 @@ test("disposing stops the watch, and clears its timer", async (t) => {
     stopped.push(id)
     reallyClear(id)
   }) as typeof globalThis.clearInterval)
+  // So that this test *fails* rather than hangs when the assertion below trips.
+  // A 4ms interval nobody cleared keeps node's loop alive, and the last leaked
+  // handle in this file turned a 700ms run into forty-five seconds.
+  t.after(() => {
+    for (const id of started) reallyClear(id as Parameters<typeof globalThis.clearInterval>[0])
+  })
   t.mock.method(console, "error", () => {})
 
   const test = harness(t, { box: { width: 0, height: 0 }, liveness: WATCH_BOX })

--- a/dynawalla/dynawalla-app/src/packs/frame.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.ts
@@ -64,9 +64,20 @@ const HANDSHAKE_TIMEOUT_MS = 20_000
 // So neither channel separates a blank pack from a playing one, and **nothing
 // here could have caught VOLTA.** That collapse happened one document deeper
 // than the host can reach, and catching it needs the pack to measure its own
-// stage and say so — which is what `makeStage` and the stage-collapse error in
-// `games/runner` and `games/merge` now do, in the only place the measurement
-// exists.
+// stage and say so, in the only place the measurement exists. `games/merge` does
+// that now (`makeStage`, and a stage-collapse error in its `resize`).
+// **`games/runner` does not** — as of this commit it still carries the line that
+// blanked it, and the repair is in an open PR, not in this tree. Nothing here
+// fixes VOLTA and nothing here can notice it.
+//
+// Neither fault has a consumer in a release build yet. They are written to the
+// console and offered on `onFault` / `MountedPack.faults()`, and `Stage.tsx` does
+// not pass `onFault`; there is also no console-to-native bridge in this app, so
+// on a device these lines reach a WebInspector session and nowhere else. That
+// makes this a dev-loop instrument today rather than the thing that would have
+// told somebody other than the founder. Wiring a consumer — a fault on the
+// developer surface, or a native log — is the next step and belongs to
+// `Stage.tsx`.
 //
 // What the box *does* catch is the host's own copy of that bug, one level up,
 // which was completely unwatched. That is not hypothetical either: taking
@@ -113,7 +124,7 @@ export type LivenessFault =
   /**
    * The pack took its port and then never used it.
    *
-   * All twenty-eight shipping games do the same three things in the same order:
+   * All twenty-seven shipping games do the same three things in the same order:
    * `createGameHost()`, `await warm()`, then mount. `warm()` is `items.next`, so
    * every one of them speaks within milliseconds of the handshake — measured at
    * **11ms** in a real framed pack. A pack that was granted `items` and has said

--- a/dynawalla/games/merge/src/mount.ts
+++ b/dynawalla/games/merge/src/mount.ts
@@ -130,7 +130,11 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
     // collapsing its stage to 820x0: a stage with no box quietly rendered at
     // window size, so an honest measurement was never available to anybody. Now
     // the measurement is honest and a missing stage is said out loud instead.
-    if (!saidCollapsed && (el.clientWidth < 2 || el.clientHeight < 2)) {
+    // Only when the *window* has a box. A Tauri window being restored and an
+    // Android rotation both hand out a momentary zero-size viewport, and the
+    // latch below says a thing once and can never retract it.
+    const room = window.innerWidth >= 1 && window.innerHeight >= 1;
+    if (!saidCollapsed && room && (el.clientWidth < 2 || el.clientHeight < 2)) {
       saidCollapsed = true;
       console.error(
         `[fuse] the stage measures ${String(el.clientWidth)}x${String(el.clientHeight)}. ` +


### PR DESCRIPTION
Five corrections to what #704 landed, all from an adversarial pass that finished
after the merge queue did. Nothing here changes behaviour except one guard.

**The comment claimed a fix that is not in the tree, for the bug the PR was
named after.** `frame.ts` said the pack-side measurement is "what `makeStage` and
the stage-collapse error in `games/runner` and `games/merge` now do". `merge` does.
`games/runner` does not: `rg makeStage dynawalla/games/` returns only `merge`, and
`runner/src/game/mount.ts` still reads

    el.style.position = el.style.position || "relative";
    el.style.overflow = "hidden";

which is worse off than merge ever was — it has the `overflow: hidden` merge
lacked, so the canvas is clipped to the collapsed box rather than painting outside
it, and its `resize()` has no `|| window.innerHeight` to swallow the zero. The
repair is in an open PR, not on main. The failure this wording invites is somebody
reading it as the record, concluding VOLTA is repaired, and shipping a release
with a black screen in it — while the same paragraph correctly explains that the
host's liveness watch cannot catch that. Now stated the other way round, in bold.

**The new signal has no consumer, and did not say so.** `onFault` and
`MountedPack.faults()` have zero callers outside `frame.ts` and its test:
`Stage.tsx` does not pass `onFault`, and this app has no console-to-native bridge.
So on a device both faults reach a WebInspector session and nowhere else — which
is the case where a blank screen was already visible. The module note set out to
fix "the only thing that noticed was the founder" and stops one step short of it;
it now says that plainly and names `Stage.tsx` as where the next step lives.

**A test that could not fail.** `frameBox` opened with
`if (ancestor === null) return { ...IFRAME_DEFAULT }`, and the assertion under it
compared that constant to itself while a comment promised a pinned measurement.
It now carries an indefinite size *through the real `packs.css` declarations*, so
300x150 is reached by resolving a percentage against nothing rather than asserted
about a literal. Breaking that resolution now fails it:

    ✖ the box the host's chain hands the frame, in both states, is what the watch judges
      AssertionError: a boxless ancestor no longer defaults the frame

**A leaked-interval regression that failed slowly.** Removing `clearInterval`
from `dispose()` did fail the assertion, but the leaked 4ms interval also kept
node's loop alive and turned a 700ms file into forty-five seconds — in a file
whose own harness note is about the runner time the last leaked handle here cost.
A `t.after` now clears any interval the test recorded, so the same regression
fails in under a second. Verified by removing `clearInterval` again.

**One behaviour change.** `games/merge`'s stage-collapse error is now gated on the
window having a box. A Tauri window being restored and an Android rotation both
hand out a momentary zero-size viewport, the `ResizeObserver` heals the canvas a
frame later, and the say-once latch could never retract the line it had already
printed. Same guard the host's watch uses for the same reason.

Also: twenty-eight shipping games became twenty-seven, which is what
`dynawalla/games/` and `ci.yml` both say.

Verified on Node 24: `dynawalla-app` 323 tests and `games/merge` 79, five
consecutive runs each, plus lint, `tsc` on all three projects, the app build and
the FUSE pack build. FUSE re-measured in a headless browser on the rebuilt
`dist-pack`, framed on an opaque origin at 820x1180: stage 820x1180, inline
position empty, a played run, and nothing on the console until the collapse is
injected deliberately.

Claude-Session: https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb

