### PR TITLE
dynawalla: a mount spent 130 calls against a limit of 120, and horde's ladder test was a 1-in-50 coin toss

### DIFF
--- a/dynawalla/games/horde/src/game/curriculum.test.ts
+++ b/dynawalla/games/horde/src/game/curriculum.test.ts
@@ -79,9 +79,45 @@ function recordingHost(): {
  */
 const LONG_RUN = 50
 
+/**
+ * Why every bot below is handed a seed.
+ *
+ * `askUnit` draws a random step down the band for each question, and `Curriculum`
+ * defaults its `rng` to `Math.random` — which is right for the game and wrong for
+ * a test that reads one of those draws back. The all-right-answers bot asserted
+ * on its LAST draw, so one time in forty-nine that draw was the bottom of the
+ * six-rung spread and the whole suite went red: measured on pristine main,
+ * **4 failures in 400 runs, every one of them `topped out at 0.8898305084745763`**
+ * — which is the top of the ladder less exactly `SPREAD_RUNGS` rungs, i.e. the
+ * band doing precisely what it is designed to do. It red-lit the merge queue for
+ * unrelated PRs twice in one day.
+ *
+ * The production default stays `Math.random`, and that is not a dodge:
+ *
+ *   - It is not what makes a run reproducible. The QUESTIONS come from the host
+ *     (`items.next`), which this game cannot seed; the seedable one is
+ *     `stubHost.ts`, and `main.ts` already passes it a fixed seed. All this rng
+ *     picks is how far under the earned edge one question is drawn from.
+ *   - Everything else in DEEPSWARM that is random is unseeded too — `game.ts`
+ *     derives its own generator from `Date.now()`, and `loadout.ts`,
+ *     `ui/shuffle.ts` and `core/audio.ts` call `Math.random` directly. A run
+ *     reproducible from a seed is a real feature and it is a run-seed threaded
+ *     through all of them plus a host that replays, not one default in this file.
+ *   - A fixed default would make every child's band descend in the same order in
+ *     every run, forever, which is worse than the thing it fixes.
+ *
+ * So the seed belongs to the bot, and the assertion that read one random draw is
+ * replaced below by the two claims that draw was standing in for.
+ */
+const seedFor = (name: string): (() => number) => {
+  let h = 0x811c9dc5
+  for (let i = 0; i < name.length; i++) h = Math.imul(h ^ name.charCodeAt(i), 0x01000193) >>> 0
+  return seeded(h)
+}
+
 test("a bot that answers everything WRONG never climbs past the first rung", () => {
   const { host, asks } = recordingHost()
-  const c = new Curriculum()
+  const c = new Curriculum(seedFor("wrong"))
 
   for (let i = 0; i < LONG_RUN; i++) {
     const q = c.ask(host)
@@ -105,7 +141,7 @@ test("a bot that answers everything WRONG never climbs past the first rung", () 
 
 test("a bot that never answers at all never climbs either", () => {
   const { host, asks } = recordingHost()
-  const c = new Curriculum()
+  const c = new Curriculum(seedFor("silent"))
 
   for (let i = 0; i < LONG_RUN; i++) {
     c.ask(host)
@@ -119,7 +155,7 @@ test("a bot that never answers at all never climbs either", () => {
 
 test("a bot that answers everything RIGHT climbs, and reaches the top", () => {
   const { host, asks } = recordingHost()
-  const c = new Curriculum()
+  const c = new Curriculum(seedFor("right"))
 
   for (let i = 0; i < LONG_RUN; i++) {
     const q = c.ask(host)
@@ -132,9 +168,36 @@ test("a bot that answers everything RIGHT climbs, and reaches the top", () => {
     asks[asks.length - 1]! > asks[0]!,
     "the ladder has to actually move for a child who is getting them right",
   )
+
+  // What "reaches the top" means, in the two parts the old single-sample
+  // assertion conflated. The band is `SPREAD_RUNGS` wide by design, so no ONE
+  // draw can be the top — but every draw is inside the band, and the run does
+  // reach the top of it.
+  const edge = c.edgeUnit()
+  // Said in absolute terms as well as against the game's own edge, so a ladder
+  // that quietly stopped climbing at the middle cannot satisfy the two claims
+  // below by moving the goalposts with itself.
   assert.ok(
-    (asks[asks.length - 1] as number) > 0.9,
-    `a run that answered fifty questions right topped out at ${asks[asks.length - 1]}`,
+    edge > 1 - 1 / LADDER_SPAN,
+    `a run that has topped the ladder out should be drawing from its top rung; the edge is ${edge}`,
+  )
+  const bandFloor = edge - SPREAD_RUNGS / LADDER_SPAN
+  for (const [i, ask] of asks.entries()) {
+    // From the point the ladder is topped out — solved 18 earns rung 10 — every
+    // question comes from the top band and none from below it. True of every
+    // seed: this is the width the band states, not a tolerance.
+    if (i < 2 * (MAX_DIFFICULTY - 1) + 2) continue
+    assert.ok(
+      ask >= bandFloor - 1e-12,
+      `question ${i + 1} of a run that has answered everything right came from ${ask}, below the ` +
+        `stated ${SPREAD_RUNGS}-rung band under the top of the ladder (${bandFloor})`,
+    )
+  }
+  assert.equal(
+    Math.max(...asks),
+    edge,
+    `a run that answered fifty questions right never once saw the top of the ladder (${edge}); ` +
+      `the hardest question it was asked came from ${Math.max(...asks)}`,
   )
 })
 
@@ -152,7 +215,7 @@ test("the ladder tracks right answers alone — the clock is not an input", () =
 
 test("a timeout reports NOTHING to the host", () => {
   const { host, reports } = recordingHost()
-  const c = new Curriculum()
+  const c = new Curriculum(seedFor("timeout"))
 
   const q = c.ask(host)
   c.expired()
@@ -173,7 +236,7 @@ test("a timeout reports NOTHING to the host", () => {
 
 test("an answer — right or wrong — reports the exact payload the host expects", () => {
   const { host, reports } = recordingHost()
-  const c = new Curriculum()
+  const c = new Curriculum(seedFor("payload"))
 
   const a = c.ask(host)
   c.answered(host, a, a.answer, true, 1234.6)
@@ -216,7 +279,7 @@ test("the rift asks below what the run has earned, never above", () => {
 
 test("the run panel counts questions the child ANSWERED, not questions it served", () => {
   const { host } = recordingHost()
-  const c = new Curriculum()
+  const c = new Curriculum(seedFor("panel"))
 
   for (let i = 0; i < 5; i++) {
     const q = c.ask(host)

--- a/dynawalla/games/horde/src/game/curriculum.test.ts
+++ b/dynawalla/games/horde/src/game/curriculum.test.ts
@@ -107,17 +107,14 @@ const LONG_RUN = 50
  *     every run, forever, which is worse than the thing it fixes.
  *
  * So the seed belongs to the bot, and the assertion that read one random draw is
- * replaced below by the two claims that draw was standing in for.
+ * replaced below by the two claims that draw was standing in for. Every bot that
+ * draws gets its own `seeded(n)`, the convention the measurement tests further
+ * down already use — one generator per bot, so two of them cannot share a stream.
  */
-const seedFor = (name: string): (() => number) => {
-  let h = 0x811c9dc5
-  for (let i = 0; i < name.length; i++) h = Math.imul(h ^ name.charCodeAt(i), 0x01000193) >>> 0
-  return seeded(h)
-}
 
 test("a bot that answers everything WRONG never climbs past the first rung", () => {
   const { host, asks } = recordingHost()
-  const c = new Curriculum(seedFor("wrong"))
+  const c = new Curriculum(seeded(0x1a))
 
   for (let i = 0; i < LONG_RUN; i++) {
     const q = c.ask(host)
@@ -141,7 +138,7 @@ test("a bot that answers everything WRONG never climbs past the first rung", () 
 
 test("a bot that never answers at all never climbs either", () => {
   const { host, asks } = recordingHost()
-  const c = new Curriculum(seedFor("silent"))
+  const c = new Curriculum(seeded(0x2b))
 
   for (let i = 0; i < LONG_RUN; i++) {
     c.ask(host)
@@ -155,7 +152,7 @@ test("a bot that never answers at all never climbs either", () => {
 
 test("a bot that answers everything RIGHT climbs, and reaches the top", () => {
   const { host, asks } = recordingHost()
-  const c = new Curriculum(seedFor("right"))
+  const c = new Curriculum(seeded(0x3c))
 
   for (let i = 0; i < LONG_RUN; i++) {
     const q = c.ask(host)
@@ -215,7 +212,7 @@ test("the ladder tracks right answers alone — the clock is not an input", () =
 
 test("a timeout reports NOTHING to the host", () => {
   const { host, reports } = recordingHost()
-  const c = new Curriculum(seedFor("timeout"))
+  const c = new Curriculum(seeded(0x4d))
 
   const q = c.ask(host)
   c.expired()
@@ -236,7 +233,7 @@ test("a timeout reports NOTHING to the host", () => {
 
 test("an answer — right or wrong — reports the exact payload the host expects", () => {
   const { host, reports } = recordingHost()
-  const c = new Curriculum(seedFor("payload"))
+  const c = new Curriculum(seeded(0x5e))
 
   const a = c.ask(host)
   c.answered(host, a, a.answer, true, 1234.6)
@@ -279,7 +276,7 @@ test("the rift asks below what the run has earned, never above", () => {
 
 test("the run panel counts questions the child ANSWERED, not questions it served", () => {
   const { host } = recordingHost()
-  const c = new Curriculum(seedFor("panel"))
+  const c = new Curriculum(seeded(0x6f))
 
   for (let i = 0; i < 5; i++) {
     const q = c.ask(host)

--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -41,10 +41,13 @@ import {
  * is no longer a neutral fake: it models a wire with infinite bandwidth, and
  * every test below that serves two dozen questions would be claiming a child
  * answered them all inside the same millisecond. Fifteen milliseconds a call is
- * a plausible `postMessage` round trip through the host's generator, and it puts
- * the fake at 66 calls a second — under the prefetch share, so the pacing never
- * binds and every assertion in this file means exactly what it meant before it
- * existed.
+ * a plausible `postMessage` round trip through the host's generator, and every
+ * method the adapter charges spends one — see `tick`, which is separate from
+ * `record` for exactly that reason. That puts the fake at 66 calls a second:
+ * measured peak 67 in any virtual second against a gate of 84, so the pacing
+ * never binds and every assertion in this file means what it meant before it
+ * existed. The two `[measured]` lines this file prints are byte-identical to the
+ * ones it printed on main, which is the check that says so.
  *
  * A test that wants the *worst* case says so, by passing a frozen clock: see
  * "an attach and a first question stay inside the host's own rate limit".
@@ -123,10 +126,25 @@ function fakeHost(
   const skillAt = options.skillAt ?? ((index: number) => `arith.rung.${String(Math.floor(index / 4))}`)
   const asks: Ask[] = []
   const calls: string[] = []
+  /**
+   * A round trip's worth of virtual time.
+   *
+   * Separate from `record` because three of the methods the adapter CHARGES —
+   * `haptic`, `progress` and `transition` — are deliberately not in `calls`,
+   * which several tests count. They still cross the wire and still cost time, and
+   * a fake that charged them without spending any clock ran at 89 charged calls a
+   * virtual second: over the prefetch gate, which stalled the top-up half way
+   * through `skillsServed(24)` and quietly made the budget, rather than the pool
+   * logic, the thing that test was measuring.
+   */
+  const tick = (): void => {
+    clock += ROUND_TRIP_MS
+  }
+
   /** One call across the wire: recorded, and the clock moves by a round trip. */
   const record = (method: string): void => {
     calls.push(method)
-    clock += ROUND_TRIP_MS
+    tick()
   }
   const answers: { itemId: string; response: string }[] = []
   const skips: string[] = []
@@ -219,7 +237,10 @@ function fakeHost(
         return Promise.resolve(canonicals.get(itemId) ?? "")
       },
       learnerSummary: () => Promise.resolve({ skills: [] }),
-      haptic: () => Promise.resolve(),
+      haptic: () => {
+        tick()
+        return Promise.resolve()
+      },
       sound: () => Promise.resolve(),
       milestone: () => Promise.resolve(),
       storage: {
@@ -228,9 +249,15 @@ function fakeHost(
         remove: () => Promise.resolve(),
         keys: () => Promise.resolve([]),
       },
-      progress: () => Promise.resolve(),
+      progress: () => {
+        tick()
+        return Promise.resolve()
+      },
       end: () => Promise.resolve(),
-      transition: () => Promise.resolve(),
+      transition: () => {
+        tick()
+        return Promise.resolve()
+      },
       on: () => () => {},
       dispose: () => {},
     },
@@ -1260,7 +1287,13 @@ test("honouring the declaration does not spend the host's request budget", async
  * of all 27 packs.
  */
 
-/** Every call a mount makes, counted — including the ones `fakeHost` ignores. */
+/**
+ * Every call a mount makes, counted — including the ones `fakeHost` ignores.
+ *
+ * `{...client}` is safe for the fake, which is a plain object; it would drop
+ * getters and prototype methods from a real `connect()` client, and there is no
+ * reason to point one at this.
+ */
 function countingClient(client: HostClient): { client: HostClient; count: () => number } {
   let n = 0
   const tick = <T,>(run: () => T): T => {
@@ -1290,35 +1323,48 @@ test("an attach and a first question stay inside the host's own rate limit", asy
   // all of it to land inside one window.
   const spend = async (skills?: readonly string[]) => {
     const fake = fakeHost({ skillAt })
-    fake.standing = 12
+    // Rung 5 for the pinned arm, because that is the ONE band in this ladder
+    // TREBUCHET cannot use (`dw.mul.scale.times-power-of-ten`) and standing
+    // anywhere else means measuring an unpinned pack while calling it pinned.
+    fake.standing = skills === undefined ? 12 : 5
     const counted = countingClient(fake.client)
     const mounted = attachOnClock(counted.client, {
       now: () => 0,
       ...(skills === undefined ? {} : { skills }),
     })
-    await mounted.warm()
-    // Everything a child's first question costs: the question, the answer they
-    // give, the haptic under it, and the top-up behind all three.
-    const first = mounted.host.next()
-    mounted.host.haptic("light")
-    mounted.host.report({ questionId: first.id, correct: true, ms: 1200, answered: first.answer })
-    await settle()
+    await withConsole(async () => {
+      await mounted.warm()
+      // Everything a child's first question costs: the question, the answer they
+      // give, the haptic under it, and the top-up behind all three.
+      const first = mounted.host.next()
+      mounted.host.haptic("light")
+      mounted.host.report({ questionId: first.id, correct: true, ms: 1200, answered: first.answer })
+      await settle()
+    })
     mounted.dispose()
-    return counted.count()
+    return { calls: counted.count(), pinnedAsks: fake.asks.filter((ask) => ask.skillId !== undefined).length }
   }
 
   const plain = await spend()
   const pinned = await spend(TREBUCHET)
 
+  // The arms have to be the two things they claim to be, or this test is one
+  // measurement written down twice.
+  assert.equal(plain.pinnedAsks, 0, "the unrestricted arm named a skill")
   assert.ok(
-    plain <= MAX_REQUESTS_PER_SECOND,
-    `an attach and a first question spent ${String(plain)} calls in one sliding second; the host ` +
+    pinned.pinnedAsks > 0,
+    "the pinned arm never named a skill, so it measured an unrestricted mount",
+  )
+
+  assert.ok(
+    plain.calls <= MAX_REQUESTS_PER_SECOND,
+    `an attach and a first question spent ${String(plain.calls)} calls in one sliding second; the host ` +
       `refuses everything past ${String(MAX_REQUESTS_PER_SECOND)}, so the pool comes up short and ` +
       `the child waits for a question that was rate-limited`,
   )
   assert.ok(
-    pinned <= MAX_REQUESTS_PER_SECOND,
-    `the same mount for a pack whose declaration has it pinned spent ${String(pinned)} calls`,
+    pinned.calls <= MAX_REQUESTS_PER_SECOND,
+    `the same mount for a pack whose declaration has it pinned spent ${String(pinned.calls)} calls`,
   )
 })
 
@@ -1327,26 +1373,49 @@ test("and the pool is still stocked when the child arrives", async () => {
   // budget kept by never stocking anything is a blank chip in a child's hand.
   // POOL_FLOOR questions back to back, on the same frozen clock, out of a pool
   // that was never allowed a second call.
-  const fake = fakeHost()
-  const mounted = attachOnClock(fake.client, { now: () => 0 })
-  const said = await withConsole(async () => {
-    await mounted.warm()
-    await settle()
-    for (let i = 0; i < POOL_FLOOR; i++) {
-      const question = mounted.host.next()
-      assert.notEqual(
-        question.id,
-        "",
-        `question ${String(i + 1)} of ${String(POOL_FLOOR)} came out of a dry pool`,
-      )
-    }
-  })
-  mounted.dispose()
-  assert.deepEqual(
-    said.filter((line) => line.includes("ran dry")),
-    [],
-    "the pool ran dry inside the first POOL_FLOOR questions",
-  )
+  //
+  // Both arms, because `warm` is now allowed to stop early and a PINNED pack pays
+  // three calls a question rather than two — so what its mount comes back with is
+  // a thing this file has to state rather than leave to the arithmetic. The
+  // promise is the same for both and it is the one `warm` always made: POOL_FLOOR
+  // questions a child can play out of, before the first frame, inside one window.
+  // Measured, frozen clock: 43 drainable questions unrestricted and 37 pinned.
+  const stocked = async (skills?: readonly string[]) => {
+    const fake = fakeHost({ skillAt })
+    // Rung 5 is the band TREBUCHET cannot use; see the test above.
+    fake.standing = skills === undefined ? 12 : 5
+    const mounted = attachOnClock(fake.client, {
+      now: () => 0,
+      ...(skills === undefined ? {} : { skills }),
+    })
+    const want = POOL_FLOOR
+    const said = await withConsole(async () => {
+      await mounted.warm()
+      await settle()
+      for (let i = 0; i < want; i++) {
+        const question = mounted.host.next()
+        assert.notEqual(
+          question.id,
+          "",
+          `question ${String(i + 1)} of ${String(want)} came out of a dry pool` +
+            `${skills === undefined ? "" : " (pinned pack)"}`,
+        )
+      }
+    })
+    mounted.dispose()
+    assert.deepEqual(
+      said.filter((line) => line.includes("ran dry")),
+      [],
+      `the pool ran dry inside the first ${String(want)} questions`,
+    )
+    assert.equal(
+      fake.asks.some((ask) => ask.skillId !== undefined),
+      skills !== undefined,
+      "the pinned arm has to be pinned and the plain arm has to not be",
+    )
+  }
+  await stocked()
+  await stocked(TREBUCHET)
 })
 
 test("the prefetch resumes once the window has drained", async () => {
@@ -1359,6 +1428,15 @@ test("the prefetch resumes once the window has drained", async () => {
   await mounted.warm()
   await settle()
   const atMount = fake.asks.length
+  // The premise: a full pool costs more than the share, so a mount inside one
+  // window cannot have reached POOL_TARGET. Said out loud, because lowering
+  // POOL_TARGET below the share would make the assertion below meaningless
+  // rather than false.
+  assert.ok(
+    2 * POOL_TARGET > PREFETCH_BUDGET,
+    `a full pool costs ${String(2 * POOL_TARGET)} calls and the prefetch share is ` +
+      `${String(PREFETCH_BUDGET)}; this test cannot say anything while it fits`,
+  )
   assert.ok(
     atMount < POOL_TARGET,
     `the mount stocked ${String(atMount)} questions inside one window, which is more than the ` +

--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -16,16 +16,47 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 
 import type { Capability, HostClient, Item, ItemRequest, Judgement, Settings } from "../../sdk/src/index.ts"
+import { MAX_REQUESTS_PER_SECOND } from "../../sdk/src/index.ts"
+import type { GameHostOptions, MountedHost } from "./index.ts"
 import {
   attachDeclared,
-  attachGameHost,
+  attachGameHost as attachOnClock,
   declaredSkills,
   domainOf,
   packRootUrl,
   toUnit,
+  ACQUIRE_MAX_CALLS,
   FLUSH_KEEP,
   POOL_FLOOR,
+  POOL_TARGET,
+  PREFETCH_BUDGET,
+  RATE_WINDOW_MS,
 } from "./index.ts"
+
+/**
+ * How long a fake round trip takes.
+ *
+ * The adapter now measures what it spends of the host's per-second request
+ * budget (`PREFETCH_BUDGET`), so a fake host that answers in *zero* elapsed time
+ * is no longer a neutral fake: it models a wire with infinite bandwidth, and
+ * every test below that serves two dozen questions would be claiming a child
+ * answered them all inside the same millisecond. Fifteen milliseconds a call is
+ * a plausible `postMessage` round trip through the host's generator, and it puts
+ * the fake at 66 calls a second — under the prefetch share, so the pacing never
+ * binds and every assertion in this file means exactly what it meant before it
+ * existed.
+ *
+ * A test that wants the *worst* case says so, by passing a frozen clock: see
+ * "an attach and a first question stay inside the host's own rate limit".
+ */
+const ROUND_TRIP_MS = 15
+
+/** Virtual milliseconds. Monotonic across the file; only ever moves forward. */
+let clock = 0
+
+/** `attachGameHost` on that clock, unless a test brings its own. */
+const attachGameHost = (client: HostClient, options: GameHostOptions = {}): MountedHost =>
+  attachOnClock(client, { now: () => clock, ...options })
 
 /** Rungs on the fake host's ladder. Enough that 1/16 is a visible step. */
 const RUNGS = 16
@@ -92,6 +123,11 @@ function fakeHost(
   const skillAt = options.skillAt ?? ((index: number) => `arith.rung.${String(Math.floor(index / 4))}`)
   const asks: Ask[] = []
   const calls: string[] = []
+  /** One call across the wire: recorded, and the clock moves by a round trip. */
+  const record = (method: string): void => {
+    calls.push(method)
+    clock += ROUND_TRIP_MS
+  }
   const answers: { itemId: string; response: string }[] = []
   const skips: string[] = []
   const canonicals = new Map<string, string>()
@@ -115,7 +151,7 @@ function fakeHost(
 
       nextItem: (ask: Ask = {}) => {
         asks.push(ask)
-        calls.push("items.next")
+        record("items.next")
         const span = Math.max(1, rungs - 1)
         const cap = ask.maxDifficulty === undefined ? 1 : ask.maxDifficulty
         const wanted = ask.difficulty === undefined ? fake.standing / span : ask.difficulty
@@ -161,7 +197,7 @@ function fakeHost(
       },
 
       answer: (input) => {
-        calls.push("items.answer")
+        record("items.answer")
         answers.push({ itemId: input.itemId, response: input.response })
         if (fake.answerFails) return Promise.reject(new Error("the host is gone"))
         return Promise.resolve({
@@ -171,7 +207,7 @@ function fakeHost(
         } satisfies Judgement)
       },
       skip: (itemId) => {
-        calls.push("items.skip")
+        record("items.skip")
         skips.push(itemId)
         // What an older host — one shipped before `items.skip` existed — would
         // do with the call, so the adapter is held to surviving it.
@@ -179,7 +215,7 @@ function fakeHost(
         return Promise.resolve()
       },
       reveal: (itemId) => {
-        calls.push("items.reveal")
+        record("items.reveal")
         return Promise.resolve(canonicals.get(itemId) ?? "")
       },
       learnerSummary: () => Promise.resolve({ skills: [] }),
@@ -1207,6 +1243,152 @@ test("honouring the declaration does not spend the host's request budget", async
     restricted.session <= baseline.session * 1.25,
     `24 questions cost ${String(restricted.session)} calls with a declaration against ` +
       `${String(baseline.session)} without — ${(restricted.session / baseline.session).toFixed(2)}×`,
+  )
+})
+
+/* ────────────────────── the budget in absolute terms ────────────────────────
+ *
+ * The test above compares a restricted mount to an unrestricted one and never
+ * asks what either of them costs, which is how the unrestricted one went on
+ * breaching the limit in every pack for as long as it did. `warm()` awaits
+ * POOL_FLOOR questions and the fill behind it goes on to POOL_TARGET, at two
+ * calls each: 128 calls before the first question, against a hundred and twenty
+ * in a sliding second. Measured on the code before this, with a frozen clock:
+ * 130 calls, 10 of them refused with `rate_limited`; 150 and 30 for a pack whose
+ * declaration has it pinned. What a child got for that was a pool that came up
+ * short and a `fill` that died on the rejection, and it happened at every mount
+ * of all 27 packs.
+ */
+
+/** Every call a mount makes, counted — including the ones `fakeHost` ignores. */
+function countingClient(client: HostClient): { client: HostClient; count: () => number } {
+  let n = 0
+  const tick = <T,>(run: () => T): T => {
+    n += 1
+    return run()
+  }
+  const counted: HostClient = {
+    ...client,
+    nextItem: (ask) => tick(() => client.nextItem(ask)),
+    reveal: (itemId) => tick(() => client.reveal(itemId)),
+    skip: (itemId) => tick(() => client.skip(itemId)),
+    answer: (input) => tick(() => client.answer(input)),
+    progress: (fraction) => tick(() => client.progress(fraction)),
+    haptic: (cue) => tick(() => client.haptic(cue)),
+    sound: (cue) => tick(() => client.sound(cue)),
+    milestone: (name) => tick(() => client.milestone(name)),
+    transition: (kind, label) => tick(() => client.transition(kind, label)),
+    learnerSummary: () => tick(() => client.learnerSummary()),
+  }
+  return { client: counted, count: () => n }
+}
+
+test("an attach and a first question stay inside the host's own rate limit", async () => {
+  // The clock is FROZEN, which is the worst case and also the one the app is:
+  // `bridge.ts` counts every method in one sliding second and dispatches on the
+  // same thread that generates the question, so nothing here has to be slow for
+  // all of it to land inside one window.
+  const spend = async (skills?: readonly string[]) => {
+    const fake = fakeHost({ skillAt })
+    fake.standing = 12
+    const counted = countingClient(fake.client)
+    const mounted = attachOnClock(counted.client, {
+      now: () => 0,
+      ...(skills === undefined ? {} : { skills }),
+    })
+    await mounted.warm()
+    // Everything a child's first question costs: the question, the answer they
+    // give, the haptic under it, and the top-up behind all three.
+    const first = mounted.host.next()
+    mounted.host.haptic("light")
+    mounted.host.report({ questionId: first.id, correct: true, ms: 1200, answered: first.answer })
+    await settle()
+    mounted.dispose()
+    return counted.count()
+  }
+
+  const plain = await spend()
+  const pinned = await spend(TREBUCHET)
+
+  assert.ok(
+    plain <= MAX_REQUESTS_PER_SECOND,
+    `an attach and a first question spent ${String(plain)} calls in one sliding second; the host ` +
+      `refuses everything past ${String(MAX_REQUESTS_PER_SECOND)}, so the pool comes up short and ` +
+      `the child waits for a question that was rate-limited`,
+  )
+  assert.ok(
+    pinned <= MAX_REQUESTS_PER_SECOND,
+    `the same mount for a pack whose declaration has it pinned spent ${String(pinned)} calls`,
+  )
+})
+
+test("and the pool is still stocked when the child arrives", async () => {
+  // The other half, and the reason this is not fixed by prefetching less: a
+  // budget kept by never stocking anything is a blank chip in a child's hand.
+  // POOL_FLOOR questions back to back, on the same frozen clock, out of a pool
+  // that was never allowed a second call.
+  const fake = fakeHost()
+  const mounted = attachOnClock(fake.client, { now: () => 0 })
+  const said = await withConsole(async () => {
+    await mounted.warm()
+    await settle()
+    for (let i = 0; i < POOL_FLOOR; i++) {
+      const question = mounted.host.next()
+      assert.notEqual(
+        question.id,
+        "",
+        `question ${String(i + 1)} of ${String(POOL_FLOOR)} came out of a dry pool`,
+      )
+    }
+  })
+  mounted.dispose()
+  assert.deepEqual(
+    said.filter((line) => line.includes("ran dry")),
+    [],
+    "the pool ran dry inside the first POOL_FLOOR questions",
+  )
+})
+
+test("the prefetch resumes once the window has drained", async () => {
+  // Stopping is only safe if it starts again. `fill` is called on every hand-out,
+  // so the top-up resumes at the next question the game asks for — with the
+  // window a second emptier, and without a timer anywhere.
+  const fake = fakeHost()
+  let at = 0
+  const mounted = attachOnClock(fake.client, { now: () => at })
+  await mounted.warm()
+  await settle()
+  const atMount = fake.asks.length
+  assert.ok(
+    atMount < POOL_TARGET,
+    `the mount stocked ${String(atMount)} questions inside one window, which is more than the ` +
+      `budget allows it to`,
+  )
+
+  at += RATE_WINDOW_MS + 1
+  mounted.host.next()
+  await settle()
+  assert.ok(
+    fake.asks.length > POOL_TARGET,
+    `the pool stopped at ${String(fake.asks.length)} questions and never came back for the rest ` +
+      `of POOL_TARGET (${String(POOL_TARGET)}) — a prefetch that stops has to start again`,
+  )
+  mounted.dispose()
+})
+
+test("the share leaves the host room, and warm fits inside the share", () => {
+  // Two facts about the constants, so that raising one of them fails here rather
+  // than at a child's mount.
+  assert.ok(
+    PREFETCH_BUDGET < MAX_REQUESTS_PER_SECOND,
+    `the prefetch may spend ${String(PREFETCH_BUDGET)} of the host's ` +
+      `${String(MAX_REQUESTS_PER_SECOND)}, which leaves nothing for the answer a child just gave`,
+  )
+  assert.ok(
+    2 * POOL_FLOOR + ACQUIRE_MAX_CALLS <= PREFETCH_BUDGET,
+    `warm() stocks POOL_FLOOR (${String(POOL_FLOOR)}) questions at two calls each before the first ` +
+      `frame, which is ${String(2 * POOL_FLOOR)} of the ${String(PREFETCH_BUDGET)} the prefetch ` +
+      `has — so the pool a child starts with would be capped by the budget rather than by the floor`,
   )
 })
 

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -152,7 +152,7 @@ import type {
 } from "../../sdk/src/index.ts"
 import { setHostInsets } from "../game-chrome/insets.ts"
 import { setHostSound } from "../game-audio/index.ts"
-import { connect } from "../../sdk/src/index.ts"
+import { MAX_REQUESTS_PER_SECOND, connect } from "../../sdk/src/index.ts"
 
 /** The shape both games declare locally. Kept structurally identical. */
 export type Question = {
@@ -387,12 +387,57 @@ const HAPTIC: Record<HapticKind, "tick" | "seat" | "settle" | "refuse"> = {
  * How many questions to keep ahead of the game.
  *
  * FUSE pumps ten at a time when a level turns over, so the pool has to absorb a
- * burst without the loop ever seeing an empty one. Two round trips per question
- * (`items.next` then `items.reveal`) at 120 requests per second is far more
- * headroom than 64 items need.
+ * burst without the loop ever seeing an empty one.
+ *
+ * The arithmetic that used to be written here — "two round trips per question at
+ * 120 requests per second is far more headroom than 64 items need" — was the
+ * wrong way round, and it was wrong at every mount of every pack. A question
+ * costs two calls, sixty-four of them cost a hundred and twenty-eight, and the
+ * limit is a hundred and twenty in a SLIDING second, not a hundred and twenty
+ * per question. Measured on the shipped code against a fake host that answers
+ * immediately: **130 calls between `attach` and the first question, 10 of them
+ * refused with `rate_limited`** — and 150 with 30 refused for a pack whose
+ * declaration has it pinned, which is the shape the note on `parked` was
+ * already worried about. See `PREFETCH_BUDGET` for what now paces it.
  */
 export const POOL_TARGET = 64
 export const POOL_FLOOR = 32
+
+/**
+ * The share of the host's request budget the PREFETCH is allowed to spend.
+ *
+ * `bridge.ts` allows `MAX_REQUESTS_PER_SECOND` calls from a pack in a sliding
+ * second and refuses the rest with `rate_limited` — every method, prefetch and
+ * answers and haptics alike, counted in one window. Stocking the pool is the
+ * only thing in this module that ever asks for anything in bulk, and it is also
+ * the only thing here that is not urgent: a prefetch is by definition a question
+ * nobody is waiting for. So it gets a share rather than the whole budget, and
+ * the rest is left for the calls a child IS waiting on — the answer they just
+ * gave, the haptic under their thumb.
+ *
+ * Three quarters. Thirty calls a second is a question answered every second
+ * with two dozen haptics under it and still room, and prefetch resumes the
+ * instant the window drains, so the reserve costs nothing when nobody is using
+ * it.
+ *
+ * It is expressed against the SDK's own constant so the two cannot drift: the
+ * pack does not get to have an opinion about what the host allows.
+ */
+export const PREFETCH_BUDGET = Math.floor(MAX_REQUESTS_PER_SECOND * 0.75)
+
+/**
+ * The most calls one `acquire()` can spend.
+ *
+ * Worst case is the pinned path that falls through: a pin, the skip that closes
+ * it, the host's own arrival, the swap, the skip that closes THAT, and a reveal.
+ * The budget is checked with this much room left, because an `acquire` abandoned
+ * half way through has already taken an item out of the host and would leave it
+ * open.
+ */
+export const ACQUIRE_MAX_CALLS = 6
+
+/** The window the host's limit is measured over. Its rule, not ours. */
+export const RATE_WINDOW_MS = 1000
 
 /** A pack that has not seen a question in this long has been left running. */
 const IDLE_MS = 5 * 60 * 1000
@@ -532,6 +577,14 @@ export type GameHostOptions = {
    * behaves exactly as this module did before the field existed.
    */
   readonly skills?: readonly string[]
+  /**
+   * The clock the request budget and the flush cooldown are measured on.
+   *
+   * Injectable for the same reason `bridge.ts` injects one: the host's limit is
+   * a sliding SECOND, and a test that has to sleep through one to prove the
+   * prefetch resumes is a test nobody runs. Defaults to `Date.now`.
+   */
+  readonly now?: () => number
 }
 
 export type MountedHost = {
@@ -729,6 +782,78 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   const domain = options.domain ?? "arith"
   const autoFlush = options.autoFlush ?? true
   const granted = new Set<Capability>(client.granted)
+  const now = options.now ?? ((): number => Date.now())
+
+  // ── What this pack has spent of the host's request budget ──────────────────
+  //
+  // The same sliding window `bridge.ts` enforces, kept on this side of the wire
+  // so the prefetch can stay inside it instead of discovering the limit by being
+  // refused. Every call this module makes is charged here — not only the
+  // prefetch — because the host counts them all in one window, and a prefetch
+  // that ignored the answers and haptics a game is producing would be pacing
+  // itself against a budget that is not the one it is spending.
+  //
+  // What is NOT here is any throttle on the calls a child is waiting for. An
+  // answer, a skip and a haptic are sent the moment the game says so, and the
+  // prefetch yields to them. Nor are the calls a game makes on `mounted.client`
+  // itself — forge and merge-idle read a save at mount — which is another reason
+  // the prefetch takes a share and not the lot: the reserve is what covers the
+  // traffic this module cannot see.
+
+  /** When each call this module made was made, oldest first. */
+  const spend: number[] = []
+
+  /** Calls inside the current window, with the expired ones dropped. */
+  const spent = (): number => {
+    const cutoff = now() - RATE_WINDOW_MS
+    while (spend.length > 0 && (spend[0] ?? 0) <= cutoff) spend.shift()
+    return spend.length
+  }
+
+  /** Whether the prefetch may start one more `acquire` without going over. */
+  const affordsPrefetch = (): boolean => spent() + ACQUIRE_MAX_CALLS <= PREFETCH_BUDGET
+
+  /**
+   * The client, with every call charged against the window above.
+   *
+   * A wrapper rather than a `charge()` at each of the nine call sites, so a call
+   * added later cannot quietly escape the budget: nothing below this line
+   * touches `client` except `settings`, `on` and `dispose`, none of which cross
+   * the wire.
+   */
+  const metered: Pick<
+    HostClient,
+    "nextItem" | "reveal" | "skip" | "answer" | "progress" | "haptic" | "transition"
+  > = {
+    nextItem: (ask) => {
+      spend.push(now())
+      return client.nextItem(ask)
+    },
+    reveal: (itemId) => {
+      spend.push(now())
+      return client.reveal(itemId)
+    },
+    skip: (itemId) => {
+      spend.push(now())
+      return client.skip(itemId)
+    },
+    answer: (input) => {
+      spend.push(now())
+      return client.answer(input)
+    },
+    progress: (fraction) => {
+      spend.push(now())
+      return client.progress(fraction)
+    },
+    haptic: (cue) => {
+      spend.push(now())
+      return client.haptic(cue)
+    },
+    transition: (kind, label) => {
+      spend.push(now())
+      return client.transition(kind, label)
+    },
+  }
 
   const pool: Pooled[] = []
   /** Questions this module has handed to the game and not yet reported on. */
@@ -738,7 +863,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   let filling = false
   let disposed = false
   let lastServed: Question | null = null
-  let lastAsk = Date.now()
+  let lastAsk = now()
   let reported = 0
   /** Whether a failed `items.skip` has already been said out loud. */
   let skipFailed = false
@@ -903,7 +1028,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
    * Failure is the older-host case and is already said out loud by `skip`.
    */
   const close = (itemId: string) => {
-    void client.skip(itemId).catch(() => {
+    void metered.skip(itemId).catch(() => {
       // Deliberately quiet HERE: `host.skip` owns that message, says it once,
       // and states the consequence. Two copies of it is one too many.
     })
@@ -952,7 +1077,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
 
   /** Reveal the answer and build the question, or `null` if it cannot be placed. */
   const draw = async (item: Item): Promise<Pooled | null> => {
-    const canonical = canReveal ? await client.reveal(item.id) : ""
+    const canonical = canReveal ? await metered.reveal(item.id) : ""
     if (canonical === "") {
       // No reveal grant means no placeable answer. Both games need one,
       // so this is loud rather than a silently duller game.
@@ -995,7 +1120,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       const pin = rescueSkill()
       if (pin !== null) {
         sincePeek += 1
-        const pinned = await client.nextItem(askShape(pin))
+        const pinned = await metered.nextItem(askShape(pin))
         if (pinned !== null) {
           record(pin, pinned)
           if (admits(pinned.skillId) && !overCeiling(pinned)) return await draw(pinned)
@@ -1009,7 +1134,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     }
     sincePeek = 0
 
-    const arrival = await client.nextItem(askShape())
+    const arrival = await metered.nextItem(askShape())
     if (arrival === null) return null
     if (!restricting() || admits(arrival.skillId)) {
       // The host is serving something this pack covers, so it is not parked and
@@ -1023,7 +1148,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       surrender("any of them")
       return await draw(arrival)
     }
-    const swap = await client.nextItem(askShape(pin))
+    const swap = await metered.nextItem(askShape(pin))
     if (swap === null) {
       // The host had one question and not two. Use the one it gave.
       return await draw(arrival)
@@ -1086,7 +1211,16 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     void (async () => {
       try {
         while (!disposed && pool.length < POOL_TARGET) {
-          if (Date.now() - lastAsk > IDLE_MS) break
+          if (now() - lastAsk > IDLE_MS) break
+          // The one place in this module that asks for anything in bulk, and so
+          // the one place that has to look at what is left of the host's budget.
+          // Stopping is safe and waiting is not: `fill` is called again on every
+          // hand-out, on `focus` and on every flush, so the top-up resumes at the
+          // next question the game asks for with the window a second emptier —
+          // and the pool is `POOL_FLOOR` deep before the first frame either way.
+          // Awaiting a timer here instead would put a sleep in front of a child
+          // for questions nobody is waiting for.
+          if (!affordsPrefetch()) break
           // Read every time round the loop, not once: a difficulty change while
           // a refill is in flight has to reach the questions still to come.
           const entry = await acquire()
@@ -1111,7 +1245,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   }
 
   const flushNow = () => {
-    lastFlush = Date.now()
+    lastFlush = now()
     filledFor = aim()
     if (aim() !== null && pool.length > FLUSH_KEEP) {
       // A focused value survives a flush whatever its difficulty. `focus`
@@ -1145,7 +1279,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     // spread the host serves from.
     const band = target === null ? HOST_FLUSH_BAND : FLUSH_BAND
     if (moved < band) return
-    if (moved < FLUSH_URGENT && Date.now() - lastFlush < FLUSH_COOLDOWN_MS) return
+    if (moved < FLUSH_URGENT && now() - lastFlush < FLUSH_COOLDOWN_MS) return
     flushNow()
   }
 
@@ -1165,7 +1299,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   }
 
   const take = (request?: DifficultyRequest): Question => {
-    lastAsk = Date.now()
+    lastAsk = now()
     applyRequest(request)
     // Once per question, whether or not the game said anything. `applyRequest`
     // returns early when there is no request, and that early return is exactly
@@ -1267,7 +1401,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       // at a tablet wants: forty answered questions is a session.
       reported += 1
       const fraction = Math.min(1, reported / SESSION_ITEMS)
-      void client.progress(fraction).catch(() => {})
+      void metered.progress(fraction).catch(() => {})
       options.onProgress?.(fraction)
 
       const land = (verdict: boolean, judged: boolean) => {
@@ -1289,7 +1423,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       // kept beside it rather than discarded: it is the only signal available
       // if this round trip never comes back, and it is available a round trip
       // sooner when it does.
-      void client
+      void metered
         .answer({ itemId: questionId, response: answered, latencyMs: Math.max(0, Math.round(ms)) })
         .then(
           (judgement) => {
@@ -1310,7 +1444,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       // no longer produce an `items.answer` call, so nothing about this
       // question can turn into a wrong attempt afterwards.
       served.delete(questionId)
-      void client.skip(questionId).catch((error: unknown) => {
+      void metered.skip(questionId).catch((error: unknown) => {
         if (skipFailed) return
         skipFailed = true
         // Loud, once. The consequence is small and worth stating precisely: the
@@ -1327,7 +1461,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
 
     haptic: (kind) => {
       if (!granted.has("haptics")) return
-      void client.haptic(HAPTIC[kind]).catch(() => {
+      void metered.haptic(HAPTIC[kind]).catch(() => {
         // A device with no motor is not an error a child should hear about,
         // and the host has already logged anything that is.
       })
@@ -1362,7 +1496,7 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       // Synchronous on the outside, because it is called from inside a game
       // loop where there is no `await`, and swallowed on the inside: a host
       // that could not take a stopping point must not take the game down.
-      void client.transition(kind, label).catch((error: unknown) => {
+      void metered.transition(kind, label).catch((error: unknown) => {
         console.error("[pack] a stopping point could not be reported", error)
       })
     },
@@ -1379,7 +1513,17 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       // the opening wave too: trebuchet's first wave was the unplayable one, and
       // a restriction that starts working on question nine is a restriction that
       // misses the only part of the session a child might not come back from.
-      for (let i = 0; i < POOL_FLOOR && !disposed; i++) {
+      //
+      // Inside the budget like every other question too. `2 * POOL_FLOOR` is 64
+      // and the prefetch share is 90, so on a fresh mount — an empty window, by
+      // construction: the bridge is built with the pack — this loop runs all the
+      // way and the first frame is stocked exactly as deep as it was. The check
+      // is here for the shapes that cost more than two calls a question: a pinned
+      // pack pays three, and a `PEEK_EVERY` fall-through pays five. Stocking
+      // twenty-five questions and letting the pool finish filling as the child
+      // plays is a game that works; stocking thirty-two and being refused for the
+      // last of them is a game that logs `rate_limited` at every mount.
+      for (let i = 0; i < POOL_FLOOR && !disposed && affordsPrefetch(); i++) {
         const entry = await acquire()
         if (entry === null) break
         pool.push(entry)

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -420,8 +420,27 @@ export const POOL_FLOOR = 32
  * instant the window drains, so the reserve costs nothing when nobody is using
  * it.
  *
- * It is expressed against the SDK's own constant so the two cannot drift: the
- * pack does not get to have an opinion about what the host allows.
+ * **The ceiling this puts on sustained supply, since it is a real one.** A
+ * question costs two calls, and the urgent traffic is charged to the same window,
+ * so a pack can be fed `(PREFETCH_BUDGET − urgent) / 2` questions a second
+ * indefinitely: 45 with nothing else going on, and about 40 for a game that
+ * answers and buzzes on every one of them. Above that the pool drains, `take`
+ * hands out `{ ...lastServed, id: "" }`, and 24 of the 27 games draw the previous
+ * question again rather than checking for the empty id. Measured against the
+ * shipped packs, nothing is near it — the deepest bulk consumer in the repo is
+ * FUSE's 26-question pool (`games/merge/src/game.ts`) and every retry loop caps
+ * at eight — and the code this replaces was worse at every rate a pack actually
+ * reaches, because it was being refused outright. If a game ever does become a
+ * bulk consumer, the fix is a hungry-pool tier (a pool under `POOL_FLOOR` is not
+ * a prefetch — the child is about to arrive at it — so it should be allowed past
+ * the share), not a bigger share.
+ *
+ * It is expressed against the SDK's own constant so the two cannot drift on the
+ * DEFAULT: the pack does not get to have an opinion about what the host allows.
+ * `bridge.ts` does take a `maxRequestsPerSecond` override, which today only its
+ * own tests pass; a host that lowered it for a low-end device would put every
+ * pack back over budget, and the honest fix for that is the limit arriving on
+ * `Connect` rather than being assumed here.
  */
 export const PREFETCH_BUDGET = Math.floor(MAX_REQUESTS_PER_SECOND * 0.75)
 
@@ -899,7 +918,9 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   let fresh: number | null = null
   /** The difficulty the pool was last stocked for. */
   let filledFor: number | null = null
-  let lastFlush = 0
+  /** `now()` and not 0: an injected clock starting near zero would otherwise
+   * arm the flush cooldown at mount, which `Date.now()` never does. */
+  let lastFlush = now()
 
   // ── What kind of maths this pack declared it does ──────────────────────────
 

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -810,6 +810,19 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     return spend.length
   }
 
+  /**
+   * Charge one call to the window.
+   *
+   * Expired timestamps are dropped HERE and not only where the budget is read,
+   * because a game with a full pool reads it rarely and spends anyway: horde
+   * asks for a haptic per hit, and a window pruned only by the prefetch would
+   * hold every one of them for as long as the pack ran.
+   */
+  const charge = (): void => {
+    spent()
+    spend.push(now())
+  }
+
   /** Whether the prefetch may start one more `acquire` without going over. */
   const affordsPrefetch = (): boolean => spent() + ACQUIRE_MAX_CALLS <= PREFETCH_BUDGET
 
@@ -826,31 +839,31 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
     "nextItem" | "reveal" | "skip" | "answer" | "progress" | "haptic" | "transition"
   > = {
     nextItem: (ask) => {
-      spend.push(now())
+      charge()
       return client.nextItem(ask)
     },
     reveal: (itemId) => {
-      spend.push(now())
+      charge()
       return client.reveal(itemId)
     },
     skip: (itemId) => {
-      spend.push(now())
+      charge()
       return client.skip(itemId)
     },
     answer: (input) => {
-      spend.push(now())
+      charge()
       return client.answer(input)
     },
     progress: (fraction) => {
-      spend.push(now())
+      charge()
       return client.progress(fraction)
     },
     haptic: (cue) => {
-      spend.push(now())
+      charge()
       return client.haptic(cue)
     },
     transition: (kind, label) => {
-      spend.push(now())
+      charge()
       return client.transition(kind, label)
     },
   }


### PR DESCRIPTION
Two live bugs found by other agents, neither in their scope. Neither fix widens a tolerance.

## 1. `game-host`: every mount breached the host's own rate limit

`bridge.ts` refuses a pack past `MAX_REQUESTS_PER_SECOND` (120) in a **sliding second**, counting every method — prefetch, answers and haptics in one window. `warm()` awaits `POOL_FLOOR` (32) questions and the fill behind it goes on to `POOL_TARGET` (64), at two calls each (`items.next` + `items.reveal`).

Measured in-suite over a mount, the first question, the child's answer and the haptic under it, all inside one frozen window — the shape the app is, since `bridge.ts` dispatches on the same thread that generates the question:

| | attach → first question | refused `rate_limited` |
|---|---|---|
| before | **133 calls** | **13** |
| before, pack pinned by its declaration | **151 calls** | **31** |
| after | 85 calls | 0 |
| after, pack pinned | 87 calls | 0 |

The comment on `POOL_TARGET` had the arithmetic backwards — *"120 requests per second is far more headroom than 64 items need"* — and it was wrong at every mount of all 27 packs. A refused `items.next` rejects, `fill` dies in its catch, and the pool comes up short: a plausible cause of the first-question stalls nobody could pin down. **Severity ceiling:** `warm()` has no try/catch, so a refusal landing inside it rejects the mount and e.g. horde's entry file renders the "runs inside Dynawalla" panel — the game never starts. `bridge.stats.rateLimited` is read by nothing outside its own test, which is why 13 refusals per mount were invisible.

**The fix paces the prefetch and nothing else.** The module keeps the same sliding window the bridge enforces, charges every call it makes through one metered client wrapper, and stops the fill loop while the prefetch's share of the budget (`PREFETCH_BUDGET`, three quarters of the host's limit) is spent. No timer: `fill` is already called on every hand-out, on `focus` and on every flush, so the top-up resumes at the next question with the window a second emptier. Nothing a child waits for is delayed — an answer, a skip and a haptic go the moment the game says so, and the prefetch yields to them. `warm()` still stocks `POOL_FLOOR` before the first frame (2 × 32 = 64 of the 90 the prefetch has), and a test pins that relationship so raising `POOL_FLOOR` fails in CI rather than at a child's mount.

**What remains, in another agent's files.** A question costs two wire calls only because the canonical answer comes back through a separate `items.reveal`, while `items.ts` already has it when it generates the item (`createItemService` is synchronous throughout). `items.next` carrying the canonical for packs already granted `items.reveal` would halve every burst in the product — mount, flush and steady state — and it needs `packs/sdk/src/protocol.ts`, `bridge.ts`, `services.ts` and `items.ts`. Batching (`count` on `items.next`) is the alternative and is a bigger protocol change for the same win.

## 2. `horde`: the flaky test that has been red-lighting the merge queue

`Curriculum` defaults `rng` to `Math.random` and the all-right-answers bot asserted on its **last random draw** (`> 0.9`). `askUnit` draws a step of 0..6 rungs down a band `SPREAD_RUNGS` wide, so that assertion was a 1-in-49 coin toss.

* 100,000 unseeded runs of that bot: **2,000 failures = 2.00%** (theory 1/49 = 2.04%)
* the suite, **400 runs on pristine main: 4 failures**, every one `topped out at 0.8898305084745763` — the top of the ladder less exactly six rungs, i.e. the band working as designed
* the whole horde suite, **400 runs after: 0 failures**

**The seed goes in the test, not in production.** The production default is right: the questions come from the host, which this game cannot seed (the seedable one is `stubHost.ts`, and `main.ts` already passes it a seed); everything else random in DEEPSWARM is unseeded too (`game.ts` derives its generator from `Date.now()`, plus `loadout.ts`, `ui/shuffle.ts`, `core/audio.ts`); and a fixed default would make every child's band descend in the same order in every run forever. The reasoning is written into the file.

The single-sample assertion is replaced by the two claims it stood in for, both stronger: every question from the point the ladder tops out is inside the stated six-rung band (true of **every** seed — a width, not a tolerance), and the run does serve the top rung. The edge is pinned in absolute terms too, so a ladder that stopped climbing halfway cannot satisfy the rest by moving with them.

## Third commit: self-review found the pinned arm of both new tests was vacuous

Worth reading first, because it is a finding against my own tests. `fakeHost`'s ladder puts `dw.mul.scale.times-power-of-ten` at rungs 4-7 and `dw.add.*` everywhere else, so a host standing on rung 12 serves TREBUCHET something TREBUCHET declares. Both new tests stood their "pinned" arm there: nothing was pinned, no `skillId` ever went on the wire, and the second arm was the first arm written down twice. The shipped tests that do this correctly (`THE GAP`, the budget test) stand the host on rung 5.

Both arms now stand where they claim to and **assert the condition they rest on** (`pinnedAsks > 0` for the pinned arm, `=== 0` for the plain one), which is what makes an arm's disappearance a failure rather than a silence. The pinned arm is now load-bearing: with `parked` never latching, so a pinned question costs four calls instead of three, it fails with `question 22 of 32 came out of a dry pool (pinned pack)`.

The same commit fixes a false claim in my own harness comment: `record()` advanced the fake clock, but `haptic`, `progress` and `transition` are charged by the adapter and deliberately absent from `calls`, so they cost budget and no time. The fake ran at **89 charged calls a virtual second against a gate of 84** — the top-up stalled at question 20 of `skillsServed(24)`, making the budget rather than the pool logic the thing that pre-existing test measured. `tick()` is now separate from `record()`; measured peak is **67** against the 84 gate, and the top-up is 1 for all 24 questions. Both `[measured]` lines this file prints are byte-identical to main's.

Also in that commit: `PREFETCH_BUDGET` states the ceiling it puts on sustained supply (`(share − urgent) / 2` questions a second, ~40 for a game that answers and buzzes on each one), names the dry-pool consequence (24 of 27 games do not check for the empty id), shows nothing shipped is near it (deepest bulk consumer is FUSE's 26-question pool; every retry loop caps at eight), and names the fix if one ever is — a hungry-pool tier, not a bigger share. The drift claim is narrowed to what is true (`bridge.ts` takes a `maxRequestsPerSecond` override; only its own tests pass one, and the honest fix is the limit arriving on `Connect`). `lastFlush` starts at `now()` rather than 0, so an injected clock near zero cannot arm the flush cooldown where `Date.now()` never would — no production change, since the first flush has `filledFor === null`, which is `moved = 1` and always urgent. The resume test states its premise instead of failing spuriously if `POOL_TARGET` is lowered. horde uses the file's own `seeded(n)` convention, and all three perturbations were re-run against the new seeds.

## Every test was checked by deleting the fix

| perturbation | failure |
|---|---|
| pacer removed | `an attach and a first question spent 133 calls in one sliding second; the host refuses everything past 120, so the pool comes up short and the child waits for a question that was rate-limited` |
| pacer removed | `the mount stocked 64 questions inside one window, which is more than the budget allows it to` |
| `PREFETCH_BUDGET` starved to 20 | `question 9 of 32 came out of a dry pool` |
| pinned pack pays 4 calls a question (`parked` never latches) | `question 22 of 32 came out of a dry pool (pinned pack)` |
| `POOL_FLOOR` raised to 64 | `warm() stocks POOL_FLOOR (64) questions at two calls each before the first frame, which is 128 of the 90 the prefetch has` |
| horde band widened 3× | `question 22 of a run that has answered everything right came from 0.8389830508474576, below the stated 6-rung band under the top of the ladder (0.8898305084745763)` |
| horde edge shaved a rung | `a run that has topped the ladder out should be drawing from its top rung; the edge is 0.9745762711864407` |
| horde ladder pinned at rung 5 | `a run that is all right answers must top out` |

## Verification (Node 24.18.0)

* `game-host` 54/54 and `horde` 66/66, **200 consecutive runs each with 0 failures**, re-run after every revision above; `tsc --noEmit` clean for both; horde's `build:pack` builds
* the flake itself: 400 runs on pristine main (4 failures) and 400 after the seed (0), plus the 100,000-run direct measurement of the old assertion
* The 50 pre-existing `game-host` tests are unchanged. The fake host now advances a 15 ms-per-round-trip clock on every method the adapter charges (`options.now`, injectable exactly as `bridge.ts` does it). A fake that answers in zero elapsed time is not neutral once the module measures calls per second — seven of those tests assert an instantaneous 64-question restock, which a 120/second host makes physically impossible. At 66 calls/second the pacing never binds, and the two `[measured]` lines prove nothing moved.

Only `dynawalla/games/horde/` and `dynawalla/packs/shared/game-host/` are touched. `items.ts`, `packs/shared/curriculum/` and the games being rewritten elsewhere are untouched.

**Not enqueued** — over to the owner.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
