### PR TITLE
fix(dynawalla/games/runner): the answers sit with the windows, and a harder sum gets more road

### DIFF
--- a/dynawalla/games/runner/README.md
+++ b/dynawalla/games/runner/README.md
@@ -61,34 +61,58 @@ read.
 
 - The **prompt lives in DOM**, at a fixed spot just above the horizon, at native
   crispness. It never moves and it is never a texture.
-- **The three candidates are typeset in screen units, not world units.** This is
-  the single most important thing in the game and it took two attempts. The
-  camera sits 11.4 units behind a causeway whose lanes are 3.35 apart, so the
+- **The three candidates are typeset in screen units, and placed from the gate.**
+  This is the single most important thing in the game and it took three attempts.
+  The camera sits 11.4 units behind a causeway whose lanes are 3.35 apart, so the
   *widest* the lane pitch ever gets on screen is about 12% of the viewport, and
   only in the last third of a second before the gate lands. Numerals placed at
   the lanes therefore ran together — a judge captured `13 | 42 | 36` rendering as
   `134236` — and a fan-out compensation big enough to fix that pushed the third
-  value clean off a 390px phone. Perspective is the wrong tool for typesetting
-  three values a child has half a second to compare. So `readband.ts` decides an
-  explicit pitch, an explicit 30% gutter, an explicit page margin and one shared
-  ink height, all in NDC, and `project.ts` converts that layout back into the
-  world positions the instanced digit shader wants — so the numerals still fog,
-  still bend with the causeway, still belong to the world. They lift above the
-  arches, keep left-middle-right order, trail a dotted leader down to their own
-  gate, and converge into it as it arrives.
-- `readband.test.ts` hammers that layout across nine viewports × three fields of
-  view × seven distances × three font widths × four digit counts and asserts the
-  two things that actually matter: **adjacent numerals never touch** and
-  **nothing leaves the viewport**. The same file covers the two other places ink
-  can escape the frame — the winning numeral rushing the camera, and the score
-  popups over the outer lanes.
+  value clean off a 390px phone. So `readband.ts` decides an explicit pitch, an
+  explicit 30% gutter, an explicit page margin and one shared ink height, all in
+  NDC, and `project.ts` converts that layout back into the world positions the
+  instanced digit shader wants — the numerals still fog, still bend with the
+  causeway, still belong to the world.
+- **The row belongs to its gate, and the second attempt did not.** Measured on a
+  360x780 phone at 78°, against the version the founder played: the outer
+  candidate was drawn at x = 305px for the *entire* approach while the arch it
+  names travelled from 198px to 286px; it was 98px tall from the moment it
+  appeared to the moment it was crossed, while the arch grew from 27px to 158px;
+  and it floated a flat 27px above the lintel throughout. Steering made it worse —
+  the chase camera follows the player at 0.6x, so with the child in the left lane
+  the outer answer ended up 44px on the *wrong side* of its own arch. Three
+  numbers, none of them a function of the gate: that is a HUD element drawn in the
+  world, and "the answers would be better if they sat with the windows" was the
+  right note. The row is now derived from the gate's own projected geometry — its
+  centre, its lane pitch, the height of its arch — and falls back on the
+  legibility floors only where the geometry cannot honour them. Same measurement
+  after: 52px at a hundred units, 28px at thirty, 3px at ten, 0px at six, with the
+  numeral growing 46px → 80px and sitting *inside* the window from about forty
+  units in. Where the answer is too wide for the window — three readable
+  three-digit numerals need 315 of a phone's 360 pixels — the row converges as far
+  as legibility allows and no further, and that limit is written down in
+  `gatelayout.test.ts` with the numbers rather than smoothed over.
+- Two test files, deliberately split. `readband.test.ts` is pure arithmetic and
+  hammers the layout across nine viewports × three fields of view × seven
+  distances × three font widths × four digit counts × four gate positions,
+  asserting the two things that always matter — **adjacent numerals never touch**
+  and **nothing leaves the viewport** — plus the two other places ink can escape
+  the frame, the winning numeral rushing the camera and the score popups over the
+  outer lanes. `gatelayout.test.ts` builds the *real* `THREE.PerspectiveCamera`,
+  poses it exactly as `render()` does, runs the real `Projector` and measures in
+  CSS pixels, because "do the answers sit with the windows" is a question about a
+  pitched, lane-following camera and a hand-rolled pinhole model would answer it
+  about a camera the game does not have.
 - **Gate numerals are baked with a dark stroke *and* a soft dark shadow**, and
   the red channel separates fill from outline, so the shader can recolour a
   numeral without ever recolouring its own contrast. They stay readable over an
   aurora, over a white-out, over a shockwave.
-- Apparent size does not depend on distance, so a numeral is never eleven pixels
-  tall at the far end of the reading window and never a wall of ink at the near
-  end.
+- Apparent size **tracks the gate**, floored at a 46px cap height. It used to be
+  flat — identical at 240 units and at 4 — which is precisely what made the row
+  read as chrome rather than as something on the causeway. A numeral is still
+  never eleven pixels tall at the far end of the reading window, because the floor
+  is in pixels and not in NDC: 0.1 NDC is 39px on a 780-tall phone and 108px on a
+  desktop.
 - Numerals **never depth-test**. A roadside monolith eclipsing the one value a
   child needed is not atmosphere, it is a lost run.
 - A character the atlas does not know renders as `?`, never as nothing. Silently
@@ -103,6 +127,40 @@ read.
   `subtract-across-zero`, and `docs/EXPERIENCE_DESIGN.md` instruments two-digit
   regrouping at p50 6s; a gate cycle — read it, then run the corridor — is about
   5.3 seconds, which is the number that has to answer to that table.
+- **A harder question gets more time, not less — and it gets it as road.** VOLTA
+  had the fleet's root pacing defect: the comprehension window was derived from a
+  motion constant, and the motion constant was also the escalation knob, so every
+  step that made the run more exciting took thinking time away. Measured through
+  the real scheduler: 8.00s with the question on the opening gate, where the
+  content is `5 − 2`, falling to 4.78s at terminal velocity on the smallest
+  quality tier, where it is four- and five-digit column arithmetic. The founder,
+  exactly: *"you have 5 seconds to do 2x1 and then 2 seconds to do 84302+4186."*
+  `docs/PACING_AUDIT_2026-07.md` names it across seventeen games and sets the
+  invariant — **`window(d)` must be monotone non-decreasing in item difficulty.**
+
+  The obvious fix is to slow down as the arithmetic hardens. The founder offered
+  that and then offered the better one: *"the vehicle could still be racing but ...
+  we maybe need some miles to figure out the answer."* So nothing about the speed
+  changes. `comprehension.ts` reads the *item* — operand width, whether a column
+  carries or borrows, which operation — and returns the seconds
+  `docs/EXPERIENCE_DESIGN.md` instruments for that shape: 2.8s for a single-digit
+  fact, 6s for a two-digit regroup, 16s for the `5,001 − 2,798` class. It imports
+  nothing at all, so there is no speed, no travel, no draw distance and no tier in
+  scope for it to be derived from, and `comprehension.test.ts` asserts that by
+  reading the module's own source. `pacing.ts` then buys those seconds as
+  **runway**: the dodge corridor in front of a hard gate gets longer, the prompt
+  sits on the HUD across the whole of it, and hazards and sparks keep arriving
+  through it at their own cadence. At terminal velocity a 16s question is about
+  900 units of road. After: 8.00s, 6.91s, 10.10s, 16.08s across that same ladder,
+  and every rung is asserted through the scheduler, not from the formula.
+
+  Two honest edges. The floor is generous, so an easy question early in a run still
+  gets 8.00s — more than its 2.8s target, and more than a two-digit regroup gets
+  mid-run; the invariant is an ordering at a given state of the world, and nothing
+  ever gets *less* than its own target. And the hazard guard's projection knows the
+  live corridor exactly but cannot know how hard the *next* item will be, so it
+  models later cycles at the shortest corridor a run can have — wrong in the safe
+  direction, and written down where it happens.
 - **The sum arrives a corridor before the gate does.** The far plane caps the time
   between a gate becoming visible and reaching the answer plane at 3.20s at p50
   however the pacing is tuned, which is half of that 6s. So the next question is
@@ -116,6 +174,28 @@ read.
   velocity, and both of those are decisions about frame rate and feel rather than
   about reading. `pacing.test.ts` pins the number as a band so neither shrinking
   the pre-read nor quietly reaching the target goes unnoticed.
+- **The HUD is laid out from the insets the host measured, never from `env()`.**
+  `env(safe-area-inset-*)` belongs to the top-level browsing context, and a pack
+  frame is sandboxed `allow-scripts` with no `allow-same-origin` — so all four
+  resolve to **zero** inside it, on every device, for ever. `hud.ts` read them
+  directly, so on the founder's phone the score painted at y = 63 instead of y = 87
+  and sat eighteen pixels under the host's exit chevron, the surge meter did the
+  same under the how-to-play control, and the tests passed because they handed the
+  arithmetic a 24px inset the stylesheet never saw. The fix is not a better test:
+  the stylesheet no longer computes any position at all. Every in-run HUD box comes
+  from `hudBoxes` in `chrome.ts` and is written on as a custom property, and
+  `chrome.test.ts` fails the build if `env(safe-area-inset` appears in the sheet or
+  if any positional declaration on those five selectors is not a `var()`.
+- **Android's gesture strip is not the reported bottom inset.** The value the
+  WebView reports describes the display *cutout*; the thing that eats the pixels
+  and the tap is the gesture-navigation handle, and plenty of devices report a
+  bottom inset of zero while it is there. The voltage bar sat 12px off the bottom
+  edge, so all 13px of it were inside the strip — which is what the founder's
+  screenshot shows. `GESTURE_STRIP` is 24 CSS px, taken off the raw bottom edge as
+  well as the reported inset, whichever binds harder; `games/pulse` met this first
+  and this is its constant. Every readable and tappable box is asserted clear of it
+  at seven viewports including **a zero bottom inset**, which is the case that
+  broke.
 - **The host's element is the only thing on screen with a size.** The canvas and
   every HUD layer are `position:absolute; inset:0` inside it, so a stage with no
   box is the whole game gone. `pack.html` gives `#app` its box with
@@ -198,6 +278,42 @@ nothing carries information on its own.
 - Readable at 320px (verified at 320×640 portrait). Full keyboard play.
 - No ads, loot boxes, variable-ratio rewards, streak anxiety, scarcity or social
   pressure.
+
+## Motion control, and why it is not here
+
+It was asked for — *"Volta could ask for motion control on a mobile device .. or
+the user could toggle it optionally"* — and the toggle is deliberately absent,
+because an opt-in that silently does nothing is worse than not offering one.
+
+`DeviceOrientationEvent` and `DeviceMotionEvent` are gated by the
+Permissions-Policy features `gyroscope`, `accelerometer` and `magnetometer`, whose
+default allowlist is `self`. A pack is mounted by `dynawalla-app`'s
+`packs/frame.ts` with `sandbox="allow-scripts"` — no `allow-same-origin`, so the
+pack's origin is *opaque* — and with `allow=""`, which disables every
+policy-controlled feature explicitly. So the events cannot reach a pack twice
+over: the default allowlist already excludes a cross-origin child, and the empty
+container policy would exclude it anyway. On iOS there is a third barrier:
+`DeviceOrientationEvent.requestPermission()` grants **per origin**, and an opaque
+origin is not an origin a grant can be remembered against.
+
+Nothing in the fleet uses either API — the grep across all 27 games, the shared
+modules and the app is empty — so there is no precedent to copy and no evidence
+this works anywhere in the product today.
+
+**What a host change would have to be.** Not `allow="gyroscope; accelerometer"`
+on the pack frame: that hands motion sensors to all 27 packs at once to serve one
+of them, and `frame.ts` says out loud what it is protecting — *"Nothing in the
+permissions policy: no camera, no microphone, no geolocation, no autoplay grant. A
+pack asks the host for feedback, it does not take it."* The shape that fits the
+boundary already exists in this repository: the **host** reads the orientation and
+posts it, exactly as it already measures the safe-area insets a pack cannot see
+and sends them over the `settings` channel. One number crossing a message port,
+one permission prompt owned by the app, one place to turn it off. That is a host
+decision and a host PR, and it is the founder's to make.
+
+None of the above has been checked on a device by this change. It is read off the
+Permissions Policy and DeviceOrientation Event specifications and off the host's
+own source; what would settle it is a build with the grant added, on hardware.
 
 ## Performance
 

--- a/dynawalla/games/runner/src/game/chrome.test.ts
+++ b/dynawalla/games/runner/src/game/chrome.test.ts
@@ -23,21 +23,28 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  chromeRects,
   HOST_CONTROL,
   hitsHostChrome,
   safeRect,
   type Insets,
+  type Rect,
 } from "../../../../packs/shared/game-chrome/index.ts";
 import {
+  GESTURE_STRIP,
+  hudBoxes,
   hudEdge,
+  hudVars,
   makeStage,
   ndcFrame,
   readoutRect,
   READOUT_CLEAR,
   STAGE_BG,
+  systemBottom,
   type StageEl,
 } from "./chrome.ts";
-import { BAND, FULL_FRAME, payoffEdge, popupEdge, readBand } from "./readband.ts";
+import { HUD_CSS } from "./hud.ts";
+import { BAND, fullFrame, payoffEdge, popupEdge, readBand, type GateGeom } from "./readband.ts";
 import { INK, TRACK } from "./glyphs.ts";
 
 const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
@@ -129,6 +136,234 @@ test("the HUD margin matches the clamp the stylesheet resolves to", () => {
 });
 
 /* -------------------------------------------------------------------------- */
+/* Every HUD box, at every viewport, against every piece of chrome.            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The insets a phone can actually report, including the one that broke.
+ *
+ * A **zero bottom inset with a real top inset** is not a hypothetical: it is what
+ * Android reports on a device with gesture navigation and a punch-hole camera,
+ * and it is the founder's phone. The reported inset describes the display cutout;
+ * the gesture handle eats the bottom of the glass and is not in it. Every case
+ * with `bottom: 0` below is that case, and the voltage bar was underneath the
+ * navigation bar in all of them.
+ */
+const DEVICE_INSETS: Array<[string, Insets]> = [
+  ["no insets at all (a browser window)", NONE],
+  ["android, gesture nav, zero bottom inset", { top: 24, right: 0, bottom: 0, left: 0 }],
+  ["android, punch-hole status bar, zero bottom inset", { top: 40, right: 0, bottom: 0, left: 0 }],
+  ["ios portrait, notch and home indicator", { top: 47, right: 0, bottom: 34, left: 0 }],
+  ["ios landscape, cutout on both sides", { top: 0, right: 47, bottom: 21, left: 47 }],
+];
+
+/** The founder's phone first: 1080x2340 physical, DPR 3, and DPR 2.75 beside it. */
+const DEVICE_VIEWPORTS: Array<[string, number, number]> = [
+  ["founder's phone at dpr 3", 360, 780],
+  ["founder's phone at dpr 2.75", 393, 851],
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["phone landscape", 844, 390],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+];
+
+/**
+ * Every (viewport, insets) pair a device can actually be in.
+ *
+ * Crossed by orientation rather than exhaustively, for the reason `insetsFor`
+ * already gives above: a 360-wide portrait phone never has 47 pixels of cutout
+ * down each side, and asserting against shapes no device produces only tempts the
+ * fix into clamping the safe area away to make an imaginary case pass.
+ */
+function deviceCases(): Array<[string, number, number, Insets]> {
+  const out: Array<[string, number, number, Insets]> = [];
+  for (const [vname, w, h] of DEVICE_VIEWPORTS) {
+    for (const [iname, insets] of DEVICE_INSETS) {
+      const sideways = insets.left > 0 || insets.right > 0;
+      if (sideways !== w > h && (sideways || insets.top > 0)) continue;
+      out.push([`${vname} (${w}x${h}), ${iname}`, w, h, insets]);
+    }
+  }
+  return out;
+}
+
+const overlap = (a: Rect, b: Rect): { w: number; h: number } => ({
+  w: Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x)),
+  h: Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y)),
+});
+
+test("no HUD box a child reads or touches is under the host's chrome", () => {
+  for (const [ctx, w, h, insets] of deviceCases()) {
+    const boxes = hudBoxes(w, h, insets);
+    for (const [key, rect] of Object.entries(boxes)) {
+      assert.equal(
+        hitsHostChrome(rect, w, insets),
+        false,
+        `${ctx}: the ${key} box ${JSON.stringify(rect)} is under the host's chrome ` +
+          `(exit ${JSON.stringify(chromeRects(w, insets)[0])}, help ${JSON.stringify(chromeRects(w, insets)[1])})`,
+      );
+    }
+    assert.ok(h > 0);
+  }
+});
+
+test("no HUD box a child reads or touches is outside the safe rect", () => {
+  for (const [name, w, h, insets] of deviceCases()) {
+    const safe = safeRect(w, h, insets);
+    for (const [key, r] of Object.entries(hudBoxes(w, h, insets))) {
+      const ctx = `${name}: the ${key} box`;
+      assert.ok(r.x >= safe.x - 1e-9, `${ctx} starts at x=${r.x.toFixed(1)}, inside the left inset`);
+      assert.ok(r.y >= safe.y - 1e-9, `${ctx} starts at y=${r.y.toFixed(1)}, under the top inset`);
+      assert.ok(
+        r.x + r.w <= safe.x + safe.w + 1e-9,
+        `${ctx} reaches x=${(r.x + r.w).toFixed(1)} of a safe area ending at ${(safe.x + safe.w).toFixed(1)}`,
+      );
+      assert.ok(
+        r.y + r.h <= safe.y + safe.h + 1e-9,
+        `${ctx} reaches y=${(r.y + r.h).toFixed(1)} of a safe area ending at ${(safe.y + safe.h).toFixed(1)}`,
+      );
+    }
+  }
+});
+
+/**
+ * Height of Android's gesture-navigation handle, in CSS pixels.
+ *
+ * Written here as its own number rather than read from `GESTURE_STRIP`, because a
+ * test whose floor is the constant it is checking passes when somebody sets that
+ * constant to zero. This is a fact about the platform; `GESTURE_STRIP` is the
+ * game's response to it, and the two are asserted against each other below.
+ */
+const ANDROID_HANDLE_PX = 24;
+
+test("nothing at the bottom is inside the strip the system swipes in", () => {
+  // The safe rect is not enough here and that is the entire point: on the
+  // founder's phone the reported bottom inset is ZERO and the gesture handle
+  // still owns the bottom 24 CSS pixels. Before this allowance the voltage bar
+  // sat 12px off the bottom edge, so all 13px of it were inside the strip.
+  assert.ok(
+    GESTURE_STRIP >= ANDROID_HANDLE_PX,
+    `GESTURE_STRIP is ${String(GESTURE_STRIP)}px against a ${String(ANDROID_HANDLE_PX)}px handle`,
+  );
+  for (const [ctx, w, h, insets] of deviceCases()) {
+    const boxes = hudBoxes(w, h, insets);
+    const floor = h - ANDROID_HANDLE_PX;
+    for (const key of ["voltage", "tools", "perf"] as const) {
+      const r = boxes[key];
+      assert.ok(
+        r.y + r.h <= floor + 1e-9,
+        `${ctx}: the ${key} box ends at y=${(r.y + r.h).toFixed(1)} of ${String(h)} — ` +
+          `${(r.y + r.h - floor).toFixed(1)}px inside the ${String(ANDROID_HANDLE_PX)}px the system swipes in`,
+      );
+    }
+    assert.ok(systemBottom(insets) >= ANDROID_HANDLE_PX, `${ctx}: the bottom allowance collapsed`);
+  }
+});
+
+test("the bottom readouts and the two buttons do not sit on each other", () => {
+  // Only the three bottom boxes, and deliberately not the corner readouts
+  // against the prompt. `READOUT_W`/`READOUT_H` and `PROMPT_W` are *allowances* —
+  // each is far larger than the ink it stands for, on purpose, so that every
+  // clearance assertion above is conservative. Two allowances overlapping tells
+  // you about the allowances. These three are tight boxes around real furniture
+  // and are stacked in the same corner, so their overlap is real.
+  for (const [ctx, w, h, insets] of deviceCases()) {
+    const b = hudBoxes(w, h, insets);
+    for (const [a, c] of [
+      ["voltage", "tools"],
+      ["voltage", "perf"],
+      ["tools", "perf"],
+    ] as const) {
+      const o = overlap(b[a], b[c]);
+      assert.ok(o.w === 0 || o.h === 0, `${ctx}: ${a} and ${c} overlap by ${o.w.toFixed(1)}x${o.h.toFixed(1)}px`);
+    }
+    assert.ok(w > 0 && h > 0);
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* ...and the stylesheet cannot disagree with any of it.                       */
+/* -------------------------------------------------------------------------- */
+
+test("the stylesheet never reaches for env(safe-area-inset-*)", () => {
+  // The whole defect, in one assertion. `env()` belongs to the top-level
+  // browsing context; a pack frame is sandboxed `allow-scripts` with no
+  // `allow-same-origin`, so all four resolve to ZERO inside it, on every device,
+  // for ever. The tests above were passing with insets the CSS never saw.
+  assert.ok(
+    !/env\(\s*safe-area-inset/.test(HUD_CSS),
+    "hud.ts reads env(safe-area-inset-*), which is 0 inside a pack — use the host's measured insets",
+  );
+});
+
+test("every in-run HUD box takes its position from chrome.ts and nowhere else", () => {
+  // A structural guard, not a string match on the values: if a positional
+  // declaration on one of these five selectors is anything other than a `var()`,
+  // the stylesheet has geometry of its own again and the two can drift — which
+  // is how this shipped twice.
+  const rules = new Map<string, string>();
+  for (const m of HUD_CSS.matchAll(/(^|\n)(\.vt-[a-z-]+)\s*\{([^}]*)\}/g)) {
+    rules.set(m[2] ?? "", (rules.get(m[2] ?? "") ?? "") + ";" + (m[3] ?? ""));
+  }
+  const POSITIONAL = ["left", "right", "top", "bottom"];
+  for (const sel of [".vt-prompt", ".vt-tl", ".vt-tr", ".vt-volt", ".vt-tools", ".vt-perf"]) {
+    const body = rules.get(sel);
+    assert.ok(body !== undefined, `${sel} is not in the stylesheet any more; this test is measuring nothing`);
+    for (const decl of body.split(";")) {
+      const colon = decl.indexOf(":");
+      if (colon < 0) continue;
+      const prop = decl.slice(0, colon).trim();
+      const value = decl.slice(colon + 1).trim();
+      if (!POSITIONAL.includes(prop)) continue;
+      // `left: 50%` on the prompt is the centring transform's own anchor, not an
+      // inset, and it is paired with `translate(-50%, 0)`.
+      if (sel === ".vt-prompt" && prop === "left") continue;
+      assert.ok(
+        value.startsWith("var(--vt-"),
+        `${sel} { ${prop}: ${value} } — that is arithmetic the stylesheet owns, and chrome.ts owns the same number`,
+      );
+    }
+  }
+});
+
+test("hudVars fills in every custom property the stylesheet asks for", () => {
+  // The other half of the guard above: a `var()` with no author-supplied value
+  // silently falls back to its default, which is how a HUD laid out for a phone
+  // with no insets would keep painting on one that has them.
+  const vars = hudVars(360, 780, { top: 24, right: 0, bottom: 0, left: 0 });
+  // `--vt-accent` is the live biome colour, written on the root by `mount.ts` on
+  // every biome change. It is not geometry and does not belong in `hudVars`.
+  const setElsewhere = new Set(["--vt-accent"]);
+  for (const m of HUD_CSS.matchAll(/var\((--vt-[a-z-]+)/g)) {
+    const name = m[1] ?? "";
+    if (setElsewhere.has(name)) continue;
+    assert.ok(name in vars, `the stylesheet reads ${name} and hudVars never sets it`);
+  }
+  for (const [name, value] of Object.entries(vars)) {
+    assert.ok(/^-?\d+(\.\d+)?px$/.test(value), `${name} is "${value}", which is not a length`);
+  }
+});
+
+test("the measured insets reach the boxes at all — the drift that shipped", () => {
+  // Stated as an assertion because the previous two tests would both pass on a
+  // HUD that ignored its argument. The founder's phone: a 24px top inset and the
+  // host's chevron 37..81px down the glass.
+  const flat = hudBoxes(360, 780, NONE);
+  const android = hudBoxes(360, 780, { top: 24, right: 0, bottom: 0, left: 0 });
+  assert.equal(android.score.y - flat.score.y, 24, "the top inset does not move the score");
+  assert.equal(flat.score.y, READOUT_CLEAR, "with no insets the score sits exactly under the control");
+  // And the geometry it used to paint at — 63px, inside a 37..81px chevron.
+  const exit = chromeRects(360, { top: 24, right: 0, bottom: 0, left: 0 })[0];
+  assert.ok(exit !== undefined);
+  assert.ok(
+    flat.score.y < exit.y + exit.h,
+    `a score at y=${String(flat.score.y)} would be clear of a chevron ending at ${String(exit.y + exit.h)} — ` +
+      "the regression this pins is gone and so is its evidence",
+  );
+});
+
+/* -------------------------------------------------------------------------- */
 /* The safe area, in NDC, where the answers are drawn.                        */
 /* -------------------------------------------------------------------------- */
 
@@ -141,8 +376,11 @@ test("with no insets the frame is exactly the margins the game always had", () =
   const f = ndcFrame(390, 844, NONE);
   assert.equal(f.edge, BAND.edge);
   assert.equal(f.top, BAND.top);
-  assert.equal(f.bottom, BAND.bottom);
-  assert.deepEqual(f, FULL_FRAME);
+  assert.equal(f.minH, fullFrame(844).minH);
+  // The floor is the HUD's own bottom furniture, which exists on every device,
+  // so it is never the bare bottom of the glass.
+  assert.ok(f.bottom > -1, "the row may sink under the voltage bar");
+  assert.ok(f.bottom < -0.7, `the floor is ${f.bottom.toFixed(2)} NDC — that is a reserved band`);
 });
 
 test("a side cutout pulls the page margin in, so the outer answer stays visible", () => {
@@ -154,9 +392,15 @@ test("a side cutout pulls the page margin in, so the outer answer stays visible"
 
 /* The camera, mirrored from `mount.ts` so the numbers are the real ones. */
 const CAM_Z = 11.4;
+const ARCH = 4.9;
+const LANE_W = 3.35;
 function scales(w: number, h: number, fovDeg: number, dist: number): { kx: number; ky: number } {
   const ky = 1 / Math.tan((fovDeg * Math.PI) / 360) / (dist + CAM_Z);
   return { kx: ky / (w / h), ky };
+}
+function geomFor(kx: number, ky: number, archTop: number, centre = 0): GateGeom {
+  const archH = Math.abs(ky) * ARCH;
+  return { centre, lanePitch: Math.abs(kx) * LANE_W, archTop, archH, deck: archTop - archH };
 }
 /** World width of a numeral at ink height 1, for `digits` digits. */
 const unit = (digits: number, advance: number): number => digits * advance * (1 / INK) * TRACK;
@@ -175,10 +419,10 @@ test("no answer is ever drawn under the cutout, at any viewport or rotation", ()
           for (const adv of [0.36, 0.43, 0.5]) {
             for (const n of [1, 2, 3, 4]) {
               const u = unit(n, adv);
-              for (const approach of [0, 0.5, 1]) {
+              for (const centre of [-0.8, -0.25, 0, 0.4]) {
                 for (const archTop of [-0.4, 0.2, 1.4]) {
-                  const band = readBand([u, u, u], kx, ky, approach, archTop, frame);
-                  const ctx = `${name} ${label} fov${fov} d${dist} adv${adv} n${n} a${approach}`;
+                  const band = readBand([u, u, u], kx, ky, geomFor(kx, ky, archTop, centre), frame);
+                  const ctx = `${name} ${label} fov${fov} d${dist} adv${adv} n${n} cx${centre}`;
 
                   const leftPx = ndcToPx(band.x[0] - band.wNdc / 2, w);
                   const rightPx = ndcToPx(band.x[2] + band.wNdc / 2, w);
@@ -223,7 +467,7 @@ test("the answers are still large enough to read once the cutout is respected", 
       const frame = ndcFrame(w, h, insets);
       const { kx, ky } = scales(w, h, 74, 90);
       const u = unit(3, 0.5);
-      const band = readBand([u, u, u], kx, ky, 0, 0.1, frame);
+      const band = readBand([u, u, u], kx, ky, geomFor(kx, ky, 0.1), frame);
       const capPx = (band.hNdc / 2) * h;
       const gutterPx = ((band.pitch - band.wNdc) / 2) * w;
       assert.ok(capPx >= 24, `${name}, ${label}: three digits render at ${capPx.toFixed(1)}px cap height`);

--- a/dynawalla/games/runner/src/game/chrome.ts
+++ b/dynawalla/games/runner/src/game/chrome.ts
@@ -1,7 +1,7 @@
 /**
  * Where VOLTA is allowed to put things a child has to read or touch.
  *
- * Two separate encroachments, both invisible in a browser window and both
+ * Three separate encroachments, all invisible in a browser window and all
  * certain on a device:
  *
  * **The safe area.** `pack.html` declares `viewport-fit=cover`, which is not a
@@ -19,9 +19,37 @@
  * VOLTA put its score in one of those corners and its surge meter in the other,
  * so both readouts shipped underneath a button.
  *
+ * **The system's bottom edge.** Android's gesture-navigation handle eats a strip
+ * of the bottom of the glass and reports a safe-area inset of ZERO on plenty of
+ * devices, so a bar placed correctly inside the reported safe area is still
+ * under it. `games/pulse` hit this and named the allowance; VOLTA now carries
+ * the same one. See `GESTURE_STRIP`.
+ *
  * The chrome *overlays* — it does not reserve a band, and this file must not
  * pretend it does. The causeway, the sky and the ocean still bleed to all four
  * edges; that is the entire point of `cover`. Only the readouts move.
+ *
+ * ── one source of truth, because the last two were not ──────────────────────
+ *
+ * The first version of this file was arithmetic that *described* the stylesheet:
+ * `readoutRect` computed what `hud.ts` was believed to resolve to, and the tests
+ * asserted against the arithmetic. They were not the same thing, and the
+ * disagreement was the whole bug. `hud.ts` wrote
+ * `top: calc(env(safe-area-inset-top) + 63px)`, and **`env()` is zero inside a
+ * pack**: the frame is sandboxed `allow-scripts` with no `allow-same-origin`, and
+ * the safe-area environment variables belong to the TOP-LEVEL browsing context,
+ * so a cross-origin child resolves all four to 0. The host measures the real
+ * values and posts them; `safeInsets()` returns those. So the arithmetic here was
+ * handed a 24px top inset by the test, and the CSS on the device was handed 0 —
+ * a row the test placed at y = 87 painted at y = 63, eighteen pixels under the
+ * exit chevron, and the test passed.
+ *
+ * The fix is not a better test. It is that the stylesheet no longer computes any
+ * position at all: every box below is produced *here*, by `hudBoxes`, and written
+ * onto the root as custom properties by `hudVars`. There is nothing left for the
+ * CSS to disagree with, and `chrome.test.ts` asserts that too — no `env()`
+ * anywhere in the sheet, and every positional declaration on the five HUD boxes
+ * is a `var()`.
  */
 
 import {
@@ -85,6 +113,8 @@ export function makeStage(el: StageEl, computedPosition: string): void {
   el.style.background = STAGE_BG;
 }
 
+/* ------------------------------- the HUD boxes ---------------------------- */
+
 /** Clear air between the bottom of a host control and the readout under it. */
 const GAP = 6;
 
@@ -97,9 +127,36 @@ const GAP = 6;
  */
 export const READOUT_CLEAR = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL + GAP;
 
-/** The HUD's own side margin, mirroring `clamp(10px, 2.2vw, 26px)` in the CSS. */
+/**
+ * How much of the bottom edge belongs to the system rather than to the game.
+ *
+ * The reported bottom inset is honest on iOS, where it is the home indicator. On
+ * Android it is not enough: the value the WebView reports describes the DISPLAY
+ * CUTOUT, while the thing that eats the pixels and the tap is the
+ * gesture-navigation handle — a strip along the bottom edge that the system
+ * claims for swipe-up-to-home and that reports a bottom inset of **zero** on
+ * plenty of devices. That is exactly the shape of the founder's screenshot: the
+ * voltage bar was inside the reported safe area, correctly, and underneath the
+ * navigation bar.
+ *
+ * 24 CSS px is the Android gesture handle's own height, and it is taken off the
+ * raw bottom edge *as well as* the reported inset, whichever binds harder.
+ * Lifted verbatim from `games/pulse`, which met this first.
+ */
+export const GESTURE_STRIP = 24;
+
+/** The bottom edge the HUD may actually use, in CSS px from the bottom. */
+export function systemBottom(insets: Insets): number {
+  return Math.max(insets.bottom, GESTURE_STRIP);
+}
+
+/** `clamp(lo, mid, hi)` as CSS resolves it. */
+const clampPx = (lo: number, mid: number, hi: number): number =>
+  Math.min(hi, Math.max(lo, mid));
+
+/** The HUD's own side margin: the old `clamp(10px, 2.2vw, 26px)`. */
 export function hudEdge(w: number): number {
-  return Math.min(26, Math.max(10, w * 0.022));
+  return clampPx(10, w * 0.022, 26);
 }
 
 /**
@@ -117,18 +174,138 @@ const READOUT_H = 110;
 /**
  * The box a top-corner readout occupies: `left` is the score, `right` the surge.
  *
- * This is what the CSS in `hud.ts` resolves to, expressed as arithmetic so a
- * test can assert it against `hitsHostChrome` at every viewport instead of
- * finding out on a device.
+ * This is what `hud.ts` *is*, not what it is believed to resolve to — the
+ * stylesheet reads `left: var(--vt-tl-x)` and this is what fills it in.
  */
 export function readoutRect(side: "left" | "right", w: number, insets: Insets): Rect {
   const m = hudEdge(w);
-  const x =
-    side === "left"
-      ? insets.left + m
-      : Math.max(0, w - insets.right - m - READOUT_W);
+  const x = side === "left" ? insets.left + m : Math.max(0, w - insets.right - m - READOUT_W);
   return { x, y: insets.top + READOUT_CLEAR, w: READOUT_W, h: READOUT_H };
 }
+
+/** The prompt's nominal box: centred, and as wide as a five-digit sum gets. */
+const PROMPT_W = 300;
+
+/**
+ * Room above the voltage bar for its own label.
+ *
+ * An *allowance*, not a mirror: the label is `font-size:clamp(8px,1.5vw,11px)`
+ * five pixels above the bar, so 16px is the most it ever needs and 18 is what it
+ * gets. Erring upward is the safe direction — it makes the box this file reports
+ * slightly larger than the ink, so every clearance assertion is conservative.
+ */
+const VOLT_LABEL_H = 18;
+
+/**
+ * Every HUD box a child reads or touches, in CSS pixels.
+ *
+ * The four in-run surfaces plus the debug readout. The veils are deliberately
+ * absent: an overlay owns the whole screen, is dismissed by its own button, and
+ * pads itself off all four insets.
+ */
+export type HudBoxes = {
+  /** `5 − 2`, just above the horizon. */
+  prompt: Rect;
+  /** Score and distance, top-left, under the exit control. */
+  score: Rect;
+  /** Surge and the chain pips, top-right, under the how-to-play control. */
+  surge: Rect;
+  /** The voltage bar and its label, across the bottom. */
+  voltage: Rect;
+  /** Sound and reduce-motion, bottom-right, above the voltage bar. */
+  tools: Rect;
+  /** The perf readout, bottom-left. `?perf` only, but it is still text. */
+  perf: Rect;
+};
+
+export function hudBoxes(w: number, h: number, insets: Insets): HudBoxes {
+  const m = hudEdge(w);
+  const sysB = systemBottom(insets);
+
+  // Prompt: a fifteenth of the way down, or under the host's controls, whichever
+  // is lower. It is centred and `white-space:nowrap`, so a five-digit sum is wide
+  // enough to reach both top corners — on a short viewport with a real top inset
+  // it used to reach them at exactly their own height.
+  const promptH = clampPx(30, w * 0.074, 72);
+  const prompt: Rect = {
+    x: Math.max(0, (w - PROMPT_W) / 2),
+    y: Math.max(h * 0.15, insets.top + READOUT_CLEAR),
+    w: Math.min(w, PROMPT_W),
+    h: promptH,
+  };
+
+  // Voltage: the bar, plus its label sitting on top of it.
+  const voltLift = clampPx(12, w * 0.026, 28);
+  const voltH = clampPx(9, w * 0.018, 15);
+  const voltBottom = h - sysB - voltLift;
+  const voltage: Rect = {
+    x: insets.left + m,
+    y: voltBottom - voltH - VOLT_LABEL_H,
+    w: Math.max(0, w - insets.left - insets.right - 2 * m),
+    h: voltH + VOLT_LABEL_H,
+  };
+
+  // The two tool buttons sit on the voltage readout rather than at their own
+  // offset from the bottom edge. Derived, so the gap between them cannot be
+  // closed by a change to either one.
+  const toolS = clampPx(30, w * 0.06, 40);
+  const toolsBottom = voltage.y - GAP;
+  const tools: Rect = {
+    x: Math.max(0, w - insets.right - m - (2 * toolS + 6)),
+    y: toolsBottom - toolS,
+    w: 2 * toolS + 6,
+    h: toolS,
+  };
+
+  const perf: Rect = { x: insets.left + m, y: tools.y - GAP - 44, w: 220, h: 44 };
+
+  return {
+    prompt,
+    score: readoutRect("left", w, insets),
+    surge: readoutRect("right", w, insets),
+    voltage,
+    tools,
+    perf,
+  };
+}
+
+/**
+ * The custom properties `hud.ts` positions itself from.
+ *
+ * Written onto `.vt-root` on mount and again on every resize and every inset
+ * change. The stylesheet holds no arithmetic of its own — see the module note.
+ */
+export function hudVars(w: number, h: number, insets: Insets): Record<string, string> {
+  const b = hudBoxes(w, h, insets);
+  const px = (v: number): string => `${String(Math.round(v * 100) / 100)}px`;
+  return {
+    // The two sizes the stylesheet would otherwise carry itself. They are here
+    // because `hudBoxes` uses them to place the boxes: a height in CSS and a
+    // height in the arithmetic are two heights, and they drift.
+    "--vt-volt-h": px(clampPx(9, w * 0.018, 15)),
+    "--vt-tool-s": px(clampPx(30, w * 0.06, 40)),
+    "--vt-prompt-y": px(b.prompt.y),
+    "--vt-tl-x": px(b.score.x),
+    "--vt-tl-y": px(b.score.y),
+    "--vt-tr-x": px(w - (b.surge.x + b.surge.w)),
+    "--vt-tr-y": px(b.surge.y),
+    "--vt-volt-l": px(b.voltage.x),
+    "--vt-volt-r": px(w - (b.voltage.x + b.voltage.w)),
+    "--vt-volt-b": px(h - (b.voltage.y + b.voltage.h)),
+    "--vt-tools-r": px(w - (b.tools.x + b.tools.w)),
+    "--vt-tools-b": px(h - (b.tools.y + b.tools.h)),
+    "--vt-perf-l": px(b.perf.x),
+    "--vt-perf-b": px(h - (b.perf.y + b.perf.h)),
+    // The veils pad themselves off all four edges. They own the screen, so they
+    // want the raw insets and not the gesture allowance.
+    "--vt-sa-t": px(insets.top),
+    "--vt-sa-r": px(insets.right),
+    "--vt-sa-b": px(systemBottom(insets)),
+    "--vt-sa-l": px(insets.left),
+  };
+}
+
+/* ----------------------------- the answer frame --------------------------- */
 
 /**
  * The NDC rectangle the numeral row may occupy on a `w`x`h` surface.
@@ -144,7 +321,11 @@ export function ndcFrame(w: number, h: number, insets: Insets): Frame {
   const side = Math.max(insets.left, insets.right);
 
   const edge = Math.max(0.2, Math.min(BAND.edge, 1 - (2 * side) / vw));
-  const bottom = Math.max(BAND.bottom, -1 + (2 * insets.bottom) / vh);
+  // The floor is the HUD's own bottom furniture, measured, not a guess at where
+  // the horizon is: the row's real vertical limit at any given moment is the
+  // deck at its gate's depth, and `readBand` takes that from the gate.
+  const bottomPx = hudBoxes(vw, vh, insets).voltage;
+  const bottom = Math.min(0.9, -1 + (2 * (vh - bottomPx.y)) / vh);
   // The top is bounded by the prompt, by the safe area, and by the host's two
   // controls. The controls only bite on a surface short enough that a twelfth
   // of it reaches down past the prompt line — but that is exactly the surface
@@ -154,5 +335,5 @@ export function ndcFrame(w: number, h: number, insets: Insets): Frame {
     Math.min(BAND.top, 1 - (2 * (insets.top + READOUT_CLEAR)) / vh),
   );
 
-  return { edge, top, bottom };
+  return { edge, top, bottom, minH: (2 * BAND.minCapPx) / vh };
 }

--- a/dynawalla/games/runner/src/game/comprehension.test.ts
+++ b/dynawalla/games/runner/src/game/comprehension.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { comprehensionTarget, itemShape, opOf, MAX_DIGITS, MAX_TARGET } from "./comprehension.ts";
+
+/**
+ * The invariant `docs/PACING_AUDIT_2026-07.md` sets for the whole fleet:
+ *
+ *   > `window(d)` must be MONOTONE NON-DECREASING in item difficulty. A harder
+ *   > question may never get less time than an easier one.
+ *
+ * VOLTA was inverted. The founder:
+ *
+ *   > "you have 5 seconds to do 2x1 and then 2 seconds to do 84302+4186"
+ *
+ * Measured through the real scheduler before this module existed: the gate's own
+ * window was 5.40s on the opening gate, where the content is `5 − 2`, and 2.42s at
+ * terminal velocity on the smallest quality tier, where the content is four- and
+ * five-digit column arithmetic. Comprehension including the pre-read: 8.00s and
+ * 4.02s. His numbers, and the direction is the defect.
+ *
+ * This file holds the item→seconds function. `pacing.test.ts` holds the other
+ * half — that the seconds are actually delivered, and that no motion constant can
+ * take them away.
+ */
+
+const item = (prompt: string, answer: string): { prompt: string; answer: string } => ({ prompt, answer });
+
+test("the three anchors are the cadence table's own", () => {
+  // docs/EXPERIENCE_DESIGN.md, p50: single-digit fact 2.8s, two-digit with
+  // regrouping 6s, the `5,001 − 2,798` class 16s. Not approximately.
+  assert.equal(comprehensionTarget(item("5 − 2", "3")), 2.8);
+  assert.equal(comprehensionTarget(item("36 + 47", "83")), 6.0);
+  assert.equal(comprehensionTarget(item("5001 − 2798", "2203")), 16.0);
+});
+
+test("the founder's two examples are now the right way round", () => {
+  const easy = comprehensionTarget(item("2 × 1", "2"));
+  const hard = comprehensionTarget(item("84302 + 4186", "88488"));
+  assert.ok(hard > easy, `${hard}s for the five-digit sum against ${easy}s for 2 × 1`);
+  assert.equal(easy, 2.8);
+  // No column in `84302 + 4186` carries, which is why it is the plain row and not
+  // the regrouping one. It is still five times the single-digit fact.
+  assert.equal(hard, 14.0);
+  assert.equal(itemShape(item("84302 + 4186", "88488")).regroup, false);
+});
+
+test("a single-digit fact is a single-digit fact even when it carries", () => {
+  // `7 + 8` answers 15, and reading the answer's width instead of the operands'
+  // would call that two-digit work. The cadence table calls it a fact: 2.8s.
+  assert.equal(comprehensionTarget(item("7 + 8", "15")), 2.8);
+  assert.equal(itemShape(item("7 + 8", "15")).digits, 1);
+});
+
+test("carrying and borrowing are detected per column, not guessed", () => {
+  assert.equal(itemShape(item("21 + 34", "55")).regroup, false);
+  assert.equal(itemShape(item("28 + 34", "62")).regroup, true);
+  assert.equal(itemShape(item("85 − 23", "62")).regroup, false);
+  assert.equal(itemShape(item("83 − 25", "58")).regroup, true);
+  // Across a zero, which is the skill this pack's `pack.json` claims by name.
+  assert.equal(itemShape(item("5001 − 2798", "2203")).regroup, true);
+  // The larger operand second, which a host is free to write.
+  assert.equal(itemShape(item("25 − 83", "−58")).regroup, true);
+  // A borrow that only appears in a later column.
+  assert.equal(itemShape(item("941 − 152", "789")).regroup, true);
+});
+
+test("a regrouping question is never given less time than the same width without", () => {
+  for (let d = 1; d <= MAX_DIGITS + 2; d++) {
+    const a = "1".repeat(d);
+    const carry = "9".repeat(d);
+    const plain = comprehensionTarget(item(`${a} + ${a}`, "x"));
+    const regroup = comprehensionTarget(item(`${carry} + ${carry}`, "x"));
+    assert.ok(regroup >= plain, `${String(d)} digits: ${regroup}s with a carry against ${plain}s without`);
+  }
+});
+
+test("the target is monotone non-decreasing in every axis of difficulty", () => {
+  // The fleet invariant, over the whole cross product this function can produce
+  // rather than over the handful of prompts above.
+  const widths = [1, 2, 3, 4, 5, 6, 9];
+  const build = (d: number, regroup: boolean, op: string): { prompt: string; answer: string } => {
+    const digit = regroup ? "9" : "1";
+    return item(`${digit.repeat(d)} ${op} ${digit.repeat(d)}`, "x");
+  };
+  // A PARTIAL order, and deliberately so. Four digits with a borrow asks for 16s
+  // and five digits without asks for 14s, because `5,001 − 2,798` really is harder
+  // than `84302 + 4186` — the cadence table says so by name. What must hold is
+  // monotonicity along each axis with the others fixed, not one total ranking.
+  for (const op of ["+", "−"]) {
+    for (const regroup of [false, true]) {
+      let prev = -Infinity;
+      for (const d of widths) {
+        const t = comprehensionTarget(build(d, regroup, op));
+        assert.ok(
+          t >= prev,
+          `${op} regroup=${String(regroup)}: ${String(d)} digits asks for ${t}s, less than the ${prev}s the narrower one got`,
+        );
+        prev = t;
+      }
+    }
+  }
+  // Multiplication and division are never cheaper than addition of the same width.
+  for (const d of widths) {
+    const add = comprehensionTarget(build(d, true, "+"));
+    for (const op of ["×", "÷"]) {
+      const t = comprehensionTarget(build(d, true, op));
+      assert.ok(t >= add, `${op} at ${String(d)} digits is ${t}s against ${add}s for +`);
+    }
+  }
+});
+
+test("nothing a host can write makes the target smaller than the smallest fact", () => {
+  // Every branch that cannot read the item has to fall to *more* time, never less.
+  // A generous target costs a few seconds of runway; a stingy one is the defect.
+  const odd = [
+    item("", ""),
+    item("what is left?", "4"),
+    item("3/4 + 1/4", "1"),
+    item("? + 5 = 12", "7"),
+    item("1.5 + 2.25", "3.75"),
+    item("−7 + −8", "−15"),
+    item("12 × 34 ÷ 6", "68"),
+    item("2 + 3 + 4", "9"),
+    item("one hundred and four", "104"),
+  ];
+  for (const q of odd) {
+    const t = comprehensionTarget(q);
+    assert.ok(t >= 2.8, `"${q.prompt}" asks for only ${t}s`);
+    assert.ok(t <= MAX_TARGET, `"${q.prompt}" asks for ${t}s, past the top of the table`);
+    assert.ok(Number.isFinite(t));
+  }
+  // A prompt with no operands at all still gets a width from its answer rather
+  // than defaulting to "easy".
+  assert.equal(itemShape(item("how many?", "4821")).digits, 4);
+});
+
+test("the operator is read from the glyphs a host actually writes", () => {
+  assert.equal(opOf("5 − 2"), "sub");
+  assert.equal(opOf("5 - 2"), "sub");
+  assert.equal(opOf("5 – 2"), "sub");
+  assert.equal(opOf("5 + 2"), "add");
+  assert.equal(opOf("5 × 2"), "mul");
+  assert.equal(opOf("5 * 2"), "mul");
+  assert.equal(opOf("6 ÷ 2"), "div");
+  assert.equal(opOf("6 / 2"), "div");
+  assert.equal(opOf("count the shells"), "other");
+});
+
+test("no motion constant can reach this function", () => {
+  // The property that makes the fleet invariant enforceable rather than asserted:
+  // there is nothing in this module's scope that a run can change. If it imported
+  // `pacing.ts` it could see the speed curve, the draw distance and the corridor,
+  // and the defect would be one edit away from returning.
+  const src = readFileSync(new URL("./comprehension.ts", import.meta.url), "utf8");
+  const imports = [...src.matchAll(/^\s*import\b[^;]*;/gm)].map((m) => m[0]);
+  assert.equal(imports.length, 0, `comprehension.ts imports something: ${imports.join(" ")}`);
+  for (const forbidden of ["speed", "travel", "elapsed", "far", "reduced", "surge", "tier", "Date", "performance"]) {
+    assert.ok(
+      !new RegExp(`\\b${forbidden}\\b`).test(src.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, "")),
+      `comprehension.ts mentions "${forbidden}" outside its comments`,
+    );
+  }
+});
+
+test("the same item always asks for the same time", () => {
+  // No randomness, no state, no drift between the two calls a frame apart that
+  // `mount.ts` and the tests each make.
+  const q = item("5001 − 2798", "2203");
+  const first = comprehensionTarget(q);
+  for (let i = 0; i < 50; i++) assert.equal(comprehensionTarget(q), first);
+});

--- a/dynawalla/games/runner/src/game/comprehension.ts
+++ b/dynawalla/games/runner/src/game/comprehension.ts
@@ -1,0 +1,183 @@
+/**
+ * How long a child should have with a question, as a function of the question.
+ *
+ * **The defect this file exists to remove.** VOLTA derived the child's thinking
+ * time from a motion constant, and the motion constant was also the escalation
+ * knob — so every step that made the run more exciting took thinking time away,
+ * and the hardest arithmetic in the pack arrived with the least time to do it.
+ * Measured through the real scheduler before this file existed: 8.0s of
+ * comprehension on the opening gate, where the content is `5 − 2`, falling to
+ * 4.0s at terminal velocity on the smallest quality tier, where the content is
+ * four- and five-digit column arithmetic. The founder put it exactly:
+ *
+ *   > "you have 5 seconds to do 2x1 and then 2 seconds to do 84302+4186"
+ *
+ * `docs/PACING_AUDIT_2026-07.md` names it as one design error replicated across
+ * seventeen games, and states the invariant:
+ *
+ *   > `window(d)` must be MONOTONE NON-DECREASING in item difficulty. A harder
+ *   > question may never get less time than an easier one.
+ *
+ * **So this function may not see the world.** No speed, no elapsed time, no
+ * travel, no draw distance, no tier, no surge — nothing that a run can change is
+ * in scope here, and there is nothing in this module's imports that could supply
+ * one. It reads the item and returns seconds. `pacing.ts` then buys those seconds
+ * the only way VOLTA can afford them: **runway.** Not deceleration — the vehicle
+ * keeps racing, and the road in front of the gate gets longer.
+ *
+ * **Where the numbers come from.** `docs/EXPERIENCE_DESIGN.md` instruments a
+ * cadence table, p50/p90, which is the product's own measured account of how long
+ * these things take:
+ *
+ *   - single-digit fact                 2.8s / 6s
+ *   - two-digit with regrouping         6s   / 14s
+ *   - the `5,001 − 2,798` class         16s  / 40s
+ *
+ * The three anchors below are the p50 column, placed on the shapes the table
+ * names, and the rows between them are interpolated monotonically. p50 and not
+ * p90 because this is a *recognition* task — the answer is one of three numerals
+ * already on screen — and picking a shown candidate is cheaper than producing an
+ * answer cold. It is not four times cheaper, which is what the old 3.2s window
+ * was implicitly claiming.
+ */
+
+/** Which operation a prompt is asking for. `other` gets the cautious branch. */
+export type Op = "add" | "sub" | "mul" | "div" | "other";
+
+export type Shape = {
+  /**
+   * Digits in the longest operand.
+   *
+   * The operands and not the answer: `7 + 8` is a single-digit fact whose answer
+   * has two digits, and the cadence table calls that 2.8s, not 6.
+   */
+  digits: number;
+  /** Does a column carry or borrow? */
+  regroup: boolean;
+  op: Op;
+};
+
+const DIGIT_RUN = /\d+/g;
+
+/** Every run of digits in `s`, longest-first order not guaranteed. */
+function runs(s: string): string[] {
+  DIGIT_RUN.lastIndex = 0;
+  return s.match(DIGIT_RUN) ?? [];
+}
+
+/**
+ * The operator, from the first operator glyph in the prompt.
+ *
+ * `−` is the typographic minus the atlas uses and `-` is what a host writes;
+ * both are here. A prompt with no operator at all — a word problem, a
+ * fill-in-the-blank — is `other`, which is treated as the *harder* branch, for
+ * the same reason an unparseable operand pair is: this function's failure mode
+ * must be "the child got more time than they needed".
+ */
+export function opOf(prompt: string): Op {
+  for (const ch of prompt) {
+    if (ch === "+") return "add";
+    if (ch === "-" || ch === "−" || ch === "–" || ch === "—") return "sub";
+    if (ch === "×" || ch === "*" || ch === "·") return "mul";
+    if (ch === "÷" || ch === "/" || ch === ":") return "div";
+  }
+  return "other";
+}
+
+/** Does adding these two decimal strings carry out of any column? */
+function addCarries(a: string, b: string): boolean {
+  let carry = 0;
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const da = Number(a[a.length - 1 - i] ?? "0");
+    const db = Number(b[b.length - 1 - i] ?? "0");
+    const sum = da + db + carry;
+    if (sum > 9) return true;
+    carry = 0;
+  }
+  return false;
+}
+
+/** Does subtracting the smaller from the larger borrow out of any column? */
+function subBorrows(a: string, b: string): boolean {
+  const [big, small] = a.length > b.length || (a.length === b.length && a >= b) ? [a, b] : [b, a];
+  let borrow = 0;
+  for (let i = 0; i < big.length; i++) {
+    const db = Number(big[big.length - 1 - i] ?? "0");
+    const ds = Number(small[small.length - 1 - i] ?? "0");
+    if (db - borrow < ds) {
+      return true;
+    }
+    borrow = 0;
+  }
+  return false;
+}
+
+/**
+ * What kind of arithmetic this is, from the item's own text.
+ *
+ * A host can write anything — `3/4`, a word problem, an equation with the unknown
+ * on the left — so every branch that cannot read the item falls to the *slower*
+ * classification. Being generous with time to a question that did not need it
+ * costs a few seconds of runway; being stingy is the defect.
+ */
+export function itemShape(item: { prompt: string; answer: string }): Shape {
+  const operands = runs(item.prompt);
+  const op = opOf(item.prompt);
+  const widest = operands.length > 0 ? operands : runs(item.answer);
+  const digits = widest.reduce((m, r) => Math.max(m, r.length), 1);
+
+  let regroup: boolean;
+  if (operands.length !== 2) {
+    // One operand (or three: an equation, a chained expression) is not a column
+    // sum this function can reason about. Assume the work is there.
+    regroup = true;
+  } else if (op === "add") {
+    regroup = addCarries(operands[0] ?? "", operands[1] ?? "");
+  } else if (op === "sub") {
+    regroup = subBorrows(operands[0] ?? "", operands[1] ?? "");
+  } else {
+    // Multiplication and division past a single digit are partial products and
+    // trial quotients all the way down; there is no column that does not carry.
+    regroup = digits > 1;
+  }
+
+  return { digits, regroup, op };
+}
+
+/**
+ * The cadence table, p50 seconds, by operand width and whether a column carries.
+ *
+ * Index 0 is unused so the row index reads as the digit count. Rows 1, 2 and 4
+ * are the three anchors `EXPERIENCE_DESIGN.md` instruments; 3 and 5 are
+ * interpolated. Every column is non-decreasing down the table and the regrouping
+ * row is never below the plain one, which is the invariant, and it is asserted
+ * over the whole cross product rather than left to inspection.
+ *
+ * A single-digit fact is 2.8s whether or not it carries: `7 + 8` is the thing the
+ * table calls a single-digit fact, and a child who knows their facts is not doing
+ * columns at all.
+ */
+const PLAIN = [0, 2.8, 4.2, 7.0, 11.0, 14.0] as const;
+const REGROUP = [0, 2.8, 6.0, 10.0, 16.0, 20.0] as const;
+
+/** The widest content the table describes. Beyond it, the last row stands. */
+export const MAX_DIGITS = 5;
+
+/** The most any item can ask for, in seconds. */
+export const MAX_TARGET = REGROUP[MAX_DIGITS];
+
+/**
+ * Seconds a child should have with `item`, before it must be answered.
+ *
+ * Pure in the item. Nothing about the run reaches this function, and that is the
+ * property the fleet invariant needs — see the module note.
+ */
+export function comprehensionTarget(item: { prompt: string; answer: string }): number {
+  const { digits, regroup, op } = itemShape(item);
+  // Multi-digit multiplication and division are a row harder than their width:
+  // `12 × 34` is four single-digit products and a two-column sum, not a
+  // two-column anything.
+  const heavy = (op === "mul" || op === "div" || op === "other") && digits > 1 ? 1 : 0;
+  const row = Math.min(MAX_DIGITS, Math.max(1, digits + heavy));
+  return regroup ? REGROUP[row] : PLAIN[row];
+}

--- a/dynawalla/games/runner/src/game/entities.ts
+++ b/dynawalla/games/runner/src/game/entities.ts
@@ -4,7 +4,10 @@ import type { DigitField } from "./digits.ts";
 import type { Rng } from "./rng.ts";
 import type { Projector } from "./project.ts";
 import { LANE_W, DECK_HALF } from "./world.ts";
-import { readBand, payoffHeight, keepInside, payoffEdge, popupEdge, type Frame } from "./readband.ts";
+import {
+  readBand, payoffHeight, keepInside, payoffEdge, popupEdge,
+  type Frame, type GateGeom,
+} from "./readband.ts";
 import { laneOptions } from "./options.ts";
 import { clamp01, easeOutBack, easeOutCubic, easeOutQuint } from "./juice.ts";
 
@@ -46,8 +49,6 @@ export type Gate = {
   burst: number;
   /** Reading window this gate was granted, in seconds. Reported for tuning. */
   window: number;
-  /** Distance ahead the gate was spawned at; drives the read-band spread. */
-  spawn: number;
   /** Where the three numerals last drew, in NDC, so the payoff can start there. */
   ndcX: [number, number, number];
   ndcY: number;
@@ -107,7 +108,7 @@ export class Entities {
       this.gates.push({
         active: false, z: 0, q: null, values: ["", "", ""], correctLane: 1,
         chosenLane: -1, state: "incoming", shownAt: 0, intro: 0, burst: 0, window: 0,
-        spawn: 100, ndcX: [-0.58, 0, 0.58], ndcY: 0.3, ndcH: 0.2,
+        ndcX: [-0.58, 0, 0.58], ndcY: 0.3, ndcH: 0.2,
       });
     for (let i = 0; i < hazardCap; i++)
       this.hazards.push({ active: false, kind: "pylon", z: 0, lane: 1, phase: 0, span: 1, hit: false, grazed: false });
@@ -140,7 +141,6 @@ export class Entities {
     g.intro = 0;
     g.burst = 0;
     g.window = window;
-    g.spawn = distance;
     for (let i = 0; i < 3; i++) g.values[i] = values[i];
     return g;
   }
@@ -310,6 +310,12 @@ export class Entities {
    * where the row wants to sit, the second re-linearises around the row's own
    * height. The camera is pitched about three degrees, and one refinement takes
    * the residual well under a pixel.
+   *
+   * Every input to the layout is measured off this gate: where its middle lane
+   * projects to, how far apart its lanes are on screen, how tall its arches are.
+   * The row therefore travels with the gate, grows with it and settles into the
+   * windows — before, all three numbers were screen constants and the row was a
+   * HUD element that happened to be drawn in the world.
    */
   private drawCandidates(
     g: Gate, digits: DigitField, glow: GlowField, proj: Projector,
@@ -318,21 +324,33 @@ export class Entities {
     H: number,
     frame: Frame,
   ): void {
-    const dist = Math.max(0, -g.z);
-    const approach = clamp01(1 - dist / Math.max(1, g.spawn));
-
     const u = TMP_UNITS;
     proj.at(g.z, H);
-    const archTop = proj.ndcY(H);
+    const geom: GateGeom = {
+      centre: proj.x0,
+      lanePitch: Math.abs(proj.kx) * LANE_W,
+      archTop: proj.ndcY(H),
+      archH: Math.abs(proj.ky) * H,
+      deck: proj.ndcY(0),
+    };
     for (let i = 0; i < 3; i++) u[i] = Math.max(1e-4, digits.measure(g.values[i], 1));
 
-    let band = readBand(u, proj.kx, proj.ky, approach, archTop, frame);
+    let band = readBand(u, proj.kx, proj.ky, geom, frame);
+    // Re-linearise around the row's own height. `centre`, `lanePitch`, `archTop`,
+    // `archH` and `deck` are re-measured with it: they are all functions of the
+    // reference height, and holding the first pass's values here is what would
+    // put the row half a lane off its arch on a pitched camera.
     proj.at(g.z, proj.worldY(band.y));
-    band = readBand(u, proj.kx, proj.ky, approach, archTop, frame);
+    geom.centre = proj.x0;
+    geom.lanePitch = Math.abs(proj.kx) * LANE_W;
+    geom.archTop = proj.ndcY(H);
+    geom.archH = Math.abs(proj.ky) * H;
+    geom.deck = proj.ndcY(0);
+    band = readBand(u, proj.kx, proj.ky, geom, frame);
 
-    // The row is dealt outward from the vanishing point as the gate resolves out
-    // of the fog. Overshoot is deliberate — `readBand` keeps a 30% gutter, so a
-    // 13% back-ease can never close it.
+    // The row is dealt outward from the gate's centre as it resolves out of the
+    // fog. Overshoot is deliberate — `readBand` keeps a 30% gutter, so a 13%
+    // back-ease can never close it.
     const deal = clamp01(g.intro * 1.35);
     const spread = easeOutBack(deal);
     const scale = easeOutBack(clamp01(g.intro * 1.6));
@@ -344,23 +362,27 @@ export class Entities {
     g.ndcH = band.hNdc * scale;
 
     for (let i = 0; i < 3; i++) {
-      const nx = band.x[i] * spread;
+      const nx = band.x[1] + (band.x[i] - band.x[1]) * spread;
       g.ndcX[i] = nx;
       const xW = proj.worldX(nx);
 
-      // A leader from the numeral down to the top of its own arch. Left-to-right
-      // order alone is enough to guess the mapping from; the leader means a
-      // child never has to guess it.
+      // A leader from the numeral down to the top of its own arch, for as long as
+      // there is a gap to lead across. It fades out as the numeral settles into
+      // the window: a line of dots from a numeral to the arch it is already
+      // standing in is a line of dots to nowhere.
       const ax = laneX(i);
       const ay = H + 0.5;
-      for (let k = 1; k <= 5; k++) {
-        const t = k / 6;
-        const lt = t * t; // bunch the dots toward the arch, where the answer is
-        glow.add(
-          xW + (ax - xW) * lt, yW - hW * 0.62 + (ay - (yW - hW * 0.62)) * lt, g.z + 0.02,
-          hW * (0.16 + t * 0.1), alpha * (0.1 + t * 0.42), 1, 0,
-          ac[0], ac[1], ac[2],
-        );
+      const lead = alpha * (1 - band.onGate);
+      if (lead > 0.02) {
+        for (let k = 1; k <= 5; k++) {
+          const t = k / 6;
+          const lt = t * t; // bunch the dots toward the arch, where the answer is
+          glow.add(
+            xW + (ax - xW) * lt, yW - hW * 0.62 + (ay - (yW - hW * 0.62)) * lt, g.z + 0.02,
+            hW * (0.16 + t * 0.1), lead * (0.1 + t * 0.42), 1, 0,
+            ac[0], ac[1], ac[2],
+          );
+        }
       }
       // ...and a hard cap sitting on the arch, so the endpoint is unmissable.
       glow.add(ax, ay, g.z + 0.02, LANE_W * 0.5, alpha * 0.5, 0.12, 3, ac[0], ac[1], ac[2]);

--- a/dynawalla/games/runner/src/game/gatelayout.test.ts
+++ b/dynawalla/games/runner/src/game/gatelayout.test.ts
@@ -1,0 +1,368 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as THREE from "three";
+
+import { Projector } from "./project.ts";
+import { readBand, type GateGeom } from "./readband.ts";
+import { ndcFrame } from "./chrome.ts";
+import { INK, TRACK } from "./glyphs.ts";
+import { LANE_W } from "./world.ts";
+
+/**
+ * Do the answers sit with the windows?
+ *
+ * The founder's note, on an Android phone at 0.3.3:
+ *
+ *   > "the answers would be better if they sat with the windows like they used
+ *   > to I think."
+ *
+ * His screenshot has the prompt on the HUD, the three candidates as enormous
+ * free-standing numerals in the sky, and the neon gate arches behind and below
+ * them. He was right, and it was not a matter of taste: measured on his viewport,
+ * against the shipped `readBand`, at 78° of field of view —
+ *
+ *     d=80  outer numeral x=305px   its arch x=198px   dx=107px   cap 98px  arch  27px tall
+ *     d=60  outer numeral x=305px   its arch x=203px   dx=102px   cap 98px  arch  34px tall
+ *     d=30  outer numeral x=305px   its arch x=219px   dx= 86px   cap 98px  arch  59px tall
+ *     d=10  outer numeral x=305px   its arch x=256px   dx= 49px   cap 98px  arch 114px tall
+ *     d= 4  outer numeral x=305px   its arch x=286px   dx= 19px   cap 98px  arch 158px tall
+ *
+ * — and, with the child in the left lane so the chase camera has slid the gate
+ * cluster right, `d=4` becomes `numeral x=305, arch x=350, dx=-44px`: the outer
+ * answer on the *wrong side* of the arch it belongs to.
+ *
+ * Three numbers, none of them a function of the gate: a fixed screen x, a fixed
+ * cap height, and a fixed 27px of air above the lintel. That is a HUD element
+ * drawn in the world.
+ *
+ * This file is separate from `readband.test.ts` because it needs the *real*
+ * projection — the chase camera is pitched, positioned off-centre by the player's
+ * lane and springs its field of view around, and a hand-rolled pinhole model
+ * would be asserting against a camera the game does not have. It builds the real
+ * `THREE.PerspectiveCamera`, poses it exactly as `render()` does, runs the real
+ * `Projector`, and measures in CSS pixels.
+ */
+
+/* Verbatim from `mount.ts`'s render(), which is the only place the camera is posed. */
+const CAM = { x: 0.6, y: 4.45, z: 11.4, lift: 0.42, target: { x: 0.3, y: 2.35, z: -26 } };
+/** Arch height, from `drawGates`: `H = 4.9 * intro`, at intro 1. */
+const ARCH_H = 4.9;
+
+type Shot = {
+  /** CSS pixels from the left edge, per candidate. */
+  numeralX: [number, number, number];
+  /** CSS pixels from the left edge, per lane's arch centre. */
+  archX: [number, number, number];
+  numeralTop: number;
+  numeralBottom: number;
+  archTop: number;
+  deck: number;
+  capPx: number;
+  onGate: number;
+};
+
+/**
+ * Lay one gate out, and report it in pixels.
+ *
+ * @param playerX the child's world x — the camera follows it at 0.6x, which is
+ *                what slid the gate cluster out from under the old row
+ */
+function shoot(
+  w: number,
+  h: number,
+  fovDeg: number,
+  dist: number,
+  digitsPerValue: number,
+  playerX = 0,
+): Shot {
+  const camera = new THREE.PerspectiveCamera(fovDeg, w / h, 0.35, 300);
+  camera.fov = fovDeg;
+  camera.position.set(playerX * CAM.x, CAM.y, CAM.z);
+  camera.lookAt(new THREE.Vector3(playerX * CAM.target.x, CAM.target.y, CAM.target.z));
+  camera.updateProjectionMatrix();
+
+  const proj = new Projector();
+  proj.update(camera, 0, 0);
+
+  const z = -dist;
+  // `digits.measure(text, 1)`, without the atlas: an Archivo Black digit advances
+  // about 0.444 of the cell it is drawn in. `INK` and `TRACK` are the renderer's
+  // own, imported rather than copied.
+  const u = digitsPerValue * 0.444 * (1 / INK) * TRACK;
+
+  proj.at(z, ARCH_H);
+  const geom: GateGeom = {
+    centre: proj.x0,
+    lanePitch: Math.abs(proj.kx) * LANE_W,
+    archTop: proj.ndcY(ARCH_H),
+    archH: Math.abs(proj.ky) * ARCH_H,
+    deck: proj.ndcY(0),
+  };
+  let band = readBand([u, u, u], proj.kx, proj.ky, geom, ndcFrame(w, h, ZERO));
+  proj.at(z, proj.worldY(band.y));
+  geom.centre = proj.x0;
+  geom.lanePitch = Math.abs(proj.kx) * LANE_W;
+  geom.archTop = proj.ndcY(ARCH_H);
+  geom.archH = Math.abs(proj.ky) * ARCH_H;
+  geom.deck = proj.ndcY(0);
+  band = readBand([u, u, u], proj.kx, proj.ky, geom, ndcFrame(w, h, ZERO));
+
+  const toX = (ndc: number): number => ((ndc + 1) / 2) * w;
+  const toY = (ndc: number): number => ((1 - ndc) / 2) * h;
+  const lane = (i: number): number => toX(proj.x0 + proj.kx * (i - 1) * LANE_W);
+
+  return {
+    numeralX: [toX(band.x[0]), toX(band.x[1]), toX(band.x[2])],
+    archX: [lane(0), lane(1), lane(2)],
+    numeralTop: toY(band.y + band.hNdc / 2),
+    numeralBottom: toY(band.y - band.hNdc / 2),
+    archTop: toY(geom.archTop),
+    deck: toY(geom.deck),
+    capPx: (band.hNdc / 2) * h,
+    onGate: band.onGate,
+  };
+}
+
+const ZERO = { top: 0, right: 0, bottom: 0, left: 0 };
+
+/** The founder's phone, and the field of view portrait actually settles at. */
+const W = 360;
+const H = 780;
+const FOV = 78;
+
+/**
+ * Where in the approach a candidate can physically be *inside* its own window,
+ * per answer width, measured on this viewport.
+ *
+ * There is a hard geometric limit here and pretending otherwise would be the
+ * dishonest version of this fix. A window is `LANE_W - 0.42` world units wide,
+ * which on this viewport is 34 CSS px at thirty units out and 91 px at four; a
+ * two-digit numeral at the legibility floor is 83 px wide and a three-digit one is
+ * 88 px. So a wide answer physically cannot stand inside a distant window, and the
+ * only way to make it appear to is to shrink it to the eleven pixels this game
+ * shipped once and was rewritten to stop shipping.
+ *
+ * What holds at every width is that the row converges on its gate monotonically
+ * and never runs away from it. Measured, on the founder's phone at 78°, the
+ * distance from the outer candidate to the centre of its own arch:
+ *
+ *     digits   d=100   d=60   d=40   d=20   d=10   d=6   d=4
+ *     1         52px   44px   35px   16px    3px   0px   0px
+ *     2        104px   96px   88px   68px   44px  27px  15px
+ *     3        111px  103px   94px   74px   50px  33px  21px
+ *
+ * Before, at every width and every distance: 107px, 102px, 94px, 73px, 49px, 30px,
+ * 19px — identical for one digit and for four, because the row never moved. What
+ * closed the gap in those columns was the arch sweeping underneath a stationary
+ * numeral, not the numeral going anywhere.
+ *
+ * The distances below are where a candidate's *centre* is inside its own window,
+ * per width, on this viewport. On a tablet the same figures for a two-digit answer
+ * are 93px at forty units falling to 10px at four, so the lock arrives earlier
+ * wherever the glass is wider.
+ */
+const INSIDE_FROM: Record<number, number> = { 1: 20, 2: 6, 3: 6 };
+
+/** Where the child is actually deciding: the gate is visible and not yet on them. */
+const APPROACH = [100, 80, 60, 40, 30, 20, 12];
+
+test("a candidate closes on its own arch for the whole time it is being read", () => {
+  // The number the fix is for. Before: 107px at d=80 falling to 19px at d=4 —
+  // and not because the row moved, but because the arch swept underneath it.
+  for (const digits of [1, 2, 3, 4]) {
+    let prev = Infinity;
+    for (const dist of APPROACH) {
+      const s = shoot(W, H, FOV, dist, digits);
+      const dx = Math.abs(s.numeralX[2] - s.archX[2]);
+      assert.ok(
+        dx <= prev + 1e-6,
+        `n=${String(digits)}: the outer answer moved AWAY from its arch at d=${String(dist)}: ` +
+          `${dx.toFixed(0)}px, was ${prev.toFixed(0)}px`,
+      );
+      prev = dx;
+    }
+  }
+});
+
+test("the row's pitch converges on the lane pitch and never runs away from it", () => {
+  // The scale-free version of the same statement, and the one that holds at every
+  // answer width: the ratio of the row's pitch to the gate's own only ever falls.
+  for (const digits of [1, 2, 3, 4]) {
+    let prev = Infinity;
+    for (const dist of APPROACH) {
+      const s = shoot(W, H, FOV, dist, digits);
+      const rowPitch = Math.abs(s.numeralX[2] - s.numeralX[1]);
+      const lanePitch = Math.abs(s.archX[2] - s.archX[1]);
+      const ratio = rowPitch / lanePitch;
+      assert.ok(ratio >= 1 - 1e-6, `n=${String(digits)} d=${String(dist)}: the row is TIGHTER than the lanes`);
+      assert.ok(
+        ratio <= prev + 1e-6,
+        `n=${String(digits)}: the row spread relative to its gate at d=${String(dist)}: ` +
+          `${ratio.toFixed(2)}x the lane pitch, was ${prev.toFixed(2)}x`,
+      );
+      prev = ratio;
+    }
+    assert.ok(prev < 2, `n=${String(digits)}: the row is still ${prev.toFixed(2)}x the lane pitch at twelve units out`);
+  }
+});
+
+test("an answer narrow enough to fit its window is inside it while the child steers", () => {
+  let checked = 0;
+  for (const [digitsKey, from] of Object.entries(INSIDE_FROM)) {
+    const digits = Number(digitsKey);
+    for (const dist of [from, 16, 12, 10, 8, 6, 4]) {
+      if (dist > from) continue;
+      for (const playerX of [-LANE_W, 0, LANE_W]) {
+        const s = shoot(W, H, FOV, dist, digits, playerX);
+        const halfWindow = (Math.abs(s.archX[1] - s.archX[0]) * ((LANE_W - 0.42) / LANE_W)) / 2;
+        // Only while the gate cluster is still ON the glass. In the last couple of
+        // units the outer arch is genuinely off the edge of the screen — at four
+        // units out on this viewport its centre projects past x = 333 of 360 with
+        // the child in the far lane — and a numeral that followed it there would
+        // be a numeral the child cannot see. By then the answer is given: the gate
+        // is 0.06s away at terminal velocity.
+        if (s.archX[0] - halfWindow < 0 || s.archX[2] + halfWindow > W) continue;
+        // ...and only where the row had room to follow the gate at all. A row is
+        // one object with one pitch, so a two-digit row 125px between centres on a
+        // 360px screen already spans the glass and the page margin pins it: there
+        // is nowhere for it to go. That case is covered by the convergence test
+        // above and by the assertion below, not silently by a loose tolerance here.
+        if (Math.abs(s.numeralX[1] - s.archX[1]) > 0.5) continue;
+        for (const i of [0, 1, 2]) {
+          const dx = Math.abs(s.numeralX[i] - s.archX[i]);
+          assert.ok(
+            dx <= halfWindow + 1e-6,
+            `n=${String(digits)} d=${String(dist)} playerX=${playerX.toFixed(1)}: candidate ${String(i)} is ` +
+              `${dx.toFixed(0)}px from the centre of a window ${(halfWindow * 2).toFixed(0)}px wide`,
+          );
+        }
+        checked++;
+      }
+    }
+  }
+  assert.ok(checked >= 6, `only ${String(checked)} cases survived the on-screen filter; this test is measuring nothing`);
+});
+
+test("a row too wide to follow its gate is still pinned toward it, never away", () => {
+  // The honest statement of the limit. A wide answer on a narrow phone fills the
+  // glass, so the page margin stops the row before it reaches the gate. What must
+  // hold is that the clamp never moves the row to the WRONG side — which is what
+  // pinning it to the centre of the screen did: at four units out, with the child
+  // in the left lane, the outer numeral was 44px past its own arch.
+  let clamped = 0;
+  for (const digits of [2, 3, 4]) {
+    for (const dist of [12, 8, 6, 4]) {
+      for (const playerX of [-LANE_W, LANE_W]) {
+        const s = shoot(W, H, FOV, dist, digits, playerX);
+        const off = s.numeralX[1] - s.archX[1];
+        if (Math.abs(off) <= 0.5) continue;
+        clamped++;
+        const centred = shoot(W, H, FOV, dist, digits, 0);
+        // The row moved toward the gate from where a screen-pinned row would be,
+        // or it had no room at all — never in the opposite direction.
+        const towards = (s.archX[1] - centred.numeralX[1]) * (s.numeralX[1] - centred.numeralX[1]);
+        assert.ok(
+          towards >= -1e-6,
+          `n=${String(digits)} d=${String(dist)} playerX=${playerX.toFixed(1)}: the gate is at ` +
+            `${s.archX[1].toFixed(0)}px, a screen-pinned row would be at ${centred.numeralX[1].toFixed(0)}px, ` +
+            `and this row is at ${s.numeralX[1].toFixed(0)}px — the wrong way`,
+        );
+      }
+    }
+  }
+  assert.ok(clamped > 0, "no case was clamped, so this test is asserting nothing; re-derive the widths");
+});
+
+test("steering moves the answers with the gate instead of leaving them behind", () => {
+  // The worst case measured before the fix: at four units out, with the child in
+  // the left lane, the outer numeral was 44px to the WRONG side of its own arch,
+  // because the row was pinned to the middle of the glass while the chase camera
+  // slid the gate. The row now travels with it.
+  for (const dist of [40, 30, 20, 12, 10]) {
+    const left = shoot(W, H, FOV, dist, 1, -LANE_W);
+    const right = shoot(W, H, FOV, dist, 1, LANE_W);
+    // A child in the RIGHT lane moves the camera right, so the gate projects
+    // further LEFT. Both numbers are negative, and they have to be the same
+    // number: the row moves exactly as far as the gate it belongs to.
+    const gateShift = right.archX[1] - left.archX[1];
+    const rowShift = right.numeralX[1] - left.numeralX[1];
+    assert.ok(gateShift < -5, `d=${String(dist)}: the test's own premise is wrong, the gate barely moved`);
+    assert.ok(
+      Math.abs(rowShift - gateShift) < 1.5,
+      `d=${String(dist)}: the gate moved ${gateShift.toFixed(0)}px and the row moved ${rowShift.toFixed(0)}px`,
+    );
+  }
+});
+
+test("a candidate is framed by its arch, not floating above it", () => {
+  // Before: the numeral's bottom edge sat a flat 27px above the lintel at every
+  // distance, with the arch "behind and below" — the founder's own words.
+  // From thirty units. Forty is the crossover, where the window is exactly as tall
+  // as the legibility floor and `onGate` reaches 1 to within a rounding error;
+  // asserting it there would be asserting a float comparison.
+  for (const dist of [30, 20, 12, 10, 6, 4]) {
+    const s = shoot(W, H, FOV, dist, 1);
+    assert.ok(
+      s.numeralBottom > s.archTop,
+      `d=${String(dist)}: the numeral ends at y=${s.numeralBottom.toFixed(0)} and the lintel is at ` +
+        `y=${s.archTop.toFixed(0)} — it is entirely above the window`,
+    );
+    assert.ok(
+      s.numeralBottom <= s.deck + 1e-6,
+      `d=${String(dist)}: the numeral reaches y=${s.numeralBottom.toFixed(0)}, past a deck at y=${s.deck.toFixed(0)}`,
+    );
+    assert.ok(s.onGate >= 1 - 1e-9, `d=${String(dist)}: the row is only ${(s.onGate * 100).toFixed(0)}% into its window`);
+  }
+});
+
+test("further out, where no numeral fits the arch, the row still sits ON the gate", () => {
+  // The row cannot be *in* a 13px window, so it is held above the lintel with the
+  // leader dots the renderer fades with `onGate`. What must not happen is the old
+  // behaviour: a fixed 27px of air at every distance, so the gap never closed.
+  let prev = Infinity;
+  for (const dist of [160, 120, 100, 80, 60]) {
+    const s = shoot(W, H, FOV, dist, 1);
+    const gap = s.archTop - s.numeralBottom;
+    assert.ok(gap <= prev + 1e-6, `the gap above the lintel grew at d=${String(dist)}: ${gap.toFixed(0)}px was ${prev.toFixed(0)}px`);
+    assert.ok(s.onGate > 0, `d=${String(dist)}: onGate is 0, so the leaders never fade`);
+    prev = gap;
+  }
+  assert.ok(prev < 20, `the row is still ${prev.toFixed(0)}px clear of the lintel at sixty units`);
+});
+
+test("and it grows with its gate instead of being a constant on the glass", () => {
+  const far = shoot(W, H, FOV, 100, 1);
+  const near = shoot(W, H, FOV, 4, 1);
+  let prev = -Infinity;
+  for (const dist of [240, 160, 100, 60, 30, 20, 12, 6, 4]) {
+    const s = shoot(W, H, FOV, dist, 1);
+    assert.ok(s.capPx >= prev - 1e-9, `the numeral shrank on approach at d=${String(dist)}`);
+    prev = s.capPx;
+  }
+  assert.ok(
+    near.capPx > far.capPx * 1.6,
+    `a single digit is ${far.capPx.toFixed(0)}px at 100 units and ${near.capPx.toFixed(0)}px at 4 — ` +
+      "that is not perspective, it is a HUD",
+  );
+  assert.ok(far.capPx >= 44, `at 100 units a digit is only ${far.capPx.toFixed(0)}px tall`);
+});
+
+test("the answers still clear the cutout and the host's chrome on a real camera", () => {
+  // The pure sweep in `chrome.test.ts` covers this against synthesised geometry.
+  // This one covers it against the projection the game actually uses, including
+  // the pitch and the camera's lane follow, which is where a numeral would
+  // realistically be pushed off an edge.
+  for (const dist of [100, 60, 30, 12, 4]) {
+    for (const digits of [1, 2, 3, 4]) {
+      for (const playerX of [-LANE_W, 0, LANE_W]) {
+        for (const fov of [58, 78, 104]) {
+          const s = shoot(W, H, fov, dist, digits, playerX);
+          const ctx = `d=${String(dist)} n=${String(digits)} fov${String(fov)} playerX=${playerX.toFixed(1)}`;
+          assert.ok(s.numeralX[0] >= 0, `${ctx}: left answer at ${s.numeralX[0].toFixed(0)}px, off screen`);
+          assert.ok(s.numeralX[2] <= W, `${ctx}: right answer at ${s.numeralX[2].toFixed(0)}px of ${String(W)}`);
+          assert.ok(s.numeralTop >= 0 && s.numeralBottom <= H, `${ctx}: the row left the glass vertically`);
+        }
+      }
+    }
+  }
+});

--- a/dynawalla/games/runner/src/game/hud.ts
+++ b/dynawalla/games/runner/src/game/hud.ts
@@ -13,7 +13,8 @@
  * reads as a worksheet or a settings app.
  */
 
-import { READOUT_CLEAR } from "./chrome.ts";
+import { hudVars } from "./chrome.ts";
+import type { Insets } from "../../../../packs/shared/game-chrome/index.ts";
 
 /**
  * The safe-area insets, as CSS values.
@@ -23,16 +24,31 @@ import { READOUT_CLEAR } from "./chrome.ts";
  * edge of the glass. The HUD should not: a voltage bar under the home indicator
  * is a voltage bar with a white pill through it, and a score under the cutout is
  * a score nobody can read.
+ *
+ * **These are custom properties and not `env()`, and that is the whole point.**
+ * `env(safe-area-inset-*)` belongs to the top-level browsing context. A pack runs
+ * in an iframe sandboxed `allow-scripts` with no `allow-same-origin`, so all four
+ * resolve to **0** inside it — on every device, in every orientation, for ever.
+ * This stylesheet used to read them directly, so on the founder's phone the score
+ * painted eighteen pixels under the host's exit chevron and the voltage bar
+ * painted inside Android's gesture strip. The host measures the real insets and
+ * posts them; `chrome.ts` turns them into these properties and `layoutHud` writes
+ * them on. Nothing here may reach for `env()` again — `chrome.test.ts` fails the
+ * build if it does.
  */
-const SA_T = "env(safe-area-inset-top, 0px)";
-const SA_R = "env(safe-area-inset-right, 0px)";
-const SA_B = "env(safe-area-inset-bottom, 0px)";
-const SA_L = "env(safe-area-inset-left, 0px)";
+const SA_T = "var(--vt-sa-t, 0px)";
+const SA_R = "var(--vt-sa-r, 0px)";
+const SA_B = "var(--vt-sa-b, 0px)";
+const SA_L = "var(--vt-sa-l, 0px)";
 
-/** The HUD's own margin from the safe edge. */
-const M = "clamp(10px,2.2vw,26px)";
-
-const CSS = `
+/**
+ * The stylesheet, exported so `chrome.test.ts` can hold it to two rules that
+ * cannot be checked any other way: it contains no `env(safe-area-inset-*)` — the
+ * value that is zero inside a pack and shipped the founder's three collisions —
+ * and every positional declaration on the five in-run HUD boxes is a `var()`
+ * filled in by `chrome.ts`, so the sheet has no geometry of its own to drift.
+ */
+export const HUD_CSS = `
 .vt-root { position:absolute; inset:0; pointer-events:none; overflow:hidden;
   font-family:"Archivo Black","Helvetica Neue","Arial Black","Segoe UI",system-ui,sans-serif;
   font-weight:900; -webkit-font-smoothing:antialiased; text-transform:uppercase;
@@ -41,7 +57,7 @@ const CSS = `
 .vt-num { font-variant-numeric:tabular-nums; letter-spacing:0.01em; }
 
 /* ---- prompt ---- */
-.vt-prompt { position:absolute; left:50%; top:max(15%, calc(${SA_T} + 8px)); transform:translate(-50%,0);
+.vt-prompt { position:absolute; left:50%; top:var(--vt-prompt-y,15%); transform:translate(-50%,0);
   display:flex; align-items:center; gap:clamp(8px,2.2vw,18px); white-space:nowrap; }
 .vt-prompt-bar { width:clamp(10px,3vw,26px); height:clamp(3px,0.7vw,5px); background:currentColor;
   opacity:0.55; }
@@ -55,9 +71,11 @@ const CSS = `
 /* The host paints an exit control in the top-LEFT 44px corner and a
    how-to-play control in the top-RIGHT one, over this pack. The score used
    to sit under the first and the surge meter under the second. They drop
-   clear of both — the readouts move, the world behind them does not. */
-.vt-tl { position:absolute; left:calc(${SA_L} + ${M}); top:calc(${SA_T} + ${READOUT_CLEAR}px); }
-.vt-tr { position:absolute; right:calc(${SA_R} + ${M}); top:calc(${SA_T} + ${READOUT_CLEAR}px); text-align:right; }
+   clear of both — the readouts move, the world behind them does not.
+   Every offset comes from hudBoxes in chrome.ts. There is deliberately no
+   arithmetic here to disagree with it. */
+.vt-tl { position:absolute; left:var(--vt-tl-x,10px); top:var(--vt-tl-y,63px); }
+.vt-tr { position:absolute; right:var(--vt-tr-x,10px); top:var(--vt-tr-y,63px); text-align:right; }
 .vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; opacity:0.5; }
 /* Tracking adds a trailing space after the last letter, which right-aligned
    text pushes off a narrow screen. Pull it back. */
@@ -80,9 +98,11 @@ const CSS = `
 .vt-chain.vt-clean .vt-pip { animation:vt-clean 0.5s ease-out; }
 @keyframes vt-clean { 0%{transform:scaleY(3.4); opacity:1;} 100%{transform:scaleY(1);} }
 
-/* ---- voltage ---- */
-.vt-volt { position:absolute; left:calc(${SA_L} + ${M}); right:calc(${SA_R} + ${M});
-  bottom:calc(${SA_B} + clamp(12px,2.6vw,28px)); height:clamp(9px,1.8vw,15px);
+/* ---- voltage ----
+   The bottom offset clears Android's gesture strip as well as the reported inset: the
+   strip eats the pixels and reports an inset of zero. See GESTURE_STRIP. */
+.vt-volt { position:absolute; left:var(--vt-volt-l,10px); right:var(--vt-volt-r,10px);
+  bottom:var(--vt-volt-b,36px); height:var(--vt-volt-h,9px);
   border:2px solid rgba(255,255,255,0.30); display:flex; align-items:stretch; padding:2px; }
 .vt-volt-fill { height:100%; width:100%; transform-origin:0 50%; transition:none;
   box-shadow:0 0 18px currentColor; background:currentColor; }
@@ -190,16 +210,18 @@ const CSS = `
 .vt-stat b { display:block; font-size:clamp(20px,5vw,40px); line-height:1; font-variant-numeric:tabular-nums; }
 .vt-stat i { display:block; font-style:normal; font-size:clamp(8px,1.6vw,11px); letter-spacing:0.26em; opacity:0.5; margin-top:5px; }
 
-/* ---- settings ---- */
-.vt-tools { position:absolute; right:calc(${SA_R} + ${M}); bottom:calc(${SA_B} + clamp(34px,6vw,58px));
+/* ---- settings ----
+   Stacked on the voltage readout rather than measured from the bottom edge, so
+   the gap between the two cannot be closed by a change to either. */
+.vt-tools { position:absolute; right:var(--vt-tools-r,10px); bottom:var(--vt-tools-b,66px);
   display:flex; gap:6px; pointer-events:auto; }
-.vt-tool { width:clamp(30px,6vw,40px); height:clamp(30px,6vw,40px); border:2px solid rgba(255,255,255,0.28);
+.vt-tool { width:var(--vt-tool-s,30px); height:var(--vt-tool-s,30px); border:2px solid rgba(255,255,255,0.28);
   background:rgba(2,5,14,0.55); color:inherit; font:inherit; font-size:clamp(11px,2.2vw,14px);
   cursor:pointer; display:flex; align-items:center; justify-content:center; padding:0; }
 .vt-tool[aria-pressed="true"] { background:currentColor; }
 .vt-tool[aria-pressed="true"] span { color:#04060f; }
 .vt-tool:focus-visible { outline:3px solid #fff; outline-offset:2px; }
-.vt-perf { position:absolute; left:calc(${SA_L} + ${M}); bottom:calc(${SA_B} + clamp(58px,10vw,96px));
+.vt-perf { position:absolute; left:var(--vt-perf-l,10px); bottom:var(--vt-perf-b,110px);
   font-size:11px; letter-spacing:0.1em; opacity:0.6; white-space:pre; display:none;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-weight:400; text-transform:none; }
 .vt-perf.vt-on { display:block; }
@@ -269,7 +291,7 @@ const RING_C = 2 * Math.PI * RING_R;
 
 export function buildHud(host: HTMLElement): HudRefs {
   const style = document.createElement("style");
-  style.textContent = CSS;
+  style.textContent = HUD_CSS;
   host.appendChild(style);
 
   const root = document.createElement("div");
@@ -372,6 +394,23 @@ export function buildHud(host: HTMLElement): HudRefs {
     motionBtn: q('[data-a="motion"]'),
     perf: q(".vt-perf"),
   };
+}
+
+/**
+ * Put the HUD where the host's measured insets say it goes.
+ *
+ * Called on mount, on every resize and on every inset change — rotation swaps
+ * top and bottom with left and right, and iPadOS moves them again when the pack
+ * is resized in Split View, so a HUD laid out once at mount is correct until the
+ * first rotation and wrong after it.
+ *
+ * There is no path by which the stylesheet can place these boxes itself: it
+ * declares `left: var(--vt-tl-x)` and friends, and `chrome.ts` owns every one of
+ * those values.
+ */
+export function layoutHud(refs: HudRefs, w: number, h: number, insets: Insets): void {
+  const vars = hudVars(w, h, insets);
+  for (const [name, value] of Object.entries(vars)) refs.root.style.setProperty(name, value);
 }
 
 export const ringCircumference = RING_C;

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -17,7 +17,7 @@ import { InputController } from "./input.ts";
 import { Rng } from "./rng.ts";
 import { biomeAt, biomeLength } from "./biomes.ts";
 import { detectTier, TierController, type TierName } from "./tiers.ts";
-import { buildHud, groupDigits, ringCircumference } from "./hud.ts";
+import { buildHud, groupDigits, layoutHud, ringCircumference } from "./hud.ts";
 import { makeStage, ndcFrame } from "./chrome.ts";
 import type { Frame } from "./readband.ts";
 import {
@@ -32,8 +32,9 @@ import {
   GAIN_GATE, GAIN_SPARK, GAIN_GRAZE, VOLT_BLEED, CHAIN_PER_SURGE, SURGE_MAX,
   STUMBLE_TIME, CLEAN_READ_SHARE, REVIVE_GRACE, RESOLVE_HOLD,
   speedAt, readWindow, breather, beatTime, difficultyFor,
-  gateDistance, hazardLandsOnRead,
+  gateDistance, hazardLandsOnRead, preReadLead,
 } from "./pacing.ts";
+import { comprehensionTarget } from "./comprehension.ts";
 
 type Phase = "idle" | "running" | "dying" | "revive" | "over";
 
@@ -290,7 +291,13 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     }
     vw = Math.max(1, Math.round(r.width));
     vh = Math.max(1, Math.round(r.height));
-    frameNdc = ndcFrame(vw, vh, safeInsets());
+    const insets = safeInsets();
+    frameNdc = ndcFrame(vw, vh, insets);
+    // The DOM HUD is laid out from the same measured insets as the read band, on
+    // the same call. It used to lay itself out from `env(safe-area-inset-*)` in
+    // its own stylesheet, which is ZERO inside a pack — so the two disagreed by
+    // the whole inset on every device that has one.
+    layoutHud(hud, vw, vh, insets);
     const dpr = Math.min(window.devicePixelRatio || 1, tiers.settings.dprCap) * tiers.renderScale;
     renderer.setPixelRatio(1);
     const bw = Math.max(2, Math.round(vw * dpr));
@@ -526,6 +533,20 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     pendingQuestion = q;
     promptShown = true;
     setPrompt(q.prompt);
+    // ...and then lengthen the road, not the clock. The item says how long it
+    // takes (`comprehensionTarget`, which cannot see the world); the gate itself
+    // can only ever deliver ~3.2s of that, because it cannot spawn beyond the far
+    // plane; the rest is bought as runway in front of it. Nothing about the speed
+    // changes — a five-digit sum simply has a lot more road before its gate.
+    //
+    // Written onto `gateCooldown` rather than kept beside it so there is exactly
+    // one number that decides when the next gate is requested, and so
+    // `hazardLandsOnRead` — which is handed `gateCooldown` — sees the real
+    // corridor rather than the one `breather` would have predicted.
+    gateCooldown = Math.max(
+      gateCooldown,
+      preReadLead(comprehensionTarget(q)),
+    );
   }
 
   function requestGate(): void {

--- a/dynawalla/games/runner/src/game/pacing.test.ts
+++ b/dynawalla/games/runner/src/game/pacing.test.ts
@@ -3,14 +3,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   speedAt, readWindow, breather, beatTime, difficultyFor,
-  gateDistance, deliveredWindow, comprehensionWindow, hazardLandsOnRead,
+  gateDistance, deliveredWindow, comprehensionWindow, comprehensionFor,
+  preReadLead, hazardLandsOnRead,
   READ_WINDOW_FLOOR, DELIVERED_WINDOW_FLOOR, DODGE_CORRIDOR_FLOOR,
-  COMPREHENSION_FLOOR, RESOLVE_HOLD,
+  COMPREHENSION_FLOOR, RESOLVE_HOLD, RUNWAY_MAX,
   V_SURGE_BOOST_MAX, GATES_PER_STEP,
   V_START, V_TERMINAL, V_REDUCED_CAP,
   COST_WRONG_GATE, COST_HAZARD, GAIN_GATE, VOLT_BLEED, VOLT_MAX,
 } from "./pacing.ts";
 import { Rng } from "./rng.ts";
+import { comprehensionTarget, MAX_TARGET } from "./comprehension.ts";
 
 /* ------------------------- the spawn loop, headless ------------------------ */
 
@@ -41,8 +43,19 @@ type Sim = {
   minComprehension: number;
 };
 
-function replay(opts: { until: number; from?: number; far: number; guard?: boolean }): Sim {
-  const { until, from = 0, far, guard = true } = opts;
+function replay(opts: {
+  until: number;
+  from?: number;
+  far: number;
+  guard?: boolean;
+  /**
+   * Seconds the ITEM asks for, as `comprehensionTarget` would answer. 0 models a
+   * host serving nothing but content the geometry already covers, which is what
+   * this harness measured before the runway existed.
+   */
+  target?: number;
+}): Sim {
+  const { until, from = 0, far, guard = true, target = 0 } = opts;
   const rng = new Rng(1234);
   const dt = 1 / 60;
   const spawnZ = far * 0.88;
@@ -90,8 +103,13 @@ function replay(opts: { until: number; from?: number; far: number; guard?: boole
     }
     if (!gate) {
       gateCooldown -= dt;
-      // `preRead()`: the next sum goes on the HUD partway through the corridor.
-      if (promptAt === null && gateCooldown <= breather(travel) - RESOLVE_HOLD) promptAt = elapsed;
+      // `preRead()`: the next sum goes on the HUD partway through the corridor,
+      // and then lengthens the corridor to whatever the item asks for. Both halves,
+      // in the order and with the arithmetic `mount.ts` uses.
+      if (promptAt === null && gateCooldown <= breather(travel) - RESOLVE_HOLD) {
+        promptAt = elapsed;
+        gateCooldown = Math.max(gateCooldown, preReadLead(target));
+      }
       if (gateCooldown <= 0) {
         const dist = gateDistance(speed, readWindow(travel, false), far);
         gate = { z: -dist };
@@ -322,6 +340,166 @@ test("and the pre-read is wired into the corridor, not just available", () => {
   // the question was not pre-read.
   const req = src.slice(src.indexOf("function requestGate("), src.indexOf("function resolveGate("));
   assert.ok(req.includes("if (!announced) setPrompt("), "a pre-read sum must not be announced twice");
+});
+
+/* ---------------------- the window a question asks for --------------------- */
+
+/** Everything the motion can be, which is what may not be allowed to matter. */
+const MOTION: Array<[string, number, number, number, boolean]> = [];
+for (const far of FARS) {
+  for (const travel of [0, 600, 2600, 20000, 1e6]) {
+    for (let speed = V_START; speed <= V_TERMINAL * V_SURGE_BOOST_MAX + 0.01; speed += 2.5) {
+      for (const reduced of [false, true]) {
+        MOTION.push([`far=${far} travel=${travel} speed=${speed.toFixed(1)} rm=${String(reduced)}`, travel, speed, far, reduced]);
+      }
+    }
+  }
+}
+
+/** Every target the cadence table can produce, in order. */
+const TARGETS = [2.8, 4.2, 6.0, 7.0, 10.0, 11.0, 14.0, 16.0, 20.0];
+
+test("a harder question is never given less time than an easier one", () => {
+  // `docs/PACING_AUDIT_2026-07.md`: "window(d) must be MONOTONE NON-DECREASING in
+  // item difficulty." VOLTA was inverted — 8.00s for `5 − 2` on the opening gate
+  // and 4.02s for a five-digit sum at terminal velocity on the smallest tier,
+  // because the window was derived from the speed and the speed was the escalation
+  // knob. Asserted at EVERY state of the world, not at a representative one.
+  for (const [ctx, travel, speed, far, reduced] of MOTION) {
+    let prev = -Infinity;
+    for (const target of TARGETS) {
+      const w = comprehensionFor(target, travel, speed, far, reduced);
+      assert.ok(
+        w >= prev - 1e-9,
+        `${ctx}: a ${target}s question gets ${w.toFixed(2)}s, less than the ${prev.toFixed(2)}s an easier one got`,
+      );
+      prev = w;
+    }
+  }
+});
+
+test("the window is never shorter than the item asked for, in any state of the world", () => {
+  // The other half, and the one that makes the invariant a floor rather than an
+  // ordering: no combination of speed, distance travelled, draw distance or reduced
+  // motion can take a question below its own target. Motion is on the left of a
+  // `max` in `comprehensionFor` and nowhere else, so it can only ever add.
+  for (const [ctx, travel, speed, far, reduced] of MOTION) {
+    for (const target of TARGETS) {
+      const w = comprehensionFor(target, travel, speed, far, reduced);
+      assert.ok(w >= target - 1e-9, `${ctx}: a ${target}s question got ${w.toFixed(2)}s`);
+    }
+  }
+});
+
+test("the speed is untouched — the runway is what grows", () => {
+  // The founder offered slowing down and then offered the better mechanism:
+  // "the vehicle could still be racing but ... we maybe need some miles". So the
+  // extra time has to arrive as distance, and the speed curve may not appear in
+  // any of it. `preReadLead` takes one argument and it is the item's target, so
+  // this is enforced by the signature; what is asserted here is that the seconds
+  // it asks for are real road at the speed the world is actually moving.
+  for (const target of TARGETS) {
+    const lead = preReadLead(target);
+    if (target <= DELIVERED_WINDOW_FLOOR) continue;
+    assert.ok(lead > 0, `a ${target}s question bought no road at all`);
+    for (const [ctx, , speed] of MOTION) {
+      assert.ok(lead * speed > 0, `${ctx}: a ${target}s question bought no road`);
+    }
+  }
+  assert.ok(
+    preReadLead(16) * V_TERMINAL > 700,
+    `16s at terminal velocity is only ${(preReadLead(16) * V_TERMINAL).toFixed(0)} units of road`,
+  );
+  // ...and the speed curve itself is untouched: the two ends of the run are the
+  // same numbers they were before the runway existed.
+  assert.equal(speedAt(0, false), V_START);
+  assert.ok(Math.abs(speedAt(1e6, false) - V_TERMINAL) < 1e-6);
+});
+
+test("the runway ceiling is a guard, not a limiter", () => {
+  // If `RUNWAY_MAX` ever binds, some item is being served less time than the table
+  // says it needs and the clamp is hiding it. Raising the table without thinking
+  // about the runway fails here.
+  for (const target of [...TARGETS, MAX_TARGET]) {
+    assert.ok(
+      preReadLead(target) < RUNWAY_MAX - 1e-9,
+      `a ${target}s question hit the ${RUNWAY_MAX}s ceiling: ${preReadLead(target).toFixed(2)}s of lead`,
+    );
+  }
+  assert.ok(MAX_TARGET <= 20, `the table now tops out at ${MAX_TARGET}s; re-derive RUNWAY_MAX`);
+});
+
+test("the runway is road, not dead air: hazards keep arriving across it", () => {
+  // A long corridor must not become a pause. Hazard beats are on their own cadence
+  // — `beatTime` knows nothing about the gate cycle — so the longest runway the
+  // table can ask for still has a dozen beats in it.
+  for (const travel of [0, 2600, 20000]) {
+    const lead = preReadLead(MAX_TARGET);
+    const beats = lead / beatTime(travel);
+    assert.ok(beats >= 8, `the longest runway at travel=${travel} holds only ${beats.toFixed(1)} hazard beats`);
+  }
+});
+
+test("measured through the scheduler: the inversion the founder saw is gone", () => {
+  // The replay, not the formula. `5 − 2` on the opening gate against the hardest
+  // thing the table describes deep into a run on the smallest quality tier — the
+  // exact two ends of his sentence.
+  const easy = replay({ until: 40, far: 520, target: comprehensionTarget({ prompt: "5 − 2", answer: "3" }) });
+  const hard = replay({ until: 300, from: 90, far: 300, target: comprehensionTarget({ prompt: "5001 − 2798", answer: "2203" }) });
+  assert.ok(easy.gates > 3 && hard.gates > 3, "nothing was measured");
+  assert.ok(
+    hard.minComprehension > easy.minComprehension,
+    `the hard question gets ${hard.minComprehension.toFixed(2)}s and the easy one ${easy.minComprehension.toFixed(2)}s`,
+  );
+  assert.ok(
+    hard.minComprehension >= 16 - 1e-9,
+    `a four-digit borrow across zero gets ${hard.minComprehension.toFixed(2)}s against the table's 16s`,
+  );
+  // And the gate's own hazard-free window is untouched by any of it.
+  assert.ok(hard.minDelivered >= DELIVERED_WINDOW_FLOOR - 1e-9, `the gate's window fell to ${hard.minDelivered.toFixed(2)}s`);
+});
+
+test("measured through the scheduler: every rung of the table is delivered", () => {
+  let prev = -Infinity;
+  for (const target of TARGETS) {
+    const sim = replay({ until: 400, from: 90, far: 300, target });
+    assert.ok(sim.gates > 3, `${target}s: only ${sim.gates} gates`);
+    assert.ok(sim.minComprehension >= target - 1e-9, `${target}s: a real run gave ${sim.minComprehension.toFixed(2)}s`);
+    assert.ok(sim.minComprehension >= prev - 1e-9, `${target}s went backwards from ${prev.toFixed(2)}s`);
+    assert.ok(sim.minDelivered >= DELIVERED_WINDOW_FLOOR - 1e-9, `${target}s: the gate's own window fell to ${sim.minDelivered.toFixed(2)}s`);
+    prev = sim.minComprehension;
+  }
+});
+
+test("and the runway is wired into the corridor, not just available", () => {
+  // Same reason as the pre-read test above: the replay is a model, so it would
+  // pass with `mount.ts` never applying the lead.
+  const src = readFileSync(new URL("./mount.ts", import.meta.url), "utf8");
+  const pre = src.slice(src.indexOf("function preRead("), src.indexOf("function requestGate("));
+  assert.ok(pre.length > 80, "preRead has moved; this test needs re-aiming");
+  assert.ok(pre.includes("comprehensionTarget(q)"), "the runway must be sized from the ITEM");
+  assert.ok(pre.includes("preReadLead("), "the corridor must be lengthened for a hard question");
+  assert.ok(pre.includes("gateCooldown = Math.max("), "the lead must reach the one number that schedules the gate");
+  // And nothing in the scheduling may reach for the speed to size it.
+  assert.ok(
+    !/preReadLead\([^)]*speedAt/.test(src),
+    "the runway is being sized from the speed curve, which is the defect it exists to remove",
+  );
+});
+
+test("a hazard is still kept out of a read across the longer corridor", () => {
+  // #665's guard is handed the LIVE cooldown, so a runway-lengthened corridor is
+  // exact for the cycle a hazard is actually flying through. Asserted rather than
+  // assumed, at the longest runway the table can produce.
+  for (const far of FARS) {
+    const sim = replay({ until: 400, from: 90, far, target: MAX_TARGET });
+    assert.ok(sim.gates > 3, `far=${far}: nothing was measured`);
+    assert.equal(
+      sim.arrivalsWhileReading,
+      0,
+      `far=${far}: ${sim.arrivalsWhileReading} of ${sim.arrivals} hazards landed while a gate was up`,
+    );
+  }
 });
 
 test("the pre-read is still short of the cadence table, and that is written down", () => {

--- a/dynawalla/games/runner/src/game/pacing.ts
+++ b/dynawalla/games/runner/src/game/pacing.ts
@@ -191,7 +191,89 @@ export function deliveredWindow(travel: number, speed: number, far: number, redu
  */
 export const COMPREHENSION_FLOOR = 4.7;
 export function comprehensionWindow(travel: number, speed: number, far: number, reduced: boolean): number {
-  return Math.max(0, breather(travel) - RESOLVE_HOLD) + deliveredWindow(travel, speed, far, reduced);
+  return comprehensionFor(0, travel, speed, far, reduced);
+}
+
+/* ------------------------------- the runway ---------------------------------- */
+
+/**
+ * Ceiling on the pre-read lead, in seconds.
+ *
+ * A guard rather than a limiter: the widest content the cadence table describes
+ * asks for 20s and the gate is separately held to delivering at least
+ * `DELIVERED_WINDOW_FLOOR` of it, so the lead never exceeds 16.9s and this number
+ * never binds. It is here so that a future
+ * table, or a host that starts serving long division, cannot silently turn VOLTA
+ * into a road with no gates on it — and `pacing.test.ts` asserts that it does not
+ * bind today, so raising the table without thinking about the runway fails.
+ */
+export const RUNWAY_MAX = 18;
+
+/**
+ * Seconds of road, ahead of the gate, that the prompt is already on the HUD for.
+ *
+ * **Runway, not deceleration.** The founder offered both and then chose:
+ *
+ *   > "the vehicle could still be racing but ... we maybe need some miles to
+ *   > figure out the answer"
+ *
+ * Slowing down as the arithmetic hardens is the obvious fix and it is the wrong
+ * one: the velocity is what VOLTA *is*, and trading it for thinking time swaps
+ * one complaint for another. So nothing about the motion changes. The dodge
+ * corridor in front of a hard question simply gets longer, the prompt sits on the
+ * HUD across the whole of it, and hazards and sparks keep arriving through it at
+ * their own cadence — the runner is still a runner, there is just more road
+ * before the next gate.
+ *
+ * **Why the lead is the only lever.** A gate cannot spawn beyond the far plane,
+ * so the time between one becoming visible and reaching the answer plane is
+ * capped at ~3.2s (`deliveredWindow`) however the pacing is tuned. The pre-read
+ * is not bounded by the draw distance, because the prompt is on the HUD before
+ * the gate is in view at all.
+ *
+ * **Sized against the FLOOR of the gate's own window, not the live one.** The
+ * obvious arithmetic is `target - deliveredWindow(now)`, and it is wrong twice
+ * over. The world accelerates across the runway, so the gate that eventually
+ * spawns gets a shorter window than the one predicted when the prompt went up —
+ * measured through the scheduler, a 16s question came out at 15.85s. And, worse,
+ * it would put a motion constant inside the one number that exists to be free of
+ * them. `DELIVERED_WINDOW_FLOOR` is a floor the geometry is separately held to, so
+ * subtracting it makes this a pure function of the item, and errs by handing a
+ * child *more* time early in a run, when the gate's own window is at its longest.
+ *
+ * @param target seconds the ITEM asks for — `comprehensionTarget`. The only
+ *               argument, and that is the point: there is nothing else in scope
+ *               for a lead to be derived from.
+ */
+export function preReadLead(target: number): number {
+  return clampN(target - DELIVERED_WINDOW_FLOOR, 0, RUNWAY_MAX);
+}
+
+/**
+ * The whole time a child has with a question of a given target: the runway the
+ * prompt is up for, plus the gate's own window.
+ *
+ * Monotone non-decreasing in `target` by construction — `max` and `clamp` both
+ * are — and never below `target` for any state of the world, which is the fleet
+ * invariant `docs/PACING_AUDIT_2026-07.md` sets out. Motion constants can only
+ * ever *add* to this number; they are on the left of a `max` and nowhere else.
+ *
+ * Still **not** a hazard-free window, and must not turn into one: pylons live in
+ * the corridor, which is what #665 built it for. The window in which nothing can
+ * hit a child is `deliveredWindow`.
+ */
+export function comprehensionFor(
+  target: number,
+  travel: number,
+  speed: number,
+  far: number,
+  reduced: boolean,
+): number {
+  const corridor = Math.max(
+    Math.max(0, breather(travel) - RESOLVE_HOLD),
+    preReadLead(target),
+  );
+  return corridor + deliveredWindow(travel, speed, far, reduced);
 }
 
 /* ------------------------- the reading corridor ------------------------ */
@@ -242,6 +324,17 @@ export type FlightState = {
  * lands, and answers with what the child will be doing when it gets there.
  *
  * ~500 iterations of arithmetic, once per hazard beat. It is not a frame cost.
+ *
+ * **One honest limit, since the runway landed.** The corridor in front of a hard
+ * question is now `preReadLead` long rather than `breather(travel)` long. The
+ * *live* corridor is exact here — the caller passes the real `cooldown` — but the
+ * projection cannot know how hard the *next* item will be, so every cycle after
+ * this one is modelled at `breather(travel)`, the shortest a corridor can be. A
+ * hazard is airborne for one to three cycles, so the error is real and it is in
+ * the safe direction: modelling gates as arriving sooner than they will means
+ * this occasionally reports a read that turns out to be open road, and a beat is
+ * spent on a decorative arch instead of a pylon. It never reports open road that
+ * turns out to be a read.
  */
 export function hazardLandsOnRead(s: FlightState): boolean {
   const step = 1 / 30;

--- a/dynawalla/games/runner/src/game/readband.test.ts
+++ b/dynawalla/games/runner/src/game/readband.test.ts
@@ -1,8 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  BAND, FULL_FRAME, readBand, payoffHeight, keepInside,
-  PAYOFF_EDGE, PAYOFF_MAX_H, POPUP_EDGE,
+  BAND, fullFrame, readBand, payoffHeight, keepInside,
+  PAYOFF_EDGE, PAYOFF_MAX_H, POPUP_EDGE, type GateGeom,
 } from "./readband.ts";
 import { INK, TRACK } from "./glyphs.ts";
 
@@ -15,19 +15,39 @@ import { INK, TRACK } from "./glyphs.ts";
  * return, on any device, for any answer the curriculum can produce.
  *
  * Nothing here needs a GPU: `readBand` is pure arithmetic over the projection's
- * two scale factors, so the whole device matrix is a loop.
+ * two scale factors, so the whole device matrix is a loop. The row's *relationship
+ * to its gate* is asserted separately, in `gatelayout.test.ts`, against the real
+ * `Projector` and the real camera pose — that one is about whether the answers sit
+ * with the windows, and it cannot be checked without a projection.
  */
 
 /* The camera, mirrored from mount.ts so the numbers are the real ones. */
 const FOV_MIN = 58;
 const FOV_MAX = 104;
 const CAM_Z = 11.4;
+/** Height of a gate arch in world units, from `drawGates`. */
+const ARCH = 4.9;
+/** Lane spacing in world units, from `world.ts`. */
+const LANE_W = 3.35;
 
 /** NDC-per-world-unit at a gate `dist` metres ahead, for a viewport and FOV. */
 function scales(w: number, h: number, fovDeg: number, dist: number): { kx: number; ky: number } {
   const aspect = w / h;
   const ky = 1 / Math.tan((fovDeg * Math.PI) / 360) / (dist + CAM_Z);
   return { kx: ky / aspect, ky };
+}
+
+/**
+ * A gate at that depth, with its arch top wherever the sweep puts it.
+ *
+ * `archTop` is swept rather than derived because it depends on the camera's
+ * pitch, its height, the causeway bend and the player's own vertical position —
+ * all of which move during a run. The values swept below bracket everything the
+ * game can produce, including a gate whose arch is above the top of the screen.
+ */
+function geomFor(kx: number, ky: number, archTop: number, centre = 0): GateGeom {
+  const archH = Math.abs(ky) * ARCH;
+  return { centre, lanePitch: Math.abs(kx) * LANE_W, archTop, archH, deck: archTop - archH };
 }
 
 /**
@@ -48,7 +68,7 @@ function unit(digits: number, advance: number): number {
 
 const VIEWPORTS: Array<[number, number, string]> = [
   [320, 568, "320 phone portrait"],
-  [360, 640, "360 phone portrait"],
+  [360, 780, "360 phone portrait"],
   [390, 844, "390 phone portrait"],
   [844, 390, "phone landscape"],
   [768, 1024, "tablet portrait"],
@@ -60,10 +80,12 @@ const VIEWPORTS: Array<[number, number, string]> = [
 const ADVANCES = [0.36, 0.43, 0.5];
 const DIGIT_COUNTS = [1, 2, 3, 4];
 const DISTANCES = [4, 12, 30, 60, 100, 160, 240];
-const APPROACHES = [0, 0.25, 0.5, 0.75, 1];
+/** How far off screen-centre the chase camera can put the gate. */
+const CENTRES = [-0.9, -0.3, 0, 0.45];
 
 function forEachCase(fn: (b: ReturnType<typeof readBand>, ctx: string, w: number, h: number) => void): void {
   for (const [vw, vh, label] of VIEWPORTS) {
+    const frame = fullFrame(vh);
     for (const fov of [FOV_MIN, 74, FOV_MAX]) {
       for (const dist of DISTANCES) {
         const { kx, ky } = scales(vw, vh, fov, dist);
@@ -71,10 +93,10 @@ function forEachCase(fn: (b: ReturnType<typeof readBand>, ctx: string, w: number
           for (const n of DIGIT_COUNTS) {
             // Worst case for collision is every candidate at the widest size.
             const u = unit(n, adv);
-            for (const a of APPROACHES) {
-              for (const archTop of [-0.4, 0, 0.2, 0.6, 1.4]) {
-                const band = readBand([u, u, u], kx, ky, a, archTop, FULL_FRAME);
-                fn(band, `${label} fov${fov} d${dist} adv${adv} n${n} a${a} arch${archTop}`, vw, vh);
+            for (const archTop of [-0.4, 0, 0.2, 0.6, 1.4]) {
+              for (const centre of CENTRES) {
+                const band = readBand([u, u, u], kx, ky, geomFor(kx, ky, archTop, centre), frame);
+                fn(band, `${label} fov${fov} d${dist} adv${adv} n${n} arch${archTop} cx${centre}`, vw, vh);
               }
             }
           }
@@ -96,10 +118,26 @@ test("adjacent candidates never touch", () => {
 
 test("no candidate is clipped by the viewport", () => {
   forEachCase((band, ctx) => {
-    const outer = Math.abs(band.x[2]) + band.wNdc / 2;
-    assert.ok(outer <= BAND.edge + 1e-9, `${ctx}: right candidate reaches ${outer.toFixed(3)} NDC`);
+    // Both ends, because the row now follows the gate across the screen and the
+    // gate can be off to either side. Checking only x[2] was sound when the row
+    // was symmetric about the centre of the glass and is not any more.
+    const left = band.x[0] - band.wNdc / 2;
+    const right = band.x[2] + band.wNdc / 2;
+    assert.ok(left >= -BAND.edge - 1e-9, `${ctx}: left candidate reaches ${left.toFixed(3)} NDC`);
+    assert.ok(right <= BAND.edge + 1e-9, `${ctx}: right candidate reaches ${right.toFixed(3)} NDC`);
     assert.ok(band.y - band.hNdc / 2 > -1, `${ctx}: row sinks off the bottom`);
     assert.ok(band.y + band.hNdc / 2 < 1, `${ctx}: row rises off the top`);
+  });
+});
+
+test("the row keeps its pitch even where the frame has to pull it in", () => {
+  // The row is one object. Clamping the outer candidates individually would give
+  // three unequal gaps, which is exactly what the gutter rule exists to stop, so
+  // the whole row shifts instead.
+  forEachCase((band, ctx) => {
+    const leftGap = band.x[1] - band.x[0];
+    const rightGap = band.x[2] - band.x[1];
+    assert.ok(Math.abs(leftGap - rightGap) < 1e-9, `${ctx}: pitch is ${leftGap.toFixed(3)} / ${rightGap.toFixed(3)}`);
   });
 });
 
@@ -111,10 +149,12 @@ test("the row never collides with the prompt", () => {
 
 test("numerals stay big enough to read on the smallest supported screen", () => {
   // The floor is the smallest phone we claim to support, the widest font, and
-  // the most digits an answer realistically has.
+  // the most digits an answer realistically has, on a gate far enough away that
+  // its arch cannot carry a readable numeral — so this is `frame.minH` and the
+  // width ceiling doing their jobs, with nothing from the gate.
   const { kx, ky } = scales(320, 568, 74, 90);
   const u = unit(3, 0.5);
-  const band = readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME);
+  const band = readBand([u, u, u], kx, ky, geomFor(kx, ky, 0.1), fullFrame(568));
   const capPx = (band.hNdc / 2) * 568;
   assert.ok(capPx >= 24, `three digits at 320px render at ${capPx.toFixed(1)}px cap height`);
 });
@@ -122,39 +162,151 @@ test("numerals stay big enough to read on the smallest supported screen", () => 
 test("two digits on a 390px phone are unmistakable", () => {
   const { kx, ky } = scales(390, 844, 74, 90);
   const u = unit(2, 0.43);
-  const band = readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME);
+  const band = readBand([u, u, u], kx, ky, geomFor(kx, ky, 0.1), fullFrame(844));
   const capPx = (band.hNdc / 2) * 844;
   const gapPx = ((band.pitch - band.wNdc) / 2) * 390;
   assert.ok(capPx >= 44, `two digits at 390px render at ${capPx.toFixed(1)}px cap height`);
   assert.ok(gapPx >= 24, `only ${gapPx.toFixed(1)}px of clear air between candidates at 390px`);
 });
 
-test("apparent size does not depend on how far away the gate is", () => {
-  // The old layout scaled with distance, so a numeral was eleven pixels tall
-  // when it mattered and a wall of ink when it no longer did.
-  const u = unit(2, 0.43);
-  const sizes = DISTANCES.map((d) => {
-    const { kx, ky } = scales(1280, 800, 74, d);
-    return readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME).hNdc;
-  });
-  for (const s of sizes) assert.ok(Math.abs(s - sizes[0]) < 1e-6, `sizes drift with distance: ${sizes.join(", ")}`);
+test("apparent size never falls below the legibility floor, however far the gate is", () => {
+  // This replaces "apparent size does not depend on how far away the gate is".
+  //
+  // That property was the defect. A numeral that is exactly the same size at 240
+  // units and at 4 units is not an object in the world, it is a HUD element drawn
+  // in one — which is what the founder was looking at when he said the answers
+  // should sit with the windows. Size now tracks the arch, so it grows on the
+  // approach; what has to be true is that it never goes UNDER what a child can
+  // read, and that is a floor, not a constant.
+  for (const [vw, vh, label] of VIEWPORTS) {
+    const frame = fullFrame(vh);
+    for (const fov of [FOV_MIN, 74, FOV_MAX]) {
+      for (const adv of ADVANCES) {
+        for (const n of DIGIT_COUNTS) {
+          const u = unit(n, adv);
+          // The width ceiling is allowed to bind below the floor — a four-digit
+          // answer on a 320px phone cannot be 46px tall and fit — so the floor
+          // asserted here is the floor OR the widest the frame allows, whichever
+          // is smaller, and the two are named separately so a failure says which.
+          const wCeil = (BAND.fill * frame.edge) / (1 + BAND.fill / 2);
+          const { kx, ky } = scales(vw, vh, fov, 240);
+          const widthBound = (wCeil / (u * Math.abs(kx))) * Math.abs(ky);
+          const want = Math.min(frame.minH, widthBound);
+          for (const dist of DISTANCES) {
+            const s = scales(vw, vh, fov, dist);
+            const band = readBand([u, u, u], s.kx, s.ky, geomFor(s.kx, s.ky, 0.1), frame);
+            assert.ok(
+              band.hNdc >= want - 1e-9,
+              `${label} fov${fov} adv${adv} n${n} d${dist}: ${((band.hNdc / 2) * vh).toFixed(1)}px cap height, floor is ${((want / 2) * vh).toFixed(1)}px`,
+            );
+          }
+        }
+      }
+    }
+  }
+});
+
+test("a candidate grows as its own gate grows", () => {
+  // The thing the constant-size row could not do. Same viewport, same answer,
+  // one gate closing: the numeral has to get bigger, because the window it is
+  // standing in is getting bigger.
+  const u = unit(1, 0.43);
+  const frame = fullFrame(780);
+  let prev = -Infinity;
+  for (const dist of [240, 160, 100, 60, 30, 12, 4]) {
+    const { kx, ky } = scales(360, 780, 74, dist);
+    const band = readBand([u, u, u], kx, ky, geomFor(kx, ky, 0.1), frame);
+    assert.ok(band.hNdc >= prev - 1e-9, `the numeral shrank on approach at d=${dist}`);
+    prev = band.hNdc;
+  }
+  const f = scales(360, 780, 74, 240);
+  const n = scales(360, 780, 74, 4);
+  const far = readBand([u, u, u], f.kx, f.ky, geomFor(f.kx, f.ky, 0.1), frame);
+  const near = readBand([u, u, u], n.kx, n.ky, geomFor(n.kx, n.ky, 0.1), frame);
+  assert.ok(
+    near.hNdc > far.hNdc * 1.5,
+    `a single digit went from ${far.hNdc.toFixed(3)} to ${near.hNdc.toFixed(3)} NDC — that is not perspective`,
+  );
 });
 
 test("a mixed-width gate sizes every candidate to the widest", () => {
   const { kx, ky } = scales(1280, 800, 74, 60);
   const wide = unit(3, 0.43);
   const narrow = unit(1, 0.43);
-  const mixed = readBand([narrow, wide, narrow], kx, ky, 0.3, 0.1, FULL_FRAME);
-  const allWide = readBand([wide, wide, wide], kx, ky, 0.3, 0.1, FULL_FRAME);
+  const geom = geomFor(kx, ky, 0.1);
+  const mixed = readBand([narrow, wide, narrow], kx, ky, geom, fullFrame(800));
+  const allWide = readBand([wide, wide, wide], kx, ky, geom, fullFrame(800));
   assert.equal(mixed.hNdc, allWide.hNdc);
 });
 
-test("the row opens outward as the gate arrives", () => {
-  const u = unit(2, 0.43);
-  const { kx, ky } = scales(1280, 800, 74, 60);
-  const far = readBand([u, u, u], kx, ky, 0, 0.1, FULL_FRAME);
-  const near = readBand([u, u, u], kx, ky, 1, 0.1, FULL_FRAME);
-  assert.ok(near.pitch > far.pitch, "candidates should spread as the gate closes");
+test("the row opens outward as the gate arrives, and never closes back up", () => {
+  // It used to open on a clock — `lerp(pitchFar, pitchNear, approach)` — which is
+  // why it opened identically whatever the gate was doing. It now opens because the
+  // lanes it sits on are getting further apart on screen, so the property to hold
+  // is monotonicity in distance, at every viewport and every answer width.
+  for (const [vw, vh, label] of VIEWPORTS) {
+    const frame = fullFrame(vh);
+    for (const n of DIGIT_COUNTS) {
+      const u = unit(n, 0.43);
+      let prev = -Infinity;
+      for (const dist of [240, 160, 100, 60, 30, 20, 12, 6, 4]) {
+        const s = scales(vw, vh, 74, dist);
+        const band = readBand([u, u, u], s.kx, s.ky, geomFor(s.kx, s.ky, 0.1), frame);
+        assert.ok(
+          band.pitch >= prev - 1e-9,
+          `${label} n${n}: the row closed up at d=${String(dist)}: ${band.pitch.toFixed(3)} was ${prev.toFixed(3)}`,
+        );
+        prev = band.pitch;
+      }
+    }
+  }
+  // And on the surface the founder is holding, with the content the pack opens on,
+  // it does actually spread rather than merely not-shrink.
+  const u = unit(1, 0.43);
+  const frame = fullFrame(780);
+  const far = scales(360, 780, 78, 200);
+  const near = scales(360, 780, 78, 4);
+  const a = readBand([u, u, u], far.kx, far.ky, geomFor(far.kx, far.ky, 0.1), frame);
+  const b = readBand([u, u, u], near.kx, near.ky, geomFor(near.kx, near.ky, 0.1), frame);
+  assert.ok(b.pitch > a.pitch * 1.3, `the row went from ${a.pitch.toFixed(3)} to ${b.pitch.toFixed(3)} NDC`);
+});
+
+test("the row settles into the window once the window can hold it", () => {
+  // `onGate` is what the renderer fades the leader dots out with, so it has to
+  // reach 1 while the gate is still being read, not on the frame it is crossed.
+  const u = unit(1, 0.43);
+  const frame = fullFrame(780);
+  const s = scales(360, 780, 74, 20);
+  const geom = geomFor(s.kx, s.ky, 0.08);
+  const band = readBand([u, u, u], s.kx, s.ky, geom, frame);
+  assert.equal(band.onGate, 1, `at twenty units out the row is only ${(band.onGate * 100).toFixed(0)}% in its window`);
+  const top = band.y + band.hNdc / 2;
+  const bottom = band.y - band.hNdc / 2;
+  assert.ok(bottom > geom.deck, "the row is below the deck");
+  assert.ok(top < geom.archTop + 1e-9, "the row is above the lintel, not in the window");
+});
+
+test("the row is centred on its gate, not on the glass", () => {
+  // The chase camera follows the player at 0.6x, so the gate cluster slides
+  // across the screen as the child steers. A row that ignores that is a row
+  // whose outer numeral can end up on the wrong side of its own arch — measured
+  // at 44px on the wrong side, four units out, on a 360px phone.
+  const u = unit(1, 0.43);
+  const frame = fullFrame(780);
+  const s = scales(360, 780, 74, 30);
+  for (const centre of [-0.3, -0.1, 0, 0.1, 0.3]) {
+    const band = readBand([u, u, u], s.kx, s.ky, geomFor(s.kx, s.ky, 0.08, centre), frame);
+    assert.ok(
+      Math.abs(band.x[1] - centre) < 1e-9,
+      `the middle candidate is at ${band.x[1].toFixed(3)} for a gate centred at ${centre.toFixed(3)}`,
+    );
+  }
+  // Past the point where following the gate would push the outer numeral off the
+  // glass, the row stops following — but it stops on the correct side and it never
+  // snaps back to the middle, which is what pinning it to the screen did.
+  const far = readBand([u, u, u], s.kx, s.ky, geomFor(s.kx, s.ky, 0.08, -0.95), frame);
+  assert.ok(far.x[1] < -0.3, `the row gave up on a gate at -0.95 and sat at ${far.x[1].toFixed(3)}`);
+  assert.ok(far.x[0] - far.wNdc / 2 >= -BAND.edge - 1e-9, "and it went off the left edge doing it");
 });
 
 /* -------------------------------------------------------------------------- */

--- a/dynawalla/games/runner/src/game/readband.ts
+++ b/dynawalla/games/runner/src/game/readband.ts
@@ -15,29 +15,74 @@
  * Everything is NDC: x and y run -1..+1 across the viewport, so "0.5" means a
  * quarter of the screen's width regardless of device, orientation or DPR. The
  * caller converts back to world space with `Projector`.
+ *
+ * ── the row belongs to the gate ─────────────────────────────────────────────
+ *
+ * It did not. The founder's screenshot, and then the arithmetic: on a 360x780
+ * phone the outer candidate was drawn at x = 305px for the *entire* approach,
+ * while the arch it names travelled from 198px to 286px; it was 98px tall from
+ * the moment it appeared to the moment it was crossed, while the arch grew from
+ * 27px to 158px; and it sat 27px clear above the lintel throughout. Worse, the
+ * chase camera follows the player at 0.6x, so steering slid the whole gate
+ * cluster sideways under a row that was pinned to the middle of the glass — at
+ * four units out, with the child in the left lane, the outer numeral was 44px
+ * to the *wrong side* of its own arch.
+ *
+ * Three numbers, none of which was a function of the gate. "Which lane says
+ * what" was a guess supported by left-to-right order and a line of dots.
+ *
+ * So the row is now derived from the gate's own projected geometry — its centre,
+ * its lane pitch, the height of its arch — and falls back on the legibility
+ * floors only where the geometry cannot honour them. Far out, the arch is 16px
+ * wide and no readable numeral fits in it, so the row is a legible board held
+ * above the gate; as the gate closes the pitch, the size and the height all
+ * converge and each numeral settles into its own window and travels with it.
+ * Choosing a lane and choosing an answer become the same act, which is the whole
+ * design of the game.
+ *
+ * The floors are not negotiable and are asserted here: a numeral that sits
+ * prettily on an arch at eleven pixels is the bug this file was written to kill,
+ * and it killed it once already.
  */
 
 const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
-const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 
 export const BAND = {
-  /** NDC x between adjacent candidates while the gate is still distant. */
-  pitchFar: 0.58,
-  /** ...and by the time it arrives. The row opens out as it comes at you. */
-  pitchNear: 0.72,
   /**
    * The share of the pitch a numeral's ink may occupy. The remaining 30% is
    * gutter, and it is the whole reason this file exists. Do not raise it.
    */
   fill: 0.7,
+  /**
+   * ...and a floor on that gutter in absolute NDC, because `fill` alone is a
+   * *ratio*: it keeps a wide numeral apart and lets three small ones close to
+   * within a couple of pixels of each other. Since the row now shrinks with its
+   * gate, small is the common case.
+   */
+  gutter: 0.14,
   /** Ceiling on apparent size, in NDC y. A single digit would otherwise fill the screen. */
   maxH: 0.3,
+  /**
+   * Cap height, in CSS pixels, below which a numeral stops being an answer.
+   *
+   * The floor the row falls back on when its gate is too far away to carry a
+   * readable numeral. 46px is a shade over the 44px the two named legibility
+   * tests demand, so the margin is visible in the constant rather than implied
+   * by one. It is in *pixels*, not NDC, because legibility is: 0.1 NDC is 39px
+   * on a 780-tall phone and 108px on a desktop.
+   */
+  minCapPx: 46,
+  /**
+   * Share of its window's height a numeral standing in one may fill.
+   *
+   * 0.62 leaves a visible margin of arch above and below the ink, which is what
+   * makes it read as framed by the gate rather than jammed into it.
+   */
+  archShare: 0.62,
   /** Hard page margin on a device with no insets: no ink past |x| = this. */
   edge: 0.94,
   /** The row never rises past here — above it lives the prompt. */
   top: 0.56,
-  /** ...nor sinks below here, which is roughly the horizon. */
-  bottom: 0.06,
   /** Clear air between the numeral row and the top of its own gate arch. */
   lift: 0.07,
 } as const;
@@ -62,12 +107,62 @@ export type Frame = {
   edge: number;
   /** The row's top edge never rises above this NDC y. */
   top: number;
-  /** The row's bottom edge never sinks below this NDC y. */
+  /**
+   * The row's bottom edge never sinks below this NDC y.
+   *
+   * This is the HUD's own bottom furniture — the voltage bar, plus whatever the
+   * system has taken off the bottom edge — and nothing else. It used to be a
+   * flat 0.06, "roughly the horizon", which is the wrong shape of limit: the
+   * horizon is a property of the *gate's depth*, not of the screen, and a flat
+   * screen-space floor is exactly what stopped the row descending into its own
+   * window at mid range. The deck now bounds the row from `GateGeom.deck`,
+   * measured at the gate.
+   */
   bottom: number;
+  /**
+   * Floor on the row's ink height, in NDC, for this surface.
+   *
+   * `BAND.minCapPx` resolved against the viewport height. Carried on the frame
+   * rather than computed here because this file never learns how tall the
+   * surface is — everything else it does is scale-free.
+   */
+  minH: number;
 };
 
-/** The frame on a surface with no insets at all: the old constants, exactly. */
-export const FULL_FRAME: Frame = { edge: BAND.edge, top: BAND.top, bottom: BAND.bottom };
+/** The frame on a surface of height `vh` with no insets at all. */
+export function fullFrame(vh: number): Frame {
+  return {
+    edge: BAND.edge,
+    top: BAND.top,
+    bottom: -1,
+    minH: (2 * BAND.minCapPx) / Math.max(1, vh),
+  };
+}
+
+/**
+ * The gate the row belongs to, in NDC, at the depth it currently sits at.
+ *
+ * Every field is a projection of something the child can see, and that is the
+ * point: the row is laid out *from the gate* and only clamped by the frame.
+ */
+export type GateGeom = {
+  /**
+   * NDC x of the gate's middle lane.
+   *
+   * Not zero. The chase camera follows the player at 0.6x, so the gate cluster
+   * slides across the glass as the child steers, and a row centred on the
+   * screen leaves its arches behind.
+   */
+  centre: number;
+  /** NDC x between adjacent lane centres, magnitude. */
+  lanePitch: number;
+  /** NDC y of the top of the arch — the underside of the lintel. */
+  archTop: number;
+  /** NDC height of the arch, deck to lintel. */
+  archH: number;
+  /** NDC y of the deck at the gate's depth. The row never sinks below it. */
+  deck: number;
+};
 
 export type Band = {
   /** Ink height, in NDC y. Multiply by `1/|ky|` for world units. */
@@ -80,61 +175,97 @@ export type Band = {
   pitch: number;
   /** NDC width of the widest candidate at `hNdc`. */
   wNdc: number;
+  /**
+   * How much of the row is standing in its window: 0 held above the lintel, 1
+   * framed by the arch.
+   *
+   * The renderer fades the leader dots out with it — a leader from a numeral to
+   * the arch it is already sitting in is a line of dots to nowhere.
+   */
+  onGate: number;
 };
 
 /**
- * @param units    world width of each candidate at ink height 1, left to right
- * @param kx       NDC x per world unit at the gate's depth (magnitude)
- * @param ky       NDC y per world unit at the gate's depth (magnitude)
- * @param approach 0 when the gate spawns, 1 when it reaches the answer plane
- * @param archTop  NDC y of the top of the gate's arch
- * @param frame    the NDC rectangle the row may occupy — see `Frame`
+ * @param units world width of each candidate at ink height 1, left to right
+ * @param kx    NDC x per world unit at the gate's depth (magnitude)
+ * @param ky    NDC y per world unit at the gate's depth (magnitude)
+ * @param geom  the gate, in NDC — see `GateGeom`
+ * @param frame the NDC rectangle the row may occupy — see `Frame`
  */
 export function readBand(
   units: readonly [number, number, number],
   kx: number,
   ky: number,
-  approach: number,
-  archTop: number,
+  geom: GateGeom,
   frame: Frame,
 ): Band {
   const ax = Math.max(1e-6, Math.abs(kx));
   const ay = Math.max(1e-6, Math.abs(ky));
-  const t = clamp01(approach);
 
   // One size for all three. Three different sizes on one row reads as three
   // different kinds of thing, and the eye stops comparing them.
   const widest = Math.max(units[0], units[1], units[2], 1e-6);
+  /** NDC width the widest candidate occupies per NDC of ink height. */
+  const wPerH = Math.max(1e-6, (widest * ax) / ay);
+
+  // The size the GATE asks for, floored at what a child can read. Far out the
+  // floor wins and the row is bigger than the arch; from about twenty units the
+  // arch wins and the row is a thing standing in a window.
+  //
+  // Bounded by the window in BOTH dimensions, which is not fussiness. Sizing off
+  // the arch's height alone, a numeral on a tablet outgrew the arch's *width* on
+  // the approach — the gutter rule then pushed the row wider than the lanes to
+  // keep the ink apart, so the answers came unstuck again in the last twenty
+  // units, on the larger screen only. `fill` rather than the window's full width
+  // so that a numeral sized this way needs exactly the lane pitch and no more.
+  const wantH = Math.min(
+    geom.archH * BAND.archShare,
+    (BAND.fill * geom.lanePitch) / Math.max(1e-6, wPerH),
+  );
+  let hNdc = Math.min(BAND.maxH, Math.max(frame.minH, wantH));
+  let wNdc = hNdc * wPerH;
 
   // The widest a numeral can ever be: the point where the gutter rule
-  // (w <= fill * pitch) and the page margin (pitch + w/2 <= edge) meet.
+  // (w <= fill * pitch) and the page margin (pitch + w/2 <= edge) meet. A
+  // three-digit answer on a 320px phone is held here, not by the floor above,
+  // and that has always been the binding constraint for wide answers.
   const wCeil = (BAND.fill * frame.edge) / (1 + BAND.fill / 2);
-  // The width at which the apparent-size cap bites. On a narrow phone this is
-  // enormous, which is exactly why the pitch has to be free to open up: a
-  // three-digit answer on a 320px screen needs most of the width or it lands at
-  // twenty pixels, and twenty pixels is the bug we are here to kill.
-  const wWanted = (BAND.maxH * widest * ax) / ay;
+  if (wNdc > wCeil) wNdc = wCeil;
 
-  let wNdc = Math.min(wCeil, wWanted);
-  // The row spreads as the gate closes, but never tighter than the gutter needs.
-  let pitch = Math.max(lerp(BAND.pitchFar, BAND.pitchNear, t), wNdc / BAND.fill);
+  // The row sits on the lanes, and opens wider than them only when it must.
+  let pitch = Math.max(geom.lanePitch, wNdc / BAND.fill, wNdc + BAND.gutter);
   const pitchCeil = frame.edge - wNdc / 2;
   if (pitch > pitchCeil) pitch = pitchCeil;
-  wNdc = Math.min(wNdc, BAND.fill * pitch);
+  wNdc = Math.min(wNdc, BAND.fill * pitch, Math.max(0, pitch - BAND.gutter));
 
-  const hNdc = (wNdc / (widest * ax)) * ay;
-
+  hNdc = wNdc / wPerH;
   const half = hNdc / 2;
-  // Sit just clear of the arch, but never behind the prompt and never under the
-  // deck. When the two limits collide the top wins: off the bottom is invisible,
-  // slightly tight against the prompt is merely close.
-  const lo = frame.bottom + half;
+
+  // Centred on the gate, and pulled back inside the page margin as a whole
+  // rather than per numeral: the row is one object and a row whose left half is
+  // clamped and right half is not is a row with an uneven pitch, which is the
+  // one thing the gutter rule exists to prevent.
+  const room = Math.max(0, frame.edge - (pitch + wNdc / 2));
+  const centre = geom.centre < -room ? -room : geom.centre > room ? room : geom.centre;
+
+  // Descend into the window as the window grows big enough to hold the row.
+  // Continuous by construction: `onGate` is a ratio of two heights, so there is
+  // no frame on which the numerals jump.
+  const onGate = clamp01(geom.archH / Math.max(1e-6, hNdc));
+  const above = geom.archTop + half + BAND.lift;
+  const inside = geom.archTop - geom.archH / 2;
+  let y = above + (inside - above) * onGate;
+
+  // Never below the deck at the gate's own depth — under it a numeral lies on
+  // the causeway instead of standing in a window — nor into the HUD's bottom
+  // furniture, nor behind the prompt. When two limits collide the top wins: off
+  // the bottom is invisible, slightly tight against the prompt is merely close.
+  const lo = Math.max(frame.bottom, geom.deck) + half;
   const hi = frame.top - half;
-  let y = archTop + half + BAND.lift;
   if (y < lo) y = lo;
   if (y > hi) y = hi;
 
-  return { hNdc, x: [-pitch, 0, pitch], y, pitch, wNdc };
+  return { hNdc, x: [centre - pitch, centre, centre + pitch], y, pitch, wNdc, onGate };
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
fix(dynawalla/games/runner): the answers sit with the windows, and a harder sum gets more road

Four notes from the founder on an Android phone at 0.3.3, and the fourth is the
one that matters.

── the answers had come unstuck from the gates ─────────────────────────────────

> "the answers would be better if they sat with the windows like they used to"

He was right, and it was not a matter of taste. Measured on his viewport
(360x780 CSS at 78°) against the shipped `readBand`, the outer candidate:

    d=80  numeral x=305px  its arch x=198px  dx=107px  cap 98px  arch  27px tall
    d=30  numeral x=305px  its arch x=219px  dx= 86px  cap 98px  arch  59px tall
    d= 4  numeral x=305px  its arch x=286px  dx= 19px  cap 98px  arch 158px tall

The numeral was drawn at x = 305 for the *entire* approach while the arch it
names travelled from 198px to 286px; it was 98px tall from the moment it appeared
to the moment it was crossed, while the arch grew from 27px to 158px; and it
floated a flat 27px above the lintel throughout. With the child in the left lane —
the chase camera follows the player at 0.6x — `d=4` becomes `numeral 305, arch
350, dx=-44px`: the outer answer on the *wrong side* of its own arch.

Three numbers, none of them a function of the gate. That is a HUD element drawn
in the world, and it is not a regression from #697: #697 added the pre-read and
touched neither `readband.ts` nor `entities.ts`. The layout has been screen-space
since #557, which fixed the *opposite* defect — numerals placed at the lanes ran
together as `134236` — and overshot into a row that belonged to nobody.

`readBand` now takes the gate: its projected centre, its lane pitch, the height
of its arch, and the deck at its depth. Size tracks the window in both
dimensions, floored at a 46px cap height; pitch tracks the lane pitch, floored at
the 30% gutter and an absolute one; the row descends into the window as the window
grows tall enough to hold it, and the leader dots fade out as it arrives. Same
measurement after: dx 52px → 28px → 3px → 0px, cap height 46px → 80px, and the
numeral inside its window from about forty units in.

Where the answer is too wide for the window the row converges as far as legibility
allows and no further: three readable three-digit numerals need 315 of a phone's
360 pixels while the whole gate cluster is 208px wide at the answer plane. That
limit is in `gatelayout.test.ts` with its numbers, not smoothed over.

`gatelayout.test.ts` is new and builds the *real* `THREE.PerspectiveCamera`, poses
it exactly as `render()` does and runs the real `Projector`, because the camera is
pitched and lane-following and a hand-rolled pinhole model would answer the
question about a camera the game does not have.

── three host-chrome collisions, all one root cause ────────────────────────────

The score clipped under the exit chevron, SURGE ×2 under the `?`, the VOLTAGE bar
under Android's navigation bar.

`hud.ts` laid itself out from `env(safe-area-inset-*)`, which is **zero inside a
pack**: the frame is sandboxed `allow-scripts` with no `allow-same-origin`, and
the safe-area environment variables belong to the top-level browsing context. The
host measures the real values and posts them, and `chrome.ts` had arithmetic that
*described* what the stylesheet was believed to resolve to — so the tests were
handed a 24px top inset and the CSS on the device was handed 0. Measured at
360x780 with a 24px status bar: the score box painted at y = 63 against a chevron
occupying 37..81, an **18px x 44px overlap**; the surge meter the same under the
help control; the voltage bar at 755..768 of 780, entirely inside Android's 24px
gesture strip, **12px of overlap on a 13px-tall bar**. After: score at y = 87, 6px
clear; bar at 731..744, 12px clear. Same at 393x851 (DPR 2.75) — the fix is
inset-driven, so the DPR assumption does not load-bear.

The fix is not a better test. The stylesheet no longer computes any position:
every in-run HUD box comes from `hudBoxes` and is written on as a custom property,
and `chrome.test.ts` fails the build if `env(safe-area-inset` appears in the sheet
or if any positional declaration on those five selectors is not a `var()`.
`GESTURE_STRIP = 24` is lifted from `games/pulse`, which met the zero-bottom-inset
case first, and every readable and tappable box is asserted clear of it and inside
the safe rect at seven viewports **including a zero bottom inset**.

── a harder question was getting less time ─────────────────────────────────────

> "the problem progression is maybe OK but we maybe need some miles to figure out
> the answer instead of you have 5 seconds to do 2x1 and then 2 seconds to do
> 84302+4186"

The fleet's root pacing defect, in VOLTA. Measured through the real scheduler:
8.00s with the question on the opening gate where the content is `5 − 2`, and
4.78s at terminal velocity on the smallest quality tier where it is four- and
five-digit column arithmetic. `docs/PACING_AUDIT_2026-07.md` names it across
seventeen games: the comprehension window was derived from a motion constant, and
the motion constant was also the escalation knob.

His mechanism, not the obvious one. `comprehension.ts` reads the *item* — operand
width, whether a column carries or borrows, which operation — and returns the
seconds `docs/EXPERIENCE_DESIGN.md` instruments: 2.8s for a single-digit fact, 6s
for a two-digit regroup, 16s for the `5,001 − 2,798` class. It imports nothing at
all, so no speed, travel, draw distance or tier is in scope, and its test asserts
that by reading its own source. `preReadLead` then buys those seconds as
**runway** — one argument, the item's target — so the corridor in front of a hard
gate gets longer and the speed curve is untouched. At terminal velocity a 16s
question is about 900 units of road.

    item                            target   BEFORE   AFTER
    5 − 2, opening gate               2.8s    8.00s   8.00s
    36 + 47, mid run                  6.0s    5.92s   6.91s
    941 − 152, late                  10.0s    4.80s  10.10s
    84302 + 4186, late               14.0s    4.78s  14.08s
    5001 − 2798, late                16.0s    4.78s  16.08s

Monotone non-decreasing in item difficulty at every state of the world, and never
below the item's own target for any of them — both asserted over the whole motion
sweep, and every rung measured through the scheduler rather than from the formula.
The runway is not dead air: hazard beats are on their own cadence, and the longest
runway the table can ask for still holds a dozen of them. `RUNWAY_MAX` is a guard
that is asserted never to bind.

Two honest edges. The floor is generous, so an easy question early still gets
8.00s — more than a two-digit regroup gets mid-run; the invariant is an ordering
at a given state of the world, and nothing ever gets less than its own target.
And #665's hazard guard knows the live corridor exactly but cannot know how hard
the next item will be, so it models later cycles at the shortest corridor a run
can have — wrong in the safe direction, and written down where it happens. The
guard is re-measured at the longest runway and still admits zero hazards into a
read, on every tier.

── motion control: not built, and why ─────────────────────────────────────────

`DeviceOrientationEvent` is gated by the Permissions-Policy features `gyroscope`,
`accelerometer` and `magnetometer`, whose default allowlist is `self`. The pack
frame is mounted `sandbox="allow-scripts"` (opaque origin) with `allow=""`, so the
events cannot arrive twice over, and on iOS `requestPermission()` grants per
origin and an opaque origin cannot hold a grant. Nothing in the fleet uses either
API. An opt-in toggle that silently did nothing would be worse than none, so there
is no toggle — the README says what a host change would have to be, and recommends
the shape this repository already uses for exactly this problem: the host measures
it and posts it, like the safe-area insets.

── proof ──────────────────────────────────────────────────────────────────────

Each fix deleted in turn:

    ✖ the stylesheet never reaches for env(safe-area-inset-*)
      AssertionError: hud.ts reads env(safe-area-inset-*), which is 0 inside a pack
    ✖ nothing at the bottom is inside the strip the system swipes in
      AssertionError: the voltage box ends at y=768.0 of 780 — 12.0px inside the
      24px the system swipes in
    ✖ an answer narrow enough to fit its window is inside it while the child steers
      AssertionError: n=1 d=20 playerX=0.0: candidate 0 is 78px from the centre of
      a window 45px wide
    ✖ steering moves the answers with the gate instead of leaving them behind
      AssertionError: d=40: the gate moved -12px and the row moved 0px
    ✖ a candidate is framed by its arch, not floating above it
      AssertionError: d=30: the row is only 59% into its window
    ✖ a candidate grows as its own gate grows
      AssertionError: a single digit went from 0.257 to 0.257 NDC — that is not
      perspective
    ✖ measured through the scheduler: the inversion the founder saw is gone
      AssertionError: the hard question gets 4.82s and the easy one 5.93s
    ✖ the window is never shorter than the item asked for, in any state of the world
      AssertionError: far=300 travel=0 speed=27.0 rm=false: a 10s question got 8.00s
    ✖ and the runway is wired into the corridor, not just available
      AssertionError: the runway must be sized from the ITEM
    ✖ no motion constant can reach this function
      AssertionError: comprehension.ts imports something: import { speedAt } from
      "./pacing.ts"

The gesture-strip test asserts against its own `ANDROID_HANDLE_PX = 24` rather
than against `GESTURE_STRIP`, because a test whose floor is the constant it is
checking passes when somebody sets that constant to zero — the first version did.

121 tests, five consecutive runs, `npm run tsc`, both builds, and `dw-pack check`
through `packs/build.mjs`. **No device.** What is proven is the arithmetic and the
projection; what needs hardware is how a 12-second runway *feels*, whether the
prompt holding still for that long reads as the game having stopped, and the three
chrome clearances on the founder's actual phone.

Claude-Session: https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb


https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
