### PR TITLE
dynawalla/games/merge-idle: CLEAR wipes the reef, a bloom churns it, and a 0.3.7 save stops being a junk board

### DIFF
--- a/dynawalla/games/merge-idle/src/core/board.test.ts
+++ b/dynawalla/games/merge-idle/src/core/board.test.ts
@@ -9,14 +9,15 @@ import {
   hasLegalMerge,
   invariant,
   isCrowded,
-  lowestValue,
   makeBoard,
   move,
   peakValue,
   place,
   polyps,
-  purgeLowest,
+  purgeAll,
+  purgeTop,
   reefMass,
+  shuffleCells,
   spawn,
   trySplit,
   tryMerge,
@@ -131,16 +132,67 @@ test('an empty or partly empty shelf is never crowded', () => {
   assert.equal(isCrowded(b), false)
 })
 
-test('purge dissolves exactly the lowest rung and pays out its whole value', () => {
+test('CLEAR takes every polyp and pays out the whole shelf', () => {
   const b = makeBoard(3, 1)
   place(b, 0, 3)
   place(b, 1, 3)
   place(b, 2, 24)
-  const { gained, cells } = purgeLowest(b)
-  assert.equal(gained, 6)
-  assert.deepEqual(cells, [0, 1])
-  assert.equal(polyps(b).length, 1)
-  assert.equal(lowestValue(b), 24)
+  const { gained, cells } = purgeAll(b)
+  assert.equal(gained, 30)
+  assert.deepEqual(cells, [0, 1, 2])
+  assert.equal(polyps(b).length, 0, 'nothing may survive CLEAR')
+  assert.equal(emptyCells(b).length, 3)
+})
+
+test('the undertow takes the biggest polyps and nothing else', () => {
+  const b = makeBoard(5, 1)
+  place(b, 0, 3)
+  place(b, 1, 96)
+  place(b, 2, 5)
+  place(b, 3, 48)
+  place(b, 4, 1)
+  const { gained, cells } = purgeTop(b, 2)
+  assert.equal(gained, 144, '96 + 48 is what the undertow carried off')
+  assert.deepEqual(cells, [1, 3])
+  assert.deepEqual(
+    polyps(b)
+      .map((p) => p.value)
+      .sort((a, z) => a - z),
+    [1, 3, 5],
+    'the small useful polyps are exactly what stays',
+  )
+})
+
+test('the undertow takes nothing when asked for nothing', () => {
+  const b = makeBoard(2, 1)
+  place(b, 0, 3)
+  place(b, 1, 96)
+  const { gained, cells } = purgeTop(b, 0)
+  assert.equal(gained, 0)
+  assert.equal(cells.length, 0)
+  assert.equal(polyps(b).length, 2)
+})
+
+test('the shuffle moves polyps without creating, destroying or changing one', () => {
+  const b = makeBoard(4, 3)
+  const before = [1, 3, 5, 7, 9, 11, 13]
+  for (let i = 0; i < before.length; i++) place(b, i, before[i] as number)
+  shuffleCells(b, makeRng(20260728))
+  assert.deepEqual(
+    polyps(b)
+      .map((p) => p.value)
+      .sort((a, z) => a - z),
+    [...before].sort((a, z) => a - z),
+    'the shuffle is pure churn — the bag the target is answered from is unchanged',
+  )
+  assert.ok(invariant(b), 'every polyp still agrees with the cell it sits in')
+  const after = polyps(b).map((p) => p.cell)
+  assert.equal(new Set(after).size, after.length, 'no two polyps may share a cell')
+  // Churn, not a no-op: with seven polyps a fixed-point permutation is possible
+  // but this seed is not one, and a shuffle that never moved anything would be
+  // no turnover at all.
+  const moved = polyps(b).filter((p) => p.value !== before[p.cell]).length
+  assert.ok(moved > 0, 'the shuffle must actually move something')
 })
 
 test('growing the shelf keeps every polyp at the same column and row', () => {

--- a/dynawalla/games/merge-idle/src/core/board.ts
+++ b/dynawalla/games/merge-idle/src/core/board.ts
@@ -215,67 +215,91 @@ export function cull(b: Board, cell: number): number {
   return p.value
 }
 
-/** Lowest value present, or 0 on an empty board. */
-export function lowestValue(b: Board): number {
-  let lo = 0
-  for (const c of b.cells) if (c && (lo === 0 || c.value < lo)) lo = c.value
-  return lo
-}
-
 /**
- * CLEAR — dissolve from the bottom of the shelf until there is `want` room.
+ * CLEAR — wipe the shelf. Every polyp, no exceptions.
  *
- * ## Why this is not `purgeLowest`
+ * ## Why this takes everything, and why the two cleverer versions did not work
  *
- * It was, and the manual's promise — *"You can never get stuck. CLEAR always
- * works."* — was false because of it. One value class is often one polyp, so on
- * the full board the founder was handed, CLEAR freed a single cell, the reef put
- * something back into it, and he was exactly where he started:
+ * The manual promises the child *"You can never get stuck. CLEAR always works."*
+ * Two shipped attempts at making that true both failed, in opposite directions:
  *
- *   "now I hit 'clear' and only one goes away and a FREAKING 44 comes out .. so,
- *    now I just have a full board and it's stuck and the game sucks."
+ *   * `purgeLowest` cleared one value class, which on a shelf of forty distinct
+ *     numbers is ONE polyp. The reef put something back into the hole and the
+ *     founder was exactly where he started — *"only one goes away and a FREAKING
+ *     44 comes out .. so, now I just have a full board and it's stuck"*.
+ *   * `purgeUpTo` climbed the values until there was room. It made room, and it
+ *     made it out of the wrong polyps: smallest first takes the 1, 3, 5 and 7 —
+ *     the only values a small target can be answered with — and leaves the
+ *     accumulated giants standing. *"'clear' tends to just take out the good
+ *     (small) numbers instead of the enormous retarded numbers."*
  *
- * So CLEAR keeps going up the values until the shelf has real room, and the room
- * it makes is measured against what the reef owes: enough cells for every polyp
- * the current target still needs, plus slack to shuffle them. Smallest first,
- * because that is the cheapest reef mass to spend and it is what the child was
- * told would happen.
+ * Both were reasoning about *room*. Room was never the scarce thing; USEFUL
+ * polyps were. So CLEAR stops choosing. It takes the lot, the reef re-seeds (see
+ * `Engine.dissolve`), and the promise becomes trivially true rather than argued —
+ * there is no shelf from which pressing it fails to help, because there is no
+ * shelf afterwards.
  *
- * Free, always, and it stops the moment there is room — so it can never take more
- * of a reef than the escape costs.
+ * `gained` is the total value that left, which the floaters print so the child
+ * can see the size of what they spent.
  */
-export function purgeUpTo(b: Board, want: number): { gained: number; cells: number[] } {
-  const cells: number[] = []
-  let gained = 0
-  while (emptyCells(b).length < want) {
-    const round = purgeLowest(b)
-    if (round.cells.length === 0) break
-    gained += round.gained
-    cells.push(...round.cells)
-  }
-  return { gained, cells }
-}
-
-/**
- * DISSOLVE — clear every polyp at the lowest value on the shelf.
- *
- * One rung of `purgeUpTo`. `gained` is the total value that left, which the
- * floaters print so the child can see the size of what they spent.
- */
-export function purgeLowest(b: Board): { gained: number; cells: number[] } {
-  const lo = lowestValue(b)
-  if (lo === 0) return { gained: 0, cells: [] }
+export function purgeAll(b: Board): { gained: number; cells: number[] } {
   const cells: number[] = []
   let gained = 0
   for (let i = 0; i < b.cells.length; i++) {
     const c = b.cells[i]
-    if (c && c.value === lo) {
-      gained += c.value
-      cells.push(i)
-      b.cells[i] = null
-    }
+    if (!c) continue
+    gained += c.value
+    cells.push(i)
+    b.cells[i] = null
   }
   return { gained, cells }
+}
+
+/**
+ * THE UNDERTOW — carry the `n` biggest polyps off the shelf.
+ *
+ * Fired on a BLOOM, which is the maths moment: answer the number and the reef
+ * takes back what the answer was built beside. It is the turnover the founder
+ * asked for — *"when you get one right it shuffles and smashes and clears"* — and
+ * it is also the mechanism that stops the junk in the first place, because the
+ * only way a polyp gets big is that a child merged it, and the reef never hands
+ * one out (`EMIT_STEP` is 0). Take from the TOP and a shelf cannot silently
+ * accumulate a wall of numbers no small target can use.
+ */
+export function purgeTop(b: Board, n: number): { gained: number; cells: number[] } {
+  if (n <= 0) return { gained: 0, cells: [] }
+  const ranked = polyps(b)
+    .slice()
+    .sort((a, z) => z.value - a.value || a.cell - z.cell)
+    .slice(0, n)
+  const cells: number[] = []
+  let gained = 0
+  for (const p of ranked) {
+    gained += p.value
+    cells.push(p.cell)
+    b.cells[p.cell] = null
+  }
+  cells.sort((a, z) => a - z)
+  return { gained, cells }
+}
+
+/**
+ * Re-scatter every polyp into a fresh cell. Pure churn: nothing is created,
+ * destroyed or changed in value, and the bag the target is answered out of is
+ * bit-for-bit the same one. It exists so a bloom visibly *moves* the reef.
+ */
+export function shuffleCells(b: Board, rng: Rng): void {
+  const live = polyps(b)
+  if (live.length < 2) return
+  const slots = rng.shuffle(live.map((p) => p.cell))
+  b.cells = new Array(b.cols * b.rows).fill(null)
+  for (let i = 0; i < live.length; i++) {
+    const p = live[i] as Polyp
+    const cell = slots[i] as number
+    p.cell = cell
+    p.squash = 1
+    b.cells[cell] = p
+  }
 }
 
 /**

--- a/dynawalla/games/merge-idle/src/core/economy.ts
+++ b/dynawalla/games/merge-idle/src/core/economy.ts
@@ -276,6 +276,63 @@ export function bloomYield(depth: number): number {
   return Math.min(7, 3 + Math.floor(depth / 8))
 }
 
+/* ---------------------------------------------------------------- turnover */
+
+/**
+ * THE UNDERTOW — what a bloom carries away, and why a reward takes something.
+ *
+ * The founder played 0.3.8 with a shelf inherited from an older build and could
+ * not get out of it:
+ *
+ *   "I'm in this state where I have all of the old numbers from previous versions
+ *    so I have a bunch of irrelevant crap numbers and I can[not] clear them ...
+ *    there is no way to shake them up or get some random new numbers ... I think
+ *    the answer is constant juicy turnover and change"
+ *
+ * and he said what the turnover should be attached to: *"when you get one right it
+ * shuffles and smashes and clears"*. So a bloom does three things to the shelf
+ * instead of one — it re-scatters it, it carries the biggest polyps off it, and it
+ * throws `bloomYield` fresh seeds onto it.
+ *
+ * ## Why the BIGGEST, and why a quarter
+ *
+ * The reef only ever emits seeds (`EMIT_STEP` is 0), so every large polyp on the
+ * shelf is one a child merged. Without an undertow they are permanent: nothing
+ * consumes them but the mouth, and the mouth only takes the ones a target happens
+ * to call for. That is exactly how forty cells fill with numbers no small target
+ * can use, and it is the state he is stuck in.
+ *
+ * A quarter, measured against what a bloom puts back: `bloomYield` is 3 rising to
+ * 7, so on a shelf of 12 the undertow takes 3 and the bloom returns 3 — churn at
+ * flat mass. On a full 42-cell shelf it takes 10 and returns 5, which drains it,
+ * which is the point: the shelf that needs turning over most is the one that is
+ * full. Below the floor nothing is taken at all, because a sparse shelf has no
+ * accumulation to clear and a child in the first minute should never watch a
+ * reward remove things.
+ */
+export const UNDERTOW_DIVISOR = 4
+
+/** At or under this many polyps a bloom takes nothing. */
+export const UNDERTOW_FLOOR = 5
+
+export function undertowAt(count: number): number {
+  if (count <= UNDERTOW_FLOOR) return 0
+  return Math.max(1, Math.round(count / UNDERTOW_DIVISOR))
+}
+
+/**
+ * How many fresh seeds CLEAR leaves on the wiped shelf.
+ *
+ * CLEAR takes everything (see `board.ts`, `purgeAll`), and a bare shelf is not an
+ * escape: the reef owes at most six polyps, pays them at `STOCK_PERIOD_MS`, and
+ * then trickles at `emitPeriodMs` — 1.4 s at the very best, 4.2 s at the start. A
+ * target usually needs joining as well as landing, so a wipe with no re-seed is
+ * the better part of a minute of a child watching an empty board. Eight is what
+ * `seed()` opens a fresh reef with, so pressing CLEAR hands back exactly the
+ * position the game begins from.
+ */
+export const CLEAR_SEEDS = 8
+
 /* ------------------------------------------------------------------ offline */
 
 /** Eight hours. Past this the reef stops growing, so nobody feels obliged. */

--- a/dynawalla/games/merge-idle/src/core/engine.ts
+++ b/dynawalla/games/merge-idle/src/core/engine.ts
@@ -32,7 +32,9 @@ import {
   move,
   place,
   polyps,
-  purgeUpTo,
+  purgeAll,
+  purgeTop,
+  shuffleCells,
   spawn,
   trySplit,
   tryMerge,
@@ -43,12 +45,14 @@ import {
   baseStepFor,
   bloomLevel,
   bloomYield,
+  CLEAR_SEEDS,
   EMIT_STEP,
   emitPeriodMs,
   growthsAt,
   offlineGrowth,
   STOCK_PERIOD_MS,
   sumSlotsAt,
+  undertowAt,
 } from './economy.ts'
 import { canSplit, decompose, rank, valueOf, type Strain } from './ladder.ts'
 import {
@@ -75,6 +79,8 @@ export type Event =
   | { kind: 'grow'; cols: number; rows: number }
   | { kind: 'emit'; cell: number; value: number }
   | { kind: 'dissolve'; cells: number[]; gained: number }
+  | { kind: 'undertow'; cells: number[]; gained: number }
+  | { kind: 'shuffle' }
   | { kind: 'crowded' }
   | { kind: 'target'; value: number; form: Form; face: string }
   | { kind: 'refuse'; why: 'mouth-full' | 'no-halves' | 'no-room' | 'shelf-full' }
@@ -126,6 +132,39 @@ export const MAX_DEBT = 6
 
 /** The room CLEAR restores, and the point below which it is offered. */
 export const ESCAPE_CELLS = MAX_DEBT + ESCAPE_SLACK
+
+/**
+ * The save schema this reef writes.
+ *
+ * ## Why the shelf, and only the shelf, is thrown away on the way up from 2
+ *
+ * Version 2 was written by every build from 0.3.0 to 0.3.8, and 0.3.8's whole
+ * subject was the emitter: up to and including 0.3.7 a fresh polyp was
+ * `strain * 2 ** baseStepFor(depth)`, so the reef handed out 18s and 44s and the
+ * shelf filled with numbers no small target can use. 0.3.8 fixed the emitter and
+ * fixed nothing for anybody who already had a save — which was every tester:
+ *
+ *   "I'm in this state where I have all of the old numbers from previous versions
+ *    so I have a bunch of irrelevant crap numbers and I can[not] clear them and
+ *    leaving and coming back doesn't clear."
+ *
+ * The alternative considered and rejected was a load-time sweep of "values the
+ * current emitter could not have produced". It cannot work, and it is worth
+ * saying why rather than leaving it as a taste: the current emitter produces only
+ * seeds, and MERGING produces everything else, so the predicate "this game could
+ * not have made this polyp" is false for every value on the ladder. A sweep that
+ * dropped everything above step 0 would delete a legitimately merged 512 from a
+ * child at depth 40, and one that dropped nothing would leave the founder exactly
+ * where he is.
+ *
+ * So the version carries it. A v2 save loads, keeps `depth` and `grows` and the
+ * shelf's dimensions, and gets a fresh eight-seed shelf; it is then written back
+ * as v3 and never migrated again.
+ */
+export const SAVE_VERSION = 3
+
+/** The version whose SHELF cannot be trusted, though the rest of it can. */
+export const STALE_SHELF_VERSION = 2
 
 export class Engine {
   readonly s: State
@@ -352,6 +391,21 @@ export class Engine {
   }
 
   /**
+   * May CLEAR be pressed? Whenever there is a polyp to clear — *"'clear' should
+   * always be active"*.
+   *
+   * `needsRoom` used to gate the button as well as glow it, so a child who simply
+   * did not like the shelf they were looking at could not do anything about it
+   * until the shelf was nearly jammed. That is the founder's *"there is no way to
+   * shake them up or get some random new numbers"*, and it costs nothing to fix:
+   * CLEAR takes the reef with it, so pressing it early is a price, not an exploit.
+   * `needsRoom` still drives the glow, which is the only job it should have had.
+   */
+  get canClear(): boolean {
+    return polyps(this.s.board).length > 0
+  }
+
+  /**
    * Make the reef owe whatever the target still needs.
    *
    * Called after EVERY change to the shelf, which is the whole repair. The
@@ -503,6 +557,18 @@ export class Engine {
     this.s.baseStep = baseStepFor(this.s.depth)
     events.push({ kind: 'bloom', value: t.value, form: t.form, depth: this.s.depth })
 
+    // THE UNDERTOW — "when you get one right it shuffles and smashes and clears".
+    // The biggest polyps go, the survivors are re-scattered, and fresh seeds land
+    // in the churn. All three fire on the MATHS moment, not on a collision, and
+    // all three happen BEFORE `ask()` so the next target is chosen against the
+    // shelf the child is actually going to answer it from.
+    const swept = purgeTop(this.s.board, undertowAt(polyps(this.s.board).length))
+    if (swept.cells.length > 0) events.push({ kind: 'undertow', cells: swept.cells, gained: swept.gained })
+    if (polyps(this.s.board).length > 1) {
+      shuffleCells(this.s.board, this.deps.rng)
+      events.push({ kind: 'shuffle' })
+    }
+
     // The reward that is material: more life to merge.
     for (let i = 0; i < bloomYield(this.s.depth); i++) {
       const p = this.emitOne()
@@ -583,18 +649,35 @@ export class Engine {
   /**
    * CLEAR — the escape hatch, and the one promise this game makes out loud.
    *
-   * The manual tells the child *"You can never get stuck. CLEAR always works."*
-   * That sentence was false: `purgeLowest` cleared one value class, which on a
-   * shelf of forty distinct numbers is one polyp, the reef put something back into
-   * the hole, and the founder was exactly where he started. So CLEAR now goes up
-   * the values until there is room for everything the reef owes plus slack to work
-   * in, and `settle` reloads that debt on the way out — pressing it leaves a
-   * position the child can win from, which is the only thing the word means.
+   * **It wipes the shelf and re-seeds it.** Founder's ruling, and the third
+   * attempt at this button; the two that came before it are argued in `board.ts`
+   * above `purgeAll`. The short of it: both of them chose *which* polyps to take,
+   * both chose wrong, and the second chose wrong in the worst possible direction —
+   * smallest first eats the 1, 3, 5 and 7 that a small target is answered with and
+   * leaves the giants standing.
+   *
+   *   "'clear' tends to just take out the good (small) numbers instead of the
+   *    enormous retarded numbers that have accumulated ... maybe 'clear' should
+   *    always be active and should just wipe out all of the polyps or something."
+   *
+   * So it takes the lot and hands back `CLEAR_SEEDS` fresh seeds — the same eight
+   * a brand-new reef opens with. There is now nothing to argue about: the shelf
+   * after CLEAR is the shelf the game starts from, which is a position every
+   * target in the game is answerable from, so *"you can never get stuck"* is true
+   * by construction rather than by an argument about room.
+   *
+   * Free, always, and — see `canClear` — never greyed out while there is anything
+   * on the shelf at all.
    */
   dissolve(): Event[] {
-    const { gained, cells } = purgeUpTo(this.s.board, this.escapeRoom())
+    const { gained, cells } = purgeAll(this.s.board)
     if (cells.length === 0) return []
     const events: Event[] = [{ kind: 'dissolve', cells, gained }]
+    for (let i = 0; i < CLEAR_SEEDS; i++) {
+      const strain = this.deps.rng.int(0, 7) as Strain
+      const p = spawn(this.s.board, valueOf(strain, 0), this.deps.rng)
+      if (p) events.push({ kind: 'emit', cell: p.cell, value: p.value })
+    }
     this.settle(events)
     return events
   }
@@ -716,7 +799,7 @@ export class Engine {
       if (p) cells.push([i, p.value])
     }
     return JSON.stringify({
-      v: 2,
+      v: SAVE_VERSION,
       depth: this.s.depth,
       grows: this.s.grows,
       cols: this.s.board.cols,
@@ -741,7 +824,10 @@ export class Engine {
       mouth?: number[]
       lastSeen?: number
     }
-    if (Number(d.v) !== 2) throw new Error('merge-idle: save is from an older reef')
+    const v = Number(d.v)
+    if (v !== SAVE_VERSION && v !== STALE_SHELF_VERSION) {
+      throw new Error('merge-idle: save is from an older reef')
+    }
     this.s.depth = Math.max(0, Number(d.depth) || 0)
     this.s.grows = Math.max(0, Number(d.grows) || 0)
     this.s.bloom = bloomLevel(this.s.depth)
@@ -751,12 +837,25 @@ export class Engine {
     const cols = Math.max(START_COLS, Math.min(maxCols, Number(d.cols) || START_COLS))
     const rows = Math.max(START_ROWS, Math.min(maxRows, Number(d.rows) || START_ROWS))
     this.s.board = makeBoard(cols, rows)
-    for (const [cell, value] of d.cells ?? []) {
-      place(this.s.board, cell, value, this.deps.rng.int(0, 999) / 1000)
+    if (v === STALE_SHELF_VERSION) {
+      // A shelf written by a reef that emitted `strain * 2 ** baseStepFor(depth)`.
+      // Every polyp on it may be a number this game would never have handed out,
+      // and there is no way to tell which: a 44 a child MERGED and a 44 the old
+      // vent coughed up are the same integer. So the shelf goes and nothing else
+      // does — `depth` survives, and depth is all the progress there is. It drives
+      // how bright the water is, which operator forms are unlocked, what the host
+      // is asked for, how much a bloom yields and how big the shelf has grown, so
+      // a returning child keeps every one of those and loses only the junk they
+      // wrote in to complain about.
+      this.seed(CLEAR_SEEDS)
+    } else {
+      for (const [cell, value] of d.cells ?? []) {
+        place(this.s.board, cell, value, this.deps.rng.int(0, 999) / 1000)
+      }
+      // Anything that was in the mouth comes back to the shelf, not to the mouth:
+      // a target chosen for the old board may not be the one that comes up now.
+      for (const value of d.mouth ?? []) spawn(this.s.board, value, this.deps.rng)
     }
-    // Anything that was in the mouth comes back to the shelf, not to the mouth:
-    // a target chosen for the old board may not be the one that comes up now.
-    for (const value of d.mouth ?? []) spawn(this.s.board, value, this.deps.rng)
     for (const p of polyps(this.s.board)) p.born = 1
     this.s.crowded = isCrowded(this.s.board)
     return Math.max(0, Date.now() - (Number(d.lastSeen) || Date.now()))

--- a/dynawalla/games/merge-idle/src/core/engine.ts
+++ b/dynawalla/games/merge-idle/src/core/engine.ts
@@ -215,12 +215,17 @@ export class Engine {
    * band starts at the seeds too, and a shelf that opens above it is a shelf
    * nothing can be built out of.
    */
-  seed(n = 8): void {
+  seed(n = CLEAR_SEEDS): Polyp[] {
+    const made: Polyp[] = []
     for (let i = 0; i < n; i++) {
       const strain = this.deps.rng.int(0, 7) as Strain
       const p = spawn(this.s.board, valueOf(strain, 0), this.deps.rng)
-      if (p) p.born = 1
+      if (p) {
+        p.born = 1
+        made.push(p)
+      }
     }
+    return made
   }
 
   /** Away time, paid in polyps. See `economy.ts`, `offlineGrowth`. */
@@ -673,10 +678,11 @@ export class Engine {
     const { gained, cells } = purgeAll(this.s.board)
     if (cells.length === 0) return []
     const events: Event[] = [{ kind: 'dissolve', cells, gained }]
-    for (let i = 0; i < CLEAR_SEEDS; i++) {
-      const strain = this.deps.rng.int(0, 7) as Strain
-      const p = spawn(this.s.board, valueOf(strain, 0), this.deps.rng)
-      if (p) events.push({ kind: 'emit', cell: p.cell, value: p.value })
+    // Literally `seed()` — the same call a brand-new reef opens with, which is the
+    // whole claim this button now makes and not a second implementation of it.
+    for (const p of this.seed(CLEAR_SEEDS)) {
+      p.born = 0
+      events.push({ kind: 'emit', cell: p.cell, value: p.value })
     }
     this.settle(events)
     return events

--- a/dynawalla/games/merge-idle/src/core/stuck.test.ts
+++ b/dynawalla/games/merge-idle/src/core/stuck.test.ts
@@ -27,12 +27,28 @@
  *
  * `the founder's board` below reproduces all three against the real `Engine`
  * through nothing but public methods, and it FAILS on the code that shipped.
+ *
+ * ## What 0.3.9 adds, and why the file grew
+ *
+ * 0.3.8 fixed the emitter and the debt. The founder played it and was still stuck,
+ * for three reasons that are all here too:
+ *
+ *   4. **CLEAR took the wrong polyps.** It climbed from the SMALLEST, so it ate the
+ *      1, 3, 5 and 7 a small target is answered with and left the giants — *"'clear'
+ *      tends to just take out the good (small) numbers"*. It now wipes the shelf.
+ *   5. **A save from 0.3.7 was a permanent junk board.** The emitter fix reached
+ *      nobody who already had one, which was every tester. `a 0.3.7 save full of
+ *      old-emitter junk` is that save, byte for byte.
+ *   6. **Nothing ever left the shelf.** A polyp was permanent unless the mouth
+ *      happened to call for it, so the board could only accumulate. A bloom now
+ *      shuffles, sweeps the top and re-seeds.
  */
 
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { Engine, ESCAPE_CELLS } from './engine.ts'
-import { at, emptyCells, hasLegalMerge, place, polyps } from './board.ts'
+import { Engine, ESCAPE_CELLS, SAVE_VERSION, STALE_SHELF_VERSION } from './engine.ts'
+import { at, emptyCells, place, polyps } from './board.ts'
+import { CLEAR_SEEDS, UNDERTOW_FLOOR } from './economy.ts'
 import { canSplit, decompose } from './ladder.ts'
 import { makeRng } from './rng.ts'
 import { bagOf, ladderRoute, ladderValues, routeIn } from './target.ts'
@@ -69,7 +85,7 @@ function makeEngine(host: AskHost & { report(r: never): void }, seed: number): E
 function loadShelf(engine: Engine, depth: number, values: readonly number[]): void {
   engine.restore(
     JSON.stringify({
-      v: 2,
+      v: SAVE_VERSION,
       depth,
       grows: 0,
       cols: 6,
@@ -199,7 +215,7 @@ test('the reef owes the polyps the target needs the moment the shelf stops holdi
 
 /* ------------------------------------------------------------------------ CLEAR */
 
-test('CLEAR always works: a full shelf is always opened up, and SPLIT works again', () => {
+test('CLEAR wipes the wall of giants and leaves a shelf a small target can be built from', () => {
   const engine = makeEngine(fixedHost(5), 7)
   loadShelf(engine, 6, [...HIGH, 1, 4, 4])
   engine.ask()
@@ -207,11 +223,26 @@ test('CLEAR always works: a full shelf is always opened up, and SPLIT works agai
   engine.merge((fours[0] as { cell: number }).cell, (fours[1] as { cell: number }).cell)
   while (emptyCells(engine.s.board).length > 0) engine.tick(STEP_MS)
   assert.equal(emptyCells(engine.s.board).length, 0, 'the shelf is full again')
+  const giantsBefore = polyps(engine.s.board).filter((p) => p.value >= 18).length
+  assert.ok(giantsBefore >= 30, `only ${giantsBefore} giants on the founder's shelf`)
 
-  // The founder's exact complaint about the old CLEAR: "only one goes away".
   const events = engine.dissolve()
   const cleared = events.find((e) => e.kind === 'dissolve')
   assert.ok(cleared, 'CLEAR must do something on a full shelf')
+  assert.equal(cleared.cells.length, 42, 'CLEAR takes the WHOLE shelf, not a value class')
+
+  // The founder's complaint about the 0.3.8 CLEAR, which is the opposite of the
+  // 0.3.7 one: it took the small useful polyps and left the giants standing.
+  assert.equal(
+    polyps(engine.s.board).filter((p) => p.value >= 18).length,
+    0,
+    'not one of the accumulated giants may survive CLEAR',
+  )
+  const left = polyps(engine.s.board)
+  assert.equal(left.length, CLEAR_SEEDS, 'CLEAR hands back the eight a fresh reef opens with')
+  for (const p of left) {
+    assert.equal(decompose(p.value)?.step, 0, `CLEAR left a ${p.value}; only seeds may come back`)
+  }
   const free = emptyCells(engine.s.board).length
   assert.ok(
     free >= ESCAPE_CELLS,
@@ -221,17 +252,22 @@ test('CLEAR always works: a full shelf is always opened up, and SPLIT works agai
     engine.s.stock.length <= free,
     `the reef owes ${engine.s.stock.length} polyps into ${free} cells`,
   )
+  assert.equal(engine.solvable(), true, 'the position after CLEAR must be winnable')
 
   // "88 on a full board so you can't even split it" — a split needs a free cell,
   // so an escape that does not restore one has not restored the game either.
-  const big = polyps(engine.s.board).find((p) => canSplit(p.value))
-  assert.ok(big, 'the shelf still holds something halvable')
+  // Nothing on a re-seeded shelf halves (they are all seeds), so put an 88 back on
+  // it and check the gesture the jammed board refused.
+  const spare = emptyCells(engine.s.board)[0]
+  assert.ok(spare !== undefined, 'CLEAR left somewhere to put it')
+  assert.ok(place(engine.s.board, spare, 88), 'the 88 goes back on the shelf')
   const before = engine.s.splits
-  engine.split(big.cell)
+  engine.split(spare)
   assert.equal(engine.s.splits, before + 1, 'SPLIT must be possible again after CLEAR')
+  assert.equal(at(engine.s.board, spare)?.value, 44, 'and the 88 is now a pair of 44s')
 })
 
-test('CLEAR is offered before the shelf jams solid, and never when there is already room', () => {
+test('CLEAR is always pressable, and glows once the shelf is short of room', () => {
   const engine = makeEngine(fixedHost(5), 11)
   // ONE free cell — not jammed, but nowhere near enough to pay a debt into and
   // one drag away from being jammed. Waiting for the last cell to go before
@@ -240,6 +276,7 @@ test('CLEAR is offered before the shelf jams solid, and never when there is alre
   engine.ask()
   assert.equal(emptyCells(engine.s.board).length, 1, 'the shelf must have exactly one cell left')
   assert.equal(engine.needsRoom, true, 'one free cell is not room')
+  assert.equal(engine.canClear, true, 'a shelf with polyps on it can always be cleared')
 
   engine.dissolve()
   assert.ok(
@@ -247,6 +284,216 @@ test('CLEAR is offered before the shelf jams solid, and never when there is alre
     'CLEAR must leave at least the slack it promises',
   )
   assert.equal(engine.needsRoom, false, 'a shelf CLEAR has just opened up does not need more')
+  // And it is STILL pressable — the founder wants to be able to shake the reef up
+  // whenever he likes, not only once it has jammed.
+  assert.equal(engine.canClear, true, 'CLEAR is never greyed out while there is a polyp')
+})
+
+test('CLEAR is pressable on a roomy shelf a child simply does not like', () => {
+  const engine = makeEngine(fixedHost(5), 13)
+  loadShelf(engine, 6, [96, 96, 96])
+  assert.ok(emptyCells(engine.s.board).length > ESCAPE_CELLS, 'this shelf has plenty of room')
+  assert.equal(engine.needsRoom, false, 'and so it does not glow')
+  assert.equal(engine.canClear, true, 'but it is still pressable')
+  const events = engine.dissolve()
+  assert.ok(
+    events.some((e) => e.kind === 'dissolve'),
+    'pressing CLEAR on a roomy shelf must still clear it',
+  )
+  assert.equal(
+    polyps(engine.s.board).some((p) => p.value === 96),
+    false,
+    'the numbers the child wanted rid of are gone',
+  )
+})
+
+test('CLEAR does nothing at all on an empty shelf, and is not offered there', () => {
+  const engine = makeEngine(fixedHost(5), 17)
+  loadShelf(engine, 6, [])
+  assert.equal(polyps(engine.s.board).length, 0)
+  assert.equal(engine.canClear, false, 'there is nothing to clear')
+  assert.equal(engine.dissolve().length, 0, 'and pressing it must not re-seed out of nowhere')
+})
+
+/* --------------------------------------------------- the save he is actually in */
+
+/**
+ * The exact 0.3.7 shelf, written by the old emitter: `strain * 2 ** baseStepFor
+ * (depth)` at depth 30, so `baseStep` is 5 and every polyp is a seed times 32.
+ * Not one of these values is something the current reef could ever hand out, and
+ * a shelf of nothing but them is the founder's *"bunch of irrelevant crap
+ * numbers"*.
+ */
+const OLD_EMITTER_SHELF: readonly number[] = Array.from(
+  { length: 42 },
+  (_, i) => ([1, 3, 5, 7, 9, 11, 13, 15][i % 8] as number) * 32,
+)
+
+/** The literal bytes 0.3.7 wrote into `dynawalla.abyssal-bloom.v1`. */
+function stale037Save(depth: number, values: readonly number[]): string {
+  return JSON.stringify({
+    v: STALE_SHELF_VERSION,
+    depth,
+    grows: 4,
+    cols: 8,
+    rows: 9,
+    cells: values.map((v, i) => [i, v]),
+    mouth: [],
+    lastSeen: Date.now(),
+  })
+}
+
+test('a 0.3.7 save full of old-emitter junk loads into a shelf that is not stuck', () => {
+  const engine = makeEngine(fixedHost(5), 20260728)
+  engine.restore(stale037Save(30, OLD_EMITTER_SHELF))
+
+  // Every one of them is gone. This is the whole defect: 0.3.8 fixed the emitter
+  // and did nothing for a player who already had a save, which was every tester.
+  const left = polyps(engine.s.board)
+  assert.equal(left.length, CLEAR_SEEDS, `the stale shelf left ${left.length} polyps behind`)
+  for (const p of left) {
+    assert.equal(decompose(p.value)?.step, 0, `a ${p.value} survived the migration; only seeds may`)
+  }
+  assert.equal(
+    left.some((p) => OLD_EMITTER_SHELF.includes(p.value)),
+    false,
+    'not one of the old numbers may come back',
+  )
+
+  // And nothing else was taken. Depth is the only progress this game has: it is
+  // what brightens the water, unlocks the operator forms, sizes the ask and pays
+  // the bloom yield.
+  assert.equal(engine.s.depth, 30, 'depth must survive the migration')
+  assert.equal(engine.s.grows, 4, 'and the growths that earned the bigger shelf')
+  assert.equal(engine.s.board.cols, 8, 'and the shelf he grew')
+  assert.equal(engine.s.board.rows, 9)
+
+  // The founder's actual situation, stated as the thing he could not do: play.
+  engine.ask()
+  assert.equal(engine.solvable(), true, 'a migrated shelf must be a winnable position')
+  assert.ok(
+    playUntilBloom(engine, 400),
+    `never bloomed after migrating. shelf: [${polyps(engine.s.board)
+      .map((p) => p.value)
+      .sort((a, b) => a - b)
+      .join(', ')}]`,
+  )
+
+  // And it is written back as v3, so the migration happens once and never again.
+  assert.equal(JSON.parse(engine.snapshot()).v, SAVE_VERSION)
+})
+
+test('a v3 save keeps the shelf it was written with', () => {
+  const engine = makeEngine(fixedHost(5), 3)
+  loadShelf(engine, 6, [1, 3, 5, 7, 96])
+  assert.deepEqual(
+    polyps(engine.s.board)
+      .map((p) => p.value)
+      .sort((a, z) => a - z),
+    [1, 3, 5, 7, 96],
+    'the migration must not fire on a save this build wrote',
+  )
+})
+
+test('a save from a schema this reef has never seen is refused rather than misread', () => {
+  const engine = makeEngine(fixedHost(5), 3)
+  assert.throws(() => engine.restore(JSON.stringify({ v: 1, depth: 9, cells: [[0, 3]] })), /older reef/)
+})
+
+/* --------------------------------------------------------------- the turnover */
+
+test('a bloom carries the biggest polyps off the shelf and shakes the rest', () => {
+  const engine = makeEngine(fixedHost(5), 20260728)
+  // Twelve giants and the route to five, so the bloom is one feed away and the
+  // shelf it blooms on is exactly the accumulation the founder is complaining of.
+  loadShelf(engine, 6, [512, 256, 128, 96, 88, 80, 72, 64, 56, 48, 40, 32, 5])
+  engine.ask()
+  const before = polyps(engine.s.board).map((p) => p.value)
+  const five = polyps(engine.s.board).find((p) => p.value === 5)
+  assert.ok(five, 'the shelf holds the five')
+
+  const events = engine.feed(five.cell)
+  assert.ok(
+    events.some((e) => e.kind === 'bloom'),
+    'feeding the five must bloom',
+  )
+  const swept = events.find((e) => e.kind === 'undertow')
+  assert.ok(swept, 'a bloom must carry something off a shelf of thirteen')
+  // Thirteen polyps, one eaten by the mouth: twelve left, a quarter of which is 3.
+  assert.equal(swept.cells.length, 3, `the undertow took ${swept.cells.length}`)
+  assert.equal(swept.gained, 512 + 256 + 128, 'and it took them off the TOP')
+  assert.equal(
+    polyps(engine.s.board).some((p) => p.value === 512),
+    false,
+    'the biggest number on the shelf is exactly what a bloom is supposed to clear',
+  )
+  assert.ok(
+    events.some((e) => e.kind === 'shuffle'),
+    'and the survivors are shaken up',
+  )
+  assert.ok(
+    events.some((e) => e.kind === 'emit'),
+    'and fresh polyps land in the churn',
+  )
+  assert.ok(before.length > 0)
+})
+
+test('a bloom takes nothing off a sparse shelf — a reward may not feel like a tax', () => {
+  const engine = makeEngine(fixedHost(5), 5)
+  loadShelf(engine, 6, [5, 96, 48])
+  assert.ok(polyps(engine.s.board).length <= UNDERTOW_FLOOR, 'this shelf is under the floor')
+  engine.ask()
+  const five = polyps(engine.s.board).find((p) => p.value === 5)
+  assert.ok(five)
+  const events = engine.feed(five.cell)
+  assert.ok(events.some((e) => e.kind === 'bloom'))
+  assert.equal(
+    events.some((e) => e.kind === 'undertow'),
+    false,
+    'nothing may be carried off a shelf a child has barely started',
+  )
+  assert.equal(
+    polyps(engine.s.board).some((p) => p.value === 96),
+    true,
+    'the 96 they built is still theirs',
+  )
+})
+
+test('over a real session no polyp is permanent — the shelf is a different shelf twenty blooms later', () => {
+  // The founder's state is a shelf that only ever accumulates: *"I have all of the
+  // old numbers from previous versions ... and leaving and coming back doesn't
+  // clear."* So the claim to check is about IDENTITY, not about values — every
+  // polyp is stamped with one at birth and nothing ever copies it — and it is the
+  // claim the old build fails outright: without an undertow a polyp only leaves
+  // the shelf if the mouth happens to call for it.
+  const host = makeStubHost({ seed: 0x51ed })
+  const engine = makeEngine(host as never, 20260728)
+  engine.seed()
+  engine.ask()
+  // Get past the opening so the shelf is a real one, not eight seeds.
+  for (let i = 0; i < 4000 && engine.s.depth < 20; i++) {
+    engine.tick(STEP_MS)
+    step(engine)
+  }
+  assert.ok(engine.s.depth >= 20, `only reached depth ${engine.s.depth}`)
+  const before = new Set(polyps(engine.s.board).map((p) => p.id))
+  assert.ok(before.size >= 10, `only ${before.size} polyps on the shelf to measure`)
+  const mark = engine.s.depth
+  for (let i = 0; i < 4000 && engine.s.depth < mark + 20; i++) {
+    engine.tick(STEP_MS)
+    step(engine)
+  }
+  assert.ok(engine.s.depth >= mark + 20, `only reached depth ${engine.s.depth}`)
+  const survivors = polyps(engine.s.board).filter((p) => before.has(p.id)).length
+  const share = survivors / before.size
+  console.log(
+    `   twenty blooms on, ${survivors} of ${before.size} polyps are the same ones ` +
+      `(${(share * 100).toFixed(1)}%)`,
+  )
+  assert.ok(
+    share < 0.25,
+    `${survivors} of ${before.size} polyps sat through twenty blooms — that is the silt`,
+  )
 })
 
 /* ------------------------------------------------------------- the emission band */
@@ -271,7 +518,11 @@ test('the strains the reef emits are strains the target can actually use', () =>
   let onRoute = 0
   let total = 0
   for (let seed = 1; seed <= 6; seed++) {
-    drive(seed, 500, (value, owed, engine) => {
+    // 900 steps and not 500: the reef turns over faster now, so a larger share of
+    // what it emits is DEBT — the halves it owes — and those are excluded from
+    // this measurement by design. The sample is of ambient draws, so it has to be
+    // taken over enough play to still be one.
+    drive(seed, 900, (value, owed, engine) => {
       if (owed) return
       const t = engine.s.target
       if (!t) return
@@ -432,20 +683,23 @@ function step(engine: Engine, after: (where: string) => void = () => {}): void {
       return
     }
   }
-  if (emptyCells(s.board).length < 2 || !hasLegalMerge(s.board)) {
-    engine.dissolve()
-    after('CLEAR')
-    return
-  }
+  // SPLIT before CLEAR, and CLEAR only as the last thing left. This changed when
+  // CLEAR became a full wipe: the old bot pressed it whenever the shelf was merely
+  // *cramped*, which under the new button throws away a reef the child spent the
+  // session building. No player does that — CLEAR is the way out of a position you
+  // cannot play, and a bot that spends it casually is modelling nobody. Measured
+  // over the same 16 seeds × 2,500 steps: the casual bot bloomed 51 times at worst
+  // and sat on one target for 2,200 steps; this one blooms 412 times at worst and
+  // never sits longer than 131.
   const half = polyps(s.board)
     .filter((p) => canSplit(p.value))
     .sort((a, z) => z.value - a.value)[0]
-  if (half) {
+  if (half && emptyCells(s.board).length > 0) {
     engine.split(half.cell)
     after('a split')
+    return
   }
+  engine.dissolve()
+  after('CLEAR')
 }
 
-/** Kept honest: `place` and `at` are the shelf's only writers. */
-void place
-void at

--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -133,13 +133,22 @@ const INSTRUCTIONS = (reducedMotion: boolean): InstructionsSpec => ({
       ],
     },
     {
-      heading: 'When the reef is full',
+      heading: 'CLEAR',
       lines: [
-        'When the reef runs out of room, the CLEAR button starts glowing.',
-        'Press it. It is free.',
-        'It clears away the smallest polyps until there is real room again.',
-        'Then the reef grows the polyps your number needs.',
+        'The CLEAR button is always ready, and it is free.',
+        'Press it and every polyp goes. The reef starts again with eight small ones.',
+        'Use it whenever you like — when the reef is full, or when you just want different numbers.',
+        'When the reef runs out of room, CLEAR starts glowing to remind you.',
         'You can never get stuck. CLEAR always works.',
+      ],
+    },
+    {
+      heading: 'Every bloom shakes the reef',
+      lines: [
+        'When you make the number, the reef blooms — and it does not sit still.',
+        'The biggest polyps are carried away, the rest are shaken into new places,',
+        'and new small ones grow in the gaps.',
+        'So the reef never fills up with huge numbers you cannot use.',
       ],
     },
     {
@@ -826,6 +835,24 @@ export class Game {
           }
           break
         }
+        case 'undertow': {
+          // The smash half of "it shuffles and smashes and clears". It arrives in
+          // the same batch as the bloom, so it reads as one event with the maths
+          // moment rather than as a separate thing happening TO the child.
+          for (const cell of ev.cells) {
+            const c = cellCentre(l, s.board, cell)
+            if (!s.reduceMotion) this.particles.burst(c.x, c.y, 10, TIDE, 200, this.rnd)
+          }
+          this.audio.cull()
+          break
+        }
+        case 'shuffle': {
+          if (!s.reduceMotion) {
+            this.waves.add(l.w / 2, l.h * 0.45, 6, Math.max(l.w, l.h) * 0.7, 0.5, 11, TIDE)
+            this.punch.add(0.35)
+          }
+          break
+        }
         case 'grew-away':
           this.hud.toast(`${ev.polyps} NEW POLYPS GREW WHILE YOU WERE GONE`)
           break
@@ -941,10 +968,11 @@ export class Game {
       this.hud.setFace(face, `rgba(${hue[0]},${hue[1]},${hue[2]},.55)`)
     }
     this.hud.setMeter(s.depth % GROW_EVERY, GROW_EVERY, hex(hue))
-    // Offered the moment the shelf has less room than the reef needs to pay what
-    // it owes — not once the board has jammed solid. Waiting for the jam is a
-    // minute of a child watching nothing happen with the way out greyed out.
-    this.hud.setDissolve(this.engine.needsRoom, s.crowded)
+    // Live whenever there is a polyp to clear — a child who does not like the
+    // shelf they are looking at may say so at any moment, and CLEAR takes the reef
+    // with it, so it is a price rather than an exploit. `needsRoom` and `crowded`
+    // only make it GLOW, which is the job the gate should always have had.
+    this.hud.setDissolve(this.engine.canClear, this.engine.needsRoom || s.crowded)
 
     if (this.debug) {
       const n = this.fpsSamples.length

--- a/dynawalla/games/merge-idle/src/pause.test.ts
+++ b/dynawalla/games/merge-idle/src/pause.test.ts
@@ -601,3 +601,83 @@ test('opening and closing the manual repeatedly never double-pauses or double-re
     restore()
   }
 })
+
+/* ------------------------------------------------------------------- CLEAR */
+
+/**
+ * The CLEAR button is live from the first frame — mount level, because the wiring
+ * is the only thing here that can be wrong.
+ *
+ * `Engine.canClear` is asserted in `core/stuck.test.ts`. What that file cannot see
+ * is `game.ts` passing it to `hud.setDissolve`, and that line is the whole of the
+ * founder's *"maybe 'clear' should always be active"*: before it, the button was
+ * gated on `needsRoom`, so a reef with room was a reef whose way out was greyed
+ * out. Revert it and this test fails on the first assertion.
+ */
+function clearButton(h: Harness): FakeEl {
+  const found = h.made.filter(
+    (el) =>
+      el.className === 'ab-sbtn' &&
+      (el.children as FakeEl[]).some((c) => c.textContent === 'CLEAR'),
+  )
+  assert.equal(found.length, 1, `expected exactly one CLEAR button, found ${found.length}`)
+  return found[0] as FakeEl
+}
+
+test('CLEAR is live on a reef with plenty of room, and it takes the giants with it', () => {
+  const h = harness()
+  const restore = h.install()
+  // The founder's shelf, at mount: twelve numbers he cannot use and thirty free
+  // cells, so this is emphatically NOT the crowded case — which is the only case
+  // the old button was ever offered in.
+  const giants = [512, 256, 128, 96, 88, 80, 72, 64, 56, 48, 40, 32]
+  const saves: Save[] = []
+  useSaveSlot({
+    read: () =>
+      JSON.stringify({
+        v: 3,
+        depth: 12,
+        grows: 0,
+        cols: 6,
+        rows: 7,
+        cells: giants.map((v, i) => [i, v]),
+        mouth: [],
+        lastSeen: Date.now(),
+      }),
+    write: (value) => {
+      saves.push(JSON.parse(value) as Save)
+    },
+  })
+  const handle = new Game(h.root, makeStubHost({ seed: 0xab1e })).handle()
+  try {
+    for (let i = 0; i < 900 && saves.length === 0; i++) h.step(16)
+    const btn = clearButton(h)
+    assert.equal(btn.disabled, false, 'CLEAR must not be greyed out on a reef with room')
+
+    const before = saves[saves.length - 1] as Save
+    assert.ok(before, 'the reef never saved — the observable proves nothing')
+    const bigBefore = before.cells.filter(([, v]) => v >= 32).length
+    assert.equal(bigBefore, giants.length, `only ${bigBefore} giants were on the shelf`)
+
+    click(btn)
+    assert.equal(btn.disabled, false, 'and it is still live afterwards')
+    // One frame, then unmount — which saves. The shelf is read as CLEAR left it,
+    // BEFORE the reef has had a chance to pay any debt into it: a debt is settled
+    // at `STOCK_PERIOD_MS`, 320 ms, and those payments can legitimately be large,
+    // so a snapshot taken four seconds later is a snapshot of the reef and not of
+    // the button.
+    h.step(16)
+    handle.unmount()
+    const after = saves[saves.length - 1] as Save
+    assert.equal(
+      after.cells.filter(([, v]) => v >= 32).length,
+      0,
+      `CLEAR left ${after.cells.filter(([, v]) => v >= 32).length} of the giants standing`,
+    )
+    assert.ok(after.cells.length >= 8, `CLEAR left only ${after.cells.length} polyps to play with`)
+    assert.equal(after.depth, 12, 'and it costs the child none of their depth')
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})

--- a/dynawalla/games/merge-idle/src/qa/ask.test.ts
+++ b/dynawalla/games/merge-idle/src/qa/ask.test.ts
@@ -119,10 +119,33 @@ test('the target distribution is reported: sizes, forms, and where they come fro
   console.log('   depth   : ' + [...bands].sort().map(([b, n]) => `${b} ${pc(n)}`).join('  '))
   console.log(`   from the curriculum: ${pc(viaHost)}   multiples of 10: ${pc(round10)}, of 5: ${pc(round5)}`)
 
-  // The founder's "it might be kinda simple usually - 18": the great majority of
-  // targets are one to three digits, which is what a shelf of polyps can say.
+  // The founder's "it might be kinda simple usually - 18", asserted where the
+  // sentence actually means something: **inside the first 34 blooms**, which is
+  // every child who has not yet unlocked division. Measured over these 100
+  // sessions, 100.0% of the 3,400 targets in that band are one to three digits.
+  //
+  // The flat share over the whole run is NOT that claim and never was. It is
+  // `wantDigitsAt`, which is designed to reach four digits at depth 36 and does;
+  // so the number it reports is mostly a measure of how far the bot got, and it
+  // moved from 79.6% to 77.3% for the honest reason that the turnover in 0.3.9
+  // makes a 700-step session reach 118 blooms instead of 96. It is kept, below the
+  // measurement, as a floor on the mix rather than as the small-targets claim.
+  const early = rows.filter((t) => t.depth < 34)
+  const earlySmall = early.filter((t) => String(t.value).length <= 3).length
+  assert.ok(early.length > 2000, `only ${early.length} targets inside the first 34 blooms`)
+  assert.equal(
+    earlySmall,
+    early.length,
+    `${early.length - earlySmall} of ${early.length} early targets ran past three digits`,
+  )
   const small = (digits.get(1) ?? 0) + (digits.get(2) ?? 0) + (digits.get(3) ?? 0)
-  assert.ok(small / rows.length > 0.8, `only ${pc(small)} of targets were 1-3 digits`)
+  assert.ok(small / rows.length > 0.72, `only ${pc(small)} of targets were 1-3 digits`)
+  // Five figures is the founder's photograph — `58042 + 968`. It is not zero here
+  // only because the very deepest sessions brush it; it must stay a rounding error.
+  assert.ok(
+    (digits.get(5) ?? 0) / rows.length < 0.005,
+    `${pc(digits.get(5) ?? 0)} of targets were five figures`,
+  )
   // And not so simple that one polyp does it: the big five-figure numbers are gone.
   assert.equal(digits.get(6) ?? 0, 0, 'a six-figure target is the bug this redesign is about')
 })

--- a/dynawalla/games/merge-idle/src/ui/hud.ts
+++ b/dynawalla/games/merge-idle/src/ui/hud.ts
@@ -17,7 +17,9 @@
  * each deletion; this file is what is left.
  *
  * Two buttons survive, in the corners the host's chrome does not use: CLEAR,
- * because a crowded shelf must never be a losing position, and the mute toggle.
+ * because a crowded shelf must never be a losing position — and because a child
+ * who simply does not like the numbers in front of them must be able to say so —
+ * and the mute toggle.
  * `ui/chrome.ts` decides where they go — in landscape they both move to the right,
  * because the bottom-left of a landscape stage is shelf.
  */
@@ -135,7 +137,10 @@ export class Hud {
 
     this.dissolveBtn.className = 'ab-sbtn'
     this.dissolveBtn.type = 'button'
-    this.dissolveBtn.setAttribute('aria-label', 'Dissolve the smallest polyps')
+    // Not "dissolve the smallest polyps" any more, and the label mattered: it was
+    // the only place a child was told which polyps CLEAR takes, and it was telling
+    // them the thing the founder played and hated. It takes all of them.
+    this.dissolveBtn.setAttribute('aria-label', 'Clear the whole reef and start it again')
     const dk = document.createElement('span')
     dk.className = 'k'
     dk.textContent = '✳'


### PR DESCRIPTION
The founder is stuck in 0.3.8. Three defects, all fixed here.

## 1 — CLEAR removed exactly the wrong polyps

`dissolve()` called `purgeUpTo`, which climbs from the **smallest** value up
until there is room. So it ate the 1, 3, 5 and 7 a small target is answered
with, and left the accumulated giants standing:

> "'clear' tends to just take out the good (small) numbers instead of the
> enormous retarded numbers that have accumulated ... maybe 'clear' should
> always be active and should just wipe out all of the polyps or something."

**Implemented as ruled.** CLEAR takes every polyp (`purgeAll`) and hands back
`CLEAR_SEEDS` = 8 fresh seeds — the same eight `seed()` opens a brand-new reef
with. It is never greyed out while there is a polyp on the shelf
(`Engine.canClear`); `needsRoom` now only makes it *glow*.

Wiping literally everything and leaving the shelf bare **is** wrong for the
economy, and the eight seeds are the fix, with the numbers: the reef owes at
most 6 polyps, pays them at `STOCK_PERIOD_MS` (320 ms) and then trickles at
`emitPeriodMs` — 4.2 s at the start, 1.4 s at the floor. A target needs joining
as well as landing, so a bare wipe is the better part of a minute of a child
watching an empty board. Re-seeding hands back exactly the position the game
begins from, which is a position every target in the game is answerable from.

`purgeUpTo` and `purgeLowest` are **deleted**, so the wrong-polyp logic cannot
come back.

## 2 — a save from a previous version was a permanent junk board

Every build from 0.3.0 to 0.3.8 wrote `v: 2` (checked: `v: 2` was introduced in
#722). So the 0.3.8 emitter fix reached nobody who already had a save, which is
every existing tester.

**Save version bumped to 3, with a migration — not an orphan.** A v2 save
loads; `depth`, `grows`, `cols` and `rows` survive; the shelf is dropped and
re-seeded; it is written back as v3 and never migrated again. Depth is all the
progress this game has — it drives the bloom level, the form unlocks, the host
difficulty, the bloom yield and the shelf size — and every bit of it is kept.

A **load-time sweep was considered and rejected**, and the reasoning is in the
code: the current emitter produces only seeds and MERGING produces everything
else, so the predicate "this game could not have produced this polyp" is false
for every value on the ladder. A sweep that dropped everything above step 0
would delete a legitimately merged 512 from a child at depth 40; one that
dropped nothing would leave the founder exactly where he is. The version has to
carry it.

## 3 — no turnover

> "there is no way to shake them up or get some random new numbers ... when you
> get one right it shuffles and smashes and clears"

A bloom now does all three, in that order, **before** the next target is chosen:

* **sweeps** the biggest quarter of the shelf (`purgeTop` + `undertowAt`). The
  top, because the reef only ever emits seeds — every big polyp is one a child
  merged, and without an undertow it is permanent.
* **shuffles** the survivors (`shuffleCells`) — pure churn, the bag the target
  is answered from is bit-for-bit unchanged.
* **re-seeds** via the existing `bloomYield`.

Nothing is taken from a shelf of five polyps or fewer (`UNDERTOW_FLOOR`): a
reward may not feel like a tax to a child in their first minute.

All of it fires on the maths moment, never on a collision. No clock is added
anywhere.

## Measured

| | before | after |
|---|---|---|
| worst time on one target (16 seeds × 2500 steps) | 2,200 steps | 131 |
| worst blooms in a session | 51 | 412 |
| blooms in a 700-step qa session (median of 100) | 96 | 118 |
| polyps surviving 20 blooms | — | 0 of 39 |

The faster progression moves the global target digit-mix (77.3% 1–3 digits vs
79.6%) purely because a fixed-length session now reaches deeper. `qa/ask.test.ts`
now asserts the claim where it means something — **100.0% of the 3,400 targets
inside the first 34 blooms are 1–3 digits** — plus a floor on the global mix and
a new cap on five-figure targets.

## Copy

The manual promised "It clears away the smallest polyps until there is real
room again", and the button's aria-label said "Dissolve the smallest polyps".
Both are rewritten, plus a new manual section on the bloom churn. A promise the
code does not keep is how this game got here.

## Verification

* `npm run -s tsc` clean; `npm run -s test` **1091 pass / 0 fail, five
  consecutive runs**.
* `node dynawalla/packs/build.mjs merge-idle` builds and passes the SDK checker.
* `src/core/stuck.test.ts` never-stuck property test green, seed 20260728.
* New: **`a 0.3.7 save full of old-emitter junk loads into a shelf that is not
  stuck`** — a byte-for-byte v2 save whose 42 polyps are all
  `strain * 2 ** baseStepFor(30)`, asserted to migrate, keep depth 30, and then
  actually bloom.
* One driver change: the property test's bot now presses CLEAR as a **last
  resort** (after split) rather than whenever the shelf is merely cramped. Under
  a full-wipe CLEAR the old bot threw away a reef it had spent the session
  building, which is a player who does not exist. Documented at the call site
  with the numbers above.

### Mutation transcript — 19 mutants, 19 killed

Every one applied to the source, run, and reverted. The exact failure message:

| # | mutation | message |
|---|---|---|
| M1 | `purgeAll` spares the biggest polyp | `Expected values to be strictly equal:` (gained 30 vs 18) |
| M2 | undertow takes the SMALLEST | `96 + 48 is what the undertow carried off` |
| M3 | undertow ignores its `n <= 0` guard | `Expected values to be strictly equal:` |
| M4 | the shuffle is a no-op | `the shuffle must actually move something` |
| M5 | the shuffle loses a polyp | `the shuffle is pure churn — the bag the target is answered from is unchanged` |
| M6 | CLEAR spares the giants again | `CLEAR takes the WHOLE shelf, not a value class` |
| M7 | `canClear` gated on `needsRoom` | `but it is still pressable` |
| M8 | CLEAR re-seeds an empty shelf | `and pressing it must not re-seed out of nowhere` |
| M9 | stale-shelf migration never fires (0.3.8 behaviour) | `the stale shelf left 42 polyps behind` |
| M10 | migration fires on a v3 save too | `the migration must not fire on a save this build wrote` |
| M11 | any save version accepted | `Missing expected exception.` |
| M12 | a bloom sweeps nothing | `a bloom must carry something off a shelf of thirteen` |
| M13 | a bloom does not shuffle | `and the survivors are shaken up` |
| M14 | the undertow floor removed | `nothing may be carried off a shelf a child has barely started` |
| M15 | nothing ever leaves the shelf (pre-0.3.9) | `12 of 39 polyps sat through twenty blooms — that is the silt` |
| M16 | the depth ramp gone, top rung from bloom one | `2050 of 3376 early targets ran past three digits` |
| M17 | the five-figure ceiling lifted | `only 68.3% of targets were 1-3 digits` |
| M18 | `game.ts` wiring reverted to `needsRoom` | `CLEAR must not be greyed out on a reef with room` |
| M19 | CLEAR takes one polyp (seen through the mount) | `CLEAR left 11 of the giants standing` |

M18/M19 are killed by a new **mount-level** test in `pause.test.ts` — the game's
only headless harness — because the `setDissolve` wiring is the one thing a pure
test cannot see, and it is exactly the line the founder's complaint is about.

An earlier M16 (`wantDigitsAt` forced to 4) did **not** fail, which was the
mutant being wrong rather than the assertion being vacuous: `wantDigitsAt` only
feeds the candidate *score*, not the ceiling. Replaced with `difficultyAt`,
above, which does.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb