### PR TITLE
dynawalla/soundscape: the steelyard stops playing the same ding and starts playing a tune

### DIFF
--- a/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
+++ b/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
@@ -1,0 +1,453 @@
+# The Dynawalla soundscape
+
+**Status:** designed, and one game built against it. `packs/shared/game-soundscape/`
+exists, has 45 tests, and THE STEELYARD plays through it behind a gate that is off
+in production. Everything in *Where it lives* below stage 1 is proposed and needs
+a founder decision — the open questions are at the end.
+
+---
+
+## The brief
+
+> *"we need a global pass on these elements. Maybe even a shared library of
+> infinite music and sounds that we can draw from so nothing is boring or lame …
+> here is a fantastic idea … we use some stochasticity and randomness … but in a
+> lot of cases we have a nice drone that is in tune with the little sound effects
+> that play a melody. so for the steelyard, right now have the same sound for
+> every +1/−1 … it would be way cooler if it randomly played a melody based on
+> the randomly chosen soundscape for any given moment .. so we are in a certain
+> maqam in a certain root note, then the little sound effects play a nice little
+> song .. this in itself could be satisfying and addictive. right now it's too
+> predictable, too annoying, too static .. we need some life. All of the Raga,
+> all of the maqam, all of the western modes, many chord progressions to choose
+> from .. I think this is a place that we can have a standardized interface from
+> the native side that informs the game what the current soundscape is .. and
+> then from the game side, we could say 'level complete' or 'more tension' or
+> 'less tension' or high-level changes like this that would affect the global
+> soundscape."*
+
+Plus, on the state of the fleet: *"the sound effects… tend to be a bit abrasive ..
+maybe lower pitched in a lot of cases ... like building crumbling here instead of
+white noise"*, and on the bed: *"Premium, chill (usually), not too loud. Never
+empty, always optional."*
+
+---
+
+## What is actually wrong today, measured
+
+Twenty-eight games, **11,064 lines of audio code**, and not one line of it shared
+except the safety bus. Three facts, counted rather than felt:
+
+| | |
+|---|---|
+| Games whose cues are a table of fixed frequencies | all 28. THE STEELYARD's is `{ 1: 1180, 10: 830, 100: 520, 1000: 288 }` |
+| Games with a white-noise buffer source | **24 of 28** |
+| Distinct pitches a child hears from ten taps on THE STEELYARD's ones plate | **one** |
+
+That last row is the whole problem, and it is worth being precise about why,
+because the obvious fixes are all wrong:
+
+- It is **not** that the sounds are ugly. `audio.ts` in THE STEELYARD is careful,
+  hand-shaped work: a bowed band-passed drone that tracks the beam, place-pitched
+  clangs, a shear that falls 760 Hz to 74. Making it *prettier* changes nothing.
+- It is **not** that it is too loud. `game-audio` already holds a −1 dBFS ceiling,
+  a 6 ms minimum attack and a polyphony cap, and PR #696 routed the last two games
+  through it. Turning it down changes nothing either.
+- It is that **nothing that happens changes what the next sound is.** The tenth
+  blow is bit-for-bit the first. A system with no memory cannot be surprising, and
+  a child stops hearing it in about ninety seconds — which is exactly the founder's
+  "too predictable, too annoying, too static".
+
+Fixing that is a *state* problem, not a synthesis problem, and it is fixed in
+about 500 lines of pure arithmetic with no Web Audio in them at all.
+
+---
+
+## 1. The musical core
+
+### Cents, not semitones
+
+Every pitch collection is stored as **exact cents above the tonic**, ported from
+Corpán's beatlounge pack (`corpan/packs/beatlounge/src/music/modes/`), whose
+corpus is 130 modes over six families in precisely this representation.
+
+This is not fussiness. Maqam Rast's third is a neutral interval at ~350 cents —
+three-quarters of a tone — and Saba's fourth is narrowed. There is no integer
+number of semitones that says either. A semitone table does not *approximate* the
+maqamat, it **deletes** them and silently substitutes the nearest Western mode.
+The founder rejected a blanket 24-TET grid in beatlounge for the same reason, and
+that decision carries over unchanged.
+
+Shipped in `packs/shared/game-soundscape/modes.ts`: **38 modes** — 16 Western, the
+10 Hindustani thaats, 12 Arabic maqamat. The 72 Carnatic melakartas, the 7 Persian
+dastgāh and the 10 Turkish makamlar exist in beatlounge and are a data change away
+with zero migration; they were left out to keep a pack's vendored payload small
+until somebody has *heard* 38 and wants more.
+
+> **On "all of the Raga".** A thaat is a raga's parent scale, not a raga: a raga
+> adds an ascent, a descent, a resting note and a set of characteristic phrases.
+> What the walker below supplies is exactly an ascent, a descent and a resting
+> note — so a thaat plus this walker is much closer to a raga than a thaat alone.
+> The ids still say `thaat`, because claiming otherwise would be a lie a musician
+> would catch.
+
+### A soundscape is four numbers
+
+```ts
+type Soundscape = {
+  modeId: string   // "maqam.rast"
+  rootHz: number   // 130.72 — the tonic, and the drone
+  seed: number     // every stochastic choice comes from here
+  tension: number  // 0..1
+}
+```
+
+Small enough to sit on the host↔pack wire beside `locale` and `reducedMotion`,
+which is the whole reason it is four numbers and not an object graph.
+
+The **root band is Bb2–Eb3 (116–156 Hz)** and it is narrow on purpose: the melody's
+brightest register is root×4 to root×8, so the top of the root band times eight is
+the highest note the entire system can produce — 1244 Hz. Widening the roots by a
+fourth would put that at 1600 Hz, inside the 2–5 kHz band the ear is most sensitive
+in. **The ceiling on the music is set by choosing the roots, not by clamping
+later.** The chosen root is then detuned by up to ±6 cents — under the threshold at
+which anyone hears "out of tune", over the threshold at which two sessions sound
+like the same session.
+
+### The walker: how consecutive +1s become a phrase
+
+One integer of state: a signed scale degree. Each `step` gesture moves it, and the
+pitch that comes out is wherever it now is.
+
+1. **Direction is the mode's own grammar.** `+1` walks ascending, `−1` walks
+   descending. This is why the founder's example is the right one to build against:
+   THE STEELYARD's rack has an on-face and an off-face on every pillar, so hanging
+   brass and trimming it are opposite motions — and the balanced-base-ten shortcut
+   the whole game exists to teach (*eight is ten less two*) is literally **one step
+   up and two steps down**. That figure now sounds like a turn instead of like
+   three identical ticks. `soundscape.test.ts` asserts it descends in 60 of 60
+   soundscapes.
+2. **Interval by tension.** The step is 1 degree most of the time, 2 sometimes, 3–4
+   rarely, on a distribution the tension scalar reweights. Calm is nearly all
+   stepwise — that is what "chill" means mechanically, and it is asserted rather
+   than hoped.
+3. **Gravity and cadence.** Each mode declares `rest` degrees (its own 1-3-5, or a
+   jins tonic and its ghammaz). After 3–8 steps — length drawn per phrase, longer
+   under tension — the walk *resolves* onto one, weighted heavily toward the tonic.
+   **This is the part that makes it satisfying.** Without it a run of taps is a
+   scale exercise that never arrives; with it, it is a sentence that lands.
+4. **Colour under tension.** Each mode also declares its `colour` degree — Lydian's
+   sharp fourth, Phrygian's flat second, Hijaz's augmented second. Tension spends
+   itself by leaning on that degree. So a soundscape can get more wound-up **without
+   anything going out of tune**, because the extra tension is still inside the mode.
+5. **Register is bought with weight, not with pitch.** `weight: 0..1` is *how heavy
+   the thing the child did was*. THE STEELYARD's ones plate is 0 and its thousands
+   plate is 1, mapping to four one-octave bands at root×4, ×2, ×1 and ÷2. The bands
+   are exactly one octave wide and a degree is folded into its band, so **they never
+   overlap**: the ones plate is above the tens plate in every mode on every root,
+   with no ordering left to chance. The game's existing "place value is a thing you
+   can hear" property is kept *exactly* and made musical rather than replaced.
+
+### In tune with the drone, by construction
+
+Every frequency is `rootHz * 2^(cents/1200)`. The drone is the same `rootHz`.
+**There is one number, so there is nothing to drift.**
+
+The drone is the root, the octave below it, and the fifth **only when the mode has
+one** within 25 cents of 702. Whole tone does not; Saba's is elsewhere. A fixed
+"root plus fifth" drone would put a pitch under one soundscape in five that is not
+in the scale, which is the exact clash this branch exists to avoid.
+
+One consequence in the prototype worth calling out: THE STEELYARD's drone used to
+*transpose* a major third across the beam's travel. With a soundscape live it
+**bends ±35 cents** instead — a bowed string leaning under load. A tonic that
+slides a major third is a melody out of tune with itself.
+
+---
+
+## 2. The event vocabulary
+
+Eight things a game may say. Games cannot say a frequency.
+
+```ts
+type Gesture =
+  | { kind: "step"; direction: 1 | -1; weight?: number }
+  | { kind: "success" }        // it worked
+  | { kind: "failure" }        // it did not — warm, low, never a buzzer
+  | { kind: "levelComplete" }  // the only gesture allowed to be big
+  | { kind: "refuse" }         // declined: too soon, not allowed, nothing there
+  | { kind: "arrive" }         // something appeared or was laid out
+  | { kind: "moreTension" }    // silent in itself
+  | { kind: "lessTension" }
+```
+
+`melody.emit(gesture)` returns `Voice[]` — `{ hz, at, seconds, gain, timbre }` —
+which is a **plan, not a sound**. The pack owns synthesis; the module owns music.
+That split is why 45 tests can assert every note in Node with no device.
+
+The two tension gestures return `[]`. That is the answer rather than an omission:
+winding a soundscape up is not a sound, it is a change in every sound after it.
+
+**Why a game must not pass a pitch.** Given the option, a game will eventually pass
+one that is not in the mode — and then the drone is wrong and nobody can say why,
+in a codebase where the drone is in a different file from the cue. The type system
+is the enforcement, and it costs nothing: THE STEELYARD's entire musical vocabulary
+after this change is `tune.ts`, which is 45 lines including comments.
+
+---
+
+## 3. Where it lives — two options, and the recommendation
+
+The founder asks for *"a standardized interface from the native side that informs
+the game what the current soundscape is"*. There are two honest readings.
+
+### Option A — native owns the audio
+
+A `tauri-plugin-soundscape` synthesises the bed natively; packs ask it for pitches
+and cues over a stream capability. Genuinely process-wide, survives the WebView,
+one engine for the whole app.
+
+**Rejected, for three reasons and the first is fatal:**
+
+1. **Latency.** A melody note is caused by a finger. A pack↔host round trip is a
+   `MessagePort` post plus a native IPC hop plus scheduling — two frames at best,
+   unbounded under load. `budgetMs` exists in the capability table *because* native
+   answers are slow (2 s for a store read, 10 s for anything that may prompt). A
+   note that arrives 40 ms after the tap is not a melody, it is a fault.
+2. **It punches a hole in the only safety guarantee this fleet has.**
+   `game-audio`'s WaveShaper ceiling governs the *pack's* graph. A natively
+   synthesised bed is a separate output path that the ceiling cannot see, and it
+   cannot duck to the pack's cues either. The MOSAIC incident (+22.9 dBFS, a
+   nine-year-old saying it almost made his ears explode) is what that guarantee was
+   built out of.
+3. **It is the most expensive possible first native capability.** Every trap in
+   `docs/NATIVE_CAPABILITIES.md` — the capability grant, the serde wire format
+   silently dropping fields, `links =` uniqueness, cross-compiling both targets —
+   for a feature whose value is entirely in the arithmetic.
+
+### Option B — native owns the *selection*; the pack owns the *sound* **← recommended**
+
+The pivot, and the one sentence this document exists to write down:
+
+> **Pitch decisions must be local and synchronous. Soundscape selection must be
+> global and slow.** A soundscape changes every few minutes. A note happens ten
+> times a second. Put the slow thing on the wire and keep the fast thing in the
+> pack.
+
+So:
+
+| | Where | Why |
+|---|---|---|
+| The mode corpus, the walker, the gesture vocabulary | **shared TS**, vendored into every pack | Pure arithmetic. Testable in Node. No device, no latency, no ceiling hole. |
+| *Which* soundscape is current | **the host**, on the existing `settings` event | Cross-pack coherence cannot come from a pack: the frame is opaque-origin, its storage is not the app's, and it can see nothing of the pack open a minute ago. |
+| Rotation and persistence — the soundscape drifting over a session and across days | **the host** | A pack does not have a session. The host does. |
+| Synthesis — oscillators, envelopes, filters | **the pack**, through `game-audio`'s safety bus | Where the ceiling already is. |
+| The always-on ambient bed | **the host** (stage 3, below) | So it does not stop at every doorway. |
+
+**This needs no new capability, no new method, no permission, no stream, and no
+Rust.** It is one optional field on `Settings`, which already re-fires on every
+change — the same channel that carries `sound` and `safeArea`, both of which were
+added exactly this way. `game-host` publishes it in one line beside those two.
+
+### The three stages, and what is actually built
+
+**Stage 1 — shipped in this change, off in production.**
+`packs/shared/game-soundscape/` (six source files and an index, 45 tests). `Settings.soundscape?`
+on the wire. `game-host` publishes it. `game-audio`-style module state means
+`currentSoundscape()` is `null` until somebody publishes one, and **no host
+publishes one today**, so nothing in production changes audibly. THE STEELYARD is
+wired end to end and its dev harness (`npm run dev`) publishes a soundscape, which
+is where the idea can be heard: `?mode=maqam.rast&seed=7` to pin one,
+`?soundscape=off` for the A/B against what ships now.
+
+**Stage 2 — the host chooses, and games can talk back.** The host picks a
+soundscape at launch, rotates it on a slow schedule, and publishes it. Games get
+to *affect* it with a `feedback.soundscape` method under the **existing `audio`
+capability** — `{ gesture: "moreTension" | "lessTension" | "levelComplete" }`, fire
+and forget, 2 s budget, not native. The host adjusts and re-publishes through
+`settings`, which every pack already handles. No parent-facing permission changes,
+because "Play the app's sounds" already covers it.
+
+**Stage 3 — the bed moves to the host.** The always-on ambient bed lives in the
+host's own document, so it is continuous across the shell and under every pack and
+there is no silent gap at a doorway. It stays in tune with whatever pack is open
+because **both derive from the same `{ modeId, rootHz, seed }`** — the host does
+not send audio, it sends four numbers, and the same pure module turns them into
+the same pitches on both sides. That is the elegant part and it is why Option B
+is not a compromise.
+
+> **A defect stage 3 must fix on the way past.** `dynawalla-app/src/packs/services.ts`
+> `playCue()` connects straight to `context.destination`. The host's own cues are
+> **not** subject to any ceiling. Nothing has complained yet because they are five
+> short triangle tones, but the moment the host owns a continuous bed it needs
+> `createSafetyBus` too.
+
+---
+
+## 4. Premium and chill: the numbers
+
+Concrete replacements for "abrasive", so this is checkable rather than tasteful.
+
+### Pitch centres — go down
+
+| | today | soundscape |
+|---|---|---|
+| Brightest cue | 1180 Hz (fixed, every tap) | 1244 Hz **worst case**, at the top root and top degree; typical note far below |
+| Heaviest cue | 288 Hz | 58–117 Hz |
+| Melody low-pass | none | `min(2400, hz × 6)` on every voice |
+
+The 2–5 kHz band is where the ear is most sensitive and where "abrasive" lives.
+Nothing melodic goes there, and the one-off transient that does (the metallic
+`edge` on a struck plate) is 90 ms long and rides the note rather than sitting on
+top of the music at a pitch nothing else is at.
+
+### Attacks — 6 ms is a floor, not a target
+
+`game-audio`'s `MIN_ATTACK` is 6 ms and it stops the click. Chill needs more:
+
+| timbre | attack | use |
+|---|---|---|
+| `bloom` | **180 ms** | bowed, breathed in. Failures and arrivals. Never a transient. |
+| `bell` | 14 ms | struck. The melodic default. |
+| `pluck` | 10 ms | plucked. |
+| impacts | 6 ms | only where the *impact* is the information. |
+
+A failure that is a bloom rather than a buzz is most of what "not cruel" means in
+practice, and it costs one number.
+
+### White noise → modelled sound
+
+**24 of 28 games have a noise buffer.** Noise is one event with no size to it,
+which is why it reads as hiss rather than as a thing. The founder's example —
+a building crumbling — is the recipe:
+
+> **Rubble.** Many small impacts whose sizes follow a power law. Sixteen grains
+> over ~340 ms; grain *i* has size `1/(1+i)`; amplitude ∝ size, centre frequency ∝
+> 1/size, so a few big low ones and a lot of small high ones. Scatter the onsets
+> unevenly. Low-pass the whole cloud at 1.4 kHz. **That distribution is the entire
+> difference between "static" and "masonry"**, and it costs sixteen short
+> oscillators — which must be budgeted as ONE voice, because it is one gesture.
+
+Implemented in `games/counterweight/src/audio.ts` `rubble()`. The same recipe with
+different size exponents is gravel, a collapsing shelf, a wave, a fire.
+
+### Loudness
+
+| | linear peak | ≈ dBFS |
+|---|---|---|
+| Melodic voice (`MELODY_PEAK`) | 0.14 | −17 |
+| Drone, bowed | 0.075 | −22 |
+| Drone anchors (sub, fifth) | 0.05 / 0.028 | −26 / −31 |
+| Ambient bed (proposed) | ≤ 0.04 | −28 |
+| Output ceiling (`game-audio`) | 0.89 | −1 |
+
+The bed must sit ~10 dB under the melody. "Not too loud" is a ratio, not a volume
+knob — a bed you notice is a bed that is too loud.
+
+### Always optional
+
+Already true and unchanged: the app's Sound switch closes `game-audio`'s gate after
+the ceiling, so muted means silent and not merely quiet, and a game's own mute
+cannot reopen a gate a parent closed. Stage 3's bed needs **its own** switch as
+well — a parent may reasonably want cues without music, and one setting is the
+whole cost.
+
+---
+
+## 5. Never empty
+
+An ambient bed that is always there and never repeats. Three layers, and the point
+of each is aperiodicity **by construction** rather than by being long:
+
+1. **Drone.** Root, sub-octave, and the mode's own fifth where it has one. Two
+   detuned oscillators per pitch, ~4 cents apart, so the beating gives slow motion
+   with nothing repeating.
+2. **Pad.** Re-voices on a Poisson schedule (mean ~11 s) onto degrees drawn from
+   the mode, weighted to the rest degrees, coloured by tension. Aperiodic by
+   definition — there is no loop point because there is no loop.
+3. **Air.** A very low-level filtered layer whose filter frequency is the sum of
+   three LFOs at 0.013, 0.021 and 0.034 Hz. Deliberately incommensurable: the
+   combined pattern's period is longer than any session a child will play.
+
+Cost: about six oscillators and two filters, permanently. Cheaper than one of the
+27 games' particle systems.
+
+---
+
+## 6. What is proven, and what is not
+
+**Proven in Node, no device, 45 module tests + 6 in the game + 4 on the wire:**
+
+- Twelve taps produce ≥5 distinct pitches in all 40 seeds tried (today: 1).
+- Every pitch every gesture can emit is a degree of the live mode — 60 seeds × 6
+  rounds × 8 gestures, exhaustively.
+- The four register bands never overlap and nothing is ever folded — 200 seeds ×
+  25 steps × 4 weights.
+- Ascending steps ascend and descending steps descend, 100/100 seeds.
+- A phrase resolves onto a rest degree ≥6 times in 60 taps, all seeds.
+- Calm walks by smaller intervals than wound-up.
+- The drone takes the fifth iff the mode has one (Dorian yes, whole tone no).
+- The same seed is the same music, exactly.
+- Malformed wire input can never become a `NaN` frequency.
+- The `10 − 2` shortcut descends in 60 of 60 soundscapes.
+- Place-value register order holds in 100 of 100 soundscapes.
+- Nothing in the shipped pack publishes a soundscape (a source scan, so it fails
+  if somebody wires it on by accident).
+
+**Not proven, and needs ears:**
+
+- **Whether it is actually nice.** Thirty-eight modes is a lot of surface and some
+  of them will be wrong for a maths game — whole tone under a drone may be
+  seasick, Todi may be too strange. The corpus is data; culling is cheap.
+- **The rubble recipe on a tablet speaker.** Sixteen grains under 1.4 kHz is
+  modelled on paper. A small speaker rolls off below ~300 Hz and may turn it into
+  a click.
+- **The heaviest register.** 58–117 Hz is a real low clang on headphones and may be
+  inaudible on a tablet. The metallic `edge` at hz×3.4 is what carries it; that is
+  a hypothesis, not a measurement.
+- **Everything in stages 2 and 3.** Not built.
+
+---
+
+## 7. Open questions for the founder
+
+1. **Is the bed the host's or the pack's?** (Stage 3.) Host = never a silent gap at
+   a doorway, one continuous piece of music, and the shell has music too. Pack =
+   simpler, already inside the ceiling, and dies at every doorway. Recommendation:
+   host, and give it its own switch.
+2. **How often does the soundscape rotate?** Per launch? Per game? On a slow timer?
+   Recommendation: per launch, plus on `levelComplete` at most once every few
+   minutes, so a child notices the key changed after they achieved something.
+3. **Chord progressions.** The brief asks for "many chord progressions to choose
+   from" and beatlounge has ~994 generated ones. This design deliberately has
+   **none** — a moving progression means the melody's home note moves, and a
+   walker that resolves to a tonic that is itself moving is much harder to make
+   sound good. Worth it, or is a static drone the more chill answer?
+4. **How wide should the corpus be?** 38 now; 130 is a data change (adds the 72
+   melakartas, Persian, Turkish). More variety, larger pack payload, more of it
+   unvetted.
+5. **Should the whole fleet convert at once, or game by game?** All 28 have their
+   own `audio.ts`. Converting one is ~40 lines. Converting 28 is a week and a
+   fleet-wide behaviour change with no A/B.
+6. **Do we cull?** Some modes will not suit a maths game for a nine-year-old. Is
+   "every mode is available" a feature, or should there be a chill subset that is
+   the default with the rest behind something?
+
+---
+
+## Files
+
+| | |
+|---|---|
+| Cents and the two conversions | `packs/shared/game-soundscape/pitch.ts` |
+| The 38-mode corpus | `packs/shared/game-soundscape/modes.ts` |
+| Mode + root + seed + tension, and the wire guard | `packs/shared/game-soundscape/soundscape.ts` |
+| The walker, the gestures, the voices | `packs/shared/game-soundscape/melody.ts` |
+| The soundscape the app is in | `packs/shared/game-soundscape/host.ts` |
+| The wire field | `packs/sdk/src/protocol.ts` → `Settings.soundscape` |
+| Where it is published to a pack | `packs/shared/game-host/index.ts` → `publish()` |
+| THE STEELYARD's whole musical vocabulary | `games/counterweight/src/tune.ts` |
+| The synthesis, and the rubble recipe | `games/counterweight/src/audio.ts` |
+| Where it is turned on, for now | `games/counterweight/src/main.ts` |
+| The corpus this was ported from | `corpan/packs/beatlounge/src/music/modes/` |
+| The ceiling everything still passes | `packs/shared/game-audio/` |

--- a/dynawalla/games/counterweight/src/audio.ts
+++ b/dynawalla/games/counterweight/src/audio.ts
@@ -14,9 +14,39 @@
 // and the thousands plate is a low, heavy clang. Place value is a thing you can
 // hear here, and a child working the rack learns the four voices before they
 // could tell you why.
+//
+// ── The soundscape ───────────────────────────────────────────────────────────
+//
+// All of the above was true and still boring, and the founder said so: *"right
+// now [we] have the same sound for every +1/−1 … it would be way cooler if it
+// randomly played a melody based on the randomly chosen soundscape for any
+// given moment."* He is right, and the reason is not the timbre. It is that
+// `PLACE_HZ` is a fixed table, so the tenth blow on the ones plate is bit-for-
+// bit the first one. Nothing that happens changes what the next sound is.
+//
+// So when the app publishes a soundscape — a mode, a root and a seed — this
+// class stops reading `PLACE_HZ` and starts asking `packs/shared/game-soundscape`
+// what the next note is. Hanging brass walks the mode up, taking it off walks
+// it down, place buys register instead of a fixed frequency, and a run of blows
+// arcs and comes to rest like a phrase. The drone becomes the soundscape's own
+// root, so the melody cannot be out of tune with it: both are the same number.
+//
+// **Until a host publishes one, none of that happens and the yard sounds
+// exactly as it shipped.** `currentSoundscape()` is `null` by default and no
+// host sends the field yet, so this is the ship-safe path and the four fixed
+// pitches below are still the production sound. The dev harness publishes one
+// (`main.ts`), which is where the idea can be heard.
 
-import type { Place } from "./game/places.ts"
-import { createSafetyBus } from "../../../packs/shared/game-audio/index.ts"
+import { type Place, type Strike } from "./game/places.ts"
+import { createSafetyBus, safeAttack } from "../../../packs/shared/game-audio/index.ts"
+import {
+  Melody,
+  currentSoundscape,
+  onSoundscape,
+  type Gesture,
+  type Voice,
+} from "../../../packs/shared/game-soundscape/index.ts"
+import { gestureForStrike } from "./tune.ts"
 
 type Ctor = new () => AudioContext
 
@@ -26,6 +56,18 @@ const DRONE_SPAN = 0.28
 
 const PLACE_HZ: Record<Place, number> = { 1: 1180, 10: 830, 100: 520, 1000: 288 }
 
