### PR TITLE
chore(dynawalla): 0.3.6

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.5 → 0.3.6. One line.

- **#725 ARENA** — time to think at the top. Answer windows come off the cadence table's p90 at 10×, so `7 + 5` gets a minute and `34,801 ÷ 37` gets ten minutes, with `NO TIMER · USE PAPER` shown only on the hardest class. Speed is still rewarded, never enforced.
- **#730 curriculum** — the `ns`, `alg` and `frac` rungs written out end to end: 102 levels where there were 67, the graph 152 → 187, `CG10_BLOCKED_LEVELS` emptied, and three equality rows promoted now that COUNTERPOISE can build them.
- **#731 games** — the miss-reveal fills the blank in again. The curriculum writes `□`; MONUMENT and ARENA still looked for `?`, so a child who missed saw the card back with the box still empty, and ARENA's ribbon read `47 + □ = 68 = 68`. Live since 0.3.5, and #730 would have widened it to blank-first statements.
- **#726 docs** — MATH NINJA design round 2.

A main push does not release. The tag `dynawalla-v0.3.6` does, and I push it once this is on main.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb