### PR TITLE
fix(dynawalla/games/runner): derive every ink from the surface it lands on, and give the ship a warmer voice

### DIFF
--- a/dynawalla/games/runner/src/game/audio.test.ts
+++ b/dynawalla/games/runner/src/game/audio.test.ts
@@ -18,7 +18,212 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { ENGINE, engineAt } from "./audio.ts";
+import { Audio, ENGINE, engineAt } from "./audio.ts";
+
+/* -------------------------------------------------------------------------- */
+/* A fake AudioContext, so the GRAPH is under test and not just the record.    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Enough of Web Audio to build VOLTA's graph and read it back.
+ *
+ * Without this, every assertion below is a claim about a frozen object literal:
+ * `ENGINE.detuneCents > 0` passes perfectly well on a `buildEngine` that never
+ * applies the detune, and nothing at all covered the shimmer LFO — an oscillator
+ * connected to an AudioParam *adds* to that param's value, and a `GainNode`
+ * arrives with `gain` already at 1, so getting either wrong is silent and loud.
+ */
+type FakeParam = { value: number; readonly inputs: FakeNode[] } & Record<string, unknown>;
+type FakeNode = {
+  kind: string;
+  type?: string;
+  outputs: (FakeNode | FakeParam)[];
+  started: boolean;
+  stopped: boolean;
+  [k: string]: unknown;
+};
+
+function makeFakeContext(): { ctx: unknown; nodes: FakeNode[] } {
+  const nodes: FakeNode[] = [];
+  const param = (v: number): FakeParam => {
+    const p: FakeParam = {
+      value: v,
+      inputs: [],
+      setValueAtTime() {
+        return p;
+      },
+      linearRampToValueAtTime() {
+        return p;
+      },
+      exponentialRampToValueAtTime() {
+        return p;
+      },
+      setTargetAtTime(target: number) {
+        p.value = target;
+        return p;
+      },
+      cancelScheduledValues() {
+        return p;
+      },
+      setValueCurveAtTime() {
+        return p;
+      },
+    };
+    return p;
+  };
+  const node = (kind: string, extra: Record<string, unknown> = {}): FakeNode => {
+    const n: FakeNode = {
+      kind,
+      outputs: [],
+      started: false,
+      stopped: false,
+      connect(dest: FakeNode | FakeParam) {
+        n.outputs.push(dest);
+        if (dest && Array.isArray((dest as FakeParam).inputs)) (dest as FakeParam).inputs.push(n);
+        return dest;
+      },
+      disconnect() {},
+      start() {
+        n.started = true;
+      },
+      stop() {
+        n.stopped = true;
+      },
+      ...extra,
+    };
+    nodes.push(n);
+    return n;
+  };
+  const ctx = {
+    currentTime: 0,
+    sampleRate: 48000,
+    state: "running",
+    destination: node("destination"),
+    createGain: () => node("gain", { gain: param(1) }),
+    createOscillator: () =>
+      node("osc", { type: "sine", frequency: param(440), detune: param(0) }),
+    createBiquadFilter: () =>
+      node("biquad", { type: "lowpass", frequency: param(350), Q: param(1), gain: param(0) }),
+    createDelay: () => node("delay", { delayTime: param(0) }),
+    createWaveShaper: () => node("shaper", { curve: null, oversample: "none" }),
+    createDynamicsCompressor: () =>
+      node("comp", {
+        threshold: param(-24),
+        knee: param(30),
+        ratio: param(12),
+        attack: param(0.003),
+        release: param(0.25),
+      }),
+    createBufferSource: () => node("bufsrc", { buffer: null, loop: false }),
+    createBuffer: (_c: number, len: number) => ({
+      length: len,
+      getChannelData: () => new Float32Array(len),
+    }),
+    resume: () => Promise.resolve(),
+    suspend: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  };
+  return { ctx, nodes };
+}
+
+/** Build the real graph against the fake, and hand back every node in it. */
+function buildGraph(): { audio: Audio; nodes: FakeNode[] } {
+  const { ctx, nodes } = makeFakeContext();
+  const g = globalThis as unknown as { window?: unknown };
+  const hadWindow = "window" in g;
+  const prev = g.window;
+  g.window = { AudioContext: function (this: unknown) { return ctx; } };
+  try {
+    const audio = new Audio();
+    audio.start();
+    return { audio, nodes };
+  } finally {
+    if (hadWindow) g.window = prev;
+    else delete g.window;
+  }
+}
+
+const oscs = (nodes: FakeNode[]): FakeNode[] => nodes.filter((n) => n.kind === "osc");
+
+test("the graph the ship actually builds carries the detuned pair", () => {
+  // The claim `ENGINE.detuneCents > 0` cannot make on its own: that buildEngine
+  // applies it, to two oscillators, in opposite directions, on the same note.
+  const { nodes } = buildGraph();
+  const body = oscs(nodes).filter(
+    (o) => o.type === ENGINE.type && (o.detune as FakeParam).value !== 0,
+  );
+  assert.equal(body.length, 2, `expected two detuned ${ENGINE.type} oscillators`);
+  const cents = body.map((o) => (o.detune as FakeParam).value).sort((a, b) => a - b);
+  assert.deepEqual(cents, [-ENGINE.detuneCents / 2, ENGINE.detuneCents / 2]);
+  assert.equal((body[0].frequency as FakeParam).value, (body[1].frequency as FakeParam).value);
+  assert.equal((body[0].frequency as FakeParam).value, ENGINE.hz[0]);
+  for (const o of body) assert.ok(o.started, "a body oscillator was never started");
+  // No sawtooth anywhere in the bed. This is the assertion that would have
+  // caught a revert of the waveform in the graph rather than in the record.
+  assert.ok(
+    !oscs(nodes).some((o) => o.type === "sawtooth"),
+    "a sawtooth is back in the graph",
+  );
+});
+
+test("the body filter in the graph is the un-resonant one", () => {
+  const { nodes } = buildGraph();
+  const lowpass = nodes.filter(
+    (n) => n.kind === "biquad" && n.type === "lowpass" && (n.Q as FakeParam).value === ENGINE.q,
+  );
+  assert.equal(lowpass.length, 1, `no lowpass at Q ${ENGINE.q} in the graph`);
+  assert.equal((lowpass[0].frequency as FakeParam).value, ENGINE.cutoffHz[0]);
+  assert.ok(
+    !nodes.some((n) => n.kind === "biquad" && (n.Q as FakeParam).value >= 4),
+    "a filter with a sweepable resonant peak is back in the bed",
+  );
+});
+
+test("the shimmer LFO offsets its gain rather than replacing it", () => {
+  // An oscillator connected to an AudioParam ADDS to the param's intrinsic
+  // value. So the depth must be half the swing and the intrinsic value the other
+  // half, or the shimmer either clips negative (inverting the partial every
+  // cycle) or sits at a DC offset of 1 — which is the whole partial at full
+  // volume, permanently.
+  const { nodes } = buildGraph();
+  const lfo = oscs(nodes).find(
+    (o) => (o.frequency as FakeParam).value === ENGINE.shimmerLfoHz,
+  );
+  assert.ok(lfo, "there is no shimmer LFO in the graph");
+  const depth = lfo.outputs[0] as FakeNode;
+  assert.equal(depth.kind, "gain", "the LFO is wired straight at something, with no depth");
+  assert.equal((depth.gain as FakeParam).value, ENGINE.shimmerGain / 2);
+  const target = depth.outputs[0] as FakeParam;
+  assert.ok(target && Array.isArray(target.inputs), "the LFO depth is not connected to a param");
+  assert.equal(target.value, ENGINE.shimmerGain / 2, "the shimmer's intrinsic gain is not the offset");
+  // Therefore the partial swings 0..shimmerGain and never goes negative.
+  assert.ok(target.value - (depth.gain as FakeParam).value >= 0, "the shimmer inverts");
+  assert.ok(
+    target.value + (depth.gain as FakeParam).value <= ENGINE.shimmerGain + 1e-9,
+    "the shimmer overshoots its own budget",
+  );
+});
+
+test("nothing in the bed sums past the headroom the master expects", () => {
+  // Every static gain that meets `engGain`, at once. The old bed reached ~0.216
+  // at full speed; this must be materially under that and must not be able to
+  // clip the stage it feeds.
+  const worst =
+    (ENGINE.bodyGain + ENGINE.noiseGain + ENGINE.subGain + ENGINE.shimmerGain) *
+    ENGINE.gain[1];
+  assert.ok(worst < 0.216, `the bed peaks at ${worst.toFixed(3)}, which is not quieter`);
+  assert.ok(worst < 1, "the bed alone can clip");
+});
+
+test("every oscillator the bed starts is also stopped on dispose", () => {
+  const { audio, nodes } = buildGraph();
+  const started = oscs(nodes).filter((o) => o.started);
+  assert.ok(started.length >= 4, `only ${started.length} oscillators started`);
+  audio.dispose();
+  for (const o of started) {
+    assert.ok(o.stopped, "an oscillator survives dispose and keeps running after unmount");
+  }
+});
 
 /** The bed exactly as it shipped in 0.3.6, for the "quieter" claim to mean something. */
 const SHIPPED = {

--- a/dynawalla/games/runner/src/game/audio.test.ts
+++ b/dynawalla/games/runner/src/game/audio.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The ship's bed, held to the four things the founder asked it to be.
+ *
+ * "the sound effect of the ship could be better, maybe more space age .. it's
+ * sort of static and annoying like 4-bit motorcycle sound .. it could be more
+ * magical electrical .. maybe not so loud."
+ *
+ * Three of those four are measurable without listening, and the fourth — is it
+ * magical — is at least falsifiable in one direction: a single oscillator with
+ * no detune cannot beat, and a bed that does not beat is a drone. So this asserts
+ * the properties that made it a motorcycle, rather than asserting a waveform.
+ *
+ * There is no `AudioContext` here on purpose. `setDrive` reads every number it
+ * writes out of `ENGINE` via `engineAt`, so the curve this file measures is the
+ * curve the ship makes.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ENGINE, engineAt } from "./audio.ts";
+
+/** The bed exactly as it shipped in 0.3.6, for the "quieter" claim to mean something. */
+const SHIPPED = {
+  type: "sawtooth",
+  q: 7,
+  gain: (s: number) => 0.13 + s * 0.11,
+  windGain: (s: number) => 0.006 + s * 0.05,
+  noiseGain: 0.09,
+};
+
+const SPEEDS = [0, 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 1];
+
+test("the bed is quieter than the one the founder heard, at every speed", () => {
+  for (const s of SPEEDS) {
+    const now = engineAt(s, true).gain;
+    const was = SHIPPED.gain(s);
+    assert.ok(now < was, `at speed ${s} the bed is ${now}, and it shipped at ${was}`);
+    // Quieter, but still a bed — silence is not the fix and would take the sense
+    // of speed with it.
+    assert.ok(now > was * 0.4, `at speed ${s} the bed dropped to ${now}, which is a mute`);
+  }
+  for (const s of SPEEDS) {
+    assert.ok(
+      engineAt(s, true).windGain < SHIPPED.windGain(s),
+      `the wind band is not quieter at speed ${s}`,
+    );
+  }
+  assert.ok(ENGINE.noiseGain < SHIPPED.noiseGain / 2, "the grit is not at least halved");
+});
+
+test("it is not a two-stroke: no sawtooth, and no resonant peak to sweep", () => {
+  // The two things that made it read as an engine. A sawtooth's harmonics fall
+  // off at 1/n and a triangle's at 1/n², which is the entire difference between
+  // "motorcycle" and "warm"; and a Q of 7 is a ~17 dB peak being swept by the
+  // player's own speed, heard as a whine that follows them.
+  assert.notEqual(ENGINE.type, SHIPPED.type);
+  assert.equal(ENGINE.type, "triangle");
+  assert.ok(ENGINE.q < 1.5, `the body filter is at Q ${ENGINE.q}; anything resonant whines`);
+  assert.ok(ENGINE.q >= 0.5, "a Q below 0.5 is a filter doing nothing");
+  assert.ok(ENGINE.q < SHIPPED.q / 4);
+});
+
+test("it can beat, which is what makes it electrical rather than a drone", () => {
+  assert.ok(ENGINE.detuneCents > 0, "a single detune of zero is one oscillator");
+  // Wide enough to hear as movement, narrow enough to stay one note. At 58 Hz,
+  // 9 cents is a beat every ~3 seconds; a semitone would be a chord.
+  assert.ok(ENGINE.detuneCents >= 4 && ENGINE.detuneCents <= 25, `${ENGINE.detuneCents} cents`);
+  assert.ok(ENGINE.shimmerGain > 0, "the high partial is muted, so there is no space-age end");
+  // ...and the shimmer must stay under the body, or it is a whistle.
+  assert.ok(ENGINE.shimmerGain < ENGINE.gain[0] / 3, "the shimmer is louder than a shimmer");
+  assert.ok(ENGINE.shimmerLfoHz < 1, "the shimmer flutters rather than breathes");
+});
+
+test("speed still opens the bed, in every axis, monotonically", () => {
+  // The fix must not have flattened the thing that sells velocity.
+  let prev = engineAt(0, true);
+  for (const s of SPEEDS.slice(1)) {
+    const now = engineAt(s, true);
+    assert.ok(now.gain > prev.gain, `gain did not rise by ${s}`);
+    assert.ok(now.cutoff > prev.cutoff, `cutoff did not open by ${s}`);
+    assert.ok(now.hz > prev.hz, `pitch did not rise by ${s}`);
+    assert.ok(now.windGain > prev.windGain, `wind did not rise by ${s}`);
+    prev = now;
+  }
+  // A real range, not a rounding error: the ship at speed must be audibly a
+  // different machine from the ship at rest.
+  assert.ok(engineAt(1, true).cutoff > engineAt(0, true).cutoff * 3);
+  assert.ok(engineAt(1, true).gain > engineAt(0, true).gain * 1.5);
+});
+
+test("dying drops the bed to almost nothing and takes the wind with it", () => {
+  const dead = engineAt(1, false);
+  assert.equal(dead.windGain, 0);
+  assert.ok(dead.gain < engineAt(0, true).gain / 4, "the bed is still running after a crash");
+  assert.ok(dead.gain > 0, "the bed cut out entirely, which reads as a bug not a crash");
+});
+
+test("the sub stays a sub and the fundamental stays out of the harsh band", () => {
+  // 2-4 kHz is where the ear is most sensitive and where the old bed had a
+  // resonant peak parked at full speed. The fundamental never goes near it.
+  assert.ok(engineAt(1, true).hz < 120, "the fundamental climbed into the midrange");
+  for (const s of SPEEDS) {
+    const e = engineAt(s, true);
+    assert.ok(e.subHz < e.hz, `at speed ${s} the sub is above the fundamental`);
+    assert.ok(e.subHz >= 20, "the sub dropped below hearing and is just cone excursion");
+  }
+});

--- a/dynawalla/games/runner/src/game/audio.ts
+++ b/dynawalla/games/runner/src/game/audio.ts
@@ -63,6 +63,8 @@ const SCALES: Record<ScaleName, { root: number; degrees: number[] }> = {
 export const ENGINE = {
   /** The two body oscillators. Triangle, not sawtooth: 1/n² and not 1/n. */
   type: "triangle" as OscillatorType,
+  /** The pair's shared trim into the body filter. */
+  bodyGain: 0.3,
   /** Cents between the pair. Wide enough to beat, narrow enough to stay one note. */
   detuneCents: 9,
   /** Fundamental, in Hz, at rest and at terminal velocity. */
@@ -231,7 +233,7 @@ export class Audio {
     // The pair. Same note, `detuneCents` apart, so they drift in and out of
     // phase over a couple of seconds — an electrical shimmer rather than a tone.
     const bodyG = ctx.createGain();
-    bodyG.gain.value = 0.3;
+    bodyG.gain.value = ENGINE.bodyGain;
     bodyG.connect(this.engFilter);
     this.engOsc = ctx.createOscillator();
     this.engOsc.type = ENGINE.type;
@@ -262,9 +264,11 @@ export class Audio {
     this.engShimmer.type = "sine";
     this.engShimmer.frequency.value = ENGINE.hz[0] * ENGINE.shimmerMul;
     const shG = ctx.createGain();
-    // Every GainNode arrives at 1. The LFO writes an offset onto this, so it
-    // starts at zero and the LFO's own depth is what it swings by.
-    shG.gain.value = 0;
+    // Every GainNode arrives at 1, and an oscillator connected to an AudioParam
+    // ADDS to that param rather than driving it — so the swing is split in two:
+    // half is the param's own value and half is the LFO's depth. The partial
+    // then breathes across [0, shimmerGain] and never inverts.
+    shG.gain.value = ENGINE.shimmerGain / 2;
     this.engShimmer.connect(shG);
     shG.connect(this.engGain);
     this.engShimmer.start();
@@ -275,7 +279,6 @@ export class Audio {
     lfoDepth.gain.value = ENGINE.shimmerGain / 2;
     this.engShimmerLfo.connect(lfoDepth);
     lfoDepth.connect(shG.gain);
-    shG.gain.value = ENGINE.shimmerGain / 2;
     this.engShimmerLfo.start();
 
     this.engNoise = ctx.createBufferSource();

--- a/dynawalla/games/runner/src/game/audio.ts
+++ b/dynawalla/games/runner/src/game/audio.ts
@@ -28,6 +28,88 @@ const SCALES: Record<ScaleName, { root: number; degrees: number[] }> = {
   void: { root: 60, degrees: [0, 2, 4, 6, 7, 9, 11, 12, 14, 16, 18, 19] },
 };
 
+/**
+ * The ship's voice.
+ *
+ * ── what it was ─────────────────────────────────────────────────────────────
+ *
+ * A sawtooth at 52-86 Hz and a band of white noise, both into one lowpass with
+ * **Q = 7**. That is not a spaceship; it is the standard recipe for a two-stroke
+ * engine, and the founder heard it as exactly that — "static and annoying like a
+ * 4-bit motorcycle". Two things did it. A sawtooth has every harmonic at 1/n, so
+ * at 58 Hz there is significant energy right through the ear's most sensitive
+ * band; and a Q of 7 puts a 17 dB resonant peak on a filter that is being swept
+ * by the player's own speed, which is heard as a nasal whine that tracks them.
+ *
+ * ── what it is ──────────────────────────────────────────────────────────────
+ *
+ * Two triangles a few cents apart. A triangle's harmonics fall off at 1/n², so
+ * it is warm at the same fundamental, and the detune makes the pair beat slowly
+ * against each other — that beating is the "magical electrical" the founder
+ * asked for, and it costs one extra oscillator. The filter's resonance comes
+ * down to just above flat so the sweep reads as opening rather than whining, and
+ * a quiet high partial drifts over the top for the space-age end of it. The
+ * noise stays, because a bed with no noise at all sounds synthetic, but at a
+ * quarter of what it was.
+ *
+ * And it is quieter. `ENGINE.gain` is a little over half the old curve at every
+ * speed, and the wind band roughly half — the founder asked for that too, and a
+ * bed is the one sound in a game that is never not playing.
+ *
+ * Exported as data rather than buried in `setDrive` so `audio.test.ts` can hold
+ * it to those claims without a real `AudioContext`: quieter than the old curve
+ * everywhere, no sawtooth, resonance under the whine threshold, detune non-zero.
+ */
+export const ENGINE = {
+  /** The two body oscillators. Triangle, not sawtooth: 1/n² and not 1/n. */
+  type: "triangle" as OscillatorType,
+  /** Cents between the pair. Wide enough to beat, narrow enough to stay one note. */
+  detuneCents: 9,
+  /** Fundamental, in Hz, at rest and at terminal velocity. */
+  hz: [52, 86] as const,
+  /** The sub sine, an octave below and a touch flat of it. */
+  subHz: [26, 41] as const,
+  subGain: 0.38,
+  /** Body filter. Q was 7 — a 17 dB peak swept by the player. */
+  cutoffHz: [420, 1900] as const,
+  q: 1.1,
+  /** Noise into the body filter. Air, not grit. */
+  noiseGain: 0.022,
+  /** The high partial that drifts over the top, as a multiple of the fundamental. */
+  shimmerMul: 6,
+  shimmerGain: 0.014,
+  /** How fast the shimmer breathes, in Hz. Slow enough to be weather. */
+  shimmerLfoHz: 0.19,
+  /** Bed level at rest and at terminal velocity. Was 0.13 and 0.24. */
+  gain: [0.075, 0.13] as const,
+  /** Level while dead. */
+  deadGain: 0.014,
+  /** The wind band. Was 0.006..0.056 at 700..2600 Hz. */
+  windGain: [0.004, 0.032] as const,
+  windHz: [520, 1670] as const,
+} as const;
+
+/** Everything the engine bed should be doing at `speed01`. */
+export function engineAt(speed01: number, alive: boolean): {
+  gain: number;
+  cutoff: number;
+  hz: number;
+  subHz: number;
+  windGain: number;
+  windHz: number;
+} {
+  const s = Math.max(0, Math.min(1, speed01));
+  const at = ([lo, hi]: readonly [number, number]): number => lo + (hi - lo) * s;
+  return {
+    gain: alive ? at(ENGINE.gain) : ENGINE.deadGain,
+    cutoff: at(ENGINE.cutoffHz),
+    hz: at(ENGINE.hz),
+    subHz: at(ENGINE.subHz),
+    windGain: alive ? at(ENGINE.windGain) : 0,
+    windHz: at(ENGINE.windHz),
+  };
+}
+
 export class Audio {
   private ctx: AudioContext | null = null;
   private master!: GainNode;
@@ -40,7 +122,11 @@ export class Audio {
 
   // engine bed
   private engOsc: OscillatorNode | null = null;
+  /** The detuned twin. The beat between the two is the whole character. */
+  private engOsc2: OscillatorNode | null = null;
   private engSub: OscillatorNode | null = null;
+  private engShimmer: OscillatorNode | null = null;
+  private engShimmerLfo: OscillatorNode | null = null;
   private engNoise: AudioBufferSourceNode | null = null;
   private engFilter!: BiquadFilterNode;
   private engGain!: GainNode;
@@ -138,33 +224,65 @@ export class Audio {
 
     this.engFilter = ctx.createBiquadFilter();
     this.engFilter.type = "lowpass";
-    this.engFilter.frequency.value = 420;
-    this.engFilter.Q.value = 7;
+    this.engFilter.frequency.value = ENGINE.cutoffHz[0];
+    this.engFilter.Q.value = ENGINE.q;
     this.engFilter.connect(this.engGain);
 
+    // The pair. Same note, `detuneCents` apart, so they drift in and out of
+    // phase over a couple of seconds — an electrical shimmer rather than a tone.
+    const bodyG = ctx.createGain();
+    bodyG.gain.value = 0.3;
+    bodyG.connect(this.engFilter);
     this.engOsc = ctx.createOscillator();
-    this.engOsc.type = "sawtooth";
-    this.engOsc.frequency.value = 58;
-    const oscG = ctx.createGain();
-    oscG.gain.value = 0.32;
-    this.engOsc.connect(oscG);
-    oscG.connect(this.engFilter);
+    this.engOsc.type = ENGINE.type;
+    this.engOsc.frequency.value = ENGINE.hz[0];
+    this.engOsc.detune.value = -ENGINE.detuneCents / 2;
+    this.engOsc.connect(bodyG);
     this.engOsc.start();
+    this.engOsc2 = ctx.createOscillator();
+    this.engOsc2.type = ENGINE.type;
+    this.engOsc2.frequency.value = ENGINE.hz[0];
+    this.engOsc2.detune.value = ENGINE.detuneCents / 2;
+    this.engOsc2.connect(bodyG);
+    this.engOsc2.start();
 
     this.engSub = ctx.createOscillator();
     this.engSub.type = "sine";
-    this.engSub.frequency.value = 29;
+    this.engSub.frequency.value = ENGINE.subHz[0];
     const subG = ctx.createGain();
-    subG.gain.value = 0.5;
+    subG.gain.value = ENGINE.subGain;
     this.engSub.connect(subG);
     subG.connect(this.engGain);
     this.engSub.start();
+
+    // A high partial that breathes. This is the space-age end of it, and it is
+    // deliberately below the noise floor of anything else in the mix — it should
+    // be noticeable only when it stops.
+    this.engShimmer = ctx.createOscillator();
+    this.engShimmer.type = "sine";
+    this.engShimmer.frequency.value = ENGINE.hz[0] * ENGINE.shimmerMul;
+    const shG = ctx.createGain();
+    // Every GainNode arrives at 1. The LFO writes an offset onto this, so it
+    // starts at zero and the LFO's own depth is what it swings by.
+    shG.gain.value = 0;
+    this.engShimmer.connect(shG);
+    shG.connect(this.engGain);
+    this.engShimmer.start();
+    this.engShimmerLfo = ctx.createOscillator();
+    this.engShimmerLfo.type = "sine";
+    this.engShimmerLfo.frequency.value = ENGINE.shimmerLfoHz;
+    const lfoDepth = ctx.createGain();
+    lfoDepth.gain.value = ENGINE.shimmerGain / 2;
+    this.engShimmerLfo.connect(lfoDepth);
+    lfoDepth.connect(shG.gain);
+    shG.gain.value = ENGINE.shimmerGain / 2;
+    this.engShimmerLfo.start();
 
     this.engNoise = ctx.createBufferSource();
     this.engNoise.buffer = this.noiseBuf;
     this.engNoise.loop = true;
     const nG = ctx.createGain();
-    nG.gain.value = 0.09;
+    nG.gain.value = ENGINE.noiseGain;
     this.engNoise.connect(nG);
     nG.connect(this.engFilter);
     this.engNoise.start();
@@ -175,7 +293,7 @@ export class Audio {
     this.windGain.connect(this.master);
     this.windFilter = ctx.createBiquadFilter();
     this.windFilter.type = "bandpass";
-    this.windFilter.frequency.value = 900;
+    this.windFilter.frequency.value = ENGINE.windHz[0];
     this.windFilter.Q.value = 0.7;
     this.windFilter.connect(this.windGain);
     const wSrc = ctx.createBufferSource();
@@ -194,7 +312,10 @@ export class Audio {
   dispose(): void {
     try {
       this.engOsc?.stop();
+      this.engOsc2?.stop();
       this.engSub?.stop();
+      this.engShimmer?.stop();
+      this.engShimmerLfo?.stop();
       this.engNoise?.stop();
       void this.ctx?.close();
     } catch {
@@ -217,13 +338,17 @@ export class Audio {
   setDrive(speed01: number, alive: boolean): void {
     if (!this.ctx) return;
     const t = this.ctx.currentTime;
-    const s = Math.max(0, Math.min(1, speed01));
-    this.engGain.gain.setTargetAtTime(alive ? 0.13 + s * 0.11 : 0.02, t, 0.25);
-    this.engFilter.frequency.setTargetAtTime(300 + s * 1150, t, 0.3);
-    this.engOsc?.frequency.setTargetAtTime(52 + s * 34, t, 0.4);
-    this.engSub?.frequency.setTargetAtTime(26 + s * 15, t, 0.4);
-    this.windGain.gain.setTargetAtTime(alive ? 0.006 + s * 0.05 : 0, t, 0.3);
-    this.windFilter.frequency.setTargetAtTime(700 + s * 1900, t, 0.3);
+    // Every number here is `ENGINE`'s, so `audio.test.ts` is measuring the bed
+    // the ship actually makes rather than a second copy of the curve.
+    const e = engineAt(speed01, alive);
+    this.engGain.gain.setTargetAtTime(e.gain, t, 0.25);
+    this.engFilter.frequency.setTargetAtTime(e.cutoff, t, 0.3);
+    this.engOsc?.frequency.setTargetAtTime(e.hz, t, 0.4);
+    this.engOsc2?.frequency.setTargetAtTime(e.hz, t, 0.4);
+    this.engShimmer?.frequency.setTargetAtTime(e.hz * ENGINE.shimmerMul, t, 0.5);
+    this.engSub?.frequency.setTargetAtTime(e.subHz, t, 0.4);
+    this.windGain.gain.setTargetAtTime(e.windGain, t, 0.3);
+    this.windFilter.frequency.setTargetAtTime(e.windHz, t, 0.3);
   }
 
   setScale(name: ScaleName, bpm: number): void {

--- a/dynawalla/games/runner/src/game/chrome.test.ts
+++ b/dynawalla/games/runner/src/game/chrome.test.ts
@@ -337,7 +337,7 @@ test("hudVars fills in every custom property the stylesheet asks for", () => {
   // `contrast.ts` — geometry here, ink there, and between them every `var()` in
   // the sheet has an author-supplied value. `--vt-accent` is the live biome
   // colour, written on the root by `mount.ts` on every biome change.
-  const inks = inkVars(0x071230, 0x070a18, 0x37ecff);
+  const inks = inkVars(0x02030c, 0x071230, 0x070a18, 0x37ecff);
   const setElsewhere = new Set(["--vt-accent", ...Object.keys(inks)]);
   for (const m of HUD_CSS.matchAll(/var\((--vt-[a-z-]+)/g)) {
     const name = m[1] ?? "";

--- a/dynawalla/games/runner/src/game/chrome.test.ts
+++ b/dynawalla/games/runner/src/game/chrome.test.ts
@@ -44,6 +44,7 @@ import {
   type StageEl,
 } from "./chrome.ts";
 import { HUD_CSS } from "./hud.ts";
+import { inkVars } from "./contrast.ts";
 import { BAND, fullFrame, payoffEdge, popupEdge, readBand, type GateGeom } from "./readband.ts";
 import { INK, TRACK } from "./glyphs.ts";
 
@@ -332,13 +333,20 @@ test("hudVars fills in every custom property the stylesheet asks for", () => {
   // silently falls back to its default, which is how a HUD laid out for a phone
   // with no insets would keep painting on one that has them.
   const vars = hudVars(360, 780, { top: 24, right: 0, bottom: 0, left: 0 });
-  // `--vt-accent` is the live biome colour, written on the root by `mount.ts` on
-  // every biome change. It is not geometry and does not belong in `hudVars`.
-  const setElsewhere = new Set(["--vt-accent"]);
+  // The colours are the other half of the same contract and are owned by
+  // `contrast.ts` — geometry here, ink there, and between them every `var()` in
+  // the sheet has an author-supplied value. `--vt-accent` is the live biome
+  // colour, written on the root by `mount.ts` on every biome change.
+  const inks = inkVars(0x071230, 0x070a18, 0x37ecff);
+  const setElsewhere = new Set(["--vt-accent", ...Object.keys(inks)]);
   for (const m of HUD_CSS.matchAll(/var\((--vt-[a-z-]+)/g)) {
     const name = m[1] ?? "";
     if (setElsewhere.has(name)) continue;
     assert.ok(name in vars, `the stylesheet reads ${name} and hudVars never sets it`);
+  }
+  // ...and neither module may quietly claim the other's property.
+  for (const name of Object.keys(vars)) {
+    assert.ok(!(name in inks), `${name} is set by BOTH hudVars and inkVars; one of them loses`);
   }
   for (const [name, value] of Object.entries(vars)) {
     assert.ok(/^-?\d+(\.\d+)?px$/.test(value), `${name} is "${value}", which is not a length`);

--- a/dynawalla/games/runner/src/game/chrome.ts
+++ b/dynawalla/games/runner/src/game/chrome.ts
@@ -190,11 +190,17 @@ const PROMPT_W = 300;
  * Room above the voltage bar for its own label.
  *
  * An *allowance*, not a mirror: the label is `font-size:clamp(8px,1.5vw,11px)`
- * five pixels above the bar, so 16px is the most it ever needs and 18 is what it
- * gets. Erring upward is the safe direction — it makes the box this file reports
- * slightly larger than the ink, so every clearance assertion is conservative.
+ * five pixels above the bar, inside 1px of padding on a bed of its own — so 18px
+ * is the most it ever needs and 20 is what it gets. Erring upward is the safe
+ * direction: it makes the box this file reports slightly larger than the ink, so
+ * every clearance assertion is conservative.
+ *
+ * The bed is why the padding is here at all. In landscape this label is out over
+ * the OCEAN rather than the deck, and in THE BLEACH the ocean is bone while the
+ * deck is near-black — one ink cannot clear both, so it is given a backdrop it
+ * can be derived against. See `contrast.ts`.
  */
-const VOLT_LABEL_H = 18;
+const VOLT_LABEL_H = 20;
 
 /**
  * Every HUD box a child reads or touches, in CSS pixels.

--- a/dynawalla/games/runner/src/game/contrast.test.ts
+++ b/dynawalla/games/runner/src/game/contrast.test.ts
@@ -22,6 +22,9 @@ import { biomeAt } from "./biomes.ts";
 import {
   AA,
   INK_DARK,
+  INK_LIGHT,
+  minContrast,
+  toward,
   LANE_FACE,
   PLAIN_STOPS,
   REVIVE_CONTENT_TOP,
@@ -37,6 +40,8 @@ import {
   inkFor,
   inkVars,
   laneBackdrops,
+  oceanFrom,
+  skyBackdrops,
   luma,
   mix,
   over,
@@ -103,7 +108,7 @@ test("toward keeps as much of the hue as clearing the bar allows", () => {
   // the way to white — the RECHARGE label should still read as the biome.
   const bg = 0x21242d;
   const dim = 0x2f4f7f;
-  const fixed = inkFor(0xfdfaf2, 0x0b0b0d, dim).accentOnVeil;
+  const fixed = inkFor(0xe9e3d4, 0xfdfaf2, 0x0b0b0d, dim).accentOnVeil;
   assert.ok(contrast(fixed, bg) >= AA || luma(fixed) >= luma(dim));
   assert.notEqual(fixed, 0xffffff, "correction jumped straight to the pole");
 });
@@ -116,10 +121,19 @@ test("toward keeps as much of the hue as clearing the bar allows", () => {
 const LAPS = 8;
 const BIOMES = 4 * LAPS;
 
-/** The blends a crossing actually puts on screen, including the endpoints. */
-const CROSSFADE = [0, 0.25, 0.5, 0.75, 1];
+/**
+ * The blends a crossing actually puts on screen, including the endpoints.
+ *
+ * Eleven points and not five. `mount.ts` eases the mix with `easeOutCubic`, so
+ * the interesting region — where a dark world and a bone world are averaged into
+ * a mid grey and the right ink flips from one pole to the other — is a narrow
+ * band around 0.45, and a five-point grid steps straight over it. A crossing is
+ * about 1.6s and this band is roughly 130ms of it, which is 130ms in which the
+ * biggest text on screen was picking the wrong pole.
+ */
+const CROSSFADE = [0, 0.1, 0.2, 0.3, 0.4, 0.45, 0.5, 0.6, 0.7, 0.85, 1];
 
-type World = { label: string; sky: number; deck: number; accent: number };
+type World = { label: string; skyTop: number; sky: number; deck: number; accent: number };
 
 /**
  * Every world the generator can produce, discrete and mid-crossing.
@@ -135,6 +149,7 @@ function worlds(): World[] {
     for (const m of CROSSFADE) {
       out.push({
         label: m === 0 ? a.name : `${a.name} -> ${b.name} @${m}`,
+        skyTop: mix(a.skyTop, b.skyTop, m),
         sky: mix(a.skyBot, b.skyBot, m),
         deck: mix(a.deck, b.deck, m),
         accent: mix(a.accent, b.accent, m),
@@ -148,7 +163,7 @@ const WORLDS = worlds();
 
 test("the world list is the real generator and is not trivially small", () => {
   assert.equal(WORLDS.length, BIOMES * CROSSFADE.length);
-  assert.ok(WORLDS.length >= 160, `only ${WORLDS.length} worlds — this is a spot check`);
+  assert.ok(WORLDS.length >= 300, `only ${WORLDS.length} worlds — this is a spot check`);
   // A guard on the guard: if `biomeAt` ever stopped rotating, every lap would be
   // identical and this whole file would be testing four worlds while claiming
   // thirty-two.
@@ -166,38 +181,57 @@ test("the world list is the real generator and is not trivially small", () => {
  * This is the table the whole file turns on, so each entry names the surface in
  * the terms a person debugging a screenshot would use.
  */
-function surfaces(w: World): { what: string; ink: number; bgs: number[] }[] {
-  const k = inkFor(w.sky, w.deck, w.accent);
+/**
+ * `soft` marks an ink that is deliberately NOT the most readable colour
+ * available — the quiet labels, and the accent label that keeps its hue. They
+ * still have to clear 4.5:1; they just cannot be held to "no worse than plain
+ * white or plain black", because being worse than that on purpose is the point.
+ */
+function surfaces(
+  w: World,
+): { what: string; ink: number; bgs: number[]; target?: number; soft?: boolean }[] {
+  const k = inkFor(w.skyTop, w.sky, w.deck, w.accent);
+  // Everything along the bottom edge is bedded, and the bed is what the ink is
+  // derived against — the raw deck and the raw ocean are behind it, not under
+  // the glyphs.
+  const bedded = (c: number): number => over(VOLT_BED, VOLT_BED_A, c);
+  const deckBgs = [bedded(w.deck), bedded(oceanFrom(w.sky)), bedded(oceanFrom(w.skyTop))];
   return [
-    { what: "the prompt, score and surge, on the sky", ink: k.sky, bgs: [w.sky] },
-    { what: "SCORE / SURGE, tracked and quiet, on the sky", ink: k.skyDim, bgs: [w.sky] },
+    // The sky-band text is stroked, so its real backdrop is the halo. Against a
+    // mid-grey sky no flat ink clears 4.5:1 at all — the glyph brings its own
+    // ground instead of arguing with the world.
+    { what: "the prompt, score and surge, against their own halo", ink: k.sky, bgs: [k.halo] },
+    { what: "SCORE / SURGE, quiet, against their own halo", ink: k.skyDim, bgs: [k.halo], soft: true },
+
+    { what: "the voltage readout, on its bed over deck or ocean", ink: k.deck, bgs: deckBgs },
+    { what: "the voltage fill, on its bed", ink: k.voltFill, bgs: deckBgs },
     {
-      what: "the voltage readout, on the deck",
-      ink: k.deck,
-      bgs: [w.deck, over(VOLT_BED, VOLT_BED_A, w.deck)],
+      what: "the recharge question, on the veil",
+      ink: k.veil,
+      bgs: [...reviveBackdrops(w.sky), ...reviveBackdrops(w.skyTop)],
     },
-    {
-      what: "the voltage fill, on its bed",
-      ink: k.voltFill,
-      bgs: [over(VOLT_BED, VOLT_BED_A, w.deck)],
-    },
-    { what: "the recharge question, on the veil", ink: k.veil, bgs: reviveBackdrops(w.sky) },
     { what: "the start and run-over veils", ink: k.veil, bgs: plainBackdrops(w.sky) },
-    {
-      what: "the VOLTAGE label, quiet, on the deck",
-      ink: k.deckDim,
-      bgs: [w.deck, over(VOLT_BED, VOLT_BED_A, w.deck)],
-    },
+    { what: "the VOLTAGE label, quiet, on its bed", ink: k.deckDim, bgs: deckBgs, soft: true },
     {
       what: "the recharge counter and the start hint, quiet, on the veil",
+      soft: true,
       ink: k.veilDim,
-      bgs: [...reviveBackdrops(w.sky), ...plainBackdrops(w.sky)],
+      bgs: [...reviveBackdrops(w.sky), ...plainBackdrops(w.sky), ...reviveBackdrops(w.skyTop)],
     },
-    { what: "a recharge lane's numeral, on the lane face", ink: k.lane, bgs: laneBackdrops(w.sky) },
+    {
+      what: "a recharge lane's numeral, on the lane face",
+      ink: k.lane,
+      bgs: [...laneBackdrops(w.sky), ...laneBackdrops(w.skyTop)],
+    },
     { what: "the chosen lane's numeral, on the accent fill", ink: k.onAccent, bgs: [w.accent] },
     { what: "the RUN button's label, on a fill of the veil ink", ink: k.onVeilInk, bgs: [k.veil] },
     { what: "a pressed tool's glyph, on a fill of the deck ink", ink: k.onDeckInk, bgs: [k.deck] },
-    { what: "the RECHARGE label, accent-hued, on the veil", ink: k.accentOnVeil, bgs: reviveBackdrops(w.sky) },
+    {
+      what: "the RECHARGE label, accent-hued, on the veil",
+      soft: true,
+      ink: k.accentOnVeil,
+      bgs: [...reviveBackdrops(w.sky), ...reviveBackdrops(w.skyTop)],
+    },
   ];
 }
 
@@ -208,10 +242,11 @@ test("every ink clears WCAG AA in every world VOLTA can generate", () => {
     for (const s of surfaces(w)) {
       for (const bg of s.bgs) {
         checks++;
+        const bar = s.target ?? AA;
         const r = contrast(s.ink, bg);
-        if (r < AA) {
+        if (r < bar) {
           failures.push(
-            `${w.label}: ${s.what} — ${hex(s.ink)} on ${hex(bg)} is ${r.toFixed(2)}:1, under ${AA}:1`,
+            `${w.label}: ${s.what} — ${hex(s.ink)} on ${hex(bg)} is ${r.toFixed(2)}:1, under ${bar}:1`,
           );
         }
       }
@@ -221,12 +256,140 @@ test("every ink clears WCAG AA in every world VOLTA can generate", () => {
   assert.deepEqual(failures.slice(0, 12), [], `${failures.length} of ${checks} surfaces are illegible`);
 });
 
+test("toward tries BOTH poles before giving up", () => {
+  // It used to choose the pole by `luma(ink) >= luma(bgs[0])` and return it
+  // unexamined. On any ink whose backgrounds straddle mid grey that is a coin
+  // toss, and it loses about one time in six. This is one of the losses.
+  const ink = 0x089828;
+  const bg = 0x9d6f9a;
+  const out = toward(ink, [bg]);
+  assert.ok(
+    contrast(out, bg) >= AA,
+    `toward(${hex(ink)}, [${hex(bg)}]) returned ${hex(out)} at ${contrast(out, bg).toFixed(2)}:1 — ` +
+      `the other pole reaches ${contrast(0x000000, bg).toFixed(2)}:1`,
+  );
+  // And it must still prefer the NEARER pole when the nearer pole works — and
+  // move only as far as it has to, or the accent label stops looking like the
+  // accent. Lifted toward white, not all the way to it.
+  const easy = toward(0x2a2a2a, [0x000000]);
+  assert.ok(luma(easy) > luma(0x2a2a2a), "it went the wrong way on an easy case");
+  assert.ok(contrast(easy, 0x000000) >= AA);
+  assert.notEqual(easy, 0xffffff, "it overshot to the pole on a case with room to spare");
+});
+
+test("every derived ink is at least as good as either house ink would have been", () => {
+  // The assertion that makes the backdrop MODEL load-bearing rather than
+  // decorative. Deriving from the wrong backdrop — the sky's bottom instead of
+  // the whole band, or a raw deck instead of the bed that is actually painted —
+  // does not usually produce an unreadable colour; it produces a colour that is
+  // beaten by simply picking the better of white and black. That is the shape of
+  // the bug, so that is the shape of the test.
+  const EPS = 1e-9;
+  for (const w of WORLDS) {
+    for (const s of surfaces(w)) {
+      if (s.soft || s.bgs.length === 0) continue;
+      const got = minContrast(s.ink, s.bgs);
+      for (const house of [INK_LIGHT, INK_DARK]) {
+        assert.ok(
+          got + EPS >= minContrast(house, s.bgs),
+          `${w.label}: ${s.what} — derived ${hex(s.ink)} manages ${got.toFixed(2)}:1, but plain ` +
+            `${hex(house)} manages ${minContrast(house, s.bgs).toFixed(2)}:1. The ink is being ` +
+            `derived against a backdrop it does not land on.`,
+        );
+      }
+    }
+  }
+});
+
+test("the bed under the bottom furniture is required, not decorative", () => {
+  // Standing proof that removing it cannot be right: there is a world where the
+  // deck and the ocean are so far apart that NO ink clears both, and the bottom
+  // HUD crosses both of them because the deck is only DECK_HALF metres wide.
+  const bleach = WORLDS.find((w) => luma(w.sky) > 0.7);
+  assert.ok(bleach, "no bone world in the set");
+  const raw = [bleach.deck, oceanFrom(bleach.sky)];
+  assert.ok(
+    minContrast(readableInk(raw), raw) < AA,
+    "the deck and the ocean no longer conflict, so this test proves nothing",
+  );
+  const bed = [over(VOLT_BED, VOLT_BED_A, bleach.deck), over(VOLT_BED, VOLT_BED_A, oceanFrom(bleach.sky))];
+  assert.ok(minContrast(readableInk(bed), bed) >= AA, "the bed is not opaque enough to fix it");
+  // ...and the bed has to actually be painted on every one of them.
+  const rules = new Map(rulesOf(HUD_CSS).map((r) => [r.prelude, r.body]));
+  const bedCss = `rgba(${(VOLT_BED >> 16) & 255},${(VOLT_BED >> 8) & 255},${VOLT_BED & 255},${VOLT_BED_A})`;
+  for (const sel of [".vt-volt", ".vt-volt-label", ".vt-perf"]) {
+    const body = rules.get(sel);
+    assert.ok(body !== undefined, `${sel} left the stylesheet; this test is measuring nothing`);
+    assert.ok(body.includes(bedCss), `${sel} has no bed, so its ink is derived against a lie`);
+  }
+});
+
+test("the sky-band text is readable either on the sky or on its own halo", () => {
+  // Two ways to be legible on the sky, and every world must have at least one.
+  //
+  //   - the ink clears 4.5:1 against the sky directly (every dark biome: pale ink
+  //     on a near-black sky is 18:1 and the halo is never noticed), or
+  //   - the halo clears 3:1 against the sky, so the stroke is a visible ground
+  //     and the ink is measured against THAT instead.
+  //
+  // Only the second saves the mid-crossing grey, where the sky defeats every flat
+  // ink there is. Requiring both would fail every dark world for no reason and
+  // requiring neither is what the first draft of this file did.
+  for (const w of WORLDS) {
+    const k = inkFor(w.skyTop, w.sky, w.deck, w.accent);
+    const skyBgs = skyBackdrops(w.skyTop, w.sky);
+    // The halo makes the sky ink hard to get catastrophically wrong, which is
+    // exactly why the CHOICE still has to be checked on its own terms: deriving
+    // it from `skyBot` alone picks the dark pole against a backdrop where the
+    // light one is 30% better, and the halo quietly covers for it.
+    for (const house of [INK_LIGHT, INK_DARK]) {
+      assert.ok(
+        minContrast(k.sky, skyBgs) + 1e-9 >= minContrast(house, skyBgs),
+        `${w.label}: the sky ink ${hex(k.sky)} manages ${minContrast(k.sky, skyBgs).toFixed(2)}:1 ` +
+          `across the sky band, but plain ${hex(house)} manages ` +
+          `${minContrast(house, skyBgs).toFixed(2)}:1 — the band is not being sampled`,
+      );
+    }
+    assert.ok(
+      contrast(k.sky, k.halo) >= AA,
+      `${w.label}: the ink ${hex(k.sky)} does not even clear its own halo ${hex(k.halo)}`,
+    );
+    for (const bg of skyBgs) {
+      const onSky = contrast(k.sky, bg);
+      const haloOnSky = contrast(k.halo, bg);
+      assert.ok(
+        onSky >= AA || haloOnSky >= 3,
+        `${w.label}: ink ${hex(k.sky)} is ${onSky.toFixed(2)}:1 on ${hex(bg)} and its halo ` +
+          `${hex(k.halo)} is only ${haloOnSky.toFixed(2)}:1 — neither the word nor its ground reads`,
+      );
+    }
+  }
+});
+
+test("the sky-band text is stroked, or the halo is a variable nothing uses", () => {
+  // The halo only works because `paint-order: stroke fill` puts it BEHIND the
+  // fill. Without the paint-order it is painted over the glyph and eats it.
+  const rules = new Map(rulesOf(HUD_CSS).map((r) => [r.prelude, r.body]));
+  for (const sel of [".vt-prompt-text", ".vt-score", ".vt-surge-n", ".vt-label", ".vt-banner"]) {
+    const body = rules.get(sel);
+    assert.ok(body !== undefined, `${sel} left the stylesheet; this test is measuring nothing`);
+    assert.ok(
+      body.includes("var(--vt-halo-sky"),
+      `${sel} is not stroked with the derived halo`,
+    );
+    assert.ok(
+      /paint-order:\s*stroke fill/.test(body),
+      `${sel} strokes without paint-order, so the stroke is painted OVER the glyph`,
+    );
+  }
+});
+
 test("the recharge gate specifically — the screen the founder photographed", () => {
   // Stated separately from the sweep above so that a regression on this one
   // screen cannot hide inside a general failure count, and so the failure
   // message names the gate.
   for (const w of WORLDS) {
-    const k = inkFor(w.sky, w.deck, w.accent);
+    const k = inkFor(w.skyTop, w.sky, w.deck, w.accent);
     for (const bg of reviveBackdrops(w.sky)) {
       assert.ok(
         contrast(k.veil, bg) >= AA,
@@ -259,7 +422,7 @@ test("the three colours that shipped are each provably illegible", () => {
   const wasVeil = contrast(INK_DARK, veilBottom);
   assert.ok(wasVeil < 2, `the shipped recharge ink was ${wasVeil.toFixed(2)}:1, expected under 2:1`);
   assert.ok(
-    contrast(inkFor(bleach.skyBot, bleach.deck, bleach.accent).veil, veilBottom) >= AA,
+    contrast(inkFor(bleach.skyTop, bleach.skyBot, bleach.deck, bleach.accent).veil, veilBottom) >= AA,
     "and the derived one must not be",
   );
 
@@ -272,7 +435,7 @@ test("the three colours that shipped are each provably illegible", () => {
     wasOnAccent < AA,
     `${auroraII.name}'s accent ${hex(auroraII.accent)} gave the fixed black label ${wasOnAccent.toFixed(2)}:1`,
   );
-  assert.ok(contrast(inkFor(auroraII.skyBot, auroraII.deck, auroraII.accent).onAccent, auroraII.accent) >= AA);
+  assert.ok(contrast(inkFor(auroraII.skyTop, auroraII.skyBot, auroraII.deck, auroraII.accent).onAccent, auroraII.accent) >= AA);
 
   // 3. The voltage bar took the sky's ink and sits on the deck, which is
   //    near-black in the biome whose sky is bone.
@@ -283,6 +446,113 @@ test("the three colours that shipped are each provably illegible", () => {
 /* -------------------------------------------------------------------------- */
 /* ...and the stylesheet cannot disagree with any of it.                      */
 /* -------------------------------------------------------------------------- */
+
+/**
+ * The stylesheet, split into `[prelude, body]` by a brace walker.
+ *
+ * Every other assertion in this file that mentions `HUD_CSS` is a substring
+ * search, and a substring search cannot see the difference between a rule and a
+ * rule that a CSS parser throws away. One stray comment terminator above
+ * the recharge veil's rule left five lines of English in the selector
+ * prelude, which invalidates the selector and drops the whole declaration block
+ * — the recharge gate silently fell back to the generic veil, and every
+ * gradient assertion here went on passing because the text was still in the
+ * template literal. So: parse it.
+ */
+function rulesOf(source: string): { prelude: string; body: string }[] {
+  // Comments come out first, and a terminator with no opener is deliberately
+  // LEFT IN — that orphan is the whole signature of the defect, and a stripper
+  // that tidied it away would hide exactly what this is looking for.
+  let css = "";
+  for (let j = 0; j < source.length; ) {
+    if (source[j] === "/" && source[j + 1] === "*") {
+      const end = source.indexOf("*/", j + 2);
+      assert.notEqual(end, -1, "an unterminated comment swallows the rest of the sheet");
+      j = end + 2;
+      continue;
+    }
+    css += source[j];
+    j++;
+  }
+
+  const out: { prelude: string; body: string }[] = [];
+  let i = 0;
+  let depth = 0;
+  let start = 0;
+  let prelude = "";
+  while (i < css.length) {
+    const c = css[i];
+    if (c === "{") {
+      if (depth === 0) {
+        prelude = css.slice(start, i);
+        start = i + 1;
+      }
+      depth++;
+    } else if (c === "}") {
+      depth--;
+      assert.ok(depth >= 0, "a stray } in the stylesheet");
+      if (depth === 0) {
+        out.push({ prelude: prelude.trim(), body: css.slice(start, i) });
+        start = i + 1;
+      }
+    }
+    i++;
+  }
+  assert.equal(depth, 0, "an unclosed { in the stylesheet");
+  return out;
+}
+
+test("every rule in the stylesheet has a selector a browser would accept", () => {
+  // The guard the HIGH above needed. A prelude that is prose does not throw and
+  // does not warn — the rule is simply dropped, on the device, silently.
+  const rules = rulesOf(HUD_CSS);
+  assert.ok(rules.length > 60, `only ${rules.length} rules parsed out of the sheet`);
+  for (const { prelude } of rules) {
+    assert.ok(prelude.length > 0, "a rule with an empty selector");
+    assert.ok(
+      !/\*\//.test(prelude),
+      `a comment leaked into a selector: "${prelude.slice(0, 90)}" — the rule is dropped`,
+    );
+    // Conservative, but it is exactly the class of damage that shipped: a
+    // selector prelude has no sentence punctuation in it.
+    assert.ok(
+      !/[.,]\s+[a-z]{2,}\s+[a-z]{2,}\s+[a-z]{2,}/.test(prelude),
+      `this selector is prose: "${prelude.slice(0, 90)}"`,
+    );
+    assert.ok(
+      prelude.startsWith("@") || /^[.#:a-zA-Z[][^;]*$/.test(prelude),
+      `not a selector: "${prelude.slice(0, 90)}"`,
+    );
+  }
+});
+
+test("the rules the recharge gate is actually made of are in the sheet as rules", () => {
+  // Named individually, because the founder's screen is built out of exactly
+  // these and losing any one of them changes the screen without failing a build.
+  const preludes = new Set(rulesOf(HUD_CSS).map((r) => r.prelude));
+  for (const sel of [
+    '.vt-veil[data-v="revive"]',
+    ".vt-charge-label",
+    ".vt-revive-prompt",
+    ".vt-lane",
+    ".vt-lane span",
+    ".vt-lane.vt-right span",
+    ".vt-veil",
+  ]) {
+    assert.ok(preludes.has(sel), `${sel} is not a rule in the stylesheet`);
+  }
+  // ...and the revive veil's own scrim, in the rule that actually carries it.
+  const revive = rulesOf(HUD_CSS).find((r) => r.prelude === '.vt-veil[data-v="revive"]');
+  assert.ok(revive, "the recharge veil has no rule");
+  assert.ok(
+    revive.body.includes(gradientStops(REVIVE_STOPS)),
+    "the recharge veil's rule does not carry the REVIVE_STOPS scrim",
+  );
+  assert.ok(
+    revive.body.includes("flex-end"),
+    "the recharge veil no longer stacks its content from the bottom, which is what REVIVE_CONTENT_TOP assumes",
+  );
+});
 
 test("the veils' scrims are generated from the stops the test samples", () => {
   // The same contract chrome.ts imposes on geometry. If the CSS carried its own
@@ -356,7 +626,7 @@ test("the stylesheet holds no ink of its own for anything a child reads", () => 
 });
 
 test("inkVars produces a colour for every ink var the stylesheet asks for", () => {
-  const vars = inkVars(0x071230, 0x070a18, 0x37ecff);
+  const vars = inkVars(0x02030c, 0x071230, 0x070a18, 0x37ecff);
   for (const m of HUD_CSS.matchAll(/var\((--vt-(?:ink|on|accent-veil|volt-fill)[a-z-]*)/g)) {
     const name = m[1] ?? "";
     assert.ok(name in vars, `the stylesheet reads ${name} and inkVars never sets it`);

--- a/dynawalla/games/runner/src/game/contrast.test.ts
+++ b/dynawalla/games/runner/src/game/contrast.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Every colour a child has to read, in every world this game can generate.
+ *
+ * The founder's report was "recharge questions are not always legible in every
+ * theme ... black numbers on dark background". The honest way to answer that is
+ * not to look at four screenshots — VOLTA does not have four themes. It has an
+ * unbounded number: `biomeAt(i)` cycles four bases and hue-rotates the whole
+ * palette 0.14 turns on every lap, for ever, and the *crossfade* between two of
+ * them is a further continuum of worlds that are on screen for two seconds each
+ * and are exactly as likely to be the one a child dies in.
+ *
+ * So this walks 32 biomes — eight laps, a full circuit of the hue wheel and
+ * then some — and five points across each crossing between neighbours, and
+ * computes WCAG contrast for every ink against every backdrop that ink can land
+ * on. Nothing here is a spot check and nothing here is eyeballed.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { biomeAt } from "./biomes.ts";
+import {
+  AA,
+  INK_DARK,
+  LANE_FACE,
+  PLAIN_STOPS,
+  REVIVE_CONTENT_TOP,
+  REVIVE_STOPS,
+  VEIL_TINT,
+  VOLT_BED,
+  VOLT_BED_A,
+  alphaAt,
+  contrast,
+  gradientStops,
+  laneFaceStops,
+  hex,
+  inkFor,
+  inkVars,
+  laneBackdrops,
+  luma,
+  mix,
+  over,
+  plainBackdrops,
+  readableInk,
+  reviveBackdrops,
+} from "./contrast.ts";
+import { HUD_CSS } from "./hud.ts";
+
+/* -------------------------------------------------------------------------- */
+/* The primitives, against values that can be checked by hand.                */
+/* -------------------------------------------------------------------------- */
+
+test("luminance and contrast are the WCAG ones, not a lookalike", () => {
+  assert.equal(luma(0x000000), 0);
+  assert.equal(luma(0xffffff), 1);
+  // The defining pair: white on black is 21:1 exactly.
+  assert.equal(Math.round(contrast(0xffffff, 0x000000) * 100) / 100, 21);
+  assert.equal(contrast(0x123456, 0x123456), 1);
+  // Order must not matter — a ratio, not a difference.
+  assert.equal(contrast(0xffffff, 0x336699), contrast(0x336699, 0xffffff));
+  // The green channel dominates: same 8-bit value, very different luminance.
+  assert.ok(luma(0x00ff00) > luma(0xff0000));
+  assert.ok(luma(0xff0000) > luma(0x0000ff));
+});
+
+test("compositing matches what a browser paints rgba() over an opaque backdrop", () => {
+  assert.equal(over(0xffffff, 0, 0x102030), 0x102030);
+  assert.equal(over(0xffffff, 1, 0x102030), 0xffffff);
+  assert.equal(over(0x000000, 0.5, 0xffffff), 0x808080);
+  // The exact composite from the shipped defect: the recharge veil's lower band
+  // over THE BLEACH's bone sky.
+  assert.equal(over(0x030712, 0.88, 0xfdfaf2), 0x21242d);
+});
+
+test("alphaAt interpolates the gradient stops and clamps outside them", () => {
+  const s = [
+    [0, 0.2],
+    [0.5, 0.8],
+    [1, 1],
+  ] as const;
+  assert.equal(alphaAt(s, -1), 0.2);
+  assert.equal(alphaAt(s, 0), 0.2);
+  assert.ok(Math.abs(alphaAt(s, 0.25) - 0.5) < 1e-9);
+  assert.equal(alphaAt(s, 0.5), 0.8);
+  assert.ok(Math.abs(alphaAt(s, 0.75) - 0.9) < 1e-9);
+  assert.equal(alphaAt(s, 2), 1);
+});
+
+test("readableInk picks the pole that is actually further away", () => {
+  assert.ok(luma(readableInk([0x000000])) > 0.5, "on black it must go light");
+  assert.ok(luma(readableInk([0xffffff])) < 0.5, "on white it must go dark");
+  // A mid grey defeats both house inks. It must still return the best available
+  // rather than a colour under the bar, and say so by clearing it.
+  const grey = readableInk([0x808080]);
+  assert.ok(
+    contrast(grey, 0x808080) >= AA,
+    `mid grey resolved to ${hex(grey)} at ${contrast(grey, 0x808080).toFixed(2)}:1`,
+  );
+});
+
+test("toward keeps as much of the hue as clearing the bar allows", () => {
+  // A dim accent on a dim scrim has to be lifted, but it must not be lifted all
+  // the way to white — the RECHARGE label should still read as the biome.
+  const bg = 0x21242d;
+  const dim = 0x2f4f7f;
+  const fixed = inkFor(0xfdfaf2, 0x0b0b0d, dim).accentOnVeil;
+  assert.ok(contrast(fixed, bg) >= AA || luma(fixed) >= luma(dim));
+  assert.notEqual(fixed, 0xffffff, "correction jumped straight to the pole");
+});
+
+/* -------------------------------------------------------------------------- */
+/* Every world.                                                               */
+/* -------------------------------------------------------------------------- */
+
+/** Eight laps of four biomes: a full circuit of the 0.14-turn hue rotation. */
+const LAPS = 8;
+const BIOMES = 4 * LAPS;
+
+/** The blends a crossing actually puts on screen, including the endpoints. */
+const CROSSFADE = [0, 0.25, 0.5, 0.75, 1];
+
+type World = { label: string; sky: number; deck: number; accent: number };
+
+/**
+ * Every world the generator can produce, discrete and mid-crossing.
+ *
+ * `mount.ts` derives its inks from `uSkyBot`, `uDeck` and `uAccent`, which are
+ * the crossfade's live blends, so this reproduces exactly those three.
+ */
+function worlds(): World[] {
+  const out: World[] = [];
+  for (let i = 0; i < BIOMES; i++) {
+    const a = biomeAt(i);
+    const b = biomeAt(i + 1);
+    for (const m of CROSSFADE) {
+      out.push({
+        label: m === 0 ? a.name : `${a.name} -> ${b.name} @${m}`,
+        sky: mix(a.skyBot, b.skyBot, m),
+        deck: mix(a.deck, b.deck, m),
+        accent: mix(a.accent, b.accent, m),
+      });
+    }
+  }
+  return out;
+}
+
+const WORLDS = worlds();
+
+test("the world list is the real generator and is not trivially small", () => {
+  assert.equal(WORLDS.length, BIOMES * CROSSFADE.length);
+  assert.ok(WORLDS.length >= 160, `only ${WORLDS.length} worlds — this is a spot check`);
+  // A guard on the guard: if `biomeAt` ever stopped rotating, every lap would be
+  // identical and this whole file would be testing four worlds while claiming
+  // thirty-two.
+  const accents = new Set(WORLDS.map((w) => w.accent));
+  assert.ok(accents.size > 60, `only ${accents.size} distinct accents across ${BIOMES} biomes`);
+  // Both a bone world and near-black worlds must be in the set, or the test is
+  // not exercising the case that shipped.
+  assert.ok(WORLDS.some((w) => luma(w.sky) > 0.7), "no bright sky in the set");
+  assert.ok(WORLDS.some((w) => luma(w.sky) < 0.02), "no dark sky in the set");
+});
+
+/**
+ * Every ink, and every backdrop it is drawn on, for one world.
+ *
+ * This is the table the whole file turns on, so each entry names the surface in
+ * the terms a person debugging a screenshot would use.
+ */
+function surfaces(w: World): { what: string; ink: number; bgs: number[] }[] {
+  const k = inkFor(w.sky, w.deck, w.accent);
+  return [
+    { what: "the prompt, score and surge, on the sky", ink: k.sky, bgs: [w.sky] },
+    { what: "SCORE / SURGE, tracked and quiet, on the sky", ink: k.skyDim, bgs: [w.sky] },
+    {
+      what: "the voltage readout, on the deck",
+      ink: k.deck,
+      bgs: [w.deck, over(VOLT_BED, VOLT_BED_A, w.deck)],
+    },
+    {
+      what: "the voltage fill, on its bed",
+      ink: k.voltFill,
+      bgs: [over(VOLT_BED, VOLT_BED_A, w.deck)],
+    },
+    { what: "the recharge question, on the veil", ink: k.veil, bgs: reviveBackdrops(w.sky) },
+    { what: "the start and run-over veils", ink: k.veil, bgs: plainBackdrops(w.sky) },
+    {
+      what: "the VOLTAGE label, quiet, on the deck",
+      ink: k.deckDim,
+      bgs: [w.deck, over(VOLT_BED, VOLT_BED_A, w.deck)],
+    },
+    {
+      what: "the recharge counter and the start hint, quiet, on the veil",
+      ink: k.veilDim,
+      bgs: [...reviveBackdrops(w.sky), ...plainBackdrops(w.sky)],
+    },
+    { what: "a recharge lane's numeral, on the lane face", ink: k.lane, bgs: laneBackdrops(w.sky) },
+    { what: "the chosen lane's numeral, on the accent fill", ink: k.onAccent, bgs: [w.accent] },
+    { what: "the RUN button's label, on a fill of the veil ink", ink: k.onVeilInk, bgs: [k.veil] },
+    { what: "a pressed tool's glyph, on a fill of the deck ink", ink: k.onDeckInk, bgs: [k.deck] },
+    { what: "the RECHARGE label, accent-hued, on the veil", ink: k.accentOnVeil, bgs: reviveBackdrops(w.sky) },
+  ];
+}
+
+test("every ink clears WCAG AA in every world VOLTA can generate", () => {
+  const failures: string[] = [];
+  let checks = 0;
+  for (const w of WORLDS) {
+    for (const s of surfaces(w)) {
+      for (const bg of s.bgs) {
+        checks++;
+        const r = contrast(s.ink, bg);
+        if (r < AA) {
+          failures.push(
+            `${w.label}: ${s.what} — ${hex(s.ink)} on ${hex(bg)} is ${r.toFixed(2)}:1, under ${AA}:1`,
+          );
+        }
+      }
+    }
+  }
+  assert.ok(checks > 5000, `only ${checks} contrast checks were made`);
+  assert.deepEqual(failures.slice(0, 12), [], `${failures.length} of ${checks} surfaces are illegible`);
+});
+
+test("the recharge gate specifically — the screen the founder photographed", () => {
+  // Stated separately from the sweep above so that a regression on this one
+  // screen cannot hide inside a general failure count, and so the failure
+  // message names the gate.
+  for (const w of WORLDS) {
+    const k = inkFor(w.sky, w.deck, w.accent);
+    for (const bg of reviveBackdrops(w.sky)) {
+      assert.ok(
+        contrast(k.veil, bg) >= AA,
+        `${w.label}: the recharge QUESTION is ${hex(k.veil)} on ${hex(bg)} — ${contrast(k.veil, bg).toFixed(2)}:1`,
+      );
+    }
+    for (const bg of laneBackdrops(w.sky)) {
+      assert.ok(
+        contrast(k.lane, bg) >= AA,
+        `${w.label}: a recharge ANSWER is ${hex(k.lane)} on ${hex(bg)} — ${contrast(k.lane, bg).toFixed(2)}:1`,
+      );
+    }
+    assert.ok(
+      contrast(k.onAccent, w.accent) >= AA,
+      `${w.label}: the CHOSEN answer is ${hex(k.onAccent)} on the accent ${hex(w.accent)} — ${contrast(k.onAccent, w.accent).toFixed(2)}:1`,
+    );
+  }
+});
+
+test("the three colours that shipped are each provably illegible", () => {
+  // The regression this file exists for, stated as the failure rather than the
+  // fix — so that if someone reverts contrast.ts to a fixed ink, the reason it
+  // was wrong is still written down and still computed.
+  const bleach = biomeAt(3);
+  assert.equal(bleach.id, "void", "THE BLEACH moved; this test is measuring the wrong world");
+
+  // 1. The whole HUD's ink came from `biome.inverted`, i.e. from the SKY, and
+  //    the veil does not sit on the sky.
+  const veilBottom = over(VEIL_TINT, alphaAt(REVIVE_STOPS, 1), bleach.skyBot);
+  const wasVeil = contrast(INK_DARK, veilBottom);
+  assert.ok(wasVeil < 2, `the shipped recharge ink was ${wasVeil.toFixed(2)}:1, expected under 2:1`);
+  assert.ok(
+    contrast(inkFor(bleach.skyBot, bleach.deck, bleach.accent).veil, veilBottom) >= AA,
+    "and the derived one must not be",
+  );
+
+  // 2. `.vt-lane.vt-right span` was a fixed #04060f on the live accent, and the
+  //    hue rotation walks the accent to royal blue on the second lap.
+  const auroraII = biomeAt(4);
+  assert.equal(auroraII.id, "aurora");
+  const wasOnAccent = contrast(0x04060f, auroraII.accent);
+  assert.ok(
+    wasOnAccent < AA,
+    `${auroraII.name}'s accent ${hex(auroraII.accent)} gave the fixed black label ${wasOnAccent.toFixed(2)}:1`,
+  );
+  assert.ok(contrast(inkFor(auroraII.skyBot, auroraII.deck, auroraII.accent).onAccent, auroraII.accent) >= AA);
+
+  // 3. The voltage bar took the sky's ink and sits on the deck, which is
+  //    near-black in the biome whose sky is bone.
+  const wasVolt = contrast(INK_DARK, bleach.deck);
+  assert.ok(wasVolt < 1.5, `the shipped voltage fill was ${wasVolt.toFixed(2)}:1 on the deck`);
+});
+
+/* -------------------------------------------------------------------------- */
+/* ...and the stylesheet cannot disagree with any of it.                      */
+/* -------------------------------------------------------------------------- */
+
+test("the veils' scrims are generated from the stops the test samples", () => {
+  // The same contract chrome.ts imposes on geometry. If the CSS carried its own
+  // copy of these numbers, every contrast assertion above would be measuring a
+  // gradient that is not on screen — which is precisely how the geometry bug
+  // shipped twice before it was tracked to the same shape of mistake.
+  assert.ok(
+    HUD_CSS.includes(gradientStops(REVIVE_STOPS)),
+    "the recharge veil's gradient is not built from REVIVE_STOPS",
+  );
+  assert.ok(
+    HUD_CSS.includes(gradientStops(PLAIN_STOPS)),
+    "the start / run-over veil's gradient is not built from PLAIN_STOPS",
+  );
+});
+
+test("the content band of the recharge veil is scrimmed, not transparent", () => {
+  // The fix is a *sparser field*, not a heavier ink: no ink clears 4.5:1 against
+  // a band that runs from bone to black behind it, so the band under the
+  // question and the answers has a floor. Above it the causeway still shows.
+  for (let i = 0; i <= 20; i++) {
+    const p = REVIVE_CONTENT_TOP + ((1 - REVIVE_CONTENT_TOP) * i) / 20;
+    assert.ok(
+      alphaAt(REVIVE_STOPS, p) >= 0.85,
+      `the scrim is ${alphaAt(REVIVE_STOPS, p)} at ${p.toFixed(2)}, where an answer is drawn`,
+    );
+  }
+  const clear = alphaAt(REVIVE_STOPS, 0.27);
+  assert.ok(clear <= 0.25, `the window onto the causeway closed to ${clear} — this is a dialog box now`);
+});
+
+test("the stylesheet holds no ink of its own for anything a child reads", () => {
+  // Structural, like the positional guard next door: a literal colour on one of
+  // these selectors is an ink the stylesheet owns and contrast.ts also owns, and
+  // the two drift. Glows, strokes, scrims and hairlines are exempt — they are
+  // not text, and `text-shadow`/`background` are not `color`.
+  const READ = [
+    ".vt-root",
+    ".vt-prompt",
+    ".vt-tl",
+    ".vt-tr",
+    ".vt-volt",
+    ".vt-tools",
+    ".vt-veil",
+    ".vt-charge-label",
+  ];
+  // Comments are stripped first: a rule preceded by one would otherwise have the
+  // whole comment glued onto the front of its selector list.
+  const sheet = HUD_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rules = new Map<string, string>();
+  for (const m of sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    for (const sel of (m[1] ?? "").split(",")) {
+      const key = sel.trim();
+      rules.set(key, (rules.get(key) ?? "") + ";" + (m[2] ?? ""));
+    }
+  }
+  for (const sel of READ) {
+    const body = rules.get(sel);
+    assert.ok(body !== undefined, `${sel} left the stylesheet; this test is measuring nothing`);
+    for (const decl of body.split(";")) {
+      const colon = decl.indexOf(":");
+      if (colon < 0) continue;
+      if (decl.slice(0, colon).trim() !== "color") continue;
+      const value = decl.slice(colon + 1).trim();
+      assert.ok(
+        value.startsWith("var(--vt-"),
+        `${sel} { color: ${value} } — a fixed ink is the whole defect; derive it in contrast.ts`,
+      );
+    }
+  }
+});
+
+test("inkVars produces a colour for every ink var the stylesheet asks for", () => {
+  const vars = inkVars(0x071230, 0x070a18, 0x37ecff);
+  for (const m of HUD_CSS.matchAll(/var\((--vt-(?:ink|on|accent-veil|volt-fill)[a-z-]*)/g)) {
+    const name = m[1] ?? "";
+    assert.ok(name in vars, `the stylesheet reads ${name} and inkVars never sets it`);
+  }
+  for (const [name, value] of Object.entries(vars)) {
+    assert.ok(/^#[0-9a-f]{6}$/.test(value), `${name} is "${value}", which is not a colour`);
+  }
+});
+
+test("the lane face and the subdued opacity are the ones the sheet uses", () => {
+  // The remaining two numbers that exist in both places. LANE_FACE is what the
+  // lane's own gradient composites, and SUBDUED is the opacity that turns a
+  // 4.5:1 ink into a 3.9:1 one.
+  assert.ok(LANE_FACE.length >= 3, "the lane face lost its stops");
+  assert.ok(
+    HUD_CSS.includes(laneFaceStops()),
+    "the recharge lane's face is not built from LANE_FACE",
+  );
+  // No text may carry an `opacity` again. An opacity composites the ink into the
+  // backdrop, which is a contrast cut that no amount of ink derivation can see —
+  // it is applied after `color` is chosen. The tracked labels used to, and every
+  // one of them was under the bar in THE BLEACH.
+  for (const sel of [".vt-label", ".vt-hint", ".vt-sub", ".vt-surge-x", ".vt-dist", ".vt-stat i"]) {
+    const m = new RegExp(`\\${sel.replace(/ /g, " ")}\\s*\\{([^}]*)\\}`).exec(HUD_CSS);
+    assert.ok(m, `${sel} left the stylesheet; this test is measuring nothing`);
+    assert.ok(
+      !/(^|;)\s*opacity\s*:/.test(m[1] ?? ""),
+      `${sel} carries an opacity again — soften it with a derived ink, not by fading it`,
+    );
+    assert.ok(
+      /color:var\(--vt-ink-[a-z]+-dim/.test(m[1] ?? ""),
+      `${sel} does not take a derived dim ink`,
+    );
+  }
+});

--- a/dynawalla/games/runner/src/game/contrast.ts
+++ b/dynawalla/games/runner/src/game/contrast.ts
@@ -120,16 +120,30 @@ export function minContrast(ink: number, bgs: readonly number[]): number {
  */
 export function toward(ink: number, bgs: readonly number[], target = AA): number {
   if (minContrast(ink, bgs) >= target) return ink;
-  const pole = luma(ink) >= luma(bgs[0] ?? 0) ? 0xffffff : 0x000000;
-  if (minContrast(pole, bgs) < target) return pole;
-  let lo = 0;
-  let hi = 1;
-  for (let i = 0; i < 24; i++) {
-    const midT = (lo + hi) / 2;
-    if (minContrast(mix(ink, pole, midT), bgs) >= target) hi = midT;
-    else lo = midT;
-  }
-  return mix(ink, pole, hi);
+  const search = (pole: number): number => {
+    let lo = 0;
+    let hi = 1;
+    for (let i = 0; i < 24; i++) {
+      const midT = (lo + hi) / 2;
+      if (minContrast(mix(ink, pole, midT), bgs) >= target) hi = midT;
+      else lo = midT;
+    }
+    // `hi` is only ever assigned a blend that satisfied the predicate, so the
+    // result clears `target` even though min-contrast-over-a-set is not monotone
+    // in the blend.
+    return mix(ink, pole, hi);
+  };
+  // The near pole first, because moving less keeps more of the hue — but if it
+  // cannot clear the bar, the far one is tried before giving up. Picking the
+  // pole by `bgs[0]` alone and never reconsidering loses outright on any ink
+  // whose backgrounds straddle mid grey.
+  const near = luma(ink) >= luma(bgs[0] ?? 0) ? 0xffffff : 0x000000;
+  const far = near === 0xffffff ? 0x000000 : 0xffffff;
+  if (minContrast(near, bgs) >= target) return search(near);
+  if (minContrast(far, bgs) >= target) return search(far);
+  // Neither pole clears it — no ink does. Hand back the better of the two, which
+  // is still the most readable colour available.
+  return minContrast(near, bgs) >= minContrast(far, bgs) ? near : far;
 }
 
 /**
@@ -306,6 +320,60 @@ export function laneBackdrops(sky: number): number[] {
 }
 
 /**
+ * The band of sky the HUD's top furniture is actually printed on.
+ *
+ * The sky is not one colour. `world.ts`'s fragment shader is
+ * `mix(uSkyBot, uSkyTop, pow(d.y * 0.5 + 0.5, 0.75))`, so the prompt at 15% down
+ * sits on roughly 72% `uSkyTop` and the corner readouts on roughly 81% of it —
+ * and this used to derive the ink from `uSkyBot` alone. Halfway through the
+ * crossing from THE ABYSS to THE BLEACH that is not a rounding error: the ink
+ * came out *dark* against a backdrop where the light one was the right choice.
+ *
+ * Sampling the whole span rather than one point in it costs nothing here — within
+ * a biome the two ends are the same family, and across a crossing they move
+ * together — and it means the ink is right wherever on the sky the text lands.
+ *
+ * Both mix spaces are sampled: the shader blends in linear light and a browser
+ * would blend in gamma, and the ink has to survive whichever is nearer the truth.
+ */
+export function skyBackdrops(skyTop: number, skyBot: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i <= 8; i++) {
+    const t = i / 8;
+    out.push(mix(skyBot, skyTop, t), mixLinear(skyBot, skyTop, t));
+  }
+  return out;
+}
+
+/** Blend two packed colours in linear light, as a shader does. */
+export function mixLinear(a: number, b: number, t: number): number {
+  const toLin = (v: number): number => {
+    const s = v / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const toSrgb = (v: number): number => {
+    const s = v <= 0.0031308 ? v * 12.92 : 1.055 * Math.pow(v, 1 / 2.4) - 0.055;
+    return s * 255;
+  };
+  const c = (i: number): number =>
+    toSrgb(toLin(ch(a, i)) + (toLin(ch(b, i)) - toLin(ch(a, i))) * t);
+  return pack(c(0), c(1), c(2));
+}
+
+/**
+ * The ocean's surface colour, as `world.ts` derives it.
+ *
+ * The ocean shader bases itself on `uSkyBot * 0.35` in linear light, and the
+ * bottom HUD furniture crosses it: the deck is only `DECK_HALF` metres wide, so
+ * on a landscape viewport the voltage readout's left end is out over the water.
+ * In THE BLEACH that is a bone deck-side and a near-black deck, which is why
+ * everything down there sits on a bed — no single ink clears both.
+ */
+export function oceanFrom(skyBot: number): number {
+  return mixLinear(0x000000, skyBot, 0.35);
+}
+
+/**
  * `ink`, softened toward its backdrop by `SOFTEN`, then corrected back to AA.
  *
  * The whole trick is that the correction is unconditional: on a backdrop with
@@ -341,6 +409,22 @@ export type Ink = {
   accentOnVeil: number;
   /** The voltage fill, on its own bed. */
   voltFill: number;
+  /**
+   * The stroke the sky-band text is painted around, so it carries its own ground.
+   *
+   * Exactly halfway through the crossing between a dark biome and THE BLEACH the
+   * sky is a mid grey — around `#70756f` — and against a mid grey *no flat ink
+   * clears 4.5:1*. Pure black reaches 4.46 and pure white less; the sky is
+   * simply the worst backdrop there is, and no amount of choosing a colour fixes
+   * a colour problem that has no solution.
+   *
+   * So the glyph stops relying on the sky. `paint-order: stroke fill` puts a
+   * contrasting stroke behind the fill, which means the ink's real backdrop is
+   * the stroke and not the world — the same move `.vt-banner` and
+   * `.vt-revive-prompt` already make in this stylesheet, for the same reason.
+   * Sparsen the field; the effects stay.
+   */
+  halo: number;
   /** SCORE / SURGE, tracked and quiet, on the sky. */
   skyDim: number;
   /** VOLTAGE, tracked and quiet, on the deck. */
@@ -356,22 +440,32 @@ export type Ink = {
  * crossfade's current blend, so a child who dies half way between AURORA and
  * SOLAR gets a recharge gate derived from the sky that is actually on screen.
  */
-export function inkFor(sky: number, deck: number, accent: number): Ink {
-  const veilBgs = [...reviveBackdrops(sky), ...plainBackdrops(sky)];
+export function inkFor(skyTop: number, skyBot: number, deck: number, accent: number): Ink {
+  // The veils scrim the sky, and the darkest thing they can scrim is what sets
+  // how much scrim is enough — so they are modelled against the whole sky band,
+  // not just its bottom.
+  const skyBgs = skyBackdrops(skyTop, skyBot);
+  const veilBgs = [...reviveBackdrops(skyBot), ...plainBackdrops(skyBot), ...reviveBackdrops(skyTop)];
   const veil = readableInk(veilBgs);
-  const deckBgs = [deck, over(VOLT_BED, VOLT_BED_A, deck)];
+  // Everything along the bottom edge is drawn on a bed, because the alternative
+  // is an ink that has to clear both a near-black deck and a bone ocean at once,
+  // and there is no such ink. The bed is what makes the backdrop knowable.
+  const bedded = (c: number): number => over(VOLT_BED, VOLT_BED_A, c);
+  const deckBgs = [bedded(deck), bedded(oceanFrom(skyBot)), bedded(oceanFrom(skyTop))];
   const deckInk = readableInk(deckBgs);
+  const skyInk = readableInk(skyBgs);
   return {
-    sky: readableInk([sky]),
+    sky: skyInk,
     deck: deckInk,
     veil,
-    lane: readableInk(laneBackdrops(sky)),
+    lane: readableInk([...laneBackdrops(skyBot), ...laneBackdrops(skyTop)]),
     onAccent: readableInk([accent]),
     onVeilInk: readableInk([veil]),
     onDeckInk: readableInk([deckInk]),
     accentOnVeil: toward(accent, veilBgs),
-    voltFill: readableInk([over(VOLT_BED, VOLT_BED_A, deck)]),
-    skyDim: dimInk(readableInk([sky]), [sky]),
+    halo: readableInk([skyInk]),
+    voltFill: readableInk(deckBgs),
+    skyDim: dimInk(skyInk, skyBgs),
     deckDim: dimInk(deckInk, deckBgs),
     veilDim: dimInk(veil, veilBgs),
   };
@@ -384,8 +478,13 @@ export function inkFor(sky: number, deck: number, accent: number): Ink {
  * same contract `hudVars` has for geometry. `chrome.test.ts` checks that every
  * `var(--vt-ink-*)` and `var(--vt-on-*)` the sheet asks for is produced here.
  */
-export function inkVars(sky: number, deck: number, accent: number): Record<string, string> {
-  const k = inkFor(sky, deck, accent);
+export function inkVars(
+  skyTop: number,
+  skyBot: number,
+  deck: number,
+  accent: number,
+): Record<string, string> {
+  const k = inkFor(skyTop, skyBot, deck, accent);
   return {
     "--vt-ink-sky": hex(k.sky),
     "--vt-ink-deck": hex(k.deck),
@@ -396,6 +495,7 @@ export function inkVars(sky: number, deck: number, accent: number): Record<strin
     "--vt-on-deck-ink": hex(k.onDeckInk),
     "--vt-accent-veil": hex(k.accentOnVeil),
     "--vt-volt-fill": hex(k.voltFill),
+    "--vt-halo-sky": hex(k.halo),
     "--vt-ink-sky-dim": hex(k.skyDim),
     "--vt-ink-deck-dim": hex(k.deckDim),
     "--vt-ink-veil-dim": hex(k.veilDim),

--- a/dynawalla/games/runner/src/game/contrast.ts
+++ b/dynawalla/games/runner/src/game/contrast.ts
@@ -1,0 +1,403 @@
+/**
+ * Which colours VOLTA is allowed to write text in.
+ *
+ * ── the defect this exists to make impossible ────────────────────────────────
+ *
+ * The recharge gate — the one screen in the game that is *only* a question, and
+ * the screen a child is looking at when they decide whether to keep playing —
+ * shipped with unreadable numerals. Three separate fixed colours, each of which
+ * happened to work in the biome it was authored in:
+ *
+ *   1. The whole HUD's ink was `biome.inverted ? "#12121a" : "#eaf6ff"`, chosen
+ *      from the *sky*. The veils do not sit on the sky; they paint their own
+ *      dark scrim over it. In THE BLEACH the sky is bone, so `inverted` is true,
+ *      so the ink went to near-black — and the recharge veil's lower band is
+ *      `rgba(3,7,18,0.88)` over that bone, which composites to rgb(33,36,45).
+ *      Near-black numerals on a near-black panel: **1.19:1**. That is the
+ *      founder's screenshot, and it is not a subtle miss — 4.5:1 is the bar.
+ *
+ *   2. `.vt-lane.vt-right span` was a fixed `#04060f` on a fill of the live
+ *      accent. Accents are hue-rotated 0.14 turns per lap, for ever, and hue
+ *      moves relative luminance enormously at constant HSL lightness. AURORA
+ *      SHELF II's accent lands on royal blue `#3744ff`, where black text is
+ *      **3.43:1**. Nobody authored that colour; the rotation produced it.
+ *
+ *   3. The voltage readout took the sky's ink too, and it sits on the *deck* —
+ *      which is near-black in all four biomes, including the one whose sky is
+ *      bone. In THE BLEACH the bar's fill was `#12121a` on `#0b0b0d`.
+ *
+ * The common shape is a colour picked from something other than the thing the
+ * text actually lands on. So nothing here is authored: every ink below is
+ * *derived* from the composited background of the specific surface, and
+ * `contrast.test.ts` walks every biome the generator can produce — thirty-two
+ * of them, a full lap of the hue circle, plus every crossfade between
+ * neighbours — and fails the build on anything under 4.5:1.
+ *
+ * The luminance formula is WCAG 2.x relative luminance, and it is the same one
+ * `games/stack` derives its own chrome from (`strata.ts`, `luma`/`isBright`).
+ * That game learned this lesson first: AZURE shipped white-on-pale-blue because
+ * a hand-maintained `invert` boolean was wrong on one stratum, and a run reaches
+ * all of them.
+ */
+
+/** WCAG AA for body text. Everything here is body text. */
+export const AA = 4.5;
+
+/** The two house inks. Derivation starts from these and corrects from there. */
+export const INK_LIGHT = 0xeaf6ff;
+export const INK_DARK = 0x12121a;
+
+const ch = (hex: number, i: number): number => (hex >> (8 * (2 - i))) & 255;
+const pack = (r: number, g: number, b: number): number =>
+  (clamp255(r) << 16) | (clamp255(g) << 8) | clamp255(b);
+const clamp255 = (v: number): number => Math.max(0, Math.min(255, Math.round(v)));
+
+/** `0x37ecff` -> `"#37ecff"`. */
+export function hex(c: number): string {
+  return `#${(c >>> 0).toString(16).padStart(6, "0")}`;
+}
+
+/**
+ * WCAG relative luminance of a packed `0xRRGGBB`, 0..1.
+ *
+ * Lifted from `games/stack/src/game/strata.ts` rather than reinvented — same
+ * formula, same constants, same reason for existing.
+ */
+export function luma(c: number): number {
+  const f = (v: number): number => {
+    const s = v / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(ch(c, 0)) + 0.7152 * f(ch(c, 1)) + 0.0722 * f(ch(c, 2));
+}
+
+/** WCAG contrast ratio between two opaque colours, 1..21. Order-insensitive. */
+export function contrast(a: number, b: number): number {
+  const la = luma(a);
+  const lb = luma(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/**
+ * `fg` at `alpha` composited over `bg`.
+ *
+ * A straight per-channel lerp on 8-bit values, because that is what a browser
+ * does for `rgba()` over an opaque backdrop in an un-managed sRGB document.
+ * Compositing in linear light would be more correct and would not match what
+ * the child is looking at.
+ */
+export function over(fg: number, alpha: number, bg: number): number {
+  const a = Math.max(0, Math.min(1, alpha));
+  return pack(
+    ch(bg, 0) + (ch(fg, 0) - ch(bg, 0)) * a,
+    ch(bg, 1) + (ch(fg, 1) - ch(bg, 1)) * a,
+    ch(bg, 2) + (ch(fg, 2) - ch(bg, 2)) * a,
+  );
+}
+
+/** Linear blend of two packed colours, `t` = 0 gives `a`. */
+export function mix(a: number, b: number, t: number): number {
+  return over(b, t, a);
+}
+
+/** The worst contrast `ink` achieves against any one of `bgs`. */
+export function minContrast(ink: number, bgs: readonly number[]): number {
+  let worst = Infinity;
+  for (const bg of bgs) worst = Math.min(worst, contrast(ink, bg));
+  return worst === Infinity ? 21 : worst;
+}
+
+/**
+ * Push `ink` toward whichever pole it is already nearer until it clears
+ * `target` against every background in `bgs`.
+ *
+ * A binary search on the blend, not a step to white or black: the accent-hued
+ * "RECHARGE" label should still read as the biome's accent after correction,
+ * and the smallest correction that clears the bar is the one that keeps most of
+ * the hue. If even the pole cannot clear it — which no surface in this game
+ * reaches, and `contrast.test.ts` is what says so — the pole is returned, which
+ * is still the most readable colour available.
+ */
+export function toward(ink: number, bgs: readonly number[], target = AA): number {
+  if (minContrast(ink, bgs) >= target) return ink;
+  const pole = luma(ink) >= luma(bgs[0] ?? 0) ? 0xffffff : 0x000000;
+  if (minContrast(pole, bgs) < target) return pole;
+  let lo = 0;
+  let hi = 1;
+  for (let i = 0; i < 24; i++) {
+    const midT = (lo + hi) / 2;
+    if (minContrast(mix(ink, pole, midT), bgs) >= target) hi = midT;
+    else lo = midT;
+  }
+  return mix(ink, pole, hi);
+}
+
+/**
+ * The readable ink for a surface: the better house ink, then corrected.
+ *
+ * Choosing between the two first rather than always correcting one of them is
+ * what keeps THE BLEACH's in-run HUD dark-on-bone instead of dragging it to
+ * white — the biome's whole visual card is black ink on a pale world.
+ */
+export function readableInk(bgs: readonly number[], target = AA): number {
+  const lightWorst = minContrast(INK_LIGHT, bgs);
+  const darkWorst = minContrast(INK_DARK, bgs);
+  const start = lightWorst >= darkWorst ? INK_LIGHT : INK_DARK;
+  return toward(start, bgs, target);
+}
+
+/* -------------------------------------------------------------------------- */
+/* The surfaces, described once so the stylesheet and the tests cannot drift.  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A gradient, as `[position 0..1, alpha]` stops of one colour over the world.
+ *
+ * `hud.ts` builds its `linear-gradient()` from these arrays and nowhere else,
+ * and `contrast.test.ts` samples the same arrays. There is deliberately no
+ * second copy of these numbers in the CSS to disagree with them — the same
+ * discipline `chrome.ts` imposes on geometry, for the same reason.
+ */
+export type Stops = readonly (readonly [number, number])[];
+
+/** The scrim every veil paints over the causeway. */
+export const VEIL_TINT = 0x030712;
+
+/**
+ * The recharge veil, top to bottom.
+ *
+ * The clear window — where the causeway is genuinely visible in full colour, and
+ * the reason this screen is a gate and not a dialog box — is the 20%..34% band,
+ * with soft ramps either side, so the world shows through roughly the top two
+ * fifths of the glass. Below `REVIVE_CONTENT_TOP` the scrim comes up to a floor,
+ * because that is where the question and the three answers are and a numeral
+ * cannot be legible against a background that runs from bone to black underneath
+ * it. Sparsen the field; do not sand down the effect.
+ */
+export const REVIVE_STOPS: Stops = [
+  [0, 0.86],
+  [0.2, 0.18],
+  [0.34, 0.18],
+  [0.46, 0.9],
+  [1, 0.94],
+];
+
+/**
+ * Where the recharge veil's content starts, as a fraction of its height.
+ *
+ * The veil is `justify-content:flex-end`, so the charge ring, the question and
+ * the three lanes stack up from the bottom. On the tallest content this game
+ * produces — a 1024x768 tablet, where the lanes are capped at 820px wide and so
+ * are 217px tall — the stack reaches a little under half way. 0.46 is that,
+ * rounded toward the top.
+ */
+export const REVIVE_CONTENT_TOP = 0.46;
+
+/**
+ * The start and run-over veils: a radial scrim, sampled centre to edge.
+ *
+ * The centre used to be `rgba(2,4,12,0.55)`, which over THE BLEACH's bone sky
+ * composites to rgb(115,114,116) — a mid grey where *neither* house ink clears
+ * 4.5:1 (3.86:1 dark, 4.18:1 light). No choice of ink fixes a mid-grey
+ * backdrop; the scrim itself had to come up.
+ */
+export const PLAIN_STOPS: Stops = [
+  [0, 0.74],
+  [0.72, 0.94],
+  [1, 0.94],
+];
+
+/**
+ * The recharge lane's own face, over the veil: `[position, colour, alpha]`.
+ *
+ * A numeral sits in the middle of this, so every stop is a candidate backdrop.
+ */
+export const LANE_FACE: readonly (readonly [number, number, number])[] = [
+  [0, 0xffffff, 0.1],
+  [0.55, 0x040a16, 0.3],
+  [1, 0x040a16, 0.62],
+];
+
+/**
+ * How far a secondary line of text is softened toward its own backdrop.
+ *
+ * This used to be an `opacity`, and an opacity is not decoration: it composites
+ * the ink into the backdrop, so a 4.5:1 ink at 0.45 is a 3.86:1 ink. SCORE,
+ * SURGE, VOLTAGE, the recharge counter and the start hint were at 0.45, 0.5 and
+ * 0.6 — under the bar in THE BLEACH on every one of them.
+ *
+ * Raising the number was not the fix either. Halfway through the crossing from
+ * THE ABYSS to THE BLEACH the sky is a mid grey, and against a mid grey the best
+ * ink available clears 4.5:1 by a hair — so *any* opacity below 1 puts it under.
+ * There is no constant that works.
+ *
+ * So the softening is applied as a derived colour instead: soften toward the
+ * backdrop, then correct back until the result clears the bar. On a dark sky
+ * SCORE is the quiet grey it was designed to be; on a mid-grey sky the
+ * correction hands back the full-strength ink on its own, and nothing has to
+ * know which sky it was. See `dimInk`.
+ */
+export const SOFTEN = 0.68;
+
+/** The bed the voltage bar's fill is drawn on, so the fill has a known backdrop. */
+export const VOLT_BED = 0x02050e;
+export const VOLT_BED_A = 0.55;
+
+/** `alpha` at position `p` along `stops`, linearly interpolated and clamped. */
+export function alphaAt(stops: Stops, p: number): number {
+  const first = stops[0];
+  const last = stops[stops.length - 1];
+  if (!first || !last) return 0;
+  if (p <= first[0]) return first[1];
+  if (p >= last[0]) return last[1];
+  for (let i = 1; i < stops.length; i++) {
+    const a = stops[i - 1];
+    const b = stops[i];
+    if (!a || !b || p > b[0]) continue;
+    const span = b[0] - a[0];
+    const t = span === 0 ? 0 : (p - a[0]) / span;
+    return a[1] + (b[1] - a[1]) * t;
+  }
+  return last[1];
+}
+
+const rgba = (c: number, a: number): string =>
+  `rgba(${ch(c, 0)},${ch(c, 1)},${ch(c, 2)},${a})`;
+
+/** `stops` as the body of a CSS gradient, in the tint the veils use. */
+export function gradientStops(stops: Stops): string {
+  return stops.map(([p, a]) => `${rgba(VEIL_TINT, a)} ${Math.round(p * 100)}%`).join(", ");
+}
+
+/** `LANE_FACE` as the body of the recharge lane's own CSS gradient. */
+export function laneFaceStops(): string {
+  return LANE_FACE.map(([p, c, a]) => `${rgba(c, a)} ${Math.round(p * 100)}%`).join(", ");
+}
+
+const SAMPLES = 17;
+
+/** Every backdrop the recharge veil's *content* can land on, over `sky`. */
+export function reviveBackdrops(sky: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    const p = REVIVE_CONTENT_TOP + ((1 - REVIVE_CONTENT_TOP) * i) / (SAMPLES - 1);
+    out.push(over(VEIL_TINT, alphaAt(REVIVE_STOPS, p), sky));
+  }
+  return out;
+}
+
+/** Every backdrop the start / run-over veils' content can land on, over `sky`. */
+export function plainBackdrops(sky: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    const p = i / (SAMPLES - 1);
+    out.push(over(VEIL_TINT, alphaAt(PLAIN_STOPS, p), sky));
+  }
+  return out;
+}
+
+/** Every backdrop a recharge lane's numeral can land on, over `sky`. */
+export function laneBackdrops(sky: number): number[] {
+  const out: number[] = [];
+  for (const veil of reviveBackdrops(sky)) {
+    for (const [, c, a] of LANE_FACE) out.push(over(c, a, veil));
+  }
+  return out;
+}
+
+/**
+ * `ink`, softened toward its backdrop by `SOFTEN`, then corrected back to AA.
+ *
+ * The whole trick is that the correction is unconditional: on a backdrop with
+ * room to spare it does nothing and the label is quiet, and on a backdrop with
+ * no room it undoes the softening entirely. Neither the stylesheet nor the
+ * caller has to know which case it is in.
+ */
+export function dimInk(ink: number, bgs: readonly number[], target = AA): number {
+  const anchor = bgs[0] ?? 0;
+  return toward(mix(ink, anchor, 1 - SOFTEN), bgs, target);
+}
+
+/* -------------------------------------------------------------------------- */
+/* The inks themselves.                                                       */
+/* -------------------------------------------------------------------------- */
+
+export type Ink = {
+  /** Prompt, score, surge, banner — text that sits on the sky. */
+  sky: number;
+  /** Voltage and the tool buttons — furniture that sits on the deck. */
+  deck: number;
+  /** Every veil's text, derived from the scrim rather than from the sky. */
+  veil: number;
+  /** A recharge lane's numeral, over the lane face over the veil. */
+  lane: number;
+  /** Text on a solid fill of the live accent — the chosen lane. */
+  onAccent: number;
+  /** Text on a fill painted in `veil` — the Run / Run-again button label. */
+  onVeilInk: number;
+  /** Text on a fill painted in `deck` — a pressed tool button's glyph. */
+  onDeckInk: number;
+  /** The accent, corrected until it is legible as text on the veil scrim. */
+  accentOnVeil: number;
+  /** The voltage fill, on its own bed. */
+  voltFill: number;
+  /** SCORE / SURGE, tracked and quiet, on the sky. */
+  skyDim: number;
+  /** VOLTAGE, tracked and quiet, on the deck. */
+  deckDim: number;
+  /** The recharge counter and the start hint, quiet, on the veil. */
+  veilDim: number;
+};
+
+/**
+ * Every ink, derived from the three world colours the HUD actually lands on.
+ *
+ * Takes the *live* colours, not the biome record: `mount.ts` calls this with the
+ * crossfade's current blend, so a child who dies half way between AURORA and
+ * SOLAR gets a recharge gate derived from the sky that is actually on screen.
+ */
+export function inkFor(sky: number, deck: number, accent: number): Ink {
+  const veilBgs = [...reviveBackdrops(sky), ...plainBackdrops(sky)];
+  const veil = readableInk(veilBgs);
+  const deckBgs = [deck, over(VOLT_BED, VOLT_BED_A, deck)];
+  const deckInk = readableInk(deckBgs);
+  return {
+    sky: readableInk([sky]),
+    deck: deckInk,
+    veil,
+    lane: readableInk(laneBackdrops(sky)),
+    onAccent: readableInk([accent]),
+    onVeilInk: readableInk([veil]),
+    onDeckInk: readableInk([deckInk]),
+    accentOnVeil: toward(accent, veilBgs),
+    voltFill: readableInk([over(VOLT_BED, VOLT_BED_A, deck)]),
+    skyDim: dimInk(readableInk([sky]), [sky]),
+    deckDim: dimInk(deckInk, deckBgs),
+    veilDim: dimInk(veil, veilBgs),
+  };
+}
+
+/**
+ * The custom properties `hud.ts` colours itself from.
+ *
+ * The stylesheet holds no colour of its own for anything a child reads — the
+ * same contract `hudVars` has for geometry. `chrome.test.ts` checks that every
+ * `var(--vt-ink-*)` and `var(--vt-on-*)` the sheet asks for is produced here.
+ */
+export function inkVars(sky: number, deck: number, accent: number): Record<string, string> {
+  const k = inkFor(sky, deck, accent);
+  return {
+    "--vt-ink-sky": hex(k.sky),
+    "--vt-ink-deck": hex(k.deck),
+    "--vt-ink-veil": hex(k.veil),
+    "--vt-ink-lane": hex(k.lane),
+    "--vt-on-accent": hex(k.onAccent),
+    "--vt-on-veil-ink": hex(k.onVeilInk),
+    "--vt-on-deck-ink": hex(k.onDeckInk),
+    "--vt-accent-veil": hex(k.accentOnVeil),
+    "--vt-volt-fill": hex(k.voltFill),
+    "--vt-ink-sky-dim": hex(k.skyDim),
+    "--vt-ink-deck-dim": hex(k.deckDim),
+    "--vt-ink-veil-dim": hex(k.veilDim),
+  };
+}

--- a/dynawalla/games/runner/src/game/hud.ts
+++ b/dynawalla/games/runner/src/game/hud.ts
@@ -79,8 +79,13 @@ export const HUD_CSS = `
   display:flex; align-items:center; gap:clamp(8px,2.2vw,18px); white-space:nowrap; }
 .vt-prompt-bar { width:clamp(10px,3vw,26px); height:clamp(3px,0.7vw,5px); background:currentColor;
   opacity:0.55; }
+/* Paint-order stroke, so the ink's backdrop is the stroke and not the sky.
+   Halfway through a crossing into THE BLEACH the sky is a mid grey, and against
+   a mid grey NO flat ink clears 4.5:1 — black gets to 4.46 and white less. The
+   glyph has to bring its own ground. Same move .vt-banner already makes. */
 .vt-prompt-text { font-size:clamp(30px,7.4vw,72px); line-height:0.95; letter-spacing:0.005em;
-  text-shadow:0 0 22px rgba(0,0,0,0.85), 0 3px 0 rgba(0,0,0,0.55), 0 0 60px currentColor;
+  paint-order:stroke fill; -webkit-text-stroke:clamp(4px,0.9vw,7px) var(--vt-halo-sky,#04060f);
+  text-shadow:0 0 22px rgba(0,0,0,0.85), 0 0 60px currentColor;
   transform-origin:50% 50%; }
 .vt-prompt.vt-punch .vt-prompt-text { animation:vt-punch 0.34s cubic-bezier(.16,1.4,.4,1); }
 @keyframes vt-punch { 0%{transform:scale(1.55);opacity:0.25;} 45%{transform:scale(0.94);opacity:1;} 100%{transform:scale(1);} }
@@ -100,18 +105,23 @@ export const HUD_CSS = `
    contrast to spare, so every value below 1 was under the bar. contrast.ts
    softens and then corrects back, so the number does not have to be a
    compromise between the darkest world and the greyest one. */
-.vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; color:var(--vt-ink-sky-dim,#eaf6ff); }
+.vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; color:var(--vt-ink-sky-dim,#eaf6ff);
+  paint-order:stroke fill; -webkit-text-stroke:2px var(--vt-halo-sky,#04060f); }
 /* Tracking adds a trailing space after the last letter, which right-aligned
    text pushes off a narrow screen. Pull it back. */
 .vt-tr .vt-label { margin-right:-0.28em; }
 .vt-tr .vt-surge { margin-right:-0.02em; }
-.vt-score { font-size:clamp(24px,5.4vw,48px); line-height:1; text-shadow:0 2px 14px rgba(0,0,0,0.8); }
-.vt-dist { font-size:clamp(12px,2.4vw,19px); color:var(--vt-ink-sky-dim,#eaf6ff); line-height:1.3; }
+.vt-score { font-size:clamp(24px,5.4vw,48px); line-height:1;
+  paint-order:stroke fill; -webkit-text-stroke:clamp(3px,0.7vw,5px) var(--vt-halo-sky,#04060f); }
+.vt-dist { font-size:clamp(12px,2.4vw,19px); color:var(--vt-ink-sky-dim,#eaf6ff); line-height:1.3;
+  paint-order:stroke fill; -webkit-text-stroke:2px var(--vt-halo-sky,#04060f); }
 
 .vt-surge { display:flex; align-items:baseline; justify-content:flex-end; gap:2px; }
-.vt-surge-x { font-size:clamp(14px,2.6vw,22px); color:var(--vt-ink-sky-dim,#eaf6ff); }
+.vt-surge-x { font-size:clamp(14px,2.6vw,22px); color:var(--vt-ink-sky-dim,#eaf6ff);
+  paint-order:stroke fill; -webkit-text-stroke:2px var(--vt-halo-sky,#04060f); }
 .vt-surge-n { font-size:clamp(28px,6.4vw,56px); line-height:1;
-  text-shadow:0 0 26px currentColor, 0 2px 12px rgba(0,0,0,0.85); }
+  paint-order:stroke fill; -webkit-text-stroke:clamp(3px,0.7vw,5px) var(--vt-halo-sky,#04060f);
+  text-shadow:0 0 26px currentColor; }
 .vt-surge.vt-bump .vt-surge-n { animation:vt-bump 0.42s cubic-bezier(.16,1.5,.4,1); }
 @keyframes vt-bump { 0%{transform:scale(1.9) rotate(-5deg);} 60%{transform:scale(0.92);} 100%{transform:scale(1);} }
 .vt-chain { display:flex; gap:3px; justify-content:flex-end; margin-top:5px; }
@@ -140,15 +150,21 @@ export const HUD_CSS = `
 .vt-volt-ticks i:last-child { border-right:0; }
 .vt-volt.vt-crit { animation:vt-crit 0.85s steps(2,end) infinite; }
 @keyframes vt-crit { 0%,60%{opacity:1;} 61%,100%{opacity:0.45;} }
+/* Above the bar, so the bar's own bed does not reach it. It gets its own —
+   in landscape this label is out over the OCEAN rather than the deck (the deck
+   is only DECK_HALF metres wide), and in THE BLEACH the ocean is bone while the
+   deck is near-black. One ink cannot clear both; a bed means it does not have
+   to. */
 .vt-volt-label { position:absolute; left:0; bottom:calc(100% + 5px); font-size:clamp(8px,1.5vw,11px);
-  letter-spacing:0.28em; color:var(--vt-ink-deck-dim,#eaf6ff); }
+  letter-spacing:0.28em; color:var(--vt-ink-deck-dim,#eaf6ff); padding:1px 5px;
+  background:rgba(${(VOLT_BED >> 16) & 255},${(VOLT_BED >> 8) & 255},${VOLT_BED & 255},${VOLT_BED_A}); }
 
 /* ---- biome banner ---- */
 .vt-banner { position:absolute; left:0; right:0; top:38%; text-align:center; opacity:0;
   font-size:clamp(20px,5.6vw,54px); letter-spacing:0.2em;
   /* Paint-order stroke, not a glow: in the inverted biome the banner is dark
      ink on bone and a same-colour glow just smears it. */
-  paint-order:stroke fill; -webkit-text-stroke:6px rgba(0,0,0,0.28);
+  paint-order:stroke fill; -webkit-text-stroke:6px var(--vt-halo-sky,#04060f);
   text-shadow:0 0 40px currentColor; }
 .vt-banner.vt-show { animation:vt-banner 2.6s ease-out forwards; }
 @keyframes vt-banner {
@@ -185,7 +201,8 @@ export const HUD_CSS = `
    a flat near-black panel and the run visibly died behind it. Now the causeway
    keeps rushing past in full colour through a thin scrim, the whole rig is lit
    in the current biome's accent, and the three answers are built out of the same
-   posts-and-lintel the gates out on the track are. It is a gate, indoors. */
+   posts-and-lintel the gates out on the track are. It is a gate, indoors.
+
    The scrim's stops live in contrast.ts, not here: the clear window where the
    causeway shows through is the top two fifths, and below it the scrim comes up
    to a floor because that is where the question and the three answers are. A
@@ -260,6 +277,7 @@ export const HUD_CSS = `
 .vt-tool[aria-pressed="true"] span { color:var(--vt-on-deck-ink,#04060f); }
 .vt-tool:focus-visible { outline:3px solid #fff; outline-offset:2px; }
 .vt-perf { position:absolute; left:var(--vt-perf-l,10px); bottom:var(--vt-perf-b,110px);
+  padding:2px 5px; background:rgba(${(VOLT_BED >> 16) & 255},${(VOLT_BED >> 8) & 255},${VOLT_BED & 255},${VOLT_BED_A});
   font-size:11px; letter-spacing:0.1em; opacity:0.6; white-space:pre; display:none;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-weight:400; text-transform:none; }
 .vt-perf.vt-on { display:block; }

--- a/dynawalla/games/runner/src/game/hud.ts
+++ b/dynawalla/games/runner/src/game/hud.ts
@@ -14,6 +14,14 @@
  */
 
 import { hudVars } from "./chrome.ts";
+import {
+  PLAIN_STOPS,
+  REVIVE_STOPS,
+  VOLT_BED,
+  VOLT_BED_A,
+  gradientStops,
+  laneFaceStops,
+} from "./contrast.ts";
 import type { Insets } from "../../../../packs/shared/game-chrome/index.ts";
 
 /**
@@ -42,17 +50,27 @@ const SA_B = "var(--vt-sa-b, 0px)";
 const SA_L = "var(--vt-sa-l, 0px)";
 
 /**
- * The stylesheet, exported so `chrome.test.ts` can hold it to two rules that
+ * The stylesheet, exported so `chrome.test.ts` can hold it to three rules that
  * cannot be checked any other way: it contains no `env(safe-area-inset-*)` — the
  * value that is zero inside a pack and shipped the founder's three collisions —
- * and every positional declaration on the five in-run HUD boxes is a `var()`
- * filled in by `chrome.ts`, so the sheet has no geometry of its own to drift.
+ * every positional declaration on the five in-run HUD boxes is a `var()` filled
+ * in by `chrome.ts`, so the sheet has no geometry of its own to drift, and every
+ * `color` on something a child reads is a `var()` filled in by `contrast.ts`, so
+ * it has no *ink* of its own either. A fixed ink is how the recharge gate came
+ * to be near-black numerals on a near-black panel in THE BLEACH; see
+ * `contrast.ts` for the three separate instances of that one mistake.
  */
 export const HUD_CSS = `
 .vt-root { position:absolute; inset:0; pointer-events:none; overflow:hidden;
   font-family:"Archivo Black","Helvetica Neue","Arial Black","Segoe UI",system-ui,sans-serif;
   font-weight:900; -webkit-font-smoothing:antialiased; text-transform:uppercase;
-  color:#eaf6ff; user-select:none; -webkit-user-select:none; }
+  color:var(--vt-ink-sky,#eaf6ff); user-select:none; -webkit-user-select:none; }
+/* Each family of surfaces takes the ink derived for the thing it lands on. The
+   sky and the deck are different backdrops and used to share one colour, which
+   is why the voltage bar was #12121a on a #0b0b0d deck in THE BLEACH. */
+.vt-prompt, .vt-tl, .vt-tr, .vt-banner { color:var(--vt-ink-sky,#eaf6ff); }
+.vt-volt, .vt-tools, .vt-perf { color:var(--vt-ink-deck,#eaf6ff); }
+.vt-veil { color:var(--vt-ink-veil,#eaf6ff); }
 .vt-root * { box-sizing:border-box; }
 .vt-num { font-variant-numeric:tabular-nums; letter-spacing:0.01em; }
 
@@ -76,16 +94,22 @@ export const HUD_CSS = `
    arithmetic here to disagree with it. */
 .vt-tl { position:absolute; left:var(--vt-tl-x,10px); top:var(--vt-tl-y,63px); }
 .vt-tr { position:absolute; right:var(--vt-tr-x,10px); top:var(--vt-tr-y,63px); text-align:right; }
-.vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; opacity:0.5; }
+/* Quiet, but never quiet enough to stop being readable. These carried an
+   opacity, and an opacity composites the ink into the sky — halfway through the
+   crossing from THE ABYSS to THE BLEACH the sky is a mid grey where no ink has
+   contrast to spare, so every value below 1 was under the bar. contrast.ts
+   softens and then corrects back, so the number does not have to be a
+   compromise between the darkest world and the greyest one. */
+.vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; color:var(--vt-ink-sky-dim,#eaf6ff); }
 /* Tracking adds a trailing space after the last letter, which right-aligned
    text pushes off a narrow screen. Pull it back. */
 .vt-tr .vt-label { margin-right:-0.28em; }
 .vt-tr .vt-surge { margin-right:-0.02em; }
 .vt-score { font-size:clamp(24px,5.4vw,48px); line-height:1; text-shadow:0 2px 14px rgba(0,0,0,0.8); }
-.vt-dist { font-size:clamp(12px,2.4vw,19px); opacity:0.72; line-height:1.3; }
+.vt-dist { font-size:clamp(12px,2.4vw,19px); color:var(--vt-ink-sky-dim,#eaf6ff); line-height:1.3; }
 
 .vt-surge { display:flex; align-items:baseline; justify-content:flex-end; gap:2px; }
-.vt-surge-x { font-size:clamp(14px,2.6vw,22px); opacity:0.6; }
+.vt-surge-x { font-size:clamp(14px,2.6vw,22px); color:var(--vt-ink-sky-dim,#eaf6ff); }
 .vt-surge-n { font-size:clamp(28px,6.4vw,56px); line-height:1;
   text-shadow:0 0 26px currentColor, 0 2px 12px rgba(0,0,0,0.85); }
 .vt-surge.vt-bump .vt-surge-n { animation:vt-bump 0.42s cubic-bezier(.16,1.5,.4,1); }
@@ -103,16 +127,21 @@ export const HUD_CSS = `
    strip eats the pixels and reports an inset of zero. See GESTURE_STRIP. */
 .vt-volt { position:absolute; left:var(--vt-volt-l,10px); right:var(--vt-volt-r,10px);
   bottom:var(--vt-volt-b,36px); height:var(--vt-volt-h,9px);
-  border:2px solid rgba(255,255,255,0.30); display:flex; align-items:stretch; padding:2px; }
+  border:2px solid rgba(255,255,255,0.30); display:flex; align-items:stretch; padding:2px;
+  /* A bed, so the fill has a backdrop that is known rather than whatever stretch
+     of deck or ocean happens to be under the bar. THE BLEACH's deck is #0b0b0d
+     and its ocean is #c9c3b4 — no single fill colour clears 4.5:1 against both,
+     and a full-width bar crosses both. */
+  background:rgba(${(VOLT_BED >> 16) & 255},${(VOLT_BED >> 8) & 255},${VOLT_BED & 255},${VOLT_BED_A}); }
 .vt-volt-fill { height:100%; width:100%; transform-origin:0 50%; transition:none;
-  box-shadow:0 0 18px currentColor; background:currentColor; }
+  box-shadow:0 0 18px currentColor; background:var(--vt-volt-fill,#eaf6ff); }
 .vt-volt-ticks { position:absolute; inset:2px; display:flex; }
 .vt-volt-ticks i { flex:1; border-right:2px solid rgba(0,0,0,0.55); }
 .vt-volt-ticks i:last-child { border-right:0; }
 .vt-volt.vt-crit { animation:vt-crit 0.85s steps(2,end) infinite; }
 @keyframes vt-crit { 0%,60%{opacity:1;} 61%,100%{opacity:0.45;} }
 .vt-volt-label { position:absolute; left:0; bottom:calc(100% + 5px); font-size:clamp(8px,1.5vw,11px);
-  letter-spacing:0.28em; opacity:0.5; }
+  letter-spacing:0.28em; color:var(--vt-ink-deck-dim,#eaf6ff); }
 
 /* ---- biome banner ---- */
 .vt-banner { position:absolute; left:0; right:0; top:38%; text-align:center; opacity:0;
@@ -133,19 +162,20 @@ export const HUD_CSS = `
   justify-content:center; pointer-events:auto;
   padding:calc(${SA_T} + clamp(14px,4vw,40px)) calc(${SA_R} + clamp(14px,4vw,40px))
           calc(${SA_B} + clamp(14px,4vw,40px)) calc(${SA_L} + clamp(14px,4vw,40px));
-  background:radial-gradient(ellipse at 50% 45%, rgba(2,4,12,0.55) 0%, rgba(2,4,12,0.93) 72%); }
+  background:radial-gradient(ellipse at 50% 45%, ${gradientStops(PLAIN_STOPS)}); }
 .vt-veil.vt-on { display:flex; }
 .vt-title { font-size:clamp(38px,12vw,110px); line-height:0.86; letter-spacing:0.04em;
   text-shadow:0 0 60px currentColor; }
-.vt-sub { font-size:clamp(11px,2.3vw,16px); letter-spacing:0.3em; opacity:0.62; margin-top:14px; text-align:center; }
-.vt-hint { font-size:clamp(10px,2vw,14px); letter-spacing:0.22em; opacity:0.45; margin-top:26px; text-align:center; line-height:2; }
-/* background:currentColor only works while color is still the inherited accent
-   — setting color on the button itself paints it black on black. The label
-   carries its own dark colour instead. */
+.vt-sub { font-size:clamp(11px,2.3vw,16px); letter-spacing:0.3em; color:var(--vt-ink-veil-dim,#eaf6ff); margin-top:14px; text-align:center; }
+.vt-hint { font-size:clamp(10px,2vw,14px); letter-spacing:0.22em; color:var(--vt-ink-veil-dim,#eaf6ff); margin-top:26px; text-align:center; line-height:2; }
+/* background:currentColor only works while color is still the inherited ink —
+   setting color on the button itself paints it black on black. The label carries
+   its own colour instead, derived from the ink the fill is painted in. It was a
+   fixed #04060f, which is a coin toss the moment the ink stops being pale. */
 .vt-btn { pointer-events:auto; margin-top:26px; padding:clamp(12px,2.6vw,20px) clamp(26px,7vw,64px);
   font:inherit; font-size:clamp(15px,3.4vw,26px); letter-spacing:0.18em; text-transform:uppercase;
   background:currentColor; border:0; cursor:pointer; box-shadow:0 0 40px currentColor; }
-.vt-btn span { color:#04060f; }
+.vt-btn span { color:var(--vt-on-veil-ink,#04060f); }
 .vt-btn:active { transform:translateY(2px); }
 .vt-btn:focus-visible { outline:3px solid #fff; outline-offset:3px; }
 
@@ -156,10 +186,14 @@ export const HUD_CSS = `
    keeps rushing past in full colour through a thin scrim, the whole rig is lit
    in the current biome's accent, and the three answers are built out of the same
    posts-and-lintel the gates out on the track are. It is a gate, indoors. */
+   The scrim's stops live in contrast.ts, not here: the clear window where the
+   causeway shows through is the top two fifths, and below it the scrim comes up
+   to a floor because that is where the question and the three answers are. A
+   numeral cannot be legible against a band that runs from bone to black behind
+   it, and that band is exactly what shipped. */
 .vt-veil[data-v="revive"] {
   background:
-    linear-gradient(180deg, rgba(3,7,18,0.82) 0%, rgba(3,7,18,0.16) 26%,
-                            rgba(3,7,18,0.16) 52%, rgba(3,7,18,0.88) 82%),
+    linear-gradient(180deg, ${gradientStops(REVIVE_STOPS)}),
     radial-gradient(ellipse at 50% 42%, rgba(0,0,0,0) 40%, rgba(2,5,14,0.55) 100%);
   justify-content:flex-end; padding-bottom:calc(${SA_B} + clamp(20px,5vh,54px)); }
 /* A charge front sweeping up the screen. Slow, wide, low-contrast: energy, not
@@ -170,8 +204,11 @@ export const HUD_CSS = `
 @keyframes vt-charge { 0%{transform:translateY(120%);} 100%{transform:translateY(-160%);} }
 
 .vt-charge { display:flex; align-items:center; gap:clamp(10px,2.4vw,20px); margin-bottom:clamp(6px,1.4vh,14px); }
-.vt-charge-label { font-size:clamp(11px,2.3vw,16px); letter-spacing:0.34em; opacity:0.8;
-  color:var(--vt-accent, currentColor); text-shadow:0 0 22px currentColor; }
+/* The accent, corrected only as far as it takes to clear 4.5:1 on the scrim —
+   so it still reads as the biome you died in. --vt-accent is the raw world
+   colour and belongs to glows and rules, never to a word. */
+.vt-charge-label { font-size:clamp(11px,2.3vw,16px); letter-spacing:0.34em; opacity:1;
+  color:var(--vt-accent-veil, currentColor); text-shadow:0 0 22px var(--vt-accent, currentColor); }
 .vt-revive-prompt { font-size:clamp(36px,9.6vw,88px); line-height:1; margin:2px 0 clamp(14px,2.4vh,28px);
   paint-order:stroke fill; -webkit-text-stroke:8px rgba(2,5,14,0.6);
   text-shadow:0 0 46px var(--vt-accent, currentColor); }
@@ -180,7 +217,7 @@ export const HUD_CSS = `
 .vt-lane { pointer-events:auto; position:relative; flex:1; min-width:0; aspect-ratio:3/2.5;
   border:0; border-left:clamp(4px,0.9vw,7px) solid var(--vt-accent, #6cf);
   border-right:clamp(4px,0.9vw,7px) solid var(--vt-accent, #6cf);
-  background:linear-gradient(180deg, rgba(255,255,255,0.10), rgba(4,10,22,0.30) 55%, rgba(4,10,22,0.62));
+  background:linear-gradient(180deg, ${laneFaceStops()});
   color:inherit; font:inherit; cursor:pointer; overflow:hidden;
   font-size:clamp(30px,8.6vw,66px); display:flex; align-items:center; justify-content:center;
   font-variant-numeric:tabular-nums; letter-spacing:0.01em;
@@ -191,11 +228,12 @@ export const HUD_CSS = `
   background:var(--vt-accent, #6cf); box-shadow:0 0 24px var(--vt-accent, #6cf); }
 .vt-lane::after { content:""; position:absolute; left:0; right:0; bottom:0; height:2px;
   background:var(--vt-accent, #6cf); opacity:0.45; }
-.vt-lane span { position:relative; text-shadow:0 0 30px rgba(0,0,0,0.9), 0 3px 0 rgba(0,0,0,0.55); }
+.vt-lane span { position:relative; color:var(--vt-ink-lane,#eaf6ff);
+  text-shadow:0 0 30px rgba(0,0,0,0.9), 0 3px 0 rgba(0,0,0,0.55); }
 .vt-lane:active { transform:translateY(3px); }
 .vt-lane:focus-visible { outline:3px solid #fff; outline-offset:4px; }
 .vt-lane.vt-right { background:var(--vt-accent, #6cf); box-shadow:0 0 70px var(--vt-accent, #6cf); }
-.vt-lane.vt-right span { color:#04060f; text-shadow:none; }
+.vt-lane.vt-right span { color:var(--vt-on-accent,#04060f); text-shadow:none; }
 .vt-lane.vt-wrong { opacity:0.22; }
 .vt-ring { width:clamp(52px,11vw,84px); height:clamp(52px,11vw,84px); }
 .vt-ring circle { fill:none; stroke-width:9; }
@@ -208,7 +246,7 @@ export const HUD_CSS = `
   margin-top:clamp(16px,3vw,30px); }
 .vt-stat { text-align:left; }
 .vt-stat b { display:block; font-size:clamp(20px,5vw,40px); line-height:1; font-variant-numeric:tabular-nums; }
-.vt-stat i { display:block; font-style:normal; font-size:clamp(8px,1.6vw,11px); letter-spacing:0.26em; opacity:0.5; margin-top:5px; }
+.vt-stat i { display:block; font-style:normal; font-size:clamp(8px,1.6vw,11px); letter-spacing:0.26em; color:var(--vt-ink-veil-dim,#eaf6ff); margin-top:5px; }
 
 /* ---- settings ----
    Stacked on the voltage readout rather than measured from the bottom edge, so
@@ -219,7 +257,7 @@ export const HUD_CSS = `
   background:rgba(2,5,14,0.55); color:inherit; font:inherit; font-size:clamp(11px,2.2vw,14px);
   cursor:pointer; display:flex; align-items:center; justify-content:center; padding:0; }
 .vt-tool[aria-pressed="true"] { background:currentColor; }
-.vt-tool[aria-pressed="true"] span { color:#04060f; }
+.vt-tool[aria-pressed="true"] span { color:var(--vt-on-deck-ink,#04060f); }
 .vt-tool:focus-visible { outline:3px solid #fff; outline-offset:2px; }
 .vt-perf { position:absolute; left:var(--vt-perf-l,10px); bottom:var(--vt-perf-b,110px);
   font-size:11px; letter-spacing:0.1em; opacity:0.6; white-space:pre; display:none;

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -229,6 +229,7 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
   // The last blend the inks were derived from. Deriving is a dozen luminance
   // sums and this runs on every frame of a crossing, so it is skipped when the
   // three colours it depends on have not moved — which is most frames.
+  let inkTop = -1;
   let inkSky = -1;
   let inkDeck = -1;
   let inkAccent = -1;
@@ -259,14 +260,21 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     // screen. This used to be one flat `hud.root.style.color` chosen from
     // `biome.inverted` — which describes the sky, and the veils do not sit on
     // the sky. See contrast.ts.
+    const topHex = shared.uSkyTop.value.getHex(THREE.SRGBColorSpace);
     const skyHex = shared.uSkyBot.value.getHex(THREE.SRGBColorSpace);
     const deckHex = shared.uDeck.value.getHex(THREE.SRGBColorSpace);
     const accentHex = shared.uAccent.value.getHex(THREE.SRGBColorSpace);
-    if (skyHex !== inkSky || deckHex !== inkDeck || accentHex !== inkAccent) {
+    if (
+      topHex !== inkTop ||
+      skyHex !== inkSky ||
+      deckHex !== inkDeck ||
+      accentHex !== inkAccent
+    ) {
+      inkTop = topHex;
       inkSky = skyHex;
       inkDeck = deckHex;
       inkAccent = accentHex;
-      const vars = inkVars(skyHex, deckHex, accentHex);
+      const vars = inkVars(topHex, skyHex, deckHex, accentHex);
       for (const [name, value] of Object.entries(vars)) hud.root.style.setProperty(name, value);
     }
     post.composite.uniforms.uExposure.value = biome.inverted ? 0.88 : 1.06;

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -19,6 +19,7 @@ import { biomeAt, biomeLength } from "./biomes.ts";
 import { detectTier, TierController, type TierName } from "./tiers.ts";
 import { buildHud, groupDigits, layoutHud, ringCircumference } from "./hud.ts";
 import { makeStage, ndcFrame } from "./chrome.ts";
+import { inkVars } from "./contrast.ts";
 import type { Frame } from "./readband.ts";
 import {
   createInstructions,
@@ -225,6 +226,12 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
   const tmpA = new THREE.Color();
   const tmpB = new THREE.Color();
   const numeralInk: [number, number, number] = [1, 1, 1];
+  // The last blend the inks were derived from. Deriving is a dozen luminance
+  // sums and this runs on every frame of a crossing, so it is skipped when the
+  // three colours it depends on have not moved — which is most frames.
+  let inkSky = -1;
+  let inkDeck = -1;
+  let inkAccent = -1;
   function applyBiomeUniforms(): void {
     const m = easeOutCubic(biomeMix);
     const mixHex = (a: number, b: number, out: THREE.Color) => {
@@ -243,10 +250,25 @@ export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
     (sky.material.uniforms.uStars as { value: number }).value = lerp(prevBiome.starDensity, biome.starDensity, m);
     const vig = post.composite.uniforms.uVignetteColor.value as THREE.Color;
     vig.copy(shared.uFogColor.value).multiplyScalar(biome.inverted ? 1.1 : 0.55);
-    hud.root.style.color = biome.inverted ? "#12121a" : "#eaf6ff";
     // The chrome borrows the world's accent, so the recharge gate is lit by the
     // biome you died in rather than being a grey box bolted over the top of it.
     hud.root.style.setProperty("--vt-accent", `#${shared.uAccent.value.getHexString()}`);
+    // ...and every ink is derived from the surface it lands on, off the LIVE
+    // blend rather than the biome record, so a child who dies half way through a
+    // crossing gets a recharge gate legible against the sky that is actually on
+    // screen. This used to be one flat `hud.root.style.color` chosen from
+    // `biome.inverted` — which describes the sky, and the veils do not sit on
+    // the sky. See contrast.ts.
+    const skyHex = shared.uSkyBot.value.getHex(THREE.SRGBColorSpace);
+    const deckHex = shared.uDeck.value.getHex(THREE.SRGBColorSpace);
+    const accentHex = shared.uAccent.value.getHex(THREE.SRGBColorSpace);
+    if (skyHex !== inkSky || deckHex !== inkDeck || accentHex !== inkAccent) {
+      inkSky = skyHex;
+      inkDeck = deckHex;
+      inkAccent = accentHex;
+      const vars = inkVars(skyHex, deckHex, accentHex);
+      for (const [name, value] of Object.entries(vars)) hud.root.style.setProperty(name, value);
+    }
     post.composite.uniforms.uExposure.value = biome.inverted ? 0.88 : 1.06;
     // Candidate numerals are hot white ink with a black stroke in the dark
     // worlds, and black ink with a bone stroke in THE BLEACH. Contrast is never


### PR DESCRIPTION
Two founder playtest defects from 0.3.6 in VOLTA.

## The recharge question was unreadable

> "recharge questions are not always legible in every theme, or maybe most/all screens .. black numbers on dark background."

Three separate fixed colours, all the same mistake — a colour picked from something other than the thing the text actually lands on.

| where | was | now |
|---|---|---|
| the recharge **question**, THE BLEACH (every lap) | **1.20:1** | 14.99:1 |
| the recharge **question**, worst mid-crossing | **1.00:1** — ink and panel are the same colour | 14.90:1 |
| the **chosen answer**, AURORA SHELF II (accent `#3c37ff`) | **3.07:1** | 6.01:1 |
| the **voltage** readout, THE BLEACH (deck `#0b0b0d`) | **1.06:1** | 17.9:1 |
| the **VOLTAGE label** over the ocean in landscape, THE BLEACH | **1.15:1** | 8.9:1 |
| SCORE / SURGE at `opacity:0.5`, THE BLEACH | **3.43:1** | ≥4.5:1 |

1. The whole HUD's ink was `biome.inverted ? "#12121a" : "#eaf6ff"` — chosen from the **sky**. The veils do not sit on the sky; they paint their own dark scrim over it. In THE BLEACH the sky is bone, so `inverted` is true, so the ink went near-black, and the recharge veil's lower band composites to `rgb(33,36,45)`. That is the screenshot.
2. `.vt-lane.vt-right span` was a fixed `#04060f` on a fill of the **live accent**. Accents hue-rotate 0.14 turns per lap for ever, and hue moves relative luminance enormously at constant HSL lightness. Nobody authored `#3c37ff`; the rotation produced it, so no amount of checking the four base biomes would have found it.
3. The voltage readout took the sky's ink and sits on the **deck**, which is near-black in all four biomes — including the one whose sky is bone.

New `contrast.ts` derives each ink from the composited background of its own surface. `hud.ts` has no ink of its own left — the same contract `chrome.ts` already imposes on geometry. The luminance formula is the one `games/stack/src/game/strata.ts` already derives its chrome from; that game learned this lesson first.

### Four things fell out of fixing it properly rather than patching the ink

- **`opacity` is a contrast cut nothing was measuring.** SCORE / SURGE / VOLTAGE / the hints were dimmed with `opacity: 0.45`–`0.6`, and an opacity composites the ink into the backdrop — a 4.5:1 ink at 0.45 is a 3.86:1 ink. Raising it does not work either: halfway through THE ABYSS → THE BLEACH the sky is a mid grey where the best ink clears the bar by a hair, so *every* value below 1 is under it. They now soften toward the backdrop and correct back, so a dark world still gets a quiet label and a grey one gets full strength.
- **No ink clears 4.5:1 against a band that runs from bone to black behind it**, and that is what the recharge scrim did under the question. The content band gets a floor; the clear window onto the causeway moves to the top two fifths, where no text lives. Still a gate, not a dialog box.
- **Against a mid-grey sky no flat ink clears 4.5:1 at all** — black reaches 4.46 and white less. So the sky-band text stops relying on the sky: `paint-order: stroke fill` with a derived halo gives each glyph its own ground. That is the move `.vt-banner` and `.vt-revive-prompt` already made in this stylesheet, for this exact reason. Sparsen the field; the effects stay.
- **The bottom furniture crosses two worlds.** The deck is only `DECK_HALF` metres wide, so in landscape the voltage readout's left end is out over the ocean — bone in THE BLEACH, against a near-black deck. No single ink clears both, so everything down there sits on a bed, and the ink is derived against the bed.

### Verification

`contrast.test.ts` walks **32 biomes** (eight laps — a full circuit of the 0.14-turn hue wheel) × **eleven points across every crossing**, and computes WCAG contrast for every ink against every backdrop it can land on: **88,704 assertions**, none eyeballed.

Eleven crossfade points and not five: `mount.ts` eases the mix, so the band where the correct pole flips is roughly 130 ms of a 1.6 s crossing, and a five-point grid steps straight over it.

## The ship sounded like a motorcycle

> "sort of static and annoying like 4-bit motorcycle sound .. it could be more magical electrical .. maybe not so loud."

It was a **sawtooth** at 52-86 Hz into a lowpass at **Q = 7** — the standard recipe for a two-stroke. Sawtooth harmonics fall off at 1/n, so there is real energy right through the ear's most sensitive band, and a Q of 7 is a ~17 dB resonant peak swept by the player's own speed: a whine that follows them.

Now: two **triangles** nine cents apart (1/n², and the pair beats slowly against itself — that beating is the "magical electrical", and it costs one oscillator). Q down to 1.1 so the sweep reads as opening rather than whining. A quiet high partial breathing at 0.19 Hz for the space-age end. Grit down to a quarter. The bed is a little over half its old level at every speed, wind roughly half.

No new audio infrastructure — one voice inside the existing `packs/shared/game-audio` routing, deliberately kept small so it will not collide with the soundscape work in flight.

## Adversarial review found that the main change never reached the screen

A stray comment terminator left five lines of English in the selector prelude, which invalidates `.vt-veil[data-v="revive"]` and makes a CSS parser drop the whole declaration block — silently, on the device. The recharge gate fell back to the generic veil. Verified against a real engine: 86 rules parsed instead of 87.

**Every assertion about that rule went on passing**, because they were substring searches on the template literal and the text was still in it. The suite now *parses* `HUD_CSS` with a brace walker that strips comments while deliberately leaving an orphaned terminator in place — that orphan is the signature of the defect — and asserts every prelude is a selector a browser would accept, that the seven rules the gate is built from exist as rules, and that the revive rule carries the scrim and the `flex-end`.

Three further review findings, all fixed: the sky ink was derived from `uSkyBot` while the text sits on ~72–81% `uSkyTop`; the VOLTAGE label was the one element still coloured from a surface it does not land on; and `toward()` picked its pole from `bgs[0]` and never reconsidered, losing about one time in six on inks whose backgrounds straddle mid grey.

**Three of my own new assertions were vacuous.** "Every ink clears 4.5:1" cannot catch a backdrop *model* that is wrong, because a wrong model usually still yields a readable colour — it yields one that plain white or plain black would have beaten. So there is now an assertion that every derived ink is at least as good as either house ink would have been on the same backdrop, with the deliberately-softened inks marked exempt.

## Gates

- `npm run -s tsc` clean; `npm run -s test` **153 pass / 0 fail, 5 consecutive runs**; `npm run -s build:pack` builds
- **18 mutation tests**, each breaking one thing and confirming the test fails by name:

| mutation | failure |
|---|---|
| veil ink taken from the sky again | `THE ABYSS -> THE BLEACH @0.5: the recharge QUESTION is #010102 on #10141e — 1.13:1` |
| `onAccent` back to fixed `#04060f` | `THE BLEACH -> AURORA SHELF II @0.3: the CHOSEN answer is #04060f on the accent #c53199 — 4.12:1` |
| `REVIVE_STOPS` back to the shipped gradient | `the scrim is 0.16 at 0.46, where an answer is drawn` |
| `dimInk` stops correcting back | `61 of 88704 surfaces are illegible` |
| sky ink from `skyBot` only | `THE ABYSS -> THE BLEACH @0.45: the sky ink #12121a manages 3.38:1 across the sky band, but plain #eaf6ff manages 3.64:1 — the band is not being sampled` |
| `toward` returns its first pole unexamined | `toward(#089828, [#9d6f9a]) returned #ffffff at 4.06:1 — the other pole reaches 5.17:1` |
| the VOLTAGE label loses its bed | `.vt-volt-label has no bed, so its ink is derived against a lie` |
| a literal ink back on `.vt-veil` | `.vt-veil { color: #eaf6ff } — a fixed ink is the whole defect; derive it in contrast.ts` |
| an `opacity` back on `.vt-hint` | `.vt-hint carries an opacity again — soften it with a derived ink, not by fading it` |
| lane gradient hand-written | `the recharge lane's face is not built from LANE_FACE` |
| the prompt loses `paint-order` | `.vt-prompt-text strokes without paint-order, so the stroke is painted OVER the glyph` |
| **stray comment terminator (the review HIGH)** | `a comment leaked into a selector: "The scrim's stops live in contrast.ts…"` + `.vt-veil[data-v="revive"] is not a rule in the stylesheet` |
| ship back to a sawtooth | `a sawtooth is back in the graph` |
| ship back to Q=7 | `a filter with a sweepable resonant peak is back in the bed` |
| bed back to the shipped volume | `at speed 0 the bed is 0.13, and it shipped at 0.13` |
| detuned twin removed | `expected two detuned triangle oscillators` |
| `buildEngine` ignores the detune (record intact, graph wrong) | `expected two detuned triangle oscillators` |
| shimmer LFO replaces its gain instead of offsetting it | `the shimmer's intrinsic gain is not the offset` |
| an oscillator survives dispose | `an oscillator survives dispose and keeps running after unmount` |

No gameplay, pacing or difficulty behaviour is touched.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb