### PR TITLE
dynawalla/games/arena: time to think at the top, and a gentler climb to get there

### DIFF
--- a/dynawalla/games/arena/README.md
+++ b/dynawalla/games/arena/README.md
@@ -11,7 +11,7 @@ you, and anything larger will hurt.**
 ```bash
 npm install
 npm run dev      # http://127.0.0.1:5188/
-npm test         # 71 tests, Node's native runner, zero dependencies
+npm test         # 91 tests, Node's native runner, zero dependencies
 npm run tsc      # typecheck
 npm run build:pack   # the installable pack; `../../packs && node build.mjs arena` checks and stages it
 ```
@@ -85,14 +85,89 @@ a direct question was also the busiest frame in the game. Both now ride the same
 curve, and the curve is fast.)
 
 - **Right** → a shockwave clears the neighbourhood, every rival is thrown off
-  you, your mass surges and the chord resolves upward with the streak.
-- **Wrong** → you lose a quarter of your mass, the chord sags, and the correct
-  sphere flares for a beat so you *see* which it was. No lecture, no modal.
-- **Timeout** → the water simply comes back. You lost the opportunity, nothing
-  more.
+  you, your mass surges and the chord resolves upward with the streak. Answer
+  *quickly* and it pays up to 70% more, and the celebration is bigger with it.
+- **Wrong** → you lose some mass — 2% near the bottom of the ladder, rising to
+  14% at the top — the chord sags, and the correct sphere flares for a beat so
+  you *see* which it was. No lecture, no modal.
+- **Nothing** → the water simply comes back. Nothing is reported to the host,
+  nothing is taken, and the question returns later.
 
 Inside a Resonance the arena is a fixed-size room however large you have grown,
 so the answer can never be the thing that outruns you.
+
+### There is no timer on a question. Paper is allowed.
+
+**Take as long as you like.** Nothing counts down. The spheres orbit but they
+never drift away, so the answer is exactly where you found it ten minutes later.
+If a question is long — `34,801 ÷ 37` is a real thing this ladder serves — put
+the tablet down, get a pencil, work it out in columns, and come back. You get the
+full points for it. On questions that long the game says so itself, in four words
+over the prompt: **NO TIMER · USE PAPER**.
+
+Answering fast is *rewarded* and answering slowly is never punished, and those are
+two different sentences. A brisk answer earns a bigger share of the wave; a slow
+one earns the whole base reward. There is nothing anywhere in the beat that a
+child loses by thinking, which is a deliberate reversal — this game used to give
+26 seconds at the bottom of the ladder and **six at the top**, on the theory that
+a countdown was something a fast player had earned. It was the wrong theory for
+the content: the house cadence table puts five-column long division at a
+40-second *median*, so the one player fast enough to have "earned" six seconds was
+the only one whose questions could not be answered inside it.
+
+What replaced it is an *allowance* (`src/sim/window.ts`), and it is ten times the
+p90 of the arithmetic rather than one: **one minute on `7 + 5`, ten minutes on
+`34,801 ÷ 37`.** It is derived from the item and from nothing about the run; it is
+never drawn anywhere — no bar, no ring, no number; and when it runs out nothing is
+reported to the host, the pacing controller does not move, and no mass changes
+hands. The seconds are free in the world too: the depth clock, the overdrive and
+the density all ride `playTime`, which excludes every second the arena spent inert,
+so you cannot come back from the paper to a meaner ocean.
+
+Unlike `games/claim` and `games/counterweight`, it is **not refilled by input**, and
+the reason is that ARENA's only control is steering. A first cut refilled on aim
+movement and got the two children exactly backwards: the one working on paper has
+their hands off the glass, so their allowance ran down — while the one ignoring the
+question and swimming about held the beat open forever, and the game could never
+resume.
+
+### The harder maths arrives a rung at a time
+
+ARENA hands the host a position on its ladder and the host decides what that
+means. Two things about that were wrong, and both were arithmetic rather than
+judgement:
+
+The request was an **integer** on a ten-rung scale, and the host's ladder is 66
+rungs — so one step of ARENA's breath was a 7.2-rung jump through the curriculum.
+Measured: ARENA rung 6 asked for `506 + 394`, and rung 7 asked for `721308 ÷ 84`.
+The request is now unrounded, so the same climb walks the curriculum a rung at a
+time.
+
+And the climb itself was as fast as the *world's* — the shared flow controller is
+tuned to escalate density and speed within tens of seconds, which is right for an
+ocean and wrong for arithmetic. Measured, a bot answering everything correctly
+reached the top of the 66-rung curriculum in **five minutes**, with one answer
+moving it eighteen rungs.
+
+The maths now follows the breath **down at once, and up one correct answer at a
+time** — at most a fifty-fifth of the ladder each, so crossing it takes 55 answers,
+which is what PR #715 measured the host's own recalibrated ladder giving a flawless
+child. Relief is never earned; only escalation is. And it is paid in *answers*, not
+in seconds: a per-second version let a child climb by **stalling** (an abandoned
+question is up to ten minutes of clock) and let six early answers carry them to the
+top over twenty minutes of just swimming about.
+
+Measured after, fifteen minutes of play:
+
+| player | curriculum rungs reached (of 65) | step per answer |
+|---|---|---|
+| everything wrong | 0–3 | — |
+| right 85% of the time | 0–14 | 1 |
+| flawless | 0–39 | 1–2 |
+| answers nothing, stalls | no climb at all | — |
+
+The world still leans in on the old fast curve. It is only the arithmetic that
+climbs slowly.
 
 ## Endless, not winnable
 

--- a/dynawalla/games/arena/src/render/gfx.ts
+++ b/dynawalla/games/arena/src/render/gfx.ts
@@ -313,7 +313,9 @@ export class Gfx {
     const res = world.resonance
     // The hush has to land almost instantly. A 0.4s ramp meant the frame in
     // which the question appears was still the loudest frame in the game.
-    const calm = res.active ? Math.min(1, res.t * 6) * (res.phase >= 3 ? Math.max(0, 1 - (res.t - res.duration) * 2.6) : 1) : 0
+    // `res.resolveT` and not `res.t - res.duration`: the beat no longer has a
+    // duration to be relative to, and the resolve carries its own clock from zero.
+    const calm = res.active ? Math.min(1, res.t * 6) * (res.phase >= 3 ? Math.max(0, 1 - res.resolveT * 2.6) : 1) : 0
 
     // --- cull bounds ------------------------------------------------------
     const halfH = span * 0.5

--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, FLOOR_MASS, MK_FOOD, MK_VOID, MK_SHED } from "./world.ts"
+import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, DIFFICULTY_RUNGS, FLOOR_MASS, MK_FOOD, MK_VOID, MK_SHED } from "./world.ts"
+import { MAX_GUARD_SECONDS, comprehensionSeconds, guardSeconds } from "./window.ts"
 import { Rng } from "../core/rng.ts"
 import { DEPTHS, depthFor, overdrive } from "./depths.ts"
 import { specFor } from "../core/tier.ts"
@@ -115,7 +116,12 @@ test("a run climbs: the band never falls and a banked rung cannot be taken back"
   // Six minutes of a deliberately BAD player: never aims, never surges, walks
   // into everything. This is the profile that used to oscillate 154 → 65 → 332
   // → 122 → 152 and finish where it started.
-  for (let f = 0; f < 60 * 60 * 6; f++) {
+  // Six minutes of PLAY time, not of wall time. The depth clock rides `playTime`
+  // now — an inert Resonance is not a second of the run — and a bot that never
+  // answers spends a real share of the wall clock inside beats, so counting frames
+  // would be counting the wrong thing and the assertion at the bottom would be
+  // measuring the guard rather than the ratchet.
+  for (let f = 0; f < 60 * 60 * 30 && world.playTime < 60 * 6; f++) {
     world.aimX = Math.sin(f * 0.011) * 1400
     world.aimY = Math.cos(f * 0.008) * 1400
     world.step(1 / 60)
@@ -130,7 +136,7 @@ test("a run climbs: the band never falls and a banked rung cannot be taken back"
       `mass ${world.mass} fell through the banked checkpoint ${world.checkpoint}`,
     )
   }
-  assert.ok(band >= 3, `six minutes must show more than a couple of depths, saw ${band + 1}`)
+  assert.ok(band >= 3, `six minutes of play must show more than a couple of depths, saw ${band + 1} in ${world.playTime.toFixed(0)}s`)
   assert.ok(lowestSinceBand >= FLOOR_MASS)
 })
 
@@ -295,43 +301,115 @@ test("the answer reported to the host is the host's own string, and slot identit
     assert.ok(r.ms >= 0 && Number.isFinite(r.ms), `latency was not a sane number: ${r.ms}`)
   }
 
-  // The specific round trip that would be silent: an answer past 2^31, which
-  // an Int32Array wraps to a *different number* rather than to an error. The
-  // stub host never emits one; a real curriculum eventually will.
-  const big: string[] = ["8030000000", "8030000001", "8029999999", "8030000010"]
-  const bigReports: { correct: boolean; answered: string }[] = []
-  const bigHost: Host = {
+  // The specific round trip that would be silent: the sphere's LABEL goes
+  // through `mval`, an Int32Array, and the answer reported to the host must not
+  // take that trip. A padded string is the cheapest item that can tell the
+  // difference — `Number("0500")` is 500, so a game reporting `String(mval)`
+  // says "500" while the host said "0500", and every other value in the product
+  // survives the round trip and hides the bug.
+  const padReports: { correct: boolean; answered: string }[] = []
+  const padHost: Host = {
     next: () => ({
-      id: "big-1",
-      prompt: "big",
-      answer: big[0] as string,
-      distractors: big.slice(1),
-      domain: "compare",
+      id: "pad-1",
+      prompt: "500 + 0",
+      answer: "0500",
+      distractors: ["0501", "0499", "0510"],
+      domain: "add",
       difficulty: 5,
     }),
-    report: (r) => bigReports.push({ correct: r.correct, answered: r.answered }),
+    report: (r) => padReports.push({ correct: r.correct, answered: r.answered }),
     haptic: () => {},
     prefersReducedMotion: () => false,
   }
-  const bw = new World(bigHost, specFor("low"), 21)
-  for (let f = 0; f < 60 * 60 * 2 && bigReports.length === 0; f++) {
-    const res = bw.resonance
+  const pw = new World(padHost, specFor("low"), 21)
+  for (let f = 0; f < 60 * 60 * 2 && padReports.length === 0; f++) {
+    const res = pw.resonance
     if (res.active && res.phase === 2) {
       const i = res.spheres[res.correctSlot] as number
-      if (i >= 0 && bw.malive[i]) {
-        bw.aimX = bw.mx[i] as number
-        bw.aimY = bw.my[i] as number
+      if (i >= 0 && pw.malive[i]) {
+        pw.aimX = pw.mx[i] as number
+        pw.aimY = pw.my[i] as number
       }
     }
-    bw.step(1 / 60)
+    pw.step(1 / 60)
   }
-  assert.equal(bigReports.length, 1, "the big-number resonance never resolved")
-  assert.equal((bigReports[0] as { correct: boolean }).correct, true)
+  assert.equal(padReports.length, 1, "the padded-answer resonance never resolved")
+  assert.equal((padReports[0] as { correct: boolean }).correct, true)
   assert.equal(
-    (bigReports[0] as { answered: string }).answered,
-    "8030000000",
-    "an answer past 2^31 came back as a different number — it went through the Int32Array",
+    (padReports[0] as { answered: string }).answered,
+    "0500",
+    "the answer came back as a different string — it went through the Int32Array",
   )
+})
+
+/**
+ * The other half of the same seam, and a live defect until this pass.
+ *
+ * `mval` is an `Int32Array` and `openResonance` clamps anything past 2^31 to
+ * **zero** on the way in. So a sphere carrying the answer to `37388 × 85585`
+ * (= 3,199,851,980) was drawn reading `0`: the child was asked to find an answer
+ * that was not on the screen, four spheres all lied, and whichever one they flew
+ * into cost them mass.
+ *
+ * Measured through the real host over the whole 66-rung ladder, 40 items a rung:
+ * the top rung is `dw.mul.multidigit.long-multiplication` L2 and **24 of 40 of
+ * its answers exceed 2^31**. ARENA's old integer difficulty request landed on
+ * exactly that rung whenever the breath reached its ceiling, so this was
+ * reachable by playing well.
+ *
+ * The fix is the rule ARENA already had for an item it cannot pose with four
+ * distinct options, applied to the other way a beat can lie: it declines.
+ */
+test("a question ARENA cannot draw is never asked, and never costs a child anything", () => {
+  const reports: unknown[] = []
+  const warnings: string[] = []
+  const realWarn = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "))
+  }
+  try {
+    const bigHost: Host = {
+      next: () => ({
+        id: "big-1",
+        prompt: "37388 × 85585",
+        answer: "3199851980",
+        distractors: ["3199851981", "3199851979", "3199851990"],
+        domain: "multiply",
+        difficulty: 5,
+      }),
+      report: (r) => reports.push(r),
+      haptic: () => {},
+      prefersReducedMotion: () => false,
+    }
+    const bw = new World(bigHost, specFor("low"), 21)
+    let everOpened = 0
+    let drawnZero = 0
+    for (let f = 0; f < 60 * 60 * 4; f++) {
+      const res = bw.resonance
+      if (res.active) {
+        everOpened++
+        for (let s = 0; s < 4; s++) {
+          const i = res.spheres[s] as number
+          if (i >= 0 && bw.malive[i] && bw.mval[i] === 0) drawnZero++
+        }
+        const i = res.spheres[res.correctSlot] as number
+        if (i >= 0 && bw.malive[i]) {
+          bw.aimX = bw.mx[i] as number
+          bw.aimY = bw.my[i] as number
+        }
+      }
+      bw.step(1 / 60)
+    }
+    assert.equal(everOpened, 0, "a question whose answer cannot be drawn was posed to a child anyway")
+    assert.equal(drawnZero, 0, "a sphere was drawn reading 0 instead of its answer")
+    assert.equal(reports.length, 0, "declining to ask a question still reported something to the host")
+    assert.ok(
+      warnings.some((w) => w.includes("cannot draw") && w.includes("3199851980")),
+      `declining was silent — warnings were ${JSON.stringify(warnings)}`,
+    )
+  } finally {
+    console.warn = realWarn
+  }
 })
 
 /**
@@ -632,40 +710,789 @@ test("the world breathes out for a child who is struggling, and in for one who i
 })
 
 /**
- * Time is MEASURED and REWARDED, never imposed.
+ * Time is MEASURED and REWARDED, never imposed — and after this pass it is not
+ * even bounded.
  *
  *   "I like infinite time to think in most cases too ... we can usually
  *    measure, pace and reward, not cause anxiety"
  *
- * Two clocks used to run on every child regardless: a window that shrank with
- * the number of questions asked — `max(6.5, 10.5 - resonanceCount * 0.16)` —
- * and spheres that drifted away at a flat 22 units a second while you thought.
+ *   "if you can do something like 34801 / 37 in your head in 5 seconds you are a
+ *    total math stud .. maybe they allow infinite time and even invite the kid to
+ *    take out a piece of paper and work it out for 10 minutes for the points"
+ *
+ * Three clocks have been deleted from this beat in turn. The first shrank with
+ * the number of questions asked (`max(6.5, 10.5 - resonanceCount * 0.16)`). The
+ * second was spheres drifting away at a flat 22 units a second while you thought.
+ * The third — deleted here — was `valueAt(intensity, 26, 6, "gentle")`: a window
+ * a fast player *earned*, which was defensible until the ladder started serving
+ * five-column long division into six seconds of it.
+ *
+ * What is left is measured over the whole cross product of run states below: the
+ * guard is a function of the item and of nothing else.
  */
-test("a struggling player is never put on a clock, and a fast one is paid for being fast", () => {
-  const world = new World(createStubHost({ seed: 8 }), specFor("mid"), 55)
+test("the time a child gets is a function of the question, and of nothing about the run", () => {
+  // The same item, asked of a world at rest, a world that has been struggling for
+  // five minutes, and a world that has been perfect for seven. If any of the
+  // three disagrees, something about the run is in the window.
+  // The guard is read off the LIVE WORLD — `world.resonance.guard`, installed by
+  // `openResonance` — and never recomputed here.
+  //
+  // The first cut of this test called `guardSeconds(item)` once per arm and
+  // compared the three results. `guardSeconds` is a pure import and `item` is a
+  // module const, so all three were the same constant expression: three
+  // assertions that could not fail, and that would have passed happily while
+  // `openResonance` installed `guardSeconds(q) * (1 - intensity)`. Building three
+  // worlds and flying them for seven minutes made it look like a measurement.
+  const item = { prompt: "34801 ÷ 37", answer: "941" }
+  const fixedHost = (): Host => ({
+    next: () => ({
+      id: "fixed-1",
+      prompt: item.prompt,
+      answer: item.answer,
+      distractors: ["942", "940", "951"],
+      domain: "divide",
+      difficulty: 5,
+    }),
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => false,
+  })
+  const at = (seconds: number, accuracy: number): { guard: number; intensity: number } => {
+    const w = new World(fixedHost(), specFor("mid"), 55)
+    if (seconds > 0) fly(w, seconds, accuracy, 13)
+    // Run on until a beat is actually open, and take what the world put there.
+    for (let f = 0; f < 60 * 120; f++) {
+      w.step(1 / 60)
+      const res = w.resonance
+      if (res.active && res.phase === 2) return { guard: res.guard, intensity: w.intensity }
+    }
+    throw new Error("no Resonance opened, so nothing was measured")
+  }
+  const rest = at(0, 0)
+  const lost = at(300, 0)
+  const ace = at(420, 1)
   assert.ok(
-    world.resonanceSeconds >= 24,
-    `a fresh run gives only ${world.resonanceSeconds.toFixed(1)}s to think`,
+    ace.intensity > lost.intensity + 0.3,
+    `the three worlds did not actually diverge, so the claim is untested: ${lost.intensity} vs ${ace.intensity}`,
   )
+  assert.equal(rest.guard, lost.guard, "five minutes of struggle changed the time the same question gets")
+  assert.equal(rest.guard, ace.guard, "seven minutes of mastery changed the time the same question gets")
+  // …and it is the founder's ten minutes, for the item he named.
+  assert.equal(rest.guard, 600, `${item.prompt} was given ${rest.guard}s, not the ten minutes he asked for`)
+  // Belt and braces: the world's number is the module's number, checked once.
+  assert.equal(rest.guard, guardSeconds(item), "the world installed something other than the item's own guard")
+
+  // The spheres do not recede, at any point on the ladder. The old drift was
+  // earned on the same curve as the old window, so at the top of the ladder the
+  // answer physically walked away from a hesitating child at 22 units a second.
+  for (const w of [
+    new World(createStubHost({ seed: 8 }), specFor("mid"), 55),
+    (() => {
+      const x = new World(createStubHost({ seed: 8 }), specFor("mid"), 55)
+      fly(x, 420, 1, 13)
+      return x
+    })(),
+  ]) {
+    // Held open with a still hand, and the ring measured at both ends.
+    let opened = false
+    let r0 = 0
+    let r1 = 0
+    for (let f = 0; f < 60 * 240; f++) {
+      const res = w.resonance
+      if (res.active && res.phase === 2) {
+        const i = res.spheres[0] as number
+        if (i >= 0 && w.malive[i]) {
+          const r = Math.hypot((w.mx[i] as number) - res.centreX, (w.my[i] as number) - res.centreY)
+          if (!opened) {
+            opened = true
+            r0 = r
+          }
+          r1 = r
+        }
+      }
+      // The hand never moves: `aim` is parked, which is what `mount` writes when
+      // nothing is being touched.
+      w.aimX = w.px
+      w.aimY = w.py
+      w.step(1 / 60)
+      if (opened && !w.resonance.active) break
+    }
+    assert.ok(opened, "no Resonance opened in four minutes")
+    assert.ok(
+      Math.abs(r1 - r0) < r0 * 0.02,
+      `the answer moved from ${r0.toFixed(0)} to ${r1.toFixed(0)} units away while the child thought`,
+    )
+  }
+})
+
+/**
+ * The guard fires only on silence, and firing costs nothing.
+ *
+ * `games/claim`: **a clock may never take anything away from a child.** So the
+ * thing that ends an unanswered Resonance measures a *pause* and not a round, it
+ * refills on any hand on the glass, and when it does fire the host is told
+ * nothing, the pacing controller does not move, and no mass changes hands.
+ */
+test("the guard measures silence, refills on a hand, and takes nothing when it fires", () => {
+  const reports: unknown[] = []
+  const world = new World(createStubHost({ seed: 3, onReport: (r) => reports.push(r) }), specFor("low"), 404)
+
+  // Sit through one whole beat without ever touching anything.
+  let fired = 0
+  let openedAt = -1
+  let guard = 0
+  let massAtOpen = 0
+  let successAtOpen = 0
+  for (let f = 0; f < 60 * 900; f++) {
+    const res = world.resonance
+    if (res.active && res.phase === 2 && openedAt < 0) {
+      openedAt = world.time
+      guard = res.guard
+      massAtOpen = world.mass
+      successAtOpen = world.success
+    }
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+    for (let e = 0; e < world.eventLen; e++) {
+      if ((world.events[e] as { kind: string }).kind === "resonance-fade") fired++
+    }
+    if (fired > 0) break
+  }
+  assert.ok(fired === 1, `the guard never fired in fifteen minutes of stillness (fired ${fired})`)
+  assert.ok(guard >= 60, `the guard was only ${guard}s`)
+  // A frame of slack: `openedAt` is stamped the first frame the harness OBSERVES
+  // phase 2, which is one step after the world zeroed `idle`.
+  const held = world.time - openedAt
+  assert.ok(held >= guard - 0.1, `the beat was withdrawn after ${held.toFixed(2)}s against a ${guard}s guard`)
+  assert.equal(reports.length, 0, "a withdrawn question was reported to the host")
+  assert.equal(world.success, successAtOpen, "a withdrawn question moved the pacing controller")
+  assert.ok(world.mass >= massAtOpen, `a withdrawn question cost ${(massAtOpen - world.mass).toFixed(1)} mass`)
+
+  // Now the same beat with a hand on it, wandering — the child is steering, not
+  // answering. This arm used to assert the beat stayed open, on the theory that any
+  // input is a hand on the rack. It is the opposite assertion now, and the reason
+  // is in `stepResonance`: steering is not answering, so a child who ignores the
+  // question must not be able to hold a beat open forever.
+  const w2 = new World(createStubHost({ seed: 3 }), specFor("low"), 404)
+  let longest = 0
+  let openFor = 0
+  let fades = 0
+  for (let f = 0; f < 60 * 1200; f++) {
+    const res = w2.resonance
+    if (res.active && res.phase === 2) {
+      openFor += 1 / 60
+      // A hand on the stick the whole time, going nowhere near a sphere.
+      w2.aimX = w2.px + (f % 120 < 60 ? 60 : -60)
+      w2.aimY = w2.py
+    } else {
+      longest = Math.max(longest, openFor)
+      openFor = 0
+    }
+    w2.step(1 / 60)
+    for (let e = 0; e < w2.eventLen; e++) {
+      if ((w2.events[e] as { kind: string }).kind === "resonance-fade") fades++
+    }
+  }
+  longest = Math.max(longest, openFor)
+  assert.ok(fades > 0, "a child who steered for twenty minutes without answering never had a beat withdrawn")
   assert.ok(
-    world.sphereDrift * world.resonanceSeconds < 2,
-    `the spheres drift ${(world.sphereDrift * world.resonanceSeconds).toFixed(1)} units over a whole window — the answer walks away from a child at the bottom of the ladder`,
+    longest <= MAX_GUARD_SECONDS + 2,
+    `a beat stayed open for ${longest.toFixed(0)}s — longer than any item's allowance, so the game could not resume`,
+  )
+})
+
+/**
+ * Speed is still worth something, and it is worth it as a BONUS.
+ *
+ * The earned countdown is gone; the reward for mastery it stood for is not. A
+ * brisk correct answer pays up to 70% more mass than a laboured one and the
+ * celebration scales with it, and that is now the whole of ARENA's relationship
+ * with the clock. `game-pacing/flow.ts`: "a countdown that kills you and a bonus
+ * that accrues when you are fast read the same clock and produce opposite
+ * emotional experiences."
+ */
+test("a fast answer earns more, and a slow one still wins", () => {
+  const play = (thinkFrames: number): { gain: number; quick: number; mass: number } => {
+    const world = new World(createStubHost({ seed: 44 }), specFor("low"), 707)
+    let gain = 0
+    let quick = -1
+    let waited = 0
+    for (let f = 0; f < 60 * 600 && quick < 0; f++) {
+      const res = world.resonance
+      if (res.active && res.phase === 2) {
+        if (waited < thinkFrames) {
+          waited++
+          // Thinking. The hand is on the stick, so the guard never runs down —
+          // and this is also the only way to spend real time in a beat now.
+          world.aimX = world.px + (waited % 2 === 0 ? 40 : -40)
+          world.aimY = world.py
+        } else {
+          const i = res.spheres[res.correctSlot] as number
+          if (i >= 0 && world.malive[i]) {
+            world.aimX = world.mx[i] as number
+            world.aimY = world.my[i] as number
+          }
+        }
+      }
+      world.step(1 / 60)
+      for (let e = 0; e < world.eventLen; e++) {
+        // `a` is the mass gained; `r` is the quickness the world paid it at —
+        // `resolveResonance` puts it there so the presentation layer can spend it
+        // on spectacle without recomputing it.
+        const ev = world.events[e] as { kind: string; a: number; r: number }
+        if (ev.kind !== "resonance-hit") continue
+        gain = ev.a
+        quick = ev.r
+      }
+    }
+    return { gain, quick, mass: 0 }
+  }
+
+  const brisk = play(0)
+  const slow = play(60 * 20)
+  assert.ok(brisk.quick > 0.5, `an immediate answer scored quickness ${brisk.quick.toFixed(2)}`)
+  assert.ok(slow.quick <= 0.001, `a twenty-second answer still scored quickness ${slow.quick.toFixed(2)}`)
+  assert.ok(brisk.gain > slow.gain, `being fast paid ${brisk.gain.toFixed(1)} against ${slow.gain.toFixed(1)} for being slow`)
+  assert.ok(slow.gain > 0, "a slow correct answer paid nothing at all — slowness must never be a punishment")
+})
+
+/**
+ * The invariant, measured through the REAL scheduler rather than by calling
+ * `guardSeconds` twice.
+ *
+ * `window.test.ts` proves the function is monotone and pure. This proves the game
+ * installs what the function returned, on every beat, over a real run — which is
+ * the assertion that survives somebody adding a "just a small nudge" multiplier
+ * inside `openResonance`.
+ *
+ * Twenty minutes at each of three abilities, every beat's guard recorded against
+ * the item that produced it. Two claims: the guard the world installed is exactly
+ * the item's, and across the whole population a wider item never got less.
+ */
+test("through the real scheduler, the guard is the item's and a harder item never gets less", () => {
+  type Seen = { prompt: string; answer: string; guard: number; p90: number; intensity: number }
+  const seen: Seen[] = []
+
+  for (const accuracy of [0, 0.5, 1]) {
+    const asked = new Map<string, Question>()
+    const stub = createStubHost({ seed: 5150 })
+    const host: Host = {
+      next: (o) => {
+        const q = stub.next(o)
+        asked.set(q.id, q)
+        return q
+      },
+      report: (r) => stub.report(r),
+      haptic: () => {},
+      prefersReducedMotion: () => false,
+    }
+    const world = new World(host, specFor("mid"), 8080)
+    let lastId = ""
+    fly(world, 1200, accuracy, 4242, () => {
+      const res = world.resonance
+      if (!res.active || res.phase < 1 || !res.question) return
+      if (res.question.id === lastId) return
+      lastId = res.question.id
+      const q = asked.get(res.question.id) as Question
+      seen.push({
+        prompt: q.prompt,
+        answer: q.answer,
+        guard: res.guard,
+        p90: comprehensionSeconds({ prompt: q.prompt, answer: q.answer }),
+        intensity: world.intensity,
+      })
+    })
+  }
+
+  assert.ok(seen.length >= 60, `only ${seen.length} questions in an hour of play across three abilities`)
+
+  // 1. What the world installed is what the item asked for. No fudge factor, no
+  //    scaling, no floor applied on the way through.
+  for (const s of seen) {
+    assert.equal(
+      s.guard,
+      guardSeconds({ prompt: s.prompt, answer: s.answer }),
+      `"${s.prompt}" was given a ${s.guard}s guard, not the item's own`,
+    )
+  }
+
+  // 2. The population is monotone in the item's own difficulty. Sorted by p90,
+  //    the guard may never step down.
+  const sorted = [...seen].sort((a, b) => a.p90 - b.p90)
+  for (let i = 1; i < sorted.length; i++) {
+    const lo = sorted[i - 1] as Seen
+    const hi = sorted[i] as Seen
+    assert.ok(
+      hi.guard >= lo.guard,
+      `"${hi.prompt}" (p90 ${hi.p90}s) got ${hi.guard}s while the easier "${lo.prompt}" (p90 ${lo.p90}s) got ${lo.guard}s`,
+    )
+  }
+
+  // 3. And the same item text always got the same guard, however hot the run was
+  //    when it came up. This is the assertion the old `resonanceSeconds` failed.
+  const byPrompt = new Map<string, Seen[]>()
+  for (const s of seen) {
+    const list = byPrompt.get(s.prompt) ?? []
+    list.push(s)
+    byPrompt.set(s.prompt, list)
+  }
+  let compared = 0
+  for (const [prompt, group] of byPrompt) {
+    if (group.length < 2) continue
+    const spread = Math.max(...group.map((g) => g.intensity)) - Math.min(...group.map((g) => g.intensity))
+    for (const g of group) {
+      assert.equal(
+        g.guard,
+        (group[0] as Seen).guard,
+        `"${prompt}" got ${g.guard}s once and ${(group[0] as Seen).guard}s another time`,
+      )
+    }
+    if (spread > 0.2) compared++
+  }
+  assert.ok(compared > 0, "no item ever came up twice at meaningfully different intensities, so the claim is untested")
+
+  const widest = seen.reduce((m, s) => Math.max(m, s.p90), 0)
+  const narrowest = seen.reduce((m, s) => Math.min(m, s.p90), 1e9)
+  assert.ok(
+    widest > narrowest,
+    `every question in an hour of play was the same class (p90 ${widest}s) — the monotonicity claim is vacuous`,
+  )
+  console.log(
+    `[measured] ${seen.length} questions through the real scheduler, ` +
+      `p90 ${narrowest}s..${widest}s, guard ${narrowest * 10}s..${widest * 10}s, ` +
+      `${byPrompt.size} distinct prompts`,
+  )
+})
+
+/**
+ * The lurch, and why it was arithmetic rather than judgement.
+ *
+ *   "the higher levels need to come more gently and not jump right into Max Cohen
+ *    mode"
+ *
+ * `DIFFICULTY_RUNGS` is 10; the shared bridge maps a 1..10 ladder index onto the
+ * host's ladder as `(value - 1) / 9`; the host's ladder is **66 rungs**. So the
+ * integer request `rung + 1` could only ever name curriculum rungs
+ * {0, 7, 14, 22, 29, 36, 43, 51, 58, 65} — and one step of ARENA's breath was a
+ * 7.2-rung jump. Measured through the real host:
+ *
+ *     ARENA rung 6 -> curriculum 43 -> dw.add.regroup.add-multidigit L2  `506 + 394`
+ *     ARENA rung 7 -> curriculum 51 -> dw.div.whole.divide-exact L3      `721308 ÷ 84`
+ *
+ * Unrounded, the same climb walks the ladder a rung at a time.
+ */
+/**
+ * The host's ladder, as the bridge maps ARENA's request onto it: `(d - 1) / 9`
+ * across 66 curriculum rungs. Both figures are the host's and neither is ARENA's
+ * to choose, so they are stated here as the frame the measurement is read in.
+ */
+const CURRICULUM_RUNGS = 66
+
+/** Every difficulty ARENA asked for in `seconds` of play, as curriculum rungs. */
+function requestedRungs(seconds: number, accuracy: number, seed: number): number[] {
+  const asks: number[] = []
+  const stub = createStubHost({ seed: 66 })
+  const host: Host = {
+    next: (o) => {
+      if (o?.difficulty !== undefined) {
+        assert.ok(
+          (o.difficulty as number) >= 1 && (o.difficulty as number) <= 10,
+          `asked the host for difficulty ${String(o.difficulty)}, outside the 1..10 ladder scale the bridge documents`,
+        )
+        asks.push(Math.round((((o.difficulty as number) - 1) / 9) * (CURRICULUM_RUNGS - 1)))
+      }
+      return stub.next(o)
+    },
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => false,
+  }
+  const world = new World(host, specFor("mid"), seed)
+  fly(world, seconds, accuracy, 271)
+  return asks
+}
+
+test("the climb walks the curriculum a rung at a time, and a lucky streak cannot reach the top", () => {
+  const perfect = requestedRungs(900, 1, 3141)
+  assert.ok(perfect.length >= 20, `only ${perfect.length} questions were asked in fifteen minutes`)
+
+  const distinct = new Set(perfect)
+  let smallestStep = Infinity
+  let largestStep = 0
+  for (let i = 1; i < perfect.length; i++) {
+    const step = Math.abs((perfect[i] as number) - (perfect[i - 1] as number))
+    if (step > 0) smallestStep = Math.min(smallestStep, step)
+    largestStep = Math.max(largestStep, step)
+  }
+  console.log(
+    `[measured] a perfect player, 15 min: ${perfect.length} requests, ` +
+      `${distinct.size} distinct curriculum rungs of ${CURRICULUM_RUNGS}, ` +
+      `steps ${smallestStep}..${largestStep}, highest rung ${Math.max(...perfect)}`,
   )
 
-  // Struggle: the window gets LONGER, never shorter.
-  const before = world.resonanceSeconds
-  fly(world, 300, 0, 13)
+  // THE LURCH, first, because it is the founder's actual sentence and every other
+  // assertion here is a corroborating measurement of it. Before this pass a
+  // perfect player's requests went `0, 3, 21, 25, 32, 39, 47, 55, 63, 65` — an
+  // EIGHTEEN-rung step between two consecutive questions.
   assert.ok(
-    world.resonanceSeconds >= before - 1e-9,
-    `five minutes of struggle SHRANK the window ${before.toFixed(1)} -> ${world.resonanceSeconds.toFixed(1)}`,
+    largestStep <= 4,
+    `one answer moved the child ${largestStep} curriculum rungs — that is "jump right into Max Cohen mode", and it is what this test exists to stop`,
   )
 
-  // Climb, and a real countdown appears — earned, not imposed.
-  const ace = new World(createStubHost({ seed: 8 }), specFor("mid"), 55)
-  fly(ace, 420, 1, 13)
-  assert.ok(ace.resonanceSeconds < 14, `a mathlete was still given ${ace.resonanceSeconds.toFixed(1)}s`)
-  assert.ok(ace.sphereDrift > 5, "…and the spheres never started moving")
-  assert.ok(ace.intensity > world.intensity)
+  // "You get a few right just by being lucky and all of a sudden you are asked to
+  // do like 87364/9." Five-digit long division is around curriculum rung 40; the
+  // top of the ladder is 65. Neither is reachable on a short lucky streak.
+  const firstFive = perfect.slice(0, 5)
+  assert.ok(
+    Math.max(...firstFive) < 12,
+    `five correct answers put a child on curriculum rung ${Math.max(...firstFive)} of ${CURRICULUM_RUNGS - 1} — a lucky streak reached content nobody has shown they can do`,
+  )
+
+  // Ten is what an INTEGER request could reach at all: `rung + 1` over
+  // `DIFFICULTY_RUNGS` = 10 could only ever name curriculum rungs
+  // {0, 7, 14, 22, 29, 36, 43, 51, 58, 65}. Anything past ten distinct rungs is a
+  // resolution the old request did not have.
+  assert.ok(
+    distinct.size > DIFFICULTY_RUNGS,
+    `the climb reached only ${distinct.size} distinct curriculum rungs — ten is all the old integer request could name`,
+  )
+  // …and it can step by ONE. Measured before this pass, the smallest non-zero step
+  // a perfect player's request ever took was 2, and the median was 7.
+  assert.ok(
+    smallestStep <= 1,
+    `the smallest non-zero step up the curriculum was ${smallestStep} rungs, so the ladder is still quantised`,
+  )
+  // Crossing the whole ladder takes the number of answers the HOST's own
+  // recalibrated ladder would take — see `LADDER_CLIMB_ANSWERS`. Fifteen minutes
+  // of flawless play is about 33 answers, so it must not be at the top yet.
+  assert.ok(
+    Math.max(...perfect) < CURRICULUM_RUNGS - 1,
+    `flawless play reached the very top of the curriculum in ${perfect.length} answers`,
+  )
+
+  // A child at the founder's own "right level" sits, rather than being raced.
+  const sitting = requestedRungs(900, 0.85, 3141)
+  console.log(
+    `[measured] an 85%-correct player, 15 min: rungs ${Math.min(...sitting)}..${Math.max(...sitting)} of ${CURRICULUM_RUNGS - 1}`,
+  )
+  assert.ok(
+    Math.max(...sitting) < 30,
+    `a child right 85% of the time was carried to curriculum rung ${Math.max(...sitting)} — "if you are getting 85% you are at the right level"`,
+  )
+
+  // And a struggling child is at the bottom, which is the property that must not
+  // regress in the other direction.
+  const lost = requestedRungs(600, 0, 3141)
+  assert.ok(Math.max(...lost) <= 4, `a child getting everything wrong was asked for curriculum rung ${Math.max(...lost)}`)
+})
+
+/**
+ * The answer does not move, **including at the edge of the world.**
+ *
+ * `sphereOrbit` rotates the ring about the ring's own centre; `stepMotes` clamps
+ * every live mote radially about the WORLD ORIGIN. Those two disagree, and with the
+ * player parked against the membrane they fight: the rotation carries a sphere
+ * outside `arenaR`, the clamp drags it back toward the origin, and the ring slides
+ * along the membrane instead of turning in place.
+ *
+ * The pull and the flip in `stepMotes` already skipped `MK_ANSWER`; the clamp was
+ * the one of the three that did not. Narrow — `ringR` is about 0.3% of `arenaR` —
+ * but `sphereOrbit` and the README both promise the answer is exactly where the
+ * child found it ten minutes later, with no qualification, so the code should hold
+ * it with no qualification.
+ */
+test("the answer stays put even with the player pinned against the membrane", () => {
+  const reports: unknown[] = []
+  const world = new World(createStubHost({ seed: 17, onReport: (r) => reports.push(r) }), specFor("low"), 2024)
+  // Open a beat, then put the player hard against the membrane so the clamp and
+  // the rotation are both live on the same spheres.
+  let opened = false
+  for (let f = 0; f < 60 * 120 && !opened; f++) {
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+    opened = world.resonance.active && world.resonance.phase === 2
+  }
+  assert.ok(opened, "no Resonance opened")
+
+  const res = world.resonance
+  const edge = world.arenaR
+  // Move the player and the whole ring out to the membrane together, so the ring
+  // straddles it — the geometry the clamp would fight.
+  const dx = edge - res.centreX
+  const dy = -res.centreY
+  world.px += dx
+  world.py += dy
+  res.centreX += dx
+  res.centreY += dy
+  for (let s = 0; s < 4; s++) {
+    const i = res.spheres[s] as number
+    if (i < 0) continue
+    world.mx[i] = (world.mx[i] as number) + dx
+    world.my[i] = (world.my[i] as number) + dy
+  }
+  const radii = (): number[] => {
+    const out: number[] = []
+    for (let s = 0; s < 4; s++) {
+      const i = res.spheres[s] as number
+      if (i < 0 || !world.malive[i]) continue
+      out.push(Math.hypot((world.mx[i] as number) - res.centreX, (world.my[i] as number) - res.centreY))
+    }
+    return out
+  }
+  const before = radii()
+  assert.equal(before.length, 4, "the ring was not intact before the measurement")
+  assert.ok(
+    before.some((r, k) => Math.hypot(res.centreX, res.centreY) + r > edge && k >= 0),
+    "the ring does not actually straddle the membrane, so the clamp is not being exercised",
+  )
+
+  const reportsAtStart = reports.length
+  for (let f = 0; f < 60 * 30; f++) {
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+  }
+
+  // **The ring must still be a ring**, asserted BEFORE the radii and by count.
+  //
+  // The first cut of this compared `before[k]` against `after[k]` over
+  // `after.length`, and the defect it was written for retires spheres — so the two
+  // arrays had different lengths, one surviving sphere was compared against the
+  // first of four, and two equal numbers agreed about nothing. Measured under the
+  // mutation: three of the four spheres were gone inside 253 frames.
+  const after = radii()
+  assert.equal(
+    after.length,
+    4,
+    `${4 - after.length} of the four spheres were consumed while the child sat still at the membrane`,
+  )
+
+  // …and what consumed them was the clamp pushing one into the player, which the
+  // beat read as the child CHOOSING it. That is the severe form of this bug: a
+  // verdict, and a mass penalty, for an answer nobody gave.
+  assert.equal(
+    reports.length,
+    reportsAtStart,
+    "a sphere was pushed into a motionless child and answered the question for them",
+  )
+
+  for (let k = 0; k < 4; k++) {
+    const r0 = before[k] as number
+    const r1 = after[k] as number
+    assert.ok(
+      Math.abs(r1 - r0) < r0 * 0.02,
+      `sphere ${k} slid from ${r0.toFixed(0)} to ${r1.toFixed(0)} units from the ring centre at the membrane`,
+    )
+  }
+})
+
+/**
+ * **Stalling must not make the maths harder.**
+ *
+ * `LADDER_CLIMB_ANSWERS` is stated in ANSWERS and converted to seconds on the
+ * assumption that seconds only pass between answers — and an allowance of up to
+ * ten minutes breaks that assumption inside a single unanswered beat. With the
+ * leash on raw `dt`, measured: six correct answers put the request on curriculum
+ * rung 9, and then two ABANDONED questions — nothing answered, nothing reported,
+ * nothing taken — carried it to rung 40, which is five-digit long division.
+ *
+ * Two things wrong with that at once. Answering nothing was a way to make the
+ * questions harder; and a child who takes the founder's ten minutes on paper and
+ * gets it right was charged nearly half the ladder for the minutes they spent
+ * thinking. Both are the bill for thinking that this pass exists to cancel.
+ */
+test("stalling on a question does not climb the ladder", () => {
+  const item = { prompt: "34801 ÷ 37", answer: "941" }
+  const host: Host = {
+    next: () => ({
+      id: "long-1",
+      prompt: item.prompt,
+      answer: item.answer,
+      distractors: ["942", "940", "951"],
+      domain: "divide",
+      difficulty: 5,
+    }),
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => false,
+  }
+  const world = new World(host, specFor("low"), 606)
+
+  // Answer six correctly and fast, so the BREATH is pinned at its ceiling and the
+  // leash is genuinely in its climbing branch. Without this the test exercises the
+  // falling branch and proves nothing.
+  let answered = 0
+  for (let f = 0; f < 60 * 600 && answered < 6; f++) {
+    const res = world.resonance
+    if (res.active && res.phase === 2) {
+      const i = res.spheres[res.correctSlot] as number
+      if (i >= 0 && world.malive[i]) {
+        world.aimX = world.mx[i] as number
+        world.aimY = world.my[i] as number
+      }
+    }
+    world.step(1 / 60)
+    for (let e = 0; e < world.eventLen; e++) {
+      if ((world.events[e] as { kind: string }).kind === "resonance-hit") answered++
+    }
+  }
+  assert.equal(answered, 6, `only ${answered} answers landed, so the climbing branch was never entered`)
+  assert.ok(world.intensity > 0.9, `the breath is only at ${world.intensity.toFixed(3)}, so the leash is not climbing`)
+  const beforeStall = world.ladderPosition
+  assert.ok(beforeStall > 0, "the ladder never left the floor, so a rise could not be detected")
+
+  // Now stall out two whole allowances without answering anything.
+  let fades = 0
+  for (let f = 0; f < 60 * 1500 && fades < 2; f++) {
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+    for (let e = 0; e < world.eventLen; e++) {
+      if ((world.events[e] as { kind: string }).kind === "resonance-fade") fades++
+    }
+  }
+  assert.equal(fades, 2, `only ${fades} questions were abandoned, so the claim is untested`)
+
+  // Time passed — twenty minutes of it — and the ladder did not move, because
+  // none of it was time anybody answered in.
+  // Exactly nothing, not merely "not much": the leash is paid in answers, so with
+  // no answers there is no rung to spend. A per-second version leaked here.
+  const climbed = world.ladderPosition - beforeStall
+  assert.ok(
+    climbed <= 1e-9,
+    `two abandoned questions carried the request ${(climbed * 100).toFixed(1)}% of the way up the ladder ` +
+      `(${beforeStall.toFixed(3)} -> ${world.ladderPosition.toFixed(3)}, about curriculum rung ` +
+      `${Math.round(world.ladderPosition * 65)} of 65) without a single answer`,
+  )
+})
+
+/**
+ * Relief is not earned. The maths ladder falls as fast as the breath does.
+ *
+ * The leash on `mathsIntensity` is one-directional on purpose, and it is the same
+ * asymmetry `game-pacing` already applies to `fallSeconds` and #715 applies to its
+ * bands: "Up needs two things, down needs one." A slew limit in both directions
+ * would be a child who missed four in a row still being asked for long division
+ * twenty minutes later.
+ */
+test("a struggling child's questions get easier at once, not on a leash", () => {
+  const world = new World(createStubHost({ seed: 71 }), specFor("mid"), 1717)
+  // Climb first, so there is something to fall from.
+  fly(world, 900, 1, 271)
+  const high = world.mathsIntensity
+  assert.ok(high > 0.2, `the climb never got anywhere: mathsIntensity ${high.toFixed(3)}`)
+
+  // Now miss everything, and watch the two scalars come down together.
+  fly(world, 120, 0, 271)
+  assert.ok(
+    world.mathsIntensity <= world.intensity + 1e-9,
+    `the maths lagged the breath on the way DOWN: ${world.mathsIntensity.toFixed(3)} against ${world.intensity.toFixed(3)}`,
+  )
+  assert.ok(
+    world.mathsIntensity < high * 0.5,
+    `two minutes of missing everything only took the maths from ${high.toFixed(3)} to ${world.mathsIntensity.toFixed(3)}`,
+  )
+})
+
+/**
+ * Thinking is not run time.
+ *
+ * With no length on a Resonance the quiet tide became a bill for using the
+ * founder's invitation: eight minutes on paper is more than the tide's whole
+ * 420-second ramp, so a child would put the tablet down in a calm ocean and pick
+ * it up in a fully escalated one. The tide rides `playTime`, which excludes every
+ * second the arena spent inert.
+ */
+test("time spent thinking does not escalate the ocean", () => {
+  // A child who does exactly what the founder invited: opens a long question, puts
+  // the tablet on the table, and works it out. Nothing is eaten, nothing is
+  // gained, and the aim never moves — the guard's own design case.
+  const longHost: Host = {
+    next: () => ({
+      id: "long-1",
+      prompt: "34801 ÷ 37",
+      answer: "941",
+      distractors: ["942", "940", "951"],
+      domain: "divide",
+      difficulty: 5,
+    }),
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => false,
+  }
+  const world = new World(longHost, specFor("mid"), 12321)
+
+  // Fly to the first open beat, and photograph the world.
+  let opened = false
+  for (let f = 0; f < 60 * 120 && !opened; f++) {
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+    opened = world.resonance.active && world.resonance.phase === 2
+  }
+  assert.ok(opened, "no Resonance opened")
+  const before = {
+    depth: world.depth.index,
+    over: world.over,
+    world: world.worldIntensity,
+    hunters: world.hunterBudget,
+    voids: world.voidRate,
+    mass: world.mass,
+    play: world.playTime,
+  }
+  assert.ok(world.resonance.guard >= 600, `the beat only carried a ${world.resonance.guard}s guard`)
+
+  // Sit out the entire guard without touching anything.
+  let inert = 0
+  for (let f = 0; f < 60 * 900; f++) {
+    if (world.resonance.active) inert++
+    world.aimX = world.px
+    world.aimY = world.py
+    world.step(1 / 60)
+    if (!world.resonance.active && inert > 60 * 300) break
+  }
+  assert.ok(inert > 60 * 550, `only ${(inert / 60).toFixed(0)}s was spent inside the beat`)
+
+  // 1. The bookkeeping. `playTime` did not advance while the arena was inert.
+  assert.ok(
+    Math.abs(world.playTime - before.play) < 2,
+    `${(world.playTime - before.play).toFixed(1)}s of thinking was charged to the run`,
+  )
+
+  // 2. THE ESCALATION SPINE, and this is the assertion the first cut of this test
+  //    was missing. `refreshDepth` was still on `this.time`, and `DEPTH_CLOCK_SECONDS`
+  //    is 100 with a floored band — so ten minutes of thinking sank the run six
+  //    bands, from DRIFT to THE ABYSSAL, and handed the child back four hunters, a
+  //    leviathan, 18% void motes and temper 0.86. It never came back, because the
+  //    band cannot fall. Asserting only the `playTime` arithmetic left that green.
+  assert.equal(
+    world.depth.index,
+    before.depth,
+    `thinking sank the run from depth ${before.depth} to depth ${world.depth.index} — the child paid for the paper in hunters`,
+  )
+  assert.ok(
+    world.over <= before.over + 1e-9,
+    `thinking drove overdrive from ${before.over.toFixed(3)} to ${world.over.toFixed(3)}`,
+  )
+  assert.ok(
+    world.worldIntensity <= before.world + 1e-9,
+    `thinking drove the world from ${before.world.toFixed(3)} to ${world.worldIntensity.toFixed(3)}`,
+  )
+  assert.ok(world.hunterBudget <= before.hunters, `thinking bought ${world.hunterBudget - before.hunters} extra hunters`)
+  assert.ok(world.voidRate <= before.voids + 1e-9, "thinking put more void motes in the water")
+
+  // 3. …and it cost no mass either, which is the other half of "takes nothing".
+  assert.ok(world.mass >= before.mass, `thinking cost ${(before.mass - world.mass).toFixed(1)} mass`)
+
+  // 4. And the ladder did not climb on seconds nobody answered in. With the leash
+  //    on raw `dt`, two abandoned questions moved the request from curriculum rung
+  //    9 to rung 40 — five-digit long division, bought by answering nothing.
+  assert.ok(
+    world.ladderPosition <= 0.12,
+    `stalling carried the request to ladder position ${world.ladderPosition.toFixed(3)} without answering anything`,
+  )
 })
 
 /** Mashing must not be a strategy, and must not be punished either. */

--- a/dynawalla/games/arena/src/sim/window.test.ts
+++ b/dynawalla/games/arena/src/sim/window.test.ts
@@ -1,0 +1,297 @@
+// THE SILENCE GUARD, held to the four things it claims.
+//
+// It is derived from the item. It is monotone non-decreasing in the item's
+// difficulty. Nothing about the run can reach it. And it is never a countdown.
+//
+// The first three are properties of `window.ts` and are asserted here over the
+// whole cross product the table can express. The fourth is a property of the
+// WORLD, and lives in `sim.test.ts` where a real scheduler can be flown.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { readFileSync } from "node:fs"
+
+import {
+  ABANDON_FACTOR,
+  MAX_COLUMNS,
+  MAX_GUARD_SECONDS,
+  MIN_GUARD_SECONDS,
+  comprehensionSeconds,
+  guardSeconds,
+  invitesPaper,
+  needsRegrouping,
+  opOf,
+  widestColumn,
+  type Item,
+} from "./window.ts"
+
+/** An item as the host hands it over: two strings and nothing else. */
+const it = (prompt: string, answer: string): Item => ({ prompt, answer })
+
+/**
+ * The house cadence table's own anchors, plus the two the founder named.
+ *
+ * `docs/EXPERIENCE_DESIGN.md`, p50/p90:
+ *
+ *     single-digit fact           2.8s / 6s
+ *     two-digit with regrouping     6s / 14s
+ *     the `5,001 − 2,798` class    16s / 40s
+ *
+ * The guard is sized off the **p90** column — see the module note — so the
+ * expectations below are `ABANDON_FACTOR ×` those rows.
+ */
+const ANCHORS: Array<{ item: Item; p90: number; note: string }> = [
+  { item: it("7 + 5", "12"), p90: 6, note: "TABLE ROW: single-digit fact, 2.8s/6s" },
+  { item: it("47 + 25", "72"), p90: 14, note: "TABLE ROW: two-digit with regrouping, 6s/14s" },
+  { item: it("5001 − 2798", "2203"), p90: 40, note: "TABLE ROW: the 5,001 − 2,798 class, 16s/40s" },
+  { item: it("43 + 25", "68"), p90: 11, note: "interpolated: two digits, no regrouping" },
+  { item: it("473 + 168", "641"), p90: 23, note: "interpolated: three digits with regrouping" },
+  { item: it("34801 ÷ 37", "941"), p90: 60, note: "extrapolated: the item the founder named" },
+]
+
+test("every anchor of the house cadence table lands where the table says", () => {
+  const rows: string[] = []
+  for (const { item, p90, note } of ANCHORS) {
+    const got = comprehensionSeconds(item)
+    const guard = guardSeconds(item)
+    rows.push(
+      `  ${item.prompt.padEnd(14)} p90 ${String(got).padStart(3)}s  guard ${String(guard).padStart(4)}s   (${note})`,
+    )
+    assert.equal(got, p90, `${item.prompt} was scored at ${got}s against the table's ${p90}s — ${note}`)
+  }
+  console.log("[measured] the guard, per item class:\n" + rows.join("\n"))
+})
+
+/**
+ * The whole point, stated as the number he asked for.
+ *
+ * "invite the kid to take out a piece of paper and work it out for 10 minutes for
+ * the points". `ABANDON_FACTOR` is derived from this rather than tuned toward it:
+ * ten times the 60s p90 of five-column long division is ten minutes.
+ */
+test("the hardest thing ARENA serves gets the founder's ten minutes, and it is derived", () => {
+  assert.equal(guardSeconds(it("34801 ÷ 37", "941")), 600, "34801 ÷ 37 does not get ten minutes")
+  assert.equal(
+    ABANDON_FACTOR * comprehensionSeconds(it("34801 ÷ 37", "941")),
+    600,
+    "the ten minutes is a coincidence of the clamps rather than the factor times the p90",
+  )
+  assert.equal(MAX_GUARD_SECONDS, 600, `the longest silence anything can ask for is ${MAX_GUARD_SECONDS}s`)
+  // …and nothing can reach past it, however wide the prompt.
+  assert.equal(
+    guardSeconds(it("123456789012 ÷ 987654321", "124")),
+    MAX_GUARD_SECONDS,
+    "a twelve-column prompt escaped the table's last row",
+  )
+})
+
+/**
+ * The invariant, over the whole cross product rather than at three points.
+ *
+ * `docs/PACING_AUDIT_2026-07.md`: "`window(d)` must be MONOTONE NON-DECREASING in
+ * item difficulty. A harder question may never get less time than an easier one."
+ *
+ * Difficulty here has three axes the table can express — column count, whether a
+ * column regroups, and whether the operation is a partial-product one — and the
+ * assertion walks all of them.
+ */
+test("more columns is never less time, and regrouping is never less time than not", () => {
+  // Column count, plain addition, no carry anywhere: 1 + 1, 11 + 11, 111 + 111…
+  let prev = 0
+  for (let n = 1; n <= 8; n++) {
+    const operand = "1".repeat(n)
+    const answer = "2".repeat(n)
+    const got = comprehensionSeconds(it(`${operand} + ${operand}`, answer))
+    assert.ok(got >= prev, `${n} columns got ${got}s against ${n - 1} columns' ${prev}s`)
+    prev = got
+  }
+
+  // Regrouping never buys less. Same width, carry vs no carry, every width.
+  for (let n = 1; n <= 6; n++) {
+    const plainA = "1".repeat(n)
+    const plainB = "1".repeat(n)
+    const carryA = "9".repeat(n)
+    const carryB = "9".repeat(n)
+    const plain = comprehensionSeconds(it(`${plainA} + ${plainB}`, String(Number(plainA) + Number(plainB))))
+    const carry = comprehensionSeconds(it(`${carryA} + ${carryB}`, String(Number(carryA) + Number(carryB))))
+    assert.ok(carry >= plain, `at ${n} columns, regrouping got ${carry}s against ${plain}s for not regrouping`)
+  }
+
+  // The table's own internal condition, which is what makes the two axes compose:
+  // a regrouping item at n columns may never outrank a PLAIN item at n + 1.
+  for (let n = 1; n < MAX_COLUMNS; n++) {
+    const carryA = "9".repeat(n)
+    const carry = comprehensionSeconds(it(`${carryA} + ${carryA}`, String(Number(carryA) * 2)))
+    const widerA = "1".repeat(n + 1)
+    const wider = comprehensionSeconds(it(`${widerA} + ${widerA}`, "2".repeat(n + 1)))
+    assert.ok(
+      carry <= wider,
+      `${n} columns with a carry (${carry}s) outranks ${n + 1} plain columns (${wider}s) — the two axes do not compose`,
+    )
+  }
+
+  // And a partial-product operation is never cheaper than the same width of
+  // addition. `12 × 34` is four single-digit products and a two-column sum.
+  for (let n = 2; n <= 5; n++) {
+    const a = "1".repeat(n)
+    const add = comprehensionSeconds(it(`${a} + ${a}`, "2".repeat(n)))
+    const mul = comprehensionSeconds(it(`${a} × ${a}`, "9".repeat(n)))
+    const div = comprehensionSeconds(it(`${a} ÷ ${a}`, "1"))
+    assert.ok(mul >= add, `${n}-column × got ${mul}s against ${n}-column + at ${add}s`)
+    assert.ok(div >= add, `${n}-column ÷ got ${div}s against ${n}-column + at ${add}s`)
+  }
+})
+
+/**
+ * `MAX_COLUMNS` is a literal, so that indexing the tables with it narrows in
+ * TypeScript. This is what stops the literal drifting away from the rows it names
+ * — read off the tables' own reach rather than restated.
+ */
+test("MAX_COLUMNS names the last row of both tables, and the clamp is what bounds the guard", () => {
+  // The last row the tables have: one more column must produce the same answer.
+  const at = (n: number): number =>
+    comprehensionSeconds(it(`${"9".repeat(n)} + ${"9".repeat(n)}`, "1"))
+  assert.ok(at(MAX_COLUMNS) > at(MAX_COLUMNS - 1), `column ${MAX_COLUMNS} is not a row of its own`)
+  assert.equal(at(MAX_COLUMNS + 1), at(MAX_COLUMNS), `column ${MAX_COLUMNS + 1} found a row past the table's last`)
+  assert.equal(at(MAX_COLUMNS + 6), at(MAX_COLUMNS), "a very wide prompt escaped the clamp")
+  // And the ceiling is that row times the factor, not an independent constant.
+  assert.equal(MAX_GUARD_SECONDS, ABANDON_FACTOR * at(MAX_COLUMNS))
+})
+
+test("the guard is never under its floor, and never over the table's last row", () => {
+  const probes = [
+    it("1 + 1", "2"),
+    it("", ""),
+    it("what is the biggest?", "0"),
+    it("factor of 48", "6"),
+    it("less than 1000", "412"),
+    it("0 − 0", "0"),
+  ]
+  for (const p of probes) {
+    const g = guardSeconds(p)
+    assert.ok(g >= MIN_GUARD_SECONDS, `"${p.prompt}" got ${g}s, under the ${MIN_GUARD_SECONDS}s floor`)
+    assert.ok(g <= MAX_GUARD_SECONDS, `"${p.prompt}" got ${g}s, over the ${MAX_GUARD_SECONDS}s ceiling`)
+  }
+})
+
+/**
+ * A prompt this cannot read gets the LONGER silence, always.
+ *
+ * The only direction these classifiers are allowed to be wrong in.
+ */
+test("an item this cannot parse is treated as the harder one, never the easier", () => {
+  const unreadable = [
+    it("factor of 48", "6"),
+    it("less than 1000", "412"),
+    it("Ali has 4 bags of 12 apples. How many apples?", "48"),
+    it("2 + 3 + 4", "9"),
+    it("x + 17 = 42", "25"),
+  ]
+  for (const p of unreadable) {
+    assert.equal(needsRegrouping(p), true, `"${p.prompt}" was assumed not to need regrouping`)
+    // …and it is never cheaper than the plain reading of the same width.
+    const width = widestColumn(p)
+    const plainOfSameWidth = comprehensionSeconds(it(`${"1".repeat(width)} + ${"1".repeat(width)}`, "2".repeat(width)))
+    assert.ok(
+      comprehensionSeconds(p) >= plainOfSameWidth,
+      `"${p.prompt}" got less time than plain addition of the same width`,
+    )
+  }
+})
+
+test("the operator is read from the glyph, including the typographic minus", () => {
+  assert.equal(opOf("7 + 5"), "add")
+  assert.equal(opOf("7 - 5"), "sub")
+  assert.equal(opOf("7 − 5"), "sub", "the curriculum's own U+2212 minus was not recognised")
+  assert.equal(opOf("7 × 5"), "mul")
+  assert.equal(opOf("7 ÷ 5"), "div")
+  assert.equal(opOf("34801 / 37"), "div", "the founder writes it with a slash")
+  assert.equal(opOf("factor of 48"), "other")
+})
+
+/**
+ * The width is the OPERANDS'. `runner`'s finding, and the reason it matters is the
+ * easiest item in the product: counting `7 + 5 = 12`'s two-digit answer put a
+ * single-digit fact in the two-column row at 14 s against the table's own 6 s.
+ */
+test("the width is the operands', and the answer is only a fallback", () => {
+  assert.equal(widestColumn(it("7 + 5", "12")), 1, "a single-digit fact was measured by its two-digit answer")
+  assert.equal(widestColumn(it("999 + 1", "1000")), 3)
+  assert.equal(widestColumn(it("34801 ÷ 37", "941")), 5)
+  // Nothing to measure in the prompt, so the answer stands in.
+  assert.equal(widestColumn(it("factor of forty-eight", "6")), 1)
+  assert.equal(widestColumn(it("how many hundreds?", "1200")), 4)
+  assert.equal(comprehensionSeconds(it("7 + 5", "12")), 6, "the single-digit fact is not on the table's own row")
+})
+
+/**
+ * The paper invitation appears where paper is plausible and nowhere else.
+ *
+ * The HUD prints `NO TIMER · USE PAPER` above the prompt on these and `RESONANCE`
+ * on the rest. Telling a child to fetch a pencil for `7 + 5` is the patronising
+ * version of the same idea, so the threshold is the row the cadence table itself
+ * marks at a 40-second p90.
+ */
+test("the paper invitation appears on long work, and never on a fact", () => {
+  for (const p of [it("7 + 5", "12"), it("43 + 25", "68"), it("47 + 25", "72"), it("473 + 168", "641")]) {
+    assert.equal(invitesPaper(p), false, `"${p.prompt}" told a child to go and get paper`)
+  }
+  for (const p of [it("5001 − 2798", "2203"), it("34801 ÷ 37", "941"), it("718 × 89", "63902")]) {
+    assert.equal(invitesPaper(p), true, `"${p.prompt}" is long work and the child was not told they may use paper`)
+  }
+})
+
+/**
+ * **The decoupling, stated structurally.**
+ *
+ * `games/runner/src/game/comprehension.ts` asserts its own purity by reading its
+ * own source, and it is the right instrument: a test that merely checks two calls
+ * agree passes the moment somebody adds an optional `intensity` argument with a
+ * default. The invariant is that there is NOTHING IN SCOPE that could tell this
+ * module about the run, and the only way to assert that is over the text.
+ */
+test("nothing about the run is in scope in window.ts — asserted over its source", () => {
+  const src = readFileSync(new URL("./window.ts", import.meta.url), "utf8")
+
+  const imports = src.match(/^\s*import\b.*$/gm) ?? []
+  assert.deepEqual(
+    imports,
+    [],
+    `window.ts imports something: ${JSON.stringify(imports)}. It must be able to see the item and nothing else.`,
+  )
+
+  // Strip the comment block, which legitimately discusses every one of these by
+  // name while explaining why none of them may appear in the code.
+  const code = src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "")
+    .replace(/^\s*\*.*$/gm, "")
+
+  for (const forbidden of [
+    "intensity",
+    "worldIntensity",
+    "rung",
+    "ladderPosition",
+    "depth",
+    "mass",
+    "speed",
+    "surge",
+    "overdrive",
+    "success",
+    "resonanceCount",
+    "elapsed",
+    "playTime",
+    "performance",
+    "Date",
+  ]) {
+    assert.ok(
+      !new RegExp(`\\b${forbidden}\\b`).test(code),
+      `window.ts's CODE mentions \`${forbidden}\` — the window must be a function of the item alone`,
+    )
+  }
+
+  // And the two functions the world calls take exactly one argument.
+  assert.equal(guardSeconds.length, 1, "guardSeconds takes more than the item")
+  assert.equal(comprehensionSeconds.length, 1, "comprehensionSeconds takes more than the item")
+  assert.equal(invitesPaper.length, 1, "invitesPaper takes more than the item")
+})

--- a/dynawalla/games/arena/src/sim/window.ts
+++ b/dynawalla/games/arena/src/sim/window.ts
@@ -1,0 +1,402 @@
+// THE SILENCE GUARD — how long the arena waits, and why it is not a clock.
+//
+// **There is no time limit on a Resonance.** A child may look at the question
+// for as long as they like. They may put the tablet on the table, take out a
+// piece of paper, work `34,801 ÷ 37` out in columns, and come back to four
+// spheres still sitting exactly where they left them. That is the founder's
+// instruction, verbatim:
+//
+//   > "if you can do something like 34801 / 37 in your head in 5 seconds you
+//   >  are a total math stud .. the higher levels need to come more gently and
+//   >  not jump right into Max Cohen mode ... maybe they allow infinite time and
+//   >  even invite the kid to take out a piece of paper and work it out for 10
+//   >  minutes for the points instead of just encouraging them to make a quick
+//   >  guess."
+//
+// ── What was here before ────────────────────────────────────────────────────
+//
+// `World.resonanceSeconds`, and it was a curve on the pacing controller:
+//
+//     valueAt(intensity, 26, 6, "gentle")
+//
+// 26 s at the floor of the ladder, earning down to 6 s at the top. That was
+// deliberate and it was defended — the shrinking window was ARENA's *reward for
+// mastery*, a countdown a player opted into by proving they were fast, never one
+// imposed on a struggling child. On the content it was written for it was right.
+//
+// It is not right for the content the ladder actually reaches. `EXPERIENCE_DESIGN.md`
+// puts long division on five digits in the **16 s p50 / 40 s p90** class. A 6 s
+// window is a third of the *median* and a seventh of the p90 — so the one player
+// the curve rewarded with a countdown is the only player whose questions were too
+// long to answer inside it. Excitement and comprehension were on one knob, and
+// the knob was labelled excitement.
+//
+// `docs/PACING_AUDIT_2026-07.md` names that as one design error replicated across
+// seventeen games and states the invariant this module exists to satisfy:
+//
+//     **`window(d)` must be MONOTONE NON-DECREASING in item difficulty, and a
+//     pure function of the item.** A harder question may never get less time
+//     than an easier one.
+//
+// **So nothing about the run may reach this file.** No intensity, no rung, no
+// depth, no mass, no speed, no elapsed time, no answer count. There is nothing in
+// this module's imports that could supply one, because there are no imports —
+// `window.test.ts` asserts that by reading this file's own source, the way
+// `games/runner/src/game/comprehension.ts` does.
+//
+// ── What replaced it, and why it is a different kind of thing ────────────────
+//
+// Not a longer window. **No window.** `games/claim` (#673) and
+// `games/counterweight` (#707) both reached the same conclusion and deleted
+// theirs, and `claim` wrote down the rule:
+//
+//     **A clock may never take anything away from a child.**
+//
+// What is left is an **allowance**, and every one of its properties is the
+// opposite of a countdown:
+//
+//   1. **It is derived from the item**, monotone non-decreasing in its
+//      difficulty, which is what the invariant above asks for — and it is TEN
+//      TIMES the p90 of the arithmetic rather than one, so it is not a pace
+//      anybody is held to. Sixty seconds on `7 + 5`; ten minutes on
+//      `34,801 ÷ 37`.
+//   2. **It is not drawn.** Nothing in `render/` or `ui/` reads it. There is no
+//      bar, no ring, no number and no draining anything, so there is nothing for
+//      a child to watch being taken away. `games/counterweight` found that a
+//      visible draining countdown is an anxiety cue *regardless of how much time
+//      it grants* — "the action is rushed by the timer going down" — and that is
+//      the property this satisfies, not the length.
+//   3. **On running out it reports nothing and takes nothing.** That was already
+//      true of ARENA's timeout before this pass and it stays true: the beat
+//      fades, the host is never told, the pacing controller never moves, and the
+//      question comes back later. A child who was still carrying the hundreds
+//      column has told us nothing about what they know.
+//   4. **And the seconds are free in the world too.** The arena is inert during a
+//      beat, so `World.playTime` excludes them and the depth clock, the
+//      overdrive and the quiet tide all ride that. A child cannot come back from
+//      the paper to a meaner ocean. Without this the guard would simply have
+//      moved the bill rather than cancelled it — measured, ten minutes of
+//      thinking sank a run six depth bands.
+//
+// ── Why it is NOT refilled by input, where claim and counterweight refill ────
+//
+// Both of those reset their guard on any hand on the controls, and both are right
+// to: in `counterweight` a hand on the rack is *striking the plates that answer
+// the question*, so input is engagement.
+//
+// ARENA's only control is **steering**, and steering is not answering. A first cut
+// of this refilled on aim movement and inverted the two populations it cares
+// about: a child working on paper has their hands off the glass, so their aim is
+// still and the guard ran down on the one child it exists to protect — while a
+// child ignoring the question and swimming about held the beat open forever,
+// which is the "a window that never closes is a game that never resumes" failure
+// `world.ts` has always warned about.
+//
+// So the allowance runs, and it treats every child alike. This is `beam`'s
+// pattern — a pure item window — at ten times the p90, wearing claim's and
+// counterweight's rules about what a clock may never do.
+//
+// ── The size of it, and where ten minutes comes from ────────────────────────
+//
+// `docs/EXPERIENCE_DESIGN.md` instruments a cadence table, p50/p90, which is the
+// product's own measured account of how long these things take:
+//
+//     single-digit fact           2.8 s / 6 s
+//     two-digit with regrouping     6 s / 14 s
+//     the `5,001 − 2,798` class     16 s / 40 s
+//
+// The **p90** column is the scale, not the p50: the p50 is the time the median
+// child needs, and a guard sized at what the median child needs fires on
+// everybody else. A guard has to clear the tail, not sit on top of it.
+//
+// And then `ABANDON_FACTOR` is **ten**, which is the founder's own figure rather
+// than a comfort margin. The hardest thing ARENA serves is five-column long
+// division; this table's p90 for that is 60 s; ten times 60 s is **ten minutes**,
+// which is the number he named for exactly that item. Every easier class falls
+// out of the same multiplication:
+//
+// Every figure below is printed by `window.test.ts` rather than restated here
+// from memory, and the `was` column is the old curve read at both of its ends:
+//
+//     item             p90    guard          was (floor → ceiling of the ladder)
+//     7 + 5             6 s   1 min          26 s → 6 s
+//     43 + 25          11 s   1 min 50 s     26 s → 6 s
+//     47 + 25          14 s   2 min 20 s     26 s → 6 s
+//     473 + 168        23 s   3 min 50 s     26 s → 6 s
+//     5,001 − 2,798    40 s   6 min 40 s     26 s → 6 s
+//     34,801 ÷ 37      60 s   10 min         26 s → 6 s
+//
+// Read the last two rows against the `was` column and the defect is plain: the
+// two hardest classes in the product were the two whose p90 most exceeded the
+// window they were given, at *every* point on the old curve — 40 s of arithmetic
+// into 26 s at best and 6 s at worst.
+//
+// A full minute of stillness on `7 + 5` is not a child thinking; it is a child
+// who has gone to get a drink. Ten minutes on five-digit long division is a
+// child with a pencil, which is the point.
+//
+// ── Speed is still rewarded ─────────────────────────────────────────────────
+//
+// Removing the countdown does not remove the payoff for being fast, and it must
+// not: the founder's rule is that a fast answer earns MORE and a slow one still
+// wins. `World.resolveResonance` pays `quickness(FLOW, took)` as up to **+70% of
+// the mass reward** and scales the celebration with it. That is the whole of
+// ARENA's relationship with the clock now — a bonus a fast player gains, never a
+// window a slow player loses. `game-pacing/flow.ts` states the same distinction:
+// "a countdown that kills you and a bonus that accrues when you are fast read the
+// same clock and produce opposite emotional experiences."
+
+/** What this module needs of an item. The host's own strings, unparsed. */
+export type Item = {
+  /** As the child reads it: `34801 ÷ 37`. */
+  readonly prompt: string
+  /** The canonical answer text the host revealed. Never computed here. */
+  readonly answer: string
+}
+
+/**
+ * Which operation a prompt is asking for. `other` takes the cautious branch.
+ *
+ * ARENA serves the whole ladder — addition facts at the bottom, long division and
+ * long multiplication at the top — so unlike `beam` and `counterweight`, whose
+ * tables only classify `+` and `−`, this one has to know the operator. `runner`
+ * made the same finding: multi-digit `×` and `÷` are partial products and trial
+ * quotients all the way down, and cost a row more than their width suggests.
+ */
+export type Op = "add" | "sub" | "mul" | "div" | "other"
+
+/**
+ * Seconds by column count — the p90 column of the house cadence table.
+ *
+ * Index 1 is the single-digit fact's p90 (6 s). Index 2 and index 4 are the two
+ * rows the table names outright: `6 + 8 = 14` is two-digit-with-regrouping
+ * exactly, and `32 + 8 = 40` is the `5,001 − 2,798` class exactly. Index 3 sits
+ * between them.
+ *
+ * Index 5 is **extrapolated and says so.** The table stops at four columns and
+ * ARENA's ladder does not — the curriculum's `dw.div.whole.divide-exact` L1
+ * reaches `29838 ÷ 6` and L3 reaches `721308 ÷ 84`. The measured rows grow by
+ * roughly half again each step (6 → 11 → 18 → 32), so index 5 continues that at
+ * 48, and `REGROUPING` continues 3 → 5 → 8 at 12. Sixty seconds for five-column
+ * work is the figure that makes `ABANDON_FACTOR` land on the founder's ten
+ * minutes, and it is the only number in this file that is not read straight off
+ * an instrumented row.
+ *
+ * Strictly increasing, which is half of the monotonicity claim.
+ */
+const BY_COLUMNS = [6, 6, 11, 18, 32, 48] as const
+
+/**
+ * What needing to regroup is worth on top, per column count.
+ *
+ * Each entry is small enough that `BY_COLUMNS[n] + REGROUPING[n] <= BY_COLUMNS[n + 1]`,
+ * which is the other half of the monotonicity claim — a regrouping item at `n`
+ * columns never outranks a plain item at `n + 1` — and `window.test.ts` asserts
+ * it over the whole cross product rather than leaving it to inspection.
+ */
+const REGROUPING = [0, 0, 3, 5, 8, 12] as const
+
+/**
+ * The widest content the table describes. Beyond it, the last row stands.
+ *
+ * A literal rather than `BY_COLUMNS.length - 1` so that indexing the tables with
+ * it narrows to a number instead of `number | undefined` — and `window.test.ts`
+ * asserts it against both tables' lengths, so the literal cannot drift away from
+ * the rows it is meant to name.
+ */
+export const MAX_COLUMNS = 5
+
+/** The p90 of the widest row: five columns, regrouping. Ten times this is the guard's ceiling. */
+const WIDEST_P90 = BY_COLUMNS[MAX_COLUMNS] + REGROUPING[MAX_COLUMNS]
+
+/**
+ * How many multiples of the arithmetic's own p90 count as "nobody is there".
+ *
+ * Ten, and derived rather than tuned: ten times the 60 s p90 of five-column long
+ * division is the ten minutes the founder named for `34801 / 37`. See the module
+ * note.
+ */
+export const ABANDON_FACTOR = 10
+
+/**
+ * The shortest silence that can end a Resonance, whatever the item.
+ *
+ * A floor rather than a budget. `ABANDON_FACTOR × BY_COLUMNS[1]` already gives
+ * the easiest item in the product a full minute, so this binds only if the table
+ * is ever edited downward; it exists so that a malformed prompt cannot produce a
+ * guard a child could actually meet.
+ */
+export const MIN_GUARD_SECONDS = 60
+
+/**
+ * The longest silence anything can ask for.
+ *
+ * Not a cap on the child — it is `ABANDON_FACTOR × (BY_COLUMNS[5] + REGROUPING[5])`,
+ * which is what the widest row of the table already yields, restated as a
+ * constant so the ten-minute claim can be asserted directly. A prompt that parses
+ * as nine columns is treated as the widest row the table knows about, so nothing
+ * can reach past it.
+ */
+export const MAX_GUARD_SECONDS = ABANDON_FACTOR * WIDEST_P90
+
+/**
+ * The operator, from the first operator glyph in the prompt.
+ *
+ * `−` is the typographic minus the curriculum writes and `-` is what a stub
+ * host writes; both are here, as are `÷` and `/`. A prompt with no operator at
+ * all — `factor of 48`, `less than 1000`, a word problem — reads as `other`,
+ * which is treated as the HARDER branch. This function's failure mode must be
+ * "the child got more silence than they needed".
+ */
+export function opOf(prompt: string): Op {
+  for (const ch of prompt) {
+    if (ch === "+") return "add"
+    if (ch === "-" || ch === "−" || ch === "–" || ch === "—") return "sub"
+    if (ch === "×" || ch === "*" || ch === "·") return "mul"
+    if (ch === "÷" || ch === "/" || ch === ":") return "div"
+  }
+  return "other"
+}
+
+/**
+ * The widest column count in the item — **the operands, not the answer.**
+ *
+ * `beam` and `counterweight` count the answer too, on the argument that a child
+ * reading a five-digit total is reading five columns. That is true of reading and
+ * false of working, and it misfiles the one row the cadence table names most
+ * explicitly: `7 + 5 = 12` has a two-digit answer, and it is a *single-digit
+ * fact*, retrieved rather than computed. Counting its answer put it in the
+ * two-column row at 14 s — more than twice the table's own 6 s figure for it, on
+ * the easiest item in the product. `runner` reached this first and states it:
+ * "The operands and not the answer: `7 + 8` is a single-digit fact whose answer
+ * has two digits, and the cadence table calls that 2.8s, not 6."
+ *
+ * The answer is still read, but only as a **fallback** — an item with no digits in
+ * its prompt at all (`factor of forty-eight`) has nothing else to be measured by,
+ * and falling back is more generous than defaulting to one column.
+ *
+ * Read as text throughout. ARENA's answers reach ten digits and there is no reason
+ * to leave the string domain to count a length.
+ */
+export function widestColumn(item: Item): number {
+  let widest = 0
+  for (const run of item.prompt.match(/\d+/g) ?? []) widest = Math.max(widest, run.length)
+  if (widest > 0) return widest
+  for (const run of item.answer.match(/\d+/g) ?? []) widest = Math.max(widest, run.length)
+  return Math.max(1, widest)
+}
+
+const OPERANDS = /\d+/g
+
+/**
+ * Does this item need a carry or a borrow anywhere?
+ *
+ * An item this cannot read as two decimal operands reads as **true**, which is
+ * the longer silence. Multi-digit `×` and `÷` also read as true, because there is
+ * no column in a partial product or a trial quotient that does not carry.
+ *
+ * Guessing in the child's favour is the only direction this function is allowed
+ * to be wrong in.
+ */
+export function needsRegrouping(item: Item): boolean {
+  OPERANDS.lastIndex = 0
+  const runs = item.prompt.match(OPERANDS) ?? []
+  if (runs.length !== 2) return true
+  const op = opOf(item.prompt)
+  if (op === "other") return true
+  // An equation is not a column sum, whatever its two operands look like.
+  // `x + 17 = 42` parses as two operands under a `+` that do not carry, and
+  // reading it as a plain two-column addition scored it 11 s — but the work is
+  // solving for the unknown, not adding. Any `=`, or a second operator glyph,
+  // means this function is not looking at what it thinks it is looking at.
+  if (item.prompt.includes("=")) return true
+  let operators = 0
+  for (const ch of item.prompt) {
+    if ("+-−–—×*·÷/:".includes(ch)) operators++
+  }
+  if (operators !== 1) return true
+  if (op === "mul" || op === "div") return (runs[0] as string).length > 1 || (runs[1] as string).length > 1
+  const a = Number(runs[0])
+  const b = Number(runs[1])
+  if (!Number.isSafeInteger(a) || !Number.isSafeInteger(b)) return true
+  const add = op === "add"
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    if (add && (x % 10) + (y % 10) >= 10) return true
+    if (!add && x % 10 < y % 10) return true
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return false
+}
+
+/**
+ * Columns, clamped into the table.
+ *
+ * A `×` or `÷` past a single digit is **a row harder than its width**, which is
+ * `runner`'s finding restated: `12 × 34` is four single-digit products and a
+ * two-column sum, not a two-column anything. `other` takes the same shift for the
+ * same reason it takes the regrouping branch — this file does not know what it is
+ * looking at, so it assumes the work is there.
+ *
+ * The clamp is also the ceiling on the whole guard, which is why
+ * `MAX_GUARD_SECONDS` is derived from the last row rather than declared
+ * independently: a nine-column prompt is treated as the widest item the table
+ * knows about.
+ */
+function columnsOf(item: Item): number {
+  const op = opOf(item.prompt)
+  const width = widestColumn(item)
+  const heavy = (op === "mul" || op === "div" || op === "other") && width > 1 ? 1 : 0
+  return Math.max(1, Math.min(MAX_COLUMNS, width + heavy))
+}
+
+/**
+ * The arithmetic's own p90, off the house table. Nothing else is in here.
+ *
+ * **This is measured, never limited.** `EXPERIENCE_DESIGN.md`: "`T=0→C`
+ * COMPREHENSION | not budgeted | The child's time. Measured, never limited." It
+ * is not a budget anybody is held to — nothing is — it is only the scale the
+ * guard is sized against.
+ */
+export function comprehensionSeconds(item: Item): number {
+  const columns = columnsOf(item)
+  const base = BY_COLUMNS[columns] ?? BY_COLUMNS[MAX_COLUMNS]
+  const extra = needsRegrouping(item) ? (REGROUPING[columns] ?? 0) : 0
+  return base + extra
+}
+
+/**
+ * How long the arena waits in silence before withdrawing this question, in
+ * seconds.
+ *
+ * Monotone non-decreasing in both of its inputs — more columns is never less
+ * patience, and needing to regroup is never less patience than not needing to —
+ * and a function of the item alone.
+ *
+ * Refilled by any input, so it measures a pause and not a round. Never drawn. On
+ * firing it reports nothing to the host and takes nothing from the child.
+ */
+export function guardSeconds(item: Item): number {
+  const seconds = ABANDON_FACTOR * comprehensionSeconds(item)
+  return Math.min(MAX_GUARD_SECONDS, Math.max(MIN_GUARD_SECONDS, seconds))
+}
+
+/**
+ * Is this item long enough that a child might reasonably reach for paper?
+ *
+ * The one thing outside this module that the item's class decides, and it decides
+ * a **label**, not a limit: `Hud` prints `NO TIMER · USE PAPER` above the prompt
+ * on items this returns true for, and `RESONANCE` on the rest. Two facts, no
+ * metaphor, no praise — and on `7 + 5` it never appears at all, because telling a
+ * child to fetch a pencil for a single-digit fact is the patronising version of
+ * the same idea.
+ *
+ * The threshold is the `5,001 − 2,798` class: the row the cadence table itself
+ * marks at a 40-second p90, which is where written work stops being optional for
+ * most children.
+ */
+export function invitesPaper(item: Item): boolean {
+  return comprehensionSeconds(item) >= BY_COLUMNS[4] + REGROUPING[4]
+}

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -14,6 +14,7 @@ import { Rng } from "../core/rng.ts"
 import { Grid } from "../core/grid.ts"
 import { tidyValue } from "../core/digits.ts"
 import { bandForMass, DEPTHS, depthFor, overdrive, type Depth } from "./depths.ts"
+import { guardSeconds } from "./window.ts"
 import type { TierSpec } from "../core/tier.ts"
 import type { Host, Question } from "../contract.ts"
 
@@ -100,7 +101,7 @@ const RIVAL_FLOOR = 0.28
  * here. When the first-grade fact spine lands, this reaches down to it with no
  * change to this file.
  */
-const DIFFICULTY_RUNGS = 10
+export const DIFFICULTY_RUNGS = 10
 
 /**
  * THE QUIET TIDE, and why the world's pace is not simply the breath.
@@ -128,6 +129,90 @@ const DIFFICULTY_RUNGS = 10
  * the world is earned.
  */
 const QUIET_TIDE_SECONDS = 420
+
+
+/**
+ * Seconds between one answered Resonance and the next. The beat's own cadence.
+ *
+ * Named rather than inlined so the cadence the pacing notes quote — "55 answers at
+ * a mean gap of 25 s is a little under 23 minutes" — is read off the constants the
+ * scheduler actually uses rather than off a literal in a call three hundred lines
+ * away.
+ */
+const BEAT_GAP_MIN = 21
+const BEAT_GAP_MAX = 29
+
+/**
+ * Answers it must take to cross the whole difficulty ladder, climbing.
+ *
+ * **The other half of "not Max Cohen mode", and the half the rounding fix did not
+ * reach.** Unrounding the request took the quantisation lurch out — one step of
+ * ARENA's breath used to be a 7.2-rung jump through a 66-rung curriculum — but it
+ * left the underlying climb rate alone, and the climb rate is the real complaint.
+ * Measured, a bot answering everything correctly:
+ *
+ *     the requests it made, as curriculum rungs:  0, 3, 21, 25, 32, 39, 47, 55, 63, 65
+ *     intensity 0.04 -> 1.00 in 300 seconds, so the top of the ladder in FIVE MINUTES
+ *
+ * Three quick correct answers and a child is on five-column long division. That is
+ * the founder's other sentence, from VOLTA and true here verbatim: "you get a few
+ * right just by being lucky and all of a sudden you are asked to do like 87364/9".
+ *
+ * The cause is not a defect in the shared controller — it is `climbBoost`, and it
+ * is deliberately large so an ADULT is not walked up every rung from `0 + 1`. But
+ * one scalar cannot serve both a world that should escalate in tens of seconds and
+ * a curriculum ladder that needs sustained evidence. `world.ts` already separates
+ * those two (`intensity` vs `worldIntensity`); this separates them one step
+ * further, on the axis that was still shared.
+ *
+ * **55 is measured, not chosen.** PR #715 recalibrated the host's own ladder to
+ * sit at 85% and climb only above 95%, and its published table gives a
+ * 100%-correct child at the published median **55 answers to reach the top of the
+ * 66-rung ladder**. So this is not a new opinion about how fast a child should
+ * climb: it is the constraint that ARENA's request may not outrun the host's own
+ * recalibrated ladder. Fewer answers than the host would take is ARENA overriding
+ * the founder's 85/95 band with a three-answer moving average, which is exactly
+ * what it was doing.
+ */
+const LADDER_CLIMB_ANSWERS = 55
+
+
+/**
+ * The largest label the renderer can carry without printing a different number.
+ *
+ * `mval` is an `Int32Array`, because the instanced numeral layer needs the value
+ * as an integer attribute. Anything past this is clamped to `0` on the way in —
+ * so a sphere carrying the right answer would be drawn reading **zero**, and a
+ * child who wanted it could not find it.
+ *
+ * This is not hypothetical. Measured through the real host over the whole
+ * 66-rung ladder, 40 items a rung: the top rung is
+ * `dw.mul.multidigit.long-multiplication` L2, whose products run to ten digits,
+ * and **24 of 40 of its answers exceed this bound** — `18309 × 53248 = 974917632`
+ * is fine, `37388 × 85585 = 3199851980` is not. ARENA's old integer request landed
+ * on exactly that rung whenever the breath reached its ceiling.
+ *
+ * **That measurement was taken against an UNRESTRICTED host, and it is worth being
+ * exact about why it still matters.** `pack.json` declares
+ * `covers.skills: ["dw.ns.compare.whole-numbers"]`, and `game-host` honours that by
+ * restricting the stream to the `dw.ns` domain — so in a normal session ARENA is not
+ * served long multiplication at all and the bound is unreachable. But the
+ * restriction is not a guarantee: `game-host` SURRENDERS it, loudly and for the rest
+ * of the session, whenever it cannot serve the declared domain, and after a
+ * surrender the whole ladder is in scope. The stub host reaches past it too, and
+ * `covers.skills` is a line in a manifest that a future edit can widen without
+ * touching this file.
+ *
+ * So this is a guard on the seam rather than a fix for a bug a child is hitting
+ * today: it costs one comparison per option, and what it prevents is a child being
+ * shown four spheres one of which silently reads `0`.
+ *
+ * `openResonance` refuses to pose an item it cannot draw, in the same way and for
+ * the same reason it already refuses one it cannot supply four distinct options
+ * for. It is a structural check on the item in hand rather than a ceiling on the
+ * request, because the request is relative and the ladder grows.
+ */
+const MAX_DRAWABLE_LABEL = 2147483647
 const QUIET_TIDE_CEILING = 0.62
 
 /**
@@ -477,8 +562,43 @@ export type Resonance = {
   active: boolean
   /** 0 = closed, 1 = opening, 2 = live, 3 = resolving. */
   phase: number
+  /** Seconds since the beat opened. Never reset while it is open. */
   t: number
-  duration: number
+  /**
+   * Seconds the question has been answerable for.
+   *
+   * **The only timer that can end an unanswered Resonance.** Nothing in `render/`
+   * or `ui/` reads it — no bar, no ring, no number — and when it runs out the host
+   * is told nothing and the child loses nothing. See `stepResonance` for why it is
+   * not refilled by input, which is the one place ARENA diverges from `claim` and
+   * `counterweight`.
+   */
+  idle: number
+  /**
+   * The allowance, for THIS item, in seconds.
+   *
+   * `sim/window.ts` computes it from the item and from nothing else. One minute on
+   * `7 + 5`; ten on five-column long division.
+   */
+  guard: number
+  /**
+   * Seconds since the answer was committed. Drives the phase-3 resolve alone.
+   *
+   * Separate from `t` because `t` used to double as the resolve clock via
+   * `res.t - res.duration`, and `duration` was the old intensity-scaled window.
+   * When the window went away there was nothing left for that subtraction to
+   * mean.
+   */
+  resolveT: number
+  /**
+   * Where the ring of spheres is centred — the player's position when the beat
+   * opened, and fixed for the life of the beat.
+   *
+   * The spheres orbit about this and not about `px, py`, so swimming toward one
+   * actually closes the gap.
+   */
+  centreX: number
+  centreY: number
   question: Question | null
   /** Indices into the mote arrays for the four spheres. */
   spheres: Int32Array
@@ -586,6 +706,29 @@ export class World {
    * once, so escalation reads as one thing rather than as six.
    */
   intensity = FLOW.start
+  /**
+   * The breath as the CURRICULUM sees it: the same number, allowed to climb only
+   * as fast as the evidence for climbing accumulates.
+   *
+   * It follows `intensity` down instantly, every frame, and climbs only in
+   * `resolveResonance` — by at most `1 / LADDER_CLIMB_ANSWERS` of the ladder per
+   * CORRECT ANSWER, and never past `intensity`. The asymmetry is the same one the
+   * shared controller uses for `fallSeconds`: **relief is not something to be
+   * earned.** A child who has just missed three gets easier questions on the next
+   * beat; a child who has just got three right does not get five-column long
+   * division on the next beat.
+   *
+   * Nothing but a correct answer moves it up. Not elapsed time, not an abandoned
+   * question, not twenty minutes of swimming on the strength of six early answers —
+   * every one of which a per-second version leaked. See `resolveResonance`.
+   *
+   * Only `ladderPosition` reads it. Density, rivals, speed, growth, the temper of
+   * the water and the reveal all still ride `intensity` or `worldIntensity`, so
+   * nothing about how the arena FEELS is slowed down by this — the world still
+   * leans in within tens of seconds of a good stretch. What is slowed down is only
+   * how fast the arithmetic gets harder.
+   */
+  mathsIntensity = FLOW.start
   /** Smoothed estimate of how the child is doing. Never rendered anywhere. */
   success = seedSuccess(FLOW)
   /** The rung of the difficulty ladder currently stood on, 0-based. */
@@ -656,6 +799,15 @@ export class World {
 
   // -- environment --------------------------------------------------------
   time = 0
+  /**
+   * Seconds the arena has actually been a game — `time` minus every second spent
+   * inside a Resonance.
+   *
+   * The quiet tide rides this. See `worldIntensity`: with no length on a
+   * Resonance, a child who takes the founder's invitation and works something out
+   * on paper must not be handed a denser, faster ocean as the bill for it.
+   */
+  playTime = 0
   arenaR = arenaRadiusFor(START_MASS)
   depth: Depth = DEPTHS[0] as Depth
   depthNext: Depth = (DEPTHS[1] ?? DEPTHS[0]) as Depth
@@ -667,7 +819,11 @@ export class World {
     active: false,
     phase: 0,
     t: 0,
-    duration: 0,
+    idle: 0,
+    guard: 0,
+    resolveT: 0,
+    centreX: 0,
+    centreY: 0,
     question: null,
     spheres: new Int32Array(4).fill(-1),
     labels: ["", "", "", ""],
@@ -730,9 +886,18 @@ export class World {
   /**
    * How hard the WORLD is pushing: the breath, or the quiet tide, whichever is
    * higher. Everything except the maths reads this rather than `intensity`.
+   *
+   * The tide rides `playTime`, not `time`, and that became load-bearing the
+   * moment a Resonance stopped having a length. During a Resonance the arena is
+   * inert — nothing can touch you and you cannot eat — so those seconds are not
+   * seconds the run has been going. Left on `time`, a child who took the
+   * founder's invitation and spent eight minutes on paper would come back to a
+   * fully escalated ocean, and the price of thinking would be a denser, faster,
+   * more crowded arena. That is a clock taking something away from a child with
+   * the countdown filed off.
    */
   get worldIntensity(): number {
-    const tide = QUIET_TIDE_CEILING * curved(Math.min(1, this.time / QUIET_TIDE_SECONDS), "gentle")
+    const tide = QUIET_TIDE_CEILING * curved(Math.min(1, this.playTime / QUIET_TIDE_SECONDS), "gentle")
     return Math.max(this.intensity, tide)
   }
 
@@ -772,56 +937,42 @@ export class World {
   }
 
   /**
-   * Seconds a Resonance stays open — and the reason it is a curve rather than a
-   * constant is the most important pacing decision in this file.
+   * How fast the four spheres orbit while a question is open, in radians a
+   * second.
    *
-   * It was `max(6.5, 10.5 - resonanceCount * 0.16)`: a window that shrank
-   * toward six and a half seconds for EVERY player, regardless of whether they
-   * were keeping up. That is a countdown imposed on a child, and a countdown
-   * imposed on a child is the thing that converts arithmetic into guessing.
+   * **It is an orbit and nothing else. The radius does not change.** This used
+   * to be `sphereDrift`, an outward velocity of up to 22 units a second earned
+   * on the same curve as the old window, and it was the second clock in the
+   * game and the one that was invisible as a clock: the answer physically walked
+   * away from a hesitating child, so "a hesitant answer costs distance" was a
+   * countdown wearing a different hat.
    *
-   * The founder's rule is that time should be measured and REWARDED, never
-   * used to cause anxiety: "I like infinite time to think in most cases ... we
-   * can usually measure, pace and reward, not cause anxiety". So the clock is
-   * something a player EARNS by demonstrating they are comfortably fast.
+   * The spheres still turn, because four dead objects read as a screenshot and
+   * this is a living ocean. What they may never do is recede. Tangential motion
+   * at a fixed radius is the whole of the difference: the picture is alive, the
+   * answer is exactly where the child found it, ten minutes later.
    *
-   *   at the floor    26 s — three times the curriculum's own p50 for this
-   *                          skill, which is as close to "unlimited" as ARENA
-   *                          can honestly offer
-   *   mid-ladder      20 s — still nowhere near pressure
-   *   at the ceiling   6 s — a real countdown, and the player climbed here
-   *
-   * `gentle` is what makes that true: two thirds of the way up the ladder the
-   * window is still over sixteen seconds. A struggling child never meets a
-   * clock. A mathlete opts into one by being visibly ready for it.
-   *
-   * It is not literally unbounded, and the reason is structural rather than
-   * pedagogical: the arena holds its breath during a Resonance — nothing can
-   * touch you and you cannot eat — so a window that never closes is a game that
-   * never resumes for a player who put the tablet down mid-question. What the
-   * floor gives instead is a window nobody working at this level will ever
-   * reach the end of, and no visible clock at all (see `sphereDrift`).
-   *
-   * It reads `intensity`, not `worldIntensity`: the quiet tide may fill the
-   * ocean up around a player who is not answering, but it may never put them
-   * on a clock they did not earn.
+   * A constant, and deliberately so — nothing about the run reaches it, which is
+   * the same prohibition `sim/window.ts` carries. There is no intensity here to
+   * make it faster for a player the game has decided is good.
    */
-  get resonanceSeconds(): number {
-    return valueAt(this.intensity, 26, 6, "gentle")
+  get sphereOrbit(): number {
+    return 0.28
   }
 
   /**
-   * How fast the four spheres drift outward while a question is open.
+   * Where on the host's ladder the next question should come from, 0..1.
    *
-   * The other clock, and the one that was invisible as a clock. At a flat 22
-   * units a second the answer physically walked away from a hesitating child,
-   * so "a hesitant answer costs distance" was a countdown wearing a different
-   * hat. It is now earned on exactly the same terms as the window: zero at the
-   * floor, so a child may think for as long as they like with the answer
-   * staying where they found it.
+   * Unrounded and unquantised — see `openResonance` for the 7.2-rung lurch that
+   * came of telling the host an integer. `rung` still exists, because the HUD
+   * prints it and it carries `rungAt`'s hysteresis so the readout does not
+   * flicker, but it is no longer what the host is told.
+   *
+   * And it is `mathsIntensity`, not `intensity`: the world may lean in over tens
+   * of seconds, and the curriculum ladder may not. See `LADDER_CLIMB_ANSWERS`.
    */
-  get sphereDrift(): number {
-    return valueAt(this.intensity, 0, 22, "gentle")
+  get ladderPosition(): number {
+    return Math.min(1, Math.max(0, this.mathsIntensity))
   }
 
   /**
@@ -1043,6 +1194,7 @@ export class World {
     this.invuln = 1.4
     this.combo = 0
     this.time = 0
+    this.playTime = 0
     this.moteCount = 0
     this.rivalCount = 0
     this.malive.fill(0)
@@ -1051,12 +1203,16 @@ export class World {
     this.ralive.fill(0)
     this.resonance.active = false
     this.resonance.phase = 0
+    this.resonance.idle = 0
+    this.resonance.guard = 0
+    this.resonance.resolveT = 0
     this.nextResonanceAt = 16
     this.resonanceCount = 0
     this.bestMass = START_MASS
     this.deepest = 0
     this.depth = DEPTHS[0] as Depth
     this.intensity = FLOW.start
+    this.mathsIntensity = FLOW.start
     this.success = seedSuccess(FLOW)
     this.rung = rungAt(FLOW.start, DIFFICULTY_RUNGS)
     this.refreshDepth()
@@ -1118,11 +1274,26 @@ export class World {
     // bestMass, not mass, and floored by the band we are already in: the water
     // is a record of how deep this run has been, never a readout of how the
     // last ten seconds went.
-    const d = depthFor(this.bestMass, this.time, this.depth.index)
+    //
+    // `playTime`, not `time`, and this is the ESCALATION SPINE — the line that
+    // makes "thinking is not run time" true rather than merely claimed.
+    //
+    // `worldIntensity` was moved onto `playTime` when the Resonance lost its
+    // length, and this was left behind. `DEPTH_CLOCK_SECONDS` is 100 and
+    // `depthFor` floors the band, so it is a one-way ratchet: measured, a single
+    // 600-second guard on `34801 ÷ 37` at mass 10 — nothing eaten, nothing
+    // gained, the aim parked on the table exactly as the guard is designed for —
+    // sank the run from DRIFT to THE ABYSSAL, six bands, and handed the child
+    // back four hunters, a leviathan, 18% void motes and temper 0.86. It never
+    // came back, because the band cannot fall.
+    //
+    // That is the bill for thinking, and it is the whole thing this pass exists
+    // to abolish. `overdrive` compounds off the same clock and moves with it.
+    const d = depthFor(this.bestMass, this.playTime, this.depth.index)
     this.depth = d.depth
     this.depthNext = d.next
     this.depthT = d.t
-    this.over = overdrive(this.bestMass, this.time)
+    this.over = overdrive(this.bestMass, this.playTime)
     this.arenaR = arenaRadiusFor(this.mass)
     if (this.depth.index > this.deepest) this.deepest = this.depth.index
     if (this.depth.index !== prev) {
@@ -1423,10 +1594,21 @@ export class World {
   step(dt: number): void {
     this.eventCount = 0
     this.time += dt
+    // Only seconds in which the arena was a game count toward the tide. A
+    // Resonance is inert by design — nothing can touch you and you cannot eat —
+    // so thinking time is not run time.
+    if (!this.resonance.active) this.playTime += dt
     // The breath, before anything reads it. One call, one number, and every
     // budget below is a pure function of it.
     this.intensity = settle(FLOW, this.intensity, this.success, dt)
-    this.rung = rungAt(this.intensity, DIFFICULTY_RUNGS, this.rung)
+    // The maths follows the breath DOWN, here and every frame. It only ever climbs
+    // in `resolveResonance`, one correct answer at a time.
+    //
+    // Relief is not something to be earned, so the fall is not on the leash at all
+    // — the same asymmetry the shared controller applies with `fallSeconds` and
+    // #715 applies with its bands ("up needs two things, down needs one").
+    if (this.mathsIntensity > this.intensity) this.mathsIntensity = this.intensity
+    this.rung = rungAt(this.mathsIntensity, DIFFICULTY_RUNGS, this.rung)
     this.invuln = Math.max(0, this.invuln - dt)
     this.stingGrace = Math.max(0, this.stingGrace - dt)
     this.heldCool = Math.max(0, this.heldCool - dt)
@@ -1612,7 +1794,22 @@ export class World {
       this.my[i] = y + vy * dt
       this.mphase[i] = (this.mphase[i] as number) + dt * 1.6
 
-      // Keep them inside the membrane.
+      // Keep them inside the membrane — but never a Resonance sphere.
+      //
+      // This clamp is radial about the WORLD ORIGIN, and the answer ring rotates
+      // about the player. With the player parked at the edge, the two fight: the
+      // rotation moves a sphere outside `arenaR`, the clamp pulls it back toward
+      // the origin, and the ring slides along the membrane instead of turning in
+      // place. `sphereOrbit` promises the answer is exactly where the child found
+      // it ten minutes later, and this is the one line that could make that false.
+      //
+      // The pull above (`pullR`) and the flip below already skip `MK_ANSWER`; this
+      // was the only one of the three that did not. `openResonance` places the ring
+      // at `ringR`, which is about 0.3% of `arenaR` at every mass, so the ring is
+      // never near the membrane except at the very edge — narrow, but the comment
+      // and the README both state the property without qualification, so the code
+      // should hold it without qualification too.
+      if (this.mkind[i] === MK_ANSWER) continue
       const rad = Math.hypot(this.mx[i] as number, this.my[i] as number)
       if (rad > this.arenaR) {
         const s = this.arenaR / rad
@@ -2170,6 +2367,7 @@ export class World {
       return
     }
     res.t += dt
+    if (res.phase === 3) res.resolveT += dt
     if (res.phase === 1 && res.t > 0.55) {
       res.phase = 2
       // THE CLOCK STARTS HERE, and it used to start 0.55 s earlier.
@@ -2188,39 +2386,95 @@ export class World {
       // question and act on it. Nothing else belongs in it.
       res.openedAt = performance.now()
       res.openedT = this.time
+      // The silence starts here too, and for the same reason: nothing before
+      // this instant was answerable, so nothing before it was a child not
+      // answering.
+      res.idle = 0
     }
-    if (res.phase === 2 && res.t > res.duration) {
-      this.emit("resonance-fade", this.px, this.py, 0, 0)
-      // A question that went unanswered comes back LATER, not on the usual
-      // cadence. A player who is not engaging with the maths right now should
-      // not be interrupted every twenty seconds to be asked again — and while a
-      // Resonance is open the arena is inert, so a stream of ignored questions
-      // is also a stream of seconds in which the game is not a game.
-      this.nextResonanceAt = this.time + this.rng.range(40, 55)
-      this.closeResonance()
-      return
+
+    if (res.phase === 2) {
+      // THE ALLOWANCE, and it is the only thing that can end an unanswered
+      // question. It is a pure function of the item — see `sim/window.ts`.
+      //
+      // **It is not refilled by input, and that is a deliberate divergence from
+      // `games/claim` and `games/counterweight`.** Both of those refill their
+      // guard on any hand on the controls, because in those games a hand on the
+      // controls IS engagement with the question: `counterweight`'s child is
+      // striking the plates that answer it.
+      //
+      // ARENA's only control is *steering*, and steering is not answering. A first
+      // cut of this refilled on aim movement and got the two populations exactly
+      // backwards:
+      //
+      //   * a child working `34,801 ÷ 37` out on paper has their hands OFF the
+      //     glass, so the aim is still — and the guard ran down on the one child
+      //     it exists to protect;
+      //   * a child ignoring the question and swimming around has their hand ON
+      //     the stick, so the guard refilled forever — and the beat could never
+      //     end, which is the "a window that never closes is a game that never
+      //     resumes" failure this file has always warned about.
+      //
+      // So the allowance simply runs, and it treats every child the same. What
+      // makes that safe is not a refill, it is the SIZE and the CONSEQUENCE: sixty
+      // seconds on `7 + 5`, ten minutes on five-column long division, nothing
+      // drawn anywhere, and on firing it reports nothing and takes nothing. It is
+      // `beam`'s pattern — an item-pure window — at ten times the p90 instead of
+      // one, wearing claim's and counterweight's rules about what a clock may
+      // never do.
+      res.idle += dt
+      if (res.idle > res.guard) {
+        this.emit("resonance-fade", this.px, this.py, 0, 0)
+        // Nothing is reported and nothing is taken. A child who was still
+        // carrying the hundreds column has told us nothing about what they know,
+        // and a game that filed that as a wrong answer would be lying to the
+        // curriculum about them. `this.success` is untouched, so the pacing
+        // controller never moves either.
+        //
+        // The question comes back LATER, not on the usual cadence: a child who is
+        // not engaging with the maths right now should not be interrupted every
+        // twenty seconds to be asked again, and while a Resonance is open the
+        // arena is inert, so a stream of ignored questions is also a stream of
+        // seconds in which the game is not a game.
+        this.nextResonanceAt = this.time + this.rng.range(40, 55)
+        this.closeResonance()
+        return
+      }
     }
+
     // A right answer resolves in a beat. A miss is held for the reveal, which
     // is long and calm at the bottom of the ladder and absent at the top.
-    if (res.phase === 3 && res.t > res.duration + (res.wasCorrect ? 0.9 : Math.max(0.9, this.revealSeconds))) {
+    if (res.phase === 3 && res.resolveT > (res.wasCorrect ? 0.9 : Math.max(0.9, this.revealSeconds))) {
       this.closeResonance()
       return
     }
 
-    // The four spheres drift outward and orbit, so a hesitant answer costs
-    // distance and the decision has a clock without a countdown bar.
+    // The four spheres ORBIT. They do not recede — see `sphereOrbit`. The answer
+    // is exactly as far away on the tenth minute as it was on the first second,
+    // which is what makes the guard above the only timer in the beat.
+    const spin = res.phase === 2 ? this.sphereOrbit : 0
+    const c = Math.cos(spin * dt)
+    const s2 = Math.sin(spin * dt)
     for (let s = 0; s < 4; s++) {
       const i = res.spheres[s] as number
       if (i < 0 || !this.malive[i]) continue
-      const dx = (this.mx[i] as number) - this.px
-      const dy = (this.my[i] as number) - this.py
-      const d = Math.hypot(dx, dy) || 1
-      const drift = res.phase === 2 ? this.sphereDrift : 0
-      const tangent = 0.32
-      this.mvx[i] = (dx / d) * drift - (dy / d) * drift * tangent
-      this.mvy[i] = (dy / d) * drift + (dx / d) * drift * tangent
-      this.mx[i] = (this.mx[i] as number) + (this.mvx[i] as number) * dt
-      this.my[i] = (this.my[i] as number) + (this.mvy[i] as number) * dt
+      // Rotated about the RING's centre, which `openResonance` fixed at the
+      // player's position when the beat opened — never about `px, py`.
+      //
+      // Rotating about the live player would make the ring follow them: every
+      // step the player took toward a sphere would carry the whole ring the same
+      // distance, the gap would never close, and committing to an answer would be
+      // impossible. Measured with the centre wrong, the solver bot answered zero
+      // of forty-eight questions in a twenty-minute run.
+      const dx = (this.mx[i] as number) - res.centreX
+      const dy = (this.my[i] as number) - res.centreY
+      // A pure rotation of the offset. `cos`/`sin` of the frame's own angle
+      // rather than a tangential velocity, because a tangent stepped by `dt`
+      // walks the radius OUTWARD a little every frame — which is the drift this
+      // pass deleted, reintroduced by arithmetic.
+      this.mx[i] = res.centreX + dx * c - dy * s2
+      this.my[i] = res.centreY + dx * s2 + dy * c
+      this.mvx[i] = 0
+      this.mvy[i] = 0
       this.mphase[i] = (this.mphase[i] as number) + dt * 2.4
     }
   }
@@ -2236,7 +2490,35 @@ export class World {
     // child who had missed the last four in a row was handed a fifth that was
     // harder than all of them. Now the rung is the rung the run's recent work
     // has earned, and it goes down as readily as it goes up.
-    const diff = this.rung + 1
+    // …and it is asked for UNROUNDED, which is the other half of the founder's
+    // complaint and the half that was invisible.
+    //
+    // `DIFFICULTY_RUNGS` is 10 and the request used to be the integer `rung + 1`.
+    // The shared bridge maps a 1..10 ladder index onto the host's own ladder as
+    // `(value - 1) / 9`, and the host's ladder is **66 rungs**. So ARENA's ten
+    // rungs landed on curriculum rungs {0, 7, 14, 22, 29, 36, 43, 51, 58, 65} —
+    // and a single step of ARENA's ladder was a **7.2-rung jump** through the
+    // curriculum. Measured, through the real host:
+    //
+    //     ARENA rung 6  ->  curriculum 43  ->  dw.add.regroup.add-multidigit L2
+    //                                          `506 + 394`
+    //     ARENA rung 7  ->  curriculum 51  ->  dw.div.whole.divide-exact L3
+    //                                          `721308 ÷ 84`
+    //
+    // One rung of the breath, and a child goes from three-digit addition to
+    // six-digit long division. That is "jump right into Max Cohen mode", exactly,
+    // and it is arithmetic rather than judgement.
+    //
+    // Sending the position unrounded gives the host all 66 rungs instead of 10 of
+    // them, so the climb is one curriculum rung at a time and there is nothing
+    // left to lurch. `1 + x * 9` is in [1, 10] for x in [0, 1] and inverts to
+    // exactly `x`, and at x = 0 it sends literally `1` — which the bridge
+    // documents as the BOTTOM of the ladder, so the one ambiguous value on that
+    // wire still reads the way ARENA means it.
+    //
+    // `rung` survives as the hysteresis-bearing readout the HUD prints and the
+    // suite asserts on; it is no longer what the host is told.
+    const diff = 1 + this.ladderPosition * (DIFFICULTY_RUNGS - 1)
     let q: Question
     try {
       q = this.host.next({ difficulty: diff })
@@ -2260,6 +2542,24 @@ export class World {
       if (d !== q.answer && !options.includes(d)) options.push(d)
     }
     if (options.length < 4) {
+      this.nextResonanceAt = this.time + 20
+      return
+    }
+    // A Resonance ARENA cannot DRAW is one it does not pose either.
+    //
+    // The same rule as the line above, applied to the other way this beat can
+    // lie to a child. A sphere's label goes through `mval`, an `Int32Array`, and a
+    // value past `MAX_DRAWABLE_LABEL` lands there as `0` — so the sphere carrying
+    // the answer to `37388 × 85585` reads **zero**, and the child is asked to find
+    // an answer that is not on the screen. Twenty-four of every forty items on the
+    // top rung of the ladder are like that; see the constant.
+    //
+    // Loud rather than silent, because a pack quietly declining to ask questions
+    // is indistinguishable from a pack that is working.
+    for (const text of options) {
+      const v = Number(text)
+      if (Number.isSafeInteger(v) && Math.abs(v) <= MAX_DRAWABLE_LABEL) continue
+      console.warn(`[arena] declining a question ARENA cannot draw: "${q.prompt}" has the option "${text}"`)
       this.nextResonanceAt = this.time + 20
       return
     }
@@ -2294,7 +2594,19 @@ export class World {
     res.active = true
     res.phase = 1
     res.t = 0
-    res.duration = this.resonanceSeconds
+    res.resolveT = 0
+    // The silence guard, from the ITEM and from nothing else.
+    //
+    // This line is the whole of the pacing change. It used to be
+    // `res.duration = this.resonanceSeconds`, and `resonanceSeconds` was
+    // `valueAt(intensity, 26, 6, "gentle")` — a countdown that got SHORTER as the
+    // maths got harder, because both rode the same scalar. `sim/window.ts` states
+    // the invariant and carries the whole argument.
+    res.guard = guardSeconds({ prompt: q.prompt, answer: q.answer })
+    // Zeroed here and re-zeroed at the phase 1 -> 2 transition, which is when the
+    // question first becomes answerable and therefore the first instant a child
+    // can be said not to be answering it.
+    res.idle = 0
     res.question = q
     res.chosen = -1
     // Provisional: both are re-stamped at the phase 1 -> 2 transition, when the
@@ -2306,6 +2618,9 @@ export class World {
 
     const ringR = Math.max(viewSpanFor(this.mass) * 0.30, this.playerRTrue * 3.4)
     res.ringR = ringR
+    // The centre the ring orbits about, fixed here for the life of the beat.
+    res.centreX = this.px
+    res.centreY = this.py
     // The traversal floor, computed the same way `stepPlayer` computes it, so
     // the two cannot drift.
     const travelSpeed = Math.max(this.playerSpeed, ringR / 1.35)
@@ -2351,7 +2666,11 @@ export class World {
 
     const correct = slot === res.correctSlot
     res.phase = 3
-    res.t = res.duration
+    // The resolve runs on its own clock from zero. It used to be `res.t =
+    // res.duration`, which forced `t` forward to the end of the window so that
+    // `res.t - res.duration` read as seconds-since-the-answer — and there is no
+    // window any more for that subtraction to be relative to.
+    res.resolveT = 0
     res.chosen = slot
     res.wasCorrect = correct
     const ms = Math.round(performance.now() - res.openedAt)
@@ -2388,6 +2707,36 @@ export class World {
     // at the moment of the answer and reported to the Host. It has simply never
     // been used to decide anything until now.
     this.success = observe(FLOW, this.success, correct, took)
+
+    // THE LEASH, and this is the only place it is ever let out.
+    //
+    // A correct answer buys at most one `LADDER_CLIMB_ANSWERS`-th of the whole
+    // ladder, and nothing else buys any of it. Never exceeding `intensity`, so the
+    // breath is still the thing that decides WHERE the child belongs; this only
+    // decides how fast they are taken there.
+    //
+    // **Paid in answers, which is what the constant says.** The first cut of this
+    // was a per-second slew limit, `dt / LADDER_CLIMB_SECONDS`, with the seconds
+    // derived from 55 answers at a 25 s cadence. Two things went wrong with that,
+    // and both are the same mistake — time is not evidence:
+    //
+    //   * an abandoned question is up to ten minutes of `dt`, so *stalling* climbed
+    //     the ladder. Measured: six correct answers put the request on curriculum
+    //     rung 9, then two abandoned questions carried it to rung 65 of 65, having
+    //     answered nothing. Answering nothing was the fastest way to hard content,
+    //     and taking the founder's ten minutes on paper was billed at nearly half
+    //     the ladder.
+    //   * and a child who answered six quickly and then simply swam about for
+    //     twenty minutes drifted to the top on the strength of those six, which is
+    //     "you get a few right just by being lucky" with a delay bolted on.
+    //
+    // Counting answers has neither failure, needs no conversion, and states the
+    // constraint exactly as #715 measured it: 55 answers to cross the ladder is
+    // what the host's own recalibrated ladder gives a flawless child, and ARENA's
+    // request may not outrun it.
+    if (correct) {
+      this.mathsIntensity = Math.min(this.intensity, this.mathsIntensity + 1 / LADDER_CLIMB_ANSWERS)
+    }
 
     if (correct) {
       this.combo++
@@ -2466,7 +2815,7 @@ export class World {
       this.moteCount--
       res.spheres[s] = -1
     }
-    this.nextResonanceAt = this.time + this.rng.range(21, 29)
+    this.nextResonanceAt = this.time + this.rng.range(BEAT_GAP_MIN, BEAT_GAP_MAX)
   }
 
   private closeResonance(): void {
@@ -2482,7 +2831,7 @@ export class World {
     res.active = false
     res.phase = 0
     res.question = null
-    if (this.nextResonanceAt <= this.time) this.nextResonanceAt = this.time + this.rng.range(21, 29)
+    if (this.nextResonanceAt <= this.time) this.nextResonanceAt = this.time + this.rng.range(BEAT_GAP_MIN, BEAT_GAP_MAX)
   }
 
   // -------------------------------------------------------------------------

--- a/dynawalla/games/arena/src/ui/hud.ts
+++ b/dynawalla/games/arena/src/ui/hud.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../packs/shared/game-chrome/index.ts"
 import { RIVAL_NAMES, type World } from "../sim/world.ts"
 import { DEPTHS } from "../sim/depths.ts"
+import { invitesPaper } from "../sim/window.ts"
 
 const DEPTH_COUNT = DEPTHS.length
 
@@ -228,6 +229,49 @@ const CSS = `
 
 const ROWS = 6
 
+/**
+ * The label above the prompt on an ordinary question.
+ *
+ * It names the moment and nothing else, which is what a kicker is for.
+ */
+export const KICKER_DEFAULT = "RESONANCE"
+
+/**
+ * …and the label on a question long enough that a child might reach for paper.
+ *
+ * **The paper invitation.** The founder:
+ *
+ *   > "maybe they allow infinite time and even invite the kid to take out a piece
+ *   >  of paper and work it out for 10 minutes for the points instead of just
+ *   >  encouraging them to make a quick guess."
+ *
+ * Two facts, four words, no metaphor and no praise. `NO TIMER` is the load-bearing
+ * half: a child cannot otherwise know that nothing is counting, and until they
+ * know it they will guess. `USE PAPER` is the invitation, stated as a permission
+ * rather than an instruction — "take out a piece of paper and work it out" told to
+ * a child who was about to do it in their head is a game correcting them.
+ *
+ * Three things it deliberately is not:
+ *
+ *   * **Not on every question.** `invitesPaper` gates it at the cadence table's
+ *     40-second row, so it appears on `5,001 − 2,798` and on `34,801 ÷ 37` and
+ *     never on `7 + 5`. Telling a seven-year-old to fetch a pencil for a
+ *     single-digit fact is the patronising version of the same idea.
+ *   * **Not a status readout.** It changes when the question changes and at no
+ *     other time, exactly like the prompt it sits over. Nothing here reflows while
+ *     a child is reading.
+ *   * **Not a wall of text.** It replaces a word that was already there. The
+ *     sentence-length version of the argument is in `README.md`, said once, where
+ *     a parent reads it.
+ *
+ * Twenty characters at the kicker's own metrics — `clamp(9px, 2.1vw, 12px)` at
+ * `.42em` tracking — is about 190px on the 320px phone this game supports and
+ * about 250px at the 12px ceiling, inside `.arena-q`'s safe-inset box in every
+ * viewport `layout.test.ts` covers. It is the same `·` separator the perf readout
+ * already uses.
+ */
+export const KICKER_PAPER = "NO TIMER · USE PAPER"
+
 export class Hud {
   readonly root: HTMLDivElement
   private depthEl: HTMLDivElement
@@ -237,6 +281,7 @@ export class Hud {
   private eqEl: HTMLDivElement
   private eqText: HTMLSpanElement
   private qEl: HTMLDivElement
+  private qKicker: HTMLDivElement
   private qPrompt: HTMLDivElement
   private verdictEl: HTMLDivElement
   private perfEl: HTMLDivElement
@@ -318,9 +363,10 @@ export class Hud {
 
     this.qEl = document.createElement("div")
     this.qEl.className = "arena-q"
-    const k = document.createElement("div")
-    k.className = "k"
-    k.textContent = "RESONANCE"
+    this.qKicker = document.createElement("div")
+    this.qKicker.className = "k"
+    this.qKicker.textContent = KICKER_DEFAULT
+    const k = this.qKicker
     this.qPrompt = document.createElement("div")
     this.qPrompt.className = "p"
     this.qEl.appendChild(k)
@@ -472,6 +518,14 @@ export class Hud {
       this.lastQ = q
       if (q) {
         this.qPrompt.textContent = q
+        // The kicker is set here and only here — once per question, in the same
+        // breath as the prompt. See `KICKER_PAPER`.
+        this.qKicker.textContent = invitesPaper({
+          prompt: q,
+          answer: res.question?.answer ?? "",
+        })
+          ? KICKER_PAPER
+          : KICKER_DEFAULT
         this.qEl.classList.add("on")
       } else {
         this.qEl.classList.remove("on")

--- a/dynawalla/games/arena/src/ui/layout.test.ts
+++ b/dynawalla/games/arena/src/ui/layout.test.ts
@@ -16,9 +16,20 @@
 
 import assert from "node:assert/strict"
 import { test } from "node:test"
+import { readFileSync } from "node:fs"
 
 import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
-import { BOARD_W, DEPTH_W, HUD_EDGE, HUD_TOP, RIBBON_H, hudRects, soundRect } from "./hud.ts"
+import {
+  BOARD_W,
+  DEPTH_W,
+  HUD_EDGE,
+  HUD_TOP,
+  KICKER_PAPER,
+  Q_EDGE,
+  RIBBON_H,
+  hudRects,
+  soundRect,
+} from "./hud.ts"
 
 const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
 
@@ -148,4 +159,62 @@ test("the ribbon is centred, and stays centred inside an asymmetric notch", () =
   const leftGap = r.x - NOTCH_LANDSCAPE.left
   const rightGap = w - NOTCH_LANDSCAPE.right - (r.x + r.w)
   assert.ok(Math.abs(leftGap - rightGap) < 1, `the ribbon is off-centre by ${Math.abs(leftGap - rightGap)}px`)
+})
+
+/**
+ * THE PAPER INVITATION, as a label rather than as a paragraph.
+ *
+ * The founder asked the game to "invite the kid to take out a piece of paper and
+ * work it out for 10 minutes for the points". What ships is four words in the
+ * kicker slot that already existed above the prompt — `NO TIMER · USE PAPER` in
+ * place of `RESONANCE` — on questions the cadence table puts at a 40-second p90
+ * and on no others.
+ *
+ * Two things are worth pinning and one is not. **Not** an exact pixel width: the
+ * kicker's advance depends on the atlas font's real metrics, which are measured
+ * from a live canvas at runtime and cannot be had in Node. A fixture guessed 15%
+ * narrow elsewhere in this fleet passed a test while the device clipped, so the
+ * bound below is a genuine upper bound rather than an estimate, and the note about
+ * wrapping is why being wrong here is survivable rather than a defect.
+ */
+test("the paper invitation is wired to the item's class, and fits the narrowest phone", () => {
+  // 1. It is not dead copy: the render path chooses between the two by asking
+  //    `invitesPaper`, which `sim/window.test.ts` pins to the 40-second row.
+  const src = readFileSync(new URL("./hud.ts", import.meta.url), "utf8")
+  assert.ok(
+    /invitesPaper\(/.test(src) && src.includes("KICKER_PAPER") && src.includes("KICKER_DEFAULT"),
+    "the HUD no longer chooses its kicker from the item's class",
+  )
+  // Set exactly once, in the same branch as the prompt — never on a timer and
+  // never per frame, so it cannot become status narration that reflows while a
+  // child is reading.
+  assert.equal(
+    (src.match(/this\.qKicker\.textContent =/g) ?? []).length,
+    2,
+    "the kicker is assigned somewhere other than its construction and the one per-question branch",
+  )
+
+  // 2. It fits. `.k` is `clamp(9px, 2.1vw, 12px)` at `.42em` tracking, inside
+  //    `.arena-q`, which is pinned `Q_EDGE` from both safe edges.
+  //
+  //    An uppercase glyph in a heavy sans is at most 0.58em wide, so 0.58 + 0.42
+  //    of tracking is at most 1.0em per character — an upper bound, not a
+  //    measurement. The `·` and the spaces are narrower than that and are counted
+  //    at the same rate, which only makes the bound looser.
+  const WORST_ADVANCE_EM = 1.0
+  for (const [name, w, h] of VIEWPORTS) {
+    const insets = w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT
+    const fontPx = Math.min(12, Math.max(9, w * 0.021))
+    const widest = KICKER_PAPER.length * fontPx * WORST_ADVANCE_EM
+    const available = w - insets.left - insets.right - 2 * Q_EDGE
+    assert.ok(
+      widest <= available,
+      `${name} (${w}×${h}): "${KICKER_PAPER}" needs up to ${widest.toFixed(0)}px and has ${available}px`,
+    )
+  }
+  // And it is short. This is the guard against the invitation growing back into
+  // the paragraph it must not be — `docs`-level house rule, and the kicker slot
+  // has no room for a sentence.
+  assert.ok(KICKER_PAPER.length <= 22, `the invitation is ${KICKER_PAPER.length} characters — it is becoming a sentence`)
+  assert.ok(!/\bYOU SHOULD\b|\bTRY\b|\bDON'T\b/.test(KICKER_PAPER), "the invitation instructs rather than permits")
 })


### PR DESCRIPTION
## The founder, on ARENA

> "Arena is almost perfect but **if you can do something like 34801 / 37 in your head in 5 seconds you are a total math stud** .. the higher levels need to come more gently and not jump right into Max Cohen mode ... maybe they **allow infinite time and even invite the kid to take out a piece of paper and work it out for 10 minutes for the points** instead of just encouraging them to make a quick guess."

And the reason to be careful with it:

> "My 3rd grader is getting in serious reps and he cares about the math and does the reps because he wants the points and is addicted to the gameplay."

So the Resonance is untouched in every respect the audit praises. What changed is the clock and the climb.

---

## 1. The window per item class, before and after

PR #663 made the window `valueAt(intensity, 26, 6, "gentle")` — 26 s at the floor of the ladder, earning down to 6 s at the top. That was ARENA's *reward for mastery* and it was right for the content it was written for. It is wrong for the content the ladder reaches.

Every figure below is printed by `window.test.ts` rather than restated from memory. The `was` column is the old curve read at **both** of its ends, because it was a function of the run and not of the item, so a single number cannot describe it.

| item | class | p90 | **guard now** | was (floor → ceiling) |
|---|---|---|---|---|
| `7 + 5` | single-digit fact — **table row**, 2.8 s / 6 s | 6 s | **1 min** | 26 s → 6 s |
| `43 + 25` | two digits, no regrouping — interpolated | 11 s | **1 min 50 s** | 26 s → 6 s |
| `47 + 25` | two-digit with regrouping — **table row**, 6 s / 14 s | 14 s | **2 min 20 s** | 26 s → 6 s |
| `473 + 168` | three digits with regrouping — interpolated | 23 s | **3 min 50 s** | 26 s → 6 s |
| `5,001 − 2,798` | the class the table names — **table row**, 16 s / 40 s | 40 s | **6 min 40 s** | 26 s → 6 s |
| `34,801 ÷ 37` | five-column long division — extrapolated | 60 s | **10 min** | 26 s → 6 s |

All three rows `EXPERIENCE_DESIGN.md` instruments land **exactly**: 6 s, 14 s (`11 + 3`) and 40 s (`32 + 8`). Read the last two rows against the `was` column and the defect is plain — the two hardest classes in the product were the two whose p90 most exceeded the window they were given, at *every* point on the old curve.

Row 5 of the table is extrapolated and `window.ts` says so: the instrumented table stops at four columns, its rows grow by roughly half again each step (6 → 11 → 18 → 32), and 48 continues that, with `REGROUPING` continuing 3 → 5 → 8 at 12. Sixty seconds for five-column work is the only figure in the file not read off an instrumented row.

**The invariant, asserted through the real scheduler.** `window.test.ts` proves the function is monotone over the whole cross product of its three axes — column count, regrouping, and partial-product operations — and that `BY_COLUMNS[n] + REGROUPING[n] <= BY_COLUMNS[n+1]` so the axes compose. `sim.test.ts` then flies three abilities for twenty minutes each and asserts, over **134 questions and 81 distinct prompts spanning p90 6 s..40 s**, that the guard the world *installed* is exactly the item's, that the population sorted by p90 never steps down, and that the same prompt got the same guard at intensities 0.2 apart. That last one is the assertion the old `resonanceSeconds` failed.

## 2. What replaced the earned countdown

Not a longer window — an **allowance that is ten times the arithmetic's p90 instead of one**, and that never behaves like a clock. `src/sim/window.ts` is `beam`'s pattern (a pure item window, satisfying the fleet invariant) wearing `games/claim`'s and `games/counterweight`'s rules about what a clock may never do — `claim` wrote the rule down: *a clock may never take anything away from a child.*

1. **Derived from the item, and it imports nothing.** `runner` asserts its purity by reading its own source; this does the same, plus a forbidden-identifier scan over the code with the comment block stripped, so the *default-argument dodge* is caught too.
2. **Never drawn.** Nothing in `render/` or `ui/` reads it — no bar, no ring, no number. `counterweight` found that a visible draining countdown is an anxiety cue *regardless of how much time it grants* ("the action is rushed by the timer going down"), so this is the property that matters, not the length.
3. **On running out it reports nothing and takes nothing.** Already true of ARENA's timeout, still true: the host is not told, `success` does not move, no mass changes hands. Asserted directly.
4. **And the seconds are free in the world too** — see below. Without that the guard would have moved the bill rather than cancelled it.

`ABANDON_FACTOR = 10` is derived, not tuned: ten times the 60 s p90 of five-column long division is the ten minutes he named for that exact item. A full minute of stillness on `7 + 5` is a child who went to get a drink; ten minutes on long division is a child with a pencil.

### It is deliberately NOT refilled by input, and that is a divergence I want on the record

`claim` and `counterweight` both refill on any hand on the controls, and both are right to: in `counterweight` a hand on the rack *is* striking the plates that answer the question. **ARENA's only control is steering, and steering is not answering.**

My first cut followed the landed pattern literally and refilled on aim movement. It inverted the two populations it exists to serve, and my own adversarial review caught it:

- a child working `34,801 ÷ 37` out on paper has their hands **off** the glass, so the aim is still — and the allowance ran down on the one child it was built to protect;
- a child ignoring the question and swimming about has their hand **on** the stick, so it refilled forever — and the beat could never end, which is the *"a window that never closes is a game that never resumes"* failure `world.ts` has always warned about.

So the allowance simply runs and treats every child alike. What makes that safe is not a refill; it is the size (60 s–10 min) and the consequence (nothing drawn, nothing reported, nothing taken).

### Two things that were pressure without being a countdown also went

**`sphereDrift`** — up to 22 units/second of *outward* velocity, earned on the same curve as the old window, so at the top of the ladder the answer physically walked away from a hesitating child. The spheres now orbit at a **fixed radius** about the ring's own centre. Rotation is `cos`/`sin` of the frame's angle rather than a tangential velocity (a tangent stepped by `dt` walks the radius outward every frame — the drift reintroduced by arithmetic), and about the ring's centre rather than the live player, or the ring would follow the player and the gap would never close.

**And `stepMotes`' membrane clamp now skips `MK_ANSWER`.** The pull and the flip already did; this was the one of the three that did not. The clamp is radial about the world origin while the ring rotates about the player, so with the player pinned against the membrane the two fight — and it turned out not to merely slide the ring: **it pushed a sphere into a motionless child and the beat read that as their answer.** A verdict and a mass penalty for an answer nobody gave.

### Thinking is not run time — and this needed three clocks, not one

`playTime` excludes every second the arena spent inert, and the quiet tide, **the depth clock and the overdrive** all ride it.

I shipped the first two and left `refreshDepth` on `this.time`; my adversarial review measured what that cost. `DEPTH_CLOCK_SECONDS` is 100 and `depthFor` floors the band, so it is a one-way ratchet:

```
at open   time  16.6  playTime 16.0  depth 0 (DRIFT)        temper 0.22  hunters 0  voidRate 0
at fade   time 616.6  playTime 16.0  depth 6 (THE ABYSSAL)  temper 0.86  hunters 4  voidRate 0.18  leviathan
                                     mass 10 -> 10   worldIntensity 0.040 -> 0.040
```

One 600-second allowance on the item the founder named, at mass 10, nothing eaten and nothing gained — and the child comes back to four hunters, a leviathan and 18% void motes, permanently, because the band cannot fall. That is the bill for thinking with the countdown filed off, and on `main` it was bounded only because `resonanceSeconds` capped an inert beat at 26 s. My own new test was green through all of it, because it asserted the `playTime` arithmetic and never read `world.depth`.

## 3. How speed is still rewarded

`quickness(FLOW, took)` is untouched and it is now the *whole* of ARENA's relationship with the clock: a brisk correct answer earns up to **+70% more mass** than a laboured one and the celebration scales with it, and a laboured one still earns the full base reward. `game-pacing/flow.ts` states the distinction this rests on — "a countdown that kills you and a bonus that accrues when you are fast read the same clock and produce opposite emotional experiences."

Asserted as a pair, because either half alone is satisfiable by a bug: an immediate answer must score quickness > 0.5 and out-earn a twenty-second one, **and** the twenty-second one must still pay more than nothing. Deleting the bonus fails it.

## 4. How the paper invitation is phrased

Four words in the kicker slot that already sat above the prompt, replacing `RESONANCE`:

> **NO TIMER · USE PAPER**

`NO TIMER` is the load-bearing half — a child cannot otherwise know that nothing is counting, and until they know it they will guess. `USE PAPER` is a permission, not an instruction; "take out a piece of paper and work it out" said to a child who was about to do it in their head is a game correcting them.

Three things it deliberately is not:

- **Not on every question.** Gated at the cadence table's 40-second row, so it appears on `5,001 − 2,798` and `34,801 ÷ 37` and never on `7 + 5`. Telling a seven-year-old to fetch a pencil for a single-digit fact is the patronising version of the same idea.
- **Not a status readout.** Set once per question, in the same branch as the prompt, and nowhere else — asserted by counting the assignments in `hud.ts`. Nothing reflows while a child is reading.
- **Not a wall of text.** It replaces a word that was already there. The sentence-length version is in `README.md`, said once, where a parent reads it.

**Fit is bounded, not guessed.** The kicker's advance depends on the atlas font's real metrics, which are measured from a live canvas and cannot be had in Node — and a fixture guessed 15% narrow elsewhere in this fleet passed a test while the device clipped. So the test uses a genuine upper bound (an uppercase glyph in a heavy sans is at most 0.58em, plus 0.42em tracking, so at most 1.0em per character) against `.arena-q`'s safe-inset box at all five viewports `layout.test.ts` covers. `.k` has no `white-space: nowrap`, so being wrong here wraps to two lines rather than clipping.

## 5. Did #715 already fix the lurch? **No — measured, it is a no-op for ARENA.**

This is the finding I was asked to report rather than assume, and it is the opposite of what I expected.

`items.ts`'s `next()` **overwrites** the whole part of `progress` with the pack's request whenever a pack sends `difficulty`. ARENA sends one on every question. So the 85/95 band, the 40-answer window and the `climbRungs` staircase all run inside `judge` and are erased before the next question is drawn. Driven through the real service, ARENA pinning its own rung 3 with a perfect child:

```
n=0 served="4 ÷ 2"   host pos 22 -> 26
n=1 served="10 ÷ 5"  host pos 22 -> 25
n=2 served="15 ÷ 3"  host pos 22 -> 24
...
```

The host climbs, and it is back at 22 on every single question. **ARENA's own breath is the sole ladder.** #715 did not reduce how fast an ARENA player reaches five-digit division, because #715 is not in the path.

It is not the fleet's usual defect — ARENA's ladder descends as readily as it climbs, so it is not a monotone counter — but it *was* lurching, in two ways that are both arithmetic rather than judgement:

**(a) The request was an integer on a ten-rung scale, and the host's ladder is 66 rungs.** The bridge maps a 1..10 index as `(d − 1) / 9`, so `rung + 1` could only ever name curriculum rungs {0, 7, 14, 22, 29, 36, 43, 51, 58, 65} — a **7.2-rung jump** per step of the breath. Measured through the real host:

| ARENA rung | curriculum rung | skill | example |
|---|---|---|---|
| 6 | 43 | `dw.add.regroup.add-multidigit` L2 | `506 + 394` |
| 7 | 51 | `dw.div.whole.divide-exact` L3 | `721308 ÷ 84` |

One rung of the breath, and a child goes from three-digit addition to six-digit long division. That is "jump right into Max Cohen mode", literally.

**(b) The climb ran at the *world's* rate.** The shared controller's `climbBoost` is deliberately large so an adult is not walked up every rung from `0 + 1` — right for an ocean that should escalate in tens of seconds, wrong for a curriculum ladder. Measured, a bot answering everything correctly: intensity 0.04 → 1.00 in **300 seconds**, requests going `0, 3, 21, 25, 32, 39, 47, 55, 63, 65` — an **eighteen-rung step between two consecutive questions**. Three quick correct answers and a child is on five-column long division, which is his other sentence, from VOLTA and true here verbatim: *"you get a few right just by being lucky and all of a sudden you are asked to do like 87364/9."*

So: the request is now **unrounded**, and the maths follows the breath down at once and up **one correct answer at a time** — at most a fifty-fifth of the ladder each, never past `intensity`. **This is not a second ladder; it is a leash on the only one.** `LADDER_CLIMB_ANSWERS = 55` is #715's own published figure for a 100%-correct child at the median reaching the top of the 66-rung ladder, so the constraint is stated as *ARENA's request may not outrun the host's own recalibrated ladder* — which is exactly what it was doing with a three-answer moving average.

**Paid in answers, not in seconds, and that correction came out of mutation testing.** I first wrote it as a per-second slew limit with the seconds derived from 55 answers at a 25 s cadence. Two leaks, both the same mistake — time is not evidence:

- an abandoned question is up to ten minutes of `dt`, so **stalling climbed the ladder**. Measured: six correct answers put the request on curriculum rung 9, then two abandoned questions carried it to **rung 65 of 65** having answered nothing. Answering nothing was the fastest route to hard content, and taking the founder's ten minutes on paper was billed at nearly half the ladder.
- and a child who answered six quickly then simply swam about for twenty minutes drifted to the top on the strength of those six — "you get a few right just by being lucky" with a delay bolted on.

Counting answers has neither failure and needs no conversion. My "stalling" test was passing at 5% climb per two beats before I noticed the residual leak was the inter-beat gaps, which is what made me change the unit rather than tune the constant.

Only `ladderPosition` reads it. Density, rivals, speed, growth, water temper and the reveal all still ride `intensity`/`worldIntensity`, so nothing about how the arena *feels* is slowed — the world still leans in within tens of seconds. Only the arithmetic climbs slowly. And the leash is one-directional, the same asymmetry `fallSeconds` and #715's bands use: **relief is never earned.**

Measured after, fifteen minutes:

| player, 15 min | curriculum rungs (of 65) | step per answer |
|---|---|---|
| everything wrong | 0–3 | — |
| **right 85% of the time** | **0–14** (was 0–65) | 1 |
| flawless | 0–39 (was: 65 in five minutes) | 1–2 |
| answers nothing, stalls | no climb at all (was: to the top) | — |

**Those are session-length figures, not ceilings**, and the difference matters — a leash that pinned a competent child low forever would be worse than the lurch. Measured over a full hour, nobody is stuck and a fluent child still reaches the top:

| accuracy | rung at 10 min | 30 min | 60 min |
|---|---|---|---|
| 100% | 5 | 58 | **65 (top)** |
| 95% | 14 | 34 | **65 (top)** |
| 90% | 14 | 2 | 31 (peaked 52) |
| 85% | 13 | 11 | 31 (peaked 30) |

100% is above `PROMOTE_AT` from the first answer, so the leash is the only thing in its way and 55 answers clears it. The wide oscillation at 85–90% is the pre-existing three-answer EMA in `game-pacing`, not this change, and it is the reason the last section below exists.

**And freezing the world during a beat is not an exploit.** Thirty minutes, same seed, same farming bot, answering versus deliberately timing every question out:

| | mass | best | depth | rung | answered |
|---|---|---|---|---|---|
| answers | **670,164** | 885,595 | 8 | 65 | 65 |
| stalls every question | 5,332 | 6,019 | 6 | 0 | 4 |

126× worse on mass and the bottom of the ladder instead of the top. Stalling pauses escalation, but it pauses every source of gain with it — you cannot eat while the field is inert — so it is strictly dominated in both directions.

## 6. A live defect found on the way: the top rung drew the answer as `0`

`mval` is an `Int32Array` and `openResonance` clamps anything past 2^31 to zero. Measured across the whole 66-rung ladder, 40 items a rung: the top rung is `dw.mul.multidigit.long-multiplication` L2, and **24 of 40 of its answers exceed 2^31** — `18309 × 53248 = 974917632` is fine, `37388 × 85585 = 3199851980` is not. So the sphere carrying the right answer was drawn reading **`0`**: the child was asked to find an answer that was not on the screen, all four spheres lied, and whichever one they flew into cost them mass. The old integer request landed on exactly that rung whenever the breath topped out, so it was reachable by playing well.

ARENA now **declines** such a question — the rule it already had for an item it cannot pose with four distinct options, applied to the other way a beat can lie — and warns, because a pack quietly not asking questions is indistinguishable from a pack that is working. It is a structural check on the item in hand rather than a ceiling on the request, because the request is relative and the ladder grows.

The #690 verbatim-string test that this displaced is **stronger** now, not weaker: it uses a padded answer (`"0500"`), which is the cheapest item that can detect the round trip at all — `Number("0500")` is 500, so a game reporting `String(mval)` says `"500"` while the host said `"0500"`, and every other value in the product survives the trip and hides the bug.

## What must not regress — all held

- **The Resonance:** field inert, spheres identical in size (`mr` unchanged), forced traversal speed, timeout free and unreported. Untouched.
- **#690 exact absorption:** untouched; the ribbon tests pass.
- **#690 surge-exhaust exploit:** still guarded — setting `EXHAUST_SHARE = 1.0` fails with `the trail (7098) is worth as much as the surge cost (7124) — boosting is free`.
- **#666 latency:** still `answerable → commit`. `openedAt`/`openedT` are still re-stamped at the phase 1→2 transition and `reachSeconds` is still subtracted for the controller; `res.t` no longer doubles as the resolve clock (`resolveT` does), which is what let `duration` go.

## Every fix verified by deleting it

Re-run against the final code on the rebased base. Each row: the change reverted, and the exact message the suite then printed.

| mutation | failure message |
|---|---|
| restore `res.guard = valueAt(intensity, 26, 6, "gentle")` | `five minutes of struggle changed the time the same question gets` · `the guard was only 25.968s` · `"3 × 4" was given a 25.968s guard, not the item's own` · `the beat only carried a 25.968s guard` · `4 of the four spheres were consumed while the child sat still at the membrane` |
| restore `sphereDrift` (the answer recedes) | `the answer moved from 250 to 258 units away while the child thought` |
| the membrane clamp drags the answer ring | `a sphere was pushed into a motionless child and answered the question for them` |
| depth clock + overdrive back on `this.time` | `thinking sank the run from depth 0 to depth 6 — the child paid for the paper in hunters` |
| the quiet tide back on `this.time` | `600.0s of thinking was charged to the run` |
| restore the integer difficulty request | `one answer moved the child 8 curriculum rungs — that is "jump right into Max Cohen mode", and it is what this test exists to stop` |
| delete the leash (`ladderPosition` reads the raw breath) | `one answer moved the child 25 curriculum rungs — …` |
| pay the leash per **second** instead of per answer | `two abandoned questions carried the request 86.7% of the way up the ladder (0.133 -> 1.000, about curriculum rung 65 of 65) without a single answer` |
| draw an undrawable answer instead of declining | `a question whose answer cannot be drawn was posed to a child anyway` |
| delete the quickness bonus | `being fast paid 1.9 against 1.9 for being slow` |
| make the guard non-monotone (division cheaper than addition) | `34801 ÷ 37 was scored at 40s against the table's 60s` · `2-column × got 6s against 2-column + at 11s` · `the beat only carried a 400s guard` (7 failures) |
| let `window.ts` import the pacing module | `window.ts imports something: ["import { valueAt } from ..."]. It must be able to see the item and nothing else.` |
| the default-argument dodge (`guardSeconds(item, intensity = 0)`) | `window.ts's CODE mentions \`intensity\` — the window must be a function of the item alone` |
| the kicker never changes (invitation is dead copy) | `the HUD no longer chooses its kicker from the item's class` |
| `EXHAUST_SHARE = 1.0` (the #690 surge exploit) | `the trail (7098) is worth as much as the surge cost (7124) — boosting is free` |

### Six of my own tests were found weak this way and rewritten

This is the part worth reading, because five of the six were green when I first thought I was finished.

1. **`widestColumn` counted the answer**, following `beam` and `counterweight`. That put `7 + 5 = 12` — the row the cadence table names most explicitly — in the two-column class at **14 s against the table's 6 s**, on the easiest item in the product. `runner` had already found this; ARENA now follows `runner` and falls back to the answer only when the prompt has no digits at all.
2. **The headline purity test was three calls to a pure function.** It built three worlds, flew them for up to seven minutes, then compared `guardSeconds(item)` against itself three times — `guardSeconds` is a pure import and `item` a module const, so the assertions could not fail, and would have passed while `openResonance` installed `guardSeconds(q) * (1 - intensity)`. It now reads `world.resonance.guard` off a live beat.
3. **The `playTime` test asserted only its own bookkeeping** (`time - playTime ≈ inert`) and never read `world.depth`, `world.over` or `worldIntensity` — which is exactly why the depth-clock bug above was green. It now photographs the world at the open and asserts six things about it after the stall.
4. **The refill test asserted the wrong direction.** It asserted a wandering child's beat stays open, which is the behaviour I later concluded is the bug. It now asserts the opposite and bounds the beat by `MAX_GUARD_SECONDS`.
5. **The membrane test compared arrays of different lengths.** `for (k = 0; k < after.length; k++)` against `before[k]` — the defect retires spheres, so one survivor was compared against the first of four and two equal numbers agreed about nothing. Caught because the mutation *passed*. It now asserts the ring is still four spheres and that nothing was reported, before it looks at any radius.
6. **Two mutations reported a true-but-weak message** because a resolution assertion was masking the lurch assertion, and a corroborating measurement was masking the property. Both reordered so the founder's actual sentence fires first.

`MAX_COLUMNS` is a literal (so indexing the tables narrows in TypeScript) and is pinned against both tables' actual reach, so it cannot drift from the rows it names.

## Verification

Node **24.18.0** (v22 is the shell default and is wrong for this repo). Rebased onto `origin/main` at `1fb4206be` (0.3.5) and re-verified there:

- `npm run -s tsc` — clean.
- `npm test` — **91/91, five consecutive runs.**
- `node packs/build.mjs arena` — builds, checks and stages (667,643 bytes, 3 files).
- Working tree clean against `HEAD` after the mutation sweep, so no residue is in the diff.

Only `dynawalla/games/arena/` is touched. Nothing under `packs/**` or `dynawalla-app/**`.

> Note on gates: there is **no `check` script** in the game packages — `npm run -s check` prints nothing and exits 1, which reads like a pass. The real gates are `tsc` and `test`.

## What needs a device

- **Sphere-label legibility past the int32 bound.** The int32 fix is exact and proven. What I could *not* verify headlessly is whether a 7-, 8- or 9-digit label overflows a sphere: `capFor` clamps cap height **up** to `NUM_MIN_PX` (13px), so a too-long label spills past the sphere rather than shrinking below legibility, and the atlas `advance` is measured from a live canvas. For data, the curriculum rungs whose answers exceed six digits are 31 (7), 35 (9), 50 (6), 57 (6), 59 (7), 61 (6), 63 (9), 65 (10). I did **not** guess a digit ceiling — guessing font metrics is how this fleet's font fixture shipped 15% narrow.
- **The feel of a ten-minute pause.** A child sitting still for ten minutes is a state no bot can judge. Ambient audio, the depth palette and the camera all keep running while the field is inert; that reads correctly in the sim but should be watched once on glass.
- **The kicker at 320×568 in the real font.** Bounded above rather than measured, and `.k` wraps rather than clips, so the risk is cosmetic.

## One thing I did not do

I did **not** take the maths ladder away from the pack and hand it to the host, which is the deeper fix implied by finding 5 — ARENA overriding `progress` on every question is what makes #715 a no-op for it. That would delete the pack-side ladder entirely and inherit the founder's 85/95 band for free, but it also unpicks the breath coupling that makes the world and the arithmetic escalate as one thing, which is the design he calls almost perfect and which his 3rd grader is currently addicted to. It wants its own PR and his eye, so it is named here rather than smuggled in.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
