### PR TITLE
dynawalla/packs/shared/game-host: a pack's covers.skills finally reaches the wire

### DIFF
--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -16,7 +16,16 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 
 import type { Capability, HostClient, Item, ItemRequest, Judgement, Settings } from "../../sdk/src/index.ts"
-import { attachGameHost, toUnit, POOL_FLOOR } from "./index.ts"
+import {
+  attachDeclared,
+  attachGameHost,
+  declaredSkills,
+  domainOf,
+  packRootUrl,
+  toUnit,
+  FLUSH_KEEP,
+  POOL_FLOOR,
+} from "./index.ts"
 
 /** Rungs on the fake host's ladder. Enough that 1/16 is a visible step. */
 const RUNGS = 16
@@ -41,6 +50,8 @@ type Fake = {
   readonly client: HostClient
   /** Every `nextItem` call, in order. */
   readonly asks: Ask[]
+  /** Every method called on the client, in order. The host counts these. */
+  readonly calls: string[]
   /** Every `answer` call, in order. */
   readonly answers: { itemId: string; response: string }[]
   /** Every `items.skip` call, in order. */
@@ -69,9 +80,18 @@ type Fake = {
  * the contract the real `items.ts` implements; this is the smallest thing that
  * implements it too.
  */
-function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fake {
+function fakeHost(
+  options: {
+    granted?: Capability[]
+    rungs?: number
+    /** The skill each rung belongs to. Default: four rungs per `arith.rung.N`. */
+    skillAt?: (index: number) => string
+  } = {},
+): Fake {
   const rungs = options.rungs ?? RUNGS
+  const skillAt = options.skillAt ?? ((index: number) => `arith.rung.${String(Math.floor(index / 4))}`)
   const asks: Ask[] = []
+  const calls: string[] = []
   const answers: { itemId: string; response: string }[] = []
   const skips: string[] = []
   const canonicals = new Map<string, string>()
@@ -83,6 +103,7 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
     skipFails: false,
     standing: RESTING_RUNG,
     asks,
+    calls,
     answers,
     skips,
     client: {
@@ -94,17 +115,32 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
 
       nextItem: (ask: Ask = {}) => {
         asks.push(ask)
+        calls.push("items.next")
         const span = Math.max(1, rungs - 1)
         const cap = ask.maxDifficulty === undefined ? 1 : ask.maxDifficulty
         const wanted = ask.difficulty === undefined ? fake.standing / span : ask.difficulty
-        const index = Math.max(
+        let index = Math.max(
           0,
           Math.min(rungs - 1, Math.round(Math.min(wanted, cap) * span)),
         )
+        // A named skill wins outright and is served at the FIRST rung that
+        // carries it, whatever the difficulty and whatever the ceiling. That is
+        // not a simplification: the shipped host is `rungs.find(r => r.node.id
+        // === skillId) ?? rungAt(drawn)`, measured returning ordinate 0.28 for a
+        // pin sent with `difficulty: 0.9`, and 0.28 again for the same pin sent
+        // with `maxDifficulty: 0.1`. An unknown id is ignored, as it is there.
+        if (ask.skillId !== undefined) {
+          for (let rung = 0; rung < rungs; rung++) {
+            if (skillAt(rung) === ask.skillId) {
+              index = rung
+              break
+            }
+          }
+        }
         sequence += 1
         const item: Item = {
           id: `i${String(sequence)}`,
-          skillId: `arith.rung.${String(Math.floor(index / 4))}`,
+          skillId: skillAt(index),
           // Deliberately NOT the ladder ordinate: `level` is the level within a
           // skill, which is what the shipped host puts here and what the old
           // read-back mistook for a difficulty.
@@ -125,6 +161,7 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
       },
 
       answer: (input) => {
+        calls.push("items.answer")
         answers.push({ itemId: input.itemId, response: input.response })
         if (fake.answerFails) return Promise.reject(new Error("the host is gone"))
         return Promise.resolve({
@@ -134,13 +171,17 @@ function fakeHost(options: { granted?: Capability[]; rungs?: number } = {}): Fak
         } satisfies Judgement)
       },
       skip: (itemId) => {
+        calls.push("items.skip")
         skips.push(itemId)
         // What an older host — one shipped before `items.skip` existed — would
         // do with the call, so the adapter is held to surviving it.
         if (fake.skipFails) return Promise.reject(new Error("unknown method: items.skip"))
         return Promise.resolve()
       },
-      reveal: (itemId) => Promise.resolve(canonicals.get(itemId) ?? ""),
+      reveal: (itemId) => {
+        calls.push("items.reveal")
+        return Promise.resolve(canonicals.get(itemId) ?? "")
+      },
       learnerSummary: () => Promise.resolve({ skills: [] }),
       haptic: () => Promise.resolve(),
       sound: () => Promise.resolve(),
@@ -808,4 +849,597 @@ test("the one value the two scales disagree about is not read in silence", async
   const notes = said.filter((line) => line.includes("exactly 1"))
   assert.equal(notes.length, 1, `said ${String(notes.length)} times: ${said.join(" | ")}`)
   assert.ok(notes[0]?.includes("BOTTOM"), `the notice does not say which reading won: ${String(notes[0])}`)
+})
+
+// ─── The other axis: what kind of maths, not how hard ────────────────────────
+//
+// The ladder these tests use is the shipped one in miniature: 16 rungs, four
+// skills, two domains, and the domains interleaved the way the real curriculum
+// interleaves them — `dw.mul` sits in the MIDDLE of the ladder, between two
+// bands of `dw.add`, because that is the fact that makes difficulty an
+// insufficient axis. On the shipped 66-rung ladder
+// `dw.mul.scale.times-power-of-ten` (answers in the millions) sits at ordinate
+// 0.45 and `dw.div.whole.divide-exact` (single-digit answers) sits at 0.55, one
+// above the other, so no ceiling and no floor can separate a pack from a domain
+// it cannot draw.
+//
+//   rungs  0–3   dw.add.facts.add-within-ten          ordinate 0.00–0.20
+//   rungs  4–7   dw.mul.scale.times-power-of-ten      ordinate 0.27–0.47
+//   rungs  8–11  dw.add.column.add-no-regroup         ordinate 0.53–0.73
+//   rungs 12–15  dw.add.regroup.subtract-across-zero  ordinate 0.80–1.00
+
+/** The skills of the interleaved ladder above, by rung. */
+const LADDER = [
+  "dw.add.facts.add-within-ten",
+  "dw.mul.scale.times-power-of-ten",
+  "dw.add.column.add-no-regroup",
+  "dw.add.regroup.subtract-across-zero",
+]
+
+const skillAt = (index: number): string => LADDER[Math.floor(index / 4)] ?? "dw.add.facts.add-within-ten"
+
+/** What TREBUCHET declares, in its own order, cut to the skills above. */
+const TREBUCHET = ["dw.add.column.add-no-regroup", "dw.add.regroup.subtract-across-zero"]
+
+/**
+ * Answer `count` questions and hand back the skill each one came from.
+ *
+ * Read through `recentOutcomes`, which is the only place a pack can see what it
+ * was served: `Question` carries no skill id, so this is also the seam a game's
+ * own pacing controller would use, and a test that read a private field would
+ * be testing something no game can observe.
+ */
+async function skillsServed(mounted: ReturnType<typeof attachGameHost>, count: number): Promise<string[]> {
+  for (let i = 0; i < count; i++) {
+    const question = mounted.host.next()
+    mounted.host.report({ questionId: question.id, correct: true, ms: 1000, answered: question.answer })
+    await settle(4)
+  }
+  await settle()
+  return mounted.host.recentOutcomes().map((outcome) => outcome.skillId)
+}
+
+test("THE GAP: a pack is served a domain it does not cover, and its declaration cannot stop it", async () => {
+  // The host is standing on rung 5 — inside the multiplication band, which is
+  // exactly where trebuchet was standing when it was asked to wind its arm to
+  // 4,510,000 metres. The pack declares add and subtract only.
+  const fake = fakeHost({ skillAt })
+  fake.standing = 5
+  const mounted = attachGameHost(fake.client, { skills: TREBUCHET })
+  await mounted.warm()
+
+  const served = await skillsServed(mounted, 12)
+  assert.ok(served.length >= 12, `only ${String(served.length)} questions were served`)
+  const foreign = served.filter((skill) => !skill.startsWith("dw.add"))
+  assert.equal(
+    foreign.length,
+    0,
+    `${String(foreign.length)} of ${String(served.length)} questions came from a domain this ` +
+      `pack does not declare: ${[...new Set(foreign)].join(", ")}`,
+  )
+  mounted.dispose()
+})
+
+test("the declaration reaches the wire as a skillId, and only when it has to", async () => {
+  const fake = fakeHost({ skillAt })
+
+  // Standing in the multiplication band: the pack cannot use what arrives, so
+  // it trades, and the trade is a `skillId` on the wire.
+  fake.standing = 5
+  const trading = attachGameHost(fake.client, { skills: TREBUCHET })
+  await trading.warm()
+  const pins = fake.asks.filter((ask) => ask.skillId !== undefined).map((ask) => ask.skillId)
+  assert.ok(pins.length > 0, "not one request named a skill, so the declaration went nowhere")
+  for (const pin of pins) {
+    assert.ok(
+      pin !== undefined && TREBUCHET.includes(pin),
+      `the host was asked for "${String(pin)}", which this pack never declared`,
+    )
+  }
+  trading.dispose()
+
+  // Standing in the addition band: everything that arrives is already something
+  // the pack declares, so nothing is pinned and the host keeps its own spread,
+  // its own levels and its own idea of where the child is.
+  const quiet = fakeHost({ skillAt })
+  quiet.standing = 9
+  const content = attachGameHost(quiet.client, { skills: TREBUCHET })
+  await content.warm()
+  await skillsServed(content, 8)
+  const uninvited = quiet.asks.filter((ask) => ask.skillId !== undefined)
+  assert.equal(
+    uninvited.length,
+    0,
+    `${String(uninvited.length)} requests pinned a skill while the host was already serving one ` +
+      `the pack declares — a pin ignores difficulty and maxDifficulty, so this would cost every ` +
+      `pack its difficulty wire`,
+  )
+  content.dispose()
+})
+
+test("a pack that declares nothing is served exactly what it was served before", async () => {
+  const bare = fakeHost({ skillAt })
+  bare.standing = 5
+  const before = attachGameHost(bare.client)
+  await before.warm()
+  const servedBefore = await skillsServed(before, 8)
+  before.dispose()
+
+  const empty = fakeHost({ skillAt })
+  empty.standing = 5
+  const after = attachGameHost(empty.client, { skills: [] })
+  await after.warm()
+  const servedAfter = await skillsServed(after, 8)
+  after.dispose()
+
+  assert.ok(servedBefore.includes("dw.mul.scale.times-power-of-ten"), "the ladder was not where this test needs it")
+  assert.deepEqual(servedAfter, servedBefore, "an empty declaration changed what a pack is served")
+  assert.equal(
+    bare.asks.filter((ask) => ask.skillId !== undefined).length +
+      empty.asks.filter((ask) => ask.skillId !== undefined).length,
+    0,
+    "a pack that declared nothing had a skill named on its behalf",
+  )
+})
+
+test("the question the pack could not use is closed on the host, not left open", async () => {
+  const fake = fakeHost({ skillAt })
+  fake.standing = 5
+  const mounted = attachGameHost(fake.client, { skills: TREBUCHET })
+  await mounted.warm()
+  await settle()
+
+  assert.ok(fake.skips.length > 0, "a rescued question was abandoned open in the host's ledger")
+  // Every skip is an item the pack never served, and no served item was skipped:
+  // a skip is the honest ending for a question that was drawn and not asked.
+  const answered = new Set(fake.answers.map((answer) => answer.itemId))
+  for (const skipped of fake.skips) {
+    assert.ok(!answered.has(skipped), `item ${skipped} was both answered and closed unanswered`)
+  }
+  mounted.dispose()
+})
+
+// A ladder whose UNUSABLE band is at the bottom, which is what puts a pack's
+// ceiling and its declaration in conflict: everything the pack covers is above
+// the highest rung it is allowed to draw.
+//
+//   rungs 0–3    dw.mul.facts.tables-within-five   0.00–0.20
+//   rungs 4–15   dw.add.column.add-no-regroup      0.27–1.00   a pin lands 0.27
+const lowBandForeign = (index: number): string =>
+  index < 4 ? "dw.mul.facts.tables-within-five" : "dw.add.column.add-no-regroup"
+
+test("a rescue never breaks a ceiling the game set", async () => {
+  const fake = fakeHost({ skillAt: lowBandForeign })
+  const said = await withConsole(async () => {
+    const mounted = attachGameHost(fake.client, { skills: ["dw.add.column.add-no-regroup"] })
+    // The ceiling is stated before the pool is stocked, because a pool stocked
+    // without one already holds questions above it — that is what a flush is for
+    // and it is not what this test is about.
+    mounted.host.next({ maxDifficulty: 0.2 })
+    await mounted.warm()
+    // The game can only draw the bottom fifth of the ladder. The only skill this
+    // pack declares starts at 0.27, and a pinned request is served that rung
+    // whatever the ceiling says — measured against the shipped host, which
+    // returns 0.28 for a pin sent with `maxDifficulty: 0.1`. So the ceiling wins
+    // and the pack keeps the question it can at least draw.
+    for (let i = 0; i < 12; i++) {
+      const question = mounted.host.next({ maxDifficulty: 0.2 })
+      assert.ok(
+        question.difficulty <= 0.2 + 1e-9,
+        `a question at ${question.difficulty.toFixed(2)} was served under a ceiling of 0.20`,
+      )
+      mounted.host.report({ questionId: question.id, correct: true, ms: 900, answered: question.answer })
+      await settle(4)
+    }
+    mounted.dispose()
+  })
+  const notes = said.filter((line) => line.includes("the ceiling wins"))
+  assert.equal(notes.length, 1, `the ceiling/declaration conflict was said ${String(notes.length)} times`)
+  assert.ok(
+    notes[0]?.includes("maxDifficulty of 0.20"),
+    `the notice does not say which ceiling it stopped at: ${String(notes[0])}`,
+  )
+})
+
+test("a trade that keeps failing stops paying for itself, loudly", async () => {
+  // The conflict above, left running: the pack declares a skill the host has and
+  // the game has set a ceiling below it, so no trade can ever succeed. The
+  // request budget is the point — every failed trade costs a second
+  // `items.next`, and the host allows 120 calls in a sliding second.
+  const fake = fakeHost({ skillAt: lowBandForeign })
+  const said = await withConsole(async () => {
+    const mounted = attachGameHost(fake.client, { skills: ["dw.add.column.add-no-regroup"] })
+    mounted.host.next({ maxDifficulty: 0.2 })
+    await mounted.warm()
+    for (let i = 0; i < 24; i++) {
+      const question = mounted.host.next({ maxDifficulty: 0.2 })
+      assert.notEqual(question.id, "", `the pool ran dry on question ${String(i)}`)
+      mounted.host.report({ questionId: question.id, correct: true, ms: 900, answered: question.answer })
+      await settle(4)
+    }
+    mounted.dispose()
+  })
+  const notes = said.filter((line) => line.includes("IGNORED for the rest of this session"))
+  assert.equal(notes.length, 1, `surrender was announced ${String(notes.length)} times: ${said.join(" | ")}`)
+  const pins = fake.asks.filter((ask) => ask.skillId !== undefined)
+  assert.ok(
+    pins.length <= 6,
+    `${String(pins.length)} trades were attempted for a skill that can never be served under ` +
+      `this game's ceiling; it should give up after ${String(3)} consecutive failures`,
+  )
+})
+
+test("a declaration this host cannot satisfy is surrendered, loudly, and once", async () => {
+  // arena, balance, claim and pulse are all in this state today: every skill
+  // they declare is missing from the shipped ladder. The game must keep getting
+  // questions, and the repository must be told.
+  const fake = fakeHost({ skillAt })
+  fake.standing = 5
+  const said = await withConsole(async () => {
+    const mounted = attachGameHost(fake.client, { skills: ["dw.ns.compare.whole-numbers"] })
+    await mounted.warm()
+    const served = await skillsServed(mounted, 20)
+    assert.ok(served.length >= 20, `the pack starved: only ${String(served.length)} questions`)
+    mounted.dispose()
+  })
+  const notes = said.filter((line) => line.includes("IGNORED for the rest of this session"))
+  assert.equal(notes.length, 1, `surrender was announced ${String(notes.length)} times: ${said.join(" | ")}`)
+  assert.ok(notes[0]?.includes("dw.ns"), `the notice does not name the domain: ${String(notes[0])}`)
+  // And it stopped paying for the trade. Two pinned requests at most: one to
+  // discover the skill is not there, and none after that.
+  const pins = fake.asks.filter((ask) => ask.skillId !== undefined)
+  assert.ok(
+    pins.length <= 2,
+    `${String(pins.length)} pinned requests were sent for a skill the host does not have`,
+  )
+})
+
+test("the trade measures each declared skill once and then asks for the nearest", async () => {
+  // Declared hardest-first, on purpose: `dw.add.regroup.subtract-across-zero` is
+  // rung 12 (ordinate 0.80) and `dw.add.column.add-no-regroup` is rung 8 (0.53).
+  // A pack cannot see where a skill sits until it has asked for it, so the first
+  // two trades are the measurement — in declaration order — and every trade
+  // after that has to be the one nearest what the game is asking for, which is
+  // the SECOND of the two. A rescue that just took the first declared skill
+  // would pass the previous test and fail this one.
+  //
+  //   rungs  0–3   dw.mul.facts.tables-within-five       0.00–0.20
+  //   rungs  4–7   dw.add.column.add-no-regroup          0.27–0.47   a pin lands 0.27
+  //   rungs  8–11  dw.mul.scale.times-power-of-ten       0.53–0.73
+  //   rungs 12–15  dw.add.regroup.subtract-across-zero   0.80–1.00   a pin lands 0.80
+  //
+  // Two bands the pack cannot use, one below its cheapest declared skill and one
+  // above it, so the nearest declared skill is a different one depending on where
+  // the game is aiming — which a rescue that always picks the same skill, or the
+  // first declared one, cannot get right twice.
+  const split = (index: number): string =>
+    [
+      "dw.mul.facts.tables-within-five",
+      "dw.add.column.add-no-regroup",
+      "dw.mul.scale.times-power-of-ten",
+      "dw.add.regroup.subtract-across-zero",
+    ][Math.floor(index / 4)] ?? ""
+  const declaredHardestFirst = [
+    "dw.add.regroup.subtract-across-zero",
+    "dw.add.column.add-no-regroup",
+  ]
+  const fake = fakeHost({ skillAt: split })
+  fake.standing = 1
+  const mounted = attachGameHost(fake.client, { skills: declaredHardestFirst })
+  await mounted.warm()
+  await settle()
+
+  const pins = (): string[] =>
+    fake.asks.filter((ask) => ask.skillId !== undefined).map((ask) => ask.skillId ?? "")
+
+  // The measurement, in declaration order, once each.
+  const measured = pins()
+  assert.equal(
+    measured[0],
+    "dw.add.regroup.subtract-across-zero",
+    `the first trade did not measure the first declared skill, it asked for "${String(measured[0])}"`,
+  )
+  assert.equal(
+    measured[1],
+    "dw.add.column.add-no-regroup",
+    `the second declared skill was not measured next; the trade asked for "${String(measured[1])}"`,
+  )
+
+  const drive = async (difficulty: number) => {
+    fake.asks.length = 0
+    for (let i = 0; i < 6; i++) {
+      const question = mounted.host.next({ difficulty })
+      mounted.host.report({ questionId: question.id, correct: true, ms: 900, answered: question.answer })
+      await settle(4)
+    }
+    await settle()
+    const asked = pins()
+    assert.ok(asked.length > 0, `nothing was traded while aiming at ${String(difficulty)}`)
+    return asked[asked.length - 1]
+  }
+
+  // Aiming at the bottom: the cheaper declared skill is the nearer one, and it is
+  // the one declared SECOND.
+  assert.equal(
+    await drive(0),
+    "dw.add.column.add-no-regroup",
+    "aiming at the bottom of the ladder still traded for the hardest skill the pack declares",
+  )
+  // Aiming above the pack's cheap skill: the answer flips to the other one.
+  assert.equal(
+    await drive(0.6),
+    "dw.add.regroup.subtract-across-zero",
+    "aiming at 0.60 traded for the skill at 0.27 rather than the one at 0.80",
+  )
+  mounted.dispose()
+})
+
+test("honouring the declaration does not spend the host's request budget", async () => {
+  // The host allows `MAX_REQUESTS_PER_SECOND` calls in a sliding second and
+  // `warm()` stocks POOL_FLOOR questions back to back, so what a restricted pack
+  // costs at mount is not a detail: the refuse-and-retry shape this started as
+  // spent four calls a question — two `items.next`, a `reveal` and a `skip` —
+  // and doubled the burst. A pack that has to name a skill asks for it directly.
+  const spend = async (skills?: readonly string[]) => {
+    const fake = fakeHost({ skillAt })
+    fake.standing = 5
+    const mounted = attachGameHost(fake.client, skills === undefined ? {} : { skills })
+    await mounted.warm()
+    const burst = fake.calls.length
+    await skillsServed(mounted, 24)
+    mounted.dispose()
+    return { burst, session: fake.calls.length }
+  }
+  const baseline = await spend()
+  const restricted = await spend(TREBUCHET)
+
+  assert.ok(baseline.burst >= 2 * POOL_FLOOR, `the baseline burst was only ${String(baseline.burst)} calls`)
+  assert.ok(
+    restricted.burst <= baseline.burst * 1.25,
+    `stocking the pool cost ${String(restricted.burst)} calls with a declaration against ` +
+      `${String(baseline.burst)} without — ${(restricted.burst / baseline.burst).toFixed(2)}× the ` +
+      `burst, which is how a restricted pack gets rate-limited at mount and shows a child an ` +
+      `empty pool`,
+  )
+  // And over a session, where a pool flushed at a difficulty none of its contents
+  // can be is the other way to spend the budget.
+  assert.ok(
+    restricted.session <= baseline.session * 1.25,
+    `24 questions cost ${String(restricted.session)} calls with a declaration against ` +
+      `${String(baseline.session)} without — ${(restricted.session / baseline.session).toFixed(2)}×`,
+  )
+})
+
+test("a ceiling that arrives after the pack is already pinned is still honoured", async () => {
+  // The pack is pinned first — the host is parked at the bottom of the ladder,
+  // in a band it cannot use — and only then does the game state a ceiling below
+  // the rung it has been pinning. Nothing re-reads a pinned request on the host's
+  // side, so the check has to happen here, on the way in, every time.
+  const fake = fakeHost({ skillAt: lowBandForeign })
+  fake.standing = 1
+  const mounted = attachGameHost(fake.client, { skills: ["dw.add.column.add-no-regroup"] })
+  await mounted.warm()
+  await settle()
+
+  const served: number[] = []
+  const pinsBefore = fake.asks.filter((ask) => ask.skillId !== undefined).length
+  for (let i = 0; i < 24; i++) {
+    const question = mounted.host.next({ maxDifficulty: 0.2 })
+    served.push(question.difficulty)
+    mounted.host.report({ questionId: question.id, correct: true, ms: 900, answered: question.answer })
+    await settle(4)
+  }
+  // The pool it had already stocked at 0.27 is above the new ceiling and is
+  // allowed to drain — that is what a flush is for, and a flush keeps
+  // FLUSH_KEEP of them. What must not happen is the pack going on ASKING for
+  // 0.27 by name once it knows the ceiling, which is a supply of them with no end.
+  const pinsAfter = fake.asks.filter((ask) => ask.skillId !== undefined).length - pinsBefore
+  const over = served.filter((difficulty) => difficulty > 0.2 + 1e-9)
+  assert.ok(
+    over.length <= FLUSH_KEEP,
+    `${String(over.length)} of ${String(served.length)} questions were above the ceiling of ` +
+      `0.20 — at most ${String(FLUSH_KEEP)} of them can be the pool draining`,
+  )
+  // And it stopped ASKING for that rung by name. This is the assertion that
+  // bites: a pooled question above a ceiling is never handed out while anything
+  // else exists, so a pack that goes on pinning an over-ceiling skill does not
+  // look broken from the outside — it just spends its whole pool, and its whole
+  // request budget, on questions no child will ever see. Measured: 4 pinned
+  // requests with the check, 27 without.
+  assert.ok(
+    pinsAfter <= 6,
+    `${String(pinsAfter)} requests named a skill the pack already knew sits above the ceiling ` +
+      `this game set; the pool fills with questions that can never be handed out`,
+  )
+  mounted.dispose()
+})
+
+test("the host is read again, so a child who walks back into the pack's own domain gets it", async () => {
+  //   rungs  0–3   dw.mul.facts.tables-within-five        0.00–0.20
+  //   rungs  4–7   dw.add.column.add-no-regroup           0.27–0.47   a pin lands 0.27
+  //   rungs  8–11  dw.mul.scale.times-power-of-ten        0.53–0.73
+  //   rungs 12–15  dw.add.regroup.subtract-across-zero    0.80–1.00
+  const banded = (index: number): string =>
+    [
+      "dw.mul.facts.tables-within-five",
+      "dw.add.column.add-no-regroup",
+      "dw.mul.scale.times-power-of-ten",
+      "dw.add.regroup.subtract-across-zero",
+    ][Math.floor(index / 4)] ?? ""
+  const fake = fakeHost({ skillAt: banded })
+  // Parked at the bottom, in a band the pack cannot use.
+  fake.standing = 1
+  // ONE declared skill, whose pin lands at 0.27: nothing this pack can ask for by
+  // name reaches the band the child has climbed into, so the only way to be
+  // served it is to let the host answer for itself again.
+  const mounted = attachGameHost(fake.client, { skills: ["dw.add.column.add-no-regroup"] })
+  await mounted.warm()
+  await settle()
+
+  // The child climbs. The host's own stream is now something this pack covers,
+  // and the pack has to notice: a pinned rung is one rung, and a session spent on
+  // it is a session that stopped following the child.
+  fake.standing = 14
+  const seen: number[] = []
+  for (let i = 0; i < 24; i++) {
+    const question = mounted.host.next()
+    seen.push(question.difficulty)
+    mounted.host.report({ questionId: question.id, correct: true, ms: 900, answered: question.answer })
+    await settle(4)
+  }
+  assert.ok(
+    seen.some((difficulty) => difficulty > 0.75),
+    `the child's ladder walked to 0.93 and the pack was still being served ` +
+      `${Math.max(...seen).toFixed(2)} at best — it never looked at the host again`,
+  )
+  mounted.dispose()
+})
+
+// ─── Reading the pack's own declaration ──────────────────────────────────────
+
+test("domainOf cuts a skill id where the curriculum cuts it", () => {
+  assert.equal(domainOf("dw.add.regroup.subtract-across-zero"), "dw.add")
+  assert.equal(domainOf("dw.mul.scale.times-power-of-ten"), "dw.mul")
+  assert.equal(domainOf("dw.frac.arith.add-like-denominators"), "dw.frac")
+  // Three segments is the shortest thing that has a domain.
+  assert.equal(domainOf("arith.rung.0"), "arith.rung")
+  // And anything shorter is its own domain rather than an error or a lie.
+  assert.equal(domainOf("counting"), "counting")
+  assert.equal(domainOf("dw.add"), "dw.add")
+})
+
+test("packRootUrl cuts at the pack, not at the document's directory", () => {
+  assert.equal(
+    packRootUrl("dynawalla-pack://localhost/dynawalla.trebuchet/pack.html", "dynawalla.trebuchet"),
+    "dynawalla-pack://localhost/dynawalla.trebuchet/",
+  )
+  // Android and Windows serve the same directory over the localhost form.
+  assert.equal(
+    packRootUrl("http://dynawalla-pack.localhost/dynawalla.siege/pack.html", "dynawalla.siege"),
+    "http://dynawalla-pack.localhost/dynawalla.siege/",
+  )
+  // An entry moved into a subdirectory still finds the manifest at the root.
+  assert.equal(
+    packRootUrl("dynawalla-pack://localhost/dynawalla.fuse/html/pack.html", "dynawalla.fuse"),
+    "dynawalla-pack://localhost/dynawalla.fuse/",
+  )
+  // No id in the URL is not a path to guess at.
+  assert.equal(packRootUrl("https://example.test/somewhere/index.html", "dynawalla.fuse"), null)
+  assert.equal(packRootUrl("dynawalla-pack://localhost/dynawalla.fuse/pack.html", ""), null)
+})
+
+/** A `fetch` that answers one URL and refuses everything else. */
+function fakeFetch(url: string, body: unknown, status = 200): typeof globalThis.fetch {
+  return ((asked: string | URL) => {
+    if (String(asked) !== url) return Promise.reject(new Error(`unexpected fetch of ${String(asked)}`))
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response)
+  }) as typeof globalThis.fetch
+}
+
+const MANIFEST_URL = "dynawalla-pack://localhost/dynawalla.trebuchet/manifest.json"
+const DOCUMENT_URL = "dynawalla-pack://localhost/dynawalla.trebuchet/pack.html"
+
+test("declaredSkills reads covers.skills off the pack's own manifest", async () => {
+  const skills = await declaredSkills({
+    packId: "dynawalla.trebuchet",
+    documentUrl: DOCUMENT_URL,
+    fetch: fakeFetch(MANIFEST_URL, { covers: { skills: TREBUCHET, grades: [1, 3] } }),
+  })
+  assert.deepEqual([...skills], TREBUCHET)
+})
+
+test("a manifest that cannot be read costs a warning and nothing else", async () => {
+  const cases: { name: string; fetch: typeof globalThis.fetch }[] = [
+    { name: "404", fetch: fakeFetch(MANIFEST_URL, {}, 404) },
+    { name: "no covers", fetch: fakeFetch(MANIFEST_URL, { id: "x" }) },
+    { name: "covers.skills is not a list", fetch: fakeFetch(MANIFEST_URL, { covers: { skills: "add" } }) },
+    { name: "a skill is not an id", fetch: fakeFetch(MANIFEST_URL, { covers: { skills: ["ok", 7] } }) },
+    { name: "the scheme refused", fetch: (() => Promise.reject(new Error("blocked by CSP"))) as typeof globalThis.fetch },
+  ]
+  for (const probe of cases) {
+    const said = await withConsole(async () => {
+      const skills = await declaredSkills({
+        packId: "dynawalla.trebuchet",
+        documentUrl: DOCUMENT_URL,
+        fetch: probe.fetch,
+      })
+      assert.equal(skills.length, 0, `${probe.name}: a broken manifest produced a restriction`)
+    })
+    const notes = said.filter((line) => line.includes("no skill restriction will be applied"))
+    assert.equal(notes.length, 1, `${probe.name}: said ${String(notes.length)} times: ${said.join(" | ")}`)
+    assert.ok(
+      notes[0]?.includes("manifest.json"),
+      `${probe.name}: the warning does not name what it tried to read: ${String(notes[0])}`,
+    )
+  }
+})
+
+test("a manifest that never answers does not hold the game up", async () => {
+  // Raced against a timer rather than simply awaited: the failure this guards
+  // against is a read that never returns, and a test that waits for one forever
+  // is a CI job that hangs instead of a test that fails.
+  const said = await withConsole(async () => {
+    const read = declaredSkills({
+      packId: "dynawalla.trebuchet",
+      documentUrl: DOCUMENT_URL,
+      timeoutMs: 5,
+      fetch: ((_url: string | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new Error("This operation was aborted"))
+          })
+        })) as typeof globalThis.fetch,
+    }).then((skills) => `gave up with ${String(skills.length)} skills`)
+    const stall = new Promise<string>((resolve) => setTimeout(() => resolve("still waiting"), 500))
+    assert.equal(
+      await Promise.race([read, stall]),
+      "gave up with 0 skills",
+      "a manifest read that never answers held the game's mount open",
+    )
+  })
+  assert.equal(said.length, 1, `a hung manifest read said: ${said.join(" | ")}`)
+})
+
+test("the declaration travels from the pack's own manifest all the way to the wire", async () => {
+  // The step `createGameHost` takes, with the two things a test cannot have —
+  // a document and a MessagePort — handed in instead.
+  const fake = fakeHost({ skillAt })
+  fake.standing = 5
+  const mounted = await attachDeclared(fake.client, {}, {
+    documentUrl: "dynawalla-pack://localhost/dynawalla.test/pack.html",
+    fetch: fakeFetch("dynawalla-pack://localhost/dynawalla.test/manifest.json", {
+      covers: { skills: TREBUCHET, grades: [1, 3] },
+    }),
+  })
+  await mounted.warm()
+  const served = await skillsServed(mounted, 8)
+  assert.ok(served.length >= 8, `only ${String(served.length)} questions were served`)
+  const foreign = served.filter((skill) => !skill.startsWith("dw.add"))
+  assert.equal(
+    foreign.length,
+    0,
+    `the manifest declared ${TREBUCHET.join(", ")} and ${String(foreign.length)} questions came ` +
+      `from ${[...new Set(foreign)].join(", ")} anyway — the declaration never reached the wire`,
+  )
+  mounted.dispose()
+})
+
+test("a skills option a game passes wins over the manifest", async () => {
+  const fake = fakeHost({ skillAt })
+  fake.standing = 5
+  const mounted = await attachDeclared(fake.client, { skills: [] }, {
+    documentUrl: "dynawalla-pack://localhost/dynawalla.test/pack.html",
+    fetch: (() => Promise.reject(new Error("the manifest must not be read"))) as typeof globalThis.fetch,
+  })
+  await mounted.warm()
+  assert.equal(
+    fake.asks.filter((ask) => ask.skillId !== undefined).length,
+    0,
+    "a pack that opted out of the restriction had a skill named on its behalf",
+  )
+  mounted.dispose()
 })

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -85,8 +85,71 @@
 // and it never chooses a difficulty of its own. That is a controller, it lives
 // in `packs/shared/game-pacing/`, and it is somebody else's file. This is the
 // wire it will drive.
+//
+// ── The other axis: what KIND of maths, not how hard ─────────────────────────
+//
+// Difficulty was only half the request. Every pack declares `covers.skills` in
+// its `pack.json`, the SDK's `ItemRequest` has carried a `skillId` since it was
+// written, and the host's `items.next` reads one — and this module never sent
+// it. A pack could not restrict the *kind* of maths it was served at all, which
+// is why TREBUCHET — a declared add/subtract game that stands a keep at the
+// answer in metres on a 122-metre field — was handed
+// `dw.mul.scale.times-power-of-ten` and asked a child to wind the arm to
+// 4,510,000 metres. It had grown a whole search phase looking for a rung it
+// could place, sweeping an axis that cannot express the thing it needed: the
+// division rungs return single-digit quotients and sit *above* placeable
+// multiplication rungs, so "how hard" and "what kind" are genuinely
+// independent orderings and no amount of `maxDifficulty` separates them.
+//
+// **The restriction is a DOMAIN, not a skill set, and that is measured.** The
+// wire names one skill, and one skill is always narrower than what a pack
+// covers, so the granularity had to be chosen against the shipped curriculum
+// (66 rungs over 20 skills) and the 27 shipped `pack.json` files:
+//
+//   * *Exactly the declared skills*: 21 of the 27 packs declare only column and
+//     regrouping skills, whose easiest rung is at ordinate 0.28 — so honouring
+//     the literal declaration would deny a six-year-old in a game that
+//     advertises grade 1 every single-digit fact the curriculum has. Four packs
+//     (arena, balance, claim, pulse) declare *nothing* the shipped ladder can
+//     generate and would be starved outright.
+//   * *The domain* — the first two segments, `dw.add` — keeps all 36 add and
+//     subtract rungs including the whole bottom of the ladder, and excludes the
+//     multiplication and division rungs the add packs never asked for. Five
+//     packs (guilty, horde, merge-idle, mosaic, serpent) declare all three
+//     domains the ladder has and are therefore unaffected, bit for bit.
+//
+// So the domain it is: `covers.skills` is treated as evidence of which domains a
+// pack works in, which is what it is honest about, and not as a whitelist of
+// rungs, which it demonstrably is not.
+//
+// **Nothing is ever refused into starvation.** A question the pack does not
+// declare is not dropped; it is held, and the host is asked *once* for a
+// declared skill instead. If that trade cannot be made — the declared skill is
+// not in this host's curriculum, or pinning it would break a ceiling the game
+// set — the held question is served anyway and the reason is said out loud. And
+// because a pack whose whole declaration is missing from the curriculum would
+// otherwise pay for that trade on every question forever, the restriction
+// SURRENDERS after `SURRENDER_AFTER` consecutive failures: it turns itself off
+// for the rest of the session, loudly, and the pack behaves exactly as it did
+// before this paragraph existed.
+//
+// **Pinning a skill is a blunt instrument and is used as little as possible.**
+// Measured against the shipped `items.ts`: a request naming a `skillId` returns
+// the *first* rung of that skill on the ladder and ignores `difficulty`
+// entirely (asking for 0.9 with a skill named returns 0.28), and it ignores
+// `maxDifficulty` too — a pin can be served *above* a stated ceiling, which
+// four shipped packs rely on being impossible. That is why the pin is a rescue
+// and not the request: an in-domain question is accepted exactly as it arrives,
+// with the host's own spread and its own idea of where the child is, and only a
+// question from a domain the pack does not work in is traded for one.
 
-import type { Capability, HostClient, Item, TransitionKind } from "../../sdk/src/index.ts"
+import type {
+  Capability,
+  HostClient,
+  Item,
+  ItemRequest,
+  TransitionKind,
+} from "../../sdk/src/index.ts"
 import { setHostInsets } from "../game-chrome/insets.ts"
 import { setHostSound } from "../game-audio/index.ts"
 import { connect } from "../../sdk/src/index.ts"
@@ -380,7 +443,7 @@ const KEEP_BAND = 0.12
  * empty pool is not a pause — it is a question with no id, whose answer is
  * dropped because there is nothing to report it against.
  */
-const FLUSH_KEEP = 8
+export const FLUSH_KEEP = 8
 
 /** Outcomes kept for a controller to read back. */
 const OUTCOME_LIMIT = 64
@@ -389,6 +452,51 @@ const OUTCOME_LIMIT = 64
 const FLOOR_REQUEST = 0.05
 
 const EPS = 1e-9
+
+/**
+ * Consecutive failed rescues after which the declaration is abandoned.
+ *
+ * Three, because the first failure is evidence and the third is a pattern. Four
+ * shipped packs (arena, balance, claim, pulse) declare only skills the current
+ * curriculum cannot generate, so for them every rescue fails, and a pack that
+ * paid for a second round trip on every question for the whole session would be
+ * a performance bug shipped in the name of a declaration nobody can honour.
+ * When it surrenders it says so — see `surrender`, which is the only place in
+ * this module that raises its voice about a thing a child will not notice.
+ */
+const SURRENDER_AFTER = 3
+
+/**
+ * Pinned questions served before the host's own stream is read again.
+ *
+ * A child's ladder walks, and it walks *through* the domains: the shipped ladder
+ * interleaves multiplication rungs between two bands of addition, so a pack that
+ * had to start naming a skill at ordinate 0.45 must notice when the child
+ * arrives at 0.6 and the host's own stream is something it covers again. Eight
+ * questions is about a minute of play, and the alternative — never looking — is
+ * a pack pinned to one rung for the rest of the session.
+ */
+const PEEK_EVERY = 8
+
+/**
+ * The domain a skill id belongs to: `dw.add` out of `dw.add.regroup.add-short`.
+ *
+ * Two segments, because that is where the curriculum's own naming puts the
+ * boundary between "what kind of maths" (`add`, `mul`, `div`, `frac`, `alg`,
+ * `ns`) and "which technique within it" (`facts`, `column`, `regroup`), and it
+ * is the coarser of the two that a pack's `covers.skills` is actually honest
+ * about — see the module note for the measurement.
+ *
+ * An id with fewer than three segments is its own domain rather than an error:
+ * this reads ids off a wire, a host is free to name a skill whatever it likes,
+ * and the only wrong answer here is one that quietly groups two unrelated
+ * skills together.
+ */
+export function domainOf(skillId: string): string {
+  const parts = skillId.split(".")
+  if (parts.length < 3) return skillId
+  return `${parts[0] ?? ""}.${parts[1] ?? ""}`
+}
 
 export type GameHostOptions = {
   /** Domain label the game shows or logs. Cosmetic; the host owns the skill. */
@@ -408,6 +516,22 @@ export type GameHostOptions = {
    * turns it off and calls `flush` itself.
    */
   readonly autoFlush?: boolean
+  /**
+   * The skill ids this pack declares it covers — `covers.skills` from its own
+   * `pack.json`, as built into `manifest.json`.
+   *
+   * `createGameHost` reads it off the pack's own manifest, so no game passes it
+   * and no game has to be edited; it is an option because that is what makes
+   * the behaviour testable without a `fetch`, and because a game that wants no
+   * restriction at all can pass `[]` and say so in one place.
+   *
+   * What is honoured is the DOMAINS these ids belong to, not the ids
+   * themselves, and only as far as the host can satisfy them — see the module
+   * note for why that is the granularity and what happens when it cannot be
+   * met. An empty list, or a list whose domains the host has no content in,
+   * behaves exactly as this module did before the field existed.
+   */
+  readonly skills?: readonly string[]
 }
 
 export type MountedHost = {
@@ -424,13 +548,24 @@ type Pooled = {
   readonly skillId: string
 }
 
+/**
+ * Where an item sits on the host's whole ladder, 0..1.
+ *
+ * The `level / 8` fallback is for a host older than the `difficulty` field and is
+ * the reading this module always had. Read through one function so that a
+ * ceiling check, a pin measurement and a printed number cannot each pick a
+ * different fallback — which they did, and one of them picked 0, i.e. "never
+ * above any ceiling".
+ */
+function ordinateOf(item: Item): number {
+  return item.difficulty ?? item.level / 8
+}
+
 function questionFrom(item: Item, canonical: string, domain: string): Question {
   const distractors = (item.choices ?? [])
     .map((choice) => choice.text)
     .filter((text) => text !== canonical)
-  // The host's own ladder ordinate when it sends one. The `level / 8` fallback
-  // is for a host older than this field and is the reading it always had.
-  const ladder = item.difficulty ?? item.level / 8
+  const ladder = ordinateOf(item)
   return {
     id: item.id,
     prompt: item.prompt,
@@ -438,6 +573,86 @@ function questionFrom(item: Item, canonical: string, domain: string): Question {
     distractors,
     domain,
     difficulty: Math.max(0, Math.min(1, ladder)),
+  }
+}
+
+/** How long a manifest read may take before the game starts without it. */
+const MANIFEST_TIMEOUT_MS = 3000
+
+/**
+ * Where this pack's own files live, given the document it is running in.
+ *
+ * A pack is served at `dynawalla-pack://localhost/<packId>/<file>` (or
+ * `http://dynawalla-pack.localhost/<packId>/<file>` on Android and Windows), and
+ * the entry document is somewhere inside that directory. Cut at the pack id
+ * rather than taking the document's own directory, so an entry moved into a
+ * subfolder does not silently start reading a manifest that is not there.
+ *
+ * `null` when the id does not appear in the URL at all, which is a pack being
+ * served from somewhere this function was not told about — the caller treats
+ * that as "no declaration" and says so, rather than guessing a path.
+ */
+export function packRootUrl(documentUrl: string, packId: string): string | null {
+  if (packId === "") return null
+  const marker = `/${packId}/`
+  const at = documentUrl.lastIndexOf(marker)
+  if (at < 0) return null
+  return documentUrl.slice(0, at + marker.length)
+}
+
+/**
+ * `covers.skills` out of the pack's own built manifest.
+ *
+ * **Why a fetch and not a build-time constant.** This module is compiled into
+ * all 27 packs by 27 separate vite configs and has no path to any one pack's
+ * `pack.json`; the host knows every manifest but the wire has no field for it
+ * (`Connect` carries `packId`, `granted` and `settings`, and adding to it is a
+ * protocol change through the app). What every pack *does* have is
+ * `manifest.json` at its own root, written by `packs/build.mjs`, validated by
+ * `dw-pack check`, and served by the same scheme handler that serves the game —
+ * with `Access-Control-Allow-Origin: *` and the scheme in `connect-src`,
+ * precisely so a pack can read its own data from an opaque origin.
+ *
+ * **It fails open, and it says so.** Everything here is best-effort: no
+ * declaration is the state every pack was in until now, so a manifest that
+ * cannot be read costs a warning and nothing else. It is a `warn` and not an
+ * `error` because it is also the honest state of a pack opened outside a host.
+ */
+export async function declaredSkills(deps: {
+  readonly packId: string
+  readonly documentUrl: string
+  readonly fetch: typeof globalThis.fetch
+  readonly timeoutMs?: number
+}): Promise<readonly string[]> {
+  const root = packRootUrl(deps.documentUrl, deps.packId)
+  const url = root === null ? null : `${root}manifest.json`
+  const giveUp = (why: string): readonly string[] => {
+    console.warn(
+      `[pack] the declared skills could not be read from ${url ?? "an unknown manifest URL"} ` +
+        `(${why}); no skill restriction will be applied and questions from every domain the ` +
+        `host has will be served`,
+    )
+    return []
+  }
+  if (url === null) return giveUp(`"${deps.packId}" is not in the document URL ${deps.documentUrl}`)
+  const abort = new AbortController()
+  const timer = setTimeout(() => {
+    abort.abort()
+  }, deps.timeoutMs ?? MANIFEST_TIMEOUT_MS)
+  try {
+    const response = await deps.fetch(url, { cache: "no-store", signal: abort.signal })
+    if (!response.ok) return giveUp(`HTTP ${String(response.status)}`)
+    const body: unknown = await response.json()
+    const covers = (body as { covers?: unknown } | null)?.covers
+    const skills = (covers as { skills?: unknown } | undefined)?.skills
+    if (!Array.isArray(skills)) return giveUp("covers.skills is not an array")
+    const ids = skills.filter((id): id is string => typeof id === "string" && id !== "")
+    if (ids.length !== skills.length) return giveUp("covers.skills holds something that is not an id")
+    return ids
+  } catch (error) {
+    return giveUp(error instanceof Error ? error.message : String(error))
+  } finally {
+    clearTimeout(timer)
   }
 }
 
@@ -449,7 +664,34 @@ function questionFrom(item: Item, canonical: string, domain: string): Question {
  * forever, and the games' entry files render that message.
  */
 export async function createGameHost(options: GameHostOptions = {}): Promise<MountedHost> {
-  return attachGameHost(await connect(), options)
+  return await attachDeclared(await connect(), options, {
+    documentUrl: document.baseURI,
+    fetch: globalThis.fetch.bind(globalThis),
+  })
+}
+
+/**
+ * `createGameHost` minus the connection: read the pack's own declaration, then
+ * attach.
+ *
+ * Separate for the reason the whole module is separate — a `document` and a
+ * `MessagePort` are the two things a test cannot have — and so the step between
+ * `manifest.json` and the wire is one a test can walk end to end rather than a
+ * line of glue nobody ever ran.
+ *
+ * The declaration is read BEFORE the game mounts, so the very first `warm()`
+ * question is already restricted: trebuchet's opening wave is the one this
+ * exists for, and a declaration that arrives a round trip late is a declaration
+ * that does not cover it.
+ */
+export async function attachDeclared(
+  client: HostClient,
+  options: GameHostOptions,
+  deps: { readonly documentUrl: string; readonly fetch: typeof globalThis.fetch },
+): Promise<MountedHost> {
+  const skills =
+    options.skills ?? (await declaredSkills({ packId: client.packId, ...deps }))
+  return attachGameHost(client, { ...options, skills })
 }
 
 /**
@@ -521,6 +763,43 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   let filledFor: number | null = null
   let lastFlush = 0
 
+  // ── What kind of maths this pack declared it does ──────────────────────────
+
+  /** `covers.skills`, in declaration order. Empty means "no restriction". */
+  const declared = (options.skills ?? []).filter((id) => id !== "")
+  /** The domains those ids belong to. What is actually honoured. */
+  const domains = new Set(declared.map(domainOf))
+  /**
+   * What a pin for each declared skill was observed to return.
+   *
+   * Learned rather than assumed, because a pack cannot see the host's ladder:
+   * naming a skill returns one fixed rung, and where that rung sits is a fact
+   * only the host knows. Recorded from the pinned request that discovered it,
+   * which is why it is the ordinate a *future* pin for the same skill will get
+   * and not a guess derived from some other arrival.
+   */
+  const pinOrdinate = new Map<string, number>()
+  /** Declared skills this host demonstrably does not have. Never pinned twice. */
+  const absentSkills = new Set<string>()
+  /** Consecutive rescues that failed to produce a question the pack declares. */
+  let rescuesFailed = 0
+  /** Set once the declaration has been abandoned for the session. */
+  let surrendered = false
+  /**
+   * Whether the host's own stream is currently outside what this pack covers.
+   *
+   * A budget, not a preference. Asking, refusing and asking again costs four
+   * calls a question — two `items.next`, a `reveal` and a `skip` — and the host
+   * allows 120 in a sliding second: `warm()` stocks 32 questions back to back, so
+   * the refuse-and-retry shape crosses that window at mount and the pool comes up
+   * short with a rate-limit error. Once the host is known to be parked somewhere
+   * this pack cannot use, the declared skill is asked for directly and a question
+   * costs exactly what it cost before this file learned about domains.
+   */
+  let parked = false
+  /** Pinned questions served since the host's own position was last read. */
+  let sincePeek = 0
+
   /**
    * Things said once per mount.
    *
@@ -534,6 +813,12 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     if (spoken.has(key)) return
     spoken.add(key)
     console.warn(message)
+  }
+  /** The same, at the volume a thing that needs fixing in the repository gets. */
+  const shoutOnce = (key: string, message: string) => {
+    if (spoken.has(key)) return
+    spoken.add(key)
+    console.error(message)
   }
 
   const canReveal = granted.has("items.reveal")
@@ -571,11 +856,228 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     return unit
   }
 
-  const askShape = (): { difficulty?: number; maxDifficulty?: number } => {
-    const ask: { difficulty?: number; maxDifficulty?: number } = {}
+  /**
+   * What the pool should be stocked and searched against, or `null` for
+   * "whatever is in it".
+   *
+   * The game's own request when it makes one, and otherwise where the host's
+   * ladder actually is. A `null` here means neither is known, which happens only
+   * before the first item has ever arrived.
+   */
+  const aim = (): number | null => target ?? fresh
+
+  /**
+   * The request, as one object, in one place.
+   *
+   * `pin` names a skill and is the rescue described in the module note, never
+   * the standing request: a pinned request is served the first rung of that
+   * skill whatever `difficulty` and `maxDifficulty` say, so sending one by
+   * default would replace the host's model of where a child is with a pack's
+   * guess at it. The difficulty fields travel with it anyway — the host reads
+   * them to keep the child's ladder position moving even on a request whose
+   * rung it will not choose with them.
+   */
+  const askShape = (pin?: string): ItemRequest => {
+    const ask: { difficulty?: number; maxDifficulty?: number; skillId?: string } = {}
     if (target !== null) ask.difficulty = target
     if (ceiling !== null) ask.maxDifficulty = ceiling
+    if (pin !== undefined) ask.skillId = pin
     return ask
+  }
+
+  /** Whether the pack's declaration is being honoured at this moment. */
+  const restricting = (): boolean => domains.size > 0 && !surrendered
+
+  /** Whether a skill is one this pack works in. */
+  const admits = (skillId: string): boolean => domains.has(domainOf(skillId))
+
+  /** Whether an item is above a ceiling the game set. */
+  const overCeiling = (item: Item): boolean =>
+    ceiling !== null && ordinateOf(item) > ceiling + EPS
+
+  /**
+   * Close an item the pack asked for and is not going to use.
+   *
+   * The alternative is leaving it open in the host's ledger, which costs a child
+   * nothing but does mean an unanswered item per rescue for a whole session.
+   * Failure is the older-host case and is already said out loud by `skip`.
+   */
+  const close = (itemId: string) => {
+    void client.skip(itemId).catch(() => {
+      // Deliberately quiet HERE: `host.skip` owns that message, says it once,
+      // and states the consequence. Two copies of it is one too many.
+    })
+  }
+
+  /**
+   * The declared skill to ask for instead, or `null` when there is none left.
+   *
+   * Unmeasured candidates first, and that is the whole of the search: a pin
+   * returns one fixed rung and nothing tells a pack where that rung is until it
+   * has asked, so each declared skill is worth one exploratory request and
+   * after that the set is known and the nearest one to what the game wants is
+   * chosen from it. Bounded by the size of the declaration, which the manifest
+   * schema caps at 512 and which no shipped pack takes past nine.
+   *
+   * A candidate known to sit above the game's own ceiling is never chosen while
+   * another exists — a pinned request ignores `maxDifficulty`, so respecting it
+   * is this side's job.
+   */
+  const rescueSkill = (): string | null => {
+    const candidates = declared.filter((id) => !absentSkills.has(id))
+    const unmeasured = candidates.filter((id) => !pinOrdinate.has(id))
+    if (unmeasured.length > 0) return unmeasured[0] ?? null
+    if (candidates.length === 0) return null
+    const want = aim() ?? 0
+    const score = (id: string): number => {
+      const ordinate = pinOrdinate.get(id) ?? 0
+      const over = ceiling !== null && ordinate > ceiling + EPS
+      return Math.abs(ordinate - want) + (over ? 1000 : 0)
+    }
+    return [...candidates].sort((a, b) => score(a) - score(b))[0] ?? null
+  }
+
+  /** Give up on the declaration for the rest of the session, loudly. */
+  const surrender = (why: string) => {
+    surrendered = true
+    shoutOnce(
+      "surrender",
+      `[pack] this pack's covers.skills names ${domains.size === 1 ? "the domain" : "the domains"} ` +
+        `${[...domains].join(", ")} and this host cannot serve ${why} — the declaration is now ` +
+        `IGNORED for the rest of this session and questions from any domain will be served, ` +
+        `because a game with no questions is worse than a game with the wrong ones. Either the ` +
+        `pack declares skills the curriculum does not have, or the curriculum has lost them.`,
+    )
+  }
+
+  /** Reveal the answer and build the question, or `null` if it cannot be placed. */
+  const draw = async (item: Item): Promise<Pooled | null> => {
+    const canonical = canReveal ? await client.reveal(item.id) : ""
+    if (canonical === "") {
+      // No reveal grant means no placeable answer. Both games need one,
+      // so this is loud rather than a silently duller game.
+      console.error("[pack] items.reveal was not granted; questions cannot be placed")
+      return null
+    }
+    const question = questionFrom(item, canonical, domain)
+    // The freshest reading of where the questions are coming from, taken on
+    // arrival rather than on hand-out: a question that is still in the pool has
+    // already told us something, and waiting until a child sees it is waiting the
+    // length of the pool. Taken from whatever is actually pooled, including a
+    // rung this module asked for by name — aiming the pool somewhere none of its
+    // contents can be is what makes a flush discard a pool it just filled, and it
+    // was measured costing a restricted pack a third of its requests again.
+    fresh = question.difficulty
+    return { question, skillId: item.skillId }
+  }
+
+  /**
+   * One question from the host, in a domain this pack declared if that is
+   * possible and with the reason said out loud when it is not.
+   *
+   * `null` is "stop asking for now" — the host has nothing, or the answer could
+   * not be revealed — and is the same signal both call sites already broke on.
+   */
+  /** What a pin for `skill` turned out to return, or that the host lacks it. */
+  const record = (skill: string, item: Item) => {
+    if (item.skillId === skill) pinOrdinate.set(skill, ordinateOf(item))
+    else absentSkills.add(skill)
+  }
+
+  const acquire = async (): Promise<Pooled | null> => {
+    // While the host is parked outside what this pack covers, ask for a declared
+    // skill directly rather than asking, refusing and asking again — see `parked`
+    // for the request budget that makes this the difference between a stocked
+    // pool and a rate-limited one. Every `PEEK_EVERY` questions it falls through
+    // anyway, because the only way to find out that the child's ladder has walked
+    // back into this pack's own domain is to let the host answer for itself.
+    if (restricting() && parked && sincePeek < PEEK_EVERY) {
+      const pin = rescueSkill()
+      if (pin !== null) {
+        sincePeek += 1
+        const pinned = await client.nextItem(askShape(pin))
+        if (pinned !== null) {
+          record(pin, pinned)
+          if (admits(pinned.skillId) && !overCeiling(pinned)) return await draw(pinned)
+          // The pin stopped working — the host lost the skill, or the game has
+          // since set a ceiling below it. Fall through to the host's own stream,
+          // which is where the accounting and the announcements live.
+          close(pinned.id)
+        }
+      }
+      parked = false
+    }
+    sincePeek = 0
+
+    const arrival = await client.nextItem(askShape())
+    if (arrival === null) return null
+    if (!restricting() || admits(arrival.skillId)) {
+      // The host is serving something this pack covers, so it is not parked and
+      // the next question is its own again — levels, spread and all.
+      parked = false
+      return await draw(arrival)
+    }
+
+    const pin = rescueSkill()
+    if (pin === null) {
+      surrender("any of them")
+      return await draw(arrival)
+    }
+    const swap = await client.nextItem(askShape(pin))
+    if (swap === null) {
+      // The host had one question and not two. Use the one it gave.
+      return await draw(arrival)
+    }
+    record(pin, swap)
+
+    if (overCeiling(swap)) {
+      // A pinned request is served whatever rung the skill sits on, ceiling or
+      // no ceiling — proved against the shipped host, which returns 0.28 for a
+      // pin under a `maxDifficulty` of 0.1. A game that set a ceiling did so
+      // because it cannot draw above it, and honouring one declaration by
+      // breaking another is not a trade this module makes.
+      sayOnce(
+        "pin-ceiling",
+        `[pack] "${pin}" is the nearest skill this pack declares and it sits at ` +
+          `${ordinateOf(swap).toFixed(2)}, above the maxDifficulty of ` +
+          `${(ceiling ?? 1).toFixed(2)} this game set — the ceiling wins, so a question from ` +
+          `"${arrival.skillId}" is being served instead of one this pack declares`,
+      )
+      close(swap.id)
+      rescuesFailed += 1
+      if (rescuesFailed >= SURRENDER_AFTER) surrender("anything under the ceiling this game set")
+      return await draw(arrival)
+    }
+
+    if (!admits(swap.skillId)) {
+      close(swap.id)
+      rescuesFailed += 1
+      if (rescuesFailed >= SURRENDER_AFTER) surrender(`"${pin}" or the rest of them`)
+      else {
+        sayOnce(
+          "pin-missing",
+          `[pack] this pack declares "${pin}" and this host does not have it — it answered with ` +
+            `"${swap.skillId}" instead, so a question outside ${[...domains].join(", ")} is being ` +
+            `served`,
+        )
+      }
+      return await draw(arrival)
+    }
+
+    rescuesFailed = 0
+    // The host is somewhere this pack cannot use and the trade worked, so the
+    // questions after this one ask for the declared skill directly.
+    parked = true
+    sayOnce(
+      "rescued",
+      `[pack] the host served "${arrival.skillId}" at ${ordinateOf(arrival).toFixed(2)}, ` +
+        `which is outside the ${[...domains].join(", ")} this pack's covers.skills declares; it ` +
+        `was asked again for "${pin}" and got "${swap.skillId}" at ` +
+        `${ordinateOf(swap).toFixed(2)}. This costs one extra request per question for as ` +
+        `long as the child's ladder position sits outside what this pack covers.`,
+    )
+    close(arrival.id)
+    return await draw(swap)
   }
 
   const fill = () => {
@@ -587,22 +1089,9 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
           if (Date.now() - lastAsk > IDLE_MS) break
           // Read every time round the loop, not once: a difficulty change while
           // a refill is in flight has to reach the questions still to come.
-          const item = await client.nextItem(askShape())
-          if (item === null) break
-          const canonical = canReveal ? await client.reveal(item.id) : ""
-          if (canonical === "") {
-            // No reveal grant means no placeable answer. Both games need one,
-            // so this is loud rather than a silently duller game.
-            console.error("[pack] items.reveal was not granted; questions cannot be placed")
-            break
-          }
-          const question = questionFrom(item, canonical, domain)
-          // The freshest reading of where the host stands, taken on arrival
-          // rather than on hand-out: a question that is still in the pool has
-          // already told us something, and waiting until a child sees it is
-          // waiting the length of the pool.
-          fresh = question.difficulty
-          pool.push({ question, skillId: item.skillId })
+          const entry = await acquire()
+          if (entry === null) break
+          pool.push(entry)
         }
       } catch (error) {
         console.error("[pack] could not fill the question pool", error)
@@ -611,16 +1100,6 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       }
     })()
   }
-
-  /**
-   * What the pool should be stocked and searched against, or `null` for
-   * "whatever is in it".
-   *
-   * The game's own request when it makes one, and otherwise where the host's
-   * ladder actually is. A `null` here means neither is known, which happens only
-   * before the first item has ever arrived.
-   */
-  const aim = (): number | null => target ?? fresh
 
   /** How wrong a pooled question is for what the game is asking for now. */
   const distance = (entry: Pooled): number => {
@@ -895,14 +1374,15 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     warm: async () => {
       // Awaited so the first frame the child sees is already stocked. Filling
       // in the background and hoping is how a game shows a blank chip once.
+      //
+      // Through `acquire` like every other question, so the declaration covers
+      // the opening wave too: trebuchet's first wave was the unplayable one, and
+      // a restriction that starts working on question nine is a restriction that
+      // misses the only part of the session a child might not come back from.
       for (let i = 0; i < POOL_FLOOR && !disposed; i++) {
-        const item = await client.nextItem(askShape())
-        if (item === null) break
-        const canonical = canReveal ? await client.reveal(item.id) : ""
-        if (canonical === "") break
-        const question = questionFrom(item, canonical, domain)
-        fresh = question.difficulty
-        pool.push({ question, skillId: item.skillId })
+        const entry = await acquire()
+        if (entry === null) break
+        pool.push(entry)
       }
       fill()
     },


### PR DESCRIPTION
## The chain, verified end to end

| link | state | evidence |
| --- | --- | --- |
| `pack.json` declares `covers.skills` | works, all 27 packs | `dw-pack check` fails a pack without it; capped at 512 ids |
| SDK `ItemRequest.skillId` | works | `packs/sdk/src/guest.ts:57`, sent by omission at `:251` |
| host `items.next` honours it | works, **bluntly** | `items.ts:1085` — `rungs.find(r => r.node.id === skillId) ?? rungAt(drawn)` |
| `game-host`'s `askShape()` sends it | **broken. Never sent one.** | `{ difficulty, maxDifficulty }` and nothing else |

**Where it broke: only in `askShape()`** — and the honouring on the other side is
narrower than the declaration, which is what decided the design.

Measured against the shipped `items.ts` with the real 66-rung ladder
(`createItemService` + `ladder()`, no fakes):

```
no request                                        dw.add.facts.add-within-ten L0 ord=0.000
difficulty 0.9                                    dw.mul.multidigit.long-mult L0 ord=0.908
skillId=add-no-regroup + difficulty 0.9           dw.add.column.add-no-regroup L0 ord=0.277  ← difficulty IGNORED
skillId=add-no-regroup + maxDifficulty 0.1        dw.add.column.add-no-regroup L0 ord=0.277  ← CEILING IGNORED
skillId=dw.frac.arith.add-like-denominators       dw.div.facts.division-facts L2 ord=0.508   ← unknown id falls back
pin ×6                                            add-no-regroup L0 every time               ← level never moves
```

A pin returns one fixed rung, ignores `difficulty`, and **can be served above a
`maxDifficulty` a game set** — which counterweight, polarity, balance and horde
rely on being impossible (PR 694 exists because polarity was handed a rung it
could not render). So a pin cannot be the standing request.

## Granularity: the domain, and it is measured not argued

`covers.skills` across the 27 packs against the 66 rungs the shipped curriculum
actually generates:

| granularity | 21 add-only packs | arena / balance / claim / pulse | trebuchet |
| --- | --- | --- | --- |
| exactly the declared skills | 22/66, **floor rises 0.00 → 0.28** | **starved, 0/66** | 13/66, 0.28–0.80 |
| `dw.add` (shipped) | 36/66, 0.00–0.98 | starved → surrenders | 36/66, 0.00–0.98 |
| `dw.add.column` (topic) | 22/66, floor 0.28 | starved | 22/66 |

Honouring the literal skill list would deny a six-year-old in a game that
advertises grade 1 every single-digit fact the curriculum has. The domain keeps
the whole bottom of the ladder and drops only the domains a pack never claimed —
which is exactly trebuchet's `dw.mul.scale.times-power-of-ten`.

## Is `covers.skills` accurate? Mostly not, and here is the list

`dw.ns.*`, `dw.alg.*` and `dw.frac.*` **do not exist in the active curriculum at
all**. 14 declared ids across 8 packs are dead:

| pack | declared | absent from the ladder | effect of honouring it |
| --- | --- | --- | --- |
| arena | 1 | **1 (all)** `dw.ns.compare.whole-numbers` | surrenders after 2 requests, then identical to today |
| balance | 5 | **5 (all)** `dw.alg.equality.*` | surrenders, identical to today |
| claim | 3 | **3 (all)** `dw.frac.*` | surrenders, identical to today |
| pulse | 4 | **4 (all)** `dw.frac.arith.*` | surrenders, identical to today |
| rhythm | 6 | 5 `dw.frac.*` | **narrows to `dw.mul` only; floor rises 0.00 → 0.215** |
| serpent | 8 | 4 | none — declares all 3 live domains |
| polarity | 5 | 3 `dw.alg.equality.*` | none — its `dw.add` ids cover the domain |
| fuse, siege | 4 each | 1 `dw.add.regroup.subtract-tenths` | drops mul/div; keeps the whole add domain |
| guilty, horde, merge-idle, mosaic | — | 0 | **none, bit for bit** — all 3 domains declared |

**rhythm is the one pack whose stream materially narrows** (a fractions game left
with multiplication because its fractions do not exist yet). It is not broken —
it renders whatever arrives — but that is the one row worth a second opinion, and
the fix is on rhythm's side or the curriculum's. Order of work I would suggest:
(1) this PR, (2) authorise `dw.frac.*`/`dw.alg.*`/`dw.ns.*` or correct those
five packs' declarations, (3) revisit `PEEK_EVERY` once packs stop being pinned.

## What ships

* **`askShape(pin?)`** is the one place a request is assembled, and it now carries
  a `skillId` when there is one.
* **A rescue, not a filter.** An in-domain arrival is used exactly as it comes —
  the host's own spread, levels and position. Only a foreign-domain arrival is
  traded, by asking again for the declared skill nearest what the game is aiming
  at (each declared skill measured once, because a pack cannot see where a pinned
  rung sits until it asks).
* **Never starves.** Trade impossible → the held question is served and the reason
  said out loud. Ceiling below the only declared skill → **the ceiling wins**.
  Three consecutive failures → the declaration is surrendered for the session with
  a `console.error` naming the domains, and the pack behaves as it did before.
* **The request budget is part of the design.** Refuse-and-retry costs 4 calls a
  question and `warm()` stocks 32 back to back, which crosses the host's
  120-per-sliding-second window — a restricted pack would have been rate-limited
  at mount. Once the host is known to be parked outside the pack's domains the
  declared skill is asked for directly, and the host's stream is re-read every 8
  questions so a child whose ladder walks back into the pack's own domain gets it.
  Measured: 1.0× the baseline burst, 1.19× over a 24-question session.
* **Backwards compatible.** No declaration, an empty one, or one the host cannot
  satisfy ⇒ byte-identical behaviour. `skills: []` is the documented opt-out.
* `covers.skills` is read from the pack's own `manifest.json` (the host has every
  manifest but `Connect` has no field for it, and this module is bundled into 27
  packs with a path to none of their `pack.json` files). Fails open with a
  warning, 3s timeout, injected as an option so it is testable in Node.

## Standards

18 new tests, 50 total, green 5× in a row. Every test was checked by deleting the
thing it covers — **16 mutations, 16 red suites**, three of which were vacuous on
the first attempt and were rewritten until they bit:

```
A  askShape drops the pin        ✖ 12 of 12 questions came from a domain this pack does not declare
B  parked ceiling check deleted  ✖ 27 requests named a skill the pack already knew sits above the ceiling
B2 rescue ceiling check deleted  ✖ a question at 0.27 was served under a ceiling of 0.20
C  surrender never takes effect  ✖ 88 trades were attempted for a skill that can never be served
D  refused question not closed   ✖ a rescued question was abandoned open in the host's ledger
E  rescue everything             ✖ 73 requests pinned a skill while the host was already serving one the pack declares
F  always take the first skill   ✖ the second declared skill was not measured next
G  ignore what the game aims at  ✖ aiming at 0.60 traded for the skill at 0.27 rather than the one at 0.80
H  never remember an absent id   ✖ 3 pinned requests were sent for a skill the host does not have
I  no parked shortcut            ✖ 130 calls with a declaration against 66 without — 1.97× the burst
J  never re-read the host        ✖ the child's ladder walked to 0.93 and the pack was still served 0.27 at best
K  accept a non-string id        ✖ a skill is not an id: a broken manifest produced a restriction
L  packRootUrl takes dirname     ✖ (subdirectory entry resolved to the wrong manifest)
M  no manifest timeout           ✖ a manifest read that never answers held the game's mount open
N  domainOf keeps the whole id   ✖ (exact-skill granularity) + the ladder-walk test also goes red
O  createGameHost drops skills   ✖ the declaration never reached the wire
```

The test fake's host was made faithful first: `ask.skillId` returns the first rung
carrying that skill, ignoring difficulty and ceiling, because that is what the
shipped `items.ts` does.

## Verified / not verified

* Verified: `game-host` 50 tests × 5, `tsc` clean; SDK 94 tests; balance (68) and
  trebuchet (177) tests plus their `tsc`; a real `vite build` of the trebuchet pack
  with the manifest reader present in the bundle.
* **Not verified: the `manifest.json` fetch on a device.** No shipped pack fetches
  anything today. It should work — the Rust scheme handler serves every pack file
  with `Access-Control-Allow-Origin: *` and `Cross-Origin-Resource-Policy:
  cross-origin` "so the pack can fetch its own level data", `connect-src` names
  the scheme, and `manifest.json` is written to the pack root by
  `packs/build.mjs` — but it has never been exercised from an opaque-origin frame
  in WKWebView. If it fails, every pack keeps today's behaviour and prints one
  warning naming the URL, which is the failure mode I chose for exactly this
  reason.
* **Pre-existing, not touched, worth a look:** `warm()` + the first `take()`
  already spend ~128 client calls in a burst against a 120-per-sliding-second
  limit, unrestricted. If that trips in production, `fill` logs "could not fill
  the question pool" and the pool comes up short. Nothing here made it worse
  (1.0× the burst) but it looks like a live bug.
* `dynawalla/games/**`, `frame.ts` and `items.ts` untouched, as instructed — which
  is also why the pin's bluntness is worked around here rather than fixed at the
  source. **The better fix is in `items.ts`:** let `items.next` take a set of
  skills or a domain and apply `difficulty` WITHIN it, at which point the rescue,
  the parked shortcut and the peek in this file all collapse into one honest
  request. Recommend that as the follow-up.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb