### PR TITLE
fix(dynawalla/games/trebuchet): the child does the wind arithmetic, and the loft lever goes

### DIFF
--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -105,7 +105,15 @@ function installDom(): { el: HTMLElement; canvas: Record<string, unknown> } {
 
 type Reported = { questionId: string; correct: boolean; ms: number; answered: string }
 
-function recordingHost(answers: number[]): { host: Host; reports: Reported[] } {
+/**
+ * A host that serves the answers it is given, on the rung it is told to.
+ *
+ * The rung matters now: `windCapFor` reads the item's own difficulty to decide
+ * whether the wind blows, so a test that wants the beginner's game asks for an easy
+ * rung and a test that wants the wind asks for a harder one. Nothing here is a wave
+ * number.
+ */
+function recordingHost(answers: number[], difficulty = 0.4): { host: Host; reports: Reported[] } {
   const reports: Reported[] = []
   let n = 0
   const host: Host = {
@@ -118,7 +126,7 @@ function recordingHost(answers: number[]): { host: Host; reports: Reported[] } {
         answer: String(a),
         distractors: [String(a + 11), String(a - 13)],
         domain: 'add-sub',
-        difficulty: 0.4,
+        difficulty,
       }
     },
     report: (r) => reports.push(r),
@@ -132,7 +140,7 @@ function recordingHost(answers: number[]): { host: Host; reports: Reported[] } {
 
 /** Tap a HUD button through the canvas's own pointerdown listener. */
 function tap(canvas: Record<string, unknown>, id: string): void {
-  const layout = hudLayout(VIEW.w, VIEW.h, { x: 0, y: 0, w: VIEW.w, h: VIEW.h }, true)
+  const layout = hudLayout(VIEW.w, VIEW.h, { x: 0, y: 0, w: VIEW.w, h: VIEW.h })
   const btn = layout.buttons.find((b) => b.id === id)
   assert.ok(btn, `no ${id} button in the HUD`)
   const listeners = canvas.__listeners as Listeners
@@ -151,12 +159,16 @@ function runUntil(game: TrebuchetGame, done: () => boolean, maxFrames = 1200): b
   return false
 }
 
-function newGame(answers: number[], wave: number): ReturnType<typeof installDom> & {
+function newGame(
+  answers: number[],
+  wave: number,
+  difficulty = 0.4,
+): ReturnType<typeof installDom> & {
   game: TrebuchetGame
   reports: Reported[]
 } {
   const dom = installDom()
-  const { host, reports } = recordingHost(answers)
+  const { host, reports } = recordingHost(answers, difficulty)
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   game.manualDrive()
   game.jumpToWave(wave)
@@ -166,6 +178,14 @@ function newGame(answers: number[], wave: number): ReturnType<typeof installDom>
   // and every assertion below it read -1 and passed anyway.
   assert.notEqual(game.currentAnswer(), -1, 'the wave became playable with an empty rack')
   return { ...dom, game, reports }
+}
+
+/**
+ * The dial a child who has done BOTH steps sets: the answer, less the wind she can
+ * see on the chip. With no wind it is just the answer, which is the beginner's game.
+ */
+function correctDial(game: TrebuchetGame): number {
+  return game.currentAnswer() - game.currentWind()
 }
 
 /**
@@ -341,7 +361,7 @@ test('the fire button is never lit over an empty rack', () => {
       assert.notEqual(game.currentAnswer(), -1, `frame ${i}: the button is lit with no boulder`)
     }
     if (game.currentPhase === 'aim' && game.currentAnswer() > 0) {
-      game.aimAt(game.currentAnswer())
+      game.aimAt(correctDial(game))
       tap(dom.canvas, 'fire')
     }
   }
@@ -547,7 +567,7 @@ test('a bullseye stays a bullseye when the dial is nudged mid-flight', () => {
   const answer = game.currentAnswer()
   assert.ok(game.towerRanges().includes(answer), 'the answer must have a keep')
 
-  game.aimAt(answer)
+  game.aimAt(correctDial(game))
   game.fireNow()
   assert.ok(runUntil(game, () => game.currentPhase === 'flight'), 'the shot never left')
 
@@ -565,16 +585,16 @@ test('a wrong dial stays wrong when it is corrected mid-flight', () => {
   // The mirror: turning the dial onto the answer after the boulder has gone must
   // not buy the answer, and must not blow up a keep the shot never went near.
   const { game, reports } = newGame([42, 60, 78, 96], 8)
-  const answer = game.currentAnswer()
   const standing = game.towerRanges()
   // A metre with no keep on it and none within blast range.
   const wrong = standing.reduce((a, b) => Math.max(a, b), 0) + 4
+  const wind = game.currentWind()
 
-  game.aimAt(wrong)
+  game.aimAt(wrong - wind)
   game.fireNow()
   assert.ok(runUntil(game, () => game.currentPhase === 'flight'), 'the shot never left')
 
-  game.aimAt(answer)
+  game.aimAt(correctDial(game))
 
   assert.ok(runUntil(game, () => reports.length > 0), 'nothing was ever reported')
   const r = reports[0]
@@ -593,7 +613,7 @@ test('the reported latency is thinking time, not boulder flight time', () => {
   try {
     const { game, reports } = newGame([42, 60, 78, 96], 4)
     clock += 4000 // she thinks for four seconds
-    game.aimAt(game.currentAnswer())
+    game.aimAt(correctDial(game))
     game.fireNow()
     assert.ok(
       runUntil(game, () => {
@@ -624,7 +644,7 @@ test('the whole rack can be answered without a false verdict', () => {
     const a = game.currentAnswer()
     if (a < 0 || !game.towerRanges().includes(a)) break
     dialled.push(a)
-    game.aimAt(a)
+    game.aimAt(correctDial(game))
     game.fireNow()
     const want = reports.length + 1
     if (!runUntil(game, () => reports.length >= want)) break
@@ -637,4 +657,256 @@ test('the whole rack can be answered without a false verdict', () => {
     assert.equal(reports[i].correct, true, `shot ${i + 1} on ${dialled[i]} was scored wrong`)
     assert.equal(reports[i].answered, String(dialled[i]), `shot ${i + 1} reported the wrong number`)
   }
+})
+
+/* ------------------------------------------------------- the wind, at the mount */
+
+test('the beginner never meets a wind, and dialling the answer is enough', () => {
+  // The founder is not complaining about the low end and it must not move. A rung
+  // of two-digit tables and no-regroup column sums — d=0.28, which is where the
+  // game's own search opens — has no wind on it at all, on any wave, however long
+  // the child plays. And the whole promise still holds: work the sum, wind the dial
+  // to that number, the keep comes down.
+  const { game, canvas, reports } = newGame([42, 60, 78, 96], 3, 0.28)
+  for (const wave of [1, 3, 6, 9, 14, 20]) {
+    game.jumpToWave(wave)
+    assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${wave} never stocked`)
+    assert.equal(game.currentWindCap(), 0, `wave ${wave} put a wind on a beginner's rung`)
+    assert.equal(game.currentWind(), 0, `wave ${wave} is blowing`)
+  }
+  const answer = game.currentAnswer()
+  game.aimAt(answer)
+  tap(canvas, 'fire')
+  assert.ok(runUntil(game, () => reports.length > 0), 'nothing was ever reported')
+  assert.equal(reports[0].answered, String(answer))
+  assert.equal(reports[0].correct, true, 'the beginner dialled her answer and was marked wrong')
+})
+
+test('on a harder rung the wind decides the shot: ignoring it misses, taking it off lands', () => {
+  // The founder's actual question — "are we supposed to shoot it longer, shorter,
+  // ignore it?" — answered through the real fire button rather than in `sim/`.
+  //
+  // Both children fire at the same keep. The one who dials her answer and ignores
+  // the wind is wrong, and is recorded as having answered the metre the boulder
+  // reached. The one who takes the wind off her answer first is right. That is the
+  // whole of "the wind does something".
+  const ignoring = newGame([42, 60, 78, 96], 6, 0.55)
+  const cap = ignoring.game.currentWindCap()
+  assert.ok(cap >= 3, `a rung at d=0.55 must have a wind; cap is ${cap}`)
+  const wind = ignoring.game.currentWind()
+  assert.notEqual(wind, 0, 'a wind of zero is not a wind')
+  const answer = ignoring.game.currentAnswer()
+
+  ignoring.game.aimAt(answer)
+  tap(ignoring.canvas, 'fire')
+  assert.ok(runUntil(ignoring.game, () => ignoring.reports.length > 0), 'nothing was reported')
+  assert.equal(ignoring.reports[0].correct, false, 'ignoring the wind still lands the shot')
+  assert.equal(
+    ignoring.reports[0].answered,
+    String(answer + wind),
+    'she is recorded as having named the metre her boulder actually reached',
+  )
+  assert.ok(
+    ignoring.game.towerRanges().includes(answer),
+    'the keep she failed to allow for must still be standing',
+  )
+
+  const thinking = newGame([42, 60, 78, 96], 6, 0.55)
+  const answer2 = thinking.game.currentAnswer()
+  thinking.game.aimAt(correctDial(thinking.game))
+  tap(thinking.canvas, 'fire')
+  assert.ok(runUntil(thinking.game, () => thinking.reports.length > 0), 'nothing was reported')
+  assert.equal(thinking.reports[0].correct, true, 'the child who did the arithmetic was marked wrong')
+  assert.equal(thinking.reports[0].answered, String(answer2), 'her answer is the sum, not the dial')
+  assert.ok(!thinking.game.towerRanges().includes(answer2), 'the keep she named must come down')
+})
+
+test('the dial reaches every compensation the wind can ask for', () => {
+  // A correct answer she cannot physically enter is the same defect as a correct
+  // answer scored wrong. The dial's stops move with the wind (`dialRange`), so this
+  // drives the REAL `setDial` through `aimAt` and checks the number stuck.
+  const { game } = newGame([14, 40, 72, 100, 118], 6, 1)
+  assert.equal(game.currentWindCap(), 9, 'the top of the ladder must blow its hardest')
+  for (let shot = 0; shot < 40; shot++) {
+    if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim')) break
+    const answer = game.currentAnswer()
+    if (answer < 0) break
+    const want = correctDial(game)
+    game.aimAt(want)
+    assert.equal(
+      game.stats().dial,
+      want,
+      `wind ${game.currentWind()}, answer ${answer}: the dial would not go to ${want}`,
+    )
+    game.fireNow()
+    if (!runUntil(game, () => game.currentPhase === 'aim' || game.currentPhase === 'clear')) break
+  }
+})
+
+test('the wind does not move between the question appearing and the boulder landing', () => {
+  // The safety property the whole mechanic rests on. The original defect was a term
+  // added AFTER the child committed; if the wind can change while she is thinking,
+  // or between her pressing fire and the impact, then `dial + wind` is not a number
+  // she could have worked out and this is the same bug again.
+  //
+  // Sampled every frame from the moment the question is on the glass to the moment
+  // the host is told, rather than at two moments — the two moments are the easy part.
+  const { game, reports } = newGame([42, 60, 78, 96], 6, 0.55)
+  for (let shot = 0; shot < 6; shot++) {
+    if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim')) break
+    const answer = game.currentAnswer()
+    if (answer < 0) break
+    const shown = game.currentWind()
+    assert.notEqual(shown, 0, 'this test is pointless without a wind')
+    const seen = new Set<number>([shown])
+    // She reads it, thinks about it, winds the dial about. Nothing may move.
+    for (let i = 0; i < 40; i++) {
+      game.stepFrames(1)
+      game.aimAt(20 + i)
+      seen.add(game.currentWind())
+    }
+    game.aimAt(answer - shown)
+    const want = reports.length + 1
+    game.fireNow()
+    assert.ok(
+      runUntil(game, () => {
+        seen.add(game.currentWind())
+        return reports.length >= want
+      }),
+      'nothing was ever reported',
+    )
+    assert.deepEqual([...seen], [shown], `the wind moved under her: saw ${[...seen].join(', ')}`)
+    assert.equal(reports[want - 1].correct, true, 'a correct, compensated shot was scored wrong')
+    assert.equal(reports[want - 1].answered, String(answer))
+  }
+  assert.ok(reports.length >= 3, `only ${reports.length} shots resolved`)
+})
+
+test('the manual is raised the first time the wind blows, and only then', () => {
+  // A mechanic that arrives silently mid-run and changes what a right answer looks
+  // like is the original defect in a new costume. `index.ts` wires this to
+  // `guide.open()`; here it is a counter, so the rule "exactly once a run" is a test
+  // and not a comment.
+  const dom = installDom()
+  const { host } = recordingHost([42, 60, 78, 96], 0.55)
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  let raised = 0
+  game.setExplainer(() => {
+    raised++
+  })
+  game.manualDrive()
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the wave never became playable')
+  assert.ok(game.currentWindCap() > 0, 'this rung must have a wind on it')
+  assert.equal(raised, 1, `the wind arrived and the manual was raised ${raised} times`)
+
+  // Twelve more waves of it, and it is never explained again.
+  for (const wave of [2, 3, 4, 7, 9, 11, 13]) {
+    game.jumpToWave(wave)
+    assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${wave} never stocked`)
+  }
+  assert.equal(raised, 1, `the manual was raised ${raised} times across nine waves`)
+})
+
+test('the manual is never raised on a run that has no wind in it', () => {
+  // The mirror. A child on the beginner's rungs must not have a panel about wind
+  // thrown at her; there is no wind, so there is nothing to explain.
+  const dom = installDom()
+  const { host } = recordingHost([42, 60, 78, 96], 0.28)
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  let raised = 0
+  game.setExplainer(() => {
+    raised++
+  })
+  game.manualDrive()
+  for (const wave of [1, 4, 8, 12, 18]) {
+    game.jumpToWave(wave)
+    assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${wave} never stocked`)
+    assert.equal(game.currentWind(), 0)
+  }
+  assert.equal(raised, 0, 'a windless run explained the wind')
+})
+
+test('a whole windy rack can be answered without one false verdict', () => {
+  // Perfect play on a rung the wind is blowing on: every report correct, every
+  // report the answer to the SUM and not the number on the dial, and every keep she
+  // named on the ground.
+  const { game, reports } = newGame([42, 60, 78, 96, 30, 110], 6, 0.55)
+  assert.ok(game.currentWindCap() > 0, 'this rung must have a wind on it')
+  const named: number[] = []
+  const dials: number[] = []
+  for (let shot = 0; shot < 12; shot++) {
+    if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim')) break
+    const a = game.currentAnswer()
+    if (a < 0 || !game.towerRanges().includes(a)) break
+    named.push(a)
+    dials.push(correctDial(game))
+    game.aimAt(correctDial(game))
+    game.fireNow()
+    const want = reports.length + 1
+    if (!runUntil(game, () => reports.length >= want)) break
+    assert.ok(!game.towerRanges().includes(a), `the keep at ${a} was named and stayed standing`)
+  }
+  assert.ok(reports.length >= 6, `only ${reports.length} shots resolved`)
+  for (let i = 0; i < reports.length; i++) {
+    assert.equal(reports[i].correct, true, `shot ${i + 1} on ${named[i]} was scored wrong`)
+    assert.equal(reports[i].answered, String(named[i]), `shot ${i + 1} reported the wrong number`)
+  }
+  // ...and the dial genuinely was a different number from the answer, or this test
+  // would pass with the wind switched off.
+  assert.ok(
+    dials.some((d, i) => d !== named[i]),
+    'no shot in this run needed any compensation at all',
+  )
+})
+
+test('the loft lever is gone, and nothing took its place in the corner', () => {
+  // It changed nothing a child could be scored on and its two lowest notches were
+  // strictly worse than the default. A control that does nothing teaches a child
+  // that controls do nothing.
+  //
+  // Checked at the mount, on a wave the lever used to be on: the layout the game
+  // hands the renderer, and the buttons the hit test walks, are the same object, so
+  // this is about the control a child can actually press.
+  const { game, canvas } = newGame([42, 60, 78, 96], 9)
+  const layout = hudLayout(VIEW.w, VIEW.h, { x: 0, y: 0, w: VIEW.w, h: VIEW.h })
+  assert.equal(layout.buttons.some((b) => b.id === 'loft'), false, 'the lever is back')
+  assert.deepEqual(
+    layout.buttons.map((b) => b.id).sort(),
+    ['fire', 'minus', 'mute', 'plus'],
+    'the control set changed',
+  )
+  // Mute has the bottom-left corner to itself now, and pressing it must be pressing
+  // mute rather than a lever that used to sit on top of it.
+  const before = game.stats().dial
+  tap(canvas, 'mute')
+  assert.equal(game.stats().dial, before, 'the bottom-left corner moved the dial')
+})
+
+test('the wind arrives because the LADDER moved, not because waves went by', () => {
+  // Driven by `ladderHost`, which is the measured shape of the shipped ladder —
+  // quantised requests, non-monotonic answer magnitudes, a lagging pool. The game
+  // opens its search at 0.28, which serves two-digit tables and no-regroup column
+  // sums, and climbs a notch a wave.
+  //
+  // Two things have to be true at once, and a wave counter can only ever manage one
+  // of them: the opening waves are windless, AND the wind does eventually arrive.
+  const dom = installDom()
+  const { host } = ladderHost()
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'wave 1 never stocked')
+  const opened = game.stockedDifficulty()
+  assert.ok(opened !== null && opened < 0.34, `the search opened at ${opened}, above the threshold`)
+  assert.equal(game.currentWindCap(), 0, 'a child on her first wave was handed a wind')
+
+  const caps: number[] = [game.currentWindCap()]
+  for (let wave = 2; wave <= 14; wave++) {
+    game.jumpToWave(wave)
+    assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${wave} never stocked`)
+    caps.push(game.currentWindCap())
+  }
+  assert.deepEqual(caps.slice(0, 2), [0, 0], `the wind blew on waves 1-2: ${caps.join(',')}`)
+  assert.ok(caps.some((c) => c > 0), `the wind never arrived across 14 waves: ${caps.join(',')}`)
+  // And when it does arrive it is a real adjustment, not a nudge.
+  for (const c of caps) assert.ok(c === 0 || c >= 3, `a cap of ${c} is not arithmetic`)
 })

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -63,13 +63,12 @@ import {
   type Outcome,
   type Solved,
 } from './sim/ballistics.ts'
-import { aimShot, rollWind, verdictFor } from './sim/verdict.ts'
+import { rollWind, shotFor, verdictFor } from './sim/verdict.ts'
 import {
   buildTower,
-  DEFAULT_LOFT,
   FIELD_MAX,
   LAUNCH_X,
-  LOFTS,
+  LOFT_DEG,
   layoutTowerValues,
   pullQuestions,
   ramAdvances,
@@ -77,6 +76,12 @@ import {
   stepBlocks,
   wallFor,
   waveConfig,
+  windCapFor,
+  dialRange,
+  DIAL_MAX,
+  DIAL_MIN,
+  PLACEABLE_HI,
+  PLACEABLE_LO,
   worldX,
   type Boulder,
   type Crater,
@@ -88,38 +93,6 @@ import {
 } from './sim/world.ts'
 
 const MIN_GAP = 8
-const DIAL_MIN = 8
-const DIAL_MAX = FIELD_MAX
-
-/**
- * The window of answers this game can physically ask about.
- *
- * A keep stands at its own answer in METRES, on a field 122 metres long, and the
- * blast is wide enough that two keeps must be `MIN_GAP` apart to be distinct
- * targets. So the answer to every question TREBUCHET poses has to be an integer
- * in this window — that is not a tuning choice, it is what "the range dial is the
- * answer" costs.
- *
- * Nothing about the question stream guarantees it. The host hands out rungs off a
- * single cross-domain ladder addressed by a 0..1 difficulty, and a pack cannot
- * see what arithmetic sits on a rung before it asks. Measured against the shipped
- * 66-rung ladder, the difficulties this game used to ask for returned:
- *
- *     wave 1  d=0.040  dw.add.facts.subtract-within-ten   answers 0-4     0/12 placeable
- *     wave 2  d=0.112  dw.add.facts.subtract-within-ten   answers 1-9     0/12
- *     wave 3  d=0.184  dw.add.facts.subtract-across-ten   answers 2-9     0/12
- *     wave 5  d=0.328  dw.mul.facts.tables-to-twelve      answers 8-81    9/12
- *     wave 6  d=0.400  dw.add.column.subtract-no-regroup  answers to 5400 0/12
- *     wave 7  d=0.472  dw.mul.scale.times-power-of-ten    answers in the millions
- *
- * Waves 1-3 and 6 upward could not put a single keep on the field, so the rack
- * came back empty, the equation plaque had nothing to draw and the fire button
- * had no boulder to throw. That is the whole of the bug this window exists to
- * make impossible: the game now FINDS a rung it can place instead of assuming it
- * was handed one.
- */
-const PLACEABLE_LO = DIAL_MIN + 6
-const PLACEABLE_HI = DIAL_MAX - 4
 
 /**
  * One step of the search for a placeable rung, as a fraction of the ladder.
@@ -209,7 +182,19 @@ export class TrebuchetGame {
   private towers: Tower[] = []
   private rack: Boulder[] = []
   private activeIdx = 0
+  /**
+   * The wind for THIS shot: an exact number of metres, on the chip, and the second
+   * term in the child's arithmetic. Rolled when the question appears and never
+   * again — see `rollWindForShot`.
+   */
   private wind = 0
+  /**
+   * The strongest wind this wave can produce, from the difficulty of the questions
+   * in the rack. 0 for a beginner's wave, which is most of them.
+   */
+  private windCap = 0
+  /** Whether the wind has ever blown in this run, so it is explained exactly once. */
+  private windSeen = false
   private ram: Ram | null = null
   private wall: { x: number; h: number } | null = null
   private scrub = new Float32Array(0)
@@ -218,7 +203,6 @@ export class TrebuchetGame {
 
   // aim
   private dial = 30
-  private loftIdx = DEFAULT_LOFT
   private dialPop = 1
   private aimEmphasis = 0
 
@@ -266,7 +250,7 @@ export class TrebuchetGame {
    * wrong because she nudged the dial while the boulder was in the air. The shot
    * carries its own answer, and impact reads nothing else.
    */
-  private fired: { dial: number; boulder: Boulder; ms: number } | null = null
+  private fired: { dial: number; wind: number; boulder: Boulder; ms: number } | null = null
   private proj = { x: 0, y: 0 }
   private armDeg = ARMED_DEG
   private recoil = 0
@@ -296,8 +280,29 @@ export class TrebuchetGame {
    * difficulty. Both stop here.
    */
   private blocked: () => boolean = () => false
+  /**
+   * Put the rules in front of the child. Wired to the how-to-play panel by
+   * `index.ts`; a no-op in a harness that mounts the game without the chrome.
+   *
+   * There is exactly one caller: the first time the wind ever blows in a run. A
+   * mechanic that arrives silently mid-run and changes what a right answer looks
+   * like is the original defect wearing a different costume, and the manual is no
+   * use to a child who has no reason to open it.
+   */
+  private explain: () => void = () => undefined
+  /**
+   * The wind has started and has not been explained yet.
+   *
+   * Deferred to the next frame rather than raised where the wind is rolled, and the
+   * reason is the constructor: `new TrebuchetGame()` lays out wave 1 before
+   * `mount()` has had a chance to build the manual and call `setExplainer`, so a run
+   * that opens ON a windy rung would have called a no-op and lost the only
+   * explanation the child was ever going to get. Draining it in `update` puts the
+   * call after mount, whatever order the two happen in.
+   */
+  private explainPending = false
   /** The HUD's geometry, re-derived from the SAFE rect on every resize. */
-  private hud: HudLayout = hudLayout(320, 240, { x: 0, y: 0, w: 320, h: 240 }, false)
+  private hud: HudLayout = hudLayout(320, 240, { x: 0, y: 0, w: 320, h: 240 })
   private clearT = -1
   private introT = 0
   private muted = false
@@ -374,6 +379,11 @@ export class TrebuchetGame {
     this.blocked = blocked
   }
 
+  /** How the game raises the manual when a new rule starts applying. */
+  setExplainer(show: () => void): void {
+    this.explain = show
+  }
+
   /** The sheet is gone: the child is looking at the question again, now. */
   restartAnswerClock(): void {
     this.questionShownAt = performance.now()
@@ -406,7 +416,7 @@ export class TrebuchetGame {
     // The notch, the home indicator and the rounded corners are re-measured
     // here, not once at mount: a rotation swaps top/bottom for left/right, and
     // Split View changes them without the game ever unmounting.
-    this.hud = hudLayout(w, h, safeRect(w, h), this.cfg.loft)
+    this.hud = hudLayout(w, h, safeRect(w, h))
     this.unit = this.hud.unit
     this.backdrop.resize(w, h, this.dpr)
     this.btns = this.hud.buttons
@@ -451,10 +461,11 @@ export class TrebuchetGame {
     this.toldAboutStocking = false
     this.probes = 0
     this.probeDir = 0
-    // The loft lever appears mid-run and it moves mute, so the controls belong to
-    // the new wave from the first frame of it, stocked or not.
-    this.hud = hudLayout(this.w, this.h, this.hud.area, cfg.loft)
-    this.btns = this.hud.buttons
+    // No wind until the field is laid out and the rack's difficulty is known: a
+    // chip left over from the last wave, read against a question from this one,
+    // would be a stated wind that is not the wind.
+    this.wind = 0
+    this.windCap = 0
     // Seeded from the band already found, nudged one notch harder: the arithmetic
     // creeps upward as the child keeps clearing waves, and it can only ever creep
     // onto a rung whose answers still fit, because a probe that does not fit is
@@ -574,10 +585,16 @@ export class TrebuchetGame {
     this.towers = values.map((v, i) => buildTower(i, v, this.rng, cfg.volley && i % 2 === 0))
     this.markWanted()
 
-    this.wind = rollWind(cfg.wind, this.rng)
+    // The wind, from the RUNG THE QUESTIONS CAME FROM and not from the wave
+    // number. The lowest difficulty in the rack decides it, so one stray hard item
+    // in a beginner's pool cannot start the wind blowing on a child the ladder has
+    // not moved yet — and it is fixed for the wave, so tapping a different rack
+    // stone can never change the wind she is looking at.
+    this.windCap = Math.min(...boulders.map((b) => windCapFor(b.q.difficulty)))
+    this.rollWindForShot()
     this.wall = null
     if (cfg.wall) {
-      const w = wallFor(Math.min(...values), cfg.wind)
+      const w = wallFor(Math.min(...values), this.windCap)
       this.wall = { x: worldX(w.x), h: w.h }
     }
     this.ram = cfg.ram
@@ -592,8 +609,8 @@ export class TrebuchetGame {
     this.parts.clear()
     this.rings.clear()
     this.hitsThisWave = 0
-    this.dial = clamp(Math.round(values[0] * 0.8), DIAL_MIN, DIAL_MAX)
-    this.loftIdx = DEFAULT_LOFT
+    const opening = dialRange(this.wind)
+    this.dial = clamp(Math.round(values[0] * 0.8), opening.lo, opening.hi)
     this.phase = 'intro'
     this.phaseT = 0
     this.introT = 0
@@ -606,12 +623,34 @@ export class TrebuchetGame {
       sc.push(this.cosmetic.range(-20, worldX(FIELD_MAX) + 20), this.cosmetic.range(0.3, 1.1))
     }
     this.scrub = new Float32Array(sc)
-    // The loft lever appears mid-run, and it changes where mute sits.
-    this.hud = hudLayout(this.w, this.h, this.hud.area, cfg.loft)
-    this.btns = this.hud.buttons
     this.audio.horn(true)
     if (!this.reduced && n % 3 === 0 && this.flash.add(0.16, 0.22, 0.5, 0.2, 1.2)) {
       this.backdrop.strike(this.cosmetic)
+    }
+  }
+
+  /**
+   * Roll the wind for the shot the child is about to take, and never again.
+   *
+   * Called at exactly two moments, and both are BEFORE she can see the question
+   * she will answer with it: when the field is laid out, and when the next boulder
+   * is loaded after a shot has settled. Nothing rolls at release, in flight or at
+   * impact. That is the whole safety property of this mechanic — the wind she reads
+   * is the wind that carries the boulder, so `dial + wind` is a number she can work
+   * out to the metre before she touches anything.
+   *
+   * The first wind of a run raises the manual. The rule about what a right answer
+   * looks like has just changed, and a child cannot be expected to deduce a rule.
+   */
+  private rollWindForShot(): void {
+    this.wind = rollWind(this.windCap, this.rng)
+    // A new wind moves the dial's stops. Re-clamped here so the dial cannot be
+    // left holding a value that names a metre off the field.
+    const range = dialRange(this.wind)
+    this.dial = clamp(this.dial, range.lo, range.hi)
+    if (this.wind !== 0 && !this.windSeen) {
+      this.windSeen = true
+      this.explainPending = true
     }
   }
 
@@ -639,7 +678,7 @@ export class TrebuchetGame {
     if (b) {
       this.canvas.setPointerCapture?.(e.pointerId)
       this.held = { id: b.id, t: 0, accum: 0 }
-      this.pressBtn(b, p)
+      this.pressBtn(b)
       return
     }
     // tapping a rack stone loads that boulder
@@ -694,14 +733,6 @@ export class TrebuchetGame {
         this.setDial(this.dial + big)
         e.preventDefault()
         break
-      case 'ArrowUp':
-        this.setLoft(this.loftIdx + 1)
-        e.preventDefault()
-        break
-      case 'ArrowDown':
-        this.setLoft(this.loftIdx - 1)
-        e.preventDefault()
-        break
       case ' ':
       case 'Enter':
         this.audio.resume()
@@ -723,7 +754,7 @@ export class TrebuchetGame {
     }
   }
 
-  private pressBtn(b: Btn, p: { x: number; y: number }): void {
+  private pressBtn(b: Btn): void {
     switch (b.id) {
       case 'fire':
         this.fire()
@@ -737,11 +768,6 @@ export class TrebuchetGame {
       case 'mute':
         this.toggleMute()
         break
-      case 'loft': {
-        const rel = 1 - clamp01((p.y - b.y) / b.h)
-        this.setLoft(Math.round(rel * (LOFTS.length - 1)))
-        break
-      }
     }
   }
 
@@ -780,9 +806,6 @@ export class TrebuchetGame {
       combo: this.combo,
       wind: this.wind,
       showWind: this.wind !== 0,
-      loftUnlocked: this.cfg.loft,
-      loftIndex: this.loftIdx,
-      loftCount: LOFTS.length,
       muted: this.muted,
       introT: this.introT,
       clearT: this.clearT,
@@ -808,7 +831,10 @@ export class TrebuchetGame {
   }
 
   private setDial(v: number): void {
-    const nv = clamp(Math.round(v), DIAL_MIN, DIAL_MAX)
+    // The stops move with the wind, so the metre she is claiming is always a metre
+    // that exists — see `dialRange`. They never bind on a correct answer.
+    const range = dialRange(this.wind)
+    const nv = clamp(Math.round(v), range.lo, range.hi)
     if (nv === this.dial) return
     const delta = Math.abs(nv - this.dial)
     this.dial = nv
@@ -820,14 +846,6 @@ export class TrebuchetGame {
       this.audio.tick(clamp01((this.dial - DIAL_MIN) / (DIAL_MAX - DIAL_MIN)))
       if (delta >= 1) this.host.haptic('light')
     }
-  }
-
-  private setLoft(i: number): void {
-    const ni = clamp(Math.round(i), 0, LOFTS.length - 1)
-    if (ni === this.loftIdx || !this.cfg.loft) return
-    this.loftIdx = ni
-    this.audio.detent()
-    this.host.haptic('light')
   }
 
   /* ----------------------------------------------------------------- fire */
@@ -845,13 +863,27 @@ export class TrebuchetGame {
   private release(): void {
     const b = this.activeBoulder
     if (!b) return
-    // Aimed at the dial, not displaced by the wind: `aimShot` lays the machine
-    // off into the crosswind so the boulder comes down on the metre she named.
-    const shot = aimShot(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+    // The dial is the range in still air; the wind carries it the rest of the way.
+    // Her arithmetic, not the crew's — see `shotFor`.
+    const shot = shotFor(this.dial, LOFT_DEG, this.wind, LAUNCH_H)
     // Her answer, and how long it took her — both as they stood when she fired.
     // The flight is the game's time, not hers, so it is not in the latency.
+    //
+    // **The wind is in the snapshot too**, and it has to be: her answer to the sum
+    // is `dial + wind`, so a wind read at impact rather than at release would be a
+    // term in her reported answer that she never saw.
+    //
+    // Said plainly rather than dressed up as coverage: **no test reaches this
+    // field.** `rollWindForShot` is called from exactly two places, the wave layout
+    // and the settle→aim handover, and neither can run between `release` and
+    // `impact` — so swapping `fired.wind` for `this.wind` at impact leaves all 131
+    // tests green. It is here because the dial was in exactly this position before
+    // #661, where the same argument held right up until it did not, and because the
+    // realistic version of the failure — a wind rolled at release, after she has
+    // committed — IS caught, by four tests.
     this.fired = {
       dial: this.dial,
+      wind: this.wind,
       boulder: b,
       ms: Math.max(1, Math.round(performance.now() - this.questionShownAt)),
     }
@@ -907,7 +939,7 @@ export class TrebuchetGame {
     // nothing else — not the keep the blast happened to reach, not the metre the
     // ground recorded, not where the dial has drifted to since. A boulder spent on
     // the ram is not an answer at all.
-    const v = verdictFor({ dial: fired.dial, landing, answer: b.answer, kind })
+    const v = verdictFor({ dial: fired.dial, wind: fired.wind, landing, answer: b.answer, kind })
     const correct = v.correct
     // The ram swallows the boulder where it stands: no keep is touched by a shot
     // that never got past the siege engine.
@@ -1019,19 +1051,24 @@ export class TrebuchetGame {
     }
 
     // --- record -------------------------------------------------------
+    // The crater is labelled with what she SAID, not with what the ground measured.
+    // The two are the same integer while the sim is honest, and if they ever part
+    // company the number burnt into the field must be the one she is being marked
+    // on — a crater reading 72 beside a verdict of "wrong" is the game arguing with
+    // itself in front of her.
     this.craters.push({
       x,
       r: correct ? 3.4 : 2.4,
       depth: 1,
       age: 0,
-      label: landing,
+      label: v.claim,
       correct,
     })
     if (this.craters.length > 14) this.craters.shift()
     if (this.shot) {
       this.ghosts.push({
         pts: samplePath(this.shot, 30).map((p) => ({ x: p.x + LAUNCH_X, y: p.y })),
-        landing,
+        landing: v.claim,
         age: 0,
         hit: correct,
       })
@@ -1170,6 +1207,12 @@ export class TrebuchetGame {
   }
 
   private update(dt: number, rawDt: number): void {
+    // The wind has just started blowing and the rules have changed. Said before
+    // anything else moves — see `explainPending`.
+    if (this.explainPending) {
+      this.explainPending = false
+      this.explain()
+    }
     this.phaseT += rawDt
     this.dialPop = Math.min(1, this.dialPop + rawDt / 0.16)
     this.scorePop = Math.min(1, this.scorePop + rawDt / 0.5)
@@ -1331,7 +1374,9 @@ export class TrebuchetGame {
             this.phase = 'aim'
             this.phaseT = 0
             this.questionShownAt = performance.now()
-            if (this.cfg.gusty) this.wind = rollWind(this.cfg.wind, this.rng)
+            // A fresh wind for a fresh question, rolled here — before she has had a
+            // chance to look at either.
+            this.rollWindForShot()
           }
         }
         break
@@ -1552,10 +1597,14 @@ export class TrebuchetGame {
     ctx.fillStyle = C.steel
     ctx.fill()
 
-    // The loft stub — the first slice of the arc — only once the lever exists to
-    // change it. Before that it would be decoration teaching nothing.
-    if (this.cfg.loft) {
-      const st = aimShot(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+    // The first slice of the arc, drawn only when there is a wind to bend it —
+    // that the shot leans downwind is the mechanic, made visible in the world where
+    // the eye already is. It stops at a third of the flight ON PURPOSE: extend it
+    // to the ground and it becomes a landing marker, and a landing marker does the
+    // child's `dial + wind` for her and turns the game into sliding a caret until
+    // it touches the right keep.
+    if (this.wind !== 0) {
+      const st = shotFor(this.dial, LOFT_DEG, this.wind, LAUNCH_H)
       ctx.beginPath()
       const pts = samplePath(st, 14, st.T * 0.34)
       for (let i = 0; i < pts.length; i++) {
@@ -1682,6 +1731,11 @@ export class TrebuchetGame {
 
   currentWind(): number {
     return this.wind
+  }
+
+  /** The strongest wind this wave can produce; 0 means the wind is not in play. */
+  currentWindCap(): number {
+    return this.windCap
   }
 
   /**

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -23,18 +23,18 @@ export function mount(el: HTMLElement, host: Host): Mounted {
     title: 'TREBUCHET',
     summary: [
       'Your boulder has a sum written on it. Work out the answer.',
-      'Set the range dial to that number and fire. The keep standing at that many metres comes down.',
+      'The keeps are the stone towers out on the field, and each one stands at its own number of metres. Wind the dial to your answer and fire, and the keep standing at that many metres comes down.',
     ],
     sections: [
       {
         heading: 'Taking a shot',
         lines: [
           'The boulder says something like 7 x 8. The answer is 56.',
-          'Out on the field there is a keep standing at 56 metres.',
+          'Out on the field there is a keep standing at 56 metres. A keep is a small stone tower, and its number is how far away it is.',
+          'The dial is the number between the minus and plus buttons. It sets how far the boulder will fly.',
           'Use the plus and minus buttons to wind the dial to 56.',
           'You can also drag across the field to move the dial a long way at once.',
           'Then fire, and the boulder flies exactly that far and knocks it down.',
-          'When there is a wind, your crew aims into it. The shot bends, and still lands on your number.',
         ],
       },
       {
@@ -43,6 +43,24 @@ export function mount(el: HTMLElement, host: Host): Mounted {
           'Say you dial 54 instead of 56. The boulder lands two metres short.',
           'It leaves a crater with 54 written in it, out where you can see it.',
           'So you do not just get told you were wrong. You get to see how far off you were.',
+        ],
+      },
+      {
+        // The mechanic that arrives after the child has already learnt the game, so
+        // it is spelt all the way out, with the arithmetic done on the page. This
+        // panel opens by itself the first time the wind blows.
+        heading: 'Wind',
+        lines: [
+          'When the sums get harder, a wind starts blowing across the field.',
+          'The wind readout sits under your row of boulders: an arrow, and a number.',
+          'The arrow shows which way the wind will push your boulder, and the number is how many metres it will push it.',
+          'So the wind moves the boulder AFTER it leaves. You have to aim into the wind, and let the wind carry the stone the rest of the way.',
+          'Say the answer is 72, and the arrow points away from you with a 5 beside it.',
+          'The wind will carry the boulder 5 metres further than the dial says, so dial 5 less. 72 take away 5 is 67.',
+          'Dial 67, fire, and the wind pushes it the last 5 metres onto 72.',
+          'If the arrow points back towards you, the wind holds the boulder 5 metres short instead, so dial 5 more. 72 and 5 is 77.',
+          'Work out the sum first. Then take the wind off your answer, or add it on.',
+          'The wind does not change while you are thinking. The number you can see is the number you get.',
         ],
       },
       {
@@ -63,6 +81,13 @@ export function mount(el: HTMLElement, host: Host): Mounted {
   // Nothing behind the panel is something the child did: the space bar would
   // otherwise fire the loaded boulder at whatever the dial happens to hold.
   game.setInputGuard(() => guide.isOpen)
+  // And the game may raise the panel itself. It does that exactly once a run, the
+  // first time the wind blows — the moment the rule about what a right answer looks
+  // like changes. A mechanic that arrives silently and starts deciding whether a
+  // child is right is the defect this game has already shipped once.
+  game.setExplainer(() => {
+    guide.open()
+  })
 
   return {
     unmount(): void {

--- a/dynawalla/games/trebuchet/src/render/hud.ts
+++ b/dynawalla/games/trebuchet/src/render/hud.ts
@@ -86,7 +86,7 @@ const eqSizeFor = (unit: number, area: Rect): number =>
  *
  * `area` is required on purpose — see the file header.
  */
-export function hudLayout(w: number, h: number, area: Rect, loftUnlocked: boolean): HudLayout {
+export function hudLayout(w: number, h: number, area: Rect): HudLayout {
   const unit = hudUnit(w, h)
   const pad = Math.round(unit * 0.4)
   const right = area.x + area.w
@@ -141,27 +141,25 @@ export function hudLayout(w: number, h: number, area: Rect, loftUnlocked: boolea
   }
 
   // Controls. Fire and its steppers ride the bottom-right corner of the SAFE
-  // rect; the loft lever the bottom-left. Mute used to sit top-right, directly
-  // under the host's how-to-play button — it moves to the bottom-left, beside
-  // the lever when there is one, where nothing floats over it.
+  // rect. Mute used to sit top-right, directly under the host's how-to-play
+  // button — it moves to the bottom-left, where nothing floats over it.
+  //
+  // The bottom-left used to hold a five-notch loft lever as well, from wave 4 on.
+  // It is gone: every notch on it landed the boulder on the same metre, and the
+  // two below the default were blocked by the wall 42.9% and 21.9% of the time,
+  // so the lever's whole range was "the same, or worse". See `LOFT_DEG`.
   const fire = Math.round(unit * 1.6)
   const small = Math.round(unit * 0.72)
   const gap = Math.round(fire - small * 2)
   const by = bottom - pad - fire
   const bx = right - pad - fire
   const mute = Math.round(small * 0.8)
-  const lw = Math.round(unit * 0.95)
-  const lh = Math.round(unit * 2.6)
-  // A full pad between the lever and mute: the lever is tall and a child
-  // grabbing the bottom of it must not silence the game by accident.
-  const muteX = area.x + pad + (loftUnlocked ? lw + pad : 0)
   const buttons: Btn[] = [
     { id: 'fire', x: bx, y: by, w: fire, h: fire },
     { id: 'plus', x: bx - Math.round(pad * 0.6) - small, y: by, w: small, h: small },
     { id: 'minus', x: bx - Math.round(pad * 0.6) - small, y: by + small + gap, w: small, h: small },
-    { id: 'mute', x: muteX, y: bottom - pad - mute, w: mute, h: mute },
+    { id: 'mute', x: area.x + pad, y: bottom - pad - mute, w: mute, h: mute },
   ]
-  if (loftUnlocked) buttons.push({ id: 'loft', x: area.x + pad, y: bottom - pad - lh, w: lw, h: lh })
 
   return {
     w,
@@ -223,9 +221,6 @@ export type HudState = {
   combo: number
   wind: number
   showWind: boolean
-  loftUnlocked: boolean
-  loftIndex: number
-  loftCount: number
   muted: boolean
   /** 0..1 intro banner progress */
   introT: number
@@ -297,26 +292,54 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
   ctx.globalAlpha = 1
   void time
 
-  /* ---- wind ---- */
+  /* ---- wind ----
+   *
+   * The second number in the sum, and the only other thing on the glass a child
+   * has to read. It used to be a decoration — the crew aimed off for her, so the
+   * chip was true and irrelevant — and it now decides where the boulder comes
+   * down, so it is drawn as an instrument: a bordered pill, sitting up off the
+   * background, big enough to read from arm's length.
+   *
+   * A magnitude and a direction, and no words: the arrow points the way the wind
+   * will carry the stone. The number is unsigned, because the arrow already says
+   * which way and a `−` next to a leftward arrow is the same fact twice — and this
+   * number is about to be added to or taken off the answer, so the one thing it
+   * must not look like is a negative number.
+   *
+   * What is deliberately NOT drawn anywhere: the metre the boulder is going to
+   * land on. `dial + wind` is the child's arithmetic to do. A landing marker would
+   * turn this game into sliding a caret until it touches the right keep. */
   if (st.showWind) {
     const wy = st.layout.windY
-    const s = Math.round(unit * 0.5)
+    const s = Math.round(unit * 0.52)
     ctx.font = font(s, 900)
-    const txt = (st.wind > 0 ? '+' : '') + String(st.wind)
+    const txt = String(Math.abs(st.wind))
     const tw = ctx.measureText(txt).width
     const aw = s * 1.5
     const cx = area.x + area.w / 2
+    const innerW = aw + s * 0.35 + tw
+    const padX = s * 0.42
     ctx.globalAlpha = intro
-    // the arrow: direction is shape, not colour
+    roundRect(ctx, cx - innerW / 2 - padX, wy - s * 0.72, innerW + padX * 2, s * 1.44, 5)
+    ctx.fillStyle = 'rgba(6,8,18,0.62)'
+    ctx.fill()
+    ctx.strokeStyle = 'rgba(143,227,255,0.34)'
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+    // The arrow: direction is shape, not colour. It stays inside its own slot,
+    // whichever way it points — the old one was drawn from a fixed tail and ran
+    // out of the left of the readout on every leftward wind.
     const dir = Math.sign(st.wind) || 1
-    const ax = cx - (tw + aw) / 2
+    const ax = cx - innerW / 2
+    const tail = dir > 0 ? ax : ax + aw
+    const head = dir > 0 ? ax + aw : ax
     ctx.beginPath()
-    ctx.moveTo(ax, wy)
-    ctx.lineTo(ax + aw * dir, wy)
-    ctx.moveTo(ax + aw * dir, wy)
-    ctx.lineTo(ax + (aw - s * 0.4) * dir, wy - s * 0.25)
-    ctx.moveTo(ax + aw * dir, wy)
-    ctx.lineTo(ax + (aw - s * 0.4) * dir, wy + s * 0.25)
+    ctx.moveTo(tail, wy)
+    ctx.lineTo(head, wy)
+    ctx.moveTo(head, wy)
+    ctx.lineTo(head - s * 0.4 * dir, wy - s * 0.25)
+    ctx.moveTo(head, wy)
+    ctx.lineTo(head - s * 0.4 * dir, wy + s * 0.25)
     ctx.strokeStyle = C.windChip
     ctx.lineWidth = Math.max(2, s * 0.12)
     ctx.lineCap = 'round'
@@ -362,7 +385,6 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
     else if (b.id === 'minus') drawStep(ctx, b, '−')
     else if (b.id === 'plus') drawStep(ctx, b, '+')
     else if (b.id === 'mute') drawMute(ctx, b, st.muted)
-    else if (b.id === 'loft') drawLoft(ctx, b, st.loftIndex, st.loftCount)
   }
 
   /* ---- wave clear card ---- */
@@ -468,35 +490,6 @@ function drawMute(ctx: CanvasRenderingContext2D, b: Btn, muted: boolean): void {
     }
   }
   ctx.restore()
-}
-
-function drawLoft(ctx: CanvasRenderingContext2D, b: Btn, idx: number, count: number): void {
-  roundRect(ctx, b.x, b.y, b.w, b.h, b.w * 0.24)
-  ctx.fillStyle = 'rgba(10,14,28,0.42)'
-  ctx.fill()
-  ctx.strokeStyle = 'rgba(143,227,255,0.22)'
-  ctx.lineWidth = 2
-  ctx.stroke()
-  const n = count
-  const cell = b.h / n
-  for (let i = 0; i < n; i++) {
-    // bottom = flat, top = lofted; the notch shape says which is which
-    const y = b.y + b.h - (i + 0.5) * cell
-    const on = i === idx
-    const wdt = b.w * (0.22 + (i / (n - 1)) * 0.42)
-    ctx.beginPath()
-    ctx.moveTo(b.x + b.w / 2 - wdt / 2, y)
-    ctx.lineTo(b.x + b.w / 2 + wdt / 2, y)
-    ctx.strokeStyle = on ? C.steel : 'rgba(143,227,255,0.28)'
-    ctx.lineWidth = on ? 4 : 2
-    ctx.lineCap = 'round'
-    ctx.stroke()
-  }
-  const y = b.y + b.h - (idx + 0.5) * cell
-  ctx.beginPath()
-  ctx.arc(b.x + b.w / 2, y, b.w * 0.16, 0, Math.PI * 2)
-  ctx.fillStyle = C.steel
-  ctx.fill()
 }
 
 /**

--- a/dynawalla/games/trebuchet/src/render/layout.test.ts
+++ b/dynawalla/games/trebuchet/src/render/layout.test.ts
@@ -15,7 +15,7 @@
  *     button, and a centred equation plaque reaches both corners on a 320px
  *     phone. Nothing a child must read or touch may land in those two squares.
  *
- * Everything here goes through `hudLayout(w, h, safeRect(w, h, insets), loft)` —
+ * Everything here goes through `hudLayout(w, h, safeRect(w, h, insets))` —
  * the exact call `TrebuchetGame.resize()` makes — rather than a hand-built rect,
  * so removing the fix turns this red.
  */
@@ -68,9 +68,6 @@ function stateFor(layout: HudLayout): HudState {
     combo: 1,
     wind: -2,
     showWind: true,
-    loftUnlocked: true,
-    loftIndex: 2,
-    loftCount: 5,
     muted: false,
     introT: 1,
     clearT: -1,
@@ -83,23 +80,30 @@ function stateFor(layout: HudLayout): HudState {
 
 for (const [vname, w, h] of VIEWPORTS) {
   for (const [pname, insets] of PROFILES) {
-    for (const loft of [false, true]) {
-      const label = `${vname} (${w}×${h}), ${pname}${loft ? ', loft' : ''}`
+    {
+      const label = `${vname} (${w}×${h}), ${pname}`
 
       test(`every control is inside the safe rect — ${label}`, () => {
-        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
-        assert.ok(layout.buttons.length >= 4, 'the controls went missing')
+        const layout = hudLayout(w, h, safeRect(w, h, insets))
+        // Fire, plus, minus, mute. The loft lever used to be a fifth, appearing
+        // from wave 4; it is gone, because every notch on it landed the boulder on
+        // the same metre — see `LOFT_DEG`.
+        assert.equal(layout.buttons.length, 4, 'the controls went missing, or grew')
+        assert.equal(
+          layout.buttons.some((b) => b.id === 'loft'),
+          false,
+          'the loft lever is back, and it still does nothing',
+        )
         for (const b of layout.buttons) {
           assert.ok(
             inside(b, layout.area),
             `${b.id} ${show(b)} is outside the safe rect ${show(layout.area)}`,
           )
         }
-        if (loft) assert.ok(layout.buttons.some((b) => b.id === 'loft'), 'no loft lever')
       })
 
       test(`nothing a child touches sits under the host's chrome — ${label}`, () => {
-        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        const layout = hudLayout(w, h, safeRect(w, h, insets))
         for (const b of layout.buttons) {
           assert.equal(
             hitsHostChrome(b, w, insets),
@@ -110,7 +114,7 @@ for (const [vname, w, h] of VIEWPORTS) {
       })
 
       test(`the question stays readable — ${label}`, () => {
-        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        const layout = hudLayout(w, h, safeRect(w, h, insets))
         // `plaqueMax` is the widest the plaque can ever be drawn: a long sum on a
         // narrow phone reaches BOTH corners, so the whole pinned stack starts
         // under them.
@@ -141,7 +145,7 @@ for (const [vname, w, h] of VIEWPORTS) {
       })
 
       test(`the dial numeral is legible wherever the camera puts it — ${label}`, () => {
-        const layout = hudLayout(w, h, safeRect(w, h, insets), loft)
+        const layout = hudLayout(w, h, safeRect(w, h, insets))
         // The numeral rides the aim marker in the world, so the camera decides
         // its anchor — which means every anchor on the glass has to be safe, not
         // just the one a particular shot produces.
@@ -170,7 +174,7 @@ for (const [vname, w, h] of VIEWPORTS) {
 
 test('the pinned stack is ordered, and leaves the field its room', () => {
   for (const [, w, h] of VIEWPORTS) {
-    const layout = hudLayout(w, h, safeRect(w, h), true)
+    const layout = hudLayout(w, h, safeRect(w, h))
     assert.ok(layout.topClear > layout.area.y, 'the stack starts at the very top edge')
     assert.ok(layout.rackTop > layout.plaqueMax.y + layout.plaqueMax.h - 1, 'the rack is on the plaque')
     assert.ok(layout.windY > layout.rackTop + layout.rackH, 'the wind chip is on the rack')

--- a/dynawalla/games/trebuchet/src/sim/ballistics.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/ballistics.test.ts
@@ -3,6 +3,8 @@ import { test } from 'node:test'
 
 import { G, GRAZE_M, heightAtX, posAt, resolve, samplePath, shotScore, solve } from './ballistics.ts'
 
+// Angles, not settings. `solve` is the physics and it has to be right at any
+// angle; the game only ever throws at `LOFT_DEG`.
 const LOFTS = [26, 34, 42, 52, 63]
 
 test('the dial IS the range: landing = power + wind, exactly, for every integer input', () => {
@@ -30,7 +32,7 @@ test('the arc actually arrives where the integer says it does', () => {
   }
 })
 
-test('loft changes the shape of the arc, never the landing', () => {
+test('the launch angle changes the shape of the arc, never the landing', () => {
   const flat = solve(70, LOFTS[0], 0)
   const high = solve(70, LOFTS[4], 0)
   assert.equal(flat.landing, high.landing)
@@ -38,7 +40,7 @@ test('loft changes the shape of the arc, never the landing', () => {
   assert.ok(high.T > flat.T, 'a high loft must hang longer')
 })
 
-test('a high loft clears an obstacle a flat one hits', () => {
+test('a high angle clears an obstacle a flat one hits', () => {
   const wallX = 30
   const flat = heightAtX(solve(80, LOFTS[0], 0), wallX)
   const high = heightAtX(solve(80, LOFTS[4], 0), wallX)

--- a/dynawalla/games/trebuchet/src/sim/ballistics.ts
+++ b/dynawalla/games/trebuchet/src/sim/ballistics.ts
@@ -1,17 +1,21 @@
 /**
  * Ballistics.
  *
- * The honesty rule: **the dial is the range**. A shot dialled to 56 with no wind
- * lands at exactly 56 metres — not 55.98. The float maths below shapes the arc for
- * the eye; it never decides anything. Every outcome is decided by integer compare
- * in `resolve()`.
+ * The honesty rule: **the dial is the range, and the wind is exactly the wind**. A
+ * shot dialled to 56 in a wind of 5 lands at exactly 61 metres — not 60.98. The
+ * float maths below shapes the arc for the eye; it never decides anything. Every
+ * outcome is decided by integer compare in `resolve()`.
  *
  * Solution: launch from height `h`, land on y = 0, horizontal distance R, at the
- * chosen launch angle. Two knobs that do genuinely different jobs:
- *   power  -> WHERE it lands   (R, integer metres)
- *   loft   -> the SHAPE of the arc getting there (same landing, different sky)
+ * chosen launch angle. Two inputs that do genuinely different jobs:
+ *   R      -> WHERE it lands in still air (integer metres)
+ *   angle  -> the SHAPE of the arc getting there (same landing, different sky)
  * Wind is a constant horizontal acceleration sized so the landing is displaced by
  * exactly `wind` metres — the arc visibly bends and the arithmetic stays exact.
+ *
+ * The angle is not a control any more. The game throws every boulder at `LOFT_DEG`
+ * and the child never chooses it; the parameter stays because the physics has to be
+ * right at any angle and the wall clearance is measured through it.
  */
 
 /** Heavier-than-Earth gravity: a 100 m shot flies for ~2.5 s, which is the drama window. */

--- a/dynawalla/games/trebuchet/src/sim/targeting.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/targeting.test.ts
@@ -15,6 +15,9 @@ import { test } from 'node:test'
 
 import { LAUNCH_H, posAt, resolve, solve } from './ballistics.ts'
 
+// The one loft the machine throws at, plus the four the lever used to offer: the
+// resolution of a shot must not depend on the shape of its arc, and it is worth
+// keeping the spread here even though nothing can select it any more.
 const LOFTS = [30, 38, 46, 55, 65]
 const WORLD_X = (r: number): number => 6 + r
 const KEEP_HALF_W = 4.6 / 2 + 0.55

--- a/dynawalla/games/trebuchet/src/sim/verdict.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.test.ts
@@ -6,19 +6,38 @@
  * hold the whole shot pipeline — aim, land, resolve, report — to that sentence.
  *
  * The child modelled here is a competent one. She reads `47 + 25`, works out 72,
- * dials 72, and fires. Every assertion below is about what happens to her.
+ * takes the stated wind off it, dials the result, and fires. Every assertion below
+ * is about what happens to her.
+ *
+ * There have now been two ways of getting the wind wrong, and this file has to rule
+ * out both at once:
+ *
+ *   - **Punishing her.** The original defect: the wind was added to the landing
+ *     after she committed and nothing let her account for it. `the correct child
+ *     always lands it` is the sweep that closes this, over every wind at every cap.
+ *   - **Being pointless.** The first fix: the machine compensated for her, so
+ *     ignoring the wind was optimal and reasoning about it was punished. `the wind
+ *     is not decoration` closes that one, and it is the test the founder's question
+ *     is about.
  */
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { posAt, resolve, samplePath, type TargetRef } from './ballistics.ts'
-import { aimShot, rollWind, verdictFor, windValues, type ShotKind } from './verdict.ts'
-import { waveConfig } from './world.ts'
+import { claimOf, rollWind, shotFor, verdictFor, windValues, type ShotKind } from './verdict.ts'
+import {
+  dialRange,
+  DIAL_MAX,
+  DIAL_MIN,
+  LOFT_DEG,
+  PLACEABLE_HI,
+  PLACEABLE_LO,
+  WIND_MAX,
+  windCapFor,
+} from './world.ts'
 import { makeRng } from '../core/rng.ts'
 
-/** The lofts the machine offers. The landing may not depend on any of them. */
-const LOFTS = [30, 38, 46, 55, 65]
 const LAUNCH_H = 11
 
 /** A plausible field: keeps at least MIN_GAP (8 m) apart, one of them the answer. */
@@ -29,27 +48,36 @@ const towers = (): TargetRef[] =>
   FIELD.map((range, id) => ({ id, range, value: range, alive: true }))
 
 /**
- * One shot, through exactly the path `game.ts` walks: aim at the dialled metre,
- * see where it comes down, resolve that against the keeps, and turn the result
- * into what the host is told.
+ * One shot, through exactly the path `game.ts` walks: throw at the dialled range in
+ * the stated wind, see where it comes down, resolve that against the keeps, and turn
+ * the result into what the host is told.
  */
 function takeShot(
   dial: number,
   answer: number,
   wind: number,
-  angleDeg: number,
   kind: ShotKind = 'ground',
-): { landing: number; felled: boolean; report: boolean; correct: boolean; answered: string } {
-  const shot = aimShot(dial, angleDeg, wind, LAUNCH_H)
+): {
+  landing: number
+  felled: boolean
+  report: boolean
+  correct: boolean
+  answered: string
+  claim: number
+} {
+  const shot = shotFor(dial, LOFT_DEG, wind, LAUNCH_H)
   // The game resolves the landing against the keeps to decide what comes apart.
   // The verdict may not depend on the answer to that question — but the child
   // watching does: being told she is right while the keep stays standing is its
   // own kind of lie, so both are measured.
   const out = resolve(shot.landing, towers())
   const felled = out.quality === 'direct' && out.target?.value === answer
-  const v = verdictFor({ dial, landing: shot.landing, answer, kind })
+  const v = verdictFor({ dial, wind, landing: shot.landing, answer, kind })
   return { landing: shot.landing, felled, ...v }
 }
+
+/** The dial a child who has done both steps correctly winds on. */
+const dialFor = (answer: number, wind: number): number => answer - wind
 
 /**
  * The host does not receive `correct`. `game-host/index.ts` sends
@@ -58,178 +86,309 @@ function takeShot(
  */
 const recordedCorrect = (answered: string, answer: number): boolean => answered === String(answer)
 
-const WAVES = [3, 5, 7, 10, 12, 16]
+/** Every wind cap the game can put on the field, weakest first. */
+const CAPS = [0, 3, 4, 5, 6, 7, 8, WIND_MAX]
 const pct = (n: number, d: number): string => (d === 0 ? 'n/a' : `${((n / d) * 100).toFixed(1)}%`)
 
-test('wind never turns a correct answer into a wrong one, at any wave', () => {
-  const rows: string[] = []
-  for (const w of WAVES) {
-    const cap = waveConfig(w).wind
-    let shots = 0
-    let falseWrong = 0
-    let stoodThere = 0
-    for (const wind of windValues(cap)) {
-      for (const angle of LOFTS) {
-        const r = takeShot(ANSWER, ANSWER, wind, angle)
+/* ------------------------------------------------------------------ *
+ * The sweep. Every wind, every answer, one competent child.
+ * ------------------------------------------------------------------ */
+
+test('the correct child always lands it: every wind, every answer on the field', () => {
+  // THE test. A child who works out the sum and then takes the stated wind off it
+  // must land on the metre she named — every time, at every wind the game can
+  // produce, for every answer the field can hold. If a single case in here fails,
+  // the original defect is back: correct arithmetic, scored wrong.
+  const failures: string[] = []
+  let shots = 0
+  for (const cap of CAPS) {
+    for (const wind of cap ? windValues(cap) : [0]) {
+      for (let answer = PLACEABLE_LO; answer <= PLACEABLE_HI; answer++) {
         shots++
-        if (!r.correct) falseWrong++
-        if (!r.felled) stoodThere++
+        const dial = dialFor(answer, wind)
+        const where = `cap ${cap}, wind ${wind}, answer ${answer}, dial ${dial}`
+        // 1. She can physically enter it. A compensation off the end of the dial is
+        //    a right answer she is unable to give.
+        const stops = dialRange(wind)
+        if (dial < stops.lo || dial > stops.hi) {
+          failures.push(`${where}: the dial does not reach (${stops.lo}..${stops.hi})`)
+          continue
+        }
+        const r = takeShot(dial, answer, wind)
+        // 2. The boulder comes down on the metre she named, exactly.
+        if (r.landing !== answer) failures.push(`${where}: landed at ${r.landing}`)
+        // 3. The game agrees she was right.
+        if (!r.correct) failures.push(`${where}: scored WRONG`)
+        // 4. The curriculum is told she was right, and told her number.
+        if (!recordedCorrect(r.answered, answer)) {
+          failures.push(`${where}: recorded as "${r.answered}"`)
+        }
+      }
+    }
+  }
+  assert.equal(
+    failures.slice(0, 8).join('\n'),
+    '',
+    `${failures.length} of ${shots} correct shots were punished`,
+  )
+  // A guard on the sweep itself, so a loop that quietly stopped iterating cannot
+  // pass by testing nothing. 8,925 today: 85 winds across the caps, 105 answers.
+  assert.ok(shots > 8000, `only ${shots} shots were swept`)
+})
+
+test('the correct child always lands it, at every difficulty the ladder has', () => {
+  // The same sweep, driven the way the game drives it: the wind cap comes from the
+  // item's difficulty, so walk the whole ladder rather than a list of caps someone
+  // chose. A rung whose cap the dial cannot express is a rung that punishes her.
+  const failures: string[] = []
+  for (let d = 0; d <= 1.0001; d += 0.01) {
+    const cap = windCapFor(d)
+    for (const wind of cap ? windValues(cap) : [0]) {
+      for (const answer of [PLACEABLE_LO, 40, 72, 99, PLACEABLE_HI]) {
+        const dial = dialFor(answer, wind)
+        const stops = dialRange(wind)
+        const r = takeShot(dial, answer, wind)
+        if (dial < stops.lo || dial > stops.hi || r.landing !== answer || !r.correct) {
+          failures.push(`d=${d.toFixed(2)} cap ${cap} wind ${wind} answer ${answer}: dial ${dial}, landed ${r.landing}, correct ${String(r.correct)}`)
+        }
+      }
+    }
+  }
+  assert.equal(failures.slice(0, 8).join('\n'), '', `${failures.length} punished cases`)
+})
+
+/* ------------------------------------------------------------------ *
+ * The wind now earns its place on the glass.
+ * ------------------------------------------------------------------ */
+
+test('the wind is not decoration: ignoring it misses, accounting for it lands', () => {
+  // The founder's question, as a measurement. "It seems that usually we just ignore
+  // for the best results but then I'm not sure what the point is."
+  //
+  // Before this change the answer was: ignore it, always. The machine aimed off for
+  // her, so a child who ignored the wind was right 492/492 times and a child who
+  // reasoned about it was scored WRONG 480/492 times. The wind bent the arc, read a
+  // number on a chip, and decided nothing.
+  const rows: string[] = []
+  for (const cap of CAPS.filter((c) => c > 0)) {
+    let cases = 0
+    let ignoreLands = 0
+    let compensateLands = 0
+    for (const wind of windValues(cap)) {
+      for (const answer of FIELD) {
+        cases++
+        // The child who reads the sum and dials the answer, wind and all.
+        if (takeShot(answer, answer, wind).correct) ignoreLands++
+        // The child who takes the wind off first.
+        if (takeShot(dialFor(answer, wind), answer, wind).correct) compensateLands++
       }
     }
     rows.push(
-      `wave ${w} (wind cap ${cap}): ${pct(falseWrong, shots)} of correct answers scored WRONG, ` +
-        `${pct(stoodThere, shots)} left the keep standing`,
+      `cap ${cap}: ignoring the wind lands ${pct(ignoreLands, cases)}, ` +
+        `accounting for it lands ${pct(compensateLands, cases)}`,
     )
   }
   assert.equal(
     rows.join('\n'),
-    WAVES.map(
-      (w) =>
-        `wave ${w} (wind cap ${waveConfig(w).wind}): 0.0% of correct answers scored WRONG, ` +
-        `0.0% left the keep standing`,
-    ).join('\n'),
+    CAPS.filter((c) => c > 0)
+      .map((cap) => `cap ${cap}: ignoring the wind lands 0.0%, accounting for it lands 100.0%`)
+      .join('\n'),
   )
 })
 
-test('wind never turns a correct answer into a wrong one IN THE LEARNER MODEL', () => {
-  const rows: string[] = []
-  for (const w of WAVES) {
-    const cap = waveConfig(w).wind
-    let shots = 0
-    let falseWrong = 0
-    for (const wind of windValues(cap)) {
-      for (const angle of LOFTS) {
-        const r = takeShot(ANSWER, ANSWER, wind, angle)
-        shots++
-        if (!recordedCorrect(r.answered, ANSWER)) falseWrong++
-      }
-    }
-    rows.push(`wave ${w} (wind cap ${cap}): ${pct(falseWrong, shots)} recorded as a WRONG ANSWER`)
+test('below the threshold there is no wind, and the dial is the answer', () => {
+  // The low end is untouched, and that is a promise: a child meeting this game gets
+  // one idea — read the sum, dial the answer, the keep falls. Every rung the shipped
+  // ladder has below `WIND_FROM_D` that this field can hold.
+  for (const d of [0, 0.169, 0.2, 0.246, 0.262, 0.277, 0.292, 0.308, 0.323, 0.339]) {
+    assert.equal(windCapFor(d), 0, `d=${String(d)} has a wind on it`)
   }
-  assert.equal(
-    rows.join('\n'),
-    WAVES.map((w) => `wave ${w} (wind cap ${waveConfig(w).wind}): 0.0% recorded as a WRONG ANSWER`).join('\n'),
-  )
+  for (const answer of FIELD) {
+    const r = takeShot(answer, answer, 0)
+    assert.equal(r.claim, answer, 'with no wind, her claim is the dial')
+    assert.equal(r.landing, answer)
+    assert.equal(r.correct, true)
+    assert.equal(r.answered, String(answer))
+    assert.equal(r.felled, true, 'the keep she named comes down')
+  }
+  // ...and the ends of the window, where there is no keep in this fixture but the
+  // arithmetic still has to hold.
+  for (const answer of [PLACEABLE_LO, PLACEABLE_HI]) {
+    const r = takeShot(answer, answer, 0)
+    assert.equal(r.claim, answer)
+    assert.equal(r.landing, answer)
+    assert.equal(r.correct, true)
+  }
+})
+
+/* ------------------------------------------------------------------ *
+ * What reaches the curriculum.
+ * ------------------------------------------------------------------ */
+
+test('the number reported is her answer to the SUM, not the dial', () => {
+  // The dial and her answer are now deliberately different numbers, so which one is
+  // reported is the whole question. #654 established that the dial was reported,
+  // because then the dial WAS her answer. It is not any more: she is asked for 72
+  // and turns the dial to 67.
+  for (const wind of [-9, -5, -1, 1, 5, 9]) {
+    for (const answer of [20, 47, 72, 100]) {
+      const dial = dialFor(answer, wind)
+      const r = takeShot(dial, answer, wind)
+      assert.equal(r.answered, String(answer), `wind ${wind}, answer ${answer}: dialled ${dial}`)
+      assert.notEqual(r.answered, String(dial), 'the dial is not what she was asked for')
+    }
+  }
+})
+
+test('her answer is computed from what she saw, never read off the ground', () => {
+  // `claimOf` takes the dial she set and the wind she was shown, and adds two
+  // integers. Nothing from the simulation is in it. That is not fastidiousness: the
+  // original defect reported the metre the wind chose, and it did that by reading
+  // the ground.
+  for (const dial of [-4, 0, 8, 72, 127, 500]) {
+    for (const wind of [-9, 0, 9]) {
+      assert.equal(claimOf(dial, wind), dial + wind, `dial ${dial}, wind ${wind}`)
+    }
+  }
+  // And a landing that disagrees cannot change it.
+  const real = console.error
+  const shouted: string[] = []
+  console.error = (...args: unknown[]) => shouted.push(args.join(' '))
+  try {
+    for (const drift of [-9, -4, -1, 1, 5, 9]) {
+      const v = verdictFor({ dial: 67, wind: 5, landing: 72 + drift, answer: 72, kind: 'ground' })
+      assert.equal(v.answered, '72', `drift ${drift}`)
+      assert.equal(v.correct, true, `drift ${drift}`)
+    }
+  } finally {
+    console.error = real
+  }
+  assert.equal(shouted.length, 6, 'every disagreement is logged')
+  assert.match(shouted[0], /landed at 63 but the dial said 67 in a wind of 5, which is 72/)
 })
 
 test('a wrong dial is never recorded as a right answer', () => {
-  // The mirror image, and just as poisoning: a child who dials one short must
-  // not be written into the model as a child who knew it.
+  // The mirror image, and just as poisoning: a child who is one out must not be
+  // written into the model as a child who knew it. Two ways to be one out now — the
+  // sum, or the adjustment — and neither may be forgiven.
   const bad: string[] = []
-  for (const w of WAVES) {
-    const cap = waveConfig(w).wind
+  for (const cap of CAPS.filter((c) => c > 0)) {
     for (const wind of windValues(cap)) {
-      for (const dial of [ANSWER - 3, ANSWER - 2, ANSWER - 1, ANSWER + 1, ANSWER + 2, ANSWER + 3]) {
-        const r = takeShot(dial, ANSWER, wind, LOFTS[2])
+      const right = dialFor(ANSWER, wind)
+      for (const off of [-3, -2, -1, 1, 2, 3]) {
+        const r = takeShot(right + off, ANSWER, wind)
         if (recordedCorrect(r.answered, ANSWER)) {
-          bad.push(`wave ${w}: dialled ${dial} for ${ANSWER} with wind ${wind} -> recorded "${r.answered}"`)
+          bad.push(`wind ${wind}: dialled ${right + off} instead of ${right} -> recorded "${r.answered}"`)
         }
-        if (r.correct) {
-          bad.push(`wave ${w}: dialled ${dial} for ${ANSWER} with wind ${wind} -> scored CORRECT`)
-        }
+        if (r.correct) bad.push(`wind ${wind}: dialled ${right + off} -> scored CORRECT`)
+      }
+      // The particular wrong answer this mechanic invites: the right sum, the
+      // adjustment applied the WRONG WAY.
+      const flipped = takeShot(ANSWER + wind, ANSWER, wind)
+      if (flipped.correct) bad.push(`wind ${wind}: adjusting the wrong way scored CORRECT`)
+      if (recordedCorrect(flipped.answered, ANSWER)) {
+        bad.push(`wind ${wind}: adjusting the wrong way recorded "${flipped.answered}"`)
+      }
+      // ...and it is recorded as the number she actually named, so the curriculum
+      // can see how she was wrong instead of only that she was.
+      if (flipped.answered !== String(ANSWER + 2 * wind)) {
+        bad.push(`wind ${wind}: adjusting the wrong way recorded "${flipped.answered}"`)
       }
     }
   }
   assert.equal(bad.slice(0, 6).join('\n'), '', `${bad.length} wrong dials were treated as right`)
 })
 
-test('the number reported to the host is the number the child dialled', () => {
-  for (const wind of [-9, -4, -1, 0, 1, 4, 9]) {
-    for (const dial of [14, 40, 71, 72, 73, 104, 118]) {
-      const r = takeShot(dial, ANSWER, wind, LOFTS[2])
-      assert.equal(r.answered, String(dial), `dial ${dial}, wind ${wind}`)
-    }
-  }
-})
+/* ------------------------------------------------------------------ *
+ * The physics under it.
+ * ------------------------------------------------------------------ */
 
-test('if anything ever moves the landing again, the dial still wins — loudly', () => {
-  // `aimShot` makes landing === dial, so today this cannot happen. It could not
-  // happen before either, right up until the wind was added. The report is pinned
-  // to the child's number independently of the ground, and the disagreement is
-  // logged rather than swallowed, because the alternative is silently marking a
-  // child on a number she never chose.
-  const real = console.error
-  const shouted: string[] = []
-  console.error = (...args: unknown[]) => shouted.push(args.join(' '))
-  try {
-    for (const drift of [-9, -4, -1, 1, 5, 9]) {
-      const v = verdictFor({ dial: 72, landing: 72 + drift, answer: 72, kind: 'ground' })
-      assert.equal(v.answered, '72', `drift ${drift}`)
-      assert.equal(v.correct, true, `drift ${drift}`)
-    }
-    const wrong = verdictFor({ dial: 71, landing: 72, answer: 72, kind: 'ground' })
-    assert.equal(wrong.answered, '71', 'the metre struck is not the answer given')
-    assert.equal(wrong.correct, false)
-  } finally {
-    console.error = real
-  }
-  assert.equal(shouted.length, 7, 'every disagreement is logged')
-  assert.match(shouted[0], /landed at 63 but the dial said 72/)
-})
-
-test('the dial IS the landing metre — the wind does not move it', () => {
-  for (const w of WAVES) {
-    for (const wind of windValues(waveConfig(w).wind)) {
-      for (const angle of LOFTS) {
-        for (const dial of [8, 14, 40, 72, 104, 122]) {
-          assert.equal(
-            aimShot(dial, angle, wind, LAUNCH_H).landing,
-            dial,
-            `wave ${w}: dial ${dial}, wind ${wind}, loft ${angle}`,
-          )
-        }
+test('the landing metre is dial + wind, exactly, for every input', () => {
+  for (const cap of CAPS) {
+    for (const wind of cap ? windValues(cap) : [0]) {
+      for (const dial of [DIAL_MIN, 8, 14, 40, 72, 104, PLACEABLE_HI, DIAL_MAX]) {
+        // `solve` is unconditional: the arithmetic holds for anything, and the
+        // stops are a separate rule about what the dial will let her ask for.
+        assert.equal(
+          shotFor(dial, LOFT_DEG, wind, LAUNCH_H).landing,
+          dial + wind,
+          `dial ${dial}, wind ${wind}`,
+        )
       }
     }
   }
 })
 
-test('aiming into the wind still produces a real arc, even in the worst corner', () => {
-  // The compensation launches at `dial − wind`, which at the bottom of the dial
-  // against the strongest wind is a very short throw. It must still be a finite,
-  // drawable arc that reaches the ground on the dialled metre.
-  for (const wind of windValues(9)) {
-    for (const angle of LOFTS) {
-      for (const dial of [8, 9, 10, 17, 122]) {
-        const where = `dial ${dial}, wind ${wind}, loft ${angle}`
-        const s = aimShot(dial, angle, wind, LAUNCH_H)
-        assert.ok(Number.isFinite(s.T) && s.T > 0, `flight time ${where}: ${s.T}`)
-        // Out of the sling forwards and upwards — never lobbed backwards off the
-        // escarpment to be dragged onto the target by the crosswind.
-        assert.ok(s.vx > 0, `${where}: launched backwards at ${s.vx} m/s`)
-        assert.ok(s.vy > 0, `${where}: launched downwards at ${s.vy} m/s`)
-        assert.ok(s.apexY > LAUNCH_H, `${where}: never rose above the sling`)
-        for (const p of samplePath(s, 12)) {
-          assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y), `path ${where}`)
-        }
-        assert.ok(Math.abs(posAt(s, s.T).x - dial) < 1e-9, `comes down on the dial, ${where}`)
+test('every shot the dial can express is a real arc, even in the worst corner', () => {
+  // The shortest throw the dial allows, against the strongest wind, must still be a
+  // finite drawable arc that leaves the sling forwards and upwards and comes down
+  // where the arithmetic says.
+  for (const wind of windValues(WIND_MAX)) {
+    const stops = dialRange(wind)
+    for (const dial of [stops.lo, stops.lo + 1, 20, 72, stops.hi - 1, stops.hi]) {
+      const where = `dial ${dial}, wind ${wind}`
+      const s = shotFor(dial, LOFT_DEG, wind, LAUNCH_H)
+      assert.ok(Number.isFinite(s.T) && s.T > 0, `flight time ${where}: ${s.T}`)
+      assert.ok(s.vx > 0, `${where}: launched backwards at ${s.vx} m/s`)
+      assert.ok(s.vy > 0, `${where}: launched downwards at ${s.vy} m/s`)
+      assert.ok(s.apexY > LAUNCH_H, `${where}: never rose above the sling`)
+      for (const p of samplePath(s, 12)) {
+        assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y), `path ${where}`)
+      }
+      assert.ok(Math.abs(posAt(s, s.T).x - (dial + wind)) < 1e-9, `comes down on dial+wind, ${where}`)
+    }
+  }
+})
+
+test('nothing the boulder does can carry it off the drawn field', () => {
+  // The dial reaches past the field so the compensation is expressible. That must
+  // not let a boulder fly out past where the ground is drawn (40 m beyond the field)
+  // on its way to a landing that IS on the field.
+  for (const wind of windValues(WIND_MAX)) {
+    const stops = dialRange(wind)
+    for (let dial = stops.lo; dial <= stops.hi; dial++) {
+      const s = shotFor(dial, LOFT_DEG, wind, LAUNCH_H)
+      // Never behind the machine: a boulder that turns round in mid-air and lands
+      // on the crew is what an unbounded dial produced, and it is what `dialRange`
+      // exists to stop.
+      assert.ok(s.landing >= 1, `dial ${dial}, wind ${wind}: lands at ${s.landing}`)
+      for (const p of samplePath(s, 48)) {
+        assert.ok(
+          p.x >= 0 && p.x <= DIAL_MAX + 1,
+          `dial ${dial}, wind ${wind}: reached x=${String(p.x)}`,
+        )
       }
     }
   }
 })
+
+/* ------------------------------------------------------------------ *
+ * Shots that are not answers.
+ * ------------------------------------------------------------------ */
 
 test('a boulder spent on the ram is not an answer to the question', () => {
   // A child who knocks the siege engine off her walls has not said anything
   // about 47 + 25. Reporting it as a wrong answer writes "does not know this"
   // into the model for a shot that was never an attempt at the sum.
-  const ram = takeShot(30, ANSWER, 0, LOFTS[2], 'ram')
+  const ram = takeShot(30, ANSWER, 4, 'ram')
   assert.equal(ram.report, false, 'a ram shot must not be reported as an answer')
 
   // And the mirror: the ram can stand on the very metre the answer is at, so a
-  // perfectly dialled boulder can be swallowed on its way out. That is not a hit
+  // perfectly aimed boulder can be swallowed on its way out. That is not a hit
   // either — no keep came down, so nothing may be scored as one.
-  const intercepted = takeShot(ANSWER, ANSWER, 0, LOFTS[2], 'ram')
+  const intercepted = takeShot(dialFor(ANSWER, 4), ANSWER, 4, 'ram')
   assert.equal(intercepted.report, false, 'still not an answer')
   assert.equal(intercepted.correct, false, 'no keep fell, so nothing was struck')
 
   for (const kind of ['tower', 'ground', 'wall'] as ShotKind[]) {
-    const r = takeShot(ANSWER, ANSWER, 0, LOFTS[2], kind)
+    const r = takeShot(dialFor(ANSWER, 4), ANSWER, 4, kind)
     assert.equal(r.report, true, `${kind} is an answer`)
     assert.equal(r.correct, true, `${kind} on the right metre is right`)
   }
 })
 
 test('rollWind only ever produces a wind the tests enumerate', () => {
-  for (const cap of [2, 3, 5, 9]) {
+  for (const cap of [3, 5, 9]) {
     const allowed = new Set(windValues(cap))
     const rng = makeRng(0x51e6e)
     const seen = new Set<number>()
@@ -241,4 +400,8 @@ test('rollWind only ever produces a wind the tests enumerate', () => {
     assert.equal(seen.size, allowed.size, `cap ${cap} did not cover its range`)
   }
   assert.equal(rollWind(0, makeRng(1)), 0, 'no wind means no wind')
+  // Never zero when there IS a wind: a chip reading 0 tells a child to adjust by
+  // nothing, which is a lie about a mechanic she has just been taught.
+  const rng = makeRng(9)
+  for (let i = 0; i < 2000; i++) assert.notEqual(rollWind(3, rng), 0)
 })

--- a/dynawalla/games/trebuchet/src/sim/verdict.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.ts
@@ -3,21 +3,47 @@
  *
  * `game.ts` states the law at the top of `pending`: a keep standing in the way is
  * scenery, because "anything else would punish correct arithmetic, which is the one
- * thing this game may never do." The wind used to do exactly that. From wave 3 the
- * landing was `dial + wind` while the aim caret, the numeral and the whole promise
- * of the game stood on `dial`, so a child who worked out 47 + 25 = 72 and dialled 72
- * watched her shot land somewhere else and was told she was wrong — and, worse, the
- * metre the wind chose was the string sent to the curriculum as her answer.
+ * thing this game may never do."
  *
- * Two rules now hold this together, and both are tested:
+ * ## The wind, and the two ways of getting it wrong
  *
- *   1. **The dial is the landing metre.** The crew aims upwind by exactly the
- *      crosswind, so the boulder is launched off-target and blown onto the number.
- *      The arc still visibly bends — the wind is real, it is drawn, it is on the
- *      chip — it simply no longer decides whether a child knows her sums.
- *   2. **The child's answer is the number on the dial.** Not the metre struck, not
- *      the value of whichever keep happened to be nearest, not a landing the wind
- *      moved. What she named is what is reported.
+ * **The original defect (fixed in #654).** The crosswind was a hidden term added
+ * after the child committed: `landing = dial + wind`, while the aim caret, the
+ * numeral and the whole promise of the game stood on `dial`. Nothing on the screen
+ * told her the wind was going to move her boulder and nothing let her account for
+ * it, so a child who worked out `47 + 25 = 72` and dialled 72 was scored wrong with
+ * probability `1 − 1/cap` — 8/9 by wave 16 — and the metre the wind chose was sent
+ * to the curriculum as her answer.
+ *
+ * **The fix that made the wind pointless (#654).** `aimShot` laid the machine off
+ * into the crosswind, launching at `dial − wind`, so the boulder came down on the
+ * metre she named whatever the wind did. Correct, and it left the wind decorative:
+ * the arc bent, the chip read a number, and ignoring it was optimal. Measured over
+ * 2,460 shots across waves 1–20, the wind moved the landing metre 0 times, changed
+ * the verdict 0 times and changed the report 0 times — while a child who *did*
+ * reason about it and aimed off herself was scored WRONG in 480 of 492 cases. The
+ * game punished exactly the child who was thinking.
+ *
+ * ## What holds now
+ *
+ * The crew does not do the subtraction any more. The child does, and she is told
+ * everything she needs to do it before she commits to anything:
+ *
+ *   1. **The wind is exact, stated, and fixed before the shot.** An integer number
+ *      of metres, on the chip, rolled when the question appears and never touched
+ *      again — not at release, not in flight, not at impact. So the metre the
+ *      boulder will come down on is `dial + wind`, and she can work that out to the
+ *      metre before she presses anything. There is nothing left in this game that a
+ *      child could not have accounted for.
+ *   2. **Her answer to the sum is `dial + wind`** — the metre she is claiming the
+ *      keep stands at. That number, and not the dial, is what reaches the
+ *      curriculum, because the dial is now deliberately a different number from her
+ *      answer. It is computed from her own two inputs by integer addition, never
+ *      read back off the physics; the landing is checked against it and a
+ *      disagreement is logged loudly, with her claim still winning.
+ *   3. **Below `WIND_FROM_D` there is no wind at all**, the cap is 0, and every
+ *      formula above collapses to `claim = dial`. The beginner's game is the game
+ *      it always was.
  */
 
 import { solve, type Solved } from './ballistics.ts'
@@ -30,7 +56,7 @@ export function windValues(cap: number): number[] {
   return out
 }
 
-/** A crosswind for the wave. Never 0: a wind chip reading 0 lies about the mechanic. */
+/** A crosswind for the shot. Never 0: a wind chip reading 0 lies about the mechanic. */
 export function rollWind(cap: number, rng: Rng): number {
   if (!cap) return 0
   let v = 0
@@ -39,19 +65,20 @@ export function rollWind(cap: number, rng: Rng): number {
 }
 
 /**
- * The shot that comes down on the metre the child dialled.
+ * The shot the machine actually throws.
  *
- * `solve` lands at `power + wind`, so the power asked for is `dial − wind`: the
- * machine is laid off into the wind and the wind carries the boulder home. Both
- * terms are integers, so the landing is the dial exactly — not 71.98.
+ * `dialM` is the range wound onto the dial — where the boulder would land in still
+ * air — and the wind carries it `wind` metres further on top of that. Both terms
+ * are integers, so the landing metre is `dial + wind` exactly, not 71.98.
+ *
+ * There is no compensation in here any more. The physical shot is unchanged from
+ * the one #654 fired: a child who wants to hit metre `A` in a wind of `w` dials
+ * `A − w`, and this launches at power `A − w` — the same power the old `aimShot`
+ * computed for her behind her back. The only thing that moved is which number she
+ * turns and who does the subtraction.
  */
-export function aimShot(dialM: number, angleDeg: number, wind: number, h: number): Solved {
-  // Never laid off past the launch point. A target nearer than the wind's push
-  // would ask for a backwards throw, so the offset stops at 1 m of power and the
-  // modelled bend gives instead — the LANDING is exact either way, which is the
-  // part a child is marked on. Only reachable by dialling below the whole field.
-  const power = Math.max(1, dialM - wind)
-  return solve(power, angleDeg, dialM - power, h)
+export function shotFor(dialM: number, angleDeg: number, wind: number, h: number): Solved {
+  return solve(dialM, angleDeg, wind, h)
 }
 
 /**
@@ -61,9 +88,11 @@ export function aimShot(dialM: number, angleDeg: number, wind: number, h: number
 export type ShotKind = 'tower' | 'ground' | 'wall' | 'ram'
 
 export type ShotFacts = {
-  /** the metre the child named */
+  /** the range wound onto the dial */
   dial: number
-  /** the metre the boulder came down on — must equal the dial */
+  /** the wind she was shown, frozen when she committed */
+  wind: number
+  /** the metre the boulder came down on — must equal `dial + wind` */
   landing: number
   /** what the loaded boulder asked for */
   answer: number
@@ -81,21 +110,37 @@ export type Verdict = {
   correct: boolean
   /** the string the host is given, and the only thing the curriculum judges */
   answered: string
+  /** the metre she named as the answer: `dial + wind` */
+  claim: number
 }
 
+/**
+ * The metre the child is claiming the keep stands at.
+ *
+ * Her answer to the sum, in one integer addition over the two numbers she had in
+ * front of her: the dial she set and the wind she was shown. Nothing from the
+ * simulation is in here, which is the point — the last time this game read the
+ * ground to find out what a child had said, it reported the metre the wind chose.
+ */
+export const claimOf = (dial: number, wind: number): number => dial + wind
+
 export function verdictFor(f: ShotFacts): Verdict {
-  if (f.landing !== f.dial) {
-    // Unreachable while `aimShot` is what fires the boulder. If it ever happens,
-    // something has put a term between the dial and the ground again, and a child
-    // is about to be marked on it — so it is loud, and the dial still wins.
+  const claim = claimOf(f.dial, f.wind)
+  if (f.landing !== claim) {
+    // Unreachable while `shotFor` is what throws the boulder: `solve` returns
+    // `R + wind` and this adds the same two integers. If it ever happens,
+    // something has put a term between her arithmetic and the ground again, and a
+    // child is about to be marked on it — so it is loud, and her claim still wins.
     console.error(
-      `[trebuchet] the boulder landed at ${f.landing} but the dial said ${f.dial}; reporting the dial`,
+      `[trebuchet] the boulder landed at ${f.landing} but the dial said ${f.dial} in a wind of ` +
+        `${f.wind}, which is ${claim}; reporting ${claim}`,
     )
   }
   const answersTheQuestion = f.kind !== 'ram'
   return {
     report: answersTheQuestion,
-    correct: answersTheQuestion && f.dial === f.answer,
-    answered: String(f.dial),
+    correct: answersTheQuestion && claim === f.answer,
+    answered: String(claim),
+    claim,
   }
 }

--- a/dynawalla/games/trebuchet/src/sim/world.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.test.ts
@@ -5,11 +5,10 @@ import type { Question } from '../contract.ts'
 import { makeRng } from '../core/rng.ts'
 import { createStubHost } from '../stubHost.ts'
 import { heightAtX, LAUNCH_H } from './ballistics.ts'
-import { aimShot, windValues } from './verdict.ts'
+import { shotFor, windValues } from './verdict.ts'
 import {
   buildTower,
-  DEFAULT_LOFT,
-  LOFTS,
+  LOFT_DEG,
   layoutTowerValues,
   pullQuestions,
   ramAdvances,
@@ -17,6 +16,9 @@ import {
   stepBlocks,
   wallFor,
   waveConfig,
+  WIND_FROM_D,
+  WIND_MAX,
+  windCapFor,
   type Phase,
 } from './world.ts'
 
@@ -99,21 +101,73 @@ test('escalation is monotonic where it should be and bounded everywhere', () => 
     prevDiff = c.difficulty
     assert.ok(c.ammo >= 2 && c.ammo <= 6)
     assert.ok(c.extraTowers >= 1 && c.extraTowers <= 3)
-    assert.ok(c.wind >= 0 && c.wind <= 9)
   }
   // the first two waves are deliberately bare: one idea at a time
   for (const w of [1, 2]) {
     const c = waveConfig(w)
-    assert.equal(c.wind, 0)
-    assert.equal(c.loft, false)
     assert.equal(c.wall, false)
     assert.equal(c.ram, false)
     assert.equal(c.banners, true)
   }
-  assert.ok(waveConfig(3).wind > 0, 'wind arrives at wave 3')
-  assert.equal(waveConfig(4).loft, true, 'the loft lever arrives at wave 4')
   assert.equal(waveConfig(5).volley, true, 'every fifth wave is a volley')
   assert.ok(waveConfig(7).ram, 'the ram arrives at wave 7')
+})
+
+test('the wave number cannot start the wind blowing — only the ladder can', () => {
+  // The founder's complaint about the wind was that it was pointless; the fix for
+  // that is a second arithmetic step, and a second arithmetic step handed out on a
+  // TIMER is worse than a pointless one. `waveConfig` no longer has a `wind` field
+  // to read, which is what makes this a compile-time fact and not a convention:
+  // there is nowhere left for a wave counter to say how hard the wind blows.
+  const cfg = waveConfig(20) as Record<string, unknown>
+  assert.equal('wind' in cfg, false, 'the wave still decides the wind')
+  assert.equal('gusty' in cfg, false, 'the wave still decides whether the wind rerolls')
+  assert.equal('loft' in cfg, false, 'the wave still unlocks a lever that no longer exists')
+})
+
+test('the wind arrives on the ladder, above the facts and the no-regroup columns', () => {
+  // Measured over the shipped 66-rung ladder: every rung whose answers a 122-metre
+  // field can stand a keep at, and what arithmetic it is. The threshold sits above
+  // the last of the easy ones on purpose — a child still on tables or on column sums
+  // with no regrouping is meeting this game for the first time and gets the game
+  // that has no wind in it at all.
+  const beginner = [
+    { d: 0.246, what: 'tables-to-twelve L0' },
+    { d: 0.277, what: 'add.column.add-no-regroup L0' },
+    { d: 0.292, what: 'add.column.subtract-no-regroup L0' },
+    { d: 0.323, what: 'tables-to-twelve L1' },
+  ]
+  for (const rung of beginner) {
+    assert.equal(windCapFor(rung.d), 0, `${rung.what} (d=${String(rung.d)}) must have no wind`)
+  }
+  const higher = [
+    { d: 0.369, what: 'add.column.subtract-no-regroup L1' },
+    { d: 0.415, what: 'tables-to-twelve L2' },
+    { d: 0.462, what: 'add.regroup.add-multidigit L0' },
+    { d: 0.492, what: 'add.regroup.subtract-multidigit L0' },
+  ]
+  for (const rung of higher) {
+    assert.ok(windCapFor(rung.d) >= 3, `${rung.what} (d=${String(rung.d)}) must have a wind`)
+  }
+})
+
+test('the wind is never 1, never past WIND_MAX, and never shrinks with difficulty', () => {
+  // A wind of 1 metre is not arithmetic: a child can nudge the dial one notch and
+  // watch. And the dial only carries WIND_MAX of slack past the field, so a cap
+  // above it would ask for a compensation she cannot enter.
+  let prev = 0
+  for (let d = 0; d <= 1.0001; d += 0.002) {
+    const cap = windCapFor(d)
+    assert.ok(cap === 0 || cap >= 3, `d=${d.toFixed(3)} gives a cap of ${String(cap)}`)
+    assert.ok(cap <= WIND_MAX, `d=${d.toFixed(3)} gives a cap of ${String(cap)}`)
+    assert.ok(cap >= prev, `the wind dropped at d=${d.toFixed(3)}`)
+    prev = cap
+  }
+  assert.equal(windCapFor(WIND_FROM_D - 0.001), 0, 'just below the threshold, no wind')
+  assert.equal(windCapFor(WIND_FROM_D), 3, 'at the threshold, three metres')
+  assert.equal(windCapFor(1), WIND_MAX, 'at the top of the ladder, the strongest wind')
+  // A difficulty that is not a number must not become a wind.
+  assert.equal(windCapFor(Number.NaN), 0, 'NaN is not a difficulty')
 })
 
 test('the ram does not roll while the child is working the sum out', () => {
@@ -130,33 +184,41 @@ test('the ram does not roll while the child is working the sum out', () => {
   }
 })
 
-test('the wall can always be cleared, in any wind, at the loft the lever starts on', () => {
-  // The wall is the only reason the loft lever exists. It may never stand between
-  // a child and a keep she has named correctly — and the compensation for the
-  // wind launches lower, so still air is not the case to size it against.
-  let blocks = 0
+test('the wall can never stand between a child and a keep she named correctly', () => {
+  // It may never block a correct shot — and a correct shot in a tailwind is
+  // launched at `answer - wind`, which flies lower than the same shot in still
+  // air, so still air is not the case to size the wall against.
+  //
+  // The wall used to have a second job: be tall enough that the FLATTEST loft
+  // could not clear it, so the loft lever had a reason to exist. The lever is gone
+  // (see `LOFT_DEG`) and so is that bound.
   let walls = 0
+  let worstMargin = Infinity
   for (let w = 1; w <= 40; w++) {
     const cfg = waveConfig(w)
     if (!cfg.wall) continue
-    for (let nearest = 14; nearest <= 118; nearest += 3) {
-      const wall = wallFor(nearest, cfg.wind)
-      walls++
-      assert.ok(wall.x < nearest, `wave ${w}: the wall stands on the keep at ${nearest}`)
-      let flatBlocked = false
-      for (const wind of cfg.wind ? windValues(cfg.wind) : [0]) {
-        const opened = aimShot(nearest, LOFTS[DEFAULT_LOFT], wind, LAUNCH_H)
-        assert.ok(
-          heightAtX(opened, wall.x) > wall.h,
-          `wave ${w}, keep ${nearest}, wind ${wind}: the default loft cannot clear a ${wall.h.toFixed(1)} m wall`,
-        )
-        if (heightAtX(aimShot(nearest, LOFTS[0], wind, LAUNCH_H), wall.x) < wall.h) flatBlocked = true
+    for (const cap of [0, 3, 5, 7, WIND_MAX]) {
+      for (let nearest = 14; nearest <= 118; nearest += 3) {
+        const wall = wallFor(nearest, cap)
+        walls++
+        assert.ok(wall.x < nearest, `wave ${w}: the wall stands on the keep at ${nearest}`)
+        for (const wind of cap ? windValues(cap) : [0]) {
+          // The shot a child who got it right actually fires: dial the answer less
+          // the wind, and let the wind carry it home.
+          const opened = shotFor(nearest - wind, LOFT_DEG, wind, LAUNCH_H)
+          const margin = heightAtX(opened, wall.x) - wall.h
+          worstMargin = Math.min(worstMargin, margin)
+          assert.ok(
+            margin > 0,
+            `wave ${w}, keep ${nearest}, wind ${wind}, cap ${cap}: a correct shot cannot clear a ` +
+              `${wall.h.toFixed(1)} m wall (margin ${margin.toFixed(2)} m)`,
+          )
+        }
       }
-      if (flatBlocked) blocks++
     }
   }
-  // ...and it must still be worth having: most walls stop the flattest shot.
-  assert.ok(blocks / walls > 0.6, `only ${blocks}/${walls} walls stop a flat shot`)
+  assert.ok(walls > 500, `only ${walls} walls were measured`)
+  assert.ok(worstMargin > 0.3, `the worst clearance is only ${worstMargin.toFixed(2)} m`)
 })
 
 test('a struck keep comes apart and then settles — no perpetual motion', () => {

--- a/dynawalla/games/trebuchet/src/sim/world.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.ts
@@ -9,7 +9,7 @@
 import type { Question } from '../contract.ts'
 import { type Rng } from '../core/rng.ts'
 import { heightAtX, LAUNCH_H } from './ballistics.ts'
-import { aimShot } from './verdict.ts'
+import { shotFor } from './verdict.ts'
 
 /** World x of the launch point; ranges are measured from here. */
 export const LAUNCH_X = 6
@@ -23,12 +23,6 @@ export type WaveConfig = {
   ammo: number
   /** rival keeps beyond the ones your boulders are for */
   extraTowers: number
-  /** magnitude cap of the crosswind, 0 for none */
-  wind: number
-  /** wind rerolls between shots */
-  gusty: boolean
-  /** the loft lever is available */
-  loft: boolean
   wall: boolean
   ram: boolean
   /** keeps wear their number on a banner (the choice scaffold) */
@@ -45,9 +39,6 @@ export function waveConfig(i: number): WaveConfig {
     difficulty: d,
     ammo: Math.min(5, 2 + Math.floor((i - 1) / 2)) + (boss ? 1 : 0),
     extraTowers: Math.min(3, 1 + Math.floor((i - 1) / 3)),
-    wind: i < 3 ? 0 : Math.min(9, 2 + Math.floor((i - 3) / 1.6)),
-    gusty: i >= 7,
-    loft: i >= 4,
     wall: i >= 5 && i % 3 !== 1,
     ram: i >= 7 && i % 2 === 1,
     banners: i < 8 ? true : i % 3 !== 0,
@@ -55,33 +46,187 @@ export function waveConfig(i: number): WaveConfig {
   }
 }
 
-/** The lofts the lever offers, flattest first, and the one it starts on. */
-export const LOFTS = [30, 38, 46, 55, 65]
-export const DEFAULT_LOFT = 2
+/**
+ * The one loft the machine throws at.
+ *
+ * There used to be five, on a lever that appeared at wave 4. It changed nothing
+ * a child could be scored on: the shot is solved for the metre she names, so all
+ * five landed on the same metre, and measured over 1,616 wall situations three of
+ * the five settings were identical to this one and the two below it were blocked
+ * by the wall 42.9% and 21.9% of the time. A lever whose every position is either
+ * the default or worse than it is not a choice; it is a way to lose. It is gone.
+ *
+ * The alternative — making the loft the wind's multiplier, so a higher arc hangs
+ * longer and drifts further — was considered and rejected. It would stack a
+ * multiplication on top of the sum and the wind adjustment, three steps deep, on
+ * a child who is here to practise `47 + 25`, and the founder's complaint is that
+ * this game is confusing.
+ */
+export const LOFT_DEG = 46
+
+/**
+ * When the wind starts blowing, as a position on the host's ladder.
+ *
+ * NOT a wave number. A wave counter is a ratchet the pack owns, and it says
+ * nothing about whether this particular child is ready for a second arithmetic
+ * step: it arrives on her twelfth minute whether she has been landing every
+ * boulder or none of them. The item's own difficulty is the host's judgement of
+ * where she is, and it is on every `Question`.
+ *
+ * Measured over the shipped 66-rung ladder, taking 60 questions off every rung
+ * and keeping the ones whose answers a 122-metre field can stand a keep at:
+ *
+ *     0.246  PLACEABLE   4..49     dw.mul.facts.tables-to-twelve L0
+ *     0.277  PLACEABLE  27..99     dw.add.column.add-no-regroup L0
+ *     0.292  PLACEABLE   1..82     dw.add.column.subtract-no-regroup L0
+ *     0.323  PLACEABLE   6..72     dw.mul.facts.tables-to-twelve L1
+ *     ---- 0.34: the wind starts here ----
+ *     0.369  PLACEABLE   6..765    dw.add.column.subtract-no-regroup L1
+ *     0.415  PLACEABLE   6..144    dw.mul.facts.tables-to-twelve L2
+ *     0.462  PLACEABLE  33..171    dw.add.regroup.add-multidigit L0
+ *     0.492  PLACEABLE   3..78     dw.add.regroup.subtract-multidigit L0
+ *
+ * So everything below the line is a table fact or a column sum with no
+ * regrouping. A child on those is meeting the game for the first time and gets
+ * the game the founder is not complaining about: read the sum, dial the answer,
+ * the keep falls. The wind arrives once the ladder has taken her past that —
+ * `game.ts` opens its search at 0.28 and climbs a notch a wave.
+ *
+ * Driven against the real `ladder()` with the real generators and the app's own
+ * rung quantisation, that lands as:
+ *
+ *     wave 1   rung 0.277  answers 98, 87        no wind
+ *     wave 2   rung 0.292  answers 27, 71        no wind
+ *     wave 3   rung 0.308  answers 25, 16        no wind
+ *     wave 4   rung 0.323  answers 16, 30, 45    no wind
+ *     wave 5   rung 0.369  answers 43,80,97,112  WIND, up to 3 metres
+ *     ...      rung 0.369                        WIND, up to 3 metres
+ *
+ * So four waves of the game the founder is not complaining about, and then the
+ * second step. It holds at three metres from there because the pack's arithmetic
+ * escalation is itself pinned by the 122-metre field — the sweep cannot climb past
+ * rung 24 without landing on four-digit column sums no keep can stand at, which is
+ * the plateau #702 documented and is not this change's to move.
+ */
+export const WIND_FROM_D = 0.34
+/** The strongest wind there is. The dial carries this much slack at both ends. */
+export const WIND_MAX = 9
+/** One more metre of wind every this far up the ladder. */
+const WIND_RAMP = 0.06
+
+/**
+ * How hard the wind blows for an item of this difficulty — the size of the second
+ * arithmetic step, in metres.
+ *
+ * Zero below the threshold, and it never OPENS below 3 — so from the first wind she
+ * meets, `rollWind` has the whole of ±1..±3 to draw from and the adjustment is a
+ * different number every shot. A cap of 1 would have made the mechanic a single
+ * nudge of the dial, learnable without arithmetic and then boring.
+ *
+ * It grows a metre every `WIND_RAMP` up the ladder, to `WIND_MAX`. On today's ladder
+ * the pack's own escalation plateaus before that headroom is used — see
+ * `WIND_FROM_D` — so the ramp is what happens when the curriculum or the field
+ * grows, not a promise about this month's content.
+ */
+export function windCapFor(difficulty: number): number {
+  if (!Number.isFinite(difficulty) || difficulty < WIND_FROM_D) return 0
+  return Math.min(WIND_MAX, 3 + Math.floor((difficulty - WIND_FROM_D) / WIND_RAMP))
+}
+
+/* ------------------------------------------------------------------ *
+ * The field, the answers it can hold, and how far the dial reaches.
+ * ------------------------------------------------------------------ */
+
+/**
+ * The window of answers this game can physically ask about.
+ *
+ * A keep stands at its own answer in METRES, on a field 122 metres long, and the
+ * blast is wide enough that two keeps must be `MIN_GAP` (8 m) apart to be distinct
+ * targets. So the answer to every question TREBUCHET poses has to be an integer
+ * in this window — that is not a tuning choice, it is what "the range dial is the
+ * answer" costs.
+ *
+ * Nothing about the question stream guarantees it. The host hands out rungs off a
+ * single cross-domain ladder addressed by a 0..1 difficulty, and a pack cannot
+ * see what arithmetic sits on a rung before it asks. Measured against the shipped
+ * 66-rung ladder, the difficulties this game used to ask for returned:
+ *
+ *     wave 1  d=0.040  dw.add.facts.subtract-within-ten   answers 0-4     0/12 placeable
+ *     wave 2  d=0.112  dw.add.facts.subtract-within-ten   answers 1-9     0/12
+ *     wave 3  d=0.184  dw.add.facts.subtract-across-ten   answers 2-9     0/12
+ *     wave 5  d=0.328  dw.mul.facts.tables-to-twelve      answers 8-81    9/12
+ *     wave 6  d=0.400  dw.add.column.subtract-no-regroup  answers to 5400 0/12
+ *     wave 7  d=0.472  dw.mul.scale.times-power-of-ten    answers in the millions
+ *
+ * Waves 1-3 and 6 upward could not put a single keep on the field, so the rack
+ * came back empty, the equation plaque had nothing to draw and the fire button
+ * had no boulder to throw. That is the whole of the bug this window exists to
+ * make impossible: the game now FINDS a rung it can place instead of assuming it
+ * was handed one.
+ */
+export const PLACEABLE_LO = 14
+export const PLACEABLE_HI = FIELD_MAX - 4
+
+/**
+ * How far the dial winds — and it is WIDER than the field, on purpose.
+ *
+ * The dial is the range in still air, and in a wind the child aims off it: to put
+ * a boulder on metre 14 with the wind pushing 9 metres downrange she has to dial
+ * 5, and to put one on 118 against a 9-metre headwind she has to dial 127. If the
+ * dial stopped at the field the compensation would be inexpressible at both ends —
+ * a correct answer she is physically unable to enter, which is the same defect as
+ * a correct answer scored wrong. So the dial carries `WIND_MAX` of slack past
+ * `PLACEABLE_LO..PLACEABLE_HI` at both ends, and `windValues` can never ask for
+ * more than that.
+ *
+ * Nothing lands out there: a shot dialled to 127 into a 9-metre headwind
+ * decelerates the whole way and comes down at 118, and the drawn ground already
+ * runs 40 metres past the field.
+ */
+export const DIAL_MIN = PLACEABLE_LO - WIND_MAX
+export const DIAL_MAX = PLACEABLE_HI + WIND_MAX
+
+/**
+ * How far the dial may be wound IN THIS WIND, so that the metre she is claiming is
+ * a metre that exists.
+ *
+ * The dial reaches past both ends of the field so that the compensation is always
+ * expressible, and that slack has to be paid for at the other end: dialling 5 into
+ * a nine-metre headwind claims metre −4, and a boulder aimed at metre −4 arcs
+ * forward, turns round in mid-air and comes down behind the trebuchet. Found by
+ * sweeping the dial rather than by reading the code, which is the only way this
+ * kind of corner ever turns up.
+ *
+ * So the claim is held inside `1..DIAL_MAX` and the dial's own stops move with the
+ * wind. **This can never bind on a child who is right**, and that is arithmetic and
+ * not a hope: her dial is `answer − wind` with the answer in `PLACEABLE_LO..HI`, so
+ * the tightest corner is `answer = PLACEABLE_LO` in the strongest tailwind, which
+ * asks for exactly `PLACEABLE_LO − WIND_MAX = DIAL_MIN`, the floor itself. Asserted
+ * over every wind and every answer in `verdict.test.ts`.
+ */
+export function dialRange(wind: number): { lo: number; hi: number } {
+  return { lo: Math.max(DIAL_MIN, 1 - wind), hi: DIAL_MAX - Math.max(0, wind) }
+}
 
 /**
  * Where the rival's outwork stands, and how tall.
  *
- * Two things must both be true of it, and neither was:
+ * **A shot at the nearest keep can always be made.** The wall used to be placed
+ * at `max(14, nearest × 0.46)`, which for a keep at 14–17 m is the keep's own
+ * ground — every shot at it hit the wall. And it was sized off a still-air probe,
+ * while a shot that beats a tailwind launches at `answer − wind` and flies lower,
+ * so on windy waves a correctly aimed shot smashed into it. Height is taken from
+ * the LOWEST the loft can ever be over that point — the strongest tailwind the
+ * wave can produce — so a correct shot clears it in any wind.
  *
- *   - **A shot at the nearest keep can always be made.** The wall used to be
- *     placed at `max(14, nearest × 0.46)`, which for a keep at 14–17 m is the
- *     keep's own ground — every shot at it hit the wall. And it was sized off a
- *     still-air probe, while aiming into a tailwind launches at `dial − wind`
- *     and flies lower, so on windy waves a correctly dialled shot smashed into
- *     it. Height is taken from the LOWEST the default loft can ever be over that
- *     point — the strongest tailwind of the wave — so it clears in any wind.
- *   - **The flattest loft should not clear it**, or the lever it exists to teach
- *     is decoration. Height is also kept above the HIGHEST the flattest can be
- *     there. Where those two bounds cross — a keep so near that no wall can do
- *     both — solvability wins and the wall is scenery for that wave.
+ * It no longer has a second job. The old upper bound existed to keep the wall
+ * tall enough that the flattest loft could not clear it, so that the loft lever
+ * had something to be for; the lever is gone and the bound went with it.
  */
 export function wallFor(nearest: number, windCap: number): { x: number; h: number } {
   const x = Math.max(10, Math.min(Math.round(nearest * 0.46), Math.max(10, nearest - 6)))
-  const ceiling = heightAtX(aimShot(nearest, LOFTS[DEFAULT_LOFT], windCap, LAUNCH_H), x)
-  const floor = heightAtX(aimShot(nearest, LOFTS[0], -windCap, LAUNCH_H), x)
-  const h = floor + 0.7 < ceiling - 0.7 ? (floor + ceiling) / 2 : ceiling * 0.78
-  return { x, h: Math.max(4, h) }
+  const lowest = heightAtX(shotFor(nearest - windCap, LOFT_DEG, windCap, LAUNCH_H), x)
+  return { x, h: Math.max(4, lowest * 0.78) }
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
"for trebuchet, we can't figure out what the wind .. are we supposed to shoot it
longer, shorter, ignore it? It seems that usually we just ignore for the best
results but then I'm not sure what the point is. Similarly, is there a point to
changing the angle?"

He is right on both counts, and the measurements are worse than the question.

## What the wind and the loft did before this

Measured over 2,460 shots across waves 1-20, every wind the roll can produce at
every loft:

| | |
|---|---|
| landing metre moved by the wind | **0 / 2460** |
| verdict changed by the wind | **0 / 2460** |
| report changed by the wind | **0 / 2460** |
| landing differed between the five lofts | **0 / 2460** |

And the strategy table, over 492 (wave, wind, answer) cases:

| the child who... | scored right |
|---|---|
| ignores the wind and dials her answer | **492/492** |
| reasons about the wind and aims off | **12/492** |

So ignoring it was not merely optimal, it was the only thing that worked: the
game punished the child who thought about the wind 97.6% of the time. #654 did
that on purpose and for a good reason — the wind used to be a hidden term added
AFTER she committed, which scored a correct answer wrong with probability
1 - 1/cap, 8/9 by wave 16, and filed the metre the wind chose as her answer.
`aimShot` laid the machine off into the crosswind so the boulder came down on the
metre she named. Correct, and it made the wind decoration.

The loft was worse than decoration. Over 1,616 wall situations:

    loft 30deg            blocked by the wall 42.9%
    loft 38deg            blocked by the wall 21.9%
    loft 46deg (default)  blocked  0.0%
    loft 55deg            blocked  0.0%
    loft 65deg            blocked  0.0%

Three of the five settings were indistinguishable from the default and the two
below it could only lose. A five-notch lever whose entire range is "the same, or
worse" is not a choice.

## The wind now costs her a second sum

`shotFor` throws the boulder at the dialled range and the wind carries it
`wind` metres further, so the metre it comes down on is `dial + wind`. She works
out the sum, reads the wind off the chip, and takes it off her answer: answer 72,
arrow pointing away from her with a 5 beside it, dial 67, and the wind pushes it
the last five metres onto 72.

The physical shot is byte-identical to the one #654 fired — the crew was already
launching at `answer - wind` behind her back. All that moved is who does the
subtraction and which number is on the dial.

**Nothing left in this game is something she could not have accounted for.**

  * The wind is an exact integer, displayed, and rolled at exactly two moments,
    both of them before she can see the question: the wave layout and the
    settle->aim handover. Nothing rolls at release, in flight or at impact.
  * `dial + wind` is therefore knowable to the metre before she presses anything.
  * The dial reaches every compensation the wind can ask for. It carries
    `WIND_MAX` of slack past the placeable window at both ends, because a correct
    answer she cannot physically enter is the same defect as one scored wrong.
  * No landing marker is drawn anywhere. `dial + wind` is her arithmetic; a
    landing marker turns the game into sliding a caret onto the right keep.

**What reaches the curriculum is her answer to the SUM.** #654 established that
the dial was reported, because then the dial WAS her answer. It is not any more.
`claimOf(dial, wind)` adds the two numbers she had in front of her — nothing from
the simulation is in it, because the last time this game read the ground to find
out what a child had said, it reported the metre the wind chose. A landing that
disagrees is logged loudly and her claim still wins.

## It arrives on the ladder, not on a wave counter

`windCapFor(difficulty)` is 0 below `WIND_FROM_D` (0.34) and 3..9 above it, and
`WaveConfig` no longer HAS a `wind` field, so there is nowhere left for a wave
number to say how hard the wind blows. The threshold is measured, not chosen:
every one of the 66 shipped rungs, driven through the real generators, banded by
whether a 122-metre field can stand a keep at its answers —

    0.246  PLACEABLE   4..49     tables-to-twelve L0
    0.277  PLACEABLE  27..99     add.column.add-no-regroup L0
    0.292  PLACEABLE   1..82     add.column.subtract-no-regroup L0
    0.323  PLACEABLE   6..72     tables-to-twelve L1
    ---- 0.34: the wind starts here ----
    0.369  PLACEABLE   6..765    add.column.subtract-no-regroup L1
    0.415  PLACEABLE   6..144    tables-to-twelve L2
    0.462  PLACEABLE  33..171    add.regroup.add-multidigit L0

Everything under the line is a table fact or a column sum with no regrouping.
Driving the real ladder through the game's own search:

    wave 1   rung 0.277  answers 98, 87        no wind
    wave 2   rung 0.292  answers 27, 71        no wind
    wave 3   rung 0.308  answers 25, 16        no wind
    wave 4   rung 0.323  answers 16, 30, 45    no wind
    wave 5   rung 0.369  answers 43,80,97,112  WIND, up to 3 metres

Four waves of exactly the game the founder is not complaining about, then the
second step. It holds at three metres from there because the pack's arithmetic
escalation is itself pinned by the 122-metre field — the plateau #702 documented,
not this change's to move. The cap ramps to 9 if the curriculum or the field ever
grows.

## It is explained where it appears

The manual gained a `Wind` section that does the arithmetic on the page, in plain
words, and **the game raises the manual itself the first time the wind blows** —
once a run, between waves, with the answer clock stopped. A mechanic that arrives
silently and starts deciding whether a child is right is the original defect in a
new costume, and the manual is no use to a child with no reason to open it.

The rest of that copy was suspect too: it credited "your crew" for aiming into the
wind, and there is no crew anywhere in this game. Gone, along with the claim it
was making, which is now false. `keep` and `dial` are defined at first use.

## The loft lever is removed

Not given a job. The obvious candidate is clearing the wall, and the wall already
clears itself — `wallFor` sizes it off the LOWEST the loft can ever be over that
point, so a correct shot gets through in any wind, and a wall hit resolves as
though it had landed anyway. The other candidate, making the loft the wind's
multiplier so a higher arc drifts further, would stack a multiplication on top of
the sum and the wind, three steps deep, on a child who is here to practise
47 + 25 — and the complaint is that this game is confusing. `LOFT_DEG` is one
angle, the lever and the arrow keys are gone, and `wallFor` lost the second bound
that existed only to give the lever something to be for.

## Verification

132 tests, 5 runs, `tsc --noEmit` clean, pack build clean. The sweep that matters
walks every wind at every cap against every answer the field can hold — 8,925
shots — and asserts a child who computes correctly and compensates correctly can
enter the dial, lands on the metre she named, is scored right, and is reported
right. A second sweep does the same driven off `windCapFor` across the whole
ladder.

Two defects were found by sweeping rather than by reading:

  * **A boulder could land behind the trebuchet.** Dial 5 into a nine-metre
    headwind claims metre -4; the shot arced forward, turned round in mid-air and
    came down on the crew. `dialRange` holds the claim inside `1..DIAL_MAX` and
    the stops move with the wind. Proved never to bind on a correct answer: her
    dial is `answer - wind`, so the tightest corner asks for exactly `DIAL_MIN`.
  * **The explanation was lost on a run that opened windy.** The constructor lays
    out wave 1 before `mount()` can call `setExplainer`, so raising the manual
    where the wind is rolled called a no-op. Deferred one frame.

Every fix removed in turn, and the exact failure:

| fix removed | failure |
|---|---|
| the crew compensates again (#654) | `the correct child always lands it` — *8925 of 8925 correct shots were punished*; `the wind is not decoration`; `the whole rack can be answered without a false verdict` — *the keep at 110 was named and stayed standing* |
| report the dial, not her claim | `a bullseye stays a bullseye when the dial is nudged mid-flight` — `'76' !== '78'`; `the number reported is her answer to the SUM, not the dial` |
| judge the dial, not her claim | `a bullseye stays a bullseye...` — *a keep struck dead centre is a right answer*; `a wrong dial is never recorded as a right answer` |
| the difficulty gate | `the beginner never meets a wind` — *wave 1 put a wind on a beginner's rung*, `2 !== 0` |
| gate on `waveConfig(n).difficulty` instead of the item's | `the beginner never meets a wind` — *wave 6 put a wind on a beginner's rung*, `3 !== 0` |
| re-roll the wind at release | `a bullseye stays a bullseye...` — `'72' !== '78'`; `the wind does not move between the question appearing and the boulder landing` |
| the dial's slack past the field | `the dial reaches every compensation the wind can ask for` — *wind 9, answer 14: the dial would not go to 5*; *322 of 8925 correct shots were punished* |
| the claim bound in `dialRange` | `nothing the boulder does can carry it off the drawn field` — *dial 5, wind -9: lands at -4* |
| the explainer | `the manual is raised the first time the wind blows` — `0 !== 1` |
| the one-frame deferral | `the manual is raised the first time the wind blows` — `0 !== 1` |
| put the loft lever back | `the loft lever is gone, and nothing took its place in the corner`; and 15 × `every control is inside the safe rect` |

One line is honestly uncovered and says so in place: swapping `fired.wind` for
`this.wind` at impact leaves all 132 tests green, because nothing can roll the
wind between release and impact today. It stays because the dial was in exactly
that position before #661, and because the realistic version of the failure — a
wind rolled at release — is caught by four tests.

**Needs a device.** The wind readout is a new shape on the glass (a bordered pill
where a bare arrow used to float) and the arrow no longer runs off the left of the
readout on a leftward wind; `layout.test.ts` covers geometry at every viewport the
fleet has but not legibility at arm's length. The manual opening itself mid-run is
the other thing to watch: it is the right behaviour and it is still an overlay
appearing unasked.



https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
