### PR TITLE
chore(dynawalla): 0.3.5

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.4 → 0.3.5. One line changed.

Ships the founder's 0.3.4 playtest round:

- **#713** the bottom of the ladder was nine trivial items, so `2+0` came round and round. "Easy" now means `4+5` too.
- **#712** every invented word defined where a child first meets it. Two games' copy was corrected during the rebase where a later rebuild had made it false: merge-idle described an essence odometer, a FLOW pill and a magnitude meter that ABYSSAL BLOOM had deleted, and slice claimed a timeout resets FAVOUR when it does not.
- **#696** arena and claim routed through the shared audio ceiling.
- **#724** COUNTERPOISE — every operator gets a physically true apparatus. Also fixed the guard sweep, which wrote its own prompts as `a OP b` and so reported `missing-addend` as undrawable; given the statement the host actually sends, all three levels serve 40/40 seeds.

A main push does not release. The tag `dynawalla-v0.3.5` does, and I will push it once this is on main.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb