### PR TITLE
dynawalla/games/balance: COUNTERPOISE — every ink derived from the brass it lands on, and a second digit stops costing a quarter of the type

### DIFF
--- a/dynawalla/games/balance/src/draw.ts
+++ b/dynawalla/games/balance/src/draw.ts
@@ -22,7 +22,22 @@ import {
   NUMERAL_FACE,
   fittedNumeralPx,
   idealNumeralPx,
+  stackedNumeralPx,
 } from "./layout.ts";
+import {
+  BALLOON_BODY,
+  BRASS_BODY,
+  BRASS_HI,
+  BRASS_LO,
+  BRASS_MID,
+  BRASS_TOP,
+  COPPER,
+  balloonGround,
+  haloFor,
+  inkFor,
+  weightGround,
+  type CrateState,
+} from "./ink.ts";
 import type { Beam, Body } from "./sim.ts";
 import { dishCentre } from "./sim.ts";
 import type { PuzzleSpec, Side } from "./puzzle.ts";
@@ -30,6 +45,76 @@ import type { Camera, Particles } from "./juice.ts";
 import { clamp01, easeOutCubic, easeOutQuint, easeOutBack } from "./ease.ts";
 
 const BG_SCALE = 0.5;
+
+/**
+ * Paint a gradient from a stop list in `ink.ts`.
+ *
+ * The point of the indirection is that the legibility test measures those same
+ * arrays. A numeral's contrast is a claim about the surface under it, so the
+ * surface a test believes in and the surface the canvas paints have to be one
+ * object — otherwise the first person to warm up the brass silently invalidates
+ * every number in the table without a single test going red.
+ */
+function stops(
+  gr: CanvasGradient,
+  list: ReadonlyArray<readonly [number, string]>,
+): CanvasGradient {
+  for (const [at, colour] of list) gr.addColorStop(at, colour);
+  return gr;
+}
+
+/**
+ * The ink a numeral on plain brass is engraved in, and the halo behind it.
+ *
+ * Derived once, from the brass itself, rather than typed in. What was typed in
+ * was `#ffeec4`, which measures **1.03:1** against the specular streak of the
+ * disc it is engraved on — the numeral and the brass being, to a reader, the same
+ * colour. See the header of `ink.ts`.
+ */
+export const WEIGHT_INK = inkFor(weightGround());
+export const BALLOON_INK = inkFor(balloonGround());
+
+/**
+ * Which of the three things a crate window can be showing.
+ *
+ * Pulled out of the draw call so the legibility test can drive the same three
+ * states the renderer does, off the same predicate. A test that re-derived
+ * "wrong beats declared" by hand would keep passing after somebody swapped the
+ * order here, which is the whole failure it exists to catch.
+ */
+export function crateState(v: Pick<ViewState, "wrong" | "declared">): CrateState {
+  if (v.wrong > 0) return v.declared ? "rejected" : "rejectedEmpty";
+  return v.declared ? "declared" : "unknown";
+}
+
+/**
+ * The verdigris a rejected value is written in — lifted from `C.verdigris`.
+ *
+ * The frame around a rejected crate stays `#5fae95`; the numeral inside it does
+ * not. Verdigris is the one ink in this pack whose luminance sits in the middle
+ * (0.349), which is the worst place to be: too dark to separate from mist-lit
+ * glass, too light for the dark halo to carry it. Measured against the darkest
+ * ground a crate label reaches — mist over `#0f1a20`, the `rejectedEmpty` state
+ * — `#5fae95` and its halo come to **2.82:1**, under the non-text bar.
+ *
+ * `#7fccb3` is the same hue at luminance 0.510 and measures 3.39:1 there. It is
+ * still unmistakably cold copper-oxide rather than the celebration gold, which
+ * is the whole job the colour is doing.
+ */
+const VERDIGRIS_INK = "#7fccb3";
+
+/**
+ * The ink a crate's label is written in. Unlike the brass and the balloon these
+ * colours carry meaning and are not free to be derived — a rejected value goes
+ * cold copper-oxide and never warm, so the colour agrees with the slam and the
+ * returned weight rather than contradicting them. What IS derived is the halo
+ * behind them, and `legibility.test.ts` measures all four states against the
+ * window, the specular arc, the rim, the iron and the banding.
+ */
+export function crateInk(state: CrateState): string {
+  if (state === "rejected" || state === "rejectedEmpty") return VERDIGRIS_INK;
+  return state === "declared" ? C.gold : "#cfe3ea";
+}
 
 export const SERIF =
   '"Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, "Times New Roman", serif';
@@ -39,9 +124,12 @@ const C = {
   night1: "#101725",
   night2: "#18213247",
   brassDark: "#3a2a0e",
-  brassMid: "#b08a3c",
-  brassHi: "#f7e6b4",
-  brassLo: "#6a4f1d",
+  // The brass lives in `ink.ts`, which is where its contrast is measured. Two
+  // copies of `#f7e6b4` meant the disc could be warmed up without the column it
+  // stands on following, and without the legibility table noticing either.
+  brassMid: BRASS_MID,
+  brassHi: BRASS_HI,
+  brassLo: BRASS_LO,
   ivory: "#f2e9d8",
   ink: "#1a1207",
   iron0: "#161b22",
@@ -51,7 +139,7 @@ const C = {
   stone1: "#171a20",
   stone2: "#3a3d46",
   gold: "#ffd07a",
-  copper: "#c8763f",
+  copper: COPPER,
   verdigris: "#5fae95",
   glass: "#8fb6c9",
 };
@@ -820,16 +908,9 @@ export class Renderer {
     }
 
     // body
-    const g = this.grad(`wbody${r.toFixed(1)}`, (c) => {
-      const gr = c.createLinearGradient(-r, 0, r, 0);
-      gr.addColorStop(0, "#2b1e07");
-      gr.addColorStop(0.14, C.brassLo);
-      gr.addColorStop(0.34, C.brassHi);
-      gr.addColorStop(0.52, C.brassMid);
-      gr.addColorStop(0.8, "#7a5a1e");
-      gr.addColorStop(1, "#201604");
-      return gr;
-    });
+    const g = this.grad(`wbody${r.toFixed(1)}`, (c) =>
+      stops(c.createLinearGradient(-r, 0, r, 0), BRASS_BODY),
+    );
     ctx.save();
     ctx.shadowColor = "rgba(0,0,0,0.45)";
     ctx.shadowBlur = 10;
@@ -846,14 +927,9 @@ export class Renderer {
     ctx.restore();
 
     // top face
-    const tg = this.grad(`wtop${r.toFixed(1)}`, (c) => {
-      const gr = c.createLinearGradient(-r, -h / 2 - ry, r, -h / 2 + ry);
-      gr.addColorStop(0, "#8a6a26");
-      gr.addColorStop(0.4, "#e9d197");
-      gr.addColorStop(0.62, C.brassHi);
-      gr.addColorStop(1, "#7c5d1f");
-      return gr;
-    });
+    const tg = this.grad(`wtop${r.toFixed(1)}`, (c) =>
+      stops(c.createLinearGradient(-r, -h / 2 - ry, r, -h / 2 + ry), BRASS_TOP),
+    );
     ctx.fillStyle = tg;
     ctx.beginPath();
     ctx.ellipse(0, -h / 2, r, ry, 0, 0, Math.PI * 2);
@@ -886,7 +962,7 @@ export class Renderer {
       ctx.stroke();
     }
 
-    this.numeral(toKeyDisplay(b.value), 0, h * 0.06, r, v);
+    this.numeral(toKeyDisplay(b.value), 0, h * 0.06, r, v, WEIGHT_INK);
   }
 
   private balloon(L: Layout, v: ViewState, b: Body, r: number): void {
@@ -903,14 +979,9 @@ export class Renderer {
     ctx.quadraticCurveTo(r * 0.3, r * 1.9, -r * 0.08, r * 2.65);
     ctx.stroke();
 
-    const g = this.grad(`balloon${r.toFixed(1)}`, (c) => {
-      const gr = c.createRadialGradient(-r * 0.35, -r * 0.5, r * 0.08, 0, 0, r * 1.35);
-      gr.addColorStop(0, "#ffe6c8");
-      gr.addColorStop(0.28, "#e79a5c");
-      gr.addColorStop(0.72, C.copper);
-      gr.addColorStop(1, "#612f12");
-      return gr;
-    });
+    const g = this.grad(`balloon${r.toFixed(1)}`, (c) =>
+      stops(c.createRadialGradient(-r * 0.35, -r * 0.5, r * 0.08, 0, 0, r * 1.35), BALLOON_BODY),
+    );
     ctx.save();
     ctx.shadowColor = "rgba(0,0,0,0.4)";
     ctx.shadowBlur = 12;
@@ -938,7 +1009,7 @@ export class Renderer {
     ctx.fill();
     ctx.restore();
 
-    this.numeral(toKeyDisplay(b.value), 0, r * 0.08, r * 0.94, v, "#3a1a08");
+    this.numeral(toKeyDisplay(b.value), 0, r * 0.08, r * 0.94, v, BALLOON_INK);
     ctx.restore();
   }
 
@@ -1032,10 +1103,7 @@ export class Renderer {
     ctx.restore();
 
     const label = v.declared ? toKeyDisplay(v.declared) : "x";
-    // A rejected value goes cold copper-oxide, never warm: the colour agrees
-    // with the slam and the returned weight rather than contradicting them.
-    const labelColour = v.wrong > 0 ? C.verdigris : v.declared ? C.gold : "#cfe3ea";
-    this.numeral(label, 0, 0, wr * 1.45, v, labelColour, true);
+    this.numeral(label, 0, 0, wr * 1.45, v, crateInk(crateState(v)), true);
 
     if (v.wrong > 0) {
       ctx.save();
@@ -1056,27 +1124,47 @@ export class Renderer {
     y: number,
     r: number,
     v: ViewState,
-    color = "#ffeec4",
+    color: string,
     glow = false,
   ): void {
     const ctx = this.ctx;
     const slash = label.indexOf("/");
+    // The counter-ink, derived from the ink, which was derived from the surface.
+    // See the header of `ink.ts`: there is provably no single colour that reads
+    // against all of the brass, so the numeral is drawn as a pair.
+    const halo = haloFor(color);
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
     if (slash > 0) {
       const n = label.slice(0, slash);
       const d = label.slice(slash + 1);
-      const s = r * 0.5;
-      const yy = y + r * 0.12; // clear the machined top face
+      const s = stackedNumeralPx(r);
+      // Was `r * 0.12`. The bigger rows plus their halos put the denominator's
+      // descender 0.03px past the brass belly on a 320×568 phone — measured, by
+      // the assertion in `legibility.test.ts` that now guards it — so the whole
+      // stack sits a little higher. The top face it was dropping clear of is a
+      // surface the halo is measured against now anyway.
+      const yy = y + r * 0.09;
       ctx.font = `600 ${s.toFixed(1)}px ${SERIF}`;
-      engrave(ctx, n, x, yy - s * 0.52, color, glow);
-      engrave(ctx, d, x, yy + s * 0.54, color, glow);
-      ctx.strokeStyle = color;
-      ctx.lineWidth = Math.max(1, r * 0.055);
+      // Pushed apart from 0.52/0.54: at the bigger type both rows carry a halo,
+      // and at the old spacing the numerator's halo and the bar's halo closed to
+      // within half a pixel and read as one dark mass with a hairline in it.
+      engrave(ctx, n, x, yy - s * 0.58, color, glow, s, halo);
+      engrave(ctx, d, x, yy + s * 0.6, color, glow, s, halo);
+      // The bar carries the same pair. A hairline in the ink alone disappears
+      // into the specular streak exactly as the digits did, and a vanished bar
+      // turns 1/2 into two stacked numbers.
+      ctx.lineCap = "round";
       ctx.beginPath();
       ctx.moveTo(x - s * 0.44, yy);
       ctx.lineTo(x + s * 0.44, yy);
+      ctx.strokeStyle = halo;
+      ctx.lineWidth = Math.max(1, r * 0.055) + haloWidth(s);
       ctx.stroke();
+      ctx.strokeStyle = color;
+      ctx.lineWidth = Math.max(1, r * 0.055);
+      ctx.stroke();
+      ctx.lineCap = "butt";
     } else {
       // Fitted, not guessed. The old line picked `r * 0.78` for anything two
       // digits or wider and drew centred, so `4232831450` — which the shipped
@@ -1092,7 +1180,7 @@ export class Renderer {
       ctx.font = `600 ${ideal.toFixed(1)}px ${SERIF}`;
       const s = fittedNumeralPx(ideal, ctx.measureText(label).width, r * NUMERAL_FACE);
       if (s !== ideal) ctx.font = `600 ${s.toFixed(1)}px ${SERIF}`;
-      engrave(ctx, label, x, y, color, glow);
+      engrave(ctx, label, x, y, color, glow, s, halo);
     }
     void v;
   }
@@ -1456,16 +1544,57 @@ function measureTracked(ctx: CanvasRenderingContext2D, s: string, track: number)
   return w;
 }
 
-function engrave(
+/**
+ * How wide the halo behind a numeral of `px` type is, in pixels.
+ *
+ * A stroke is centred on the outline, so half of this lies outside the glyph —
+ * `px * 0.075` — and half lies inside, where the fill immediately paints over it.
+ * The stems therefore keep their full weight and only the outside is gained,
+ * which is the whole reason the halo is stroked before the fill and not after.
+ *
+ * 0.15em is a working span rather than a maximum, and the counters — the holes in
+ * 0, 6, 8 and 9 — are the constraint in the other direction, because nothing
+ * fills those back in. At the pack's 15px floor the halo closes in by 1.13px on
+ * each side of a counter roughly 4px wide, which leaves it open; at twice this
+ * width it would shut. `legibility.test.ts` holds both ends.
+ */
+export function haloWidth(px: number): number {
+  return Math.max(2, px * 0.15);
+}
+
+/**
+ * A numeral, cut into whatever it is lying on.
+ *
+ * Three passes, and each one is load-bearing:
+ *
+ *   1. the halo, offset down — the shadow that makes the digit read as *struck
+ *      into* the brass rather than painted onto it. This is what the old single
+ *      `rgba(28,18,4,0.85)` copy was doing, and it is the only part of the old
+ *      version that was doing anything for contrast: one direction out of four.
+ *   2. the halo, on the glyph's own centre — the ring. This is the new part. It
+ *      is what makes the contrast claim in `ink.ts` true in every direction
+ *      rather than only below the glyph.
+ *   3. the ink.
+ */
+export function engrave(
   ctx: CanvasRenderingContext2D,
   text: string,
   x: number,
   y: number,
   color: string,
   glow: boolean,
+  px: number,
+  halo: string,
 ): void {
-  ctx.fillStyle = "rgba(28,18,4,0.85)";
-  ctx.fillText(text, x, y + 1.4);
+  const w = haloWidth(px);
+  ctx.save();
+  ctx.lineJoin = "round";
+  ctx.miterLimit = 2;
+  ctx.strokeStyle = halo;
+  ctx.lineWidth = w;
+  ctx.strokeText(text, x, y + Math.max(1, px * 0.06));
+  ctx.strokeText(text, x, y);
+  ctx.restore();
   if (glow) {
     ctx.save();
     ctx.shadowColor = color;

--- a/dynawalla/games/balance/src/ink.ts
+++ b/dynawalla/games/balance/src/ink.ts
@@ -1,0 +1,354 @@
+// WHAT THE NUMERAL LANDS ON.
+//
+// The founder played COUNTERPOISE and reported two things about the numbers
+// engraved on the weights: *"they are a bit small and not enough contrast for
+// me."* Size is `layout.ts`. This file is contrast, and it is here because the
+// old answer to contrast was a hard-coded `#ffeec4` — one colour, chosen once,
+// against a brass disc whose own gradient runs from `#201604` to `#f7e6b4`.
+//
+// `#ffeec4` on `#f7e6b4` measures **1.08:1**. That is not "a bit low"; that is
+// the numeral and the specular streak of the brass being the same colour, and
+// the streak sits at gradient stop 0.34 — a third of the way across the disc,
+// which is exactly where a two-digit numeral is drawn. VOLTA had the same class
+// of bug and it was found the same way: by measuring every surface instead of
+// spot-checking the one the author happened to be looking at.
+//
+// ## Recolouring alone cannot fix this, and that is arithmetic
+//
+// For an ink to clear 4.5:1 against `#f7e6b4` (relative luminance 0.797) it
+// needs luminance <= 0.138. To clear 4.5:1 against `#201604` (luminance 0.0089)
+// it needs luminance >= 0.215. No colour satisfies both. `bestSingleInk` scans
+// the whole grey ramp and reports the real ceiling for each object in this pack:
+// **1.30:1 on a weight, 1.92:1 on a balloon, 1.90:1 in a crate.** A lone
+// `fillText` on these surfaces is unfixable by choosing a better colour, and
+// `legibility.test.ts` asserts that so nobody rediscovers the dead end by hand.
+//
+// So a numeral is drawn as a **pair**: an ink, and an opaque counter-ink halo
+// stroked behind it. Both are derived from the surfaces of the object being
+// drawn. The guarantee has two layers, because the reader's eye has two jobs:
+//
+//   1. **Letterform.** The glyph is resolved against the halo that rings it, not
+//      against the brass — the halo is opaque and encircles the glyph, so it IS
+//      the ground for the shape of the digit. `MIN_LETTERFORM = 4.5:1`, WCAG AA
+//      for body text. Held at the body-text number rather than the 3:1 large-text
+//      allowance because the reader is a child and the brief was that what
+//      shipped was not enough.
+//   2. **Object.** The inked blob as a whole must be visible against whatever it
+//      is lying on. `MIN_OBJECT = 3.0:1`, WCAG 1.4.11 non-text contrast, and one
+//      of the ink or the halo must clear it on every surface.
+//
+// The second bar is 3.0 and not 4.5 for a reason worth stating: **4.5 against an
+// arbitrary ground is impossible for any two-colour scheme.** An ink and a halo
+// at opposite poles leave a crossover band of ground luminance where neither
+// clears 4.5; solving (1.05)/(L+0.05) = (L+0.05)/(0.05) puts the crossover at
+// L = 0.179 and the best achievable there at **4.58:1 — and that is with pure
+// `#000` on pure `#fff`.** Any real palette does worse. Claiming 4.5:1 against
+// every raw surface would therefore be a claim no implementation could keep.
+// What is claimed instead is measured, and it holds: see the table in the test.
+
+export type RGB = readonly [number, number, number];
+
+/** Ink against the halo that rings it. WCAG AA body text. */
+export const MIN_LETTERFORM = 4.5;
+
+/** The inked blob against the ground it lies on. WCAG 1.4.11 non-text contrast. */
+export const MIN_OBJECT = 3.0;
+
+export function rgb(hex: string): RGB {
+  const s = hex.replace("#", "");
+  const n = Number.parseInt(s.slice(0, 6), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/**
+ * Relative luminance, 0..1 — the same sRGB transfer curve `luma` uses in STACK's
+ * `strata.ts`, where the HUD picks light-on-dark or dark-on-light from the sky
+ * it actually sits in front of. Same idea, same maths, a different surface.
+ */
+export function luma(c: RGB): number {
+  const f = (v: number): number => {
+    const x = v / 255;
+    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2]);
+}
+
+/** WCAG contrast ratio between two opaque colours, 1..21. */
+export function contrast(a: RGB, b: RGB): number {
+  const la = luma(a);
+  const lb = luma(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** `globalCompositeOperation = "source-over"` at `alpha`. */
+export function over(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.round(src[i] * alpha + dst[i] * (1 - alpha));
+  return [m(0), m(1), m(2)];
+}
+
+/** `globalCompositeOperation = "lighter"` at `alpha` — additive, clamped. */
+export function plus(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.min(255, Math.round(src[i] * alpha + dst[i]));
+  return [m(0), m(1), m(2)];
+}
+
+// ------------------------------------------------------------------- the poles
+
+/**
+ * The two colours an ink or a halo is ever drawn in.
+ *
+ * Warm rather than pure black and white: the observatory is lamplit brass, and a
+ * `#ffffff` glyph on it reads as a browser rather than as an instrument. Both are
+ * pushed far enough into their corners to leave the letterform bar room —
+ * `INK_LIGHT` is luminance 0.927, `INK_DARK` is 0.0026, and between them they
+ * measure 18.56:1, four times the bar.
+ */
+export const INK_LIGHT = "#fff6e2";
+export const INK_DARK = "#0d0801";
+
+/**
+ * Which pole an ink should be, for an object whose dominant ground is `ground`.
+ *
+ * Counted, not chosen: whichever pole clears the letterform bar against more of
+ * the ground wins, ties going to light. `ground` is deliberately the object's own
+ * gradient and not the exhaustive surface catalogue — a thin collar arc and a
+ * knurl mark are ground under a few percent of the glyph and would otherwise get
+ * an equal vote with the body of the brass and swing the answer.
+ *
+ * On brass this returns "light" (six of the ten body and top-face stops are dark
+ * enough for a pale glyph, four are not). On the copper balloon it returns
+ * "dark", which is what the art already did by hand. The point is not that every
+ * answer changes; it is that no answer is asserted by hand any more.
+ */
+export function inkPole(ground: readonly RGB[]): "light" | "dark" {
+  const light = rgb(INK_LIGHT);
+  const dark = rgb(INK_DARK);
+  let nl = 0;
+  let nd = 0;
+  for (const s of ground) {
+    if (contrast(light, s) >= MIN_LETTERFORM) nl++;
+    if (contrast(dark, s) >= MIN_LETTERFORM) nd++;
+  }
+  return nl >= nd ? "light" : "dark";
+}
+
+/** The ink for an object with this dominant ground, when no colour carries meaning. */
+export function inkFor(ground: readonly RGB[]): string {
+  return inkPole(ground) === "light" ? INK_LIGHT : INK_DARK;
+}
+
+/**
+ * The halo for an ink: the opposite pole.
+ *
+ * Not a free choice — a mid-grey halo would satisfy "opposite" while failing the
+ * letterform bar. Splitting on 0.18 puts every ink this pack uses (`#ffd07a` at
+ * 0.678, `#5fae95` at 0.349, `#cfe3ea` at 0.741, `INK_LIGHT` at 0.927,
+ * `INK_DARK` at 0.003) on the side that clears the other pole.
+ */
+export function haloFor(ink: string): string {
+  return luma(rgb(ink)) > 0.18 ? INK_DARK : INK_LIGHT;
+}
+
+/**
+ * The worst object-contrast this ink/halo pair presents over `surfaces`.
+ *
+ * Per surface, the better of the two edges — the ink's own contrast, or the
+ * halo's — because an inked blob is visible if *either* the glyph or the ring
+ * around it separates from the ground. The minimum over every surface is the
+ * number `MIN_OBJECT` is asserted against.
+ */
+export function worstEdge(ink: string, halo: string, surfaces: readonly RGB[]): number {
+  const i = rgb(ink);
+  const h = rgb(halo);
+  let worst = Infinity;
+  for (const s of surfaces) worst = Math.min(worst, Math.max(contrast(i, s), contrast(h, s)));
+  return worst;
+}
+
+/**
+ * The best contrast ANY single opaque ink could achieve against all of
+ * `surfaces` — the ceiling the shipped `fillText` was working under.
+ *
+ * Contrast depends on the ink only through its luminance, so scanning the 256
+ * greys bounds every colour: no hue can beat the grey of the same luminance.
+ */
+export function bestSingleInk(surfaces: readonly RGB[]): number {
+  let best = 0;
+  for (let v = 0; v <= 255; v++) {
+    const ink: RGB = [v, v, v];
+    let worst = Infinity;
+    for (const s of surfaces) worst = Math.min(worst, contrast(ink, s));
+    best = Math.max(best, worst);
+  }
+  return best;
+}
+
+// ------------------------------------------------------- the surfaces themselves
+
+/**
+ * The brass body of a weight, as gradient stops.
+ *
+ * `draw.ts` builds its `wbody` gradient from this array rather than from six
+ * literals of its own, so the catalogue the legibility test measures and the
+ * gradient the canvas paints cannot drift apart. That was the failure mode worth
+ * designing against: a colour list living in a test file is a snapshot, and a
+ * snapshot goes stale the first time somebody warms up the brass.
+ */
+/**
+ * The brass itself, and the copper of a balloon.
+ *
+ * These live here and `draw.ts` reads them into its `C` palette, rather than the
+ * other way round, because the numeral's contrast is a claim about them. When
+ * they were literals in two places the disc could be warmed up without the
+ * column it stands on following, and — worse — without a single number in the
+ * legibility table changing.
+ */
+export const BRASS_LO = "#6a4f1d";
+export const BRASS_MID = "#b08a3c";
+export const BRASS_HI = "#f7e6b4";
+export const COPPER = "#c8763f";
+
+export const BRASS_BODY: ReadonlyArray<readonly [number, string]> = [
+  [0, "#2b1e07"],
+  [0.14, BRASS_LO],
+  [0.34, BRASS_HI],
+  [0.52, BRASS_MID],
+  [0.8, "#7a5a1e"],
+  [1, "#201604"],
+];
+
+/** The machined top face of a weight. A tall single digit reaches up into it. */
+export const BRASS_TOP: ReadonlyArray<readonly [number, string]> = [
+  [0, "#8a6a26"],
+  [0.4, "#e9d197"],
+  [0.62, BRASS_HI],
+  [1, "#7c5d1f"],
+];
+
+/** The foil balloon a "how many of these" board floats. */
+export const BALLOON_BODY: ReadonlyArray<readonly [number, string]> = [
+  [0, "#ffe6c8"],
+  [0.28, "#e79a5c"],
+  [0.72, COPPER],
+  [1, "#612f12"],
+];
+
+const stops = (g: ReadonlyArray<readonly [number, string]>): RGB[] => g.map(([, c]) => rgb(c));
+
+/** The dominant ground under a numeral on a weight: the brass itself. */
+export function weightGround(): RGB[] {
+  return [...stops(BRASS_BODY), ...stops(BRASS_TOP)];
+}
+
+/**
+ * EVERY surface a numeral on a weight can land on.
+ *
+ * The brass, plus the two overlays drawn between the body and the numeral, which
+ * therefore change the ground under it:
+ *
+ *   - the knurl marks, `rgba(50,34,8,0.28)`, whose band the numeral's ascenders
+ *     reach into;
+ *   - the bright collar a player-placed weight wears, `rgba(255,240,206,0.5)`,
+ *     which crosses the numeral's descender band on every weight the child put
+ *     there — that is, on most of them, for most of the turn;
+ *   - the two rings around the machined top face, `rgba(255,244,214,0.6)` and
+ *     `rgba(60,42,10,0.4)`. The lower arc of that ellipse crosses `y = -0.17r`
+ *     at the disc's centre line, and a solo digit reaches `y ≈ -0.34r` before
+ *     its halo, so it is genuinely underneath the glyph rather than above it.
+ *
+ * The drag and hover glow is deliberately absent, and that is a checked absence
+ * rather than an assumed one: it is painted *before* the body and the body is
+ * opaque, so it never reaches the numeral's ground.
+ */
+export function weightSurfaces(): RGB[] {
+  const base = weightGround();
+  const knurl = rgb("#322208");
+  const collar = rgb("#fff0ce");
+  const faceRim = rgb("#fff4d6");
+  const innerRing = rgb("#3c2a0a");
+  return [
+    ...base,
+    ...base.map((s) => over(knurl, s, 0.28)),
+    ...base.map((s) => over(collar, s, 0.5)),
+    ...base.map((s) => over(faceRim, s, 0.6)),
+    ...base.map((s) => over(innerRing, s, 0.4)),
+  ];
+}
+
+/** The dominant ground under a numeral on a balloon. */
+export function balloonGround(): RGB[] {
+  return stops(BALLOON_BODY);
+}
+
+/** Every surface on a balloon: the body, plus the additive foil highlight whose
+ * ellipse overlaps the numeral's upper half. */
+export function balloonSurfaces(): RGB[] {
+  const base = balloonGround();
+  const foil = rgb("#fff0dc");
+  return [...base, ...base.map((s) => plus(foil, s, 0.25))];
+}
+
+/**
+ * What a crate window is showing — **four states, not three.**
+ *
+ * `Renderer.crate` switches on two independent flags and they do not line up:
+ * the window's base colour is keyed on `v.declared` alone, while the mist is
+ * keyed on `!v.declared || v.wrong > 0` and the ink on `v.wrong > 0` first. A
+ * three-state model collapses the fourth combination — **rejected, with the
+ * value already cleared** — onto the wrong base, and it is reachable: a child
+ * who presses Backspace inside the ~0.6s rejection window leaves `wrong > 0`
+ * with `declared === null`, so the cold label is read over mist on `#0f1a20`
+ * rather than mist on `#2c2412`. That is the darkest ground any crate label
+ * lands on, and modelling it as the lighter one hid a genuine 2.82:1.
+ */
+export type CrateState = "unknown" | "declared" | "rejected" | "rejectedEmpty";
+
+/** The mist drifting in an unresolved crate window: four ellipses, stacked. */
+function mistOver(base: RGB): RGB[] {
+  const mist = rgb("#78aabe");
+  const out: RGB[] = [base];
+  let c = base;
+  for (let i = 0; i < 4; i++) {
+    c = over(mist, c, 0.1 + i * 0.03);
+    out.push(c);
+  }
+  return out;
+}
+
+/**
+ * The dominant ground under a crate's label: the window it is read through.
+ *
+ * Built the way `Renderer.crate` builds it — base from `declared`, mist or
+ * win-glow from `!declared || wrong` — rather than from a state name, so the two
+ * cannot drift into disagreeing about which of the four combinations is which.
+ */
+export function crateGround(state: CrateState): RGB[] {
+  const declared = state === "declared" || state === "rejected";
+  const base = rgb(declared ? "#2c2412" : "#0f1a20");
+  if (declared && state === "declared") {
+    // the warm win-glow, additive, brightest dead centre — where the numeral is
+    return [base, plus(rgb("#ffd68c"), base, 0.5)];
+  }
+  return mistOver(base);
+}
+
+/**
+ * Every surface a crate's label can land on.
+ *
+ * The label is laid out from `wr * 1.45` where `wr` is the window radius, so it
+ * is deliberately wider than the window: it crosses the glass rim and runs out
+ * onto the iron shell, the brass banding and the rivets. It also passes under
+ * the specular arc struck across the glass — `rgba(255,255,255,0.25)` in
+ * `lighter`, at `0.82wr` — which is additive and therefore the brightest thing
+ * inside the window. All of that is ground under the numeral, so all of it is
+ * here.
+ */
+export function crateSurfaces(state: CrateState): RGB[] {
+  const iron = [rgb("#2b333d"), rgb("#161b22"), rgb("#0d1116")];
+  const band = iron.map((s) => over(rgb("#c69e54"), s, 0.75));
+  const rivet = [rgb("#d8b877")];
+  const window = crateGround(state);
+  const specular = window.map((s) => plus(rgb("#ffffff"), s, 0.25));
+  const rim = [...window, ...iron].map((s) => over(rgb("#d6b268"), s, 0.9));
+  return [...window, ...specular, ...iron, ...band, ...rivet, ...rim];
+}

--- a/dynawalla/games/balance/src/layout.ts
+++ b/dynawalla/games/balance/src/layout.ts
@@ -50,7 +50,8 @@ export const MAX_PEG = 5;
  * real thing:
  *
  *   - `NUMERAL_MIN_PX` — the floor a numeral may be shrunk to. 15px, which is
- *     the floor a repo-wide audit set for an answer a child has to read.
+ *     the floor a repo-wide audit set for an answer a child has to read, and
+ *     which is load-bearing for the character budget — see below.
  *   - `NUMERAL_ADVANCE_EM` — how wide one digit is in the game's serif stack.
  *     Lining figures in Palatino, Georgia and Times all advance 0.50em; 0.58 is
  *     deliberately above every one of them, because over-estimating costs a
@@ -65,21 +66,98 @@ export const MAX_PEG = 5;
  * second to the adapter, which refuses a question whose numerals still would not
  * fit. Neither guesses.
  */
+/**
+ * The floor a numeral may be shrunk to. **Still 15, and that is a finding.**
+ *
+ * The founder's second reading of this pack was *"they are a bit small"*, and
+ * this looks like the number to raise. It is not, and the reason is worth
+ * writing down so the next person does not spend the afternoon rediscovering it.
+ *
+ * Raising this floor is not free. `charsAtRadius` divides by it, so every pixel
+ * costs the disc characters of budget; `numeralCapacity` hands that budget to the
+ * adapter; and the adapter **refuses** a board whose numerals no longer fit. A
+ * raised floor does not draw a board smaller, it deletes the board.
+ *
+ * Measured, at rack 9 — which is the rack size `game.ts` passes to
+ * `numeralCapacity` — over every viewport from 280×280 to 1600×1600, counting the
+ * ones that could show a six-character board (the widest the shipping ladder
+ * serves) and then could not:
+ *
+ *   | floor | viewports that stop serving six characters | band                        |
+ *   |-------|--------------------------------------------|-----------------------------|
+ *   | 15px  | — (the baseline)                            | —                           |
+ *   | 16px  |  3,080                                      | w 280–354, h 715–761        |
+ *   | 17px  |  7,073                                      | w 280–376, h 715–807        |
+ *   | 18px  | 12,057                                      | w 280–399, h 715–853        |
+ *
+ * They are not all obscure. At 17px the band has grown far enough to swallow
+ * **360×800 — Pixel-class Android, one of the most common viewports in the
+ * world**, which drops from six characters to five, taking 360×780 with it. At
+ * 18px it reaches 390×844 and 393×873. Sixteen keeps every named device but
+ * still costs three thousand viewports, and buys one pixel.
+ *
+ * So the floor holds at 15 and the numerals get bigger a different way: through
+ * `NUMERAL_EM` below, which `charsAtRadius` does not read and which therefore
+ * costs no board anywhere. `legibility.test.ts` pins 360×800 at exactly six
+ * characters so that a future raise of this constant fails loudly instead of
+ * quietly emptying a phone's question pool.
+ */
 export const NUMERAL_MIN_PX = 15;
 export const NUMERAL_ADVANCE_EM = 0.58;
 export const NUMERAL_FACE = 1.7;
 
 /**
- * The type size an engraved numeral starts at, before it is fitted.
+ * How much of the disc's radius a numeral's type size is, before fitting.
  *
- * `r * 0.78` for two characters or more and `r * 1.02` for one, which is what the
- * renderer always used — with the legibility floor now under it. That floor
- * matters at the small end and was being missed there: `weightR` clamps to 17 on
- * a narrow screen, and `17 × 0.78` is 13.3px, so a plain two-digit answer was
- * drawn under the 15px floor before any question of width came up.
+ * `0.78` for two characters or more and `1.02` for one is what shipped, and the
+ * 0.78 is the one the founder was looking at: a two-digit answer on a 320×568
+ * phone came out at **16.1px**, and on the 390×844 phone at 19.6px. There was no
+ * reason for a two-digit numeral to be a quarter smaller than a one-digit one —
+ * `fittedNumeralPx` already shrinks anything that does not fit, so the ideal size
+ * is free to be generous and let the fitter take it back.
+ *
+ * `0.98` and `1.14` are what the face can actually carry. Two characters at
+ * `0.98r` lay `2 × 0.58 × 0.98r = 1.14r` of ink inside a `1.7r` face, so they are
+ * never fitted down at all; three characters land at `1.71r`, a hair over, and
+ * come back essentially unchanged. Nothing is clipped and nothing overflows,
+ * because the fitter is still underneath — this only raises where it starts.
+ *
+ * Measured effect on a plain two-digit weight: 16.1px → **20.2px** at 320×568,
+ * 19.6px → 24.7px at 390×844, 22.5px in phone landscape, 26.5px → 33.3px on a
+ * tablet.
+ *
+ * **This is the knob that was safe to turn.** `charsAtRadius` and
+ * `radiusForChars` do not read it, so the disc's character budget, the layout it
+ * produces and every refusal the adapter makes are bit-for-bit what they were —
+ * unlike `NUMERAL_MIN_PX` above, where the same size gain would have cost a
+ * 360×800 phone its six-character boards.
  */
+export const NUMERAL_EM = 0.98;
+export const NUMERAL_EM_SOLO = 1.14;
+
+/** The type size an engraved numeral starts at, before it is fitted. */
 export function idealNumeralPx(r: number, chars: number): number {
-  return Math.max(NUMERAL_MIN_PX, r * (chars >= 2 ? 0.78 : 1.02));
+  return Math.max(NUMERAL_MIN_PX, r * (chars >= 2 ? NUMERAL_EM : NUMERAL_EM_SOLO));
+}
+
+/**
+ * The type size of ONE ROW of a stacked fraction — `1/2` engraved on a disc.
+ *
+ * Its own knob, because two rows and a bar have to share the height one row had,
+ * so it cannot simply be `NUMERAL_EM`. It shipped at a flat `r * 0.5`, which put
+ * a `1/2` weight at **10.3px** on a 320×568 phone while a `12` weight on the same
+ * disc got 16.1px — so the founder's "a bit small" was worse on the fractions
+ * than on the integers he happened to be looking at, and the size pass would have
+ * widened that gap rather than closed it.
+ *
+ * `0.58r` is what the belly of the disc carries with a halo on both rows,
+ * measured at every viewport. The floor is `NUMERAL_MIN_PX * 0.8` and is
+ * load-bearing rather than decorative: `haloWidth`'s 2px minimum is a larger
+ * FRACTION of a smaller glyph, and under 12px the halo begins closing the
+ * counters of 0, 6, 8 and 9. `legibility.test.ts` holds both ends.
+ */
+export function stackedNumeralPx(r: number): number {
+  return Math.max(NUMERAL_MIN_PX * 0.8, r * 0.58);
 }
 
 /**

--- a/dynawalla/games/balance/src/legibility.test.ts
+++ b/dynawalla/games/balance/src/legibility.test.ts
@@ -1,0 +1,556 @@
+// CAN THE CHILD READ THE NUMBER?
+//
+// The founder played COUNTERPOISE and said the numerals on the weights "are a
+// bit small and not enough contrast for me." Two defects, and a bigger numeral
+// in an invisible colour is still an invisible numeral, so this file gates them
+// separately: sizes come off `layoutForViewport`, which is the entry point
+// `Game.resize` really calls, and contrasts come off the ink constants and the
+// surface catalogue `draw.ts` really paints from.
+//
+// Everything here is measured. "Improved contrast" is not a claim this file can
+// make; every assertion below is a number against a named bar.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MIN_LETTERFORM,
+  MIN_OBJECT,
+  balloonGround,
+  balloonSurfaces,
+  bestSingleInk,
+  contrast,
+  crateGround,
+  crateSurfaces,
+  haloFor,
+  inkPole,
+  luma,
+  over,
+  plus,
+  rgb,
+  weightGround,
+  weightSurfaces,
+  type CrateState,
+  type RGB,
+} from "./ink.ts";
+import { INK_DARK, INK_LIGHT } from "./ink.ts";
+import {
+  BALLOON_INK,
+  WEIGHT_INK,
+  crateInk,
+  crateState,
+  engrave,
+  haloWidth,
+} from "./draw.ts";
+import {
+  NUMERAL_ADVANCE_EM,
+  NUMERAL_FACE,
+  NUMERAL_MIN_PX,
+  charsAtRadius,
+  fittedNumeralPx,
+  idealNumeralPx,
+  layoutForViewport,
+  numeralCapacity,
+  stackedNumeralPx,
+} from "./layout.ts";
+
+/** The viewports `layout.test.ts` gates the frame on. Same six, same order. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+  ["laptop", 1440, 900],
+];
+
+/**
+ * Every numeral this pack draws, as the renderer's own constants and functions
+ * report them — not as this file remembers them. `WEIGHT_INK` and `BALLOON_INK`
+ * are the values `Renderer.weight` and `Renderer.balloon` pass to `numeral`, and
+ * `crateInk` is the function `Renderer.crate` calls. A table of colour literals
+ * copied into a test would keep passing after the renderer stopped using them.
+ */
+const ENGRAVED: Array<{
+  name: string;
+  ink: string;
+  ground: () => RGB[];
+  surfaces: () => RGB[];
+}> = [
+  {
+    name: "weight — on the rack, in a dish, hung from a peg, or dragged",
+    ink: WEIGHT_INK,
+    ground: weightGround,
+    surfaces: weightSurfaces,
+  },
+  {
+    name: "balloon",
+    ink: BALLOON_INK,
+    ground: balloonGround,
+    surfaces: balloonSurfaces,
+  },
+  ...(["unknown", "declared", "rejected", "rejectedEmpty"] as CrateState[]).map((state) => ({
+    name: `crate — ${state}`,
+    ink: crateInk(state),
+    ground: () => crateGround(state),
+    surfaces: () => crateSurfaces(state),
+  })),
+];
+
+// ------------------------------------------------------------------- CONTRAST
+
+test("no single ink can read against these surfaces — the halo is not a preference", () => {
+  // The load-bearing fact under the whole design. A brass disc's own gradient
+  // runs from `#201604` to `#f7e6b4`; an ink clearing 4.5:1 against the light end
+  // needs luminance <= 0.138 and against the dark end needs >= 0.215, so no
+  // colour clears both and `fillText` alone cannot be fixed by recolouring it.
+  //
+  // Asserted as a hard ceiling rather than "the old colour was bad", because the
+  // weaker statement is true of one colour and this one is true of all 16 million.
+  for (const { name, surfaces } of ENGRAVED) {
+    const ceiling = bestSingleInk(surfaces());
+    assert.ok(
+      ceiling < 2,
+      `${name}: some single ink reaches ${ceiling.toFixed(2)}:1 — a lone fillText would do`,
+    );
+  }
+});
+
+test("what shipped did not clear even the non-text bar, anywhere", () => {
+  // The defect, stated as a measurement so it cannot come back quietly. These are
+  // the three colours COUNTERPOISE shipped with, each against the surfaces it was
+  // really drawn on and with no halo behind it, which is how it was drawn.
+  const shipped: Array<[string, string, RGB[]]> = [
+    ["the brass weight", "#ffeec4", weightSurfaces()],
+    ["the balloon", "#3a1a08", balloonSurfaces()],
+    ["the crate window", "#5fae95", crateSurfaces("rejected")],
+  ];
+  for (const [name, ink, surfaces] of shipped) {
+    let worst = Infinity;
+    for (const s of surfaces) worst = Math.min(worst, contrast(rgb(ink), s));
+    assert.ok(
+      worst < MIN_OBJECT,
+      `${name}: ${ink} alone already measured ${worst.toFixed(2)}:1 — this test is asserting nothing`,
+    );
+  }
+});
+
+test("every numeral clears the letterform bar against the halo that rings it", () => {
+  for (const { name, ink } of ENGRAVED) {
+    const halo = haloFor(ink);
+    const c = contrast(rgb(ink), rgb(halo));
+    assert.ok(
+      c >= MIN_LETTERFORM,
+      `${name}: ${ink} on its own halo ${halo} is ${c.toFixed(2)}:1, under ${String(MIN_LETTERFORM)}:1`,
+    );
+  }
+});
+
+test("every numeral clears the object bar on every surface it can land on", () => {
+  // Per surface, the better of the two edges the glyph presents: its own ink, or
+  // the opaque ring around it. One of them has to separate from the ground or
+  // the digit is a smudge. `MIN_OBJECT` is 3.0 and not 4.5 for a reason stated in
+  // full in `ink.ts`: 4.5 against an ARBITRARY ground is impossible for any two
+  // colours — the crossover is at ground luminance 0.179 and the best achievable
+  // there is 4.58:1 with pure black on pure white. The bar is the one that can
+  // actually be kept, and the letterform bar above is the strict one.
+  for (const { name, ink, surfaces } of ENGRAVED) {
+    const halo = rgb(haloFor(ink));
+    const i = rgb(ink);
+    for (const s of surfaces()) {
+      const best = Math.max(contrast(i, s), contrast(halo, s));
+      assert.ok(
+        best >= MIN_OBJECT,
+        `${name}: ${ink}/${haloFor(ink)} on #${s.map((v) => v.toString(16).padStart(2, "0")).join("")} ` +
+          `is ${best.toFixed(2)}:1, under ${String(MIN_OBJECT)}:1`,
+      );
+    }
+  }
+});
+
+test("the catalogue contains the overlays, not just the gradients", () => {
+  // The bars above are only as honest as the list of surfaces they are minimised
+  // over, and the surfaces that actually broke were never gradient stops: they
+  // were things painted ON TOP of the body and UNDER the numeral. Two of them
+  // were missed on the first pass and each was hiding a **1.00:1** — literally
+  // the numeral and its ground being the same colour, which is the exact shape
+  // of the bug VOLTA was fixed for.
+  //
+  // So each one is asserted present by construction, from the same blend the
+  // canvas uses. A catalogue that quietly stopped listing an overlay would leave
+  // every contrast number in this file true and the screen unreadable.
+  const has = (list: RGB[], c: RGB, what: string): void => {
+    assert.ok(
+      list.some((s) => s[0] === c[0] && s[1] === c[1] && s[2] === c[2]),
+      `${what} — #${c.map((v) => v.toString(16).padStart(2, "0")).join("")} is not in the catalogue`,
+    );
+  };
+  const weight = weightSurfaces();
+  // draw.ts: the bright collar on a player-placed weight, over the specular streak
+  has(weight, over(rgb("#fff0ce"), rgb("#f7e6b4"), 0.5), "the collar");
+  // draw.ts: the rim struck around the machined top face, whose lower arc crosses
+  // the glyph box of every numeral on the disc
+  has(weight, over(rgb("#fff4d6"), rgb("#f7e6b4"), 0.6), "the top-face rim");
+  // draw.ts: the knurl marks, whose band the ascenders reach into
+  has(weight, over(rgb("#322208"), rgb("#201604"), 0.28), "the knurl");
+
+  for (const state of ["unknown", "declared", "rejected", "rejectedEmpty"] as CrateState[]) {
+    const crate = crateSurfaces(state);
+    const window = crateGround(state);
+    // draw.ts: the specular arc across the glass — additive, so it is the
+    // brightest thing inside the window and the numeral runs straight under it
+    for (const w of window) has(crate, plus(rgb("#ffffff"), w, 0.25), `the ${state} specular arc`);
+    // draw.ts: the brass rivets, the brightest thing a spilling label reaches
+    has(crate, rgb("#d8b877"), "a rivet");
+  }
+});
+
+test("the pole is read off the surface, and it disagrees between the objects", () => {
+  // The guarantee this file exists to make is not "these five colours are fine",
+  // it is "the colour is derived". So: the derivation must actually look at what
+  // it is handed. Brass wants a pale glyph and a copper balloon wants a dark one,
+  // and `inkPole` returns those two different answers from the two grounds — a
+  // stub that ignored its argument and returned "light" could not.
+  assert.equal(inkPole(weightGround()), "light", "brass no longer wants a pale numeral");
+  assert.equal(inkPole(balloonGround()), "dark", "a bright copper balloon wants a pale numeral?");
+  assert.equal(WEIGHT_INK !== BALLOON_INK, true, "the brass and the balloon got the same ink");
+  // Every halo is one of the two poles and nothing in between, and BOTH poles
+  // are actually reached across the pack — a `haloFor` that always returned the
+  // dark one would satisfy "is a pole" on four of the five inks and still leave
+  // the balloon's dark numeral ringed in black.
+  const halos = new Set(ENGRAVED.map((e) => haloFor(e.ink)));
+  for (const h of halos) {
+    assert.ok(
+      h === INK_LIGHT || h === INK_DARK,
+      `${h} is not one of the two poles — a mid-grey halo passes "opposite" and fails contrast`,
+    );
+  }
+  assert.deepEqual([...halos].sort(), [INK_DARK, INK_LIGHT].sort(), "only one pole is ever used");
+  assert.equal(haloFor(BALLOON_INK), INK_LIGHT, "the balloon's dark numeral lost its light halo");
+  assert.equal(haloFor(WEIGHT_INK), INK_DARK, "the brass numeral lost its dark halo");
+});
+
+test("the compositing the catalogue does is the compositing canvas does", () => {
+  // `weightSurfaces` and `crateSurfaces` do not list the collar, the knurl, the
+  // mist or the win-glow as colours: they COMPOSITE them, because that is what
+  // the canvas does and a numeral lands on the result, not on the ingredient. If
+  // these two blend modes were wrong the whole table above would be measuring
+  // surfaces that never appear on screen.
+  assert.deepEqual(over([255, 255, 255], [0, 0, 0], 0.5), [128, 128, 128]);
+  assert.deepEqual(over([10, 20, 30], [50, 100, 150], 0), [50, 100, 150]);
+  assert.deepEqual(over([10, 20, 30], [50, 100, 150], 1), [10, 20, 30]);
+  // "lighter" adds and clamps — it does not average, which is the whole reason
+  // the win-glow makes the crate window brighter than either of its parts.
+  assert.deepEqual(plus([100, 100, 100], [40, 40, 40], 0.5), [90, 90, 90]);
+  assert.deepEqual(plus([255, 255, 255], [40, 40, 40], 1), [255, 255, 255]);
+  // Luminance is the sRGB-linearised, green-weighted one, not a channel average:
+  // pure green is far brighter to a reader than pure blue at the same value.
+  assert.ok(luma(rgb("#00ff00")) > 0.7, "green is not being weighted as green");
+  assert.ok(luma(rgb("#0000ff")) < 0.1, "blue is not being weighted as blue");
+  assert.equal(contrast(rgb("#000000"), rgb("#ffffff")).toFixed(0), "21");
+});
+
+test("the crate has four states, and they are the renderer's four", () => {
+  // `crateState` is the predicate `Renderer.crate` runs, exported so this file
+  // drives the same branch order rather than a copy of it.
+  //
+  // Four, not three, and the fourth is the one that hid a defect. The renderer
+  // keys the window's BASE colour on `v.declared` alone but the mist on
+  // `!v.declared || v.wrong > 0`, so "rejected" splits: with a value still in the
+  // window the ground is mist over `#2c2412`, and with the value already cleared
+  // it is mist over `#0f1a20`, which is darker and is the worst ground any crate
+  // label sits on. A three-state model measured the first and shipped the second.
+  //
+  // It is reachable: `wrong` decays over ~0.6s and Backspace is live throughout,
+  // so undoing inside the rejection window leaves `wrong > 0, declared === null`.
+  assert.equal(crateState({ wrong: 0, declared: null }), "unknown", "an untouched crate");
+  assert.equal(
+    crateState({ wrong: 0, declared: { n: 7, d: 1 } }),
+    "declared",
+    "a crate holding an accepted value",
+  );
+  assert.equal(
+    crateState({ wrong: 0.5, declared: { n: 7, d: 1 } }),
+    "rejected",
+    "a rejected value is being drawn as if it had been accepted",
+  );
+  assert.equal(
+    crateState({ wrong: 0.5, declared: null }),
+    "rejectedEmpty",
+    "a rejection whose value was undone is not being told apart from an untouched crate",
+  );
+
+  // A rejection must never be drawn in celebration gold, and must never be
+  // mistaken for the unresolved `x`.
+  assert.equal(crateInk("rejected"), crateInk("rejectedEmpty"), "one rejection, two colours");
+  assert.notEqual(crateInk("rejected"), crateInk("declared"), "wrong and right look alike");
+  assert.notEqual(crateInk("rejected"), crateInk("unknown"), "rejected reads as still-unknown");
+
+  // The two grounds really are different, which is the whole reason the state
+  // split. If `crateGround` collapsed them this would be the assertion that says so.
+  assert.notDeepEqual(
+    crateGround("rejected"),
+    crateGround("rejectedEmpty"),
+    "the two rejection states were modelled as one window",
+  );
+});
+
+// ----------------------------------------------------------------------- HALO
+
+/** A canvas that draws nothing and remembers everything. */
+type Op = { kind: "stroke" | "fill"; text: string; x: number; y: number; style: string; w: number };
+
+function recorder(): { ctx: CanvasRenderingContext2D; ops: Op[] } {
+  const ops: Op[] = [];
+  const stack: Array<Record<string, unknown>> = [];
+  const ctx = {
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    lineJoin: "miter",
+    miterLimit: 10,
+    shadowColor: "",
+    shadowBlur: 0,
+    font: "",
+    strokeText(text: string, x: number, y: number) {
+      ops.push({ kind: "stroke", text, x, y, style: String(ctx.strokeStyle), w: ctx.lineWidth });
+    },
+    fillText(text: string, x: number, y: number) {
+      ops.push({ kind: "fill", text, x, y, style: String(ctx.fillStyle), w: ctx.lineWidth });
+    },
+    save() {
+      stack.push({
+        fillStyle: ctx.fillStyle,
+        strokeStyle: ctx.strokeStyle,
+        lineWidth: ctx.lineWidth,
+      });
+    },
+    restore() {
+      Object.assign(ctx, stack.pop() ?? {});
+    },
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, ops };
+}
+
+test("the halo is laid down behind the ink, in every direction", () => {
+  // The old `engrave` drew one dark copy at `y + 1.4` and then the ink. That is a
+  // drop shadow: it separates the glyph from its ground BELOW the glyph and
+  // nowhere else, and the brass specular streak that made `#ffeec4` unreadable
+  // runs left-to-right. So the ring — a stroke centred on the outline — is the
+  // part of this change that makes the contrast table true, and it has to be
+  // stroked BEFORE the fill or it would eat the stems it is supposed to be
+  // separating.
+  const { ctx, ops } = recorder();
+  engrave(ctx, "42", 10, 20, "#ffffff", false, 24, "#000000");
+
+  assert.deepEqual(
+    ops.map((o) => o.kind),
+    ["stroke", "stroke", "fill"],
+    "the halo is not two strokes laid down before the ink",
+  );
+  assert.equal(ops[0]?.style, "#000000", "the offset pass is not in the halo colour");
+  assert.equal(ops[1]?.style, "#000000", "the ring is not in the halo colour");
+  assert.equal(ops[2]?.style, "#ffffff", "the ink pass is not in the ink colour");
+
+  // The ring is on the glyph's own centre; the shadow is below it. If both
+  // landed on `y` the engraved depth would be gone, and if neither did there
+  // would be no ring at all — only a fatter drop shadow.
+  assert.equal(ops[1]?.y, 20, "the ring is not centred on the glyph");
+  assert.ok((ops[0]?.y ?? 0) > 20, `the shadow pass is at y=${String(ops[0]?.y)}, not below`);
+  assert.equal(ops[2]?.y, 20, "the ink moved off the glyph's own baseline");
+  for (const o of ops) assert.equal(o.text, "42", "a pass drew something other than the numeral");
+
+  // And it is a real ring, not a hairline.
+  assert.ok((ops[1]?.w ?? 0) >= 2, `the ring is ${String(ops[1]?.w)}px wide`);
+});
+
+test("the halo is wide enough to see and narrow enough to leave the counters open", () => {
+  // A stroke is centred, so half of it is outside the glyph and half is inside,
+  // where the fill covers it — except in a counter, the hole in a 0, 6, 8 or 9,
+  // which nothing fills back in. That is the constraint from the other side, and
+  // it is why this is not simply "wider is better".
+  // The list starts at `NUMERAL_MIN_PX * 0.8` and not at `NUMERAL_MIN_PX`,
+  // because the smallest type this renderer really passes to `engrave` is a
+  // stacked fraction's row, which is floored there — and that is exactly where
+  // `haloWidth`'s 2px minimum is the largest fraction of the glyph.
+  for (const px of [NUMERAL_MIN_PX * 0.8, NUMERAL_MIN_PX, 20, 24, 28, 34, 42]) {
+    const w = haloWidth(px);
+    assert.ok(w / 2 >= 1, `at ${String(px)}px the halo shows ${(w / 2).toFixed(2)}px outside`);
+    assert.ok(
+      w / 2 <= px * 0.085,
+      `at ${String(px)}px the halo closes ${(w / 2).toFixed(2)}px into each side of a counter`,
+    );
+  }
+});
+
+// ------------------------------------------------------------------------ SIZE
+
+test("a numeral is legible-sized on the smallest phone, not just on a tablet", () => {
+  // The founder's other word was "small". These are the sizes a plain two-digit
+  // weight is drawn at, measured through `layoutForViewport` — the same entry
+  // point `Game.resize` uses — rather than through hand-picked radii.
+  //
+  // What shipped: 16.1px at 320×568, 19.6px at 390×844, 26.5px on a tablet. The
+  // floors below are under the current numbers with a pixel of slack and over
+  // every one of the shipped ones, so a revert cannot pass this test.
+  const floors: Record<string, number> = {
+    "phone portrait, small": 19.5,
+    "phone portrait, tall": 24,
+    "tablet portrait": 32,
+    "tablet landscape": 32,
+    "phone landscape": 22,
+    laptop: 32,
+  };
+  for (const [name, w, h] of VIEWPORTS) {
+    const L = layoutForViewport(w, h, 9);
+    const two = idealNumeralPx(L.weightR, 2);
+    const one = idealNumeralPx(L.weightR, 1);
+    const floor = floors[name] ?? 0;
+    assert.ok(
+      two >= floor,
+      `${name}: a two-digit weight is ${two.toFixed(1)}px, under the ${String(floor)}px this viewport must clear`,
+    );
+    // A second digit must not cost a quarter of the type size. The old ratio was
+    // 1.02 against 0.78 — a 31% penalty — which is the specific thing that made
+    // "12" harder to read than "9" on the same disc. `one >= two` is the ordering
+    // (a solo digit may be taller, having no neighbour); `one <= two * 1.25` is
+    // the assertion that fails on a revert, since 1.02/0.78 is 1.31.
+    assert.ok(
+      one >= two,
+      `${name}: one digit (${one.toFixed(1)}px) is smaller than two (${two.toFixed(1)}px)`,
+    );
+    assert.ok(one <= two * 1.25, `${name}: a solo digit is ${(one / two).toFixed(2)}× a pair`);
+  }
+});
+
+test("the bigger numeral still fits its disc at the widest the ladder serves", () => {
+  // Growing the type is only a fix if nothing overflows. Six characters is the
+  // widest numeral the shipping ladder produces (`unstuck.test.ts` establishes
+  // that from the ladder end); this asserts it from the pixel end, at the real
+  // layout each viewport hands back for a six-character board, using the widest
+  // digit advance in the game's serif stack.
+  for (const [name, w, h] of VIEWPORTS) {
+    for (let chars = 1; chars <= 6; chars++) {
+      const L = layoutForViewport(w, h, 9, chars);
+      const face = L.weightR * NUMERAL_FACE;
+      const ideal = idealNumeralPx(L.weightR, chars);
+      const drawn = fittedNumeralPx(ideal, ideal * NUMERAL_ADVANCE_EM * chars, face);
+      assert.ok(
+        drawn * NUMERAL_ADVANCE_EM * chars <= face + 0.001,
+        `${name}: ${String(chars)} characters lay ${(drawn * NUMERAL_ADVANCE_EM * chars).toFixed(1)}px of ink in a ${face.toFixed(1)}px face`,
+      );
+      // The halo is stroked OUTSIDE the ink, and `fittedNumeralPx` never sees it
+      // — it fits the ink to `NUMERAL_FACE`, which is what the character budget
+      // is priced in and must stay that way. So the real no-overrun guarantee is
+      // this one: ink plus halo stays inside the brass, which is `2r` wide at the
+      // numeral's own row and not the `1.7r` nominal face.
+      const withHalo = drawn * NUMERAL_ADVANCE_EM * chars + haloWidth(drawn);
+      assert.ok(
+        withHalo <= L.weightR * 2 * 0.98,
+        `${name}: ${String(chars)} characters plus halo are ${withHalo.toFixed(1)}px on a ${(L.weightR * 2).toFixed(1)}px disc`,
+      );
+      assert.ok(
+        charsAtRadius(L.weightR) >= chars,
+        `${name}: a ${String(chars)}-character board got a disc that holds ${String(charsAtRadius(L.weightR))}`,
+      );
+    }
+  }
+});
+
+test("a stacked fraction is a numeral too, and it was the smallest thing here", () => {
+  // The size pass nearly shipped having made this WORSE. `Renderer.numeral` sends
+  // a `1/2` weight down a different branch that never touches `idealNumeralPx`,
+  // so raising `NUMERAL_EM` widened the gap between an integer weight and a
+  // fraction on the identical disc instead of closing it. Fractions are real
+  // boards: the adapter serves quarters, thirds and halves.
+  for (const [name, w, h] of VIEWPORTS) {
+    const L = layoutForViewport(w, h, 9);
+    const row = stackedNumeralPx(L.weightR);
+    const whole = idealNumeralPx(L.weightR, 2);
+
+    // It shipped at a flat `r * 0.5`. Asserting against that ratio rather than
+    // against a pixel count is what makes this fail on a revert at EVERY size.
+    assert.ok(
+      row > L.weightR * 0.5 + 0.5,
+      `${name}: a fraction row is ${row.toFixed(1)}px on an r=${L.weightR.toFixed(1)} disc — still r/2`,
+    );
+    // And it must not have drifted so far that a fraction outgrows an integer.
+    assert.ok(
+      row < whole,
+      `${name}: a fraction row (${row.toFixed(1)}px) is bigger than a whole numeral (${whole.toFixed(1)}px)`,
+    );
+    // The floor that keeps `haloWidth`'s 2px minimum from closing the counters.
+    assert.ok(
+      row >= NUMERAL_MIN_PX * 0.8,
+      `${name}: a fraction row is ${row.toFixed(1)}px, under the halo's counter floor`,
+    );
+
+    // Two rows, a bar and two halos, inside the brass. `numeral` stacks them at
+    // -0.58 and +0.60 of the row size around a centre `r * 0.09` below the
+    // numeral's own y; the disc's belly reaches `0.78r` below centre and its flat
+    // top is at `-0.51r`. This is the assertion that caught the descender poking
+    // through the bottom of the brass when the rows were first made bigger.
+    const centre = L.weightR * 1.02 * 0.06 + L.weightR * 0.09;
+    const lowest = centre + row * 0.6 + row * 0.35 + haloWidth(row) / 2;
+    assert.ok(
+      lowest <= L.weightR * 0.78,
+      `${name}: the denominator reaches ${lowest.toFixed(1)}px, past the brass at ${(L.weightR * 0.78).toFixed(1)}px`,
+    );
+    const highest = centre - row * 0.58 - row * 0.35 - haloWidth(row) / 2;
+    assert.ok(
+      highest >= -L.weightR * 0.51,
+      `${name}: the numerator reaches ${highest.toFixed(1)}px, above the brass at ${(-L.weightR * 0.51).toFixed(1)}px`,
+    );
+  }
+});
+
+test("making the numerals bigger did not make any board unshowable", () => {
+  // The trap this change walked into and backed out of, nailed down.
+  //
+  // The obvious way to make a numeral bigger is to raise `NUMERAL_MIN_PX`. But
+  // `charsAtRadius` DIVIDES by that floor, `numeralCapacity` reports the result
+  // to the adapter, and the adapter refuses any board it cannot draw. Measured at
+  // rack 9 — the rack size `game.ts` really passes — over every viewport from
+  // 280×280 to 1600×1600: a 16px floor stops 3,080 viewports from being able to
+  // show a six-character board, a 17px floor stops 7,073, an 18px floor 12,057.
+  //
+  // **360×800 is one of them.** Pixel-class Android, one of the most common
+  // viewports in the world, drops from six characters to five at a 17px floor —
+  // and six is the widest numeral the shipping ladder serves. 390×844 goes at
+  // 18px. So the size came from `NUMERAL_EM` instead, which the budget
+  // arithmetic does not read and which therefore costs no board anywhere.
+  //
+  // Pinned as an equality at 360×800 because that viewport's margin is exactly
+  // zero, so `>= 6` there would still pass at a floor of 16.9. Anyone raising the
+  // floor has to come back through this test.
+  assert.equal(
+    numeralCapacity(360, 800, 9),
+    6,
+    "a 360×800 Android can no longer show the widest board the ladder serves",
+  );
+  assert.equal(numeralCapacity(360, 780, 9), 6, "360×780 lost the ladder's widest board");
+
+  // Every viewport the frame is gated on, plus the real device sizes either side
+  // of that narrow-and-tall band where the disc-growth walk is at its tightest.
+  const devices: Array<[string, number, number]> = [
+    ...VIEWPORTS,
+    ["Pixel-class Android", 360, 800],
+    ["Galaxy-class Android", 384, 854],
+    ["iPhone 12/13 mini", 375, 812],
+    ["iPhone 15 Pro", 393, 873],
+    ["iPhone 14 Plus", 428, 926],
+  ];
+  for (const [name, w, h] of devices) {
+    const cap = numeralCapacity(w, h, 9);
+    assert.ok(
+      cap >= 6,
+      `${name} (${String(w)}×${String(h)}) reports room for only ${String(cap)} characters, ` +
+        `and the ladder serves six`,
+    );
+  }
+
+  // Last, so the failures above speak first: they say WHICH phone lost WHICH
+  // board, which is the thing worth knowing. This one only says that the knob
+  // moved.
+  assert.equal(NUMERAL_MIN_PX, 15, "the character budget was re-priced without re-measuring it");
+});


### PR DESCRIPTION
> "counterpoise is decent but the numbers on the weights need to be a bit more legible ... they are a bit small and not enough contrast for me."

Two defects, fixed separately, because a bigger numeral in an invisible colour is still an invisible numeral.

## Contrast — measured, before and after

Every surface a numeral can land on, per disc state: the gradients **and** the overlays painted between the object body and the glyph. `BEFORE worst` is the shipped single-colour `fillText` against the worst of them.

| disc / state | surfaces | BEFORE ink | BEFORE worst (on) | pole (derived) | AFTER ink | halo | letterform (ink:halo) | AFTER worst object edge | ceiling for ANY single ink |
|---|---|---|---|---|---|---|---|---|---|
| weight — rack / dish / hung / dragged | 50 | `#ffeec4` | **1.00:1** on `#fceec8` | light | `#fff6e2` | `#0d0801` | **18.56:1** | **4.48:1** | 1.24:1 |
| balloon | 8 | `#3a1a08` | **1.45:1** on `#612f12` | dark | `#0d0801` | `#fff6e2` | **18.56:1** | **4.48:1** | 1.92:1 |
| crate — unknown (`x`) | 25 | `#cfe3ea` | **1.43:1** on `#d8b877` | light | `#cfe3ea` | `#0d0801` | **15.04:1** | **4.34:1** | 1.90:1 |
| crate — declared, correct | 16 | `#ffd07a` | **1.04:1** on `#eccf98` | light | `#ffd07a` | `#0d0801` | **13.83:1** | **4.06:1** | 1.51:1 |
| crate — rejected | 25 | `#5fae95` | **1.00:1** on `#90a3a2` | light | `#7fccb3` | `#0d0801` | **10.63:1** | **3.39:1** | 1.90:1 |
| crate — rejected, value undone | 25 | `#5fae95` | **1.08:1** on `#c2a260` | light | `#7fccb3` | `#0d0801` | **10.63:1** | **3.47:1** | 1.90:1 |

Two of those are **1.00:1** — the numeral and its ground the same colour, on the collar of every weight a child has placed and under the specular arc of a rejected crate. Neither was a gradient stop; both were overlays, and both were invisible until the catalogue listed them.

**Recolouring cannot fix this, and it is proved rather than asserted.** `bestSingleInk` scans the whole grey ramp: the best contrast *any* opaque ink can reach against a weight is **1.24:1**. So a numeral is now an ink plus an opaque counter-ink halo, and both are derived — `inkPole` reads the object's own gradient and returns `light` for brass and `dark` for the copper balloon, which is what the art already did by hand for one of them and got wrong for the rest.

Two bars, because the eye has two jobs:
- **Letterform**, ink against the halo that rings it — **4.5:1**, WCAG AA body text. Held at the body-text number rather than the 3:1 large-text allowance because the reader is a child.
- **Object**, the inked blob against its ground — **3.0:1**, WCAG 1.4.11 non-text contrast.

The second is 3.0 and not 4.5 for a stated reason: **4.5 against an arbitrary ground is impossible for any two-colour scheme.** Solving `(1.05)/(L+0.05) = (L+0.05)/(0.05)` puts the crossover at ground luminance 0.179 and the best achievable there at **4.58:1 — with pure `#000` on pure `#fff`.** Claiming 4.5 against every raw surface would be a claim no implementation could keep. This is written into `ink.ts`, not buried here.

`draw.ts` now builds its `wbody`/`wtop`/`balloon` gradients from the same arrays the test measures, and its `C` palette reads the shared brass constants, so the surface a test believes in and the surface the canvas paints are one object.

## Size

A two-digit weight was `r * 0.78` against a solo digit's `r * 1.02` — a 31% penalty for a second digit, which is exactly what made `12` harder to read than `9` on the same disc.

| viewport | 2-digit before | after | tablet/solo |
|---|---|---|---|
| 320×568 | 16.1px | **20.2px** | — |
| 390×844 | 19.6px | **24.7px** | — |
| 844×390 | 17.9px | **22.5px** | — |
| 768×1024 | 26.5px | **33.3px** | 38.8px |

`fittedNumeralPx` is still underneath, so nothing clips and nothing overflows — this only raises where the fitter starts.

### `NUMERAL_MIN_PX` is deliberately NOT raised, and that is the finding

It is the divisor in `charsAtRadius`. Every pixel of floor costs the disc characters of budget, `numeralCapacity` hands that budget to the adapter, and the adapter **refuses** boards that no longer fit — a raised floor does not draw a board smaller, it deletes it. Measured at rack 9 (the size `game.ts` really passes) over every viewport from 280×280 to 1600×1600, counting viewports that could serve a six-character board — the widest the ladder produces — and then could not:

| floor | viewports that stop serving six characters | band |
|---|---|---|
| 15px | — (baseline, shipped) | — |
| 16px | 3,080 | w 280–354, h 715–761 |
| 17px | 7,073 | w 280–376, h 715–807 |
| 18px | 12,057 | w 280–399, h 715–853 |

At 17px that band swallows **360×800 — Pixel-class Android**, and 360×780 with it. At 18px it reaches 390×844 and 393×873. So the floor holds at 15 and the size came entirely from `NUMERAL_EM`, which the budget arithmetic does not read: **`charsAtRadius`, `radiusForChars` and `numeralCapacity` are bit-for-bit unchanged, and the adapter refuses exactly the boards it refused before.** `SHIPPED_NUMERAL_MAX_CHARS = 10` in `promotionBlockers.ts` is derived from POLARITY's orb lanes, not from this pack, and is untouched and unaffected — COUNTERPOISE's own ceiling is 6, reported per viewport.

`legibility.test.ts` pins `numeralCapacity(360, 800, 9) === 6` as an equality, not `>= 6`, because that viewport's margin is exactly zero.

## Two more defects, found by widening the catalogue rather than by looking

- **Stacked fractions never touched `idealNumeralPx`.** A `1/2` weight drew at **10.3px** next to a `12` weight at 20.2px on the identical disc — so the founder's "a bit small" was worse on fractions than on the integers he was looking at, and the size pass would have widened the gap. New `stackedNumeralPx`, floored at `NUMERAL_MIN_PX * 0.8` because below that `haloWidth`'s 2px minimum starts closing the counters of 0, 6, 8 and 9.
- **A crate has four states, not three.** The window's base colour is keyed on `v.declared` but the mist on `!v.declared || v.wrong > 0`, so a rejection whose value was already undone — reachable, Backspace is live throughout the ~0.6s rejection window — is read over the darkest ground in the game. Verdigris measured **2.82:1** there. Lifted to `#7fccb3`: same hue, luminance 0.349 → 0.510, 3.39:1. The rejection frame stays `#5fae95`.

## Verification

- `npm run -s tsc` clean. **114 tests** (was 100), five consecutive clean runs.
- `node packs/build.mjs balance` builds and passes the SDK checker; `pack.json` untouched.
- `unstuck.test.ts` green throughout — every board the shipping ladder serves still has a legal move.

### Mutation transcript — 30 mutants, 30 caught

Every new assertion was broken, confirmed FAILING, and restored.

| # | mutation | failure message |
|---|---|---|
| 1 | `bestSingleInk` always finds a perfect ink | `some single ink reaches 21.00:1 — a lone fillText would do` |
| 2 | the shipped-ink defect test is handed a halo it never had | `#ffeec4 alone already measured 4.19:1 — this test is asserting nothing` |
| 3 | `haloFor` returns the ink itself | `#fff6e2 on its own halo #fff6e2 is 1.00:1, under 4.5:1` |
| 4 | `haloFor` always returns the dark pole | `balloon: #0d0801 on its own halo #0d0801 is 1.00:1` / `only one pole is ever used` |
| 5 | `inkPole` ignores its argument | `a bright copper balloon wants a pale numeral?` |
| 6 | `over()` ignores alpha | `crate — unknown: some single ink reaches 2.23:1` |
| 7 | `plus()` averages instead of adding | `Expected values to be strictly deep-equal` |
| 8 | `luma()` is a flat channel average | `green is not being weighted as green` |
| 9 | `crateState` lets `declared` beat `wrong` | `a rejected value is being drawn as if it had been accepted` |
| 10 | a rejected value painted in celebration gold | `wrong and right look alike` |
| 11 | `engrave` fills the ink before the halo | `the halo is not two strokes laid down before the ink` |
| 12 | only the old one-directional drop shadow | `the halo is not two strokes laid down before the ink` |
| 13 | the halo is a hairline | `at 12px the halo shows 0.25px outside` |
| 14 | the halo is fat enough to close the counters | `at 12px the halo closes 3.00px into each side of a counter` |
| 15 | the ring is offset like the shadow | `the ring is not centred on the glyph` |
| 16 | numeral size reverts to `0.78`/`1.02` | `a two-digit weight is 16.1px, under the 19.5px this viewport must clear` |
| 17 | the multi-character penalty comes back halved | `a two-digit weight is 18.2px, under the 19.5px` |
| 18 | a solo digit far larger than a pair | `a solo digit is 1.63× a pair` |
| 19 | floor raised to 17px | `a 360×800 Android can no longer show the widest board the ladder serves` |
| 20 | floor raised to 18px | `6 characters lay 62.6px of ink in a 61.2px face` |
| 21 | `fittedNumeralPx` stops fitting | `3 characters lay 35.2px of ink in a 35.1px face` |
| 22 | `numeralCapacity` ignores its viewport | `a 360×800 Android can no longer show the widest board` |
| 23 | `crateState` collapses the two rejections | `a rejection whose value was undone is not being told apart from an untouched crate` |
| 24 | `crateGround` models both rejections on the lighter window | `the two rejection states were modelled as one window` |
| 25 | verdigris back to `#5fae95` | `crate — rejectedEmpty: #5fae95/#0d0801 on #405d6a is 2.84:1, under 3:1` |
| 26 | catalogue stops listing the specular arc | `the unknown specular arc — #4f5a60 is not in the catalogue` |
| 27 | catalogue stops listing the top-face rim | `the top-face rim — #fceec8 is not in the catalogue` |
| 28 | `stackedNumeralPx` reverts to `r/2` | `a fraction row is 10.3px on an r=20.6 disc — still r/2` |
| 29 | fraction rows grow past the brass | `the denominator reaches 19.0px, past the brass at 16.1px` |
| 30 | the halo runs off the disc | `3 characters plus halo are 45.2px on a 41.3px disc` |

Four assertions flagged as unfalsifiable during self-review were removed or replaced rather than left in: `two >= NUMERAL_MIN_PX` and `drawn >= NUMERAL_MIN_PX` (both restate `Math.max` in the function under test), a duplicated halo-floor bound, and a halo-pole check that re-derived `haloFor`'s own branch predicate.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb