### PR TITLE
chore(dynawalla): 0.3.7

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.6 → 0.3.7. One line.

The 0.3.6 playtest round, eight PRs:

- **#740 MATH NINJA** — THE SPLIT was 16 objects on screen at t=13s and 27.4 free cuts per arithmetic decision. Now 2, and 0.05–0.69. A masher wrecks 83–189 orders while completing 9–48; a reader gets 2.3–9.6× more. Every answering window in the pack is deleted.
- **#738 / #742 THE STEELYARD stops playing the same ding** — 38 modes (16 western, 12 maqamat, 10 thaats) as exact cents, ported from beatlounge. The app chooses a key and packs inherit it, so the bazaar does not change key at every doorway. `+1`/`−1` walk the mode. Music is its own switch; off means "keep your own sounds".
- **#739 THE LATTICE** — a factor tree that unfolds in six stages (`129 ⟶ 3 and ⟶ ?`, then `16 × 7`), free until a thumb crosses the line, never costing the child anything.
- **#734 VOLTA** — the recharge question measured **1.00:1** contrast mid-crossfade: ink and panel the identical colour. Every ink is now derived from the surface it lands on, across 32 biomes × 11 crossfade points.
- **#741 THE TRUE DRAW** — full-screen layout, and success/failure are finally events.
- **#735 the difficulty clamp** — a pack's request is a hint clamped to ±1 rung of the host's band, so the 95/85/75 rule governs the fleet rather than 10 of 27 games.
- **#736** — grades and the age band expunged from the catalog; the manual's last line no longer sits under the fade.

A main push does not release. The tag `dynawalla-v0.3.7` does, and I push it once this is on main.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb