### PR TITLE
dynawalla/games/lattice: the first screen is ONE number, and the field says which ones divide

### DIFF
--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -187,6 +187,83 @@ no extra wiring.
 
 ---
 
+## The opening, and why the first screen is one number
+
+The founder's report is the specification:
+
+> Lattice runner is pretty cool but it's too hard and fast for a human .. maybe
+> one number at a time and a slower ramp up from an easier baseline .. first
+> time you enter it could be just one number calmly coming down the lattice.
+> Maybe it even highlights/hints when it is blastable and why. It needs to be a
+> bit more hand-holdy on the first run. slower, easier, more hand-holdy. the way
+> it starts for me now is chaotic and impossible.
+
+### What it opened with, measured
+
+Driving the real `Arena` against the stub host at three viewports over sixty
+seeds, at the rung a brand new profile actually starts on:
+
+| | at t=0 | fully ground down | fastest thing on the field |
+|---|---|---|---|
+| **as it shipped** | up to **6** numbers | up to **9** | **10.4%** of the arena's diagonal a second |
+| **a first sitting now** | **1** | up to **5** | **3.0%** |
+
+Four to six numbers, every one of them already moving, all of which the child is
+expected to read and sort into "shoot this one" and "collect that one", on the
+first screen they have ever seen. That is the "chaotic and impossible", and it
+was not a difficulty setting — it was the whole field arriving at once.
+
+### The ramp
+
+Six positions, indexed by how many resonators this child has ever opened.
+`game/seen.ts` remembers that across sittings, so a child coming back to their
+fifth ring is not walked through the first one again.
+
+| step | numbers at t=0 | ground down | drift | guided |
+|---|---|---|---|---|
+| 0 | 1 | 5 | 3.0% | yes |
+| 1 | 1 | 5 | 4.5% | yes |
+| 2 | 3 | 6 | 6.3% | yes |
+| 3 | 5 | 7 | 7.5% | yes |
+| 4 | 6 | 8 | 9.8% | no |
+| 5+ | 6 | 9 | 10.4% | no |
+
+Step 5 is the shipped game, unchanged. Every quantity is monotone
+non-decreasing in the step and the guidance is monotone non-increasing;
+`opening.test.ts` asserts both rather than taking the table on trust.
+
+Nothing here is a window, a timer or a deadline. THE LATTICE has never had one
+and this does not add one — `openingAt` reads one integer and that integer counts
+rings the child *finished*.
+
+### The first field carries the answer, and that is on purpose
+
+At steps 0 and 1 the whole factorisation is gathered into **one** husk, so the
+numeral on that stone is the target. The first screen teaches the *mechanic* —
+shoot it, it becomes two, collect the lit ones, fly into the ring — not the
+arithmetic. Because the answer is on the field, `arena.enter` treats the round
+exactly as `hint.ts` treats a tree that stated the answer: the host still hears
+the outcome, so the progress bar still moves, and the arena does **not** climb
+its own ladder.
+
+## Which one goes in, and why
+
+`game/live.ts`. Take the target, take out what the hold already carries, and
+what remains is a number. A lit mote belongs in the hold **iff it divides that
+number**; a stone husk is worth shooting **iff it shares a factor with it**.
+
+While the opening is guided, the field says so. A mote that goes in wears a
+celestial collar and states the reason underneath it as arithmetic — `18÷3` —
+and a stone with a piece of the answer inside it wears a brass one. A `spare` is
+drawn exactly as it always was: nothing is crossed out, dimmed or marked wrong,
+because half the point is that the contrast does the teaching.
+
+**This is not the factor tree.** The tree says *how to factor the target* and
+unfolds on a clock the child can outrun; this says *which of the numbers in front
+of you right now is live*. A child can have the whole tree up and still not know
+whether the 13 drifting past is one of theirs. What the two share is the rule
+above: a round the game guided does not climb the arena's ladder.
+
 ## The hint, and why it is a factor tree
 
 The founder's report is the specification:
@@ -522,7 +599,7 @@ src/
 ## Tests
 
 ```
-npm test        181 tests
+npm test        207 tests
 npm run tsc     0 errors
 npm run build   the library build
 npm run build:pack   the pack build → dist-pack/
@@ -530,6 +607,24 @@ npm run build:pack   the pack build → dist-pack/
 
 The ones that matter:
 
+* `opening.test.ts` — **the calm opening, as a measurement.** The real `Arena`
+  is armed at every step of the ramp, at three viewports, over sixty seeds, and
+  what the child is looking at is counted: numbers on the screen at t=0, numbers
+  once that field has been shot all the way down to primes, and the fastest
+  thing on it as a fraction of the arena's own diagonal. Then a minute of a child
+  who is just *looking* at it, sampled every second, and a husk knocked down to a
+  crawl to check that the band's floor came down with its ceiling. Also: the table
+  is monotone in both directions, `gather` conserves the product over four
+  thousand fuzzed cases, and a round the opening guided does not climb the
+  arena's ladder — counted at `Ladder.opened` itself, because reading the ladder's
+  *position* would have passed with the rule deleted.
+* `live.test.ts` — **the marking may not lie.** Checked at three levels: against
+  an independent trial-division oracle over roughly a million (target, hold,
+  value) triples, exactly the divisors and no more; through the real `Arena`, by
+  a child who does exactly what the marking says and nothing else and opens the
+  ring on thirty seeds; and through the real `Scene.draw` against a context that
+  records instead of paints, where the collars on the field must be one per
+  marked number and not one more.
 * `hint.test.ts` — **the tree may not lie.** The generator is checked as a
   property, not by example: every whole number from 12 to 999, on twelve seeds,
   every node the exact product of its two children, every leaf prime, and the

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -38,6 +38,8 @@ import {
   stageCount,
 } from "./hint.ts"
 import { CEILING, FLOOR, Ladder, rungOf } from "./ladder.ts"
+import { markField, remainingOf, type Mark } from "./live.ts"
+import { gather, openingAt, type Opening } from "./opening.ts"
 import { factorTree, placeTree, type Placed } from "./tree.ts"
 import {
   isAskable,
@@ -255,7 +257,22 @@ export type ArenaEvent =
   | { kind: "hint"; at: Vec; stage: number; stages: number }
   | { kind: "stalled" }
 
-export type ArenaOptions = { width: number; height: number; domain?: string }
+export type ArenaOptions = {
+  width: number
+  height: number
+  domain?: string
+  /**
+   * How many resonators this child has opened **before this sitting**.
+   *
+   * REQUIRED, and deliberately not defaulted. The whole of `game/opening.ts`
+   * hangs off it, and a default would mean a shell that never wired it still
+   * compiled and quietly shipped either the chaotic opening the founder
+   * reported or the calm one to a child who has played for a month — with
+   * nothing failing anywhere and no way to notice from inside the canvas.
+   * `render/scene.ts` makes the same argument about its `hint` argument.
+   */
+  experience: number
+}
 
 export class Arena {
   readonly bank = new Bank()
@@ -335,6 +352,31 @@ export class Arena {
   private hintCache: { stage: number; state: HintState } | null = null
   /** The domain label the resonator's questions are drawn under. */
   private readonly domain: string
+  /** Resonators opened before this sitting. See `ArenaOptions.experience`. */
+  private readonly experience: number
+  /**
+   * The drift band this field was seeded with, as a fraction of the ordinary
+   * one. Latched at `arm` rather than read per frame, so the field keeps its
+   * character for the whole of the question it was stocked for.
+   *
+   * It is applied to the band in `step` as well as to the velocities at spawn,
+   * and that second half is the one that is easy to miss: `step` *accelerates*
+   * anything drifting below `DRIFT_MIN_SPAN`, so a husk seeded at three tenths
+   * of the pace would have been wound back up to full speed inside a second and
+   * the calm opening would have been calm for exactly one frame.
+   */
+  private driftScale = 1
+  /**
+   * Does the field, as seeded, hand the answer over?
+   *
+   * True at the very start of a child's first sitting, where the whole
+   * factorisation is gathered into one husk and the numeral on that stone IS
+   * the target. That is the point of the first screen — it teaches the
+   * mechanic, not the arithmetic — and it is treated exactly as `hint.ts`
+   * treats a tree that stated the answer: the host still hears the outcome, so
+   * the progress bar still moves, and the arena does not climb its own ladder.
+   */
+  private givenByField = false
 
   private readonly host: Host
   private readonly rng: Rng
@@ -343,6 +385,9 @@ export class Arena {
     this.host = host
     this.rng = rng
     this.domain = options.domain ?? "add"
+    this.experience = Number.isFinite(options.experience)
+      ? Math.max(0, Math.floor(options.experience))
+      : 0
     this.width = Math.max(320, Number.isFinite(options.width) ? options.width : 320)
     this.height = Math.max(320, Number.isFinite(options.height) ? options.height : 320)
     this.ship.x = this.width / 2
@@ -367,6 +412,44 @@ export class Arena {
   /** How far the ship carries after the thumb comes off, in arena units. */
   get shipCoast(): number {
     return this.shipMax / SHIP_DRAG
+  }
+
+  // ── the opening ──────────────────────────────────────────────────────────
+
+  /**
+   * Where this child stands on the calm ramp: everything they have ever opened,
+   * plus everything they have opened this sitting.
+   */
+  get openingStep(): number {
+    return this.experience + this.opened
+  }
+
+  /** The opening this field was stocked under. See `game/opening.ts`. */
+  get opening(): Opening {
+    return openingAt(this.openingStep)
+  }
+
+  /**
+   * What is left of the target once the hold is taken out. `null` when there is
+   * no question, or when the hold has already gone past what the ring wants.
+   */
+  get remaining(): number | null {
+    const res = this.resonator
+    if (!res) return null
+    return remainingOf(res.target, this.bank.tiles)
+  }
+
+  /**
+   * Which numbers on the field divide what is left, for the renderer.
+   *
+   * `null` — not an empty map — once the child is past the guided opening, so
+   * there is exactly one place the guidance is switched off and the renderer
+   * cannot draw a stale marking by forgetting to ask.
+   */
+  liveMarks(): Map<number, Mark> | null {
+    const res = this.resonator
+    if (!res || !this.opening.guided) return null
+    return markField(res.target, this.bank.tiles, this.bodies)
   }
 
   // ── the frame ────────────────────────────────────────────────────────────
@@ -561,7 +644,13 @@ export class Arena {
       const dy = this.ship.y - body.y
       const m = Math.hypot(dx, dy) || 1
       const kick = JOSTLE_SPAN * REFERENCE_SPAN * this.span
-      const shove = JOSTLE_HUSK_SPAN * REFERENCE_SPAN * this.span
+      // The husk's half of a bump is the FIELD's motion, so it is scaled with
+      // the field's pace; the ship's half is the ship's and is not. Measured,
+      // unscaled: a lone husk drifting into a ship nobody was flying bumped it
+      // once a second and wound itself up to 6.1% of the arena's diagonal a
+      // second — three times the calm opening's whole drift band, off one
+      // untouched screen. The ship's kick is `SHIP_*` territory; see #716.
+      const shove = JOSTLE_HUSK_SPAN * REFERENCE_SPAN * this.span * this.driftScale
       this.ship.vx += (dx / m) * kick
       this.ship.vy += (dy / m) * kick
       body.vx -= (dx / m) * shove
@@ -622,7 +711,21 @@ export class Arena {
     // It is only ever true because the child **asked**: the clock stops at
     // `hintFree`, one stage short of the line, so nothing that happens to a
     // child who is sitting still can reach here.
-    const given = this.hint()?.given === true
+    //
+    // Two more things count as the game having given it away, and both are
+    // read BEFORE the counters move, because `opening` is a function of
+    // `opened` and this method is about to increment it:
+    //
+    //   * the field itself stated the answer — the calm opening's one husk
+    //     carries the target and its numeral is on the stone;
+    //   * the opening was **guided**, so `live.ts` marked which primes divide
+    //     what was left and the hold was assembled with that in front of them.
+    //
+    // Neither is a penalty and neither is reported differently. What they do is
+    // hold the arena's own ladder still, exactly as a tree that stated the
+    // answer does, so nothing here walks a child up into harder arithmetic on
+    // the strength of a round the game helped them through.
+    const given = this.hint()?.given === true || this.givenByField || this.opening.guided
 
     // Once per question. A refusal spends the id — the resonator stays as a
     // goal the child can still open, but the host hears one answer, which is
@@ -740,8 +843,8 @@ export class Arena {
     const steps = Math.min(MAX_SUBSTEPS, Math.max(1, Math.ceil(clamped / SUBSTEP_MS)))
     const h = clamped / steps / 1000
     const shipMax = this.shipMax
-    const driftMin = DRIFT_MIN_SPAN * REFERENCE_SPAN * this.span
-    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span
+    const driftMin = DRIFT_MIN_SPAN * REFERENCE_SPAN * this.span * this.driftScale
+    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span * this.driftScale
     const decay = Math.exp(-SHIP_DRAG * h)
     const turn = 1 - Math.exp(-FACING_TURN_PER_SEC * h)
 
@@ -1116,11 +1219,19 @@ export class Arena {
     // Computed once, here, rather than per frame: it is a walk of the whole tree
     // at every stage and the shell asks for the hint sixty times a second.
     this.hintFree = freeStages(this.hintTree)
-    const values = huskify(wanted, this.rng)
+
+    // How busy this field is allowed to be. See `game/opening.ts` — at the very
+    // start it is one husk, no decoy, no chaff, drifting at three tenths of the
+    // pace, and it walks out to the shipped field over five openings.
+    const plan = this.opening
+    this.driftScale = plan.drift
+    const values = Number.isFinite(plan.husks)
+      ? gather(wanted, plan.husks)
+      : huskify(wanted, this.rng)
 
     // One reachable mal-rule: the primes it needs that the answer does not
     // already supply. Kept small, or the field becomes a haystack.
-    const decoy = this.pickDecoy(question, wanted)
+    const decoy = plan.decoy ? this.pickDecoy(question, wanted) : []
     if (decoy.length > 0) values.push(...huskify(decoy, this.rng))
 
     // A little chaff, so "sweep only what you need" is a decision rather than
@@ -1131,10 +1242,23 @@ export class Arena {
     // arithmetic cannot go further; the *sweep* can. Two extra decoy motes at the
     // top of the band is a field where getting the hold exactly right is work.
     const reach = (this.ladder.at - FLOOR) / Math.max(1e-6, CEILING - FLOOR)
-    const chaff = this.rng.int(1, 3 + Math.round(2 * Math.max(0, Math.min(1, reach))))
+    const chaff = Number.isFinite(plan.chaff)
+      ? plan.chaff
+      : this.rng.int(1, 3 + Math.round(2 * Math.max(0, Math.min(1, reach))))
     for (let i = 0; i < chaff; i++) values.push(this.rng.pick(MOTE_PRIMES.slice(0, 6)))
 
-    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span
+    // **Does the field, as it now stands, state the answer?**
+    //
+    // Asked here rather than off `plan.husks`, and after the decoy and the chaff
+    // have gone in, because it is a question about the picture and not about the
+    // plan. One stone, alone, carrying the target: the numeral on it IS the
+    // answer and there is nothing else it could be. That is true of the first
+    // two openings and of nothing else — a prime target puts the target on the
+    // field as a mote at every step of the ramp, but from step 2 on there is
+    // chaff drifting beside it and knowing *which* mote is the one is the round.
+    this.givenByField = values.length === 1 && values[0] === target
+
+    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span * this.driftScale
     this.bodies = []
     this.shots = []
     this.rng.shuffle(values)
@@ -1152,8 +1276,8 @@ export class Arena {
       difficulty: landedAt,
       x: this.width / 2,
       y: this.height * 0.26,
-      vx: this.rng.range(-26, 26) * this.span,
-      vy: this.rng.range(-14, 14) * this.span,
+      vx: this.rng.range(-26, 26) * this.span * this.driftScale,
+      vy: this.rng.range(-14, 14) * this.span * this.driftScale,
       cooldown: 0,
       reported: false,
       age: 0,
@@ -1180,11 +1304,17 @@ export class Arena {
    * nothing here is a hardcoded problem.
    */
   private stockPassiveField(): void {
+    const plan = this.opening
+    this.driftScale = plan.drift
+    this.givenByField = false
     const primes: number[] = []
     const many = this.rng.int(5, 8)
     for (let i = 0; i < many; i++) primes.push(this.rng.pick(MOTE_PRIMES.slice(0, 8)))
-    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span
-    for (const value of huskify(primes, this.rng)) {
+    const driftMax = DRIFT_MAX_SPAN * REFERENCE_SPAN * this.span * this.driftScale
+    const values = Number.isFinite(plan.husks)
+      ? gather(primes, plan.husks)
+      : huskify(primes, this.rng)
+    for (const value of values) {
       const edge = 70
       this.spawnAt(
         value,
@@ -1267,7 +1397,10 @@ export class Arena {
         this.height - MOTE_R,
       )
       const speed =
-        this.rng.range(DRIFT_MIN_SPAN, DRIFT_MAX_SPAN) * REFERENCE_SPAN * this.span
+        this.rng.range(DRIFT_MIN_SPAN, DRIFT_MAX_SPAN) *
+        REFERENCE_SPAN *
+        this.span *
+        this.driftScale
       this.spawnAt(values[i] as number, px, py, Math.cos(angle) * speed, Math.sin(angle) * speed)
     }
   }

--- a/dynawalla/games/lattice/src/game/live.ts
+++ b/dynawalla/games/lattice/src/game/live.ts
@@ -1,0 +1,112 @@
+// WHICH ONE GOES IN — divisibility, drawn on the field.
+//
+// The founder asked for it in one line: "maybe it even highlights/hints when it
+// is blastable and why."
+//
+// The rule the whole game stands on is stated in `factor.ts`: **a prime cannot
+// be split**, so primes are what the hold is made of, and a hold opens the ring
+// when its product is exactly the target. Every child who plays this has to work
+// out, mote by mote, whether the lit `3` drifting past is one of the pieces or
+// one of the chaff. That question has an exact answer and it is one line of
+// arithmetic — **does it divide what is left** — and until now nothing on the
+// screen said so.
+//
+// So: take the target, take out what the hold already carries, and what remains
+// is a number. A lit mote belongs in the hold **iff it divides that number**. A
+// stone husk is worth shooting **iff it shares a factor with it** — crack it and
+// at least one of the two pieces is a piece the hold needs.
+//
+// That is the whole of this file. It decides nothing about pacing and nothing
+// about difficulty; it reads the field and says which numbers divide.
+//
+// ## This is not the factor tree
+//
+// `game/hint.ts` and `game/tree.ts` answer a different question, and the two
+// must not be folded together. The tree says **how to factor the target** — it
+// unfolds `112` into `2·2·2·2·7` a stage at a time, on a clock the child can
+// outrun and a control they can tap, and it is about the arithmetic. This says
+// **which of the numbers actually in front of you right now is live**, and it is
+// about the field. A child can have the whole tree up and still not know whether
+// the `13` drifting past is one of theirs; a child can have this and still not
+// know what `642 − 530` is.
+//
+// They do share one thing, and it is shared rather than duplicated: an opening
+// that is guided does not climb the arena's ladder, exactly as a tree that
+// stated the answer does not. See `arena.enter`.
+//
+// ## A hint that lies is worse than no hint
+//
+// `hint.heldLeaves` says the same thing about the tree's collars, and it is the
+// reason both are pure functions with their own tests rather than four lines
+// inside the renderer. Mark one mote too many and a child sweeps it, flies into
+// the ring, and is refused by a game that told them to. `live.test.ts` asserts
+// the marking against an independent trial-division oracle over the whole band —
+// exactly the divisors, no more and no fewer.
+
+import { isPrime, productOf } from "./factor.ts"
+
+/**
+ * What is left of `target` once the hold is taken out of it.
+ *
+ * `null` when the hold does not divide the target at all — which is not an
+ * error and not a scold: it is the honest reading of a hold that has already
+ * gone past what the ring wants. Nothing on the field can complete it, so
+ * nothing is marked, and the way out is one tap on the bar.
+ *
+ * `1` means the hold is exactly right and there is nothing left to find.
+ */
+export function remainingOf(target: number, tiles: readonly number[]): number | null {
+  if (!Number.isInteger(target) || target < 1) return null
+  for (const tile of tiles) {
+    if (!Number.isInteger(tile) || tile < 1) return null
+  }
+  const held = productOf(tiles)
+  if (!Number.isSafeInteger(held) || held < 1) return null
+  if (target % held !== 0) return null
+  return target / held
+}
+
+export type Mark =
+  /** A prime that divides what is left. Go and get it. */
+  | "needed"
+  /** A composite that shares a factor with what is left. Shoot it. */
+  | "carries"
+  /** Neither. Not a mistake to touch, just not one of yours. */
+  | "spare"
+
+/**
+ * What a number on the field is, against what is left.
+ *
+ * Primeness is derived here rather than taken as an argument, so there is no
+ * way for a caller to hand this a wrong answer about the one property the game
+ * stands on.
+ */
+export function markOf(remaining: number | null, value: number): Mark {
+  if (remaining === null || remaining <= 1) return "spare"
+  if (!Number.isInteger(value) || value < 2) return "spare"
+  if (isPrime(value)) return remaining % value === 0 ? "needed" : "spare"
+  return gcd(value, remaining) > 1 ? "carries" : "spare"
+}
+
+/** The whole field at once, by body id. */
+export function markField(
+  target: number,
+  tiles: readonly number[],
+  bodies: readonly { readonly id: number; readonly value: number }[],
+): Map<number, Mark> {
+  const remaining = remainingOf(target, tiles)
+  const out = new Map<number, Mark>()
+  for (const body of bodies) out.set(body.id, markOf(remaining, body.value))
+  return out
+}
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a)
+  let y = Math.abs(b)
+  while (y !== 0) {
+    const t = x % y
+    x = y
+    y = t
+  }
+  return x
+}

--- a/dynawalla/games/lattice/src/game/opening.ts
+++ b/dynawalla/games/lattice/src/game/opening.ts
@@ -1,0 +1,165 @@
+// THE OPENING — what a child who has never played this before walks into.
+//
+// The founder's report, verbatim, is the specification:
+//
+// > "Lattice runner is pretty cool but it's too hard and fast for a human ..
+// > maybe one number at a time and a slower ramp up from an easier baseline ..
+// > first time you enter it could be just one number calmly coming down the
+// > lattice. Maybe it even highlights/hints when it is blastable and why. It
+// > needs to be a bit more hand-holdy on the first run. slower, easier, more
+// > hand-holdy. the way it starts for me now is chaotic and impossible."
+//
+// ## What it opened with before
+//
+// Measured, driving the real `Arena` against the stub host at a phone (390×740)
+// and a tablet (1180×820), sixteen seeds, at the rung a brand new profile
+// actually starts on:
+//
+//   * **five bodies on the screen at t=0** (mean 5.00, never fewer than four,
+//     as many as six) — the answer's primes gathered into husks by `huskify`,
+//     plus a mal-rule decoy's primes, plus one to three loose chaff motes;
+//   * **every one of them already moving**, at a mean 5.5% of the arena's
+//     diagonal a second and as much as 7.6%;
+//   * and once the child starts shooting, **a peak of ten and as many as
+//     fifteen** inside the first minute, because every shot turns one husk into
+//     two bodies.
+//
+// Four to six numbers, all drifting, all of which the child is expected to read
+// and sort into "shoot this one" and "collect that one", on the first screen
+// they have ever seen. That is the "chaotic and impossible" in the report, and
+// it is not a difficulty setting — it is the whole field arriving at once.
+//
+// ## The ramp
+//
+// Six positions, indexed by how many resonators this child has ever opened —
+// `game/seen.ts` remembers that across sittings, so a child coming back to their
+// fifth resonator does not get walked through the first one again.
+//
+//   0. **One number.** The answer's whole factorisation gathered into a single
+//      husk, no decoy, no chaff, drifting at three tenths of the ordinary pace.
+//      One stone, crossing the sheet slowly, with a numeral on it. Shoot it and
+//      it becomes two. That is the entire first lesson.
+//   1. Still one number, a little quicker.
+//   2. Two husks and one chaff mote. Now there is a choice to make.
+//   3. Two husks, one chaff mote, and the decoy comes back — the field can hold
+//      a wrong answer again, which is what makes the hold a decision.
+//   4. Three husks, two chaff motes, nearly full pace. The guidance comes off.
+//   5. and after: the game as it was, unchanged.
+//
+// Every quantity here is **monotone non-decreasing in `step`** and the guidance
+// is monotone non-increasing, and `opening.test.ts` asserts both exhaustively
+// rather than taking the table on trust. A child is never overtaken by their own
+// progress; the field they get is never busier than the one they get next time.
+//
+// ## What this is NOT
+//
+// It is not a window, a timer or a deadline. THE LATTICE has never had one and
+// this does not add one — nothing here reads a clock, a speed, a streak or an
+// accuracy. `openingAt` is a pure function of one integer, and the only thing
+// that integer counts is resonators the child *finished*.
+
+import { MAX_HUSK, ascending } from "./factor.ts"
+
+/**
+ * Openings after which the game is simply the game.
+ *
+ * Five, because that is the last index with a hand on it — `openingAt(5)` and
+ * everything above it is the steady state. Exported so a test or a rig can say
+ * "a child who is past all this" without knowing the table.
+ */
+export const CALM_OPENINGS = 5
+
+export type Opening = {
+  readonly step: number
+  /**
+   * How many husks the answer's primes may be gathered into.
+   *
+   * `1` is the founder's one number: the whole factorisation in one stone.
+   * `Infinity` hands the job back to `factor.huskify`, which is what the game
+   * has always done.
+   */
+  readonly husks: number
+  /**
+   * Loose chaff motes on the field. `Infinity` means "as many as the ladder
+   * asks for", which is the shipped behaviour and rises with the band.
+   */
+  readonly chaff: number
+  /** Whether one of the host's mal-rule answers is made assemblable. */
+  readonly decoy: boolean
+  /** The drift band, as a fraction of the arena's ordinary one. */
+  readonly drift: number
+  /**
+   * Whether the field marks which numbers divide what is left. See `live.ts`.
+   *
+   * While this is on the arena does not climb its own ladder — the guidance
+   * says which primes the hold needs, so an opening it helped with is not
+   * evidence about arithmetic. Exactly the rule `hint.ts` already applies to a
+   * tree that stated the answer, for exactly the same reason.
+   */
+  readonly guided: boolean
+}
+
+const CALM: readonly Omit<Opening, "step">[] = [
+  { husks: 1, chaff: 0, decoy: false, drift: 0.3, guided: true },
+  { husks: 1, chaff: 0, decoy: false, drift: 0.45, guided: true },
+  { husks: 2, chaff: 1, decoy: false, drift: 0.6, guided: true },
+  { husks: 2, chaff: 1, decoy: true, drift: 0.75, guided: true },
+  { husks: 3, chaff: 2, decoy: true, drift: 0.9, guided: false },
+]
+
+const STEADY: Omit<Opening, "step"> = {
+  husks: Number.POSITIVE_INFINITY,
+  chaff: Number.POSITIVE_INFINITY,
+  decoy: true,
+  drift: 1,
+  guided: false,
+}
+
+/**
+ * The opening a child who has opened `step` resonators gets. Pure, total, and
+ * defined for every number including the ones that are not numbers.
+ */
+export function openingAt(step: number): Opening {
+  const at = Number.isFinite(step) ? Math.max(0, Math.floor(step)) : 0
+  const row = at < CALM.length ? (CALM[at] as Omit<Opening, "step">) : STEADY
+  return { step: at, ...row }
+}
+
+/**
+ * Gather primes into at most `husks` composite husks whose product is exactly
+ * the product of the primes handed in.
+ *
+ * Ascending and contiguous, which is what makes the split *seeable*: four twos
+ * and a seven gathered into two husks is `8` and `14`, not `56` and `2` — the
+ * child watches a balanced tree come apart rather than a stalk. `huskify` does
+ * the same job with a generator when the field is allowed to be busy; this one
+ * is deterministic, because the calm opening must be the same calm opening.
+ *
+ * `MAX_HUSK` is respected: a group that would overflow it is cut short and what
+ * is left rides as its own husk. The product is conserved in every case, which
+ * is the property `opening.test.ts` fuzzes.
+ */
+export function gather(primes: readonly number[], husks: number): number[] {
+  const sorted = ascending(primes.filter((p) => Number.isInteger(p) && p >= 2))
+  if (sorted.length === 0) return []
+  const cap = Math.max(1, Math.min(Math.floor(Number.isFinite(husks) ? husks : sorted.length), sorted.length))
+  const out: number[] = []
+  let i = 0
+  for (let g = 0; g < cap && i < sorted.length; g++) {
+    const want = Math.ceil((sorted.length - i) / (cap - g))
+    let value = 1
+    let taken = 0
+    while (taken < want && i < sorted.length) {
+      const p = sorted[i] as number
+      if (value * p > MAX_HUSK && taken > 0) break
+      value *= p
+      i += 1
+      taken += 1
+    }
+    if (value > 1) out.push(value)
+  }
+  // Only reachable through the `MAX_HUSK` guard above. The product is still
+  // exact; the field is simply one husk busier than the plan asked for.
+  while (i < sorted.length) out.push(sorted[i++] as number)
+  return out
+}

--- a/dynawalla/games/lattice/src/game/seen.ts
+++ b/dynawalla/games/lattice/src/game/seen.ts
@@ -1,0 +1,69 @@
+// How many resonators this child has ever opened.
+//
+// The one thing the calm opening reads, and it is never shown to anybody. It is
+// not a score, it is not accuracy, and it is not a claim about how good the
+// child is — it counts rings they finished, which is the only signal that
+// distinguishes "has never seen this game" from "has played it before". A child
+// coming back to their fifth resonator does not get walked through the first one
+// again; see `game/opening.ts`.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, so every access is guarded and the value is held in memory as well,
+// exactly as `best.ts` does. The failure mode when storage is unreachable is
+// that a child gets the calm opening again next sitting, which is the right way
+// round: the cost of an extra gentle first minute is nothing, and the cost of
+// dropping a first-time child into the full field is the report this work came
+// from.
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const OPENS_SLOT = "dw.lattice.opens" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn("[lattice] localStorage is not reachable from this frame", error)
+    return null
+  }
+}
+
+/** Resonators opened, ever, across every sitting this device remembers. */
+export function opensEver(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(OPENS_SLOT) ?? "0")
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn("[lattice] the opened count could not be read back", error)
+    }
+  }
+  return memory
+}
+
+/** One more. Returns the new total. */
+export function noteOpen(): number {
+  const next = opensEver() + 1
+  memory = next
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(OPENS_SLOT, String(next))
+    } catch (error) {
+      console.warn("[lattice] the opened count could not be written", error)
+    }
+  }
+  return next
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetOpensForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -32,6 +32,7 @@ import type { Host } from "./contract.ts"
 import { Rng } from "./core/rng.ts"
 import { Arena, RESONATOR_R, SHIP_R, type ArenaEvent } from "./game/arena.ts"
 import { bestChain, recordChain } from "./game/best.ts"
+import { noteOpen, opensEver } from "./game/seen.ts"
 import { shapeStick, STICK_RANGE } from "./game/steer.ts"
 import { Scene } from "./render/scene.ts"
 import { BRASS_LIGHT, CELESTIAL, OXIDE } from "./render/palette.ts"
@@ -78,6 +79,9 @@ export function mountLattice(
   const arena = new Arena(host, new Rng(seed), {
     width: scene.cssWidth,
     height: scene.cssHeight,
+    // Everything this child has ever opened, so a first sitting starts on one
+    // number moving slowly and a fifth one does not. See `game/opening.ts`.
+    experience: opensEver(),
   })
   const grid = new Grid({
     cols: Math.max(6, Math.round(scene.cssWidth / GRID_CELL)),
@@ -244,6 +248,10 @@ export function mountLattice(
           scene.celebrate(event.at.x, event.at.y, event.tiles)
           audio.open(event.tiles.length)
           if (recordChain(arena.chain)) best = arena.chain
+          // Remembered across sittings, and never shown. The ramp in
+          // `game/opening.ts` is indexed on it, so a child who opened three
+          // rings yesterday comes back to the fourth field and not the first.
+          noteOpen()
           break
         }
         case "refuse": {

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -18,6 +18,7 @@ import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import type { Arena, Body, Resonator } from "../game/arena.ts"
 import { HUSK_R, MOTE_R, RESONATOR_R, SHIP_R, SHOT_R } from "../game/arena.ts"
 import { heldLeaves, type HintState, revealPaceMs } from "../game/hint.ts"
+import type { Mark } from "../game/live.ts"
 import type { PlacedNode } from "../game/tree.ts"
 import type { Grid } from "../sim/grid.ts"
 import { hudLayout, type HudLayout } from "./hud.ts"
@@ -194,7 +195,12 @@ export class Scene {
 
     this.drawGrid(grid)
     if (arena.resonator) this.drawResonator(arena.resonator, arena.ship)
-    for (const body of arena.bodies) this.drawBody(body)
+    // Which numbers divide what is left. `null` — never an empty map — once the
+    // child is past the guided opening, so there is exactly one switch and the
+    // renderer cannot draw a stale marking by forgetting to ask. See `live.ts`.
+    const marks = arena.liveMarks()
+    const remaining = marks === null ? null : arena.remaining
+    for (const body of arena.bodies) this.drawBody(body, marks?.get(body.id) ?? null, remaining)
 
     ctx.fillStyle = BRASS_LIGHT
     for (const shot of arena.shots) {
@@ -285,10 +291,42 @@ export class Scene {
 
   // ── the bodies ───────────────────────────────────────────────────────────
 
-  private drawBody(body: Body): void {
+  /**
+   * One number on the field, and — while the opening is guided — whether it
+   * divides what is left.
+   *
+   * The marking is drawn in the materials the pieces are already made of
+   * rather than in a new colour: a mote that goes in is collared in the same
+   * celestial light it is lit with, a stone with a piece of the answer inside
+   * it is collared in brass. **And a needed mote states the reason underneath
+   * it**, as arithmetic and not as a sentence: `18÷3`. That is the "and why"
+   * in the report, it is language-free so it costs nothing to translate, and it
+   * is the exact rule the game runs on rather than a paraphrase of it.
+   *
+   * A `spare` is drawn as it always was. Nothing is crossed out, dimmed or
+   * marked wrong — a mote that is not one of yours is not a mistake, and half
+   * the point of the guidance is that the contrast does the teaching.
+   */
+  private drawBody(body: Body, mark: Mark | null, remaining: number | null): void {
     const ctx = this.ctx
     const pop = Math.min(1, body.age / 160)
     const r = (body.prime ? MOTE_R : HUSK_R) * (0.6 + 0.4 * pop)
+
+    if (mark === "needed" || mark === "carries") {
+      const beat = this.reduced ? 0 : Math.sin(this.clock / 260 + body.id) * 1.6
+      ctx.beginPath()
+      ctx.arc(body.x, body.y, r + 9 + beat, 0, Math.PI * 2)
+      ctx.strokeStyle = mark === "needed" ? CELESTIAL : BRASS
+      ctx.lineWidth = 3
+      ctx.stroke()
+    }
+    if (mark === "needed" && remaining !== null && remaining > 1) {
+      ctx.fillStyle = CELESTIAL
+      ctx.font = numeralFont(Math.max(11, r * 0.62))
+      ctx.textAlign = "center"
+      ctx.textBaseline = "top"
+      ctx.fillText(`${remaining}÷${body.value}`, body.x, body.y + r + 14)
+    }
 
     if (body.prime) {
       // A prime is the only thing in the arena that is its own light source.

--- a/dynawalla/games/lattice/src/test/arena.test.ts
+++ b/dynawalla/games/lattice/src/test/arena.test.ts
@@ -10,6 +10,7 @@ import { test } from "node:test"
 import { Rng } from "../core/rng.ts"
 import { Arena, MAX_TARGET } from "../game/arena.ts"
 import { isPrime, primeFactors, productOf, sameMultiset } from "../game/factor.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { createStubHost } from "../stubHost.ts"
 import { grindToPrimes, rig, sweepFactorisation } from "./harness.ts"
 
@@ -177,7 +178,7 @@ test("a resonator asking for a prime opens only for the mote carrying it", () =>
   // The wall, in the arena rather than in the rule: a stub host wound forward
   // to a prime answer, ground down, and every smaller prime on the field swept.
   const host = createStubHost({ seed: 0x7a11, reducedMotion: true })
-  const arena = new Arena(host, new Rng(0x7a11), { width: 900, height: 700 })
+  const arena = new Arena(host, new Rng(0x7a11), { width: 900, height: 700, experience: CALM_OPENINGS })
   arena.begin(0)
   let guard = 0
   while (arena.resonator && !isPrime(arena.resonator.target) && guard++ < 200) {

--- a/dynawalla/games/lattice/src/test/chrome.test.ts
+++ b/dynawalla/games/lattice/src/test/chrome.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../../../../packs/shared/game-chrome/index.ts"
 import { Rng } from "../core/rng.ts"
 import { Arena } from "../game/arena.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { hudLayout } from "../render/hud.ts"
 import { Scene } from "../render/scene.ts"
 import { Grid } from "../sim/grid.ts"
@@ -194,7 +195,7 @@ function frame(
   const host = createStubHost({ seed, reducedMotion: true })
   const { ctx, log, restores } = recorder()
   const scene = new Scene(fakeCanvas(w, h, ctx), true)
-  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: w, height: h })
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: w, height: h, experience: CALM_OPENINGS })
   const grid = new Grid({ cols: 8, rows: 8, width: w, height: h, reduced: true })
   arena.begin(0)
 

--- a/dynawalla/games/lattice/src/test/harness.ts
+++ b/dynawalla/games/lattice/src/test/harness.ts
@@ -8,6 +8,7 @@ import type { Host } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
 import { Arena } from "../game/arena.ts"
 import { multisetDifference, primeFactors } from "../game/factor.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { createStubHost } from "../stubHost.ts"
 
 export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
@@ -22,7 +23,18 @@ export type Rig = {
   haptics: string[]
 }
 
-export function rig(seed = 0x1a771ce, opts: { difficulty?: number } = {}): Rig {
+/**
+ * A rig, at the steady state by default.
+ *
+ * `experience` is `CALM_OPENINGS` unless a test says otherwise, so every test
+ * written before `game/opening.ts` existed keeps asking about the game a child
+ * who has played before actually gets. `opening.test.ts` is the one that asks
+ * for a first sitting, and it says so out loud.
+ */
+export function rig(
+  seed = 0x1a771ce,
+  opts: { difficulty?: number; experience?: number } = {},
+): Rig {
   const reports: Report[] = []
   const skips: string[] = []
   const transitions: Array<{ kind: string; label?: string }> = []
@@ -37,7 +49,11 @@ export function rig(seed = 0x1a771ce, opts: { difficulty?: number } = {}): Rig {
     onTransition: (kind, label) =>
       transitions.push(label === undefined ? { kind } : { kind, label }),
   })
-  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), {
+    width: 900,
+    height: 700,
+    experience: opts.experience ?? CALM_OPENINGS,
+  })
   arena.begin(0)
   return { host, arena, reports, skips, transitions, haptics }
 }

--- a/dynawalla/games/lattice/src/test/hint.test.ts
+++ b/dynawalla/games/lattice/src/test/hint.test.ts
@@ -43,6 +43,7 @@ import {
   stageCount,
   WALL_STAGES,
 } from "../game/hint.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { isResonant, MIN_TARGET } from "../game/resonance.ts"
 import {
   factorTree,
@@ -764,7 +765,7 @@ test("the ladder holds rather than climbing on an answer the game handed over", 
       haptic: () => undefined,
       prefersReducedMotion: () => true,
     }
-    const arena = new Arena(host, new Rng(0x5eed ^ 0x51de), { width: 900, height: 700 })
+    const arena = new Arena(host, new Rng(0x5eed ^ 0x51de), { width: 900, height: 700, experience: CALM_OPENINGS })
     arena.begin(0)
     const firstArming = asked.length
     const res = arena.resonator
@@ -890,7 +891,7 @@ test("with no resonator there is nothing to hint about and nothing throws", () =
       prefersReducedMotion: () => true,
     },
     new Rng(3),
-    { width: 900, height: 700 },
+    { width: 900, height: 700, experience: CALM_OPENINGS },
   )
   // Every draw is `2`, which is not a target this game asks for, so the arena
   // arms nothing at all.

--- a/dynawalla/games/lattice/src/test/live.test.ts
+++ b/dynawalla/games/lattice/src/test/live.test.ts
@@ -1,0 +1,454 @@
+// WHICH ONE GOES IN — checked against arithmetic, and checked at the glass.
+//
+// "A hint that lies is worse than no hint" is the whole reason this file is
+// long. The marking says which of the numbers drifting in front of a child
+// divides what is left of the target, and if it marks one mote too many the
+// child sweeps it, flies into the ring, and is refused by a game that told them
+// to.
+//
+// So it is checked three times over, at three different levels, because a
+// sibling pack's hint tests all passed with the hint entirely unwired:
+//
+//   1. **The arithmetic**, against an independent oracle. Not `markOf`'s own
+//      reasoning re-run — trial division, from scratch, over the whole band.
+//   2. **The rules**, through the real `Arena`: a child who does exactly what
+//      the marking says, and nothing else, opens the ring.
+//   3. **The glass**, through the real `Scene.draw` against a context that
+//      records instead of paints — because the arithmetic being right is worth
+//      nothing if the renderer never asks for it, which is exactly the shape of
+//      the bug this pack has been bitten by before.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena, MOTE_R } from "../game/arena.ts"
+import { isPrime, primeFactors, productOf } from "../game/factor.ts"
+import { markField, markOf, remainingOf } from "../game/live.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
+import { resonate } from "../game/resonance.ts"
+import { Scene } from "../render/scene.ts"
+import { CELESTIAL, BRASS } from "../render/palette.ts"
+import { Grid } from "../sim/grid.ts"
+import { createStubHost } from "../stubHost.ts"
+
+// ── 1. the arithmetic ───────────────────────────────────────────────────────
+
+/** Trial division, written out longhand. Nothing here imports the game's own. */
+function divides(divisor: number, of: number): boolean {
+  if (divisor < 2 || of < 1) return false
+  let count = 0
+  for (let k = divisor; k <= of; k += divisor) {
+    if (k === of) count += 1
+  }
+  return count === 1
+}
+
+/** Primeness, longhand, so the oracle and the game share no code at all. */
+function primeByHand(n: number): boolean {
+  if (n < 2) return false
+  for (let d = 2; d < n; d++) {
+    if (n % d === 0) return false
+  }
+  return true
+}
+
+test("what is left is exact, and a hold that has gone past is not a number", () => {
+  assert.equal(remainingOf(72, []), 72, "an empty hold does not leave the whole target")
+  assert.equal(remainingOf(72, [2, 2]), 18)
+  assert.equal(remainingOf(72, [2, 2, 2, 3, 3]), 1, "the finished hold does not leave 1")
+  assert.equal(remainingOf(72, [5]), null, "a 5 in the hold of a 72 was not refused")
+  assert.equal(remainingOf(72, [2, 2, 2, 2]), null, "a fourth 2 in a 72 was not refused")
+  assert.equal(remainingOf(41, []), 41)
+  assert.equal(remainingOf(41, [41]), 1)
+  // Nothing that is not a number is a hold.
+  assert.equal(remainingOf(Number.NaN, []), null)
+  assert.equal(remainingOf(72, [Number.NaN]), null)
+  assert.equal(remainingOf(72, [0]), null)
+  assert.equal(remainingOf(0, []), null)
+})
+
+test("the marking is exactly the divisors — no more, and no fewer", () => {
+  // Every target the resonator can put up, against every value that can be on
+  // the field, at four different stages of a hold. Roughly a million triples.
+  const rng = new Rng(0x11e)
+  let needed = 0
+  let carries = 0
+  for (let target = 4; target <= 999; target++) {
+    const wanted = primeFactors(target)
+    const holds: number[][] = [[], wanted.slice(0, 1), wanted.slice(0, 2), [rng.pick([5, 7, 11])]]
+    for (const hold of holds) {
+      const remaining = remainingOf(target, hold)
+      for (let value = 2; value <= 200; value++) {
+        const mark = markOf(remaining, value)
+        const prime = primeByHand(value)
+        const truth =
+          remaining === null || remaining <= 1
+            ? "spare"
+            : prime
+              ? divides(value, remaining)
+                ? "needed"
+                : "spare"
+              : sharesAFactor(value, remaining)
+                ? "carries"
+                : "spare"
+        assert.equal(
+          mark,
+          truth,
+          `target ${target} hold [${hold.join(",")}] value ${value}: marked ${mark}, is ${truth}`,
+        )
+        if (mark === "needed") needed += 1
+        if (mark === "carries") carries += 1
+      }
+    }
+  }
+  // A marking that marked nothing at all would satisfy every assertion above.
+  // Measured: 4,377 and 158,152 over the sweep.
+  assert.ok(needed > 4_000, `only ${needed} motes were ever marked as wanted`)
+  assert.ok(carries > 150_000, `only ${carries} stones were ever marked as worth shooting`)
+})
+
+/** Longhand: is there a number above 1 that goes into both? */
+function sharesAFactor(a: number, b: number): boolean {
+  const top = Math.min(a, b)
+  for (let d = 2; d <= top; d++) {
+    if (a % d === 0 && b % d === 0) return true
+  }
+  return false
+}
+
+test("a marked prime is one the hold can still take, at every stage of a hold", () => {
+  // The property the child actually relies on: sweep a marked mote and the hold
+  // still divides the target. Sweep an unmarked one and it does not.
+  for (let target = 12; target <= 400; target++) {
+    const wanted = primeFactors(target)
+    if (wanted.length < 2) continue
+    const hold: number[] = []
+    for (const step of [0, 1]) {
+      void step
+      const remaining = remainingOf(target, hold)
+      for (const value of [2, 3, 5, 7, 11, 13, 17, 19, 23]) {
+        const after = remainingOf(target, [...hold, value])
+        if (markOf(remaining, value) === "needed") {
+          assert.notEqual(after, null, `target ${target}: a marked ${value} broke the hold`)
+        } else if (isPrime(value)) {
+          assert.equal(after, null, `target ${target}: an unmarked ${value} would have been fine`)
+        }
+      }
+      hold.push(wanted[hold.length] as number)
+    }
+  }
+})
+
+// ── 2. the rules, through the real arena ────────────────────────────────────
+
+test("a child who does exactly what the marking says opens the ring", () => {
+  // The strongest statement available: follow the guidance and nothing else —
+  // shoot what is collared brass, sweep what is collared celestial — and the
+  // resonator opens. Driving `Arena.liveMarks` and `Arena.enter`, not the pure
+  // functions, so a marking that is right but unreachable fails here.
+  let opened = 0
+  for (let seed = 1; seed <= 40; seed++) {
+    const host = createStubHost({ seed, reducedMotion: true })
+    const arena = new Arena(host, new Rng(seed ^ 0x51de), {
+      width: 900,
+      height: 700,
+      experience: 2,
+    })
+    arena.begin(0)
+    const res = arena.resonator
+    if (!res) continue
+    assert.ok(arena.liveMarks(), `seed ${seed}: the guided opening marked nothing`)
+
+    for (let guard = 0; guard < 400; guard++) {
+      const marks = arena.liveMarks()
+      assert.ok(marks, `seed ${seed}: the marking went away mid-round`)
+      const shoot = arena.bodies.find((b) => marks.get(b.id) === "carries")
+      if (shoot) {
+        arena.strike(shoot.id)
+        continue
+      }
+      const sweep = arena.bodies.find((b) => marks.get(b.id) === "needed")
+      if (!sweep) break
+      const before = arena.bank.size
+      arena.touch(sweep.id)
+      assert.equal(arena.bank.size, before + 1, `seed ${seed}: a marked mote refused to be swept`)
+    }
+
+    // Nothing left is marked, which must mean the hold is finished rather than
+    // that the guidance ran out of things to say.
+    assert.equal(
+      remainingOf(res.target, arena.bank.tiles),
+      1,
+      `seed ${seed}: following the marking left ${remainingOf(res.target, arena.bank.tiles)} to find`,
+    )
+    const verdict = resonate(res.target, arena.bank.tiles)
+    assert.equal(verdict.kind, "open", `seed ${seed}: the ring refused a hold it had asked for`)
+    arena.enter(1000)
+    opened += 1
+  }
+  assert.ok(opened >= 30, `only ${opened} of 40 seeds ever armed a guided resonator`)
+})
+
+test("the marking goes quiet the moment the hold has gone wrong, and comes back", () => {
+  const host = createStubHost({ seed: 0x9a17, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0x9a17 ^ 0x51de), {
+    width: 900,
+    height: 700,
+    experience: 2,
+  })
+  arena.begin(0)
+  const res = arena.resonator
+  assert.ok(res, "nothing was armed")
+  // Put something in the hold that cannot be part of the answer.
+  const stray = [43, 41, 37, 31].find((p) => res.target % p !== 0) as number
+  arena.bank.take(stray)
+  assert.equal(arena.remaining, null, "a hold that has gone past still left a number")
+  const marks = arena.liveMarks()
+  assert.ok(marks, "the marking disappeared entirely rather than going quiet")
+  for (const [, mark] of marks) {
+    assert.equal(mark, "spare", "something was still marked under a hold nothing can complete")
+  }
+  // One tap on the bar, and it is a game again.
+  arena.vent()
+  assert.equal(arena.remaining, res.target, "venting did not put the whole target back in front")
+})
+
+test("a fluent child is not walked through it", () => {
+  const host = createStubHost({ seed: 0xf1, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0xf1 ^ 0x51de), {
+    width: 900,
+    height: 700,
+    experience: CALM_OPENINGS,
+  })
+  arena.begin(0)
+  assert.ok(arena.resonator, "nothing was armed")
+  assert.equal(arena.liveMarks(), null, "the field was marked for a child who is past it")
+})
+
+test("with no question there is nothing to mark and nothing throws", () => {
+  const host = createStubHost({ seed: 0xd0, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0xd0), { width: 900, height: 700, experience: 0 })
+  assert.equal(arena.liveMarks(), null)
+  assert.equal(arena.remaining, null)
+  assert.deepEqual(markField(72, [], []), new Map())
+})
+
+// ── 3. the glass, through the real renderer ─────────────────────────────────
+
+type Ring = { x: number; y: number; r: number; colour: string }
+
+/**
+ * A 2D context that answers everything and writes down the rings it was asked
+ * to stroke and the strings it was asked to fill.
+ *
+ * Only the arcs that are actually stroked count, and each one carries the
+ * `strokeStyle` that was live when `stroke` was called — which is what makes
+ * "the celestial collar went round exactly these motes" a thing that can be
+ * asserted rather than described.
+ */
+function recorder(): { ctx: CanvasRenderingContext2D; rings: Ring[]; text: string[] } {
+  const rings: Ring[] = []
+  const text: string[] = []
+  const state: Record<string, unknown> = { strokeStyle: "#000", font: "16px sans" }
+  let pending: Array<{ x: number; y: number; r: number }> = []
+  const api: Record<string, unknown> = {
+    measureText: (s: string) => ({ width: s.length * 8 }),
+    createRadialGradient: () => ({ addColorStop() {} }),
+    beginPath: () => {
+      pending = []
+    },
+    arc: (x: number, y: number, r: number) => {
+      pending.push({ x, y, r })
+    },
+    stroke: () => {
+      for (const arc of pending) rings.push({ ...arc, colour: String(state.strokeStyle) })
+    },
+    fillText: (s: string) => {
+      text.push(s)
+    },
+  }
+  return {
+    ctx: new Proxy(
+      {},
+      {
+        get: (_t, prop: string) =>
+          prop in api ? api[prop] : prop in state ? state[prop] : () => undefined,
+        set: (_t, prop: string, value) => {
+          state[prop] = value
+          return true
+        },
+      },
+    ) as unknown as CanvasRenderingContext2D,
+    rings,
+    text,
+  }
+}
+
+function fakeCanvas(w: number, h: number, ctx: CanvasRenderingContext2D): HTMLCanvasElement {
+  return {
+    width: 0,
+    height: 0,
+    style: {},
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width: w, height: h, left: 0, top: 0 }),
+    remove() {},
+  } as unknown as HTMLCanvasElement
+}
+
+/** One real frame, and what came out of it. */
+function frame(arena: Arena, w: number, h: number): { rings: Ring[]; text: string[] } {
+  const { ctx, rings, text } = recorder()
+  const scene = new Scene(fakeCanvas(w, h, ctx), true)
+  const grid = new Grid({ cols: 6, rows: 6, width: w, height: h, reduced: true })
+  scene.draw(arena, grid, { best: 0, paused: false, stalled: arena.stalled, hint: arena.hint() })
+  return { rings, text }
+}
+
+test("the collar goes round exactly the numbers that divide what is left", () => {
+  let checked = 0
+  for (let seed = 1; seed <= 30; seed++) {
+    const host = createStubHost({ seed, reducedMotion: true })
+    const arena = new Arena(host, new Rng(seed ^ 0x51de), {
+      width: 900,
+      height: 700,
+      experience: 3,
+    })
+    arena.begin(0)
+    const res = arena.resonator
+    if (!res) continue
+    // Break the field open so there is a mix of stone and light to mark, then
+    // let the pieces drift apart — two children of the same husk are born at the
+    // same point, and a collar found by position would then be found on both.
+    for (let guard = 0; guard < 6; guard++) {
+      const composite = arena.bodies.find((b) => !b.prime)
+      if (!composite) break
+      arena.strike(composite.id)
+    }
+    for (let f = 0; f < 90; f++) arena.step(16.7)
+    const marks = arena.liveMarks()
+    assert.ok(marks, `seed ${seed}: nothing was marked`)
+
+    const { rings, text } = frame(arena, 900, 700)
+    // Only the rings that landed on something the child is looking at. The
+    // resonator strokes brass too, and the ship and the tree stroke their own
+    // shapes; none of them is at a body.
+    const onBodies = rings.filter(
+      (ring) =>
+        (ring.colour === CELESTIAL || ring.colour === BRASS) &&
+        arena.bodies.some((b) => Math.hypot(ring.x - b.x, ring.y - b.y) < 0.5),
+    )
+    let wanted = 0
+    for (const body of arena.bodies) {
+      const mark = marks.get(body.id)
+      const at = onBodies.filter((ring) => Math.hypot(ring.x - body.x, ring.y - body.y) < 0.5)
+      if (mark === "needed") {
+        assert.ok(
+          at.some((ring) => ring.colour === CELESTIAL && ring.r > MOTE_R),
+          `seed ${seed}: the ${body.value} that goes in wears no collar`,
+        )
+        // And the reason, as arithmetic: `18÷3`, under the mote it is about.
+        assert.ok(
+          text.includes(`${arena.remaining}÷${body.value}`),
+          `seed ${seed}: the ${body.value} says it goes in but not why`,
+        )
+        wanted += 1
+        checked += 1
+      } else if (mark === "carries") {
+        assert.ok(
+          at.some((ring) => ring.colour === BRASS),
+          `seed ${seed}: the ${body.value} worth shooting wears no collar`,
+        )
+        wanted += 1
+        checked += 1
+      } else {
+        assert.ok(
+          !text.includes(`${arena.remaining}÷${body.value}`),
+          `seed ${seed}: the ${body.value} was told it divides ${arena.remaining} and it does not`,
+        )
+      }
+    }
+    // **No more, and no fewer.** One collar per marked number and not one more,
+    // so a renderer that collared the whole field fails here even though every
+    // per-body assertion above would still pass.
+    assert.equal(
+      onBodies.length,
+      wanted,
+      `seed ${seed}: ${onBodies.length} collars on the field for ${wanted} marked numbers`,
+    )
+  }
+  assert.ok(checked > 60, `only ${checked} collars were ever drawn`)
+})
+
+test("a fluent child's field is drawn with nothing on it", () => {
+  const host = createStubHost({ seed: 0x5ea, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0x5ea ^ 0x51de), {
+    width: 900,
+    height: 700,
+    experience: CALM_OPENINGS,
+  })
+  arena.begin(0)
+  assert.ok(arena.resonator, "nothing was armed")
+  const { rings, text } = frame(arena, 900, 700)
+  for (const body of arena.bodies) {
+    const collar = rings.find(
+      (ring) =>
+        Math.hypot(ring.x - body.x, ring.y - body.y) < 0.5 &&
+        (ring.colour === CELESTIAL || ring.colour === BRASS),
+    )
+    assert.equal(collar, undefined, `a ${body.value} was collared for a child who is past it`)
+  }
+  assert.ok(
+    text.every((s) => !s.includes("÷")),
+    "a division was spelled out for a child who is past it",
+  )
+})
+
+test("the collar follows the hold: what is swept stops being asked for", () => {
+  const host = createStubHost({ seed: 0x40d, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0x40d ^ 0x51de), {
+    width: 900,
+    height: 700,
+    experience: 2,
+  })
+  arena.begin(0)
+  const res = arena.resonator
+  assert.ok(res, "nothing was armed")
+  for (let guard = 0; guard < 400; guard++) {
+    const composite = arena.bodies.find((b) => !b.prime)
+    if (!composite) break
+    arena.strike(composite.id)
+  }
+  const wanted = primeFactors(res.target)
+  assert.ok(wanted.length >= 2, "the target has nothing to take apart")
+  // The rarest prime in the answer, so the count is unambiguous.
+  const rare = wanted[wanted.length - 1] as number
+  const before = arena.liveMarks()
+  assert.ok(before, "nothing was marked")
+  const lit = arena.bodies.filter((b) => before.get(b.id) === "needed" && b.value === rare)
+  assert.ok(lit.length > 0, `no ${rare} was marked on a field that needs one`)
+  // Take every copy of it the answer wants, and it stops being asked for.
+  let taken = 0
+  const wants = wanted.filter((p) => p === rare).length
+  for (const mote of lit) {
+    if (taken >= wants) break
+    arena.touch(mote.id)
+    taken += 1
+  }
+  assert.equal(taken, wants, "the field could not supply the answer's own primes")
+  const after = arena.liveMarks()
+  assert.ok(after, "the marking disappeared")
+  for (const body of arena.bodies) {
+    if (body.value !== rare) continue
+    assert.equal(
+      after.get(body.id),
+      "spare",
+      `a ${rare} is still being asked for after the hold took all of them`,
+    )
+  }
+  assert.equal(
+    productOf(arena.bank.tiles) * (arena.remaining ?? 0),
+    res.target,
+    "what is left no longer multiplies back to the target",
+  )
+})

--- a/dynawalla/games/lattice/src/test/loop.test.ts
+++ b/dynawalla/games/lattice/src/test/loop.test.ts
@@ -22,6 +22,7 @@ import { test } from "node:test"
 
 import { Rng } from "../core/rng.ts"
 import { Arena } from "../game/arena.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { createStubHost } from "../stubHost.ts"
 import { playCarefully } from "./harness.ts"
 
@@ -35,7 +36,7 @@ test("a child who plays it properly opens resonators, over and over", () => {
       reducedMotion: true,
       onReport: (r) => reports.push({ correct: r.correct, answered: r.answered }),
     })
-    const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
+    const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700, experience: CALM_OPENINGS })
     arena.begin(0)
 
     playCarefully(arena, 9000)
@@ -56,7 +57,7 @@ test("a child who plays it properly opens resonators, over and over", () => {
 
 test("a chain builds when nothing goes wrong, and the count is honest", () => {
   const host = createStubHost({ seed: 0xc4a1, reducedMotion: true })
-  const arena = new Arena(host, new Rng(0xc4a1), { width: 1100, height: 800 })
+  const arena = new Arena(host, new Rng(0xc4a1), { width: 1100, height: 800, experience: CALM_OPENINGS })
   arena.begin(0)
   playCarefully(arena, 9000)
   assert.equal(arena.chain, arena.opened, "a clean run did not build a chain")
@@ -67,7 +68,7 @@ test("the arena never runs out of things to shoot", () => {
   // Every resonator restocks the field, so a sitting cannot arrive at an empty
   // arena with a question still on the board.
   const host = createStubHost({ seed: 0x5106, reducedMotion: true })
-  const arena = new Arena(host, new Rng(0x5106), { width: 900, height: 700 })
+  const arena = new Arena(host, new Rng(0x5106), { width: 900, height: 700, experience: CALM_OPENINGS })
   arena.begin(0)
   let emptyFrames = 0
   for (let f = 0; f < 6000; f++) {

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -20,6 +20,7 @@ import { mount } from "../contract.ts"
 import { safeRect } from "../../../../packs/shared/game-chrome/index.ts"
 import { hudLayout } from "../render/hud.ts"
 import { createStubHost } from "../stubHost.ts"
+import { noteOpen, opensEver, resetOpensForTest } from "../game/seen.ts"
 
 type Listener = (event: unknown) => void
 
@@ -668,5 +669,198 @@ test("the shell is wired to the hint: a tap unfolds the tree, and so does the qu
     Date.now = realNow
     if (savedPerformance) Object.defineProperty(globalThis, "performance", savedPerformance)
     else Reflect.deleteProperty(globalThis, "performance")
+  }
+})
+
+// ── THE FIRST SCREEN, THROUGH THE REAL SHELL ────────────────────────────────
+//
+// The calm opening hangs off one wire: `mountLattice` reads `game/seen.ts` and
+// hands it to the arena as `experience`. Every assertion in `opening.test.ts`
+// is about the arena and would pass in full with that wire cut — the arena
+// would simply never be told, and a first-time child would get the field the
+// founder reported. So it is asserted here, at the shell, on the frame a child
+// actually sees.
+//
+// What is counted is the numerals the renderer was asked to fill that are
+// nothing but digits. On the first frame that is exactly the numbers on the
+// field: the resonator's prompt has an operator and a space in it, the counters
+// read `OPENED 0` and `BEST 0`, the empty hold reads `SWEEP THE LIT ONES`, and
+// the factor tree is at stage nought and draws nothing at all.
+
+/** Run `body` with a `localStorage` that starts out holding `seed`. */
+function withStorage(seed: Record<string, string>, body: () => void): void {
+  const store = new Map(Object.entries(seed))
+  const saved = Object.getOwnPropertyDescriptor(globalThis, "localStorage")
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, String(v)),
+      removeItem: (k: string) => store.delete(k),
+    },
+  })
+  try {
+    body()
+  } finally {
+    if (saved) Object.defineProperty(globalThis, "localStorage", saved)
+    else Reflect.deleteProperty(globalThis, "localStorage")
+  }
+}
+
+/** The numerals on the field, on the first frame after mounting. */
+function numeralsOnFirstFrame(opens: string | null): string[] {
+  const counter = { calls: 0, text: [] as string[] }
+  let out: string[] = []
+  withStorage(opens === null ? {} : { "dw.lattice.opens": opens }, () => {
+    resetOpensForTest()
+    withBrowser({ w: 390, h: 740 }, counter, ({ host, frames }) => {
+      const stub = createStubHost({ seed: 0x1a771ce, reducedMotion: true })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      counter.text.length = 0
+      pump(frames, 1)
+      out = counter.text.filter((s) => /^\d+$/.test(s))
+      handle.unmount()
+    })
+    resetOpensForTest()
+  })
+  return out
+}
+
+test("a child who has never played this opens on ONE number", () => {
+  const numerals = numeralsOnFirstFrame(null)
+  assert.equal(
+    numerals.length,
+    1,
+    `the first screen of a first sitting had ${numerals.length} numbers on it: ${numerals.join(", ")}`,
+  )
+})
+
+test("a child who has played before does not get walked through it again", () => {
+  const fresh = numeralsOnFirstFrame(null)
+  const returning = numeralsOnFirstFrame("9")
+  assert.equal(fresh.length, 1)
+  assert.ok(
+    returning.length > fresh.length,
+    `a child on their tenth ring got ${returning.length} numbers, the same as a first sitting`,
+  )
+})
+
+test("what a sitting opened is remembered for the next one", () => {
+  withStorage({}, () => {
+    resetOpensForTest()
+    assert.equal(opensEver(), 0, "a device that has never run this remembers something")
+    assert.equal(noteOpen(), 1)
+    assert.equal(noteOpen(), 2)
+    assert.equal(noteOpen(), 3)
+    // A new sitting: the module's memory is gone and only what was written back
+    // is left, which is the whole point of the slot.
+    resetOpensForTest()
+    assert.equal(opensEver(), 3, "three rings opened were not there the next morning")
+    resetOpensForTest()
+  })
+})
+
+test("a frame with no storage at all still runs, and starts calm", () => {
+  // `localStorage` throws on an opaque origin, which a pack frame is. The
+  // failure mode has to be the gentle opening, never a game that will not start.
+  const saved = Object.getOwnPropertyDescriptor(globalThis, "localStorage")
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() {
+      throw new Error("SecurityError: the document is on an opaque origin")
+    },
+  })
+  try {
+    resetOpensForTest()
+    assert.equal(opensEver(), 0)
+    assert.equal(noteOpen(), 1, "a write that could not land lost the count in memory too")
+  } finally {
+    if (saved) Object.defineProperty(globalThis, "localStorage", saved)
+    else Reflect.deleteProperty(globalThis, "localStorage")
+    resetOpensForTest()
+  }
+})
+
+test("a ring opened through the shell is written down for the next sitting", () => {
+  // The other half of the wire. `numeralsOnFirstFrame` proves the shell READS
+  // what a child has opened; this proves it WRITES it, by flying the real ship
+  // through the real ring until the host hears a correct answer and then asking
+  // the storage slot what it holds.
+  //
+  // Reachable blind precisely because of the calm opening: the first field is
+  // one husk carrying the whole answer and nothing else, so every prime the
+  // ship can possibly sweep is one of the answer's own.
+  const realNow = Date.now
+  Date.now = () => 1_700_000_000_000
+  const store = new Map<string, string>()
+  const saved = Object.getOwnPropertyDescriptor(globalThis, "localStorage")
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, String(v)),
+      removeItem: (k: string) => store.delete(k),
+    },
+  })
+  try {
+    resetOpensForTest()
+    const counter = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 900, h: 700 }, counter, ({ host, frames, created }) => {
+      let opened = 0
+      const stub = createStubHost({
+        seed: 0x1a771ce,
+        reducedMotion: true,
+        // Every open calls `transition("level", ...)` and nothing else does.
+        // `report` will not do: a resonator that refused once has spent its id,
+        // so the open that follows it is never reported at all — measured, the
+        // slot held 2 against 1 correct answer, which is the shell being right
+        // and the assertion being wrong.
+        onTransition: (kind) => {
+          if (kind === "level") opened += 1
+        },
+      })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      const move = canvas.listeners.get("pointermove")?.[0]
+      assert.ok(down && move, "the twin-stick listeners were not installed")
+      down({ preventDefault() {}, pointerId: 1, pointerType: "touch", clientX: 225, clientY: 350 })
+      down({ preventDefault() {}, pointerId: 2, pointerType: "touch", clientX: 675, clientY: 350 })
+      let t = 0
+      // A circle whose heading turns about 1.4 radians a second — at the ship's
+      // top speed that is an orbit of roughly 250 units — with the heading's
+      // bias walking slowly round, so the orbit's centre crawls over the whole
+      // arena and the ship passes through everything on it, the ring included.
+      for (let i = 0; i < 30_000 && opened === 0; i++) {
+        const heading = i * 0.023 + Math.sin(i / 900) * 2.4
+        move({
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 225 + Math.cos(heading) * 70,
+          clientY: 350 + Math.sin(heading) * 70,
+        })
+        move({
+          pointerId: 2,
+          pointerType: "touch",
+          clientX: 675 + Math.cos(i / 11) * 50,
+          clientY: 350 + Math.sin(i / 13) * 50,
+        })
+        t = pump(frames, 1, t)
+      }
+      assert.ok(opened > 0, "no ring was ever opened, so there is nothing to have written down")
+      assert.equal(
+        store.get("dw.lattice.opens"),
+        String(opened),
+        `${opened} rings opened and the slot holds ${String(store.get("dw.lattice.opens"))}`,
+      )
+      handle.unmount()
+    })
+  } finally {
+    Date.now = realNow
+    if (saved) Object.defineProperty(globalThis, "localStorage", saved)
+    else Reflect.deleteProperty(globalThis, "localStorage")
+    resetOpensForTest()
   }
 })

--- a/dynawalla/games/lattice/src/test/opening.test.ts
+++ b/dynawalla/games/lattice/src/test/opening.test.ts
@@ -1,0 +1,364 @@
+// THE OPENING, MEASURED.
+//
+// "the way it starts for me now is chaotic and impossible."
+//
+// Every number in `game/opening.ts`'s header comes from this file, and the
+// point of it is that "calmer" is not a claim anybody has to take on trust. The
+// real `Arena` is armed at every step of the ramp, at three viewports, over
+// sixty seeds, and what a child would be looking at is counted.
+//
+// The shipped opening, measured the same way (the `step: 5` row below is
+// literally it, unchanged): up to six numbers on the screen before the child
+// has touched anything, the fastest of them crossing the arena's diagonal in
+// nine and a half seconds, and up to nine on the screen once that field is
+// ground down to primes.
+//
+// What a child who has never played gets instead: **one**, at a third of the
+// pace — thirty-three seconds to cross the diagonal — and never more than five
+// even after they have shot it to pieces.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena } from "../game/arena.ts"
+import { MAX_HUSK, primeFactors, productOf } from "../game/factor.ts"
+import { CALM_OPENINGS, gather, openingAt } from "../game/opening.ts"
+import { createStubHost } from "../stubHost.ts"
+
+/** Every shape the fleet has, so a bound is not a bound on one aspect ratio. */
+const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait", 390, 740],
+  ["tablet portrait", 1180, 820],
+  ["phone landscape", 844, 390],
+]
+
+const SEEDS = Array.from({ length: 60 }, (_, i) => i * 7919 + 1)
+
+/**
+ * The bounds. Measured, then written down one notch loose so an unlucky seed
+ * does not fail the suite and a regression of any size does.
+ *
+ * `bodies` is what is on the screen at t=0. `ground` is what is on the screen
+ * after every husk in that field has been shot all the way down to primes —
+ * the most that one question can ever put in front of the child. `drift` is the
+ * fastest anything is moving, as a percentage of the arena's own diagonal per
+ * second, which is the only frame-of-reference that means the same thing on a
+ * phone and on a tablet (see `arena.REFERENCE_SPAN`).
+ */
+const BOUNDS: Array<{ step: number; bodies: number; ground: number; drift: number }> = [
+  { step: 0, bodies: 1, ground: 5, drift: 3.0 },
+  { step: 1, bodies: 1, ground: 5, drift: 4.5 },
+  { step: 2, bodies: 3, ground: 6, drift: 6.3 },
+  { step: 3, bodies: 5, ground: 7, drift: 7.5 },
+  { step: 4, bodies: 6, ground: 8, drift: 9.8 },
+  { step: 5, bodies: 6, ground: 9, drift: 10.5 },
+]
+
+function armed(seed: number, w: number, h: number, experience: number): Arena {
+  const host = createStubHost({ seed, reducedMotion: true })
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: w, height: h, experience })
+  arena.begin(0)
+  return arena
+}
+
+/** The fastest thing on the field, as a fraction of the arena's diagonal. */
+function topDrift(arena: Arena, diagonal: number): number {
+  let top = 0
+  for (const body of arena.bodies) top = Math.max(top, Math.hypot(body.vx, body.vy) / diagonal)
+  return top
+}
+
+// ── the table itself ────────────────────────────────────────────────────────
+
+test("the table only ever gets busier, never calmer, as a child gets further in", () => {
+  let previous = openingAt(0)
+  for (let step = 1; step <= 40; step++) {
+    const at = openingAt(step)
+    assert.ok(at.husks >= previous.husks, `husks fell at step ${step}`)
+    assert.ok(at.chaff >= previous.chaff, `chaff fell at step ${step}`)
+    assert.ok(at.drift >= previous.drift, `the drift band fell at step ${step}`)
+    assert.ok(
+      Number(at.guided) <= Number(previous.guided),
+      `the guidance came back at step ${step}`,
+    )
+    assert.ok(at.decoy || !previous.decoy, `the decoy went away again at step ${step}`)
+    previous = at
+  }
+})
+
+test("past the ramp it is the same opening forever, and nothing before it is", () => {
+  const steady = openingAt(CALM_OPENINGS)
+  for (const step of [CALM_OPENINGS, CALM_OPENINGS + 1, 40, 4000]) {
+    assert.deepEqual({ ...openingAt(step), step: 0 }, { ...steady, step: 0 })
+  }
+  assert.equal(steady.guided, false, "the steady game walks a child through it")
+  assert.equal(steady.drift, 1, "the steady game is not the arena's own pace")
+  for (let step = 0; step < CALM_OPENINGS; step++) {
+    const at = openingAt(step)
+    assert.ok(
+      at.husks < steady.husks || at.chaff < steady.chaff || at.drift < steady.drift,
+      `step ${step} is already the full field`,
+    )
+  }
+  // Nothing that is not a number is a step, and none of them throws.
+  for (const bad of [Number.NaN, -1, Number.POSITIVE_INFINITY, -Number.MAX_VALUE]) {
+    assert.equal(openingAt(bad).step, 0, `${bad} was not read as the very beginning`)
+  }
+})
+
+test("gather conserves the product exactly, whatever it is asked for", () => {
+  const rng = new Rng(0xca1)
+  for (let trial = 0; trial < 4000; trial++) {
+    const many = rng.int(1, 8)
+    const primes: number[] = []
+    for (let i = 0; i < many; i++) primes.push(rng.pick([2, 3, 5, 7, 11, 13, 17, 19, 23, 47]))
+    const cap = rng.int(1, 6)
+    const husks = gather(primes, cap)
+    assert.equal(
+      productOf(husks),
+      productOf(primes),
+      `gather(${primes.join(",")}, ${cap}) lost or invented a factor`,
+    )
+    assert.ok(husks.length <= Math.max(cap, primes.length), "gather made more husks than asked")
+    assert.ok(husks.length >= 1, "gather made nothing out of something")
+    for (const husk of husks) {
+      assert.ok(Number.isInteger(husk) && husk >= 2, `a husk of ${husk} is not a number to shoot`)
+      assert.ok(husk <= MAX_HUSK, `a husk of ${husk} is past what the game will draw`)
+    }
+    // Cracked all the way down, it is the same multiset it was handed.
+    const back = husks.flatMap((h) => primeFactors(h)).sort((a, b) => a - b)
+    assert.deepEqual(back, primes.slice().sort((a, b) => a - b), "gather changed the factorisation")
+  }
+  assert.deepEqual(gather([], 3), [], "gather invented a husk out of nothing")
+})
+
+// ── the real arena, at every step, at every viewport ────────────────────────
+
+test("the first field is ONE number, and it carries the whole answer", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    for (const seed of SEEDS) {
+      const arena = armed(seed, w, h, 0)
+      const res = arena.resonator
+      if (!res) continue
+      assert.equal(
+        arena.bodies.length,
+        1,
+        `${name} seed ${seed}: ${arena.bodies.length} numbers on the first screen, not one`,
+      )
+      assert.equal(
+        arena.bodies[0]?.value,
+        res.target,
+        `${name} seed ${seed}: the one number is not the answer`,
+      )
+    }
+  }
+})
+
+test("the opening stays inside its bounds at every step, at every shape", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const diagonal = Math.hypot(w, h)
+    for (const bound of BOUNDS) {
+      for (const seed of SEEDS) {
+        const arena = armed(seed, w, h, bound.step)
+        const where = `${name} seed ${seed} step ${bound.step}`
+        assert.ok(
+          arena.bodies.length <= bound.bodies,
+          `${where}: ${arena.bodies.length} numbers at t=0, over the bound of ${bound.bodies}`,
+        )
+        const drift = topDrift(arena, diagonal) * 100
+        assert.ok(
+          drift <= bound.drift,
+          `${where}: something crossing ${drift.toFixed(2)}% of the diagonal a second, over ${bound.drift}`,
+        )
+
+        // Now shoot the whole field to pieces without opening anything. This is
+        // the most this one question can ever put in front of the child, and it
+        // is the number the report was actually about — every shot turns one
+        // husk into two bodies, so a busy field compounds.
+        let peak = arena.bodies.length
+        for (let guard = 0; guard < 400; guard++) {
+          const composite = arena.bodies.find((b) => !b.prime)
+          if (!composite) break
+          arena.strike(composite.id)
+          peak = Math.max(peak, arena.bodies.length)
+        }
+        assert.ok(
+          peak <= bound.ground,
+          `${where}: ${peak} numbers once the field is ground down, over ${bound.ground}`,
+        )
+      }
+    }
+  }
+})
+
+test("a child who just looks at it for a minute is never overtaken", () => {
+  for (const [name, w, h] of VIEWPORTS) {
+    const diagonal = Math.hypot(w, h)
+    for (const seed of SEEDS.slice(0, 20)) {
+      const arena = armed(seed, w, h, 0)
+      if (!arena.resonator) continue
+      // Sixty seconds, hands off the glass, sampled every second.
+      let total = 0
+      for (let second = 0; second < 60; second++) {
+        for (let frame = 0; frame < 60; frame++) arena.step(16.7)
+        assert.equal(
+          arena.bodies.length,
+          1,
+          `${name} seed ${seed}: the field grew to ${arena.bodies.length} on its own`,
+        )
+        const drift = topDrift(arena, diagonal) * 100
+        total += drift
+        // The ceiling is loose because a husk that drifts into a ship nobody is
+        // flying still shoves off it — `JOSTLE_HUSK_SPAN` is the ship's own
+        // dynamics and is deliberately not scaled down with the field. It
+        // decays back inside a second, which is what the average is for.
+        assert.ok(
+          drift <= 4.5,
+          `${name} seed ${seed}: it wound itself up to ${drift.toFixed(2)}% of a diagonal a second`,
+        )
+      }
+      const average = total / 60
+      assert.ok(
+        average <= 2.4,
+        `${name} seed ${seed}: it averaged ${average.toFixed(2)}% of a diagonal a second over the minute`,
+      )
+    }
+  }
+})
+
+test("a number that has been slowed down stays slow on a calm field", () => {
+  // The floor as well as the ceiling. `Arena.step` *accelerates* anything
+  // drifting below `DRIFT_MIN_SPAN` — the arena refuses to let a husk park —
+  // and that floor has to come down with the rest of the band or the calm field
+  // is not calm, it is merely pinned into a very narrow fast one.
+  //
+  // Measured with the floor left at the ordinary value: a husk knocked down to
+  // a crawl is wound back up to 2.1% of the arena's diagonal a second, against
+  // the 0.6% the calm band asks for. Nothing else in this file notices, because
+  // a freshly seeded husk is already near the ceiling and never visits the
+  // floor at all — it takes a bump, or a very long sitting, to get there.
+  for (const [name, w, h] of VIEWPORTS) {
+    const diagonal = Math.hypot(w, h)
+    for (const seed of SEEDS.slice(0, 10)) {
+      const arena = armed(seed, w, h, 0)
+      const body = arena.bodies[0]
+      if (!body) continue
+      // Knocked almost to a stop, the way a bump leaves one.
+      body.vx = diagonal * 0.0005
+      body.vy = 0
+      for (let f = 0; f < 900; f++) arena.step(16.7)
+      const settled = topDrift(arena, diagonal) * 100
+      assert.ok(
+        settled > 0.2,
+        `${name} seed ${seed}: the field stopped dead at ${settled.toFixed(2)}%`,
+      )
+      assert.ok(
+        settled <= 1.0,
+        `${name} seed ${seed}: a husk at a crawl was wound back up to ${settled.toFixed(2)}% of a diagonal a second`,
+      )
+    }
+  }
+})
+
+test("the ramp is walked by opening rings, and it is remembered across sittings", () => {
+  // A child who opened three yesterday comes back to the fourth field, not the
+  // first — which is the whole reason `experience` exists rather than a counter
+  // that starts at zero every time the pack is mounted.
+  const fresh = armed(0x09e11, 900, 700, 0)
+  assert.equal(fresh.openingStep, 0)
+  assert.equal(fresh.opening.guided, true, "a first sitting is not guided")
+
+  const returning = armed(0x09e11, 900, 700, 3)
+  assert.equal(returning.openingStep, 3)
+  assert.ok(
+    returning.bodies.length > fresh.bodies.length,
+    "a child on their fourth ring got the first-ring field again",
+  )
+
+  const fluent = armed(0x09e11, 900, 700, 20)
+  assert.equal(fluent.opening.guided, false, "a fluent child is still being walked through it")
+  assert.equal(fluent.liveMarks(), null, "a fluent child's field is still being marked")
+})
+
+test("opening a ring walks the child one step along the ramp", () => {
+  const host = createStubHost({ seed: 0x57e9, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0x57e9 ^ 0x51de), {
+    width: 900,
+    height: 700,
+    experience: 0,
+  })
+  arena.begin(0)
+  const before = arena.openingStep
+  const res = arena.resonator
+  assert.ok(res, "nothing was armed")
+  // Grind the one husk down and carry exactly the answer in.
+  for (let guard = 0; guard < 400; guard++) {
+    const composite = arena.bodies.find((b) => !b.prime)
+    if (!composite) break
+    arena.strike(composite.id)
+  }
+  for (const prime of primeFactors(res.target)) {
+    const mote = arena.bodies.find((b) => b.prime && b.value === prime)
+    assert.ok(mote, `the field could not supply a ${prime}`)
+    arena.touch(mote.id)
+  }
+  arena.enter(1000)
+  assert.equal(arena.opened, 1, "the ring did not open on the exact factorisation")
+  assert.equal(arena.openingStep, before + 1, "the ramp did not move")
+})
+
+test("a round the opening helped with does not climb the arena's own ladder", () => {
+  // The same rule `hint.ts` applies to a tree that stated the answer, and for
+  // the same reason: the first field carries the target on one stone and the
+  // guidance says which primes divide it, so an opening is not evidence about
+  // arithmetic. The host still hears the outcome — the progress bar still moves
+  // — and only the game's own idea of where to ask next is held.
+  //
+  // Counted at `Ladder.opened` itself rather than off `ladder.at`, because
+  // `arm` also calls `landed()` on every arming and the position therefore moves
+  // whether or not anything climbed. Reading the position would have passed
+  // with the rule deleted.
+  const play = (experience: number): { climbs: number; opened: number } => {
+    const host = createStubHost({ seed: 0x1adde2, reducedMotion: true })
+    const arena = new Arena(host, new Rng(0x1adde2 ^ 0x51de), {
+      width: 900,
+      height: 700,
+      experience,
+    })
+    let climbs = 0
+    const climb = arena.ladder.opened.bind(arena.ladder)
+    arena.ladder.opened = (): void => {
+      climbs += 1
+      climb()
+    }
+    arena.begin(0)
+    for (let round = 0; round < 3; round++) {
+      const res = arena.resonator
+      if (!res) break
+      for (let guard = 0; guard < 400; guard++) {
+        const composite = arena.bodies.find((b) => !b.prime)
+        if (!composite) break
+        arena.strike(composite.id)
+      }
+      let ok = true
+      for (const prime of primeFactors(res.target)) {
+        const mote = arena.bodies.find((b) => b.prime && b.value === prime)
+        if (!mote) {
+          ok = false
+          break
+        }
+        arena.touch(mote.id)
+      }
+      if (!ok) break
+      arena.enter(1000 * (round + 1))
+    }
+    return { climbs, opened: arena.opened }
+  }
+  const guided = play(0)
+  assert.ok(guided.opened >= 3, `only ${guided.opened} rings opened on the guided ramp`)
+  assert.equal(guided.climbs, 0, "the guided opening climbed the ladder on rounds it helped with")
+  const steady = play(CALM_OPENINGS)
+  assert.ok(steady.opened >= 3, `only ${steady.opened} rings opened at the steady state`)
+  assert.equal(steady.climbs, steady.opened, "the steady game stopped climbing at all")
+})

--- a/dynawalla/games/lattice/src/test/pacing.test.ts
+++ b/dynawalla/games/lattice/src/test/pacing.test.ts
@@ -46,6 +46,7 @@ import { Rng } from "../core/rng.ts"
 import { Arena } from "../game/arena.ts"
 import { primeFactors } from "../game/factor.ts"
 import { CEILING, FLOOR, RUNGS, rungOf } from "../game/ladder.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { MIN_TARGET, MIN_TILES, isSmooth } from "../game/resonance.ts"
 import { createStubHost, type StubHost } from "../stubHost.ts"
 import { grindToPrimes, playCarefully, rig } from "./harness.ts"
@@ -66,7 +67,7 @@ function sit(seed: number, frames = TEN_MINUTES) {
     onDraw: (d) => draws.push(d),
     onSkip: (id) => skipped.push(id),
   })
-  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700, experience: CALM_OPENINGS })
   arena.begin(0)
   const played = playCarefully(arena, frames, FRAME_MS)
   return { host, arena, draws, skipped, ...played }
@@ -274,7 +275,7 @@ test("a barren band is an arena with something to shoot, not an empty screen", (
     ...bottom,
     next: () => bottom.next({ difficulty: 0 }),
   }
-  const arena = new Arena(stuck, new Rng(0x60770), { width: 900, height: 700 })
+  const arena = new Arena(stuck, new Rng(0x60770), { width: 900, height: 700, experience: CALM_OPENINGS })
   const events = arena.begin(0)
 
   assert.equal(arena.stalled, true, "the bottom of the ladder armed a resonator")
@@ -336,7 +337,7 @@ test("the game learns from the rung that answered, not the rung it asked for", (
       return inner.next({ ...request, difficulty: STALE / (RUNGS - 1) })
     },
   }
-  const arena = new Arena(stale, new Rng(0x57a1e), { width: 900, height: 700 })
+  const arena = new Arena(stale, new Rng(0x57a1e), { width: 900, height: 700, experience: CALM_OPENINGS })
   arena.begin(0)
   assert.ok(arena.resonator, "the stale host armed nothing")
   assert.ok(asked.length > 0)
@@ -415,7 +416,7 @@ test("a question with no id is not a question, however answerable it looks", () 
     // Perfectly resonant, and unreportable.
     next: (request) => ({ ...inner.next(request), id: "", answer: "72" }),
   }
-  const arena = new Arena(dry, new Rng(0x0117e55), { width: 900, height: 700 })
+  const arena = new Arena(dry, new Rng(0x0117e55), { width: 900, height: 700, experience: CALM_OPENINGS })
   const events = arena.begin(0)
   assert.equal(arena.resonator, null, "a resonator was armed on a question with no id")
   assert.ok(events.some((e) => e.kind === "stalled"), "the arena took it and said nothing")
@@ -431,6 +432,7 @@ test("a host with no skip is still a host this game runs on", () => {
   const arena = new Arena(rest as unknown as StubHost, new Rng(0x0b4e), {
     width: 900,
     height: 700,
+    experience: CALM_OPENINGS,
   })
   arena.begin(0)
   assert.ok(arena.resonator, "a host without skip armed nothing")

--- a/dynawalla/games/lattice/src/test/ship.test.ts
+++ b/dynawalla/games/lattice/src/test/ship.test.ts
@@ -38,6 +38,7 @@ import { test } from "node:test"
 
 import { Rng } from "../core/rng.ts"
 import { Arena, HUSK_R, MOTE_R, SHIP_R, SHOT_R } from "../game/arena.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
 import { createStubHost } from "../stubHost.ts"
 
 /** The three screens this pack has to be the same game on. */
@@ -63,7 +64,7 @@ type Spawn = { spawnAt(v: number, x: number, y: number, vx: number, vy: number):
 /** An arena with nothing in it, so the ship is the only thing being measured. */
 function bare(w: number, h: number, seed = 0x5417): Arena {
   const host = createStubHost({ seed, reducedMotion: true })
-  const arena = new Arena(host, new Rng(seed), { width: w, height: h })
+  const arena = new Arena(host, new Rng(seed), { width: w, height: h, experience: CALM_OPENINGS })
   arena.begin(0)
   arena.bodies.length = 0
   arena.shots.length = 0


### PR DESCRIPTION
> "Lattice runner is pretty cool but it's too hard and fast for a human .. maybe one number at a time and a slower ramp up from an easier baseline .. first time you enter it could be just one number calmly coming down the lattice. Maybe it even highlights/hints when it is blastable and why. It needs to be a bit more hand-holdy on the first run. slower, easier, more hand-holdy. the way it starts for me now is chaotic and impossible."

## What it opened with, measured

Driving the **real `Arena`** against the stub host at three viewports over sixty seeds, at the rung a brand new profile actually starts on. `drift` is the fastest thing on the field as a percentage of the arena's own diagonal per second — the only frame of reference that means the same thing on a phone and a tablet (see `REFERENCE_SPAN`, #716). `ground down` is what is on the screen once every husk in that first field has been shot all the way to primes: the most one question can ever put in front of the child, and the number the report was actually about, because every shot turns one husk into two bodies.

| | numbers at t=0 | ground down | drift | time to cross the diagonal |
|---|---|---|---|---|
| **as it ships today** | mean 5.0, **up to 6** | **up to 9** | **10.4%** | 9.6s |
| **a first sitting now** | **1** | **up to 5** | **3.0%** | 33s |

Four to six numbers, all moving, all of which a child has to read and sort into "shoot this one" and "collect that one", on the first screen they have ever seen. That is the "chaotic and impossible", and it was not a difficulty setting — it was the whole field arriving at once.

## The ramp

Six positions, indexed by how many resonators this child has **ever** opened. `game/seen.ts` remembers that across sittings, so a child coming back to their fifth ring is not walked through the first one again.

| step | numbers at t=0 | ground down | drift | guided |
|---|---|---|---|---|
| 0 | **1** | 5 | 3.0% | yes |
| 1 | **1** | 5 | 4.5% | yes |
| 2 | 3 | 6 | 6.3% | yes |
| 3 | 5 | 7 | 7.5% | yes |
| 4 | 6 | 8 | 9.8% | no |
| 5+ | 6 | 9 | 10.4% | no |

**Step 5 is the shipped game, byte for byte** — `husks: Infinity` hands the field back to `factor.huskify` and `chaff: Infinity` hands it back to the ladder's own formula. Every quantity is monotone non-decreasing in the step and the guidance is monotone non-increasing; asserted exhaustively rather than taken on trust.

**No window, no timer, no deadline.** THE LATTICE has never had one and this does not add one. `openingAt` is a pure function of one integer and that integer counts rings the child *finished* — no speed, no accuracy, no streak, no clock.

Three things move with the step:

* **how many husks the answer is gathered into** — `gather` is deterministic and ascending, so `2·2·2·2·7` at two husks is `8` and `14` rather than `56` and `2`: the child watches a balanced tree come apart rather than a stalk;
* **the drift band**, floor *and* ceiling — the floor matters and is easy to miss, because `Arena.step` *accelerates* anything below `DRIFT_MIN_SPAN` and a husk seeded at three tenths of the pace would have been wound back to full speed inside a second;
* **the decoy and the chaff**, which arrive at steps 3 and 2 respectively.

One thing outside the table also moved: **the husk's half of a bump** is now scaled with the field (the ship's half is not — that is `SHIP_*` territory, #716). Measured unscaled: a lone husk drifting into a ship nobody was flying bumped it once a second and wound itself up to 6.1% of the diagonal — three times the calm opening's whole band, off one untouched screen.

## Which one goes in, and why

`game/live.ts`. Take the target, take out what the hold already carries, and what remains is a number.

* a lit **mote** belongs in the hold **iff it divides that number** — `needed`;
* a stone **husk** is worth shooting **iff it shares a factor with it** — `carries`, because at least one of the two pieces it breaks into is one the hold needs;
* anything else is `spare`, and a hold that has already gone *past* the target leaves `null`, so nothing is marked at all. That is the honest reading: nothing on the field can complete it, and the way out is one tap on the bar.

Drawn in the materials the pieces are already made of, not a new colour: a mote that goes in wears a **celestial collar**, a stone with a piece of the answer inside it wears a **brass** one. **And a needed mote states the reason underneath it, as arithmetic and not as a sentence — `18÷3`.** That is the "and why": language-free, so it costs nothing to translate, and it is the exact rule the game runs on rather than a paraphrase of it. A `spare` is drawn exactly as it always was — nothing is crossed out, dimmed or marked wrong, because half the point is that the contrast does the teaching.

No new manual copy. The collar and the division are the design saying it; a section describing something a child sees four times would be standing copy nobody reads and everybody pays to translate.

### It is not the factor tree (#739), and it should not share machinery

They answer different questions and the split is worth keeping:

* **`game/tree.ts` + `game/hint.ts`** say *how to factor the target* — `112` unfolding into `2·2·2·2·7` a stage at a time, on a clock the child can outrun and a control they can tap. It is about the **arithmetic**.
* **`game/live.ts`** says *which of the numbers actually in front of you right now is live*. It is about the **field**, it has no stages, no clock and no control, and it is a pure function of (target, hold, value).

A child can have the whole tree up and still not know whether the `13` drifting past is one of theirs; a child can have the collars and still not know what `642 − 530` is. Folding them together would mean the field marking inherits the tree's escalation — which is exactly wrong, because the field marking has nothing to escalate.

What they *do* share is one rule, and it is shared rather than duplicated: **a round the game guided does not climb the arena's own ladder.** `arena.enter` now reads

```ts
const given = this.hint()?.given === true || this.givenByField || this.opening.guided
```

`givenByField` is the first field carrying the target on one stone — the numeral on it *is* the answer, and that is deliberate: the first screen teaches the mechanic, not the arithmetic. It is computed from the picture after the decoy and the chaff have gone in, not from the plan, so a prime target with chaff beside it (where knowing *which* mote is the one is the round) does not trip it. As in #739 the host is still told, so the progress hairline still moves; only the game's own idea of where to ask next is held.

## Verification

* `npm run -s tsc` clean; `npm run -s test` **5× consecutively, 207/207** (was 182).
* `node packs/build.mjs lattice` builds and passes the SDK checker — `dynawalla.lattice@0.1.0`, 3 files, 88,695 bytes, capabilities `items, items.reveal, haptics`.

New assertions, at three levels:

* **`opening.test.ts`** — the real `Arena` armed at every step, three viewports, sixty seeds: numbers at t=0, numbers once ground down, top drift, then a minute of a child who is just *looking* at it sampled every second, then a husk knocked to a crawl to check the band's floor came down with its ceiling. Plus: the table is monotone both ways, `gather` conserves the product over 4,000 fuzzed cases, and the ladder rule — counted at `Ladder.opened` **itself**, because `arm` also calls `landed()` on every arming, so reading `ladder.at` would have passed with the rule deleted (it did; that is how the first cut of this test was caught).
* **`live.test.ts`** — the marking against an **independent trial-division oracle** (`divides`, `primeByHand` and `sharesAFactor` written longhand, sharing no code with the game) over ~1M (target, hold, value) triples: exactly the divisors, no more and no fewer. Then through the real `Arena`: a child who does exactly what the marking says and nothing else opens the ring on 30 seeds. Then through the real `Scene.draw` against a context that records instead of paints: the collars on the field are one per marked number **and not one more**.
* **`mount.test.ts`** — the wire. Every assertion in `opening.test.ts` would pass in full with `mount.ts` never wiring `opensEver()`, so the read side is asserted on the frame a child actually sees (the digit-only `fillText` calls on frame 1 are exactly the numbers on the field), and the write side by flying the **real ship** through the **real ring** until the host reports a level transition, then asking the storage slot what it holds. Counting opens by `report({correct})` there was wrong and the test said so out loud: a resonator that refused once has spent its id, so the open that follows it is never reported — measured, the slot held 2 against 1 correct answer.

## Mutation transcript

Twenty-one mutations, each applied to the source, the tests run, the source restored. **All twenty-one fail.**

| # | mutation | first failure |
|---|---|---|
| M1 | `arm` ignores the plan and huskifies like the shipped game | 7 failed — `a ship flew through the resonator for 5000 frames and the host was never told anything` |
| M2 | the first field is two numbers, not one | 9 failed — `the first screen of a first sitting had 2 numbers on it` |
| M3 | the field is seeded at full pace | `phone portrait seed 1 step 0: something crossing 7.85% of the diagonal a second, over 3` |
| M4 | `step`'s drift **floor** left unscaled | `phone portrait seed 1: a husk at a crawl was wound back up to 2.12% of a diagonal a second` |
| M5 | a bump shoves the husk at full pace | `phone portrait seed 79191: it wound itself up to 6.12% of a diagonal a second` |
| M6 | `openingStep` never advances within a sitting | `the ramp did not move` |
| M7 | the shell hardcodes `experience: 0` | `a child on their tenth ring got 1 numbers, the same as a first sitting` |
| M8 | the shell never calls `noteOpen()` | `1 rings opened and the slot holds undefined` |
| M9 | a guided round climbs the ladder after all | `the guided opening climbed the ladder on rounds it helped with` |
| M10 | the marking wants a prime that does **not** divide | `target 4 hold [] value 2: marked spare, is needed` |
| M11 | the marking wants every prime on the field | `target 4 hold [] value 3: marked needed, is spare` / `target 12: a marked 5 broke the hold` |
| M12 | the marking marks nothing | `seed 1: following the marking left 44 to find` / `only 0 collars were ever drawn` |
| M13 | a hold that has gone past still leaves a number | `a 5 in the hold of a 72 was not refused` |
| M14 | every stone is marked worth shooting | `target 4 hold [] value 9: marked carries, is spare` |
| M15 | the renderer never draws the collar | `seed 1: the 2 that goes in wears no collar` |
| M16 | the renderer collars everything | `seed 1: 7 collars on the field for 4 marked numbers` |
| M17 | the renderer never says why | `seed 1: the 2 says it goes in but not why` |
| M18 | the renderer never asks for the marking at all | `seed 1: the 2 that goes in wears no collar` |
| M19 | the guidance never comes off | `the guidance came back at step 5` / `a 10 was collared for a child who is past it` |
| M20 | `gather` drops the leftovers | `gather(19,17,47,11,3, 1) lost or invented a factor` |
| M21 | the persisted count is never read back | `three rings opened were not there the next morning` |

**M4 survived the first pass** and that is worth writing down: the idle-minute assertion could not see it, because a freshly seeded husk lives near the band's *ceiling* and never visits the floor at all — with the floor left at the ordinary value the band is merely pinned into a very narrow fast one, and 60 seconds of sitting still produced a byte-identical measurement. It took a new assertion that knocks a husk down to a crawl and steps it for fifteen seconds. The mutation is only killed by that test.

## What is deliberately unchanged

`ArenaOptions.experience` is **required**, not defaulted. Every construction site states it, so no shell can quietly ship either the chaotic opening or the calm one to a child who has played for a month — the same argument `render/scene.ts` makes about its `hint` argument. `test/harness.ts`'s `rig()` defaults to `CALM_OPENINGS`, so every test written before this keeps asking about the game a child who has played before actually gets.

Nothing in #739's hint work is touched, and nothing in #716's ship handling is: the ship's top speed, drag, coast, closed-form solve and its half of a jostle are all exactly as they were. A refusal is still `OXIDE` and never red.


https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
