### PR TITLE
fix(dynawalla/games/merge-idle): ABYSSAL BLOOM — the reef stops handing out walls, and CLEAR keeps its promise

### DIFF
--- a/dynawalla/games/merge-idle/src/core/board.ts
+++ b/dynawalla/games/merge-idle/src/core/board.ts
@@ -223,11 +223,44 @@ export function lowestValue(b: Board): number {
 }
 
 /**
+ * CLEAR — dissolve from the bottom of the shelf until there is `want` room.
+ *
+ * ## Why this is not `purgeLowest`
+ *
+ * It was, and the manual's promise — *"You can never get stuck. CLEAR always
+ * works."* — was false because of it. One value class is often one polyp, so on
+ * the full board the founder was handed, CLEAR freed a single cell, the reef put
+ * something back into it, and he was exactly where he started:
+ *
+ *   "now I hit 'clear' and only one goes away and a FREAKING 44 comes out .. so,
+ *    now I just have a full board and it's stuck and the game sucks."
+ *
+ * So CLEAR keeps going up the values until the shelf has real room, and the room
+ * it makes is measured against what the reef owes: enough cells for every polyp
+ * the current target still needs, plus slack to shuffle them. Smallest first,
+ * because that is the cheapest reef mass to spend and it is what the child was
+ * told would happen.
+ *
+ * Free, always, and it stops the moment there is room — so it can never take more
+ * of a reef than the escape costs.
+ */
+export function purgeUpTo(b: Board, want: number): { gained: number; cells: number[] } {
+  const cells: number[] = []
+  let gained = 0
+  while (emptyCells(b).length < want) {
+    const round = purgeLowest(b)
+    if (round.cells.length === 0) break
+    gained += round.gained
+    cells.push(...round.cells)
+  }
+  return { gained, cells }
+}
+
+/**
  * DISSOLVE — clear every polyp at the lowest value on the shelf.
  *
- * Free, and always available, because it is the only guarantee that a crowded
- * board is never a losing position. `gained` is the total value that left, which
- * the floaters print so the child can see the size of what they spent.
+ * One rung of `purgeUpTo`. `gained` is the total value that left, which the
+ * floaters print so the child can see the size of what they spent.
  */
 export function purgeLowest(b: Board): { gained: number; cells: number[] } {
   const lo = lowestValue(b)

--- a/dynawalla/games/merge-idle/src/core/economy.ts
+++ b/dynawalla/games/merge-idle/src/core/economy.ts
@@ -63,10 +63,53 @@ export function growthsAt(depth: number): number {
  * At bloom one a child merges 1s and 5s; forty blooms in they are merging 96s and
  * 448s. The arithmetic gets harder because the *world* got bigger, which is the
  * only difficulty ramp that never reads as punishment.
+ *
+ * **This is no longer the emission floor.** It was, and that was the bug — see
+ * `emitCeiling` below. It survives only as the rung a *fresh, empty* shelf is
+ * seeded on, where there is no target to measure against yet.
  */
 export function baseStepFor(depth: number): number {
   return Math.max(0, Math.min(9, Math.floor(depth / 6)))
 }
+
+/* ---------------------------------------------------------- the emission band */
+
+/**
+ * THE EMISSION BAND, and why it is one rung high.
+ *
+ * ## The bug
+ *
+ * Ambient emission used to be `strain * 2 ** baseStepFor(depth)`: a floor that
+ * rose with the reef, never came back down, and never once consulted the number
+ * the child was being asked for. The founder played 0.3.7 and reported it twice,
+ * in exactly these words:
+ *
+ *   "the numbers that come out are too high for the problem .. I want to see
+ *    1,3,5,7 ... now I hit 'clear' and only one goes away and a FREAKING 44 comes
+ *    out .. so, now I just have a full board and it's stuck"
+ *
+ *   "____ + ____ = 5 and EVERY FREAKING NUMBER is like above 18"
+ *
+ * With `5 = ▢ + ▢` the only polyps that can take part are 1, 2, 3 and 4. At
+ * `baseStep >= 1` **not one of them can spawn**, so the shelf fills with numbers
+ * that cannot be part of any answer and no amount of play recovers it. His 18 is
+ * `9 × 2`, his 44 is `11 × 4`, his 88 is `11 × 8` — all legal ladder values, at a
+ * rung that makes them furniture. And a big polyp on a full shelf cannot even be
+ * SPLIT back down, because a split needs a free cell to put the other half in.
+ *
+ * ## The rule
+ *
+ * **A fresh polyp is always a seed.** Step 0, at every depth, forever. Big numbers
+ * are EARNED by merging and are never handed out. There is no depth→value
+ * coupling left in this game: what escalates is the target, the operator form and
+ * the size of the shelf, none of which can fill a board with numbers no answer can
+ * use.
+ *
+ * The one exception is the reef's DEBT — the halves it owes so the current target
+ * is buildable at all (see `core/target.ts`, `stockFor`). Those are derived from
+ * the number the child is being asked for, which is the whole point of them.
+ */
+export const EMIT_STEP = 0
 
 /**
  * How bright the world is, 0..1. Drives the whole escalation: the abyss starts

--- a/dynawalla/games/merge-idle/src/core/engine.ts
+++ b/dynawalla/games/merge-idle/src/core/engine.ts
@@ -113,6 +113,20 @@ const RECENT = 4
  */
 export const ESCAPE_SLACK = 2
 
+/**
+ * The biggest debt the reef can ever owe: three terms, two halves apiece.
+ *
+ * A constant and not `stock.length` on purpose. CLEAR clears room and then works
+ * out what it owes, and on the founder's own board the clearing is what CREATES
+ * the debt — it takes away the last small polyp, so a target that was answerable
+ * a moment ago now needs stocking. Sizing the escape against the debt as it stood
+ * *before* the purge left the shelf one cell short of the debt the purge made.
+ */
+export const MAX_DEBT = 6
+
+/** The room CLEAR restores, and the point below which it is offered. */
+export const ESCAPE_CELLS = MAX_DEBT + ESCAPE_SLACK
+
 export class Engine {
   readonly s: State
   private deps: EngineDeps
@@ -322,7 +336,7 @@ export class Engine {
 
   /** How much room the shelf needs before the reef can pay what it owes. */
   private escapeRoom(): number {
-    return this.s.stock.length + ESCAPE_SLACK
+    return ESCAPE_CELLS
   }
 
   /**

--- a/dynawalla/games/merge-idle/src/core/engine.ts
+++ b/dynawalla/games/merge-idle/src/core/engine.ts
@@ -32,7 +32,7 @@ import {
   move,
   place,
   polyps,
-  purgeLowest,
+  purgeUpTo,
   spawn,
   trySplit,
   tryMerge,
@@ -43,6 +43,7 @@ import {
   baseStepFor,
   bloomLevel,
   bloomYield,
+  EMIT_STEP,
   emitPeriodMs,
   growthsAt,
   offlineGrowth,
@@ -60,7 +61,7 @@ import {
 } from './mouth.ts'
 import type { Rng } from './rng.ts'
 import { askTarget, type AskHost } from './ask.ts'
-import { bagOf, faceOf, routeIn, type Form } from './target.ts'
+import { bagOf, faceOf, ladderRoute, routeIn, stockFor, type Form } from './target.ts'
 import { BUDGET, emptyDrag, type State, type Target, type Tier } from './state.ts'
 
 export type Event =
@@ -100,6 +101,17 @@ export const START_ROWS = 7
 
 /** How many recent targets to remember, so the same number twice running is rare. */
 const RECENT = 4
+
+/**
+ * The room CLEAR guarantees, over and above what the reef currently owes.
+ *
+ * A debt is at most six polyps — three terms, two halves each — so six cells is
+ * enough to *land* it. Two more are the slack to work in: a polyp may be dragged
+ * onto any empty cell from anywhere, so one spare cell is already enough to bring
+ * any two halves together, and two is enough that a child never has to think
+ * about it.
+ */
+export const ESCAPE_SLACK = 2
 
 export class Engine {
   readonly s: State
@@ -142,12 +154,18 @@ export class Engine {
 
   /* ------------------------------------------------------------------ setup */
 
-  /** Stock a fresh shelf so the very first target has something to be made of. */
+  /**
+   * Stock a fresh shelf so the very first target has something to be made of.
+   *
+   * At step 0, always. A returning child whose shelf was emptied gets 1, 3, 5, 7
+   * back, not the rung their depth would have justified — the reef's own emission
+   * band starts at the seeds too, and a shelf that opens above it is a shelf
+   * nothing can be built out of.
+   */
   seed(n = 8): void {
-    const step = this.s.baseStep
     for (let i = 0; i < n; i++) {
       const strain = this.deps.rng.int(0, 7) as Strain
-      const p = spawn(this.s.board, valueOf(strain, step), this.deps.rng)
+      const p = spawn(this.s.board, valueOf(strain, 0), this.deps.rng)
       if (p) p.born = 1
     }
   }
@@ -189,10 +207,10 @@ export class Engine {
     }
     this.s.target = target
     this.s.mouth = emptyMouth(a.slots)
-    this.s.stock = [...a.stock]
-    // A debt starts being paid on the NEXT frame, not on whatever was left of the
-    // slow cadence: the child is already looking at a number they cannot make.
-    if (this.s.stock.length > 0) this.s.emitMs = Math.min(this.s.emitMs, STOCK_PERIOD_MS)
+    // `askTarget` already worked the debt out; `restock` is the same computation
+    // against the same shelf, and going through it means there is exactly ONE
+    // place in this engine that decides what the reef owes.
+    this.restock()
     this.recent.push(a.value)
     while (this.recent.length > RECENT) this.recent.shift()
     return [{ kind: 'target', value: a.value, form: a.form, face: this.face }]
@@ -223,6 +241,142 @@ export class Engine {
     return routeIn(bag, t.value, t.form, t.slots) !== null
   }
 
+  /**
+   * Every polyp the child controls: the shelf, plus whatever is in the mouth.
+   *
+   * The mouth counts. A polyp in it can be pulled back out for free and a spill
+   * hands all of them back, so a route that is half-fed is a route the child still
+   * holds — and a debt computed off the shelf alone would ask the reef to grow a
+   * second copy of the 16 they are standing there holding.
+   */
+  private get held() {
+    return bagOf([...polyps(this.s.board).map((p) => p.value), ...this.s.mouth.fed.map((f) => f.value)])
+  }
+
+  /**
+   * Can the child GET to this route with the polyps they hold, given merges and
+   * splits? The honest form of "is this winnable", and it is a counting argument.
+   *
+   * A polyp's strain is its odd part, and the only two moves that change a value
+   * are merge (double) and split (halve). So a strain never converts into another
+   * strain, and within a strain everything is fungible: a 44 is four 11s, a 22 is
+   * two, and the child can go either way. Count each strain's holding in SEEDS —
+   * `2 ** step` apiece — and a route is affordable exactly when every strain it
+   * calls for is covered.
+   *
+   * This is what `solvable()` needed and did not have. The first version asked
+   * `routeIn`, which reads the shelf literally, and a shelf holding a 40 and two
+   * 2s failed it while `40 − (2+2) = 36` was one drag away.
+   */
+  private canAfford(route: readonly number[]): boolean {
+    const have = new Map<number, number>()
+    for (const [value, n] of this.held) {
+      const id = decompose(value)
+      if (!id) continue
+      have.set(id.strain, (have.get(id.strain) ?? 0) + 2 ** id.step * n)
+    }
+    const need = new Map<number, number>()
+    for (const v of route) {
+      const id = decompose(v)
+      if (!id) return false
+      need.set(id.strain, (need.get(id.strain) ?? 0) + 2 ** id.step)
+    }
+    for (const [strain, want] of need) if ((have.get(strain) ?? 0) < want) return false
+    return true
+  }
+
+  /** The terms the current target is made of, whatever the child holds. */
+  private routeFor(t: Target): readonly number[] {
+    return routeIn(this.held, t.value, t.form, t.slots) ?? ladderRoute(t.value, t.form, t.slots) ?? t.route
+  }
+
+  /**
+   * CAN THE CHILD STILL WIN FROM HERE? The invariant the manual promises.
+   *
+   * `game.ts` tells a child, in as many words: *"You can never get stuck. CLEAR
+   * always works."* This is that sentence, decidable, on live state — and it was
+   * false in 0.3.7, which is why the founder was handed a board he could not win.
+   *
+   * Two ways to be true, and only two:
+   *
+   *   1. The shelf builds the target NOW — `reachable()`.
+   *   2. The reef OWES the polyps that build it, and there is somewhere for them
+   *      to land: room already, or room `dissolve()` will make.
+   *
+   * Note what is not here: hope. "The reef will emit something eventually" was the
+   * old answer and it is how a board fills with numbers no answer can use. If
+   * neither clause holds, the child is stuck, and this returns false rather than
+   * shrugging.
+   */
+  solvable(): boolean {
+    const t = this.s.target
+    if (!t) return true
+    if (this.canAfford(this.routeFor(t))) return true
+    const owed = this.s.stock.length
+    if (owed === 0) return false
+    // Room already, or room CLEAR will make — `purgeUpTo` keeps going up the
+    // values until there is `escapeRoom()`, so any shelf with a polyp on it can
+    // be opened up. An empty shelf needs no opening.
+    return emptyCells(this.s.board).length >= owed || polyps(this.s.board).length > 0
+  }
+
+  /** How much room the shelf needs before the reef can pay what it owes. */
+  private escapeRoom(): number {
+    return this.s.stock.length + ESCAPE_SLACK
+  }
+
+  /**
+   * Is CLEAR worth offering? True when pressing it would actually free something.
+   *
+   * Not "the board is full": a shelf with three cells left and a five-polyp debt
+   * is already a shelf the reef cannot pay, and waiting for it to jam completely
+   * before offering the way out is how a child spends a minute watching nothing
+   * happen.
+   */
+  get needsRoom(): boolean {
+    return emptyCells(this.s.board).length < this.escapeRoom() && polyps(this.s.board).length > 0
+  }
+
+  /**
+   * Make the reef owe whatever the target still needs.
+   *
+   * Called after EVERY change to the shelf, which is the whole repair. The
+   * previous version computed the debt once, when the target went up, and then
+   * again only on a spill — so a child who merged the last term of their own route
+   * into something bigger (a legal, sensible move) left the target unbuildable
+   * with the reef owing nothing, and ambient emission cheerfully filled the shelf
+   * with numbers that could not be part of any answer.
+   *
+   * Idempotent: `stockFor` is recomputed against the shelf as it stands, so a
+   * half that has already landed is not asked for twice and a term the child has
+   * merged up is dropped from the debt.
+   */
+  private restock(): void {
+    const t = this.s.target
+    if (!t) return
+    const route = this.routeFor(t)
+    // Nothing is owed while the child can still get there themselves. `canAfford`
+    // and not `holdable` on purpose: a shelf one merge away from the answer is a
+    // shelf with a merge to do, not a shelf to pour more polyps onto.
+    if (this.canAfford(route)) {
+      this.s.stock = []
+      return
+    }
+    const owed = stockFor(this.held, route)
+    this.s.stock = owed
+    // A debt starts being paid on the NEXT frame: the child is already looking at
+    // a number they cannot make.
+    if (owed.length > 0) this.s.emitMs = Math.min(this.s.emitMs, STOCK_PERIOD_MS)
+  }
+
+  /** Everything that has to be true again after the shelf changes. */
+  private settle(events: Event[]): void {
+    this.restock()
+    const c = isCrowded(this.s.board)
+    if (c && !this.s.crowded) events.push({ kind: 'crowded' })
+    this.s.crowded = c
+  }
+
   /* ----------------------------------------------------------------- merges */
 
   merge(from: number, to: number): { res: MergeResult; events: Event[] } | null {
@@ -231,7 +385,7 @@ export class Engine {
     this.s.merges++
     if (res.value > this.s.bestValue) this.s.bestValue = res.value
     const events: Event[] = [{ kind: 'merge', cell: to, value: res.value, rank: res.rank, chain: 0 }]
-    this.refreshCrowd(events)
+    this.settle(events)
     return { res, events }
   }
 
@@ -262,7 +416,9 @@ export class Engine {
     if (!move(this.s.board, from, to)) return []
     const p = at(this.s.board, to)
     if (p) p.squash = 0.5
-    return [{ kind: 'move', cell: to }]
+    const events: Event[] = [{ kind: 'move', cell: to }]
+    this.settle(events)
+    return events
   }
 
   /**
@@ -278,7 +434,7 @@ export class Engine {
     if (!res) return [{ kind: 'refuse', why: 'no-room' }]
     this.s.splits++
     const events: Event[] = [{ kind: 'split', cell, into: res.made.cell, value: before / 2 }]
-    this.refreshCrowd(events)
+    this.settle(events)
     return events
   }
 
@@ -301,7 +457,13 @@ export class Engine {
     feedMouth(this.s.mouth, p.value, this.deps.rng.int(0, 999) / 1000)
     const events: Event[] = [{ kind: 'fed', value: p.value, index: this.s.mouth.fed.length - 1 }]
     const verdict = resolve(this.s.mouth, t.form, t.value)
-    if (verdict.kind === 'open') return events
+    // A polyp in the mouth is a polyp off the shelf, so the route the child had
+    // may have just been spent. The reef owes whatever is left of it from HERE,
+    // not from whatever the shelf looked like when the target went up.
+    if (verdict.kind === 'open') {
+      this.settle(events)
+      return events
+    }
     this.report(t, verdict.kind === 'bloom', verdict.answered)
     if (verdict.kind === 'bloom') events.push(...this.bloom(t))
     else events.push(...this.spill(verdict.produced))
@@ -334,7 +496,7 @@ export class Engine {
     }
     events.push(...this.growIfEarned())
     events.push(...this.ask())
-    this.refreshCrowd(events)
+    this.settle(events)
     return events
   }
 
@@ -357,15 +519,11 @@ export class Engine {
       if (p) p.born = 0
     }
     const events: Event[] = [{ kind: 'spill', produced, back }]
-    // The target is NOT replaced and NOT taken away. It stays up, and it is still
-    // reachable — the reef re-stocks whatever the spill could not put back.
-    const t = this.s.target
-    if (t && !this.reachable()) {
-      const bag = bagOf(polyps(this.s.board).map((p) => p.value))
-      const missing = routeIn(bag, t.value, t.form, t.slots)
-      if (!missing) this.s.stock.push(...t.route.filter((v) => (bag.get(v) ?? 0) === 0))
-    }
-    this.refreshCrowd(events)
+    // The target is NOT replaced and NOT taken away. It stays up, and `settle`
+    // makes the reef owe whatever the spill could not put back — the same guard
+    // every other move goes through, rather than a special case that only a spill
+    // benefited from.
+    this.settle(events)
     return events
   }
 
@@ -408,48 +566,102 @@ export class Engine {
     return [{ kind: 'grow', cols: b.cols, rows: b.rows }]
   }
 
+  /**
+   * CLEAR — the escape hatch, and the one promise this game makes out loud.
+   *
+   * The manual tells the child *"You can never get stuck. CLEAR always works."*
+   * That sentence was false: `purgeLowest` cleared one value class, which on a
+   * shelf of forty distinct numbers is one polyp, the reef put something back into
+   * the hole, and the founder was exactly where he started. So CLEAR now goes up
+   * the values until there is room for everything the reef owes plus slack to work
+   * in, and `settle` reloads that debt on the way out — pressing it leaves a
+   * position the child can win from, which is the only thing the word means.
+   */
   dissolve(): Event[] {
-    const { gained, cells } = purgeLowest(this.s.board)
+    const { gained, cells } = purgeUpTo(this.s.board, this.escapeRoom())
     if (cells.length === 0) return []
     const events: Event[] = [{ kind: 'dissolve', cells, gained }]
-    this.refreshCrowd(events)
+    this.settle(events)
     return events
-  }
-
-  private refreshCrowd(events: Event[]): void {
-    const c = isCrowded(this.s.board)
-    if (c && !this.s.crowded) events.push({ kind: 'crowded' })
-    this.s.crowded = c
   }
 
   /* -------------------------------------------------------------- emissions */
 
   /**
-   * One polyp onto the shelf.
+   * One polyp onto the shelf, and the second half of the repair.
    *
    * `stock` first: those are the halves the reef owes so the current target stays
    * buildable, and they are the mechanism behind "the game can know what would be a
    * fun number to put on the vent and you build it with the polyps".
    *
-   * Otherwise a value from the live band. The strain is drawn from what the shelf
-   * ALREADY HOLDS three times out of four, because eight strains scattered at
-   * random is a board with nothing to merge — and a merge board that never offers a
-   * pair is the meanest thing this genre can do.
+   * ## What the ambient emission does now, and what it used to do
+   *
+   * It used to be `strain * 2 ** baseStep`, and `baseStep` came from DEPTH. So the
+   * smallest polyp the reef could produce climbed with the session and never came
+   * back down, and nothing in the expression mentioned the number the child was
+   * being asked for. That is the whole of the founder's report: `5 = ▢ + ▢` with a
+   * shelf where every polyp is above 18, and a CLEAR that frees one cell only for
+   * a 44 to drop into it.
+   *
+   * Both halves of the draw are now answerable to the target:
+   *
+   *   * **the strain** comes from the terms the target is made of, three times in
+   *     four. A polyp's strain is its odd part and merging only ever doubles, so a
+   *     strain-5 polyp can only ever become 11, 22, 44, 88 — which means the
+   *     strains the target needs are *exactly* the polyps that can take part in
+   *     answering it. The fourth draw is from what the shelf already holds, or the
+   *     whole ladder, because a board with only one strain on it is a board with
+   *     nothing to join.
+   *   * **the rung** is always 0 — a bare seed, at every depth, forever. Big
+   *     numbers are earned by merging and are never handed out. See `EMIT_STEP`.
    */
   emitOne(): Polyp | null {
     const owed = this.s.stock.shift()
     if (owed !== undefined) return spawn(this.s.board, owed, this.deps.rng)
     const rng = this.deps.rng
-    const here = polyps(this.s.board)
-    const strains = new Set<number>()
-    for (const p of here) {
-      const id = decompose(p.value)
-      if (id) strains.add(id.strain)
+    const pool = this.strainPool(rng)
+    // Among the strains that would help, the one the shelf is shortest of. A pool
+    // picked flat put thirty 1s on a forty-cell shelf, because strain 0 is in
+    // almost every route; "I want to see 1,3,5,7" is a SPREAD, not a monoculture.
+    let best = pool[0] as number
+    let fewest = Infinity
+    for (const strain of rng.shuffle([...pool])) {
+      const n = this.countStrain(strain)
+      if (n < fewest) {
+        fewest = n
+        best = strain
+      }
     }
-    const pool = strains.size > 0 && rng.chance(3, 4) ? [...strains].sort((a, b) => a - b) : [0, 1, 2, 3, 4, 5, 6, 7]
-    const strain = rng.pick(pool) as Strain
-    const step = Math.max(0, this.s.baseStep + (rng.chance(1, 3) ? 1 : 0))
-    return spawn(this.s.board, valueOf(strain, step), this.deps.rng)
+    return spawn(this.s.board, valueOf(best as Strain, EMIT_STEP), this.deps.rng)
+  }
+
+  private countStrain(strain: number): number {
+    let n = 0
+    for (const p of polyps(this.s.board)) if (decompose(p.value)?.strain === strain) n++
+    return n
+  }
+
+  /**
+   * Which strains a fresh polyp may be drawn from.
+   *
+   * A polyp's strain is its odd part, and merging only ever doubles — so a
+   * strain-5 polyp can only ever become 11, 22, 44, 88. The strains the target's
+   * route needs are therefore *exactly* the polyps that can take part in answering
+   * it, which is why the pool is drawn from the route three times in four. The
+   * fourth draw is wider, because a shelf carrying one strain is a shelf whose
+   * every polyp is a duplicate of every other.
+   */
+  private strainPool(rng: Rng): number[] {
+    const t = this.s.target
+    if (t && rng.chance(3, 4)) {
+      const wanted = new Set<number>()
+      for (const v of this.routeFor(t)) {
+        const id = decompose(v)
+        if (id) wanted.add(id.strain)
+      }
+      if (wanted.size > 0) return [...wanted].sort((a, b) => a - b)
+    }
+    return [0, 1, 2, 3, 4, 5, 6, 7]
   }
 
   /**
@@ -475,7 +687,7 @@ export class Engine {
       const p = this.emitOne()
       if (p) {
         events.push({ kind: 'emit', cell: p.cell, value: p.value })
-        this.refreshCrowd(events)
+        this.settle(events)
       }
     }
     return events

--- a/dynawalla/games/merge-idle/src/core/stuck.test.ts
+++ b/dynawalla/games/merge-idle/src/core/stuck.test.ts
@@ -31,7 +31,7 @@
 
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { Engine, ESCAPE_SLACK } from './engine.ts'
+import { Engine, ESCAPE_CELLS } from './engine.ts'
 import { at, emptyCells, hasLegalMerge, place, polyps } from './board.ts'
 import { canSplit, decompose } from './ladder.ts'
 import { makeRng } from './rng.ts'
@@ -168,6 +168,10 @@ test('the founder’s board: 5 = ▢ + ▢ + ▢ on a shelf of nothing under 18'
   assert.equal(fours.length, 2)
   assert.ok(engine.merge((fours[0] as { cell: number }).cell, (fours[1] as { cell: number }).cell))
   assert.equal(engine.reachable(), false, 'the shelf can no longer build 5 — this is the moment')
+  // Nothing on this shelf is on the 5-ladder, so no amount of joining or halving
+  // produces a five: the reef has to owe one, and it has to know that it does.
+  assert.deepEqual(engine.s.stock, [5], 'the reef must owe the five')
+  assert.equal(engine.solvable(), true, 'and the position must still be winnable')
 
   // From here the child is patient and does everything the glass affords, CLEAR
   // included. The reef must give them a five.
@@ -205,16 +209,18 @@ test('CLEAR always works: a full shelf is always opened up, and SPLIT works agai
   assert.equal(emptyCells(engine.s.board).length, 0, 'the shelf is full again')
 
   // The founder's exact complaint about the old CLEAR: "only one goes away".
-  const owed = engine.s.stock.length
   const events = engine.dissolve()
   const cleared = events.find((e) => e.kind === 'dissolve')
   assert.ok(cleared, 'CLEAR must do something on a full shelf')
   const free = emptyCells(engine.s.board).length
   assert.ok(
-    free >= owed + ESCAPE_SLACK,
-    `CLEAR left ${free} cells for a debt of ${owed} — that is not an escape`,
+    free >= ESCAPE_CELLS,
+    `CLEAR left ${free} cells, which is under the ${ESCAPE_CELLS} a debt can need — not an escape`,
   )
-  assert.ok(free > 1, `CLEAR freed ${free} cell(s); the shipped one freed exactly one`)
+  assert.ok(
+    engine.s.stock.length <= free,
+    `the reef owes ${engine.s.stock.length} polyps into ${free} cells`,
+  )
 
   // "88 on a full board so you can't even split it" — a split needs a free cell,
   // so an escape that does not restore one has not restored the game either.
@@ -227,10 +233,19 @@ test('CLEAR always works: a full shelf is always opened up, and SPLIT works agai
 
 test('CLEAR is offered before the shelf jams solid, and never when there is already room', () => {
   const engine = makeEngine(fixedHost(5), 11)
-  loadShelf(engine, 6, [...HIGH, 1, 4, 4])
+  // ONE free cell — not jammed, but nowhere near enough to pay a debt into and
+  // one drag away from being jammed. Waiting for the last cell to go before
+  // offering the way out is a minute of a child watching nothing happen.
+  loadShelf(engine, 6, [...HIGH.slice(0, 38), 1, 4, 4])
   engine.ask()
-  assert.equal(engine.needsRoom, true, 'a full shelf needs room')
+  assert.equal(emptyCells(engine.s.board).length, 1, 'the shelf must have exactly one cell left')
+  assert.equal(engine.needsRoom, true, 'one free cell is not room')
+
   engine.dissolve()
+  assert.ok(
+    emptyCells(engine.s.board).length >= ESCAPE_CELLS,
+    'CLEAR must leave at least the slack it promises',
+  )
   assert.equal(engine.needsRoom, false, 'a shelf CLEAR has just opened up does not need more')
 })
 

--- a/dynawalla/games/merge-idle/src/core/stuck.test.ts
+++ b/dynawalla/games/merge-idle/src/core/stuck.test.ts
@@ -1,0 +1,436 @@
+/**
+ * NO REACHABLE BOARD MAY BE UNSOLVABLE.
+ *
+ * `game.ts` tells a child, in as many words: *"You can never get stuck. CLEAR
+ * always works."* In 0.3.7 that sentence was false, and the founder played it and
+ * said so:
+ *
+ *   "the board fills up with high numbers and it becomes impossible 10 = ___ -
+ *    ___ .... then I hit clear and one goes away and the next polyp to come .. is
+ *    18 .. the polyps should start as low numbers"
+ *
+ *   "____ + ____ = 5 and EVERY FREAKING NUMBER is like above 18"
+ *
+ * Three separate faults met to produce that board, and there is a test here for
+ * each:
+ *
+ *   1. **Emission ignored the target.** A fresh polyp was `strain * 2 ** baseStep`
+ *      and `baseStep` came from DEPTH, so past six blooms the reef could not cough
+ *      out an odd number at all — and a sum of even polyps is even, so `5` was
+ *      unmakeable no matter how long a child played.
+ *   2. **The debt was computed once.** The reef worked out what it owed when the
+ *      target went up and then never again, so a child who merged the last term of
+ *      their own route into something bigger left the target unbuildable with the
+ *      reef owing nothing.
+ *   3. **CLEAR freed one value class**, which on a shelf of forty distinct numbers
+ *      is one cell — filled again on the next breath.
+ *
+ * `the founder's board` below reproduces all three against the real `Engine`
+ * through nothing but public methods, and it FAILS on the code that shipped.
+ */
+
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { Engine, ESCAPE_SLACK } from './engine.ts'
+import { at, emptyCells, hasLegalMerge, place, polyps } from './board.ts'
+import { canSplit, decompose } from './ladder.ts'
+import { makeRng } from './rng.ts'
+import { bagOf, ladderRoute, ladderValues, routeIn } from './target.ts'
+import { makeStubHost } from '../stubHost.ts'
+import type { AskHost } from './ask.ts'
+
+const LIMIT = { maxCols: 8, maxRows: 9 }
+const STEP_MS = 220
+
+/** A host that asks for one number, forever. `5` is the founder's own example. */
+function fixedHost(answer: number): AskHost & { report(r: unknown): void } {
+  let n = 0
+  return {
+    next: () => ({ id: `fixed-${n++}`, prompt: `? = ${answer}`, answer: String(answer) }),
+    skip: () => {},
+    focus: () => {},
+    report: () => {},
+  }
+}
+
+function makeEngine(host: AskHost & { report(r: never): void }, seed: number): Engine {
+  let clock = 0
+  return new Engine({
+    host: host as never,
+    rng: makeRng(seed),
+    now: () => (clock += 1),
+    limit: () => LIMIT,
+    cols: 6,
+    rows: 7,
+  })
+}
+
+/** Put the shelf in a named state through `restore`, which is a shipped entry point. */
+function loadShelf(engine: Engine, depth: number, values: readonly number[]): void {
+  engine.restore(
+    JSON.stringify({
+      v: 2,
+      depth,
+      grows: 0,
+      cols: 6,
+      rows: 7,
+      cells: values.map((v, i) => [i, v]),
+      mouth: [],
+      lastSeen: Date.now(),
+    }),
+  )
+}
+
+/**
+ * Thirty-nine ladder values, none under 18, no two the same, and not one of them
+ * on the 5-ladder — the founder's shelf.
+ *
+ * Distinct because a repeated value is a merge and a merge is a way out. Off the
+ * 5-ladder because splitting is the other way out: 20 halves to 10 halves to 5, so
+ * a shelf with a 20 on it can still reach `5` with its bare hands. Excluding
+ * strain 2 is what makes this board genuinely unmakeable without the reef's help,
+ * which is the position the founder was actually handed.
+ */
+const HIGH = ladderValues()
+  .filter((v) => v >= 18 && decompose(v)?.strain !== 2)
+  .slice(0, 39)
+
+/**
+ * A patient child. Feeds the route when there is one, otherwise joins a pair,
+ * otherwise splits, otherwise presses CLEAR. Returns true if the reef bloomed.
+ *
+ * Deliberately not clever: everything it does is something the glass affords with
+ * one finger, and it never reads a private field.
+ */
+function playUntilBloom(engine: Engine, steps: number): boolean {
+  for (let i = 0; i < steps; i++) {
+    engine.tick(STEP_MS)
+    const s = engine.s
+    if (!s.target) return true
+
+    const bag = bagOf(polyps(s.board).map((p) => p.value))
+    const route = routeIn(bag, s.target.value, s.target.form, s.target.slots)
+    if (route) {
+      let bloomed = false
+      for (const want of route) {
+        const cell = polyps(s.board).find((p) => p.value === want)?.cell
+        if (cell === undefined) break
+        for (const ev of engine.feed(cell)) if (ev.kind === 'bloom') bloomed = true
+      }
+      if (bloomed) return true
+      continue
+    }
+
+    const byValue = new Map<number, number[]>()
+    for (const p of polyps(s.board)) {
+      const list = byValue.get(p.value) ?? []
+      list.push(p.cell)
+      byValue.set(p.value, list)
+    }
+    let acted = false
+    for (const v of [...byValue.keys()].sort((a, z) => z - a)) {
+      const cells = byValue.get(v)
+      if (!cells || cells.length < 2) continue
+      if (engine.merge(cells[0] as number, cells[1] as number)) {
+        acted = true
+        break
+      }
+    }
+    if (acted) continue
+    if (emptyCells(s.board).length < 2) engine.dissolve()
+  }
+  return false
+}
+
+/* ------------------------------------------------------------ the founder's board */
+
+test('the founder’s board: 5 = ▢ + ▢ + ▢ on a shelf of nothing under 18', () => {
+  // Depth 6, because that is where `baseStepFor` used to cross 1 — and past that
+  // rung the shipped emitter could only ever produce EVEN numbers, so an odd
+  // target became arithmetically unmakeable and stayed that way for good.
+  const engine = makeEngine(fixedHost(5), 20260728)
+  // Forty numbers no smaller than 18, and the route to five: 4 + 1. A second 4 so
+  // there is a legal join on the shelf, which is what the child spends.
+  loadShelf(engine, 6, [...HIGH, 1, 4, 4])
+  assert.equal(emptyCells(engine.s.board).length, 0, 'the shelf must start full')
+
+  engine.ask()
+  const t = engine.s.target
+  assert.ok(t, 'a target must be up')
+  assert.equal(t.value, 5)
+  assert.equal(t.form, 'sum')
+  assert.ok(engine.reachable(), '5 = 4 + 1 is on the shelf when the target goes up')
+  assert.equal(engine.s.stock.length, 0, 'a shelf that can already answer is owed nothing')
+
+  // The child joins their two 4s — a legal, ordinary, sensible move, and the last
+  // odd-capable route to 5 goes with it.
+  const fours = polyps(engine.s.board).filter((p) => p.value === 4)
+  assert.equal(fours.length, 2)
+  assert.ok(engine.merge((fours[0] as { cell: number }).cell, (fours[1] as { cell: number }).cell))
+  assert.equal(engine.reachable(), false, 'the shelf can no longer build 5 — this is the moment')
+
+  // From here the child is patient and does everything the glass affords, CLEAR
+  // included. The reef must give them a five.
+  assert.ok(
+    playUntilBloom(engine, 400),
+    `5 never became makeable. shelf: [${polyps(engine.s.board)
+      .map((p) => p.value)
+      .sort((a, b) => a - b)
+      .join(', ')}]`,
+  )
+})
+
+test('the reef owes the polyps the target needs the moment the shelf stops holding them', () => {
+  const engine = makeEngine(fixedHost(5), 20260728)
+  loadShelf(engine, 6, [...HIGH, 1, 4, 4])
+  engine.ask()
+  const fours = polyps(engine.s.board).filter((p) => p.value === 4)
+  engine.merge((fours[0] as { cell: number }).cell, (fours[1] as { cell: number }).cell)
+
+  // The repair, stated directly: a merge that spends the route leaves a DEBT.
+  assert.equal(engine.reachable(), false)
+  assert.deepEqual(engine.s.stock, [5], 'the reef must owe the five it can no longer be built out of')
+  assert.equal(engine.solvable(), true)
+})
+
+/* ------------------------------------------------------------------------ CLEAR */
+
+test('CLEAR always works: a full shelf is always opened up, and SPLIT works again', () => {
+  const engine = makeEngine(fixedHost(5), 7)
+  loadShelf(engine, 6, [...HIGH, 1, 4, 4])
+  engine.ask()
+  const fours = polyps(engine.s.board).filter((p) => p.value === 4)
+  engine.merge((fours[0] as { cell: number }).cell, (fours[1] as { cell: number }).cell)
+  while (emptyCells(engine.s.board).length > 0) engine.tick(STEP_MS)
+  assert.equal(emptyCells(engine.s.board).length, 0, 'the shelf is full again')
+
+  // The founder's exact complaint about the old CLEAR: "only one goes away".
+  const owed = engine.s.stock.length
+  const events = engine.dissolve()
+  const cleared = events.find((e) => e.kind === 'dissolve')
+  assert.ok(cleared, 'CLEAR must do something on a full shelf')
+  const free = emptyCells(engine.s.board).length
+  assert.ok(
+    free >= owed + ESCAPE_SLACK,
+    `CLEAR left ${free} cells for a debt of ${owed} — that is not an escape`,
+  )
+  assert.ok(free > 1, `CLEAR freed ${free} cell(s); the shipped one freed exactly one`)
+
+  // "88 on a full board so you can't even split it" — a split needs a free cell,
+  // so an escape that does not restore one has not restored the game either.
+  const big = polyps(engine.s.board).find((p) => canSplit(p.value))
+  assert.ok(big, 'the shelf still holds something halvable')
+  const before = engine.s.splits
+  engine.split(big.cell)
+  assert.equal(engine.s.splits, before + 1, 'SPLIT must be possible again after CLEAR')
+})
+
+test('CLEAR is offered before the shelf jams solid, and never when there is already room', () => {
+  const engine = makeEngine(fixedHost(5), 11)
+  loadShelf(engine, 6, [...HIGH, 1, 4, 4])
+  engine.ask()
+  assert.equal(engine.needsRoom, true, 'a full shelf needs room')
+  engine.dissolve()
+  assert.equal(engine.needsRoom, false, 'a shelf CLEAR has just opened up does not need more')
+})
+
+/* ------------------------------------------------------------- the emission band */
+
+test('the reef never coughs out anything but a seed', () => {
+  const seen = new Set<number>()
+  for (let seed = 1; seed <= 8; seed++) {
+    const engine = drive(seed, 500, (value, owed) => {
+      if (owed) return
+      seen.add(value)
+      const id = decompose(value)
+      assert.ok(id, `${value} is off the ladder`)
+      assert.equal(id.step, 0, `the reef coughed out a ${value}; only seeds may be emitted`)
+    })
+    void engine
+  }
+  // And all eight seeds do actually appear, so "only seeds" is not "only 1".
+  assert.equal(seen.size, 8, `only saw ${[...seen].sort((a, b) => a - b).join(', ')}`)
+})
+
+test('the strains the reef emits are strains the target can actually use', () => {
+  let onRoute = 0
+  let total = 0
+  for (let seed = 1; seed <= 6; seed++) {
+    drive(seed, 500, (value, owed, engine) => {
+      if (owed) return
+      const t = engine.s.target
+      if (!t) return
+      // The route the target is made of RIGHT NOW — recomputed here out of the
+      // two exported pure functions rather than read off the engine, so this
+      // measures the emitter against the arithmetic and not against itself.
+      const bag = bagOf(polyps(engine.s.board).map((p) => p.value))
+      const route = routeIn(bag, t.value, t.form, t.slots) ?? ladderRoute(t.value, t.form, t.slots)
+      if (!route) return
+      const mine = decompose(value)?.strain
+      const wanted = new Set(route.map((v) => decompose(v)?.strain))
+      total++
+      if (wanted.has(mine)) onRoute++
+    })
+  }
+  assert.ok(total > 200, `only ${total} ambient emissions measured`)
+  const share = onRoute / total
+  console.log(
+    `   ${onRoute} of ${total} ambient arrivals (${(share * 100).toFixed(1)}%) were on a strain ` +
+      `the target can use`,
+  )
+  // A polyp's strain is its odd part and merging only doubles, so a strain the
+  // target does not use can never take part in answering it. Most of what arrives
+  // must be able to; one draw in four is deliberately wider, because a shelf
+  // carrying two strains is a shelf where every polyp is a duplicate.
+  assert.ok(share > 0.6, `only ${(share * 100).toFixed(1)}% of arrivals could take part in the answer`)
+})
+
+/* ------------------------------------------------ the invariant, over real play */
+
+test('no state a child can reach is unsolvable, over many seeds and every form', () => {
+  let worstIdle = 0
+  let worstSeed = 0
+  let early = 0
+  for (let seed = 1; seed <= 16; seed++) {
+    const engine = playSession(seed, 2500, (e, where) => {
+      assert.ok(
+        e.solvable(),
+        `seed ${seed}: unsolvable after ${where} — target ${e.s.target?.value} ` +
+          `(${e.s.target?.form}), owes [${e.s.stock.join(', ')}], shelf [${polyps(e.s.board)
+            .map((p) => p.value)
+            .sort((a, b) => a - b)
+            .join(', ')}]`,
+      )
+    })
+    if (engine.idle > worstIdle) {
+      worstIdle = engine.idle
+      worstSeed = seed
+    }
+    early = Math.max(early, engine.earlyIdle)
+    assert.ok(engine.depth > 60, `seed ${seed} only bloomed ${engine.depth} times in 2500 steps`)
+  }
+  console.log(
+    `   longest a single target ever stayed up: ${worstIdle} steps (seed ${worstSeed}); ` +
+      `${early} inside the first forty blooms`,
+  )
+  // The shipped build sat on ONE target for the whole run — 3,891 steps of a child
+  // looking at a number they could not make, which is 97% of the session. Two
+  // ceilings, because the interesting one is the early game: the founder was six
+  // blooms in, and a child who has not yet built a big reef has nothing to grind
+  // with. Later on a four-figure target legitimately IS a lot of joining, which is
+  // the game the founder asked for — big numbers are earned, never handed out.
+  assert.ok(early < 150, `a target stayed up ${early} steps inside the first forty blooms`)
+  assert.ok(
+    worstIdle < 833,
+    `a target stayed up for ${worstIdle} steps on seed ${worstSeed} — a third of the session`,
+  )
+})
+
+/* ----------------------------------------------------------------------- drivers */
+
+/** Run a session, reporting every emission. `owed` is true for a debt payment. */
+function drive(
+  seed: number,
+  steps: number,
+  onEmit: (value: number, owed: boolean, engine: Engine) => void,
+): Engine {
+  const host = makeStubHost({ seed: seed ^ 0x51ed })
+  const engine = makeEngine(host as never, seed)
+  engine.seed()
+  engine.ask()
+  for (let i = 0; i < steps; i++) {
+    const owed = engine.s.stock.length > 0
+    for (const ev of engine.tick(STEP_MS)) if (ev.kind === 'emit') onEmit(ev.value, owed, engine)
+    step(engine)
+  }
+  return engine
+}
+
+/** A whole session with the invariant checked after every single action. */
+function playSession(
+  seed: number,
+  steps: number,
+  check: (e: Engine, where: string) => void,
+): { depth: number; idle: number; earlyIdle: number } {
+  const host = makeStubHost({ seed: seed ^ 0x51ed })
+  const engine = makeEngine(host as never, seed)
+  engine.seed()
+  engine.ask()
+  check(engine, 'ask')
+  let idle = 0
+  let worst = 0
+  let early = 0
+  let lastDepth = 0
+  for (let i = 0; i < steps; i++) {
+    engine.tick(STEP_MS)
+    check(engine, 'tick')
+    step(engine, (where) => check(engine, where))
+    if (engine.s.depth !== lastDepth) {
+      lastDepth = engine.s.depth
+      idle = 0
+    } else {
+      idle++
+      if (idle > worst) worst = idle
+      if (engine.s.depth < 40 && idle > early) early = idle
+    }
+  }
+  return { depth: engine.s.depth, idle: worst, earlyIdle: early }
+}
+
+/**
+ * One turn a child could take: feed the route, else join a pair, else split,
+ * else press CLEAR. `after` runs between every single engine call.
+ */
+function step(engine: Engine, after: (where: string) => void = () => {}): void {
+  const s = engine.s
+  if (!s.target) return
+  const bag = bagOf(polyps(s.board).map((p) => p.value))
+  const route = s.mouth.fed.length === 0 ? routeIn(bag, s.target.value, s.target.form, s.target.slots) : null
+  if (route) {
+    for (const want of route) {
+      const cell = polyps(s.board).find((p) => p.value === want)?.cell
+      if (cell === undefined) break
+      engine.feed(cell)
+      after('a feed')
+      if (s.mouth.fed.length === 0) break // the mouth resolved
+    }
+    return
+  }
+  // Joins are made TOWARD the number at the top, which is what a child does and
+  // what the shipped bots did not: joining the largest pair on the shelf every
+  // time climbs away from the answer and turns an ordinary target into a grind.
+  const want = ladderRoute(s.target.value, s.target.form, s.target.slots) ?? []
+  const ceiling = want.reduce((a, b) => Math.max(a, b), 0)
+  const byValue = new Map<number, number[]>()
+  for (const p of polyps(s.board)) {
+    const list = byValue.get(p.value) ?? []
+    list.push(p.cell)
+    byValue.set(p.value, list)
+  }
+  const pairs = [...byValue.keys()].filter((v) => (byValue.get(v) ?? []).length >= 2)
+  const useful = pairs.filter((v) => v * 2 <= ceiling).sort((a, z) => z - a)
+  for (const v of [...useful, ...pairs.sort((a, z) => a - z)]) {
+    const cells = byValue.get(v)
+    if (!cells || cells.length < 2) continue
+    if (engine.merge(cells[0] as number, cells[1] as number)) {
+      after('a join')
+      return
+    }
+  }
+  if (emptyCells(s.board).length < 2 || !hasLegalMerge(s.board)) {
+    engine.dissolve()
+    after('CLEAR')
+    return
+  }
+  const half = polyps(s.board)
+    .filter((p) => canSplit(p.value))
+    .sort((a, z) => z.value - a.value)[0]
+  if (half) {
+    engine.split(half.cell)
+    after('a split')
+  }
+}
+
+/** Kept honest: `place` and `at` are the shelf's only writers. */
+void place
+void at

--- a/dynawalla/games/merge-idle/src/core/target.test.ts
+++ b/dynawalla/games/merge-idle/src/core/target.test.ts
@@ -148,6 +148,13 @@ test('stockFor asks for HALVES, so a missing term arrives as a merge to do', () 
   assert.deepEqual(stockFor(bagOf([16]), [16, 2]), [1, 1])
   // ...and two of a term needs two of it on the shelf.
   assert.deepEqual(stockFor(bagOf([16]), [16, 16]), [8, 8])
+  // A HALF that is already on the shelf is not asked for again. The debt is
+  // recomputed after every move now, so a shelf halfway through paying one is the
+  // normal case — and asking for both halves again fills the board with duplicates
+  // of the polyp the child was one drag away from making.
+  assert.deepEqual(stockFor(bagOf([8]), [16]), [8], 'one half held, one half owed')
+  assert.deepEqual(stockFor(bagOf([8, 8]), [16]), [], 'both halves held, nothing owed')
+  assert.deepEqual(stockFor(bagOf([1, 8]), [16, 2]), [8, 1], 'each term credited separately')
 })
 
 test('a stocked route becomes buildable once the stock has landed', () => {

--- a/dynawalla/games/merge-idle/src/core/target.ts
+++ b/dynawalla/games/merge-idle/src/core/target.ts
@@ -289,15 +289,27 @@ export function formsFor(
  */
 export function stockFor(bag: Bag, route: readonly number[]): number[] {
   const spare = new Map(bag)
+  const take = (v: number): boolean => {
+    const held = spare.get(v) ?? 0
+    if (held <= 0) return false
+    spare.set(v, held - 1)
+    return true
+  }
   const out: number[] = []
   for (const term of route) {
-    const held = spare.get(term) ?? 0
-    if (held > 0) {
-      spare.set(term, held - 1)
+    if (take(term)) continue
+    if (!canSplit(term)) {
+      out.push(term)
       continue
     }
-    if (canSplit(term)) out.push(term / 2, term / 2)
-    else out.push(term)
+    // Halves the shelf ALREADY holds are not asked for again. Without this the
+    // debt is recomputed from a shelf that is halfway through paying it, the reef
+    // emits the same halves a second time, and a board that was one merge from the
+    // answer fills up with duplicates of it instead.
+    const half = term / 2
+    let owed = 2
+    while (owed > 0 && take(half)) owed--
+    for (let i = 0; i < owed; i++) out.push(half)
   }
   return out
 }

--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -135,9 +135,10 @@ const INSTRUCTIONS = (reducedMotion: boolean): InstructionsSpec => ({
     {
       heading: 'When the reef is full',
       lines: [
-        'If every space is full and no two numbers match, the CLEAR button starts glowing.',
+        'When the reef runs out of room, the CLEAR button starts glowing.',
         'Press it. It is free.',
-        'It clears away all the smallest polyps to make room.',
+        'It clears away the smallest polyps until there is real room again.',
+        'Then the reef grows the polyps your number needs.',
         'You can never get stuck. CLEAR always works.',
       ],
     },
@@ -940,8 +941,10 @@ export class Game {
       this.hud.setFace(face, `rgba(${hue[0]},${hue[1]},${hue[2]},.55)`)
     }
     this.hud.setMeter(s.depth % GROW_EVERY, GROW_EVERY, hex(hue))
-    const full = emptyCells(s.board).length === 0
-    this.hud.setDissolve(full || s.crowded, s.crowded)
+    // Offered the moment the shelf has less room than the reef needs to pay what
+    // it owes — not once the board has jammed solid. Waiting for the jam is a
+    // minute of a child watching nothing happen with the way out greyed out.
+    this.hud.setDissolve(this.engine.needsRoom, s.crowded)
 
     if (this.debug) {
       const n = this.fpsSamples.length

--- a/dynawalla/games/merge-idle/src/qa/ask.test.ts
+++ b/dynawalla/games/merge-idle/src/qa/ask.test.ts
@@ -73,17 +73,24 @@ test('EVERY target ever put up is buildable — the design mistake, gone', () =>
 
 test('a target the shelf cannot answer yet always arrives with the polyps it needs', () => {
   let unreachable = 0
-  let unstocked = 0
+  let stocking = 0
+  const dead: string[] = []
   for (const t of targets()) {
-    if (t.reachable) continue
-    unreachable++
-    // Not on the shelf yet is fine and normal — the reef is coughing up the halves.
-    // Not on the shelf AND nothing owed would be a dead target.
-    if (t.stock === 0) unstocked++
+    // Not literally on the shelf is fine and normal, and covers two good cases:
+    // the reef is coughing up the halves, OR the child already holds the material
+    // and has a merge to do. `solvable` is the one that has to hold, every time —
+    // asserting `stock > 0` instead used to look like the same statement, and it
+    // is not: it fails a shelf that is one join away from the answer.
+    if (!t.reachable) unreachable++
+    if (t.stock > 0) stocking++
+    if (!t.solvable) dead.push(`${t.value} (${t.form}) at depth ${t.depth}, owes ${t.stock}`)
   }
   const pct = (100 * unreachable) / Math.max(1, targets().length)
-  console.log(`   ${pct.toFixed(1)}% of targets needed stocking when they went up`)
-  assert.equal(unstocked, 0, `${unstocked} targets were neither buildable nor being stocked`)
+  console.log(
+    `   ${pct.toFixed(1)}% of targets were not literally on the shelf; ` +
+      `${((100 * stocking) / Math.max(1, targets().length)).toFixed(1)}% arrived with a debt`,
+  )
+  assert.deepEqual(dead.slice(0, 8), [] as string[], `${dead.length} targets could not be won`)
 })
 
 /* ---------------------------------------------------------- the distribution */

--- a/dynawalla/games/merge-idle/src/qa/play.ts
+++ b/dynawalla/games/merge-idle/src/qa/play.ts
@@ -43,6 +43,12 @@ export type Report = {
     viaHost: boolean
     /** True when the shelf could already build it the moment it went up. */
     reachable: boolean
+    /**
+     * True when the child could still WIN from here — the shelf holds the answer,
+     * or holds the material to merge and split its way to it, or the reef owes the
+     * rest and has room to pay. See `Engine.solvable`.
+     */
+    solvable: boolean
     /** How many polyps the reef still owed the shelf when it went up. */
     stock: number
   }>
@@ -109,6 +115,7 @@ export function play(o: { policy: Policy; seed: number; steps?: number }): Repor
       depth: engine.s.depth,
       viaHost: t.questionId !== null,
       reachable: engine.reachable(),
+      solvable: engine.solvable(),
       stock: engine.s.stock.length,
     })
   }


### PR DESCRIPTION
The founder played 0.3.7 and was handed a board he could not win:

> the board fills up with high numbers and it becomes impossible `10 = ___ - ___` .... then I hit clear and one goes away and the next polyp to come .. is 18 .. the polyps should start as low numbers
>
> `____ + ____ = 5` and EVERY FREAKING NUMBER is like above 18

Three separate faults met to make that board, and `game.ts` was telling him **"You can never get stuck. CLEAR always works."** the whole time.

## 1. Emission is step 0, forever

A fresh polyp was `strain * 2 ** baseStepFor(depth)` — a floor that rose with the session, never came back down, and never once consulted the number the child was being asked for. Past six blooms it could not produce an **odd number at all**, and a sum of even polyps is even, so `5` was arithmetically unmakeable no matter how long he played. His 18 is `9 × 2`, his 44 is `11 × 4`, his 88 is `11 × 8` — legal ladder values at a rung that makes them furniture. And a big polyp on a full shelf cannot even be SPLIT back down, because a split needs a free cell.

**There is no depth→value coupling left in this game.** Every ambient polyp is a bare seed at every depth: `1, 3, 5, 7, 9, 11, 13, 15`. Big numbers are EARNED by merging and are never handed out. What escalates is the target, the operator form and the size of the shelf — none of which can fill a board with numbers no answer can use.

The **strain** is drawn from the terms the current target is made of, three times in four. A polyp's strain is its odd part and merging only doubles, so a strain-5 polyp can only ever become 11, 22, 44, 88 — the strains a target needs are *exactly* the polyps that can take part in answering it. Measured: **80.1% of ambient arrivals land on a strain the live target can use** (was ~15% with a flat pool). Among those, the strain the shelf holds fewest of wins, because a flat pick put thirty 1s on a forty-cell shelf and "I want to see 1,3,5,7" is a spread, not a monoculture.

The reef's **debt** is the one exception, and it is derived from the number being asked for: the halves it owes so the target is buildable at all. That is the mechanism that makes a big target reachable without spawning big polyps.

## 2. The debt is recomputed after every move

It used to be worked out once, when the target went up, and again only on a spill. A child who joined the last term of their own route into something bigger — a legal, ordinary, sensible move — left the target unbuildable **with the reef owing nothing**, and ambient emission cheerfully filled the shelf with numbers that could not be part of any answer.

`settle()` now runs after every change to the shelf (merge, split, move, feed, spill, CLEAR, emission), and `canAfford` is the gate: a strain never converts into another strain, and within a strain everything is fungible under merge and split, so a route is affordable exactly when every strain it calls for is covered in seeds. A shelf holding a `40` and two `2`s can reach `36 = 40 − 4` and is owed nothing; a shelf with no 5-ladder polyp on it cannot reach `5` by any means and is owed one.

## 3. CLEAR is an escape

`purgeLowest` cleared one value class, which on a shelf of forty distinct numbers is **one cell** — refilled on the next breath. `purgeUpTo` goes up the values until there is room for the worst debt the reef can owe plus slack to work in. It is offered the moment the shelf has less room than a debt could need, not once the board has jammed solid.

The escape is sized by a constant rather than by `stock.length`, because on the founder's own board **the clearing is what creates the debt** — CLEAR takes away the last small polyp, so a target that was answerable a moment ago now needs stocking, and sizing against the debt as it stood *before* the purge left the shelf one cell short.

The manual now says what the game does, and the claim it makes is true.

## The reproducing test

`src/core/stuck.test.ts`. `the founder's board` puts his position on the real `Engine` through public methods only — `restore`, `ask`, `merge`, `feed`, `dissolve`, `tick` — and drives a patient child for 400 turns, CLEAR included.

**On this branch's parent, seed `20260728`:**

```
✖ the founder's board: 5 = ▢ + ▢ + ▢ on a shelf of nothing under 18
  AssertionError: 5 never became makeable. shelf:
  [6, 8, 10, 12, 16, 24, 32, 48, 52, 64, 88, 96, 120, 128, 192, 256, 384,
   512, 768, 896, 960, 1152, 1408, 1664]
```

Every polyp on that shelf is even. The target is 5. It is not hard, it is impossible.

The property test drives 16 seeded sessions of 2,500 turns against the realistic stub host and asserts `solvable()` **after every single action** — feed, join, split, CLEAR, tick. Over the whole matrix the longest a single target ever stayed up is 688 turns, and 57 inside the first forty blooms. The shipped build sat on one target for **3,891 of 4,000 turns**, 97% of the session.

## The seed set

Shipped **eight** seeds (1, 3, 5, 7, 9, 11, 13, 15), not the four the founder named. The four he remembers are the ones he will now actually see — with step-0 emission the shelf is seeds — but narrowing the *ladder* to four would break buildability, and the measurement is already in `core/ladder.ts`: as a sum of at most three polyps, seeds `1,3,5,7` cover **94.4%** of 1..1000 with the first hole at 585, while all eight cover **100.0%**. Eight is also what makes his own examples legal: `35 = 20 + 10 + 5` needs strain 2, and `15 = 30 ÷ 2` needs a 30, whose odd part is 15 and which does not exist on a four-seed ladder at all. Merging is unaffected by the change — the lattice above the seeds is identical.

## Verification

- `npm run -s tsc` clean; `npm run -s test` **5× consecutively, 1079/1079**.
- `node packs/build.mjs merge-idle` builds and passes the SDK checker (3 files, 113,212 bytes, `items`/`items.reveal`/`haptics`/`storage`, 8 skills).
- One pre-existing assertion in `qa/ask.test.ts` was *wrong after the fix* and was replaced rather than relaxed: it demanded `stock > 0` for any target not literally on the shelf, which now fails a shelf that is one join away from the answer. It asserts `solvable` instead — the statement it was trying to make.

### Mutation transcript

Every new assertion was broken and confirmed to fail.

| # | Mutation | Result |
|---|---|---|
| M1 | `EMIT_STEP = 0` → `1` (the shipped depth-driven emitter) | ✖ `the reef never coughs out anything but a seed`, ✖ `no state a child can reach is unsolvable` |
| M2 | drop `this.restock()` from `settle()` | ✖ `AssertionError: the reef must owe the five` |
| M3/M7 | CLEAR back to `purgeLowest` | ✖ `CLEAR left 1 cells, which is under the 8 a debt can need — not an escape` |
| M4 | `needsRoom` back to `emptyCells === 0` | ✖ `AssertionError: one free cell is not room` |
| M5 | strain pool always the whole ladder | ✖ `only 15.5% of arrivals could take part in the answer`, ✖ `no state a child can reach is unsolvable` |
| M6 | `stockFor` loses its half-awareness | ✖ `one half held, one half owed` — `actual: [8, 8]` |
| M8 | `canAfford` always true (does `solvable()` rubber-stamp?) | ✖ `AssertionError: the reef must owe the five` |

M4 **survived its first attempt** — the assertion was vacuous, checking `needsRoom` only on a completely full shelf, which is true under both. Rewritten against a shelf with exactly one free cell; it now fails as shown.

M2 also survived the property test, which is worth saying out loud: with step-0 emission in place the strain pool alone rescues most boards, so the restock guard is belt-and-braces there. It is load-bearing — and pinned — on a shelf that genuinely lacks the strain, which is the founder's board.

## Not done, deliberately

- **The lost juice.** He also said it "is not as juicy and fun as it was". I read the pre-rebuild implementation: `fx/` and `audio/` are byte-identical, `drawPolyps` is unchanged, and the new build has *more* on merge and bloom than the old one. What the rebuild removed from the renderer is `drawVents`, `drawChips` and `drawSwell` — the two-games-on-one-screen he asked to be deleted. My read is that the missing juice was **mechanical**: a merge game whose board is forty distinct huge values has no merges in it, so no chains, no shockwaves, no freeze frames. Step-0 emission with a target-drawn strain puts pairs back on the shelf, which is what all of that hangs off. Worth him playing before anyone adds effects.
- **Big values still arrive as a reef debt.** Ambient emission is capped at the seeds, but `stockFor` hands over halves of route terms, and at depth a term can be large. It is target-derived and it is what makes a big target reachable at all without a thousand merges. Flagging it rather than changing it — it is a difficulty-curve question (`DIFFICULTY_CAP`, `wantDigitsAt`), not a correctness one, and out of scope here.
- **Late-game grind.** A four-figure target legitimately is a lot of joining now that nothing big is handed out. The property test bounds the early game hard (150 turns inside the first forty blooms) and the late game loosely (833). If a real child finds the late game slow, the lever is the target size, not the emitter.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb