### PR TITLE
fix(dynawalla/host): a pack's difficulty is a hint clamped to ±1 rung of the host's band

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -497,6 +497,9 @@ test("the founder's rule: a pack asking for the top while the child sustains 60%
   )
   // Said again as a number a person can check against the ladder: asking for the
   // hardest rung in the curriculum, three hundred times, never got half way to it.
+  // Guarded on the ladder's size, because this form of the claim is the only one
+  // in this test that a shorter curriculum could falsify on correct code.
+  assert.ok(span >= 44, `a ${String(span)}-rung ladder is too short for the claim below`)
   assert.ok(
     2 * highest < span,
     `the pack asked for rung ${String(span)} on every one of 300 questions and reached rung ` +
@@ -607,11 +610,24 @@ test("the banked fraction survives a pack that names a difficulty on every quest
   // Nothing is written to `progress` by a request now, so the fraction and the
   // rung both survive; this holds the property from the outside, where a future
   // author who reintroduces a write can see it fail.
+  //
+  // **The child is walked off rung 0 first, and the request names a different
+  // rung, and both of those are load-bearing.** An earlier draft of this test ran
+  // the whole thing at rung 0 asking for rung 0, and it passed with the fix
+  // reverted — at an anchor of 0 the old `progress = index + (progress −
+  // Math.floor(progress))` is the identity, so it exercised the one arrangement
+  // in which the deleted write does nothing. A test that passes against the code
+  // it was written to reject is worse than no test, because it is counted.
   const rungs = ladder()
   const span = rungs.length - 1
+  assert.ok(span > 8)
   const service = createItemService({ profileId: "p-slow", record: noRecord, rungs })
+  climbTo(service, 5)
+  const from = service.position()
   let answers = 0
-  while (service.position() < 1 && answers < 200) {
+  while (service.position() <= from && answers < 200) {
+    // A rung below the child, every question, which is what a game whose own
+    // ladder is pinned lower than the host's does all session.
     const item = service.next({ packId: "dynawalla.truedraw", difficulty: 0 })
     assert.ok(item)
     answers += 1
@@ -625,9 +641,9 @@ test("the banked fraction survives a pack that names a difficulty on every quest
     })
   }
   assert.ok(
-    service.position() >= 1,
-    `a slow-and-correct child with a pack naming a difficulty every question never left rung 0 ` +
-      `in ${String(answers)} answers`,
+    service.position() > from,
+    `a slow-and-correct child with a pack naming a difficulty every question never got off rung ` +
+      `${String(from)} in ${String(answers)} answers`,
   )
   // And it was banked rather than bought: more than one answer went into it, so
   // what moved the child was the accumulated fraction and not one whole stride.
@@ -635,7 +651,45 @@ test("the banked fraction survives a pack that names a difficulty on every quest
     answers > 1,
     "the first answer in the slow tail was worth a whole rung, so this proves nothing about the fraction",
   )
-  assert.ok(span > 1)
+})
+
+test("a ceiling below the child still pins the ladder, which is the one way a pack still drives it", () => {
+  // The boundary of the clamp, asserted so that nobody reads the tests above as
+  // saying more than they do. `maxDifficulty` is not a hint and is not banded: it
+  // is a pack declaring what it can physically draw, and a pack whose ceiling
+  // sits below the child's rung both gets served at its ceiling *and* pulls the
+  // host's ladder down to it — exactly as it did before the band existed, and
+  // deliberately, because a position standing above content the pack can never
+  // test the child on is a fiction, and because handing a game a rung it cannot
+  // render is how PR 694 happened.
+  //
+  // The cost is real and is worth stating plainly: a pack that pins its ceiling
+  // to its own request has opted out of the clamp entirely. `counterweight` does
+  // exactly that (`games/counterweight/src/game/ladder.ts`, `difficulty: rung,
+  // maxDifficulty: rung`), and `balance`, `horde`, `merge-idle`, `polarity`,
+  // `gavel` and `lattice` all carry a standing ceiling that dilutes it. Widening
+  // what those games can draw is pack work; it cannot be done from here without
+  // serving a game a question it cannot put on the screen.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-ceiling", record: noRecord, rungs })
+  climbTo(service, 20)
+  assert.ok(service.position() >= 20)
+
+  const pinned = 3
+  const item = service.next({
+    packId: "dynawalla.counterweight",
+    difficulty: pinned / span,
+    maxDifficulty: pinned / span,
+  })
+  assert.ok(item)
+  assert.equal(Math.round((item.difficulty ?? -1) * span), pinned, "the ceiling was not honoured")
+  assert.equal(
+    service.position(),
+    pinned,
+    "a ceiling under the child's rung no longer pins the ladder — that is a change to what " +
+      "`maxDifficulty` means, not to what `difficulty` means",
+  )
 })
 
 test("every rung on the ladder draws a question with numbers in it", () => {

--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -26,6 +26,7 @@ import {
   DESCENT_FAR,
   DESCENT_NEAR,
   descentOf,
+  HINT_BAND,
   isQuick,
   itemPace,
   ladder,
@@ -46,7 +47,7 @@ import {
   STEP_START,
   STEP_TRACK,
 } from "./items.ts"
-import type { Band, Recent, Rung, Staircase } from "./items.ts"
+import type { Band, ItemService, Recent, Rung, Staircase } from "./items.ts"
 import type { PromptBlank, PromptSlot } from "./curriculum.ts"
 import {
   activeNodes,
@@ -61,6 +62,33 @@ import {
 } from "./curriculum.ts"
 
 const noRecord = () => {}
+
+/**
+ * Walk a service up to a rung the way a child does: by being right, at the pace
+ * the item's own class publishes.
+ *
+ * There is no other way in, and since issue 733 there is deliberately no other way
+ * in — a `difficulty` is a hint clamped to `HINT_BAND` rungs of where the host
+ * already stands, so a test that wants the host on rung 20 has to put it there
+ * with evidence. Which is the point: it is the same route a child takes.
+ */
+function climbTo(service: ItemService, rung: number, packId = "dynawalla.fuse"): void {
+  for (let guard = 0; guard < 400 && service.position() < rung; guard++) {
+    const item = service.next({ packId })
+    assert.ok(item)
+    service.judge({
+      packId,
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+  }
+  assert.ok(
+    service.position() >= rung,
+    `400 correct answers at the published median did not reach rung ${String(rung)} — the ladder ` +
+      `stopped at ${String(service.position())}`,
+  )
+}
 
 test("the ladder is every generatable binding, easiest first, and it is not empty", () => {
   const rungs = ladder()
@@ -282,10 +310,12 @@ test("choices are stable for an exercise, so a redraw does not move the right sl
   assert.deepEqual(choicesFor(exercise, 0), choicesFor(exercise, 0))
 })
 
-test("a difficulty request selects the rung, and the item says which rung it came from", () => {
+test("a difficulty request selects a rung inside the host's band, and the item says which rung it came from", () => {
   const rungs = ladder()
-  assert.ok(rungs.length > 1, "a one-rung ladder cannot demonstrate selection")
+  const span = rungs.length - 1
+  assert.ok(span > 2 * HINT_BAND, "the ladder is too short to tell a band from the whole of it")
   const service = createItemService({ profileId: "p1", record: noRecord })
+  assert.equal(service.position(), 0, "a fresh service does not start on rung 0")
 
   const easiest = service.next({ packId: "dynawalla.slice", difficulty: 0 })
   const hardest = service.next({ packId: "dynawalla.slice", difficulty: 1 })
@@ -293,17 +323,28 @@ test("a difficulty request selects the rung, and the item says which rung it cam
 
   // The ordinate the pack is told is the position of the rung it was served,
   // 0..1 across the whole ladder — not `level`, which is the level within one
-  // skill and is not comparable between two of them.
+  // skill and is not comparable between two of them. And it is the rung it was
+  // *served*: this service stands on rung 0 with no evidence about the child at
+  // all, so a request for the top of the ladder is honoured as far as the band
+  // reaches and stops there. Before issue 733 the second line of this test asserted
+  // `1`, and a pack could put a beginner on the hardest rung the curriculum has
+  // by asking.
   assert.equal(easiest.difficulty, 0)
-  assert.equal(hardest.difficulty, 1)
+  assert.equal(hardest.difficulty, HINT_BAND / span)
   assert.equal(rungs[0]?.node.id, easiest.skillId)
-  assert.equal(rungs[rungs.length - 1]?.node.id, hardest.skillId)
-  assert.notEqual(easiest.prompt, hardest.prompt)
+  assert.equal(rungs[HINT_BAND]?.node.id, hardest.skillId)
 
-  // The middle of the ladder is the middle of the ladder, and it moves.
-  const middle = service.next({ packId: "dynawalla.slice", difficulty: 0.5 })
-  const where = middle?.difficulty ?? -1
-  assert.ok(where > 0.3 && where < 0.7, `0.5 landed at ${String(where)}`)
+  // The request still selects *within* the band, in both directions, and the
+  // band moves with the child rather than with the ladder. Walked up on the
+  // host's own evidence first, because a band around rung 0 has only one side.
+  climbTo(service, 20)
+  const where = service.position()
+  const low = service.next({ packId: "dynawalla.slice", difficulty: 0 })
+  const high = service.next({ packId: "dynawalla.slice", difficulty: 1 })
+  assert.ok(low && high)
+  assert.equal(Math.round((low.difficulty ?? -1) * span), where - HINT_BAND)
+  assert.equal(Math.round((high.difficulty ?? -1) * span), where + HINT_BAND)
+  assert.notEqual(low.prompt, high.prompt)
 })
 
 test("a ceiling is honoured, and an unsatisfiable request clamps to the nearest rung that exists", () => {
@@ -336,51 +377,265 @@ test("a ceiling is honoured, and an unsatisfiable request clamps to the nearest 
   assert.equal(under.difficulty, 0, "an impossible request did not land on the easiest rung")
   const over = service.next({ packId: "dynawalla.siege", difficulty: 99 })
   assert.ok(over)
-  assert.equal(over.difficulty, 1, "an impossible request did not land on the hardest rung")
+  // The nearest satisfiable request, and since issue 733 what is satisfiable is the
+  // band as well as the ladder: this service stands on rung 0, so the nearest
+  // rung it can be asked for is `HINT_BAND` above it. Worth noting because a
+  // request of 99 is not hypothetical — `beam` sends `2 + Math.round(level × 7)`
+  // and `stack` sends a floor number, on scales that were never 0..1, and every
+  // one of them used to arrive as "the hardest rung in the curriculum, please".
+  assert.equal(
+    over.difficulty,
+    HINT_BAND / (ladder().length - 1),
+    "an impossible request did not land on the hardest rung the band allows",
+  )
 })
 
-test("driving the difficulty moves the one ladder, so judging resumes from where the pack left it", () => {
-  const service = createItemService({ profileId: "p1", record: noRecord })
-  assert.equal(service.position(), 0)
+test("driving the difficulty does not move the ladder: the pack proposes and the band disposes", () => {
+  // This test asserted the *opposite* until issue 733, and the sentence it asserted —
+  // "driving the difficulty moves the one ladder" — is the defect written down
+  // as a property. `next()` used to apply a request by rewriting the whole rung
+  // of `progress`, keeping only the banked fraction, so a pack that drives
+  // difficulty every question overwrote the band's climb before the band could
+  // serve a single item from it. ARENA measured `host pos 22 → 26 → 22`, every
+  // question, on the real scheduler. Seventeen of the twenty-seven shipping
+  // packs drive difficulty and not one of them reads `position()`, so for
+  // seventeen games the founder's 85/95 rule was computed and then discarded.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p1", record: noRecord, rungs })
+  climbTo(service, 20)
+  const where = service.position()
 
   const item = service.next({ packId: "dynawalla.stack", difficulty: 1 })
   assert.ok(item)
-  const top = service.position()
-  assert.ok(top > 0, "a difficulty request left the ladder standing where it was")
+  assert.equal(service.position(), where, "a difficulty request moved the host's rung")
+  // Honoured, as far as the band reaches: the pack asked for the top and got one
+  // rung up, which is a game shaping the texture of a question.
+  assert.equal(Math.round((item.difficulty ?? -1) * span), where + HINT_BAND)
 
-  // A pack that stops driving resumes from where it left the child, and the
-  // host's own climb-and-step-down goes on from there. Two positions would mean
-  // a child who was moved down by their game gets moved back up by the ladder
-  // the moment the game stops asking.
+  // And a pack that stops driving is served from the host's own spread around
+  // the host's own rung — which is where the child was the whole time, because
+  // nothing the pack asked for was ever written into it.
   const after = service.next({ packId: "dynawalla.stack" })
   assert.ok(after)
-  assert.equal(service.position(), top)
-  // Not the same ordinate: with the pack no longer naming a difficulty the host
-  // serves from its own spread around where it was left (`rungWeights`). What
-  // must hold is that it is still *there* — within the spread of the rung the
-  // pack drove it to, and not back at the bottom of the ladder.
-  const span = ladder().length - 1
-  const drove = item.difficulty ?? -1
-  const served = after.difficulty ?? -1
+  assert.equal(service.position(), where)
+  const served = Math.round((after.difficulty ?? -1) * span)
   assert.ok(
-    served >= drove - (SPREAD_BELOW + 1) / span && served <= drove + SPREAD_ABOVE / span,
-    `the pack left the child at ${drove.toFixed(3)} and the host served ${served.toFixed(3)}`,
+    served >= where - SPREAD_BELOW && served <= where + SPREAD_ABOVE,
+    `the host stands on rung ${String(where)} and served rung ${String(served)}`,
   )
 
+  // And judging goes on from the host's rung, whatever the pack asked for on the
+  // way in. This child climbed on a clean window, so one miss costs them nothing
+  // — see `PROMOTE_AT`, "a miss inside a sustained window costs nothing" — and
+  // what the assertion is really about is that they are still standing where the
+  // *evidence* put them and not where `difficulty: 1` did.
   service.judge({
     packId: "dynawalla.stack",
     itemId: after.id,
     response: "definitely wrong",
     latencyMs: 1000,
   })
-  // Exactly the opening stride: nothing has been answered yet, so the staircase
-  // is still where `openStaircase` puts it.
   assert.equal(
     service.position(),
-    // `"lost"` because the window holds one answer and it was wrong, which is 0%.
-    top - descentOf(openStaircase(), "lost"),
-    "the ladder did not step down from the pack's position by the opening stride",
+    where,
+    "a miss inside a sustained window moved the ladder off the rung the evidence put it on",
   )
+})
+
+test("the founder's rule: a pack asking for the top while the child sustains 60% is served the child's rung", () => {
+  // > "you only progress when sustaining >~95% ... if you are getting 85% you
+  // > are at the right level. if you are less than ~75% its too hard."
+  //
+  // The rule, from the pack's side of the boundary. A child is walked up to a
+  // real rung on their own evidence, then starts getting three in five right —
+  // under the founder's floor at every rung — while the pack goes on asking for
+  // the hardest content the curriculum has, every single question. What the
+  // child is *served* has to follow the child down.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-60", record: noRecord, rungs })
+  climbTo(service, 20)
+  const started = service.position()
+  assert.ok(started >= 20)
+
+  let highest = 0
+  let everStood = 0
+  for (let answered = 0; answered < 300; answered++) {
+    const standing = service.position()
+    everStood = Math.max(everStood, standing)
+    const item = service.next({ packId: "dynawalla.arena", difficulty: 1 })
+    assert.ok(item)
+    const served = Math.round((item.difficulty ?? 0) * span)
+    assert.ok(
+      served <= standing + HINT_BAND,
+      `the child stands on rung ${String(standing)}, the pack asked for rung ${String(span)}, ` +
+        `and rung ${String(served)} was served`,
+    )
+    highest = Math.max(highest, served)
+    const right = answered % 5 < 3
+    service.judge({
+      packId: "dynawalla.arena",
+      itemId: item.id,
+      response: right ? service.reveal(item.id) : "definitely wrong",
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+  }
+  // Walked down off a level they cannot sit on, with the pack asking for the top
+  // the entire way. Under the old rule every one of those 300 questions was rung
+  // 76 — the hardest thing in the curriculum, handed to a child getting three in
+  // five right, forever.
+  assert.ok(
+    service.position() < started - 5,
+    `a child sustaining 60% was left on rung ${String(service.position())} having started on ` +
+      `rung ${String(started)}`,
+  )
+  assert.ok(
+    highest <= everStood + HINT_BAND,
+    `the pack asked for rung ${String(span)} and reached rung ${String(highest)}, and the highest ` +
+      `rung the child ever stood on was ${String(everStood)}`,
+  )
+  // Said again as a number a person can check against the ladder: asking for the
+  // hardest rung in the curriculum, three hundred times, never got half way to it.
+  assert.ok(
+    2 * highest < span,
+    `the pack asked for rung ${String(span)} on every one of 300 questions and reached rung ` +
+      `${String(highest)} of ${String(span)}`,
+  )
+})
+
+test("the founder's rule, the other way: a pack asking for rung 2 cannot hold a child who sustains 95%", () => {
+  // The converse, and it matters as much: a game whose own ladder is pinned low
+  // — `merge-idle` at depth 1, `stack` on floor 1 — must not be able to park a
+  // fluent child on the easiest content in the curriculum. The child is pulled
+  // up by their own evidence and the pack's request is dragged up with them.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-95", record: noRecord, rungs })
+  const packRung = 2
+
+  let lowest = span
+  for (let answered = 0; answered < 200; answered++) {
+    const standing = service.position()
+    const item = service.next({ packId: "dynawalla.stack", difficulty: packRung / span })
+    assert.ok(item)
+    const served = Math.round((item.difficulty ?? 0) * span)
+    assert.ok(
+      served >= standing - HINT_BAND,
+      `the child stands on rung ${String(standing)} and was served rung ${String(served)}`,
+    )
+    if (standing > packRung) lowest = Math.min(lowest, served)
+    service.judge({
+      packId: "dynawalla.stack",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+  }
+  assert.ok(
+    service.position() > 20,
+    `a child who was right every time was held at rung ${String(service.position())} by a pack ` +
+      `asking for rung ${String(packRung)}`,
+  )
+  assert.ok(
+    lowest > packRung,
+    `the pack asked for rung ${String(packRung)} and was still being served rung ` +
+      `${String(lowest)} after the child had climbed past it`,
+  )
+})
+
+test("the ARENA pattern: a pack asking for its own number every question no longer resets the climb", () => {
+  // The measurement in issue 733, as a test. ARENA derives its difficulty from its
+  // own game state — the depth of the arena — and asks for it on every draw. The
+  // host's position was observed going 22 → 26 → 22 → 26 → 22: the band climbed
+  // on the evidence, `next()` wrote the pack's rung back over it, and the child
+  // spent the session on a ladder the pack was holding still.
+  //
+  // Here the pack pins its number *below* the child and asks for it every
+  // question while the child answers every one correctly. The host's rung must
+  // never once move on a `next()`, and it must never be reset to the pack's.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-arena", record: noRecord, rungs })
+  const packRung = 4
+
+  const walked: number[] = []
+  for (let answered = 0; answered < 150; answered++) {
+    const before = service.position()
+    const item = service.next({ packId: "dynawalla.arena", difficulty: packRung / span })
+    assert.ok(item)
+    assert.equal(
+      service.position(),
+      before,
+      `drawing a question with a difficulty of ${String(packRung)}/${String(span)} moved the host ` +
+        `from rung ${String(before)} to rung ${String(service.position())}`,
+    )
+    walked.push(service.position())
+    service.judge({
+      packId: "dynawalla.arena",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: publishedP50Ms(widthOf(item.operands)),
+    })
+  }
+
+  // A child who is never wrong never steps down, so the walk is monotonic — and
+  // that is precisely the property the sawtooth broke.
+  assert.ok(walked.length === 150)
+  for (let i = 1; i < walked.length; i++) {
+    assert.ok(
+      (walked[i] as number) >= (walked[i - 1] as number),
+      `the host stood on rung ${String(walked[i - 1])} and then on rung ${String(walked[i])} ` +
+        `without a single wrong answer between them`,
+    )
+  }
+  assert.ok(
+    service.position() > 4 * packRung,
+    `a child who was right 150 times running finished on rung ${String(service.position())} with ` +
+      `a pack asking for rung ${String(packRung)}`,
+  )
+})
+
+test("the banked fraction survives a pack that names a difficulty on every question", () => {
+  // The property the rule this replaced kept by hand, and the reason it kept it.
+  // A child who is right every time and slow every time earns a *fraction* of a
+  // rung per answer — in the tail regime an item's own p90 over the latency —
+  // and it is carried in the fraction of `progress` until it adds up to a rung.
+  // Overwriting the whole number on every draw is what deleted it, over and over,
+  // and that child never moved at all.
+  //
+  // Nothing is written to `progress` by a request now, so the fraction and the
+  // rung both survive; this holds the property from the outside, where a future
+  // author who reintroduces a write can see it fail.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-slow", record: noRecord, rungs })
+  let answers = 0
+  while (service.position() < 1 && answers < 200) {
+    const item = service.next({ packId: "dynawalla.truedraw", difficulty: 0 })
+    assert.ok(item)
+    answers += 1
+    service.judge({
+      packId: "dynawalla.truedraw",
+      itemId: item.id,
+      // Ten times the widest published median: deep in the tail, so no single
+      // answer is worth anything close to a whole rung.
+      response: service.reveal(item.id),
+      latencyMs: 10 * P50_WIDEST_PUBLISHED_MS,
+    })
+  }
+  assert.ok(
+    service.position() >= 1,
+    `a slow-and-correct child with a pack naming a difficulty every question never left rung 0 ` +
+      `in ${String(answers)} answers`,
+  )
+  // And it was banked rather than bought: more than one answer went into it, so
+  // what moved the child was the accumulated fraction and not one whole stride.
+  assert.ok(
+    answers > 1,
+    "the first answer in the slow tail was worth a whole rung, so this proves nothing about the fraction",
+  )
+  assert.ok(span > 1)
 })
 
 test("every rung on the ladder draws a question with numbers in it", () => {
@@ -394,16 +649,22 @@ test("every rung on the ladder draws a question with numbers in it", () => {
   //
   // Every rung, not a sample: the rung this would next catch is by definition
   // one nobody thought to name.
+  // Addressed by building the service on the one rung under test rather than by
+  // asking for a `difficulty`. Since issue 733 a difficulty is a hint clamped to
+  // `HINT_BAND` rungs of where the host's own evidence stands, so it cannot
+  // address the ladder at all — and it never should have been the way to,
+  // because `deps.rungs` says which rung exactly and a request only ever said
+  // roughly. A sweep that could be made to skip rungs by a change in the host's
+  // ladder policy was a sweep in name.
   const rungs = ladder()
-  const service = createItemService({ profileId: "p1", record: noRecord })
   const families = new Set<string>()
 
   for (let i = 0; i < rungs.length; i++) {
-    const at = rungs.length === 1 ? 0 : i / (rungs.length - 1)
-    const item = service.next({ packId: "dynawalla.fuse", difficulty: at })
     const rung = rungs[i]
-    assert.ok(item, `rung ${String(i)} (${String(rung?.node.id)}) served nothing at all`)
     assert.ok(rung !== undefined)
+    const service = createItemService({ profileId: "p1", record: noRecord, rungs: [rung] })
+    const item = service.next({ packId: "dynawalla.fuse" })
+    assert.ok(item, `rung ${String(i)} (${String(rung.node.id)}) served nothing at all`)
     families.add(rung.family.family)
 
     assert.equal(item.operands.length, 2, `${item.skillId} did not draw two operands`)
@@ -444,11 +705,11 @@ test("every rung on the ladder draws a question with numbers in it", () => {
   // counted as coverage.
   assert.ok(families.size >= 1)
   for (let i = 0; i < rungs.length; i++) {
-    const at = rungs.length === 1 ? 0 : i / (rungs.length - 1)
-    const item = service.next({ packId: "dynawalla.fuse", difficulty: at })
-    assert.ok(item)
     const rung = rungs[i]
     assert.ok(rung)
+    const service = createItemService({ profileId: "p2", record: noRecord, rungs: [rung] })
+    const item = service.next({ packId: "dynawalla.fuse" })
+    assert.ok(item)
     const declared = declaredOperatorsOf(rung)
     assert.equal(
       declared.size,
@@ -583,8 +844,10 @@ test("every blank statement the shipped ladder draws is a true equation, read ba
   //
   // Held over the whole ladder rather than over the one row that has a blank today, so
   // the next row promoted is covered by this existing.
+  // One service per rung, for the reason given on the sweep above: a
+  // `difficulty` is a hint clamped to the host's band since issue 733 and does not
+  // address the ladder. `deps.rungs` does, exactly.
   const rungs = ladder()
-  const service = createItemService({ profileId: "p1", record: noRecord })
   let statements = 0
   // Cards where the answer is the number already printed on the far side. Counted, so
   // that the one exception below is known to be *exercised* rather than merely written:
@@ -592,9 +855,15 @@ test("every blank statement the shipped ladder draws is a true equation, read ba
   let halvings = 0
 
   for (let i = 0; i < rungs.length; i++) {
-    const at = rungs.length === 1 ? 0 : i / (rungs.length - 1)
-    for (let repeat = 0; repeat < 8; repeat++) {
-      const item = service.next({ packId: "dynawalla.balance", difficulty: at })
+    const rung = rungs[i]
+    assert.ok(rung !== undefined)
+    const service = createItemService({ profileId: "p1", record: noRecord, rungs: [rung] })
+    // Thirty-two draws a rung rather than eight. The halving coincidence the
+    // exception below is written for arrives about one item in nine on one row,
+    // and eight draws of one row is not enough of it to be *exercised* — see the
+    // `halvings > 0` assertion at the end, which is what noticed.
+    for (let repeat = 0; repeat < 32; repeat++) {
+      const item = service.next({ packId: "dynawalla.balance" })
       assert.ok(item)
       if (!item.prompt.includes(BLANK)) continue
       statements += 1

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -608,6 +608,64 @@ export const PACE_ALPHA = 0.25
  */
 export const PACE_FLOOR = 0.1
 
+/**
+ * ## How far a pack's `difficulty` may reach past the rung the evidence gives
+ *
+ * A pack proposes; the host disposes. A `difficulty` is honoured only within
+ * this many rungs of where the host's own band has put the child, so a game can
+ * shape the texture of a question and cannot outrun the evidence about the
+ * child.
+ *
+ * **What it was before.** Issue 733 measured it. Seventeen of the twenty-seven
+ * shipping packs send a `difficulty`, **none** of them reads `position()`, and
+ * `next()` applied the request by rewriting the whole rung —
+ * `progress = index + (progress − Math.floor(progress))`. The band would climb
+ * on the evidence and the very next draw put it back: ARENA measured
+ * `host pos 22 → 26 → 22`, every question. Every one of the seventeen derives
+ * its number from its own game state — `stack` asks for `difficultyFor(floor)`,
+ * the height of the tower — so for those seventeen games arithmetic difficulty
+ * was a function of how well the *game* was going, which is close to the inverse
+ * of the founder's rule and is the pacing audit's single defect one level up.
+ * The band governed only the ten packs that never asked.
+ *
+ * **Why one rung.**
+ *
+ *   * **Not zero.** Zero is "the host owns the ladder outright", and it deletes
+ *     the texture seventeen games are built out of — ARENA's breath, MONUMENT's
+ *     floors — one of which the founder has called "almost perfect". A game
+ *     saying "this chip should feel like a hard one" is a legitimate thing for a
+ *     game to say. It is only not a legitimate thing for it to *decide*.
+ *   * **Not two.** One rung is the size of the largest move the host itself can
+ *     make on a single answer once the search has bracketed the child:
+ *     `DESCENT_FAR × STEP_TRACK` is `3 × 0.25` = 0.75 of a rung at a pace of 1,
+ *     and the climb at the same point is `STEP_TRACK` times what the answer was
+ *     worth. So ±1 is about one decisive answer's worth of evidence — the most a
+ *     pack can be handed while the host is still able to take it back within a
+ *     handful of answers. At ±2 a pack moves the served content further in one
+ *     draw than the band can correct in eight answers of evidence, and the pack
+ *     is driving again with extra steps.
+ *   * **Whole rungs**, because a rung is the unit the ladder moves a child in —
+ *     see `progress`, where the whole part is the rung and the fraction is
+ *     credit toward the next one.
+ *
+ * **It is a reach and not a drift.** The clamp is anchored on `Math.floor(progress)`
+ * as `judge` left it and the request is *never written back* to `progress` — see
+ * `next()`. A clamp that re-derived its anchor from its own previous output would
+ * be a ratchet: a pack asking for rung 40 would be handed 23, then 24, then 25,
+ * and would arrive at 40 in seventeen questions having answered to nobody.
+ *
+ * **A pack can still pull a child up — at the rate the evidence allows.** Asking
+ * for one rung above serves one rung above; if the child sustains `PROMOTE_AT`
+ * there, the band climbs and the anchor climbs with it, and the next request is
+ * measured from the new rung. What cannot happen is arriving somewhere the last
+ * forty answers do not support.
+ *
+ * The ceiling is not this. `maxDifficulty` is a *capability* — "I cannot draw a
+ * question harder than this" — and it still binds absolutely, below the band and
+ * above it, because handing a pack a rung it cannot render is PR 694 again.
+ */
+export const HINT_BAND = 1
+
 /** Where the search is: the stride, the direction, and the child's own currency. */
 export type Staircase = {
   /** Rungs, before the regime multiplier. Never below the current floor. */
@@ -1249,9 +1307,21 @@ export type ItemService = {
      * it are authored, the same request lands on those instead and no pack is
      * rebuilt. What it can never do is fail — the index is clamped into the
      * ladder, so an unsatisfiable request becomes the nearest satisfiable one.
+     *
+     * **A hint, not an instruction.** It is honoured within `HINT_BAND` rungs of
+     * where the host's own band has the child and clamped there otherwise: a
+     * game shapes the texture of a question, it does not decide what the child
+     * is ready for. A pack that wants to know what it got reads the ordinate on
+     * the item that comes back, which is the rung that was used and not the one
+     * that was asked for.
      */
     difficulty?: number
-    /** A ceiling on the same scale. The stream never goes above it. */
+    /**
+     * A ceiling on the same scale. The stream never goes above it.
+     *
+     * Unlike `difficulty` this is absolute — it is a pack saying what it can
+     * physically draw, and it binds below `HINT_BAND` as well as above it.
+     */
     maxDifficulty?: number
   }): Item | null
   judge(input: {
@@ -1419,7 +1489,13 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
 
   return {
     /** The rung being stood on: the whole part of `progress`, never a fraction.
-        A pack asked for a rung index and a half-climbed one is not one. */
+        A pack asked for a rung index and a half-climbed one is not one.
+
+        This is the *host's* rung — what the last `RECENT_WINDOW` answers say —
+        and while a pack is driving `difficulty` the rung it is served may sit up
+        to `HINT_BAND` away from it. That is the one place the two numbers differ,
+        and the item's own `difficulty` ordinate is what says where a question
+        actually came from. */
     position: () => Math.floor(progress),
 
     next: ({ packId, skillId, difficulty, maxDifficulty }) => {
@@ -1429,32 +1505,62 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       const wanted =
         skillId === undefined ? null : (rungs.find((rung) => rung.node.id === skillId) ?? null)
 
-      // A difficulty is the same kind of request, one rung lower down. It moves
-      // the ladder rather than reading past it, so there is one position and
-      // not two: a pack that drives the difficulty and then stops driving it
-      // resumes from where it left the child, and `judge` keeps climbing and
-      // stepping down from there.
+      // A difficulty is the same kind of request, one rung lower down — and it
+      // is a request. It is honoured within `HINT_BAND` rungs of where the
+      // host's own evidence stands and no further, which is what makes the
+      // founder's 85/95 rule reach the seventeen packs that drive difficulty
+      // off their own game state. See `HINT_BAND` for why one rung.
       const span = Math.max(0, rungs.length - 1)
-      let index = Math.floor(progress)
-      if (difficulty !== undefined || maxDifficulty !== undefined) {
-        const asked = difficulty === undefined ? index / Math.max(1, span) : difficulty
-        // The request rounds to the nearest rung — a pack asking for 0.5 wants the
-        // middle and not the rung below it. The **ceiling floors**, and the two are
-        // deliberately different: `maxDifficulty` is documented as "the stream never
-        // goes above it", and rounding a cap can only round it up. A pack that says
-        // 0.2 on a 59-rung ladder got 12/58 = 0.203 — over its own ceiling, by a
-        // rung, silently. It passed for as long as it did because 0.2 × 42 happened
-        // to round down; the ladder grew and it stopped happening, which is the
-        // shape of every rounding bug this codebase has met.
-        const cap = maxDifficulty === undefined ? span : Math.floor(maxDifficulty * span)
-        index = Math.max(0, Math.min(span, cap, Math.round(asked * span)))
-        // The rung the pack named, carrying the credit already earned toward
-        // the next one. Overwriting the whole number would let a game that
-        // drives difficulty on every question quietly delete the fraction a
-        // slow-and-correct child had banked, over and over, and that child
-        // would never move — which is the bug this rule was rewritten to end.
-        progress = index + (progress - Math.floor(progress))
+      // **The anchor**, read once and read here: the rung `judge` left the child
+      // on, before a single thing the pack asked for has been looked at.
+      //
+      // Nothing below writes a pack's request into `progress`, and that is not
+      // tidiness, it is the whole clamp. `progress` is moved by `judge` and by
+      // the ceiling and by nothing else, so the next question's anchor is the
+      // next question's *evidence*. Anchoring on the previous draw instead — on
+      // this function's own clamped output — would make the band a ratchet a
+      // pack could climb one rung per question, which is the bug wearing a
+      // clamp as a hat.
+      //
+      // The banked fraction is safe by construction now rather than by
+      // arithmetic: the rule this replaced kept `progress − Math.floor(progress)`
+      // by hand, because rewriting the whole number would let a game that drives
+      // difficulty every question quietly delete the credit a slow-and-correct
+      // child had earned toward their next rung. Not writing at all keeps the
+      // fraction *and* the rung.
+      const anchor = Math.floor(progress)
+      let index = anchor
+      if (difficulty !== undefined) {
+        // The request rounds to the nearest rung — a pack asking for 0.5 wants
+        // the middle and not the rung below it — and is then pulled inside the
+        // band. What comes back to the pack is the ordinate it *got*, so a
+        // clamped request is visible on the pack's side.
+        const asked = Math.round(difficulty * span)
+        index = Math.max(anchor - HINT_BAND, Math.min(anchor + HINT_BAND, asked))
       }
+      if (maxDifficulty !== undefined) {
+        // The **ceiling floors** where the request rounds, and the two are
+        // deliberately different: `maxDifficulty` is documented as "the stream
+        // never goes above it", and rounding a cap can only round it up. A pack
+        // that says 0.2 on a 59-rung ladder got 12/58 = 0.203 — over its own
+        // ceiling, by a rung, silently. It passed for as long as it did because
+        // 0.2 × 42 happened to round down; the ladder grew and it stopped
+        // happening, which is the shape of every rounding bug this codebase has
+        // met.
+        //
+        // It binds after the band and it wins, because it is not a pedagogy
+        // request: it is a pack saying what it can physically draw, and PR 694
+        // exists because polarity was handed a rung it could not render.
+        const cap = Math.floor(maxDifficulty * span)
+        index = Math.min(index, cap)
+        // And a standing ceiling pins the ladder itself, exactly as it always
+        // has: a position standing above content the pack can never test the
+        // child on is a fiction. Downward only, and only when it bites — so it
+        // cannot be the ratchet the note above is about — carrying the banked
+        // fraction, which is what `progress − anchor` is.
+        if (cap < anchor) progress = Math.max(0, cap) + (progress - anchor)
+      }
+      index = Math.max(0, Math.min(span, index))
 
       sequence += 1
 
@@ -1466,7 +1572,9 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       // ceiling the spread could reach over is not a ceiling.
       //
       // **Only when the centre is the host's own.** A `difficulty` the pack
-      // named is honoured as the point the SDK documents it to be, and the
+      // named is honoured as the point the SDK documents it to be — a point
+      // inside `HINT_BAND` of the host's rung since issue 733, but still a
+      // point — and the
       // reason is not caution, it is four shipped games: `counterweight` pins
       // `maxDifficulty` *equal* to its request, `polarity` and `balance` and
       // `horde` pin a ceiling to what they can physically draw, and PR 694 exists

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -663,6 +663,18 @@ export const PACE_FLOOR = 0.1
  * The ceiling is not this. `maxDifficulty` is a *capability* — "I cannot draw a
  * question harder than this" — and it still binds absolutely, below the band and
  * above it, because handing a pack a rung it cannot render is PR 694 again.
+ *
+ * **Which leaves one way out, and it should be said rather than implied.** A
+ * pack that pins its ceiling *to* its request has opted out of the band: it is
+ * served at its ceiling and it pulls the ladder down to it, exactly as it did
+ * before. `counterweight` does this on purpose (`difficulty: rung,
+ * maxDifficulty: rung`), and `balance`, `horde`, `merge-idle`, `polarity`,
+ * `gavel` and `lattice` carry standing ceilings that dilute it. So this constant
+ * makes the founder's rule govern the `difficulty` channel across the fleet; it
+ * does not make it govern a game that has declared it can only draw one rung.
+ * That is pack work — widen what those games can render — and it cannot be done
+ * from here without serving a game a question it cannot put on the screen.
+ * `items.test.ts` pins the boundary so it is not mistaken for coverage.
  */
 export const HINT_BAND = 1
 
@@ -1508,8 +1520,10 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
       // A difficulty is the same kind of request, one rung lower down — and it
       // is a request. It is honoured within `HINT_BAND` rungs of where the
       // host's own evidence stands and no further, which is what makes the
-      // founder's 85/95 rule reach the seventeen packs that drive difficulty
-      // off their own game state. See `HINT_BAND` for why one rung.
+      // founder's 85/95 rule reach the seventeen packs that drive difficulty off
+      // their own game state — every one of them except where a pack has also
+      // declared a ceiling it cannot draw above. See `HINT_BAND` for why one
+      // rung, and for the ceiling's way out of it.
       const span = Math.max(0, rungs.length - 1)
       // **The anchor**, read once and read here: the rung `judge` left the child
       // on, before a single thing the pack asked for has been looked at.

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -132,9 +132,27 @@ export type ItemRequest = {
    * rungs, 0 follows them down and no pack has to be rebuilt. The item that
    * comes back reports the position it was actually drawn from, on the same
    * scale, so a pack can see when a request was clamped.
+   *
+   * **A hint, and it is clamped to the host's own band.** The host serves it
+   * only within one rung of where its own evidence about this child stands, so
+   * a request of 1 is "one rung harder than they are on", not "the hardest
+   * thing in the curriculum" — a game shapes how a question feels and does not
+   * decide what the child is ready for. Sustained accuracy is what moves the
+   * ladder, and a pack that keeps asking upward moves the child up exactly as
+   * fast as they can sustain it. Read the ordinate on the item that comes back
+   * to see where a request actually landed; the difference between what was
+   * asked and what was served is the host disagreeing, and it is not an error.
    */
   readonly difficulty?: number
-  /** A ceiling on the same 0..1 scale. Never serve harder than this. */
+  /**
+   * A ceiling on the same 0..1 scale. Never serve harder than this.
+   *
+   * Unlike `difficulty` this is absolute, because it is a pack saying what it
+   * can physically draw rather than what it would like: a ceiling is honoured
+   * below the host's band as well as above it. Set it only to what the game
+   * genuinely cannot render — a ceiling pinned to the request is a game
+   * deciding a child's level, which `difficulty` deliberately no longer does.
+   */
   readonly maxDifficulty?: number
 }
 


### PR DESCRIPTION
Closes #733. Option **B**, as the founder chose: a pack's `difficulty` becomes a
hint, honoured only within **±1 rung** of the host's own position.

## The change

`dynawalla-app/src/packs/items.ts`, in `next()`:

```ts
const anchor = Math.floor(progress)          // the host's rung, as `judge` left it
let index = anchor
if (difficulty !== undefined) {
  const asked = Math.round(difficulty * span)
  index = Math.max(anchor - HINT_BAND, Math.min(anchor + HINT_BAND, asked))
}
if (maxDifficulty !== undefined) { … }        // the ceiling, unchanged
index = Math.max(0, Math.min(span, index))
```

The line the issue names — `progress = index + (progress − Math.floor(progress))`
— **is gone from the `difficulty` path entirely**. A request no longer writes to
`progress` at all.

## The anchor, and why it cannot drift

The anchor is `Math.floor(progress)` **read at the top of `next()`, before
anything the pack asked for is looked at**, and it stays honest because the
request is never written back. `progress` is moved by `judge` and by a binding
ceiling, and by nothing else, so the next question's anchor is the next
question's *evidence*.

The alternative — clamp to ±1 and write the clamped index back — passes a naive
reading of "±1 rung" and is a **ratchet**: a pack asking for rung 40 while the
child sits at 22 is handed 23, then 24, then 25, and arrives at 40 in seventeen
questions having answered to nobody. That is mutation **M3** below, and it walks
a child who is sustaining 60% from rung 20 to **rung 75**. It is a strictly worse
bug than the one being fixed, because it looks fixed.

Not writing at all is also what makes the **banked fraction** safe. The old line
kept `progress − Math.floor(progress)` by hand so that a pack driving difficulty
every question could not delete the credit a slow-but-correct child had earned;
keeping the whole number as well as the fraction is a superset of that promise.
Mutation **M5** adds a write back and the fraction test fails.

## `maxDifficulty` is untouched and still absolute

The ceiling **floors** where a request **rounds** — the asymmetry PR 694's
rounding bug is about — and it binds *below* the band as well as above it:

* it is a **capability**, not a pedagogy request ("I cannot draw a question
  harder than this"), and overriding it hands a pack a rung it cannot render;
* it still pins the ladder down when it bites, exactly as before, because a
  position standing above content the pack can never test the child on is a
  fiction. Downward only, so it cannot become the ratchet above.

Mutations **M6** (cap rounds) and **M7** (cap stops binding) both fail.

### The one way out, named rather than implied

A pack that pins `maxDifficulty` **to** its own `difficulty` has opted out of the
band entirely: it is served at its ceiling and it pulls the ladder down to it,
exactly as before. `counterweight` does this on purpose
(`games/counterweight/src/game/ladder.ts:67`), and `balance`, `horde`,
`merge-idle`, `polarity`, `gavel` and `lattice` carry standing ceilings that
dilute it.

This is not a regression — main does the same — and it is not closable from
`items.ts`: the alternative is serving a game a question it cannot put on the
screen. So it is pinned by its own test (*"a ceiling below the child still pins
the ladder, which is the one way a pack still drives it"*) and stated in the
`HINT_BAND` doc, so nobody reads the other tests as covering it. **Founder call
worth having:** whether those seven packs should widen what they can render, which
is pack work, one game at a time.

## Why ±1, and why it is a named constant

`HINT_BAND = 1`, exported, with the derivation in its doc comment:

* **Not 0.** That is option A, and it deletes the texture seventeen games are
  built out of — ARENA's breath, MONUMENT's floors — one of which the founder has
  called "almost perfect". A game saying "this chip should feel hard" is a
  legitimate thing for a game to say. It is only not legitimate for it to
  *decide*.
* **Not 2.** One rung is the size of the largest move the *host* can make on a
  single answer once the search has bracketed the child: `DESCENT_FAR ×
  STEP_TRACK` = `3 × 0.25` = 0.75 of a rung. So ±1 is about one decisive answer's
  worth of evidence — the most a pack can be handed while the band can still take
  it back inside a handful of answers. At ±2 the pack moves the content further
  in one draw than the band can correct in eight answers, and the pack is driving
  again with extra steps.
* **Whole rungs**, because that is the unit `progress` moves a child in.

A pack can still *pull a child up*: asking for +1 serves +1, and if the child
sustains `PROMOTE_AT` there the band climbs and the anchor climbs with it. What
cannot happen is arriving somewhere the last forty answers do not support.

## Side effect worth knowing

Several packs send difficulty on scales that were never 0..1 — `beam` sends
`2 + Math.round(level × 7)`, `stack` sends a floor number — and `unitParam`
clamps every one of those to `1.0`, i.e. *"the hardest rung in the curriculum,
please"*, on every question. The band now absorbs that class of scale bug
instead of a child absorbing it. Those packs should still be fixed; they are no
longer a hazard while they wait.

## Tests

Five new/rewritten tests in `items.test.ts`, all through the real service:

* **the founder's rule** — a child walked to rung 20 on their own evidence, then
  sustaining 60%, with the pack asking for rung 76 on all 300 questions: every
  served rung is `≤ position + 1`, the child is walked *down* below rung 15, and
  the highest rung ever reached never gets half way to what was asked for.
* **the converse** — a pack asking for rung 2 while the child is right every time
  cannot hold them: served rung is always `≥ position − 1`, and the child
  finishes above rung 20.
* **the ARENA pattern** — the pack asks for its own lower number every question
  while the judge is driven upward; `position()` is asserted **unchanged across
  every single `next()`**, and the 150-answer walk is asserted monotonic. That is
  the sawtooth, pinned.
* **the banked fraction** — a child walked to rung 5, then answering in the tail
  regime with the pack asking for a *lower* rung every question, still climbs off
  it, and takes more than one answer to do so (banked, not bought). The first
  draft of this test ran at rung 0 asking for rung 0 and **passed with the fix
  reverted** — at an anchor of 0 the old write is the identity. Caught by the
  adversarial review, fixed, and the trap is written into the test's comment.
* **the ceiling boundary** — what the clamp does *not* cover, above.
* **"driving the difficulty does not move the ladder"** — the replacement for the
  test that asserted the *opposite*. That old title, `driving the difficulty
  moves the one ladder`, was the defect written down as a property.

Three sweeps that used `difficulty` as a *rung-addressing mechanism* now build a
one-rung service via `deps.rungs` instead. A difficulty was never an addressing
mechanism; `deps.rungs` says which rung exactly, where a request only ever said
roughly.

### Mutation transcript

Ten mutations, each applied to the shipped file, `items.test.ts` run, then
restored (`diff` against a pristine copy confirms every restore).

| # | mutation | tests failed |
|---|----------|--------------|
| M1 | clamp deleted (`index = asked`) | 5 |
| M2 | the whole pre-733 rule restored, `progress` write included | 8 |
| M3 | ratchet: the clamp anchored on its own output | 8 |
| M4 | `HINT_BAND = 2` | 1 |
| M5 | `progress = index` after the clamp (eats the fraction) | 8 |
| M6 | ceiling rounds instead of flooring | 1 |
| M7 | ceiling stops binding | 2 |
| M8 | upper half of the band only | 2 |
| M9 | lower half of the band only | 4 |
| M10 | the ceiling stops pinning the ladder | 1 |

The messages, quoted:

```
### M2-pre-733   (the code as it ships on main today)
  FAIL driving the difficulty does not move the ladder: the pack proposes and the band disposes
       AssertionError: a difficulty request moved the host's rung — 76 !== 20
  FAIL the founder's rule: a pack asking for the top while the child sustains 60% …
       AssertionError: the child stands on rung 20, the pack asked for rung 76, and rung 76 was served
  FAIL the founder's rule, the other way: a pack asking for rung 2 cannot hold a child who sustains 95%
       AssertionError: the child stands on rung 6 and was served rung 2
  FAIL the ARENA pattern: a pack asking for its own number every question no longer resets the climb
       AssertionError: drawing a question with a difficulty of 4/76 moved the host from rung 0 to rung 4
  FAIL the banked fraction survives a pack that names a difficulty on every question
       AssertionError: a slow-and-correct child with a pack naming a difficulty every question never got off rung 7 in 200 answers
  FAIL a ceiling below the child still pins the ladder …
       AssertionError: … -14 !== 3
  FAIL a difficulty request selects a rung inside the host's band … + 1  - 0.013157894736842105
  FAIL a ceiling is honoured … an impossible request did not land on the hardest rung the band allows
  ℹ pass 61  ℹ fail 8

### M3-ratchet   (the clamp that anchors on its own output)
  FAIL the founder's rule …
       AssertionError: a child sustaining 60% was left on rung 75 having started on rung 20
  FAIL the founder's rule, the other way …
       AssertionError: a child who was right every time was held at rung 17 by a pack asking for rung 2
  FAIL the ARENA pattern …
       AssertionError: drawing a question with a difficulty of 4/76 moved the host from rung 0 to rung 1
  FAIL driving the difficulty does not move the ladder …
       AssertionError: a difficulty request moved the host's rung — 21 !== 20
  FAIL the banked fraction survives a pack that names a difficulty on every question
  FAIL a ceiling below the child still pins the ladder …
  FAIL a difficulty request selects a rung inside the host's band … 20 !== 21
  FAIL a ceiling is honoured … an impossible request did not land on the easiest rung: + 0.513…  - 0
  ℹ pass 61  ℹ fail 8

### M1-no-clamp
  FAIL the founder's rule …
       AssertionError: the child stands on rung 20, the pack asked for rung 76, and rung 76 was served
  FAIL the founder's rule, the other way …
       AssertionError: the child stands on rung 4 and was served rung 2
  FAIL driving the difficulty does not move the ladder … 76 !== 21
  FAIL a difficulty request selects a rung inside the host's band … + 1  - 0.013157894736842105
  FAIL a ceiling is honoured … an impossible request did not land on the hardest rung the band allows
  ℹ pass 64  ℹ fail 5

### M5-eat-fraction
  FAIL the banked fraction survives a pack that names a difficulty on every question
       AssertionError: a slow-and-correct child with a pack naming a difficulty every question never got off rung 7 in 200 answers
  FAIL the founder's rule … a child sustaining 60% was left on rung 30 having started on rung 20
  FAIL the founder's rule, the other way … held at rung 9 by a pack asking for rung 2
  FAIL the ARENA pattern … moved the host from rung 0 to rung 1
  FAIL a ceiling below the child still pins the ladder … 2 !== 3
  (+ 3 more)
  ℹ pass 61  ℹ fail 8

### M4-band-2
  FAIL the founder's rule, the other way …
       AssertionError: the pack asked for rung 2 and was still being served rung 2 after the child had climbed past it
  ℹ pass 68  ℹ fail 1

### M6-cap-rounds
  FAIL a ceiling is honoured …
       AssertionError: the ceiling 0.01 served 0.013157894736842105 for a request of 0.5
  ℹ pass 68  ℹ fail 1

### M7-no-cap
  FAIL a ceiling is honoured …
       AssertionError: the ceiling 0 served 0.013157894736842105 for a request of 0.5
  FAIL a ceiling below the child still pins the ladder …
  ℹ pass 67  ℹ fail 2

### M8-upper-only   (a pack could still hold a child down)
  FAIL a difficulty request selects a rung inside the host's band … 0 !== 19
  FAIL the founder's rule, the other way … the child stands on rung 4 and was served rung 2
  ℹ pass 67  ℹ fail 2

### M9-lower-only   (a pack could still outrun the evidence)
  FAIL the founder's rule … the child stands on rung 20, the pack asked for rung 76, and rung 76 was served
  FAIL driving the difficulty does not move the ladder … 76 !== 21
  FAIL a difficulty request selects a rung inside the host's band … + 1  - 0.013157894736842105
  FAIL a ceiling is honoured … an impossible request did not land on the hardest rung the band allows
  ℹ pass 65  ℹ fail 4

### M10-no-ceiling-pin
  FAIL a ceiling below the child still pins the ladder, which is the one way a pack still drives it
       AssertionError: a ceiling under the child's rung no longer pins the ladder — that is a change
                       to what `maxDifficulty` means, not to what `difficulty` means — 20 !== 3
  ℹ pass 68  ℹ fail 1
```

Every new assertion is killed by at least one mutation; the two halves of the
band are killed independently (M8 / M9); and **M2 is the code as it ships on
main**, which is the only mutation that matters for "does this test suite reject
the bug".

## Suites

* `dynawalla-app` — **378 pass / 0 fail**, five consecutive runs (373 on main;
  +5 net new tests). `npm run tsc` and `npm run lint` clean.
* `dynawalla/packs/sdk` — 118 pass / 0 fail, `tsc` clean (the `guest.ts` doc,
  which said `difficulty: 1` returns the hardest content the host can generate —
  the type twenty-seven packs are compiled against, and no longer true).
* `dynawalla/curriculum/` — **221 pass / 0 fail**, five consecutive runs, `tsc`
  clean.
* Packs that **do** send a difficulty: arena 96, stack 65, beam 102, runner 121,
  truedraw 245, counterweight 159 — all 0 fail.
* Packs that **do not**: siege 35, trebuchet 132, claim 78, mosaic 79, pulse 129
  — all 0 fail.

Every pack suite runs against its own stub host, so none of them exercises this
code path — which is the honest reading of "the packs are unaffected", and also
the reason the seventeen stubs still model the *old* host semantics. Bringing the
stubs into line is fleet work and is not in this PR.

## Residual, named rather than fixed

* **`skillId` is still an unclamped channel** — a pack naming a skill gets that
  skill's easiest rung whatever the band says. **No shipping pack sends one**
  (`grep` over `games/*/src`), so it is a hole in the contract and not a hole in
  the product.
* **Seventeen pack stub hosts still model the old semantics.** Every pack suite
  runs against its own stub, which is why they all pass untouched — and why none
  of them exercises this path. Bringing the stubs into line is fleet work.
* **Two packs' design prose is now falsified by this change**, and both are
  measurements written into the file: `games/horde/src/game/curriculum.ts:96`
  justifies a 6-rung *downward* band with "46 of 60 rungs and 17 of 18 skills"
  (a horde-shaped simulation now reaches 20 rungs / 10 skills), and
  `games/balance/src/pacing.ts:110` ends "so the top of the ladder is still
  reachable", which by asking it is not. Left to the packs rather than edited
  from the host PR.
* **Every launch opens at rung 0**, because `progress` is per-mount by design.
  Unchanged by this PR, but it is now the *only* thing that sets the opening
  rung, where a pack's request used to jump it. Measured on this branch: a child
  answering correctly at the published median is at rung 20 after 10 answers and
  at the top after 66 — roughly the first ten questions of a session.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
