### PR TITLE
dynawalla/curriculum: the ns, alg and frac rungs written out, and three equality rows a child can reach

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -535,10 +535,15 @@ test("the founder's card is drawn, exactly, by the renderer the graph uses", () 
   // > understand the problem to use it correctly) we could use blanks in an equation
   // > `___ × 15 = 165`"
   //
-  // `dw.alg.equality.missing-factor` is **draft** — no pack that declares it can draw a
-  // missing factor, see `PACK_STATEMENT_BLOCKED_SKILLS` — so this drives `ladder([node])`
-  // directly rather than the shipped ladder. The renderer is the same one, which is the
-  // point: the row is held back by a pack, not by the host, and this is what says so.
+  // `dw.alg.equality.missing-factor` is **active** now. It was draft when this test was
+  // written, because `games/balance` could not build a board for a product it did not know
+  // yet, and the row came off `PACK_STATEMENT_BLOCKED_SKILLS` when COUNTERPOISE PR 724
+  // rebuilt its tokeniser around signed `product`/`quotient`/`countOf` terms. The status
+  // line below is the tripwire that made this comment get revisited rather than rot.
+  //
+  // It still drives `ladder([node])` rather than the shipped ladder, and deliberately: the
+  // claim is about one specific card, and picking it out of a 77-rung ladder by difficulty
+  // would make the assertion depend on where the row happens to sit.
   //
   // Pinned on a seed rather than swept, because the assertion is about a specific card:
   // the box **opens** the statement, the 15 is the known factor, the 165 is the given
@@ -546,7 +551,7 @@ test("the founder's card is drawn, exactly, by the renderer the graph uses", () 
   // be wrong in a way a swept "some equation was drawn" check would pass.
   const node = allNodes.find((candidate) => String(candidate.id) === "dw.alg.equality.missing-factor")
   assert.ok(node !== undefined)
-  assert.equal(node.status, "draft", "missing-factor went active without this test being revisited")
+  assert.equal(node.status, "active", "missing-factor left the ladder without this test being revisited")
   const rung = ladder([node]).find((candidate) => candidate.level === 1)
   assert.ok(rung !== undefined)
   const exercise = rung.family.generate({
@@ -581,6 +586,10 @@ test("every blank statement the shipped ladder draws is a true equation, read ba
   const rungs = ladder()
   const service = createItemService({ profileId: "p1", record: noRecord })
   let statements = 0
+  // Cards where the answer is the number already printed on the far side. Counted, so
+  // that the one exception below is known to be *exercised* rather than merely written:
+  // a branch nothing reaches is a branch that has stopped meaning anything.
+  let halvings = 0
 
   for (let i = 0; i < rungs.length; i++) {
     const at = rungs.length === 1 ? 0 : i / (rungs.length - 1)
@@ -619,10 +628,33 @@ test("every blank statement the shipped ladder draws is a true equation, read ba
       // And the answer is not simply the other side of the card, which is the shape of
       // the failure this whole change is about: a missing factor whose "answer" is the
       // product reads perfectly and is wrong.
-      assert.notEqual(revealed, sides[1], `"${item.prompt}" wants the number already printed on it`)
+      //
+      // With one exception, and it is arithmetic rather than a waiver. On `a − □ = c` the
+      // answer *is* `c` exactly when `a = 2c` — `12 − □ = 6` wants 6 — and that is a
+      // halving fact, not a card asking the wrong question. It arrives about one item in
+      // nine on `dw.alg.equality.missing-subtrahend`, which went active with the pack fix
+      // that let COUNTERPOISE build a board for a signed blank. So the coincidence is
+      // allowed and *checked*: where the answer equals the printed result, the card must
+      // be a subtraction whose minuend is twice it. Every other glyph, and every other
+      // minuend, still fails.
+      if (revealed === sides[1]) {
+        halvings += 1
+        assert.equal(glyph, "−", `"${item.prompt}" wants the number already printed on it`)
+        assert.equal(right, BLANK, `"${item.prompt}" wants the number already printed on it`)
+        assert.equal(
+          value(left),
+          2n * BigInt(sides[1] ?? ""),
+          `"${item.prompt}" wants the number already printed on it and is not a halving fact`,
+        )
+      }
     }
   }
   assert.ok(statements >= 8, `only ${String(statements)} blank statement(s) were drawn by the shipped ladder`)
+  assert.ok(
+    halvings > 0,
+    "no card drew an answer equal to its printed result, so the halving exception above is unreachable — " +
+      "if the ladder no longer serves a missing subtrahend, delete it",
+  )
 })
 
 test("a missing addend is judged on the addend, and adding the whole card is the diagnosed mistake", () => {

--- a/dynawalla/games/balance/src/unstuck.test.ts
+++ b/dynawalla/games/balance/src/unstuck.test.ts
@@ -333,8 +333,15 @@ test("every board the shipping ladder can serve has a legal move", () => {
   }
   // And two thirds of the ladder is fully served, which it was not before: the
   // ten division rungs were 0 of 400.
+  //
+  // Sixty-six became seventy-seven when the curriculum promoted the three equality rows
+  // this pack's own fix unblocked — `missing-subtrahend`, `unknown-minuend` and
+  // `missing-factor`, four rungs, four rungs and two — plus a fourth rung on
+  // `missing-addend`. Every one of those eleven boards passed the no-stuck-board
+  // assertion above and none of them joined `dead`, which is the measurement the
+  // promotion was made on.
   const whole = [...byRung.values()].filter((r) => r.refused === 0).length;
-  assert.equal(byRung.size, 66);
+  assert.equal(byRung.size, 77);
   assert.ok(whole >= 53, `only ${String(whole)} of ${String(byRung.size)} rungs are served in full`);
 });
 

--- a/dynawalla/packs/shared/curriculum/CHANGELOG.md
+++ b/dynawalla/packs/shared/curriculum/CHANGELOG.md
@@ -73,16 +73,43 @@ digits, and every `frac` row from its smallest denominators to the family's ceil
   so promoting one serves a rung that generates a question, declines to draw it and asks
   the child nothing. Measured against the registry in both directions.
 
-**Nothing is promoted, and that is the finding.** Every row authored here stays `draft`
-because no shipping pack can serve it: `ns` and the `frac` equivalence and comparison rows
-on `NON_BINARY_QUESTION_TEMPLATES`, all eleven `frac` rows on
-`FRACTION_ANSWER_BLOCKED_SKILLS` (`answerText` returns `null` for a fraction and everything
-downstream reads `null` as `""`), and four of the five `alg` rows on
-`PACK_STATEMENT_BLOCKED_SKILLS`. Four fraction games and two algebra games ship declaring
-these ids today and every one of them is being served nothing. What clears it is a pack
-that can print a fraction, take one as an answer, and draw a question that is not two
-operands and an operator — one PR, in `games/`, with a curriculum that is now waiting on
-nothing else.
+**Three `alg` rows go active, and `PACK_STATEMENT_BLOCKED_SKILLS` drops from four to one.**
+Not by a curriculum argument: `games/balance` is the one pack of twenty-eight that builds a
+physical apparatus out of a statement rather than drawing it, and its tokeniser pushed a
+blank without applying the sign it had just read — so the box in `93 − □` was *added* to
+the pan — and could not collapse a product it did not know yet. COUNTERPOISE rebuilt that
+tokeniser around signed `product`/`quotient`/`countOf` terms, and its own `whyUnsolvable`
+now reports a levelling board for every statement this host writes. So
+`dw.alg.equality.missing-subtrahend`, `unknown-minuend` and `missing-factor` are `active`,
+which takes the equality strand from one served row to four and gives it an active row in
+every grade band from 1 to 5.
+
+Independently confirmed by the pack: `games/balance`'s own ladder sweep now walks 77 rungs
+instead of 66, found a legal move on every board the eleven new rungs produce, and added
+none of them to the seven rungs it refuses.
+
+`dw.alg.equality.balance-meaning` stays draft, and **not** for the pack's sake — COUNTERPOISE
+builds a solvable board for `8 + 4 = □ + 5`. Nothing can hand it that string:
+`drawStatement` writes three shapes and no fourth, which is why the row is on
+`NON_BINARY_QUESTION_TEMPLATES`, and it declares the balance scale `required`, which `Item`
+has no field to transmit.
+
+**Every `ns` and `frac` row stays draft, and that is the other half of the finding.** `ns`
+and the `frac` equivalence and comparison rows are on `NON_BINARY_QUESTION_TEMPLATES`; all
+eleven `frac` rows are on `FRACTION_ANSWER_BLOCKED_SKILLS`, because `answerText` returns
+`null` for a fraction and everything downstream reads `null` as `""`. Four fraction games
+ship declaring those ids and are being served nothing. What clears it is a pack that can
+print a fraction, take one as an answer, and draw a question that is not two operands and
+an operator — one PR, in `games/`, with a curriculum that is now waiting on nothing else.
+
+Two tripwires in other packages were revisited rather than deleted, which is what they were
+left for. `dynawalla-app`'s pinned missing-factor card asserted the row was `draft`; it
+asserts `active` now. And its blank-statement sweep asserted that no answer is the number
+already printed on the far side of the card — written to catch a missing factor whose
+"answer" is the product, and now met by `12 − □ = 6`, which wants 6 and is a *halving fact*
+rather than a misstated card. The exception is arithmetic and checked: where the answer
+equals the printed result the card must be a subtraction whose minuend is twice it, and a
+counter asserts the branch is reached at all.
 
 `rev` goes to 2 on all twenty-two rows. **No id moved.** Two `ns` rows and nine `frac` rows
 have a rung **inserted below their top**, which renumbers the levels above it; all eleven

--- a/dynawalla/packs/shared/curriculum/CHANGELOG.md
+++ b/dynawalla/packs/shared/curriculum/CHANGELOG.md
@@ -9,6 +9,90 @@ installed pack until that pack is rebuilt and republished.
 
 ## 0.1.0 — Unreleased
 
+### `ns`, `alg` and `frac`: the rungs written out, and a variety floor under every one
+
+Twenty-two rows across three domains had between two and four levels each, and most
+started partway up their own ladder. `dw.ns.compare.whole-numbers` — `gradeBand.earliest:
+1` — began at *three-digit* comparison; `dw.ns.round.whole-numbers` began at three digits;
+the `alg` rows stopped at three when their family reaches four. So a controller walking a
+struggling child down these domains ran out of rungs while the questions were still too
+hard, and a child at the top ran out of ladder before the standards the rows cite do.
+
+**The level tables are authored end to end.** 102 levels across the three domains where
+there were 67 — the whole graph goes from 152 to 187 — from the smallest question each
+family can pose to the largest: place value and comparison to seven digits, rounding from
+`47` to the nearest ten up to six digits with the halfway number, the `alg` shapes to four
+digits, and every `frac` row from its smallest denominators to the family's ceiling.
+
+- **`MIN_RUNG_VARIANTS` now also measures the draft graph.** The floor and its exemption
+  list arrived in the section below, measured by `ladder.test.ts` over `activeNodes` — the
+  right graph for the claim it makes, since that is what a child can be served. But
+  twenty-eight rows are draft and this change more than doubles their level count, so a
+  rung authored under the floor today would be found by the promotion PR at best and by a
+  child at worst. `families.property.test.ts` runs the same bound over the whole graph
+  against the same `SMALL_RUNG_LEVELS`, which is deliberately the *active* exemption list:
+  a draft rung has no claim on an exemption nobody has had to weigh.
+
+  It earned its place immediately. `equivalence("build", 12, 4, 1)` is the natural easiest
+  rung for `dw.frac.equivalence.build-equivalent` and holds nineteen problems — an honest
+  declaration and not a rung — so the row starts at a ceiling of 16 and thirty-five
+  instead.
+- **`CG10_BLOCKED_LEVELS` is empty.** All twenty-four entries resolved, none by argument.
+  Levels whose ceiling was arbitrary were **widened** — `dw.ns.round.whole-numbers`' easiest
+  three-digit rung rounded only to the nearest ten (720 problems) and now rounds to ten or
+  hundred (1,602); `dw.frac.arith.add-like-denominators` L2 went from a ceiling of 16
+  (1,008 problems, read as ~780 by the gate's estimator) to 20 (2,100, read as ~1,180).
+  Levels whose space is all there is **declare `closedFactSet`**: `dw.alg.equality.*` at
+  one digit are 81, 81, 64 and 729 sentences, and the whole `build`/`simplify` fraction
+  task holds six hundred problems at the family's widest denominator, so no level of
+  `dw.frac.equivalence.build-equivalent` could ever clear the floor.
+- **`closedSpaces.test.ts`, and the other half of the same loophole.**
+  `MIN_RUNG_VARIANTS` closed the half where a rung is honestly declared too small. This
+  closes the half where the declaration is simply not the space: CG-10's substituted check
+  is `distinct <= declared`, an upper bound alone, so `closedFactSet: [999_999]` satisfies
+  both the gate and the new floor beside a rung of nine items. Every declaration in the
+  graph is now **exhausted** — drawn until the level stops yielding new items, required to
+  equal the declaration exactly — so over- and under-declaring both fail. All 69 pass,
+  including the 37 that were already here and had never been measured from below. It is
+  also why the field is used only below CG-10's floor: the largest of these needs about
+  15,000 seeds and a 2,280-item space needs six figures.
+- **Every level table is checked to increase, on draft rows as well as active ones.** CG-9
+  checks it over `activeNodes` only, and twenty-eight rows are draft; `dw.div.facts.division-facts`
+  already shipped a table stated against coefficients it did not have because of that gap.
+  It matters more than bookkeeping because `b_item` is what an answering window is priced
+  off: `PACING_AUDIT_2026-07.md` requires `window(d)` to be monotone non-decreasing in
+  difficulty, and a rung easier than the one below it hands a climbing child a *shorter*
+  window for harder work in every pack that prices its clock off difficulty at all.
+- **`NON_BINARY_QUESTION_TEMPLATES`** — the largest promotion blocker in the graph, and it
+  was prose in a file header. Eleven templates declare `operator: "none"`, and the only
+  thing that serves an item composes a question from two operands and a glyph, so it
+  refuses them out loud. "In 4,193, what is the digit in the hundreds place worth?" is a
+  numeral and a place *name*; `2/3 = ☐/12` is an equation between two written fractions.
+  Thirteen draft rows — all six of `ns`, the four `frac.equivalence` rows, the two
+  `frac.compare` rows and `dw.alg.equality.balance-meaning` — can draw no other question,
+  so promoting one serves a rung that generates a question, declines to draw it and asks
+  the child nothing. Measured against the registry in both directions.
+
+**Nothing is promoted, and that is the finding.** Every row authored here stays `draft`
+because no shipping pack can serve it: `ns` and the `frac` equivalence and comparison rows
+on `NON_BINARY_QUESTION_TEMPLATES`, all eleven `frac` rows on
+`FRACTION_ANSWER_BLOCKED_SKILLS` (`answerText` returns `null` for a fraction and everything
+downstream reads `null` as `""`), and four of the five `alg` rows on
+`PACK_STATEMENT_BLOCKED_SKILLS`. Four fraction games and two algebra games ship declaring
+these ids today and every one of them is being served nothing. What clears it is a pack
+that can print a fraction, take one as an answer, and draw a question that is not two
+operands and an operator — one PR, in `games/`, with a curriculum that is now waiting on
+nothing else.
+
+`rev` goes to 2 on all twenty-two rows. **No id moved.** Two `ns` rows and nine `frac` rows
+have a rung **inserted below their top**, which renumbers the levels above it; all eleven
+are `draft` and `shipped-ids.json` carries no release, so nothing keys off the old
+numbering. No `alg` row is renumbered — that domain is append-only here, because one of its
+rows is `active`, and a rung inserted under a live row's levels is the one edit this program
+does not make. Of the probes, three `entry` probes at L0 now land on the new easiest rung,
+which is what an entry probe is for, and `dw.frac.equivalence.mixed-to-improper`'s
+`promotion` probe moved from L2 to L3 to stay on the rung it was written against.
+
 ### "Easy" means `4 + 5`, not the nine smallest facts
 
 The founder, after an hour with four different games:

--- a/dynawalla/packs/shared/curriculum/README.md
+++ b/dynawalla/packs/shared/curriculum/README.md
@@ -41,7 +41,7 @@ npm run snapshots:update    # rewrite the CG-16 output hashes
 | `src/generators/columnOp/` | `gen.arith.column-op` — the column algorithm, add and subtract, with exact regrouping control including across zeros. |
 | `src/malrules/` | Sixteen executable buggy procedures, and the classifier. |
 | `src/board/` | Reading a column item back out of the public prompt contract, and the **counting-board contrast pair**. |
-| `src/graph/` | The graph, and `ladder.test.ts` — one root, everything climbing from it, `activeNodes()` in prerequisite order. |
+| `src/graph/` | The graph, `ladder.test.ts` — one root, everything climbing from it, `activeNodes()` in prerequisite order — and `closedSpaces.test.ts`, which exhausts every `closedFactSet` declaration so the CG-10 exemption cannot be bought with a large number. |
 | `src/render/registry.ts` | Renderer *declarations*. The data behind CG-8. |
 | `src/validate/` | The gates and `dw-curriculum check`. Tooling: never imported by a pack. |
 | `src/boundary.test.ts` | The pack-consumability boundary, enforced. |

--- a/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
@@ -37,7 +37,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { allNodes } from "../graph/graph.ts";
-import { CG10_BLOCKED_LEVELS } from "../graph/promotionBlockers.ts";
+import { CG10_BLOCKED_LEVELS, MIN_RUNG_VARIANTS, SMALL_RUNG_LEVELS } from "../graph/promotionBlockers.ts";
 import { familyById } from "./registry.ts";
 import { malRules } from "../malrules/registry.ts";
 import { fingerprintItem, serializeExercise } from "../serialize.ts";
@@ -45,7 +45,7 @@ import { answerAccepted, fractionRational, schemaDefect } from "../types/answer.
 import type { AnswerValue } from "../types/answer.ts";
 import type { Exercise, PromptSlot } from "../types/exercise.ts";
 import { LOC_KEY_PATTERN } from "../types/ids.ts";
-import { cmp, eq as rationalEq, rational } from "../math/rational.ts";
+import { cmp, eq as rationalEq, rational, toString as rationalToString } from "../math/rational.ts";
 import type { Rational } from "../math/rational.ts";
 import { findPromptTemplate, promptRegistry } from "../render/prompts.ts";
 import { repSpecDefect } from "../render/representations.ts";
@@ -447,9 +447,99 @@ test("sweep: every level clears its own minVariants, and the sub-floor levels ar
   });
   assert.deepEqual(
     activeBelow.map((level) => level.label),
-    [],
+    [] as readonly string[],
     "an active level is below CG-10's variant-space floor",
   );
+});
+
+/**
+ * `MIN_RUNG_VARIANTS` over the **whole** graph, drafts included.
+ *
+ * `ladder.test.ts` already measures this floor, and over the right graph for the claim it
+ * makes: `activeNodes`, which is what a child can be served. It is the gate that would
+ * have caught the nine-item bottom rung the founder met by playing four games for an
+ * hour, and it is where the exemption list lives.
+ *
+ * This is the same bound over the twenty-eight rows that are **not** active yet, and it
+ * exists for the reason this whole file does. The gates run on the active graph; most of
+ * this graph is draft; so a rung authored under the floor today is discovered by the
+ * promotion PR at best and by a child at worst. `dw.div.facts.division-facts` is the
+ * precedent — it shipped a difficulty table stated against coefficients it did not have,
+ * because CG-9 does not look at draft rows.
+ *
+ * It matters most for the domain this file's graph has just doubled. `frac` is full of
+ * genuinely small closed spaces — `equivalence("build", 12, 4, 1)` is nineteen problems —
+ * and nineteen is a perfectly honest declaration that must not be a rung. Without this,
+ * the only thing standing between that and a child would be somebody remembering.
+ *
+ * Asserted in both directions against `SMALL_RUNG_LEVELS`, which is the *active* exemption
+ * list: a draft rung under the floor is not on it and fails here, and an exempt rung
+ * widened past the floor has to be struck off.
+ */
+test("sweep: every rung in the whole graph holds MIN_RUNG_VARIANTS distinct items", () => {
+  const subFloor: string[] = [];
+  for (const level of LEVELS) {
+    const distinct = new Set(level.exercises.map(fingerprintItem)).size;
+    if (distinct < MIN_RUNG_VARIANTS) subFloor.push(`${level.label} (${String(distinct)} distinct)`);
+  }
+
+  process.stdout.write(
+    subFloor.length === 0
+      ? `# every rung holds at least ${String(MIN_RUNG_VARIANTS)} distinct items\n`
+      : `# ${String(subFloor.length)} rung(s) below MIN_RUNG_VARIANTS=${String(MIN_RUNG_VARIANTS)}:\n#   ${subFloor.join("\n#   ")}\n`,
+  );
+
+  // Both directions. The exemption list is `SMALL_RUNG_LEVELS`, and it is deliberately the
+  // *active* list rather than a second one: a draft rung has no claim on an exemption
+  // nobody has had to weigh, so the only way a draft level clears this is by being wide
+  // enough.
+  assert.deepEqual(
+    subFloor.map((line) => line.slice(0, line.indexOf(" ("))).sort(),
+    [...SMALL_RUNG_LEVELS].sort(),
+    `the rungs below MIN_RUNG_VARIANTS=${String(MIN_RUNG_VARIANTS)} and promotionBlockers.ts disagree`,
+  );
+});
+
+/**
+ * A level table only ever goes up — on **every** row, draft included.
+ *
+ * CG-9 already checks this, and only over `activeNodes`. That asymmetry has cost real
+ * money once already: `dw.div.facts.division-facts` shipped a difficulty table stated
+ * against coefficients it did not have, and no gate could see it while the row was
+ * draft. Twenty-eight rows are draft right now.
+ *
+ * It matters more than a bookkeeping slip because of what reads the number. `b_item` is
+ * what an answering window is priced off — `PACING_AUDIT_2026-07.md` states the
+ * invariant as "`window(d)` must be MONOTONE NON-DECREASING in item difficulty" — so a
+ * rung that is *easier* than the one below it hands a climbing child a **shorter**
+ * window for harder work, in every pack that prices its clock off difficulty at all. A
+ * level table that goes backwards makes that invariant unsatisfiable no matter how
+ * carefully the pacing primitive is written.
+ */
+test("sweep: every level table strictly increases, on draft rows as well as active ones", () => {
+  const backwards: string[] = [];
+  let compared = 0;
+
+  for (const node of allNodes) {
+    if (node.status === "deprecated") continue;
+    const levels = node.difficulty.levels;
+    for (let index = 1; index < levels.length; index++) {
+      const lower = levels[index - 1];
+      const upper = levels[index];
+      if (lower === undefined || upper === undefined) continue;
+      compared += 1;
+      if (cmp(upper, lower) <= 0) {
+        backwards.push(
+          `${node.id} L${String(index)} is ${rationalToString(upper)} and L${String(index - 1)} is ${rationalToString(lower)}`,
+        );
+      }
+    }
+  }
+
+  // A vacuity guard: the loop above passes on a graph of one-level rows.
+  assert.ok(compared > 100, `only ${String(compared)} level steps compared`);
+  assert.deepEqual(backwards, [] as readonly string[], backwards.join("; "));
+  process.stdout.write(`# level tables: ${String(compared)} step(s) compared, all increasing\n`);
 });
 
 /**

--- a/dynawalla/packs/shared/curriculum/src/graph/closedSpaces.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/closedSpaces.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Every `closedFactSet` declaration in the graph, **exhausted**.
+ *
+ * ## The loophole this closes
+ *
+ * `GeneratorBinding.closedFactSet` exempts a level from CG-10's variant-space floor,
+ * and the exemption is right: there are forty-five additions within ten and there is
+ * no forty-sixth, so a floor derived from "would a forty-item run repeat itself"
+ * would forbid teaching number facts at all.
+ *
+ * But look at what the substituted check actually is. In
+ * `families.property.test.ts` it is
+ *
+ * ```ts
+ * assert.ok(distinct <= level.closedFactSet)
+ * ```
+ *
+ * — an upper bound, and an upper bound alone. `closedFactSet: [999_999]` passes it
+ * on every level in this graph, forever. `MIN_RUNG_VARIANTS` closed the half of the gap
+ * where a rung is honestly declared too small; this closes the other half, where the
+ * declaration is simply not the space. Writing a big enough number beside a rung of nine
+ * items satisfied both CG-10 and the new floor, and the whole point of the floor is that
+ * the nine-item rung is the defect the founder found by playing.
+ *
+ * Two families were pinned from the other side and the rest were not.
+ * `numberFacts.test.ts` and `timesTable.test.ts` enumerate their sets from the level's
+ * stated rules and require the generator to reach every member, which is a stronger
+ * claim than anything here; `families.test.ts` counts the eighty-one one-digit missing
+ * addends the same way. That leaves the four other families — place value, comparison,
+ * rounding, and both fraction families — declaring closed spaces that nothing
+ * measured.
+ *
+ * ## What this test does instead
+ *
+ * It draws seeds until the level stops producing new items, and requires the count it
+ * arrives at to equal the declaration **exactly**. Over-declaring fails, because the
+ * space never reaches the number. Under-declaring fails, because the space passes it.
+ * Neither direction is available, so a declaration is a measurement of the level's
+ * reachable space rather than an assertion about it.
+ *
+ * The budget is a multiple of the declared size, because that is what coupon collection
+ * scales with, floored so that a nine-item set still gets a fair number of draws. It is
+ * spent in full on every level and deliberately: an earlier draft stopped as soon as the
+ * declared count was reached, which made under-declaring free — a level claiming 100
+ * against a space of 180 reaches 100, stops, and reports agreement. That was caught by
+ * breaking the declaration and watching this file stay green, which is the only way that
+ * class of defect is ever caught.
+ *
+ * The observed cost, for scale: the widest level here needs about 15,000 draws to reach
+ * its 840 and the whole file runs in a couple of seconds.
+ *
+ * ## What it does not claim
+ *
+ * That the reachable set is the *mathematically correct* set. A generator that reached
+ * exactly 180 wrong items would pass here. That claim is made per family, by the
+ * enumerations above and by `families.test.ts`, which re-derives every generated
+ * answer from the prompt in exact rationals. What this file adds is the one claim none
+ * of those make and CG-10 depends on: the *size* is the declared size.
+ *
+ * It is also why `promotionBlockers.ts` uses the field only where the space is below
+ * CG-10's floor. Exhausting a few hundred items costs a few thousand seeds; exhausting
+ * the 2,280 same-numerator comparisons inside twentieths costs six figures, which is
+ * not a PR gate. A level above the floor does not need the exemption and does not get
+ * the declaration.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { allNodes } from "./graph.ts";
+import { MIN_RUNG_VARIANTS, SMALL_RUNG_LEVELS } from "./promotionBlockers.ts";
+import { familyById } from "../generators/registry.ts";
+import { fingerprintItem } from "../serialize.ts";
+// The gate's own number, imported rather than restated: the rule below is "closure is
+// only claimed where it buys the exemption", and a second copy of 975 in this file
+// would let the rule and the gate drift apart. `validate/` is tooling and a test may
+// reach it — see `boundary.test.ts`, which exempts both.
+import { VARIANT_SPACE_FLOOR } from "../validate/gates/generatorGates.ts";
+
+/** Seeds per declared item. Coupon collection over `S` items is `S·ln S` in the */
+/** uniform case and worse on a skewed draw, so forty is generous at these sizes. */
+const SEEDS_PER_DECLARED_ITEM = 40;
+
+/** A floor on the budget, so an eight-item set still gets a real number of draws. */
+const MIN_SEED_BUDGET = 4_000;
+
+type ClosedLevel = {
+  readonly label: string;
+  readonly declared: number;
+  readonly reached: number;
+  readonly seedsUsed: number;
+  readonly budget: number;
+};
+
+function exhaust(): ClosedLevel[] {
+  const out: ClosedLevel[] = [];
+
+  for (const node of allNodes) {
+    if (node.status === "deprecated") continue;
+    const declaredSets = node.generator.closedFactSet;
+    if (declaredSets === undefined) continue;
+
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined, `${node.id} binds unregistered family ${node.generator.family}`);
+
+    node.generator.params.forEach((params, level) => {
+      const declared = declaredSets[level] ?? null;
+      if (declared === null) return;
+
+      const validated = family.paramSchema.validate(params);
+      assert.ok(validated.ok, `${node.id} L${String(level)} params rejected`);
+      if (!validated.ok) return;
+
+      const budget = Math.max(MIN_SEED_BUDGET, declared * SEEDS_PER_DECLARED_ITEM);
+      const seen = new Set<string>();
+      let seed = 0;
+      // The whole budget, every time, and **not** stopping when the declared count is
+      // reached. Stopping there is what the first draft of this file did and it defanged
+      // exactly half the check: a level declaring 100 against a space of 180 hits 100,
+      // breaks, reports `reached === declared` and passes. Under-declaring was free — and
+      // under-declaring is the more dangerous direction, because CG-10's substituted check
+      // is `distinct ≤ declared`, so a level that claims fewer problems than it has is a
+      // level whose *sample* is being compared against a number that is not its space.
+      //
+      // The only early exit is on a count that has already exceeded the declaration, which
+      // is a failure with nothing further to learn from another 30,000 draws.
+      while (seed < budget) {
+        seed += 1;
+        seen.add(
+          fingerprintItem(
+            family.generate({
+              skillId: node.id,
+              level,
+              seed,
+              params: validated.value,
+              forms: node.generator.forms,
+            }),
+          ),
+        );
+        if (seen.size > declared) break;
+      }
+
+      out.push({
+        label: `${node.id} L${String(level)}`,
+        declared,
+        reached: seen.size,
+        seedsUsed: seed,
+        budget,
+      });
+    });
+  }
+
+  return out;
+}
+
+const CLOSED = exhaust();
+
+test("every closed level is reached exactly, and no further", () => {
+  // A vacuity guard first. Every assertion below passes on an empty list, and an empty
+  // list is what a refactor that stopped reading `closedFactSet` would produce.
+  assert.ok(
+    CLOSED.length >= 40,
+    `expected the graph's closed levels, found ${String(CLOSED.length)} — has closedFactSet stopped being read?`,
+  );
+
+  const lines: string[] = [];
+  for (const level of CLOSED) {
+    lines.push(
+      `#   ${level.label}: declared ${String(level.declared)}, reached ${String(level.reached)} ` +
+        `in ${String(level.seedsUsed)}/${String(level.budget)} seeds`,
+    );
+    assert.equal(
+      level.reached,
+      level.declared,
+      level.reached < level.declared
+        ? `${level.label} declares a closed space of ${String(level.declared)} and its generator reaches only ` +
+            `${String(level.reached)} in ${String(level.budget)} seeds — the declaration buys this level an ` +
+            `exemption from CG-10's floor that it has not earned`
+        : `${level.label} declares a closed space of ${String(level.declared)} and its generator reaches ` +
+            `${String(level.reached)} — the level has more problems in it than the row says it does, so CG-10 is ` +
+            `measuring against a number that is not the space`,
+    );
+  }
+  process.stdout.write(`# closed spaces, exhausted:\n${lines.join("\n")}\n`);
+});
+
+test("no closed level is thinner than MIN_RUNG_VARIANTS, beyond the one already exempt", () => {
+  // The third reading of the same bound. `ladder.test.ts` measures it over the active
+  // graph and `families.property.test.ts` over the whole graph, both from a 500-seed
+  // sample; this measures it over a level's **whole declared space**. A sample reports
+  // what it happened to draw, and a space reports what exists — and a rung whose entire
+  // universe is nineteen items cannot be made wider by sampling it harder.
+  //
+  // A **subset** of `SMALL_RUNG_LEVELS`, not an equality, and the list is imported rather
+  // than restated so the two files cannot drift. The relation is forced: nothing can draw
+  // more distinct items than exist, so a closed level under the floor is necessarily
+  // under it in a sample too. The reverse does not hold — an *open* level could draw
+  // thinly from a wide space — so requiring equality here would assert something this
+  // file does not measure.
+  const thin = CLOSED.filter((level) => level.declared < MIN_RUNG_VARIANTS);
+  const exempt = new Set(SMALL_RUNG_LEVELS);
+  const unregistered = thin
+    .filter((level) => !exempt.has(level.label))
+    .map((level) => `${level.label} (${String(level.declared)} problems in the world)`);
+
+  assert.deepEqual(
+    unregistered,
+    [] as readonly string[],
+    `these levels declare a closed space below MIN_RUNG_VARIANTS=${String(MIN_RUNG_VARIANTS)} and are not ` +
+      `exempt in promotionBlockers.ts: ${unregistered.join("; ")}`,
+  );
+  // A vacuity guard on the filter: if `declared` ever stopped being read, `thin` would be
+  // empty and the assertion above would pass on anything. It also catches the other
+  // direction — an exempt level that has been widened has to be struck off the list.
+  assert.equal(
+    thin.length,
+    SMALL_RUNG_LEVELS.length,
+    `${String(thin.length)} closed level(s) declare a space under the floor and ${String(SMALL_RUNG_LEVELS.length)} ` +
+      `are exempt`,
+  );
+});
+
+test("closure is only claimed where it buys the CG-10 exemption", () => {
+  // The rule `promotionBlockers.ts` states, enforced. A declaration above CG-10's floor
+  // is not an exemption from anything — the level clears the floor on its own — and it
+  // is what makes this file unaffordable: exhausting a 2,280-item space costs six
+  // figures of seeds. So the field is reserved for the case it was written for, and the
+  // reservation is checked rather than remembered.
+  const oversized = CLOSED.filter((level) => level.declared > VARIANT_SPACE_FLOOR).map(
+    (level) => `${level.label} declares ${String(level.declared)}`,
+  );
+  assert.deepEqual(
+    oversized,
+    [] as readonly string[],
+    `closedFactSet is for a space below CG-10's floor of ${String(VARIANT_SPACE_FLOOR)}; ` +
+      `these declare more, and each would either clear the floor unaided or cost this test six figures of ` +
+      `seeds to verify: ${oversized.join("; ")}`,
+  );
+});

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/alg.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/alg.ts
@@ -9,29 +9,35 @@
  * answer" is not making an arithmetic mistake, and waiting until grade 6 to find out
  * is how it survives to grade 6.
  *
- * ## One row is active now, and four are not
+ * ## Four rows are active now, and one is not
  *
- * The domain was entirely `draft` because the host could not state its questions:
- * every shape here puts the unknown *inside* the expression, and a two-operand string
- * cannot say that. `render/prompts.ts` grew `PromptBlank` and the host draws
- * `47 + □ = 68` — so `dw.alg.equality.missing-addend` is `active`, and it is the first
- * equality row this program has ever served a child.
+ * The domain was entirely `draft` because the host could not state its questions: every
+ * shape here puts the unknown *inside* the expression, and a two-operand string cannot
+ * say that. `render/prompts.ts` grew `PromptBlank` and the host draws `47 + □ = 68`,
+ * which made `missing-addend` the first equality row this program ever served a child.
+ * Three more follow it here, and by a **pack** fix rather than a curriculum one.
  *
- * The other four are still draft and **not** for that reason any more. Each has its
- * own blocker, measured rather than assumed, and each is named in
- * `promotionBlockers.ts` with what would clear it:
+ * `games/balance` was the one pack of twenty-eight that does not merely draw the
+ * statement — it builds a physical apparatus out of each side — and its tokeniser pushed
+ * a blank without applying the sign it had just read, so the box in `93 − □` was added to
+ * the pan instead of taken off it, and `□ × 15` was a product it could not collapse.
+ * COUNTERPOISE #724 rebuilt that tokeniser around signed terms with `product`, `quotient`
+ * and `countOf`, and its own `whyUnsolvable` now reports a levelling board for every
+ * statement this host can write. So `missing-subtrahend`, `unknown-minuend` and
+ * `missing-factor` are `active` — the measurement is in `promotionBlockers.ts`, because
+ * the curriculum imports nothing from `games/` and must not.
  *
- * - `missing-subtrahend` — `93 − □ = 47`. The pack drops the minus in front of a box.
- * - `missing-factor` — `□ × 15 = 165`. The pack's apparatus adds; a missing factor
- *   multiplies.
- * - `unknown-minuend` — `□ − 47 = 68`. Draws correctly; its own prerequisite is one
- *   of the two above, so CG-4 makes it unreachable until that one moves.
- * - `balance-meaning` — `8 + 4 = □ + 5`. Three numbers and an operator on each side of
- *   the relation, which `PromptBlank` does not reach: its template is the one shape in
- *   this family that declares `operator: "none"`, so it is named in
- *   `NON_BINARY_QUESTION_TEMPLATES` alongside the whole `ns` domain and the row is
- *   refused rather than mis-drawn. The row also requires the balance scale, which `Item`
- *   in `packs/sdk/src/protocol.ts` has no field to ask a pack for.
+ * `unknown-minuend` comes free with the other two: it drew correctly all along, and CG-4
+ * made it unreachable only because its one prerequisite was `missing-subtrahend`.
+ *
+ * **`balance-meaning` stays draft, and not for the pack's sake.** COUNTERPOISE builds a
+ * solvable board for `8 + 4 = □ + 5`; nothing can hand it that string. `drawStatement`
+ * writes `a OP b`, `□ OP a = b` and `a OP □ = b` and no fourth shape, which is why this
+ * row's template declares `operator: "none"` and is named in
+ * `NON_BINARY_QUESTION_TEMPLATES` alongside the whole `ns` domain. It carries a second
+ * blocker that would outlast the first: the row declares the balance scale `required`,
+ * and `Item` in `packs/sdk/src/protocol.ts` has no field to ask a pack for a
+ * representation.
  *
  * ## CG-10 at L0, which was never the right blocker for any row here
  *
@@ -231,7 +237,7 @@ const balanceMeaning: SkillNode = {
 const missingSubtrahend: SkillNode = {
   id: SKILL_MISSING_SUBTRAHEND,
   rev: 2,
-  status: "draft",
+  status: "active",
   title: locKey("dw.skill.alg.equality.missing-subtrahend.title"),
   learnerGoal: locKey("dw.skill.alg.equality.missing-subtrahend.goal"),
   domain: "alg",
@@ -273,7 +279,7 @@ const missingSubtrahend: SkillNode = {
 const unknownMinuend: SkillNode = {
   id: SKILL_UNKNOWN_MINUEND,
   rev: 2,
-  status: "draft",
+  status: "active",
   title: locKey("dw.skill.alg.equality.unknown-minuend.title"),
   learnerGoal: locKey("dw.skill.alg.equality.unknown-minuend.goal"),
   domain: "alg",
@@ -317,7 +323,7 @@ const unknownMinuend: SkillNode = {
 const missingFactor: SkillNode = {
   id: SKILL_MISSING_FACTOR,
   rev: 2,
-  status: "draft",
+  status: "active",
   title: locKey("dw.skill.alg.equality.missing-factor.title"),
   learnerGoal: locKey("dw.skill.alg.equality.missing-factor.goal"),
   domain: "alg",

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/alg.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/alg.ts
@@ -27,10 +27,13 @@
  * - `unknown-minuend` — `□ − 47 = 68`. Draws correctly; its own prerequisite is one
  *   of the two above, so CG-4 makes it unreachable until that one moves.
  * - `balance-meaning` — `8 + 4 = □ + 5`. Three numbers and an operator on each side of
- *   the relation, which `PromptBlank` does not reach; and the row requires the balance
- *   scale, which `Item` has no field to ask a pack for.
+ *   the relation, which `PromptBlank` does not reach: its template is the one shape in
+ *   this family that declares `operator: "none"`, so it is named in
+ *   `NON_BINARY_QUESTION_TEMPLATES` alongside the whole `ns` domain and the row is
+ *   refused rather than mis-drawn. The row also requires the balance scale, which `Item`
+ *   in `packs/sdk/src/protocol.ts` has no field to ask a pack for.
  *
- * ## CG-10 at L0, which was never the right blocker for this row
+ * ## CG-10 at L0, which was never the right blocker for any row here
  *
  * A one-digit missing addend has 9 × 9 = 81 items in the world and CG-10's floor is
  * 975, so every row here sat under it at L0. That is not a thin draw and no generator
@@ -40,6 +43,26 @@
  * its 7,400 and 19,800 measured problems clear the floor on their own — see
  * `GeneratorBinding.closedFactSet` for why an entry may now be `null`, and
  * `families.test.ts`, which enumerates the eighty-one and pins them.
+ *
+ * **The other four rows take the same route, because the same thing is true of them.**
+ * `sub-unknown` and `sub-unknown-minuend` are 81 apiece at `digits: 1`, `mul-unknown`
+ * is 64 — eight factors by eight, since a factor of one is a sentence whose box is the
+ * product written twice — and `both-sides` is 729, which is `Σ(a + b − 1)` over the
+ * eighty-one one-digit pairs. Every count is *exhausted* rather than argued, in
+ * `closedSpaces.test.ts`, and `CG10_BLOCKED_LEVELS` holds none of this domain as a
+ * result. What keeps a closed rung from being a *thin* one is `MIN_RUNG_VARIANTS`, the
+ * floor of 24 that `promotionBlockers.ts` defines and the sweep measures on every
+ * level in the graph.
+ *
+ * ## Four digits, on every row that can reach them
+ *
+ * `MAX_DIGITS` in this family is 4 and the rows stopped at 3, so the top of the domain
+ * was `☐ − 471 = 682` while the family could pose `☐ − 4,715 = 6,824`. The three
+ * additive rows and `balance-meaning` gain that rung on the end — appended, never
+ * inserted, because `missing-addend` is `active` and a rung inserted below an active
+ * row's levels renumbers every level above it. `missing-factor` does not gain one and
+ * cannot: its own validator refuses a missing factor past two digits, on the argument
+ * that `☐ × 471 = 227,151` is a long division wearing a box.
  *
  * `dw.alg.equality.balance-meaning` is the one row in this domain that requires a
  * representation: the balance scale, whose renderer **does** exist (PR-2.12). It is
@@ -110,7 +133,7 @@ export const SKILL_MISSING_FACTOR = skillId("dw.alg.equality.missing-factor");
  */
 const missingAddend: SkillNode = {
   id: SKILL_MISSING_ADDEND,
-  rev: 1,
+  rev: 2,
   status: "active",
   title: locKey("dw.skill.alg.equality.missing-addend.title"),
   learnerGoal: locKey("dw.skill.alg.equality.missing-addend.goal"),
@@ -123,19 +146,25 @@ const missingAddend: SkillNode = {
   classification: "procedural",
   fluencyTarget: { p50Ms: 10000 },
   prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_WITHIN_TEN }],
-  difficulty: { b: b(-40n), levels: [b(-105n), b(-75n), b(-45n)] },
+  difficulty: { b: b(-40n), levels: [b(-105n), b(-75n), b(-45n), b(-15n)] },
   misconceptions: [MIS_ADD_ALL_NUMBERS],
   representations: { required: [], optional: [REP_BALANCE_SCALE] },
   generator: {
     family: MISSING_OPERAND_FAMILY,
     familyRev: MISSING_OPERAND_FAMILY_REV,
-    params: [sentence("add-unknown", 1), sentence("add-unknown", 2), sentence("add-unknown", 3)],
+    params: [
+      sentence("add-unknown", 1),
+      sentence("add-unknown", 2),
+      sentence("add-unknown", 3),
+      sentence("add-unknown", 4),
+    ],
     forms: [ALG_FORM],
     minVariants: 40,
     // L0 is the eighty-one one-digit missing addends and there is no eighty-second;
-    // L1 and L2 measure 7,406 and 19,757 problems and take the ordinary floor. Both
-    // numbers are pinned by enumeration in `families.test.ts`.
-    closedFactSet: [81, null, null],
+    // L1 upward measure thousands of problems and take the ordinary floor. The 81 is
+    // pinned by enumeration in `families.test.ts` and exhausted again, alongside every
+    // other closed level in the graph, in `closedSpaces.test.ts`.
+    closedFactSet: [81, null, null, null],
     consumes: [CAP_DIFFERENCES_WITHIN_TEN],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
@@ -153,7 +182,7 @@ const missingAddend: SkillNode = {
  */
 const balanceMeaning: SkillNode = {
   id: SKILL_BALANCE_MEANING,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.alg.equality.balance-meaning.title"),
   learnerGoal: locKey("dw.skill.alg.equality.balance-meaning.goal"),
@@ -168,7 +197,7 @@ const balanceMeaning: SkillNode = {
   proficiency: { conceptual: 3, procedural: 1, strategic: 3, adaptive: 3 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_MISSING_ADDEND }],
-  difficulty: { b: b(-40n), levels: [b(-15n), b(15n), b(45n)] },
+  difficulty: { b: b(-40n), levels: [b(-15n), b(15n), b(45n), b(75n)] },
   misconceptions: [MIS_EQUALS_AS_OPERATOR, MIS_ADD_ALL_NUMBERS],
   // Required, not optional: on this row the scale is the skill. Its renderer
   // exists (PR-2.12), which is why the requirement can be stated at all.
@@ -176,9 +205,19 @@ const balanceMeaning: SkillNode = {
   generator: {
     family: MISSING_OPERAND_FAMILY,
     familyRev: MISSING_OPERAND_FAMILY_REV,
-    params: [sentence("both-sides", 1, true), sentence("both-sides", 2, true), sentence("both-sides", 3, true)],
+    params: [
+      sentence("both-sides", 1, true),
+      sentence("both-sides", 2, true),
+      sentence("both-sides", 3, true),
+      sentence("both-sides", 4, true),
+    ],
     forms: [ALG_FORM],
     minVariants: 40,
+    // `a + b = ☐ + d` over three one-digit numbers is 9³ = 729 sentences and there is
+    // no 730th, which is why L0 sat under CG-10's floor at 350 distinct in a 500-seed
+    // sample. Closed and exhausted, not widened: a two-digit `8 + 4 = ☐ + 5` is not
+    // the grade-1 item this row exists for.
+    closedFactSet: [729, null, null, null],
     consumes: [CAP_MISSING_ADDEND],
   },
   probes: [
@@ -191,7 +230,7 @@ const balanceMeaning: SkillNode = {
 
 const missingSubtrahend: SkillNode = {
   id: SKILL_MISSING_SUBTRAHEND,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.alg.equality.missing-subtrahend.title"),
   learnerGoal: locKey("dw.skill.alg.equality.missing-subtrahend.goal"),
@@ -206,14 +245,23 @@ const missingSubtrahend: SkillNode = {
   // addend, undone the other way. See the rule at the top of this file.
   fluencyTarget: { p50Ms: 10000 },
   prereqs: [{ kind: "requires", to: SKILL_MISSING_ADDEND }],
-  difficulty: { b: b(-40n), levels: [b(-70n), b(-40n), b(-10n)] },
+  difficulty: { b: b(-40n), levels: [b(-70n), b(-40n), b(-10n), b(20n)] },
   misconceptions: [MIS_ADD_ALL_NUMBERS],
   representations: { required: [], optional: [] },
   generator: {
     family: MISSING_OPERAND_FAMILY,
     familyRev: MISSING_OPERAND_FAMILY_REV,
-    params: [sentence("sub-unknown", 1), sentence("sub-unknown", 2), sentence("sub-unknown", 3)],
+    params: [
+      sentence("sub-unknown", 1),
+      sentence("sub-unknown", 2),
+      sentence("sub-unknown", 3),
+      sentence("sub-unknown", 4),
+    ],
     forms: [ALG_FORM],
+    // `a − ☐ = c` at `digits: 1` is eighty-one sentences: the subtrahend in the box
+    // and the difference are each drawn 1..9 and the minuend is their sum, so the
+    // number printed first may run to eighteen while the *space* is 9 × 9.
+    closedFactSet: [81, null, null, null],
     minVariants: 40,
     consumes: [CAP_MISSING_ADDEND],
   },
@@ -224,7 +272,7 @@ const missingSubtrahend: SkillNode = {
 
 const unknownMinuend: SkillNode = {
   id: SKILL_UNKNOWN_MINUEND,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.alg.equality.unknown-minuend.title"),
   learnerGoal: locKey("dw.skill.alg.equality.unknown-minuend.goal"),
@@ -239,7 +287,7 @@ const unknownMinuend: SkillNode = {
   // is the number being taken from, so recovering it is an addition.
   fluencyTarget: { p50Ms: 10000 },
   prereqs: [{ kind: "requires", to: SKILL_MISSING_SUBTRAHEND }],
-  difficulty: { b: b(-40n), levels: [b(-45n), b(-15n), b(15n)] },
+  difficulty: { b: b(-40n), levels: [b(-45n), b(-15n), b(15n), b(45n)] },
   // On `☐ − a = c`, adding every number on the card gives the correct answer, so
   // the add-all rule is not instantiated here and this row declares nothing. A
   // wrong answer is unclassified, which is the honest outcome.
@@ -252,8 +300,12 @@ const unknownMinuend: SkillNode = {
       sentence("sub-unknown-minuend", 1),
       sentence("sub-unknown-minuend", 2),
       sentence("sub-unknown-minuend", 3),
+      sentence("sub-unknown-minuend", 4),
     ],
     forms: [ALG_FORM],
+    // `☐ − a = c` at `digits: 1` is eighty-one sentences the same way: the subtrahend
+    // and the difference are drawn 1..9 and the minuend in the box is their sum.
+    closedFactSet: [81, null, null, null],
     minVariants: 40,
     consumes: [],
   },
@@ -264,7 +316,7 @@ const unknownMinuend: SkillNode = {
 
 const missingFactor: SkillNode = {
   id: SKILL_MISSING_FACTOR,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.alg.equality.missing-factor.title"),
   learnerGoal: locKey("dw.skill.alg.equality.missing-factor.goal"),
@@ -292,6 +344,10 @@ const missingFactor: SkillNode = {
     familyRev: MISSING_OPERAND_FAMILY_REV,
     params: [sentence("mul-unknown", 1), sentence("mul-unknown", 2)],
     forms: [ALG_FORM],
+    // Sixty-four: `☐ × a = c` at one digit draws both the factor and the answer from
+    // 2..9, since a factor of one is a sentence whose box is the product written
+    // twice. L1 measures over 8,000 and takes the ordinary floor.
+    closedFactSet: [64, null],
     minVariants: 40,
     consumes: [],
   },

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/frac.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/frac.ts
@@ -14,10 +14,53 @@
  * renderer can only write as `0.75`. The slot exists now; the renderer that draws
  * it does not. See `render/prompts.ts`.
  *
- * The renderer is not the whole of it here. Nine of these eleven rows also sit
- * under CG-10's variant-space floor on their easiest levels — small denominators
- * genuinely hold few problems — so promoting them is a generator question as well
- * as a `status` flip. `promotionBlockers.ts` names the levels.
+ * There are two renderer blockers, not one, and they are data rather than this
+ * paragraph. `FRACTION_ANSWER_BLOCKED_SKILLS` is all eleven rows: `answerText` in the
+ * app returns `null` for a fraction, and everything downstream reads `null` as `""`, so
+ * the card draws complete and marks every response wrong.
+ * `NON_BINARY_QUESTION_TEMPLATES` is six of them on top of that: the four
+ * `frac.equivalence` templates and the two comparisons declare `operator: "none"`, and
+ * `2/3 = ☐/12` is an equation between two written fractions rather than `a OP b`. Both
+ * clear in the same pack PR, which is the honest reading — a fraction nobody can enter
+ * is not an answer, and a fraction nobody can print is not a question.
+ *
+ * The renderers used to not be the whole of it: nine of these eleven rows also sat
+ * under CG-10's variant-space floor on their easiest levels. That half is settled
+ * below, and the answer turned out to be the same one nearly every time.
+ *
+ * ## Small denominators genuinely hold few problems, and that is not a thin draw
+ *
+ * CG-10's floor of 975 is derived from a model of generators that do not close — it
+ * asks whether a forty-item practice run would repeat itself and reads a repeat as
+ * evidence of a shallow draw. Fractions are where that model breaks hardest.
+ * "Add two fractions with the same denominator, denominators up to eight" is
+ * **eighty-eight problems in the world**; there is no eighty-ninth, and no amount of
+ * generator work produces one without changing which denominators the rung is about.
+ * The whole `build`/`simplify` task tops out at six hundred items even at the family's
+ * widest denominator, so no level of `build-equivalent` can ever clear the floor.
+ *
+ * So every level here whose space is genuinely below the floor declares
+ * `closedFactSet`, and every declared count is **exhausted** — drawn until the space
+ * stops yielding new items — in `closedSpaces.test.ts`, which is a measurement rather
+ * than an argument. Two levels took the other route, widening rather than closing,
+ * because their ceiling was arbitrary and not about the content.
+ *
+ * What stops a closed rung from being a *thin* one is `MIN_RUNG_VARIANTS`: the floor
+ * of 24 distinct items in `promotionBlockers.ts`, measured on every level in the
+ * graph. It is doing real work here — `equivalence("build", 12, 4, 1)` is 19 items and
+ * would have been the natural easiest rung for `build-equivalent`. It is not authored,
+ * because nineteen items is a rung that repeats itself twice in a forty-item run.
+ *
+ * ## The rungs
+ *
+ * Every row is written out from the smallest denominators the family admits to the
+ * largest, so a controller walking a child down this domain has somewhere to go: 51
+ * levels across eleven rows where there were 33. Nine of the eleven gain a rung
+ * **inserted below their top** rather than appended, which renumbers the levels above
+ * it. That is safe because every row here is `draft` and `shipped-ids.json` carries no
+ * release, so nothing keys off the old numbering — and the two probes that name a level
+ * were checked against it: `add-unlike`'s promotion probe at L2 still draws the rung it
+ * was written for, and `mixed-to-improper`'s moved to L3 to follow its.
  *
  * `mis.frac.whole-number-bias` is the root of two of the three mal-rules here, so a
  * child who believes a fraction is two whole numbers stacked up is repaired once
@@ -109,7 +152,7 @@ export const SKILL_MULTIPLY_FRACTION = skillId("dw.frac.arith.multiply-fractions
  */
 const compareSameNumerator: SkillNode = {
   id: SKILL_COMPARE_SAME_NUMERATOR,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.compare.same-numerator.title"),
   learnerGoal: locKey("dw.skill.frac.compare.same-numerator.goal"),
@@ -121,15 +164,42 @@ const compareSameNumerator: SkillNode = {
   proficiency: { conceptual: 3, procedural: 1, strategic: 2, adaptive: 2 },
   classification: "conceptual",
   prereqs: [],
-  difficulty: { b: b(-90n), levels: [b(-25n), b(-5n), b(25n)] },
+  difficulty: {
+    b: b(-90n),
+    levels: [b(-85n), b(-65n), b(-5n), b(25n), b(75n)],
+  },
   misconceptions: [MIS_LARGER_DENOMINATOR_LARGER_FRACTION],
   representations: { required: [], optional: [] },
   generator: {
     family: COMPARE_ORDER_FAMILY,
     familyRev: COMPARE_ORDER_FAMILY_REV,
-    params: [comparePair(20, true), comparePair(24, true, "lesser"), comparePair(30, true)],
+    // Halves through eighths first — `1/3` against `1/8`, the pair a child can hold in
+    // their head as two pictures — then twelfths, and on up to fortieths where the two
+    // denominators are close enough that only the rule decides it.
+    //
+    // **There is a gap between twelfths and twenty-fourths, and it is CG-10's, not the
+    // content's.** Ceilings of 16 and 20 are the natural rungs there and both are
+    // excluded: their true spaces are 1,120 and 2,280 problems, comfortably above the
+    // floor of 975, but the gate's `N²/2C` estimator reads them as ~700 and ~880 from
+    // a 500-seed sample. Same-numerator pairs are a strongly non-uniform draw — the
+    // numerator must sit below both denominators, so small numerators dominate — and
+    // that is the regime where the estimator undercounts. Declaring `closedFactSet` for
+    // them is not available either: a space above the floor is not "small in the world",
+    // and exhausting a 2,280-item space costs six figures of seeds in a PR gate. So the
+    // two rungs are left out and the finding is recorded here rather than worked
+    // around; whoever owns CG-10 has a measured case to size the estimator against.
+    params: [
+      comparePair(8, true),
+      comparePair(12, true),
+      comparePair(24, true, "lesser"),
+      comparePair(30, true),
+      comparePair(40, true),
+    ],
     forms: [COMPARE_FORM],
     minVariants: 80,
+    // 112 and 440: every same-numerator pair inside those denominator ceilings, and
+    // no more. From twenty-fourths up the space clears CG-10 on its own.
+    closedFactSet: [112, 440, null, null, null],
     consumes: [],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
@@ -139,7 +209,7 @@ const compareSameNumerator: SkillNode = {
 
 const compareUnlike: SkillNode = {
   id: SKILL_COMPARE_UNLIKE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.compare.unlike-fractions.title"),
   learnerGoal: locKey("dw.skill.frac.compare.unlike-fractions.goal"),
@@ -151,7 +221,7 @@ const compareUnlike: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_COMPARE_SAME_NUMERATOR }],
-  difficulty: { b: b(-90n), levels: [b(-40n), b(-10n), b(30n)] },
+  difficulty: { b: b(-90n), levels: [b(-50n), b(-40n), b(-10n), b(30n), b(110n)] },
   // These levels draw the two fractions independently, so a same-numerator pair
   // turns up by chance — measured at roughly one item in eight — and the
   // whole-number-bias rule fires on it. A diagnosis the items emit and the node
@@ -162,9 +232,18 @@ const compareUnlike: SkillNode = {
   generator: {
     family: COMPARE_ORDER_FAMILY,
     familyRev: COMPARE_ORDER_FAMILY_REV,
-    params: [comparePair(10, false), comparePair(16, false, "lesser"), comparePair(24, false)],
+    params: [
+      comparePair(8, false),
+      comparePair(10, false),
+      comparePair(16, false, "lesser"),
+      comparePair(24, false),
+      comparePair(40, false),
+    ],
     forms: [COMPARE_FORM],
     minVariants: 80,
+    // 736 pairs inside eighths, which is all of them. Every level above draws from
+    // thousands.
+    closedFactSet: [736, null, null, null, null],
     consumes: [CAP_FRAC_COMPARE],
   },
   probes: [],
@@ -174,7 +253,7 @@ const compareUnlike: SkillNode = {
 
 const buildEquivalent: SkillNode = {
   id: SKILL_BUILD_EQUIVALENT,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.equivalence.build-equivalent.title"),
   learnerGoal: locKey("dw.skill.frac.equivalence.build-equivalent.goal"),
@@ -186,15 +265,34 @@ const buildEquivalent: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
   classification: "conceptual",
   prereqs: [],
-  difficulty: { b: b(-120n), levels: [b(150n), b(290n), b(420n)] },
+  difficulty: { b: b(-120n), levels: [b(50n), b(150n), b(290n), b(420n)] },
   misconceptions: [],
   representations: { required: [], optional: [] },
   generator: {
     family: FRAC_EQUIVALENCE_FAMILY,
     familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
-    params: [equivalence("build", 24, 6, 1), equivalence("build", 40, 8, 1), equivalence("build", 60, 9, 1)],
+    // `1/2 = ☐/8` before `3/5 = ☐/45`. The prepended rung is the smallest this task
+    // admits above `MIN_RUNG_VARIANTS`: at a denominator ceiling of 16 and a factor of
+    // 4 there are 35 problems, and the next step down — ceiling 12, factor 4 — is 19,
+    // which is a rung a child meets twice in a practice run and is therefore not
+    // authored.
+    params: [
+      equivalence("build", 16, 4, 1),
+      equivalence("build", 24, 6, 1),
+      equivalence("build", 40, 8, 1),
+      equivalence("build", 60, 9, 1),
+    ],
     forms: [EQUIV_FORM],
-    minVariants: 40,
+    // Thirty, not forty: L0's whole space is 35 and CG-7 fails a row that claims more
+    // variants than its own closed level holds.
+    minVariants: 30,
+    // Every level of this task is closed and below CG-10's floor, and that is a fact
+    // about the mathematics rather than about this generator: a built equivalent is a
+    // reduced fraction times a factor, so the space is bounded by the denominator
+    // ceiling the *child reads*, and at the family's widest — sixtieths, factors to
+    // nine — it is six hundred problems. Widening is not available; the numbers below
+    // are exhausted in `closedSpaces.test.ts`.
+    closedFactSet: [35, 87, 265, 600],
     consumes: [],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
@@ -204,7 +302,7 @@ const buildEquivalent: SkillNode = {
 
 const simplify: SkillNode = {
   id: SKILL_SIMPLIFY,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.equivalence.lowest-terms.title"),
   learnerGoal: locKey("dw.skill.frac.equivalence.lowest-terms.goal"),
@@ -216,19 +314,23 @@ const simplify: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 1 },
   classification: "procedural",
   prereqs: [{ kind: "requires", to: SKILL_BUILD_EQUIVALENT }],
-  difficulty: { b: b(-120n), levels: [b(90n), b(230n), b(420n)] },
+  difficulty: { b: b(-120n), levels: [b(50n), b(90n), b(230n), b(420n)] },
   misconceptions: [],
   representations: { required: [], optional: [] },
   generator: {
     family: FRAC_EQUIVALENCE_FAMILY,
     familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
     params: [
+      equivalence("simplify", 16, 4, 1),
       equivalence("simplify", 24, 4, 1),
       equivalence("simplify", 40, 6, 1),
       equivalence("simplify", 60, 9, 1),
     ],
     forms: [EQUIV_FORM],
-    minVariants: 40,
+    minVariants: 30,
+    // Closed for the same reason `build-equivalent` is, and to the same ceiling: the
+    // two tasks are one space read in two directions.
+    closedFactSet: [35, 77, 247, 600],
     consumes: [CAP_FRAC_EQUIVALENT],
   },
   probes: [],
@@ -238,7 +340,7 @@ const simplify: SkillNode = {
 
 const improperToMixed: SkillNode = {
   id: SKILL_IMPROPER_TO_MIXED,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.equivalence.improper-to-mixed.title"),
   learnerGoal: locKey("dw.skill.frac.equivalence.improper-to-mixed.goal"),
@@ -253,19 +355,30 @@ const improperToMixed: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
   classification: "conceptual",
   prereqs: [],
-  difficulty: { b: b(-100n), levels: [b(-40n), b(-20n), b(20n)] },
+  difficulty: {
+    b: b(-100n),
+    levels: [b(-40n), b(-20n), b(0n), b(20n), b(70n), b(120n)],
+  },
   misconceptions: [],
   representations: { required: [], optional: [] },
   generator: {
     family: FRAC_EQUIVALENCE_FAMILY,
     familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+    // `9/4` as `2 1/4`, up to fortieths and a whole part of twenty. Sixtieths are not
+    // authored: `1,187/60` is a division problem wearing a fraction, and the row that
+    // owns division of that size is `dw.div.whole.quotient-and-remainder`.
     params: [
       equivalence("to-mixed", 8, 2, 4),
       equivalence("to-mixed", 12, 2, 9),
+      equivalence("to-mixed", 16, 2, 12),
       equivalence("to-mixed", 20, 2, 15),
+      equivalence("to-mixed", 30, 2, 18),
+      equivalence("to-mixed", 40, 2, 20),
     ],
     forms: [EQUIV_FORM],
     minVariants: 60,
+    // 112 and 594 are whole spaces; from sixteenths up the ordinary floor is cleared.
+    closedFactSet: [112, 594, null, null, null, null],
     consumes: [],
   },
   probes: [],
@@ -275,7 +388,7 @@ const improperToMixed: SkillNode = {
 
 const mixedToImproper: SkillNode = {
   id: SKILL_MIXED_TO_IMPROPER,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.equivalence.mixed-to-improper.title"),
   learnerGoal: locKey("dw.skill.frac.equivalence.mixed-to-improper.goal"),
@@ -287,7 +400,10 @@ const mixedToImproper: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_IMPROPER_TO_MIXED }],
-  difficulty: { b: b(-100n), levels: [b(-5n), b(15n), b(55n)] },
+  difficulty: {
+    b: b(-100n),
+    levels: [b(-5n), b(15n), b(35n), b(55n), b(105n), b(155n)],
+  },
   misconceptions: [MIS_MIXED_NUMBER_CONCATENATION],
   representations: { required: [], optional: [] },
   generator: {
@@ -296,20 +412,26 @@ const mixedToImproper: SkillNode = {
     params: [
       equivalence("to-improper", 8, 2, 4),
       equivalence("to-improper", 12, 2, 9),
+      equivalence("to-improper", 16, 2, 12),
       equivalence("to-improper", 20, 2, 15),
+      equivalence("to-improper", 30, 2, 18),
+      equivalence("to-improper", 40, 2, 20),
     ],
     forms: [EQUIV_FORM],
     minVariants: 60,
+    closedFactSet: [112, 513, null, null, null, null],
     consumes: [CAP_FRAC_MIXED],
   },
-  probes: [{ level: 2, seed: 7, purpose: "promotion" }],
+  // Level 3 is `equivalence("to-improper", 20, 2, 15)`, which is the rung this probe
+  // was written against; it moved from index 2 when the sixteenths rung was inserted.
+  probes: [{ level: 3, seed: 7, purpose: "promotion" }],
   provides: [],
   standards: { ccss: ["4.NF.B.3.B"] },
 };
 
 const addLike: SkillNode = {
   id: SKILL_ADD_LIKE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.arith.add-like-denominators.title"),
   learnerGoal: locKey("dw.skill.frac.arith.add-like-denominators.goal"),
@@ -321,15 +443,33 @@ const addLike: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
   classification: "conceptual",
   prereqs: [],
-  difficulty: { b: b(-80n), levels: [b(-40n), b(0n), b(65n)] },
+  difficulty: { b: b(-80n), levels: [b(-40n), b(-20n), b(20n), b(65n)] },
   misconceptions: [MIS_ADD_NUMERATORS_AND_DENOMINATORS],
   representations: { required: [], optional: [] },
   generator: {
     family: FRAC_ARITH_FAMILY,
     familyRev: FRAC_ARITH_FAMILY_REV,
-    params: [addSub("add", "like", 8, false), addSub("add", "like", 16, false), addSub("add", "like", 24, true)],
+    // Eighths, twelfths, twentieths, then twenty-fourths with the sum reduced. The
+    // twelfths rung is inserted rather than appended: the step from eighths to the top
+    // was the widest in the row and this is the middle of it.
+    //
+    // Twentieths and not sixteenths at L2, and by measurement: a ceiling of 16 holds
+    // 1,008 problems, which clears CG-10's floor of 975 in truth and reads as ~780
+    // through the gate's estimator, so the rung would have stayed blocked for a
+    // sampling artifact. A ceiling of 20 holds 2,100 and reads as ~1,180. This is the
+    // widening the blocker list asks for — a level that could be widened and simply
+    // had not been.
+    params: [
+      addSub("add", "like", 8, false),
+      addSub("add", "like", 12, false),
+      addSub("add", "like", 20, false),
+      addSub("add", "like", 24, true),
+    ],
     forms: [ARITH_FORM],
     minVariants: 40,
+    // 88 and 380 whole spaces: every pair of numerators over every denominator inside
+    // the ceiling. The two rungs above draw from thousands.
+    closedFactSet: [88, 380, null, null],
     consumes: [],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
@@ -339,7 +479,7 @@ const addLike: SkillNode = {
 
 const addUnlike: SkillNode = {
   id: SKILL_ADD_UNLIKE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.arith.add-unlike-denominators.title"),
   learnerGoal: locKey("dw.skill.frac.arith.add-unlike-denominators.goal"),
@@ -354,7 +494,7 @@ const addUnlike: SkillNode = {
     { kind: "requires", to: SKILL_ADD_LIKE },
     { kind: "requires", to: SKILL_BUILD_EQUIVALENT },
   ],
-  difficulty: { b: b(-80n), levels: [b(10n), b(35n), b(100n)] },
+  difficulty: { b: b(-80n), levels: [b(10n), b(35n), b(100n), b(120n)] },
   misconceptions: [MIS_ADD_NUMERATORS_AND_DENOMINATORS],
   representations: { required: [], optional: [] },
   generator: {
@@ -364,9 +504,13 @@ const addUnlike: SkillNode = {
       addSub("add", "multiple", 12, false),
       addSub("add", "unlike", 12, false),
       addSub("add", "unlike", 20, true),
+      addSub("add", "unlike", 24, true),
     ],
     forms: [ARITH_FORM],
     minVariants: 40,
+    // 184: every pair of denominators up to twelve where one divides the other, with
+    // both numerators. The unlike levels draw from thousands.
+    closedFactSet: [184, null, null, null],
     consumes: [CAP_FRAC_LIKE_SUM, CAP_FRAC_EQUIVALENT],
   },
   probes: [{ level: 2, seed: 11, purpose: "promotion" }],
@@ -376,7 +520,7 @@ const addUnlike: SkillNode = {
 
 const subtractFractions: SkillNode = {
   id: SKILL_SUBTRACT,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.arith.subtract-fractions.title"),
   learnerGoal: locKey("dw.skill.frac.arith.subtract-fractions.goal"),
@@ -388,7 +532,7 @@ const subtractFractions: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
   classification: "procedural",
   prereqs: [{ kind: "requires", to: SKILL_ADD_LIKE }],
-  difficulty: { b: b(-80n), levels: [b(-20n), b(30n), b(100n)] },
+  difficulty: { b: b(-80n), levels: [b(-20n), b(0n), b(30n), b(100n), b(120n)] },
   // The documented whole-number-bias rule is stated for addition. Its subtraction
   // analogue divides by zero on like denominators and cannot be shown to diverge on
   // the rest, so it is not shipped: never invent a bug.
@@ -399,11 +543,18 @@ const subtractFractions: SkillNode = {
     familyRev: FRAC_ARITH_FAMILY_REV,
     params: [
       addSub("sub", "like", 12, false),
+      addSub("sub", "like", 16, false),
       addSub("sub", "multiple", 16, false),
       addSub("sub", "unlike", 20, true),
+      addSub("sub", "unlike", 24, true),
     ],
     forms: [ARITH_FORM],
     minVariants: 40,
+    // 220, 560 and 518 whole spaces. The counts are not monotone across the levels and
+    // do not have to be — the *difficulty* is, and a difference over denominators one
+    // of which divides the other is harder work than a difference over sixteenths
+    // however many of each there happen to be.
+    closedFactSet: [220, 560, 518, null, null],
     consumes: [CAP_FRAC_LIKE_SUM],
   },
   probes: [],
@@ -413,7 +564,7 @@ const subtractFractions: SkillNode = {
 
 const multiplyByWhole: SkillNode = {
   id: SKILL_MULTIPLY_WHOLE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.arith.multiply-by-a-whole.title"),
   learnerGoal: locKey("dw.skill.frac.arith.multiply-by-a-whole.goal"),
@@ -425,15 +576,23 @@ const multiplyByWhole: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_ADD_LIKE }],
-  difficulty: { b: b(-60n), levels: [b(-45n), b(-15n), b(50n)] },
+  difficulty: { b: b(-60n), levels: [b(-45n), b(-35n), b(-15n), b(50n)] },
   misconceptions: [MIS_SCALE_BOTH_PARTS],
   representations: { required: [], optional: [] },
   generator: {
     family: FRAC_ARITH_FAMILY,
     familyRev: FRAC_ARITH_FAMILY_REV,
-    params: [multiply(true, 10, 6, false), multiply(true, 16, 9, false), multiply(true, 24, 12, true)],
+    params: [
+      multiply(true, 10, 6, false),
+      multiply(true, 12, 6, false),
+      multiply(true, 16, 9, false),
+      multiply(true, 24, 12, true),
+    ],
     forms: [ARITH_FORM],
     minVariants: 40,
+    // 184, 278 and 840 whole spaces: a fraction inside the ceiling times a whole
+    // number that is never one.
+    closedFactSet: [184, 278, 840, null],
     consumes: [CAP_FRAC_LIKE_SUM],
   },
   probes: [],
@@ -443,7 +602,7 @@ const multiplyByWhole: SkillNode = {
 
 const multiplyFractions: SkillNode = {
   id: SKILL_MULTIPLY_FRACTION,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.frac.arith.multiply-fractions.title"),
   learnerGoal: locKey("dw.skill.frac.arith.multiply-fractions.goal"),
@@ -455,15 +614,23 @@ const multiplyFractions: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
   classification: "procedural",
   prereqs: [{ kind: "requires", to: SKILL_MULTIPLY_WHOLE }],
-  difficulty: { b: b(-60n), levels: [b(-20n), b(0n), b(65n)] },
+  difficulty: { b: b(-60n), levels: [b(-20n), b(0n), b(65n), b(85n)] },
   misconceptions: [],
   representations: { required: [], optional: [] },
   generator: {
     family: FRAC_ARITH_FAMILY,
     familyRev: FRAC_ARITH_FAMILY_REV,
-    params: [multiply(false, 8, 2, false), multiply(false, 12, 2, false), multiply(false, 20, 2, true)],
+    params: [
+      multiply(false, 8, 2, false),
+      multiply(false, 12, 2, false),
+      multiply(false, 20, 2, true),
+      multiply(false, 24, 2, true),
+    ],
     forms: [ARITH_FORM],
     minVariants: 40,
+    // 784 pairs of proper fractions inside eighths. Above that the product space runs
+    // into the thousands and takes the ordinary floor.
+    closedFactSet: [784, null, null, null],
     consumes: [],
   },
   probes: [],

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/ns.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/ns.ts
@@ -3,19 +3,55 @@
  *
  * **Every row here is `draft`, and the reason is not the generator.** Each of these
  * nodes binds a family that generates, checks and diagnoses correctly over hundreds
- * of thousands of seeds. What does not exist is a renderer for the *question*: the
- * app reads an item out of `prompt.slots` by matching `prompt.key` against the two
- * column-op templates and draws nothing for any other, so promoting these rows
- * would put an answer keypad on a child's screen with no problem above it. That is
- * the failure gate CG-8 exists for, and `render/prompts.ts` now makes it mechanical
- * rather than a thing somebody has to notice.
+ * of thousands of seeds. What does not exist is a renderer for the *question*, and the
+ * shape of that gap is now data rather than this paragraph:
+ * `NON_BINARY_QUESTION_TEMPLATES` in `promotionBlockers.ts`. Every template this domain
+ * emits declares `operator: "none"`, and the only thing that serves an item composes a
+ * question out of two operands and a glyph, so it refuses all six rows out loud. "In
+ * 4,193, what is the digit in the hundreds place worth?" is a numeral and a *place
+ * name*; "which is greater, 432 or 737?" is two numbers and a *relation*. Neither is
+ * `a OP b`, and promoting either would serve a rung that generates a question, declines
+ * to draw it, and asks the child nothing.
  *
- * `PR-2.13` is not the only blocker on every row, and the difference matters to
- * whoever plans the promotion. `dw.ns.place.digit-in-place` L0 and
- * `dw.ns.round.whole-numbers` L0 are also under CG-10's variant-space floor and
- * need a wider draw or a reconciliation with the floor before they can go active;
- * the rest of this domain flips on `status` alone. `promotionBlockers.ts` holds the
- * whole list and the property sweep keeps it honest.
+ * That blocker used to have company: `dw.ns.place.digit-in-place` L0 and
+ * `dw.ns.round.whole-numbers` L0 also sat under CG-10's variant-space floor. Both are
+ * resolved below, by the two instruments this package already had — one widened, one
+ * declared closed and exhausted — so the domain now waits on the renderer alone.
+ *
+ * ## The rungs, and why there are more of them than there were
+ *
+ * Every row here used to hold three or four levels, and every one of them started
+ * partway up. `compare.whole-numbers` — a row whose `gradeBand.earliest` is 1 — began
+ * at *three-digit* comparison; `round.whole-numbers` began at three digits too. The
+ * shipped ladder therefore had no floor a six-year-old could stand on and no ceiling
+ * near the millions the standards it cites actually name, so an adaptive controller
+ * walking a struggling child down this domain ran out of rungs while the questions
+ * were still too hard.
+ *
+ * So the level tables are written out end to end: down to the smallest question each
+ * family can pose, and up to the seven digits `MAX_WHOLE_DIGITS` allows. Two rules
+ * govern the result and both are checked rather than asserted:
+ *
+ * - **A rung is never only its easiest case.** `MIN_RUNG_VARIANTS` in
+ *   `promotionBlockers.ts` is the floor and the sweep measures every level against
+ *   it. The bottom rung of `round.whole-numbers` is "round a two-digit number to the
+ *   nearest ten", which is seventy-two problems — few, and *all* of them, which is
+ *   the distinction `closedFactSet` exists to draw.
+ * - **A level table only ever goes up.** CG-9 checks that on the active graph and
+ *   `families.property.test.ts` now checks it on the whole of it, because a rung that
+ *   is easier than the one below it hands a climbing child a *shorter* answering
+ *   window for *harder* work in every pack that prices its clock off difficulty.
+ *
+ * Two rows have a level **prepended** rather than appended, which renumbers the
+ * levels above it. That is safe here and only here: both are `draft` and nothing has
+ * shipped (`shipped-ids.json` carries no release), so no mastery record keys off the
+ * old numbering. On an `active` row a new rung goes on the end.
+ *
+ * Four `gradeBand` labels move with the tables — three rows reach `latest: 5` now that
+ * they reach seven digits, and `round.whole-numbers` reaches `earliest: 2` now that its
+ * easiest rung is `47` to the nearest ten. A band is a placement hint for a parent and a
+ * seed for onboarding; the scheduler reads prerequisites and nothing reads a band, so
+ * each of those is a one-line relabel with no effect on ids, difficulty or ordering.
  *
  * Ids are final. A draft id is as immutable as an active one — it is a mastery key
  * the moment it ships, and the promotion PR must not be free to rename it.
@@ -71,6 +107,10 @@ function decimalPair(digits: number, decimalPlaces: number, placeGap: number): C
   return { numberType: "decimal", task: "greater", digits, decimalPlaces, placeGap };
 }
 
+function decimalPairLesser(digits: number, decimalPlaces: number, placeGap: number): CompareOrderParams {
+  return { numberType: "decimal", task: "lesser", digits, decimalPlaces, placeGap };
+}
+
 function round(digits: number, minPlace: number, maxPlace: number, ties: boolean): RoundEstimateParams {
   return { digits, minPlace, maxPlace, ties };
 }
@@ -84,20 +124,27 @@ export const SKILL_ROUND_WHOLE = skillId("dw.ns.round.whole-numbers");
 
 const digitInPlace: SkillNode = {
   id: SKILL_DIGIT_IN_PLACE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.ns.place.digit-in-place.title"),
   learnerGoal: locKey("dw.skill.ns.place.digit-in-place.goal"),
   domain: "ns",
   cluster: "place",
   bigIdeas: [locKey("dw.idea.place-value.position-carries-value")],
-  gradeBand: { earliest: 1, nominal: 2, latest: 3 },
+  // `latest` reaches 5 because the level table does: the top rung reads a place in a
+  // seven-digit numeral, which is where 4.NBT.A.2 and the grade-5 place-value work
+  // sit. A grade band is a placement hint and nothing else reads it — the scheduler
+  // reads prerequisites — so widening it is a label change with no other effect.
+  gradeBand: { earliest: 1, nominal: 2, latest: 5 },
   strandRole: "spine",
   proficiency: { conceptual: 2, procedural: 2, strategic: 0, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 8000 },
   prereqs: [],
-  difficulty: { b: b(-70n), levels: [b(-95n), b(-55n), b(-15n)] },
+  difficulty: {
+    b: b(-70n),
+    levels: [b(-95n), b(-55n), b(-15n), b(25n), b(75n), b(125n)],
+  },
   // Reading a digit off the page has no arithmetic in it to get wrong, so it has
   // no mal-rule. The rule this family does carry is defined on the two tasks that
   // ask for a quantity.
@@ -106,9 +153,29 @@ const digitInPlace: SkillNode = {
   generator: {
     family: PLACE_VALUE_FAMILY,
     familyRev: PLACE_VALUE_FAMILY_REV,
-    params: [place("digit-in-place", 2, 0, 1), place("digit-in-place", 3, 0, 2), place("digit-in-place", 4, 0, 3)],
+    // Two digits through seven: tens and units, then a place anywhere in a numeral up
+    // to the millions. The four narrowest rungs include the units column (`minPlace:
+    // 0`); the six-digit rung starts at tens and the seven-digit one at hundreds,
+    // because "which digit is in the ones place of 4,193,608" is a question about the
+    // last character on the card rather than about place value, and a level whose range
+    // still admits it would keep drawing it.
+    params: [
+      place("digit-in-place", 2, 0, 1),
+      place("digit-in-place", 3, 0, 2),
+      place("digit-in-place", 4, 0, 3),
+      place("digit-in-place", 5, 0, 4),
+      place("digit-in-place", 6, 1, 5),
+      place("digit-in-place", 7, 2, 6),
+    ],
     forms: [PLACE_FORM],
     minVariants: 60,
+    // L0 is every two-digit numeral asked about either of its two places: 90 × 2 =
+    // 180, and there is no 181st. It cannot be widened without making the easiest
+    // place-value question in the program a three-digit one, which is the case
+    // `closedFactSet` is for — and 180 problems is a rung a child can practise
+    // rather than a rung that repeats itself twice a minute. Every level above it
+    // clears CG-10's floor on its own; `closedSpaces.test.ts` exhausts the 180.
+    closedFactSet: [180, null, null, null, null, null],
     consumes: [],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
@@ -118,25 +185,35 @@ const digitInPlace: SkillNode = {
 
 const digitValue: SkillNode = {
   id: SKILL_DIGIT_VALUE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.ns.place.digit-value.title"),
   learnerGoal: locKey("dw.skill.ns.place.digit-value.goal"),
   domain: "ns",
   cluster: "place",
   bigIdeas: [locKey("dw.idea.place-value.position-carries-value")],
-  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  gradeBand: { earliest: 2, nominal: 3, latest: 5 },
   strandRole: "spine",
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_DIGIT_IN_PLACE }],
-  difficulty: { b: b(-40n), levels: [b(20n), b(60n), b(110n)] },
+  difficulty: { b: b(-40n), levels: [b(20n), b(60n), b(110n), b(150n), b(200n)] },
   misconceptions: [MIS_DIGIT_FOR_VALUE],
   representations: { required: [], optional: [] },
   generator: {
     family: PLACE_VALUE_FAMILY,
     familyRev: PLACE_VALUE_FAMILY_REV,
-    params: [place("digit-value", 3, 1, 2), place("digit-value", 4, 1, 3), place("digit-value", 5, 2, 4)],
+    // "What is the digit in the hundreds place worth" through to the millions. The
+    // units column is never asked: in units the answer is the digit, which is the
+    // question `digit-in-place` already asks and the one item the digit-for-value
+    // mal-rule would get right.
+    params: [
+      place("digit-value", 3, 1, 2),
+      place("digit-value", 4, 1, 3),
+      place("digit-value", 5, 2, 4),
+      place("digit-value", 6, 2, 5),
+      place("digit-value", 7, 3, 6),
+    ],
     forms: [PLACE_FORM],
     minVariants: 60,
     consumes: [CAP_READ_PLACE],
@@ -148,7 +225,7 @@ const digitValue: SkillNode = {
 
 const regroupedCount: SkillNode = {
   id: SKILL_REGROUPED_COUNT,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.ns.place.regrouped-count.title"),
   learnerGoal: locKey("dw.skill.ns.place.regrouped-count.goal"),
@@ -163,16 +240,20 @@ const regroupedCount: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_DIGIT_VALUE }],
-  difficulty: { b: b(-40n), levels: [b(95n), b(135n), b(185n)] },
+  difficulty: { b: b(-40n), levels: [b(95n), b(135n), b(185n), b(225n)] },
   misconceptions: [MIS_DIGIT_FOR_VALUE],
   representations: { required: [], optional: [] },
   generator: {
     family: PLACE_VALUE_FAMILY,
     familyRev: PLACE_VALUE_FAMILY_REV,
+    // "How many hundreds are in 4,193 altogether" — 41, not 1. The family's own
+    // validator keeps two digits above the place it counts, so a seven-digit numeral
+    // is counted in hundreds through hundred-thousands and no higher.
     params: [
       place("total-in-place", 4, 1, 2),
       place("total-in-place", 5, 1, 3),
       place("total-in-place", 6, 2, 4),
+      place("total-in-place", 7, 2, 5),
     ],
     forms: [PLACE_FORM],
     minVariants: 60,
@@ -185,20 +266,23 @@ const regroupedCount: SkillNode = {
 
 const compareWhole: SkillNode = {
   id: SKILL_COMPARE_WHOLE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.ns.compare.whole-numbers.title"),
   learnerGoal: locKey("dw.skill.ns.compare.whole-numbers.goal"),
   domain: "ns",
   cluster: "compare",
   bigIdeas: [locKey("dw.idea.magnitude.numbers-have-order")],
-  gradeBand: { earliest: 1, nominal: 2, latest: 4 },
+  gradeBand: { earliest: 1, nominal: 2, latest: 5 },
   strandRole: "spine",
   proficiency: { conceptual: 2, procedural: 2, strategic: 1, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 9000 },
   prereqs: [{ kind: "requires", to: SKILL_DIGIT_IN_PLACE }],
-  difficulty: { b: b(-60n), levels: [b(-30n), b(5n), b(70n), b(135n)] },
+  difficulty: {
+    b: b(-60n),
+    levels: [b(-60n), b(-30n), b(5n), b(70n), b(135n), b(200n), b(265n)],
+  },
   // The whole-number comparisons this level table poses are between two numbers of
   // the same written width, so "the longer number is bigger" is not a rule that can
   // fire on them — and where it could, it would be right.
@@ -207,7 +291,23 @@ const compareWhole: SkillNode = {
   generator: {
     family: COMPARE_ORDER_FAMILY,
     familyRev: COMPARE_ORDER_FAMILY_REV,
-    params: [whole(3, 0), whole(3, 1, "lesser"), whole(4, 2), whole(5, 3, "lesser")],
+    // A rung is **prepended** here: `whole(2, 0)` — "which is more, 47 or 82?" — is
+    // the smallest comparison this family can pose, and it is where a row whose
+    // `gradeBand.earliest` is 1 has to start. It began at three digits, which is why
+    // an adaptive controller had nowhere left to walk a struggling child down to. The
+    // renumbering is safe because the row is draft and nothing has shipped; the entry
+    // probe at L0 now lands on the two-digit rung, which is what an entry probe is
+    // for. From there: three digits, three digits sharing a leading digit, and on up
+    // to seven sharing five, where every comparison is decided in the tens.
+    params: [
+      whole(2, 0),
+      whole(3, 0),
+      whole(3, 1, "lesser"),
+      whole(4, 2),
+      whole(5, 3, "lesser"),
+      whole(6, 4),
+      whole(7, 5, "lesser"),
+    ],
     forms: [COMPARE_FORM],
     minVariants: 80,
     consumes: [CAP_READ_PLACE],
@@ -228,7 +328,7 @@ const compareWhole: SkillNode = {
  */
 const compareDecimal: SkillNode = {
   id: SKILL_COMPARE_DECIMAL,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.ns.compare.decimals.title"),
   learnerGoal: locKey("dw.skill.ns.compare.decimals.goal"),
@@ -243,13 +343,17 @@ const compareDecimal: SkillNode = {
   proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
   classification: "conceptual",
   prereqs: [{ kind: "requires", to: SKILL_COMPARE_WHOLE }],
-  difficulty: { b: b(-40n), levels: [b(-30n), b(20n), b(50n)] },
+  difficulty: { b: b(-40n), levels: [b(-30n), b(20n), b(50n), b(100n)] },
   misconceptions: [MIS_LONGER_IS_BIGGER],
   representations: { required: [], optional: [] },
   generator: {
     family: COMPARE_ORDER_FAMILY,
     familyRev: COMPARE_ORDER_FAMILY_REV,
-    params: [decimalPair(1, 1, 1), decimalPair(2, 1, 2), decimalPair(3, 2, 1)],
+    // The top rung asks for the *lesser* of two numbers written to two and four
+    // places, which is where the longer-is-bigger rule is most tempting and where
+    // asking for the smaller one stops a child from answering "the long one" by
+    // reflex on every card.
+    params: [decimalPair(1, 1, 1), decimalPair(2, 1, 2), decimalPair(3, 2, 1), decimalPairLesser(4, 2, 2)],
     forms: [COMPARE_FORM],
     minVariants: 80,
     consumes: [CAP_COMPARE_WHOLE],
@@ -261,14 +365,14 @@ const compareDecimal: SkillNode = {
 
 const roundWhole: SkillNode = {
   id: SKILL_ROUND_WHOLE,
-  rev: 1,
+  rev: 2,
   status: "draft",
   title: locKey("dw.skill.ns.round.whole-numbers.title"),
   learnerGoal: locKey("dw.skill.ns.round.whole-numbers.goal"),
   domain: "ns",
   cluster: "round",
   bigIdeas: [locKey("dw.idea.magnitude.nearest-landmark")],
-  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  gradeBand: { earliest: 2, nominal: 4, latest: 5 },
   strandRole: "application",
   proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
   classification: "procedural",
@@ -276,7 +380,10 @@ const roundWhole: SkillNode = {
     { kind: "requires", to: SKILL_COMPARE_WHOLE },
     { kind: "supports", to: SKILL_DIGIT_VALUE },
   ],
-  difficulty: { b: b(-30n), levels: [b(20n), b(60n), b(110n), b(145n)] },
+  difficulty: {
+    b: b(-30n),
+    levels: [b(-10n), b(20n), b(30n), b(70n), b(110n), b(145n), b(205n)],
+  },
   // No mal-rule, and `malrules/placeValue.ts` and this family's own header say why:
   // every documented rounding bug produces the correct answer on about half of all
   // items, and the only routes to CG-12's 95% divergence are to bias the content
@@ -287,9 +394,42 @@ const roundWhole: SkillNode = {
   generator: {
     family: ROUND_ESTIMATE_FAMILY,
     familyRev: ROUND_ESTIMATE_FAMILY_REV,
-    params: [round(3, 1, 1, false), round(4, 1, 2, false), round(5, 2, 3, false), round(5, 2, 3, true)],
+    // A rung is **prepended**: `round(2, 1, 1, false)` is "round 47 to the nearest
+    // ten", the smallest rounding question there is, and the row began at three
+    // digits. The rung after it is unchanged; the one after *that* widens the place
+    // range to ten-or-hundred, which is the reconciliation
+    // `dw.ns.round.whole-numbers L0` was waiting on — a level that could be widened
+    // and simply had not been.
+    //
+    // L4 and L5 are the same parameters with `ties` turned on, and stay that way. The
+    // one thing that pair teaches is that a halfway number rounds up, so isolating it
+    // is the whole point of it and a wider place range on L4 would have hidden the
+    // difference inside a harder question. The reach to six digits therefore goes
+    // above them rather than between them.
+    params: [
+      round(2, 1, 1, false),
+      round(3, 1, 1, false),
+      round(3, 1, 2, false),
+      round(4, 1, 3, false),
+      round(5, 2, 3, false),
+      round(5, 2, 3, true),
+      round(6, 3, 5, true),
+    ],
     forms: [ROUND_FORM],
-    minVariants: 80,
+    // Sixty rather than eighty, because L0's whole problem space is seventy-two and
+    // `minVariants` is one number for the row: CG-7 fails a row that declares more
+    // variants than its own closed level holds. Every level above L1 clears CG-10's
+    // floor of 975 by an order of magnitude, so nothing above is measured by this.
+    minVariants: 60,
+    // The two to-the-nearest-ten rungs are closed and small in the world, and the count
+    // follows from the family's own two exclusions: the part below the rounding place is
+    // never 0, because the number would already be round, and on a level that poses no
+    // ties it is never 5 either. So a two-digit item is nine tens-digits by eight
+    // units-digits — 72 — and a three-digit one is ninety by eight, which is 720. Both
+    // are exhausted in `closedSpaces.test.ts`. L2 is the same content with the hundreds
+    // place added and has 1,602 problems, which is why widening was the right instrument
+    // there and closure is the right one here.
+    closedFactSet: [72, 720, null, null, null, null, null],
     consumes: [CAP_READ_PLACE],
   },
   probes: [],

--- a/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
@@ -10,13 +10,20 @@
  *
  * Three further blockers are named below, and each is a different kind of thing.
  *
- * **CG-10**, the variant-space floor. It requires an estimated space of 975 — a
- * 40-item practice run repeating no more than one item in fifty — and the levels
- * in `CG10_BLOCKED_LEVELS` do not clear it. Some are genuinely short of problems in
- * the world: `dw.alg.equality.missing-subtrahend` L0 draws both operands from 1..9,
- * so its true space is exactly 81 items and no generator work changes that. Others
- * would clear the floor with a wider draw, and two of them now have one — see the
- * note under the list.
+ * **CG-10**, the variant-space floor — and `CG10_BLOCKED_LEVELS` is now **empty**. It
+ * requires an estimated space of 975, a 40-item practice run repeating no more than
+ * one item in fifty. Twenty-four levels did not clear it and every one is resolved,
+ * by one of the two instruments and never by argument: a level whose ceiling was
+ * arbitrarily small was widened, and a level whose space is genuinely all there is
+ * declares `closedFactSet` and is exhausted in `closedSpaces.test.ts`. See the note
+ * under the list.
+ *
+ * **`MIN_RUNG_VARIANTS`**, the floor *under* the floor: 24 distinct problems per rung,
+ * whatever CG-10 says about it, with `SMALL_RUNG_LEVELS` naming the one active level
+ * that is exempt and why. `ladder.test.ts` measures it over the *active* graph, which
+ * is what a child stands on; `families.property.test.ts` measures the same bound over
+ * the **whole** graph, so a draft rung authored under the floor is named before it can
+ * be promoted rather than after.
  *
  * **The apparatus a pack builds**, in `PACK_STATEMENT_BLOCKED_SKILLS`, and this one
  * is new with the blank statement. A question the host can now *state* is not a
@@ -44,49 +51,52 @@
  * Labels are `<skill id> L<level>`, the same form the sweep prints.
  */
 
-export const CG10_BLOCKED_LEVELS: readonly string[] = [
-  "dw.ns.place.digit-in-place L0",
-  "dw.ns.round.whole-numbers L0",
-  "dw.frac.equivalence.build-equivalent L0",
-  "dw.frac.equivalence.build-equivalent L1",
-  "dw.frac.equivalence.build-equivalent L2",
-  "dw.frac.equivalence.lowest-terms L0",
-  "dw.frac.equivalence.lowest-terms L1",
-  "dw.frac.equivalence.lowest-terms L2",
-  "dw.frac.equivalence.improper-to-mixed L0",
-  "dw.frac.equivalence.improper-to-mixed L1",
-  "dw.frac.equivalence.mixed-to-improper L0",
-  "dw.frac.equivalence.mixed-to-improper L1",
-  "dw.frac.arith.add-like-denominators L0",
-  "dw.frac.arith.add-like-denominators L1",
-  "dw.frac.arith.add-unlike-denominators L0",
-  "dw.frac.arith.subtract-fractions L0",
-  "dw.frac.arith.subtract-fractions L1",
-  "dw.frac.arith.multiply-by-a-whole L0",
-  "dw.frac.arith.multiply-by-a-whole L1",
-  "dw.frac.arith.multiply-fractions L0",
-  "dw.alg.equality.balance-meaning L0",
-  "dw.alg.equality.missing-subtrahend L0",
-  "dw.alg.equality.unknown-minuend L0",
-  "dw.alg.equality.missing-factor L0",
-];
+export const CG10_BLOCKED_LEVELS: readonly string[] = [];
 
 /**
- * Two levels came off this list, and neither by argument.
+ * **Empty**, and it stays here for the reason `NUMERAL_WIDTH_BLOCKED_LEVELS` does: the
+ * list is asserted in *both* directions, so the day a level slips under the floor it is
+ * named by a failing build rather than by somebody noticing.
  *
- * `dw.mul.scale.times-power-of-ten L0` was `47 × 100` — ninety multiplicands times
- * one power, ninety problems — and is now three digits by two powers, which is
- * 1,800. `dw.div.whole.divide-exact L0` was a two-digit quotient over a one-digit
- * divisor, 720 problems, and is now a three-digit quotient, which is 7,200. Both
- * were bounded by a digit count that nothing about the content asked to be small,
- * which is precisely the case `GeneratorBinding.closedFactSet` must not be used
- * for. A level that could be widened and simply has not been is a level that gets
- * widened.
+ * ## What was on it, and what took it off
  *
- * The fact rows added alongside them are the other case and take the other route:
- * there are 121 multiplications in the tables to twelve and no 122nd, so they
- * declare `closedFactSet` and are measured against it. Nothing on this list moved
- * because the floor was argued down.
+ * Twenty-four levels, and two before them. `dw.mul.scale.times-power-of-ten L0` was
+ * `47 × 100` — ninety multiplicands times one power, ninety problems — and is three
+ * digits by two powers, which is 1,800. `dw.div.whole.divide-exact L0` was a two-digit
+ * quotient over a one-digit divisor, 720 problems, and is a three-digit quotient, which
+ * is 7,200. Both were bounded by a digit count that nothing about the content asked to
+ * be small: **a level that could be widened and simply has not been is a level that
+ * gets widened.**
+ *
+ * The remaining twenty-four were the whole of `ns`'s two sub-floor levels, nine `frac`
+ * rows and four `alg` rows, and they split the same way:
+ *
+ * - **Widened**, because the ceiling was arbitrary. `dw.ns.round.whole-numbers`' easiest
+ *   three-digit rung rounded only to the nearest ten (720 problems) and now rounds to
+ *   ten *or* hundred (1,602). `dw.frac.arith.add-like-denominators` L2 was a ceiling of
+ *   16 (1,008 problems, read as ~780 by the gate's estimator) and is a ceiling of 20
+ *   (2,100, read as ~1,180).
+ * - **Declared closed and exhausted**, because the space is all there is.
+ *   `dw.alg.equality.missing-subtrahend` L0 draws both operands from 1..9, so its space
+ *   is exactly 81 items and no generator work changes that. Neither does anything change
+ *   `dw.frac.equivalence.build-equivalent`, whose *entire task* — a reduced fraction
+ *   scaled up, at the family's widest denominator — holds six hundred problems.
+ *
+ * ## The rule the second route now follows, and the loophole it closes
+ *
+ * `closedFactSet` exempts a level from the floor, so an inflated declaration would be a
+ * way to buy the exemption without earning it: CG-10's substituted check is
+ * `distinct ≤ declared`, which passes trivially for any number large enough. So every
+ * declaration in this graph is **exhausted** in `closedSpaces.test.ts` — drawn until the
+ * level stops yielding new items, and required to equal the declared count exactly.
+ * Over-declaring fails, and so does under-declaring.
+ *
+ * That test is also why the field is used only where the space is **below** the floor.
+ * Exhausting a space of a few hundred costs a few thousand seeds; exhausting the 2,280
+ * same-numerator comparisons inside twentieths costs six figures, which is not a PR
+ * gate. Two rungs are left unauthored as a result and `domains/frac.ts` records them:
+ * their true spaces clear the floor and the estimator says otherwise, which is a finding
+ * about CG-10's estimator rather than about the content.
  */
 
 /** The skills above, deduplicated. */
@@ -165,6 +175,23 @@ export const MIN_RUNG_VARIANTS = 24;
  */
 export const SMALL_RUNG_LEVELS: readonly string[] = ["dw.mul.facts.tables-within-five L2"];
 
+/*
+ * Measured twice, over two different graphs, and both directions each time.
+ *
+ * `ladder.test.ts` runs the list above over `activeNodes` — what a child can actually be
+ * served, which is the claim that matters most. `families.property.test.ts` runs the same
+ * bound over the whole graph including the twenty-eight draft rows, and it has to: this
+ * package authors rungs long before it promotes them, so a draft level under the floor
+ * that nothing measured would be discovered by the promotion PR at best and by a child at
+ * worst. It is the same asymmetry that let `dw.div.facts.division-facts` ship a difficulty
+ * table no gate had checked.
+ *
+ * `closedSpaces.test.ts` adds the third reading, from the other side of the same number:
+ * over a level's **whole declared space** rather than over a 500-seed sample of it. A
+ * sample reports what it happened to draw; a space reports what exists, and a rung whose
+ * universe is nineteen items cannot be made wider by sampling it harder.
+ */
+
 /**
  * Prompt templates whose question the host still cannot state — **one**, and what is
  * left after the operator problem and then the blank were fixed.
@@ -228,6 +255,67 @@ export const SMALL_RUNG_LEVELS: readonly string[] = ["dw.mul.facts.tables-within
  * named here by an existing test, not by somebody noticing.
  */
 export const MISSTATED_QUESTION_TEMPLATES: readonly string[] = ["dw.prompt.long-div.remainder"];
+
+/**
+ * Templates whose question is **not a binary operation at all**, and which the only
+ * thing that serves an item therefore refuses outright.
+ *
+ * ## Why this needed to be data
+ *
+ * Because it is the whole reason the `ns` domain has never served a child a single
+ * question, and it was prose in a file header.
+ *
+ * `dynawalla-app/src/packs/items.ts` composes a question out of two operands, an
+ * operator glyph and a blank position. `binaryOperator()` returns `null` for a
+ * template that declares `operator: "none"`, and the caller returns `null` rather than
+ * guessing:
+ *
+ * ```
+ * [packs] … emits the prompt template …, which the curriculum does not declare as a
+ * binary operation — there is no operator to draw between "295" and
+ * "dw.term.place.hundreds", so nothing is served.
+ * ```
+ *
+ * That is correct behaviour and it is the right log line. But it means a promotion of
+ * any row below buys a rung that generates a question, refuses to draw it, and serves
+ * the child *nothing* — the failure `NUMERAL_WIDTH_BLOCKED_LEVELS` describes as "a Seal
+ * Bearer that asks nothing, forever". `MISSTATED_QUESTION_TEMPLATES` catches a card that
+ * states the wrong question; this catches a card that states no question.
+ *
+ * The three shapes here are not one missing feature. "In 4,193, what is the digit in
+ * the hundreds place worth?" needs a numeral and a **place name**; "which is greater,
+ * 3/8 or 3/5?" needs two numbers and a **relation**; `2/3 = ☐/12` needs an equation
+ * between two written fractions. `PromptBlank` reaches none of them, deliberately —
+ * `a OP b`, `☐ OP a = b` and `a OP ☐ = b` and no wider — and stretching it to would be
+ * the guess this registry exists to retire.
+ *
+ * ## How it is checked
+ *
+ * `render/prompts.test.ts` reads the operator off every registered declaration and
+ * requires the `none` set to equal this list, and requires every skill whose bound
+ * levels emit *only* such templates to be `draft`. Both directions: a template that
+ * gains an operator must be struck off, and one added as `none` must be named.
+ *
+ * The rows it blocks are all six of `ns`, the four `frac.equivalence` rows, the two
+ * `frac.compare` rows and `dw.alg.equality.balance-meaning` — thirteen of the graph's
+ * twenty-eight draft rows, and the largest single reason the draft list is as long as
+ * it is. It clears when a pack lands a renderer for a question that is not two
+ * operands and a glyph; that is the same PR as `--strict-renderers` going green, and
+ * it is a pack's, not the curriculum's.
+ */
+export const NON_BINARY_QUESTION_TEMPLATES: readonly string[] = [
+  "dw.prompt.compare-order.greater",
+  "dw.prompt.compare-order.lesser",
+  "dw.prompt.frac-equivalence.build",
+  "dw.prompt.frac-equivalence.simplify",
+  "dw.prompt.frac-equivalence.to-improper",
+  "dw.prompt.frac-equivalence.to-mixed",
+  "dw.prompt.missing-operand.both-sides",
+  "dw.prompt.place-value.digit-in-place",
+  "dw.prompt.place-value.digit-value",
+  "dw.prompt.place-value.total-in-place",
+  "dw.prompt.round-estimate.round",
+];
 
 /**
  * Rows the host can now state and a **pack** cannot draw, with what each one needs.

--- a/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
@@ -318,70 +318,71 @@ export const NON_BINARY_QUESTION_TEMPLATES: readonly string[] = [
 ];
 
 /**
- * Rows the host can now state and a **pack** cannot draw, with what each one needs.
+ * Rows the host can state and a **pack** cannot draw. **One**, and it is not the pack's.
  *
  * ## Why this list has to exist at all
  *
- * Because a stated question is not a drawn one, and the layer that finds out is the
- * one nobody was checking. `packs/shared/game-host` flattens an `Item` to six fields
- * and forwards `prompt` byte for byte, so for twenty-seven of the twenty-eight packs
- * a statement is a string to draw and a longer string is a layout problem at worst.
+ * Because a stated question is not a drawn one, and the layer that finds out is the one
+ * nobody was checking. `packs/shared/game-host` flattens an `Item` to six fields and
+ * forwards `prompt` byte for byte, so for twenty-seven of the twenty-eight packs a
+ * statement is a string to draw and a longer string is a layout problem at worst.
  * `games/balance` is the twenty-eighth: it splits the prompt at the `=` and builds a
- * **physical apparatus** out of each side (`src/adapter.ts:251-253`), and it is the
- * only pack that declares all five of these rows. Its model is a pan of weights that
- * add.
+ * **physical apparatus** out of each side, and it is the only pack that declares all five
+ * of these rows. Its model was a pan of weights that add, and two of these statements are
+ * not sums.
  *
- * Measured by running that pack's own `specFromQuestion` on the statements this host
- * now writes, and asking whether the board balances once the canonical answer is
- * placed on the fill side:
+ * ## Four came off, and by a pack fix rather than an argument
+ *
+ * The list held `missing-subtrahend` (`93 − □ = 47`: `tokenizeSide` set a sign when it
+ * read a minus and pushed the blank term without applying it, so the box was *added* to
+ * the pan), `missing-factor` (`□ × 15 = 165`: the tokeniser collapsed `6 × 2` to a single
+ * weight and could not collapse a product it did not know yet), and `unknown-minuend`,
+ * which drew correctly and was unreachable under CG-4 only because its one prerequisite
+ * was `missing-subtrahend`.
+ *
+ * `games/balance` #724 rebuilt the tokeniser around a signed `Item` with `product`,
+ * `quotient` and `countOf` terms — the founder had been locked into a board by a
+ * *correct* answer to `88965 ÷ 9`, which is the same defect one operator over. Measured
+ * afterwards, by running that pack's own `specFromQuestion` on the statements this host
+ * writes and asking `whyUnsolvable` whether the beam levels with the canonical answer on
+ * the fill side:
  *
  * | statement | board | verdict |
  * |---|---|---|
- * | `47 + □ = 68` | 47 vs 68, fill left, answer 21 | 68 = 68 — **balances** |
- * | `□ − 47 = 68` | −47 vs 68, fill left, answer 115 | 68 = 68 — **balances** |
- * | `8 + 4 = □ + 5` | 8 + 4 vs 5, fill right, answer 7 | 12 = 12 — **balances** |
- * | `93 − □ = 47` | 93 vs 47, fill left, answer 46 | 139 vs 47 — **does not** |
- * | `□ × 15 = 165` | 15 vs 165, fill left, answer 11 | 26 vs 165 — **does not** |
+ * | `47 + □ = 68` | `fill`, left | **solvable** |
+ * | `93 − □ = 47` | `fill`, left | **solvable** |
+ * | `□ − 47 = 68` | `fill`, left | **solvable** |
+ * | `□ × 15 = 165` | `fill`, left | **solvable** |
+ * | `8 + 4 = □ + 5` | `fill`, right | **solvable** |
  *
- * Two distinct defects, and only one of them is a bug:
+ * So three rows are `active`, and the measurement cannot live in this package — the
+ * curriculum imports nothing from `games/` and must not — which is why it is written
+ * down here in the form the previous four measurements were.
  *
- * - `sub-unknown` — `tokenizeSide` sets a `sign` when it reads a minus and then
- *   pushes the blank term **without applying it** (`src/adapter.ts:57-64`), so the box
- *   in `93 − □` is added to the pan instead of taken off it. A pack bug, and a
- *   one-line one.
- * - `mul-unknown` — the tokeniser collapses `6 × 2` to a single weight of 12 and
- *   cannot collapse `□ × 15`, because the product is not known until the child
- *   answers. A missing factor is not a sum of weights at all; balance has a `beam`
- *   mode where distance from the fulcrum multiplies (`6 × 2 = □ × 3`) and
- *   `specFromQuestion` always builds `pans`. Not a bug — a mode the adapter does not
- *   reach for.
+ * ## The one that is left, and it is the host's
  *
- * `unknown-minuend` draws correctly and is here for a third reason entirely: its only
- * `requires` prerequisite is `missing-subtrahend`, so CG-4 makes it unreachable while
- * that row is draft. It is a promotion that comes free with the pack fix above.
+ * `balance-meaning` is the fifth row in that table and it *is* drawable: COUNTERPOISE
+ * builds a solvable board for `8 + 4 = □ + 5`. It stays draft because **nothing can hand
+ * the pack that string.** `drawStatement` in `dynawalla-app/src/packs/items.ts` writes
+ * `a OP b`, `□ OP a = b` and `a OP □ = b` and no fourth shape, and the row's template
+ * declares `operator: "none"` for exactly that reason — see
+ * `NON_BINARY_QUESTION_TEMPLATES`, where it is named alongside the whole `ns` domain.
  *
- * `balance-meaning` draws correctly too, and stays draft on two things neither of
- * which is the pack's: `a + b = □ + d` is three numbers and an operator on each side
- * of the relation, which `PromptBlank` does not express; and the row declares the
- * balance scale `required`, which `Item` in `packs/sdk/src/protocol.ts` has no field
- * to ask a pack for — so promoting it would assert a requirement the host cannot
- * transmit.
+ * It carries a second blocker that would outlast the first: the row declares the balance
+ * scale `required`, and `Item` in `packs/sdk/src/protocol.ts` has no field to ask a pack
+ * for a representation. Promoting it would assert a requirement the host cannot transmit,
+ * to the one pack that would honour it anyway.
  *
  * ## How it is checked
  *
- * `render/prompts.test.ts` asserts every entry is a real node and is `draft`, and — in
- * the other direction — that the draft rows of the `alg` domain are **exactly** these.
- * So promoting one without striking it fails, demoting one without naming it fails,
- * and the day a pack learns to draw a missing factor the list is what the promotion PR
- * reads first. The board measurements themselves cannot live in this package: the
- * curriculum imports nothing from `games/`, and it must not.
+ * `render/prompts.test.ts` asserts every entry is a real node and is `draft`, and — in the
+ * other direction — that the draft rows of the `alg` domain are **exactly** these. So
+ * promoting one without striking it fails, and demoting one without naming it fails.
  */
 export const PACK_STATEMENT_BLOCKED_SKILLS: readonly string[] = [
   "dw.alg.equality.balance-meaning",
-  "dw.alg.equality.missing-factor",
-  "dw.alg.equality.missing-subtrahend",
-  "dw.alg.equality.unknown-minuend",
 ];
+
 
 /**
  * The longest numeral a shipped game will put in front of a child, in characters.

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.test.ts
@@ -537,13 +537,21 @@ test("the alg rows a pack cannot draw are exactly the ones promotionBlockers.ts 
     "the draft rows of the alg domain and PACK_STATEMENT_BLOCKED_SKILLS disagree",
   );
 
-  // And the row that came off the list is genuinely on the ladder rather than merely
-  // absent from a blocker list, which is the direction a deletion would satisfy.
+  // And the rows that came off the list are genuinely on the ladder rather than merely
+  // absent from a blocker list, which is the direction a deletion would satisfy. Named
+  // rather than counted, and in the order `algDomainNodes` declares them, because the
+  // claim is about *which* four shapes a child can be asked — the missing addend, both
+  // subtraction shapes, and the missing factor.
   const active = allNodes.filter((node) => node.domain === "alg" && node.status === "active");
   assert.deepEqual(
     active.map((node) => String(node.id)),
-    ["dw.alg.equality.missing-addend"],
-    "the equality row this host can draw is not the one that is active",
+    [
+      "dw.alg.equality.missing-addend",
+      "dw.alg.equality.missing-subtrahend",
+      "dw.alg.equality.unknown-minuend",
+      "dw.alg.equality.missing-factor",
+    ],
+    "the equality rows this host can draw are not the ones that are active",
   );
 });
 

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.test.ts
@@ -55,6 +55,7 @@ import { allNodes } from "../graph/graph.ts";
 import {
   FRACTION_ANSWER_BLOCKED_SKILLS,
   MISSTATED_QUESTION_TEMPLATES,
+  NON_BINARY_QUESTION_TEMPLATES,
   NUMERAL_WIDTH_BLOCKED_LEVELS,
   NUMERAL_WIDTH_BLOCKED_SKILLS,
   PACK_STATEMENT_BLOCKED_SKILLS,
@@ -269,6 +270,70 @@ test("the templates the host cannot state are exactly the blocked list", () => {
   assert.ok(checked.size >= 15, `only ${String(checked.size)} templates were arithmetically checked`);
   process.stdout.write(
     `# stated question: ${String(checked.size)} template(s) checked, ${String(misstated.size)} misstated\n`,
+  );
+});
+
+test("the templates that state no binary operation are exactly the blocked list, and every row they alone bind is draft", () => {
+  // The other half of "the string a game draws states the question the answer answers":
+  // the templates that state *no* question a two-operand string can hold. The loop above
+  // skips them (`if (operator === "none") continue`), which is right — there is no
+  // arithmetic claim to check — and left the largest promotion blocker in the graph
+  // measured by nothing at all.
+  const nonBinary = promptRegistry
+    .filter((entry) => promptOperator(String(entry.id)) === "none")
+    .map((entry) => String(entry.id));
+
+  assert.deepEqual(
+    [...nonBinary].sort(),
+    [...NON_BINARY_QUESTION_TEMPLATES].sort(),
+    "promotionBlockers.ts and the prompt registry disagree about which templates state no binary operation",
+  );
+
+  // And the direction that matters to a child: a row whose every bound level emits one
+  // of these has no question the shipped serving path will draw, so promoting it serves
+  // silence. Measured off generated output rather than off the row's family, because a
+  // family may emit several templates and only some of them may be `none` — `long-div`
+  // is one — and it is the *level table* that decides which a row can reach.
+  const blocked = new Set(nonBinary);
+  const silent: string[] = [];
+
+  for (const node of allNodes) {
+    if (node.status === "deprecated") continue;
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined, `${node.id} binds an unregistered family`);
+    let emitted = 0;
+    let unstatable = 0;
+    node.generator.params.forEach((raw, level) => {
+      const validated = family.paramSchema.validate(raw);
+      if (!validated.ok) return;
+      for (let seed = 1; seed <= 12; seed++) {
+        const exercise = family.generate({
+          skillId: node.id,
+          level,
+          seed,
+          params: validated.value,
+          forms: node.generator.forms,
+        });
+        emitted += 1;
+        if (blocked.has(String(exercise.prompt.key))) unstatable += 1;
+      }
+    });
+    if (emitted > 0 && unstatable === emitted) silent.push(node.id);
+  }
+
+  const served = silent.filter((id) => allNodes.find((node) => node.id === id)?.status === "active");
+  assert.deepEqual(
+    served,
+    [] as readonly string[],
+    `these rows are active and every question they can draw states no binary operation, so the only thing ` +
+      `that serves an item refuses all of them: ${served.join(", ")}`,
+  );
+  assert.ok(
+    silent.length >= 13,
+    `expected the rows a two-operand string cannot state, found ${String(silent.length)}`,
+  );
+  process.stdout.write(
+    `# non-binary questions: ${String(nonBinary.length)} template(s), blocking ${String(silent.length)} draft row(s)\n`,
   );
 });
 

--- a/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
+++ b/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
@@ -66,6 +66,7 @@
     "gen.arith.multidigit-mul@1|dw.mul.multidigit.long-multiplication|L2": "1239bfc39b12417f",
     "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L0": "44651d77b0560687",
     "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L1": "b9d84b5000ca76cb",
-    "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L2": "e29ba443acfffd08"
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L2": "e29ba443acfffd08",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L3": "eb4ebb3d04a9468c"
   }
 }

--- a/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
+++ b/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
@@ -67,6 +67,16 @@
     "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L0": "44651d77b0560687",
     "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L1": "b9d84b5000ca76cb",
     "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L2": "e29ba443acfffd08",
-    "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L3": "eb4ebb3d04a9468c"
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-addend|L3": "eb4ebb3d04a9468c",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-subtrahend|L0": "4e07386678287a17",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-subtrahend|L1": "1a74fd97c8721bde",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-subtrahend|L2": "3a98e0ab2474d59d",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-subtrahend|L3": "a925bdf7dcf43d44",
+    "gen.arith.missing-operand@1|dw.alg.equality.unknown-minuend|L0": "5a05f3c506861ef7",
+    "gen.arith.missing-operand@1|dw.alg.equality.unknown-minuend|L1": "ebdd7cb510ebfe40",
+    "gen.arith.missing-operand@1|dw.alg.equality.unknown-minuend|L2": "0a07317ae46e525b",
+    "gen.arith.missing-operand@1|dw.alg.equality.unknown-minuend|L3": "fdf75af1f79f7e5b",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-factor|L0": "e04016a32e8c3b33",
+    "gen.arith.missing-operand@1|dw.alg.equality.missing-factor|L1": "05582769a862aa74"
   }
 }


### PR DESCRIPTION
Twenty-two rows across `ns`, `alg` and `frac` had three or four levels each, and most
started partway up their own ladder. `dw.ns.compare.whole-numbers` — a row whose
`gradeBand.earliest` is 1 — began at *three-digit* comparison. So a controller walking a
struggling child down these domains ran out of rungs while the questions were still too
hard, and a child at the top ran out of ladder before the standards the rows cite do.

**102 levels where there were 67**, the whole graph from 152 to 187: place value and
comparison to seven digits, rounding from `47` to the nearest ten up to six digits with
the halfway number, the `alg` shapes to the four digits their family can reach, and every
`frac` row from its smallest denominators to the family's ceiling.

## Three equality rows go active

`PACK_STATEMENT_BLOCKED_SKILLS` held four `alg` rows because `games/balance` is the one
pack of twenty-eight that builds a *physical apparatus* out of a statement rather than
drawing it, and its tokeniser pushed a blank without applying the sign it had just read —
so the box in `93 − □` was added to the pan instead of taken off it — and could not
collapse a product it did not know yet.

COUNTERPOISE (PR 724, on main since this branch was opened) rebuilt that tokeniser around
signed `product`, `quotient` and `countOf` terms, to fix the founder being locked into a
board by a *correct* answer to `88965 ÷ 9`. It cleared these rows as a side effect and did
not strike them off. Measured by running the pack's own `specFromQuestion` and
`whyUnsolvable` on the statements this host writes:

| statement | board | verdict |
|---|---|---|
| `47 + □ = 68` | `fill`, left | solvable |
| `93 − □ = 47` | `fill`, left | solvable |
| `□ − 47 = 68` | `fill`, left | solvable |
| `□ × 15 = 165` | `fill`, left | solvable |
| `8 + 4 = □ + 5` | `fill`, right | solvable |

So `missing-subtrahend`, `unknown-minuend` and `missing-factor` are **active**. The
equality strand goes from one served row to four and now has an active row in every grade
band from 1 to 5. Confirmed independently by the pack: `games/balance`'s own ladder sweep
walks 77 rungs instead of 66, finds a legal move on every board the eleven new rungs
produce, and adds none of them to the seven it refuses.

`balance-meaning` stays draft and **not** for the pack's sake — the board is solvable.
Nothing can hand it `8 + 4 = □ + 5`: `drawStatement` writes `a OP b`, `□ OP a = b` and
`a OP □ = b` and no fourth shape, and the row declares the balance scale `required`, which
`Item` has no field to transmit.

## `CG10_BLOCKED_LEVELS` is empty

All twenty-four entries resolved, none by argument.

- **Widened** where the ceiling was arbitrary. `dw.ns.round.whole-numbers`' easiest
  three-digit rung rounded only to the nearest ten (720 problems) and now rounds to ten or
  hundred (1,602). `dw.frac.arith.add-like-denominators` L2 went from a ceiling of 16 —
  1,008 problems, which clears the floor in truth and reads as ~780 through the gate's
  estimator — to 20, which is 2,100 and reads as ~1,180.
- **Declared closed and exhausted** where the space is all there is. The `alg` shapes at
  one digit are 81, 81, 64 and 729 sentences. The whole `build`/`simplify` fraction task
  holds six hundred problems at the family's widest denominator, so no level of
  `dw.frac.equivalence.build-equivalent` could ever clear 975.

## `closedSpaces.test.ts` — the other half of the `MIN_RUNG_VARIANTS` gap

`MIN_RUNG_VARIANTS` arrived on main in #713 and closed the half of the gap where a rung is
*honestly declared* too small. This closes the half where the declaration is simply not the
space: CG-10's substituted check is `distinct <= declared`, an upper bound alone, so
`closedFactSet: [999_999]` satisfies both the gate and the new floor beside a rung of nine
items.

Every declaration in the graph is now **exhausted** — drawn until the level stops yielding
new items, required to equal the declaration exactly — so over- and under-declaring both
fail. All 69 pass, including the 37 that were already here and had never been measured from
below. It is also why the field is used only *below* CG-10's floor, which is asserted: the
largest of these needs about 15,000 seeds and a 2,280-item space needs six figures.

## Two more gates over the draft graph

- **`MIN_RUNG_VARIANTS` over the whole graph.** `ladder.test.ts` measures it over
  `activeNodes`, which is the right graph for the claim it makes. Twenty-eight rows are
  draft and this change more than doubles their level count, so `families.property.test.ts`
  runs the same bound over all of them, against the same `SMALL_RUNG_LEVELS` — deliberately
  the *active* exemption list, because a draft rung has no claim on an exemption nobody has
  weighed. It earned its place immediately: `equivalence("build", 12, 4, 1)` is the natural
  easiest rung for `build-equivalent` and holds nineteen problems, so the row starts at a
  ceiling of 16 and thirty-five instead.
- **Every level table is checked to increase, on draft rows as well as active ones.** CG-9
  checks it over `activeNodes` only; `dw.div.facts.division-facts` already shipped a table
  stated against coefficients it did not have because of that gap. It matters more than
  bookkeeping because `b_item` is what an answering window is priced off:
  `PACING_AUDIT_2026-07.md` requires `window(d)` to be monotone non-decreasing in
  difficulty, and a rung easier than the one below it makes that unsatisfiable however
  carefully the pacing primitive is written.

## `NON_BINARY_QUESTION_TEMPLATES`

The largest promotion blocker in the graph, and it was prose in a file header. Eleven
templates declare `operator: "none"`; the only thing that serves an item composes a
question from two operands and a glyph, so it refuses them out loud. Thirteen draft rows
can draw no other question — all six of `ns`, the four `frac.equivalence` rows, the two
`frac.compare` rows and `alg.balance-meaning`. Asserted against the registry in both
directions, plus the direction that matters to a child: no active row may be one of them.

## What stays draft, and why

| blocker | rows | what clears it |
|---|---|---|
| `NON_BINARY_QUESTION_TEMPLATES` | all 6 `ns`, 4 `frac.equivalence`, 2 `frac.compare`, `alg.balance-meaning` | a pack renderer for a question that is not `a OP b` |
| `FRACTION_ANSWER_BLOCKED_SKILLS` | all 11 `frac` | `answerText` learning to write a fraction and `judge` to read one |
| `PACK_STATEMENT_BLOCKED_SKILLS` | `alg.balance-meaning` | a statement writer for three operands, and a field on `Item` for a required representation |

Four fraction games ship declaring those `frac` ids and are being served nothing. The
curriculum side of each blocker is finished; what is left is one PR in `games/`.

## Ids and numbering

`rev` goes to 2 on all twenty-two rows; **no id moved.** Eleven `draft` rows have a rung
inserted below their top, which renumbers the levels above it — safe because
`shipped-ids.json` carries no release. `alg` is append-only, because one of its rows was
already live. Three `entry` probes at L0 now land on the new easiest rung, which is what an
entry probe is for, and `mixed-to-improper`'s `promotion` probe moved from L2 to L3 to stay
on the rung it was written against.

## Tripwires revisited rather than deleted

`dynawalla-app`'s pinned missing-factor card asserted the row was `draft` — it asserts
`active` now. And its blank-statement sweep asserted that no answer is the number already
printed on the far side of the card, written to catch a missing factor whose "answer" is the
product, and now met by `12 − □ = 6` — which wants 6 and is a *halving fact*, not a
misstated card. The exception is arithmetic and checked: where the answer equals the printed
result the card must be a subtraction whose minuend is twice it, and a counter asserts the
branch is reached at all. `games/balance`'s rung count moved 66 → 77.

## Verification

- `npm test` from `dynawalla/curriculum/`: **221 pass, 0 fail, five consecutive runs**, no
  flakes. `npm run tsc`, `npm run check`, `npm run check:full`: clean.
- `dynawalla-app` 373, `games/balance` 100, `polarity` 62, `serpent` 59, `pulse` 129,
  `rhythm` 70, `claim` 78, `arena` 71 — all green; `dynawalla-app` and `games/balance`
  typecheck clean.
- Snapshots: eleven hashes added for the newly active levels, none changed.
- Twelve mutation tests, each breaking the thing the assertion covers and confirming the
  failure. Two found real defects in this PR's own work: a closed-space check that passed
  when the declaration was too *small*, and a duplicated nine-item literal across two files.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb