### PR TITLE
dynawalla/games/arena: apparent speed is a designed band — the camera was outrunning the swimmer

### DIFF
--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, DIFFICULTY_RUNGS, FLOOR_MASS, MK_FOOD, MK_VOID, MK_SHED } from "./world.ts"
+import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, APPARENT_FLOOR, baseSpeedFor, speedScaleFor, traversalSpeedFor, DIFFICULTY_RUNGS, FLOOR_MASS, MK_FOOD, MK_VOID, MK_SHED } from "./world.ts"
 import { MAX_GUARD_SECONDS, comprehensionSeconds, guardSeconds } from "./window.ts"
 import { Rng } from "../core/rng.ts"
 import { DEPTHS, depthFor, overdrive } from "./depths.ts"
@@ -1595,6 +1595,148 @@ test("a child cannot find the edge of the world by swimming at it", () => {
     assert.ok(Number.isFinite(arenaRadiusFor(m)))
     assert.ok(arenaRadiusFor(m) > viewSpanFor(m) * 60, `the arena is only ${arenaRadiusFor(m) / viewSpanFor(m)} spans wide at mass ${m}`)
   }
+})
+
+/**
+ * "when you get big the game seems to slow down ... It seems like maybe the
+ *  scale of the world just changes such that it feels like I'm moving extremely
+ *  slowly ... it could stay a little faster feeling when floating around"
+ *
+ * He was right about the cause and it was worth measuring before touching
+ * anything, because two duller explanations had to die first.
+ *
+ *   * NOT the framerate. Mid tier, one seed, a twenty-minute run: the sim cost
+ *     0.030 ms a frame at mass 36 and 0.030 ms a frame at mass 47,301, with no
+ *     trend anywhere in between. It cannot move — the mote and rival budgets are
+ *     hard caps (360 and 26) that are not functions of mass, and the field at
+ *     twenty minutes carried 94 motes against the opening field's 83.
+ *   * NOT a damping term. There is no speed-versus-mass penalty in the sim at
+ *     all; world speed RISES with mass, 403 u/s to 2,456 u/s across that run.
+ *
+ * It was the third thing: `viewSpanFor` widened 6.4x while speed rose 4.7x, so
+ * the ratio — the only quantity a player can actually perceive — fell from 1.03
+ * screen-widths a second to 0.23. Nothing in the file owned that number, so it
+ * was whatever the two curves happened to leave behind.
+ *
+ * It is owned now, and this is the assertion on it. The property is a BAND, not
+ * a constant: growing must still slow you down, because that is where the sense
+ * of scale comes from. It may no longer slow you down without limit.
+ */
+test("apparent speed is a designed band, and the opening is not in it", () => {
+  const masses: number[] = []
+  for (let m = 10; m <= 1_000_000; m *= 1.3) masses.push(Math.round(m))
+
+  let lo = Infinity
+  let hi = 0
+  let loAt = 0
+  for (const m of masses) {
+    const apparent = traversalSpeedFor(m) / viewSpanFor(m)
+    if (apparent < lo) {
+      lo = apparent
+      loAt = m
+    }
+    hi = Math.max(hi, apparent)
+  }
+
+  // The floor is the whole fix: at a million mass the old curve crossed the
+  // glass at 0.037 screen-heights a second, which is the founder's "extremely
+  // slowly" and is 13x slower than the opening.
+  // The number is written out here rather than read from `APPARENT_FLOOR`, and
+  // that is not a style choice: the first cut of this test asserted against the
+  // constant, so setting the constant to zero — deleting the entire fix — moved
+  // the goalposts with it and the assertion passed. A design decision has to be
+  // pinned somewhere the code cannot reach.
+  assert.ok(
+    lo >= 0.24 - 1e-9,
+    `the slowest the arena ever feels is ${lo.toFixed(4)} screen-heights/s at mass ${loAt}, under the 0.24 floor the design chose`,
+  )
+  // …and the ceiling is the opening, untouched. A "fix" that made the whole
+  // game faster would pass the floor and fail the founder, who likes the
+  // opening: "Arena is pretty good."
+  assert.ok(hi <= 0.49, `the arena now peaks at ${hi.toFixed(4)} screen-heights/s; the opening was 0.4835`)
+  assert.ok(hi / lo <= 2.05, `apparent speed still swings ${(hi / lo).toFixed(2)}x across a run; it used to swing 13x`)
+
+  // Growing is still a real cost — this is a floor, not a flattening.
+  const openApparent = traversalSpeedFor(10) / viewSpanFor(10)
+  const grownApparent = traversalSpeedFor(1000) / viewSpanFor(1000)
+  assert.ok(
+    openApparent > grownApparent,
+    `growing to mass 1,000 cost nothing: ${openApparent.toFixed(4)} -> ${grownApparent.toFixed(4)} screen-heights/s`,
+  )
+
+  // Bigger is never slower in WORLD units. Agar's law lives on `agility`, and a
+  // floor that ran downhill anywhere would be a floor applied to the wrong term.
+  for (let i = 1; i < masses.length; i++) {
+    const a = traversalSpeedFor(masses[i - 1] as number)
+    const b = traversalSpeedFor(masses[i] as number)
+    assert.ok(b >= a, `speed fell from ${a.toFixed(1)} to ${b.toFixed(1)} between mass ${masses[i - 1]} and ${masses[i]}`)
+  }
+
+  // Below the crossover nothing changed at all, to the bit. The opening was
+  // tuned by hand and is not what he complained about.
+  for (const m of [10, 30, 100, 300, 1000, 2000]) {
+    assert.equal(speedScaleFor(m), 1, `the scale engaged at mass ${m}, inside the opening`)
+    assert.equal(traversalSpeedFor(m), baseSpeedFor(m), `travel speed moved at mass ${m}, inside the opening`)
+  }
+
+  assert.equal(APPARENT_FLOOR, 0.24, "the floor moved; if that was deliberate, the numbers in this file move with it")
+})
+
+/**
+ * The same property, measured off the simulation rather than off the formula.
+ *
+ * A test that only calls `traversalSpeedFor` is a test that passes with the fix
+ * deleted from `stepPlayer`, which is exactly the failure mode this file has
+ * shipped before. So this one swims: it pins a mass, points the core at a
+ * horizon five million units away, waits out the turn lag, and measures how much
+ * of the SCREEN the next two seconds actually bought.
+ */
+test("a child at any size crosses the glass at a rate the design chose", () => {
+  const swum = (mass: number, seed: number): number => {
+    const world = new World(createStubHost({ seed }), specFor("mid"), seed * 13)
+    world.mass = mass
+    world.bestMass = mass
+    world.massVis = mass
+    // Mass is re-pinned every frame: this measures travel, and a swallow or a
+    // sting mid-sample would be measuring the economy instead.
+    const aim = (): void => {
+      world.mass = mass
+      world.aimX = world.px + 5_000_000
+      world.aimY = world.py
+    }
+    for (let f = 0; f < 180; f++) {
+      aim()
+      world.step(1 / 60)
+    }
+    let travelled = 0
+    for (let f = 0; f < 120; f++) {
+      aim()
+      const x0 = world.px
+      const y0 = world.py
+      world.step(1 / 60)
+      travelled += Math.hypot(world.px - x0, world.py - y0)
+    }
+    return travelled / 2 / viewSpanFor(mass)
+  }
+
+  // Measured before this pass, same harness: 0.484 / 0.368 / 0.248 / 0.147 /
+  // 0.073 / 0.037. The last three are the complaint.
+  for (const seed of [3, 21]) {
+    for (const mass of [5_000, 20_000, 100_000, 400_000]) {
+      const apparent = swum(mass, seed)
+      // 0.228 is the 0.24 floor with 5% of slack for the turn lag and for
+      // Float32 position resolution out at the far coordinates. Written out,
+      // not read from the constant — see the note in the test above.
+      assert.ok(
+        apparent >= 0.228,
+        `at mass ${mass} a child actually swims ${apparent.toFixed(4)} screen-heights a second, under the 0.24 the design chose`,
+      )
+      assert.ok(apparent <= 0.49, `at mass ${mass} a child swims ${apparent.toFixed(4)} screen-heights a second — faster than the opening`)
+    }
+  }
+
+  // And the opening still swims at the number the previous pass tuned it to.
+  assert.ok(Math.abs(swum(10, 3) - 0.4835) < 0.01, `the opening now swims at ${swum(10, 3).toFixed(4)}, not 0.4835`)
 })
 
 /**

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -477,6 +477,81 @@ export function viewSpanFor(mass: number): number {
 }
 
 /**
+ * The floor under APPARENT speed, in screen-heights per second.
+ *
+ * "when you get big the game seems to slow down. I'm not sure if it's the actual
+ *  framerate. It doesn't seem like it. It seems like maybe the scale of the world
+ *  just changes such that it feels like I'm moving extremely slowly."
+ *
+ * He is right, and it is neither the framerate nor a damping term. Measured, mid
+ * tier, a twenty-minute run at 0.7 accuracy:
+ *
+ *   t=5s    mass 36      world speed  526 u/s   0.030 ms/frame   1.025 screen-widths/s
+ *   t=60s   mass 1,095   world speed 1065 u/s   0.032 ms/frame   0.616
+ *   t=300s  mass 19,429  world speed 1905 u/s   0.039 ms/frame   0.299
+ *   t=1200s mass 47,301  world speed 2263 u/s   0.030 ms/frame   0.234
+ *
+ * The simulation cost does not move — it cannot, because the mote and rival
+ * budgets are hard caps (360 and 26) that do not grow with mass, and the field
+ * at twenty minutes carried FEWER motes than the field at five seconds. World
+ * speed does not fall either; it rises 4.7x. What falls is the ratio, because
+ * `viewSpanFor` widens 6.4x faster than speed rises. Apparent speed is a
+ * quantity nothing in this file owned, so it was whatever the two curves
+ * happened to leave behind: a 4.6x decay, running the wrong way round.
+ *
+ * So apparent speed becomes a DESIGNED quantity with a floor. Below the
+ * crossover — about mass 2,200, roughly the second minute — nothing changes at
+ * all, because the opening is not what he complained about. Above it, speed is
+ * whatever holds the view crossing at this rate, which is exactly half the
+ * opening's 0.483. Growing still slows you down; it can no longer slow you down
+ * without limit.
+ *
+ * The floor is stated in screen-heights because that is the unit `gfx` renders
+ * in. On a 1080x2340 the same number is 0.52 screen-WIDTHS per second.
+ */
+export const APPARENT_FLOOR = 0.24
+
+/**
+ * The speed curve as it has always been, extracted unchanged so that the player
+ * and every rival read it from one place.
+ *
+ * `base` is the speed a 28-unit body makes; 400 is the player's. `exp` is
+ * Agar's law — mass buys back only part of its speed. Nothing here is new; the
+ * apparent-speed floor is a multiplier ON this, applied by `speedScaleFor`.
+ */
+export function baseSpeedFor(mass: number, base = 400, exp = 0.42): number {
+  return base * Math.pow(Math.max(18, R_K * Math.sqrt(mass)) / 28, exp)
+}
+
+/**
+ * ONE multiplier on every travel speed in the arena, keyed to the CAMERA rather
+ * than to the body that is moving.
+ *
+ * The first attempt floored each body against its own view span, which looks
+ * equivalent and is not. `baseSpeedFor` is a 0.21 power of mass; a span floor is
+ * a 0.5 power of mass. Flooring per-body therefore makes speed far more
+ * sensitive to size than the curve ever was, and the sign of a chase flips: the
+ * largest legally edible rival (mass / 1.07) used to make 1.01x the player's
+ * speed and would have made 0.99x, which turns the one prize that cannot be
+ * caught into the one prize that always can. Measured, the hunting bot went from
+ * 13 kills and a peak of 2.8e5 to 42 kills and 1.5e9 — every kill compounds, so
+ * a small change in catchability is orders of magnitude in mass.
+ *
+ * A single scale cannot do that. Player:rival, rival:rival and leviathan:
+ * everything are all preserved exactly, because they are all multiplied by the
+ * same number. What changes is only the thing that was wrong — how much of the
+ * SCREEN a second of swimming buys.
+ */
+export function speedScaleFor(playerMass: number): number {
+  return Math.max(1, (viewSpanFor(playerMass) * APPARENT_FLOOR) / baseSpeedFor(playerMass))
+}
+
+/** The player's own travel speed, in world units per second. */
+export function traversalSpeedFor(playerMass: number): number {
+  return baseSpeedFor(playerMass) * speedScaleFor(playerMass)
+}
+
+/**
  * How many view-spans of world lie between the player and the membrane.
  *
  * "Why is there an edge of the board?" — because there was one, five seconds
@@ -1055,9 +1130,12 @@ export class World {
     // mass still costs agility, below, which is where "majestic" actually comes
     // from. Measured, with the wider opening view: 0.48 screen-heights per
     // second at the start (was 1.13) and 0.13 at mass 20,000 (was 0.12).
+    //
+    // That pass fixed the opening and left the far end alone; APPARENT_FLOOR is
+    // the far end. Everything below the crossover is still exactly the two
+    // numbers above.
   get playerSpeed(): number {
-    const r = this.playerRTrue
-    return 400 * Math.pow(Math.max(18, r) / 28, 0.42)
+    return traversalSpeedFor(this.mass)
   }
 
   /** The largest rival `k` may be before the world recycles it. */
@@ -1870,6 +1948,7 @@ export class World {
 
   private stepRivals(dt: number): void {
     const frame = (this.time * 60) | 0
+    const scale = speedScaleFor(this.mass)
     for (let i = 0; i < MAX_RIVALS; i++) {
       if ((this.rrespawn[i] as number) > 0) {
         this.rrespawn[i] = (this.rrespawn[i] as number) - dt
@@ -1924,8 +2003,12 @@ export class World {
       // did: at DRIFT's temper of 0.22 a rival makes 324 against the player's
       // 403, so early prey is genuinely catchable; at THE LAST LIGHT's 1.0 it
       // makes 410 and nothing is safe.
+      //
+      // Both ends move together at the far end too. `speedScaleFor` is keyed to
+      // the PLAYER's mass, not this rival's, precisely so that every ratio this
+      // comment is about survives the apparent-speed floor untouched.
       const base = lev ? 240 : 300 + temper * 110
-      let speed = base * Math.pow(Math.max(18, rr) / 28, lev ? 0.35 : 0.42)
+      let speed = baseSpeedFor(m, base, lev ? 0.35 : 0.42) * scale
 
       // Surging costs a rival mass exactly as it costs the player, so a long
       // chase genuinely wears the hunter down and the leaderboard churns.


### PR DESCRIPTION
## The report

> "Arena is pretty good. when you get big the game seems to slow down. I'm not sure if it's the actual framerate. It doesn't seem like it. It seems like maybe the scale of the world just changes such that it feels like I'm moving extremely slowly. I'm not sure. But it could stay a little faster feeling when floating around maybe"

He is right, and it is the camera. Measured before touching anything.

## Diagnosis — the two duller explanations are dead

**Not the framerate.** Mid tier, seeded, twenty-minute run at 0.7 accuracy, timing 200 real `world.step` calls at each mark:

| t (s) | mass | motes | rivals | sim ms/frame |
| --- | --- | --- | --- | --- |
| 5 | 36 | 83 | 4 | 0.030 |
| 60 | 1,095 | 103 | 8 | 0.032 |
| 300 | 19,429 | 154 | 16 | 0.039 |
| 900 | 53,405 | 133 | 16 | 0.037 |
| 1200 | 47,301 | 94 | 9 | 0.030 |

There is no trend, and there cannot be one: `MAX_MOTES` is 360 and `MAX_RIVALS` is 26, neither is a function of mass, and the field at twenty minutes carried **fewer** motes (94) than the opening field (83→103). Per-frame cost is flat to the noise floor.

**Not a damping term.** There is no speed-versus-mass penalty in the sim at all. World speed *rises* with mass, 403 u/s → 2,263 u/s across that run. Mass costs *agility* (`agility = 10.0 * (30/r)^0.45`, turn authority), never top speed.

**It is the camera.** `viewSpanFor(mass)` widens as `sqrt(mass)`; `playerSpeed` rose as `mass^0.21`. So the view widened 6.4x while speed rose 4.3x, and apparent speed — screen-widths per second, the only thing a player can actually perceive — fell 4.6x. Nothing in the file owned that number; it was whatever the two curves happened to leave behind.

## The before/after curve

Screen-widths per second, phone held tall (1080x2340, aspect 0.4615). `viewSpanFor` is world units across the screen's **height**, so widths = span x 0.4615.

| mass | view width (u) | world u/s BEFORE | world u/s AFTER | scr-w/s BEFORE | scr-w/s AFTER |
| --- | --- | --- | --- | --- | --- |
| 10 | 384 | 403 | 403 | 1.047 | 1.047 |
| 30 | 490 | 507 | 507 | 1.035 | 1.035 |
| 100 | 697 | 653 | 653 | 0.937 | 0.937 |
| 300 | 1031 | 823 | 823 | 0.798 | 0.798 |
| 1,000 | 1685 | 1059 | 1059 | 0.629 | 0.629 |
| 2,000 | 2283 | 1225 | 1225 | 0.537 | 0.537 |
| 3,000 | 2743 | 1334 | 1426 | 0.486 | **0.520** |
| 10,000 | 4809 | 1718 | 2501 | 0.357 | **0.520** |
| 30,000 | 8154 | 2164 | 4240 | 0.265 | **0.520** |
| 100,000 | 14689 | 2786 | 7638 | 0.190 | **0.520** |
| 300,000 | 25267 | 3509 | 13139 | 0.139 | **0.520** |

Along the actual twenty-minute run:

| t (s) | mass | scr-w/s BEFORE | scr-w/s AFTER |
| --- | --- | --- | --- |
| 5 | 36 | 1.025 | 1.025 |
| 30 | 264 | 0.815 | 0.815 |
| 60 | 1,095 | 0.616 | 0.616 |
| 120 | 2,128 | 0.529 | 0.529 |
| 300 | 19,429 | 0.299 | **0.520** |
| 600 | 19,110 | 0.300 | **0.520** |
| 900 | 53,405 | 0.226 | **0.520** |
| 1200 | 47,301 | 0.234 | **0.520** |

Apparent speed used to swing 13x across the mass range. It now swings 2.0x, and the whole change lives above mass ~2,200 — roughly the second minute. Below the crossover the diff is a no-op to the bit, because the opening is not what he complained about ("Arena is pretty good").

## The fix

`APPARENT_FLOOR = 0.24` screen-heights per second, applied as **one multiplier keyed to the camera**:

```ts
export function speedScaleFor(playerMass: number): number {
  return Math.max(1, (viewSpanFor(playerMass) * APPARENT_FLOOR) / baseSpeedFor(playerMass))
}
```

The player and every rival are multiplied by the same number.

### The trap, because it nearly shipped

The first cut floored each body against **its own** view span. That looks equivalent and is not. `baseSpeedFor` is a 0.21 power of mass; a span floor is a 0.5 power. Flooring per-body therefore makes speed far more sensitive to size than the curve ever was, and the sign of a chase flips — the largest legally edible rival (`mass / 1.07`) went from making 1.01x the player's speed to 0.99x. Every kill compounds, so:

| construction | hunting bot, 20 min, 3 seeds |
| --- | --- |
| before this PR | 13 / 10 / 9 kills, peaks 2.8e5 / 1.9e5 / 2.0e5 |
| **per-body floor (rejected)** | **42 / 21 / 49 kills, peaks 1.5e9 / 2.2e5 / 1.5e10** |
| camera-keyed scale (shipped) | 13 / 10 / 12 kills, peaks 7.1e4 / 5.9e4 / 1.1e5 |

`"hunting nothing but rivals for twenty minutes is not an exponential"` caught it — 1.5e9 through a 1e6 legibility ceiling. The shipped construction preserves player:rival, rival:rival and leviathan:everything exactly, and kill counts are unchanged.

## What was NOT touched

- **The breath.** `intensity`, `worldIntensity`, `growth`, the depth ladder and the escalation are untouched. The mass trajectory across seeded runs is inside its ordinary seed-to-seed variance.
- **The ANSWER windows.** `window.ts` is not in the diff. `guardSeconds`/`comprehensionSeconds` remain pure functions of the item and monotone non-decreasing in difficulty; `"the time a child gets is a function of the question, and of nothing about the run"` and `"through the real scheduler, the guard is the item's and a harder item never gets less"` both pass. The only interaction is `reachSeconds = ringR / travelSpeed`, which gets **smaller**, so `thinkSeconds = latency - reach` gets **larger** — the change can only give a child credit for more thinking, never less. No clock a child sees moved.
- `viewSpanFor`, `arenaRadiusFor`, `absorbGain`, `devourGain`, the mote economy, the ribbon.

## Verification

- `npm run -s tsc` clean. `npm run -s test` — **98/98, five consecutive runs.**
- `node packs/build.mjs arena` builds and passes the SDK checker (`items, items.reveal, haptics`, 3 files, 670,540 bytes).

## Mutation transcript

Every new assertion broken, confirmed FAILING, restored.

**M0 — the vacuity the mutation test caught in my own test.** The first cut asserted `lo >= APPARENT_FLOOR`. Setting `APPARENT_FLOOR = 0` — deleting the entire fix — moved the goalposts with it: **`pass 97, fail 1`**, and the only failure was an unrelated clause. Every threshold is now a literal (`0.24`, `0.228`, `0.49`) written where the code cannot reach it, with a comment saying why.

| # | mutation | result |
| --- | --- | --- |
| M1 | `APPARENT_FLOOR = 0.24 -> 0` | `fail 2` — `the slowest the arena ever feels is 0.0485 screen-heights/s at mass 793531, under the 0.24 floor the design chose` and `at mass 5000 a child actually swims 0.1975 screen-heights a second, under the 0.24 the design chose` |
| M2 | `playerSpeed` returns `baseSpeedFor(this.mass)` — fix deleted from the sim, formula left intact | `fail 1` — `at mass 5000 a child actually swims 0.1975 screen-heights a second, under the 0.24 the design chose` |
| M3 | `APPARENT_FLOOR = 0.6` | `fail 10` across the suite, including the band test |
| M4 | `speedScaleFor`: `Math.max` -> `Math.min` | `fail 3` — `the slowest the arena ever feels is 0.0485 screen-heights/s at mass 793531, under the 0.24 floor the design chose` |
| M5 | `Math.max(1, ..)` -> `Math.max(1.2, ..)` (opening sped up too) | `fail 3` — `the arena now peaks at 0.5823 screen-heights/s; the opening was 0.4835` and `the opening now swims at 0.5801, not 0.4835` |
| M6 | `stepRivals` drops `* scale` (player floored, rivals not) | `fail 1` — `kills ran away: peak mass 39572785026 is not a readable number` |
| M7 | `Math.max(1, ..)` -> `Math.max(1.005, ..)` | `fail 1` — `the scale engaged at mass 10, inside the opening` |
| M8 | `baseSpeedFor` exp `0.42 -> -0.42` | `fail 1` — `speed fell from 397.3 to 376.0 between mass 10 and 13` |
| M9 | `speedScaleFor` drops the `max` (apparent pinned dead flat) | `fail 1` — `growing to mass 1,000 cost nothing: 0.2400 -> 0.2400 screen-heights/s` |
| M10 | `APPARENT_FLOOR = 0.239` | `fail 1` — `the slowest the arena ever feels is 0.2390 screen-heights/s at mass 2471, under the 0.24 floor the design chose` |

Restored after every one; `pass 98, fail 0`.

M2 is the one that matters most: the formula test still passes with the fix deleted from `stepPlayer`, which is why `"a child at any size crosses the glass at a rate the design chose"` swims a real `World` — pins a mass, points the core at a horizon five million units away, waits out the turn lag, and measures how much of the screen the next two seconds actually bought.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb