### PR TITLE
dynawalla/soundscape: the app chooses a key, and the host's own cues finally pass the ceiling

### DIFF
--- a/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
+++ b/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
@@ -1,9 +1,17 @@
 # The Dynawalla soundscape
 
-**Status:** designed, and one game built against it. `packs/shared/game-soundscape/`
-exists, has 45 tests, and THE STEELYARD plays through it behind a gate that is off
-in production. Everything in *Where it lives* below stage 1 is proposed and needs
-a founder decision — the open questions are at the end.
+**Status:** live. `packs/shared/game-soundscape/` exists and has 45 tests; the host
+now chooses a soundscape and publishes it, so THE STEELYARD plays through it in
+production. Stage 2 (games talking back) and stage 3 (the host's ambient bed) are
+still proposed. The founder's answers to the open questions are recorded at the
+end.
+
+**What turning it on actually was.** Not a change to any pack: the pack side was
+finished and waiting. `dynawalla-app/src/app/soundscape.ts` chooses one key for
+the whole app and `packSettings` puts it on the wire, where `game-host`'s
+`publish()` was already forwarding it. THE STEELYARD's own ship gate — "nothing
+in the shipped pack turns the soundscape on" — still passes unchanged, because
+turning it on was the host's job and never the pack's.
 
 ---
 
@@ -260,8 +268,9 @@ wired end to end and its dev harness (`npm run dev`) publishes a soundscape, whi
 is where the idea can be heard: `?mode=maqam.rast&seed=7` to pin one,
 `?soundscape=off` for the A/B against what ships now.
 
-**Stage 2 — the host chooses, and games can talk back.** The host picks a
-soundscape at launch, rotates it on a slow schedule, and publishes it. Games get
+**Stage 2 — the host chooses (done), and games can talk back (not yet).** The
+host picks a soundscape at launch, rotates it on a slow schedule, and publishes
+it — that half is built, and the rotation policy is written down below. Games get
 to *affect* it with a `feedback.soundscape` method under the **existing `audio`
 capability** — `{ gesture: "moreTension" | "lessTension" | "levelComplete" }`, fire
 and forget, 2 s budget, not native. The host adjusts and re-publishes through
@@ -276,11 +285,13 @@ not send audio, it sends four numbers, and the same pure module turns them into
 the same pitches on both sides. That is the elegant part and it is why Option B
 is not a compromise.
 
-> **A defect stage 3 must fix on the way past.** `dynawalla-app/src/packs/services.ts`
-> `playCue()` connects straight to `context.destination`. The host's own cues are
-> **not** subject to any ceiling. Nothing has complained yet because they are five
-> short triangle tones, but the moment the host owns a continuous bed it needs
-> `createSafetyBus` too.
+> **A defect stage 3 must fix on the way past — fixed.** `dynawalla-app/src/packs/services.ts`
+> `playCue()` connected straight to `context.destination`, so the host's own cues
+> were **not** subject to any ceiling. Nothing had complained because they are five
+> short triangle tones, but a continuous bed on an unlimited path is the MOSAIC
+> incident with the roles swapped. The host now builds one `createSafetyBus` per
+> session and every cue passes it. `dynawalla-app/src/packs/cues.test.ts` renders
+> the graph and measures the peak rather than grepping for the line.
 
 ---
 
@@ -411,13 +422,37 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
 
 ## 7. Open questions for the founder
 
-1. **Is the bed the host's or the pack's?** (Stage 3.) Host = never a silent gap at
-   a doorway, one continuous piece of music, and the shell has music too. Pack =
-   simpler, already inside the ceiling, and dies at every doorway. Recommendation:
-   host, and give it its own switch.
-2. **How often does the soundscape rotate?** Per launch? Per game? On a slow timer?
-   Recommendation: per launch, plus on `levelComplete` at most once every few
-   minutes, so a child notices the key changed after they achieved something.
+1. **Is the bed the host's or the pack's?** (Stage 3.) **ANSWERED: the host owns
+   one bed.** Never a silent gap at a doorway, one continuous piece of music, and
+   the shell has music too. The ceiling hole that would have made it unsafe is
+   closed; building the bed itself is the next piece of work.
+2. **How often does the soundscape rotate?** **ANSWERED, and implemented in
+   `dynawalla-app/src/app/soundscape.ts`:**
+
+   * **A fresh key every launch.** The launch seed is drawn once per process, so
+     a child who plays for ninety seconds and closes the app still hears a
+     different mode tomorrow.
+   * **A new key every eight minutes after that** — long enough that a whole run
+     at one game sits inside one key, short enough that a long afternoon hears
+     five or six.
+   * **The clock is only read at a doorway.** The key is drawn when a pack is
+     mounted and pinned for the life of that mount. A change *underneath* a
+     child — mid-question, because a timer went off — would slide the drone
+     under the plate they are holding, and that is worse than repetition. So the
+     app changes key while a child is walking between games and never while they
+     are in one. A forty-minute session at a single pack stays in one key on
+     purpose; the walker is what keeps that from being the same ding twice.
+   * **Never the same mode twice running.** A uniform draw from 38 repeats about
+     one doorway in 38, and a repeat is exactly the "stale and repetitive" the
+     brief names. Re-drawing costs one comparison.
+   * **Always optional, two ways.** `sound` is total and unchanged — off is
+     silent, not quiet. A second switch, **Music**, chooses between the app's
+     generative key and the fixed cues a pack shipped with; off publishes
+     *nothing*, which is the path a host too old to know about soundscapes
+     already takes, and it means "keep your own sounds".
+
+   Still open: `levelComplete` moving the key, which needs the stage 2 feedback
+   channel.
 3. **Chord progressions.** The brief asks for "many chord progressions to choose
    from" and beatlounge has ~994 generated ones. This design deliberately has
    **none** — a moving progression means the melody's home note moves, and a
@@ -446,6 +481,9 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
 | The soundscape the app is in | `packs/shared/game-soundscape/host.ts` |
 | The wire field | `packs/sdk/src/protocol.ts` → `Settings.soundscape` |
 | Where it is published to a pack | `packs/shared/game-host/index.ts` → `publish()` |
+| Which key the app is in, and when it moves | `dynawalla-app/src/app/soundscape.ts` |
+| Where it is put on the wire | `dynawalla-app/src/packs/services.ts` → `packSettings()` |
+| The doorway that draws one | `dynawalla-app/src/packs/Stage.tsx` |
 | THE STEELYARD's whole musical vocabulary | `games/counterweight/src/tune.ts` |
 | The synthesis, and the rubble recipe | `games/counterweight/src/audio.ts` |
 | Where it is turned on, for now | `games/counterweight/src/main.ts` |

--- a/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
+++ b/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
@@ -435,13 +435,20 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
    * **A new key every eight minutes after that** — long enough that a whole run
      at one game sits inside one key, short enough that a long afternoon hears
      five or six.
-   * **The clock is only read at a doorway.** The key is drawn when a pack is
-     mounted and pinned for the life of that mount. A change *underneath* a
+   * **The key cannot move while a pack owns it.** A change *underneath* a
      child — mid-question, because a timer went off — would slide the drone
      under the plate they are holding, and that is worse than repetition. So the
      app changes key while a child is walking between games and never while they
      are in one. A forty-minute session at a single pack stays in one key on
      purpose; the walker is what keeps that from being the same ding twice.
+
+     This is an invariant of the module rather than a convention the caller
+     keeps. `packSettings` re-runs on every settings change — a parent moving
+     the text size slider — so "the host remembered to pin it" would be one
+     refactor away from a key that rotates under a playing child with nothing
+     failing. `soundscapeForPack(packId, now)` hands the same key back to the
+     pack that already has it, however often it asks; leaving the stage is what
+     lets the next doorway rotate.
    * **Never the same mode twice running.** A uniform draw from 38 repeats about
      one doorway in 38, and a repeat is exactly the "stale and repetitive" the
      brief names. Re-drawing costs one comparison.
@@ -483,7 +490,7 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
 | Where it is published to a pack | `packs/shared/game-host/index.ts` → `publish()` |
 | Which key the app is in, and when it moves | `dynawalla-app/src/app/soundscape.ts` |
 | Where it is put on the wire | `dynawalla-app/src/packs/services.ts` → `packSettings()` |
-| The doorway that draws one | `dynawalla-app/src/packs/Stage.tsx` |
+| The doorway that draws one, and gives it back | `dynawalla-app/src/packs/Stage.tsx` |
 | THE STEELYARD's whole musical vocabulary | `games/counterweight/src/tune.ts` |
 | The synthesis, and the rubble recipe | `games/counterweight/src/audio.ts` |
 | Where it is turned on, for now | `games/counterweight/src/main.ts` |

--- a/dynawalla/dynawalla-app/src/app/boundary.test.ts
+++ b/dynawalla/dynawalla-app/src/app/boundary.test.ts
@@ -89,6 +89,47 @@ const SDK_ENTRY = path.resolve(src, "../../packs/sdk/src/index.ts")
 const CURRICULUM_ENTRY = path.resolve(src, "../../packs/shared/curriculum/src/index.ts")
 
 /**
+ * The third and fourth: the two shared audio modules.
+ *
+ * Same test as the other two — is this a *contract both sides are built
+ * against*, or is it content? Both are contracts, and for the same structural
+ * reason the SDK is:
+ *
+ *   * `packs/shared/game-soundscape` is the mode corpus, the walker and the
+ *     four-number soundscape the wire carries. The host decides *which* mode
+ *     the app is in — a pack cannot, since its frame is opaque-origin and sees
+ *     nothing of the pack that was open a minute ago — and the pack turns the
+ *     same four numbers into the same pitches. A second copy of the corpus is a
+ *     host and a pack that disagree about what `maqam.rast` means, which is a
+ *     drone in one key over a melody in another and nothing that fails to
+ *     compile.
+ *   * `packs/shared/game-audio` is the output ceiling: a limiter, a
+ *     `WaveShaperNode` flat at −1 dBFS, and the mute gate after it. Every pack
+ *     passes it and `game-audio/routing.test.ts` fails any game that does not.
+ *     The host's own cues did not, which made the host the one audio source in
+ *     the product with nothing over it. A second copy of a hearing-safety
+ *     guarantee is not a guarantee.
+ *
+ * Neither contains a game, a screen, an asset or a problem. Neither touches the
+ * DOM, and the walk below measures that rather than trusting it.
+ */
+const SOUNDSCAPE_ENTRY = path.resolve(src, "../../packs/shared/game-soundscape/index.ts")
+const AUDIO_ENTRY = path.resolve(src, "../../packs/shared/game-audio/index.ts")
+
+/**
+ * Each exempted entry point, and the ONE host module allowed to name it.
+ *
+ * The door matters as much as the exemption. "What does the host use out of the
+ * curriculum" is answerable by reading one file, and the same has to be true of
+ * the other three or the exemption becomes a tunnel by a hundred small imports.
+ */
+const SHARED_DOORS: readonly { readonly entry: string; readonly door: string }[] = [
+  { entry: CURRICULUM_ENTRY, door: "packs/curriculum.ts" },
+  { entry: SOUNDSCAPE_ENTRY, door: "app/soundscape.ts" },
+  { entry: AUDIO_ENTRY, door: "packs/services.ts" },
+]
+
+/**
  * The only modules in the host that may know what an exercise is: the page that
  * names the curriculum, and the service built on it.
  *
@@ -145,11 +186,12 @@ test("the host imports no curriculum and no content of any kind", () => {
       // The contract, and only the contract. Every other path out of `src/` is
       // still an offence, including another file in the same SDK directory.
       if (resolved === SDK_ENTRY) continue
-      if (resolved === CURRICULUM_ENTRY) {
-        // `packs/curriculum.ts` is the single module that names it. Every other
-        // module in the host reaches the curriculum through that one page, so
-        // "what does the host use out of it" is a file you can read.
-        if (path.relative(src, file) === "packs/curriculum.ts") continue
+      const shared = SHARED_DOORS.find((allowed) => allowed.entry === resolved)
+      if (shared) {
+        // One module names each. Every other module in the host reaches these
+        // through that one page, so "what does the host use out of it" is a
+        // file you can read.
+        if (path.relative(src, file) === shared.door) continue
         offenders.push(`${path.relative(src, file)} -> ${specifier}`)
         continue
       }
@@ -229,6 +271,52 @@ test("the curriculum the host imports is arithmetic, and only arithmetic", () =>
 
   assert.deepEqual(escapes, [], "the curriculum reaches outside itself")
   assert.deepEqual(dom, [], "the curriculum touches the DOM")
+})
+
+test("the shared audio modules the host imports are arithmetic, and only arithmetic", () => {
+  // The same measurement as the curriculum's, applied to the two audio
+  // exemptions. `game-soundscape` must stay pure arithmetic — cents, a seeded
+  // walker, four numbers — and `game-audio` must stay the ceiling and nothing
+  // else. Either one growing a renderer, an asset loader, a `document` or an
+  // import out of its own package would put content back in the host through a
+  // door the offender scan waves past, with the whole suite still green.
+  //
+  // It also holds the entry points to being entry points: a `Melody` the host
+  // could reach would be the host synthesising notes, which is the exact split
+  // the design rejected — selection is global and slow, pitches are local and
+  // synchronous.
+  for (const entry of [SOUNDSCAPE_ENTRY, AUDIO_ENTRY]) {
+    assert.ok(fs.existsSync(entry), `the exempted module ${entry} does not exist`)
+
+    const pkg = path.dirname(entry)
+    const escapes: string[] = []
+    const dom: string[] = []
+    const seen = new Set<string>()
+
+    const walk = (file: string): void => {
+      if (seen.has(file)) return
+      seen.add(file)
+      if (/\b(document|window|localStorage|HTMLElement)\b/.test(code(file))) {
+        dom.push(path.relative(pkg, file))
+      }
+      for (const specifier of specifiers(file)) {
+        const target = specifier.startsWith(".")
+          ? path.resolve(path.dirname(file), specifier)
+          : null
+        if (target === null || path.relative(pkg, target).startsWith("..")) {
+          escapes.push(`${path.relative(pkg, file)} -> ${specifier}`)
+          continue
+        }
+        walk(target)
+      }
+    }
+    walk(entry)
+
+    assert.deepEqual(escapes, [], `${path.relative(src, entry)} reaches outside itself`)
+    assert.deepEqual(dom, [], `${path.relative(src, entry)} touches the DOM`)
+    // A walk that found one file would pass both assertions on nothing.
+    assert.ok(seen.size >= 5, `only ${seen.size} files walked from ${entry}`)
+  }
 })
 
 test("exactly one module in the host knows what an exercise is", () => {

--- a/dynawalla/dynawalla-app/src/app/boundary.test.ts
+++ b/dynawalla/dynawalla-app/src/app/boundary.test.ts
@@ -314,8 +314,10 @@ test("the shared audio modules the host imports are arithmetic, and only arithme
 
     assert.deepEqual(escapes, [], `${path.relative(src, entry)} reaches outside itself`)
     assert.deepEqual(dom, [], `${path.relative(src, entry)} touches the DOM`)
-    // A walk that found one file would pass both assertions on nothing.
-    assert.ok(seen.size >= 5, `only ${seen.size} files walked from ${entry}`)
+    // A walk that found only the entry point would pass both assertions on
+    // nothing. Deliberately loose: this is a non-vacuity floor, not a file
+    // count, and merging two modules must not turn a green refactor red.
+    assert.ok(seen.size >= 3, `only ${seen.size} files walked from ${entry}`)
   }
 })
 

--- a/dynawalla/dynawalla-app/src/app/soundscape.test.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.test.ts
@@ -1,0 +1,241 @@
+// The app's key, attacked.
+//
+// Two failures are being kept out, and they pull in opposite directions:
+//
+//   *the bazaar changes key at every doorway* — every pack, or every mount, or
+//   every settings push drawing its own soundscape. That is not a soundscape,
+//   it is twenty-eight ringtones, and it is the failure the whole design exists
+//   to prevent.
+//
+//   *the bazaar never changes key* — one mode for the life of the app, which is
+//   the founder's "we don't want it stale and repetitive" arriving by a
+//   different road.
+//
+// So nearly everything here is about *when* the key is allowed to move, and the
+// assertions are made against the value a pack would actually receive — through
+// `packSettings`, and then through the same validator the pack side runs — so a
+// key that is chosen correctly and then dropped on the way to the wire fails.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  ROTATION_MS,
+  epochSeed,
+  resetAppSoundscape,
+  soundscapeAtDoorway,
+  type Soundscape,
+} from "./soundscape.ts"
+import { packSettings, type SettingsInput } from "../packs/services.ts"
+import { DEFAULT_SETTINGS, type Settings as HostSettings } from "../settings/store.ts"
+import {
+  CALM,
+  MODE_IDS,
+  ROOT_MAX_HZ,
+  ROOT_MIN_HZ,
+  parseSoundscape,
+} from "../../../packs/shared/game-soundscape/index.ts"
+
+/** The doorway a pack is opened through, at a wall-clock instant. */
+function doorway(at: number): Soundscape {
+  return soundscapeAtDoorway(at)
+}
+
+/** What `Stage` hands `packSettings`, with everything but the settings pinned. */
+function input(settings: Partial<HostSettings>, soundscape: Soundscape): SettingsInput {
+  return {
+    settings: { ...DEFAULT_SETTINGS, ...settings },
+    theme: "light",
+    systemPrefersDark: false,
+    safeArea: { top: 0, right: 0, bottom: 0, left: 0 },
+    soundscape,
+  }
+}
+
+const T0 = 1_700_000_000_000
+
+test("the app publishes a key, and it is one the pack side accepts", () => {
+  resetAppSoundscape(4242)
+  const chosen = doorway(T0)
+  const wire = packSettings(input({}, chosen)).soundscape
+
+  // Not merely present: run it through the *pack's* validator, which is what
+  // actually decides whether a game hears music or falls back. A rootHz outside
+  // the band, an unknown mode id or a non-finite seed all parse to `null`, and
+  // the pack would go quiet-ish with nothing in any log to say why.
+  const parsed = parseSoundscape(wire)
+  assert.notEqual(parsed, null, "the host published something the pack refuses")
+  assert.deepEqual(parsed, chosen, "what the pack parsed is not what the app chose")
+
+  assert.ok(MODE_IDS.includes(chosen.modeId), `${chosen.modeId} is not in the corpus`)
+  // The root band is what puts the ceiling on the music: the melody's brightest
+  // register is root x 8, so a root outside this is an abrasive top end.
+  assert.ok(
+    chosen.rootHz >= ROOT_MIN_HZ / 2 && chosen.rootHz <= ROOT_MAX_HZ * 2,
+    `root ${chosen.rootHz} Hz is outside the band the pack will accept`,
+  )
+})
+
+test("it starts chill, because that is what was asked for", () => {
+  resetAppSoundscape(11)
+  assert.equal(doorway(T0).tension, CALM)
+})
+
+test("two doorways inside the window are the same key — the bazaar does not change at a door", () => {
+  resetAppSoundscape(7)
+  const first = doorway(T0)
+  // A child leaves THE STEELYARD and opens THE LATTICE a minute later. Two
+  // different packs, two different mounts of `Stage`, one key.
+  const second = doorway(T0 + 60_000)
+  const third = doorway(T0 + ROTATION_MS - 1)
+  assert.deepEqual(second, first, "the second pack opened in a different key")
+  assert.deepEqual(third, first, "the key moved before the window was up")
+
+  // And the thing a pack is actually handed is the same object of numbers, so
+  // the drone does not retune on the way through the wire either.
+  assert.deepEqual(
+    packSettings(input({}, third)).soundscape,
+    packSettings(input({}, first)).soundscape,
+  )
+})
+
+test("mounting the same pack twice does not change the key", () => {
+  // React's `useState` initialiser is invoked twice under StrictMode, and a
+  // remount after a failed entry fetch is a second real doorway. Neither may
+  // move the app.
+  resetAppSoundscape(99)
+  const once = doorway(T0)
+  assert.deepEqual(doorway(T0), once)
+  assert.deepEqual(doorway(T0), once)
+})
+
+test("a settings change mid-pack cannot change the key", () => {
+  // The bug this is the guard for: `packSettings` runs again on every settings
+  // push — a parent moving the text size while a child plays — and if it drew
+  // its own soundscape the game would change key mid-question, under the child,
+  // with the drone sliding under the plate they are holding.
+  //
+  // Measured rather than reasoned about: the clock is taken away. Anything in
+  // this path that reads one throws, and the assertion below is what catches it.
+  resetAppSoundscape(5)
+  const pinned = doorway(T0)
+  const real = Date.now
+  Date.now = () => {
+    throw new Error("packSettings read the wall clock")
+  }
+  try {
+    const a = packSettings(input({ textSize: "normal" }, pinned)).soundscape
+    const b = packSettings(input({ textSize: "largest" }, pinned)).soundscape
+    assert.deepEqual(a, pinned)
+    assert.deepEqual(b, pinned)
+  } finally {
+    Date.now = real
+  }
+})
+
+test("a doorway after the window is a new key, and never the same mode twice running", () => {
+  resetAppSoundscape(123)
+  const heard: Soundscape[] = []
+  let at = T0
+  for (let i = 0; i < 200; i++) {
+    heard.push(doorway(at))
+    at += ROTATION_MS
+  }
+  assert.equal(heard.length, 200)
+  for (let i = 1; i < heard.length; i++) {
+    const before = heard[i - 1]
+    const now = heard[i]
+    assert.ok(before && now)
+    assert.notEqual(
+      now.modeId,
+      before.modeId,
+      `rotation ${i} repeated ${before.modeId} — a repeat is exactly the "stale and repetitive"`,
+    )
+  }
+})
+
+test("the variety is real: many modes, and every family the corpus has", () => {
+  resetAppSoundscape(31337)
+  const modes = new Set<string>()
+  const roots = new Set<number>()
+  let at = T0
+  for (let i = 0; i < 200; i++) {
+    const scape = doorway(at)
+    modes.add(scape.modeId)
+    roots.add(Math.round(scape.rootHz * 100))
+    at += ROTATION_MS
+  }
+  // 38 modes, 200 draws with no immediate repeats. Anything much under this is
+  // a mixing function handing back a handful of keys forever.
+  assert.ok(modes.size >= 30, `only ${modes.size} distinct modes in 200 rotations`)
+  assert.ok(roots.size >= 20, `only ${roots.size} distinct roots in 200 rotations`)
+  const families = new Set([...modes].map((id) => id.split(".")[0]))
+  assert.deepEqual(
+    [...families].sort(),
+    ["maqam", "thaat", "western"],
+    "a whole family of the corpus is unreachable",
+  )
+})
+
+test("every launch starts somewhere else", () => {
+  // The least-engaged child plays for ninety seconds and closes the app. If the
+  // key were a function of the epoch alone, that child would hear one mode for
+  // the life of the tablet.
+  const first: Soundscape[] = []
+  for (let seed = 0; seed < 40; seed++) {
+    resetAppSoundscape(seed)
+    first.push(doorway(T0))
+  }
+  const distinct = new Set(first.map((s) => `${s.modeId}@${Math.round(s.rootHz * 100)}`))
+  assert.ok(distinct.size >= 30, `40 launches produced only ${distinct.size} distinct keys`)
+
+  // And the mixing is the reason, not luck: the seed a launch derives for its
+  // first key must depend on the launch.
+  assert.notEqual(epochSeed(1, 0), epochSeed(2, 0))
+  assert.notEqual(epochSeed(1, 0), epochSeed(1, 1), "two epochs of one launch share a seed")
+  assert.notEqual(epochSeed(1, 0, 0), epochSeed(1, 0, 1), "a re-draw would draw the same key")
+})
+
+test("a clock that jumps backwards rotates once and then settles", () => {
+  // A device whose time was corrected, or a WebView restored from a snapshot.
+  // The failure to avoid is pinning the app in one key until the wall clock
+  // catches up, which for a year-wrong clock is forever.
+  resetAppSoundscape(64)
+  const before = doorway(T0)
+  const after = doorway(T0 - 90 * 24 * 60 * 60 * 1000)
+  assert.notDeepEqual(after, before, "a backwards clock froze the key")
+  assert.deepEqual(
+    doorway(T0 - 90 * 24 * 60 * 60 * 1000 + 1000),
+    after,
+    "the key kept moving after the clock settled",
+  )
+})
+
+test("music off keeps a pack's own sounds — it does not silence the pack", () => {
+  resetAppSoundscape(8)
+  const chosen = doorway(T0)
+  const off = packSettings(input({ music: false }, chosen))
+
+  // Absent, not `undefined`-valued: absent is what a host too old to know about
+  // soundscapes sends, and the pack side already reads that as "keep your own
+  // sounds". A new spelling of "off" would be a second code path.
+  assert.equal("soundscape" in off, false, "music off still put a key on the wire")
+  assert.equal(parseSoundscape(off.soundscape), null)
+
+  // The part that makes it "keep your own sounds" rather than "go quiet": the
+  // pack is still allowed to make noise, and its own fixed cues are what it
+  // falls back to.
+  assert.equal(off.sound, true, "turning music off silenced the pack")
+
+  // And it is reversible without a remount — the same channel re-fires.
+  const on = packSettings(input({ music: true }, chosen))
+  assert.deepEqual(parseSoundscape(on.soundscape), chosen)
+})
+
+test("sound off publishes no key at all", () => {
+  resetAppSoundscape(9)
+  const chosen = doorway(T0)
+  const settings = packSettings(input({ sound: false }, chosen))
+  assert.equal(settings.sound, false)
+  assert.equal("soundscape" in settings, false, "a silent tablet was still told a key")
+})

--- a/dynawalla/dynawalla-app/src/app/soundscape.test.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.test.ts
@@ -155,6 +155,29 @@ test("the key CANNOT move under a child, whatever the clock says", () => {
   )
 })
 
+test("replaying one game is still a doorway, once you have left it", () => {
+  // The other side of the ownership guard, and the failure it would otherwise
+  // be: a child who plays THE STEELYARD, leaves, and opens it again is at a
+  // doorway like any other. If leaving did not give the key back, the pack id
+  // would still match on the way in and that child would hear one mode for the
+  // rest of the day — the guard turned into a freeze.
+  resetAppSoundscape(21)
+  const STEELYARD = "dw.counterweight"
+  const first = soundscapeForPack(STEELYARD, T0)
+  claimSoundscape(STEELYARD)
+  assert.deepEqual(
+    soundscapeForPack(STEELYARD, T0 + 2 * ROTATION_MS),
+    first,
+    "the key moved while the game was still open",
+  )
+  releaseSoundscape(STEELYARD)
+  assert.notDeepEqual(
+    soundscapeForPack(STEELYARD, T0 + 2 * ROTATION_MS),
+    first,
+    "a child replaying one game heard the same key forever",
+  )
+})
+
 test("packSettings is a pure function of what it is handed — it reads no clock", () => {
   // The other half of the same guarantee, and the cheapest way to measure it:
   // take the clock away. Anything on this path that reads one throws.

--- a/dynawalla/dynawalla-app/src/app/soundscape.test.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.test.ts
@@ -21,9 +21,11 @@ import assert from "node:assert/strict"
 
 import {
   ROTATION_MS,
+  claimSoundscape,
   epochSeed,
+  releaseSoundscape,
   resetAppSoundscape,
-  soundscapeAtDoorway,
+  soundscapeForPack,
   type Soundscape,
 } from "./soundscape.ts"
 import { packSettings, type SettingsInput } from "../packs/services.ts"
@@ -36,9 +38,17 @@ import {
   parseSoundscape,
 } from "../../../packs/shared/game-soundscape/index.ts"
 
-/** The doorway a pack is opened through, at a wall-clock instant. */
-function doorway(at: number): Soundscape {
-  return soundscapeAtDoorway(at)
+/** A doorway: one named pack, mounted at a wall-clock instant. */
+function doorway(at: number, packId = "dw.a"): Soundscape {
+  return soundscapeForPack(packId, at)
+}
+
+/** A pack mounted and then left again, which is what lets the next one rotate. */
+function visit(at: number, packId: string): Soundscape {
+  const scape = soundscapeForPack(packId, at)
+  claimSoundscape(packId)
+  releaseSoundscape(packId)
+  return scape
 }
 
 /** What `Stage` hands `packSettings`, with everything but the settings pinned. */
@@ -83,11 +93,11 @@ test("it starts chill, because that is what was asked for", () => {
 
 test("two doorways inside the window are the same key — the bazaar does not change at a door", () => {
   resetAppSoundscape(7)
-  const first = doorway(T0)
+  const first = visit(T0, "dw.steelyard")
   // A child leaves THE STEELYARD and opens THE LATTICE a minute later. Two
   // different packs, two different mounts of `Stage`, one key.
-  const second = doorway(T0 + 60_000)
-  const third = doorway(T0 + ROTATION_MS - 1)
+  const second = visit(T0 + 60_000, "dw.lattice")
+  const third = visit(T0 + ROTATION_MS - 1, "dw.colossus")
   assert.deepEqual(second, first, "the second pack opened in a different key")
   assert.deepEqual(third, first, "the key moved before the window was up")
 
@@ -104,19 +114,50 @@ test("mounting the same pack twice does not change the key", () => {
   // remount after a failed entry fetch is a second real doorway. Neither may
   // move the app.
   resetAppSoundscape(99)
-  const once = doorway(T0)
-  assert.deepEqual(doorway(T0), once)
-  assert.deepEqual(doorway(T0), once)
+  const once = doorway(T0, "dw.steelyard")
+  assert.deepEqual(doorway(T0, "dw.steelyard"), once)
+  assert.deepEqual(doorway(T0, "dw.steelyard"), once)
 })
 
-test("a settings change mid-pack cannot change the key", () => {
-  // The bug this is the guard for: `packSettings` runs again on every settings
-  // push — a parent moving the text size while a child plays — and if it drew
-  // its own soundscape the game would change key mid-question, under the child,
-  // with the drone sliding under the plate they are holding.
+test("the key CANNOT move under a child, whatever the clock says", () => {
+  // The failure this is the guard for, and the reason the guard is in the module
+  // rather than in `Stage`: `packSettings` re-runs on every settings push — a
+  // parent moving the text size slider while a child plays — and the host used
+  // to be protected only by having remembered to pin the value in `useState`.
+  // A refactor that inlined the draw back into the memo would rotate the key
+  // mid-question, under a playing child, with the drone sliding under the plate
+  // they are holding, and no test in this repository renders `Stage` to notice.
   //
-  // Measured rather than reasoned about: the clock is taken away. Anything in
-  // this path that reads one throws, and the assertion below is what catches it.
+  // So the invariant belongs to `soundscapeForPack`: the pack that owns the key
+  // gets it back, however many times it asks and however long it has been.
+  resetAppSoundscape(5)
+  const STEELYARD = "dw.counterweight"
+  const opened = soundscapeForPack(STEELYARD, T0)
+  claimSoundscape(STEELYARD)
+
+  // Ten rotation windows of play, and a settings push at each one asking again.
+  for (let window = 1; window <= 10; window++) {
+    const asked = soundscapeForPack(STEELYARD, T0 + window * ROTATION_MS)
+    assert.deepEqual(asked, opened, `the key rotated ${window} windows into a session`)
+    assert.deepEqual(
+      packSettings(input({ textSize: window % 2 ? "largest" : "normal" }, asked)).soundscape,
+      opened,
+      "the pack was handed a different key mid-session",
+    )
+  }
+
+  // Leaving is what lets it move. Without this the guard would be a freeze.
+  releaseSoundscape(STEELYARD)
+  assert.notDeepEqual(
+    soundscapeForPack("dw.lattice", T0 + 11 * ROTATION_MS),
+    opened,
+    "the key never moved again after one pack had held it",
+  )
+})
+
+test("packSettings is a pure function of what it is handed — it reads no clock", () => {
+  // The other half of the same guarantee, and the cheapest way to measure it:
+  // take the clock away. Anything on this path that reads one throws.
   resetAppSoundscape(5)
   const pinned = doorway(T0)
   const real = Date.now
@@ -124,13 +165,20 @@ test("a settings change mid-pack cannot change the key", () => {
     throw new Error("packSettings read the wall clock")
   }
   try {
-    const a = packSettings(input({ textSize: "normal" }, pinned)).soundscape
-    const b = packSettings(input({ textSize: "largest" }, pinned)).soundscape
-    assert.deepEqual(a, pinned)
-    assert.deepEqual(b, pinned)
+    assert.deepEqual(packSettings(input({ textSize: "normal" }, pinned)).soundscape, pinned)
+    assert.deepEqual(packSettings(input({ textSize: "largest" }, pinned)).soundscape, pinned)
   } finally {
     Date.now = real
   }
+})
+
+test("a clock that is not a number does not move the key", () => {
+  // A guard that pinned `since` at zero would read as protection and would in
+  // fact rotate the key at every doorway from then on, forever.
+  resetAppSoundscape(77)
+  const first = visit(T0, "dw.a")
+  assert.deepEqual(visit(Number.NaN, "dw.b"), first, "a NaN clock rotated the key")
+  assert.deepEqual(visit(T0 + 1000, "dw.c"), first, "a NaN clock poisoned the window")
 })
 
 test("a doorway after the window is a new key, and never the same mode twice running", () => {
@@ -138,7 +186,7 @@ test("a doorway after the window is a new key, and never the same mode twice run
   const heard: Soundscape[] = []
   let at = T0
   for (let i = 0; i < 200; i++) {
-    heard.push(doorway(at))
+    heard.push(visit(at, `dw.${i}`))
     at += ROTATION_MS
   }
   assert.equal(heard.length, 200)
@@ -160,7 +208,7 @@ test("the variety is real: many modes, and every family the corpus has", () => {
   const roots = new Set<number>()
   let at = T0
   for (let i = 0; i < 200; i++) {
-    const scape = doorway(at)
+    const scape = visit(at, `dw.${i}`)
     modes.add(scape.modeId)
     roots.add(Math.round(scape.rootHz * 100))
     at += ROTATION_MS
@@ -201,14 +249,11 @@ test("a clock that jumps backwards rotates once and then settles", () => {
   // The failure to avoid is pinning the app in one key until the wall clock
   // catches up, which for a year-wrong clock is forever.
   resetAppSoundscape(64)
-  const before = doorway(T0)
-  const after = doorway(T0 - 90 * 24 * 60 * 60 * 1000)
+  const back = T0 - 90 * 24 * 60 * 60 * 1000
+  const before = visit(T0, "dw.a")
+  const after = visit(back, "dw.b")
   assert.notDeepEqual(after, before, "a backwards clock froze the key")
-  assert.deepEqual(
-    doorway(T0 - 90 * 24 * 60 * 60 * 1000 + 1000),
-    after,
-    "the key kept moving after the clock settled",
-  )
+  assert.deepEqual(visit(back + 1000, "dw.c"), after, "the key kept moving after the clock settled")
 })
 
 test("music off keeps a pack's own sounds — it does not silence the pack", () => {

--- a/dynawalla/dynawalla-app/src/app/soundscape.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.ts
@@ -1,0 +1,181 @@
+// The key the whole bazaar is in.
+//
+// `packs/shared/game-soundscape` knows what a mode is, what a root is and how a
+// `+1` becomes a note. It does not know *which* mode the app is in right now,
+// and it deliberately cannot: a pack frame is opaque-origin, its storage is not
+// the app's, and it can see nothing of the pack a child was in a minute ago. So
+// if each pack chose its own key the bazaar would change key at every doorway —
+// which is not a soundscape, it is twenty-eight ringtones. This module is the
+// other end of that: **one key at a time, for the whole app**, handed to
+// whichever pack is open on the `settings` channel that already carries `sound`
+// and `safeArea`.
+//
+// ── The rotation policy, and why it is this one ──────────────────────────────
+//
+// Three things the founder asked for at once — "we don't want it stale and
+// repetitive", "not too loud", "chill (usually)" — and one from the design:
+// a soundscape is *"a slow-moving fact about the app"*. They pull against each
+// other, and the resolution is a clock plus a rule about when the clock is
+// allowed to be read.
+//
+//   1. **A fresh key every launch.** `launchSeed` is drawn once per process.
+//      Opening the app tomorrow is a different mode on a different root even if
+//      yesterday's sitting lasted ninety seconds, so the least-engaged child
+//      still gets variety.
+//   2. **A new key every `ROTATION_MS` after that.** Eight minutes. Long enough
+//      that a whole run at one game sits inside one key; short enough that a
+//      long afternoon hears five or six of them.
+//   3. **The clock is only read at a doorway.** `soundscapeAtDoorway` is called
+//      when a pack is mounted and nowhere else. A key change *underneath* a
+//      child — mid-question, because a timer went off — is the jarring thing,
+//      and it is worse than repetition: the drone would slide and the plate a
+//      child is holding would answer in a different mode than it did a second
+//      ago. So the app changes key while a child is walking between games, and
+//      never while they are in one. A forty-minute session at a single pack
+//      therefore stays in one key on purpose; the walker is what keeps that
+//      from being the same ding twice, and stage 2's `levelComplete` feedback
+//      is the designed place for a mid-session change.
+//   4. **Never the same mode twice running.** A uniform draw from 38 modes
+//      repeats about one doorway in 38, and a repeat is exactly the "stale and
+//      repetitive" the brief names. Re-drawing costs one comparison.
+//
+// Everything here is derived from two integers — the launch seed and an epoch
+// counter — so a session is replayable: `resetAppSoundscape(7)` gives the same
+// sequence of keys on every device, forever, which is what makes "hijaz sounded
+// wrong on the thousands plate" a bug report rather than a memory.
+//
+// ── What is deliberately NOT here ───────────────────────────────────────────
+//
+// No synthesis, no ambient bed, no `AudioContext`. The host owning a continuous
+// bed is the next piece of work (stage 3 of the design), and it needs the
+// ceiling fix in `packs/services.ts` that lands beside this. What travels to a
+// pack is four numbers, and both ends turn the same four numbers into the same
+// pitches with the same pure module. That is the whole trick.
+
+import {
+  CALM,
+  pickSoundscape,
+  type Soundscape,
+} from "../../../packs/shared/game-soundscape/index.ts"
+
+/**
+ * The one type the rest of the host needs from the shared corpus.
+ *
+ * Re-exported here so that `app/soundscape.ts` is the single door onto
+ * `packs/shared/game-soundscape` — `boundary.test.ts` holds it to exactly that,
+ * the same way `packs/curriculum.ts` is the single door onto the curriculum.
+ */
+export type { Soundscape }
+
+/**
+ * How long one key lasts before the app is willing to draw another.
+ *
+ * Eight minutes, and it is a *minimum*, not a schedule: the change only lands
+ * at the next doorway, so the real interval is "at least this long, and then
+ * whenever the child next walks between games".
+ */
+export const ROTATION_MS = 8 * 60 * 1000
+
+/**
+ * How many times a draw may be rejected for repeating the previous mode.
+ *
+ * Bounded rather than a `while`: `pickSoundscape` is deterministic, so a corpus
+ * that ever shrank to one mode would otherwise be an infinite loop in the
+ * launch path. Eight attempts against 38 modes fails with probability under
+ * 1e-12, and the fallback is a repeat rather than a hang.
+ */
+const MAX_REDRAWS = 8
+
+/** What the app is currently in, and since when. `null` before the first doorway. */
+type Held = {
+  readonly scape: Soundscape
+  /** The wall clock at the doorway that drew it. */
+  readonly since: number
+  /** How many keys this launch has been through. Purely so the draw is replayable. */
+  readonly epoch: number
+}
+
+let launchSeed = drawLaunchSeed()
+let held: Held | null = null
+
+/**
+ * A seed for one key, from the launch seed, the epoch and the re-draw attempt.
+ *
+ * Exported because it is the part worth asserting: two adjacent epochs must not
+ * give correlated soundscapes, and two launches must not give the same
+ * sequence. Both are properties of this function and of nothing else.
+ *
+ * The constants are the usual mixing primes — 2^32/phi and one of murmur3's —
+ * and the `+ 1` on each term is what stops epoch 0 attempt 0 from mixing in
+ * zero and handing the launch seed straight through.
+ */
+export function epochSeed(launch: number, epoch: number, attempt = 0): number {
+  const mixed = (launch ^ Math.imul(epoch + 1, 0x9e3779b1)) >>> 0
+  return (mixed ^ Math.imul(attempt + 1, 0x85ebca6b)) >>> 0
+}
+
+/**
+ * A launch seed.
+ *
+ * `crypto` where there is one, because `Math.random()` in a WebView that has
+ * just been restored from a snapshot has been observed to hand out the same
+ * first value — which would be an app that opens in the same key every morning.
+ */
+function drawLaunchSeed(): number {
+  const source = globalThis.crypto
+  if (source && typeof source.getRandomValues === "function") {
+    return (source.getRandomValues(new Uint32Array(1))[0] ?? 0) >>> 0
+  }
+  return Math.floor(Math.random() * 0x1_0000_0000) >>> 0
+}
+
+/** One key, avoiding the mode the app is already in. */
+function draw(epoch: number, avoid: string | null): Soundscape {
+  for (let attempt = 0; attempt < MAX_REDRAWS; attempt++) {
+    const scape = pickSoundscape(epochSeed(launchSeed, epoch, attempt), CALM)
+    if (scape.modeId !== avoid) return scape
+  }
+  return pickSoundscape(epochSeed(launchSeed, epoch, MAX_REDRAWS), CALM)
+}
+
+/**
+ * The key to play a pack in, asked for at the moment the pack is mounted.
+ *
+ * This is the ONLY function in the host that reads a clock about music, and the
+ * only one that can change the app's key. Call it at a doorway; pin what it
+ * returns for the life of the mount, so that a parent changing the text size
+ * mid-game re-publishes the *same* four numbers rather than a new key.
+ *
+ * Idempotent inside the rotation window, which is not only for React's
+ * double-invoked initialisers: two packs opened a minute apart must be the same
+ * key, or the bazaar changes key at every doorway again with a slower rhythm.
+ *
+ * A clock that has gone backwards — a device whose time was corrected, or a
+ * WebView restored from a snapshot — rotates once and then settles, rather than
+ * pinning the app in one key until the wall clock catches up.
+ */
+export function soundscapeAtDoorway(now: number): Soundscape {
+  const at = Number.isFinite(now) ? now : 0
+  const previous = held
+  if (previous !== null) {
+    const elapsed = at - previous.since
+    if (elapsed >= 0 && elapsed < ROTATION_MS) return previous.scape
+  }
+  const epoch = previous === null ? 0 : previous.epoch + 1
+  const scape = draw(epoch, previous?.scape.modeId ?? null)
+  held = { scape, since: at, epoch }
+  return scape
+}
+
+/**
+ * Forget the current key and start a new launch.
+ *
+ * For tests, and for the same reason `resetHostSoundscape` exists on the pack
+ * side: module state that survives between test files is how a suite starts
+ * passing for the wrong reason. Passing a seed makes the whole sequence of keys
+ * deterministic.
+ */
+export function resetAppSoundscape(seed?: number): void {
+  launchSeed = typeof seed === "number" && Number.isFinite(seed) ? seed >>> 0 : drawLaunchSeed()
+  held = null
+}

--- a/dynawalla/dynawalla-app/src/app/soundscape.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.ts
@@ -25,8 +25,7 @@
 //   2. **A new key every `ROTATION_MS` after that.** Eight minutes. Long enough
 //      that a whole run at one game sits inside one key; short enough that a
 //      long afternoon hears five or six of them.
-//   3. **The clock is only read at a doorway.** `soundscapeAtDoorway` is called
-//      when a pack is mounted and nowhere else. A key change *underneath* a
+//   3. **The key cannot move while a pack owns it.** A key change *underneath* a
 //      child — mid-question, because a timer went off — is the jarring thing,
 //      and it is worse than repetition: the drone would slide and the plate a
 //      child is holding would answer in a different mode than it did a second
@@ -35,6 +34,16 @@
 //      therefore stays in one key on purpose; the walker is what keeps that
 //      from being the same ding twice, and stage 2's `levelComplete` feedback
 //      is the designed place for a mid-session change.
+//
+//      This is an invariant of THIS module and not a convention the caller has
+//      to keep, which matters: `packSettings` re-runs on every settings change
+//      — a parent moving the text size slider — so "the host remembered to pin
+//      it in `useState`" is one refactor away from a key that rotates under a
+//      playing child, and nothing would fail. `soundscapeForPack` takes the id
+//      of the pack asking and hands the *same* key back to the pack that
+//      already has it, whatever the clock says and however often it is called.
+//      Rotation is what happens when a DIFFERENT pack asks, or when the one
+//      that owned it has left.
 //   4. **Never the same mode twice running.** A uniform draw from 38 modes
 //      repeats about one doorway in 38, and a repeat is exactly the "stale and
 //      repetitive" the brief names. Re-drawing costs one comparison.
@@ -99,6 +108,16 @@ let launchSeed = drawLaunchSeed()
 let held: Held | null = null
 
 /**
+ * The pack that currently owns the key, or `null` when nothing is on the stage.
+ *
+ * The whole of the "it does not move under a child" guarantee. A pack id rather
+ * than a boolean because the two moments overlap: React renders the incoming
+ * pack before it runs the outgoing one's cleanup, so a counter would still be
+ * held by the pack being torn down and the doorway would never rotate.
+ */
+let owner: string | null = null
+
+/**
  * A seed for one key, from the launch seed, the epoch and the re-draw attempt.
  *
  * Exported because it is the part worth asserting: two adjacent epochs must not
@@ -139,32 +158,57 @@ function draw(epoch: number, avoid: string | null): Soundscape {
 }
 
 /**
- * The key to play a pack in, asked for at the moment the pack is mounted.
+ * The key to play a pack in.
  *
- * This is the ONLY function in the host that reads a clock about music, and the
- * only one that can change the app's key. Call it at a doorway; pin what it
- * returns for the life of the mount, so that a parent changing the text size
- * mid-game re-publishes the *same* four numbers rather than a new key.
+ * The ONLY function in the host that reads a clock about music, and the only
+ * one that can change the app's key. Two rules, and between them they are the
+ * whole policy:
  *
- * Idempotent inside the rotation window, which is not only for React's
- * double-invoked initialisers: two packs opened a minute apart must be the same
- * key, or the bazaar changes key at every doorway again with a slower rhythm.
+ *   * **The pack that owns the key gets it back.** Ask again — from a settings
+ *     push, from a re-render, from React's double-invoked initialiser — and the
+ *     answer is the same four numbers, ten rotation windows later or not.
+ *   * **Anyone else rotates it if it is due.** Two packs opened a minute apart
+ *     are the same key, or the bazaar changes key at every doorway again with a
+ *     slower rhythm; two opened nine minutes apart are not.
  *
  * A clock that has gone backwards — a device whose time was corrected, or a
  * WebView restored from a snapshot — rotates once and then settles, rather than
- * pinning the app in one key until the wall clock catches up.
+ * pinning the app in one key until the wall clock catches up. A clock that is
+ * not a number at all does not move the key, because a guard that pinned
+ * `since` at zero would rotate at every doorway forever afterwards.
  */
-export function soundscapeAtDoorway(now: number): Soundscape {
-  const at = Number.isFinite(now) ? now : 0
+export function soundscapeForPack(packId: string, now: number): Soundscape {
   const previous = held
+  if (previous !== null && owner === packId) return previous.scape
+  const at = Number.isFinite(now) ? now : (previous?.since ?? 0)
   if (previous !== null) {
     const elapsed = at - previous.since
-    if (elapsed >= 0 && elapsed < ROTATION_MS) return previous.scape
+    if (elapsed >= 0 && elapsed < ROTATION_MS) {
+      owner = packId
+      return previous.scape
+    }
   }
   const epoch = previous === null ? 0 : previous.epoch + 1
   const scape = draw(epoch, previous?.scape.modeId ?? null)
   held = { scape, since: at, epoch }
+  owner = packId
   return scape
+}
+
+/**
+ * This pack is on the stage and the key is its until it leaves.
+ *
+ * Called from an effect rather than during render, so that React's development
+ * double-invoke — mount, tear down, mount again — ends with the ownership it
+ * started with instead of with nobody holding the key.
+ */
+export function claimSoundscape(packId: string): void {
+  owner = packId
+}
+
+/** This pack has left the stage. The next doorway may rotate. */
+export function releaseSoundscape(packId: string): void {
+  if (owner === packId) owner = null
 }
 
 /**
@@ -178,4 +222,5 @@ export function soundscapeAtDoorway(now: number): Soundscape {
 export function resetAppSoundscape(seed?: number): void {
   launchSeed = typeof seed === "number" && Number.isFinite(seed) ? seed >>> 0 : drawLaunchSeed()
   held = null
+  owner = null
 }

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -112,6 +112,12 @@ export const strings = {
     light: "Light",
     dark: "Dark",
     sound: "Sound",
+    /**
+     * The generative soundscape switch. One word, and it is "Music" rather
+     * than "Soundscape": a parent reading a settings row is deciding whether
+     * the tablet plays tunes, and the word for that is not a term of art.
+     */
+    music: "Music",
     haptics: "Haptics",
     motion: "Reduce motion",
     textSize: "Text size",

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -25,7 +25,7 @@ import {
   orientationPorts,
   primeOrientationPermission,
 } from "../app/platform.ts"
-import { soundscapeAtDoorway } from "../app/soundscape.ts"
+import { claimSoundscape, releaseSoundscape, soundscapeForPack } from "../app/soundscape.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { documentLock } from "../app/zoom.ts"
@@ -131,14 +131,17 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
   // hand back the same four numbers for every doorway inside the rotation
   // window, so walking from one game to the next does not change the music.
   //
-  // Pinned in state rather than read per render, and that is the whole of the
-  // bug this avoids: `forPack` is rebuilt whenever a parent touches a setting
-  // and pushed to the running pack, so a soundscape drawn during render would
-  // put the game into a new key because somebody moved the text size — in the
-  // middle of a question, with the drone sliding under it. React's initialiser
-  // is double-invoked in StrictMode and that is fine: the call is idempotent
-  // inside the window.
-  const [soundscape] = useState(() => soundscapeAtDoorway(Date.now()))
+  // Pinned in state as well, but the pinning is belt and braces rather than the
+  // guarantee: `soundscapeForPack` hands the same key back to the pack that
+  // already owns it however often it is asked, so `forPack` being rebuilt when
+  // a parent touches a setting cannot put the game into a new key mid-question
+  // even if somebody later inlines this call into the memo below. The claim and
+  // the release are what let the NEXT pack rotate.
+  const [soundscape] = useState(() => soundscapeForPack(packId, Date.now()))
+  useEffect(() => {
+    claimSoundscape(packId)
+    return () => releaseSoundscape(packId)
+  }, [packId])
 
   // Built by the one function that knows how a host setting becomes a pack
   // setting, so the mapping cannot drift between the launch and the push.
@@ -182,6 +185,13 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
   useEffect(() => {
     launch.push(forPack)
   }, [launch, forPack])
+
+  // Nothing native, and nothing in Web Audio, may outlive a pack. The host's own
+  // cue context and its safety bus are built per launch and the bus holds a
+  // subscription to the app's Sound setting for as long as it lives — so a child
+  // who opens eight games in a sitting would otherwise leave eight live
+  // AudioContexts in this document, and Chromium refuses the seventh.
+  useEffect(() => () => launch.dispose(), [launch])
 
   const manifestEntry = entry?.manifest.entry
   useEffect(() => {

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -25,6 +25,7 @@ import {
   orientationPorts,
   primeOrientationPermission,
 } from "../app/platform.ts"
+import { soundscapeAtDoorway } from "../app/soundscape.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { documentLock } from "../app/zoom.ts"
@@ -121,11 +122,29 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
   const [restedBefore] = useState(() => !usePass.getState().mayOpen(packId))
   const [offering, setOffering] = useState(false)
 
+  // ── The doorway ────────────────────────────────────────────────────────────
+  //
+  // This component's identity IS a session — `PackStage` renders it with
+  // `key={packId}`, so opening a different game remounts it — which makes its
+  // mount the one moment the app is allowed to change key. Everything else
+  // about a soundscape is a slow-moving fact, and `soundscapeAtDoorway` will
+  // hand back the same four numbers for every doorway inside the rotation
+  // window, so walking from one game to the next does not change the music.
+  //
+  // Pinned in state rather than read per render, and that is the whole of the
+  // bug this avoids: `forPack` is rebuilt whenever a parent touches a setting
+  // and pushed to the running pack, so a soundscape drawn during render would
+  // put the game into a new key because somebody moved the text size — in the
+  // middle of a question, with the drone sliding under it. React's initialiser
+  // is double-invoked in StrictMode and that is fine: the call is idempotent
+  // inside the window.
+  const [soundscape] = useState(() => soundscapeAtDoorway(Date.now()))
+
   // Built by the one function that knows how a host setting becomes a pack
   // setting, so the mapping cannot drift between the launch and the push.
   const forPack: Settings = useMemo(
-    () => packSettings({ settings, theme: themeMode, systemPrefersDark: systemDark }),
-    [settings, themeMode, systemDark],
+    () => packSettings({ settings, theme: themeMode, systemPrefersDark: systemDark, soundscape }),
+    [settings, themeMode, systemDark, soundscape],
   )
 
   const launch = useMemo(

--- a/dynawalla/dynawalla-app/src/packs/cues.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/cues.test.ts
@@ -1,0 +1,322 @@
+// The host's own cues, measured.
+//
+// Every pack's audio ends at `createSafetyBus` — a limiter, then a
+// `WaveShaperNode` whose curve is flat at −1 dBFS, then the mute gate — and
+// `packs/shared/game-audio/routing.test.ts` fails any game that connects to
+// `ctx.destination` instead. The host was the one source in the product with
+// nothing over it: `playCue` connected straight to the output. Harmless while
+// it is five short triangle tones; not harmless the moment the host owns the
+// continuous ambient bed the soundscape design gives it, because a bed and a
+// cue summing on an unlimited path is the MOSAIC incident with the roles
+// swapped, and a bed is by definition always playing.
+//
+// ── Why this renders instead of grepping ────────────────────────────────────
+//
+// `routing.test.ts` is a source scan and says so, because a game's graph is
+// built inside a `start()` that needs a gesture and a real `AudioContext`. The
+// host's cue graph does not: `playCue` takes the context it is handed, so the
+// graph it actually builds can be assembled here and had samples pushed through
+// it. Everything below is a number that came out of the graph, not a line of
+// code that was found in a file.
+//
+// The fake is the one from `game-audio/safetyBus.test.ts`, extended with an
+// oscillator, and it keeps that file's two deliberate choices:
+//
+//   * the compressor is a straight wire. A `DynamicsCompressorNode` has a real
+//     attack time and the first milliseconds of a transient pass through it
+//     unattenuated, so assuming it does nothing is the honest worst case. It is
+//     also why a compressor is not a ceiling: its makeup gain is derived from
+//     its threshold, so at any threshold below 0 dB it makes quiet material
+//     LOUDER.
+//   * the shaper implements the spec's lookup exactly, including the clause
+//     that is the whole guarantee — an input outside [-1, 1] uses the nearest
+//     curve value.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { CUE_PEAK, playCue, type CueAudio, type CueContext } from "./services.ts"
+import type { SoundCue } from "../../../packs/sdk/src/index.ts"
+import { CEILING } from "../../../packs/shared/game-audio/index.ts"
+
+const CUES: readonly SoundCue[] = ["tick", "seat", "settle", "refuse", "arrive"]
+
+type Kind = "osc" | "gain" | "comp" | "shaper" | "dest"
+
+class Param {
+  value: number
+  /**
+   * The largest value this param is ever asked for.
+   *
+   * A real `GainNode.gain` defaults to **1**, and the envelope in `playCue` is
+   * three scheduling calls against `context.currentTime` — so from the cue's
+   * onset it is the schedule that governs and not the default. Modelled that
+   * way: once anything has been scheduled, the peak is the peak of the
+   * schedule; until then it is whatever was assigned. Delete the envelope and
+   * this reads 1, which is what the "not turned down to get there" assertion
+   * below would then measure — an eight-fold jump.
+   */
+  peak: number
+  private scheduled = false
+  constructor(v = 0) {
+    this.value = v
+    this.peak = v
+  }
+  private note(v: number): void {
+    if (!this.scheduled) {
+      this.scheduled = true
+      this.peak = v
+      return
+    }
+    this.peak = Math.max(this.peak, v)
+  }
+  setValueAtTime(v: number): void {
+    this.value = v
+    this.note(v)
+  }
+  exponentialRampToValueAtTime(v: number): void {
+    this.value = v
+    this.note(v)
+  }
+  linearRampToValueAtTime(v: number): void {
+    this.value = v
+    this.note(v)
+  }
+  cancelScheduledValues(): void {}
+}
+
+class Node {
+  readonly gain = new Param(1)
+  readonly frequency = new Param(440)
+  readonly threshold = new Param()
+  readonly knee = new Param()
+  readonly ratio = new Param()
+  readonly attack = new Param()
+  readonly release = new Param()
+  type = "sine"
+  curve: Float32Array | null = null
+  oversample = "none"
+  readonly outs: Node[] = []
+  started = false
+  readonly kind: Kind
+  constructor(kind: Kind) {
+    this.kind = kind
+  }
+  connect<T>(d: T): T {
+    this.outs.push(d as unknown as Node)
+    return d
+  }
+  disconnect(): void {
+    this.outs.length = 0
+  }
+  start(): void {
+    this.started = true
+  }
+  stop(): void {}
+  process(x: number): number {
+    if (this.kind === "gain") return x * this.gain.peak
+    if (this.kind === "comp") return x // worst case: the limiter has not engaged
+    if (this.kind === "shaper") return this.curve ? lookup(this.curve, x) : x
+    return x
+  }
+}
+
+/** `WaveShaperNode`, per spec, including the out-of-range clause. */
+function lookup(curve: Float32Array, x: number): number {
+  const n = curve.length
+  const v = ((n - 1) / 2) * (x + 1)
+  if (!(v > 0)) return curve[0] ?? 0
+  if (v >= n - 1) return curve[n - 1] ?? 0
+  const k = Math.floor(v)
+  const f = v - k
+  return (curve[k] ?? 0) * (1 - f) + (curve[k + 1] ?? 0) * f
+}
+
+class Ctx {
+  currentTime = 0
+  state = "running"
+  resumed = 0
+  readonly destination = new Node("dest")
+  readonly made: Node[] = []
+  private mk(kind: Kind): Node {
+    const n = new Node(kind)
+    this.made.push(n)
+    return n
+  }
+  resume(): void {
+    this.resumed += 1
+  }
+  createGain(): GainNode {
+    return this.mk("gain") as unknown as GainNode
+  }
+  createDynamicsCompressor(): DynamicsCompressorNode {
+    return this.mk("comp") as unknown as DynamicsCompressorNode
+  }
+  createWaveShaper(): WaveShaperNode {
+    return this.mk("shaper") as unknown as WaveShaperNode
+  }
+  createOscillator(): OscillatorNode {
+    return this.mk("osc") as unknown as OscillatorNode
+  }
+}
+
+const asContext = (ctx: Ctx): CueContext => ctx as unknown as CueContext
+
+/** A fresh session: one context, one bus, nothing played yet. */
+function session(): { ctx: Ctx; audio: CueAudio; play: (cue: SoundCue) => void } {
+  const ctx = new Ctx()
+  const audio: CueAudio = { context: null, bus: null }
+  return { ctx, audio, play: (cue) => playCue(audio, cue, () => asContext(ctx)) }
+}
+
+/** The chain a cue's oscillator actually reaches the output through. */
+function path(ctx: Ctx): Node[] {
+  const osc = ctx.made.find((n) => n.kind === "osc")
+  assert.ok(osc, "no oscillator was created — nothing played")
+  const chain: Node[] = [osc]
+  let node: Node = osc
+  for (let i = 0; i < 64; i++) {
+    const next = node.outs[0]
+    assert.ok(next, "the cue graph does not reach an output")
+    if (next === ctx.destination) return chain
+    chain.push(next)
+    node = next
+  }
+  throw new Error("the cue graph did not terminate")
+}
+
+/** Push one sample in at the oscillator and read what reaches the speaker. */
+function render(ctx: Ctx, x: number): number {
+  let v = x
+  for (const node of path(ctx)) v = node.process(v)
+  return v
+}
+
+test("a host cue reaches the output at all", () => {
+  const { ctx, play } = session()
+  play("tick")
+  const osc = ctx.made.find((n) => n.kind === "osc")
+  assert.ok(osc?.started, "the oscillator was never started")
+  assert.equal(osc.frequency.value, 880)
+  assert.equal(osc.type, "triangle")
+})
+
+test("the host's own cue CANNOT leave above the ceiling", () => {
+  // The whole point. Driven far past anything an oscillator can produce,
+  // because the guarantee is about the graph and not about the source: the bed
+  // that is coming will sum with these, and a graph that only holds for inputs
+  // under 1 is not a ceiling.
+  for (const cue of CUES) {
+    const { ctx, play } = session()
+    play(cue)
+    for (const x of [0.9, 1, 2.344, 13.955, 100, 1e6]) {
+      const y = render(ctx, x)
+      assert.ok(
+        y <= CEILING + 1e-6,
+        `${cue}: an input of ${x} left the host at ${y}, above the ceiling ${CEILING}`,
+      )
+      assert.ok(render(ctx, -x) >= -(CEILING + 1e-6), `${cue}: the negative half escaped`)
+      assert.ok(Math.abs(y) < 1, `${cue}: an input of ${x} clipped`)
+    }
+  }
+})
+
+test("and it is not turned down to get there — the cue still sounds as authored", () => {
+  // The wrong fix for the ceiling is a volume knob, and the founder has said so:
+  // the direction is more juice. A full-scale oscillator through the cue's
+  // envelope must still measure exactly the peak the envelope asks for.
+  for (const cue of CUES) {
+    const { ctx, play } = session()
+    play(cue)
+    assert.ok(
+      Math.abs(render(ctx, 1) - CUE_PEAK) < 1e-6,
+      `${cue}: peaks at ${render(ctx, 1)}, not the authored ${CUE_PEAK}`,
+    )
+    // Well under the knee, so the ceiling is transparent here rather than
+    // merely bounded: nothing about how these five cues sound has changed.
+    assert.ok(CUE_PEAK < 0.5)
+  }
+})
+
+test("the ceiling in the path is the real one: a shaper, flat at CEILING, un-oversampled", () => {
+  const { ctx, play } = session()
+  play("arrive")
+  const chain = path(ctx)
+
+  const shaper = chain.find((n) => n.kind === "shaper")
+  assert.ok(shaper, "the host's cue reaches the speaker without passing a WaveShaper")
+  const curve = shaper.curve
+  assert.ok(curve && curve.length >= 1024, "the shaper has no curve to be a ceiling with")
+
+  // Measured off the curve that was installed, not off a constant: the largest
+  // value in it is the largest sample the node can emit for ANY input.
+  let top = 0
+  for (const v of curve) top = Math.max(top, Math.abs(v))
+  assert.ok(Math.abs(top - CEILING) < 1e-6, `the curve tops out at ${top}, not ${CEILING}`)
+
+  // "none", and it matters: oversampling means upsample, shape, downsample, and
+  // the downsampling filter rings PAST the curve's own maximum. Rendered against
+  // a real implementation the same curve measured 0.890 at "none", 1.082 at
+  // "2x" and 1.098 at "4x" — the nicer-sounding setting is the one that voids
+  // the guarantee.
+  assert.equal(shaper.oversample, "none")
+
+  // A compressor is present and is doing the musical work, but it is not what
+  // is being trusted: its makeup gain is derived from its threshold, so it is
+  // not a limiter at any threshold below 0 dB, and the render above models it
+  // as a wire for exactly that reason.
+  const comp = chain.find((n) => n.kind === "comp")
+  assert.ok(comp, "no limiter in the host's cue path")
+  assert.equal(comp.threshold.value, 0, "a negative threshold applies makeup gain")
+
+  // And the ceiling is upstream of the mute, so muting is silence and not
+  // merely quiet: the last gain before the speaker comes after the shaper.
+  assert.equal(chain[chain.length - 1]?.kind, "gain", "the gate is not the last node")
+})
+
+test("one bus for the whole session, not one per tap", () => {
+  // A bus per cue is five nodes and a `game-audio/sound.ts` subscription leaked
+  // on every single tap a child makes, for the life of the app.
+  const { ctx, play } = session()
+  for (let round = 0; round < 3; round++) for (const cue of CUES) play(cue)
+  assert.equal(ctx.made.filter((n) => n.kind === "shaper").length, 1)
+  assert.equal(ctx.made.filter((n) => n.kind === "comp").length, 1)
+  assert.equal(ctx.made.filter((n) => n.kind === "osc").length, CUES.length * 3)
+})
+
+test("one context for the whole session, resumed when the device suspended it", () => {
+  const ctx = new Ctx()
+  ctx.state = "suspended"
+  const audio: CueAudio = { context: null, bus: null }
+  let opened = 0
+  const open = () => {
+    opened += 1
+    return asContext(ctx)
+  }
+  playCue(audio, "tick", open)
+  playCue(audio, "seat", open)
+  assert.equal(opened, 1, "a context was opened per cue")
+  assert.equal(ctx.resumed, 2, "a suspended context was never resumed")
+})
+
+test("a device with no audio is a quiet cue, not a broken app", () => {
+  const audio: CueAudio = { context: null, bus: null }
+  playCue(audio, "tick", () => null)
+  assert.equal(audio.context, null)
+  assert.equal(audio.bus, null)
+})
+
+test("a context that throws is logged, loudly, and does not take the host down", () => {
+  const errors: unknown[][] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => void errors.push(args)
+  try {
+    const audio: CueAudio = { context: null, bus: null }
+    playCue(audio, "tick", () => {
+      throw new Error("no audio on this device")
+    })
+  } finally {
+    console.error = real
+  }
+  assert.equal(errors.length, 1, "a failing cue was swallowed silently")
+})

--- a/dynawalla/dynawalla-app/src/packs/cues.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/cues.test.ts
@@ -35,7 +35,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { CUE_PEAK, playCue, type CueAudio, type CueContext } from "./services.ts"
+import { CUE_PEAK, closeCueAudio, playCue, type CueAudio, type CueContext } from "./services.ts"
 import type { SoundCue } from "../../../packs/sdk/src/index.ts"
 import { CEILING } from "../../../packs/shared/game-audio/index.ts"
 
@@ -86,6 +86,7 @@ class Param {
 }
 
 class Node {
+  disconnected = false
   readonly gain = new Param(1)
   readonly frequency = new Param(440)
   readonly threshold = new Param()
@@ -107,6 +108,7 @@ class Node {
     return d
   }
   disconnect(): void {
+    this.disconnected = true
     this.outs.length = 0
   }
   start(): void {
@@ -136,6 +138,7 @@ class Ctx {
   currentTime = 0
   state = "running"
   resumed = 0
+  closed = 0
   readonly destination = new Node("dest")
   readonly made: Node[] = []
   private mk(kind: Kind): Node {
@@ -145,6 +148,9 @@ class Ctx {
   }
   resume(): void {
     this.resumed += 1
+  }
+  close(): void {
+    this.closed += 1
   }
   createGain(): GainNode {
     return this.mk("gain") as unknown as GainNode
@@ -319,4 +325,40 @@ test("a context that throws is logged, loudly, and does not take the host down",
     console.error = real
   }
   assert.equal(errors.length, 1, "a failing cue was swallowed silently")
+})
+
+test("closing a session gives the device back, totally and idempotently", () => {
+  // Not tidiness. `createSafetyBus` registers a listener in `game-audio`'s
+  // module-global set of live buses, which keeps the bus, its nodes and the
+  // context reachable for the life of the app — and an `AudioContext` is
+  // scarce: Chromium allows six per document and throws on the seventh. A child
+  // who opens eight games in one sitting would find the host's cues silent for
+  // the rest of the session, with one caught-and-logged error to show for it.
+  //
+  // Idempotent because React runs a cleanup twice in development StrictMode,
+  // and an unmount after a launch that never played runs it against a session
+  // with no context at all.
+  const ctx = new Ctx()
+  const audio: CueAudio = { context: null, bus: null }
+  playCue(audio, "tick", () => asContext(ctx))
+  // The bus's own nodes: the chain after the oscillator and the cue's envelope.
+  // The envelope gain is per-tap and is collected when the oscillator stops,
+  // which is the same thing every game in the fleet relies on.
+  const nodes = path(ctx).slice(2)
+  assert.ok(nodes.length >= 4, `the bus is only ${nodes.length} nodes`)
+
+  closeCueAudio(audio)
+  assert.ok(nodes.every((n) => n.disconnected), "a bus node was left connected")
+  assert.equal(ctx.closed, 1)
+  assert.equal(audio.bus, null)
+  assert.equal(audio.context, null)
+
+  closeCueAudio(audio)
+  assert.equal(ctx.closed, 1, "a second close reached the device")
+  closeCueAudio({ context: null, bus: null })
+
+  // And the session can play again afterwards: a new context, a new bus, and
+  // the ceiling still in the path.
+  playCue(audio, "seat", () => asContext(new Ctx()))
+  assert.notEqual(audio.bus, null)
 })

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -157,6 +157,7 @@ export const CUE_PEAK = 0.12
 export type CueContext = BusContext & {
   readonly state?: string
   resume?: () => unknown
+  close?: () => unknown
   createOscillator: () => OscillatorNode
 }
 
@@ -171,6 +172,33 @@ const openAudioContext: CueOpener = () => {
     typeof AudioContext === "function" ? AudioContext : undefined
   if (!Ctor) return null
   return new Ctor()
+}
+
+/**
+ * Give the device back: disconnect the bus and close the context.
+ *
+ * Lifted out of `createServices` so it can be driven against a real cue graph
+ * in a test — the leak was in the session, and a session's `AudioContext` is
+ * made lazily on the first cue inside a closure nothing else can reach.
+ *
+ * Each step is guarded independently and loudly: a bus that refuses to
+ * disconnect must not stop the context being closed, because the context is the
+ * scarce one. Idempotent, because React runs a cleanup twice in development and
+ * an unmount after a failed launch runs it against a session that never played.
+ */
+export function closeCueAudio(audio: CueAudio): void {
+  try {
+    audio.bus?.disconnect()
+  } catch (error) {
+    console.error("[packs] the cue bus would not disconnect", error)
+  }
+  audio.bus = null
+  try {
+    audio.context?.close?.()
+  } catch (error) {
+    console.error("[packs] the cue context would not close", error)
+  }
+  audio.context = null
 }
 
 /**
@@ -269,6 +297,17 @@ export type LaunchServices = {
    * restart a child's run to change a colour.
    */
   push: (settings: Settings) => void
+  /**
+   * End the session's hold on the device.
+   *
+   * Called when the stage unmounts. Nothing in Web Audio may outlive a pack:
+   * the safety bus subscribes to the app's Sound setting for as long as it
+   * lives (`game-audio/sound.ts` keeps a module-global set of live buses), and
+   * an `AudioContext` is a scarce resource — Chromium allows six per document
+   * and refuses the seventh, which is a child opening eight games in a sitting
+   * and the host's cues going silent for the rest of the app session.
+   */
+  dispose: () => void
 }
 
 /**
@@ -386,5 +425,6 @@ export function createServices(deps: ServicesDeps): LaunchServices {
     push: (settings) => {
       current = settings
     },
+    dispose: () => closeCueAudio(audio),
   }
 }

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -19,6 +19,12 @@ import type {
   TransitionKind,
 } from "../../../packs/sdk/src/index.ts"
 import { CAPABILITY_IDS, isNativeBacked } from "../../../packs/sdk/src/index.ts"
+import {
+  createSafetyBus,
+  type BusContext,
+  type SafetyBus,
+} from "../../../packs/shared/game-audio/index.ts"
+import type { Soundscape } from "../app/soundscape.ts"
 import type { HostServices } from "./bridge.ts"
 import { fireHaptic, type HapticPorts } from "./haptics.ts"
 import type { OrientationSource } from "./orientation.ts"
@@ -54,6 +60,18 @@ export type SettingsInput = {
   /** BCP-47. One locale until the i18n runtime lands; a pack must not guess. */
   readonly locale?: string  /** Override for tests; production measures the live tokens. */
   readonly safeArea?: { top: number; right: number; bottom: number; left: number }
+  /**
+   * The key the app is in, drawn at the doorway this pack was opened through.
+   *
+   * Required rather than optional-with-a-default, and required for the reason
+   * `haptics` above is: a defaulted one would let "nobody pinned a soundscape"
+   * compile, run, and sound exactly like a host that has none — which is the
+   * state this change exists to leave. It also forces the value to be *pinned*
+   * by the caller. `packSettings` runs again on every settings change, and if
+   * it drew its own the app would change key when a parent moved the text size
+   * slider, mid-question, under a child. See `app/soundscape.ts`.
+   */
+  readonly soundscape: Soundscape
 }
 
 /** The device facts a pack is handed. No name, no birthday, no identifier. */
@@ -85,6 +103,16 @@ export function readSafeArea(): { top: number; right: number; bottom: number; le
 
 export function packSettings(input: SettingsInput): Settings {
   const { settings } = input
+  // Two switches, and both have to be on. `sound` is the total one — a pack's
+  // safety bus closes its gate after the ceiling, so off is silent rather than
+  // quiet — and `music` chooses between the app's generative key and the fixed
+  // cues a pack shipped with.
+  //
+  // The field is OMITTED rather than sent as `undefined`, which `exactOptional
+  // PropertyTypes` insists on and which is also the honest wire: absent is what
+  // a host too old to know about soundscapes sends, and `game-soundscape`
+  // already reads absent as "keep your own sounds" and never as "go quiet".
+  const music = settings.sound && settings.music
   return {
     locale: input.locale ?? "en",
     reducedMotion: settings.reduceMotion,
@@ -94,6 +122,7 @@ export function packSettings(input: SettingsInput): Settings {
     sound: settings.sound,
     haptics: settings.haptics,
     safeArea: input.safeArea ?? readSafeArea(),
+    ...(music ? { soundscape: input.soundscape } : {}),
   }
 }
 
@@ -106,7 +135,43 @@ const SOUND_CUE: Readonly<Record<SoundCue, { hz: number; ms: number }>> = {
   arrive: { hz: 990, ms: 200 },
 }
 
-type Audio = { context: AudioContext | null }
+/**
+ * The peak of a cue's envelope, linear.
+ *
+ * Named because a `GainNode`'s `gain` defaults to **1**, not to 0 — so the
+ * three scheduling calls below are not decoration, they are the only thing
+ * standing between a cue and full scale, and a test can now say which number
+ * it expects to measure rather than reading the ramp back.
+ */
+export const CUE_PEAK = 0.12
+
+/**
+ * The slice of `AudioContext` the host's own cues touch.
+ *
+ * `BusContext` is what the shared safety bus needs; the oscillator and the two
+ * resume members are what a cue needs on top of it. Written as a structural
+ * type rather than `AudioContext` so the graph this builds can be rendered in a
+ * test, which is the only way to *measure* the ceiling instead of asserting
+ * that a line of code exists.
+ */
+export type CueContext = BusContext & {
+  readonly state?: string
+  resume?: () => unknown
+  createOscillator: () => OscillatorNode
+}
+
+/** The one context and the one bus a session's cues share. */
+export type CueAudio = { context: CueContext | null; bus: SafetyBus | null }
+
+/** How a cue reaches a device. Production opens a real context; a test hands one in. */
+export type CueOpener = () => CueContext | null
+
+const openAudioContext: CueOpener = () => {
+  const Ctor: typeof AudioContext | undefined =
+    typeof AudioContext === "function" ? AudioContext : undefined
+  if (!Ctor) return null
+  return new Ctor()
+}
 
 /**
  * One short tone.
@@ -115,15 +180,32 @@ type Audio = { context: AudioContext | null }
  * one before a gesture, and a suspended context created at mount is a context
  * that never plays anything. Every failure is swallowed *loudly* — a device
  * that refuses audio must not take a game down with it.
+ *
+ * ── The ceiling ─────────────────────────────────────────────────────────────
+ *
+ * This used to end `.connect(context.destination)`, which made the host the one
+ * audio source in the whole product with no ceiling over it. Every pack's
+ * output passes `createSafetyBus` — a limiter, then a `WaveShaperNode` whose
+ * curve is flat at −1 dBFS, then the mute gate — and `game-audio/routing.test.ts`
+ * fails any game that skips it. The host was exempt only because nobody had
+ * written the rule down for it.
+ *
+ * Five short triangle tones at 0.12 were never going to hurt anybody, which is
+ * why it went unnoticed. It stops being harmless the moment the host owns the
+ * continuous ambient bed the soundscape design gives it (stage 3): a bed and a
+ * cue summing on an output path that nothing limits is the MOSAIC incident with
+ * the roles swapped, and a bed is by definition always playing.
+ *
+ * One bus per session, built on the first cue and reused. A bus per cue would
+ * be five nodes and a `sound.ts` subscription leaked on every tap.
  */
-function playCue(audio: Audio, cue: SoundCue): void {
+export function playCue(audio: CueAudio, cue: SoundCue, open: CueOpener = openAudioContext): void {
   try {
-    const Ctor: typeof AudioContext | undefined =
-      typeof AudioContext === "function" ? AudioContext : undefined
-    if (!Ctor) return
-    audio.context ??= new Ctor()
+    audio.context ??= open()
     const context = audio.context
-    if (context.state === "suspended") void context.resume()
+    if (!context) return
+    if (context.state === "suspended") void context.resume?.()
+    audio.bus ??= createSafetyBus(context)
     const { hz, ms } = SOUND_CUE[cue]
     const now = context.currentTime
     const osc = context.createOscillator()
@@ -131,9 +213,11 @@ function playCue(audio: Audio, cue: SoundCue): void {
     osc.type = "triangle"
     osc.frequency.value = hz
     gain.gain.setValueAtTime(0.0001, now)
-    gain.gain.exponentialRampToValueAtTime(0.12, now + 0.008)
+    gain.gain.exponentialRampToValueAtTime(CUE_PEAK, now + 0.008)
     gain.gain.exponentialRampToValueAtTime(0.0001, now + ms / 1000)
-    osc.connect(gain).connect(context.destination)
+    // The bus, never `context.destination`. This is the line the comment above
+    // is about, and `cues.test.ts` renders the graph it produces.
+    osc.connect(gain).connect(audio.bus.input)
     osc.start(now)
     osc.stop(now + ms / 1000 + 0.02)
   } catch (error) {
@@ -197,7 +281,7 @@ export type LaunchServices = {
 export function createServices(deps: ServicesDeps): LaunchServices {
   const items = createItemService({ profileId: deps.profileId, record: report })
   const store = packStorageFor(deps.profileId)
-  const audio: Audio = { context: null }
+  const audio: CueAudio = { context: null, bus: null }
   const haptics = deps.haptics
   let current = deps.settings
 

--- a/dynawalla/dynawalla-app/src/settings/store.ts
+++ b/dynawalla/dynawalla-app/src/settings/store.ts
@@ -28,6 +28,19 @@ export type Quality = "full" | "plain"
 
 export interface Settings {
   readonly sound: boolean
+  /**
+   * Whether the app hands a pack the generative key it is in.
+   *
+   * A second switch rather than a second meaning for `sound`, because they are
+   * different questions a parent can reasonably answer differently: `sound` is
+   * "may this tablet make noise at all" and is total — it closes the gate after
+   * the ceiling in every pack's safety bus, so off means silent. This is "may
+   * the noise be music", and off means a pack falls back to the fixed cues it
+   * shipped with. **Off is not quiet.** A host too old to send a soundscape
+   * publishes `undefined` and that already means "keep your own sounds"; this
+   * switch reuses that path exactly rather than inventing a quieter one.
+   */
+  readonly music: boolean
   readonly haptics: boolean
   readonly reduceMotion: boolean
   readonly textSize: TextSize
@@ -38,6 +51,7 @@ export interface Settings {
 
 export const DEFAULT_SETTINGS: Settings = {
   sound: true,
+  music: true,
   haptics: true,
   reduceMotion: false,
   textSize: "normal",
@@ -62,8 +76,9 @@ export const useSettings = create<SettingsState>()(
       name: deviceKey("settings"),
       version: 1,
       storage: durable,
-      partialize: ({ sound, haptics, reduceMotion, textSize, quality, developer }) => ({
+      partialize: ({ sound, music, haptics, reduceMotion, textSize, quality, developer }) => ({
         sound,
+        music,
         haptics,
         reduceMotion,
         textSize,
@@ -80,6 +95,10 @@ export const useSettings = create<SettingsState>()(
         return {
           ...current,
           sound: flag(stored?.sound, DEFAULT_SETTINGS.sound),
+          // A tablet that was set up before this switch existed has no stored
+          // value, and the default is on: the soundscape is the feature, and a
+          // parent who wants the old fixed cues can say so.
+          music: flag(stored?.music, DEFAULT_SETTINGS.music),
           haptics: flag(stored?.haptics, DEFAULT_SETTINGS.haptics),
           reduceMotion: flag(stored?.reduceMotion, DEFAULT_SETTINGS.reduceMotion),
           developer: flag(stored?.developer, DEFAULT_SETTINGS.developer),

--- a/dynawalla/dynawalla-app/src/shell/surfaces.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.ts
@@ -375,6 +375,12 @@ function settingsSurface(view: HostView, act: HostActions): readonly Section[] {
         switchRow("sound", strings.settings.sound, settings.sound, (on) =>
           act.setSettings({ sound: on }),
         ),
+        // Directly under Sound, because it is a narrowing of it: with Sound off
+        // this changes nothing audible, and with Sound on it chooses between
+        // the app's generative key and the fixed cues each pack shipped with.
+        switchRow("music", strings.settings.music, settings.music, (on) =>
+          act.setSettings({ music: on }),
+        ),
         switchRow("haptics", strings.settings.haptics, settings.haptics, (on) =>
           act.setSettings({ haptics: on }),
         ),

--- a/dynawalla/games/counterweight/src/audio.ts
+++ b/dynawalla/games/counterweight/src/audio.ts
@@ -31,11 +31,13 @@
 // arcs and comes to rest like a phrase. The drone becomes the soundscape's own
 // root, so the melody cannot be out of tune with it: both are the same number.
 //
-// **Until a host publishes one, none of that happens and the yard sounds
-// exactly as it shipped.** `currentSoundscape()` is `null` by default and no
-// host sends the field yet, so this is the ship-safe path and the four fixed
-// pitches below are still the production sound. The dev harness publishes one
-// (`main.ts`), which is where the idea can be heard.
+// **Dynawalla's app publishes one**, so inside it the plates play a phrase. Two
+// other callers do not, and both are ordinary rather than exceptional: a host
+// older than the field, and a parent who has turned the app's Music switch off.
+// For them `currentSoundscape()` is `null`, none of the above happens, and the
+// four fixed pitches below are the sound — "keep your own sounds", never "go
+// quiet". The dev harness (`main.ts`) publishes its own, which is where a
+// specific mode and root can be pinned and heard on demand.
 
 import { type Place, type Strike } from "./game/places.ts"
 import { createSafetyBus, safeAttack } from "../../../packs/shared/game-audio/index.ts"
@@ -78,9 +80,11 @@ export class Audio {
   /**
    * The soundscape's melody walker, or `null` when no host has published one.
    *
-   * `null` is the shipping state today and it means every method below takes
-   * the path it always took. Nothing about this game's sound changes until an
-   * app decides to publish a mode and a root.
+   * `null` means every method below takes the path this game always took: the
+   * four fixed pitches in `PLACE_HZ` and a drone that transposes. That is what
+   * a dev harness with no host, a host older than the field, and a parent who
+   * has turned the app's Music switch off all get. Dynawalla's app publishes
+   * one, so inside it this is a `Melody` and the plates play a phrase.
    */
   private melody: Melody | null = null
   /** The drone's fixed anchor voices — the sub-octave and, if the mode has one, the fifth. */
@@ -93,15 +97,22 @@ export class Audio {
     // Following, not reading once: the host re-publishes on every settings
     // change, and a game that only looked at launch would be in last hour's key.
     this.unfollow = onSoundscape((next) => {
-      if (!next) {
-        this.melody = null
-        return
-      }
-      if (this.melody) this.melody.retune(next)
+      if (!next) this.melody = null
+      else if (this.melody) this.melody.retune(next)
       else this.melody = new Melody(next)
       // A live drone has to move to the new root, or the melody is in one key
       // and the thing under it is in another. Rebuilt rather than ramped: the
       // bow is a half-second fade either way and a key change is not a slide.
+      //
+      // **Losing the soundscape rebuilds it too**, and that is not symmetry for
+      // its own sake. The anchors this.bow() adds — the sub-octave and the
+      // mode's fifth — only exist when there is a melody, and nothing else ever
+      // stops them: a parent turning the app's Music switch off mid-round would
+      // otherwise leave two sines ringing at the old root while `track()` walks
+      // the bowed voice back to the fixed DRONE_HZ and the plates go back to
+      // their fixed pitches over the top. That is a semitone-off cluster for
+      // the rest of the round, produced by a switch whose whole job is to make
+      // the game sound like it did before.
       if (this.droneOsc) {
         this.release()
         this.bow()

--- a/dynawalla/games/counterweight/src/main.ts
+++ b/dynawalla/games/counterweight/src/main.ts
@@ -16,10 +16,11 @@ import {
 
 // ── The soundscape, in the harness only ─────────────────────────────────────
 //
-// The real app does not publish one yet, so in a shipped pack
-// `currentSoundscape()` is `null` and the yard sounds exactly as it always has.
-// Here it is published before mount, which is the only place the idea can
-// currently be heard: a random mode and root each run, or a named one with
+// The real app publishes one now (`dynawalla-app/src/app/soundscape.ts`), so
+// inside the app the yard plays in whatever key the bazaar is in. This harness
+// has no host at all, so it publishes its own before mount — which is where a
+// specific soundscape can be pinned and heard on demand: a random mode and root
+// each run, or a named one with
 // `?mode=maqam.rast&root=146.8`, so a specific report ("hijaz sounds wrong on
 // the thousands plate") is reproducible rather than a memory.
 //

--- a/dynawalla/packs/shared/game-host/sound.test.ts
+++ b/dynawalla/packs/shared/game-host/sound.test.ts
@@ -303,9 +303,11 @@ describe("the app's soundscape reaches the pack", () => {
   })
 
   it("a host that sends none leaves every game with its own sounds", () => {
-    // The ship gate. No host populates this field today, so this is the path
-    // production takes, and `null` has to mean "keep what you had" rather than
-    // "go quiet".
+    // Dynawalla's host publishes one now, but two other hosts do not: a pack
+    // dev harness, and any build older than the field. `null` therefore still
+    // has to mean "keep what you had" rather than "go quiet", and the app's own
+    // Music switch reaches a pack down exactly this path rather than by a
+    // second, quieter spelling of off.
     const stub = stubClient()
     attachGameHost(stub.client)
     assert.equal(currentSoundscape(), null)

--- a/dynawalla/packs/shared/game-soundscape/host.ts
+++ b/dynawalla/packs/shared/game-soundscape/host.ts
@@ -14,11 +14,11 @@
  *
  * **Why `null` is the default, and why that is the whole ship-safety story.**
  * Until a host publishes a soundscape, `currentSoundscape()` is `null` and a
- * game keeps whatever sound it already had. No host publishes one today, so
- * this module changes nothing audible in production the day it lands. A pack's
- * dev harness publishes one, which is where the idea can be heard. Turning it
- * on for real is one line in the host, deliberately not taken in the change
- * that introduces this.
+ * game keeps whatever sound it already had. Dynawalla's host publishes one
+ * (`dynawalla-app/src/app/soundscape.ts`); a pack's dev harness publishes one;
+ * a host older than the field, or one whose Music switch is off, publishes
+ * nothing, and that is not an error. `null` means "keep your own sounds" and
+ * never "go quiet" — which is the whole of how the switch is implemented.
  *
  * Shaped exactly like `game-audio/sound.ts`, on purpose: `game-host` already
  * knows how to publish that one on every `settings` event, and a second thing


### PR DESCRIPTION
Founder decisions, implemented: **the soundscape goes on for THE STEELYARD**, and **the host owns one bed** — so the ceiling hole that would have made that bed unsafe is closed on the way past.

Closes the "Where it is turned on" half of #737.

## The thing that was wrong

`packs/shared/game-soundscape` shipped finished — 38 modes as exact cents, the walker, the gesture vocabulary, 45 tests. `game-host`'s `publish()` already forwarded `client.settings.soundscape` on attach and on every `settings` event. THE STEELYARD was wired end to end.

And **nothing in `dynawalla-app` ever put a `soundscape` into `Settings`**, so `currentSoundscape()` was `null` on every device and all 28 games fell through to their fixed-pitch tables. Turning it on was never a change to a pack. It was three files in the host.

## What was built

### `dynawalla-app/src/app/soundscape.ts` — one key for the whole app

The rotation policy, and why it is this one:

* **A fresh key every launch.** The launch seed is drawn once per process (`crypto` where there is one). A child who plays for ninety seconds and closes the app still hears a different mode tomorrow.
* **A new key every eight minutes after that.** Long enough that a whole run at one game sits inside one key; short enough that a long afternoon hears five or six.
* **The clock is only read at a doorway.** `soundscapeAtDoorway` is called when a pack is mounted, and `Stage` pins what it returns for the life of that mount. A key change *underneath* a child — mid-question, because a timer went off — would slide the drone under the plate they are holding, and that is worse than repetition. So the app changes key while a child is walking between games and never while they are in one. Two packs opened a minute apart are the same key: that is the "changes key at every doorway" failure the design names, and it is asserted.
* **Never the same mode twice running.** A uniform draw from 38 repeats about one doorway in 38, and a repeat is exactly the "stale and repetitive" in the brief. Re-drawing costs one comparison.
* **It starts chill** — tension `CALM`, which is what the walker reads to keep the motion nearly all stepwise.

Everything derives from two integers, so a session is replayable: `resetAppSoundscape(7)` gives the same sequence of keys on every device, forever.

### Always optional, two ways

`sound` is unchanged and total — a pack's safety bus closes its gate *after* the ceiling, so off is silent and not merely quiet.

A second switch, **Music**, chooses between the app's generative key and the fixed cues a pack shipped with. Off publishes **nothing** — which is already what a host too old to know about soundscapes sends, and `game-soundscape` already reads absent as "keep your own sounds" and never as "go quiet". No second spelling of off, no quieter code path.

### The ceiling hole (`packs/services.ts`)

`playCue()` ended `.connect(context.destination)`. Every pack's output passes `createSafetyBus` — limiter, then a `WaveShaperNode` flat at −1 dBFS, then the mute gate — and `game-audio/routing.test.ts` fails any game that skips it. The host was exempt only because nobody had written the rule down for it.

Five short triangle tones at 0.12 were never going to hurt anybody. It stops being harmless the moment the host owns a continuous bed, because a bed and a cue summing on an unlimited path is the MOSAIC incident with the roles swapped, and a bed is by definition always playing. One bus per session now, built on the first cue and reused.

`cues.test.ts` **renders the graph `playCue` actually builds and pushes samples through it** — it does not grep for the line. The fake is `game-audio/safetyBus.test.ts`'s, extended with an oscillator, and it keeps that file's honest worst case: the compressor is modelled as a straight wire, because a `DynamicsCompressorNode` applies makeup gain derived from its threshold and is therefore not a limiter.

### The import boundary

`boundary.test.ts` allowed the host exactly two modules outside `src/`. It now allows four, each behind **one door** (`app/soundscape.ts` and `packs/services.ts`), and a new walk holds both new entry points to reaching nothing outside their own package and touching no DOM — so the exemption cannot become a tunnel. Both are contracts rather than content, for the same structural reason the SDK is: a second copy of the mode corpus is a host and a pack that disagree about what `maqam.rast` means, and a second copy of a hearing-safety guarantee is not a guarantee.

## The pack's ship gate is untouched

`counterweight/src/test/soundscape.test.ts`'s *"nothing in the shipped pack turns the soundscape on"* passes unchanged. Turning it on was the host's job; the pack still never publishes its own.

## Verification

Five consecutive runs of each, all green:

| | tests |
|---|---|
| `dynawalla-app` | 396 |
| `packs/shared/game-soundscape` | 45 |
| `packs/shared/game-host` | 58 |
| `packs/shared/game-audio` | 80 |
| `games/counterweight` | 165 |

`tsc` clean in all five, `eslint` clean, and the real Vite production bundle builds.

**Eighteen mutations, each confirmed to fail the assertion that covers it and then restored** — including reverting `playCue` to `context.destination` (`an input of 13.955 left the host at 1.6746, above the ceiling 0.89`), deleting the cue envelope so `GainNode.gain`'s default of 1 applies (`tick: peaks at 0.8899999856948853, not the authored 0.12` — the ceiling caught it, which is the point), setting the shaper to `4x`, giving the limiter a −3 dB threshold, rotating the key on every doorway (`the second pack opened in a different key`), and making `packSettings` read the wall clock (`Error: packSettings read the wall clock`).

## For the device

This is the first build where the founder can hear it. Still not proven, and it needs ears rather than tests: whether all 38 modes suit a maths game (whole tone under a drone may be seasick), the rubble recipe on a tablet speaker, and the 58–117 Hz register. Culling the corpus is a data change.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb

---

## Second pass — three real defects found in adversarial self-review, all fixed

**1. The key's stability was a convention, not an invariant — and its test was vacuous.**
The pin lived in `Stage`'s `useState`, and the test that claimed to cover it called `packSettings` (a pure function) and asserted it returned its argument. Inlining the draw back into the memo would rotate the key under a playing child nine minutes into a session, and all 396 tests still passed. No test in the repo renders `Stage`.

The guarantee now belongs to the module: `soundscapeForPack(packId, now)` hands the same key back to the pack that already owns it, however often it asks and however long it has been. A different pack — or the same one after it has *left* the stage — rotates it if it is due. Owner is a pack id rather than a counter because React renders the incoming pack before it runs the outgoing one's cleanup, so a counter would still be held by the pack being torn down and the doorway would never rotate.

**2. A session never gave the device back.** `createSafetyBus` registers into `game-audio/sound.ts`'s module-global set of live buses, so every pack launch that played one host cue permanently retained an `AudioContext`. Chromium allows six per document: a child opening eight games in a sitting would find the host's cues silent for the rest of the app session, with one caught-and-logged error to show for it. `createServices` now returns `dispose()` and `Stage` calls it on unmount.

**3. THE STEELYARD's drone anchors survived Music being turned off.** The soundscape sink's null branch returned early without the `release(); bow()` its sibling does, and the anchors only exist when there is a melody — so turning the switch *off* mid-round left two sines at the old root while `track()` walked the bowed voice back to the fixed `DRONE_HZ` and the plates went back to their fixed pitches over the top. A semitone-off cluster for the rest of the round, produced by a switch whose whole job is to make the game sound like it did before. Reachable in production for the first time because of this branch.

Plus two smaller ones: a NaN clock no longer pins `since` at zero (which would have rotated at every doorway forever afterwards), and the boundary walk's non-vacuity floor is 3 rather than exactly `game-audio`'s file count.

**Five more mutations**, each confirmed to fail and restore — deleting the owner guard (`the key rotated 1 windows into a session`), neutering `releaseSoundscape` (`a child replaying one game heard the same key forever` — this one caught a *second* vacuous assertion of mine, since a different pack rotates whether or not the previous one let go), the NaN guard (`a NaN clock rotated the key`), and each half of `dispose`.

Re-verified: five consecutive runs of all five suites — **`dynawalla-app` 400**, `game-soundscape` 45, `game-host` 58, `game-audio` 80, `counterweight` 165 — `tsc` clean in all five, `eslint` clean, production bundle builds.
