### PR TITLE
dynawalla/games/horde: a card is as tall as its own words, and a level-up waits for the question

### DIFF
--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -27,6 +27,7 @@ import {
   type Build, type Card,
 } from "./loadout.ts"
 import { Curriculum } from "./curriculum.ts"
+import { LevelUps } from "./levelup.ts"
 import { ORB_RADIUS, type Orb, advance as advanceOrbs, place as placeOrbs, reached } from "./orbs.ts"
 import { Bullets, Enemies, Gems, Grid, Numbers, Particles, Shocks } from "./world.ts"
 import { Overlay } from "../ui/overlay.ts"
@@ -94,6 +95,11 @@ export class Game {
   private revives = 0
   private hurtCd = 0
   private levelUps = 0
+  /**
+   * Levels earned but not yet spent on a panel of cards. A level earned inside
+   * a CORE waits for the question to finish instead of killing it.
+   */
+  private levels = new LevelUps()
   /**
    * Every question this run: which one to ask next, and what the host is told
    * about it. Escalation lives in here and it reads right answers, not the
@@ -310,6 +316,9 @@ export class Game {
     const h = Math.max(200, rect.height || window.innerHeight)
     const dpr = Math.min(window.devicePixelRatio || 1, this.T.maxDpr)
     this.r.resize(w, h, dpr * this.T.renderScale)
+    // The level-up cards are cut to the frame they are dealt into; a rotation
+    // is a different frame. See `ui/cards.ts`.
+    this.ui.relayout()
     const aspect = w / h
     this.halfW = AREA * Math.sqrt(aspect)
     this.halfH = AREA / Math.sqrt(aspect)
@@ -340,6 +349,7 @@ export class Game {
     this.overcharge = 0
     this.revives = 0
     this.levelUps = 0
+    this.levels.clear()
     this.curriculum.reset()
     this.bestMs = 0
     this.spawnAcc = 0
@@ -436,6 +446,11 @@ export class Game {
 
     if (this.mode === "rift" && !reading) this.riftTick(frame)
     this.desat += ((this.mode === "rift" ? 0.85 : 0) - this.desat) * Math.min(1, frame * 6)
+
+    // A level earned inside a CORE, a RIFT or another panel of cards opens here
+    // — on the first frame the game is back in ordinary play — and never in the
+    // middle of the step that earned it. See `levelup.ts`.
+    if (!reading && this.levels.take(this.mode)) this.levelUp()
 
     this.draw(frame)
   }
@@ -1257,7 +1272,12 @@ export class Game {
       this.xp -= this.xpNeed
       this.level++
       this.xpNeed = xpForLevel(this.level)
-      this.levelUp()
+      // Banked, not opened. A gem collected inside a CORE used to take the
+      // screen mid-question and leave the ring of orbs dead for the rest of the
+      // run; two levels from one gem used to overwrite the first three cards
+      // before they were touched. See `levelup.ts`.
+      this.levels.earned()
+      this.ui.setLevel(this.level)
     }
     this.ui.setXp(this.xp / this.xpNeed)
     this.ui.setKills(this.kills)
@@ -1540,6 +1560,13 @@ export class Game {
 
   /* -------------------------------------------------------------- level up */
 
+  /**
+   * Open the cards for one banked level.
+   *
+   * Called from the frame loop and from nowhere else — never from inside the
+   * physics step, where it used to interrupt a live question. `levelup.ts` says
+   * why at length.
+   */
   private levelUp(): void {
     this.levelUps++
     this.ui.setLevel(this.level)
@@ -1587,7 +1614,13 @@ export class Game {
       this.feel.flash(1, 0.88, 0.5, 0.28, 3.6)
       this.feel.punch(0.5)
       this.feel.shake(0.4)
+      // Tagged with the panel it belongs to. A child who opens the cache and
+      // then picks an upgrade inside this beat is already back in play, and a
+      // banked level may have opened the NEXT panel by the time this fires —
+      // which this would then close without a card being taken.
+      const panel = this.levelUps
       window.setTimeout(() => {
+        if (this.levelUps !== panel || this.mode !== "levelup") return
         this.ui.hideCards()
         this.ui.say(reward.title, `${reward.tag} — SEALED CACHE`, "#ffd166")
         this.syncHud()

--- a/dynawalla/games/horde/src/game/levelup.test.ts
+++ b/dynawalla/games/horde/src/game/levelup.test.ts
@@ -1,0 +1,221 @@
+// A LEVEL-UP MUST NOT KILL A LIVE QUESTION.
+//
+// The founder: "sometimes a level up can happen when a math problem is active
+// and you can never activate the answer after that." The screenshot is LV 9 at
+// 1:25 with `5 + 4` on the field and the orbs `8`, `9`, `10` still glowing —
+// nothing is missing from the picture, and nothing the child does to them
+// registers.
+//
+// The word that matters is SOMETIMES. This is a race between two things that
+// are each fine on their own: bullet time keeps the world running inside a
+// CORE, so gems are still collected there, and `gain` used to open the upgrade
+// panel from the middle of that physics step. `pickCard` then returned the game
+// to "play" — the only mode it knew — and "core" was gone with the question
+// still open. `questTick` runs only in "core", so nothing turned the ring or
+// tested a strike ever again.
+//
+// So the test is the race, not the happy path: a level is earned at several
+// points across a question's life and the question has to survive every one of
+// them. The sequences below are the real orderings from `game.ts`, driven
+// through the real `LevelUps`.
+
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+
+import { LevelUps, type Mode } from "./levelup.ts"
+
+const GAME = readFileSync(fileURLToPath(new URL("./game.ts", import.meta.url)), "utf8")
+
+/**
+ * The frame loop, as `game.ts` runs it: the sim steps, then the panel opens if
+ * it may. Returns whether the cards opened on this frame.
+ */
+function frame(levels: LevelUps, mode: Mode): boolean {
+  return levels.take(mode)
+}
+
+test("a level earned inside a CORE does not take the screen", () => {
+  const levels = new LevelUps()
+  // The diver swims into a core. The question is open and bullet time is on.
+  let mode: Mode = "core"
+  levels.earned() // a gem crossed a level, mid-question
+  assert.equal(frame(levels, mode), false, "the cards opened over a live question")
+  // Several more frames of the child thinking about 5 + 4.
+  for (let i = 0; i < 120; i++) {
+    assert.equal(frame(levels, mode), false, `the cards opened on frame ${i} of the question`)
+  }
+  assert.equal(levels.waiting, 1, "the level was dropped instead of banked")
+
+  // The child touches an orb; `closeQuestion` puts the game back in play.
+  mode = "play"
+  assert.equal(frame(levels, mode), true, "the banked level never opened after the question")
+  assert.equal(levels.waiting, 0)
+})
+
+test("the level is banked wherever in the question it is earned", () => {
+  // Immediately, mid-window, and on the last frame before the strike.
+  for (const offset of [0, 1, 30, 119, 120]) {
+    const levels = new LevelUps()
+    for (let i = 0; i <= 120; i++) {
+      if (i === offset) levels.earned()
+      assert.equal(
+        frame(levels, "core"),
+        false,
+        `earned at frame ${offset}: the panel opened at frame ${i}, mid-question`,
+      )
+    }
+    assert.equal(levels.waiting, 1, `earned at frame ${offset}: the level was lost`)
+    assert.equal(frame(levels, "play"), true, `earned at frame ${offset}: it never opened`)
+  }
+})
+
+test("two levels from one gem are two panels, one after the other", () => {
+  // `gain`'s loop can cross two thresholds on a single pickup. It used to call
+  // `levelUp` twice in a row, and the second `showCards` replaced the first
+  // three cards before the child had touched one of them.
+  const levels = new LevelUps()
+  levels.earned()
+  levels.earned()
+  assert.equal(frame(levels, "play"), true, "the first panel did not open")
+  // The panel is up; the mode is "levelup" until a card is picked.
+  assert.equal(frame(levels, "levelup"), false, "the second panel opened over the first")
+  assert.equal(levels.waiting, 1)
+  // Card picked, back in play.
+  assert.equal(frame(levels, "play"), true, "the second panel was swallowed")
+  assert.equal(levels.waiting, 0)
+})
+
+test("a level earned in the RIFT waits for the run to come back", () => {
+  const levels = new LevelUps()
+  levels.earned()
+  for (const mode of ["rift", "rift", "rift"] as Mode[]) {
+    assert.equal(frame(levels, mode), false, "the cards opened over the rift's questions")
+  }
+  assert.equal(frame(levels, "play"), true)
+})
+
+test("nothing opens in the modes with no run in them", () => {
+  for (const mode of ["title", "over", "paused"] as Mode[]) {
+    const levels = new LevelUps()
+    levels.earned()
+    assert.equal(frame(levels, mode), false, `the cards opened in "${mode}"`)
+    assert.equal(levels.waiting, 1, `the level was spent in "${mode}"`)
+  }
+})
+
+test("an empty queue opens nothing, however long the game runs", () => {
+  const levels = new LevelUps()
+  for (let i = 0; i < 600; i++) assert.equal(frame(levels, "play"), false)
+  assert.equal(levels.waiting, 0)
+})
+
+test("a new run owes nothing", () => {
+  const levels = new LevelUps()
+  levels.earned()
+  levels.earned()
+  levels.clear()
+  assert.equal(levels.waiting, 0)
+  assert.equal(frame(levels, "play"), false, "last run's levels opened in this one")
+})
+
+/* ------------------------------------------------- and that game.ts uses it */
+
+/** The body of a method of `Game`, by brace matching rather than by grep. */
+function methodBody(src: string, name: string): string {
+  const at = src.search(new RegExp(`^  (?:private )?${name}\\(`, "m"))
+  assert.notEqual(at, -1, `Game.${name} is gone — this test is about nothing`)
+  const open = src.indexOf("{", at)
+  let depth = 0
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth++
+    else if (src[i] === "}") {
+      depth--
+      if (depth === 0) return src.slice(open + 1, i)
+    }
+  }
+  throw new Error(`Game.${name} does not close`)
+}
+
+test("the physics step never opens the panel itself", () => {
+  const gain = methodBody(GAME, "gain")
+  assert.ok(
+    gain.includes("this.levels.earned()"),
+    "`gain` no longer banks the level through the queue",
+  )
+  assert.ok(
+    !/this\.levelUp\(\)/.test(gain),
+    "`gain` calls `levelUp()` from inside the physics step again — that is the founder's " +
+      "dead CORE, exactly: the panel takes the screen mid-question and the mode never " +
+      "comes back to it",
+  )
+})
+
+test("the panel opens from the frame loop, through the queue, and nowhere else", () => {
+  const calls = [...GAME.matchAll(/this\.levelUp\(\)/g)]
+  assert.equal(
+    calls.length,
+    1,
+    `\`levelUp()\` is called from ${calls.length} places; it may only be called from the ` +
+      `frame loop, guarded by the queue`,
+  )
+  assert.ok(
+    /this\.levels\.take\(this\.mode\)\)\s*this\.levelUp\(\)/.test(GAME),
+    "the one call is no longer guarded by `levels.take(this.mode)`",
+  )
+})
+
+test("only levelUp puts the game into the card panel", () => {
+  const setters = [...GAME.matchAll(/this\.mode = "levelup"/g)]
+  assert.equal(
+    setters.length,
+    1,
+    "something other than `levelUp()` moves the game into the card panel",
+  )
+  assert.ok(
+    methodBody(GAME, "levelUp").includes('this.mode = "levelup"'),
+    "the one place that enters the panel is not `levelUp`",
+  )
+})
+
+test("a question is still only ever ended by closeQuestion", () => {
+  // The other half of the founder's bug: `closeQuestion` is guarded on the mode
+  // being "core", so anything that changed the mode out from under a live
+  // question silently disabled the close as well.
+  const close = methodBody(GAME, "closeQuestion")
+  assert.ok(close.includes('if (this.mode !== "core") return'), "the guard changed")
+  assert.ok(close.includes("this.orbs.length = 0"), "the orbs are no longer cleared on close")
+  const tick = methodBody(GAME, "questTick")
+  assert.ok(tick.includes("this.closeQuestion(null)"), "the thinking clock no longer closes it")
+})
+
+test("a question cannot be orphaned by dying inside a CORE either", () => {
+  // The other way the founder's symptom could be produced: `die()` sets the
+  // mode to "rift" and does not clear `this.q` or `this.orbs`, so a run that
+  // came back from the rift would have a ring of dead orbs on the field for
+  // exactly the same reason. It cannot happen — a CORE is bullet time, not
+  // safety, but damage is only ever applied in "play" — and this is what keeps
+  // it that way.
+  const hurt = methodBody(GAME, "hurt")
+  assert.ok(
+    hurt.includes('if (this.invuln > 0 || this.mode !== "play") return'),
+    "`hurt` no longer refuses to hurt outside play — a child can now be killed " +
+      "mid-question, and `die` leaves the question open behind the rift",
+  )
+  assert.ok(hurt.includes("this.die()"), "`hurt` no longer leads to `die`")
+  const deaths = [...GAME.matchAll(/this\.die\(\)/g)]
+  assert.equal(
+    deaths.length,
+    1,
+    `\`die()\` is reached from ${deaths.length} places; only \`hurt\` may reach it, because ` +
+      `only \`hurt\` checks the mode first`,
+  )
+})
+
+test("the run's own reset empties the queue", () => {
+  assert.ok(
+    methodBody(GAME, "reset").includes("this.levels.clear()"),
+    "a level banked in the last run opens over the start of the next one",
+  )
+})

--- a/dynawalla/games/horde/src/game/levelup.ts
+++ b/dynawalla/games/horde/src/game/levelup.ts
@@ -1,0 +1,97 @@
+/**
+ * When the upgrade cards are allowed to open.
+ *
+ * ── The bug this file exists to end ─────────────────────────────────────────
+ *
+ * The founder: "sometimes a level up can happen when a math problem is active
+ * and you can never activate the answer after that."
+ *
+ * He is describing a dead CORE. The three numbered orbs are still on the field
+ * and still glowing — the renderer draws `this.orbs` whatever the mode is — and
+ * swimming into one does nothing at all, for the rest of the run or until
+ * another CORE drifts in forty seconds later.
+ *
+ * The ordering, exactly:
+ *
+ *   1. The diver swims into a CORE. `openQuestion` sets `mode = "core"`, lays
+ *      the ring of orbs down and starts the thinking clock.
+ *   2. Time crawls, but the world still runs: gems are still magneted in and
+ *      `gain` is still called. That is not a bug — bullet time is the reward
+ *      for reaching the core, not a pause.
+ *   3. One of those gems crosses a level. `gain` called `levelUp` **straight
+ *      out of the middle of the physics step**, and `levelUp` did
+ *      `this.mode = "levelup"`.
+ *   4. The child picks a card. `pickCard` ends `this.mode = "play"` — because
+ *      "play" is the only place it knew to go back to.
+ *
+ * And "core" is gone. `questTick` is called only in "core", so the ring stops
+ * turning and no strike is ever tested; `closeQuestion` returns early unless
+ * the mode is "core", so the thinking clock never expires either. The question
+ * is still open, the orbs are still drawn, and nothing on earth will collect
+ * one. Nothing is reported to the host — not an answer, not a timeout — so the
+ * child is at least not marked wrong for it, but a question they were part-way
+ * through has silently stopped existing.
+ *
+ * The same step also loses a card whenever ONE gem crosses TWO levels, which
+ * the late game does regularly: `gain`'s `while` loop called `levelUp` twice,
+ * and the second `showCards` overwrote the first three cards before the child
+ * had touched them.
+ *
+ * ── What replaces it ────────────────────────────────────────────────────────
+ *
+ * Earning a level and being shown the cards are two different events. A level
+ * is banked the moment it is earned — the number on the HUD goes up at once,
+ * because that is what the child just did — and the cards open on the next
+ * frame that the game is in ordinary play. A CORE finishes as a CORE: the ring
+ * keeps turning, the answer still counts, and the cards are waiting when the
+ * question closes.
+ *
+ * This is not a defensive reset. Nothing is reset: the interrupt simply never
+ * happens, so there is no state to restore and no race to lose.
+ */
+
+/** `game.ts`'s mode, repeated here so this file needs nothing from it. */
+export type Mode = "title" | "play" | "levelup" | "core" | "rift" | "over" | "paused"
+
+/**
+ * The only mode in which a level-up may take the screen.
+ *
+ * Not "core": a question is open and the child is mid-thought. Not "rift":
+ * they are dead and answering for their life. Not "levelup": one panel of
+ * cards at a time, or the second overwrites the first. Not "paused", "title"
+ * or "over", where there is no run to upgrade.
+ */
+const OPENS_IN: Mode = "play"
+
+export class LevelUps {
+  private queued = 0
+
+  /** Levels earned and not yet spent on a panel of cards. */
+  get waiting(): number {
+    return this.queued
+  }
+
+  /** The XP bar came round. The level is the child's from this moment. */
+  earned(): void {
+    this.queued++
+  }
+
+  /**
+   * May the cards open now? Takes one level from the queue if they may.
+   *
+   * Called once a frame with the current mode, so a level earned inside a CORE
+   * opens on the first frame after the question closes — and one earned while
+   * the cards are already up waits for the card that is on screen to be picked.
+   */
+  take(mode: Mode): boolean {
+    if (this.queued <= 0) return false
+    if (mode !== OPENS_IN) return false
+    this.queued--
+    return true
+  }
+
+  /** A new run. Nothing is owed. */
+  clear(): void {
+    this.queued = 0
+  }
+}

--- a/dynawalla/games/horde/src/game/loadout.test.ts
+++ b/dynawalla/games/horde/src/game/loadout.test.ts
@@ -1,0 +1,137 @@
+// WHAT A CARD CAN SAY, AT MOST.
+//
+// `ui/cards.ts` cuts the lettering on a card so that the longest thing the card
+// can be handed still fits on the lines it budgeted for it. That is only a
+// guarantee if the budgets are a measurement of this file rather than a guess
+// about it, so this deals thousands of real cards — every weapon, every
+// passive, a build deep enough that the numbers have four digits — and reads
+// the longest string out of them.
+//
+// If a new upgrade arrives with a longer name or a wordier offer, this fails
+// with the string and the budget, and `CHARS` in `ui/cards.ts` is the thing to
+// change. It is not decoration: `SEALED CACHE`, the longest of them, is what
+// sets the headline size on a phone.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { CHARS } from "../ui/cards.ts"
+import {
+  CARD_TITLES, LONGEST_TITLE, MAX_WEAPONS, WEAPON_BLURB,
+  makeBuild, makeWeapon, rollCards, type WeaponKey,
+} from "./loadout.ts"
+
+/** mulberry32, the generator the game itself runs on. */
+function rng(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const KEYS: WeaponKey[] = ["splinter", "halo", "arc", "pulse", "swarm", "lance", "spore"]
+
+/**
+ * Every card a long run can produce: fresh builds, loaded builds, and builds
+ * whose numbers have run away — a two-hour run with every damage card taken.
+ */
+function everyCard() {
+  const out = []
+  for (let seed = 0; seed < 400; seed++) {
+    for (const minutes of [0, 1, 2, 3, 6, 12, 40]) {
+      const build = makeBuild()
+      // Load it up: a late run has the maximum weapons at high levels and a
+      // stat block that has been multiplied for half an hour.
+      for (const key of KEYS.slice(0, MAX_WEAPONS)) {
+        if (!build.has(key)) build.weapons.push(makeWeapon(key))
+      }
+      for (const w of build.weapons) {
+        w.count = 24
+        w.dmg = 480
+        w.radius = 430
+        w.cdMs = 90
+      }
+      build.stats.dmgPct = 900
+      build.stats.ratePct = 400
+      build.stats.areaPct = 500
+      build.stats.maxHp = 940
+      build.stats.hp = 3
+      build.stats.speed = 941
+      build.stats.magnet = 1078
+      build.stats.critPct = 95
+      build.stats.regenPer10s = 44
+      build.stats.armor = 22
+      build.stats.xpPct = 975
+      out.push(...rollCards(build, rng(seed * 7919 + minutes), 4, minutes))
+      // …and a first-level build, where the new-weapon blurbs live.
+      out.push(...rollCards(makeBuild(), rng(seed), 3, minutes))
+    }
+  }
+  return out
+}
+
+const CARDS = everyCard()
+
+test("thousands of real cards, and every headline is in CARD_TITLES", () => {
+  assert.ok(CARDS.length > 5000, `only ${CARDS.length} cards were dealt`)
+  const seen = new Set(CARDS.map((c) => c.title))
+  for (const title of seen) {
+    assert.ok(
+      CARD_TITLES.includes(title),
+      `"${title}" is dealt by the game and is not in CARD_TITLES, so ui/cards.ts has never ` +
+        `sized a card for it`,
+    )
+  }
+  // The other direction: the list is not padded with names that do not exist.
+  // SEALED CACHE is the overlay's own and never comes out of `rollCards`.
+  for (const title of CARD_TITLES) {
+    if (title === "SEALED CACHE") continue
+    assert.ok(seen.has(title), `CARD_TITLES lists "${title}", which no card ever carries`)
+  }
+})
+
+test("no headline is longer than the budget the card is cut for", () => {
+  for (const c of CARDS) {
+    assert.ok(
+      c.title.length <= CHARS.title,
+      `"${c.title}" is ${c.title.length} characters and cards.ts budgets ${CHARS.title}`,
+    )
+  }
+  assert.equal(LONGEST_TITLE, CHARS.title)
+})
+
+test("no offer line is longer than the budget", () => {
+  let worst = ""
+  for (const c of CARDS) if (c.tag.length > worst.length) worst = c.tag
+  assert.ok(
+    worst.length <= CHARS.tag,
+    `"${worst}" is ${worst.length} characters and cards.ts budgets ${CHARS.tag} for the offer`,
+  )
+})
+
+test("no line of arithmetic is longer than the budget", () => {
+  // `before → after`, which for a new weapon is a sentence: "a ring that shoves
+  // the swarm off you → 1 × 14 = 14".
+  let worst = ""
+  for (const c of CARDS) {
+    const line = `${c.before} → ${c.after}`
+    if (line.length > worst.length) worst = line
+  }
+  assert.ok(
+    worst.length <= CHARS.math,
+    `"${worst}" is ${worst.length} characters and cards.ts budgets ${CHARS.math} — the card ` +
+      `will wrap onto a line nothing reserved height for`,
+  )
+})
+
+test("the wordiest thing on any card is a weapon's own description", () => {
+  // Named here so that adding a longer blurb fails loudly rather than quietly
+  // pushing a card past its budget.
+  const longest = Object.values(WEAPON_BLURB).reduce((a, b) => (b.length > a.length ? b : a))
+  assert.equal(longest, "a ring that shoves the swarm off you")
+  assert.ok(longest.length + 3 + 13 <= CHARS.math)
+})

--- a/dynawalla/games/horde/src/game/loadout.ts
+++ b/dynawalla/games/horde/src/game/loadout.ts
@@ -62,6 +62,27 @@ export const WEAPON_BLURB: Record<WeaponKey, string> = {
 
 export const MAX_WEAPONS = 5
 
+/**
+ * Every headline a card can carry.
+ *
+ * The overlay sizes a card's lettering so that the LONGEST of these still fits
+ * on one line inside the card — see `ui/cards.ts`. That is only true if this
+ * list is the whole set, so `loadout.test.ts` deals thousands of real cards out
+ * of real builds and fails on any headline that is not in here.
+ */
+export const CARD_TITLES: readonly string[] = [
+  // weapons — a new-weapon card and every weapon upgrade card use `w.name`
+  "SPLINTER", "HALO", "ARC", "PULSE", "SWARM", "LANCE", "SPORE",
+  // passives
+  "FEROCITY", "QUICKENING", "WIDENING", "CARAPACE", "CURRENT", "PULL",
+  "FRACTURE", "SHATTER", "MEND", "PLATING", "AVARICE",
+  // the heal, and the fourth card
+  "SURGE", "SEALED CACHE",
+]
+
+/** The longest headline in the game, in characters. The card is cut for this. */
+export const LONGEST_TITLE = CARD_TITLES.reduce((n, t) => Math.max(n, t.length), 0)
+
 export function makeWeapon(key: WeaponKey): Weapon {
   return { ...BASE[key], t: 0, phase: Math.random() * Math.PI * 2, level: 1 }
 }

--- a/dynawalla/games/horde/src/style.css
+++ b/dynawalla/games/horde/src/style.css
@@ -231,7 +231,9 @@
   /* All four edges. The top and bottom were padded and the SIDES were a bare
      12px, so in landscape on a notched phone the outermost rift answer and the
      outermost upgrade card — both things a child taps — ran under the sensor
-     housing and the rounded corner. */
+     housing and the rounded corner.
+
+     */
   padding:
     max(12px, var(--hz-safe-top, env(safe-area-inset-top)))
     max(12px, var(--hz-safe-right, env(safe-area-inset-right)))
@@ -242,9 +244,33 @@
   backdrop-filter: blur(9px) saturate(0.85);
   -webkit-backdrop-filter: blur(9px) saturate(0.85);
 }
+/* The level-up panel, and ONLY it, clears the host's chrome as well as the safe
+   edge. The host floats a back chevron and a how-to-play button over the game
+   rather than reserving a band for them, so a full-width row of cards centred in
+   the whole frame puts something a child taps under both. `--hz-chrome-top` is
+   where those two squares end and it is the host's own published geometry — see
+   `ui/layout.ts`; `ui/cards.ts` measures its band from the same number.
+
+   The rift, the title and the game-over panels keep the plain safe-area padding:
+   they are narrow and short, they never reached the corners, and 63px of extra
+   top padding on a phone held sideways pushed DIVE AGAIN toward the bottom edge
+   for nothing. */
+.hz-picks {
+  padding-top: max(12px, calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-chrome-top)));
+}
+
 .hz-modal.hz-open { display: flex; animation: hz-fade 170ms ease-out; }
 @keyframes hz-fade { from { opacity: 0; } to { opacity: 1; } }
 
+/* `LEVEL 7` over the cards is sized with them — it shares their band, so when
+   they shrink to fit a small screen it has to. Every other panel's heading is
+   sized by the design: `--hz-c-heading` is the CARDS' number and means nothing
+   to a rift that has the whole frame to itself. */
+.hz-picks .hz-title {
+  font-size: var(--hz-c-heading, clamp(13px, 3.4vw, 19px));
+  line-height: var(--hz-c-line, 1.3);
+  margin-bottom: var(--hz-c-heading-gap, clamp(8px, 2vw, 18px));
+}
 .hz-title {
   font-size: clamp(13px, 3.4vw, 19px);
   font-weight: 900;
@@ -255,10 +281,17 @@
   text-align: center;
 }
 
-/* cards */
+/* cards
+
+   EVERY size below comes from `ui/cards.ts` through a custom property. The
+   clamps that remain are `var()` fallbacks for a stylesheet loaded without a
+   mounted root; the mounted game always overwrites them, and the tests assert
+   the numbers the game computes, not these. Sizing anything here on its own
+   again would make those assertions a fiction — `cards.test.ts` parses this
+   file and fails if a rule stops reading its variable. */
 .hz-cards {
   display: flex;
-  gap: clamp(7px, 1.6vw, 16px);
+  gap: var(--hz-c-gap, clamp(7px, 1.6vw, 16px));
   width: min(1080px, 96vw);
   justify-content: center;
   align-items: stretch;
@@ -275,11 +308,11 @@
   border: 1px solid rgba(140, 200, 255, 0.22);
   background: linear-gradient(170deg, rgba(16, 26, 52, 0.94), rgba(6, 10, 24, 0.96));
   border-radius: 5px;
-  padding: clamp(9px, 1.8vw, 20px) clamp(8px, 1.6vw, 18px);
+  padding: var(--hz-c-pad, clamp(9px, 1.8vw, 20px)) var(--hz-c-padx, clamp(8px, 1.6vw, 18px));
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: clamp(3px, 0.8vw, 8px);
+  gap: var(--hz-c-inner, clamp(3px, 0.8vw, 8px));
   overflow: hidden;
   transition: transform 110ms cubic-bezier(0.16, 1, 0.3, 1), border-color 110ms, box-shadow 140ms;
   animation: hz-card-in 260ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
@@ -287,6 +320,18 @@
   color: inherit;
   font: inherit;
 }
+/* Portrait puts the main axis in the BLOCK direction, and `flex: 1 1 0` up
+   there means a base HEIGHT of zero, to be grown out of free space that a
+   content-sized container does not have. Every card came out 20px tall — one
+   border, two paddings, no content — and `overflow: hidden` then cut the labels
+   through the middle of their capitals. Down this axis a card is as tall as
+   what it holds, and `cards.ts` has already cut what it holds to fit the
+   screen. This rule must stay AFTER `.hz-card` above: a media query adds no
+   specificity, so source order is the whole of its authority. */
+@media (max-aspect-ratio: 4/5) {
+  .hz-card { flex: 0 0 auto; }
+}
+
 .hz-card:nth-child(1) { animation-delay: 0ms; }
 .hz-card:nth-child(2) { animation-delay: 55ms; }
 .hz-card:nth-child(3) { animation-delay: 110ms; }
@@ -323,15 +368,22 @@
 }
 .hz-card-r0 .hz-card-rarity { display: none; }
 
+/* Every label states its own line height. A card's height is then arithmetic
+   `cards.ts` can do, instead of a property of whichever system font the device
+   turned out to have — SF Pro Rounded on an iPad, Roboto on a Pixel, and 8%
+   between them in ascender-plus-descender. `--hz-c-line` is over both. */
 .hz-card-title {
-  font-size: clamp(13px, 2.6vw, 20px);
+  font-size: var(--hz-c-title, clamp(13px, 2.6vw, 20px));
+  line-height: var(--hz-c-line, 1.3);
+  white-space: nowrap;
   font-weight: 900;
   letter-spacing: 0.11em;
   color: var(--hue, #cfe9ff);
   padding-left: 8px;
 }
 .hz-card-tag {
-  font-size: clamp(10px, 2vw, 13px);
+  font-size: var(--hz-c-tag, clamp(10px, 2vw, 13px));
+  line-height: var(--hz-c-line, 1.3);
   font-weight: 800;
   letter-spacing: 0.08em;
   color: #e9f5ff;
@@ -340,10 +392,10 @@
 .hz-card-math {
   padding-left: 8px;
   margin-top: auto;
-  font-size: clamp(10px, 1.9vw, 13px);
+  font-size: var(--hz-c-math, clamp(10px, 1.9vw, 13px));
   color: #7fa0c0;
   letter-spacing: 0.02em;
-  line-height: 1.5;
+  line-height: var(--hz-c-line, 1.3);
 }
 .hz-card-math .hz-was { text-decoration: line-through; opacity: 0.65; }
 .hz-card-math .hz-now { color: #eaf7ff; font-weight: 800; }
@@ -352,16 +404,21 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
+  /* The row is given the full reserve even though the numeral's own line box is
+     tighter, so the height `cards.ts` budgeted is the height it gets. */
+  font-size: var(--hz-c-head, clamp(26px, 6vw, 46px));
+  line-height: var(--hz-c-head-line, 1.15);
+  min-height: calc(var(--hz-c-head, 26px) * var(--hz-c-head-row, 1.4));
 }
 .hz-card-head b {
-  font-size: clamp(26px, 6vw, 46px);
+  font-size: 1em;
   font-weight: 900;
-  line-height: 0.95;
+  line-height: var(--hz-c-head-line, 1.15);
   color: #fff;
   text-shadow: 0 0 22px var(--hue, #7fe6ff);
 }
 .hz-card-head span {
-  font-size: clamp(8px, 1.7vw, 11px);
+  font-size: var(--hz-c-sub, clamp(8px, 1.7vw, 11px));
   letter-spacing: 0.2em;
   color: #85a8c8;
   font-weight: 800;
@@ -376,20 +433,27 @@
 }
 .hz-sealed:hover { transform: none; box-shadow: none; border-color: rgba(255, 209, 102, 0.5); }
 .hz-seal-prompt {
-  font-size: clamp(20px, 5vw, 38px);
+  font-size: var(--hz-c-seal, clamp(20px, 5vw, 38px));
+  line-height: var(--hz-c-line, 1.3);
   font-weight: 900;
   color: #fff;
   text-align: center;
   letter-spacing: 0.02em;
   text-shadow: 0 0 26px rgba(255, 209, 102, 0.8);
-  padding: clamp(2px, 1vw, 8px) 0;
+  padding: 0;
 }
+/* The answers wrap when three of them will not fit across the card, and
+   `cards.ts` budgets the rows they take. `--hz-c-orbmin` is the width one of
+   them needs for the widest number the curriculum asks — it is what makes the
+   wrap happen where the metrics say it happens rather than wherever the text
+   ran out of room. */
 .hz-seal-orbs { display: flex; gap: 6px; justify-content: center; flex-wrap: wrap; }
 .hz-orb {
   flex: 1 1 0;
-  min-width: 52px;
-  padding: clamp(7px, 1.6vw, 13px) 4px;
-  font-size: clamp(15px, 3.4vw, 24px);
+  min-width: var(--hz-c-orbmin, 52px);
+  padding: var(--hz-c-orbpad, clamp(7px, 1.6vw, 13px)) 2px;
+  font-size: var(--hz-c-orb, clamp(15px, 3.4vw, 24px));
+  line-height: var(--hz-c-line, 1.3);
   font-weight: 900;
   color: #ffe9b8;
   background: rgba(255, 209, 102, 0.09);
@@ -407,7 +471,8 @@
 @keyframes hz-pop { 0% { transform: scale(1); } 40% { transform: scale(1.18); } 100% { transform: scale(1); } }
 .hz-seal-note {
   text-align: center;
-  font-size: clamp(8px, 1.7vw, 11px);
+  font-size: var(--hz-c-note, clamp(8px, 1.7vw, 11px));
+  line-height: var(--hz-c-line, 1.3);
   letter-spacing: 0.18em;
   color: #c8a95e;
   font-weight: 800;

--- a/dynawalla/games/horde/src/ui/cards.test.ts
+++ b/dynawalla/games/horde/src/ui/cards.test.ts
@@ -1,0 +1,493 @@
+// NO GLYPH IS CUT IN HALF.
+//
+// The founder, on an Android phone at 1080×2340: the LEVEL 2 panel is up and
+// every upgrade row is sliced through the middle of its capitals. `PULL`,
+// `QUICKENING` and `SPLINTER` show their top halves and nothing else, and what
+// is left of each label is overlapped by the row beneath it.
+//
+// Measured in Chromium at that screen's CSS size, before the fix: every card
+// reported `height: 20, scrollHeight: 95`. Twenty is one border, two paddings
+// and NO content — `flex: 1 1 0` down a column axis with `overflow: hidden` to
+// zero the minimum that would have pushed back. `cards.ts` has the full
+// autopsy.
+//
+// This file is the guarantee. It works out where every line of text lands, in
+// pixels, at every screen the game supports, and fails if any of them crosses
+// the edge of the row it is in. It also parses `style.css`, because a metric
+// the stylesheet has stopped reading is a metric about nothing — this repo has
+// twice shipped a CSS change that never reached a screen behind an assertion
+// that was really a substring search.
+
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+
+import { hitsHostChrome, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+import { CARD_TITLES, LONGEST_TITLE } from "../game/loadout.ts"
+import {
+  CHARS, CHAR_EM, EDGE, HEAD_LINE, HEAD_ROW, INK, LINE, MIN_FONT, ORB_MIN_FONT,
+  band, labelBoxes, metrics, rowBoxes,
+} from "./cards.ts"
+import { declared, parse, rulesFor, stripComments } from "./css.ts"
+
+const CSS = readFileSync(fileURLToPath(new URL("../style.css", import.meta.url)), "utf8")
+const RULES = parse(CSS)
+const PORTRAIT = "@media (max-aspect-ratio: 4/5)"
+
+const NONE: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+const NOTCH_PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 }
+const NOTCH_LANDSCAPE: Insets = { top: 0, right: 47, bottom: 21, left: 47 }
+
+/** Every screen this game claims to run on, and the founder's own phone. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["the smallest phone we support", 320, 568],
+  ["phone portrait", 390, 844],
+  ["the founder's phone, 1080×2340 at its CSS size", 360, 780],
+  ["tablet portrait", 768, 1024],
+  ["that phone on its side", 780, 360],
+  ["the smallest phone on its side", 568, 320],
+  ["phone landscape", 844, 390],
+  ["tablet landscape", 1024, 768],
+]
+
+/** Three upgrades, and the every-third-level panel with the sealed cache. */
+const DEALS: Array<[number, boolean]> = [[3, false], [4, true]]
+
+const each = (
+  fn: (name: string, w: number, h: number, insets: Insets, n: number, sealed: boolean) => void,
+) => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const insets of [NONE, w > h ? NOTCH_LANDSCAPE : NOTCH_PORTRAIT]) {
+      for (const [n, sealed] of DEALS) fn(name, w, h, insets, n, sealed)
+    }
+  }
+}
+
+const where = (name: string, w: number, h: number, i: Insets, n: number, s: boolean) =>
+  `${name} (${w}×${h}, insets ${i.top}/${i.bottom}, ${n} cards${s ? " with the cache" : ""})`
+
+/* ------------------------------------------------------------ the clipping */
+
+test("no line of text crosses the edge of the card it is in", () => {
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    for (const row of rowBoxes(m, n, sealed)) {
+      for (const label of labelBoxes(m, row)) {
+        // A line box is ascender to descender. Inside the padding, with the
+        // padding itself as the margin the founder's rows did not have.
+        assert.ok(
+          label.top >= row.top + m.pad,
+          `${where(name, w, h, insets, n, sealed)}: the ${label.name} starts at ` +
+            `${label.top.toFixed(1)}, above its card's padded top ${(row.top + m.pad).toFixed(1)}`,
+        )
+        assert.ok(
+          label.bottom <= row.bottom - m.pad + 0.01,
+          `${where(name, w, h, insets, n, sealed)}: the ${label.name} runs to ` +
+            `${label.bottom.toFixed(1)} and the card's padded bottom is ` +
+            `${(row.bottom - m.pad).toFixed(1)} — ` +
+            `${(label.bottom - (row.bottom - m.pad)).toFixed(1)}px of glyph is cut off`,
+        )
+      }
+    }
+  })
+})
+
+test("no glyph crosses the card's edge, and none touches the row below it", () => {
+  // The one assertion in this file that is NOT about the model's own numbers:
+  // a glyph is 1.34 em of ink whatever line box the metrics choose for it, and
+  // half-leading centres it in that box. Cut the reserve and the letters do not
+  // get smaller — they start overlapping each other and running out of the card.
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    for (const row of rowBoxes(m, n, sealed)) {
+      const labels = labelBoxes(m, row)
+      const ink = labels.map((l) => {
+        const mid = (l.top + l.bottom) / 2
+        return { ...l, inkTop: mid - (l.font * INK) / 2, inkBottom: mid + (l.font * INK) / 2 }
+      })
+      for (const l of ink) {
+        assert.ok(
+          l.inkTop >= row.top && l.inkBottom <= row.bottom,
+          `${where(name, w, h, insets, n, sealed)}: the ${l.name}'s glyphs run ` +
+            `${l.inkTop.toFixed(1)}–${l.inkBottom.toFixed(1)} and the card is ` +
+            `${row.top.toFixed(1)}–${row.bottom.toFixed(1)} — \`overflow: hidden\` cuts the ` +
+            `letters in half, which is what the founder photographed`,
+        )
+      }
+      for (let i = 1; i < ink.length; i++) {
+        const above = ink[i - 1] as { inkBottom: number; name: string }
+        const below = ink[i] as { inkTop: number; name: string }
+        assert.ok(
+          below.inkTop >= above.inkBottom,
+          `${where(name, w, h, insets, n, sealed)}: the ${above.name}'s descenders reach ` +
+            `${above.inkBottom.toFixed(1)} and the ${below.name} starts at ` +
+            `${below.inkTop.toFixed(1)} — they are written over each other`,
+        )
+      }
+    }
+  })
+})
+
+test("a card is taller than the text it holds, never the other way round", () => {
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    for (const [parts, kind, box] of [
+      [m.parts, "an upgrade card", m.rowH],
+      [m.sealParts, "the sealed cache", m.sealH],
+    ] as const) {
+      const content = parts.reduce((a, b) => a + b, 0) + 3 * m.inner
+      assert.ok(
+        box - content >= 2 * m.pad - 0.01,
+        `${where(name, w, h, insets, n, sealed)}: ${kind} is ${box.toFixed(1)}px tall and ` +
+          `holds ${content.toFixed(1)}px of text — the 95-in-20 bug, again`,
+      )
+    }
+  })
+})
+
+test("the rows do not overlap each other", () => {
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    const rows = rowBoxes(m, n, sealed)
+    if (!m.column) return // side by side: they share a top and a bottom by design
+    for (let i = 1; i < rows.length; i++) {
+      const above = rows[i - 1] as { bottom: number }
+      const below = rows[i] as { top: number }
+      assert.ok(
+        below.top >= above.bottom + m.gap - 0.01,
+        `${where(name, w, h, insets, n, sealed)}: row ${i} starts at ${below.top.toFixed(1)} ` +
+          `and row ${i - 1} ends at ${above.bottom.toFixed(1)} — they are ` +
+          `${(above.bottom - below.top).toFixed(1)}px into each other`,
+      )
+    }
+  })
+})
+
+/* ------------------------------------------------------------- the framing */
+
+test("the whole panel stays inside the frame", () => {
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    const rows = rowBoxes(m, n, sealed)
+    const first = rows[0] as { top: number }
+    const last = rows[rows.length - 1] as { bottom: number }
+    const floor = h - Math.max(EDGE, insets.bottom)
+    assert.ok(
+      m.total <= m.avail + 0.01,
+      `${where(name, w, h, insets, n, sealed)}: the panel wants ${m.total.toFixed(1)}px and ` +
+        `the frame has ${m.avail.toFixed(1)}px for it`,
+    )
+    assert.ok(
+      first.top >= m.top - 0.01,
+      `${where(name, w, h, insets, n, sealed)}: the first card starts at ` +
+        `${first.top.toFixed(1)}, above the band at ${m.top.toFixed(1)}`,
+    )
+    assert.ok(
+      last.bottom <= floor + 0.01,
+      `${where(name, w, h, insets, n, sealed)}: the last card ends at ` +
+        `${last.bottom.toFixed(1)} and the frame ends at ${floor.toFixed(1)}`,
+    )
+  })
+})
+
+test("no card lands under the host's back chevron or its how-to-play button", () => {
+  // The host floats both over the game rather than reserving a band for them,
+  // so an overlay centred in the whole frame puts a card a child taps under a
+  // control that is not the game's. The cards span the width; the block is one
+  // rectangle for this purpose.
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    const rows = rowBoxes(m, n, sealed)
+    const first = rows[0] as { top: number }
+    const last = rows[rows.length - 1] as { bottom: number }
+    const block = { x: insets.left, y: first.top, w: w - insets.left - insets.right, h: last.bottom - first.top }
+    assert.equal(
+      hitsHostChrome(block, w, insets),
+      false,
+      `${where(name, w, h, insets, n, sealed)}: the cards reach y=${first.top.toFixed(1)}, ` +
+        `into a host control`,
+    )
+  })
+})
+
+/* ---------------------------------------------------------------- the text */
+
+test("the longest headline the game can deal still fits on one line", () => {
+  // Not the three in the screenshot: every title `loadout.ts` can produce.
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    for (const title of CARD_TITLES) {
+      const width = title.length * CHAR_EM.title * m.title
+      assert.ok(
+        width <= m.textW + 0.01,
+        `${where(name, w, h, insets, n, sealed)}: "${title}" is ${width.toFixed(1)}px wide at ` +
+          `${m.title}px and the card gives it ${m.textW.toFixed(1)}px — it wraps, and a ` +
+          `headline on two lines reads as two upgrades`,
+      )
+    }
+  })
+})
+
+test("the lettering never falls below what a child can read", () => {
+  each((name, w, h, insets, n, sealed) => {
+    const m = metrics(w, h, insets, n, sealed)
+    // 8px is the design's own smallest — the caption under the big number and
+    // the sealed cache's footnote. Nothing else may go under MIN_FONT.
+    for (const [what, size, floor] of [
+      ["headline", m.title, MIN_FONT],
+      ["offer", m.tag, MIN_FONT],
+      ["big number", m.head, MIN_FONT],
+      ["arithmetic", m.math, MIN_FONT],
+      ["cache prompt", m.seal, MIN_FONT],
+      // A digit in a button of its own is legible smaller than a word is,
+      // and three of them share the width of one card. 8 is the design's
+      // own smallest lettering.
+      ["cache answer", m.orb, ORB_MIN_FONT],
+      ["caption", m.sub, 8],
+      ["footnote", m.note, 8],
+      ["LEVEL n", m.heading, MIN_FONT],
+    ] as const) {
+      assert.ok(
+        size >= floor,
+        `${where(name, w, h, insets, n, sealed)}: the ${what} is ${size}px, under ${floor}px`,
+      )
+    }
+  })
+})
+
+test("the panel only shrinks when it has to", () => {
+  // A phone with room uses the design's own sizes. If this starts failing the
+  // budget has quietly grown and every card got smaller for nothing.
+  const roomy = metrics(390, 844, NOTCH_PORTRAIT, 4, true)
+  assert.equal(roomy.scale, 1, `a 390×844 phone had to shrink the cards to ${roomy.scale}`)
+  assert.equal(roomy.title, 13)
+  assert.equal(roomy.head, 26)
+
+  // And it does shrink where it must: the smallest phone we support, with a
+  // notch, dealing four cards.
+  const tight = metrics(320, 568, NOTCH_PORTRAIT, 4, true)
+  assert.ok(tight.scale < 1, "320×568 with a notch and four cards did not need to shrink?")
+  assert.ok(tight.total <= tight.avail, "…and did not fit even after shrinking")
+})
+
+test("the band the panel may use is the one the host leaves behind", () => {
+  const b = band(844, NOTCH_PORTRAIT)
+  // 47 of notch, then the host's hairline, margin and 44px control, then 6.
+  assert.equal(b.top, 47 + 63)
+  assert.equal(b.avail, 844 - 47 - 63 - 34)
+  // With no insets at all the host's controls are still there.
+  assert.equal(band(844, NONE).top, 63)
+})
+
+/* ------------------------------------------------------ the stylesheet ties */
+
+test("the stylesheet reads every size from the metrics and computes none", () => {
+  // Everything inside the level-up panel. `.hz-title` on its own belongs to
+  // the rift as well and is deliberately sized by the design there.
+  const cardRules = RULES.filter(
+    (r) => /^\.hz-(card|seal|orb)/.test(r.selector) || r.selector === ".hz-picks .hz-title",
+  )
+  assert.ok(cardRules.length > 6, "the card rules vanished from style.css")
+  for (const r of cardRules) {
+    // The rarity chip is `position: absolute` — out of the flow, so it adds no
+    // height to the card and is free to size itself. Everything IN the flow is
+    // height, and height is this file's business.
+    if (r.decls["position"] === "absolute") continue
+    // `gap` is left out on purpose: on `.hz-card-head` and `.hz-seal-orbs` it
+    // is the space BESIDE a thing, not under it. The two gaps that are height —
+    // `.hz-cards` and `.hz-card` — are asserted by name below.
+    for (const prop of ["font-size", "line-height", "padding", "min-height"]) {
+      const v = r.decls[prop]
+      if (v === undefined) continue
+      if (/^0(px)?$/.test(v)) continue
+      // `1em` inherits the row's own variable; it is not a size of its own.
+      if (v === "1em" || v === "inherit") continue
+      if (prop === "line-height" && /^[0-9.]+$/.test(v)) continue
+      assert.match(
+        v,
+        /var\(--hz-c-/,
+        `\`${r.selector} { ${prop}: ${v} }\` sizes itself. Every size on a card comes from ` +
+          `cards.ts through a custom property, or the tests in this file are about a ` +
+          `stylesheet nobody is using`,
+      )
+    }
+  }
+})
+
+test("each label reads its own variable", () => {
+  for (const [selector, prop, needle] of [
+    [".hz-card-title", "font-size", "--hz-c-title"],
+    [".hz-card-title", "line-height", "--hz-c-line"],
+    [".hz-card-tag", "font-size", "--hz-c-tag"],
+    [".hz-card-tag", "line-height", "--hz-c-line"],
+    [".hz-card-math", "font-size", "--hz-c-math"],
+    [".hz-card-math", "line-height", "--hz-c-line"],
+    [".hz-card-head", "font-size", "--hz-c-head"],
+    [".hz-card-head", "line-height", "--hz-c-head-line"],
+    [".hz-card-head", "min-height", "--hz-c-head-row"],
+    [".hz-card-head span", "font-size", "--hz-c-sub"],
+    [".hz-seal-prompt", "font-size", "--hz-c-seal"],
+    [".hz-orb", "font-size", "--hz-c-orb"],
+    [".hz-picks .hz-title", "font-size", "--hz-c-heading"],
+    [".hz-card", "padding", "--hz-c-pad"],
+    [".hz-card", "gap", "--hz-c-inner"],
+    [".hz-cards", "gap", "--hz-c-gap"],
+  ] as const) {
+    const v = declared(RULES, selector, prop)
+    assert.ok(v !== undefined, `\`${selector}\` no longer declares ${prop}`)
+    assert.ok(
+      (v as string).includes(needle),
+      `\`${selector} { ${prop}: ${v} }\` does not read ${needle}`,
+    )
+  }
+})
+
+test("a headline is one line because the stylesheet says so", () => {
+  assert.equal(
+    declared(RULES, ".hz-card-title", "white-space"),
+    "nowrap",
+    "the headline may wrap again — `metrics()` budgets it one line",
+  )
+})
+
+test("a four-digit answer fits inside its own button", () => {
+  // Caught in Chromium and not by the model: at 8px a tabular digit's advance
+  // rounds up to a whole pixel, so `1000` was 32px wide inside a 22.8px button
+  // — four digits lying across the button beside them. The answers wrap now,
+  // and the rows they wrap onto are budgeted.
+  each((name, w, h, insets, n, sealed) => {
+    if (!sealed) return
+    const m = metrics(w, h, insets, n, sealed)
+    const row = m.textW + 8
+    const perRow = Math.ceil(3 / m.orbRows)
+    const button = Math.max(m.orbMin, (row - (perRow - 1) * 6) / perRow)
+    const text = CHARS.orb * CHAR_EM.orb * m.orb
+    assert.ok(
+      text <= button - 2 * 2 - 2,
+      `${where(name, w, h, insets, n, sealed)}: "1000" is ${text.toFixed(1)}px at ${m.orb}px ` +
+        `and its button is ${button.toFixed(1)}px — the digits run onto the button beside it`,
+    )
+    assert.ok(
+      perRow * m.orbMin + (perRow - 1) * 6 <= row + 0.01,
+      `${where(name, w, h, insets, n, sealed)}: ${perRow} answers of ${m.orbMin}px do not ` +
+        `fit across ${row.toFixed(1)}px, so they wrap onto a row the card did not budget`,
+    )
+  })
+})
+
+test("the answers wrap where the metrics say they wrap", () => {
+  // Wrapping is fine — an unbudgeted row is not. `--hz-c-orbmin` is what makes
+  // the browser break the row in the same place `metrics()` did.
+  assert.equal(declared(RULES, ".hz-seal-orbs", "flex-wrap"), "wrap")
+  assert.match(
+    declared(RULES, ".hz-orb", "min-width") as string,
+    /var\(--hz-c-orbmin/,
+    "the answers wrap wherever the text happens to run out, not where the card budgeted",
+  )
+  // The model measures the button from these two, so they may not drift.
+  assert.match(declared(RULES, ".hz-orb", "padding") as string, /\) 2px$/)
+  assert.match(declared(RULES, ".hz-seal-orbs", "gap") as string, /^6px$/)
+})
+
+test("portrait cards take their height from their content, and that rule wins", () => {
+  const portrait = RULES.filter((r) => r.selector === ".hz-card" && r.media === PORTRAIT)
+  assert.equal(portrait.length, 1, "the portrait `.hz-card` override is gone")
+  assert.equal(
+    (portrait[0] as { decls: Record<string, string> }).decls["flex"],
+    "0 0 auto",
+    "portrait cards are back on a zero flex basis — the bug the founder photographed",
+  )
+  // A media query adds no specificity, so this is entirely a question of which
+  // rule comes last in the file.
+  const base = rulesFor(RULES, ".hz-card").filter((r) => r.media === "" && r.decls["flex"])
+  assert.ok(base.length > 0, "`.hz-card` no longer sets `flex` at the top level")
+  const lastBase = Math.max(...base.map((r) => r.index))
+  assert.ok(
+    (portrait[0] as { index: number }).index > lastBase,
+    `the portrait override is at rule ${(portrait[0] as { index: number }).index} and the ` +
+      `landscape \`flex: 1 1 0\` at ${lastBase} — the later one wins, so the override does ` +
+      `nothing at all`,
+  )
+})
+
+test("the card panel clears the host's controls before it centres anything", () => {
+  const pad = declared(RULES, ".hz-picks", "padding-top")
+  assert.ok(pad !== undefined, "`.hz-picks` no longer declares a top padding")
+  assert.match(
+    pad as string,
+    /--hz-chrome-top/,
+    "the panel is centred in the whole frame again, so its top card sits under the " +
+      "host's back chevron",
+  )
+})
+
+test("and the other three panels are NOT paid for that clearance", () => {
+  // The rift, the title and the game-over screen are short and narrow and never
+  // reached a corner. 63px of top padding on a phone held sideways pushed DIVE
+  // AGAIN toward the bottom edge for nothing.
+  const shared = declared(RULES, ".hz-modal", "padding")
+  assert.ok(shared !== undefined, "`.hz-modal` no longer declares padding")
+  assert.ok(
+    !(shared as string).includes("--hz-chrome-top"),
+    `every modal pays for the cards' clearance: .hz-modal { padding: ${shared} }`,
+  )
+  // And their heading keeps the design's size rather than the cards' computed
+  // one — the rift has the whole frame and does not shrink with them.
+  const title = declared(RULES, ".hz-title", "font-size")
+  assert.ok(
+    !(title as string).includes("--hz-c-"),
+    `.hz-title { font-size: ${title} } — THE RIFT now shrinks with the upgrade cards`,
+  )
+})
+
+test("the line height the stylesheet uses is the one the metrics assume", () => {
+  // The whole model rests on a card's height being arithmetic rather than a
+  // property of the device's font.
+  assert.equal(LINE, 1.3)
+  assert.equal(HEAD_LINE, 1.15)
+  assert.equal(HEAD_ROW, 1.4)
+  const head = declared(RULES, ".hz-card-head", "min-height")
+  assert.equal(head, "calc(var(--hz-c-head, 26px) * var(--hz-c-head-row, 1.4))")
+  // The fallbacks in the sheet are the same numbers, for a sheet loaded before
+  // the root is mounted.
+  assert.ok(stripComments(CSS).includes("var(--hz-c-line, 1.3)"))
+})
+
+/* --------------------------------------------------- the strings themselves */
+
+test("the character widths are at or above what the browser actually renders", () => {
+  // Measured in Chromium against this stylesheet, at the real weights and
+  // tracking, with strings the game really deals — the widest per-character
+  // figure found for each label. The budgets have to sit ON or ABOVE these, or
+  // a label takes a line the card never reserved, and the reserve and the
+  // measurement would both be coming from the same wrong number.
+  //
+  // The answers carry two figures because a tabular digit's advance is rounded
+  // to a whole pixel: `1000` is 0.807 em per digit at 24px and a full 1.000 em
+  // at 8px, which is where `1000` ended up 9px wider than its own button.
+  const MEASURED = {
+    title: 0.850, // SPLINTER at 13px
+    tag: 0.808, // +25% ALL DAMAGE at 13px
+    math: 0.568, // 24 × 12 = 288 → 26 × 12 = 312 at 13px
+    note: 0.761, // OPEN IT, OR IGNORE IT at 11px
+    prompt: 0.599, // 144 ÷ 12 at 38px
+    orb: 1.000, // 1000 at 8px
+  } as const
+  for (const [label, em] of Object.entries(MEASURED)) {
+    const budget = CHAR_EM[label as keyof typeof CHAR_EM]
+    assert.ok(
+      budget >= em,
+      `CHAR_EM.${label} is ${budget} and Chromium renders ${em} em per character — the card ` +
+        `budgets less room than the text takes`,
+    )
+  }
+})
+
+test("the character budgets cover every string the game can put on a card", () => {
+  assert.equal(LONGEST_TITLE, CHARS.title, "a longer card title exists than cards.ts budgets")
+  for (const t of CARD_TITLES) {
+    assert.ok(t.length <= CHARS.title, `"${t}" is longer than the title budget`)
+  }
+  assert.equal(CHARS.note, "OPEN IT, OR IGNORE IT".length)
+})

--- a/dynawalla/games/horde/src/ui/cards.ts
+++ b/dynawalla/games/horde/src/ui/cards.ts
@@ -1,0 +1,502 @@
+/**
+ * How big a level-up card is, and how big its lettering is. In numbers.
+ *
+ * ── The bug this file exists to end ─────────────────────────────────────────
+ *
+ * On a phone the three upgrade rows were cut through the middle of their
+ * letters. `PULL`, `QUICKENING` and `SPLINTER` showed the top half of their
+ * capitals and nothing else; the bottom of every glyph was sliced off by the
+ * row's own lower edge, and what was left of each label was overlapped by the
+ * row beneath it.
+ *
+ * The row was **twenty pixels tall and held ninety-five pixels of text**.
+ * Measured in Chromium at 360×780 — the founder's 1080×2340 at its CSS size —
+ * every card reported `height: 20, scrollHeight: 95`. Twenty is exactly
+ * `border 1 + padding 9 + padding 9 + border 1`: the card had NO content height
+ * at all.
+ *
+ * The cause is two ordinary lines of CSS that are only wrong together:
+ *
+ *     .hz-card  { flex: 1 1 0; overflow: hidden; }
+ *     @media (max-aspect-ratio: 4/5) { .hz-cards { flex-direction: column; } }
+ *
+ * `flex: 1 1 0` sets the flex BASE SIZE to zero on the main axis. In landscape
+ * the main axis is horizontal and that is exactly right — four cards, four
+ * equal columns. Rotate to portrait and the same declaration means a base
+ * HEIGHT of zero, to be grown out of the container's free space. There is no
+ * free space: `.hz-cards` is itself a flex item of a `justify-content: center`
+ * column, so its height is its CONTENT height, and its content is three cards
+ * that just asked to be zero tall. Normally an item's automatic minimum size
+ * would push back — but `overflow: hidden` sets that minimum to zero too, and
+ * the same declaration then clips the text that fell out. Nothing in the
+ * cascade was left to notice.
+ *
+ * ── What replaces it ────────────────────────────────────────────────────────
+ *
+ * The row's height is its text's height, and the text's height is cut to the
+ * screen. One derives from the other, in that order:
+ *
+ *   1. `metrics()` is handed the frame, the safe insets and how many cards are
+ *      being dealt. It works out the band the overlay may occupy — under the
+ *      host's back chevron and how-to-play square, above the home indicator —
+ *      and how tall the cards want to be at their design sizes.
+ *   2. If they want more than there is, every font on the card is scaled by
+ *      one factor until they fit. Nothing is ever clipped, and nothing is ever
+ *      pushed off the bottom of the frame.
+ *   3. `applyCardVars` writes the result onto the root as custom properties.
+ *      `style.css` reads them through `var()` and sizes NOTHING on its own.
+ *
+ * Every line box is given an explicit `line-height`, so a card's height is a
+ * number this file can compute rather than a property of whichever system font
+ * the device happens to have — SF Pro Rounded on an iPad, Roboto on the
+ * founder's Pixel. `LINE` is the reserve per em and it is larger than the
+ * ascender-plus-descender of both.
+ *
+ * `cards.test.ts` parses `style.css` and fails if any of those rules stops
+ * reading the variables, because a stylesheet that quietly keeps its own
+ * `clamp()` would make every assertion in that file a fiction.
+ */
+
+import { CHROME_TOP } from "./layout.ts"
+import { NO_INSETS, safeInsets, type Insets } from "../../../../packs/shared/game-chrome/index.ts"
+
+/**
+ * The line box every card label gets, per em, written into the stylesheet.
+ *
+ * Ascender-to-descender is 1.25 em in SF Pro Rounded and 1.17 em in Roboto, so
+ * a 1.3 em box holds the whole glyph on both with room to spare. It is stated
+ * rather than left at `normal` so that a card's height is arithmetic and not a
+ * font's opinion.
+ */
+export const LINE = 1.3
+
+/**
+ * How tall the GLYPHS are, per em, independent of any line box we choose.
+ *
+ * This is the font's own content area — ascender, descender and line gap — and
+ * it is the number a clipping test has to be about, because a line box narrower
+ * than this does not shrink the letters, it just stops reserving room for them.
+ * Measured in Chromium with the stylesheet's own family list: 1.332 em with SF
+ * Pro Rounded, which is the tallest of the faces the stack can resolve to
+ * (Roboto is 1.172). 1.34 is that, rounded up.
+ *
+ * `LINE` is deliberately just under it — a line box of 1.3 em with a 1.34 em
+ * glyph puts 0.02 em past each edge of the box, and the card's padding is what
+ * holds that. `cards.test.ts` asserts exactly this and would fail if `LINE`
+ * were cut without the padding growing.
+ */
+export const INK = 1.34
+
+/**
+ * The big number's own line box. Tighter than `LINE` because a lone numeral
+ * has no descender to speak of and the design wants it to sit close; the card
+ * still RESERVES `LINE` for it, so the extra quarter-em is margin, not overflow.
+ */
+export const HEAD_LINE = 1.15
+
+/**
+ * What the card RESERVES for the big number's row, per em of it.
+ *
+ * The row is a baseline-aligned flex line holding a 900-weight numeral and a
+ * small caption, and Chromium measures it at 1.332 em however tight the
+ * `line-height` on it is. The reserve is stated as a `min-height` in the
+ * stylesheet so the row is exactly this tall and not "whatever the font did",
+ * which is the only way `metrics()` can be arithmetic about it.
+ */
+export const HEAD_ROW = 1.4
+
+/** The modal's own margin from the frame, where nothing else claims the space. */
+export const EDGE = 12
+
+/**
+ * Width of one character, in em, per kind of label.
+ *
+ * Measured in Chromium against the real stylesheet, at the real weights and
+ * tracking, with the strings the game actually deals:
+ *
+ *     .hz-card-title   SPLINTER 0.850   QUICKENING 0.811   SEALED CACHE 0.800
+ *     .hz-card-tag     +25% ALL DAMAGE 0.808   −2 DAMAGE TAKEN 0.792
+ *     .hz-card-math    24 × 12 = 288 → … 0.568   a ring that shoves … 0.522
+ *     .hz-seal-note    OPEN IT, OR IGNORE IT 0.761
+ *     .hz-seal-prompt  144 ÷ 12 0.599
+ *     .hz-orb          1000 0.807 at 24px, and 1.000 at 8px
+ *
+ * The numbers here are those rounded UP, because they are used to decide how
+ * many lines a label takes and a low guess would under-budget the card. A face
+ * wider than SF Pro Rounded costs a line of slack, never a clipped glyph.
+ *
+ * The answers are the reason two of these figures are quoted: a digit's advance
+ * is rounded to whole pixels, so four tabular digits are 0.81 em each at 24px
+ * and a full 1.0 em each at 8px. Budgeting the large-size figure put `1000`
+ * 9px wider than its own button on the narrowest card the game deals — caught
+ * in Chromium, not by the model, which is why `CHAR_EM.orb` is the small-size
+ * number with a margin on top.
+ */
+export const CHAR_EM = {
+  title: 0.90,
+  tag: 0.90,
+  math: 0.62,
+  note: 0.85,
+  prompt: 0.68,
+  orb: 1.05,
+} as const
+
+/**
+ * The longest string each label can be handed.
+ *
+ * `loadout.test.ts` deals thousands of real cards and fails if any of them is
+ * longer than these, so they are a measurement of the game and not a hope.
+ * The prompt comes from the HOST, whose questions this pack does not write;
+ * 16 covers every shape the reference generator produces, `(−123) + (−45)`
+ * included, and a longer one costs a second line rather than a clipped one.
+ */
+export const CHARS = {
+  title: 12,
+  tag: 16,
+  math: 56,
+  note: 21,
+  prompt: 16,
+  orb: 4,
+} as const
+
+/** Below this the lettering is too small for a child, however well it fits. */
+export const MIN_FONT = 9
+
+/**
+ * The floor for a sealed-cache ANSWER, which is a numeral in a button.
+ *
+ * Lower than `MIN_FONT` because three of them share the width of one card and
+ * the width is what has to give: four cards across a phone held sideways leave
+ * about 33px per answer, and `1000` at 9px does not fit inside that. A digit is
+ * legible smaller than a word is, and a clipped digit is not legible at all.
+ */
+export const ORB_MIN_FONT = 8
+
+type Clamp = readonly [min: number, vw: number, max: number]
+
+/** The design sizes, as the stylesheet used to state them. `vw` is per cent. */
+const F = {
+  title: [13, 2.6, 20] as Clamp,
+  tag: [10, 2.0, 13] as Clamp,
+  head: [26, 6.0, 46] as Clamp,
+  sub: [8, 1.7, 11] as Clamp,
+  math: [10, 1.9, 13] as Clamp,
+  seal: [20, 5.0, 38] as Clamp,
+  orb: [15, 3.4, 24] as Clamp,
+  note: [8, 1.7, 11] as Clamp,
+  heading: [13, 3.4, 19] as Clamp,
+}
+
+const BOX = {
+  headingGap: [8, 2.0, 18] as Clamp,
+  gap: [7, 1.6, 16] as Clamp,
+  pad: [9, 1.8, 20] as Clamp,
+  padX: [8, 1.6, 18] as Clamp,
+  inner: [3, 0.8, 8] as Clamp,
+  orbPad: [7, 1.6, 13] as Clamp,
+}
+
+const BORDER = 1
+/** `.hz-card-title` and its siblings are indented off the card's hue rail. */
+const RAIL = 8
+/** The gap and side padding of one sealed-cache answer, from `style.css`. */
+const ORB_GAP = 6
+const ORB_PAD_X = 2
+
+const clamp = (c: Clamp, w: number): number =>
+  Math.min(c[2], Math.max(c[0], (c[1] * w) / 100))
+
+export type CardMetrics = {
+  /** Portrait: one card per row. Mirrors `@media (max-aspect-ratio: 4/5)`. */
+  column: boolean
+  /** The single factor every font on the card is multiplied by. 1 when it fits. */
+  scale: number
+  title: number
+  tag: number
+  head: number
+  sub: number
+  math: number
+  seal: number
+  orb: number
+  note: number
+  heading: number
+  headingGap: number
+  gap: number
+  pad: number
+  padX: number
+  inner: number
+  orbPad: number
+  /** The width one sealed-cache answer needs. Below it they wrap, on purpose. */
+  orbMin: number
+  /** How many rows the three answers take at this size. */
+  orbRows: number
+  /** The four line boxes of an ordinary card, top to bottom. */
+  parts: number[]
+  /** The four line boxes of the sealed cache, top to bottom. */
+  sealParts: number[]
+  /** An ordinary upgrade card, border box. */
+  rowH: number
+  /** The sealed cache, border box. Taller: a prompt and a row of answers. */
+  sealH: number
+  /** One card's width, border box. */
+  cardW: number
+  /** Room for the title on one line, inside the padding and off the rail. */
+  textW: number
+  /** Heading plus every card plus the gaps between them. */
+  total: number
+  /** What `total` may not exceed. */
+  avail: number
+  /** Top of the band the overlay may use: under the host's two squares. */
+  top: number
+}
+
+/**
+ * The band between the host's chrome and the bottom of the frame.
+ *
+ * The host does not reserve a strip for its back chevron and its how-to-play
+ * button — it floats them over the game — so an overlay that centres itself in
+ * the whole frame puts a tappable card under both. `CHROME_TOP` is where they
+ * end; it is the host's own published geometry, not a number typed here.
+ */
+export function band(h: number, insets: Insets): { top: number; avail: number } {
+  const top = Math.max(EDGE, insets.top + CHROME_TOP)
+  const bottom = h - Math.max(EDGE, insets.bottom)
+  return { top, avail: Math.max(0, bottom - top) }
+}
+
+/**
+ * @param n how many cards are dealt, the sealed cache included
+ * @param sealed whether the last of them is the sealed cache
+ */
+export function metrics(
+  w: number,
+  h: number,
+  insets: Insets = NO_INSETS,
+  n = 3,
+  sealed = false,
+): CardMetrics {
+  const column = w / h <= 0.8
+  const { top, avail } = band(h, insets)
+
+  const gap = clamp(BOX.gap, w)
+  const pad = clamp(BOX.pad, w)
+  const padX = clamp(BOX.padX, w)
+  const inner = clamp(BOX.inner, w)
+  const orbPad = clamp(BOX.orbPad, w)
+  const headingGap = clamp(BOX.headingGap, w)
+
+  const cardW = column
+    ? Math.min(520, w * 0.96)
+    : (Math.min(1080, w * 0.96) - (n - 1) * gap) / Math.max(1, n)
+  const textW = Math.max(1, cardW - 2 * padX - 2 * BORDER - RAIL)
+
+  const ordinaryFixed = 3 * inner + 2 * pad + 2 * BORDER
+  const sealedFixed = ordinaryFixed
+  const ordinaries = sealed ? n - 1 : n
+
+  // The title is cut to the card's WIDTH as well: it is the one label that may
+  // not wrap, because a headline broken across two lines reads as two upgrades.
+  // A cap, not a scale — a narrow card shortens its headline, it does not shrink
+  // its big number too.
+  const titleCap = Math.max(MIN_FONT, textW / (CHARS.title * CHAR_EM.title))
+
+  /**
+   * The width one answer needs, and how many rows the three of them take.
+   *
+   * They are buttons with a widest-case number in them, so the width is what it
+   * is; what gives is the number of rows, and the rows are budgeted. Three
+   * across a card four-across in landscape do not fit at any size a child can
+   * read, and a fourth answer half off the side of its own button is the same
+   * defect as a clipped headline.
+   */
+  const orbMin = (font: number) =>
+    Math.ceil(CHARS.orb * CHAR_EM.orb * font) + 2 * ORB_PAD_X + 2 * BORDER
+  const orbRows = (font: number) => {
+    const room = textW + RAIL + ORB_GAP
+    const perRow = Math.max(1, Math.min(3, Math.floor(room / (orbMin(font) + ORB_GAP))))
+    return Math.ceil(3 / perRow)
+  }
+
+  /** How many lines a label of this size takes in a card this wide. */
+  const lines = (font: number, chars: number, em: number, width = textW): number =>
+    Math.max(1, Math.ceil((chars * em * font) / width))
+
+  /** Every font on the card at scale `s`, floored where a child stops reading. */
+  const sizesAt = (s: number) => {
+    const one = (c: Clamp) => {
+      const floor = Math.min(c[0], MIN_FONT)
+      return Math.max(floor, Math.floor(clamp(c, w) * s * 10) / 10)
+    }
+    return {
+      title: Math.min(one(F.title), Math.floor(titleCap * 10) / 10),
+      tag: one(F.tag),
+      head: one(F.head),
+      sub: one(F.sub),
+      math: one(F.math),
+      seal: one(F.seal),
+      orb: one(F.orb),
+      note: one(F.note),
+      heading: one(F.heading),
+    }
+  }
+
+  /**
+   * The four line boxes of one card, top to bottom, at scale `s`.
+   *
+   * Only the title is held to a single line. The tag and the arithmetic wrap
+   * as they please and are BUDGETED for it: a new-weapon card reads
+   * `a ring that shoves the swarm off you → 1 × 14 = 14`, which is three lines
+   * on a card four-across in landscape, and a card that budgeted one would put
+   * two of them through its own lower border.
+   */
+  const partsAt = (s: number) => {
+    const z = sizesAt(s)
+    const ordinary = [
+      z.title * LINE,
+      z.tag * LINE * lines(z.tag, CHARS.tag, CHAR_EM.tag),
+      Math.max(z.head * HEAD_ROW, z.sub * LINE),
+      z.math * LINE * lines(z.math, CHARS.math, CHAR_EM.math),
+    ]
+    const cache = [
+      z.title * LINE,
+      z.seal * LINE * lines(z.seal, CHARS.prompt, CHAR_EM.prompt, textW + RAIL),
+      // The answers: buttons, with their own padding and border, on as many
+      // rows as they need.
+      orbRows(z.orb) * (z.orb * LINE + 2 * orbPad + 2 * BORDER) +
+        (orbRows(z.orb) - 1) * ORB_GAP,
+      z.note * LINE * lines(z.note, CHARS.note, CHAR_EM.note, textW + RAIL),
+    ]
+    return { z, ordinary, cache }
+  }
+
+  const sum = (a: readonly number[]) => a.reduce((x, y) => x + y, 0)
+
+  const heightAt = (s: number) => {
+    const { z, ordinary, cache } = partsAt(s)
+    const row = sum(ordinary) + ordinaryFixed
+    const seal = sum(cache) + sealedFixed
+    const heading = LINE * z.heading + headingGap
+    const stack = column
+      ? ordinaries * row + (sealed ? seal : 0) + (n - 1) * gap
+      : Math.max(row, sealed ? seal : 0)
+    return { row, seal, total: stack + heading }
+  }
+
+  // Height is monotone in the scale and the floors make it a step function, so
+  // it is bisected rather than inverted. Thirty halvings of [0,1] land inside a
+  // billionth of the true root; the fonts are rounded to a tenth of a pixel
+  // long before that matters.
+  let scale = 1
+  if (heightAt(1).total > avail) {
+    let lo = 0
+    let hi = 1
+    for (let i = 0; i < 30; i++) {
+      const mid = (lo + hi) / 2
+      if (heightAt(mid).total <= avail) lo = mid
+      else hi = mid
+      }
+    scale = lo
+  }
+
+  const { z: m, ordinary: parts, cache: sealParts } = partsAt(scale)
+  const { row: rowH, seal: sealH, total } = heightAt(scale)
+
+  return {
+    column, scale, ...m,
+    headingGap, gap, pad, padX, inner, orbPad,
+    orbMin: orbMin(m.orb), orbRows: orbRows(m.orb),
+    parts, sealParts,
+    rowH, sealH, cardW, textW, total, avail, top,
+  }
+}
+
+/** The heights of the cards as they are stacked, top to bottom, in the band. */
+export function rowBoxes(
+  m: CardMetrics,
+  n: number,
+  sealed: boolean,
+): Array<{ top: number; bottom: number; sealed: boolean }> {
+  const block = m.total
+  const start = m.top + Math.max(0, (m.avail - block) / 2) + LINE * m.heading + m.headingGap
+  const out: Array<{ top: number; bottom: number; sealed: boolean }> = []
+  let y = start
+  for (let i = 0; i < n; i++) {
+    const isSeal = sealed && i === n - 1
+    const height = m.column ? (isSeal ? m.sealH : m.rowH) : Math.max(m.rowH, sealed ? m.sealH : 0)
+    if (m.column) {
+      out.push({ top: y, bottom: y + height, sealed: isSeal })
+      y += height + m.gap
+    } else {
+      out.push({ top: start, bottom: start + height, sealed: isSeal })
+    }
+  }
+  return out
+}
+
+/**
+ * The line boxes inside one card, in frame coordinates, in painting order.
+ *
+ * This is what the clipping assertion is about: every one of these must lie
+ * inside its card, because `overflow: hidden` will cut in half anything that
+ * does not.
+ */
+export function labelBoxes(
+  m: CardMetrics,
+  row: { top: number; bottom: number; sealed: boolean },
+): Array<{ name: string; font: number; top: number; bottom: number }> {
+  const names = row.sealed
+    ? (["title", "prompt", "orbs", "note"] as const)
+    : (["title", "tag", "head", "math"] as const)
+  const fonts = row.sealed
+    ? [m.title, m.seal, m.orb, m.note]
+    : [m.title, m.tag, Math.max(m.head, m.sub), m.math]
+  const heights = row.sealed ? m.sealParts : m.parts
+  const out: Array<{ name: string; font: number; top: number; bottom: number }> = []
+  let y = row.top + BORDER + m.pad
+  for (let i = 0; i < names.length; i++) {
+    const height = heights[i] as number
+    out.push({ name: names[i] as string, font: fonts[i] as number, top: y, bottom: y + height })
+    y += height + m.inner
+  }
+  return out
+}
+
+/**
+ * Hand the stylesheet the numbers above.
+ *
+ * Called every time the cards are dealt and again on a rotation, because the
+ * band a phone has in portrait is not the band it has on its side.
+ */
+export function applyCardVars(
+  root: HTMLElement,
+  n: number,
+  sealed: boolean,
+  // The same fallback `Game.resize` uses: before the first layout a root
+  // reports 0×0, and a panel measured against nothing comes out at the floor.
+  w = Math.max(200, root.clientWidth || window.innerWidth),
+  h = Math.max(200, root.clientHeight || window.innerHeight),
+  insets: Insets = safeInsets(),
+): CardMetrics {
+  const m = metrics(w, h, insets, n, sealed)
+  const px = (v: number) => `${v}px`
+  root.style.setProperty("--hz-c-title", px(m.title))
+  root.style.setProperty("--hz-c-tag", px(m.tag))
+  root.style.setProperty("--hz-c-head", px(m.head))
+  root.style.setProperty("--hz-c-sub", px(m.sub))
+  root.style.setProperty("--hz-c-math", px(m.math))
+  root.style.setProperty("--hz-c-seal", px(m.seal))
+  root.style.setProperty("--hz-c-orb", px(m.orb))
+  root.style.setProperty("--hz-c-note", px(m.note))
+  root.style.setProperty("--hz-c-heading", px(m.heading))
+  root.style.setProperty("--hz-c-heading-gap", px(m.headingGap))
+  root.style.setProperty("--hz-c-gap", px(m.gap))
+  root.style.setProperty("--hz-c-pad", px(m.pad))
+  root.style.setProperty("--hz-c-padx", px(m.padX))
+  root.style.setProperty("--hz-c-inner", px(m.inner))
+  root.style.setProperty("--hz-c-orbpad", px(m.orbPad))
+  root.style.setProperty("--hz-c-orbmin", px(m.orbMin))
+  root.style.setProperty("--hz-c-line", String(LINE))
+  root.style.setProperty("--hz-c-head-line", String(HEAD_LINE))
+  root.style.setProperty("--hz-c-head-row", String(HEAD_ROW))
+  return m
+}

--- a/dynawalla/games/horde/src/ui/css.ts
+++ b/dynawalla/games/horde/src/ui/css.ts
@@ -1,0 +1,128 @@
+/**
+ * Enough of a CSS parser to assert about `style.css`.
+ *
+ * A test that looks for a string inside a stylesheet proves nothing: `grep`
+ * cannot tell a live declaration from one inside a comment, from one a later
+ * rule overrides, or from one sitting in a media query that never matches. This
+ * fleet has shipped a CSS change twice that never reached a screen because the
+ * assertion was a substring search. So the sheet is parsed into rules, in
+ * source order, with their at-rule context, and the tests ask questions of
+ * that.
+ *
+ * It is not a general CSS parser and does not want to be. `style.css` is one
+ * file, flat, with at most one level of `@media`, and this reads exactly that.
+ */
+
+export type Rule = {
+  /** The selector as written, whitespace collapsed. */
+  selector: string
+  /** The `@media …` this rule sits inside, or "" at the top level. */
+  media: string
+  /** Declarations, last one winning, as CSS itself resolves duplicates. */
+  decls: Record<string, string>
+  /** Position in the file, so a test can assert which rule wins a tie. */
+  index: number
+}
+
+/** Everything between `/*` and the closing pair, gone. */
+export function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "")
+}
+
+export function parse(css: string): Rule[] {
+  const src = stripComments(css)
+  const rules: Rule[] = []
+  let i = 0
+  let media = ""
+
+  while (i < src.length) {
+    const open = src.indexOf("{", i)
+    const shut = src.indexOf("}", i)
+    if (open < 0) break
+    // A `}` before the next `{` is the end of the `@media` we are inside.
+    if (shut >= 0 && shut < open) {
+      media = ""
+      i = shut + 1
+      continue
+    }
+    const prelude = src.slice(i, open).trim().replace(/\s+/g, " ")
+
+    if (prelude.startsWith("@media")) {
+      media = prelude
+      i = open + 1
+      continue
+    }
+
+    const close = matchBrace(src, open)
+    if (close < 0) break
+    const body = src.slice(open + 1, close)
+    const decls: Record<string, string> = {}
+    for (const part of splitDecls(body)) {
+      const colon = part.indexOf(":")
+      if (colon < 0) continue
+      decls[part.slice(0, colon).trim()] = part.slice(colon + 1).trim().replace(/\s+/g, " ")
+    }
+    for (const selector of prelude.split(",").map((s) => s.trim()).filter(Boolean)) {
+      rules.push({ selector, media, decls, index: rules.length })
+    }
+    i = close + 1
+  }
+  return rules
+}
+
+/** Declarations, split on semicolons that are not inside parentheses. */
+function splitDecls(body: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i]
+    if (c === "(") depth++
+    else if (c === ")") depth--
+    else if (c === ";" && depth === 0) {
+      out.push(body.slice(start, i))
+      start = i + 1
+    }
+  }
+  out.push(body.slice(start))
+  return out.map((s) => s.trim()).filter(Boolean)
+}
+
+function matchBrace(src: string, open: number): number {
+  let depth = 0
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth++
+    else if (src[i] === "}") {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/**
+ * The rules for one selector, in source order.
+ *
+ * Selectors here have equal specificity and a media query adds none, so the
+ * LAST match is the one that paints — which is a thing tests need to assert.
+ */
+export function rulesFor(rules: readonly Rule[], selector: string): Rule[] {
+  return rules.filter((r) => r.selector === selector)
+}
+
+/** The winning value of a property for a selector, given a media context. */
+export function declared(
+  rules: readonly Rule[],
+  selector: string,
+  prop: string,
+  media = "",
+): string | undefined {
+  let value: string | undefined
+  for (const r of rules) {
+    if (r.selector !== selector) continue
+    if (r.media !== "" && r.media !== media) continue
+    const v = r.decls[prop]
+    if (v !== undefined) value = v
+  }
+  return value
+}

--- a/dynawalla/games/horde/src/ui/overlay.ts
+++ b/dynawalla/games/horde/src/ui/overlay.ts
@@ -4,6 +4,7 @@
  */
 import type { Card } from "../game/loadout.ts"
 import type { Question } from "../contract.ts"
+import { applyCardVars } from "./cards.ts"
 import { applyChromeVars, watchChromeVars } from "./layout.ts"
 import { shuffleWithAnswer } from "./shuffle.ts"
 
@@ -56,6 +57,9 @@ export class Overlay {
   private soundBtn: HTMLButtonElement
   private pauseBtn: HTMLButtonElement
   private unwatch: () => void = () => {}
+  /** How many cards are on screen, so a rotation can re-cut them to fit. */
+  private dealt = 3
+  private sealedDealt = false
 
   onPickCard: (i: number) => void = () => {}
   onSealed: (r: SealedResult) => void = () => {}
@@ -80,6 +84,7 @@ export class Overlay {
     // arrives through `safeInsets()`; `watchChromeVars` keeps it current
     // through a rotation.
     applyChromeVars(root)
+    applyCardVars(root, 3, false)
     this.unwatch = watchChromeVars(root)
 
     const hud = h("div", "hz-hud")
@@ -125,7 +130,10 @@ export class Overlay {
     hud.append(xp, top, life, this.weps, this.banner, this.subBanner, this.fps, corner)
 
     /* ---- level-up ---- */
-    this.cardModal = h("div", "hz-modal")
+    // `hz-picks` is what carries the host-chrome clearance and the computed
+    // lettering. The other three panels are short and narrow and keep the
+    // design's own sizes — see `style.css`.
+    this.cardModal = h("div", "hz-modal hz-picks")
     this.cardTitle = h("div", "hz-title", "CHOOSE")
     this.cardRow = h("div", "hz-cards")
     this.cardModal.append(this.cardTitle, this.cardRow)
@@ -240,6 +248,12 @@ export class Overlay {
   showCards(cards: Card[], sealed: Question | null, level: number): void {
     this.cardTitle.textContent = `LEVEL ${level}`
     this.cardRow.textContent = ""
+    // How tall a card may be depends on how many are being dealt and on the
+    // band the host's chrome leaves behind, so the sizes are worked out here
+    // and not by the stylesheet. Kept for the rotation: see `relayout`.
+    this.dealt = cards.length + (sealed ? 1 : 0)
+    this.sealedDealt = sealed !== null
+    applyCardVars(this.root, this.dealt, this.sealedDealt)
 
     cards.forEach((c, i) => {
       const el = h("button", `hz-card hz-card-r${c.rarity}`)
@@ -298,6 +312,18 @@ export class Overlay {
 
   hideCards(): void {
     this.cardModal.classList.remove("hz-open")
+  }
+
+  /**
+   * Re-cut the cards to the frame.
+   *
+   * A phone turned on its side while the panel is open has a different band to
+   * put the cards in — shorter, and side by side rather than stacked — and a
+   * card sized for the old one is either clipped or lost. `game.ts` calls this
+   * from the same `ResizeObserver` that resizes the canvas.
+   */
+  relayout(): void {
+    applyCardVars(this.root, this.dealt, this.sealedDealt)
   }
 
   /* ---------------------------------------------------------------- rift */


### PR DESCRIPTION
Two defects the founder found in DEEPSWARM's level-up panel. Both are in the overlay; nothing about the upgrades, their balance or the game changes.

## 1. The upgrade rows were cut through the middle of the letters

His screenshot: `PULL`, `QUICKENING` and `SPLINTER` each showing the top half of its capitals, the rest sliced off by the row's own lower edge.

The overlay is **DOM**, not canvas. Measured in Chromium at 360×780 — his 1080×2340 at its CSS size — every card reported `height: 20, scrollHeight: 95`. Twenty is exactly `border 1 + padding 9 + padding 9 + border 1`: the card had no content height at all, and `overflow: hidden` cut the 95px of text down to the 11px that fitted. Eleven pixels of a 16.9px line box is the top half of a capital.

**Root cause** — two ordinary declarations that are only wrong together:

```css
.hz-card  { flex: 1 1 0; overflow: hidden; }
@media (max-aspect-ratio: 4/5) { .hz-cards { flex-direction: column; } }
```

`flex: 1 1 0` is a flex base size of **zero on the main axis**. In landscape the main axis is horizontal and it is exactly right — four cards, four equal columns. Rotate to portrait and the same declaration means a base HEIGHT of zero, to be grown out of the container's free space; `.hz-cards` is itself a flex item of a `justify-content: center` column, so its height is its content height, and its content is three cards that just asked to be zero tall. An item's automatic minimum size would normally push back — `overflow: hidden` sets that to zero as well, and then clips what fell out. The founder's second observation was the same fact from outside: the `GOOD` chips looked fine because they are `position: absolute`, out of the flow that had collapsed.

**Row 1's missing `GOOD` chip is not a defect.** `.hz-card-r0 .hz-card-rarity { display: none }` — a common upgrade is deliberately unchipped, and `PULL` (`+55 MAGNET`) is rarity 0 while `QUICKENING` and `SPLINTER` are rarity 1. Left alone.

**The fix.** The row's height is its text's height, and the text is cut to the screen — one derives from the other, in that order. New `src/ui/cards.ts` is handed the frame, the safe insets and how many cards are being dealt (3, or 4 on the sealed-cache level); it works out the band the host's chrome leaves behind, scales every font by one factor until the panel fits, and writes the result onto the root as custom properties. `style.css` reads them through `var()` and sizes nothing on its own. Portrait cards become `flex: 0 0 auto`.

Every label now states its own `line-height`, so a card's height is arithmetic this file can do rather than a property of whichever system font the device resolved to — SF Pro Rounded on an iPad, Roboto on the founder's Pixel, and 8% between them in ascender-plus-descender.

The insets come from `packs/shared/game-chrome` as always; nothing reads `env()`. The clearance for the host's back chevron and how-to-play square is on the card panel alone (`.hz-picks`) — the rift, title and game-over panels are short and narrow, never reached a corner, and are byte-for-byte where `main` puts them.

**Verified in a real browser, not only in the model.** A temporary probe page (not committed) rendered the real `Overlay` with real `rollCards` output through the real stylesheet in Chromium at every viewport in the test matrix, and compared every card and every label against `metrics()`:

| | before | after |
|---|---|---|
| card height at 360×780 | 20px, holding 95px | 108px, holding 104px |
| cards with `scrollHeight > clientHeight` | all of them | none |
| panel off the bottom of the frame | — | none |
| model vs. rendered height | — | model is an upper bound everywhere |

(The only rows measuring taller than the model are the focused first cards, which carry `transform: scale(1.025)` — paint, not layout.)

## 2. A level-up could kill a live question

> "sometimes a level up can happen when a math problem is active and you can never activate the answer after that"

**Root cause, in order.** A CORE keeps the world running in bullet time, so gems are still magneted in and `gain()` is still called there. `gain()` called `levelUp()` **from inside the physics step**, and `levelUp()` did `this.mode = "levelup"`. When the child picked a card, `pickCard()` ended with `this.mode = "play"` — the only mode it knew to return to. `"core"` was gone with the question still open:

* `questTick` is called only in `"core"`, so the ring stopped turning and no strike was ever tested again — the orbs stayed lit and uncollectable, exactly as photographed;
* `closeQuestion` starts `if (this.mode !== "core") return`, so the thinking clock could not expire either, and the pending 620 ms close after an answer was swallowed too.

That is the "sometimes": it needs a gem to cross a level inside the few seconds a question is open.

**Nothing was reported to the host** on this path — not an answer, not a timeout — so the learner model was not poisoned, and the `skip`-vs-report trap from #739 does not arise. The question is not abandoned now; it is simply never interrupted.

**The fix.** Earning a level and being shown the cards are two different events. `src/game/levelup.ts` banks the level the moment it is earned — the HUD counts it at once, because that is what the child just did — and the cards open on the next frame the game is in ordinary play. The interrupt never happens, so there is no state to restore and no race to lose. This is not a defensive reset.

The same queue fixes a second bug in the same lines: `gain`'s `while` loop crossed two levels on one gem in the late game and called `levelUp()` twice, so the second `showCards` replaced the first three cards before the child had touched one. They are now two panels, one after the other.

**The one other way that symptom could be produced** — dying inside a CORE, which would leave the same orphaned ring behind the rift — cannot happen: `hurt()` is the only route to `die()` and it returns unless the mode is `"play"`. That was incidentally true; `levelup.test.ts` now asserts it.

## Tests

`src/ui/cards.test.ts` (19), `src/game/levelup.test.ts` (13), `src/game/loadout.test.ts` (5), and a small CSS parser in `src/ui/css.ts`. **105 pass, 0 fail, five consecutive runs.**

* Every line of text is placed in pixels at **320×568, 390×844, 360×780 (the founder's phone), 768×1024 and four landscape sizes**, each with and without a notch, each with 3 and with 4 cards, and asserted to fit inside its card with the padding as margin — and the **glyphs**, at 1.34 em of ink measured off the real font, asserted not to leave the card or touch the row below.
* The per-character widths and the ink figure are pinned to what Chromium actually renders, so the reserve and the measurement cannot both come from the same wrong number.
* Rows do not overlap; the panel fits the band; no card lands in a host control at any size; the other three panels do not pay for the cards' clearance.
* The longest headline the game can deal fits on one line — checked against every title in `loadout.ts`, not the three in the screenshot, with `loadout.test.ts` dealing thousands of real cards from real builds.
* `style.css` is **parsed** — rules, at-rule context and source order — not searched. That is how the cascade assertion is possible at all: the portrait `flex: 0 0 auto` override must come after the base rule, because a media query adds no specificity.

### Mutation transcript

Every new assertion broken, run, restored. All twenty fail:

| # | mutation | message |
|---|---|---|
| M1 | portrait `.hz-card` back to `flex: 1 1 0` (the founder's bug) | `portrait cards are back on a zero flex basis — the bug the founder photographed` |
| M2 | portrait override moved above the base rule | `the portrait override is at rule 32 and the landscape flex: 1 1 0 at 33 — the later one wins, so the override does nothing at all` |
| M3 | never shrink the lettering (`scale` pinned at 1) | `the smallest phone we support (320×568…): the panel wants 527.6px and the frame has 493.0px for it` |
| M4 | line reserve 1.3 em → 1.0 em | `the title's descenders reach 175.6 and the tag starts at 174.7 — they are written over each other` |
| M5 | `.hz-card-title` sizes itself again | ``.hz-card-title { font-size: clamp(13px, 2.6vw, 20px) } does not read --hz-c-title`` |
| M6 | headline may wrap | `the headline may wrap again — metrics() budgets it one line` |
| M7 | band forgets the host chrome | `the cards reach y=45.1, into a host control` |
| M8 | `gain()` opens the panel mid-step again | ``gain no longer banks the level through the queue`` / ``levelUp() is called from 2 places`` |
| M9 | queue lets the panel open inside a CORE | `the cards opened over a live question` |
| M10 | a second banked level is dropped | `two levels from one gem are two panels…: 0 !== 1` |
| M11 | an upgrade named longer than the budget | `"PULSE OF THE DEEP" is 17 characters and cards.ts budgets 12` |
| M12 | sealed answers may wrap freely | `the answers may wrap onto a second row, which no card budgeted height for` |
| M13 | frame loop stops draining the queue | ``levelUp() is called from 0 places; it may only be called from the frame loop`` |
| M14 | card panel centres in the whole frame again | `the panel is centred in the whole frame again, so its top card sits under the host's back chevron` |
| M15 | answers wrap wherever the text runs out | `the answers wrap wherever the text happens to run out, not where the card budgeted` |
| M16 | budget one row of answers however narrow the card | `3 answers of 84px do not fit across 150.9px, so they wrap onto a row the card did not budget` |
| M17 | answer width back to the large-size figure | `CHAR_EM.orb is 0.85 and Chromium renders 1 em per character — the card budgets less room than the text takes` |
| M18 | every modal pays for the cards' clearance | `every modal pays for the cards' clearance: .hz-modal { padding: max(12px, calc(… + var(--hz-chrome-top))) … }` |
| M19 | `THE RIFT` shrinks with the upgrade cards | `.hz-title { font-size: var(--hz-c-heading, …) } — THE RIFT now shrinks with the upgrade cards` |
| M20 | `hurt()` stops checking the mode | `hurt no longer refuses to hurt outside play — a child can now be killed mid-question, and die leaves the question open behind the rift` |

**Three of these found the assertion, not the code.** M4 passed the first time round: the clipping test compared the model to itself, and cutting the line reserve to 1.0 em shrank the boxes and the labels together. It is now written against 1.34 em of measured ink. M17 passed for the same reason one layer down, which is what the measured-width table is for. And the browser found what neither caught: at 8px a tabular digit's advance rounds up to a whole pixel, so `1000` rendered 32px wide inside a 22.8px button on the narrowest card the game deals — the answers wrap now, and the rows they wrap onto are budgeted.

### Gates

`npm run -s tsc` clean; `npm run -s test` — **105 pass, 0 fail, five consecutive runs**; `node packs/build.mjs horde` builds and passes the SDK checker (3 files, capabilities `items, items.reveal, haptics`, 9 skills).

Reviewed adversarially before this push; the findings above about the shared modal padding, the rift heading and the answer buttons came out of that pass and are fixed here.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb