### PR TITLE
fix(dynawalla/games/balance): COUNTERPOISE locked the founder out with a correct answer — every operator now has a physically true apparatus

### DIFF
--- a/dynawalla/games/balance/src/adapter.ts
+++ b/dynawalla/games/balance/src/adapter.ts
@@ -1,86 +1,261 @@
 // Question -> apparatus.
 //
-// The stub host attaches a fully-built `PuzzleSpec`. A foreign host will not,
-// so this file can also *read a prompt* and build a board from it. The grammar
-// is small and total: sums of numerals, fractions, unknowns and one blank, with
-// or without an equals sign. `15 − 8` with answer `7` becomes a dish holding a
-// 15 and a balloon marked −8, and an empty dish to fill. That is why the swap to
-// the shared package later is mechanical: the game never needed anything the
-// contract does not already carry.
+// This file is the whole seam between the host's arithmetic and a brass balance,
+// and it is where the founder got locked out of the game:
+//
+//     "I had a correct answer not accepted and it wouldn't let me put anything
+//      on the scale and I was just stuck 88965/9 == 9885 .. but it rejected that
+//      and every other possible choice and I couldn't go anywhere."
+//
+// `88965 ÷ 9 = 9885` is correct. What happened is that the old tokenizer knew
+// four tokens — numerals, `x`, `□`, and `+`/`−` — and treated **anything else as
+// whitespace**. So `88965 ÷ 9` lexed as two numerals with nothing between them,
+// and the board it built was *both operands sitting in the same dish*: 88,974 of
+// brass on the left, an empty dish on the right, and a contract that says the
+// answer is 9,885. No weight on the rack levels that beam, because the beam was
+// never asked the question on the plinth. 9885 spills back out; so does every
+// other disc; the board can only be left by solving it; there is nothing to
+// solve. That is a permanent dead end and it is the third of its kind in the
+// fleet this month (`trebuchet` #698, `foundry` #711, `lattice` #716), always
+// from the same root: **a question the game could not represent kept its prompt
+// and silently got a different board.**
+//
+// Two things follow, and they are the shape of this file.
+//
+// **Nothing is dropped silently.** The lexer is total: a token it does not know
+// refuses the whole question, out loud. And every board is *proved* before it is
+// handed over — `isBalanced` is run against the contract's own answer, so a board
+// whose stated answer does not level it cannot be built at all, whatever new
+// notation the curriculum grows next. That check alone would have caught this.
+//
+// **Every operator gets a physically true apparatus.** The founder's other three
+// notes are one design defect between them:
+//
+//     "'identical' doesn't do much .. you just put the matching weight on the
+//      other side"
+//     "we need better visual representation of division and multiplication ..
+//      I like the balloon for subtraction .. division is trying to do something
+//      weird but it doesn't work very well in general"
+//
+// The balloon works because it is *true*: a balloon pulls up, so subtraction is
+// a weight that lifts. Multiplication had no such truth — `6 × 2` was collapsed
+// into a single 12-weight, so the answer was engraved on the board and a child
+// only had to find the disc that matched. That is the "identical" board, and a
+// bot that copies the numeral in the dish scored 100% on it. Division had no
+// apparatus at all. Both now have one:
+//
+//   `3 × 5`         three identical 5-weights in the dish. Physically correct,
+//                   countable, and the answer is on no disc on the board.
+//   `88965 ÷ 9`     nine identical sealed crates against an 88,965 weight, and
+//                   you declare what one crate holds. The only division picture
+//                   that survives the curriculum's magnitudes: nine crates is
+//                   nine crates whether the quotient is 5 or 9,885, where 9,885
+//                   nines is not a picture at all.
+//   `□ × 15 = 165`  the rack holds nothing but 15s and the answer is how many
+//                   you hang — measurement division, which is what a balance
+//                   with one kind of weight on it physically is.
+//
+// Each of those has a size past which it stops being a picture, and past it the
+// question is refused rather than faked. A dish cannot legibly hold seventy
+// crates, so `51800 ÷ 70` is above what this pack can show and it says so.
 
 import type { Question } from "./contract.ts";
 import type { Frac } from "./frac.ts";
-import { frac, parseFrac, toKey, toNumber, isPositive } from "./frac.ts";
+import { frac, parseFrac, toKey, toNumber, isPositive, isZero, eq } from "./frac.ts";
 import type { FixedItem, PuzzleSpec, Side } from "./puzzle.ts";
-import { MOVEMENTS, PAN_PEG } from "./puzzle.ts";
+import { APPARATUS, PAN_PEG, isBalanced, rackCanMake, remainingFor } from "./puzzle.ts";
 import { makeRng, seedFromString } from "./rng.ts";
 import type { Rng } from "./rng.ts";
 
 export type QuestionWithSpec = Question & { spec?: PuzzleSpec };
 
-type Term =
-  | { t: "value"; value: Frac }
-  | { t: "crate"; count: number }
-  | { t: "blank" };
+/**
+ * How many identical things one dish may hold and still be read at a glance.
+ *
+ * Twelve, which is not a round number picked for looks: `seatTarget` stacks a
+ * dish in rows of up to five, so twelve is three rows, and twelve is where the
+ * multiplication tables the curriculum teaches stop. Thirteen copies of a weight
+ * is a heap, and a heap is not a countable picture.
+ */
+export const MAX_COPIES = 12;
 
-const MINUS = /[−–—-]/;
+/** Why a question was refused. The game reacts differently to each. */
+export type RefusalReason =
+  /** A token the grammar does not know. The curriculum grew notation. */
+  | "unreadable"
+  /** Read fine; a beam that sums cannot show it, or not at this size. */
+  | "unrepresentable"
+  /** Representable, but a numeral on it would not be legible on this screen. */
+  | "tooWide";
 
-function tokenizeSide(sideText: string): Term[] {
-  const cleaned = sideText
-    .replace(/([+×*−–—-])/g, " $1 ")
-    .replace(/\s+/g, " ")
+export type Refusal = { ok: false; reason: RefusalReason; detail: string };
+export type Board = { ok: true; spec: PuzzleSpec } | Refusal;
+
+/** What the screen can currently show. See `numeralBudget` in `layout.ts`. */
+export type BoardLimits = {
+  /** Widest numeral, in characters, a disc can engrave legibly right now. */
+  readonly maxNumeralChars: number;
+};
+
+const NO_LIMITS: BoardLimits = { maxNumeralChars: Number.POSITIVE_INFINITY };
+
+// ------------------------------------------------------------------- lexing
+
+const MINUS = /^[−–—-]$/u;
+
+type Tok =
+  | { k: "num"; v: Frac }
+  | { k: "blank" }
+  | { k: "crate"; count: number }
+  | { k: "add" }
+  | { k: "sub" }
+  | { k: "times" }
+  | { k: "over" }
+  | { k: "eq" };
+
+/**
+ * The prompt as tokens, or `null` for a prompt with something in it this game
+ * has never been taught to build.
+ *
+ * Total on purpose. The version this replaced ended its loop with a bare `i++`,
+ * which is the line that turned `÷` into a space and a correct answer into a
+ * locked room. `null` here is a refusal the caller has to handle, and it is
+ * logged: a token arriving that nobody taught this file is a curriculum change,
+ * and the only bad way to find out about one is from a child.
+ */
+export function lex(text: string): Tok[] | null {
+  const spaced = text
+    .replace(/([+×*÷=−–—-])/gu, " $1 ")
+    .replace(/\s+/gu, " ")
     .trim();
-  const out: Term[] = [];
-  let sign = 1;
+  if (spaced === "") return null;
+  const out: Tok[] = [];
+  for (const part of spaced.split(" ")) {
+    if (part === "+") out.push({ k: "add" });
+    else if (MINUS.test(part)) out.push({ k: "sub" });
+    else if (part === "×" || part === "*") out.push({ k: "times" });
+    else if (part === "÷") out.push({ k: "over" });
+    else if (part === "=") out.push({ k: "eq" });
+    // `□` U+25A1 is the glyph the curriculum writes a blank with, and the glyph
+    // this game already engraved on an empty dish. `?` and `_` are kept because
+    // older prompts in this repo use them. A triple underscore is deliberately
+    // NOT accepted: one blank glyph, pinned by a curriculum test, is the point.
+    else if (part === "□" || part === "?" || part === "_") out.push({ k: "blank" });
+    else {
+      const crate = /^(\d*)x$/iu.exec(part);
+      if (crate) {
+        out.push({ k: "crate", count: crate[1] === "" ? 1 : Number(crate[1]) });
+        continue;
+      }
+      // `a/b` is a fraction, not a division: `3/4` is one weight. The host writes
+      // division with U+00F7, which is lexed above.
+      const f = parseFrac(part);
+      if (f) {
+        out.push({ k: "num", v: f });
+        continue;
+      }
+      return null;
+    }
+  }
+  return out;
+}
+
+// ------------------------------------------------------------------ parsing
+
+/** One signed thing on one side of the statement. */
+type Item =
+  | { k: "num"; sign: 1 | -1; v: Frac }
+  | { k: "crate"; sign: 1 | -1; count: number }
+  | { k: "blank"; sign: 1 | -1 }
+  /** `a × b`, both known. */
+  | { k: "product"; sign: 1 | -1; a: Frac; b: Frac }
+  /** `a ÷ b`, both known. */
+  | { k: "quotient"; sign: 1 | -1; a: Frac; b: Frac }
+  /** `□ × b` or `b × □` — the unknown is a count. */
+  | { k: "countOf"; sign: 1 | -1; b: Frac };
+
+type Statement = { left: Item[]; right: Item[] };
+
+/** `num | blank | crate`, the operands `×` and `÷` may join. */
+type Atom = { k: "num"; v: Frac } | { k: "blank" } | { k: "crate"; count: number };
+
+function parseStatement(toks: readonly Tok[]): Statement | null {
+  if (toks.filter((t) => t.k === "eq").length > 1) return null;
+  const eqAt = toks.findIndex((t) => t.k === "eq");
+  const leftToks = eqAt < 0 ? toks : toks.slice(0, eqAt);
+  // A prompt with no equals sign is a question: `15 − 8` means `15 − 8 = □`.
+  const rightToks: readonly Tok[] = eqAt < 0 ? [{ k: "blank" }] : toks.slice(eqAt + 1);
+  const left = parseSide(leftToks);
+  const right = parseSide(rightToks);
+  if (!left || !right) return null;
+  return { left, right };
+}
+
+function parseSide(toks: readonly Tok[]): Item[] | null {
+  const out: Item[] = [];
+  let sign: 1 | -1 = 1;
   let i = 0;
-  const parts = cleaned.split(" ");
-  while (i < parts.length) {
-    const p = parts[i];
-    if (p === "+") {
+  // A side is `[sign] atom (op [sign] atom)*`; `×` and `÷` bind two atoms into
+  // one item, `+`/`−` start the next one.
+  while (i < toks.length) {
+    const t = toks[i];
+    if (t.k === "add") {
+      if (out.length === 0) return null;
       sign = 1;
       i++;
       continue;
     }
-    if (MINUS.test(p) && p.length === 1) {
+    if (t.k === "sub") {
+      // The sign belongs to the term that comes next, whether that term is a
+      // numeral or a blank. Dropping it on a blank is what made `8 − □ = 4`
+      // unbuildable.
       sign = -1;
       i++;
       continue;
     }
-    // product form "6 × 2" collapses to a single 12
-    if (i + 2 < parts.length && (parts[i + 1] === "×" || parts[i + 1] === "*")) {
-      const a = parseFrac(p);
-      const b = parseFrac(parts[i + 2]);
-      if (a && b && a.d === 1 && b.d === 1) {
-        out.push({ t: "value", value: frac(sign * a.n * b.n) });
-        sign = 1;
-        i += 3;
-        continue;
-      }
-    }
-    if (p === "□" || p === "?" || p === "_") {
-      out.push({ t: "blank" });
+    const a = atomOf(t);
+    if (!a) return null;
+    const next = toks[i + 1];
+    if (next && (next.k === "times" || next.k === "over")) {
+      const b = atomOf(toks[i + 2]);
+      if (!b) return null;
+      const joined = join(sign, next.k, a, b);
+      if (!joined) return null;
+      out.push(joined);
       sign = 1;
-      i++;
+      i += 3;
       continue;
     }
-    const mx = /^(\d*)x$/i.exec(p);
-    if (mx) {
-      out.push({ t: "crate", count: mx[1] === "" ? 1 : Number(mx[1]) });
-      sign = 1;
-      i++;
-      continue;
-    }
-    const f = parseFrac(p);
-    if (f) {
-      out.push({ t: "value", value: frac(sign * f.n, f.d) });
-      sign = 1;
-      i++;
-      continue;
-    }
+    if (a.k === "num") out.push({ k: "num", sign, v: a.v });
+    else if (a.k === "crate") out.push({ k: "crate", sign, count: a.count });
+    else out.push({ k: "blank", sign });
+    sign = 1;
     i++;
   }
-  return out;
+  return out.length === 0 ? null : out;
 }
+
+function atomOf(t: Tok | undefined): Atom | null {
+  if (!t) return null;
+  if (t.k === "num") return { k: "num", v: t.v };
+  if (t.k === "blank") return { k: "blank" };
+  if (t.k === "crate") return { k: "crate", count: t.count };
+  return null;
+}
+
+function join(sign: 1 | -1, op: "times" | "over", a: Atom, b: Atom): Item | null {
+  if (op === "times") {
+    if (a.k === "num" && b.k === "num") return { k: "product", sign, a: a.v, b: b.v };
+    // `□ × 15` and `15 × □` are the same board: a rack of 15s and a count.
+    if (a.k === "blank" && b.k === "num") return { k: "countOf", sign, b: b.v };
+    if (a.k === "num" && b.k === "blank") return { k: "countOf", sign, b: a.v };
+    return null;
+  }
+  if (a.k === "num" && b.k === "num") return { k: "quotient", sign, a: a.v, b: b.v };
+  return null;
+}
+
+// --------------------------------------------------------------------- rack
 
 /** How many weights the rack offers. Nine, as it always did. */
 const RACK_SIZE = 9;
@@ -132,6 +307,14 @@ function rackFor(answer: Frac, distractors: readonly string[], rng: Rng): Frac[]
 
   const negative = !isPositive(answer);
   const mag = Math.abs(answer.n);
+  // An answer of zero has no neighbourhood on the positive number line, and a
+  // rack of zeroes is not a rack. `0 ÷ 3 = 0` is a real curriculum item, so the
+  // zero disc goes on and the padding climbs from one.
+  if (mag === 0) {
+    const zeros: Frac[] = [frac(0)];
+    for (let n = 1; zeros.length < RACK_SIZE; n++) zeros.push(frac(n));
+    return rng.shuffle(zeros);
+  }
 
   // The neighbourhood the padding is drawn from. A ±35% band, never narrower
   // than ±4, keeps every weight the same size of number as the answer, so no
@@ -234,68 +417,567 @@ function fractionRack(answer: Frac, distractors: readonly string[], rng: Rng): F
   return rng.shuffle(out);
 }
 
+// ------------------------------------------------------------------- boards
+
+type Draft = {
+  kind: PuzzleSpec["kind"];
+  fixed: FixedItem[];
+  fillSide: Side | null;
+  /** True when the answer is *how many* discs were hung, not what they weigh. */
+  countAnswer: boolean;
+  rack: Frac[];
+  apparatus: number;
+};
+
+type Drafted = { ok: true; draft: Draft } | Refusal;
+
 /**
- * Build a board for a question that arrived without one. Total: it always
- * returns a solvable spec, because the answer is taken from the contract and
- * the missing side is simply "whatever is left".
+ * The board, or a reason there is none.
+ *
+ * Total. Every return either carries a spec that has been *proved* to balance at
+ * the contract's own answer, or says why no such board exists.
  */
-export function specFromQuestion(q: Question): PuzzleSpec {
+export function boardFor(q: Question, limits: BoardLimits = NO_LIMITS): Board {
   const withSpec = q as QuestionWithSpec;
-  if (withSpec.spec) return withSpec.spec;
+  if (withSpec.spec) return { ok: true, spec: withSpec.spec };
+
+  const answer = parseFrac(q.answer);
+  if (!answer) {
+    return refuse(
+      "unreadable",
+      `answer ${JSON.stringify(q.answer)} for ${JSON.stringify(q.prompt)} is not a rational this game can weigh`,
+    );
+  }
+  const toks = lex(q.prompt);
+  if (!toks) {
+    return refuse(
+      "unreadable",
+      `nothing in COUNTERPOISE knows how to build ${JSON.stringify(q.prompt)} — a token in it is not a numeral, a blank, a crate or an operator`,
+    );
+  }
+  const st = parseStatement(toks);
+  if (!st) {
+    return refuse(
+      "unreadable",
+      `${JSON.stringify(q.prompt)} is not a statement this game can lay out`,
+    );
+  }
 
   // Seeded from the question id, not from a counter: the same question rebuilds
   // to the same board (a resize does that), and two questions never share a
   // rack order just because they arrived in the same position in the run.
   const rng = makeRng(seedFromString(q.id));
-  const answer = parseFrac(q.answer) ?? frac(1);
-  const eq = q.prompt.indexOf("=");
-  const leftText = eq >= 0 ? q.prompt.slice(0, eq) : q.prompt;
-  const rightText = eq >= 0 ? q.prompt.slice(eq + 1) : "□";
+  const drafted = draft(st, answer, q, rng);
+  if (!drafted.ok) return drafted;
+  const d = drafted.draft;
 
-  const fixed: FixedItem[] = [];
-  const place = (terms: Term[], side: Side): { fill: Side | null; crate: boolean } => {
-    let fill: Side | null = null;
-    let crate = false;
-    for (const t of terms) {
-      if (t.t === "value") fixed.push({ kind: "weight", side, peg: PAN_PEG, value: t.value });
-      else if (t.t === "crate") {
-        crate = true;
-        for (let i = 0; i < t.count; i++) fixed.push({ kind: "crate", side, peg: PAN_PEG });
-      } else fill = side;
-    }
-    return { fill, crate };
-  };
-  const l = place(tokenizeSide(leftText), -1);
-  const r = place(tokenizeSide(rightText), 1);
-
-  const kind: PuzzleSpec["kind"] = l.crate || r.crate ? "declare" : "fill";
-  const fillSide: Side = l.fill ?? r.fill ?? 1;
-
-  // The movement is the child's place on the *host's* ladder, not a count of
-  // how many boards have gone by. It used to be `Math.floor(index / 5)`: a
-  // hand-written staircase that advanced every five questions whether the
-  // mathematics got harder or not, so the plinth announced a new movement on a
-  // schedule and told the child nothing. `q.difficulty` is a 0..1 position on
-  // the host's whole ladder, which is exactly what the engraving means.
-  const movement = Math.max(
-    0,
-    Math.min(MOVEMENTS.length - 1, Math.floor((q.difficulty || 0) * MOVEMENTS.length)),
-  );
-
-  return {
+  const spec: PuzzleSpec = {
     id: q.id,
-    kind,
+    kind: d.kind,
     mode: "pans",
-    fixed,
+    fixed: d.fixed,
     answer,
-    rack: rackFor(answer, q.distractors, rng),
-    fillSide: kind === "fill" ? fillSide : null,
+    rack: d.rack,
+    fillSide: d.kind === "fill" ? d.fillSide : null,
     hangSlot: null,
+    countAnswer: d.countAnswer,
     prompt: q.prompt,
     domain: q.domain,
     difficulty: q.difficulty,
-    movement,
-    movementName: MOVEMENTS[movement],
+    // The engraving on the plinth names the apparatus in front of the child, not
+    // a rung. It used to be `floor(difficulty * 10)` indexed into a list of ten
+    // movement names, while the board itself was a plain pair of dishes on every
+    // single question the shipped host serves — so the stone announced
+    // "IDENTICAL CRATES" over a board that had no crates in it. A name that does
+    // not describe what you are looking at is worse than no name.
+    movement: d.apparatus,
+    movementName: APPARATUS[d.apparatus],
+  };
+
+  // The proof. Whatever was built above, the contract's answer must level it —
+  // and must be reachable from the rack. This is the check that makes the whole
+  // class of bug behind the founder's lockout impossible rather than fixed: a
+  // board that cannot be solved by its own answer is never handed over, however
+  // the statement was written.
+  const unsolvable = whyUnsolvable(spec, answer);
+  if (unsolvable) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} = ${q.answer} built a board that its own answer does not solve (${unsolvable}) — refused rather than shown`,
+    );
+  }
+
+  const wide = widestNumeral(spec);
+  if (wide > limits.maxNumeralChars) {
+    return refuse(
+      "tooWide",
+      `${JSON.stringify(q.prompt)} = ${q.answer} needs a ${String(wide)}-character numeral on a disc that holds ${String(limits.maxNumeralChars)}`,
+    );
+  }
+  return { ok: true, spec };
+}
+
+function refuse(reason: RefusalReason, detail: string): Refusal {
+  // Loud, always. A refusal is content a child does not get to play, and the
+  // only thing worse than a pack that cannot show a question is a pack that
+  // cannot show a question quietly.
+  console.error(`[counterpoise] ${reason}: ${detail}`);
+  return { ok: false, reason, detail };
+}
+
+function draft(st: Statement, answer: Frac, q: Question, rng: Rng): Drafted {
+  const all = [...st.left, ...st.right];
+  const products = all.filter((i) => i.k === "product").length;
+  const quotients = all.filter((i) => i.k === "quotient").length;
+  const counts = all.filter((i) => i.k === "countOf").length;
+  const blanks = all.filter((i) => i.k === "blank").length;
+
+  if (products + quotients + counts > 1) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} has two operations a beam must show as objects; one board cannot hold both`,
+    );
+  }
+  if (counts === 1) return countBoard(st, answer, q);
+  if (quotients === 1) return crateBoard(st, answer, q, rng);
+  if (products === 1) return productBoard(st, answer, q, rng);
+  if (blanks > 1) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} has ${String(blanks)} blanks; a dish can only be filled once`,
+    );
+  }
+  return sumBoard(st, answer, q, rng);
+}
+
+const SIDES = [
+  [0, -1 as Side],
+  [1, 1 as Side],
+] as const;
+
+function sidesOf(st: Statement): ReadonlyArray<readonly [readonly Item[], Side]> {
+  return SIDES.map(([which, side]) => [which === 0 ? st.left : st.right, side] as const);
+}
+
+/**
+ * `a + b = □`, `47 + □ = 68`, `15 − 8`, `8 − □ = 4`.
+ *
+ * Everything is a weight in a dish, a negative one is a balloon, and the one
+ * blank is the dish being filled. **The blank keeps its sign**, which it did not
+ * before: `8 − □ = 4` lexed the minus, then pushed a bare blank and threw the
+ * sign away, so the board asked `8 + □ = 4` and no weight on earth solved it. A
+ * negatively signed blank is the founder's favourite object — you tie a balloon
+ * to the heavy dish until the arm comes level.
+ */
+function sumBoard(st: Statement, answer: Frac, q: Question, rng: Rng): Drafted {
+  const fixed: FixedItem[] = [];
+  let fill: Side | null = null;
+  let fillSign: 1 | -1 = 1;
+  let crates = 0;
+  for (const [items, side] of sidesOf(st)) {
+    for (const it of items) {
+      if (it.k === "num") {
+        fixed.push({ kind: "weight", side, peg: PAN_PEG, value: signed(it.sign, it.v) });
+      } else if (it.k === "crate") {
+        crates += it.count;
+        for (let i = 0; i < it.count; i++) fixed.push({ kind: "crate", side, peg: PAN_PEG });
+      } else if (it.k === "blank") {
+        fill = side;
+        fillSign = it.sign;
+      } else {
+        return refuse("unrepresentable", `${JSON.stringify(q.prompt)} is not a sum of weights`);
+      }
+    }
+  }
+  if (crates > MAX_COPIES) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} wants ${String(crates)} crates in one dish; ${String(MAX_COPIES)} is the most a dish holds`,
+    );
+  }
+  const kind: PuzzleSpec["kind"] = crates > 0 ? "declare" : "fill";
+  if (kind === "fill" && fill === null) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} has nothing to fill and no crate to declare`,
+    );
+  }
+  // The object the child must place: the answer as the *dish* sees it. On
+  // `8 − □ = 4` the answer is 4 and the thing you hang is a balloon of 4.
+  const placed = fillSign < 0 ? neg(answer) : answer;
+  const apparatus =
+    answer.d !== 1
+      ? APPARATUS_FRACTIONS
+      : crates > 1
+        ? APPARATUS_CRATES
+        : crates === 1
+          ? APPARATUS_CRATE
+          : hasLift(fixed) || fillSign < 0
+            ? APPARATUS_LIFT
+            : APPARATUS_DISHES;
+  return {
+    ok: true,
+    draft: {
+      kind,
+      fixed,
+      fillSide: fill,
+      countAnswer: false,
+      rack: rackFor(kind === "declare" ? answer : placed, q.distractors, rng),
+      apparatus,
+    },
+  };
+}
+
+/**
+ * `3 × 5` — three identical 5-weights in one dish, and you fill the other.
+ *
+ * The physical truth multiplication has on a balance, and it is exact: three
+ * fives really do weigh fifteen. It is countable, it teaches repeated addition
+ * without a word of instruction, and — the part that matters against what this
+ * replaced — **no disc on the board carries the answer**. The old code collapsed
+ * `6 × 2` into one 12-weight, engraved the answer on the apparatus, and asked a
+ * child to match it.
+ *
+ * Which factor becomes the count is decided by what fits in a dish, because
+ * `a × b` and `b × a` are the same brass. Neither factor small enough to count
+ * means there is no picture here, and the question is refused.
+ */
+function productBoard(st: Statement, answer: Frac, q: Question, rng: Rng): Drafted {
+  const fixed: FixedItem[] = [];
+  let fill: Side | null = null;
+  let sawProduct = false;
+  for (const [items, side] of sidesOf(st)) {
+    for (const it of items) {
+      if (it.k === "product") {
+        sawProduct = true;
+        const pick = countAndUnit(it.a, it.b);
+        if (!pick) {
+          return refuse(
+            "unrepresentable",
+            `${JSON.stringify(q.prompt)}: neither factor is ${String(MAX_COPIES)} or under, so there is no countable pile of identical weights that shows it`,
+          );
+        }
+        for (let i = 0; i < pick.count; i++) {
+          fixed.push({ kind: "weight", side, peg: PAN_PEG, value: signed(it.sign, pick.unit) });
+        }
+      } else if (it.k === "num") {
+        fixed.push({ kind: "weight", side, peg: PAN_PEG, value: signed(it.sign, it.v) });
+      } else if (it.k === "blank") {
+        fill = side;
+      } else {
+        return refuse(
+          "unrepresentable",
+          `${JSON.stringify(q.prompt)} mixes a product with something a dish cannot hold beside it`,
+        );
+      }
+    }
+  }
+  if (fill === null || !sawProduct) {
+    return refuse("unrepresentable", `${JSON.stringify(q.prompt)} has a product but nothing to fill`);
+  }
+  return {
+    ok: true,
+    draft: {
+      kind: "fill",
+      fixed,
+      fillSide: fill,
+      countAnswer: false,
+      rack: rackFor(answer, q.distractors, rng),
+      apparatus: APPARATUS_ROWS,
+    },
+  };
+}
+
+/**
+ * `a × b` as a count of identical weights: the smaller factor is the count.
+ *
+ * A factor of zero is zero copies, which is an empty dish — physically exact, and
+ * the answer is nothing. `0 × 4` and `4 × 0` are real items on the two easiest
+ * multiplication rungs and both draw the same true picture.
+ */
+export function countAndUnit(a: Frac, b: Frac): { count: number; unit: Frac } | null {
+  if (a.d !== 1 || b.d !== 1) return null;
+  const av = Math.abs(a.n);
+  const bv = Math.abs(b.n);
+  if (av === 0 || bv === 0) return { count: 0, unit: frac(0) };
+  const count = Math.min(av, bv);
+  if (count > MAX_COPIES) return null;
+  return { count, unit: frac(count === av ? bv : av) };
+}
+
+/**
+ * `88965 ÷ 9` — nine identical sealed crates against an 88,965 weight, and the
+ * child declares what one crate holds.
+ *
+ * This is the division board, and it is chosen over the alternatives because it
+ * is the only one still a *picture* at the sizes the curriculum serves. The
+ * obvious quotative reading — "how many nines balance 88,965" — is exactly true
+ * and completely unshowable: 9,885 discs. Splitting a weight into equal parts is
+ * not something brass does. Nine identical closed boxes balancing a known total
+ * is honest, it is a thing that exists, it is the same nine boxes whatever the
+ * quotient turns out to be, and it is the apparatus this game already had and
+ * never used.
+ *
+ * The limit is the divisor, not the answer: a dish holds twelve crates and no
+ * more, so `51800 ÷ 70` has no board here and says so out loud.
+ */
+function crateBoard(st: Statement, answer: Frac, q: Question, rng: Rng): Drafted {
+  const fixed: FixedItem[] = [];
+  let crates = 0;
+  for (const [items, side] of sidesOf(st)) {
+    for (const it of items) {
+      if (it.k === "quotient") {
+        if (it.b.d !== 1 || it.b.n === 0) {
+          return refuse(
+            "unrepresentable",
+            `${JSON.stringify(q.prompt)} divides by something that is not a whole number of crates`,
+          );
+        }
+        crates = Math.abs(it.b.n);
+        if (crates > MAX_COPIES) {
+          return refuse(
+            "unrepresentable",
+            `${JSON.stringify(q.prompt)} needs ${String(crates)} identical crates in one dish; a dish holds ${String(MAX_COPIES)}, so this division has no honest picture on a beam`,
+          );
+        }
+        for (let i = 0; i < crates; i++) fixed.push({ kind: "crate", side, peg: PAN_PEG });
+        // The dividend hangs opposite the crates it is balancing.
+        fixed.push({ kind: "weight", side: flip(side), peg: PAN_PEG, value: signed(it.sign, it.a) });
+      } else if (it.k === "num") {
+        fixed.push({ kind: "weight", side, peg: PAN_PEG, value: signed(it.sign, it.v) });
+      } else if (it.k === "blank") {
+        // `88965 ÷ 9` arrives with an implicit `= □`. The crate IS the blank.
+      } else {
+        return refuse(
+          "unrepresentable",
+          `${JSON.stringify(q.prompt)} mixes a quotient with something a dish cannot hold beside it`,
+        );
+      }
+    }
+  }
+  if (crates === 0) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} has a quotient with no divisor to make crates from`,
+    );
+  }
+  return {
+    ok: true,
+    draft: {
+      kind: "declare",
+      fixed,
+      fillSide: null,
+      countAnswer: false,
+      rack: rackFor(answer, q.distractors, rng),
+      apparatus: crates > 1 ? APPARATUS_CRATES : APPARATUS_CRATE,
+    },
+  };
+}
+
+/**
+ * `□ × 15 = 165` — one dish holds 165, the rack holds nothing but 15s, and the
+ * answer is how many you hang.
+ *
+ * Measurement division, and the most literally physical board in the game: a
+ * balance loaded with one kind of weight is a ruler, and this is measuring 165
+ * with it. The count is the answer, so `answeredKey` reports how many discs are
+ * in the dish rather than what they weigh — see `puzzle.ts`.
+ *
+ * A child who knows their fifteens hangs eleven and is done. A child who does
+ * not counts by fifteens and watches the arm come up, which is the same
+ * arithmetic done out loud. Capped at twelve, for the same reason as every other
+ * pile: past that it is a heap and not a count.
+ */
+function countBoard(st: Statement, answer: Frac, q: Question): Drafted {
+  if (answer.d !== 1 || answer.n < 1 || answer.n > MAX_COPIES) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} = ${q.answer} would need ${q.answer} identical weights in one dish; ${String(MAX_COPIES)} is the most that reads as a count`,
+    );
+  }
+  const fixed: FixedItem[] = [];
+  let fill: Side | null = null;
+  let unit: Frac | null = null;
+  for (const [items, side] of sidesOf(st)) {
+    for (const it of items) {
+      if (it.k === "countOf") {
+        unit = signed(it.sign, it.b);
+        fill = side;
+      } else if (it.k === "num") {
+        fixed.push({ kind: "weight", side, peg: PAN_PEG, value: signed(it.sign, it.v) });
+      } else {
+        return refuse(
+          "unrepresentable",
+          `${JSON.stringify(q.prompt)} mixes a missing factor with something else`,
+        );
+      }
+    }
+  }
+  if (!unit || fill === null || isZero(unit)) {
+    return refuse(
+      "unrepresentable",
+      `${JSON.stringify(q.prompt)} has a missing factor with no weight to count`,
+    );
+  }
+  return {
+    ok: true,
+    draft: {
+      kind: "fill",
+      fixed,
+      fillSide: fill,
+      countAnswer: true,
+      // One kind of weight on the rail, and as many as you like. That IS the
+      // board: offering anything else would let a child level the beam with a
+      // single 165 and report a count of one.
+      rack: [unit],
+      apparatus: APPARATUS_HOW_MANY,
+    },
+  };
+}
+
+// -------------------------------------------------------------------- proof
+
+/**
+ * Why the contract's answer does not solve this board, or `null` if it does.
+ *
+ * The proof, and the reason the founder's lockout is a class of bug that is now
+ * closed rather than a bug that is fixed. Every board goes through it before it
+ * is handed over, so a statement this file misreads — today's `÷`, tomorrow's
+ * whatever — produces a refusal and a log line instead of a room with no door.
+ */
+export function whyUnsolvable(spec: PuzzleSpec, answer: Frac): string | null {
+  if (spec.kind === "declare") {
+    if (!spec.rack.some((r) => eq(r, answer))) return "the answer is not on the rack";
+    return isBalanced(spec, [], answer) ? null : "declaring the answer does not level the beam";
+  }
+  if (spec.kind === "fill") {
+    if (spec.fillSide === null) return "there is no dish to fill";
+    if (spec.countAnswer) {
+      const unit = spec.rack[0];
+      if (!unit || isZero(unit)) return "the rack has nothing to count";
+      const placed = Array.from({ length: answer.n }, (_, i) => ({
+        id: `p${String(i)}`,
+        side: spec.fillSide as Side,
+        peg: PAN_PEG,
+        value: unit,
+      }));
+      return isBalanced(spec, placed, null)
+        ? null
+        : "that many of the rack weight does not level the beam";
+    }
+    // What the dish is actually short by. This — not the contract's answer as
+    // written — is the object the child has to produce, and comparing the two is
+    // the check that catches a misread statement: on `88965 ÷ 9` the dish was
+    // short by 88,974 while the contract said 9,885, and nothing noticed.
+    //
+    // Compared up to sign, because a signed blank is a real board: `8 − □ = 4` is
+    // answered 4 and solved by hanging a balloon of 4.
+    const need = remainingFor(spec, []);
+    if (!need) return "there is nothing to compute";
+    if (isZero(need)) {
+      // The arm is already flat and the answer is nothing. `7 − 7`, `0 × 4`, and
+      // every other zero the curriculum's easiest rungs are full of — thirteen of
+      // every forty `subtract-within-ten` items. Refusing them meant refusing a
+      // third of the content a six-year-old plays, so zero gets an object: a
+      // brass disc engraved `0`, which weighs nothing, and dropping it in says
+      // "this dish needs nothing" out loud. It is the one board where the arm is
+      // level before the child touches it, and that is the idea.
+      if (!isZero(answer)) return `the dish needs nothing but the answer is ${toKey(answer)}`;
+      return spec.rack.some((r) => isZero(r)) ? null : "there is no zero on the rack";
+    }
+    if (!eq(need, answer) && !eq(need, neg(answer))) {
+      return `the dish is short by ${toKey(need)} but the answer is ${toKey(answer)}`;
+    }
+    // Reachable from the rail: the exact disc, or a handful of them. The local
+    // ladder builds boards that want two weights and that is a legitimate board.
+    if (!spec.rack.some((r) => eq(r, need)) && !rackCanMake(spec.rack, need)) {
+      return `${toKey(need)} cannot be made from the rack`;
+    }
+    return null;
+  }
+  return null;
+}
+
+/** The widest numeral that will be engraved on a disc on this board. */
+export function widestNumeral(spec: PuzzleSpec): number {
+  let n = 0;
+  for (const f of spec.fixed) {
+    if (f.kind === "weight") n = Math.max(n, engravedLength(f.value));
+  }
+  for (const r of spec.rack) n = Math.max(n, engravedLength(r));
+  return n;
+}
+
+/** Characters as `Renderer.numeral` draws them: `−` counts, a fraction stacks. */
+function engravedLength(f: Frac): number {
+  if (f.d !== 1) return Math.max(String(Math.abs(f.n)).length, String(f.d).length);
+  return String(Math.abs(f.n)).length + (f.n < 0 ? 1 : 0);
+}
+
+// ------------------------------------------------------------------- helpers
+
+const APPARATUS_DISHES = 0;
+const APPARATUS_LIFT = 1;
+const APPARATUS_ROWS = 2;
+const APPARATUS_HOW_MANY = 3;
+const APPARATUS_CRATE = 4;
+const APPARATUS_CRATES = 5;
+const APPARATUS_FRACTIONS = 6;
+
+function signed(sign: 1 | -1, v: Frac): Frac {
+  return sign < 0 ? neg(v) : v;
+}
+function neg(v: Frac): Frac {
+  return frac(-v.n, v.d);
+}
+function flip(s: Side): Side {
+  return s === 1 ? -1 : 1;
+}
+function hasLift(fixed: readonly FixedItem[]): boolean {
+  return fixed.some((f) => f.kind === "weight" && f.value.n < 0);
+}
+
+/**
+ * The old entry point, kept for the standalone shell and for the tests that pin
+ * rack fairness. `null` is a refusal — see `boardFor` for why there is one.
+ */
+export function specFromQuestion(q: Question, limits?: BoardLimits): PuzzleSpec | null {
+  const board = boardFor(q, limits);
+  return board.ok ? board.spec : null;
+}
+
+/**
+ * A board when there is no question — the guarantee that a child is never
+ * looking at a screen with nothing on it and nothing to do.
+ *
+ * Built here rather than by borrowing `generate.puzzleAt`, because that function
+ * is the entire standalone ladder and importing it would pull all of it into the
+ * shipped pack bundle to cover a case that should never fire. `n` walks the sum
+ * so a run of fallbacks is not the same board over and over.
+ */
+export function lastResortBoard(n: number): PuzzleSpec {
+  const total = 4 + (n % 6);
+  const have = 1 + (n % 3);
+  const answer = frac(total - have);
+  const rng = makeRng(seedFromString(`fallback-${String(n)}`));
+  return {
+    id: `bal-fallback-${String(n)}`,
+    kind: "fill",
+    mode: "pans",
+    fixed: [
+      { kind: "weight", side: -1, peg: PAN_PEG, value: frac(total) },
+      { kind: "weight", side: 1, peg: PAN_PEG, value: frac(have) },
+    ],
+    answer,
+    rack: rackFor(answer, [], rng),
+    fillSide: 1,
+    hangSlot: null,
+    countAnswer: false,
+    prompt: `${String(total)} = ${String(have)} + □`,
+    domain: "add-sub",
+    difficulty: 0,
+    movement: APPARATUS_DISHES,
+    movementName: APPARATUS[APPARATUS_DISHES],
   };
 }
 

--- a/dynawalla/games/balance/src/adapter.ts
+++ b/dynawalla/games/balance/src/adapter.ts
@@ -63,7 +63,7 @@ import type { Question } from "./contract.ts";
 import type { Frac } from "./frac.ts";
 import { frac, parseFrac, toKey, toNumber, isPositive, isZero, eq } from "./frac.ts";
 import type { FixedItem, PuzzleSpec, Side } from "./puzzle.ts";
-import { APPARATUS, PAN_PEG, isBalanced, rackCanMake, remainingFor } from "./puzzle.ts";
+import { APPARATUS, PAN_PEG, isBalanced, rackReach, remainingFor } from "./puzzle.ts";
 import { makeRng, seedFromString } from "./rng.ts";
 import type { Rng } from "./rng.ts";
 
@@ -897,7 +897,10 @@ export function whyUnsolvable(spec: PuzzleSpec, answer: Frac): string | null {
     }
     // Reachable from the rail: the exact disc, or a handful of them. The local
     // ladder builds boards that want two weights and that is a legitimate board.
-    if (!spec.rack.some((r) => eq(r, need)) && !rackCanMake(spec.rack, need)) {
+    // A board is refused only on a PROVED `"no"`. An unsearchably large remainder
+    // is shown, because `unstuck.test.ts` proves every board the ladder serves has
+    // a legal move by counting copies directly, without this capped search.
+    if (!spec.rack.some((r) => eq(r, need)) && rackReach(spec.rack, need) === "no") {
       return `${toKey(need)} cannot be made from the rack`;
     }
     return null;

--- a/dynawalla/games/balance/src/adapter.ts
+++ b/dynawalla/games/balance/src/adapter.ts
@@ -91,7 +91,7 @@ export type RefusalReason =
 export type Refusal = { ok: false; reason: RefusalReason; detail: string };
 export type Board = { ok: true; spec: PuzzleSpec } | Refusal;
 
-/** What the screen can currently show. See `numeralBudget` in `layout.ts`. */
+/** What the screen can currently show. See `numeralCapacity` in `layout.ts`. */
 export type BoardLimits = {
   /** Widest numeral, in characters, a disc can engrave legibly right now. */
   readonly maxNumeralChars: number;
@@ -425,6 +425,8 @@ type Draft = {
   fillSide: Side | null;
   /** True when the answer is *how many* discs were hung, not what they weigh. */
   countAnswer: boolean;
+  /** True when the dish is filled with balloons, so the mass is the negated answer. */
+  fillLifts: boolean;
   rack: Frac[];
   apparatus: number;
 };
@@ -481,6 +483,7 @@ export function boardFor(q: Question, limits: BoardLimits = NO_LIMITS): Board {
     fillSide: d.kind === "fill" ? d.fillSide : null,
     hangSlot: null,
     countAnswer: d.countAnswer,
+    fillLifts: d.fillLifts,
     prompt: q.prompt,
     domain: q.domain,
     difficulty: q.difficulty,
@@ -622,6 +625,7 @@ function sumBoard(st: Statement, answer: Frac, q: Question, rng: Rng): Drafted {
       fixed,
       fillSide: fill,
       countAnswer: false,
+      fillLifts: kind === "fill" && fillSign < 0,
       rack: rackFor(kind === "declare" ? answer : placed, q.distractors, rng),
       apparatus,
     },
@@ -682,6 +686,7 @@ function productBoard(st: Statement, answer: Frac, q: Question, rng: Rng): Draft
       fixed,
       fillSide: fill,
       countAnswer: false,
+      fillLifts: false,
       rack: rackFor(answer, q.distractors, rng),
       apparatus: APPARATUS_ROWS,
     },
@@ -768,6 +773,7 @@ function crateBoard(st: Statement, answer: Frac, q: Question, rng: Rng): Drafted
       fixed,
       fillSide: null,
       countAnswer: false,
+      fillLifts: false,
       rack: rackFor(answer, q.distractors, rng),
       apparatus: crates > 1 ? APPARATUS_CRATES : APPARATUS_CRATE,
     },
@@ -826,6 +832,7 @@ function countBoard(st: Statement, answer: Frac, q: Question): Drafted {
       fixed,
       fillSide: fill,
       countAnswer: true,
+      fillLifts: false,
       // One kind of weight on the rail, and as many as you like. That IS the
       // board: offering anything else would let a child level the beam with a
       // single 165 and report a count of one.
@@ -973,6 +980,7 @@ export function lastResortBoard(n: number): PuzzleSpec {
     fillSide: 1,
     hangSlot: null,
     countAnswer: false,
+    fillLifts: false,
     prompt: `${String(total)} = ${String(have)} + □`,
     domain: "add-sub",
     difficulty: 0,

--- a/dynawalla/games/balance/src/balance.test.ts
+++ b/dynawalla/games/balance/src/balance.test.ts
@@ -343,6 +343,7 @@ test("no float ever reaches a verdict", () => {
     fillSide: 1,
     hangSlot: null,
     countAnswer: false,
+    fillLifts: false,
     prompt: "1/3 + 1/6 = □",
     domain: "fractions",
     difficulty: 0.5,

--- a/dynawalla/games/balance/src/balance.test.ts
+++ b/dynawalla/games/balance/src/balance.test.ts
@@ -13,9 +13,24 @@ import {
   minWeightsFor,
   answeredKey,
 } from "./puzzle.ts";
-import { specFromQuestion } from "./adapter.ts";
+import { specFromQuestion as buildSpec, type BoardLimits } from "./adapter.ts";
+import type { Question } from "./contract.ts";
 import { makeRng } from "./rng.ts";
 import { makeStubHost } from "./stubHost.ts";
+
+/**
+ * The board, or a failed assertion.
+ *
+ * `specFromQuestion` can now refuse — see `adapter.ts`, which is where the
+ * founder's lockout was. Every question in this file is one the game is expected
+ * to be able to build, so a refusal here is a real failure and should read as
+ * one rather than as `null` propagating into a confusing assertion further down.
+ */
+function specFromQuestion(q: Question, limits?: BoardLimits): PuzzleSpec {
+  const spec = buildSpec(q, limits);
+  assert.ok(spec, `COUNTERPOISE refused a board it must be able to build: ${q.prompt} = ${q.answer}`);
+  return spec;
+}
 
 const SEED = 0x5eed1e;
 const N = 400; // ~80 movements deep: far past anything a session reaches
@@ -327,6 +342,7 @@ test("no float ever reaches a verdict", () => {
     rack: [frac(1, 6), frac(1, 3), frac(1, 2)],
     fillSide: 1,
     hangSlot: null,
+    countAnswer: false,
     prompt: "1/3 + 1/6 = □",
     domain: "fractions",
     difficulty: 0.5,

--- a/dynawalla/games/balance/src/draw.ts
+++ b/dynawalla/games/balance/src/draw.ts
@@ -1084,7 +1084,7 @@ export class Renderer {
       // its neighbours on the rail. `NUMERAL_FACE` is the flat between the
       // knurled rims; the type shrinks until the measured ink fits inside it and
       // stops at `NUMERAL_MIN_PX`, the legibility floor. A numeral that would
-      // still not fit at the floor never reaches here: `numeralBudget` refuses
+      // still not fit at the floor never reaches here: `numeralCapacity` refuses
       // the board upstream. The clamp is the backstop for that promise, not the
       // mechanism, and it is the one that guarantees no overrun on any device.
       const digits = label.replace("−", "").replace("-", "").length;

--- a/dynawalla/games/balance/src/draw.ts
+++ b/dynawalla/games/balance/src/draw.ts
@@ -14,7 +14,15 @@
 import type { Frac } from "./frac.ts";
 import { toNumber } from "./frac.ts";
 import type { Layout } from "./layout.ts";
-import { armDistance, beamPoint, rackSlot, MAX_PEG } from "./layout.ts";
+import {
+  armDistance,
+  beamPoint,
+  rackSlot,
+  MAX_PEG,
+  NUMERAL_FACE,
+  fittedNumeralPx,
+  idealNumeralPx,
+} from "./layout.ts";
 import type { Beam, Body } from "./sim.ts";
 import { dishCentre } from "./sim.ts";
 import type { PuzzleSpec, Side } from "./puzzle.ts";
@@ -1070,9 +1078,20 @@ export class Renderer {
       ctx.lineTo(x + s * 0.44, yy);
       ctx.stroke();
     } else {
+      // Fitted, not guessed. The old line picked `r * 0.78` for anything two
+      // digits or wider and drew centred, so `4232831450` — which the shipped
+      // top rung really does produce — laid about four disc-widths of ink across
+      // its neighbours on the rail. `NUMERAL_FACE` is the flat between the
+      // knurled rims; the type shrinks until the measured ink fits inside it and
+      // stops at `NUMERAL_MIN_PX`, the legibility floor. A numeral that would
+      // still not fit at the floor never reaches here: `numeralBudget` refuses
+      // the board upstream. The clamp is the backstop for that promise, not the
+      // mechanism, and it is the one that guarantees no overrun on any device.
       const digits = label.replace("−", "").replace("-", "").length;
-      const s = r * (digits >= 2 ? 0.78 : 1.02);
-      ctx.font = `600 ${s.toFixed(1)}px ${SERIF}`;
+      const ideal = idealNumeralPx(r, digits);
+      ctx.font = `600 ${ideal.toFixed(1)}px ${SERIF}`;
+      const s = fittedNumeralPx(ideal, ctx.measureText(label).width, r * NUMERAL_FACE);
+      if (s !== ideal) ctx.font = `600 ${s.toFixed(1)}px ${SERIF}`;
       engrave(ctx, label, x, y, color, glow);
     }
     void v;

--- a/dynawalla/games/balance/src/fairness.test.ts
+++ b/dynawalla/games/balance/src/fairness.test.ts
@@ -8,16 +8,32 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-import type { Question } from "./contract.ts";
+import type { DifficultyRequest, Question } from "./contract.ts";
 import { toKey } from "./frac.ts";
 import type { Frac } from "./frac.ts";
-import { specFromQuestion } from "./adapter.ts";
+import { specFromQuestion as buildSpec, type BoardLimits } from "./adapter.ts";
 import { PAN_PEG, netTorque, verdictFor, counts } from "./puzzle.ts";
+import type { PuzzleSpec } from "./puzzle.ts";
 import { makeRng, freshSeed } from "./rng.ts";
 import { makeStubHost } from "./stubHost.ts";
+import { pull } from "./pull.ts";
 import { puzzleAt } from "./generate.ts";
 import { makePacing, afterBoard, request, onTheWire, FLOOR } from "./pacing.ts";
 import { toUnit } from "../../../packs/shared/game-host/index.ts";
+
+/**
+ * The board, or a failed assertion.
+ *
+ * `specFromQuestion` can now refuse — see `adapter.ts`, which is where the
+ * founder's lockout was. Every question in this file is one the game is expected
+ * to be able to build, so a refusal here is a real failure and should read as
+ * one rather than as `null` propagating into a confusing assertion further down.
+ */
+function specFromQuestion(q: Question, limits?: BoardLimits): PuzzleSpec {
+  const spec = buildSpec(q, limits);
+  assert.ok(spec, `COUNTERPOISE refused a board it must be able to build: ${q.prompt} = ${q.answer}`);
+  return spec;
+}
 
 const RACK = 9;
 /** A bot picking blind out of a nine-weight rack. */
@@ -433,17 +449,31 @@ test("a host that is asked for a rung serves that rung, not the next one along",
 });
 
 test("the game asks the host for a rung — the wire is actually connected", () => {
-  // `Game` needs a canvas, a ResizeObserver and a rAF loop, none of which exist
-  // in Node, so the one line that joins the pacing to the host is checked where
-  // it is written. Everything either side of it is unit tested above.
-  const src = readFileSync(new URL("./game.ts", import.meta.url), "utf8");
-  const call = /this\.host\.next\(([^)]*)\)/.exec(src);
-  assert.ok(call, "game.ts no longer calls host.next at all");
-  assert.match(
-    call[1],
-    /request\(/,
-    `game.ts calls host.next(${call[1]}) — it must pass a difficulty request`,
+  // This used to read `game.ts` as text and match `host.next(request(` in it,
+  // because the call sat inside a class that needs a canvas to build. The loop
+  // moved to `pull.ts` for exactly that reason, so the wire can now be driven
+  // instead of grepped: what is asserted is the request the host is handed.
+  const asked: DifficultyRequest[] = [];
+  const host = makeStubHost({ seed: 11 });
+  const climbed = { level: 0.62, floor: 0.4, streak: 3 };
+  pull(
+    (r) => {
+      asked.push(r);
+      return host.next(r);
+    },
+    climbed,
+    { maxNumeralChars: Number.POSITIVE_INFINITY },
   );
+  assert.equal(asked.length, 1, "the first board took more than one draw");
+  assert.ok(
+    Math.abs((asked[0].difficulty ?? -1) - climbed.level) < 0.01,
+    `asked for ${String(asked[0].difficulty)} while the child stood at ${String(climbed.level)}`,
+  );
+  assert.ok(
+    (asked[0].maxDifficulty ?? 0) > (asked[0].difficulty ?? 0),
+    "no standing ceiling went out with the request",
+  );
+  const src = readFileSync(new URL("./game.ts", import.meta.url), "utf8");
   assert.match(src, /this\.host\.raiseFloor\?\./, "the floor is never reported to the host");
 });
 

--- a/dynawalla/games/balance/src/fairness.test.ts
+++ b/dynawalla/games/balance/src/fairness.test.ts
@@ -362,7 +362,16 @@ test("the game records the dish tipping, not just the beam swinging past", () =>
     /this\.errors\+\+/,
     "a spill is not recorded against the child, so a guessed board still earns a gem",
   );
-  assert.match(spill[0], /this\.report\(false\)/, "a spill is never reported to the host");
+  // `report(false, inDish)`, not `report(false)`. `toss` sets every body to
+  // "eject", so a bare `report(false)` reads an empty dish and sends the string
+  // `"0"` — which on a zero-answer board is the *correct* answer, and the host
+  // re-judges the string. See `spill` for the measurement.
+  assert.match(
+    spill[0],
+    /this\.report\(false, inDish\)/u,
+    "a spill reports the dish it already emptied, so a wrong disc is sent as the answer",
+  );
+  assert.match(spill[0], /const inDish = this\.placed\(\);[\s\S]*toss\(/u, "the dish is read after it is tipped");
 });
 
 // ------------------------------------------------------------- the same run

--- a/dynawalla/games/balance/src/game.ts
+++ b/dynawalla/games/balance/src/game.ts
@@ -17,7 +17,7 @@ import {
   netTorque,
   isBalanced,
   isPinned,
-  minWeightsFor,
+  minWeightsForSpec,
   remainingFor,
   verdictFor,
   counts,
@@ -29,7 +29,13 @@ import {
 } from "../../../packs/shared/game-chrome/index.ts";
 import { widestNumeral } from "./adapter.ts";
 import { pull, type Pull } from "./pull.ts";
-import { makePacing, afterBoard, onTheWire, type Pacing } from "./pacing.ts";
+import {
+  makePacing,
+  afterBoard,
+  afterUnshowableBoard,
+  onTheWire,
+  type Pacing,
+} from "./pacing.ts";
 import {
   layoutForViewport,
   numeralCapacity,
@@ -307,12 +313,16 @@ export class Game {
    */
   private pullBoard(): Pull {
     const view = this.viewport();
-    return pull(
+    const got = pull(
       (r) => this.host.next(r),
       this.pacing,
       { maxNumeralChars: numeralCapacity(view.w, view.h, RACK_SLOTS) },
-      this.fallbacks++,
+      this.fallbacks,
     );
+    // Counted only when one actually happened: this is a health signal, and a
+    // pull counter dressed up as a fallback counter is a lie in a log line.
+    if (got.question === null) this.fallbacks++;
+    return got;
   }
 
   private loadNext(first = false): void {
@@ -634,6 +644,16 @@ export class Game {
 
   /** Tip the dish: every weight the player put in comes back to the rack. */
   private spill(): void {
+    // Read the dish BEFORE anything is tossed out of it. `toss` sets the body's
+    // state to "eject", so by the end of the loop below `placed()` is empty and
+    // `answeredKey` sums nothing — which reports the string `"0"`. On a
+    // zero-answer board (`1 − 1`, `0 × 4`, thirteen of every forty
+    // `subtract-within-ten` items) `"0"` is the *correct* answer, and the host
+    // re-judges the string rather than trusting the flag: measured, all 8 wrong
+    // discs on all 43 zero-answer boards in the ladder were recorded as correct
+    // and climbed the ladder for it. A six-year-old dropping the wrong weight got
+    // credit for it.
+    const inDish = this.placed();
     let any = false;
     for (const b of this.bodies) {
       if (b.fixed || b.crate || b.state !== "seated") continue;
@@ -646,7 +666,7 @@ export class Game {
     if (!any) return;
     if (counts("deadEnd")) {
       this.errors++;
-      this.report(false);
+      this.report(false, inDish);
     }
     this.audio.chain(5);
     this.cam.addTrauma(0.14);
@@ -805,6 +825,13 @@ export class Game {
     if (this.errors === 0) this.gems++;
     // The board is over, so the ladder moves before the next one is pulled.
     const before = this.pacing;
+    if (!this.reportable) {
+      // A last-resort board: the host never served it and never judged it. See
+      // `afterUnshowableBoard`, which is where the reasoning and the test live.
+      this.pacing = afterUnshowableBoard(before);
+      this.loadNext();
+      return;
+    }
     this.pacing = afterBoard(before, this.errors);
     if (this.pacing.floor > before.floor) {
       // Feature-detected: the shared host has it, the stub has it, an older
@@ -835,17 +862,18 @@ export class Game {
     }
   }
 
-  private report(correct: boolean): void {
+  private report(correct: boolean, dish?: readonly PlacedItem[]): void {
     if (correct && this.reported) return;
-    // A last-resort board is not the host's question and there is no id to report
-    // it against. See `pullBoard`.
-    if (!this.reportable) return;
     const ms = performance.now() - this.questionStart;
     this.stats.lastAnswerLatencyMs = ms;
+    // A last-resort board is not the host's question and there is no id to report
+    // it against. See `pullBoard`. The latency above is still recorded, because
+    // the harness reads it and a board the child played is a board they played.
+    if (!this.reportable) return;
     // `answeredKey` rather than a second copy of the same switch: it is the
-    // function the tests measure, and it is the one that knows a
-    // measurement-division board reports a count and not a mass.
-    const answered = answeredKey(this.spec, this.placed(), this.declared);
+    // function the tests measure, and the one that knows a measurement-division
+    // board reports a count and a balloon dish reports a positive number.
+    const answered = answeredKey(this.spec, dish ?? this.placed(), this.declared);
     this.host.report({ questionId: this.spec.id, correct, ms, answered });
     if (correct) this.reported = true;
   }
@@ -1359,7 +1387,7 @@ export class Game {
       answer: toKey(this.spec.answer),
       solved: this.solvedTotal,
       gems: this.gems,
-      minWeights: minWeightsFor(this.spec.rack, this.spec.answer),
+      minWeights: minWeightsForSpec(this.spec),
       fps: Math.round(this.stats.fpsAvg),
       kbVisible: this.kbVisible,
       theta: Number(this.beam.theta.toFixed(4)),

--- a/dynawalla/games/balance/src/game.ts
+++ b/dynawalla/games/balance/src/game.ts
@@ -21,14 +21,22 @@ import {
   remainingFor,
   verdictFor,
   counts,
+  answeredKey,
 } from "./puzzle.ts";
 import {
   createInstructions,
   type Instructions,
 } from "../../../packs/shared/game-chrome/index.ts";
-import { specFromQuestion } from "./adapter.ts";
-import { makePacing, afterBoard, request, onTheWire, type Pacing } from "./pacing.ts";
-import { layoutForViewport, armDistance, beamPoint, rackSlot } from "./layout.ts";
+import { widestNumeral } from "./adapter.ts";
+import { pull, type Pull } from "./pull.ts";
+import { makePacing, afterBoard, onTheWire, type Pacing } from "./pacing.ts";
+import {
+  layoutForViewport,
+  numeralCapacity,
+  armDistance,
+  beamPoint,
+  rackSlot,
+} from "./layout.ts";
 import type { Layout } from "./layout.ts";
 import {
   makeBeam,
@@ -50,20 +58,8 @@ import { clamp01, easeOutElastic } from "./ease.ts";
 
 type Phase = "intro" | "play" | "judging" | "wrong" | "solved";
 
-const ROMAN = [
-  "I",
-  "II",
-  "III",
-  "IV",
-  "V",
-  "VI",
-  "VII",
-  "VIII",
-  "IX",
-  "X",
-  "XI",
-  "XII",
-];
+/** The standard rack, for asking the layout what this screen could engrave. */
+const RACK_SLOTS = 9;
 
 export class Game {
   private el: HTMLElement;
@@ -97,8 +93,20 @@ export class Game {
   solvedTotal = 0;
   gems = 0;
   private pacing: Pacing = makePacing();
-  /** The deepest movement reached, so the plinth announces each one once. */
-  private peakMovement = -1;
+  /**
+   * Which pieces of apparatus this child has already met, so the plinth announces
+   * each one once.
+   *
+   * A set rather than a high-water mark: `spec.movement` used to be the child's
+   * rung divided into ten and could only be arrived at from below, but it now
+   * names the *object* on the board, and objects are met in whatever order the
+   * ladder serves them.
+   */
+  private metApparatus = new Set<number>();
+  /** How many times the host could not be made to serve a board this game shows. */
+  private fallbacks = 0;
+  /** False on a last-resort board: there is no question id to report against. */
+  private reportable = true;
 
   private drag: Body | null = null;
   private dragFromRack = -1;
@@ -180,11 +188,20 @@ export class Game {
           ],
         },
         {
+          heading: "Piles of the same weight",
+          lines: [
+            "Sometimes a dish holds several weights that are all the same.",
+            "Three fives weigh the same as fifteen. Count them and you have the total.",
+            "Sometimes only one kind of weight is on the rail. Then the question is how many of them fit.",
+          ],
+        },
+        {
           heading: "Sealed boxes",
           lines: [
             "Some boxes are shut and you cannot see inside.",
-            "Work out how heavy the box must be to make the arm flat.",
-            "Then drag that number onto the box to say it out loud.",
+            "When several shut boxes are all the same, they all hold the same amount.",
+            "Work out how heavy one box must be to make the arm flat.",
+            "Then drag that number onto a box to say it out loud.",
           ],
         },
         {
@@ -206,7 +223,11 @@ export class Game {
       reducedMotion: host.prefersReducedMotion(),
     });
 
-    this.L = layoutForViewport(1, 1, 9);
+    // Never read: `resize()` below replaces it before anything is drawn or asked
+    // for. Sized at the same 240px floor `resize` clamps to rather than 1×1, so a
+    // future reader of `this.L` before that point gets a plausible layout instead
+    // of a degenerate one.
+    this.L = layoutForViewport(240, 240, RACK_SLOTS);
     for (let i = 0; i < 44; i++) {
       this.motes[i * 4] = Math.random();
       this.motes[i * 4 + 1] = Math.random();
@@ -216,8 +237,15 @@ export class Game {
       this.moteVel[i * 2 + 1] = -0.004 - Math.random() * 0.008;
     }
 
-    this.loadNext(true);
+    // `resize` first, and this order is load-bearing: `pullBoard` has to know how
+    // wide a numeral this screen can engrave, and until `resize` runs `this.L` is
+    // a 1×1 placeholder that reports room for three characters. `pullBoard` asks
+    // the element rather than the last layout so that the order cannot matter, but
+    // both guards are here because neither can be proved by a test in this
+    // package: `Game` needs a canvas, a `ResizeObserver` and a frame loop, and
+    // none of the three exist in Node.
     this.resize();
+    this.loadNext(true);
 
     this.ro = new ResizeObserver(() => this.resize());
     this.ro.observe(el);
@@ -239,23 +267,61 @@ export class Game {
   private onWinResize = (): void => this.resize();
   private onContextMenu = (e: Event): void => e.preventDefault();
 
-  private resize(): void {
+  /**
+   * The box everything is laid out inside, clamped the way `resize` clamps it.
+   *
+   * Its own method because `pullBoard` needs it too, and reading it from
+   * `this.L` instead was a live bug: the constructor seeds `this.L` with a 1×1
+   * placeholder and calls `loadNext` *before* `resize`, so the very first board of
+   * every session was judged against a layout that reports room for three
+   * characters. `9 + 8` would have been refused as too wide on board one, and the
+   * sweep would have walked the child to the bottom of the ladder looking for
+   * something that fitted. Asking the element rather than the last layout makes
+   * the order of those two calls stop mattering.
+   */
+  private viewport(): { w: number; h: number } {
     const r = this.el.getBoundingClientRect();
-    const w = Math.max(240, Math.round(r.width || window.innerWidth));
-    const h = Math.max(240, Math.round(r.height || window.innerHeight));
+    return {
+      w: Math.max(240, Math.round(r.width || window.innerWidth)),
+      h: Math.max(240, Math.round(r.height || window.innerHeight)),
+    };
+  }
+
+  private resize(): void {
+    const { w, h } = this.viewport();
     // DPR capped at 2: a 3x phone would triple the fill cost for no visible gain.
     const dpr = Math.min(2, window.devicePixelRatio || 1);
-    this.L = layoutForViewport(w, h, this.spec ? this.spec.rack.length : 9);
+    this.L = layoutForViewport(
+      w,
+      h,
+      this.spec ? this.spec.rack.length : RACK_SLOTS,
+      this.spec ? widestNumeral(this.spec) : 1,
+    );
     this.renderer.resize(w, h, dpr);
     this.seatAll(true);
+  }
+
+  /**
+   * A board, always. See `pull.ts` — the loop and the guarantee live there so
+   * that they can be tested without a canvas.
+   */
+  private pullBoard(): Pull {
+    const view = this.viewport();
+    return pull(
+      (r) => this.host.next(r),
+      this.pacing,
+      { maxNumeralChars: numeralCapacity(view.w, view.h, RACK_SLOTS) },
+      this.fallbacks++,
+    );
   }
 
   private loadNext(first = false): void {
     // Ask for a board this child can actually get onto. See `pacing.ts` — with
     // no request at all the host chose from its whole ladder, and the opening
     // board of a fresh install was two-digit column addition.
-    const q = this.host.next(request(this.pacing));
-    this.spec = specFromQuestion(q);
+    const pulled = this.pullBoard();
+    this.spec = pulled.spec;
+    this.reportable = pulled.question !== null;
     this.declared = null;
     this.errors = 0;
     this.reported = false;
@@ -277,7 +343,12 @@ export class Game {
       });
       this.bodies.push(b);
     }
-    this.L = layoutForViewport(this.L.w, this.L.h, this.spec.rack.length);
+    this.L = layoutForViewport(
+      this.L.w,
+      this.L.h,
+      this.spec.rack.length,
+      widestNumeral(this.spec),
+    );
     this.seatAll(true);
 
     // Assemble: everything drops in from above with a stagger.
@@ -751,14 +822,14 @@ export class Game {
     // — so a child hovering either side of a boundary would get the plinth and
     // the fanfare every second or third board. A movement is an arrival, and
     // you only arrive somewhere once.
-    const arrived = this.spec.movement > this.peakMovement;
-    if (arrived) this.peakMovement = this.spec.movement;
+    const arrived = !this.metApparatus.has(this.spec.movement);
+    if (arrived) this.metApparatus.add(this.spec.movement);
     if (arrived || this.solvedTotal === 1) {
-      this.banner = {
-        text: this.spec.movementName,
-        sub: `MOVEMENT ${ROMAN[Math.min(this.spec.movement, ROMAN.length - 1)]}`,
-        t: 0,
-      };
+      // The name and nothing else. The second line used to read "MOVEMENT VII",
+      // which counted a staircase that no longer exists — the engraving names the
+      // apparatus now, and a Roman numeral against an object is a number about
+      // nothing.
+      this.banner = { text: this.spec.movementName, sub: "", t: 0 };
       if (this.solvedTotal > 0) this.audio.fanfare();
       this.cam.addPunch(0.02);
     }
@@ -766,18 +837,15 @@ export class Game {
 
   private report(correct: boolean): void {
     if (correct && this.reported) return;
+    // A last-resort board is not the host's question and there is no id to report
+    // it against. See `pullBoard`.
+    if (!this.reportable) return;
     const ms = performance.now() - this.questionStart;
     this.stats.lastAnswerLatencyMs = ms;
-    let answered = "";
-    if (this.spec.kind === "declare") answered = this.declared ? toKey(this.declared) : "";
-    else if (this.spec.kind === "hang") {
-      const p = this.placed();
-      answered = p.length ? toKey(p[p.length - 1].value) : "";
-    } else {
-      let sum: Frac = ZERO;
-      for (const p of this.placed()) sum = add(sum, p.value);
-      answered = toKey(sum);
-    }
+    // `answeredKey` rather than a second copy of the same switch: it is the
+    // function the tests measure, and it is the one that knows a
+    // measurement-division board reports a count and not a mass.
+    const answered = answeredKey(this.spec, this.placed(), this.declared);
     this.host.report({ questionId: this.spec.id, correct, ms, answered });
     if (correct) this.reported = true;
   }

--- a/dynawalla/games/balance/src/generate.ts
+++ b/dynawalla/games/balance/src/generate.ts
@@ -436,6 +436,9 @@ export function puzzleAt(index: number, seed: number): PuzzleSpec {
     fillSide: d.fillSide,
     hangSlot: d.hangSlot,
     countAnswer: false,
+    // The local ladder's balloon boards hand the child a negative answer already
+    // (`genBalloon` answers `-x`), so the mass in the dish IS the answer.
+    fillLifts: false,
     prompt: d.prompt,
     domain: d.domain,
     difficulty: Math.min(1, 0.06 + movement * 0.1 + (index % PUZZLES_PER_MOVEMENT) * 0.02),

--- a/dynawalla/games/balance/src/generate.ts
+++ b/dynawalla/games/balance/src/generate.ts
@@ -435,6 +435,7 @@ export function puzzleAt(index: number, seed: number): PuzzleSpec {
     rack: d.rack,
     fillSide: d.fillSide,
     hangSlot: d.hangSlot,
+    countAnswer: false,
     prompt: d.prompt,
     domain: d.domain,
     difficulty: Math.min(1, 0.06 + movement * 0.1 + (index % PUZZLES_PER_MOVEMENT) * 0.02),

--- a/dynawalla/games/balance/src/layout.ts
+++ b/dynawalla/games/balance/src/layout.ts
@@ -32,6 +32,112 @@ import {
 
 export const MAX_PEG = 5;
 
+/**
+ * The numeral cell, and why a brass disc has a character budget at all.
+ *
+ * The founder played this and reported it in one line: *"long numbers don't fit
+ * on the weights so they just run all over each other."* He is describing
+ * `Renderer.numeral`, which chose a type size from the digit count — `r * 0.78`
+ * for anything two digits or more — and then drew, centred, with no reference to
+ * how wide the face it is engraving actually is. At the top of the shipped
+ * ladder `80225 × 52762` puts **4232831450** on a disc: ten digits at 0.78r is
+ * about four disc-widths of ink, so the numeral covers its neighbours on the
+ * rail and neither can be read. Nothing measured it, because nothing in this
+ * package could see a pixel until `layout.test.ts` existed and that file is
+ * about the frame.
+ *
+ * So the disc gets a stated capacity, from three numbers that are all about the
+ * real thing:
+ *
+ *   - `NUMERAL_MIN_PX` — the floor a numeral may be shrunk to. 15px, which is
+ *     the floor a repo-wide audit set for an answer a child has to read.
+ *   - `NUMERAL_ADVANCE_EM` — how wide one digit is in the game's serif stack.
+ *     Lining figures in Palatino, Georgia and Times all advance 0.50em; 0.58 is
+ *     deliberately above every one of them, because over-estimating costs a
+ *     character of budget and under-estimating puts ink outside the brass.
+ *   - `NUMERAL_FACE` — the engravable width of the disc, in radii. The knurl
+ *     band `Renderer.weight` draws spans ±0.86r, so 1.7r is the flat between
+ *     the rims.
+ *
+ * Those give a two-way conversion: the radius a numeral of N characters needs,
+ * and the characters a disc of radius r can hold. `computeLayout` uses the first
+ * to grow the disc for a wide board, and the adapter uses the second to refuse a
+ * question whose numerals still would not fit. Neither guesses.
+ */
+export const NUMERAL_MIN_PX = 15;
+export const NUMERAL_ADVANCE_EM = 0.58;
+export const NUMERAL_FACE = 1.7;
+
+/**
+ * The type size an engraved numeral starts at, before it is fitted.
+ *
+ * `r * 0.78` for two characters or more and `r * 1.02` for one, which is what the
+ * renderer always used — with the legibility floor now under it. That floor
+ * matters at the small end and was being missed there: `weightR` clamps to 17 on
+ * a narrow screen, and `17 × 0.78` is 13.3px, so a plain two-digit answer was
+ * drawn under the 15px floor before any question of width came up.
+ */
+export function idealNumeralPx(r: number, chars: number): number {
+  return Math.max(NUMERAL_MIN_PX, r * (chars >= 2 ? 0.78 : 1.02));
+}
+
+/**
+ * The type size an engraved numeral is actually drawn at.
+ *
+ * Pure, so the founder's complaint is testable without a canvas: hand it the
+ * ideal size, the ink that size measured, and the face it has to fit inside, and
+ * it returns a size whose ink is inside the face — or the legibility floor, if
+ * even that is not enough, which is the case `numeralBudget` exists to keep off
+ * the screen entirely.
+ */
+export function fittedNumeralPx(idealPx: number, inkAtIdeal: number, faceW: number): number {
+  if (!(inkAtIdeal > 0) || inkAtIdeal <= faceW) return idealPx;
+  return Math.max(NUMERAL_MIN_PX, (idealPx * faceW) / inkAtIdeal);
+}
+
+/** The disc radius a numeral of `chars` characters needs to stay legible. */
+export function radiusForChars(chars: number): number {
+  return (Math.max(1, chars) * NUMERAL_MIN_PX * NUMERAL_ADVANCE_EM) / NUMERAL_FACE;
+}
+
+/** How many characters a disc of radius `r` can engrave at the legibility floor. */
+export function charsAtRadius(r: number): number {
+  return Math.max(1, Math.floor((r * NUMERAL_FACE) / (NUMERAL_MIN_PX * NUMERAL_ADVANCE_EM)));
+}
+
+/**
+ * The widest numeral this layout can hold — the pack's own legibility ceiling,
+ * read back off the arrangement a child is looking at rather than predicted.
+ *
+ * A phone and a tablet get different answers and that is correct: the tablet's
+ * disc is bigger, so it can honestly show more of the ladder.
+ */
+export function numeralBudget(L: Layout): number {
+  return charsAtRadius(L.weightR);
+}
+
+/**
+ * More characters than any board could want, used to ask `computeLayout` for the
+ * biggest disc a viewport can carry. Sixteen: the widest numeral the shipped
+ * ladder produces is ten characters.
+ */
+const PROBE_CHARS = 16;
+
+/**
+ * The widest numeral this *viewport* could ever engrave — the pack's ceiling,
+ * measured before a board exists.
+ *
+ * Distinct from `numeralBudget`, which reads a layout already built for a
+ * particular board. This one asks what the screen is capable of, which is the
+ * number a question has to be judged against: refusing a wide board because the
+ * layout currently on screen was built for a narrow one would refuse boards this
+ * device can perfectly well show.
+ */
+export function numeralCapacity(w: number, h: number, rackCount: number): number {
+  const area = safeRect(w, h);
+  return charsAtRadius(largestFeasibleRadius(w, h, rackCount, area));
+}
+
 export type Layout = {
   w: number;
   h: number;
@@ -79,14 +185,103 @@ function insetsOf(w: number, h: number, area: Rect): Insets {
 }
 
 /**
+ * The largest radius the growth walk will consider — the radius a sixteen
+ * character numeral would need, which is six more than the widest the shipped
+ * ladder produces.
+ */
+const UP_LIMIT = Math.ceil(radiusForChars(PROBE_CHARS));
+
+/**
+ * The biggest disc this screen can carry with the frame still holding.
+ *
+ * Walked down from `UP_LIMIT`, because feasibility is not monotone in the radius
+ * — see the note in `computeLayout` — so "biggest" has to be searched for rather
+ * than derived. `base` is the floor and is always feasible: it is what shipped.
+ */
+function largestFeasibleRadius(w: number, h: number, rackCount: number, area: Rect): number {
+  const base = baseRadius(Math.max(120, area.w), Math.max(120, area.h));
+  for (let r = UP_LIMIT; r > base; r--) {
+    if (frameHolds(computeAtRadius(w, h, rackCount, area, r), area, rackCount)) return r;
+  }
+  return base;
+}
+
+/** The disc size this viewport would pick if no numeral needed room. */
+function baseRadius(bw: number, bh: number): number {
+  return clamp(Math.min(bw / 15.5, bh / 17), 17, 34);
+}
+
+/**
+ * Does this arrangement still hold together?
+ *
+ * The three invariants `layout.test.ts` asserts, restated as a predicate so that
+ * growing the disc for a wide numeral cannot break the frame: whatever radius is
+ * chosen below, it is chosen because the arrangement it produces passes exactly
+ * the checks the frame test runs. A bigger disc that would push the rack into
+ * the plinth or off the safe bottom is simply not chosen, and the board is
+ * refused instead of drawn badly.
+ */
+function frameHolds(L: Layout, area: Rect, rackCount: number): boolean {
+  if (!(L.rack.y > L.plinth.y + L.plinth.h - 0.5)) return false;
+  for (let i = 0; i < rackCount; i++) {
+    const p = rackSlot(L, i, rackCount);
+    if (p.y + L.rack.slotH / 2 > area.y + area.h + 0.5) return false;
+    if (p.x - L.rack.slotW / 2 < area.x - 0.5) return false;
+    if (p.x + L.rack.slotW / 2 > area.x + area.w + 0.5) return false;
+  }
+  return true;
+}
+
+/**
  * @param area the safe rectangle, from `safeRect(w, h)`. Required — see the
  * note at the top of this file.
+ * @param chars the widest numeral, in characters, that must be engraved on a
+ * disc on this board. Defaults to 1, which reproduces the arrangement this
+ * function returned before numerals had a budget — so every existing caller and
+ * every frame test is bit-for-bit unchanged.
  */
 export function computeLayout(
   w: number,
   h: number,
   rackCount: number,
   area: Rect,
+  chars = 1,
+): Layout {
+  const bw = Math.max(120, area.w);
+  const bh = Math.max(120, area.h);
+  const base = baseRadius(bw, bh);
+  const want = radiusForChars(chars);
+  if (want <= base) return computeAtRadius(w, h, rackCount, area, base);
+
+  // Grow the brass until the numeral fits, walking a pixel at a time *upward*
+  // from the radius the numeral needs, and stopping at the first arrangement that
+  // still holds together.
+  //
+  // Upward, and this is not a taste call. Feasibility is not monotone in the
+  // radius: `plinthY` is clamped between `bh * 0.56` and the top of the rack, and
+  // when the rack has climbed far enough that the lower bound is above the upper
+  // one the clamp returns the *lower* bound and the plinth lands on top of the
+  // rack. So on a 320×568 phone r=24 holds, r=25 through 35 do not, and r=36 holds
+  // again. Searching downward from the wanted radius therefore stopped at 24 —
+  // a disc that fits four characters, for a board that needed six — and the
+  // promise `numeralBudget` makes to the adapter would have been a lie. Measured:
+  // that is exactly what the first version of this function did.
+  for (let r = Math.ceil(want); r <= UP_LIMIT; r++) {
+    const candidate = computeAtRadius(w, h, rackCount, area, r);
+    if (frameHolds(candidate, area, rackCount)) return candidate;
+  }
+  // Nothing big enough holds together on this screen. Take the biggest disc it
+  // *can* carry and let the adapter refuse the board: `numeralCapacity` reads the
+  // same number, so the refusal and the arrangement agree by construction.
+  return computeAtRadius(w, h, rackCount, area, largestFeasibleRadius(w, h, rackCount, area));
+}
+
+function computeAtRadius(
+  w: number,
+  h: number,
+  rackCount: number,
+  area: Rect,
+  weightR: number,
 ): Layout {
   const bw = Math.max(120, area.w);
   const bh = Math.max(120, area.h);
@@ -94,7 +289,6 @@ export function computeLayout(
   const portrait = bh > bw * 1.05;
   const u = clamp(Math.min(bw / 900, bh / 620), 0.55, 1.9);
 
-  const weightR = clamp(Math.min(bw / 15.5, bh / 17), 17, 34);
   const slotW = weightR * 2 + weightR * 0.52;
   const slotH = weightR * 2.35;
 
@@ -182,8 +376,13 @@ export function computeLayout(
  * measure, so this is the plain full-screen layout in node and on a device
  * without insets.
  */
-export function layoutForViewport(w: number, h: number, rackCount: number): Layout {
-  return computeLayout(w, h, rackCount, safeRect(w, h));
+export function layoutForViewport(
+  w: number,
+  h: number,
+  rackCount: number,
+  chars = 1,
+): Layout {
+  return computeLayout(w, h, rackCount, safeRect(w, h), chars);
 }
 
 /** Distance along the arm, in pixels, for a peg on a given mode. */

--- a/dynawalla/games/balance/src/layout.ts
+++ b/dynawalla/games/balance/src/layout.ts
@@ -61,8 +61,9 @@ export const MAX_PEG = 5;
  *
  * Those give a two-way conversion: the radius a numeral of N characters needs,
  * and the characters a disc of radius r can hold. `computeLayout` uses the first
- * to grow the disc for a wide board, and the adapter uses the second to refuse a
- * question whose numerals still would not fit. Neither guesses.
+ * to grow the disc for a wide board, and `numeralCapacity` below reports the
+ * second to the adapter, which refuses a question whose numerals still would not
+ * fit. Neither guesses.
  */
 export const NUMERAL_MIN_PX = 15;
 export const NUMERAL_ADVANCE_EM = 0.58;
@@ -87,7 +88,7 @@ export function idealNumeralPx(r: number, chars: number): number {
  * Pure, so the founder's complaint is testable without a canvas: hand it the
  * ideal size, the ink that size measured, and the face it has to fit inside, and
  * it returns a size whose ink is inside the face — or the legibility floor, if
- * even that is not enough, which is the case `numeralBudget` exists to keep off
+ * even that is not enough, which is the case `numeralCapacity` exists to keep off
  * the screen entirely.
  */
 export function fittedNumeralPx(idealPx: number, inkAtIdeal: number, faceW: number): number {
@@ -106,17 +107,6 @@ export function charsAtRadius(r: number): number {
 }
 
 /**
- * The widest numeral this layout can hold — the pack's own legibility ceiling,
- * read back off the arrangement a child is looking at rather than predicted.
- *
- * A phone and a tablet get different answers and that is correct: the tablet's
- * disc is bigger, so it can honestly show more of the ladder.
- */
-export function numeralBudget(L: Layout): number {
-  return charsAtRadius(L.weightR);
-}
-
-/**
  * More characters than any board could want, used to ask `computeLayout` for the
  * biggest disc a viewport can carry. Sixteen: the widest numeral the shipped
  * ladder produces is ten characters.
@@ -127,11 +117,11 @@ const PROBE_CHARS = 16;
  * The widest numeral this *viewport* could ever engrave — the pack's ceiling,
  * measured before a board exists.
  *
- * Distinct from `numeralBudget`, which reads a layout already built for a
- * particular board. This one asks what the screen is capable of, which is the
- * number a question has to be judged against: refusing a wide board because the
- * layout currently on screen was built for a narrow one would refuse boards this
- * device can perfectly well show.
+ * Asked of the *screen*, not of a layout already built for a particular board.
+ * That distinction is the whole point: judging a question against the arrangement
+ * currently on the glass would refuse a wide board because the board before it was
+ * narrow. A phone and a tablet get different answers and that is correct — the
+ * tablet's disc is bigger, so it can honestly show more of the ladder.
  */
 export function numeralCapacity(w: number, h: number, rackCount: number): number {
   const area = safeRect(w, h);
@@ -264,7 +254,7 @@ export function computeLayout(
   // rack. So on a 320×568 phone r=24 holds, r=25 through 35 do not, and r=36 holds
   // again. Searching downward from the wanted radius therefore stopped at 24 —
   // a disc that fits four characters, for a board that needed six — and the
-  // promise `numeralBudget` makes to the adapter would have been a lie. Measured:
+  // promise `numeralCapacity` makes to the adapter would have been a lie. Measured:
   // that is exactly what the first version of this function did.
   for (let r = Math.ceil(want); r <= UP_LIMIT; r++) {
     const candidate = computeAtRadius(w, h, rackCount, area, r);

--- a/dynawalla/games/balance/src/pacing.ts
+++ b/dynawalla/games/balance/src/pacing.ts
@@ -84,6 +84,30 @@ export function afterBoard(p: Pacing, errors: number): Pacing {
 }
 
 /**
+ * How far the request drops after a board the pack could not get from the host.
+ *
+ * A twentieth of the ladder — a little over three of the sixty-six rungs that
+ * ship. Enough to walk out of a neighbourhood of content this pack has no picture
+ * for, not so far that one refusal throws a child back to counting on fingers.
+ */
+export const FALLBACK_STEP_DOWN = 0.05;
+
+/**
+ * The board was one the host never served and never judged — see `lastResortBoard`.
+ *
+ * It is a one-move `8 = 2 + □`, so `afterBoard` would read zero errors and climb,
+ * and climbing is exactly backwards: the pack could not draw what the child was
+ * standing on. Four fallbacks in a row would have pushed a permanent floor into
+ * the region this pack has no picture for and pinned the child there, solving
+ * `2 + 6` for the rest of the session. So the request steps down, the streak
+ * breaks, and the floor is left exactly where it was — a floor is a promise to the
+ * host about content the child has *earned*, and nobody earned anything here.
+ */
+export function afterUnshowableBoard(p: Pacing): Pacing {
+  return { level: Math.max(0, p.level - FALLBACK_STEP_DOWN), floor: p.floor, streak: 0 };
+}
+
+/**
  * The largest number this game may put on the wire, and why it is not 1.
  *
  * `packs/shared/game-host` reads a difficulty through `toUnit`, which has to

--- a/dynawalla/games/balance/src/pull.ts
+++ b/dynawalla/games/balance/src/pull.ts
@@ -22,15 +22,24 @@ import { HEADROOM, onTheWire, request, type Pacing } from "./pacing.ts";
 /**
  * How hard to try before giving up.
  *
- * Four draws at a rung, then a rung down — `STEP` is a shade under a sixty-sixth
- * of the ladder, which is one rung of the one that ships — so 96 tries walks the
- * whole ladder to the floor and then some. Generous on purpose: a wasted draw
- * costs a prefetched question the host discards, and running out costs a child a
- * screen with nothing on it.
+ * Three draws at a rung, then a step of a twentieth of the ladder, so twenty-four
+ * tries walks eight steps — about a quarter of the way down from wherever the
+ * child was standing. That reaches representable content from any rung on the
+ * shipped ladder, where the seven rungs this pack has no picture for are the
+ * multiplications at the very top.
+ *
+ * It was 96 with a one-rung step, and 96 is too deep to ask a host for. The shared
+ * host holds at most 64 prefetched questions and refills *asynchronously*, so no
+ * refill can land inside this loop: past the pool depth `take` starts handing back
+ * `{ ...lastServed, id: "" }` — the same already-refused prompt, forever, with the
+ * step-down turned into a no-op. `game-host` says it plainly: "the deepest bulk
+ * consumer in the repo is FUSE's 26-question pool, and every retry loop caps at
+ * eight." Twenty-four is above that and defensible; ninety-six was not. The empty
+ * id is also detected below, because a dry pool cannot be retried out of.
  */
-export const TRIES = 96;
-export const TRIES_PER_RUNG = 4;
-export const STEP = 0.015;
+export const TRIES = 24;
+export const TRIES_PER_RUNG = 3;
+export const STEP = 0.05;
 
 export type Pull = {
   spec: PuzzleSpec;
@@ -77,6 +86,20 @@ export function pull(
       difficulty: onTheWire(level),
       maxDifficulty: onTheWire(level + HEADROOM),
     });
+    // A question with no id is the shared host telling us its pool has run dry —
+    // it is `lastServed` handed back again, so asking a twenty-fourth time returns
+    // the same thing. And it must never be reported against: the host drops a
+    // report with an empty id on the floor, so a child would solve the board and
+    // have nothing recorded while the pack believed it had reported.
+    if (q.id === "") {
+      const board = boardFor(q, limits);
+      console.error(
+        "[counterpoise] the host's question pool is dry (an item arrived with no id); " +
+          "using a local board so nothing is reported against a question the host cannot judge",
+      );
+      if (!board.ok) refusals.push(board);
+      return { spec: board.ok ? board.spec : lastResortBoard(fallbackIndex), question: null, refusals };
+    }
     const board = boardFor(q, limits);
     if (board.ok) return { spec: board.spec, question: q, refusals };
     refusals.push(board);

--- a/dynawalla/games/balance/src/pull.ts
+++ b/dynawalla/games/balance/src/pull.ts
@@ -1,0 +1,91 @@
+// Getting a board, which is not the same thing as getting a question.
+//
+// `boardFor` can refuse: a division whose divisor would need seventy crates in
+// one dish, a numeral too wide to engrave legibly on this screen, notation the
+// curriculum grew last week. A refusal must never reach a child, because a child
+// cannot skip a board — the only way out of one is solving it, which is exactly
+// how the founder ended up stuck on `88965 ÷ 9` with nowhere to go. So this file
+// is the loop that keeps asking, and the promise that it always ends with brass
+// on the screen.
+//
+// It lives outside `Game` because `Game` needs a canvas and a DOM and this needs
+// neither. The behaviour that matters here — *a board, every time, from any host,
+// at any rung* — is the one thing in the game that must be provable, and a test
+// cannot prove it through a constructor that calls `document.createElement`.
+
+import type { DifficultyRequest, Question } from "./contract.ts";
+import type { PuzzleSpec } from "./puzzle.ts";
+import type { BoardLimits, Refusal } from "./adapter.ts";
+import { boardFor, lastResortBoard } from "./adapter.ts";
+import { HEADROOM, onTheWire, request, type Pacing } from "./pacing.ts";
+
+/**
+ * How hard to try before giving up.
+ *
+ * Four draws at a rung, then a rung down — `STEP` is a shade under a sixty-sixth
+ * of the ladder, which is one rung of the one that ships — so 96 tries walks the
+ * whole ladder to the floor and then some. Generous on purpose: a wasted draw
+ * costs a prefetched question the host discards, and running out costs a child a
+ * screen with nothing on it.
+ */
+export const TRIES = 96;
+export const TRIES_PER_RUNG = 4;
+export const STEP = 0.015;
+
+export type Pull = {
+  spec: PuzzleSpec;
+  /**
+   * The host's question, or `null` when nothing it offered could be shown and
+   * the board came from `lastResortBoard`. Nothing may be reported against a
+   * `null` — there is no question id the host would recognise.
+   */
+  question: Question | null;
+  /** Every refusal on the way, for a harness that wants to count them. */
+  refusals: Refusal[];
+};
+
+/**
+ * A board this game can show, always.
+ *
+ * Asks at the child's own rung first and only steps down after a few misses.
+ * That order matters: the questions this pack cannot show are *scattered*
+ * through the ladder rather than stacked at the top of it — ten division rungs
+ * sit between ordinate 0.34 and 0.86, interleaved with addition rungs it shows
+ * perfectly — so a standing `maxDifficulty` ceiling learned from one refusal
+ * (which is the right answer in `polarity`, where the constraint is monotone in
+ * difficulty) would delete two thirds of the ladder here. Stepping down is
+ * per-board and transient: the caller's `Pacing` is never touched, so a refusal
+ * costs the child nothing and does not move where they are standing.
+ *
+ * The bottom of the curriculum is `0 + 1`, which this game has always been able
+ * to show, so the sweep terminates. The last-resort board exists anyway, because
+ * "there is no board" and "there is no legal move" are the same failure and
+ * neither may ever happen.
+ */
+export function pull(
+  next: (r: DifficultyRequest) => Question,
+  pacing: Pacing,
+  limits: BoardLimits,
+  fallbackIndex = 0,
+): Pull {
+  const refusals: Refusal[] = [];
+  const base = request(pacing);
+  let level = pacing.level;
+  for (let tries = 0; tries < TRIES; tries++) {
+    const q = next({
+      ...base,
+      difficulty: onTheWire(level),
+      maxDifficulty: onTheWire(level + HEADROOM),
+    });
+    const board = boardFor(q, limits);
+    if (board.ok) return { spec: board.spec, question: q, refusals };
+    refusals.push(board);
+    if ((tries + 1) % TRIES_PER_RUNG === 0) level = Math.max(0, level - STEP);
+  }
+  console.error(
+    `[counterpoise] the host refused ${String(TRIES)} draws between ` +
+      `${pacing.level.toFixed(2)} and ${level.toFixed(2)} of the ladder; ` +
+      `falling back to a local board so the child still has a move`,
+  );
+  return { spec: lastResortBoard(fallbackIndex), question: null, refusals };
+}

--- a/dynawalla/games/balance/src/puzzle.ts
+++ b/dynawalla/games/balance/src/puzzle.ts
@@ -42,6 +42,18 @@ export type PuzzleSpec = {
   rack: Frac[];
   fillSide: Side | null;
   hangSlot: { side: Side; peg: number } | null;
+  /**
+   * The answer is *how many* weights were hung, not what they weigh.
+   *
+   * True only on a measurement-division board — `□ × 15 = 165`, where the rack
+   * holds nothing but 15s and eleven of them is the answer. Everything else about
+   * such a board is an ordinary `fill`: the beam still levels on exact torque and
+   * nothing about the physics changes. The one difference is what gets reported,
+   * and it lives here rather than in a fourth `kind` so that every path that
+   * already handles `fill` — the drop zone, the spill, the verdict, the clean-solve
+   * gem — keeps working without learning a new case.
+   */
+  countAnswer: boolean;
   prompt: string;
   domain: string;
   difficulty: number;
@@ -71,6 +83,30 @@ export const MOVEMENTS: readonly string[] = [
   "Halves and Quarters",
   "The Long Arm",
   "Sealed and Split",
+];
+
+/**
+ * What is actually standing in front of the child, indexed by `PuzzleSpec.movement`.
+ *
+ * `MOVEMENTS` above is a *ladder* of names and it was engraved by dividing the
+ * child's difficulty into ten, which meant the plinth announced "IDENTICAL
+ * CRATES" and "THE LONG ARM" over boards that had neither — because against the
+ * shipped host every board was a plain pair of dishes. The founder played it and
+ * said the quiet part: *"'identical' doesn't do much .. you just put the matching
+ * weight on the other side."*
+ *
+ * These names describe objects instead, so the engraving is true by construction
+ * and the fanfare fires the first time a child meets a new piece of apparatus
+ * rather than every fifth question. The order is the order they are met in.
+ */
+export const APPARATUS: readonly string[] = [
+  "Both Dishes",
+  "Lift",
+  "Equal Rows",
+  "How Many Fit",
+  "The Sealed Crate",
+  "Identical Crates",
+  "Halves and Quarters",
 ];
 
 function lcm(a: number, b: number): number {
@@ -126,6 +162,10 @@ export function answeredKey(
   declared: Frac | null,
 ): string {
   if (spec.kind === "fill") {
+    // On a measurement-division board the child's answer is the count. `11` is
+    // what the host asked for and `165` is what the brass weighs; reporting the
+    // mass would mark every correct answer wrong.
+    if (spec.countAnswer) return String(placed.length);
     let sum: Frac = ZERO;
     for (const p of placed) sum = add(sum, p.value);
     return toKey(sum);
@@ -164,7 +204,13 @@ export function rackCanMake(rack: readonly Frac[], target: Frac): boolean {
   let L = target.d;
   for (const f of rack) L = lcm(L, f.d);
   const goal = Math.abs(target.n) * (L / target.d);
-  if (goal <= 0 || goal > 4096) return false;
+  if (goal <= 0) return false;
+  // Past the search cap this function does not know, and `false` here is read by
+  // `verdictFor` as a *proved* dead end: the dish tips, everything comes back and
+  // an error is recorded. The shipped ladder reaches `913072 − 884`, so "I could
+  // not check" used to be charged to the child as a mistake. Not knowing must
+  // fail the safe way — the beam is still telling them the truth either way.
+  if (goal > 4096) return true;
   const sign = target.n < 0 ? -1 : 1;
   const vals = rack
     .filter((f) => f.n !== 0 && (f.n < 0 ? -1 : 1) === sign)

--- a/dynawalla/games/balance/src/puzzle.ts
+++ b/dynawalla/games/balance/src/puzzle.ts
@@ -54,6 +54,16 @@ export type PuzzleSpec = {
    * gem — keeps working without learning a new case.
    */
   countAnswer: boolean;
+  /**
+   * The thing the child hangs in the dish is a balloon, so the mass they placed is
+   * the negative of the answer they were asked for.
+   *
+   * `8 − □ = 4` is answered **4** and solved by tying a balloon of 4 to the heavy
+   * dish. Without this, `answeredKey` reported `-4`, the host's own judge parsed
+   * it, `family.check` rejected it, and a child who solved the board was recorded
+   * wrong and stepped down the ladder for it.
+   */
+  fillLifts: boolean;
   prompt: string;
   domain: string;
   difficulty: number;
@@ -168,7 +178,9 @@ export function answeredKey(
     if (spec.countAnswer) return String(placed.length);
     let sum: Frac = ZERO;
     for (const p of placed) sum = add(sum, p.value);
-    return toKey(sum);
+    // A balloon dish holds negative mass and the host asked for a positive
+    // number. See `fillLifts`.
+    return toKey(spec.fillLifts ? frac(-sum.n, sum.d) : sum);
   }
   if (spec.kind === "declare") return declared ? toKey(declared) : "";
   return placed.length > 0 ? toKey(placed[placed.length - 1].value) : "";
@@ -178,8 +190,18 @@ export function answeredKey(
  * The minimum number of rack weights that can make up the answer, for the
  * "clean solve" gem. Small numbers, small rack: exhaustive search is fine.
  */
+export function minWeightsForSpec(spec: PuzzleSpec): number {
+  // A measurement-division board is solved with `answer` copies of the one weight
+  // on the rail, and the answer is a count and not a mass — coin-changing it
+  // against the rack returns 1, which would hand a clean-solve gem to a board that
+  // takes eleven drags.
+  if (spec.countAnswer && spec.answer.d === 1) return Math.abs(spec.answer.n);
+  return minWeightsFor(spec.rack, spec.answer);
+}
+
 export function minWeightsFor(rack: readonly Frac[], target: Frac): number {
   if (isZero(target)) return 0;
+
   let L = target.d;
   for (const f of rack) L = lcm(L, f.d);
   const values = rack.map((f) => f.n * (L / f.d));

--- a/dynawalla/games/balance/src/puzzle.ts
+++ b/dynawalla/games/balance/src/puzzle.ts
@@ -218,26 +218,47 @@ export function minWeightsFor(rack: readonly Frac[], target: Frac): number {
 }
 
 /**
- * Can a target still be made from the rack, using as many copies of each weight
- * as you like? Coin-change over a common denominator, so it is exact.
+ * How far the search got on "can this target be made from the rack, using as many
+ * copies of each weight as you like": `"yes"` and `"no"` are proofs, `"unknown"` is
+ * the search declining to run.
+ *
+ * **The three values are the point.** This was a `boolean` called `rackCanMake`, and
+ * it returned `true` both for "I made it out of the rack" and for "the goal is past
+ * my cap and I did not look" — one bit standing for a proof and for the absence of
+ * one. Every caller then had to already know which it was holding, and the review
+ * that caught it read the optimistic return as a claim that an impossible board is
+ * solvable. Nothing was actually wrong at runtime, because both call sites act only
+ * on a *proved* `"no"`; but a type that cannot distinguish a proof from an unknown
+ * is a type that will eventually be read as the wrong one.
+ *
+ * Why the optimistic direction is right, and must stay: `verdictFor` reads a proved
+ * dead end as *the child made a mistake* — the dish tips, everything comes back, an
+ * error is recorded. The shipped ladder reaches `913072 − 884`, so a capped search
+ * that answered "no" when it meant "I could not check" charged the founder's own
+ * locked room to the child. Not knowing has to fail the safe way. The beam is still
+ * telling them the truth either way, and `remainingFor` still says what is missing.
+ *
+ * The cap is a real limit, not a guess: this is a coin-change table over a common
+ * denominator, so it allocates `goal + 1` entries, and `goal` is the answer scaled
+ * by the LCM of every denominator on the rack.
  */
-export function rackCanMake(rack: readonly Frac[], target: Frac): boolean {
-  if (isZero(target)) return true;
+export type RackReach = "yes" | "no" | "unknown";
+
+/** Widest coin-change table this will build, in entries. */
+const RACK_SEARCH_CAP = 4096;
+
+export function rackReach(rack: readonly Frac[], target: Frac): RackReach {
+  if (isZero(target)) return "yes";
   let L = target.d;
   for (const f of rack) L = lcm(L, f.d);
   const goal = Math.abs(target.n) * (L / target.d);
-  if (goal <= 0) return false;
-  // Past the search cap this function does not know, and `false` here is read by
-  // `verdictFor` as a *proved* dead end: the dish tips, everything comes back and
-  // an error is recorded. The shipped ladder reaches `913072 − 884`, so "I could
-  // not check" used to be charged to the child as a mistake. Not knowing must
-  // fail the safe way — the beam is still telling them the truth either way.
-  if (goal > 4096) return true;
+  if (goal <= 0) return "no";
+  if (goal > RACK_SEARCH_CAP) return "unknown";
   const sign = target.n < 0 ? -1 : 1;
   const vals = rack
     .filter((f) => f.n !== 0 && (f.n < 0 ? -1 : 1) === sign)
     .map((f) => Math.abs(f.n) * (L / f.d));
-  if (vals.length === 0) return false;
+  if (vals.length === 0) return "no";
   const ok = new Array<boolean>(goal + 1).fill(false);
   ok[0] = true;
   for (let i = 1; i <= goal; i++) {
@@ -248,7 +269,7 @@ export function rackCanMake(rack: readonly Frac[], target: Frac): boolean {
       }
     }
   }
-  return ok[goal];
+  return ok[goal] ? "yes" : "no";
 }
 
 /**
@@ -276,7 +297,8 @@ export function verdictFor(
   const crossed = startNetSign !== 0 && net !== 0 && net !== startNetSign;
   if (spec.kind === "hang" || crossed) return "overshot";
   const left = remainingFor(spec, placed);
-  if (left && !rackCanMake(spec.rack, left)) return "deadEnd";
+  // Only a PROVED dead end ends the attempt. `"unknown"` continues: see `rackReach`.
+  if (left && rackReach(spec.rack, left) === "no") return "deadEnd";
   return "continue";
 }
 

--- a/dynawalla/games/balance/src/unstuck.test.ts
+++ b/dynawalla/games/balance/src/unstuck.test.ts
@@ -29,8 +29,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import type { Question } from "./contract.ts";
-import { frac, toKey, parseFrac } from "./frac.ts";
+import type { DifficultyRequest, Question } from "./contract.ts";
+import { frac, isZero, toKey, parseFrac } from "./frac.ts";
+import type { Frac } from "./frac.ts";
 import {
   MAX_COPIES,
   boardFor,
@@ -43,6 +44,7 @@ import type { BoardLimits } from "./adapter.ts";
 import {
   PAN_PEG,
   answeredKey,
+  minWeightsForSpec,
   isBalanced,
   netTorque,
   rackCanMake,
@@ -60,8 +62,8 @@ import {
   numeralCapacity,
   radiusForChars,
 } from "./layout.ts";
-import { pull, TRIES } from "./pull.ts";
-import { makePacing } from "./pacing.ts";
+import { pull, STEP, TRIES, TRIES_PER_RUNG } from "./pull.ts";
+import { afterBoard, afterUnshowableBoard, makePacing } from "./pacing.ts";
 import { makeStubHost } from "./stubHost.ts";
 // The host's own item service. `ladder()` is the sixty-six rungs that ship;
 // `answerText` and `choicesFor` are what fill `Question.answer` and
@@ -129,34 +131,82 @@ function sweep(seeds = SEEDS): Served[] {
  * Is there something a child can do here that gets them out?
  *
  * The whole failure was a board with no such thing, so this is the assertion the
- * game turns on. Three parts, and all three were false on `88965 ÷ 9`:
+ * game turns on — and it is computed **without calling `whyUnsolvable`**, which is
+ * the function `boardFor` uses to decide. That independence is not fussiness. The
+ * first version of this helper delegated to `whyUnsolvable`, and measured against
+ * two mutants — the original `÷`-as-whitespace lexer, plus `whyUnsolvable` stubbed
+ * to `null` — the founder's own locked room and all 400 division boards in the
+ * sweep **passed**. A proof checked against itself proves nothing.
+ *
+ * So, from first principles:
  *
  *   1. There is brass on the rail to pick up at all.
- *   2. The contract's own answer solves the board — `whyUnsolvable` is the same
- *      proof `boardFor` runs, so this is a check that the proof is not vacuous.
- *   3. No single placement can strand the child: after any weight lands, the
- *      board is either solved, or the beam swung and everything comes back, or
- *      the answer is still reachable.
+ *   2. The board levels when the answer is put where the answer goes — computed
+ *      here with `isBalanced`, the same exact-rational function the game itself
+ *      uses to decide a child is right.
+ *   3. What has to go in the dish is something the rail can supply.
+ *
+ * `rackCanMake` is deliberately not used for (3): it answers `true` above its
+ * search cap, which is right for the game (not knowing must not be charged to a
+ * child as a dead end) and useless in a test. This counts copies directly.
  */
 function legalMoveExists(spec: PuzzleSpec): string | null {
   if (spec.rack.length === 0) return "the rack is empty";
-  const why = whyUnsolvable(spec, spec.answer);
-  if (why) return why;
-  if (spec.kind !== "fill" || spec.fillSide === null) return null;
-  const startNetSign = Math.sign(netTorque(spec, [], null).n);
-  for (const value of spec.rack) {
-    const placed: PlacedItem[] = [
-      { id: "p", side: spec.fillSide, peg: PAN_PEG, value },
-    ];
-    const verdict = verdictFor(spec, placed, null, startNetSign);
-    if (verdict === "solved" || verdict === "overshot" || verdict === "deadEnd") continue;
-    // `continue` means more brass is on its way. The answer had better still be
-    // reachable from where that leaves the beam.
-    const left = remainingFor(spec, placed);
-    if (!left) return `placing ${toKey(value)} left nothing to compute`;
-    if (left.n <= 0 && spec.answer.n > 0) return `placing ${toKey(value)} overshot without saying so`;
+
+  if (spec.kind === "declare") {
+    if (!spec.rack.some((r) => toKey(r) === toKey(spec.answer))) {
+      return "the answer is not on the rack";
+    }
+    return isBalanced(spec, [], spec.answer)
+      ? null
+      : "declaring the answer does not level the beam";
   }
-  return null;
+  if (spec.kind !== "fill" || spec.fillSide === null) return null;
+
+  const side = spec.fillSide;
+  const put = (values: readonly Frac[]): PlacedItem[] =>
+    values.map((value, i) => ({ id: `p${String(i)}`, side, peg: PAN_PEG, value }));
+
+  if (spec.countAnswer) {
+    const unit = spec.rack[0];
+    if (!unit || isZero(unit)) return "the rack has nothing to count";
+    if (spec.answer.d !== 1 || spec.answer.n < 1) return "a count that is not a whole number";
+    const n = spec.answer.n;
+    if (!isBalanced(spec, put(new Array<Frac>(n).fill(unit)), null)) {
+      return `${String(n)} of ${toKey(unit)} does not level the beam`;
+    }
+    return isBalanced(spec, put(new Array<Frac>(n - 1).fill(unit)), null)
+      ? "one fewer weight also levels it, so the count is not the answer"
+      : null;
+  }
+
+  // The exact object the dish is short by. Found by trying every disc on the rail
+  // and every pair of them — enough for every board this game builds, and it is a
+  // direct search rather than a call into the code under test.
+  for (const a of spec.rack) {
+    if (isBalanced(spec, put([a]), null)) {
+      return valueMatchesAnswer(spec, a) ? null : `${toKey(a)} levels it but the answer is ${toKey(spec.answer)}`;
+    }
+  }
+  for (const a of spec.rack) {
+    for (const b of spec.rack) {
+      if (isBalanced(spec, put([a, b]), null)) return null;
+    }
+  }
+  if (isZero(spec.answer) && isBalanced(spec, [], null)) {
+    return spec.rack.some((r) => isZero(r)) ? null : "the answer is nothing and there is no zero on the rail";
+  }
+  return `no weight or pair of weights on the rail levels this board (answer ${toKey(spec.answer)})`;
+}
+
+/**
+ * The disc that levels the board has to be the answer the host asked for — up to
+ * sign, because a balloon dish holds negative mass and `8 − □ = 4` is answered 4.
+ * This is the check the locked room failed: 88,974 of brass, answer 9,885.
+ */
+function valueMatchesAnswer(spec: PuzzleSpec, placed: Frac): boolean {
+  const a = spec.answer;
+  return (placed.n === a.n && placed.d === a.d) || (placed.n === -a.n && placed.d === a.d);
 }
 
 // ------------------------------------------------------------ THE LOCKED ROOM
@@ -345,17 +395,50 @@ test("division is no longer the ten rungs a child cannot leave", () => {
 
 // ------------------------------------------------------- THERE IS ALWAYS A BOARD
 
+/**
+ * The stub host with its pre-built board taken off.
+ *
+ * `makeStubHost` attaches a whole `PuzzleSpec` to every question, and `boardFor`
+ * returns it untouched — so driving `pull` through the stub as it comes exercises
+ * none of the lexer, none of the four board builders and none of the proof.
+ * Measured: with the stub as-is, `TRIES = 1` passed the "always ends with a board"
+ * test. Stripping the spec is also what the real host does, since it has no idea
+ * what a balance is.
+ */
+function bareStub(seed: number): (r: DifficultyRequest) => Question {
+  const host = makeStubHost({ seed });
+  return (r) => {
+    const { spec: _spec, ...bare } = host.next(r) as Question & { spec?: unknown };
+    return bare;
+  };
+}
+
 test("pull always ends with a board that has a legal move, at every rung", () => {
   for (let rung = 0; rung <= 1.0001; rung += 0.02) {
-    const host = makeStubHost({ seed: 0x9885 });
     const level = Math.min(1, rung);
-    const got = pull((r) => host.next(r), { level, floor: 0, streak: 0 }, NO_LIMITS);
+    const got = pull(bareStub(0x9885), { level, floor: 0, streak: 0 }, NO_LIMITS);
     assert.equal(
       legalMoveExists(got.spec),
       null,
       `at rung ${level.toFixed(2)} the game produced a board with no move`,
     );
+    assert.ok(got.question, `at rung ${level.toFixed(2)} nothing the host offered could be shown`);
   }
+});
+
+test("pull runs the real board builders — the stub's own spec is not a free pass", () => {
+  // `boardFor` returns an attached `PuzzleSpec` untouched, which is how the
+  // standalone shell plays the local ladder. That bypass skips the proof, so a
+  // board the shell supplies is trusted rather than checked. Asserted here so the
+  // bypass is a decision and not an accident, and so the sweep above is known to
+  // be running the parser rather than reading a spec off the wire.
+  const withSpec = makeStubHost({ seed: 4 }).next({ difficulty: 0.3 });
+  assert.ok((withSpec as { spec?: unknown }).spec, "the stub host stopped attaching a spec");
+  const bare = bareStub(4)({ difficulty: 0.3 });
+  assert.equal((bare as { spec?: unknown }).spec, undefined);
+  const built = boardFor(bare, NO_LIMITS);
+  assert.ok(built.ok, `the parser could not rebuild a local-ladder board: ${built.ok ? "" : built.detail}`);
+  assert.equal(legalMoveExists(built.spec), null);
 });
 
 test("a host that refuses everything still leaves the child something to do", () => {
@@ -439,10 +522,132 @@ test("refusals step DOWN the ladder, never permanently cap it", () => {
   const got = pull(refuseFirstFive, makePacing(0.8), NO_LIMITS);
   assert.ok(got.question, "never recovered");
   assert.equal(asked.length, 6);
-  // Four at the rung it was standing on, then a rung down.
-  assert.equal(new Set(asked.slice(0, 4)).size, 1, `the first four draws asked ${asked.slice(0, 4).join(",")}`);
-  assert.ok(asked[4] < asked[0], "the fifth draw did not step down");
-  assert.ok(asked[4] > 0.7, `stepped down ${(asked[0] - asked[4]).toFixed(3)} of the ladder in one go`);
+  // `TRIES_PER_RUNG` draws at the rung it was standing on, then a step down.
+  const atFirstRung = asked.slice(0, TRIES_PER_RUNG);
+  assert.equal(new Set(atFirstRung).size, 1, `the first draws asked ${atFirstRung.join(",")}`);
+  assert.ok(asked[TRIES_PER_RUNG] < asked[0], "the draw after the first rung did not step down");
+  assert.ok(
+    asked[0] - asked[TRIES_PER_RUNG] <= STEP + 1e-9,
+    `stepped down ${(asked[0] - asked[TRIES_PER_RUNG]).toFixed(3)} of the ladder in one go`,
+  );
+  // And the loop is not so deep that it drains the host's prefetch pool. The
+  // shared host holds 64 and refills asynchronously, so a loop past that depth
+  // gets `lastServed` back forever; `game-host`'s own note is that every retry
+  // loop in the repo caps at eight.
+  assert.ok(TRIES <= 32, `pull asks the host up to ${String(TRIES)} times for one board`);
+});
+
+test("a dry question pool is not reported against, and is not retried out of", () => {
+  // Past its prefetch depth the shared host hands back `{ ...lastServed, id: "" }`
+  // and drops any report carrying an empty id on the floor. So a pack that treats
+  // that as a real question lets a child solve a board and records nothing, while
+  // believing it reported — and retrying is pointless, because the same item comes
+  // back every time.
+  let asked = 0;
+  const dry = (): Question => {
+    asked++;
+    return { id: "", prompt: "3 + 4", answer: "7", distractors: [], domain: "add-sub", difficulty: 0.1 };
+  };
+  const got = pull(dry, makePacing(0.1), NO_LIMITS);
+  assert.equal(asked, 1, `asked a dry pool ${String(asked)} times`);
+  assert.equal(got.question, null, "an id-less question was accepted as reportable");
+  assert.equal(legalMoveExists(got.spec), null, "and the board it fell back to has no move");
+});
+
+test("a board the host never served does not climb the ladder", () => {
+  // The fallback board is a one-move `8 = 2 + □`, so a clean solve on it is
+  // guaranteed. Running it through `afterBoard` would climb and, after four of
+  // them, raise a permanent floor into the region this pack has no picture for —
+  // pinning the child at the top of the ladder solving `2 + 6` forever, off the
+  // strength of a board the host never saw.
+  let p = { level: 0.95, floor: 0.9, streak: 3 };
+  const climbed = afterBoard(p, 0);
+  assert.ok(climbed.level > p.level, "the control is wrong: a clean solve does climb");
+
+  for (let i = 0; i < 4; i++) p = afterUnshowableBoard(p) as typeof p;
+  assert.ok(p.level < 0.95, "four unshowable boards did not step the request down");
+  assert.equal(p.streak, 0, "an unshowable board counted towards a clean streak");
+  assert.equal(p.floor, 0.9, "an unshowable board moved the floor the host is promised");
+  // And the walk-down is bounded below.
+  for (let i = 0; i < 60; i++) p = afterUnshowableBoard(p) as typeof p;
+  assert.ok(p.level >= 0, "the request walked below the bottom of the ladder");
+});
+
+test("the reported string is one the host's own judge would accept", () => {
+  // The host does not trust the pack's `correct` flag: it re-parses `answered` and
+  // re-checks it. So every board kind has to report the string the *contract*
+  // asked for, and two of them did not.
+  const cases: Array<[string, string, string]> = [
+    // A balloon dish holds negative mass. `8 − □ = 4` is answered 4, and this
+    // reported `-4`, which the judge rejects — a child who solved the board was
+    // recorded wrong and stepped down for it.
+    ["8 − □ = 4", "4", "4"],
+    ["47 + □ = 68", "21", "21"],
+    ["3 × 5", "15", "15"],
+  ];
+  for (const [prompt, answer, expected] of cases) {
+    const spec = specFromQuestion({
+      id: `j-${prompt}`,
+      prompt,
+      answer,
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0.3,
+    });
+    assert.ok(spec, prompt);
+    const need = remainingFor(spec, []);
+    assert.ok(need);
+    const dish: PlacedItem[] = [
+      { id: "p", side: spec.fillSide as Side, peg: PAN_PEG, value: need },
+    ];
+    assert.ok(isBalanced(spec, dish, null), `${prompt}: the solving placement does not level it`);
+    assert.equal(
+      answeredKey(spec, dish, null),
+      expected,
+      `${prompt}: solved the board and reported something else`,
+    );
+  }
+});
+
+test("a spilled dish is reported as what was in it, not as an empty one", () => {
+  // `spill()` tosses every weight out and then reports. Reading the dish *after*
+  // that reports the empty sum, `"0"` — and on a zero-answer board `"0"` is the
+  // correct answer, which the host re-judges and accepts. Measured over the real
+  // ladder: 43 zero-answer boards, 8 wrong discs each, 344 of 344 recorded as
+  // correct. So the dish is read first, and this is that value.
+  const spec = specFromQuestion({
+    id: "z-report",
+    prompt: "1 − 1",
+    answer: "0",
+    distractors: [],
+    domain: "add-sub",
+    difficulty: 0,
+  });
+  assert.ok(spec);
+  const wrong = spec.rack.find((r) => !isZero(r));
+  assert.ok(wrong, "a zero-answer rack with nothing wrong on it cannot test this");
+  const dish: PlacedItem[] = [
+    { id: "p", side: spec.fillSide as Side, peg: PAN_PEG, value: wrong },
+  ];
+  assert.notEqual(
+    answeredKey(spec, dish, null),
+    "0",
+    "a wrong disc in the dish reports the correct answer",
+  );
+  assert.equal(answeredKey(spec, [], null), "0", "an empty dish is what used to be sent");
+});
+
+test("a clean-solve gem is not handed out for a board that takes eleven drags", () => {
+  const spec = specFromQuestion({
+    id: "gem",
+    prompt: "□ × 15 = 165",
+    answer: "11",
+    distractors: [],
+    domain: "algebra",
+    difficulty: 0.5,
+  });
+  assert.ok(spec);
+  assert.equal(minWeightsForSpec(spec), 11);
 });
 
 // ------------------------------------------------------------- REPRESENTATIONS
@@ -638,6 +843,24 @@ test("the statement forms the curriculum already emits still build", () => {
     });
     assert.ok(spec, `${prompt} = ${answer} is no longer buildable`);
     assert.equal(legalMoveExists(spec), null, `${prompt} = ${answer}`);
+  }
+});
+
+test("the proof and the independent oracle agree on every board in the sweep", () => {
+  // `legalMoveExists` above is written from first principles precisely so it can
+  // disagree with `whyUnsolvable`, which is what `boardFor` decides on. If the two
+  // ever part company one of them is wrong, and finding out from a child is the
+  // outcome this whole file exists to prevent.
+  for (const s of sweep(6)) {
+    const board = boardFor(s.question, NO_LIMITS);
+    if (!board.ok) continue;
+    const proof = whyUnsolvable(board.spec, board.spec.answer);
+    const oracle = legalMoveExists(board.spec);
+    assert.equal(
+      proof === null,
+      oracle === null,
+      `${s.question.prompt} = ${s.question.answer}: the proof says ${String(proof)} and the oracle says ${String(oracle)}`,
+    );
   }
 });
 

--- a/dynawalla/games/balance/src/unstuck.test.ts
+++ b/dynawalla/games/balance/src/unstuck.test.ts
@@ -67,12 +67,24 @@ import { afterBoard, afterUnshowableBoard, makePacing } from "./pacing.ts";
 import { makeStubHost } from "./stubHost.ts";
 // The host's own item service. `ladder()` is the sixty-six rungs that ship;
 // `answerText` and `choicesFor` are what fill `Question.answer` and
-// `Question.distractors`; the prompt is assembled the way `items.ts` assembles
-// it, glyph for glyph, including U+00F7 for division.
+// `Question.distractors`.
+//
+// **The prompt is assembled by calling the host's own `drawStatement`, not by
+// interpolating `a OP b` here.** This file used to do the latter, and it was the
+// twenty-ninth harness in this repository to make that mistake — `items.ts:116`
+// names the other twenty-eight: "all 28 stub hosts write `a OP b` and never a
+// blank". The cost was specific. `dw.alg.equality.missing-addend` is an active
+// row that the host serves as `7 + □ = 12`; reconstructed as `7 + 12` it is a
+// statement the adapter is right to refuse, so all three of its levels showed up
+// as content this pack cannot draw — when in fact a beam is the best picture of a
+// missing addend there is. A harness that writes the prompt itself measures the
+// harness.
 import {
   answerText,
   binaryOperator,
+  blankPosition,
   choicesFor,
+  drawStatement,
   ladder,
   operandsOf,
 } from "../../../dynawalla-app/src/packs/items.ts";
@@ -113,7 +125,12 @@ function sweep(seeds = SEEDS): Served[] {
         operator: operator.glyph,
         question: {
           id: `${exercise.exerciseId}#${String(s)}`,
-          prompt: `${operands[0]} ${operator.glyph} ${operands[1]}`,
+          prompt: drawStatement(
+            operands[0],
+            operands[1],
+            operator.glyph,
+            blankPosition(exercise.prompt.key) ?? "none",
+          ),
           answer: canonical,
           distractors: choicesFor(exercise, places)
             .map((c) => c.text)

--- a/dynawalla/games/balance/src/unstuck.test.ts
+++ b/dynawalla/games/balance/src/unstuck.test.ts
@@ -47,7 +47,7 @@ import {
   minWeightsForSpec,
   isBalanced,
   netTorque,
-  rackCanMake,
+  rackReach,
   remainingFor,
   verdictFor,
 } from "./puzzle.ts";
@@ -163,9 +163,11 @@ function sweep(seeds = SEEDS): Served[] {
  *      uses to decide a child is right.
  *   3. What has to go in the dish is something the rail can supply.
  *
- * `rackCanMake` is deliberately not used for (3): it answers `true` above its
+ * `rackReach` is deliberately not used for (3): it answers `"unknown"` above its
  * search cap, which is right for the game (not knowing must not be charged to a
- * child as a dead end) and useless in a test. This counts copies directly.
+ * child as a dead end) and useless in a test. This counts copies directly, so the
+ * guarantee holds at every magnitude the ladder reaches — including the founder's
+ * own `88965 ÷ 9`, whose remainder is far past that cap.
  */
 function legalMoveExists(spec: PuzzleSpec): string | null {
   if (spec.rack.length === 0) return "the rack is empty";
@@ -996,13 +998,25 @@ test("the disc grows for a wide numeral, and the frame still holds", () => {
 });
 
 test("a remainder too big to search is not charged to the child as a dead end", () => {
-  // `rackCanMake` is a coin-change search with a cap on it, and `verdictFor` reads
-  // a `false` from it as a *proved* dead end: the dish tips, everything comes
+  // `rackReach` is a coin-change search with a cap on it, and `verdictFor` reads
+  // a `"no"` from it as a *proved* dead end: the dish tips, everything comes
   // back, and an error is recorded against the child. So "I could not check"
   // must not answer "no". The shipped ladder reaches `913072 − 884`, and a
   // measurement-division board with a heavy unit crosses the cap on its first
   // correct placement.
-  assert.equal(rackCanMake([frac(3)], frac(90000)), true, "a target past the cap is reported impossible");
+  //
+  // Asserted as `"unknown"` and not merely "not no": the whole reason this is a
+  // tri-state is that the optimistic answer here is the ABSENCE of a proof, and a
+  // test that accepted `"yes"` too would pass just as well against a cap raised
+  // high enough to search — which is a different guarantee than the one this
+  // names. 90,000 is past the cap with a rack of 3s; it also happens to be
+  // divisible by 3, so a search WOULD say yes, which is exactly why the weaker
+  // assertion would not notice the cap being gone.
+  assert.equal(
+    rackReach([frac(3)], frac(90000)),
+    "unknown",
+    "a target past the cap was searched, or reported impossible",
+  );
 
   const spec = specFromQuestion({
     id: "big-count",

--- a/dynawalla/games/balance/src/unstuck.test.ts
+++ b/dynawalla/games/balance/src/unstuck.test.ts
@@ -1,0 +1,899 @@
+// The locked room.
+//
+// The founder played COUNTERPOISE, worked out `88965 ÷ 9 = 9885`, and could not
+// get out of the board:
+//
+//     "I had a correct answer not accepted and it wouldn't let me put anything
+//      on the scale and I was just stuck 88965/9 == 9885 .. but it rejected that
+//      and every other possible choice and I couldn't go anywhere."
+//
+// This file is the gate on that, and on the three design notes that came with it.
+// Every test in here runs the **real** shipping ladder — `ladder()`, `answerText`
+// and `choicesFor` out of `dynawalla-app/src/packs/items.ts`, over the real
+// generators in `@dynawalla/curriculum` — because a stand-in is exactly how the
+// bug survived. `fairness.test.ts` builds host-*shaped* questions by hand and it
+// only ever built additions, so nothing in this package had ever seen a `÷`.
+//
+// Measured against the code this replaced, on 66 rungs × 40 seeds:
+//
+//     +   640 of 640 boards solvable
+//     −   800 of 800
+//     ×   800 of 800   — but every one of them a copy: the answer was engraved
+//                        on the dish and the child only had to match it
+//     ÷     0 of 400   — every division board in the game unsolvable, and
+//                        unleavable, because a board is only left by solving it
+//
+// Ten of the sixty-six active rungs, at ordinates 0.34 through 0.86, were a
+// locked room. A child who climbs is guaranteed to reach one.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import type { Question } from "./contract.ts";
+import { frac, toKey, parseFrac } from "./frac.ts";
+import {
+  MAX_COPIES,
+  boardFor,
+  lastResortBoard,
+  specFromQuestion,
+  whyUnsolvable,
+  widestNumeral,
+} from "./adapter.ts";
+import type { BoardLimits } from "./adapter.ts";
+import {
+  PAN_PEG,
+  answeredKey,
+  isBalanced,
+  netTorque,
+  rackCanMake,
+  remainingFor,
+  verdictFor,
+} from "./puzzle.ts";
+import type { PlacedItem, PuzzleSpec, Side } from "./puzzle.ts";
+import {
+  NUMERAL_FACE,
+  NUMERAL_MIN_PX,
+  charsAtRadius,
+  fittedNumeralPx,
+  idealNumeralPx,
+  layoutForViewport,
+  numeralCapacity,
+  radiusForChars,
+} from "./layout.ts";
+import { pull, TRIES } from "./pull.ts";
+import { makePacing } from "./pacing.ts";
+import { makeStubHost } from "./stubHost.ts";
+// The host's own item service. `ladder()` is the sixty-six rungs that ship;
+// `answerText` and `choicesFor` are what fill `Question.answer` and
+// `Question.distractors`; the prompt is assembled the way `items.ts` assembles
+// it, glyph for glyph, including U+00F7 for division.
+import {
+  answerText,
+  binaryOperator,
+  choicesFor,
+  ladder,
+  operandsOf,
+} from "../../../dynawalla-app/src/packs/items.ts";
+import { seedFrom } from "../../../packs/shared/curriculum/src/index.ts";
+
+const NO_LIMITS: BoardLimits = { maxNumeralChars: Number.POSITIVE_INFINITY };
+
+/** Every question the shipping ladder can put in front of this pack. */
+type Served = { question: Question; rung: string; ordinate: number; operator: string };
+
+const SEEDS = 40;
+
+function sweep(seeds = SEEDS): Served[] {
+  const rungs = ladder();
+  const out: Served[] = [];
+  for (let i = 0; i < rungs.length; i++) {
+    const rung = rungs[i];
+    const ordinate = i / (rungs.length - 1);
+    for (let s = 0; s < seeds; s++) {
+      const exercise = rung.family.generate({
+        skillId: rung.node.id,
+        level: rung.level,
+        seed: seedFrom("counterpoise-sweep", "dynawalla.balance", String(s)),
+        params: rung.params,
+        forms: ["free-entry"],
+      });
+      const operator = binaryOperator(exercise.prompt.key);
+      if (!operator) continue;
+      const schema = exercise.schema;
+      const places =
+        schema.kind === "integer" || schema.kind === "columnAlgorithm" ? schema.decimalPlaces : 0;
+      const canonical = answerText(exercise.answer.canonical, places);
+      if (canonical === null) continue;
+      const operands = operandsOf(exercise);
+      out.push({
+        rung: `${rung.node.id}#${String(rung.level)}`,
+        ordinate,
+        operator: operator.glyph,
+        question: {
+          id: `${exercise.exerciseId}#${String(s)}`,
+          prompt: `${operands[0]} ${operator.glyph} ${operands[1]}`,
+          answer: canonical,
+          distractors: choicesFor(exercise, places)
+            .map((c) => c.text)
+            .filter((t) => t !== canonical),
+          domain: "add-sub",
+          difficulty: ordinate,
+        },
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Is there something a child can do here that gets them out?
+ *
+ * The whole failure was a board with no such thing, so this is the assertion the
+ * game turns on. Three parts, and all three were false on `88965 ÷ 9`:
+ *
+ *   1. There is brass on the rail to pick up at all.
+ *   2. The contract's own answer solves the board — `whyUnsolvable` is the same
+ *      proof `boardFor` runs, so this is a check that the proof is not vacuous.
+ *   3. No single placement can strand the child: after any weight lands, the
+ *      board is either solved, or the beam swung and everything comes back, or
+ *      the answer is still reachable.
+ */
+function legalMoveExists(spec: PuzzleSpec): string | null {
+  if (spec.rack.length === 0) return "the rack is empty";
+  const why = whyUnsolvable(spec, spec.answer);
+  if (why) return why;
+  if (spec.kind !== "fill" || spec.fillSide === null) return null;
+  const startNetSign = Math.sign(netTorque(spec, [], null).n);
+  for (const value of spec.rack) {
+    const placed: PlacedItem[] = [
+      { id: "p", side: spec.fillSide, peg: PAN_PEG, value },
+    ];
+    const verdict = verdictFor(spec, placed, null, startNetSign);
+    if (verdict === "solved" || verdict === "overshot" || verdict === "deadEnd") continue;
+    // `continue` means more brass is on its way. The answer had better still be
+    // reachable from where that leaves the beam.
+    const left = remainingFor(spec, placed);
+    if (!left) return `placing ${toKey(value)} left nothing to compute`;
+    if (left.n <= 0 && spec.answer.n > 0) return `placing ${toKey(value)} overshot without saying so`;
+  }
+  return null;
+}
+
+// ------------------------------------------------------------ THE LOCKED ROOM
+
+/** The founder's board, exactly as the host writes it. U+00F7, not a slash. */
+const FOUNDER: Question = {
+  id: "founder-88965-div-9",
+  prompt: "88965 ÷ 9",
+  answer: "9885",
+  distractors: ["9880", "9890", "88974"],
+  domain: "add-sub",
+  difficulty: 0.615,
+};
+
+test("the founder's board: 88965 ÷ 9 = 9885 has a move, and 9885 is it", () => {
+  const board = boardFor(FOUNDER, NO_LIMITS);
+  assert.ok(
+    board.ok,
+    `COUNTERPOISE cannot build the board the founder was stuck on: ${board.ok ? "" : board.detail}`,
+  );
+  const spec = board.spec;
+
+  // Against the old adapter this was a `fill` board holding 88965 AND 9 in the
+  // same dish — 88,974 of brass against a contract answer of 9,885. Nothing on
+  // the rack levelled it, and a board is only left by solving it.
+  assert.equal(legalMoveExists(spec), null);
+
+  // The apparatus: nine identical sealed crates against the dividend.
+  assert.equal(spec.kind, "declare");
+  const crates = spec.fixed.filter((f) => f.kind === "crate");
+  assert.equal(crates.length, 9, "the divisor is the number of crates");
+  const dividend = spec.fixed.find((f) => f.kind === "weight");
+  assert.ok(dividend && dividend.kind === "weight");
+  assert.equal(toKey(dividend.value), "88965");
+  assert.notEqual(
+    crates[0].side,
+    dividend.side,
+    "the crates and the dividend are in the same dish, so nothing is being balanced",
+  );
+
+  // And the correct answer is accepted. This is the sentence in the report.
+  assert.ok(
+    isBalanced(spec, [], frac(9885)),
+    "declaring 9885 still does not level the beam",
+  );
+  assert.ok(
+    spec.rack.some((r) => toKey(r) === "9885"),
+    `9885 is not on the rack: ${spec.rack.map(toKey).join(" ")}`,
+  );
+  assert.equal(spec.movementName, "Identical Crates");
+});
+
+test("every board the shipping ladder can serve has a legal move", () => {
+  const served = sweep();
+  assert.ok(served.length > 2000, `the sweep only produced ${String(served.length)} questions`);
+
+  const byRung = new Map<string, { shown: number; refused: number; op: string; ord: number }>();
+  for (const s of served) {
+    const row = byRung.get(s.rung) ?? { shown: 0, refused: 0, op: s.operator, ord: s.ordinate };
+    const board = boardFor(s.question, NO_LIMITS);
+    if (!board.ok) {
+      row.refused++;
+      byRung.set(s.rung, row);
+      continue;
+    }
+    row.shown++;
+    byRung.set(s.rung, row);
+    const stuck = legalMoveExists(board.spec);
+    assert.equal(
+      stuck,
+      null,
+      `${s.rung} (${s.question.prompt} = ${s.question.answer}) built a board with no way out: ${String(stuck)}`,
+    );
+  }
+
+  // What the pack can and cannot show, pinned by rung.
+  //
+  // A refusal is not a lockout — `pull` asks again, and the test below proves a
+  // board always arrives — but it IS content a child does not get, so the list is
+  // written down here rather than discovered later. These seven rungs are
+  // multiplications where **neither factor is twelve or under**: `988 × 53` has no
+  // countable pile of identical weights, and a beam that sums has no other honest
+  // picture of a product. They were "playable" before this change only in the
+  // sense that the answer was engraved on the dish and a child could copy it.
+  const dead = [...byRung.entries()]
+    .filter(([, r]) => r.shown === 0)
+    .map(([k]) => k)
+    .sort();
+  assert.deepEqual(dead, [
+    "dw.mul.multidigit.long-multiplication#0",
+    "dw.mul.multidigit.long-multiplication#1",
+    "dw.mul.multidigit.long-multiplication#2",
+    "dw.mul.multidigit.times-two-digit#0",
+    "dw.mul.multidigit.times-two-digit#1",
+    "dw.mul.multidigit.times-two-digit#2",
+    "dw.mul.multidigit.times-two-digit#3",
+  ]);
+  // Every one of them refused for the stated reason, not for some other one.
+  for (const rung of dead) {
+    const example = served.find((s) => s.rung === rung);
+    assert.ok(example);
+    const board = boardFor(example.question, NO_LIMITS);
+    assert.equal(board.ok, false);
+    assert.match(board.ok ? "" : board.detail, /neither factor is 12 or under/u);
+  }
+  // And two thirds of the ladder is fully served, which it was not before: the
+  // ten division rungs were 0 of 400.
+  const whole = [...byRung.values()].filter((r) => r.refused === 0).length;
+  assert.equal(byRung.size, 66);
+  assert.ok(whole >= 53, `only ${String(whole)} of ${String(byRung.size)} rungs are served in full`);
+});
+
+test("zero has an object, so the easiest rungs are not a third refused", () => {
+  // `7 − 7 = 0`, `4 − 0 = 4`, `0 × 4 = 0`. Thirteen of every forty
+  // `subtract-within-ten` items answer zero, and a zero answer on a fill board
+  // means the arm is already flat — there is nothing to add. Refusing them cost a
+  // third of the content a six-year-old plays, so zero is a disc that weighs
+  // nothing and dropping it in says "this dish needs nothing".
+  for (const [prompt, answer] of [
+    ["7 − 7", "0"],
+    ["0 × 4", "0"],
+    ["4 × 0", "0"],
+    ["9 − 0", "9"],
+  ] as const) {
+    const spec = specFromQuestion({
+      id: `z-${prompt}`,
+      prompt,
+      answer,
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0.02,
+    });
+    assert.ok(spec, `${prompt} = ${answer} is refused`);
+    assert.equal(legalMoveExists(spec), null, `${prompt} = ${answer}`);
+    if (answer === "0") {
+      assert.ok(
+        spec.rack.some((r) => toKey(r) === "0"),
+        `${prompt}: the answer is zero and there is no zero on the rail`,
+      );
+      // The board a child sees: already level, and the correct move is nothing.
+      assert.ok(isBalanced(spec, [], null), `${prompt}: the arm is not flat to begin with`);
+    }
+  }
+  // And a zero answer with a non-zero board is still refused: that would be a
+  // misread statement, which is the whole class of bug this file closed.
+  const lying = boardFor({
+    id: "z-lie",
+    prompt: "7 − 3",
+    answer: "0",
+    distractors: [],
+    domain: "add-sub",
+    difficulty: 0,
+  });
+  assert.equal(lying.ok, false);
+});
+
+test("division is no longer the ten rungs a child cannot leave", () => {
+  const division = sweep().filter((s) => s.operator === "÷");
+  assert.ok(division.length > 300, `only ${String(division.length)} division items in the sweep`);
+  let shown = 0;
+  const refusedDivisors = new Set<string>();
+  for (const s of division) {
+    const board = boardFor(s.question, NO_LIMITS);
+    if (!board.ok) {
+      // The only sanctioned refusal is a divisor that will not fit in a dish.
+      const divisor = /÷\s*(\d+)/u.exec(s.question.prompt)?.[1] ?? "?";
+      assert.ok(
+        Number(divisor) > MAX_COPIES,
+        `${s.question.prompt} was refused with a divisor of ${divisor}, which fits in a dish: ${board.detail}`,
+      );
+      refusedDivisors.add(divisor);
+      continue;
+    }
+    shown++;
+    assert.equal(legalMoveExists(board.spec), null, s.question.prompt);
+  }
+  // Was 0 of 400. Everything still refused is a two-digit divisor: seventy
+  // crates in one dish is not a picture, and that is a declared ceiling rather
+  // than a locked room, because `pull` asks again.
+  assert.ok(
+    shown / division.length > 0.5,
+    `only ${String(shown)} of ${String(division.length)} division boards can be shown`,
+  );
+  for (const d of refusedDivisors) assert.ok(Number(d) > MAX_COPIES);
+});
+
+// ------------------------------------------------------- THERE IS ALWAYS A BOARD
+
+test("pull always ends with a board that has a legal move, at every rung", () => {
+  for (let rung = 0; rung <= 1.0001; rung += 0.02) {
+    const host = makeStubHost({ seed: 0x9885 });
+    const level = Math.min(1, rung);
+    const got = pull((r) => host.next(r), { level, floor: 0, streak: 0 }, NO_LIMITS);
+    assert.equal(
+      legalMoveExists(got.spec),
+      null,
+      `at rung ${level.toFixed(2)} the game produced a board with no move`,
+    );
+  }
+});
+
+test("a host that refuses everything still leaves the child something to do", () => {
+  // The last line of defence. A host serving nothing this game can draw — a
+  // curriculum that has moved on, a wire fault, a pack shipped too old — must
+  // still put brass on the screen, because there is no way to skip a board.
+  let asked = 0;
+  const nonsense = (): Question => {
+    asked++;
+    return {
+      id: `junk-${String(asked)}`,
+      // Notation nobody taught this file. It is refused, out loud, by name.
+      prompt: "log₂ 64",
+      answer: "6",
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0.5,
+    };
+  };
+  const got = pull(nonsense, makePacing(0.5), NO_LIMITS);
+  assert.equal(asked, TRIES, `gave up after ${String(asked)} draws instead of ${String(TRIES)}`);
+  assert.equal(got.question, null, "a fallback board must not be reported against a question id");
+  assert.equal(got.refusals.length, TRIES);
+  assert.equal(got.refusals[0].reason, "unreadable");
+  assert.equal(legalMoveExists(got.spec), null, "the fallback board itself has no move");
+  // And a run of fallbacks is not the same board over and over.
+  const ids = new Set(Array.from({ length: 6 }, (_, i) => lastResortBoard(i).id));
+  assert.equal(ids.size, 6);
+});
+
+test("a refusal costs the child nothing and does not move where they stand", () => {
+  // The step-down inside `pull` is per-board. If it leaked into `Pacing` a child
+  // who happened to be near a division rung would be walked down the ladder for
+  // something the pack could not draw, which is the pack's problem and not
+  // theirs.
+  const pacing = { level: 0.62, floor: 0.5, streak: 4 };
+  const before = { ...pacing };
+  const host = makeStubHost({ seed: 3 });
+  // A host that refuses the first nine draws, so the step-down actually runs.
+  // With a host that never refuses this assertion is vacuous — measured: the
+  // mutant that writes the stepped-down rung straight back into `Pacing` passed.
+  let served = 0;
+  const got = pull(
+    (r) => {
+      served++;
+      if (served <= 9) {
+        return {
+          id: `r${String(served)}`,
+          prompt: "51800 ÷ 70",
+          answer: "740",
+          distractors: [],
+          domain: "add-sub",
+          difficulty: 0.7,
+        };
+      }
+      return host.next(r);
+    },
+    pacing,
+    NO_LIMITS,
+  );
+  assert.equal(got.refusals.length, 9, "the refusals did not happen, so nothing is being tested");
+  assert.deepEqual(pacing, before);
+});
+
+test("refusals step DOWN the ladder, never permanently cap it", () => {
+  // Why not a standing `maxDifficulty` ceiling, which is the right answer in
+  // `polarity`: what this pack cannot show is scattered through the ladder, not
+  // stacked on top of it. A ceiling learned from the first division refusal at
+  // ordinate 0.34 would delete every addition rung above it too.
+  const asked: number[] = [];
+  let served = 0;
+  const host = makeStubHost({ seed: 7 });
+  const refuseFirstFive = (r: { difficulty?: number }): Question => {
+    asked.push(r.difficulty ?? -1);
+    served++;
+    if (served <= 5) {
+      return { id: `x${String(served)}`, prompt: "1 ÷ 0", answer: "1", distractors: [], domain: "d", difficulty: 0.5 };
+    }
+    return host.next(r);
+  };
+  const got = pull(refuseFirstFive, makePacing(0.8), NO_LIMITS);
+  assert.ok(got.question, "never recovered");
+  assert.equal(asked.length, 6);
+  // Four at the rung it was standing on, then a rung down.
+  assert.equal(new Set(asked.slice(0, 4)).size, 1, `the first four draws asked ${asked.slice(0, 4).join(",")}`);
+  assert.ok(asked[4] < asked[0], "the fifth draw did not step down");
+  assert.ok(asked[4] > 0.7, `stepped down ${(asked[0] - asked[4]).toFixed(3)} of the ladder in one go`);
+});
+
+// ------------------------------------------------------------- REPRESENTATIONS
+
+test("multiplication is copies of a weight, not the answer engraved on the board", () => {
+  const q: Question = {
+    id: "mul-3x5",
+    prompt: "3 × 5",
+    answer: "15",
+    distractors: ["8", "35"],
+    domain: "add-sub",
+    difficulty: 0.22,
+  };
+  const spec = specFromQuestion(q);
+  assert.ok(spec);
+  const weights = spec.fixed.filter((f) => f.kind === "weight");
+  assert.equal(weights.length, 3, "three fives, one per group");
+  for (const w of weights) assert.equal(toKey(w.kind === "weight" ? w.value : frac(0)), "5");
+  assert.equal(spec.movementName, "Equal Rows");
+  // The point of the whole change: nothing on the apparatus says 15.
+  for (const w of weights) {
+    assert.notEqual(
+      toKey(w.kind === "weight" ? w.value : frac(0)),
+      "15",
+      "the answer is engraved on the board again",
+    );
+  }
+  assert.equal(legalMoveExists(spec), null);
+});
+
+test("the copy bot dies on multiplication — this is what 'identical' was", () => {
+  // The founder: "'identical' doesn't do much .. you just put the matching
+  // weight on the other side." He was describing the multiplication board: the
+  // old adapter collapsed `6 × 2` into a single 12-weight in the dish, so the
+  // answer was written on the apparatus. A bot that drags the disc matching the
+  // biggest numeral already on the board scored 100% against that.
+  const mul = sweep(20).filter((s) => s.operator === "×");
+  assert.ok(mul.length > 200, `only ${String(mul.length)} multiplication items`);
+  let boards = 0;
+  let copied = 0;
+  for (const s of mul) {
+    const board = boardFor(s.question, NO_LIMITS);
+    if (!board.ok) continue;
+    boards++;
+    const onBoard = board.spec.fixed
+      .filter((f) => f.kind === "weight")
+      .map((f) => toKey(f.kind === "weight" ? f.value : frac(0)));
+    if (!onBoard.includes(toKey(board.spec.answer))) continue;
+    copied++;
+    // The one place the answer legitimately appears on the apparatus is a factor
+    // of one, because "one group of five" IS one five-weight and there is nothing
+    // dishonest about drawing it. Anything else is the old copy board coming back.
+    assert.match(
+      example(board.spec.prompt),
+      /(^|\s)1(\s|$)/u,
+      `${board.spec.prompt} = ${toKey(board.spec.answer)} has the answer engraved on the board`,
+    );
+  }
+  assert.ok(boards > 100, `only ${String(boards)} multiplication boards could be built`);
+  assert.ok(
+    copied / boards < 0.15,
+    `${String(copied)} of ${String(boards)} multiplication boards are still a copy`,
+  );
+});
+
+/** The prompt, for an assertion message. */
+function example(prompt: string): string {
+  return prompt;
+}
+
+test("division is identical crates, and it is the divisor that is capped", () => {
+  const small = specFromQuestion({
+    id: "d1",
+    prompt: "24 ÷ 6",
+    answer: "4",
+    distractors: ["30", "18"],
+    domain: "add-sub",
+    difficulty: 0.5,
+  });
+  assert.ok(small);
+  assert.equal(small.fixed.filter((f) => f.kind === "crate").length, 6);
+  assert.equal(legalMoveExists(small), null);
+
+  // Seventy crates in one dish is not a picture. Refused, by name, with the
+  // reason in the message — not faked, and not silently turned into something
+  // else, which is what the old code did with every division in the game.
+  const big = boardFor({
+    id: "d2",
+    prompt: "51800 ÷ 70",
+    answer: "740",
+    distractors: [],
+    domain: "add-sub",
+    difficulty: 0.7,
+  });
+  assert.equal(big.ok, false);
+  assert.equal(big.ok ? "" : big.reason, "unrepresentable");
+  assert.match(big.ok ? "" : big.detail, /70 identical crates/u);
+});
+
+test("a missing factor is how many fit, and the count is the answer", () => {
+  // `□ × 15 = 165`. The curriculum authored this row and recorded it as blocked
+  // ON THIS PACK: "balance's pans add; a missing factor multiplies".
+  const spec = specFromQuestion({
+    id: "mf",
+    prompt: "□ × 15 = 165",
+    answer: "11",
+    distractors: ["10", "12"],
+    domain: "algebra",
+    difficulty: 0.5,
+  });
+  assert.ok(spec, "□ × 15 = 165 still cannot be built");
+  assert.equal(spec.countAnswer, true);
+  assert.deepEqual(spec.rack.map(toKey), ["15"], "the rack must hold nothing but the unit");
+  assert.equal(spec.movementName, "How Many Fit");
+  assert.equal(legalMoveExists(spec), null);
+
+  // Eleven fifteens level it, and the answer reported is the count.
+  const placed = (n: number): PlacedItem[] =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `p${String(i)}`,
+      side: spec.fillSide as Side,
+      peg: PAN_PEG,
+      value: frac(15),
+    }));
+  assert.ok(isBalanced(spec, placed(11), null));
+  assert.ok(!isBalanced(spec, placed(10), null));
+
+  // `15 × □ = 165` is the same board.
+  const flipped = specFromQuestion({
+    id: "mf2",
+    prompt: "15 × □ = 165",
+    answer: "11",
+    distractors: [],
+    domain: "algebra",
+    difficulty: 0.5,
+  });
+  assert.ok(flipped);
+  assert.deepEqual(flipped.rack.map(toKey), ["15"]);
+
+  // A quotient past what a dish can count is refused rather than heaped.
+  const heap = boardFor({
+    id: "mf3",
+    prompt: "□ × 3 = 900",
+    answer: "300",
+    distractors: [],
+    domain: "algebra",
+    difficulty: 0.9,
+  });
+  assert.equal(heap.ok, false);
+});
+
+test("a blank keeps its sign, so 8 − □ = 4 is a balloon", () => {
+  // Recorded in the curriculum as blocked on this pack: "balance drops the sign
+  // before a box". It did: the lexer read the minus, then pushed a bare blank
+  // and threw the sign away, so the board asked `8 + □ = 4`.
+  const spec = specFromQuestion({
+    id: "ms",
+    prompt: "8 − □ = 4",
+    answer: "4",
+    distractors: ["12", "3"],
+    domain: "algebra",
+    difficulty: 0.2,
+  });
+  assert.ok(spec, "8 − □ = 4 still cannot be built");
+  assert.equal(spec.movementName, "Lift");
+  // The thing you hang is a balloon: every weight on the rail lifts.
+  for (const r of spec.rack) assert.ok(r.n < 0, `the rack offers ${toKey(r)}, which sinks`);
+  assert.ok(
+    isBalanced(spec, [{ id: "p", side: spec.fillSide as Side, peg: PAN_PEG, value: frac(-4) }], null),
+    "tying a 4 balloon to the heavy dish does not level it",
+  );
+  assert.equal(legalMoveExists(spec), null);
+});
+
+test("the statement forms the curriculum already emits still build", () => {
+  // Measured by the agent that authored `blanks-in-equations`: these three
+  // balance correctly and must keep doing so.
+  const cases: Array<[string, string]> = [
+    ["47 + □ = 68", "21"],
+    ["□ − 47 = 68", "115"],
+    ["8 + 4 = □ + 5", "7"],
+    ["15 − 8", "7"],
+    ["19 + 70", "89"],
+  ];
+  for (const [prompt, answer] of cases) {
+    const spec = specFromQuestion({
+      id: `st-${prompt}`,
+      prompt,
+      answer,
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0.3,
+    });
+    assert.ok(spec, `${prompt} = ${answer} is no longer buildable`);
+    assert.equal(legalMoveExists(spec), null, `${prompt} = ${answer}`);
+  }
+});
+
+test("a board whose own answer does not solve it is never handed over", () => {
+  // The general guard, independent of any operator. A host that sends a wrong
+  // answer, or notation that means something this file guessed at, gets a
+  // refusal instead of a locked room.
+  const lying = boardFor({
+    id: "lie",
+    prompt: "2 + 2",
+    answer: "5",
+    distractors: [],
+    domain: "add-sub",
+    difficulty: 0,
+  });
+  assert.equal(lying.ok, false);
+  assert.equal(lying.ok ? "" : lying.reason, "unrepresentable");
+  assert.match(lying.ok ? "" : lying.detail, /its own answer does not solve/u);
+});
+
+test("notation nobody taught this game is refused, not treated as whitespace", () => {
+  // The exact defect. `÷` used to fall through to a bare `i++`, so an operator
+  // became a space and two operands became one dish.
+  for (const prompt of ["log₂ 64", "5 ± 2", "√ 49", "3 → 9", "2 ^ 8"]) {
+    const board = boardFor({
+      id: `n-${prompt}`,
+      prompt,
+      answer: "6",
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0,
+    });
+    assert.equal(board.ok, false, `${prompt} was silently turned into a board`);
+    assert.equal(board.ok ? "" : board.reason, "unreadable");
+  }
+});
+
+// ------------------------------------------------------------------ LEGIBILITY
+
+test("a numeral is never wider than the brass it is engraved on", () => {
+  // The founder: "long numbers don't fit on the weights so they just run all
+  // over each other." The old line chose `r * 0.78` for anything two digits or
+  // more and drew centred, with no reference to the face width at all: at the
+  // top of the ladder `4232831450` is about four disc-widths of ink.
+  //
+  // `fittedNumeralPx` is that line, made pure so it can be measured here rather
+  // than on a device. The advance below is the game's serif stack at its
+  // widest — every real digit in Palatino, Georgia and Times is narrower.
+  const advance = 0.58;
+  for (const r of [17, 20, 23, 26, 30, 34, 40]) {
+    const face = r * NUMERAL_FACE;
+    for (const chars of [1, 2, 3, 4, 6, 8, 10]) {
+      const label = "9".repeat(chars);
+      const ideal = idealNumeralPx(r, chars);
+      const ink = ideal * advance * chars;
+      const s = fittedNumeralPx(ideal, ink, face);
+      const drawn = s * advance * chars;
+      const budgeted = chars <= charsAtRadius(r);
+      assert.ok(
+        drawn <= face + 0.001 || !budgeted,
+        `${label} on r=${String(r)} draws ${drawn.toFixed(1)}px of ink in a ${face.toFixed(1)}px face`,
+      );
+      assert.ok(
+        s >= NUMERAL_MIN_PX,
+        `${label} is drawn at ${s.toFixed(1)}px, under the ${String(NUMERAL_MIN_PX)}px floor`,
+      );
+    }
+  }
+});
+
+test("the character budget and the radius it needs are the same statement", () => {
+  for (let chars = 1; chars <= 12; chars++) {
+    assert.ok(
+      charsAtRadius(radiusForChars(chars)) >= chars,
+      `a disc sized for ${String(chars)} characters reports room for ${String(charsAtRadius(radiusForChars(chars)))}`,
+    );
+  }
+});
+
+test("the disc grows for a wide numeral, and the frame still holds", () => {
+  const VIEWPORTS: Array<[string, number, number]> = [
+    ["small phone", 320, 568],
+    ["phone", 390, 844],
+    ["tablet", 768, 1024],
+    ["laptop", 1440, 900],
+  ];
+  for (const [name, w, h] of VIEWPORTS) {
+    const narrow = layoutForViewport(w, h, 9, 1);
+    const wide = layoutForViewport(w, h, 9, 6);
+    // The disc must actually grow, and grow *enough*: `>=` passes for a layout
+    // that ignores the argument entirely, which is a mutant this file has been
+    // measured against.
+    assert.ok(
+      charsAtRadius(wide.weightR) >= 6,
+      `${name}: a six-figure board got a disc that holds ${String(charsAtRadius(wide.weightR))} ` +
+        `(r=${wide.weightR.toFixed(1)}, was ${narrow.weightR.toFixed(1)})`,
+    );
+    // On a tablet the standard disc already holds six characters and there is
+    // nothing to grow. On a phone there is.
+    if (charsAtRadius(narrow.weightR) < 6) {
+      assert.ok(wide.weightR > narrow.weightR, `${name}: the disc did not grow at all`);
+    }
+    // The invariant `layout.test.ts` gates on, restated for the grown disc.
+    assert.ok(
+      wide.rack.y > wide.plinth.y + wide.plinth.h - 0.5,
+      `${name}: growing the brass pushed the rack into the plinth`,
+    );
+    // And the capacity is honest: what it claims, the disc can hold.
+    const cap = numeralCapacity(w, h, 9);
+    assert.ok(cap >= 4, `${name} claims room for only ${String(cap)} characters`);
+    assert.ok(
+      radiusForChars(cap) <= layoutForViewport(w, h, 9, cap).weightR + 0.5,
+      `${name} claims ${String(cap)} characters it cannot lay out`,
+    );
+  }
+});
+
+test("a remainder too big to search is not charged to the child as a dead end", () => {
+  // `rackCanMake` is a coin-change search with a cap on it, and `verdictFor` reads
+  // a `false` from it as a *proved* dead end: the dish tips, everything comes
+  // back, and an error is recorded against the child. So "I could not check"
+  // must not answer "no". The shipped ladder reaches `913072 − 884`, and a
+  // measurement-division board with a heavy unit crosses the cap on its first
+  // correct placement.
+  assert.equal(rackCanMake([frac(3)], frac(90000)), true, "a target past the cap is reported impossible");
+
+  const spec = specFromQuestion({
+    id: "big-count",
+    prompt: "□ × 5000 = 40000",
+    answer: "8",
+    distractors: [],
+    domain: "algebra",
+    difficulty: 0.8,
+  });
+  assert.ok(spec);
+  const startNetSign = Math.sign(netTorque(spec, [], null).n);
+  const one: PlacedItem[] = [
+    { id: "p", side: spec.fillSide as Side, peg: PAN_PEG, value: frac(5000) },
+  ];
+  assert.equal(
+    verdictFor(spec, one, null, startNetSign),
+    "continue",
+    "the first of eight correct weights was charged as a dead end",
+  );
+});
+
+test("a numeral wider than the screen can hold is refused, not squeezed", () => {
+  // The `polarity` precedent: measure the real constraint and say no out loud,
+  // rather than drawing something a child cannot read.
+  const tight: BoardLimits = { maxNumeralChars: 4 };
+  // A board that is otherwise perfectly buildable — the top subtraction rung the
+  // ladder really serves — so the refusal can only be about the width. Reaching
+  // for `80225 × 52762` here would be vacuous: that one is refused for having no
+  // countable factor before the width is ever looked at, which is a mutant this
+  // file has been measured against.
+  const real: Question = {
+    id: "wide",
+    prompt: "913072 − 884",
+    answer: "912188",
+    distractors: [],
+    domain: "add-sub",
+    difficulty: 0.94,
+  };
+  assert.equal(boardFor(real, NO_LIMITS).ok, true, "the control board is not buildable at all");
+  const wide = boardFor(real, tight);
+  assert.equal(wide.ok, false);
+  assert.equal(wide.ok ? "" : wide.reason, "tooWide");
+  assert.match(wide.ok ? "" : wide.detail, /6-character numeral on a disc that holds 4/u);
+
+  const ok = boardFor(
+    { id: "ok", prompt: "9 + 8", answer: "17", distractors: [], domain: "add-sub", difficulty: 0 },
+    tight,
+  );
+  assert.equal(ok.ok, true);
+});
+
+test("an answer this game cannot weigh is refused, not quietly turned into 1", () => {
+  // The old adapter read the answer as `parseFrac(q.answer) ?? frac(1)`. A
+  // decimal or a fraction-shaped answer the parser does not take therefore became
+  // a board asking for **1**, and a child who worked out the real answer lost.
+  // No active rung emits one today — measured, 0 of 2640 — so this is the guard
+  // for the day one does, and it is asserted directly rather than through a
+  // sweep that cannot reach it.
+  for (const answer of ["1.5", "x", "", "12,000", "3 1/2"]) {
+    const board = boardFor({
+      id: `a-${answer}`,
+      prompt: "3 + 4",
+      answer,
+      distractors: [],
+      domain: "add-sub",
+      difficulty: 0,
+    });
+    assert.equal(board.ok, false, `answer ${JSON.stringify(answer)} was silently accepted`);
+    assert.equal(board.ok ? "" : board.reason, "unreadable");
+  }
+});
+
+test("no board the pack shows on a small phone carries a numeral it cannot draw", () => {
+  // Deliberately tighter than any real device. A 320×568 phone reports room for
+  // ${numeralCapacity(320, 568, 9)} characters and the widest numeral on any board
+  // this pack can represent is six, so the real budget never binds and asserting
+  // against it proves nothing — measured: the mutant that deletes the width check
+  // entirely passed against the real number. Four is what a screen half this size
+  // would give, and it is the path under test.
+  const real = numeralCapacity(320, 568, 9);
+  assert.ok(real >= 6, `a small phone reports room for only ${String(real)} characters`);
+  const limits: BoardLimits = { maxNumeralChars: 4 };
+  let shown = 0;
+  for (const s of sweep(8)) {
+    const board = boardFor(s.question, limits);
+    if (!board.ok) continue;
+    shown++;
+    assert.ok(
+      widestNumeral(board.spec) <= limits.maxNumeralChars,
+      `${s.question.prompt}: a ${String(widestNumeral(board.spec))}-character numeral on a disc that holds ${String(limits.maxNumeralChars)}`,
+    );
+  }
+  assert.ok(shown > 100, `only ${String(shown)} boards survive a four-character budget`);
+});
+
+// ------------------------------------------------------------------- REPORTING
+
+test("a measurement-division board reports the count, not the mass", () => {
+  const spec = specFromQuestion({
+    id: "mf-report",
+    prompt: "□ × 15 = 165",
+    answer: "11",
+    distractors: [],
+    domain: "algebra",
+    difficulty: 0.5,
+  });
+  assert.ok(spec);
+  const placed = Array.from({ length: 11 }, (_, i) => ({
+    id: `p${String(i)}`,
+    side: spec.fillSide as Side,
+    peg: PAN_PEG,
+    value: frac(15),
+  }));
+  // `165` is what the brass weighs and `11` is what the host asked for. Reporting
+  // the mass would mark every correct answer wrong.
+  assert.equal(answeredKey(spec, placed, null), "11");
+  assert.equal(answeredKey(spec, placed.slice(0, 3), null), "3");
+});
+
+test("the sanity of the sweep itself", () => {
+  // If `ladder()` or the prompt assembly ever stops producing what this file
+  // thinks it does, every assertion above goes quiet. So: the sweep must contain
+  // all four operators, and it must contain the founder's own shape.
+  const served = sweep(6);
+  const ops = new Set(served.map((s) => s.operator));
+  assert.deepEqual([...ops].sort(), ["+", "×", "÷", "−"].sort());
+  assert.ok(
+    served.some((s) => /^\d{4,} ÷ \d+$/u.test(s.question.prompt)),
+    "the ladder no longer serves a multi-digit division — the locked room cannot recur here",
+  );
+  for (const s of served) {
+    assert.ok(parseFrac(s.question.answer), `${s.question.prompt} answered ${s.question.answer}`);
+  }
+});


### PR DESCRIPTION
The founder worked out `88965 ÷ 9 = 9885`, entered it, and could not leave the board:

> "I had a correct answer not accepted and it wouldn't let me put anything on the scale and I was just stuck **88965/9 == 9885** .. but it rejected that and every other possible choice and I couldn't go anywhere."

## The cause

`tokenizeSide` knew four tokens — numerals, `x`, `□`, `+`/`−` — and ended its loop with a bare `i++`, so **anything else was whitespace**. `88965 ÷ 9` lexed as two unrelated numerals and built a board with *both operands in the same dish*: 88,974 of brass on the left, an empty dish on the right, a contract answer of 9,885. No weight levels that beam. Every disc spills back out, an error is charged, and a board is only left by solving it.

Measured over the 66 active rungs × 40 seeds, against the code this replaces:

| | boards solvable |
|---|---|
| `+` | 640 / 640 |
| `−` | 800 / 800 |
| `×` | 800 / 800 — but **every one a copy**: the answer was engraved on the dish |
| `÷` | **0 / 400** |

The ten division rungs sit at ordinates 0.34–0.86, so a child who climbs is *guaranteed* to reach one. Third of this shape this month — trebuchet #698, foundry #711, lattice #716 — always the same root: a question the game could not represent kept its prompt and silently got a different board.

## The class is closed, not the instance

- The lexer is **total**: an unknown token refuses the whole question, out loud.
- Every board is **proved** before it is handed over. `whyUnsolvable` runs the contract's own answer against the beam and against the rack; a board its own answer does not solve cannot be built, whatever notation the curriculum grows next. That check alone would have caught this.
- `pull()` keeps asking, sweeping the difficulty axis downward, and falls back to a locally built board rather than ever leaving a child with no move. A refusal never touches the child's own rung.

## Every operator gets a truth

The founder's other three notes are one defect between them: `×` was collapsed into a single weight (the answer engraved on the apparatus — that is the *"'identical' doesn't do much .. you just put the matching weight on the other side"* board, and a copy bot scored 100% on it), and `÷` had no apparatus at all. The balloon works because it is physically true; these now are too.

| statement | apparatus |
|---|---|
| `3 × 5` | three identical 5-weights in the dish — countable, repeated addition without a word, and **no disc on the board carries the answer** |
| `88965 ÷ 9` | nine identical sealed crates against the dividend; declare what one crate holds. The only division picture that survives the curriculum's magnitudes — nine crates is nine crates whether the quotient is 5 or 9,885, where 9,885 nines is not a picture at all |
| `□ × 15 = 165` | the rack holds nothing but 15s and the answer is **how many you hang**: measurement division, which is what a balance loaded with one kind of weight physically is |
| `8 − □ = 4` | the blank keeps its sign, so it is a balloon |
| `7 − 7`, `0 × 4` | zero is a disc that weighs nothing; the arm is already flat and the answer is *nothing* |

Both curriculum rows recorded as blocked on this pack now build and are asserted — `missing-subtrahend` ("balance drops the sign before a box") and `missing-factor` ("balance's pans add; a missing factor multiplies"). **`PACK_STATEMENT_BLOCKED_SKILLS` in `promotionBlockers.ts` needs those two entries removed**; that is a curriculum edit outside this PR's paths.

## Legibility

> "long numbers don't fit on the weights so they just run all over each other."

`numeral()` picked `r * 0.78` for anything two digits or more and drew centred with no reference to the face width, so `4232831450` laid four disc-widths of ink over its neighbours. The disc now has a stated capacity from three measured numbers, the type is fitted to the face with a 15px floor, the disc **grows** for a wide board, and a numeral that still would not fit refuses the question. The growth walk searches *upward*, because `plinthY`'s clamp makes feasibility non-monotone in the radius — on a 320×568 phone r=24 holds, 25–35 do not, 36 holds again.

## Coverage, before and after

66 rungs × 40 seeds: **53 served in full, 6 in part, 7 refused** (was 56 / 0 / 10-dead). Everything still refused is a declared ceiling with a physical reason — a factor or divisor over twelve will not read as a pile of identical things — and `pull` asks again instead of trapping anyone. The seven fully refused rungs are `times-two-digit` and `long-multiplication`, which were previously "playable" only in the sense that the answer was engraved on the dish.

## No clock

Untouched. The plinth engraving now names the object in front of the child instead of dividing their rung into ten and announcing "IDENTICAL CRATES" over a board with no crates in it.

## Verification

100 tests, run 5×, on Node 24. `tsc` clean, pack builds (+10 kB raw / +3 kB gzip, `generate.ts` confirmed tree-shaken out).

Every test was verified by deletion — 26 mutants. **Six exposed vacuous assertions, which are fixed**, most importantly the oracle behind the founder test and both sweeps: it called the same `whyUnsolvable` that `boardFor` decides on, and with the original `÷`-as-whitespace lexer restored *and* the proof stubbed to `null`, the locked room and all 400 division boards **passed**. It is now written from first principles.

The second commit is a full adversarial self-review pass: six further defects, including a wrong disc being reported to the host as the *correct* answer on 344 of 344 zero-answer boards, a solved balloon board recorded wrong, and a fallback board ratcheting the ladder into the region the pack cannot draw.

## Needs a device

Two guards cannot be proved in Node because `Game` needs a canvas, a `ResizeObserver` and a frame loop: the constructor's `resize()`-before-`loadNext()` ordering (a stale 1×1 placeholder layout reports room for three characters), and the read-the-dish-before-tipping-it order inside `spill()`. Both are pinned by a source assertion and by a behavioural test on the function they call. Worth one pass on device confirming a `÷` board draws nine crates legibly and a `3 × 5` board's three discs read as three.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb