### PR TITLE
dynawalla/games/serpent: the board is the screen — the vent is now an ellipse inscribed in the safe box

### DIFF
--- a/dynawalla/games/serpent/src/game/arena.test.ts
+++ b/dynawalla/games/serpent/src/game/arena.test.ts
@@ -1,0 +1,347 @@
+/**
+ * The shape of the vent, checked against something that is not itself.
+ *
+ * The arena stopped being a circle: it is the ellipse inscribed in the safe
+ * rectangle, so the board is the screen. That is a one-line change to a constant
+ * and a real change to the *physics*, because on a circle "how far is the wall",
+ * "which way does it face" and "where is the nearest legal spot inside it" are
+ * `Math.hypot` and on an ellipse they are the root of a quartic. Those three
+ * answers decide where a child dies, where they are paid for grazing, and where
+ * an orb is allowed to appear, so every one of them is checked here against a
+ * **brute-force sweep of the rim** rather than against a rearrangement of the
+ * same algebra.
+ *
+ * The other half is the promise the change was made for and the promise it must
+ * not break at the same time: the rim reaches the ends of the screen, and no part
+ * of it — through the worst shake and the peak of the camera's punch — leaves the
+ * safe box. Both are asserted at the five viewports the rest of the pack is held
+ * at, with and without a cutout.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { NO_INSETS, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts";
+import {
+  ARENA_FILL,
+  MAX_ARENA_ASPECT,
+  arenaAspect,
+  arenaScale,
+  closestOnRim,
+  insideRim,
+  pullInside,
+  rimEdge,
+} from "./arena.ts";
+import { addTrauma, createCamera, punch, updateCamera } from "./fx/camera.ts";
+import { TAU } from "./num.ts";
+import { TUNE } from "./tuning.ts";
+
+/* -------------------------------------------------------------------------- */
+/* The geometry, against a sweep.                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The nearest point on the rim, found by looking at 60,000 of them.
+ *
+ * Dumb on purpose. It can only ever be *worse* than the true minimum, so
+ * "`closestOnRim` is no further than this" is a real bound and not a tolerance —
+ * an implementation that lands on the wrong side of the ellipse, or stops
+ * iterating, is further away and this catches it.
+ */
+function sweepNearest(a: number, b: number, px: number, py: number): number {
+  let best = Infinity;
+  const N = 60000;
+  for (let i = 0; i < N; i++) {
+    const t = (i / N) * TAU;
+    const d = Math.hypot(a * Math.cos(t) - px, b * Math.sin(t) - py);
+    if (d < best) best = d;
+  }
+  return best;
+}
+
+/** Every shape the game can be in, from a square to the cap, at both vent sizes. */
+const SHAPES: Array<[number, number]> = [];
+for (const r of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
+  for (const k of [1, 1.2, 1.777, 2.165, MAX_ARENA_ASPECT]) {
+    SHAPES.push([r, r * k]);
+    if (k !== 1) SHAPES.push([r * k, r]);
+  }
+}
+
+/** Points worth asking about: the middle, the axes, off-axis, and well outside. */
+function probes(a: number, b: number): Array<[number, number]> {
+  const out: Array<[number, number]> = [[0, 0]];
+  for (const f of [0.01, 0.35, 0.9, 0.99, 1, 1.05, 1.6]) {
+    for (let i = 0; i < 12; i++) {
+      const t = (i / 12) * TAU + 0.11;
+      out.push([Math.cos(t) * a * f, Math.sin(t) * b * f]);
+    }
+  }
+  return out;
+}
+
+test("the nearest point on the rim is on the rim, and nothing on the rim is nearer", () => {
+  for (const [a, b] of SHAPES) {
+    for (const [px, py] of probes(a, b)) {
+      const c = closestOnRim(a, b, px, py);
+      const on = (c.x / a) ** 2 + (c.y / b) ** 2;
+      assert.ok(
+        Math.abs(on - 1) < 1e-9,
+        `a=${a} b=${b} from (${px.toFixed(3)},${py.toFixed(3)}): the "nearest point on the rim" ` +
+          `is not on the rim — x²/a²+y²/b² = ${on}`,
+      );
+      const mine = Math.hypot(px - c.x, py - c.y);
+      const swept = sweepNearest(a, b, px, py);
+      assert.ok(
+        mine <= swept + 1e-9,
+        `a=${a} b=${b} from (${px.toFixed(3)},${py.toFixed(3)}): a sweep of the rim found a point ` +
+          `${swept.toFixed(9)} away and closestOnRim settled for ${mine.toFixed(9)}`,
+      );
+    }
+  }
+});
+
+test("the rim's normal is the unit outward normal, and the query sits on it", () => {
+  for (const [a, b] of SHAPES) {
+    for (const [px, py] of probes(a, b)) {
+      const e = rimEdge(a, b, px, py);
+      const len = Math.hypot(e.nx, e.ny);
+      assert.ok(Math.abs(len - 1) < 1e-9, `a=${a} b=${b}: the normal is ${len} long, not 1`);
+      // Outward: stepping along it leaves the ellipse, stepping back stays in.
+      assert.ok(
+        !insideRim(a, b, e.x + e.nx * 1e-6, e.y + e.ny * 1e-6),
+        `a=${a} b=${b}: the normal points INTO the vent`,
+      );
+      assert.ok(insideRim(a, b, e.x - e.nx * 1e-6, e.y - e.ny * 1e-6));
+      // The foot of a perpendicular: the query lies on the normal line.
+      const cross = e.nx * (py - e.y) - e.ny * (px - e.x);
+      assert.ok(
+        Math.abs(cross) < 1e-7,
+        `a=${a} b=${b} from (${px.toFixed(3)},${py.toFixed(3)}): the query is ${cross} off the ` +
+          `normal line, so the "nearest" point is not a foot of a perpendicular`,
+      );
+      // The sign of the gap is the side of the wall you are on. Asked only of
+      // points that are on a side: a probe placed exactly ON the rim has a gap of
+      // zero and rounds either way, which is not a fact about the shape.
+      if (Math.abs(e.gap) > 1e-9) {
+        assert.equal(e.gap > 0, insideRim(a, b, px, py), `a=${a} b=${b}: the gap's sign is inside-out`);
+      }
+      assert.ok(
+        Math.abs(Math.abs(e.gap) - Math.hypot(px - e.x, py - e.y)) < 1e-12,
+        "the gap is not the distance to the point it names",
+      );
+    }
+  }
+});
+
+/** Every clearance the game asks the shape for, largest last. */
+const MARGINS: Array<[string, number]> = [
+  ["the graze band", TUNE.grazeBand],
+  ["a head thrown off the wall", TUNE.headRadius * 1.6],
+  ["an orb held off the wall", TUNE.orbRadius * 1.1],
+  ["an orb's spawn clearance", TUNE.orbRadius * 2.2],
+];
+
+test("pullInside puts a body exactly its margin inside, whatever the shape", () => {
+  for (const [a, b] of SHAPES) {
+    for (const [what, m] of MARGINS) {
+      for (const [px, py] of probes(a, b)) {
+        const p = pullInside(a, b, px, py, m);
+        const gap = rimEdge(a, b, p.x, p.y).gap;
+        assert.ok(
+          gap >= m - 1e-9,
+          `a=${a} b=${b}, ${what} (${m}): (${px.toFixed(3)},${py.toFixed(3)}) was put at ` +
+            `(${p.x.toFixed(3)},${p.y.toFixed(3)}), which is ${gap.toFixed(6)} from the wall`,
+        );
+      }
+    }
+  }
+});
+
+test("the aspect cap is what keeps pullInside exact", () => {
+  // Walking `m` back along the normal lands exactly `m` inside only while `m` is
+  // under the smallest radius of curvature the ellipse has. That is the real
+  // reason MAX_ARENA_ASPECT exists, and it is worth the smallest vent and the
+  // largest margin the game can put together.
+  const short = TUNE.arenaFloor;
+  const long = TUNE.arenaFloor * MAX_ARENA_ASPECT;
+  const tightest = (short * short) / long;
+  const worst = Math.max(...MARGINS.map(([, m]) => m));
+  assert.ok(
+    tightest > worst * 1.3,
+    `at the vent floor and the aspect cap the rim's tightest radius of curvature is ` +
+      `${tightest.toFixed(4)} and the game asks for ${worst.toFixed(4)} of clearance — ` +
+      `the offset stops being exact`,
+  );
+});
+
+/* -------------------------------------------------------------------------- */
+/* The board is the screen — and stays inside it.                             */
+/* -------------------------------------------------------------------------- */
+
+const PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
+const LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
+
+/** The five the HUD and the prompt are held at. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+];
+
+function insetsFor(w: number, h: number): Array<[string, Insets]> {
+  return [
+    ["no insets", NO_INSETS],
+    w > h ? ["cutout at the side", LANDSCAPE] : ["cutout at the top", PORTRAIT],
+  ];
+}
+
+/**
+ * What the camera can actually do to the picture, measured by running it.
+ *
+ * Hand-derived numbers are how a margin goes stale. `prompt.ts` records that this
+ * spring undershoots to 0.990 for exactly the same reason; this takes the other
+ * end of it, and the shake, off the shipping code.
+ */
+function cameraExtremes(): { zoom: number; shake: number } {
+  const cam = createCamera(false);
+  const biggest = Math.max(TUNE.punchEat, TUNE.punchWrong, TUNE.punchDepth, TUNE.punchDeath);
+  punch(cam, biggest);
+  addTrauma(cam, 1);
+  let zoom = 1;
+  let shake = 0;
+  for (let i = 0; i < 1200; i++) {
+    updateCamera(cam, 1 / 240);
+    zoom = Math.max(zoom, cam.zoom);
+    shake = Math.max(shake, Math.abs(cam.shakeX), Math.abs(cam.shakeY));
+  }
+  return { zoom, shake };
+}
+
+/**
+ * The furthest ink `scene.ts: drawRim` puts from the centre, on one axis.
+ *
+ * Mirrors the draw calls: the rim stroke straddles the semi-axis by half its
+ * width, and the polyps ride at `1.012` of it with half a sprite beyond that.
+ * The soft halo is deliberately not here — it is a radial gradient that has faded
+ * out before it reaches its own edge, it is not a wall, and the 0.44 circle this
+ * replaces let it past the safe box too.
+ */
+function rimReach(semiAxisPx: number, S: number): number {
+  const stroke = semiAxisPx + Math.max(2.5, S * (0.014 + 0.016)) / 2;
+  const polyps = semiAxisPx * 1.012 + (S * 0.016 * 1.4) / 2;
+  return Math.max(stroke, polyps);
+}
+
+test("no part of the rim ever leaves the safe box", () => {
+  const cam = cameraExtremes();
+  for (const [name, vw, vh] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(vw, vh)) {
+      const safe = safeRect(vw, vh, insets);
+      const scale = arenaScale(safe.w, safe.h);
+      const aspect = arenaAspect(safe.w, safe.h);
+      const cx = safe.x + safe.w / 2;
+      const cy = safe.y + safe.h / 2;
+      for (const arenaR of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
+        const S = scale * cam.zoom;
+        const jitter = cam.shake * scale;
+        const rx = rimReach(arenaR * aspect.x * S, S) + jitter;
+        const ry = rimReach(arenaR * aspect.y * S, S) + jitter;
+        const where = `${name} (${vw}x${vh}), ${label}, vent ${arenaR}`;
+        assert.ok(cx - rx >= safe.x - 1e-9, `${where}: the rim crosses the left inset by ${(safe.x - (cx - rx)).toFixed(2)}px`);
+        assert.ok(cx + rx <= safe.x + safe.w + 1e-9, `${where}: the rim crosses the right inset by ${(cx + rx - safe.x - safe.w).toFixed(2)}px`);
+        assert.ok(cy - ry >= safe.y - 1e-9, `${where}: the rim crosses the top inset by ${(safe.y - (cy - ry)).toFixed(2)}px`);
+        assert.ok(cy + ry <= safe.y + safe.h + 1e-9, `${where}: the rim crosses the bottom inset by ${(cy + ry - safe.y - safe.h).toFixed(2)}px`);
+      }
+    }
+  }
+});
+
+test("the board really is the screen, on every shape of screen", () => {
+  // The assertion the founder asked for, and the one a revert cannot pass: the
+  // vent spans ARENA_FILL of the safe box on BOTH axes, not on the short one with
+  // dead black bands on the other. A disc sized off the short side spans that
+  // fraction of the short side and a much smaller fraction of the long one.
+  for (const [name, vw, vh] of VIEWPORTS) {
+    for (const [label, insets] of insetsFor(vw, vh)) {
+      const safe = safeRect(vw, vh, insets);
+      const scale = arenaScale(safe.w, safe.h);
+      const aspect = arenaAspect(safe.w, safe.h);
+      const where = `${name} (${vw}x${vh}), ${label}`;
+      const spanX = TUNE.arenaStart * aspect.x * scale * 2;
+      const spanY = TUNE.arenaStart * aspect.y * scale * 2;
+      assert.ok(
+        Math.abs(spanX / safe.w - ARENA_FILL) < 1e-9,
+        `${where}: the vent is ${((spanX / safe.w) * 100).toFixed(1)}% of the safe width, not ${ARENA_FILL * 100}%`,
+      );
+      assert.ok(
+        Math.abs(spanY / safe.h - ARENA_FILL) < 1e-9,
+        `${where}: the vent is ${((spanY / safe.h) * 100).toFixed(1)}% of the safe height, not ${ARENA_FILL * 100}%`,
+      );
+      // And the fit the condition is measured against is still the disc inside
+      // the ellipse, so `arenaR × scale` has to stay the SHORT semi-axis.
+      assert.equal(Math.min(aspect.x, aspect.y), 1, `${where}: the short semi-axis is no longer arenaR`);
+    }
+  }
+});
+
+test("the shape reaches the renderer and the run, and by no other route", () => {
+  // Source-level for the same reason `prompt.test.ts` is: `createRenderer` needs a
+  // canvas and there is none in Node. Two half-done states this guards, and both
+  // compile clean and look almost right:
+  //
+  //   · `mount.ts` never tells the world its shape, so the simulation stays a
+  //     circle, the renderer draws that circle, and the whole change ships as a
+  //     4% larger disc that nobody asked for;
+  //   · the simulation is an ellipse and the renderer still strokes a circle, so
+  //     the drawn wall and the wall a child dies against are different curves.
+  const here = dirname(new URL(import.meta.url).pathname);
+  const mount = readFileSync(join(here, "mount.ts"), "utf8");
+  assert.ok(
+    /setArenaAspect\(\s*world,\s*renderer\.view\.safe\.w,\s*renderer\.view\.safe\.h\s*\)/.test(mount),
+    "mount.ts no longer fits the vent to the measured safe box — the arena is a circle again",
+  );
+
+  const scene = readFileSync(join(here, "render", "scene.ts"), "utf8");
+  assert.ok(
+    scene.includes("arenaScale(safe.w, safe.h)"),
+    "scene.ts sizes the arena itself again — that expression is `arenaScale` now, and a second " +
+      "copy of it is how the renderer and the shape part company",
+  );
+  assert.ok(
+    scene.includes("w.arenaR * w.aspectX * S") && scene.includes("w.arenaR * w.aspectY * S"),
+    "scene.ts draws the arena off one radius again, so it is a circle inside an elliptical vent",
+  );
+  assert.ok(
+    scene.includes("g.ellipse(X(0), Y(0), aX, aY, 0, 0, TAU)"),
+    "the arena's clip is not the arena's shape",
+  );
+  assert.ok(
+    scene.includes("g.ellipse(cx, cy, aX, aY, 0, a0, a1)"),
+    "the rim a child steers against is still stroked as a circle",
+  );
+});
+
+test("an absurd surface produces a shape, not a NaN", () => {
+  // A pack frame can be resized to anything, and a safe box can go to nothing.
+  for (const [w, h] of [
+    [0, 0],
+    [1, 1],
+    [320, 4000],
+    [4000, 320],
+    [200, 60],
+  ] as const) {
+    const s = arenaScale(w, h);
+    const k = arenaAspect(w, h);
+    assert.ok(Number.isFinite(s) && s > 0, `${w}x${h}: the scale is ${s}`);
+    assert.ok(Number.isFinite(k.x) && Number.isFinite(k.y), `${w}x${h}: the aspect is NaN`);
+    assert.equal(Math.min(k.x, k.y), 1, `${w}x${h}: neither axis is the short one`);
+    assert.ok(Math.max(k.x, k.y) <= MAX_ARENA_ASPECT + 1e-12, `${w}x${h}: the aspect cap was passed`);
+    const e = rimEdge(TUNE.arenaFloor * k.x, TUNE.arenaFloor * k.y, 0, 0);
+    assert.ok(Number.isFinite(e.gap) && Number.isFinite(e.nx), `${w}x${h}: the rim went NaN at the centre`);
+  }
+});

--- a/dynawalla/games/serpent/src/game/arena.ts
+++ b/dynawalla/games/serpent/src/game/arena.ts
@@ -1,0 +1,195 @@
+/**
+ * The vent, as a shape.
+ *
+ * The arena used to be a circle sized off the **short** side of the safe box, so
+ * a phone held upright played inside a disc about 0.88 screens wide with two
+ * dead black bands above and below it. The founder asked the obvious question —
+ * why is the board not the screen — and the answer is that it now is: the vent
+ * is an **ellipse inscribed in the safe rectangle**, so it reaches the top and
+ * the bottom of a tall phone and the left and right of a wide one.
+ *
+ * ## Why the shape is a module and not a constant
+ *
+ * The rim is a wall a child can die against, and grazing it is worth points, so
+ * the boundary is not decoration: `world.ts` asks it three questions every
+ * simulated step — how far am I from the wall, which way is the wall facing, and
+ * where is the nearest legal spot inside it. On a circle all three were one line
+ * of arithmetic on `Math.hypot`. On an ellipse none of them are, because the
+ * nearest point on an ellipse is the root of a quartic, so the answers live here
+ * and are checked in `arena.test.ts` against a brute-force sweep of the rim.
+ *
+ * Everything is in world units: the arena's SHORT semi-axis is exactly
+ * `world.arenaR`, which is what makes this change feel like nothing on the axis
+ * the game was tuned on. The long semi-axis is `arenaR × aspect`; the serpent,
+ * the orbs and every radius in `TUNE` are untouched, and the pixels-per-world-unit
+ * scale stays isotropic, so the snake is still round and turns the same way in
+ * every direction. Only the room it swims in got bigger.
+ */
+
+import { clamp } from "./num.ts";
+
+/**
+ * How much of the safe box the arena's outer rim may use, per axis.
+ *
+ * The rim is not a hairline. Measured against what `scene.ts: drawRim` actually
+ * puts on the glass, and what `camera.ts` can do to it, the furthest ink from the
+ * centre on the short axis is
+ *
+ *   · the polyps, drawn at `1.012 × semiAxis` with a sprite `0.016 × scale` wide
+ *     at up to 1.4× its size, so a half-sprite of `0.0112 × scale` beyond that;
+ *   · all of it multiplied by `cam.zoom`, whose spring peaks at about 1.007
+ *     (`prompt.ts` records the matching 0.990 undershoot);
+ *   · plus `cam.shakeX × view.scale`, and `shakeMax` is 0.055.
+ *
+ * That is `1.0 × 1.007 × 1.012 + 0.0112 × 1.007 + 0.055 ≈ 1.086` semi-axes, so a
+ * fill of 0.9 puts the worst frame at `0.45 × 1.086 = 0.489` of the safe box's
+ * short side against a budget of 0.5 — the same margin the old 0.44 bought, held
+ * by `arena.test.ts` rather than by belief.
+ *
+ * The soft halo behind the rim is deliberately outside this: it is a radial
+ * gradient that is already transparent where it meets the edge, it is not
+ * something a child can steer into, and the shipped 0.44 arena let it out too.
+ */
+export const ARENA_FILL = 0.9;
+
+/**
+ * The most elongated the vent is allowed to get.
+ *
+ * Not taste — curvature. `pullInside` puts a body `m` inside the rim by walking
+ * `m` back along the surface normal, which is exact only while `m` stays under
+ * the smallest radius of curvature the ellipse has, `min(a,b)² / max(a,b)`. At
+ * the vent's floor (`TUNE.arenaFloor` = 0.62) that is `0.62 / aspect`, and the
+ * largest margin anything asks for is an orb's spawn clearance, `0.062 × 2.2 =
+ * 0.136`. So the shape stays exact up to an aspect of about 4.5, and this cap
+ * keeps a 50% margin on it.
+ *
+ * Nothing a person holds is anywhere near it — the tallest phone is about 2.2:1
+ * — but an iPad Slide Over is 3.7:1 and a pack frame can be resized to anything.
+ * Past the cap the ellipse simply stops growing along the long axis and the game
+ * is letterboxed, which is a smaller arena and never a wrong one.
+ */
+export const MAX_ARENA_ASPECT = 3;
+
+/** The arena's aspect: one axis is exactly 1, the other is the safe box's ratio. */
+export type Aspect = { x: number; y: number };
+
+/**
+ * Pixels per world unit, for a safe box.
+ *
+ * Isotropic on purpose. The stretch that fills the screen is in the arena's
+ * semi-axes, never in the transform — squeezing the canvas instead would make the
+ * serpent fat one way and thin the other and turn its turning circle into an egg.
+ */
+export function arenaScale(safeW: number, safeH: number): number {
+  return (Math.max(1, Math.min(safeW, safeH)) * ARENA_FILL) / 2;
+}
+
+/** The aspect of the ellipse inscribed in a safe box, short axis normalised to 1. */
+export function arenaAspect(safeW: number, safeH: number): Aspect {
+  const short = Math.max(1, Math.min(safeW, safeH));
+  const long = Math.max(1, Math.max(safeW, safeH));
+  const k = clamp(long / short, 1, MAX_ARENA_ASPECT);
+  return safeW >= safeH ? { x: k, y: 1 } : { x: 1, y: k };
+}
+
+/**
+ * The point on the rim nearest `(px, py)`.
+ *
+ * The evolute iteration: from a guess on the rim, step to the point whose normal
+ * line passes through the query, using the centre of curvature as the pivot. It
+ * is the standard construction and it converges quadratically. Six rounds, which
+ * is two more than the point where the eccentricities this game can produce stop
+ * moving; `arena.test.ts` checks the answer against an exhaustive sweep of the
+ * rim, and the count against the residual it leaves behind.
+ *
+ * Solved in the first quadrant and mirrored back, because the ellipse is
+ * symmetric in both axes and the iteration is only well behaved there.
+ */
+export function closestOnRim(a: number, b: number, px: number, py: number): { x: number; y: number } {
+  const sx = px < 0 ? -1 : 1;
+  const sy = py < 0 ? -1 : 1;
+  const qx0 = Math.abs(px);
+  const qy0 = Math.abs(py);
+  const aa = a * a;
+  const bb = b * b;
+  let tx = Math.SQRT1_2;
+  let ty = Math.SQRT1_2;
+  for (let i = 0; i < 6; i++) {
+    // The centre of curvature under the current guess — a point on the evolute.
+    const ex = ((aa - bb) * tx * tx * tx) / a;
+    const ey = ((bb - aa) * ty * ty * ty) / b;
+    const rx = a * tx - ex;
+    const ry = b * ty - ey;
+    const qx = qx0 - ex;
+    const qy = qy0 - ey;
+    const q = Math.hypot(qx, qy);
+    // The query sits exactly on the evolute: every direction is as good as any
+    // other and the next step would divide by zero. The guess in hand is already
+    // a nearest point.
+    if (q < 1e-12) break;
+    const r = Math.hypot(rx, ry);
+    tx = clamp((qx * (r / q) + ex) / a, 0, 1);
+    ty = clamp((qy * (r / q) + ey) / b, 0, 1);
+    const t = Math.hypot(tx, ty);
+    if (t < 1e-12) break;
+    tx /= t;
+    ty /= t;
+  }
+  return { x: a * tx * sx, y: b * ty * sy };
+}
+
+export type Edge = {
+  /** The nearest point on the rim. */
+  x: number;
+  y: number;
+  /** The outward unit normal of the rim there. */
+  nx: number;
+  ny: number;
+  /** Distance from the query to the rim: positive inside the vent, negative outside. */
+  gap: number;
+};
+
+/** Where the rim is from here, which way it faces, and how far away it is. */
+export function rimEdge(a: number, b: number, px: number, py: number): Edge {
+  const c = closestOnRim(a, b, px, py);
+  // The gradient of x²/a² + y²/b² points out of the ellipse.
+  let nx = c.x / (a * a);
+  let ny = c.y / (b * b);
+  const n = Math.hypot(nx, ny);
+  if (n > 1e-12) {
+    nx /= n;
+    ny /= n;
+  } else {
+    nx = 1;
+    ny = 0;
+  }
+  const d = Math.hypot(px - c.x, py - c.y);
+  const inside = (px / a) ** 2 + (py / b) ** 2 <= 1;
+  return { x: c.x, y: c.y, nx, ny, gap: inside ? d : -d };
+}
+
+/** Is this point inside the vent at all? */
+export function insideRim(a: number, b: number, px: number, py: number): boolean {
+  return (px / a) ** 2 + (py / b) ** 2 <= 1;
+}
+
+/**
+ * The nearest legal spot at least `margin` inside the rim.
+ *
+ * A point already deep enough is returned untouched; anything nearer (or outside)
+ * is put on the inward normal at exactly `margin`. Every "keep this thing off the
+ * wall" in the game goes through here, so a spawn, an orb bouncing off the edge
+ * and a serpent thrown back by a wall hit all agree about where the wall is —
+ * which is the whole failure mode a stretched arena invites.
+ */
+export function pullInside(
+  a: number,
+  b: number,
+  px: number,
+  py: number,
+  margin: number,
+): { x: number; y: number } {
+  const e = rimEdge(a, b, px, py);
+  if (e.gap >= margin) return { x: px, y: py };
+  return { x: e.x - e.nx * margin, y: e.y - e.ny * margin };
+}

--- a/dynawalla/games/serpent/src/game/mount.ts
+++ b/dynawalla/games/serpent/src/game/mount.ts
@@ -19,7 +19,7 @@ import { simDelta, updateCamera } from "./fx/camera.ts";
 import { createRenderer, type View } from "./render/scene.ts";
 import { hudLayout, soundTarget } from "./render/chrome.ts";
 import { drawHud } from "./render/hud.ts";
-import { confirmPressed, createWorld, setPaused, stepWorld, type World } from "./world.ts";
+import { confirmPressed, createWorld, setArenaAspect, setPaused, stepWorld, type World } from "./world.ts";
 import { clamp } from "./num.ts";
 
 const FIXED = 1 / 120;
@@ -69,6 +69,10 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
     // inset for two side ones, and iPadOS changes them when the pack is resized
     // in Split View. Read once and you are correct until the first rotation.
     renderer.resize(w, h, Math.min(window.devicePixelRatio || 1, 2.5), safeInsets());
+    // The board IS the screen: the vent is the ellipse inscribed in that same
+    // safe box. The renderer measures the box, the simulation takes the shape
+    // from it, and neither owns a second copy of the arithmetic.
+    setArenaAspect(world, renderer.view.safe.w, renderer.view.safe.h);
   }
   layout();
   // A rotation does not always change the element's box — a square-ish split

--- a/dynawalla/games/serpent/src/game/orbs.ts
+++ b/dynawalla/games/serpent/src/game/orbs.ts
@@ -14,6 +14,10 @@
 
 import { TAU, randRange } from "./num.ts";
 import { TUNE } from "./tuning.ts";
+import { pullInside, rimEdge } from "./arena.ts";
+
+/** The vent's semi-axes this frame. The short one is `world.arenaR`; see `arena.ts`. */
+export type Axes = { a: number; b: number };
 
 export type Orb = {
   x: number;
@@ -58,16 +62,22 @@ export function createOrb(): Orb {
  * and not on top of another orb. Falls back to the best of N tries rather than
  * looping forever.
  */
-export function placeOrb(orb: Orb, orbs: Orb[], arenaR: number, headX: number, headY: number): void {
+export function placeOrb(orb: Orb, orbs: Orb[], axes: Axes, headX: number, headY: number): void {
   let bestX = 0;
   let bestY = 0;
   let bestScore = -1;
-  const limit = arenaR - TUNE.orbRadius * 2.2;
+  const clear = TUNE.orbRadius * 2.2;
+  // Candidates are drawn from the vent shrunk by the clearance, which is uniform
+  // over the ellipse rather than over a disc; the `pullInside` at the end is what
+  // actually guarantees the clearance, because a concentric ellipse is not the
+  // same curve as the rim offset inward and only one of those is the rule.
+  const sa = Math.max(TUNE.orbRadius, axes.a - clear);
+  const sb = Math.max(TUNE.orbRadius, axes.b - clear);
   for (let attempt = 0; attempt < 14; attempt++) {
     const a = randRange(0, TAU);
-    const r = Math.sqrt(Math.random()) * limit;
-    const x = Math.cos(a) * r;
-    const y = Math.sin(a) * r;
+    const r = Math.sqrt(Math.random());
+    const x = Math.cos(a) * r * sa;
+    const y = Math.sin(a) * r * sb;
     const dHead = Math.hypot(x - headX, y - headY);
     if (dHead < TUNE.spawnClearance && attempt < 10) continue;
     let nearest = dHead;
@@ -82,8 +92,9 @@ export function placeOrb(orb: Orb, orbs: Orb[], arenaR: number, headX: number, h
     }
     if (bestScore > TUNE.spawnClearance) break;
   }
-  orb.x = bestX;
-  orb.y = bestY;
+  const put = pullInside(axes.a, axes.b, bestX, bestY, clear);
+  orb.x = put.x;
+  orb.y = put.y;
   const a = randRange(0, TAU);
   const s = randRange(0.3, 1) * TUNE.orbDrift;
   orb.vx = Math.cos(a) * s;
@@ -103,7 +114,7 @@ export function molt(orb: Orb, label: string, good: boolean, dur: number): void 
 
 export type OrbStepOptions = {
   dt: number;
-  arenaR: number;
+  axes: Axes;
   headX: number;
   headY: number;
   /** Rotating current, from depth 4. 0 disables it. */
@@ -153,16 +164,20 @@ export function stepOrbs(orbs: Orb[], o: OrbStepOptions): void {
     orb.x += orb.vx * dt;
     orb.y += orb.vy * dt;
 
-    const d = Math.hypot(orb.x, orb.y);
-    const limit = o.arenaR - TUNE.orbRadius * 1.1;
-    if (d > limit && d > 0) {
-      const nx = orb.x / d;
-      const ny = orb.y / d;
-      orb.x = nx * limit;
-      orb.y = ny * limit;
-      const dot = orb.vx * nx + orb.vy * ny;
-      orb.vx -= 2 * dot * nx;
-      orb.vy -= 2 * dot * ny;
+    // The rim contains the field too, and by the same shape the serpent hits.
+    const limit = TUNE.orbRadius * 1.1;
+    const e = rimEdge(o.axes.a, o.axes.b, orb.x, orb.y);
+    if (e.gap < limit) {
+      orb.x = e.x - e.nx * limit;
+      orb.y = e.y - e.ny * limit;
+      const dot = orb.vx * e.nx + orb.vy * e.ny;
+      // Only a drift that is still heading OUT is turned around. Reflecting
+      // unconditionally would flip an orb that the line above has already sent
+      // inward straight back at the wall, and it would sit there buzzing.
+      if (dot > 0) {
+        orb.vx -= 2 * dot * e.nx;
+        orb.vy -= 2 * dot * e.ny;
+      }
     }
   }
 }

--- a/dynawalla/games/serpent/src/game/render/prompt.test.ts
+++ b/dynawalla/games/serpent/src/game/render/prompt.test.ts
@@ -48,6 +48,7 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 
 import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
+import { arenaScale } from "../arena.ts";
 import { CAP_EM, type Ink } from "./glyphs.ts";
 import { TUNE } from "../tuning.ts";
 import {
@@ -178,9 +179,11 @@ function frames(): Frame[] {
   for (const [name, w, h] of VIEWPORTS) {
     for (const [label, insets] of insetsFor(w, h)) {
       const safe = safeRect(w, h, insets);
-      // `scene.ts: resize` — the arena is centred in the safe box and sized off
-      // its short side.
-      const scale = Math.min(safe.w, safe.h) * 0.44;
+      // `scene.ts: resize` — the arena is centred in the safe box and inscribed
+      // in it. `arenaScale` is the shipping expression, imported rather than
+      // copied; the condition is fitted to the disc INSIDE the ellipse, which is
+      // the short semi-axis, so `arenaR × scale` is still the radius that binds.
+      const scale = arenaScale(safe.w, safe.h);
       for (const arenaR of ARENA_RADII) {
         out.push({
           where: `${name} (${w}x${h}), ${label}, vent ${(arenaR * scale * 2).toFixed(0)}px across`,

--- a/dynawalla/games/serpent/src/game/render/scene.ts
+++ b/dynawalla/games/serpent/src/game/render/scene.ts
@@ -18,6 +18,7 @@ import { COLORS, TUNE } from "../tuning.ts";
 import { bolusTintAt } from "../serpent.ts";
 import { orbDrawRadius } from "../orbs.ts";
 import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
+import { arenaScale } from "../arena.ts";
 import type { World } from "../world.ts";
 import { GLOW_PX, MOTE_PX, sprites } from "./sprites.ts";
 import { drawLabel, labelInk, labelWidth, type LabelStyle } from "./glyphs.ts";
@@ -234,13 +235,14 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     view.dpr = dpr;
     view.insets = insets;
     view.safe = safe;
-    // The arena is centred in the SAFE box and sized off its short side. On a
-    // device with no insets this is exactly what it always was; on a phone held
-    // sideways it stops the rim — a wall you can die against — from sliding
-    // under the rounded corner.
+    // The arena is centred in the SAFE box and INSCRIBED in it: the ellipse
+    // reaches the top and bottom of a tall phone and the sides of a wide one,
+    // while every part of the rim — a wall a child can die against — stays clear
+    // of the cutout and the rounded corner. `arena.ts` owns both numbers; the
+    // shape itself is `world.aspectX/aspectY`, set from the same safe box.
     view.cx = safe.x + safe.w / 2;
     view.cy = safe.y + safe.h / 2;
-    view.scale = Math.min(safe.w, safe.h) * 0.44;
+    view.scale = arenaScale(safe.w, safe.h);
     canvas.width = Math.max(1, Math.floor(w * dpr));
     canvas.height = Math.max(1, Math.floor(h * dpr));
     canvas.style.width = `${w}px`;
@@ -315,29 +317,39 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     drawSnow(snowFar, 0);
 
     // --- the arena floor --------------------------------------------------
-    const aR = w.arenaR * S;
+    const aX = w.arenaR * w.aspectX * S;
+    const aY = w.arenaR * w.aspectY * S;
     g.save();
     g.beginPath();
-    g.arc(X(0), Y(0), aR, 0, TAU);
+    g.ellipse(X(0), Y(0), aX, aY, 0, 0, TAU);
     g.clip();
 
-    const floor = g.createRadialGradient(X(0), Y(0), 0, X(0), Y(0), aR);
+    // A radial gradient is a circle, so the floor is painted in a squashed frame
+    // and comes out as the same ellipse the clip already is — the alternative is
+    // a round pool of light sitting inside an oval board with dark ends.
+    g.save();
+    g.translate(X(0), Y(0));
+    g.scale(1, aY / aX);
+    const floor = g.createRadialGradient(0, 0, 0, 0, 0, aX);
     floor.addColorStop(0, "rgba(34,124,150,0.7)");
     floor.addColorStop(0.45, "rgba(14,72,104,0.56)");
     floor.addColorStop(0.82, "rgba(6,36,62,0.4)");
     floor.addColorStop(1, "rgba(2,14,28,0.16)");
     g.fillStyle = floor;
-    g.fillRect(X(0) - aR, Y(0) - aR, aR * 2, aR * 2);
+    g.fillRect(-aX, -aX, aX * 2, aX * 2);
+    g.restore();
 
     // The vent itself: a slow amber heart. Teal water against a warm centre is
     // the only complementary pair in the palette, and without it the whole
     // screen is one hue and reads flat however bright you make it.
     const ventGlow = sp.glow[0];
     if (ventGlow) {
-      const vs = aR * (1.15 + 0.05 * Math.sin(w.cam.t * 0.55));
+      const k = 1.15 + 0.05 * Math.sin(w.cam.t * 0.55);
+      const vw = aX * k;
+      const vh = aY * k;
       g.globalCompositeOperation = "lighter";
       g.globalAlpha = 0.13 + 0.03 * Math.sin(w.cam.t * 0.8) + w.depthPulse * 0.16;
-      g.drawImage(ventGlow, X(0) - vs / 2, Y(0) - vs / 2, vs, vs);
+      g.drawImage(ventGlow, X(0) - vw / 2, Y(0) - vh / 2, vw, vh);
       g.globalAlpha = 1;
       g.globalCompositeOperation = "source-over";
     }
@@ -450,7 +462,7 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     g.globalCompositeOperation = "source-over";
 
     // --- the vent rim -----------------------------------------------------
-    drawRim(w, X, Y, S, aR);
+    drawRim(w, X, Y, S, aX, aY);
 
     // --- floating score ---------------------------------------------------
     const floatStyle: LabelStyle = {
@@ -718,19 +730,25 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     X: (x: number) => number,
     Y: (y: number) => number,
     S: number,
-    aR: number,
+    aX: number,
+    aY: number,
   ): void {
     const cx = X(0);
     const cy = Y(0);
-    const headA = Math.atan2(w.serpent.y, w.serpent.x);
+    // The head's ECCENTRIC angle, not its polar one: `ctx.ellipse` walks the
+    // parameter, so the arc a segment covers is `(aX cos t, aY sin t)` and the
+    // hot patch has to be found in the same parameter or the glow drifts away
+    // from the serpent everywhere except the four axis points.
+    const headA = Math.atan2(w.serpent.y / (w.arenaR * w.aspectY), w.serpent.x / (w.arenaR * w.aspectX));
     const segs = 72;
 
     g.globalCompositeOperation = "lighter";
     const halo = sp.softRing[w.grazeGlow > 0.4 ? 5 : 2];
     if (halo) {
-      const size = aR * 2 * 1.14;
+      const hw = aX * 2 * 1.14;
+      const hh = aY * 2 * 1.14;
       g.globalAlpha = 0.5 + w.grazeGlow * 0.4 + w.depthPulse * 0.35;
-      g.drawImage(halo, cx - size / 2, cy - size / 2, size, size);
+      g.drawImage(halo, cx - hw / 2, cy - hh / 2, hw, hh);
     }
 
     g.lineCap = "butt";
@@ -745,7 +763,7 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
       g.strokeStyle = heat > 0.05 ? COLORS.rimHot : COLORS.rim;
       g.lineWidth = Math.max(2.5, S * (0.014 + heat * 0.016));
       g.beginPath();
-      g.arc(cx, cy, aR, a0, a1);
+      g.ellipse(cx, cy, aX, aY, 0, a0, a1);
       g.stroke();
       // A thin white-hot lip just inside, so the edge is a hard line the eye
       // can trust rather than a soft glow you can misjudge at speed.
@@ -753,7 +771,7 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
       g.strokeStyle = heat > 0.05 ? "#ffd9c4" : "#d6fbff";
       g.lineWidth = Math.max(1, S * 0.004);
       g.beginPath();
-      g.arc(cx, cy, aR - S * 0.009, a0, a1);
+      g.ellipse(cx, cy, Math.max(1, aX - S * 0.009), Math.max(1, aY - S * 0.009), 0, a0, a1);
       g.stroke();
     }
 
@@ -766,7 +784,7 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
         const wob = 1 + Math.sin(w.cam.t * 1.3 + i) * 0.012;
         const size = S * 0.016 * (1 + 0.4 * Math.sin(w.cam.t * 2 + i * 1.7));
         g.globalAlpha = 0.5;
-        g.drawImage(dot, cx + Math.cos(a) * aR * wob - size / 2, cy + Math.sin(a) * aR * wob - size / 2, size, size);
+        g.drawImage(dot, cx + Math.cos(a) * aX * wob - size / 2, cy + Math.sin(a) * aY * wob - size / 2, size, size);
       }
     }
     g.globalAlpha = 1;

--- a/dynawalla/games/serpent/src/game/world.test.ts
+++ b/dynawalla/games/serpent/src/game/world.test.ts
@@ -10,10 +10,20 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createWorld, confirmPressed, stepWorld, startRun, type World } from "./world.ts";
+import {
+  arenaAxes,
+  arenaEdge,
+  createWorld,
+  confirmPressed,
+  setArenaAspect,
+  stepWorld,
+  startRun,
+  type World,
+} from "./world.ts";
+import { createOrb, placeOrb } from "./orbs.ts";
 import { createStubHost } from "../stub/host.ts";
 import { TUNE } from "./tuning.ts";
-import { angleDelta } from "./num.ts";
+import { TAU, angleDelta } from "./num.ts";
 import { parseLabel, satisfies, type Predicate } from "../stub/exact.ts";
 import type { Audio } from "./audio.ts";
 import type { Host, Question, Report } from "../contract.ts";
@@ -289,11 +299,12 @@ test("the wall costs length and throws you back — it never ends the run", () =
   assert.equal(hits, 1, "driving straight at the wall must register a wall hit");
   assert.equal(w.phase, "play", "the rim must not end the run");
   assert.ok(w.serpent.targetSegments < before, "the rim must cost length");
-  assert.ok(Math.hypot(w.serpent.x, w.serpent.y) < w.arenaR, "the serpent must be put back inside the arena");
+  assert.ok(arenaEdge(w, w.serpent.x, w.serpent.y).gap > 0, "the serpent must be put back inside the arena");
   assert.equal(w.combo, 0, "the rim must break the combo");
   // And the deflection must not aim the head back down its own body.
-  const away = Math.cos(w.serpent.heading) * w.serpent.x + Math.sin(w.serpent.heading) * w.serpent.y;
-  assert.ok(away < 0, "the deflection must send the serpent inward, not along the wall forever");
+  const e = arenaEdge(w, w.serpent.x, w.serpent.y);
+  const away = -(Math.cos(w.serpent.heading) * e.nx + Math.sin(w.serpent.heading) * e.ny);
+  assert.ok(away > 0, "the deflection must send the serpent inward, not along the wall forever");
 });
 
 test("outgrowing your own turning circle is what ends a run", () => {
@@ -388,4 +399,229 @@ test("the simulation step stays far inside a 60fps budget", () => {
   // Two sim steps per rendered frame at 60fps. The whole simulation must be a
   // rounding error next to the 16.7ms frame, leaving the budget for drawing.
   assert.ok(perStep < 0.35, `sim step cost ${perStep.toFixed(3)}ms at body ${heavy}`);
+});
+
+/* -------------------------------------------------------------------------- */
+/* The board is the screen — and the wall came with it.                       */
+/* -------------------------------------------------------------------------- */
+
+/** The safe box the arena is inscribed in, at the shapes a child holds. */
+const SCREENS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait", 390, 844],
+  ["phone landscape", 844, 390],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["square", 600, 600],
+];
+
+function fresh(seed: string, safeW: number, safeH: number): World {
+  const { host } = instrument(seed);
+  const w = createWorld(host, silentAudio(), false);
+  setArenaAspect(w, safeW, safeH);
+  startRun(w);
+  return w;
+}
+
+test("the rim is a wall you can die against from every direction, on every screen", () => {
+  // The circle is gone, so the direction back to the middle is no longer the
+  // direction the wall faces — off the end of a long vent they differ by about
+  // 30°. Drive at the rim from twelve headings on six screens and check the three
+  // things a wall owes the player: it registers, it puts you back inside, and it
+  // turns you off the wall rather than turning you round into your own neck.
+  for (const [name, sw, sh] of SCREENS) {
+    for (let i = 0; i < 12; i++) {
+      const heading = (i / 12) * TAU;
+      const w = fresh(`wall-${name}-${i}`, sw, sh);
+      // Nothing but the wall may interrupt: a bite would change the heading.
+      w.orbs.length = 0;
+      // The heading on the frame the wall took it, not the random one the run
+      // opened with — the turn being measured is the deflection's own.
+      let before = w.serpent.heading;
+      let hit = false;
+      for (let step = 0; step < 4000 && !hit; step++) {
+        const prior = w.serpent.heading;
+        stepWorld(w, FIXED, { heading, boost: false });
+        if (w.wallT > 0) {
+          before = prior;
+          hit = true;
+        }
+      }
+      const where = `${name}, heading ${((heading * 180) / Math.PI).toFixed(0)}°`;
+      assert.ok(hit, `${where}: driving straight at the rim never registered a wall hit`);
+      const s = w.serpent;
+      const e = arenaEdge(w, s.x, s.y);
+      assert.ok(
+        e.gap > 0,
+        `${where}: the wall left the serpent ${(-e.gap).toFixed(4)} OUTSIDE the vent`,
+      );
+      // Deflection, not reflection. The head keeps most of its along-wall speed
+      // and picks up a definite push off the surface; a mirror bounce at normal
+      // incidence would instead be a 180° turn into its own body.
+      const inward = -(Math.cos(s.heading) * e.nx + Math.sin(s.heading) * e.ny);
+      assert.ok(
+        inward > 0.5,
+        `${where}: after the hit the head is only ${inward.toFixed(3)} of the way off the wall`,
+      );
+      // A deflection turns the head at most 136° even head-on (`0.7 × tangent −
+      // 0.72 × normal`); a mirror bounce at normal incidence turns it a full π.
+      assert.ok(
+        Math.abs(angleDelta(before, s.heading)) < 2.6,
+        `${where}: the head was turned ${Math.abs(angleDelta(before, s.heading)).toFixed(2)} rad — ` +
+          `that is a mirror bounce, and it drives the serpent back down its own neck`,
+      );
+    }
+  }
+});
+
+test("the graze band is the same wall, paid for a moment earlier", () => {
+  // Two expressions about the edge that disagree is the bug this change invites:
+  // paid for grazing a circle while dying against an ellipse. So the band a child
+  // is paid in must always have opened BEFORE the wall bites, on every screen.
+  assert.ok(
+    TUNE.grazeBand > TUNE.headRadius * 0.75,
+    "the graze band is narrower than the wall — there is nothing to be paid for",
+  );
+  for (const [name, sw, sh] of SCREENS) {
+    for (const heading of [0, Math.PI / 2, 2.2, 4.4]) {
+      const w = fresh(`graze-${name}-${heading}`, sw, sh);
+      w.orbs.length = 0;
+      let grazedFor = 0;
+      let hit = false;
+      // The band is not observable directly, but `grazeGlow` only ever RISES
+      // while the game thinks the serpent is in it, which is the same thing.
+      let glow = w.grazeGlow;
+      let deepest = 0;
+      for (let step = 0; step < 4000 && !hit; step++) {
+        stepWorld(w, FIXED, { heading, boost: false });
+        if (w.grazeGlow > glow) {
+          grazedFor++;
+          deepest = Math.max(deepest, arenaEdge(w, w.serpent.x, w.serpent.y).gap);
+        }
+        glow = w.grazeGlow;
+        hit = w.wallT > 0;
+      }
+      const where = `${name}, heading ${heading}`;
+      assert.ok(hit, `${where}: never reached the wall`);
+      // Neither half of the deal may drift from the other: the band never opens
+      // out in open water. The 15% is slack for a frame of travel, not for a
+      // different curve — a circular band inside this ellipse pays from sixteen
+      // times the band's width out.
+      assert.ok(
+        deepest <= TUNE.grazeBand * 1.15,
+        `${where}: the serpent was credited with grazing while it was ${deepest.toFixed(3)} from ` +
+          `the rim, and the band is ${TUNE.grazeBand}`,
+      );
+      // … and it always opens before the wall bites.
+      assert.ok(
+        grazedFor > 4,
+        `${where}: the wall bit after only ${grazedFor} frames in the graze band — the band and ` +
+          `the wall are not the same curve`,
+      );
+    }
+  }
+});
+
+test("an orb is never spawned against the wall, whatever shape the vent is", () => {
+  // Asserted at the spawner and not through a frame of play, because `stepOrbs`
+  // walks a stray orb back inside on the very next step and would hide this — the
+  // clearance exists so an orb is REACHABLE, and one that appears on the rim and
+  // is shoved off it has already been placed somewhere a child cannot bite.
+  const clear = TUNE.orbRadius * 2.2;
+  for (const [name, sw, sh] of SCREENS) {
+    const w = fresh(`spawn-${name}`, sw, sh);
+    for (const arenaR of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
+      w.arenaR = arenaR;
+      const axes = arenaAxes(w);
+      const orb = createOrb();
+      let worst = Infinity;
+      for (let i = 0; i < 300; i++) {
+        placeOrb(orb, w.orbs, axes, w.serpent.x, w.serpent.y);
+        worst = Math.min(worst, arenaEdge(w, orb.x, orb.y).gap);
+      }
+      assert.ok(
+        worst >= clear - 1e-9,
+        `${name}, vent ${arenaR}: an orb was placed ${worst.toFixed(4)} from the rim and the ` +
+          `spawn clearance is ${clear.toFixed(4)}`,
+      );
+    }
+  }
+});
+
+test("nothing is ever put outside the vent, whatever shape it is", () => {
+  // Spawning, drifting, hunting and the shape changing under everything at once.
+  // An orb outside the rim is a correct answer a child cannot reach.
+  for (const [name, sw, sh] of SCREENS) {
+    const w = fresh(`field-${name}`, sw, sh);
+    let worst = Infinity;
+    let worstAt = "";
+    const steps = Math.round(90 / FIXED);
+    for (let i = 0; i < steps; i++) {
+      if (w.phase === "dead" && w.deathT > 0.6) confirmPressed(w);
+      stepWorld(w, FIXED, { heading: pilotHeading(w, 0.9), boost: i % 700 < 90 });
+      for (const o of w.orbs) {
+        const gap = arenaEdge(w, o.x, o.y).gap;
+        if (gap < worst) {
+          worst = gap;
+          worstAt = `(${o.x.toFixed(3)},${o.y.toFixed(3)}) carrying "${o.label}"`;
+        }
+      }
+    }
+    assert.ok(
+      worst >= -1e-9,
+      `${name}: an orb was ${(-worst).toFixed(4)} outside the rim at ${worstAt}`,
+    );
+    // And it is a real ellipse being tested, not a circle wearing a new name.
+    const axes = arenaAxes(w);
+    const ratio = Math.max(axes.a, axes.b) / Math.min(axes.a, axes.b);
+    assert.ok(
+      name === "square" ? ratio === 1 : ratio > 1.2,
+      `${name}: the vent came out ${ratio.toFixed(2)}:1 — the screen's shape did not reach the game`,
+    );
+  }
+});
+
+test("a rotation reshapes the board without stranding anything outside it", () => {
+  // The one moment the vent gets SMALLER along an axis: a tall ellipse becomes a
+  // wide one and everything in the ends of the old shape is now in the black.
+  const w = fresh("rotate", 390, 844);
+  for (let i = 0; i < Math.round(45 / FIXED); i++) {
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 0.9), boost: false });
+  }
+  const before = w.orbs.map((o) => ({ x: o.x, y: o.y }));
+  assert.ok(
+    before.some((o) => Math.abs(o.y) > w.arenaR * 1.05),
+    "no orb was out in the tall end of the vent, so the rotation proves nothing",
+  );
+  setArenaAspect(w, 844, 390);
+  for (const o of w.orbs) {
+    assert.ok(
+      arenaEdge(w, o.x, o.y).gap >= TUNE.orbRadius * 1.1 - 1e-9,
+      `an orb was left at (${o.x.toFixed(3)},${o.y.toFixed(3)}) after the rotation`,
+    );
+  }
+  assert.ok(arenaEdge(w, w.serpent.x, w.serpent.y).gap > 0, "the serpent was left outside the new vent");
+  // And the run keeps running through it.
+  for (let i = 0; i < 600; i++) stepWorld(w, FIXED, { heading: pilotHeading(w, 0.9), boost: false });
+  assert.ok(Number.isFinite(w.serpent.x) && Number.isFinite(w.serpent.y));
+});
+
+test("a taller board carries a proportionally denser field, not a sparser one", () => {
+  // The field IS the maze — `orbs.ts` says so. A 2.2x board holding the same ten
+  // orbs is half the density and half the obstacle course, on the device most
+  // children hold.
+  const square = fresh("density-square", 600, 600);
+  const tall = fresh("density-tall", 390, 844);
+  const areaRatio = (tall.aspectX * tall.aspectY) / (square.aspectX * square.aspectY);
+  assert.ok(areaRatio > 2, `the tall board is only ${areaRatio.toFixed(2)}x the area`);
+  const ratio = tall.orbs.length / square.orbs.length;
+  assert.ok(
+    Math.abs(ratio - areaRatio) < 0.25,
+    `the tall board is ${areaRatio.toFixed(2)}x the area but carries ${ratio.toFixed(2)}x the orbs`,
+  );
+  const goodShare = (x: World): number => x.orbs.filter((o) => o.good).length / x.orbs.length;
+  assert.ok(
+    Math.abs(goodShare(tall) - goodShare(square)) < 0.12,
+    `the share of edible orbs changed with the screen: ${goodShare(square).toFixed(2)} to ${goodShare(tall).toFixed(2)}`,
+  );
 });

--- a/dynawalla/games/serpent/src/game/world.ts
+++ b/dynawalla/games/serpent/src/game/world.ts
@@ -55,7 +55,8 @@ import {
   stepSerpent,
   type Serpent,
 } from "./serpent.ts";
-import { createOrb, molt, orbDrawRadius, placeOrb, stepOrbs, type Orb } from "./orbs.ts";
+import { createOrb, molt, orbDrawRadius, placeOrb, stepOrbs, type Axes, type Orb } from "./orbs.ts";
+import { arenaAspect, pullInside, rimEdge, type Edge } from "./arena.ts";
 import type { Audio } from "./audio.ts";
 
 const BEST_KEY = "serpent.best";
@@ -105,8 +106,24 @@ export type World = {
   correctEats: number;
   wrongEats: number;
 
+  /**
+   * The vent's SHORT semi-axis, in world units. It closes as a child dives.
+   *
+   * Called a radius for most of this pack's life and still the same number: the
+   * arena is an ellipse now (see `arena.ts`) and this is the axis it was tuned
+   * on, so nothing about how the game feels across the narrow way changed.
+   */
   arenaR: number;
   arenaTargetR: number;
+  /**
+   * The vent's proportions, short axis normalised to exactly 1.
+   *
+   * Set from the safe rectangle by `setArenaAspect` on every layout, so the board
+   * is the screen. Both are 1 until the first layout arrives, which is a circle —
+   * the shape the game shipped with, and one that every later aspect contains.
+   */
+  aspectX: number;
+  aspectY: number;
 
   prompt: string;
   pending: Trial[];
@@ -176,6 +193,8 @@ export function createWorld(host: Host, audio: Audio, reduced: boolean): World {
 
     arenaR: TUNE.arenaStart,
     arenaTargetR: TUNE.arenaStart,
+    aspectX: 1,
+    aspectY: 1,
 
     prompt: "",
     pending: [],
@@ -198,6 +217,44 @@ export function createWorld(host: Host, audio: Audio, reduced: boolean): World {
   };
   resetRun(w, "attract");
   return w;
+}
+
+// -------------------------------------------------------------------- shape
+
+/** The vent's semi-axes, this frame. */
+export function arenaAxes(w: World): Axes {
+  return { a: w.arenaR * w.aspectX, b: w.arenaR * w.aspectY };
+}
+
+/** Where the rim is from a point, which way it faces, how far away it is. */
+export function arenaEdge(w: World, x: number, y: number): Edge {
+  return rimEdge(w.arenaR * w.aspectX, w.arenaR * w.aspectY, x, y);
+}
+
+/**
+ * Fit the vent to the safe rectangle.
+ *
+ * Called on every layout, so a rotation reshapes the board. That is the one
+ * moment the arena can get *smaller* along an axis — portrait to landscape swaps
+ * a tall ellipse for a wide one — so everything loose is walked back inside the
+ * new rim rather than left stranded in the black with a wall between it and the
+ * game. The serpent's recorded path is not: it is history, the head drags it back
+ * within a body length, and rewriting it would put a kink in the animal.
+ */
+export function setArenaAspect(w: World, safeW: number, safeH: number): void {
+  const next = arenaAspect(safeW, safeH);
+  if (next.x === w.aspectX && next.y === w.aspectY) return;
+  w.aspectX = next.x;
+  w.aspectY = next.y;
+  const { a, b } = arenaAxes(w);
+  for (const o of w.orbs) {
+    const put = pullInside(a, b, o.x, o.y, TUNE.orbRadius * 1.1);
+    o.x = put.x;
+    o.y = put.y;
+  }
+  const head = pullInside(a, b, w.serpent.x, w.serpent.y, TUNE.headRadius * 1.6);
+  w.serpent.x = head.x;
+  w.serpent.y = head.y;
 }
 
 // ------------------------------------------------------------------ content
@@ -230,10 +287,24 @@ function pullQuestion(w: World): boolean {
   return false;
 }
 
+/**
+ * How many orbs, and how many of them are edible.
+ *
+ * Both scale with the vent's AREA, which is the one gameplay consequence of the
+ * board becoming the screen. `orbs.ts` says the field is the maze — "the arena is
+ * dense with wrong answers you have to swim *through*, so reading the field is
+ * the same act as steering through it" — and a tall phone is a 2.2× larger board,
+ * so holding the counts fixed would have halved that density and quietly taken
+ * the obstacle course out of the game on the device most children hold. The ratio
+ * of edible to inedible is preserved exactly; only the scale changes.
+ */
 function fieldTargets(w: World): { count: number; good: number } {
+  const area = w.aspectX * w.aspectY;
   return {
-    count: Math.min(TUNE.orbMaxCount, TUNE.orbBaseCount + (w.depth - 1) * TUNE.orbPerDepth),
-    good: Math.min(TUNE.goodMax, TUNE.goodBase + Math.floor((w.depth - 1) / 3)),
+    count: Math.round(
+      Math.min(TUNE.orbMaxCount, TUNE.orbBaseCount + (w.depth - 1) * TUNE.orbPerDepth) * area,
+    ),
+    good: Math.round(Math.min(TUNE.goodMax, TUNE.goodBase + Math.floor((w.depth - 1) / 3)) * area),
   };
 }
 
@@ -253,7 +324,7 @@ function addOrb(w: World, good: boolean): Orb {
   orb.label = pickLabel(w, good);
   orb.good = good;
   orb.hunter = w.depth >= TUNE.hunterFromDepth && Math.random() < TUNE.hunterChance;
-  placeOrb(orb, w.orbs, w.arenaR, w.serpent.x, w.serpent.y);
+  placeOrb(orb, w.orbs, arenaAxes(w), w.serpent.x, w.serpent.y);
   w.orbs.push(orb);
   return orb;
 }
@@ -302,7 +373,8 @@ function beginMutation(w: World, q: Question): void {
   slowmo(w.cam, TUNE.slowmoMutateTime, TUNE.slowmoMutateScale);
   addTrauma(w.cam, 0.18);
   flash(w.cam, "#4ff0d6", 0.1);
-  ring(w.rings, 0, 0, w.arenaR * 0.05, w.arenaR * 0.9, 0.7, 0.02, 2);
+  const reach = w.arenaR * Math.max(w.aspectX, w.aspectY);
+  ring(w.rings, 0, 0, reach * 0.05, reach * 0.9, 0.7, 0.02, 2);
   w.audio.mutate();
   if (w.phase === "play") w.host.haptic("medium");
 }
@@ -469,7 +541,10 @@ function descend(w: World): void {
   w.scorePulse = 1;
   addTrauma(w.cam, TUNE.traumaDepth);
   punch(w.cam, TUNE.punchDepth);
-  ring(w.rings, 0, 0, w.arenaR * 1.02, w.arenaR * 0.55, 0.75, 0.02, 4);
+  // Out to the LONG axis, so the "the water is closing in" beat sweeps the whole
+  // board rather than stopping halfway up a tall one.
+  const reach = w.arenaR * Math.max(w.aspectX, w.aspectY);
+  ring(w.rings, 0, 0, reach * 1.02, reach * 0.55, 0.75, 0.02, 4);
   burstBubbles(w.particles, w.serpent.x, w.serpent.y, 12);
   w.audio.depth(w.depth);
   if (w.phase === "play") w.host.haptic("medium");
@@ -477,22 +552,25 @@ function descend(w: World): void {
 }
 
 /** Slam into the vent wall: bounce inward, pay for it, keep the run. */
-function hitWall(w: World, dist: number): void {
+function hitWall(w: World, e: Edge): void {
   const s = w.serpent;
-  const d = dist || 1;
-  const nx = s.x / d;
-  const ny = s.y / d;
-  const px = nx * w.arenaR;
-  const py = ny * w.arenaR;
+  // The wall's own normal at the point that was actually hit, not the direction
+  // back to the middle. On a circle those were the same vector and the code could
+  // not tell; on an ellipse they differ by up to about 30°, and using the wrong
+  // one would slide the serpent along the rim instead of off it and put the
+  // debris burst somewhere the serpent never touched.
+  const nx = e.nx;
+  const ny = e.ny;
+  const px = e.x;
+  const py = e.y;
 
   // Deflect along the wall, never *reflect* off it. A mirror bounce at normal
   // incidence turns the head through 180° and drives it straight back into its
   // own neck — an instant death handed out for touching a wall, which is the
   // opposite of the point. Sliding picks the tangent the serpent was already
   // closest to and adds a little inward drift.
-  const inside = w.arenaR - TUNE.headRadius * 1.6;
-  s.x = nx * inside;
-  s.y = ny * inside;
+  s.x = px - nx * TUNE.headRadius * 1.6;
+  s.y = py - ny * TUNE.headRadius * 1.6;
   const hx = Math.cos(s.heading);
   const hy = Math.sin(s.heading);
   const sign = hx * -ny + hy * nx >= 0 ? 1 : -1;
@@ -509,7 +587,7 @@ function hitWall(w: World, dist: number): void {
   burstDebris(w.particles, px, py, Math.atan2(ny, nx), TUNE.shrinkPerWall);
   burstBad(w.particles, px, py);
   ring(w.rings, px, py, 0.01, 0.34, 0.5, 0.016, 5);
-  floater(w, px * 0.92, py * 0.92, `−${TUNE.shrinkPerWall}`, 1);
+  floater(w, px - nx * 0.08, py - ny * 0.08, `−${TUNE.shrinkPerWall}`, 1);
   hitstop(w.cam, TUNE.hitstopWallMs);
   addTrauma(w.cam, TUNE.traumaWall);
   punch(w.cam, TUNE.punchWrong);
@@ -573,9 +651,10 @@ function die(w: World, x: number, y: number): void {
 /** Attract-mode pilot. It plays the game so the player never reads a rule. */
 function autoHeading(w: World): number {
   const s = w.serpent;
-  const d = Math.hypot(s.x, s.y);
-  // Turn away from the rim before anything else.
-  if (d > w.arenaR - TUNE.headRadius * 7) return Math.atan2(-s.y, -s.x) + Math.sin(w.time * 0.7) * 0.5;
+  // Turn away from the rim before anything else — straight off the wall it is
+  // near, which on a long vent is nothing like "toward the middle".
+  const e = arenaEdge(w, s.x, s.y);
+  if (e.gap < TUNE.headRadius * 7) return Math.atan2(-e.ny, -e.nx) + Math.sin(w.time * 0.7) * 0.5;
   let best: Orb | null = null;
   let bestD = Infinity;
   for (const o of w.orbs) {
@@ -633,7 +712,7 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
     w.deathT += dt;
     stepOrbs(w.orbs, {
       dt,
-      arenaR: w.arenaR,
+      axes: arenaAxes(w),
       headX: s.x,
       headY: s.y,
       current: 0,
@@ -660,7 +739,7 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
 
   stepOrbs(w.orbs, {
     dt,
-    arenaR: w.arenaR,
+    axes: arenaAxes(w),
     headX: s.x,
     headY: s.y,
     current: w.depth >= 4 ? 0.03 : 0,
@@ -686,8 +765,12 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
   }
 
   // --- grazing the rim, which is worth points precisely because it is stupid
-  const dist = Math.hypot(s.x, s.y);
-  const grazing = dist > w.arenaR - TUNE.grazeBand;
+  //
+  // One measurement of the rim serves the graze band, the wall and nothing else,
+  // so the band a child is paid for and the line they are punished on are the
+  // same curve by construction rather than by two expressions agreeing.
+  const edge = arenaEdge(w, s.x, s.y);
+  const grazing = edge.gap < TUNE.grazeBand;
   w.grazeGlow = clamp(w.grazeGlow + (grazing ? dt * 6 : -dt * 3), 0, 1);
   if (grazing && s.alive) {
     w.grazeT += dt;
@@ -711,16 +794,17 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
   // outgrowing your own turning circle. That is also what makes the arena
   // closing in mean something: it squeezes you into yourself.
   w.wallT = Math.max(0, w.wallT - dt);
-  if (dist > w.arenaR - TUNE.headRadius * 0.75 && w.wallT <= 0) {
-    hitWall(w, dist);
+  if (edge.gap < TUNE.headRadius * 0.75 && w.wallT <= 0) {
+    hitWall(w, edge);
   } else if (w.invulnT <= 0 && selfHit(s)) {
     die(w, s.x, s.y);
   }
 
   if (Math.random() < dt * 2.4) {
     const a = randRange(0, TAU);
-    const r = Math.sqrt(Math.random()) * w.arenaR;
-    burstBubbles(w.particles, Math.cos(a) * r, Math.sin(a) * r, 1);
+    const r = Math.sqrt(Math.random());
+    const { a: ax, b: ay } = arenaAxes(w);
+    burstBubbles(w.particles, Math.cos(a) * r * ax, Math.sin(a) * r * ay, 1);
   }
 }
 


### PR DESCRIPTION
## What the founder asked

> serpent - keep but why not make the board the full screen?

## Why it was not

`scene.ts:243` sized the arena off the **short** side of the safe box:

```ts
view.scale = Math.min(safe.w, safe.h) * 0.44;
```

so on a 390×844 phone the board was a 343px circle with two 250px bands of dead
black above and below it. The 0.44 was not arbitrary — it kept the rim, a wall a
child can die against, out from under the rounded corner and the cutout.

## The shape

**An ellipse inscribed in the safe rectangle.** On that same phone the vent is
351×760 — **2.16× the water** — and on a tablet or a phone held sideways it
reaches the ends the same way. The short semi-axis is still exactly `arenaR`, so
nothing about how the game feels across the narrow way changed; the
pixels-per-world-unit scale stays **isotropic**, so the serpent is still round
and its turning circle is still a circle. Only the room it swims in got bigger.

A rounded rect was the alternative. The ellipse won because every angle-
parameterised thing the renderer already does — 72 rim segments, per-segment
graze heat, 40 polyps, the arc clip — maps to `ctx.ellipse` unchanged, and
because the art is a hydrothermal vent, not a tank.

## Why this is not a constant

The rim is a wall you die against and grazing it is worth points, so `world.ts`
asks the boundary three questions every simulated step — how far is the wall,
which way does it face, where is the nearest legal spot inside it. On a circle
all three were `Math.hypot`. On an ellipse the nearest point is the root of a
quartic.

`src/game/arena.ts` answers them **exactly**: the evolute iteration for the
nearest point on the rim, the gradient of `x²/a² + y²/b²` for the normal, and one
`pullInside` that every "keep this off the wall" in the game goes through — so
the wall, the graze band and the spawner cannot drift apart. `arena.test.ts`
checks the answers against a **60,000-point brute-force sweep of the rim**, which
can only ever be worse than the true minimum, so "no further than this" is a
bound and not a tolerance.

### Deflect, not reflect — preserved and now asserted

`hitWall` takes the surface normal at the point actually struck rather than the
direction back to the middle; on a long vent those differ by up to ~30°. The
property the old comment describes is now a test, at 12 headings × 6 screens:

* the head ends up **inside** the rim,
* it picks up a definite push **off** the wall (`> 0.5` of the normal),
* and it is turned **at most 2.6 rad** — a mirror bounce at normal incidence is a
  full π straight back into its own neck, and the deflection is 136°.

### Two consequential choices

**`ARENA_FILL = 0.9`, not 1.0.** The rim is not a hairline: polyps ride at
`1.012 × semi-axis` with half a sprite beyond, all of it times `cam.zoom`, plus
`cam.shake × scale`. The test **measures the camera by running it** rather than
believing a hand-derived peak, and holds the entire rim inside the safe box at
five viewports with and without a cutout, at the vent's full size and its floor.

**The orb count scales with the vent's area.** `orbs.ts` says the field IS the
maze — "the arena is dense with wrong answers you have to swim *through*, so
reading the field is the same act as steering through it". A 2.16× board holding
ten orbs is half that density, on the device most children hold. The
edible:inedible ratio is preserved exactly. **This is the one change here that is
a game-feel decision rather than a consequence of the shape** — it is three lines
in `fieldTargets` and trivially revertible if you'd rather have the sparser
board.

**`MAX_ARENA_ASPECT = 3`** is curvature, not taste. Walking a margin back along
the normal lands exactly that far inside only while the margin is under the rim's
tightest radius of curvature (`min(a,b)²/max(a,b)`). At the vent's floor that
holds to an aspect of ~4.5; 3 keeps a 50% margin, and covers every phone (2.2:1)
and tablet. Past it the board letterboxes — smaller, never wrong. Mutation M6
below is the empirical proof that this is the real constraint.

## Verification

* `npm run -s tsc` clean; **73 tests, 5 consecutive green runs**.
* `node packs/build.mjs serpent` builds and passes the SDK checker.
* Boundary asserted at 320×568, 390×844, 844×390, 768×1024, 1024×768 and 600×600,
  with and without a cutout, at `arenaStart`, 0.8 and `arenaFloor`.
* Simulation cost at a 2.16:1 aspect with a full field: **0.013 ms/step**, against
  a 0.35 ms budget. The ellipse math is not a cost.

## Mutation transcript

Fourteen removals, fourteen distinct failures. Each was applied alone to a clean
tree and reverted.

| # | mutation | the assertion that trips |
|---|---|---|
| M1 | `arenaScale` back to the shipped `min(w,h)*0.44` | `the vent is 88.0% of the safe width, not 90%` |
| M2 | `ARENA_FILL` 0.9 → 1.0 | `the rim crosses the left inset by 11.42px` |
| M3 | `closestOnRim` stops iterating | `a sweep of the rim found a point 0.990000000 away and closestOnRim settled for 0.992215117` |
| M4 | `pullInside` stops offsetting | `the graze band (0.075): (0.984,0.109) was put at (0.984,0.109), which is 0.010000 from the wall` |
| M5 | `rimEdge` normal → the radial direction (the circle assumption) | `the query is 0.001275422305707641 off the normal line, so the "nearest" point is not a foot of a perpendicular` |
| M6 | `MAX_ARENA_ASPECT` 3 → 20 | `a=1 b=20, the graze band (0.075): (-0.115,20.873) was put at (0.003,19.925), which is 0.068382 from the wall` |
| M7 | `hitWall` takes the direction back to the middle as the wall's normal | `heading 60°: after the hit the head is only 0.019 of the way off the wall` |
| M8 | the graze band goes back to a circle while the wall is an ellipse | `the serpent was credited with grazing while it was 0.677 from the rim, and the band is 0.075` |
| M9 | the spawner samples the whole vent with no clearance | `an orb was placed 0.0023 from the rim and the spawn clearance is 0.1364` |
| M9b | the spawner keeps the concentric shrink but drops `pullInside` | `an orb was placed 0.1317 from the rim and the spawn clearance is 0.1364` |
| M10 | `stepOrbs` stops containing the field | `an orb was 1.6009 outside the rim at (2.400,-1.346) carrying "69"` |
| M10b | `stepOrbs` contains against the inscribed circle, not the rim | `a rotation reshapes the board without stranding anything outside it` |
| M11 | a rotation reshapes the vent but leaves the field where it was | `an orb was left at (-0.315,0.996) after the rotation` |
| M12 | `fieldTargets` stops scaling with area | `the tall board is 2.16x the area but carries 1.00x the orbs` |
| M13 | `mount.ts` never tells the world its shape | `mount.ts no longer fits the vent to the measured safe box — the arena is a circle again` |
| M14 | the renderer strokes the rim as a circle again | `the rim a child steers against is still stroked as a circle` |

**M9b is worth reading twice.** Sampling spawns from the *concentric* ellipse
shrunk by the clearance looks like it should be enough, and it is not — a
concentric ellipse is not the rim offset inward, and it lands orbs 0.1317 from a
wall that owes them 0.1364. That is exactly the "spawn outside the new boundary"
failure this change invites, caught because the guarantee is asserted at the
spawner and not through a frame of play (`stepOrbs` walks a stray orb back inside
on the next step and would have hidden it — which is how M9 first passed).

**M8 also went through two rounds.** The first version of that test only asserted
that grazing opened *before* the wall bit, which a circular band inside an
elliptical vent passes trivially — the band is wide open from the middle
outwards. It now asserts both directions, and the deepest the game will pay a
graze from.

## Not done

* The condition's fit is still measured against the disc **inside** the ellipse
  (`arenaR × scale`), which is conservative and unchanged. Widening it to use the
  long axis is a separate call.
* The soft halo behind the rim is deliberately outside the safe-box invariant: it
  is a radial gradient that has faded out before its own edge, it is not
  something a child can steer into, and the shipped 0.44 circle let it past too.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
