### PR TITLE
fix(dynawalla/games/forge): the FORGE MARK compares one C, and it cannot move

### DIFF
--- a/dynawalla/games/forge/src/core/economy.ts
+++ b/dynawalla/games/forge/src/core/economy.ts
@@ -103,7 +103,12 @@ export type Tier = {
   purchased: bigint
   /** Units produced by the station above, in micro. */
   stock: Micro
-  /** Extra doublings won from FORGE MARKs, on top of purchased/10. */
+  /**
+   * Extra doublings banked by older saves. Nothing writes this any more: a
+   * FORGE MARK `x2` now doubles the count on the row, which is the number the
+   * ingot printed. Still read, and still persisted, so a save made before that
+   * change keeps every doubling it earned.
+   */
   bonusDoublings: bigint
   unlocked: boolean
   /** Cached cost of the next purchase, in whole sparks. Exact. */

--- a/dynawalla/games/forge/src/game/forge.ts
+++ b/dynawalla/games/forge/src/game/forge.ts
@@ -116,7 +116,7 @@ export function mount(el: HTMLElement, host: Host): Mounted {
     sealTier: -1,
     sealT: 0,
     mark: null,
-    pendingMark: null,
+    pendingMark: false,
     pendingMarkIn: 0,
     markT: 0,
     markPicked: -1,
@@ -488,7 +488,7 @@ export function mount(el: HTMLElement, host: Host): Mounted {
       // settles, and THEN two ingots rise out of the crucible.
       if (oom >= 4 && oom > markOom && !g.pendingMark && !g.mark) {
         markOom = oom
-        g.pendingMark = makeMarkRound(economy, rng)
+        g.pendingMark = true
         g.pendingMarkIn = 0.95
       }
     }
@@ -801,12 +801,12 @@ export function mount(el: HTMLElement, host: Host): Mounted {
       {
         heading: "Forge marks",
         lines: [
-          "Sometimes two glowing ingots rise out of the crucible. That pair is a forge mark: a free choice between two rewards, and taking either one makes everything you own a little faster.",
-          "One says something like +14 HAMMER. The other says ×2 HAMMER.",
-          "Look at the HAMMER row to see how many you own, then work out which ingot gives you more.",
-          "Own 9 hammers? ×2 gives 18, and +14 gives 23. Take the +14.",
-          "Own 400 hammers? ×2 gives 800, and +14 gives 414. Now take the ×2.",
-          "Neither one is wrong and nothing is lost. But the better one changes as you play, so look at the row every time.",
+          "Sometimes two glowing ingots rise out of the crucible. That pair is a FORGE MARK: a free choice between two rewards, and taking either one makes everything you own a little faster.",
+          "One says something like +14 HAMMER. The other says ×2 HAMMER. Take the one that leaves you with more hammers. That is the whole mission.",
+          "The card tells you how many you have, and each ingot shows you what you would end up with. You keep whichever you take.",
+          "Own 9 hammers? ×2 leaves 18, and +14 leaves 23. Take the +14.",
+          "Own 400 hammers? ×2 leaves 800, and +14 leaves 414. Now take the ×2.",
+          "Neither one is wrong and nothing is ever lost. But which one is bigger changes as you grow, so read the numbers every time.",
         ],
       },
       {
@@ -923,8 +923,12 @@ export function mount(el: HTMLElement, host: Host): Mounted {
     if (g.pendingMark) {
       g.pendingMarkIn -= dt
       if (g.pendingMarkIn <= 0 && g.mode === "play" && g.struckAt < 0) {
-        g.mark = g.pendingMark
-        g.pendingMark = null
+        // Cut the card HERE, on the frame it opens, so the C it prints is the
+        // C the player owns as they look at it. The wait above can be long —
+        // the player holds a row and buys thirty more of the very station the
+        // mark is about — and every number on the card is frozen from now on.
+        g.mark = makeMarkRound(economy, rng)
+        g.pendingMark = false
         g.markPicked = -1
         g.markGood = false
         g.markT = 0

--- a/dynawalla/games/forge/src/game/marks.test.ts
+++ b/dynawalla/games/forge/src/game/marks.test.ts
@@ -2,9 +2,17 @@ import { strict as assert } from "node:assert"
 import { test } from "node:test"
 
 import { MICRO } from "../core/bigmath.ts"
-import { addSparks, buy, newEconomy, sparksPerSecond, tierCount } from "../core/economy.ts"
+import {
+  type Economy,
+  addSparks,
+  buy,
+  newEconomy,
+  sparksPerSecond,
+  step,
+  tierCount,
+} from "../core/economy.ts"
 import { makeRng } from "../core/rng.ts"
-import { applyOffer, makeMarkRound, resultingCount } from "./marks.ts"
+import { type MarkRound, applyOffer, makeMarkRound, markOutcome } from "./marks.ts"
 
 function stocked(purchases: number) {
   const e = newEconomy()
@@ -13,14 +21,35 @@ function stocked(purchases: number) {
   return e
 }
 
+/**
+ * An economy whose HAMMER row is genuinely being produced into: two ANVILs (a
+ * deliberate two, so `chooseTier` still lands the mark on HAMMER rather than on
+ * the ANVIL row above it) pouring hammers in on every tick.
+ */
+function producing(hammers: number): Economy {
+  const e = newEconomy()
+  addSparks(e, 10n ** 15n * MICRO)
+  for (let i = 0; i <= 3; i++) e.tiers[i].unlocked = true
+  buy(e, 3, 2)
+  buy(e, 2, hammers)
+  return e
+}
+
+/** Run `seconds` of simulation at 60 Hz, exactly as the game loop does. */
+function run(e: Economy, seconds: number): void {
+  for (let i = 0; i < seconds * 60; i++) step(e, 60n)
+}
+
+const whole = (e: Economy, tier: number) => tierCount(e.tiers[tier]) / MICRO
+
 test("the better offer is always the one that yields more, and never a tie", () => {
   const rng = makeRng(31337)
   for (const owned of [3, 4, 9, 17, 40, 120, 400]) {
     for (let i = 0; i < 200; i++) {
       const e = stocked(owned)
       const m = makeMarkRound(e, rng)
-      const c0 = resultingCount(e, m.offers[0])
-      const c1 = resultingCount(e, m.offers[1])
+      const c0 = markOutcome(m, 0)
+      const c1 = markOutcome(m, 1)
       assert.notEqual(c0, c1, "a tie would make the choice meaningless")
       assert.equal(m.better, c0 > c1 ? 0 : 1)
 
@@ -69,19 +98,120 @@ test("+N adds exactly N units of production and moves neither price nor pips", (
   assert.equal(e.tiers[0].purchased, purchasedBefore)
 })
 
-test("x2 exactly doubles that station's output", () => {
+test("x2 exactly doubles that station's count AND its output", () => {
   const e = stocked(9)
   const before = sparksPerSecond(e)
+  const countBefore = tierCount(e.tiers[0])
   applyOffer(e, { kind: "double", tier: 0 })
+  assert.equal(tierCount(e.tiers[0]), countBefore * 2n)
   assert.equal(sparksPerSecond(e), before * 2n)
 })
 
 test("the crossover really moves as the player grows", () => {
   // The same offer, +20, is right when you own 9 and wrong when you own 400.
-  const small = stocked(9)
-  const large = stocked(400)
   const offer = { kind: "add", tier: 0, n: 20n } as const
   const dbl = { kind: "double", tier: 0 } as const
-  assert.ok(resultingCount(small, offer) > resultingCount(small, dbl))
-  assert.ok(resultingCount(large, offer) < resultingCount(large, dbl))
+  const small: MarkRound = { tier: 0, have: 9n, offers: [offer, dbl], better: 0 }
+  const large: MarkRound = { tier: 0, have: 400n, offers: [offer, dbl], better: 1 }
+  assert.ok(markOutcome(small, 0) > markOutcome(small, 1))
+  assert.ok(markOutcome(large, 0) < markOutcome(large, 1))
+})
+
+// --- the card must not move under the child ---------------------------------
+//
+// The bug this guards: `have` was snapshotted when the round was built, while
+// the two previews were recomputed live from `tierCount` at render time. In an
+// idle game that count climbs every tick, so the card printed HAMMER 16 and
+// then offered `+27 -> 73` and `x2 -> 93` — three numbers measured from three
+// different C's, none of which agreed. A child reasoning correctly from the 16
+// they were shown was told they were wrong.
+//
+// Every assertion below reads the round AFTER real simulation, never on the
+// frame it was built.
+
+test("the whole card is frozen while the station keeps producing", () => {
+  const rng = makeRng(4242)
+  const e = producing(16)
+  const m = makeMarkRound(e, rng)
+  assert.equal(m.tier, 2, "the mark should be on the producing HAMMER row")
+
+  const have = m.have
+  const before = [markOutcome(m, 0), markOutcome(m, 1)]
+  const better = m.better
+  const countAtCut = whole(e, 2)
+
+  // Time passes, exactly as it does between the milestone and the tap: the
+  // anvils pour in hammers and the player keeps buying more.
+  run(e, 400)
+  buy(e, 2, 25)
+  const drift = whole(e, 2) - countAtCut
+  assert.ok(drift > 30n, `the count must really have moved; it moved ${drift}`)
+
+  assert.equal(m.have, have, "C moved under the child")
+  assert.equal(markOutcome(m, 0), before[0], "the left preview moved")
+  assert.equal(markOutcome(m, 1), before[1], "the right preview moved")
+  assert.equal(m.better, better, "the right answer changed after the question")
+})
+
+test("both previews are exactly the frozen C put through the ingot's own sum", () => {
+  const rng = makeRng(99)
+  for (let i = 0; i < 120; i++) {
+    const e = producing(9 + i)
+    const m = makeMarkRound(e, rng)
+    run(e, 60)
+    for (let k = 0; k < 2; k++) {
+      const o = m.offers[k]
+      const want = o.kind === "add" ? m.have + o.n : m.have * 2n
+      assert.equal(markOutcome(m, k), want, `ingot ${k} does not equal its own sum`)
+    }
+    // ...and the game's idea of the better one is that same comparison.
+    assert.equal(m.better, markOutcome(m, 0) > markOutcome(m, 1) ? 0 : 1)
+  }
+})
+
+test("the number on the ingot is the number you are left holding", () => {
+  const rng = makeRng(777)
+  for (let i = 0; i < 60; i++) {
+    for (const pick of [0, 1] as const) {
+      const e = producing(12 + i * 3)
+      const m = makeMarkRound(e, rng)
+      const promised = markOutcome(m, pick)
+      applyOffer(e, m.offers[pick])
+      assert.equal(
+        whole(e, m.tier),
+        promised,
+        `${m.offers[pick].kind} promised ${promised} and left ${whole(e, m.tier)}`,
+      )
+    }
+  }
+})
+
+test("taking the better ingot really does leave you producing more", () => {
+  const rng = makeRng(31415)
+  for (let i = 0; i < 60; i++) {
+    const worse = producing(10 + i * 5)
+    const m = makeMarkRound(worse, rng)
+    const best = producing(10 + i * 5)
+    run(worse, 30)
+    run(best, 30)
+    applyOffer(best, m.offers[m.better])
+    applyOffer(worse, m.offers[1 - m.better])
+    assert.ok(
+      tierCount(best.tiers[m.tier]) > tierCount(worse.tiers[m.tier]),
+      "the ingot the game calls better must be the one that leaves more",
+    )
+  }
+})
+
+test("C of 1 is an offer, not a tie", () => {
+  // chooseTier falls back to BELLOWS when nothing is running yet, and an empty
+  // BELLOWS row floors C to 1. `x2` leaves 2 there, so the addition must win.
+  const rng = makeRng(5)
+  for (let i = 0; i < 200; i++) {
+    const m = makeMarkRound(newEconomy(), rng)
+    assert.equal(m.have, 1n)
+    assert.notEqual(markOutcome(m, 0), markOutcome(m, 1), "a tie at C=1")
+    const addIndex = m.offers[0].kind === "add" ? 0 : 1
+    assert.equal(m.better, addIndex, "with one unit, adding must beat doubling")
+  }
 })

--- a/dynawalla/games/forge/src/game/marks.ts
+++ b/dynawalla/games/forge/src/game/marks.ts
@@ -15,9 +15,18 @@
 // That is the entire lesson, and it is a *comparison of two expressions in one
 // variable*, which is pre-algebra. The crossover moves as you play: early, when
 // C is 3, +14 is obviously right. An hour later, when C is 400, the same +14 is
-// laughable. Nobody memorises an answer; you have to look at the row.
+// laughable. Nobody memorises an answer; you have to look at what you own.
+//
+// THE ONE RULE OF THIS FILE: there is exactly one C, it is `MarkRound.have`, it
+// is cut once when the card opens, and nothing on the card is ever recomputed
+// from the live economy afterwards. This is an idle game — the station is
+// producing while the child is thinking, so a C read live would tick upward
+// between the number on the card and the number in the sum. A quantity you are
+// asked to compare against cannot move while you are looking at it, and a card
+// whose printed C is not the C in its own arithmetic teaches the child that
+// correct reasoning gives the wrong answer.
 
-import { MICRO, type Micro } from "../core/bigmath.ts"
+import { MICRO } from "../core/bigmath.ts"
 import { TIERS, type Economy, tierCount } from "../core/economy.ts"
 import type { Rng } from "../core/rng.ts"
 
@@ -27,17 +36,30 @@ export type Offer =
 
 export type MarkRound = {
   tier: number
-  /** Whole units the player currently owns of that station — shown on the row. */
+  /**
+   * C. Whole units of that station at the instant the card was cut, and the
+   * only base any number on this card is ever measured from. Frozen.
+   */
   have: bigint
   offers: [Offer, Offer]
-  /** Index of the offer that yields more production. Exact integer comparison. */
+  /** Index of the offer that leaves you with more. Exact integer comparison. */
   better: 0 | 1
 }
 
-/** Production after taking an offer, in micro-units of the station. Exact. */
-export function resultingCount(e: Economy, o: Offer): Micro {
-  const c = tierCount(e.tiers[o.tier])
-  return o.kind === "add" ? c + o.n * MICRO : c * 2n
+/** What `o` leaves you holding, in whole units, measured from a fixed `have`. */
+function outcomeFrom(have: bigint, o: Offer): bigint {
+  return o.kind === "add" ? have + o.n : have * 2n
+}
+
+/**
+ * The number printed under ingot `i`, in whole units of the station.
+ *
+ * It reads the frozen `have` and nothing else. There is deliberately no
+ * overload that takes an `Economy`: the live count is not an input to this
+ * card, and the previous version of this function taking one is the whole bug.
+ */
+export function markOutcome(m: MarkRound, i: number): bigint {
+  return outcomeFrom(m.have, m.offers[i])
 }
 
 export function offerLabel(o: Offer): string {
@@ -61,8 +83,13 @@ export function makeMarkRound(e: Economy, rng: Rng): MarkRound {
   // Half the time the addition wins, half the time the doubling does — and the
   // margin is kept well clear of the crossover so the comparison is decidable
   // by looking, not by arithmetic luck. Never a tie.
-  const addWins = rng.chance(1, 2)
+  let addWins = rng.chance(1, 2)
   const spread = 25 + rng.int(0, 60) // percent away from the crossover
+  // C = 1 has no room below the crossover: x2 leaves you with 2, and the only
+  // addition that loses to it is +0, which is not an offer. Give the addition
+  // rather than print a tie. The draw above is still spent so the sequence a
+  // seed produces does not depend on how big the player is.
+  if (h <= 1n) addWins = true
   let n: bigint
   if (addWins) {
     n = (h * BigInt(100 + spread)) / 100n + 1n
@@ -78,18 +105,26 @@ export function makeMarkRound(e: Economy, rng: Rng): MarkRound {
   const flip = rng.chance(1, 2)
   const offers: [Offer, Offer] = flip ? [b, a] : [a, b]
 
-  const c0 = resultingCount(e, offers[0])
-  const c1 = resultingCount(e, offers[1])
-  return { tier, have: h, offers, better: c0 >= c1 ? 0 : 1 }
+  // Decided from the same frozen C the card prints, so the game's idea of the
+  // better ingot can never disagree with the two numbers the child compares.
+  const c0 = outcomeFrom(h, offers[0])
+  const c1 = outcomeFrom(h, offers[1])
+  return { tier, have: h, offers, better: c0 > c1 ? 0 : 1 }
 }
 
 /**
- * Apply the chosen offer. `+N` lands as stock rather than purchases so it adds
- * exactly N units of production and moves neither the price nor the doubling
- * pips — the arithmetic on the ingot is the arithmetic that happens.
+ * Apply the chosen offer.
+ *
+ * Both arms move the COUNT on the row, because the count is what the ingot
+ * promised. `+N` lands as stock rather than purchases so it adds exactly N
+ * units and moves neither the price nor the doubling pips. `x2` doubles that
+ * same count, which multiplies the station's output by exactly two — the older
+ * version banked a hidden `bonusDoublings` instead, so an ingot reading
+ * `x2 HAMMER -> 92` left the HAMMER row still reading 46 and the promised
+ * number appeared nowhere on the screen.
  */
 export function applyOffer(e: Economy, o: Offer): void {
   const t = e.tiers[o.tier]
   if (o.kind === "add") t.stock += o.n * MICRO
-  else t.bonusDoublings += 1n
+  else t.stock += tierCount(t)
 }

--- a/dynawalla/games/forge/src/game/types.ts
+++ b/dynawalla/games/forge/src/game/types.ts
@@ -91,8 +91,14 @@ export type Game = {
   sealTier: number
   sealT: number
   mark: MarkRound | null
-  /** Queued behind the milestone punch so the two big moments do not collide. */
-  pendingMark: MarkRound | null
+  /**
+   * A mark is OWED, not yet cut. Queued behind the milestone punch so the two
+   * big moments do not collide — and the round itself is built at the instant
+   * the card opens rather than here, because the player keeps buying and the
+   * stations keep producing during the wait, and a card cut a second early
+   * prints a C the player no longer has.
+   */
+  pendingMark: boolean
   pendingMarkIn: number
   markT: number
   markPicked: number

--- a/dynawalla/games/forge/src/scene/overlays.ts
+++ b/dynawalla/games/forge/src/scene/overlays.ts
@@ -4,7 +4,7 @@
 import { MICRO, compact, readout, superscript } from "../core/bigmath.ts"
 import { QUENCH_FLOOR, TIERS } from "../core/economy.ts"
 import type { Rect } from "../game/layout.ts"
-import { offerLabel, resultingCount } from "../game/marks.ts"
+import { markOutcome, offerLabel } from "../game/marks.ts"
 import type { Game } from "../game/types.ts"
 import { GLOW_COLD, GLOW_GOLD, GLOW_HOT, PAL, glow, plate, text } from "../render/gfx.ts"
 import { clamp01, ease } from "../render/juice.ts"
@@ -223,8 +223,8 @@ function drawMark(ctx: CanvasRenderingContext2D, g: Game): void {
     rimWidth: 2.5,
   })
 
-  text(ctx, "FORGE MARK", panel.x + panel.w / 2, panel.y + 48 * S, {
-    size: Math.round(20 * S),
+  text(ctx, "FORGE MARK", panel.x + panel.w / 2, panel.y + 38 * S, {
+    size: Math.round(18 * S),
     align: "center",
     color: PAL.gold,
     tracking: 6 * S,
@@ -232,15 +232,29 @@ function drawMark(ctx: CanvasRenderingContext2D, g: Game): void {
   })
 
   // The one fact you need: how many you already have. Everything else on this
-  // screen is the two expressions being compared.
-  const have = `${TIERS[m.tier].name}  ${m.have}`
-  text(ctx, have, panel.x + panel.w / 2, panel.y + 108 * S, {
-    size: Math.round(34 * S),
+  // screen is the two expressions being compared. This number is `m.have`, the
+  // frozen C — never the live count, which is still climbing behind the scrim.
+  const have = `YOU HAVE ${m.have} ${TIERS[m.tier].name}`
+  const hs = fitSize(ctx, have, panel.w - 60 * S, Math.round(32 * S), true)
+  text(ctx, have, panel.x + panel.w / 2, panel.y + 90 * S, {
+    size: hs,
     mono: true,
     align: "center",
     color: PAL.white,
     glowColor: GLOW_HOT,
     glowRadius: 60 * S,
+  })
+
+  // The mission, in words, because a child who cannot tell what is being asked
+  // cannot do the maths even when they can do the maths.
+  const mission = "TAKE THE ONE THAT LEAVES YOU MORE"
+  const mtrack = 2.5 * S
+  const ms = fitSize(ctx, mission, panel.w - 50 * S, Math.round(13 * S), false, mtrack)
+  text(ctx, mission, panel.x + panel.w / 2, panel.y + 124 * S, {
+    size: ms,
+    align: "center",
+    color: "rgba(255,206,84,0.85)",
+    tracking: mtrack,
   })
 
   for (let i = 0; i < 2; i++) {
@@ -279,13 +293,21 @@ function drawMark(ctx: CanvasRenderingContext2D, g: Game): void {
       glowColor: GLOW_HOT,
       glowRadius: fs,
     })
-    // The consequence, small, under the offer: the number this becomes.
-    const res = resultingCount(g.economy, m.offers[i]) / MICRO
-    text(ctx, `→ ${res}`, 0, fs * 0.34 + 30 * S, {
-      size: Math.round(17 * S),
+    // The consequence, under the offer: the number this leaves you with. It is
+    // on the card BEFORE the choice, because the whole decision is which of
+    // these two is bigger — hiding both until after the tap removes the thing
+    // being decided. It comes off the frozen `have`, so it is the same number
+    // whether it is read now or three seconds from now.
+    const res = `→ ${markOutcome(m, i)}`
+    // Offset from the ingot's own height: the two-up landscape plate is twice
+    // the height of the stacked portrait one, and a fixed drop hangs the
+    // number off the bottom edge of the short plate.
+    const rs = fitSize(ctx, res, r.w - 34 * S, Math.round(Math.min(20 * S, r.h * 0.22)), true)
+    text(ctx, res, 0, fs * 0.34 + Math.min(34 * S, r.h * 0.32), {
+      size: rs,
       mono: true,
       align: "center",
-      color: g.markPicked >= 0 ? PAL.bright : "rgba(255,200,140,0.0)",
+      color: picked ? PAL.white : PAL.bright,
     })
     ctx.restore()
     if (good) glow(ctx, r.x + r.w / 2, r.y + r.h / 2, r.h * 1.2, GLOW_GOLD, 0.7)


### PR DESCRIPTION
## The report

> "forge is pretty good, feels good, lots of math but I don't think I understand this interlude. I thought it says: you have hammer 16 so would you rather double that or add 27 ... but it's not clear what the mission is there... i do +27 but was I right?"

He read the card exactly as designed and still could not tell — because the card was lying. It said `HAMMER 16`, then revealed `+27 HAMMER → 73` and `×2 HAMMER → 93`. `73 − 27 = 46`, not 16. `2 × 46 = 92`, not 93. Three numbers measured from three different C's. His reasoning was right (`16+27 = 43 > 32`) and the game marked him wrong, because against the ~46 it was secretly using, doubling wins.

`marks.ts` opens by calling this "the best maths in this game" and it is right — `C + N > 2C ⟺ N > C` is a comparison of two expressions in one variable, genuinely pre-algebra. It is unlearnable if C moves while the child is looking at it.

## Mechanism — confirmed, and there were three leaks, not one

1. **The suspected one, confirmed.** `marks.ts:58` snapshotted `have = tierCount(...) / MICRO` at round creation; `resultingCount(e, o)` recomputed `tierCount(e.tiers[o.tier])` **live at render time**. `tierCount = purchased * MICRO + stock`, and `stock` is production — it grows on every tick of an idle game. `better` was fixed at creation from creation-time values, so the game's own idea of the right answer could disagree with the outcome shown.
2. **Bigger than expected: the round was built long before it was shown.** `forge.ts` built the round at the milestone (`g.pendingMark = makeMarkRound(...)`) and only opened the card ≥0.95 s later, and then only once `mode === "play" && struckAt < 0`. The player is buying with hold-to-repeat during that gap, and purchases move `tierCount` too. So even the generated offer `+N` — sized to sit 25–85% clear of the crossover — was calibrated against a C the player no longer had. This is the likely source of the 16→46 gap.
3. **A third leak, same bug wearing a different hat.** `applyOffer` implemented `×2` as `t.bonusDoublings += 1n`, a hidden output multiplier. The count on the row did not move. So an ingot promising `×2 HAMMER → 92` left the HAMMER row reading 46, and the promised number appeared nowhere on the screen — while `+N` *did* land on the row. The two ingots were not even quoted in the same currency.

Units: `have` divided by `MICRO`; `resultingCount` returned micro-units. Everything on the card is now plain whole units, one currency, no division at the call site.

## The fix

* **One C.** `MarkRound.have` is the only base. `markOutcome(round, i)` **takes no `Economy`** — it structurally cannot read live state, and the old signature taking one is the whole bug. `have`, both previews, and `better` are now the same frozen number put through the ingot's own sum.
* **Cut the card when it opens, not when it is earned.** `pendingMark` became a boolean "a mark is owed"; `makeMarkRound` runs on the frame the overlay opens, so the printed C is the C the player owns as they look at it.
* **`×2` doubles the count on the row.** `t.stock += tierCount(t)` — exactly production-equivalent to the old hidden doubling (both are a factor of 2 in the numerator before the single truncating divide, asserted), and now the row shows the number the ingot promised. `bonusDoublings` is kept and still read so pre-existing saves keep every doubling they earned; nothing writes it any more.
* **Both outcomes are on the card before the choice.** They were drawn at alpha `0.0` until after the tap. The entire decision is which of the two is bigger; hiding both until the child has committed removes the thing being decided. **I agree with the founder that this does not give it away** — comparing 43 against 32 *is* `C + N > 2C ⟺ N > C` seen from the inside, and without the two figures there is no feedback loop at all from which the rule can be induced. What is lost is the child computing `16+27` themselves; what is gained is thirty repetitions of "the `+N` wins exactly when N is bigger than what I have", which is the stated lesson.
* **The mission, in words.** The card now reads `FORGE MARK` / `YOU HAVE 46 HAMMER` / `TAKE THE ONE THAT LEAVES YOU MORE`, and each ingot carries its `→ N`. The how-to-play page no longer says "look at the HAMMER row" (the card carries its own C now) and defines FORGE MARK where a child first meets it.
* **Latent tie fixed.** At C=1 the "doubling wins" branch could only produce `+1`, tying 2 against 2. The rng draw is still spent so a seed's sequence does not depend on player size.

Kept: you keep whichever you take, there is no wrong answer to punish, no red X. Not scored, not redesigned.

## Verification

`npm run -s test` × 5 consecutive: 84 pass / 0 fail each time. `npm run -s tsc` clean. `node packs/build.mjs forge` builds and passes the SDK checker.

New assertions all read the round **after** real simulation — `run(e, 400)` is 24 000 `step(e, 60n)` calls at 60 Hz plus 25 live purchases, on a HAMMER row genuinely being produced into by two ANVILs, with a guard that the count really moved (`drift > 30`) and a guard that the mark landed on the growing row (`m.tier === 2`).

### Mutation transcript

Every new assertion was broken at the source, failed, and was restored.

| # | Mutation | Result |
|---|---|---|
| M1 | `outcomeFrom` add → `have + o.n + 1n` | **3 fail** — `ingot 1 does not equal its own sum`; `add promised 21 and left 20`; `a tie would make the choice meaningless` |
| M2 | `outcomeFrom` double → `have * 3n` | **6 fail** — `ingot 0 does not equal its own sum`; `double promised 36 and left 24`; `the ingot the game calls better must be the one that leaves more`; `a tie at C=1`; `add won 0/400` |
| M3 | `applyOffer` double → `t.bonusDoublings += 1n` (the original code) | **3 fail** — `double promised 24 and left 12`; `x2 exactly doubles that station's count AND its output`; `the ingot the game calls better must be the one that leaves more` |
| M4 | `better: c0 > c1` → `c1 > c0` | **4 fail** — `with one unit, adding must beat doubling`; `the ingot the game calls better must be the one that leaves more` |
| M5 | drop the `if (h <= 1n) addWins = true` guard | **1 fail** — `a tie at C=1` |
| M6 | **reinstate the original bug**: `have` becomes a getter returning `tierCount(e.tiers[tier]) / MICRO` | **2 fail** — `C moved under the child` |
| M7 | `markOutcome` drifts on every read while `have` stays frozen | **4 fail** — `the left preview moved`; `ingot 0 does not equal its own sum`; `double promised 28 and left 24` |
| M8 | `run(e, 400); buy(e, 2, 25)` → `run(e, 0)` (stop time between cut and read) | **1 fail** — `the count must really have moved; it moved 0` |
| M9 | `buy(e, 3, 2)` → `buy(e, 3, 3)` (mark lands on a row that cannot grow) | **1 fail** — `the mark should be on the producing HAMMER row` |

M6 is the important one: it puts the shipped bug back byte-for-byte in behaviour, and `the whole card is frozen while the station keeps producing` catches it. M8 and M9 prove the test's own setup is not vacuous — without real ticks on a real producing row, the frozen assertions would pass while proving nothing.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb