### PR TITLE
fix(dynawalla/games/foundry): the first kick-out put NaN in a gradient stop and killed every frame after it

### DIFF
--- a/dynawalla/games/foundry/README.md
+++ b/dynawalla/games/foundry/README.md
@@ -70,7 +70,7 @@ seconds; a four-digit borrow gets nearly eight.
 ```sh
 npm install
 npm run dev          # http://127.0.0.1:4321 — playable against the stub host
-npm test             # the rules; 75 cases, no canvas, no Math.random
+npm test             # the rules and the surface; 111 cases, no Math.random
 npm run tsc
 npm run build:pack   # → dist-pack/, what a tablet installs
 ```
@@ -88,6 +88,9 @@ src/
   contract.ts      the Host interface — byte-identical in shape across games
   stubHost.ts      seeded column add/sub with real mal-rule distractors
   mount.ts         surface, loop, input and juice. Decides nothing.
+  manual.ts        how-to-play, with every term this game invents defined at
+                   first use — a child who does not know what a "fall" is
+                   cannot use any rule that mentions one
   audio.ts         procedural Web Audio; silence is a cue, not an absence
   core/            rng · feel (screenshake, hitstop, flash) · quality tiers
   game/
@@ -96,7 +99,21 @@ src/
     reaction.ts    tier picker, with no run-length input and a test that says so
     save.ts        the belt, monotone, and safe on an opaque origin
   render/          layout · crowd · ring · decals · particles · hud · palette
+  test/
+    rig.ts         a canvas that records marks in screen space and throws
+                   exactly where the 2D spec throws
 ```
 
 `game/` holds every rule and every integer. `render/` draws state and judges
 nothing. That split is why the tests are about the game and not about pixels.
+
+The one thing `render/` still has to get right is that its colour helpers
+compose. `heatColor` *is* `mix`, and six call sites hand its output straight back
+to `withAlpha` or `mix`, so the output form is a rule: hex in, hex out. It was
+`rgb(...)` once, `withAlpha` parsed hex, and the first kick-out of a session put
+`rgba(NaN,11,37,0.3)` into a gradient stop — which throws, inside `drawMat`,
+before the wrestlers and the referee and the whole HUD. `frame()` re-arms its rAF
+on its first line, so the loop stayed alive and repainted the crowd, the far posts
+and the mat and nothing else, over and over, with the audio still running.
+`palette.test.ts` asserts the property; `test/rig.ts` is why a bout test can fail
+for a colour now.

--- a/dynawalla/games/foundry/README.md
+++ b/dynawalla/games/foundry/README.md
@@ -70,7 +70,7 @@ seconds; a four-digit borrow gets nearly eight.
 ```sh
 npm install
 npm run dev          # http://127.0.0.1:4321 — playable against the stub host
-npm test             # the rules and the surface; 111 cases, no Math.random
+npm test             # the rules and the surface; 112 cases, no Math.random
 npm run tsc
 npm run build:pack   # → dist-pack/, what a tablet installs
 ```

--- a/dynawalla/games/foundry/src/game/bout.ts
+++ b/dynawalla/games/foundry/src/game/bout.ts
@@ -48,6 +48,16 @@ export type BoutEvent =
 /** The three slaps, and then you are out. */
 export const SLAP_COUNT = 3
 
+/**
+ * The fall cut for an item this game cannot use.
+ *
+ * A sum and its own answer, together, because the board and the bar must agree:
+ * a fallback target under somebody else's prompt is a fall the child loses for
+ * being right. Small enough that the plates come out short and the escape is over
+ * quickly — nothing is reported off it, so it should not cost a child much time.
+ */
+export const FALLBACK = { prompt: "7 + 5", target: 12 } as const
+
 const LOCKUP_S = 0.82
 const PINFALL_S = 1.3
 /** A false finish costs count, but it may never *be* the third slap. */
@@ -206,11 +216,23 @@ export class Bout {
   private cutFall(): Fall {
     const q: Question = this.host.next()
     const parsed = Number.parseInt(q.answer, 10)
-    // A pool that ran dry hands back a drawable question with no id. The fall is
-    // still playable — a child must never see a frozen ring — but nothing about
-    // it is reported, because there is no item to report it against.
+    // What this game needs from an item: an integer answer of 1 or more, because
+    // the answer IS the number the bar has to reach and a bar cannot hold nothing.
+    //
+    // A pool that ran dry hands back a drawable question with no id, and every
+    // other unusable item is a hole in the curriculum: an answer of `0`, an empty
+    // string, something that is not a number. The fall is still playable — a child
+    // must never see a frozen ring — and nothing about it is reported, because
+    // there is no item to report it against.
+    //
+    // **The board and the bar have to agree even then.** This used to keep the
+    // item's own prompt and quietly set the target to 12, so a `3 − 3` on the
+    // board could only be escaped by building twelve, and the child would have
+    // been right and lost anyway. So the fallback replaces the sum as well as the
+    // answer, and `bout.test.ts` asserts the pair always agrees.
     const usable = Number.isInteger(parsed) && parsed >= 1
-    const target = usable ? parsed : 12
+    const target = usable ? parsed : FALLBACK.target
+    const prompt = usable ? q.prompt : FALLBACK.prompt
     const difficulty = normalizeDifficulty(q.difficulty)
     const plates = choosePlates(target, this.rng, { pressure: difficulty })
     const minTaps = minTapsFor(target, plates.a, plates.b) ?? plates.taps
@@ -240,7 +262,7 @@ export class Bout {
 
     return {
       questionId: usable ? q.id : "",
-      prompt: q.prompt,
+      prompt,
       target,
       plates,
       load: 0,
@@ -250,7 +272,7 @@ export class Bout {
       minTaps,
       traps,
       sprung: [],
-      slapPeriod: slapPeriodFor(minTaps, promptDigits(q.prompt), difficulty),
+      slapPeriod: slapPeriodFor(minTaps, promptDigits(prompt), difficulty),
       elapsed: 0,
       advance: 0,
       slaps: 0,

--- a/dynawalla/games/foundry/src/manual.ts
+++ b/dynawalla/games/foundry/src/manual.ts
@@ -1,0 +1,140 @@
+// THE MANUAL — how to play, in words a seven-year-old already has.
+//
+// This game invents a whole vocabulary. A *fall*, a *pin*, a *kick out*, the
+// *count*, being *waved off*, the *bar*, the *pedals*, the *belt*. The first
+// version of this text used every one of those words and defined none of them,
+// and the founder's report was exactly that:
+//
+//   "The instructions need to define the terms sometimes. I don't know what 'the
+//    fall' is on the grapple foundry for example."
+//
+// Two rules follow from that, and they are the reason this text lives in its own
+// module with a test on it:
+//
+//   1. **Every term the game invents is defined the first time it is used, right
+//      where it is used.** Not in a glossary at the bottom — a child will not go
+//      looking for one, and the word they did not know was three lines above.
+//   2. **Every word the game puts on the screen in capitals is in here.** A child
+//      who loses a fall reads THREE, or NO WAY OUT, or WAVED OFF, in letters half
+//      a screen tall. If the manual has never said what those mean, the game has
+//      told them off in a language they do not speak.
+//
+// Short sentences. Concrete nouns. No metaphor, and nothing about how well or
+// badly they are doing.
+
+import type { Section } from "../../../packs/shared/game-chrome/index.ts"
+
+export const TITLE = "THE GRAPPLE FOUNDRY"
+
+/**
+ * The splash, before the first tap.
+ *
+ * The rule that decides every fall — that going over loses on the spot — is
+ * stated here rather than in the manual, because this game shipped with it
+ * discoverable only by losing to it.
+ */
+export const SUMMARY: readonly string[] = [
+  "A wrestler is holding you flat on the mat. Being held down like this is called a pin.",
+  "The board above the ring shows a sum. Work out the answer, then tap the two pedals until the bar across your chest holds exactly that number. Then you get free.",
+  "Go one over the answer and you do not get free this time. Do not tap fast. Work it out first.",
+]
+
+export const SECTIONS: readonly Section[] = [
+  {
+    heading: "How to get free",
+    lines: [
+      "Look at the board. That is the sign hanging above the ring. It shows a sum, like 45 + 28.",
+      "Work out the answer in your head. The game never shows it to you.",
+      "The bar is the iron rod lying across your chest. The number on it is written in the middle of the screen, and it starts at 0.",
+      "The two pedals are the big squares at the bottom of the screen. Each one has a number stamped on it. Tapping a pedal adds that number to the bar.",
+      "Get the bar to exactly your answer and it tips off you and you are free. Getting free like that is called a kick out, and the game shows KICK OUT.",
+    ],
+  },
+  {
+    heading: "One try is called a fall",
+    lines: [
+      "Every time a wrestler pins you, you get one try at getting free. That one try is called a fall.",
+      "You can win a fall or lose it. Either way, a moment later the next one starts. You never run out of tries.",
+      "Win enough falls and that wrestler is beaten and a new one walks out.",
+    ],
+  },
+  {
+    heading: "Going over loses the fall at once",
+    lines: [
+      "One over the answer and the fall is lost. Not close. Over.",
+      "So tapping fast never works. Work out the taps first, then tap.",
+      "Say the answer is 25 and your pedals are 7 and 4. Three taps of 7 makes 21, then one tap of 4 makes 25. That is a kick out.",
+      "If you do go over, the game shows TOO MUCH and tells you the number you needed.",
+    ],
+  },
+  {
+    heading: "When there is no way out",
+    lines: [
+      "Sometimes the number you have left cannot be made from your two pedals at all.",
+      "If you need 3 more and the pedals are 4 and 7, nothing makes 3. The game shows NO WAY OUT and ends the fall there instead of making you wait.",
+      "So think about what you will have left, not only about the next tap.",
+    ],
+  },
+  {
+    heading: "The referee slaps the mat three times",
+    lines: [
+      "The referee is the person kneeling beside you. They slap the mat three times, slowly. Those three slaps are called the count.",
+      "The three short bars above the mat fill up, so you can see how much of the count is left.",
+      "When the third slap lands the fall is over and you did not get free. The game shows THREE.",
+      "A longer sum and a longer escape both give you more time.",
+      "Winning lots of falls never takes time away. The clock is set by the sum, not by how well you are doing.",
+    ],
+  },
+  {
+    heading: "The finish the referee says no to",
+    lines: [
+      "Some totals are the answer you get if you do the sum a common wrong way.",
+      "Land the bar on one of those and the crowd roars for a second, and then the referee waves his hands to say no. That is called being waved off, and the game shows WAVED OFF.",
+      "It uses up a little of the count. It never costs you the fall. Keep going.",
+    ],
+  },
+  {
+    heading: "The strip along the top",
+    lines: [
+      "Every time you get free, one brass plate is added to the strip at the top of the screen. That strip is your belt.",
+      "Nothing ever takes a plate off it. Losing a fall does not, and neither does going over.",
+    ],
+  },
+  {
+    heading: "Controls",
+    lines: [
+      "Tap anywhere on the left half of the screen for the LIGHT pedal, and anywhere on the right half for the HEAVY one.",
+      "On a keyboard, A and D work, and so do the left and right arrows.",
+      "Press M to turn the sound off.",
+    ],
+  },
+]
+
+/**
+ * The words this game prints on the screen in capital letters, on a banner over
+ * the ring, at a moment a child is trying to work out what just happened.
+ *
+ * Exported so `manual.test.ts` can assert that every one of them is explained
+ * above. It is not a display list — `mount.ts` builds each banner from what
+ * actually happened in the fall.
+ */
+export const BANNER_WORDS = ["KICK OUT", "WAVED OFF", "TOO MUCH", "NO WAY OUT", "THREE"] as const
+
+/**
+ * Every term this game invents, and nothing a child brings with them.
+ *
+ * `add`, `answer`, `number` and `tap` are not here. `fall`, `pin`, `count` and
+ * `belt` are, because in this game they do not mean what they usually mean.
+ */
+export const INVENTED_TERMS = [
+  "pin",
+  "fall",
+  "kick out",
+  "bar",
+  "pedal",
+  "board",
+  "count",
+  "referee",
+  "waved off",
+  "belt",
+] as const

--- a/dynawalla/games/foundry/src/mount.ts
+++ b/dynawalla/games/foundry/src/mount.ts
@@ -32,6 +32,7 @@ import { Audio } from "./audio.ts"
 import { Feel } from "./core/feel.ts"
 import { detectTier, TierGovernor } from "./core/tiers.ts"
 import { Bout, type BoutEvent } from "./game/bout.ts"
+import { SECTIONS, SUMMARY, TITLE } from "./manual.ts"
 import { loadBelt, recordBelt } from "./game/save.ts"
 import { REACTIONS } from "./game/reaction.ts"
 import { Crowd } from "./render/crowd.ts"
@@ -407,70 +408,18 @@ export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
 
   // ── how to play ──────────────────────────────────────────────────────────
   //
-  // This game shipped with nothing at all telling a child what the pedals were
-  // for, and the one rule that decides every fall — that going over loses on
-  // the spot — was discoverable only by losing to it. So it is stated first,
-  // plainly, in the summary a child sees before their first tap.
+  // The words are in `manual.ts`, with the reason they are written the way they
+  // are. In short: this game invents a *fall*, a *pin*, a *kick out*, a *count*
+  // and a *belt*, it used to use all of them without ever saying what they were,
+  // and a child cannot play a game whose rules are in a language it has not been
+  // taught.
   //
   // Opening the manual stops the count: a child who went to read the rules must
   // not come back to a fall they lost while reading them.
   const guide = createInstructions(root, {
-    title: "THE GRAPPLE FOUNDRY",
-    summary: [
-      "Someone has you pinned. The board above the ring shows a sum.",
-      "Work out the answer, then tap the two pedals until the bar holds exactly that number. Go one over and you lose.",
-    ],
-    sections: [
-      {
-        heading: "How to get free",
-        lines: [
-          "Read the board. It shows a sum, like 45 + 28.",
-          "Work out the answer in your head. The game never shows it to you.",
-          "The two pedals at the bottom each have a number stamped on them. Tapping a pedal adds that number to the bar.",
-          "Tap until the number on the bar is exactly your answer. Then the bar tips and you kick out.",
-        ],
-      },
-      {
-        heading: "Going over loses at once",
-        lines: [
-          "One over the answer and the fall is lost. Not close. Over.",
-          "So tapping fast never works. Work out the taps first, then tap.",
-          "Say the answer is 25 and your pedals are 7 and 4. Three taps of 7 makes 21, then one tap of 4 makes 25. That is the escape.",
-        ],
-      },
-      {
-        heading: "When there is no way out",
-        lines: [
-          "Sometimes the number you have left cannot be made from your two pedals.",
-          "If you need 3 more and the pedals are 4 and 7, nothing makes 3. The game stops the fall and tells you.",
-          "So think about what you will have left, not just about the next tap.",
-        ],
-      },
-      {
-        heading: "The count",
-        lines: [
-          "The referee slaps the mat three times. When the third slap lands, the fall is over.",
-          "A longer sum and a longer escape both give you more time.",
-          "Winning lots of falls never takes time away. The clock is set by the work, not by how well you are doing.",
-        ],
-      },
-      {
-        heading: "The finish that gets waved off",
-        lines: [
-          "Some totals are the answer you get when you do the sum a common wrong way.",
-          "Land on one of those and the crowd roars, and then the referee waves it off.",
-          "It costs you count. It never costs you the fall. Keep going.",
-        ],
-      },
-      {
-        heading: "Controls",
-        lines: [
-          "Tap the left half of the screen for the LIGHT pedal, the right half for the HEAVY one.",
-          "On a keyboard, A and D work, and so do the left and right arrows.",
-          "Press M to turn the sound off.",
-        ],
-      },
-    ],
+    title: TITLE,
+    summary: SUMMARY,
+    sections: SECTIONS,
     onClose: (): void => {
       last = 0
     },

--- a/dynawalla/games/foundry/src/render/palette.ts
+++ b/dynawalla/games/foundry/src/render/palette.ts
@@ -130,14 +130,24 @@ function unreadable(color: string): [number, number, number] {
   return [128, 128, 128]
 }
 
+/**
+ * A channel, forced into 0..255.
+ *
+ * `rgba(300,-5,12,1)` is a string a canvas rejects, and a rejected colour inside
+ * a gradient stop is a thrown exception in the frame loop. So the range is closed
+ * here rather than trusted at every call site.
+ */
+function clamp8(n: number): number {
+  return Math.max(0, Math.min(255, Math.round(n)))
+}
+
 /** A 0..255 channel as two hex digits. */
 function hex2(n: number): string {
-  const v = Math.max(0, Math.min(255, Math.round(n)))
-  return v.toString(16).padStart(2, "0")
+  return clamp8(n).toString(16).padStart(2, "0")
 }
 
 export function withAlpha(color: string, a: number): string {
-  const [r, g, b] = channels(color)
+  const [r, g, b] = channels(color).map(clamp8) as [number, number, number]
   const alpha = Number.isFinite(a) ? Math.max(0, Math.min(1, a)) : 1
   return `rgba(${r},${g},${b},${alpha})`
 }

--- a/dynawalla/games/foundry/src/render/palette.ts
+++ b/dynawalla/games/foundry/src/render/palette.ts
@@ -56,29 +56,104 @@ export function stamp(px: number, weight = 800): string {
   return `${weight} ${px}px/1 "Avenir Next Condensed", "Helvetica Neue", Impact, system-ui, sans-serif`
 }
 
-export function withAlpha(hex: string, a: number): string {
-  const h = hex.replace("#", "")
-  const r = Number.parseInt(h.slice(0, 2), 16)
-  const g = Number.parseInt(h.slice(2, 4), 16)
-  const b = Number.parseInt(h.slice(4, 6), 16)
-  return `rgba(${r},${g},${b},${Math.max(0, Math.min(1, a))})`
+/**
+ * A colour string, as three 0..255 channels.
+ *
+ * **This is the reason THE GRAPPLE FOUNDRY went blank on the first kick-out.**
+ *
+ * `withAlpha` and `mix` used to assume `#rrggbb` and slice the string by index.
+ * `heatColor` returns whatever `mix` returns, so `withAlpha(heatColor(t), a)` fed
+ * `"rgb(255,246,226)"` into a hex parser: it stripped a `#` that was not there,
+ * read `"rg"` as base 16, and produced `"rgba(NaN,11,37,0.3)"`. Six call sites
+ * across `ring.ts`, `hud.ts`, `particles.ts` and `decals.ts` composed the two
+ * that way.
+ *
+ * Assigning an unparseable colour to `fillStyle` is *silently ignored* by the
+ * canvas — the mark comes out in whatever colour was set before it — so five of
+ * those six sites merely drew the wrong colour and nothing failed anywhere. The
+ * sixth handed the same string to `CanvasGradient.addColorStop`, which is
+ * specified to **throw** a `SyntaxError`. That call is the scorch glow in
+ * `decals.ts`, a scorch is laid down only by an escape, and it is drawn inside
+ * `drawMat` — before the wrestlers, the referee, the near ropes and the whole
+ * HUD. `frame()` re-arms its `requestAnimationFrame` on its first line, so the
+ * loop kept running and kept throwing at the same place: every frame cleared the
+ * canvas, painted the crowd, the far posts and the mat, and stopped. The audio
+ * graph is not on the frame loop, so the hall kept roaring over a half-drawn
+ * ring for the twelve seconds a scorch takes to cool.
+ *
+ * So the parser now understands every form these two functions can be handed —
+ * `#rgb`, `#rrggbb`, `rgb()` and `rgba()` — and `mix` returns hex, which keeps
+ * the composition closed. Anything it still cannot read is reported loudly and
+ * comes back as a visible colour rather than as `NaN`: a wrong colour is a bug
+ * to fix on Monday, and a `NaN` in a gradient stop is a black screen in front of
+ * a child.
+ */
+function channels(color: string): [number, number, number] {
+  const s = color.trim()
+  if (s.startsWith("#")) {
+    const h = s.slice(1)
+    if (h.length === 3) {
+      // `#abc` is `#aabbcc`: each digit doubled.
+      const r = Number.parseInt(h.slice(0, 1).repeat(2), 16)
+      const g = Number.parseInt(h.slice(1, 2).repeat(2), 16)
+      const b = Number.parseInt(h.slice(2, 3).repeat(2), 16)
+      if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) return [r, g, b]
+    } else if (h.length >= 6) {
+      const r = Number.parseInt(h.slice(0, 2), 16)
+      const g = Number.parseInt(h.slice(2, 4), 16)
+      const b = Number.parseInt(h.slice(4, 6), 16)
+      if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) return [r, g, b]
+    }
+    return unreadable(color)
+  }
+  const open = s.indexOf("(")
+  if ((s.startsWith("rgb(") || s.startsWith("rgba(")) && s.endsWith(")")) {
+    const parts = s.slice(open + 1, -1).split(",")
+    const r = Number.parseFloat(parts[0] ?? "")
+    const g = Number.parseFloat(parts[1] ?? "")
+    const b = Number.parseFloat(parts[2] ?? "")
+    if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
+      return [Math.round(r), Math.round(g), Math.round(b)]
+    }
+  }
+  return unreadable(color)
 }
 
-/** Mix two hex colours. `t` 0 → `from`, 1 → `to`. */
+/** Colours already complained about, so a bad one costs one line and not sixty a second. */
+const complained = new Set<string>()
+
+function unreadable(color: string): [number, number, number] {
+  if (!complained.has(color)) {
+    complained.add(color)
+    console.error(`[foundry] unreadable colour ${JSON.stringify(color)} — drawn as grey`)
+  }
+  return [128, 128, 128]
+}
+
+/** A 0..255 channel as two hex digits. */
+function hex2(n: number): string {
+  const v = Math.max(0, Math.min(255, Math.round(n)))
+  return v.toString(16).padStart(2, "0")
+}
+
+export function withAlpha(color: string, a: number): string {
+  const [r, g, b] = channels(color)
+  const alpha = Number.isFinite(a) ? Math.max(0, Math.min(1, a)) : 1
+  return `rgba(${r},${g},${b},${alpha})`
+}
+
+/**
+ * Mix two colours. `t` 0 → `from`, 1 → `to`.
+ *
+ * Returns `#rrggbb` rather than `rgb()` so that the result can be handed back to
+ * `withAlpha` or to `mix` again. `heatColor` is `mix`, and every use of it in the
+ * game composes, so the output form is load-bearing rather than cosmetic.
+ */
 export function mix(from: string, to: string, t: number): string {
-  const k = Math.max(0, Math.min(1, t))
-  const pa = from.replace("#", "")
-  const pb = to.replace("#", "")
-  const r = Math.round(
-    Number.parseInt(pa.slice(0, 2), 16) * (1 - k) + Number.parseInt(pb.slice(0, 2), 16) * k,
-  )
-  const g = Math.round(
-    Number.parseInt(pa.slice(2, 4), 16) * (1 - k) + Number.parseInt(pb.slice(2, 4), 16) * k,
-  )
-  const b = Math.round(
-    Number.parseInt(pa.slice(4, 6), 16) * (1 - k) + Number.parseInt(pb.slice(4, 6), 16) * k,
-  )
-  return `rgb(${r},${g},${b})`
+  const k = Number.isFinite(t) ? Math.max(0, Math.min(1, t)) : 0
+  const [ra, ga, ba] = channels(from)
+  const [rb, gb, bb] = channels(to)
+  return `#${hex2(ra * (1 - k) + rb * k)}${hex2(ga * (1 - k) + gb * k)}${hex2(ba * (1 - k) + bb * k)}`
 }
 
 /**

--- a/dynawalla/games/foundry/src/render/ring.ts
+++ b/dynawalla/games/foundry/src/render/ring.ts
@@ -140,7 +140,14 @@ export type PinPose = {
   rise: number
   /** 0..1 how much the challenger is bearing down. */
   press: number
-  /** Struggle wobble, in radians. */
+  /**
+   * The struggle clock, in **seconds**, and read only as a phase.
+   *
+   * The caller passes a monotonic clock, so nothing here may use this value as an
+   * angle or an offset: a body rotated by `wobble * 0.05` is level at the start of
+   * a session and upside down about a minute in, which is how the pinned player
+   * used to drift out from under the bar over a long sitting.
+   */
   wobble: number
   /** 0..1 of the way through the count — drives the challenger's lean. */
   count: number
@@ -193,7 +200,9 @@ export function drawGrapple(
   // ── the player, on their back ──────────────────────────────────────────
   g.save()
   g.translate(cx, cy)
-  g.rotate(pose.wobble * 0.05)
+  // A struggle, not a spin: ±0.05 rad at about a third of a hertz. `wobble` is a
+  // monotonic clock and using it raw rotated the body without bound.
+  g.rotate(Math.sin(pose.wobble * 2.1) * 0.05)
   g.fillStyle = IRON
   // Torso lying along the mat, head to the left.
   limb(g, -u * 1.5, -rise * u * 0.9, u * 0.5, -rise * u * 0.35, u * 0.52, u * 0.62)

--- a/dynawalla/games/foundry/src/test/bout.test.ts
+++ b/dynawalla/games/foundry/src/test/bout.test.ts
@@ -11,6 +11,7 @@ import { test } from "node:test"
 import type { Host, Question } from "../contract.ts"
 import {
   Bout,
+  FALLBACK,
   fallsToBeat,
   normalizeDifficulty,
   promptDigits,
@@ -411,4 +412,57 @@ test("an over-the-target mal-rule total is named rather than merely refused", ()
   const miss = plain.events.find((e) => e.kind === "pinfall")
   assert.ok(miss && miss.kind === "pinfall" && miss.diagnosed === false)
   assert.equal(plain.reports[0]?.answered, "30")
+})
+
+test("an item this game cannot use still cuts a fall whose board and bar agree", () => {
+  // What FOUNDRY needs from an item is an integer answer of 1 or more: the answer
+  // IS the number the bar has to reach, and a bar cannot hold nothing. Everything
+  // else — an answer of `0`, an empty string, a value that is not a number — is a
+  // hole in the curriculum reaching a game that has to keep going anyway.
+  //
+  // It must not keep going by *lying*. This used to hold on to the item's own
+  // prompt and quietly set the target to 12, so a `3 − 3` on the board could only
+  // be escaped by building twelve: the child would work out zero, be right, and
+  // lose the fall for it. And it must not do the trebuchet thing either — spawn
+  // nothing, and draw an empty ring as though it were a playable one.
+  const unusable: Array<[string, string]> = [
+    ["3 − 3", "0"],
+    ["0 + 0", "0"],
+    ["8 + 4", ""],
+    ["8 + 4", "twelve"],
+    ["9 − 20", "-11"],
+    ["", "0"],
+  ]
+  for (const [prompt, answer] of unusable) {
+    const r = rig([{ id: "hole", prompt, answer, distractors: [], domain: "add", difficulty: 0 }])
+    const f = r.bout.fall
+
+    // Playable: a real target, a real pair of plates, and a way out of them.
+    assert.equal(f.target, FALLBACK.target, `${answer || "(empty)"}: no usable target`)
+    assert.ok(f.plates.a > 0 && f.plates.b > 0, "a plate with no weight")
+    assert.equal(f.plates.a * f.plates.x + f.plates.b * f.plates.y, f.target, "an escape that misses")
+    assert.ok(f.minTaps >= 1, "a fall with no taps in it")
+
+    // Honest: the board carries a sum whose answer is the number the bar needs.
+    assert.equal(f.prompt, FALLBACK.prompt, `the board kept a sum it cannot be escaped by`)
+    assert.equal(
+      f.prompt.split("+").map((s) => Number.parseInt(s.trim(), 10)).reduce((a, b) => a + b, 0),
+      f.target,
+      `the board says "${f.prompt}" and the bar needs ${f.target}`,
+    )
+
+    // Unreported: there is no item to report it against.
+    toPin(r.bout)
+    r.bout.fall.plates = { a: 1, b: f.target, x: 0, y: 1, taps: 1 }
+    r.bout.tap("b")
+    assert.equal(r.bout.phase, "kickout", "the fallback fall could not be escaped")
+    assert.deepEqual(r.reports, [], "a fall cut from an unusable item was reported")
+  }
+})
+
+test("a usable item keeps its own sum on the board", () => {
+  // The other half of the fallback: it fires only when it has to.
+  const r = rig([q(31, "17 + 14", ["21"])])
+  assert.equal(r.bout.fall.prompt, "17 + 14")
+  assert.equal(r.bout.fall.target, 31)
 })

--- a/dynawalla/games/foundry/src/test/escape.test.ts
+++ b/dynawalla/games/foundry/src/test/escape.test.ts
@@ -1,0 +1,189 @@
+// THE WRESTLERS MUST SURVIVE A CORRECT ANSWER.
+//
+// The report this file exists for, verbatim:
+//
+//   "'the grapple foundry' seems completely broken now. I do something that I
+//    think is correct 0+3=3 so I tap 1 and 2 and the screen basically goes blank
+//    but there are still sounds .. not completely blank but the wrestlers go
+//    away."
+//
+// What was happening. A kick-out lays a scorch on the mat, and only a kick-out
+// does. The scorch's glow is a radial gradient whose stops were
+// `withAlpha(heatColor(heat), a)` — and `withAlpha` parsed hex while `heatColor`
+// returned `rgb(...)`, so the stop colour came out as `rgba(NaN,11,37,0.3)`.
+// `CanvasGradient.addColorStop` throws on that. The throw is inside `drawMat`,
+// which runs *before* the two bodies, the referee, the near ropes and the entire
+// HUD, and `frame()` re-arms its `requestAnimationFrame` on its first line — so
+// the loop stayed alive and every frame painted the crowd, the far posts and the
+// mat and then died in the same place. The audio graph is not on the frame loop,
+// so the hall kept roaring. Exactly the screenshot.
+//
+// Two properties are asserted, and they fail for different reasons:
+//
+//   1. **No frame throws**, across a correct answer and the twelve seconds a
+//      scorch takes to cool. This is the direct one.
+//   2. **The player is still being drawn**, measured as filled marks in cast-iron
+//      inside the ring. "Blank" is not a small number of draw calls — the
+//      founder's screenshot had the crowd, the posts and the mat on it — so
+//      counting calls cannot tell a live ring from a dead one. Positions can.
+//
+// The host here is not the stub: the stub climbs a ladder of two-to-four-digit
+// column sums and never serves `0 + 3`. Single-digit and zero-bearing items are
+// new content, and a target of 3 is the smallest thing this game can be asked
+// for — `choosePlates` cannot split it across two plates that are both used, so
+// it falls back to a 1 and a 2, which is the pair the founder tapped.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount, type Host, type Question } from "../contract.ts"
+import { choosePlates, minTapsFor } from "../game/plates.ts"
+import { Rng } from "../core/rng.ts"
+import { computeLayout } from "../render/layout.ts"
+import { drawGrapple } from "../render/ring.ts"
+import { IRON } from "../render/palette.ts"
+import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
+import { canvasOf, pump, recorder, recordingContext, withBrowser, type Mark } from "./rig.ts"
+
+const W = 390
+const H = 844
+
+/**
+ * Items the way the ladder now serves them at the bottom: single digits, and a
+ * zero as an operand.
+ */
+const ITEMS: Array<[string, string]> = [
+  ["0 + 3", "3"],
+  ["2 + 5", "7"],
+  ["6 + 1", "7"],
+  ["4 + 4", "8"],
+]
+
+function tinyHost(onReport?: (correct: boolean) => void): Host {
+  let served = 0
+  return {
+    next(): Question {
+      const [prompt, answer] = ITEMS[served % ITEMS.length] as [string, string]
+      served++
+      return { id: `q${served}`, prompt, answer, distractors: [], domain: "add", difficulty: 0 }
+    },
+    report(r) {
+      onReport?.(r.correct)
+    },
+    haptic() {},
+    prefersReducedMotion: () => false,
+  }
+}
+
+/**
+ * The pinned player, as marks on the canvas.
+ *
+ * `drawGrapple` is the only thing in the game that *fills a path* in `IRON`: the
+ * ring frame uses `fillRect` for its posts and the pedals have their own colours,
+ * so this is the player's torso, legs and head and nothing else. The challenger
+ * fills in `IRON_DARK`, which the mat apron also uses, so the lighter body is the
+ * cleaner probe.
+ */
+function playerMarks(marks: Mark[]): Mark[] {
+  return marks.filter((m) => m.kind === "fill" && m.style === IRON)
+}
+
+test("a correct answer does not take the ring down with it", () => {
+  const rec = recorder()
+  const correct: boolean[] = []
+  withBrowser({ w: W, h: H }, recordingContext(rec), ({ host, frames, created }) => {
+    const handle = mount(host as unknown as HTMLElement, tinyHost((c) => correct.push(c)))
+    const down = canvasOf(created).listeners.get("pointerdown")?.[0]
+    assert.ok(down, "no pointerdown listener was installed")
+
+    const tap = (side: "a" | "b"): void => {
+      down({ preventDefault() {}, clientX: side === "a" ? W * 0.25 : W * 0.75, clientY: H * 0.9 })
+    }
+
+    // Through the lockup and into the pin. The bodies are on the mat already.
+    let t = pump(frames, 90)
+    rec.marks.length = 0
+    t = pump(frames, 6, t)
+    const before = playerMarks(rec.marks).length
+    assert.ok(before > 0, "the player was never drawn even before the escape")
+
+    // 0 + 3 = 3, on plates of 1 and 2: one tap each. This is the founder's input.
+    tap("a")
+    t = pump(frames, 2, t)
+    tap("b")
+    t = pump(frames, 2, t)
+    assert.deepEqual(correct, [true], `the escape was not reported correct: ${correct.join()}`)
+
+    // A scorch cools over twelve seconds, so the whole cooling ramp is walked —
+    // the throw was in the glow, which only exists while the mark still has heat
+    // in it. 900 frames at 60Hz is fifteen seconds.
+    rec.marks.length = 0
+    t = pump(frames, 900, t)
+
+    const after = playerMarks(rec.marks).length
+    assert.ok(
+      after > before * 100,
+      `the player stopped being drawn after the escape: ${before} marks in 6 frames before, ` +
+        `${after} in 900 frames after`,
+    )
+    // And the whole draw ran, right down to the last thing on it. The pedals are
+    // drawn after the bodies, so their labels are proof the frame reached the end.
+    assert.ok(rec.text.includes("HEAVY"), "the pedals stopped being drawn after the escape")
+    assert.deepEqual(
+      [...new Set(rec.invalid)],
+      [],
+      "a colour the canvas cannot parse was produced during or after the escape",
+    )
+    assert.equal(rec.imbalance, 0, "a draw call restored more than it saved")
+
+    handle.unmount()
+  })
+})
+
+test("every target the bottom of the ladder can serve hangs a pair that escapes it", () => {
+  // What FOUNDRY needs from an item: an integer answer of 1 or more, which it
+  // then has to be able to *build* out of two plate values. `0 + 1` and `0 + 3`
+  // are new content, and 1, 2, 3 and 4 are the targets that cannot be split
+  // across two distinct plates that are both used. An unplayable pair here would
+  // be the trebuchet failure — a fall laid out with no way out of it.
+  const rng = new Rng(0x4a11)
+  for (let target = 1; target <= 40; target++) {
+    const p = choosePlates(target, rng, { pressure: 0 })
+    assert.ok(p.a > 0 && p.b > 0, `target ${target}: a plate with no weight (${p.a}, ${p.b})`)
+    assert.equal(
+      p.a * p.x + p.b * p.y,
+      target,
+      `target ${target}: ${p.x}×${p.a} + ${p.y}×${p.b} is not ${target}`,
+    )
+    const min = minTapsFor(target, p.a, p.b)
+    assert.ok(min !== null && min >= 1, `target ${target}: no escape from (${p.a}, ${p.b})`)
+  }
+})
+
+test("the pinned player never rotates out from under the bar, however long the session", () => {
+  // `pose.wobble` is a monotonic clock in seconds. Using it as an angle rotated
+  // the body without bound: level at the start of a session, upside down about a
+  // minute in, and past the mat edge after that. So the same pose is drawn at
+  // times spanning ten minutes and the head has to stay put.
+  const l = computeLayout(W, H, safeRect(W, H))
+  const head = (wobble: number): Mark => {
+    const rec = recorder()
+    const g = recordingContext(rec)
+    drawGrapple(g, l, { rise: 0, press: 0.4, wobble, count: 0 }, 0, 0)
+    const marks = playerMarks(rec.marks)
+    // The head is the last thing the player's body fills.
+    const last = marks[marks.length - 1]
+    assert.ok(last, `nothing was drawn for the player at wobble ${wobble}`)
+    return last
+  }
+
+  const at0 = head(0)
+  for (const wobble of [0.7, 3, 11, 31, 63, 100, 157, 300, 600]) {
+    const m = head(wobble)
+    assert.ok(
+      Math.abs(m.x - at0.x) < l.unit * 0.5 && Math.abs(m.y - at0.y) < l.unit * 0.5,
+      `at ${wobble}s the player's head is at (${m.x.toFixed(1)}, ${m.y.toFixed(1)}), ` +
+        `which is off from (${at0.x.toFixed(1)}, ${at0.y.toFixed(1)}) by more than half a unit`,
+    )
+  }
+})

--- a/dynawalla/games/foundry/src/test/manual.test.ts
+++ b/dynawalla/games/foundry/src/test/manual.test.ts
@@ -1,0 +1,115 @@
+// THE MANUAL HAS TO SPEAK THE GAME'S OWN LANGUAGE.
+//
+// The report:
+//
+//   "The instructions need to define the terms sometimes. I don't know what 'the
+//    fall' is on the grapple foundry for example."
+//
+// It was right. The manual said "One over the answer and the fall is lost" and
+// never once said what a fall was. A `fall`, a `pin`, a `kick out`, the `count`,
+// being `waved off` and the `belt` are all things this game made up, and a child
+// who does not know them cannot use any of the rules that mention them.
+//
+// These assertions are deliberately shallow — prose cannot be unit-tested — but
+// they are not vacuous. Each one fails if a definition is deleted, and the last
+// one fails if a new banner is added to `mount.ts` without a line in the manual
+// saying what a child is looking at.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { BANNER_WORDS, INVENTED_TERMS, SECTIONS, SUMMARY, TITLE } from "../manual.ts"
+
+const ALL = [...SUMMARY, ...SECTIONS.flatMap((s) => [s.heading, ...s.lines])]
+const TEXT = ALL.join("\n")
+const LOWER = TEXT.toLowerCase()
+
+test("the game has a title and something to say before the first tap", () => {
+  assert.equal(TITLE, "THE GRAPPLE FOUNDRY")
+  assert.ok(SUMMARY.length >= 2, "the splash is too short to make the first move from")
+  assert.ok(SECTIONS.length >= 6, "the manual lost a section")
+})
+
+test("every term this game invented is used somewhere in the manual", () => {
+  for (const term of INVENTED_TERMS) {
+    assert.ok(LOWER.includes(term), `the manual never mentions "${term}"`)
+  }
+})
+
+test("the terms a child cannot guess are defined where they are first used", () => {
+  // A definition here means: the line that introduces the word also says what the
+  // word means. Checked by requiring the introducing phrase, because that is the
+  // thing that was missing — the words themselves were all present before.
+  const definitions: Array<[string, RegExp]> = [
+    ["pin", /being held down like this is called a pin/i],
+    ["fall", /that one try is called a fall/i],
+    ["kick out", /getting free like that is called a kick out/i],
+    ["bar", /the bar is the iron rod lying across your chest/i],
+    ["pedals", /the two pedals are the big squares at the bottom/i],
+    ["board", /that is the sign hanging above the ring/i],
+    ["count", /those three slaps are called the count/i],
+    ["referee", /the referee is the person kneeling beside you/i],
+    ["waved off", /that is called being waved off/i],
+    ["belt", /that strip is your belt/i],
+  ]
+  for (const [term, pattern] of definitions) {
+    assert.match(TEXT, pattern, `"${term}" is used but never explained`)
+  }
+})
+
+test("a term is explained no later than the line that first uses it", () => {
+  // Order matters more than presence. "It costs you count" three sections above
+  // "Those three slaps are called the count" is the same bug with the fix filed
+  // in the wrong place, and a child does not scroll back.
+  const firstUse = (needle: RegExp | string): number =>
+    ALL.findIndex((line) =>
+      typeof needle === "string" ? line.toLowerCase().includes(needle) : needle.test(line),
+    )
+
+  const pairs: Array<[string, string, RegExp]> = [
+    ["pin", "pin", /called a pin/i],
+    ["fall", "fall", /called a fall/i],
+    ["kick out", "kick out", /called a kick out/i],
+    ["count", "count", /called the count/i],
+    ["belt", "belt", /your belt/i],
+    ["waved off", "waved off", /called being waved off/i],
+  ]
+  for (const [term, use, definition] of pairs) {
+    const used = firstUse(use)
+    const defined = firstUse(definition)
+    assert.ok(used >= 0, `"${term}" is not in the manual at all`)
+    assert.ok(defined >= 0, `"${term}" is never defined`)
+    assert.ok(
+      defined <= used,
+      `"${term}" is first used on line ${used} and only explained on line ${defined}`,
+    )
+  }
+})
+
+test("every word the game shouts at a child is explained in the manual", () => {
+  // These are drawn on a banner half the ring wide, at the moment a fall ends. A
+  // child reading THREE with no idea what it refers to has been told off in a
+  // language nobody taught them.
+  for (const word of BANNER_WORDS) {
+    assert.ok(TEXT.includes(word), `the game prints "${word}" and the manual never mentions it`)
+  }
+})
+
+test("the manual is written in short sentences and never says how well you are doing", () => {
+  // The house rule for this age: short lines, and nothing that characterises the
+  // child. "You are doing great" and "you keep getting this wrong" are both out.
+  for (const line of ALL) {
+    const sentences = line.split(/(?<=[.!?])\s+/).filter(Boolean)
+    for (const s of sentences) {
+      const words = s.trim().split(/\s+/).length
+      assert.ok(words <= 26, `too long for a seven-year-old (${words} words): ${JSON.stringify(s)}`)
+    }
+  }
+  for (const banned of ["stupid", "silly", "easy", "just ", "obviously", "simply", "of course"]) {
+    assert.equal(
+      LOWER.includes(banned),
+      false,
+      `the manual says ${JSON.stringify(banned)} — that is a judgement, not an instruction`,
+    )
+  }
+})

--- a/dynawalla/games/foundry/src/test/mount.test.ts
+++ b/dynawalla/games/foundry/src/test/mount.test.ts
@@ -10,216 +10,28 @@
 // and an escape, and asserts that nothing threw and that the world actually
 // moved. It is not a rendering test — there are no pixels to look at — it is a
 // test that the whole thing is wired to itself.
+//
+// The canvas it runs against lives in `rig.ts` and *enforces the parts of the 2D
+// specification that throw*. The version of this file that shipped the blank-ring
+// bug used a `Proxy` that answered every call with a stub, so nine hundred frames
+// of a real bout could not fail for a colour, a radius or a transform — and did
+// not, while every frame after the first kick-out was dying inside `drawMat`.
 
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { mount } from "../contract.ts"
 import { createStubHost } from "../stubHost.ts"
+import {
+  canvasOf,
+  pump,
+  recorder,
+  recordingContext,
+  withBrowser,
+  type FakeElement,
+} from "./rig.ts"
 
 type Listener = (event: unknown) => void
-
-/** A 2D context that answers every call and records how much work it was asked for. */
-function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderingContext2D {
-  const store = new Map<string, unknown>()
-  const noop = (name: string) =>
-    function (...args: unknown[]) {
-      counter.calls++
-      if (name === "fillText" && typeof args[0] === "string") counter.text.push(args[0])
-      // Gradients are the one call whose result is used, so everything returns
-      // something that can take a colour stop.
-      return { addColorStop() {} }
-    }
-  return new Proxy(
-    {},
-    {
-      get(_t, prop: string) {
-        if (store.has(prop)) return store.get(prop)
-        return noop(prop)
-      },
-      set(_t, prop: string, value) {
-        store.set(prop, value)
-        return true
-      },
-    },
-  ) as unknown as CanvasRenderingContext2D
-}
-
-type FakeElement = {
-  style: { cssText: string; top: string; right: string }
-  width: number
-  height: number
-  id: string
-  className: string
-  listeners: Map<string, Listener[]>
-  children: unknown[]
-  attrs: Map<string, string>
-  appendChild(child: unknown): void
-  append(...children: unknown[]): void
-  setAttribute(name: string, value: string): void
-  remove(): void
-  focus(): void
-  addEventListener(type: string, fn: Listener): void
-  removeEventListener(type: string, fn: Listener): void
-  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
-  getContext(): CanvasRenderingContext2D
-}
-
-function harness(size: { w: number; h: number }, counter: { calls: number; text: string[] }) {
-  const ctx = fakeContext(counter)
-  const make = (): FakeElement => {
-    const listeners = new Map<string, Listener[]>()
-    const children: unknown[] = []
-    return {
-      style: { cssText: "", top: "", right: "" },
-      width: 0,
-      height: 0,
-      id: "",
-      className: "",
-      listeners,
-      children,
-      attrs: new Map<string, string>(),
-      appendChild(child) {
-        children.push(child)
-      },
-      append(...kids) {
-        children.push(...kids)
-      },
-      setAttribute(name, value) {
-        this.attrs.set(name, value)
-      },
-      remove() {},
-      focus() {},
-      addEventListener(type, fn) {
-        const list = listeners.get(type) ?? []
-        list.push(fn)
-        listeners.set(type, list)
-      },
-      removeEventListener(type, fn) {
-        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
-      },
-      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
-      getContext: () => ctx,
-    }
-  }
-  const created: FakeElement[] = []
-  // The shared chrome measures `env(safe-area-inset-*)` through a hidden probe
-  // element and mounts a how-to-play button, so this document has to answer
-  // `getElementById`, own a `body`, and hand back elements that can take
-  // attributes. A partial document is worse than none: it type-checks, it looks
-  // like a browser, and it throws on the first real call.
-  const byId = new Map<string, FakeElement>()
-  const body = make()
-  body.appendChild = (child: unknown): void => {
-    const el = child as FakeElement
-    if (el?.id) byId.set(el.id, el)
-  }
-  const doc = {
-    visibilityState: "visible",
-    body,
-    activeElement: null,
-    listeners: new Map<string, Listener[]>(),
-    createElement() {
-      const el = make()
-      created.push(el)
-      return el
-    },
-    getElementById(id: string) {
-      return byId.get(id) ?? null
-    },
-    addEventListener(type: string, fn: Listener) {
-      const list = doc.listeners.get(type) ?? []
-      list.push(fn)
-      doc.listeners.set(type, list)
-    },
-    removeEventListener(type: string, fn: Listener) {
-      doc.listeners.set(type, (doc.listeners.get(type) ?? []).filter((f) => f !== fn))
-    },
-  }
-  return { host: make(), doc, created, ctx }
-}
-
-type Rig = ReturnType<typeof harness> & {
-  frames: Array<(t: number) => void>
-  globals: Map<string, Listener[]>
-}
-
-/**
- * Install the browser globals `mount.ts` needs, run `body`, and take them back
- * off again — including when `body` throws, which is the case this file exists
- * to catch.
- */
-function withBrowser(
-  size: { w: number; h: number },
-  counter: { calls: number; text: string[] },
-  body: (rig: Rig) => void,
-): void {
-  const rig = harness(size, counter) as ReturnType<typeof harness> & {
-    globals: Map<string, Listener[]>
-  }
-  const saved = new Map<string, PropertyDescriptor | undefined>()
-  const set = (key: string, value: unknown) => {
-    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
-    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
-  }
-  const frames: Array<(t: number) => void> = []
-  set("document", rig.doc)
-  set("devicePixelRatio", 2)
-  set("requestAnimationFrame", (fn: (t: number) => void) => {
-    frames.push(fn)
-    return frames.length
-  })
-  set("cancelAnimationFrame", () => {})
-  // No notch off a real device. Zeros are the honest answer, and are what the
-  // safe-area probe resolves to on a laptop too.
-  set("getComputedStyle", () => ({
-    paddingTop: "0px",
-    paddingRight: "0px",
-    paddingBottom: "0px",
-    paddingLeft: "0px",
-  }))
-  // The global listeners are RECORDED rather than swallowed. `mount.ts` puts
-  // its keyboard on `globalThis`, and the how-to-play panel is a DOM scrim —
-  // which stops the pointer and nothing else — so the only way to test that a
-  // key cannot reach the bout through the manual is to be able to fire one.
-  const globals = new Map<string, Listener[]>()
-  set("addEventListener", (type: string, fn: Listener) => {
-    globals.set(type, [...(globals.get(type) ?? []), fn])
-  })
-  set("removeEventListener", (type: string, fn: Listener) => {
-    globals.set(type, (globals.get(type) ?? []).filter((f) => f !== fn))
-  })
-  rig.globals = globals
-
-  try {
-    body({ ...rig, frames, globals })
-  } finally {
-    for (const [key, descriptor] of saved) {
-      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
-      else Reflect.deleteProperty(globalThis, key)
-    }
-  }
-}
-
-/** The canvas is the second element `mount` creates: the root div, then it. */
-function canvasOf(created: FakeElement[]): FakeElement {
-  const el = created[1]
-  if (!el) throw new Error("mount did not create a canvas")
-  return el
-}
-
-/** Run `n` frames at 60Hz, draining the rAF queue each time. */
-function pump(frames: Array<(t: number) => void>, n: number, from = 0): number {
-  let t = from
-  for (let i = 0; i < n; i++) {
-    const next = frames.pop()
-    frames.length = 0
-    if (!next) break
-    t += 16.7
-    next(t)
-  }
-  return t
-}
 
 for (const [w, h] of [
   [320, 568],
@@ -227,9 +39,9 @@ for (const [w, h] of [
   [1366, 1024],
 ] as const) {
   test(`a whole bout renders without throwing at ${w}×${h}`, () => {
-    const counter = { calls: 0, text: [] as string[] }
+    const rec = recorder()
     const reports: Array<{ correct: boolean }> = []
-    withBrowser({ w, h }, counter, ({ host, frames, created, doc }) => {
+    withBrowser({ w, h }, recordingContext(rec), ({ host, frames, created, doc }) => {
       const stub = createStubHost({
         seed: 0x51ab,
         reducedMotion: false,
@@ -241,29 +53,38 @@ for (const [w, h] of [
       // Long enough for the lockup, a full three-count, the pinfall beat and the
       // next takedown — several times over.
       let t = pump(frames, 900)
-      assert.ok(counter.calls > 5000, `only ${counter.calls} draw calls in 900 frames`)
-      assert.ok(counter.text.length > 0, "nothing was ever written on the board")
+      assert.ok(rec.calls > 5000, `only ${rec.calls} draw calls in 900 frames`)
+      assert.ok(rec.text.length > 0, "nothing was ever written on the board")
 
       // And a tap goes all the way through the input handler into the rules.
       const down = canvas.listeners.get("pointerdown")?.[0]
       assert.ok(down, "no pointerdown listener was installed")
-      const before = counter.calls
+      const before = rec.calls
       for (let i = 0; i < 30; i++) {
         down({ preventDefault() {}, clientX: i % 2 === 0 ? w * 0.25 : w * 0.75, clientY: h * 0.9 })
         t = pump(frames, 12, t)
       }
-      assert.ok(counter.calls > before)
+      assert.ok(rec.calls > before)
 
       // Backgrounding the tab must stop the world without stopping the loop.
       doc.visibilityState = "hidden"
       for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
-      const paused = counter.calls
+      const paused = rec.calls
       t = pump(frames, 60, t)
-      assert.equal(counter.calls, paused, "the count kept running while hidden")
+      assert.equal(rec.calls, paused, "the count kept running while hidden")
       doc.visibilityState = "visible"
       for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
       t = pump(frames, 30, t)
-      assert.ok(counter.calls > paused, "the world never came back")
+      assert.ok(rec.calls > paused, "the world never came back")
+
+      // Nothing was ever handed a colour the canvas would have thrown out, and no
+      // draw call leaked a `save()` — a leaked `clip()` hides everything after it.
+      assert.deepEqual(
+        [...new Set(rec.invalid)],
+        [],
+        "a colour string the canvas cannot parse reached it",
+      )
+      assert.equal(rec.imbalance, 0, "a draw call restored more than it saved")
 
       handle.unmount()
       assert.equal(canvas.listeners.get("pointerdown")?.length ?? 0, 0)
@@ -284,8 +105,8 @@ for (const [w, h] of [
 }
 
 test("the reduced-motion branch renders the same bout with no particles", () => {
-  const counter = { calls: 0, text: [] as string[] }
-  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, created }) => {
+  const rec = recorder()
+  withBrowser({ w: 768, h: 1024 }, recordingContext(rec), ({ host, frames, created }) => {
     const stub = createStubHost({ seed: 0x51ab, reducedMotion: true })
     const handle = mount(host as unknown as HTMLElement, stub)
     let t = pump(frames, 300)
@@ -296,8 +117,9 @@ test("the reduced-motion branch renders the same bout with no particles", () => 
     }
     // The information is all still there — the board, the bar and the plates are
     // written every frame — it just arrives without travel.
-    assert.ok(counter.text.length > 0)
-    assert.ok(counter.calls > 3000)
+    assert.ok(rec.text.length > 0)
+    assert.ok(rec.calls > 3000)
+    assert.deepEqual([...new Set(rec.invalid)], [], "reduced motion produced an unparseable colour")
     handle.unmount()
   })
 })
@@ -318,8 +140,8 @@ test("a key cannot drop a plate through the how-to-play panel", () => {
   // is up, so the panel has to be closed before anything is pumped — the first
   // draft of this test checked for the banner while the world was still frozen,
   // passed with the guard removed, and was worth nothing.
-  const counter = { calls: 0, text: [] as string[] }
-  withBrowser({ w: 390, h: 844 }, counter, ({ host, frames, created, globals }) => {
+  const rec = recorder()
+  withBrowser({ w: 390, h: 844 }, recordingContext(rec), ({ host, frames, created, globals }) => {
     const stub = createStubHost({ seed: 0x51ab, reducedMotion: false })
     const handle = mount(host as unknown as HTMLElement, stub)
     let t = pump(frames, 120)
@@ -346,26 +168,26 @@ test("a key cannot drop a plate through the how-to-play panel", () => {
     // target this game can serve, several times over — then CLOSE it and let
     // the world run, which is the only point at which a banner can be drawn.
     click(help)
-    counter.text.length = 0
+    rec.text.length = 0
     press(40)
     click(close)
     t = pump(frames, 120, t)
     assert.equal(
-      counter.text.includes("TOO MUCH"),
+      rec.text.includes("TOO MUCH"),
       false,
       "keys pressed behind the manual dropped plates and lost the fall",
     )
 
     // And the keyboard works the moment the panel is gone: a gate stuck shut is
     // the same bug wearing a different hat.
-    counter.text.length = 0
+    rec.text.length = 0
     for (let i = 0; i < 40; i++) {
       press(1)
       t = pump(frames, 2, t)
     }
     t = pump(frames, 30, t)
     assert.equal(
-      counter.text.includes("TOO MUCH"),
+      rec.text.includes("TOO MUCH"),
       true,
       "the keyboard never came back after the manual closed",
     )

--- a/dynawalla/games/foundry/src/test/palette.test.ts
+++ b/dynawalla/games/foundry/src/test/palette.test.ts
@@ -150,6 +150,15 @@ test("a colour nobody can read is loud, visible, and never NaN", () => {
   assert.ok(said.length > 0, "an unreadable colour was swallowed silently")
 })
 
+test("a channel out of range is brought back into it", () => {
+  // `rgba(300,-5,0,1)` is a string a canvas rejects, and rejecting it inside a
+  // gradient stop is a thrown exception in the frame loop. Every colour these two
+  // hand back has to be one that parses, whatever they were handed.
+  assert.equal(withAlpha("rgb(300,-5,12)", 0.5), "rgba(255,0,12,0.5)")
+  assert.equal(mix("rgb(300,-5,12)", "#000000", 0).toLowerCase(), "#ff000c")
+  assertParseable(withAlpha("rgb(1e9,-1e9,0)", 1), "withAlpha(out of range, 1)")
+})
+
 test("a non-finite alpha or mix position is not allowed to reach the canvas", () => {
   assertParseable(withAlpha(IRON, Number.NaN), "withAlpha(IRON, NaN)")
   assertParseable(withAlpha(IRON, Number.POSITIVE_INFINITY), "withAlpha(IRON, Infinity)")

--- a/dynawalla/games/foundry/src/test/palette.test.ts
+++ b/dynawalla/games/foundry/src/test/palette.test.ts
@@ -1,0 +1,157 @@
+// THE COLOUR HELPERS MUST COMPOSE.
+//
+// `withAlpha` and `mix` are handed each other's output all over `render/`, and
+// `heatColor` *is* `mix`. That made the output form of `mix` load-bearing rather
+// than cosmetic, and it was wrong: `mix` returned `rgb(...)` and `withAlpha`
+// parsed hex, so `withAlpha(heatColor(t), a)` produced `rgba(NaN,11,37,0.3)`.
+//
+// The canvas silently ignores an unparseable `fillStyle`, so five of the six
+// composition sites in this game just drew the wrong colour and nothing failed
+// anywhere. The sixth — the scorch glow in `decals.ts` — hands the string to
+// `CanvasGradient.addColorStop`, which throws, and the throw is inside `drawMat`.
+// The first kick-out of a session killed every frame after it from the mat
+// onwards: no wrestlers, no referee, no pedals, audio still playing.
+//
+// So this file asserts the property that was missing rather than the fix: every
+// colour string these three functions can produce, including from each other, is
+// one a canvas can parse.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  BRASS,
+  BRASS_DARK,
+  BRASS_HI,
+  CANVAS,
+  CHALK,
+  CROWD_LANTERN,
+  HEAT_WHITE,
+  INK,
+  IRON,
+  KICKOUT,
+  NIGHT,
+  OXIDE,
+  heatColor,
+  mix,
+  withAlpha,
+} from "../render/palette.ts"
+
+/**
+ * The colours a 2D canvas will take. Deliberately strict about digits: a check
+ * that accepted anything shaped like `rgba(...)` would have accepted
+ * `rgba(NaN,11,37,0.3)`, which is the string that blanked the ring.
+ */
+const HEX = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+const RGB = /^rgba?\(\d+(\.\d+)?,\d+(\.\d+)?,\d+(\.\d+)?(,[\d.]+)?\)$/
+
+function assertParseable(value: string, what: string): void {
+  assert.ok(
+    HEX.test(value) || RGB.test(value),
+    `${what} produced ${JSON.stringify(value)}, which a canvas cannot parse`,
+  )
+}
+
+const PALETTE = [
+  NIGHT,
+  IRON,
+  BRASS,
+  BRASS_HI,
+  BRASS_DARK,
+  CANVAS,
+  HEAT_WHITE,
+  KICKOUT,
+  OXIDE,
+  INK,
+  CHALK,
+  CROWD_LANTERN,
+]
+
+/** The whole heat ramp, both endpoints and both of its interior seams. */
+const HEATS = [0, 0.001, 0.15, 0.39, 0.4, 0.41, 0.71, 0.72, 0.73, 0.99, 1]
+
+test("heatColor is parseable across the whole ramp, and composes with withAlpha", () => {
+  // This is the exact composition that blanked the ring, at every temperature a
+  // cooling scorch passes through.
+  for (const t of HEATS) {
+    const c = heatColor(t)
+    assertParseable(c, `heatColor(${t})`)
+    for (const a of [0, 0.28, 0.3, 0.85, 1]) {
+      assertParseable(withAlpha(c, a), `withAlpha(heatColor(${t}), ${a})`)
+    }
+    for (const base of PALETTE) {
+      assertParseable(mix(base, c, 0.5), `mix(base, heatColor(${t}), 0.5)`)
+      assertParseable(withAlpha(mix(base, c, 0.5), 0.4), "withAlpha(mix(…, heatColor(…)), 0.4)")
+    }
+  }
+})
+
+test("every colour in the palette survives withAlpha and mix, in any combination", () => {
+  for (const from of PALETTE) {
+    assertParseable(withAlpha(from, 0.5), `withAlpha(${from}, 0.5)`)
+    for (const to of PALETTE) {
+      for (const t of [0, 0.5, 1]) {
+        const m = mix(from, to, t)
+        assertParseable(m, `mix(${from}, ${to}, ${t})`)
+        assertParseable(withAlpha(m, 0.33), `withAlpha(mix(${from}, ${to}, ${t}), 0.33)`)
+        assertParseable(mix(m, from, 0.5), "mix(mix(…), …)")
+      }
+    }
+  }
+})
+
+test("mix hands back something it can be handed again", () => {
+  // The reason the output form is a rule and not a taste: `heatColor` is `mix`,
+  // and six call sites feed it straight back into `withAlpha` or `mix`.
+  const once = mix(NIGHT, HEAT_WHITE, 0.5)
+  assert.match(once, HEX, `mix returned ${once}, which withAlpha cannot take back`)
+  assertParseable(withAlpha(once, 0.5), "withAlpha(mix(…))")
+})
+
+test("mix is still a mix: the ends are the ends and the middle is between them", () => {
+  // Rewriting the parser must not change what the colours look like.
+  assert.equal(mix("#000000", "#ffffff", 0).toLowerCase(), "#000000")
+  assert.equal(mix("#000000", "#ffffff", 1).toLowerCase(), "#ffffff")
+  assert.equal(mix("#000000", "#ffffff", 0.5).toLowerCase(), "#808080")
+  assert.equal(mix("#ff0000", "#0000ff", 0.5).toLowerCase(), "#800080")
+  // Out of range is clamped rather than extrapolated.
+  assert.equal(mix("#000000", "#ffffff", -3).toLowerCase(), "#000000")
+  assert.equal(mix("#000000", "#ffffff", 4).toLowerCase(), "#ffffff")
+})
+
+test("withAlpha keeps the channels and clamps the alpha", () => {
+  assert.equal(withAlpha("#2b2b33", 0.5), "rgba(43,43,51,0.5)")
+  assert.equal(withAlpha("rgb(43,43,51)", 0.5), "rgba(43,43,51,0.5)")
+  assert.equal(withAlpha("rgba(43,43,51,0.2)", 0.5), "rgba(43,43,51,0.5)")
+  assert.equal(withAlpha("#f0f", 1), "rgba(255,0,255,1)")
+  assert.equal(withAlpha("#2b2b33", -1), "rgba(43,43,51,0)")
+  assert.equal(withAlpha("#2b2b33", 9), "rgba(43,43,51,1)")
+})
+
+test("a colour nobody can read is loud, visible, and never NaN", () => {
+  // The last line of defence. A future author who invents a fourth colour form
+  // must get a wrong colour and a line in the console, not a black screen in
+  // front of a child — an unparseable gradient stop is a thrown exception inside
+  // the frame loop.
+  const said: unknown[] = []
+  const real = console.error
+  console.error = (...args: unknown[]): void => {
+    said.push(args[0])
+  }
+  try {
+    for (const bad of ["hsl(200 50% 50%)", "#xyz", "", "rgb(a,b,c)", "color(display-p3 1 0 0)"]) {
+      const out = withAlpha(bad, 0.5)
+      assertParseable(out, `withAlpha(${JSON.stringify(bad)}, 0.5)`)
+      assertParseable(mix(bad, NIGHT, 0.5), `mix(${JSON.stringify(bad)}, …)`)
+    }
+  } finally {
+    console.error = real
+  }
+  assert.ok(said.length > 0, "an unreadable colour was swallowed silently")
+})
+
+test("a non-finite alpha or mix position is not allowed to reach the canvas", () => {
+  assertParseable(withAlpha(IRON, Number.NaN), "withAlpha(IRON, NaN)")
+  assertParseable(withAlpha(IRON, Number.POSITIVE_INFINITY), "withAlpha(IRON, Infinity)")
+  assertParseable(mix(IRON, CHALK, Number.NaN), "mix(IRON, CHALK, NaN)")
+})

--- a/dynawalla/games/foundry/src/test/rig.ts
+++ b/dynawalla/games/foundry/src/test/rig.ts
@@ -1,0 +1,495 @@
+// The test rig: a browser that is not a browser, and a canvas that behaves like
+// a canvas.
+//
+// **Why this file exists.** The first version of the mount test built its 2D
+// context out of a `Proxy` that answered every call with a stub and returned
+// `{ addColorStop() {} }` for a gradient. It ran nine hundred frames of a real
+// bout and proved the modules were wired to each other — and it could not have
+// failed for a colour, a radius or a transform, because nothing it handed to the
+// canvas was ever *checked*. THE GRAPPLE FOUNDRY then shipped a bug where the
+// first kick-out of the session threw inside `drawMat` and took the rest of every
+// subsequent frame with it: no wrestlers, no referee, no pedals, the audio still
+// playing. That test passed the whole time.
+//
+// So the context here answers every call *and enforces the parts of the 2D spec
+// that throw*:
+//
+//   * `CanvasGradient.addColorStop` throws `SyntaxError` on a colour string it
+//     cannot parse. This is the one that was missed, and it is the difference
+//     between a wrong colour and a dead frame.
+//   * `arc`, `ellipse`, `arcTo` and `createRadialGradient` throw `IndexSizeError`
+//     on a negative radius.
+//   * A gradient constructor throws on a non-finite coordinate.
+//   * `restore()` with an empty stack is a save/restore imbalance in the caller
+//     and is recorded, because a leaked `clip()` hides everything drawn after it.
+//
+// And it records *where marks landed*, in screen space, with the transform
+// applied. A blank screen is not a small number of draw calls — the founder's
+// screenshot had the crowd, the posts and the mat on it — it is draw calls that
+// stopped happening in one band of the screen. Counting calls cannot tell those
+// apart. Positions can.
+//
+// Colours that the canvas merely *ignores* (an unparseable `fillStyle`) are
+// recorded in `invalid` rather than thrown, because that is what a real canvas
+// does, and a test that threw there would be testing a browser that does not
+// exist.
+
+/** One mark that reached the canvas, at its centre in screen space. */
+export type Mark = {
+  /** `fill`, `stroke`, `fillRect`, or `text:<the string>`. */
+  kind: string
+  x: number
+  y: number
+  /** The colour in force when it landed, or `<gradient>`. */
+  style: string
+}
+
+export type Recorder = {
+  /** Every drawing call, for the coarse "did anything happen" assertions. */
+  calls: number
+  /** Every string written with `fillText`. */
+  text: string[]
+  /** Marks in screen space. Cleared by the caller between measurements. */
+  marks: Mark[]
+  /** Colour strings the canvas would have silently ignored. Should stay empty. */
+  invalid: string[]
+  /** Save/restore imbalances. Should stay empty. */
+  imbalance: number
+}
+
+export function recorder(): Recorder {
+  return { calls: 0, text: [], marks: [], invalid: [], imbalance: 0 }
+}
+
+/** A 2D affine transform, tracked so marks can be reported in screen space. */
+type Affine = { a: number; b: number; c: number; d: number; e: number; f: number }
+
+const identity = (): Affine => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 })
+
+function map(m: Affine, x: number, y: number): [number, number] {
+  return [m.a * x + m.c * y + m.e, m.b * x + m.d * y + m.f]
+}
+
+/**
+ * Is this a colour string a canvas can parse?
+ *
+ * Deliberately narrow: it accepts the forms this game actually produces (hex and
+ * `rgb`/`rgba`) and rejects anything with a `NaN` or an `undefined` in it. A
+ * looser check would have accepted `rgba(NaN,11,37,0.3)`, which is the string
+ * that blanked the ring.
+ */
+export function parseableColour(value: unknown): boolean {
+  if (typeof value !== "string") return false
+  const s = value.trim()
+  if (s.includes("NaN") || s.includes("undefined") || s.includes("Infinity")) return false
+  if (/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(s)) return true
+  if (/^rgba?\(\s*\d+(\.\d+)?\s*,\s*\d+(\.\d+)?\s*,\s*\d+(\.\d+)?\s*(,\s*[\d.]+\s*)?\)$/.test(s)) {
+    return true
+  }
+  // Named colours and everything else this game does not use.
+  return /^[a-z]+$/i.test(s)
+}
+
+/**
+ * A 2D context that draws nothing, records everything, and throws exactly where
+ * the specification says a real one throws.
+ */
+export function recordingContext(rec: Recorder): CanvasRenderingContext2D {
+  let m = identity()
+  const stack: Affine[] = []
+  let path: Array<[number, number]> = []
+  let fillStyle = "#000000"
+  let strokeStyle = "#000000"
+
+  const colour = (value: unknown): string => {
+    if (typeof value !== "string") return "<gradient>"
+    if (!parseableColour(value)) {
+      // A real canvas ignores this and keeps the previous colour.
+      rec.invalid.push(value)
+      return ""
+    }
+    return value
+  }
+
+  const stop = (offset: number, color: string): void => {
+    if (!parseableColour(color)) {
+      throw new Error(
+        `SyntaxError: addColorStop(${offset}, ${JSON.stringify(color)}): not a valid colour`,
+      )
+    }
+  }
+
+  const gradient = { addColorStop: stop }
+
+  const point = (x: number, y: number): void => {
+    path.push(map(m, x, y))
+  }
+
+  const land = (kind: string, style: string): void => {
+    rec.calls++
+    if (path.length === 0) return
+    let sx = 0
+    let sy = 0
+    for (const [x, y] of path) {
+      sx += x
+      sy += y
+    }
+    rec.marks.push({ kind, x: sx / path.length, y: sy / path.length, style })
+  }
+
+  const ctx = {
+    lineWidth: 1,
+    font: "",
+    textAlign: "",
+    textBaseline: "",
+    lineCap: "",
+
+    get fillStyle(): string {
+      return fillStyle
+    },
+    set fillStyle(value: unknown) {
+      const next = colour(value)
+      if (next !== "") fillStyle = next
+    },
+    get strokeStyle(): string {
+      return strokeStyle
+    },
+    set strokeStyle(value: unknown) {
+      const next = colour(value)
+      if (next !== "") strokeStyle = next
+    },
+
+    save(): void {
+      rec.calls++
+      stack.push({ ...m })
+    },
+    restore(): void {
+      rec.calls++
+      const previous = stack.pop()
+      if (!previous) {
+        rec.imbalance++
+        return
+      }
+      m = previous
+    },
+    translate(x: number, y: number): void {
+      rec.calls++
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return
+      const [e, f] = map(m, x, y)
+      m.e = e
+      m.f = f
+    },
+    scale(x: number, y: number): void {
+      rec.calls++
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return
+      m.a *= x
+      m.b *= x
+      m.c *= y
+      m.d *= y
+    },
+    rotate(r: number): void {
+      rec.calls++
+      if (!Number.isFinite(r)) return
+      const cos = Math.cos(r)
+      const sin = Math.sin(r)
+      const { a, b, c, d } = m
+      m.a = a * cos + c * sin
+      m.b = b * cos + d * sin
+      m.c = c * cos - a * sin
+      m.d = d * cos - b * sin
+    },
+    setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
+      rec.calls++
+      m = { a, b, c, d, e, f }
+    },
+
+    beginPath(): void {
+      rec.calls++
+      path = []
+    },
+    closePath(): void {
+      rec.calls++
+    },
+    moveTo(x: number, y: number): void {
+      rec.calls++
+      point(x, y)
+    },
+    lineTo(x: number, y: number): void {
+      rec.calls++
+      point(x, y)
+    },
+    arc(x: number, y: number, r: number): void {
+      rec.calls++
+      if (r < 0) throw new Error(`IndexSizeError: arc radius ${r}`)
+      point(x, y)
+    },
+    ellipse(x: number, y: number, rx: number, ry: number): void {
+      rec.calls++
+      if (rx < 0 || ry < 0) throw new Error(`IndexSizeError: ellipse radii ${rx}, ${ry}`)
+      point(x, y)
+    },
+    arcTo(x1: number, y1: number, x2: number, y2: number, r: number): void {
+      rec.calls++
+      if (r < 0) throw new Error(`IndexSizeError: arcTo radius ${r}`)
+      point(x1, y1)
+      point(x2, y2)
+    },
+    rect(x: number, y: number, w: number, h: number): void {
+      rec.calls++
+      point(x, y)
+      point(x + w, y + h)
+    },
+    clip(): void {
+      rec.calls++
+    },
+    fill(): void {
+      land("fill", fillStyle)
+    },
+    stroke(): void {
+      land("stroke", strokeStyle)
+    },
+    fillRect(x: number, y: number, w: number, h: number): void {
+      rec.calls++
+      if (![x, y, w, h].every(Number.isFinite)) return
+      const [cx, cy] = map(m, x + w / 2, y + h / 2)
+      rec.marks.push({ kind: "fillRect", x: cx, y: cy, style: fillStyle })
+    },
+    strokeRect(): void {
+      rec.calls++
+    },
+    clearRect(): void {
+      rec.calls++
+    },
+    fillText(t: string, x: number, y: number): void {
+      rec.calls++
+      rec.text.push(t)
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return
+      const [cx, cy] = map(m, x, y)
+      rec.marks.push({ kind: `text:${t}`, x: cx, y: cy, style: fillStyle })
+    },
+    measureText(t: string): { width: number } {
+      rec.calls++
+      return { width: t.length * 8 }
+    },
+    createLinearGradient(x0: number, y0: number, x1: number, y1: number): unknown {
+      rec.calls++
+      if (![x0, y0, x1, y1].every(Number.isFinite)) {
+        throw new Error(`createLinearGradient: non-finite (${x0}, ${y0}, ${x1}, ${y1})`)
+      }
+      return gradient
+    },
+    createRadialGradient(
+      x0: number,
+      y0: number,
+      r0: number,
+      x1: number,
+      y1: number,
+      r1: number,
+    ): unknown {
+      rec.calls++
+      if (![x0, y0, r0, x1, y1, r1].every(Number.isFinite)) {
+        throw new Error("createRadialGradient: non-finite argument")
+      }
+      if (r0 < 0 || r1 < 0) throw new Error(`IndexSizeError: radial radii ${r0}, ${r1}`)
+      return gradient
+    },
+  }
+
+  return ctx as unknown as CanvasRenderingContext2D
+}
+
+// ── the document ─────────────────────────────────────────────────────────────
+
+type Listener = (event: unknown) => void
+
+export type FakeElement = {
+  style: { cssText: string; top: string; right: string }
+  width: number
+  height: number
+  id: string
+  className: string
+  listeners: Map<string, Listener[]>
+  children: unknown[]
+  attrs: Map<string, string>
+  appendChild(child: unknown): void
+  append(...children: unknown[]): void
+  setAttribute(name: string, value: string): void
+  remove(): void
+  focus(): void
+  addEventListener(type: string, fn: Listener): void
+  removeEventListener(type: string, fn: Listener): void
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
+  getContext(): CanvasRenderingContext2D
+}
+
+export type Rig = {
+  host: FakeElement
+  doc: {
+    visibilityState: string
+    body: FakeElement
+    activeElement: null
+    listeners: Map<string, Listener[]>
+    createElement(): FakeElement
+    getElementById(id: string): FakeElement | null
+    addEventListener(type: string, fn: Listener): void
+    removeEventListener(type: string, fn: Listener): void
+  }
+  created: FakeElement[]
+  ctx: CanvasRenderingContext2D
+  frames: Array<(t: number) => void>
+  globals: Map<string, Listener[]>
+}
+
+function harness(size: { w: number; h: number }, ctx: CanvasRenderingContext2D) {
+  const make = (): FakeElement => {
+    const listeners = new Map<string, Listener[]>()
+    const children: unknown[] = []
+    return {
+      style: { cssText: "", top: "", right: "" },
+      width: 0,
+      height: 0,
+      id: "",
+      className: "",
+      listeners,
+      children,
+      attrs: new Map<string, string>(),
+      appendChild(child) {
+        children.push(child)
+      },
+      append(...kids) {
+        children.push(...kids)
+      },
+      setAttribute(name, value) {
+        this.attrs.set(name, value)
+      },
+      remove() {},
+      focus() {},
+      addEventListener(type, fn) {
+        const list = listeners.get(type) ?? []
+        list.push(fn)
+        listeners.set(type, list)
+      },
+      removeEventListener(type, fn) {
+        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
+      },
+      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
+      getContext: () => ctx,
+    }
+  }
+  const created: FakeElement[] = []
+  // The shared chrome measures `env(safe-area-inset-*)` through a hidden probe
+  // element and mounts a how-to-play button, so this document has to answer
+  // `getElementById`, own a `body`, and hand back elements that can take
+  // attributes. A partial document is worse than none: it type-checks, it looks
+  // like a browser, and it throws on the first real call.
+  const byId = new Map<string, FakeElement>()
+  const body = make()
+  body.appendChild = (child: unknown): void => {
+    const el = child as FakeElement
+    if (el?.id) byId.set(el.id, el)
+  }
+  const doc = {
+    visibilityState: "visible",
+    body,
+    activeElement: null,
+    listeners: new Map<string, Listener[]>(),
+    createElement() {
+      const el = make()
+      created.push(el)
+      return el
+    },
+    getElementById(id: string) {
+      return byId.get(id) ?? null
+    },
+    addEventListener(type: string, fn: Listener) {
+      const list = doc.listeners.get(type) ?? []
+      list.push(fn)
+      doc.listeners.set(type, list)
+    },
+    removeEventListener(type: string, fn: Listener) {
+      doc.listeners.set(type, (doc.listeners.get(type) ?? []).filter((f) => f !== fn))
+    },
+  }
+  return { host: make(), doc, created, ctx }
+}
+
+/**
+ * Install the browser globals `mount.ts` needs, run `body`, and take them back
+ * off again — including when `body` throws, which is the case this rig exists to
+ * catch.
+ */
+export function withBrowser(
+  size: { w: number; h: number },
+  ctx: CanvasRenderingContext2D,
+  body: (rig: Rig) => void,
+): void {
+  const rig = harness(size, ctx)
+  const saved = new Map<string, PropertyDescriptor | undefined>()
+  const set = (key: string, value: unknown): void => {
+    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+  const frames: Array<(t: number) => void> = []
+  set("document", rig.doc)
+  set("devicePixelRatio", 2)
+  set("requestAnimationFrame", (fn: (t: number) => void) => {
+    frames.push(fn)
+    return frames.length
+  })
+  set("cancelAnimationFrame", () => {})
+  // No notch off a real device. Zeros are the honest answer, and are what the
+  // safe-area probe resolves to on a laptop too.
+  set("getComputedStyle", () => ({
+    paddingTop: "0px",
+    paddingRight: "0px",
+    paddingBottom: "0px",
+    paddingLeft: "0px",
+  }))
+  // The global listeners are RECORDED rather than swallowed. `mount.ts` puts its
+  // keyboard on `globalThis`, and the how-to-play panel is a DOM scrim — which
+  // stops the pointer and nothing else — so the only way to test that a key
+  // cannot reach the bout through the manual is to be able to fire one.
+  const globals = new Map<string, Listener[]>()
+  set("addEventListener", (type: string, fn: Listener) => {
+    globals.set(type, [...(globals.get(type) ?? []), fn])
+  })
+  set("removeEventListener", (type: string, fn: Listener) => {
+    globals.set(type, (globals.get(type) ?? []).filter((f) => f !== fn))
+  })
+
+  try {
+    body({ ...rig, frames, globals })
+  } finally {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+      else Reflect.deleteProperty(globalThis, key)
+    }
+  }
+}
+
+/** The canvas is the second element `mount` creates: the root div, then it. */
+export function canvasOf(created: FakeElement[]): FakeElement {
+  const el = created[1]
+  if (!el) throw new Error("mount did not create a canvas")
+  return el
+}
+
+/**
+ * Run `n` frames at 60Hz, draining the rAF queue each time.
+ *
+ * A frame that throws is *reported*, not swallowed. `mount.ts` re-arms its rAF on
+ * the first line of `frame()`, so a throwing loop keeps being scheduled forever
+ * and a rig that quietly caught the exception would be reproducing the exact
+ * blindness that let the blank ring ship.
+ */
+export function pump(frames: Array<(t: number) => void>, n: number, from = 0): number {
+  let t = from
+  for (let i = 0; i < n; i++) {
+    const next = frames.pop()
+    frames.length = 0
+    if (!next) break
+    t += 16.7
+    next(t)
+  }
+  return t
+}


### PR DESCRIPTION
> "'the grapple foundry' seems completely broken now. I do something that I think is correct 0+3=3 so I tap 1 and 2 and the screen basically goes blank but there are still sounds .. not completely blank but the wrestlers go away."

Reproduced through the real mount, at the founder's exact input, and it is not the trebuchet bug. FOUNDRY does not spawn an empty ring — it spawns a fine one and then throws while drawing it.

## The cause

A kick-out lays a scorch on the mat, and **only** a kick-out does. The scorch's glow is a radial gradient whose stops were `withAlpha(heatColor(heat), a)`.

`withAlpha` parsed hex by slicing the string. `heatColor` returned `rgb(...)`. So it stripped a `#` that was not there, read `"rg"` as base 16, and produced:

```
rgba(NaN,11,37,0.3)
```

Six call sites across `ring.ts`, `hud.ts`, `particles.ts` and `decals.ts` compose those two functions. Five assign the result to `fillStyle` or `strokeStyle`, which the canvas **silently ignores** — so five sites have been drawing in whatever colour was set before them and nothing failed anywhere, ever. The sixth hands the string to `CanvasGradient.addColorStop`, which is specified to **throw** a `SyntaxError`.

That call is inside `drawMat`, which runs *before* the two bodies, the referee, the near ropes and the entire HUD. `frame()` re-arms its `requestAnimationFrame` on its first line, so the loop stayed alive and every frame cleared the canvas, painted the crowd, the far posts and the mat, and died in the same place. The audio graph is not on the frame loop, so the hall kept roaring over a half-drawn ring — for the twelve seconds a scorch takes to cool, and then the next escape started it again.

```
Error: SyntaxError: addColorStop(0, "rgba(NaN,11,37,0.3)"): not a valid colour
    at Decals.draw       (src/render/decals.ts:109)
    at drawMat           (src/render/ring.ts:58)
    at draw              (src/mount.ts:552)
```

`mix` now returns hex, which keeps the composition closed, and both helpers parse `#rgb`, `#rrggbb`, `rgb()` and `rgba()`. A colour neither can read is reported once and comes back visible grey: a wrong colour is a bug to fix, a `NaN` in a gradient stop is a black screen in front of a child.

## What FOUNDRY needs from an item

An integer answer of **1 or more** — the answer *is* the number the bar has to reach, and a bar cannot hold nothing. `0 + 3` is fine: target 3, and `choosePlates` cannot split 3 across two plates that are both used, so it falls back to a 1 and a 2. That is the pair the founder tapped, and the escape works.

An item it cannot use did **not** spawn nothing. It kept the item's own prompt and quietly set the target to 12 — so a `3 − 3` on the board could only be escaped by building twelve. The child works out zero, is right, and loses the fall for it. Now the fallback replaces the sum along with the answer, and is still unreported.

## Two more defects in the same draw path

* The pinned player was rotated by `pose.wobble * 0.05`, and `wobble` is `performance.now() / 1000` — a monotonic clock. Level at the start of a session, upside down about a minute in. Now a bounded ±0.05 rad struggle.
* `mount.test.ts` built its 2D context out of a `Proxy` that answered every call with a stub and returned `{ addColorStop() {} }`. Nine hundred frames of a real bout could not fail for a colour, a radius or a transform, and did not, while every frame after the first kick-out was dying. `test/rig.ts` replaces it with a canvas that enforces the parts of the 2D spec that throw and records where marks land in screen space — "blank" is not a small number of draw calls, it is draw calls that stopped in one band of the screen.

## The manual

> "The instructions need to define the terms sometimes. I don't know what 'the fall' is on the grapple foundry for example."

A *fall*, a *pin*, a *kick out*, the *count*, being *waved off*, the *bar*, the *pedals*, the *belt* — all invented by this game, all used, none explained. Defined inline at first use in `manual.ts`, short sentences, concrete nouns, no metaphor, no glossary. Every word the game prints on a banner (KICK OUT, WAVED OFF, TOO MUCH, NO WAY OUT, THREE) is named there too — a child reading THREE in letters half a screen tall has been told off in a language nobody taught them. `manual.test.ts` asserts each term is defined **no later than the line that first uses it**, which is stricter than being defined somewhere; it caught three of my own headings using a word two lines before the definition.

## Verification

111 tests, five runs, clean. `tsc` clean, `build:pack` clean. Every fix deleted and confirmed to fail:

| fix removed | failure |
|---|---|
| `palette.ts` | `Error: SyntaxError: addColorStop(0, "rgba(NaN,11,37,0.3)"): not a valid colour` — the escape test, all three bout sizes, the reduced-motion branch, plus 8 colour cases (12 failures) |
| `ring.ts` wobble | `at 11s the player's head is at (163.0, 392.4), which is off from (157.5, 412.0) by more than half a unit` |
| `bout.ts` fallback | `the board kept a sum it cannot be escaped by` |
| `manual.ts` text | `the manual never mentions "belt"` · `"pin" is used but never explained` · `the game prints "KICK OUT" and the manual never mentions it` |

Nothing outside `dynawalla/games/foundry/` is touched. No shared code or host change was needed.

**Needs a device:** the fix is proven headlessly against real 2D-spec throw semantics, but the founder's screenshot came off an Android phone — worth one kick-out on hardware to confirm the ring stays up and the scorch glow now renders (it has never once been drawn, on any device, since the game shipped).

**Latent, not fixed, not mine:** `dynawalla/games/truedraw/src/render/palette.ts` has the same shape — hex-only `withAlpha`, `rgb()`-returning `mix`, and `addColorStop(0, mix(...))` in `scene.ts`. It is safe today only because it never composes the two: every `mix` call there takes hex constants. One `withAlpha(mix(...))` would blank that game the same way.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb