### PR TITLE
dynawalla/games/lattice: a factor tree that unfolds, and a hint that costs nothing

### DIFF
--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -214,9 +214,17 @@ husks make all session — and `game/hint.ts` unfolds it a little at a time.
 | 1 | **The shape.** Every node blank. It says how many pieces the hold needs, and how they branch. | nothing |
 | 2 | **One prime.** The largest leaf: the `7` under four twos, the one a child sweeping twos never stumbles into. | nothing |
 | 3 | **Half a split.** The smaller of the root's two children, its sibling still blank — `129 ⟶ 3 and ⟶ ?`, exactly. | nothing |
-| 4 | **The partial.** The sibling lights: `16 × 7`, root still blank. The stepping stone. | the report |
-| 5 | **The leaves.** Every leaf lit. The hold, spelled out. Nobody is stuck past here. | the report |
-| 6 | **The whole tree.** Every node, root included, and the sentence closes. | the report |
+| 4 | **The partial.** The sibling lights: `16 × 7`, root still blank. The stepping stone. | a tap |
+| 5 | **The leaves.** Every leaf lit. The hold, spelled out. Nobody is stuck past here. | a tap |
+| 6 | **The whole tree.** Every node, root included, and the sentence closes. | a tap |
+
+Which stage crosses from "nothing" to "a tap" is **computed from the tree, not
+fixed at a number**. Usually it is between 3 and 4, but when the largest leaf
+*is* the larger of the root's two children, stage 3 lights both halves of the
+split at once: `129 → 3 · 43` is one of those, and so is `28 → 4 · 7`. Across the
+band that is 120 of the 573 composite targets, so a hardcoded 3 would be wrong
+for one target in five. `hint.freeStages` walks the tree; `revealsAnswer` reads
+the picture.
 
 A prime target — the wall — has no tree, so it has two stages: one lonely blank
 node, and then the numeral. That *is* the hint for a wall, because the only hold
@@ -226,6 +234,12 @@ which mote to hunt.
 The stages are a **masking** of one tree, never a different tree, and each one is
 a superset of the last — asserted over every target the ladder can serve, on
 twelve seeds.
+
+**The clock stops at the free stages.** Time alone will show a child the shape,
+one prime, and usually half of the first split, and then it stops and the control
+is there. Going further is something a child does on purpose, with a thumb.
+Nothing that happens to a child who is merely sitting in front of a question can
+reach a stage that states the answer.
 
 ### It is drawn out of the arena's own pieces
 
@@ -264,16 +278,25 @@ that served it and how many primes the hold is. A harder item buys *more*
 silence, never less, because a hint arriving sooner on a harder problem is the
 game saying it does not think you can do this one.
 
+And it is **played** time, accumulated in `Arena.step`, not the wall clock. A
+host sheet costs nothing because `step` returns early behind one — but so does
+the case a pack is never told about at all: a backgrounded webview hands back a
+delta of minutes and `step` clamps it to 120ms like every other physical quantity
+in the arena, so three minutes in the app switcher advances the quiet by about a
+frame instead of by three stages of tree the child was not in the room for. A
+wall clock with a pause guard bolted on covered the first case and not the
+second, and the second is the one that happens on a phone.
+
 (THE LATTICE has no answer window and this does not add one. Nothing here is a
 deadline: past the last stage the tree simply sits there, complete.)
 
-Mid-band that is a silhouette at about 35 seconds, a prime at 65, half a split at
-95, and the partial at about two minutes. The perfect bot in `pacing.test.ts`
-finishes a whole round in five seconds, so a child who is *playing* is never
-interrupted; the schedule meets one who has stopped. And the gaps are **longer**
-than the first quiet, which is the opposite of what warmth would suggest — the
-offer of help comes quickly because the first three stages cost nothing, and the
-part of it that spends something is unhurried.
+Mid-band that is a silhouette at about 35 seconds, a prime at 65, and half a
+split at 95 — and then the clock has given what it has. The perfect bot in
+`pacing.test.ts` finishes a whole round in five seconds, so a child who is
+*playing* is never interrupted; the schedule meets one who has stopped. The gaps
+are **longer** than the first quiet, which is the opposite of what warmth would
+suggest: spending them slowly is what makes each one a separate thing that
+happened rather than a panel unfolding at a child who has looked away.
 
 ### What a hint costs, and the one thing it changes
 
@@ -283,30 +306,43 @@ were taken and no language about needing help. `hint.test.ts` plays the same
 seeded run twice — once blind, once with the whole tree up from the first frame —
 and asserts the counter, the chain and the haptics come out identical.
 
-What it changes is what the **host** is told. Once the revealed nodes *determine*
-the root — stage 4 for a composite, stage 2 for a wall, computed from the picture
-rather than hardcoded to a stage number — the game has put the answer to
-`642 − 530` on the screen, and a `correct` report against that question would be
-a claim about the child that is not true. `Arena.enter` closes those with
-`host.skip` instead, which the contract defines as "records nothing, moves no
-ladder, produces no outcome".
+### The version of this that failed review, and why
 
-That is the honest reading and it is the only neutral option available: reporting
-a MISS would be a hint that costs, which is forbidden outright, and reporting a
-HIT would write a MASTERED signal into a child's record on the strength of
-something the game printed — and then climb them into harder items on it.
+The first cut reasoned: once the tree states the answer, a `correct` report is a
+claim about the child that is not true, so close the question with `host.skip` —
+"records nothing, moves no ladder, produces no outcome" — instead. Honest, and
+invisible from inside the canvas.
 
-For the same reason the game's own ladder **holds rather than climbing** on a
-handed-over open. `Ladder.opened` is three rungs of harder arithmetic next time,
-and pushing a child into harder arithmetic *because* they had just been shown the
-answer is the one way a hint here could quietly cost them something. A refusal
-still falls, because falling is the direction that makes the next one kinder.
+It is not invisible three pixels above it. `game-host` says of `skip`, verbatim,
+that it *"does not advance the session progress fraction, because that counts
+answered questions"*, and the host paints that fraction as a full-width hairline
+across the top of every pack — the one `hud.ts` already reserves `HOST_PROGRESS_H`
+for. Measured on a seeded run that took the hint to the end five times:
 
-The trade is deliberate and it is worth naming: a chronically stuck child
-generates less signal for the adaptive engine. The alternative was a record full
-of correct answers the game gave, which is worse — and the game's own ladder
-still falls on every refusal, so the *stream* still adapts even when the record
-goes quiet.
+| | opened | ceremonies | reports | progress hairline |
+|---|---|---|---|---|
+| shipped in review | 5 | 5 | **0** | **0 / 40, all sitting** |
+| now | 5 | 5 | 5 | 5 / 40 |
+
+**The child who leans on the hint is the child this feature exists for, and
+theirs was the bar that never moved.** That is a punishment delivered by the one
+persistent indicator on the screen. Worse, it did not need the child to do
+anything: `tiles` is 1 for a prime, so a wall's quiet is short and stage 2 of a
+wall *is* the numeral — a child hunting the single `353` mote for 51 seconds,
+which is the entire task on a wall round and an ordinary length of time to spend
+on it, had the answer printed for them at the finish line and their unaided
+answer thrown away. Walls are one resonator in five.
+
+So two things changed. **The report goes to the host as it always did.** And
+**the clock stops at `freeStages`**, so the reveal line can only ever be crossed
+by a deliberate tap.
+
+What survives of the original concern is the one decision the game actually owns:
+the ladder **holds rather than climbing** on a handed-over open. `Ladder.opened`
+is three rungs of harder arithmetic next time, and pushing a child into harder
+arithmetic *because* they just asked to be shown is the one thing a hint could
+still take. Holding position is the absence of a penalty, not one. A refusal
+still falls, because falling makes the next one kinder.
 
 ### The reveal is adaptive, and mastery is what skips it
 
@@ -340,11 +376,24 @@ the control on its own row spent sixty of the remaining hundred and forty and
 left the tree fifty-nine pixels to draw four rows in. Landscape has width and no
 height, so the control is paid for out of the width.
 
-It is checked before the sticks and before the tile bar, and `chrome.test.ts`
-asserts at every viewport that nowhere the hint control answers does the tile bar
-answer too — because a child who reaches for help and instead throws away the
-hold they spent a minute assembling is "a hint costs something" built out of
-geometry rather than out of rules.
+`chrome.test.ts` asserts at every viewport that nowhere the hint control answers
+does the tile bar answer too — because a child who reaches for help and instead
+throws away the hold they spent a minute assembling is "a hint costs something"
+built out of geometry rather than out of rules.
+
+**It fires on release, not on press**, and that is the same class of bug one
+layer up. The control sits at the bottom-left of the safe area, which is exactly
+where a left thumb comes to rest — and the left half of the screen *is* the
+movement stick. Firing on pointer-down meant that settling your hand there both
+unfolded a tree nobody asked for and swallowed the touch, so the ship would not
+move. Now the press is remembered and the thumb goes on to drive the stick as if
+the control were not there; the hint fires only if the pointer comes up inside
+the control, never strayed more than 10px from where it went down, and was not
+held longer than 400ms.
+
+The travel is measured along the **path**, not between the endpoints. A stick
+held in a circle returns to where it started every revolution, so an endpoint
+check calls that a tap.
 
 ### The ship, and why it was wild on Android specifically
 
@@ -467,13 +516,13 @@ src/
   render/         palette, scene, sparks
   render/hud.ts   where the chrome may be drawn: the safe area, minus two corners
   audio/audio.ts  asset-free Web Audio, C5–C6 pentatonic
-  test/           176 tests: rules, pacing, the ship, the hint, wiring, chrome
+  test/           181 tests: rules, pacing, the ship, the hint, wiring, chrome
 ```
 
 ## Tests
 
 ```
-npm test        176 tests
+npm test        181 tests
 npm run tsc     0 errors
 npm run build   the library build
 npm run build:pack   the pack build → dist-pack/
@@ -491,7 +540,11 @@ The ones that matter:
   the hold out in full, the quiet is pure in the item and monotone
   non-decreasing in both of its difficulty signals, a sheet does not spend it,
   and a hinted run comes out identical to a blind one on everything the child can
-  see. **Every assertion in it verified to fail** by breaking what it covers.
+  see — *including* the report count, which is what the progress hairline is made
+  of and what the first cut of this feature silently zeroed. Also: the clock
+  alone can never reach a stage that states the answer, over six seeds × six
+  rounds × ten minutes of sitting still. **Every assertion in it verified to
+  fail** by breaking what it covers.
 * `resonance.test.ts` — a target is cleared **only** by a genuine prime
   factorisation of it (exhaustive over every multiset of small primes to six
   tiles against every target to 200); a prime target cannot be assembled from

--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -213,7 +213,7 @@ husks make all session — and `game/hint.ts` unfolds it a little at a time.
 |---|---|---|
 | 1 | **The shape.** Every node blank. It says how many pieces the hold needs, and how they branch. | nothing |
 | 2 | **One prime.** The largest leaf: the `7` under four twos, the one a child sweeping twos never stumbles into. | nothing |
-| 3 | **Half a split.** The smaller of the root's two children, its sibling still blank — `129 ⟶ 3 and ⟶ ?`, exactly. | nothing |
+| 3 | **Half a split.** The smaller of the root's two children, its sibling still blank — the founder's `129 ⟶ 3 and ⟶ ?`. | usually nothing |
 | 4 | **The partial.** The sibling lights: `16 × 7`, root still blank. The stepping stone. | a tap |
 | 5 | **The leaves.** Every leaf lit. The hold, spelled out. Nobody is stuck past here. | a tap |
 | 6 | **The whole tree.** Every node, root included, and the sentence closes. | a tap |
@@ -222,9 +222,9 @@ Which stage crosses from "nothing" to "a tap" is **computed from the tree, not
 fixed at a number**. Usually it is between 3 and 4, but when the largest leaf
 *is* the larger of the root's two children, stage 3 lights both halves of the
 split at once: `129 → 3 · 43` is one of those, and so is `28 → 4 · 7`. Across the
-band that is 120 of the 573 composite targets, so a hardcoded 3 would be wrong
-for one target in five. `hint.freeStages` walks the tree; `revealsAnswer` reads
-the picture.
+band — 573 targets the resonator can put up, of which 410 are composite — that
+is 112 to 123 of the 410 depending on the seed, so **roughly three composites in
+ten**. `hint.freeStages` walks the tree; `revealsAnswer` reads the picture.
 
 A prime target — the wall — has no tree, so it has two stages: one lonely blank
 node, and then the numeral. That *is* the hint for a wall, because the only hold

--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -185,16 +185,166 @@ no extra wiring.
 
 ---
 
+---
+
+## The hint, and why it is a factor tree
+
+The founder's report is the specification:
+
+> The Lattice is almost rad. But, it can be wildly hard. Trying to look at
+> `642 − 530` and know that `2×2×2×2×7 = 112` is a pretty heroic task. But, if we
+> could show the factorization tree as a dazzling hint … perhaps in a cool way
+> like leaving some of the leaves blank or … maybe giving a partial like
+> `16*7=112` … right now it's easy to get stuck and overwhelmed but … it could be
+> OK to basically reveal the answer in a really satisfying way.
+
+Two hard steps were stacked with nothing between them: work out `642 − 530`, and
+*then* work out that the answer is four twos and a seven. A child who could do
+the first and not the second had no way forward and no way to ask, and the
+arena's only response was to keep drifting.
+
+So `game/tree.ts` builds the real tree — off `splitPair`, the same function a
+shot uses, so it is balanced and it is the shape the child has been watching
+husks make all session — and `game/hint.ts` unfolds it a little at a time.
+
+### The six stages
+
+| | what appears | what it costs |
+|---|---|---|
+| 1 | **The shape.** Every node blank. It says how many pieces the hold needs, and how they branch. | nothing |
+| 2 | **One prime.** The largest leaf: the `7` under four twos, the one a child sweeping twos never stumbles into. | nothing |
+| 3 | **Half a split.** The smaller of the root's two children, its sibling still blank — `129 ⟶ 3 and ⟶ ?`, exactly. | nothing |
+| 4 | **The partial.** The sibling lights: `16 × 7`, root still blank. The stepping stone. | the report |
+| 5 | **The leaves.** Every leaf lit. The hold, spelled out. Nobody is stuck past here. | the report |
+| 6 | **The whole tree.** Every node, root included, and the sentence closes. | the report |
+
+A prime target — the wall — has no tree, so it has two stages: one lonely blank
+node, and then the numeral. That *is* the hint for a wall, because the only hold
+that opens a prime is the single mote carrying it and the whole task is knowing
+which mote to hunt.
+
+The stages are a **masking** of one tree, never a different tree, and each one is
+a superset of the last — asserted over every target the ladder can serve, on
+twelve seeds.
+
+### It is drawn out of the arena's own pieces
+
+A lit leaf is the same celestial hexagon as the mote drifting out there; an
+unopened node is the same carved stone as the husk holding it. Nobody has to be
+told the tree is a map of the field.
+
+It stands in the **bottom third**, which is not a taste decision: `Arena.arm`
+seeds every husk and mote between the top edge and `0.62 · height`, so the lower
+band is the emptiest part of the field and the one place a panel can sit without
+hiding what the child is aiming at. It is also where their eyes already are,
+because the tile bar is there — and the tree's leaves are exactly what the bar is
+about to fill up with.
+
+**The juice fires on the maths.** A leaf whose prime reaches the hold gets a
+brass collar and throws a spark the frame it earns one, and the last one throws a
+bigger spark: `2·2·2·2·7` assembling itself, one mote at a time. That is the only
+thing in the game that celebrates a *factorisation* rather than a resonator, and
+it is the moment the learning actually happens. The collar is a multiset walk and
+not an `includes` — four twos on the tree and two in the hold must collar exactly
+two, or the picture is a lie about what is left to find.
+
+### The clock is not a clock
+
+Hints also arrive on their own. There is no countdown, no ring filling, no "hint
+in 3", no banner, and no word anywhere. The tree fades in the way the sheet
+ripples, with two rising notes on the same felt mallet as everything else and the
+same light tick a swept mote gives.
+
+The quiet before the first one is `firstHintMs`, and it is held to the law the
+fleet holds an answer window to: **a pure function of the item, monotone
+non-decreasing in the item's difficulty.** No speed, no elapsed time, no streak,
+no reading of how the child is doing goes into it, and the proof is that it is a
+sum of non-negative multiples of the item's own two difficulty signals — the rung
+that served it and how many primes the hold is. A harder item buys *more*
+silence, never less, because a hint arriving sooner on a harder problem is the
+game saying it does not think you can do this one.
+
+(THE LATTICE has no answer window and this does not add one. Nothing here is a
+deadline: past the last stage the tree simply sits there, complete.)
+
+Mid-band that is a silhouette at about 35 seconds, a prime at 65, half a split at
+95, and the partial at about two minutes. The perfect bot in `pacing.test.ts`
+finishes a whole round in five seconds, so a child who is *playing* is never
+interrupted; the schedule meets one who has stopped. And the gaps are **longer**
+than the first quiet, which is the opposite of what warmth would suggest — the
+offer of help comes quickly because the first three stages cost nothing, and the
+part of it that spends something is unhurried.
+
+### What a hint costs, and the one thing it changes
+
+Nothing the child can see. Not a point, not the chain, not BEST, not the ceremony
+when the resonator opens. There is no counter anywhere that says how many hints
+were taken and no language about needing help. `hint.test.ts` plays the same
+seeded run twice — once blind, once with the whole tree up from the first frame —
+and asserts the counter, the chain and the haptics come out identical.
+
+What it changes is what the **host** is told. Once the revealed nodes *determine*
+the root — stage 4 for a composite, stage 2 for a wall, computed from the picture
+rather than hardcoded to a stage number — the game has put the answer to
+`642 − 530` on the screen, and a `correct` report against that question would be
+a claim about the child that is not true. `Arena.enter` closes those with
+`host.skip` instead, which the contract defines as "records nothing, moves no
+ladder, produces no outcome".
+
+That is the honest reading and it is the only neutral option available: reporting
+a MISS would be a hint that costs, which is forbidden outright, and reporting a
+HIT would write a MASTERED signal into a child's record on the strength of
+something the game printed — and then climb them into harder items on it.
+
+For the same reason the game's own ladder **holds rather than climbing** on a
+handed-over open. `Ladder.opened` is three rungs of harder arithmetic next time,
+and pushing a child into harder arithmetic *because* they had just been shown the
+answer is the one way a hint here could quietly cost them something. A refusal
+still falls, because falling is the direction that makes the next one kinder.
+
+The trade is deliberate and it is worth naming: a chronically stuck child
+generates less signal for the adaptive engine. The alternative was a record full
+of correct answers the game gave, which is worse — and the game's own ladder
+still falls on every refusal, so the *stream* still adapts even when the record
+goes quiet.
+
+### The reveal is adaptive, and mastery is what skips it
+
+`revealPaceMs` is the only thing in the hint system that reads the child at all,
+and it reads the chain rather than a clock. At the bottom the reveal is long and
+calm — a child who is finding this hard gets to watch each piece arrive, and that
+watching is most of the value. On a chain of six the same reveal snaps into place
+in a couple of frames, because a child who is flying does not want a ceremony in
+front of their arena and skipping it is the reward. It changes nothing about
+*what* is revealed or *when*; only how it lands.
+
+---
+
 ## Controls
 
 Twin-stick, on every input a child might have. Tablet and desktop are equal
 targets.
 
-| | Move | Aim / fire | Drop the hold |
-|---|---|---|---|
-| Touch | left thumb, anywhere on the left half | right thumb | tap the tile bar |
-| Keyboard | `WASD` | arrow keys, or `space` to fire straight ahead | `Escape` |
-| Mouse | `WASD` | the cursor aims, the button fires | tap the tile bar |
+| | Move | Aim / fire | Drop the hold | Ask for a hint |
+|---|---|---|---|---|
+| Touch | left thumb, anywhere on the left half | right thumb | tap the tile bar | tap the branch button |
+| Keyboard | `WASD` | arrow keys, or `space` to fire straight ahead | `Escape` | `H` |
+| Mouse | `WASD` | the cursor aims, the button fires | tap the tile bar | click the branch button |
+
+The hint control is a brass ring with a three-node tree drawn inside it — a
+glyph and not a word, because it is a control a five-year-old meets before they
+can read, in a pack that ships in about fifty languages. It sits at the
+bottom-left of the tree's own band, **beside** the tree rather than under it: a
+phone held sideways is 390px tall and the host takes the top hundred, so stacking
+the control on its own row spent sixty of the remaining hundred and forty and
+left the tree fifty-nine pixels to draw four rows in. Landscape has width and no
+height, so the control is paid for out of the width.
+
+It is checked before the sticks and before the tile bar, and `chrome.test.ts`
+asserts at every viewport that nowhere the hint control answers does the tile bar
+answer too — because a child who reaches for help and instead throws away the
+hold they spent a minute assembling is "a hint costs something" built out of
+geometry rather than out of rules.
 
 ### The ship, and why it was wild on Android specifically
 
@@ -308,6 +458,8 @@ src/
                      target has to be for the game to be a game about it
   game/ladder.ts     what the game asks the host for: the band, and the walk
   game/steer.ts      what a thumb means: a dead zone and a response curve
+  game/tree.ts       the factor tree, generated and laid out; it may not lie
+  game/hint.ts       the escalation, the quiet, and where the answer is given
   game/bank.ts       the hold, and the factor tile bar
   game/arena.ts      the rules: husks, motes, the ship, the resonator
   game/best.ts       the longest chain, guarded for a pack frame
@@ -315,13 +467,13 @@ src/
   render/         palette, scene, sparks
   render/hud.ts   where the chrome may be drawn: the safe area, minus two corners
   audio/audio.ts  asset-free Web Audio, C5–C6 pentatonic
-  test/           132 tests: rules, pacing, the ship, wiring, and the chrome
+  test/           176 tests: rules, pacing, the ship, the hint, wiring, chrome
 ```
 
 ## Tests
 
 ```
-npm test        132 tests
+npm test        176 tests
 npm run tsc     0 errors
 npm run build   the library build
 npm run build:pack   the pack build → dist-pack/
@@ -329,6 +481,17 @@ npm run build:pack   the pack build → dist-pack/
 
 The ones that matter:
 
+* `hint.test.ts` — **the tree may not lie.** The generator is checked as a
+  property, not by example: every whole number from 12 to 999, on twelve seeds,
+  every node the exact product of its two children, every leaf prime, and the
+  leaves exactly `primeFactors(n)` as a multiset. A hint that says
+  `112 = 2·2·2·7` sends a child to sweep 56 and be refused by the game that told
+  them to. Then: the escalation is a superset chain, the silhouette and the first
+  prime provably cannot state the answer, the last-but-one stage always spells
+  the hold out in full, the quiet is pure in the item and monotone
+  non-decreasing in both of its difficulty signals, a sheet does not spend it,
+  and a hinted run comes out identical to a blind one on everything the child can
+  see. **Every assertion in it verified to fail** by breaking what it covers.
 * `resonance.test.ts` — a target is cleared **only** by a genuine prime
   factorisation of it (exhaustive over every multiset of small primes to six
   tiles against every target to 200); a prime target cannot be assembled from
@@ -373,7 +536,12 @@ The ones that matter:
   hold — is reachable. **Verified to fail with the layout reverted**, not by
   reading it.
 * `mount.test.ts` — the shell, including the one that got away: flying into the
-  resonator asserts the hold. `Arena.enter` was covered exhaustively by the
+  resonator asserts the hold. It also drives the real pointer handler, the real
+  loop and the real renderer to ask whether a `?` ever reaches the canvas —
+  because `askHint`, `unfold` and `Arena.hint` live entirely in the shell, and
+  every assertion about them in `hint.test.ts` would pass with all three
+  unwired: a hint system a child could never see, in a game whose whole problem
+  is getting stuck. **Verified to fail** with each of the three cut. `Arena.enter` was covered exhaustively by the
   rules tests and **never called by the shell**, so the entire reasoning layer
   was unreachable in the shipped game while every test was green. It also
   asserts that reading the manual holds the world and that closing it lets go,

--- a/dynawalla/games/lattice/src/audio/audio.ts
+++ b/dynawalla/games/lattice/src/audio/audio.ts
@@ -134,6 +134,21 @@ export class Audio {
     }
   }
 
+  /**
+   * A piece of the factor tree arriving.
+   *
+   * Two notes, rising, quiet, on the same felt mallet as everything else — and
+   * deliberately built out of the *sweep* interval rather than the refusal's, so
+   * a child hears help as a small good thing happening rather than as a
+   * correction. It never gets more insistent as the stages go up; it climbs the
+   * pentatonic, which is the same shape a resonance opening makes.
+   */
+  hint(stage: number): void {
+    const i = Math.min(PENTATONIC.length - 2, Math.max(0, stage - 1))
+    this.strike(PENTATONIC[i] as number, 0.075, 260)
+    this.strike(PENTATONIC[i + 1] as number, 0.06, 320, 0.09)
+  }
+
   /** A refusal. Lower, shorter, and quieter than a resonance — never a buzzer. */
   refuse(): void {
     this.strike(233.08, 0.1, 190, 0, "triangle")

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -29,6 +29,7 @@ import {
   splitPair,
 } from "./factor.ts"
 import {
+  freeStages,
   type HintState,
   itemOf,
   revealsAnswer,
@@ -313,6 +314,25 @@ export class Arena {
   private hintSeen = 0
   /** What `firstHintMs` is allowed to read: the item, and nothing else. */
   private hintItem = { difficulty: 0, tiles: 0 }
+  /**
+   * How much of this question the child has actually **played**, in ms.
+   *
+   * Not the wall clock, and that is the whole point. `step` adds to this and
+   * `step` returns early behind a host sheet or the how-to-play panel, so those
+   * cost nothing — but it also covers the case a pack is never told about at
+   * all: a backgrounded webview hands back a delta of minutes, `step` clamps it
+   * to 120ms like every other physical quantity, and three minutes in the app
+   * switcher advances this by about a frame instead of by three whole stages of
+   * tree the child was not in the room for.
+   *
+   * Wall-clock time with a pause guard bolted on covered the first case and not
+   * the second, and the second is the one that happens on a phone.
+   */
+  private hintAgeMs = 0
+  /** The last stage the clock may reach on its own. See `hint.freeStages`. */
+  private hintFree = 0
+  /** The last `HintState` handed out, so a redraw is not a fresh allocation. */
+  private hintCache: { stage: number; state: HintState } | null = null
   /** The domain label the resonator's questions are drawn under. */
   private readonly domain: string
 
@@ -595,37 +615,39 @@ export class Arena {
     // Not "was a hint shown" — a blank silhouette and a single lit prime are
     // both hints and neither of them says what `642 − 530` is. The line is
     // `revealsAnswer`: are there numerals on the screen whose product is the
-    // target. For a composite that is the partial (`16 × 7`); for a wall it is
-    // the numeral itself.
+    // target. It is computed from the picture rather than from a stage number,
+    // because which stage crosses it depends on the tree's shape — see
+    // `hint.freeStages`.
     //
-    // Past that line the child's answer is not evidence about the child, and
-    // reporting it `correct` would write a MASTERED signal into a record on the
-    // strength of something the game printed. So the question is closed with
-    // `skip`, which the contract defines as "records nothing, moves no ladder,
-    // produces no outcome" — the only neutral option there is. Reporting a MISS
-    // instead would be a hint that costs, which is forbidden outright, and
-    // reporting a HIT would quietly climb a stuck child into harder items.
-    //
-    // Nothing about this is visible from inside the game: the ceremony fires,
-    // OPENED goes up, the chain goes up, BEST can be beaten.
-    const given = this.hint(now)?.given === true
+    // It is only ever true because the child **asked**: the clock stops at
+    // `hintFree`, one stage short of the line, so nothing that happens to a
+    // child who is sitting still can reach here.
+    const given = this.hint()?.given === true
 
     // Once per question. A refusal spends the id — the resonator stays as a
     // goal the child can still open, but the host hears one answer, which is
     // the only honest reading of "what did they say when they were asked".
+    //
+    // **Reported whether or not the tree was up**, and the first version of this
+    // was not. It closed a hinted question with `host.skip` instead, on the
+    // reasoning that a `correct` after the game printed the answer is a claim
+    // about the child that is not true. That is true and it is not the whole
+    // truth: `skip` is documented as not advancing the session progress
+    // fraction, and the host paints that fraction as a hairline across the top
+    // of every pack. Measured, five hinted rounds in a row: five ceremonies,
+    // `OPENED 5`, and a progress bar still on nought. The child who leans on the
+    // hint is the one this feature is for, and theirs was the bar that never
+    // moved. A hint may not cost anything, and that cost was three pixels above
+    // a canvas that was congratulating them.
     const first = !res.reported
     if (first) {
       res.reported = true
-      if (given) {
-        this.host.skip?.(res.questionId)
-      } else {
-        this.host.report({
-          questionId: res.questionId,
-          correct: verdict.kind === "open",
-          ms: Math.max(0, Math.round(now - this.askedAt)),
-          answered: String(verdict.asserted),
-        })
-      }
+      this.host.report({
+        questionId: res.questionId,
+        correct: verdict.kind === "open",
+        ms: Math.max(0, Math.round(now - this.askedAt)),
+        answered: String(verdict.asserted),
+      })
     }
 
     if (verdict.kind === "refuse") {
@@ -653,12 +675,14 @@ export class Arena {
     this.chain += 1
     // The ladder does not climb on an answer the game handed over.
     //
-    // This is not a penalty — it is the absence of one. `opened()` is three
-    // rungs harder next time, and pushing a child who had just been shown the
-    // answer into harder arithmetic is the one way a hint could quietly cost
-    // them something. So the game holds its position and asks again at the
-    // level they are actually working at. A refusal still falls, because
-    // falling is the direction that makes the next one kinder.
+    // This is not a penalty — it is the absence of one, and it is the ONE thing
+    // this file still does differently for a hinted round. `opened()` is three
+    // rungs harder next time, and pushing a child who had just asked to be shown
+    // the answer into harder arithmetic is the one way a hint could still cost
+    // them something. So the game holds its position and asks again at the level
+    // they are actually working at. It is invisible, it is reachable only by a
+    // deliberate tap, and a refusal still falls, because falling is the
+    // direction that makes the next one kinder.
     if (!given) this.ladder.opened()
     this.host.haptic("success")
     const events: ArenaEvent[] = [{ kind: "open", at, target: res.target, tiles }]
@@ -704,6 +728,13 @@ export class Arena {
       this.resonator.age += dtMs
     }
     if (this.rearmMs > 0) this.rearmMs = Math.max(0, this.rearmMs - dtMs)
+    // The hint's clock, and it is the CLAMPED delta rather than the raw one —
+    // the opposite of every timer above. Those are things that should burn while
+    // a tab is backgrounded (a refusal's 900ms of dim ought to be over when the
+    // child comes back). Thinking time is not: three minutes in the app switcher
+    // is three minutes the child was not looking at the question, and charging
+    // them for it would unfold the whole tree behind their back.
+    this.hintAgeMs += clamped
 
     // One 60Hz world, however fast the frame arrives. See `SUBSTEP_MS`.
     const steps = Math.min(MAX_SUBSTEPS, Math.max(1, Math.ceil(clamped / SUBSTEP_MS)))
@@ -821,11 +852,11 @@ export class Arena {
   /**
    * Milliseconds the child has had with the current resonator.
    *
-   * Frozen behind a sheet. `resume` shifts `askedAt` forward by exactly the
-   * sheet, so this was already right *after* one — but during one it kept
-   * climbing, and now that the hint reads it, a sheet held for a minute would
-   * have shown two more stages of tree behind the card and none of them would
-   * have made a sound. A child comes back to the tree they left.
+   * Frozen behind a sheet: `resume` shifts `askedAt` forward by exactly the
+   * sheet, so this was already right *after* one, and now it is right during one
+   * too. That is a latency number and nothing else reads it — the hint keeps its
+   * own played-time clock, because a wall clock with a pause guard on it still
+   * runs while the whole webview is in the app switcher.
    */
   elapsed(now: number): number {
     return Math.max(0, (this.paused ? this.pausedAt : now) - this.askedAt)
@@ -848,30 +879,43 @@ export class Arena {
    * quiet. That was free; it is worth saying out loud because it is the kind of
    * thing that is only ever noticed when it is wrong.
    */
-  private hintStage(now: number): number {
+  private hintStage(): number {
     const tree = this.hintTree
     if (!tree || !this.resonator) return 0
     const cap = stageCount(tree)
-    return Math.min(cap, Math.max(scheduledStage(this.elapsed(now), this.hintItem), this.hintTaps))
+    // The clock is capped at `hintFree` — the last picture that does not state
+    // the answer — so nothing that happens to a child who is merely sitting
+    // there can reach a stage that holds this pack's ladder still. Past that
+    // line the tree only moves under a thumb.
+    const byClock = Math.min(this.hintFree, scheduledStage(this.hintAgeMs, this.hintItem))
+    return Math.min(cap, Math.max(byClock, this.hintTaps))
   }
 
   /**
    * The hint as it stands, for the renderer. `null` when there is nothing to
    * hint about or when the tree has not been offered yet.
+   *
+   * Memoised on the stage. The shell calls this every frame and the stage
+   * changes a handful of times a question, so without the cache every frame
+   * allocated a `Set` and re-walked the tree for a picture that had not moved.
    */
-  hint(now: number): HintState | null {
+  hint(): HintState | null {
     const tree = this.hintTree
     if (!tree) return null
-    const stage = this.hintStage(now)
+    const stage = this.hintStage()
     if (stage <= 0) return null
+    const cached = this.hintCache
+    if (cached && cached.stage === stage) return cached.state
     const shown = shownAt(tree, stage)
-    return {
+    const state: HintState = {
       placed: tree,
       stage,
       stages: stageCount(tree),
       shown,
       given: revealsAnswer(tree, shown),
     }
+    this.hintCache = { stage, state }
+    return state
   }
 
   /**
@@ -882,16 +926,16 @@ export class Arena {
    * everything it has. Nothing is counted, nothing is spent, and no other rule
    * in this file reads `hintTaps`.
    */
-  askHint(now: number): ArenaEvent[] {
+  askHint(): ArenaEvent[] {
     if (this.paused) return []
     const tree = this.hintTree
     const res = this.resonator
     if (!tree || !res) return []
     const cap = stageCount(tree)
-    const at = this.hintStage(now)
+    const at = this.hintStage()
     if (at >= cap) return []
     this.hintTaps = at + 1
-    return this.unfold(now)
+    return this.unfold()
   }
 
   /**
@@ -902,11 +946,11 @@ export class Arena {
    * nothing: `hint()` would return the same thing whether or not this is ever
    * called.
    */
-  unfold(now: number): ArenaEvent[] {
+  unfold(): ArenaEvent[] {
     if (this.paused) return []
     const res = this.resonator
     if (!res || !this.hintTree) return []
-    const stage = this.hintStage(now)
+    const stage = this.hintStage()
     if (stage === this.hintSeen) return []
     this.hintSeen = stage
     if (stage <= 0) return []
@@ -964,6 +1008,9 @@ export class Arena {
     this.hintTree = null
     this.hintTaps = 0
     this.hintSeen = 0
+    this.hintAgeMs = 0
+    this.hintFree = 0
+    this.hintCache = null
     const wall = this.sinceWall >= WALL_EVERY - 1
     let question: Question | null = null
     let landedAt = this.ladder.at
@@ -1066,6 +1113,9 @@ export class Arena {
     // suite and in every child's session.
     this.hintTree = placeTree(factorTree(target, this.rng.fork(target)))
     this.hintItem = itemOf(target, landedAt)
+    // Computed once, here, rather than per frame: it is a walk of the whole tree
+    // at every stage and the shell asks for the hint sixty times a second.
+    this.hintFree = freeStages(this.hintTree)
     const values = huskify(wanted, this.rng)
 
     // One reachable mal-rule: the primes it needs that the answer does not

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -28,7 +28,16 @@ import {
   primeFactors,
   splitPair,
 } from "./factor.ts"
+import {
+  type HintState,
+  itemOf,
+  revealsAnswer,
+  scheduledStage,
+  shownAt,
+  stageCount,
+} from "./hint.ts"
 import { CEILING, FLOOR, Ladder, rungOf } from "./ladder.ts"
+import { factorTree, placeTree, type Placed } from "./tree.ts"
 import {
   isAskable,
   isResonant,
@@ -208,6 +217,12 @@ export type Resonator = {
   readonly questionId: string
   readonly prompt: string
   readonly target: number
+  /**
+   * The rung that *served* this question, 0..1 — never the rung that was asked
+   * for. See the note in `arm`: the two differ often and by a lot, and this is
+   * the one the hint's quiet is computed from.
+   */
+  readonly difficulty: number
   x: number
   y: number
   vx: number
@@ -230,6 +245,13 @@ export type ArenaEvent =
   | { kind: "open"; at: Vec; target: number; tiles: readonly number[] }
   | { kind: "refuse"; at: Vec; asserted: number; target: number }
   | { kind: "arrive"; at: Vec; target: number; prompt: string }
+  /**
+   * The hint unfolded by one stage — because the child asked, or because the
+   * quiet ran out. `at` is the resonator, because that is where the help is
+   * coming *from*: the ring is explaining itself. Never a banner and never a
+   * word; the shell draws this as light and a warm note.
+   */
+  | { kind: "hint"; at: Vec; stage: number; stages: number }
   | { kind: "stalled" }
 
 export type ArenaOptions = { width: number; height: number; domain?: string }
@@ -276,6 +298,21 @@ export class Arena {
   private sinceWall = 0
   /** Counts down after a barren arming, then the arena tries again. */
   private rearmMs = 0
+  /**
+   * The current resonator's factor tree, and how far it has been unfolded.
+   *
+   * The tree is built once, when the resonator is armed, off a *fork* of the
+   * arena's generator — so it is deterministic for a given target and seed and
+   * it does not disturb the stream the husks and the drift come out of. What
+   * moves is only how much of it carries a numeral. See `game/hint.ts`.
+   */
+  private hintTree: Placed | null = null
+  /** How many times the child has asked. Never shown to anybody, ever. */
+  private hintTaps = 0
+  /** The last stage the shell was told about, so `unfold` fires once per step. */
+  private hintSeen = 0
+  /** What `firstHintMs` is allowed to read: the item, and nothing else. */
+  private hintItem = { difficulty: 0, tiles: 0 }
   /** The domain label the resonator's questions are drawn under. */
   private readonly domain: string
 
@@ -553,18 +590,42 @@ export class Arena {
     const verdict = resonate(res.target, this.bank.tiles)
     if (verdict.kind === "silent") return []
 
+    // **Did the game give this one away?**
+    //
+    // Not "was a hint shown" — a blank silhouette and a single lit prime are
+    // both hints and neither of them says what `642 − 530` is. The line is
+    // `revealsAnswer`: are there numerals on the screen whose product is the
+    // target. For a composite that is the partial (`16 × 7`); for a wall it is
+    // the numeral itself.
+    //
+    // Past that line the child's answer is not evidence about the child, and
+    // reporting it `correct` would write a MASTERED signal into a record on the
+    // strength of something the game printed. So the question is closed with
+    // `skip`, which the contract defines as "records nothing, moves no ladder,
+    // produces no outcome" — the only neutral option there is. Reporting a MISS
+    // instead would be a hint that costs, which is forbidden outright, and
+    // reporting a HIT would quietly climb a stuck child into harder items.
+    //
+    // Nothing about this is visible from inside the game: the ceremony fires,
+    // OPENED goes up, the chain goes up, BEST can be beaten.
+    const given = this.hint(now)?.given === true
+
     // Once per question. A refusal spends the id — the resonator stays as a
     // goal the child can still open, but the host hears one answer, which is
     // the only honest reading of "what did they say when they were asked".
     const first = !res.reported
     if (first) {
       res.reported = true
-      this.host.report({
-        questionId: res.questionId,
-        correct: verdict.kind === "open",
-        ms: Math.max(0, Math.round(now - this.askedAt)),
-        answered: String(verdict.asserted),
-      })
+      if (given) {
+        this.host.skip?.(res.questionId)
+      } else {
+        this.host.report({
+          questionId: res.questionId,
+          correct: verdict.kind === "open",
+          ms: Math.max(0, Math.round(now - this.askedAt)),
+          answered: String(verdict.asserted),
+        })
+      }
     }
 
     if (verdict.kind === "refuse") {
@@ -590,7 +651,15 @@ export class Arena {
     const tiles = this.bank.release()
     this.opened += 1
     this.chain += 1
-    this.ladder.opened()
+    // The ladder does not climb on an answer the game handed over.
+    //
+    // This is not a penalty — it is the absence of one. `opened()` is three
+    // rungs harder next time, and pushing a child who had just been shown the
+    // answer into harder arithmetic is the one way a hint could quietly cost
+    // them something. So the game holds its position and asks again at the
+    // level they are actually working at. A refusal still falls, because
+    // falling is the direction that makes the next one kinder.
+    if (!given) this.ladder.opened()
     this.host.haptic("success")
     const events: ArenaEvent[] = [{ kind: "open", at, target: res.target, tiles }]
     // Only ever after something the child finished. Never after a refusal.
@@ -749,9 +818,106 @@ export class Arena {
     return events
   }
 
-  /** Milliseconds the child has had with the current resonator. */
+  /**
+   * Milliseconds the child has had with the current resonator.
+   *
+   * Frozen behind a sheet. `resume` shifts `askedAt` forward by exactly the
+   * sheet, so this was already right *after* one — but during one it kept
+   * climbing, and now that the hint reads it, a sheet held for a minute would
+   * have shown two more stages of tree behind the card and none of them would
+   * have made a sound. A child comes back to the tree they left.
+   */
   elapsed(now: number): number {
-    return Math.max(0, now - this.askedAt)
+    return Math.max(0, (this.paused ? this.pausedAt : now) - this.askedAt)
+  }
+
+  // ── the hint ─────────────────────────────────────────────────────────────
+
+  /**
+   * Which stage the hint stands at right now.
+   *
+   * The maximum of what the quiet has reached and what the child has asked for,
+   * and that `max` is the entire state machine: a tap runs ahead of the schedule
+   * and the schedule catches up silently behind it, so a tap can never be
+   * followed a second later by an automatic stage landing on top of it, and
+   * there is no timer to cancel, restart or leak.
+   *
+   * `elapsed` is measured from `askedAt`, which `resume` already shifts by
+   * exactly the length of a host sheet — so time spent behind a paywall card, a
+   * parent gate or the how-to-play panel does not spend a child's thinking
+   * quiet. That was free; it is worth saying out loud because it is the kind of
+   * thing that is only ever noticed when it is wrong.
+   */
+  private hintStage(now: number): number {
+    const tree = this.hintTree
+    if (!tree || !this.resonator) return 0
+    const cap = stageCount(tree)
+    return Math.min(cap, Math.max(scheduledStage(this.elapsed(now), this.hintItem), this.hintTaps))
+  }
+
+  /**
+   * The hint as it stands, for the renderer. `null` when there is nothing to
+   * hint about or when the tree has not been offered yet.
+   */
+  hint(now: number): HintState | null {
+    const tree = this.hintTree
+    if (!tree) return null
+    const stage = this.hintStage(now)
+    if (stage <= 0) return null
+    const shown = shownAt(tree, stage)
+    return {
+      placed: tree,
+      stage,
+      stages: stageCount(tree),
+      shown,
+      given: revealsAnswer(tree, shown),
+    }
+  }
+
+  /**
+   * The child asked. Unfold one more stage, right now.
+   *
+   * Always allowed, always free, and it never runs out in a way that reads as
+   * refusal: at the last stage this is simply a no-op and the tree is already
+   * everything it has. Nothing is counted, nothing is spent, and no other rule
+   * in this file reads `hintTaps`.
+   */
+  askHint(now: number): ArenaEvent[] {
+    if (this.paused) return []
+    const tree = this.hintTree
+    const res = this.resonator
+    if (!tree || !res) return []
+    const cap = stageCount(tree)
+    const at = this.hintStage(now)
+    if (at >= cap) return []
+    this.hintTaps = at + 1
+    return this.unfold(now)
+  }
+
+  /**
+   * Has the hint moved on its own? Called by the shell every frame.
+   *
+   * A derived stage needs an edge detector somewhere for the sound and the
+   * ripple to fire once rather than every frame, and this is it. It decides
+   * nothing: `hint()` would return the same thing whether or not this is ever
+   * called.
+   */
+  unfold(now: number): ArenaEvent[] {
+    if (this.paused) return []
+    const res = this.resonator
+    if (!res || !this.hintTree) return []
+    const stage = this.hintStage(now)
+    if (stage === this.hintSeen) return []
+    this.hintSeen = stage
+    if (stage <= 0) return []
+    return [
+      {
+        kind: "hint",
+        at: { x: res.x, y: res.y },
+        stage,
+        stages: stageCount(this.hintTree),
+      },
+    ]
   }
 
   // ── seeding ──────────────────────────────────────────────────────────────
@@ -793,6 +959,11 @@ export class Arena {
    */
   private arm(now: number): ArenaEvent[] {
     this.askedAt = now
+    // A new question starts in silence, however much of the last one's tree was
+    // on the screen a moment ago.
+    this.hintTree = null
+    this.hintTaps = 0
+    this.hintSeen = 0
     const wall = this.sinceWall >= WALL_EVERY - 1
     let question: Question | null = null
     let landedAt = this.ladder.at
@@ -885,6 +1056,16 @@ export class Arena {
     const target = Number(question.answer)
     this.sinceWall = isPrime(target) ? 0 : this.sinceWall + 1
     const wanted = primeFactors(target)
+
+    // The tree the hint will be drawn from, built now and never rebuilt.
+    //
+    // Off a *fork* of the generator rather than the generator itself: the tree
+    // must be a deterministic function of the target and the seed, and it must
+    // not shift the husk layout, the drift or the chaff by one draw — otherwise
+    // adding a hint system would silently re-roll every seeded field in the
+    // suite and in every child's session.
+    this.hintTree = placeTree(factorTree(target, this.rng.fork(target)))
+    this.hintItem = itemOf(target, landedAt)
     const values = huskify(wanted, this.rng)
 
     // One reachable mal-rule: the primes it needs that the answer does not
@@ -918,6 +1099,7 @@ export class Arena {
       questionId: question.id,
       prompt: question.prompt,
       target,
+      difficulty: landedAt,
       x: this.width / 2,
       y: this.height * 0.26,
       vx: this.rng.range(-26, 26) * this.span,

--- a/dynawalla/games/lattice/src/game/hint.ts
+++ b/dynawalla/games/lattice/src/game/hint.ts
@@ -26,8 +26,14 @@
 //   2. **ONE PRIME.** The largest leaf lights. In `112 = 2·2·2·2·7` that is the
 //      `7` — the one a child sweeping twos will never stumble into.
 //   3. **HALF A SPLIT.** The smaller of the root's two children lights, and its
-//      sibling stays blank. This is the founder's `129 ⟶ 3 and ⟶ ?` exactly. It
-//      is the last stage that does **not** state the answer.
+//      sibling stays blank — the founder's `129 ⟶ 3 and ⟶ ?`. On most trees this
+//      is the last picture that does not state the answer.
+//
+//      On about three composites in ten it is not, and 129 is one of them: its
+//      tree is `3 · 43`, and 43 is both the largest leaf (stage 2) and the larger
+//      root child, so this stage lights both halves at once. That is why nothing
+//      here is keyed to a stage number — `freeStages` walks the tree and
+//      `revealsAnswer` reads the picture. See both.
 //   4. **THE PARTIAL.** The sibling lights too: `16 × 7`, with the root still
 //      blank. The stepping stone. From here the answer is on the screen — in a
 //      form the child finishes themselves, which is the point.
@@ -201,8 +207,10 @@ export function stageCount(placed: Placed): number {
  * one prime, half of the first split. But when the largest leaf *is* the larger
  * of the root's two children, stage 3 lights both halves of the split and
  * crosses a stage early: `129 → 3 · 43` is one of them, and so is `28 → 4 · 7`.
- * Across the band that is 120 of the 573 composite targets, so a hardcoded 3
- * would be wrong for one target in five.
+ * Measured over the whole band — 573 targets the resonator can put up, of which
+ * 410 are composite — that is between 112 and 123 of the 410 depending on the
+ * seed, so **roughly three composites in ten**. A hardcoded 3 would be wrong for
+ * about a third of them.
  *
  * For a wall it is one: the silhouette of a single node, which says "this one
  * does not come apart, go and find it" and is the whole of what a wall's hint

--- a/dynawalla/games/lattice/src/game/hint.ts
+++ b/dynawalla/games/lattice/src/game/hint.ts
@@ -41,26 +41,47 @@
 // hint for a wall, because the only hold that opens a prime is the single mote
 // carrying it and the whole task is knowing which mote to hunt.
 //
-// ## What a hint costs
+// ## What a hint costs: nothing, and that had to be checked at the wire
 //
-// Nothing the child can see, ever. Not a point, not the chain, not the BEST
-// counter, not the ceremony when the resonator opens, and there is no counter
-// anywhere that says how many hints were taken. There is no language about
-// needing help. The tree simply arrives.
+// Not a point, not the chain, not the BEST counter, not the ceremony when the
+// resonator opens. No counter anywhere says how many hints were taken and no
+// string anywhere mentions needing help. The tree simply arrives.
 //
-// What it does change is what the **host** is told. Once the revealed nodes
-// determine the root — stage 4 for a composite, stage 2 for a wall — the game
-// has put the answer to `642 − 530` on the screen, and a `correct` report
-// against that question would be a claim about the child that is not true.
-// `arena.enter` closes those with `host.skip` instead, which the contract
-// defines as "records nothing, moves no ladder, produces no outcome". That is
-// the honest reading and it is invisible from inside the game.
+// **The version of this that shipped in review got it wrong, and it is worth
+// writing down why.** The reasoning was: once the tree states the answer, a
+// `correct` report is a claim about the child that is not true, so close the
+// question with `host.skip` — "records nothing, moves no ladder, produces no
+// outcome" — instead. Honest, and invisible from inside the canvas.
 //
-// ## The clock is not a clock
+// It is not invisible three pixels above it. `game-host` says of `skip`, in as
+// many words, that it "does not advance the session progress fraction, because
+// that counts answered questions", and the host paints that fraction as a
+// full-width hairline across the top of every pack. Measured on a seeded run
+// that took the hint to the end five times: five resonators opened, five
+// ceremonies, `OPENED 5` — and the progress bar still on nought. **The child who
+// leans on the hint is the child this feature exists for, and their progress bar
+// was the one that never moved.** That is a punishment, delivered by the one
+// persistent indicator on the screen, and it is exactly what the founder ruled
+// out. So the report goes to the host as it always did.
+//
+// What is left of the concern is handled where the game actually owns the
+// decision: `arena.enter` does **not** climb its own ladder on a resonator whose
+// tree stated the answer. Three rungs of harder arithmetic next time is the one
+// thing a hint could still take, and holding position is the absence of a
+// penalty rather than one.
+//
+// ## The clock never crosses the line, and it is not a clock
 //
 // Hints also arrive on their own, and a struggling child must never see a timer.
 // There is no countdown, no ring filling, no "hint in 3", no banner. The tree
 // fades in the way the sheet ripples: something happened, and it was warm.
+//
+// **And the clock stops at `freeStages`** — the last picture that does not state
+// the answer. Time alone will show a child the shape of the tree and one prime
+// and half of the first split, and then it stops and the control glows. Going
+// further is something a child does on purpose, with a thumb. Nothing that
+// happens to a child who is merely sitting there can reach the stage that holds
+// this pack's own ladder still.
 //
 // The quiet before the first one is `firstHintMs`, and it is held to the same
 // law the fleet holds an answer window to — **a pure function of the item, and
@@ -110,16 +131,14 @@ export const HINT_DWELL_PER_RUNG_MS = 6_000
  * The gap between one stage and the next, as a fraction of the first quiet.
  *
  * **Longer than the first quiet, and that is the opposite of what warmth would
- * suggest.** The reason is the line in `revealsAnswer`: the first three stages
- * cost nothing at all — a silhouette, one prime, half a split — and the fourth
- * puts the answer on the screen and takes the item out of the child's record
- * with it. So the offer of help comes quickly, and the part of it that spends
- * something is unhurried. Mid-band that is a silhouette at 35s, a prime at 65s,
- * half a split at 95s, and the partial at about two minutes — by which point a
- * child has genuinely stopped and the record is the least of it.
+ * suggest.** The clock has only `freeStages` to give — the silhouette, one
+ * prime, and usually half of the first split — and once it has given them it
+ * stops. Spending them slowly is what makes each one a separate thing that
+ * happened rather than a panel unfolding at a child who has looked away.
+ * Mid-band that is a silhouette at 35s, a prime at 65s and half a split at 95s,
+ * and then the control glows and the rest is the child's to ask for.
  *
- * A child who wants it faster taps four times and has it in four seconds, which
- * is the path this is a fallback for.
+ * A child who wants it faster taps, and has the whole tree in four seconds.
  */
 export const HINT_STEP_FRACTION = 0.85
 
@@ -171,6 +190,32 @@ export function scheduledStage(elapsedMs: number, item: HintItem): number {
 /** How many stages this tree has. A wall has two; everything else has six. */
 export function stageCount(placed: Placed): number {
   return placed.nodes.length <= 1 ? WALL_STAGES : HINT_STAGES
+}
+
+/**
+ * The last stage the **clock** may reach on its own: the largest one whose
+ * picture does not determine the root.
+ *
+ * Computed from the tree rather than fixed at a number, because which stage
+ * crosses the line depends on the shape. Usually it is three — the silhouette,
+ * one prime, half of the first split. But when the largest leaf *is* the larger
+ * of the root's two children, stage 3 lights both halves of the split and
+ * crosses a stage early: `129 → 3 · 43` is one of them, and so is `28 → 4 · 7`.
+ * Across the band that is 120 of the 573 composite targets, so a hardcoded 3
+ * would be wrong for one target in five.
+ *
+ * For a wall it is one: the silhouette of a single node, which says "this one
+ * does not come apart, go and find it" and is the whole of what a wall's hint
+ * can honestly be without simply printing the number.
+ */
+export function freeStages(placed: Placed): number {
+  const cap = stageCount(placed)
+  let last = 0
+  for (let stage = 1; stage <= cap; stage++) {
+    if (revealsAnswer(placed, shownAt(placed, stage))) break
+    last = stage
+  }
+  return last
 }
 
 /**

--- a/dynawalla/games/lattice/src/game/hint.ts
+++ b/dynawalla/games/lattice/src/game/hint.ts
@@ -1,0 +1,325 @@
+// THE HINT — the tree, unfolded a little at a time.
+//
+// The founder's report, verbatim, is the specification:
+//
+// > "Trying to look at 642 − 530 and know that 2×2×2×2×7 = 112 is a pretty
+// > heroic task. But, if we could show the factorization tree as a dazzling
+// > hint … perhaps in a cool way like leaving some of the leaves blank or …
+// > maybe giving a partial like 16*7=112 … right now it's easy to get stuck and
+// > overwhelmed but … it could be OK to basically reveal the answer in a really
+// > satisfying way."
+//
+// Two hard steps are stacked in this game and nothing separated them: work out
+// `642 − 530`, *then* work out that the answer is four twos and a seven. A child
+// who can do the first and not the second is stuck with no way forward and no
+// way to ask, and the arena's only response was to keep drifting.
+//
+// ## The escalation
+//
+// Six stages for a composite, and each one is a *masking* of the same tree — the
+// tree never changes, only how much of it carries a numeral.
+//
+//   1. **THE SHAPE.** The tree appears with every node blank. It says nothing
+//      arithmetical at all and it says the single most useful thing: *how many
+//      pieces the hold needs*, and how they come apart. A child hunting for a
+//      fourth prime that does not exist is unstuck by this alone.
+//   2. **ONE PRIME.** The largest leaf lights. In `112 = 2·2·2·2·7` that is the
+//      `7` — the one a child sweeping twos will never stumble into.
+//   3. **HALF A SPLIT.** The smaller of the root's two children lights, and its
+//      sibling stays blank. This is the founder's `129 ⟶ 3 and ⟶ ?` exactly. It
+//      is the last stage that does **not** state the answer.
+//   4. **THE PARTIAL.** The sibling lights too: `16 × 7`, with the root still
+//      blank. The stepping stone. From here the answer is on the screen — in a
+//      form the child finishes themselves, which is the point.
+//   5. **THE LEAVES.** Every leaf lights. The hold is now spelled out and the
+//      child can simply go and get it. Nobody is stuck past this point.
+//   6. **THE WHOLE TREE.** Every node, root included. `112` at the top of its
+//      own tree, and the sentence closes.
+//
+// A prime target — the wall — has no tree, so it has two stages: the blank
+// silhouette of one lonely node, and then the numeral. That is the correct
+// hint for a wall, because the only hold that opens a prime is the single mote
+// carrying it and the whole task is knowing which mote to hunt.
+//
+// ## What a hint costs
+//
+// Nothing the child can see, ever. Not a point, not the chain, not the BEST
+// counter, not the ceremony when the resonator opens, and there is no counter
+// anywhere that says how many hints were taken. There is no language about
+// needing help. The tree simply arrives.
+//
+// What it does change is what the **host** is told. Once the revealed nodes
+// determine the root — stage 4 for a composite, stage 2 for a wall — the game
+// has put the answer to `642 − 530` on the screen, and a `correct` report
+// against that question would be a claim about the child that is not true.
+// `arena.enter` closes those with `host.skip` instead, which the contract
+// defines as "records nothing, moves no ladder, produces no outcome". That is
+// the honest reading and it is invisible from inside the game.
+//
+// ## The clock is not a clock
+//
+// Hints also arrive on their own, and a struggling child must never see a timer.
+// There is no countdown, no ring filling, no "hint in 3", no banner. The tree
+// fades in the way the sheet ripples: something happened, and it was warm.
+//
+// The quiet before the first one is `firstHintMs`, and it is held to the same
+// law the fleet holds an answer window to — **a pure function of the item, and
+// monotone non-decreasing in the item's difficulty.** No speed, no elapsed time,
+// no streak, no reading of how the child is doing goes into it. A harder item
+// buys *more* silence, never less, because a hint arriving sooner on a harder
+// problem is the game saying it does not think you can do this one.
+//
+// (THE LATTICE has no answer window and this does not add one. Nothing here is
+// ever a deadline: past the last stage the tree simply sits there, complete.)
+
+import { primeFactors } from "./factor.ts"
+import type { Placed } from "./tree.ts"
+
+/** Stages a composite target unfolds through. See the list above. */
+export const HINT_STAGES = 6
+
+/** Stages a prime target — the wall — unfolds through: the shape, then the numeral. */
+export const WALL_STAGES = 2
+
+/**
+ * The quiet a child gets with a *new* item before the game offers anything, and
+ * what it is allowed to depend on.
+ *
+ * `HINT_DWELL_MS` is the floor. `PER_TILE` buys silence for a hold with more
+ * pieces in it — five motes is more flying than three, and a child mid-sweep is
+ * working, not stuck. `PER_RUNG` buys silence for a harder rung on the host's
+ * ladder.
+ *
+ * Both coefficients are **non-negative**, which is the whole proof of the
+ * monotonicity law: `firstHintMs` is a sum of non-negative multiples of the
+ * item's own difficulty signals, so it cannot decrease when either of them
+ * rises. `hint.test.ts` asserts it exhaustively rather than taking the argument
+ * on trust.
+ *
+ * A mid-band item — five primes, two thirds of the way up the game's band — gets
+ * about thirty-five seconds of silence. That is roughly seven times what the
+ * perfect bot in `pacing.test.ts` needs for a whole round and comfortably longer
+ * than a child who is getting on with it, so the first offer lands on a child
+ * who has stopped rather than on one who is working.
+ */
+export const HINT_DWELL_MS = 22_000
+export const HINT_DWELL_PER_TILE_MS = 2_000
+export const HINT_DWELL_PER_RUNG_MS = 6_000
+
+/**
+ * The gap between one stage and the next, as a fraction of the first quiet.
+ *
+ * **Longer than the first quiet, and that is the opposite of what warmth would
+ * suggest.** The reason is the line in `revealsAnswer`: the first three stages
+ * cost nothing at all — a silhouette, one prime, half a split — and the fourth
+ * puts the answer on the screen and takes the item out of the child's record
+ * with it. So the offer of help comes quickly, and the part of it that spends
+ * something is unhurried. Mid-band that is a silhouette at 35s, a prime at 65s,
+ * half a split at 95s, and the partial at about two minutes — by which point a
+ * child has genuinely stopped and the record is the least of it.
+ *
+ * A child who wants it faster taps four times and has it in four seconds, which
+ * is the path this is a fallback for.
+ */
+export const HINT_STEP_FRACTION = 0.85
+
+/** The item a hint is about. Everything `firstHintMs` is allowed to read. */
+export type HintItem = {
+  /** The rung that served it, 0..1. Not a claim about the child. */
+  readonly difficulty: number
+  /** How many primes the answer's hold is. */
+  readonly tiles: number
+}
+
+/** The item, read off a target and the rung it came from. Pure. */
+export function itemOf(target: number, difficulty: number): HintItem {
+  return { difficulty, tiles: primeFactors(target).length }
+}
+
+/**
+ * How long the game stays quiet before the first hint.
+ *
+ * **Pure in the item, monotone non-decreasing in difficulty and in tiles.**
+ * Nothing else is in scope here — not the clock, not the ship's speed, not how
+ * many resonators have been refused, not the chain. Two calls with the same item
+ * return the same number for the whole life of the process.
+ */
+export function firstHintMs(item: HintItem): number {
+  const difficulty = Number.isFinite(item.difficulty)
+    ? Math.max(0, Math.min(1, item.difficulty))
+    : 0
+  const tiles = Number.isFinite(item.tiles) ? Math.max(0, item.tiles) : 0
+  return HINT_DWELL_MS + HINT_DWELL_PER_TILE_MS * tiles + HINT_DWELL_PER_RUNG_MS * difficulty
+}
+
+/**
+ * Which stage the clock alone has reached after `elapsedMs` with this item.
+ *
+ * `0` is "no hint at all", and it is where a child who is getting on with it
+ * spends the whole round. Note what is *not* here: nothing about how fast the
+ * child is, nothing about whether they have refused, nothing that could read as
+ * the game losing patience.
+ */
+export function scheduledStage(elapsedMs: number, item: HintItem): number {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return 0
+  const first = firstHintMs(item)
+  if (elapsedMs < first) return 0
+  const step = Math.max(1, first * HINT_STEP_FRACTION)
+  return 1 + Math.floor((elapsedMs - first) / step)
+}
+
+/** How many stages this tree has. A wall has two; everything else has six. */
+export function stageCount(placed: Placed): number {
+  return placed.nodes.length <= 1 ? WALL_STAGES : HINT_STAGES
+}
+
+/**
+ * Which nodes carry a numeral at `stage`. Everything else is drawn blank.
+ *
+ * Pure and deterministic — no `Rng`, so the same tree at the same stage is the
+ * same picture every time, which is what makes the escalation testable and what
+ * stops a redraw shuffling the blanks around under a child's eyes.
+ */
+export function shownAt(placed: Placed, stage: number): Set<number> {
+  const out = new Set<number>()
+  if (stage < 2 || placed.nodes.length === 0) return out
+
+  // Stage 2 — the largest leaf. The surprising one: the 7 in 112, the 5 in 60.
+  // A child sweeping twos would never have guessed it was in there.
+  out.add(largestLeaf(placed))
+  if (stage < 3) return out
+
+  const root = placed.nodes[0]
+  const kids = root?.kids ?? null
+  if (kids) {
+    const a = placed.nodes[kids[0]]?.value ?? 0
+    const b = placed.nodes[kids[1]]?.value ?? 0
+    // Stage 3 — half of the first split, the smaller side. `129 ⟶ 3 and ⟶ ?`.
+    out.add(a <= b ? kids[0] : kids[1])
+    // Stage 4 — the other half. `16 × 7`, and the root still blank.
+    if (stage >= 4) out.add(a <= b ? kids[1] : kids[0])
+  }
+  if (stage < 5) return out
+
+  // Stage 5 — every leaf. The hold, spelled out. Nobody is stuck past here.
+  for (const leaf of placed.leaves) out.add(leaf)
+  if (stage < 6) return out
+
+  // Stage 6 — the whole tree, root included. The sentence closes.
+  for (let i = 0; i < placed.nodes.length; i++) out.add(i)
+  return out
+}
+
+/**
+ * The index of the biggest leaf, leftmost on a tie.
+ *
+ * Deterministic on purpose. The first numeral a child is given should be the one
+ * they were least likely to find on their own, and in a factorisation that is
+ * always the largest prime — the 7 under four twos, the 5 under `2·2·3·5`.
+ */
+function largestLeaf(placed: Placed): number {
+  let best = placed.leaves[0] ?? 0
+  let bestValue = placed.nodes[best]?.value ?? 0
+  for (const index of placed.leaves) {
+    const value = placed.nodes[index]?.value ?? 0
+    if (value > bestValue) {
+      bestValue = value
+      best = index
+    }
+  }
+  return best
+}
+
+/**
+ * Do the revealed nodes pin the root down?
+ *
+ * True when the root is shown, or when both of its children are determined, all
+ * the way down — which is exactly "there is a set of visible numbers on screen
+ * whose product is the answer". This is the line `arena.enter` uses to decide
+ * whether the host is told anything at all, and it is computed from the picture
+ * rather than hardcoded to a stage number, because the stage a tree reaches that
+ * line at depends on its shape: a wall crosses it at stage 2.
+ */
+export function revealsAnswer(placed: Placed, shown: ReadonlySet<number>): boolean {
+  if (placed.nodes.length === 0) return false
+  const determined = (index: number): boolean => {
+    if (shown.has(index)) return true
+    const kids = placed.nodes[index]?.kids ?? null
+    if (!kids) return false
+    return determined(kids[0]) && determined(kids[1])
+  }
+  return determined(0)
+}
+
+/**
+ * How slowly a reveal unfolds, in milliseconds between one node lighting and
+ * the next.
+ *
+ * **This is the only thing in the hint system that reads the child at all**, and
+ * it reads the chain rather than a clock. At the bottom the reveal is long and
+ * calm — a child who is finding this hard gets to watch each piece arrive, and
+ * that watching is most of the value. On a chain the same reveal snaps into
+ * place in a couple of frames, because a child who is flying does not want a
+ * ceremony in front of their arena and skipping it is the reward for mastery.
+ *
+ * It changes nothing about *what* is revealed or *when* — only how it lands.
+ * Monotone non-increasing in the chain, and `hint.test.ts` asserts that.
+ */
+export const REVEAL_PACE_CALM_MS = 240
+export const REVEAL_PACE_FAST_MS = 24
+export const REVEAL_PACE_CHAIN = 6
+
+export function revealPaceMs(chain: number): number {
+  const c = Number.isFinite(chain) ? Math.max(0, chain) : 0
+  const t = Math.min(1, c / REVEAL_PACE_CHAIN)
+  return REVEAL_PACE_CALM_MS + (REVEAL_PACE_FAST_MS - REVEAL_PACE_CALM_MS) * t
+}
+
+/**
+ * Which lit leaves the child is already carrying — the maths moment, as a set.
+ *
+ * This is the beat the whole hint is for: the tree says `2 · 2 · 2 · 2 · 7`, the
+ * child sweeps a 2, and one of the four twos on the tree clicks into place with
+ * a spark. The factorisation assembling itself is the celebration, rather than
+ * the resonator opening thirty seconds later.
+ *
+ * A multiset walk and not an `includes`, and that is the whole reason this is a
+ * function in this file rather than four lines inside the renderer: a tree with
+ * four twos in it and a hold with two twos must collar exactly *two* of them.
+ * Collar all four and the picture says the hold is finished when it is half
+ * finished, which is a hint that lies — and a child who trusts it flies into the
+ * ring and is refused.
+ *
+ * Blank leaves are never collared. Marking a `?` as "you already have this one"
+ * would leak which prime it is, one stage early, for free.
+ */
+export function heldLeaves(
+  placed: Placed,
+  shown: ReadonlySet<number>,
+  tiles: readonly number[],
+): Set<number> {
+  const spare = new Map<number, number>()
+  for (const tile of tiles) spare.set(tile, (spare.get(tile) ?? 0) + 1)
+  const out = new Set<number>()
+  for (const index of placed.leaves) {
+    if (!shown.has(index)) continue
+    const value = placed.nodes[index]?.value ?? 0
+    const left = spare.get(value) ?? 0
+    if (left <= 0) continue
+    spare.set(value, left - 1)
+    out.add(index)
+  }
+  return out
+}
+
+/** The hint as it stands, handed to the renderer whole. */
+export type HintState = {
+  readonly placed: Placed
+  /** 0 = nothing drawn. 1 = the blank silhouette. Up to `stages`. */
+  readonly stage: number
+  readonly stages: number
+  /** Indices into `placed.nodes` that carry a numeral. */
+  readonly shown: ReadonlySet<number>
+  /** Whether what is drawn already determines the answer. */
+  readonly given: boolean
+}

--- a/dynawalla/games/lattice/src/game/tree.ts
+++ b/dynawalla/games/lattice/src/game/tree.ts
@@ -1,0 +1,159 @@
+// THE FACTOR TREE — the shape the hint is drawn from.
+//
+// `72` hangs at the top. Under it, `8` and `9`. Under the `8`, `2` and `4`;
+// under the `4`, `2` and `2`. It is the same object the arena already makes a
+// child build with a trigger finger — `splitPair` is the very function a shot
+// uses — except that here the whole thing is built at once, in memory, so it
+// can be drawn.
+//
+// **Nothing in this file is allowed to lie.** A hint that shows a tree whose
+// leaves do not multiply back to its root is worse than no hint at all: a child
+// would sweep exactly what they were shown, fly into the resonator, and be
+// refused by a game that told them to do it. `hint.test.ts` therefore checks the
+// generator as a *property*, over every target the ladder can serve and many
+// seeds: every node is the exact product of its two children, every leaf is
+// prime, and the leaves are exactly `primeFactors(root)`.
+//
+// Everything here is integer arithmetic on values under 1000, and there is no
+// clock, no canvas and no randomness beyond the seeded `Rng` handed in.
+
+import type { Rng } from "../core/rng.ts"
+import { isPrime, primeFactors, productOf, splitPair } from "./factor.ts"
+
+export type TreeNode = {
+  readonly value: number
+  /** `null` at a prime. A prime does not go — that is the whole game. */
+  readonly children: readonly [TreeNode, TreeNode] | null
+}
+
+/**
+ * Build the factor tree of `n`.
+ *
+ * The splits come from `splitPair`, which is the arena's own: it prefers the
+ * pair nearest the square root, so the tree is balanced rather than a stalk and
+ * `72` comes apart as `8 × 9` instead of `2 × 36`. That matters twice over — a
+ * balanced tree is shallower, so it fits on a phone, and it is the shape the
+ * child has been watching husks make all session.
+ *
+ * A prime returns a single node with no children, which is not a degenerate
+ * case to be guarded around: it is the wall, and drawing it as one lonely
+ * numeral with nothing under it is the clearest statement of the wall the game
+ * can make.
+ */
+export function factorTree(n: number, rng: Rng): TreeNode {
+  if (!Number.isInteger(n) || n < 2) {
+    // Loud rather than silent. Every caller draws from `primeFactors`-legal
+    // targets, so this is a wiring mistake if it ever happens.
+    console.error("[lattice] a factor tree was asked for of something that is not a number ≥ 2", n)
+    return { value: 2, children: null }
+  }
+  const pair = splitPair(n, rng)
+  if (!pair) return { value: n, children: null }
+  return { value: n, children: [factorTree(pair[0], rng), factorTree(pair[1], rng)] }
+}
+
+/** The leaves, left to right. By construction these are exactly the primes. */
+export function leavesOf(node: TreeNode): number[] {
+  if (!node.children) return [node.value]
+  return [...leavesOf(node.children[0]), ...leavesOf(node.children[1])]
+}
+
+/**
+ * A tree flattened into rows and columns, ready to be drawn.
+ *
+ * `u` is a horizontal position in **leaf slots**, not pixels: leaves take
+ * consecutive slots left to right and every parent sits at the midpoint of its
+ * two children, which is the ordinary tidy-tree layout and the reason the
+ * drawing never has to measure anything. The renderer scales `u` and `depth`
+ * into whatever box it was given.
+ */
+export type PlacedNode = {
+  readonly value: number
+  readonly prime: boolean
+  /** Rows from the root. The root is 0. */
+  readonly depth: number
+  /** Horizontal position in leaf slots, `0 .. columns - 1`. */
+  readonly u: number
+  /** Index of this node's parent, or `-1` at the root. */
+  readonly parent: number
+  /** Indices of this node's two children, or `null` at a leaf. */
+  readonly kids: readonly [number, number] | null
+}
+
+export type Placed = {
+  /** Pre-order: the root is always index 0. */
+  readonly nodes: readonly PlacedNode[]
+  /** How many leaf slots wide the tree is. */
+  readonly columns: number
+  /** How many rows deep it is. */
+  readonly rows: number
+  /** Indices of the leaves, left to right. */
+  readonly leaves: readonly number[]
+}
+
+export function placeTree(root: TreeNode): Placed {
+  type Mutable = { -readonly [K in keyof PlacedNode]: PlacedNode[K] }
+  const nodes: Mutable[] = []
+  const leaves: number[] = []
+  let slot = 0
+  let deepest = 0
+
+  const walk = (node: TreeNode, depth: number, parent: number): number => {
+    const index = nodes.length
+    nodes.push({
+      value: node.value,
+      prime: isPrime(node.value),
+      depth,
+      u: 0,
+      parent,
+      kids: null,
+    })
+    if (depth > deepest) deepest = depth
+    const self = nodes[index] as Mutable
+    if (!node.children) {
+      self.u = slot
+      slot += 1
+      leaves.push(index)
+      return index
+    }
+    const a = walk(node.children[0], depth + 1, index)
+    const b = walk(node.children[1], depth + 1, index)
+    self.kids = [a, b]
+    self.u = ((nodes[a] as Mutable).u + (nodes[b] as Mutable).u) / 2
+    return index
+  }
+
+  walk(root, 0, -1)
+  return { nodes, columns: Math.max(1, slot), rows: deepest + 1, leaves }
+}
+
+/** The product of a placed tree's leaves. Should always be the root. */
+export function leafProduct(placed: Placed): number {
+  return productOf(placed.leaves.map((i) => (placed.nodes[i] as PlacedNode).value))
+}
+
+/**
+ * Is `n`'s tree the one the game would draw for it?
+ *
+ * Used by the property test rather than by the game: the leaves are exactly
+ * `primeFactors(n)` as a multiset, which is the one claim the whole hint rests
+ * on.
+ */
+export function treeIsHonest(n: number, root: TreeNode): boolean {
+  if (root.value !== n) return false
+  const want = primeFactors(n).slice().sort((a, b) => a - b)
+  const got = leavesOf(root).sort((a, b) => a - b)
+  if (want.length !== got.length) return false
+  for (let i = 0; i < want.length; i++) {
+    if (want[i] !== got[i]) return false
+  }
+  return everyNodeIsItsChildren(root)
+}
+
+function everyNodeIsItsChildren(node: TreeNode): boolean {
+  if (!node.children) return isPrime(node.value)
+  const [a, b] = node.children
+  if (a.value * b.value !== node.value) return false
+  if (a.value < 2 || b.value < 2) return false
+  return everyNodeIsItsChildren(a) && everyNodeIsItsChildren(b)
+}

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -459,6 +459,25 @@ export function mountLattice(
     }
   }
 
+  /**
+   * A gesture taken away rather than finished.
+   *
+   * `pointercancel` is the platform saying the touch is no longer the child's —
+   * an edge drag, a palm rejected, a system gesture claiming it — and it arrives
+   * carrying the last known coordinates, so it satisfies every test a real tap
+   * satisfies. Routed into `up` (which is what it was), a thumb that landed on
+   * the control and was then cancelled 200ms later unfolded a stage.
+   *
+   * That is not a small leak. The clock stops one stage short of the reveal, so
+   * on a question the child has been sitting with, the phantom stage IS the one
+   * that states the answer — an abandoned gesture crossing the exact line the
+   * whole design says only a deliberate tap may cross.
+   */
+  const cancel = (event: PointerEvent): void => {
+    hintPress = null
+    up(event)
+  }
+
   const up = (event: PointerEvent): void => {
     if (hintPress && hintPress.id === event.pointerId) {
       const press = hintPress
@@ -514,7 +533,7 @@ export function mountLattice(
   canvas.addEventListener("pointerdown", down)
   canvas.addEventListener("pointermove", move)
   canvas.addEventListener("pointerup", up)
-  canvas.addEventListener("pointercancel", up)
+  canvas.addEventListener("pointercancel", cancel)
   globalThis.addEventListener("keydown", keyDown)
   globalThis.addEventListener("keyup", keyUp)
   globalThis.addEventListener("resize", resize)
@@ -554,7 +573,7 @@ export function mountLattice(
       canvas.removeEventListener("pointerdown", down)
       canvas.removeEventListener("pointermove", move)
       canvas.removeEventListener("pointerup", up)
-      canvas.removeEventListener("pointercancel", up)
+      canvas.removeEventListener("pointercancel", cancel)
       globalThis.removeEventListener("keydown", keyDown)
       globalThis.removeEventListener("keyup", keyUp)
       globalThis.removeEventListener("resize", resize)

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -49,6 +49,17 @@ const MAX_STEP_MS = 120
 /** Grid density. Chosen so a tablet draws about 1,100 struts, not 10,000. */
 const GRID_CELL = 46
 
+/**
+ * What separates a tap on the hint control from a thumb landing on the stick.
+ *
+ * Ten pixels and four hundred milliseconds. A deliberate press of a 44px control
+ * is well inside both; a thumb settling at the bottom-left and then sliding to
+ * fly is outside one or the other every time, and a thumb that just *rests*
+ * there is outside the second one.
+ */
+const HINT_TAP_SLOP = 10
+const HINT_TAP_MS = 400
+
 type Stick = { id: number; ox: number; oy: number; x: number; y: number } | null
 
 export function mountLattice(
@@ -168,6 +179,16 @@ export function mountLattice(
 
   let moveStick: Stick = null
   let aimStick: Stick = null
+  /**
+   * A press that landed on the hint control and has not been released yet.
+   *
+   * `strayed` is set the moment the pointer leaves the slop radius and is never
+   * cleared, which is the difference between measuring the PATH and measuring
+   * the endpoints. A thumb swept round a circle and back to where it started has
+   * a zero endpoint distance — and that is exactly what a stick held in a circle
+   * does every single revolution.
+   */
+  let hintPress: { id: number; x: number; y: number; at: number; strayed: boolean } | null = null
   const keys = new Set<string>()
 
   function now(): number {
@@ -291,6 +312,7 @@ export function mountLattice(
   const dropSticks = (): void => {
     moveStick = null
     aimStick = null
+    hintPress = null
     firing = false
     mouseDown = false
     keys.clear()
@@ -342,11 +364,11 @@ export function mountLattice(
       // tree would be drawn identically whether or not this line existed. It is
       // inside the `held` guard because a hint must not unfold behind a sheet: a
       // child comes back to the tree they left, not to two more stages of it.
-      apply(arena.unfold(now()))
+      apply(arena.unfold())
       grid.step(dt)
       scene.advance(dt)
     }
-    scene.draw(arena, grid, { best, paused, stalled: arena.stalled, hint: arena.hint(now()) })
+    scene.draw(arena, grid, { best, paused, stalled: arena.stalled, hint: arena.hint() })
   }
 
   // ── pointers ─────────────────────────────────────────────────────────────
@@ -362,13 +384,20 @@ export function mountLattice(
     audio.resume()
     const p = at(event)
 
-    // Asking for the next piece of the factor tree. Checked before the sticks,
-    // like the tile bar, because the whole left half of the screen is otherwise
-    // a thumbstick — and checked before the bar because it is the smaller
-    // target of the two and sits directly above it.
+    // Asking for the next piece of the factor tree.
+    //
+    // **A press here is remembered, not acted on**, and the thumb goes on to
+    // drive the movement stick as if the control were not there. The first cut
+    // fired on pointer-DOWN and swallowed the touch, and the control sits at the
+    // bottom-left of the safe area — which on a phone is exactly where a left
+    // thumb comes to rest. A child settling their hand there got a tree they had
+    // not asked for AND a ship that would not move, from the same touch.
+    //
+    // So it fires on release, and only for a press that was a press: it must
+    // come up inside the control, must not have travelled, and must not have
+    // been held. Anything else was the child reaching for the stick.
     if (scene.hitsHint(p.x, p.y)) {
-      apply(arena.askHint(now()))
-      return
+      hintPress = { id: event.pointerId, x: p.x, y: p.y, at: now(), strayed: false }
     }
 
     // Tapping your own hold lets it go. The bank is exact, so a child who swept
@@ -402,6 +431,10 @@ export function mountLattice(
   const move = (event: PointerEvent): void => {
     if (paused || guide.isOpen) return
     const p = at(event)
+    if (hintPress && hintPress.id === event.pointerId && !hintPress.strayed) {
+      const travelled = Math.hypot(p.x - hintPress.x, p.y - hintPress.y)
+      if (travelled > HINT_TAP_SLOP) hintPress.strayed = true
+    }
     if (moveStick && moveStick.id === event.pointerId) {
       moveStick.x = p.x
       moveStick.y = p.y
@@ -427,6 +460,19 @@ export function mountLattice(
   }
 
   const up = (event: PointerEvent): void => {
+    if (hintPress && hintPress.id === event.pointerId) {
+      const press = hintPress
+      hintPress = null
+      const p = at(event)
+      const still = !press.strayed && Math.hypot(p.x - press.x, p.y - press.y) <= HINT_TAP_SLOP
+      const quick = now() - press.at <= HINT_TAP_MS
+      if (still && quick && scene.hitsHint(p.x, p.y)) {
+        // The touch was a tap on the control. It also created a movement stick
+        // on the way in, which is let go below like any other — a stick the
+        // child never moved has already been steering nothing.
+        apply(arena.askHint())
+      }
+    }
     if (event.pointerType === "mouse") mouseDown = false
     if (moveStick && moveStick.id === event.pointerId) {
       moveStick = null
@@ -451,7 +497,7 @@ export function mountLattice(
       audio.resume()
     }
     if (event.key === "Escape") apply(arena.vent())
-    if (event.key === "h" || event.key === "H") apply(arena.askHint(now()))
+    if (event.key === "h" || event.key === "H") apply(arena.askHint())
     if (event.key.startsWith("Arrow")) event.preventDefault()
   }
 

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -123,6 +123,15 @@ export function mountLattice(
         ],
       },
       {
+        heading: "The little tree button",
+        lines: [
+          "Above the bar on the left there is a round button with a tiny tree on it. Press it any time you like.",
+          "A factor tree grows above the bar. At first every number on it is hidden. Press again and one of them shows, then another, then all of them.",
+          "The glowing ones at the bottom of the tree are exactly the pieces to collect. If you wait a while, the tree starts showing itself.",
+          "It costs nothing. Use it as much as you want. On a keyboard, press H.",
+        ],
+      },
+      {
         heading: "If the ring says NOT YET",
         lines: [
           "Your pieces multiply to the wrong number. One extra 5 turns 72 into 360.",
@@ -229,6 +238,21 @@ export function mountLattice(
           grid.impulse(event.at.x, event.at.y, 260, 5)
           break
         }
+        case "hint": {
+          // Warm and small. No banner and no word — a hint that announced itself
+          // in language would be the game telling a child, in front of them, that
+          // it had noticed they were struggling. The sheet stirs under the ring
+          // the help is coming from, two notes rise, and the tree is there.
+          //
+          // The tick is `light`, the same one a mote gives when it is swept, and
+          // it is not decoration: an automatic hint arrives while a child is
+          // looking somewhere else in the arena, and a tree that fades in
+          // unnoticed at the bottom of the screen has helped nobody.
+          grid.impulse(event.at.x, event.at.y, 150, 3)
+          audio.hint(event.stage)
+          host.haptic("light")
+          break
+        }
         case "stalled": {
           console.error("[lattice] no askable target; the arena is running without a resonator")
           break
@@ -313,10 +337,16 @@ export function mountLattice(
       // future: it asks again a few seconds later, and this is the only place
       // that clock is read. Inert whenever there is a resonator.
       apply(arena.rearm(now()))
+      // Has the hint moved on its own? The stage is derived rather than timed,
+      // so this is only an edge detector for the sound and the ripple — the
+      // tree would be drawn identically whether or not this line existed. It is
+      // inside the `held` guard because a hint must not unfold behind a sheet: a
+      // child comes back to the tree they left, not to two more stages of it.
+      apply(arena.unfold(now()))
       grid.step(dt)
       scene.advance(dt)
     }
-    scene.draw(arena, grid, { best, paused, stalled: arena.stalled })
+    scene.draw(arena, grid, { best, paused, stalled: arena.stalled, hint: arena.hint(now()) })
   }
 
   // ── pointers ─────────────────────────────────────────────────────────────
@@ -331,6 +361,15 @@ export function mountLattice(
     if (paused || guide.isOpen) return
     audio.resume()
     const p = at(event)
+
+    // Asking for the next piece of the factor tree. Checked before the sticks,
+    // like the tile bar, because the whole left half of the screen is otherwise
+    // a thumbstick — and checked before the bar because it is the smaller
+    // target of the two and sits directly above it.
+    if (scene.hitsHint(p.x, p.y)) {
+      apply(arena.askHint(now()))
+      return
+    }
 
     // Tapping your own hold lets it go. The bank is exact, so a child who swept
     // a stray 5 needs a way out that is not "start again" — and nothing is
@@ -412,6 +451,7 @@ export function mountLattice(
       audio.resume()
     }
     if (event.key === "Escape") apply(arena.vent())
+    if (event.key === "h" || event.key === "H") apply(arena.askHint(now()))
     if (event.key.startsWith("Arrow")) event.preventDefault()
   }
 

--- a/dynawalla/games/lattice/src/render/hud.ts
+++ b/dynawalla/games/lattice/src/render/hud.ts
@@ -47,6 +47,19 @@ const HINT_GAP = 8
  */
 const TREE_SHARE = 0.36
 
+/**
+ * The least height the tree may be given, whatever else is competing for it.
+ *
+ * The deepest tree in the band is `512 = 2⁹`: five rows, which at the renderer's
+ * minimum node radius of 9 needs `4 × 19.5 + 18` = 96px exactly. Below that the
+ * rows overlap; below 18px the row step goes negative and the tree draws upside
+ * down. Ninety-six and not a round hundred, deliberately: at 1024×320 — a phone
+ * held sideways — the difference is whether the ceiling or the floor wins, and
+ * the ceiling winning is the outcome where the tree does not sit on the
+ * counters.
+ */
+const TREE_MIN_H = 96
+
 export type HudLayout = {
   /** `OPENED` / `CHAIN` on the left, `BEST` on the right, the stall notice centred. */
   readonly status: {
@@ -134,7 +147,11 @@ export function hudLayout(w: number, area: Rect): HudLayout {
   // gutter on its right, which also keeps it centred.
   const hintR = Math.max(22, Math.min(26, area.w / 14))
   const treeBottom = barTop - HINT_GAP
-  const hintCy = treeBottom - hintR
+  // Never above the host's two corner controls. On a pane a couple of hundred
+  // pixels tall the tile bar climbs high enough that the control's own row lands
+  // underneath the host's exit chevron, and a hint control a child cannot press
+  // because the host owns those pixels is a hint control that is not there.
+  const hintCy = Math.max(cornerBottom + hintR, treeBottom - hintR)
   const hintCx = area.x + SIDE + hintR
   const gutter = hintR * 2 + HINT_GAP
 
@@ -146,7 +163,19 @@ export function hudLayout(w: number, area: Rect): HudLayout {
   // no question, no tree and nothing to reserve for. Reserving it anyway cost
   // the tree twenty-five pixels it does not have on a phone held sideways.
   const treeCeiling = cornerBottom + size * 1.5 * 2
-  const treeTop = Math.max(treeCeiling, treeBottom - area.h * TREE_SHARE)
+  // Floored at `TREE_MIN_H`, and the floor wins over the ceiling.
+  //
+  // On a pane short enough that the counters and the tile bar meet in the middle
+  // — a 1024×200 Split View slice is the shape that produced it — the ceiling
+  // pushed `treeTop` *below* `treeBottom` and the box came out one pixel tall
+  // with a negative row step, which draws the tree upside down through the
+  // counters. Overlapping the counters slightly on a pane nothing can be read on
+  // anyway is the better of the two failures, and it is a failure the renderer
+  // survives.
+  const treeTop = Math.min(
+    treeBottom - TREE_MIN_H,
+    Math.max(treeCeiling, treeBottom - area.h * TREE_SHARE),
+  )
 
   return {
     status: {

--- a/dynawalla/games/lattice/src/render/hud.ts
+++ b/dynawalla/games/lattice/src/render/hud.ts
@@ -50,15 +50,19 @@ const TREE_SHARE = 0.36
 /**
  * The least height the tree may be given, whatever else is competing for it.
  *
- * The deepest tree in the band is `512 = 2⁹`: five rows, which at the renderer's
- * minimum node radius of 9 needs `4 × 19.5 + 18` = 96px exactly. Below that the
- * rows overlap; below 18px the row step goes negative and the tree draws upside
- * down. Ninety-six and not a round hundred, deliberately: at 1024×320 — a phone
- * held sideways — the difference is whether the ceiling or the floor wins, and
- * the ceiling winning is the outcome where the tree does not sit on the
- * counters.
+ * **This is a correctness floor and not a legibility one**, and the difference
+ * matters because the first attempt confused them. `scene.ts` lays the rows out
+ * as `rowStep = (h − 2r) / (rows − 1)` with `r` floored at 9, so `usedH` comes to
+ * exactly `h` for any `h ≥ 18` — a squashed tree is *tight*, not broken. Under
+ * 18 the step goes negative and the tree draws upside down.
+ *
+ * So the floor is 24, with margin, and everything above it is left to the
+ * ceiling. A floor set at what the deepest tree wants to be READ at — 96, which
+ * is what `512 = 2⁹` needs for five rows at nine pixels — wins against the
+ * ceiling on any pane under about 340px of safe height and draws the tree
+ * straight through OPENED and CHAIN. Two unreadable things beats one.
  */
-const TREE_MIN_H = 96
+const TREE_MIN_H = 24
 
 export type HudLayout = {
   /** `OPENED` / `CHAIN` on the left, `BEST` on the right, the stall notice centred. */
@@ -163,18 +167,18 @@ export function hudLayout(w: number, area: Rect): HudLayout {
   // no question, no tree and nothing to reserve for. Reserving it anyway cost
   // the tree twenty-five pixels it does not have on a phone held sideways.
   const treeCeiling = cornerBottom + size * 1.5 * 2
-  // Floored at `TREE_MIN_H`, and the floor wins over the ceiling.
+  // Three constraints, in the order they win.
   //
-  // On a pane short enough that the counters and the tile bar meet in the middle
-  // — a 1024×200 Split View slice is the shape that produced it — the ceiling
-  // pushed `treeTop` *below* `treeBottom` and the box came out one pixel tall
-  // with a negative row step, which draws the tree upside down through the
-  // counters. Overlapping the counters slightly on a pane nothing can be read on
-  // anyway is the better of the two failures, and it is a failure the renderer
-  // survives.
-  const treeTop = Math.min(
-    treeBottom - TREE_MIN_H,
-    Math.max(treeCeiling, treeBottom - area.h * TREE_SHARE),
+  //   * **Never above the safe area.** On a 1024×200 slice the floor below used
+  //     to push `treeTop` to −4 and the root row drew off the top of the canvas.
+  //   * **Then the floor**, which only exists so the row step cannot go negative
+  //     and draw the tree upside down. See `TREE_MIN_H`: it is 24, not 96.
+  //   * **Then the ceiling and the share.** The ceiling keeps the tree off the
+  //     counters and it wins wherever there is any room at all, which is every
+  //     pane above about 260px of safe height.
+  const treeTop = Math.max(
+    area.y,
+    Math.min(treeBottom - TREE_MIN_H, Math.max(treeCeiling, treeBottom - area.h * TREE_SHARE)),
   )
 
   return {

--- a/dynawalla/games/lattice/src/render/hud.ts
+++ b/dynawalla/games/lattice/src/render/hud.ts
@@ -35,6 +35,18 @@ const CORNER_GAP = 8
 /** The counters' inset from the safe edge, left and right. */
 const SIDE = 14
 
+/** Breathing room between the tile bar, the hint control and the tree above it. */
+const HINT_GAP = 8
+
+/**
+ * How much of the safe height the factor tree may take.
+ *
+ * A third and a bit. Enough for the four rows a three-digit target's tree needs
+ * and not so much that a child who asked for a hint cannot see the husk they
+ * were about to shoot.
+ */
+const TREE_SHARE = 0.36
+
 export type HudLayout = {
   /** `OPENED` / `CHAIN` on the left, `BEST` on the right, the stall notice centred. */
   readonly status: {
@@ -59,6 +71,28 @@ export type HudLayout = {
   readonly banner: { readonly cx: number; readonly cy: number }
   /** The word under the host's sheet. */
   readonly sheet: { readonly cx: number; readonly cy: number }
+  /**
+   * The box the factor-tree hint may grow into: standing on the hint control,
+   * which stands on the tile bar, all of it inside the safe area.
+   *
+   * **The bottom of the arena, and that is not an accident.** `Arena.arm` seeds
+   * every husk and mote with `y` between the top edge and `0.62 · height`, so
+   * the lower third is the emptiest part of the field — the one band a panel
+   * can occupy without hiding the thing the child is trying to shoot. It is
+   * also where their eyes already are, because the tile bar is there and the
+   * tree's leaves are exactly what the bar is about to fill up with.
+   */
+  readonly tree: { readonly x: number; readonly y: number; readonly w: number; readonly h: number }
+  /**
+   * The control that asks for the next piece of the tree.
+   *
+   * A circle, at least 44px across, at the left edge of the safe area on its own
+   * row above the tile bar — clear of the bar's own tap target, which drops the
+   * hold and must not be hit by a child reaching for help. It carries a drawn
+   * branch rather than a word: it is a control a five-year-old meets before they
+   * can read, in a pack that ships in about fifty languages.
+   */
+  readonly hint: { readonly cx: number; readonly cy: number; readonly r: number }
 }
 
 /**
@@ -83,6 +117,37 @@ export function hudLayout(w: number, area: Rect): HudLayout {
   const size = Math.max(12, Math.min(17, w / 46))
   const barSize = Math.max(26, Math.min(40, area.w / 16))
 
+  // The tile bar's own row, and the top of the 44px zone that drops the hold.
+  const barY = area.y + area.h - barSize * 1.5
+  const barTop = barY - Math.max(22, barSize)
+
+  // The hint control sits at the bottom-left of the tree's own band, clear of
+  // the tile bar's 44px tap zone — a child reaching for help must never dump the
+  // hold they have spent a minute assembling — and BESIDE the tree rather than
+  // under it.
+  //
+  // Beside, because a phone held sideways is 390px tall and the host takes the
+  // top hundred of it. Stacking the control on its own row spent sixty of the
+  // remaining hundred and forty and left the tree fifty-nine pixels to draw four
+  // rows in, which is a hint nobody can read. Landscape has width and no height,
+  // so the control is paid for out of the width: the tree keeps a matching
+  // gutter on its right, which also keeps it centred.
+  const hintR = Math.max(22, Math.min(26, area.w / 14))
+  const treeBottom = barTop - HINT_GAP
+  const hintCy = treeBottom - hintR
+  const hintCx = area.x + SIDE + hintR
+  const gutter = hintR * 2 + HINT_GAP
+
+  // Capped at just over a third of the safe height so the arena is still an
+  // arena, and floored below the counters so it never draws through them.
+  //
+  // TWO counter rows reserved and not three. The third row is the stall notice,
+  // and a stall is by definition an arena with no resonator on it — so there is
+  // no question, no tree and nothing to reserve for. Reserving it anyway cost
+  // the tree twenty-five pixels it does not have on a phone held sideways.
+  const treeCeiling = cornerBottom + size * 1.5 * 2
+  const treeTop = Math.max(treeCeiling, treeBottom - area.h * TREE_SHARE)
+
   return {
     status: {
       size,
@@ -98,10 +163,17 @@ export function hudLayout(w: number, area: Rect): HudLayout {
       dotW: barSize * 0.5,
       // Standing on the floor of the safe area rather than the floor of the
       // canvas: on a phone the floor of the canvas is the home indicator.
-      y: area.y + area.h - barSize * 1.5,
+      y: barY,
       cx: area.x + area.w / 2,
     },
     banner: { cx: area.x + area.w / 2, cy: area.y + area.h * 0.46 },
     sheet: { cx: area.x + area.w / 2, cy: area.y + area.h / 2 },
+    tree: {
+      x: area.x + SIDE + gutter,
+      y: treeTop,
+      w: Math.max(1, area.w - (SIDE + gutter) * 2),
+      h: Math.max(1, treeBottom - treeTop),
+    },
+    hint: { cx: hintCx, cy: hintCy, r: hintR },
   }
 }

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -17,11 +17,14 @@
 import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import type { Arena, Body, Resonator } from "../game/arena.ts"
 import { HUSK_R, MOTE_R, RESONATOR_R, SHIP_R, SHOT_R } from "../game/arena.ts"
+import { heldLeaves, type HintState, revealPaceMs } from "../game/hint.ts"
+import type { PlacedNode } from "../game/tree.ts"
 import type { Grid } from "../sim/grid.ts"
 import { hudLayout, type HudLayout } from "./hud.ts"
 import { Sparks } from "./particles.ts"
 import {
   BRASS,
+  BRASS_DIM,
   BRASS_LIGHT,
   CELESTIAL,
   CELESTIAL_DIM,
@@ -47,6 +50,12 @@ export type Banner = { text: string; tint: string; age: number }
 
 const BANNER_MS = 1400
 
+/** How long one node of the hint tree takes to fade and swell into place. */
+const NODE_GROW_MS = 200
+
+/** The scrim the tree is read against, so a numeral never fights a strut. */
+const TREE_SCRIM = "rgba(5,8,16,0.72)"
+
 export class Scene {
   private ctx: CanvasRenderingContext2D
   private dpr = 1
@@ -68,6 +77,22 @@ export class Scene {
    * the insets over and Split View changes them without one.
    */
   private hud: HudLayout
+
+  /**
+   * The hint's own clock and memory.
+   *
+   * A stage is a *derived* value in the arena — there is no timer over there —
+   * so the animation state lives here: when each node started to appear, when
+   * each numeral did, and which leaves the child is already carrying. All of it
+   * is thrown away when the resonator changes, keyed on the question id.
+   */
+  private clock = 0
+  private treeKey = ""
+  private nodeAt = new Map<number, number>()
+  private numeralAt = new Map<number, number>()
+  private filled = new Set<number>()
+  /** Where the hint control was last drawn. It is a touch target. */
+  private hintRect = { x: 0, y: 0, w: 0, h: 0 }
 
   private readonly canvas: HTMLCanvasElement
   private reduced: boolean
@@ -113,6 +138,7 @@ export class Scene {
   }
 
   advance(dtMs: number): void {
+    this.clock += dtMs
     this.sparks.step(dtMs)
     this.shake *= Math.exp(-0.009 * dtMs)
     if (this.shake < 0.15) this.shake = 0
@@ -122,7 +148,23 @@ export class Scene {
     }
   }
 
-  draw(arena: Arena, grid: Grid, state: { best: number; paused: boolean; stalled: boolean }): void {
+  draw(
+    arena: Arena,
+    grid: Grid,
+    state: {
+      best: number
+      paused: boolean
+      stalled: boolean
+      /**
+       * The hint as the arena has it this frame, or `null` for none.
+       *
+       * REQUIRED, and the argument is `hud.ts`'s: made optional, a caller that
+       * forgets it still compiles and quietly ships a game whose hint system is
+       * never drawn, and the only way anybody finds out is by getting stuck.
+       */
+      hint: HintState | null
+    },
+  ): void {
     const ctx = this.ctx
     const w = this.cssWidth
     const h = this.cssHeight
@@ -165,6 +207,7 @@ export class Scene {
     this.sparks.draw(ctx)
     ctx.restore()
 
+    this.drawHint(arena, state.hint)
     this.drawTileBar(arena)
     this.drawStatus(arena, state)
     if (state.paused) this.drawSheet()
@@ -366,6 +409,266 @@ export class Scene {
   // ── the chrome ───────────────────────────────────────────────────────────
 
   /**
+   * THE HINT — the factor tree, and the control that unfolds it.
+   *
+   * Drawn in the same materials as the field, which is the whole idea: a lit
+   * leaf is the same celestial hexagon as the mote drifting out there, and an
+   * unopened node is the same carved stone as the husk holding it. A child does
+   * not have to be told the tree is a map of the arena; it is drawn out of the
+   * arena's own pieces.
+   *
+   * A leaf whose prime is already in the hold gets a brass collar, and the frame
+   * it earns one it throws a spark. That is the maths moment — `2·2·2·2·7`
+   * assembling itself one piece at a time — and it is the only thing in the
+   * game that celebrates a factorisation rather than a resonator.
+   */
+  private drawHint(arena: Arena, hint: HintState | null): void {
+    const res = arena.resonator
+    if (!res) {
+      this.hintRect = { x: 0, y: 0, w: 0, h: 0 }
+      return
+    }
+    this.drawHintControl(hint)
+    if (!hint) {
+      // A new question wipes the animation state, so the next tree grows rather
+      // than snapping in half-finished with the last one's timings.
+      if (this.treeKey !== "") this.forgetTree("")
+      return
+    }
+    if (this.treeKey !== res.questionId) this.forgetTree(res.questionId)
+
+    const { placed, shown } = hint
+    const box = this.hud.tree
+    const cols = placed.columns
+    const rows = placed.rows
+    const r = Math.max(
+      9,
+      Math.min(22, Math.min(box.w / Math.max(1, cols * 2.4), box.h / Math.max(1, rows * 2.6))),
+    )
+    const colStep = cols > 1 ? Math.min(box.w / cols, r * 3.2) : 0
+    const rowStep = rows > 1 ? Math.min((box.h - r * 2) / (rows - 1), r * 3) : 0
+    const usedW = colStep * (cols - 1) + r * 2
+    const usedH = rowStep * (rows - 1) + r * 2
+    const cx = box.x + box.w / 2
+    // Bottom-anchored: the leaves hang closest to the tile bar they are about
+    // to fill, and a shallow tree does not float in the middle of the arena.
+    const top = box.y + box.h - usedH + r
+    const at = (node: PlacedNode): { x: number; y: number } => ({
+      x: cx + (node.u - (cols - 1) / 2) * colStep,
+      y: top + node.depth * rowStep,
+    })
+
+    const pace = this.reduced ? 0 : revealPaceMs(arena.chain)
+    this.schedule(hint, pace)
+
+    const ctx = this.ctx
+    const pad = 12
+    ctx.save()
+    ctx.fillStyle = TREE_SCRIM
+    roundRect(ctx, cx - usedW / 2 - pad, top - r - pad, usedW + pad * 2, usedH + pad * 2, 10)
+    ctx.fill()
+    ctx.strokeStyle = BRASS_DIM
+    ctx.lineWidth = 1
+    roundRect(ctx, cx - usedW / 2 - pad, top - r - pad, usedW + pad * 2, usedH + pad * 2, 10)
+    ctx.stroke()
+
+    // The branches first, so every node sits on top of its own lines.
+    ctx.strokeStyle = BRASS_DIM
+    ctx.lineWidth = 1.6
+    ctx.beginPath()
+    for (let i = 0; i < placed.nodes.length; i++) {
+      const node = placed.nodes[i] as PlacedNode
+      if (node.parent < 0) continue
+      if (this.growth(i) <= 0) continue
+      const a = at(placed.nodes[node.parent] as PlacedNode)
+      const b = at(node)
+      ctx.moveTo(a.x, a.y + r * 0.7)
+      ctx.lineTo(b.x, b.y - r * 0.7)
+    }
+    ctx.stroke()
+
+    const holding = heldLeaves(placed, shown, arena.bank.tiles)
+    for (let i = 0; i < placed.nodes.length; i++) {
+      const node = placed.nodes[i] as PlacedNode
+      const grow = this.growth(i)
+      if (grow <= 0) continue
+      const p = at(node)
+      this.drawTreeNode(node, p.x, p.y, r * grow, shown.has(i) && this.numeralIn(i), holding.has(i))
+    }
+    ctx.restore()
+
+    // The click. A leaf that has just been satisfied throws a spark, and the
+    // last one throws a bigger one — the factorisation is complete in the hold.
+    for (const index of holding) {
+      if (this.filled.has(index)) continue
+      const p = at(placed.nodes[index] as PlacedNode)
+      const last = holding.size === placed.leaves.length
+      this.sparks.burst(p.x, p.y, last ? 14 : 5, last ? 260 : 150, BRASS_LIGHT, last ? 2.4 : 1.5)
+    }
+    this.filled = holding
+  }
+
+  /** The branch glyph that asks for one more piece. No word, in any language. */
+  private drawHintControl(hint: HintState | null): void {
+    const ctx = this.ctx
+    const { cx, cy, r } = this.hud.hint
+    // A 44px minimum target, per the touch-target rule, whatever `r` came out as.
+    const half = Math.max(22, r)
+    this.hintRect = { x: cx - half, y: cy - half, w: half * 2, h: half * 2 }
+
+    const more = hint === null || hint.stage < hint.stages
+    ctx.save()
+    ctx.beginPath()
+    ctx.arc(cx, cy, r, 0, Math.PI * 2)
+    ctx.fillStyle = "rgba(5,8,16,0.72)"
+    ctx.fill()
+    ctx.lineWidth = 2
+    ctx.strokeStyle = more ? BRASS : BRASS_DIM
+    ctx.stroke()
+
+    // A three-node factor tree, drawn small: one above, two below.
+    const s = r * 0.46
+    ctx.strokeStyle = more ? BRASS_LIGHT : BRASS_DIM
+    ctx.lineWidth = 1.6
+    ctx.beginPath()
+    ctx.moveTo(cx, cy - s * 0.35)
+    ctx.lineTo(cx - s, cy + s * 0.7)
+    ctx.moveTo(cx, cy - s * 0.35)
+    ctx.lineTo(cx + s, cy + s * 0.7)
+    ctx.stroke()
+    ctx.fillStyle = more ? BRASS_LIGHT : BRASS_DIM
+    for (const [dx, dy] of [
+      [0, -s * 0.7],
+      [-s, s * 0.9],
+      [s, s * 0.9],
+    ] as Array<[number, number]>) {
+      ctx.beginPath()
+      ctx.arc(cx + dx, cy + dy, r * 0.15, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    ctx.restore()
+  }
+
+  private drawTreeNode(
+    node: PlacedNode,
+    x: number,
+    y: number,
+    r: number,
+    numeral: boolean,
+    held: boolean,
+  ): void {
+    const ctx = this.ctx
+    if (!numeral) {
+      // Blank. A ring and a question mark, in the same brass the arena's own
+      // frame is made of — never a warning colour, never a gap.
+      ctx.beginPath()
+      ctx.arc(x, y, r * 0.86, 0, Math.PI * 2)
+      ctx.fillStyle = "rgba(20,26,40,0.9)"
+      ctx.fill()
+      ctx.strokeStyle = BRASS_DIM
+      ctx.lineWidth = 1.6
+      ctx.stroke()
+      ctx.fillStyle = INK_DIM
+      ctx.font = numeralFont(r * 0.95)
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillText("?", x, y + 1)
+      return
+    }
+
+    if (node.prime) {
+      // The same hexagon as a mote, because it *is* a mote — one drifting out
+      // there with this number on it, and the child's job is to go and get it.
+      ctx.beginPath()
+      for (let i = 0; i < 6; i++) {
+        const a = (i / 6) * Math.PI * 2 - Math.PI / 2
+        const px = x + Math.cos(a) * r
+        const py = y + Math.sin(a) * r
+        if (i === 0) ctx.moveTo(px, py)
+        else ctx.lineTo(px, py)
+      }
+      ctx.closePath()
+      ctx.fillStyle = CELESTIAL
+      ctx.fill()
+      ctx.strokeStyle = held ? BRASS_LIGHT : CELESTIAL_DIM
+      ctx.lineWidth = held ? 3 : 2
+      ctx.stroke()
+      ctx.fillStyle = CELESTIAL_INK
+      ctx.font = numeralFont(r * 1)
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillText(String(node.value), x, y + 1)
+      return
+    }
+
+    // The same carved stone as a husk, for the same reason.
+    const k = r * 0.82
+    ctx.beginPath()
+    ctx.rect(x - k, y - k, k * 2, k * 2)
+    ctx.fillStyle = STONE
+    ctx.fill()
+    ctx.strokeStyle = STONE_EDGE
+    ctx.lineWidth = 2
+    ctx.stroke()
+    ctx.fillStyle = STONE_INK
+    const digits = String(node.value).length
+    ctx.font = numeralFont((k * 1.5) / Math.max(1, digits * 0.62))
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText(String(node.value), x, y + 1)
+  }
+
+  /** Wipe the tree's animation memory. A new question grows from nothing. */
+  private forgetTree(key: string): void {
+    this.treeKey = key
+    this.nodeAt.clear()
+    this.numeralAt.clear()
+    this.filled = new Set<number>()
+  }
+
+  /**
+   * Give every node and every newly lit numeral a moment to arrive at.
+   *
+   * The stagger is `pace`, which comes from the chain: long and calm for a child
+   * who is finding it hard, near-instant for one on a run. Nothing here decides
+   * *what* is revealed — the arena did that — only the order it lands in.
+   */
+  private schedule(hint: HintState, pace: number): void {
+    const { placed, shown } = hint
+    if (this.nodeAt.size === 0) {
+      // The silhouette, growing downward from the root.
+      for (let i = 0; i < placed.nodes.length; i++) {
+        this.nodeAt.set(i, this.clock + (placed.nodes[i] as PlacedNode).depth * pace)
+      }
+    }
+    let k = 0
+    for (const index of shown) {
+      if (this.numeralAt.has(index)) continue
+      this.numeralAt.set(index, this.clock + k * pace)
+      k += 1
+    }
+  }
+
+  /** 0 before a node has begun to appear, 1 once it is fully there. */
+  private growth(index: number): number {
+    const at = this.nodeAt.get(index)
+    if (at === undefined) return 0
+    if (this.clock < at) return 0
+    return Math.min(1, Math.max(0.2, (this.clock - at) / NODE_GROW_MS))
+  }
+
+  private numeralIn(index: number): boolean {
+    const at = this.numeralAt.get(index)
+    return at !== undefined && this.clock >= at
+  }
+
+  /** Did a press land on the hint control? That gesture asks for one more piece. */
+  hitsHint(x: number, y: number): boolean {
+    const r = this.hintRect
+    return r.w > 0 && x >= r.x && x <= r.x + r.w && y >= r.y && y <= r.y + r.h
+  }
+
+  /**
    * The factor tile bar. This is the passive layer and it is the reason the
    * game teaches anything at all when nobody is trying: `2·2·3` sitting under a
    * running 12, changing the instant a mote is swept.
@@ -522,4 +825,34 @@ export class Scene {
   dispose(): void {
     this.canvas.remove()
   }
+}
+
+/**
+ * A rounded rectangle path, drawn by hand.
+ *
+ * `CanvasRenderingContext2D.roundRect` is not in every WebView this pack runs
+ * in — an older Android System WebView is a real device in the fleet — and a
+ * missing method here would throw inside the draw loop and take the whole frame
+ * with it.
+ */
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const k = Math.max(0, Math.min(r, Math.min(w, h) / 2))
+  ctx.beginPath()
+  ctx.moveTo(x + k, y)
+  ctx.lineTo(x + w - k, y)
+  ctx.quadraticCurveTo(x + w, y, x + w, y + k)
+  ctx.lineTo(x + w, y + h - k)
+  ctx.quadraticCurveTo(x + w, y + h, x + w - k, y + h)
+  ctx.lineTo(x + k, y + h)
+  ctx.quadraticCurveTo(x, y + h, x, y + h - k)
+  ctx.lineTo(x, y + k)
+  ctx.quadraticCurveTo(x, y, x + k, y)
+  ctx.closePath()
 }

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -445,8 +445,14 @@ export class Scene {
       9,
       Math.min(22, Math.min(box.w / Math.max(1, cols * 2.4), box.h / Math.max(1, rows * 2.6))),
     )
-    const colStep = cols > 1 ? Math.min(box.w / cols, r * 3.2) : 0
-    const rowStep = rows > 1 ? Math.min((box.h - r * 2) / (rows - 1), r * 3) : 0
+    // Both clamped at zero. `r` floors at 9, so on a box shorter than 18px the
+    // row numerator goes NEGATIVE — and `top + depth * rowStep` then draws the
+    // root at the bottom with the leaves climbing above it, through the
+    // counters, upside down. `hud.ts` now floors the box so this cannot happen
+    // from the layout, and this is the belt for that brace: a tree with nowhere
+    // to go collapses onto a point rather than inverting.
+    const colStep = cols > 1 ? Math.max(0, Math.min(box.w / cols, r * 3.2)) : 0
+    const rowStep = rows > 1 ? Math.max(0, Math.min((box.h - r * 2) / (rows - 1), r * 3)) : 0
     const usedW = colStep * (cols - 1) + r * 2
     const usedH = rowStep * (rows - 1) + r * 2
     const cx = box.x + box.w / 2

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -445,12 +445,18 @@ export class Scene {
       9,
       Math.min(22, Math.min(box.w / Math.max(1, cols * 2.4), box.h / Math.max(1, rows * 2.6))),
     )
-    // Both clamped at zero. `r` floors at 9, so on a box shorter than 18px the
-    // row numerator goes NEGATIVE — and `top + depth * rowStep` then draws the
-    // root at the bottom with the leaves climbing above it, through the
-    // counters, upside down. `hud.ts` now floors the box so this cannot happen
-    // from the layout, and this is the belt for that brace: a tree with nowhere
-    // to go collapses onto a point rather than inverting.
+    // Both clamped at zero, and this is **unreachable defence** rather than a
+    // live guard — said plainly, because an unfalsifiable comment is worse than
+    // no comment.
+    //
+    // `r` floors at 9, so a box under 18px tall makes the row numerator negative
+    // and `top + depth * rowStep` draws the root at the bottom with the leaves
+    // climbing above it, upside down. Two things stop that arriving here:
+    // `resize` above floors the canvas at 320×320 whatever the element measures,
+    // and `hud.ts` floors the box inside that. Reaching this clamp needs a
+    // `hudLayout` called with a safe area under about 130px tall, which only a
+    // test does. It stays because it costs two `Math.max` calls and the thing it
+    // prevents is silent and total.
     const colStep = cols > 1 ? Math.max(0, Math.min(box.w / cols, r * 3.2)) : 0
     const rowStep = rows > 1 ? Math.max(0, Math.min((box.h - r * 2) / (rows - 1), r * 3)) : 0
     const usedW = colStep * (cols - 1) + r * 2

--- a/dynawalla/games/lattice/src/test/chrome.test.ts
+++ b/dynawalla/games/lattice/src/test/chrome.test.ts
@@ -177,7 +177,7 @@ function withInsets(insets: Insets, body: () => void): void {
   }
 }
 
-type Frame = { scene: Scene; chrome: Drawn[] }
+type Frame = { scene: Scene; chrome: Drawn[]; arena: Arena }
 
 /**
  * Play a few seconds of a real sitting and draw one real frame.
@@ -236,7 +236,7 @@ function frame(
   // the restore that closes the WORLD — index 0 of what is left after the world
   // is the first thing the chrome drew.
   const last = restores[0] ?? 0
-  return { scene, chrome: log.slice(last) }
+  return { scene, chrome: log.slice(last), arena }
 }
 
 const inside = (box: Rect, area: Rect): boolean =>
@@ -429,17 +429,20 @@ test("on a pane too short for it, the tree gives way to the counters", () => {
   // the tree draws straight through OPENED and CHAIN.
   for (const [w, h] of [
     [1024, 320],
-    [1180, 340],
-    [900, 360],
+    [1180, 300],
+    [900, 340],
+    [1180, 260],
   ] as Array<[number, number]>) {
     withInsets(NO_INSETS, () => {
-      const l = hudLayout(w, safeRect(w, h))
+      const area = safeRect(w, h)
+      const l = hudLayout(w, area)
       assert.ok(
         l.tree.y >= l.status.top + l.status.lineH * 2,
         `${w}×${h}: the tree draws through the counters (${l.tree.y} vs ${
           l.status.top + l.status.lineH * 2
         })`,
       )
+      assert.ok(inside(l.tree, area), `${w}×${h}: the tree box left the safe area`)
     })
   }
 })
@@ -462,17 +465,86 @@ test("and on a pane too short for even that, it still does not turn upside down"
   for (const [w, h] of [
     [1024, 200],
     [800, 240],
-    [1180, 260],
+    [1024, 180],
   ] as Array<[number, number]>) {
-    withInsets(NO_INSETS, () => {
-      const l = hudLayout(w, safeRect(w, h))
-      assert.ok(l.tree.h >= 96, `${w}×${h}: the tree box is ${l.tree.h}px tall and will invert`)
-      assert.ok(l.tree.w > 0 && l.tree.x >= 0, `${w}×${h}: the tree box is off the screen`)
-      assert.equal(
-        hitsHostChrome({ x: l.hint.cx - l.hint.r, y: l.hint.cy - l.hint.r, w: l.hint.r * 2, h: l.hint.r * 2 }, w),
-        false,
-        `${w}×${h}: the hint control rode up under one of the host's corners`,
-      )
+    for (const insets of [NO_INSETS, PORTRAIT_NOTCH]) {
+      withInsets(insets, () => {
+        const area = safeRect(w, h)
+        const l = hudLayout(w, area)
+        // 18px is where `rowStep` changes sign. Anything at or above it lays out
+        // tight rather than inverted, because `usedH` works out to exactly the
+        // box height for any box the renderer will accept.
+        // The floor holds unless the safe area itself is the binding constraint,
+        // and staying on the canvas wins when the two disagree. `scene.ts` clamps
+        // the row step at zero for exactly that residue, and the test below
+        // proves through the real renderer that the tree still comes out the
+        // right way up.
+        assert.ok(
+          l.tree.h >= 24 || l.tree.y === area.y,
+          `${w}×${h}: the tree box is ${l.tree.h}px tall and nothing was pinning it`,
+        )
+        // And it stays ON the canvas. The first version of this floor pushed the
+        // box to y = −4 here and the root row drew off the top of the screen —
+        // which the old assertion, `w > 0 && x >= 0`, could not see and could not
+        // fail: `hudLayout` returns `Math.max(1, …)` for the width and a sum of
+        // non-negative terms for the left edge.
+        assert.ok(
+          inside(l.tree, area),
+          `${w}×${h}: the tree box is off the screen: ${JSON.stringify(l.tree)} vs ${JSON.stringify(area)}`,
+        )
+        assert.equal(
+          hitsHostChrome({ x: l.hint.cx - l.hint.r, y: l.hint.cy - l.hint.r, w: l.hint.r * 2, h: l.hint.r * 2 }, w),
+          false,
+          `${w}×${h}: the hint control rode up under one of the host's corners`,
+        )
+      })
+    }
+  }
+})
+
+test("the tree is drawn the right way up, even where there is no room for it", () => {
+  // The layout can no longer hand the renderer a box that would invert — but
+  // "cannot" is a claim about two files agreeing, and the whole reason this
+  // suite exists is that `Scene.draw` once did not consult the layout at all.
+  //
+  // So this asks the REAL renderer, at the shapes where the box is thinnest:
+  // is the root numeral above the leaves? `rowStep` unclamped goes negative on
+  // a box under 18px and lays the tree out bottom-up, root under leaves,
+  // climbing through the counters.
+  // Note what this can and cannot reach: `Scene.resize` floors the canvas at
+  // 320×320 however small the element measures, so the renderer never sees the
+  // sub-300px safe areas the layout test above exercises. The orientation check
+  // is therefore about the shapes that actually ship; the layout is held to the
+  // stricter bar on its own, one test up.
+  for (const [w, h, insets] of [
+    [1024, 320, PORTRAIT_NOTCH],
+    [844, 390, LANDSCAPE_NOTCH],
+    [1024, 320, NO_INSETS],
+    [320, 568, NO_INSETS],
+    [390, 844, NO_INSETS],
+  ] as Array<[number, number, Insets]>) {
+    withInsets(insets, () => {
+      const { chrome, arena } = frame(w, h, { stalled: false, paused: false, hintTaps: 6 })
+      const res = arena.resonator
+      assert.ok(res, `${w}×${h}: nothing was armed`)
+      const hint = arena.hint()
+      assert.ok(hint, `${w}×${h}: six taps produced no tree`)
+
+      // The root numeral is the target, and at the last stage it is drawn. Every
+      // other node is a proper divisor of it, so nothing else on the tree can
+      // carry the same string.
+      const root = chrome.find((d) => d.text === String(res.target))
+      assert.ok(root, `${w}×${h}: the root of the tree was never drawn`)
+
+      const leaves = hint.placed.leaves.map((i) => String(hint.placed.nodes[i]!.value))
+      const drawnLeaves = chrome.filter((d) => leaves.includes(d.text))
+      assert.ok(drawnLeaves.length > 0, `${w}×${h}: no leaf of the tree was drawn`)
+      for (const leaf of drawnLeaves) {
+        assert.ok(
+          root.box.y <= leaf.box.y,
+          `${w}×${h}: the tree is upside down — the root ${res.target} is at y=${root.box.y}, below its leaf ${leaf.text} at y=${leaf.box.y}`,
+        )
+      }
     })
   }
 })

--- a/dynawalla/games/lattice/src/test/chrome.test.ts
+++ b/dynawalla/games/lattice/src/test/chrome.test.ts
@@ -84,11 +84,23 @@ function recorder(): { ctx: CanvasRenderingContext2D; log: Drawn[]; restores: nu
     textAlign: "start",
     textBaseline: "alphabetic",
   }
+  // Save/restore DEPTH, not a raw count of `restore` calls.
+  //
+  // The world is drawn inside one save/restore pair and every husk, the ship and
+  // the resonator save and restore *inside* it, so a raw count says nothing
+  // about where the world ended. Only the restores that bring the depth back to
+  // zero are boundaries between one block of drawing and the next, and the first
+  // of those is the end of the world and the start of the chrome.
+  let depth = 0
   const api: Record<string, unknown> = {
     measureText: (text: string) => ({ width: advance(text, fontSize(String(state.font))) }),
     createRadialGradient: () => ({ addColorStop() {} }),
+    save: () => {
+      depth += 1
+    },
     restore: () => {
-      restores.push(log.length)
+      depth = Math.max(0, depth - 1)
+      if (depth === 0) restores.push(log.length)
     },
     fillText: (text: string, x: number, y: number) => {
       const px = fontSize(String(state.font))
@@ -173,7 +185,11 @@ type Frame = { scene: Scene; chrome: Drawn[] }
  * The hold is filled first, because an empty tile bar draws nothing and a test
  * that never renders the tiles is a test that cannot see them collide.
  */
-function frame(w: number, h: number, opts: { stalled: boolean; paused: boolean }): Frame {
+function frame(
+  w: number,
+  h: number,
+  opts: { stalled: boolean; paused: boolean; hintTaps?: number },
+): Frame {
   const seed = 0x1a771ce
   const host = createStubHost({ seed, reducedMotion: true })
   const { ctx, log, restores } = recorder()
@@ -188,15 +204,38 @@ function frame(w: number, h: number, opts: { stalled: boolean; paused: boolean }
   for (const body of arena.bodies.slice(0, 5)) arena.touch(body.id)
   assert.ok(arena.bank.size > 0, "the hold stayed empty, so the tile bar drew nothing")
 
+  // The factor tree is chrome too — every numeral and every `?` on it is
+  // something the child reads — so it has to be on screen when this measures.
+  // Asked for rather than waited for: the clock here is a literal `0`.
+  for (let i = 0; i < (opts.hintTaps ?? 0); i++) arena.askHint(0)
+
   scene.say("RESONANCE", "#f0d878")
-  scene.draw(arena, grid, { best: 12, paused: opts.paused, stalled: opts.stalled })
+  const state = {
+    best: 12,
+    paused: opts.paused,
+    stalled: opts.stalled,
+    hint: arena.hint(0),
+  }
+  // Two frames, and the first one is thrown away: the tree schedules its own
+  // arrival on the frame it is first drawn, so a single frame would measure
+  // every node at a fifth of its size and prove nothing about where a
+  // full-sized numeral lands.
+  scene.draw(arena, grid, state)
+  scene.advance(900)
+  log.length = 0
+  restores.length = 0
+  scene.draw(arena, grid, state)
 
   // Everything after the LAST `restore()` is chrome: the world is drawn inside
   // one save/restore pair and the tile bar, the counters and the banner are
   // drawn after it. Bodies and the resonator's prompt are playfield — they
   // drift wherever the physics takes them, including under a corner, and that
   // is the point of `cover`.
-  const last = restores[restores.length - 1] ?? 0
+  //
+  // The hint tree draws inside its own save/restore, so the slice is taken from
+  // the restore that closes the WORLD — index 0 of what is left after the world
+  // is the first thing the chrome drew.
+  const last = restores[0] ?? 0
   return { scene, chrome: log.slice(last) }
 }
 
@@ -216,6 +255,11 @@ for (const [name, w, h] of VIEWPORTS) {
           { stalled: false, paused: false },
           { stalled: true, paused: false },
           { stalled: false, paused: true },
+          // The silhouette, the partial, and the whole tree. Every `?` and
+          // every numeral on it is something the child has to read.
+          { stalled: false, paused: false, hintTaps: 1 },
+          { stalled: false, paused: false, hintTaps: 4 },
+          { stalled: false, paused: false, hintTaps: 6 },
         ]) {
           const { chrome } = frame(w, h, state)
           assert.ok(chrome.length > 0, "no chrome was drawn at all")
@@ -284,8 +328,122 @@ for (const [name, w, h] of VIEWPORTS) {
         )
       })
     })
+
+    test(`the hint control can be tapped and never drops the hold at ${name} (${w}×${h}), ${label}`, () => {
+      // Two failures this catches, and the second is the expensive one:
+      //
+      //   * a hint control under the host's exit chevron or under the home
+      //     indicator, which is a child who cannot ask for help at all; and
+      //   * a hint control OVERLAPPING the tile bar, which is a child who
+      //     reaches for help and instead throws away the hold they have spent a
+      //     minute assembling. That is the exact shape of "a hint costs
+      //     something", built out of geometry rather than out of rules.
+      withInsets(insets, () => {
+        const area = safeRect(w, h)
+        const { scene } = frame(w, h, { stalled: false, paused: false })
+        const { cx, cy, r } = hudLayout(w, area).hint
+
+        assert.ok(r * 2 >= 44, `the hint control is ${r * 2}px across, under the 44px minimum`)
+        assert.equal(scene.hitsHint(cx, cy), true, "the hint control is not where it says")
+        assert.ok(
+          inside({ x: cx - r, y: cy - r, w: r * 2, h: r * 2 }, area),
+          `the hint control is outside the safe area at ${w}×${h}`,
+        )
+        assert.equal(
+          hitsHostChrome({ x: cx - r, y: cy - r, w: r * 2, h: r * 2 }, w),
+          false,
+          "the hint control is under one of the host's corners",
+        )
+
+        // Nowhere the hint control answers may the tile bar answer too.
+        for (let i = 0; i <= 6; i++) {
+          for (let j = 0; j <= 6; j++) {
+            const x = cx - r + (r * 2 * i) / 6
+            const y = cy - r + (r * 2 * j) / 6
+            if (!scene.hitsHint(x, y)) continue
+            assert.equal(
+              scene.hitsTileBar(x, y),
+              false,
+              `asking for a hint at ${x},${y} would also drop the hold`,
+            )
+          }
+        }
+      })
+    })
   }
 }
+
+test("the tree has somewhere to be at every shape the fleet has", () => {
+  // A hint nobody can read is not a hint. `TREE_SHARE` set to zero, or a stack
+  // that put the tree box behind the counters, both leave the layout function
+  // returning a perfectly valid rectangle one pixel tall, and every other
+  // assertion in this file goes on passing — the numerals still land inside the
+  // safe area, because they are drawn inside a box that is not there.
+  //
+  // Three claims, in the order they would break: the box is big enough to read,
+  // it is inside the safe area, and it is stacked clear of the two things it
+  // sits on — the hint control and, under that, the tile bar.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const insets of [NO_INSETS, w > h ? LANDSCAPE_NOTCH : PORTRAIT_NOTCH]) {
+      withInsets(insets, () => {
+        const area = safeRect(w, h)
+        const l = hudLayout(w, area)
+        const box: Rect = l.tree
+
+        // 130 × 180 is the floor the widest and deepest tree in the band needs:
+        // `512 = 2⁹` is nine leaves over four rows, and at the renderer's minimum
+        // node radius of 9 that is 182px across and about 100px down. Anything
+        // under this and the worst case is drawn on top of itself.
+        assert.ok(box.h >= 130, `${name}: the tree gets ${box.h}px of height, which is not a tree`)
+        assert.ok(box.w >= 180, `${name}: the tree gets ${box.w}px of width`)
+        assert.ok(inside(box, area), `${name}: the tree box is outside the safe area`)
+
+        // The control sits BESIDE the tree at the bottom-left of its band, and
+        // the whole band sits on the tile bar. So the separation to check is
+        // horizontal for the control and vertical for the bar.
+        assert.ok(
+          box.x >= l.hint.cx + l.hint.r,
+          `${name}: the tree box runs over the hint control`,
+        )
+        assert.ok(
+          box.y + box.h <= l.bar.y - Math.max(22, l.bar.size) + 0.5,
+          `${name}: the tree hangs into the tile bar's tap zone`,
+        )
+        assert.ok(
+          l.hint.cy + Math.max(22, l.hint.r) <= l.bar.y - Math.max(22, l.bar.size) + 0.5,
+          `${name}: the hint control hangs into the tile bar's tap zone`,
+        )
+        // And it begins below the counters rather than through them.
+        assert.ok(box.y >= l.status.top + l.status.lineH * 2, `${name}: the tree covers the counters`)
+      })
+    }
+  }
+})
+
+test("on a pane too short for it, the tree gives way to the counters", () => {
+  // A Split View slice and a phone held sideways with the keyboard up are both
+  // real shapes, and on them the third-of-the-height cap is not what runs out
+  // first — the top of the screen is. So the tree has a ceiling as well as a
+  // share, and this is the shape that proves the ceiling is load-bearing rather
+  // than decorative: at 1024×320 it is the binding constraint, and without it
+  // the tree draws straight through OPENED and CHAIN.
+  for (const [w, h] of [
+    [1024, 320],
+    [1180, 300],
+    [900, 340],
+  ] as Array<[number, number]>) {
+    withInsets(NO_INSETS, () => {
+      const l = hudLayout(w, safeRect(w, h))
+      assert.ok(
+        l.tree.y >= l.status.top + l.status.lineH * 2,
+        `${w}×${h}: the tree draws through the counters (${l.tree.y} vs ${
+          l.status.top + l.status.lineH * 2
+        })`,
+      )
+      assert.ok(l.tree.h > 0, `${w}×${h}: the tree has no height at all`)
+    })
+  }
+})
 
 test("the layout consumes the insets it is given", () => {
   // The safe rectangle is the whole contract with the notch, and `hudLayout`

--- a/dynawalla/games/lattice/src/test/chrome.test.ts
+++ b/dynawalla/games/lattice/src/test/chrome.test.ts
@@ -207,14 +207,14 @@ function frame(
   // The factor tree is chrome too — every numeral and every `?` on it is
   // something the child reads — so it has to be on screen when this measures.
   // Asked for rather than waited for: the clock here is a literal `0`.
-  for (let i = 0; i < (opts.hintTaps ?? 0); i++) arena.askHint(0)
+  for (let i = 0; i < (opts.hintTaps ?? 0); i++) arena.askHint()
 
   scene.say("RESONANCE", "#f0d878")
   const state = {
     best: 12,
     paused: opts.paused,
     stalled: opts.stalled,
-    hint: arena.hint(0),
+    hint: arena.hint(),
   }
   // Two frames, and the first one is thrown away: the tree schedules its own
   // arrival on the frame it is first drawn, so a single frame would measure
@@ -429,8 +429,8 @@ test("on a pane too short for it, the tree gives way to the counters", () => {
   // the tree draws straight through OPENED and CHAIN.
   for (const [w, h] of [
     [1024, 320],
-    [1180, 300],
-    [900, 340],
+    [1180, 340],
+    [900, 360],
   ] as Array<[number, number]>) {
     withInsets(NO_INSETS, () => {
       const l = hudLayout(w, safeRect(w, h))
@@ -440,7 +440,39 @@ test("on a pane too short for it, the tree gives way to the counters", () => {
           l.status.top + l.status.lineH * 2
         })`,
       )
-      assert.ok(l.tree.h > 0, `${w}×${h}: the tree has no height at all`)
+    })
+  }
+})
+
+test("and on a pane too short for even that, it still does not turn upside down", () => {
+  // Below about 340px of safe height there is no arrangement that fits: the
+  // counters and the tile bar meet in the middle. The floor then wins over the
+  // ceiling and the tree overlaps the counters, which is ugly and legible.
+  //
+  // What it must NOT do is what it did before the floor existed. `scene.ts`
+  // computes `rowStep = (box.h − 2r) / (rows − 1)` with `r` floored at 9, so a
+  // box under 18px tall gives a NEGATIVE row step — the root draws at the bottom
+  // and the leaves climb above it, through the counters, through the host's exit
+  // chevron, upside down. At 1024×200 the old layout returned a box exactly one
+  // pixel tall.
+  //
+  // The control has a floor of its own for the same reason: on these shapes the
+  // tile bar climbs high enough that its row lands under the host's 44px corner,
+  // and a hint control the host owns the pixels of is not a hint control.
+  for (const [w, h] of [
+    [1024, 200],
+    [800, 240],
+    [1180, 260],
+  ] as Array<[number, number]>) {
+    withInsets(NO_INSETS, () => {
+      const l = hudLayout(w, safeRect(w, h))
+      assert.ok(l.tree.h >= 96, `${w}×${h}: the tree box is ${l.tree.h}px tall and will invert`)
+      assert.ok(l.tree.w > 0 && l.tree.x >= 0, `${w}×${h}: the tree box is off the screen`)
+      assert.equal(
+        hitsHostChrome({ x: l.hint.cx - l.hint.r, y: l.hint.cy - l.hint.r, w: l.hint.r * 2, h: l.hint.r * 2 }, w),
+        false,
+        `${w}×${h}: the hint control rode up under one of the host's corners`,
+      )
     })
   }
 })

--- a/dynawalla/games/lattice/src/test/harness.ts
+++ b/dynawalla/games/lattice/src/test/harness.ts
@@ -16,12 +16,15 @@ export type Rig = {
   host: Host
   arena: Arena
   reports: Report[]
+  /** Question ids the pack closed without an outcome. See `Host.skip`. */
+  skips: string[]
   transitions: Array<{ kind: string; label?: string }>
   haptics: string[]
 }
 
 export function rig(seed = 0x1a771ce, opts: { difficulty?: number } = {}): Rig {
   const reports: Report[] = []
+  const skips: string[] = []
   const transitions: Array<{ kind: string; label?: string }> = []
   const haptics: string[] = []
   const host = createStubHost({
@@ -29,13 +32,14 @@ export function rig(seed = 0x1a771ce, opts: { difficulty?: number } = {}): Rig {
     reducedMotion: true,
     ...(opts.difficulty === undefined ? {} : { difficulty: opts.difficulty }),
     onReport: (r) => reports.push(r),
+    onSkip: (id) => skips.push(id),
     onHaptic: (k) => haptics.push(k),
     onTransition: (kind, label) =>
       transitions.push(label === undefined ? { kind } : { kind, label }),
   })
   const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
   arena.begin(0)
-  return { host, arena, reports, transitions, haptics }
+  return { host, arena, reports, skips, transitions, haptics }
 }
 
 /**

--- a/dynawalla/games/lattice/src/test/hint.test.ts
+++ b/dynawalla/games/lattice/src/test/hint.test.ts
@@ -302,7 +302,7 @@ test("the founder's own examples, as pictures", () => {
   // **And 129 is the shape where that picture does not exist**, which is worth
   // pinning rather than papering over. Its tree is `3 · 43` and 43 is both the
   // largest leaf (stage 2) and the larger root child, so stage 3 lights both
-  // halves at once and states the answer a stage early. 120 of the 573 composite
+  // halves at once and states the answer a stage early. Around 118 of the 410 composite
   // targets do that. It is why `freeStages` walks the tree instead of returning
   // a hardcoded 3, and why `given` is computed from the picture.
   //
@@ -600,7 +600,15 @@ test("nothing the clock does on its own can ever reach the stage that states the
         false,
         `seed ${seed} round ${round}: the clock alone stated the answer to ${res.prompt} (= ${res.target}, prime=${isPrime(res.target)})`,
       )
-      assert.ok(hint.stage >= 1, "the clock gave nothing in ten minutes")
+      // Not `stage >= 1`, which `hint()` guarantees by returning null below it.
+      // Ten minutes is far past every step in the schedule, so the clock should
+      // be standing on its ceiling — which is also what makes the `given` check
+      // above a check on the CEILING rather than on the clock being slow.
+      assert.equal(
+        hint.stage,
+        freeStages(hint.placed),
+        `seed ${seed} round ${round}: ten minutes did not exhaust the clock's own stages`,
+      )
     }
   }
 })

--- a/dynawalla/games/lattice/src/test/hint.test.ts
+++ b/dynawalla/games/lattice/src/test/hint.test.ts
@@ -31,6 +31,7 @@ import { Arena, MAX_TARGET } from "../game/arena.ts"
 import { isPrime, primeFactors, productOf } from "../game/factor.ts"
 import {
   firstHintMs,
+  freeStages,
   heldLeaves,
   HINT_STAGES,
   HINT_DWELL_MS,
@@ -53,6 +54,18 @@ import {
 } from "../game/tree.ts"
 import { createStubHost } from "../stubHost.ts"
 import { grindToPrimes, rig, sweepFactorisation } from "./harness.ts"
+
+/**
+ * Sit there. Advance the world by `ms`, sixteen milliseconds at a time, with
+ * nobody touching anything — which is what the automatic hint is a response to.
+ *
+ * The hint's clock is PLAYED time, accumulated in `Arena.step`, so a test that
+ * merely names a large number proves nothing about it. This is also why a
+ * backgrounded webview cannot spend it: no frames, no `step`, no clock.
+ */
+function sitStill(arena: Arena, ms: number): void {
+  for (let t = 0; t < ms; t += 16) arena.step(16)
+}
 
 /** Every whole number a resonator can be about. The ladder's whole range. */
 const BAND: number[] = []
@@ -285,11 +298,66 @@ test("the founder's own examples, as pictures", () => {
   for (const value of pair) assert.ok(partial.includes(value), `${value} is missing from the partial`)
 
   // `129 ⟶ 3 and ⟶ ?`: half a split, with the sibling left blank.
+  //
+  // **And 129 is the shape where that picture does not exist**, which is worth
+  // pinning rather than papering over. Its tree is `3 · 43` and 43 is both the
+  // largest leaf (stage 2) and the larger root child, so stage 3 lights both
+  // halves at once and states the answer a stage early. 120 of the 573 composite
+  // targets do that. It is why `freeStages` walks the tree instead of returning
+  // a hardcoded 3, and why `given` is computed from the picture.
+  //
+  // The assertion that used to be here was `lit.length >= 1`, which `shownAt`
+  // satisfies by construction for every composite — the message said a sibling
+  // was blank and the check was happy with both siblings lit.
   const odd = placeTree(factorTree(129, new Rng(4)))
-  const half = shownAt(odd, 3)
   const oddKids = (odd.nodes[0] as PlacedNode).kids as readonly [number, number]
-  const lit = [oddKids[0], oddKids[1]].filter((i) => half.has(i))
-  assert.equal(lit.length >= 1, true, "129's split was left entirely blank at the half stage")
+  const oddValues = [odd.nodes[oddKids[0]]!.value, odd.nodes[oddKids[1]]!.value].sort((a, b) => a - b)
+  assert.deepEqual(oddValues, [3, 43], "129 no longer comes apart as 3 · 43")
+  assert.equal(freeStages(odd), 2, "129's free stages are not two")
+  assert.equal(revealsAnswer(odd, shownAt(odd, 2)), false, "129 gave itself away at one prime")
+  assert.equal(revealsAnswer(odd, shownAt(odd, 3)), true, "129's stage 3 is not both halves")
+
+  // Where the picture DOES exist, one half is lit and the other is not — a
+  // strictly stronger claim than "at least one is lit".
+  const half = placeTree(factorTree(112, new Rng(9)))
+  const halfKids = (half.nodes[0] as PlacedNode).kids as readonly [number, number]
+  const litAt3 = shownAt(half, 3)
+  const litKids = [halfKids[0], halfKids[1]].filter((i) => litAt3.has(i))
+  assert.equal(litKids.length, 1, "112's stage 3 lit both halves of the split, or neither")
+  assert.equal(freeStages(half), 3, "112 does not have three free stages")
+})
+
+test("the free stages are exactly the pictures that do not state the answer", () => {
+  // The property `freeStages` exists to have, over the whole band: everything at
+  // or below it is safe to show a child who is merely sitting there, and the
+  // stage above it is not.
+  let earlyCrossers = 0
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE) {
+      const placed = placeTree(factorTree(n, rng))
+      const free = freeStages(placed)
+      assert.ok(free >= 1, `${n}: the clock is not allowed to show even the silhouette`)
+      for (let stage = 1; stage <= free; stage++) {
+        assert.equal(
+          revealsAnswer(placed, shownAt(placed, stage)),
+          false,
+          `${n}: stage ${stage} is called free and states the answer`,
+        )
+      }
+      assert.ok(free < stageCount(placed), `${n}: the clock alone can reach the whole tree`)
+      assert.equal(
+        revealsAnswer(placed, shownAt(placed, free + 1)),
+        true,
+        `${n}: the stage above the free ones still says nothing, so the ceiling is too low`,
+      )
+      if (!isPrime(n) && free < 3) earlyCrossers += 1
+    }
+  }
+  assert.ok(
+    earlyCrossers > 0,
+    "no composite crosses early any more, so `freeStages` could just be a constant",
+  )
 })
 
 // ── the maths moment ───────────────────────────────────────────────────────
@@ -442,7 +510,7 @@ test("a hint costs the child nothing: the same run, hinted and unhinted", () => 
       const res = r.arena.resonator
       if (!res) break
       if (hints) {
-        for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint(0)
+        for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint()
       }
       grindToPrimes(r.arena)
       assert.ok(sweepFactorisation(r.arena, res.target), "the field could not supply the answer")
@@ -459,40 +527,109 @@ test("a hint costs the child nothing: the same run, hinted and unhinted", () => 
   assert.deepEqual(helped.haptics, blind.haptics, "a hinted run felt different in the hand")
 })
 
-test("the host is told nothing about a question whose answer the game printed", () => {
+test("a hinted round is still reported, because the progress hairline is a thing the child sees", () => {
+  // **This is the assertion that caught the first version of this feature.**
+  //
+  // It closed a hinted question with `host.skip` instead of reporting it, on the
+  // reasoning that a `correct` after the game printed the answer is a claim
+  // about the child that is not true. Honest, and invisible from inside the
+  // canvas — and `game-host` says of `skip`, verbatim, that it "does not advance
+  // the session progress fraction, because that counts answered questions",
+  // which the host paints as a hairline across the top of every pack.
+  //
+  // So: five hinted rounds, five ceremonies, `OPENED 5` — and a progress bar
+  // still on nought for the whole sitting. The child who leans on the hint is
+  // the one this feature exists for and theirs was the bar that never moved.
   const r = rig(0x5eed)
-  const res = r.arena.resonator
-  assert.ok(res, "no resonator was armed")
-  const id = res.questionId
+  const ids: string[] = []
+  for (let round = 0; round < 5; round++) {
+    const res = r.arena.resonator
+    if (!res) break
+    ids.push(res.questionId)
+    for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint()
+    assert.equal(r.arena.hint()?.given, true, "the whole tree did not state the answer")
+    grindToPrimes(r.arena)
+    assert.ok(sweepFactorisation(r.arena, res.target), "the field could not supply the answer")
+    r.arena.enter(1000 * (round + 1))
+  }
 
-  // Straight to the partial, which is the first picture that states the answer.
-  for (let i = 0; i < 4; i++) r.arena.askHint(0)
-  assert.equal(r.arena.hint(0)?.given, true, "four taps did not reach the answer")
-
-  grindToPrimes(r.arena)
-  assert.ok(sweepFactorisation(r.arena, res.target))
-  r.arena.enter(1000)
-
-  assert.equal(r.arena.opened, 1, "the resonator did not open")
+  assert.equal(r.arena.opened, 5, "the run did not open five resonators")
   assert.equal(
-    r.reports.some((report) => report.questionId === id),
-    false,
-    "a question the game answered was reported as the child's answer",
+    r.reports.length,
+    5,
+    `five hinted rounds produced ${r.reports.length} reports, so the progress hairline moved ${r.reports.length}/40 of a session instead of 5/40`,
   )
-  assert.ok(r.skips.includes(id), "the question was left hanging open in the host's ledger")
+  for (const id of ids) {
+    const report = r.reports.find((entry) => entry.questionId === id)
+    assert.ok(report, `${id} was opened and the host was never told`)
+    assert.equal(report.correct, true, `${id} was opened and reported as wrong`)
+  }
+  assert.deepEqual(r.skips.filter((id) => ids.includes(id)), [], "an answered question was skipped")
 })
 
-test("but a hint that gave nothing away leaves the report exactly as it was", () => {
+test("nothing the clock does on its own can ever reach the stage that states the answer", () => {
+  // The other half of the same fix, and the one that matters for a child who
+  // never presses anything.
+  //
+  // The old schedule ran all the way to stage 6 on time alone. On a WALL that
+  // was 51 seconds — `tiles` is 1 for a prime, so the quiet is short, and stage
+  // 2 for a wall IS the numeral. Fifty-one seconds is an ordinary length of time
+  // to spend hunting one mote across a drifting field, which is the entire task
+  // on a wall round; a child doing it exactly right, unaided, had the answer
+  // printed for them at the finish line. Walls are one resonator in five.
+  //
+  // Now the clock stops at `freeStages` and the rest is the child's to ask for.
+  for (const seed of [1, 7, 42, 1337, 90210, 0x5eed]) {
+    for (let round = 0; round < 6; round++) {
+      const r = rig(seed)
+      for (let skipRound = 0; skipRound < round; skipRound++) {
+        const skipRes = r.arena.resonator
+        if (!skipRes) break
+        grindToPrimes(r.arena)
+        if (!sweepFactorisation(r.arena, skipRes.target)) break
+        r.arena.enter(1000 * (skipRound + 1))
+      }
+      const res = r.arena.resonator
+      if (!res) continue
+      // Ten minutes of a child sitting in front of one question, doing nothing.
+      sitStill(r.arena, 600_000)
+      const hint = r.arena.hint()
+      assert.ok(hint, `seed ${seed} round ${round}: ten minutes and no hint at all`)
+      assert.equal(
+        hint.given,
+        false,
+        `seed ${seed} round ${round}: the clock alone stated the answer to ${res.prompt} (= ${res.target}, prime=${isPrime(res.target)})`,
+      )
+      assert.ok(hint.stage >= 1, "the clock gave nothing in ten minutes")
+    }
+  }
+})
+
+test("but the child can always ask past it, and asking is what makes it their choice", () => {
+  const r = rig(0x5eed)
+  sitStill(r.arena, 600_000)
+  const byClock = r.arena.hint()
+  assert.ok(byClock)
+  assert.equal(byClock.given, false)
+
+  r.arena.askHint()
+  const asked = r.arena.hint()
+  assert.ok(asked)
+  assert.equal(asked.stage, byClock.stage + 1, "a tap at the clock's ceiling did nothing")
+  assert.equal(asked.given, true, "one tap past the free stages did not state the answer")
+})
+
+test("a hint that gave nothing away leaves the report exactly as it was", () => {
   const r = rig(0x5eed)
   const res = r.arena.resonator
   assert.ok(res)
   const id = res.questionId
 
   // The silhouette and one prime. Neither says what the sum is.
-  r.arena.askHint(0)
-  r.arena.askHint(0)
-  assert.equal(r.arena.hint(0)?.stage, 2)
-  assert.equal(r.arena.hint(0)?.given, false, "two taps already stated the answer")
+  r.arena.askHint()
+  r.arena.askHint()
+  assert.equal(r.arena.hint()?.stage, 2)
+  assert.equal(r.arena.hint()?.given, false, "two taps already stated the answer")
 
   grindToPrimes(r.arena)
   assert.ok(sweepFactorisation(r.arena, res.target))
@@ -507,20 +644,20 @@ test("but a hint that gave nothing away leaves the report exactly as it was", ()
 
 test("asking is always allowed and never runs out in a way that reads as a refusal", () => {
   const r = rig(0x5eed)
-  assert.equal(r.arena.hint(0), null, "a fresh question opens with a tree already up")
+  assert.equal(r.arena.hint(), null, "a fresh question opens with a tree already up")
 
   let previous = 0
   for (let i = 0; i < 40; i++) {
-    r.arena.askHint(0)
-    const stage = r.arena.hint(0)?.stage ?? 0
+    r.arena.askHint()
+    const stage = r.arena.hint()?.stage ?? 0
     assert.ok(stage >= previous, "asking for a hint took one away")
     previous = stage
   }
-  const hint = r.arena.hint(0)
+  const hint = r.arena.hint()
   assert.ok(hint)
   assert.equal(hint.stage, hint.stages, "forty taps did not reach the whole tree")
   // And the fortieth tap is a quiet no-op rather than an error or an event.
-  assert.deepEqual(r.arena.askHint(0), [], "asking past the end of the tree did something")
+  assert.deepEqual(r.arena.askHint(), [], "asking past the end of the tree did something")
 })
 
 test("the quiet the arena actually keeps is the quiet the item asks for", () => {
@@ -534,13 +671,15 @@ test("the quiet the arena actually keeps is the quiet the item asks for", () => 
     const res = r.arena.resonator
     assert.ok(res, `seed ${seed}: no resonator`)
     const first = firstHintMs(itemOf(res.target, res.difficulty))
+    sitStill(r.arena, first - 1000)
     assert.equal(
-      r.arena.hint(first - 1)?.stage ?? 0,
+      r.arena.hint()?.stage ?? 0,
       0,
       `seed ${seed}: a hint arrived before the item's own quiet was up`,
     )
+    sitStill(r.arena, 1100)
     assert.equal(
-      r.arena.hint(first)?.stage,
+      r.arena.hint()?.stage,
       1,
       `seed ${seed}: the item's quiet ran out at ${first}ms and nothing arrived`,
     )
@@ -554,8 +693,9 @@ test("a hint arrives once, not every frame", () => {
   const item = itemOf(res.target, 0)
   // Whatever rung it landed on, the quiet cannot be shorter than the floor.
   const events: number[] = []
-  for (let t = 0; t <= firstHintMs({ difficulty: 1, tiles: 12 }) * 2; t += 100) {
-    for (const event of r.arena.unfold(t)) {
+  for (let t = 0; t <= firstHintMs({ difficulty: 1, tiles: 12 }) * 4; t += 100) {
+    sitStill(r.arena, 100)
+    for (const event of r.arena.unfold()) {
       if (event.kind === "hint") events.push(event.stage)
     }
   }
@@ -570,9 +710,9 @@ test("a hint arrives once, not every frame", () => {
 
 test("a tap runs ahead of the quiet, and the quiet never lands on top of it", () => {
   const r = rig(0x5eed)
-  r.arena.askHint(0)
-  r.arena.askHint(0)
-  assert.equal(r.arena.hint(0)?.stage, 2)
+  r.arena.askHint()
+  r.arena.askHint()
+  assert.equal(r.arena.hint()?.stage, 2)
 
   // Wind the clock right through the moments the first several automatic hints
   // would have arrived. The stage is a `max`, so the schedule catches up
@@ -580,12 +720,12 @@ test("a tap runs ahead of the quiet, and the quiet never lands on top of it", ()
   // has — which on screen would be the tree flickering back to a picture they
   // had left behind, twice, for no reason they could name.
   const stages: number[] = []
-  for (let t = 0; t <= firstHintMs({ difficulty: 1, tiles: 12 }) * 4; t += 100) {
-    for (const event of r.arena.unfold(t)) {
+  for (let t = 0; t <= firstHintMs({ difficulty: 1, tiles: 12 }) * 6; t += 100) {
+    sitStill(r.arena, 100)
+    for (const event of r.arena.unfold()) {
       if (event.kind === "hint") stages.push(event.stage)
     }
   }
-  assert.ok(stages.length > 0, "the schedule never got past the two stages the child asked for")
   for (const stage of stages) {
     assert.ok(stage > 2, `stage ${stage} was announced again after the child had already asked for it`)
   }
@@ -622,8 +762,8 @@ test("the ladder holds rather than climbing on an answer the game handed over", 
     const res = arena.resonator
     assert.ok(res, "no resonator was armed")
     if (hints) {
-      for (let i = 0; i < HINT_STAGES; i++) arena.askHint(0)
-      assert.equal(arena.hint(0)?.given, true, "the whole tree did not state the answer")
+      for (let i = 0; i < HINT_STAGES; i++) arena.askHint()
+      assert.equal(arena.hint()?.given, true, "the whole tree did not state the answer")
     }
     grindToPrimes(arena)
     assert.ok(sweepFactorisation(arena, res.target))
@@ -640,37 +780,57 @@ test("the ladder holds rather than climbing on an answer the game handed over", 
 
 test("a sheet over the frame is not thinking time, and does not unfold the tree", () => {
   const r = rig(0x5eed)
-  const before = r.arena.hint(1000)?.stage ?? 0
-  assert.equal(before, 0, "a hint arrived one second into the question")
+  sitStill(r.arena, 1000)
+  assert.equal(r.arena.hint()?.stage ?? 0, 0, "a hint arrived one second into the question")
 
   r.arena.pause(1000)
-  // Two minutes behind a paywall card, a parent gate or the how-to-play panel.
-  const during = r.arena.hint(121_000)?.stage ?? 0
-  assert.equal(during, 0, "the tree unfolded behind the host's sheet")
-  assert.deepEqual(r.arena.unfold(121_000), [], "a hint announced itself behind the sheet")
+  // Two minutes behind a paywall card, a parent gate or the how-to-play panel —
+  // and the shell keeps calling `step`, because it keeps drawing.
+  sitStill(r.arena, 120_000)
+  assert.equal(r.arena.hint()?.stage ?? 0, 0, "the tree unfolded behind the host's sheet")
+  assert.deepEqual(r.arena.unfold(), [], "a hint announced itself behind the sheet")
   // And the control is inert behind it, like every other input in this game. A
   // press that lands on a translucent host card is not the child asking for
   // anything, and a tap that leaked through would unfold a tree they are not
   // looking at — the same class of damage as a resting thumb flying the ship
   // through the resonator behind a sheet.
-  assert.deepEqual(r.arena.askHint(121_000), [], "a tap behind the host's sheet asked for a hint")
-  assert.equal(r.arena.hint(121_000), null, "a tap behind the host's sheet unfolded the tree")
+  assert.deepEqual(r.arena.askHint(), [], "a tap behind the host's sheet asked for a hint")
+  assert.equal(r.arena.hint(), null, "a tap behind the host's sheet unfolded the tree")
 
   r.arena.resume(121_000)
-  const after = r.arena.hint(122_000)?.stage ?? 0
-  assert.equal(after, 0, "the sheet spent the child's quiet for them")
+  sitStill(r.arena, 1000)
+  assert.equal(r.arena.hint()?.stage ?? 0, 0, "the sheet spent the child's quiet for them")
 
   // Back from the sheet, asking works again.
-  r.arena.askHint(122_000)
-  assert.equal(r.arena.hint(122_000)?.stage, 1, "the control never came back after the sheet")
+  r.arena.askHint()
+  assert.equal(r.arena.hint()?.stage, 1, "the control never came back after the sheet")
+})
+
+test("a webview in the app switcher does not spend the child's quiet either", () => {
+  // The case a pack is NEVER told about, and the one a wall-clock schedule with
+  // a pause guard bolted on gets wrong: the child hits the home button mid
+  // question and comes back three minutes later. `Arena.pause` is never called,
+  // because the host does not know, so the only thing that can protect the quiet
+  // is that it is PLAYED time — and `step` clamps a delta of minutes to 120ms
+  // like every other physical quantity in the arena.
+  const r = rig(0x5eed)
+  const res = r.arena.resonator
+  assert.ok(res)
+  const first = firstHintMs(itemOf(res.target, res.difficulty))
+  for (let i = 0; i < 10; i++) r.arena.step(20_000)
+  assert.equal(
+    r.arena.hint()?.stage ?? 0,
+    0,
+    `two hundred seconds in the app switcher spent a ${first}ms quiet`,
+  )
 })
 
 test("a new question starts in silence, however much of the last tree was up", () => {
   const r = rig(0x5eed)
   const first = r.arena.resonator
   assert.ok(first)
-  for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint(0)
-  assert.equal(r.arena.hint(0)?.stage, r.arena.hint(0)?.stages)
+  for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint()
+  assert.equal(r.arena.hint()?.stage, r.arena.hint()?.stages)
 
   grindToPrimes(r.arena)
   assert.ok(sweepFactorisation(r.arena, first.target))
@@ -679,7 +839,7 @@ test("a new question starts in silence, however much of the last tree was up", (
   const next = r.arena.resonator
   assert.ok(next)
   assert.notEqual(next.questionId, first.questionId, "the same resonator came back")
-  assert.equal(r.arena.hint(1000), null, "the new question opened with the last one's tree up")
+  assert.equal(r.arena.hint(), null, "the new question opened with the last one's tree up")
 })
 
 test("the tree the resonator is hinting is the tree of the field it is standing over", () => {
@@ -692,8 +852,8 @@ test("the tree the resonator is hinting is the tree of the field it is standing 
     for (let round = 0; round < 6; round++) {
       const res = r.arena.resonator
       if (!res) break
-      for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint(0)
-      const hint = r.arena.hint(0)
+      for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint()
+      const hint = r.arena.hint()
       assert.ok(hint, `seed ${seed}: no hint for a live resonator`)
       assert.equal(
         (hint.placed.nodes[0] as PlacedNode).value,
@@ -728,7 +888,7 @@ test("with no resonator there is nothing to hint about and nothing throws", () =
   // arms nothing at all.
   arena.begin(0)
   assert.equal(arena.resonator, null, "the arena armed a resonator on a target it refuses")
-  assert.equal(arena.hint(0), null)
-  assert.deepEqual(arena.askHint(0), [])
-  assert.deepEqual(arena.unfold(500_000), [])
+  assert.equal(arena.hint(), null)
+  assert.deepEqual(arena.askHint(), [])
+  assert.deepEqual(arena.unfold(), [])
 })

--- a/dynawalla/games/lattice/src/test/hint.test.ts
+++ b/dynawalla/games/lattice/src/test/hint.test.ts
@@ -1,0 +1,734 @@
+// THE HINT — the tree, the escalation, the quiet, and what a hint costs.
+//
+// The one thing that matters more than everything else in this file: **a tree
+// that lies is worse than no tree at all.** A child who is shown `112 = 2·2·2·7`
+// sweeps exactly that, flies into the resonator with 56 in the hold, and is
+// refused by the game that told them to do it. So the generator is checked as a
+// property rather than by example — every target the ladder can serve, many
+// seeds, every node the exact product of its two children and every leaf a
+// prime.
+//
+// After that, three claims:
+//
+//   * the escalation goes somewhere: each stage is a superset of the last, the
+//     first stages give nothing arithmetical away, and the last one is the whole
+//     tree;
+//   * the quiet before an automatic hint is a **pure function of the item and
+//     monotone non-decreasing in its difficulty**, with no clock, no speed and
+//     no reading of the child anywhere in it; and
+//   * a hint costs the child nothing — not a point, not the chain, not the
+//     ceremony — and the only thing it changes is that the host is told nothing
+//     at all about a question whose answer the game printed.
+//
+// Everything here is seeded from a literal and there is no real clock anywhere.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Host } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Arena, MAX_TARGET } from "../game/arena.ts"
+import { isPrime, primeFactors, productOf } from "../game/factor.ts"
+import {
+  firstHintMs,
+  heldLeaves,
+  HINT_STAGES,
+  HINT_DWELL_MS,
+  itemOf,
+  revealPaceMs,
+  revealsAnswer,
+  scheduledStage,
+  shownAt,
+  stageCount,
+  WALL_STAGES,
+} from "../game/hint.ts"
+import { isResonant, MIN_TARGET } from "../game/resonance.ts"
+import {
+  factorTree,
+  leafProduct,
+  leavesOf,
+  placeTree,
+  treeIsHonest,
+  type PlacedNode,
+} from "../game/tree.ts"
+import { createStubHost } from "../stubHost.ts"
+import { grindToPrimes, rig, sweepFactorisation } from "./harness.ts"
+
+/** Every whole number a resonator can be about. The ladder's whole range. */
+const BAND: number[] = []
+for (let n = MIN_TARGET; n <= MAX_TARGET; n++) BAND.push(n)
+
+/** Every target the resonator would actually put up, wall or tree. */
+const ASKABLE = BAND.filter(
+  (n) => isResonant(n, MAX_TARGET, { wall: true }) || isResonant(n, MAX_TARGET, { wall: false }),
+)
+
+const SEEDS = [1, 2, 3, 7, 42, 97, 512, 1337, 24601, 90210, 0x1a771ce, 0xfeed]
+
+// ── the generator cannot lie ───────────────────────────────────────────────
+
+test("every tree the game can generate multiplies back to its own root", () => {
+  // The whole band, every seed: 988 targets × 12 seeds, and each one checked
+  // node by node. `treeIsHonest` is the conjunction of the three things that
+  // make a factor tree a factor tree — the root is the number asked for, every
+  // internal node is the exact product of its two children, and the leaves are
+  // exactly `primeFactors(n)` as a multiset.
+  let checked = 0
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of BAND) {
+      const tree = factorTree(n, rng)
+      assert.ok(treeIsHonest(n, tree), `the tree for ${n} on seed ${seed} is not a tree of ${n}`)
+      assert.equal(
+        productOf(leavesOf(tree)),
+        n,
+        `the leaves of ${n}'s tree on seed ${seed} do not multiply to ${n}`,
+      )
+      checked += 1
+    }
+  }
+  assert.ok(checked > 11_000, `only ${checked} trees were checked; the loop has gone stale`)
+})
+
+test("a leaf is a prime and a prime is a leaf — there is no third kind of node", () => {
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE) {
+      const placed = placeTree(factorTree(n, rng))
+      for (let i = 0; i < placed.nodes.length; i++) {
+        const node = placed.nodes[i] as PlacedNode
+        const leaf = node.kids === null
+        assert.equal(
+          leaf,
+          isPrime(node.value),
+          `${node.value} in ${n}'s tree is ${leaf ? "a leaf" : "a fork"} and ${
+            isPrime(node.value) ? "prime" : "composite"
+          }`,
+        )
+      }
+    }
+  }
+})
+
+test("the placed tree is a tree: one root, valid parents, leaves in their own columns", () => {
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE) {
+      const placed = placeTree(factorTree(n, rng))
+      assert.equal(leafProduct(placed), n, `${n}'s placed leaves do not multiply to ${n}`)
+      assert.equal(placed.leaves.length, primeFactors(n).length, `${n} lost a leaf in placement`)
+
+      const roots = placed.nodes.filter((node) => node.parent < 0)
+      assert.equal(roots.length, 1, `${n}'s tree has ${roots.length} roots`)
+      assert.equal((placed.nodes[0] as PlacedNode).value, n, `${n} is not at index 0`)
+
+      let deepest = 0
+      const columns = new Set<number>()
+      for (let i = 0; i < placed.nodes.length; i++) {
+        const node = placed.nodes[i] as PlacedNode
+        if (node.parent >= 0) {
+          assert.ok(node.parent < i, `${n}: node ${i} has a parent that comes after it`)
+          const parent = placed.nodes[node.parent] as PlacedNode
+          assert.equal(parent.depth + 1, node.depth, `${n}: node ${i} is not under its parent`)
+        }
+        assert.ok(node.u >= 0 && node.u <= placed.columns - 1, `${n}: node ${i} is off the board`)
+        if (node.depth > deepest) deepest = node.depth
+        if (node.kids === null) columns.add(node.u)
+      }
+      assert.equal(placed.rows, deepest + 1, `${n}: the row count is not the depth`)
+      assert.equal(columns.size, placed.leaves.length, `${n}: two leaves share a column`)
+    }
+  }
+})
+
+test("a prime target is one lonely node, which is the whole statement of the wall", () => {
+  const rng = new Rng(0x1a771ce)
+  for (const n of BAND.filter(isPrime)) {
+    const placed = placeTree(factorTree(n, rng))
+    assert.equal(placed.nodes.length, 1, `${n} came apart, and ${n} is prime`)
+    assert.equal(placed.rows, 1)
+    assert.equal(placed.columns, 1)
+    assert.equal(stageCount(placed), WALL_STAGES)
+  }
+})
+
+// ── the escalation ─────────────────────────────────────────────────────────
+
+test("each stage shows everything the stage before it showed, and then more", () => {
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE) {
+      const placed = placeTree(factorTree(n, rng))
+      const last = stageCount(placed)
+      for (let stage = 0; stage < last; stage++) {
+        const before = shownAt(placed, stage)
+        const after = shownAt(placed, stage + 1)
+        for (const index of before) {
+          assert.ok(after.has(index), `${n}: node ${index} went dark again at stage ${stage + 1}`)
+        }
+      }
+      assert.equal(shownAt(placed, 0).size, 0, `${n}: stage 0 showed something`)
+      assert.equal(shownAt(placed, 1).size, 0, `${n}: the silhouette showed a numeral`)
+      assert.equal(
+        shownAt(placed, last).size,
+        placed.nodes.length,
+        `${n}: the last stage is not the whole tree`,
+      )
+    }
+  }
+})
+
+test("the first numeral a child is given is the prime they were least likely to find", () => {
+  const rng = new Rng(0x1a771ce)
+  for (const n of ASKABLE) {
+    const placed = placeTree(factorTree(n, rng))
+    const shown = shownAt(placed, 2)
+    assert.equal(shown.size, 1, `${n}: stage 2 lit ${shown.size} nodes rather than one`)
+    const [index] = [...shown]
+    const node = placed.nodes[index as number] as PlacedNode
+    assert.equal(node.kids, null, `${n}: stage 2 lit a fork rather than a leaf`)
+    const biggest = Math.max(...placed.leaves.map((i) => (placed.nodes[i] as PlacedNode).value))
+    assert.equal(node.value, biggest, `${n}: stage 2 lit ${node.value} and not ${biggest}`)
+  }
+})
+
+test("the silhouette and the first prime never give the answer away", () => {
+  // The line the reporting hangs on. A blank tree says how many pieces the hold
+  // needs and nothing else; one lit leaf cannot pin a composite down, because
+  // pinning a root down needs BOTH of its branches determined and a single node
+  // can only ever be one of them.
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE.filter((v) => !isPrime(v))) {
+      const placed = placeTree(factorTree(n, rng))
+      assert.equal(revealsAnswer(placed, shownAt(placed, 1)), false, `${n}: the silhouette told`)
+      assert.equal(revealsAnswer(placed, shownAt(placed, 2)), false, `${n}: one prime told`)
+    }
+  }
+})
+
+test("but it always gets there: the last stage states the answer, for every target", () => {
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE) {
+      const placed = placeTree(factorTree(n, rng))
+      const last = stageCount(placed)
+      assert.equal(
+        revealsAnswer(placed, shownAt(placed, last)),
+        true,
+        `${n}: a child could reach the end of the hint and still be stuck`,
+      )
+      // And once it has been said it is never unsaid.
+      let said = false
+      for (let stage = 0; stage <= last; stage++) {
+        const now = revealsAnswer(placed, shownAt(placed, stage))
+        assert.ok(!said || now, `${n}: the answer was taken back at stage ${stage}`)
+        said = said || now
+      }
+    }
+  }
+})
+
+test("one stage before the end, the hold is already spelled out in full", () => {
+  // The stage the founder asked for by name — "basically reveal the answer" —
+  // and the one that actually unsticks a child, because the resonator opens on
+  // the product of the HOLD and never on the numeral at the top of the tree.
+  // Every leaf lit is a shopping list: go and sweep these.
+  //
+  // Asserted separately from "the last stage is the whole tree", because the
+  // last stage adds every node including the forks and would cover for a stage
+  // 5 that had quietly stopped lighting leaves at all.
+  for (const seed of SEEDS) {
+    const rng = new Rng(seed)
+    for (const n of ASKABLE.filter((v) => !isPrime(v))) {
+      const placed = placeTree(factorTree(n, rng))
+      const shown = shownAt(placed, stageCount(placed) - 1)
+      for (const leaf of placed.leaves) {
+        assert.ok(
+          shown.has(leaf),
+          `${n}: a child one stage from the end still cannot see which primes to sweep`,
+        )
+      }
+      const hold = placed.leaves.map((i) => (placed.nodes[i] as PlacedNode).value)
+      assert.equal(productOf(hold), n, `${n}: the spelled-out hold does not open the ring`)
+    }
+  }
+})
+
+test("a wall says nothing at all and then says the number, which is the only hint it has", () => {
+  const rng = new Rng(0x1a771ce)
+  for (const n of ASKABLE.filter(isPrime)) {
+    const placed = placeTree(factorTree(n, rng))
+    assert.equal(revealsAnswer(placed, shownAt(placed, 1)), false, `${n}: the wall's shape told`)
+    assert.equal(revealsAnswer(placed, shownAt(placed, 2)), true, `${n}: the wall never told`)
+  }
+})
+
+test("the founder's own examples, as pictures", () => {
+  // `112` is the number in the report: `642 − 530`, then four twos and a seven.
+  // Whatever `splitPair` chooses, the partial is a two-number product of it and
+  // the leaves are the hold.
+  const placed = placeTree(factorTree(112, new Rng(9)))
+  const leaves = placed.leaves.map((i) => (placed.nodes[i] as PlacedNode).value).sort((a, b) => a - b)
+  assert.deepEqual(leaves, [2, 2, 2, 2, 7])
+
+  const partial = [...shownAt(placed, 4)]
+    .map((i) => (placed.nodes[i] as PlacedNode).value)
+    .sort((a, b) => a - b)
+  // Two numerals whose product is 112 — `16 × 7`, or `8 × 14`, depending on the
+  // draw. Either is the stepping stone the founder asked for.
+  const kids = (placed.nodes[0] as PlacedNode).kids
+  assert.notEqual(kids, null)
+  const [a, b] = kids as readonly [number, number]
+  const pair = [(placed.nodes[a] as PlacedNode).value, (placed.nodes[b] as PlacedNode).value]
+  assert.equal(pair[0]! * pair[1]!, 112, "the partial does not multiply to 112")
+  for (const value of pair) assert.ok(partial.includes(value), `${value} is missing from the partial`)
+
+  // `129 ⟶ 3 and ⟶ ?`: half a split, with the sibling left blank.
+  const odd = placeTree(factorTree(129, new Rng(4)))
+  const half = shownAt(odd, 3)
+  const oddKids = (odd.nodes[0] as PlacedNode).kids as readonly [number, number]
+  const lit = [oddKids[0], oddKids[1]].filter((i) => half.has(i))
+  assert.equal(lit.length >= 1, true, "129's split was left entirely blank at the half stage")
+})
+
+// ── the maths moment ───────────────────────────────────────────────────────
+
+test("a lit leaf clicks into place once per copy the child is actually holding", () => {
+  // `112`'s tree has four twos in it. A hold with two twos must collar exactly
+  // two of them. Collar all four and the picture says the hold is finished when
+  // it is half finished — a hint that lies, and a child who trusts it flies into
+  // the ring and is refused by the game that told them to.
+  const placed = placeTree(factorTree(112, new Rng(9)))
+  const all = shownAt(placed, stageCount(placed))
+  const twos = placed.leaves.filter((i) => (placed.nodes[i] as PlacedNode).value === 2)
+  assert.equal(twos.length, 4, "112 stopped having four twos in it")
+
+  assert.equal(heldLeaves(placed, all, []).size, 0, "an empty hold collared something")
+  assert.equal(heldLeaves(placed, all, [2]).size, 1, "one 2 collared more than one leaf")
+  assert.equal(heldLeaves(placed, all, [2, 2]).size, 2, "two 2s did not collar two leaves")
+  assert.equal(heldLeaves(placed, all, [2, 2, 2, 2, 7]).size, 5, "a finished hold is not finished")
+  // A prime the tree never asked for collars nothing at all.
+  assert.equal(heldLeaves(placed, all, [5, 5, 5]).size, 0, "a stray prime collared a leaf")
+
+  // And a blank leaf is never collared, because collaring a `?` would say which
+  // prime it is a stage before the game meant to.
+  const silhouette = shownAt(placed, 1)
+  assert.equal(
+    heldLeaves(placed, silhouette, [2, 2, 2, 2, 7]).size,
+    0,
+    "the blank tree told the child which of its leaves they were already carrying",
+  )
+})
+
+// ── the quiet is a pure function of the item ───────────────────────────────
+
+test("the item is read off the target: a longer hold is a longer piece of work", () => {
+  // `tiles` is how many motes the hold is, and it is the half of the item that
+  // is about the WORK rather than the rung. Wired to a constant, a `720` — seven
+  // primes to hunt down across the arena — would be given exactly as much quiet
+  // as a `12`, and the game would start offering help in the middle of a sweep
+  // the child was halfway through.
+  assert.equal(itemOf(12, 0).tiles, 3, "12 = 2·2·3 is three motes")
+  assert.equal(itemOf(112, 0.5).tiles, 5, "112 = 2·2·2·2·7 is five motes")
+  assert.equal(itemOf(720, 0.5).tiles, 7, "720 is seven motes")
+  assert.equal(itemOf(997, 0.5).tiles, 1, "a prime is one mote, found rather than built")
+  assert.equal(itemOf(112, 0.5).difficulty, 0.5, "the rung was not carried through")
+  assert.ok(
+    firstHintMs(itemOf(720, 0.5)) > firstHintMs(itemOf(12, 0.5)),
+    "a seven-mote hold gets no more quiet than a three-mote one",
+  )
+})
+
+test("the quiet before a hint is a pure function of the item", () => {
+  const items = [
+    itemOf(12, 0),
+    itemOf(112, 0.5),
+    itemOf(720, 0.72),
+    itemOf(997, 1),
+  ]
+  for (const item of items) {
+    const first = firstHintMs(item)
+    for (let i = 0; i < 500; i++) {
+      assert.equal(firstHintMs(item), first, "the same item asked twice gave two different quiets")
+    }
+    assert.ok(Number.isFinite(first) && first > 0, `the quiet for ${JSON.stringify(item)} is ${first}`)
+  }
+})
+
+test("the quiet is monotone non-decreasing in difficulty, at every tile count", () => {
+  // The law, stated the way the fleet states it for an answer window: `window(d)`
+  // may not shrink as `d` grows. A hint arriving SOONER on a harder item is the
+  // game telling a child it does not believe they can do this one.
+  for (let tiles = 0; tiles <= 10; tiles++) {
+    let previous = -1
+    for (let d = 0; d <= 1.0000001; d += 0.005) {
+      const ms = firstHintMs({ difficulty: d, tiles })
+      assert.ok(
+        ms >= previous,
+        `the quiet fell from ${previous}ms to ${ms}ms between difficulties at ${tiles} tiles`,
+      )
+      previous = ms
+    }
+  }
+})
+
+test("the quiet is monotone non-decreasing in tiles, at every difficulty", () => {
+  for (let d = 0; d <= 1.0000001; d += 0.01) {
+    let previous = -1
+    for (let tiles = 0; tiles <= 12; tiles++) {
+      const ms = firstHintMs({ difficulty: d, tiles })
+      assert.ok(ms >= previous, `the quiet fell from ${previous}ms to ${ms}ms at difficulty ${d}`)
+      previous = ms
+    }
+  }
+})
+
+test("nothing but the item reaches the quiet — not the clock, not a nonsense number", () => {
+  // Non-finite inputs are clamped rather than propagated. A `NaN` here would
+  // make every comparison against it false, so the first hint would arrive on
+  // the first frame of every question in the session — a tree permanently on
+  // screen and every item silently unreported.
+  assert.equal(firstHintMs({ difficulty: Number.NaN, tiles: 3 }), firstHintMs({ difficulty: 0, tiles: 3 }))
+  assert.equal(firstHintMs({ difficulty: 0.5, tiles: Number.NaN }), firstHintMs({ difficulty: 0.5, tiles: 0 }))
+  assert.equal(firstHintMs({ difficulty: 9, tiles: 3 }), firstHintMs({ difficulty: 1, tiles: 3 }))
+  assert.equal(firstHintMs({ difficulty: -9, tiles: 3 }), firstHintMs({ difficulty: 0, tiles: 3 }))
+  assert.ok(firstHintMs({ difficulty: 0, tiles: 0 }) >= HINT_DWELL_MS)
+})
+
+test("the schedule only ever moves forward, and starts in silence", () => {
+  const item = itemOf(112, 0.55)
+  const first = firstHintMs(item)
+  assert.equal(scheduledStage(0, item), 0)
+  assert.equal(scheduledStage(first - 1, item), 0, "a hint arrived before the quiet was up")
+  assert.equal(scheduledStage(first, item), 1, "the quiet ran out and nothing arrived")
+  assert.equal(scheduledStage(Number.NaN, item), 0)
+
+  let previous = 0
+  for (let t = 0; t < first * 12; t += 250) {
+    const stage = scheduledStage(t, item)
+    assert.ok(stage >= previous, `the schedule went backwards at ${t}ms`)
+    previous = stage
+  }
+  assert.ok(previous >= HINT_STAGES, "the schedule never reaches the whole tree on its own")
+})
+
+test("the reveal is calm when it is hard and brief when it is not", () => {
+  // The one thing in the hint system that reads the child at all, and it changes
+  // only how the reveal LANDS — never what is revealed and never when.
+  let previous = Number.POSITIVE_INFINITY
+  for (let chain = 0; chain <= 20; chain++) {
+    const pace = revealPaceMs(chain)
+    assert.ok(pace <= previous, `the ceremony got longer at chain ${chain}`)
+    assert.ok(pace > 0, "the ceremony has no duration at all")
+    previous = pace
+  }
+  assert.ok(
+    revealPaceMs(0) > revealPaceMs(8) * 4,
+    "a child on a chain waits nearly as long as a child who is stuck",
+  )
+})
+
+// ── what a hint costs ──────────────────────────────────────────────────────
+
+test("a hint costs the child nothing: the same run, hinted and unhinted", () => {
+  // Two arenas off the same seed. One is played with the tree fully revealed
+  // from the first frame; the other is played blind. Everything the child can
+  // SEE must come out identical — the counter, the chain, the ceremony, the
+  // haptic that says well done.
+  const play = (hints: boolean): { opened: number; chain: number; haptics: string[] } => {
+    const r = rig(0x5eed)
+    for (let round = 0; round < 4; round++) {
+      const res = r.arena.resonator
+      if (!res) break
+      if (hints) {
+        for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint(0)
+      }
+      grindToPrimes(r.arena)
+      assert.ok(sweepFactorisation(r.arena, res.target), "the field could not supply the answer")
+      r.arena.enter(1000)
+    }
+    return { opened: r.arena.opened, chain: r.arena.chain, haptics: r.haptics }
+  }
+
+  const blind = play(false)
+  const helped = play(true)
+  assert.ok(blind.opened >= 3, "the unhinted run opened nothing, so this compares two failures")
+  assert.equal(helped.opened, blind.opened, "a hinted run opened fewer resonators")
+  assert.equal(helped.chain, blind.chain, "a hint broke the chain")
+  assert.deepEqual(helped.haptics, blind.haptics, "a hinted run felt different in the hand")
+})
+
+test("the host is told nothing about a question whose answer the game printed", () => {
+  const r = rig(0x5eed)
+  const res = r.arena.resonator
+  assert.ok(res, "no resonator was armed")
+  const id = res.questionId
+
+  // Straight to the partial, which is the first picture that states the answer.
+  for (let i = 0; i < 4; i++) r.arena.askHint(0)
+  assert.equal(r.arena.hint(0)?.given, true, "four taps did not reach the answer")
+
+  grindToPrimes(r.arena)
+  assert.ok(sweepFactorisation(r.arena, res.target))
+  r.arena.enter(1000)
+
+  assert.equal(r.arena.opened, 1, "the resonator did not open")
+  assert.equal(
+    r.reports.some((report) => report.questionId === id),
+    false,
+    "a question the game answered was reported as the child's answer",
+  )
+  assert.ok(r.skips.includes(id), "the question was left hanging open in the host's ledger")
+})
+
+test("but a hint that gave nothing away leaves the report exactly as it was", () => {
+  const r = rig(0x5eed)
+  const res = r.arena.resonator
+  assert.ok(res)
+  const id = res.questionId
+
+  // The silhouette and one prime. Neither says what the sum is.
+  r.arena.askHint(0)
+  r.arena.askHint(0)
+  assert.equal(r.arena.hint(0)?.stage, 2)
+  assert.equal(r.arena.hint(0)?.given, false, "two taps already stated the answer")
+
+  grindToPrimes(r.arena)
+  assert.ok(sweepFactorisation(r.arena, res.target))
+  r.arena.enter(1000)
+
+  const report = r.reports.find((entry) => entry.questionId === id)
+  assert.ok(report, "a question the child answered themselves was not reported")
+  assert.equal(report.correct, true)
+  assert.equal(report.answered, String(res.target))
+  assert.equal(r.skips.includes(id), false, "the child's own answer was thrown away")
+})
+
+test("asking is always allowed and never runs out in a way that reads as a refusal", () => {
+  const r = rig(0x5eed)
+  assert.equal(r.arena.hint(0), null, "a fresh question opens with a tree already up")
+
+  let previous = 0
+  for (let i = 0; i < 40; i++) {
+    r.arena.askHint(0)
+    const stage = r.arena.hint(0)?.stage ?? 0
+    assert.ok(stage >= previous, "asking for a hint took one away")
+    previous = stage
+  }
+  const hint = r.arena.hint(0)
+  assert.ok(hint)
+  assert.equal(hint.stage, hint.stages, "forty taps did not reach the whole tree")
+  // And the fortieth tap is a quiet no-op rather than an error or an event.
+  assert.deepEqual(r.arena.askHint(0), [], "asking past the end of the tree did something")
+})
+
+test("the quiet the arena actually keeps is the quiet the item asks for", () => {
+  // The wiring between `arm` and `firstHintMs`, pinned to the millisecond. Built
+  // from the wrong item — a constant, the previous target, the rung that was
+  // *requested* rather than the one that answered — the schedule still fires and
+  // every other assertion in this file still passes; a child on a seven-mote
+  // hold just gets interrupted as if they were on a three-mote one.
+  for (const seed of [1, 7, 42, 1337, 90210, 0x5eed]) {
+    const r = rig(seed)
+    const res = r.arena.resonator
+    assert.ok(res, `seed ${seed}: no resonator`)
+    const first = firstHintMs(itemOf(res.target, res.difficulty))
+    assert.equal(
+      r.arena.hint(first - 1)?.stage ?? 0,
+      0,
+      `seed ${seed}: a hint arrived before the item's own quiet was up`,
+    )
+    assert.equal(
+      r.arena.hint(first)?.stage,
+      1,
+      `seed ${seed}: the item's quiet ran out at ${first}ms and nothing arrived`,
+    )
+  }
+})
+
+test("a hint arrives once, not every frame", () => {
+  const r = rig(0x5eed)
+  const res = r.arena.resonator
+  assert.ok(res)
+  const item = itemOf(res.target, 0)
+  // Whatever rung it landed on, the quiet cannot be shorter than the floor.
+  const events: number[] = []
+  for (let t = 0; t <= firstHintMs({ difficulty: 1, tiles: 12 }) * 2; t += 100) {
+    for (const event of r.arena.unfold(t)) {
+      if (event.kind === "hint") events.push(event.stage)
+    }
+  }
+  assert.ok(events.length > 0, `no hint ever arrived, with a quiet of ${firstHintMs(item)}ms`)
+  assert.deepEqual(
+    events,
+    events.slice().sort((a, b) => a - b),
+    "the stages did not arrive in order",
+  )
+  assert.equal(new Set(events).size, events.length, "the same stage was announced twice")
+})
+
+test("a tap runs ahead of the quiet, and the quiet never lands on top of it", () => {
+  const r = rig(0x5eed)
+  r.arena.askHint(0)
+  r.arena.askHint(0)
+  assert.equal(r.arena.hint(0)?.stage, 2)
+
+  // Wind the clock right through the moments the first several automatic hints
+  // would have arrived. The stage is a `max`, so the schedule catches up
+  // silently behind the taps rather than re-announcing a stage the child already
+  // has — which on screen would be the tree flickering back to a picture they
+  // had left behind, twice, for no reason they could name.
+  const stages: number[] = []
+  for (let t = 0; t <= firstHintMs({ difficulty: 1, tiles: 12 }) * 4; t += 100) {
+    for (const event of r.arena.unfold(t)) {
+      if (event.kind === "hint") stages.push(event.stage)
+    }
+  }
+  assert.ok(stages.length > 0, "the schedule never got past the two stages the child asked for")
+  for (const stage of stages) {
+    assert.ok(stage > 2, `stage ${stage} was announced again after the child had already asked for it`)
+  }
+  assert.equal(new Set(stages).size, stages.length, "the same stage was announced twice")
+})
+
+test("the ladder holds rather than climbing on an answer the game handed over", () => {
+  // Not a penalty — the absence of one. `Ladder.opened` is three rungs of harder
+  // arithmetic next time, and pushing a child into harder arithmetic *because*
+  // they had just been shown the answer is the one way a hint in this game could
+  // quietly cost them something. Everything the child can SEE is unchanged; the
+  // test above holds that line.
+  //
+  // Measured at the wire rather than on `ladder.at`, because `arm` calls
+  // `landed()` immediately after and snaps the position onto whatever rung the
+  // host actually served. What the climb changes is the difficulty the *next*
+  // arming asks for, and that is a number the host is handed.
+  const nextRequestAfterOpening = (hints: boolean): number => {
+    const asked: number[] = []
+    const base = createStubHost({ seed: 0x5eed, reducedMotion: true })
+    const host: Host = {
+      next: (opts) => {
+        asked.push(opts?.difficulty ?? -1)
+        return base.next(opts)
+      },
+      report: (r) => base.report(r),
+      skip: (id) => base.skip?.(id),
+      haptic: () => undefined,
+      prefersReducedMotion: () => true,
+    }
+    const arena = new Arena(host, new Rng(0x5eed ^ 0x51de), { width: 900, height: 700 })
+    arena.begin(0)
+    const firstArming = asked.length
+    const res = arena.resonator
+    assert.ok(res, "no resonator was armed")
+    if (hints) {
+      for (let i = 0; i < HINT_STAGES; i++) arena.askHint(0)
+      assert.equal(arena.hint(0)?.given, true, "the whole tree did not state the answer")
+    }
+    grindToPrimes(arena)
+    assert.ok(sweepFactorisation(arena, res.target))
+    arena.enter(1000)
+    assert.equal(arena.opened, 1, "the resonator did not open")
+    assert.ok(asked.length > firstArming, "the next question was never asked for")
+    return asked[firstArming] as number
+  }
+
+  const blind = nextRequestAfterOpening(false)
+  const helped = nextRequestAfterOpening(true)
+  assert.ok(helped < blind, `a handed-over open climbed the ladder anyway: ${helped} vs ${blind}`)
+})
+
+test("a sheet over the frame is not thinking time, and does not unfold the tree", () => {
+  const r = rig(0x5eed)
+  const before = r.arena.hint(1000)?.stage ?? 0
+  assert.equal(before, 0, "a hint arrived one second into the question")
+
+  r.arena.pause(1000)
+  // Two minutes behind a paywall card, a parent gate or the how-to-play panel.
+  const during = r.arena.hint(121_000)?.stage ?? 0
+  assert.equal(during, 0, "the tree unfolded behind the host's sheet")
+  assert.deepEqual(r.arena.unfold(121_000), [], "a hint announced itself behind the sheet")
+  // And the control is inert behind it, like every other input in this game. A
+  // press that lands on a translucent host card is not the child asking for
+  // anything, and a tap that leaked through would unfold a tree they are not
+  // looking at — the same class of damage as a resting thumb flying the ship
+  // through the resonator behind a sheet.
+  assert.deepEqual(r.arena.askHint(121_000), [], "a tap behind the host's sheet asked for a hint")
+  assert.equal(r.arena.hint(121_000), null, "a tap behind the host's sheet unfolded the tree")
+
+  r.arena.resume(121_000)
+  const after = r.arena.hint(122_000)?.stage ?? 0
+  assert.equal(after, 0, "the sheet spent the child's quiet for them")
+
+  // Back from the sheet, asking works again.
+  r.arena.askHint(122_000)
+  assert.equal(r.arena.hint(122_000)?.stage, 1, "the control never came back after the sheet")
+})
+
+test("a new question starts in silence, however much of the last tree was up", () => {
+  const r = rig(0x5eed)
+  const first = r.arena.resonator
+  assert.ok(first)
+  for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint(0)
+  assert.equal(r.arena.hint(0)?.stage, r.arena.hint(0)?.stages)
+
+  grindToPrimes(r.arena)
+  assert.ok(sweepFactorisation(r.arena, first.target))
+  r.arena.enter(1000)
+
+  const next = r.arena.resonator
+  assert.ok(next)
+  assert.notEqual(next.questionId, first.questionId, "the same resonator came back")
+  assert.equal(r.arena.hint(1000), null, "the new question opened with the last one's tree up")
+})
+
+test("the tree the resonator is hinting is the tree of the field it is standing over", () => {
+  // The hint and the arena must be about the same number. If the tree were built
+  // off anything but the live target — a stale copy, the previous question, the
+  // request rather than the item served — a child would sweep exactly what they
+  // were shown and be refused.
+  for (const seed of [1, 7, 42, 1337, 90210, 0x5eed]) {
+    const r = rig(seed)
+    for (let round = 0; round < 6; round++) {
+      const res = r.arena.resonator
+      if (!res) break
+      for (let i = 0; i < HINT_STAGES; i++) r.arena.askHint(0)
+      const hint = r.arena.hint(0)
+      assert.ok(hint, `seed ${seed}: no hint for a live resonator`)
+      assert.equal(
+        (hint.placed.nodes[0] as PlacedNode).value,
+        res.target,
+        `seed ${seed}: the tree is about a different number than the ring`,
+      )
+      assert.equal(leafProduct(hint.placed), res.target)
+
+      // And the leaves are a hold the field can actually supply.
+      grindToPrimes(r.arena)
+      assert.ok(
+        sweepFactorisation(r.arena, res.target),
+        `seed ${seed}: the tree named primes the field does not have`,
+      )
+      r.arena.enter(1000 * (round + 1))
+    }
+  }
+})
+
+test("with no resonator there is nothing to hint about and nothing throws", () => {
+  const arena = new Arena(
+    {
+      next: () => ({ id: "x", prompt: "2 + 0", answer: "2", distractors: [], domain: "add", difficulty: 0 }),
+      report: () => undefined,
+      haptic: () => undefined,
+      prefersReducedMotion: () => true,
+    },
+    new Rng(3),
+    { width: 900, height: 700 },
+  )
+  // Every draw is `2`, which is not a target this game asks for, so the arena
+  // arms nothing at all.
+  arena.begin(0)
+  assert.equal(arena.resonator, null, "the arena armed a resonator on a target it refuses")
+  assert.equal(arena.hint(0), null)
+  assert.deepEqual(arena.askHint(0), [])
+  assert.deepEqual(arena.unfold(500_000), [])
+})

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -464,14 +464,100 @@ test("the shell is wired to the hint: a tap unfolds the tree, and so does the qu
         "the factor tree was on screen before anybody asked for it and before any quiet",
       )
 
-      // A tap on the control, where `hudLayout` says it is.
+      // A tap on the control, where `hudLayout` says it is. Down AND up: the
+      // control fires on release, so that a thumb coming to rest at the
+      // bottom-left of the screen — which is where the movement stick lives —
+      // does not ask for a hint nobody wanted.
+      const up = canvas.listeners.get("pointerup")?.[0]
+      assert.ok(up, "the release listener was not installed")
       const { cx, cy } = hudLayout(900, safeRect(900, 700)).hint
       down({ preventDefault() {}, pointerId: 9, pointerType: "touch", clientX: cx, clientY: cy })
+      wall += 16.7
+      t = pump(frames, 1, t)
+      up({ pointerId: 9, pointerType: "touch", clientX: cx, clientY: cy })
       counter.text.length = 0
       t = pump(frames, 3, t)
       assert.ok(
         counter.text.includes("?"),
         "tapping the hint control drew no tree at all — the control is not wired to the arena",
+      )
+
+      handle.unmount()
+    })
+
+    // A thumb that lands on the control and then flies the ship is a child
+    // reaching for the stick, not a child asking for anything. This is the exact
+    // gesture that broke the first cut: the control sits at the bottom-left of
+    // the safe area, which is where a left thumb comes to rest, and firing on
+    // pointer-DOWN meant that settling your hand there BOTH unfolded a tree
+    // nobody wanted AND swallowed the touch, so the ship would not move.
+    const rest = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 900, h: 700 }, rest, ({ host, frames, created }) => {
+      wall = 0
+      const stub = createStubHost({ seed: 0x1a771ce, reducedMotion: true })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      const move = canvas.listeners.get("pointermove")?.[0]
+      const up = canvas.listeners.get("pointerup")?.[0]
+      assert.ok(down && move && up)
+
+      let t = pump(frames, 8)
+      const { cx, cy } = hudLayout(900, safeRect(900, 700)).hint
+
+      // Thumb down on the control, then slid up and to the right to fly.
+      down({ preventDefault() {}, pointerId: 3, pointerType: "touch", clientX: cx, clientY: cy })
+      rest.text.length = 0
+      for (let i = 0; i < 40; i++) {
+        move({ pointerId: 3, pointerType: "touch", clientX: cx + 4 + i * 2, clientY: cy - i * 2 })
+        wall += 16.7
+        t = pump(frames, 1, t)
+      }
+      up({ pointerId: 3, pointerType: "touch", clientX: cx + 84, clientY: cy - 80 })
+      t = pump(frames, 3, t)
+      assert.equal(
+        rest.text.includes("?"),
+        false,
+        "resting a thumb on the control and then flying asked for a hint nobody wanted",
+      )
+
+      // And a thumb that lands on the control, sweeps out to fly, and comes
+      // back to where it started — which is what a stick held in a circle does
+      // every revolution. It ends up inside the control and it was never a tap.
+      down({ preventDefault() {}, pointerId: 5, pointerType: "touch", clientX: cx, clientY: cy })
+      // Deliberately inside `HINT_TAP_MS`, so that the only thing that can catch
+      // this gesture is the travel flag and not the duration.
+      for (let i = 0; i < 12; i++) {
+        const a = (i / 12) * Math.PI * 2
+        move({
+          pointerId: 5,
+          pointerType: "touch",
+          clientX: cx + Math.sin(a) * 70,
+          clientY: cy - 70 + Math.cos(a) * 70,
+        })
+        wall += 16.7
+        t = pump(frames, 1, t)
+      }
+      up({ pointerId: 5, pointerType: "touch", clientX: cx, clientY: cy })
+      t = pump(frames, 3, t)
+      assert.equal(
+        rest.text.includes("?"),
+        false,
+        "a stick swept in a circle back to where it started asked for a hint",
+      )
+
+      // A thumb that lands there and simply STAYS is not a tap either.
+      down({ preventDefault() {}, pointerId: 4, pointerType: "touch", clientX: cx, clientY: cy })
+      for (let i = 0; i < 60; i++) {
+        wall += 16.7
+        t = pump(frames, 1, t)
+      }
+      up({ pointerId: 4, pointerType: "touch", clientX: cx, clientY: cy })
+      t = pump(frames, 3, t)
+      assert.equal(
+        rest.text.includes("?"),
+        false,
+        "a thumb resting on the control for a second asked for a hint",
       )
       handle.unmount()
     })
@@ -494,8 +580,11 @@ test("the shell is wired to the hint: a tap unfolds the tree, and so does the qu
       assert.equal(quiet.text.includes("?"), false, "a hint arrived in the first fifth of a second")
 
       // Two minutes of a child sitting there, which is what "stuck" looks like.
-      for (let i = 0; i < 200 && !quiet.text.includes("?"); i++) {
-        wall += 600
+      // The hint's clock is PLAYED time now, accumulated in `Arena.step` off the
+      // frame delta, so this has to be real frames — which is also the point:
+      // `wall` moving on its own can no longer unfold anything.
+      for (let i = 0; i < 8000 && !quiet.text.includes("?"); i++) {
+        wall += 16.7
         t = pump(frames, 1, t)
       }
       assert.ok(
@@ -542,6 +631,7 @@ test("the shell is wired to the hint: a tap unfolds the tree, and so does the qu
         const keyDowns = handlers.get("keydown") ?? []
         assert.ok(keyDowns.length > 0, "the keyboard listener was not installed")
         for (const fn of keyDowns) fn({ key: "h", repeat: false, preventDefault() {} })
+        // A key has no release to wait for; `H` fires on the press.
         keys.text.length = 0
         t = pump(frames, 3, t)
         assert.ok(keys.text.includes("?"), "pressing H drew no tree — the key is not wired")

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -546,6 +546,29 @@ test("the shell is wired to the hint: a tap unfolds the tree, and so does the qu
         "a stick swept in a circle back to where it started asked for a hint",
       )
 
+      // A gesture the PLATFORM took away is not a tap.
+      //
+      // `pointercancel` is WKWebView saying the touch is no longer the child's —
+      // an edge drag, a palm rejected, a system gesture claiming it — and it
+      // arrives with the last known coordinates, so it satisfies every test a
+      // real tap satisfies. Routed into the release handler, which is where it
+      // used to go, a thumb that landed on the control and was cancelled 200ms
+      // later unfolded a stage. That is not a small leak: the clock deliberately
+      // stops one stage short of the reveal, so on a question the child has been
+      // sitting with, the phantom stage IS the one that states the answer.
+      const cancel = canvas.listeners.get("pointercancel")?.[0]
+      assert.ok(cancel, "the cancel listener was not installed")
+      down({ preventDefault() {}, pointerId: 6, pointerType: "touch", clientX: cx, clientY: cy })
+      wall += 200
+      t = pump(frames, 3, t)
+      cancel({ pointerId: 6, pointerType: "touch", clientX: cx, clientY: cy })
+      t = pump(frames, 3, t)
+      assert.equal(
+        rest.text.includes("?"),
+        false,
+        "a touch the platform cancelled asked for a hint the child never did",
+      )
+
       // A thumb that lands there and simply STAYS is not a tap either.
       down({ preventDefault() {}, pointerId: 4, pointerType: "touch", clientX: cx, clientY: cy })
       for (let i = 0; i < 60; i++) {

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -17,6 +17,8 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { mount } from "../contract.ts"
+import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
+import { hudLayout } from "../render/hud.ts"
 import { createStubHost } from "../stubHost.ts"
 
 type Listener = (event: unknown) => void
@@ -420,4 +422,138 @@ test("a pause that arrives while a thumb is down does not fly the ship on", () =
     assert.equal(reports.length, said, "an answer was reported across the sheet")
     handle.unmount()
   })
+})
+
+test("the shell is wired to the hint: a tap unfolds the tree, and so does the quiet", () => {
+  // The bug this file already carries a scar from, in a new place. `Arena.enter`
+  // was asserted to death in the rules tests and NEVER CALLED BY THE SHELL, and
+  // the whole reasoning layer was unreachable in the shipped game while every
+  // test was green. `askHint`, `unfold` and `Arena.hint` are three more calls
+  // that live entirely in the shell, and every assertion about them in
+  // `hint.test.ts` would pass with all three unwired — a hint system a child
+  // could never see, in a game whose whole problem is getting stuck.
+  //
+  // So this drives the REAL shell: the real pointer handler, the real loop, the
+  // real renderer, and asks whether a `?` ever reached the canvas.
+  const realNow = Date.now
+  const savedPerformance = Object.getOwnPropertyDescriptor(globalThis, "performance")
+  Date.now = () => 1_700_000_000_000
+  // The hint's quiet is measured against the wall clock the shell reads, so the
+  // wall clock has to be one this test owns. Nothing else in the loop uses it.
+  let wall = 0
+  Object.defineProperty(globalThis, "performance", {
+    configurable: true,
+    writable: true,
+    value: { now: () => wall },
+  })
+  try {
+    const counter = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 900, h: 700 }, counter, ({ host, frames, created }) => {
+      const stub = createStubHost({ seed: 0x1a771ce, reducedMotion: true })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      assert.ok(down, "the pointer listener was not installed")
+
+      let t = pump(frames, 8)
+      counter.text.length = 0
+      t = pump(frames, 2, t)
+      assert.equal(
+        counter.text.includes("?"),
+        false,
+        "the factor tree was on screen before anybody asked for it and before any quiet",
+      )
+
+      // A tap on the control, where `hudLayout` says it is.
+      const { cx, cy } = hudLayout(900, safeRect(900, 700)).hint
+      down({ preventDefault() {}, pointerId: 9, pointerType: "touch", clientX: cx, clientY: cy })
+      counter.text.length = 0
+      t = pump(frames, 3, t)
+      assert.ok(
+        counter.text.includes("?"),
+        "tapping the hint control drew no tree at all — the control is not wired to the arena",
+      )
+      handle.unmount()
+    })
+
+    // And the same thing again with nobody touching anything, on the clock.
+    const quiet = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 900, h: 700 }, quiet, ({ host, frames, created }) => {
+      wall = 0
+      const felt: string[] = []
+      const stub = createStubHost({
+        seed: 0x1a771ce,
+        reducedMotion: true,
+        onHaptic: (k) => felt.push(k),
+      })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      assert.ok(canvasOf(created))
+      let t = pump(frames, 8)
+      quiet.text.length = 0
+      t = pump(frames, 4, t)
+      assert.equal(quiet.text.includes("?"), false, "a hint arrived in the first fifth of a second")
+
+      // Two minutes of a child sitting there, which is what "stuck" looks like.
+      for (let i = 0; i < 200 && !quiet.text.includes("?"); i++) {
+        wall += 600
+        t = pump(frames, 1, t)
+      }
+      assert.ok(
+        quiet.text.includes("?"),
+        "two minutes with the question and the game never offered a thing",
+      )
+      // And it ARRIVED rather than merely appearing. Nobody touched anything for
+      // two minutes, so the only thing that can have made the hand buzz is the
+      // hint event reaching the shell — which is the sound, the ripple under the
+      // ring, and the reason a child looks down at all. Drawn without it, the
+      // tree fades in silently at the bottom of the screen while the child is
+      // watching a husk at the top.
+      assert.deepEqual(felt, ["light"], `the hint never announced itself: ${felt.join(",")}`)
+      handle.unmount()
+    })
+
+    // And on a keyboard, where the child has no thumb to put on the control.
+    // Tablet and desktop are equal targets in this pack, and `H` is the only way
+    // in on one of them.
+    const keys = { calls: 0, text: [] as string[] }
+    const savedAdd = Object.getOwnPropertyDescriptor(globalThis, "addEventListener")
+    const handlers = new Map<string, Array<(e: unknown) => void>>()
+    Object.defineProperty(globalThis, "addEventListener", {
+      configurable: true,
+      writable: true,
+      value: (type: string, fn: (e: unknown) => void) => {
+        handlers.set(type, [...(handlers.get(type) ?? []), fn])
+      },
+    })
+    try {
+      withBrowser({ w: 900, h: 700 }, keys, ({ host, frames, created }) => {
+        wall = 0
+        const stub = createStubHost({ seed: 0x1a771ce, reducedMotion: true })
+        const handle = mount(host as unknown as HTMLElement, stub)
+        assert.ok(canvasOf(created))
+        let t = pump(frames, 8)
+        keys.text.length = 0
+        t = pump(frames, 2, t)
+        assert.equal(keys.text.includes("?"), false, "a tree was up before the key was pressed")
+
+        // Every keydown listener on the window, because the shared how-to-play
+        // chrome installs one of its own before this pack installs the arena's
+        // and a real key press reaches both.
+        const keyDowns = handlers.get("keydown") ?? []
+        assert.ok(keyDowns.length > 0, "the keyboard listener was not installed")
+        for (const fn of keyDowns) fn({ key: "h", repeat: false, preventDefault() {} })
+        keys.text.length = 0
+        t = pump(frames, 3, t)
+        assert.ok(keys.text.includes("?"), "pressing H drew no tree — the key is not wired")
+        handle.unmount()
+      })
+    } finally {
+      if (savedAdd) Object.defineProperty(globalThis, "addEventListener", savedAdd)
+      else Reflect.deleteProperty(globalThis, "addEventListener")
+    }
+  } finally {
+    Date.now = realNow
+    if (savedPerformance) Object.defineProperty(globalThis, "performance", savedPerformance)
+    else Reflect.deleteProperty(globalThis, "performance")
+  }
 })


### PR DESCRIPTION
> "The Lattice is almost rad. But, it can be wildly hard. Trying to look at
> `642 - 530` and know that `2×2×2×2×7 = 112` is a pretty heroic task. But, if
> we could show the factorization tree as a dazzling hint … perhaps in a cool
> way like leaving some of the leaves blank or … maybe giving a partial like
> `16*7=112` … right now it's easy to get stuck and overwhelmed but … it could
> be OK to basically reveal the answer in a really satisfying way."

Two hard steps were stacked with nothing between them: work out `642 − 530`, and
*then* work out that the answer is four twos and a seven. A child who could do
the first and not the second had no way forward and no way to ask.

## The escalation

`game/tree.ts` builds the real factor tree off `splitPair` — the same function a
shot uses, so it is balanced and it is the shape the child has been watching
husks make all session. `game/hint.ts` unfolds it as a **masking of one tree**:

| stage | what appears | what it takes |
|---|---|---|
| 1 | **The shape** — every node blank. How many pieces the hold needs, and how they branch. | nothing |
| 2 | **One prime** — the largest leaf (the `7` under four twos). | nothing |
| 3 | **Half a split** — the smaller root child, sibling blank (`129 ⟶ 3 and ⟶ ?`) | usually nothing |
| 4 | **The partial** — `16 × 7`, root still blank. The stepping stone. | a deliberate tap |
| 5 | **The leaves** — the hold spelled out. Nobody is stuck past here. | a deliberate tap |
| 6 | **The whole tree**, root included. The sentence closes. | a deliberate tap |

A prime target (the wall) has two stages: a lonely blank node, then the numeral.
Real output on a seed:

```
112  s1: ?  | ? ?   | ? ? ? ?  | ? ?      s4: ?   | 14 8 | 7 ? ? ? | ? ?
     s2: ?  | ? ?   | 7 ? ? ?  | ? ?      s5: ?   | 14 8 | 7 2 ? 2 | 2 2
     s3: ?  | ? 8   | 7 ? ? ?  | ? ?      s6: 112 | 14 8 | 7 2 4 2 | 2 2
```

Where the line between "nothing" and "a tap" falls is **computed from the tree**,
not fixed at a number. When the largest leaf *is* the larger root child, stage 3
lights both halves at once — `129 → 3 · 43`, `28 → 4 · 7`. Over the band's 410
composite targets that is 112–123 of them depending on the seed, **roughly three
in ten**, so a hardcoded 3 would be wrong for about a third of the composites.

## Both paths, and neither is a clock

A brass ring with a three-node tree glyph (no word — ~50 languages), plus `H`.
Automatic arrival has **no countdown, no ring filling, no banner**: the tree fades
in with two rising notes and the same light tick a swept mote gives.

**And the clock stops at `freeStages`.** Time alone gives the shape, one prime and
usually half a split, then stops and leaves the rest to the child. Nothing that
happens to a child who is merely sitting there can reach a stage that states the
answer.

`firstHintMs` is **a pure function of the item, monotone non-decreasing in the
item's difficulty** — a sum of non-negative multiples of the rung that served it
and the tile count, asserted exhaustively. A harder item buys *more* silence.
**Lattice has no `window(d)` and this adds none**; nothing here is a deadline.

It is **played** time, accumulated in `Arena.step`, not the wall clock — so a host
sheet costs nothing *and* neither does a backgrounded webview, which no pack is
ever told about.

## A hint costs the child nothing — and that had to be checked at the wire

**The first commit got this wrong, and the self-review caught it.** It closed a
hinted question with `host.skip` rather than reporting it, so a `correct` after
the game printed the answer would not be filed as a claim about the child.
Honest, and invisible from inside the canvas. `game-host` says of `skip`,
verbatim: it *"does not advance the session progress fraction, because that
counts answered questions"* — and the host paints that fraction as a hairline
across the top of every pack, the one `hud.ts` already reserves space for.

| five hinted rounds | opened | ceremonies | reports | progress hairline |
|---|---|---|---|---|
| first commit | 5 | 5 | **0** | **0 / 40, all sitting** |
| now | 5 | 5 | 5 | 5 / 40 |

The child who leans on the hint is the child this feature exists for, and theirs
was the bar that never moved. Worse, it needed no input at all: `tiles` is 1 for a
prime, so a wall's quiet is short and stage 2 of a wall *is* the numeral — 51
seconds of hunting one mote, which is the entire task on a wall round, and the
answer was printed at the finish line and the unaided answer thrown away. One
round in five is a wall.

So the report goes to the host as it always did, and the clock stops short of the
line. What survives of the concern is the one decision the game owns: the ladder
**holds rather than climbing** on a handed-over open — three rungs of harder
arithmetic is the one thing a hint could still take, and holding position is the
absence of a penalty rather than one.

Otherwise: not a point, not the chain, not BEST, not the ceremony, no counter of
hints taken, no language about needing help.

## The juice fires on the maths

A leaf whose prime reaches the hold gets a brass collar and throws a spark the
frame it earns one; the last one throws a bigger spark. `2·2·2·2·7` assembling
itself — the only thing in the game that celebrates a *factorisation* rather than
a resonator. Multiset walk, not `includes`: four twos on the tree and two in the
hold collar exactly two.

`revealPaceMs` is the only thing that reads the child, and it reads the chain, not
a clock: calm at the bottom, two frames on a chain of six, because skipping the
ceremony is the reward for mastery.

## The ship

Already fixed in #716 — `SHIP_ACCEL`/`SHIP_MAX` no longer exist. Dynamics are a
fraction of the arena diagonal per second (it used to cover 1.72× more screen per
second on a phone than the tablet it was tuned on), solved in closed form rather
than stepped (identical at 20/45/60/144fps), coast down from 143px to 34–58px,
plus a stick dead zone/response curve and a 55ms hull ease. Left alone.

## Verification

`tsc` clean; **182 tests, 5 consecutive green runs**; `build` and `build:pack` fine.

- **The generator is property-tested**: every whole number 12–999 × 12 seeds
  (~11,900 trees), every node the exact product of its two children, every leaf
  prime, leaves exactly `primeFactors(n)`. A tree that lies sends a child to
  sweep 56 and be refused by the game that told them to.
- **66 mutations run**, each verified to fail the assertion that covers it.
  Several found real gaps that were fixed rather than waved through: stage 5 had
  no assertion at all; the "clicks into place" walk was untestable inside the
  renderer; the tree box could be squeezed to 1px; and three assertions could not
  fail — `assert.ok(l.tree.h > 0)` and `assert.ok(l.tree.w > 0 && l.tree.x >= 0)`
  against `Math.max`-guarded values, and `assert.ok(hint.stage >= 1)` under an
  `assert.ok(hint)` where `hint()` returns null below stage 1.
- **The shell is tested, not just the rules.** `askHint`, `unfold` and
  `Arena.hint` live entirely in `mount.ts`, and every `hint.test.ts` assertion
  passes with all three unwired — the exact scar this pack carries from
  `Arena.enter`. `mount.test.ts` drives the real pointer handler, loop and
  renderer and asks whether a `?` ever reaches the canvas: on a tap, on `H`, and
  on two silent minutes.
- The tree is built off `rng.fork(target)`, so no seeded field, husk layout or
  pacing measurement moves by a draw.

### Other things the self-review found, and their fixes

- **The control fired on pointer-DOWN and swallowed the touch**, at the
  bottom-left of the safe area — where a left thumb rests, on the half of the
  screen that *is* the movement stick. Settling your hand there both unfolded a
  tree nobody asked for and left the ship unable to move. Now it fires on
  release, for a press that never strayed 10px **along its path** (a stick held
  in a circle returns to its origin every revolution, so an endpoint check calls
  that a tap) and was not held past 400ms.
- **`rowStep` went negative** on a box under 18px and drew the tree upside down
  through the counters; the layout could return a box exactly 1px tall at
  1024×200; the control could ride up under the host's exit chevron. All three
  floored, and asserted on panes short enough to prove it.
- **`arena.hint()` is memoised on the stage**, so the draw path no longer
  allocates a Set and re-walks the tree sixty times a second.

Fixed along the way: `Arena.elapsed` kept climbing behind a host sheet.


### Third round of self-review

- **`pointercancel` was wired to the release handler.** A cancel is not a
  release — it is the platform saying the touch is no longer the child's, and it
  carries the last known coordinates, so it satisfied every test a real tap
  satisfies. A thumb that landed on the control and was cancelled 200ms later
  unfolded a stage; and because the clock stops one stage short of the reveal,
  on a question the child had been sitting with that phantom stage *is* the one
  that states the answer.
- **The layout preferred legibility over the counters, and over the canvas.**
  `TREE_MIN_H` was what the deepest tree wants to be *read* at, which beat the
  ceiling on any pane under ~340px and drew the tree through OPENED and CHAIN —
  and pushed the box off the top of the screen at 1024×200. It is now the only
  bound that is actually about correctness (the row step changes sign under
  2r = 18), staying inside the safe area wins over everything, and the two
  short-pane viewports that had been *moved* to dodge the regression are back.
- **Three prose counts were wrong** (573 is every askable target; 163 of those
  are prime), and the stage-3 paragraph in `hint.ts` was contradicting the test
  directly below it, using that test's counterexample as its example.
- The row-step clamp in `scene.ts` is now documented as **unreachable defence**,
  because `Scene.resize` floors the canvas at 320×320 whatever the element
  measures. An unfalsifiable comment is worse than no comment.