### PR TITLE
fix(dynawalla/games/serpent): the condition is measured before it is written, and 19px is the floor

### DIFF
--- a/dynawalla/games/serpent/src/game/render/glyphs.ts
+++ b/dynawalla/games/serpent/src/game/render/glyphs.ts
@@ -40,8 +40,75 @@ export type LabelStyle = {
   tracking: number;
 };
 
+/**
+ * Ink extent of a label, in CSS pixels: the glyphs and nothing else.
+ *
+ * `labelWidth` is the width of the *canvas* a label rasterises into, and that
+ * canvas is mostly transparent — `pad` is `0.28em` on every side and the plain
+ * box is `1.34em` tall for glyphs whose ink is `CAP_EM`. Measuring a fit
+ * against the padded box makes a label that would sit comfortably read as too
+ * big by roughly a third at each edge, and a fit that is wrong in the safe
+ * direction still shrinks type a child has to read.
+ *
+ * So: fits are measured here, blits are still positioned by `labelWidth`. The
+ * two are deliberately different numbers and the doc comment on each says which.
+ */
+export type Ink = { w: number; h: number };
+
+/**
+ * Ink height of one plain line, in ems.
+ *
+ * Every glyph a condition or an orb is written with — the ten digits, `+`,
+ * U+2212, `×`, `÷`, `=`, `<`, `>`, U+25A1 — sits on the baseline with no
+ * descender, so this is a cap height and not an em box. A prompt that grew a
+ * lowercase letter would need this raised, which is why it is a named constant
+ * with this comment on it rather than a number inside an expression.
+ *
+ * Measured, not chosen: `FONT_STACK` at `800 100px` in a Chromium on macOS gives
+ * `actualBoundingBoxAscent + Descent` of **74.8px** for `8` and **74.6px** for
+ * U+25A1. 0.75 rounds that up, so the fit never underestimates a height.
+ */
+export const CAP_EM = 0.75;
+
+const inkCache = new Map<string, Ink>();
+
 function font(style: LabelStyle, size: number): string {
   return `${style.weight} ${size}px ${FONT_STACK}`;
+}
+
+/** Advance width of `text` at `size`, in CSS pixels. Linear in `size`. */
+function advance(text: string, style: LabelStyle, size: number): number {
+  const m = measureCtx();
+  m.font = font(style, size);
+  return m.measureText(text).width;
+}
+
+/**
+ * The ink `text` would occupy at `style.size`. See `Ink`.
+ *
+ * Mirrors `render()` branch for branch: a bare `a/b` is a stacked fraction and is
+ * therefore short and tall, everything else is one line of `size * CAP_EM`.
+ */
+export function labelInk(text: string, style: LabelStyle): Ink {
+  const key = `${text}|${Math.round(style.size * 4)}|${style.weight}|${style.tracking}`;
+  const hit = inkCache.get(key);
+  if (hit) return hit;
+  if (inkCache.size > MAX_ENTRIES) inkCache.clear();
+
+  const frac = FRACTION.exec(text);
+  let made: Ink;
+  if (frac) {
+    const partSize = style.size * 0.62;
+    const top = advance(frac[1] as string, style, partSize);
+    const bot = advance(frac[2] as string, style, partSize);
+    // `render()` draws the bar at 1.5x the wider numeral, so the bar is the ink.
+    made = { w: Math.max(top, bot) * 1.5, h: partSize * 2.35 };
+  } else {
+    const run = advance(text, style, style.size) + style.tracking * Math.max(0, text.length - 1);
+    made = { w: run, h: style.size * CAP_EM };
+  }
+  inkCache.set(key, made);
+  return made;
 }
 
 function render(text: string, style: LabelStyle, dpr: number): Cached {
@@ -162,10 +229,17 @@ export function drawLabel(
   g.globalAlpha = prev;
 }
 
+/**
+ * Width of the CANVAS a label rasterises into, padding included.
+ *
+ * This is the number to position a blit with. It is NOT the number to fit
+ * against — see `labelInk`.
+ */
 export function labelWidth(text: string, style: LabelStyle, dpr: number): number {
   return label(text, style, dpr).w;
 }
 
 export function clearGlyphCache(): void {
   cache.clear();
+  inkCache.clear();
 }

--- a/dynawalla/games/serpent/src/game/render/prompt.test.ts
+++ b/dynawalla/games/serpent/src/game/render/prompt.test.ts
@@ -1,0 +1,606 @@
+/**
+ * The condition fits the water, at every shape the fleet has.
+ *
+ * ## What was broken
+ *
+ * `scene.ts` drew the condition at `Math.max(56, view.scale * 0.52)` and blitted it
+ * at whatever width that came out — **no measurement anywhere**. The first test
+ * below is the record of that: at 320px, the smallest viewport the fleet tests, the
+ * unmeasured size needs more than three times the width of the vent it is clipped
+ * to, and the string ran out of the disc and out of the safe box.
+ *
+ * It was already wrong on the **shipped** ladder — this is not a future problem.
+ * `WIDEST` is measured, not guessed: `activeNodes()` was swept for every
+ * (skill, level) in the five domains this pack declares (`dw.add`, `dw.mul`,
+ * `dw.div`, `dw.frac`, `dw.alg`), 6,000 seeds each, and the widest string the
+ * shipped host can put on the water today is **thirteen** characters. With PR #720's
+ * `dw.alg.equality.missing-addend` active it is **fourteen**, because
+ * `packs/shared/game-host` admits items by *domain* and this pack declares
+ * `dw.alg.equality.balance-meaning`.
+ *
+ * ## Removing the fix
+ *
+ * Each part of the fix has been deleted in turn and the failures are quoted in the
+ * PR body. Seven removals, seven distinct failures. What each one guards:
+ *
+ * | delete this | and this trips |
+ * |---|---|
+ * | the fit (`layoutPrompt` returns `ideal`, one line) | inside the vent · measured DOWN · animation clears · cannot-reach-the-floor |
+ * | the floor (`MIN_PROMPT_PX = 1`) | the audit's floor · cannot-reach-the-floor |
+ * | fitting the ink → fitting the padded canvas box | inside the vent · reaches the floor honestly · unchanged where there is room |
+ * | the peak headroom (`PROMPT_PEAK_SCALE = 1`) | the pop-in headroom |
+ * | the circle → a width-only check | measured DOWN · animation clears |
+ * | breaks allowed anywhere | never ends on an operator · measured DOWN |
+ * | `scene.ts` back to its own size expression | scene.ts goes through the fit |
+ *
+ * ## Why the measurement is injected
+ *
+ * `labelInk` needs a canvas, and there is no canvas in Node. So the fit takes a
+ * `MeasureLine` and the faces below stand in for one — the pattern `truedraw`
+ * already uses. Three of them, and the third is the point: `PESSIMIST` gives every
+ * glyph a full em, wider than any face a platform resolves, so the guarantees are
+ * statements about the geometry and not about one metric table.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
+import { CAP_EM, type Ink } from "./glyphs.ts";
+import { TUNE } from "../tuning.ts";
+import {
+  MAX_PROMPT_LINES,
+  MIN_PROMPT_PX,
+  PROMPT_PEAK_SCALE,
+  breakings,
+  fitsBudget,
+  promptBudget,
+  promptDrawScale,
+  promptFit,
+  promptIdeal,
+  type MeasureLine,
+} from "./prompt.ts";
+
+/* -------------------------------------------------------------------------- */
+/* The faces.                                                                 */
+/* -------------------------------------------------------------------------- */
+
+type Face = { name: string; em(ch: string): number };
+
+/**
+ * The real face, measured rather than guessed.
+ *
+ * `FONT_STACK` at `800 100px` in a Chromium on macOS, straight off
+ * `measureText().width / 100`:
+ *
+ *     0-9  0.700   space 0.250   + − × ÷ = < >  0.666
+ *     □    0.942   /     0.455   -              0.336
+ *
+ * Written down because the first version of this table was *guessed* at 0.60 for a
+ * digit and 0.58 for an operator, which is 15% narrow — an optimistic fixture is a
+ * test that passes while the device clips. Whatever a platform actually resolves,
+ * `PESSIMIST` below brackets it from above.
+ */
+const ROUNDED: Face = {
+  name: "rounded 800 (measured)",
+  em(ch) {
+    if (ch >= "0" && ch <= "9") return 0.7;
+    if (ch === " ") return 0.25;
+    if (ch === "□") return 0.942;
+    if (ch === "/") return 0.455;
+    if (ch === "-") return 0.336;
+    return 0.666; // + − × ÷ = < >
+  },
+};
+
+/** A condensed face, to prove the fit is not tuned to one set of advances. */
+const NARROW: Face = { name: "narrow", em: (ch) => (ch === " " ? 0.22 : 0.48) };
+
+/**
+ * A face where every glyph is as wide as its own em box.
+ *
+ * No proportional face is this wide — an em is the type size, and the widest glyph
+ * a condition uses in the measured face above is U+25A1 at 0.942 of one. It is here
+ * so that "the condition fits" is a statement about the geometry rather than about
+ * a metric fixture: any face a platform resolves is narrower than this one, so a
+ * fit that holds here holds there.
+ */
+const PESSIMIST: Face = { name: "pessimist (1em per glyph)", em: () => 1 };
+
+const FACES = [ROUNDED, NARROW, PESSIMIST];
+
+/** Tracking, copied from `PROMPT_LABEL` in `scene.ts`. */
+const TRACKING = 2;
+const FRACTION = /^(-?\d+)\/(\d+)$/;
+
+/** Mirrors `labelInk` branch for branch, over a face instead of a canvas. */
+function measurer(face: Face): MeasureLine {
+  return (line, size): Ink => {
+    const frac = FRACTION.exec(line);
+    if (frac) {
+      const part = size * 0.62;
+      const run = (s: string): number => [...s].reduce((a, ch) => a + face.em(ch), 0) * part;
+      return { w: Math.max(run(frac[1] as string), run(frac[2] as string)) * 1.5, h: part * 2.35 };
+    }
+    const advance = [...line].reduce((a, ch) => a + face.em(ch), 0) * size;
+    return { w: advance + TRACKING * Math.max(0, line.length - 1), h: size * CAP_EM };
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* The frame, exactly as `scene.ts` computes it.                              */
+/* -------------------------------------------------------------------------- */
+
+const PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+const LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+/** The same five the HUD is asserted at. 320 wide is the tightest. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+function insetsFor(w: number, h: number): Array<[string, Insets]> {
+  return [
+    ["no insets", NO_INSETS],
+    w > h ? ["cutout at the side", LANDSCAPE] : ["cutout at the top", PORTRAIT],
+  ];
+}
+
+/** The vent shrinks as a child dives. `arenaFloor` is as small as it ever gets. */
+const ARENA_RADII = [1, 0.85, TUNE.arenaFloor];
+
+/**
+ * A frame the game can actually be in.
+ *
+ * `safe` and `scale` are computed the way `scene.ts: resize` computes them, and
+ * everything downstream of that — the ideal size, the budget, the block — comes
+ * from `prompt.ts` itself via `fit()`. Nothing here re-derives a number the
+ * shipping code owns, which is the difference between a test of the renderer and
+ * a test of a copy of the renderer.
+ */
+type Frame = {
+  where: string;
+  safe: { x: number; y: number; w: number; h: number };
+  scale: number;
+  arenaR: number;
+  arenaPx: number;
+  ideal: number;
+};
+
+function frames(): Frame[] {
+  const out: Frame[] = [];
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(w, h)) {
+      const safe = safeRect(w, h, insets);
+      // `scene.ts: resize` — the arena is centred in the safe box and sized off
+      // its short side.
+      const scale = Math.min(safe.w, safe.h) * 0.44;
+      for (const arenaR of ARENA_RADII) {
+        out.push({
+          where: `${name} (${w}x${h}), ${label}, vent ${(arenaR * scale * 2).toFixed(0)}px across`,
+          safe,
+          scale,
+          arenaR,
+          arenaPx: arenaR * scale,
+          ideal: promptIdeal(scale),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/** The shipping path, for one condition in one frame. */
+const fit = (f: Frame, text: string, measure: MeasureLine) =>
+  promptFit(text, f.safe, f.scale, f.arenaR, measure);
+
+/* -------------------------------------------------------------------------- */
+/* What the host can actually send.                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The widest condition per shape the host can put on the water, measured.
+ *
+ * Rows 1-3 are the **shipped** ladder. Rows 4-6 arrive with PR #720. Row 7 is not
+ * on any ladder and is here as headroom — an 18-character statement, half again
+ * the longest thing the curriculum can currently draw.
+ */
+const WIDEST: Array<[string, string]> = [
+  ["dw.mul.scale.times-power-of-ten L2 (active today)", "42739 × 10000"],
+  ["dw.mul.multidigit.long-multiplication L2 (active today)", "41299 × 55313"],
+  ["dw.add.regroup.subtract-short-subtrahend L2 (active today)", "927732 − 788"],
+  ["dw.div.whole.divide-exact L3 (active today)", "132594 ÷ 66"],
+  ["dw.alg.equality.missing-addend L2 (#720)", "946 + □ = 1142"],
+  ["dw.alg.equality.missing-subtrahend L2 (#720, draft)", "1438 − □ = 947"],
+  ["dw.alg.equality.missing-factor L1 (#720, draft)", "□ × 30 = 1680"],
+  ["headroom: an 18-character statement no row serves yet", "12345 + □ = 67890"],
+];
+
+/** What this pack's own stub host serves, so the dev harness is covered too. */
+const STUB: string[] = ["= 12", "6 × ?", "> 3/4", "< 17/20", "= −8"];
+
+/* -------------------------------------------------------------------------- */
+/* 1. The defect, on the record.                                              */
+/* -------------------------------------------------------------------------- */
+
+test("the unmeasured size overran the vent — this is what was shipping", () => {
+  // Not a test of the fix. A test of the claim the fix is answering, so that the
+  // number is in the tree rather than in a PR description.
+  const measure = measurer(ROUNDED);
+  const worst: string[] = [];
+  for (const f of frames()) {
+    const b = promptBudget(f.safe, f.arenaPx);
+    for (const [, text] of WIDEST) {
+      const ink = measure(text, f.ideal);
+      if (!fitsBudget(ink.w, ink.h, b)) {
+        worst.push(
+          `${f.where}: "${text}" at the unmeasured ${f.ideal.toFixed(0)}px is ` +
+            `${ink.w.toFixed(0)}x${ink.h.toFixed(0)}px of ink and the vent holds ` +
+            `${(b.radius * 2).toFixed(0)}px`,
+        );
+      }
+    }
+  }
+  assert.ok(
+    worst.length > 0,
+    "the unmeasured size fits everywhere, so there was nothing to fix — check WIDEST",
+  );
+  // The tightest viewport must be among the failures, and by a wide margin: at
+  // 320px the unmeasured condition is more than twice the vent.
+  const small = frames().filter((f) => f.safe.w === 320);
+  for (const f of small) {
+    const ink = measure("946 + □ = 1142", f.ideal);
+    const b = promptBudget(f.safe, f.arenaPx);
+    assert.ok(
+      ink.w > b.radius * 2 * 2,
+      `${f.where}: the unmeasured condition is only ${(ink.w / (b.radius * 2)).toFixed(2)}x the vent`,
+    );
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* 2. The gate.                                                               */
+/* -------------------------------------------------------------------------- */
+
+test("every condition the host can send is drawn inside the vent", () => {
+  for (const face of FACES) {
+    const measure = measurer(face);
+    for (const f of frames()) {
+      const b = promptBudget(f.safe, f.arenaPx);
+      for (const [row, text] of [...WIDEST, ...STUB.map((s) => ["the stub host", s] as [string, string])]) {
+        const block = fit(f, text, measure);
+        assert.ok(
+          fitsBudget(block.w, block.h, b),
+          `${face.name}, ${f.where}: ${row} — "${text}" is drawn ` +
+            `${block.size.toFixed(0)}px on ${block.lines.length} line(s), ` +
+            `${block.w.toFixed(0)}x${block.h.toFixed(0)}px of ink, and the vent holds ` +
+            `${(b.radius * 2).toFixed(0)}px`,
+        );
+        assert.ok(block.lines.length <= MAX_PROMPT_LINES, `${text} broke into ${block.lines.length} lines`);
+      }
+    }
+  }
+});
+
+/**
+ * The floor, as a literal.
+ *
+ * NOT `MIN_PROMPT_PX`. Asserting a module against its own constant is a test that
+ * passes whatever the constant becomes: set `MIN_PROMPT_PX = 1` and a floor test
+ * written that way still goes green while a 14px condition ships. 19 is the repo
+ * legibility audit's number for a prompt, so the audit's number is what is written
+ * here, and moving the constant has to be a deliberate edit in two places.
+ */
+const AUDIT_PROMPT_FLOOR_PX = 19;
+
+test("the module's floor is still the audit's floor", () => {
+  assert.equal(MIN_PROMPT_PX, AUDIT_PROMPT_FLOOR_PX);
+});
+
+test("nothing is ever drawn below the legibility floor", () => {
+  // Shrinking past a floor is not fitting, it is hiding: a sibling pack shipped a
+  // 15.1px answer under a bloom and the founder filed it as illegible.
+  for (const face of FACES) {
+    const measure = measurer(face);
+    for (const f of frames()) {
+      for (const [row, text] of WIDEST) {
+        const block = fit(f, text, measure);
+        assert.ok(
+          block.size >= AUDIT_PROMPT_FLOOR_PX,
+          `${face.name}, ${f.where}: ${row} — "${text}" is drawn at ` +
+            `${block.size.toFixed(1)}px, under the ${AUDIT_PROMPT_FLOOR_PX}px floor`,
+        );
+      }
+    }
+  }
+});
+
+test("every condition on the shipped ladder and in #720 reaches the floor honestly", () => {
+  // `fits: false` means the block was drawn AT the floor and did not get there
+  // legitimately. No row the host can serve may be in that state, on any face.
+  for (const face of FACES) {
+    const measure = measurer(face);
+    for (const f of frames()) {
+      const b = promptBudget(f.safe, f.arenaPx);
+      for (const [row, text] of WIDEST) {
+        const block = fit(f, text, measure);
+        assert.equal(
+          block.fits,
+          true,
+          `${face.name}, ${f.where}: ${row} — "${text}" cannot be drawn at the ` +
+            `${MIN_PROMPT_PX}px floor at all; it needs ` +
+            `${block.w.toFixed(0)}x${block.h.toFixed(0)}px and the vent holds ` +
+            `${(b.radius * 2).toFixed(0)}px`,
+        );
+      }
+    }
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* 3. That the fit is in the build, and is a fit rather than a shrink.        */
+/* -------------------------------------------------------------------------- */
+
+test("on the tightest viewport the widest condition is measured DOWN and broken", () => {
+  // The assertion a no-op fix cannot pass. If `layoutPrompt` ever returns `ideal`
+  // unmeasured, or stops breaking, this trips before anything reaches a device.
+  const measure = measurer(ROUNDED);
+  const f = frames().find((x) => x.safe.w === 320 && x.arenaPx === TUNE.arenaFloor * x.scale);
+  assert.ok(f, "no 320px frame at the vent floor — the frame table changed");
+  const block = fit(f, "946 + □ = 1142", measure);
+  assert.ok(
+    block.size < Math.floor(f.ideal),
+    `the condition was drawn at the ideal ${f.ideal.toFixed(0)}px unmeasured`,
+  );
+  assert.ok(block.lines.length >= 2, "a fourteen-character statement was left on one line");
+  assert.deepEqual([...block.lines], ["946 + □", "= 1142"], "the break is not at the relation");
+});
+
+test("a condition with room is drawn exactly as it always was", () => {
+  // The fit must be a no-op where nothing was wrong, or it is a redesign rather
+  // than a repair. A tablet at the surface has room for the stub's conditions at
+  // the full ideal size, on one line.
+  const measure = measurer(ROUNDED);
+  const f = frames().find((x) => x.safe.w === 768 && x.arenaPx === x.scale);
+  assert.ok(f, "no tablet-portrait frame at the surface");
+  for (const text of ["= 12", "6 × ?", "> 3/4"]) {
+    const block = fit(f, text, measure);
+    assert.equal(block.lines.length, 1, `"${text}" was broken on a screen with room for it`);
+    assert.equal(block.size, Math.floor(f.ideal), `"${text}" was shrunk on a screen with room for it`);
+    assert.deepEqual([...block.offsets], [0], `"${text}" was offset off centre`);
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* 4. How it breaks.                                                          */
+/* -------------------------------------------------------------------------- */
+
+test("a line never ends on an operator or a relation", () => {
+  const trailing = ["+", "−", "×", "÷", "=", "<", ">", "-", "≤", "≥"];
+  for (const [, text] of [...WIDEST, ...STUB.map((s) => ["", s] as [string, string])]) {
+    for (const lines of breakings(text)) {
+      for (const line of lines) {
+        assert.ok(line.length > 0, `"${text}" produced an empty line`);
+        const last = line.slice(-1);
+        assert.ok(
+          !trailing.includes(last),
+          `"${text}" broke to [${lines.join(" / ")}] — a line ends on "${last}"`,
+        );
+      }
+    }
+  }
+});
+
+test("a break never splits a number", () => {
+  for (const [, text] of WIDEST) {
+    const want = text.split(/\s+/).filter((t) => t.length > 0).join(" ");
+    for (const lines of breakings(text)) {
+      assert.equal(lines.join(" "), want, `"${text}" lost or moved a token: [${lines.join(" / ")}]`);
+    }
+  }
+});
+
+test("a condition with no break point is left alone", () => {
+  assert.deepEqual([...breakings("1234")], [["1234"]]);
+  assert.deepEqual([...breakings("")], [[""]]);
+});
+
+/* -------------------------------------------------------------------------- */
+/* 5. The premises the fit rests on.                                          */
+/* -------------------------------------------------------------------------- */
+
+test("ink width is monotone in size, which is what the binary search assumes", () => {
+  for (const face of FACES) {
+    const measure = measurer(face);
+    for (const [, text] of [...WIDEST, ...STUB.map((s) => ["", s] as [string, string])]) {
+      let last = -1;
+      for (let size = MIN_PROMPT_PX; size <= 220; size++) {
+        const w = measure(text, size).w;
+        assert.ok(w >= last, `${face.name}: "${text}" got narrower from ${size - 1}px to ${size}px`);
+        last = w;
+      }
+    }
+  }
+});
+
+test("the pop-in never exceeds the headroom the budget reserved", () => {
+  // `PROMPT_PEAK_SCALE` is what `promptBudget` divides by. `easeOutBack`
+  // overshoots, so the largest the condition is ever drawn is NOT the size it was
+  // fitted at, and this is the test that keeps that number honest if the
+  // animation is ever retuned.
+  let peak = 0;
+  for (let promptT = 0; promptT <= 1.0001; promptT += 0.002) {
+    for (let camT = 0; camT < 7.1; camT += 0.01) {
+      peak = Math.max(peak, promptDrawScale(promptT, camT).core);
+    }
+  }
+  assert.ok(
+    peak <= PROMPT_PEAK_SCALE,
+    `the condition is drawn at up to ${peak.toFixed(4)}x and the budget reserved ${PROMPT_PEAK_SCALE}x`,
+  );
+  // And not wastefully loose, or the reserve is quietly shrinking the type.
+  assert.ok(peak > PROMPT_PEAK_SCALE - 0.02, `the reserve is ${PROMPT_PEAK_SCALE} for a peak of ${peak.toFixed(4)}`);
+  // The halo is deliberately outside the fit. It is the same glyphs at a tenth of
+  // the alpha and it is allowed to bleed over the rim; the core is not.
+  const at = promptDrawScale(1, 0);
+  assert.ok(at.halo > at.core, "the halo is no longer the outer pass");
+});
+
+test("the drawn condition, animation included, still clears the vent", () => {
+  // The end-to-end statement: fitted size times the largest scale the animation
+  // reaches, against the vent as it really is — `ARENA_USE` and the peak reserve
+  // both removed from the budget, so nothing in the chain is measuring itself.
+  const measure = measurer(ROUNDED);
+  let peak = 0;
+  for (let t = 0; t <= 1.0001; t += 0.005) peak = Math.max(peak, promptDrawScale(t, 0.9).core);
+  for (const f of frames()) {
+    for (const [row, text] of WIDEST) {
+      const block = fit(f, text, measure);
+      const w = block.w * peak;
+      const h = block.h * peak;
+      assert.ok(
+        (w / 2) ** 2 + (h / 2) ** 2 <= f.arenaPx ** 2,
+        `${f.where}: ${row} — at the peak of the pop-in "${text}" is ` +
+          `${w.toFixed(0)}x${h.toFixed(0)}px and the vent is ${(f.arenaPx * 2).toFixed(0)}px across`,
+      );
+      assert.ok(w <= f.safe.w && h <= f.safe.h, `${f.where}: ${row} — "${text}" leaves the safe box`);
+    }
+  }
+});
+
+test("a condition that cannot reach the floor is drawn and says so", () => {
+  // Only reachable on a surface no device has, which is exactly when nobody is
+  // watching. It must not be a blank arena and it must not be silent.
+  const measure = measurer(PESSIMIST);
+  const block = promptFit("12345 + □ = 67890", { x: 0, y: 0, w: 60, h: 60 }, 55, 1, measure);
+  assert.equal(block.fits, false, "an impossible condition reported that it fitted");
+  assert.equal(block.size, MIN_PROMPT_PX, "an impossible condition was shrunk below the floor anyway");
+  assert.ok(block.lines.length > 1, "an impossible condition was not broken as far as it goes");
+  assert.equal(block.lines.join(" "), "12345 + □ = 67890", "an impossible condition lost a token");
+});
+
+test("the block is centred: the line offsets sum to zero", () => {
+  const measure = measurer(ROUNDED);
+  for (const f of frames()) {
+    for (const [, text] of WIDEST) {
+      const block = fit(f, text, measure);
+      const sum = block.offsets.reduce((a, o) => a + o, 0);
+      assert.ok(Math.abs(sum) < 1e-9, `"${text}" offsets sum to ${sum}`);
+      assert.equal(block.offsets.length, block.lines.length);
+    }
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* 6. The renderer really goes through the fit.                               */
+/* -------------------------------------------------------------------------- */
+
+test("scene.ts writes the condition through the fit and by no other route", () => {
+  // Everything above tests `prompt.ts`. This is the one assertion that the
+  // RENDERER uses it — the gap a module-only suite leaves is a perfect fit sitting
+  // beside a `drawLabel` call that ignores it, which is what shipped.
+  //
+  // Source-level because `createRenderer` needs a canvas and there is none in
+  // Node. It is two facts, both cheap to keep true: the fit is called, and the
+  // expression it replaced is gone.
+  const scene = readFileSync(join(dirname(new URL(import.meta.url).pathname), "scene.ts"), "utf8");
+  assert.ok(scene.includes("promptFit("), "scene.ts no longer calls promptFit — the fit is not in the build");
+  assert.ok(
+    scene.includes("drawPromptBlock(block"),
+    "scene.ts no longer draws the fitted block; a fit nothing draws is not a fix",
+  );
+  assert.ok(
+    !scene.includes("view.scale * 0.52"),
+    "scene.ts computes the prompt size itself again — that expression is `promptIdeal` now, " +
+      "and a second copy of it is how the renderer and this test part company",
+  );
+  // The condition is written INSIDE the vent's clip, which is the whole reason the
+  // budget is a circle. If the clip goes, the budget is measuring the wrong shape.
+  assert.ok(scene.includes("g.clip()"), "the arena clip is gone — see the header of prompt.ts");
+});
+
+/* -------------------------------------------------------------------------- */
+/* 7. The safe area is measured, never read from CSS.                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Lines that would actually *use* `env(safe-area-inset-*)`, as opposed to the ones
+ * that explain why nothing may.
+ *
+ * `chrome.ts` and `chrome.test.ts` both name the token in prose and must stay able
+ * to, so a plain substring sweep over the tree is not the check — it is a check
+ * that fails on its own documentation, which is the shape of guard that gets
+ * deleted rather than obeyed. A comment line is skipped; anything else is not.
+ *
+ * Exported to the two control tests below rather than inlined, because a
+ * rule-walker nobody exercised is how a guard passes green over the very
+ * regression it stands for.
+ */
+function envInsetUses(source: string): string[] {
+  const out: string[] = [];
+  let inBlockComment = false;
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    const opened = line.includes("/*");
+    const closed = line.includes("*/");
+    const commented =
+      inBlockComment || line.startsWith("//") || line.startsWith("*") || (opened && !closed);
+    if (opened && !closed) inBlockComment = true;
+    if (closed) inBlockComment = false;
+    if (commented) continue;
+    if (line.includes("env(safe-area-inset")) out.push(line);
+  }
+  return out;
+}
+
+test("the safe-area guard catches a real use and ignores the prose about it", () => {
+  // The positive control. Without this the guard below could be walking nothing.
+  assert.deepEqual(envInsetUses("#app { padding-top: env(safe-area-inset-top); }"), [
+    "#app { padding-top: env(safe-area-inset-top); }",
+  ]);
+  assert.deepEqual(envInsetUses('el.style.top = "env(safe-area-inset-top)"'), [
+    'el.style.top = "env(safe-area-inset-top)"',
+  ]);
+  // The negative control: the three comment shapes this tree actually uses.
+  assert.deepEqual(envInsetUses(" * `env(safe-area-inset-*)` is zero inside a pack"), []);
+  assert.deepEqual(envInsetUses("// env(safe-area-inset-top) is zero here"), []);
+  assert.deepEqual(
+    envInsetUses("/* a block\n   env(safe-area-inset-top) never works\n*/\n#app { inset: 0 }"),
+    [],
+  );
+  // And a use on the line AFTER a block comment closes is still caught.
+  assert.deepEqual(envInsetUses("/* why not */\n#app { top: env(safe-area-inset-top) }"), [
+    "#app { top: env(safe-area-inset-top) }",
+  ]);
+});
+
+test("nothing in this pack uses env(safe-area-inset", () => {
+  // `env(safe-area-inset-*)` is ZERO inside a pack: the insets belong to the
+  // top-level browsing context and this document is framed. Four packs in this
+  // fleet have shipped that bug. `runner`'s fix was to delete every positional CSS
+  // declaration and let the test fail the build if the token reappears — the
+  // insets come from `safeInsets()` in `packs/shared/game-chrome`, which measures.
+  const root = join(dirname(new URL(import.meta.url).pathname), "..", "..", "..");
+  const offenders: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".") || entry.name.startsWith("dist")) continue;
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!/\.(html|css|ts|tsx)$/.test(entry.name)) continue;
+      if (entry.name === "prompt.test.ts") continue;
+      for (const line of envInsetUses(readFileSync(path, "utf8"))) offenders.push(`${path}: ${line}`);
+    }
+  };
+  walk(root);
+  assert.ok(offenders.length === 0, `env(safe-area-inset is zero inside a pack:\n${offenders.join("\n")}`);
+});

--- a/dynawalla/games/serpent/src/game/render/prompt.ts
+++ b/dynawalla/games/serpent/src/game/render/prompt.ts
@@ -1,0 +1,346 @@
+/**
+ * Fitting the condition to the water it is written on.
+ *
+ * ## The defect this replaces
+ *
+ * The condition used to be drawn at `Math.max(56, view.scale * 0.52)` and blitted
+ * at its natural width, measured against nothing. On a 320px phone that is a
+ * 73px numeral inside an arena whose diameter is 282px at the surface and **175px
+ * at `arenaFloor`** — so the string ran out of the disc it is clipped to and out
+ * of the safe box, and the deeper a child dived the worse it got. It was already
+ * wrong on the shipped ladder: `dw.mul.scale.times-power-of-ten` L2 serves
+ * `42739 × 10000`, thirteen characters. It gets worse the moment any `alg` row
+ * goes active, because `packs/shared/game-host` admits items by **domain** and
+ * this pack declares `dw.alg.*` — `946 + □ = 1142` is fourteen.
+ *
+ * ## What replaces it
+ *
+ * A measured fit with a hard floor, and a break rather than a squash:
+ *
+ *   1. **Measured.** Every candidate is measured, at every size, against the
+ *      *ink* extent (`labelInk`, not `labelWidth` — see the doc comment there).
+ *   2. **Broken, not squashed.** A condition is a sentence about a relation, so
+ *      it breaks where the mathematics breaks: `946 + □` over `= 1142`, never a
+ *      horizontally compressed smear and never mid-token. A break is only ever
+ *      allowed *before* an operator or a relation, so no line can end on one.
+ *   3. **Floored.** `MIN_PROMPT_PX` is the bottom, and it is not negotiable.
+ *      Shrinking past a legibility floor is not fitting, it is hiding: a sibling
+ *      pack shipped a 15.1px answer under a bloom and the founder filed it as
+ *      illegible. A condition that cannot reach the floor is drawn AT the floor,
+ *      wrapped as far as it goes, and says so out loud — `fits: false`.
+ *
+ * ## Why the fit is a circle and not a rectangle
+ *
+ * The condition is drawn inside the arena's own clip (`scene.ts` clips to the
+ * vent disc before writing on the water), so the boundary that actually cuts a
+ * numeral in half is a circle, not the viewport. A block of width `w` and height
+ * `h` centred on that disc fits exactly when its corners do:
+ *
+ *     (w/2)² + (h/2)² ≤ radius²
+ *
+ * which is also, read the other way, "`w` is no wider than the chord at `h/2`".
+ * Fitting the bounding *square* instead would refuse sizes that are provably
+ * legible, and fitting the width alone would clip the tops off two-line blocks.
+ *
+ * Everything here is arithmetic over numbers a test can supply, which is the
+ * point: the widths are wrong on a device or they are wrong in `prompt.test.ts`,
+ * and only one of those is discoverable.
+ */
+
+import { easeOutBack } from "../num.ts";
+import { CAP_EM, type Ink } from "./glyphs.ts";
+
+/**
+ * The smallest cap height a condition may ever be drawn at, in CSS pixels.
+ *
+ * The repo's legibility audit sets 19px for a prompt and 15px for an answer
+ * candidate. This is the prompt.
+ */
+export const MIN_PROMPT_PX = 19;
+
+/** No condition is ever broken into more lines than this. */
+export const MAX_PROMPT_LINES = 3;
+
+/** Baseline-to-baseline of a broken condition, in ems. */
+export const PROMPT_LINE_EM = 1.24;
+
+/**
+ * The relation glyphs a condition can turn on, and the operators.
+ *
+ * A line may begin with one of these and may never end with one, which is what
+ * makes `946 + □` / `= 1142` the only two-line reading of that statement and
+ * `946 +` / `□ = 1142` unreachable. U+2212 MINUS SIGN, U+00D7, U+00F7 — the
+ * glyphs the curriculum actually writes; an ASCII hyphen is accepted too because
+ * this pack's own stub host emits one in a negative literal's company.
+ */
+const RELATIONS: readonly string[] = ["=", "<", ">", "≤", "≥"];
+const OPERATORS: readonly string[] = ["+", "−", "×", "÷", "-"];
+
+/**
+ * How the pop-in and the breathing scale the condition, this frame.
+ *
+ * Extracted from `scene.ts` so that `PROMPT_PEAK_SCALE` can be *checked* against
+ * the expressions it claims to bound instead of being a number somebody believed.
+ * `easeOutBack` overshoots, which is the whole reason a reserved headroom exists
+ * at all: the largest the condition is ever drawn is not the size it was fitted
+ * at.
+ *
+ * `halo` is the outer additive pass. It is deliberately outside the fit — it is
+ * the same glyphs 8% larger at a tenth of the alpha, i.e. a glow, and clipping
+ * the outer rim of a glow against the vent is invisible. The `core` pass is the
+ * one a child reads and it is what the budget reserves for.
+ */
+export function promptDrawScale(
+  promptT: number,
+  camT: number,
+): { core: number; halo: number; breathe: number } {
+  const breathe = 1 + Math.sin(camT * 0.9) * 0.012;
+  const inK = easeOutBack(Math.min(1, promptT * 1.25));
+  const core = (0.74 + 0.26 * inK) * breathe;
+  // `breathe` is handed back for the OUTGOING condition, which expands and fades
+  // on its own curve but breathes with the same lungs.
+  return { core, halo: core * 1.08, breathe };
+}
+
+/**
+ * The largest `core` scale `promptDrawScale` can ever return.
+ *
+ * `promptBudget` divides by it, so the peak of the pop-in lands exactly on the
+ * boundary rather than through it. Held against a sweep of the real expressions
+ * in `prompt.test.ts` — if the animation is ever retuned, that test fails here
+ * rather than a numeral overrunning the vent for two frames on a device.
+ *
+ * It is 1.039 and not 1.016, which is what this constant was first written as:
+ * `easeOutBack` peaks at **1.0999**, not at the 1.014 an eyeball reading of it
+ * suggests, so the settle overshoots by four percent rather than one and a half.
+ * The sweep is the only reason that is known. Do not hand-derive it again.
+ */
+export const PROMPT_PEAK_SCALE = 1.039;
+
+/**
+ * How much of the vent disc the condition may use.
+ *
+ * `0.94` is two separate margins folded into one number, both measured:
+ *   · `cam.zoom` is a spring (`1 + punch`), and the largest punch in `TUNE` is
+ *     0.14 into a spring of stiffness 190, so the zoom undershoots to about
+ *     0.990. The fit is computed from the *unzoomed* radius, so it has to hold
+ *     when the disc is 1% smaller than it was measured.
+ *   · the rim draws a white-hot lip just inside `arenaR`, and ink that touches
+ *     the lip reads as ink that has hit the wall.
+ */
+const ARENA_USE = 0.94;
+
+/** Clear air between the condition and the edge of the safe box. */
+const SAFE_MARGIN = 8;
+
+export type Rect = { x: number; y: number; w: number; h: number };
+
+export type PromptBudget = {
+  /** Radius of the disc the block must fit inside, peak headroom already taken. */
+  radius: number;
+  maxW: number;
+  maxH: number;
+};
+
+export type PromptBlock = {
+  lines: readonly string[];
+  /** Cap height the block is drawn at, in CSS pixels. Never below the floor. */
+  size: number;
+  /** Ink extent of the whole block at `size`. */
+  w: number;
+  h: number;
+  /** Each line's centre offset from the block's centre, in CSS pixels. */
+  offsets: readonly number[];
+  /**
+   * `false` when even `MIN_PROMPT_PX`, wrapped as far as it wraps, does not fit.
+   * The block is still drawn — a condition a child cannot see is a game with no
+   * rule in it — but the caller shouts, because that is a curriculum row this
+   * pack should not have been served.
+   */
+  fits: boolean;
+};
+
+/**
+ * The disc and the box a condition has to live inside.
+ *
+ * `arenaPx` is `world.arenaR * view.scale` — the arena radius WITHOUT `cam.zoom`,
+ * because a fit recomputed on a spring is a fit that jitters. `ARENA_USE` carries
+ * the zoom undershoot instead.
+ */
+export function promptBudget(safe: Rect, arenaPx: number): PromptBudget {
+  return {
+    radius: Math.max(1, (arenaPx * ARENA_USE) / PROMPT_PEAK_SCALE),
+    maxW: Math.max(1, (safe.w - SAFE_MARGIN * 2) / PROMPT_PEAK_SCALE),
+    maxH: Math.max(1, (safe.h - SAFE_MARGIN * 2) / PROMPT_PEAK_SCALE),
+  };
+}
+
+/** Does a block of this ink extent, centred on the disc, fit? See the header. */
+export function fitsBudget(w: number, h: number, b: PromptBudget): boolean {
+  if (w > b.maxW || h > b.maxH) return false;
+  return w * w + h * h <= 4 * b.radius * b.radius;
+}
+
+/** Ink of one line at one size. `scene.ts` passes `labelInk`; tests pass a face. */
+export type MeasureLine = (line: string, size: number) => Ink;
+
+/**
+ * Every way this condition may be broken, fewest lines first and relation breaks
+ * before operator breaks.
+ *
+ * The order is load-bearing: `layoutPrompt` keeps the first candidate that
+ * reaches the largest size, so a tie is resolved toward one line, and then toward
+ * breaking at the `=` rather than mid-expression. That is the reading a person
+ * would choose, arrived at by ordering rather than by a scoring function nobody
+ * can predict.
+ */
+export function breakings(text: string): readonly (readonly string[])[] {
+  const tokens = text.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length <= 1) return [[text.trim() === "" ? text : (tokens[0] as string)]];
+
+  // Position 0 is not a break: a first line is not a break, it is a beginning.
+  const relations: number[] = [];
+  const operators: number[] = [];
+  for (let i = 1; i < tokens.length; i++) {
+    const t = tokens[i] as string;
+    if (RELATIONS.includes(t)) relations.push(i);
+    else if (OPERATORS.includes(t)) operators.push(i);
+  }
+  const points = [...relations, ...operators];
+
+  const out: string[][] = [[tokens.join(" ")]];
+  const cut = (at: readonly number[]): string[] => {
+    const lines: string[] = [];
+    let from = 0;
+    for (const p of at) {
+      lines.push(tokens.slice(from, p).join(" "));
+      from = p;
+    }
+    lines.push(tokens.slice(from).join(" "));
+    return lines;
+  };
+  for (const a of points) out.push(cut([a]));
+  for (const a of points) {
+    for (const b of points) {
+      if (b > a) out.push(cut([a, b].sort((x, y) => x - y)));
+    }
+  }
+
+  const seen = new Set<string>();
+  const unique: string[][] = [];
+  for (const lines of out) {
+    if (lines.length > MAX_PROMPT_LINES) continue;
+    const key = lines.join("\n");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(lines);
+  }
+  return unique;
+}
+
+function blockInk(lines: readonly string[], size: number, measure: MeasureLine): Ink {
+  let w = 0;
+  let tallest = size * CAP_EM;
+  for (const line of lines) {
+    const ink = measure(line, size);
+    if (ink.w > w) w = ink.w;
+    if (ink.h > tallest) tallest = ink.h;
+  }
+  return { w, h: (lines.length - 1) * size * PROMPT_LINE_EM + tallest };
+}
+
+/**
+ * The largest whole-pixel size at or below `ideal` at which these lines fit, or
+ * 0 when not even the floor does.
+ *
+ * Whole pixels on purpose: `glyphs.ts` keys its raster cache on the size, and a
+ * size that tracks a continuously shrinking arena would rebuild every glyph
+ * every frame and still look like it was crawling.
+ *
+ * Binary search is sound because ink width is an advance plus a constant
+ * tracking term and is therefore monotone non-decreasing in size — asserted over
+ * the test's faces rather than assumed.
+ */
+function largestFitting(
+  lines: readonly string[],
+  ideal: number,
+  b: PromptBudget,
+  measure: MeasureLine,
+): number {
+  const fitsAt = (size: number): boolean => {
+    const ink = blockInk(lines, size, measure);
+    return fitsBudget(ink.w, ink.h, b);
+  };
+  let hi = Math.max(MIN_PROMPT_PX, Math.floor(ideal));
+  if (fitsAt(hi)) return hi;
+  let lo = MIN_PROMPT_PX;
+  if (!fitsAt(lo)) return 0;
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (fitsAt(mid)) lo = mid;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * The size the condition is drawn at when there is room for it.
+ *
+ * Unchanged from what shipped, so a short condition on a roomy screen looks
+ * exactly as it always did and this whole file is a no-op there. It lives here
+ * rather than inline in `scene.ts` for one reason: `prompt.test.ts` asserts the fit
+ * at every viewport the fleet has, and a test that re-derives the ideal size from
+ * its own copy of `Math.max(56, scale * 0.52)` is a test that keeps passing after
+ * the renderer's copy changes.
+ */
+export function promptIdeal(scale: number): number {
+  return Math.max(56, scale * 0.52);
+}
+
+/**
+ * The whole chain, from a frame to a laid-out condition.
+ *
+ * `scene.ts` calls exactly this and then draws `block.lines` at `block.offsets`;
+ * there is no other path to the water. Everything the fit depends on — the safe
+ * box, the unzoomed scale, the live arena radius — is an argument, so the test
+ * drives the shipping code rather than a reconstruction of it.
+ */
+export function promptFit(
+  text: string,
+  safe: Rect,
+  scale: number,
+  arenaR: number,
+  measure: MeasureLine,
+): PromptBlock {
+  return layoutPrompt(text, promptIdeal(scale), promptBudget(safe, arenaR * scale), measure);
+}
+
+/** Lay the condition out: how it breaks, how big it is, where each line sits. */
+export function layoutPrompt(
+  text: string,
+  ideal: number,
+  b: PromptBudget,
+  measure: MeasureLine,
+): PromptBlock {
+  const candidates = breakings(text);
+  let bestLines: readonly string[] | null = null;
+  let bestSize = 0;
+  for (const lines of candidates) {
+    const size = largestFitting(lines, ideal, b, measure);
+    // Strictly greater, so a tie keeps the earlier candidate: fewer lines, and
+    // then the relation break. See `breakings`.
+    if (size > bestSize) {
+      bestSize = size;
+      bestLines = lines;
+    }
+  }
+
+  const fits = bestLines !== null;
+  // Nothing reached the floor. Draw at the floor, broken as far as it breaks —
+  // the widest break is the last candidate, which is the most-wrapped one.
+  const lines = bestLines ?? (candidates[candidates.length - 1] as readonly string[]);
+  const size = fits ? bestSize : MIN_PROMPT_PX;
+  const ink = blockInk(lines, size, measure);
+  const offsets = lines.map((_, i) => (i - (lines.length - 1) / 2) * size * PROMPT_LINE_EM);
+  return { lines, size, w: ink.w, h: ink.h, offsets, fits };
+}

--- a/dynawalla/games/serpent/src/game/render/scene.ts
+++ b/dynawalla/games/serpent/src/game/render/scene.ts
@@ -120,7 +120,10 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
   let promptComplaint = "";
 
   function fittedPrompt(text: string, arenaR: number): PromptBlock {
-    const key = `${text}|${Math.round(arenaR * view.scale)}|${Math.round(view.safe.w)}`;
+    // Every input the fit reads is in the key, `view.safe.h` included: on a wide,
+    // short viewport the height is what binds a three-line block, and it can change
+    // while `view.scale` and `view.safe.w` do not.
+    const key = `${text}|${Math.round(arenaR * view.scale)}|${Math.round(view.safe.w)}|${Math.round(view.safe.h)}`;
     if (promptBlock && promptKey === key) return promptBlock;
     const block = promptFit(text, view.safe, view.scale, arenaR, (line, size) =>
       labelInk(line, { ...PROMPT_LABEL, size }),

--- a/dynawalla/games/serpent/src/game/render/scene.ts
+++ b/dynawalla/games/serpent/src/game/render/scene.ts
@@ -13,14 +13,15 @@
  *     rising chime *and* growth *and* a bulge travelling down the body.
  */
 
-import { TAU, clamp, easeOutBack, easeOutCubic, easeOutExpo } from "../num.ts";
+import { TAU, clamp, easeOutCubic, easeOutExpo } from "../num.ts";
 import { COLORS, TUNE } from "../tuning.ts";
 import { bolusTintAt } from "../serpent.ts";
 import { orbDrawRadius } from "../orbs.ts";
 import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
 import type { World } from "../world.ts";
 import { GLOW_PX, MOTE_PX, sprites } from "./sprites.ts";
-import { drawLabel, labelWidth, type LabelStyle } from "./glyphs.ts";
+import { drawLabel, labelInk, labelWidth, type LabelStyle } from "./glyphs.ts";
+import { promptDrawScale, promptFit, type PromptBlock } from "./prompt.ts";
 import { PK_BUBBLE, PK_MOTE, PK_SHARD } from "../fx/particles.ts";
 
 /**
@@ -97,9 +98,63 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
   const snowFar: Snow[] = [];
   const snowNear: Snow[] = [];
   let shownPrompt = "";
-  let outgoingPrompt = "";
   let promptT = 1;
   let lastTime = 0;
+
+  /**
+   * The fitted condition, and the block the previous one was fitted to.
+   *
+   * Cached because a fit is a binary search over a measurement and neither belongs
+   * in a frame, and because the outgoing condition has to keep the size it was
+   * fitted at while it blows away — re-fitting it against the new arena would make
+   * the departing string jump before it faded.
+   *
+   * The key carries the arena radius rounded to a whole pixel, so the block is
+   * re-laid-out a handful of times as the vent closes rather than 60 times a
+   * second, and never at all on a screen that is not moving.
+   */
+  let promptBlock: PromptBlock | null = null;
+  let promptKey = "";
+  let outgoingBlock: PromptBlock | null = null;
+  /** The last condition we shouted about, so the shout is once and not per frame. */
+  let promptComplaint = "";
+
+  function fittedPrompt(text: string, arenaR: number): PromptBlock {
+    const key = `${text}|${Math.round(arenaR * view.scale)}|${Math.round(view.safe.w)}`;
+    if (promptBlock && promptKey === key) return promptBlock;
+    const block = promptFit(text, view.safe, view.scale, arenaR, (line, size) =>
+      labelInk(line, { ...PROMPT_LABEL, size }),
+    );
+    if (!block.fits && promptComplaint !== text) {
+      promptComplaint = text;
+      // Never silent. A condition that cannot be drawn at the legibility floor is
+      // a row this pack should not have been served, and the only way anyone finds
+      // out is if it says so.
+      console.error(
+        `[serpent] the condition "${text}" does not fit the vent at the legibility ` +
+          `floor: ${block.lines.length} line(s) of ${block.size.toFixed(0)}px need ` +
+          `${block.w.toFixed(0)}x${block.h.toFixed(0)}px and the disc is ` +
+          `${(arenaR * view.scale * 2).toFixed(0)}px across. It is drawn anyway, cramped.`,
+      );
+    }
+    promptKey = key;
+    promptBlock = block;
+    return block;
+  }
+
+  /** One condition, one pass, `block.size` already decided. */
+  function drawPromptBlock(
+    block: PromptBlock,
+    x: number,
+    y: number,
+    scale: number,
+    alpha: number,
+  ): void {
+    const style: LabelStyle = { ...PROMPT_LABEL, size: block.size };
+    for (let i = 0; i < block.lines.length; i++) {
+      drawLabel(g, block.lines[i] as string, style, x, y + (block.offsets[i] as number) * scale, view.dpr, scale, alpha);
+    }
+  }
 
   // Scratch buffers for the body outline. Allocated once.
   const nx = new Float32Array(TUNE.maxSegments + 2);
@@ -285,26 +340,29 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     }
 
     // --- the condition, written on the water ------------------------------
+    //
+    // Measured, broken and floored — see `prompt.ts`. The fit is handed
+    // `w.arenaR` and `view.scale` and deliberately NOT `cam.zoom`: the budget
+    // carries the spring's undershoot as a margin, because a fit recomputed on a
+    // spring is a fit that jitters.
     if (w.prompt !== shownPrompt) {
-      outgoingPrompt = shownPrompt;
+      outgoingBlock = promptBlock;
       shownPrompt = w.prompt;
       promptT = 0;
     }
     promptT = Math.min(1, promptT + dt * 1.9);
-    const promptSize = Math.max(56, view.scale * 0.52);
-    const style: LabelStyle = { ...PROMPT_LABEL, size: promptSize };
-    const breathe = 1 + Math.sin(w.cam.t * 0.9) * 0.012;
+    const block = fittedPrompt(shownPrompt, w.arenaR);
     // Additive, so the condition is *light in the water* — it can never read as
     // a dark smudge whatever is behind it, and the serpent swims through it.
     g.globalCompositeOperation = "lighter";
-    if (outgoingPrompt && promptT < 1) {
+    const pop = promptDrawScale(promptT, w.cam.t);
+    if (outgoingBlock && promptT < 1) {
       const k = easeOutCubic(promptT);
-      drawLabel(g, outgoingPrompt, style, X(0), Y(0), view.dpr, (1 + k * 0.55) * breathe, (1 - k) * 0.2);
+      drawPromptBlock(outgoingBlock, X(0), Y(0), (1 + k * 0.55) * pop.breathe, (1 - k) * 0.2);
     }
-    const inK = easeOutBack(Math.min(1, promptT * 1.25));
     const inA = Math.min(1, promptT * 2.2);
-    drawLabel(g, shownPrompt, style, X(0), Y(0), view.dpr, (0.74 + 0.26 * inK) * breathe * 1.08, 0.1 * inA);
-    drawLabel(g, shownPrompt, style, X(0), Y(0), view.dpr, (0.74 + 0.26 * inK) * breathe, 0.26 * inA);
+    drawPromptBlock(block, X(0), Y(0), pop.halo, 0.1 * inA);
+    drawPromptBlock(block, X(0), Y(0), pop.core, 0.26 * inA);
     g.globalCompositeOperation = "source-over";
     g.restore();
 


### PR DESCRIPTION
> `games/serpent` draws the prompt with **no measured fit** (`scene.ts:294`); its widest today is ~9 chars, `473 + □ = 1641` is 14.

#720's author was right about the defect and **wrong about the urgency**. serpent is not about to overrun. It is overrunning now, on `main`, on the shipped ladder.

## The number, measured in a real browser

`game-host` admits by **domain**, and serpent's `covers.skills` names five: `dw.add`, `dw.mul`, `dw.div`, `dw.frac`, `dw.alg`. The ~9-character figure comes from serpent's *declared skills*; the domains it actually receives are much wider. Swept over `activeNodes()` — every (skill, level) in those five domains, 6,000 seeds each, 462,000 prompts:

| | widest string | chars |
|---|---|---|
| **shipped ladder, today** | `42739 × 10000` (`dw.mul.scale.times-power-of-ten` L2) | **13** |
| | `41299 × 55313` (`dw.mul.multidigit.long-multiplication` L2) | 13 |
| | `927732 − 788` (`dw.add.regroup.subtract-short-subtrahend` L2) | 12 |
| **with #720** | `946 + □ = 1142` (`dw.alg.equality.missing-addend` L2) | **14** |
| the other alg rows, still draft | `1438 − □ = 947`, `□ × 30 = 1680` | 14, 13 |

**13 characters is the current requirement. 14 is the requirement the day #720 lands.** Neither fits.

Measured in Chromium against the real `FONT_STACK`, at 320×568 with the vent at `TUNE.arenaFloor`:

```
viewport 320x568   scale 140.8   arenaR 0.62   vent 175px   ideal size 73px
  "42739 × 10000"   622px of ink   →  3.56× the vent
  "946 + □ = 1142"  624px of ink   →  3.58× the vent
```

The vent is 282px across at the surface and **175px at `arenaFloor`**, so this gets worse the deeper a child dives — and the condition is drawn inside the vent's `g.clip()`, so the overrun is a numeral cut in half by the rim, not a numeral hanging over the water.

## Fitted, not refused

**Fitted.** The room exists: the worst case in the fleet is 30px on two lines against a 19px floor, so a refusal would have narrowed what the game teaches for nothing. And the fleet lesson from `trebuchet` says a per-item refusal starves a pack that is served by rung, which every serpent row is.

Three rules, in `src/game/render/prompt.ts`:

**1. Measured against the ink, not the raster.** `labelWidth` returns the width of the *canvas* a label rasterises into, and that canvas is mostly transparent — `pad` is `0.28em` a side and the box is `1.34em` tall around ink that measures `0.75em`. Fitting against it shrinks type that would have sat comfortably by roughly a third at each edge. So `labelInk` is new, `labelWidth` keeps its old job of positioning a blit, and both doc comments now say which is which.

**2. Broken where the mathematics breaks, never squashed.** `946 + □` over `= 1142`. A break is **structurally** only permitted immediately *before* an operator or a relation, so `946 +` / `□ = 1142` is not a reachable layout and no line can end on a sign. `polarity` squashes horizontally (`atlas.ts:147`, `g.scale(maxW/w, 1)`); a condensed smear is not what a child reading `946 + □ = 1142` needs.

**3. 19px is a floor, not a target.** A condition that cannot reach it is drawn AT it, wrapped as far as it wraps, and `console.error`s with the string, the block size and the vent diameter. `fits: false` is on the block. Nothing is ever quietly smaller — `pulse`'s 15.1px answer is the precedent.

### Why the budget is a circle

The condition is written inside the vent's clip, so the boundary that cuts a numeral is a circle. A block centred on it fits exactly when its corners do:

```
(w/2)² + (h/2)² ≤ radius²
```

which read the other way is "`w` is no wider than the chord at `h/2`". Fitting the bounding square refuses sizes that are provably legible; fitting the width alone clips the tops off a two-line block — both were tried, and removal 5 below is the second one.

### The pop-in gets its own reserve

`promptDrawScale` came out of `scene.ts` so the peak can be *swept* rather than believed. `PROMPT_PEAK_SCALE` is **1.039**. I first wrote 1.016 by reading `easeOutBack` off the page; it peaks at **1.0999**, so the settle overshoots by four percent, not one and a half. The test found that, not me. The outer halo pass (same glyphs, 8% larger, a tenth of the alpha) is deliberately left outside the reserve and documented as intentional bleed — it is a glow, and clipping the rim of a glow is invisible.

## Before and after

Measured off the real font metrics. `arenaR=0.62` is the vent at its floor, which is the case that binds.

| viewport | vent | condition | before | after |
|---|---|---|---|---|
| 320×568, arenaR 1.00 | 282px | `= 12` | 176px, 0.62× | **73px**, 1 line — unchanged |
| | | `42739 × 10000` | 622px, **2.21×** | 50px, 2 lines, 233×100 |
| | | `946 + □ = 1142` | 624px, **2.22×** | 52px, 2 lines, 231×103 |
| 320×568, arenaR 0.62 | **175px** | `= 12` | 176px, **1.01×** | 62px, 1 line |
| | | `42739 × 10000` | 622px, **3.56×** | **30px**, 2 lines, 144×60 |
| | | `946 + □ = 1142` | 624px, **3.58×** | **31px**, 2 lines, 142×62 |
| | | `12345 + □ = 67890` (17ch) | 784px, **4.49×** | 27px, 3 lines, 131×87 |
| 390×844, arenaR 0.62 | 213px | `946 + □ = 1142` | 755px, 3.55× | 39px, 2 lines |
| 768×1024, arenaR 0.62 | 419px | `946 + □ = 1142` | 1462px, 3.49× | 79px, 2 lines |
| 844×390 + side cutout, 0.62 | 201px | `946 + □ = 1142` | 716px, 3.56× | 36px, 2 lines |

**Worst case anywhere in the fleet's five viewports × both inset shapes × the vent from 1.00 to 0.62: 27px.** Floor is 19. `= 12` on a screen with room is drawn at exactly the size it always was, on one line — asserted, because a fit that is a redesign where nothing was wrong is not a repair.

Confirmed on screen at 320×568 with the vent closed and the widest #720 statement pinned: two lines, both inside the disc, the serpent still swims through them.

## Removed the fix, confirmed it fails — seven times

| removed | failure |
|---|---|
| the fit (`layoutPrompt` returns `ideal`, one line) | `rounded 800 (measured), phone portrait, small (320x568), no insets, vent 282px across: dw.mul.scale.times-power-of-ten L2 (active today) — "42739 × 10000" is drawn 73px on 1 line(s), 545x54px of ink, and the vent holds 255px` · `the condition was drawn at the ideal 73px unmeasured` · `at the peak of the pop-in "42739 × 10000" is 564x56px and the vent is 282px across` · `an impossible condition reported that it fitted` |
| the floor (`MIN_PROMPT_PX = 1`) | `the module's floor is still the audit's floor` (`19 !== 1`) · `an impossible condition reported that it fitted` |
| fitting the ink → fitting the padded canvas box | `pessimist (1em per glyph), phone portrait, small (320x568), no insets, vent 175px across: … "42739 × 10000" is drawn 19px on 2 line(s), 157x61px of ink, and the vent holds 158px` · `… cannot be drawn at the 19px floor at all` · `"6 × ?" was shrunk on a screen with room for it` |
| the peak headroom (`PROMPT_PEAK_SCALE = 1`) | `the condition is drawn at up to 1.0383x and the budget reserved 1x` |
| the circle → a width-only check | `the break is not at the relation` · `phone portrait, small (320x568), no insets, vent 282px across: … at the peak of the pop-in "42739 × 10000" is 260x127px and the vent is 282px across` |
| breaks allowed anywhere | `"42739 × 10000" broke to [42739 × / 10000] — a line ends on "×"` · `the break is not at the relation` |
| `scene.ts` back to its own size expression | `scene.ts computes the prompt size itself again — that expression is `promptIdeal` now, and a second copy of it is how the renderer and this test part company` |

Two vacuous tests were caught and fixed in the writing, both worth naming:

* **The floor test was a tautology.** It asserted `block.size >= MIN_PROMPT_PX` — against the very constant it was guarding, so `MIN_PROMPT_PX = 1` left it green. It now asserts against a literal `AUDIT_PROMPT_FLOOR_PX = 19` with the reason on it, plus a separate `MIN_PROMPT_PX === 19`.
* **The `env(safe-area-inset` guard failed on its own documentation.** A substring sweep flagged `chrome.ts`'s prose about the bug. The scanner is now comment-aware **and has a positive and a negative control** — a planted declaration must be caught and all three comment shapes must not be — because a rule-walker nobody exercised is exactly how a guard passes green over the regression it stands for.

* **And the metric fixture was optimistic.** The three faces the fit is asserted against started as a guess: 0.60em for a digit, 0.58em for an operator. Measured in Chromium against the real stack, digits are **0.700em** and operators **0.666em** — 15% narrow, i.e. a test that passes while the device clips. The table is now the measured one, with the measurement written into the doc comment, and `CAP_EM` moved 0.74 → 0.75 to match the real `actualBoundingBox` of 74.8px at 100px. Every guarantee is *additionally* asserted against a `PESSIMIST` face of 1em per glyph, which brackets any font a platform can resolve, so "it fits" is a statement about geometry rather than about one metric table.

## `env(safe-area-inset` and the safe area

Zero occurrences in this pack, and now a test fails the build if one appears. serpent already measures via `safeInsets()`/`safeRect()` from `packs/shared/game-chrome` (`chrome.ts`, unchanged), and the fit is handed `view.safe` — never the raw viewport. The 18 assertions sweep both inset shapes at all five viewports. `packs/shared/game-chrome` was read, not edited.

---

## The typographic note and the death-on-the-wall finding ARE the same finding — and the prompt is only half of it

`PACING_AUDIT_2026-07.md:123` on serpent: *"on a phone the numerals printed on the orbs render at roughly 4-7 CSS pixels, so the child guesses for a reason that has nothing to do with time."* `world.ts:706`: *"58 deaths, 58 of them on the wall … you die while reading a number."*

Same defect. A child who cannot read the numeral parks at the rim while squinting, and the rim is where they die. But **the prompt was not the illegible thing the audit measured — the orbs were**, and this PR does not fix them. Measured with the same machinery, `orbLabelSize * fit` where `fit = (r*1.72)/labelWidth`:

| viewport | orb radius | `"7"` | `"35"` | `"1142"` | `"927732"` |
|---|---|---|---|---|---|
| 320×568 | 8.7px | 6.4px | 5.1px | **3.6px** | **2.8px** |
| 390×844 | 10.6px | 9.1px | 7.0px | 4.8px | 3.6px |
| 768×1024 | 21.0px | 22.4px | 16.3px | 10.6px | 7.8px |

**The answer candidates are under the 15px answer floor at every viewport the fleet tests, and are 3.6px on a small phone** — `scene.ts:353`'s comment *"the numeral has to live inside the bell, so it is fitted to it"* is an art rule that the legibility floor beats, and it is the rule that produced these numbers.

I did **not** fix it here, deliberately. It cannot be fixed by typography: to print `1142` at 15px you need an orb radius of ~34px against the current 8.7, which is a **four-fold change to `TUNE.orbRadius`** and therefore to `orbMaxCount`, `orbCoreFactor`, `spawnClearance` and the whole threadability of the field — a gameplay redesign, not a text fix, and not something to bundle into a typography PR with nine agents live. The alternative (let the numeral overflow the bell) trades unreadable labels for colliding ones and is a founder call, not mine.

**It should be its own issue and it is worse than the bug I was sent to fix.** The prompt was 3.6× too wide; the answers are 4× too small, and the answer is the thing a child is graded on.

## What needs a device

* **Font resolution.** The metrics above are Chromium/macOS. iOS resolves `ui-rounded` to SF Pro Rounded and Android to something else; if either is wider than 1em per glyph the fit still holds by construction, but the *chosen* sizes will differ from the table. The runtime measures the real font, so only the table is machine-specific.
* **The 27px worst case, read by a child.** It clears the audit's floor with 8px to spare. Whether a 27px two-line condition at the bottom of a dive on a 320px phone reads as comfortably as the 73px one-liner does at the surface is a judgement a screen makes, not a test.
* Nothing about safe-area behaviour needs hardware: `chrome.test.ts` and the new sweep are arithmetic over insets.

## Verification

Node 24.18.0. `npm test` **5×**, identical: **59 pass, 0 fail** (18 new). `tsc --noEmit` clean. `npm run build:pack` clean, 90.60 kB.

Untouched: `packs/**`, `dynawalla-app/**`, `dynawalla/curriculum/**`, every other game. Four files, all under `dynawalla/games/serpent/src/game/render/`.

**#720 is unblocked by this.** Its `missing-addend` row is in the fixture table and fits at every viewport with the vent closed.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
