### PR TITLE
dynawalla: an abstract interface to the native side, and device tilt as its first case

### DIFF
--- a/dynawalla/docs/DECISIONS.md
+++ b/dynawalla/docs/DECISIONS.md
@@ -63,6 +63,7 @@ saying what changed, so the history is readable without `git log`.
 | [0021](DECISIONS/ADR-0021-pack-capabilities-are-per-pack.md) | Capability is per pack; the microphone stays closed | Accepted |
 | [0022](DECISIONS/ADR-0022-host-ships-no-content.md) | The host ships no content; packs are the product | Accepted |
 | [0024](DECISIONS/ADR-0024-day-pass-not-subscription.md) | The day pass replaces the subscription | Accepted |
+| [0025](DECISIONS/ADR-0025-native-capability-interface.md) | The native side is reached through the pack capability seam | Accepted |
 
 ## Reversed on 2026-07-26
 
@@ -106,6 +107,12 @@ Four ADRs closed in one pass, recorded from the founder's own words in each ADR:
   analytics or SDKs) are locked unconditionally; a parental-gate primitive is built and
   every link-out routes through it; the category election, **and the age band inside
   it**, are deferred to submission.
+
+- **ADR-0025 The native side is reached through the pack capability seam** — a pack is
+  never handed a sensor, a socket, a token or an `invoke`; a native capability is a row
+  in the same closed table, and **a capability is never delivered by relaxing the
+  sandbox**. Grant and availability become two different questions. The contract is
+  [NATIVE_CAPABILITIES.md](NATIVE_CAPABILITIES.md).
 
 ## Still open
 

--- a/dynawalla/docs/DECISIONS/ADR-0025-native-capability-interface.md
+++ b/dynawalla/docs/DECISIONS/ADR-0025-native-capability-interface.md
@@ -1,0 +1,98 @@
+# ADR-0025 — The native side is reached through the pack capability seam, never directly
+
+**Status:** Accepted
+**Date:** 2026-07-29
+**Related:** [ADR-0021](ADR-0021-pack-capabilities-are-per-pack.md),
+[ADR-0020](ADR-0020-content-packs-are-the-product.md),
+[ADR-0022](ADR-0022-host-ships-no-content.md),
+[ADR-0011](ADR-0011-native-workspace-and-patch-placement.md),
+[ADR-0001](ADR-0001-kids-category-posture.md)
+
+## Context
+
+ADR-0021 lifted the blanket ban on the microphone, an on-device model and 3D, and
+said capability is decided per pack at the boundary. It did not say *how* a pack
+reaches a device capability, because at the time none of them did.
+
+`corpan/plugins/` holds eleven Tauri plugins — text to speech, three speech
+recognisers, an on-device LLM runtime, haptics, audio keep-alive. Dynawalla's
+`src-tauri/Cargo.toml` declares two of them. The native surface exists and this
+product uses almost none of it.
+
+The founder's direction:
+
+> "we will need more bidirectional communication between the native side and the
+> games in the future. We sort of forgot about LLMs and TTS and other possible
+> things we may utilize from the native side. In the end, **every game shouldn't
+> just be a browser game** … **I think we should make a sort of abstract
+> interface to the native side**."
+
+> "**Look at all of the native features packs in corpan can use** … we don't want
+> to limit ourselves to webview only for every game forever. **The host should be
+> able to provide elegant interfaces that the games can use if they want to.**"
+
+And a concrete request already blocked: ARENA wants real online competition, and
+VOLTA wants tilt steering and cannot have it.
+
+## Decision
+
+**A pack reaches the native side only through the existing capability seam. There
+is no second channel, and there will not be one.**
+
+Concretely:
+
+1. **A native capability is a row in the same table** as every other
+   (`packs/sdk/src/capabilities.ts`), marked `native: true`, with a declared
+   `budgetMs`. It is declared in a manifest, granted by `gateRun`, and enforced by
+   `bridge.ts`, exactly like `storage` or `haptics`.
+2. **A pack is never handed the thing itself.** Not a sensor, not a socket, not a
+   token, not an `invoke`. It is handed a value or a stream over its port. The
+   host holds the resource and the credential.
+3. **Grant and availability are different questions.** A native capability stays
+   in `HOST_SUPPORTS` once the build implements it, whatever a particular device
+   can do. Absence is `Connect.available` at runtime, and a stream may still end
+   `unavailable` after starting.
+4. **Absence is loud to the developer and invisible to the child.** The SDK's
+   native surfaces never throw and never reject; each absent path writes one
+   `console.error` naming the capability and the fix.
+5. **Consent is asked for by the host, in the host's document, from a real user
+   gesture, at most once per install.** A pack has no user activation to lend and
+   no origin to hold a grant.
+6. **Nothing native outlives a pack.** Teardown ends every stream and releases
+   every source, and a paused pack receives nothing.
+
+The contract, with worked examples for text to speech, an on-device model and a
+leaderboard socket, is [`../NATIVE_CAPABILITIES.md`](../NATIVE_CAPABILITIES.md).
+
+### Rejected: widening the pack frame
+
+`allow="gyroscope; accelerometer"` on the pack frame would have delivered tilt
+steering in one line. It is rejected: it grants motion sensors to all
+twenty-eight installed packs in order to serve one, and `frame.ts` states what
+that attribute protects. The same reasoning rejects adding a remote origin to the
+pack CSP's `connect-src` to give a game a socket — verified as the single
+directive that closes the network today, in `src-tauri/src/packs/mod.rs`.
+
+The general form: **a capability is never delivered by relaxing the sandbox.** If
+the boundary has to move to serve one pack, the answer is a host-owned capability
+instead.
+
+## Consequences
+
+- Every native capability costs a host PR. That is the intended price: the list
+  of what a pack can reach stays a closed, reviewable table, and ADR-0021's
+  "the host grants only what it uses" survives contact with eleven plugins.
+- **A capability whose only source is a web API is still a capability.**
+  `sensors.orientation` ships with a `DeviceOrientationEvent` source and a port
+  shaped for the plugin that replaces it. The seam is what is being fixed; where
+  the bytes come from is an implementation detail that may change once.
+- The first capability that introduces a real Tauri plugin pays the ACL tax: a
+  command grant in `capabilities/default.json`, a row in `permissions.ts`, and a
+  serde round-trip test. Registering a plugin without the grant is denied at
+  runtime with everything compiling.
+- `SDK_VERSION` becomes a thing that moves. A pack built against 1.1 does not run
+  on a 1.0 host, by design.
+- **A leaderboard is not only an engineering decision.** Real players means
+  visible handles, and anything identifying collected from under-13s is a
+  compliance question (COPPA; `G-01` is still open). Recorded in the contract as a
+  constraint for the founder to choose deliberately rather than discover.

--- a/dynawalla/docs/NATIVE_CAPABILITIES.md
+++ b/dynawalla/docs/NATIVE_CAPABILITIES.md
@@ -1,0 +1,493 @@
+# Native capabilities
+
+**What this is.** The contract a pack and the host agree on when the answer comes
+from the *device* rather than from the host's own TypeScript: a sensor, a speech
+synthesiser, an on-device model, a socket. One capability is built against it
+today (`sensors.orientation`); this document is what the next five get built
+against, and the shape is the deliverable rather than the feature.
+
+**Read this first if you are adding one.** The checklist at the end is short and
+every line of it is a mistake this repository has already made.
+
+---
+
+## The seam that already existed, and whether it was the right shape
+
+A pack reaches the host through one `MessagePort` into an opaque-origin
+sandboxed iframe. Everything it may ask for is a closed table
+(`packs/sdk/src/capabilities.ts`), every method belongs to exactly one
+capability, and the bridge (`dynawalla-app/src/packs/bridge.ts`) is the only
+thing on the other end of the port.
+
+**That was already the abstract interface, and it was 80% of the right one.**
+Declare / grant / gate / dispatch needed no reshaping at all: a native capability
+is a row in the same table, a string in the same manifest field, and an arm in
+the same `switch`. The parts that had to change are the parts that only matter
+when an answer is slow, repeated, refusable, or physically absent — and there
+were four of them.
+
+| | Before | Now |
+|---|---|---|
+| **Latency** | Every method answered in microseconds. No deadline anywhere: a host that dropped a request left the pack holding a promise that never settled. | `budgetMs` per capability, declared in the table. The guest arms a timer from it and rejects with `timeout`. 2s for a store read, 10s for something that may have to ask a person for permission. |
+| **Streaming** | Not expressible. `Response` is one-shot; `HostEvent` is four names with no correlation to anything a pack asked for. | A third envelope: `StreamUpdate` / `StreamEnd`, correlated by a handle that **is** the request id. |
+| **Cancellation** | Not expressible. The only way to stop anything was to end the session. | `stream.cancel`, a session method — not a grant, because a pack that cannot stop a stream leaves a sensor running after a child has left. |
+| **Absence** | Conflated with grant. `HOST_SUPPORTS` is a compile-time list, and `gateInstall` *refuses the install* of a pack asking for something not in it. | `Connect.available`, a runtime intersection. Grant and availability are two questions, and a native capability stays in `HOST_SUPPORTS` forever once implemented. |
+
+The fifth — **permission** — needed no protocol change at all, only a rule, and
+the rule is the interesting part. It is below.
+
+Nothing about the existing seam had to be replaced. That is the finding: a
+capability table plus a validated port generalises to native work, provided the
+envelope grows a stream and the table grows a budget.
+
+---
+
+## The five properties, and where each one lives
+
+### 1. Latency — declared, not discovered
+
+`budgetMs` is a field on the capability row. A pack does not have to guess how
+long something might take, and a host that hangs is a `timeout` rather than a
+loading screen forever.
+
+- Declared: `packs/sdk/src/capabilities.ts` → `budgetOf(method)`.
+- Enforced: `packs/sdk/src/guest.ts` → the timer in `call`.
+- Asserted: every method has a finite budget ≤ 30s, and every native capability
+  is allowed strictly longer than the slowest local one.
+
+**A pack must never block a frame on a native call.** Nothing in the seam makes
+that impossible; the promise is a promise and the game loop keeps running. What
+the budget buys is that the promise *settles*.
+
+### 2. Streaming — one envelope, one handle
+
+```
+pack → host   { id: 7, method: "sensors.orientation.start", params: {} }
+host → pack   { id: 7, ok: true, result: { stream: 7 } }
+host → pack   { stream: 7, seq: 1, data: {...} }
+host → pack   { stream: 7, seq: 2, data: {...} }
+pack → host   { id: 8, method: "stream.cancel", params: { stream: 7 } }
+host → pack   { stream: 7, done: true, reason: "cancelled" }
+```
+
+The handle is the request id: no second namespace, no allocation, and the pack
+already holds the number. Two guarantees the host owes:
+
+- **Exactly one end**, always, with a reason — `complete`, `cancelled`,
+  `unavailable`, `closed`, `internal`. A stream that goes quiet without an end is
+  a host bug. (A start cancelled *while it was still starting* never became a
+  stream the pack knows about, and gets no end.)
+- **`seq` monotonic from 1.** A gap is a deliberate drop — throttled, or
+  delivery suspended while the pack was paused. Nothing is retransmitted.
+
+`PROTOCOL_VERSION` is **not** bumped by this. A stream envelope carries neither
+`id`+`ok` nor `event`, so a 1.0 pack ignores one; and a 1.0 pack never opens a
+stream, so it never receives one. `SDK_VERSION` goes to 1.1.0, which is what
+`sdkCompatible` reads: a 1.0 pack runs on a 1.1 host, a 1.1 pack is refused by a
+1.0 host.
+
+### 3. Cancellation — and the two things it is not
+
+`stream.cancel` is ungated and idempotent, and says nothing about what it found:
+a pack must not be able to learn whether a handle it invented was real.
+
+Beyond it, two host-side guarantees, because a pack cannot be trusted to be the
+only thing that stops a sensor:
+
+- **`pause` suspends delivery.** A game steering behind the day-pass sheet is a
+  game the child is not playing. Samples are **dropped, not queued** — a buffer
+  of stale tilt delivered on resume would snap whatever it steers across the
+  screen. `frame.ts`'s `send` → `Bridge.setPaused`.
+- **Nothing outlives the pack.** `dispose` calls `bridge.close()`, which ends
+  every stream `closed` and releases every source, *before* the port dies.
+
+### 4. Absence — loud to the developer, invisible to the child
+
+Four layers, and the important one is the third.
+
+1. **`HOST_SUPPORTS`** (`library.ts`) — what this *build* implements. A native
+   capability belongs here as soon as the build implements it and **must never be
+   removed to describe a device that cannot do it.** This list feeds
+   `gateInstall`, which refuses the *install*; dropping `sensors.orientation`
+   would stop a tablet with no gyroscope installing the pack rather than letting
+   the pack run without tilt.
+2. **The manifest's `capabilities`** — what the pack asked for. `gateRun`
+   intersects the two every launch, and the result is `Connect.granted`.
+3. **`HostServices.available()`** — what this *device* can do, right now. The
+   frame intersects it with `granted` and sends `Connect.available`. It is a
+   `Record<NativeCapability, boolean>` in `services.ts`, so **adding a native
+   capability fails to compile** until somebody decides how to detect it.
+4. **A stream that ends `unavailable`** — the case that only shows up after
+   starting. `typeof DeviceOrientationEvent !== "undefined"` is true in every
+   desktop browser with no sensor anywhere near it; what settles it is whether a
+   reading with numbers in it ever arrives (`orientation.ts`, the warm-up).
+
+**What a pack must do.** Nothing, in the failure case — which is the design.
+The SDK's native surfaces never throw and never reject:
+
+```ts
+const host = await connect()
+
+// Only needed before DRAWING a control that would otherwise be a lie.
+if (host.available("sensors.orientation")) showTiltToggle()
+
+// Never throws. On a device that cannot, the handler is simply never called.
+const stop = host.tilt.start((sample) => steer(sample.x, sample.y))
+```
+
+and every absent path writes **one** loud `console.error` naming the capability
+and what to do about it. `console.error` because Vite's dev client forwards
+errors to the terminal and nothing else, and on a device that line is what
+reaches a WebInspector session. Once per reason per pack, because a game loop
+would print it sixty times a second.
+
+Four packs have shipped blank in this repository and every one of them was quiet
+about it. A tablet with no gyroscope is not a fault and a child must never see a
+message about one; a developer whose tilt control silently does nothing must.
+
+### 5. Permission — the host asks, on a gesture, in its own document
+
+The constraint, which is not going away: **a pack has no user activation to lend
+and no origin to hold a grant.** iOS requires transient user activation for
+`DeviceOrientationEvent.requestPermission()` and remembers the answer per origin.
+Activation does not cross a `postMessage`, and a pack's origin is opaque — not
+something a grant can be remembered against.
+
+So the rule, for this and for every native capability that needs consent:
+
+> **The host asks, in the host's own document, from a real user gesture, at most
+> once per install, and only when a pack that declared the capability is being
+> launched. The pack is told the outcome as `available` and never the reason.**
+
+Implemented as `primeOrientationPermission()` (`app/platform.ts`) called from
+`useLaunch.play` (`packs/Stage.tsx`) — which runs synchronously inside the tap on
+a pack's card, the last real gesture before the pack exists. A child playing the
+other twenty-seven games is never shown a prompt about a sensor.
+
+A refusal, a throw and a silence are all treated as the same answer: *this device
+cannot*. The capability degrades to absent rather than to broken.
+
+---
+
+## What landed, and what is unproven
+
+`sensors.orientation` — the host reads the tilt and posts it, exactly as it
+already measures the safe-area insets a pack cannot see.
+
+A pack is granted **no sensor**, and cannot be: the frame is
+`sandbox="allow-scripts"` with no `allow-same-origin` (opaque origin) and
+`allow=""` (every policy-controlled feature off), so `DeviceOrientationEvent` is
+unreachable from a pack twice over. `allow="gyroscope; accelerometer"` on the
+pack frame was rejected: it hands motion sensors to all twenty-eight installed
+packs to serve one, and `frame.ts` says out loud what that line protects.
+
+What crosses the port is two numbers in −1..1 and their angles. A sample says
+**which way a marble sitting on the screen would roll**. No compass heading, no
+magnetometer, no rotation rate, no acceleration — nothing that could become a
+claim about where a child is or which way they are facing.
+
+**Proven by tests, in Node, with no device:** the neutral pose (nobody plays with
+a tablet flat on a table), the wrap at ±180 (a device held near the seam that
+rocks two degrees must not read as a 358° swing), the re-zero when a tablet is
+turned, the dead zone (subtracted, not clipped), the throttle, the change gate,
+the null-readings case, the warm-up, the permission refusal paths, the stream
+lifecycle end to end over a real `MessagePort`, and that no sensor outlives a
+pack.
+
+**Not proven, and needs hardware:**
+
+- **Whether `deviceorientation` fires at all inside iOS WKWebView.** Quite
+  possibly it does not: `requestPermission` may be absent, may resolve `denied`
+  regardless, and motion in a WKWebView has historically needed app
+  configuration Tauri does not expose. Every branch treats that as absence.
+- **`SCREEN_ROTATION`** — the four signs mapping the device's frame onto the
+  screen's are read off the Screen Orientation specification, not measured. It is
+  deliberately one table with four one-line rows so a correction from a device is
+  a one-line change with a failing test to point at. Portrait (`angle` 0) is the
+  row every other claim rests on.
+
+**The source today is a web API, not a plugin, and that is a first step rather
+than the finished shape.** `OrientationPorts` is the interface a
+`tauri-plugin-orientation` reading CoreMotion and Android's `SensorManager`
+implements, and nothing above `app/platform.ts` changes when it lands. This
+capability therefore adds **zero new Tauri IPC surface** — no command, no
+`capabilities/default.json` entry, no Rust. The first native capability that does
+hits every trap in the checklist below.
+
+---
+
+## Worked example: text to speech
+
+`tauri-plugin-tts` already exists in `corpan/plugins/`. The shape it would take:
+
+```ts
+{
+  id: "speech",
+  methods: ["speech.say"],
+  label: "Read words out loud",
+  budgetMs: 10_000,   // a voice may have to be loaded
+  native: true,
+}
+```
+
+`speech.say` is a **stream method**: `{ stream }` back immediately, then
+`{ seq, data: { boundary: "word", index: 4 } }` as it speaks, then
+`{ done: true, reason: "complete" }` when the utterance finishes. `stream.cancel`
+is how a child leaving a screen stops a voice mid-sentence — which is the whole
+reason cancellation is ungated.
+
+What the shape forces you to get right:
+
+- **Absence is normal.** A device with no voice for the child's locale is not an
+  error. `available()` asks the plugin for the voice list at startup; a locale
+  with no voice is `speech` unavailable, and a game that drew a "read it to me"
+  button without checking `host.available("speech")` has drawn a lie.
+- **`pause` must stop the voice.** Suspending *delivery* is not enough here: the
+  audio is native and does not care about the port. This is the first capability
+  where `setPaused` has to reach through to the source, and the `Bridge` should
+  grow a `suspend`/`resume` on the source rather than only gating `emit`. **Write
+  that down when you build it; the current `setPaused` only drops messages.**
+- **One utterance at a time, or `MAX_OPEN_STREAMS` is the wrong bound.** Four
+  concurrent voices is four voices.
+
+## Worked example: an on-device model
+
+```ts
+{
+  id: "llm.generate",
+  methods: ["llm.generate"],
+  label: "Make up new puzzles on this device",
+  budgetMs: 30_000,
+  native: true,
+}
+```
+
+Streams tokens; `stream.cancel` when the child leaves. Reuse Corpán's RAM
+tiering (a 4B model silently OOM-crashed low-memory phones — that is a real
+incident, not a hypothesis), so `available()` is **RAM-tiered**: the same build
+on two tablets answers differently, which is exactly why availability is a
+runtime fact and not a build constant.
+
+Three constraints that are the product rather than the plumbing:
+
+- **A wrong sentence must be harmless where it is used.** ADR-0021 already says
+  this. The model never decides whether a child's answer is right — the host owns
+  the mathematics (ADR-0023) and `items.answer` is the only judge.
+- **Never on the critical path.** A child waiting thirty seconds for a question
+  is a child who has left. Generate ahead, behind a `Random` fallback that is
+  already good enough for almost everything.
+- **The budget is a real deadline, not a formality.** 30s is the ceiling in the
+  table; a game should be asking with much less patience than that and drawing
+  something else meanwhile.
+
+---
+
+## Worked example: networking, a leaderboard, and ARENA
+
+**Design only. Nothing here is built, and one part of it is a product decision
+rather than an engineering one.**
+
+### Can a pack open a socket today? No — verified
+
+The answer is no, and the reason is worth knowing exactly, because it is one line
+of Rust rather than an emergent property.
+
+A pack document is served by the app's own scheme handler, which sets the pack's
+CSP explicitly — `dynawalla-app/src-tauri/src/packs/mod.rs`, `pack_csp()`:
+
+```
+default-src 'none'; … connect-src dynawalla-pack: http://dynawalla-pack.localhost; …
+```
+
+`connect-src` is the directive that governs `WebSocket` as well as `fetch` and
+`XHR`, it is explicitly set (so there is no `default-src` fallback to argue
+about), and it names no remote origin and no `ws:`/`wss:` source. A
+`new WebSocket("wss://…")` inside a pack is refused by the WebView.
+
+Three corrections to the obvious reading of this:
+
+- **It is the *pack's* CSP that closes it, not the app's.** A nested browsing
+  context does not inherit its parent's policy; a document loaded from
+  `dynawalla-pack://` gets the policy in its own response headers. The app's own
+  `connect-src` in `tauri.conf.json` is irrelevant to what a pack can reach.
+- **The sandbox alone would not have closed it.** `sandbox="allow-scripts"`
+  without `allow-same-origin` gives an opaque origin — which means no cookies and
+  no credentials, so there is no session a pack could authenticate with — but it
+  does not block `WebSocket`. The CSP is the gate.
+- **There is no side channel either.** `img-src`/`media-src` admit only the pack
+  scheme plus `blob:`/`data:`, `form-action` and `frame-src` are `'none'`, and a
+  `blob:` Worker inherits the creating document's policy. A pack cannot
+  exfiltrate a score, let alone open a connection.
+
+**This is not a security finding; it is a finding about fragility.** The whole
+boundary is that one directive, and the temptation when a leaderboard is wanted
+will be to add its origin to it — which grants arbitrary network reach to all
+twenty-eight installed packs in order to serve one. Two tests were hardened in
+this PR because neither would have caught it:
+`src-tauri/src/packs/tests.rs::a_pack_cannot_open_a_socket_either` now pins
+`connect-src` to equality, and `src/app/capabilities.test.ts`'s origin scan now
+matches `ws:`/`wss:` — it previously matched only `https?://`, so `wss://arena…`
+would have gone straight past it in both places.
+
+### So where does the socket live?
+
+**In Rust, and the host owns exactly one connection.** Not merely "should" —
+*can only*. The app's own document is under
+`connect-src 'self' ipc: http://ipc.localhost`, and `capabilities.test.ts` fails
+the build on a remote origin appearing there. Both WebViews are closed by
+policy; the only place a socket can exist is the native side, which is also the
+only place a credential can be kept out of reach of every pack.
+
+Shape, following everything above:
+
+```ts
+{
+  id: "contest",
+  methods: ["contest.join", "contest.submit"],
+  label: "Play against other people and appear on a leaderboard",
+  budgetMs: 15_000,
+  native: true,
+}
+```
+
+`contest.join` opens a stream. Everything the server pushes — a rival's score, a
+round starting, the board changing — arrives as `StreamUpdate`. `contest.submit`
+is an ordinary request/response.
+
+### Does the capability shape actually hold up here?
+
+Point by point, because if it does not, it is the wrong shape and better to know
+now.
+
+- **Long-lived connection state.** Held by the host, in Rust, for the app rather
+  than for a pack. A stream is a *view* of it: two packs joining get two streams
+  over one socket, and a pack's stream ending never closes the socket. The
+  envelope needs nothing new.
+- **Server-pushed events.** `StreamUpdate` with no request in flight is exactly
+  this. This is the case the old seam could not express at all.
+- **Reconnection and offline.** The gap the envelope does *not* currently cover.
+  A stream has exactly one end, so "the socket dropped and is retrying" cannot be
+  `StreamEnd` — that would tell a pack the contest is over when it is not. It
+  needs a **liveness value inside the stream**, not a new envelope: every update
+  carries `{ state: "live" | "reconnecting" | "offline", … }`, and the pack draws
+  the leaderboard greyed rather than gone. **A leaderboard must never lie**: a
+  stale board shown as current is worse than one shown as stale, and a child on a
+  phone in a car loses signal every few minutes. Corpán's rule applies directly —
+  *never block an offline subscriber* — so a child who is offline keeps playing
+  and keeps earning, and their score reconciles when the socket returns.
+- **Authenticated identity.** No existing capability needs one, and this is where
+  the design has to be deliberate rather than incremental. The credential lives in
+  Rust and **never crosses the port**. A pack is never given a token; it gets a
+  stream. This falls out of the shape rather than being bolted on, and it is the
+  strongest argument for the host owning the connection.
+- **A shared clock.** The server's, carried in the stream, never the device's. A
+  device clock is a thing a child can change, and any time-ranked score computed
+  from one is a score computed from a setting.
+- **Backpressure.** `MAX_REQUESTS_PER_SECOND` (120) already bounds what a pack
+  can send *to the host*, and it is far too generous for something that leaves
+  the device. A network capability needs its own, much smaller budget —
+  submissions are per-answer, not per-frame — and the host must coalesce rather
+  than forward. Worth a `submitsPerMinute` on the capability row, in the same
+  spirit as `budgetMs`.
+
+**Verdict: the shape holds, with one addition** — a liveness field inside a
+stream's payload, so that "degraded" is expressible without ending the stream.
+That is a payload convention rather than a protocol change, and naming it here is
+the point of writing the example down before building it.
+
+### Two things for the founder to decide, not for us
+
+**1. A leaderboard in a children's product is a compliance decision before it is
+an engineering one.** Real players means visible handles. Scores are innocuous;
+names, chat and free text are not, and collecting anything identifying from
+under-13s carries real regulatory weight (COPPA in the US, and ADR-0001's Kids
+Category posture is still open at `G-01`). A **scores-and-a-chosen-handle-only**
+surface with no free text, no chat, no avatars and no way for one child to send
+another child anything is a very different product from anything social — and it
+is achievable. Handles drawn from a generated word list rather than typed removes
+the last free-text field. This should be chosen deliberately now rather than
+discovered at submission.
+
+**2. Infinite thinking time and a live leaderboard are in tension, and the
+tension is the good part.** The founder wants both: *"infinite time for the
+problems even to the point of stepping away and working on it for a few
+minutes"* and real-time competition. Ranking by throughput destroys exactly the
+behaviour he is trying to reward — a child who spends eleven minutes doing long
+division on paper would be beaten by one tapping single-digit sums.
+
+The observation that resolves it: **rank by difficulty conquered, not by rate.**
+`Item.difficulty` is already a 0..1 ordinate across the host's whole ladder and
+already relative, so it already moves as the curriculum grows. A board ranked on
+the hardest thing a child has *correctly* answered, with volume as the
+tiebreaker, pays for the eleven minutes and pays nothing for speed. Time can
+still matter without being the ranking — a per-item stopwatch shown to nobody but
+the child, as a personal best.
+
+That is a design opinion, offered rather than decided. What the doc is asserting
+is narrower: **whatever the ranking is, it must not be throughput**, or the
+feature undoes the behaviour it exists to reward.
+
+---
+
+## Checklist for adding a native capability
+
+1. **A row in `packs/sdk/src/capabilities.ts`** with `native: true`, a
+   `budgetMs`, a parent-readable `label` (`labelOf` is asserted to be a sentence,
+   not jargon), and its methods. Add streaming methods to `STREAM_METHODS`.
+2. **A branch in `HostServices`** (`bridge.ts`) and a dispatch arm. Streaming
+   ones go through `openStream`, which already handles the quota, the cancel
+   arriving during a permission prompt, and the source refusing.
+3. **An entry in `services.ts`'s availability `Record`.** It will not compile
+   without one — that is deliberate.
+4. **Add it to `HOST_SUPPORTS`.** Never remove it later to describe a device.
+5. **Bump `SDK_VERSION`'s minor.** Not `PROTOCOL_VERSION`, unless an envelope
+   shape changed in a way an old pack would misread.
+6. **A port, in `app/platform.ts`,** so the decision is testable in Node with no
+   WebView. Follow `HapticPorts` and `OrientationPorts`: required rather than
+   defaulted at the call site, because a defaulted port makes "nobody wired it"
+   compile and look exactly like a device that cannot.
+7. **A guest surface that cannot throw.** Absence is not an error path.
+8. **If it needs consent, the host asks it, on a gesture, in the host's
+   document.** Never from a pack.
+
+### The traps, when it becomes a real plugin
+
+None of these bite the orientation capability, because it adds no IPC. All of
+them bite the first one that does.
+
+- **A Tauri plugin needs a capability grant.** Registering the plugin is not
+  enough: without an entry in `src-tauri/capabilities/default.json` the invoke is
+  **denied at runtime** with everything compiling perfectly. Grant the single
+  command (`tts:allow-speak`), never `<plugin>:default` — `capabilities.test.ts`
+  fails the build on `:default` and on a grant/call mismatch in either direction.
+  Add the row to `src/app/permissions.ts` in the same commit.
+- **The Rust wire format silently drops unknown serde fields, in both
+  directions.** A field added on one side vanishes with no error. Round-trip it
+  in a test.
+- **`links =` must be unique** across every crate in the graph. Two crates
+  declaring the same value is a hard resolve error that often surfaces only on
+  device. Every plugin here uses `links = "<crate-name>"`.
+- **Never add a `[workspace]` and never move a `[patch]`.** ADR-0011.
+  `dynawalla-app/src-tauri/Cargo.toml` is its own implicit workspace root, and
+  hoisting either app's patches into a shared one silently reverts Corpán to an
+  `ndk-context` that aborts on Android Activity recreation — compiling, testing
+  and clippying clean the whole way. `capabilities.test.ts` asserts the absence
+  of a `[workspace]` section here.
+- **`cargo check` both shipping targets.** `#[cfg(target_os = "android")]` and
+  `ios` arms are where the JNI and Swift bridges live and they are not compiled
+  on macOS. Nothing in CI builds Android at all.
+
+## Files
+
+| | |
+|---|---|
+| The capability table, budgets, stream methods | `packs/sdk/src/capabilities.ts` |
+| Envelopes, guards, the `Orientation` payload and its constants | `packs/sdk/src/protocol.ts` |
+| The pack's client: deadlines, stream demux, `tilt`, the loud lines | `packs/sdk/src/guest.ts` |
+| The enforcement point: gating, streams, pause, teardown | `dynawalla-app/src/packs/bridge.ts` |
+| The sandbox, the handshake, `Connect.available`, teardown | `dynawalla-app/src/packs/frame.ts` |
+| Availability, and the native surface implemented | `dynawalla-app/src/packs/services.ts` |
+| The tilt itself: neutral pose, wrap, screen rotation, throttle, warm-up | `dynawalla-app/src/packs/orientation.ts` |
+| The ports, and the permission asked on a gesture | `dynawalla-app/src/app/platform.ts` |
+| What the build supports (never what a device supports) | `dynawalla-app/src/packs/library.ts` |
+| The pack's CSP — the network boundary, in one directive | `dynawalla-app/src-tauri/src/packs/mod.rs` |

--- a/dynawalla/docs/README.md
+++ b/dynawalla/docs/README.md
@@ -25,6 +25,11 @@ Read in this order on your first task. Skim headings after that.
   reactions, the character, construction, art direction and the hostile reference board.
 - [PACK_SYSTEM.md](PACK_SYSTEM.md) — why V1 has no downloadable packs and what would
   have to be true to add them.
+- [NATIVE_CAPABILITIES.md](NATIVE_CAPABILITIES.md) — the contract for a capability
+  answered by the *device* rather than by the host: how it is declared, granted,
+  versioned, feature-detected, and what a pack must do when it is absent. Worked
+  examples for text to speech, an on-device model and a leaderboard socket.
+  **Read before adding one.**
 - [RELEASE_ENGINEERING.md](RELEASE_ENGINEERING.md) — CI topology, the merge queue,
   release triggers, build numbers, the traps.
 - [TEST_STRATEGY.md](TEST_STRATEGY.md) — what is tested where, and what tests cannot

--- a/dynawalla/docs/STATUS.md
+++ b/dynawalla/docs/STATUS.md
@@ -71,6 +71,9 @@ where they will be read before the mistake is made:
 |---|---|
 | The reset: strip the host, reverse ADR-0003 / ADR-0004, record ADR-0022 | this PR |
 | The pack runtime — install, verify, update, remove, mount | not started; top of the queue |
+| The native capability seam ([ADR-0025](DECISIONS/ADR-0025-native-capability-interface.md), [NATIVE_CAPABILITIES.md](NATIVE_CAPABILITIES.md)) — stream envelope, per-capability budgets, runtime availability, and `sensors.orientation` as its first case | landed; the source is a web API and the plugin behind it is not written |
+| A `tauri-plugin-orientation` behind `OrientationPorts` — the first native capability with real IPC, and the first to pay the ACL tax | not started |
+| Real online competition in ARENA — designed in [NATIVE_CAPABILITIES.md](NATIVE_CAPABILITIES.md), **not built**; blocked on two founder decisions (a handles-and-scores-only surface, and a ranking that is not throughput) | design only |
 | Founder decisions recorded in ADRs 0001 / 0013 / 0015 / 0017 | done 2026-07-25 |
 | Repository-license research ([ADR-0014](DECISIONS/ADR-0014-repository-license.md)) | commissioned 2026-07-25, recommendation pending |
 | Standards-alignment research ([ADR-0010](DECISIONS/ADR-0010-standards-alignment-claim.md)) | commissioned 2026-07-25, recommendation pending |

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
@@ -258,6 +258,34 @@ fn the_pack_policy_admits_no_remote_origin_and_never_says_self() {
 }
 
 #[test]
+fn a_pack_cannot_open_a_socket_either() {
+    // The test above checks for `https://` and for a stray `http://`, and would
+    // have watched `wss://` go straight past — `"wss://"` does not contain
+    // `"http"` and does not contain `"ws://"`.
+    //
+    // That is not a hypothetical gap. `connect-src` is the directive that governs
+    // `WebSocket`, and the first network capability this product is likely to
+    // want is a leaderboard socket for ARENA. The obvious wrong way to build one
+    // is to add its origin here, which hands every installed pack arbitrary
+    // network reach in order to serve one of them — and the pack boundary is
+    // exactly this string. See `docs/NATIVE_CAPABILITIES.md`.
+    //
+    // Pinned to equality rather than to a list of things it must not contain, so
+    // that any added source fails rather than only the ones somebody thought of.
+    let policy = pack_csp();
+    let connect = policy
+        .split(';')
+        .map(str::trim)
+        .find(|d| d.starts_with("connect-src"))
+        .expect("connect-src");
+    assert_eq!(
+        connect,
+        format!("connect-src {SCHEME_SOURCES}"),
+        "a source was added to the directive that governs fetch, XHR and WebSocket"
+    );
+}
+
+#[test]
 fn scripts_are_external_only_and_wasm_is_allowed() {
     let policy = pack_csp();
     let script = policy

--- a/dynawalla/dynawalla-app/src/app/capabilities.test.ts
+++ b/dynawalla/dynawalla-app/src/app/capabilities.test.ts
@@ -21,6 +21,20 @@ const tauriRoot = path.resolve(here, "../../src-tauri")
 const readJson = (file: string): Record<string, unknown> =>
   JSON.parse(fs.readFileSync(path.join(tauriRoot, file), "utf8")) as Record<string, unknown>
 
+/**
+ * Every origin in a policy that could reach off the device.
+ *
+ * `ws:` and `wss:` are in the pattern and were not, which was a hole rather than
+ * an omission: the first real network capability this app is likely to grow is a
+ * leaderboard socket (see `docs/NATIVE_CAPABILITIES.md`), the obvious wrong way
+ * to build it is `connect-src wss://…` in this file, and an `http`-only scan
+ * would have watched that go past. There is no `wss:` source here today and this
+ * is what keeps it that way.
+ */
+export function remoteOrigins(policy: string): string[] {
+  return [...policy.matchAll(/(?:https?|wss?):\/\/[^\s;]+/g)].map((match) => match[0])
+}
+
 const config = readJson("tauri.conf.json")
 const capability = readJson("capabilities/default.json")
 
@@ -53,8 +67,8 @@ test("the CSP is non-null and closed by default", () => {
   // `dynawalla-pack:` everywhere else, which is not an http source at all).
   // Content packs are downloaded and verified in Rust, never fetched here.
   const LOCAL_SCHEME_HOSTS = new Set(["http://ipc.localhost", "http://dynawalla-pack.localhost"])
-  for (const source of policy.matchAll(/https?:\/\/[^\s;]+/g)) {
-    assert.ok(LOCAL_SCHEME_HOSTS.has(source[0]), `remote origin in CSP: ${source[0]}`)
+  for (const source of remoteOrigins(policy)) {
+    assert.ok(LOCAL_SCHEME_HOSTS.has(source), `remote origin in CSP: ${source}`)
   }
 
   // A pack is framed, and the only thing that may be framed is a pack.
@@ -64,6 +78,22 @@ test("the CSP is non-null and closed by default", () => {
 
   // script-src must not admit inline script: the whole point of the policy.
   assert.match(policy, /script-src 'self'\s*;/)
+})
+
+test("the origin scan sees a socket, not only an http fetch", () => {
+  // A guard that silently does not fire is worse than no guard, and this one is
+  // read by hand nowhere: it is the only thing standing between this app and a
+  // remote origin in its own policy. Checked against synthetic policies, because
+  // the real one is supposed to have nothing in it to find.
+  assert.deepEqual(remoteOrigins("connect-src 'self' ipc: http://ipc.localhost"), [
+    "http://ipc.localhost",
+  ])
+  assert.deepEqual(remoteOrigins("connect-src 'self' wss://arena.example"), [
+    "wss://arena.example",
+  ])
+  assert.deepEqual(remoteOrigins("connect-src ws://10.0.0.2:8080"), ["ws://10.0.0.2:8080"])
+  assert.deepEqual(remoteOrigins("connect-src https://api.example/v1"), ["https://api.example/v1"])
+  assert.deepEqual(remoteOrigins("default-src 'none'; connect-src 'self'"), [])
 })
 
 test("nothing sets a style attribute the CSP would refuse to apply", () => {

--- a/dynawalla/dynawalla-app/src/app/platform.ts
+++ b/dynawalla/dynawalla-app/src/app/platform.ts
@@ -15,6 +15,7 @@ import { getVersion } from "@tauri-apps/api/app"
 import { invoke } from "@tauri-apps/api/core"
 
 import type { HapticPorts, HapticStyle } from "../packs/haptics.ts"
+import type { OrientationPorts, RawOrientation } from "../packs/orientation.ts"
 
 declare const __APP_VERSION__: string
 
@@ -61,4 +62,107 @@ export const hapticPorts: HapticPorts = {
     typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
       ? navigator.vibrate.bind(navigator)
       : null,
+}
+
+/* ─── orientation ──────────────────────────────────────────────────────────── */
+//
+// The only source of a tilt reading this build has, and it is a WEB API rather
+// than a plugin. That is a deliberate first step and not the finished shape:
+// `OrientationPorts` is what a `tauri-plugin-orientation` reading CoreMotion and
+// Android's `SensorManager` implements, and nothing above this file changes when
+// it lands. See `docs/NATIVE_CAPABILITIES.md`.
+//
+// What it means today, stated plainly because nobody here can run a phone:
+//
+//   * **Desktop and Android WebView.** `deviceorientation` fires with numbers in
+//     it where there is a sensor, and with `null`s where there is not. Neither
+//     needs a permission. The `null` case is why `orientation.ts` has a warm-up
+//     rather than trusting `typeof DeviceOrientationEvent`.
+//   * **iOS WKWebView.** Unverified, and quite possibly `null` forever:
+//     `DeviceOrientationEvent.requestPermission` may be absent, may resolve
+//     `denied` regardless, and motion in a WKWebView has historically needed app
+//     configuration Tauri does not expose. Every branch below therefore treats a
+//     refusal, a throw and a silence as the same answer — this device cannot —
+//     and the capability degrades to absent rather than to broken.
+
+/** `DeviceOrientationEvent` with the iOS-only static that gates it. */
+type PermissionGate = {
+  requestPermission?: () => Promise<"granted" | "denied" | "prompt">
+}
+
+const orientationEvent: (typeof DeviceOrientationEvent & PermissionGate) | null =
+  typeof window !== "undefined" && typeof DeviceOrientationEvent !== "undefined"
+    ? (DeviceOrientationEvent as typeof DeviceOrientationEvent & PermissionGate)
+    : null
+
+const needsPermission = typeof orientationEvent?.requestPermission === "function"
+
+/**
+ * The permission decision for this app install, asked at most once.
+ *
+ * Memoised at module scope rather than per launch, because it is a fact about
+ * the app and the person holding it and not about a game: prompting once per
+ * game would be a prompt a child learns to dismiss.
+ */
+let orientationPermission: Promise<boolean> | null = null
+
+function askOrientationPermission(): Promise<boolean> {
+  orientationPermission ??= (async () => {
+    const ask = orientationEvent?.requestPermission
+    if (!ask) return true
+    try {
+      return (await ask.call(orientationEvent)) === "granted"
+    } catch {
+      // Thrown when there is no user activation, and on any platform where the
+      // static exists but does not work. The answer is "no", and a game plays
+      // without it.
+      return false
+    }
+  })()
+  return orientationPermission
+}
+
+/**
+ * Ask for the motion permission now, from inside a real user gesture.
+ *
+ * **This is the whole answer to "some native features need a gesture and a
+ * per-origin grant, which an opaque origin cannot hold."** iOS requires
+ * transient user activation for `DeviceOrientationEvent.requestPermission()`,
+ * and it remembers the grant per origin. A pack has neither: activation does not
+ * cross a `postMessage`, and a pack's origin is opaque and therefore not
+ * something a grant can be remembered against.
+ *
+ * So the host asks, in the host's own document, on the tap that launched the
+ * game — the last real gesture before a pack exists. The grant is then the
+ * app's, held against the app's origin, and the pack is only ever told the
+ * outcome as `available`.
+ *
+ * Fire and forget: the answer is memoised, and whoever needs it awaits the same
+ * promise later.
+ */
+export function primeOrientationPermission(): void {
+  if (!needsPermission) return
+  void askOrientationPermission()
+}
+
+export const orientationPorts: OrientationPorts = {
+  present: orientationEvent !== null,
+  requestPermission: needsPermission ? askOrientationPermission : null,
+  subscribe: (onRaw) => {
+    if (typeof window === "undefined") return () => {}
+    const listener = (event: DeviceOrientationEvent) => {
+      const raw: RawOrientation = { beta: event.beta, gamma: event.gamma }
+      onRaw(raw)
+    }
+    window.addEventListener("deviceorientation", listener)
+    return () => window.removeEventListener("deviceorientation", listener)
+  },
+  screenAngle: () => {
+    // Guarded rather than optional-chained: `screen.orientation` is
+    // non-optional in the DOM types and absent in older WebViews, and a throw
+    // here would stop a sample instead of straightening one.
+    if (typeof screen === "undefined") return 0
+    const angle: unknown = (screen as { orientation?: { angle?: unknown } }).orientation?.angle
+    return typeof angle === "number" && Number.isFinite(angle) ? angle : 0
+  },
 }

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -19,7 +19,12 @@ import { useEffect, useLayoutEffect, useMemo, useState } from "react"
 import { create } from "zustand"
 
 import type { Settings } from "../../../packs/sdk/src/index.ts"
-import { BUILD_VERSION, hapticPorts } from "../app/platform.ts"
+import {
+  BUILD_VERSION,
+  hapticPorts,
+  orientationPorts,
+  primeOrientationPermission,
+} from "../app/platform.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { documentLock } from "../app/zoom.ts"
@@ -29,6 +34,7 @@ import { useProfiles } from "../profiles/store.ts"
 import { useSettings } from "../settings/store.ts"
 import { entryOf, useLibrary } from "./libraryStore.ts"
 import { tauriNative } from "./native.ts"
+import { createOrientationSource } from "./orientation.ts"
 import { PackFrame } from "./PackFrame.tsx"
 import { createServices, packSettings } from "./services.ts"
 
@@ -41,7 +47,21 @@ export interface LaunchState {
 
 export const useLaunch = create<LaunchState>()((set) => ({
   packId: null,
-  play: (packId) => set({ packId }),
+  play: (packId) => {
+    // The one place a motion permission can be asked for.
+    //
+    // `play` runs synchronously inside the tap on a pack's card, which is the
+    // last real user gesture before the pack exists — and iOS will only show
+    // `DeviceOrientationEvent.requestPermission()` from one. A pack cannot ask:
+    // user activation does not cross a `postMessage`, and its opaque origin is
+    // not something a grant could be remembered against. Only for a pack that
+    // declared the capability, so a child playing the other twenty-seven games
+    // is never shown a prompt about a sensor.
+    if (entryOf(packId)?.granted.includes("sensors.orientation")) {
+      primeOrientationPermission()
+    }
+    set({ packId })
+  },
   leave: () => set({ packId: null }),
 }))
 
@@ -117,6 +137,10 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
         // native bridge and whether this WebView has `navigator.vibrate` are
         // facts about the device, and neither can change while a child plays.
         haptics: hapticPorts,
+        // Built per launch, unlike the ports it wraps: the neutral pose a tilt
+        // is measured against belongs to one session, and carrying it between
+        // games would start the next one already steering.
+        orientation: createOrientationSource(orientationPorts),
         onProgress: setProgress,
         onEnd: () => onLeave(),
         onMilestone: (name) => console.info(`[packs] ${packId} reached ${name}`),

--- a/dynawalla/dynawalla-app/src/packs/bridge.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.test.ts
@@ -8,10 +8,22 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { createBridge, MAX_STORAGE_KEYS, MAX_STORAGE_VALUE_LENGTH } from "./bridge.ts"
+import {
+  createBridge,
+  MAX_OPEN_STREAMS,
+  MAX_STORAGE_KEYS,
+  MAX_STORAGE_VALUE_LENGTH,
+} from "./bridge.ts"
 import type { HostServices } from "./bridge.ts"
 import { CAPABILITIES, CAPABILITY_IDS, METHODS, SESSION_METHODS } from "../../../packs/sdk/src/index.ts"
-import type { Capability, Item, Response } from "../../../packs/sdk/src/index.ts"
+import type {
+  Capability,
+  Item,
+  Orientation,
+  Response,
+  StreamEnd,
+  StreamUpdate,
+} from "../../../packs/sdk/src/index.ts"
 
 const ITEM: Item = {
   id: "i1",
@@ -57,6 +69,10 @@ function services(calls: Calls, overrides: Partial<HostServices> = {}): HostServ
       remove: async ({ key }) => void store.delete(key),
       keys: async () => [...store.keys()],
     },
+    // Inert by default: a device with no sensor, which is the case every test
+    // that is not about streams should be running against.
+    sensors: { orientation: async () => null },
+    available: () => CAPABILITY_IDS.filter((id) => id !== "sensors.orientation"),
     progress: (input) => void record("progress", undefined)(input),
     end: (input) => void record("end", undefined)(input),
     transition: (input) => void record("transition", undefined)(input),
@@ -122,7 +138,12 @@ test("session methods work with no grants at all", async () => {
           ? { reason: "quit" }
           : method === "session.transition"
             ? { kind: "level" }
-            : {}
+            : method === "stream.cancel"
+              ? // A handle this pack never opened. Cancelling is idempotent and
+                // says nothing about what it found, so a pack cannot probe for
+                // another stream's existence by inventing a number.
+                { stream: 0 }
+              : {}
     const response = await bridge.handle({ id: 1, method, params })
     assert.ok(response?.ok, `${method} was refused`)
   }
@@ -151,8 +172,21 @@ test("a message with no usable id is dropped rather than answered", async () => 
 test("the whole method table is reachable when everything is granted", async () => {
   // A method in the SDK that the bridge forgot to implement would return
   // undefined and hang the pack's promise forever.
-  const bridge = bridgeWith(CAPABILITY_IDS)
+  //
+  // A device that can do everything, deliberately: a native method refused
+  // because the fixture has no sensor would pass this test for the wrong reason
+  // and hide the case where the dispatch arm is missing entirely.
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: CAPABILITY_IDS,
+    services: services([], {
+      available: () => CAPABILITY_IDS,
+      sensors: { orientation: async () => () => {} },
+    }),
+    push: () => {},
+  })
   const params: Record<string, unknown> = {
+    stream: 0,
     itemId: "i1",
     response: "2203",
     latencyMs: 100,
@@ -375,4 +409,331 @@ test("a difficulty request crosses the boundary, clamped rather than refused", a
   // not thereby pin every question to the easiest rung on the ladder.
   await bridge.handle({ id: 3, method: "items.next", params: { difficulty: "hard" } })
   assert.deepEqual(calls[2]?.input, { packId: "p" })
+})
+
+/* ─── streams, and the native-backed capability behind them ────────────────── */
+//
+// A stream is the first thing on this seam that OUTLIVES the message that opened
+// it, and it is the first thing on it that holds a device resource. Both are new
+// kinds of mistake: a stream nothing ends, and a sensor nothing releases.
+
+type Sensor = {
+  /** A working source. Every started stream is recorded here. */
+  readonly orientation: HostServices["sensors"]["orientation"]
+  /** How many times a stop function was called. */
+  released: () => number
+  /** How many subscriptions were ever handed out. */
+  started: () => number
+  /** Push a sample at every live subscription. */
+  feed: (sample: Orientation) => void
+  /** Tell every live subscription its source has gone. */
+  lose: () => void
+}
+
+function sensor(options: { present?: boolean } = {}): Sensor {
+  let released = 0
+  let started = 0
+  const live = new Set<{ emit: (sample: Orientation) => void; lost: () => void }>()
+  return {
+    orientation: async (input) => {
+      if (options.present === false) return null
+      started += 1
+      const entry = { emit: input.emit, lost: input.lost }
+      live.add(entry)
+      return () => {
+        released += 1
+        live.delete(entry)
+      }
+    },
+    released: () => released,
+    started: () => started,
+    feed: (sample) => {
+      for (const entry of [...live]) entry.emit(sample)
+    },
+    lose: () => {
+      for (const entry of [...live]) entry.lost()
+    },
+  }
+}
+
+const SAMPLE: Orientation = { x: 0.5, y: -0.25, degrees: { x: 12, y: -6 } }
+
+function streamBridge(options: { present?: boolean; granted?: readonly Capability[] } = {}) {
+  const pushed: (StreamUpdate | StreamEnd)[] = []
+  const device = sensor(options.present === false ? { present: false } : {})
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: options.granted ?? ["sensors.orientation"],
+    services: services([], {
+      sensors: { orientation: device.orientation },
+      available: () =>
+        options.present === false
+          ? CAPABILITY_IDS.filter((id) => id !== "sensors.orientation")
+          : CAPABILITY_IDS,
+    }),
+    push: (message) => pushed.push(message),
+  })
+  return { bridge, device, pushed }
+}
+
+const updates = (pushed: readonly (StreamUpdate | StreamEnd)[]): StreamUpdate[] =>
+  pushed.filter((message): message is StreamUpdate => !("done" in message))
+
+const ends = (pushed: readonly (StreamUpdate | StreamEnd)[]): StreamEnd[] =>
+  pushed.filter((message): message is StreamEnd => "done" in message)
+
+test("a stream hands back its own request id and numbers its samples from one", async () => {
+  const { bridge, device, pushed } = streamBridge()
+  const response = await bridge.handle({ id: 9, method: "sensors.orientation.start", params: {} })
+  assert.ok(response?.ok)
+  // The handle IS the request id: no second namespace, and the pack already held
+  // the number it sent.
+  assert.deepEqual(response.result, { stream: 9 })
+  assert.deepEqual(bridge.streams(), [9])
+  assert.equal(device.started(), 1)
+
+  device.feed(SAMPLE)
+  device.feed(SAMPLE)
+  assert.deepEqual(updates(pushed), [
+    { stream: 9, seq: 1, data: SAMPLE },
+    { stream: 9, seq: 2, data: SAMPLE },
+  ])
+})
+
+test("a pack that did not declare the capability cannot open the stream", async () => {
+  const { bridge, device } = streamBridge({ granted: ["items"] })
+  const response = await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  assert.equal(errorOf(response), "denied")
+  // And the denial happened before anything touched the device.
+  assert.equal(device.started(), 0)
+  assert.deepEqual(bridge.streams(), [])
+})
+
+test("a source that refuses is unavailable rather than an open stream", async () => {
+  const { bridge, device } = streamBridge({ present: false })
+  const response = await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  assert.equal(errorOf(response), "unavailable")
+  assert.equal(device.started(), 0)
+  assert.deepEqual(bridge.streams(), [])
+})
+
+test("the bridge refuses an unavailable capability before it touches the device", async () => {
+  // Checked HERE and not only in the guest: the guest short-circuits to save a
+  // round trip, and the bridge is the boundary — it cannot rely on the other side
+  // of itself having done the check.
+  //
+  // The device in this fixture WORKS. That is the whole point of it: a fixture
+  // whose source also returns `null` makes this test pass with the bridge's check
+  // deleted, because the refusal then comes from the source instead. It was
+  // written that way first and measured passing with the fix removed.
+  const device = sensor()
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: ["sensors.orientation"],
+    services: services([], {
+      sensors: { orientation: device.orientation },
+      available: () => CAPABILITY_IDS.filter((id) => id !== "sensors.orientation"),
+    }),
+    push: () => {},
+  })
+  const response = await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  assert.equal(errorOf(response), "unavailable")
+  assert.equal(device.started(), 0, "a capability the device cannot do was started anyway")
+  assert.deepEqual(bridge.streams(), [])
+})
+
+test("cancelling ends the stream once and releases the device", async () => {
+  const { bridge, device, pushed } = streamBridge()
+  await bridge.handle({ id: 3, method: "sensors.orientation.start", params: {} })
+  const response = await bridge.handle({ id: 4, method: "stream.cancel", params: { stream: 3 } })
+  assert.ok(response?.ok)
+  assert.equal(device.released(), 1, "the sensor was left running")
+  assert.deepEqual(ends(pushed), [{ stream: 3, done: true, reason: "cancelled" }])
+  assert.deepEqual(bridge.streams(), [])
+
+  // Nothing arrives afterwards, even if the source is still being fed.
+  device.feed(SAMPLE)
+  assert.deepEqual(updates(pushed), [])
+
+  // And cancelling again is not an error and does not end it twice: a pack
+  // racing its own teardown against a host that already closed the stream is the
+  // normal case, not a fault.
+  const again = await bridge.handle({ id: 5, method: "stream.cancel", params: { stream: 3 } })
+  assert.ok(again?.ok)
+  assert.equal(ends(pushed).length, 1)
+  assert.equal(device.released(), 1)
+})
+
+test("cancelling a handle the pack invented says nothing about it", async () => {
+  const { bridge, pushed } = streamBridge()
+  const response = await bridge.handle({ id: 1, method: "stream.cancel", params: { stream: 7777 } })
+  assert.ok(response?.ok, "a pack learned that a handle was not real")
+  assert.deepEqual(pushed, [])
+  assert.equal(
+    errorOf(await bridge.handle({ id: 2, method: "stream.cancel", params: {} })),
+    "invalid_params",
+  )
+})
+
+test("a stream cancelled while it was still starting leaves nothing behind", async () => {
+  // A permission prompt is on screen, the child presses the back button, and the
+  // pack cancels a stream whose handle it has not been given yet. Before the
+  // handle is reserved ahead of the await there is nothing for the cancel to
+  // find, and the sensor stays subscribed to a stream nobody is reading.
+  const pushed: (StreamUpdate | StreamEnd)[] = []
+  let released = 0
+  // A holder rather than a `let`: assigned inside a callback, so TypeScript's
+  // control-flow analysis still believes the variable is `null` at the assertion
+  // below and narrows it to `never`.
+  const held: { release: (() => void) | null } = { release: null }
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: ["sensors.orientation"],
+    services: services([], {
+      available: () => CAPABILITY_IDS,
+      sensors: {
+        orientation: async () =>
+          new Promise<() => void>((resolve) => {
+            held.release = () =>
+              resolve(() => {
+                released += 1
+              })
+          }),
+      },
+    }),
+    push: (message) => pushed.push(message),
+  })
+
+  const start = bridge.handle({ id: 2, method: "sensors.orientation.start", params: {} })
+  await new Promise((resolve) => setImmediate(resolve))
+  // The handle exists before the source has finished starting, which is the
+  // whole point: the cancel has something to find.
+  assert.deepEqual(bridge.streams(), [2])
+  await bridge.handle({ id: 3, method: "stream.cancel", params: { stream: 2 } })
+  assert.ok(held.release)
+  held.release()
+
+  const response = await start
+  assert.equal(errorOf(response), "unavailable")
+  assert.equal(released, 1, "a source started for a cancelled stream was never released")
+  assert.deepEqual(bridge.streams(), [])
+  // No end message: nothing was ever handed out, so there was no stream to end.
+  // "Exactly one end per stream" is a promise about streams that were opened.
+  assert.deepEqual(ends(pushed), [])
+})
+
+test("a source that turns out to be feeding nothing ends the stream unavailable", async () => {
+  const { bridge, device, pushed } = streamBridge()
+  await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  device.lose()
+  assert.deepEqual(ends(pushed), [{ stream: 1, done: true, reason: "unavailable" }])
+  assert.equal(device.released(), 1)
+  assert.deepEqual(bridge.streams(), [])
+})
+
+test("a paused pack stops receiving samples, and the gap shows in the sequence", async () => {
+  const { bridge, device, pushed } = streamBridge()
+  await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  device.feed(SAMPLE)
+
+  // A game steering behind the day-pass sheet is a game the child is not
+  // playing. The samples are DROPPED rather than queued: a buffer of stale tilt
+  // delivered all at once on resume would snap whatever it steers across the
+  // screen.
+  bridge.setPaused(true)
+  device.feed(SAMPLE)
+  device.feed(SAMPLE)
+  assert.equal(updates(pushed).length, 1)
+
+  bridge.setPaused(false)
+  device.feed(SAMPLE)
+  const seen = updates(pushed)
+  assert.deepEqual(
+    seen.map((message) => message.seq),
+    [1, 2],
+    "a dropped sample consumed a sequence number",
+  )
+  assert.equal(seen.length, 2)
+})
+
+test("closing the bridge ends every stream and releases every device", async () => {
+  // The one guarantee that matters: nothing outlives the pack. A sensor left
+  // subscribed after a child has left is a battery cost nobody can see and
+  // nothing else in this app would notice.
+  const { bridge, device, pushed } = streamBridge()
+  await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  await bridge.handle({ id: 2, method: "sensors.orientation.start", params: {} })
+  assert.equal(device.started(), 2)
+
+  bridge.close()
+  assert.equal(device.released(), 2)
+  assert.deepEqual(ends(pushed), [
+    { stream: 1, done: true, reason: "closed" },
+    { stream: 2, done: true, reason: "closed" },
+  ])
+  assert.deepEqual(bridge.streams(), [])
+
+  // And a message already in flight when the session ended is not served — the
+  // one that must not be is another stream start.
+  assert.equal(await bridge.handle({ id: 3, method: "sensors.orientation.start", params: {} }), null)
+  assert.equal(device.started(), 2)
+  bridge.close()
+  assert.equal(device.released(), 2, "close ran twice")
+})
+
+test("a source whose stop throws still leaves the stream ended", async () => {
+  // `stop` is host code and host code throws. A throw that left the handle in
+  // the table would leave a stream nothing can ever end.
+  const pushed: (StreamUpdate | StreamEnd)[] = []
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: ["sensors.orientation"],
+    services: services([], {
+      available: () => CAPABILITY_IDS,
+      sensors: {
+        orientation: async () => () => {
+          throw new Error("the sensor was already gone")
+        },
+      },
+    }),
+    push: (message) => pushed.push(message),
+  })
+  await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  bridge.close()
+  assert.deepEqual(bridge.streams(), [])
+  assert.deepEqual(ends(pushed), [{ stream: 1, done: true, reason: "closed" }])
+})
+
+test("a pack cannot hoard streams", async () => {
+  const { bridge, device } = streamBridge()
+  for (let id = 1; id <= MAX_OPEN_STREAMS; id += 1) {
+    assert.ok((await bridge.handle({ id, method: "sensors.orientation.start", params: {} }))?.ok)
+  }
+  const over = await bridge.handle({
+    id: MAX_OPEN_STREAMS + 1,
+    method: "sensors.orientation.start",
+    params: {},
+  })
+  assert.equal(errorOf(over), "quota")
+  assert.equal(device.started(), MAX_OPEN_STREAMS)
+  bridge.close()
+})
+
+test("a bridge with nowhere to push does not pretend to stream", async () => {
+  // `push` is optional so that a test about request/response need not supply
+  // one. A pack in that host gets a stream that delivers nothing, which must not
+  // be a throw: this is the shape every existing bridge test constructs.
+  const device = sensor()
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: ["sensors.orientation"],
+    services: services([], {
+      available: () => CAPABILITY_IDS,
+      sensors: { orientation: device.orientation },
+    }),
+  })
+  assert.ok((await bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} }))?.ok)
+  device.feed(SAMPLE)
+  bridge.close()
+  assert.equal(device.released(), 1)
 })

--- a/dynawalla/dynawalla-app/src/packs/bridge.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.ts
@@ -28,9 +28,13 @@ import type {
   Judgement,
   LearnerSummary,
   Method,
+  Orientation,
   Response,
   Settings,
   SoundCue,
+  StreamEnd,
+  StreamEndReason,
+  StreamUpdate,
   TransitionKind,
 } from "../../../packs/sdk/src/index.ts"
 import {
@@ -51,6 +55,17 @@ export const MAX_STORAGE_VALUE_LENGTH = 16 * 1024
 /** A latency a pack reports is clamped to this. Anything longer is not a fact. */
 const MAX_LATENCY_MS = 10 * 60 * 1000
 const MAX_REVISIONS = 1000
+
+/**
+ * How many streams one pack may hold open at once.
+ *
+ * A stream is a subscription to something outside the WebView — a sensor, and
+ * one day a synthesiser or a model — and each one costs a device resource that
+ * nothing else can reclaim. Four is more than any game has a use for and small
+ * enough that a loop calling `start` cannot exhaust the device before the rate
+ * limiter catches it.
+ */
+export const MAX_OPEN_STREAMS = 4
 
 const HAPTIC_CUES: readonly HapticCue[] = ["tick", "seat", "settle", "refuse"]
 const SOUND_CUES: readonly SoundCue[] = ["tick", "seat", "settle", "refuse", "arrive"]
@@ -92,6 +107,42 @@ export type HostServices = {
     remove(input: { packId: string; key: string }): Promise<void>
     keys(input: { packId: string }): Promise<string[]>
   }
+  /**
+   * The native-backed surface: things answered by the device rather than here.
+   *
+   * Separated from everything above it because the shape is different, and the
+   * difference is the whole reason `docs/NATIVE_CAPABILITIES.md` exists. A method
+   * up there returns a value, quickly, always. One down here may have to ask
+   * somebody for permission, may take seconds, may answer over time, and may
+   * turn out to be impossible on this particular device — so it returns a
+   * *subscription*, and `null` for "not on this hardware" is a first-class
+   * answer rather than an error.
+   */
+  sensors: {
+    /**
+     * Start feeding orientation samples to `emit`.
+     *
+     * Resolves to a stop function, or `null` when this device cannot do it at
+     * all — no source in the build, no sensor in the hardware, or a permission
+     * somebody declined. `lost` is for the case that only shows up after
+     * starting: subscribed successfully, and then nothing usable ever arrived.
+     */
+    orientation(input: {
+      packId: string
+      emit: (sample: Orientation) => void
+      lost: () => void
+    }): Promise<(() => void) | null>
+  }
+  /**
+   * Everything this DEVICE can do, right now.
+   *
+   * Not what the build supports — `library.ts`'s `HOST_SUPPORTS` is that, and it
+   * must never shrink to express a missing sensor, because a capability dropped
+   * from it refuses to *install* a pack rather than letting the pack degrade.
+   * This is the runtime layer: the frame intersects it with the pack's grants
+   * and sends the result as `Connect.available`.
+   */
+  available(): readonly Capability[]
   progress(input: { packId: string; fraction: number }): void
   end(input: { packId: string; reason: "finished" | "quit" }): void
   /**
@@ -105,6 +156,26 @@ export type HostServices = {
 export type Bridge = {
   /** One message in, one response out. `null` for a message with no reply. */
   handle(message: unknown): Promise<Response | null>
+  /**
+   * Stop delivering stream samples, or start again.
+   *
+   * A paused pack is a pack with something over it — the day-pass sheet — and a
+   * game steering behind a sheet is a game the child is not playing. The samples
+   * are **dropped**, not queued: a buffer of stale tilt delivered all at once on
+   * resume would snap whatever it steers across the screen. The gap shows up in
+   * the stream's `seq`, which is exactly what `seq` is for.
+   */
+  setPaused(paused: boolean): void
+  /**
+   * End every open stream and release what is behind it.
+   *
+   * The one guarantee that matters here: **nothing outlives the pack.** A sensor
+   * left running after a child leaves is a battery cost nobody can see and
+   * nothing else in this app would notice.
+   */
+  close(): void
+  /** Open stream handles. For the developer surface and for the tests. */
+  readonly streams: () => readonly number[]
   /** Counters, for the developer surface and for the tests. */
   readonly stats: { denied: number; rateLimited: number; malformed: number; served: number }
 }
@@ -113,9 +184,36 @@ export type BridgeOptions = {
   readonly packId: string
   readonly granted: readonly Capability[]
   readonly services: HostServices
+  /**
+   * Where an unsolicited stream message goes, host → pack.
+   *
+   * The third envelope, and the reason it is a constructor argument rather than
+   * a return value: `handle` answers one message with one response, and a stream
+   * is by definition traffic nobody asked for at the moment it is sent. Absent
+   * in a test that only exercises request/response, in which case a pack that
+   * opens a stream gets one that delivers nothing — which is why every stream
+   * test passes one.
+   */
+  readonly push?: (message: StreamUpdate | StreamEnd) => void
   /** Injectable so a test does not sleep. Milliseconds. */
   readonly now?: () => number
   readonly maxRequestsPerSecond?: number
+}
+
+/** One stream this pack has open, from the host's side. */
+type Open = {
+  /** Monotonic from 1. The pack drops anything at or below its high-water mark. */
+  seq: number
+  /** Release whatever is behind it. Replaced once the source has started. */
+  stop: () => void
+  /**
+   * Whether the pack has been given the handle yet.
+   *
+   * A start that is cancelled while it is still starting never becomes a stream
+   * the pack knows about, so it gets no end message: "exactly one end per stream
+   * that was opened" is a promise about streams that were opened.
+   */
+  handed: boolean
 }
 
 const ok = (id: number, result: unknown): Response => ({ id, ok: true, result })
@@ -130,6 +228,90 @@ export function createBridge(options: BridgeOptions): Bridge {
   const now = options.now ?? (() => Date.now())
   const limit = options.maxRequestsPerSecond ?? MAX_REQUESTS_PER_SECOND
   const stats = { denied: 0, rateLimited: 0, malformed: 0, served: 0 }
+
+  /* ------------------------------- streams -------------------------------- */
+
+  const open = new Map<number, Open>()
+  const push = options.push
+  let paused = false
+  let closed = false
+
+  const emit = (stream: number, data: unknown): void => {
+    if (closed || paused) return
+    const entry = open.get(stream)
+    if (!entry || !entry.handed) return
+    entry.seq += 1
+    push?.({ stream, seq: entry.seq, data })
+  }
+
+  /**
+   * End one stream, once.
+   *
+   * Deleting from the table before stopping the source is deliberate: `stop` is
+   * host code that can throw, and a throw that left the handle in the table
+   * would leave a stream nothing can ever end.
+   */
+  const endStream = (stream: number, reason: StreamEndReason): void => {
+    const entry = open.get(stream)
+    if (!entry) return
+    open.delete(stream)
+    try {
+      entry.stop()
+    } catch (error) {
+      console.error(`[packs] ${packId} stream ${String(stream)} failed to stop`, error)
+    }
+    if (entry.handed) push?.({ stream, done: true, reason })
+  }
+
+  /**
+   * Open a stream against a native source, or say why not.
+   *
+   * The whole lifecycle is here rather than in the `switch` below so that adding
+   * speech or a model is one more call to this: reserve the handle, await a
+   * source that may be asking a person for permission, and handle the two things
+   * that can go wrong meanwhile — the device saying no, and the pack having
+   * cancelled while we waited.
+   */
+  const openStream = async (
+    id: number,
+    source: (input: {
+      emit: (sample: Orientation) => void
+      lost: () => void
+    }) => Promise<(() => void) | null>,
+    unavailable: string,
+  ): Promise<Response> => {
+    if (open.size >= MAX_OPEN_STREAMS) {
+      return err(id, "quota", `a pack may hold ${MAX_OPEN_STREAMS} streams open`)
+    }
+    // The handle is reserved BEFORE the await, so a `stream.cancel` arriving
+    // while a permission prompt is on screen has something to find. Its `stop`
+    // is a flag until the real one exists.
+    let cancelled = false
+    const entry: Open = { seq: 0, stop: () => (cancelled = true), handed: false }
+    open.set(id, entry)
+
+    const stop = await source({
+      emit: (sample) => emit(id, sample),
+      lost: () => endStream(id, "unavailable"),
+    })
+
+    if (stop === null) {
+      open.delete(id)
+      return err(id, "unavailable", unavailable)
+    }
+    if (cancelled || closed) {
+      // Nothing was ever handed out, so there is no stream to end — just a
+      // source to release. The pack learns this as a failed start, and its SDK
+      // stays quiet about it because the pack is the thing that cancelled.
+      open.delete(id)
+      stop()
+      return err(id, "unavailable", "the stream was cancelled while it was starting")
+    }
+    entry.stop = stop
+    entry.handed = true
+    // The handle IS the request id. Echoed anyway, so nothing has to infer it.
+    return ok(id, { stream: id })
+  }
 
   /**
    * A sliding one-second window rather than a token bucket: the rule the SDK
@@ -296,12 +478,52 @@ export function createBridge(options: BridgeOptions): Bridge {
 
       case "storage.keys":
         return ok(id, { keys: await services.storage.keys({ packId }) })
+
+      case "sensors.orientation.start": {
+        // Checked here and not only in the guest. The guest short-circuits an
+        // unavailable capability to save a round trip, and this is the boundary:
+        // it cannot rely on the other side of itself having done the check.
+        if (!services.available().includes("sensors.orientation")) {
+          return err(id, "unavailable", "this device cannot report how it is being held")
+        }
+        return openStream(
+          id,
+          (input) => services.sensors.orientation({ packId, ...input }),
+          "this device cannot report how it is being held",
+        )
+      }
+
+      case "stream.cancel": {
+        const stream = numberParam(params, "stream", Number.MAX_SAFE_INTEGER)
+        if (stream === null) return err(id, "invalid_params", "stream must be a stream handle")
+        // Idempotent, and silent about what it found. Cancelling something that
+        // has already ended is not an error — a pack racing its own teardown
+        // against a stream the host closed is the normal case — and a pack must
+        // not be able to learn whether a handle it invented was ever real.
+        endStream(Math.round(stream), "cancelled")
+        return ok(id, null)
+      }
     }
   }
 
   return {
     stats,
+    streams: () => [...open.keys()],
+    setPaused: (value) => {
+      paused = value
+    },
+    close: () => {
+      if (closed) return
+      closed = true
+      // A copy of the keys: `endStream` mutates the map it is walking.
+      for (const stream of [...open.keys()]) endStream(stream, "closed")
+    },
     handle: async (message: unknown): Promise<Response | null> => {
+      // A closed bridge answers nothing. `close()` runs before the port does, so
+      // a message already in flight can land here — and the one that must not be
+      // served is a stream start, which would subscribe to a sensor for a session
+      // that has ended.
+      if (closed) return null
       const parsed = parseRequest(message)
       if (!parsed.ok) {
         stats.malformed += 1

--- a/dynawalla/dynawalla-app/src/packs/frame.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.test.ts
@@ -26,7 +26,14 @@ import {
   type Watch,
 } from "./frame.ts"
 import type { HostServices } from "./bridge.ts"
-import type { Capability, Connect, Settings } from "../../../packs/sdk/src/index.ts"
+import { CAPABILITY_IDS } from "../../../packs/sdk/src/index.ts"
+import type {
+  Capability,
+  Connect,
+  Orientation,
+  Settings,
+  StreamUpdate,
+} from "../../../packs/sdk/src/index.ts"
 
 const SETTINGS: Settings = {
   locale: "en",
@@ -38,7 +45,7 @@ const SETTINGS: Settings = {
   haptics: true,
 }
 
-const services = (): HostServices => ({
+const services = (overrides: Partial<HostServices> = {}): HostServices => ({
   nextItem: async () => null,
   judge: async () => ({ correct: true, canonical: "2203", advance: true }),
   skip: async () => {},
@@ -56,7 +63,10 @@ const services = (): HostServices => ({
   progress: () => {},
   end: () => {},
   transition: () => {},
+  sensors: { orientation: async () => null },
+  available: () => CAPABILITY_IDS,
   settings: () => SETTINGS,
+  ...overrides,
 })
 
 type Posted = { data: unknown; targetOrigin: string; transfer: readonly MessagePort[] }
@@ -81,6 +91,8 @@ type HarnessOptions = {
   /** The frame's box. Defaults to a 820x1180 tablet, which is what it is. */
   readonly box?: { readonly width: number; readonly height: number }
   readonly liveness?: Partial<LivenessLimits>
+  /** Replaces part of the host surface. For the native-backed capabilities. */
+  readonly services?: Partial<HostServices>
 }
 
 /**
@@ -151,7 +163,7 @@ function harness(t: TestContext, options: HarnessOptions = {}): Harness {
     packId: "abacus.tower",
     entryUrl: "dynawalla-pack://localhost/abacus.tower/index.html",
     granted,
-    services: services(),
+    services: services(options.services ?? {}),
     hostVersion: "0.4.0",
     title: "Abacus Tower",
     document: doc,
@@ -809,4 +821,123 @@ test("disposing stops the watch, and clears its timer", async (t) => {
 
   await new Promise((resolve) => setTimeout(resolve, 150))
   assert.equal(test.faults.length, 0, `a disposed pack was accused of ${test.faults.join(", ")}`)
+})
+
+/* ─── native-backed capabilities, at the frame ────────────────────────────── */
+
+test("the connect payload states what is granted AND what this device can do", async (t) => {
+  // Two different questions, and conflating them is the mistake the field exists
+  // to prevent. A grant is a decision about a pack; availability is a fact about
+  // a device — a tablet with no gyroscope, a build with no plugin, a permission
+  // somebody declined.
+  const test1 = harness(t, {
+    granted: ["items", "sensors.orientation"],
+    services: { available: () => ["items", "haptics"] },
+  })
+  shake(test1)
+  await until(() => test1.mounted.connected())
+  const connect = test1.posted[0]?.data as Connect
+  assert.deepEqual([...connect.granted], ["items", "sensors.orientation"])
+  // Intersected, so "available" can never exceed "granted": `haptics` is
+  // something this device can do and this pack did not ask for.
+  assert.deepEqual([...(connect.available ?? [])], ["items"])
+})
+
+test("everything granted is available when the device can do it all", async (t) => {
+  const test1 = harness(t, { granted: ["items", "sensors.orientation"] })
+  shake(test1)
+  await until(() => test1.mounted.connected())
+  const connect = test1.posted[0]?.data as Connect
+  assert.deepEqual([...(connect.available ?? [])], ["items", "sensors.orientation"])
+})
+
+test("no sensor outlives the pack it was started for", async (t) => {
+  // The failure this is the net for is invisible: a stream left open holds a
+  // subscription in the host's realm, the frame is removed, the child goes back
+  // to the catalogue, and the sensor keeps running for the rest of the app's
+  // life with nothing on the other end of it.
+  let released = 0
+  const test1 = harness(t, {
+    granted: ["sensors.orientation"],
+    services: {
+      sensors: {
+        orientation: async () => () => {
+          released += 1
+        },
+      },
+    },
+  })
+  shake(test1)
+  await until(() => test1.mounted.connected())
+  const started = await test1.mounted.bridge.handle({
+    id: 1,
+    method: "sensors.orientation.start",
+    params: {},
+  })
+  assert.ok(started?.ok)
+  assert.deepEqual(test1.mounted.bridge.streams(), [1])
+
+  test1.mounted.dispose()
+  assert.equal(released, 1, "the pack was torn down and the sensor was not")
+  assert.deepEqual(test1.mounted.bridge.streams(), [])
+})
+
+test("stream samples reach the pack's port, and a paused pack gets none", async (t) => {
+  // Read from the pack's own end of the port — the one the frame transferred —
+  // so this is the wire and not a spy on the bridge. Two things it holds that
+  // nothing else does: `push` is actually wired to the port at all, and `send`
+  // reaches `setPaused`, without which a game keeps steering behind the day-pass
+  // sheet.
+  const feed: ((sample: Orientation) => void)[] = []
+  const test1 = harness(t, {
+    granted: ["sensors.orientation"],
+    services: {
+      sensors: {
+        orientation: async (input) => {
+          feed.push(input.emit)
+          return () => {}
+        },
+      },
+    },
+  })
+  shake(test1)
+  await until(() => test1.mounted.connected())
+
+  const port = test1.posted[0]?.transfer[0]
+  assert.ok(port, "no port was transferred")
+  const seen: StreamUpdate[] = []
+  port.onmessage = (event: MessageEvent) => {
+    const data: unknown = event.data
+    if (data !== null && typeof data === "object" && "seq" in data) seen.push(data as StreamUpdate)
+  }
+  port.start()
+  t.after(() => {
+    port.onmessage = null
+  })
+
+  await test1.mounted.bridge.handle({ id: 1, method: "sensors.orientation.start", params: {} })
+  const emit = feed[0]
+  assert.ok(emit)
+
+  const sample: Orientation = { x: 0.5, y: 0, degrees: { x: 12, y: 0 } }
+  emit(sample)
+  await until(() => seen.length === 1)
+  assert.deepEqual(seen, [{ stream: 1, seq: 1, data: sample }])
+
+  test1.mounted.send("pause")
+  emit(sample)
+  emit(sample)
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(seen.length, 1, "a paused pack was still being fed")
+
+  test1.mounted.send("resume")
+  emit(sample)
+  await until(() => seen.length === 2)
+  // The gap is visible in `seq`, which is exactly what `seq` is for: the pack can
+  // tell that samples were dropped rather than that the sensor went quiet.
+  assert.deepEqual(
+    seen.map((message) => message.seq),
+    [1, 2],
+  )
+  assert.deepEqual(test1.mounted.bridge.streams(), [1])
 })

--- a/dynawalla/dynawalla-app/src/packs/frame.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.ts
@@ -349,6 +349,13 @@ export function mountPack(options: MountOptions): MountedPack {
     packId: options.packId,
     granted: options.granted,
     services: options.services,
+    // The third envelope. Streams are traffic nobody asked for at the moment it
+    // is sent, so it cannot come back out of `handle` — the bridge is handed the
+    // port instead, and it is still the only thing that can write to it.
+    push: (message) => {
+      if (disposed || !connected) return
+      channel?.port1.postMessage(message)
+    },
   })
 
   const frame = doc.createElement("iframe")
@@ -451,6 +458,13 @@ export function mountPack(options: MountOptions): MountedPack {
     // the net for that.
     poll = setInterval(tick, limits.pollMs)
 
+    // Granted and available are different questions, and the pack is told both.
+    // A grant is a decision about the pack; availability is a fact about this
+    // device — a tablet with no gyroscope, a build with no plugin, a permission
+    // somebody declined. Intersected here rather than in `services` so that
+    // "available" can never exceed "granted" by construction.
+    const capable = options.services.available()
+    const available = options.granted.filter((capability) => capable.includes(capability))
     const connect: Connect = {
       event: "connect",
       protocol: PROTOCOL_VERSION,
@@ -458,6 +472,7 @@ export function mountPack(options: MountOptions): MountedPack {
       host: options.hostVersion,
       packId: options.packId,
       granted: options.granted,
+      available,
       settings: options.services.settings(),
     }
     // `"*"` because an opaque origin cannot be named. The payload is not a
@@ -480,6 +495,12 @@ export function mountPack(options: MountOptions): MountedPack {
 
   const send = (event: HostEventName, data?: unknown) => {
     if (!connected || disposed) return
+    // Pausing a pack pauses its streams. A game steering behind the day-pass
+    // sheet is a game the child is not playing, and a sensor feeding it is a
+    // battery cost with nobody on the other end. The samples are dropped rather
+    // than queued — see `Bridge.setPaused`.
+    if (event === "pause") bridge.setPaused(true)
+    if (event === "resume") bridge.setPaused(false)
     channel?.port1.postMessage(data === undefined ? { event } : { event, data })
   }
 
@@ -492,12 +513,17 @@ export function mountPack(options: MountOptions): MountedPack {
     pushSettings: (settings) => send("settings", settings),
     dispose: () => {
       if (disposed) return
+      // Streams first, and before `disposed` is set so the end messages can
+      // still reach the pack. Nothing native may outlive a pack: a sensor left
+      // subscribed after a child has left is a cost nobody can see and nothing
+      // else in this app would notice.
+      bridge.close()
       disposed = true
       if (timer !== null) clearTimeout(timer)
       timer = null
       if (poll !== null) clearInterval(poll)
       poll = null
-      // Tell the pack first, so it can stop its own loop before its port dies.
+      // Then tell the pack, so it can stop its own loop before its port dies.
       if (connected) channel?.port1.postMessage({ event: "dispose" })
       win.removeEventListener("message", onReady)
       if (channel) {

--- a/dynawalla/dynawalla-app/src/packs/library.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/library.test.ts
@@ -9,6 +9,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
+import { CAPABILITY_IDS } from "../../../packs/sdk/src/index.ts"
 import { HOST_SUPPORTS, cardFacts, hostProfile, readLibrary } from "./library.ts"
 import type { InstalledPackRow, PackNative } from "./native.ts"
 
@@ -105,12 +106,23 @@ test("the localised name is what a child is shown", async () => {
 test("this build supports every capability the SDK defines", () => {
   // A capability in the table that no build honours is a capability a pack can
   // declare, be refused for, and never find out why. If one is ever genuinely
-  // unsupported it belongs here as a deliberate omission with a note, not as an
-  // oversight.
-  assert.deepEqual(
-    [...HOST_SUPPORTS].sort(),
-    ["audio", "haptics", "items", "items.reveal", "learner.read", "milestones", "storage"],
-  )
+  // unsupported it belongs in `DELIBERATELY_UNSUPPORTED` with a sentence saying
+  // which build it is missing from and why, not as an oversight.
+  //
+  // Compared against the SDK's own table rather than a frozen literal, which is
+  // what makes this the invariant its name claims: a hard-coded list passes by
+  // being edited, and the edit is exactly the moment somebody would have had to
+  // notice the omission.
+  //
+  // In particular a NATIVE-backed capability belongs here as soon as the build
+  // implements it, whatever the device in somebody's hand can do. This list
+  // feeds `gateInstall`, which refuses the *install* of a pack asking for
+  // something missing from it, so removing one to describe a tablet with no
+  // gyroscope would stop that tablet installing the pack rather than letting the
+  // pack run without tilt. Device-level absence is `HostServices.available()`.
+  const DELIBERATELY_UNSUPPORTED: readonly string[] = []
+  const expected = CAPABILITY_IDS.filter((id) => !DELIBERATELY_UNSUPPORTED.includes(id))
+  assert.deepEqual([...HOST_SUPPORTS].sort(), [...expected].sort())
 })
 
 test("the card's facts carry the minimum age, and carry its absence as absence", async () => {

--- a/dynawalla/dynawalla-app/src/packs/library.ts
+++ b/dynawalla/dynawalla-app/src/packs/library.ts
@@ -17,7 +17,18 @@ import { gateRun, type HostProfile, type Refusal } from "./gate.ts"
 import { readInstalled } from "./install.ts"
 import type { PackNative } from "./native.ts"
 
-/** Everything this build can honour. A pack asking for more is refused. */
+/**
+ * Everything this build can honour. A pack asking for more is refused.
+ *
+ * **A native-backed capability belongs here as soon as the build implements it,
+ * and must never be removed to express a device that cannot do it.** This list
+ * feeds `gateInstall`, which *refuses the install* of a pack that asks for
+ * something missing from it — so dropping `sensors.orientation` for a tablet
+ * with no gyroscope would stop that tablet installing the pack at all instead of
+ * letting the pack run without tilt. Which capabilities a *device* can actually
+ * do is a separate, runtime answer: `HostServices.available()`, sent to the pack
+ * as `Connect.available`. See `docs/NATIVE_CAPABILITIES.md`.
+ */
 export const HOST_SUPPORTS: readonly Capability[] = [
   "items",
   "items.reveal",
@@ -26,6 +37,7 @@ export const HOST_SUPPORTS: readonly Capability[] = [
   "audio",
   "milestones",
   "storage",
+  "sensors.orientation",
 ]
 
 /**

--- a/dynawalla/dynawalla-app/src/packs/orientation.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/orientation.test.ts
@@ -1,0 +1,337 @@
+// The tilt, driven as a sequence of readings.
+//
+// Nobody here can run this on a phone, so the split matters: everything that is
+// *decidable* — the neutral pose, the wrap at ±180, the re-zero when a tablet is
+// turned, the dead zone, the throttle, and what happens when a device reports
+// nulls forever — is decided here, in Node, from readings. What is left for
+// hardware is two things and they are named: whether `deviceorientation` fires
+// at all inside a WKWebView, and whether `SCREEN_ROTATION` has the four signs
+// the specification implies.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  angleDelta,
+  createOrientationSource,
+  createSampler,
+  SAMPLER_LIMITS,
+  SCREEN_ROTATION,
+  shape,
+} from "./orientation.ts"
+import type { OrientationPorts, RawOrientation } from "./orientation.ts"
+import type { Orientation } from "../../../packs/sdk/src/index.ts"
+import { ORIENTATION_FULL_TILT_DEG } from "../../../packs/sdk/src/index.ts"
+
+/** Faster than any real gap, so the throttle never hides a value in these. */
+const SLOW = { ...SAMPLER_LIMITS, minIntervalMs: 0 }
+
+const raw = (beta: number | null, gamma: number | null): RawOrientation => ({ beta, gamma })
+
+/* ─── angles ──────────────────────────────────────────────────────────────── */
+
+test("an angle delta takes the short way round", () => {
+  assert.equal(angleDelta(0, 10), 10)
+  assert.equal(angleDelta(10, 0), -10)
+  // The bug this exists to stop: beta runs −180..180 and wraps, so a device held
+  // near the seam that rocks two degrees would otherwise read as a 358° swing —
+  // full deflection the wrong way, once per pass, and only ever in somebody's
+  // hands.
+  assert.equal(angleDelta(179, -179), 2)
+  assert.equal(angleDelta(-179, 179), -2)
+  assert.equal(angleDelta(-180, 180), 0)
+})
+
+test("the dead zone is subtracted, not clipped", () => {
+  // Inside it, nothing. A hand is not still, and a game that drifts while a
+  // child holds it as steadily as they can reads as broken rather than as human.
+  assert.equal(shape(0), 0)
+  assert.equal(shape(1.9), 0)
+  assert.equal(shape(-2), 0)
+  // And immediately outside it the value grows from zero rather than jumping to
+  // the fraction the raw angle would have given. A clipping dead zone would step
+  // from 0 to 0.08 the instant a hand moved, which reads as the control catching.
+  assert.ok(shape(2.5) > 0 && shape(2.5) < 0.03, `${String(shape(2.5))} is a step, not a start`)
+  assert.equal(shape(ORIENTATION_FULL_TILT_DEG), 1)
+  assert.equal(shape(-ORIENTATION_FULL_TILT_DEG), -1)
+  // Clamped past full deflection rather than growing: a tablet turned right over
+  // must not steer four times as hard as one held at the stated angle.
+  assert.equal(shape(90), 1)
+  assert.equal(shape(-90), -1)
+})
+
+/* ─── the neutral pose ────────────────────────────────────────────────────── */
+
+test("the pose the stream opened in is zero, whatever it was", () => {
+  // Nobody plays with a tablet flat on a table. Held at forty degrees, an
+  // absolute reading is pinned at full deflection before the game starts.
+  const fold = createSampler(SLOW)
+  const first = fold.push(raw(40, 0), 0, 1000)
+  assert.deepEqual(first, { x: 0, y: 0, degrees: { x: 0, y: 0 } })
+  // And everything after it is measured from there.
+  const tilted = fold.push(raw(40 - ORIENTATION_FULL_TILT_DEG, 0), 0, 2000)
+  assert.equal(tilted?.y, 1)
+})
+
+test("a sample says which way a marble on the screen would roll", () => {
+  // The whole convention, as a physical statement rather than an axis name.
+  const fold = createSampler(SLOW)
+  fold.push(raw(0, 0), 0, 1000)
+
+  // Positive gamma puts the right-hand edge down, so a marble rolls right.
+  const right = fold.push(raw(0, ORIENTATION_FULL_TILT_DEG), 0, 2000)
+  assert.equal(right?.x, 1)
+  assert.equal(right?.y, 0)
+  assert.equal(right?.degrees.x, ORIENTATION_FULL_TILT_DEG)
+
+  const left = fold.push(raw(0, -ORIENTATION_FULL_TILT_DEG), 0, 3000)
+  assert.equal(left?.x, -1)
+
+  // Positive beta LIFTS the top edge, so a marble rolls toward the bottom of the
+  // screen: y is the negative of beta.
+  const up = fold.push(raw(-ORIENTATION_FULL_TILT_DEG, 0), 0, 4000)
+  assert.equal(up?.y, 1)
+  const down = fold.push(raw(ORIENTATION_FULL_TILT_DEG, 0), 0, 5000)
+  assert.equal(down?.y, -1)
+})
+
+test("the wrap at the seam is two degrees, not a full swing", () => {
+  const fold = createSampler(SLOW)
+  fold.push(raw(179, 0), 0, 1000)
+  const rocked = fold.push(raw(-179, 0), 0, 2000)
+  // Two degrees of beta, inside the dead zone, so no steering at all — and
+  // certainly not the −1 a naive subtraction would produce.
+  assert.equal(rocked?.y, 0)
+  assert.equal(rocked?.degrees.y, -2)
+})
+
+/* ─── the screen ──────────────────────────────────────────────────────────── */
+
+test("the rotation table is four rows and each one is a quarter turn", () => {
+  // Read off the Screen Orientation specification and NOT measured on hardware.
+  // Locked here so that a correction from a device is a one-line change with a
+  // failing test to point at.
+  const at = (angle: number) => SCREEN_ROTATION[angle]?.(1, 0)
+  assert.deepEqual(at(0), { x: 1, y: 0 })
+  assert.deepEqual(at(90), { x: 0, y: 1 })
+  assert.deepEqual(at(180), { x: -1, y: 0 })
+  assert.deepEqual(at(270), { x: 0, y: -1 })
+  // And every row is a rotation: length is preserved on both axes.
+  for (const angle of [0, 90, 180, 270]) {
+    const out = SCREEN_ROTATION[angle]?.(3, 4) ?? { x: 0, y: 0 }
+    assert.equal(Math.round(Math.hypot(out.x, out.y)), 5, `angle ${String(angle)} is not a rotation`)
+  }
+})
+
+test("turning the tablet remaps the axes and re-zeroes the pose", () => {
+  const fold = createSampler(SLOW)
+  fold.push(raw(0, 0), 0, 1000)
+  const portrait = fold.push(raw(0, ORIENTATION_FULL_TILT_DEG), 0, 2000)
+  assert.equal(portrait?.x, 1, "right edge down is not steering right in portrait")
+
+  // A quarter turn. The old neutral described "flat", and after the turn that
+  // same physical pose is a different pair of numbers — so keeping it would peg
+  // the steering the moment a child rotated the device.
+  const rezeroed = fold.push(raw(0, ORIENTATION_FULL_TILT_DEG), 90, 3000)
+  assert.deepEqual(rezeroed, { x: 0, y: 0, degrees: { x: 0, y: 0 } })
+  // And from the new neutral, gamma now drives the screen's y axis.
+  const landscape = fold.push(raw(0, ORIENTATION_FULL_TILT_DEG * 2), 90, 4000)
+  assert.equal(landscape?.x, 0)
+  assert.equal(landscape?.y, 1)
+})
+
+test("an angle the platform cannot express steers as though upright", () => {
+  // Better a game that steers as though the device were natural than a game that
+  // stops steering because a WebView reported 45.
+  const fold = createSampler(SLOW)
+  fold.push(raw(0, 0), 45, 1000)
+  const sample = fold.push(raw(0, ORIENTATION_FULL_TILT_DEG), 45, 2000)
+  assert.equal(sample?.x, 1)
+})
+
+/* ─── absence, and silence ────────────────────────────────────────────────── */
+
+test("a device with no sensor reports nulls, and nulls are not readings", () => {
+  // The single most likely way this capability is absent. `deviceorientation`
+  // fires on every desktop browser, sensor or no sensor, with nulls in it — so
+  // `typeof DeviceOrientationEvent` is not a feature test and never was.
+  const fold = createSampler(SLOW)
+  assert.equal(fold.push(raw(null, null), 0, 1000), null)
+  assert.equal(fold.push(raw(0, null), 0, 1100), null)
+  assert.equal(fold.push(raw(null, 0), 0, 1200), null)
+  assert.equal(fold.push(raw(Number.NaN, 0), 0, 1300), null)
+  assert.equal(fold.everRead, false, "a null reading counted as a reading")
+  assert.ok(fold.push(raw(0, 0), 0, 1400))
+  assert.equal(fold.everRead, true)
+})
+
+test("a device held still posts nothing at all", () => {
+  const fold = createSampler(SLOW)
+  assert.ok(fold.push(raw(10, 10), 0, 1000), "the first reading is always worth posting")
+  // A sensor's last digit never settles. Without the change gate a tablet lying
+  // on a table would post thirty structured clones a second forever, each one a
+  // task in the pack's event loop.
+  assert.equal(fold.push(raw(10, 10), 0, 2000), null)
+  assert.equal(fold.push(raw(10.001, 10.001), 0, 3000), null)
+  // A real movement still gets through.
+  assert.ok(fold.push(raw(10, 16), 0, 4000))
+})
+
+test("the throttle is a ceiling on messages, not on readings", () => {
+  const fold = createSampler({ ...SAMPLER_LIMITS, minIntervalMs: 33 })
+  assert.ok(fold.push(raw(0, 0), 0, 1000))
+  // Inside the window, dropped — even though the value moved a long way. The gap
+  // shows up in the stream's `seq`, which is what `seq` is for.
+  assert.equal(fold.push(raw(0, 10), 0, 1010), null)
+  assert.equal(fold.push(raw(0, 20), 0, 1032), null)
+  // Past it, delivered, and it carries the CURRENT value rather than a queued
+  // stale one.
+  const sample = fold.push(raw(0, ORIENTATION_FULL_TILT_DEG), 0, 1033)
+  assert.equal(sample?.x, 1)
+})
+
+/* ─── the source ──────────────────────────────────────────────────────────── */
+
+type Rig = {
+  ports: OrientationPorts
+  /** Push a reading at whoever subscribed. */
+  fire: (reading: RawOrientation) => void
+  subscribed: () => number
+  released: () => number
+}
+
+function rig(options: Partial<OrientationPorts> = {}): Rig {
+  let subscribed = 0
+  let released = 0
+  const listeners = new Set<(reading: RawOrientation) => void>()
+  const ports: OrientationPorts = {
+    present: true,
+    requestPermission: null,
+    subscribe: (onRaw) => {
+      subscribed += 1
+      listeners.add(onRaw)
+      return () => {
+        released += 1
+        listeners.delete(onRaw)
+      }
+    },
+    screenAngle: () => 0,
+    ...options,
+  }
+  return {
+    ports,
+    fire: (reading) => {
+      for (const listener of [...listeners]) listener(reading)
+    },
+    subscribed: () => subscribed,
+    released: () => released,
+  }
+}
+
+const FAST = { warmupMs: 30 }
+
+test("a build with no source says so instead of subscribing to nothing", async () => {
+  const harness = rig({ present: false })
+  const source = createOrientationSource(harness.ports, FAST)
+  assert.equal(source.available, false)
+  assert.equal(await source.start({ emit: () => {}, lost: () => {} }), null)
+  assert.equal(harness.subscribed(), 0)
+})
+
+test("a declined permission is a device that cannot, not an error", async () => {
+  const harness = rig({ requestPermission: async () => false })
+  const source = createOrientationSource(harness.ports, FAST)
+  const stop = await source.start({ emit: () => {}, lost: () => {} })
+  assert.equal(stop, null)
+  // And nothing was subscribed, so a refusal costs no listener and no battery.
+  assert.equal(harness.subscribed(), 0)
+})
+
+test("a permission call that throws is a refusal", async () => {
+  // iOS throws when there is no user activation, and any platform where the
+  // static exists but does not work will throw or reject. All of it is "no".
+  const harness = rig({
+    requestPermission: () => Promise.reject(new Error("no user gesture")),
+  })
+  const source = createOrientationSource(harness.ports, FAST)
+  assert.equal(await source.start({ emit: () => {}, lost: () => {} }), null)
+  assert.equal(harness.subscribed(), 0)
+})
+
+test("a granted permission subscribes once and delivers samples", async () => {
+  const harness = rig({ requestPermission: async () => true })
+  // Unthrottled: the source clocks the throttle off `Date.now()`, and two fires
+  // in one test land in the same millisecond.
+  const source = createOrientationSource(harness.ports, FAST, SLOW)
+  const samples: Orientation[] = []
+  const stop = await source.start({ emit: (sample) => samples.push(sample), lost: () => {} })
+  assert.ok(stop)
+  assert.equal(harness.subscribed(), 1)
+  harness.fire(raw(0, 0))
+  harness.fire(raw(0, ORIENTATION_FULL_TILT_DEG))
+  assert.equal(samples.length, 2)
+  assert.equal(samples[0]?.x, 0)
+  assert.equal(samples[1]?.x, 1)
+  stop()
+  assert.equal(harness.released(), 1)
+  // Idempotent, and nothing arrives afterwards.
+  stop()
+  harness.fire(raw(0, -ORIENTATION_FULL_TILT_DEG))
+  assert.equal(harness.released(), 1)
+  assert.equal(samples.length, 2)
+})
+
+test("a source that never produces a reading gives up and says it is lost", async (t) => {
+  // The real absence check. A desktop browser and a WebView with no sensor both
+  // subscribe successfully and then fire nulls forever, so "did it subscribe" is
+  // not the question — "did a number ever arrive" is.
+  const harness = rig()
+  const source = createOrientationSource(harness.ports, FAST)
+  let lost = 0
+  const stop = await source.start({ emit: () => {}, lost: () => (lost += 1) })
+  assert.ok(stop)
+  harness.fire(raw(null, null))
+  harness.fire(raw(null, null))
+  assert.equal(lost, 0, "given up before the warm-up was over")
+  await new Promise((resolve) => setTimeout(resolve, 60))
+  assert.equal(lost, 1)
+  // And it let go of the listener rather than leaving one attached forever.
+  assert.equal(harness.released(), 1)
+  t.after(stop)
+})
+
+test("one usable reading settles it, and the warm-up never fires", async () => {
+  const harness = rig()
+  const source = createOrientationSource(harness.ports, FAST)
+  let lost = 0
+  const stop = await source.start({ emit: () => {}, lost: () => (lost += 1) })
+  assert.ok(stop)
+  harness.fire(raw(null, null))
+  harness.fire(raw(12, -3))
+  await new Promise((resolve) => setTimeout(resolve, 60))
+  assert.equal(lost, 0, "a working sensor was called lost")
+  assert.equal(harness.released(), 0)
+  stop()
+})
+
+test("stopping inside the warm-up cannot end a stream afterwards", async () => {
+  // This property has TWO independent guards and either one alone is enough: the
+  // `clearTimeout` in `stop`, and the `stopped` check inside the warm-up
+  // callback. Removing either on its own leaves this test green, which was
+  // measured rather than assumed; removing BOTH fails it with
+  // `actual: 1, expected: 0`. The redundancy is deliberate — one stops the timer,
+  // the other stops the effect — and the test is written against the property
+  // rather than against either mechanism, which is why its name no longer claims
+  // "leaves no timer": that is a statement about the mechanism it cannot see.
+  const harness = rig()
+  const source = createOrientationSource(harness.ports, FAST)
+  let lost = 0
+  const stop = await source.start({ emit: () => {}, lost: () => (lost += 1) })
+  assert.ok(stop)
+  stop()
+  await new Promise((resolve) => setTimeout(resolve, 60))
+  // A child who left during the warm-up must not cause a stream to be ended
+  // "unavailable" after the session it belonged to has gone.
+  assert.equal(lost, 0)
+  assert.equal(harness.released(), 1)
+})

--- a/dynawalla/dynawalla-app/src/packs/orientation.ts
+++ b/dynawalla/dynawalla-app/src/packs/orientation.ts
@@ -1,0 +1,387 @@
+// How the device is being held, turned into something a game can steer with.
+//
+// ── Why this is the host's job and not a pack's ──────────────────────────────
+//
+// A pack cannot read a sensor and must not be able to. It is mounted in an
+// iframe with `sandbox="allow-scripts"` and no `allow-same-origin`, so its
+// origin is opaque, and with `allow=""`, which switches off every
+// policy-controlled feature by name. `DeviceOrientationEvent` sits behind the
+// `gyroscope` and `accelerometer` features whose default allowlist is `self`, so
+// it is unreachable from a pack twice over — and on iOS a third time, because
+// `DeviceOrientationEvent.requestPermission()` grants **per origin** and an
+// opaque origin is not something a grant can be remembered against.
+//
+// The fix is not to widen the frame. `allow="gyroscope; accelerometer"` would
+// hand motion sensors to all twenty-eight installed packs in order to serve the
+// one that asked, and `frame.ts` says out loud what that line protects. So the
+// host reads it, resolves it, and posts it — exactly as it already measures the
+// safe-area insets a pack cannot see.
+//
+// ── What crosses the boundary ───────────────────────────────────────────────
+//
+// Two numbers in −1..1 and their angles. No compass heading, no magnetometer,
+// no rotation rate, no acceleration, nothing that could be turned into a claim
+// about where a child is or which way they are facing.
+//
+// ── The sign convention, and the one part that is not verified ──────────────
+//
+// A sample says **which way a marble sitting on the screen would roll**: `x` is
+// +1 when it would roll toward the right-hand edge of the screen, `y` is +1 when
+// it would roll toward the top. That is a physical statement rather than an axis
+// name, so it survives being read by somebody who has never seen
+// `DeviceOrientationEvent`.
+//
+// Getting there needs two facts. The first is settled: with the device flat and
+// face up, positive `gamma` puts the right-hand edge down and positive `beta`
+// lifts the top edge, so the downhill direction in the *device's* frame is
+// `(gamma, −beta)`. The second is `SCREEN_ROTATION` below, which maps the
+// device's frame onto the screen's, and it is read off the Screen Orientation
+// specification rather than measured: **nobody here can run this on a phone.**
+// It is therefore one table with four rows, each one a sentence, so that a
+// correction from a device is a one-line change with a failing test to point at
+// rather than an archaeology exercise. Portrait — `angle` 0 — is the row every
+// claim in this file's tests rests on.
+
+import type { Orientation } from "../../../packs/sdk/src/index.ts"
+import {
+  ORIENTATION_DEADZONE_DEG,
+  ORIENTATION_FULL_TILT_DEG,
+  ORIENTATION_MAX_HZ,
+} from "../../../packs/sdk/src/index.ts"
+
+/**
+ * `-0` collapsed to `0`.
+ *
+ * Negation and `Math.round` both produce negative zero, and it leaks: it is not
+ * `deepEqual` to zero, `1 / -0` is `-Infinity`, and a game normalising a
+ * direction vector at rest gets a sign nobody wrote. Nothing negative-zero
+ * leaves this module.
+ */
+const zeroed = (value: number): number => (value === 0 ? 0 : value)
+
+/** One reading as the platform gives it. `null` is what a device with no sensor sends. */
+export type RawOrientation = {
+  /** Front-back tilt in degrees. Positive lifts the top edge. */
+  readonly beta: number | null
+  /** Left-right tilt in degrees. Positive puts the right-hand edge down. */
+  readonly gamma: number | null
+}
+
+/**
+ * Device frame → screen frame, by the screen's rotation from its natural one.
+ *
+ * `angle` is the screen's rotation from natural, and this table reads it as the
+ * device having been turned **counter-clockwise** by that much — so at 90 the
+ * device's top edge points to the viewer's left, the device's right-hand edge is
+ * what the viewer now sees as up, and a vector `(u, v)` in device axes is
+ * `(−v, u)` in screen axes.
+ *
+ * Anything that is not one of the four is treated as 0 rather than refused: a
+ * platform reporting 45 is a platform whose orientation this host cannot
+ * resolve, and a game that steers as though the device were upright is far
+ * better than a game that stops steering.
+ */
+export const SCREEN_ROTATION: Readonly<
+  Record<number, (u: number, v: number) => { x: number; y: number }>
+> = {
+  /** Natural. The device's axes and the screen's are the same axes. */
+  0: (u, v) => ({ x: zeroed(u), y: zeroed(v) }),
+  /** Turned a quarter counter-clockwise: the device's right edge is screen-up. */
+  90: (u, v) => ({ x: zeroed(-v), y: zeroed(u) }),
+  /** Upside down: both axes reverse. */
+  180: (u, v) => ({ x: zeroed(-u), y: zeroed(-v) }),
+  /** Turned a quarter clockwise: the device's left edge is screen-up. */
+  270: (u, v) => ({ x: zeroed(v), y: zeroed(-u) }),
+}
+
+export type SamplerLimits = {
+  /** Degrees from neutral that read as full deflection. */
+  readonly fullTiltDeg: number
+  /** Degrees from neutral that read as exactly zero. */
+  readonly deadzoneDeg: number
+  /** The shortest gap between two posted samples, in milliseconds. */
+  readonly minIntervalMs: number
+  /**
+   * The smallest change in `x` or `y` worth a message.
+   *
+   * A five-thousandth of full deflection. Below it a device lying still on a
+   * table would post at the throttle rate forever because a sensor's last digit
+   * never settles, and every one of those messages is a structured clone and a
+   * task in the pack's event loop.
+   */
+  readonly quantum: number
+}
+
+export const SAMPLER_LIMITS: SamplerLimits = {
+  fullTiltDeg: ORIENTATION_FULL_TILT_DEG,
+  deadzoneDeg: ORIENTATION_DEADZONE_DEG,
+  minIntervalMs: Math.round(1000 / ORIENTATION_MAX_HZ),
+  quantum: 0.005,
+}
+
+/**
+ * Shortest signed difference between two angles, in degrees.
+ *
+ * `beta` runs −180..180 and wraps. Without this, a device held at 179° that
+ * rocks two degrees reads as a 358° swing — full deflection the wrong way, once
+ * per pass, which is the class of bug that only ever shows up in somebody's
+ * hands.
+ */
+export function angleDelta(from: number, to: number): number {
+  const difference = ((to - from + 540) % 360) - 180
+  return difference
+}
+
+/**
+ * Degrees of tilt → a steering value in −1..1.
+ *
+ * The dead zone is *subtracted* rather than skipped: at exactly the edge of it
+ * the result is 0 and it grows continuously from there. A dead zone that clipped
+ * instead would jump from 0 to 0.08 the instant a hand moved, which reads as the
+ * control catching rather than as a control.
+ */
+export function shape(degrees: number, limits: SamplerLimits = SAMPLER_LIMITS): number {
+  const magnitude = Math.abs(degrees)
+  if (magnitude <= limits.deadzoneDeg) return 0
+  const span = limits.fullTiltDeg - limits.deadzoneDeg
+  if (span <= 0) return Math.sign(degrees)
+  return Math.sign(degrees) * Math.min(1, (magnitude - limits.deadzoneDeg) / span)
+}
+
+export type Sampler = {
+  /**
+   * Fold one platform reading in. Returns the sample to post, or `null` when
+   * there is nothing worth posting.
+   */
+  push(raw: RawOrientation, screenAngle: number, nowMs: number): Orientation | null
+  /** Whether any usable reading has ever arrived. See the warm-up in the source. */
+  readonly everRead: boolean
+}
+
+/**
+ * The whole decision, as a pure function of readings.
+ *
+ * Pure so that the parts that are actually hard — the neutral pose, the wrap at
+ * ±180, the re-zero when a tablet is turned, the throttle — are a Node test
+ * rather than a person holding hardware. What is left for hardware is the sign
+ * table above and whether the events arrive at all.
+ */
+export function createSampler(limits: SamplerLimits = SAMPLER_LIMITS): Sampler {
+  /**
+   * The pose the device was in when the stream opened, in the device's own
+   * frame.
+   *
+   * Nobody plays with a tablet flat on a table. A child holds it at thirty or
+   * forty degrees, so an absolute reading is pinned at full deflection before
+   * the game starts. Held in the *device's* frame rather than the screen's, so
+   * that the neutral is a physical pose and not a pair of numbers that means
+   * something different after a rotation.
+   */
+  let neutral: { beta: number; gamma: number } | null = null
+  let angle = 0
+  let lastEmitMs = Number.NEGATIVE_INFINITY
+  let lastX = 0
+  let lastY = 0
+  let lastDegrees = { x: 0, y: 0 }
+  let emitted = false
+  let everRead = false
+
+  return {
+    get everRead() {
+      return everRead
+    },
+    push: (raw, screenAngle, nowMs) => {
+      // A device with no sensor still fires the event, with nulls in it. That is
+      // the single most likely way this capability is absent, and it is not an
+      // error: it is why the source below has a warm-up rather than trusting
+      // `typeof DeviceOrientationEvent`.
+      if (raw.beta === null || raw.gamma === null) return null
+      if (!Number.isFinite(raw.beta) || !Number.isFinite(raw.gamma)) return null
+      everRead = true
+
+      // Turning the tablet re-zeroes. The old neutral described "the top edge
+      // raised forty degrees", and after a quarter turn that same physical pose
+      // is forty degrees of roll — so keeping it would peg the steering the
+      // moment a child rotated the device.
+      if (screenAngle !== angle) {
+        angle = screenAngle
+        neutral = null
+      }
+
+      if (neutral === null) {
+        neutral = { beta: raw.beta, gamma: raw.gamma }
+      }
+
+      const deltaGamma = angleDelta(neutral.gamma, raw.gamma)
+      const deltaBeta = angleDelta(neutral.beta, raw.beta)
+      // Downhill, in the device's frame: positive gamma puts the right edge
+      // down, positive beta lifts the top edge.
+      const rotate = SCREEN_ROTATION[angle] ?? SCREEN_ROTATION[0]
+      // `?? SCREEN_ROTATION[0]` cannot actually be reached — 0 is a key of the
+      // literal — but `noUncheckedIndexedAccess` is on and a non-null assertion
+      // here would be the one place in this file that says "trust me".
+      const screen = rotate ? rotate(deltaGamma, -deltaBeta) : { x: deltaGamma, y: -deltaBeta }
+
+      const degrees = { x: zeroed(Math.round(screen.x)), y: zeroed(Math.round(screen.y)) }
+      const x = zeroed(shape(screen.x, limits))
+      const y = zeroed(shape(screen.y, limits))
+
+      // The throttle. A sensor fires faster than any game can use and every
+      // message is a structured clone and a task in the pack's event loop.
+      if (emitted && nowMs - lastEmitMs < limits.minIntervalMs) return null
+      // And a device held still posts nothing at all: the pack keeps the last
+      // value it was given, which is what `seq` gaps in the contract are for.
+      //
+      // `degrees` is part of the comparison and not only the steering values,
+      // because a game may be drawing a gauge rather than steering: inside the
+      // dead zone x and y are both pinned at zero while the angle a child is
+      // being asked to hold is still moving, and a gauge that froze there would
+      // be the one surface where this reads as broken.
+      const still =
+        Math.abs(x - lastX) < limits.quantum &&
+        Math.abs(y - lastY) < limits.quantum &&
+        degrees.x === lastDegrees.x &&
+        degrees.y === lastDegrees.y
+      if (emitted && still) return null
+
+      lastEmitMs = nowMs
+      lastX = x
+      lastY = y
+      lastDegrees = degrees
+      emitted = true
+      return { x, y, degrees }
+    },
+  }
+}
+
+/* ─── the platform side ────────────────────────────────────────────────────── */
+
+/**
+ * The ways this build can reach an orientation reading, as a port.
+ *
+ * A port rather than a direct `addEventListener`, for the same reason
+ * `haptics.ts` has one: every decision above and below it is then testable in
+ * Node with no WebView, no device and no Tauri, and the day a native plugin
+ * lands it is a second implementation of this interface rather than a rewrite of
+ * the logic that uses it.
+ *
+ * **There is no native implementation yet, and that is the point of the shape.**
+ * `platform.ts` builds the web one. A `tauri-plugin-orientation` reading
+ * CoreMotion and Android's `SensorManager` plugs in here and changes nothing
+ * else — see `docs/NATIVE_CAPABILITIES.md`.
+ */
+export type OrientationPorts = {
+  /**
+   * Whether this platform exposes a source at all.
+   *
+   * Deliberately weak: it is true in every desktop browser, including ones with
+   * no sensor anywhere near them. It is the *static* answer that goes into
+   * `Connect.available`, and the warm-up below is what settles the real one.
+   */
+  readonly present: boolean
+  /**
+   * Ask for permission, or `null` where none is needed.
+   *
+   * `null` on Android and on the desktop. A function on iOS, where
+   * `DeviceOrientationEvent.requestPermission()` exists and must be called from
+   * a real user gesture — which is why it is called from the launch tap in the
+   * *host's* document and never from a pack. A pack has no user activation to
+   * lend and no origin to hold the grant.
+   */
+  readonly requestPermission: (() => Promise<boolean>) | null
+  /** Subscribe to raw readings. Returns the unsubscribe. */
+  readonly subscribe: (onRaw: (raw: RawOrientation) => void) => () => void
+  /** The screen's rotation from natural, in degrees. */
+  readonly screenAngle: () => number
+}
+
+/** Injected in tests so a suite does not wait out the warm-up. */
+export type SourceLimits = {
+  /**
+   * How long a started stream has to produce one usable reading.
+   *
+   * This is the real absence check. `typeof DeviceOrientationEvent !== "undefined"`
+   * is true in every desktop browser and in WebViews with no sensor behind them;
+   * what separates a device that can do this from one that cannot is whether a
+   * reading with numbers in it ever turns up. A second and a half is far longer
+   * than any sensor takes to produce its first sample and short enough that a
+   * game asking at startup is not left waiting.
+   */
+  readonly warmupMs: number
+}
+
+export const SOURCE_LIMITS: SourceLimits = { warmupMs: 1_500 }
+
+export type OrientationSource = {
+  /** The static answer, for `Connect.available`. */
+  readonly available: boolean
+  /**
+   * Start reading.
+   *
+   * Resolves to a stop function, or to `null` when this device cannot — a
+   * missing source, or a permission somebody declined. `lost` is called at most
+   * once, later, if the stream was started and then turned out to be feeding
+   * nothing; the caller ends the stream `unavailable` on it.
+   */
+  start(input: {
+    emit: (sample: Orientation) => void
+    lost: () => void
+  }): Promise<(() => void) | null>
+}
+
+export function createOrientationSource(
+  ports: OrientationPorts,
+  limits: SourceLimits = SOURCE_LIMITS,
+  sampler: SamplerLimits = SAMPLER_LIMITS,
+): OrientationSource {
+  return {
+    available: ports.present,
+    start: async ({ emit, lost }) => {
+      if (!ports.present) return null
+      if (ports.requestPermission) {
+        // A rejected prompt is a refusal, not a crash: on a platform where the
+        // call throws because there was no user activation, the answer is the
+        // same as "no" and the game plays without it.
+        const granted = await ports.requestPermission().catch(() => false)
+        if (!granted) return null
+      }
+
+      const fold = createSampler(sampler)
+      let stopped = false
+      let warmup: ReturnType<typeof setTimeout> | null = null
+
+      const unsubscribe = ports.subscribe((raw) => {
+        if (stopped) return
+        const sample = fold.push(raw, ports.screenAngle(), Date.now())
+        if (fold.everRead && warmup !== null) {
+          clearTimeout(warmup)
+          warmup = null
+        }
+        if (sample !== null) emit(sample)
+      })
+
+      const stop = () => {
+        if (stopped) return
+        stopped = true
+        if (warmup !== null) {
+          clearTimeout(warmup)
+          warmup = null
+        }
+        unsubscribe()
+      }
+
+      warmup = setTimeout(() => {
+        warmup = null
+        if (stopped || fold.everRead) return
+        // Started, subscribed, and nothing usable ever arrived. Stop the
+        // subscription and say so: the caller ends the stream `unavailable`,
+        // the pack's SDK writes one loud line for whoever is building it, and
+        // the child sees a game that simply has no tilt control.
+        stop()
+        lost()
+      }, limits.warmupMs)
+
+      return stop
+    },
+  }
+}

--- a/dynawalla/dynawalla-app/src/packs/services.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.test.ts
@@ -13,12 +13,16 @@ import assert from "node:assert/strict"
 
 import { createServices } from "./services.ts"
 import type { HapticPorts, HapticStyle } from "./haptics.ts"
+import type { OrientationSource } from "./orientation.ts"
 import type { HapticCue, Settings } from "../../../packs/sdk/src/index.ts"
 
 const CUES: readonly HapticCue[] = ["tick", "seat", "settle", "refuse"]
 
 /** Which pack asked. Carried by every host call; irrelevant to the gate. */
 const PACK = "dw.test"
+
+/** A device with no sensor. `orientation.test.ts` is where the real one is driven. */
+const NO_SENSOR: OrientationSource = { available: false, start: async () => null }
 
 const SETTINGS = (haptics: boolean): Settings => ({
   locale: "en",
@@ -51,7 +55,7 @@ function recorder(): { ports: HapticPorts; fired: (HapticStyle | number | number
 /** A fresh session. `profileId` is unique per test so no storage is shared. */
 function session(profileId: string, haptics: boolean) {
   const { ports, fired } = recorder()
-  const launch = createServices({ profileId, settings: SETTINGS(haptics), haptics: ports })
+  const launch = createServices({ profileId, settings: SETTINGS(haptics), haptics: ports, orientation: NO_SENSOR })
   return { launch, fired }
 }
 
@@ -101,7 +105,12 @@ test("haptics off silences the vibrator too, not just the plugin", async () => {
       return true
     },
   }
-  const launch = createServices({ profileId: "p-web", settings: SETTINGS(false), haptics: ports })
+  const launch = createServices({
+    profileId: "p-web",
+    settings: SETTINGS(false),
+    haptics: ports,
+    orientation: NO_SENSOR,
+  })
   for (const cue of CUES) await launch.services.haptic({ packId: PACK, cue })
   assert.deepEqual(fired, [])
 

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -11,13 +11,17 @@
 // child who played.
 
 import type {
+  Capability,
   Item,
+  NativeCapability,
   Settings,
   SoundCue,
   TransitionKind,
 } from "../../../packs/sdk/src/index.ts"
+import { CAPABILITY_IDS, isNativeBacked } from "../../../packs/sdk/src/index.ts"
 import type { HostServices } from "./bridge.ts"
 import { fireHaptic, type HapticPorts } from "./haptics.ts"
+import type { OrientationSource } from "./orientation.ts"
 import { createItemService, type ItemService } from "./items.ts"
 import { report } from "./host.ts"
 import { packStorageFor } from "./storage.ts"
@@ -151,6 +155,14 @@ export type ServicesDeps = {
    * fix, reintroduced one layer up. The compiler asks instead.
    */
   readonly haptics: HapticPorts
+  /**
+   * Where a tilt reading comes from.
+   *
+   * Required for the same reason `haptics` is: a defaulted source would make
+   * "nobody wired the sensor" compile, run, and look exactly like a device that
+   * has none. The compiler asks instead.
+   */
+  readonly orientation: OrientationSource
   readonly onProgress?: (fraction: number) => void
   readonly onEnd?: (reason: "finished" | "quit") => void
   readonly onMilestone?: (name: string) => void
@@ -237,6 +249,45 @@ export function createServices(deps: ServicesDeps): LaunchServices {
         return Promise.resolve()
       },
       keys: (input) => Promise.resolve(keysOf(input.packId)),
+    },
+
+    /**
+     * The native-backed surface. One entry so far, and the shape is the point.
+     *
+     * Nothing here is gated on a setting: `settings.haptics` exists because a
+     * buzz is something the app *does to* a child, and how a tablet is being
+     * held is something the app reads at a game's request. There is a real
+     * consent question here and it is answered one layer down — the permission
+     * is asked for by the host on a user gesture, and a device that says no is
+     * simply unavailable.
+     */
+    sensors: {
+      orientation: (input) => deps.orientation.start({ emit: input.emit, lost: input.lost }),
+    },
+
+    /**
+     * What this device can do, as opposed to what this build supports.
+     *
+     * A `Record` over `NativeCapability` rather than a list, so that adding a
+     * native capability to the SDK's table **fails to compile here** until
+     * somebody has decided how to detect it. A missing entry would otherwise
+     * mean "unavailable forever", which degrades correctly and says nothing.
+     */
+    available: () => {
+      const native: Readonly<Record<NativeCapability, boolean>> = {
+        "sensors.orientation": deps.orientation.available,
+      }
+      const list: Capability[] = []
+      for (const capability of CAPABILITY_IDS) {
+        // Everything the host answers itself is available by definition: it is
+        // this code, and this code is running.
+        if (!isNativeBacked(capability)) {
+          list.push(capability)
+          continue
+        }
+        if (native[capability as NativeCapability]) list.push(capability)
+      }
+      return list
     },
 
     progress: (input) => deps.onProgress?.(input.fraction),

--- a/dynawalla/packs/sdk/README.md
+++ b/dynawalla/packs/sdk/README.md
@@ -151,9 +151,80 @@ locally in the client, without a round trip.
 | `audio`        | `host.sound("settle")`                                  |
 | `milestones`   | `host.milestone("tower.built")`                         |
 | `storage`      | 200 keys, 16 KB per value, scoped to your pack          |
+| `sensors.orientation` | `host.tilt` — how the device is being held             |
 
-`host.progress(fraction)`, `host.end(reason)` and `host.transition(kind)` need
-no capability: they are how a session is a session.
+`host.progress(fraction)`, `host.end(reason)`, `host.transition(kind)` and
+cancelling a stream need no capability: they are how a session is a session.
+
+### Native capabilities, and how to fail well
+
+A capability marked **native** is answered by the *device* rather than by the
+host's own code — a sensor today, a voice or an on-device model later. Two things
+about them are different from everything above, and one of them is your job.
+
+**They can be granted and still unavailable.** A tablet with no gyroscope, a
+build shipped without a plugin, a permission somebody declined: all of those are
+normal, none of them is an error, and a child must never see a message about one.
+
+```ts
+// The check to write before DRAWING a control that depends on one — a tilt
+// toggle, a "read it to me" button. Not before calling it.
+if (host.available("sensors.orientation")) drawTiltToggle()
+```
+
+**Calling one that is absent is already harmless.** Nothing on the native surface
+throws or rejects. It writes **one** loud `console.error` naming the capability
+and the fix, and then does nothing — so a game with no `if` and no `try` is
+already correct, and the only way to get this wrong is to draw a control that
+promises something the device cannot do.
+
+**They may be slow.** Each one declares its own budget: 2 seconds for anything
+local, 10 for something that may have to ask a person for permission, more for a
+model. If the host does not answer inside it you get `PackError("timeout")`
+rather than a promise that never settles. Never block a frame on one.
+
+### `host.tilt` — steering by how the device is held
+
+```ts
+if (!host.tilt.available) return                    // draw no tilt control
+const stop = host.tilt.start(({ x, y, degrees }) => {
+  steer(x, y)                                       // −1..1, screen-relative
+  gauge(degrees.x)                                  // whole degrees, for a dial
+})
+// …later, when the child leaves the part of the game that steers:
+stop()
+```
+
+**A sample says which way a marble sitting on your screen would roll.** `x` is
++1 when it would roll toward the right-hand edge, `y` is +1 when it would roll
+toward the top — whatever way up the device is being held, because the host has
+already resolved the screen's rotation for you.
+
+Three things the host has done that you must not redo:
+
+- **Zeroed on the pose the stream opened in.** Nobody plays with a tablet flat on
+  a table, and an absolute reading is pinned before your game starts. Turning the
+  device re-zeroes it.
+- **Dead-zoned and clamped.** Full deflection at 25° from neutral, nothing inside
+  2°, and never outside −1..1.
+- **Throttled to 30 Hz, and silent when the device is still.** No message is not
+  a stream that stopped: keep the last value you were given. Your samples carry a
+  `seq` and a gap in it is a deliberate drop.
+
+**Call `stop()`.** The host ends every stream when your pack goes away, so
+nothing leaks — but a sensor running behind your menu is a battery cost for
+nothing. And a paused pack receives no samples at all, so the `pause` event you
+already handle is enough to stop steering behind a sheet.
+
+You cannot read `DeviceOrientationEvent` yourself and you should not try: a pack
+frame is `sandbox="allow-scripts"` with `allow=""`, so its origin is opaque and
+motion sensors are switched off explicitly. That is why this is a capability and
+not an API.
+
+To develop against it, `npm run serve` gives you a real stream — from the
+machine's own sensor if it has one, and otherwise from **dragging the pointer**
+over the workbench. That is synthetic and the log says so; a control that felt
+right against a mouse can feel wrong against a wrist.
 
 ### `host.transition` — say when your game reached a natural ending
 

--- a/dynawalla/packs/sdk/bin/harness.js
+++ b/dynawalla/packs/sdk/bin/harness.js
@@ -148,6 +148,75 @@ async function answer(method, params) {
 
 const frame = document.getElementById("pack")
 
+/* ─── tilt ──────────────────────────────────────────────────────────────────
+ *
+ * A pack that declares `sensors.orientation` gets a real stream here, because
+ * otherwise there is no way to develop tilt steering at all: the capability is
+ * host-pushed by design, so a pack cannot fake it from inside itself.
+ *
+ * The reading comes from `deviceorientation` where there is one, and from the
+ * POINTER otherwise — drag anywhere over the workbench and the pack is steered.
+ * That is synthetic and is said out loud in the log, because a control that felt
+ * right against a mouse and wrong against a wrist is the mistake this is for.
+ *
+ * The angles match the contract: full deflection at ±25°, dead zone 2°, and a
+ * sample says which way a marble on the screen would roll.
+ */
+const FULL_TILT_DEG = 25
+const DEADZONE_DEG = 2
+/** Open tilt streams, handle → the last `seq` sent on it. */
+const streams = new Map()
+
+/** The same curve `orientation.ts` uses: the dead zone is subtracted, not clipped. */
+const shape = (degrees) => {
+  const magnitude = Math.abs(degrees)
+  if (magnitude <= DEADZONE_DEG) return 0
+  const span = FULL_TILT_DEG - DEADZONE_DEG
+  return Math.sign(degrees) * Math.min(1, (magnitude - DEADZONE_DEG) / span)
+}
+
+function feedTilt(port, degX, degY) {
+  if (streams.size === 0) return
+  const sample = {
+    x: shape(degX),
+    y: shape(degY),
+    degrees: { x: Math.round(degX), y: Math.round(degY) },
+  }
+  for (const [stream, seq] of [...streams]) {
+    streams.set(stream, seq + 1)
+    port.postMessage({ stream, seq: seq + 1, data: sample })
+  }
+}
+
+function wireTilt(port) {
+  let neutral = null
+  addEventListener("deviceorientation", (event) => {
+    if (event.beta === null || event.gamma === null) return
+    neutral ??= { beta: event.beta, gamma: event.gamma }
+    feedTilt(port, event.gamma - neutral.gamma, -(event.beta - neutral.beta))
+  })
+
+  // The pointer fallback. Dragging from the centre of the window to an edge is
+  // full deflection, which is the only mapping a mouse can honestly offer.
+  let dragging = false
+  const fromPointer = (event) => {
+    const x = ((event.clientX / innerWidth) * 2 - 1) * FULL_TILT_DEG
+    const y = -((event.clientY / innerHeight) * 2 - 1) * FULL_TILT_DEG
+    feedTilt(port, x, y)
+  }
+  addEventListener("pointerdown", (event) => {
+    dragging = true
+    fromPointer(event)
+  })
+  addEventListener("pointermove", (event) => {
+    if (dragging) fromPointer(event)
+  })
+  addEventListener("pointerup", () => {
+    dragging = false
+    feedTilt(port, 0, 0)
+  })
+}
+
 addEventListener("message", (event) => {
   if (event.source !== frame.contentWindow) return
   if (!event.data || event.data.event !== "ready") return
@@ -160,6 +229,21 @@ addEventListener("message", (event) => {
       channel.port1.postMessage({ id, ok: false, error: { code: "unknown_method", message: String(method) } })
       return
     }
+    if (method === "sensors.orientation.start") {
+      streams.set(id, 0)
+      write("in", `tilt stream ${id} opened — drag over the workbench to steer (synthetic)`)
+      channel.port1.postMessage({ id, ok: true, result: { stream: id } })
+      return
+    }
+    if (method === "stream.cancel") {
+      const stream = params.stream
+      if (streams.delete(stream)) {
+        write("out", `stream ${stream} cancelled`)
+        channel.port1.postMessage({ stream, done: true, reason: "cancelled" })
+      }
+      channel.port1.postMessage({ id, ok: true, result: null })
+      return
+    }
     try {
       const result = await answer(method, params)
       channel.port1.postMessage({ id, ok: true, result: result ?? null })
@@ -169,6 +253,7 @@ addEventListener("message", (event) => {
     }
   }
   channel.port1.start()
+  wireTilt(channel.port1)
 
   frame.contentWindow.postMessage(
     {
@@ -177,6 +262,12 @@ addEventListener("message", (event) => {
       sdk: surface.sdk,
       host: "0.0.0-workbench",
       packId: surface.packId,
+      // Everything granted is available in the workbench: this is a desktop
+      // browser and the point of it is to exercise the capability, not to
+      // simulate a tablet that lacks it. A pack's absent path is exercised by
+      // REMOVING the capability from its manifest, which is one line and is what
+      // an author should do before shipping.
+      available: surface.granted,
       granted: surface.granted,
       settings,
     },

--- a/dynawalla/packs/sdk/src/capabilities.test.ts
+++ b/dynawalla/packs/sdk/src/capabilities.test.ts
@@ -5,11 +5,17 @@ import {
   CAPABILITIES,
   CAPABILITY_IDS,
   METHODS,
+  NATIVE_CAPABILITIES,
+  SESSION_BUDGET_MS,
   SESSION_METHODS,
+  STREAM_METHODS,
+  budgetOf,
   capabilityOf,
   isCapability,
   isMethod,
+  isNativeBacked,
   labelOf,
+  opensStream,
   permits,
 } from "./capabilities.ts"
 import type { Method } from "./capabilities.ts"
@@ -96,4 +102,86 @@ test("nothing in the table grants the things a pack must never have", () => {
   for (const forbidden of ["fetch", "network", "http", "file", "exec", "invoke", "eval", "camera", "microphone", "location"]) {
     assert.ok(!surface.includes(forbidden), `the capability table mentions ${forbidden}`)
   }
+})
+
+test("every method has a budget, and it is a number a pack can wait out", () => {
+  // Totality is the property that matters: the guest arms its deadline from
+  // this, so a method with no budget is a method a pack waits on forever, which
+  // is the failure this field exists to end. A `?? SESSION_BUDGET_MS` fallback
+  // makes that unobservable at the call site, so it is checked here instead.
+  for (const method of METHODS) {
+    const budget = budgetOf(method)
+    assert.equal(typeof budget, "number")
+    assert.ok(Number.isFinite(budget) && budget > 0, `${method} has a budget of ${String(budget)}`)
+    // A minute is not a budget, it is a hang with extra steps: nothing a child
+    // is waiting on may be allowed to take that long.
+    assert.ok(budget <= 30_000, `${method} may take ${String(budget)}ms`)
+  }
+  for (const method of SESSION_METHODS) {
+    assert.equal(budgetOf(method), SESSION_BUDGET_MS)
+  }
+})
+
+test("a native-backed capability is allowed longer than a local one", () => {
+  // Not decoration. The whole reason `budgetMs` is per capability rather than
+  // one constant is that an on-device model and a store read cannot share a
+  // deadline, and a native capability that inherited the local budget would
+  // time out on a device that was working correctly.
+  const local = CAPABILITIES.filter((entry) => !entry.native)
+  const native = CAPABILITIES.filter((entry) => entry.native)
+  assert.ok(native.length > 0, "there is no native-backed capability to check")
+  const slowestLocal = Math.max(...local.map((entry) => entry.budgetMs))
+  for (const entry of native) {
+    assert.ok(
+      entry.budgetMs > slowestLocal,
+      `${entry.id} has ${String(entry.budgetMs)}ms, no more than the slowest local ${String(slowestLocal)}ms`,
+    )
+  }
+})
+
+test("the native-backed list is derived from the table, not written twice", () => {
+  // Widened deliberately: TypeScript infers a type predicate from
+  // `(entry) => entry.native` and narrows the array to the one native row, which
+  // would make `includes` below reject every other capability at compile time
+  // instead of answering the question the test is asking.
+  const fromTable: readonly string[] = CAPABILITIES.filter((entry) => entry.native).map(
+    (entry) => entry.id,
+  )
+  assert.deepEqual([...NATIVE_CAPABILITIES], fromTable)
+  for (const id of CAPABILITY_IDS) {
+    assert.equal(isNativeBacked(id), fromTable.includes(id), `isNativeBacked disagrees about ${id}`)
+  }
+})
+
+test("every streaming method is a real method, and needs a grant", () => {
+  for (const method of STREAM_METHODS) {
+    assert.equal(isMethod(method), true, `${method} is in STREAM_METHODS and is not a method`)
+    assert.equal(opensStream(method), true)
+    // A stream is a subscription to something outside the WebView. Nothing that
+    // opens one may be a session method, or every pack would hold one whether
+    // its manifest declared it or not.
+    assert.notEqual(capabilityOf(method), null, `${method} opens a stream with no capability`)
+  }
+  for (const method of METHODS) {
+    if ((STREAM_METHODS as readonly string[]).includes(method)) continue
+    assert.equal(opensStream(method), false, `${method} claims to open a stream`)
+  }
+})
+
+test("cancelling a stream is not a privilege", () => {
+  // A pack that could not stop a stream is a pack that leaves a sensor running
+  // after a child has left, and it could only be stopped by tearing the whole
+  // session down. Ownership is structural instead: the host's stream table is
+  // per pack, so a cancel can only ever reach a stream this pack opened.
+  assert.equal(permits([], "stream.cancel"), true)
+  assert.equal(capabilityOf("stream.cancel"), null)
+})
+
+test("the tilt capability grants a stream and nothing else", () => {
+  assert.equal(permits(["sensors.orientation"], "sensors.orientation.start"), true)
+  // Not reachable by declaring anything else, and in particular not by
+  // declaring every other capability in the table.
+  const others = CAPABILITY_IDS.filter((id) => id !== "sensors.orientation")
+  assert.equal(permits(others, "sensors.orientation.start"), false)
+  assert.equal(isNativeBacked("sensors.orientation"), true)
 })

--- a/dynawalla/packs/sdk/src/capabilities.ts
+++ b/dynawalla/packs/sdk/src/capabilities.ts
@@ -25,14 +25,59 @@
 // decline to declare it and thereby decline ever to reach a stopping point —
 // the day pass would then be enforceable only by a clock, which is the thing
 // this product does not do.
+//
+// ── Native-backed capabilities ───────────────────────────────────────────────
+//
+// Some rows below are answered by the *device* rather than by the host's own
+// TypeScript: a sensor, a speech synthesiser, a model. Three things about them
+// are different, and each is a field rather than a convention because a
+// convention is what the next five capabilities will forget.
+//
+//   `native`    This capability's answer comes from outside the WebView. It is
+//               therefore allowed to be *absent on a device that the build
+//               otherwise supports*, which no other capability is. See
+//               `docs/NATIVE_CAPABILITIES.md`; the rule that matters is that
+//               absence is a runtime fact reported in `Connect.available`, and
+//               is NEVER expressed by dropping the row from the host's
+//               `HOST_SUPPORTS` — doing that refuses to *install* a pack on a
+//               device that merely lacks a sensor.
+//
+//   `budgetMs`  How long the host may take to answer, stated in the contract
+//               rather than discovered. Every capability that existed before
+//               this field answers in microseconds; an on-device model does
+//               not, and a pack holding a promise that never settles is the
+//               silent failure this repository keeps paying for. The guest
+//               client arms a timer from this number and rejects with
+//               `timeout` rather than waiting forever.
+//
+//   Streams     A native answer often arrives over time — samples from a
+//               sensor, words from a synthesiser, tokens from a model. Those
+//               methods are listed in `STREAM_METHODS`: they answer with a
+//               stream handle, and everything after that arrives on the
+//               `StreamUpdate` envelope in `protocol.ts`.
 
-/** Methods every pack may call, with no declaration and no grant. */
+/**
+ * Methods every pack may call, with no declaration and no grant.
+ *
+ * `stream.cancel` is here and not behind a capability on purpose. A pack can
+ * only cancel a stream it opened — the host's stream table is per-pack, so
+ * ownership is structural rather than checked — and a pack that could not stop
+ * a stream is a pack that leaves a sensor running after a child has left. The
+ * ability to stop is never a privilege.
+ */
 export const SESSION_METHODS = [
   "session.settings",
   "session.progress",
   "session.end",
   "session.transition",
+  "stream.cancel",
 ] as const
+
+/**
+ * The budget for a session method. Small, because every one of them is a
+ * store write or a field read in the host's own realm.
+ */
+export const SESSION_BUDGET_MS = 2_000
 
 export const CAPABILITIES = [
   {
@@ -40,40 +85,94 @@ export const CAPABILITIES = [
     methods: ["items.next", "items.answer", "items.skip"],
     /** Shown to a parent, in their language, before the pack is installed. */
     label: "Ask for practice questions and report answers",
+    budgetMs: 2_000,
+    native: false,
   },
   {
     id: "items.reveal",
     methods: ["items.reveal"],
     label: "Read the answer to the current question before it is answered",
+    budgetMs: 2_000,
+    native: false,
   },
   {
     id: "learner.read",
     methods: ["learner.summary"],
     label: "Read which topics have been practised",
+    budgetMs: 2_000,
+    native: false,
   },
   {
     id: "haptics",
     methods: ["feedback.haptic"],
     label: "Vibrate the device",
+    budgetMs: 2_000,
+    native: false,
   },
   {
     id: "audio",
     methods: ["feedback.sound"],
     label: "Play the app's sounds",
+    budgetMs: 2_000,
+    native: false,
   },
   {
     id: "milestones",
     methods: ["milestone.reach"],
     label: "Mark that something was finished",
+    budgetMs: 2_000,
+    native: false,
   },
   {
     id: "storage",
     methods: ["storage.get", "storage.set", "storage.remove", "storage.keys"],
     label: "Save its own progress on this device",
+    budgetMs: 2_000,
+    native: false,
+  },
+  {
+    /**
+     * How the device is being held, as a stream, measured by the HOST.
+     *
+     * The first native-backed capability, and it is deliberately the smallest
+     * one: the pack is granted no sensor. It cannot be. A pack frame is
+     * `sandbox="allow-scripts"` with no `allow-same-origin` and `allow=""`, so
+     * its origin is opaque and every policy-controlled feature is off —
+     * `DeviceOrientationEvent` is unreachable from a pack twice over, and on
+     * iOS a third time because `requestPermission()` grants per origin and an
+     * opaque origin cannot hold a grant. Handing the frame
+     * `allow="gyroscope; accelerometer"` would give motion sensors to every
+     * installed pack in order to serve one, which is the boundary the frame
+     * exists to hold.
+     *
+     * So the host reads it and posts it, exactly as it already measures the
+     * safe-area insets a pack cannot see. What crosses the port is two numbers
+     * in −1..1 and their angles: no raw sensor frame, no magnetometer, no
+     * heading, nothing that says which way a child is facing.
+     *
+     * The budget is ten seconds because starting one may include a permission
+     * decision a person has to make. See `docs/NATIVE_CAPABILITIES.md`.
+     */
+    id: "sensors.orientation",
+    methods: ["sensors.orientation.start"],
+    label: "Read how the device is being tilted",
+    budgetMs: 10_000,
+    native: true,
   },
 ] as const
 
 export type Capability = (typeof CAPABILITIES)[number]["id"]
+
+/**
+ * The capabilities answered by the device.
+ *
+ * Extracted from the table rather than listed, so that a host's availability
+ * table is a `Record<NativeCapability, boolean>` and **adding a native
+ * capability fails to compile until somebody decides how to detect it**. The
+ * alternative is a lookup that returns `undefined`, which degrades to
+ * "unavailable forever" — the safe direction, and a silent one.
+ */
+export type NativeCapability = Extract<(typeof CAPABILITIES)[number], { native: true }>["id"]
 
 export type SessionMethod = (typeof SESSION_METHODS)[number]
 export type CapabilityMethod = (typeof CAPABILITIES)[number]["methods"][number]
@@ -81,11 +180,38 @@ export type Method = SessionMethod | CapabilityMethod
 
 export const CAPABILITY_IDS: readonly Capability[] = CAPABILITIES.map((entry) => entry.id)
 
+/**
+ * The capabilities whose answer comes from the device rather than from the
+ * host's own code, and which may therefore be granted and still unavailable.
+ */
+export const NATIVE_CAPABILITIES: readonly Capability[] = CAPABILITIES.filter(
+  (entry) => entry.native,
+).map((entry) => entry.id)
+
+/**
+ * Methods that answer with a stream handle instead of a value.
+ *
+ * Listed here rather than inferred from a name so that a generic client — the
+ * SDK's own workbench, a future host in another language — can tell the two
+ * kinds of call apart without knowing what any of them mean.
+ */
+export const STREAM_METHODS = ["sensors.orientation.start"] as const
+
+export type StreamMethod = (typeof STREAM_METHODS)[number]
+
 const BY_METHOD = new Map<string, Capability>(
   CAPABILITIES.flatMap((entry) => entry.methods.map((method) => [method as string, entry.id])),
 )
 
+const BUDGET_BY_METHOD = new Map<string, number>(
+  CAPABILITIES.flatMap((entry) =>
+    entry.methods.map((method) => [method as string, entry.budgetMs] as const),
+  ),
+)
+
 const SESSION = new Set<string>(SESSION_METHODS)
+
+const STREAMS = new Set<string>(STREAM_METHODS)
 
 export const METHODS: readonly Method[] = [
   ...SESSION_METHODS,
@@ -98,6 +224,16 @@ export function isMethod(value: unknown): value is Method {
 
 export function isCapability(value: unknown): value is Capability {
   return typeof value === "string" && CAPABILITY_IDS.includes(value as Capability)
+}
+
+/** Whether this method's answer is a stream handle rather than a value. */
+export function opensStream(method: Method): boolean {
+  return STREAMS.has(method)
+}
+
+/** Whether this capability is answered by the device rather than by the host. */
+export function isNativeBacked(capability: Capability): boolean {
+  return NATIVE_CAPABILITIES.includes(capability)
 }
 
 /** The parent-facing label for a capability, for the install sheet. */
@@ -116,6 +252,18 @@ export function capabilityOf(method: Method): Capability | null {
   if (SESSION.has(method)) return null
   const capability = BY_METHOD.get(method)
   return capability ?? null
+}
+
+/**
+ * How long the host may take to answer this method.
+ *
+ * Total over `METHODS`, and it has to be: the guest arms a timer from it, and a
+ * method with no budget would be a method a pack can wait on forever. A value
+ * that is not in the table is not a method, and gets the session budget rather
+ * than infinity.
+ */
+export function budgetOf(method: Method): number {
+  return BUDGET_BY_METHOD.get(method) ?? SESSION_BUDGET_MS
 }
 
 /** Whether `granted` admits `method`. The single enforcement predicate. */

--- a/dynawalla/packs/sdk/src/guest.test.ts
+++ b/dynawalla/packs/sdk/src/guest.test.ts
@@ -26,6 +26,10 @@ type Frame = {
 function withFakeFrame(
   options: {
     granted?: string[]
+    /** What the device can actually do. Defaults to all of `granted`. */
+    available?: string[]
+    /** Omit `available` from the connect payload, the way a 1.0 host does. */
+    legacyHost?: boolean
     /** Answers one request. Return `undefined` to leave it pending. */
     answer?: (request: Request) => Omit<Response, "id"> | undefined
     framed?: boolean
@@ -48,6 +52,9 @@ function withFakeFrame(
             host: "0.1.0",
             packId: "abacus.tower",
             granted: options.granted ?? ["items", "storage"],
+            ...(options.legacyHost
+              ? {}
+              : { available: options.available ?? options.granted ?? ["items", "storage"] }),
             settings: {
               locale: "en",
               reducedMotion: false,
@@ -347,5 +354,407 @@ test("connecting installs the tap guard on the pack document", async (t) => {
   const host = await client
   assert.ok(bound.includes("touchend"), `no touchend guard on the pack document: ${bound.join(", ")}`)
   assert.ok(bound.includes("touchstart"))
+  host.dispose()
+})
+
+/* ─── deadlines ──────────────────────────────────────────────────────────── */
+
+test("a host that never answers times out, and the budget is the capability's own", async (t) => {
+  t.after(cleanup)
+  // Two failures in one test, because the second only means anything next to
+  // the first.
+  //
+  // Before the deadline, a host that dropped a request left the pack holding a
+  // promise that never settled: a game awaiting it sat on its loading state for
+  // the rest of the session with nothing in any log. `answer: () => undefined`
+  // is exactly that host.
+  //
+  // And a *single* global deadline would be wrong in both directions — it would
+  // either give a store read ten seconds to fail in, or time out a working
+  // sensor that had to ask a person for permission first. So the same silent
+  // host is asked for both at once: `items.next` gives up at its 2s budget while
+  // `sensors.orientation.start`, on 10s, is still waiting.
+  const said: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(" "))
+  t.after(() => {
+    console.error = real
+  })
+
+  const { client } = withFakeFrame({
+    granted: ["items", "sensors.orientation"],
+    answer: () => undefined,
+  })
+  const host = await client
+
+  const stop = host.tilt.start(() => {})
+  const local = assert.rejects(
+    () => host.nextItem(),
+    (error: unknown) =>
+      error instanceof PackError &&
+      error.code === "timeout" &&
+      // The message names the budget: "it timed out" without the number is a
+      // line nobody can act on.
+      /items\.next did not answer within 2000ms/.test(error.message),
+  )
+  const started = Date.now()
+  await local
+  const elapsed = Date.now() - started
+  assert.ok(elapsed >= 1900, `items.next gave up after ${String(elapsed)}ms`)
+
+  // 600ms past the local budget, and the native start has said nothing: it is
+  // still on its own, longer deadline rather than on a shared one.
+  await new Promise((resolve) => setTimeout(resolve, 600))
+  assert.deepEqual(said, [], "the native start gave up on the local budget")
+  stop()
+  host.dispose()
+})
+
+test("a settled call disarms its deadline rather than leaving it armed", async (t) => {
+  t.after(cleanup)
+  // Measured, not read. The first version of this test asserted that `dispose`
+  // returned quickly and passed perfectly with the `clearTimeout` deleted — the
+  // leaked timers were real (the suite went from 2.6s to 13.2s, because node will
+  // not exit while a timer is pending) and the assertion could not see one.
+  //
+  // `process.getActiveResourcesInfo()` can. A leaked deadline per call is a leak
+  // per call, and in a real pack that is one live timer for every question a
+  // child answers.
+  const timers = () => process.getActiveResourcesInfo().filter((name) => name === "Timeout").length
+
+  const { client } = withFakeFrame({ granted: ["items"], answer: () => ok({ item: null }) })
+  const host = await client
+  const before = timers()
+  for (let index = 0; index < 8; index += 1) {
+    assert.equal(await host.nextItem(), null)
+  }
+  assert.equal(
+    timers(),
+    before,
+    "a settled call left its 2s deadline armed — eight calls, eight live timers",
+  )
+  host.dispose()
+})
+
+/* ─── absence ────────────────────────────────────────────────────────────── */
+
+test("granted and available are different questions", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({
+    granted: ["items", "sensors.orientation"],
+    available: ["items"],
+  })
+  const host = await client
+  // The pack declared it, the build implements it, so the method is not refused
+  // — a pack cannot tell a declined permission from a missing sensor.
+  assert.equal(host.can("sensors.orientation.start"), true)
+  // But this device cannot do it, and that is the check a game reads before
+  // drawing a control that would otherwise be a lie.
+  assert.equal(host.available("sensors.orientation"), false)
+  assert.equal(host.available("items"), true)
+  assert.deepEqual([...host.usable], ["items"])
+  assert.equal(host.tilt.available, false)
+  host.dispose()
+})
+
+test("an older host that sends no `available` is read as everything working", async (t) => {
+  t.after(cleanup)
+  // A 1.0 host cannot send the field. Reading its absence as "nothing works"
+  // would break every pack on it; reading it as "everything granted works" is
+  // exactly what those packs were already assuming.
+  const { client } = withFakeFrame({ granted: ["items", "storage"], legacyHost: true })
+  const host = await client
+  assert.equal(host.available("items"), true)
+  assert.equal(host.available("storage"), true)
+  assert.deepEqual([...host.usable], ["items", "storage"])
+  host.dispose()
+})
+
+test("starting an unavailable capability is silent for a child and loud for a developer", async (t) => {
+  t.after(cleanup)
+  const said: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(" "))
+  t.after(() => {
+    console.error = real
+  })
+
+  const { client, seen } = withFakeFrame({
+    granted: ["items", "sensors.orientation"],
+    available: ["items"],
+  })
+  const host = await client
+
+  const samples: unknown[] = []
+  // Never throws and never rejects: absence is not an error path, so a game
+  // needs no try/catch to be correct.
+  const stop = host.tilt.start((sample) => samples.push(sample))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(samples, [], "an unavailable capability delivered something")
+  // And it cost no round trip, so a pack cannot probe what a device or a person
+  // declined by timing the answer.
+  assert.deepEqual(seen, [])
+  // Stop is safe on a stream that never opened.
+  stop()
+  stop()
+
+  assert.equal(said.length, 1, `expected one loud line, got ${String(said.length)}`)
+  const line = said[0] ?? ""
+  assert.match(line, /sensors\.orientation/)
+  assert.match(line, /host\.available/, "the message does not say what to do about it")
+  host.dispose()
+})
+
+test("calling an undeclared native capability says which manifest field is missing", async (t) => {
+  t.after(cleanup)
+  const said: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(" "))
+  t.after(() => {
+    console.error = real
+  })
+
+  const { client, seen } = withFakeFrame({ granted: ["items"] })
+  const host = await client
+  assert.equal(host.tilt.available, false)
+  const samples: unknown[] = []
+  host.tilt.start((sample) => samples.push(sample))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  assert.deepEqual(samples, [])
+  assert.deepEqual(seen, [])
+  assert.equal(said.length, 1)
+  assert.match(said[0] ?? "", /manifest\.json/)
+  host.dispose()
+})
+
+/* ─── streams ────────────────────────────────────────────────────────────── */
+
+/** A sample the host would send. `degrees` is what a gauge reads. */
+const sample = (x: number, y: number) => ({
+  x,
+  y,
+  degrees: { x: x * 25, y: y * 25 },
+})
+
+test("a stream opens, delivers, and is cancelled by the stop function", async (t) => {
+  t.after(cleanup)
+  const { client, seen, hostPort } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: (request) =>
+      request.method === "sensors.orientation.start" ? ok({ stream: request.id }) : ok(null),
+  })
+  const host = await client
+  assert.equal(host.tilt.available, true)
+
+  const samples: { x: number; y: number }[] = []
+  const stop = host.tilt.start((value) => samples.push({ x: value.x, y: value.y }))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  const start = seen.find((request) => request.method === "sensors.orientation.start")
+  assert.ok(start, "the start never reached the host")
+  // The stream id IS the request id. No second namespace, and the pack already
+  // held the number.
+  hostPort.postMessage({ stream: start.id, seq: 1, data: sample(0.5, -0.25) })
+  hostPort.postMessage({ stream: start.id, seq: 2, data: sample(-1, 1) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(samples, [
+    { x: 0.5, y: -0.25 },
+    { x: -1, y: 1 },
+  ])
+
+  stop()
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const cancel = seen.find((request) => request.method === "stream.cancel")
+  assert.ok(cancel, "stopping did not tell the host")
+  assert.deepEqual(cancel.params, { stream: start.id })
+
+  // And nothing arrives after the stop, even if the host is still sending.
+  hostPort.postMessage({ stream: start.id, seq: 3, data: sample(1, 1) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(samples.length, 2)
+  host.dispose()
+})
+
+test("stopping before the host has answered still cancels the stream it opened", async (t) => {
+  t.after(cleanup)
+  // The leak this prevents: a child leaves during the round trip, the pack's
+  // stop runs before there is a handle to cancel, and the host is left feeding a
+  // sensor to a stream nobody is reading.
+  // A holder rather than a `let`: assigned inside a callback, so TypeScript's
+  // control-flow analysis still believes the variable is `null` at the assertion
+  // below and narrows it to `never`.
+  const held: { release: (() => void) | null } = { release: null }
+  const { client, seen, hostPort } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: (request) => {
+      if (request.method !== "sensors.orientation.start") return ok(null)
+      held.release = () =>
+        hostPort.postMessage({ id: request.id, ok: true, result: { stream: request.id } })
+      return undefined
+    },
+  })
+  const host = await client
+  const samples: unknown[] = []
+  const stop = host.tilt.start((value) => samples.push(value))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  stop()
+  assert.ok(held.release, "the host never saw the start")
+  held.release()
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  const start = seen.find((request) => request.method === "sensors.orientation.start")
+  assert.ok(start)
+  const cancel = seen.find((request) => request.method === "stream.cancel")
+  assert.ok(cancel, "a stream opened after the stop was never cancelled")
+  assert.deepEqual(cancel.params, { stream: start.id })
+  // And the late handle is not registered, so a sample on it goes nowhere.
+  hostPort.postMessage({ stream: start.id, seq: 1, data: sample(1, 0) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(samples, [])
+  host.dispose()
+})
+
+test("a sample that is not a sample is dropped rather than fed to the game", async (t) => {
+  t.after(cleanup)
+  const said: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(" "))
+  t.after(() => {
+    console.error = real
+  })
+
+  const { client, seen, hostPort } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: (request) =>
+      request.method === "sensors.orientation.start" ? ok({ stream: request.id }) : ok(null),
+  })
+  const host = await client
+  const samples: unknown[] = []
+  host.tilt.start((value) => samples.push(value))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const id = seen.find((request) => request.method === "sensors.orientation.start")?.id ?? 0
+
+  // One NaN through a game's steering makes every position after it NaN, the
+  // world vanishes and nothing throws. That is the blank screen this drops.
+  hostPort.postMessage({ stream: id, seq: 1, data: { x: Number.NaN, y: 0, degrees: { x: 0, y: 0 } } })
+  hostPort.postMessage({ stream: id, seq: 2, data: sample(0.25, 0) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(samples, [sample(0.25, 0)])
+  assert.equal(said.length, 1, "a dropped sample was dropped quietly")
+  host.dispose()
+})
+
+test("a repeated or reordered sequence number is dropped", async (t) => {
+  t.after(cleanup)
+  const { client, seen, hostPort } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: (request) =>
+      request.method === "sensors.orientation.start" ? ok({ stream: request.id }) : ok(null),
+  })
+  const host = await client
+  const samples: number[] = []
+  host.tilt.start((value) => samples.push(value.x))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const id = seen.find((request) => request.method === "sensors.orientation.start")?.id ?? 0
+
+  hostPort.postMessage({ stream: id, seq: 1, data: sample(0.1, 0) })
+  hostPort.postMessage({ stream: id, seq: 3, data: sample(0.3, 0) })
+  // Behind the high-water mark: a step backwards in time for whatever this is
+  // steering, so it is dropped rather than replayed.
+  hostPort.postMessage({ stream: id, seq: 2, data: sample(0.2, 0) })
+  hostPort.postMessage({ stream: id, seq: 3, data: sample(0.9, 0) })
+  hostPort.postMessage({ stream: id, seq: 4, data: sample(0.4, 0) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  // A gap (2 missing) is deliberate — the host throttles — so 3 is delivered.
+  assert.deepEqual(samples, [0.1, 0.3, 0.4])
+  host.dispose()
+})
+
+test("a stream on a pack that was disposed delivers nothing", async (t) => {
+  t.after(cleanup)
+  const { client, seen, hostPort } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: (request) =>
+      request.method === "sensors.orientation.start" ? ok({ stream: request.id }) : ok(null),
+  })
+  const host = await client
+  const samples: unknown[] = []
+  host.tilt.start((value) => samples.push(value))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const id = seen.find((request) => request.method === "sensors.orientation.start")?.id ?? 0
+
+  hostPort.postMessage({ stream: id, seq: 1, data: sample(0.5, 0) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(samples.length, 1)
+
+  host.dispose()
+  hostPort.postMessage({ stream: id, seq: 2, data: sample(1, 1) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  // Two independent mechanisms hold this and either one alone is enough —
+  // dropping the sink table, and tearing the port down. Removing either on its
+  // own leaves this green, which was measured; removing both fails it here. The
+  // test is written against the property rather than against a mechanism, and the
+  // redundancy is deliberate: the port stops delivery, the table stops a
+  // reference to a torn-down game's closure being held.
+  assert.equal(samples.length, 1, "a sample reached a game that had been torn down")
+})
+
+test("a stream the host says has become unavailable stops quietly for the child", async (t) => {
+  t.after(cleanup)
+  const said: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(" "))
+  t.after(() => {
+    console.error = real
+  })
+
+  const { client, seen, hostPort } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: (request) =>
+      request.method === "sensors.orientation.start" ? ok({ stream: request.id }) : ok(null),
+  })
+  const host = await client
+  const samples: unknown[] = []
+  const stop = host.tilt.start((value) => samples.push(value))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const id = seen.find((request) => request.method === "sensors.orientation.start")?.id ?? 0
+
+  hostPort.postMessage({ stream: id, done: true, reason: "unavailable" })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  hostPort.postMessage({ stream: id, seq: 1, data: sample(1, 1) })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(samples, [], "an ended stream kept delivering")
+  assert.equal(said.length, 1)
+  assert.match(said[0] ?? "", /keep playing|without it/i)
+  // And stopping an already-ended stream is not an error.
+  stop()
+  host.dispose()
+})
+
+test("a start the host refuses is announced, and the game is left running", async (t) => {
+  t.after(cleanup)
+  const said: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => said.push(args.map(String).join(" "))
+  t.after(() => {
+    console.error = real
+  })
+
+  const { client } = withFakeFrame({
+    granted: ["sensors.orientation"],
+    answer: () => ({ ok: false as const, error: { code: "unavailable" as const, message: "no sensor" } }),
+  })
+  const host = await client
+  const samples: unknown[] = []
+  // No throw, no rejection: a game must not have to catch this to be correct.
+  const stop = host.tilt.start((value) => samples.push(value))
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  stop()
+  assert.deepEqual(samples, [])
+  assert.equal(said.length, 1)
+  assert.match(said[0] ?? "", /unavailable/)
   host.dispose()
 })

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -20,7 +20,7 @@
 // and would therefore be worth nothing.
 
 import type { Capability, Method } from "./capabilities.ts"
-import { permits } from "./capabilities.ts"
+import { budgetOf, permits } from "./capabilities.ts"
 import type {
   Connect,
   HapticCue,
@@ -28,12 +28,80 @@ import type {
   Item,
   Judgement,
   LearnerSummary,
+  Orientation,
   Settings,
   SoundCue,
   TransitionKind,
 } from "./protocol.ts"
-import { isConnect, isResponse, PROTOCOL_VERSION } from "./protocol.ts"
+import {
+  isConnect,
+  isOrientation,
+  isResponse,
+  isStreamEnd,
+  isStreamUpdate,
+  PROTOCOL_VERSION,
+} from "./protocol.ts"
 import { installTapZoomGuard } from "./tapzoom.ts"
+
+/**
+ * Say something to whoever is building this pack, once, and loudly.
+ *
+ * The rule for a native-backed capability is that absence is **loud to the
+ * developer and invisible to the child**: a tablet with no gyroscope is not a
+ * fault and a child must never see a message about one, but a pack author whose
+ * tilt control silently does nothing has to be told why, in a sentence that
+ * names what to do. Four packs have shipped blank in this repository and every
+ * one of them was quiet about it.
+ *
+ * `console.error` rather than `warn`: Vite's dev client forwards errors to the
+ * terminal and nothing else, and on a device this is what reaches a
+ * WebInspector session. Once per reason **per connected pack**, because a game
+ * loop would otherwise print it sixty times a second and the message would
+ * become the noise it is meant to cut through — and per pack rather than per
+ * process so that the second pack a session mounts is told the same things as
+ * the first.
+ */
+function makeAnnouncer(): (key: string, message: string) => void {
+  const said = new Set<string>()
+  return (key, message) => {
+    if (said.has(key)) return
+    said.add(key)
+    console.error(message)
+  }
+}
+
+/**
+ * Reading the tilt of the device, as a pack sees it.
+ *
+ * Shaped so that **absence is not an error path**. `start` never throws and
+ * never returns a rejected promise; on a device that cannot do this it returns a
+ * stop function that stops nothing and the handler is simply never called. A
+ * game therefore needs no try/catch and no fallback branch to be correct — it
+ * needs one `available` check, and only if it draws a control that would
+ * otherwise be a lie.
+ */
+export type TiltReader = {
+  /**
+   * Whether this device can report a tilt right now.
+   *
+   * False when the pack did not declare `sensors.orientation`, when the build
+   * has no orientation source, when the hardware has no sensor, or when a
+   * permission was declined. A pack is told the answer, never the reason: which
+   * of those it is is not a pack's business and is not stable enough to branch
+   * on.
+   */
+  readonly available: boolean
+  /**
+   * Start reading. Returns a stop function; both are always safe to call.
+   *
+   * Stop is idempotent, is safe before the stream has even opened, and is safe
+   * after the host has closed it. Call it when the child leaves the part of the
+   * game that steers — the host ends every stream at teardown regardless, so
+   * nothing outlives the pack, but a sensor running behind a menu is a sensor
+   * costing a battery for nothing.
+   */
+  start(onSample: (sample: Orientation) => void): () => void
+}
 
 export class PackError extends Error {
   readonly code: string
@@ -75,10 +143,28 @@ export type HostClient = {
   /** The host app's version, for a pack that renders a compatibility note. */
   readonly hostVersion: string
   readonly granted: readonly Capability[]
+  /**
+   * The granted capabilities this device can actually do.
+   *
+   * A subset of `granted`. Everything that is not native-backed is always in
+   * here; a native one may be missing because the hardware, the build or a
+   * person said no. See `available`.
+   */
+  readonly usable: readonly Capability[]
   /** Live: re-read it, it follows the host's `settings` event. */
   readonly settings: Settings
 
   can(method: Method): boolean
+  /**
+   * Whether a granted capability can do anything on this device.
+   *
+   * The check to write before **drawing a control** that depends on a native
+   * capability — an on/off switch for tilt steering, a "read it to me" button.
+   * It is not the check to write before *calling* one: calling an unavailable
+   * capability is already harmless, and a guard on every call site is a guard
+   * somebody will forget.
+   */
+  available(capability: Capability): boolean
 
   /** The next question for this pack, or `null` when the host has none. */
   nextItem(options?: ItemRequest): Promise<Item | null>
@@ -103,6 +189,9 @@ export type HostClient = {
   haptic(cue: HapticCue): Promise<void>
   sound(cue: SoundCue): Promise<void>
   milestone(name: string): Promise<void>
+
+  /** Requires the `sensors.orientation` capability. Degrades to nothing. */
+  readonly tilt: TiltReader
 
   storage: {
     get(key: string): Promise<string | null>
@@ -133,6 +222,15 @@ export type HostClient = {
 type Pending = {
   resolve: (value: unknown) => void
   reject: (error: PackError) => void
+  /** Armed from `budgetOf(method)`. See `call`. */
+  timer: ReturnType<typeof setTimeout>
+}
+
+/** One open stream, from the pack's side. */
+type Sink = {
+  /** The highest `seq` delivered. A repeat or a reordering is dropped. */
+  lastSeq: number
+  deliver: (data: unknown) => void
 }
 
 const DEFAULT_TIMEOUT_MS = 15_000
@@ -179,18 +277,52 @@ export function connect(options: { timeoutMs?: number } = {}): Promise<HostClien
 
 function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
   const pending = new Map<number, Pending>()
+  const streams = new Map<number, Sink>()
   const listeners = new Map<HostEventName, Set<(data: unknown) => void>>()
   let nextId = 1
   let closed = false
 
   const settings: { current: Settings } = { current: connectMessage.settings }
+  const announce = makeAnnouncer()
+
+  // A 1.0 host does not send `available`. Falling back to `granted` restores
+  // exactly what a pack on that host was already assuming, rather than reading
+  // a missing field as "nothing works".
+  const usable: readonly Capability[] = connectMessage.available ?? connectMessage.granted
+  const usableSet = new Set<Capability>(usable)
 
   port.onmessage = (event: MessageEvent) => {
     const data: unknown = event.data
+    // Streams first: on an open sensor these outnumber everything else on the
+    // port by two orders of magnitude, and none of the shapes overlap — an
+    // update carries `stream`, a response carries `id`, an event carries
+    // `event`.
+    if (isStreamUpdate(data)) {
+      const sink = streams.get(data.stream)
+      if (!sink) return
+      // Monotonic from 1, so a repeat or a reordering is a host bug and is
+      // dropped rather than fed to a game as a step backwards in time.
+      if (data.seq <= sink.lastSeq) return
+      sink.lastSeq = data.seq
+      sink.deliver(data.data)
+      return
+    }
+    if (isStreamEnd(data)) {
+      const sink = streams.get(data.stream)
+      streams.delete(data.stream)
+      if (sink && data.reason === "unavailable") {
+        announce(
+          "stream-unavailable",
+          "[pack] the host ended a stream because the device stopped being able to " +
+            "feed it. Nothing is wrong with this pack; whatever it was reading is " +
+            "gone until the next launch, and the game has to keep playing without it.",
+        )
+      }
+      return
+    }
     if (isResponse(data)) {
-      const entry = pending.get(data.id)
+      const entry = settle(data.id)
       if (!entry) return
-      pending.delete(data.id)
       if (data.ok) entry.resolve(data.result)
       else entry.reject(new PackError(data.error.code, data.error.message))
       return
@@ -207,13 +339,34 @@ function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
   }
   port.start()
 
+  /**
+   * Take a pending call off the book and disarm its deadline.
+   *
+   * One function, so that no path can resolve a promise and leave its timer
+   * armed. A timer that fires after its promise settled is harmless today —
+   * `pending` no longer has the id — but it is harmless by luck rather than by
+   * construction, and a leaked timer per call is a leak per call.
+   */
+  const settle = (id: number): Pending | null => {
+    const entry = pending.get(id)
+    if (!entry) return null
+    pending.delete(id)
+    clearTimeout(entry.timer)
+    return entry
+  }
+
   const close = () => {
     if (closed) return
     closed = true
-    for (const entry of pending.values()) {
-      entry.reject(new PackError("closed", "the host closed this pack"))
+    for (const id of [...pending.keys()]) {
+      const entry = settle(id)
+      entry?.reject(new PackError("closed", "the host closed this pack"))
     }
     pending.clear()
+    // Not cancelled over the wire: the port is about to close and the host ends
+    // every stream it opened for this pack at teardown. Dropping the sinks is
+    // what stops a late sample reaching a game that has already been torn down.
+    streams.clear()
     port.onmessage = null
     port.close()
   }
@@ -227,21 +380,146 @@ function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
       return Promise.reject(new PackError("denied", `${method} was not granted to this pack`))
     }
     const id = nextId++
+    const budget = budgetOf(method)
     return new Promise<unknown>((resolve, reject) => {
-      pending.set(id, { resolve, reject })
+      // The deadline. Before this, a host that never answered left the pack
+      // holding a promise that never settled — no error, no log, and a game
+      // stuck on a loading state forever. The budget is the capability's own,
+      // declared in `capabilities.ts`, because "how long may this take" is part
+      // of the contract and not something a pack should have to guess: two
+      // seconds for a store read, ten for something that may have to ask a
+      // person for permission first.
+      const timer = setTimeout(() => {
+        pending.delete(id)
+        reject(new PackError("timeout", `${method} did not answer within ${String(budget)}ms`))
+      }, budget)
+      pending.set(id, { resolve, reject, timer })
       port.postMessage({ id, method, params })
     })
+  }
+
+  /**
+   * Open a stream and route it, or say why not and route nothing.
+   *
+   * The whole degradation policy for a native capability lives here, once, so
+   * that adding text-to-speech or an on-device model is a call to this rather
+   * than a second copy of the same four failure branches.
+   */
+  const openStream = (
+    method: Method,
+    capability: Capability,
+    params: Record<string, unknown>,
+    deliver: (data: unknown) => void,
+  ): (() => void) => {
+    const noop = () => {}
+    if (!permits(connectMessage.granted, method)) {
+      announce(
+        `ungranted:${capability}`,
+        `[pack] this pack called ${method} without declaring "${capability}" in its ` +
+          `manifest, so nothing will happen. Add it to \`capabilities\` in ` +
+          `manifest.json and rebuild the pack. A child sees no error, which is why ` +
+          `this line is the only sign.`,
+      )
+      return noop
+    }
+    if (!usableSet.has(capability)) {
+      announce(
+        `unavailable:${capability}`,
+        `[pack] "${capability}" was granted but this device cannot do it, so ` +
+          `${method} will not be called and nothing will happen. This is not a bug ` +
+          `and it is not rare — the build may have shipped without the plugin, the ` +
+          `hardware may have no such sensor, or somebody may have declined a ` +
+          `permission. Read host.available("${capability}") before drawing a ` +
+          `control that depends on it, and make sure the game is playable without it.`,
+      )
+      return noop
+    }
+
+    let stream: number | null = null
+    let stopped = false
+
+    const cancel = (id: number) => {
+      // `.catch` and not `await`: the pack is not told whether a cancel landed,
+      // and a rejected cancel — the port already closed, say — is not a failure
+      // a game can do anything about.
+      void call("stream.cancel", { stream: id }).catch(() => {})
+    }
+
+    const stop = () => {
+      if (stopped) return
+      stopped = true
+      if (stream === null) return
+      streams.delete(stream)
+      cancel(stream)
+    }
+
+    void call(method, params)
+      .then((result) => {
+        const handle = (result as { stream?: unknown } | null)?.stream
+        if (typeof handle !== "number") {
+          announce(
+            `nohandle:${method}`,
+            `[pack] ${method} answered without a stream handle, so no samples can be ` +
+              `routed. This is a host bug rather than a pack bug; the game will run ` +
+              `with nothing arriving on this stream.`,
+          )
+          return
+        }
+        // Stopped while the start was still in flight. The host has an open
+        // stream it does not know is unwanted, so it is told.
+        if (stopped || closed) {
+          cancel(handle)
+          return
+        }
+        stream = handle
+        streams.set(handle, { lastSeq: 0, deliver })
+      })
+      .catch((error: unknown) => {
+        const code = error instanceof PackError ? error.code : "unknown"
+        announce(
+          `startfailed:${method}`,
+          `[pack] ${method} failed to start (${code}), so nothing will arrive on it. ` +
+            `The game must keep playing: a child cannot be shown this and cannot fix it.`,
+        )
+      })
+
+    return stop
+  }
+
+  const tilt: TiltReader = {
+    available:
+      permits(connectMessage.granted, "sensors.orientation.start") &&
+      usableSet.has("sensors.orientation"),
+    start: (onSample) =>
+      openStream("sensors.orientation.start", "sensors.orientation", {}, (data) => {
+        // Guarded even though the host is the more trusted side, because the
+        // failure it prevents is silent: one NaN through a game's steering makes
+        // every position after it NaN, the world vanishes, and nothing throws.
+        if (isOrientation(data)) {
+          onSample(data)
+          return
+        }
+        announce(
+          "badsample",
+          "[pack] the host sent a tilt sample that is not one, and it was dropped. " +
+            "Every sample carries x and y in −1..1 and degrees.x / degrees.y; " +
+            "anything else would put a NaN through this game's steering.",
+        )
+      }),
   }
 
   return {
     packId: connectMessage.packId,
     hostVersion: connectMessage.host,
     granted: connectMessage.granted,
+    usable,
     get settings() {
       return settings.current
     },
 
     can: (method) => permits(connectMessage.granted, method),
+    available: (capability) =>
+      connectMessage.granted.includes(capability) && usableSet.has(capability),
 
     nextItem: async (options = {}) => {
       // Built by omission rather than by sending `undefined`: a structured
@@ -277,6 +555,8 @@ function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
     milestone: async (name) => {
       await call("milestone.reach", { name })
     },
+
+    tilt,
 
     storage: {
       get: async (key) => ((await call("storage.get", { key })) as { value: string | null }).value,

--- a/dynawalla/packs/sdk/src/index.ts
+++ b/dynawalla/packs/sdk/src/index.ts
@@ -8,14 +8,27 @@ export {
   CAPABILITIES,
   CAPABILITY_IDS,
   METHODS,
+  NATIVE_CAPABILITIES,
+  SESSION_BUDGET_MS,
   SESSION_METHODS,
+  STREAM_METHODS,
+  budgetOf,
   capabilityOf,
   isCapability,
   isMethod,
+  isNativeBacked,
   labelOf,
+  opensStream,
   permits,
 } from "./capabilities.ts"
-export type { Capability, Method, CapabilityMethod, SessionMethod } from "./capabilities.ts"
+export type {
+  Capability,
+  Method,
+  CapabilityMethod,
+  NativeCapability,
+  SessionMethod,
+  StreamMethod,
+} from "./capabilities.ts"
 
 export {
   MANIFEST_SCHEMA,
@@ -33,12 +46,19 @@ export type { ManifestResult, PackManifest } from "./manifest.ts"
 
 export {
   MAX_REQUESTS_PER_SECOND,
+  ORIENTATION_DEADZONE_DEG,
+  ORIENTATION_FULL_TILT_DEG,
+  ORIENTATION_MAX_HZ,
   PROTOCOL_VERSION,
   SDK_VERSION,
+  STREAM_END_REASONS,
   TRANSITION_KINDS,
   isConnect,
   isHostEvent,
+  isOrientation,
   isResponse,
+  isStreamEnd,
+  isStreamUpdate,
   isTransitionKind,
   numberParam,
   parseRequest,
@@ -55,11 +75,15 @@ export type {
   ItemChoice,
   Judgement,
   LearnerSummary,
+  Orientation,
   ParsedRequest,
   Request,
   Response,
   Settings,
   SoundCue,
+  StreamEnd,
+  StreamEndReason,
+  StreamUpdate,
   TransitionKind,
 } from "./protocol.ts"
 
@@ -67,7 +91,7 @@ export { compareSemver, compareVersions, isSemver, parseSemver, satisfies, sdkCo
 export type { HostRange, Semver } from "./semver.ts"
 
 export { PackError, connect } from "./guest.ts"
-export type { HostClient, ItemRequest } from "./guest.ts"
+export type { HostClient, ItemRequest, TiltReader } from "./guest.ts"
 
 // `connect()` installs the guard itself — a pack never has to call this. It is
 // exported so the host and the dev harness can install the same one, and so a

--- a/dynawalla/packs/sdk/src/protocol.test.ts
+++ b/dynawalla/packs/sdk/src/protocol.test.ts
@@ -4,7 +4,10 @@ import assert from "node:assert/strict"
 import {
   isConnect,
   isHostEvent,
+  isOrientation,
   isResponse,
+  isStreamEnd,
+  isStreamUpdate,
   numberParam,
   parseRequest,
   stringParam,
@@ -128,4 +131,115 @@ test("the guards a pack uses on host traffic are equally exact", () => {
   assert.equal(isConnect(connect), true)
   assert.equal(isConnect({ ...connect, granted: "items" }), false)
   assert.equal(isConnect({ ...connect, event: "ready" }), false)
+})
+
+test("the three host-to-pack envelopes are told apart by shape alone", () => {
+  // The property the guest's demultiplexer depends on. If any two of these
+  // could match the same message, a sensor sample would resolve a promise or a
+  // response would be fed to a game as a sample — both silent.
+  const update = { stream: 7, seq: 1, data: { x: 0, y: 0, degrees: { x: 0, y: 0 } } }
+  const end = { stream: 7, done: true, reason: "cancelled" }
+  const response = { id: 7, ok: true, result: null }
+  const event = { event: "pause" }
+
+  assert.equal(isStreamUpdate(update), true)
+  assert.equal(isStreamEnd(update), false)
+  assert.equal(isResponse(update), false)
+  assert.equal(isHostEvent(update), false)
+
+  assert.equal(isStreamEnd(end), true)
+  assert.equal(isStreamUpdate(end), false, "an end must not also read as an update")
+  // And an envelope carrying BOTH is an end, not an update. This is the case the
+  // `done` check in `isStreamUpdate` exists for: an end has no `seq`, so without
+  // one that carries a `seq` the check is unreachable and would have been deleted
+  // by anyone measuring it. A message that is both would otherwise be dispatched
+  // to a game as a sample and never end the stream.
+  assert.equal(isStreamUpdate({ ...end, seq: 1 }), false, "a done envelope read as a sample")
+  assert.equal(isStreamEnd({ ...end, seq: 1 }), true)
+  assert.equal(isResponse(end), false)
+
+  assert.equal(isResponse(response), true)
+  assert.equal(isStreamUpdate(response), false)
+  assert.equal(isStreamEnd(response), false)
+
+  assert.equal(isHostEvent(event), true)
+  assert.equal(isStreamUpdate(event), false)
+  assert.equal(isStreamEnd(event), false)
+})
+
+test("a stream envelope that is not one is rejected", () => {
+  for (const value of [
+    null,
+    7,
+    [],
+    {},
+    { stream: 7 },
+    { stream: 7, seq: 0 },
+    { stream: 7, seq: -1 },
+    { stream: 7, seq: 1.5 },
+    { stream: -1, seq: 1 },
+    { stream: 1.5, seq: 1 },
+    { stream: "7", seq: 1 },
+  ]) {
+    assert.equal(isStreamUpdate(value), false, `${JSON.stringify(value)} parsed as an update`)
+  }
+  for (const value of [
+    { stream: 7, done: true },
+    { stream: 7, done: true, reason: "bored" },
+    { stream: 7, done: false, reason: "cancelled" },
+    { stream: 7, reason: "cancelled" },
+    { done: true, reason: "cancelled" },
+  ]) {
+    assert.equal(isStreamEnd(value), false, `${JSON.stringify(value)} parsed as an end`)
+  }
+  // Every reason the contract names is accepted, so the guard cannot drift from
+  // the union by somebody adding one to the type and not to the list.
+  for (const reason of ["complete", "cancelled", "unavailable", "closed", "internal"]) {
+    assert.equal(isStreamEnd({ stream: 0, done: true, reason }), true, reason)
+  }
+})
+
+test("a tilt sample must be finite and in range, or it is not a sample", () => {
+  assert.equal(isOrientation({ x: 0, y: 0, degrees: { x: 0, y: 0 } }), true)
+  assert.equal(isOrientation({ x: -1, y: 1, degrees: { x: -25, y: 25 } }), true)
+  // Every one of these would put a NaN or an out-of-range multiplier through a
+  // game's steering, and none of them would throw.
+  for (const value of [
+    null,
+    {},
+    { x: 0, y: 0 },
+    { x: Number.NaN, y: 0, degrees: { x: 0, y: 0 } },
+    { x: 0, y: Number.POSITIVE_INFINITY, degrees: { x: 0, y: 0 } },
+    { x: 1.5, y: 0, degrees: { x: 0, y: 0 } },
+    { x: -1.5, y: 0, degrees: { x: 0, y: 0 } },
+    { x: "0", y: 0, degrees: { x: 0, y: 0 } },
+    { x: 0, y: 0, degrees: { x: Number.NaN, y: 0 } },
+    { x: 0, y: 0, degrees: null },
+  ]) {
+    assert.equal(isOrientation(value), false, `${JSON.stringify(value)} passed as a tilt sample`)
+  }
+})
+
+test("cancelling a stream is a request like any other", () => {
+  const parsed = parseRequest({ id: 4, method: "stream.cancel", params: { stream: 7 } })
+  assert.equal(parsed.ok, true)
+  if (!parsed.ok) return
+  assert.equal(parsed.request.method, "stream.cancel")
+})
+
+test("a connect without `available` is still a connect", () => {
+  // The 1.0 host. A pack on one reads the absent field as "everything granted
+  // works", which is exactly what it was already assuming, so an older host
+  // must not fail the guard.
+  const connect = {
+    event: "connect",
+    protocol: 1,
+    sdk: "1.0.0",
+    host: "0.1.0",
+    packId: "abacus.tower",
+    granted: ["items"],
+    settings: {},
+  }
+  assert.equal(isConnect(connect), true)
+  assert.equal(isConnect({ ...connect, available: ["items"] }), true)
 })

--- a/dynawalla/packs/sdk/src/protocol.ts
+++ b/dynawalla/packs/sdk/src/protocol.ts
@@ -33,8 +33,19 @@ import { isMethod } from "./capabilities.ts"
 /** Bumped when a message shape changes in a way an old pack would misread. */
 export const PROTOCOL_VERSION = 1
 
-/** The version of this SDK's method surface. Compared with `sdkCompatible`. */
-export const SDK_VERSION = "1.0.0"
+/**
+ * The version of this SDK's method surface. Compared with `sdkCompatible`.
+ *
+ * 1.1.0 added the stream envelopes below, `stream.cancel`, per-method budgets
+ * and the first native-backed capability. All additive: `sdkCompatible` lets a
+ * 1.0 pack run on a 1.1 host, and a 1.1 pack is refused by a 1.0 host, which is
+ * exactly right — the methods it was built against do not exist there.
+ *
+ * `PROTOCOL_VERSION` is deliberately NOT bumped. A stream envelope carries
+ * neither `id`+`ok` nor `event`, so a 1.0 pack's `port.onmessage` ignores one
+ * outright; and a 1.0 pack never opens a stream, so it never receives one.
+ */
+export const SDK_VERSION = "1.1.0"
 
 /**
  * A pack may not queue work faster than a child can cause it. 120 requests per
@@ -81,6 +92,73 @@ export type HostEventName = "settings" | "pause" | "resume" | "dispose"
 
 export type HostEvent = { readonly event: HostEventName; readonly data?: unknown }
 
+// ─── Streams ─────────────────────────────────────────────────────────────────
+//
+// The third envelope, and the one the request/response pair could not express.
+//
+// A native answer often arrives over time: samples off a sensor, word
+// boundaries out of a synthesiser, tokens out of a model. Before this there was
+// no way to say that on the wire. `Response` is one-shot, and `HostEvent` is a
+// closed set of four names with no correlation to anything a pack asked for, so
+// two concurrent utterances or two concurrent generations would be
+// indistinguishable.
+//
+//     pack → host   { id: 7, method: "sensors.orientation.start", params: {} }
+//     host → pack   { id: 7, ok: true, result: { stream: 7 } }
+//     host → pack   { stream: 7, seq: 1, data: {...} }
+//     host → pack   { stream: 7, seq: 2, data: {...} }
+//     pack → host   { id: 8, method: "stream.cancel", params: { stream: 7 } }
+//     host → pack   { stream: 7, done: true, reason: "cancelled" }
+//
+// **The stream id IS the request id that opened it.** No second namespace, no
+// allocation on the host side, and a pack already holds the number — it is the
+// id it sent. The host echoes it in the result anyway, so a reader following
+// raw traffic never has to infer it.
+//
+// Two guarantees the host owes, and both are what a pack is entitled to assume:
+//
+//   * **Exactly one end.** Every stream that was opened is ended, with a
+//     reason, including when the session is torn down. A pack that never sees
+//     an end has found a host bug, not a quiet stream.
+//   * **`seq` is monotonic from 1.** A pack that cares can see a gap. Nothing
+//     is retransmitted; a gap means samples were dropped on purpose (throttled,
+//     or delivery suspended while the pack was paused).
+
+export type StreamEndReason =
+  /** The host had nothing more to send. A finite stream ran out. */
+  | "complete"
+  /** The pack asked, with `stream.cancel`. */
+  | "cancelled"
+  /** The device stopped being able to do this. Not the pack's fault. */
+  | "unavailable"
+  /** The session ended underneath it. Nothing outlives a pack. */
+  | "closed"
+  /** The host threw. The pack is told nothing about what. */
+  | "internal"
+
+/** One datum on an open stream, host → pack. */
+export type StreamUpdate = {
+  readonly stream: number
+  /** Monotonic from 1. A gap is a drop, and drops are deliberate. */
+  readonly seq: number
+  readonly data: unknown
+}
+
+/** The end of a stream, host → pack. Exactly one per stream, always. */
+export type StreamEnd = {
+  readonly stream: number
+  readonly done: true
+  readonly reason: StreamEndReason
+}
+
+export const STREAM_END_REASONS: readonly StreamEndReason[] = [
+  "complete",
+  "cancelled",
+  "unavailable",
+  "closed",
+  "internal",
+]
+
 /**
  * The first message on the port, host → pack: what the pack got and what it
  * did not. A pack reads `granted` and hides the surfaces it cannot drive
@@ -93,6 +171,27 @@ export type Connect = {
   readonly host: string
   readonly packId: string
   readonly granted: readonly Capability[]
+  /**
+   * Which of `granted` can actually do something on THIS device, right now.
+   *
+   * Granted and available are different questions, and conflating them is the
+   * mistake this field exists to prevent. A grant is a decision about a pack —
+   * it declared the capability, the build implements it, so the method is not
+   * refused. Availability is a fact about a device: a tablet with no gyroscope,
+   * a build shipped without a plugin, a permission somebody declined. The first
+   * is stable for the life of an install; the second is not knowable until the
+   * app is running on the hardware.
+   *
+   * Every non-native capability is always available, so for a pack that asks
+   * for nothing native this list equals `granted`.
+   *
+   * Optional so that an older host is not a breaking change: a pack that sees
+   * `undefined` should read it as "everything granted is available", which is
+   * what it was already assuming. A pack built against 1.1 will never see
+   * `undefined` from a 1.1 host — `sdkCompatible` refuses that pairing — so the
+   * fallback is a courtesy to 1.0 packs rather than a path anything relies on.
+   */
+  readonly available?: readonly Capability[]
   readonly settings: Settings
 }
 
@@ -125,6 +224,83 @@ export type Settings = {
    */
   readonly safeArea?: { top: number; right: number; bottom: number; left: number }
 }
+
+/**
+ * How the device is being held, resolved by the host into something a game can
+ * steer with.
+ *
+ * ── Why not raw angles ──────────────────────────────────────────────────────
+ *
+ * `DeviceOrientationEvent` reports `beta` and `gamma` in the *device's* frame.
+ * Rotate the tablet a quarter turn and the two axes swap and one of them
+ * inverts; a game that read them directly would steer sideways in landscape and
+ * backwards upside-down, and every pack would have to rediscover the same
+ * `screen.orientation.angle` table. The host resolves it once.
+ *
+ * ── Why it is relative to a neutral pose ────────────────────────────────────
+ *
+ * Nobody plays with a tablet flat on a table. A child holds it at thirty or
+ * forty degrees, and an absolute reading is therefore pinned at full deflection
+ * before the game starts. The pose the device was in when the stream opened is
+ * zero, and everything after it is measured from there.
+ *
+ * ── What is deliberately not here ───────────────────────────────────────────
+ *
+ * No compass heading, no magnetometer, no rotation rate, no acceleration, no
+ * `absolute` flag. Two axes of tilt and their angles is all a game needs to
+ * steer, and it is the smallest thing that cannot be turned into a claim about
+ * where a child is or which way they are facing.
+ */
+export type Orientation = {
+  /**
+   * Left/right tilt, −1..1, screen-relative and clamped.
+   *
+   * +1 is the right-hand edge of the screen pushed down, whatever way up the
+   * device is being held.
+   */
+  readonly x: number
+  /** Front/back tilt, −1..1. +1 is the top edge pushed away from the child. */
+  readonly y: number
+  /**
+   * The same two axes in whole degrees from the neutral pose, unclamped in
+   * meaning but bounded in practice by the sensor.
+   *
+   * For a game that shows a slope on a gauge rather than steering with it: a
+   * child reading "hold it at fifteen degrees" needs the number, and −1..1 is
+   * not a number they can be asked to hold.
+   */
+  readonly degrees: { readonly x: number; readonly y: number }
+}
+
+/**
+ * The tilt, in degrees from neutral, that reads as full deflection.
+ *
+ * Part of the contract rather than a host preference: `x = 1` has to mean the
+ * same thing in every pack, or a game tuned on one build steers differently on
+ * the next. Twenty-five degrees is a wrist, not a shoulder — reachable while
+ * holding a 12" tablet with two hands, and reachable in both directions from a
+ * pose a child is already holding.
+ */
+export const ORIENTATION_FULL_TILT_DEG = 25
+
+/**
+ * Tilt inside this many degrees of neutral reads as exactly zero.
+ *
+ * A hand is not still. Without a dead zone a game drifts while a child holds it
+ * as steadily as they can, which reads as the game being broken rather than as
+ * the child being human.
+ */
+export const ORIENTATION_DEADZONE_DEG = 2
+
+/**
+ * The most samples per second the host will post.
+ *
+ * The sensor fires faster than this on both platforms and a game cannot use it:
+ * at 30 Hz a sample lands at least once per frame at 30 fps and there is
+ * nothing to interpolate. It is a ceiling, not a rate — a device held still
+ * produces no messages at all, and a pack keeps the last value it was given.
+ */
+export const ORIENTATION_MAX_HZ = 30
 
 export type ItemChoice = {
   readonly id: string
@@ -317,4 +493,42 @@ export function isHostEvent(value: unknown): value is HostEvent {
   if (!isRecord(value)) return false
   const name = value["event"]
   return name === "settings" || name === "pause" || name === "resume" || name === "dispose"
+}
+
+/** A stream handle, non-negative and safe: the request id that opened it. */
+const isStreamId = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+
+export function isStreamUpdate(value: unknown): value is StreamUpdate {
+  if (!isRecord(value)) return false
+  if (!isStreamId(value["stream"])) return false
+  if (value["done"] !== undefined) return false
+  const seq = value["seq"]
+  return typeof seq === "number" && Number.isSafeInteger(seq) && seq >= 1
+}
+
+export function isStreamEnd(value: unknown): value is StreamEnd {
+  if (!isRecord(value)) return false
+  if (!isStreamId(value["stream"])) return false
+  if (value["done"] !== true) return false
+  return STREAM_END_REASONS.includes(value["reason"] as StreamEndReason)
+}
+
+/**
+ * Whether a sample off the orientation stream is one.
+ *
+ * The host is more trusted than a pack, and this is still checked, because the
+ * failure it prevents is silent: one `NaN` reaching a game's steering makes
+ * every position after it `NaN`, the world disappears, and nothing throws.
+ * A dropped sample is a frame of stale steering; an accepted `NaN` is a blank
+ * screen, which is the failure mode this repository has shipped four times.
+ */
+export function isOrientation(value: unknown): value is Orientation {
+  if (!isRecord(value)) return false
+  const unit = (n: unknown): boolean => typeof n === "number" && Number.isFinite(n) && n >= -1 && n <= 1
+  if (!unit(value["x"]) || !unit(value["y"])) return false
+  const degrees = value["degrees"]
+  if (!isRecord(degrees)) return false
+  const angle = (n: unknown): boolean => typeof n === "number" && Number.isFinite(n)
+  return angle(degrees["x"]) && angle(degrees["y"])
 }

--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -164,6 +164,14 @@ function fakeHost(
       packId: "dynawalla.test",
       hostVersion: "0.1.0",
       granted: options.granted ?? ["items", "items.reveal", "haptics"],
+      // Every capability this stub is granted works, and none of them is
+      // native-backed. `usable`, `available` and `tilt` are the native-capability
+      // surface (SDK 1.1, `docs/NATIVE_CAPABILITIES.md`); nothing in this file
+      // exercises one, so the stub reports "everything granted works" and a tilt
+      // reader that is honestly unavailable.
+      usable: options.granted ?? ["items", "items.reveal", "haptics"],
+      available: () => true,
+      tilt: { available: false, start: () => () => {} },
       settings: SETTINGS,
       can: () => true,
 

--- a/dynawalla/packs/shared/game-host/sound.test.ts
+++ b/dynawalla/packs/shared/game-host/sound.test.ts
@@ -49,6 +49,12 @@ function stubClient(initial: Partial<Settings> = {}): Stub {
     packId: "dynawalla.test",
     hostVersion: "0.1.0",
     granted: [],
+    // Nothing is granted to this stub, so nothing is usable and the tilt reader
+    // is unavailable — which is what the SDK's own client reports for a pack that
+    // declared no native capability. See `docs/NATIVE_CAPABILITIES.md`.
+    usable: [],
+    available: () => false,
+    tilt: { available: false, start: () => () => {} },
     get settings() {
       return settings
     },


### PR DESCRIPTION
> "every game shouldn't just be a browser game .. **I think we should make a sort of abstract interface to the native side** .. the host should be able to provide elegant interfaces that the games can use if they want to."

`corpan/plugins/` holds **eleven** Tauri plugins — TTS, three speech recognisers, an on-device LLM runtime, haptics. `dynawalla-app/src-tauri/Cargo.toml` declares **two**. This is the seam that closes that gap without handing a pack anything.

## Does the existing seam extend to native, or need reshaping?

**It extends. Declare / grant / gate / dispatch needed no change at all** — a native capability is a row in the same closed table, a string in the same manifest field, an arm in the same `switch`. Four things it did not have had to be added, each now a mechanism rather than a convention:

| | before | now |
|---|---|---|
| **Latency** | no deadline anywhere; a dropped request left a promise that never settled | `budgetMs` per capability. The guest arms a timer and rejects `timeout`. 2s local, 10s for something that may ask a person |
| **Streaming** | inexpressible. `Response` is one-shot; `HostEvent` is four names with no correlation | `StreamUpdate` / `StreamEnd`, correlated by a handle that **is** the request id |
| **Cancellation** | inexpressible; the only way to stop anything was to end the session | `stream.cancel`, ungated — plus a paused pack is not fed, and nothing native outlives a pack |
| **Absence** | conflated with grant; `gateInstall` **refuses the install** of a pack asking for something unsupported | `Connect.available`, a runtime intersection. A native capability stays in `HOST_SUPPORTS` forever once implemented |

**Permission needed no protocol change, only a rule.** iOS wants transient user activation and grants per origin; a pack has neither to offer. So the host asks, in the host's own document, from the launch tap, at most once per install, and only for a pack that declared the capability.

## What landed

`sensors.orientation`. VOLTA wanted tilt steering and was denied twice over — opaque origin, plus `allow=""`. `allow="gyroscope; accelerometer"` was rejected: it hands motion sensors to all 28 packs to serve one. The host reads it and posts it, as it already does for safe-area insets.

A sample says **which way a marble sitting on the screen would roll**. Two numbers in −1..1 and their angles: no heading, no magnetometer, no acceleration, nothing that becomes a claim about where a child is.

```ts
if (host.available("sensors.orientation")) drawTiltToggle()   // before DRAWING a control
const stop = host.tilt.start(({ x, y }) => steer(x, y))       // never throws, never rejects
```

**Absence is loud to the developer and invisible to the child.** Every absent path writes one `console.error` naming the capability and the fix. A game with no `if` and no `try` is already correct.

## A security finding that is a fragility finding

The coordinator asked me to verify whether a pack can open a WebSocket today. **It cannot** — but the mechanism is not the one expected. It is the **pack's own CSP**, served in Rust (`dynawalla-app/src-tauri/src/packs/mod.rs`, `pack_csp()`), where `connect-src` names only the pack scheme. A nested context does not inherit its parent's policy, so the app's CSP is irrelevant to a pack. The sandbox alone would *not* have closed it — an opaque origin means no cookies, not no sockets.

So: not a hole. But **the whole boundary is one directive**, and two tests would not have caught the obvious wrong way to build a leaderboard:

- `src-tauri/src/packs/tests.rs` checked for `https://` and a stray `http://`. `wss://arena…` contains neither. Now pinned to equality.
- `src/app/capabilities.test.ts`'s origin scan matched `https?://` only. Now matches `ws:`/`wss:` too.

Both verified by adding `wss://arena.dynawalla.example` and watching them fail — while the *old* assertion passed.

## Removed-fix verification

Every fix was deleted and the failure quoted. Highlights, and the uncomfortable part:

**Three of my own tests were vacuous and were found this way.**

1. *"a settled call disarms its deadline"* passed with `clearTimeout` deleted — the leak was real (suite 2.6s → 13.2s, node will not exit on a pending timer) and the assertion could not see it. Rewritten against `process.getActiveResourcesInfo()`; now fails with `a settled call left its 2s deadline armed — eight calls, eight live timers`.
2. *"a device that cannot do it is unavailable"* passed with the bridge's `available()` check deleted, because the fixture's source also returned `null`. Split into two tests; the isolating one uses a **working** device.
3. `isStreamUpdate`'s `done` guard had no discriminating case — an end has no `seq`, so it was unreachable. Added `{ …end, seq: 1 }`; now fails `a done envelope read as a sample`.

**Two properties have redundant guards where either alone suffices** (the warm-up's `clearTimeout` + `stopped` check; the guest's `streams.clear()` + port teardown). Measured, not assumed: each single removal is green, both together fail. Both tests now say so and are named for the property rather than a mechanism they cannot observe.

Representative failures from the ~25 that behaved:

```
angleDelta wrap removed        →  ✖ the wrap at the seam is two degrees, not a full swing
dead zone clipped not subtracted → ✖ AssertionError: 0.1 is a step, not a start
re-zero on rotation removed    →  ✖ turning the tablet remaps the axes and re-zeroes the pose
budgetOf → a constant          →  ✖ AssertionError: the native start gave up on the local budget
endStream's stop() removed     →  ✖ AssertionError: the sensor was left running
bridge.close() gutted          →  ✖ closing the bridge ends every stream and releases every device
paused-drop removed            →  ✖ AssertionError: a paused pack was still being fed
frame dispose → no bridge.close() → ✖ AssertionError: the pack was torn down and the sensor was not
handle reserved after the await →  ✖ a stream cancelled while it was still starting leaves nothing behind
a second native capability added →  services.ts TS2741: Property 'speech' is missing
                                    bridge.ts TS2366: Function lacks ending return statement
wss:// added to pack_csp        →  ✖ a source was added to the directive that governs fetch, XHR and WebSocket
```

## The doc

`dynawalla/docs/NATIVE_CAPABILITIES.md` — how a native capability is declared, granted, versioned, feature-detected, and what a pack must do when it is absent. Worked examples as **shapes, not implementations**:

- **Text to speech.** Names the gap it will hit: `setPaused` currently drops *messages*, and native audio does not care about the port.
- **An on-device model.** `available()` is RAM-tiered, so the same build answers differently on two tablets — which is why availability is a runtime fact.
- **Networking / a leaderboard for ARENA.** Design only, checked against all six things the coordinator named. **The shape holds, with one addition**: reconnection cannot be a `StreamEnd` (a stream has exactly one end, and ending it would tell a pack the contest is over when it is not), so liveness belongs *inside* the payload — `{ state: "live" | "reconnecting" | "offline" }`. A leaderboard must never lie.

Two things raised for the founder rather than decided:

1. **A leaderboard is a compliance decision before an engineering one.** Real players means visible handles; anything identifying from under-13s carries COPPA weight and `G-01` is still open. A scores-and-a-generated-handle-only surface with no free text is achievable and is a very different product from anything social. Choose it deliberately.
2. **Infinite thinking time and a live leaderboard are in tension.** *"Kids will be doing long division for hours"* and *"stepping away for a few minutes"* cannot coexist with throughput ranking — a child spending eleven minutes on long division would be beaten by one tapping single-digit sums. The doc asserts the narrow thing (**whatever the ranking is, it must not be throughput**) and offers, without deciding, ranking by `Item.difficulty` conquered with volume as tiebreaker.

## Compilation vs. hardware

**Proven, in Node, with no device:** the neutral pose, the ±180 wrap, the re-zero on rotation, the dead zone, the throttle, the change gate, null readings, the warm-up, every permission-refusal path, the stream lifecycle end to end over a real `MessagePort`, and that no sensor outlives a pack. 486 TS tests (368 app + 118 SDK), 29 Rust tests, all green.

**Needs a device, and isolated so it is one line to correct:**

- Whether `deviceorientation` fires at all inside iOS WKWebView. Possibly it never does — `requestPermission` may be absent or always `denied`, and WKWebView motion has historically needed app config Tauri does not expose. **Every branch treats that as absence, so the failure mode is "no tilt control", not "broken".**
- `SCREEN_ROTATION` — four signs read off the Screen Orientation spec, not measured. Four one-line rows with a test that locks them. Portrait (`angle` 0) is the row everything else rests on.

**The source today is a web API, not a plugin.** `OrientationPorts` is what a `tauri-plugin-orientation` implements; nothing above `platform.ts` changes when it lands. So this adds **zero new Tauri IPC** — no command, no `capabilities/default.json` entry. The first capability that *does* pays the ACL tax, and the checklist spells it out.

## Native gate

- `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` clean · 29 tests pass
- `cargo check` clean for `aarch64-apple-ios` **and** `aarch64-linux-android`
- No `[workspace]` in any `Cargo.toml`; 12 crates declare `links`, all distinct
- **No `Cargo.toml` changed anywhere.** Corpán's patch graph re-verified with `cargo metadata --filter-platform aarch64-linux-android`: `llama-cpp-sys-2` → `corpan-app/src-tauri/vendor/llama-cpp-sys-2/Cargo.toml`, `source: null`; zero registry copies; **no unused-patch and no non-root-patch warnings**; `ndk-context` absent from the graph, consistent with #528.

## Scope

`dynawalla/docs/`, `dynawalla/packs/sdk/`, `dynawalla/dynawalla-app/`. **`corpan/**` untouched** (`tauri-plugin-haptics` remains a path dep, unmodified). No `dynawalla/games/**`, no `packs/shared/**`, no `dynawalla-app/src/packs/items.ts`.

`docs/STATUS.md` gains three In-flight rows. I deliberately did **not** bump its `Last updated`: its narrative predates the games programme and this PR does not refresh it, so moving the date would be a false claim of currency.

`SDK_VERSION` → 1.1.0 (additive). `PROTOCOL_VERSION` deliberately **not** bumped: a stream envelope carries neither `id`+`ok` nor `event`, so a 1.0 pack ignores one, and never opens a stream so never receives one.

## I touched `packs/shared/game-host/`, and I was told not to — read this

Second commit. `HostClient` grew three members, and **two test fixtures in `game-host` build one as an object literal**, so `dynawalla-packs` went red:

```
index.test.ts(163,5): error TS2739: … is missing the following properties
  from type 'HostClient': usable, available, tilt
sound.test.ts(48,9):  error TS2739: … same
```

**14 added lines, in two `.test.ts` files, nothing in `index.ts`.** It is a break I caused rather than a change I wanted. The alternative was to make `usable`/`available`/`tilt` optional on `HostClient`, which would force `host.tilt?.start` on all 28 packs in order to leave two fixtures untouched — a worse contract for every pack, to protect two stubs.

Both stubs now report the honest thing for a pack that declared no native capability: everything granted is usable, and a tilt reader that says `available: false` with a no-op `start`. **No game constructs a `HostClient`** (checked by grep), so nothing under `games/**` is affected. All four shared modules were run the way CI runs them: `game-audio` 80, `game-chrome` 54, `game-host` 54, `game-pacing` 20 — all pass.

## CI

`ci-gate` **pass** · `adversarial-review` **pass** · `hygiene` **pass** · `native · fmt + compile + clippy` **pass** · `dynawalla-packs · games + pack build` **pass** · `dynawalla-app · lint + tsc + test + build` **pass**.

The branch is `BEHIND` main (other agents landed while this was in flight). No conflicts are possible — nothing here shares a file with `games/**`.

Not enqueued.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