+/**
+ * How far the beam's bow may bend the drone when a soundscape is live, in cents.
+ *
+ * Thirty-five, which is a third of a semitone: audible as a bowed string
+ * leaning under pressure, and far too small to be heard as a different note.
+ * The old behaviour moved the drone a major third across the beam's travel,
+ * which is fine when the drone is the only pitched thing in the game and
+ * ruinous when it is the tonic the melody is being derived from — a tonic that
+ * slides is a melody that goes out of tune with itself.
+ */
+const BOW_BEND_CENTS = 35
+
 export class Audio {
   private ctx: AudioContext | null = null
   private master: GainNode | null = null
@@ -33,6 +75,39 @@ export class Audio {
   private droneBand: BiquadFilterNode | null = null
   private droneGain: GainNode | null = null
   private failed = false
+  /**
+   * The soundscape's melody walker, or `null` when no host has published one.
+   *
+   * `null` is the shipping state today and it means every method below takes
+   * the path it always took. Nothing about this game's sound changes until an
+   * app decides to publish a mode and a root.
+   */
+  private melody: Melody | null = null
+  /** The drone's fixed anchor voices — the sub-octave and, if the mode has one, the fifth. */
+  private anchors: OscillatorNode[] = []
+  private readonly unfollow: () => void
+
+  constructor() {
+    const scape = currentSoundscape()
+    this.melody = scape ? new Melody(scape) : null
+    // Following, not reading once: the host re-publishes on every settings
+    // change, and a game that only looked at launch would be in last hour's key.
+    this.unfollow = onSoundscape((next) => {
+      if (!next) {
+        this.melody = null
+        return
+      }
+      if (this.melody) this.melody.retune(next)
+      else this.melody = new Melody(next)
+      // A live drone has to move to the new root, or the melody is in one key
+      // and the thing under it is in another. Rebuilt rather than ramped: the
+      // bow is a half-second fade either way and a key change is not a slide.
+      if (this.droneOsc) {
+        this.release()
+        this.bow()
+      }
+    })
+  }
 
   private context(): AudioContext | null {
     if (this.ctx || this.failed) return this.ctx
@@ -76,16 +151,22 @@ export class Audio {
     })
   }
 
+  /** The pitch the bowed drone sits on: the soundscape's tonic, or the old fixed note. */
+  private droneHz(): number {
+    return this.melody?.soundscape.rootHz ?? DRONE_HZ
+  }
+
   /** Bring the drone up. Called when a round opens. */
   bow(): void {
     const ctx = this.context()
     if (!ctx || !this.master || this.droneOsc) return
+    const root = this.droneHz()
     const osc = ctx.createOscillator()
     osc.type = "sawtooth"
-    osc.frequency.value = DRONE_HZ
+    osc.frequency.value = root
     const band = ctx.createBiquadFilter()
     band.type = "bandpass"
-    band.frequency.value = DRONE_HZ * 3
+    band.frequency.value = root * 3
     band.Q.value = 5.5
     const gain = ctx.createGain()
     gain.gain.value = 0
@@ -97,6 +178,28 @@ export class Audio {
     this.droneOsc = osc
     this.droneBand = band
     this.droneGain = gain
+
+    // The anchor. The bowed voice above bends with the beam; these do not, and
+    // that is what the melody is actually in tune with. Sines, well under the
+    // bow, because a drone you notice is a drone that is too loud.
+    if (!this.melody) return
+    const pitches = this.melody.drone()
+    for (let i = 0; i < pitches.length; i++) {
+      const f = pitches[i]
+      // Skip the tonic itself: the bowed voice is already there and doubling it
+      // exactly would only make it louder.
+      if (f === undefined || Math.abs(f - root) < 0.01) continue
+      const anchor = ctx.createOscillator()
+      anchor.type = "sine"
+      anchor.frequency.value = f
+      const level = ctx.createGain()
+      level.gain.value = 0
+      level.gain.linearRampToValueAtTime(f < root ? 0.05 : 0.028, ctx.currentTime + 1.2)
+      anchor.connect(level)
+      level.connect(gain)
+      anchor.start()
+      this.anchors.push(anchor)
+    }
   }
 
   /**
@@ -112,7 +215,15 @@ export class Audio {
     if (!ctx || !this.droneOsc || !this.droneBand || !this.droneGain) return
     const t = ctx.currentTime
     const clamped = Math.max(-1, Math.min(1, tilt))
-    const hz = DRONE_HZ * (1 + clamped * DRONE_SPAN)
+    const root = this.droneHz()
+    // With a soundscape live the bow BENDS rather than transposes: the tonic is
+    // what the melody is derived from, and a tonic that slides a major third is
+    // a melody that is out of tune with the game it is in. A third of a
+    // semitone still reads as the steel leaning under load, which is all the
+    // cue was ever for.
+    const hz = this.melody
+      ? root * Math.pow(2, (clamped * BOW_BEND_CENTS) / 1200)
+      : root * (1 + clamped * DRONE_SPAN)
     this.droneOsc.frequency.setTargetAtTime(hz, t, 0.06)
     this.droneBand.frequency.setTargetAtTime(hz * (2.4 + ring * 4.5), t, 0.05)
     this.droneGain.gain.setTargetAtTime(0.06 + ring * 0.045, t, 0.08)
@@ -130,20 +241,45 @@ export class Audio {
     const t = ctx.currentTime
     gain.gain.cancelScheduledValues(t)
     gain.gain.setTargetAtTime(0, t, 0.09)
-    try {
-      osc.stop(t + 0.5)
-    } catch {
-      console.warn("[counterweight] the drone would not stop")
+    const anchors = this.anchors
+    this.anchors = []
+    for (const anchor of [osc, ...anchors]) {
+      try {
+        anchor.stop(t + 0.5)
+      } catch {
+        // Loud, never silent: an oscillator that refuses to stop is a drone that
+        // outlives the round it belongs to, and two of them is the game in two
+        // keys at once.
+        console.warn("[counterweight] the drone would not stop")
+      }
     }
   }
 
   /** A plate lands. Pitched by place; harder blows bite harder. */
-  clang(place: Place, impulse: number): void {
+  clang(strike: Strike, impulse: number): void {
     const ctx = this.context()
     if (!ctx || !this.master) return
     const t = ctx.currentTime
-    const hz = PLACE_HZ[place]
     const bite = Math.max(0, Math.min(1, (impulse - 2) / 9))
+
+    // With a soundscape live the plate is a note in a phrase rather than a
+    // fixed pitch. The metallic edge below still fires and still scales with
+    // the blow, so a mashed rack still sounds like a mashed rack — the strain
+    // feedback the game depends on is untouched. Only the pitch became music.
+    if (this.melody) {
+      let top = this.melody.soundscape.rootHz * 4
+      for (const voice of this.melody.emit(gestureForStrike(strike))) {
+        this.play(voice, 1 + bite * 0.3)
+        top = voice.hz
+      }
+      // The edge rides the note the soundscape chose, not a fixed frequency, so
+      // the bite belongs to the plate that was struck instead of sitting on top
+      // of the music at a pitch nothing else in the game is at.
+      this.edge(top, bite, t)
+      return
+    }
+
+    const hz = PLACE_HZ[strike.place]
 
     const osc = ctx.createOscillator()
     osc.type = "triangle"
@@ -158,8 +294,20 @@ export class Audio {
     osc.start(t)
     osc.stop(t + 0.5)
 
-    // The metallic edge: a short burst through a high band-pass. A resonant blow
-    // gets more of it, so mashing sounds like what it is.
+    this.edge(hz, bite, t)
+  }
+
+  /**
+   * The metallic edge: a short burst through a high band-pass. A resonant blow
+   * gets more of it, so mashing sounds like what it is.
+   *
+   * Lifted out of `clang` so the soundscape path keeps it. This is the part of
+   * the cue that reports on the child's *hands* rather than on the maths, and
+   * losing it would have made a mashed rack sound the same as a considered one.
+   */
+  private edge(hz: number, bite: number, t: number): void {
+    const ctx = this.ctx
+    if (!ctx || !this.master) return
     const noise = ctx.createOscillator()
     noise.type = "square"
     noise.frequency.setValueAtTime(hz * 3.7, t)
@@ -180,6 +328,7 @@ export class Audio {
 
   /** A refused strike: the plate is still swinging. A dead, unmusical thud. */
   refuse(): void {
+    if (this.speak({ kind: "refuse" })) return
     const ctx = this.context()
     if (!ctx || !this.master) return
     const t = ctx.currentTime
@@ -204,6 +353,7 @@ export class Audio {
    * behaviour is gone; the sound was worth keeping.
    */
   slide(): void {
+    if (this.speak({ kind: "arrive" })) return
     const ctx = this.context()
     if (!ctx || !this.master) return
     const t = ctx.currentTime
@@ -223,11 +373,13 @@ export class Audio {
 
   /** A good weight: a cold, clean fifth. The best sound in the game. */
   held(): void {
+    if (this.speak({ kind: "success" })) return
     this.chord([784, 1176], 0.1, 0.5)
   }
 
   /** The docket is refused. Low, short, not cruel. */
   lost(): void {
+    if (this.speak({ kind: "failure" })) return
     this.chord([196, 233], 0.085, 0.32)
   }
 
@@ -252,10 +404,139 @@ export class Audio {
 
   /** A scale is cleared. */
   fanfare(): void {
+    if (this.speak({ kind: "levelComplete" })) return
     this.chord([523, 659, 784], 0.09, 0.85)
     const ctx = this.ctx
     if (!ctx) return
     globalThis.setTimeout(() => this.chord([659, 784, 1046], 0.085, 0.9), 190)
+  }
+
+  /**
+   * Say something to the soundscape, and report whether it answered.
+   *
+   * `false` when no host has published one, which is every call in production
+   * today — and is exactly what makes each caller above a two-line change with
+   * the old cue still underneath it.
+   */
+  private speak(gesture: Gesture): boolean {
+    if (!this.melody) return false
+    if (!this.context()) return false
+    for (const voice of this.melody.emit(gesture)) this.play(voice, 1)
+    return true
+  }
+
+  /**
+   * One voice from the soundscape, made audible.
+   *
+   * This is the whole of what the pack owns: the module decided *which* pitch
+   * and *how loud*, and this decides what it is made of. Four timbres, all
+   * warm-ended, none of them white noise.
+   *
+   * Every envelope goes through `safeAttack`, so nothing here can be the 1 ms
+   * step that a child hears as "too loud" however short the module asked for.
+   */
+  private play(voice: Voice, scale: number): void {
+    const ctx = this.ctx
+    if (!ctx || !this.master) return
+    if (voice.timbre === "rubble") {
+      this.rubble(voice)
+      return
+    }
+    const t = ctx.currentTime + Math.max(0, voice.at)
+    const peak = Math.max(0.0002, voice.gain * scale)
+    // Attacks, by timbre. Bloom is bowed and must never be a transient; bell
+    // and pluck are struck and are still four times slower than the 1 ms step
+    // this fleet used to write.
+    const attack = safeAttack(voice.timbre === "bloom" ? 0.18 : voice.timbre === "pluck" ? 0.01 : 0.014)
+
+    // A fundamental plus one partial. The partial is what makes it a struck
+    // object rather than a test tone, and it is an octave rather than an
+    // inharmonic ratio because inharmonic is the sound the founder is calling
+    // abrasive.
+    const partials: readonly { ratio: number; level: number; type: OscillatorType }[] =
+      voice.timbre === "bloom"
+        ? [
+            { ratio: 1, level: 0.62, type: "sine" },
+            { ratio: 2.001, level: 0.2, type: "sine" },
+          ]
+        : voice.timbre === "pluck"
+          ? [
+              { ratio: 1, level: 0.7, type: "triangle" },
+              { ratio: 3, level: 0.12, type: "sine" },
+            ]
+          : [
+              { ratio: 1, level: 0.68, type: "triangle" },
+              { ratio: 2, level: 0.22, type: "sine" },
+              { ratio: 4, level: 0.06, type: "sine" },
+            ]
+
+    // One low-pass over the whole voice, so the top of the register is not the
+    // brightest thing in the game. 2.4 kHz is under the band the ear is most
+    // sensitive in, which is the band "abrasive" lives in.
+    const tone = ctx.createBiquadFilter()
+    tone.type = "lowpass"
+    tone.frequency.value = Math.min(2400, voice.hz * 6)
+    tone.Q.value = 0.7
+    tone.connect(this.master)
+
+    for (const partial of partials) {
+      const osc = ctx.createOscillator()
+      osc.type = partial.type
+      osc.frequency.value = voice.hz * partial.ratio
+      const gain = ctx.createGain()
+      gain.gain.setValueAtTime(0.0001, t)
+      gain.gain.exponentialRampToValueAtTime(peak * partial.level, t + attack)
+      gain.gain.exponentialRampToValueAtTime(0.0001, t + voice.seconds)
+      osc.connect(gain)
+      gain.connect(tone)
+      osc.start(t)
+      osc.stop(t + voice.seconds + 0.1)
+    }
+  }
+
+  /**
+   * A shelf of brass going over — the founder's "building crumbling here
+   * instead of white noise".
+   *
+   * A noise burst is one event with no size to it, which is why it reads as a
+   * hiss rather than as a thing. Rubble is *many* small impacts whose sizes
+   * follow a power law: a few big low ones, a lot of small high ones, scattered
+   * unevenly over a third of a second. That distribution is the difference
+   * between "static" and "masonry", and it costs sixteen short oscillators.
+   *
+   * Every grain is band-passed and none of them is above 1.4 kHz, so the whole
+   * event sits below the band that hurts.
+   */
+  private rubble(voice: Voice): void {
+    const ctx = this.ctx
+    if (!ctx || !this.master) return
+    const t0 = ctx.currentTime + Math.max(0, voice.at)
+    const grains = 16
+    const shelf = ctx.createBiquadFilter()
+    shelf.type = "lowpass"
+    shelf.frequency.value = 1400
+    shelf.Q.value = 0.6
+    shelf.connect(this.master)
+    for (let i = 0; i < grains; i++) {
+      // Size, 1 down to about 1/16. Amplitude goes with size and pitch goes
+      // inversely with it — a small stone is quiet and high, a big one is loud
+      // and low, which is the whole of why this sounds like rubble.
+      const size = 1 / (1 + i)
+      const at = t0 + (i / grains) * voice.seconds * (0.5 + ((i * 7919) % 100) / 200)
+      const osc = ctx.createOscillator()
+      osc.type = "triangle"
+      osc.frequency.setValueAtTime(voice.hz * (0.7 + 1 / Math.max(0.12, size) / 6), at)
+      osc.frequency.exponentialRampToValueAtTime(voice.hz * 0.6, at + 0.05)
+      const gain = ctx.createGain()
+      const peak = Math.max(0.0002, voice.gain * size * 0.9)
+      gain.gain.setValueAtTime(0.0001, at)
+      gain.gain.exponentialRampToValueAtTime(peak, at + safeAttack(0.004))
+      gain.gain.exponentialRampToValueAtTime(0.0001, at + 0.04 + size * 0.12)
+      osc.connect(gain)
+      gain.connect(shelf)
+      osc.start(at)
+      osc.stop(at + 0.25)
+    }
   }
 
   private chord(hz: readonly number[], peak: number, seconds: number): void {
@@ -278,6 +559,9 @@ export class Audio {
   }
 
   dispose(): void {
+    // Before anything else: a closure that retunes a torn-down graph outlives
+    // the game otherwise, and the next mount would have two of them.
+    this.unfollow()
     this.release()
     const ctx = this.ctx
     this.ctx = null

--- a/dynawalla/games/counterweight/src/main.ts
+++ b/dynawalla/games/counterweight/src/main.ts
@@ -7,6 +7,41 @@
 
 import { mount } from "./contract.ts"
 import { createStubHost } from "./stubHost.ts"
+import {
+  MODE_IDS,
+  modeById,
+  pickSoundscape,
+  setHostSoundscape,
+} from "../../../packs/shared/game-soundscape/index.ts"
+
+// ── The soundscape, in the harness only ─────────────────────────────────────
+//
+// The real app does not publish one yet, so in a shipped pack
+// `currentSoundscape()` is `null` and the yard sounds exactly as it always has.
+// Here it is published before mount, which is the only place the idea can
+// currently be heard: a random mode and root each run, or a named one with
+// `?mode=maqam.rast&root=146.8`, so a specific report ("hijaz sounds wrong on
+// the thousands plate") is reproducible rather than a memory.
+//
+// `?mode=list` prints the corpus. `?soundscape=off` is the A/B — the same game
+// with the fixed four pitches, for hearing what this replaces.
+const params = new URLSearchParams(globalThis.location?.search ?? "")
+if (params.get("mode") === "list") console.info("[counterweight] modes:", MODE_IDS.join(", "))
+if (params.get("soundscape") !== "off") {
+  const seed = Number(params.get("seed") ?? ((Date.now() ^ 0x5ca9e) >>> 0))
+  const chosen = pickSoundscape(Number.isFinite(seed) ? seed : 1)
+  const wanted = params.get("mode")
+  const root = Number(params.get("root"))
+  const scape = {
+    ...chosen,
+    ...(wanted && modeById(wanted) ? { modeId: wanted } : {}),
+    ...(Number.isFinite(root) && root > 0 ? { rootHz: root } : {}),
+  }
+  setHostSoundscape(scape)
+  console.info(
+    `[counterweight] soundscape ${scape.modeId} on ${scape.rootHz.toFixed(2)} Hz, seed ${scape.seed}`,
+  )
+}
 
 const root = document.getElementById("app")
 if (!root) throw new Error("counterweight: #app missing")

--- a/dynawalla/games/counterweight/src/mount.ts
+++ b/dynawalla/games/counterweight/src/mount.ts
@@ -198,7 +198,7 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
         case "strike": {
           beam.aim(bout.margin)
           beam.hit(event.impulse, event.strike.dir)
-          audio.clang(event.strike.place, event.impulse)
+          audio.clang(event.strike, event.impulse)
           host.haptic(event.impulse >= 6 ? "medium" : "light")
           if (!reduced) {
             const at = scene.faceCentre(event.strike.place, event.strike.dir)

--- a/dynawalla/games/counterweight/src/test/soundscape.test.ts
+++ b/dynawalla/games/counterweight/src/test/soundscape.test.ts
@@ -1,0 +1,149 @@
+// The soundscape, as THE STEELYARD hears it.
+//
+// The claim being settled here is the founder's: that a run of `+1`s should be
+// a little song rather than the same ding ten times. It is settled by playing
+// the strikes a *correct* player actually makes — `planStrikes` is this game's
+// optimal player — through the shared soundscape and looking at what comes out.
+// No `AudioContext` is involved: `tune.ts` and `game-soundscape` are pure, which
+// is the whole reason they are separate files from `audio.ts`.
+
+import assert from "node:assert/strict"
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+
+import {
+  MELODY_MAX_HZ,
+  MELODY_MIN_HZ,
+  Melody,
+  currentSoundscape,
+  modeOf,
+  pickSoundscape,
+  centsBetween,
+} from "../../../../packs/shared/game-soundscape/index.ts"
+import { PLACES, planStrikes, type Strike } from "../game/places.ts"
+import { PLACE_WEIGHT, gestureForStrike } from "../tune.ts"
+
+const SRC = fileURLToPath(new URL("..", import.meta.url))
+
+test("the rack is weighted from lightest to heaviest, with nothing missed", () => {
+  const weights = PLACES.map((p) => PLACE_WEIGHT[p])
+  assert.equal(weights.length, PLACES.length)
+  assert.equal(new Set(weights).size, PLACES.length, "two pillars share a register")
+  assert.equal(PLACE_WEIGHT[1], 0, "the ones plate should be the brightest")
+  assert.equal(PLACE_WEIGHT[1000], 1, "the thousands plate should be the heaviest")
+  for (const w of weights) assert.ok(w >= 0 && w <= 1)
+})
+
+test("a blow carries its direction and its heaviness and nothing else", () => {
+  const on = gestureForStrike({ place: 10, dir: 1 })
+  assert.deepEqual(on, { kind: "step", direction: 1, weight: PLACE_WEIGHT[10] })
+  const off = gestureForStrike({ place: 1000, dir: -1 })
+  assert.deepEqual(off, { kind: "step", direction: -1, weight: 1 })
+  // The thing that must never appear in a gesture: a frequency.
+  assert.ok(!Object.keys(on).includes("hz"))
+})
+
+test("doing the arithmetic right sounds like a phrase, not like one note ten times", () => {
+  // 142 is the delta from the README's worked example — a pan on 500 and a lot
+  // that needs 642. `planStrikes` is the balanced-base-ten path a child who has
+  // worked it out actually takes: one hundred, four tens, two ones.
+  const strikes = planStrikes(142)
+  assert.ok(strikes.length >= 7, `the worked example is only ${strikes.length} blows`)
+  for (let seed = 0; seed < 40; seed++) {
+    const scape = pickSoundscape(seed)
+    const melody = new Melody(scape)
+    const heard: number[] = []
+    for (const strike of strikes) {
+      for (const v of melody.emit(gestureForStrike(strike))) heard.push(v.hz)
+    }
+    assert.equal(heard.length, strikes.length, "a blow did not make a sound")
+    assert.ok(
+      new Set(heard.map((f) => Math.round(f * 100))).size >= 4,
+      `seed ${seed}: the whole plan produced ${new Set(heard).size} distinct pitches`,
+    )
+    // And it is a phrase in the mode, not just a set of different numbers.
+    const degrees = new Set(modeOf(scape).degrees.map((c) => Math.round(c * 1000)))
+    for (const f of heard) {
+      const within = Math.round(((((centsBetween(scape.rootHz, f) % 1200) + 1200) % 1200) * 1000))
+      assert.ok(degrees.has(within), `${f.toFixed(2)} Hz is not in ${scape.modeId}`)
+    }
+  }
+})
+
+test("the ten-less-two shortcut sounds like a turn, not like more of the same", () => {
+  // Going from 613 to 621: one on the tens and two OFF the ones. The two
+  // take-offs must descend the mode, because that is what makes trimming a pan
+  // audibly different from loading it — the property the fixed table could not
+  // express at all, since it played the identical tick either way.
+  const strikes = planStrikes(8)
+  assert.deepEqual(
+    strikes.map((s) => [s.place, s.dir]),
+    [
+      [10, 1],
+      [1, -1],
+      [1, -1],
+    ],
+  )
+  let turns = 0
+  for (let seed = 0; seed < 60; seed++) {
+    const melody = new Melody(pickSoundscape(seed))
+    const positions: number[] = []
+    for (const strike of strikes) {
+      melody.emit(gestureForStrike(strike))
+      positions.push(melody.position)
+    }
+    const [a, b, c] = positions
+    assert.ok(a !== undefined && b !== undefined && c !== undefined)
+    if (b < a && c < b) turns++
+  }
+  assert.ok(turns >= 55, `the trim descended in only ${turns} of 60 soundscapes`)
+})
+
+test("place value is still a thing you can hear", () => {
+  // The property the game already had and must not lose: the ones plate is a
+  // bright tick and the thousands plate is a low clang. It is now register
+  // rather than a fixed frequency, so it survives every mode and every root.
+  let ordered = 0
+  for (let seed = 0; seed < 100; seed++) {
+    const scape = pickSoundscape(seed)
+    const pitches = PLACES.map((place) => {
+      const melody = new Melody(scape)
+      const strike: Strike = { place, dir: 1 }
+      return melody.emit(gestureForStrike(strike))[0]?.hz ?? 0
+    })
+    // PLACES is heaviest-first, so this should be ascending.
+    let rising = true
+    for (let i = 1; i < pitches.length; i++) {
+      if ((pitches[i] ?? 0) <= (pitches[i - 1] ?? 0)) rising = false
+    }
+    if (rising) ordered++
+    for (const f of pitches) assert.ok(f >= MELODY_MIN_HZ && f <= MELODY_MAX_HZ)
+  }
+  assert.ok(ordered >= 95, `the rack was in register order in only ${ordered} of 100 soundscapes`)
+})
+
+test("nothing in the shipped pack turns the soundscape on", () => {
+  // The ship gate, asserted rather than intended. `currentSoundscape()` is
+  // `null` until something publishes one; the dev harness (`main.ts`, which
+  // `pack.html` does not load) is the only file allowed to. If a second one
+  // appears, this pack has started shipping a behaviour change that nobody
+  // decided to make.
+  assert.equal(currentSoundscape(), null, "something in this suite left a soundscape published")
+  const offenders: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        if (entry !== "test") walk(full)
+        continue
+      }
+      if (!entry.endsWith(".ts")) continue
+      if (full === path.join(SRC, "main.ts")) continue
+      if (readFileSync(full, "utf8").includes("setHostSoundscape")) offenders.push(full)
+    }
+  }
+  walk(SRC)
+  assert.deepEqual(offenders, [], "these files publish a soundscape into the shipped pack")
+})

--- a/dynawalla/games/counterweight/src/tune.ts
+++ b/dynawalla/games/counterweight/src/tune.ts
@@ -1,0 +1,46 @@
+// What the weigh-house says to the soundscape.
+//
+// The whole of THE STEELYARD's musical vocabulary is in this file, and it is
+// eight lines of it, because a game is not allowed to pick pitches. It says
+// *what happened* — a weight went on, a weight came off, how heavy it was —
+// and `packs/shared/game-soundscape` decides what that sounds like in whatever
+// mode and root the app is currently in.
+//
+// Kept out of `audio.ts` on purpose: `audio.ts` needs an `AudioContext` and
+// therefore a browser, and this is the part worth asserting. `tune.test.ts`
+// plays a whole round through it in Node with no device.
+
+import type { Gesture } from "../../../packs/shared/game-soundscape/index.ts"
+import { PLACES, type Place, type Strike } from "./game/places.ts"
+
+/**
+ * How heavy each pillar of the rack is, 0..1.
+ *
+ * The soundscape spends this on register, so the ones plate stays a bright tick
+ * and the thousands plate stays a low clang — the game's "place value is a
+ * thing you can hear" property, kept exactly and made musical. Derived from
+ * `PLACES` rather than written out, so a rack that grows a ten-thousands pillar
+ * cannot silently leave it at the wrong weight.
+ */
+export const PLACE_WEIGHT: Readonly<Record<Place, number>> = Object.fromEntries(
+  // `PLACES` is heaviest-first, so the first entry is weight 1.
+  PLACES.map((place, i) => [place, 1 - i / Math.max(1, PLACES.length - 1)]),
+) as Record<Place, number>
+
+/**
+ * A blow on the rack, as something the soundscape can sing.
+ *
+ * **The direction is the interesting half.** Hanging brass ascends the mode and
+ * taking it off descends it, so `+1` and `−1` are not two arbitrary noises —
+ * they are opposite motions in the same scale, which is the closest a pitch
+ * collection gets to having a grammar. A child walking a pan up to its answer
+ * and then trimming it back down hears the trim as a return, not as more of the
+ * same.
+ */
+export function gestureForStrike(strike: Strike): Gesture {
+  return {
+    kind: "step",
+    direction: strike.dir,
+    weight: PLACE_WEIGHT[strike.place],
+  }
+}

--- a/dynawalla/packs/sdk/src/protocol.ts
+++ b/dynawalla/packs/sdk/src/protocol.ts
@@ -223,6 +223,41 @@ export type Settings = {
    * getting.
    */
   readonly safeArea?: { top: number; right: number; bottom: number; left: number }
+  /**
+   * The mode, root and seed every pack should be making music in right now.
+   *
+   * **Why this is on the wire and not decided by each pack.** A child leaves
+   * one game and opens another. If each pack chose its own key the app would
+   * change key at every doorway, which is not a soundscape — it is
+   * twenty-eight ringtones. A pack cannot coordinate this itself: its frame is
+   * opaque-origin and sandboxed, its storage is not the app's, and it can see
+   * nothing of the pack that was open a minute ago. So the one slow-moving
+   * fact travels with the other slow-moving facts, on the channel that already
+   * re-fires whenever any of them changes.
+   *
+   * **What is deliberately NOT here.** Pitches, note events, timing. Those are
+   * decided inside the pack, synchronously, because a note is caused by a
+   * finger and a port round-trip is at best two frames — a melody note that
+   * arrives forty milliseconds after the tap is not a melody. The wire carries
+   * what changes every few minutes; the pack computes what changes ten times a
+   * second. See `dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md`.
+   *
+   * Optional, so an older host is not a breaking change, and validated rather
+   * than trusted: `packs/shared/game-soundscape` refuses anything malformed and
+   * a pack that gets `undefined` keeps whatever sounds it already had. That is
+   * also why no `SDK_VERSION` bump belongs with this field — it adds no method
+   * and no capability, exactly like `safeArea` before it.
+   */
+  readonly soundscape?: {
+    /** A mode id from the shared corpus, e.g. `maqam.rast`. */
+    readonly modeId: string
+    /** The tonic, in Hz. Low — the drone sits here. */
+    readonly rootHz: number
+    /** Drives every stochastic choice a pack makes from this soundscape. */
+    readonly seed: number
+    /** 0..1. How wound-up the app currently is. */
+    readonly tension?: number
+  }
 }
 
 /**

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -152,6 +152,7 @@ import type {
 } from "../../sdk/src/index.ts"
 import { setHostInsets } from "../game-chrome/insets.ts"
 import { setHostSound } from "../game-audio/index.ts"
+import { setHostSoundscape } from "../game-soundscape/index.ts"
 import { MAX_REQUESTS_PER_SECOND, connect } from "../../sdk/src/index.ts"
 
 /** The shape both games declare locally. Kept structurally identical. */
@@ -792,9 +793,18 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   // host pushes one whenever the store changes, which is the whole point: a
   // switch that only takes effect at launch is a switch a parent flips while a
   // game is loud and watches do nothing.
+  //
+  // The soundscape joins them for the third time the same reason applies: it is
+  // a slow-moving fact about the app that a pack cannot work out for itself. A
+  // pack frame is opaque-origin and sees nothing of the pack the child was in a
+  // minute ago, so if each one chose its own key the bazaar would change key at
+  // every doorway. `game-soundscape` validates it and refuses anything
+  // malformed; a host too old to send one publishes `undefined`, which means
+  // "keep your own sounds" and not "go quiet".
   const publish = (): void => {
     setHostInsets(client.settings.safeArea)
     setHostSound(client.settings.sound)
+    setHostSoundscape(client.settings.soundscape)
   }
   publish()
   client.on("settings", publish)

--- a/dynawalla/packs/shared/game-host/sound.test.ts
+++ b/dynawalla/packs/shared/game-host/sound.test.ts
@@ -17,6 +17,11 @@ import { beforeEach, describe, it } from "node:test"
 import type { HostClient, HostEventName, Settings } from "../../sdk/src/index.ts"
 import { createSafetyBus, resetHostSound, type BusContext } from "../game-audio/index.ts"
 import { setHostInsets, safeInsets } from "../game-chrome/insets.ts"
+import {
+  currentSoundscape,
+  pickSoundscape,
+  resetHostSoundscape,
+} from "../game-soundscape/index.ts"
 import { attachGameHost } from "./index.ts"
 
 // ─── The smallest host that can change its mind ──────────────────────────────
@@ -264,5 +269,54 @@ describe("the app's Sound setting silences the game", () => {
     stub.setSound(false)
     assert.equal(heard(music, musicBus, CUE), 0, "the music bus kept playing")
     assert.equal(heard(sfx, sfxBus, CUE), 0, "the effects bus kept playing")
+  })
+})
+
+// ─── The soundscape, on the same channel ─────────────────────────────────────
+//
+// The third slow-moving fact that has to reach a pack from the host, and the
+// same failure mode is available: publish it once at attach and a child who
+// plays across a key change is in the wrong key for the rest of the session.
+// These assert the wire rather than the music — `game-soundscape` owns whether
+// the notes are right, and this owns whether the pack was told.
+
+describe("the app's soundscape reaches the pack", () => {
+  beforeEach(() => {
+    resetHostSoundscape()
+  })
+
+  it("is published at attach", () => {
+    const scape = pickSoundscape(31)
+    const stub = stubClient({ soundscape: scape })
+    attachGameHost(stub.client)
+    assert.deepEqual(currentSoundscape(), scape)
+    resetHostSoundscape()
+  })
+
+  it("follows a change without a remount", () => {
+    const stub = stubClient({ soundscape: pickSoundscape(1) })
+    attachGameHost(stub.client)
+    const next = pickSoundscape(2)
+    stub.push({ soundscape: next })
+    assert.deepEqual(currentSoundscape(), next, "the pack stayed in the old key")
+    resetHostSoundscape()
+  })
+
+  it("a host that sends none leaves every game with its own sounds", () => {
+    // The ship gate. No host populates this field today, so this is the path
+    // production takes, and `null` has to mean "keep what you had" rather than
+    // "go quiet".
+    const stub = stubClient()
+    attachGameHost(stub.client)
+    assert.equal(currentSoundscape(), null)
+    resetHostSoundscape()
+  })
+
+  it("a malformed one is refused rather than played", () => {
+    const stub = stubClient()
+    attachGameHost(stub.client)
+    stub.push({ soundscape: { modeId: "not.a.mode", rootHz: 130, seed: 1 } as never })
+    assert.equal(currentSoundscape(), null, "a mode the pack does not have was accepted")
+    resetHostSoundscape()
   })
 })

--- a/dynawalla/packs/shared/game-soundscape/host.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/host.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  currentSoundscape,
+  onSoundscape,
+  resetHostSoundscape,
+  setHostSoundscape,
+} from "./host.ts"
+import { CALM, ROOT_MAX_HZ, ROOT_MIN_HZ, parseSoundscape, pickSoundscape } from "./soundscape.ts"
+
+test("nobody has published one, so a game keeps its own sounds", () => {
+  resetHostSoundscape()
+  assert.equal(currentSoundscape(), null)
+})
+
+test("a published soundscape reaches every listener", () => {
+  resetHostSoundscape()
+  const seen: (string | null)[] = []
+  const off = onSoundscape((s) => seen.push(s?.modeId ?? null))
+  const scape = pickSoundscape(17)
+  setHostSoundscape(scape)
+  assert.deepEqual(currentSoundscape(), scape)
+  setHostSoundscape(undefined)
+  assert.equal(currentSoundscape(), null)
+  off()
+  setHostSoundscape(pickSoundscape(18))
+  assert.deepEqual(seen, [scape.modeId, null])
+  resetHostSoundscape()
+})
+
+test("republishing the same soundscape does not retune anybody", () => {
+  // The host re-sends `settings` on every change to anything in it, including
+  // the ones this module does not care about. Retuning a live drone on a text
+  // size change would be audible for no reason.
+  resetHostSoundscape()
+  let calls = 0
+  onSoundscape(() => {
+    calls++
+  })
+  const scape = pickSoundscape(5)
+  setHostSoundscape(scape)
+  setHostSoundscape({ ...scape })
+  assert.equal(calls, 1)
+  resetHostSoundscape()
+})
+
+test("a listener that throws is loud and does not stop the others", () => {
+  resetHostSoundscape()
+  const errors: unknown[][] = []
+  const original = console.error
+  console.error = (...args: unknown[]): void => {
+    errors.push(args)
+  }
+  let reached = false
+  try {
+    onSoundscape(() => {
+      throw new Error("no")
+    })
+    onSoundscape(() => {
+      reached = true
+    })
+    setHostSoundscape(pickSoundscape(1))
+  } finally {
+    console.error = original
+  }
+  assert.ok(reached, "a throwing listener stopped the next one")
+  assert.equal(errors.length, 1)
+  resetHostSoundscape()
+})
+
+test("unsubscribing from inside a callback does not skip the listeners after it", () => {
+  // Deleting yourself mid-iteration is safe on a JS Set, so a test that only
+  // does that passes against an implementation with no copy at all. The case
+  // that is NOT safe is a listener that tears down a sibling — the sibling is
+  // still ahead in the iteration and silently never runs, which is a drone left
+  // in the old key with nothing in the log.
+  resetHostSoundscape()
+  let self = 0
+  let sibling = 0
+  const off = onSoundscape(() => {
+    self++
+    offSibling()
+  })
+  const offSibling = onSoundscape(() => {
+    sibling++
+  })
+  setHostSoundscape(pickSoundscape(2))
+  assert.equal(self, 1)
+  assert.equal(sibling, 1, "a listener was skipped because a sibling unsubscribed mid-publish")
+  setHostSoundscape(pickSoundscape(3))
+  assert.equal(self, 2)
+  assert.equal(sibling, 1)
+  off()
+  resetHostSoundscape()
+})
+
+test("nothing malformed can become a NaN frequency", () => {
+  // The failure mode this guard exists for: an oscillator handed NaN throws on
+  // start, and the game is silent with nothing in the log.
+  assert.equal(parseSoundscape(undefined), null)
+  assert.equal(parseSoundscape(null), null)
+  assert.equal(parseSoundscape("western.dorian"), null)
+  assert.equal(parseSoundscape([]), null)
+  assert.equal(parseSoundscape({ modeId: "western.dorian", rootHz: 130, seed: 1 })?.tension, CALM)
+  assert.equal(parseSoundscape({ modeId: "nope", rootHz: 130, seed: 1 }), null)
+  assert.equal(parseSoundscape({ modeId: "western.dorian", rootHz: Number.NaN, seed: 1 }), null)
+  assert.equal(parseSoundscape({ modeId: "western.dorian", rootHz: "130", seed: 1 }), null)
+  assert.equal(parseSoundscape({ modeId: "western.dorian", rootHz: 130, seed: Number.NaN }), null)
+  // A root far outside the band is a bug or an attack, not a low note.
+  assert.equal(parseSoundscape({ modeId: "western.dorian", rootHz: 20000, seed: 1 }), null)
+  assert.equal(parseSoundscape({ modeId: "western.dorian", rootHz: 1, seed: 1 }), null)
+})
+
+test("a chosen soundscape is inside the chill band and replays exactly", () => {
+  for (let seed = 0; seed < 200; seed++) {
+    const a = pickSoundscape(seed)
+    const b = pickSoundscape(seed)
+    assert.deepEqual(a, b)
+    assert.ok(
+      a.rootHz >= ROOT_MIN_HZ * 0.99 && a.rootHz <= ROOT_MAX_HZ * 1.01,
+      `seed ${seed} chose a root at ${a.rootHz} Hz`,
+    )
+    assert.ok(parseSoundscape(a) !== null, `seed ${seed} chose something the wire would refuse`)
+  }
+})
+
+test("the roll spreads over the corpus rather than favouring one mode", () => {
+  const seen = new Set<string>()
+  for (let seed = 0; seed < 400; seed++) seen.add(pickSoundscape(seed).modeId)
+  assert.ok(seen.size >= 30, `400 rolls found only ${seen.size} modes`)
+})

--- a/dynawalla/packs/shared/game-soundscape/host.ts
+++ b/dynawalla/packs/shared/game-soundscape/host.ts
@@ -1,0 +1,92 @@
+/**
+ * The soundscape the app is in, as a fact a pack is told rather than one it
+ * invents.
+ *
+ * **Why this is not a per-pack decision.** A child leaves THE STEELYARD and
+ * opens THE LATTICE. If each pack rolled its own key, the bazaar would change
+ * key at every doorway — which is not a soundscape, it is twenty-eight
+ * ringtones. One mode, one root, one seed, published by the host and read by
+ * whichever pack is open, is what makes the whole app sound like one place.
+ * Cross-pack state cannot come from a pack: a pack frame is opaque-origin and
+ * sandboxed, its `localStorage` is not the app's, and it can see nothing of the
+ * pack the child was in a minute ago. It has to come from the other end of the
+ * port.
+ *
+ * **Why `null` is the default, and why that is the whole ship-safety story.**
+ * Until a host publishes a soundscape, `currentSoundscape()` is `null` and a
+ * game keeps whatever sound it already had. No host publishes one today, so
+ * this module changes nothing audible in production the day it lands. A pack's
+ * dev harness publishes one, which is where the idea can be heard. Turning it
+ * on for real is one line in the host, deliberately not taken in the change
+ * that introduces this.
+ *
+ * Shaped exactly like `game-audio/sound.ts`, on purpose: `game-host` already
+ * knows how to publish that one on every `settings` event, and a second thing
+ * with the same shape is a line rather than a mechanism.
+ */
+
+import { parseSoundscape, type Soundscape } from "./soundscape.ts"
+
+let current: Soundscape | null = null
+
+type Sink = (scape: Soundscape | null) => void
+
+const sinks = new Set<Sink>()
+
+/**
+ * Publish the app's soundscape.
+ *
+ * Takes `unknown` because the value comes off a `MessagePort`: it is whatever a
+ * host of some version put there. Anything that is not a soundscape — including
+ * `undefined`, which is what a host too old to send one sends — clears it, and
+ * clearing it means every game goes back to its own sounds rather than to
+ * silence.
+ */
+export function setHostSoundscape(value: unknown): void {
+  const next = parseSoundscape(value)
+  if (same(next, current)) return
+  current = next
+  // A copy, so a sink that unsubscribes from inside the callback cannot mutate
+  // the set being iterated.
+  for (const sink of [...sinks]) {
+    try {
+      sink(next)
+    } catch (error) {
+      // Loud. A game that could not take the new soundscape is a game playing
+      // in the wrong key over the app's drone, which is worse than no drone.
+      console.error("[game-soundscape] a listener refused the app's soundscape", error)
+    }
+  }
+}
+
+/** The soundscape right now, or `null` when no host has published one. */
+export function currentSoundscape(): Soundscape | null {
+  return current
+}
+
+/**
+ * Follow the soundscape. Returns an unsubscribe; call it when the graph the
+ * closure retunes is torn down.
+ */
+export function onSoundscape(sink: Sink): () => void {
+  sinks.add(sink)
+  return () => {
+    sinks.delete(sink)
+  }
+}
+
+/**
+ * Forget the published soundscape and every subscriber.
+ *
+ * For tests. Module state that survives between test files is how a suite
+ * starts passing for the wrong reason.
+ */
+export function resetHostSoundscape(): void {
+  current = null
+  sinks.clear()
+}
+
+function same(a: Soundscape | null, b: Soundscape | null): boolean {
+  if (a === null || b === null) return a === b
+  return a.modeId === b.modeId && a.rootHz === b.rootHz && a.seed === b.seed && a.tension === b.tension
+}

--- a/dynawalla/packs/shared/game-soundscape/index.ts
+++ b/dynawalla/packs/shared/game-soundscape/index.ts
@@ -1,0 +1,61 @@
+/**
+ * A generative soundscape every Dynawalla game can play in.
+ *
+ * The founder's brief, and the thing this exists to make true: *"right now
+ * [THE STEELYARD has] the same sound for every +1/−1 … it would be way cooler
+ * if it randomly played a melody based on the randomly chosen soundscape for
+ * any given moment … so we are in a certain maqam in a certain root note, then
+ * the little sound effects play a nice little song."*
+ *
+ * Six files, and no Web Audio in any of them:
+ *
+ *   `pitch`      cents, and the two conversions everything is built from.
+ *   `modes`      38 modes — Western, Hindustani thaats, Arabic maqamat —
+ *                as exact cents above the tonic, ported from beatlounge.
+ *   `rng`        a seeded stream, so "random" is a thing a test can assert.
+ *   `soundscape` mode + root + seed + tension, small enough to sit on the wire.
+ *   `melody`     the walker: gestures in, in-tune voices out.
+ *   `host`       the soundscape the app is in, published by the host.
+ *
+ * Usage, in a game:
+ *
+ *     import { Melody, currentSoundscape, pickSoundscape }
+ *       from "../../../packs/shared/game-soundscape/index.ts"
+ *
+ *     const melody = new Melody(currentSoundscape() ?? pickSoundscape(seed))
+ *     for (const v of melody.emit({ kind: "step", direction: 1, weight: 0 })) {
+ *       play(v)   // the game owns the synthesis; this module owns the music
+ *     }
+ *
+ * The game never names a frequency. That is the rule, and it is what keeps
+ * every sound in the pack in tune with the drone and with every other pack.
+ */
+export { CENTS_PER_OCTAVE, centsBetween, centsToRatio, foldIntoRange, hz } from "./pitch.ts"
+export { MODES, MODE_IDS, modeById, type Mode, type ModeFamily } from "./modes.ts"
+export { Rng } from "./rng.ts"
+export {
+  CALM,
+  ROOT_MAX_HZ,
+  ROOT_MIN_HZ,
+  modeOf,
+  parseSoundscape,
+  pickSoundscape,
+  withTension,
+  type Soundscape,
+} from "./soundscape.ts"
+export {
+  MELODY_MAX_HZ,
+  MELODY_MIN_HZ,
+  MELODY_PEAK,
+  Melody,
+  TENSION_STEP,
+  type Gesture,
+  type Timbre,
+  type Voice,
+} from "./melody.ts"
+export {
+  currentSoundscape,
+  onSoundscape,
+  resetHostSoundscape,
+  setHostSoundscape,
+} from "./host.ts"

--- a/dynawalla/packs/shared/game-soundscape/melody.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/melody.test.ts
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  MELODY_MAX_HZ,
+  MELODY_MIN_HZ,
+  MELODY_PEAK,
+  Melody,
+  TENSION_STEP,
+  type Gesture,
+  type Voice,
+} from "./melody.ts"
+import { modeById } from "./modes.ts"
+import { centsBetween } from "./pitch.ts"
+import { CALM, modeOf, pickSoundscape, type Soundscape } from "./soundscape.ts"
+
+const scape = (seed: number, tension = CALM): Soundscape => pickSoundscape(seed, tension)
+
+/** Every degree of the live mode, in cents, folded into one octave. */
+function degreeSet(s: Soundscape): Set<number> {
+  return new Set(modeOf(s).degrees.map((c) => Math.round(c * 1000)))
+}
+
+/** Where a frequency sits above the root, in cents, folded into one octave. */
+function pitchClass(rootHz: number, f: number): number {
+  const cents = centsBetween(rootHz, f)
+  const within = ((cents % 1200) + 1200) % 1200
+  return Math.round(within * 1000)
+}
+
+test("a run of taps is a phrase, not the same ding twelve times", () => {
+  // The founder's complaint, as an assertion: THE STEELYARD plays one fixed
+  // frequency per plate, so twelve strikes on the ones plate are twelve
+  // identical sounds. One is not a melody and twelve of it is not either.
+  for (let seed = 0; seed < 40; seed++) {
+    const melody = new Melody(scape(seed))
+    const heard = new Set<number>()
+    for (let i = 0; i < 12; i++) {
+      for (const v of melody.emit({ kind: "step", direction: 1 })) heard.add(Math.round(v.hz * 100))
+    }
+    assert.ok(heard.size >= 5, `seed ${seed} produced only ${heard.size} distinct pitches in 12 taps`)
+  }
+})
+
+test("every note a game can cause is a degree of the live mode", () => {
+  // The in-tune guarantee, exhaustively. If one gesture ever emits a pitch that
+  // is not in the mode, it is a pitch that fights the drone, and the whole
+  // premise of the module is gone.
+  const gestures: Gesture[] = [
+    { kind: "step", direction: 1 },
+    { kind: "step", direction: -1, weight: 1 },
+    { kind: "step", direction: 1, weight: 0.5 },
+    { kind: "success" },
+    { kind: "failure" },
+    { kind: "levelComplete" },
+    { kind: "refuse" },
+    { kind: "arrive" },
+  ]
+  for (let seed = 0; seed < 60; seed++) {
+    const s = scape(seed, seed % 2 === 0 ? 0 : 0.9)
+    const melody = new Melody(s)
+    const degrees = degreeSet(s)
+    for (let round = 0; round < 6; round++) {
+      for (const g of gestures) {
+        for (const v of melody.emit(g)) {
+          assert.ok(
+            degrees.has(pitchClass(s.rootHz, v.hz)),
+            `${s.modeId} seed ${seed}: ${v.hz.toFixed(3)} Hz is not a degree of the mode`,
+          )
+        }
+      }
+    }
+  }
+})
+
+test("every voice is inside the register and the loudness budget", () => {
+  for (let seed = 0; seed < 40; seed++) {
+    const melody = new Melody(scape(seed, 0.7))
+    const voices: Voice[] = []
+    for (let i = 0; i < 30; i++) {
+      voices.push(...melody.emit({ kind: "step", direction: i % 3 === 0 ? -1 : 1, weight: (i % 4) / 3 }))
+    }
+    voices.push(...melody.emit({ kind: "levelComplete" }))
+    voices.push(...melody.emit({ kind: "failure" }))
+    voices.push(...melody.emit({ kind: "refuse" }))
+    voices.push(...melody.emit({ kind: "arrive" }))
+    voices.push(...melody.emit({ kind: "success" }))
+    for (const v of voices) {
+      assert.ok(v.hz >= MELODY_MIN_HZ && v.hz <= MELODY_MAX_HZ, `${v.hz} Hz is outside the register`)
+      assert.ok(v.gain > 0 && v.gain <= MELODY_PEAK, `gain ${v.gain} is outside the budget`)
+      assert.ok(v.at >= 0 && Number.isFinite(v.at), `offset ${v.at} is not a time`)
+      assert.ok(v.seconds > 0 && v.seconds <= 2, `duration ${v.seconds} is not a length`)
+    }
+  }
+})
+
+test("the register bands never overlap and nothing is ever folded", () => {
+  // The claim `MELODY_MIN_HZ`/`MELODY_MAX_HZ` are documented as a backstop for.
+  // A band is one octave wide, so a weight of 0 must always be strictly above a
+  // weight of 1/3, which must be above 2/3, which must be above 1 — in every
+  // mode, on every root, at every point in the walk. If a note ever needed
+  // folding the bands would start overlapping, and a heavy action would
+  // sometimes sound lighter than a light one.
+  for (let seed = 0; seed < 200; seed++) {
+    const s = scape(seed, seed % 3 === 0 ? 1 : 0)
+    const walkers = [0, 1 / 3, 2 / 3, 1].map(() => new Melody(s))
+    for (let i = 0; i < 25; i++) {
+      const heard = walkers.map((m, k) => {
+        const v = m.emit({ kind: "step", direction: i % 4 === 3 ? -1 : 1, weight: k / 3 })[0]
+        assert.ok(v)
+        return v.hz
+      })
+      for (let k = 1; k < heard.length; k++) {
+        assert.ok(
+          (heard[k] ?? 0) < (heard[k - 1] ?? 0),
+          `seed ${seed} step ${i}: weight ${k / 3} came out at ${heard[k]} Hz, not below ${heard[k - 1]}`,
+        )
+      }
+      assert.ok((heard[0] ?? 0) <= MELODY_MAX_HZ && (heard[3] ?? 0) >= MELODY_MIN_HZ)
+    }
+  }
+})
+
+test("up walks up and down walks down", () => {
+  // Direction is musical, not decorative: hanging a weight ascends the mode and
+  // taking one off descends it, which is what makes the two sound like opposite
+  // things rather than like two arbitrary noises.
+  for (let seed = 0; seed < 100; seed++) {
+    const up = new Melody(scape(seed))
+    up.emit({ kind: "step", direction: 1 })
+    assert.ok(up.position > 0, `seed ${seed}: an ascending step went to ${up.position}`)
+    const down = new Melody(scape(seed))
+    down.emit({ kind: "step", direction: -1 })
+    assert.ok(down.position < 0, `seed ${seed}: a descending step went to ${down.position}`)
+  }
+})
+
+test("a phrase comes to rest, over and over, and lands where it says it does", () => {
+  // Gravity toward the mode's resting degrees is what makes a run of taps a
+  // sentence. Without it the walk is a scale exercise that never arrives.
+  //
+  // Counted through `resolved` rather than by watching for the walker to be on
+  // a rest degree: with three resting degrees out of seven, a walk that never
+  // cadences at all still stands on one about four times in ten, so counting
+  // those would pass on a module with the cadence deleted. This does not — and
+  // it also checks that a claimed resolution really is on a resting degree,
+  // which is the part that makes the count mean anything.
+  for (let seed = 0; seed < 40; seed++) {
+    const s = scape(seed)
+    const melody = new Melody(s)
+    const mode = modeOf(s)
+    const rest = new Set(mode.rest)
+    const size = mode.degrees.length
+    let last = melody.resolved
+    for (let i = 0; i < 60; i++) {
+      melody.emit({ kind: "step", direction: i % 5 === 4 ? -1 : 1 })
+      if (melody.resolved === last) continue
+      last = melody.resolved
+      const within = ((melody.position % size) + size) % size
+      assert.ok(rest.has(within), `seed ${seed}: a cadence landed on degree ${within}, not a rest`)
+    }
+    // Phrases are 3..8 steps, so 60 taps is at least seven of them.
+    assert.ok(melody.resolved >= 7, `seed ${seed} resolved only ${melody.resolved} times in 60 taps`)
+    assert.ok(melody.resolved <= 20, `seed ${seed} resolved ${melody.resolved} times, which is not a phrase`)
+  }
+})
+
+test("weight buys register and never buys a pitch", () => {
+  // A heavy action is the same music, lower. THE STEELYARD's thousands plate
+  // stays a low clang and its ones plate stays a bright tick — the property the
+  // game already had, kept, and made musical.
+  let lower = 0
+  for (let seed = 0; seed < 100; seed++) {
+    const light = new Melody(scape(seed))
+    const heavy = new Melody(scape(seed))
+    const a = light.emit({ kind: "step", direction: 1, weight: 0 })[0]
+    const b = heavy.emit({ kind: "step", direction: 1, weight: 1 })[0]
+    assert.ok(a && b)
+    // The same walk — weight must not touch the degree.
+    assert.equal(light.position, heavy.position, `seed ${seed}: weight moved the walker`)
+    if (b.hz < a.hz) lower++
+  }
+  assert.ok(lower >= 95, `a heavy step was lower in only ${lower} of 100 soundscapes`)
+})
+
+test("tension is a dial, is silent, and is bounded", () => {
+  const melody = new Melody(scape(7, 0.5))
+  assert.deepEqual(melody.emit({ kind: "moreTension" }), [])
+  assert.ok(Math.abs(melody.soundscape.tension - (0.5 + TENSION_STEP)) < 1e-9)
+  assert.deepEqual(melody.emit({ kind: "lessTension" }), [])
+  assert.ok(Math.abs(melody.soundscape.tension - 0.5) < 1e-9)
+  for (let i = 0; i < 20; i++) melody.emit({ kind: "moreTension" })
+  assert.equal(melody.soundscape.tension, 1)
+  for (let i = 0; i < 40; i++) melody.emit({ kind: "lessTension" })
+  assert.equal(melody.soundscape.tension, 0)
+})
+
+test("tension buys leaps and calm stays stepwise", () => {
+  // What "chill" means mechanically: a calm soundscape walks by one degree
+  // almost always. If this stops being true the module has stopped being chill
+  // and nobody would notice from the types.
+  //
+  // Cadence steps are excluded, and that exclusion is the whole reason this
+  // test is worth having: a cadence jumps the walker back to a resting degree,
+  // and tension also lengthens phrases, so a naive average over every step
+  // rises with tension even if the interval distribution never changes at all.
+  // Measured that way this test passed against a module with the tension term
+  // deleted from the interval weights.
+  // The octave wrap is excluded for the same reason: a walk that runs past the
+  // top of its range comes back down by a whole octave, which is a big number
+  // that says nothing about the interval that was chosen. Both are excluded by
+  // the same rule — every ascending step that is neither is a step UP, so any
+  // step that went down is one of the two.
+  const span = (tension: number): number => {
+    let total = 0
+    let steps = 0
+    for (let seed = 0; seed < 60; seed++) {
+      const melody = new Melody(scape(seed, tension))
+      let last = melody.position
+      let cadences = melody.resolved
+      for (let i = 0; i < 20; i++) {
+        melody.emit({ kind: "step", direction: 1 })
+        if (melody.resolved === cadences && melody.position > last) {
+          total += melody.position - last
+          steps++
+        }
+        cadences = melody.resolved
+        last = melody.position
+      }
+    }
+    return total / steps
+  }
+  const calm = span(0)
+  const wound = span(1)
+  assert.ok(calm < 1.6, `calm averaged ${calm} degrees a step, which is not stepwise`)
+  assert.ok(wound > calm + 0.3, `calm averaged ${calm} and wound-up averaged ${wound}`)
+})
+
+test("finishing something is the only big gesture, and it goes home", () => {
+  const melody = new Melody(scape(3))
+  for (let i = 0; i < 5; i++) melody.emit({ kind: "step", direction: 1 })
+  const voices = melody.emit({ kind: "levelComplete" })
+  assert.ok(voices.length >= 4, `a flourish of ${voices.length} voices is not a flourish`)
+  for (let i = 1; i < voices.length; i++) {
+    assert.ok((voices[i]?.at ?? 0) > (voices[i - 1]?.at ?? 0), "the flourish is not in order")
+  }
+  assert.equal(melody.position, 0, "the walker did not go home after a level")
+})
+
+test("a refusal is low, short and modelled rather than noise", () => {
+  const melody = new Melody(scape(11))
+  const voices = melody.emit({ kind: "refuse" })
+  assert.equal(voices.length, 1)
+  const v = voices[0]
+  assert.ok(v)
+  assert.equal(v.timbre, "rubble")
+  assert.ok(v.seconds < 0.5, "a refusal that long is a telling-off")
+  assert.ok(v.hz < 300, `a refusal at ${v.hz} Hz is a beep, not a crumble`)
+})
+
+test("a failure is warm and never a buzzer", () => {
+  for (let seed = 0; seed < 30; seed++) {
+    const melody = new Melody(scape(seed))
+    for (const v of melody.emit({ kind: "failure" })) {
+      assert.equal(v.timbre, "bloom", "a failure must not be struck")
+      assert.ok(v.gain <= 0.09, `a failure at gain ${v.gain} is louder than the music`)
+    }
+  }
+})
+
+test("the drone doubles the fifth only when the mode has one", () => {
+  const root = 130.81
+  const withFifth = new Melody({ modeId: "western.dorian", rootHz: root, seed: 1, tension: 0 })
+  const drone = withFifth.drone()
+  assert.equal(drone[0], root / 2)
+  assert.equal(drone[1], root)
+  assert.equal(drone.length, 3, "Dorian has a perfect fifth and the drone should take it")
+  assert.ok(Math.abs(centsBetween(root, drone[2] ?? 0) - 700) < 3)
+
+  // Whole tone has no perfect fifth at all. A fixed root-and-fifth drone would
+  // put a pitch under it that is not in the scale, which is the specific clash
+  // this branch exists to avoid.
+  const wholeTone = modeById("western.wholeTone")
+  assert.ok(wholeTone)
+  assert.ok(!wholeTone.rest.some((i) => Math.abs((wholeTone.degrees[i] ?? 0) - 702) <= 25))
+  const bare = new Melody({ modeId: "western.wholeTone", rootHz: root, seed: 1, tension: 0 })
+  assert.equal(bare.drone().length, 2)
+})
+
+test("the same seed is the same music, forever", () => {
+  const play = (): number[] => {
+    const melody = new Melody(scape(4242))
+    const out: number[] = []
+    const script: Gesture[] = [
+      { kind: "step", direction: 1 },
+      { kind: "step", direction: 1, weight: 0.66 },
+      { kind: "step", direction: -1 },
+      { kind: "success" },
+      { kind: "step", direction: 1, weight: 1 },
+      { kind: "levelComplete" },
+    ]
+    for (const g of script) for (const v of melody.emit(g)) out.push(v.hz)
+    return out
+  }
+  assert.deepEqual(play(), play())
+})
+
+test("retuning carries the line across instead of restarting it", () => {
+  const melody = new Melody(scape(9))
+  for (let i = 0; i < 4; i++) melody.emit({ kind: "step", direction: 1 })
+  const before = melody.position
+  melody.retune(scape(10))
+  assert.equal(melody.position, before, "a key change threw the phrase away")
+  assert.equal(melody.soundscape.seed, scape(10).seed)
+})
+
+test("an unknown mode is loud and still plays", () => {
+  // The host and the pack can disagree about the corpus across a version skew.
+  // That must be visible to a developer and inaudible to a child.
+  const warnings: unknown[][] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]): void => {
+    warnings.push(args)
+  }
+  try {
+    const melody = new Melody({ modeId: "maqam.notathing", rootHz: 130.81, seed: 1, tension: 0 })
+    const voices = melody.emit({ kind: "step", direction: 1 })
+    assert.equal(voices.length, 1)
+    assert.ok((voices[0]?.hz ?? 0) > 0)
+  } finally {
+    console.warn = original
+  }
+  assert.ok(warnings.length > 0, "an unknown mode was swallowed")
+})

--- a/dynawalla/packs/shared/game-soundscape/melody.ts
+++ b/dynawalla/packs/shared/game-soundscape/melody.ts
@@ -1,0 +1,435 @@
+/**
+ * The part that makes a run of taps into a tune.
+ *
+ * **The defect this closes.** THE STEELYARD plays the same four pitches for
+ * every strike — 1180 Hz for a one, 288 Hz for a thousand — forever. A child
+ * hanging eight weights hears the same bright tick eight times. Every game in
+ * the fleet is built the same way: one cue per event, a fixed frequency written
+ * in the file. That is why the sound gets old in a minute, and turning it down
+ * or making it prettier does not fix it, because the problem is not the timbre.
+ * It is that **nothing that happens changes what the next sound is.**
+ *
+ * **The idea.** A soundscape is in a mode and on a root. A walker holds one
+ * scale degree. Each gesture the game reports moves that degree — up for a
+ * weight going on, down for one coming off — and the pitch that comes out is
+ * wherever the walker now is. So eight weights in a row are eight *different*
+ * notes that are all in the same mode, over the same drone, and they arc and
+ * come to rest like a phrase, because the walker is pulled toward the mode's
+ * resting degrees and cadences onto one when the phrase has run long enough.
+ *
+ * **Games do not pick pitches.** The whole vocabulary is in `Gesture`: a step
+ * with a direction and a weight, and five named things that happened. A game
+ * that could pass a frequency would eventually pass one that is not in the
+ * mode, and then the drone is wrong and nobody can say why. Weight is not a
+ * pitch — it is *how heavy the thing the child did was*, and this module spends
+ * it on register.
+ *
+ * **In tune by construction.** Every frequency here is `rootHz` multiplied by
+ * two to the power of some cents over twelve hundred. The drone is the same
+ * `rootHz`. There is exactly one number, so there is nothing to drift.
+ *
+ * Pure but stateful, in the way `game-pacing` is not: the walker's whole point
+ * is that where it is now depends on what has already happened. The state is
+ * held in an object the game owns, the randomness comes from a seed, and there
+ * are no timers and no Web Audio — so a test can play a hundred taps in a
+ * microsecond and assert every pitch.
+ */
+
+import { foldIntoRange, hz } from "./pitch.ts"
+import { modeOf, withTension, type Soundscape } from "./soundscape.ts"
+import { Rng } from "./rng.ts"
+
+/**
+ * How a voice should be made to sound. Named rather than parameterised: the
+ * pack owns the synthesis and this module owns the music, and a field called
+ * `filterQ` here would be this module starting to own both.
+ */
+export type Timbre =
+  /** Struck metal or glass. Short, bright-ish, the melodic default. */
+  | "bell"
+  /** Plucked. Softer onset, shorter tail. */
+  | "pluck"
+  /** Bowed or breathed in. Slow onset, long. Never a transient. */
+  | "bloom"
+  /**
+   * Something falling apart — masonry, gravel, a shelf of brass going over.
+   *
+   * The founder's word for what a refusal should sound like, and it is a
+   * *modelled* sound rather than a noise burst: many small impacts with a
+   * power-law size distribution, low-centred. See `SOUNDSCAPE_DESIGN_2026-07.md`
+   * for the recipe. It exists in this list so that no game reaches for white
+   * noise, which is the sound this replaces everywhere.
+   */
+  | "rubble"
+
+export type Voice = {
+  /** Hertz. Always a pitch of the live mode. */
+  readonly hz: number
+  /** Seconds from the moment the gesture happened. Lets one gesture be a figure. */
+  readonly at: number
+  /** How long it rings. */
+  readonly seconds: number
+  /**
+   * Peak amplitude, linear, before the game's own master trim.
+   *
+   * Inside the fleet's loudness budget already: nothing here exceeds
+   * `MELODY_PEAK`, and the bed sits far under it. See the design note.
+   */
+  readonly gain: number
+  readonly timbre: Timbre
+}
+
+/**
+ * Everything a game is allowed to say.
+ *
+ * Six things that happened and two dials. Any game in the fleet can express
+ * itself in this, and no game can express a pitch.
+ */
+export type Gesture =
+  /**
+   * The child moved something by one unit.
+   *
+   * `direction` is which way — and it matters musically, not just as a label:
+   * up walks the mode ascending, down walks it descending, which is the closest
+   * a scale gets to having a grammar.
+   *
+   * `weight` is 0..1, how heavy the unit was. THE STEELYARD's ones plate is 0
+   * and its thousands plate is 1. It buys register and a little loudness, and
+   * nothing else.
+   */
+  | { readonly kind: "step"; readonly direction: 1 | -1; readonly weight?: number }
+  /** Something the child was trying to do worked. */
+  | { readonly kind: "success" }
+  /** It did not. Soft, low, short — never a buzzer. */
+  | { readonly kind: "failure" }
+  /** A level, a scale, a run finished. The only gesture that is allowed to be big. */
+  | { readonly kind: "levelComplete" }
+  /** An input was declined — too soon, not allowed, nothing there. */
+  | { readonly kind: "refuse" }
+  /** Something appeared, arrived, or was laid out. */
+  | { readonly kind: "arrive" }
+  /** Wind the soundscape up. Silent in itself; the bed and the melody change. */
+  | { readonly kind: "moreTension" }
+  /** Let it down. */
+  | { readonly kind: "lessTension" }
+
+/** The loudest a single melodic voice may be asked for. */
+export const MELODY_PEAK = 0.14
+
+/**
+ * The register the melody is confined to, in Hz.
+ *
+ * Deliberately low. The fleet's cues today sit at 830 and 1180 Hz, which is the
+ * band the ear is most sensitive in and the band the founder means by
+ * "abrasive". Everything here lives under 1.1 kHz, and the heaviest gestures
+ * live under 130 — where a low clang has a body rather than an edge.
+ *
+ * These are a backstop rather than a working limit, and the difference matters.
+ * The bands below are one octave wide and the root band is narrow enough that
+ * the topmost band's top (root x8, at most 1244 Hz) is under this ceiling — so
+ * NOTHING is ever folded in normal play, and the four register bands never
+ * overlap. If a fold does start happening it is a bug in that arithmetic, not a
+ * note going quietly out of range, and `melody.test.ts` asserts it does not.
+ */
+export const MELODY_MIN_HZ = 55
+export const MELODY_MAX_HZ = 1250
+
+/**
+ * The octave a weightless gesture sits in, above the root, and how many octaves
+ * of register a full weight takes off it.
+ *
+ * Two and three, so a four-way rack lands on the bands root x4, x2, x1 and
+ * root/2 — four octaves that do not overlap, because each band is exactly one
+ * octave wide (see `pitch`). THE STEELYARD's "place value is a thing you can
+ * hear" property is therefore kept *exactly* rather than approximately: the
+ * ones plate is always above the tens plate, in every mode and on every root,
+ * with no ordering left to chance.
+ */
+const TOP_OCTAVE = 2
+const REGISTER_SPAN = 3
+
+/** How much one `moreTension` or `lessTension` moves the dial. */
+export const TENSION_STEP = 0.18
+
+/** A phrase is this many steps, plus up to two more, plus tension. */
+const PHRASE_MIN = 3
+const PHRASE_SPREAD = 3
+
+/** How near a perfect fifth a degree must be for the drone to double it. */
+const FIFTH_CENTS = 702
+const FIFTH_TOLERANCE = 25
+
+export class Melody {
+  private scape: Soundscape
+  private rng: Rng
+  /** Where the walker is, as a signed degree index. 0 is the tonic. */
+  private degree = 0
+  /** Steps taken since the last cadence. */
+  private sinceRest = 0
+  private phrase: number
+  /** How many phrases have come to rest. */
+  private resolutions = 0
+
+  constructor(scape: Soundscape) {
+    this.scape = scape
+    this.rng = new Rng(scape.seed)
+    this.phrase = this.nextPhraseLength()
+  }
+
+  /** The soundscape this melody is singing in. */
+  get soundscape(): Soundscape {
+    return this.scape
+  }
+
+  /** Where the walker is. For tests and for a debug read-out. */
+  get position(): number {
+    return this.degree
+  }
+
+  /**
+   * How many phrases have come to rest since this walker was made.
+   *
+   * Exposed because "it cadences" is the claim that separates a phrase from a
+   * scale exercise, and a claim that cannot be observed cannot be tested — a
+   * walk that never resolves still wanders across resting degrees by accident
+   * often enough that counting those proves nothing. A game may also want it:
+   * a resolution is a natural moment to punctuate with something visual.
+   */
+  get resolved(): number {
+    return this.resolutions
+  }
+
+  /**
+   * Move to a different soundscape.
+   *
+   * The walker keeps its degree rather than resetting: a scale degree means the
+   * same thing in the new mode, so the line carries across the change instead of
+   * restarting, which is what makes a key change sound like a modulation rather
+   * than like the music stopping and different music starting.
+   */
+  retune(scape: Soundscape): void {
+    this.scape = scape
+    this.rng = new Rng(scape.seed ^ 0x9e3779b1)
+  }
+
+  /**
+   * The drone's pitches, in Hz, lowest first.
+   *
+   * The root and the octave below it always. The fifth only when the mode
+   * actually has one within a comma or so of 702 cents — Saba does not, Locrian
+   * does not, and droning a wrong fifth under them is the exact clash a fixed
+   * "root plus fifth" drone would produce in every fifth soundscape.
+   */
+  drone(): readonly number[] {
+    const root = this.scape.rootHz
+    const out = [root / 2, root]
+    const mode = modeOf(this.scape)
+    for (const index of mode.rest) {
+      const cents = mode.degrees[index]
+      if (cents === undefined) continue
+      if (Math.abs(cents - FIFTH_CENTS) <= FIFTH_TOLERANCE) {
+        out.push(hz(root, cents))
+        break
+      }
+    }
+    return out
+  }
+
+  /**
+   * What this gesture sounds like.
+   *
+   * Empty for the two tension gestures, and that is the answer rather than an
+   * omission: winding a soundscape up is not a sound, it is a change in every
+   * sound after it.
+   */
+  emit(gesture: Gesture): readonly Voice[] {
+    switch (gesture.kind) {
+      case "step":
+        return this.step(gesture.direction, gesture.weight ?? 0)
+      case "success":
+        return this.cadence()
+      case "failure":
+        return this.sink()
+      case "levelComplete":
+        return this.flourish()
+      case "refuse":
+        return this.crumble()
+      case "arrive":
+        return this.bloom()
+      case "moreTension":
+        this.scape = withTension(this.scape, this.scape.tension + TENSION_STEP)
+        return []
+      case "lessTension":
+        this.scape = withTension(this.scape, this.scape.tension - TENSION_STEP)
+        return []
+    }
+  }
+
+  // ── the walk ──────────────────────────────────────────────────────────────
+
+  private step(direction: 1 | -1, weight: number): readonly Voice[] {
+    const w = clamp01(weight)
+    const t = this.scape.tension
+    const mode = modeOf(this.scape)
+    const size = mode.degrees.length
+
+    this.sinceRest += 1
+    if (this.sinceRest >= this.phrase) {
+      this.degree = this.resolve(direction, mode.rest, size)
+      this.resolutions += 1
+      this.sinceRest = 0
+      this.phrase = this.nextPhraseLength()
+    } else {
+      // Mostly a step, sometimes a skip, rarely a leap — and tension is what
+      // buys the leaps. A calm soundscape is nearly all stepwise, which is what
+      // "chill" sounds like; a wound-up one starts jumping.
+      const interval = 1 + this.rng.weighted([0.66 - 0.34 * t, 0.24, 0.07 + 0.16 * t, 0.03 + 0.18 * t])
+      this.degree += direction * interval
+      // Keep the line from walking off into the next county. A phrase lives
+      // within an octave either side of home; register is what the weight is
+      // for, and it is applied separately below.
+      if (this.degree > size) this.degree -= size
+      if (this.degree < -size) this.degree += size
+      // Under tension, lean on the degree that makes this mode itself.
+      if (this.rng.next() < t * 0.35) {
+        const towards = octaveOf(this.degree, size) * size + mode.colour
+        if (Math.abs(towards - this.degree) <= 1) this.degree = towards
+      }
+    }
+
+    const octave = TOP_OCTAVE - Math.round(w * REGISTER_SPAN)
+    return [
+      {
+        hz: this.pitch(this.degree, octave),
+        at: 0,
+        seconds: 0.34 + (1 - w) * 0.16,
+        gain: 0.085 + w * 0.045,
+        timbre: "bell",
+      },
+    ]
+  }
+
+  /** Where a phrase comes to rest, given which way it was travelling. */
+  private resolve(direction: 1 | -1, rest: readonly number[], size: number): number {
+    const home = octaveOf(this.degree, size)
+    // The tonic is the heaviest resting place, and the further down the list a
+    // degree is the lighter it gets — so a phrase usually ends at home and
+    // sometimes ends somewhere that leaves the door open.
+    const weights = rest.map((_, i) => (i === 0 ? 3 : 1))
+    const index = rest[this.rng.weighted(weights)] ?? 0
+    // A descending phrase resolves in the octave it came down into; an
+    // ascending one is allowed to land in the octave above, which is what makes
+    // a long climb feel like it arrived somewhere.
+    const oct = direction > 0 && index === 0 && this.degree > 0 ? home : Math.min(0, home)
+    return oct * size + index
+  }
+
+  private nextPhraseLength(): number {
+    return PHRASE_MIN + this.rng.int(PHRASE_SPREAD) + Math.round(this.scape.tension * 3)
+  }
+
+  // ── the named gestures ────────────────────────────────────────────────────
+
+  /** Two notes that arrive. The walker goes home, because something finished. */
+  private cadence(): readonly Voice[] {
+    const mode = modeOf(this.scape)
+    const middle = mode.rest[1] ?? 2
+    this.degree = 0
+    this.sinceRest = 0
+    this.phrase = this.nextPhraseLength()
+    // The second note is the tonic an octave up — reached through the REGISTER
+    // argument rather than by asking for degree `size`, because a degree is
+    // folded into its band and would come back as the same note.
+    return [
+      { hz: this.pitch(middle, TOP_OCTAVE - 1), at: 0, seconds: 0.42, gain: 0.1, timbre: "bell" },
+      { hz: this.pitch(0, TOP_OCTAVE), at: 0.1, seconds: 0.72, gain: 0.12, timbre: "bell" },
+    ]
+  }
+
+  /** Down a step and settled. Low, warm, short. Nothing here is a buzzer. */
+  private sink(): readonly Voice[] {
+    const mode = modeOf(this.scape)
+    this.degree = 0
+    this.sinceRest = 0
+    return [
+      { hz: this.pitch(1, 1), at: 0, seconds: 0.4, gain: 0.075, timbre: "bloom" },
+      { hz: this.pitch(0, 1), at: 0.11, seconds: 0.62, gain: 0.085, timbre: "bloom" },
+      { hz: this.pitch(mode.rest[1] ?? 2, 0), at: 0.11, seconds: 0.62, gain: 0.05, timbre: "bloom" },
+    ]
+  }
+
+  /** The one gesture allowed to be big: the mode's own chord, climbing. */
+  private flourish(): readonly Voice[] {
+    const mode = modeOf(this.scape)
+    const middle = mode.rest[1] ?? 2
+    // The mode's own chord, climbing through two registers and landing on the
+    // tonic at the top.
+    const rungs: readonly [number, number][] = [
+      ...mode.rest.map((d) => [d, TOP_OCTAVE - 1] as [number, number]),
+      [0, TOP_OCTAVE],
+      [middle, TOP_OCTAVE],
+    ]
+    this.degree = 0
+    this.sinceRest = 0
+    this.phrase = this.nextPhraseLength()
+    return rungs.map(([degree, octave], i) => ({
+      hz: this.pitch(degree, octave),
+      at: i * 0.115,
+      seconds: 0.5 + i * 0.14,
+      gain: 0.075 + i * 0.012,
+      timbre: "bell" as const,
+    }))
+  }
+
+  /** A shelf of brass going over. Low, brief, and not a note anyone chose. */
+  private crumble(): readonly Voice[] {
+    return [{ hz: this.pitch(0, 0), at: 0, seconds: 0.34, gain: 0.09, timbre: "rubble" }]
+  }
+
+  /** Something was laid out. The tonic, breathed in rather than struck. */
+  private bloom(): readonly Voice[] {
+    const mode = modeOf(this.scape)
+    return [
+      { hz: this.pitch(0, 1), at: 0, seconds: 0.9, gain: 0.055, timbre: "bloom" },
+      { hz: this.pitch(mode.rest[1] ?? 2, 1), at: 0.04, seconds: 0.8, gain: 0.04, timbre: "bloom" },
+    ]
+  }
+
+  // ── degrees to hertz ──────────────────────────────────────────────────────
+
+  /**
+   * A signed degree in a register, as a frequency inside the melodic range.
+   *
+   * The one place cents become hertz, so the claim "everything is in tune with
+   * the drone" is a claim about four lines rather than about the whole file.
+   *
+   * **The degree is folded into its band, and the octave it walked through is
+   * dropped.** A band is one octave wide and the bands are what carry the
+   * game's own meaning — how heavy the thing the child did was — so a walker
+   * that had wandered up a degree too far must not be allowed to spill into the
+   * band above and sound like a heavier action than it was. What is lost is
+   * nothing: the walk's contour is still there, it simply wraps at the octave,
+   * which is what a harp does when a run reaches the end of the strings.
+   */
+  private pitch(degree: number, octave: number): number {
+    const mode = modeOf(this.scape)
+    const size = mode.degrees.length
+    const within = mode.degrees[degree - octaveOf(degree, size) * size] ?? 0
+    return foldIntoRange(
+      hz(this.scape.rootHz, within + octave * 1200),
+      MELODY_MIN_HZ,
+      MELODY_MAX_HZ,
+    )
+  }
+}
+
+/** Which octave a signed degree index falls in. Floors toward negative infinity. */
+function octaveOf(degree: number, size: number): number {
+  if (size <= 0) return 0
+  return Math.floor(degree / size)
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0
+  return Math.min(1, Math.max(0, v))
+}

--- a/dynawalla/packs/shared/game-soundscape/modes.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/modes.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { MODES, MODE_IDS, modeById } from "./modes.ts"
+import { CENTS_PER_OCTAVE } from "./pitch.ts"
+
+test("every mode starts on its tonic and stays inside one octave", () => {
+  for (const mode of MODES) {
+    assert.equal(mode.degrees[0], 0, `${mode.id} does not start at 0 cents`)
+    for (const cents of mode.degrees) {
+      assert.ok(
+        cents >= 0 && cents < CENTS_PER_OCTAVE,
+        `${mode.id} has a degree at ${cents}, outside [0, 1200)`,
+      )
+    }
+  }
+})
+
+test("every mode is strictly ascending", () => {
+  for (const mode of MODES) {
+    for (let i = 1; i < mode.degrees.length; i++) {
+      const prev = mode.degrees[i - 1] ?? 0
+      const here = mode.degrees[i] ?? 0
+      assert.ok(here > prev, `${mode.id} degree ${i} (${here}) does not rise above ${prev}`)
+    }
+  }
+})
+
+test("every mode can be rested on and coloured, and the indices exist", () => {
+  for (const mode of MODES) {
+    assert.ok(mode.rest.length >= 2, `${mode.id} has fewer than two resting degrees`)
+    assert.equal(mode.rest[0], 0, `${mode.id} cannot rest on its own tonic`)
+    for (const index of mode.rest) {
+      assert.ok(
+        index >= 0 && index < mode.degrees.length,
+        `${mode.id} rests on degree ${index}, which it does not have`,
+      )
+    }
+    assert.ok(
+      mode.colour >= 0 && mode.colour < mode.degrees.length,
+      `${mode.id} is coloured by degree ${mode.colour}, which it does not have`,
+    )
+  }
+})
+
+test("ids are unique and looked up", () => {
+  assert.equal(new Set(MODE_IDS).size, MODE_IDS.length)
+  for (const id of MODE_IDS) assert.equal(modeById(id)?.id, id)
+  assert.equal(modeById("western.nope"), null)
+})
+
+test("the corpus is broad enough not to repeat itself in a month", () => {
+  // 38 modes x 8 roots is 304 distinct soundscapes, which is what "we need a
+  // lot of variety" costs. If this ever shrinks it is because somebody deleted
+  // data, and that should be a decision rather than an accident.
+  assert.ok(MODES.length >= 38, `only ${MODES.length} modes`)
+  const families = new Set(MODES.map((m) => m.family))
+  assert.deepEqual([...families].sort(), ["maqam", "thaat", "western"])
+})
+
+test("the maqamat keep their neutral degrees", () => {
+  // The whole reason the corpus is in cents. Rast's third is a three-quarter
+  // tone; rounded to a semitone it is Ionian and the maqam is gone.
+  const rast = modeById("maqam.rast")
+  assert.ok(rast)
+  assert.equal(rast.degrees[2], 350)
+  const bayati = modeById("maqam.bayati")
+  assert.ok(bayati)
+  assert.equal(bayati.degrees[1], 150)
+  // And at least one degree in the family is genuinely off the semitone grid.
+  const offGrid = MODES.filter((m) => m.family === "maqam").flatMap((m) =>
+    m.degrees.filter((c) => c % 100 !== 0),
+  )
+  assert.ok(offGrid.length > 0, "no maqam degree is off the 12-TET grid")
+})
+
+test("the western modes are on the semitone grid", () => {
+  for (const mode of MODES.filter((m) => m.family === "western")) {
+    for (const cents of mode.degrees) {
+      assert.equal(cents % 100, 0, `${mode.id} has a non-semitone degree ${cents}`)
+    }
+  }
+})

--- a/dynawalla/packs/shared/game-soundscape/modes.ts
+++ b/dynawalla/packs/shared/game-soundscape/modes.ts
@@ -1,0 +1,169 @@
+/**
+ * The pitch collections a soundscape can be in.
+ *
+ * Ported — not imported — from Corpán's beatlounge pack, whose corpus
+ * (`corpan/packs/beatlounge/src/music/modes/`) holds 130 modes across six
+ * families with every degree given as exact cents-above-tonic. Ported because a
+ * Dynawalla pack must not have an edge into a Corpán pack: `packs/shared/` is
+ * vendored into each pack at build time through the `@shared` alias, and a
+ * cross-product import would put beatlounge's build graph inside a maths game's
+ * bundle. The representation is deliberately identical, so widening this table
+ * from that one is a copy rather than a translation.
+ *
+ * **What is here, and what is deliberately not yet.** Thirty-eight modes: the
+ * Western modes worth being chill in, the ten Hindustani thaats (the parent
+ * scales the ragas are drawn from), and twelve Arabic maqamat with their
+ * neutral degrees intact. Not here: the 72 Carnatic melakartas, the Persian
+ * dastgāh and the Turkish makamlar, which exist in beatlounge and are a data
+ * change away. Thirty-eight already means a child who plays for an hour a day
+ * for a month does not hear the same scale twice in the same key, which was the
+ * point.
+ *
+ * **The maqam degrees are not on a 24-TET grid by accident.** Rast's third at
+ * 350 cents and Saba's narrowed fourth are what make those maqamat themselves;
+ * rounding them to the nearest semitone turns Rast into Ionian and Bayati into
+ * Phrygian, which is the specific failure this representation exists to avoid.
+ *
+ * Every entry also carries two things beatlounge's schema does not, because a
+ * *game* needs them and a DAW does not:
+ *
+ *   `rest`    the degrees a phrase may end on. This is what makes a run of
+ *             taps a sentence rather than a list: the walker is pulled toward
+ *             these and cadences onto one. Without it, eight ascending steps
+ *             end wherever the eighth happened to land, which is the sound of
+ *             a scale being practised rather than a tune.
+ *   `colour`  the one degree whose presence is what makes the mode sound like
+ *             itself — Lydian's sharp fourth, Phrygian's flat second, Hijaz's
+ *             augmented second. Tension spends its budget here: a tense
+ *             soundscape leans on the colour degree, a calm one avoids it.
+ *             Both are still the same mode, which is why tension can rise
+ *             without anything going out of tune.
+ */
+
+export type ModeFamily = "western" | "thaat" | "maqam"
+
+export type Mode = {
+  /** Stable, and the same id beatlounge uses where the mode exists in both. */
+  readonly id: string
+  readonly name: string
+  readonly family: ModeFamily
+  /**
+   * Ascending degrees within one octave, exact cents above the tonic.
+   * `degrees[0]` is 0 and the octave is implied, so a seven-note mode has
+   * seven entries.
+   */
+  readonly degrees: readonly number[]
+  /** Indices into `degrees` a phrase may come to rest on. Always contains 0. */
+  readonly rest: readonly number[]
+  /** The index that makes this mode sound like itself. */
+  readonly colour: number
+}
+
+type Spec = {
+  readonly id: string
+  readonly name: string
+  /** Semitone offsets, for the 12-TET families. Multiplied by 100. */
+  readonly semis?: readonly number[]
+  /** Exact cents, for anything that is not on the semitone grid. */
+  readonly cents?: readonly number[]
+  readonly rest: readonly number[]
+  readonly colour: number
+}
+
+const WESTERN: readonly Spec[] = [
+  { id: "western.ionian", name: "Ionian", semis: [0, 2, 4, 5, 7, 9, 11], rest: [0, 2, 4], colour: 6 },
+  { id: "western.dorian", name: "Dorian", semis: [0, 2, 3, 5, 7, 9, 10], rest: [0, 2, 4], colour: 5 },
+  { id: "western.phrygian", name: "Phrygian", semis: [0, 1, 3, 5, 7, 8, 10], rest: [0, 2, 4], colour: 1 },
+  { id: "western.lydian", name: "Lydian", semis: [0, 2, 4, 6, 7, 9, 11], rest: [0, 2, 4], colour: 3 },
+  { id: "western.mixolydian", name: "Mixolydian", semis: [0, 2, 4, 5, 7, 9, 10], rest: [0, 2, 4], colour: 6 },
+  { id: "western.aeolian", name: "Aeolian", semis: [0, 2, 3, 5, 7, 8, 10], rest: [0, 2, 4], colour: 5 },
+  { id: "western.harmonicMinor", name: "Harmonic Minor", semis: [0, 2, 3, 5, 7, 8, 11], rest: [0, 2, 4], colour: 6 },
+  { id: "western.melodicMinor", name: "Melodic Minor", semis: [0, 2, 3, 5, 7, 9, 11], rest: [0, 2, 4], colour: 6 },
+  { id: "western.phrygianDominant", name: "Phrygian Dominant", semis: [0, 1, 4, 5, 7, 8, 10], rest: [0, 2, 4], colour: 1 },
+  { id: "western.lydianDominant", name: "Lydian Dominant", semis: [0, 2, 4, 6, 7, 9, 10], rest: [0, 2, 4], colour: 3 },
+  { id: "western.majorPentatonic", name: "Major Pentatonic", semis: [0, 2, 4, 7, 9], rest: [0, 2, 3], colour: 4 },
+  { id: "western.minorPentatonic", name: "Minor Pentatonic", semis: [0, 3, 5, 7, 10], rest: [0, 1, 3], colour: 4 },
+  { id: "western.egyptianPentatonic", name: "Egyptian Pentatonic", semis: [0, 2, 5, 7, 10], rest: [0, 2, 3], colour: 4 },
+  { id: "western.hirajoshi", name: "Hirajoshi", semis: [0, 2, 3, 7, 8], rest: [0, 2, 3], colour: 4 },
+  { id: "western.blues", name: "Blues", semis: [0, 3, 5, 6, 7, 10], rest: [0, 1, 4], colour: 3 },
+  { id: "western.wholeTone", name: "Whole Tone", semis: [0, 2, 4, 6, 8, 10], rest: [0, 2, 4], colour: 3 },
+]
+
+/**
+ * The ten Hindustani thaats — the parent scales the ragas are classified under.
+ *
+ * A thaat is not a raga: a raga adds an ascent, a descent, a resting note and a
+ * set of phrases on top of one. What this module's walker supplies is precisely
+ * an ascent, a descent and a resting note, so a thaat plus a walk is much
+ * closer to a raga than a thaat alone — which is the honest claim, and it is
+ * why the ids say `thaat`.
+ */
+const THAATS: readonly Spec[] = [
+  { id: "thaat.bilawal", name: "Bilawal", semis: [0, 2, 4, 5, 7, 9, 11], rest: [0, 2, 4], colour: 6 },
+  { id: "thaat.khamaj", name: "Khamaj", semis: [0, 2, 4, 5, 7, 9, 10], rest: [0, 2, 4], colour: 6 },
+  { id: "thaat.kafi", name: "Kafi", semis: [0, 2, 3, 5, 7, 9, 10], rest: [0, 2, 4], colour: 5 },
+  { id: "thaat.asavari", name: "Asavari", semis: [0, 2, 3, 5, 7, 8, 10], rest: [0, 2, 4], colour: 5 },
+  { id: "thaat.bhairav", name: "Bhairav", semis: [0, 1, 4, 5, 7, 8, 11], rest: [0, 2, 4], colour: 1 },
+  { id: "thaat.bhairavi", name: "Bhairavi", semis: [0, 1, 3, 5, 7, 8, 10], rest: [0, 2, 4], colour: 1 },
+  { id: "thaat.todi", name: "Todi", semis: [0, 1, 3, 6, 7, 8, 11], rest: [0, 2, 4], colour: 3 },
+  { id: "thaat.purvi", name: "Purvi", semis: [0, 1, 4, 6, 7, 8, 11], rest: [0, 2, 4], colour: 3 },
+  { id: "thaat.marwa", name: "Marwa", semis: [0, 1, 4, 6, 7, 9, 11], rest: [0, 2, 4], colour: 3 },
+  { id: "thaat.kalyan", name: "Kalyan", semis: [0, 2, 4, 6, 7, 9, 11], rest: [0, 2, 4], colour: 3 },
+]
+
+/**
+ * The maqamat, at beatlounge's default (Cairo-Congress grid) intonation.
+ *
+ * The neutral degrees — 150, 350, 450, 550, 850, 1050 — are the whole point.
+ * They are not typos and they must not be rounded.
+ */
+const MAQAMAT: readonly Spec[] = [
+  { id: "maqam.rast", name: "Rast", cents: [0, 204, 350, 498, 702, 906, 1050], rest: [0, 2, 4], colour: 2 },
+  { id: "maqam.bayati", name: "Bayati", cents: [0, 150, 294, 498, 702, 792, 996], rest: [0, 2, 4], colour: 1 },
+  { id: "maqam.hijaz", name: "Hijaz", cents: [0, 128, 386, 498, 702, 792, 996], rest: [0, 2, 4], colour: 1 },
+  { id: "maqam.hijazkar", name: "Hijazkar", cents: [0, 128, 386, 498, 702, 830, 1088], rest: [0, 2, 4], colour: 1 },
+  { id: "maqam.saba", name: "Saba", cents: [0, 150, 300, 400, 700, 800, 1000], rest: [0, 2, 4], colour: 3 },
+  { id: "maqam.sikah", name: "Sikah", cents: [0, 150, 350, 550, 700, 850, 1050], rest: [0, 2, 4], colour: 3 },
+  { id: "maqam.huzam", name: "Huzam", cents: [0, 150, 350, 450, 750, 850, 1050], rest: [0, 2, 4], colour: 3 },
+  { id: "maqam.nahawand", name: "Nahawand", cents: [0, 204, 294, 498, 702, 792, 1088], rest: [0, 2, 4], colour: 6 },
+  { id: "maqam.kurd", name: "Kurd", cents: [0, 90, 294, 498, 702, 792, 996], rest: [0, 2, 4], colour: 1 },
+  { id: "maqam.ajam", name: "Ajam", cents: [0, 204, 408, 498, 702, 906, 1110], rest: [0, 2, 4], colour: 6 },
+  { id: "maqam.nikriz", name: "Nikriz", cents: [0, 204, 294, 594, 702, 906, 996], rest: [0, 2, 4], colour: 3 },
+  { id: "maqam.suznak", name: "Suznak", cents: [0, 204, 350, 498, 702, 830, 1088], rest: [0, 2, 4], colour: 5 },
+]
+
+function build(spec: Spec, family: ModeFamily): Mode {
+  const degrees = spec.cents ?? (spec.semis ?? []).map((s) => s * 100)
+  return {
+    id: spec.id,
+    name: spec.name,
+    family,
+    degrees,
+    rest: spec.rest,
+    colour: spec.colour,
+  }
+}
+
+/** Every mode this module knows, in a stable order. */
+export const MODES: readonly Mode[] = [
+  ...WESTERN.map((s) => build(s, "western")),
+  ...THAATS.map((s) => build(s, "thaat")),
+  ...MAQAMAT.map((s) => build(s, "maqam")),
+]
+
+const BY_ID = new Map<string, Mode>(MODES.map((m) => [m.id, m]))
+
+export const MODE_IDS: readonly string[] = MODES.map((m) => m.id)
+
+/**
+ * A mode by id, or `null`.
+ *
+ * `null` rather than a throw, and rather than a silent fallback to Ionian: the
+ * id can arrive from the host over a `MessagePort`, so an unknown one is an
+ * ordinary runtime event and not a bug in the caller. The caller decides — and
+ * `soundscape.ts` decides to keep whatever it already had, which is the only
+ * choice that cannot make a game go silent.
+ */
+export function modeById(id: string): Mode | null {
+  return BY_ID.get(id) ?? null
+}

--- a/dynawalla/packs/shared/game-soundscape/package-lock.json
+++ b/dynawalla/packs/shared/game-soundscape/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/game-soundscape",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-soundscape",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/packs/shared/game-soundscape/package.json
+++ b/dynawalla/packs/shared/game-soundscape/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dynawalla/game-soundscape",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "A generative soundscape the whole fleet can play in: 38 modes as exact cents, a mode-and-root the host publishes, and a walker that turns a game's +1 and -1 into a phrase instead of the same ding twice. No Web Audio anywhere in it, so every note is assertable in Node.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"*.test.ts\"",
+    "tsc": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/packs/shared/game-soundscape/pitch.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/pitch.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { CENTS_PER_OCTAVE, centsBetween, centsToRatio, foldIntoRange, hz } from "./pitch.ts"
+
+test("an octave is a doubling and a fifth is 702 cents", () => {
+  assert.ok(Math.abs(centsToRatio(CENTS_PER_OCTAVE) - 2) < 1e-12)
+  assert.ok(Math.abs(centsToRatio(0) - 1) < 1e-12)
+  // 3/2 is 701.955 cents. A tempered fifth at 702 is within a twentieth of a
+  // cent of it, which nobody can hear and every drone in this module relies on.
+  assert.ok(Math.abs(centsToRatio(702) - 1.5) < 0.0006)
+})
+
+test("cents and hertz round-trip", () => {
+  const root = 130.81
+  for (const cents of [0, 150, 350, 498, 702, 1200, -1200]) {
+    const f = hz(root, cents)
+    assert.ok(Math.abs(centsBetween(root, f) - cents) < 1e-9, `${cents} did not round-trip`)
+  }
+})
+
+test("a bad root or a bad interval never produces NaN", () => {
+  // A NaN frequency is an oscillator that throws on start, which is a game with
+  // no sound and no explanation. Every entry point has to be total.
+  assert.equal(hz(Number.NaN, 700), 0)
+  assert.equal(hz(0, 700), 0)
+  assert.equal(hz(-10, 700), 0)
+  assert.equal(hz(130, Number.NaN), 130)
+  assert.equal(centsBetween(0, 100), 0)
+  assert.equal(centsBetween(100, Number.NaN), 0)
+})
+
+test("folding keeps the pitch class and lands inside the range", () => {
+  const lo = 130
+  const hi = 1100
+  // Deliberately NOT powers of two times the bounds: clamping 65 to 130 is also
+  // exactly one octave, so a test built on those values passes against a fold
+  // that is really a clamp — which is the bug that would flatten the top of
+  // every melody into a held note.
+  for (const value of [70, 45, 2100, 3300, 819]) {
+    const out = foldIntoRange(value, lo, hi)
+    assert.ok(out >= lo && out <= hi, `${value} folded to ${out}, outside [${lo}, ${hi}]`)
+    // Same pitch class: the ratio to the original is a whole number of octaves.
+    const octaves = Math.log2(out / value)
+    assert.ok(Math.abs(octaves - Math.round(octaves)) < 1e-9, `${value} -> ${out} is not an octave`)
+  }
+})
+
+test("folding a value already in range leaves it alone", () => {
+  assert.equal(foldIntoRange(440, 130, 1100), 440)
+})
+
+test("folding a range narrower than an octave clamps instead of looping", () => {
+  // A range under 2:1 has pitches with no octave inside it at all. Looping
+  // would never terminate; clamping is the honest degradation.
+  assert.equal(foldIntoRange(2000, 400, 500), 500)
+  assert.equal(foldIntoRange(100, 400, 500), 400)
+  assert.equal(foldIntoRange(Number.NaN, 130, 1100), 130)
+})

--- a/dynawalla/packs/shared/game-soundscape/pitch.ts
+++ b/dynawalla/packs/shared/game-soundscape/pitch.ts
@@ -1,0 +1,72 @@
+/**
+ * Cents, and the two conversions everything else in this module is built from.
+ *
+ * **Why cents and not semitones.** A semitone table can express the Western
+ * modes and nothing else. Maqam Rast's third is a neutral interval near 350
+ * cents — three-quarters of a tone — and Saba's fourth is narrowed to about 590.
+ * There is no integer number of semitones that says either of those, so a
+ * semitone representation does not merely lose precision, it loses the maqamat
+ * entirely and quietly replaces them with the nearest Western mode. Corpán's
+ * beatlounge pack reached the same conclusion and its whole corpus
+ * (`corpan/packs/beatlounge/src/music/modes/types.ts`) is cents-above-tonic;
+ * this is the same currency, so a mode can be lifted from there without
+ * translation.
+ *
+ * The consequence that matters for a game: **every pitch in this module is
+ * derived from the root by an exponential of cents.** A drone at the root and a
+ * melody note at 702 cents are the same number multiplied by 2^(702/1200). They
+ * cannot drift out of tune with each other, because there is only one number.
+ *
+ * No Web Audio here, and none anywhere in this module. Everything is a pure
+ * function over numbers, which is what lets an entire melody be asserted in Node
+ * with no device, no browser and no `AudioContext` — the same discipline
+ * `game-audio/ceiling.ts` and `game-pacing` already hold.
+ */
+
+/** One octave. The only magic number in the file. */
+export const CENTS_PER_OCTAVE = 1200
+
+/** Cents as a frequency multiplier. */
+export function centsToRatio(cents: number): number {
+  return Math.pow(2, cents / CENTS_PER_OCTAVE)
+}
+
+/**
+ * A pitch, `cents` above `rootHz`.
+ *
+ * Negative cents go below the root, which is how the low register is reached —
+ * a heavy gesture is the same degree an octave or two down, not a different
+ * table.
+ */
+export function hz(rootHz: number, cents: number): number {
+  if (!Number.isFinite(rootHz) || rootHz <= 0) return 0
+  if (!Number.isFinite(cents)) return rootHz
+  return rootHz * centsToRatio(cents)
+}
+
+/** The interval between two frequencies, in cents. For tests and for reporting. */
+export function centsBetween(a: number, b: number): number {
+  if (!Number.isFinite(a) || !Number.isFinite(b) || a <= 0 || b <= 0) return 0
+  return CENTS_PER_OCTAVE * Math.log2(b / a)
+}
+
+/**
+ * Fold a frequency into `[lo, hi]` by whole octaves.
+ *
+ * Clamping would be the obvious thing and it is the wrong thing: a melody that
+ * hits its ceiling and stays there has stopped being a melody and become a
+ * held note. Folding by an octave keeps the pitch *class* — so it is still the
+ * scale degree the walker chose, still in tune with the drone — and simply
+ * plays it in a register that exists. A harp does the same thing when a run
+ * reaches the end of the strings.
+ *
+ * Returns `lo` for a range that is not a range, rather than looping forever.
+ */
+export function foldIntoRange(value: number, lo: number, hi: number): number {
+  if (!Number.isFinite(value) || value <= 0) return lo
+  if (!(lo > 0) || !(hi > lo) || hi / lo < 2) return Math.min(hi, Math.max(lo, value))
+  let out = value
+  while (out > hi) out /= 2
+  while (out < lo) out *= 2
+  return out
+}

--- a/dynawalla/packs/shared/game-soundscape/rng.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/rng.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "./rng.ts"
+
+test("the same seed is the same stream", () => {
+  const a = new Rng(12345)
+  const b = new Rng(12345)
+  for (let i = 0; i < 50; i++) assert.equal(a.next(), b.next())
+})
+
+test("different seeds diverge", () => {
+  const a = new Rng(1)
+  const b = new Rng(2)
+  let same = 0
+  for (let i = 0; i < 50; i++) if (a.next() === b.next()) same++
+  assert.equal(same, 0)
+})
+
+test("values stay in [0, 1), on a 2^32 grid", () => {
+  const rng = new Rng(7)
+  for (let i = 0; i < 5000; i++) {
+    const v = rng.next()
+    assert.ok(v >= 0 && v < 1, `produced ${v}`)
+    // The divisor is 2^32 and not 2^32 - 1, which is the difference between a
+    // half-open range and one that can return exactly 1.0 about once every four
+    // billion draws. That is untestable by sampling and trivially checkable
+    // structurally: every value has to land on the 2^-32 grid.
+    assert.equal((v * 4294967296) % 1, 0, `${v} is not on the 2^-32 grid`)
+  }
+})
+
+test("a negative or fractional seed is still a stream", () => {
+  // A soundscape's seed arrives over the wire. It is validated, but "validated"
+  // means finite, not "a non-negative integer" — and an engine that coerced a
+  // negative seed differently would give two devices different music from the
+  // same soundscape, which is a bug nobody would ever reproduce.
+  for (const seed of [-1, -(2 ** 31), 3.7, 0]) {
+    const rng = new Rng(seed)
+    const v = rng.next()
+    assert.ok(Number.isFinite(v) && v >= 0 && v < 1, `seed ${seed} produced ${v}`)
+    assert.equal(new Rng(seed).next(), v)
+  }
+})
+
+test("an index is inside the array it is for", () => {
+  const rng = new Rng(9)
+  for (let i = 0; i < 2000; i++) {
+    const n = rng.int(38)
+    assert.ok(Number.isInteger(n) && n >= 0 && n < 38, `produced ${n}`)
+  }
+  // The degenerate cases, which reach this from `MODES[rng.int(MODES.length)]`
+  // if the corpus ever ends up empty. Anything but 0 is an out-of-bounds read.
+  assert.equal(rng.int(0), 0)
+  assert.equal(rng.int(-5), 0)
+  assert.equal(rng.int(Number.NaN), 0)
+  assert.equal(rng.int(1), 0)
+})
+
+test("a weighted pick follows the weights", () => {
+  const rng = new Rng(3)
+  const counts = [0, 0, 0]
+  for (let i = 0; i < 30000; i++) counts[rng.weighted([0.7, 0.2, 0.1])]!++
+  assert.ok(Math.abs((counts[0] ?? 0) / 30000 - 0.7) < 0.02, `got ${counts[0]}`)
+  assert.ok(Math.abs((counts[1] ?? 0) / 30000 - 0.2) < 0.02, `got ${counts[1]}`)
+  assert.ok(Math.abs((counts[2] ?? 0) / 30000 - 0.1) < 0.02, `got ${counts[2]}`)
+})
+
+test("a zero weight is never picked", () => {
+  // The interval weights go to zero at the ends of the tension range, and a
+  // "calm" soundscape that still threw in the occasional fourth would be the
+  // dial not working.
+  const rng = new Rng(4)
+  for (let i = 0; i < 5000; i++) assert.notEqual(rng.weighted([1, 0, 1]), 1)
+})
+
+test("weights that are all zero, or negative, do not read past the end", () => {
+  const rng = new Rng(5)
+  assert.equal(rng.weighted([]), 0)
+  assert.equal(rng.weighted([0, 0, 0]), 0)
+  // A negative weight is a bug upstream; treating it as ZERO — rather than
+  // letting it shrink the total — is the only reading that cannot return an
+  // index outside the array. Summed naively these weights total -8, the
+  // "no total" branch fires, and every draw collapses onto index 0.
+  const picked = new Set<number>()
+  for (let i = 0; i < 500; i++) picked.add(rng.weighted([-10, 1, 1]))
+  assert.deepEqual([...picked].sort(), [1, 2], "a negative weight was allowed to shrink the total")
+})

--- a/dynawalla/packs/shared/game-soundscape/rng.ts
+++ b/dynawalla/packs/shared/game-soundscape/rng.ts
@@ -1,0 +1,56 @@
+/**
+ * A seeded generator, so that "random" is a thing a test can assert.
+ *
+ * mulberry32 — the same one beatlounge's `chords/random.ts` and this repo's
+ * game RNGs use. Thirty-two bits of state, no dependencies, and identical
+ * output on every engine, which is what makes a melody reproducible: the whole
+ * point of this module is that the notes are not written down anywhere, so the
+ * only way to test them is to be able to replay them.
+ *
+ * Deliberately NOT `Math.random()`. A soundscape that cannot be replayed cannot
+ * be reported: "the steelyard sounded wrong on the fourth weight" would be
+ * unreproducible, which is how audio bugs become opinions.
+ */
+export class Rng {
+  private state: number
+
+  constructor(seed: number) {
+    // `>>> 0` because the algorithm is defined over unsigned 32-bit state, so
+    // the invariant holds from construction rather than from the first draw.
+    // It is also the whole of the input validation, and it is enough: `>>>`
+    // truncates a fraction, wraps a negative and turns a non-finite into 0, so
+    // every number is a seed and no seed can produce a different stream on a
+    // different engine. A seed arrives over the wire, so that has to be true of
+    // all of them. (`next` applies the same coercion to the sum, which is why
+    // dropping this line changes no output — it is an invariant, not a fix.)
+    this.state = seed >>> 0
+  }
+
+  /** The next value in [0, 1). */
+  next(): number {
+    this.state = (this.state + 0x6d2b79f5) >>> 0
+    let t = this.state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** An integer in [0, n). Returns 0 for a non-positive or absurd `n`. */
+  int(n: number): number {
+    if (!Number.isFinite(n) || n <= 0) return 0
+    return Math.min(Math.floor(n) - 1, Math.floor(this.next() * Math.floor(n)))
+  }
+
+  /** An index into `weights`, chosen in proportion to them. */
+  weighted(weights: readonly number[]): number {
+    let total = 0
+    for (const w of weights) total += Math.max(0, w)
+    if (!(total > 0)) return 0
+    let roll = this.next() * total
+    for (let i = 0; i < weights.length; i++) {
+      roll -= Math.max(0, weights[i] ?? 0)
+      if (roll < 0) return i
+    }
+    return weights.length - 1
+  }
+}

--- a/dynawalla/packs/shared/game-soundscape/soundscape.ts
+++ b/dynawalla/packs/shared/game-soundscape/soundscape.ts
@@ -1,0 +1,145 @@
+/**
+ * What "the soundscape right now" is: four numbers, and where they come from.
+ *
+ * A soundscape is a mode, a root, a seed and a tension. That is the whole of
+ * it, and its smallness is the design — it is small enough to sit on the
+ * host↔pack wire beside `locale` and `reducedMotion`, which is what lets the
+ * bazaar be in one key at a time across every pack a child walks between.
+ *
+ * **Why the root is in Hz and not a note name.** A note name has to be resolved
+ * against a reference pitch and a spelling convention before it is a frequency,
+ * and both of those are decisions no pack should be making. A number in Hz is
+ * already the thing the oscillator wants. It also lets the root be *slightly*
+ * off a piano key on purpose, which is how a drone stops sounding like a
+ * synthesiser preset.
+ *
+ * **Why tension is a scalar and not a name.** The game says `moreTension`; the
+ * soundscape decides what that costs. Naming the states ("calm", "urgent")
+ * would put a vocabulary of moods in every game, and the next game would want a
+ * mood the vocabulary does not have. One number in 0..1, moved by named
+ * gestures, read by the melody walker and the bed.
+ */
+
+import { MODES, modeById, type Mode } from "./modes.ts"
+import { Rng } from "./rng.ts"
+
+export type Soundscape = {
+  readonly modeId: string
+  /**
+   * The tonic, in Hz, and the pitch the drone sits on.
+   *
+   * Low on purpose: `ROOT_MIN_HZ`..`ROOT_MAX_HZ` is Bb2 to Eb3. The melody
+   * lives between half this and eight times it, so the very top of everything
+   * the system can produce is 1244 Hz and the ordinary note is far below that —
+   * rather than through the 2–5 kHz band the ear is most sensitive in, which is
+   * the band the founder is describing when he says the fleet's effects are
+   * abrasive.
+   */
+  readonly rootHz: number
+  /** Drives every stochastic choice made from this soundscape. */
+  readonly seed: number
+  /** 0 = as calm as this mode gets. 1 = as wound-up as it gets. */
+  readonly tension: number
+}
+
+/**
+ * The lowest and highest tonic a soundscape may sit on. Bb2 and Eb3.
+ *
+ * A narrow band, and narrow on purpose. The melody's brightest register is the
+ * root times four to times eight (see `melody.ts`), so the top of the root band
+ * multiplied by eight is the highest note the whole system can produce — 1244
+ * Hz here. Widening the roots by a fourth would put that at 1600, which is
+ * inside the band the ear is most sensitive in and the band the founder is
+ * calling abrasive. The ceiling on the music is set by choosing the roots, and
+ * it is set here rather than by clamping later.
+ */
+export const ROOT_MIN_HZ = 116.5
+export const ROOT_MAX_HZ = 156
+
+/**
+ * The roots to choose between.
+ *
+ * Twelve-tone-equal-tempered pitches, and then deliberately detuned by up to
+ * six cents when one is chosen (see `pickSoundscape`). Six cents is under the
+ * threshold at which a listener hears "out of tune" and well over the threshold
+ * at which two sessions sound like the same session.
+ */
+const ROOTS: readonly number[] = [116.54, 123.47, 130.81, 138.59, 146.83, 155.56]
+
+/** How far a chosen root may be nudged off the grid, in cents. */
+const ROOT_DETUNE_CENTS = 6
+
+/** Where tension starts, for a soundscape nobody has said anything about yet. */
+export const CALM = 0.2
+
+/**
+ * Choose a soundscape from a seed.
+ *
+ * Deterministic, so a session can be replayed and a bug can be reported. The
+ * seed is the only input: the same seed is the same mode, the same root and the
+ * same melody, on every device, forever.
+ */
+export function pickSoundscape(seed: number, tension: number = CALM): Soundscape {
+  const rng = new Rng(seed)
+  const mode = MODES[rng.int(MODES.length)] ?? MODES[0]
+  const base = ROOTS[rng.int(ROOTS.length)] ?? ROOTS[0] ?? 130.81
+  const detune = (rng.next() * 2 - 1) * ROOT_DETUNE_CENTS
+  return {
+    modeId: mode?.id ?? "western.dorian",
+    rootHz: base * Math.pow(2, detune / 1200),
+    seed: seed >>> 0,
+    tension: clamp01(tension),
+  }
+}
+
+/** The mode this soundscape is in, or Dorian if the id is not one we know. */
+export function modeOf(scape: Soundscape): Mode {
+  const mode = modeById(scape.modeId)
+  if (mode) return mode
+  // Loud, never silent: an unknown mode id means the host and the pack disagree
+  // about the corpus, which is a version skew a developer must see. The game
+  // still plays, in a mode that exists, because a silent game is worse.
+  console.warn(`[game-soundscape] unknown mode ${scape.modeId}; falling back`)
+  return modeById("western.dorian") ?? (MODES[0] as Mode)
+}
+
+/** The same soundscape, wound up or let down. */
+export function withTension(scape: Soundscape, tension: number): Soundscape {
+  return { ...scape, tension: clamp01(tension) }
+}
+
+/**
+ * A soundscape as it arrives from the host, validated.
+ *
+ * Everything crossing the port is attacker-controlled — a pack cannot be
+ * attacked by the host it is running inside, but a pack CAN be handed a
+ * malformed object by a host version it was not built against, and the failure
+ * mode of an unchecked one is a `NaN` frequency, which in Web Audio is a node
+ * that throws on `start()` and a game with no sound and no explanation.
+ *
+ * Returns `null` for anything that is not a soundscape, including `undefined` —
+ * which is what a host too old to send one sends, and is not an error.
+ */
+export function parseSoundscape(value: unknown): Soundscape | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  const modeId = raw["modeId"]
+  const rootHz = raw["rootHz"]
+  const seed = raw["seed"]
+  const tension = raw["tension"]
+  if (typeof modeId !== "string" || modeById(modeId) === null) return null
+  if (typeof rootHz !== "number" || !Number.isFinite(rootHz)) return null
+  if (rootHz < ROOT_MIN_HZ / 2 || rootHz > ROOT_MAX_HZ * 2) return null
+  if (typeof seed !== "number" || !Number.isFinite(seed)) return null
+  return {
+    modeId,
+    rootHz,
+    seed: Math.floor(seed) >>> 0,
+    tension: typeof tension === "number" && Number.isFinite(tension) ? clamp01(tension) : CALM,
+  }
+}
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0
+  return Math.min(1, Math.max(0, v))
+}

--- a/dynawalla/packs/shared/game-soundscape/tsconfig.json
+++ b/dynawalla/packs/shared/game-soundscape/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  /* The same strictness the app and the SDK are held to, so a type that passes
+     here cannot fail when a game imports the identical file by relative path —
+     which is how all 27 of them consume this module. `erasableSyntaxOnly` keeps
+     every file runnable under `node --experimental-strip-types`. */
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
Closes nothing; opens the conversation in #737.

The founder, on THE STEELYARD: *"right now [we] have the same sound for every
+1/−1 ... it would be way cooler if it randomly played a melody based on the
randomly chosen soundscape for any given moment .. so we are in a certain maqam
in a certain root note, then the little sound effects play a nice little song."*

## Why the obvious fixes are all wrong

Twenty-eight games, **11,064 lines of audio code**, and every one of them ends in
a table of fixed frequencies. THE STEELYARD's is `{1: 1180, 10: 830, 100: 520,
1000: 288}` and ten taps on the ones plate produce **one** distinct pitch.

- Not that the sounds are ugly. `audio.ts` is careful hand-shaped work.
- Not that they are too loud. `game-audio` already holds a −1 dBFS ceiling.
- It is that **nothing that happens changes what the next sound is**, so the
  tenth blow is bit-for-bit the first. A system with no memory cannot be
  surprising.

That is a *state* problem, and it is fixed in ~500 lines of pure arithmetic with
no Web Audio in them at all.

## What this adds

**`packs/shared/game-soundscape/`** — six source files, 45 tests, no Web Audio,
no DOM, runs under `--experimental-strip-types` in Node.

| | |
|---|---|
| `pitch.ts` | cents ↔ hertz, and octave folding |
| `modes.ts` | 38 modes as exact cents above the tonic — 16 Western, the 10 Hindustani thaats, 12 Arabic maqamat. **Ported, not imported**, from `corpan/packs/beatlounge/src/music/modes/`, because a Dynawalla pack must not have an edge into a Corpán pack's build graph |
| `rng.ts` | seeded mulberry32, so "random" is a thing a test can assert |
| `soundscape.ts` | `{ modeId, rootHz, seed, tension }` and the wire guard |
| `melody.ts` | the walker, the eight gestures, the voices |
| `host.ts` | the soundscape the app is in, shaped exactly like `game-audio/sound.ts` |

**Cents and not semitones** because Maqam Rast's third is a neutral interval near
350¢. There is no integer number of semitones that says it, so a semitone table
does not *approximate* the maqamat — it deletes them and silently substitutes the
nearest Western mode.

**The walker.** One scale degree of state. `+1` walks the mode ascending, `−1`
descending, and after 3–8 steps the phrase *resolves* onto a resting degree. That
cadence is the part that makes it satisfying rather than a scale exercise that
never arrives. Tension buys leaps and longer phrases and leans on the mode's own
colour degree, so a soundscape can wind up **without anything going out of tune**.

**In tune by construction.** Every pitch is `rootHz · 2^(cents/1200)` and the
drone is the same `rootHz`. One number, nothing to drift. The drone takes the
fifth *only when the mode has one* — whole tone does not, and a fixed root-and-
fifth drone would put a pitch under one soundscape in five that is not in the
scale.

**Games cannot pick pitches.** Eight gestures. THE STEELYARD's entire musical
vocabulary after this change is `tune.ts`, 45 lines including comments. `weight`
is not a pitch — it is *how heavy the thing the child did was* — and it buys
register: the four plates land on four one-octave bands that never overlap, so
"place value is a thing you can hear" is kept **exactly** and made musical rather
than replaced.

## Where it lives

> **Pitch decisions must be local and synchronous. Soundscape SELECTION must be
> global and slow.**

A soundscape changes every few minutes; a note happens ten times a second. So
selection rides the wire — one optional field on `Settings`, published by
`game-host` in one line beside `sound` and `safeArea`, on the channel that
already re-fires whenever anything changes — and the notes are computed in the
pack. **No new capability, no new method, no permission, no stream, no Rust, and
no `SDK_VERSION` bump** (additive optional field, exactly like `safeArea`).

A native audio engine was considered and rejected in the design doc: a
MessagePort round trip per note is two frames at best, and a native output path
is one the pack's WaveShaper ceiling cannot see — a hole in the only loudness
guarantee this fleet has, and that guarantee was built out of a nine-year-old
saying MOSAIC almost made his ears explode.

## Ship safety

**Nothing changes audibly in production.** No host populates the field, so
`currentSoundscape()` is `null` and every cue in the game falls through to
exactly what it plays today — same code path, same frequencies. The dev harness
publishes one:

```
npm run dev                             # a random mode and root each run
?mode=maqam.rast&seed=7&root=146.8      # pinned, so a report is reproducible
?soundscape=off                         # the A/B against what ships now
?mode=list                              # the corpus
```

`main.ts` is not loaded by `pack.html`, and `soundscape.test.ts` scans every
non-test source file under `src/` and fails if a second one ever calls
`setHostSoundscape`.

## Premium and chill

- Everything under **1244 Hz** worst case, against today's fixed 1180 on *every
  tap*; heaviest gestures at 58–117 Hz; a low-pass on every voice.
  **The ceiling on the music is set by choosing the root band, not by clamping
  later** — widening the roots by a fourth would put the top at 1600 Hz, inside
  the band the ear is most sensitive in.
- Attacks: **180 ms** bowed, 14 ms struck, 6 ms only where the impact *is* the
  information. A failure that blooms rather than buzzes is most of what "not
  cruel" means, and it costs one number.
- **White noise → modelled sound.** `rubble()`: sixteen grains, sizes on a power
  law, amplitude ∝ size and centre frequency ∝ 1/size, scattered unevenly, under
  a 1.4 kHz shelf. That distribution is the entire difference between "static"
  and "masonry". 24 of the 28 games currently reach for a noise buffer instead.
- The drone now **bends ±35 cents** with the beam instead of transposing a major
  third: a tonic that slides is a melody out of tune with itself. The metallic
  edge on a struck plate is kept and now rides the note, so a mashed rack still
  sounds like a mashed rack and `strain.ts`'s feedback is untouched.

## Verification

- `npm run -s test` and `npm run -s tsc` green on `game-soundscape` (45),
  `game-audio` (80), `game-host` (58), `packs/sdk` (118) and `counterweight`
  (165) — **five consecutive runs, identical**.
- `gavel`, `balance`, `lattice` and `street` also tsc, test and `build:pack`
  clean, since `game-host` now imports the new module.
- **Every new assertion mutation-tested** — 48 mutations, each applied,
  confirmed failing with the expected message, and restored. Four survivors were
  not tolerated: the cadence test was counting rest-degree *visits* (which a walk
  with the cadence deleted still passes), the tension test was polluted by
  cadence jumps and octave wraps, the fold test used powers of two (where a clamp
  is also an exact octave), and the unsubscribe test only removed *itself* (safe
  on a JS Set). All four were rewritten until the mutant died; a `resolved`
  counter was added to `Melody` to make "it cadences" observable at all.

## Design, options and open questions

`dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md` — two options with a recommendation,
the three delivery stages, the loudness table, the "never empty" bed design, what
is proven and what needs ears, and six questions for the founder (host bed vs
pack bed, rotation cadence, chord progressions, corpus width, fleet-wide vs
game-by-game, culling).

### One defect found on the way, not fixed here

`dynawalla-app/src/packs/services.ts` `playCue()` connects straight to
`context.destination`. **The host's own sound cues pass no ceiling at all.**
Harmless today — five short triangle tones — and not harmless the moment the host
owns a continuous bed. Noted in the doc and in #737.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb