### PR TITLE
dynawalla/games/polarity: POLARITY — a numeral drawn ON the glow instead of under it

### DIFF
--- a/dynawalla/games/polarity/src/game/constants.ts
+++ b/dynawalla/games/polarity/src/game/constants.ts
@@ -90,6 +90,41 @@ export const BULLET = {
  */
 export const ORB_SPREAD = (HALF_W - 8) * 2;
 
+/**
+ * The lane geometry that keeps two answers from sitting on top of each other.
+ *
+ * The founder's screenshot is three orbs BUNCHED, each inside the others'
+ * additive halos, and the reason was not the weave: it was that an orb never
+ * reached the lane it was aimed at. `askQuestion` gave it `vx = (tx - e.x) *
+ * 0.55` and `stepOrb` then decayed that velocity with a 0.4s half-life, so the
+ * orb travelled `0.55 * 0.4 / ln 2 ≈ 0.317` of the way to `tx` and stopped.
+ * Three orbs aimed at −28, 0 and +28 arrived at −8.9, 0 and +8.9 — nine units
+ * apart, wearing numerals nineteen units wide.
+ *
+ * So the lane is a POSITION the orb eases to, and the weave happens about it:
+ *
+ *   - `ORB_LANE_EASE` is the half-life of that ease, and it is 0.1s because the
+ *     arithmetic says so: adjacent lanes are 21 units apart at four orbs and a
+ *     numeral is 19.4 wide, so the row is only clear of itself once the ease is
+ *     92.2% of the way home — 3.68 half-lives. At 0.1s that is 0.37s, and
+ *     `seal.test.ts` holds it under half a second. A numeral is read on the way
+ *     down as well as at rest.
+ *   - `ORB_SWAY` is how far the row drifts either side, and it is driven by the
+ *     WORLD clock rather than each orb's own phase, so all of them sway
+ *     together like a curtain and the distance between two lanes is exactly the
+ *     lane width whatever the sway is doing. The weave is not sanded down to
+ *     buy the separation — it is 5.5 units, the same amplitude as the vertical
+ *     bob it plays against, and the separation is bought by the phase instead.
+ *
+ * The cap on `ORB_SWAY` is the field edge: the outermost lane of four sits at
+ * `ORB_SPREAD * 3/8 = 31.5`, its numeral reaches 9.7 further at the widest, and
+ * the field ends at 50 — so anything up to 8.8 keeps the whole row on the
+ * glass. `core/labels.test.ts` holds both bounds.
+ */
+export const ORB_LANE_EASE = 0.1;
+export const ORB_SWAY = 5.5;
+export const ORB_SWAY_RATE = 1.0;
+
 // --- enemies ----------------------------------------------------------------
 /** Enemy kinds. Same shape and the same reason as `BK`. */
 export const EK = {

--- a/dynawalla/games/polarity/src/game/seal.test.ts
+++ b/dynawalla/games/polarity/src/game/seal.test.ts
@@ -3,8 +3,17 @@ import assert from "node:assert/strict";
 
 import type { Host, Question } from "../contract.ts";
 import { tierByName } from "../core/tier.ts";
-import { BK, EK, PACE } from "./constants.ts";
-import { bossDefeated, launchBoss, onOrbTouched, stepBoss, tryLock } from "./seal.ts";
+import { BK, BULLET, EK, HALF_W, ORB_SWAY, PACE } from "./constants.ts";
+import { LABEL_ASPECT } from "../core/labels.ts";
+import {
+  bossDefeated,
+  launchBoss,
+  onOrbTouched,
+  orbLane,
+  stepBoss,
+  stepOrb,
+  tryLock,
+} from "./seal.ts";
 import { startRun, step, stratumOf, rosterOf } from "./sim.ts";
 import type { Bullet, Enemy } from "./types.ts";
 import { makeWorld, type World } from "./world.ts";
@@ -412,4 +421,125 @@ test("the run gets harder on seals broken", () => {
   step(w, 1 / 60);
   assert.equal(w.stratum, 3);
   assert.ok(w.events.includes("stratum"), "nothing marked the depth the child earned");
+});
+
+// ---------------------------------------------------------------------------
+// the answers do not sit on top of each other
+// ---------------------------------------------------------------------------
+
+/**
+ * How wide the numeral drawn on an orb is, in playfield units.
+ *
+ * `renderer.ts` draws an orb's label at `r * 1.35` tall by `LABEL_ASPECT` times
+ * that wide, and boosts it 1.18 on a screen under 520 CSS px — the founder's
+ * phone. The quad and not the ink, because the halo the numeral now wears goes
+ * right out to the ink's edge and two halos touching is two numerals touching.
+ */
+const LABEL_W = BULLET.orbR * 1.35 * LABEL_ASPECT * 1.18;
+
+/**
+ * The founder's screenshot: three answers bunched, each one inside the others'
+ * additive halos, one of them illegible.
+ *
+ * The cause was not the weave. `askQuestion` aimed each orb at a lane with
+ * `vx = (tx - e.x) * 0.55` and `stepOrb` decayed that velocity with a 0.4s
+ * half-life, so an orb covered `0.55 * 0.4 / ln 2 ≈ 32%` of the distance to its
+ * lane and stopped — three orbs aimed at −28, 0 and +28 arriving at −8.9, 0 and
+ * +8.9, wearing numerals 19.4 wide.
+ */
+test("two answers never sit inside each other's halo", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  launchBoss(w);
+  const e = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, e);
+  const dropped = orbs(w, w.seal.serial);
+  assert.equal(dropped.length, 4, "the Bearer dropped a different number of orbs");
+
+  const dt = 1 / 60;
+  let closest = Infinity;
+  let settled = -1;
+  // twelve seconds — longer than any seal is on the field
+  for (let f = 0; f < 720; f++) {
+    w.t += dt;
+    for (const b of dropped) stepOrb(w, b, dt, 1);
+    let gap = Infinity;
+    for (let i = 0; i < dropped.length; i++) {
+      for (let j = i + 1; j < dropped.length; j++) {
+        const a = dropped[i] as Bullet;
+        const b = dropped[j] as Bullet;
+        gap = Math.min(gap, Math.abs(a.x - b.x));
+      }
+    }
+    if (gap >= LABEL_W && settled < 0) settled = f * dt;
+    if (settled >= 0) closest = Math.min(closest, gap);
+    // nothing leaves the field, numeral and all
+    for (const b of dropped) {
+      assert.ok(
+        Math.abs(b.x) + LABEL_W / 2 <= HALF_W,
+        `an orb's numeral reached ${(Math.abs(b.x) + LABEL_W / 2).toFixed(1)} of ${String(HALF_W)}`,
+      );
+    }
+  }
+  assert.ok(settled >= 0, "the orbs never separated at all");
+  assert.ok(
+    settled <= 0.5,
+    `the answers were still overlapping ${settled.toFixed(2)}s after they were dropped`,
+  );
+  assert.ok(
+    closest >= LABEL_W,
+    `two answers came within ${closest.toFixed(1)} units, and a numeral is ${LABEL_W.toFixed(1)} wide`,
+  );
+});
+
+/**
+ * The sway is not sanded down to buy that separation — it is bought with PHASE.
+ * Every orb is at the same offset at the same instant, so the gap between two
+ * lanes is the lane width whatever the row is doing, and the amplitude stays
+ * the same 5.5 units as the bob it plays against.
+ */
+test("the row still sways, all of it together", () => {
+  const { host } = fakeHost(CURRICULUM);
+  const w = world(host);
+  launchBoss(w);
+  const e = w.enemies[w.enemyN - 1] as Enemy;
+  askUntilSeal(w, e);
+  const dropped = orbs(w, w.seal.serial);
+  const dt = 1 / 60;
+  for (let f = 0; f < 240; f++) {
+    w.t += dt;
+    for (const b of dropped) stepOrb(w, b, dt, 1);
+  }
+  // on station: x is exactly lane + sway, and the offsets agree
+  const offsets = dropped.map((b) => b.x - b.lane);
+  const spread = Math.max(...offsets) - Math.min(...offsets);
+  assert.ok(spread < 1e-9, `the orbs sway out of step by ${spread.toFixed(4)} units`);
+
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (let f = 0; f < 600; f++) {
+    w.t += dt;
+    for (const b of dropped) stepOrb(w, b, dt, 1);
+    const o = (dropped[0] as Bullet).x - (dropped[0] as Bullet).lane;
+    lo = Math.min(lo, o);
+    hi = Math.max(hi, o);
+  }
+  assert.ok(
+    hi - lo > ORB_SWAY * 1.9,
+    `the row only swept ${(hi - lo).toFixed(1)} units of a possible ${String(ORB_SWAY * 2)}`,
+  );
+});
+
+test("a lane is wide enough for the numeral that stands in it", () => {
+  // Two, three or four orbs — `orbValues` fills up to four and stops early if
+  // the distractors collide, and the tightest lane is therefore four.
+  for (const n of [2, 3, 4]) {
+    for (let i = 0; i + 1 < n; i++) {
+      const gap = orbLane(i + 1, n) - orbLane(i, n);
+      assert.ok(gap >= LABEL_W, `with ${String(n)} orbs the lanes are ${gap.toFixed(1)} apart`);
+    }
+    // and the outermost numeral stays on the glass at the far end of the sway
+    const outer = Math.abs(orbLane(n - 1, n)) + ORB_SWAY + LABEL_W / 2;
+    assert.ok(outer <= HALF_W, `the outer numeral reaches ${outer.toFixed(1)} at full sway`);
+  }
 });

--- a/dynawalla/games/polarity/src/game/seal.ts
+++ b/dynawalla/games/polarity/src/game/seal.ts
@@ -10,7 +10,10 @@ import {
   EK,
   ENEMY,
   HALF_W,
+  ORB_LANE_EASE,
   ORB_SPREAD,
+  ORB_SWAY,
+  ORB_SWAY_RATE,
   PACE,
   SCORE,
   polColor,
@@ -278,10 +281,10 @@ function askQuestion(w: World, e: Enemy, orbCount: number): boolean {
     if (!o) continue;
     const b = addBullet(w);
     if (!b) continue;
-    const tx = -ORB_SPREAD / 2 + (ORB_SPREAD * (i + 0.5)) / n;
+    b.lane = orbLane(i, n);
     b.x = e.x;
     b.y = e.y - e.r * 0.4;
-    b.vx = (tx - e.x) * 0.55;
+    b.vx = 0;
     b.vy = -ORB_SPEED_IN;
     b.v = o.v;
     b.r = BULLET.orbR;
@@ -302,19 +305,37 @@ function askQuestion(w: World, e: Enemy, orbCount: number): boolean {
   return true;
 }
 
-/** Orb flight: glide to the presentation band, hover and weave, then leave. */
+/**
+ * Where the i-th of n orbs presents its numeral. Lanes, evenly across the
+ * spread, and the ONLY thing that decides an orb's x once it is on station.
+ */
+export function orbLane(i: number, n: number): number {
+  return -ORB_SPREAD / 2 + (ORB_SPREAD * (i + 0.5)) / Math.max(1, n);
+}
+
+/**
+ * Orb flight: glide to the presentation band, hover and weave, then leave.
+ *
+ * `x` is `lane + sway` and nothing else — no integration, no leftover velocity.
+ * The sway is a function of the WORLD clock, so every orb in a row is at the
+ * same offset at the same instant and two lanes stay exactly one lane width
+ * apart for the whole presentation. That is what keeps a numeral out of its
+ * neighbour's halo; see `ORB_SWAY` for why it is bought with phase instead of
+ * with amplitude.
+ */
 export function stepOrb(w: World, b: Bullet, dt: number, hurry: number): void {
   const band = -w.halfH * 0.06;
   b.wob += dt * 1.15;
+  const sway = Math.cos(w.t * ORB_SWAY_RATE) * ORB_SWAY;
   if (b.y > band) {
     b.y += b.vy * dt * hurry;
-    b.vx = approach(b.vx, 0, 0.4, dt);
-    b.x += b.vx * dt;
+    // ease to the lane on the way down: an orb is read while it is falling
+    b.x = approach(b.x, b.lane + sway, ORB_LANE_EASE, dt);
   } else {
     b.y = approach(b.y, band + Math.sin(b.wob * 1.3) * 5.5, 0.5, dt);
-    b.x += Math.cos(b.wob * 0.9 + b.v) * 11 * dt * hurry;
-    b.x = clamp(b.x, -HALF_W + b.r, HALF_W - b.r);
+    b.x = b.lane + sway;
   }
+  b.x = clamp(b.x, -HALF_W + b.r, HALF_W - b.r);
   b.rot += (b.v > 0 ? 0.9 : -0.7) * dt;
   if (b.grow > 0) b.grow = Math.max(0, b.grow - dt * 3.4);
 }

--- a/dynawalla/games/polarity/src/game/sim.ts
+++ b/dynawalla/games/polarity/src/game/sim.ts
@@ -263,7 +263,7 @@ function absorb(w: World, b: Bullet): void {
   });
   if (big) {
     ring(w, w.px, w.py, 3.2, polHot(b.v), 0.3, 1.4);
-    addText(w, b.v, b.x, b.y, polHot(b.v));
+    addText(w, b.v, b.x, b.y);
     punch(w, 0.18);
     w.host.haptic("light");
   }

--- a/dynawalla/games/polarity/src/game/types.ts
+++ b/dynawalla/games/polarity/src/game/types.ts
@@ -43,6 +43,13 @@ export type Bullet = {
   dmg: number;
   wob: number;
   grow: number;
+  /**
+   * Seal orbs only: the x this orb presents at, in playfield units.
+   *
+   * The lane is state and not a velocity because a velocity was what shipped,
+   * and a decaying velocity does not arrive — see `ORB_LANE_EASE`.
+   */
+  lane: number;
 };
 
 export type Enemy = {
@@ -105,9 +112,6 @@ export type FloatText = {
   /** the number to print */
   value: number;
   size: number;
-  r: number;
-  g: number;
-  b: number;
 };
 
 export type SealState = "idle" | "asking" | "won" | "lost";

--- a/dynawalla/games/polarity/src/game/world.ts
+++ b/dynawalla/games/polarity/src/game/world.ts
@@ -190,6 +190,7 @@ const mkBullet = (): Bullet => ({
   dmg: 1,
   wob: 0,
   grow: 0,
+  lane: 0,
 });
 
 const mkEnemy = (): Enemy => ({
@@ -247,9 +248,6 @@ const mkText = (): FloatText => ({
   life: 1,
   value: 0,
   size: 1,
-  r: 1,
-  g: 1,
-  b: 1,
 });
 
 function fill<T>(n: number, f: () => T): T[] {
@@ -365,6 +363,7 @@ export function addBullet(w: World): Bullet | null {
   b.dmg = 1;
   b.wob = 0;
   b.grow = 0;
+  b.lane = 0;
   b.spin = 0;
   b.rot = 0;
   b.owner = 0;
@@ -405,7 +404,13 @@ export function addPart(w: World): Particle | null {
   return p;
 }
 
-export function addText(w: World, value: number, x: number, y: number, c: readonly number[]): void {
+/**
+ * A rising numeral. It carries no colour of its own: what it is drawn in is
+ * derived from the surfaces it rises through, in `render/ink.ts`, keyed on the
+ * sign of the value — which is the same thing the `polHot` tint it used to be
+ * handed was keyed on, and now it comes with a halo that can survive them.
+ */
+export function addText(w: World, value: number, x: number, y: number): void {
   if (w.textN >= w.texts.length) return;
   const t = w.texts[w.textN] as FloatText;
   w.textN++;
@@ -417,9 +422,6 @@ export function addText(w: World, value: number, x: number, y: number, c: readon
   t.life = 0.95;
   t.value = value;
   t.size = 6.4;
-  t.r = c[0] as number;
-  t.g = c[1] as number;
-  t.b = c[2] as number;
 }
 
 // ---------------------------------------------------------------------------

--- a/dynawalla/games/polarity/src/render/atlas.ts
+++ b/dynawalla/games/polarity/src/render/atlas.ts
@@ -1,4 +1,5 @@
 import { CanvasTexture, LinearFilter, SRGBColorSpace, Texture } from "three";
+import { HALO_ALPHA } from "./ink.ts";
 import {
   LABEL_ASPECT,
   LABEL_CELL_H,
@@ -16,10 +17,11 @@ const FACE =
 /**
  * The numerals on the playfield, painted on demand.
  *
- * White on transparent so the shader can tint per instance; a soft dark rim is
- * baked in so a numeral stays readable when it lands on top of its own additive
- * glow. Nothing is baked ahead of time — a cell is painted the first frame its
- * value is asked for, which is what lets an orb carry `3916` as easily as `7`.
+ * A MASK, not a picture: the glyph is white and the halo stroked around it is
+ * black, so `t.r` is the glyph and `t.a` is the blob, and the shader colours
+ * both per instance from `ink.ts`. Nothing is baked ahead of time — a cell is
+ * painted the first frame its value is asked for, which is what lets an orb
+ * carry `3916` as easily as `7`.
  *
  * Cells are `LABEL_ASPECT` times wider than they are tall. A long answer gets
  * width, not a horizontal squeeze: every numeral on the field is drawn at the
@@ -117,10 +119,21 @@ export class LabelAtlas {
     const w = g.measureText(s).width;
     if (w > LABEL_INK_W) g.scale(LABEL_INK_W / w, 1);
 
-    // dark contrast rim first, then the solid face
+    // The halo first, then the glyph inside it. Both are painted in pure
+    // channels rather than in colour: `a` is the whole inked blob and `r` is
+    // the glyph alone, and `LABEL_FRAG` mixes the instance's ink and counter-
+    // ink between them. So the atlas never decides a colour, which is the
+    // point — the colour is decided by the surface, in `ink.ts`.
+    //
+    // OPAQUE, and that is the fix. It was `rgba(0,0,0,0.92)`, which under the
+    // additive blending this layer used to have contributed literally nothing:
+    // black adds nothing, so the contrast rim the pack believed it had never
+    // existed. At alpha 1 over `NormalBlending` the halo replaces the ground,
+    // which is what makes the 4.5:1 letterform claim a claim about the halo
+    // instead of about whatever the glyph happened to land on.
     g.lineJoin = "round";
     g.miterLimit = 2;
-    g.strokeStyle = "rgba(0,0,0,0.92)";
+    g.strokeStyle = `rgba(0,0,0,${String(HALO_ALPHA)})`;
     g.lineWidth = 13;
     g.strokeText(s, 0, 2);
     g.fillStyle = "#ffffff";
@@ -151,7 +164,8 @@ export function buildPromptTexture(prompt: string, wpx = 1024, hpx = 256): Textu
   if (w > maxW) g.scale(maxW / w, 1);
   g.lineJoin = "round";
   g.miterLimit = 2;
-  g.strokeStyle = "rgba(0,0,0,0.94)";
+  // opaque, for the same reason the numerals' halo is — see `LabelAtlas.paint`
+  g.strokeStyle = `rgba(0,0,0,${String(HALO_ALPHA)})`;
   g.lineWidth = 20;
   g.strokeText(prompt, 0, 4);
   g.fillStyle = "#ffffff";

--- a/dynawalla/games/polarity/src/render/ink.test.ts
+++ b/dynawalla/games/polarity/src/render/ink.test.ts
@@ -1,0 +1,303 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  AA_WIDTHS,
+  FLOAT_HOLD,
+  HALO_ALPHA,
+  INK_DARK,
+  INK_LIGHT,
+  LABEL_CLASSES,
+  MIN_LETTERFORM,
+  MIN_OBJECT,
+  add,
+  bestAdditiveInk,
+  bestSingleInk,
+  contrast,
+  inkPole,
+  inkTable,
+  labelInk,
+  letterformEdge,
+  luma,
+  surfacesFor,
+  worstEdge,
+  type RGB,
+} from "./ink.ts";
+
+/**
+ * THE LEGIBILITY TABLE, and the arithmetic that says why it had to be a pair.
+ *
+ * The founder could not see one of three answers. What follows is measured over
+ * a port of the fragment shader evaluated on the exact rectangle each numeral's
+ * quad covers, at the antialias width of three real devices, over every
+ * additive lift that lands on it — not spot-checked on one screen, which is how
+ * the illegible orb shipped in the first place.
+ *
+ * ```
+ *  class        shipped   any additive   any opaque      NOW: letterform  object
+ *  orbPos         1.00        1.00          1.04              18.40        4.31
+ *  orbNeg         1.00        1.00          1.03              18.40        4.30
+ *  chargePos      1.00        1.00          1.02              18.40        4.30
+ *  chargeNeg      1.00        1.00          1.05              18.40        4.30
+ *  floatPos       1.04        1.04          1.22              18.40        4.43
+ *  floatNeg       1.15        1.15          1.23              18.40        4.29
+ *  wardenLock     1.00        1.00          1.03              18.40        4.29
+ *  prompt         1.04        1.04          1.22              18.40        4.43
+ * ```
+ *
+ * Read the middle two columns first, because they are the reason this is not a
+ * palette change. **"any additive"** is the best ratio ANY additive ink could
+ * reach against these surfaces, and on an orb it is 1.00:1 — the ground is
+ * already clipped, so there is nothing left to add. The shipped `polHot` tint
+ * was ALREADY at that ceiling: recolouring it could not have gained a
+ * hundredth. **"any opaque"** is the best a single non-additive ink could do,
+ * 1.02–1.23:1, because these numerals are drawn over both a bright hull and the
+ * black field at once and no one colour separates from both.
+ *
+ * So: an ink plus an opaque counter-ink halo, `NormalBlending`, drawn in an
+ * overlay pass after the bloom. 18.40:1 letterform, 4.29:1 worst object.
+ */
+test("the legibility table: every numeral, every surface, before and after", () => {
+  const rows = inkTable();
+  const lines = ["", "  class        shipped   any additive   any opaque   letterform   object  pole"];
+  for (const r of rows) {
+    lines.push(
+      "  " +
+        r.cls.padEnd(12) +
+        r.before.toFixed(2).padStart(6) +
+        r.additiveCeiling.toFixed(2).padStart(14) +
+        r.singleCeiling.toFixed(2).padStart(13) +
+        r.letterform.toFixed(2).padStart(13) +
+        r.object.toFixed(2).padStart(9) +
+        "  " +
+        r.pole,
+    );
+  }
+  console.log(lines.join("\n"));
+
+  assert.equal(rows.length, LABEL_CLASSES.length);
+  for (const r of rows) {
+    assert.ok(
+      r.letterform >= MIN_LETTERFORM,
+      `${r.cls}: a numeral reads ${r.letterform.toFixed(2)}:1 against its own halo`,
+    );
+    assert.ok(
+      r.object >= MIN_OBJECT,
+      `${r.cls}: the inked numeral reads ${r.object.toFixed(2)}:1 against the worst surface it lands on`,
+    );
+  }
+});
+
+/**
+ * The dead end, stated as arithmetic so nobody rediscovers it by hand.
+ *
+ * This is the assertion that says "choose a better colour" was never going to
+ * work. It is about the SHIPPED compositing mode, so it does not move when the
+ * ink does — it moves when the surfaces do.
+ */
+test("no additive ink of any colour could have been read on these objects", () => {
+  for (const cls of LABEL_CLASSES) {
+    const steady = surfacesFor(cls, "glow");
+    const ceiling = bestAdditiveInk(steady);
+    assert.ok(
+      ceiling < MIN_LETTERFORM,
+      `${cls}: an additive glyph could reach ${ceiling.toFixed(2)}:1, which clears the bar — ` +
+        `the pack would not have needed a halo`,
+    );
+  }
+  // and on the four objects with a lit hull it is the floor of the scale: there
+  // is a surface under the numeral that is already clipped to white.
+  for (const cls of ["orbPos", "orbNeg", "wardenLock", "chargePos"] as const) {
+    const ceiling = bestAdditiveInk(surfacesFor(cls, "glow"));
+    assert.ok(
+      ceiling < 1.01,
+      `${cls}: additive ceiling is ${ceiling.toFixed(3)}:1 — the saturated surface has gone`,
+    );
+  }
+});
+
+test("no single opaque ink could have been read on them either", () => {
+  for (const cls of LABEL_CLASSES) {
+    const steady = surfacesFor(cls, "glow");
+    const ceiling = bestSingleInk(steady);
+    assert.ok(
+      ceiling < MIN_LETTERFORM,
+      `${cls}: one opaque ink could reach ${ceiling.toFixed(2)}:1 — recolouring alone would do`,
+    );
+  }
+});
+
+/**
+ * The bars hold on the smallest screen this program supports, on the founder's
+ * phone, and on a tablet — which is what the antialias width IS.
+ *
+ * `w = max(0.012, uPx / size * 1.6)` and `uPx` is world units per device pixel,
+ * so a coarse screen is a wide soft edge and therefore a whole band of
+ * intermediate surface that a crisp screen never produces. Measuring only the
+ * crisp one is measuring the device the author happens to be sitting at.
+ */
+test("every bar holds at 320×568, at the founder's 1080×2340, and on a tablet", () => {
+  const named = [
+    ["320×568 dpr1", AA_WIDTHS[2] as number],
+    ["1080×2340 dpr2", AA_WIDTHS[1] as number],
+    ["tablet / desktop", AA_WIDTHS[0] as number],
+  ] as const;
+  for (const [screen, w] of named) {
+    for (const cls of LABEL_CLASSES) {
+      const s = surfacesFor(cls, "flash", [w]);
+      const pair = labelInk(cls);
+      const lf = letterformEdge(pair, s);
+      const ob = worstEdge(pair, s);
+      assert.ok(lf >= MIN_LETTERFORM, `${cls} on ${screen}: letterform ${lf.toFixed(2)}:1`);
+      assert.ok(ob >= MIN_OBJECT, `${cls} on ${screen}: object ${ob.toFixed(2)}:1`);
+    }
+  }
+});
+
+/**
+ * The halo is what the letterform bar is a claim ABOUT, so the bar has to be
+ * sensitive to the halo's alpha — and it is: both colours are composited
+ * against the surface at their own alpha, so a translucent halo is a tint of
+ * whatever is behind it and the two converge.
+ *
+ * The value that shipped was 0.92, which under additive blending meant nothing
+ * at all. It is 1 now, and if it ever stops being 1 this number falls.
+ */
+test("a translucent halo would fail the letterform bar, which is why it is opaque", () => {
+  const pair = labelInk("orbPos");
+  const surfaces = surfacesFor("orbPos", "flash");
+  // the shipped alpha, applied to the pair that ships now
+  const shaky = (haloAlpha: number): number => {
+    let worst = Infinity;
+    for (const s of surfaces) {
+      const halo: RGB = [0, 1, 2].map(
+        (i) => pair.halo[i as 0 | 1 | 2] * haloAlpha + s[i as 0 | 1 | 2] * (1 - haloAlpha),
+      ) as unknown as RGB;
+      worst = Math.min(worst, contrast(pair.ink, halo));
+    }
+    return worst;
+  };
+  assert.equal(HALO_ALPHA, 1, "the atlas strokes the halo at HALO_ALPHA");
+  assert.ok(shaky(1) >= MIN_LETTERFORM, `opaque: ${shaky(1).toFixed(2)}:1`);
+  assert.ok(
+    shaky(0.5) < MIN_LETTERFORM,
+    `a half-opaque halo measures ${shaky(0.5).toFixed(2)}:1, so this test would not notice one`,
+  );
+  assert.ok(letterformEdge(pair, surfaces) >= MIN_LETTERFORM);
+});
+
+/**
+ * A float text dissolves as it rises, and a dissolving numeral loses contrast
+ * by construction — both its colours fade toward the ground. So the question is
+ * not whether it stays at 4.5:1 forever (nothing that fades does) but for how
+ * much of its life it is above the bar, and the answer has to be most of it.
+ *
+ * `renderer.ts` holds the instance alpha at 1 for the first stretch of the rise
+ * and dissolves after. The alpha at which the letterform bar breaks is ~0.565,
+ * which lands at just past half of the 0.95s life.
+ */
+test("a rising float text is above the letterform bar for most of its life", () => {
+  const pair = labelInk("floatPos");
+  const surfaces = surfacesFor("floatPos", "flash");
+  // `fillLabels`: alpha = clamp01((1 - k) * FLOAT_HOLD) ** 2, k = age / life
+  const alphaAt = (k: number): number => Math.min(1, Math.max(0, (1 - k) * FLOAT_HOLD)) ** 2;
+  let legibleUntil = 0;
+  for (let i = 0; i <= 100; i++) {
+    const k = i / 100;
+    if (letterformEdge(pair, surfaces, alphaAt(k)) >= MIN_LETTERFORM) legibleUntil = k;
+  }
+  assert.ok(
+    legibleUntil >= 0.5,
+    `a float text drops under ${String(MIN_LETTERFORM)}:1 after ${(legibleUntil * 100).toFixed(0)}% of its rise`,
+  );
+  assert.ok(
+    letterformEdge(pair, surfaces, alphaAt(1)) < MIN_LETTERFORM,
+    "a fully dissolved numeral is somehow still above the bar — the fade is not a fade",
+  );
+});
+
+/**
+ * The pole is DERIVED. Same function, two grounds, two answers — which is the
+ * thing a fixed colour cannot do and the reason `labelInk` takes a class rather
+ * than a constant.
+ */
+test("the ink pole follows the ground rather than being chosen", () => {
+  const ground = surfacesFor("orbPos", "none");
+  const brighter = ground.map((s) => add([0.6, 0.6, 0.6], s));
+  const darker = ground.map((s) => [s[0] * 0.05, s[1] * 0.05, s[2] * 0.05] as RGB);
+  assert.equal(inkPole(brighter), "dark", "a washed-out ground is still being given a light ink");
+  assert.equal(inkPole(darker), "light", "a black ground is still being given a dark ink");
+  assert.notEqual(inkPole(brighter), inkPole(darker), "the pole does not depend on the ground");
+  // and the pair really is the two poles, opposite ways round
+  const pair = labelInk("orbPos");
+  assert.deepEqual([...pair.ink], [...INK_LIGHT]);
+  assert.deepEqual([...pair.halo], [...INK_DARK]);
+});
+
+/**
+ * The poles themselves. `MIN_OBJECT` is a guarantee and not a hope because
+ * these two are far enough apart that their CROSSOVER — the ground luminance at
+ * which neither is the obviously better choice — still clears 3.0. A softer
+ * pair would leave a band of ground where a numeral is invisible whichever way
+ * round it is drawn, and the band is exactly where a bright hull meets a dark
+ * field, which is where every numeral in this pack is.
+ */
+test("the poles are far enough apart that no ground can defeat both", () => {
+  assert.ok(contrast(INK_LIGHT, INK_DARK) >= 18, "the poles are 18:1 or better apart");
+  let worst = Infinity;
+  let worstAt = 0;
+  for (let i = 0; i <= 1000; i++) {
+    const v = i / 1000;
+    const s: RGB = [v, v, v];
+    const best = Math.max(contrast(INK_LIGHT, s), contrast(INK_DARK, s));
+    if (best < worst) {
+      worst = best;
+      worstAt = luma(s);
+    }
+  }
+  assert.ok(
+    worst >= MIN_OBJECT,
+    `the worst ground for this pair is luminance ${worstAt.toFixed(3)} at ${worst.toFixed(2)}:1`,
+  );
+  // and a softer pair genuinely fails it, so the bar above is about THESE poles
+  let soft = Infinity;
+  for (let i = 0; i <= 1000; i++) {
+    const v = i / 1000;
+    const s: RGB = [v, v, v];
+    soft = Math.min(soft, Math.max(contrast([0.75, 0.75, 0.78], s), contrast([0.2, 0.2, 0.24], s)));
+  }
+  assert.ok(soft < MIN_OBJECT, `a softened pair reaches ${soft.toFixed(2)}:1, so 3.0 is free`);
+});
+
+/**
+ * The two facts about the renderer that the model above cannot see, and that
+ * the whole table depends on.
+ *
+ * Everything else here is arithmetic over a port of the shader, and arithmetic
+ * cannot tell you which blend mode a `ShaderMaterial` was handed or which scene
+ * a mesh was added to. Those two lines ARE the fix — an additive numeral
+ * measures 1.00:1 on a clipped ground however carefully its colours were
+ * derived, and a numeral inside the bloomed scene is read through the bloom —
+ * and both are one word long, easy to change back by accident, and silent when
+ * wrong. A WebGL context in node would be a better guard; there isn't one, and
+ * a brittle guard on the exact thing that broke beats no guard.
+ */
+test("the numerals are normal-blended, and they are in the overlay scene", () => {
+  const src = readFileSync(new URL("./renderer.ts", import.meta.url), "utf8");
+  const start = src.indexOf("this.labels = makeLayer(");
+  assert.ok(start > 0, "the label layer is not built by `this.labels = makeLayer(` any more");
+  const block = src.slice(start, src.indexOf("\n    );", start));
+  assert.match(
+    block,
+    /NormalBlending/,
+    "the label layer is additive again — see the header of ink.ts: its ceiling is 1.00:1",
+  );
+  assert.match(
+    src,
+    /this\.overlay\.add\(this\.labels\.mesh/,
+    "the numerals are back inside the bloomed scene, under the glow instead of over it",
+  );
+  // and the overlay pass has to be composited without clearing what came before
+  assert.match(src, /over\.clear = false;/, "the overlay pass clears the frame it lands on");
+});

--- a/dynawalla/games/polarity/src/render/ink.ts
+++ b/dynawalla/games/polarity/src/render/ink.ts
@@ -1,0 +1,659 @@
+/**
+ * WHAT A NUMERAL LANDS ON, AND WHAT COLOUR IT THEREFORE HAS TO BE.
+ *
+ * The founder played POLARITY and reported: *"polarity needs contrast in some
+ * parts like i cant see the answers."* The screenshot shows three answer orbs
+ * bunched together in the hot palette; two are readable and pale, and the third
+ * has no numeral on it at all that a person can see.
+ *
+ * The third orb is not a colour-list problem, and the difference matters,
+ * because recolouring cannot fix it. **The numerals were drawn with
+ * `AdditiveBlending`** (`renderer.ts` defaulted the label layer to it, like
+ * every other layer in this vector-monitor pack). Two things follow, and both
+ * are arithmetic rather than taste:
+ *
+ *   1. **The baked contrast rim was a no-op.** `atlas.ts` strokes a dark ring
+ *      around every glyph and `LABEL_FRAG` resolves that ring to `vec3(0.0)`.
+ *      Under `src * srcAlpha + dst`, black adds nothing. The rim the pack
+ *      believed it had never darkened a single pixel. It cost texture, it cost
+ *      a stroke per tile, and it did nothing at all.
+ *   2. **An additive glyph cannot exceed 1.00:1 on a saturated ground.** Where
+ *      the framebuffer is already at 1.0 in a channel, adding ink cannot change
+ *      it. An orb's own additive halo is `exp(-...)*0.55` over a body that is
+ *      already `POS_A` bright, and orbs OVERLAP — their halos add — so the
+ *      centre of a bunch genuinely clips to white. `bestAdditiveInk()` scans
+ *      every colour and reports the ceiling: **1.00:1 on an orb.** That is not
+ *      "low contrast". That is the third orb, exactly, and no palette change
+ *      reaches it.
+ *
+ * COUNTERPOISE (`games/balance/src/ink.ts`, PR #758) hit the same wall from the
+ * other side — an opaque `fillText` on bright brass, ceiling 1.24:1 — and the
+ * answer it landed on is the one used here, because it is the only one that
+ * works: **a numeral is a pair.** An ink, and an opaque counter-ink halo
+ * stroked behind it, both derived from the surfaces of the object being drawn,
+ * with two bars:
+ *
+ *   1. **Letterform**, `MIN_LETTERFORM = 4.5:1`. The glyph is resolved against
+ *      the halo that rings it. The halo is opaque and encircles the glyph, so
+ *      it IS the ground for the shape of the digit — but only once the layer is
+ *      `NormalBlending`, which is the other half of the fix.
+ *   2. **Object**, `MIN_OBJECT = 3.0:1`. The inked blob as a whole against
+ *      whatever it lies on, with either the ink or the halo allowed to carry
+ *      it. 3.0 and not 4.5 for the reason `balance/src/ink.ts` sets out: at the
+ *      crossover ground luminance no two-colour scheme clears 4.5, not even
+ *      pure black and pure white.
+ *
+ * ## The bloom is part of the surface, and here it is part of the SCENE
+ *
+ * POLARITY composites glow in two places. Every tier has the in-shader additive
+ * halo, which is what actually blew out the founder's screenshot (that device
+ * detects as `mid`, which has no bloom pass at all). The `ultra` tier adds an
+ * `UnrealBloomPass` on top. Both are modelled here, both land in the surface
+ * catalogue, and the renderer now draws the numerals into an OVERLAY scene
+ * composited after the bloom pass rather than into the bloomed scene — so the
+ * glow is under the glyph instead of over it. What the glyph is read against is
+ * therefore `SURFACES`, which is measured, and not "whatever the post chain did
+ * to it afterwards", which is not.
+ *
+ * ## Why the surfaces are computed and not listed
+ *
+ * A colour list in a test file is a snapshot, and a snapshot goes stale the
+ * first time somebody warms up a palette. So the shader's own numbers live here
+ * — `PAL`, `ORB`, `CHG`, `HALO` — and `shaders.ts` interpolates them into the
+ * GLSL. The catalogue is then produced by evaluating a port of the fragment
+ * function over the exact rectangle the label quad covers. If the orb gets
+ * brighter, the table moves.
+ */
+
+export type RGB = readonly [number, number, number];
+
+/** Ink against the halo that rings it. WCAG AA body text. */
+export const MIN_LETTERFORM = 4.5;
+
+/** The inked blob against the ground it lies on. WCAG 1.4.11 non-text contrast. */
+export const MIN_OBJECT = 3.0;
+
+// ------------------------------------------------------------------ the maths
+
+/**
+ * Relative luminance, 0..1, of an sRGB triple in 0..1.
+ *
+ * These shaders write raw values to the framebuffer — no tone map, no transfer
+ * — so a shader's `vec3` IS an sRGB triple and this is the curve that applies
+ * to it. Same maths as `balance/src/ink.ts` and STACK's `strata.ts`, a
+ * different unit only because this pack's palette is floats.
+ */
+export function luma(c: RGB): number {
+  const f = (v: number): number => {
+    const x = Math.min(1, Math.max(0, v));
+    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2]);
+}
+
+/** WCAG contrast ratio between two opaque colours, 1..21. */
+export function contrast(a: RGB, b: RGB): number {
+  const la = luma(a);
+  const lb = luma(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** `AdditiveBlending`: `src * srcAlpha + dst`, clamped by the framebuffer. */
+export function add(src: RGB, dst: RGB, alpha = 1): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.min(1, src[i] * alpha + dst[i]);
+  return [m(0), m(1), m(2)];
+}
+
+/** `NormalBlending`: `src * srcAlpha + dst * (1 - srcAlpha)`. */
+export function over(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => src[i] * alpha + dst[i] * (1 - alpha);
+  return [m(0), m(1), m(2)];
+}
+
+const mix = (a: RGB, b: RGB, t: number): RGB => [
+  a[0] + (b[0] - a[0]) * t,
+  a[1] + (b[1] - a[1]) * t,
+  a[2] + (b[2] - a[2]) * t,
+];
+
+const scale = (a: RGB, k: number): RGB => [a[0] * k, a[1] * k, a[2] * k];
+
+const WHITE: RGB = [1, 1, 1];
+
+// ------------------------------------------------------------------ the poles
+
+/**
+ * The two colours an ink or a halo is ever drawn in.
+ *
+ * Cool rather than pure black and white: the cabinet clears to `#03040b` and
+ * the whole register is a phosphor monitor, so `INK_DARK` is that same deep
+ * navy pushed to its floor and `INK_LIGHT` is a slightly blue paper white.
+ * Between them they measure 18.4:1, four times the letterform bar, and — the
+ * number that matters for `MIN_OBJECT` — their crossover is 4.29:1, so against
+ * ANY ground whatsoever one of the two clears 3.0. That is what lets the object
+ * bar be a guarantee rather than a hope, and it is why they sit this far into
+ * their corners instead of being tastefully softened.
+ */
+export const INK_LIGHT: RGB = [0.933, 0.957, 1.0];
+export const INK_DARK: RGB = [0.016, 0.02, 0.055];
+
+/**
+ * Which pole an ink should be, for an object whose ground is `ground`.
+ *
+ * Counted, not chosen: whichever pole clears the letterform bar against more of
+ * the ground wins, ties going to light. The halo is then the other one, so the
+ * decision is made once and the pair follows.
+ */
+export function inkPole(ground: readonly RGB[]): "light" | "dark" {
+  let nl = 0;
+  let nd = 0;
+  for (const s of ground) {
+    if (contrast(INK_LIGHT, s) >= MIN_LETTERFORM) nl++;
+    if (contrast(INK_DARK, s) >= MIN_LETTERFORM) nd++;
+  }
+  return nl >= nd ? "light" : "dark";
+}
+
+export type InkPair = { ink: RGB; halo: RGB };
+
+/** The ink and the counter-ink halo for a numeral read against `ground`. */
+export function inkPairFor(ground: readonly RGB[]): InkPair {
+  return inkPole(ground) === "light"
+    ? { ink: INK_LIGHT, halo: INK_DARK }
+    : { ink: INK_DARK, halo: INK_LIGHT };
+}
+
+/**
+ * The alpha the halo is stroked at in `atlas.ts`, and the reason the letterform
+ * bar is a claim rather than a tautology.
+ *
+ * At 1 the halo replaces the ground and the glyph is read against the halo,
+ * which is 18.4:1 whatever is underneath. Below 1 the halo is a tint of the
+ * ground and the two converge — at the 0.92 that shipped it is still fine, at
+ * 0.5 it is not — so `letterformEdge` blends both through it and the bar is
+ * measured rather than restated.
+ */
+export const HALO_ALPHA = 1;
+
+/**
+ * How long a rising float text holds full opacity before it dissolves.
+ *
+ * Its instance alpha is `clamp01((1 - age/life) * FLOAT_HOLD) ** 2`, so at 1
+ * the numeral starts fading the instant it appears and is under the letterform
+ * bar by a quarter of the way up — measurably, `ink.test.ts` computes the
+ * crossing. At 1.6 it is opaque for the first 37% of the rise and above the bar
+ * for just over half of it, and it still dissolves to nothing at the same
+ * moment it always did. A confirmation a child cannot read is not a
+ * confirmation.
+ */
+export const FLOAT_HOLD = 1.6;
+
+/**
+ * The worst letterform contrast this pair presents over `surfaces`.
+ *
+ * One fragment carries both colours — `mix(halo, ink, t.r)` at `t.a * vAlpha` —
+ * so the glyph and the ring around it are each composited against the SURFACE
+ * at their own alpha, and it is the pair of results that the eye resolves the
+ * shape of the digit from. `alpha` is the instance alpha, which is 1 for
+ * everything except a float text dissolving as it rises.
+ */
+export function letterformEdge(pair: InkPair, surfaces: readonly RGB[], alpha = 1): number {
+  let worst = Infinity;
+  for (const s of surfaces) {
+    const halo = over(pair.halo, s, HALO_ALPHA * alpha);
+    const ink = over(pair.ink, s, alpha);
+    worst = Math.min(worst, contrast(ink, halo));
+  }
+  return worst;
+}
+
+/**
+ * The worst object-contrast an ink/halo pair presents over `surfaces`.
+ *
+ * Per surface the better of the two edges, because an inked blob is visible if
+ * EITHER the glyph or the ring around it separates from the ground; the minimum
+ * over every surface is the number `MIN_OBJECT` is asserted against.
+ */
+export function worstEdge(pair: InkPair, surfaces: readonly RGB[]): number {
+  let worst = Infinity;
+  for (const s of surfaces) {
+    worst = Math.min(worst, Math.max(contrast(pair.ink, s), contrast(pair.halo, s)));
+  }
+  return worst;
+}
+
+/**
+ * The best contrast ANY single opaque ink could reach against all of
+ * `surfaces` — the ceiling a lone `fillText` works under.
+ *
+ * Contrast depends on an ink only through its luminance, so scanning the 256
+ * greys bounds every colour: no hue beats the grey of the same luminance.
+ */
+export function bestSingleInk(surfaces: readonly RGB[]): number {
+  let best = 0;
+  for (let v = 0; v <= 255; v++) {
+    const ink: RGB = [v / 255, v / 255, v / 255];
+    let worst = Infinity;
+    for (const s of surfaces) worst = Math.min(worst, contrast(ink, s));
+    best = Math.max(best, worst);
+  }
+  return best;
+}
+
+/**
+ * The best contrast any single ADDITIVE ink could reach — the ceiling the
+ * shipped numerals worked under, and the reason this file exists.
+ *
+ * An additive glyph can only ever brighten what is behind it, so its edge
+ * against a surface `s` is `contrast(min(1, s + ink), s)`. Where `s` is already
+ * at 1.0 that is 1.00:1 for every ink there is, and the scan says so.
+ */
+export function bestAdditiveInk(surfaces: readonly RGB[]): number {
+  let best = 0;
+  for (let v = 0; v <= 255; v++) {
+    const ink: RGB = [v / 255, v / 255, v / 255];
+    let worst = Infinity;
+    for (const s of surfaces) worst = Math.min(worst, contrast(add(ink, s), s));
+    best = Math.max(best, worst);
+  }
+  return best;
+}
+
+/** What the SHIPPED scheme measured: an additive ink of `ink` over `surfaces`. */
+export function additiveEdge(ink: RGB, surfaces: readonly RGB[]): number {
+  let worst = Infinity;
+  for (const s of surfaces) worst = Math.min(worst, contrast(add(ink, s), s));
+  return worst;
+}
+
+// --------------------------------------------------------------- the palette
+//
+// The shader's own colours. `shaders.ts` interpolates these into `COMMON`, so
+// the catalogue below and the GLSL that paints the pixels cannot disagree.
+
+export const PAL = {
+  posA: [1.0, 0.8, 0.28] as RGB,
+  posB: [1.0, 0.38, 0.06] as RGB,
+  negA: [0.22, 0.86, 1.0] as RGB,
+  negB: [0.44, 0.28, 1.0] as RGB,
+  neuA: [0.8, 0.83, 0.92] as RGB,
+} as const;
+
+/** The seal orb, as the fragment shader draws it. */
+export const ORB = {
+  r: 0.86,
+  body: 0.68,
+  rim: 0.075,
+  rimAmp: 1.4,
+  collar: 1.16,
+  collarTh: 0.045,
+} as const;
+
+/** The charge plate — the other bullet that carries a printed numeral. */
+export const CHG = { r: 0.92, body: 0.8, rim: 0.1 } as const;
+
+/** The additive glow every bullet wears, on every tier. */
+export const HALO = { r: 0.9, k: 2.6, amp: 0.55 } as const;
+
+/** How the three layers are mixed into the fragment's colour. */
+export const MIXW = { body: 0.9, rim: 1.5 } as const;
+
+/** The Warden hull, which prints the total its lock demands. */
+export const WARD = { r: 1.0, shell: 0.075, haloR: 0.95, haloK: 3.0, haloAmp: 0.3 } as const;
+
+// -------------------------------------------------------------- the backdrop
+//
+// Not sampled: the backdrop fragment is a sum of independent terms and what the
+// catalogue needs is its RANGE, so the terms are added at their extremes. Dim
+// is the vignette floor with nothing lit; bright is every term at once — the
+// grid line, the nebula band, the overload floor glow and the grain — which is
+// what the bottom of the field looks like at a full core band.
+
+function backdropSet(pol: RGB): RGB[] {
+  const base: RGB = [0.026, 0.016, 0.036];
+  const dim: RGB = scale(base, 0.35);
+  // every term at once: the polarity wash, a grid line, the nebula band, the
+  // overload floor glow and the grain — the bottom of the field at a full band.
+  const grid = mix([0.1, 0.34, 0.62], pol, 0.35);
+  const overload: RGB = [1.0, 0.25, 0.3];
+  const bright = ([0, 1, 2] as const).map(
+    (i) => base[i] + pol[i] * 0.03 + grid[i] * 0.26 + pol[i] * 0.022 + overload[i] * 0.22 + 0.007,
+  ) as unknown as RGB;
+  return [dim, base, mix(dim, bright, 0.5), bright];
+}
+
+// --------------------------------------------------------- the fragment port
+//
+// A port of the branches of `BULLET_FRAG` and `ENEMY_FRAG` that carry numerals.
+// Every constant it uses is imported from the block above, which is the same
+// block the GLSL is built from.
+
+const aa = (d: number, w: number): number => 1 - smoothstep(-w, w, d);
+
+function smoothstep(e0: number, e1: number, x: number): number {
+  const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return t * t * (3 - 2 * t);
+}
+
+/** `ngon` from `COMMON`: a regular n-gon as a radius-like scalar. */
+function ngon(x: number, y: number, n: number, rot: number): number {
+  const a = Math.atan2(y, x) - rot;
+  const k = (Math.PI * 2) / n;
+  const m = ((((a + k * 0.5) % k) + k) % k) - k * 0.5;
+  return Math.hypot(x, y) * (Math.cos(m) / Math.cos(k * 0.5));
+}
+
+/**
+ * The colour a seal orb or a charge plate contributes at local point (x, y).
+ *
+ * `pull` is the magnet state — a charge bullet being sucked into the ship, which
+ * triples its halo and lights its body. Orbs are never pulled (`PLAYER.absorb`
+ * is documented as never reaching them), which is why they are only ever
+ * sampled at zero.
+ */
+function bulletAt(
+  kind: "orb" | "charge",
+  pol: 1 | -1,
+  x: number,
+  y: number,
+  w: number,
+  pull: number,
+): RGB {
+  const A = pol > 0 ? PAL.posA : PAL.negA;
+  const B = pol > 0 ? PAL.posB : PAL.negB;
+  const r = Math.hypot(x, y);
+  if (r > 3) return [0, 0, 0];
+  let body: number;
+  let rim: number;
+  if (kind === "orb") {
+    const d = (pol > 0 ? ngon(x, y, 6, 0) : r) - ORB.r;
+    body = aa(d, w) * ORB.body;
+    rim = aa(Math.abs(d) - ORB.rim, w) * ORB.rimAmp;
+    const coll = Math.abs(r - ORB.collar) - ORB.collarTh;
+    rim += aa(coll, w) * (0.5 + 0.5 * Math.sin(Math.atan2(y, x) * 8));
+  } else {
+    const d = (pol > 0 ? ngon(x, y, 4, 0.785) : r) - CHG.r;
+    body = aa(d, w) * CHG.body;
+    rim = aa(Math.abs(d) - CHG.rim, w);
+  }
+  const halo = Math.exp(-Math.max(0, r - HALO.r) * HALO.k) * HALO.amp;
+  const col: RGB = [0, 1, 2].map((i) => {
+    const j = i as 0 | 1 | 2;
+    return (
+      B[j] * body * MIXW.body +
+      A[j] * rim * MIXW.rim +
+      A[j] * halo * (0.5 + pull) +
+      A[j] * pull * 0.7 * body
+    );
+  }) as unknown as RGB;
+  const a = Math.min(1, Math.max(Math.max(body, rim * 1.1), halo));
+  return scale(col, a);
+}
+
+/** The colour the Warden hull contributes at local point (x, y). */
+function wardenAt(pol: 1 | -1, x: number, y: number, w: number, t: number, hurt: number): RGB {
+  const A = pol > 0 ? PAL.posA : PAL.negA;
+  const r = Math.hypot(x, y);
+  if (r > 2.4) return [0, 0, 0];
+  const o = ngon(x, y, 8, 0) - WARD.r;
+  let shell = aa(Math.abs(o) - WARD.shell, w);
+  shell += aa(Math.abs(ngon(x, y, 4, t * 0.4) - 0.7) - 0.045, w) * 0.9;
+  shell += aa(Math.abs(r - 0.34) - 0.05, w);
+  const halo = Math.exp(-Math.max(0, r - WARD.haloR) * WARD.haloK) * WARD.haloAmp;
+  const col: RGB = [0, 1, 2].map((i) => {
+    const j = i as 0 | 1 | 2;
+    return (
+      A[j] * shell * (1.3 + hurt * 0.9) +
+      mix([0, 0, 0], [1.0, 0.35, 0.32], hurt * 0.5)[j] * shell * 0.5 +
+      A[j] * halo
+    );
+  }) as unknown as RGB;
+  const a = Math.min(1, Math.max(shell, 0) + halo);
+  return scale(col, a);
+}
+
+// ------------------------------------------------------------- the catalogue
+
+/**
+ * The classes of numeral this pack prints. Each one is a different object with
+ * a different ground, which is the entire point of deriving rather than fixing:
+ * "one colour that works on the orb" is what shipped.
+ */
+export type LabelClass =
+  | "orbPos"
+  | "orbNeg"
+  | "chargePos"
+  | "chargeNeg"
+  | "floatPos"
+  | "floatNeg"
+  | "wardenLock"
+  | "prompt";
+
+export const LABEL_CLASSES: readonly LabelClass[] = [
+  "orbPos",
+  "orbNeg",
+  "chargePos",
+  "chargeNeg",
+  "floatPos",
+  "floatNeg",
+  "wardenLock",
+  "prompt",
+];
+
+/**
+ * The antialias widths a fragment is evaluated at, which is where SCREEN SIZE
+ * enters the table.
+ *
+ * `w` is `max(0.012, clamp(uPx / size, 0.004, 0.9) * 1.6)` and `uPx` is world
+ * units per device pixel, so it is the whole of the device in one number: 0.012
+ * is the shader's own floor and what a desktop or a retina tablet reaches,
+ * 0.031 is the founder's 1080 × 2340 phone, and 0.09 is a 320 × 568 phone at
+ * dpr 1 — the smallest screen this program supports. A soft edge is a wide band
+ * of intermediate colour, so sampling all three is what puts the in-between
+ * surfaces of a small screen into the catalogue instead of only the crisp ones.
+ */
+export const AA_WIDTHS: readonly number[] = [0.012, 0.031, 0.09];
+
+/**
+ * The additive lifts that land on a numeral AFTER its own object is drawn.
+ *
+ * In order: nothing; then the `UnrealBloomPass` on the `ultra` tier, which
+ * runs at strength 0.55 to 1.55 over a blurred copy of the frame and therefore
+ * adds back a fraction of the object's own colour on top of it, bounded here at
+ * all of it; then the full-screen flash in `FRONT_FRAG`, which is a whiteout by
+ * design and is why `WHITE` is in every catalogue.
+ *
+ * A NEIGHBOURING orb's halo is deliberately not a term any more, and that is a
+ * measured absence rather than an assumed one: with the lane keeping in
+ * `seal.ts` the closest two orbs come is one lane width, 3.9 orb radii, where
+ * `exp(-(3.9 - 0.9) * 2.6) * 0.55` is 0.0002 — four thousandths of a percent.
+ * Before it, three orbs sat inside one another and their halos added.
+ *
+ * None of this is what makes the shipped scheme unfixable, though, and that is
+ * worth being exact about: an orb's own rim is `A * rim * 1.5` with `rim`
+ * reaching 1.4, which clips a channel on its own. `bestAdditiveInk` over the
+ * catalogue with NO lift at all is still 1.007:1. The founder's third orb needs
+ * no neighbour and no bloom to explain it — a numeral crossing the orb's own
+ * rim was additive ink on a surface that was already at 1.0.
+ *
+ * They are LIFTS and not replacements because every one of them is composited
+ * with `src * srcAlpha + dst` — the framebuffer keeps what was already there
+ * and gains this on top, clamped at 1.0. Which is exactly why the third orb has
+ * no numeral: at the top of this list there is nothing left to add.
+ */
+function liftsFor(glow: RGB, flash: boolean): readonly RGB[] {
+  const steady: RGB[] = [
+    [0, 0, 0],
+    scale(glow, 0.25),
+    scale(glow, 0.55),
+    scale(glow, 1.0),
+  ];
+  return flash ? [...steady, scale(WHITE, 0.5), WHITE] : steady;
+}
+
+/** The label quad's half-extent, in the units the object's fragment uses. */
+function labelRect(cls: LabelClass): { hx: number; hy: number } {
+  // `renderer.ts`: an orb's label is drawn at `r * 1.35`, a charge's at
+  // `r * 1.55`, the Warden's at `r * 1.15`, each times `LABEL_ASPECT` wide and
+  // times a 1.18 boost on a narrow screen; the object's own fragment is in
+  // units of its radius. The boosts do not cancel — the bullet's is 1.22 — so
+  // the widest relative label is the unboosted one, and that is what is used.
+  const aspect = 2.25;
+  if (cls === "wardenLock") return { hx: (1.15 * aspect) / 2, hy: 1.15 / 2 };
+  if (cls === "chargePos" || cls === "chargeNeg") return { hx: (1.55 * aspect) / 2, hy: 1.55 / 2 };
+  return { hx: (1.35 * aspect) / 2, hy: 1.35 / 2 };
+}
+
+/**
+ * How much of the additive stack a catalogue includes.
+ *
+ *   - `"none"` — the DOMINANT GROUND: the object and the field, and nothing
+ *     composited on top. This is what picks the pole, for the reason
+ *     `balance/src/ink.ts` gives: a surface that is under the glyph for a
+ *     hundred milliseconds of a flash should not get an equal vote with the
+ *     body of the thing the numeral is written on.
+ *   - `"glow"` — the STEADY state: plus the object's own halo, a neighbour's,
+ *     and the `ultra` bloom. Everything that is on the glass continuously. This
+ *     is what the "before" column is measured against, because the founder's
+ *     third orb was not mid-flash — it was just sitting there.
+ *   - `"flash"` — everything, including the whiteout in `FRONT_FRAG`. The bars
+ *     are asserted against this.
+ */
+export type Lift = "none" | "glow" | "flash";
+
+/**
+ * EVERY surface a numeral of this class can land on.
+ *
+ * The object's own fragment, evaluated on a grid over the exact rectangle the
+ * label quad covers, composited over each backdrop extreme, at each of the
+ * antialias widths a real device produces — then every one of those lifted by
+ * each of `LIFTS`. Float texts and the prompt have no object of their own, so
+ * their ground is the field: the backdrop, plus a bullet's halo, because a
+ * float text rises through whatever it was spawned on top of.
+ */
+export function surfacesFor(
+  cls: LabelClass,
+  lift: Lift = "flash",
+  widths: readonly number[] = AA_WIDTHS,
+): RGB[] {
+  const pol: 1 | -1 = cls.endsWith("Neg") ? -1 : 1;
+  const A = pol > 0 ? PAL.posA : PAL.negA;
+  const back = backdropSet(A);
+  const lifts = lift === "none" ? [[0, 0, 0] as RGB] : liftsFor(A, lift === "flash");
+  const out: RGB[] = [];
+  const push = (s: RGB): void => {
+    for (const l of lifts) out.push(add(l, s));
+  };
+
+  if (cls === "floatPos" || cls === "floatNeg" || cls === "prompt") {
+    // No hull of its own. It rises through the field, and the field's brightest
+    // thing that is not an object is a bullet's halo at full strength.
+    for (const b of back) {
+      push(b);
+      push(add(scale(A, HALO.amp), b));
+    }
+    return out;
+  }
+
+  const { hx, hy } = labelRect(cls);
+  const N = 13;
+  for (const w of widths) {
+    for (let iy = 0; iy < N; iy++) {
+      const y = -hy + (2 * hy * iy) / (N - 1);
+      for (let ix = 0; ix < N; ix++) {
+        const x = -hx + (2 * hx * ix) / (N - 1);
+        const pulls = cls.startsWith("charge") ? [0, 1] : [0];
+        for (const pull of pulls) {
+          const obj =
+            cls === "wardenLock"
+              ? wardenAt(pol, x, y, w, 0, 0)
+              : bulletAt(cls.startsWith("orb") ? "orb" : "charge", pol, x, y, w, pull);
+          for (const b of back) push(add(obj, b));
+        }
+      }
+    }
+  }
+  if (cls === "wardenLock") {
+    // A hit flash whites the hull out for a few frames, and the rotating inner
+    // ring means the sample grid alone misses phases of the hull.
+    for (const t of [1.6, 3.1]) {
+      for (let iy = 0; iy < 5; iy++) {
+        const y = -hy + (2 * hy * iy) / 4;
+        for (let ix = 0; ix < 9; ix++) {
+          const x = -hx + (2 * hx * ix) / 8;
+          push(add(wardenAt(pol, x, y, 0.031, t, 1), back[1] as RGB));
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/** The ink and halo a numeral of this class is drawn in. Derived, once. */
+const CACHE = new Map<LabelClass, InkPair>();
+
+export function labelInk(cls: LabelClass): InkPair {
+  const hit = CACHE.get(cls);
+  if (hit) return hit;
+  const pair = inkPairFor(surfacesFor(cls, "none"));
+  CACHE.set(cls, pair);
+  return pair;
+}
+
+/** Which class a bullet's numeral belongs to. */
+export function classOfBullet(isOrb: boolean, v: number): LabelClass {
+  if (isOrb) return v < 0 ? "orbNeg" : "orbPos";
+  return v < 0 ? "chargeNeg" : "chargePos";
+}
+
+/** Which class a rising float text belongs to. */
+export function classOfFloat(v: number): LabelClass {
+  return v < 0 ? "floatNeg" : "floatPos";
+}
+
+/** A row of the legibility table: what shipped, and what ships now. */
+export type InkRow = {
+  cls: LabelClass;
+  /** the ceiling for ANY additive ink — what the shipped scheme could reach */
+  additiveCeiling: number;
+  /** what the shipped `polHot`/`gold` additive tint actually measured */
+  before: number;
+  /** the ceiling for any single opaque ink, i.e. recolouring alone */
+  singleCeiling: number;
+  /** ink against its own halo */
+  letterform: number;
+  /** the inked blob against the worst surface it lands on */
+  object: number;
+  pole: "light" | "dark";
+};
+
+/** What the shipped numeral of each class was tinted. `constants.ts` colours. */
+const SHIPPED: Record<LabelClass, RGB> = {
+  orbPos: [1.0, 0.97, 0.86],
+  orbNeg: [0.83, 0.95, 1.0],
+  chargePos: [1.0, 0.97, 0.86],
+  chargeNeg: [0.83, 0.95, 1.0],
+  floatPos: [1.0, 0.97, 0.86],
+  floatNeg: [0.83, 0.95, 1.0],
+  wardenLock: [1.0, 0.88, 0.5],
+  prompt: [1.0, 0.88, 0.5],
+};
+
+export function inkRow(cls: LabelClass): InkRow {
+  const steady = surfacesFor(cls, "glow");
+  const everything = surfacesFor(cls, "flash");
+  const pair = labelInk(cls);
+  return {
+    cls,
+    additiveCeiling: bestAdditiveInk(steady),
+    before: additiveEdge(SHIPPED[cls], steady),
+    singleCeiling: bestSingleInk(steady),
+    letterform: letterformEdge(pair, everything),
+    object: worstEdge(pair, everything),
+    pole: pair.ink === INK_LIGHT ? "light" : "dark",
+  };
+}
+
+export const inkTable = (): InkRow[] => LABEL_CLASSES.map(inkRow);
+
+export { WHITE };

--- a/dynawalla/games/polarity/src/render/renderer.ts
+++ b/dynawalla/games/polarity/src/render/renderer.ts
@@ -22,10 +22,11 @@ import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPa
 import { LABEL_COLS, LABEL_ROWS } from "../core/labels.ts";
 import type { Tier } from "../core/tier.ts";
 import { clamp, clamp01, wobble } from "../core/util.ts";
-import { BK, COL, EK, HALF_W, PLAYER, polColor, polHot } from "../game/constants.ts";
+import { BK, EK, HALF_W, PLAYER, polColor } from "../game/constants.ts";
 import type { Bullet, Enemy, FloatText, Particle } from "../game/types.ts";
 import type { World } from "../game/world.ts";
 import { LabelAtlas, buildPromptTexture } from "./atlas.ts";
+import { FLOAT_HOLD, classOfBullet, classOfFloat, labelInk, type LabelClass } from "./ink.ts";
 import {
   BACKDROP_FRAG,
   BACKDROP_VERT,
@@ -100,6 +101,20 @@ export class Renderer {
   readonly canvas: HTMLCanvasElement;
   private readonly gl: WebGLRenderer;
   private readonly scene = new Scene();
+  /**
+   * The numerals, and only the numerals.
+   *
+   * A second scene composited AFTER the bloom pass and after the full-screen
+   * composite, rather than a layer inside the first one. Both of those are
+   * additive whole-screen lifts, and a numeral drawn underneath them is read
+   * THROUGH them: the bloom bleeds an orb's own glow across its digits and a
+   * flash whites the field out. Underneath is where the founder's third orb
+   * was. Above, the glyph's ground is its own opaque halo and nothing
+   * composited later can wash it out — which is what makes the table in
+   * `ink.test.ts` a statement about what is on the glass rather than about an
+   * intermediate buffer.
+   */
+  private readonly overlay = new Scene();
   private readonly cam = new OrthographicCamera(-50, 50, 70, -70, 0, 10);
   private composer: EffectComposer | null = null;
   private bloom: UnrealBloomPass | null = null;
@@ -190,7 +205,13 @@ export class Renderer {
     };
     this.uBullet = { uBoost: { value: 1 }, uPx: { value: 0.1 } };
     this.uEnemy = { uTime: { value: 0 }, uPx: { value: 0.1 } };
-    this.uPrompt = { uMap: { value: null }, uAlpha: { value: 0 }, uCol: { value: [1, 1, 1] } };
+    const promptInk = labelInk("prompt");
+    this.uPrompt = {
+      uMap: { value: null },
+      uAlpha: { value: 0 },
+      uCol: { value: [...promptInk.ink] },
+      uHalo: { value: [...promptInk.halo] },
+    };
 
     this.backdrop = new Mesh(QUAD, shader(BACKDROP_VERT, BACKDROP_FRAG, this.uBack, NormalBlending));
     this.backdrop.frustumCulled = false;
@@ -223,12 +244,20 @@ export class Renderer {
     );
     this.labels = makeLayer(
       512,
-      { iPos: 2, iSize: 1, iTile: 1, iAlpha: 1, iCol: 3 },
-      shader(LABEL_VERT, LABEL_FRAG, {
-        uMap: { value: this.atlas.texture },
-        uGrid: { value: new Vector2(LABEL_COLS, LABEL_ROWS) },
-        uAspect: { value: this.atlas.aspect },
-      }),
+      { iPos: 2, iSize: 1, iTile: 1, iAlpha: 1, iCol: 3, iHalo: 3 },
+      shader(
+        LABEL_VERT,
+        LABEL_FRAG,
+        {
+          uMap: { value: this.atlas.texture },
+          uGrid: { value: new Vector2(LABEL_COLS, LABEL_ROWS) },
+          uAspect: { value: this.atlas.aspect },
+        },
+        // NOT additive, unlike every other layer here. An additive glyph cannot
+        // darken anything, so its halo is a no-op and its ceiling on a clipped
+        // ground is 1.00:1 — see `ink.ts`.
+        NormalBlending,
+      ),
       40,
     );
 
@@ -243,12 +272,13 @@ export class Renderer {
         varying vec2 vUv; uniform vec2 uPos; uniform vec2 uSize;
         void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(uPos + position.xy * uSize, 0.0, 1.0); }`,
         /* glsl */ `
-        varying vec2 vUv; uniform sampler2D uMap; uniform float uAlpha; uniform vec3 uCol;
+        varying vec2 vUv;
+        uniform sampler2D uMap; uniform float uAlpha; uniform vec3 uCol; uniform vec3 uHalo;
         void main(){
           vec4 t = texture2D(uMap, vUv);
           float a = t.a * uAlpha;
           if (a < 0.005) discard;
-          gl_FragColor = vec4(mix(vec3(0.0), uCol, t.r), a);
+          gl_FragColor = vec4(mix(uHalo, uCol, t.r), a);
         }`,
         { ...this.uPrompt, uPos: { value: new Vector2(0, 0) }, uSize: { value: new Vector2(1, 1) } },
         NormalBlending,
@@ -261,13 +291,24 @@ export class Renderer {
     this.front.frustumCulled = false;
     this.front.renderOrder = 100;
 
-    for (const l of [this.waves, this.parts, this.enemies, this.bullets, this.labels])
-      this.scene.add(l.mesh);
-    this.scene.add(this.player, this.promptMesh, this.front);
+    for (const l of [this.waves, this.parts, this.enemies, this.bullets]) this.scene.add(l.mesh);
+    this.scene.add(this.player, this.front);
+    this.overlay.add(this.labels.mesh, this.promptMesh);
 
     this.buildPost(tier);
   }
 
+  /**
+   * The post chain, and where the numerals sit in it.
+   *
+   * `RenderPass` draws into the READ buffer and declares `needsSwap = false`,
+   * which is exactly what an overlay needs: a second one with `clear = false`
+   * placed after the bloom paints the numerals on top of the frame the rest of
+   * the chain has built, and the grade still runs over the result so the
+   * numerals get the same aberration and grain as everything else and do not
+   * look pasted on. When there is no grade the bloom is the pass that reaches
+   * the screen, and the overlay follows it there.
+   */
   private buildPost(tier: Tier): void {
     this.composer?.dispose();
     this.composer = null;
@@ -280,12 +321,17 @@ export class Renderer {
       this.bloom = new UnrealBloomPass(new Vector2(this.w, this.h), 0.62, 0.68, 0.12);
       c.addPass(this.bloom);
     }
+    const over = new RenderPass(this.overlay, this.cam);
+    over.clear = false;
     if (tier.grade) {
+      c.addPass(over);
       this.grade = new ShaderPass(GRADE_SHADER as never);
       this.grade.renderToScreen = true;
       c.addPass(this.grade);
-    } else if (this.bloom) {
-      this.bloom.renderToScreen = true;
+    } else {
+      if (this.bloom) this.bloom.renderToScreen = true;
+      over.renderToScreen = true;
+      c.addPass(over);
     }
     this.composer = c;
     c.setSize(this.w, this.h);
@@ -393,8 +439,16 @@ export class Renderer {
       this.bloom.strength = 0.55 + fx.glow * 0.5 + (w.reduced ? 0 : tr * 0.5);
     }
 
-    if (this.composer) this.composer.render();
-    else this.gl.render(this.scene, this.cam);
+    if (this.composer) {
+      this.composer.render();
+    } else {
+      // LOW tier: no post chain at all, so the overlay is a second direct
+      // render with the clear suppressed. The numerals still land last.
+      this.gl.render(this.scene, this.cam);
+      this.gl.autoClear = false;
+      this.gl.render(this.overlay, this.cam);
+      this.gl.autoClear = true;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -517,24 +571,22 @@ export class Renderer {
     const tile = (L.attrs.iTile as InstancedBufferAttribute).array as Float32Array;
     const alpha = (L.attrs.iAlpha as InstancedBufferAttribute).array as Float32Array;
     const col = (L.attrs.iCol as InstancedBufferAttribute).array as Float32Array;
+    const halo = (L.attrs.iHalo as InstancedBufferAttribute).array as Float32Array;
     let n = 0;
-    const put = (
-      x: number,
-      y: number,
-      s: number,
-      t: number,
-      a: number,
-      c: readonly number[],
-    ): void => {
+    const put = (x: number, y: number, s: number, t: number, a: number, cls: LabelClass): void => {
       if (n >= L.cap || t < 0) return;
+      const pair = labelInk(cls);
       pos[n * 2] = x;
       pos[n * 2 + 1] = y;
       size[n] = s;
       tile[n] = t;
       alpha[n] = a;
-      col[n * 3] = c[0] as number;
-      col[n * 3 + 1] = c[1] as number;
-      col[n * 3 + 2] = c[2] as number;
+      col[n * 3] = pair.ink[0];
+      col[n * 3 + 1] = pair.ink[1];
+      col[n * 3 + 2] = pair.ink[2];
+      halo[n * 3] = pair.halo[0];
+      halo[n * 3 + 1] = pair.halo[1];
+      halo[n * 3 + 2] = pair.halo[2];
       n++;
     };
 
@@ -547,20 +599,22 @@ export class Renderer {
         this.orbFault(b.v, b.kind === BK.Orb);
         continue;
       }
-      const s = (b.kind === BK.Orb ? b.r * 1.35 : b.r * 1.55) * boost;
-      put(b.x, b.y, s, t, 1, polHot(b.v));
+      const isOrb = b.kind === BK.Orb;
+      const s = (isOrb ? b.r * 1.35 : b.r * 1.55) * boost;
+      put(b.x, b.y, s, t, 1, classOfBullet(isOrb, b.v));
     }
     for (let i = 0; i < w.textN; i++) {
       const t = w.texts[i] as FloatText;
       const k = clamp01(t.age / t.life);
-      put(t.x, t.y, t.size * (1 + k * 0.5), A.tileFor(t.value), (1 - k) * (1 - k), [t.r, t.g, t.b]);
+      const a = Math.min(1, (1 - k) * FLOAT_HOLD) ** 2;
+      put(t.x, t.y, t.size * (1 + k * 0.5), A.tileFor(t.value), a, classOfFloat(t.value));
     }
     // the Warden prints the exact total it demands, right on its hull
     for (let i = 0; i < w.enemyN; i++) {
       const e = w.enemies[i] as Enemy;
       if (e.kind !== EK.Warden || e.lockState !== 1) continue;
       const pulse = 0.7 + 0.3 * Math.sin(w.wall * 5);
-      put(e.x, e.y, e.r * 1.15, A.tileFor(e.lockWant), pulse, COL.gold);
+      put(e.x, e.y, e.r * 1.15, A.tileFor(e.lockWant), pulse, "wardenLock");
     }
     A.flush();
     L.geo.instanceCount = n;
@@ -620,7 +674,6 @@ export class Renderer {
     (u.uPos as { value: Vector2 }).value.set(host.x, host.y + host.r * 1.28);
     (u.uSize as { value: Vector2 }).value.set(wide, wide * 0.25);
     (u.uAlpha as { value: number }).value = 1;
-    (u.uCol as { value: number[] }).value = [...COL.gold] as number[];
   }
 
   /** The polarity colour a HUD element should use. Kept here so CSS matches GLSL. */

--- a/dynawalla/games/polarity/src/render/shaders.ts
+++ b/dynawalla/games/polarity/src/render/shaders.ts
@@ -9,13 +9,49 @@
  * therefore never load-bearing on its own.
  */
 
-export const COMMON = /* glsl */ `
+import { CHG, HALO, MIXW, ORB, PAL, WARD, type RGB } from "./ink.ts";
+
+/**
+ * A `vec3` literal, and a `#define`, built from a number that lives in TS.
+ *
+ * The palette and the shapes a numeral is read against are declared in
+ * `ink.ts`, not here, and interpolated in — because the numerals' contrast is a
+ * measured claim ABOUT them. While they were literals in two places the orb
+ * could be warmed up without a single number in the legibility table moving,
+ * which is the failure mode `balance/src/ink.ts` was written to design against.
+ */
+const v3 = (c: RGB): string => `vec3(${c.map((n) => n.toFixed(3)).join(", ")})`;
+const def = (name: string, v: number): string => `  #define ${name} ${v.toFixed(4)}\n`;
+
+export const COMMON =
+  /* glsl */ `
   #define TAU 6.28318530718
-  vec3 POS_A = vec3(1.00, 0.80, 0.28);
-  vec3 POS_B = vec3(1.00, 0.38, 0.06);
-  vec3 NEG_A = vec3(0.22, 0.86, 1.00);
-  vec3 NEG_B = vec3(0.44, 0.28, 1.00);
-  vec3 NEU_A = vec3(0.80, 0.83, 0.92);
+  vec3 POS_A = ${v3(PAL.posA)};
+  vec3 POS_B = ${v3(PAL.posB)};
+  vec3 NEG_A = ${v3(PAL.negA)};
+  vec3 NEG_B = ${v3(PAL.negB)};
+  vec3 NEU_A = ${v3(PAL.neuA)};
+` +
+  def("ORB_R", ORB.r) +
+  def("ORB_BODY", ORB.body) +
+  def("ORB_RIM", ORB.rim) +
+  def("ORB_RIMAMP", ORB.rimAmp) +
+  def("ORB_COLLAR", ORB.collar) +
+  def("ORB_COLLARTH", ORB.collarTh) +
+  def("CHG_R", CHG.r) +
+  def("CHG_BODY", CHG.body) +
+  def("CHG_RIM", CHG.rim) +
+  def("HALO_R", HALO.r) +
+  def("HALO_K", HALO.k) +
+  def("HALO_AMP", HALO.amp) +
+  def("MIX_BODY", MIXW.body) +
+  def("MIX_RIM", MIXW.rim) +
+  def("WARD_R", WARD.r) +
+  def("WARD_SHELL", WARD.shell) +
+  def("WARD_HALO_R", WARD.haloR) +
+  def("WARD_HALO_K", WARD.haloK) +
+  def("WARD_HALO_AMP", WARD.haloAmp) +
+  /* glsl */ `
 
   vec3 polA(float p){ return p > 0.5 ? POS_A : (p < -0.5 ? NEG_A : NEU_A); }
   vec3 polB(float p){ return p > 0.5 ? POS_B : (p < -0.5 ? NEG_B : NEU_A); }
@@ -181,15 +217,15 @@ export const BULLET_FRAG =
       }
     } else if (vKind < 1.5) {
       // CHARGE — a heavy plate that carries a printed numeral
-      float d = (vPol > 0.0) ? (ngon(p, 4.0, 0.785) - 0.92) : (r - 0.92);
-      body = aa(d, w) * 0.80;
-      rim  = aa(abs(d) - 0.10, w);
+      float d = (vPol > 0.0) ? (ngon(p, 4.0, 0.785) - CHG_R) : (r - CHG_R);
+      body = aa(d, w) * CHG_BODY;
+      rim  = aa(abs(d) - CHG_RIM, w);
     } else if (vKind < 2.5) {
       // SEAL ORB — big, slow, unmistakable, with a counter-rotating collar
-      float d = (vPol > 0.0) ? (ngon(p, 6.0, 0.0) - 0.86) : (r - 0.86);
-      body = aa(d, w) * 0.68;
-      rim  = aa(abs(d) - 0.075, w) * 1.4;
-      float coll = abs(r - 1.16) - 0.045;
+      float d = (vPol > 0.0) ? (ngon(p, 6.0, 0.0) - ORB_R) : (r - ORB_R);
+      body = aa(d, w) * ORB_BODY;
+      rim  = aa(abs(d) - ORB_RIM, w) * ORB_RIMAMP;
+      float coll = abs(r - ORB_COLLAR) - ORB_COLLARTH;
       rim += aa(coll, w) * (0.5 + 0.5 * sin(atan(p.y, p.x) * 8.0));
     } else if (vKind < 3.5) {
       // PLAYER SHOT — a hot little bolt
@@ -208,8 +244,8 @@ export const BULLET_FRAG =
       rim = aa(abs(d) - 0.07, w);
     }
 
-    float halo = exp(-max(0.0, r - 0.9) * 2.6) * 0.55;
-    vec3 col = B * body * 0.9 + A * rim * 1.5 + A * halo * (0.5 + vPull);
+    float halo = exp(-max(0.0, r - HALO_R) * HALO_K) * HALO_AMP;
+    vec3 col = B * body * MIX_BODY + A * rim * MIX_RIM + A * halo * (0.5 + vPull);
     col += vec3(1.0) * glyph * 1.25;
     col += A * vPull * 0.7 * body;
 
@@ -294,8 +330,8 @@ export const ENEMY_FRAG =
       shell += aa(ring2, w) * 0.8;
       mark = aa(abs(ngon(p, 3.0, -uTime * 0.7) - 0.34) - 0.06, w);
     } else {                                  // WARDEN
-      float o = ngon(p, 8.0, 0.0) - 1.0;
-      shell = aa(abs(o) - 0.075, w);
+      float o = ngon(p, 8.0, 0.0) - WARD_R;
+      shell = aa(abs(o) - WARD_SHELL, w);
       shell += aa(abs(ngon(p, 4.0, uTime * 0.4) - 0.70) - 0.045, w) * 0.9;
       shell += aa(abs(r - 0.34) - 0.05, w);
       mark = aa(plusMask(p, 0.22, 0.055), w) * step(0.0, vPol);
@@ -306,7 +342,7 @@ export const ENEMY_FRAG =
     vec3 col = A * shell * (1.3 + hurt * 0.9) + B * core * 0.55 + vec3(1.0) * mark * 0.9;
     col += mix(vec3(0.0), vec3(1.0, 0.35, 0.32), hurt * 0.5) * shell * 0.5;
     col += vec3(1.0) * vFlash * (shell + core) * 1.8;
-    float halo = exp(-max(0.0, r - 0.95) * 3.0) * 0.30;
+    float halo = exp(-max(0.0, r - WARD_HALO_R) * WARD_HALO_K) * WARD_HALO_AMP;
     col += A * halo;
 
     float a = clamp(max(max(shell, core * 0.9), mark) + halo + vFlash * 0.3, 0.0, 1.0);
@@ -390,9 +426,11 @@ export const LABEL_VERT = /* glsl */ `
   attribute float iTile;
   attribute float iAlpha;
   attribute vec3 iCol;
+  attribute vec3 iHalo;
   varying vec2 vUv;
   varying float vAlpha;
   varying vec3 vCol;
+  varying vec3 vHalo;
   uniform vec2 uGrid;
   // Cells are wider than they are tall, so a four-digit answer is drawn WIDE
   // rather than squeezed: iSize is the numeral's height, always.
@@ -401,24 +439,39 @@ export const LABEL_VERT = /* glsl */ `
     float col = mod(iTile, uGrid.x);
     float row = floor(iTile / uGrid.x);
     vUv = (uv + vec2(col, uGrid.y - 1.0 - row)) / uGrid;
-    vAlpha = iAlpha; vCol = iCol;
+    vAlpha = iAlpha; vCol = iCol; vHalo = iHalo;
     vec2 quad = position.xy * vec2(iSize * uAspect, iSize);
     gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + quad, 0.0, 1.0);
   }
 `;
 
+/**
+ * A numeral is an INK and an opaque COUNTER-INK HALO, and this is where the
+ * pair is resolved.
+ *
+ * `t.a` is the whole inked blob — the stroked halo plus the glyph inside it —
+ * and `t.r` is the glyph alone, so `mix` puts the ink inside the halo and lets
+ * the antialiased boundary between them ramp. Neither colour is decided here:
+ * both arrive per instance from `ink.ts`, derived from the surfaces the object
+ * being labelled actually presents.
+ *
+ * **This material is `NormalBlending`, and that is load-bearing.** It used to
+ * be additive like every other layer in the pack, which meant the halo — then a
+ * hard-coded `vec3(0.0)` — added exactly nothing, and the glyph could only
+ * brighten a ground that on a bunched-up orb was already clipped to white. See
+ * the header of `ink.ts`: the ceiling for any additive ink is 1.00:1.
+ */
 export const LABEL_FRAG = /* glsl */ `
   varying vec2 vUv;
   varying float vAlpha;
   varying vec3 vCol;
+  varying vec3 vHalo;
   uniform sampler2D uMap;
   void main(){
     vec4 t = texture2D(uMap, vUv);
     float a = t.a * vAlpha;
     if (a < 0.005) discard;
-    // the baked dark rim stays dark; the face takes the instance tint
-    vec3 col = mix(vec3(0.0), vCol, t.r);
-    gl_FragColor = vec4(col, a);
+    gl_FragColor = vec4(mix(vHalo, vCol, t.r), a);
   }
 `;
 


### PR DESCRIPTION
> *"polarity needs contrast in some parts like i cant see the answers"*

The screenshot is three answer orbs bunched together; two are pale and one has no numeral a person can see. Neither of those is a colour-list problem, and this PR says so with arithmetic.

## What was actually wrong

**The numerals were additive.** `renderer.ts` defaulted the label layer to `AdditiveBlending` like every other layer in this vector-monitor pack. Two things follow:

1. **The dark contrast rim was a no-op.** `atlas.ts` strokes a ring around every glyph and `LABEL_FRAG` resolved it to `vec3(0.0)`. Under `src * srcAlpha + dst`, black adds nothing. It cost a stroke per tile and darkened nothing, ever.
2. **An additive glyph cannot exceed 1.00:1 on a clipped ground.** An orb's own rim is `A * rim * 1.5` with `rim` reaching 1.4 — it clips a channel on its own, no neighbour and no bloom required. A wide numeral crosses it.

`bestAdditiveInk()` scans every colour and reports the ceiling. **The shipped `polHot` tint was already at it.** Recolouring could not have gained a hundredth.

**And the orbs never reached their lanes.** `askQuestion` aimed each one at a lane with `vx = (tx - e.x) * 0.55`, and `stepOrb` decayed that velocity with a 0.4s half-life — so an orb covered `0.55 * 0.4 / ln 2 ≈ 32%` of the distance and stopped. Three orbs aimed at −28, 0 and +28 arrived at −8.9, 0 and +8.9, wearing numerals 19.4 units wide.

## The contrast table

Measured over a port of the fragment shader evaluated on the exact rectangle each label quad covers, at three real antialias widths, over every additive lift that lands on it. Printed by the test.

| class | shipped | any additive ink | any opaque ink | **letterform** | **object** | pole |
|---|---|---|---|---|---|---|
| orbPos | 1.00 | 1.00 | 1.04 | **18.40** | **4.31** | light |
| orbNeg | 1.00 | 1.00 | 1.03 | **18.40** | **4.30** | light |
| chargePos | 1.00 | 1.00 | 1.02 | **18.40** | **4.30** | light |
| chargeNeg | 1.00 | 1.00 | 1.05 | **18.40** | **4.30** | light |
| floatPos | 1.04 | 1.04 | 1.22 | **18.40** | **4.43** | light |
| floatNeg | 1.15 | 1.15 | 1.23 | **18.40** | **4.29** | light |
| wardenLock | 1.00 | 1.00 | 1.03 | **18.40** | **4.29** | light |
| prompt | 1.04 | 1.04 | 1.22 | **18.40** | **4.43** | light |

Columns 2 and 3 are the point: **1.00–1.15:1 is the ceiling for any additive ink**, and **1.02–1.23:1 for any single opaque one**, because these numerals are drawn over a bright hull and the black field at once and no one colour separates from both. Bars: 4.5:1 letterform (WCAG AA body text), 3.0:1 object (WCAG 1.4.11) — the same two `balance/src/ink.ts` settled on, and 3.0 for the same reason: no two-colour scheme clears 4.5 at the crossover ground, not even pure black on pure white.

Every bar is asserted separately at **320×568**, at the founder's **1080×2340**, and at tablet/desktop — the antialias width IS the screen, and a coarse screen produces a band of intermediate surface a crisp one never does.

## The fix, per the brief

- **`render/ink.ts`** — the surface catalogue and the poles, reusing COUNTERPOISE's approach rather than inventing one: an ink plus an **opaque counter-ink halo**, both derived from the object's own surfaces. `atlas.ts` now paints a pure mask (`t.r` = glyph, `t.a` = blob) and the shader colours both per instance; the atlas never decides a colour.
- **The bloom is part of the surface, so the numerals moved out from under it.** They render in an overlay `Scene` composited *after* the bloom and *after* the full-screen flash — a second `RenderPass`, which writes to the read buffer and declares `needsSwap = false`, with `clear = false`. The grade still runs over them so nothing looks pasted on. On the founder's device (which detects as `mid`) there is no bloom pass at all — the blowout was the in-shader additive halo, which this also handles.
- **The shader palette and shapes now live in `ink.ts`** and are interpolated into the GLSL as `vec3` literals and `#define`s. Byte-identical output; the orb can no longer be warmed up without the table moving.
- **Overlap: stopped, not survived — and also survived.** The lane is a position eased to with a 0.1s half-life (0.37s to clear, from the arithmetic: 21-unit lanes, 19.4-wide numerals, so 92.2% convergence = 3.68 half-lives), and the weave is a sway on the **world** clock so every orb is at the same offset at the same instant and two lanes stay exactly one lane width apart. **The amplitude did not shrink** — it is still 5.5 units, the same as the vertical bob; the separation is bought with phase, not with stillness. The ink survives a saturated ground anyway, which is what the `WHITE` row of the catalogue is for.
- A float text now holds full opacity for the first 37% of its rise. It was under the letterform bar after 25% of its life; it is above it for 53% now, and still dissolves at the same moment.

Not touched: `core/labels.ts` (the atlas/tile allocator) — the known −40..40 issue there is already fixed on main and is not this screenshot.

## Gameplay

Nothing about difficulty, timing, or what an orb means changes. `window(d)` is untouched. The orbs weave the same distance in the same time; they simply arrive where they were always aimed.

## Verification

- `npm run -s tsc` clean; `npm run -s test` **74 passing, 5 consecutive runs**.
- `node packs/build.mjs polarity` builds and passes the SDK checker.

### Mutation transcript — every new assertion broken, confirmed failing, restored

| # | mutation | result |
|---|---|---|
| 1 | `HALO_ALPHA` 1 → 0.6 | ✖ `the atlas strokes the halo at HALO_ALPHA` · ✖ `a float text drops under 4.5:1 after 38% of its rise` |
| 2 | `INK_DARK` → mid grey | ✖ `orbPos: the inked numeral reads 2.45:1 against the worst surface it lands on` · ✖ `orbPos on 320×568 dpr1: object 2.45:1` · ✖ the poles test |
| 3 | `ORB_LANE_EASE` 0.1 → 0.6 | ✖ `the answers were still overlapping 2.00s after they were dropped` |
| 4 | sway back to a per-orb phase | ✖ `the orbs sway out of step by 4.0622 units` · ✖ `the answers were still overlapping 1.38s after they were dropped` |
| 5 | `FLOAT_HOLD` 1.6 → 1 | ✖ `a float text drops under 4.5:1 after 25% of its rise` |
| 6 | `PAL.posA` dimmed so nothing clips | ✖ `floatPos: an additive glyph could reach 6.48:1, which clears the bar` · ✖ `floatPos: one opaque ink could reach 6.48:1 — recolouring alone would do` |
| 7 | model the label as additive again | ✖ `orbPos: a numeral reads 1.00:1 against its own halo` — the shipped defect, reproduced through the test |
| 8 | label layer handed `AdditiveBlending` | ✖ `the label layer is additive again — see the header of ink.ts: its ceiling is 1.00:1` |
| 9 | numerals back in the bloomed scene | ✖ `the numerals are back inside the bloomed scene, under the glow instead of over it` |

8 and 9 are a source-text guard, deliberately: arithmetic over a shader port cannot see which blend mode a `ShaderMaterial` was handed or which scene a mesh was added to, and those two words *are* the fix. A WebGL context in node would be a better guard; there isn't one, and a brittle guard on the exact thing that broke beats no guard.

One thing worth flagging as a null result: mutating `ORB.body` to nothing did **not** fail the additive-ceiling assertion, because the clipping comes from the rim and the palette, not the body — which is why #6 mutates the palette instead. Reported rather than quietly dropped.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
