### PR TITLE
dynawalla/games/guilty: hold your fire — the opening waits, and a miss never speeds the trench up

### DIFF
--- a/dynawalla/games/guilty/src/core/config.ts
+++ b/dynawalla/games/guilty/src/core/config.ts
@@ -23,8 +23,17 @@ export const SHIP_HALF_W = 8.5;
 
 export const BULLET_SPEED = 560;
 export const BULLET_R = 2.6;
+/**
+ * The shortest gap between two shots the player asks for.
+ *
+ * It is a rate limit on a deliberate act, not a metronome for an automatic one.
+ * The gun used to fire on this interval by itself, which is the defect this
+ * file's history turns on: "the default of just going into the game is that you
+ * are just blasting everything, it's all wrong and you don't know what the F is
+ * going on."
+ */
 export const FIRE_INTERVAL = 0.155;
-/** Above this lateral speed the gun sleeps — see `Ship.settled`. */
+/** Above this lateral speed the ship is crossing rather than aiming. */
 export const FIRE_SPEED_GATE = 74;
 
 export const SHIP_MAX_SPEED = 460;

--- a/dynawalla/games/guilty/src/game/game.ts
+++ b/dynawalla/games/guilty/src/game/game.ts
@@ -203,6 +203,8 @@ export function mount(
     focusT: 0,
     question: null,
     askedAt: 0,
+    answerClock: 0,
+    answeredFrom: 0,
     firstWrong: null,
     resolved: true,
     perfectWave: true,
@@ -287,6 +289,7 @@ export function mount(
     const q: Question = host.next();
     world.question = q;
     world.askedAt = world.time;
+    world.answeredFrom = world.answerClock;
     world.firstWrong = null;
     world.resolved = false;
 
@@ -382,7 +385,7 @@ export function mount(
     host.report({
       questionId: world.question.id,
       correct: clean,
-      ms: Math.round((world.time - world.askedAt) * 1000),
+      ms: Math.round((world.answerClock - world.answeredFrom) * 1000),
       answered: world.firstWrong ?? (correct ? world.question.answer : ""),
     });
   }
@@ -396,12 +399,22 @@ export function mount(
    * is not an answer, so it does not become one here: the item is closed, the
    * ladder never sees it, and it costs the run a life exactly as it always did.
    *
-   * There is no `skip` on this game's `Host`, so "not reported" is literal —
-   * the session simply does not advance for an item nobody attempted. That is
-   * the honest trade and it is bounded: a run has three lives and one second
-   * wind, so an idle player reaches the game-over screen rather than looping
-   * forever against a session that never moves. And with `armed` in front of
-   * it, a child who is only looking never reaches this path at all.
+   * **What was chosen, and what was not.** The runtime host does have a
+   * `skip(itemId)` — `packs/shared/game-host` exposes one, and it closes the
+   * item on the host's ledger without scoring it. This game's own `contract.ts`
+   * copy of `Host` has four methods and `skip` is not among them, and skip is
+   * not free either: it closes an item without advancing session progress,
+   * which is its own trap (it bit LATTICE and had to be reverted). So the
+   * choice here is silence rather than either lie: not `report`, because a
+   * timeout is not a wrong answer, and not `skip`, because widening this game's
+   * contract to reach for a call whose progress semantics are still a live
+   * problem elsewhere is not this change.
+   *
+   * The cost of silence is that the session does not advance for an item nobody
+   * attempted, and the item stays open in the host's `served` map. It is
+   * bounded: a run has three lives and one second wind, so an idle player
+   * reaches the game-over screen rather than looping forever. And with `armed`
+   * in front of it, a child who is only looking never reaches this path at all.
    */
   function abandonQuestion(): void {
     world.resolved = true;
@@ -451,7 +464,7 @@ export function mount(
 
   function onCorrect(h: Husk): void {
     resolveQuestion(true);
-    const seconds = world.time - world.askedAt;
+    const seconds = world.answerClock - world.answeredFrom;
     world.combo += 1;
     world.bestCombo = Math.max(world.bestCombo, world.combo);
     const speedBonus = Math.round(100 * clamp(1 - (seconds - 0.9) / 4, 0, 1));
@@ -853,6 +866,11 @@ export function mount(
     // line. A child who has just opened the game and is reading it is not on a
     // clock, and cannot lose anything by taking their time.
     if (playing && world.armed) {
+      // The one clock an answer is measured against, and it runs on exactly the
+      // condition the trench moves on: if the shells are not sinking, the child
+      // is not on the hook for the seconds. That covers both new stillnesses —
+      // the opening before the first shot, and the held correction.
+      world.answerClock += realDt;
       // The last stretch is the fastest: once the formation is in the gate's
       // shadow it dives. Every wave gets a heartbeat ending instead of a
       // constant slide, and the player feels the deadline without a timer.
@@ -1031,15 +1049,25 @@ export function mount(
     }
 
     if (world.phase === Phase.Title) drawTitle(world);
-    else if (world.phase === Phase.Over) drawGameOver(world);
-    else {
+    else if (world.phase === Phase.Over) {
+      // THE LEDGER WAITS BEHIND THE CORRECTION. `drawGameOver` fades in on
+      // `phaseT`, and `phaseT` is frozen while a reveal is up — so drawing it
+      // here would paint the score, the wave, the best run and TAP TO DIVE
+      // AGAIN at alpha zero, forever, over a trench that had also stopped. The
+      // most common way to reach this state is the one this whole change is
+      // for: a struggling child losing their last life to a wave that ran out.
+      // So the sum stands alone first, and the ledger arrives when a hand takes
+      // it down.
+      if (world.revealPrompt === null) drawGameOver(world);
+    } else {
       if (world.phase === Phase.SecondWind) drawSecondWind(world);
       drawHud(world);
-      // Last, over everything: the rule while the trench is still waiting, and
-      // the completed sum while it is stopped.
+      // The rule, while the trench is still waiting.
       if (!world.armed) drawReady(world);
-      drawReveal(world);
     }
+    // Last, over everything, in every phase: the completed sum while the trench
+    // is stopped.
+    drawReveal(world);
   }
 
   /* -------------------------------------------------------------- the loop */
@@ -1076,6 +1104,12 @@ export function mount(
   /** Returns true if this input actually began a run, so its owner can stop. */
   function begin(): boolean {
     void world.audio.resume();
+    // A correction outranks a new run. Losing the last life to a wave that ran
+    // out puts the sum up on the game-over screen, and the press that would
+    // otherwise restart has to take that down first — otherwise the one moment
+    // the lesson was most worth showing is also the one moment a reflex wipes
+    // it, along with the score the child never got to see.
+    if (world.revealPrompt !== null) return false;
     if (world.phase !== Phase.Title && world.phase !== Phase.Over) return false;
     for (const h of world.husks) h.active = false;
     for (const b of world.bullets) b.active = false;
@@ -1109,8 +1143,10 @@ export function mount(
    * first time, or fire.
    */
   function onFire(): void {
-    if (world.phase === Phase.Title || world.phase === Phase.Over) return;
+    // The correction first, and in EVERY phase — including `Over`, which is
+    // where a run that ended on an unanswered wave puts one.
     if (dismissReveal()) return;
+    if (world.phase === Phase.Title || world.phase === Phase.Over) return;
     if (world.paused) return;
     if (!tryFire(world)) return;
     // THE FIRST SHOT STARTS THE GAME. Not the tap that dismissed the title, not
@@ -1119,8 +1155,12 @@ export function mount(
   }
 
   function spendFocus(): void {
+    // A press on a held correction takes it down, whichever gesture the press
+    // turned out to be. Every hand on the glass means the same thing while the
+    // sum is up — "I have read it" — and a long press that did nothing there
+    // would leave a child pressing a screen that is asking to be pressed.
+    if (dismissReveal()) return;
     if (world.phase === Phase.Title || world.phase === Phase.Over) return;
-    if (world.revealPrompt !== null) return;
     if (world.focus < 1 || world.focusT > 0) return;
     world.focus = 0;
     world.focusT = FOCUS_DURATION;

--- a/dynawalla/games/guilty/src/game/game.ts
+++ b/dynawalla/games/guilty/src/game/game.ts
@@ -8,6 +8,31 @@
  * The loop, the phases, the collisions and the scoring all live here; the feel
  * lives in `../core/juice.ts` and the look in `./husk.ts`, `./scene.ts` and
  * `./ship.ts`.
+ *
+ * ── THE OPENING ─────────────────────────────────────────────────────────────
+ *
+ * "The first time you jump in, you don't know what is going on but you are
+ * blasting all of the wrong things ... I think maybe you should choose when to
+ * shoot, eh?"
+ *
+ * Three things used to compound into that report, and all three are gone.
+ *
+ * 1. The gun fired by itself from a standstill, so standing still and reading
+ *    the trench WAS answering, over and over, wrongly. Firing is now a tap, a
+ *    click or the space bar (`tryFire`), and nothing else makes a bullet.
+ *
+ * 2. A miss did `world.descent *= 1.14`. The game got faster because the child
+ *    got it wrong — so every accidental answer bought them less time to work
+ *    out what was happening than they had a second earlier. Nothing in this
+ *    file escalates on a wrong answer any more.
+ *
+ * 3. A shell crossing the line reported `correct: false` — a wrong answer
+ *    nobody had given. An unanswered wave is now reported to nobody at all.
+ *
+ * On top of those, `world.armed`: from the first frame of a run until the
+ * player's first shot the formation hangs still and the trench costs nothing,
+ * and the rule is stated on the glass. Doing nothing is safe, and it is the
+ * state the game opens in.
  */
 
 import {
@@ -56,7 +81,16 @@ import { bakeVignette, clearGlyphCache } from "../render/bake.ts";
 import { clamp, damp, makeLineBatch } from "../render/draw.ts";
 import { drawBoss } from "./boss.ts";
 import { drawParticles, embers, ring, shards, sparks, stepParticles } from "./fx.ts";
-import { drawEquation, drawGameOver, drawHud, drawSecondWind, drawTitle, frameStats } from "./hud.ts";
+import {
+  drawEquation,
+  drawGameOver,
+  drawHud,
+  drawReady,
+  drawReveal,
+  drawSecondWind,
+  drawTitle,
+  frameStats,
+} from "./hud.ts";
 import { drawHusk, resetHusk, updateHusk } from "./husk.ts";
 import { attachInput } from "./input.ts";
 import { bakeScene, drawBackground, drawFloor, drawVignette, seedMotes } from "./scene.ts";
@@ -67,23 +101,42 @@ import {
   findTarget,
   fireBolt as fireBoltAt,
   stepBullets,
+  tryFire,
   updateShip,
 } from "./ship.ts";
+import {
+  SECOND_GRADE_FLOW,
+  revealPlan,
+} from "../../../../packs/shared/game-pacing/index.ts";
 import { hudLayout } from "./hudLayout.ts";
 import { bannerFor, specFor } from "./waves.ts";
 import { Mode, Phase, freeHusk, makePools, type Husk, type World } from "./world.ts";
 
 const BEST_KEY = "dynawalla.guilty.best";
 
+/** A read-only snapshot of the pacing. Nothing here can be written back. */
+export type Pacing = {
+  descent: number;
+  formationY: number;
+  armed: boolean;
+  revealed: boolean;
+  lives: number;
+  wave: number;
+  over: boolean;
+};
+
 /**
  * Mounts the game. The return type is the contract's `GameHandle` plus a
- * read-only `stats()` — extra structure a host may ignore entirely, and the
- * only way the QA driver ever touches the running game.
+ * read-only `stats()` and `pacing()` — extra structure a host may ignore
+ * entirely, and the only way the QA driver ever touches the running game.
+ *
+ * `pacing()` is a *reading*, never a lever: there is no setter beside it, so a
+ * test that wants the trench to move has to play the game to move it.
  */
 export function mount(
   el: HTMLElement,
   host: Host,
-): GameHandle & { stats(): ReturnType<typeof frameStats> } {
+): GameHandle & { stats(): ReturnType<typeof frameStats>; pacing(): Pacing } {
   const canvas = document.createElement("canvas");
   canvas.style.cssText = "display:block;width:100%;height:100%;touch-action:none;outline:none";
   canvas.tabIndex = 0;
@@ -153,6 +206,12 @@ export function mount(
     firstWrong: null,
     resolved: true,
     perfectWave: true,
+    armed: false,
+    revealPrompt: null,
+    revealAnswer: null,
+    revealSettle: 0,
+    revealAge: 0,
+    taughtFocus: false,
     descent: 12,
     swingAmp: 0,
     swingFreq: 0.4,
@@ -328,6 +387,66 @@ export function mount(
     });
   }
 
+  /**
+   * The wave ended and nobody answered it. Report NOTHING.
+   *
+   * A shell crossing the line used to be sent to the host as `correct: false`
+   * with an empty `answered` — a wrong answer attributed to a child who had not
+   * given one, from a game that until now was firing on their behalf. A timeout
+   * is not an answer, so it does not become one here: the item is closed, the
+   * ladder never sees it, and it costs the run a life exactly as it always did.
+   *
+   * There is no `skip` on this game's `Host`, so "not reported" is literal —
+   * the session simply does not advance for an item nobody attempted. That is
+   * the honest trade and it is bounded: a run has three lives and one second
+   * wind, so an idle player reaches the game-over screen rather than looping
+   * forever against a session that never moves. And with `armed` in front of
+   * it, a child who is only looking never reaches this path at all.
+   */
+  function abandonQuestion(): void {
+    world.resolved = true;
+  }
+
+  /* ---------------------------------------------------------------- reveal */
+
+  /**
+   * Put the completed sum on the glass and stop the trench.
+   *
+   * `revealPlan` decides whether it is worth showing at all, and the intensity
+   * it is asked about is the difficulty the HOST is currently serving — which
+   * is exactly the adaptive signal here, since the ladder walks up on clean
+   * answers and drops on a miss. High on the ladder, the plan is no reveal and
+   * an immediate carry-on: skipping the ceremony is the reward for mastery.
+   * Below that, `holdMs` is `Infinity` and only a hand takes it down.
+   */
+  function raiseReveal(): void {
+    const q = world.question;
+    if (!q) return;
+    const plan = revealPlan(SECOND_GRADE_FLOW, q.difficulty);
+    if (plan.holdMs <= 0) return;
+    world.revealPrompt = q.prompt;
+    world.revealAnswer = q.answer;
+    world.revealSettle = plan.settleMs / 1000;
+    world.revealAge = 0;
+  }
+
+  function clearReveal(): void {
+    world.revealPrompt = null;
+    world.revealAnswer = null;
+    world.revealSettle = 0;
+    world.revealAge = 0;
+  }
+
+  /** A hand on the glass while the sum is up. Takes it down, and nothing else. */
+  function dismissReveal(): boolean {
+    if (world.revealPrompt === null) return false;
+    // The settle floor is latency, not pedagogy: the tap that ended the
+    // question is routinely still arriving.
+    if (world.revealSettle > 0) return true;
+    clearReveal();
+    return true;
+  }
+
   /* --------------------------------------------------------------- outcomes */
 
   function onCorrect(h: Husk): void {
@@ -338,6 +457,13 @@ export function mount(
     const speedBonus = Math.round(100 * clamp(1 - (seconds - 0.9) / 4, 0, 1));
     world.score += (100 + speedBonus) * world.combo;
     world.focus = Math.min(1, world.focus + FOCUS_PER_SOLVE);
+    // DEEP FOCUS, named the first time a child has one. The bar along the
+    // bottom charging is not a sentence, and a power nobody knows the gesture
+    // for is not a power.
+    if (world.focus >= 1 && !world.taughtFocus) {
+      world.taughtFocus = true;
+      showBanner("DEEP FOCUS", world.touch ? "HOLD TO SLOW THE TRENCH" : "PRESS F TO SLOW THE TRENCH");
+    }
 
     kill(h, true);
     host.haptic("success");
@@ -364,7 +490,8 @@ export function mount(
   }
 
   function onWrong(h: Husk): void {
-    if (world.firstWrong === null) world.firstWrong = h.label;
+    const first = world.firstWrong === null;
+    if (first) world.firstWrong = h.label;
     world.combo = 0;
     world.perfectWave = false;
     h.hostile = true;
@@ -375,8 +502,18 @@ export function mount(
     h.shroud = 0;
     h.hitFlash = 1;
     h.squash = 0.7;
-    // The rest of the formation takes it personally.
-    world.descent *= 1.14;
+    // NOTHING ESCALATES HERE. `world.descent *= 1.14` used to live on this
+    // line, and a boss answered a mistake with a three-bolt volley. Both made
+    // the game faster because the child got it wrong, which is the one thing a
+    // miss must never do — least of all while the correction is on screen.
+    // The shell turning on you is the premise and it stays; the clock does not
+    // move.
+    if (first) {
+      // Answered, once, at the moment they answered. Waiting for the eventual
+      // right shot would bill the reading of the correction as thinking time.
+      resolveQuestion(false);
+      raiseReveal();
+    }
 
     host.haptic("failure");
     world.audio.wrong();
@@ -387,7 +524,6 @@ export function mount(
     flash(world.juice, 0.24, C.hostile);
     ring(world, h.x, h.y, 0, C.hostile, h.radius, 150, 0.42, 3);
     sparks(world, h.x, h.y, 0, 26, 130, C.hostile, { life: 0.6, size: 1.8 });
-    if (world.boss.active) bossVolley(3);
   }
 
   function kill(h: Husk, big: boolean): void {
@@ -434,7 +570,14 @@ export function mount(
   }
 
   function onBreach(x: number): void {
-    resolveQuestion(false);
+    // A shell crossed the line. If the child had already answered, `onWrong`
+    // reported it at the time and has already shown them the sum; if they had
+    // not, nobody answered, nobody is told anything, and the sum finishes
+    // itself here — a wave that ran out is the most useful moment in the game
+    // to be shown what the answer was.
+    const unanswered = !world.resolved;
+    abandonQuestion();
+    if (unanswered) raiseReveal();
     world.combo = 0;
     host.haptic("heavy");
     world.audio.breach();
@@ -663,7 +806,18 @@ export function mount(
   function update(realDt: number): void {
     const dt = stepJuice(world.juice, realDt);
     world.time += realDt;
-    world.phaseT += realDt;
+    // THE HELD CORRECTION. While the completed sum is up, the trench does not
+    // move: no descent, no swing, no bullets, no husks, no boss, no collisions
+    // and no phase timer. Light, sound and the shake from the hit carry on, so
+    // it reads as time stopping on the numbers rather than as a crash. Nothing
+    // takes it down but a hand.
+    const holding = world.revealPrompt !== null;
+    if (holding) {
+      world.revealAge += realDt;
+      world.revealSettle = Math.max(0, world.revealSettle - realDt);
+    } else {
+      world.phaseT += realDt;
+    }
     world.bannerT = Math.max(0, world.bannerT - realDt);
     world.displayScore = damp(world.displayScore, world.score, 9, realDt);
     world.audio.tick(realDt);
@@ -689,12 +843,16 @@ export function mount(
     if (bot) bot(realDt);
 
     updateShip(world, dt, realDt);
-    stepBullets(world, dt);
+    if (!holding) stepBullets(world, dt);
     stepParticles(world, dt);
 
-    const playing = world.phase === Phase.Wave || world.phase === Phase.SecondWind;
+    const playing = !holding && (world.phase === Phase.Wave || world.phase === Phase.SecondWind);
 
-    if (playing) {
+    // `armed` is the opening. Until the player's first shot the formation hangs
+    // exactly where it was born: no descent, no swing, nothing approaching the
+    // line. A child who has just opened the game and is reading it is not on a
+    // clock, and cannot lose anything by taking their time.
+    if (playing && world.armed) {
       // The last stretch is the fastest: once the formation is in the gate's
       // shadow it dives. Every wave gets a heartbeat ending instead of a
       // constant slide, and the player feels the deadline without a timer.
@@ -704,7 +862,7 @@ export function mount(
       world.swingPhaseX = Math.sin(world.swingPhase * Math.PI * 2) * world.swingAmp;
     }
 
-    if (world.boss.active) {
+    if (world.boss.active && !holding) {
       const boss = world.boss;
       boss.spin += dt * 0.55;
       boss.flash = Math.max(0, boss.flash - realDt * 2.6);
@@ -723,7 +881,7 @@ export function mount(
             { life: 0.8, size: 2 },
           );
         }
-      } else if (world.phase === Phase.Wave) {
+      } else if (world.phase === Phase.Wave && world.armed) {
         boss.y -= 3.4 * dt;
         boss.volleyCd -= dt;
         if (boss.volleyCd <= 0) {
@@ -733,21 +891,25 @@ export function mount(
       }
     }
 
-    for (const h of world.husks) {
-      if (!h.active) continue;
-      updateHusk(world, h, dt);
+    if (!holding) {
+      for (const h of world.husks) {
+        if (!h.active) continue;
+        updateHusk(world, h, dt);
+      }
     }
 
     if (playing) collide();
 
-    if (world.phase === Phase.Clear && world.phaseT > (bossFinishing ? 1.9 : WAVE_GAP)) {
-      advance();
-    }
-    if (world.phase === Phase.Breach && world.phaseT > 1) {
-      if (world.lives > 0) advance();
-    }
-    if (world.phase === Phase.Title) {
-      idleDrift(realDt);
+    if (!holding) {
+      if (world.phase === Phase.Clear && world.phaseT > (bossFinishing ? 1.9 : WAVE_GAP)) {
+        advance();
+      }
+      if (world.phase === Phase.Breach && world.phaseT > 1) {
+        if (world.lives > 0) advance();
+      }
+      if (world.phase === Phase.Title) {
+        idleDrift(realDt);
+      }
     }
 
     // Adaptive quality: hold 60 by thinning the fireworks, never the game.
@@ -827,7 +989,10 @@ export function mount(
     world.batch.reset();
     if (world.boss.active) drawBoss(world);
     if (world.phase !== Phase.Title && world.phase !== Phase.Over) {
-      drawSight(world, world.ship.settled > 0.05 ? findTarget(world) : null);
+      // Always. The sight used to appear only once the ship had settled, which
+      // meant the one thing that answers "which number will my tap destroy" was
+      // missing from exactly the frames a hesitating child spends deciding.
+      drawSight(world, findTarget(world));
     }
     drawBullets(world);
 
@@ -870,6 +1035,10 @@ export function mount(
     else {
       if (world.phase === Phase.SecondWind) drawSecondWind(world);
       drawHud(world);
+      // Last, over everything: the rule while the trench is still waiting, and
+      // the completed sum while it is stopped.
+      if (!world.armed) drawReady(world);
+      drawReveal(world);
     }
   }
 
@@ -904,34 +1073,54 @@ export function mount(
 
   /* ------------------------------------------------------------ start/stop */
 
-  function begin(): void {
+  /** Returns true if this input actually began a run, so its owner can stop. */
+  function begin(): boolean {
     void world.audio.resume();
-    if (world.phase === Phase.Title || world.phase === Phase.Over) {
-      for (const h of world.husks) h.active = false;
-      for (const b of world.bullets) b.active = false;
-      world.wave = 1;
-      world.lives = START_LIVES;
-      world.score = 0;
-      world.displayScore = 0;
-      world.combo = 0;
-      world.bestCombo = 0;
-      world.focus = 0;
-      world.focusT = 0;
-      world.usedSecondWind = false;
-      world.ship.alive = true;
-      world.ship.invuln = 1.2;
-      world.ship.x = 0;
-      world.ship.targetX = 0;
-      bossFinishing = false;
-      startWave();
-    }
+    if (world.phase !== Phase.Title && world.phase !== Phase.Over) return false;
+    for (const h of world.husks) h.active = false;
+    for (const b of world.bullets) b.active = false;
+    world.wave = 1;
+    world.lives = START_LIVES;
+    world.score = 0;
+    world.displayScore = 0;
+    world.combo = 0;
+    world.bestCombo = 0;
+    world.focus = 0;
+    world.focusT = 0;
+    world.usedSecondWind = false;
+    world.taughtFocus = false;
+    world.ship.alive = true;
+    world.ship.invuln = 1.2;
+    world.ship.x = 0;
+    world.ship.targetX = 0;
+    // The run opens UNARMED and with nothing held over from the last one.
+    world.armed = false;
+    clearReveal();
+    bossFinishing = false;
+    startWave();
+    return true;
+  }
+
+  /**
+   * The player asked for a shot.
+   *
+   * Three jobs in order, because they are three different meanings of the same
+   * tap: take down a correction that is being read, arm the trench for the
+   * first time, or fire.
+   */
+  function onFire(): void {
+    if (world.phase === Phase.Title || world.phase === Phase.Over) return;
+    if (dismissReveal()) return;
+    if (world.paused) return;
+    if (!tryFire(world)) return;
+    // THE FIRST SHOT STARTS THE GAME. Not the tap that dismissed the title, not
+    // the mount, not a timer: the first bullet the child chose to send.
+    world.armed = true;
   }
 
   function spendFocus(): void {
-    if (world.phase === Phase.Title || world.phase === Phase.Over) {
-      begin();
-      return;
-    }
+    if (world.phase === Phase.Title || world.phase === Phase.Over) return;
+    if (world.revealPrompt !== null) return;
     if (world.focus < 1 || world.focusT > 0) return;
     world.focus = 0;
     world.focusT = FOCUS_DURATION;
@@ -948,6 +1137,7 @@ export function mount(
     // it is read long after the whole mount has finished.
     blocked: () => guide.isOpen,
     onStart: begin,
+    onFire,
     onFocus: spendFocus,
     onToggleMute: () => world.audio.setMuted(!world.audio.muted()),
     onTogglePause: () => {
@@ -969,30 +1159,42 @@ export function mount(
   // which reads as the game being unfair rather than as a punishment for
   // guessing.
   //
+  // The sheet is no longer the only place the rule lives — `drawTitle` and
+  // `drawReady` state it on the glass, before the trench costs anything — but
+  // it is still where the whole of it is written down.
+  //
   // The panel stays reachable during play, and opening it freezes the descent:
   // a child who goes to read the rules must not lose a life while reading them.
   const guide = createInstructions(el, {
     title: "GUILTY",
     summary: [
-      "A sum hangs over the trench. Four shells sink out of it, each with a different answer on it.",
-      "Only one answer is right. Shoot that one. Shoot a wrong one and it turns on you.",
+      "A sum hangs over the trench. Shells sink out of it, each with a different answer on it.",
+      "The guilty shell is the one telling the truth: the one with the right answer. Shoot that one.",
     ],
     sections: [
       {
         heading: "How to play",
         lines: [
           "Read the sum at the top and work out the answer yourself.",
-          "Four shells sink towards the line above your ship. Each shell carries a number.",
-          "Find the shell with your answer on it and shoot it. The other three scatter and you are safe.",
+          "The shells sink towards the line above your ship. Each shell carries a number.",
+          "Find the shell with your answer on it and shoot it. The others scatter and you are safe.",
           "Do not let a shell reach the line. If one crosses it, you lose a life.",
+        ],
+      },
+      {
+        heading: "Nothing happens until you shoot",
+        lines: [
+          "When a run begins the shells hang still and nothing sinks. Take as long as you like to look at them.",
+          "The trench starts moving on your first shot, and not before. If you are not sure yet, do not shoot yet.",
         ],
       },
       {
         heading: "The wrong answers are real mistakes",
         lines: [
-          "The three wrong numbers are not random. Each one is what you get if you make a mistake people really make.",
+          "The wrong numbers are not random. Each one is what you get if you make a mistake people really make.",
           "So a wrong number can look very close to the right one. Work the sum out properly instead of picking the one that looks about right.",
-          "Shoot a wrong shell and it turns red and starts shooting back. That is why guessing is a bad plan.",
+          "Shoot a wrong shell and it turns and comes at you. That is why guessing is a bad plan.",
+          "When that happens the sum finishes itself in the middle of the screen and everything stops. Read it for as long as you want; tap when you are ready to carry on.",
         ],
       },
       {
@@ -1001,14 +1203,15 @@ export function mount(
           "On a touch screen, drag anywhere to steer. Your finger does not have to be on the ship, so your hand never covers what you are aiming at.",
           "With a mouse, just move it. The ship follows the pointer.",
           "The arrow keys and A and D work too.",
-          "Your gun fires by itself. It stops while you are sliding fast and starts again the moment you settle, so aim first, then hold still.",
+          "A quick tap shoots. With a keyboard, the space bar shoots. The gun never fires on its own, so you decide when to answer.",
+          "The thin beam from the nose of your ship shows exactly which shell your next shot will hit.",
         ],
       },
       {
         heading: "Deep focus",
         lines: [
           "Every right answer fills the thin bar along the bottom of the screen.",
-          "When it is full, tap once quickly, or press the space bar, to slow the whole trench down.",
+          "When it is full, press and hold anywhere for a moment, or press F, to slow the whole trench down.",
           "Use it when the shells are close to the line and you need a moment to think.",
         ],
       },
@@ -1016,6 +1219,7 @@ export function mount(
         heading: "Waves and lives",
         lines: [
           "You start with three lives. Clear a wave and the next one sinks faster.",
+          "Getting one wrong never makes the trench faster. Only clearing a wave does that.",
           "Every sixth wave brings THE ARBITER, one huge ship. An arbiter is someone who decides who is right.",
           "Bullets bounce off its shield. Only a right answer breaks it, so keep reading the sums.",
           "From wave twelve the screen says SHUT SHELLS. The numbers are scrambled until a shell has sunk part of the way down, so wait for it to open before you read it.",
@@ -1027,7 +1231,7 @@ export function mount(
         heading: "Keyboard",
         lines: [
           "Left and right arrows, or A and D, steer.",
-          "Space uses deep focus. M turns the sound off. P pauses.",
+          "Space shoots. F uses deep focus. M turns the sound off. P pauses.",
         ],
       },
     ],
@@ -1042,7 +1246,7 @@ export function mount(
   let bot: ((dt: number) => void) | null = null;
   if (params.has("bot")) {
     const skill = Number(params.get("bot")) || 1;
-    bot = makeBot(world, skill, begin, spendFocus);
+    bot = makeBot(world, skill, begin, onFire, spendFocus);
   }
   if (params.has("wave")) {
     world.wave = Math.max(1, Number(params.get("wave")) || 1);
@@ -1053,6 +1257,15 @@ export function mount(
 
   return {
     stats: () => frameStats(world),
+    pacing: () => ({
+      descent: world.descent,
+      formationY: world.formationY,
+      armed: world.armed,
+      revealed: world.revealPrompt !== null,
+      lives: world.lives,
+      wave: world.wave,
+      over: world.phase === Phase.Over,
+    }),
     unmount() {
       running = false;
       cancelAnimationFrame(raf);
@@ -1088,13 +1301,15 @@ function saveBest(value: number): void {
 
 /**
  * A deterministic autoplayer. It exists for QA — it drives the *real* input
- * surface (a target x and the focus button), never a private hook, so anything
- * it proves is true of a human playing.
+ * surface (a target x, the trigger and the focus button), never a private hook,
+ * so anything it proves is true of a human playing. It now has to pull the
+ * trigger itself, like everybody else.
  */
 function makeBot(
   world: World,
   skill: number,
-  begin: () => void,
+  begin: () => boolean,
+  onFire: () => void,
   spendFocus: () => void,
 ): (dt: number) => void {
   let think = 0;
@@ -1106,6 +1321,11 @@ function makeBot(
     }
     if (world.phase === Phase.Over) {
       begin();
+      return;
+    }
+    // A reveal is a hand's job. The bot has a hand.
+    if (world.revealPrompt !== null) {
+      onFire();
       return;
     }
     think -= dt;
@@ -1140,6 +1360,9 @@ function makeBot(
           : aim.vx;
       const flight = Math.max(0, (aim.y - SHIP_Y) / 560);
       world.ship.targetX = aim.x + swingV * flight;
+      // Pull the trigger only when the nose is actually on it, which is what a
+      // player does and what the sight line is for.
+      if (Math.abs(world.ship.x - aim.x) < aim.radius * 0.8) onFire();
     }
     if (world.focus >= 1 && world.rng.nextFloat() < dt * 0.6) spendFocus();
   };

--- a/dynawalla/games/guilty/src/game/hud.ts
+++ b/dynawalla/games/guilty/src/game/hud.ts
@@ -23,6 +23,25 @@ import type { World } from "./world.ts";
 const UI_FONT = `700 %SIZE%px system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif`;
 const font = (size: number): string => UI_FONT.replace("%SIZE%", String(Math.round(size)));
 
+/**
+ * Sets the font to the largest size at or under `size` that fits `maxW`.
+ *
+ * Every line in this file that a child must READ goes through here. A phone in
+ * portrait has a third of a laptop's width and these are whole sentences, not
+ * numerals — a constant size means the rule of the game runs off the glass on
+ * the device most likely to be a child's first one.
+ */
+function fitFont(ctx: CanvasRenderingContext2D, text: string, size: number, maxW: number): number {
+  let px = size;
+  ctx.font = font(px);
+  const w = ctx.measureText(text).width;
+  if (w > maxW && w > 0) {
+    px = Math.max(9, size * (maxW / w));
+    ctx.font = font(px);
+  }
+  return px;
+}
+
 export function drawEquation(world: World): void {
   const q = world.question;
   if (!q) return;
@@ -157,6 +176,96 @@ function drawBanner(world: World): void {
   ctx.globalAlpha = 1;
 }
 
+/**
+ * The rule, on the glass, while the trench is still waiting.
+ *
+ * Shown from the first frame of a run until the first shot, over a formation
+ * that is not moving and cannot cost anything. GUILTY shipped with the rule
+ * that makes it a maths game stated nowhere a player would find it, and the
+ * word GUILTY is itself an inversion — the guilty shell is the one telling the
+ * TRUTH — so it is spelled out here, where a child first meets it, in the same
+ * breath as the only control they need.
+ */
+export function drawReady(world: World): void {
+  const { ctx, hud } = world;
+  const { w, h } = hud.safe;
+  const maxW = w * 0.9;
+  const y = hud.safe.y + h * 0.6;
+
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  const rule = "THE GUILTY SHELL IS THE ONE WITH THE RIGHT ANSWER";
+  const ruleSize = fitFont(ctx, rule, Math.min(w * 0.05, h * 0.03), maxW);
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.amber, hud.cx, y, ruleSize * 6, 0.06);
+  ctx.globalCompositeOperation = "source-over";
+  ctx.fillStyle = rgba(C.amber, 0.88);
+  ctx.fillText(rule, hud.cx, y);
+
+  const call = "SHOOT IT";
+  const callSize = fitFont(ctx, call, Math.min(w * 0.075, h * 0.045), maxW);
+  ctx.fillStyle = rgba(C.white, 0.9);
+  ctx.fillText(call, hud.cx, y + ruleSize * 1.9);
+
+  const how = world.touch ? "TAP TO FIRE" : "PRESS SPACE TO FIRE";
+  fitFont(ctx, how, callSize * 0.62, maxW);
+  ctx.fillStyle = rgba(C.cyan, 0.45 + Math.sin(world.time * 3) * 0.3);
+  ctx.fillText(how, hud.cx, y + ruleSize * 1.9 + callSize * 1.4);
+
+  const wait = "NOTHING MOVES UNTIL YOU DO";
+  fitFont(ctx, wait, callSize * 0.44, maxW);
+  ctx.fillStyle = rgba(C.cyan, 0.4);
+  ctx.fillText(wait, hud.cx, y + ruleSize * 1.9 + callSize * 2.4);
+  ctx.textAlign = "left";
+}
+
+/**
+ * The completed sum, standing still, with no deadline on it.
+ *
+ * The accent colour, never red, and it never says WRONG. A child who has just
+ * missed is the slowest reader in the session, so nothing here is on a timer:
+ * `game.ts` freezes the trench while this is up and only a hand takes it down.
+ */
+export function drawReveal(world: World): void {
+  if (world.revealPrompt === null || world.revealAnswer === null) return;
+  const { ctx, hud } = world;
+  const { w, h } = hud.safe;
+  const t = clamp(world.revealAge / 0.26, 0, 1);
+  const fade = ease.outCubic(t);
+
+  // A scrim over the whole GLASS. The trench behind it is frozen; dimming it is
+  // what says so, and a scrim that stopped at the safe area would draw a bright
+  // band across the notch.
+  ctx.fillStyle = rgba("#02060c", 0.62 * fade);
+  ctx.fillRect(0, 0, world.w, world.h);
+
+  const line = `${world.revealPrompt} = ${world.revealAnswer}`;
+  const maxW = w * 0.88;
+  const y = hud.cy;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.globalAlpha = fade;
+
+  const size = fitFont(ctx, line, Math.min(w * 0.16, h * 0.085), maxW);
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.amber, hud.cx, y, size * 2.6, 0.1 * fade);
+  ctx.globalCompositeOperation = "source-over";
+  ctx.fillStyle = C.amber;
+  ctx.fillText(line, hud.cx, y);
+
+  // The way on, and only once the tap that ended the question can no longer be
+  // the tap that dismisses this.
+  if (world.revealSettle <= 0) {
+    const go = world.touch ? "TAP WHEN YOU HAVE READ IT" : "PRESS SPACE WHEN YOU HAVE READ IT";
+    fitFont(ctx, go, size * 0.3, maxW);
+    ctx.fillStyle = rgba(C.cyan, 0.4 + Math.sin(world.time * 3) * 0.22);
+    ctx.fillText(go, hud.cx, y + size * 1.1);
+  }
+  ctx.globalAlpha = 1;
+  ctx.textAlign = "left";
+}
+
 export function drawTitle(world: World): void {
   const { ctx, hud } = world;
   const { w, h } = hud.safe;
@@ -169,15 +278,22 @@ export function drawTitle(world: World): void {
   ctx.globalCompositeOperation = "source-over";
   drawGlyph(ctx, getGlyph("GUILTY", C.amber, 900), hud.cx, y, size * ease.outBack(clamp(t, 0, 1)));
 
-  ctx.font = font(Math.max(13, size * 0.13));
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
+  // The rule, before anything can cost anything. A child meets the word GUILTY
+  // here and nowhere else, and it means the opposite of what they will guess.
+  const rule = "SHOOT THE SHELL WITH THE RIGHT ANSWER ON IT";
+  fitFont(ctx, rule, Math.max(12, size * 0.145), hud.safe.w * 0.9);
+  ctx.fillStyle = rgba(C.amber, 0.78);
+  ctx.fillText(rule, hud.cx, y + size * 0.62);
+
+  ctx.font = font(Math.max(13, size * 0.13));
   ctx.fillStyle = rgba(C.cyan, 0.5 + Math.sin(world.time * 3) * 0.28);
-  ctx.fillText(world.touch ? "TAP TO BEGIN" : "PRESS ANY KEY", hud.cx, y + size * 0.72);
+  ctx.fillText(world.touch ? "TAP TO BEGIN" : "PRESS ANY KEY", hud.cx, y + size * 0.86);
   if (world.best > 0) {
     ctx.fillStyle = rgba(C.amber, 0.45);
     ctx.font = font(Math.max(11, size * 0.1));
-    ctx.fillText(`BEST ${world.best}`, hud.cx, y + size * 0.95);
+    ctx.fillText(`BEST ${world.best}`, hud.cx, y + size * 1.07);
   }
   ctx.globalAlpha = 1;
 }
@@ -231,7 +347,14 @@ export function drawSecondWind(world: World): void {
   ctx.textBaseline = "middle";
   ctx.fillStyle = rgba(C.hostile, 0.6 + Math.sin(world.time * 4) * 0.3);
   // Above the ship, under the action: the husks stay readable.
-  ctx.fillText("ONE MORE", hud.cx, hud.safe.y + h * 0.8);
+  const y = hud.safe.y + h * 0.8;
+  ctx.fillText("ONE MORE", hud.cx, y);
+  // What it MEANS, where it is met. Two words in a red pulse is a threat; the
+  // line under it is the only thing that makes it a chance.
+  const sub = "GET THIS ONE RIGHT AND YOU KEEP GOING";
+  fitFont(ctx, sub, size * 0.24, w * 0.9);
+  ctx.fillStyle = rgba(C.cyan, 0.6);
+  ctx.fillText(sub, hud.cx, y + size * 0.46);
 }
 
 function drawStats(world: World): void {

--- a/dynawalla/games/guilty/src/game/input.test.ts
+++ b/dynawalla/games/guilty/src/game/input.test.ts
@@ -32,6 +32,8 @@ type Listener = (event: unknown) => void;
 function rig(): {
   fire(type: string, event: Record<string, unknown>): void;
   listenerCount(): number;
+  /** Advance the clock the tap/hold split is measured on. */
+  advance(ms: number): void;
   restore(): void;
   canvas: HTMLCanvasElement;
 } {
@@ -59,10 +61,17 @@ function rig(): {
     writable: true,
     value: fakeWindow,
   });
-  if (typeof savedPerf !== "object") g.performance = { now: () => 0 };
+  // A clock this file owns, always. The tap/hold split is measured in
+  // milliseconds of wall time, and a test that hopes a real clock stays under a
+  // 230ms threshold is a test that goes red on a loaded machine for no reason.
+  let clock = 0;
+  g.performance = { now: () => clock };
 
   return {
     canvas,
+    advance(ms) {
+      clock += ms;
+    },
     fire(type, event) {
       // Every real event has these; supplying them here means a gate that is
       // removed fails on the ASSERTION rather than on a TypeError, which is the
@@ -79,7 +88,8 @@ function rig(): {
     restore() {
       if (savedWindow) Object.defineProperty(globalThis, "window", savedWindow);
       else Reflect.deleteProperty(globalThis, "window");
-      if (typeof savedPerf !== "object") Reflect.deleteProperty(g, "performance");
+      if (savedPerf === undefined) Reflect.deleteProperty(g, "performance");
+      else g.performance = savedPerf;
     },
   };
 }
@@ -92,12 +102,20 @@ const fakeWorld = (): World =>
     cam: { f: 600, z: 300, cx: 400, x: 0 },
   }) as unknown as World;
 
-function counted(blocked: () => boolean): {
+function counted(
+  blocked: () => boolean,
+  /** What `onStart` says: true means "I began a run and spent this input". */
+  startConsumes = false,
+): {
   handlers: InputHandlers;
   calls: Record<string, number>;
+  /** The run has begun; from now on `onStart` consumes nothing. */
+  started(): void;
 } {
+  let consumes = startConsumes;
   const calls: Record<string, number> = {
     onStart: 0,
+    onFire: 0,
     onFocus: 0,
     onToggleMute: 0,
     onTogglePause: 0,
@@ -108,9 +126,16 @@ function counted(blocked: () => boolean): {
   };
   return {
     calls,
+    started(): void {
+      consumes = false;
+    },
     handlers: {
       blocked,
-      onStart: bump("onStart"),
+      onStart: (): boolean => {
+        calls.onStart = (calls.onStart ?? 0) + 1;
+        return consumes;
+      },
+      onFire: bump("onFire"),
       onFocus: bump("onFocus"),
       onToggleMute: bump("onToggleMute"),
       onTogglePause: bump("onTogglePause"),
@@ -166,7 +191,11 @@ test("every key reaches the game the moment the manual closes", () => {
     assert.equal(calls.onTogglePause, 1, "p no longer pauses");
 
     r.fire("keydown", { key: " " });
-    assert.equal(calls.onFocus, 1, "space no longer spends deep focus");
+    assert.equal(calls.onFire, 1, "space no longer shoots");
+    assert.equal(calls.onFocus, 0, "space still spends deep focus");
+
+    r.fire("keydown", { key: "f" });
+    assert.equal(calls.onFocus, 1, "f no longer spends deep focus");
 
     r.fire("keydown", { key: "m" });
     assert.equal(calls.onToggleMute, 1, "m no longer mutes");
@@ -197,6 +226,123 @@ test("a key released while the manual is open still lets go", () => {
     open = true;
     r.fire("keyup", { key: "ArrowRight" });
     assert.equal(input.axis(), 0, "the held key survived the panel");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});
+
+/* ────────────────────────────────────────────────────────────── the trigger */
+//
+// "I think maybe you should choose when to shoot, eh?"
+//
+// The gun used to fire on a timer from a standstill, so the input layer had no
+// trigger at all. It has one now, and the tests below are about the two ways
+// that trigger can go wrong: never firing, and firing for a child who was doing
+// something else entirely.
+
+const down = (x = 400, type = "touch"): Record<string, unknown> => ({
+  pointerId: 1,
+  clientX: x,
+  pointerType: type,
+});
+
+test("a quick still tap is a shot", () => {
+  const r = rig();
+  try {
+    const { handlers, calls } = counted(() => false);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+    r.fire("pointerdown", down());
+    r.advance(90);
+    r.fire("pointerup", { pointerId: 1 });
+    assert.equal(calls.onFire, 1, "a tap did not fire");
+    assert.equal(calls.onFocus, 0, "a tap spent deep focus");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});
+
+test("the tap that begins a run does not also answer its first question", () => {
+  // The whole change, in one gesture. TAP TO BEGIN is a single tap, and if its
+  // release fires, a child's first act in the game is a shot they did not aim —
+  // the auto-fire defect surviving in a smaller hat.
+  const r = rig();
+  try {
+    const c = counted(() => false, true);
+    const { handlers, calls } = c;
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+    r.fire("pointerdown", down());
+    r.advance(90);
+    r.fire("pointerup", { pointerId: 1 });
+    assert.equal(calls.onStart, 1, "the tap did not start the game");
+    assert.equal(calls.onFire, 0, "the tap that started the game also fired");
+
+    // And the very next tap, which begins nothing, does fire — a swallow that
+    // sticks is the same bug the other way round.
+    c.started();
+    r.fire("pointerdown", down());
+    r.advance(90);
+    r.fire("pointerup", { pointerId: 1 });
+    assert.equal(calls.onFire, 1, "the trigger stayed swallowed after the start tap");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});
+
+test("the key that begins a run does not also answer its first question", () => {
+  const r = rig();
+  try {
+    const { handlers, calls } = counted(() => false, true);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+    r.fire("keydown", { key: " " });
+    assert.equal(calls.onStart, 1, "space did not start the game");
+    assert.equal(calls.onFire, 0, "the space that started the game also fired");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});
+
+test("a long still press is deep focus, and never also a shot", () => {
+  const r = rig();
+  try {
+    const { handlers, calls } = counted(() => false);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+    r.fire("pointerdown", down());
+    r.advance(600);
+    r.fire("pointerup", { pointerId: 1 });
+    assert.equal(calls.onFocus, 1, "a long press did not spend deep focus");
+    assert.equal(calls.onFire, 0, "a long press also fired");
+    input.detach();
+  } finally {
+    r.restore();
+  }
+});
+
+test("steering is neither a shot nor deep focus", () => {
+  // A drag is how the ship crosses the field, and crossing the field must never
+  // cost an answer — that was the original sin of the settle-gate auto-fire.
+  const r = rig();
+  try {
+    const { handlers, calls } = counted(() => false);
+    const input = attachInput(r.canvas, fakeWorld(), handlers);
+    r.fire("pointerdown", down(200));
+    r.advance(40);
+    r.fire("pointermove", { pointerId: 1, clientX: 520, pointerType: "touch" });
+    r.advance(40);
+    r.fire("pointerup", { pointerId: 1 });
+    assert.equal(calls.onFire, 0, "a drag fired the gun");
+    assert.equal(calls.onFocus, 0, "a drag spent deep focus");
+
+    // Same again, but slow enough to pass the hold threshold: still steering.
+    r.fire("pointerdown", down(200));
+    r.advance(900);
+    r.fire("pointermove", { pointerId: 1, clientX: 520, pointerType: "touch" });
+    r.fire("pointerup", { pointerId: 1 });
+    assert.equal(calls.onFire, 0, "a slow drag fired the gun");
+    assert.equal(calls.onFocus, 0, "a slow drag spent deep focus");
     input.detach();
   } finally {
     r.restore();

--- a/dynawalla/games/guilty/src/game/input.test.ts
+++ b/dynawalla/games/guilty/src/game/input.test.ts
@@ -305,6 +305,32 @@ test("the key that begins a run does not also answer its first question", () => 
   }
 });
 
+test("no still press does nothing at all", () => {
+  // There were two thresholds — a tap under 230ms, a hold at 430 — and a silent
+  // gap between them, which is exactly where an unhurried, deliberate press by
+  // a child who is not rushing lands. A press that does nothing on a screen
+  // asking to be pressed is the same confusion as a shot nobody asked for. Now
+  // there is one threshold and every still press means something.
+  for (const held of [0, 40, 120, 229, 230, 300, 380, 429, 430, 700, 2000]) {
+    const r = rig();
+    try {
+      const { handlers, calls } = counted(() => false);
+      const input = attachInput(r.canvas, fakeWorld(), handlers);
+      r.fire("pointerdown", down());
+      r.advance(held);
+      r.fire("pointerup", { pointerId: 1 });
+      assert.equal(
+        calls.onFire + calls.onFocus,
+        1,
+        `a still press of ${held}ms did ${calls.onFire + calls.onFocus} things`,
+      );
+      input.detach();
+    } finally {
+      r.restore();
+    }
+  }
+});
+
 test("a long still press is deep focus, and never also a shot", () => {
   const r = rig();
   try {

--- a/dynawalla/games/guilty/src/game/input.ts
+++ b/dynawalla/games/guilty/src/game/input.ts
@@ -4,16 +4,27 @@
  * TOUCH — drag anywhere. The ship keeps its offset from the finger, so a child
  * can steer from the bottom corner without their hand covering the thing they
  * are aiming at, and the first touch never teleports the ship. A quick tap
- * (short, still) spends Deep Focus.
+ * (short, still) FIRES. Press and hold, still, and let go: Deep Focus.
  *
  * DESKTOP — the ship tracks the mouse's x directly, with no button held: the
- * pointer *is* the ship. Arrow keys and A/D work at full speed for players who
- * want them, space spends Deep Focus. Both schemes are live at once and either
- * can take over mid-run.
+ * pointer *is* the ship. A click fires. Arrow keys and A/D work at full speed
+ * for players who want them, space fires, F spends Deep Focus. Both schemes are
+ * live at once and either can take over mid-run.
+ *
+ * **The tap that begins a run is not also a shot.** `onStart` says whether it
+ * consumed the input, and when it did, the matching release fires nothing.
+ * Otherwise the single tap on TAP TO BEGIN would start the game and immediately
+ * answer its first question — the exact reflex this whole change exists to
+ * remove, wearing a smaller hat.
  */
 
 import { screenToWorldX } from "../core/camera.ts";
 import type { World } from "./world.ts";
+
+/** Under this, a press is a tap and a tap is a shot. */
+const TAP_MS = 230;
+/** At or over this, a still press is a request for Deep Focus. */
+const HOLD_MS = 430;
 
 export type Input = {
   /** -1..1 from the keyboard, 0 when nothing is held. */
@@ -36,7 +47,10 @@ export type InputHandlers = {
    * on screen saying why.
    */
   blocked(): boolean;
-  onStart(): void;
+  /** Begin a run from the title or the game-over screen. True if it did. */
+  onStart(): boolean;
+  /** The player asked for a shot — a tap, a click, or the space bar. */
+  onFire(): void;
   onFocus(): void;
   onToggleMute(): void;
   onTogglePause(): void;
@@ -52,6 +66,8 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
   let downAt = 0;
   let downX = 0;
   let moved = 0;
+  /** The press that began a run. Its release fires nothing. */
+  let consumedByStart = false;
 
   const rectX = (): number => canvas.getBoundingClientRect().left;
 
@@ -70,7 +86,7 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
       dragOffset = 0;
       world.ship.targetX = screenToWorldX(world.cam, e.clientX - rectX());
     }
-    on.onStart();
+    consumedByStart = on.onStart();
     e.preventDefault();
   };
 
@@ -89,11 +105,26 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
     if (e.pointerId !== pointerId || on.blocked()) return;
     dragging = false;
     pointerId = -1;
-    if (performance.now() - downAt < 230 && moved < 14) on.onFocus();
+    const held = performance.now() - downAt;
+    const still = moved < 14;
+    if (consumedByStart) {
+      consumedByStart = false;
+      return;
+    }
+    if (!still) return;
+    // Two gestures on one finger, separated by how long it stayed down. A tap
+    // is a shot; a deliberate press is the slow-motion. Deep Focus resolves on
+    // RELEASE rather than on a timer, so nothing in here needs a clock — and a
+    // press that turns into a drag is steering and is neither.
+    if (held < TAP_MS) on.onFire();
+    else if (held >= HOLD_MS) on.onFocus();
   };
 
   const keyDown = (e: KeyboardEvent): void => {
     if (e.repeat || on.blocked()) return;
+    // First, not last: the key that begins a run must be able to tell the rest
+    // of this switch that it has already been spent.
+    const started = on.onStart();
     switch (e.key) {
       case "ArrowLeft":
       case "a":
@@ -107,8 +138,12 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
         break;
       case " ":
       case "Spacebar":
-        on.onFocus();
+        if (!started) on.onFire();
         e.preventDefault();
+        break;
+      case "f":
+      case "F":
+        if (!started) on.onFocus();
         break;
       case "m":
       case "M":
@@ -122,7 +157,6 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
         on.onToggleStats();
         break;
     }
-    on.onStart();
   };
 
   const keyUp = (e: KeyboardEvent): void => {
@@ -136,6 +170,7 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
     left = false;
     right = false;
     dragging = false;
+    consumedByStart = false;
   };
 
   canvas.addEventListener("pointerdown", pointerDown);

--- a/dynawalla/games/guilty/src/game/input.ts
+++ b/dynawalla/games/guilty/src/game/input.ts
@@ -21,9 +21,15 @@
 import { screenToWorldX } from "../core/camera.ts";
 import type { World } from "./world.ts";
 
-/** Under this, a press is a tap and a tap is a shot. */
-const TAP_MS = 230;
-/** At or over this, a still press is a request for Deep Focus. */
+/**
+ * At or over this, a still press is a request for Deep Focus. Under it, a shot.
+ *
+ * ONE threshold, not two. It was a tap under 230 ms and a hold over 430, which
+ * left a silent dead zone in between — and a deliberate, unhurried press by a
+ * child who is not rushing lands squarely in it. A press that does nothing, on
+ * a screen that is asking to be tapped, is the same confusion as a shot nobody
+ * asked for.
+ */
 const HOLD_MS = 430;
 
 export type Input = {
@@ -116,8 +122,8 @@ export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHa
     // is a shot; a deliberate press is the slow-motion. Deep Focus resolves on
     // RELEASE rather than on a timer, so nothing in here needs a clock — and a
     // press that turns into a drag is steering and is neither.
-    if (held < TAP_MS) on.onFire();
-    else if (held >= HOLD_MS) on.onFocus();
+    if (held >= HOLD_MS) on.onFocus();
+    else on.onFire();
   };
 
   const keyDown = (e: KeyboardEvent): void => {

--- a/dynawalla/games/guilty/src/game/opening.test.ts
+++ b/dynawalla/games/guilty/src/game/opening.test.ts
@@ -119,6 +119,7 @@ function makeSurface(): {
   frame(ms?: number): TextOp[];
   said(needle: string): TextOp | undefined;
   key(k: string): void;
+  press(ms: number): void;
   /** Point the ship at a world x, and give it time to get there. */
   aim(worldX: number): void;
   canvas(): FakeEl | undefined;
@@ -289,6 +290,16 @@ function makeSurface(): {
     key(k: string): void {
       fireWindow("keydown", { key: k, repeat: false });
       fireWindow("keyup", { key: k });
+    },
+    /** A finger, down and up, held for `ms` and never moving. */
+    press(ms: number): void {
+      const c = canvas();
+      assert.ok(c, "the game mounted no canvas");
+      c.fire("pointerdown", { pointerId: 3, pointerType: "touch", clientX: WIDTH / 2, clientY: 500 });
+      clock += ms;
+      // On the WINDOW, which is where `attachInput` listens for a release — a
+      // finger that leaves the canvas mid-gesture still has to end it.
+      fireWindow("pointerup", { pointerId: 3 });
     },
     aim(worldX: number): void {
       // Screen x from world x, through the camera's own arithmetic: the focal
@@ -570,7 +581,10 @@ test("a shell that crosses the line is never reported as an answer", () => {
     // reading and flip the wave in the frame they looked up.
     const wave = r.handle.pacing().wave;
     for (let i = 0; i < 1250; i++) r.surface.step(16);
-    r.surface.key(" ");
+    // A LONG press, not a tap. Every hand on the glass means "I have read it"
+    // while the sum is up — a deliberate press that did nothing there would
+    // leave a child pressing a screen that is asking to be pressed.
+    r.surface.press(700);
     r.surface.frame();
     assert.equal(r.handle.pacing().revealed, false, "a tap did not take the correction down");
     assert.equal(r.handle.pacing().wave, wave, "the wave turned over in the frame the correction came down");
@@ -607,6 +621,97 @@ test("a right answer is still reported, and still clears the wave", () => {
     if (cleared) break;
   }
   assert.ok(cleared, "no lane in wave one could be answered correctly at all");
+});
+
+test("reading time is billed to nobody", () => {
+  // Speed is REWARDED, never enforced — so the reward has to be measured on
+  // time the child could actually have been answering in. `world.time` runs
+  // every animation in the game and cannot stop; it used to be what latency was
+  // measured on, so half a minute of looking at a motionless opening was
+  // reported to the ladder as half a minute of thinking, and `quickness()`
+  // scores anything past twelve seconds at zero. A child who read carefully and
+  // then answered at once came out looking like the slowest in the session.
+  let checked = false;
+  for (const lane of lanes()) {
+    const r = rig();
+    try {
+      begin(r);
+      // Half a minute of a child reading the sum before touching anything.
+      for (let i = 0; i < 1875; i++) r.surface.step(16);
+      r.surface.aim(lane);
+      r.surface.key(" ");
+      pumpUntil(r, () => r.reports.length > 0, 120);
+      const report = r.reports[0];
+      if (!report) continue;
+      assert.ok(
+        report.ms < 8000,
+        `${report.ms}ms was reported for an answer given seconds after a long look`,
+      );
+      assert.ok(report.ms > 0, "the answer clock never ran at all");
+      checked = true;
+    } finally {
+      r.stop();
+    }
+    if (checked) break;
+  }
+  assert.ok(checked, "no lane in wave one produced an answer to measure");
+});
+
+test("a run that ends on a wave nobody answered still shows the sum, then the ledger", () => {
+  // The compound of two new rules. `phaseT` is frozen while a correction is up,
+  // and the game-over screen fades in on `phaseT` — so a run whose LAST life
+  // goes to a wave that ran out used to reach a state where the ledger was
+  // painted at alpha zero over a stopped trench, forever, with the correction
+  // suppressed too. That is the most likely ending for exactly the child this
+  // change is for.
+  const r = rig();
+  try {
+    begin(r);
+    r.surface.aim(EMPTY_LANE);
+    r.surface.key(" ");
+
+    // Let wave after wave run out, dismissing each correction, until the run is
+    // over. Three lives and one second wind.
+    let guard = 0;
+    while (!r.handle.pacing().over && guard++ < 20) {
+      pumpUntil(r, () => r.handle.pacing().revealed || r.handle.pacing().over);
+      if (r.handle.pacing().over) break;
+      for (let i = 0; i < 40; i++) r.surface.step(16);
+      r.surface.key(" ");
+      r.surface.frame();
+    }
+    assert.equal(r.handle.pacing().over, true, "the run never ended");
+    assert.equal(r.reports.length, 0, "a run of waves nobody answered reported something");
+
+    // The sum stands, alone, and the ledger is not painted invisibly behind it.
+    assert.equal(r.handle.pacing().revealed, true, "the last wave taught nothing");
+    const held = r.surface.frame();
+    assert.ok(
+      held.some((op) => op.text.includes("=") && op.style === C.amber),
+      "no completed sum on the screen that ended the run",
+    );
+    assert.ok(
+      !held.some((op) => op.text.includes("THE TRENCH TAKES YOU")),
+      "the ledger was drawn behind the correction, where its fade-in cannot run",
+    );
+
+    // A hand takes it down; only then does the ledger arrive, and it is legible.
+    for (let i = 0; i < 40; i++) r.surface.step(16);
+    r.surface.key(" ");
+    assert.equal(r.handle.pacing().revealed, false, "the correction outlived the hand");
+    let ledger: TextOp[] = [];
+    for (let i = 0; i < 90; i++) ledger = r.surface.frame();
+    assert.ok(
+      ledger.some((op) => op.text.includes("THE TRENCH TAKES YOU")),
+      "the run ended and never said so",
+    );
+    assert.ok(
+      ledger.some((op) => op.text.includes("BEST")),
+      "the run ended and never showed the ledger",
+    );
+  } finally {
+    r.stop();
+  }
 });
 
 test("the gate is where the game says it is", () => {

--- a/dynawalla/games/guilty/src/game/opening.test.ts
+++ b/dynawalla/games/guilty/src/game/opening.test.ts
@@ -1,0 +1,617 @@
+// THE FIRST THIRTY SECONDS.
+//
+// "'guilty' is not a bad concept but I think the auto-fire when sitting is a
+// problem. The first time you jump in, you don't know what is going on but you
+// are blasting all of the wrong things .. the default of just going into the
+// game is that you are just blasting everything, it's all wrong and you don't
+// know what the F is going on. I think maybe you should choose when to shoot,
+// eh?"
+//
+// Three faults compounded into that, and this file is the gate on all three.
+//
+//   1. The gun fired by itself from a standstill, so a child standing still and
+//      reading the trench was answering, repeatedly, wrongly.
+//   2. A miss did `world.descent *= 1.14`, so every one of those answers made
+//      the game faster — the child had less time to work out what was going on
+//      than they had a second earlier.
+//   3. A shell crossing the line was reported to the host as `correct: false`,
+//      a wrong answer from a child who had given none.
+//
+// **Nothing here checks a flag.** Every test below mounts the real `mount()`
+// against a headless surface, drives the real `attachInput` listeners the way a
+// hand does — a pointer move to aim, the space bar to shoot — and pumps the
+// real `requestAnimationFrame` loop. What it then reads is what the host was
+// told, what is painted on the glass, and `pacing()`, which is a reading with
+// no setter beside it: to make the trench move, these tests have to play.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/audioHold.ts";
+import type { Host, Question } from "../contract.ts";
+import { GATE_Y, VIEW_HALF_H } from "../core/config.ts";
+import { C } from "../core/palette.ts";
+import { mount } from "./game.ts";
+
+const WIDTH = 800;
+const HEIGHT = 600;
+
+type Handler = (e: unknown) => void;
+type Report = { questionId: string; correct: boolean; ms: number; answered: string };
+type TextOp = { text: string; style: string };
+
+/* ─────────────────────────────────────────────────────────── the fake glass */
+
+/**
+ * A 2D context that answers everything and remembers the words.
+ *
+ * Only two things about it matter. `measureText` has to be plausible, because
+ * every line a child must read is shrunk to fit through `fitFont` and a zero
+ * width there would silently disable the fitting. And `fillText` is recorded
+ * with the fill style in force at the time, because "the correction is in the
+ * accent colour and never says WRONG" is an assertion about a colour.
+ */
+function recordingContext(): { ctx: CanvasRenderingContext2D; text: TextOp[]; reset(): void } {
+  const text: TextOp[] = [];
+  const store: Record<string, unknown> = {
+    font: "10px sans-serif",
+    fillStyle: "#000",
+    strokeStyle: "#000",
+    globalAlpha: 1,
+    globalCompositeOperation: "source-over",
+    lineWidth: 1,
+    lineCap: "butt",
+    textAlign: "left",
+    textBaseline: "alphabetic",
+    shadowBlur: 0,
+    shadowColor: "#000",
+  };
+  const gradient = { addColorStop: (): void => undefined };
+  const named: Record<string, unknown> = {
+    measureText: (s: string): { width: number } => {
+      const px = Number(/(\d+(?:\.\d+)?)px/.exec(String(store.font))?.[1] ?? 10);
+      return { width: String(s).length * px * 0.56 };
+    },
+    fillText: (s: string): void => {
+      text.push({ text: String(s), style: String(store.fillStyle) });
+    },
+    strokeText: (s: string): void => {
+      text.push({ text: String(s), style: String(store.strokeStyle) });
+    },
+    createLinearGradient: () => gradient,
+    createRadialGradient: () => gradient,
+    createPattern: () => null,
+    getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+  };
+  const ctx = new Proxy(store, {
+    get(target, prop: string) {
+      if (prop in named) return named[prop];
+      if (prop in target) return target[prop];
+      // Anything else is a drawing call this test does not care about.
+      return () => undefined;
+    },
+    set(target, prop: string, value: unknown) {
+      target[prop] = value;
+      return true;
+    },
+  }) as unknown as CanvasRenderingContext2D;
+  return {
+    ctx,
+    text,
+    reset(): void {
+      text.length = 0;
+    },
+  };
+}
+
+type FakeEl = {
+  tag: string;
+  className: string;
+  fire(type: string, event?: Record<string, unknown>): void;
+  [key: string]: unknown;
+};
+
+function makeSurface(): {
+  root: FakeEl;
+  install(): () => void;
+  step(ms: number): void;
+  /** One frame, and every word it painted. */
+  frame(ms?: number): TextOp[];
+  said(needle: string): TextOp | undefined;
+  key(k: string): void;
+  /** Point the ship at a world x, and give it time to get there. */
+  aim(worldX: number): void;
+  canvas(): FakeEl | undefined;
+} {
+  const created: FakeEl[] = [];
+  const rect = { left: 0, top: 0, right: WIDTH, bottom: HEIGHT, width: WIDTH, height: HEIGHT, x: 0, y: 0 };
+  // Each canvas gets its own context: `bake.ts` makes offscreen canvases for
+  // every glyph and glow, and their bake-time `fillText` calls must not land in
+  // the record of what is on the glass.
+  const glassRecord = recordingContext();
+  // The FIRST canvas anyone asks for is the glass — `mount` makes it before it
+  // makes anything else. Counting `created` instead would be wrong, because the
+  // root div and `document.body` are already in there.
+  let glassClaimed = false;
+
+  const makeEl = (tag: string): FakeEl => {
+    const listeners = new Map<string, Handler[]>();
+    let own = recordingContext();
+    if (tag === "canvas" && !glassClaimed) {
+      glassClaimed = true;
+      own = glassRecord;
+    }
+    const el = {
+      tag,
+      style: { setProperty: (): void => undefined, removeProperty: (): void => undefined } as Record<string, unknown>,
+      classList: { add: (): void => undefined, remove: (): void => undefined, toggle: (): void => undefined },
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: 400,
+      appendChild: (c: unknown) => c,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      blur: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => own.ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener(type: string, h: Handler) {
+        listeners.set(type, [...(listeners.get(type) ?? []), h]);
+      },
+      removeEventListener(type: string, h: Handler) {
+        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== h));
+      },
+      fire(type: string, event: Record<string, unknown> = {}) {
+        const full = { preventDefault: () => undefined, stopPropagation: () => undefined, ...event };
+        for (const h of [...(listeners.get(type) ?? [])]) h(full);
+      },
+    } as unknown as FakeEl;
+    created.push(el);
+    return el;
+  };
+
+  const root = makeEl("div");
+  const windowListeners = new Map<string, Handler[]>();
+  let pending: ((t: number) => void) | null = null;
+  let clock = 0;
+
+  const g = globalThis as Record<string, unknown>;
+  const saved: Record<string, unknown> = {};
+
+  const install = (): (() => void) => {
+    for (const k of [
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+      "ResizeObserver",
+      "document",
+      "window",
+      "location",
+      "devicePixelRatio",
+      "performance",
+      "addEventListener",
+      "removeEventListener",
+    ]) {
+      saved[k] = g[k];
+    }
+    g.requestAnimationFrame = (cb: (t: number) => void): number => {
+      pending = cb;
+      return 1;
+    };
+    g.cancelAnimationFrame = (): void => {
+      pending = null;
+    };
+    g.ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    };
+    g.performance = { now: () => clock };
+    g.devicePixelRatio = 2;
+    // Seeded from the query string, not from `Date.now()`: a suite that is
+    // green four runs in five has proved nothing.
+    g.location = { search: "?seed=20260728" };
+    const addWindow = (type: string, h: Handler): void => {
+      windowListeners.set(type, [...(windowListeners.get(type) ?? []), h]);
+    };
+    const removeWindow = (type: string, h: Handler): void => {
+      windowListeners.set(type, (windowListeners.get(type) ?? []).filter((f) => f !== h));
+    };
+    // `input.ts` listens on `window`; `game-chrome` listens on `globalThis`.
+    // One map behind both, so a key sent by this rig reaches whoever asked for
+    // it — and so a listener left behind by either is visible to `detach`.
+    g.addEventListener = addWindow;
+    g.removeEventListener = removeWindow;
+    const fakeWindow = {
+      addEventListener: addWindow,
+      removeEventListener: removeWindow,
+      innerWidth: WIDTH,
+      innerHeight: HEIGHT,
+      devicePixelRatio: 2,
+    };
+    Object.defineProperty(globalThis, "window", { configurable: true, writable: true, value: fakeWindow });
+    g.document = {
+      createElement: (tag: string) => makeEl(tag),
+      getElementById: () => null,
+      body: makeEl("body"),
+      documentElement: makeEl("html"),
+      activeElement: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    };
+    return () => {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) Reflect.deleteProperty(g, k);
+        else g[k] = v;
+      }
+      forgetAudioContexts();
+    };
+  };
+
+  const step = (ms: number): void => {
+    clock += ms;
+    const cb = pending;
+    pending = null;
+    cb?.(clock);
+  };
+
+  const fireWindow = (type: string, event: Record<string, unknown>): void => {
+    const full = { preventDefault: () => undefined, stopPropagation: () => undefined, ...event };
+    for (const h of [...(windowListeners.get(type) ?? [])]) h(full);
+  };
+
+  const canvas = (): FakeEl | undefined => created.find((e) => e.tag === "canvas");
+
+  return {
+    root,
+    install,
+    step,
+    canvas,
+    frame(ms = 16): TextOp[] {
+      glassRecord.reset();
+      step(ms);
+      return [...glassRecord.text];
+    },
+    said(needle: string): TextOp | undefined {
+      return glassRecord.text.find((op) => op.text.includes(needle));
+    },
+    key(k: string): void {
+      fireWindow("keydown", { key: k, repeat: false });
+      fireWindow("keyup", { key: k });
+    },
+    aim(worldX: number): void {
+      // Screen x from world x, through the camera's own arithmetic: the focal
+      // length is fitted to the glass, so this is the pixel a finger would be
+      // over. `pointermove` with a mouse steers with no button held, which is
+      // this game's desktop scheme.
+      const f = (HEIGHT / 2) * (300 / VIEW_HALF_H);
+      const sx = WIDTH / 2 + (worldX * f) / 300;
+      const c = canvas();
+      assert.ok(c, "the game mounted no canvas");
+      c.fire("pointermove", { pointerId: 7, pointerType: "mouse", clientX: sx, clientY: 500 });
+      // The ship is not a teleport. Give it a second of real frames to arrive.
+      for (let i = 0; i < 60; i++) step(16);
+    },
+  };
+}
+
+/* ─────────────────────────────────────────────────────────────── the ladder */
+
+/**
+ * A deterministic host. Fixed items, real mal-rule-shaped distractors, and a
+ * difficulty low enough that `revealPlan` calls for a held reveal — which is
+ * where a child who has just missed actually is.
+ */
+const ITEMS: readonly Question[] = [
+  { id: "g1", prompt: "47 + 25", answer: "72", distractors: ["62", "612", "61"], domain: "add-sub", difficulty: 0.1 },
+  { id: "g2", prompt: "63 − 28", answer: "35", distractors: ["45", "25", "41"], domain: "add-sub", difficulty: 0.1 },
+  { id: "g3", prompt: "34 × 3", answer: "102", distractors: ["92", "912", "97"], domain: "mul", difficulty: 0.1 },
+  { id: "g4", prompt: "56 ÷ 8", answer: "7", distractors: ["6", "8", "9"], domain: "div", difficulty: 0.1 },
+];
+
+function stubHost(reports: Report[]): Host {
+  let i = 0;
+  return {
+    next: () => ITEMS[i++ % ITEMS.length] as Question,
+    report: (r) => {
+      reports.push(r);
+    },
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  };
+}
+
+function rig(): {
+  surface: ReturnType<typeof makeSurface>;
+  handle: ReturnType<typeof mount>;
+  reports: Report[];
+  stop(): void;
+} {
+  const surface = makeSurface();
+  const restore = surface.install();
+  const reports: Report[] = [];
+  const handle = mount(surface.root as unknown as HTMLElement, stubHost(reports));
+  return {
+    surface,
+    handle,
+    reports,
+    stop(): void {
+      handle.unmount();
+      restore();
+    },
+  };
+}
+
+/** Press space on the title, then let the shells fly out and settle. */
+function begin(r: ReturnType<typeof rig>): void {
+  r.surface.step(16);
+  r.surface.key(" ");
+  for (let i = 0; i < 90; i++) r.surface.step(16);
+}
+
+/** The three lanes wave one puts its shells in, in world units. */
+function lanes(): number[] {
+  const worldHalfW = VIEW_HALF_H * (WIDTH / HEIGHT);
+  const playHalfW = Math.max(52, Math.min(168, worldHalfW * 0.84));
+  const spread = playHalfW * 0.82;
+  return [-spread, 0, spread];
+}
+
+/** A world x with no shell anywhere near it. */
+const EMPTY_LANE = -60;
+
+/** Pump frames until `done` or the budget runs out. Returns the frames spent. */
+function pumpUntil(r: ReturnType<typeof rig>, done: () => boolean, frames = 2400): number {
+  for (let i = 0; i < frames; i++) {
+    if (done()) return i;
+    r.surface.frame();
+  }
+  return frames;
+}
+
+/* ──────────────────────────────────────────────────────────────── the tests */
+
+test("a child who only looks is never answered for, never hurried and never wrong", () => {
+  const r = rig();
+  try {
+    begin(r);
+    const opening = r.handle.pacing();
+    assert.equal(opening.armed, false, "the trench armed itself without a shot");
+
+    // Two minutes of a child holding the tablet and reading it. No pointer, no
+    // key, nothing. This is the exact state the founder opened the game in.
+    for (let i = 0; i < 7500; i++) r.surface.step(16);
+    const after = r.handle.pacing();
+
+    assert.equal(r.reports.length, 0, `${r.reports.length} answers were reported for a child who did nothing`);
+    assert.equal(after.descent, opening.descent, "the trench got faster while nobody was playing");
+    assert.equal(after.formationY, opening.formationY, "the shells sank towards the line while nobody was playing");
+    assert.equal(after.lives, opening.lives, "a life was taken from a child who did nothing");
+    assert.equal(after.wave, 1, "the wave turned over on its own");
+    assert.equal(after.over, false, "the run ended while nobody was playing");
+
+    // And the glass says why nothing is happening, and what the game is.
+    const painted = r.surface.frame();
+    const rule = painted.find((op) => op.text.includes("RIGHT ANSWER"));
+    assert.ok(rule, "the trench is waiting and never says what the player is meant to do");
+    assert.ok(
+      painted.some((op) => op.text.includes("TO FIRE")),
+      "the trench is waiting and never says how to fire",
+    );
+    assert.ok(
+      painted.some((op) => op.text.includes("NOTHING MOVES UNTIL YOU DO")),
+      "the trench is waiting and never says that it is waiting",
+    );
+  } finally {
+    r.stop();
+  }
+});
+
+test("the first shot is the player's, and it is what starts the trench", () => {
+  // The counterpart to the test above, and the reason it is not just a game
+  // that never begins: one deliberate shot, at nothing at all, and the trench
+  // starts — without that shot having answered anything.
+  const r = rig();
+  try {
+    begin(r);
+    const before = r.handle.pacing();
+    r.surface.aim(EMPTY_LANE);
+    r.surface.key(" ");
+    for (let i = 0; i < 60; i++) r.surface.step(16);
+    const after = r.handle.pacing();
+
+    assert.equal(after.armed, true, "a deliberate shot did not start the trench");
+    assert.ok(
+      after.formationY < before.formationY - 1,
+      `the shells never began to sink (${before.formationY} -> ${after.formationY})`,
+    );
+    assert.equal(r.reports.length, 0, "a shot that hit nothing was reported as an answer");
+    assert.equal(after.descent, before.descent, "arming the trench also made it faster");
+  } finally {
+    r.stop();
+  }
+});
+
+/**
+ * Play until an innocent shell has been shot.
+ *
+ * Which lane holds the truth is decided by a shuffle seeded from the item's id,
+ * and reproducing that here would be a second copy of it that could drift. At
+ * most one of the three lanes is the right answer, so trying two of them finds
+ * a wrong one — and the second attempt gets a fresh rig, because a right answer
+ * clears the wave and there would be nothing left to measure.
+ */
+function rigAfterWrongShot(): { r: ReturnType<typeof rig>; descentBefore: number } {
+  const order = [0, 1];
+  for (const lane of order) {
+    const r = rig();
+    begin(r);
+    r.surface.aim(lanes()[lane] as number);
+    // Read the speed of the trench BEFORE the trigger is pulled. Reading it
+    // after would make the whole assertion vacuous — `descent *= 1.14` ran on
+    // the miss itself, so a "before" sampled once the correction was already up
+    // is a "before" that has the escalation baked into it. It did, and this
+    // comment is here because a mutation caught it.
+    const descentBefore = r.handle.pacing().descent;
+    r.surface.key(" ");
+    pumpUntil(r, () => r.reports.length > 0, 120);
+    const report = r.reports[0];
+    assert.ok(report, `a shot down lane ${lane} hit nothing at all`);
+    if (!report.correct) return { r, descentBefore };
+    r.stop();
+  }
+  throw new Error("two different lanes were both the right answer");
+}
+
+test("a wrong answer never speeds the trench up, and nothing moves while the correction is up", () => {
+  const { r, descentBefore } = rigAfterWrongShot();
+  try {
+    const report = r.reports[0] as Report;
+    assert.equal(report.correct, false);
+    assert.notEqual(report.answered, "", "a wrong answer was reported with nothing answered");
+
+    const hit = r.handle.pacing();
+    assert.equal(hit.revealed, true, "a miss did not put the completed sum on the glass");
+
+    // THE ESCALATION THAT IS GONE. `world.descent *= 1.14` used to run on this
+    // exact path, so the game got faster because the child got it wrong — and
+    // it did it while the correction was on screen, so the child had less time
+    // to work out what had happened than they had a second earlier.
+    assert.equal(
+      hit.descent,
+      descentBefore,
+      `a wrong answer made the trench faster (${descentBefore} -> ${hit.descent})`,
+    );
+
+    const item = ITEMS.find((q) => q.id === report.questionId) as Question;
+    assert.ok(item, "the report named a question the host never asked");
+
+    // Half a minute of the child reading the correction. In a game with a timer
+    // on the reveal this would be five reveals ago.
+    const before = r.handle.pacing();
+    for (let i = 0; i < 1875; i++) r.surface.step(16);
+    const after = r.handle.pacing();
+    assert.equal(after.descent, before.descent, "the trench sped up while the correction was being read");
+    assert.equal(after.formationY, before.formationY, "the shells sank while the correction was being read");
+    assert.equal(after.lives, before.lives, "a life was lost while the correction was being read");
+    assert.equal(after.wave, before.wave, "the wave turned over while the correction was being read");
+    assert.equal(after.revealed, true, "the correction took itself down on a timer");
+    assert.equal(r.reports.length, 1, "the held correction reported something else on its own");
+
+    // The completed sum, in the accent colour, and nowhere the word WRONG.
+    const painted = r.surface.frame();
+    const line = painted.find((op) => op.text === `${item.prompt} = ${item.answer}`);
+    assert.ok(line, `the completed sum "${item.prompt} = ${item.answer}" is not on the glass`);
+    assert.equal(line.style, C.amber, "the completed sum is not in the accent colour");
+    assert.notEqual(line.style, C.hostile, "the completed sum is in the red used for hostiles");
+    for (const op of painted) {
+      assert.ok(!/WRONG|INCORRECT/i.test(op.text), `the glass says "${op.text}"`);
+    }
+
+    // A hand takes it down, and only then does the trench start again.
+    r.surface.key(" ");
+    r.surface.frame();
+    assert.equal(r.handle.pacing().revealed, false, "a tap did not take the correction down");
+    const resumedFrom = r.handle.pacing();
+    for (let i = 0; i < 60; i++) r.surface.step(16);
+    assert.ok(
+      r.handle.pacing().formationY < resumedFrom.formationY - 1,
+      "the trench never started again after the correction",
+    );
+  } finally {
+    r.stop();
+  }
+});
+
+test("a shell that crosses the line is never reported as an answer", () => {
+  // A timeout is not an answer. It used to be sent to the host as
+  // `correct: false` with an empty `answered` — a wrong answer from a child who
+  // had not given one. There is no `skip` on this game's Host, so the honest
+  // thing is silence: the item is closed, the ladder never sees it, and the run
+  // still pays a life for it.
+  const r = rig();
+  try {
+    begin(r);
+    r.surface.aim(EMPTY_LANE);
+    r.surface.key(" ");
+    assert.equal(r.handle.pacing().armed, true, "the arming shot did not arm the trench");
+
+    const lives = r.handle.pacing().lives;
+    const spent = pumpUntil(r, () => r.handle.pacing().lives < lives);
+    assert.ok(spent < 2400, "no shell ever reached the line");
+
+    assert.equal(
+      r.reports.length,
+      0,
+      `a wave nobody answered was reported: ${JSON.stringify(r.reports)}`,
+    );
+    // And it still teaches: the sum finishes itself, held, exactly as a miss does.
+    assert.equal(r.handle.pacing().revealed, true, "a wave that ran out taught nothing");
+    const painted = r.surface.frame();
+    assert.ok(
+      painted.some((op) => op.text.includes("=") && op.style === C.amber),
+      "no completed sum was drawn after a shell crossed the line",
+    );
+
+    // Twenty seconds of reading it, and then a hand. The beat that turns the
+    // wave over starts from the hand, not from the breach — a phase timer that
+    // ran behind the correction would spend the whole beat while the child was
+    // reading and flip the wave in the frame they looked up.
+    const wave = r.handle.pacing().wave;
+    for (let i = 0; i < 1250; i++) r.surface.step(16);
+    r.surface.key(" ");
+    r.surface.frame();
+    assert.equal(r.handle.pacing().revealed, false, "a tap did not take the correction down");
+    assert.equal(r.handle.pacing().wave, wave, "the wave turned over in the frame the correction came down");
+    pumpUntil(r, () => r.handle.pacing().wave > wave, 240);
+    assert.equal(r.handle.pacing().wave, wave + 1, "the wave never turned over after the correction");
+    assert.equal(r.reports.length, 0, "the abandoned wave was reported after all");
+  } finally {
+    r.stop();
+  }
+});
+
+test("a right answer is still reported, and still clears the wave", () => {
+  // The gate stuck shut is the same bug in a hat. A game nobody can answer
+  // would pass every test above.
+  let cleared = false;
+  for (const lane of lanes()) {
+    const r = rig();
+    try {
+      begin(r);
+      r.surface.aim(lane);
+      r.surface.key(" ");
+      pumpUntil(r, () => r.reports.length > 0, 120);
+      const report = r.reports[0];
+      if (!report || !report.correct) continue;
+      assert.equal(report.answered, "72", "a right answer reported something other than the answer");
+      assert.ok(report.ms > 0, "a right answer was reported with no time on it");
+      // The wave turns over on its own beat once the truth is destroyed.
+      pumpUntil(r, () => r.handle.pacing().wave > 1, 240);
+      assert.equal(r.handle.pacing().wave, 2, "a cleared wave never turned over");
+      cleared = true;
+    } finally {
+      r.stop();
+    }
+    if (cleared) break;
+  }
+  assert.ok(cleared, "no lane in wave one could be answered correctly at all");
+});
+
+test("the gate is where the game says it is", () => {
+  // A guard on the two constants the tests above reason about. If the gate ever
+  // moves above the formation's birthplace, "nothing sank" and "a shell crossed
+  // the line" both stop meaning what they say here.
+  assert.ok(GATE_Y < VIEW_HALF_H - 26 - 62, "the gate is no longer below the formation");
+});

--- a/dynawalla/games/guilty/src/game/ship.ts
+++ b/dynawalla/games/guilty/src/game/ship.ts
@@ -3,10 +3,15 @@
  *
  * The sight line is the single most important piece of interface in the game
  * and it is not text: a thin beam runs from the nose to whatever the next shot
- * will hit, and brackets close around that husk. The gun fires on its own, so
- * the player's whole job is *where to stand* — and the beam means they always
- * know, exactly, which number they are about to destroy. Shooting an innocent
- * is then a decision, never an accident, which is what earns the punishment.
+ * will hit, and brackets close around that husk. It is always drawn, from the
+ * first frame of a run, so a child can stand still and read the beam and the
+ * numbers for as long as they like before anything happens at all.
+ *
+ * **The gun does not fire by itself.** It used to, from a standstill, which
+ * made the first thirty seconds of this game a burst of answers nobody chose to
+ * give. Now `tryFire` is called by a tap, a click or the space bar and by
+ * nothing else, and `FIRE_INTERVAL` is only a rate limit on how fast the player
+ * may ask.
  */
 
 import { project } from "../core/camera.ts";
@@ -65,20 +70,13 @@ export function updateShip(world: World, dt: number, realDt: number): void {
 
   if (!ship.alive) return;
 
-  // Settle gate. Cross the field freely; the gun wakes when you stop.
+  // Steadiness, as a readout and nothing more: the sight brightens and the
+  // brackets close as the ship comes to rest. It does not fire anything.
   const moving = Math.abs(ship.vx) > FIRE_SPEED_GATE;
   const was = ship.settled;
   ship.settled = moving ? 0 : Math.min(1, ship.settled + realDt / 0.11);
   if (was < 1 && ship.settled >= 1) world.audio.lock();
-  if (moving) {
-    ship.fireCd = Math.max(ship.fireCd, 0.05);
-  } else if (ship.settled >= 1) {
-    ship.fireCd -= realDt;
-    if (ship.fireCd <= 0) {
-      ship.fireCd += FIRE_INTERVAL;
-      fire(world);
-    }
-  }
+  ship.fireCd = Math.max(0, ship.fireCd - realDt);
 
   // Thruster wake, on world time so it stretches beautifully in slow motion.
   if (world.rng.nextFloat() < dt * 62) {
@@ -91,6 +89,22 @@ export function updateShip(world: World, dt: number, realDt: number): void {
       drag: 5,
     });
   }
+}
+
+/**
+ * The player asked for a shot. Returns true if one left the nose.
+ *
+ * The only path to a bullet. It refuses only while the gun is on its cooldown
+ * or the ship is gone — never because the ship is moving, because a tap the
+ * game silently swallows is exactly as confusing as a shot the child never
+ * asked for.
+ */
+export function tryFire(world: World): boolean {
+  const ship = world.ship;
+  if (!ship.alive || ship.fireCd > 0) return false;
+  ship.fireCd = FIRE_INTERVAL;
+  fire(world);
+  return true;
 }
 
 function fire(world: World): void {
@@ -162,7 +176,10 @@ export function drawSight(world: World, target: Husk | null): void {
   const ax = a.x;
   const ay = a.y;
   const b = project(cam, ship.x, topY, 0);
-  const ready = ship.settled;
+  // Never fully dark. The beam is the answer to "which number will this tap
+  // destroy", and that question is asked hardest by a child who has not decided
+  // to shoot yet — so it is legible while crossing and blazing once settled.
+  const ready = 0.45 + ship.settled * 0.55;
   const locked = target !== null;
   batch.push(
     ax,

--- a/dynawalla/games/guilty/src/game/waves.ts
+++ b/dynawalla/games/guilty/src/game/waves.ts
@@ -48,10 +48,17 @@ export function specFor(wave: number): WaveSpec {
   };
 }
 
-/** The banner a wave earns, if any. Empty means no banner at all. */
+/**
+ * The banner a wave earns, if any. Empty means no banner at all.
+ *
+ * Every invented name here is defined on the line under it. THE ARBITER and
+ * SHUT SHELLS were explained only in the how-to-play sheet, which is the one
+ * place a child in the middle of a wave is not looking — and "IT ONLY BREAKS TO
+ * THE TRUTH" explained a name with a riddle rather than with a rule.
+ */
 export function bannerFor(wave: number): [string, string] {
-  if (wave % BOSS_EVERY === 0) return ["THE ARBITER", "IT ONLY BREAKS TO THE TRUTH"];
-  if (wave === 12) return ["SHUT SHELLS", ""];
+  if (wave % BOSS_EVERY === 0) return ["THE ARBITER", "ONLY THE RIGHT ANSWER BREAKS ITS SHIELD"];
+  if (wave === 12) return ["SHUT SHELLS", "THE NUMBERS SHOW ONCE THE SHELLS OPEN"];
   if (wave % 25 === 0) return [`WAVE ${wave}`, ""];
   return ["", ""];
 }

--- a/dynawalla/games/guilty/src/game/world.ts
+++ b/dynawalla/games/guilty/src/game/world.ts
@@ -18,8 +18,8 @@ import { MAX_BULLETS, MAX_HUSKS, MAX_PARTICLES } from "../core/config.ts";
 import type { HudLayout } from "./hudLayout.ts";
 
 /*
- * The three enumerations below are frozen objects with a companion type rather
- * than `const enum`s.
+ * The three enumerations below are `as const` objects with a companion type
+ * rather than `const enum`s.
  *
  * `const enum` needs a compiler to erase it, and this package's tests run under
  * Node's strip-only TypeScript, which refuses one outright — so a `const enum`
@@ -27,6 +27,12 @@ import type { HudLayout } from "./hudLayout.ts";
  * `game.ts` is exactly that import graph, and the opening of this game is the
  * thing most worth a test. The values are unchanged and every `Mode.Dying`
  * still reads the same at every call site.
+ *
+ * **What is lost, honestly.** A `const enum` is nominal; these are structural,
+ * so `Mode` and `Phase` are both `0|1|2|3|4|5` to the checker and it would no
+ * longer object to `world.phase = Mode.Dying`. No call site crosses them today.
+ * They are also not `Object.freeze`d — `as const` is a compile-time promise, so
+ * `Mode.Dying = 9` is a type error and not a runtime one.
  */
 
 export const Mode = {
@@ -215,7 +221,28 @@ export type World = {
   focusT: number;
 
   question: Question | null;
+  /** Wall time the question was asked. Drives its entrance animation ONLY. */
   askedAt: number;
+
+  /**
+   * The only clock a child's answer is ever measured against.
+   *
+   * It advances when — and only when — the player could actually be acting on
+   * the question in front of them: the run is in a wave, the trench is armed,
+   * and no correction is being held. So the seconds spent looking at a
+   * motionless opening, and the seconds spent reading a completed sum, are
+   * billed to nobody.
+   *
+   * `world.time` cannot do this job: it drives every animation in the game and
+   * has to keep running through both. Measuring latency on it made a child who
+   * read carefully for thirty seconds and then answered in two look, to the
+   * host's ladder and to this game's own speed bonus, like the slowest answer
+   * in the session — which is the exact inversion of "speed is REWARDED, never
+   * enforced".
+   */
+  answerClock: number;
+  /** `answerClock` when the current question was asked. */
+  answeredFrom: number;
   firstWrong: string | null;
   resolved: boolean;
   perfectWave: boolean;

--- a/dynawalla/games/guilty/src/game/world.ts
+++ b/dynawalla/games/guilty/src/game/world.ts
@@ -17,15 +17,28 @@ import type { Rng } from "../math/rng.ts";
 import { MAX_BULLETS, MAX_HUSKS, MAX_PARTICLES } from "../core/config.ts";
 import type { HudLayout } from "./hudLayout.ts";
 
-export const enum Mode {
-  Entering = 0,
-  Formation = 1,
-  Hostile = 2,
-  Dying = 3,
-  Orbit = 4,
+/*
+ * The three enumerations below are frozen objects with a companion type rather
+ * than `const enum`s.
+ *
+ * `const enum` needs a compiler to erase it, and this package's tests run under
+ * Node's strip-only TypeScript, which refuses one outright — so a `const enum`
+ * anywhere in the import graph makes the game itself untestable in process.
+ * `game.ts` is exactly that import graph, and the opening of this game is the
+ * thing most worth a test. The values are unchanged and every `Mode.Dying`
+ * still reads the same at every call site.
+ */
+
+export const Mode = {
+  Entering: 0,
+  Formation: 1,
+  Hostile: 2,
+  Dying: 3,
+  Orbit: 4,
   /** Attract mode only: sinks on its own, hurts nobody. */
-  Drift = 5,
-}
+  Drift: 5,
+} as const;
+export type Mode = (typeof Mode)[keyof typeof Mode];
 
 export type Husk = {
   active: boolean;
@@ -72,11 +85,12 @@ export type Bullet = {
   prevY: number;
 };
 
-export const enum PKind {
-  Spark = 0,
-  Shard = 1,
-  Ember = 2,
-}
+export const PKind = {
+  Spark: 0,
+  Shard: 1,
+  Ember: 2,
+} as const;
+export type PKind = (typeof PKind)[keyof typeof PKind];
 
 export type Particle = {
   active: boolean;
@@ -121,23 +135,26 @@ export type Ship = {
   alive: boolean;
   muzzle: number;
   /**
-   * The gun only fires from a standstill. That is the rule that makes a
-   * fixed-position shooter with auto-fire *fair*: crossing the field to reach
-   * the guilty number can never cost you an innocent, because you are not
-   * shooting while you cross. It also gives the loop its rhythm — dash, settle,
-   * fire — and it is taught entirely by the nose lighting up.
+   * 0 while crossing the field, 1 once the ship has come to rest.
+   *
+   * It no longer gates anything. It used to BE the trigger — the gun fired by
+   * itself from a standstill — and that is the whole reason a child who had
+   * just opened the game was answering questions they had not chosen to answer.
+   * What survives is the readout: the sight brightens and the brackets close as
+   * the ship settles, so "my aim is steady" is still a shape on the glass.
    */
   settled: number;
 };
 
-export const enum Phase {
-  Title = 0,
-  Wave = 1,
-  Clear = 2,
-  Breach = 3,
-  SecondWind = 4,
-  Over = 5,
-}
+export const Phase = {
+  Title: 0,
+  Wave: 1,
+  Clear: 2,
+  Breach: 3,
+  SecondWind: 4,
+  Over: 5,
+} as const;
+export type Phase = (typeof Phase)[keyof typeof Phase];
 
 export type Boss = {
   active: boolean;
@@ -202,6 +219,37 @@ export type World = {
   firstWrong: string | null;
   resolved: boolean;
   perfectWave: boolean;
+
+  /**
+   * False from the moment a run begins until the player's FIRST shot.
+   *
+   * While it is false the formation hangs where it was born and the trench
+   * costs nothing at all. "The first time you jump in, you don't know what is
+   * going on" — so the opening state of this game is *looking*, and the child
+   * decides when it turns into playing. It is set by firing and by nothing
+   * else, so a child who never touches the glass is never scored, never
+   * hurried, and never wrong.
+   */
+  armed: boolean;
+
+  /**
+   * The completed sum, standing still, with no deadline on it.
+   *
+   * Raised on a miss and on a shell that crossed the line, never on a clean
+   * answer — there is nothing to marinate on in a sum you just got right.
+   * While it is up NOTHING in the trench advances: no descent, no swing, no
+   * bullets, no collisions, no phase timer. It is taken down by the child's own
+   * hand and by nothing else, which is `revealPlan`'s `holdMs: Infinity`.
+   */
+  revealPrompt: string | null;
+  revealAnswer: string | null;
+  /** Seconds left before the child's own input may take the reveal down. */
+  revealSettle: number;
+  /** Seconds the reveal has been up. Drives its fade-in only. */
+  revealAge: number;
+
+  /** One-shot: has this run already explained Deep Focus? */
+  taughtFocus: boolean;
   /** Formation descent, world units per second. */
   descent: number;
   swingAmp: number;


### PR DESCRIPTION
> "'guilty' is not a bad concept but I think the auto-fire when sitting is a problem. The first time you jump in, you don't know what is going on but you are blasting all of the wrong things .. the default of just going into the game is that you are just blasting everything, it's all wrong and you don't know what the F is going on. I think maybe you should choose when to shoot, eh?"

Three faults compounded into that opening. Auto-fire produced answers the child never chose to give; each wrong answer made the game **faster**; and a wave that ran out was reported as a wrong answer nobody had given. All three are gone.

## Firing is now deliberate

The gun fired on a 155 ms timer whenever the ship was standing still, so standing still and reading the trench **was** answering — repeatedly, wrongly. `tryFire` is now the only path to a bullet and it is called by a hand:

| | shoot | Deep Focus | steer |
|---|---|---|---|
| touch | tap (still, under 430 ms) | still press ≥ 430 ms | drag anywhere |
| mouse | click | press and hold | move, no button |
| keyboard | **space** | **F** | arrows / A / D |

`FIRE_INTERVAL` survives as a rate limit on how fast the player may *ask*. The tap that begins a run is swallowed so it cannot also answer the first question — the same defect in a smaller hat. The sight line, which answers "which number will this shot destroy", is now drawn from the first frame instead of only once the ship had settled: it is most needed by a child who has not decided to shoot yet. One threshold splits tap from hold, not two, because two left a silent dead zone in between.

## Nothing escalates because a child was wrong

`world.descent *= 1.14` ran on the miss path — the trench got faster *because* the child got it wrong, and it did it while the correction was on screen. Gone, along with the boss's three-bolt punishment volley. A miss instead completes the sum in the accent colour, held, and the whole trench stops behind it: no descent, no swing, no bullets, no husks, no boss, no collisions, no phase timer.

`revealPlan(SECOND_GRADE_FLOW, …)` from `packs/shared/game-pacing` decides whether the reveal is worth showing at all — the intensity it is asked about is the difficulty the host is currently serving, which is exactly the adaptive signal here since the ladder walks up on clean answers and drops on a miss. When it is shown, `holdMs` is `Infinity` and only a hand takes it down (with `REVEAL_SETTLE_MS` in front, because the tap that ended the question is routinely still arriving). No timer was written.

## The opening waits

From the first frame of a run until the player's first shot, `world.armed` is false: the formation hangs where it was born, nothing sinks, nothing can be lost, and the glass states the rule. The natural first state is *looking*, and the child decides when it turns into playing.

## Timeouts

**Chosen: report nothing at all.** A shell crossing the line used to send `correct: false` with an empty `answered`. It now reports neither an answer nor a skip:

- not `report`, because a timeout is not a wrong answer — that is the binding rule;
- not `skip`, because the runtime host's `skip` closes an item **without advancing session progress**, which is its own trap (it bit LATTICE in #739 and had to be reverted). This game's `contract.ts` copy of `Host` does not have `skip` at all, so reaching for it would mean widening the contract to adopt a call whose progress semantics are still a live problem elsewhere.

The cost of silence is that the session does not advance for an item nobody attempted, and the item stays open in the host's `served` map. It is bounded — three lives and one second wind, so an idle player reaches the game-over screen rather than looping — and with `armed` in front of it a child who is only looking never reaches the path at all. A wave that ran out still completes the sum on the glass, held: it is the most useful moment in the game to be shown the answer.

## The game now explains itself before it judges

The word GUILTY is an inversion — the guilty shell is the one telling the **truth** — and the game stated that nowhere a player would find it.

- **Title screen**: `SHOOT THE SHELL WITH THE RIGHT ANSWER ON IT`, before anything can cost anything.
- **The opening hold**: `THE GUILTY SHELL IS THE ONE WITH THE RIGHT ANSWER` / `SHOOT IT` / `TAP TO FIRE` / `NOTHING MOVES UNTIL YOU DO`.
- **THE ARBITER** — was "IT ONLY BREAKS TO THE TRUTH", a riddle explaining a name. Now `ONLY THE RIGHT ANSWER BREAKS ITS SHIELD`.
- **SHUT SHELLS** — had no subtitle at all. Now `THE NUMBERS SHOW ONCE THE SHELLS OPEN`.
- **ONE MORE** — two words in a red pulse is a threat. Now `GET THIS ONE RIGHT AND YOU KEEP GOING`.
- **DEEP FOCUS** — never named on screen; a power nobody knows the gesture for is not a power. Banner the first time the bar fills in a run.

The how-to-play sheet matches the new controls and says that a miss never makes the trench faster.

## Adversarial pass

Three further defects, all in seams this change opened, fixed in the second commit:

1. **The game-over screen could render permanently invisible.** `phaseT` is frozen while a correction is up and `drawGameOver` fades in on `phaseT` — so a run whose *last* life went to an unanswered wave painted the whole ledger at alpha zero, forever, over a stopped trench, with the correction suppressed too. That is the likeliest ending for exactly the child this change is for. The sum now stands alone first, `begin()` refuses while a reveal is up, and the ledger arrives when a hand takes the sum down.
2. **Reading time was billed as thinking time.** Latency was measured on `world.time`, which cannot stop — so a long look at a motionless opening, or at a held correction, was reported to the ladder as thinking, and `quickness()` scores anything past twelve seconds at zero. `world.answerClock` now runs on precisely the condition the trench moves on.
3. **The 230–430 ms dead zone** described above.

## Verification

`src/game/opening.test.ts` mounts the real `mount()` against a headless surface, drives the real `attachInput` listeners the way a hand does, and pumps the real rAF loop. It reads what the host was told, what is painted on the glass, and `pacing()` — a reading with no setter beside it, so to make the trench move the tests have to play.

- two minutes of a child touching nothing: nothing reported, nothing lost, `descent` and `formationY` unchanged, and the rule on screen;
- one deliberate shot at nothing arms the trench and reports nothing;
- a wrong shot does not raise `descent` (sampled **before** the trigger — sampling after made the assertion vacuous, and a mutation caught it);
- thirty seconds behind a held correction advances nothing and reports nothing; a hand takes it down and only then does the trench start again;
- a shell crossing the line is never reported; the wave turns over on the beat *after* the hand, not the beat that ran while the child was reading;
- an answer given seconds after a long look is reported as seconds;
- a run ending on an unanswered wave shows the sum, then a legible ledger;
- a right answer is still reported and still clears the wave — a permanently jammed gun would otherwise pass everything above.

Every new assertion was mutation-tested: 22 mutations, each confirmed to produce a specific failure, then restored. Two mutations (a vacuous `descent` sample, an unasserted phase-timer gate; later a third, the dead zone) survived on the first pass and the tests were strengthened until they did not.

`world.ts`'s three `const enum`s became `as const` objects — a `const enum` anywhere in the import graph makes `game.ts` unloadable under Node's strip-only TypeScript, so the game could not be tested in process at all. Values unchanged; what the nominal typing cost is written down beside them.

**Gates:** `npm run -s tsc` clean; `npm run -s test` 50/50, five consecutive runs; `node packs/build.mjs guilty` builds and passes the SDK checker. `pack.json` untouched — `items`, `items.reveal` and `haptics` were already declared and `revealPlan` only places the answer, never judges it.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb