### PR TITLE
fix(dynawalla/games/gavel): a magnitude is not a rung, a cap above its own bound is dead code, and four numerals were under the floor

### DIFF
--- a/dynawalla/games/gavel/src/game/auction.ts
+++ b/dynawalla/games/gavel/src/game/auction.ts
@@ -85,9 +85,17 @@ export const MAX_CONSIGNMENT = 12
  * The assembler wants a wide choice — see `lot.ts` — and the bench is what stops that
  * costing ten fresh questions a lot. The cap is what stops it becoming a hoard: a
  * benched question the room never wants is closed rather than held forever, oldest
- * first, so the bench turns over on its own as the ladder moves.
+ * first.
+ *
+ * **It must be smaller than `POOL_EXTRA` or it is dead code.** The assembler fills to
+ * `want + POOL_EXTRA` and keeps `want`, so the bench it hands back is at most
+ * `POOL_EXTRA` entries — and the first version of this constant was 14 against a
+ * `POOL_EXTRA` of 10. Instrumented over 120 lots: max bench 10, trims executed 0. The
+ * hoard the cap exists to prevent was therefore real and unprevented, because
+ * `tightest` keeps the cluster and benches the outliers, so ten questions the room never
+ * wants would have sat open in the host's ledger for the whole session.
  */
-export const BENCH_CAP = 14
+export const BENCH_CAP = 7
 
 /**
  * What the broker pays for being told a lot is not worth bidding on.
@@ -204,6 +212,15 @@ export class Auction {
   coins = 0
   /** Lots bought above the offer and still on the shelf. Countable, and it stays. */
   storeroom = 0
+  /**
+   * Benched questions closed to keep the bench inside `BENCH_CAP`.
+   *
+   * Test-facing, and it exists because the cap it counts was dead code once already: at
+   * `BENCH_CAP = 14` against a `POOL_EXTRA` of 10 the trim could never run, two tests
+   * claimed to guard it, and both passed with the whole trim deleted. A counter is the
+   * cheapest thing that cannot be satisfied by the ordinary per-lot closing.
+   */
+  trimmed = 0
   readonly tally: Tally = {
     sold: 0,
     even: 0,
@@ -281,6 +298,11 @@ export class Auction {
 
   get ceiling(): number | null {
     return this.drawCeiling
+  }
+
+  /** Questions drawn, unshown, and waiting for a board. Test-facing. */
+  get benched(): number {
+    return this.bench.length
   }
 
   get stalled(): boolean {
@@ -536,6 +558,25 @@ export class Auction {
     return [{ kind: "settled", settled }]
   }
 
+  /**
+   * Close every question this pack is still holding.
+   *
+   * Called from `unmount`. A pack that is going away holds up to `POOL_EXTRA` on the
+   * bench plus the three to five on the live board — about fifteen questions that were
+   * drawn, never shown and never answered. `lot.ts` says outright that such a question
+   * "has to be skipped, not silently dropped, or it stays open in the host's ledger
+   * forever", and this is the one path where that was not honoured.
+   *
+   * An open item costs a child nothing, so this is tidiness rather than a defect. It is
+   * here because this game holds fifteen of them where a one-question game holds one.
+   */
+  closeAll(): void {
+    for (const tablet of this.bench) this.close(tablet)
+    this.bench = []
+    for (const tablet of this.roomState?.tablets ?? []) this.close(tablet)
+    this.roomState = null
+  }
+
   /** The reveal is over. Wrap the consignment if it is empty, then draw a room. */
   private nextLot(now: number): AuctionEvent[] {
     const events: AuctionEvent[] = []
@@ -585,7 +626,10 @@ export class Auction {
     this.bench = [...assembly.bench]
     while (this.bench.length > BENCH_CAP) {
       const stale = this.bench.shift()
-      if (stale) this.close(stale)
+      if (stale) {
+        this.close(stale)
+        this.trimmed += 1
+      }
     }
 
     if (!assembly.room) {

--- a/dynawalla/games/gavel/src/game/ladder.ts
+++ b/dynawalla/games/gavel/src/game/ladder.ts
@@ -53,10 +53,9 @@ export const SPEC: FlowSpec = {
  *
  * A number, not a measurement. `settle` needs a step to move on and the only
  * honest step in a game with no clock is "one lot happened": six is roughly what
- * a lot takes when a child knows what they are doing, so `climbSeconds: 300`
- * reads as "fifty unhurried lots to cross the whole ladder at the slowest
- * climb", and `climbBoost` carries somebody who is obviously fluent up in five
- * or six.
+ * a lot takes when a child knows what they are doing, so `climbSeconds` reads
+ * as "seventy unhurried lots to cross the whole ladder at the slowest climb", and
+ * `climbBoost` carries somebody who is obviously fluent up in about a dozen.
  */
 export const LOT_STEP_SECONDS = 6
 
@@ -139,14 +138,21 @@ export function settleAfterLot(intensity: number, success: number): number {
 // ── what fits on a tablet ────────────────────────────────────────────────────
 
 /**
- * The largest bid the paddle can hold and the largest value a tablet can carry.
+ * The largest value a tablet can carry, and the paddle that has to hold one more.
  *
- * Five digits fit on the paddle; four is the cap on what the room may ask for,
- * because the broker's offer sits above the highest rival bid and the child's
- * bid sits above that, and all three have to stay inside the same paddle.
+ * The chain is: a rival bids `v`, the broker's offer sits up to `MAX_MARGIN` above it,
+ * and the child's bid sits above the rival — so the paddle has to hold `v + MAX_MARGIN`
+ * and `MAX_TABLET_VALUE` is that bound read backwards from five digits.
+ *
+ * **It was 9,999, and that was a real cost.** `dw.mul.multidigit.times-one-digit` is
+ * active and reaches `4827 × 6 = 28962`, so about half that rung's items were refused —
+ * and the refusal used to cap the whole rung and everything above it, which took
+ * `dw.add.regroup.subtract-across-zero` out of the run entirely even though its answers
+ * fit a tablet perfectly. Widening the paddle is the honest half of that fix; the other
+ * half is `rungCannotDraw` below, which no longer mistakes a magnitude for a rung.
  */
-export const MAX_TABLET_VALUE = 9999
 export const MAX_BID_DIGITS = 5
+export const MAX_TABLET_VALUE = 99_999 - MAX_MARGIN
 
 /** Narrowest tablet the gallery layout will ever produce, in CSS pixels. */
 export const MIN_TABLET_W = 132
@@ -187,16 +193,32 @@ export function tryParseBid(text: string): number | null {
 /**
  * The value a tablet would carry for this question, or null if it cannot.
  *
- * A tablet is a *price*. A price is a whole number of coins, it is not negative,
- * and it has to be small enough that one more coin than it still fits on the
- * paddle. A fraction, a decimal, a negative or a five-digit answer is refused —
- * and refusing is loud where it happens.
+ * A tablet is a *price*. A price is a whole number of coins, it is not negative, and it
+ * has to be small enough that one more coin than it still fits on the paddle. A
+ * fraction, a decimal, a negative or a six-digit answer is refused — and refusing is
+ * loud where it happens.
+ *
+ * The three reasons are not interchangeable, and `rungCannotDraw` is where that matters.
  */
 export function tabletValue(q: Question): number | null {
+  if (!priceable(q.answer)) return null
   const value = tryParseBid(q.answer)
   if (value === null || value > MAX_TABLET_VALUE) return null
   if (visibleLength(q.prompt) > PROMPT_MAX_CHARS) return null
   return value
+}
+
+/**
+ * Is this answer even the SHAPE of a price — a whole number, of any size or sign?
+ *
+ * Separate from `tabletValue` because it is the only refusal that is a fact about the
+ * *representation a rung uses* rather than about one item. A fraction rung emits
+ * fractions and a tenths rung emits decimals for every item it will ever produce; a
+ * multiplication rung emits some answers that fit a five-digit paddle and some that do
+ * not, from the very same rung.
+ */
+export function priceable(answer: string): boolean {
+  return /^[+-]?\d+$/.test(answer.trim())
 }
 
 /** Characters that count against the tablet's width. */
@@ -207,24 +229,47 @@ export function visibleLength(prompt: string): number {
 /**
  * Is this refusal a fact about the RUNG, or only about this item?
  *
- * Everything `tabletValue` refuses is a property of the rung — the width of the
- * paddle and the width of the tablet are constants, so if one item from a rung
- * will not fit then every item from it is equally hopeless. That is not true of
- * the one other reason a board rejects an item, which is a value already on the
- * board: a collision is a fact about a pair of items and nothing about a rung.
- * `polarity` conflated the two and pinned a whole session at the easiest rung in
- * the product off one transient empty pool.
+ * Getting this wrong in either direction is expensive, and it has been shipped both
+ * ways in this repository:
+ *
+ *   * Too eager, and one unlucky item deletes a third of the curriculum. The first
+ *     version of this function read "`tabletValue` said no" as a rung fact, and that
+ *     included *magnitude*. On `dw.mul.multidigit.times-one-digit` — a live rung — a
+ *     single `4827 × 6 = 28962` capped the stream below its ordinate for the rest of the
+ *     run, which excluded 21 of the shipped ladder's 66 rungs including all three of
+ *     `dw.add.regroup.subtract-across-zero`, a skill `pack.json` promises and whose
+ *     answers fit a tablet perfectly. From the same rung, `1023 × 2 = 2046` is drawable.
+ *     Magnitude depends on the operands drawn, so it is an ITEM fact.
+ *   * Too shy, and a rung this game genuinely cannot draw is a soft-lock rather than a
+ *     degradation: declining is per-item and the host serves by RUNG, so asking again at
+ *     the same difficulty gets the same rung, the board spends its whole draw budget
+ *     being refused, and the child is served a stall.
+ *
+ * So exactly two things are rung facts, and both are constants of this game rather than
+ * of the item drawn:
+ *
+ *   * **The prompt is wider than a tablet.** The tablet is a fixed width, so if one
+ *     item's prompt overflows it, every item from that rung does.
+ *   * **The answer is not a whole number at all.** A fraction rung emits fractions and a
+ *     tenths rung emits decimals, for every item, forever. Nothing from such a rung can
+ *     ever be a price.
+ *
+ * Everything else — a value too large for the paddle, a negative value, a value already
+ * on the board — is declined per item and caps nothing. `polarity` conflated exactly
+ * this and pinned a whole session at the easiest rung in the product off one transient
+ * empty pool.
  *
  * `id === ""` is the shared host's marker for "the pool ran dry, here is something
  * drawable". It describes no rung and must never cap one. Today's sentinel answers
- * `"0"`, which is a perfectly good price, so the check below would refuse to cap on it
+ * `"0"`, which is a perfectly good price, so the checks below would refuse to cap on it
  * anyway — the id line is there because the sentinel belongs to the host and the next
  * one may not parse. `test/lot.test.ts` covers both, so the line is load-bearing
  * against a future host rather than against this one.
  */
 export function rungCannotDraw(q: Question): boolean {
   if (q.id === "") return false
-  return tabletValue(q) === null
+  if (visibleLength(q.prompt) > PROMPT_MAX_CHARS) return true
+  return !priceable(q.answer)
 }
 
 /**

--- a/dynawalla/games/gavel/src/game/lot.ts
+++ b/dynawalla/games/gavel/src/game/lot.ts
@@ -182,6 +182,11 @@ function tabletOf(q: Question, value: number): Tablet {
  * Sorted by value, then the window of `take` consecutive entries with the
  * smallest span. Ties go to the lowest window, which keeps the room's prices
  * nearer the bottom of what the rung offers and costs nothing.
+ *
+ * **`dropped` comes back in the pool's own order, not in value order.** The caller uses
+ * it as a bench and trims the front of it when it overflows, so value order would trim
+ * the cheapest questions rather than the stalest ones — and since the pool is
+ * `[...bench, ...freshly drawn]`, pool order is draw order and the trim is a real FIFO.
  */
 export function tightest(
   pool: readonly Tablet[],
@@ -202,7 +207,8 @@ export function tightest(
     }
   }
   const kept = sorted.slice(bestAt, bestAt + n)
-  const dropped = [...sorted.slice(0, bestAt), ...sorted.slice(bestAt + n)]
+  const keeping = new Set<Tablet>(kept)
+  const dropped = pool.filter((entry) => !keeping.has(entry))
   return { kept, dropped }
 }
 

--- a/dynawalla/games/gavel/src/mount.ts
+++ b/dynawalla/games/gavel/src/mount.ts
@@ -21,7 +21,7 @@ import { Rng } from "./core/rng.ts"
 import { Auction, type AuctionEvent } from "./game/auction.ts"
 import { MIN_TABLETS } from "./game/ladder.ts"
 import { Scene, type View } from "./render/scene.ts"
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 
 /**
  * The largest step the clock may take in one frame.
@@ -199,7 +199,6 @@ export function mountGavel(
     coins: game.coins,
     storeroom: game.storeroom,
     remaining: game.remaining,
-    consignment: game.consignmentNumber,
     armed: game.armed,
     paused,
     stalled: game.stalled,
@@ -301,6 +300,14 @@ export function mountGavel(
     scene.resize()
   }
 
+  // The insets change more often than "never": rotation swaps them, and iPadOS changes
+  // them when a pack is resized in Split View. They also arrive from the HOST rather
+  // than from anything this frame can measure, so a push with no size change is a real
+  // event and `resize` alone would miss it.
+  const stopWatchingInsets = onInsetsChange(() => {
+    scene.resize()
+  })
+
   canvas.addEventListener("pointerdown", press)
   globalThis.addEventListener("keydown", key)
   globalThis.addEventListener("resize", resize)
@@ -330,7 +337,10 @@ export function mountGavel(
       canvas.removeEventListener("pointerdown", press)
       globalThis.removeEventListener("keydown", key)
       globalThis.removeEventListener("resize", resize)
+      stopWatchingInsets()
       observer?.disconnect()
+      // Every question still on the bench or the board, closed rather than left open.
+      game.closeAll()
       audio.dispose()
       guide.destroy()
       canvas.remove()

--- a/dynawalla/games/gavel/src/render/scene.ts
+++ b/dynawalla/games/gavel/src/render/scene.ts
@@ -12,6 +12,7 @@
 import { easeOutCubic, unit } from "../core/feel.ts"
 import type { Settled } from "../game/auction.ts"
 import type { Room } from "../game/lot.ts"
+import { MIN_NUMERAL_PX } from "../game/ladder.ts"
 import { hitKey, hitTablet, layout, promptPx, type Key, type Layout, type Rect } from "./layout.ts"
 import {
   BRASS,
@@ -40,7 +41,6 @@ export type View = {
   coins: number
   storeroom: number
   remaining: number
-  consignment: number
   armed: boolean
   paused: boolean
   stalled: boolean
@@ -241,34 +241,48 @@ export class Scene {
     void view
   }
 
-  /** One pip per lot still owed to the broker. A wrong bid adds pips. */
+  /**
+   * One pip per lot still owed to the broker, and one oxide pip per lot on the shelf.
+   *
+   * **Countable, and drawn rather than written.** This used to print `CONSIGNMENT 1` and
+   * `3 UNSOLD` at nine pixels — numerals a child has to read, at two thirds of this pack's
+   * own stated floor of thirteen, next to a comment citing SERPENT's four-pixel orbs. The
+   * information was never the numeral: a wrong bid means one more pip, and the shelf is a
+   * row of dull ones. Both are legible from across a room, which nine-pixel type is not,
+   * and the consignment ordinal was narration nobody needs.
+   */
   private strip(view: View): void {
     const g = this.ctx
     const r = this.lay.strip
-    const n = Math.max(1, view.remaining)
-    const pip = Math.min(12, (r.w - 90) / Math.max(6, n) - 2)
-    g.textBaseline = "middle"
-    g.textAlign = "left"
-    g.font = `600 9px ${TITLE}`
-    g.fillStyle = INK_DIM
-    g.fillText(`CONSIGNMENT ${String(view.consignment)}`, r.x, r.y + r.h / 2)
-    let x = r.x + 96
-    for (let i = 0; i < n; i++) {
+    const owed = Math.max(1, view.remaining)
+    const total = owed + view.storeroom
+    const pip = Math.max(4, Math.min(13, r.w / Math.max(10, total + 2) - 3))
+    let x = r.x
+    for (let i = 0; i < owed; i++) {
       g.fillStyle = i === 0 ? BRASS_LIT : BRASS_DIM
-      g.beginPath()
-      g.moveTo(x + pip / 2, r.y + 1)
-      g.lineTo(x + pip, r.y + r.h / 2)
-      g.lineTo(x + pip / 2, r.y + r.h - 1)
-      g.lineTo(x, r.y + r.h / 2)
-      g.closePath()
-      g.fill()
+      this.pip(x, r, pip)
       x += pip + 3
     }
-    if (view.storeroom > 0) {
-      g.textAlign = "right"
+    // The shelf, in copper oxide: lots bought over the offer that nobody will buy. Set
+    // apart by a gap, because they are not lots still to be sold.
+    x += pip
+    for (let i = 0; i < view.storeroom; i++) {
       g.fillStyle = OXIDE
-      g.fillText(`${String(view.storeroom)} UNSOLD`, r.x + r.w, r.y + r.h / 2)
+      this.pip(x, r, pip)
+      x += pip + 3
     }
+  }
+
+  /** One lozenge on the consignment strip. */
+  private pip(x: number, r: Rect, w: number): void {
+    const g = this.ctx
+    g.beginPath()
+    g.moveTo(x + w / 2, r.y + 1)
+    g.lineTo(x + w, r.y + r.h / 2)
+    g.lineTo(x + w / 2, r.y + r.h - 1)
+    g.lineTo(x, r.y + r.h / 2)
+    g.closePath()
+    g.fill()
   }
 
   /** The lot on the block, and the offer plate beside it. */
@@ -295,9 +309,15 @@ export class Scene {
     this.sigil(left.x + left.w - 14 - sigilR, left.y + left.h / 2, sigilR, view.lot)
 
     const settled = view.phase === "settled" ? view.settled : null
-    g.font = `600 11px ${TITLE}`
+    // The verdict carries the coins earned, so it is a numeral a child reads and it obeys
+    // the floor. It used to print at eleven pixels.
+    g.font = `600 ${String(MIN_NUMERAL_PX)}px ${TITLE}`
     g.fillStyle = settled ? this.tint(settled) : INK_DIM
-    g.fillText(settled ? this.verdict(settled) : "ON THE BLOCK", left.x + 12, left.y + left.h - 14)
+    g.fillText(
+      settled ? this.verdict(settled) : "ON THE BLOCK",
+      left.x + 12,
+      left.y + left.h - 13,
+    )
 
     // The offer. Lapis, and lapis is used for nothing else in the game.
     this.plate(o, LAPIS, LAPIS_LIT)
@@ -375,10 +395,12 @@ export class Scene {
 
     g.textBaseline = "middle"
     g.textAlign = "left"
-    g.font = `600 10px ${TITLE}`
+    // `BEATING 88 + 61` is the marked tablet's own sum — exactly the class of text the
+    // floor exists for — and it used to print at ten pixels.
+    g.font = `600 ${String(MIN_NUMERAL_PX)}px ${TITLE}`
     g.fillStyle = INK_DIM
     g.fillText(
-      marked ? `BEATING  ${marked.prompt}` : "MARK A TABLET, THEN SET YOUR BID",
+      marked ? `BEATING  ${marked.prompt}` : "MARK A TABLET, THEN BID",
       r.x + 12,
       r.y + r.h / 2,
     )
@@ -470,18 +492,21 @@ export class Scene {
 
   private verdict(s: Settled): string {
     switch (s.outcome) {
+      // Short, because they are drawn at the legibility floor on a 320px phone, where the
+      // block's left plate is about 180 pixels wide. The long-form versions of these
+      // ("PAID OVER THE OFFER — NOBODY WILL BUY IT") needed 254 pixels at that size, so
+      // the choice was between shortening them and printing them too small to read. What
+      // a wrong bid costs is on the strip and in the manual; the verdict names it.
       case "sold":
-        return s.keen
-          ? `KEEN BID  ONE OVER THE ROOM  +${String(s.coins)} ◉`
-          : `SOLD ON  +${String(s.coins)} ◉`
+        return s.keen ? `KEEN BID  +${String(s.coins)} ◉` : `SOLD  +${String(s.coins)} ◉`
       case "even":
-        return "SOLD ON  NOTHING IN IT"
+        return "SOLD  NOTHING IN IT"
       case "outbid":
-        return "OUTBID  THE LOT COMES ROUND AGAIN"
+        return "OUTBID"
       case "unsold":
-        return "PAID OVER THE OFFER  NOBODY WILL BUY IT"
+        return "OVER THE OFFER  UNSOLD"
       case "folded":
-        return s.coins > 0 ? `FOLDED  +${String(s.coins)} ◉ FOR THE WARNING` : "FOLDED"
+        return s.coins > 0 ? `FOLDED  +${String(s.coins)} ◉` : "FOLDED"
     }
   }
 

--- a/dynawalla/games/gavel/src/test/failure.test.ts
+++ b/dynawalla/games/gavel/src/test/failure.test.ts
@@ -201,20 +201,21 @@ test("the scout's fee is the only coin that arrives without a sale", () => {
   assert.ok(sales > fees * 10, `the fees are ${String(fees)} against ${String(sales)} from selling`)
 })
 
-test("the bench is bounded, so a long sitting cannot grow one", () => {
-  // Not a gameplay rule — a leak guard. The bench holds questions drawn and not shown,
-  // and an unbounded one would hold every question the room ever passed over.
-  assert.ok(BENCH_CAP > 0 && BENCH_CAP < 64)
+test("a long sitting never holds more than a boardful and a benchful of questions", () => {
+  // A leak guard, and it replaces a test that asserted a count of CLOSED questions was
+  // over a hundred — which 120 lots of ordinary play satisfies whatever the bench does.
+  // The accounting identity is in `lot.test.ts`; this is the bound over a long sitting.
   const r = rig(0xd00d)
   const clock = stepClock()
+  let worst = 0
   for (let i = 0; i < 120; i++) {
     const room = r.game.room
     if (!room) break
     PERFECT.act(r.game, room, undefined as never, clock())
     settleOn(r.game, clock)
+    worst = Math.max(worst, r.game.benched)
+    assert.ok(r.game.benched <= BENCH_CAP, `the bench reached ${String(r.game.benched)}`)
   }
-  // Every question ever served is either answered, closed, or standing on the board or
-  // the bench right now — and the last two are bounded.
-  const open = r.skips.length + r.reports.length
-  assert.ok(open > 100)
+  assert.equal(worst, BENCH_CAP, `the bench never filled: high-water mark ${String(worst)}`)
+  assert.ok(r.game.trimmed > 20, `only ${String(r.game.trimmed)} benched questions were closed`)
 })

--- a/dynawalla/games/gavel/src/test/ladder.test.ts
+++ b/dynawalla/games/gavel/src/test/ladder.test.ts
@@ -21,6 +21,9 @@ import { test } from "node:test"
 
 import {
   LOT_STEP_SECONDS,
+  MAX_BID_DIGITS,
+  MAX_MARGIN,
+  MAX_TABLET_VALUE,
   MAX_TABLETS,
   MIN_NUMERAL_PX,
   MIN_TABLETS,
@@ -164,17 +167,44 @@ test("a tablet carries a whole non-negative price, or the question is refused", 
   assert.equal(tabletValue(q({ answer: "1/2" })), null)
   assert.equal(tabletValue(q({ answer: "2.5" })), null)
   assert.equal(tabletValue(q({ answer: "-4" })), null)
-  assert.equal(tabletValue(q({ answer: "10000" })), null)
+  assert.equal(tabletValue(q({ answer: String(MAX_TABLET_VALUE) })), MAX_TABLET_VALUE)
+  assert.equal(tabletValue(q({ answer: String(MAX_TABLET_VALUE + 1) })), null)
   assert.equal(tabletValue(q({ answer: " 17 " })), 17)
   assert.equal(tabletValue(q({ prompt: "1".repeat(PROMPT_MAX_CHARS + 1) })), null)
   assert.equal(tryParseBid("007"), 7)
   assert.equal(tryParseBid(""), null)
   assert.equal(tryParseBid("1e3"), null)
+  // The paddle has to hold the offer as well as the bid, and the offer sits up to
+  // `MAX_MARGIN` above the highest tablet.
+  assert.ok(String(MAX_TABLET_VALUE + MAX_MARGIN).length <= MAX_BID_DIGITS)
 })
 
-test("a refusal that is a fact about the rung caps it; the pool sentinel never does", () => {
-  assert.equal(rungCannotDraw(q()), false)
+test("the whole live ladder fits on a tablet, including the rung that used to cap it", () => {
+  // `dw.mul.multidigit.times-one-digit` is active and reaches `4827 × 6 = 28962`. At the
+  // old 9,999 ceiling that item was refused — and, because the refusal was misread as a
+  // fact about the RUNG, it capped the stream below its own ordinate and took 21 of the
+  // shipped ladder's 66 rungs out of the run, including all three rungs of
+  // `dw.add.regroup.subtract-across-zero`, whose answers fit a tablet perfectly.
+  assert.equal(tabletValue(q({ prompt: "4827 × 6", answer: "28962" })), 28962)
+  assert.equal(tabletValue(q({ prompt: "9999 × 9", answer: "89991" })), 89991)
+})
+
+test("a refusal that is a fact about the rung caps it; an item-level refusal never does", () => {
+  // Two rung facts, both constants of this game: a prompt wider than a tablet, and an
+  // answer that is not a whole number at all. A fraction rung emits fractions forever.
   assert.equal(rungCannotDraw(q({ answer: "1/2" })), true)
+  assert.equal(rungCannotDraw(q({ answer: "2.5" })), true)
+  assert.equal(rungCannotDraw(q({ prompt: "1".repeat(PROMPT_MAX_CHARS + 1) })), true)
+
+  // Everything else is a fact about the ITEM. The pair below comes from the SAME rung,
+  // and capping on the first one is what deleted a third of the ladder.
+  assert.equal(rungCannotDraw(q()), false)
+  assert.equal(rungCannotDraw(q({ prompt: "4827 × 6", answer: "99999999" })), false)
+  assert.equal(rungCannotDraw(q({ prompt: "1023 × 2", answer: "2046" })), false)
+  // A negative comes from a signed rung that also emits positives, so it is an item too.
+  assert.equal(rungCannotDraw(q({ answer: "-4" })), false)
+  assert.equal(tabletValue(q({ answer: "-4" })), null)
+
   assert.equal(rungCannotDraw(q({ answer: "1/2", id: "" })), false)
 })
 

--- a/dynawalla/games/gavel/src/test/layout.test.ts
+++ b/dynawalla/games/gavel/src/test/layout.test.ts
@@ -20,7 +20,7 @@ import {
   setHostInsets,
   type Insets,
 } from "../../../../packs/shared/game-chrome/index.ts"
-import { MIN_NUMERAL_PX, MIN_TABLET_W, PROMPT_MAX_CHARS } from "../game/ladder.ts"
+import { MIN_TABLET_W, PROMPT_MAX_CHARS } from "../game/ladder.ts"
 import { MIN_KEY, columnsFor, criticalRects, hitKey, hitTablet, layout, promptPx } from "../render/layout.ts"
 
 type Case = { name: string; w: number; h: number; insets: Insets }
@@ -128,10 +128,15 @@ test("a tablet is never narrower than the width the prompt budget was derived fr
           `${c.name} with ${String(count)} tablets: a tablet is ${rect.w.toFixed(0)}px wide, under the ` +
             `${String(MIN_TABLET_W)}px the character budget assumes`,
         )
-        const size = promptPx("1".repeat(PROMPT_MAX_CHARS), rect.w, rect.h)
+        // `promptPx` clamps at `MIN_NUMERAL_PX`, so asserting the floor here would pass
+        // with the whole width calculation deleted. The claim worth making is that the
+        // widest prompt a tablet will ACCEPT still FITS at the size it is given.
+        const widest = "1".repeat(PROMPT_MAX_CHARS)
+        const size = promptPx(widest, rect.w, rect.h)
         assert.ok(
-          size >= MIN_NUMERAL_PX,
-          `${c.name}: the widest accepted prompt would print at ${String(size)}px`,
+          PROMPT_MAX_CHARS * size * 0.63 <= rect.w - 16 + 1,
+          `${c.name}: the widest accepted prompt is ${String(size)}px and overflows a ` +
+            `${rect.w.toFixed(0)}px tablet`,
         )
       }
     }

--- a/dynawalla/games/gavel/src/test/lot.test.ts
+++ b/dynawalla/games/gavel/src/test/lot.test.ts
@@ -21,7 +21,8 @@ import type { Ask, Host, Question } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
 import { Auction } from "../game/auction.ts"
 import { MAX_MARGIN, MIN_MARGIN, PROMPT_MAX_CHARS } from "../game/ladder.ts"
-import { assembleRoom, bestBid, isTrap, tightest, type Tablet } from "../game/lot.ts"
+import { BENCH_CAP } from "../game/auction.ts"
+import { POOL_EXTRA, assembleRoom, bestBid, isTrap, tightest, type Tablet } from "../game/lot.ts"
 import { PERFECT, rig, settleOn, stepClock } from "./harness.ts"
 
 const SEEDS = [0x1, 0xbeef, 0x2718, 0x5eed1ce, 0xfeed, 0xd00d]
@@ -208,10 +209,86 @@ test("a rung whose answers cannot go on a tablet caps the stream, and stays capp
     (capped[0]?.maxDifficulty ?? 0) < 10,
     "the ceiling was sent as the top of the ladder rather than below the banned rung",
   )
-  // Monotone: a second, higher undrawable rung must not raise it.
-  const before = game.ceiling
+})
+
+test("a ceiling only ever comes down: a higher undrawable rung cannot raise it", () => {
+  // The guard this covers — `if (this.drawCeiling !== null && this.drawCeiling <= capped)
+  // return` — was unguarded when it shipped. The test that claimed to cover it called
+  // `begin()` a second time on a game that was already stalled, where `begin` early-
+  // returns and does nothing at all, so deleting the guard left the whole suite green.
+  //
+  // A rung that could not be drawn once cannot be drawn later, so a ceiling that drifted
+  // back up would re-enter the same starve every time the child climbed.
+  let n = 0
+  const wide = "1".repeat(PROMPT_MAX_CHARS + 4)
+  const { host } = scriptedHost(() => {
+    n++
+    // The first draw is from a middling rung, everything after it from a high one. Both
+    // are undrawable, and only the first may set the ceiling.
+    return {
+      id: `q${String(n)}`,
+      prompt: `${wide} + 1`,
+      answer: "12",
+      distractors: [],
+      domain: "add",
+      difficulty: n === 1 ? 0.5 : 0.9,
+    }
+  })
+  const game = new Auction(host, new Rng(31), 0)
   game.begin(0)
-  assert.equal(game.ceiling, before)
+  assert.ok(n > 2, "the second, higher rung was never served")
+  assert.equal(game.stalled, true)
+  assert.ok(game.ceiling !== null)
+  assert.ok(
+    (game.ceiling ?? 1) < 0.5,
+    `the ceiling is ${String(game.ceiling)}: a rung at 0.9 raised a ceiling set at 0.5`,
+  )
+})
+
+test("the pool is flushed only after the new ceiling has gone out on the wire", () => {
+  // POLARITY flushed the instant it set a ceiling. `game-host`'s flush ranks the pool with
+  // a distance function that reads the host's OWN ceiling, and that is only updated inside
+  // `next()` — so flushing first ranked every pooled question against the STALE ceiling and
+  // kept precisely the rung it meant to discard. Measured there as ten consecutive silent
+  // questions, about four and a half minutes.
+  const calls: string[] = []
+  let n = 0
+  const wide = "1".repeat(PROMPT_MAX_CHARS + 4)
+  const host: Host = {
+    next(ask) {
+      calls.push(ask?.maxDifficulty === undefined ? "ask" : "ask+ceiling")
+      n++
+      return {
+        id: `q${String(n)}`,
+        prompt: `${wide} + 1`,
+        answer: "12",
+        distractors: [],
+        domain: "add",
+        difficulty: 0.6,
+      }
+    },
+    report() {},
+    skip() {},
+    flush() {
+      calls.push("flush")
+    },
+    haptic() {},
+    prefersReducedMotion: () => true,
+  }
+  const game = new Auction(host, new Rng(41), 0)
+  game.begin(0)
+
+  const firstFlush = calls.indexOf("flush")
+  const firstCeiling = calls.indexOf("ask+ceiling")
+  assert.ok(firstFlush > 0, `nothing was ever flushed: ${calls.join(" ")}`)
+  assert.ok(firstCeiling > 0, `no ask ever carried the ceiling: ${calls.join(" ")}`)
+  assert.ok(
+    firstFlush > firstCeiling,
+    `the pool was flushed at ${String(firstFlush)} before the ceiling reached the wire at ` +
+      `${String(firstCeiling)}: ${calls.join(" ")}`,
+  )
+  // Exactly one flush per ceiling change, not one per refusal.
+  assert.equal(calls.filter((c) => c === "flush").length, 1, calls.join(" "))
 })
 
 test("a duplicate value is a fact about two questions and must never cap a rung", () => {
@@ -348,13 +425,20 @@ test("a question the room passed over waits on the bench and can come up later",
 })
 
 test("the bench is a buffer and not a hoard: the overflow is closed, oldest first", () => {
-  // A stream of values the tightest window keeps passing over, so the bench fills.
+  // **The cap has to be able to bind, and it could not.** `assembleRoom` fills to
+  // `want + POOL_EXTRA` and keeps `want`, so the bench it hands back holds at most
+  // `POOL_EXTRA` — and `BENCH_CAP` shipped at 14 against a `POOL_EXTRA` of 10. Measured
+  // over 120 lots: max bench 10, trims executed 0. So the hoard the cap exists to prevent
+  // was real and unprevented, because `tightest` keeps the cluster and benches the
+  // outliers: ten questions the room never wants, open in the host's ledger all session.
+  assert.ok(BENCH_CAP < POOL_EXTRA, `BENCH_CAP ${String(BENCH_CAP)} can never bind`)
+
+  // A stream that alternates a tight cluster with far outliers, so the bench fills with
+  // values the room will keep passing over.
   let n = 0
   const { host, skips } = scriptedHost(() => {
     n++
-    // Alternating tight cluster and far outliers: the outliers are usable, are never
-    // wanted, and would sit on the bench for the whole session without the cap.
-    const value = n % 2 === 0 ? 100 + n : 5000 - n * 7
+    const value = n % 2 === 0 ? 100 + n : 8000 - n * 7
     return {
       id: `q${String(n)}`,
       prompt: `${String(value)} + 0`,
@@ -367,7 +451,62 @@ test("the bench is a buffer and not a hoard: the overflow is closed, oldest firs
   const game = new Auction(host, new Rng(29), 0)
   game.begin(0)
   const clock = stepClock()
-  for (let i = 0; i < 20; i++) {
+  const onABoard = new Set<string>()
+  for (let i = 0; i < 24; i++) {
+    const room = game.room
+    if (!room) break
+    for (const t of room.tablets) onABoard.add(t.id)
+    game.tapTablet(0)
+    const t = room.tablets[0]
+    if (!t) break
+    for (const ch of String(t.value + 1)) game.pressDigit(Number(ch))
+    game.hammer(clock())
+    game.nudge()
+    game.advance(1, clock())
+    assert.ok(game.benched <= BENCH_CAP, `the bench reached ${String(game.benched)}`)
+  }
+  assert.ok(game.trimmed > 0, "the bench never overflowed — the cap is dead code again")
+  assert.equal(new Set(skips).size, skips.length, "a question was closed twice")
+
+  // Oldest first. Every question here is usable, so a skip that never stood on a board is
+  // a bench trim, and the ids this host issues ascend with the draw order.
+  const trims = skips.filter((id) => !onABoard.has(id)).map((id) => Number(id.slice(1)))
+  assert.equal(trims.length, game.trimmed)
+  for (let i = 1; i < trims.length; i++) {
+    assert.ok(
+      (trims[i] ?? 0) > (trims[i - 1] ?? 0),
+      `the bench was trimmed out of order: ${trims.join(", ")}`,
+    )
+  }
+})
+
+test("every question ever served is answered, closed, on the board or on the bench", () => {
+  // The accounting invariant, which is the one the old bench test was reaching for and
+  // did not state: it asserted that a count of CLOSED items was over a hundred, which
+  // 24 lots of ordinary play satisfies whatever the bench does.
+  let served = 0
+  const answered: string[] = []
+  const { host, skips } = scriptedHost(() => {
+    served++
+    return {
+      id: `q${String(served)}`,
+      prompt: `${String(served)} + 7`,
+      answer: String(served + 7),
+      distractors: [],
+      domain: "add",
+      difficulty: 0.1,
+    }
+  })
+  const withReports: Host = {
+    ...host,
+    report: (r) => {
+      answered.push(r.questionId)
+    },
+  }
+  const game = new Auction(withReports, new Rng(37), 0)
+  game.begin(0)
+  const clock = stepClock()
+  for (let i = 0; i < 30; i++) {
     const room = game.room
     if (!room) break
     game.tapTablet(0)
@@ -378,8 +517,20 @@ test("the bench is a buffer and not a hoard: the overflow is closed, oldest firs
     game.nudge()
     game.advance(1, clock())
   }
-  assert.ok(skips.length > 0, "the bench grew without bound — nothing was ever closed")
-  assert.equal(new Set(skips).size, skips.length, "a question was closed twice")
+  const onBoard = game.room?.tablets.length ?? 0
+  assert.equal(
+    answered.length + skips.length + game.benched + onBoard,
+    served,
+    `${String(served)} questions served; ${String(answered.length)} answered, ` +
+      `${String(skips.length)} closed, ${String(game.benched)} benched, ${String(onBoard)} on the board`,
+  )
+
+  // …and `unmount` closes the rest, which is the one path that used to leak about fifteen.
+  const held = game.benched + onBoard
+  game.closeAll()
+  assert.equal(skips.length, served - answered.length, "unmount left questions open")
+  assert.equal(game.benched, 0)
+  assert.ok(held > 0, "there was nothing left to close, so this proved nothing")
 })
 
 test("a room is assembled from the host and never from a constant", () => {

--- a/dynawalla/games/gavel/src/test/manual-freeze.test.ts
+++ b/dynawalla/games/gavel/src/test/manual-freeze.test.ts
@@ -32,8 +32,10 @@ import { test } from "node:test"
 import { mount } from "../contract.ts"
 import type { Host } from "../contract.ts"
 import { createStubHost } from "../stubHost.ts"
+import { Auction } from "../game/auction.ts"
+import { Rng } from "../core/rng.ts"
 import { layout } from "../render/layout.ts"
-import { MIN_TABLETS } from "../game/ladder.ts"
+import { MIN_NUMERAL_PX, MIN_TABLETS } from "../game/ladder.ts"
 
 type Handler = (event: unknown) => void
 
@@ -161,8 +163,9 @@ function install(width: number, height: number): Rig {
   }
   performance.now = () => clock
   // The run is seeded from the wall clock, which is right on a device and fatal in a
-  // test. Pinned, so a green run is green every time.
-  Date.now = () => 0x9a7e1
+  // test. Pinned to the value that makes `mount`'s `Date.now() ^ 0x9a7e1` come out zero,
+  // so `firstRoom` below can mirror the run exactly.
+  Date.now = () => SEED
   ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
   globalThis.addEventListener = ((k: string, h: Handler): void => {
     globals.set(k, [...(globals.get(k) ?? []), h])
@@ -238,7 +241,7 @@ type World = {
 }
 
 function stub(world: World): Host {
-  const base = createStubHost({ seed: 0x9a7e1, reducedMotion: false })
+  const base = createStubHost({ seed: SEED, reducedMotion: false })
   return {
     ...base,
     next: (ask) => {
@@ -257,8 +260,12 @@ function stub(world: World): Host {
   }
 }
 
+
+
 const W = 768
 const H = 1024
+/** Pinned in `install`, and the seed the harness gives the stub host. */
+const SEED = 0x9a7e1
 
 function pump(rig: Rig, frames: number): void {
   for (let i = 0; i < frames; i++) rig.step(16)
@@ -272,14 +279,34 @@ function points() {
     assert.ok(k, `no ${id} key`)
     return { x: k.rect.x + k.rect.w / 2, y: k.rect.y + k.rect.h / 2 }
   }
-  const first = l.tablets[0]
-  assert.ok(first)
+  const at = (index: number) => {
+    const t = l.tablets[index]
+    assert.ok(t, `no tablet ${String(index)}`)
+    return { x: t.x + t.w / 2, y: t.y + t.h / 2 }
+  }
   return {
-    tablet: { x: first.x + first.w / 2, y: first.y + first.h / 2 },
+    tablet: at(0),
+    at,
+    digit: (d: number) => key(`d${String(d)}`),
     one: key("d1"),
     two: key("d2"),
     gavel: key("gavel"),
   }
+}
+
+/**
+ * The room the mounted game is about to show, computed rather than guessed.
+ *
+ * `install` pins `Date.now` and the harness pins the host seed, so an `Auction` built with
+ * the same two numbers draws the same first room. That is what lets a mount-level test bid
+ * a *winning* price without reaching inside the mounted game.
+ */
+function firstRoom() {
+  const mirror = new Auction(createStubHost({ seed: SEED, reducedMotion: false }), new Rng(0), 0)
+  mirror.begin(0)
+  const room = mirror.room
+  assert.ok(room, "the mirrored auction drew no room")
+  return room
 }
 
 test("a lot can be marked, bid on and hammered through the real mount", () => {
@@ -305,6 +332,79 @@ test("a lot can be marked, bid on and hammered through the real mount", () => {
       false,
       "a losing lot fired the failure haptic — this pack has no buzzer",
     )
+  } finally {
+    handle.unmount()
+    rig.restore()
+  }
+})
+
+/**
+ * Every numeral a child has to read, and the size it was drawn at.
+ *
+ * Walks the transcript keeping the current `font`, and reports each `fillText` whose text
+ * contains a digit. A caption with no digits in it is exempt: "BROKER PAYS" at ten pixels
+ * is a label on a plate whose number is drawn at thirty-four.
+ */
+function numerals(frame: readonly string[]): Array<{ text: string; px: number }> {
+  const out: Array<{ text: string; px: number }> = []
+  let px = 0
+  for (const call of frame) {
+    const font = /^font=.*?(\d+(?:\.\d+)?)px/.exec(call)
+    if (font) {
+      px = Number(font[1])
+      continue
+    }
+    const drawn = /^fillText\((.*),[-\d.]+,[-\d.]+\)$/.exec(call)
+    if (drawn && /\d/.test(drawn[1] ?? "")) out.push({ text: drawn[1] ?? "", px })
+  }
+  return out
+}
+
+test("no numeral a child has to read is drawn under the pack's own legibility floor", () => {
+  // `MIN_NUMERAL_PX = 13` is described in `ladder.ts` as "a floor, not a target", citing
+  // SERPENT's four-to-seven-pixel orbs. Four numerals were under it and nothing measured:
+  // `CONSIGNMENT 1` and `3 UNSOLD` at 9px, the verdict line carrying the coins earned at
+  // 11px, and `BEATING 88 + 61` — the marked tablet's own sum — at 10px.
+  //
+  // A transcript walk rather than a list of call sites, so the next numeral is covered by
+  // being drawn rather than by somebody remembering to add it here.
+  const rig = install(W, H)
+  const world: World = { asked: 0, reports: [], skips: [], haptics: [] }
+  const handle = mount(rig.el, stub(world))
+  try {
+    pump(rig, 3)
+    const p = points()
+    const room = firstRoom()
+    const best = room.tablets.findIndex((t) => t.value === room.highest)
+    // Live room, with a mark on a tablet so the paddle prints `BEATING <sum>`.
+    rig.tap(p.at(best).x, p.at(best).y)
+    pump(rig, 2)
+    const live = numerals(rig.frame)
+    assert.ok(live.length > 8, `only ${String(live.length)} numerals drawn on a live room`)
+
+    // A keen bid, so the settled room prints a verdict WITH COINS IN IT. Bidding blind
+    // here would usually be outbid, whose verdict has no numeral in it at all, and the
+    // 11px verdict line would go unmeasured — which is exactly how it shipped.
+    for (const ch of String(room.highest + 1)) {
+      const k = p.digit(Number(ch))
+      rig.tap(k.x, k.y)
+    }
+    rig.tap(p.gavel.x, p.gavel.y)
+    pump(rig, 30)
+    assert.equal(world.reports.length, 1)
+    assert.ok(
+      rig.frame.some((call) => call.startsWith("fillText(") && /◉/.test(call)),
+      "the settled room printed no coin verdict, so the verdict's size went unmeasured",
+    )
+    const settled = numerals(rig.frame)
+    assert.ok(settled.length > 8, `only ${String(settled.length)} numerals drawn on a settled room`)
+
+    for (const { text, px } of [...live, ...settled]) {
+      assert.ok(
+        px >= MIN_NUMERAL_PX,
+        `"${text}" was drawn at ${String(px)}px, under the ${String(MIN_NUMERAL_PX)}px floor`,
+      )
+    }
   } finally {
     handle.unmount()
     rig.restore()

--- a/dynawalla/games/gavel/src/test/report.test.ts
+++ b/dynawalla/games/gavel/src/test/report.test.ts
@@ -152,9 +152,9 @@ test("the latency reported is thinking time, with any sheet the host raised take
   const r = rig(0x777)
   r.game.tapTablet(0)
   typeBid(r.game, 9)
-  // The lot came to the block at t = 0. A sheet goes up at 1 s and comes off at 61 s,
-  // and the child answers at 63 s: two seconds of looking at the room, not
-  // sixty-three.
+  // The lot came to the block at t = 0. A sheet goes up at 1 s and comes off at 61 s, and
+  // the child answers at 63 s: one second before the sheet plus two after it, so three
+  // seconds of looking at the room rather than sixty-three.
   r.game.pause(1_000)
   r.game.resume(61_000)
   r.game.hammer(63_000)


### PR DESCRIPTION
Follow-up to #706. An adversarial review of that branch — run after it merged — found three MEDIUMs and a handful of LOWs. None of them reported a correct child as wrong. One of them quietly cost a third of the curriculum ladder, and three tests were passing on nothing.

## 1. A magnitude is not a fact about a rung, and one unlucky item deleted 21 of 66 rungs

`rungCannotDraw` read "`tabletValue` said no" as a fact about the **rung**, and that included the value being too large for the paddle. It is not: on `dw.mul.multidigit.times-one-digit` — a live rung — `4827 × 6 = 28962` was refused while `1023 × 2 = 2046` from the *same rung* is perfectly drawable. Magnitude depends on the operands drawn.

The consequence, traced end to end by the reviewer against the shipped 66-rung ladder:

* child climbs to intensity ≈ 0.69, host serves `4827 × 6`
* `capBelow` fires once → ceiling 0.691 → `maxDifficulty` 7.222 → the app's `Math.floor(maxDifficulty × span)` = rung **44**
* rungs 45–65 are excluded for the rest of the session, and the ceiling only ever comes down

The sharpest cost: **`dw.add.regroup.subtract-across-zero` is declared in `pack.json` and became unreachable.** Its three rungs sit at ordinates 0.92–0.99 and its answers fit a tablet perfectly. It was lost because an unrelated multiplication rung *below* it poisoned the ceiling.

Exactly two things are rung facts now, and both are constants of this game rather than of the item drawn:

| rung fact | why |
|---|---|
| the prompt is wider than a tablet | the tablet is a fixed width, so if one item overflows it, all of them do |
| the answer is not a whole number at all | a fraction rung emits fractions and a tenths rung emits decimals, forever |

A value too large for the paddle, a negative value, a value already on the board — all declined per item, capping nothing. That is the distinction POLARITY got wrong in the other direction.

`MAX_TABLET_VALUE` also moves from 9,999 to 99,990, which was refusing about half of `times-one-digit` for no reason: five digits was already the paddle's input budget, so it is now the bound rather than four.

## 2. `BENCH_CAP` sat above its own bound, so the trim it names could never run

`assembleRoom` fills to `want + POOL_EXTRA` and keeps `want`, so the bench it hands back holds at most `POOL_EXTRA` entries — and `BENCH_CAP` shipped at **14** against a `POOL_EXTRA` of **10**. Instrumented over 120 lots: **max bench 10, trims executed 0.** Two tests claimed to guard it and both passed with the entire trim loop deleted.

So the hoard the cap exists to prevent was real and unprevented: `tightest` keeps the cluster and benches the outliers, so ten questions the room never wants would sit open in the host's ledger for the whole session.

* `BENCH_CAP` is 7, and a test asserts `BENCH_CAP < POOL_EXTRA` so it can never go dead again.
* `tightest` returns `dropped` in the **pool's** order rather than in value order. The pool is `[...bench, ...freshly drawn]`, so pool order is draw order and "oldest first" is now true — it had been trimming the *cheapest* questions rather than the stalest.
* A `trimmed` counter makes the trim observable. Nothing else distinguishes a bench trim from the ordinary per-lot closing, which is why the old tests could not see it.

## 3. Four numerals were drawn under this pack's own legibility floor

`MIN_NUMERAL_PX = 13` is described in `ladder.ts` as "a floor, not a target", citing SERPENT's four-to-seven-pixel orbs. These were under it and nothing measured them:

| what | was | now |
|---|---|---|
| `CONSIGNMENT 1` | 9px | drawn as pips, not written |
| `3 UNSOLD` — the storeroom, the visible cost of overpaying | 9px | drawn as oxide pips |
| the verdict line, which carries the coins earned | 11px | 13px |
| `BEATING 88 + 61` — the marked tablet's own sum | 10px | 13px |

The strip is now one brass pip per lot owed and one oxide pip per lot on the shelf. The information was never the numeral — a wrong bid means one more pip — the pips are legible from across a room, and the consignment ordinal was narration. Raising the verdict to the floor meant shortening its strings: the long forms ("PAID OVER THE OFFER — NOBODY WILL BUY IT") needed 254px at 13px against a ~180px plate on a 320px phone.

**The guard is a transcript walk**, not a list of call sites: the mount-level test records every `fillText` with the font size it was drawn at and asserts that any text containing a digit is at least 13px. Captions with no digits are exempt — "BROKER PAYS" at 10px labels a plate whose number is drawn at 34. The next numeral is covered by being drawn.

The test has to bid a *winning* price to reach the verdict at all, because an outbid verdict has no numeral in it — which is precisely how the 11px line shipped. It mirrors the run with a second `Auction` on the same pinned seeds to know what the winning bid is.

## The vacuous tests, replaced rather than deleted

The reviewer mutation-tested these and each one passed with the implementation it named removed:

* **the monotone-ceiling assertion** called `begin()` a second time on an already-stalled game, where `begin` early-returns and does nothing. Replaced with a scripted host that serves an undrawable rung at 0.5 and then at 0.9, asserting the ceiling stays at 0.5.
* **two bench tests** asserted `skips.length > 0`, which 20 lots of ordinary play satisfies, and one asserted a count of *closed* questions was over a hundred. Replaced with the accounting identity — `served == answered + closed + benched + on the board` — plus the trim's FIFO order and a high-water-mark assertion.
* **two `promptPx(...) >= MIN_NUMERAL_PX` assertions** cannot fail, because `promptPx` ends in `clamp(..., MIN_NUMERAL_PX, 30)`. Replaced with the fit assertion the clamp was hiding: the widest prompt a tablet will *accept* still *fits* the tablet it is given.

## Also, all LOW from the same review

* `unmount` closes the ~15 questions the pack still holds on the bench and the board. `lot.ts` says outright that a question handed to a pack and never answered "has to be skipped, not silently dropped", and this was the one path that did not honour it. (Fleet convention is not to, and an open item costs a child nothing — but this game holds fifteen where a one-question game holds one.)
* `onInsetsChange` is wired, so a host inset push with no size change relays out. Rotation fired `resize` and was already covered; Split View and a bare settings push were not.
* The **flush-after-the-ask** ordering — the thing `auction.ts` argues hardest for, citing POLARITY's ten silent questions — now has a test that records the call sequence and asserts the flush lands after an ask that carries the new ceiling, exactly once.
* The consignment pip width could go negative below ~90px of strip (unreachable at supported viewports; floored anyway).
* Two comments had drifted off their constants: `climbSeconds: 300` where `SPEC` says 420, and "two seconds" where the assertion correctly expects three.

## Every fix verified by deleting it

| removed | test that failed | message |
|---|---|---|
| the rung/item split in `rungCannotDraw` | `ladder.test.ts` | `Expected values to be strictly equal` on `rungCannotDraw({ answer: "99999999" })` |
| `BENCH_CAP = 7` → `14` | `lot.test.ts` | `BENCH_CAP 14 can never bind` |
| the monotone ceiling guard | `lot.test.ts` | `the ceiling is 0.899: a rung at 0.9 raised a ceiling set at 0.5` |
| `dropped` in pool order → value order | `lot.test.ts` | `the bench was trimmed out of order: 8, 10, 12, 19, 17, 15, …` |
| `closeAll`'s bench/board closing | `lot.test.ts` | `unmount left questions open` |
| the deferred flush | `lot.test.ts` | `the pool was flushed at 1 before the ceiling reached the wire at 2: ask flush ask+ceiling …` |
| the verdict line back to 11px | `manual-freeze.test.ts` | `"KEEN BID  +2 ◉" was drawn at 11px, under the 13px floor` |
| `BEATING <sum>` back to 10px | `manual-freeze.test.ts` | `"BEATING  9 + 6" was drawn at 10px, under the 13px floor` |
| the strip printing `CONSIGNMENT n` again | `manual-freeze.test.ts` | `"CONSIGNMENT 5" was drawn at 9px, under the 13px floor` |

## Gates

75 tests (up from 70), **five consecutive clean runs**, `tsc` clean, `build:pack` clean. `packs/shared/game-audio` 80/80, `packs/sdk` 94/94, and the app's `catalog.test.ts` 19/19. Confirmed in a browser at phone size: the strip reads as pips, `KEEN BID  +8 ◉` is legible on the block, and nothing else moved.

Not addressed, and named rather than left silent: the reviewer's note that a landscape frame under 400 CSS px tall still runs off the bottom rather than shrinking a 44px target. That is the documented floor of this layout and the fix is a side-by-side arrangement with the keypad beside the gallery, which is a design change rather than a repair.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
