### PR TITLE
dynawalla/games/truedraw: the street uses the whole glass, and being right is finally an event

### DIFF
--- a/dynawalla/games/truedraw/src/audio/audio.test.ts
+++ b/dynawalla/games/truedraw/src/audio/audio.test.ts
@@ -1,0 +1,188 @@
+// THE AUDIO GRAPH, DRIVEN THROUGH A FAKE CONTEXT.
+//
+// Web Audio has one trap that this pack has already been bitten by elsewhere in the
+// fleet and that no amount of listening finds reliably:
+//
+//   **`GainNode.gain` defaults to 1.**
+//
+// A gain node created and connected but never set is not "neutral" — it is unity,
+// which at the point in this graph where the octave joins the fundamental is the
+// whole of the fundamental's level again, as a bare octave, on every strike. It
+// does not throw, it does not warn, and on a laptop speaker it sounds like the
+// timbre simply got harsher. On a child's headphones it is a different instrument.
+//
+// So this file plays every voice into a recording context and asserts that no gain
+// node is ever left at its default. Found by mutation: deleting the
+// `overtoneGain.gain.setValueAtTime(...)` line left the entire suite green.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Audio, VOICE_POOL, voiceCount, voiceFor } from "./audio.ts"
+import { OUTCOMES } from "../game/response.ts"
+
+type Recorded = { set: boolean; ramps: number[] }
+
+function fakeAudio(): { ctx: unknown; gains: Recorded[]; count: () => number } {
+  const gains: Recorded[] = []
+  let oscillators = 0
+  const node = () => ({ connect: (next: unknown) => next })
+  const ctx = {
+    currentTime: 0,
+    state: "running",
+    createGain: () => {
+      const rec: Recorded = { set: false, ramps: [] }
+      gains.push(rec)
+      const schedule = (v: number): void => {
+        rec.set = true
+        rec.ramps.push(v)
+      }
+      return {
+        gain: {
+          value: 1,
+          setValueAtTime: schedule,
+          exponentialRampToValueAtTime: schedule,
+          linearRampToValueAtTime: schedule,
+          cancelScheduledValues: () => undefined,
+        },
+        ...node(),
+      }
+    },
+    createOscillator: () => {
+      oscillators += 1
+      return {
+        type: "sine",
+        frequency: { setValueAtTime: () => undefined, exponentialRampToValueAtTime: () => undefined },
+        start: () => undefined,
+        stop: () => undefined,
+        ...node(),
+      }
+    },
+    createDynamicsCompressor: () => ({
+      threshold: { value: 0 },
+      knee: { value: 0 },
+      ratio: { value: 1 },
+      attack: { value: 0 },
+      release: { value: 0 },
+      ...node(),
+    }),
+    createWaveShaper: () => ({ curve: null, oversample: "none", ...node() }),
+    createBiquadFilter: () => ({
+      type: "peaking",
+      frequency: { value: 0 },
+      Q: { value: 0 },
+      gain: { value: 0 },
+      ...node(),
+    }),
+    destination: {},
+    resume: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+  }
+  // A closure, not a snapshot: `oscillators` is a number, and returning it by
+  // value hands the caller the count as it was BEFORE anything played — which is
+  // always zero, and which makes every assertion built on it vacuous.
+  return { ctx, gains, count: () => oscillators }
+}
+
+/**
+ * Play something into a recording context and report only what THAT made.
+ *
+ * The master bus and the shared safety bus are built first and are excluded by
+ * baseline rather than by index: several of their gains are pass-throughs at
+ * unity by design, and a test that could not tell those from a voice envelope
+ * would be asserting the shared module's business, not this file's.
+ */
+function play(fn: (audio: Audio) => void): { gains: Recorded[]; oscillators: number } {
+  const fake = fakeAudio()
+  const previous = globalThis.AudioContext
+  ;(globalThis as unknown as { AudioContext: unknown }).AudioContext = function Ctor() {
+    return fake.ctx
+  }
+  try {
+    const audio = new Audio()
+    // Builds the context and the safety bus, so everything after this is ours.
+    audio.resume()
+    const baseline = fake.gains.length
+    fn(audio)
+    return { gains: fake.gains.slice(baseline), oscillators: fake.count() }
+  } finally {
+    ;(globalThis as unknown as { AudioContext: unknown }).AudioContext = previous
+  }
+}
+
+test("NO GAIN NODE IS EVER LEFT AT ITS DEFAULT OF 1", () => {
+  // The trap in one line. An unset gain is not neutral, it is unity — and at the
+  // point where the octave joins the fundamental, unity is the whole fundamental
+  // again as a bare octave, on every strike, in every voice.
+  for (const outcome of OUTCOMES) {
+    // `lapse` builds no graph at all and must not: a tone at the end of a window a
+    // child was still thinking through is a buzzer aimed at slowness.
+    for (let voice = 0; voice < voiceCount(outcome); voice++) {
+      const { gains } = play((audio) => {
+        audio.outcome(outcome, voice)
+      })
+      assert.ok(gains.length > 0, `${outcome} voice ${String(voice)} built no graph at all`)
+      for (const [i, gain] of gains.entries()) {
+        assert.ok(
+          gain.set,
+          `${outcome} voice ${String(voice)}: gain node ${String(i)} was never set — it is playing at unity`,
+        )
+      }
+    }
+  }
+  for (const fn of [(a: Audio) => a.cue(), (a: Audio) => a.over()] as const) {
+    const { gains } = play(fn)
+    assert.ok(gains.length > 0)
+    for (const [i, gain] of gains.entries()) {
+      assert.ok(gain.set, `gain node ${String(i)} was never set`)
+    }
+  }
+})
+
+test("the overtone is a quiet colour, never a second fundamental", () => {
+  // The same trap, from the other side: every voice's `bright` must be well under
+  // unity, or the "quieter triangle octave" in the docblock is a lie.
+  for (const pool of Object.values(VOICE_POOL)) {
+    for (const voice of pool) {
+      assert.ok(voice.bright > 0, `a silent overtone is not a mallet: ${voice.degrees.join(",")}`)
+      assert.ok(voice.bright < 0.5, `an overtone at ${String(voice.bright)} is a second fundamental`)
+    }
+  }
+})
+
+test("every voice actually strikes, and a silent outcome touches nothing", () => {
+  for (const outcome of OUTCOMES) {
+    const voices = voiceCount(outcome)
+    if (voices === 0) {
+      const { oscillators } = play((audio) => {
+        audio.outcome(outcome, 0)
+      })
+      assert.equal(oscillators, 0, `${outcome} made a sound and must not`)
+      continue
+    }
+    for (let v = 0; v < voices; v++) {
+      const voice = voiceFor(outcome, v)
+      assert.ok(voice)
+      const { oscillators } = play((audio) => {
+        audio.outcome(outcome, v)
+      })
+      // Two oscillators per strike: the sine body and its triangle octave.
+      assert.equal(
+        oscillators,
+        voice.degrees.length * 2,
+        `${outcome} voice ${String(v)} struck ${String(oscillators / 2)} of ${String(voice.degrees.length)} notes`,
+      )
+    }
+  }
+})
+
+test("a voice index out of range wraps rather than going silent", () => {
+  // `flourish.ts` draws the index and `audio.ts` is handed it. A future change to
+  // either pool size must not be able to produce a silent celebration.
+  for (const outcome of OUTCOMES) {
+    if (voiceCount(outcome) === 0) continue
+    for (const index of [-3, -1, 0, 1, 99]) {
+      assert.ok(voiceFor(outcome, index), `${outcome} went silent at index ${String(index)}`)
+    }
+  }
+})

--- a/dynawalla/games/truedraw/src/audio/audio.ts
+++ b/dynawalla/games/truedraw/src/audio/audio.ts
@@ -1,17 +1,40 @@
 // Asset-free Web Audio: a struck felt-mallet timbre over a C5–C6 pentatonic,
 // plus one wooden knock for the slate.
 //
-// The important entries in the table are the ones that are not there. **A wrong
-// verdict makes no sound.** Not a buzz, not a thud, not a muted click — nothing,
-// in either direction: banking a counterfeit and throwing away good money are both
-// silent. The street declines to acknowledge a wrong call, the bag simply has fewer
-// coins in it, and an audio engine that sneaked in a "you got it wrong" cue would
-// undo the entire design. So `dud` and `burn` are absent from `VOICES` and
-// `outcome()` returns before touching the context.
+// ── WHAT CHANGED, AND THE ONE LINE THAT DID NOT ─────────────────────────────
 //
-// `lapse` is absent for a different reason and it is the more important one: a tone
-// at the end of a window a child was still thinking through is a buzzer aimed at
-// slowness. There is no sound for running out of time.
+// The founder's playtest: *"success and failure sounds need to be awesome and
+// varied."* They were neither. There was exactly ONE bank cue and ONE spot cue,
+// so the twentieth correct call sounded identical to the first, and a miss made
+// no sound at all.
+//
+// Both halves are now POOLS, picked with the run's seeded RNG (`flourish.ts`
+// owns the pick, so the sound and the animation are one decision and can never
+// disagree). Same seed, same sequence of voices; different seeds, different runs.
+//
+// **A MISS NOW HAS A VOICE, AND IT IS NOT A BUZZER.** The line this file used to
+// hold — "a wrong verdict makes no sound" — was written when a miss showed the
+// child nothing at all. A miss now COMPLETES THE SUM in front of them, in the
+// accent, held on screen, and the sound is the audio half of that: a quiet,
+// RISING two-note resolution, the sound of a value settling into place. It is
+// never a fall, never a dissonance, never a thud, and it is a fifth the loudness
+// of the smallest celebration.
+//
+// The invariant that governs it has not moved a millimetre. `EXPERIENCE_DESIGN.md`
+// says `energy(SLIP) < energy(SEAT)`, and `game/energy.ts` computes that from the
+// numbers in this file rather than from a comment about them:
+//
+//     energy(dud)  = 900 × 3 × 0.045 = 121.5
+//     energy(bank) = 500 × 3 × 0.20  = 300
+//     energy(spot) = 940 × 4 × 0.24  = 902.4
+//
+// so being wrong stays, by construction, the least interesting thing that can
+// happen. `energy.test.ts` fails the moment that stops being true.
+//
+// `lapse` is still absent, and for the reason it always was, which is the more
+// important one: a tone at the end of a window a child was still thinking through
+// is a buzzer aimed at slowness. There is no sound for running out of time, and
+// there must never be one.
 
 import type { Outcome } from "../game/response.ts"
 import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
@@ -19,30 +42,87 @@ import { createSafetyBus } from "../../../../packs/shared/game-audio/index.ts"
 /** C5 · D5 · E5 · G5 · A5 · C6, in Hz. Exact enough; nothing compares them. */
 const PENTATONIC = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5]
 
-type Voice = {
+export type Voice = {
   /** Indices into `PENTATONIC`, struck in order. */
   readonly degrees: readonly number[]
   /** Seconds between strikes. */
   readonly spacing: number
   readonly gain: number
   readonly decay: number
+  /**
+   * How much octave sits over the fundamental, 0..1. The felt mallet's hardness.
+   * Varying it is most of why two voices with the same notes are not the same
+   * sound.
+   */
+  readonly bright: number
+  /** Transposition in whole pentatonic steps. Lets one shape sit in two registers. */
+  readonly lift?: number
 }
 
 /**
- * What each outcome sounds like. `wild` is deliberately absent — see above.
- * `game/energy.ts` reads `gain` out of here so the "being wrong is never the
- * loudest thing" invariant is checked against the real numbers rather than
- * against a comment.
+ * Every voice each outcome can speak with. `lapse` has none and must not get one.
+ *
+ * The pools are deliberately small — three apiece. A pool of ten is not four times
+ * as varied as a pool of three, it is four times as much surface for one of them to
+ * be subtly wrong on one device, and the thing a child actually notices is that the
+ * game is not repeating itself.
  */
-export const VOICES: Partial<Record<Outcome, Voice>> = {
-  // Struck once, cleanly, high, and then a coin lands: the sound of banking a
-  // true claim.
-  bank: { degrees: [4, 5], spacing: 0.075, gain: 0.2, decay: 0.44 },
-  // A bow, and two notes falling into a third. Warmer and longer than a bank,
-  // because spotting a counterfeit is the harder thing to do and this is the
-  // game's one piece of applause.
-  spot: { degrees: [5, 2, 4], spacing: 0.12, gain: 0.24, decay: 0.9 },
-  // `dud`, `burn` and `lapse` have no entry, and must not get one. See above.
+export const VOICE_POOL: Partial<Record<Outcome, readonly Voice[]>> = {
+  // Banking a true claim. Struck cleanly, high, and short — the sound of a card
+  // going into a pile.
+  bank: [
+    { degrees: [4, 5], spacing: 0.075, gain: 0.2, decay: 0.44, bright: 0.22 },
+    { degrees: [3, 5], spacing: 0.068, gain: 0.19, decay: 0.5, bright: 0.3 },
+    { degrees: [2, 4, 5], spacing: 0.055, gain: 0.18, decay: 0.4, bright: 0.16 },
+  ],
+  // Spotting a counterfeit. Warmer, longer and three notes wide, because it is the
+  // harder thing to do and it is the game's one piece of applause.
+  spot: [
+    { degrees: [5, 2, 4], spacing: 0.12, gain: 0.24, decay: 0.9, bright: 0.26 },
+    { degrees: [0, 3, 5], spacing: 0.105, gain: 0.23, decay: 1.0, bright: 0.34 },
+    { degrees: [4, 5, 4, 5], spacing: 0.085, gain: 0.22, decay: 0.82, bright: 0.2, lift: -1 },
+  ],
+  // A miss. RISING, quiet, unhurried: the sound of the true value arriving, not of
+  // a mistake being announced. Every one of these is a fifth of a bank's gain and
+  // none of them descends.
+  dud: [
+    { degrees: [0, 2], spacing: 0.16, gain: 0.045, decay: 1.0, bright: 0.1 },
+    { degrees: [0, 3], spacing: 0.185, gain: 0.042, decay: 1.1, bright: 0.08 },
+    { degrees: [1, 3], spacing: 0.15, gain: 0.04, decay: 0.95, bright: 0.12 },
+  ],
+  burn: [
+    { degrees: [0, 3], spacing: 0.16, gain: 0.045, decay: 1.0, bright: 0.1 },
+    { degrees: [1, 4], spacing: 0.175, gain: 0.042, decay: 1.05, bright: 0.09 },
+    { degrees: [0, 2, 4], spacing: 0.13, gain: 0.04, decay: 0.9, bright: 0.11 },
+  ],
+  // `lapse` has no entry, and must not get one. See above.
+}
+
+/**
+ * The LOUDEST voice each outcome can speak with.
+ *
+ * `game/energy.ts` reads `gain` out of here to check "being wrong is never the
+ * loudest thing", so it has to be told about the worst case rather than about the
+ * average one — a pool whose third member was twice as loud as its first would
+ * otherwise pass an invariant it breaks every third round.
+ */
+export const VOICES: Partial<Record<Outcome, Voice>> = Object.fromEntries(
+  Object.entries(VOICE_POOL).map(([kind, pool]) => [
+    kind,
+    pool.reduce((loudest, v) => (v.gain > loudest.gain ? v : loudest)),
+  ]),
+) as Partial<Record<Outcome, Voice>>
+
+/** How many voices this outcome can speak with. Zero when it is silent. */
+export function voiceCount(outcome: Outcome): number {
+  return VOICE_POOL[outcome]?.length ?? 0
+}
+
+/** The `index`th voice, wrapped. Null for the outcomes that say nothing. */
+export function voiceFor(outcome: Outcome, index: number): Voice | null {
+  const pool = VOICE_POOL[outcome]
+  if (!pool || pool.length === 0) return null
+  return pool[((index % pool.length) + pool.length) % pool.length] ?? null
 }
 
 export class Audio {
@@ -79,16 +159,23 @@ export class Audio {
     osc.stop(t + 0.2)
   }
 
-  outcome(kind: Outcome): void {
-    const voice = VOICES[kind]
-    // `dud`, `burn` and `lapse` land here and leave. Silence is the whole of it.
+  /**
+   * The outcome, in the voice `flourish.ts` drew for it.
+   *
+   * `index` comes from the same seeded pick that chose the animation, so the sound
+   * and the picture are one decision. `lapse` lands here and leaves.
+   */
+  outcome(kind: Outcome, index = 0): void {
+    const voice = voiceFor(kind, index)
     if (!voice) return
     const ctx = this.context()
     const bus = this.bus
     if (!ctx || !bus) return
     const t0 = ctx.currentTime
-    voice.degrees.forEach((degree, index) => {
-      this.strike(ctx, bus, PENTATONIC[degree] ?? 523.25, t0 + index * voice.spacing, voice)
+    const lift = voice.lift ?? 0
+    voice.degrees.forEach((degree, i) => {
+      const step = Math.max(0, Math.min(PENTATONIC.length - 1, degree + lift))
+      this.strike(ctx, bus, PENTATONIC[step] ?? 523.25, t0 + i * voice.spacing, voice)
     })
   }
 
@@ -98,7 +185,11 @@ export class Audio {
     const bus = this.bus
     if (!ctx || !bus) return
     const t0 = ctx.currentTime
-    const voice: Voice = { degrees: [], spacing: 0, gain: 0.14, decay: 1.1 }
+    const voice: Pick<Voice, "gain" | "decay" | "bright"> = {
+      gain: 0.14,
+      decay: 1.1,
+      bright: 0.22,
+    }
     this.strike(ctx, bus, 261.63, t0, voice)
     this.strike(ctx, bus, 174.61, t0 + 0.22, voice)
   }
@@ -120,7 +211,7 @@ export class Audio {
     bus: GainNode,
     hz: number,
     at: number,
-    voice: Pick<Voice, "gain" | "decay">,
+    voice: Pick<Voice, "gain" | "decay" | "bright">,
   ): void {
     const env = ctx.createGain()
     env.gain.setValueAtTime(0.0001, at)
@@ -139,7 +230,9 @@ export class Audio {
     const overtoneGain = ctx.createGain()
     overtone.type = "triangle"
     overtone.frequency.setValueAtTime(hz * 2, at)
-    overtoneGain.gain.setValueAtTime(0.22, at)
+    // `GainNode.gain` defaults to 1, which at this point in the graph is the
+    // fundamental's whole level again as a bare octave. It is always set.
+    overtoneGain.gain.setValueAtTime(voice.bright, at)
     overtone.connect(overtoneGain).connect(env)
     overtone.start(at)
     overtone.stop(at + voice.decay * 0.6)

--- a/dynawalla/games/truedraw/src/game/energy.test.ts
+++ b/dynawalla/games/truedraw/src/game/energy.test.ts
@@ -1,22 +1,84 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { VOICES } from "../audio/audio.ts"
+import { VOICE_POOL, VOICES } from "../audio/audio.ts"
 import { energy, HAPTIC, MOVERS, TIMINGS } from "./energy.ts"
 import { OUTCOMES } from "./response.ts"
 import { TIMING, TIMING_REDUCED } from "./round.ts"
 
-test("a wrong verdict has no reaction at all — in either direction", () => {
-  // The bag losing coins is the ledger telling the truth, not a reaction to the
-  // child. Nothing sounds, nothing buzzes, nothing flashes, the caller does not move.
-  for (const timing of TIMINGS) {
-    assert.equal(energy("dud", timing), 0)
-    assert.equal(energy("burn", timing), 0)
+test("A MISS IS A STATEMENT OF FACT AND NEVER A PUNISHMENT", () => {
+  // This test used to say `energy("dud") === 0` — a wrong verdict made no sound and
+  // put no mark on the slate, so it was trivially the quietest thing in the game.
+  // That kept the invariant by having nothing to weigh, and it spent the single most
+  // teachable second in the game showing the child nothing at all.
+  //
+  // A miss now COMPLETES THE SUM in the accent and says one quiet rising figure over
+  // it. So the invariant has to be checked rather than assumed, and these are the
+  // three things that keep it honest.
+
+  // 1. It is a fifth of the smallest celebration, and it never got louder later.
+  const missGain = VOICES.dud?.gain ?? 0
+  const bankGain = VOICES.bank?.gain ?? 0
+  assert.ok(missGain > 0, "a miss has a voice now — see audio.ts")
+  assert.ok(
+    missGain <= bankGain * 0.25,
+    `a miss speaks at ${String(missGain)} against a bank's ${String(bankGain)}`,
+  )
+  // ...and that is true of EVERY voice in the pool, not just the loudest one the
+  // energy calculation happens to read.
+  for (const voice of VOICE_POOL.dud ?? []) assert.ok(voice.gain <= bankGain * 0.25)
+  for (const voice of VOICE_POOL.burn ?? []) assert.ok(voice.gain <= bankGain * 0.25)
+
+  // 1b. And `energy()` is told about the WORST case. `VOICES` is derived from the
+  //     pools, and if that derivation picked the quietest member instead of the
+  //     loudest, every check in this file would pass while the game played
+  //     something louder on two rounds in three. Found by mutation: reversing the
+  //     comparison in `audio.ts` left the whole suite green.
+  for (const outcome of OUTCOMES) {
+    const pool = VOICE_POOL[outcome]
+    if (!pool || pool.length === 0) {
+      assert.equal(VOICES[outcome], undefined, outcome)
+      continue
+    }
+    assert.equal(
+      VOICES[outcome]?.gain,
+      Math.max(...pool.map((v) => v.gain)),
+      `${outcome}: energy() is weighing something other than the loudest voice in the pool`,
+    )
   }
-  assert.equal(VOICES.dud, undefined, "there is no dud voice and there must not be one")
-  assert.equal(VOICES.burn, undefined, "there is no burn voice and there must not be one")
+
+  // 2. NOTHING BUZZES. A motor pulse on a wrong answer is a buzzer you can feel: it
+  //    tells a masher that something registered, which is the acknowledgement the
+  //    design withholds. This one has not moved and must not.
   assert.equal(HAPTIC.dud, null, "a motor pulse is a buzzer you can feel")
   assert.equal(HAPTIC.burn, null)
+
+  // 3. And the energy, computed from the real durations, mover counts and gains, is
+  //    still a fraction of either correct verdict in BOTH timing branches.
+  for (const timing of TIMINGS) {
+    for (const wrong of ["dud", "burn"] as const) {
+      assert.ok(
+        energy(wrong, timing) < energy("bank", timing) * 0.8,
+        `${wrong} ${energy(wrong, timing).toFixed(1)} against bank ${energy("bank", timing).toFixed(1)}`,
+      )
+    }
+  }
+})
+
+test("a miss voice never falls — it is the answer arriving, not a verdict on the child", () => {
+  // A descending figure is the universal sound of "no". Every miss voice in the pool
+  // rises, and the ones that repeat a degree do not count as falling.
+  for (const kind of ["dud", "burn"] as const) {
+    for (const voice of VOICE_POOL[kind] ?? []) {
+      const degrees = voice.degrees
+      for (let i = 1; i < degrees.length; i++) {
+        assert.ok(
+          (degrees[i] ?? 0) >= (degrees[i - 1] ?? 0),
+          `${kind} voice ${degrees.join(">")} falls`,
+        )
+      }
+    }
+  }
 })
 
 test("a lapse is the quietest thing in the game, because it is not a failure", () => {
@@ -50,7 +112,11 @@ test("reduced motion is a branch, not a deletion", () => {
     assert.ok(TIMING_REDUCED.verdict[kind] > 0, kind)
     assert.ok(TIMING_REDUCED.verdict[kind] < TIMING.verdict[kind], kind)
   }
-  // The ones that cannot shrink: there is no motion in a silent loss to reduce.
+  // The ones that must NOT shrink. Most of a miss beat is a completed sum standing
+  // still being read, and reading time is not motion: shortening it would take a
+  // child who asked for less movement and give them less time to see the answer.
+  // What reduced motion changes there is HOW the sum completes — a cross-fade in
+  // place instead of a rolling counter wheel.
   assert.equal(TIMING_REDUCED.verdict.dud, TIMING.verdict.dud)
   assert.equal(TIMING_REDUCED.verdict.burn, TIMING.verdict.burn)
 })
@@ -60,6 +126,23 @@ test("only the two correct verdicts buzz, and nothing buzzes at the cue", () => 
   // never read the slate.
   const buzzing = OUTCOMES.filter((o) => HAPTIC[o] !== null)
   assert.deepEqual(buzzing, ["bank", "spot"], `${buzzing.join(",")} buzz`)
+})
+
+test("the mover table counts what the renderer actually draws", () => {
+  // `MOVERS` is one half of the energy invariant, and a table that UNDERSTATES a
+  // reaction makes the invariant pass by lying about it rather than by holding it.
+  // Found by mutation: zeroing the two miss counts left every check in this file
+  // green while the game went on drawing the reveal.
+  //
+  // A miss draws three things — the sum completing itself, the slate leaving, and
+  // the coins coming back out — and it must be counted as three.
+  assert.ok(MOVERS.dud >= 3, `a dud draws the reveal, the slate and the coins: ${String(MOVERS.dud)}`)
+  assert.ok(MOVERS.burn >= 3, `a burn draws the reveal, the slate and the coins: ${String(MOVERS.burn)}`)
+  // A lapse draws the least of anything, and still draws something: the slate sinks.
+  assert.equal(MOVERS.lapse, 1)
+  for (const outcome of OUTCOMES) {
+    assert.ok(MOVERS[outcome] >= 1, `${outcome} draws nothing at all`)
+  }
 })
 
 test("every outcome has a mover count and a duration — no table is left short", () => {

--- a/dynawalla/games/truedraw/src/game/energy.ts
+++ b/dynawalla/games/truedraw/src/game/energy.ts
@@ -5,14 +5,27 @@
 // as `energy(SLIP) < energy(SEAT)`, where energy is the product of how long a
 // reaction runs, how many things move, and how loud it is.
 //
-// This game still states it stronger, and the bag did not weaken it. A wrong
-// verdict now has a consequence — coins leave — but a consequence is not a
-// reaction: nothing sounds, nothing buzzes, no colour flashes, the caller does not
-// move and the slate is not marked. The coins draining is the ledger telling the
-// truth, and it is the ONLY thing that happens.
+// ── what the founder's playtest changed, and what it did not ────────────────
 //
-// So `gain` is zero for `dud` and for `burn`, and therefore their energy is
-// exactly zero in both timing branches, with no dial to creep upward later.
+// It used to be stated harder than the invariant needs: a wrong verdict made NO
+// sound and put NO mark on the slate, so its energy was exactly zero. That kept
+// the invariant trivially and it also meant the most teachable second in the game
+// showed the child nothing. A miss now COMPLETES THE SUM in the accent and says
+// one quiet rising figure over it — `render/flourish.ts` and `audio/audio.ts`.
+//
+// The invariant is unchanged and is now doing real work rather than none:
+//
+//   energy(dud)  = 900 × 3 × 0.045 = 121.5
+//   energy(bank) = 500 × 3 × 0.20  = 300
+//   energy(spot) = 940 × 4 × 0.24  = 902.4
+//
+// and in the reduced branch, where the celebrations are shorter and the miss hold
+// deliberately is not, 121.5 against 180 and 499.2. Being wrong stays the least
+// interesting thing that can happen to a child in this game, by construction,
+// checked against the real numbers rather than against this comment.
+//
+// The caller still does not bow for a miss, nothing flashes red — there is no red
+// in the palette — and NOTHING BUZZES: see `HAPTIC`.
 
 import { VOICES } from "../audio/audio.ts"
 import type { Outcome } from "./response.ts"
@@ -25,11 +38,12 @@ export const MOVERS: Record<Outcome, number> = {
   // The caller bowing, the wrong numeral rolling over into the right one, and the
   // slate flying away. The biggest moment in the game.
   spot: 4,
-  // The slate goes down and the coins come back out. Two, and no more: no mark,
-  // no colour, no caller.
-  dud: 2,
-  // The slate goes up and the coins come back out.
-  burn: 2,
+  // The sum completing itself, the slate going down, and the coins coming back
+  // out. Three — and the third one is the reveal, which is the point of the beat.
+  // No caller, no strike, no flare, no colour but the accent.
+  dud: 3,
+  // The sum confirming itself, the slate going up, and the coins coming back out.
+  burn: 3,
   // The slate sinks. One thing, and it is the same thing an empty street does.
   lapse: 1,
 }

--- a/dynawalla/games/truedraw/src/game/round.ts
+++ b/dynawalla/games/truedraw/src/game/round.ts
@@ -102,11 +102,19 @@ export const TIMING: Timing = {
     // The bow, and the slate rolling itself right before it flies away. The
     // longest thing in the game, because it is the best thing in the game.
     spot: 940,
-    // You banked a counterfeit. It goes down like a bank and the coins drain
-    // back out. No sound, no buzz, no colour — the loss is the whole of it.
-    dud: 560,
-    // You threw a good slate away. It flies up and the coins drain. Also silent.
-    burn: 560,
+    // You banked a counterfeit. THE SLATE FINISHES THE SUM: the true value
+    // arrives in the accent, and then it is HELD there. `REVEAL_SHARE` in
+    // `scene.ts` spends the first 45% completing it and the remaining 55% —
+    // about half a second — standing still so it can be read. That hold is the
+    // whole reason this beat is longer than a bank's.
+    //
+    // It is not a punishment beat and it is not a spectacle: no buzz, no colour
+    // but the accent, no caller, and a voice a fifth the loudness of a
+    // celebration. `energy.ts` proves it stays the smallest reaction there is.
+    dud: 900,
+    // You threw a good slate away, so the sum on it was true all along. Same
+    // beat, and the slate confirms rather than corrects.
+    burn: 900,
     // Nobody said anything. The slate just sinks. The shortest beat there is,
     // because there is nothing to show and a child who is still thinking should
     // not be made to watch a reaction to their not answering.
@@ -123,10 +131,14 @@ export const TIMING_REDUCED: Timing = {
     // Still the longest, still the payoff: a cross-fade from the wrong numeral
     // to the right one instead of a roll. A branch, not a degradation.
     spot: 520,
-    // Unchanged, and they are the ones that could not change: there is no motion
-    // in a silent loss to reduce.
-    dud: 560,
-    burn: 560,
+    // UNCHANGED, and deliberately. The reduced branch shortens things that MOVE;
+    // most of a miss beat is a completed sum standing still being read, and
+    // reading time is not motion. Shortening it would take a child who asked for
+    // less movement and give them less time to see the answer — which is the one
+    // thing the beat exists for. What reduced motion changes here is HOW the sum
+    // completes: a cross-fade in place instead of a rolling counter wheel.
+    dud: 900,
+    burn: 900,
     lapse: 300,
   },
   overLock: 900,

--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -29,6 +29,7 @@ import { reportSettled } from "./game/report.ts"
 import { isCorrect } from "./game/response.ts"
 import { MAX_STEP_MS, Round, TIMING, TIMING_REDUCED, type RoundEvent } from "./game/round.ts"
 import { Rng } from "./core/rng.ts"
+import { Flourishes, type Flourish } from "./render/flourish.ts"
 import { Scene, type Drag } from "./render/scene.ts"
 
 /** A milestone the child *reached*. Never fired when a run ends. */
@@ -52,7 +53,14 @@ export function mountTrueDraw(
   const reduced = host.prefersReducedMotion()
   const scene = new Scene(canvas)
   const audio = new Audio()
-  const rng = new Rng((Date.now() ^ 0x51ed) >>> 0)
+  const seed = (Date.now() ^ 0x51ed) >>> 0
+  const rng = new Rng(seed)
+  // A SEPARATE stream from the dealer's, on purpose. Sharing one would make which
+  // celebration a child sees a function of how many falsehoods the dealer happened
+  // to build — so a replay of the same seed would diverge the moment the host
+  // served a question with one usable distractor instead of two, and neither the
+  // animation nor the arithmetic would be reproducible.
+  const flourishes = new Flourishes(new Rng((seed ^ 0x9e3779b9) >>> 0))
   const dealer = new Dealer(host, rng)
   const round = new Round(() => dealer.deal(), reduced ? TIMING_REDUCED : TIMING)
 
@@ -75,9 +83,10 @@ export function mountTrueDraw(
         heading: "The two moves",
         lines: [
           "Read the slate. It says something like 47 + 25 = 62.",
-          "If that sum is RIGHT, swipe down. The slate drops into your bag and you get coins.",
-          "If that sum is WRONG, swipe up. The slate is thrown away, and you get coins for spotting it.",
-          "As soon as your finger moves, the way you are heading lights up.",
+          "There is an = at the bottom of the screen and a ≠ at the top. Those are the two answers.",
+          "If the sum is right, swipe DOWN to the =. The slate lands on your pile and you get coins.",
+          "If it is not, swipe UP to the ≠. The slate is thrown away, and you get coins for spotting it.",
+          "As soon as your finger moves, the mark you are heading for lights up.",
         ],
       },
       {
@@ -130,6 +139,8 @@ export function mountTrueDraw(
   let frame = 0
   let milestones = 0
   let coins = 0
+  /** The celebration or reveal the current verdict drew. One decision, two senses. */
+  let flourish: Flourish | null = null
 
   const handle = (events: readonly RoundEvent[]): void => {
     for (const event of events) {
@@ -150,7 +161,11 @@ export function mountTrueDraw(
           // fast-and-right climbs nearly four times as fast as slow-and-right, and
           // a lapse moves nothing at all.
           dealer.settle(event.outcome, event.quickness)
-          audio.outcome(event.outcome)
+          // ONE draw, for the picture and the sound together. Two independent
+          // picks would drift and hand the child a bloom with a bank's chime
+          // under it.
+          flourish = flourishes.next(event.outcome)
+          audio.outcome(event.outcome, flourish?.voice ?? 0)
           const cue = HAPTIC[event.outcome]
           if (cue) host.haptic(cue)
           // A run of ten calls is a thing the child finished. A run that ended is
@@ -174,6 +189,7 @@ export function mountTrueDraw(
         case "begin": {
           milestones = 0
           coins = 0
+          flourish = null
           break
         }
         default:
@@ -209,6 +225,7 @@ export function mountTrueDraw(
       best,
       reduced,
       drag,
+      flourish,
       // The slate goes blank behind the sheet. It is blurred and dimmed by the
       // manual's own scrim, but "mostly illegible" is the wrong standard for a
       // file that argues at length against giving a child readable, unanswerable

--- a/dynawalla/games/truedraw/src/render/drag.test.ts
+++ b/dynawalla/games/truedraw/src/render/drag.test.ts
@@ -1,0 +1,142 @@
+// THE FEEL OF THE DRAG, as numbers.
+//
+// "Dragging can be juicy and awesome." Juice is not a thing a test can assert, but
+// every property that MAKES a drag feel like a thrown card rather than a slider is,
+// and each one below is a distinct failure a child would notice:
+//
+//   weight      the slate lags the finger at the start, so a flick has mass
+//   magnetism   it accelerates INTO the destination as it arrives
+//   resistance  and stops chasing a finger that has gone much too far
+//   direction   it never leads its finger, and never lags in the wrong direction
+//
+// Nothing here needs a canvas: `drag.ts` is pure.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { commitDistance } from "../game/gesture.ts"
+import {
+  FOLLOW_BASE,
+  FOLLOW_RUBBER,
+  TILT_MAX,
+  TRAIL_MAX,
+  followOffset,
+  magnetism,
+  tiltFor,
+  trailFor,
+} from "./drag.ts"
+
+/** The commit distances the fleet's shapes actually produce. */
+const COMMITS = [320, 390, 768, 1024].map((w, i) => commitDistance(w, [568, 844, 1024, 768][i] ?? 800))
+
+test("THE SLATE HAS WEIGHT: the first pixels move it less than the finger", () => {
+  // A control that tracks 1:1 from zero reads as a scroll view. It also makes the
+  // commit threshold feel like a cliff instead of an arrival.
+  for (const c of COMMITS) {
+    for (const dy of [4, 8, 12]) {
+      const moved = followOffset(dy, c)
+      assert.ok(moved < dy, `${String(dy)}px of finger moved ${moved.toFixed(1)}px of slate at commit ${String(c)}`)
+      assert.ok(moved / dy >= FOLLOW_BASE - 0.001, "the slate lagged further behind than the base follow")
+    }
+  }
+})
+
+test("MAGNETISM: the slate arrives faster than it left", () => {
+  // The whole of "snap as the card nears a target". The ratio of slate travel to
+  // finger travel must RISE as the finger approaches the commit line — a constant
+  // ratio is the old linear follow and is what the founder called lame.
+  for (const c of COMMITS) {
+    const ratios = [0.15, 0.4, 0.7, 0.95].map((f) => followOffset(c * f, c) / (c * f))
+    for (let i = 1; i < ratios.length; i++) {
+      assert.ok(
+        (ratios[i] ?? 0) > (ratios[i - 1] ?? 0),
+        `the follow ratio did not rise into the target: ${ratios.map((r) => r.toFixed(3)).join(" → ")}`,
+      )
+    }
+    // ...and it is a real difference, not a rounding one.
+    assert.ok(
+      (ratios.at(-1) ?? 0) > (ratios[0] ?? 0) * 1.4,
+      `magnetism is ${(((ratios.at(-1) ?? 0) / (ratios[0] ?? 1)) * 100 - 100).toFixed(0)}% — imperceptible`,
+    )
+  }
+})
+
+test("RESISTANCE: past the commit line the slate stops chasing the finger", () => {
+  // A diagonal drag can travel a very long way without committing — the recogniser
+  // wants 1.4x vertical dominance — and a slate that kept tracking it would fly off
+  // the street while the child had said nothing at all.
+  for (const c of COMMITS) {
+    const at = (dy: number): number => followOffset(dy, c)
+    const marginalInside = at(c) - at(c * 0.9)
+    const marginalOutside = at(c * 2) - at(c * 1.9)
+    assert.ok(
+      marginalOutside < marginalInside * 0.5,
+      `no rubber band: ${marginalInside.toFixed(2)}px in, ${marginalOutside.toFixed(2)}px out`,
+    )
+    // A pixel of finger past the line is worth exactly the rubber constant.
+    assert.ok(Math.abs((at(c * 3) - at(c * 3 - 10)) / 10 - FOLLOW_RUBBER) < 1e-9)
+  }
+})
+
+test("the slate never leads its finger and never lags the wrong way", () => {
+  for (const c of COMMITS) {
+    for (const dy of [-900, -200, -c, -35, -1, 0, 1, 35, c, 200, 900]) {
+      const moved = followOffset(dy, c)
+      assert.equal(Math.sign(moved), Math.sign(dy), `${String(dy)} → ${String(moved)}`)
+      assert.ok(Math.abs(moved) <= Math.abs(dy) + 1e-9, "the slate outran the finger")
+      assert.ok(Number.isFinite(moved))
+    }
+    // Monotone the whole way out, in both directions: a fold in the curve is felt
+    // as the slate stalling and then jumping.
+    let previous = Number.NEGATIVE_INFINITY
+    for (let dy = -600; dy <= 600; dy += 7) {
+      const moved = followOffset(dy, c)
+      assert.ok(moved > previous - 1e-9, `the follow folded back at ${String(dy)}`)
+      previous = moved
+    }
+  }
+})
+
+test("a zero or absurd commit distance cannot produce a NaN slate", () => {
+  for (const c of [0, -5, Number.NaN]) {
+    assert.ok(Number.isFinite(followOffset(50, c)), `commit ${String(c)}`)
+  }
+})
+
+test("the tilt leans the way the card is thrown, and reduced motion has none", () => {
+  const c = commitDistance(390, 844)
+  assert.ok(tiltFor(c, c, false) > 0, "a downward throw did not tilt down")
+  assert.ok(tiltFor(-c, c, false) < 0, "an upward throw did not tilt up")
+  assert.ok(Math.abs(tiltFor(c * 4, c, false)) <= TILT_MAX + 1e-9, "the tilt is unbounded")
+  // A card, not a door: five degrees is already a lot at this size.
+  assert.ok(TILT_MAX < 0.11, "the slate tilts far enough to read as a swinging object")
+  for (const dy of [-200, -c, -20, 0, 20, c, 200]) {
+    assert.equal(tiltFor(dy, c, true), 0, "reduced motion rotated the slate")
+  }
+})
+
+test("the trail is motion blur, not a permanent fringe", () => {
+  const c = commitDistance(390, 844)
+  assert.equal(trailFor(0, c, false).length, 0, "a resting slate has a smear under it")
+  assert.equal(trailFor(6, c, false).length, 0, "a two-pixel wander drew a trail")
+  const moving = trailFor(c * 0.9, c, false)
+  assert.ok(moving.length > 0, "a committing flick left no trail")
+  assert.ok(moving.length <= TRAIL_MAX)
+  // Every echo sits BEHIND the slate — opposite the travel — and fades with distance.
+  for (const echo of moving) {
+    assert.ok(echo.back < 0, "an echo led the slate")
+    assert.ok(echo.alpha > 0 && echo.alpha < 0.5, `echo alpha ${String(echo.alpha)}`)
+  }
+  for (let i = 1; i < moving.length; i++) {
+    assert.ok((moving[i]?.alpha ?? 1) < (moving[i - 1]?.alpha ?? 0), "the trail does not fade")
+  }
+  assert.equal(trailFor(c * 0.9, c, true).length, 0, "reduced motion drew a motion trail")
+})
+
+test("magnetism is 0 at rest and 1 at the line, and clamps beyond it", () => {
+  const c = commitDistance(768, 1024)
+  assert.equal(magnetism(0, c), 0)
+  assert.ok(Math.abs(magnetism(c, c) - 1) < 1e-9)
+  assert.equal(magnetism(c * 5, c), 1)
+  assert.equal(magnetism(-c, c), 1, "magnetism is a magnitude, not a direction")
+})

--- a/dynawalla/games/truedraw/src/render/drag.ts
+++ b/dynawalla/games/truedraw/src/render/drag.ts
@@ -1,0 +1,131 @@
+// HOW THE SLATE MOVES UNDER A FINGER.
+//
+// The founder's note: *"dragging can be juicy and awesome."* It was not. The old
+// renderer moved the slate by `dy × 0.55` and tilted it by a constant — a linear
+// map with no character in it, which reads as a slider rather than as a card you
+// are about to throw.
+//
+// Everything a drag feels like is in these four pure functions, so it can be
+// driven to the pixel by a test instead of being judged by eye on a device.
+//
+// ── the shape of the follow, in three parts ─────────────────────────────────
+//
+//   WEIGHT      the first pixels move the slate less than the finger. A card has
+//               mass; a control that tracks 1:1 from zero feels like a scroll
+//               view, and it also makes the 34 px commit threshold feel like a
+//               cliff rather than an arrival.
+//   MAGNETISM   as the travel approaches the commit line the slate accelerates
+//               INTO the destination — the ratio rises from 0.55 to 0.97. This is
+//               the "snap as the card nears a target" the brief asks for, and it
+//               is what makes the last 10 px of a flick feel like the target took
+//               it rather than like the finger delivered it.
+//   RESISTANCE  past the commit line the marginal follow collapses to 0.22. A
+//               diagonal drag can travel a long way without committing (the
+//               recogniser wants 1.4× dominance), and a slate that kept tracking
+//               it would fly off the street while the child had said nothing.
+//
+// The three are continuous at the seam, which matters: a discontinuity in a
+// follow curve is felt as a click even when it is only two pixels.
+//
+// ── and why NONE of this changes when a verdict commits ─────────────────────
+//
+// It cannot: `gesture.ts` zeroes its own live-drag accessors the instant it
+// fires, so this module never sees the travel of a finger that has already
+// spoken. That guard lives on the concept rather than at the call site
+// deliberately, and this file relies on it.
+
+/** Follow ratio at zero travel. Under 1, so the flick has weight. */
+export const FOLLOW_BASE = 0.55
+
+/** Extra follow the slate gains as it arrives at its destination. */
+export const FOLLOW_SNAP = 0.42
+
+/** Marginal follow past the commit line. The rubber band. */
+export const FOLLOW_RUBBER = 0.22
+
+/** The most the slate tilts as it is thrown, in radians. A card, not a door. */
+export const TILT_MAX = 0.085
+
+/** How many echoes trail a moving slate, and how far back the last one sits. */
+export const TRAIL_MAX = 4
+const TRAIL_REACH = 0.34
+
+/**
+ * The commit distance, made safe to divide by.
+ *
+ * `Math.max(1, NaN)` is `NaN`, which is the trap: a canvas whose bounding rect has
+ * not settled yet reports a zero or a NaN width for one frame, `commitDistance`
+ * passes it straight through, and every coordinate this module produces from it is
+ * a NaN handed to `fillRect` — where it silently draws nothing rather than
+ * throwing. `scene.test.ts` sweeps for non-finite arguments for the same reason.
+ */
+const safeCommit = (commitPx: number): number =>
+  Number.isFinite(commitPx) && commitPx > 1 ? commitPx : 1
+
+/**
+ * How far the slate has actually moved, given how far the finger has.
+ *
+ * Signed, and always the same sign as `dy` — a slate that led its finger, or lagged
+ * behind it in the wrong direction, would be a bug a child feels as the game
+ * arguing with them.
+ */
+export function followOffset(dy: number, commitPx: number): number {
+  const c = safeCommit(commitPx)
+  const mag = Math.abs(dy)
+  // Squared, so magnetism arrives LATE. Linear here would make the first few
+  // pixels of a tap-that-slipped feel snatched at.
+  const near = Math.min(1, mag / c)
+  const within = Math.min(mag, c) * (FOLLOW_BASE + FOLLOW_SNAP * near * near)
+  const past = Math.max(0, mag - c) * FOLLOW_RUBBER
+  return Math.sign(dy) * (within + past)
+}
+
+/**
+ * How close the slate is to being taken by its destination, 0..1.
+ *
+ * Not the recogniser's `pull`, which is clamped and linear. This is the eased
+ * version the LOOK is driven from: the glow, the mark, the trail and the tilt all
+ * ride it, so they arrive together rather than each on its own curve.
+ */
+export function magnetism(dy: number, commitPx: number): number {
+  const near = Math.min(1, Math.abs(dy) / safeCommit(commitPx))
+  return Number.isFinite(near) ? near * near : 0
+}
+
+/**
+ * The tilt, in radians, signed with the direction of travel.
+ *
+ * `reduced` is a branch, not a degradation: reduced motion still gets the follow
+ * and the glow, it simply does not get a rotating object.
+ */
+export function tiltFor(dy: number, commitPx: number, reduced: boolean): number {
+  if (reduced) return 0
+  return Math.sign(dy) * magnetism(dy, commitPx) * TILT_MAX
+}
+
+/**
+ * The echoes behind a moving slate, nearest first.
+ *
+ * Each is `{ back, alpha }`: how far back along the travel it sits, in the same
+ * units as `followOffset`, and how solid it is. An empty array below a threshold,
+ * so a resting slate has no smear under it and reduced motion has none ever.
+ */
+export function trailFor(
+  dy: number,
+  commitPx: number,
+  reduced: boolean,
+): readonly { readonly back: number; readonly alpha: number }[] {
+  if (reduced) return []
+  const offset = followOffset(dy, commitPx)
+  // Below a few pixels a trail is not motion blur, it is a fringe on a static
+  // object. `TAP_SLOP_PX` is the same idea in the recogniser.
+  if (Math.abs(offset) < 10) return []
+  const strength = magnetism(dy, commitPx)
+  const n = Math.max(1, Math.round(TRAIL_MAX * strength))
+  const out: { back: number; alpha: number }[] = []
+  for (let i = 1; i <= n; i++) {
+    const t = i / (TRAIL_MAX + 1)
+    out.push({ back: -offset * TRAIL_REACH * t, alpha: 0.3 * strength * (1 - t) })
+  }
+  return out
+}

--- a/dynawalla/games/truedraw/src/render/flourish.test.ts
+++ b/dynawalla/games/truedraw/src/render/flourish.test.ts
@@ -1,0 +1,152 @@
+// THE POOLS ACTUALLY VARY — and they vary the same way twice for the same seed.
+//
+// "Success and failure sounds need to be awesome and varied and so do the
+// animations." The failure mode this file exists to catch is the quiet one: a pool
+// of four that a bug narrows to one, or a `pick` that reads the RNG once and caches
+// it, or a no-repeat rule that filters the pool down to a single survivor. All
+// three of those produce a game that runs, ships, and does the same thing every
+// round — which is exactly the state the founder played.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { voiceCount, VOICE_POOL } from "../audio/audio.ts"
+import { OUTCOMES, isCorrect, isMiss, type Outcome } from "../game/response.ts"
+import { CELEBRATIONS, Flourishes, MISSES, defaultFlourish } from "./flourish.ts"
+
+const ROUNDS = 60
+
+function run(seed: number, outcomes: readonly Outcome[]): { kind: string; voice: number }[] {
+  const f = new Flourishes(new Rng(seed))
+  const out: { kind: string; voice: number }[] = []
+  for (let i = 0; i < ROUNDS; i++) {
+    const drawn = f.next(outcomes[i % outcomes.length] as Outcome)
+    if (drawn) out.push({ kind: drawn.kind, voice: drawn.voice })
+  }
+  return out
+}
+
+test("EVERY CELEBRATION IN THE POOL IS ACTUALLY REACHED", () => {
+  // Not "more than one" — all of them. A variant that a filter or an off-by-one
+  // makes unreachable is dead code that looks like variety in the source.
+  const drawn = new Set(run(2026, ["bank", "spot"]).map((f) => f.kind))
+  for (const kind of CELEBRATIONS) {
+    assert.ok(drawn.has(kind), `${kind} was never drawn in ${String(ROUNDS)} rounds`)
+  }
+  assert.ok(drawn.size > 1, "one celebration, over and over — this is the shipped defect")
+})
+
+test("EVERY MISS REVEAL IN THE POOL IS ACTUALLY REACHED", () => {
+  const drawn = new Set(run(4711, ["dud", "burn"]).map((f) => f.kind))
+  for (const kind of MISSES) {
+    assert.ok(drawn.has(kind), `${kind} was never drawn in ${String(ROUNDS)} rounds`)
+  }
+})
+
+test("EVERY VOICE IN EVERY POOL IS ACTUALLY REACHED", () => {
+  // The sound half of the same claim. A voice index that never reaches the third
+  // entry is a pool of two wearing a pool of three's clothes.
+  for (const outcome of OUTCOMES) {
+    const n = voiceCount(outcome)
+    if (n === 0) continue
+    const voices = new Set(run(913, [outcome]).map((f) => f.voice))
+    assert.equal(voices.size, n, `${outcome}: ${String(voices.size)} of ${String(n)} voices used`)
+    for (const v of voices) assert.ok(v >= 0 && v < n, `${outcome} voice index ${String(v)}`)
+  }
+})
+
+test("THE SAME SEED IS THE SAME RUN, FOREVER", () => {
+  // Determinism is not decoration here: it is what makes every other assertion in
+  // this file a fact rather than a sample, and it is what lets a bug report that
+  // names a seed be reproduced.
+  const order: readonly Outcome[] = ["bank", "dud", "spot", "burn", "lapse"]
+  const a = run(31337, order)
+  const b = run(31337, order)
+  assert.deepEqual(a, b)
+  assert.notDeepEqual(a, run(31338, order), "two different seeds produced identical runs")
+})
+
+test("THE SAME VARIANT NEVER LANDS TWICE IN A ROW", () => {
+  // A uniform draw from four repeats about a quarter of the time, and a child reads
+  // "it did the same thing again" as "it did not notice".
+  for (const seed of [1, 2, 3, 17, 999]) {
+    for (const family of [
+      ["bank", "spot"],
+      ["dud", "burn"],
+    ] as const) {
+      const kinds = run(seed, family).map((f) => f.kind)
+      for (let i = 1; i < kinds.length; i++) {
+        assert.notEqual(kinds[i], kinds[i - 1], `seed ${String(seed)}: ${String(kinds[i])} twice at ${String(i)}`)
+      }
+    }
+  }
+})
+
+test("a lapse draws nothing, in either sense", () => {
+  // A window that closed on a child who was still working is not an event the street
+  // reacts to. No animation, no sound, and — the part that matters — no consumption
+  // of the run's RNG, so a lapse cannot shift which celebration the next correct call
+  // gets.
+  const f = new Flourishes(new Rng(5))
+  assert.equal(f.next("lapse"), null)
+  assert.equal(defaultFlourish("lapse"), null)
+  assert.equal(voiceCount("lapse"), 0)
+  assert.equal(VOICE_POOL.lapse, undefined)
+
+  const withLapses = new Flourishes(new Rng(5))
+  const without = new Flourishes(new Rng(5))
+  for (let i = 0; i < 12; i++) {
+    withLapses.next("lapse")
+    assert.deepEqual(withLapses.next("bank"), without.next("bank"))
+  }
+})
+
+test("a verdict that arrives without a draw still celebrates", () => {
+  // A host pause across the settle, a resize, a re-rendered held frame. The
+  // alternative to a fallback is a correct call that celebrates NOTHING, which is by
+  // a distance the worse failure: the celebration is the reinforcement.
+  for (const outcome of OUTCOMES) {
+    const fallback = defaultFlourish(outcome)
+    if (voiceCount(outcome) === 0) {
+      assert.equal(fallback, null, outcome)
+      continue
+    }
+    assert.ok(fallback, `${outcome} falls back to nothing`)
+    assert.equal(fallback.outcome, outcome)
+    const pool: readonly string[] = isCorrect(outcome) ? CELEBRATIONS : MISSES
+    assert.ok(pool.includes(fallback.kind), `${outcome} fell back to ${fallback.kind}`)
+    assert.ok(fallback.voice >= 0 && fallback.voice < voiceCount(outcome))
+  }
+})
+
+test("a celebration is only ever drawn for a correct call", () => {
+  // The binding rule, at the level of the draw: the juice fires on the MATHS moment.
+  // A miss must never be able to receive a celebration variant and vice versa.
+  const f = new Flourishes(new Rng(77))
+  for (let i = 0; i < 200; i++) {
+    const outcome = OUTCOMES[i % OUTCOMES.length] as Outcome
+    const drawn = f.next(outcome)
+    if (!drawn) continue
+    if (isCorrect(outcome)) {
+      assert.ok(CELEBRATIONS.includes(drawn.kind as never), `${outcome} → ${drawn.kind}`)
+    } else {
+      assert.ok(isMiss(outcome))
+      assert.ok(MISSES.includes(drawn.kind as never), `${outcome} → ${drawn.kind}`)
+    }
+  }
+})
+
+test("the spin is a real 0..1 and it is not one frozen number", () => {
+  // Each variant jitters off it, so a constant spin would make one variant one
+  // picture — the same defect one level down.
+  const spins = new Set<number>()
+  const f = new Flourishes(new Rng(600))
+  for (let i = 0; i < 40; i++) {
+    const drawn = f.next("bank")
+    assert.ok(drawn)
+    assert.ok(drawn.spin >= 0 && drawn.spin < 1, `spin ${String(drawn.spin)}`)
+    spins.add(drawn.spin)
+  }
+  assert.ok(spins.size > 30, `only ${String(spins.size)} distinct spins in 40 draws`)
+})

--- a/dynawalla/games/truedraw/src/render/flourish.ts
+++ b/dynawalla/games/truedraw/src/render/flourish.ts
@@ -1,0 +1,138 @@
+// WHAT THE STREET DOES ABOUT IT — and the fact that it is never the same twice.
+//
+// The founder's playtest, verbatim: *"success/fail isn't cool and juicy, sort of
+// lame... success and failure sounds need to be awesome and varied and so do the
+// animations."*
+//
+// He is describing a pool of one. Every correct call played the same stamp and the
+// same two notes; every spot played the same bow and the same three. The twentieth
+// looked exactly like the first, which is the fastest way there is to teach a child
+// that nothing they do matters.
+//
+// So each family is a POOL, and one is drawn per verdict from the run's seeded RNG.
+//
+// ── the two rules the pools obey ────────────────────────────────────────────
+//
+//   1. **The juice fires on the MATHS MOMENT.** Every celebration here is drawn
+//      by a correct RETRIEVAL — a claim judged rightly — and by nothing else.
+//      There is no flourish for a collision, a streak counter, a menu, or a
+//      window opening. That is the whole reason it reinforces anything.
+//
+//   2. **A miss is not a punishment and is not a competing spectacle.** The three
+//      miss variants are three ways of doing the same honest thing: COMPLETE THE
+//      SUM in front of the child, in the accent, and hold it there long enough to
+//      read. `games/stack` is the fleet's reference for this and it says it in one
+//      line — "the equation simply COMPLETES ITSELF in the accent colour... the
+//      truth, stated once, with no adjective attached to the child." Never red,
+//      never the word WRONG, and never louder than a celebration:
+//      `game/energy.ts` holds that against the real numbers.
+//
+// ── why the pick lives here and not in the renderer ─────────────────────────
+//
+// Because the sound and the picture must be ONE decision. A verdict draws a
+// variant and a voice index together, once, at the moment it settles; `scene.ts`
+// draws what it was handed and `audio.ts` plays what it was handed. Two
+// independent picks would drift apart across a pause, a re-render or a reduced
+// frame, and the child would get a bloom with a bank's chime under it.
+
+import type { Rng } from "../core/rng.ts"
+import { voiceCount } from "../audio/audio.ts"
+import { isCorrect, isMiss, type Outcome } from "../game/response.ts"
+
+/** How the street celebrates a correct call. */
+export type CelebrationKind =
+  /** Rings of brass leave the slate and open across the street. */
+  | "ring"
+  /** Spokes of cold light sweep out and fade — the slate was lit from behind. */
+  | "rays"
+  /** A handful of extra coins arcs on lofted paths, over the top of the bag. */
+  | "shower"
+  /** The lamps in the haze flare and motes rise off the crowd. */
+  | "bloom"
+
+/** How the slate completes the sum after a miss. */
+export type MissKind =
+  /** The wrong column rolls over into the right one, like a counter wheel. */
+  | "settle"
+  /** The claim dissolves and the true statement is re-cut in its place. */
+  | "recut"
+  /** The right value drops into the cell as the wrong one slides out below it. */
+  | "drop"
+
+export const CELEBRATIONS: readonly CelebrationKind[] = ["ring", "rays", "shower", "bloom"]
+export const MISSES: readonly MissKind[] = ["settle", "recut", "drop"]
+
+export type Flourish = {
+  readonly outcome: Outcome
+  readonly kind: CelebrationKind | MissKind
+  /** Index into the outcome's voice pool in `audio.ts`. */
+  readonly voice: number
+  /** 0..1 of deterministic jitter, so one variant is not one frozen picture. */
+  readonly spin: number
+}
+
+/**
+ * The draw. One per settled verdict, and NEVER the same kind twice running.
+ *
+ * The no-repeat is the point rather than a polish item: a uniform draw from four
+ * repeats immediately about a quarter of the time, and a child reads "it did the
+ * same thing again" as "it did not notice". State is one field per family, which
+ * is why this is a class and not a function.
+ */
+export class Flourishes {
+  private readonly rng: Rng
+  private lastCelebration: CelebrationKind | null = null
+  private lastMiss: MissKind | null = null
+
+  constructor(rng: Rng) {
+    this.rng = rng
+  }
+
+  /**
+   * What to draw and play for `outcome`, or null when the answer is nothing.
+   *
+   * `lapse` returns null and always will. A window that closed on a child who was
+   * still working is not an event the street reacts to, in either direction.
+   */
+  next(outcome: Outcome): Flourish | null {
+    const voices = voiceCount(outcome)
+    if (voices === 0) return null
+    const spin = this.rng.next()
+    if (isCorrect(outcome)) {
+      const kind = pickDifferent(CELEBRATIONS, this.lastCelebration, this.rng)
+      this.lastCelebration = kind
+      return { outcome, kind, voice: this.rng.int(0, voices - 1), spin }
+    }
+    if (!isMiss(outcome)) return null
+    const kind = pickDifferent(MISSES, this.lastMiss, this.rng)
+    this.lastMiss = kind
+    return { outcome, kind, voice: this.rng.int(0, voices - 1), spin }
+  }
+}
+
+/** Uniform over everything that is not `avoid`. Falls back if the pool is one deep. */
+function pickDifferent<T>(pool: readonly T[], avoid: T | null, rng: Rng): T {
+  const options = pool.filter((k) => k !== avoid)
+  return rng.pick(options.length > 0 ? options : pool)
+}
+
+/**
+ * What to draw for a verdict that arrived without a draw.
+ *
+ * It happens: a host pause across the settle, a resize that re-renders a held
+ * frame, a `clear` phase re-entered after a resume. The alternative to a fallback
+ * is a correct call that celebrates nothing, which is by a distance the worse
+ * failure — the celebration IS the reinforcement, and a silent one teaches the
+ * child that being right sometimes does not count.
+ *
+ * Fixed rather than drawn, because a fallback that consumed the RNG would make the
+ * run's sequence depend on how many times the host happened to re-render.
+ */
+export function defaultFlourish(outcome: Outcome): Flourish | null {
+  if (voiceCount(outcome) === 0) return null
+  if (isCorrect(outcome)) {
+    return { outcome, kind: outcome === "spot" ? "rays" : "ring", voice: 0, spin: 0.5 }
+  }
+  if (!isMiss(outcome)) return null
+  return { outcome, kind: "settle", voice: 0, spin: 0.5 }
+}

--- a/dynawalla/games/truedraw/src/render/hint.test.ts
+++ b/dynawalla/games/truedraw/src/render/hint.test.ts
@@ -1,0 +1,142 @@
+// TEACHING THE GESTURE, AND KNOWING WHEN TO STOP.
+//
+// The hint is the only thing in this game that appears without the child asking for
+// it, so every gate on it is load-bearing. The failures this file is aimed at are
+// all failures of restraint:
+//
+//   * a ghost that keeps demonstrating after the child has plainly got it;
+//   * a ghost that appears the instant the window opens, over a slate a fast child
+//     is already answering;
+//   * a ghost that leans the way the CURRENT statement ought to go, which is the
+//     game answering the round and poisoning the learner model;
+//   * anything that gets more urgent the longer a child thinks, which is a
+//     countdown wearing a costume — speed is rewarded in this game, never enforced.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Phase } from "../game/round.ts"
+import { CYCLE_MS, MARK_REST, NUDGE_MS, hintFor, markGlow, type HintInput } from "./hint.ts"
+
+const base = (over: Partial<HintInput> = {}): HintInput => ({
+  phase: "call",
+  elapsedMs: NUDGE_MS + 2000,
+  reduced: false,
+  dragging: false,
+  calls: 0,
+  ...over,
+})
+
+test("THE TEACHING STOPS FOR GOOD AT THE FIRST CORRECT CALL", () => {
+  // One correct call is proof the gesture landed. A hint that outstays the moment it
+  // was needed is condescension, and this product does not do that to children.
+  assert.ok(hintFor(base({ calls: 0 })), "a child who has landed nothing gets no help")
+  for (const calls of [1, 2, 9, 40]) {
+    assert.equal(hintFor(base({ calls })), null, `still hinting after ${String(calls)} calls`)
+  }
+})
+
+test("IT WAITS FOR THE HESITATION AND NEVER PRE-EMPTS AN ANSWER", () => {
+  // A child who knows the gesture answers well inside `NUDGE_MS` and never sees the
+  // ghost at all. One that appeared immediately would be drawn over a slate somebody
+  // was already flicking.
+  for (const elapsedMs of [0, 100, 400, NUDGE_MS - 1, NUDGE_MS]) {
+    assert.equal(hintFor(base({ elapsedMs })), null, `hinted at ${String(elapsedMs)}ms`)
+  }
+  assert.ok(hintFor(base({ elapsedMs: NUDGE_MS + 1 })))
+})
+
+test("IT NEVER GETS MORE URGENT — a hint that escalates is a countdown", () => {
+  // The strength ramps in once and then holds, flat, forever. If a child sits for a
+  // minute the street says exactly what it said after two seconds.
+  const strengthAt = (ms: number): number => hintFor(base({ elapsedMs: ms }))?.strength ?? 0
+  const settled = strengthAt(NUDGE_MS + 3000)
+  for (const ms of [4000, 12_000, 30_000, 90_000]) {
+    assert.equal(strengthAt(NUDGE_MS + ms), settled, `the hint escalated by ${String(ms)}ms`)
+  }
+  assert.ok(settled > 0 && settled <= 1)
+})
+
+test("IT DEMONSTRATES BOTH GESTURES AND NEVER THE ANSWER", () => {
+  // The safety property. A ghost that leaned the way the CURRENT statement ought to
+  // go would be the game playing the round, and every one of those rounds would
+  // enter the learner model as evidence about arithmetic the child did not do.
+  //
+  // `hintFor` cannot even express that: it is not handed the statement, and over one
+  // cycle it shows both directions in a fixed order.
+  const calls = new Set<string>()
+  for (let ms = NUDGE_MS + 10; ms < NUDGE_MS + CYCLE_MS; ms += 40) {
+    const hint = hintFor(base({ elapsedMs: ms }))
+    assert.ok(hint)
+    calls.add(hint.call)
+  }
+  assert.deepEqual([...calls].sort(), ["keep", "toss"], "the ghost only ever showed one gesture")
+  // ...and `keep` comes first: the affirmative gesture is the one a child reaches
+  // for unprompted, so the loop starts by confirming the instinct.
+  assert.equal(hintFor(base({ elapsedMs: NUDGE_MS + 30 }))?.call, "keep")
+  assert.equal(hintFor(base({ elapsedMs: NUDGE_MS + CYCLE_MS * 0.6 }))?.call, "toss")
+})
+
+test("the ghost travels and fades within each half, and never sits still lit", () => {
+  const at = (frac: number): { drift: number; alpha: number } => {
+    const hint = hintFor(base({ elapsedMs: NUDGE_MS + CYCLE_MS * frac }))
+    assert.ok(hint)
+    return { drift: hint.drift, alpha: hint.alpha }
+  }
+  // Travel across the first half.
+  assert.ok(at(0.02).drift < at(0.2).drift, "the ghost did not travel")
+  assert.ok(at(0.2).drift < at(0.34).drift)
+  // And fade out at the ends of it, so nothing is left hanging mid-air.
+  assert.ok(at(0.02).alpha < at(0.25).alpha, "the ghost appeared fully formed")
+  assert.ok(at(0.48).alpha < at(0.25).alpha, "the ghost never faded out")
+  for (const frac of [0.01, 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 0.99]) {
+    const { drift, alpha } = at(frac)
+    assert.ok(drift >= 0 && drift <= 1, `drift ${String(drift)}`)
+    assert.ok(alpha >= 0 && alpha <= 1, `alpha ${String(alpha)}`)
+  }
+})
+
+test("REDUCED MOTION KEEPS THE TEACHING AND DROPS THE MOVING OBJECT", () => {
+  // A branch, not a deletion. There is no drifting ghost, and the two marks are lit
+  // by the hint's full strength instead — so the instruction is still there, it just
+  // is not animated.
+  const hint = hintFor(base({ reduced: true }))
+  assert.ok(hint, "reduced motion removed the teaching entirely")
+  assert.equal(hint.alpha, 0, "reduced motion still drew a moving ghost")
+  assert.ok(hint.strength > 0, "reduced motion left the marks unlit")
+})
+
+test("a finger on the glass ends the hint immediately", () => {
+  // The child is doing the thing. A demonstration competing with a live drag is
+  // noise on top of the one moment the affordance is already working.
+  assert.equal(hintFor(base({ dragging: true })), null)
+})
+
+test("nothing is taught outside an open window, or behind the manual", () => {
+  for (const phase of ["idle", "raise", "still", "verdict", "clear", "over"] as Phase[]) {
+    assert.equal(hintFor(base({ phase })), null, `hinted during ${phase}`)
+  }
+  assert.equal(hintFor(base({ masked: true })), null, "hinted behind the sheet")
+})
+
+test("THE MARKS ARE ALWAYS THERE, FAINTLY, AND THE RIGHT ONE LIGHTS", () => {
+  // The permanent half of the instructions: `≠` above, `=` below. They are not a
+  // tutorial that gets dismissed, so there is nothing to miss and nothing to recall —
+  // but at rest they must not compete with the statement, which is the only thing on
+  // the street a child has to read.
+  assert.equal(markGlow(true, 0, null, false), MARK_REST)
+  assert.ok(MARK_REST > 0.1, "the marks are invisible at rest — they teach nothing")
+  assert.ok(MARK_REST < 0.35, "the marks compete with the statement at rest")
+
+  // A finger heading for a destination lights it, and lights it much more than rest.
+  assert.ok(markGlow(true, 1, null, false) > MARK_REST * 3)
+  // The other one does not move at all.
+  assert.equal(markGlow(false, 1, null, false), MARK_REST)
+
+  const hint = hintFor(base())
+  assert.ok(hint)
+  assert.ok(markGlow(true, 0, hint, true) > MARK_REST, "the ghost's destination did not light")
+  assert.equal(markGlow(true, 0, hint, false), MARK_REST, "the other destination lit too")
+  // Never over one, whatever adds up.
+  assert.ok(markGlow(true, 1, hint, true) <= 1)
+})

--- a/dynawalla/games/truedraw/src/render/hint.ts
+++ b/dynawalla/games/truedraw/src/render/hint.ts
@@ -1,0 +1,140 @@
+// TEACHING THE GESTURE WITHOUT SAYING ANYTHING.
+//
+// The founder's note: *"Could have intuitive up == false, down == true
+// instructions in the game .. subtle, premium."*
+//
+// The game had the rule written down in six paragraphs of a manual behind a `?`
+// in the top-right corner. A child who has not read it spends a shot finding out
+// which way is which, and a child who HAS read it has read six paragraphs to learn
+// two arrows. Neither is acceptable and both were shipping.
+//
+// There are three teachers now and none of them is a sentence.
+//
+// ── 1. THE MARKS, always ────────────────────────────────────────────────────
+//
+// The chute at the top of the screen carries `≠`. The hoard at the bottom carries
+// `=`. That is the entire instruction set, it is in the notation the game is
+// already made of, and it needs no translation into any of the fifty languages
+// this fleet ships in. `47 + 25 = 62`: swipe it UP to the `≠` to say it does not,
+// DOWN to the `=` to say it does. The marks are permanent chrome — they are not a
+// tutorial that gets dismissed, so there is nothing to miss and nothing to recall.
+//
+// ── 2. THE GHOST, until the first correct call ──────────────────────────────
+//
+// A translucent copy of the slate drifts down towards the `=`, fades, then drifts
+// up towards the `≠`, and fades. Both gestures, in order, on a loop, while the
+// real slate sits still and answerable underneath it.
+//
+// **It demonstrates the two MOVES and never the ANSWER.** That distinction is the
+// whole safety of the feature: a ghost that drifted the way the current statement
+// ought to go would be the game playing the round for the child, and every one of
+// those rounds would enter the learner model as evidence about arithmetic they did
+// not do.
+//
+// ── 3. THE HESITATION, which is a nudge and never a clock ───────────────────
+//
+// The ghost does not appear the instant the window opens. It fades in after
+// `NUDGE_MS` of an untouched screen — long enough that a child who knows the
+// gesture never sees it at all, and short enough to arrive while a child who does
+// not is still looking for what to do.
+//
+// It is fixed, it does not accelerate, it does not count anything down and it goes
+// away the moment a finger touches the glass. Speed is REWARDED in this game and
+// never ENFORCED; a hint that got more urgent the longer a child thought would be
+// a countdown wearing a costume.
+//
+// **And it stops for good after the first correct call** — `run.calls > 0` and the
+// street never mentions it again for the rest of the run. A hint that outstays the
+// moment it was needed is condescension, and this product does not do that to
+// children.
+
+import type { Call } from "../game/response.ts"
+import type { Phase } from "../game/round.ts"
+
+/** How long an untouched window waits before the ghost begins. */
+export const NUDGE_MS = 900
+
+/** How long the ghost takes to fade in once it starts. */
+const NUDGE_RAMP_MS = 420
+
+/** One full demonstration: down to the `=`, then up to the `≠`. */
+export const CYCLE_MS = 2800
+
+export type Hint = {
+  /** 0..1 — how present the teaching is. Drives the two marks as well as the ghost. */
+  readonly strength: number
+  /** The gesture the ghost is demonstrating this half of the cycle. */
+  readonly call: Call
+  /** 0..1 along the ghost's travel towards its destination. */
+  readonly drift: number
+  /** 0..1 — how solid the ghost is. Zero under reduced motion: the marks carry it. */
+  readonly alpha: number
+}
+
+export type HintInput = {
+  readonly phase: Phase
+  readonly elapsedMs: number
+  readonly reduced: boolean
+  readonly masked?: boolean
+  /** Non-null while a finger is on the glass. A hint competes with nothing. */
+  readonly dragging: boolean
+  /** Correct calls made this run. The teaching ends at the first one. */
+  readonly calls: number
+}
+
+const clamp01 = (t: number): number => Math.max(0, Math.min(1, t))
+const easeInOut = (t: number): number => (t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2)
+
+/**
+ * What to teach right now, or null for nothing at all.
+ *
+ * Null is the common case and by a very long way: it is every frame of every round
+ * after a child's first correct call, every frame with a finger down, and every
+ * frame of a window younger than `NUDGE_MS`.
+ */
+export function hintFor(input: HintInput): Hint | null {
+  if (input.phase !== "call") return null
+  if (input.masked === true) return null
+  if (input.dragging) return null
+  // The one gate that matters. One correct call is proof the gesture landed.
+  if (input.calls > 0) return null
+
+  const since = input.elapsedMs - NUDGE_MS
+  if (since <= 0) return null
+  const strength = clamp01(since / NUDGE_RAMP_MS)
+
+  // Which half of the demonstration, and how far through it. `keep` first: the
+  // affirmative gesture is the one a child reaches for unprompted, so the loop
+  // starts by confirming the instinct rather than by contradicting it.
+  const t = (since % CYCLE_MS) / CYCLE_MS
+  const half = t < 0.5 ? t * 2 : (t - 0.5) * 2
+  const call: Call = t < 0.5 ? "keep" : "toss"
+
+  // Travel for the first two thirds, then hold and fade. A ghost that vanished at
+  // the top of its arc would read as a glitch rather than as a throw.
+  const drift = easeInOut(clamp01(half / 0.66))
+  const alpha = strength * (input.reduced ? 0 : Math.sin(Math.PI * clamp01(half)) ** 0.7)
+
+  return { strength, call, drift, alpha }
+}
+
+/**
+ * How bright a destination's mark is: at rest, under a finger heading for it, and
+ * while the ghost is demonstrating it.
+ *
+ * At rest it is deliberately faint — present, legible on a still frame, and never
+ * competing with the statement, which is the only thing on the street a child has
+ * to read under any kind of clock.
+ */
+export const MARK_REST = 0.2
+
+export function markGlow(
+  mine: boolean,
+  pull: number,
+  hint: Hint | null,
+  hintCall: boolean,
+): number {
+  const pulling = mine ? clamp01(pull) : 0
+  const taught = hint !== null && hintCall ? hint.strength : 0
+  return clamp01(MARK_REST + pulling * 0.8 + taught * 0.45)
+}

--- a/dynawalla/games/truedraw/src/render/palette.ts
+++ b/dynawalla/games/truedraw/src/render/palette.ts
@@ -21,6 +21,25 @@ export const BRASS_LIT = "#e6c281"
 
 export const LAPIS = "#22406b"
 
+/**
+ * THE ACCENT — and the one thing in this pack that is allowed to be called that.
+ *
+ * It is `BRASS_LIT`, the brightest material on the street, and it has exactly one
+ * job beyond being the frame's highlight: **it is the colour a missed sum
+ * completes itself in.**
+ *
+ * The fleet rule, from `games/stack`, which is the reference implementation: when
+ * a child gets it wrong the equation simply completes itself in the accent, held
+ * long enough to read, with no adjective attached to the child. NEVER red. NEVER
+ * the word WRONG. There is no red anywhere in this palette and there must never
+ * be one — `scene.test.ts` asserts that against the ink the renderer actually
+ * emits, not against this comment.
+ *
+ * Aliased rather than duplicated so a future re-tint of the brass cannot leave the
+ * correction the only thing on the street still wearing the old colour.
+ */
+export const ACCENT = BRASS_LIT
+
 /** The statement before the slate lights: legible, and plainly unlit. */
 export const CHALK_UNLIT = "#5c6577"
 /** The statement once it lights. Cold, celestial, the only bright thing. */

--- a/dynawalla/games/truedraw/src/render/scene.test.ts
+++ b/dynawalla/games/truedraw/src/render/scene.test.ts
@@ -9,6 +9,14 @@ import { newRun, applyOutcome, type Run } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
 import { fakeCanvas, numbersIn, type Recorder } from "./fakeCanvas.ts"
 import { Gesture } from "../game/gesture.ts"
+import {
+  CELEBRATIONS,
+  MISSES,
+  type CelebrationKind,
+  type Flourish,
+  type MissKind,
+} from "./flourish.ts"
+import { NUDGE_MS } from "./hint.ts"
 import { Scene, type Drag, type SceneState } from "./scene.ts"
 
 const SIZES: readonly [number, number][] = [
@@ -286,31 +294,344 @@ test("the slate leaves in the direction it was thrown", () => {
   assert.ok(yOf("burn") < rest, "a thrown good slate did not fly up")
 })
 
-test("a wrong verdict adds no mark, no light and no colour", () => {
-  // The design claim, at the level of the renderer. The bag losing coins is the ledger
-  // telling the truth; it is not a reaction. So: no strike, no correction, no bow, and
-  // the street exactly as dim as the window left it. What HAS changed since the old
-  // "not one op" fingerprint is that the slate now leaves — in the direction the child
-  // threw it — and coins come out of the bag. Those two, and nothing else.
-  const { scene: s, rec } = scene(768, 1024)
-  const st = statement({ windowMs: 2800 })
+// ── THE MISS ────────────────────────────────────────────────────────────────
+//
+// The test that used to live here asserted the opposite of everything below:
+// "a wrong verdict adds no mark, no light and no colour", and specifically that a
+// wrong keep was NEVER shown the correction. That rule was written to avoid
+// punishing a child and it succeeded — and it also meant the single most teachable
+// second in the game was spent showing them nothing at all, which is most of what
+// the founder was reacting to when he called the failure state lame.
+//
+// The fleet rule, from `games/stack`, is the opposite and it is binding: when a
+// child gets it wrong the equation simply COMPLETES ITSELF in the accent colour,
+// held long enough to read, with no adjective attached to the child. Never red.
+// Never the word WRONG.
 
-  const inkOf = (over: Partial<SceneState>): { texts: string[]; brass: number } => {
-    rec.reset()
-    s.draw(state({ statement: st, ...over }))
-    return {
-      texts: rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0])),
-      brass: rec.ops.filter((op) => op.style === "#e6c281" || /230, 194, 129/.test(op.style)).length,
+const ACCENT_HEX = "#e6c281"
+
+const missState = (over: Partial<SceneState> = {}): Partial<SceneState> => ({
+  phase: "verdict",
+  outcome: "dud",
+  progress: 0.9,
+  elapsedMs: 800,
+  coins: -12,
+  ...over,
+})
+
+const flourishOf = (kind: MissKind | CelebrationKind, outcome: Outcome): Flourish => ({
+  outcome,
+  kind,
+  voice: 0,
+  spin: 0.37,
+})
+
+/** Every colour the frame actually put on the screen, as rgb triples. */
+function inkColours(rec: Recorder): { r: number; g: number; b: number; raw: string }[] {
+  const out: { r: number; g: number; b: number; raw: string }[] = []
+  for (const op of rec.ink()) {
+    const hex = /^#([0-9a-f]{6})$/i.exec(op.style)
+    if (hex) {
+      const n = Number.parseInt(hex[1] ?? "0", 16)
+      out.push({ r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255, raw: op.style })
+      continue
+    }
+    const rgb = /rgba?\((\d+), ?(\d+), ?(\d+)/.exec(op.style)
+    if (rgb) {
+      out.push({
+        r: Number(rgb[1]),
+        g: Number(rgb[2]),
+        b: Number(rgb[3]),
+        raw: op.style,
+      })
+    }
+  }
+  return out
+}
+
+test("A MISS COMPLETES THE SUM, IN THE ACCENT, AND HOLDS IT THERE", () => {
+  // `4003 − 87 = 3926` was kept, and the truth is `3916`. The child must see that
+  // second digit become a `1`, in the accent, and it must still be there when the
+  // beat ends — the hold IS the teaching, and a reveal that flashed past would be
+  // the old "show them nothing" with extra steps.
+  const { scene: s, rec } = scene(768, 1024)
+  for (const kind of MISSES) {
+    for (const outcome of ["dud", "burn"] as const) {
+      for (const reduced of [false, true]) {
+        const seen: number[] = []
+        for (const progress of [0.5, 0.75, 1]) {
+          rec.reset()
+          s.draw(
+            state(
+              missState({
+                outcome,
+                progress,
+                reduced,
+                flourish: flourishOf(kind, outcome),
+              }),
+            ),
+          )
+          const accent = rec.ops.filter(
+            (op) => op.name === "fillText" && op.style === ACCENT_HEX && op.alpha > 0.3,
+          )
+          seen.push(accent.length)
+          assert.ok(
+            accent.length > 0,
+            `${kind}/${outcome}${reduced ? " reduced" : ""} at ${String(progress)}: the sum was not completed in the accent`,
+          )
+        }
+        assert.ok(
+          (seen.at(-1) ?? 0) >= (seen[0] ?? 0),
+          `${kind}/${outcome}: the completed sum thinned out instead of being held (${seen.join(" → ")})`,
+        )
+      }
     }
   }
 
-  const wrong = inkOf({ phase: "verdict", outcome: "dud", progress: 0.6, coins: -12 })
-  const right = inkOf({ phase: "verdict", outcome: "bank", progress: 0.6, coins: 10 })
-  // The corrected digit is the slate admitting it was wrong, and it happens only when
-  // the child spotted it. A wrong keep never gets the answer handed to it.
-  assert.ok(!wrong.texts.includes("1"), "a wrong keep was shown the correction")
-  // And the stamp — the one bright mark in the game — is only ever on a correct keep.
-  assert.ok(right.brass > wrong.brass, "a wrong verdict got as much brass as a right one")
+  // ...and the corrected DIGIT itself, not merely some accent ink.
+  rec.reset()
+  s.draw(state(missState({ flourish: flourishOf("settle", "dud"), progress: 1 })))
+  const texts = rec.ops
+    .filter((op) => op.name === "fillText" && op.style === ACCENT_HEX)
+    .map((op) => String(op.args[0]))
+  assert.ok(texts.includes("1"), `the true digit is never shown: ${texts.join("")}`)
+})
+
+test("NOTHING ABOUT A MISS IS RED, AND THE STREET NEVER SAYS WRONG", () => {
+  // Both halves of the binding rule, swept over every miss the game can draw. The
+  // failure this catches is a future "just make it a bit clearer" that reaches for
+  // the one colour a child reads as a mark against them.
+  const { scene: s, rec } = scene(390, 844)
+  for (const kind of MISSES) {
+    for (const outcome of ["dud", "burn"] as const) {
+      for (const phase of ["verdict", "clear"] as const) {
+        for (const progress of [0, 0.3, 0.6, 1]) {
+          for (const reduced of [false, true]) {
+            rec.reset()
+            s.draw(
+              state(
+                missState({ outcome, phase, progress, reduced, flourish: flourishOf(kind, outcome) }),
+              ),
+            )
+            for (const c of inkColours(rec)) {
+              assert.ok(
+                !(c.r > 150 && c.r > c.g * 1.6 && c.r > c.b * 1.6),
+                `${kind}/${outcome} at ${String(progress)} drew ${c.raw} — that reads as red`,
+              )
+            }
+            for (const op of rec.ops) {
+              if (op.name !== "fillText") continue
+              const text = String(op.args[0]).toUpperCase()
+              for (const banned of ["WRONG", "MISS", "NO", "X"]) {
+                assert.notEqual(text, banned, `the slate said "${String(op.args[0])}"`)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+})
+
+test("THE STATEMENT IS NEVER DRAWN SOLID TWICE DURING A REVEAL", () => {
+  // A shipped defect, found by looking at the screen and not by any test that
+  // existed. `95 + 5 = 90` and `95 + 5 = 100` are different WIDTHS, so they are
+  // centred at different origins. Fading out only the claimed value and drawing the
+  // corrected statement over it draws the shared prefix TWICE, both opaque, a few
+  // pixels apart — a doubled smear exactly where the child is supposed to read the
+  // answer. It was invisible while both halves were the same chalk grey; the accent
+  // made it unmissable.
+  const { scene: s, rec } = scene(768, 1024)
+  const claim = statement({ claimed: "90", answer: "100", expression: "95 + 5", text: "95 + 5 = 90" })
+  const longest = [...`95 + 5 = 100`].length
+  for (const outcome of ["dud", "burn", "spot"] as const) {
+    for (const kind of MISSES) {
+      for (const progress of [0.3, 0.5, 0.7, 0.85, 1]) {
+        rec.reset()
+        s.draw(
+          state({
+            phase: "verdict",
+            outcome,
+            progress,
+            elapsedMs: 700,
+            statement: claim,
+            coins: outcome === "spot" ? 12 : -12,
+            flourish: flourishOf(kind, outcome),
+          }),
+        )
+        const solid = rec.ops.filter((op) => op.name === "fillText" && op.alpha > 0.6)
+        assert.ok(
+          solid.length <= longest + 1,
+          `${outcome}/${kind} at ${String(progress)} drew ${String(solid.length)} opaque glyphs for a ` +
+            `${String(longest)}-glyph line: ${solid.map((op) => String(op.args[0])).join("")}`,
+        )
+      }
+    }
+  }
+})
+
+test("the three miss reveals are three different animations, not one re-skinned", () => {
+  // A pool whose members render identically is a pool of one, and the founder would
+  // read it exactly the way he read the shipped version.
+  const { scene: s, rec } = scene(768, 1024)
+  const fingerprint = (kind: MissKind): string => {
+    rec.reset()
+    s.draw(state(missState({ progress: 0.4, flourish: flourishOf(kind, "dud") })))
+    return rec.ops
+      .filter((op) => op.name === "fillText")
+      .map((op) => `${String(op.args[0])}@${Number(op.args[2]).toFixed(1)}:${op.alpha.toFixed(2)}`)
+      .join("|")
+  }
+  const prints = MISSES.map(fingerprint)
+  assert.equal(new Set(prints).size, prints.length, `two miss reveals draw identically: ${prints.join("\n")}`)
+})
+
+test("A MISS IS STILL QUIETER THAN EVERY CELEBRATION — every variant, both ways", () => {
+  // `energy.ts` holds "being wrong is never more interesting than being right" on
+  // duration × movers × loudness. This is the same invariant at the level of the
+  // pixels: the LOUDEST miss the pool can draw must put less on the screen than the
+  // QUIETEST celebration it can draw.
+  const { scene: s, rec } = scene(768, 1024)
+  const inkFor = (kind: string, outcome: Outcome, coins: number): number => {
+    rec.reset()
+    s.draw(
+      state({
+        phase: "verdict",
+        outcome,
+        progress: 0.6,
+        elapsedMs: 500,
+        coins,
+        flourish: flourishOf(kind as MissKind, outcome),
+      }),
+    )
+    return rec.ink().length
+  }
+  const celebrations = CELEBRATIONS.flatMap((k) => [inkFor(k, "bank", 10), inkFor(k, "spot", 14)])
+  const misses = MISSES.flatMap((k) => [inkFor(k, "dud", -12), inkFor(k, "burn", -12)])
+  assert.ok(
+    Math.max(...misses) < Math.min(...celebrations),
+    `the loudest miss drew ${String(Math.max(...misses))} marks, the quietest celebration ${String(Math.min(...celebrations))}`,
+  )
+})
+
+test("the four celebrations are four different animations", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  const fingerprint = (kind: CelebrationKind): string => {
+    rec.reset()
+    s.draw(
+      state({
+        phase: "verdict",
+        outcome: "bank",
+        progress: 0.55,
+        elapsedMs: 300,
+        coins: 10,
+        flourish: flourishOf(kind, "bank"),
+      }),
+    )
+    return rec.ink().map((op) => `${op.name}:${op.style}`).join("|")
+  }
+  const prints = CELEBRATIONS.map(fingerprint)
+  assert.equal(new Set(prints).size, prints.length, "two celebrations render identically")
+})
+
+test("A CELEBRATION IS ONLY EVER DRAWN BY A CORRECT ANSWER", () => {
+  // The binding rule at the level of the renderer: the juice fires on the MATHS
+  // moment. Handing the scene a celebration on a wrong outcome — which nothing in
+  // the game does, but a future refactor might — must not draw one.
+  const { scene: s, rec } = scene(768, 1024)
+  const ink = (outcome: Outcome): number => {
+    rec.reset()
+    s.draw(
+      state({
+        phase: "verdict",
+        outcome,
+        progress: 0.5,
+        elapsedMs: 300,
+        coins: 0,
+        flourish: flourishOf("bloom", outcome),
+      }),
+    )
+    return rec.ink().length
+  }
+  const cheating = ink("dud")
+  const honest = ink("bank")
+  assert.ok(cheating < honest, `a miss handed a celebration drew ${String(cheating)} against ${String(honest)}`)
+})
+
+test("THE TWO MARKS ARE ON THE STREET THE WHOLE TIME, AND THE RIGHT ONE LIGHTS", () => {
+  // `≠` above and `=` below — the whole of the instructions, in the notation the
+  // child is already reading, in no language at all. They are permanent chrome, so a
+  // child who joins mid-run has not missed a tutorial.
+  const { scene: s, rec } = scene(390, 844)
+  const brightAround = (y0: number, y1: number, drag: Drag | null): number => {
+    rec.reset()
+    s.draw(state({ phase: "call", drag }))
+    let cursorY = Number.NaN
+    let best = 0
+    for (const op of rec.ops) {
+      if (op.name === "moveTo") cursorY = Number(op.args[1])
+      if (op.name !== "stroke") continue
+      const alpha = Number(/rgba\(230, 194, 129, ([\d.]+)\)/.exec(op.style)?.[1] ?? Number.NaN)
+      if (!Number.isFinite(alpha) || !Number.isFinite(cursorY)) continue
+      if (cursorY >= y0 && cursorY <= y1) best = Math.max(best, alpha)
+    }
+    return best
+  }
+  // The mark bands come out of `street.ts`, not out of this test's opinion of where
+  // they are — and they exclude the chevron bands entirely, so a mark that stopped
+  // being drawn could not be masked by the chevrons lighting.
+  const { chuteMark, hoardMark } = s.layout
+  const topBand = [chuteMark.y, chuteMark.y + chuteMark.h] as const
+  const lowBand = [hoardMark.y, hoardMark.y + hoardMark.h] as const
+
+  assert.ok(brightAround(topBand[0], topBand[1], null) > 0.1, "the ≠ mark is not drawn at rest")
+  assert.ok(brightAround(lowBand[0], lowBand[1], null) > 0.1, "the = mark is not drawn at rest")
+
+  const up: Drag = { dy: -70, pull: 1, heading: "toss" }
+  const down: Drag = { dy: 70, pull: 1, heading: "keep" }
+  assert.ok(
+    brightAround(topBand[0], topBand[1], up) > brightAround(topBand[0], topBand[1], null) * 1.8,
+    "pulling up barely lit the ≠",
+  )
+  assert.ok(
+    brightAround(lowBand[0], lowBand[1], down) > brightAround(lowBand[0], lowBand[1], null) * 1.8,
+    "pulling down barely lit the =",
+  )
+})
+
+test("THE GHOST TEACHES THE GESTURE AND THEN GETS OUT OF THE WAY", () => {
+  // It appears only for a child who has not yet landed a correct call AND has
+  // hesitated, and it is gone for good after the first one. A tutorial that outstays
+  // its welcome is condescension; `hint.ts` owns the gating and this asserts the
+  // renderer honours it.
+  const { scene: s, rec } = scene(390, 844)
+  const ghosts = (over: Partial<SceneState>): number => {
+    rec.reset()
+    s.draw(state({ phase: "call", elapsedMs: NUDGE_MS + 600, ...over }))
+    // The ghost is the hollow slate inset by six on every side. The drag's echo
+    // trail is also a brass `strokeRect` but is inset by two, so the width tells
+    // them apart — and a test that could not tell them apart would report the
+    // trail as a demonstration.
+    const ghostW = s.layout.slate.w - 12
+    return rec.ops.filter(
+      (op) =>
+        op.name === "strokeRect" &&
+        /rgba\(230, 194, 129/.test(op.style) &&
+        Math.abs(Number(op.args[2]) - ghostW) < 0.001,
+    ).length
+  }
+  const learning = ghosts({})
+  assert.ok(learning > 0, "a child who has landed nothing and hesitated gets no demonstration")
+
+  let landed = newRun()
+  landed = settle(landed, "bank")
+  assert.equal(ghosts({ run: landed }), 0, "the ghost is still there after a correct call")
+  assert.equal(ghosts({ elapsedMs: 200 }), 0, "the ghost pre-empted a fast answer")
+  assert.equal(
+    ghosts({ drag: { dy: 20, pull: 0.3, heading: "keep" } }),
+    0,
+    "the ghost competed with a live drag",
+  )
 })
 
 test("the light goes out of the window, and that is the only clock", () => {

--- a/dynawalla/games/truedraw/src/render/scene.ts
+++ b/dynawalla/games/truedraw/src/render/scene.ts
@@ -1,27 +1,53 @@
 // The street.
 //
-// Everything about this renderer is still subtraction. There are no particles, no
-// glow layers, no confetti, no colour that means "correct". There is a dust plane,
-// a slate, a caller, the people who have gathered to watch, a chute above and a bag
-// below — and for most of every round none of them move at all.
+// Most of this renderer is still subtraction. There is a dust plane, a slate, a
+// caller, the people who have gathered to watch, a chute at the top of the frame
+// and a hoard at the bottom — and for most of every round none of them move.
 //
-// What is new is the one thing the game was missing: **the slate follows your
-// finger.** A flick down carries it towards the bag; a flick up carries it towards
-// the chute; whichever destination you are heading for lights as you commit to it,
-// and past the threshold the slate leaves in that direction and does not come back.
-// A card you have thrown is gone before your hand stops. That is the whole of the
-// added juice and it is all in `slateBox` and `drawGutters`.
+// What the founder's playtest changed is what happens at the two moments that
+// matter, and how the slate behaves under a finger.
+//
+// ── THE MATHS MOMENT IS THE ONLY MOMENT ─────────────────────────────────────
+//
+// Everything expensive in this file fires on a CORRECT RETRIEVAL — a claim judged
+// rightly — and on nothing else. Not on a collision, not on a streak, not on a
+// window opening, not on a menu. `flourish.ts` draws one of four celebrations per
+// correct call so the twentieth does not look like the first.
+//
+// ── A MISS COMPLETES THE SUM ────────────────────────────────────────────────
+//
+// The old renderer's rule was that a wrong verdict "adds no mark, no light and no
+// colour" — the coins drained and nothing else happened. That was written to avoid
+// punishing a child and it succeeded, but it also meant the single most teachable
+// second in the game was spent showing them nothing.
+//
+// A miss now finishes the sum in front of the child, in `ACCENT`, held long enough
+// to read, in one of three ways. Never red, never the word WRONG, never an
+// adjective attached to the child. `games/stack` is the fleet's reference and this
+// is the same behaviour in this game's material. The reaction is still strictly
+// smaller than a celebration — `game/energy.ts` proves it against the numbers.
+//
+// ── THE SLATE FOLLOWS THE FINGER, WITH WEIGHT ───────────────────────────────
+//
+// `drag.ts` owns the curve: weight at the start, magnetism into the destination,
+// a rubber band past the commit line, a tilt and an echo trail. All of it pure and
+// driven to the pixel by `drag.test.ts`.
 
 import { safeInsets, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import { commitDistance } from "../game/gesture.ts"
 import type { Call, Outcome } from "../game/response.ts"
-import { isCorrect } from "../game/response.ts"
+import { isCorrect, isMiss } from "../game/response.ts"
 import { exitOf, type Phase } from "../game/round.ts"
 import type { Run } from "../game/run.ts"
 import { crowdOf, SHOTS } from "../game/run.ts"
 import type { Statement } from "../game/statement.ts"
+import { followOffset, magnetism, tiltFor, trailFor } from "./drag.ts"
+import { defaultFlourish, type Flourish } from "./flourish.ts"
 import { correctionFor, digitCellWidth, layout, type Layout } from "./glyphs.ts"
+import { hintFor, markGlow, type Hint } from "./hint.ts"
 import { layoutFor, type Layout as Street } from "./street.ts"
 import {
+  ACCENT,
   BRASS,
   BRASS_DIM,
   BRASS_LIT,
@@ -68,6 +94,15 @@ export type SceneState = {
   readonly reduced: boolean
   readonly drag: Drag | null
   /**
+   * The celebration or the miss reveal this verdict drew, from `flourish.ts`.
+   *
+   * Null on a frame with no verdict on it, and null on a lapse. A verdict frame
+   * that somehow arrives without one — a resume, a re-render — falls back to
+   * `defaultFlourish`, because a correct call that celebrated nothing would be the
+   * worse failure by a distance.
+   */
+  readonly flourish?: Flourish | null
+  /**
    * The host or the manual has something over the frame. The slate stands, blank.
    *
    * Same rule as the lead-in: a statement a child can read but cannot answer is
@@ -84,15 +119,16 @@ export type SceneState = {
  */
 const WINDOW_FLOOR = 0.45
 
-/** How far the slate travels per pixel of finger. Under 1, so the flick has weight. */
-const DRAG_FOLLOW = 0.55
-
-/** The most the slate tilts as it is thrown, in radians. A card, not a door. */
-const DRAG_TILT = 0.05
+/** Share of the miss verdict spent completing the sum. The rest is the HOLD. */
+const REVEAL_SHARE = 0.45
 
 const easeOut = (t: number): number => 1 - (1 - t) * (1 - t) * (1 - t)
 const easeInOut = (t: number): number => (t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2)
 const clamp01 = (t: number): number => Math.max(0, Math.min(1, t))
+
+/** Deterministic per-element jitter. No `Math.random` anywhere in a frame. */
+const jitter = (i: number, salt: number): number =>
+  ((Math.sin(i * 12.9898 + salt * 78.233) * 43758.5453) % 1 + 1) % 1
 
 export class Scene {
   private readonly canvas: HTMLCanvasElement
@@ -100,6 +136,7 @@ export class Scene {
   private w = 0
   private h = 0
   private dpr = 1
+  private commit = 34
   private street: Street
 
   constructor(canvas: HTMLCanvasElement) {
@@ -136,6 +173,9 @@ export class Scene {
     this.canvas.width = Math.round(this.w * this.dpr)
     this.canvas.height = Math.round(this.h * this.dpr)
     this.street = layoutFor(this.w, this.h, safeRect(this.w, this.h, insets))
+    // The same threshold the recogniser is built with, so the magnetism arrives
+    // exactly where the verdict does rather than near it.
+    this.commit = commitDistance(this.w, this.h)
   }
 
   draw(state: SceneState): void {
@@ -143,15 +183,26 @@ export class Scene {
     ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
     ctx.clearRect(0, 0, this.w, this.h)
 
+    const hint = hintFor({
+      phase: state.phase,
+      elapsedMs: state.elapsedMs,
+      reduced: state.reduced,
+      ...(state.masked === undefined ? {} : { masked: state.masked }),
+      dragging: state.drag !== null,
+      calls: state.run.calls,
+    })
+
     const horizon = this.street.horizon
     this.drawSky(horizon)
     this.drawGround(horizon, state)
     this.drawWitnesses(horizon, state)
     this.drawCaller(horizon, state)
-    this.drawGutters(state)
+    this.drawDestinations(state, hint)
+    this.drawGhost(hint)
     this.drawSlate(state)
+    this.drawCelebration(state)
     this.drawShots(state)
-    this.drawBag(state)
+    this.drawHoard(state)
   }
 
   // ── ground and sky ──────────────────────────────────────────────────────
@@ -185,7 +236,7 @@ export class Scene {
   /**
    * The crowd. One witness steps out of the haze per correct call, and none of them
    * ever steps back: a tally that could shrink would be the loss-aversion loop the
-   * product bans. The BAG can fall — that is the founder's economy and it is the
+   * product bans. The HOARD can fall — that is the founder's economy and it is the
    * score. The crowd is the other thing, and it is construction.
    */
   private drawWitnesses(horizon: number, state: SceneState): void {
@@ -196,10 +247,10 @@ export class Scene {
       const rank = Math.floor(i / 2)
       // Deterministic scatter: the same call count always draws the same street,
       // so nothing shimmers between frames.
-      const jitter = ((i * 2654435761) % 1000) / 1000
-      const spread = 0.16 + rank * 0.075 + jitter * 0.05
+      const scatter = ((i * 2654435761) % 1000) / 1000
+      const spread = 0.16 + rank * 0.075 + scatter * 0.05
       const x = this.w * (0.5 + side * spread)
-      const depth = 1 - Math.min(0.55, rank * 0.09 + jitter * 0.06)
+      const depth = 1 - Math.min(0.55, rank * 0.09 + scatter * 0.06)
       const height = this.h * 0.1 * depth
       const y = horizon + this.h * 0.012 * (1 - depth) * 3
       ctx.globalAlpha = 0.34 + depth * 0.4
@@ -277,46 +328,115 @@ export class Scene {
   // ── the two destinations ────────────────────────────────────────────────
 
   /**
-   * The chute above and the mouth of the bag below, and how far you have pulled
-   * towards each.
+   * THE CHUTE at the top and the MOUTH OF THE HOARD at the bottom, the chevrons
+   * that point into each, and the two marks that are the whole of the instructions:
+   * `≠` above, `=` below.
    *
-   * This is the affordance, and it is the reason a child does not have to be told
-   * the controls twice: as soon as a finger moves at all, the direction it is moving
-   * lights up. Nothing here is a button and nothing here is touched — the gesture
-   * happens on the slate. They are destinations.
+   * Nothing here is a button and nothing here is touched — the gesture happens on
+   * the slate. They are destinations, and they light as soon as a finger commits
+   * towards one, which is why the controls do not have to be explained twice.
+   *
+   * The marks are STROKED, not typed. Partly because two rules and a slash are the
+   * same three-stroke material language as everything else on the street; partly
+   * because a glyph drawn as text at 14 px on a 320 px phone is at the mercy of
+   * whatever serif the device felt like substituting.
    */
-  private drawGutters(state: SceneState): void {
+  private drawDestinations(state: SceneState, hint: Hint | null): void {
     const { ctx } = this
     if (state.phase === "idle" || state.phase === "over") return
     const drag = state.drag
-    const lit = this.litness(state)
-    const { chute, bag } = this.street
+    const lit = Math.max(0.55, this.litness(state))
+    const { chuteFlow, chuteMark, hoardFlow, hoardMark } = this.street
 
-    for (const [call, box] of [
-      ["toss", chute],
-      ["keep", { x: bag.x, y: bag.y, w: bag.w, h: bag.h * 0.22 }],
+    for (const [call, flow, mark] of [
+      ["toss", chuteFlow, chuteMark],
+      ["keep", hoardFlow, hoardMark],
     ] as const) {
-      const pulling = drag !== null && drag.heading === call ? drag.pull : 0
-      const resting = drag !== null && drag.heading === null ? Math.min(0.35, drag.pull) : 0
-      const glow = Math.max(pulling, resting) * lit
-      // Three chevrons pointing the way out. At rest they are almost invisible;
-      // under a committing finger they are the brightest thing after the slate.
-      const rows = 3
+      const heading = drag !== null && drag.heading === call
+      const pull = heading ? magnetism(drag.dy, this.commit) : 0
+      const resting = drag !== null && drag.heading === null ? Math.min(0.3, drag.pull) : 0
+      const glow = markGlow(true, Math.max(pull, resting), hint, hint?.call === call) * lit
       const up = call === "toss"
-      ctx.strokeStyle = withAlpha(BRASS_LIT, 0.06 + glow * 0.72)
-      ctx.lineWidth = 1 + glow * 1.4
-      for (let r = 0; r < rows; r++) {
-        const t = (r + 0.5) / rows
-        const y = box.y + box.h * (up ? 1 - t : t)
-        const spread = box.w * (0.06 + 0.05 * t)
-        const rise = box.h * 0.22
+
+      // Three chevrons pointing the way out, on the side nearest the slate.
+      ctx.strokeStyle = withAlpha(BRASS_LIT, 0.05 + glow * 0.5)
+      ctx.lineWidth = 1 + glow * 1.6
+      for (let r = 0; r < 3; r++) {
+        const t = (r + 0.5) / 3
+        const y = flow.y + flow.h * (up ? 1 - t : t)
+        const spread = flow.w * (0.06 + 0.05 * t)
+        const rise = flow.h * 0.3
         ctx.beginPath()
-        ctx.moveTo(box.x + box.w / 2 - spread, y + (up ? rise : -rise))
-        ctx.lineTo(box.x + box.w / 2, y)
-        ctx.lineTo(box.x + box.w / 2 + spread, y + (up ? rise : -rise))
+        ctx.moveTo(flow.x + flow.w / 2 - spread, y + (up ? rise : -rise))
+        ctx.lineTo(flow.x + flow.w / 2, y)
+        ctx.lineTo(flow.x + flow.w / 2 + spread, y + (up ? rise : -rise))
         ctx.stroke()
       }
+
+      this.drawMark(mark, call, glow)
     }
+  }
+
+  /**
+   * `≠` on the chute, `=` on the hoard.
+   *
+   * Two rules, and a slash through the top one when the answer is "it does not".
+   * UP IS `≠`, DOWN IS `=` — the founder's "intuitive up == false, down == true",
+   * said in the notation the child is already reading on the slate, in no language
+   * at all.
+   */
+  private drawMark(box: { x: number; y: number; w: number; h: number }, call: Call, glow: number): void {
+    const { ctx } = this
+    const px = this.street.markPx
+    const half = px * 0.42
+    const cx = box.x + box.w / 2
+    // Centred in its own band. `street.ts` put that band beyond the chevrons, at
+    // the far end of the destination, where nothing else is drawn.
+    const cy = box.y + box.h / 2
+    const gap = px * 0.17
+
+    ctx.strokeStyle = withAlpha(BRASS_LIT, 0.12 + glow * 0.72)
+    ctx.lineWidth = Math.max(1.5, px * 0.09)
+    ctx.lineCap = "round"
+    for (const dy of [-gap, gap]) {
+      ctx.beginPath()
+      ctx.moveTo(cx - half, cy + dy)
+      ctx.lineTo(cx + half, cy + dy)
+      ctx.stroke()
+    }
+    if (call === "toss") {
+      ctx.beginPath()
+      ctx.moveTo(cx - half * 0.5, cy + gap * 2.2)
+      ctx.lineTo(cx + half * 0.5, cy - gap * 2.2)
+      ctx.stroke()
+    }
+  }
+
+  /**
+   * THE GHOST — the second teacher, and the one that only exists until it is not
+   * needed.
+   *
+   * A hollow copy of the slate drifts towards the `=`, fades, then towards the
+   * `≠`, and fades. It shows the two MOVES and never the answer: a ghost that
+   * leaned the way the current statement ought to go would be the game answering
+   * the round, and the learner model would take the credit for it.
+   *
+   * `hint.ts` decides whether there is one at all — there is not, after the child's
+   * first correct call, or while a finger is down, or before they have hesitated.
+   */
+  private drawGhost(hint: Hint | null): void {
+    if (!hint || hint.alpha <= 0.001) return
+    const { ctx } = this
+    const { slate, chute, bag } = this.street
+    const reach =
+      hint.call === "keep" ? (bag.y - (slate.y + slate.h)) * 0.62 : -(slate.y - (chute.y + chute.h)) * 0.62
+    const dy = reach * hint.drift
+    ctx.save()
+    ctx.globalAlpha = hint.alpha * 0.7
+    ctx.strokeStyle = withAlpha(BRASS_LIT, 0.8)
+    ctx.lineWidth = 2
+    ctx.strokeRect(slate.x + 6, slate.y + dy + 6, slate.w - 12, slate.h - 12)
+    ctx.restore()
   }
 
   // ── the slate ───────────────────────────────────────────────────────────
@@ -329,10 +449,11 @@ export class Scene {
    * back to `WINDOW_FLOOR` by the moment the window closes. That is the clock, and
    * it is the only one: no bar, no ring, no countdown, nothing that moves.
    *
-   * A WRONG VERDICT REGAINS NO LIGHT. The street stays exactly as dim as the window
-   * left it, in both directions — banking a counterfeit and throwing away good money
-   * are equally unacknowledged. A lapse is the same: nothing brightens for a window
-   * nobody touched, and nothing dims either.
+   * A WRONG VERDICT REGAINS NO LIGHT, and that has not changed even though a miss
+   * now shows the child something. The street stays exactly as dim as the window
+   * left it; the completed sum carries its own legibility because it is drawn in
+   * `ACCENT` rather than in chalk. A lapse is the same: nothing brightens for a
+   * window nobody touched, and nothing dims either.
    */
   private litness(state: SceneState): number {
     if (state.phase === "call") {
@@ -352,13 +473,11 @@ export class Scene {
   /**
    * Where the slate is, how transparent it is, and how far it has been thrown.
    *
-   * Three motions, and only the third is new:
-   *
    *   raise    up out of the dust, blank
-   *   clear    away — DOWNWARD into the bag if you kept it, UPWARD out of frame if
-   *            you threw it. `exitOf` owns that sign, so the rule lives with the
+   *   clear    away — DOWNWARD into the hoard if you kept it, UPWARD out of frame
+   *            if you threw it. `exitOf` owns that sign, so the rule lives with the
    *            outcomes rather than in the renderer.
-   *   call     following the finger, at `DRAG_FOLLOW` of its travel, with a tilt.
+   *   call     following the finger through `drag.ts`'s curve, with a tilt.
    */
   private slateBox(state: SceneState): {
     x: number
@@ -367,6 +486,7 @@ export class Scene {
     h: number
     a: number
     tilt: number
+    dragging: boolean
   } {
     // Where the slate stands is `street.ts`'s business — inside the safe area and
     // clear of the host's corners.
@@ -375,6 +495,7 @@ export class Scene {
     let drop = 0
     let a = 1
     let tilt = 0
+    let dragging = false
     if (state.phase === "raise") {
       const t = state.reduced ? 1 : easeOut(state.progress)
       drop = (1 - t) * h * 1.5
@@ -386,10 +507,11 @@ export class Scene {
     } else if (state.phase === "idle") {
       a = 0
     } else if (state.phase === "call" && state.drag !== null) {
-      drop = state.drag.dy * DRAG_FOLLOW
-      tilt = state.reduced ? 0 : clamp01(state.drag.pull) * DRAG_TILT * Math.sign(state.drag.dy)
+      drop = followOffset(state.drag.dy, this.commit)
+      tilt = tiltFor(state.drag.dy, this.commit, state.reduced)
+      dragging = true
     }
-    return { x, y: y + drop, w, h, a, tilt }
+    return { x, y: y + drop, w, h, a, tilt, dragging }
   }
 
   private drawSlate(state: SceneState): void {
@@ -397,6 +519,16 @@ export class Scene {
     const box = this.slateBox(state)
     if (box.a <= 0.001) return
     const lit = this.litness(state)
+
+    // The echoes go down first, so the slate itself is always the solid thing.
+    if (box.dragging && state.drag) {
+      const echoes = trailFor(state.drag.dy, this.commit, state.reduced)
+      for (const echo of echoes) {
+        ctx.strokeStyle = withAlpha(BRASS_LIT, echo.alpha)
+        ctx.lineWidth = 1.25
+        ctx.strokeRect(box.x + 2, box.y + echo.back + 2, box.w - 4, box.h - 4)
+      }
+    }
 
     ctx.save()
     ctx.globalAlpha = box.a
@@ -418,9 +550,11 @@ export class Scene {
     ctx.fillRect(box.x, box.y, box.w, box.h)
 
     // The brass frame. Two rules, one bright and one in shadow, so the frame reads
-    // as a machined edge rather than as a border.
-    ctx.strokeStyle = mix(BRASS_DIM, BRASS_LIT, lit)
-    ctx.lineWidth = 2
+    // as a machined edge rather than as a border. Under a committing finger the
+    // outer rule takes the destination's own light: the card knows where it is going.
+    const pull = box.dragging && state.drag ? magnetism(state.drag.dy, this.commit) : 0
+    ctx.strokeStyle = mix(mix(BRASS_DIM, BRASS_LIT, lit), BRASS_LIT, pull)
+    ctx.lineWidth = 2 + pull * 1.2
     ctx.strokeRect(box.x + 1, box.y + 1, box.w - 2, box.h - 2)
     ctx.strokeStyle = withAlpha(BRASS, 0.22 + lit * 0.3)
     ctx.lineWidth = 1
@@ -452,6 +586,19 @@ export class Scene {
     return { px, layout: layout(ctx, text, digitCellWidth(ctx)) }
   }
 
+  /**
+   * The verdict currently on the slate, resolved to something drawable.
+   *
+   * A verdict frame with no flourish on it — a resume, a re-render, a host that
+   * paused across the settle — falls back rather than showing nothing.
+   */
+  private flourishOf(state: SceneState): Flourish | null {
+    if (state.phase !== "verdict" && state.phase !== "clear") return null
+    if (state.outcome === null) return null
+    if (state.flourish && state.flourish.outcome === state.outcome) return state.flourish
+    return defaultFlourish(state.outcome)
+  }
+
   private drawStatement(
     box: { x: number; y: number; w: number; h: number },
     state: SceneState,
@@ -467,16 +614,33 @@ export class Scene {
     ctx.textAlign = "left"
     ctx.textBaseline = "alphabetic"
 
-    const correcting =
-      state.outcome === "spot" && (state.phase === "verdict" || state.phase === "clear")
+    const flourish = this.flourishOf(state)
+    const spotting = state.outcome === "spot" && flourish !== null
+    const missing = state.outcome !== null && isMiss(state.outcome) && flourish !== null
+    const correcting = spotting || missing
     const correction = correcting ? correctionFor(l, statement.claimed, statement.answer) : null
-    // The roll starts a beat into the bow: the caller acknowledges you first, and
-    // only then does the slate admit it was wrong.
-    const rollT = correcting
-      ? clamp01(((state.phase === "verdict" ? state.progress : 1) - 0.24) / 0.5)
-      : 0
 
+    // ── the two clocks the reveal can run on ──────────────────────────────
+    //
+    // A SPOT starts a beat into the caller's bow: the street acknowledges the child
+    // first, and only then does the slate admit it was wrong.
+    //
+    // A MISS starts immediately and finishes inside `REVEAL_SHARE` of the verdict,
+    // because the remainder is the HOLD — the seconds the completed sum stands
+    // still and is read. That is the entire point of the miss reveal and it is why
+    // the miss beat is the longest non-celebratory one in `round.ts`.
+    const phaseT = state.phase === "verdict" ? state.progress : 1
+    const rollT = spotting
+      ? clamp01((phaseT - 0.2) / 0.45)
+      : missing
+        ? clamp01(phaseT / REVEAL_SHARE)
+        : 0
+
+    // A miss completes the sum in the ACCENT. Never red, and there is no red in the
+    // palette to reach for. A spot keeps the cold chalk: it is a celebration, and
+    // the celebration's own colour is the light, not the ink.
     const chalk = mix(CHALK_UNLIT, CHALK_LIT, lit)
+    const truth = missing ? ACCENT : chalk
     // Every alpha below is set *from* this rather than multiplied into the context.
     // A running `*=` / `/=` pair looks equivalent and is not: at the end of the
     // cross-fade the multiplier is zero, the division cannot undo it, and everything
@@ -484,12 +648,44 @@ export class Scene {
     // is drawn fully transparent.
     const base = ctx.globalAlpha
 
+    // "recut" always cross-fades the whole statement, even when the columns would
+    // have rolled. That is what makes it a different animation and not a re-skin.
+    const recut = missing && flourish?.kind === "recut"
+    const canRoll = correction !== null && correction.canRoll && !recut
+    // "drop" inverts the wheel: the true value falls in from above while the claim
+    // slides out below it.
+    const rollDir = flourish?.kind === "drop" ? -1 : 1
+
+    /**
+     * ── THE WHOLE LINE CROSS-FADES, NOT JUST THE CLAIM ────────────────────
+     *
+     * The trap, and it shipped: `715 + 620 = 335` and `715 + 620 = 1335` are
+     * different WIDTHS, so they are centred at different origins. Fading out only
+     * the claimed value and drawing the corrected statement over it therefore
+     * draws the shared prefix TWICE, at two x positions a few pixels apart, both
+     * fully opaque — a doubled, unreadable smear exactly where the child is
+     * supposed to read the answer. It was invisible while both halves were the
+     * same chalk grey and became obvious the moment the truth was drawn in the
+     * accent.
+     *
+     * So when there is no column to roll, the ENTIRE statement dissolves and the
+     * entire corrected one is cut in AFTER it — sequentially, not on top of it.
+     * A true cross-fade of two differently-centred lines is legible at neither end
+     * and a doubled ghost in the middle, which is what the founder was looking at.
+     * The two envelopes overlap by a tenth, where both are under 0.2 alpha, so it
+     * does not read as a blink.
+     */
+    const dissolving = correction !== null && !canRoll && rollT > 0
+    const outT = 1 - clamp01(rollT / 0.5)
+    const inT = clamp01((rollT - 0.45) / 0.55)
+    const corrected = dissolving ? this.faceFor(box, `${statement.expression} = ${statement.answer}`) : null
+    const correctedX = corrected ? box.x + (box.w - corrected.layout.width) / 2 : originX
+
     for (let i = 0; i < l.cells.length; i++) {
       const cell = l.cells[i]
       if (!cell) continue
-      const rolling = correction?.rolls.find((r) => r.index === i)
+      const rolling = canRoll ? correction?.rolls.find((r) => r.index === i) : undefined
       const inClaim = correction !== null && i >= correction.start
-      const fading = inClaim && rollT > 0 && !correction.canRoll
 
       if (rolling && rollT > 0) {
         this.rollDigit(
@@ -501,30 +697,45 @@ export class Scene {
           rolling.to,
           rollT,
           state.reduced,
-          chalk,
+          truth,
+          rollDir,
         )
         continue
       }
-      if (fading) {
-        // Lengths differ, so there is no column to roll in. The wrong value fades
-        // out where it stands and the right one fades in over it.
-        ctx.globalAlpha = base * (1 - rollT)
-        this.glyph(cell.ch, cell.x + originX, baseY, cell.w, CHALK_WRONG)
+      if (dissolving) {
+        if (outT <= 0.001) continue
+        ctx.globalAlpha = base * outT
+        this.glyph(cell.ch, cell.x + originX, baseY, cell.w, inClaim ? CHALK_WRONG : chalk)
         ctx.globalAlpha = base
         continue
       }
-      this.glyph(cell.ch, cell.x + originX, baseY, cell.w, chalk)
+      this.glyph(cell.ch, cell.x + originX, baseY, cell.w, missing && rollT > 0 ? truth : chalk)
     }
 
-    if (correction !== null && !correction.canRoll && rollT > 0) {
-      const corrected = `${statement.expression} = ${statement.answer}`
-      const fixed = this.faceFor(box, corrected)
-      const fx = box.x + (box.w - fixed.layout.width) / 2
-      ctx.globalAlpha = base * rollT
-      for (const cell of fixed.layout.cells) {
-        this.glyph(cell.ch, cell.x + fx, baseY, cell.w, chalk)
+    if (corrected && inT > 0.001) {
+      ctx.globalAlpha = base * inT
+      for (const cell of corrected.layout.cells) {
+        this.glyph(cell.ch, cell.x + correctedX, baseY, cell.w, truth)
       }
       ctx.globalAlpha = base
+    }
+
+    // The rule under a completed sum: the accent saying "this is the number", and
+    // the only mark a miss ever puts on the slate. It is drawn under whichever
+    // line is arriving, so it cannot be a hair wider or narrower than the sum.
+    // It rides in with whichever envelope the truth is arriving on, so it never
+    // underlines a line that has not been cut in yet.
+    const ruleT = dissolving ? inT : rollT
+    if (missing && ruleT > 0.001) {
+      const full = corrected?.layout.width ?? l.width
+      const width = full * (state.reduced ? 1 : easeOut(ruleT))
+      const ruleY = baseY + px * 0.32
+      ctx.strokeStyle = withAlpha(ACCENT, 0.28 + 0.42 * ruleT)
+      ctx.lineWidth = Math.max(1.5, px * 0.05)
+      ctx.beginPath()
+      ctx.moveTo(correctedX, ruleY)
+      ctx.lineTo(correctedX + width, ruleY)
+      ctx.stroke()
     }
 
     if (state.outcome === "bank" && (state.phase === "verdict" || state.phase === "clear")) {
@@ -541,9 +752,13 @@ export class Scene {
   }
 
   /**
-   * The correction: a wrong digit rolls up out of its cell and the right one rolls
-   * in behind it, like a counter wheel. It is clipped to the cell, so the statement
+   * The correction: a wrong digit rolls out of its cell and the right one rolls in
+   * behind it, like a counter wheel. It is clipped to the cell, so the statement
    * never reflows and nothing moves outside the recess.
+   *
+   * `dir` is `+1` for the wheel (the claim rides up, the truth arrives from below)
+   * and `-1` for the drop (the truth falls in from above). Two of the three miss
+   * variants are that one sign.
    *
    * Reduced motion takes the same event as a cross-fade in place — a branch, not a
    * degradation. The child still watches the slate correct itself.
@@ -558,6 +773,7 @@ export class Scene {
     t: number,
     reduced: boolean,
     colour: string,
+    dir: number,
   ): void {
     const { ctx } = this
     if (reduced) {
@@ -574,8 +790,8 @@ export class Scene {
     ctx.beginPath()
     ctx.rect(x, baseY - px * 1.02, cellW, px * 1.3)
     ctx.clip()
-    this.glyph(from, x, baseY - e * px * 1.25, cellW, CHALK_WRONG)
-    this.glyph(to, x, baseY + (1 - e) * px * 1.25, cellW, colour)
+    this.glyph(from, x, baseY - dir * e * px * 1.25, cellW, CHALK_WRONG)
+    this.glyph(to, x, baseY + dir * (1 - e) * px * 1.25, cellW, colour)
     ctx.restore()
   }
 
@@ -597,13 +813,182 @@ export class Scene {
     ctx.stroke()
   }
 
+  // ── the celebrations ────────────────────────────────────────────────────
+
+  /**
+   * ONE OF FOUR, on a correct call, and never on anything else.
+   *
+   * This is the whole of the founder's "make the animations captivating", and the
+   * reason it is four rather than one is his sentence before it: the same reward
+   * twenty times running stops being a reward. `flourish.ts` draws which, from the
+   * run's seeded RNG, and never the same one twice in a row.
+   *
+   * Reduced motion keeps every element and takes away the travel — the elements
+   * stand at their final positions and fade. A branch, not a deletion: a child who
+   * needs reduced motion still gets told they were right.
+   */
+  private drawCelebration(state: SceneState): void {
+    const flourish = this.flourishOf(state)
+    if (!flourish || state.outcome === null || !isCorrect(state.outcome)) return
+    const { ctx } = this
+    const t = clamp01(state.phase === "verdict" ? state.progress : 1)
+    const e = state.reduced ? 1 : easeOut(t)
+    // A single envelope for every variant, so no two celebrations disagree about
+    // when the moment is over.
+    const fade = state.reduced ? 1 - t : Math.sin(Math.PI * clamp01(t)) ** 0.6
+    if (fade <= 0.001) return
+    const { slate } = this.street
+    const cx = slate.x + slate.w / 2
+    const cy = slate.y + slate.h / 2
+    const spin = flourish.spin
+
+    switch (flourish.kind) {
+      case "rays":
+        this.rays(cx, cy, slate, e, fade, spin)
+        break
+      case "shower":
+        this.shower(cx, cy, e, fade, spin)
+        break
+      case "bloom":
+        this.bloom(e, fade, spin)
+        break
+      default:
+        this.rings(cx, cy, slate, e, fade, spin)
+        break
+    }
+
+    // Common to all four: the frame takes the light. It is what ties the variants
+    // together as one game's celebration rather than four unrelated effects.
+    ctx.strokeStyle = withAlpha(BRASS_LIT, 0.5 * fade)
+    ctx.lineWidth = 2 + 2 * fade
+    ctx.strokeRect(slate.x - 2, slate.y - 2, slate.w + 4, slate.h + 4)
+    ctx.strokeStyle = withAlpha(CHALK_LIT, 0.22 * fade)
+    ctx.lineWidth = 1
+    ctx.strokeRect(slate.x - 6, slate.y - 6, slate.w + 12, slate.h + 12)
+  }
+
+  /** Rings of brass leaving the slate, with a scatter of sparks inside them. */
+  private rings(cx: number, cy: number, slate: { w: number }, e: number, fade: number, spin: number): void {
+    const { ctx } = this
+    const reach = slate.w * 0.9
+    for (let i = 0; i < 5; i++) {
+      const lag = clamp01((e - i * 0.09) / 0.8)
+      if (lag <= 0) continue
+      const r = Math.max(1, slate.w * 0.18 + reach * lag)
+      ctx.strokeStyle = withAlpha(BRASS_LIT, 0.4 * fade * (1 - lag))
+      ctx.lineWidth = 2.5 * (1 - lag) + 0.5
+      ctx.beginPath()
+      ctx.arc(cx, cy, r, 0, Math.PI * 2)
+      ctx.stroke()
+      ctx.strokeStyle = withAlpha(CHALK_LIT, 0.16 * fade * (1 - lag))
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      ctx.arc(cx, cy, r * 0.92, 0, Math.PI * 2)
+      ctx.stroke()
+    }
+    this.sparks(cx, cy, e, fade, spin, 12, slate.w * 0.7)
+  }
+
+  /** Spokes of cold light: the slate was lit from behind for a moment. */
+  private rays(cx: number, cy: number, slate: { w: number }, e: number, fade: number, spin: number): void {
+    const { ctx } = this
+    const n = 14
+    for (let i = 0; i < n; i++) {
+      const angle = (i / n) * Math.PI * 2 + spin * Math.PI * 2
+      const inner = slate.w * (0.2 + 0.5 * e)
+      const outer = inner + slate.w * 0.3 * (1 - e * 0.5) * (0.6 + jitter(i, spin) * 0.8)
+      ctx.strokeStyle = withAlpha(i % 2 === 0 ? BRASS_LIT : CHALK_LIT, 0.34 * fade)
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.moveTo(cx + Math.cos(angle) * inner, cy + Math.sin(angle) * inner)
+      ctx.lineTo(cx + Math.cos(angle) * outer, cy + Math.sin(angle) * outer)
+      ctx.stroke()
+    }
+    this.sparks(cx, cy, e, fade, spin, 8, slate.w * 0.55)
+  }
+
+  /** A handful of coins lofted over the top of the hoard, arriving late. */
+  private shower(cx: number, cy: number, e: number, fade: number, spin: number): void {
+    const { ctx } = this
+    const { bag } = this.street
+    const to = { x: bag.x + bag.w / 2, y: bag.y + bag.h * 0.4 }
+    const r = Math.max(2, bag.w * 0.04)
+    for (let i = 0; i < 14; i++) {
+      const lag = clamp01((e - i * 0.035) / 0.75)
+      if (lag <= 0) continue
+      const lane = (jitter(i, spin) - 0.5) * 2
+      const x = cx + (to.x - cx) * lag + lane * bag.w * 0.9 * (1 - lag)
+      // A real arc: up first, then down into the hoard.
+      const y = cy + (to.y - cy) * lag - Math.sin(Math.PI * lag) * bag.h * 0.9
+      ctx.fillStyle = withAlpha(BRASS_LIT, 0.8 * fade * (1 - lag * 0.3))
+      ctx.beginPath()
+      ctx.arc(x, y, r, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    for (let i = 0; i < 6; i++) {
+      const lag = clamp01((e - i * 0.1) / 0.7)
+      if (lag <= 0) continue
+      ctx.strokeStyle = withAlpha(BRASS_LIT, 0.3 * fade * (1 - lag))
+      ctx.lineWidth = 1.5
+      ctx.beginPath()
+      ctx.arc(to.x, to.y, bag.w * 0.3 * lag, 0, Math.PI * 2)
+      ctx.stroke()
+    }
+  }
+
+  /** The lamps in the haze flare and motes rise off the crowd. */
+  private bloom(e: number, fade: number, spin: number): void {
+    const { ctx } = this
+    const horizon = this.street.horizon
+    for (let i = 0; i < 18; i++) {
+      const lag = clamp01((e - jitter(i, spin) * 0.3) / 0.8)
+      if (lag <= 0) continue
+      const x = this.w * (0.06 + jitter(i, spin + 1) * 0.88)
+      const y = horizon - this.h * 0.22 * lag + this.h * 0.02 * jitter(i, spin + 2)
+      ctx.fillStyle = withAlpha(i % 3 === 0 ? CHALK_LIT : BRASS_LIT, 0.55 * fade * (1 - lag))
+      ctx.beginPath()
+      ctx.arc(x, y, Math.max(1, this.h * 0.004 * (1 - lag * 0.5)), 0, Math.PI * 2)
+      ctx.fill()
+    }
+    for (let i = 0; i < 4; i++) {
+      const lag = clamp01((e - i * 0.12) / 0.7)
+      if (lag <= 0) continue
+      ctx.strokeStyle = withAlpha(BRASS_LIT, 0.22 * fade * (1 - lag))
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      ctx.moveTo(0, horizon - this.h * 0.05 * lag)
+      ctx.lineTo(this.w, horizon - this.h * 0.05 * lag)
+      ctx.stroke()
+    }
+  }
+
+  private sparks(
+    cx: number,
+    cy: number,
+    e: number,
+    fade: number,
+    spin: number,
+    n: number,
+    reach: number,
+  ): void {
+    const { ctx } = this
+    for (let i = 0; i < n; i++) {
+      const angle = jitter(i, spin) * Math.PI * 2
+      const d = reach * (0.3 + jitter(i, spin + 3) * 0.7) * e
+      ctx.fillStyle = withAlpha(BRASS_LIT, 0.6 * fade)
+      ctx.beginPath()
+      ctx.arc(cx + Math.cos(angle) * d, cy + Math.sin(angle) * d, Math.max(1, reach * 0.02), 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }
+
   // ── the ledger ──────────────────────────────────────────────────────────
 
   /**
-   * The run, over. One numeral: the bag.
+   * The run, over. One numeral: the hoard.
    *
    * There is no percentage here and there never will be. A child shown "50%" reads
-   * a passing grade; a child shown a bag of coins reads a bag of coins.
+   * a passing grade; a child shown a pile of coins reads a pile of coins.
    */
   private drawLedger(
     box: { x: number; y: number; w: number; h: number },
@@ -657,56 +1042,49 @@ export class Scene {
   }
 
   /**
-   * THE BAG. The score, and the only number on the street during play.
+   * THE HOARD, locked to the bottom of the glass. The keep pile, the coin count,
+   * and the score — the only number on the street during play.
    *
-   * The coins in flight are the whole of the feedback for a wrong verdict: nothing
-   * sounds, nothing buzzes, nothing flashes and the caller does not move — coins
-   * simply come back out of the bag and go. `energy.ts` holds that line.
+   * It is a PILE now rather than a bag: one card edge per correct call, stacking up
+   * out of the bottom of the frame. The founder asked for the keep pile to be at
+   * the bottom of the screen and this is what is at the bottom of it.
+   *
+   * The coins in flight are most of the feedback for a wrong verdict: coins come
+   * back out of the hoard and go, and the slate finishes the sum. Nothing flashes
+   * red, nothing buzzes, and `energy.ts` holds that line.
    */
-  private drawBag(state: SceneState): void {
+  private drawHoard(state: SceneState): void {
     if (state.phase === "idle") return
     const { ctx } = this
-    const { bag } = this.street
+    const { bag, lipY, countY, pileY, cardH } = this.street
     const cx = bag.x + bag.w / 2
-    const lip = bag.y + bag.h * 0.22
-    const full = clamp01(state.run.bag / 240)
 
-    // A bag: a straight lip, and a body that swells with what is in it.
+    // The pile. One edge per correct call, up to a dozen — a stack a child can see
+    // getting taller without it ever needing a number to say so.
+    const cards = Math.min(CARDS_MAX, state.run.calls)
+    const step = Math.max(cardH * 1.15, (bag.y + bag.h - pileY) / CARDS_MAX)
+    for (let i = 0; i < cards; i++) {
+      const y = bag.y + bag.h - step * (i + 1)
+      const inset = bag.w * 0.06 * (i / CARDS_MAX)
+      ctx.strokeStyle = withAlpha(BRASS, 0.24 + 0.4 * (i / CARDS_MAX))
+      ctx.lineWidth = 1
+      ctx.strokeRect(bag.x + inset, y, bag.w - inset * 2, cardH)
+    }
+
+    // The lip of the pile: a straight brass rule the cards land on.
     ctx.strokeStyle = withAlpha(BRASS_DIM, 0.55)
     ctx.lineWidth = 1.25
     ctx.beginPath()
-    ctx.moveTo(bag.x + bag.w * 0.22, lip)
-    ctx.lineTo(bag.x + bag.w * 0.78, lip)
+    ctx.moveTo(bag.x + bag.w * 0.06, lipY)
+    ctx.lineTo(bag.x + bag.w * 0.94, lipY)
     ctx.stroke()
 
-    const belly = bag.w * (0.3 + full * 0.16)
-    ctx.beginPath()
-    ctx.moveTo(bag.x + bag.w * 0.26, lip)
-    ctx.bezierCurveTo(
-      cx - belly,
-      lip + bag.h * 0.34,
-      cx - belly * 0.72,
-      bag.y + bag.h,
-      cx,
-      bag.y + bag.h,
-    )
-    ctx.bezierCurveTo(
-      cx + belly * 0.72,
-      bag.y + bag.h,
-      cx + belly,
-      lip + bag.h * 0.34,
-      bag.x + bag.w * 0.74,
-      lip,
-    )
-    ctx.strokeStyle = withAlpha(BRASS, 0.3 + full * 0.4)
-    ctx.stroke()
-
-    // The count. Brass, inside the bag, and it is the score.
+    // The count. Brass, on the pile, and it is the score.
     ctx.font = `${String(this.street.bagPx)}px ${SLATE_FONT}`
     ctx.textAlign = "center"
     ctx.textBaseline = "middle"
     ctx.fillStyle = withAlpha(BRASS_LIT, state.run.bag > 0 ? 0.9 : 0.34)
-    ctx.fillText(String(state.run.bag), cx, bag.y + bag.h * 0.64)
+    ctx.fillText(String(state.run.bag), cx, countY)
 
     this.drawCoins(state)
   }
@@ -714,10 +1092,10 @@ export class Scene {
   /**
    * Coins in flight, during the verdict only.
    *
-   * Into the bag when the call was right, out of it and away when it was wrong. The
-   * count is the size of the call, so a fast correct keep visibly pays more than a
-   * slow one — the speed bonus is a thing a child can SEE rather than a number they
-   * are told.
+   * Into the hoard when the call was right, out of it and away when it was wrong.
+   * The count is the size of the call, so a fast correct keep visibly pays more than
+   * a slow one — the speed bonus is a thing a child can SEE rather than a number
+   * they are told.
    */
   private drawCoins(state: SceneState): void {
     if (state.phase !== "verdict" && state.phase !== "clear") return
@@ -753,7 +1131,7 @@ export class Scene {
         y = from.y + (to.y - from.y) * stagger
         alpha = 0.85 * (1 - stagger * 0.35)
       } else {
-        // Out of the bag and away downwards, off the bottom of the frame.
+        // Out of the hoard and away downwards, off the bottom of the frame.
         x = to.x + spread * stagger
         y = to.y + (this.h - to.y) * stagger
         alpha = 0.7 * (1 - stagger)
@@ -769,8 +1147,17 @@ export class Scene {
 }
 
 /**
- * How many coins a loss shows leaving the bag.
+ * How many coins a loss shows leaving the hoard.
  *
  * Fixed, and fewer than the smallest win puts in — see `drawCoins`.
  */
 const COINS_OUT = 2
+
+/**
+ * The tallest the keep pile ever gets.
+ *
+ * It stops growing rather than shrinking the cards, because a pile that rescaled
+ * itself would be a pile that looks the same after two calls as after forty — and
+ * the whole reason it is a pile is that a child can see it getting taller.
+ */
+const CARDS_MAX = 12

--- a/dynawalla/games/truedraw/src/render/street.test.ts
+++ b/dynawalla/games/truedraw/src/render/street.test.ts
@@ -19,13 +19,20 @@
 // makes on rotation. A clearance test that calls `layoutFor` itself is a test
 // of the arguments the test chose, not of the ones the game passes.
 
-import { hitsHostChrome, NO_INSETS, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import {
+  exitRect,
+  helpRect,
+  hitsHostChrome,
+  HOST_PROGRESS_H,
+  NO_INSETS,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts"
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { fakeCanvas } from "./fakeCanvas.ts"
 import { Scene } from "./scene.ts"
-import { layoutFor, type Rect } from "./street.ts"
+import { columnOf, densityOf, GESTURE_STRIP, layoutFor, type Rect } from "./street.ts"
 
 const VIEWPORTS: readonly (readonly [string, number, number])[] = [
   ["phone portrait, small", 320, 568],
@@ -105,6 +112,123 @@ for (const [shape, w, h] of VIEWPORTS) {
           `${name} ${show(box)} runs outside the safe area ${show(area)} at ${String(w)}×${String(h)} ${where}`,
         )
       }
+    })
+    // ── THE PINNING, which is the founder's note, at every shape ────────────
+    //
+    // "The cache/keep score/pile could be locked to the bottom of the screen and
+    // the discard target to the top." Locked, not merely near: each of the two
+    // destinations sits ON the boundary of the column the game owns, and the
+    // boundaries themselves come out of `layoutFor` rather than being recomputed
+    // here — a clearance test that derives its own edge is a test of the edge it
+    // derived.
+
+    test(`THE HOARD IS LOCKED TO THE BOTTOM — ${shape} (${String(w)}×${String(h)}), ${where}`, () => {
+      const l = streetAt(w, h, insets).layout
+      const bottom = l.bag.y + l.bag.h
+
+      assert.ok(
+        Math.abs(bottom - l.floor) < 0.5,
+        `the hoard ends at ${bottom.toFixed(1)} and the floor is ${l.floor.toFixed(1)} — ` +
+          `${(l.floor - bottom).toFixed(1)}px of nothing under the keep pile`,
+      )
+      // The floor itself clears BOTH hazards. Android's gesture strip reports an
+      // inset of ZERO on many devices — it is an overlay, not a cutout — so the
+      // bottom inset alone is not enough and never was.
+      assert.ok(
+        l.floor <= h - GESTURE_STRIP + 0.001,
+        `the floor at ${l.floor.toFixed(1)} is inside the ${String(GESTURE_STRIP)}px the system swipes in`,
+      )
+      assert.ok(
+        l.floor <= h - insets.bottom + 0.001,
+        `the floor at ${l.floor.toFixed(1)} is under the ${String(insets.bottom)}px bottom inset`,
+      )
+      // The shots ride directly above it rather than floating somewhere.
+      assert.ok(l.shots.y + l.shots.h <= l.bag.y + 0.5, "the shots are inside the hoard")
+      assert.ok(
+        l.bag.y - (l.shots.y + l.shots.h) < (l.floor - l.ceiling) * 0.1,
+        "the shots have drifted away from the hoard they belong to",
+      )
+    })
+
+    test(`THE CHUTE IS LOCKED TO THE TOP — ${shape} (${String(w)}×${String(h)}), ${where}`, () => {
+      const l = streetAt(w, h, insets).layout
+      assert.ok(
+        Math.abs(l.chute.y - l.ceiling) < 0.5,
+        `the chute starts at ${l.chute.y.toFixed(1)} and the ceiling is ${l.ceiling.toFixed(1)}`,
+      )
+      // And the ceiling clears everything the HOST paints over the game: both 44px
+      // corner controls and the progress hairline. The chute is pinned BELOW them
+      // rather than threading between them, which is the only placement correct at
+      // every width — at 320px there are 192px between the two corners and at 320px
+      // in landscape with a side notch there are fewer.
+      const exit = exitRect(insets)
+      const help = helpRect(w, insets)
+      assert.ok(l.ceiling >= exit.y + exit.h, `the ceiling is inside the exit control`)
+      assert.ok(l.ceiling >= help.y + help.h, `the ceiling is inside the how-to-play control`)
+      assert.ok(l.ceiling >= insets.top + HOST_PROGRESS_H, `the ceiling is under the progress hairline`)
+      assert.equal(hitsHostChrome(l.chute, w, insets), false)
+    })
+
+    test(`NOTHING OVERLAPS AND NO BAND IS DEAD — ${shape} (${String(w)}×${String(h)}), ${where}`, () => {
+      const l = streetAt(w, h, insets).layout
+      const column = columnOf(l)
+
+      // In order, top to bottom, with nothing sitting on anything else.
+      let cursor = l.ceiling
+      for (const [name, box] of column) {
+        assert.ok(
+          box.y >= cursor - 0.5,
+          `${name} ${show(box)} starts at ${box.y.toFixed(1)}, above ${cursor.toFixed(1)}`,
+        )
+        cursor = box.y + box.h
+      }
+      assert.ok(cursor <= l.floor + 0.5, `the column runs ${(cursor - l.floor).toFixed(1)}px past the floor`)
+
+      // ── the founder's actual complaint, as two numbers ──────────────────
+      //
+      // The layout this replaced measured everything downward from the slate and
+      // then simply stopped: on a 320×568 phone with a notch it left 163px — 39%
+      // of the column — dead in one continuous strip below the hoard, and covered
+      // only 39% of it. Those are the numbers this asserts against, and the old
+      // layout fails both by a wide margin.
+      // The chevrons and the marks each keep their own band inside their own
+      // destination. "Put the mark in the middle of the chevrons" is legible on a
+      // 190px iPad hoard and a smudge on a 40px one, which is why these are
+      // rectangles rather than fractions written into the drawing code.
+      for (const [name, band, host] of [
+        ["the chute's chevrons", l.chuteFlow, l.chute],
+        ["the ≠ mark", l.chuteMark, l.chute],
+        ["the hoard's chevrons", l.hoardFlow, l.bag],
+        ["the = mark", l.hoardMark, l.bag],
+      ] as const) {
+        assert.ok(band.y >= host.y - 0.001, `${name} starts above its destination`)
+        assert.ok(band.y + band.h <= host.y + host.h + 0.001, `${name} runs past its destination`)
+        assert.ok(band.h > 0, `${name} has no height`)
+      }
+      const apart = (a: Rect, b: Rect): boolean => a.y + a.h <= b.y + 0.001 || b.y + b.h <= a.y + 0.001
+      assert.ok(apart(l.chuteFlow, l.chuteMark), "the ≠ is drawn through the chevrons")
+      assert.ok(apart(l.hoardFlow, l.hoardMark), "the = is drawn through the chevrons")
+      // And the mark fits the band it was sized for, rather than overflowing the
+      // one thing on the street that has to be readable at 40px.
+      assert.ok(
+        l.markPx * 0.75 <= Math.min(l.chuteMark.h, l.hoardMark.h) + 1,
+        `a ${String(l.markPx)}px mark in a ${Math.min(l.chuteMark.h, l.hoardMark.h).toFixed(1)}px band`,
+      )
+      // The pile, the lip and the count stack down the hoard without colliding.
+      assert.ok(l.hoardMark.y + l.hoardMark.h <= l.lipY + 0.001, "the = mark sits on the lip")
+      assert.ok(l.lipY < l.countY, "the count is above the lip it sits on")
+      assert.ok(l.countY < l.pileY, "the count is buried in the card stack")
+      assert.ok(l.pileY + l.cardH <= l.bag.y + l.bag.h, "the card stack runs out of the hoard")
+
+      const { covered, deadest } = densityOf(l)
+      assert.ok(
+        covered >= 0.55,
+        `only ${(covered * 100).toFixed(0)}% of the playable column is used at ${String(w)}×${String(h)} ${where}`,
+      )
+      assert.ok(
+        deadest <= 0.2,
+        `a dead band of ${(deadest * 100).toFixed(0)}% of the column at ${String(w)}×${String(h)} ${where}`,
+      )
     })
   }
 }

--- a/dynawalla/games/truedraw/src/render/street.ts
+++ b/dynawalla/games/truedraw/src/render/street.ts
@@ -11,16 +11,45 @@
 // So this module splits the frame in two:
 //
 //   * the WORLD — horizon, sky, dust, figures — laid out on the full canvas;
-//   * the READABLE things — the slate, the three shots, the bag — laid out
-//     inside `area`, the safe rectangle, and clear of the host's two corners.
+//   * the READABLE things — the chute, the slate, the three shots, the hoard —
+//     laid out inside `area`, the safe rectangle, and clear of the host's two
+//     corners.
+//
+// ── WHAT CHANGED, AND WHY (the founder's playtest) ──────────────────────────
+//
+// "Too much blank space. the cache/keep score/pile could be locked to the bottom
+// of the screen and the discard target to the top."
+//
+// He was reading the layout exactly right. The old street measured EVERYTHING
+// from the slate: the chute sat one gutter above it, the shots one drop below,
+// the hoard below those — and then the layout simply stopped, wherever it
+// happened to stop. On a 320×568 phone with a notch that left a 163 px band of
+// nothing between the hoard and the bottom of the glass: 39% of the playable
+// column, dead. The game looked like a widget floating in a dark room.
+//
+// It is now laid out from BOTH ENDS INWARD.
+//
+//   * `ceiling` — the first row the game owns, immediately under the host's two
+//     44 px corner controls and its progress hairline. The CHUTE is pinned there.
+//   * `floor` — the last row the game owns, clear of the bottom inset AND of
+//     `GESTURE_STRIP`. The HOARD is pinned there, with the shots just above it.
+//   * the slate is centred in what is left, and it is much bigger than it was,
+//     because the space between the two destinations is the space it is thrown
+//     across.
+//
+// `street.test.ts` asserts the pinning, the clearances and — the one that would
+// have caught the shipped defect — that no single gap in the column is more than
+// a fifth of it.
+//
+// ── THE HOST'S CHROME OVERLAYS; IT DOES NOT RESERVE ─────────────────────────
 //
 // The host paints an exit control top-LEFT and a how-to-play control top-RIGHT,
-// 44px each, floating over the game. They do not reserve a band: reserving one
-// costs a twelfth of a 568px phone and broke a sibling game's own layout. The
+// 44 px each, floating over the game. They do not reserve a band: reserving one
+// costs a twelfth of a 568 px phone and broke a sibling game's own layout. The
 // promise each game makes instead is narrow and absolute — nothing a child must
-// read or touch lands in those two squares. The slate is 88% of the width, so
-// at most viewports it cannot pass between them; when it cannot, it goes below
-// them, and that is the whole of the clamp.
+// read or touch lands in those two squares. The chute is now pinned BELOW both
+// of them rather than trying to thread between them, which is the only placement
+// that is correct at every width.
 
 import {
   exitRect,
@@ -33,11 +62,61 @@ import { SHOTS } from "../game/run.ts"
 
 export type { Rect }
 
+/**
+ * The band at the bottom of the glass the SYSTEM swipes in from.
+ *
+ * Android's gesture strip reports a bottom inset of ZERO on many devices — it is
+ * an overlay, not a cutout — so a layout that trusted `insets.bottom` alone would
+ * put the hoard directly under the back-swipe on exactly the phones that use it.
+ * 24 px is the precedent set by `games/runner/src/game/chrome.ts` and
+ * `games/pulse/src/render/chrome.ts`, and it is deliberately the same number in
+ * all three.
+ */
+export const GESTURE_STRIP = 24
+
+/** Share of the safe width the slate takes, and the ceiling on it for tablets. */
+const SLATE_WIDTH_SHARE = 0.92
+const SLATE_MAX_W = 720
+
+/**
+ * The slate's height as a share of its own width, and the share of the middle
+ * field it is allowed to fill.
+ *
+ * The leftover is the RUNWAY — the room the slate travels through under a finger.
+ * It does not need to be the whole throw: the slate is allowed to travel over the
+ * chute and into the hoard, and past the commit line it is gone anyway. So the
+ * runway is a margin, not a reservation, and the slate takes most of the field.
+ */
+const SLATE_ASPECT = 0.5
+const SLATE_FIELD_SHARE = 0.8
+
+/** The chute at the top: share of the playable column, and its bounds. */
+const CHUTE_SHARE = 0.18
+const CHUTE_MIN = 36
+const CHUTE_MAX = 140
+
+/** The hoard at the bottom: share of the playable column, and its bounds. */
+const HOARD_SHARE = 0.22
+const HOARD_MIN = 40
+const HOARD_MAX = 190
+
+/** The breathing room between the four stacked things. */
+const GAP_SHARE = 0.045
+const GAP_MIN = 8
+const GAP_MAX = 28
+
 export type Layout = {
   readonly w: number
   readonly h: number
   /** Where the dust meets the sky. Full bleed, deliberately. */
   readonly horizon: number
+  /**
+   * The first row the game owns: under the host's corner controls and hairline.
+   * Exported so a test asserts the pinning against the number the game used.
+   */
+  readonly ceiling: number
+  /** The last row the game owns: clear of the bottom inset and the gesture strip. */
+  readonly floor: number
   /** The slate, at rest. The statement lives here and it is the whole game. */
   readonly slate: Rect
   /** The three shots as one box: the only resource there is. */
@@ -46,20 +125,43 @@ export type Layout = {
   readonly pip: number
   readonly pipGap: number
   /**
-   * The chute, immediately ABOVE the slate: where a thrown-away claim goes.
-   *
-   * It is deliberately adjacent to the slate rather than at the top of the frame.
-   * The top of the frame is where the host paints its exit and how-to-play
-   * controls, and a discard target up there would either sit under one of them or
-   * force a reserved band — which costs a twelfth of a 568px phone and broke a
-   * sibling game's layout. Adjacency also reads better: the gesture is a flick
-   * across the thing being judged, so the two destinations belong beside it.
+   * THE CHUTE, pinned to the TOP of the playable column: where a claim you do
+   * not believe is thrown. It carries the `≠` mark, and that mark is the whole
+   * of the instructions.
    */
   readonly chute: Rect
-  /** The bag, below the shots: where a kept claim goes, and where the score is. */
+  /**
+   * THE HOARD, pinned to the BOTTOM: the keep pile, the coin count, and the
+   * score. It carries the `=` mark.
+   */
   readonly bag: Rect
-  /** Type size for the coin count on the bag. */
+  /** Type size for the coin count on the hoard. */
   readonly bagPx: number
+  /**
+   * ── THE FOUR BANDS THAT MAKE THE TWO DESTINATIONS READABLE ────────────────
+   *
+   * Each destination carries two things: the CHEVRONS that light under a
+   * committing finger, and the MARK that says which answer it is — `≠` above,
+   * `=` below.
+   *
+   * They are separate rectangles rather than two fractions inside one because
+   * the hoard is 190 px tall on an iPad and 40 px tall on a 568×320 phone with a
+   * portrait notch, and "put the mark in the middle of the chevrons" is legible
+   * at one of those and a smudge at the other. Computed here, asserted by
+   * `street.test.ts`, and read by `scene.ts` — no arithmetic in the drawing code.
+   */
+  readonly chuteFlow: Rect
+  readonly chuteMark: Rect
+  readonly hoardFlow: Rect
+  readonly hoardMark: Rect
+  /** Type size for the two destination marks. Fits the SMALLER of the two bands. */
+  readonly markPx: number
+  /** Where the lip of the pile is ruled, and where the coin count sits on it. */
+  readonly lipY: number
+  readonly countY: number
+  /** The top of the card stack, and one card's thickness. */
+  readonly pileY: number
+  readonly cardH: number
 }
 
 /** The insets `area` was cut from. Exact: `safeRect` is the only thing that cuts it. */
@@ -77,6 +179,8 @@ function insetsOf(w: number, h: number, area: Rect): {
   }
 }
 
+const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v))
+
 /**
  * The street, at `w` x `h`, with `area` as the region a child may be asked to
  * read.
@@ -92,74 +196,121 @@ export function layoutFor(w: number, h: number, area: Rect): Layout {
   // bottom of the glass, under the home indicator, and the sky the top.
   const horizon = h * 0.6
 
-  const slateW = Math.min(area.w * 0.88, 640)
-  const slateX = area.x + (area.w - slateW) / 2
-
-  const pip = Math.max(3.5, h * 0.0075)
-  const pipGap = pip * 3.4
-  const shotsW = pipGap * (SHOTS - 1) + pip * 2
-  /** From the bottom of the slate down to the centre of the pips. */
-  const shotsDrop = pip * 5
-
-  const bagPx = Math.round(Math.max(15, h * 0.03))
-
   // The host's chrome, rebuilt from `area` rather than measured again, so the game
   // and the host cannot end up disagreeing about where the buttons are.
   const insets = insetsOf(w, h, area)
   const exit = exitRect(insets)
   const help = helpRect(w, insets)
   const chromeBottom = Math.max(exit.y + exit.h, help.y + help.h)
-  const passesBetween =
-    slateX >= exit.x + exit.w + HOST_MARGIN && slateX + slateW <= help.x - HOST_MARGIN
-  const ceiling = (passesBetween ? area.y : chromeBottom + HOST_MARGIN) + HOST_PROGRESS_H
 
-  /**
-   * THE VERTICAL BUDGET, and why the slate's height is now capped by it.
-   *
-   * The slate is `slateW × 0.3`, and in landscape on a phone that is enormous relative
-   * to the height: at 568×320 with a portrait notch the safe area is 239 px tall and an
-   * uncapped slate wanted 150 of them. There was room for that when the only other
-   * things were three 7 px pips; there is not now that there is a chute above and a bag
-   * below, and a bag that had to ride up onto the shots to fit is a bag pointing at the
-   * wrong place.
-   *
-   * So the slate takes at most a third of the budget and everything else is measured
-   * from it. The three shares below sum to well under one, which is what makes the
-   * overflow correction below always resolvable — a clamp that cannot succeed is how a
-   * layout ends up outside the safe area on exactly one device shape.
-   */
-  const budget = Math.max(1, area.y + area.h - ceiling)
-  const slateH = Math.min(slateW * 0.3, budget * 0.34)
-  const gutterH = Math.max(10, slateH * 0.2)
-  const bagH = Math.max(bagPx * 1.6, slateH * 0.62)
-  /** Everything under the slate: the drop to the pips, the pips, and the bag. */
-  const below = shotsDrop + pip * 3 + bagH
+  /** The two ends of the column the game owns. Everything else is measured off them. */
+  const ceiling = Math.max(area.y + HOST_PROGRESS_H, chromeBottom + HOST_MARGIN)
+  const floor = Math.min(area.y + area.h, h - GESTURE_STRIP)
+  const field = Math.max(1, floor - ceiling)
 
-  // Centred four tenths down the safe area — high enough that a thumb is not over the
-  // statement it is about to judge. The chute has to fit above it, so the roof is the
-  // host's chrome plus one gutter.
-  const roof = ceiling + gutterH
-  let slateY = Math.max(roof, area.y + area.h * 0.4 - slateH / 2)
-  // ...and lifted back up if the bag would fall off the safe bottom. The roof still
-  // wins: a slate under the exit button is worse than a bag near the home indicator,
-  // and with the budget above it never comes to that.
-  const overflow = slateY + slateH + below - (area.y + area.h)
-  if (overflow > 0) slateY = Math.max(roof, slateY - overflow)
+  const gap = clamp(field * GAP_SHARE, GAP_MIN, GAP_MAX)
+  const bagPx = Math.round(Math.max(15, h * 0.03))
+  const pip = Math.max(3.5, h * 0.0075)
+  const pipGap = pip * 3.4
+  const shotsW = pipGap * (SHOTS - 1) + pip * 2
+
+  const chuteH = clamp(field * CHUTE_SHARE, CHUTE_MIN, CHUTE_MAX)
+  const bagH = clamp(field * HOARD_SHARE, Math.max(HOARD_MIN, bagPx * 2.2), HOARD_MAX)
+
+  // ── pinned to the bottom ──────────────────────────────────────────────────
+  const bagY = floor - bagH
+  const shotsCentre = bagY - gap - pip
+  const shotsY = shotsCentre - pip
+
+  // ── pinned to the top ─────────────────────────────────────────────────────
+  const chuteY = ceiling
+
+  // ── and the slate takes the middle ────────────────────────────────────────
+  const slateW = Math.min(area.w * SLATE_WIDTH_SHARE, SLATE_MAX_W)
+  const slateX = area.x + (area.w - slateW) / 2
+  const fieldTop = chuteY + chuteH + gap
+  const fieldBottom = shotsY - gap
+  const middle = Math.max(1, fieldBottom - fieldTop)
+  const slateH = Math.min(slateW * SLATE_ASPECT, middle * SLATE_FIELD_SHARE)
+  const slateY = fieldTop + (middle - slateH) / 2
 
   const cx = area.x + area.w / 2
-  const shotsY = slateY + slateH + shotsDrop
-  const bagW = Math.max(bagH, Math.min(slateW * 0.3, bagPx * 4))
+  const bagW = Math.max(bagH, Math.min(area.w * 0.62, bagPx * 7))
+  const bagX = cx - bagW / 2
+
+  // ── inside the two destinations ───────────────────────────────────────────
+  //
+  // The chevrons go on the side nearest the SLATE, because that is the way the
+  // card is travelling; the mark goes beyond them, at the far end, where nothing
+  // is drawn over it. On the hoard that leaves the lip, the count and the card
+  // stack below, in that order, each in its own band.
+  const chuteFlow = { x: slateX, y: chuteY + chuteH * 0.46, w: slateW, h: chuteH * 0.54 }
+  const chuteMark = { x: slateX, y: chuteY, w: slateW, h: chuteH * 0.42 }
+  const hoardFlow = { x: bagX, y: bagY, w: bagW, h: bagH * 0.2 }
+  const hoardMark = { x: bagX, y: bagY + bagH * 0.22, w: bagW, h: bagH * 0.2 }
 
   return {
     w,
     h,
     horizon,
+    ceiling,
+    floor,
     slate: { x: slateX, y: slateY, w: slateW, h: slateH },
-    shots: { x: cx - shotsW / 2, y: shotsY - pip, w: shotsW, h: pip * 2 },
+    shots: { x: cx - shotsW / 2, y: shotsY, w: shotsW, h: pip * 2 },
     pip,
     pipGap,
-    chute: { x: slateX, y: Math.max(area.y, slateY - gutterH), w: slateW, h: gutterH },
-    bag: { x: cx - bagW / 2, y: shotsY + pip * 3, w: bagW, h: bagH },
+    chute: { x: slateX, y: chuteY, w: slateW, h: chuteH },
+    bag: { x: bagX, y: bagY, w: bagW, h: bagH },
     bagPx,
+    chuteFlow,
+    chuteMark,
+    hoardFlow,
+    hoardMark,
+    // 1.2 rather than 1.0 because a mark is two rules and a slash — it occupies
+    // about three quarters of its nominal size, not all of it.
+    markPx: Math.round(clamp(Math.min(chuteMark.h, hoardMark.h) * 1.2, 11, 40)),
+    lipY: bagY + bagH * 0.46,
+    countY: bagY + bagH * 0.62,
+    pileY: bagY + bagH * 0.72,
+    cardH: Math.max(1.5, bagH * 0.022),
   }
+}
+
+/**
+ * The stacked things, top to bottom, as the test reads them.
+ *
+ * Exported because "nothing overlaps and no band is dead" is a claim about the
+ * ORDER as much as about the boxes, and a test that re-derived the order would be
+ * asserting its own opinion of it.
+ */
+export function columnOf(l: Layout): readonly (readonly [string, Rect])[] {
+  return [
+    ["the chute", l.chute],
+    ["the slate", l.slate],
+    ["the shots", l.shots],
+    ["the hoard", l.bag],
+  ]
+}
+
+/**
+ * How much of the playable column is used, and the largest single band of
+ * nothing left in it.
+ *
+ * This is the founder's complaint, as two numbers. Before the layout was pinned,
+ * a 320×568 phone with a notch showed `covered 0.39, deadest 0.39` — a third of
+ * the column occupied and a third of it dead in one continuous strip below the
+ * hoard.
+ */
+export function densityOf(l: Layout): { covered: number; deadest: number } {
+  const field = Math.max(1, l.floor - l.ceiling)
+  let covered = 0
+  let deadest = 0
+  let cursor = l.ceiling
+  for (const [, box] of columnOf(l)) {
+    deadest = Math.max(deadest, box.y - cursor)
+    covered += box.h
+    cursor = Math.max(cursor, box.y + box.h)
+  }
+  deadest = Math.max(deadest, l.floor - cursor)
+  return { covered: covered / field, deadest: deadest / field }
 }


### PR DESCRIPTION
The founder played THE TRUE DRAW and wrote this:

> improved from previous versions... but not juicy enough, success/fail isn't cool
> and juicy, sort of lame. The animations should be captivating and make you want to
> keep playing. Could have intuitive up == false, down == true instructions in the
> game .. subtle, premium. Too much blank space. the cache/keep score/pile could be
> locked to the bottom of the screen and the discard target to the top .. dragging
> can be juicy and awesome. Full screen usage, juicy animations needed. success and
> failure sounds need to be awesome and varied and so do the animations. decent math
> but not awesome enough to keep people playing.

Every line of that is a specific defect with a specific cause. This is all six.

## The blank space was a layout that never reached the bottom of the glass

The old street measured EVERYTHING downward from the slate — chute one gutter
above, shots one drop below, bag below those — and then stopped wherever it
happened to stop. On a 320×568 phone with a notch that left **163 px, 39% of the
playable column, dead in one continuous strip below the bag**, with only 39% of
the column covered. It looked like a widget floating in a dark room.

It is now laid out from **both ends inward**:

* `ceiling` — the first row the game owns, immediately under the host's two 44 px
  corner controls and its progress hairline. The **chute is pinned there**.
* `floor` — the last row the game owns, clear of the bottom inset **and** of
  `GESTURE_STRIP` (24 px; Android's gesture bar reports an inset of *zero* on many
  of the devices that have one, so the inset alone was never enough). The
  **hoard is pinned there**, shots directly above it.
* the slate takes the middle, and it is half again as big as it was.

Worst case across every viewport × inset pair in the matrix is now **60% covered
with no gap over a fifth of the column**. `street.test.ts` asserts both numbers at
320×568, 390×844, 768×1024, 1024×768 and both landscape phones, with real portrait
and landscape notch insets — and the pinning, the clearances and the four bands
inside the two destinations besides. `env()` is never read: it is zero inside a
sandboxed pack iframe, and the layout arithmetic lives in TypeScript where a test
can drive it, per `games/runner`'s chrome module.

## The feedback was a pool of one

Every correct call played the same stamp and the same two notes. The twentieth
looked exactly like the first, which is the fastest way there is to teach a child
that nothing they do matters.

`render/flourish.ts` now draws one of **four celebrations** (`ring`, `rays`,
`shower`, `bloom`) and one of **three miss reveals** (`settle`, `recut`, `drop`)
per verdict, from the run's seeded RNG, **never the same one twice running** — a
uniform draw from four repeats about a quarter of the time and a child reads "it
did the same thing again" as "it did not notice". `audio.ts` gained matching voice
pools. The picture and the sound are **one draw**, so they cannot drift apart
across a pause or a re-render and hand the child a bloom with a bank's chime under
it.

Every celebration fires on a **correct retrieval and on nothing else** — no
collision, no streak, no menu, no window opening. That is the whole reason it
reinforces anything, and `scene.test.ts` asserts a miss handed a celebration does
not draw one.

## The failure state showed the child nothing

The old rule was that a wrong verdict "adds no mark, no light and no colour". It
was written to avoid punishing a child and it succeeded — and it spent the single
most teachable second in the game showing them nothing at all.

A miss now **completes the sum in front of the child, in the accent, and holds it
there** for ~half a second so it can be read. `games/stack` is the fleet's
reference and this is the same behaviour in this game's material: never red (there
is no red in the palette to reach for), never the word WRONG, never an adjective
attached to the child. A `burn` — throwing away a claim that was true — *confirms*
the sum rather than correcting it, which is the honest thing to show.

`energy.ts` used to keep `energy(SLIP) < energy(SEAT)` by having nothing to weigh.
It now keeps it against real numbers in both timing branches:

```
energy(dud)  = 900 × 3 × 0.045 = 121.5      reduced: 121.5
energy(bank) = 500 × 3 × 0.20  = 300        reduced: 180
energy(spot) = 940 × 4 × 0.24  = 902.4      reduced: 499.2
```

Nothing buzzes on a miss and nothing ever will — `HAPTIC.dud` and `HAPTIC.burn`
stay `null`, and there is still **no sound at all for a lapse**, because a tone at
the end of a window a child was still thinking through is a buzzer aimed at
slowness. The miss beat is deliberately **not** shortened under reduced motion:
most of it is a completed sum standing still being read, and reading time is not
motion.

## The gesture was explained in six paragraphs behind a `?`

It is now taught by the game, in three ways and no sentences:

* the chute carries a stroked **`≠`** and the hoard a stroked **`=`**, permanently
  — up is false, down is true, in the notation the child is already reading on the
  slate and in no language at all. Not a tutorial that gets dismissed, so there is
  nothing to miss and nothing to recall. Stroked rather than typed so a 16 px glyph
  is not at the mercy of whatever serif the device substituted;
* a hollow ghost of the slate drifts to the `=`, fades, drifts to the `≠`, fades —
  but **only** for a child who has not yet landed a correct call **and** has
  hesitated past 900 ms, and it stops for good at the first correct call;
* it never escalates. Fixed strength, fixed period, no countdown wearing a costume.
  Speed is rewarded in this game and never enforced.

**It demonstrates the two MOVES and never the ANSWER.** `hintFor` is not handed the
statement, so it cannot play the round for the child and enter arithmetic they did
not do into the learner model.

## The drag was a linear map

`dy × 0.55` and a constant tilt, which reads as a slider. `render/drag.ts` now owns
the curve — **weight** at the start (a card has mass), **magnetism** into the
destination (the follow ratio climbs 0.55 → 0.97 as the finger nears the commit
line), a **rubber band** past it (a diagonal can travel a long way without
committing and the slate must not fly off the street while the child has said
nothing), a tilt and an echo trail. All pure, all driven to the pixel.

## Two rendering defects found by looking at the screen

Neither had a test and neither would have got one from any amount of unit testing
around them.

1. **The doubled statement.** `95 + 5 = 90` and `95 + 5 = 100` are different
   *widths* and so are centred at different origins. Fading out only the claimed
   value and drawing the corrected line over it drew the shared prefix **twice,
   both opaque, a few pixels apart** — a smear exactly where the child is supposed
   to read the answer. Invisible while both halves were the same chalk grey;
   unmissable the moment the truth was drawn in the accent. The whole line now
   dissolves and the corrected one is cut in after it.
2. **`Math.max(1, NaN)` is `NaN`.** A canvas whose bounding rect has not settled
   for one frame produced NaN coordinates, which `fillRect` silently ignores rather
   than throwing.

## Tests

339 passing, **run 5× consecutively, all 5 green**, plus `tsc --noEmit` and both
vite builds. Four new test files (`drag`, `flourish`, `hint`, `audio`) and
substantial additions to `street`, `scene` and `energy`.

**Every new assertion was mutation-tested** — the thing it protects was
deliberately broken, the failure confirmed and its message recorded, then restored.
Thirty-odd mutations; three survived the first pass and each one was a real gap
that is now closed:

* `VOICES` picking the *quietest* pool member instead of the loudest left the whole
  energy invariant passing while the game played something louder on two rounds in
  three;
* deleting `overtoneGain.gain.setValueAtTime(...)` left it at Web Audio's default
  of **1** — the fundamental's whole level again as a bare octave, on every strike,
  with no error and no warning. There is now a fake-context test that asserts no
  gain node is ever left unset;
* zeroing `MOVERS.dud`/`MOVERS.burn` made the energy invariant pass by
  *understating* the reaction rather than by holding it.

Verified on the running game as well as in tests: the pinned layout, the two marks,
the ghost, a celebration, and the miss reveal completing `715 + 620 = 1335` in the
accent under a brass rule.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
