### PR TITLE
dynawalla/games/lattice: the resonator asks for a factor tree, and the ship is the same ship on every screen

### DIFF
--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -315,13 +315,13 @@ src/
   render/         palette, scene, sparks
   render/hud.ts   where the chrome may be drawn: the safe area, minus two corners
   audio/audio.ts  asset-free Web Audio, C5–C6 pentatonic
-  test/           131 tests: rules, pacing, the ship, wiring, and the chrome
+  test/           132 tests: rules, pacing, the ship, wiring, and the chrome
 ```
 
 ## Tests
 
 ```
-npm test        131 tests
+npm test        132 tests
 npm run tsc     0 errors
 npm run build   the library build
 npm run build:pack   the pack build → dist-pack/

--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -62,12 +62,106 @@ street` relies on, and it is asserted exhaustively in `resonance.test.ts`.
 
 ---
 
+---
+
+## What the resonator needs from an item to be a game at all
+
+This is the pack's own answer to "it stays way too easy way too long", and it is
+not a pacing constant — it is a property of the item:
+
+> **A target the resonator can be itself on is a whole number from 12 to 999
+> whose prime factorisation has at least three factors, every one of them a prime
+> the game draws as a readable mote — or, one resonator in five, a prime of 13 or
+> more, which is the wall.**
+
+Three, not two. At one factor there is nothing to decompose and the game's second
+stage does not exist: `2 + 0 = 2` is a resonator with a single mote to find, which
+is what ten minutes of the shipped build felt like. At two — `15 → 3·5` — there is
+exactly one crack and no choice about which one, so "decide which primes multiply
+to it" is a formality. Three is the first count at which the child chooses an
+order, a husk comes apart twice, and the tile bar shows a tree instead of a fact.
+
+Readable, because `MOTE_PRIMES` has always said which primes are "small enough to
+be drawn as a drifting mote and read at speed" and it stops at 47 — while the old
+bar happily asked for `794`, whose factorisation is `2 · 397`. Three-digit answers
+are 65% factor trees and only 37% *readable* factor trees, which is the difference
+between `600 = 2·2·2·3·5·5` and `804 = 2·2·3·67`.
+
+`game/resonance.ts` holds all of it, and `resonance.test.ts` asserts exhaustively
+that nothing the game will ask for needs a mote it will not draw.
+
+### So the game asks for a floor, and then a ceiling
+
+`game/ladder.ts` is the whole of it. The shipped ladder is 66 rungs; generating
+items from every one of them puts THE LATTICE's usable band at **rungs 16 to 47**
+— below 16 the answers cannot carry a tree, above 47 they are four and five
+digits and do not fit on a resonator's face. The game opens at the floor, climbs
+three rungs a resonator and falls four on a refusal, and never asks outside the
+band.
+
+The floor is the interesting half, and it is the opposite of what `counterweight`
+needed. `raiseFloor` is deliberately *not* called: that primitive is for an
+achievement (`siege`'s wave counter) and would permanently rewrite a child's
+ladder for every other pack because of what this one can draw. The floor is
+expressed by simply never asking below it.
+
+A rung is a distribution and not a question, so an arming draws until it finds
+something with a tree in it, walking six rungs either side of its position, and
+**skips what it discards** — `host.skip` is feature-detected, because an
+unanswered question reported as wrong is a MISS on a question nobody was shown.
+Ten of the thirty-two rungs in the band produce nothing usable at all, so the
+ladder remembers which ones never pay and tries them last: measured against the
+shipped curriculum, 2.3 items a resonator instead of 2.6, and the barren rungs
+stop costing anything at all.
+
+An arming spends **six** draws and no more, which is not a taste decision: `next`
+is synchronous and the refill is not, so a request that moves the ladder flushes
+the host's pool down to a reserve of eight and refills asynchronously. An arming
+that fired all thirteen offsets in one frame ran the pool dry and started being
+handed clones of the last question *with an empty id*, whose answers the host then
+drops — a child solving a resonator nothing can be reported against. Six leaves the
+reserve intact; the walk is a thing that happens across armings, not inside one.
+
+And the game learns from `question.difficulty` — the rung that *answered* — rather
+than the rung it asked for, because the host serves the pooled question closest to
+a request and those differ often (104 of 175 draws in one measured session, by as
+much as nineteen rungs). Learning from the request would write live rungs off as
+barren and snap the position onto content the child never saw.
+
+Measured over ten minutes of perfect play, five seeds, against a host modelling
+the shipped difficulty wire:
+
+| | before | after |
+|---|---|---|
+| draws that named a difficulty | 0 of 270 | 1,650 of 1,650 |
+| rung reached (min / median / max) | 0 / 29 / 50 | 16 / 45 / 47 |
+| targets with a factor tree | 42% | 82% |
+| targets under 12 ("find a 2") | 21% | 0% |
+| time with no resonator at all | ~500s of every 600 | 8s in 3,000 |
+| first four targets | 5, 7, 10, 16 | 36, 40, 60, 98 |
+
+That "500s of every 600" is the half nobody had reported, because nobody had
+reached it: the host's own staircase carried the game *past* rung 47, every draw
+failed, and the arena stalled — permanently, because there was no retry, leaving
+the previous resonator hanging with its id already spent. A child could fly into
+that ring forever and the host would never hear another word.
+
+There is one case where the arena still finds nothing, and it is the first session
+of a brand new profile: the host warms its pool at *its* position, which for a new
+profile is rung 0, and the first request flushes that down to a reserve of eight
+`2 + 0`s. So a stall is now a wait rather than a session — it stocks the field with
+husks and motes so the passive layer still works, says so on the HUD, and asks
+again 2.5 seconds later, by which time the pool has refilled where it was asked to.
+
+---
+
 ## What is reported, and what is the game's own mathematics
 
-Following the `slice` precedent. Only the `add` curriculum domain is active
-(`alg`, `div`, `frac`, `mul`, `ns` are all `draft`), and `covers` is a request
-rather than an instruction — the host serves whole-number column arithmetic
-regardless. So:
+Following the `slice` precedent. `covers` is a request rather than an instruction
+and `domain` is a cosmetic label, so the host serves whichever rung the game asks
+for — and the shipped ladder interleaves `dw.add.*`, `dw.mul.*` and `dw.div.*`,
+all three of them active. A sitting crosses column addition, times tables and
+exact division, which is where the variety in the stream comes from. So:
 
 * **Reported:** the product the child asserted at the resonator, as a string,
   against the question id the resonator was carrying. Exact, integer, and
@@ -78,9 +172,10 @@ regardless. So:
   arithmetic the child performs with a trigger, not a question anybody asked.
 
 `pack.json` declares the seven **active** `dw.add.*` skills, each checked by hand
-against `packs/shared/curriculum/src/graph/domains/add.ts`. There is deliberately
-no `dw.mul.*` row: the multiplication domain is 100% `draft`, and declaring one
-would imply coverage the curriculum cannot serve.
+against `packs/shared/curriculum/src/graph/domains/add.ts`. It does not name the
+`dw.mul.*` and `dw.div.*` rows the ladder now also serves inside this game's
+band — `covers` is a claim about what the pack was authored against, and widening
+it is a curriculum decision rather than a consequence of the ladder having grown.
 
 Distractors are load-bearing rather than decorative. When a resonator is armed,
 the field is seeded with the primes of the answer **plus** the extra primes one
@@ -100,6 +195,63 @@ targets.
 | Touch | left thumb, anywhere on the left half | right thumb | tap the tile bar |
 | Keyboard | `WASD` | arrow keys, or `space` to fire straight ahead | `Escape` |
 | Mouse | `WASD` | the cursor aims, the button fires | tap the tile bar |
+
+### The ship, and why it was wild on Android specifically
+
+`render/scene.ts` says it plainly: the arena's coordinate space **is** CSS pixel
+space, with no camera and no transform. So the world is exactly as big as the
+viewport — and every speed in `arena.ts` was an absolute number of CSS pixels a
+second, chosen against a tablet. Measured:
+
+| | phone landscape 800×360 | phone portrait 390×740 | tablet 1180×820 |
+|---|---|---|---|
+| top speed, before | 597px/s = **0.68 diag/s** | 597px/s = **0.71 diag/s** | 597px/s = 0.42 diag/s |
+| top speed, after | 263px/s = 0.300 diag/s | 251px/s = 0.300 diag/s | 431px/s = 0.300 diag/s |
+
+The same ship covered **1.72× more of the screen per second on the phone than on
+the tablet it was tuned on**, and no single constant can fix that — lowering it makes
+the tablet sluggish. The ship's dynamics are now a fraction of the arena's own
+diagonal per second, so the felt speed is the same everywhere. Everything else
+that is a speed or a length in the arena moved onto the same scale with it.
+
+Two frame-rate defects behind that, both of the class `games/balance` found when
+its spring integrator reached −1.2×10²⁰⁴ at 20fps:
+
+| | 144fps | 60fps | 45fps | 30fps | 20fps |
+|---|---|---|---|---|---|
+| top speed, before | 610px/s | 597px/s | 590px/s | 577px/s | 556px/s |
+| coast, before | 143px | 137px | 134px | 128px | 119px |
+| shots that hit, before | 80/80 | 80/80 | 80/80 | 80/80 | **71/80** |
+| all three, after | identical to six decimal places, and 80/80 at every rate |
+
+A ninth of every shot passed through the husk it was aimed at on a slow Android: a
+shot steps 56px in a 50ms frame against a 58px hit window, and the arena was not
+substepped. The sheet already was, at 240Hz, for exactly this reason. The arena
+now runs one 60Hz world however fast the frame arrives — a slow frame is more
+small steps, not one big one — and the 120ms clamp is still there for the frame
+that arrives after a backgrounded minute.
+
+Substepping alone was not enough for the *speed*, and it is worth saying why the
+first attempt looked like it was. `ceil(dt / 16.67)` lands on a substep of exactly
+1/60s at 60, 30 **and** 20fps — the three rates anybody measures — so an iterated
+integrator agrees perfectly at all three and is still 2% fast at 45fps and 4% fast
+on the 120 and 144Hz panels every current flagship ships with. So the ship is now
+*solved* rather than stepped: `v' = k(V − v)` has a closed form, and using it makes
+the speed exact at any frame rate and any substep count. The substepping stays,
+because it is what stops a shot stepping over a husk.
+
+And two things that are taste rather than defect:
+
+* **The coast.** `620 / 4.2` was a 143px carry after the thumb came off, four and
+  a half times the 32px reach the ship sweeps a mote at, so a child could not
+  arrive at a mote — only pass over one and come back. The drag is now 7.4 and the
+  carry is 34px on a phone and 58px on a tablet.
+* **The stick.** `game/steer.ts` puts a tenth of the range under a dead zone —
+  a resting thumb's tremor used to be full-authority thrust — and bends the rest
+  so half deflection is 29% authority instead of 50%, which is where the slow,
+  accurate part of the stick came from. The direction is never touched.
+* **The hull** eases toward the aim over about 55ms instead of snapping to it. The
+  *guns* do not: a shooter whose bullets lag its stick lies.
 
 ---
 
@@ -150,7 +302,10 @@ src/
   mount.ts        canvas, clock, twin-stick input, event wiring
   core/rng.ts     mulberry32
   game/factor.ts     primes, splitting, husking — exact integers only
-  game/resonance.ts  the rule the whole learning claim rests on
+  game/resonance.ts  the rule the whole learning claim rests on, and what a
+                     target has to be for the game to be a game about it
+  game/ladder.ts     what the game asks the host for: the band, and the walk
+  game/steer.ts      what a thumb means: a dead zone and a response curve
   game/bank.ts       the hold, and the factor tile bar
   game/arena.ts      the rules: husks, motes, the ship, the resonator
   game/best.ts       the longest chain, guarded for a pack frame
@@ -158,13 +313,13 @@ src/
   render/         palette, scene, sparks
   render/hud.ts   where the chrome may be drawn: the safe area, minus two corners
   audio/audio.ts  asset-free Web Audio, C5–C6 pentatonic
-  test/           94 tests: rules, wiring, and where the chrome lands
+  test/           131 tests: rules, pacing, the ship, wiring, and the chrome
 ```
 
 ## Tests
 
 ```
-npm test        94 tests
+npm test        131 tests
 npm run tsc     0 errors
 npm run build   the library build
 npm run build:pack   the pack build → dist-pack/
@@ -175,7 +330,24 @@ The ones that matter:
 * `resonance.test.ts` — a target is cleared **only** by a genuine prime
   factorisation of it (exhaustive over every multiset of small primes to six
   tiles against every target to 200); a prime target cannot be assembled from
-  smaller factors (exhaustive); an empty hold asserts nothing.
+  smaller factors (exhaustive); an empty hold asserts nothing; and — exhaustively
+  over every target to 999 — nothing the game will ask for needs a mote it will
+  not draw.
+* `pacing.test.ts` — **the founder's ten minutes, as a measurement.** A bot that
+  does the arithmetic perfectly plays the real arena against a host modelling the
+  shipped sixty-six-rung wire, and the assertions are about what it was *asked*:
+  every draw names a difficulty, the first question of a session already has a
+  factor tree in it, nothing under twelve is ever asked for, the stream climbs,
+  and the arena is never left without a question. Each case **verified to fail**
+  with the request reverted to `next({ domain: "add" })`.
+* `ladder.test.ts` — the floor, the ceiling, the climb, the walk, and the memory
+  of which rungs never pay.
+* `ship.test.ts` — the ship covers the same fraction of the screen on a phone and
+  a tablet, behaves identically at 60/30/20fps, can stop inside two sweeps of a
+  mote, and hits what it shoots at every frame rate. **Verified to fail** with the
+  old constants and with the substepping removed.
+* `steer.test.ts` — a resting thumb moves nothing, half the stick is under a third
+  of the authority, and the curve never bends the direction.
 * `bank.test.ts` — the tile bar is a true factorisation of the value beside it
   after **every** operation on **every** path, over a four-thousand-step seeded
   sitting.

--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -248,8 +248,10 @@ And two things that are taste rather than defect:
   carry is 34px on a phone and 58px on a tablet.
 * **The stick.** `game/steer.ts` puts a tenth of the range under a dead zone —
   a resting thumb's tremor used to be full-authority thrust — and bends the rest
-  so half deflection is 29% authority instead of 50%, which is where the slow,
-  accurate part of the stick came from. The direction is never touched.
+  so the stick reads 4 / 23 / 56 / 100% authority at a quarter, half, three
+  quarters and full deflection, against a straight line's 25 / 50 / 75 / 100. That
+  is where the slow, accurate part of the stick came from. The direction is never
+  touched, only the magnitude.
 * **The hull** eases toward the aim over about 55ms instead of snapping to it. The
   *guns* do not: a shooter whose bullets lag its stick lies.
 

--- a/dynawalla/games/lattice/src/contract.ts
+++ b/dynawalla/games/lattice/src/contract.ts
@@ -26,8 +26,29 @@ export type Question = {
 }
 
 export type Host = {
-  next(opts?: { domain?: string; difficulty?: number }): Question
+  /**
+   * The next question.
+   *
+   * `difficulty` is a 0..1 position on the host's whole ladder and
+   * `maxDifficulty` a ceiling on the same scale. THE LATTICE names both on every
+   * single draw — see `game/ladder.ts` for why a game that names neither is a
+   * game that ends up asking a child to find a 2.
+   */
+  next(opts?: { domain?: string; difficulty?: number; maxDifficulty?: number }): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  /**
+   * The child was never shown this one. Close it and record nothing.
+   *
+   * OPTIONAL and feature-detected, like `transition` — the real runtime has it
+   * and a stub host need not. It is load-bearing here rather than tidy: a
+   * resonator can only be a game about a target with a factor tree in it, so an
+   * arming draws until it finds one, and the draws it discards would otherwise
+   * sit open in the host's ledger with a child's record filling up with items
+   * nobody was ever shown. `report` cannot stand in for it — an unanswered
+   * question reported as wrong is a MISS, and the ladder steps down for a
+   * question the child never saw.
+   */
+  skip?(questionId: string): void
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean
 

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -20,6 +20,7 @@ import { Bank } from "./bank.ts"
 import type { Host, Question } from "../contract.ts"
 import type { Rng } from "../core/rng.ts"
 import {
+  LARGEST_MOTE_PRIME,
   MOTE_PRIMES,
   huskify,
   isPrime,
@@ -27,13 +28,40 @@ import {
   primeFactors,
   splitPair,
 } from "./factor.ts"
-import { isAskable, resonate } from "./resonance.ts"
+import { CEILING, FLOOR, Ladder, rungOf } from "./ladder.ts"
+import {
+  isAskable,
+  isResonant,
+  isSmooth,
+  MIN_TARGET,
+  MIN_WALL,
+  resonate,
+  tileCount,
+} from "./resonance.ts"
 
 /** The largest value a resonator will ask for. See `resonance.isAskable`. */
 export const MAX_TARGET = 999
 
-/** How many questions to draw looking for one a resonator can honestly ask. */
-const DRAW_ATTEMPTS = 8
+/**
+ * How often a prime target — the wall — comes round.
+ *
+ * One resonator in five. The wall is the property the whole game stands on and
+ * it must not be deleted, but a prime has no factor tree, so an unrationed
+ * stream of them is a fifth of the session spent hunting one mote. See
+ * `resonance.MIN_WALL`.
+ */
+const WALL_EVERY = 5
+
+/**
+ * How long the arena waits before trying to arm again after finding nothing.
+ *
+ * The old code had no retry at all: one barren draw set `stalled` and the arena
+ * never asked again for the rest of the session, leaving the *previous*
+ * resonator hanging with its id already spent — so a child could keep flying
+ * into a ring that reported nothing, forever, and the only sign was one line on
+ * a console nobody was reading.
+ */
+const REARM_MS = 2500
 
 /** Radii in arena units. The arena is nominally about 1000 units wide. */
 export const SHIP_R = 15
@@ -42,15 +70,102 @@ export const HUSK_R = 24
 export const RESONATOR_R = 46
 export const SHOT_R = 5
 
-/** Speeds, in arena units per second. */
-const SHIP_ACCEL = 2600
-const SHIP_DRAG = 4.2
-const SHIP_MAX = 620
-const SHOT_SPEED = 1150
+/**
+ * The arena's own size, as a diagonal, at which one unit of "span per second"
+ * is one arena unit per second.
+ *
+ * **This is the Android bug, and it is not tuning.** `render/scene.ts` says it
+ * plainly: "the arena's coordinate space *is* CSS pixel space — `mount.ts`
+ * resizes the arena to the element". There is no camera and no transform, so the
+ * world is exactly as big as the viewport — and every speed in this file used to
+ * be an absolute number of CSS pixels per second, chosen against a tablet. The
+ * comment above even says so: "the arena is nominally about 1000 units wide".
+ *
+ * A phone is not. An Android phone in portrait is about 390×740 CSS pixels, a
+ * diagonal of 836 against a tablet's 1437 — and the ship's measured top speed was
+ * 597px/s on both, which is 0.71 of the phone's whole world a second against 0.42
+ * of the tablet's. **The same ship covered 1.72× more screen per second on the
+ * phone.** It was not misbehaving on Android; it was moving at tablet speed through
+ * a world 58% the size. Nothing about that is fixable by lowering a constant,
+ * because lowering it would then make the tablet sluggish.
+ *
+ * So the ship's dynamics are now stated as a fraction of the arena's own
+ * diagonal per second, and the felt speed is the same on every screen. The
+ * reference is the diagonal of a 1180×820 tablet, which is what the numbers were
+ * tuned against, so a tablet keeps the size of number it had.
+ */
+const REFERENCE_SPAN = Math.hypot(1180, 820)
+
+/**
+ * The ship, in arena diagonals per second and per second squared.
+ *
+ * `SHIP_SPAN_PER_SEC` is the top speed and `SHIP_DRAG` is how hard it is held
+ * to it. There is no acceleration constant: `step` solves `v' = k(V − v)` in
+ * closed form, so the speed the stick asks for *is* the steady state and the
+ * clamp only ever catches the kick from a jostle. Two numbers instead of three,
+ * and no way for them to disagree.
+ *
+ * **What changed and why.** It was `SHIP_ACCEL 2600`, `SHIP_DRAG 4.2`,
+ * `SHIP_MAX 620`, which measured as a 143px coast after the thumb comes off —
+ * four and a half times the 32px reach the ship sweeps a mote at. A child could
+ * not stop on a mote; they could only pass over one and come back. That is what
+ * "moves around too wildly" is, mechanically. The drag is now 7.4, a time constant
+ * of 135ms, and the measured coast is 58px on a tablet and 34px on a phone —
+ * inside two sweeps of the thing you were aiming at, on both.
+ */
+const SHIP_SPAN_PER_SEC = 0.3
+const SHIP_DRAG = 7.4
+
+/** Everything else that is a speed or a length, on the same scale. */
+const SHOT_SPAN_PER_SEC = 0.78
+const DRIFT_MIN_SPAN = 0.021
+const DRIFT_MAX_SPAN = 0.077
+/** The shove a jostle gives the ship, and the one it gives the husk. */
+const JOSTLE_SPAN = 0.18
+const JOSTLE_HUSK_SPAN = 0.083
+/** The shove a shot gives a prime, which is the reward for noticing it cannot split. */
+const WALL_SHOVE_SPAN = 0.063
+
 const SHOT_LIFE_MS = 1400
 const FIRE_COOLDOWN_MS = 110
-const DRIFT_MIN = 30
-const DRIFT_MAX = 110
+
+/**
+ * The step the world is simulated at, however fast the frame arrives.
+ *
+ * A sibling pack (`games/balance`) had a spring integrator that was stable above
+ * 31fps and reached −1.2×10²⁰⁴ at 20fps, and the fix was substepping rather than
+ * clamping. This game's sheet (`sim/grid.ts`) was already substepped at 240Hz for
+ * that reason. The arena was not, and it had the same *class* of defect in a
+ * quieter form:
+ *
+ *   * **Shots tunnelled.** A shot travels 0.78 diagonals a second, which on a
+ *     tablet is 1120 units — 56 units in one 50ms frame, against a hit window of
+ *     `SHOT_R + HUSK_R` = 29 units either side, which is a 58px window against a
+ *     56px step. At 60fps a shot cannot miss a husk it is aimed at; at 20fps,
+ *     measured over sixty runs at three viewports, nine of every eighty stepped
+ *     straight over it. "My shots don't hit" on a slow Android is not the aim.
+ *   * **And the ship's own speed drifted with the frame rate**: 610px/s at 144fps
+ *     against 556px/s at 20fps — a spread of 9.7% — and a coast of 143px against
+ *     119px, because `v += a·dt` then `v *= e^(−k·dt)` is only exact in the limit.
+ *     That half is fixed by solving the ship rather than stepping it; see `step`.
+ *
+ * Sixteen and two thirds of a millisecond, capped at eight substeps so a frame
+ * that arrives after a minute is not a hundred and twenty of them.
+ */
+const SUBSTEP_MS = 1000 / 60
+const MAX_SUBSTEPS = 8
+
+/**
+ * How fast the drawn nose turns toward where the guns are pointed, per second.
+ *
+ * The guns are instant — a shooter whose bullets lag the stick is a shooter that
+ * lies — but the *hull* used to snap to the aim vector on the frame it changed,
+ * which is a large part of what reads as wild. Eighteen per second is a 55ms
+ * time constant: fast enough that the nose is never pointing anywhere the shots
+ * are not, slow enough that a thumb sliding round the right stick turns the ship
+ * instead of flicking it.
+ */
+const FACING_TURN_PER_SEC = 18
 
 /** How long a refused resonator stays dim before it will listen again. */
 const REFUSE_COOLDOWN_MS = 900
@@ -117,7 +232,7 @@ export type ArenaEvent =
   | { kind: "arrive"; at: Vec; target: number; prompt: string }
   | { kind: "stalled" }
 
-export type ArenaOptions = { width: number; height: number }
+export type ArenaOptions = { width: number; height: number; domain?: string }
 
 export class Arena {
   readonly bank = new Bank()
@@ -132,10 +247,23 @@ export class Arena {
   chain = 0
   stalled = false
 
+  /** Where the game is standing on the host's ladder. See `ladder.ts`. */
+  readonly ladder = new Ladder()
+
   private width: number
   private height: number
   private nextId = 1
   private aim: Vec = { x: 1, y: 0 }
+  /**
+   * The drawn nose, as an angle, easing toward `aim`. The guns never wait for it.
+   *
+   * An angle rather than a vector, and that is not a style choice: easing a
+   * *vector* toward its own negation walks it into the origin and back out
+   * pointing the way it came, so a ship told to turn round would freeze facing
+   * forward. A thumb sweeping across the right stick passes through exactly that
+   * every time it crosses the far side.
+   */
+  private faceAngle = 0
   private move: Vec = { x: 0, y: 0 }
   private cooldownMs = 0
   private graceMs = 0
@@ -144,6 +272,12 @@ export class Arena {
   private pausedAt = 0
   /** Wall-clock mark the current resonator was armed at, shifted over a pause. */
   private askedAt = 0
+  /** Resonators armed since the last wall, so a prime target is rationed. */
+  private sinceWall = 0
+  /** Counts down after a barren arming, then the arena tries again. */
+  private rearmMs = 0
+  /** The domain label the resonator's questions are drawn under. */
+  private readonly domain: string
 
   private readonly host: Host
   private readonly rng: Rng
@@ -151,10 +285,31 @@ export class Arena {
   constructor(host: Host, rng: Rng, options: ArenaOptions) {
     this.host = host
     this.rng = rng
-    this.width = Math.max(320, options.width)
-    this.height = Math.max(320, options.height)
+    this.domain = options.domain ?? "add"
+    this.width = Math.max(320, Number.isFinite(options.width) ? options.width : 320)
+    this.height = Math.max(320, Number.isFinite(options.height) ? options.height : 320)
     this.ship.x = this.width / 2
     this.ship.y = this.height * 0.72
+  }
+
+  /**
+   * The arena's own diagonal, which every speed in this file is a fraction of.
+   *
+   * See `REFERENCE_SPAN`: the world is exactly as big as the viewport, so a
+   * speed that is not measured against it is a different speed on every device.
+   */
+  private get span(): number {
+    return Math.hypot(this.width, this.height) / REFERENCE_SPAN
+  }
+
+  /** Top speed, in arena units per second, on this screen. */
+  get shipMax(): number {
+    return SHIP_SPAN_PER_SEC * REFERENCE_SPAN * this.span
+  }
+
+  /** How far the ship carries after the thumb comes off, in arena units. */
+  get shipCoast(): number {
+    return this.shipMax / SHIP_DRAG
   }
 
   // ── the frame ────────────────────────────────────────────────────────────
@@ -164,6 +319,13 @@ export class Arena {
   }
 
   resize(width: number, height: number): void {
+    // A non-finite box would make every speed in the arena `NaN` on the next
+    // frame and every collision test false for the rest of the session. A
+    // `ResizeObserver` on a detached element is the shape that produces one.
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+      console.error("[lattice] resize to a box that is not a box", width, height)
+      return
+    }
     this.width = Math.max(320, width)
     this.height = Math.max(320, height)
     const clamp = (p: { x: number; y: number }, r: number): void => {
@@ -205,31 +367,56 @@ export class Arena {
 
   // ── input ────────────────────────────────────────────────────────────────
 
+  /**
+   * The left stick. Magnitude 0..1; anything longer is normalised.
+   *
+   * A non-finite component is refused loudly rather than stored. This is the one
+   * input on the ship that had no guard, and it is not hypothetical bookkeeping:
+   * `move` is multiplied into the ship's velocity every substep, so a single
+   * `NaN` reaching here puts the ship's position beyond recovery for the rest of
+   * the session — `dist2` then returns `NaN`, every `<` against it is false, and
+   * nothing can be swept or struck again. Silent, total, and unreported.
+   */
   setMove(x: number, y: number): void {
     if (this.paused) return
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      console.error("[lattice] setMove was given something that is not a direction", x, y)
+      return
+    }
     const m = Math.hypot(x, y)
     this.move = m > 1 ? { x: x / m, y: y / m } : { x, y }
   }
 
   setAim(x: number, y: number): void {
     if (this.paused) return
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      console.error("[lattice] setAim was given something that is not a direction", x, y)
+      return
+    }
     const m = Math.hypot(x, y)
     if (m > 1e-6) this.aim = { x: x / m, y: y / m }
   }
 
+  /** Where the guns point. Instant, because a shooter that lags its stick lies. */
   get aiming(): Vec {
     return this.aim
+  }
+
+  /** Where the hull points. Eases toward `aiming`; only the renderer reads it. */
+  get facing(): Vec {
+    return { x: Math.cos(this.faceAngle), y: Math.sin(this.faceAngle) }
   }
 
   fire(): ArenaEvent[] {
     if (this.paused || this.cooldownMs > 0) return []
     this.cooldownMs = FIRE_COOLDOWN_MS
+    const shotSpeed = SHOT_SPAN_PER_SEC * REFERENCE_SPAN * this.span
     this.shots.push({
       id: this.nextId++,
       x: this.ship.x + this.aim.x * (SHIP_R + 4),
       y: this.ship.y + this.aim.y * (SHIP_R + 4),
-      vx: this.aim.x * SHOT_SPEED + this.ship.vx * 0.3,
-      vy: this.aim.y * SHOT_SPEED + this.ship.vy * 0.3,
+      vx: this.aim.x * shotSpeed + this.ship.vx * 0.3,
+      vy: this.aim.y * shotSpeed + this.ship.vy * 0.3,
       life: SHOT_LIFE_MS,
     })
     return [{ kind: "fire", at: { x: this.ship.x, y: this.ship.y } }]
@@ -272,8 +459,9 @@ export class Arena {
       // works this out can herd a 13 across the arena with their gun, which is
       // the reward for noticing that primes do not go.
       const m = Math.hypot(body.vx, body.vy) || 1
-      body.vx += (body.vx / m) * 90
-      body.vy += (body.vy / m) * 90
+      const shove = WALL_SHOVE_SPAN * REFERENCE_SPAN * this.span
+      body.vx += (body.vx / m) * shove
+      body.vy += (body.vy / m) * shove
       return [{ kind: "wall", at, value: body.value }]
     }
 
@@ -315,10 +503,12 @@ export class Arena {
       const dx = this.ship.x - body.x
       const dy = this.ship.y - body.y
       const m = Math.hypot(dx, dy) || 1
-      this.ship.vx += (dx / m) * 260
-      this.ship.vy += (dy / m) * 260
-      body.vx -= (dx / m) * 120
-      body.vy -= (dy / m) * 120
+      const kick = JOSTLE_SPAN * REFERENCE_SPAN * this.span
+      const shove = JOSTLE_HUSK_SPAN * REFERENCE_SPAN * this.span
+      this.ship.vx += (dx / m) * kick
+      this.ship.vy += (dy / m) * kick
+      body.vx -= (dx / m) * shove
+      body.vy -= (dy / m) * shove
       return [{ kind: "jostle", at, lost }]
     }
 
@@ -366,7 +556,8 @@ export class Arena {
     // Once per question. A refusal spends the id — the resonator stays as a
     // goal the child can still open, but the host hears one answer, which is
     // the only honest reading of "what did they say when they were asked".
-    if (!res.reported) {
+    const first = !res.reported
+    if (first) {
       res.reported = true
       this.host.report({
         questionId: res.questionId,
@@ -379,6 +570,15 @@ export class Arena {
     if (verdict.kind === "refuse") {
       res.cooldown = REFUSE_COOLDOWN_MS
       this.chain = 0
+      // Down further than up — and only on the answer the host actually heard.
+      //
+      // The second wrong hold carried into the same ring is a real thing the child
+      // did, but it is not a second wrong *answer*: the id was spent on the first
+      // one and nothing after it is reported. Moving the position on every one of
+      // them would let a bump-loop walk the whole band down in about seven
+      // seconds, with the game's idea of where the child is drifting away from the
+      // host's for questions the host never received.
+      if (first) this.ladder.refused()
       // The hold comes back onto the field rather than evaporating. The child
       // keeps every mote they worked for; what they spend is the trip.
       const back = this.bank.release()
@@ -390,6 +590,7 @@ export class Arena {
     const tiles = this.bank.release()
     this.opened += 1
     this.chain += 1
+    this.ladder.opened()
     this.host.haptic("success")
     const events: ArenaEvent[] = [{ kind: "open", at, target: res.target, tiles }]
     // Only ever after something the child finished. Never after a refusal.
@@ -409,10 +610,23 @@ export class Arena {
    */
   step(dtMs: number): ArenaEvent[] {
     if (this.paused) return []
-    const dt = Math.min(120, Math.max(0, dtMs)) / 1000
-    if (dt === 0) return []
+    if (!Number.isFinite(dtMs)) {
+      // `Math.min(120, Math.max(0, NaN))` is `NaN`, and `NaN !== 0`, so the old
+      // guard let one through — and one is enough: every position in the arena
+      // becomes `NaN` and stays that way, with nothing thrown and nothing drawn
+      // in the right place again.
+      console.error("[lattice] step was handed a delta that is not a number", dtMs)
+      return []
+    }
+    const clamped = Math.min(120, Math.max(0, dtMs))
+    if (clamped === 0) return []
     const events: ArenaEvent[] = []
 
+    // Timers advance on the *unclamped* delta and the world on the clamped one,
+    // and that difference is deliberate: a sheet held for a minute should have
+    // burned a refusal's 900ms of dim, but must not teleport a husk across the
+    // arena. `pause`/`resume` cover a sheet the host raised; this covers a
+    // backgrounded tab, which the pack is never told about.
     this.cooldownMs = Math.max(0, this.cooldownMs - dtMs)
     this.graceMs = Math.max(0, this.graceMs - dtMs)
     this.sweepGraceMs = Math.max(0, this.sweepGraceMs - dtMs)
@@ -420,77 +634,116 @@ export class Arena {
       this.resonator.cooldown = Math.max(0, this.resonator.cooldown - dtMs)
       this.resonator.age += dtMs
     }
+    if (this.rearmMs > 0) this.rearmMs = Math.max(0, this.rearmMs - dtMs)
 
-    // The ship.
-    this.ship.vx += this.move.x * SHIP_ACCEL * dt
-    this.ship.vy += this.move.y * SHIP_ACCEL * dt
-    const drag = Math.exp(-SHIP_DRAG * dt)
-    this.ship.vx *= drag
-    this.ship.vy *= drag
-    const speed = Math.hypot(this.ship.vx, this.ship.vy)
-    if (speed > SHIP_MAX) {
-      this.ship.vx = (this.ship.vx / speed) * SHIP_MAX
-      this.ship.vy = (this.ship.vy / speed) * SHIP_MAX
-    }
-    this.ship.x += this.ship.vx * dt
-    this.ship.y += this.ship.vy * dt
-    this.bounce(this.ship, SHIP_R, 0.4)
+    // One 60Hz world, however fast the frame arrives. See `SUBSTEP_MS`.
+    const steps = Math.min(MAX_SUBSTEPS, Math.max(1, Math.ceil(clamped / SUBSTEP_MS)))
+    const h = clamped / steps / 1000
+    const shipMax = this.shipMax
+    const driftMin = DRIFT_MIN_SPAN * REFERENCE_SPAN * this.span
+    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span
+    const decay = Math.exp(-SHIP_DRAG * h)
+    const turn = 1 - Math.exp(-FACING_TURN_PER_SEC * h)
 
-    // Bodies.
-    for (const body of this.bodies) {
-      body.age += dtMs
-      body.x += body.vx * dt
-      body.y += body.vy * dt
-      this.bounce(body, body.prime ? MOTE_R : HUSK_R, 1)
-      // Drifting husks slow to a readable pace rather than pinballing forever.
-      const s = Math.hypot(body.vx, body.vy)
-      if (s > DRIFT_MAX) {
-        const k = Math.exp(-2.2 * dt)
-        body.vx *= k
-        body.vy *= k
-      } else if (s < DRIFT_MIN && s > 1e-6) {
-        body.vx *= 1 + 1.5 * dt
-        body.vy *= 1 + 1.5 * dt
+    for (let n = 0; n < steps; n++) {
+      // The ship, solved rather than stepped.
+      //
+      // `v' = k(V − v)` where `V` is the speed the stick is asking for has a
+      // closed form, and using it makes the ship *exactly* frame-rate independent
+      // rather than nearly so. Substepping alone is not: `ceil(dt / 16.67)` gives
+      // a substep of exactly 1/60s at 60, 30 and 20fps — the three rates anybody
+      // measures — and 1/90s at 45fps, so an iterated integrator that agreed
+      // perfectly at those three still ran 2% fast at 45 and 4% fast on a 144Hz
+      // screen. Every current flagship is a 120 or 144Hz screen. The substepping
+      // stays, because it is what stops a shot stepping over a husk; this is what
+      // stops the ship's speed depending on the panel.
+      const wantX = this.move.x * shipMax
+      const wantY = this.move.y * shipMax
+      const wasX = this.ship.vx - wantX
+      const wasY = this.ship.vy - wantY
+      this.ship.x += wantX * h + (wasX * (1 - decay)) / SHIP_DRAG
+      this.ship.y += wantY * h + (wasY * (1 - decay)) / SHIP_DRAG
+      this.ship.vx = wantX + wasX * decay
+      this.ship.vy = wantY + wasY * decay
+      // The clamp cannot fire from flying — the steady state *is* `shipMax` now,
+      // exactly — so this only ever catches the kick from a jostle.
+      const speed = Math.hypot(this.ship.vx, this.ship.vy)
+      if (speed > shipMax) {
+        this.ship.vx = (this.ship.vx / speed) * shipMax
+        this.ship.vy = (this.ship.vy / speed) * shipMax
       }
-    }
+      this.bounce(this.ship, SHIP_R, 0.4)
 
-    if (this.resonator) {
-      this.resonator.x += this.resonator.vx * dt
-      this.resonator.y += this.resonator.vy * dt
-      this.bounce(this.resonator, RESONATOR_R, 1)
-    }
+      // The drawn nose, easing toward the guns. Never the guns themselves, and
+      // never through the origin — see `faceAngle`.
+      const want = Math.atan2(this.aim.y, this.aim.x)
+      let delta = want - this.faceAngle
+      while (delta > Math.PI) delta -= Math.PI * 2
+      while (delta < -Math.PI) delta += Math.PI * 2
+      this.faceAngle += delta * turn
 
-    // Shots, and what they hit.
-    for (let i = this.shots.length - 1; i >= 0; i--) {
-      const shot = this.shots[i] as Shot
-      shot.life -= dtMs
-      shot.x += shot.vx * dt
-      shot.y += shot.vy * dt
-      if (
-        shot.life <= 0 ||
-        shot.x < -40 ||
-        shot.y < -40 ||
-        shot.x > this.width + 40 ||
-        shot.y > this.height + 40
-      ) {
+      // Bodies.
+      for (const body of this.bodies) {
+        body.age += h * 1000
+        body.x += body.vx * h
+        body.y += body.vy * h
+        this.bounce(body, body.prime ? MOTE_R : HUSK_R, 1)
+        // Drifting husks slow to a readable pace rather than pinballing forever.
+        const s = Math.hypot(body.vx, body.vy)
+        if (s > driftMax) {
+          const k = Math.exp(-2.2 * h)
+          body.vx *= k
+          body.vy *= k
+        } else if (s < driftMin && s > 1e-6) {
+          body.vx *= 1 + 1.5 * h
+          body.vy *= 1 + 1.5 * h
+        }
+      }
+
+      if (this.resonator) {
+        this.resonator.x += this.resonator.vx * h
+        this.resonator.y += this.resonator.vy * h
+        this.bounce(this.resonator, RESONATOR_R, 1)
+      }
+
+      // Shots, and what they hit.
+      for (let i = this.shots.length - 1; i >= 0; i--) {
+        const shot = this.shots[i] as Shot
+        shot.life -= h * 1000
+        shot.x += shot.vx * h
+        shot.y += shot.vy * h
+        if (
+          shot.life <= 0 ||
+          shot.x < -40 ||
+          shot.y < -40 ||
+          shot.x > this.width + 40 ||
+          shot.y > this.height + 40
+        ) {
+          this.shots.splice(i, 1)
+          continue
+        }
+        const hit = this.bodies.find(
+          (b) => dist2(shot, b) < (SHOT_R + (b.prime ? MOTE_R : HUSK_R)) ** 2,
+        )
+        if (!hit) continue
         this.shots.splice(i, 1)
-        continue
+        events.push(...this.strike(hit.id))
       }
-      const hit = this.bodies.find(
-        (b) => dist2(shot, b) < (SHOT_R + (b.prime ? MOTE_R : HUSK_R)) ** 2,
-      )
-      if (!hit) continue
-      this.shots.splice(i, 1)
-      events.push(...this.strike(hit.id))
-    }
 
-    // The ship, and what it reaches. A copy of the id list, because `touch`
-    // mutates `bodies` and a live iteration would skip its neighbour.
-    for (const id of this.bodies.map((b) => b.id)) {
-      const body = this.bodies.find((b) => b.id === id)
-      if (!body) continue
-      const reach = (SHIP_R + (body.prime ? MOTE_R : HUSK_R)) ** 2
-      if (dist2(this.ship, body) < reach) events.push(...this.touch(id))
+      // The ship, and what it reaches.
+      //
+      // Backwards, and that is load-bearing rather than a habit: `touch` splices
+      // the body it swept out of this array and `scatter` can push new ones onto
+      // the end, so a forward loop would skip the neighbour of anything it took
+      // and revisit a mote it had just handed back. Going down, a removal is
+      // always at the index we are on and everything below it is untouched — and
+      // unlike the id-snapshot this replaces, it allocates nothing, which matters
+      // now that the loop runs up to eight times a frame.
+      for (let i = this.bodies.length - 1; i >= 0; i--) {
+        const body = this.bodies[i] as Body
+        const reach = (SHIP_R + (body.prime ? MOTE_R : HUSK_R)) ** 2
+        if (dist2(this.ship, body) < reach) events.push(...this.touch(body.id))
+      }
     }
 
     return events
@@ -504,32 +757,126 @@ export class Arena {
   // ── seeding ──────────────────────────────────────────────────────────────
 
   /**
+   * The arena is without a question and the wait is up. Try again.
+   *
+   * The shell calls this every frame; it is a no-op unless there is nothing to
+   * answer. The clock comes from the shell, like every other clock in this file.
+   */
+  rearm(now: number): ArenaEvent[] {
+    if (this.paused || this.resonator !== null || this.rearmMs > 0) return []
+    return this.arm(now)
+  }
+
+  /**
    * Draw a question, hang a resonator on it, and stock the field with husks
    * that come apart into exactly the primes its answer needs — plus the primes
    * behind one of the host's mal-rule answers, so a child who drops a carry can
    * assemble their own mistake and the misconception routes back to the host.
+   *
+   * **This is where the game says what it needs.** It used to be one line:
+   *
+   *     const drawn = this.host.next({ domain: "add" })
+   *
+   * A cosmetic label and never a difficulty, so the resonator carried whatever
+   * rung the host's ladder was standing on — rung 0 at the start of a session,
+   * which is `2 + 0`. See `ladder.ts` for the whole argument and the measured
+   * band. Three things happen here now:
+   *
+   *   1. **Every draw names a difficulty and a ceiling**, walking outward from
+   *      the game's position until one lands.
+   *   2. **The bar is `isResonant` and not `isAskable`** — a target with a factor
+   *      tree in it, because a target without one is not this game.
+   *   3. **A draw that is not used is skipped, not abandoned.** `host.skip` is
+   *      feature-detected; without it, a discarded question would sit open in the
+   *      host's ledger forever and the child's record would fill with items
+   *      nobody was ever shown.
    */
   private arm(now: number): ArenaEvent[] {
     this.askedAt = now
+    const wall = this.sinceWall >= WALL_EVERY - 1
     let question: Question | null = null
-    for (let i = 0; i < DRAW_ATTEMPTS; i++) {
-      const drawn = this.host.next({ domain: "add" })
-      const target = Number(drawn.answer)
-      if (isAskable(target, MAX_TARGET)) {
-        question = drawn
+    let landedAt = this.ladder.at
+    const drawn: Array<{ question: Question; difficulty: number }> = []
+    for (const request of this.ladder.requests(this.domain)) {
+      const q = this.host.next(request)
+      // **The rung that answered, not the rung that was asked for.**
+      //
+      // `host.next` serves the pooled question *closest* to the request, and the
+      // pool was stocked for whatever came before it — so the two differ, often
+      // and by a lot. Measured against the real adapter over one session: 104 of
+      // 175 draws came from a rung other than the one named, by as much as
+      // nineteen. Learning from the request would therefore write live rungs off
+      // as barren and snap `landed()` onto a rung the child never saw, which is
+      // the whole mechanism that makes `FLOOR` a hint rather than a dependency.
+      //
+      // `items.ts` puts this number on the question for exactly this reason:
+      // "so the pack is told what it got and not what it asked for."
+      const served = Number.isFinite(q.difficulty) ? q.difficulty : request.difficulty
+      drawn.push({ question: q, difficulty: served })
+      const hit = isResonant(Number(q.answer), MAX_TARGET, { wall })
+      // Remembered either way: ten of the thirty-two rungs in the band produce
+      // nothing this game can use. See `ladder.BARREN`.
+      this.ladder.drew(rungOf(served), hit)
+      if (hit) {
+        question = q
+        landedAt = served
         break
       }
     }
+
+    // Nothing in the band was what the game wants. Rather than stall, take the
+    // best of what was already drawn — no extra item is spent on this. A rung is
+    // a distribution, and asking eight times for a factor tree and getting eight
+    // primes is unlucky rather than broken; a wall early, or a two-tile hold, is
+    // a worse round than the game aims for and a far better one than no round.
     if (!question) {
-      // Nothing the resonator could honestly ask for. The arena stays playable
-      // — husks still crack, primes still sweep — and this is loud.
+      const best = this.bestOf(drawn.map((d) => d.question))
+      if (best) {
+        question = best
+        landedAt = drawn.find((d) => d.question.id === best.id)?.difficulty ?? landedAt
+      }
+    }
+
+    // Whatever was drawn and not used is closed rather than left hanging. A skip
+    // records nothing, moves no ladder and produces no outcome, which is exactly
+    // what "the child was never shown this" should look like in the ledger.
+    for (const entry of drawn) {
+      if (entry.question.id !== question?.id) this.host.skip?.(entry.question.id)
+    }
+
+    if (!question) {
+      // Nothing in the whole band the resonator could be a game about. The arena
+      // stays playable — husks still crack, primes still sweep — and it tries
+      // again in a few seconds rather than never asking for anything ever again,
+      // which is what it used to do.
       this.stalled = true
-      console.error("[lattice] no askable target in", DRAW_ATTEMPTS, "draws")
+      this.rearmMs = REARM_MS
+      this.resonator = null
+      // And the field is stocked if it is bare, which is the difference between
+      // "the arena stays playable" being true and being a comment.
+      //
+      // The case that made this necessary is the one that matters most: a brand
+      // new profile. The host warms its pool at *its* position, which for a fresh
+      // profile is rung 0 — answers of one to three — and the first request this
+      // game makes flushes that pool down to a reserve of eight of them. Every
+      // draw of the first arming is then a `2 + 0`, nothing is resonant, and the
+      // arena stalls on the very first frame of the very first session, before
+      // `arm` has reached the line that puts anything on the screen. Without this
+      // the child's first two and a half seconds of THE LATTICE is an empty grid.
+      if (this.bodies.length === 0) this.stockPassiveField()
+      console.error(
+        "[lattice] no resonant target anywhere in the band; retrying in",
+        REARM_MS,
+        "ms",
+      )
       return [{ kind: "stalled" }]
     }
     this.stalled = false
+    this.rearmMs = 0
+    this.ladder.landed(landedAt)
 
     const target = Number(question.answer)
+    this.sinceWall = isPrime(target) ? 0 : this.sinceWall + 1
     const wanted = primeFactors(target)
     const values = huskify(wanted, this.rng)
 
@@ -539,24 +886,25 @@ export class Arena {
     if (decoy.length > 0) values.push(...huskify(decoy, this.rng))
 
     // A little chaff, so "sweep only what you need" is a decision rather than
-    // a formality. Never more than three, and always small enough to read.
-    const chaff = this.rng.int(1, 3)
+    // a formality — and more of it higher up the band.
+    //
+    // The band has a ceiling (`MAX_TARGET` is 999), so a child who reaches the
+    // top of it would otherwise find the game stops getting harder. The
+    // arithmetic cannot go further; the *sweep* can. Two extra decoy motes at the
+    // top of the band is a field where getting the hold exactly right is work.
+    const reach = (this.ladder.at - FLOOR) / Math.max(1e-6, CEILING - FLOOR)
+    const chaff = this.rng.int(1, 3 + Math.round(2 * Math.max(0, Math.min(1, reach))))
     for (let i = 0; i < chaff; i++) values.push(this.rng.pick(MOTE_PRIMES.slice(0, 6)))
 
+    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span
     this.bodies = []
     this.shots = []
     this.rng.shuffle(values)
     for (const value of values) {
       const edge = 70
-      const x = this.rng.range(edge, this.width - edge)
-      const y = this.rng.range(edge, this.height * 0.62)
-      this.spawnAt(
-        value,
-        x,
-        y,
-        this.rng.range(-DRIFT_MAX, DRIFT_MAX),
-        this.rng.range(-DRIFT_MAX, DRIFT_MAX),
-      )
+      const x = this.rng.range(edge, Math.max(edge + 1, this.width - edge))
+      const y = this.rng.range(edge, Math.max(edge + 1, this.height * 0.62))
+      this.spawnAt(value, x, y, this.rng.range(-driftMax, driftMax), this.rng.range(-driftMax, driftMax))
     }
 
     this.resonator = {
@@ -565,8 +913,8 @@ export class Arena {
       target,
       x: this.width / 2,
       y: this.height * 0.26,
-      vx: this.rng.range(-26, 26),
-      vy: this.rng.range(-14, 14),
+      vx: this.rng.range(-26, 26) * this.span,
+      vy: this.rng.range(-14, 14) * this.span,
       cooldown: 0,
       reported: false,
       age: 0,
@@ -583,6 +931,66 @@ export class Arena {
   }
 
   /**
+   * Husks to crack and primes to sweep, with no resonator over them.
+   *
+   * The passive layer on its own. Not a question and not reported — the tile bar
+   * still reads `2·2·3` under a running 12, which is the absorption this game
+   * gives away for free, and the child has something to shoot at while the arena
+   * waits for a target it can be a game about. Drawn from `MOTE_PRIMES` through
+   * the same `huskify` every armed field uses, off the same seeded generator, so
+   * nothing here is a hardcoded problem.
+   */
+  private stockPassiveField(): void {
+    const primes: number[] = []
+    const many = this.rng.int(5, 8)
+    for (let i = 0; i < many; i++) primes.push(this.rng.pick(MOTE_PRIMES.slice(0, 8)))
+    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span
+    for (const value of huskify(primes, this.rng)) {
+      const edge = 70
+      this.spawnAt(
+        value,
+        this.rng.range(edge, Math.max(edge + 1, this.width - edge)),
+        this.rng.range(edge, Math.max(edge + 1, this.height * 0.62)),
+        this.rng.range(-driftMax, driftMax),
+        this.rng.range(-driftMax, driftMax),
+      )
+    }
+  }
+
+  /**
+   * The least bad of a handful of drawn questions, or `null` if none will do.
+   *
+   * The fallback bar, and it is deliberately weaker than `isResonant` in exactly
+   * two ways and no others: a two-tile target is allowed (one crack instead of
+   * two), and a wall may come round early. Ranked by tiles, so the best round
+   * available is the one that gets played.
+   *
+   * What it does **not** give up is either of the two things the founder actually
+   * reported. A target under `MIN_TARGET` is still refused, and so is a prime too
+   * small to be a hunt — that is "finding a 2", and no shortage of alternatives
+   * makes it a round worth playing. And readability is not negotiable either: a
+   * composite whose factorisation needs a mote larger than the game draws is
+   * refused outright rather than ranked below the others, because `2 · 397` is not
+   * a worse round of this game, it is a different one. When every draw in the band
+   * is one of those, the arena would rather have nothing for four seconds.
+   */
+  private bestOf(drawn: readonly Question[]): Question | null {
+    let best: Question | null = null
+    let bestTiles = 0
+    for (const q of drawn) {
+      const target = Number(q.answer)
+      if (!isAskable(target, MAX_TARGET) || target < MIN_TARGET) continue
+      const tiles = tileCount(target)
+      if (isPrime(target) ? target < MIN_WALL : tiles < 2 || !isSmooth(target)) continue
+      if (tiles > bestTiles) {
+        bestTiles = tiles
+        best = q
+      }
+    }
+    return best
+  }
+
+  /**
    * The extra primes one of the host's mal-rule answers needs.
    *
    * `[]` when none of them is reachable without turning the field into a
@@ -595,7 +1003,7 @@ export class Arena {
       if (!isAskable(value, MAX_TARGET)) continue
       const extra = multisetDifference(primeFactors(value), wanted)
       if (extra.length === 0 || extra.length > 3) continue
-      if (extra.some((p) => p > 47)) continue
+      if (extra.some((p) => p > LARGEST_MOTE_PRIME)) continue
       return extra
     }
     return []
@@ -618,7 +1026,8 @@ export class Arena {
         Math.max(MOTE_R, y + Math.sin(angle) * RELEASE_RADIUS),
         this.height - MOTE_R,
       )
-      const speed = this.rng.range(DRIFT_MIN, DRIFT_MAX)
+      const speed =
+        this.rng.range(DRIFT_MIN_SPAN, DRIFT_MAX_SPAN) * REFERENCE_SPAN * this.span
       this.spawnAt(values[i] as number, px, py, Math.cos(angle) * speed, Math.sin(angle) * speed)
     }
   }

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -813,6 +813,13 @@ export class Arena {
       // "so the pack is told what it got and not what it asked for."
       const served = Number.isFinite(q.difficulty) ? q.difficulty : request.difficulty
       drawn.push({ question: q, difficulty: served })
+      // A question with no id is not a question. The host hands one back when its
+      // prefetch pool has run dry — a clone of the last one, with the id blanked —
+      // and its `report` is then dropped on the floor at the far end. `MAX_DRAWS`
+      // exists so an arming cannot empty the pool in the first place, and this is
+      // the belt for that brace: a child who solves a resonator nothing can be
+      // recorded against is the worst outcome available here, and it is silent.
+      if (q.id === "") continue
       const hit = isResonant(Number(q.answer), MAX_TARGET, { wall })
       // Remembered either way: ten of the thirty-two rungs in the band produce
       // nothing this game can use. See `ladder.BARREN`.
@@ -978,6 +985,7 @@ export class Arena {
     let best: Question | null = null
     let bestTiles = 0
     for (const q of drawn) {
+      if (q.id === "") continue
       const target = Number(q.answer)
       if (!isAskable(target, MAX_TARGET) || target < MIN_TARGET) continue
       const tiles = tileCount(target)

--- a/dynawalla/games/lattice/src/game/factor.ts
+++ b/dynawalla/games/lattice/src/game/factor.ts
@@ -21,6 +21,22 @@ export const MAX_HUSK = 9999
 /** Primes small enough to be drawn as a drifting mote and read at speed. */
 export const MOTE_PRIMES = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47] as const
 
+/**
+ * The largest prime the game calls readable, derived rather than repeated.
+ *
+ * `MOTE_PRIMES` has always said which primes are small enough to be a mote, and
+ * the resonator then happily asked for 794 = 2 · 397. A hold with a 397 in it is
+ * not the game this pack describes: `resonance.isResonant` uses this so the two
+ * statements cannot drift apart.
+ */
+export const LARGEST_MOTE_PRIME = MOTE_PRIMES[MOTE_PRIMES.length - 1] as number
+
+/** The biggest prime in `n`'s factorisation. `0` for `n < 2`. */
+export function largestPrimeFactor(n: number): number {
+  const factors = primeFactors(n)
+  return factors.length === 0 ? 0 : (factors[factors.length - 1] as number)
+}
+
 export function isPrime(n: number): boolean {
   if (!Number.isInteger(n) || n < 2) return false
   if (n % 2 === 0) return n === 2

--- a/dynawalla/games/lattice/src/game/ladder.ts
+++ b/dynawalla/games/lattice/src/game/ladder.ts
@@ -249,11 +249,16 @@ export class Ladder {
   }
 
   /**
-   * An arming succeeded at `difficulty`. The position moves there.
+   * An arming succeeded, and `difficulty` is where the question it used *came
+   * from* — the rung the host reported serving, never the rung that was asked
+   * for. The position moves there.
    *
    * This is what makes `FLOOR` and `CEILING` a hint rather than a dependency: a
    * position sitting on a barren rung is corrected by the first arming that
-   * finds a live one, and it stays corrected.
+   * finds a live one, and it stays corrected. It only works on the served rung:
+   * `host.next` answers with the pooled question *closest* to a request, so
+   * landing on the request would move the position onto content the child never
+   * saw. See the note at the call site in `arena.arm`.
    */
   landed(difficulty: number): void {
     this.position = clampToBand(difficulty)

--- a/dynawalla/games/lattice/src/game/ladder.ts
+++ b/dynawalla/games/lattice/src/game/ladder.ts
@@ -1,0 +1,271 @@
+// WHAT THE LATTICE ASKS FOR — the game's one difficulty knob.
+//
+// The game used to ask the host for nothing at all:
+//
+//     const drawn = this.host.next({ domain: "add" })
+//
+// A domain, and never a difficulty. `domain` is documented as a cosmetic label,
+// so that call is a shrug: the resonator carried whatever rung the host's own
+// ladder happened to be standing on. The founder's report is both ends of what
+// that costs, and they look like opposite complaints:
+//
+//   * **"It stays way too easy way too long … it's just stuck on 2+0 and 0+3."**
+//     A session opens on rung 0 of the shipped sixty-six-rung ladder, which is
+//     `dw.add.facts.add-within-ten` — answers of one to three. `2` has no factor
+//     tree, so the game's second stage does not exist and the whole sitting is
+//     "find a 2".
+//   * **And the far end, which nobody has reported yet only because nobody got
+//     there.** Above about rung 47 the host's answers are four and five digits.
+//     Every one of them fails `isAskable`, so all eight draws fail, and the
+//     arena *stalls*: no resonator at all. Measured over ten simulated minutes
+//     of perfect play against a host modelling the shipped ladder, the arena
+//     climbed out of its own usable band in about a hundred seconds and spent
+//     the remaining eight minutes with nothing to answer.
+//
+// Both are the same bug. The game never said what it needed, so it was carried
+// past it in one direction and left below it in the other.
+//
+// ## A floor, not a ceiling — and then a ceiling too
+//
+// `counterweight` had the mirror-image defect ("starts way too hard") and fixed
+// it by pinning `difficulty` *and* `maxDifficulty` to the bottom rung. THE
+// LATTICE cannot copy that, because the bottom rung is the thing that is broken
+// here: an answer under twelve cannot carry a factor tree, so **the game must
+// never ask for those items at all.** That is a floor, and it is a statement
+// about what this game *is* rather than about what the child has earned.
+//
+// It is expressed by simply never asking below it. `host.raiseFloor` is
+// deliberately not called: that primitive raises the floor under the stream
+// permanently and is the right shape for an *achievement* (`siege`'s wave
+// counter), and would be wrong here — the floor is a property of the pack, and a
+// pack must not permanently rewrite a child's ladder for every other pack
+// because of what this one can draw.
+//
+// The ceiling is the ordinary kind, and it exists for the ordinary reason: a
+// resonator numeral is read at speed while the arena is moving, and
+// `MAX_TARGET` is 999.
+//
+// ## And it moves on achievement
+//
+// Three rungs per resonator opened, four back on a refusal — the house shape,
+// down faster than up. Nothing here reads a clock: a child who sits still is
+// never dragged up the ladder for having stayed in the room.
+//
+// ## The constants are a hint, not a dependency
+//
+// `FLOOR` and `CEILING` are read off the shipped ladder (see the table below),
+// and a ladder that grows will move them. So the game does not trust them: every
+// arming walks a spread of offsets around its position and **snaps the position
+// to whichever rung actually produced a resonant target**. If the usable band
+// moves, the game finds it again inside one resonator and stays there.
+
+/**
+ * One rung, as a fraction of the host's ladder.
+ *
+ * The shipped ladder is sixty-six rungs, so a rung is 1/65 of the way up it. A
+ * request is a 0..1 position (`toUnit` reads anything below 1 as a fraction),
+ * and the host rounds it to the nearest rung.
+ */
+export const RUNGS = 66
+export const RUNG = 1 / (RUNGS - 1)
+
+/**
+ * The band of the host's ladder THE LATTICE can be itself on.
+ *
+ * Measured by generating forty items from every rung of the shipped graph and
+ * counting how many answers land in `MIN_TARGET..MAX_TARGET` with at least
+ * `MIN_TILES` prime factors:
+ *
+ *     rung  0..13  0.00–0.20   add/subtract facts within ten     0–18% usable
+ *     rung 14,15   0.22–0.23   dw.mul.facts.tables-within-five        0% usable
+ *     rung 16      0.246       dw.mul.facts.tables-to-twelve        60% usable
+ *     rung 18      0.277       dw.add.column.add-no-regroup         48% usable
+ *     rung 30      0.462       dw.add.regroup.add-multidigit        53% usable  ← 47 + 25
+ *     rung 46      0.708       dw.div.whole.divide-exact            57% usable
+ *     rung 48+     0.738+      four- and five-digit answers          0% usable
+ *
+ * So the floor is rung 16, the first rung whose answers reach the twenties, and
+ * the ceiling is rung 47, the last rung that still fits under 999.
+ */
+export const FLOOR = 16 * RUNG
+export const CEILING = 47 * RUNG
+
+/** Rungs a resonator opened is worth, and rungs a refusal costs. */
+export const CLIMB = 3 * RUNG
+export const FALL = 4 * RUNG
+
+/**
+ * Where in the band a session opens.
+ *
+ * The floor, and not a rung above it. The founder wants `47 + 25` "fairly
+ * quickly" and not immediately: three rungs a resonator puts a child on rung 31
+ * — two-digit addition with a carry, which is that question — after five of
+ * them, and at the top of the band after ten.
+ */
+export const OPENING = FLOOR
+
+/**
+ * The offsets, in rungs, an arming tries before it gives up.
+ *
+ * A rung is a distribution of items and not a single question: about half the
+ * answers on a usable rung are prime, or under twelve, or otherwise not
+ * something a resonator can be a game about. So an arming draws more than once,
+ * and drawing at the *same* rung every time is how a rung that happens to be
+ * barren becomes a stalled arena. Walking outward finds the neighbour that is
+ * not.
+ *
+ * Six rungs out at most, which is 0.09 of the ladder — inside the host's
+ * `FLUSH_BAND` of 0.1, so walking the offsets does not churn the prefetch pool.
+ */
+export const OFFSETS: readonly number[] = [0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -6]
+
+/**
+ * How many of them one arming may actually spend.
+ *
+ * **Not `OFFSETS.length`, and the reason is the host's pool rather than taste.**
+ * `next` is synchronous and the refill is not, so every draw an arming makes comes
+ * out of whatever is already stocked. A request that moves the ladder far enough
+ * flushes the pool down to `FLUSH_KEEP` — eight — and refills asynchronously, so
+ * an arming that fired all thirteen offsets in one frame ran the pool dry: the
+ * host logged "the question pool ran dry" five times and started handing back
+ * clones of the last question *with an empty id*, whose answers it then drops. A
+ * child solving a resonator nothing can be reported against is the worst failure
+ * available here, and it is silent.
+ *
+ * Six leaves the reserve intact. An arming that misses all six stalls for
+ * `REARM_MS` and tries again — by which time the pool has refilled at the
+ * difficulty being asked for, and the barren tally knows six rungs more than it
+ * did. The walk is a thing that happens across armings, not inside one, because
+ * that is how the pipe underneath it actually works.
+ */
+export const MAX_DRAWS = 6
+
+/**
+ * The smoothed yield below which a rung is treated as barren and tried last.
+ *
+ * Ten of the thirty-two rungs in the band produce *nothing* a resonator can be a
+ * game about, measured over two hundred items each from the shipped graph:
+ *
+ *     rung 22, 28  dw.div.facts.division-facts     quotients of 0..9
+ *     rung 25      dw.add.column.add-no-regroup L2 four-digit sums
+ *     rung 29,31,35 dw.mul.scale.times-power-of-ten  1050 … 921,700,000
+ *     rung 38      dw.add.regroup.add-short-addend L0 four-digit sums
+ *     rung 40,41,45 four- and five-digit answers
+ *
+ * The band's mean yield is 25%, so an arming that walks blindly spends four items
+ * to find one question. Remembering which rungs never pay halves that, and the
+ * item it does not spend is an item the host's prefetch pool does not have to
+ * refill — a pool that empties is not a pause, it is a question with no id.
+ */
+export const BARREN = 0.15
+
+/** A request, on the fraction scale — unambiguous in `toUnit` for any value < 1. */
+export type Request = {
+  readonly domain: string
+  readonly difficulty: number
+  readonly maxDifficulty: number
+}
+
+export function clampToBand(position: number): number {
+  if (!Number.isFinite(position)) return OPENING
+  return Math.max(FLOOR, Math.min(CEILING, position))
+}
+
+/** The rung index a request lands on, the way the host rounds it. */
+export function rungOf(difficulty: number): number {
+  return Math.max(0, Math.min(RUNGS - 1, Math.round(difficulty * (RUNGS - 1))))
+}
+
+/**
+ * Where the game is standing on the host's ladder, and how it got there.
+ *
+ * Pure: it holds a number, it is moved by two things the child did, and it
+ * hands out requests. It never touches a host and never reads a clock.
+ */
+export class Ladder {
+  private position = OPENING
+  /** What each rung has actually produced. See `BARREN`. */
+  private readonly tally = new Map<number, { draws: number; hits: number }>()
+
+  /** The request the game is currently making, before any offset. */
+  get at(): number {
+    return this.position
+  }
+
+  get rung(): number {
+    return rungOf(this.position)
+  }
+
+  /**
+   * A rung's observed yield, Laplace-smoothed so a rung nobody has tried is
+   * optimistic rather than suspect.
+   *
+   * One hit out of one is 0.75 and not 1, and nought out of one is 0.25 and not
+   * 0 — so a single unlucky draw never writes a rung off, and three do.
+   */
+  yieldOf(rung: number): number {
+    const seen = this.tally.get(rung)
+    if (!seen) return 1
+    return (seen.hits + 0.5) / (seen.draws + 1)
+  }
+
+  /** One draw at `rung`, and whether it produced something to play. */
+  drew(rung: number, hit: boolean): void {
+    const seen = this.tally.get(rung) ?? { draws: 0, hits: 0 }
+    seen.draws += 1
+    if (hit) seen.hits += 1
+    this.tally.set(rung, seen)
+  }
+
+  /**
+   * The requests to try, in order, for one arming.
+   *
+   * Nearest first, deduplicated by rung — at the floor, offsets of 0 and −2 are
+   * the same rung once clamped, and drawing the same rung twice in a row is a
+   * wasted item — and then a *stable partition* that moves the rungs known to
+   * produce nothing to the back.
+   *
+   * A stable partition and not a sort by yield. Sorting would make the game hop
+   * to whichever rung in the band happens to be most fertile, which would quietly
+   * replace "how hard the game thinks this child is working" with "which
+   * curriculum row generates the roundest numbers". Nearness still decides the
+   * order among rungs that pay; the only thing memory does is stop paying for the
+   * ones that never do.
+   */
+  requests(domain: string): readonly Request[] {
+    const live: Request[] = []
+    const barren: Request[] = []
+    const seen = new Set<number>()
+    for (const offset of OFFSETS) {
+      const difficulty = clampToBand(this.position + offset * RUNG)
+      const rung = rungOf(difficulty)
+      if (seen.has(rung)) continue
+      seen.add(rung)
+      const request = { domain, difficulty, maxDifficulty: CEILING }
+      if (this.yieldOf(rung) < BARREN) barren.push(request)
+      else live.push(request)
+    }
+    return [...live, ...barren].slice(0, MAX_DRAWS)
+  }
+
+  /**
+   * An arming succeeded at `difficulty`. The position moves there.
+   *
+   * This is what makes `FLOOR` and `CEILING` a hint rather than a dependency: a
+   * position sitting on a barren rung is corrected by the first arming that
+   * finds a live one, and it stays corrected.
+   */
+  landed(difficulty: number): void {
+    this.position = clampToBand(difficulty)
+  }
+
+  /** A resonator opened. Achievement, never a clock. */
+  opened(): void {
+    this.position = clampToBand(this.position + CLIMB)
+  }
+
+  /** A refusal. Down further than up, so a struggling child is met quickly. */
+  refused(): void {
+    this.position = clampToBand(this.position - FALL)
+  }
+}

--- a/dynawalla/games/lattice/src/game/resonance.ts
+++ b/dynawalla/games/lattice/src/game/resonance.ts
@@ -27,7 +27,7 @@
 //      empty hold is not a wrong answer and is not reported — it is a child
 //      moving through the arena.
 
-import { isPrime, productOf } from "./factor.ts"
+import { isPrime, LARGEST_MOTE_PRIME, largestPrimeFactor, primeFactors, productOf } from "./factor.ts"
 
 export type Resonance =
   /** The bank was empty. Not an assertion, not a report, not a mistake. */
@@ -65,7 +65,90 @@ export function opens(target: number, bank: readonly number[]): boolean {
  * the occasional four-digit sum. A resonator asking for 1 would open to an
  * empty hold, which is not a question; one asking for 10007 would need a mote
  * nobody can read. The arena draws again rather than bending the number.
+ *
+ * This is the *floor* of legality, and it is what the mal-rule filter uses. It
+ * is deliberately weaker than `isResonant` — see below for why the resonator
+ * itself needs more than legality.
  */
 export function isAskable(target: number, max: number): boolean {
   return Number.isInteger(target) && target >= 2 && target <= max
+}
+
+/** How many motes a target's hold is: its prime factors, with multiplicity. */
+export function tileCount(target: number): number {
+  return primeFactors(target).length
+}
+
+/**
+ * The smallest target with a factor tree in it, and the fewest tiles that makes
+ * a tree rather than a fact.
+ *
+ * **This is the founder's report, stated as a predicate.** The arithmetic in
+ * this game has two stages — work out the sum, then decompose the answer — and
+ * at `2 + 0 = 2` *the second stage does not exist*. There is nothing to crack
+ * and one mote to find, so ten minutes of it felt like nothing was happening:
+ * he was playing a factor-collection game with no factors in it.
+ *
+ * So `MIN_TILES` is three, not two. At one tile there is no decomposition at
+ * all. At two — `15 → 3·5` — there is exactly one crack and no choice about
+ * which one, so the "decide which primes multiply to it" step is a formality.
+ * Three is the first count at which the child chooses an order, the husk comes
+ * apart twice, and the tile bar shows a tree instead of a fact.
+ *
+ * `MIN_TARGET` is twelve because below twelve the only value with three prime
+ * factors is 8 = 2·2·2, and a hold of three identical twos is the same
+ * absorption the passive layer gives away for free.
+ */
+export const MIN_TILES = 3
+export const MIN_TARGET = 12
+
+/**
+ * The smallest prime a resonator will put up as a wall.
+ *
+ * A prime target has no factor tree by definition — the only hold that opens it
+ * is the single mote carrying it, found drifting on the field. That is a real
+ * beat and it is the property this whole game is built on, so it is kept. But
+ * "find the 2" is the degenerate case the founder spent ten minutes in, and a
+ * wall worth walking into has to be a number you have to *hunt*.
+ */
+export const MIN_WALL = 13
+
+/**
+ * A target this game can be *itself* on.
+ *
+ * Legality (`isAskable`) says the numeral fits on the resonator's face.
+ * Resonance says there is a game in it: either a factor tree of at least
+ * `MIN_TILES` motes, or — when the caller says a wall is due — a prime big
+ * enough to be a hunt.
+ *
+ * `wall` is the caller's decision and not this function's, because how often a
+ * wall should come round is pacing and pacing belongs to the arena. Rationing
+ * it is the whole reason this parameter exists: unrationed, primes are about a
+ * fifth of the band and every fifth resonator would be a hunt for one mote.
+ */
+export function isResonant(target: number, max: number, opts: { wall: boolean }): boolean {
+  if (!isAskable(target, max)) return false
+  if (target < MIN_TARGET) return false
+  if (isPrime(target)) return opts.wall && target >= MIN_WALL
+  if (tileCount(target) < MIN_TILES) return false
+  return isSmooth(target)
+}
+
+/**
+ * Whether every prime in `target` is one the game draws as a readable mote.
+ *
+ * `794` has three digits, is composite, and its factorisation is `2 · 397`. The
+ * old bar took it: two tiles, both prime, product exact. But `MOTE_PRIMES` — the
+ * list this game has always used to say which primes are "small enough to be
+ * drawn as a drifting mote and read at speed" — stops at 47, so the child was
+ * being sent to find a 397. Three-digit targets are 65% trees and only 37%
+ * *readable* trees, so this is the difference between `804 = 2·2·3·67` and
+ * `600 = 2·2·2·3·5·5`, which is the shape the founder actually asked for.
+ *
+ * A prime target is exempt, because a prime target is the wall and the whole
+ * point of it is that the single mote carrying it is the only way in — a 991
+ * drifting on its own is the most legible thing in the game.
+ */
+export function isSmooth(target: number): boolean {
+  return largestPrimeFactor(target) <= LARGEST_MOTE_PRIME
 }

--- a/dynawalla/games/lattice/src/game/steer.ts
+++ b/dynawalla/games/lattice/src/game/steer.ts
@@ -17,9 +17,9 @@
 //      accurate part, the part you line up on a mote with — was about a
 //      centimetre wide and shared with everything else.
 //
-// So: a dead zone, then a curve that gives the first half of the stick travel a
-// quarter of the authority, then a hard clamp at full deflection. The direction
-// is never touched — only the magnitude — because a curve that bends the
+// So: a dead zone, then a curve that leaves the first half of the stick's travel
+// under a quarter of the authority, then a hard clamp at full deflection. The
+// direction is never touched — only the magnitude — because a curve that bends the
 // direction is a stick that lies about where the child pointed.
 //
 // This module is pure arithmetic on two numbers, and it is here rather than in
@@ -44,10 +44,11 @@ export const DEAD_ZONE = 0.1
 /**
  * The response curve's exponent.
  *
- * `1.8` puts half deflection at 29% authority instead of 50%. Chosen rather than
- * 2 because a pure square makes the last quarter of the stick feel like all of
- * it, and chosen rather than 1.4 because the whole complaint is that the middle
- * of the stick had too much in it.
+ * With the dead zone, `1.8` puts the stick at 4% authority a quarter of the way
+ * out, 23% at half, 56% at three quarters and 100% at the edge — against a
+ * straight line's 25/50/75/100. Chosen rather than 2 because a pure square makes
+ * the last quarter of the stick feel like all of it, and rather than 1.4 because
+ * the whole complaint is that the middle of the stick had too much in it.
  */
 export const CURVE = 1.8
 

--- a/dynawalla/games/lattice/src/game/steer.ts
+++ b/dynawalla/games/lattice/src/game/steer.ts
@@ -1,0 +1,78 @@
+// WHAT A THUMB MEANS — input shaping for the left stick.
+//
+// The founder's second note was "the ship moves around too wildly … I'd like
+// the ship to be a little bit smoother and easier to control", on Android.
+//
+// One half of that is the ship's own dynamics and lives in `arena.ts`. The other
+// half is here, and it is the difference between a stick that reports a
+// direction and a stick that reports an *intent*. Both of the shipped virtual
+// sticks fed `(dx / 64, dy / 64)` straight into `setMove`, which has two
+// problems a nine-year-old's thumb finds immediately:
+//
+//   1. **No dead zone.** A thumb resting on glass is never still. Every pixel of
+//      tremor was full-authority thrust in whatever direction the tremor went,
+//      so the ship never sat still and never quite went where it was pointed.
+//   2. **A linear ramp.** Full thrust arrived 64 pixels from where the thumb
+//      landed and half thrust at 32, so the useful part of the stick — the slow,
+//      accurate part, the part you line up on a mote with — was about a
+//      centimetre wide and shared with everything else.
+//
+// So: a dead zone, then a curve that gives the first half of the stick travel a
+// quarter of the authority, then a hard clamp at full deflection. The direction
+// is never touched — only the magnitude — because a curve that bends the
+// direction is a stick that lies about where the child pointed.
+//
+// This module is pure arithmetic on two numbers, and it is here rather than in
+// `mount.ts` so it can be tested without a canvas. It shapes the *thumb* only:
+// `WASD` already produces a unit direction with no tremor in it and no ramp to
+// bend, and the mouse is an aim rather than a throttle, so neither of them wants
+// a dead zone. `Arena.setMove` is what all three go through, and it guards the
+// same non-finite input from the other side.
+
+/** How far a virtual stick travels to reach full deflection, in CSS pixels. */
+export const STICK_RANGE = 64
+
+/**
+ * The fraction of the range that means "nothing".
+ *
+ * A tenth of 64px is about 1.5mm on a phone, which is under the tremor of a
+ * resting thumb and well under the 44px touch target the rest of the pack is
+ * laid out to.
+ */
+export const DEAD_ZONE = 0.1
+
+/**
+ * The response curve's exponent.
+ *
+ * `1.8` puts half deflection at 29% authority instead of 50%. Chosen rather than
+ * 2 because a pure square makes the last quarter of the stick feel like all of
+ * it, and chosen rather than 1.4 because the whole complaint is that the middle
+ * of the stick had too much in it.
+ */
+export const CURVE = 1.8
+
+export type Stick = { readonly x: number; readonly y: number }
+
+const ZERO: Stick = { x: 0, y: 0 }
+
+/**
+ * A thumb's offset from where it landed, as a move vector of magnitude 0..1.
+ *
+ * Non-finite in is `ZERO` out and not `NaN` out. That is not decoration: the
+ * arena integrates this vector, so one `NaN` would put the ship's position
+ * beyond recovery for the rest of the session, silently, and every collision
+ * test afterwards would be false. See `Arena.setMove`, which guards the same
+ * thing from the other side.
+ */
+export function shapeStick(dx: number, dy: number, range = STICK_RANGE): Stick {
+  if (!Number.isFinite(dx) || !Number.isFinite(dy) || !Number.isFinite(range) || range <= 0) {
+    return ZERO
+  }
+  const magnitude = Math.hypot(dx, dy) / range
+  if (magnitude <= DEAD_ZONE) return ZERO
+  // Rescaled off the dead zone rather than measured from the centre, so the
+  // first pixel past the dead zone is the smallest nudge and not a step.
+  const past = Math.min(1, (magnitude - DEAD_ZONE) / (1 - DEAD_ZONE))
+  const gain = Math.pow(past, CURVE) / magnitude
+  return { x: dx / range * gain, y: dy / range * gain }
+}

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -32,6 +32,7 @@ import type { Host } from "./contract.ts"
 import { Rng } from "./core/rng.ts"
 import { Arena, RESONATOR_R, SHIP_R, type ArenaEvent } from "./game/arena.ts"
 import { bestChain, recordChain } from "./game/best.ts"
+import { shapeStick, STICK_RANGE } from "./game/steer.ts"
 import { Scene } from "./render/scene.ts"
 import { BRASS_LIGHT, CELESTIAL, OXIDE } from "./render/palette.ts"
 import { Grid } from "./sim/grid.ts"
@@ -47,9 +48,6 @@ const MAX_STEP_MS = 120
 
 /** Grid density. Chosen so a tablet draws about 1,100 struts, not 10,000. */
 const GRID_CELL = 46
-
-/** How far a virtual stick has to travel to be at full deflection. */
-const STICK_RANGE = 64
 
 type Stick = { id: number; ox: number; oy: number; x: number; y: number } | null
 
@@ -311,6 +309,10 @@ export function mountLattice(
       if (res && Math.hypot(arena.ship.x - res.x, arena.ship.y - res.y) < RESONATOR_R + SHIP_R) {
         apply(arena.enter(now()))
       }
+      // A barren band leaves the arena without a question rather than without a
+      // future: it asks again a few seconds later, and this is the only place
+      // that clock is read. Inert whenever there is a resonator.
+      apply(arena.rearm(now()))
       grid.step(dt)
       scene.advance(dt)
     }
@@ -364,7 +366,11 @@ export function mountLattice(
     if (moveStick && moveStick.id === event.pointerId) {
       moveStick.x = p.x
       moveStick.y = p.y
-      arena.setMove((p.x - moveStick.ox) / STICK_RANGE, (p.y - moveStick.oy) / STICK_RANGE)
+      // Shaped, not divided: a dead zone under a resting thumb's tremor and a
+      // curve that leaves most of the stick's travel for the slow, accurate part.
+      // See `game/steer.ts`.
+      const shaped = shapeStick(p.x - moveStick.ox, p.y - moveStick.oy, STICK_RANGE)
+      arena.setMove(shaped.x, shaped.y)
       return
     }
     if (aimStick && aimStick.id === event.pointerId) {

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -293,7 +293,12 @@ export class Scene {
 
   private drawShip(arena: Arena): void {
     const ctx = this.ctx
-    const aim = arena.aiming
+    // The hull, not the guns. `facing` eases toward `aiming` over about 55ms, so
+    // a thumb sliding round the right stick turns the ship rather than flicking
+    // it — a large part of what read as "moves around too wildly". The shots
+    // still leave along `aiming`, because a shooter whose bullets lag its stick
+    // lies about where it is pointed.
+    const aim = arena.facing
     const a = Math.atan2(aim.y, aim.x)
     ctx.save()
     ctx.translate(arena.ship.x, arena.ship.y)

--- a/dynawalla/games/lattice/src/stubHost.ts
+++ b/dynawalla/games/lattice/src/stubHost.ts
@@ -1,20 +1,78 @@
-// A local stub Host so the game is playable standalone with `npm run dev`.
+// A local stub Host so the game is playable standalone with `npm run dev`, and
+// so the one thing this pack most needed to measure can be measured: **which
+// rung of the host's ladder the game is actually playing on.**
 //
-// Three properties the real runtime also honours, each asserted by
-// `src/test/stubHost.test.ts`:
+// It used to be a difficulty knob from 1 to 10 that stretched an operand range.
+// That is not the shape the runtime has, and it is why "the game never passes a
+// difficulty" could sit in this package unnoticed: there was nothing here that a
+// missing request would look wrong against. So the stub now models the wire:
 //
-//   1. **Exact arithmetic.** Every operand, answer and distractor is an
-//      integer. No float ever reaches an answer string or a comparison.
-//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
-//   3. **Distractors are real mal-rule outputs** — what a child with a specific
-//      broken procedure actually writes down. Never `answer ± 1` noise. THE
-//      LATTICE seeds the field so one of them is assemblable, so these values
-//      are the wrong answers the game is actually able to hear.
+//   1. **Sixty-six rungs**, the length of the shipped ladder.
+//   2. **`toUnit`**, character for character the reading in
+//      `packs/shared/game-host` — under 1 is a fraction, 1 or over is a ladder
+//      index — so a request written here means what it means there.
+//   3. **A named `difficulty` lands on exactly one rung.** `dynawalla-app`'s
+//      `items.next` spreads a rung *only* when the pack named none; a pack that
+//      drives its own difficulty is honoured as the point it asked for. So is
+//      `maxDifficulty`, which floors rather than rounds.
+//   4. **With nothing named, the rung is the host's own position**, and that
+//      moves on `report` through the shipped staircase: an opening stride of four
+//      rungs decaying by 0.72 toward one, a correct answer worth
+//      `min(1, tail/latency)` of a stride, a wrong one worth a whole one down.
+//      This is the part that makes a silent pack measurable — it is exactly the
+//      mechanism that carried THE LATTICE from rung 0 to rung 49 and off the top
+//      of its own usable band inside a hundred seconds.
+//
+// And the three promises it always kept, asserted by `src/test/stubHost.test.ts`:
+// exact integers everywhere, seeded and deterministic forever, and distractors
+// that are real mal-rule outputs rather than `answer ± 1` noise.
+//
+// The rung → operand-size curve is a smooth exponential rather than a copy of
+// the shipped skill table. That is a deliberate simplification and it is the
+// conservative one: the real ladder interleaves addition, multiplication and
+// division, so its answer sizes are *not* monotone, and a monotone stub can
+// never let a low rung hide a big answer from a test. Calibrated so the bands
+// land where they land in the product — single digits at the bottom, two-digit
+// sums around rung 18, three-digit around rung 30, past 999 from about rung 47.
 
 import type { Host, Question } from "./contract.ts"
 import { Rng } from "./core/rng.ts"
 
 type Domain = "add" | "sub"
+
+/** The shipped ladder's length. A request is a 0..1 position on it. */
+export const RUNGS = 66
+const SPAN = RUNGS - 1
+
+/**
+ * A difficulty on whichever of the two scales the caller speaks, as 0..1.
+ *
+ * The same rule as `packs/shared/game-host`, including its one ambiguous value:
+ * `1` is read as the *bottom* of the ladder index scale and not the top of the
+ * fraction scale, because serving the hardest content in the product to a child
+ * who has just started is the failure the whole wire exists to prevent.
+ */
+export function toUnit(value: number): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null
+  if (value < 1) return Math.max(0, value)
+  return Math.min(1, (value - 1) / 9)
+}
+
+/** The largest operand a rung draws. */
+export function operandCeilingAt(rung: number): number {
+  const clamped = Math.max(0, Math.min(SPAN, Math.round(rung)))
+  return Math.max(2, Math.round(3 * Math.pow(1.125, clamped)))
+}
+
+/** The staircase's constants, from `dynawalla-app/src/packs/items.ts`. */
+const STEP_START = 4
+const STEP_OPEN = 1
+const STEP_DECAY = 0.72
+
+/** The cadence table's p90, which is what a correct answer is measured against. */
+function tailMsFor(digits: number): number {
+  return digits <= 1 ? 6_000 : 14_000 + 13_000 * (digits - 2)
+}
 
 /** Digit-reversal: 63 → 36. A real transcription slip, not noise. */
 function reverseDigits(n: number): number {
@@ -81,21 +139,18 @@ function malRulesFor(domain: Domain, a: number, b: number, answer: number): numb
   }
 }
 
-function operandsFor(domain: Domain, difficulty: number, rng: Rng): [number, number] {
-  // `difficulty` is clamped to 1..10 and stretches the operand range. Answers
-  // stay under four digits at every difficulty: a resonator numeral is read at
-  // speed while the arena is moving, and the primes behind a four-digit answer
-  // are too many motes to hold.
-  const d = Math.max(1, Math.min(10, Math.round(difficulty)))
+function operandsFor(domain: Domain, rung: number, rng: Rng): [number, number] {
+  const hi = operandCeilingAt(rung)
+  // A floor under the operands as well as a ceiling, because column arithmetic
+  // is `40 + 51` and not `1 + 2`: without one, a two-digit rung spends a third of
+  // its draws on single-digit sums and the rung stops meaning anything.
+  const lo = Math.max(1, Math.round(hi * 0.35))
   switch (domain) {
-    case "add": {
-      const hi = 8 + d * 9 // 17..98
-      return [rng.int(3, hi), rng.int(3, hi)]
-    }
+    case "add":
+      return [rng.int(lo, hi), rng.int(lo, hi)]
     case "sub": {
-      const hi = 12 + d * 9 // 21..102
-      const a = rng.int(8, hi)
-      const b = rng.int(2, Math.max(2, a - 2))
+      const a = rng.int(lo, hi)
+      const b = rng.int(1, Math.max(1, a - 1))
       return [a, b]
     }
   }
@@ -105,11 +160,21 @@ function evaluate(domain: Domain, a: number, b: number): number {
   return domain === "add" ? a + b : a - b
 }
 
+function digitsOf(n: number): number {
+  return String(Math.abs(Math.round(n))).length
+}
+
 const GLYPH: Record<Domain, string> = { add: "+", sub: "−" }
 
 export type StubHostOptions = {
   seed?: number
   reducedMotion?: boolean
+  /**
+   * A standing difficulty, on either scale, for a caller that names none per
+   * question. Absent, the stub opens at the bottom of the ladder like the real
+   * host does — which is the whole point: a game that asks for nothing gets
+   * `2 + 0` until the host's own staircase carries it somewhere else.
+   */
   difficulty?: number
   /** Observe reports — the dev harness draws a running accuracy readout. */
   onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
@@ -117,21 +182,58 @@ export type StubHostOptions = {
   onHaptic?: (k: string) => void
   /** Observe stopping points. The real host may sheet the frame on one. */
   onTransition?: (kind: string, label?: string) => void
+  /** Observe every draw: what was asked for, and which rung answered. */
+  onDraw?: (draw: { asked: number | null; ceiling: number | null; rung: number; id: string }) => void
+  /** Observe skips, so a test can hold the pack to closing what it discards. */
+  onSkip?: (questionId: string) => void
 }
 
-export function createStubHost(opts: StubHostOptions = {}): Host {
+/** What the stub is willing to say about itself, for the tests that measure it. */
+export type StubHost = Host & {
+  /** The rung the host's own ladder is standing on, as an index. */
+  position(): number
+  /** Every rung actually served, in order. */
+  servedRungs(): readonly number[]
+  /** Question ids handed out and never answered or skipped. */
+  openItems(): readonly string[]
+}
+
+export function createStubHost(opts: StubHostOptions = {}): StubHost {
   const rng = new Rng(opts.seed ?? 0x1a771ce)
   let n = 0
   const domains: Domain[] = ["add", "add", "sub"]
+  const standing = opts.difficulty === undefined ? null : toUnit(opts.difficulty)
 
-  const host: Host = {
+  /** Where the host's own ladder is, carried as a real number like `items.ts`. */
+  let progress = standing === null ? 0 : standing * SPAN
+  let step = STEP_START
+  const served = new Map<string, { rung: number; digits: number }>()
+  const rungs: number[] = []
+
+  const host: StubHost = {
     next(o) {
-      const difficulty = Math.max(
-        1,
-        Math.min(10, Math.round(o?.difficulty ?? opts.difficulty ?? 3)),
-      )
+      const asked = o?.difficulty === undefined ? standing : toUnit(o.difficulty)
+      const ceiling = o?.maxDifficulty === undefined ? null : toUnit(o.maxDifficulty)
+      let rung = Math.floor(progress)
+      // Either field moves the rung, which is `items.next`'s own gate: a request
+      // that names only a ceiling still has to be honoured, or the ceiling half of
+      // the wire is modelled by nothing.
+      if (asked !== null || ceiling !== null) {
+        // The ceiling *floors* and the request *rounds*, exactly as `items.next`
+        // does it: rounding a cap can only round it up, and a cap that can be
+        // rounded over is not a cap.
+        const cap = ceiling === null ? SPAN : Math.floor(ceiling * SPAN)
+        // With no `difficulty` named, `items.next` reads the ladder's own position
+        // as the request and then applies the cap to it.
+        const want = asked === null ? Math.floor(progress) / Math.max(1, SPAN) : asked
+        rung = Math.max(0, Math.min(SPAN, cap, Math.round(want * SPAN)))
+        // The whole number the pack named, keeping the fraction already earned
+        // toward the next rung.
+        progress = rung + (progress - Math.floor(progress))
+      }
+
       const domain = (o?.domain as Domain | undefined) ?? rng.pick(domains)
-      const [a, b] = operandsFor(domain, difficulty, rng)
+      const [a, b] = operandsFor(domain, rung, rng)
       const answer = evaluate(domain, a, b)
 
       // Mal-rule outputs, deduped, filtered to values a resonator could legally
@@ -147,18 +249,44 @@ export function createStubHost(opts: StubHostOptions = {}): Host {
       rng.shuffle(pool)
 
       n++
+      const id = `stub-${n}`
+      served.set(id, { rung, digits: Math.max(digitsOf(a), digitsOf(b)) })
+      rungs.push(rung)
+      opts.onDraw?.({ asked, ceiling, rung, id })
       return {
-        id: `stub-${n}`,
+        id,
         prompt: `${a} ${GLYPH[domain]} ${b}`,
         answer: String(answer),
         distractors: pool.slice(0, 3).map(String),
         domain,
-        difficulty: Math.max(0, Math.min(1, difficulty / 10)),
+        difficulty: rung / SPAN,
       } satisfies Question
     },
 
     report(r) {
+      const entry = served.get(r.questionId)
+      // Once per item, like the real host: an id already answered or skipped, or
+      // one that was never served, moves nothing.
+      if (entry) {
+        served.delete(r.questionId)
+        if (r.correct) {
+          const gain = Math.min(1, tailMsFor(entry.digits) / Math.max(1, r.ms))
+          progress += gain * step
+        } else {
+          progress -= step
+        }
+        step = Math.max(STEP_OPEN, STEP_OPEN + (step - STEP_OPEN) * STEP_DECAY)
+        progress = Math.max(0, Math.min(SPAN, progress))
+      }
       opts.onReport?.(r)
+    },
+
+    skip(questionId) {
+      // Closed and recorded as nothing: no outcome, no ladder movement. A skip
+      // that moved the ladder would be a wrong answer for a question the child
+      // was never shown.
+      served.delete(questionId)
+      opts.onSkip?.(questionId)
     },
 
     haptic(k) {
@@ -183,6 +311,18 @@ export function createStubHost(opts: StubHostOptions = {}): Host {
       return (
         typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
       )
+    },
+
+    position() {
+      return Math.floor(progress)
+    },
+
+    servedRungs() {
+      return rungs
+    },
+
+    openItems() {
+      return [...served.keys()]
     },
   }
 

--- a/dynawalla/games/lattice/src/test/harness.ts
+++ b/dynawalla/games/lattice/src/test/harness.ts
@@ -7,7 +7,7 @@
 import type { Host } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
 import { Arena } from "../game/arena.ts"
-import { primeFactors } from "../game/factor.ts"
+import { multisetDifference, primeFactors } from "../game/factor.ts"
 import { createStubHost } from "../stubHost.ts"
 
 export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
@@ -82,4 +82,111 @@ export function stepClock(step = 1800): () => number {
     t += step
     return t
   }
+}
+
+/** Fly toward a point, and aim there too. */
+function steer(arena: Arena, x: number, y: number): void {
+  const dx = x - arena.ship.x
+  const dy = y - arena.ship.y
+  arena.setMove(dx, dy)
+  arena.setAim(dx, dy)
+}
+
+function nearest<T extends { x: number; y: number }>(arena: Arena, xs: readonly T[]): T | null {
+  let best: T | null = null
+  let bestD = Number.POSITIVE_INFINITY
+  for (const item of xs) {
+    const d = Math.hypot(item.x - arena.ship.x, item.y - arena.ship.y)
+    if (d < bestD) {
+      bestD = d
+      best = item
+    }
+  }
+  return best
+}
+
+/** What a sitting looked like, for the tests that measure one. */
+export type Sitting = {
+  /** Every target a resonator carried, in order. */
+  readonly targets: number[]
+  /** Wall-clock milliseconds the arena had no question at all. */
+  readonly withoutQuestionMs: number
+  /** How long until the first target with a real factor tree in it. */
+  readonly firstTreeMs: number | null
+}
+
+/**
+ * A child who is playing properly: work out what the resonator needs, break
+ * open whatever is holding those primes, collect exactly them, and go.
+ *
+ * The ceiling on how well this game can go, so a defect that only a perfect
+ * player would reach still shows up. `loop.test.ts` uses it to ask whether the
+ * loop closes at all; `pacing.test.ts` uses it to ask what the loop is *about*.
+ */
+export function playCarefully(arena: Arena, frames: number, frameMs = 16): Sitting {
+  const targets: number[] = []
+  const seen = new Set<string>()
+  let withoutQuestionMs = 0
+  let firstTreeMs: number | null = null
+  let t = 0
+  for (let f = 0; f < frames; f++) {
+    t += frameMs
+    const res = arena.resonator
+    if (!res) withoutQuestionMs += frameMs
+    if (res && !seen.has(res.questionId)) {
+      seen.add(res.questionId)
+      targets.push(res.target)
+      if (firstTreeMs === null && res.target >= 12 && primeFactors(res.target).length >= 3) {
+        firstTreeMs = t
+      }
+    }
+
+    if (res) {
+      const wanted = primeFactors(res.target)
+      const held = arena.bank.tiles.slice()
+      const surplus = multisetDifference(held, wanted)
+
+      if (surplus.length > 0) {
+        // Something got swept that the resonator does not want. Drop the lot and
+        // start the hold again — the primes go back on the field.
+        arena.vent()
+      } else if (held.length === wanted.length) {
+        // The hold is right. Run at it.
+        steer(arena, res.x, res.y)
+        if (Math.hypot(res.x - arena.ship.x, res.y - arena.ship.y) < 60) arena.enter(t)
+      } else {
+        const needed = multisetDifference(wanted, held)
+        const motes = arena.bodies.filter((b) => b.prime && needed.includes(b.value))
+        const mote = nearest(arena, motes)
+        if (mote) {
+          steer(arena, mote.x, mote.y)
+        } else {
+          // Nothing loose carries what is needed, so open something that does.
+          const husks = arena.bodies.filter(
+            (b) => !b.prime && needed.some((p) => b.value % p === 0),
+          )
+          const husk =
+            nearest(arena, husks) ?? nearest(arena, arena.bodies.filter((b) => !b.prime))
+          if (husk) {
+            // Stand off and shoot rather than flying into it — a husk jostles.
+            const dx = husk.x - arena.ship.x
+            const dy = husk.y - arena.ship.y
+            arena.setAim(dx, dy)
+            const range = Math.hypot(dx, dy)
+            arena.setMove(range > 220 ? dx : -dx, range > 220 ? dy : -dy)
+            arena.fire()
+          } else {
+            // The field has nothing left that helps. Sit still rather than
+            // thrashing; the assertions are what report it.
+            arena.setMove(0, 0)
+          }
+        }
+      }
+    }
+    arena.step(frameMs)
+    // The shell calls this every frame. Without it a barren band would look like
+    // a permanent stall in a test and would not be one in the game.
+    arena.rearm(t)
+  }
+  return { targets, withoutQuestionMs, firstTreeMs }
 }

--- a/dynawalla/games/lattice/src/test/ladder.test.ts
+++ b/dynawalla/games/lattice/src/test/ladder.test.ts
@@ -1,0 +1,238 @@
+// **"It stays way too easy way too long."**
+//
+// The founder played for ten minutes doing it perfectly and saw `2 + 0` over and
+// over, finding a 2; then `3 + 0`, finding a 3. The cause was one line: the game
+// asked the host for a domain and never for a difficulty, so it played whatever
+// rung the host's own ladder was standing on — rung 0 at the start of a session.
+//
+// These cases hold the three rules that replaced it: a floor because the bottom
+// of the ladder has no factor tree in it, a ceiling because `MAX_TARGET` is 999,
+// and a position that moves on what the child achieved.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  BARREN,
+  CEILING,
+  CLIMB,
+  FALL,
+  FLOOR,
+  Ladder,
+  MAX_DRAWS,
+  OFFSETS,
+  OPENING,
+  RUNG,
+  RUNGS,
+  clampToBand,
+  rungOf,
+} from "../game/ladder.ts"
+import { MIN_TARGET } from "../game/resonance.ts"
+import { createStubHost, toUnit } from "../stubHost.ts"
+
+test("a session opens on the floor, and the floor is not the bottom of the ladder", () => {
+  // The whole fix, in one assertion. `counterweight` opens on rung 1 because its
+  // defect was the opposite one; THE LATTICE cannot, because a rung whose answers
+  // are 1..3 has nothing to decompose.
+  const ladder = new Ladder()
+  assert.equal(ladder.at, OPENING)
+  assert.equal(OPENING, FLOOR)
+  assert.equal(rungOf(FLOOR), 16, "the floor moved off the rung it was measured on")
+  assert.ok(FLOOR > 0, "the game opens at the bottom of the ladder, where 2 + 0 lives")
+  // On the host's wire this is read as a fraction and not as a ladder index —
+  // `toUnit` only reads 1 and above as an index, and the band never reaches 1.
+  assert.ok(CEILING < 1, "a request of exactly 1 is read as the BOTTOM of the ladder")
+  assert.equal(toUnit(FLOOR), FLOOR)
+  assert.equal(toUnit(CEILING), CEILING)
+})
+
+test("the floor is where the host's answers can first carry a factor tree", () => {
+  // The request is only worth making if the other end honours it, and the point
+  // of the floor is the *answers* it produces rather than the number itself.
+  const host = createStubHost({ seed: 0x51ee, reducedMotion: true })
+  let big = 0
+  const n = 300
+  for (let i = 0; i < n; i++) {
+    const q = host.next({ domain: "add", difficulty: FLOOR, maxDifficulty: CEILING })
+    if (Number(q.answer) >= MIN_TARGET) big += 1
+  }
+  assert.ok(big / n > 0.75, `only ${big}/${n} floor answers reached ${MIN_TARGET}`)
+  // And the bottom of the ladder, for contrast: this is what the game used to get.
+  const bottom = createStubHost({ seed: 0x51ee, reducedMotion: true })
+  let tiny = 0
+  for (let i = 0; i < n; i++) {
+    if (Number(bottom.next({ domain: "add", difficulty: 0 }).answer) < MIN_TARGET) tiny += 1
+  }
+  assert.ok(tiny / n > 0.9, `the bottom rung produced ${n - tiny}/${n} usable answers`)
+})
+
+test("the ceiling never lets the stream past what a resonator can put on its face", () => {
+  const host = createStubHost({ seed: 0xce111, reducedMotion: true })
+  const ladder = new Ladder()
+  for (let i = 0; i < 40; i++) ladder.opened()
+  assert.equal(ladder.at, CEILING, "forty resonators did not peg the ceiling")
+  for (const request of ladder.requests("add")) {
+    assert.ok(request.difficulty <= CEILING + 1e-9, `a request at ${request.difficulty}`)
+    assert.equal(request.maxDifficulty, CEILING)
+    // The host floors a ceiling rather than rounding it, so the rung served can
+    // never be above the one named.
+    assert.ok(rungOf(request.difficulty) <= rungOf(CEILING))
+  }
+  // And the other end honours it, on the rung it *reports serving* rather than on
+  // the number it was handed — a ceiling that the pool can be answered over is not
+  // a ceiling, and `question.difficulty` is the only place the truth appears.
+  for (let i = 0; i < 60; i++) {
+    const q = host.next({ domain: "add", difficulty: CEILING, maxDifficulty: CEILING })
+    assert.ok(
+      rungOf(q.difficulty) <= rungOf(CEILING),
+      `a request capped at rung ${rungOf(CEILING)} was answered from rung ${rungOf(q.difficulty)}`,
+    )
+  }
+  // A request that names only a ceiling is still a request: the host's own
+  // position must come down to it. This is `items.next`'s gate, and a stub that
+  // ignored it would model the ceiling half of the wire with nothing.
+  // `difficulty: 10` and not `1`: on the ladder-index scale 10 is the top, and `1`
+  // is `toUnit`'s one ambiguous value, read as the *bottom*. Which is why THE
+  // LATTICE speaks the fraction scale — nothing in its band can be misread.
+  const high = createStubHost({ seed: 0xce111, reducedMotion: true, difficulty: 10 })
+  assert.equal(high.position(), RUNGS - 1)
+  assert.equal(toUnit(1), 0, "1 stopped being read as the bottom of the ladder")
+  high.next({ domain: "add", maxDifficulty: FLOOR })
+  assert.equal(
+    high.servedRungs().at(-1),
+    rungOf(FLOOR),
+    "a ceiling-only request was served from above the ceiling",
+  )
+})
+
+test("the position moves on resonators and refusals, and on nothing else", () => {
+  const ladder = new Ladder()
+  ladder.opened()
+  assert.ok(Math.abs(ladder.at - (FLOOR + CLIMB)) < 1e-9)
+  ladder.opened()
+  ladder.opened()
+  const climbed = ladder.at
+  assert.ok(Math.abs(climbed - (FLOOR + 3 * CLIMB)) < 1e-9)
+  // Down further than up: one refusal undoes more than one resonator.
+  ladder.refused()
+  assert.ok(Math.abs(ladder.at - (climbed - FALL)) < 1e-9)
+  assert.ok(FALL > CLIMB, "a refusal costs less than a resonance earns")
+  // And a hundred requests move nothing at all — this is not a clock.
+  const still = ladder.at
+  for (let i = 0; i < 100; i++) ladder.requests("add")
+  assert.equal(ladder.at, still, "asking for a question moved the ladder")
+})
+
+test("no run of refusals can push the game below its own floor", () => {
+  const ladder = new Ladder()
+  for (let i = 0; i < 50; i++) ladder.refused()
+  assert.equal(ladder.at, FLOOR, "a struggling child was handed a target with no factors in it")
+  for (let i = 0; i < 200; i++) ladder.opened()
+  assert.equal(ladder.at, CEILING)
+})
+
+test("47 + 25 arrives within a handful of resonators", () => {
+  // The founder's own example. `dw.add.regroup.add-multidigit` is rung 30 of the
+  // shipped ladder — two-digit addition with a carry — and the question is how
+  // long a child who is doing well has to wait for it.
+  const ladder = new Ladder()
+  let opens = 0
+  while (rungOf(ladder.at) < 30 && opens < 100) {
+    ladder.opened()
+    opens += 1
+  }
+  assert.ok(opens <= 6, `it took ${opens} resonators to reach rung 30`)
+  assert.ok(opens >= 3, `rung 30 arrived after ${opens} resonators, which is not a climb`)
+})
+
+test("an arming walks outward, nearest rung first, and never repeats one", () => {
+  const ladder = new Ladder()
+  for (let i = 0; i < 5; i++) ladder.opened() // somewhere in the middle of the band
+  const rungs = ladder.requests("add").map((r) => rungOf(r.difficulty))
+  assert.equal(rungs[0], rungOf(ladder.at), "the first draw was not at the game's own position")
+  assert.equal(new Set(rungs).size, rungs.length, "the same rung was drawn twice in one arming")
+  // Six draws and no more, because `next` is synchronous and the refill is not:
+  // an arming that fired every offset in one frame ran the host's pool dry and
+  // started being handed clones with an empty id, whose answers it then drops.
+  assert.equal(rungs.length, MAX_DRAWS, `an arming would spend ${rungs.length} items`)
+  assert.ok(MAX_DRAWS < 8, "an arming can drain the reserve a flush guarantees")
+  // Six rungs out at most, which is inside the host's own flush band of 0.1 — a
+  // walk that reached further would discard the prefetch pool every question.
+  for (const rung of rungs) {
+    assert.ok(
+      Math.abs(rung - rungOf(ladder.at)) <= Math.max(...OFFSETS),
+      `a request ${rung - rungOf(ladder.at)} rungs from the position`,
+    )
+  }
+  assert.ok(Math.max(...OFFSETS) * RUNG < 0.1, "the walk is wider than the host's flush band")
+  // Nearest first, all the way down: this is what makes the walk a search around
+  // where the child is rather than a hop to whichever rung reads roundest.
+  const here = rungOf(ladder.at)
+  let reach = 0
+  for (const rung of rungs) {
+    const away = Math.abs(rung - here)
+    assert.ok(away >= reach, `the walk went ${away} rungs out and then back to ${reach}`)
+    reach = away
+  }
+})
+
+test("a rung that has never produced anything is tried last, not first", () => {
+  // Ten of the thirty-two rungs in the band generate nothing this game can use —
+  // `dw.mul.scale.times-power-of-ten` answers 1050 to 921,700,000. Paying an item
+  // to find that out again on every single question is four items per resonator
+  // instead of two, and every item is a slot in the host's prefetch pool.
+  const ladder = new Ladder()
+  for (let i = 0; i < 5; i++) ladder.opened()
+  const first = ladder.requests("add").map((r) => rungOf(r.difficulty))
+  const dead = first[0] as number
+  assert.equal(dead, rungOf(ladder.at))
+  // One miss is not enough to write a rung off; three are.
+  ladder.drew(dead, false)
+  assert.equal(
+    rungOf((ladder.requests("add")[0] as { difficulty: number }).difficulty),
+    dead,
+    "a single unlucky draw wrote a rung off",
+  )
+  ladder.drew(dead, false)
+  ladder.drew(dead, false)
+  ladder.drew(dead, false)
+  assert.ok(ladder.yieldOf(dead) < BARREN, `yield ${ladder.yieldOf(dead)} after four misses`)
+  const after = ladder.requests("add").map((r) => rungOf(r.difficulty))
+  assert.equal(after.length, MAX_DRAWS)
+  assert.ok(
+    !after.includes(dead),
+    `the barren rung ${dead} was still being paid for while ${OFFSETS.length} live ones were free`,
+  )
+  // Every rung it *did* offer is one of the offsets, and the nearest ones at that
+  // — demoting a rung must not turn the walk into a hop across the band.
+  const candidates = OFFSETS.map((o) => rungOf(clampToBand(ladder.at + o * RUNG)))
+  for (const rung of after) {
+    assert.ok(candidates.includes(rung), `the walk invented rung ${rung}`)
+  }
+  // A rung that pays keeps its place, and one miss does not demote it.
+  const good = first[1] as number
+  ladder.drew(good, true)
+  assert.ok(ladder.yieldOf(good) >= BARREN)
+  assert.ok(ladder.requests("add").map((r) => rungOf(r.difficulty)).includes(good))
+})
+
+test("an arming that lands somewhere else takes the position with it", () => {
+  // What makes FLOOR and CEILING a hint rather than a dependency: the shipped
+  // ladder will grow, and a game pinned to a rung index would go quietly barren.
+  const ladder = new Ladder()
+  const target = clampToBand(FLOOR + 4 * RUNG)
+  ladder.landed(target)
+  assert.equal(ladder.at, target)
+  ladder.landed(-5)
+  assert.equal(ladder.at, FLOOR, "a landing below the band was not clamped")
+  ladder.landed(Number.NaN)
+  assert.equal(ladder.at, OPENING, "a landing that is not a number poisoned the position")
+})
+
+test("the ladder is the length the host says it is", () => {
+  assert.equal(RUNGS, 66)
+  assert.equal(rungOf(0), 0)
+  assert.equal(rungOf(1), RUNGS - 1)
+  assert.equal(clampToBand(0), FLOOR)
+  assert.equal(clampToBand(1), CEILING)
+})

--- a/dynawalla/games/lattice/src/test/loop.test.ts
+++ b/dynawalla/games/lattice/src/test/loop.test.ts
@@ -22,85 +22,10 @@ import { test } from "node:test"
 
 import { Rng } from "../core/rng.ts"
 import { Arena } from "../game/arena.ts"
-import { multisetDifference, primeFactors } from "../game/factor.ts"
 import { createStubHost } from "../stubHost.ts"
+import { playCarefully } from "./harness.ts"
 
 type Report = { correct: boolean; answered: string }
-
-/** Fly toward a point, and aim there too. */
-function steer(arena: Arena, x: number, y: number): void {
-  const dx = x - arena.ship.x
-  const dy = y - arena.ship.y
-  arena.setMove(dx, dy)
-  arena.setAim(dx, dy)
-}
-
-function nearest<T extends { x: number; y: number }>(arena: Arena, xs: readonly T[]): T | null {
-  let best: T | null = null
-  let bestD = Number.POSITIVE_INFINITY
-  for (const item of xs) {
-    const d = Math.hypot(item.x - arena.ship.x, item.y - arena.ship.y)
-    if (d < bestD) {
-      bestD = d
-      best = item
-    }
-  }
-  return best
-}
-
-/**
- * A child who is playing properly: work out what the resonator needs, break
- * open whatever is holding those primes, collect exactly them, and go.
- */
-function playCarefully(arena: Arena, frames: number): void {
-  let t = 0
-  for (let f = 0; f < frames; f++) {
-    t += 16
-    const res = arena.resonator
-    if (!res) break
-
-    const wanted = primeFactors(res.target)
-    const held = arena.bank.tiles.slice()
-    const surplus = multisetDifference(held, wanted)
-
-    if (surplus.length > 0) {
-      // Something got swept that the resonator does not want. Drop the lot and
-      // start the hold again — the primes go back on the field.
-      arena.vent()
-    } else if (held.length === wanted.length) {
-      // The hold is right. Run at it.
-      steer(arena, res.x, res.y)
-      if (Math.hypot(res.x - arena.ship.x, res.y - arena.ship.y) < 60) arena.enter(t)
-    } else {
-      const needed = multisetDifference(wanted, held)
-      const motes = arena.bodies.filter((b) => b.prime && needed.includes(b.value))
-      const mote = nearest(arena, motes)
-      if (mote) {
-        steer(arena, mote.x, mote.y)
-      } else {
-        // Nothing loose carries what is needed, so open something that does.
-        const husks = arena.bodies.filter(
-          (b) => !b.prime && needed.some((p) => b.value % p === 0),
-        )
-        const husk = nearest(arena, husks) ?? nearest(arena, arena.bodies.filter((b) => !b.prime))
-        if (husk) {
-          // Stand off and shoot rather than flying into it — a husk jostles.
-          const dx = husk.x - arena.ship.x
-          const dy = husk.y - arena.ship.y
-          arena.setAim(dx, dy)
-          const range = Math.hypot(dx, dy)
-          arena.setMove(range > 220 ? dx : -dx, range > 220 ? dy : -dy)
-          arena.fire()
-        } else {
-          // The field has nothing left that helps. Sit still rather than
-          // thrashing; the assertion below is what reports it.
-          arena.setMove(0, 0)
-        }
-      }
-    }
-    arena.step(16)
-  }
-}
 
 test("a child who plays it properly opens resonators, over and over", () => {
   for (const seed of [0x1a771ce, 0x0c105, 0x5eed, 0xbea7, 0x9a11]) {

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -363,7 +363,16 @@ test("reading the rules holds the world, and closing them lets it go", () => {
       assert.ok(counter.calls > 0, "the frame stopped being drawn behind the manual")
 
       // PLAY, and the same arena carries on being an arena.
+      //
+      // Both thumbs go down again, because that is what actually happens: the
+      // manual's PLAY button is a DOM control, so the child's thumbs came off the
+      // canvas to reach it, and opening the manual let the sticks go anyway (a
+      // stick still held behind a sheet is the bug the guard exists for). Without
+      // pressing again this test flew nothing at all and passed on the Brownian
+      // motion of a drifting resonator finding a stationary ship.
       play.listeners.get("click")?.[0]?.({})
+      down({ preventDefault() {}, pointerId: 1, pointerType: "touch", clientX: 225, clientY: 350 })
+      down({ preventDefault() {}, pointerId: 2, pointerType: "touch", clientX: 675, clientY: 350 })
       fly(8000, () => answered.length > 0)
       assert.ok(answered.length > 0, "the world never came back after the manual closed")
       handle.unmount()

--- a/dynawalla/games/lattice/src/test/pacing.test.ts
+++ b/dynawalla/games/lattice/src/test/pacing.test.ts
@@ -403,6 +403,25 @@ test("a second wrong hold in the same ring is not a second wrong answer", () => 
   )
 })
 
+test("a question with no id is not a question, however answerable it looks", () => {
+  // The host hands one back when its prefetch pool has run dry: a clone of the
+  // last question with the id blanked. `report` on it is then dropped at the far
+  // end — so a child would work out `47 + 25`, assemble `2·2·2·3·3`, open the ring
+  // and have the whole thing recorded nowhere. `MAX_DRAWS` is why the pool should
+  // never empty; this is why an empty one is not silent damage if it does.
+  const inner = createStubHost({ seed: 0x0117e55, reducedMotion: true })
+  const dry: StubHost = {
+    ...inner,
+    // Perfectly resonant, and unreportable.
+    next: (request) => ({ ...inner.next(request), id: "", answer: "72" }),
+  }
+  const arena = new Arena(dry, new Rng(0x0117e55), { width: 900, height: 700 })
+  const events = arena.begin(0)
+  assert.equal(arena.resonator, null, "a resonator was armed on a question with no id")
+  assert.ok(events.some((e) => e.kind === "stalled"), "the arena took it and said nothing")
+  assert.ok(arena.bodies.length > 0, "and it still left the child an empty screen")
+})
+
 test("a host with no skip is still a host this game runs on", () => {
   // `skip` is feature-detected, like `transition`. A runtime older than the one
   // that grew it must not be a pack that throws on its first arming.

--- a/dynawalla/games/lattice/src/test/pacing.test.ts
+++ b/dynawalla/games/lattice/src/test/pacing.test.ts
@@ -1,0 +1,442 @@
+// TEN MINUTES, MEASURED.
+//
+// > "'the lattice' has a lot of potential but it stays way too easy way too long
+// > .. I must have played for 10 minutes and I'm doing it perfectly and I'm
+// > seeing 2+0 over and over again, finding a 2 .. then 3+0 and finding a 3 ..
+// > the 'real game' never seems to come where I have eg the example 47+25 ... and
+// > I must collect 2*2*2*3*3 ... those level of problem should come fairly
+// > quickly ... 2*2*4 = 8+4 ... some variety .. it's just stuck on 2+0 and 0+3,
+// > 2+1 forever."
+//
+// This file is that report, as a measurement. A bot that does the arithmetic
+// perfectly plays the real arena through the real physics against a host that
+// models the shipped difficulty wire — sixty-six rungs, a request honoured as a
+// point, and the host's own staircase moving on `report` when the game names
+// nothing — and the assertions are about *what it was asked*.
+//
+// **What it looked like before.** Run against the shipped code, over five seeds:
+//
+//     draws 270, of which named a difficulty: 0
+//     rungs served: min 0, median 29, max 50
+//     targets with a factor tree: 42%,  prime: 21%
+//     first targets: 5  7  10  16  10  24  16  27  34  34  48 …
+//     the arena had no question at all for about 500 of the 600 seconds
+//
+// The last line is the part nobody had reported, because nobody had got there:
+// the host's own staircase carried the game up past rung 47, where every answer
+// is four or five digits, `isAskable` refused all eight draws, and the arena
+// stalled — permanently, because there was no retry, leaving the previous
+// resonator hanging with its id already spent.
+//
+// **And after**, on the same five seeds:
+//
+//     draws 1650, of which named a difficulty: 1650
+//     rungs served: min 16, median 45, max 47
+//     targets with a factor tree: 82%,  prime: 15%
+//     first targets: 36  40  60  98  75  193  156  175  370 …
+//     the arena was without a question for 8 seconds in 3,000
+//
+// Every number below is checked against a threshold well inside those margins,
+// so this file fails on a regression rather than on noise.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena } from "../game/arena.ts"
+import { primeFactors } from "../game/factor.ts"
+import { CEILING, FLOOR, RUNGS, rungOf } from "../game/ladder.ts"
+import { MIN_TARGET, MIN_TILES, isSmooth } from "../game/resonance.ts"
+import { createStubHost, type StubHost } from "../stubHost.ts"
+import { grindToPrimes, playCarefully, rig } from "./harness.ts"
+
+const FRAME_MS = 16
+/** Ten minutes, the length of the sitting in the report. */
+const TEN_MINUTES = Math.round((10 * 60 * 1000) / FRAME_MS)
+const SEEDS = [0x1a771ce, 0x0c105, 0x5eed, 0xbea7, 0x9a11]
+
+type Draw = { asked: number | null; ceiling: number | null; rung: number; id: string }
+
+function sit(seed: number, frames = TEN_MINUTES) {
+  const draws: Draw[] = []
+  const skipped: string[] = []
+  const host: StubHost = createStubHost({
+    seed,
+    reducedMotion: true,
+    onDraw: (d) => draws.push(d),
+    onSkip: (id) => skipped.push(id),
+  })
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
+  arena.begin(0)
+  const played = playCarefully(arena, frames, FRAME_MS)
+  return { host, arena, draws, skipped, ...played }
+}
+
+test("every single draw names a difficulty and a ceiling", () => {
+  // The defect itself, and the only assertion here that would have failed on the
+  // shipped code no matter how the thresholds were set: it named neither, ever.
+  const { draws } = sit(SEEDS[0] as number, 4000)
+  assert.ok(draws.length > 20, `only ${draws.length} draws`)
+  const silent = draws.filter((d) => d.asked === null)
+  assert.deepEqual(silent, [], `${silent.length} of ${draws.length} draws asked for nothing`)
+  for (const draw of draws) {
+    assert.ok(draw.ceiling !== null, "a draw named no ceiling")
+    assert.ok(
+      (draw.asked as number) >= FLOOR - 1e-9 && (draw.asked as number) <= CEILING + 1e-9,
+      `a draw asked for ${String(draw.asked)}, outside the band`,
+    )
+  }
+})
+
+test("the very first question of a session already has a factor tree in it", () => {
+  // "I'm seeing 2+0 over and over again, finding a 2." Not any more, on any seed:
+  // the game's floor is a rung whose answers can be decomposed.
+  for (const seed of SEEDS) {
+    const { arena } = sit(seed, 1)
+    const res = arena.resonator
+    assert.ok(res, `seed ${seed.toString(16)} armed nothing`)
+    assert.ok(
+      res.target >= MIN_TARGET,
+      `seed ${seed.toString(16)} opened on ${res.target}, which is smaller than ${MIN_TARGET}`,
+    )
+    const tiles = primeFactors(res.target)
+    assert.ok(
+      tiles.length >= MIN_TILES,
+      `seed ${seed.toString(16)} opened on ${res.target} = ${tiles.join("·")}, which is not a tree`,
+    )
+    assert.ok(isSmooth(res.target), `${res.target} needs a mote nobody can read`)
+  }
+})
+
+test("ten minutes of perfect play is spent on the real game, not below it", () => {
+  let targets: number[] = []
+  let withoutQuestionMs = 0
+  const rungs: number[] = []
+  for (const seed of SEEDS) {
+    const played = sit(seed)
+    targets = targets.concat(played.targets)
+    withoutQuestionMs += played.withoutQuestionMs
+    rungs.push(...played.host.servedRungs())
+    assert.equal(played.arena.stalled, false, `seed ${seed.toString(16)} ended stalled`)
+    // The host's own ladder ends inside the band too, because every request the
+    // game makes moves it — a pack that drove the stream out of its own reach and
+    // left it there is the shape of the defect at the other end of this fix.
+    const position = played.host.position()
+    assert.ok(
+      position >= rungOf(FLOOR) && position <= rungOf(CEILING),
+      `seed ${seed.toString(16)} left the host standing on rung ${position}`,
+    )
+    // And the game's second stage was there from the opening question, not after
+    // a warm-up: `firstTreeMs` is the frame the first real factor tree arrived on.
+    assert.equal(
+      played.firstTreeMs,
+      FRAME_MS,
+      `the first target with a factor tree in it arrived at ${String(played.firstTreeMs)}ms`,
+    )
+  }
+  assert.ok(targets.length > 400, `only ${targets.length} resonators over ${SEEDS.length} sittings`)
+
+  // Measured at 84%; the rest are the rationed wall and the fallback tier.
+  const trees = targets.filter(
+    (t) => t >= MIN_TARGET && primeFactors(t).length >= MIN_TILES,
+  ).length
+  assert.ok(
+    trees / targets.length > 0.7,
+    `only ${((trees / targets.length) * 100).toFixed(0)}% of targets had a factor tree — was 42%`,
+  )
+
+  // Nothing under twelve, ever. This is the founder's "finding a 2".
+  const small = targets.filter((t) => t < MIN_TARGET)
+  assert.deepEqual(small, [], `targets below ${MIN_TARGET} were still being asked for`)
+
+  // And every mote a hold needs is one the game will actually draw. Three-digit
+  // answers are 65% factor trees and only 37% *readable* ones, so over ten
+  // minutes at the top of the band this is the difference between holds made of
+  // motes a child recognises and holds with a 397 in them.
+  const unreadable = targets.filter((t) => primeFactors(t).length > 1 && !isSmooth(t))
+  assert.deepEqual(
+    unreadable.map((t) => `${t}=${primeFactors(t).join("·")}`),
+    [],
+    "a hold needed a mote larger than the game draws",
+  )
+
+  // The arena is essentially never without something to answer. Measured at
+  // roughly 500 of every 600 seconds before and at 10 seconds in 3,000 after —
+  // the fallback tier refuses a hold with an unreadable mote in it, and a couple
+  // of `REARM_MS` waits a sitting is what that costs.
+  assert.ok(
+    withoutQuestionMs < 45_000,
+    `the arena had no question for ${(withoutQuestionMs / 1000).toFixed(0)}s across five sittings`,
+  )
+
+  // And no rung below the floor was ever served — not even once, not even while
+  // the game was walking outward looking for something usable.
+  const belowFloor = rungs.filter((r) => r < rungOf(FLOOR))
+  assert.deepEqual(belowFloor, [], `${belowFloor.length} draws came from below the floor`)
+  const aboveCeiling = rungs.filter((r) => r > rungOf(CEILING))
+  assert.deepEqual(aboveCeiling, [], `${aboveCeiling.length} draws came from above the ceiling`)
+})
+
+test("the sitting climbs: the twentieth question is bigger work than the first", () => {
+  // "those level of problem should come fairly quickly." Compare the opening
+  // three targets of a sitting against three from further in, over every seed, so
+  // one lucky draw cannot carry the claim in either direction.
+  let opening = 0
+  let later = 0
+  let openingTiles = 0
+  let laterTiles = 0
+  for (const seed of SEEDS) {
+    const { targets } = sit(seed, 30_000)
+    assert.ok(targets.length > 30, `only ${targets.length} targets`)
+    for (const t of targets.slice(0, 3)) {
+      opening += t
+      openingTiles += primeFactors(t).length
+    }
+    for (const t of targets.slice(20, 23)) {
+      later += t
+      laterTiles += primeFactors(t).length
+    }
+  }
+  // Measured: about 800 → about 9,500 over five seeds' worth of three targets.
+  assert.ok(
+    later > opening * 3,
+    `the target went from ${opening} to ${later} over twenty resonators — it is not climbing`,
+  )
+  // The *hold* deliberately does not grow with it, and that is worth an assertion
+  // rather than a hope. What gets harder is the arithmetic — a two-digit sum
+  // becomes a three-digit one — while the tree stays three to five motes, because
+  // a hold is a thing a child has to fly around and collect and `BANK_CAPACITY` is
+  // twelve. A design where both grew would put a nine-mote hold behind a
+  // three-digit sum and the round would take a minute of flying.
+  const perTarget = (n: number) => n / (3 * SEEDS.length)
+  assert.ok(
+    perTarget(openingTiles) >= MIN_TILES,
+    `the opening hold averaged ${perTarget(openingTiles).toFixed(1)} tiles`,
+  )
+  assert.ok(
+    perTarget(laterTiles) >= MIN_TILES && perTarget(laterTiles) <= 7,
+    `the twentieth hold averaged ${perTarget(laterTiles).toFixed(1)} tiles, which is a lot of flying`,
+  )
+})
+
+test("and there is variety: the sitting is not one rung over and over", () => {
+  // "some variety .. it's just stuck on 2+0 and 0+3, 2+1 forever."
+  const { host, targets } = sit(SEEDS[2] as number, 30_000)
+  const rungs = new Set(host.servedRungs())
+  assert.ok(rungs.size >= 8, `a whole sitting drew from only ${rungs.size} rungs`)
+  const distinct = new Set(targets)
+  assert.ok(
+    distinct.size > targets.length * 0.6,
+    `${distinct.size} distinct targets out of ${targets.length} — the stream repeats itself`,
+  )
+  // And the holds are not all the same shape either.
+  const shapes = new Set(targets.map((t) => primeFactors(t).join("·")))
+  assert.ok(shapes.size > 20, `only ${shapes.size} distinct factor trees in a sitting`)
+})
+
+test("a question the child was never shown is closed, not left hanging", () => {
+  // An arming draws until it finds a target with a factor tree in it, so most
+  // draws are discarded. Reported as wrong they would be MISSes on questions
+  // nobody saw; left alone they would sit open in the host's ledger forever.
+  const { host, draws, skipped, targets } = sit(SEEDS[1] as number, 20_000)
+  assert.ok(draws.length > targets.length, "no draw was ever discarded, so this proves nothing")
+  assert.ok(skipped.length > 0, "discarded draws were never skipped")
+  const open = host.openItems()
+  // What may still be open: the resonator currently on the board, and at most the
+  // handful whose answers were reported. Nothing else.
+  assert.ok(
+    open.length <= 2,
+    `${open.length} of ${draws.length} drawn questions were left open in the ledger`,
+  )
+  // Exactly: every draw is either the one the resonator took or one that was
+  // closed. `>=` would have been an identity nothing could violate.
+  assert.equal(
+    skipped.length + targets.length,
+    draws.length,
+    `${draws.length} draws, ${targets.length} used, ${skipped.length} skipped — ` +
+      `${draws.length - targets.length - skipped.length} went nowhere`,
+  )
+})
+
+test("a barren band is an arena with something to shoot, not an empty screen", () => {
+  // **The fresh profile.** The real host warms its prefetch pool at *its* own
+  // position, which for a brand new profile is rung 0 — answers of one to three —
+  // and the first request this game makes flushes that pool down to a reserve of
+  // eight of them. So the first arming of the first session can be six draws of
+  // `2 + 0`, nothing resonant, nothing the fallback tier will take either, and a
+  // stall on the very first frame — before `arm` has reached the line that puts
+  // anything on the screen at all.
+  //
+  // A host that only ever serves the bottom of the ladder, whatever is asked for,
+  // is exactly that situation held still.
+  const bottom = createStubHost({ seed: 0x60770, reducedMotion: true })
+  const stuck: StubHost = {
+    ...bottom,
+    next: () => bottom.next({ difficulty: 0 }),
+  }
+  const arena = new Arena(stuck, new Rng(0x60770), { width: 900, height: 700 })
+  const events = arena.begin(0)
+
+  assert.equal(arena.stalled, true, "the bottom of the ladder armed a resonator")
+  assert.ok(events.some((e) => e.kind === "stalled"), "the stall was not announced")
+  assert.equal(arena.resonator, null, "a stall left a resonator hanging")
+  // And the thing that makes "the arena stays playable" true rather than a comment.
+  assert.ok(
+    arena.bodies.length > 0,
+    "a child's first session opened on an empty grid with nothing to shoot",
+  )
+  assert.ok(
+    arena.bodies.some((b) => !b.prime),
+    "the field had no husk on it, so there was nothing to crack",
+  )
+  // The passive layer works on it: grind it down and the tile bar fills.
+  grindToPrimes(arena)
+  const mote = arena.bodies[0]
+  assert.ok(mote)
+  assert.equal(arena.touch(mote.id)[0]?.kind, "sweep")
+  assert.equal(arena.bank.size, 1)
+  // Nothing is reported, because nobody asked anything.
+  assert.deepEqual(arena.enter(1000), [], "a resonator that does not exist answered something")
+
+  // And it keeps asking. The wait is real but it is a wait, not a session.
+  assert.deepEqual(arena.rearm(10), [], "the arena re-armed before its own wait was up")
+  arena.step(120)
+  arena.step(120)
+  let waited = 240
+  let armed = false
+  for (let i = 0; i < 200 && !armed; i++) {
+    waited += 120
+    arena.step(120)
+    armed = arena.rearm(waited).some((e) => e.kind === "arrive" || e.kind === "stalled")
+  }
+  assert.ok(armed, "the arena stopped asking for a question altogether")
+  assert.ok(waited < 10_000, `it waited ${waited}ms before asking again`)
+})
+
+test("the game learns from the rung that answered, not the rung it asked for", () => {
+  // **`host.next` does not serve what you asked for.** It serves the pooled
+  // question *closest* to the request, and the pool was stocked for whatever came
+  // before — measured against the real adapter, 104 of 175 draws came from a rung
+  // other than the one named, by as much as nineteen. `question.difficulty` is
+  // where the truth is, and `items.ts` says so in as many words: "the pack is told
+  // what it got and not what it asked for."
+  //
+  // Learning from the request instead writes live rungs off as barren and snaps
+  // the position onto a rung the child never saw, which breaks all three of the
+  // mechanisms this fix is built on.
+  const STALE = 21
+  const inner = createStubHost({ seed: 0x57a1e, reducedMotion: true })
+  const asked: number[] = []
+  const stale: StubHost = {
+    ...inner,
+    next: (request) => {
+      asked.push(request?.difficulty ?? -1)
+      // Every request answered from one rung, whatever was named — the shape of a
+      // pool stocked before the game started driving.
+      return inner.next({ ...request, difficulty: STALE / (RUNGS - 1) })
+    },
+  }
+  const arena = new Arena(stale, new Rng(0x57a1e), { width: 900, height: 700 })
+  arena.begin(0)
+  assert.ok(arena.resonator, "the stale host armed nothing")
+  assert.ok(asked.length > 0)
+  assert.ok(
+    asked.some((a) => rungOf(a) !== STALE),
+    "the game never asked for anything other than the rung it got, so this proves nothing",
+  )
+
+  // The position followed the content, not the request.
+  assert.equal(
+    arena.ladder.rung,
+    STALE,
+    `the game thinks it is on rung ${arena.ladder.rung} while every question came from ${STALE}`,
+  )
+  // And the barren tally was charged against the rung that answered. The rungs it
+  // *asked* for were never actually tried, so none of them may have been written
+  // off — a rung with no record reads as a full yield of 1.
+  for (const difficulty of asked) {
+    const rung = rungOf(difficulty)
+    if (rung === STALE) continue
+    assert.equal(
+      arena.ladder.yieldOf(rung),
+      1,
+      `rung ${rung} was scored on an item that came from rung ${STALE}`,
+    )
+  }
+})
+
+test("a second wrong hold in the same ring is not a second wrong answer", () => {
+  // The id is spent on the first assertion and nothing after it is reported, so
+  // moving the position on every subsequent one would let a child who keeps
+  // bumping the ring walk the whole band down in about seven seconds — with the
+  // game's idea of where they are drifting away from the host's over questions the
+  // host never received.
+  const { arena, reports } = rig(0x2ce2)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  const wrong = arena.bodies.filter((b) => b.prime && b.value !== res.target)
+  assert.ok(wrong.length >= 2, "not enough loose primes to be wrong twice")
+
+  // Off the floor first, or the clamp hides the whole effect.
+  for (let i = 0; i < 4; i++) arena.ladder.opened()
+  const before = arena.ladder.at
+  arena.touch((wrong[0] as { id: number }).id)
+  arena.enter(1000)
+  const afterFirst = arena.ladder.at
+  assert.ok(afterFirst < before, "a refusal did not move the ladder at all")
+  assert.equal(reports.length, 1)
+
+  // Three more trips into the same ring, each with a genuinely wrong hold.
+  for (let i = 0; i < 3; i++) {
+    arena.step(1000)
+    const mote = arena.bodies.find((b) => b.prime && b.value !== res.target)
+    if (!mote) break
+    arena.touch(mote.id)
+    arena.enter(2000 + i * 1000)
+  }
+  assert.equal(reports.length, 1, "the same question was answered to the host twice")
+  assert.equal(
+    arena.ladder.at,
+    afterFirst,
+    "bumping a ring whose id was already spent walked the ladder down again",
+  )
+})
+
+test("a host with no skip is still a host this game runs on", () => {
+  // `skip` is feature-detected, like `transition`. A runtime older than the one
+  // that grew it must not be a pack that throws on its first arming.
+  const bare = createStubHost({ seed: 0x0b4e, reducedMotion: true })
+  const { skip, ...rest } = bare
+  void skip
+  const arena = new Arena(rest as unknown as StubHost, new Rng(0x0b4e), {
+    width: 900,
+    height: 700,
+  })
+  arena.begin(0)
+  assert.ok(arena.resonator, "a host without skip armed nothing")
+  const played = playCarefully(arena, 4000, FRAME_MS)
+  assert.ok(played.targets.length > 2, `only ${played.targets.length} resonators`)
+})
+
+test("the wall still comes round, and it is never a hunt for a 2", () => {
+  // Primeness is the property this whole game stands on and it must not have been
+  // filtered out of existence — but "find the 2" is what ten minutes of it felt
+  // like, so it is rationed and it has a floor.
+  let walls = 0
+  let total = 0
+  for (const seed of SEEDS) {
+    const { targets } = sit(seed, 30_000)
+    total += targets.length
+    for (const t of targets) {
+      if (primeFactors(t).length !== 1) continue
+      walls += 1
+      assert.ok(t >= 13, `a resonator asked for the prime ${t}`)
+    }
+  }
+  assert.ok(walls > 0, "the wall was filtered out of the game entirely")
+  assert.ok(
+    walls / total < 0.3,
+    `${((walls / total) * 100).toFixed(0)}% of resonators were a hunt for one mote`,
+  )
+})

--- a/dynawalla/games/lattice/src/test/resonance.test.ts
+++ b/dynawalla/games/lattice/src/test/resonance.test.ts
@@ -8,8 +8,18 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { Bank } from "../game/bank.ts"
-import { isPrime, primeFactors, productOf } from "../game/factor.ts"
-import { isAskable, opens, resonate } from "../game/resonance.ts"
+import { isPrime, LARGEST_MOTE_PRIME, primeFactors, productOf } from "../game/factor.ts"
+import {
+  isAskable,
+  isResonant,
+  isSmooth,
+  MIN_TARGET,
+  MIN_TILES,
+  MIN_WALL,
+  opens,
+  resonate,
+  tileCount,
+} from "../game/resonance.ts"
 
 /** Every multiset of primes drawn from `alphabet` with at most `depth` tiles. */
 function banksFrom(alphabet: readonly number[], depth: number): number[][] {
@@ -113,6 +123,73 @@ test("a target the arena will not ask for is refused rather than fudged", () => 
   // And if one ever got through, the rule refuses rather than opening.
   assert.equal(opens(1, [2]), false)
   assert.equal(opens(0, [2]), false)
+})
+
+test("a target with nothing to decompose is not a target this game asks for", () => {
+  // **The founder's report, as a predicate.** "I'm seeing 2+0 over and over
+  // again, finding a 2" — every one of those answers is `isAskable` and none of
+  // them is `isResonant`, because the game's second stage does not exist at one
+  // tile and is a formality at two.
+  const wall = { wall: false }
+  for (const degenerate of [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) {
+    assert.equal(
+      isResonant(degenerate, 999, wall),
+      false,
+      `${degenerate} = ${primeFactors(degenerate).join("·")} was accepted as a resonator target`,
+    )
+  }
+  // And the founder's own examples are.
+  assert.equal(isResonant(12, 999, wall), true, "8 + 4 = 12 = 2·2·3 was refused")
+  assert.equal(isResonant(72, 999, wall), true, "47 + 25 = 72 = 2·2·2·3·3 was refused")
+  assert.equal(tileCount(72), 5)
+  // A semiprime is legal and is not this game: one crack, and no choice about it.
+  assert.equal(isResonant(15, 999, wall), false, "15 = 3·5 has one crack in it")
+  assert.equal(isResonant(91, 999, wall), false, "91 = 7·13 has one crack in it")
+  assert.equal(MIN_TILES, 3)
+  assert.equal(MIN_TARGET, 12)
+})
+
+test("the wall is kept, rationed, and never a hunt for a 2", () => {
+  // Primeness is the property the whole game stands on, so a filter that deleted
+  // it would be worse than the defect. It survives — behind a flag the arena
+  // owns, because how often a wall comes round is pacing.
+  assert.equal(isResonant(41, 999, { wall: true }), true, "the wall was filtered out of the game")
+  assert.equal(isResonant(41, 999, { wall: false }), false, "the wall is not rationed at all")
+  assert.equal(isResonant(991, 999, { wall: true }), true)
+  // But never the degenerate end of it, flag or no flag.
+  for (const small of [2, 3, 5, 7, 11]) {
+    assert.equal(
+      isResonant(small, 999, { wall: true }),
+      false,
+      `a resonator would have asked a child to find a ${small}`,
+    )
+  }
+  assert.equal(MIN_WALL, 13)
+})
+
+test("every prime in a target is one the game can draw as a readable mote", () => {
+  // `794` is three digits, composite, and factorises as `2 · 397` — so the old bar
+  // took it and sent the child to find a 397, while `MOTE_PRIMES` has always
+  // stopped at 47. Three-digit answers are 65% trees and only 37% *readable*
+  // trees, so this is the difference between 804 = 2·2·3·67 and 600 = 2·2·2·3·5·5.
+  assert.equal(LARGEST_MOTE_PRIME, 47)
+  assert.equal(isSmooth(600), true, `600 = ${primeFactors(600).join("·")}`)
+  assert.equal(isSmooth(804), false, `804 = ${primeFactors(804).join("·")}`)
+  assert.equal(isResonant(804, 999, { wall: false }), false, "804 needs a 67 mote")
+  assert.equal(isResonant(794, 999, { wall: false }), false, "794 needs a 397 mote")
+  assert.equal(isResonant(600, 999, { wall: false }), true)
+  // A prime target is exempt: the single mote carrying it is the whole point, and
+  // a 991 drifting on its own is the most legible thing in the game.
+  assert.equal(isResonant(991, 999, { wall: true }), true, "a large prime wall was refused")
+  // Exhaustively: nothing the game will ask for needs a mote it will not draw.
+  for (let target = 2; target <= 999; target++) {
+    if (!isResonant(target, 999, { wall: true })) continue
+    if (isPrime(target)) continue
+    assert.ok(
+      Math.max(...primeFactors(target)) <= LARGEST_MOTE_PRIME,
+      `${target} = ${primeFactors(target).join("·")} is a target with an unreadable mote in it`,
+    )
+  }
 })
 
 test("the bank's own invariant holds through the resonance rule", () => {

--- a/dynawalla/games/lattice/src/test/ship.test.ts
+++ b/dynawalla/games/lattice/src/test/ship.test.ts
@@ -1,0 +1,319 @@
+// THE SHIP.
+//
+// > "the ship moves around too wildly too - at least on my android .. I'd like
+// > the ship to be a little bit smoother and easier to control."
+//
+// "At least on my android" is the whole diagnosis. `render/scene.ts` says the
+// arena's coordinate space *is* CSS pixel space, so the world is exactly as big
+// as the viewport — and every speed in `arena.ts` was an absolute number of CSS
+// pixels per second, tuned against a tablet. Measured on the shipped code:
+//
+//     phone landscape 800×360   top 597px/s = 0.68 of the world's diagonal a second
+//     phone portrait  390×740   top 597px/s = 0.71 diagonals a second
+//     tablet         1180×820   top 597px/s = 0.42 diagonals a second
+//
+// The same ship crossed 1.72× more screen per second on the phone than on the
+// tablet it was tuned on. That is not tuning and it is not fixable by lowering a
+// constant — lowering it would make the tablet sluggish. After: 0.300 diag/s on
+// all three, exactly.
+//
+// And two frame-rate defects behind it, of the class `games/balance` found when a
+// spring integrator reached −1.2×10²⁰⁴ at 20fps:
+//
+//     top speed        144fps 610px/s   60fps 597px/s   20fps 556px/s
+//     coast            144fps 143px     60fps 137px     20fps 119px
+//     shots that hit   144fps 80/80     60fps 80/80     20fps 71/80
+//
+// A ninth of every shot passed straight through the husk it was aimed at on a
+// slow Android, because a shot travels 56px in a 50ms frame against a 58px-wide
+// hit window and the arena was not substepped. "My shots don't hit" is not the
+// child's aim.
+//
+// **Every assertion below has been verified to fail with the fix removed**, by
+// putting the old constants and the single-step integrator back — see the report
+// on the pull request for the exact failure messages.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena, HUSK_R, MOTE_R, SHIP_R, SHOT_R } from "../game/arena.ts"
+import { createStubHost } from "../stubHost.ts"
+
+/** The three screens this pack has to be the same game on. */
+const SCREENS: Array<readonly [string, number, number]> = [
+  ["phone landscape", 800, 360],
+  ["phone portrait", 390, 740],
+  ["tablet", 1180, 820],
+]
+/**
+ * The rates the ship has to be the same ship at.
+ *
+ * 60/30/20 are the three anybody measures, and they are also the three where
+ * `ceil(dt / 16.667)` lands on a substep of exactly 1/60s — so a merely
+ * *substepped* integrator agrees perfectly at all three and is 2% fast at 45fps
+ * and 4% fast on a 144Hz screen, which is every current flagship. The ship's
+ * dynamics are solved in closed form rather than iterated, so the list can
+ * include the awkward rates.
+ */
+const RATES = [144, 120, 90, 72, 60, 50, 45, 30, 24, 20]
+
+type Spawn = { spawnAt(v: number, x: number, y: number, vx: number, vy: number): void }
+
+/** An arena with nothing in it, so the ship is the only thing being measured. */
+function bare(w: number, h: number, seed = 0x5417): Arena {
+  const host = createStubHost({ seed, reducedMotion: true })
+  const arena = new Arena(host, new Rng(seed), { width: w, height: h })
+  arena.begin(0)
+  arena.bodies.length = 0
+  arena.shots.length = 0
+  arena.resonator = null
+  return arena
+}
+
+/**
+ * Full deflection along the long axis from the near wall, so nothing bounces.
+ *
+ * Two seconds by default, which is fifteen time constants: the ship is at its
+ * steady state to within a rounding error, so what comes back is the top speed
+ * and not "how far along the ramp 600ms happened to get at this frame rate".
+ */
+function runUp(arena: Arena, w: number, h: number, fps: number, ms = 2000): number {
+  const dt = 1000 / fps
+  const alongX = w >= h
+  arena.ship.x = alongX ? SHIP_R + 1 : w / 2
+  arena.ship.y = alongX ? h / 2 : SHIP_R + 1
+  arena.ship.vx = 0
+  arena.ship.vy = 0
+  arena.setMove(alongX ? 1 : 0, alongX ? 0 : 1)
+  for (let t = 0; t < ms; t += dt) arena.step(dt)
+  return Math.hypot(arena.ship.vx, arena.ship.vy)
+}
+
+test("the ship covers the same fraction of the screen on every screen", () => {
+  // The Android bug. Not "the same number of pixels" — the same fraction, because
+  // the world is the viewport and a fraction is what a thumb feels.
+  const fractions = SCREENS.map(([name, w, h]) => {
+    const diagonal = Math.hypot(w, h)
+    const top = runUp(bare(w, h), w, h, 60)
+    return { name, fraction: top / diagonal, top }
+  })
+  const lo = Math.min(...fractions.map((f) => f.fraction))
+  const hi = Math.max(...fractions.map((f) => f.fraction))
+  assert.ok(
+    hi / lo < 1.05,
+    `the ship crosses ${(hi / lo).toFixed(2)}× more screen per second on ` +
+      `${fractions.find((f) => f.fraction === hi)?.name} than on ` +
+      `${fractions.find((f) => f.fraction === lo)?.name}: ` +
+      fractions.map((f) => `${f.name} ${f.fraction.toFixed(3)} diag/s`).join(", "),
+  )
+  // And the absolute speeds really do differ, or the test above proves nothing:
+  // a ship that ignored the screen would pass it too.
+  const tops = fractions.map((f) => Math.round(f.top))
+  assert.notEqual(
+    new Set(tops).size,
+    1,
+    `every screen got the same absolute speed ${tops.join("/")} — the scaling is not happening`,
+  )
+})
+
+test("the ship behaves identically at every frame rate a device has", () => {
+  // Solved rather than stepped, so this is exact agreement across ten rates from
+  // 144fps down to 20 — not a tolerance, which is what makes it worth asserting.
+  for (const [name, w, h] of SCREENS) {
+    const tops = RATES.map((fps) => runUp(bare(w, h), w, h, fps))
+    const lo = Math.min(...tops)
+    const hi = Math.max(...tops)
+    assert.ok(
+      hi - lo < 0.01,
+      `${name}: top speed was ${tops.map((t) => t.toFixed(3)).join(" / ")} at ` +
+        `${RATES.join("/")}fps — the ship is faster on a fast phone`,
+    )
+
+    // And the same for the coast, which is the part a thumb feels most.
+    const coasts = RATES.map((fps) => {
+      const dt = 1000 / fps
+      const arena = bare(w, h)
+      const top = runUp(arena, w, h, fps)
+      arena.ship.x = w / 2
+      arena.ship.y = h / 2
+      arena.ship.vx = w >= h ? top : 0
+      arena.ship.vy = w >= h ? 0 : top
+      arena.setMove(0, 0)
+      const from = w >= h ? arena.ship.x : arena.ship.y
+      for (let t = 0; t < 2000; t += dt) arena.step(dt)
+      return Math.abs((w >= h ? arena.ship.x : arena.ship.y) - from)
+    })
+    assert.ok(
+      Math.max(...coasts) - Math.min(...coasts) < 0.05,
+      `${name}: the coast was ${coasts.map((c) => c.toFixed(2)).join(" / ")}px at ${RATES.join("/")}fps`,
+    )
+  }
+})
+
+test("the ship can stop on a mote instead of only passing over one", () => {
+  // What "moves around too wildly" is, mechanically. The coast was 126px against
+  // a 32px sweep reach — four sweeps' worth of overshoot, so a child could never
+  // arrive at a mote, only fly past it and come back.
+  const reach = SHIP_R + MOTE_R
+  for (const [name, w, h] of SCREENS) {
+    const arena = bare(w, h)
+    assert.ok(
+      arena.shipCoast < reach * 2,
+      `${name}: the ship carries ${arena.shipCoast.toFixed(0)}px after the thumb comes off, ` +
+        `against a ${reach}px sweep reach`,
+    )
+    // And it is not so tight that the ship cannot cross its own arena: a coast
+    // shorter than the ship's own radius would be a brick.
+    assert.ok(arena.shipCoast > SHIP_R, `${name}: the ship stops dead in ${arena.shipCoast}px`)
+  }
+})
+
+test("a shot hits the husk it was aimed at, at every frame rate", () => {
+  // The tunnelling. A shot's step at 20fps is 56px against a 58px window, so it
+  // stepped over its target about a ninth of the time; substepping closes it.
+  const window = (SHOT_R + HUSK_R) * 2
+  for (const [name, w, h] of SCREENS) {
+    for (const fps of RATES) {
+      const dt = 1000 / fps
+      let cracked = 0
+      const runs = 60
+      for (let k = 0; k < runs; k++) {
+        const arena = bare(w, h, 0x5417 + k)
+        const alongX = w >= h
+        const top = runUp(arena, w, h, fps, 500)
+        void top
+        const here = alongX ? arena.ship.x : arena.ship.y
+        const long = alongX ? w : h
+        // A husk a little further away each run, so a phase that happens to line
+        // up cannot carry the result.
+        const gap = Math.min(long - here - 60, 180 + (k / runs) * 200)
+        assert.ok(gap >= 80, `${name}: no room to fire in — the run-up ate the arena`)
+        ;(arena as unknown as Spawn).spawnAt(
+          72,
+          alongX ? here + gap : w / 2,
+          alongX ? h / 2 : here + gap,
+          0,
+          0,
+        )
+        arena.setAim(alongX ? 1 : 0, alongX ? 0 : 1)
+        const before = arena.bodies.length
+        arena.fire()
+        arena.setMove(0, 0)
+        for (let t = 0; t < 1600; t += dt) arena.step(dt)
+        if (arena.bodies.length !== before) cracked += 1
+      }
+      assert.equal(
+        cracked,
+        runs,
+        `${name} at ${fps}fps: ${runs - cracked} of ${runs} shots passed through the husk ` +
+          `(a ${window}px window)`,
+      )
+    }
+  }
+})
+
+test("a mote in the ship's path is swept and not flown over", () => {
+  for (const [name, w, h] of SCREENS) {
+    for (const fps of RATES) {
+      const dt = 1000 / fps
+      let swept = 0
+      const runs = 40
+      for (let k = 0; k < runs; k++) {
+        const arena = bare(w, h, 0x9107 + k)
+        const alongX = w >= h
+        const top = runUp(arena, w, h, fps, 500)
+        const here = alongX ? arena.ship.x : arena.ship.y
+        const gap = 110 + (k / runs) * (top / fps)
+        ;(arena as unknown as Spawn).spawnAt(
+          5,
+          alongX ? here + gap : w / 2,
+          alongX ? h / 2 : here + gap,
+          0,
+          0,
+        )
+        const limit = (alongX ? w : h) - SHIP_R - 2
+        for (let t = 0; t < 1500 && (alongX ? arena.ship.x : arena.ship.y) < limit; t += dt) {
+          arena.step(dt)
+        }
+        if (arena.bank.size > 0) swept += 1
+      }
+      assert.equal(swept, runs, `${name} at ${fps}fps: ${runs - swept} of ${runs} motes flown over`)
+    }
+  }
+})
+
+test("nothing that is not a number can reach the ship's position", () => {
+  // Three doors, and none of them was guarded. `move` is multiplied into the
+  // ship's velocity every substep, so one NaN puts the ship beyond recovery for
+  // the rest of the session: `dist2` returns NaN, every `<` against it is false,
+  // and nothing can be swept or struck again. Silent, total and unreported.
+  const said: unknown[][] = []
+  const realError = console.error
+  console.error = (...args: unknown[]) => said.push(args)
+  try {
+    const arena = bare(900, 700)
+    const x0 = arena.ship.x
+    arena.setMove(Number.NaN, 0)
+    arena.setMove(0, Number.POSITIVE_INFINITY)
+    arena.setAim(Number.NaN, Number.NaN)
+    arena.step(Number.NaN)
+    arena.step(16)
+    arena.resize(Number.NaN, 700)
+    assert.ok(Number.isFinite(arena.ship.x), `the ship's x became ${arena.ship.x}`)
+    assert.ok(Number.isFinite(arena.ship.y), `the ship's y became ${arena.ship.y}`)
+    assert.ok(Number.isFinite(arena.ship.vx) && Number.isFinite(arena.ship.vy))
+    assert.equal(arena.ship.x, x0, "a NaN stick moved the ship")
+    assert.ok(Number.isFinite(arena.aiming.x) && Number.isFinite(arena.aiming.y))
+    assert.equal(arena.bounds.width, 900, "a NaN resize took the arena's box with it")
+    // And it was loud about every one of them. Silence is the actual defect here.
+    assert.equal(said.length, 5, `${said.length} of 5 bad inputs were reported`)
+  } finally {
+    console.error = realError
+  }
+})
+
+test("the hull turns toward the guns rather than snapping to them", () => {
+  // Pure calm, and the reason it is `facing` and not `aiming`: the shots leave
+  // along `aiming` on the frame the stick moved, so nothing about this makes the
+  // ship point anywhere its bullets are not going.
+  const arena = bare(900, 700)
+  arena.setAim(1, 0)
+  arena.step(16)
+  assert.ok(arena.facing.x > 0.99, "the hull did not settle on the direction it was given")
+  arena.setAim(-1, 0)
+  assert.equal(arena.aiming.x, -1, "the guns waited for the hull")
+  arena.step(16)
+  // One 16ms step at 18/s turns the hull a quarter of the way, so it is still
+  // pointing most of the way forward. `> -1` would be satisfied by anything short
+  // of a mathematically exact snap, which is not the claim.
+  assert.ok(
+    arena.facing.x > 0.5,
+    `one frame took the hull from +1 to ${arena.facing.x.toFixed(3)}, which is a snap`,
+  )
+  // And it gets there — a hull that eased forever would be a hull that lies.
+  for (let i = 0; i < 60; i++) arena.step(16)
+  assert.ok(arena.facing.x < -0.99, `the hull stalled at ${arena.facing.x.toFixed(3)}`)
+  assert.ok(
+    Math.abs(Math.hypot(arena.facing.x, arena.facing.y) - 1) < 1e-6,
+    "the hull's direction stopped being a direction",
+  )
+})
+
+test("the arena still slows a frame that arrives after a minute", () => {
+  // The substepping must not have replaced the clamp: a backgrounded tab hands
+  // back a delta of minutes, and simulating all of it would tear the whole sheet
+  // at once and teleport every husk.
+  const arena = bare(900, 700)
+  arena.setMove(1, 0)
+  const x0 = arena.ship.x
+  arena.step(120_000)
+  const far = arena.ship.x - x0
+  const other = bare(900, 700)
+  other.setMove(1, 0)
+  other.step(120)
+  assert.ok(
+    Math.abs(far - (other.ship.x - x0)) < 1,
+    `a two-minute frame moved the ship ${far.toFixed(0)}px`,
+  )
+})

--- a/dynawalla/games/lattice/src/test/steer.test.ts
+++ b/dynawalla/games/lattice/src/test/steer.test.ts
@@ -1,0 +1,89 @@
+// WHAT A THUMB MEANS.
+//
+// The other half of "the ship moves around too wildly". Both virtual sticks used
+// to divide the thumb's offset by 64 and hand the result straight to `setMove`,
+// which gave a resting thumb's tremor full authority and put full thrust a
+// centimetre from where the thumb landed. See `game/steer.ts`.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { CURVE, DEAD_ZONE, STICK_RANGE, shapeStick } from "../game/steer.ts"
+
+const size = (dx: number, dy: number, range = STICK_RANGE): number => {
+  const s = shapeStick(dx, dy, range)
+  return Math.hypot(s.x, s.y)
+}
+
+test("a thumb resting on glass moves nothing at all", () => {
+  // The tremor. A pixel or two of it used to be full-authority thrust in whatever
+  // direction the tremor happened to go.
+  for (const wobble of [0, 0.5, 1, 2, 3, 4, 5, 6]) {
+    assert.equal(size(wobble, 0), 0, `${wobble}px of tremor moved the ship`)
+    assert.equal(size(0, -wobble), 0)
+    assert.equal(size(wobble * 0.7, wobble * 0.7), 0)
+  }
+  // And the dead zone stops somewhere: this is a dead zone, not a dead stick.
+  assert.ok(size(STICK_RANGE * (DEAD_ZONE + 0.05), 0) > 0, "the stick past the dead zone is dead")
+  assert.ok(DEAD_ZONE > 0.02 && DEAD_ZONE < 0.25, `a dead zone of ${DEAD_ZONE} is not a dead zone`)
+})
+
+test("most of the stick's travel is the slow, accurate part", () => {
+  // The linear ramp put half thrust 32px out, so the part of the stick a child
+  // lines up on a mote with was about a centimetre wide and shared with
+  // everything else. The curve gives half deflection well under half authority.
+  const half = size(STICK_RANGE / 2, 0)
+  assert.ok(half > 0.05, `half deflection is ${half.toFixed(3)} — the stick is dead`)
+  assert.ok(half < 0.4, `half deflection is ${half.toFixed(3)} authority, which is still a ramp`)
+  assert.ok(CURVE > 1.2, `a curve of ${CURVE} is a straight line`)
+  // Monotone the whole way: a stick that is not monotone is a stick that fights.
+  let last = -1
+  for (let px = 0; px <= STICK_RANGE * 1.5; px += 1) {
+    const now = size(px, 0)
+    assert.ok(now >= last - 1e-12, `authority fell from ${last} to ${now} at ${px}px`)
+    last = now
+  }
+})
+
+test("full deflection is full authority and never more", () => {
+  assert.ok(Math.abs(size(STICK_RANGE, 0) - 1) < 1e-9, `full deflection is ${size(STICK_RANGE, 0)}`)
+  // Past the edge of the stick the thumb has run out of stick, not out of screen.
+  for (const px of [STICK_RANGE, 100, 400, 4000]) {
+    assert.ok(size(px, 0) <= 1 + 1e-9, `${px}px gave ${size(px, 0)} authority`)
+  }
+  assert.ok(Math.abs(size(4000, 0) - 1) < 1e-9)
+})
+
+test("the curve bends the magnitude and never the direction", () => {
+  // A stick that bends the direction is a stick that lies about where the child
+  // pointed, and on a twin-stick arena that is unplayable rather than imprecise.
+  for (const [dx, dy] of [
+    [30, 40],
+    [-70, 10],
+    [5, -300],
+    [1, 1],
+    [-22, -22],
+  ] as const) {
+    const shaped = shapeStick(dx, dy)
+    const m = Math.hypot(shaped.x, shaped.y)
+    if (m === 0) continue
+    const wantAngle = Math.atan2(dy, dx)
+    const gotAngle = Math.atan2(shaped.y, shaped.x)
+    assert.ok(
+      Math.abs(wantAngle - gotAngle) < 1e-9,
+      `(${dx},${dy}) came out pointing ${gotAngle} instead of ${wantAngle}`,
+    )
+  }
+})
+
+test("nothing that is not a number comes out of the stick", () => {
+  // The arena guards this from its own side too, and both guards are needed: one
+  // NaN in the move vector puts the ship's position beyond recovery.
+  for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    assert.deepEqual(shapeStick(bad, 0), { x: 0, y: 0 })
+    assert.deepEqual(shapeStick(0, bad), { x: 0, y: 0 })
+    assert.deepEqual(shapeStick(10, 10, bad), { x: 0, y: 0 })
+  }
+  assert.deepEqual(shapeStick(10, 10, 0), { x: 0, y: 0 }, "a zero-range stick divided by zero")
+  assert.deepEqual(shapeStick(10, 10, -5), { x: 0, y: 0 })
+})

--- a/dynawalla/games/lattice/src/test/stubHost.test.ts
+++ b/dynawalla/games/lattice/src/test/stubHost.test.ts
@@ -64,7 +64,9 @@ test("distractors are mal-rule outputs, not answer ± 1 noise", () => {
 test("a dropped carry is actually in there", () => {
   // 27 + 15 with every carry dropped is 32. Whatever else the stub produces,
   // this specific misconception has to be reachable or the diagnosis is empty.
-  const host = createStubHost({ seed: 0xca771 })
+  // Named on the ladder, because a carry needs two columns and the bottom of the
+  // ladder is single-digit facts — the very thing THE LATTICE was stuck on.
+  const host = createStubHost({ seed: 0xca771, difficulty: 30 / 65 })
   let found = false
   for (let i = 0; i < 3000 && !found; i++) {
     const q = host.next()


### PR DESCRIPTION
> "'the lattice' has a lot of potential but it stays way too easy way too long .. I must have played for 10 minutes and I'm doing it perfectly and I'm seeing 2+0 over and over again, finding a 2 .. then 3+0 and finding a 3 .. the 'real game' never seems to come where I have eg the example 47+25 ... and I must collect 2\*2\*2\*3\*3"

> "the ship moves around too wildly too - at least on my android .. I'd like the ship to be a little bit smoother and easier to control."

## 1. It never asked to move

```ts
const drawn = this.host.next({ domain: "add" })
```

A domain, and never a difficulty. `domain` is a cosmetic label, so that line is a shrug: the resonator carried whatever rung the host's own ladder happened to be standing on — rung 0 of 66 at the start of a session, which is `dw.add.facts.add-within-ten`, answers of one to three. `2` has no factor tree, so the game's second stage did not exist and ten minutes of it was "find a 2".

**And the far end, which nobody had reported because nobody had reached it.** Above rung 47 the host's answers are four and five digits, every draw fails `isAskable`, and the arena *stalled* — permanently, because there was no retry, leaving the previous resonator hanging with its id already spent. A child could fly into that ring forever and the host would never hear another word. Both ends are the same bug: the game never said what it needed, so it was carried past it in one direction and left below it in the other.

Ten minutes of perfect play, five seeds, a bot doing the arithmetic, against a host modelling the shipped 66-rung wire (`toUnit`, a request honoured as a point, `maxDifficulty` flooring, the host's own staircase moving on `report`):

| | before | after |
|---|---|---|
| draws that named a difficulty | **0 of 270** | 1,650 of 1,650 |
| rung reached (min / median / max) | 0 / 29 / 50 | 16 / 45 / 47 |
| targets with a factor tree | 42% | **82%** |
| targets under 12 ("find a 2") | 21% | **0%** |
| time with no resonator at all | **~500s of every 600** | 8s in 3,000 |
| first four targets | 5, 7, 10, 16 | 36, 40, 60, 98 |

## 2. What the game needs from an item to be itself

> A whole number from 12 to 999 whose prime factorisation has at least three factors, every one of them a prime the game draws as a readable mote — or, one resonator in five, a prime of 13 or more, which is the wall.

**Three, not two.** At one factor there is nothing to decompose. At two — `15 → 3·5` — there is exactly one crack and no choice about which one, so "decide which primes multiply to it" is a formality. Three is the first count at which the child chooses an order, a husk comes apart twice, and the tile bar shows a tree instead of a fact.

**Twelve**, because below twelve the only value with three prime factors is `8 = 2·2·2`, and a hold of three identical twos is the absorption the passive layer gives away for free.

**Readable**, because `MOTE_PRIMES` has always said which primes are "small enough to be drawn as a drifting mote and read at speed" and it stops at 47 — while the old bar happily asked for `794 = 2 · 397`. Three-digit answers are 65% factor trees and only 37% *readable* ones, which is the difference between `600 = 2·2·2·3·5·5` and `804 = 2·2·3·67`.

**So the honest fix is a floor, and it is the opposite of what `counterweight` needed.** `raiseFloor` is deliberately not called: that primitive is for an achievement (`siege`'s wave counter) and would permanently rewrite a child's ladder for every other pack because of what this one can draw. The floor is expressed by simply never asking below it. A ceiling exists too, for the ordinary reason — `MAX_TARGET` is 999.

Generating items from every rung of the shipped graph puts the band at rungs 16–47. The floor/ceiling constants are a *hint*, not a dependency: every arming walks outward and snaps its position to whichever rung actually produced a resonant target, so a ladder that grows moves the game with it inside one resonator.

Nothing is hardcoded. Everything comes from the curriculum through `host.next`, or from the seeded `Rng`.

## 3. The ship

`render/scene.ts` says it plainly: the arena's coordinate space **is** CSS pixel space, no camera, no transform. So the world is exactly as big as the viewport — and every speed was an absolute number of CSS pixels a second, tuned on a tablet.

| | phone landscape 800×360 | phone portrait 390×740 | tablet 1180×820 |
|---|---|---|---|
| top speed, before | 597px/s = **0.68 diag/s** | 597px/s = **0.71 diag/s** | 597px/s = 0.42 diag/s |
| top speed, after | 263px/s = 0.300 diag/s | 251px/s = 0.300 diag/s | 431px/s = 0.300 diag/s |

**1.72× more screen per second on the phone than on the tablet it was tuned on** — the bug, and not fixable by lowering a constant, because lowering it makes the tablet sluggish.

Two frame-rate defects behind it, of the class `games/balance` found at −1.2×10²⁰⁴:

| | 144fps | 60fps | 45fps | 30fps | 20fps |
|---|---|---|---|---|---|
| top speed, before | 610px/s | 597px/s | 590px/s | 577px/s | 556px/s |
| coast, before | 143px | 137px | 134px | 128px | 119px |
| shots that hit, before | 80/80 | 80/80 | 80/80 | 80/80 | **71/80** |
| after | identical to six decimal places, and 80/80 at every rate |

A ninth of every shot passed through the husk it was aimed at on a slow Android — a 56px step against a 58px window, unsubstepped. The sheet already was substepped, at 240Hz, for exactly this reason.

`ceil(dt/16.67)` lands on a substep of exactly 1/60s at 60, 30 **and** 20fps — the three rates anybody measures — so a substepped-only integrator agreed perfectly at all three and was still 2% fast at 45fps and 4% fast on the 120/144Hz panels every current flagship ships. So the ship is **solved** rather than stepped: `v' = k(V − v)` in closed form. The substepping stays, because it is what stops a shot stepping over a husk.

**Which part was bug and which was taste:**

* **Bug** — the CSS-pixel world (device-dependent speed), the unsubstepped collisions (tunnelling), the iterated integrator (panel-dependent speed), and no finite guards on `setMove`/`setAim`/`step`/`resize` (one NaN in the move vector put the ship's position beyond recovery for the whole session, silently — `dist2` then returns NaN and nothing can be swept or struck again).
* **Taste** — the coast was 143px against a 32px sweep reach, four and a half times the reach, so a child could not stop on a mote, only pass over one and come back; it is 34px on a phone now. The stick gained a dead zone under a resting thumb's tremor and a curve that leaves most of its travel for the accurate part. The hull eases toward the aim over 55ms; the guns do not, because a shooter whose bullets lag its stick lies.

## Also, from a round of adversarial self-review

* **The game learns from `question.difficulty` — the rung that *answered*** — not the rung it asked for. `host.next` serves the pooled question *closest* to a request, and measured against the real adapter those differed in 104 of 175 draws, by as much as nineteen rungs. Learning from the request wrote live rungs off as barren and snapped the position onto content the child never saw.
* **An arming spends six draws and no more.** `next` is synchronous and the refill is not, so a request that moves the ladder flushes the pool to a reserve of eight. An arming firing all thirteen offsets in one frame ran it dry and started being handed clones **with an empty id**, whose answers the host drops — a child solving a resonator nothing can be reported against.
* **A stall stocks the field and asks again in 2.5s.** The case that made this necessary is a brand new profile: the host warms its pool at *its* position (rung 0), the first request flushes that to eight `2 + 0`s, and the arena stalled on the first frame of the first session — before `arm` reached the line that puts anything on the screen. That was an empty grid.
* Discarded draws are `skip`ped. An unanswered question reported as wrong is a MISS on a question nobody was shown; `skip?` is feature-detected like `transition?`.
* A second wrong hold in the same ring no longer moves the ladder — the id is spent and nothing after it is reported, and a bump-loop could otherwise walk the whole band down in seven seconds.
* `stubHost` now models the real 66-rung wire, which is what makes any of this measurable inside the package.

## Verification

`npm test` **131 tests**, run 5×, `npm run tsc`, `npm run build`, `npm run build:pack` — all green on Node 24.18.0.

**Sixteen fixes, each verified to fail with the fix deleted.** A sample of the exact failure messages:

```
119 of 119 draws asked for nothing
seed 1a771ce ended stalled
2 = 2 was accepted as a resonator target
804 needs a 67 mote  /  a hold needed a mote larger than the game draws
the ship crosses 1.72× more screen per second on phone portrait than on tablet
phone landscape: the ship carries 148px after the thumb comes off, against a 32px sweep reach
tablet at 20fps: 3 of 60 shots passed through the husk (a 58px window)
phone landscape: top speed was 256.476 / … / 247.285 at 144/120/90/72/60/50/45/30/24/20fps
the ship's x became NaN
0.5px of tremor moved the ship  /  half deflection is 0.500 authority, which is still a ramp
the hull snapped straight round
a child's first session opened on an empty grid with nothing to shoot
an arming would spend 13 items
the game thinks it is on rung 17 while every question came from 21
bumping a ring whose id was already spent walked the ladder down again
discarded draws were never skipped
a barren rung was still being tried first
```

Nothing outside `dynawalla/games/lattice/` is touched. `pack.json` is unchanged.

## What needs a device

Everything above is arithmetic and geometry measured headlessly. The *feel* is not: `0.300` diagonals a second with a 34px coast, a 10% dead zone and a 1.8 curve are a considered starting point and a nine-year-old's thumb is the only instrument that can settle them. Worth checking on the Android in particular — whether the ship is now too *slow* rather than too wild, and whether the 55ms hull ease reads as calm or as sludge.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
