### PR TITLE
chore(dynawalla): 0.3.8

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.7 → 0.3.8.

- **#750 ABYSSAL BLOOM** — emission is step 0 forever; big numbers are earned by merging, never handed out. Past depth 6 the old emitter could not produce an odd number at all, so `5 = □ + □` on a shelf of evens was impossible, not hard — a probe found targets stuck for **97% of a session**. CLEAR now keeps the promise the manual already made.
- **#749** — THE GRAPPLE FOUNDRY and THE GAVEL retired, 28 packs → 26. Redesigns preserved in #746 and #744. Already-installed copies stay installed and playable; pack sync is additive by design.
- **#748** — a revealed answer is held until the child dismisses it, rather than flashed.

A main push does not release. The tag `dynawalla-v0.3.8` does.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb