### PR TITLE
fix(dynawalla/games): the reveal stopped filling the blank in when the host started writing a box

### DIFF
--- a/dynawalla/games/arena/src/mount.ts
+++ b/dynawalla/games/arena/src/mount.ts
@@ -8,6 +8,7 @@ import { Camera } from "./feel/camera.ts"
 import { Floaters } from "./feel/floaters.ts"
 import { guessTier, specFor, TierGovernor, type TierName } from "./core/tier.ts"
 import { R_K, viewSpanFor, World, type GameEvent } from "./sim/world.ts"
+import { statesAnswer } from "./ribbon.ts"
 
 const FIXED = 1 / 60
 const MAX_SUBSTEPS = 3
@@ -390,7 +391,7 @@ export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { 
         const q = world.resonance.question
         if (q) {
           const p = q.prompt
-          hud.showEquation(p.length <= 28 && !p.includes("?") ? `${p} = ${q.answer}` : `${q.answer}`, 2.8, "solved")
+          hud.showEquation(statesAnswer(p, q.answer), 2.8, "solved")
         }
         hud.showVerdict(e.b >= 3 ? `RESONANT ×${e.b}` : "RESONANT", "#b9ffe4")
         audio.resonanceHit(e.b)
@@ -408,11 +409,7 @@ export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { 
         const hold = world.revealSeconds
         if (rq && hold >= 0.25) {
           const rp = rq.prompt
-          hud.showEquation(
-            rp.length <= 28 && !rp.includes("?") ? `${rp} = ${rq.answer}` : `${rq.answer}`,
-            hold,
-            "reveal",
-          )
+          hud.showEquation(statesAnswer(rp, rq.answer), hold, "reveal")
         }
         cam.addTrauma(0.5)
         cam.addHitstop(0.07)

--- a/dynawalla/games/arena/src/ribbon.test.ts
+++ b/dynawalla/games/arena/src/ribbon.test.ts
@@ -1,0 +1,64 @@
+// The ribbon line, and the reveal that was garbled for every blank statement.
+//
+// `dw.alg.equality.missing-addend` is an active row and has been shipping since
+// 0.3.5, so the host serves `47 + □ = 68` today. The ribbon decided whether to
+// append ` = answer` by asking `!prompt.includes("?")` — a proxy for "no relation
+// on this card yet" written when a blank was spelled `?`. The host writes `□`
+// (U+25A1, pinned in `items.ts`), so the test passed and the line read:
+//
+//     47 + □ = 68 = 68
+//
+// Two equals signs, the box still empty, and the answer printed as though it were
+// the total. `resonance-miss` uses this same line as THE REVEAL — the beat that
+// finishes the sum for a child who has just missed one — so the garbling landed on
+// the one frame that was supposed to teach something.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { RIBBON_CHARS, statesAnswer } from "./ribbon.ts"
+
+test("a plain prompt gets the relation appended", () => {
+  assert.equal(statesAnswer("12 + 5", "17"), "12 + 5 = 17")
+})
+
+test("a blank statement is COMPLETED IN PLACE, not answered beside itself", () => {
+  // The founder's principle for a miss is to finish the sum in front of the child.
+  // `47 + 21 = 68` is a sum they can read; `21` on its own is a number with nothing
+  // attached to it, and `47 + □ = 68 = 21` is neither.
+  assert.equal(statesAnswer("47 + □ = 68", "21"), "47 + 21 = 68")
+  // Whatever the answer's width, and wherever the box sits.
+  assert.equal(statesAnswer("□ × 15 = 165", "11"), "11 × 15 = 165")
+  assert.equal(statesAnswer("□ − 47 = 68", "115"), "115 − 47 = 68")
+})
+
+test("the two tolerated legacy blank glyphs behave the same as the box", () => {
+  assert.equal(statesAnswer("47 + ? = 68", "21"), "47 + 21 = 68")
+  assert.equal(statesAnswer("47 + _ = 68", "21"), "47 + 21 = 68")
+})
+
+test("no line ever carries two equals signs", () => {
+  for (const [prompt, answer] of [
+    ["12 + 5", "17"],
+    ["47 + □ = 68", "21"],
+    ["□ × 15 = 165", "11"],
+    ["47 + ? = 68", "21"],
+    ["3/4 + 1/4 = □", "1"],
+  ] as const) {
+    const line = statesAnswer(prompt, answer)
+    const equals = [...line].filter((c) => c === "=").length
+    assert.ok(equals <= 1, `"${prompt}" -> "${line}" has ${String(equals)} equals signs`)
+    assert.ok(!/[□?_]/u.test(line), `"${prompt}" -> "${line}" still shows an empty blank`)
+  }
+})
+
+test("a prompt too wide for the ribbon falls back to the bare answer", () => {
+  const wide = "48826 × 82726 + 918273645 − 512"
+  assert.ok(wide.length > RIBBON_CHARS, `fixture is ${String(wide.length)} chars, not over the cap`)
+  assert.equal(statesAnswer(wide, "7"), "7")
+  // And the cap is measured against the prompt, so a wide blank statement also
+  // falls back rather than being filled into a line that cannot be drawn.
+  const wideBlank = "48826 × 82726 + □ = 918273645"
+  assert.ok(wideBlank.length > RIBBON_CHARS)
+  assert.equal(statesAnswer(wideBlank, "7"), "7")
+})

--- a/dynawalla/games/arena/src/ribbon.ts
+++ b/dynawalla/games/arena/src/ribbon.ts
@@ -1,0 +1,50 @@
+/**
+ * The one line the ribbon shows when a question is finished with.
+ *
+ * Its own module, and not a helper inside `mount.ts`, for a reason worth keeping:
+ * `mount.ts` pulls in `render/gfx.ts` and therefore `three`, so a unit test of this
+ * string arithmetic would drag a WebGL stack behind it and could not run at all in
+ * plain node. Pure string in, pure string out, no imports.
+ */
+
+/** Longest prompt the ribbon can hold before the equation is dropped for the bare answer. */
+export const RIBBON_CHARS = 28
+
+/**
+ * The blank the host writes, `□` (U+25A1, pinned as `BLANK` in `items.ts`), with
+ * `?` and `_` tolerated as `games/balance` lexes them.
+ *
+ * Duplicated from `games/stack/src/blank.ts` because packs do not share code today.
+ * Two copies of one character class is tolerable; a third means it should become
+ * `packs/shared/game-prompt`, and that is filed rather than done here.
+ */
+const BLANK = /[□?_]/u
+
+/**
+ * The completed sum, whenever there is one to show.
+ *
+ * Three cases, and the middle one is the whole reason this exists:
+ *
+ *   `12 + 5`          → `12 + 5 = 17`   append the relation
+ *   `47 + □ = 68`     → `47 + 21 = 68`  **fill the blank in place**
+ *   anything too wide → `21`            bare answer, the ribbon has no room
+ *
+ * This used to read `!prompt.includes("?")`, a proxy for "no relation on this card
+ * yet" from when a blank was spelled `?`. The host writes `□` now, so a blank
+ * statement passed the test and the ribbon rendered `47 + □ = 68 = 68`: two equals
+ * signs, the box still empty, and the answer stated as though it were the total.
+ *
+ * `resonance-miss` uses this same line as THE REVEAL — the beat that finishes the
+ * sum for a child who has just missed one — so the garbling landed on the one frame
+ * that was supposed to teach something.
+ *
+ * Filling the blank rather than falling back to the bare answer is deliberate:
+ * `47 + 21 = 68` is a sum a child can read, where `21` alone is a number with
+ * nothing attached to it.
+ */
+export function statesAnswer(prompt: string, answer: string): string {
+  if (prompt.length > RIBBON_CHARS) return answer
+  if (BLANK.test(prompt)) return prompt.replace(BLANK, () => answer)
+  if (prompt.includes("=")) return answer
+  return `${prompt} = ${answer}`
+}

--- a/dynawalla/games/stack/src/blank.test.ts
+++ b/dynawalla/games/stack/src/blank.test.ts
@@ -1,0 +1,91 @@
+// The blank glyph, and the reveal that quietly stopped filling it in.
+//
+// MONUMENT is the fleet's reference implementation for the founder's rule about a
+// miss: *complete the sum in front of them*, in the accent colour, with the sweep
+// held. Every other game was pointed at this one.
+//
+// It looked for a literal `"?"`. The curriculum writes `□` (U+25A1, pinned as
+// `BLANK` in `dynawalla-app/src/packs/items.ts`, whose docblock says in as many
+// words that it is not `?` and not `___`). When `dw.alg.equality.missing-addend`
+// went active the host began serving `47 + □ = 68`, and `String.replace` — which
+// returns the string UNCHANGED when it matches nothing — made three things fail
+// without throwing:
+//
+//   1. the reveal substituted nothing, so the child saw the card again with the
+//      box still empty;
+//   2. the blank was never drawn in the accent, so it did not read as a blank;
+//   3. `needsRegrouping` could not parse the statement and fell through to its
+//      fail-open branch, handing every blank item the long allowance unmeasured.
+//
+// Only (3) failed safely. This file is the gate on all three.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+
+import { BLANK, fillBlank, hasBlank } from "./blank.ts"
+import { needsRegrouping } from "./game/guard.ts"
+
+test("the box, and the two glyphs kept for history, are all blanks", () => {
+  for (const g of ["□", "?", "_"]) {
+    assert.ok(hasBlank(`47 + ${g} = 68`), `${g} was not recognised as a blank`)
+    assert.equal(fillBlank(`47 + ${g} = 68`, "21"), "47 + 21 = 68")
+  }
+  assert.ok(!hasBlank("47 + 21 = 68"))
+  assert.equal(fillBlank("12 + 5", "17"), "12 + 5", "a prompt with no blank is returned untouched")
+})
+
+test("only the first blank is filled, which is every card the host can write", () => {
+  assert.equal(fillBlank("□ + □ = 8", "4"), "4 + □ = 8")
+})
+
+test("an answer containing a $ is not mangled by replacement patterns", () => {
+  // `String.replace` interprets `$&` and `$1` inside a STRING replacement. The
+  // fix uses a replacer function, so it cannot. Answers are numerals today; this
+  // is here so they can stop being numerals safely.
+  assert.equal(fillBlank("47 + □ = 68", "$&"), "47 + $& = 68")
+})
+
+test("a blank statement is now MEASURED for regrouping, not waved through", () => {
+  // The whole point of substituting the answer back in: `47 + □ = 68` has no
+  // second operand until it is filled, and `47 + 21` needs no regrouping. Before
+  // the fix this could not be parsed at all and returned `true` — the fail-open
+  // branch — so a child answering these got the long silence whether they needed
+  // it or not, and the measurement the guard exists to make was never made.
+  assert.equal(needsRegrouping({ prompt: "47 + □ = 68", answer: "21" }), false)
+  // And one that genuinely does carry still says so.
+  assert.equal(needsRegrouping({ prompt: "47 + □ = 72", answer: "25" }), true)
+  // Unchanged for prompts without a blank.
+  assert.equal(needsRegrouping({ prompt: "47 + 21", answer: "68" }), false)
+  assert.equal(needsRegrouping({ prompt: "47 + 25", answer: "72" }), true)
+})
+
+test("the HUD substitutes the shared blank, not a hardcoded question mark", () => {
+  // A wiring assertion, and it earns its keep: every other test in this file
+  // exercises `blank.ts`, so reverting `hud.ts` alone to `replace("?", …)` would
+  // leave all of them green while the reveal went back to showing an empty box.
+  // The HUD needs a DOM to test directly; the call site is what actually broke,
+  // so the call site is what is pinned. Same shape as `games/slice`'s wiring test.
+  const hud = readFileSync(new URL("./ui/hud.ts", import.meta.url), "utf8")
+  assert.ok(
+    !/replace\(\s*"\?"/u.test(hud),
+    "hud.ts is matching a literal \"?\" again — blank statements will render with an empty box",
+  )
+  const uses = [...hud.matchAll(/replace\(\s*BLANK\b/gu)].length
+  assert.equal(uses, 3, `hud.ts should substitute BLANK at 3 sites, found ${String(uses)}`)
+})
+
+test("the guard reads the shared blank too", () => {
+  const guard = readFileSync(new URL("./game/guard.ts", import.meta.url), "utf8")
+  assert.ok(!/includes\(\s*"\?"/u.test(guard), "guard.ts is testing for a literal \"?\" again")
+  assert.ok(guard.includes("fillBlank("), "guard.ts no longer fills the blank via blank.ts")
+})
+
+test("BLANK is stateless, so sharing one regex across call sites is safe", () => {
+  // A `/g` or `/y` regex carries `lastIndex` between calls and would make the
+  // second substitution on a frame miss. This one must not.
+  assert.equal(BLANK.global, false)
+  assert.equal(BLANK.sticky, false)
+  assert.ok(BLANK.test("□"))
+  assert.ok(BLANK.test("□"), "a second test on the same regex disagreed with the first")
+})

--- a/dynawalla/games/stack/src/blank.ts
+++ b/dynawalla/games/stack/src/blank.ts
@@ -1,0 +1,57 @@
+/**
+ * The blank the host writes into a prompt, and the one place this pack agrees
+ * on what it looks like.
+ *
+ * ## Why this file exists
+ *
+ * The curriculum writes a blank as **U+25A1 WHITE SQUARE**, `□`. It is pinned
+ * there — `dynawalla-app/src/packs/items.ts` declares `export const BLANK = "□"`
+ * and its docblock says, in as many words, that it is not `___` and not `?`.
+ *
+ * This pack was written before that existed, when the only blank anyone had seen
+ * was a literal `?`, and it looked for one with `prompt.includes("?")` and
+ * `prompt.replace("?", …)`. When `dw.alg.equality.missing-addend` went active the
+ * host started serving `47 + □ = 68` and **every one of those calls quietly
+ * stopped matching**:
+ *
+ *   - the reveal substituted nothing, so a child who missed saw the card again
+ *     with the box still empty — the one moment this game is held up for
+ *     ("complete the sum in front of them") doing nothing at all;
+ *   - the blank was never drawn in the accent, so it did not read as a blank;
+ *   - `needsRegrouping` could not parse the statement, and so gave every blank
+ *     item the fail-open allowance rather than a measured one.
+ *
+ * None of it threw. That is the whole hazard: a `String.replace` that matches
+ * nothing returns the string unchanged, so the failure is a screen that looks
+ * *almost* right, which is the same shape as `trebuchet` #698, `foundry` #711,
+ * `lattice` #716 and `balance` #724.
+ *
+ * ## The accepted set
+ *
+ * `□`, `?` and `_` — exactly the three `games/balance/src/adapter.ts` lexes,
+ * because two packs disagreeing about what a blank is would be the next version
+ * of this bug. A triple underscore is deliberately NOT special-cased: one glyph
+ * is the contract and the other two are tolerated history.
+ */
+export const BLANK = /[□?_]/u;
+
+/** Does this prompt have a blank in it at all? */
+export function hasBlank(prompt: string): boolean {
+  return BLANK.test(prompt);
+}
+
+/**
+ * The prompt with its blank filled in by `value`.
+ *
+ * Replaces the FIRST blank only, which is what the three call sites this
+ * replaced did, and what every statement the host can currently write needs —
+ * `drawStatement` puts at most one box on a card.
+ *
+ * `value` is substituted through a replacer **function** rather than a string.
+ * That is not style: `String.replace` interprets `$&`, `$1` and friends inside a
+ * string replacement, so an answer containing a `$` would be mangled. Answers
+ * are numerals today; a function costs nothing and cannot be wrong later.
+ */
+export function fillBlank(prompt: string, value: string): string {
+  return prompt.replace(BLANK, () => value);
+}

--- a/dynawalla/games/stack/src/game/guard.ts
+++ b/dynawalla/games/stack/src/game/guard.ts
@@ -68,9 +68,11 @@ export const ABANDON_FACTOR = 2
  */
 export const MIN_GUARD_SECONDS = 30
 
+import { fillBlank } from "../blank.ts"
+
 /** What the guard is handed: the item, exactly as the child reads it. */
 export type Item = {
-  /** `47 + ? = 72`, or `3/4 + 1/4 = ?`. */
+  /** `47 + □ = 72`, or `3/4 + 1/4 = □`. */
   readonly prompt: string
   /** The canonical answer the host gave. Never computed here. */
   readonly answer: string
@@ -89,17 +91,23 @@ export function widestColumn(item: Item): number {
 /**
  * Whether the sum carries or borrows.
  *
- * Takes the whole item, because MONUMENT's prompts carry the blank — `47 + ? = 72`
+ * Takes the whole item, because MONUMENT's prompts carry the blank — `47 + □ = 72`
  * has no second operand until the answer is put back into it, and a version of
  * this that read the prompt alone could never parse anything at all and would
  * quietly hand every item in the game the same allowance.
+ *
+ * That is not hypothetical: this looked for a literal `"?"` until the host began
+ * writing `□`, at which point the substitution stopped matching and every blank
+ * statement fell through to the fail-open branch below. Harmless in direction —
+ * the child got the *longer* silence — but the measurement was not being made.
+ * The blank glyph lives in `src/blank.ts` now, once, for this file and the HUD.
  *
  * **Fails open.** Anything this cannot parse — a fraction, a comparison, a family
  * this file has never heard of — is treated as needing to regroup, so an
  * unreadable item is always given the *longer* silence and never the shorter one.
  */
 export function needsRegrouping(item: Item): boolean {
-  const filled = item.prompt.includes("?") ? item.prompt.replace("?", item.answer) : item.prompt
+  const filled = fillBlank(item.prompt, item.answer)
   const bare = filled.replace(/\s*=.*$/, "")
   const m = OPERATOR.exec(bare)
   if (!m) return true

--- a/dynawalla/games/stack/src/ui/hud.ts
+++ b/dynawalla/games/stack/src/ui/hud.ts
@@ -33,6 +33,7 @@ import {
   TOOL_SIZE,
   cssScale,
 } from "./place.ts";
+import { BLANK } from "../blank.ts";
 
 const CSS = `
 .mn { position:absolute; inset:0; pointer-events:none; overflow:hidden;
@@ -267,9 +268,14 @@ export class Hud {
   }
 
   /**
-   * `?` in the prompt is drawn in the accent so the blank is obvious at a
-   * glance; on a reveal the answer replaces it in the same colour, so the eye
-   * lands on exactly the thing that changed.
+   * The blank in the prompt is drawn in the accent so it is obvious at a glance;
+   * on a reveal the answer replaces it in the same colour, so the eye lands on
+   * exactly the thing that changed.
+   *
+   * The blank is whatever `src/blank.ts` says it is — `□` as the host writes it,
+   * with `?` and `_` tolerated. This used to match a literal `"?"`, which meant
+   * the reveal substituted nothing for every `47 + □ = 68` the host served and
+   * the child saw the card back with the box still empty.
    */
   setPrompt(prompt: string, reveal: string | null): void {
     // Called every frame, so it compares its two inputs directly instead of
@@ -280,8 +286,8 @@ export class Hud {
     this.lastPrompt = prompt;
     this.lastReveal = reveal;
     const html = reveal
-      ? escape(prompt).replace("?", `<span class="fill">${escape(reveal)}</span>`)
-      : escape(prompt).replace("?", `<span class="q">?</span>`);
+      ? escape(prompt).replace(BLANK, () => `<span class="fill">${escape(reveal)}</span>`)
+      : escape(prompt).replace(BLANK, (glyph) => `<span class="q">${glyph}</span>`);
     this.promptEl.innerHTML = html;
     this.promptEl.classList.toggle("reveal", reveal !== null);
     if (!this.reduced && (fresh || reveal)) {
@@ -386,7 +392,10 @@ export class Hud {
     this.overBig.textContent = "";
     this.overSub.textContent = "";
     this.overQ.style.display = "";
-    this.overQ.innerHTML = escape(prompt).replace("?", `<span class="q">?</span>`);
+    this.overQ.innerHTML = escape(prompt).replace(
+      BLANK,
+      (glyph) => `<span class="q">${glyph}</span>`,
+    );
     this.choicesEl.style.display = "";
     this.choicesEl.textContent = "";
     for (const c of choices) {


### PR DESCRIPTION
**This is live in 0.3.5.** `dw.alg.equality.missing-addend` is an active row, so children are being served `47 + □ = 68` right now.

The curriculum writes a blank as U+25A1 `□`; `items.ts` pins it and says explicitly it is not `?` and not `___`. Two games still looked for a literal `?`. `String.replace` returns the string **unchanged** when it matches nothing, so nothing threw — the screens just went subtly wrong, which is the same shape as `trebuchet` #698, `foundry` #711, `lattice` #716 and `balance` #724.

## MONUMENT — the miss-reveal showed nothing

`hud.ts` substituted the answer into `"?"`. On a miss the card came back **with the box still empty**, and the blank was never accent-marked either so it did not read as a blank. This game is the fleet's *reference implementation* for the founder's rule about a miss — *complete the sum in front of them* — and it had quietly stopped doing it.

Four sites: the reveal, the accent, the revive panel, and `needsRegrouping` (which could not parse a blank statement and so handed every one its fail-open allowance — safe in direction, but the measurement was never made).

## ARENA — `47 + □ = 68 = 68`

The ribbon appended ` = answer` unless the prompt contained `?`. Two equals signs, the box still empty, the answer printed as though it were the total. `resonance-miss` uses that same line as **THE REVEAL**, so the garbling landed on the one frame meant to teach.

It now completes the sum in place — `47 + 21 = 68`, a sum a child can read, rather than `21` on its own.

## Audited and cleared (stating these explicitly, not by omission)

- **`runner`** — safe *by design*: unknown glyphs fall back to the `?` cell and `glyphIndex` never returns −1, which is the right picture for a blank. Unchanged.
- **`beam`, `counterweight`** — already fold the answer's own width into their column count, so a blank-first statement whose answer is wider than anything printed is still measured correctly. I suspected these under-measured and was wrong.
- **`pulse`** — splits on whitespace and renders tokens generically; glyph-agnostic.
- **`merge`** — its parser is its own stub generator, documented "for tests".
- **`balance`** — already correct, and the reference for the accepted set (`□`, `?`, `_`).
- No other pack parses a prompt string.

## Why now

PR #730 activates three further blank rows, two with the box **first** (`□ × 15 = 165`, `□ − 47 = 68`) — a shape nothing in the fleet has ever been served. These two should land in the same release.

## Verification

Node 24.18.0. stack **65/65** and arena **76/76**, five consecutive runs each; `tsc` clean. `statesAnswer` moved into its own module so it is testable without pulling `three` in behind `mount.ts`.

Three mutations, each caught by the assertion written for it:

| reverted | failure |
|---|---|
| `hud.ts` → `replace("?", …)` | `hud.ts is matching a literal "?" again — blank statements will render with an empty box` |
| `guard.ts` → `includes("?")` | `a blank statement is now MEASURED for regrouping, not waved through` |
| ribbon → `!includes("?")` | `a blank statement is COMPLETED IN PLACE…` + `no line ever carries two equals signs` |

The stack HUD assertion is a source-wiring check on purpose: every other test in that file exercises `blank.ts`, so reverting `hud.ts` alone would leave them all green while the reveal went back to an empty box. Same pattern `games/slice` uses.

## Known duplication

The blank character class now exists in `stack/src/blank.ts` and `arena/src/ribbon.ts` because packs do not share code. Two copies is tolerable; a third means it should become `packs/shared/game-prompt`. Noted in both files rather than done here.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb