### PR TITLE
dynawalla/app/packs: the ladder sits at 85% and climbs only above 95%

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -12,28 +12,37 @@ import assert from "node:assert/strict"
 import {
   advanceStaircase,
   ascentOf,
+  ABOVE_RATIO,
+  bandOf,
   cadenceFor,
   choicesFor,
   binaryOperator,
   climbRungs,
   climbWithinMs,
   createItemService,
-  DESCENT_RATIO,
+  DESCENT_FAR,
+  DESCENT_NEAR,
   descentOf,
   isQuick,
   itemPace,
   ladder,
+  LOST_AT,
+  noteRecent,
   normalizeMinus,
   openStaircase,
   pickRung,
+  PROMOTE_AT,
+  recentAccuracy,
+  RECENT_WINDOW,
   rungWeights,
+  SIT_AT,
   SPREAD_ABOVE,
   SPREAD_BELOW,
   STEP_OPEN,
   STEP_START,
   STEP_TRACK,
 } from "./items.ts"
-import type { Rung, Staircase } from "./items.ts"
+import type { Band, Recent, Rung, Staircase } from "./items.ts"
 import type { PromptSlot } from "./curriculum.ts"
 import {
   activeNodes,
@@ -363,7 +372,8 @@ test("driving the difficulty moves the one ladder, so judging resumes from where
   // is still where `openStaircase` puts it.
   assert.equal(
     service.position(),
-    top - descentOf(openStaircase()),
+    // `"lost"` because the window holds one answer and it was wrong, which is 0%.
+    top - descentOf(openStaircase(), "lost"),
     "the ladder did not step down from the pack's position by the opening stride",
   )
 })
@@ -569,6 +579,43 @@ test("a multiplication is drawn as a multiplication, and a division as a divisio
         want.toString(),
         `${expected.id} drew "${item.prompt}" and wants ${answer}, which is not what that string asks`,
       )
+    }
+  }
+})
+
+test("every division a row that promises exactness serves does divide exactly", () => {
+  // The founder, on the level he was thrown to: "you are asked to do like 87364/9
+  // or something super treacherous". `87364 ÷ 9` is `9707.11…`, which is not exact,
+  // and the two rows whose names promise exactness would be broken if they served
+  // it. They do not: `gen.arith.long-div` draws the quotient and multiplies it back,
+  // so the dividend is a product by construction. Pinned here rather than assumed,
+  // because "divide-exact served an inexact division" is a bug a child cannot even
+  // report — they would simply be marked wrong for the right answer.
+  //
+  // What the founder was almost certainly shown is the same *shape*: five digits
+  // over one, which is `divide-exact` L1 and `zero-in-the-quotient` L1 — rungs 40
+  // and 48 of the 66 the ladder has. Legal, and exactly the "racing you to
+  // impossible mode" this file's gate exists to stop.
+  for (const id of ["dw.div.whole.divide-exact", "dw.div.whole.zero-in-the-quotient"]) {
+    const node = allNodes.find((candidate) => String(candidate.id) === id)
+    assert.ok(node, `${id} is gone from the graph`)
+    for (const rung of ladder([node])) {
+      const service = createItemService({ profileId: `exact-${id}`, record: noRecord, rungs: [rung] })
+      for (let i = 0; i < 200; i++) {
+        const item = service.next({ packId: "dynawalla.fuse" })
+        assert.ok(item, `${id} L${String(rung.level)} served nothing`)
+        const [left = "", right = ""] = item.operands
+        const dividend = BigInt(left.replace(/[^-0-9]/gu, ""))
+        const divisor = BigInt(right.replace(/[^-0-9]/gu, ""))
+        assert.notEqual(divisor, 0n, `${id} L${String(rung.level)} drew "${item.prompt}"`)
+        assert.equal(
+          dividend % divisor,
+          0n,
+          `${id} L${String(rung.level)} drew "${item.prompt}", which leaves ` +
+            `${String(dividend % divisor)} over — a row named for exact division served an ` +
+            `inexact one, and the child who answers ${String(dividend / divisor)} is marked wrong`,
+        )
+      }
     }
   }
 })
@@ -1083,6 +1130,7 @@ test("an answer at the published median is worth a whole stride, and the bonus d
   const rungs = ladder()
   const service = createItemService({ profileId: "p1", record: noRecord, rungs })
   let stair = openStaircase()
+  let recent: Recent = []
   let expected = 0
   for (let i = 0; i < 6; i++) {
     const item = service.next({ packId: "dynawalla.siege" })
@@ -1093,10 +1141,24 @@ test("an answer at the published median is worth a whole stride, and the bonus d
       response: service.reveal(item.id),
       latencyMs: publishedP50Ms(widthOf(item.operands)),
     })
+    recent = noteRecent(recent, true)
+    assert.equal(bandOf(recent), "climb", "six right in a row is not a sustained window")
     expected += ascentOf(stair, 1)
     stair = advanceStaircase(stair, 1, 1)
   }
   assert.equal(service.position(), Math.floor(expected))
+
+  // Then three misses, which walk the window down through every band below the
+  // gate: 6/7 is still inside the sitting band and must cost **nothing at all**,
+  // 6/8 is under it and costs a stride, and 6/9 is decisive. The bands are read
+  // here rather than assumed, because what this test is for is that the service
+  // *composes* the window and the stride — the bands themselves are pinned at
+  // their edges in "the four bands are the founder's sentence".
+  //
+  // Three and not more: six misses put this child through the floor of the ladder,
+  // and two numbers that are both clamped to rung 0 agree about nothing.
+  const climbed = service.position()
+  const seen: Band[] = []
   for (let i = 0; i < 3; i++) {
     const item = service.next({ packId: "dynawalla.siege" })
     assert.ok(item)
@@ -1106,13 +1168,37 @@ test("an answer at the published median is worth a whole stride, and the bonus d
       response: "definitely wrong",
       latencyMs: 1_000,
     })
-    expected -= descentOf(stair)
-    stair = advanceStaircase(stair, -1, null)
+    recent = noteRecent(recent, false)
+    const band = bandOf(recent)
+    seen.push(band)
+    if (band !== "climb" && band !== "sit") {
+      expected -= descentOf(stair, band)
+      stair = advanceStaircase(stair, -1, null)
+    } else {
+      // Nothing is subtracted, and this is the assertion rather than an omission:
+      // a miss whose window is still sustaining costs the child nothing. It is the
+      // direct answer to "will just ream your ass if you get a few right", and it
+      // is the one branch a rewrite would most easily drop.
+      assert.equal(
+        service.position(),
+        climbed,
+        `a miss inside a window still reading ${band} cost the child ` +
+          `${String(climbed - service.position())} rungs — one miss is evidence about an item, ` +
+          `not about a level`,
+      )
+      stair = advanceStaircase(stair, 0, null)
+    }
   }
+  assert.deepEqual(
+    seen,
+    ["sit", "slip", "lost"],
+    "three misses after six right did not walk the window through the founder's bands",
+  )
+  assert.ok(expected > 0, "the arithmetic under test fell through the floor and is being clamped")
   assert.equal(
     service.position(),
     Math.floor(expected),
-    "three misses did not cost exactly three strides",
+    "the misses did not cost exactly what their bands say they cost",
   )
 })
 
@@ -1180,77 +1266,339 @@ test("the staircase opens wide, shrinks with every answer, and halves at a rever
   )
 })
 
-test("down is four times up once the child is bracketed, which is what 80% correct means", () => {
-  // Kaernbach's weighted up/down rule: a staircase converges on the proportion
-  // `p` correct when up:down is `(1 − p) : p`. The founder asked for "80%+
-  // correct", so the ratio is 1:4 and `DESCENT_RATIO` is that four. Asserted as
-  // the ratio rather than as two magnitudes, because the magnitudes are the
-  // child's own pace and the ratio is the thing that fixes the accuracy.
-  // Derived, not restated: `p / (1 − p)` at the accuracy the founder named. A
-  // test that compared `descentOf / ascentOf` to `DESCENT_RATIO` would pass at
-  // any value of `DESCENT_RATIO` at all, including the 1 this replaced.
-  // As the whole ratio `right : asked` rather than as 0.8, because `0.8 / (1 −
-  // 0.8)` is 4.000000000000001 and a test that is right about the mathematics and
-  // wrong about binary floats is a test somebody deletes.
-  const RIGHT = 4
-  const ASKED = 5
-  assert.equal(
-    DESCENT_RATIO,
-    RIGHT / (ASKED - RIGHT),
-    `a staircase with this ratio converges on ` +
-      `${((DESCENT_RATIO / (1 + DESCENT_RATIO)) * 100).toFixed(0)}% correct, not ` +
-      `${((RIGHT / ASKED) * 100).toFixed(0)}%`,
-  )
-  const settled: Staircase = { step: STEP_TRACK, lastDir: 1, reversed: true, pace: 1 }
-  assert.equal(descentOf(settled) / ascentOf(settled, 1), DESCENT_RATIO)
-  // And in a slower child's currency: a child whose correct answers are worth a
-  // quarter of a rung each falls a quarter as far, so the *ratio* — and with it
-  // the accuracy the search converges on — is the same for them.
-  const deliberate: Staircase = { ...settled, pace: 0.25 }
-  assert.equal(descentOf(deliberate) / ascentOf(deliberate, 0.25), DESCENT_RATIO)
-  assert.equal(descentOf(deliberate), descentOf(settled) / 4)
+// ---------------------------------------------------------------------------
+// The founder's band: sit at 85%, climb only above 95%, leave under 75%.
+//
+// > "i think there is a principle here. you only progress when sustaining >~95%
+// >  ... if you are getting 85% you are at the right level. if you are less than
+// >  ~75% its too hard. Volta right now will just ream your ass if you get a few
+// >  right!"
+//
+// See `PROMOTE_AT` in `items.ts` for why this is a windowed gate and not a
+// Kaernbach ratio, and `RECENT_WINDOW` for where forty comes from.
 
-  // Before the bracket closes it is symmetric. The first miss is the move that
-  // *closes* the bracket and must be the size of the moves that opened it —
-  // four times an opening stride of four rungs is sixteen, which is the lurch in
-  // the other direction.
-  const opening = openStaircase()
-  assert.equal(descentOf(opening), ascentOf(opening, 1))
+/** A window of `hits` correct answers out of `seen`, which is all `bandOf` reads. */
+function window(hits: number, seen: number): Recent {
+  const bits: boolean[] = []
+  for (let i = 0; i < seen; i++) bits.push(i < hits)
+  return bits
+}
+
+test("the three thresholds are the three numbers the founder named", () => {
+  // Restated deliberately, because these three are the founder's ruling and not a
+  // derivation — a test that recomputed them from the code would be asserting that
+  // the code equals itself. What is checked is that they are in the right order
+  // with a real dead band between them, which is the property a future edit would
+  // break by nudging one of them past another.
+  assert.equal(PROMOTE_AT, 0.95, "the founder said progress needs sustained ~95%")
+  assert.equal(SIT_AT, 0.85, "the founder said 85% is the right level")
+  assert.equal(LOST_AT, 0.75, "the founder said under ~75% is too hard")
+  assert.ok(LOST_AT < SIT_AT && SIT_AT < PROMOTE_AT, "the bands are not ordered")
+  // In whole points, because 0.95 − 0.85 in binary floats is 0.09999999999999998
+  // and a test that is right about the rule and wrong about floats gets deleted.
+  assert.ok(
+    Math.round(PROMOTE_AT * 100) - Math.round(SIT_AT * 100) >= 10,
+    `the dead band between sitting and climbing is ${((PROMOTE_AT - SIT_AT) * 100).toFixed(0)} ` +
+      `points wide — with no dead band the ladder has one threshold again, which is the whole ` +
+      `defect this replaced`,
+  )
 })
 
-test("a child who is right four times in five settles, and stays settled", () => {
-  // The founder's target, end to end: "maybe where they are getting 80%+
-  // correct". A staircase at the 1:4 ratio has zero expected drift at exactly
-  // 80%, so a child answering in that pattern must come to rest somewhere and
-  // stay there — not creep to the top, and not slide to the floor.
+test("the window is the width the dead band needs, and it is derived not chosen", () => {
+  // A Bernoulli estimate over N answers has standard error √(p(1−p)/N). For the
+  // dead band between `SIT_AT` and `PROMOTE_AT` to hold a child still rather than
+  // be crossed by noise, that error must be no wider than half the band, measured
+  // at the middle of the band. Derived from the two thresholds, so nudging either
+  // one fails this until the window is recomputed.
+  const middle = (SIT_AT + PROMOTE_AT) / 2
+  const halfBand = (PROMOTE_AT - SIT_AT) / 2
+  const needed = (middle * (1 - middle)) / (halfBand * halfBand)
+  assert.ok(
+    RECENT_WINDOW >= needed,
+    `a window of ${String(RECENT_WINDOW)} measures accuracy to ` +
+      `${(Math.sqrt((middle * (1 - middle)) / RECENT_WINDOW) * 100).toFixed(1)} points, and half ` +
+      `the dead band is ${(halfBand * 100).toFixed(1)} — the band is narrower than the ` +
+      `measurement, so the ladder wanders instead of sitting. It needs at least ` +
+      `${String(Math.ceil(needed))} answers`,
+  )
+  // And not wastefully longer than it needs to be: a window is answers a miss is
+  // held against a child, so every answer past the derivation is a cost.
+  assert.ok(
+    RECENT_WINDOW <= 2 * needed,
+    `a window of ${String(RECENT_WINDOW)} is more than twice the ${String(Math.ceil(needed))} ` +
+      `the dead band needs, and the surplus is answers a child is held down for`,
+  )
+})
+
+test("the window is a window: it forgets, and its denominator is what was seen", () => {
+  // The two ways a running estimate is got wrong, both of which would break the
+  // rule in a direction nothing else here would catch.
+  assert.equal(recentAccuracy([]), null, "an empty window has no accuracy to report")
+  assert.equal(bandOf([]), "sit", "with no evidence at all the ladder must hold still")
+  // Divided by what was seen: four right out of four is 100% and climbs. Padding
+  // the denominator to `RECENT_WINDOW` would read this child as 10%.
+  assert.equal(recentAccuracy(window(4, 4)), 1)
+  assert.equal(bandOf(window(4, 4)), "climb")
+  // It forgets. A full window plus one answer is still `RECENT_WINDOW` long, and
+  // the answer that fell off the front is the oldest one.
+  let recent: Recent = window(0, RECENT_WINDOW)
+  assert.equal(recent.length, RECENT_WINDOW)
+  for (let i = 0; i < RECENT_WINDOW; i++) recent = noteRecent(recent, true)
+  assert.equal(recent.length, RECENT_WINDOW, "the window grew past its own length")
+  assert.equal(recentAccuracy(recent), 1, "a full window of misses never aged out")
+  // One more answer than the window holds, from empty.
+  let filling: Recent = []
+  for (let i = 0; i <= RECENT_WINDOW; i++) filling = noteRecent(filling, i > 0)
+  assert.equal(filling.length, RECENT_WINDOW)
+  assert.equal(recentAccuracy(filling), 1, "the one miss at the start did not age out")
+})
+
+test("the four bands are the founder's sentence, at their exact edges", () => {
+  // Every boundary, in whole answers out of `RECENT_WINDOW`, so an off-by-one in
+  // any comparison shows up here. Written as counts rather than as ratios because
+  // `38 / 40` is exactly 0.95 and `0.95` written out is not always.
+  const misses = (k: number) => window(RECENT_WINDOW - k, RECENT_WINDOW)
+  assert.equal(bandOf(misses(0)), "climb", "a perfect window does not climb")
+  assert.equal(bandOf(misses(2)), "climb", "two misses in forty is 95% and must still climb")
+  assert.equal(bandOf(misses(3)), "sit", "three misses in forty is 92.5% and is not sustaining 95%")
+  assert.equal(bandOf(misses(6)), "sit", "six misses in forty is 85% and is the right level")
+  assert.equal(bandOf(misses(7)), "slip", "seven misses in forty is 82.5% and is under the band")
+  assert.equal(bandOf(misses(10)), "slip", "ten misses in forty is 75% and is not yet decisive")
+  assert.equal(bandOf(misses(11)), "lost", "eleven misses in forty is 72.5% and is too hard")
+  assert.equal(bandOf(misses(RECENT_WINDOW)), "lost")
+})
+
+test("a few right by being lucky cannot climb, which is the report this fixes", () => {
+  // > "you get a few right just by being lucky and all of a sudden you are asked
+  // >  to do like 87364/9"
+  //
+  // Four lucky taps in a row are 100% and do climb — nothing can tell them apart
+  // from four answers a child knew, and the stride is what bounds how far they
+  // go. What must not survive is the *fifth* answer: under the rule this replaced,
+  // one miss cost a rung and the next correct answer bought it straight back, so a
+  // guesser at one-in-four rode the noise upward. Now the miss is in the window.
+  let recent: Recent = []
+  for (let i = 0; i < 4; i++) recent = noteRecent(recent, true)
+  assert.equal(bandOf(recent), "climb", "four right in a row is not evidence of anything at all")
+  recent = noteRecent(recent, false)
+  assert.equal(bandOf(recent), "slip", "one miss in five is 80% and the climb must stop dead")
+  // And it stays stopped: the child cannot buy the climb back with one answer, or
+  // with ten. `PROMOTE_AT` over a window with a miss in it needs the window full.
+  for (let i = 0; i < 10; i++) {
+    recent = noteRecent(recent, true)
+    assert.notEqual(
+      bandOf(recent),
+      "climb",
+      `a single miss was bought back after ${String(i + 1)} correct answers — the window is ` +
+        `${String(recent.length)} long, and 95% of it does not admit a miss until it is ` +
+        `${String(Math.ceil(1 / (1 - PROMOTE_AT)))} long`,
+    )
+  }
+  // It comes back, when it has genuinely been sustained.
+  for (let i = 0; i < RECENT_WINDOW; i++) recent = noteRecent(recent, true)
+  assert.equal(bandOf(recent), "climb", "a child who did sustain 95% is still not allowed to climb")
+})
+
+test("demotion is readier than promotion, and under 75% it is not a contest", () => {
+  // The founder asked for demotion to be readier and for under-75% to be
+  // decisive. Both are properties of the *gate*, not of the step size, so both are
+  // computed from the binomial over the window rather than read off a constant.
+  //
+  // See the table on `PROMOTE_AT` in `items.ts`; this is that table, derived.
+  const choose = (n: number, k: number) => {
+    let lg = 0
+    for (let i = 1; i <= k; i++) lg += Math.log(n - k + i) - Math.log(i)
+    return lg
+  }
+  /** P(band | true accuracy p), over a full window. */
+  const spread = (p: number) => {
+    const out: Record<Band, number> = { climb: 0, sit: 0, slip: 0, lost: 0 }
+    for (let k = 0; k <= RECENT_WINDOW; k++) {
+      // `p` of exactly 1 puts a `log(0)` in the k > 0 terms, which is the child
+      // requirement 5 is about — spelled out rather than left as a `NaN`.
+      const q =
+        p === 1
+          ? k === 0
+            ? 1
+            : 0
+          : Math.exp(
+              choose(RECENT_WINDOW, k) + k * Math.log(1 - p) + (RECENT_WINDOW - k) * Math.log(p),
+            )
+      out[bandOf(window(RECENT_WINDOW - k, RECENT_WINDOW))] += q
+    }
+    return out
+  }
+  // At the bottom of the sitting band, down must be much readier than up.
+  const atFloor = spread(SIT_AT)
+  const down = atFloor.slip + atFloor.lost
+  assert.ok(
+    down > 5 * atFloor.climb,
+    `at ${(SIT_AT * 100).toFixed(0)}% correct the ladder reads climb on ` +
+      `${(atFloor.climb * 100).toFixed(1)}% of answers and down on ${(down * 100).toFixed(1)}% — ` +
+      `that is not readier down than up`,
+  )
+  // And at the too-hard threshold it is not a contest: essentially every answer
+  // moves the child down, and a large share of them decisively.
+  const tooHard = spread(LOST_AT)
+  assert.ok(
+    tooHard.slip + tooHard.lost > 0.85,
+    `at ${(LOST_AT * 100).toFixed(0)}% correct only ` +
+      `${((tooHard.slip + tooHard.lost) * 100).toFixed(1)}% of answers move the child down`,
+  )
+  assert.ok(
+    tooHard.lost > 0.25,
+    `at ${(LOST_AT * 100).toFixed(0)}% correct the decisive branch fires on only ` +
+      `${(tooHard.lost * 100).toFixed(1)}% of answers, so "too hard" is being left at the ` +
+      `same rate as "a bit hard"`,
+  )
+  assert.ok(
+    tooHard.climb < 0.01,
+    `at ${(LOST_AT * 100).toFixed(0)}% correct the ladder still climbs on ` +
+      `${(tooHard.climb * 100).toFixed(1)}% of answers — "will just ream your ass" is what that ` +
+      `feels like`,
+  )
+  // The other end: a child who is never wrong is never held. This is the property
+  // requirement 5 turns on — the gate must not be in a perfect child's way.
+  assert.equal(spread(1).climb, 1, "a child at 100% is not climbing on every single answer")
+  // And the drift changes sign inside the founder's band, which is what makes the
+  // settled accuracy land in it from either direction. Weighted by the step sizes,
+  // which is the whole of the arithmetic: up is one stride and down is one or
+  // `DESCENT_FAR`.
+  const drift = (p: number) => {
+    const s = spread(p)
+    return s.climb - s.slip * DESCENT_NEAR - s.lost * DESCENT_FAR
+  }
+  assert.ok(drift(SIT_AT) < 0, `a child at ${(SIT_AT * 100).toFixed(0)}% is drifting upward`)
+  assert.ok(
+    drift(PROMOTE_AT) > 0,
+    `a child at ${(PROMOTE_AT * 100).toFixed(0)}% is not drifting upward`,
+  )
+})
+
+test("the two descent weights are one stride and the Kaernbach weight for 75%", () => {
+  // `DESCENT_FAR` is `LOST_AT / (1 − LOST_AT)`: the up:down ratio at which a
+  // classical weighted staircase has zero drift at the accuracy the founder called
+  // too hard, so below it the ladder is driven down rather than drifting. Derived
+  // from `LOST_AT`, so a test that compared `DESCENT_FAR` to itself — which is the
+  // shape PR 699's own ratio assertion originally had — cannot pass here.
+  // As the whole ratio rather than as 0.75, because `0.75 / (1 − 0.75)` in binary
+  // floats is a thing nobody should have to reason about.
+  const RIGHT = 3
+  const ASKED = 4
+  assert.equal(LOST_AT, RIGHT / ASKED, "LOST_AT is not the three-in-four the weight is built on")
+  assert.equal(
+    DESCENT_FAR,
+    RIGHT / (ASKED - RIGHT),
+    `the decisive descent is the weight for ` +
+      `${((DESCENT_FAR / (1 + DESCENT_FAR)) * 100).toFixed(0)}% correct, not ` +
+      `${(LOST_AT * 100).toFixed(0)}%`,
+  )
+  assert.equal(DESCENT_NEAR, 1, "a level that is wrong is not left at the rate it was entered")
+  assert.ok(DESCENT_FAR > DESCENT_NEAR, "too hard is not left faster than a bit hard")
+
+  const settled: Staircase = { step: STEP_TRACK, lastDir: 1, reversed: true, pace: 1 }
+  assert.equal(descentOf(settled, "slip") / ascentOf(settled, 1), DESCENT_NEAR)
+  assert.equal(descentOf(settled, "lost") / ascentOf(settled, 1), DESCENT_FAR)
+  // And in a slower child's currency: a child whose correct answers are worth a
+  // quarter of a rung each falls a quarter as far, so the ratios are the same for
+  // them and they are not parked below the quick child who knows as much.
+  const deliberate: Staircase = { ...settled, pace: 0.25 }
+  assert.equal(descentOf(deliberate, "lost") / ascentOf(deliberate, 0.25), DESCENT_FAR)
+  assert.equal(descentOf(deliberate, "lost"), descentOf(settled, "lost") / 4)
+
+  // Before the bracket closes both are one stride. The first miss is the move that
+  // *closes* the bracket and must be the size of the moves that opened it —
+  // `DESCENT_FAR` times an opening stride of four rungs is twelve, which is the
+  // lurch in the other direction.
+  const opening = openStaircase()
+  assert.equal(
+    descentOf(opening, "lost"),
+    ascentOf(opening, 1),
+    `the first miss costs ${String(descentOf(opening, "lost"))} rungs against an opening stride ` +
+      `of ${String(ascentOf(opening, 1))} — the move that closes the bracket must be the size of ` +
+      `the moves that opened it, or one slip throws a child down the ladder`,
+  )
+  assert.equal(
+    descentOf(opening, "slip"),
+    ascentOf(opening, 1),
+    `the first miss in the slip band costs ${String(descentOf(opening, "slip"))} rungs against ` +
+      `an opening stride of ${String(ascentOf(opening, 1))}`,
+  )
+})
+
+test("a sit holds the rung, decays the stride, and is not a reversal", () => {
+  // The third direction, which the rule this replaced did not have. A child in the
+  // dead band must not move, must not have their bracket disturbed by standing
+  // still, and must not still be carrying an opening stride when they leave.
+  const climbing = advanceStaircase(advanceStaircase(openStaircase(), 1, 1), 1, 1)
+  const sat = advanceStaircase(climbing, 0, 1)
+  assert.equal(sat.lastDir, climbing.lastDir, "holding still changed the child's direction")
+  assert.equal(sat.reversed, climbing.reversed, "holding still closed the bracket")
+  assert.ok(sat.step < climbing.step, "the stride did not decay while the child sat")
+  // A sit after a sit is still not a reversal, however many there are, and the
+  // stride still lands on its floor rather than under it.
+  let long = sat
+  for (let i = 0; i < 60; i++) long = advanceStaircase(long, 0, 1)
+  assert.equal(long.lastDir, 1)
+  assert.equal(long.reversed, false)
+  assert.ok(Math.abs(long.step - STEP_OPEN) < 1e-6, `sitting left the stride at ${String(long.step)}`)
+  // The next real move after a long sit is still the move it would have been: down
+  // from a climb is a reversal, and it brackets.
+  const after = advanceStaircase(long, -1, null)
+  assert.equal(after.reversed, true, "the reversal after a sit did not close the bracket")
+})
+
+test("a child at 90% sits, a child at 80% is walked down, and both stay in the founder's band", () => {
+  // The band, end to end, through the real service. Two children in fixed
+  // patterns rather than at random, so the assertions are about the rule and not
+  // about a seed: nine right in ten is inside the sitting band and must come to
+  // rest, four right in five is under its floor and must be walked off it. The
+  // rule this replaced walked *both* of them to 80% and called it done.
   const rungs = ladder()
   const top = rungs.length - 1
-  const walked: number[] = []
-  const service = createItemService({ profileId: "p80", record: noRecord, rungs })
-  for (let answered = 0; answered < 500; answered++) {
-    const item = service.next({ packId: "dynawalla.siege" })
-    assert.ok(item)
-    // Right on four of every five, in a fixed pattern rather than at random, so
-    // the assertion is about the rule and not about a seed.
-    const right = answered % 5 !== 4
-    service.judge({
-      packId: "dynawalla.siege",
-      itemId: item.id,
-      response: right ? service.reveal(item.id) : "definitely wrong",
-      latencyMs: publishedP50Ms(widthOf(item.operands)),
-    })
-    walked.push(service.position())
+  const walkOf = (profileId: string, rightWhen: (n: number) => boolean) => {
+    const walked: number[] = []
+    const service = createItemService({ profileId, record: noRecord, rungs })
+    for (let answered = 0; answered < 600; answered++) {
+      const item = service.next({ packId: "dynawalla.siege" })
+      assert.ok(item)
+      const right = rightWhen(answered)
+      service.judge({
+        packId: "dynawalla.siege",
+        itemId: item.id,
+        response: right ? service.reveal(item.id) : "definitely wrong",
+        latencyMs: publishedP50Ms(widthOf(item.operands)),
+      })
+      walked.push(service.position())
+    }
+    return walked
   }
-  const tail = walked.slice(400)
-  const low = Math.min(...tail)
-  const high = Math.max(...tail)
-  assert.ok(low > 0, `an 80%-correct child slid to rung ${String(low)}`)
-  assert.ok(high < top, `an 80%-correct child crept to the top (rung ${String(high)} of ${String(top)})`)
-  // Settled means the last hundred answers cover a handful of rungs, not the
-  // ladder. Anything wider is a walk, not a level.
+
+  // 90%: inside the dead band, so it settles and stays — not the top, not the
+  // floor, and a handful of rungs wide.
+  const ninety = walkOf("p90", (n) => n % 10 !== 9).slice(500)
+  const low = Math.min(...ninety)
+  const high = Math.max(...ninety)
+  assert.ok(low > 0, `a 90%-correct child slid to rung ${String(low)}`)
+  assert.ok(
+    high < top,
+    `a 90%-correct child crept to the top (rung ${String(high)} of ${String(top)})`,
+  )
   assert.ok(
     high - low <= 2 * (SPREAD_BELOW + SPREAD_ABOVE),
-    `an 80%-correct child's last hundred answers ranged over rungs ${String(low)}..${String(high)}`,
+    `a 90%-correct child's last hundred answers ranged over rungs ${String(low)}..${String(high)}`,
+  )
+
+  // 80%: under the sitting band at every rung, so there is nowhere for this child
+  // to come to rest and the ladder must keep walking them down. This is the
+  // assertion that would have passed under the old rule for the wrong reason — a
+  // 1:4 Kaernbach staircase has zero drift at exactly 80% and parked them
+  // mid-ladder, at the accuracy the founder says is too low.
+  const eighty = walkOf("p80", (n) => n % 5 !== 4)
+  assert.ok(
+    (eighty.at(-1) as number) < 3,
+    `a child who is right four times in five — under the founder's floor at every rung — was ` +
+      `parked at rung ${String(eighty.at(-1))} instead of being walked down`,
   )
 })
 
@@ -1336,6 +1684,31 @@ test("regime 2: a child who is right every single time and slow every single tim
     `the slow child stalled at rung ${String(slow.rung)} of ${String(slow.top)} after ` +
       `${String(slow.answers)} correct answers`,
   )
+  // **And the accuracy gate is not in their way at all.** This is the number PR
+  // 672 brought from 33 hours to 87 answers and PR 699 measured at 126 on the
+  // 66-rung ladder, and a promotion gate is the kind of change that would quietly
+  // add a warm-up to it. A child who is never wrong is at 100%, which is over
+  // `PROMOTE_AT` from their very first answer, so the gate must cost them exactly
+  // nothing — pinned as a count, because "not much slower" is how a regression of
+  // this shape ships.
+  assert.ok(
+    slow.answers <= 2 * slow.top,
+    `a perfect child took ${String(slow.answers)} answers to climb ${String(slow.top)} rungs. ` +
+      `Being unhurried already costs them a fraction of a rung an answer; the accuracy gate must ` +
+      `cost them nothing on top of it, because 100% clears ${String(PROMOTE_AT)} on answer one`,
+  )
+  // Structurally, not just numerically: at no point in that climb was the window
+  // anything but `climb`, so there is no path by which the gate could have held
+  // them. A window of nothing but correct answers is 100% at every length.
+  let perfect: Recent = []
+  for (let i = 0; i < 3 * RECENT_WINDOW; i++) {
+    perfect = noteRecent(perfect, true)
+    assert.equal(
+      bandOf(perfect),
+      "climb",
+      `after ${String(i + 1)} correct answers in a row the gate stopped reading climb`,
+    )
+  }
 })
 
 test("regime 1 beats regime 2: the same ladder, quick, takes far fewer answers than slow", () => {
@@ -1616,13 +1989,21 @@ test("the tail cannot underflow the floor or overflow the top", () => {
   })
   assert.equal(service.position(), 0, "a fraction of a rung above the floor fell through it")
 
-  // At the top: quick answers pile up, then one miss must cost the same as it
-  // would have cost the moment the top was reached. Credit above the top is not
-  // credit — it is clamped away — and a child who kept playing after arriving
-  // must not have bought themselves a free miss.
+  // At the top: quick answers pile up, and the credit they earn above the top is
+  // not credit — it is clamped away. A child who kept playing after arriving must
+  // not have bought themselves immunity from falling.
+  //
+  // The claim used to be an exact equality between a child who missed straight
+  // away and one who lingered twenty answers. It cannot be, now: the window is
+  // what decides the direction, so the lingerer needs more misses than the
+  // newcomer to fall out of the sitting band and the two arms are not comparing
+  // the same number of descending answers. What survives the change — and is the
+  // thing the clamp is actually for — is that no amount of lingering buys a child
+  // out of falling. Delete the clamp and the lingerer's banked credit absorbs
+  // every miss below, and this test fails.
   const top = rungs.length - 1
-  /** Climbs to the top, answers `extra` more, misses once, and says where it is. */
-  const missAtTop = (profileId: string, extra: number): number => {
+  /** Climbs to the top, answers `extra` more, then misses until it moves. */
+  const missAtTop = (profileId: string, extra: number): { rung: number; misses: number } => {
     const at = createItemService({ profileId, record: noRecord, rungs })
     for (let i = 0; i < 200 && at.position() < top; i++) {
       const next = at.next({ packId: "dynawalla.siege" })
@@ -1645,25 +2026,44 @@ test("the tail cannot underflow the floor or overflow the top", () => {
         latencyMs: A_SPEEDCUBER_MS,
       })
     }
-    const missed = at.next({ packId: "dynawalla.siege" })
-    assert.ok(missed)
-    at.judge({
-      packId: "dynawalla.siege",
-      itemId: missed.id,
-      response: "definitely wrong",
-      latencyMs: 1_000,
-    })
-    return at.position()
+    // Then misses, one at a time, until the ladder moves. A perfect window means
+    // the first few cost nothing by design (see `PROMOTE_AT`), so what is counted
+    // is how many it takes and where it lands — not that the very first one bites.
+    let misses = 0
+    while (misses < 3 * RECENT_WINDOW && at.position() >= top) {
+      const missed = at.next({ packId: "dynawalla.siege" })
+      assert.ok(missed)
+      at.judge({
+        packId: "dynawalla.siege",
+        itemId: missed.id,
+        response: "definitely wrong",
+        latencyMs: 1_000,
+      })
+      misses += 1
+    }
+    return { rung: at.position(), misses }
   }
   const straightAway = missAtTop("top-0", 0)
   const afterLingering = missAtTop("top-20", 20)
-  assert.ok(straightAway < top, "a miss at the top of the ladder cost nothing at all")
-  assert.equal(
-    afterLingering,
-    straightAway,
-    `twenty quick answers at the top banked credit that a miss then paid for: the child who ` +
-      `missed straight away fell to ${String(straightAway)} and the one who lingered to ` +
-      `${String(afterLingering)}`,
+  assert.ok(
+    straightAway.rung < top,
+    `${String(straightAway.misses)} misses at the top of the ladder cost nothing at all`,
+  )
+  assert.ok(
+    afterLingering.rung < top,
+    `twenty quick answers at the top banked credit that ${String(afterLingering.misses)} misses ` +
+      `then could not pay for: the child who missed straight away fell to ` +
+      `${String(straightAway.rung)} and the one who lingered is still on rung ` +
+      `${String(afterLingering.rung)} of ${String(top)}`,
+  )
+  // And the lingering bought at most the window: twenty extra correct answers can
+  // delay the fall by no more than the answers it takes to age them out, because
+  // there is no other store of credit anywhere in the rule.
+  assert.ok(
+    afterLingering.misses <= straightAway.misses + RECENT_WINDOW,
+    `lingering twenty answers at the top delayed the fall by ` +
+      `${String(afterLingering.misses - straightAway.misses)} misses, which is more than the ` +
+      `${String(RECENT_WINDOW)}-answer window can account for — something is banking credit`,
   )
 })
 
@@ -1735,25 +2135,89 @@ test("the spread is centred, asymmetric, and reaches both ways", () => {
   }
 })
 
-test("the spread puts about a fifth of questions above the child's rung, which is what 80% is made of", () => {
+test("the spread's upward reach fits under the promotion gate, with margin", () => {
   const p = shares(20, 40)
   const below = p.slice(0, 20).reduce((a, b) => a + b, 0)
   const above = p.slice(21).reduce((a, b) => a + b, 0)
-  // A fifth above: paired with near-perfect accuracy below the rung, ~90% at it
-  // and ~60% one above, this mix measures out at ~83% correct, which is the
-  // founder's "80%+ correct" arrived at from the content side while the staircase
-  // arrives at it from the search side.
-  assert.ok(above > 0.15 && above < 0.25, `${(above * 100).toFixed(1)}% of questions are harder`)
-  // A rung the child cannot do is rare: two above is a twentieth.
-  assert.ok((p[22] as number) < 0.07, `two rungs up is ${((p[22] as number) * 100).toFixed(1)}%`)
+  const twoAbove = p[22] as number
+
+  // **The constraint that fixes `ABOVE_RATIO`, and the reason it moved from 0.35.**
+  // Content two rungs above where a child is standing is the part of the mix a
+  // child at their own level plausibly cannot do at all. `PROMOTE_AT` gives them
+  // `1 − PROMOTE_AT` of head-room. If the two-above share is bigger than the
+  // head-room, a child who is right about everything else measures under the gate
+  // and can never climb again, at any level, forever — a deadlock, not a tuning
+  // risk. At `ABOVE_RATIO` 0.35 the share was 5.2% against 5.0% of head-room,
+  // which is on the wrong side of it.
+  const headroom = 1 - PROMOTE_AT
+  assert.ok(
+    twoAbove < headroom,
+    `two rungs up is ${(twoAbove * 100).toFixed(1)}% of the stream and the promotion gate leaves ` +
+      `${(headroom * 100).toFixed(1)}% of head-room, so a child who is perfect on everything ` +
+      `else measures ${((1 - twoAbove) * 100).toFixed(1)}% and is frozen out of climbing forever`,
+  )
+  // With margin, because "cannot do at all" is an idealisation and the real number
+  // moves. A factor of one and a half is what `ABOVE_RATIO` 0.25 buys.
+  assert.ok(
+    twoAbove * 1.5 < headroom,
+    `two rungs up is ${(twoAbove * 100).toFixed(1)}% against ${(headroom * 100).toFixed(1)}% of ` +
+      `head-room — inside the gate, but with nothing in hand`,
+  )
+  // Stated the other way as well, because the deadlock is what the shares mean and
+  // a reader should not have to do the division: a fluent child who fails only the
+  // two-above items must clear the gate.
+  assert.ok(
+    1 - twoAbove >= PROMOTE_AT,
+    `a child perfect except two rungs up measures ${((1 - twoAbove) * 100).toFixed(1)}%`,
+  )
+
+  // Still a real reach upward, though: the stretch item has to exist.
+  assert.ok(above > 0.1, `only ${(above * 100).toFixed(1)}% of questions are harder`)
+  assert.ok(twoAbove > 0.01, `two rungs up is ${(twoAbove * 100).toFixed(1)}% — that is absent`)
   // And there are real easier questions in the stream — "we could still throw in
   // some single digit problems".
   assert.ok(below > 0.3, `only ${(below * 100).toFixed(1)}% of questions are easier`)
 
   // Consecutive questions differ: the chance two independent draws land on the
-  // same rung is Σp², and a spread that fails this is a point in disguise.
+  // same rung is Σp², and a spread that fails this is a point in disguise. This is
+  // the cost of narrowing the upward reach — it concentrates the centre — and is
+  // why the reach is narrowed as far as the gate needs and no further.
   const same = p.reduce((a, b) => a + b * b, 0)
   assert.ok(same < 0.3, `two questions running land on the same rung ${(same * 100).toFixed(1)}% of the time`)
+})
+
+test("the at-level mix does not put a child under the founder's floor", () => {
+  // The distribution read as an accuracy. Against the accuracy a child plausibly
+  // has at each offset — near everything below level, ~90% at it, ~60% one above,
+  // ~30% two above — a child standing exactly at their own level measures this
+  // much, and it has to be inside the founder's 85–95% band. At `ABOVE_RATIO` 0.35
+  // it was 85.4%: on the floor of the band with nothing to spare, so any pessimism
+  // about the two harder offsets put the content mix alone under his floor.
+  const byOffset: Record<number, number> = { [-3]: 0.98, [-2]: 0.98, [-1]: 0.98, 0: 0.9, 1: 0.6, 2: 0.3 }
+  const p = shares(20, 40)
+  let measured = 0
+  for (let offset = -SPREAD_BELOW; offset <= SPREAD_ABOVE; offset++) {
+    measured += (p[20 + offset] as number) * (byOffset[offset] as number)
+  }
+  assert.ok(
+    measured > SIT_AT,
+    `a child standing at their own level measures ${(measured * 100).toFixed(1)}% on this mix, ` +
+      `and the founder's floor is ${(SIT_AT * 100).toFixed(0)}% — the content alone is enough to ` +
+      `demote them`,
+  )
+  assert.ok(
+    measured - SIT_AT > 0.02,
+    `a child at their own level measures ${(measured * 100).toFixed(1)}%, which is on the floor ` +
+      `of the band rather than inside it`,
+  )
+  assert.ok(
+    measured < PROMOTE_AT,
+    `a child at their own level measures ${(measured * 100).toFixed(1)}% and would be promoted ` +
+      `off it — the mix is easier than the level it claims to be`,
+  )
+  // And the ratio it takes to get there, so the number in the doc table is pinned
+  // from the test side too.
+  assert.equal(ABOVE_RATIO, 0.25)
 })
 
 test("the spread reflects at the ends of the ladder rather than piling onto them", () => {
@@ -1862,9 +2326,16 @@ test("a beginner sees far more than nine distinct questions, without any closed 
 })
 
 test("the stream a child is served stays inside the spread of where the ladder stands", () => {
-  // The guard that the mixing cannot quietly become "any rung at all". Over a
-  // long session with a child who is right four times in five, every question
-  // must have come from within the kernel of the position at the time.
+  // The guard that the mixing cannot quietly become "any rung at all". Over a long
+  // session, every question must have come from a rung the kernel of the position
+  // at the time actually gives weight to.
+  //
+  // Read off `rungWeights` rather than off `±SPREAD_ABOVE / SPREAD_BELOW`, because
+  // the kernel *reflects* at the ends of the ladder: at rung 0 the downward tail
+  // comes back up, so a child at the floor is legitimately served rung 3 — which is
+  // three above them, and is the whole point of reflecting rather than clipping.
+  // The old form of this assertion only held because the child it used settled
+  // mid-ladder; a child who ends up at the floor made it fail on correct code.
   const rungs = ladder()
   const span = rungs.length - 1
   const service = createItemService({ profileId: "p-spread", record: noRecord, rungs })
@@ -1875,9 +2346,14 @@ test("the stream a child is served stays inside the spread of where the ladder s
     const item = service.next({ packId: "dynawalla.truedraw" })
     assert.ok(item)
     const served = Math.round((item.difficulty ?? 0) * span)
+    assert.ok(
+      (rungWeights(centre, span)[served] ?? 0) > 0,
+      `the child was standing on rung ${String(centre)} and was served rung ${String(served)}, ` +
+        `which that position's kernel gives no weight to at all`,
+    )
     worstBelow = Math.max(worstBelow, centre - served)
     worstAbove = Math.max(worstAbove, served - centre)
-    const right = answered % 5 !== 4
+    const right = answered % 10 !== 9
     service.judge({
       packId: "dynawalla.truedraw",
       itemId: item.id,
@@ -1885,9 +2361,7 @@ test("the stream a child is served stays inside the spread of where the ladder s
       latencyMs: publishedP50Ms(widthOf(item.operands)),
     })
   }
-  assert.ok(worstAbove <= SPREAD_ABOVE, `a question came ${String(worstAbove)} rungs above the child`)
-  assert.ok(worstBelow <= SPREAD_BELOW, `a question came ${String(worstBelow)} rungs below the child`)
   // And it really did use the width, rather than serving the centre forever.
-  assert.equal(worstAbove, SPREAD_ABOVE, "the spread never once reached its own ceiling")
-  assert.equal(worstBelow, SPREAD_BELOW, "the spread never once reached its own floor")
+  assert.ok(worstAbove >= SPREAD_ABOVE, "the spread never once reached its own ceiling")
+  assert.ok(worstBelow >= SPREAD_BELOW, "the spread never once reached its own floor")
 })

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -198,35 +198,60 @@ const CHOICE_COUNT = 4
  * mind. Asymmetric because *easier than you can do* and *harder than you can do*
  * are not the same event: the first is a fluency rep, the second is a child stuck.
  *
- * **What the numbers are, and where they come from.** They are not taste; they
- * are the founder's accuracy target read as a mix. With the constants below the
- * kernel is
+ * **What the numbers are, and where they come from.** They are not taste. With
+ * the constants below the kernel is
  *
  * | offset | −3   | −2   | −1   | 0    | +1   | +2   |
  * |--------|------|------|------|------|------|------|
- * | weight | .125 | .25  | .5   | 1    | .35  | .1225|
- * | share  | 5.2% | 10.4%| 20.9%| 41.7%| 14.6%| 5.1% |
+ * | weight | .125 | .25  | .5   | 1    | .25  | .0625|
+ * | share  | 5.7% | 11.4%| 22.9%| 45.7%| 11.4%| 2.9% |
  *
- * so **20% of questions are above the rung the child is standing on** and 5% are
- * two above. Against the accuracy a child plausibly has at each offset — near
- * everything below level, ~90% at level, ~60% one above, ~30% two above — that
- * mix measures out at **83% correct**, which is the "80%+ correct but slowly"
- * the founder asked the calibration to find. The distribution and the staircase
- * are therefore aiming at the same number from two directions, which is the only
- * reason it is safe to run them at once.
+ * so **14% of questions are above the rung the child is standing on** and 2.9%
+ * are two above.
+ *
+ * **`ABOVE_RATIO` is fixed by the promotion gate, and this is the one number the
+ * two mechanisms are not free to choose separately.** `PROMOTE_AT` is 0.95, so a
+ * child has five points of head-room: to be allowed to climb they may miss no
+ * more than a twentieth of what they are shown. Content two rungs above where
+ * they are standing is the part of the mix a child at their own level plausibly
+ * cannot do at all. If its share is *larger than the head-room*, then a child who
+ * is right about literally everything else measures under 95% and **can never
+ * promote again, at any level, forever.** That is not a tuning risk, it is a
+ * deadlock, and the ratio this file shipped with was on the wrong side of it:
+ *
+ * | `ABOVE_RATIO` | above | two above | a child perfect except two-above | can climb? |
+ * |---------------|-------|-----------|----------------------------------|------------|
+ * | 0.35 (was)    | 20.1% | 5.2%      | 94.8%                            | **no**     |
+ * | 0.28          | 16.0% | 3.5%      | 96.5%                            | yes        |
+ * | 0.25 (is)     | 14.3% | 2.9%      | 97.1%                            | yes        |
+ * | 0.20          | 11.3% | 1.9%      | 98.1%                            | yes        |
+ *
+ * 0.25 is the widest reach that clears the gate with better than a factor of one
+ * and a half in hand (2.9% against 5%), which is the margin worth having because
+ * "cannot do at all" is an idealisation and the real number moves.
+ *
+ * Read the other way — against the accuracy a child plausibly has at each offset,
+ * near everything below level, ~90% at level, ~60% one above, ~30% two above —
+ * the mix measures **88.1% correct** for a child standing exactly at their own
+ * level, against 85.4% at the old ratio. The founder's sitting band is 85–95%, so
+ * the old mix put a child at their own level *on its floor* with nothing to
+ * spare; this one puts them in the middle of it. See `PROMOTE_AT`.
  *
  * Two more properties it has to have, and does:
  *
  *   * **Consecutive questions differ.** The chance two draws land on the same
- *     rung is `Σ p²` = 25.5%, so three questions in four move.
- *   * **A rung the child cannot do is rare.** Two above is 5%, three above is
- *     not served at all.
+ *     rung is `Σ p²` = 29.1%, so about seven questions in ten move. Narrowing the
+ *     upward reach concentrates the centre and pushes this number up — it was
+ *     26.6% — which is why the reach is narrowed as far as the gate requires and
+ *     no further.
+ *   * **A rung the child cannot do is rare.** Two above is a thirty-fifth, three
+ *     above is not served at all.
  *
  * **Reflected at the ends, not clipped.** At the bottom of the ladder there is
  * nowhere below to go, and clipping would pile 78% of a beginner's questions
  * onto rung 0 — nine items — which is the exact defect this exists to fix. So
  * the mass that falls off an end is *reflected back inward*: at rung 0 the
- * kernel becomes 43% / 36% / 16% / 5% over rungs 0..3, which is `add-within-ten`
+ * kernel becomes 46% / 34% / 14% / 6% over rungs 0..3, which is `add-within-ten`
  * L0 and L1 and `subtract-within-ten` L0 and L1 — about sixty distinct items
  * rather than nine, with nothing inflated and no closed set relabelled. That is
  * the answer to a small honest fact set: **reach the neighbours**, never pretend
@@ -235,7 +260,7 @@ const CHOICE_COUNT = 4
 export const SPREAD_BELOW = 3
 export const SPREAD_ABOVE = 2
 export const BELOW_RATIO = 0.5
-export const ABOVE_RATIO = 0.35
+export const ABOVE_RATIO = 0.25
 
 /**
  * The weight of every rung on the ladder for a child standing on `centre`.
@@ -313,9 +338,11 @@ export function pickRung(centre: number, span: number, unit: number): number {
  * the queue finally turned over. The queue is fixed there; the search is fixed
  * here.
  *
- * **The shape: a weighted staircase with a decaying step.** Standard psychophysics,
- * and it is the right standard because the problem is literally threshold
- * estimation — find the difficulty at which this child is right 80% of the time.
+ * **The shape: a decaying stride, aimed by a gate on sustained accuracy.** The
+ * stride is standard psychophysics and is the right standard, because the problem
+ * is literally threshold estimation. What the *direction* is decided by is not
+ * standard, and it is not standard because the founder's rule is not a threshold —
+ * see `PROMOTE_AT`, which is where the band, the window and the arithmetic live.
  *
  *   * **The stride shrinks.** It opens at `STEP_START` rungs, multiplies by
  *     `STEP_DECAY` after every answer, and is *halved again at every reversal* —
@@ -329,41 +356,198 @@ export function pickRung(centre: number, span: number, unit: number): number {
  *     perfect child is preserved by construction rather than by tuning. Once
  *     bracketed it bottoms out at `STEP_TRACK`, a quarter of a rung, which is
  *     what makes the tracking gentle.
- *   * **Down is four times up.** Kaernbach's weighted up/down rule: a staircase
- *     converges on the proportion `p` correct when the step ratio is
- *     `up : down = (1 − p) : p`. For the founder's 80% that ratio is **1:4**, and
- *     `DESCENT_RATIO` is that four. It is not a punishment and it is not tuned;
- *     it is the arithmetic of the number he asked for. At the tracking floor it
- *     comes out as +0.25 of a rung for a right answer and −1 for a wrong one —
- *     so a miss costs precisely the one rung it always cost, and only the reward
- *     changed.
  *   * **In the child's own currency.** The descent is scaled by `pace`, a running
  *     mean of what this child's correct answers have actually been worth
  *     (`climbRungs`, unchanged — quick, expected and tail regimes all still
  *     apply, and they now scale the stride instead of being the whole of it). A
- *     child worth 0.4 of a rung an answer falls 0.4 × 4 × step, not 1 × 4 × step.
- *     Without this the ratio is 1:4 only for a child answering at the median and
- *     nearer 1:10 for a deliberate one, which would park every slow child several
- *     rungs below the fast child who knows exactly as much.
+ *     child worth 0.4 of a rung an answer falls 0.4 × step, not 1 × step. Without
+ *     this a deliberate child would fall at the rate of a quick one and climb at
+ *     their own, which parks every slow child several rungs below the fast child
+ *     who knows exactly as much.
  *   * **The first miss is symmetric.** Before any reversal the descent weight is
- *     1, not 4: the first wrong answer is the move that *closes* the bracket, and
- *     it should be the same size as the moves that opened it. Multiplying an
- *     opening stride of four rungs by four would throw a child sixteen rungs down
- *     for one slip, which is the lurch in the other direction.
+ *     1, whatever the band says: the first wrong answer is the move that *closes*
+ *     the bracket, and it should be the same size as the moves that opened it.
+ *     Multiplying an opening stride of four rungs by the decisive weight would
+ *     throw a child twelve rungs down for one slip, which is the lurch in the
+ *     other direction.
  *
- * **A guesser still cannot climb.** One tap in four on a four-slab grid: their
- * expected move once bracketed is `¼(+0.25) − ¾(4 × 0.25) = −0.69` rungs an
- * answer, against `¼(+1) − ¾(1) = −0.5` under the rule this replaces. The
- * speedcuber bonus is still gated behind `QUICK_RUN_FOR_BONUS` consecutive quick
- * *correct* answers, which a guesser reaches one time in 4⁶. `items.test.ts`
- * runs the bot.
+ * **A guesser still cannot climb.** One tap in four on a four-slab grid never
+ * gets a forty-answer window to 95%, so `bandOf` reads `lost` on essentially
+ * every answer and the guesser is pinned. The speedcuber bonus is still gated
+ * behind `QUICK_RUN_FOR_BONUS` consecutive quick *correct* answers, which a
+ * guesser reaches one time in 4⁶. `items.test.ts` runs the bot.
  */
 export const STEP_START = 4
 export const STEP_OPEN = 1
 export const STEP_TRACK = 0.25
 export const STEP_DECAY = 0.72
 export const REVERSAL_DECAY = 0.5
-export const DESCENT_RATIO = 4
+
+/**
+ * ## The founder's band: sit at 85%, climb only above 95%, and below 75% get out
+ *
+ * This replaces a single Kaernbach target, and the reason it replaces it is that
+ * the founder's rule has **two** thresholds in it and a weighted staircase has
+ * one. Him, having played VOLTA on 0.3.3:
+ *
+ * > "you get a few right just by being lucky and all of a sudden you are asked to
+ * > do like 87364/9 or something super treacherous.... the level should be
+ * > adjusted I think so that the person is getting 80-90% right and it's a bit
+ * > easier... not that it's smashing you through with a 50% because you are
+ * > getting lucky and it's racing you to impossible mode."
+ *
+ * and then the rule itself:
+ *
+ * > "i think there is a principle here. **you only progress when sustaining >~95%**
+ * > ... **if you are getting 85% you are at the right level. if you are less than
+ * > ~75% its too hard.** Volta right now will just ream your ass if you get a few
+ * > right!"
+ *
+ * **Why a weighted staircase cannot express that.** Kaernbach's rule — down/up =
+ * `p/(1 − p)` — has exactly one accuracy at which the drift is zero, and it drifts
+ * at every other accuracy. Set it to 80% and the child is walked to 80%; set it to
+ * 85% and the child is walked to 85%. There is no ratio that *sits still* over a
+ * range, and "85% is the right level, 95% is where you progress" is a range. What
+ * is more, the staircase moves on a single answer: at the tracking floor one
+ * correct answer was worth +0.25 of a rung and at the opening stride it was worth
+ * four, so four lucky answers in a row moved a child about twelve rungs. That is
+ * the "a few right just by being lucky" in one sentence, and no choice of ratio
+ * fixes it, because the instrument has a denominator of one.
+ *
+ * **The instrument.** A running window of the last `RECENT_WINDOW` answers, and
+ * four bands over its accuracy:
+ *
+ * | window accuracy | band     | what happens                                  |
+ * |-----------------|----------|-----------------------------------------------|
+ * | ≥ `PROMOTE_AT`  | `climb`  | a correct answer climbs, by stride × its worth |
+ * | ≥ `SIT_AT`      | `sit`    | nothing moves — this is the right level        |
+ * | ≥ `LOST_AT`     | `slip`   | down one stride, in the child's own currency  |
+ * | below that      | `lost`   | down `DESCENT_FAR` strides                     |
+ *
+ * The window is the whole fix. **A single answer can no longer move a child a
+ * rung on its own evidence**: to climb at all, the last forty answers have to be
+ * at 95%, which is at most two misses. Four lucky taps do not reach it — four
+ * correct answers out of four is 100%, but the *fifth* answer a guesser gets wrong
+ * puts the window at 80% and the band at `slip`, and it stays there. Where the old
+ * rule let one right answer buy a rung back immediately after a miss, one miss now
+ * costs a child the climb until it ages out of the window.
+ *
+ * **Two thresholds, and a dead band between them.** Climbing needs 95%; falling
+ * starts under 85%; between the two the ladder holds still. That dead band *is*
+ * "if you are getting 85% you are at the right level", said as code, and it is why
+ * the settled accuracy is a range and not a point: a child climbing from below
+ * stops just under 95%, and a child sinking from above stops just over 85%.
+ * **Every settled accuracy this rule can produce is inside the founder's band by
+ * construction, from either direction.** Simulated against the real service, five
+ * children of five different true abilities — 60%, 75%, 85% and 95% own-rung
+ * accuracy at rung 20, plus a beginner at rung 3 — settle at a **measured 88.3% to
+ * 89.9% correct**. The rule this replaced settled every one of the same five at
+ * **80.0%**, because that is what one Kaernbach target does: it walks a child to
+ * its number regardless of who they are. `items.test.ts` pins the two ends of the
+ * band through the service — a 90% child comes to rest and stays, an 80% child is
+ * walked down off a floor they cannot sit on — and the drift's change of sign
+ * inside the band from the binomial.
+ *
+ * **Demotion is readier than promotion, and it is the gate that makes it so, not
+ * the step size.** At a true accuracy of 85% — the bottom of the band — the
+ * probability that one answer's window reads `climb` is 4.9%, and the probability
+ * it reads `slip` or `lost` is 39.3%: **eight times readier down than up**, with
+ * the two step sizes equal. Computed from the binomial, not tuned:
+ *
+ * | true accuracy | `climb` | `sit` | `slip` | `lost` | down : up |
+ * |---------------|---------|-------|--------|--------|-----------|
+ * | 100%          | 100.0%  |  0.0% |   0.0% |   0.0% | never     |
+ * | 95%           |  67.7%  | 32.0% |   0.3% |   0.0% | 1 : 226   |
+ * | 90%           |  22.3%  | 67.8% |   9.8% |   0.1% | 1 : 2.2   |
+ * | 85%           |   4.9%  | 55.8% |  36.3% |   3.0% | 8 : 1     |
+ * | 80%           |   0.8%  | 27.8% |  55.3% |  16.1% | 90 : 1    |
+ * | 75%           |   0.1%  |  9.5% |  48.8% |  41.6% | 890 : 1   |
+ *
+ * Read the last two rows against "Volta right now will just ream your ass": at
+ * 75% correct the ladder now moves down on nine answers in ten and up on one in a
+ * thousand.
+ *
+ * **A perfect child is not slowed by any of this.** 100% correct is above 95% from
+ * the very first answer, so `bandOf` reads `climb` on every one of them and the
+ * gate is not in the way at all: the slow-perfect child's 126 answers to the top
+ * of the 66-rung ladder are the same 126 they were, and `items.test.ts` asserts
+ * the number rather than trusting the argument.
+ *
+ * **A miss inside a sustained window costs nothing.** Up needs both a correct
+ * answer and a window at 95%; down needs only the window. So a child at 100% who
+ * slips once holds their rung — the window still says this is their level, and one
+ * miss is not evidence about a level, it is evidence about an item. This is the
+ * direct answer to "will just ream your ass if you get a few right".
+ */
+export const PROMOTE_AT = 0.95
+export const SIT_AT = 0.85
+export const LOST_AT = 0.75
+
+/**
+ * How many recent answers the band is read off.
+ *
+ * **Derived, from the width of the dead band.** The window is a Bernoulli
+ * estimate, so its standard error at accuracy `p` is `√(p(1−p)/N)`. For the dead
+ * band between `SIT_AT` and `PROMOTE_AT` to actually *hold a child still* rather
+ * than be crossed by noise in both directions every few answers, that error has to
+ * be no wider than half the band. At the middle of the band, `p` = 0.90:
+ *
+ * `√(0.9 × 0.1 / N) ≤ (0.95 − 0.85) / 2` ⟹ `N ≥ 0.09 / 0.0025` = **36**
+ *
+ * Forty is that, rounded to a number a person can hold. Below it the band is
+ * narrower than the measurement and the ladder wanders: at N = 20 the error is
+ * 6.7 points against a 5-point half-band, and a child in the middle of the band
+ * reads `climb` on 39% of answers instead of 22%.
+ *
+ * The cost of a longer window is how long a miss is held against a child, and that
+ * cost is the point. At forty, `PROMOTE_AT` admits two misses, so a third one
+ * stops the climb until the oldest ages out — which is "sustaining", and about two
+ * minutes of play rather than about ten seconds.
+ *
+ * `items.test.ts` re-derives this from `SIT_AT` and `PROMOTE_AT` rather than
+ * restating 40, so a future edit to either threshold fails until the window is
+ * recomputed.
+ */
+export const RECENT_WINDOW = 40
+
+/**
+ * How many strides a `slip` costs, and how many a `lost` costs.
+ *
+ * `DESCENT_NEAR` is **one**: a level that turns out to be wrong is left at the
+ * same rate it was entered. The asymmetry the founder asked for lives in the gate
+ * and is worth a factor of eight there (see the table on `PROMOTE_AT`), so buying
+ * it a second time in the step size would be double-counting, and a sweep of
+ * `DESCENT_NEAR` over 1 and 2 moved neither the settled rung nor the settled
+ * accuracy of any simulated child.
+ *
+ * `DESCENT_FAR` is **three**, and three is `LOST_AT / (1 − LOST_AT)` — the
+ * Kaernbach weight for the accuracy the founder named as too hard. It is the same
+ * arithmetic PR 699 used to get four out of 80%, applied to the threshold he
+ * actually named, and it means the decisive branch falls at exactly the rate a
+ * classical staircase aimed at 75% would: below 75% correct the ladder does not
+ * merely drift down, it is being driven down.
+ *
+ * Measured, on a child parked twenty rungs above their level and answering at
+ * their true accuracy, counting answers until the standing rung is back within a
+ * rung of it:
+ *
+ * | `DESCENT_FAR` | answers to get back |
+ * |---------------|---------------------|
+ * | 1             | 73                  |
+ * | 2             | 37                  |
+ * | 3 (is)        | 25                  |
+ * | 4             | 19                  |
+ * | 6             | 13                  |
+ *
+ * Twenty-five is inside one window, which is the property that matters: a child
+ * who has been thrown into content they cannot do is out of it before the evidence
+ * that put them there has even aged out. Every one of these values leaves the
+ * settled accuracy inside the founder's band — the gate sets that, not the step —
+ * so the derivation is what picks, and the table is what confirms the derivation
+ * is not absurd.
+ */
+export const DESCENT_NEAR = 1
+export const DESCENT_FAR = 3
 
 /**
  * How fast `pace` forgets. A quarter, so five answers carry ~76% of the weight:
@@ -404,26 +588,84 @@ export function ascentOf(stair: Staircase, gain: number): number {
 }
 
 /**
- * How far this wrong answer moves the centre.
+ * How far a `slip` or a `lost` answer moves the centre.
  *
- * Symmetric with the ascent until the bracket closes, then `DESCENT_RATIO` times
- * it — in the child's own currency, so the 1:4 that produces 80% correct holds
- * for a deliberate child as well as a quick one.
+ * One stride for a `slip` and `DESCENT_FAR` for a `lost`, in the child's own
+ * currency — and one stride for both until the bracket closes, because the move
+ * that closes the bracket must be the size of the moves that opened it.
  */
-export function descentOf(stair: Staircase): number {
-  const weight = stair.reversed ? DESCENT_RATIO : 1
+export function descentOf(stair: Staircase, band: Band): number {
+  const weight = !stair.reversed ? 1 : band === "lost" ? DESCENT_FAR : DESCENT_NEAR
   return weight * stair.step * Math.max(PACE_FLOOR, stair.pace)
 }
 
-/** The search after one answer in `dir`, worth `gain` rungs if it was correct. */
-export function advanceStaircase(stair: Staircase, dir: 1 | -1, gain: number | null): Staircase {
-  const isReversal = stair.lastDir !== 0 && dir !== stair.lastDir
+/**
+ * The search after one answer in `dir`, worth `gain` rungs if it was correct.
+ *
+ * `dir` of `0` is a `sit`: the stride still decays — a child sitting in the band
+ * is not searching, and the stride they eventually leave the band with should be a
+ * tracking stride and not the one they arrived with — but the direction and the
+ * bracket are untouched, because holding still is not a reversal.
+ */
+export function advanceStaircase(
+  stair: Staircase,
+  dir: 0 | 1 | -1,
+  gain: number | null,
+): Staircase {
+  const isReversal = dir !== 0 && stair.lastDir !== 0 && dir !== stair.lastDir
   const reversed = stair.reversed || isReversal
   const floor = reversed ? STEP_TRACK : STEP_OPEN
   const base = isReversal ? stair.step * REVERSAL_DECAY : stair.step
   const step = Math.max(floor, floor + (base - floor) * STEP_DECAY)
   const pace = gain === null ? stair.pace : stair.pace + PACE_ALPHA * (gain - stair.pace)
-  return { step, lastDir: dir, reversed, pace }
+  return { step, lastDir: dir === 0 ? stair.lastDir : dir, reversed, pace }
+}
+
+/**
+ * Which of the four bands on `PROMOTE_AT`'s table a window of answers is in.
+ *
+ * `sit` on an empty window: before there is any evidence the ladder holds still,
+ * which is the only reading of no evidence that cannot be gamed.
+ */
+export type Band = "climb" | "sit" | "slip" | "lost"
+
+/**
+ * The last `RECENT_WINDOW` answers, oldest first. Plain booleans rather than a
+ * running count, because the accuracy has to be *re-read* as answers age out and a
+ * counter that only ever increments cannot do that.
+ */
+export type Recent = readonly boolean[]
+
+/** `recent` with one more answer on the end, and the oldest dropped if it is full. */
+export function noteRecent(recent: Recent, correct: boolean): Recent {
+  const kept = recent.length < RECENT_WINDOW ? recent : recent.slice(recent.length - RECENT_WINDOW + 1)
+  return [...kept, correct]
+}
+
+/**
+ * The window's accuracy, or `null` when there is nothing in it.
+ *
+ * Divided by how many answers there *are*, not by `RECENT_WINDOW`. A child four
+ * answers into a session who has been right four times is at 100% and climbing;
+ * padding the denominator to forty would read them as 10% and drive them to the
+ * floor, and padding it with imaginary correct answers would let four lucky taps
+ * read as 95% — which is the defect this whole rule exists to end.
+ */
+export function recentAccuracy(recent: Recent): number | null {
+  if (recent.length === 0) return null
+  let hits = 0
+  for (const bit of recent) if (bit) hits += 1
+  return hits / recent.length
+}
+
+/** The band, read off the window. See `PROMOTE_AT` for the table. */
+export function bandOf(recent: Recent): Band {
+  const accuracy = recentAccuracy(recent)
+  if (accuracy === null) return "sit"
+  if (accuracy >= PROMOTE_AT) return "climb"
+  if (accuracy >= SIT_AT) return "sit"
+  if (accuracy >= LOST_AT) return "slip"
+  return "lost"
 }
 
 export type Rung = {
@@ -996,6 +1238,15 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
    */
   let stair = openStaircase()
   /**
+   * The last `RECENT_WINDOW` answers, which is what decides the direction.
+   *
+   * Session-scoped for the same reason as `progress` and `stair`: it is evidence
+   * about a sitting, and a window carried across sittings would let a child who
+   * was fluent last night be demoted for warming up this morning. See
+   * `PROMOTE_AT`.
+   */
+  let recent: Recent = []
+  /**
    * Consecutive quick, correct answers. Reset by anything else — see
    * `QUICK_RUN_FOR_BONUS` for why a single one earns nothing.
    */
@@ -1285,26 +1536,42 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       if (!served.answered) {
         served.answered = true
         deps.record({ packId, correct: verdict.correct })
-        // The ladder moves on what actually happened, and how far is the
-        // staircase's stride times what this answer was worth. Up on every
-        // correct answer — by more than a rung when it was quick for this
-        // question, by a fraction of one when it came from the item's slow tail
-        // — and down on any miss. Slow is not wrong: it is the same direction,
-        // taken at the child's own speed. Wrong is the only thing that
-        // descends, which is what stops a guesser. See `STEP_START` for why the
-        // stride opens wide and shrinks, and `DESCENT_RATIO` for why down is
-        // four times up once the child's level has been bracketed.
+        // The ladder moves on the last `RECENT_WINDOW` answers, not on this one.
+        // `bandOf` is the founder's rule — climb only while sustaining 95%, sit at
+        // 85%, leave decisively under 75% — and `PROMOTE_AT` carries the whole
+        // argument for why a single answer is not evidence about a level.
+        //
+        // Up needs two things and down needs one: a climb needs both a correct
+        // answer and a window that says this child is over the level, while a fall
+        // needs only the window. So a miss inside a sustained window costs
+        // nothing, and a correct answer inside a collapsing one does not rescue
+        // it. How *far* is still the stride times what the answer was worth — see
+        // `STEP_START` for why the stride opens wide and shrinks, and
+        // `DESCENT_FAR` for the two descent weights.
+        recent = noteRecent(recent, verdict.correct)
+        const band = bandOf(recent)
         if (verdict.correct) {
           const gain = climbFor(served, latencyMs)
-          progress = progress + ascentOf(stair, gain)
-          stair = advanceStaircase(stair, 1, gain)
+          if (band === "climb") {
+            progress = progress + ascentOf(stair, gain)
+            stair = advanceStaircase(stair, 1, gain)
+          } else if (band === "sit") {
+            stair = advanceStaircase(stair, 0, gain)
+          } else {
+            progress = progress - descentOf(stair, band)
+            stair = advanceStaircase(stair, -1, gain)
+          }
         } else {
-          progress = progress - descentOf(stair)
-          stair = advanceStaircase(stair, -1, null)
           // A miss ends the run, however fast it was. Speed on a wrong answer
           // is not evidence of anything at all — it is what guessing looks
           // like — and the speedcuber's rate has to be earned again.
           quickRun = 0
+          if (band === "climb" || band === "sit") {
+            stair = advanceStaircase(stair, 0, null)
+          } else {
+            progress = progress - descentOf(stair, band)
+            stair = advanceStaircase(stair, -1, null)
+          }
         }
         // One clamp for both directions, and the floor is written as a floor:
         // no sequence of answers can put a child below the easiest rung the


### PR DESCRIPTION
## The founder, playing VOLTA on 0.3.3

> "its a little too fast and stressful and crazy. almost really awesome ... but i need more time to think ... and **you get a few right just by being lucky and all of a sudden you are asked to do like 87364/9** or something super treacherous.... the level should be adjusted I think so that the person is getting 80-90% right and it's a bit easier... not that it's smashing you through with a 50% because you are getting lucky and it's racing you to impossible mode."

> "**i think there is a principle here. you only progress when sustaining >~95% ... if you are getting 85% you are at the right level. if you are less than ~75% its too hard.** Volta right now will just ream your ass if you get a few right!"

## Why the current target is wrong

PR #699's weighted staircase works exactly as designed. Kaernbach at `up:down = 1:4` walks every child to **80.0% correct** — measured, over eight seeds and five different true abilities, all five land on 80.0%. That is below his band, and it is below it *by construction*, because a Kaernbach ratio has one accuracy at which the drift is zero and walks a child to it regardless of who they are.

Two thresholds cannot be expressed as one ratio. "85% is the right level, 95% is where you progress" is a **range**, and a staircase has no range — there is no ratio that sits still.

And the instrument had a denominator of one. At the opening stride a single correct answer moved a child four rungs; four in a row moved them about twelve. That is "a few right just by being lucky", and no choice of ratio fixes it.

## What this changes

The stride, the reversal decay, the pace currency, `climbRungs` and the three latency regimes are all untouched. What changes is **what decides the direction**: a running window of the last `RECENT_WINDOW` answers, and four bands over its accuracy.

| window accuracy | band | what happens |
|---|---|---|
| ≥ `PROMOTE_AT` = 0.95 | `climb` | a correct answer climbs, by stride × what it was worth |
| ≥ `SIT_AT` = 0.85 | `sit` | **nothing moves** — this is the right level |
| ≥ `LOST_AT` = 0.75 | `slip` | down one stride, in the child's own currency |
| below | `lost` | down `DESCENT_FAR` = 3 strides |

**Up needs two things, down needs one.** A climb needs both a correct answer and a window at 95%; a fall needs only the window. So **a miss inside a sustained window costs nothing at all** — the direct answer to "will just ream your ass if you get a few right" — and one miss otherwise costs a child the climb until it ages out, which is what "sustaining" means.

### The window is 40, and it is derived

A Bernoulli estimate over `N` answers has standard error `√(p(1−p)/N)`. For the dead band between 85% and 95% to *hold a child still* rather than be crossed by noise in both directions, that error must be no wider than half the band, at the middle of the band:

`√(0.9 × 0.1 / N) ≤ (0.95 − 0.85)/2` ⟹ `N ≥ 36`

Forty is that, rounded. At `N = 20` the error is 6.7 points against a 5-point half-band and the ladder wanders: a child in the middle of the band reads `climb` on 39% of answers instead of 22%. The test re-derives 40 from `SIT_AT` and `PROMOTE_AT` rather than restating it, so nudging either threshold fails until the window is recomputed.

### Demotion is readier, and it is the gate that makes it so

Computed from the binomial over the window, not tuned:

| true accuracy | `climb` | `sit` | `slip` | `lost` | down : up |
|---|---|---|---|---|---|
| 100% | 100.0% | 0.0% | 0.0% | 0.0% | never |
| 95% | 67.7% | 32.0% | 0.3% | 0.0% | 1 : 226 |
| 90% | 22.3% | 67.8% | 9.8% | 0.1% | 1 : 2.2 |
| 85% | **4.9%** | 55.8% | 36.3% | 3.0% | **8 : 1** |
| 80% | 0.8% | 27.8% | 55.3% | 16.1% | 90 : 1 |
| 75% | 0.1% | 9.5% | 48.8% | 41.6% | **890 : 1** |

At the bottom of the sitting band demotion is eight times readier than promotion **with the two step sizes equal**, so `DESCENT_NEAR` stays at 1 — buying the asymmetry a second time in the step size would be double-counting, and a sweep over 1 and 2 moved neither the settled rung nor the settled accuracy of any child.

`DESCENT_FAR = 3` is `LOST_AT / (1 − LOST_AT)` — the same arithmetic #699 used to get 4 out of 80%, applied to the threshold he actually named for "too hard". Measured: a child parked twenty rungs above their level is back within a rung of it in 25 answers (`FAR` 1 → 73, 2 → 37, 3 → 25, 4 → 19, 6 → 13). Inside one window, which is the property that matters.

## Settled accuracy: before and after

Both arms are the **real service**; the "before" arm is `origin/main` verbatim, imported alongside. Eight seeds × 600 answers; a child of ability θ is logistic with a slope of one rung, so `own-rung accuracy` is how often they are right at θ.

### BEFORE (`origin/main`, one Kaernbach target at 80%)

| child | settles at rung | **measured accuracy once settled** | answers to settle | highest rung reached |
|---|---|---|---|---|
| true 60% (ability r20) | 18.8 | **80.0%** | 8 | 21.5 of 65 |
| true 75% (ability r20) | 19.5 | **80.0%** | 9 | 22.4 of 65 |
| true 85% (ability r20) | 20.1 | **79.9%** | 9 | 22.9 of 65 |
| true 95% (ability r20) | 21.3 | **80.0%** | 10 | 24.0 of 65 |
| beginner 95% (ability r3) | 4.3 | **80.0%** | 1 | 8.8 of 65 |
| 100% at median | **the top**, in 55 answers | 100.0% | — | 65 of 65 |
| 100% slow (60 s/question) | **the top**, in 127 answers | 100.0% | — | 65 of 65 |
| fast-perfect adult | **the top**, in 24 answers | 100.0% | — | 65 of 65 |
| guesser (1 tap in 4) | 0.0 | 26.8% | 1 | 2.4 of 65 |

### AFTER (85–95% band + 40-answer window)

| child | settles at rung | **measured accuracy once settled** | answers to settle | highest rung reached |
|---|---|---|---|---|
| true 60% (ability r20) | 16.0 | **89.4%** | 6 | 21.3 of 65 |
| true 75% (ability r20) | 16.1 | **89.9%** | 6 | 22.3 of 65 |
| true 85% (ability r20) | 17.2 | **89.5%** | 7 | 22.9 of 65 |
| true 95% (ability r20) | 17.5 | **89.7%** | 7 | 24.3 of 65 |
| beginner 95% (ability r3) | 2.9 | **88.3%** | 1 | 8.6 of 65 |
| 100% at median | **the top**, in 55 answers | 100.0% | — | 65 of 65 |
| 100% slow (60 s/question) | **the top**, in 127 answers | 100.0% | — | 65 of 65 |
| fast-perfect adult | **the top**, in 24 answers | 100.0% | — | 65 of 65 |
| guesser (1 tap in 4) | 0.0 | 26.7% | 1 | **0.5 of 65** |

Every settled accuracy moves from 80.0% into **88.3–89.9%**, inside his band from both directions: a child climbing from below stops just under 95%, a child sinking from above stops just over 85%. The guesser's furthest reach over a 600-answer session drops from rung 2.4 to rung 0.5.

## A slow, perfect child still reaches the top — to the answer

| perfect child | before | after |
|---|---|---|
| 60 s per question | 126 answers | **126** |
| at the published median | 34 answers | **34** |
| speedcuber (200 ms) | 24 answers | **24** |

Identical, and not by luck: 100% correct is above 95% from the first answer, so `bandOf` reads `climb` on every one of them and the gate is never in the way. Asserted structurally as well as numerically — a window of nothing but correct answers reads `climb` at every length from 1 to 120.

## The distribution's upward reach: `ABOVE_RATIO` 0.35 → 0.25

Measured against his band rather than guessed at, and the measurement found something sharper than a mis-tuned share — **a deadlock**. `PROMOTE_AT` leaves a child `1 − 0.95` = 5.0% of head-room. Content two rungs above where they stand is the part of the mix a child at their own level plausibly cannot do at all. If its share exceeds the head-room, a child right about *literally everything else* measures under the gate and can **never climb again, at any level, forever**:

| `ABOVE_RATIO` | above | two above | child perfect except two-above | can climb? |
|---|---|---|---|---|
| 0.35 (was) | 20.1% | **5.2%** | **94.8%** | **no** |
| 0.28 | 16.0% | 3.5% | 96.5% | yes |
| **0.25 (is)** | 14.3% | 2.9% | 97.1% | yes |
| 0.20 | 11.3% | 1.9% | 98.1% | yes |

Read the other way — against the per-offset accuracies the existing doc uses — a child standing at their own level measures **88.1%** on the new mix against **85.4%** on the old. The old mix put them on the floor of his band with nothing to spare; this one puts them mid-band. 0.25 is the widest reach that clears the gate with better than 1.5× in hand, and it is not narrowed further because narrowing concentrates the centre (`Σp²` 26.6% → 29.1%, still under the 30% "consecutive questions differ" bound).

`SPREAD_ABOVE` stays at 2, `SPREAD_BELOW` at 3, `BELOW_RATIO` at 0.5, and the reflect-not-clip behaviour at the ends is untouched.

## `87364 / 9` is not a legal item — he is paraphrasing

`87364 ÷ 9 = 9707.11…`, not exact. All **ten** active division rungs draw the quotient and multiply it back, so the dividend is a product by construction: **40,000 sampled items across every active division rung, zero inexact.** There is no bug in `divide-exact`.

The *shape* is entirely real, though. Five digits over one is `dw.div.whole.divide-exact` **L1 (rung 40)** and `dw.div.whole.zero-in-the-quotient` **L1 (rung 48)** of the 66 the ladder has, and `87381 ÷ 9 = 9709` is a legal item on rung 48 — seventeen away from what he typed. He was on rung 40-ish, which is what "racing you to impossible mode" means and what the gate exists to stop.

A new test pins the exactness of the two rows whose names promise it, so a future curriculum edit that breaks it fails here rather than reaching a child who is marked wrong for the right answer. Nothing under `packs/shared/curriculum/` is modified.

## What is untouched

The 64-question prefetch fix in `packs/shared/game-host`, the reflect-not-clip ends, the guesser bot (now pinned harder), the item-relative windows from #668/#672, and `fluencyTarget.p50Ms` only ever *widening* a window — the graph-wide test over every node including drafts still passes, `dw.mul.*` at 15 s and `dw.div.*` at 18 s included. Only `dynawalla/dynawalla-app/src/packs/items.ts` and its test are staged.

## Every test verified by deleting the fix

Each row: the change reverted, and the exact message the suite then printed.

| mutation | failure message |
|---|---|
| `PROMOTE_AT` 0.95 → 0.80 | `a 90%-correct child crept to the top (rung 65 of 65)` · `at 85% correct the ladder reads climb on 86.5% of answers and down on 13.5% — that is not readier down than up` · `a window of 40 measures accuracy to 6.0 points, and half the dead band is -2.5 — the band is narrower than the measurement, so the ladder wanders instead of sitting. It needs at least 232 answers` |
| `SIT_AT` 0.85 → 0.75 (collapse the dead band) | `a child who is right four times in five — under the founder's floor at every rung — was parked at rung 11 instead of being walked down` · `at 75% correct only 41.6% of answers move the child down` |
| `LOST_AT` 0.75 → 0.50 | `the founder said under ~75% is too hard` · `LOST_AT is not the three-in-four the weight is built on` · `eleven misses in forty is 72.5% and is too hard` |
| `RECENT_WINDOW` 40 → 10 | `a single miss was bought back after 10 correct answers — the window is 10 long, and 95% of it does not admit a miss until it is 20 long` · `a window of 10 measures accuracy to 9.5 points, and half the dead band is 5.0 ... It needs at least 37 answers` |
| `RECENT_WINDOW` 40 → 200 | `a window of 200 is more than twice the 37 the dead band needs, and the surplus is answers a child is held down for` |
| `DESCENT_FAR` 3 → 4 (#699's constant) | `the decisive descent is the weight for 80% correct, not 75%` |
| `DESCENT_NEAR` 1 → 3 | `a level that is wrong is not left at the rate it was entered` |
| `ABOVE_RATIO` 0.25 → 0.35 | `two rungs up is 5.2% of the stream and the promotion gate leaves 5.0% of head-room, so a child who is perfect on everything else measures 94.8% and is frozen out of climbing forever` · `a child at their own level measures 85.4%, which is on the floor of the band rather than inside it` |
| delete the window (read only the last answer — #699's denominator of one) | `one miss in five is 80% and the climb must stop dead` · `a 90%-correct child crept to the top (rung 65 of 65)` · `a child at 95% is not drifting upward` |
| pad the denominator to `RECENT_WINDOW` instead of what was seen | `400 − 155 is 3 digits wide, its published median is 11000 ms, it was answered correctly in exactly that, and the ladder did not move off rung 0` |
| delete the dead band (a correct answer climbs while sitting) | `a 90%-correct child crept to the top (rung 65 of 65)` |
| delete "a miss inside a sustained window costs nothing" | `a miss inside a window still reading sit cost the child 2 rungs — one miss is evidence about an item, not about a level` |
| the window never forgets | `the window grew past its own length` |
| a `sit` clears `lastDir` | `holding still changed the child's direction` |
| a `sit` counts as a reversal | `holding still closed the bracket` |
| the first miss is no longer symmetric | `the first miss costs 12 rungs against an opening stride of 4 — the move that closes the bracket must be the size of the moves that opened it, or one slip throws a child down the ladder` |
| delete the top clamp | `top-0 never reached the top` / `66 !== 65` |
| make `gen.arith.long-div` inexact | `dw.div.whole.divide-exact L0 drew "4371 ÷ 5", which leaves 1 over — a row named for exact division served an inexact one, and the child who answers 874 is marked wrong` |

**Two assertions were found vacuous this way and rewritten.**

1. `delete "a miss inside a sustained window costs nothing"` originally produced **no failure at all**. The stride test's descent arm compared `service.position()` against `Math.max(0, Math.floor(expected))` and *both sides were clamped to rung 0* by six misses — two zeroes agreeing about nothing. Cut to three misses, with `assert.ok(expected > 0, "the arithmetic under test fell through the floor and is being clamped")` guarding the clamp, and a direct assertion on the `sit` branch.
2. `the tail cannot underflow the floor or overflow the top` asserted an exact equality between a child who missed at the top straight away and one who lingered twenty answers. Under a windowed gate the lingerer needs *more misses* to leave the sitting band, so the two arms compare different numbers of descending answers and the equality is no longer the claim. Replaced with what the clamp is actually for: no amount of lingering buys a child out of falling, and the delay it can buy is bounded by the window.

Two further tests were adjusted where the new rule made the *old* assertion wrong on correct code, both noted in the diff:

- `the stream a child is served stays inside the spread` bounded the served rung by `±SPREAD_ABOVE/BELOW`. It only ever held because the child it used settled mid-ladder; an 80% child now correctly walks to the floor, where the kernel *reflects* and legitimately serves rung 3 — three above the centre. Now read off `rungWeights` directly, which is the true statement of the property.
- `a child who is right four times in five settles, and stays settled` asserted that an 80% child comes to rest mid-ladder. That was #699's target and is under the founder's floor; it is now `a child at 90% sits, a child at 80% is walked down`.

## Verification

Node 24.18.0. `npm run tsc` (all three projects) clean, `npm run lint` clean, `npm test` **332/332 five times running**. `games/polarity` (the only pack that imports `items.ts` directly) 62/62.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
