### PR TITLE
dynawalla/games/mosaic: MOSAIC — the window is still being built while you are breaking it

### DIFF
--- a/dynawalla/games/mosaic/src/dev.ts
+++ b/dynawalla/games/mosaic/src/dev.ts
@@ -13,8 +13,9 @@ import { createStubHost } from "./stubHost.ts";
 import type { Sim } from "./game/state.ts";
 import { VW } from "./game/state.ts";
 import { buildWave } from "./game/wall.ts";
-import { chooseShard } from "./game/forge.ts";
-import { launch, paddleHalf } from "./game/sim.ts";
+import { chooseShard, dismissForge } from "./game/forge.ts";
+import { createRemix } from "./game/remix.ts";
+import { launch, paddleHalf, wallLeft } from "./game/sim.ts";
 import type { Host } from "./contract.ts";
 
 const el = document.getElementById("stage");
@@ -43,6 +44,12 @@ if (dev && q.get("wave")) {
   const wave = buildWave({ seed: dev.sim.seed, index });
   dev.sim.wave = wave;
   dev.sim.rule = wave.rule;
+  // The remix is per-wave state. Jumping the wall without rebuilding it left
+  // wave 21 running wave 1's ceiling, which is below its own pane count, so
+  // re-glazing bailed on its first line every time and the wave you jumped to
+  // was the one wave in the game that never remixed.
+  dev.sim.remix = createRemix(dev.sim.seed, wave);
+  dev.sim.sway = 0;
   dev.sim.broken = 0;
   const grid = new Int32Array(wave.cols * wave.rows).fill(-1);
   dev.sim.cellW = (VW - 100) / wave.cols;
@@ -62,6 +69,13 @@ if (dev && q.get("bot")) {
       return;
     }
     if (sim.forge) {
+      // A miss holds its reveal for ever. The bot reads it for a second and
+      // taps, the way a child does; without this it sits on the first wrong
+      // answer of the run and the watch loop is dead.
+      if (sim.forge.held) {
+        if (sim.forge.age > 1.2) dismissForge(sim);
+        return;
+      }
       // Answer correctly nine times in ten, so both outcomes get exercised.
       if (sim.forge.age > 1.2 && sim.forge.resolving <= 0) {
         const i = Math.random() < 0.9 ? sim.forge.shards.findIndex((s) => s.correct) : 0;
@@ -84,8 +98,9 @@ if (dev && q.get("bot")) {
     let best: { x: number; y: number } | null = null;
     let bestD = Infinity;
     for (const t of sim.wave.tiles) {
-      if (!t.alive || !t.guilty) continue;
-      const tx = sim.wallX + (t.col + 0.5) * sim.cellW;
+      // `drop > 0` is a pane still in the air: not solid yet, so not aimable.
+      if (!t.alive || !t.guilty || t.drop > 0) continue;
+      const tx = wallLeft(sim) + (t.col + 0.5) * sim.cellW;
       const ty = sim.wallY + sim.descent + (t.row + 0.5) * sim.cellH;
       const d = Math.hypot(tx - landing, ty - sim.paddleY);
       if (d < bestD) {

--- a/dynawalla/games/mosaic/src/fx/render.ts
+++ b/dynawalla/games/mosaic/src/fx/render.ts
@@ -16,7 +16,8 @@
  */
 import type { Sim } from "../game/state.ts";
 import { VW } from "../game/state.ts";
-import { MOLTEN_AT, paddleHalf, tileX, tileY, TRAIL_LEN } from "../game/sim.ts";
+import { MOLTEN_AT, paddleHalf, tileX, tileY, TRAIL_LEN, wallLeft } from "../game/sim.ts";
+import { DROP_SECONDS } from "../game/remix.ts";
 import { MASONRY_HP } from "../game/wall.ts";
 import { ruleBanner } from "../game/rules.ts";
 import { FORGE_TIMEOUT } from "../game/forge.ts";
@@ -461,7 +462,7 @@ export class Renderer {
   /** The stone frame the window sits in. */
   private drawTracery(sim: Sim): void {
     const g = this.ctx;
-    const x = sim.wallX - 16;
+    const x = wallLeft(sim) - 16;
     const y = sim.wallY + sim.descent - 16;
     const w = sim.wave.cols * sim.cellW + 32;
     const h = sim.wave.rows * sim.cellH + 32;
@@ -483,7 +484,13 @@ export class Renderer {
     for (const t of sim.wave.tiles) {
       if (!t.alive) continue;
       const x = tileX(sim, t.col);
-      const y = tileY(sim, t.row);
+      // A re-glazed pane falls the last two cells into its slot and fades up as
+      // it comes, so it is unmistakably arriving rather than having always been
+      // there — and it is not solid until it has landed (see `tileAt`).
+      const fall = t.drop > 0 ? t.drop / DROP_SECONDS : 0;
+      const y = tileY(sim, t.row) - fall * fall * cellH * 2.6;
+      const pane = 1 - fall * 0.75;
+      if (fall > 0) g.globalAlpha = pane;
       // Glass variants live at 0, 3 and 4; star at 1; crystal at 2.
       const cut = (t.col + t.row * 2) % 3;
       const kindIndex = t.kind === "star" ? 1 : t.kind === "crystal" ? 2 : cut === 0 ? 0 : cut + 2;
@@ -501,7 +508,7 @@ export class Renderer {
       // Numerals: dark leading on lit glass. Sized to fit the longest face.
       const size = numSize * (t.face.width > 4 ? 0.74 : t.face.width > 3 ? 0.86 : 1);
       this.text(t.face.text, x + cellW / 2, y + cellH / 2 + 1, size, 800, INK);
-      g.globalAlpha = 0.28;
+      g.globalAlpha = 0.28 * pane;
       this.text(t.face.text, x + cellW / 2, y + cellH / 2 - 1.6, size, 800, "#ffffff");
       g.globalAlpha = 1;
 
@@ -537,6 +544,18 @@ export class Renderer {
         g.globalAlpha = 1;
         g.globalCompositeOperation = "source-over";
       }
+      // Stone that has just caught light. The one thing on the wall that
+      // changed while you were looking somewhere else, so it says so loudly.
+      if (t.kindle > 0) {
+        g.globalCompositeOperation = "lighter";
+        g.globalAlpha = t.kindle * 0.7;
+        g.fillStyle = LIGHT_WARM;
+        roundRect(g, x + 1, y + 1, cellW - 2, cellH - 2, 6);
+        g.fill();
+        g.globalAlpha = 1;
+        g.globalCompositeOperation = "source-over";
+      }
+
       if (t.warm > 0 && t.guilty) {
         // The glass answers heat. Confirmation only — it never fires far
         // enough ahead of the ball to plan a shot with.
@@ -557,7 +576,7 @@ export class Renderer {
       g.globalCompositeOperation = "lighter";
       g.globalAlpha = cleared * 0.06;
       g.fillStyle = LIGHT_WARM;
-      g.fillRect(sim.wallX, sim.wallY + sim.descent, sim.wave.cols * cellW, sim.wave.rows * cellH);
+      g.fillRect(wallLeft(sim), sim.wallY + sim.descent, sim.wave.cols * cellW, sim.wave.rows * cellH);
       g.globalAlpha = 1;
       g.globalCompositeOperation = "source-over";
     }
@@ -935,7 +954,10 @@ export class Renderer {
       g.save();
       g.translate(s.x, s.y);
       g.scale(scale, scale);
-      g.globalAlpha = dim ? Math.max(0, 1 - pop * 1.4) : 1;
+      // A dimmed rune fades DOWN and stays down. It used to fade back to full
+      // as `pop` decayed, which meant that a second after a miss the wall of
+      // runes looked untouched again and the held reveal read as noise.
+      g.globalAlpha = dim ? 1 - clamp01((1 - pop) * 2) * 0.74 : 1;
 
       // A glass plate cut as a hexagon, in its power's colour.
       g.beginPath();

--- a/dynawalla/games/mosaic/src/fx/render.ts
+++ b/dynawalla/games/mosaic/src/fx/render.ts
@@ -18,6 +18,7 @@ import type { Sim } from "../game/state.ts";
 import { VW } from "../game/state.ts";
 import { MOLTEN_AT, paddleHalf, tileX, tileY, TRAIL_LEN, wallLeft } from "../game/sim.ts";
 import { DROP_SECONDS } from "../game/remix.ts";
+import { TRACERY_BLEED } from "../game/wall.ts";
 import { MASONRY_HP } from "../game/wall.ts";
 import { ruleBanner } from "../game/rules.ts";
 import { FORGE_TIMEOUT } from "../game/forge.ts";
@@ -462,10 +463,12 @@ export class Renderer {
   /** The stone frame the window sits in. */
   private drawTracery(sim: Sim): void {
     const g = this.ctx;
-    const x = wallLeft(sim) - 16;
-    const y = sim.wallY + sim.descent - 16;
-    const w = sim.wave.cols * sim.cellW + 32;
-    const h = sim.wave.rows * sim.cellH + 32;
+    // 16 + 5 for the outer rect + half of its 6-unit stroke = TRACERY_BLEED.
+    // `MAX_SWAY_CELLS` is chosen against that sum; keep them together.
+    const x = wallLeft(sim) - (TRACERY_BLEED - 8);
+    const y = sim.wallY + sim.descent - (TRACERY_BLEED - 8);
+    const w = sim.wave.cols * sim.cellW + (TRACERY_BLEED - 8) * 2;
+    const h = sim.wave.rows * sim.cellH + (TRACERY_BLEED - 8) * 2;
     g.strokeStyle = "rgba(120,110,180,0.16)";
     g.lineWidth = 2;
     roundRect(g, x, y, w, h, 18);

--- a/dynawalla/games/mosaic/src/game/forge.ts
+++ b/dynawalla/games/mosaic/src/game/forge.ts
@@ -143,15 +143,21 @@ export function stepForge(sim: Sim, dtReal: number): boolean {
   if (!forge) return false;
   forge.age += dtReal;
 
+  // A held reveal never expires, and NOTHING in it moves. `age` keeps running
+  // because the settle floor is measured in it, but the runes are frozen where
+  // they were chosen: they are on a rising arc with gravity under them, and
+  // under an unbounded hold that arc carried the lit correct answer off the
+  // bottom of the screen in about twenty seconds. A reveal advertised as
+  // unlimited that empties itself while you read it is worse than the timer it
+  // replaced.
+  if (forge.held) return false;
+
   for (const s of forge.shards) {
     s.x += s.vx * dtReal;
     s.y += s.vy * dtReal;
     s.vy += 2.2 * dtReal;
     if (s.pop > 0) s.pop = Math.max(0, s.pop - dtReal * 1.6);
   }
-
-  // A held reveal never expires. Nothing but the child ends one.
-  if (forge.held) return false;
 
   if (forge.resolving > 0) {
     forge.resolving -= dtReal;

--- a/dynawalla/games/mosaic/src/game/forge.ts
+++ b/dynawalla/games/mosaic/src/game/forge.ts
@@ -15,6 +15,7 @@
  * is explained; the correct rune simply lights up as everything else goes dark,
  * which is the same information without the scolding.
  */
+import { REVEAL_SETTLE_MS } from "../../../../packs/shared/game-pacing/index.ts";
 import type { Host } from "../contract.ts";
 import { Rng } from "../rng.ts";
 import type { Forge, ForgeShard, PowerKind, Sim, SimEvent } from "./state.ts";
@@ -60,6 +61,8 @@ export function openForge(sim: Sim, host: Host, rngSeed: number): void {
     prompt: q.prompt,
     shards,
     resolving: 0,
+    held: false,
+    settleAt: 0,
     outcome: "none",
   };
   sim.forge = forge;
@@ -93,7 +96,17 @@ export function chooseShard(
     answered: shard.text,
   });
 
-  forge.resolving = shard.correct ? 0.85 : 1.15;
+  // A win has nothing to marinate on, so it plays its flourish and goes. A MISS
+  // holds — `revealPlan`'s `holdMs: Infinity`, which is the fleet-wide answer to
+  // "the answers flashed for a second and then go on". The correct rune lights
+  // up under the prompt that asked for it, in the warm accent and never in red,
+  // and it stays there until a hand takes it down. `settleAt` is the only
+  // deadline anywhere near it and it runs the other way: it is a lockout, so the
+  // second tap of an impatient double-tap cannot dismiss the lesson it just
+  // raised.
+  forge.resolving = shard.correct ? 0.85 : Number.POSITIVE_INFINITY;
+  forge.held = !shard.correct;
+  forge.settleAt = forge.age + REVEAL_SETTLE_MS / 1000;
   forge.outcome = shard.correct ? "right" : "wrong";
   sim.charge = 0;
 
@@ -110,6 +123,20 @@ export function chooseShard(
   return "wrong";
 }
 
+/**
+ * Take a held reveal down, if the child's own input is allowed to yet.
+ *
+ * Returns true when the beat actually closed, so the caller knows whether the
+ * tap was spent here or is still free to mean something else.
+ */
+export function dismissForge(sim: Sim): boolean {
+  const forge = sim.forge;
+  if (!forge || !forge.held) return false;
+  if (forge.age < forge.settleAt) return false;
+  sim.forge = null;
+  return true;
+}
+
 /** Advance the beat in REAL time — the forge is not slowed by its own slow-mo. */
 export function stepForge(sim: Sim, dtReal: number): boolean {
   const forge = sim.forge;
@@ -122,6 +149,9 @@ export function stepForge(sim: Sim, dtReal: number): boolean {
     s.vy += 2.2 * dtReal;
     if (s.pop > 0) s.pop = Math.max(0, s.pop - dtReal * 1.6);
   }
+
+  // A held reveal never expires. Nothing but the child ends one.
+  if (forge.held) return false;
 
   if (forge.resolving > 0) {
     forge.resolving -= dtReal;

--- a/dynawalla/games/mosaic/src/game/remix.test.ts
+++ b/dynawalla/games/mosaic/src/game/remix.test.ts
@@ -1,0 +1,362 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Rng } from "../rng.ts";
+import { createSim, launch, paddleHalf, step, tileAt } from "./sim.ts";
+import type { Sim, SimEvent } from "./state.ts";
+import { VW } from "./state.ts";
+import { guilty } from "./rules.ts";
+import { MAX_SWAY_CELLS } from "./wall.ts";
+import { BEAT_MAX, ENDGAME_LOCK, kindle, reglaze, remainingTargets } from "./remix.ts";
+
+const DT = 1 / 120;
+const VH = 1560;
+
+function autoPaddle(sim: Sim, rng: Rng): void {
+  let lowest = null as null | { x: number; y: number };
+  for (const b of sim.balls) {
+    if (!b.alive) continue;
+    if (!lowest || b.y > lowest.y) lowest = { x: b.x, y: b.y };
+  }
+  if (!lowest) return;
+  const half = paddleHalf(sim);
+  const offset = (rng.f() * 1.5 - 0.75) * half;
+  sim.paddleX = Math.max(half, Math.min(VW - half, lowest.x - offset));
+}
+
+/** A snapshot of everything a child could be aiming at right now. */
+type Aimable = { tile: object; col: number; row: number; text: string };
+function aimables(sim: Sim): Aimable[] {
+  const out: Aimable[] = [];
+  for (const t of sim.wave.tiles) {
+    if (t.alive && t.guilty) out.push({ tile: t, col: t.col, row: t.row, text: t.face.text });
+  }
+  return out;
+}
+
+/**
+ * Play headless with a paddle that always returns the ball, checking every
+ * invariant every frame. Returns what happened, so a test can also assert that
+ * the remix actually did something rather than passing vacuously.
+ */
+function play(seed: number, seconds: number, waves = 1): {
+  sim: Sim;
+  beats: { reglaze: number; kindle: number; turn: number };
+  events: SimEvent[];
+  maxSway: number;
+  addedPeak: number;
+  cleared: number;
+} {
+  const sim = createSim(seed, VH);
+  launch(sim);
+  const rng = new Rng(seed * 31 + 7);
+  const events: SimEvent[] = [];
+  const out: SimEvent[] = [];
+  const steps = Math.round(seconds / DT);
+  let maxSway = 0;
+  let addedPeak = 0;
+  let cleared = 0;
+  const beats = { reglaze: 0, kindle: 0, turn: 0 };
+
+  let openingGuilty = sim.wave.guiltyTotal;
+  let openingTiles = sim.wave.tiles.length;
+  let budget = sim.remix.budget;
+  let waveIndex = sim.wave.index;
+
+  for (let i = 0; i < steps; i++) {
+    if (sim.wave.index !== waveIndex) {
+      waveIndex = sim.wave.index;
+      openingGuilty = sim.wave.guiltyTotal;
+      openingTiles = sim.wave.tiles.length;
+      budget = sim.remix.budget;
+    }
+    autoPaddle(sim, rng);
+    const before = aimables(sim);
+    const beforeRemaining = remainingTargets(sim);
+    out.length = 0;
+    step(sim, DT, out);
+    for (const e of out) events.push(e);
+
+    // 1. Nothing a child is aiming at is taken away. A live target may only
+    //    leave the board by being broken, and while it is up its face is fixed.
+    const broke = new Set(out.filter((e) => e.t === "break").map((e) => e.tile));
+    for (const a of before) {
+      const t = a.tile as { alive: boolean; guilty: boolean; face: { text: string }; col: number; row: number };
+      if (broke.has(t as never)) continue;
+      assert.equal(t.alive, true, `seed ${seed}: a live target vanished at ${a.col},${a.row}`);
+      assert.equal(t.guilty, true, `seed ${seed}: a live target stopped being a target at ${a.col},${a.row}`);
+      assert.equal(t.face.text, a.text, `seed ${seed}: a live target's face changed at ${a.col},${a.row}`);
+      assert.equal(t.col, a.col, `seed ${seed}: a target changed column`);
+      assert.equal(t.row, a.row, `seed ${seed}: a target changed row`);
+    }
+
+    // 2. The board converges: targets added over the whole wave never exceed
+    //    the budget, and none are added inside the endgame.
+    assert.ok(
+      sim.remix.added <= sim.remix.budget,
+      `seed ${seed}: remix added ${sim.remix.added} targets over a budget of ${sim.remix.budget}`,
+    );
+    if (beforeRemaining <= ENDGAME_LOCK) {
+      assert.ok(
+        remainingTargets(sim) <= beforeRemaining,
+        `seed ${seed}: a target was added inside the endgame (${beforeRemaining} left)`,
+      );
+    }
+    assert.ok(
+      sim.remix.stone <= sim.remix.stoneBudget,
+      `seed ${seed}: remix re-leaded ${sim.remix.stone} stone over a budget of ${sim.remix.stoneBudget}`,
+    );
+    addedPeak = Math.max(addedPeak, sim.remix.added);
+
+    // 3. Structure. Every tile in bounds, the grid agreeing with the list, the
+    //    printed face agreeing with the rule, the wall on screen.
+    let live = 0;
+    for (const t of sim.wave.tiles) {
+      assert.ok(t.col >= 0 && t.col < sim.wave.cols, `seed ${seed}: tile off the grid at col ${t.col}`);
+      assert.ok(t.row >= 0 && t.row < sim.wave.rows, `seed ${seed}: tile off the grid at row ${t.row}`);
+      assert.equal(guilty(sim.wave.rule, t.face.value), t.guilty, `seed ${seed}: "${t.face.text}" misjudged`);
+      if (t.alive) live++;
+      if (t.alive && t.drop <= 0) assert.equal(tileAt(sim, t.col, t.row), t, `seed ${seed}: grid/list disagree`);
+      if (t.drop > 0) assert.equal(tileAt(sim, t.col, t.row), null, `seed ${seed}: a falling pane was solid`);
+    }
+    assert.ok(live <= openingTiles, `seed ${seed}: ${live} live panes over an opening ${openingTiles}`);
+    maxSway = Math.max(maxSway, Math.abs(sim.sway));
+    // Two bounds, and the tight one is the point: a wave may only swing as far
+    // as its OWN amplitude, which is what keeps the tutorial nearly still while
+    // a late wave swings hard. The global bound is what keeps the wall on
+    // screen at all.
+    assert.ok(
+      Math.abs(sim.sway) <= sim.remix.swayMax * sim.cellW + 1e-9,
+      `seed ${seed}: wave ${sim.wave.index} swung ${sim.sway} past its own ${sim.remix.swayMax * sim.cellW}`,
+    );
+    assert.ok(
+      Math.abs(sim.sway) <= MAX_SWAY_CELLS * sim.cellW + 1e-9,
+      `seed ${seed}: sway ${sim.sway} beyond the bound`,
+    );
+
+    assert.ok(
+      sim.wave.guiltyTotal <= openingGuilty + budget,
+      `seed ${seed}: total targets ${sim.wave.guiltyTotal} above the proven ceiling`,
+    );
+
+    if (sim.phase === "serve") launch(sim);
+    if (sim.phase === "gameover") break;
+    if (sim.phase === "fever") {
+      cleared++;
+      beats.reglaze += sim.remix.fired.reglaze;
+      beats.kindle += sim.remix.fired.kindle;
+      beats.turn += sim.remix.fired.turn;
+      if (cleared >= waves) break;
+      // Ride the celebration out and pick up the next wall, so a session test
+      // reaches the waves that descend, sway hard, and carry crystal and star.
+      while (sim.phase === "fever") step(sim, DT, out);
+      launch(sim);
+    }
+  }
+  if (sim.phase !== "fever") {
+    beats.reglaze += sim.remix.fired.reglaze;
+    beats.kindle += sim.remix.fired.kindle;
+    beats.turn += sim.remix.fired.turn;
+  }
+  return { sim, beats, events, maxSway, addedPeak, cleared };
+}
+
+// ---------------------------------------------------------------------------
+
+test("a board is remixed while it runs, not only when it is built", () => {
+  let boards = 0;
+  let withBeats = 0;
+  let totalBeats = 0;
+  let seconds = 0;
+  for (let seed = 1; seed <= 24; seed++) {
+    const r = play(seed, 400);
+    boards++;
+    const n = r.beats.reglaze + r.beats.kindle + r.beats.turn;
+    totalBeats += n;
+    seconds += r.sim.waveTime;
+    if (n > 0) withBeats++;
+  }
+  // Before this change the answer to both was zero, for ever, on every board.
+  assert.equal(boards, 24);
+  assert.ok(withBeats >= 20, `only ${withBeats}/24 boards were remixed at all`);
+  assert.ok(totalBeats / boards >= 2, `only ${(totalBeats / boards).toFixed(1)} beats per board`);
+  // And the cadence is real, not one beat at the start: a board that runs for
+  // n seconds should see roughly n / BEAT_MAX beats at the very least.
+  assert.ok(totalBeats >= Math.floor(seconds / BEAT_MAX / 2), `${totalBeats} beats over ${seconds.toFixed(0)}s`);
+});
+
+test("every remix beat kind actually fires over a session", () => {
+  const seen = { reglaze: 0, kindle: 0, turn: 0 };
+  for (let seed = 1; seed <= 24; seed++) {
+    const r = play(seed, 400);
+    seen.reglaze += r.beats.reglaze;
+    seen.kindle += r.beats.kindle;
+    seen.turn += r.beats.turn;
+  }
+  assert.ok(seen.reglaze > 0, "no pane ever dropped in");
+  assert.ok(seen.kindle > 0, "no stone ever caught light");
+  assert.ok(seen.turn > 0, "the window never took a new swing");
+});
+
+test("a remixed board is still solvable — every seed, played to the end", () => {
+  for (let seed = 1; seed <= 24; seed++) {
+    const r = play(seed, 900);
+    assert.equal(r.sim.phase, "fever", `seed ${seed} never cleared`);
+    assert.equal(remainingTargets(r.sim), 0, `seed ${seed} cleared with targets standing`);
+    assert.equal(r.sim.broken, r.sim.wave.guiltyTotal, `seed ${seed}: broken/total disagree`);
+    // Including the ones the remix put there: the wave is only over once the
+    // added targets have been broken too.
+    assert.ok(r.addedPeak >= 0);
+    if (r.addedPeak > 0) {
+      assert.ok(
+        r.sim.broken > r.sim.wave.guiltyTotal - r.addedPeak,
+        `seed ${seed} cleared without breaking the added targets`,
+      );
+    }
+  }
+});
+
+test("the remix stops adding targets once the endgame has started", () => {
+  const sim = createSim(4242, VH);
+  launch(sim);
+  // Leave exactly the lock threshold standing.
+  const targets = sim.wave.tiles.filter((t) => t.guilty);
+  for (const t of targets.slice(ENDGAME_LOCK)) t.alive = false;
+  sim.broken = targets.length - ENDGAME_LOCK;
+  assert.equal(remainingTargets(sim), ENDGAME_LOCK);
+
+  const total = sim.wave.guiltyTotal;
+  const out: SimEvent[] = [];
+  // Fire both target-adding beats directly, many times, at point-blank range.
+  for (let i = 0; i < 200; i++) {
+    reglaze(sim, out);
+    kindle(sim, out);
+  }
+  assert.equal(sim.wave.guiltyTotal, total, "the finish line moved during the endgame");
+  assert.equal(sim.remix.added, 0);
+  assert.equal(out.some((e) => e.t === "kindle"), false, "stone was kindled inside the endgame");
+});
+
+test("kindling is one-directional: stone becomes glass, never the reverse", () => {
+  const sim = createSim(777, VH);
+  launch(sim);
+  const out: SimEvent[] = [];
+  let flips = 0;
+  for (let i = 0; i < 400; i++) {
+    const before = new Map(sim.wave.tiles.map((t) => [t, t.guilty] as const));
+    out.length = 0;
+    if (!kindle(sim, out)) break;
+    for (const [t, wasGuilty] of before) {
+      if (wasGuilty) assert.equal(t.guilty, true, "a target was turned back into stone");
+      if (!wasGuilty && t.guilty) flips++;
+    }
+  }
+  assert.ok(flips > 0, "nothing was ever kindled");
+});
+
+test("a re-glazed pane only ever lands in an empty cell", () => {
+  const sim = createSim(99, VH);
+  launch(sim);
+  const out: SimEvent[] = [];
+  // Empty half the wall so there is somewhere to re-glaze into.
+  for (const t of sim.wave.tiles) if (t.col % 2 === 0) t.alive = false;
+  const occupied = new Set(
+    sim.wave.tiles.filter((t) => t.alive).map((t) => `${t.col},${t.row}`),
+  );
+  let landed = 0;
+  for (let i = 0; i < 60; i++) {
+    out.length = 0;
+    if (!reglaze(sim, out)) break;
+    for (const e of out) {
+      if (e.t !== "reglaze") continue;
+      landed++;
+      assert.equal(
+        occupied.has(`${e.tile.col},${e.tile.row}`),
+        false,
+        `a pane was re-glazed on top of a live tile at ${e.tile.col},${e.tile.row}`,
+      );
+      assert.ok(e.tile.drop > 0, "a re-glazed pane was solid the instant it appeared");
+      occupied.add(`${e.tile.col},${e.tile.row}`);
+    }
+  }
+  assert.ok(landed > 0, "nothing was ever re-glazed");
+});
+
+test("the remix is a pure function of the seed", () => {
+  const a = play(31337, 120);
+  const b = play(31337, 120);
+  assert.deepEqual(a.beats, b.beats);
+  assert.equal(a.sim.score, b.sim.score);
+  assert.equal(a.sim.wave.guiltyTotal, b.sim.wave.guiltyTotal);
+  assert.equal(a.maxSway, b.maxSway);
+  assert.equal(a.events.length, b.events.length);
+});
+
+test("two runs a millisecond apart are not the same board", () => {
+  // What `mount.ts` actually does: seed from the clock. Eight launches in
+  // consecutive milliseconds must all be different boards, remixed differently.
+  const now = 1785000000000;
+  const runs = Array.from({ length: 8 }, (_, i) => play(((now + i) ^ 0x5eed1e) >>> 0, 90));
+  const shape = (r: (typeof runs)[number]): string =>
+    r.sim.wave.tiles
+      .map((t) => `${t.col},${t.row}`)
+      .sort()
+      .join("|");
+  // The remix trace: what happened, where, and in what order. Beat *counts*
+  // collide between unrelated runs often enough to be worthless as a
+  // fingerprint; the trace does not.
+  const trace = (r: (typeof runs)[number]): string =>
+    r.events
+      .filter((e) => e.t === "reglaze" || e.t === "kindle")
+      .map((e) => `${e.t}@${e.tile.col},${e.tile.row}:${e.tile.face.text}`)
+      .join(" ");
+  assert.equal(new Set(runs.map(shape)).size, runs.length, "two fresh sessions opened on the same wall");
+  assert.equal(new Set(runs.map(trace)).size, runs.length, "two fresh sessions were remixed identically");
+  for (const r of runs) assert.ok(trace(r).length > 0, "a run had no remix at all to compare");
+
+  // And the schedule is seeded from the run in its own right, rather than
+  // merely riding on a wall that happened to differ: eight fresh sims disagree
+  // about when the first beat lands and how the window swings, before a single
+  // frame has been stepped.
+  const schedules = new Set(
+    Array.from({ length: 8 }, (_, i) => {
+      const s = createSim(((now + i) ^ 0x5eed1e) >>> 0, VH).remix;
+      return `${s.next}|${s.swayPeriod}|${s.swayAngle}|${s.swayTarget}`;
+    }),
+  );
+  assert.equal(schedules.size, 8, "every session got the same remix schedule");
+});
+
+test("a whole session stays solvable, wave after remixed wave", () => {
+  // The later waves are the interesting ones: they descend, they swing hardest,
+  // and they carry crystal and star. Every invariant in `play` is checked on
+  // every frame of all of them.
+  for (const seed of [11, 23, 57, 101]) {
+    const r = play(seed, 4000, 6);
+    assert.ok(r.cleared >= 6, `seed ${seed} only cleared ${r.cleared} waves`);
+    assert.ok(r.sim.wave.index >= 5, `seed ${seed} stopped at wave ${r.sim.wave.index}`);
+    assert.ok(r.maxSway > 0, `seed ${seed} never drifted`);
+  }
+});
+
+test("a late wave swings far harder than the tutorial does", () => {
+  const early = play(5, 400, 1);
+  const late = play(5, 4000, 6);
+  assert.ok(late.maxSway > early.maxSway * 3, `${late.maxSway} vs ${early.maxSway}`);
+  // A quarter of a cell of travel is plainly visible; the tutorial gets a
+  // fifteenth of one. Both numbers are the wave's own bound, never a global.
+  assert.ok(late.maxSway > late.sim.cellW * 0.2, `a late wave only swung ${late.maxSway}`);
+  assert.ok(early.maxSway < early.sim.cellW * 0.1, `the tutorial swung ${early.maxSway}`);
+});
+
+test("the window drifts, and the drift never leaves the playfield", () => {
+  // Wave one drifts barely at all; a later wave drifts a lot. Both stay on.
+  const early = play(5, 200);
+  assert.ok(early.maxSway > 0, "the window never moved at all");
+  assert.ok(early.maxSway < early.sim.cellW * 0.2, `the tutorial wall swung ${early.maxSway}`);
+  const sim = createSim(5, VH);
+  const margin = sim.wallX;
+  assert.ok(
+    MAX_SWAY_CELLS * sim.cellW < margin,
+    `a full swing of ${MAX_SWAY_CELLS * sim.cellW} would push a ${margin}-unit margin off screen`,
+  );
+});

--- a/dynawalla/games/mosaic/src/game/remix.test.ts
+++ b/dynawalla/games/mosaic/src/game/remix.test.ts
@@ -5,7 +5,7 @@ import { createSim, launch, paddleHalf, step, tileAt } from "./sim.ts";
 import type { Sim, SimEvent } from "./state.ts";
 import { VW } from "./state.ts";
 import { guilty } from "./rules.ts";
-import { MAX_SWAY_CELLS } from "./wall.ts";
+import { MAX_SWAY_CELLS, TRACERY_BLEED } from "./wall.ts";
 import { BEAT_MAX, ENDGAME_LOCK, kindle, reglaze, remainingTargets } from "./remix.ts";
 
 const DT = 1 / 120;
@@ -205,7 +205,6 @@ test("a remixed board is still solvable — every seed, played to the end", () =
     assert.equal(r.sim.broken, r.sim.wave.guiltyTotal, `seed ${seed}: broken/total disagree`);
     // Including the ones the remix put there: the wave is only over once the
     // added targets have been broken too.
-    assert.ok(r.addedPeak >= 0);
     if (r.addedPeak > 0) {
       assert.ok(
         r.sim.broken > r.sim.wave.guiltyTotal - r.addedPeak,
@@ -355,8 +354,11 @@ test("the window drifts, and the drift never leaves the playfield", () => {
   assert.ok(early.maxSway < early.sim.cellW * 0.2, `the tutorial wall swung ${early.maxSway}`);
   const sim = createSim(5, VH);
   const margin = sim.wallX;
+  // The STONE FRAME is what has to fit, not the glass: the tracery is drawn
+  // `TRACERY_BLEED` units outside the tile grid, and at the old bound the tiles
+  // stayed on screen while the frame clipped off the left edge by eight units.
   assert.ok(
-    MAX_SWAY_CELLS * sim.cellW < margin,
-    `a full swing of ${MAX_SWAY_CELLS * sim.cellW} would push a ${margin}-unit margin off screen`,
+    MAX_SWAY_CELLS * sim.cellW + TRACERY_BLEED <= margin,
+    `a full swing puts the frame at ${margin - MAX_SWAY_CELLS * sim.cellW - TRACERY_BLEED} from the edge`,
   );
 });

--- a/dynawalla/games/mosaic/src/game/remix.ts
+++ b/dynawalla/games/mosaic/src/game/remix.ts
@@ -1,0 +1,371 @@
+/**
+ * THE REMIX — the window is still being built while you are breaking it.
+ *
+ * Before this, a MOSAIC board was a single event: the wall was generated once,
+ * and from then until the wave cleared the only thing that ever happened to it
+ * was that panes left. The middle of a board was the beginning of that board
+ * with fewer tiles in it, every time, and the founder's note is the exact
+ * consequence: "it just calmly knocks out all of the even numbers and cracks
+ * all of the odd ones and just bounces around, not that fun".
+ *
+ * So the wall now keeps working. On a seeded, jittered schedule one of three
+ * things happens to it:
+ *
+ *   RE-GLAZE  a mirrored pair of panes falls into empty cells and sets there.
+ *             The window fills back in behind you, so a board that has been
+ *             half-emptied is a different board rather than a smaller one.
+ *   KINDLE    a mirrored pair of *stone* catches light and becomes a target.
+ *             The field of targets is re-drawn under a wall you thought you
+ *             had read.
+ *   TURN      the whole rose starts drifting sideways on a new amplitude and a
+ *             new period. Nothing about the maths changes; the aim does.
+ *
+ * ---------------------------------------------------------------------------
+ * THE THREE RULES THAT KEEP IT HONEST
+ * ---------------------------------------------------------------------------
+ *
+ * 1. **Nothing a child is aiming at is ever taken away.** A live target never
+ *    stops being a target, never stops being alive, and never changes its face.
+ *    Kindling is strictly stone → glass; there is no path back. Re-glazing only
+ *    ever writes into a cell that is *empty*. So every remix is additive from
+ *    where the child is standing: the worst case is a gift they did not plan
+ *    for, never a tile that vanished from under a shot.
+ *
+ * 2. **The board provably converges.** Targets added over a whole wave are hard
+ *    capped at `budget` (about a third of the wall's opening count), and no
+ *    target may be added at all once three or fewer are left standing. Total
+ *    targets a wave can ever contain is therefore `guiltyTotal + budget`, a
+ *    finite number, and every break removes one permanently. A wave cannot be
+ *    remixed into being unwinnable, and it cannot be remixed into being endless.
+ *
+ * 3. **It is not a clock.** Every beat here is wall-side. None of it shortens
+ *    the time a child has to think about anything: the forge — the one place
+ *    MOSAIC asks a question — is untimed apart from its own constant, generous,
+ *    unpunished close, and the remix does not touch it. Movement is difficulty
+ *    of *aim*, which is a skill the child chooses to spend, and speed here is
+ *    rewarded (a faster clear pays a bigger bonus) and nowhere enforced.
+ */
+import { Rng, subSeed } from "../rng.ts";
+import type { Sim, SimEvent } from "./state.ts";
+import type { Tile, TileKind, Wave } from "./wall.ts";
+import { colourAt, faceFor, MASONRY_HP, MAX_SWAY_CELLS, stageFor } from "./wall.ts";
+
+/** Seconds between remix beats, jittered inside this band. */
+export const BEAT_MIN = 4.5;
+export const BEAT_MAX = 7.5;
+
+/** Seconds a re-glazed pane spends in the air before it is solid. */
+export const DROP_SECONDS = 0.42;
+
+/**
+ * Targets remaining at which the remix stops adding any more.
+ *
+ * The endgame belongs to the child. Once the wall is down to its last few
+ * targets, hunting them is the game, and a new one appearing behind you at that
+ * point is not variety, it is the finish line moving.
+ */
+export const ENDGAME_LOCK = 3;
+
+/** Share of the opening target count the remix may add over a whole wave. */
+const BUDGET_SHARE = 0.35;
+
+/**
+ * Share of the opening wall the remix may re-lead as STONE over a whole wave.
+ *
+ * Stone has its own budget because it is the one thing here that lengthens a
+ * board without adding anything to do. Measured over 240 headless waves,
+ * unlimited stone re-glazing took the mean wave from 75 s to 104 s while adding
+ * no maths at all; capped, it costs 15 s and the window still fills back in.
+ */
+const STONE_SHARE = 0.35;
+
+export type RemixBeat = "reglaze" | "kindle" | "turn";
+
+/** Weighted bag. Re-glazing is the one you see, so it comes up most. */
+const BEATS: readonly RemixBeat[] = ["reglaze", "reglaze", "reglaze", "kindle", "kindle", "turn"];
+
+export type Remix = {
+  rng: Rng;
+  /** Wave-seconds until the next beat. */
+  next: number;
+  /** Targets this remix has introduced so far this wave. */
+  added: number;
+  /** Stone panes this remix has re-leaded so far this wave. */
+  stone: number;
+  /** Hard cap on `stone` — pacing, not correctness. */
+  stoneBudget: number;
+  /** Hard cap on `added` — rule 2 above, and what the property test checks. */
+  budget: number;
+  /** Live panes may never exceed the count the wall was born with. */
+  ceiling: number;
+  /** Beats fired this wave, by kind and in total. Reporting and tests. */
+  beats: number;
+  fired: { reglaze: number; kindle: number; turn: number };
+  /** Sway amplitude in CELLS, so it is resolution-independent. */
+  swayAmp: number;
+  swayTarget: number;
+  swayMax: number;
+  swayPeriod: number;
+  swayAngle: number;
+};
+
+export function createRemix(seed: number, wave: Wave): Remix {
+  const rng = new Rng(subSeed(seed, wave.index, 0x7e11c));
+  // The opening waves drift barely at all: wave one is the only tutorial this
+  // game has, and a swinging wall is a worse place to learn to aim.
+  const swayMax = Math.min(MAX_SWAY_CELLS, 0.07 + wave.index * 0.05);
+  return {
+    rng,
+    next: BEAT_MIN + rng.f() * (BEAT_MAX - BEAT_MIN),
+    added: 0,
+    stone: 0,
+    stoneBudget: Math.max(2, Math.round(wave.tiles.length * STONE_SHARE)),
+    budget: Math.max(2, Math.round(wave.guiltyTotal * BUDGET_SHARE)),
+    ceiling: wave.tiles.length,
+    beats: 0,
+    fired: { reglaze: 0, kindle: 0, turn: 0 },
+    swayAmp: swayMax * 0.5,
+    swayTarget: swayMax * (0.4 + rng.f() * 0.6),
+    swayMax,
+    swayPeriod: 5.5 + rng.f() * 5,
+    swayAngle: rng.f() * Math.PI * 2,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+export function remainingTargets(sim: Sim): number {
+  let n = 0;
+  for (const t of sim.wave.tiles) if (t.alive && t.guilty) n++;
+  return n;
+}
+
+function livePanes(sim: Sim): number {
+  let n = 0;
+  for (const t of sim.wave.tiles) if (t.alive) n++;
+  return n;
+}
+
+/** Rule 2, as one function. Both halves of it, in one place, so neither drifts. */
+export function mayAddTargets(sim: Sim, n: number): boolean {
+  return sim.remix.added + n <= sim.remix.budget && remainingTargets(sim) > ENDGAME_LOCK;
+}
+
+/** A cell nothing occupies right now: never built, or long since broken. */
+function emptyCell(sim: Sim, col: number, row: number): boolean {
+  const i = sim.grid[row * sim.wave.cols + col]!;
+  if (i < 0) return true;
+  const t = sim.wave.tiles[i]!;
+  return !t.alive && t.drop <= 0;
+}
+
+/** Don't materialise a pane on top of a ball. It would read as a cheat. */
+function clearOfBalls(sim: Sim, col: number, row: number): boolean {
+  const x = sim.wallX + sim.sway + col * sim.cellW + sim.cellW / 2;
+  const y = sim.wallY + sim.descent + row * sim.cellH + sim.cellH / 2;
+  for (const b of sim.balls) {
+    if (!b.alive) continue;
+    if (Math.abs(b.x - x) < sim.cellW * 1.25 && Math.abs(b.y - y) < sim.cellH * 1.25) return false;
+  }
+  return true;
+}
+
+/** The mirrored partner of a column; equal to it on the centre column. */
+function mirrorOf(wave: Wave, col: number): number {
+  return wave.cols - 1 - col;
+}
+
+/**
+ * Every mirrored pair of cells passing `ok`, as half-grid coordinates.
+ *
+ * Working in mirrored pairs is not decoration: the wall's whole art direction
+ * is that it is a rose window, and a remix that punched one side would turn it
+ * into noise the first time it fired.
+ */
+function pairs(sim: Sim, ok: (col: number, row: number) => boolean): { col: number; row: number }[] {
+  const wave = sim.wave;
+  const half = Math.floor((wave.cols - 1) / 2);
+  const found: { col: number; row: number }[] = [];
+  for (let row = 0; row < wave.rows; row++) {
+    for (let col = 0; col <= half; col++) {
+      const m = mirrorOf(wave, col);
+      if (!ok(col, row)) continue;
+      if (m !== col && !ok(m, row)) continue;
+      found.push({ col, row });
+    }
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// The beats
+// ---------------------------------------------------------------------------
+
+function settle(sim: Sim, col: number, row: number, wantGuilty: boolean, out: SimEvent[]): void {
+  const wave = sim.wave;
+  const rx = sim.remix;
+  const stage = stageFor(wave.index);
+  const face = faceFor(wave.rule, wantGuilty, rx.rng, stage);
+  const kind: TileKind = "glass";
+  const hp = wantGuilty ? 1 : MASONRY_HP;
+  const i = sim.grid[row * wave.cols + col]!;
+
+  let tile: Tile;
+  if (i >= 0) {
+    // A cell that has held a pane before. Re-use the object so the tile array
+    // and the grid index stay exactly as long as each other for ever.
+    tile = wave.tiles[i]!;
+    tile.face = face;
+    tile.guilty = wantGuilty;
+    tile.kind = kind;
+    tile.hp = hp;
+    tile.alive = true;
+    tile.hit = 0;
+    tile.warm = 0;
+    tile.kindle = 0;
+    tile.drop = DROP_SECONDS;
+  } else {
+    tile = {
+      col,
+      row,
+      face,
+      guilty: wantGuilty,
+      kind,
+      hp,
+      colour: colourAt(col, row, wave.cols, wave.palette, wave.bands),
+      alive: true,
+      hit: 0,
+      warm: 0,
+      drop: DROP_SECONDS,
+      kindle: 0,
+    };
+    wave.tiles.push(tile);
+    sim.grid[row * wave.cols + col] = wave.tiles.length - 1;
+  }
+
+  if (wantGuilty) {
+    wave.guiltyTotal++;
+    rx.added++;
+  }
+  out.push({
+    t: "reglaze",
+    x: sim.wallX + sim.sway + col * sim.cellW + sim.cellW / 2,
+    y: sim.wallY + sim.descent + row * sim.cellH + sim.cellH / 2,
+    tile,
+  });
+}
+
+/** Panes fall back into the window. Returns false if there was nowhere to put one. */
+export function reglaze(sim: Sim, out: SimEvent[]): boolean {
+  const rx = sim.remix;
+  const slots = pairs(sim, (c, r) => emptyCell(sim, c, r) && clearOfBalls(sim, c, r));
+  if (!slots.length) return false;
+
+  // Bias upward: glass is set from the crown down, and a pane arriving in the
+  // bottom row would land where the ball is working.
+  slots.sort((a, b) => a.row - b.row || a.col - b.col);
+  const pick = slots[rx.rng.int(0, Math.max(0, Math.ceil(slots.length / 2) - 1))]!;
+  const m = mirrorOf(sim.wave, pick.col);
+  const n = m === pick.col ? 1 : 2;
+  if (livePanes(sim) + n > rx.ceiling) return false;
+
+  // Match the wall's own share so re-glazing never quietly changes what kind of
+  // window this is — and drop stone whenever the target budget is spent, until
+  // stone runs out of budget too and the wave simply drains to its end.
+  const wantGuilty = mayAddTargets(sim, n) && rx.rng.f() < sim.wave.guiltyShare;
+  if (!wantGuilty && rx.stone + n > rx.stoneBudget) return false;
+  if (!wantGuilty) rx.stone += n;
+  settle(sim, pick.col, pick.row, wantGuilty, out);
+  if (n === 2) settle(sim, m, pick.row, wantGuilty, out);
+  rx.fired.reglaze++;
+  return true;
+}
+
+/** Stone catches light. Strictly one-directional: there is no un-kindle. */
+export function kindle(sim: Sim, out: SimEvent[]): boolean {
+  const rx = sim.remix;
+  const wave = sim.wave;
+  const stage = stageFor(wave.index);
+  const stone = (c: number, r: number): boolean => {
+    const i = sim.grid[r * wave.cols + c]!;
+    if (i < 0) return false;
+    const t = wave.tiles[i]!;
+    return t.alive && !t.guilty && t.drop <= 0;
+  };
+  const slots = pairs(sim, stone);
+  if (!slots.length) return false;
+  const pick = slots[rx.rng.int(0, slots.length - 1)]!;
+  const m = mirrorOf(wave, pick.col);
+  const n = m === pick.col ? 1 : 2;
+  if (!mayAddTargets(sim, n)) return false;
+
+  for (const col of n === 1 ? [pick.col] : [pick.col, m]) {
+    const t = wave.tiles[sim.grid[pick.row * wave.cols + col]!]!;
+    t.face = faceFor(wave.rule, true, rx.rng, stage);
+    t.guilty = true;
+    t.kind = "glass";
+    t.hp = 1;
+    t.kindle = 1;
+    wave.guiltyTotal++;
+    rx.added++;
+    out.push({
+      t: "kindle",
+      x: sim.wallX + sim.sway + col * sim.cellW + sim.cellW / 2,
+      y: sim.wallY + sim.descent + pick.row * sim.cellH + sim.cellH / 2,
+      tile: t,
+    });
+  }
+  rx.fired.kindle++;
+  return true;
+}
+
+/** The rose takes a new swing. Always succeeds; changes no tile. */
+export function turn(sim: Sim, out: SimEvent[]): boolean {
+  const rx = sim.remix;
+  rx.swayTarget = rx.swayMax * (0.25 + rx.rng.f() * 0.75);
+  rx.swayPeriod = 4.5 + rx.rng.f() * 6;
+  rx.fired.turn++;
+  out.push({ t: "turn" });
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance the drift and fire beats. Wave time, so the forge's slow-motion
+ * slows the window down with everything else.
+ */
+export function stepRemix(sim: Sim, dt: number, out: SimEvent[], beats = true): void {
+  const rx = sim.remix;
+
+  rx.swayAngle += ((Math.PI * 2) / rx.swayPeriod) * dt;
+  if (rx.swayAngle > Math.PI * 2) rx.swayAngle -= Math.PI * 2;
+  rx.swayAmp += (rx.swayTarget - rx.swayAmp) * Math.min(1, dt * 0.9);
+  sim.sway = Math.min(rx.swayMax, rx.swayAmp) * sim.cellW * Math.sin(rx.swayAngle);
+
+  // The window keeps drifting while the ball sits on the paddle, but nothing is
+  // rebuilt under a child who is lining up a shot.
+  if (!beats) return;
+
+  rx.next -= dt;
+  if (rx.next > 0) return;
+  rx.next = BEAT_MIN + rx.rng.f() * (BEAT_MAX - BEAT_MIN);
+
+  // A beat with nothing to do falls through to the next thing rather than
+  // being spent on nothing — a board with no empty cells still gets kindled,
+  // and a board with no stone left still gets re-glazed.
+  const beat = rx.rng.pick(BEATS);
+  const order: RemixBeat[] =
+    beat === "reglaze"
+      ? ["reglaze", "kindle", "turn"]
+      : beat === "kindle"
+        ? ["kindle", "reglaze", "turn"]
+        : ["turn"];
+  for (const b of order) {
+    const done = b === "reglaze" ? reglaze(sim, out) : b === "kindle" ? kindle(sim, out) : turn(sim, out);
+    if (done) break;
+  }
+  rx.beats++;
+}

--- a/dynawalla/games/mosaic/src/game/sim.test.ts
+++ b/dynawalla/games/mosaic/src/game/sim.test.ts
@@ -4,7 +4,8 @@ import { Rng } from "../rng.ts";
 import { createSim, launch, paddleHalf, step, tileAt } from "./sim.ts";
 import type { Sim, SimEvent } from "./state.ts";
 import { VW } from "./state.ts";
-import { chooseShard, openForge, stepForge } from "./forge.ts";
+import { chooseShard, dismissForge, openForge, stepForge } from "./forge.ts";
+import { REVEAL_SETTLE_MS } from "../../../../packs/shared/game-pacing/index.ts";
 import type { Host, Question } from "../contract.ts";
 
 const DT = 1 / 120;
@@ -280,6 +281,61 @@ test("a wrong rune costs the charge and the power, and nothing else", () => {
   assert.equal(out.some((e) => e.t === "power"), false);
   // The right answer lights up anyway. Nobody is told off, they are shown.
   assert.equal(sim.forge!.shards.find((s) => s.correct)!.state, 1);
+});
+
+test("a miss holds the completed sum until a hand takes it down", () => {
+  const sim = createSim(2, VH);
+  launch(sim);
+  sim.charge = sim.chargeMax;
+  const host = recordingHost();
+  openForge(sim, host, 99);
+  const wrong = sim.forge!.shards.findIndex((s) => !s.correct);
+  assert.equal(chooseShard(sim, host, wrong, []), "wrong");
+
+  // Nothing but the child ends it. Ten minutes of frames do not.
+  assert.equal(sim.forge!.held, true);
+  for (let i = 0; i < 12000; i++) assert.equal(stepForge(sim, 0.05), false);
+  assert.ok(sim.forge, "the reveal expired on its own");
+  // The prompt and the correct rune are both still up: the sum is completed in
+  // front of the child, and the wrong rune is dimmed rather than marked.
+  assert.equal(sim.forge!.prompt, "7 × 8");
+  assert.equal(sim.forge!.shards.find((s) => s.correct)!.state, 1);
+  assert.equal(sim.forge!.shards[wrong]!.state, -1);
+
+  assert.equal(dismissForge(sim), true);
+  assert.equal(sim.forge, null);
+});
+
+test("the settle lockout stops a stray second tap eating the reveal", () => {
+  const sim = createSim(2, VH);
+  launch(sim);
+  sim.charge = sim.chargeMax;
+  const host = recordingHost();
+  openForge(sim, host, 99);
+  const wrong = sim.forge!.shards.findIndex((s) => !s.correct);
+  chooseShard(sim, host, wrong, []);
+  // The tap that raised the reveal is still arriving. It may not take it down.
+  assert.equal(dismissForge(sim), false);
+  assert.ok(sim.forge);
+  assert.ok(sim.forge!.settleAt > 0);
+  stepForge(sim, REVEAL_SETTLE_MS / 1000 + 0.01);
+  assert.equal(dismissForge(sim), true);
+});
+
+test("a clean win is not held — there is nothing to marinate on", () => {
+  const sim = createSim(2, VH);
+  launch(sim);
+  sim.charge = sim.chargeMax;
+  const host = recordingHost();
+  openForge(sim, host, 4242);
+  const right = sim.forge!.shards.findIndex((s) => s.correct);
+  assert.equal(chooseShard(sim, host, right, []), "right");
+  assert.equal(sim.forge!.held, false);
+  assert.equal(dismissForge(sim), false, "a win should not need dismissing");
+  let closed = false;
+  for (let i = 0; i < 200 && !closed; i++) closed = stepForge(sim, 0.02);
+  assert.equal(closed, true, "the celebration never ended");
+  assert.equal(sim.forge, null);
 });
 
 test("hesitating in the forge is never punished", () => {

--- a/dynawalla/games/mosaic/src/game/sim.test.ts
+++ b/dynawalla/games/mosaic/src/game/sim.test.ts
@@ -306,6 +306,56 @@ test("a miss holds the completed sum until a hand takes it down", () => {
   assert.equal(sim.forge, null);
 });
 
+test("a held reveal stops the world instead of running it underneath", () => {
+  const sim = createSim(2, VH);
+  launch(sim);
+  const ball = sim.balls[0]!;
+  // Mid-rally, well above the paddle, heading down: the exact moment a child
+  // would take their hand off the glass to read.
+  ball.x = VW / 2;
+  ball.y = sim.vh * 0.5;
+  ball.vx = 120;
+  ball.vy = ball.speed;
+  sim.charge = sim.chargeMax;
+  const host = recordingHost();
+  openForge(sim, host, 99);
+  chooseShard(sim, host, sim.forge!.shards.findIndex((s) => !s.correct), []);
+
+  const before = { x: ball.x, y: ball.y, descent: sim.descent, beads: sim.beads, run: sim.runTime };
+  // Two full minutes of reading.
+  for (let i = 0; i < 14400; i++) step(sim, DT, []);
+  assert.equal(ball.x, before.x, "the ball travelled under a held reveal");
+  assert.equal(ball.y, before.y, "the ball travelled under a held reveal");
+  assert.equal(sim.descent, before.descent, "the wall crept under a held reveal");
+  assert.equal(sim.beads, before.beads, "reading the answer cost a bead");
+  assert.equal(sim.runTime, before.run);
+  assert.equal(sim.phase, "play");
+
+  // And it starts again the instant the reveal is taken down.
+  stepForge(sim, 1);
+  assert.equal(dismissForge(sim), true);
+  step(sim, DT, []);
+  assert.notEqual(ball.y, before.y);
+});
+
+test("a held reveal freezes the runes where they were chosen", () => {
+  const sim = createSim(2, VH);
+  launch(sim);
+  sim.charge = sim.chargeMax;
+  const host = recordingHost();
+  openForge(sim, host, 99);
+  for (let i = 0; i < 40; i++) stepForge(sim, 1 / 60);
+  chooseShard(sim, host, sim.forge!.shards.findIndex((s) => !s.correct), []);
+  const right = sim.forge!.shards.find((s) => s.correct)!;
+  const at = { x: right.x, y: right.y };
+  // The runes rise on an arc with gravity under them. Under an unbounded hold
+  // that arc used to carry the lit answer off the bottom of the screen.
+  for (let i = 0; i < 6000; i++) stepForge(sim, 1 / 60);
+  assert.equal(right.x, at.x, "the correct rune drifted while it was being read");
+  assert.equal(right.y, at.y, "the correct rune drifted while it was being read");
+  assert.ok(right.y < VH, "the correct rune left the screen");
+});
+
 test("the settle lockout stops a stray second tap eating the reveal", () => {
   const sim = createSim(2, VH);
   launch(sim);

--- a/dynawalla/games/mosaic/src/game/sim.ts
+++ b/dynawalla/games/mosaic/src/game/sim.ts
@@ -21,6 +21,7 @@ import type { Ball, PowerKind, Sim, SimEvent } from "./state.ts";
 import { VW } from "./state.ts";
 import type { Tile, Wave } from "./wall.ts";
 import { buildWave, MASONRY_HP } from "./wall.ts";
+import { createRemix, stepRemix } from "./remix.ts";
 
 export const TRAIL_LEN = 22;
 
@@ -108,6 +109,7 @@ export function createSim(seed: number, vh: number): Sim {
     aimDir: 1,
     wallX: 0,
     wallY: 0,
+    sway: 0,
     cellW: 0,
     cellH: 0,
     grid: new Int32Array(0),
@@ -123,6 +125,7 @@ export function createSim(seed: number, vh: number): Sim {
     chargeMax: CHARGE_MAX,
     powers: { wide: 0, slow: 0, laserShots: 0 },
     forge: null,
+    remix: createRemix(seed, wave),
     phase: "serve",
     feverT: 0,
     stall: 0,
@@ -166,7 +169,9 @@ export function nextWave(sim: Sim): void {
   const wave = buildWave({ seed: sim.seed, index: sim.wave.index + 1 });
   sim.wave = wave;
   sim.rule = wave.rule;
+  sim.remix = createRemix(sim.seed, wave);
   sim.descent = 0;
+  sim.sway = 0;
   sim.stall = 0;
   sim.waveTime = 0;
   sim.broken = 0;
@@ -190,7 +195,9 @@ export function restart(sim: Sim, seed: number): void {
   sim.best = 0;
   sim.powers = { wide: 0, slow: 0, laserShots: 0 };
   sim.forge = null;
+  sim.remix = createRemix(seed, wave);
   sim.descent = 0;
+  sim.sway = 0;
   sim.stall = 0;
   sim.waveTime = 0;
   sim.runTime = 0;
@@ -203,8 +210,13 @@ export function restart(sim: Sim, seed: number): void {
 // Geometry helpers
 // ---------------------------------------------------------------------------
 
+/** Left edge of the window right now — the base origin plus the drift. */
+export function wallLeft(sim: Sim): number {
+  return sim.wallX + sim.sway;
+}
+
 export function tileX(sim: Sim, col: number): number {
-  return sim.wallX + col * sim.cellW;
+  return wallLeft(sim) + col * sim.cellW;
 }
 export function tileY(sim: Sim, row: number): number {
   return sim.wallY + row * sim.cellH + sim.descent;
@@ -215,7 +227,9 @@ export function tileAt(sim: Sim, col: number, row: number): Tile | null {
   const i = sim.grid[row * cols + col]!;
   if (i < 0) return null;
   const t = tiles[i]!;
-  return t.alive ? t : null;
+  // A pane still in the air is alive — the wave may not clear while one is
+  // falling — but it is not yet *there*, so nothing may collide with it.
+  return t.alive && t.drop <= 0 ? t : null;
 }
 
 export function paddleHalf(sim: Sim): number {
@@ -335,8 +349,9 @@ function collideTiles(sim: Sim, b: Ball, out: SimEvent[]): boolean {
   const bottom = top + rows * sim.cellH;
   if (b.y + b.r < top || b.y - b.r > bottom) return false;
 
-  const c0 = Math.max(0, Math.floor((b.x - b.r - sim.wallX) / sim.cellW));
-  const c1 = Math.min(cols - 1, Math.floor((b.x + b.r - sim.wallX) / sim.cellW));
+  const left = wallLeft(sim);
+  const c0 = Math.max(0, Math.floor((b.x - b.r - left) / sim.cellW));
+  const c1 = Math.min(cols - 1, Math.floor((b.x + b.r - left) / sim.cellW));
   const r0 = Math.max(0, Math.floor((b.y - b.r - top) / sim.cellH));
   const r1 = Math.min(rows - 1, Math.floor((b.y + b.r - top) / sim.cellH));
 
@@ -500,7 +515,7 @@ function stepBolts(sim: Sim, dt: number, out: SimEvent[]): void {
         bolt.alive = false;
         break;
       }
-      const c = Math.floor((bolt.x - sim.wallX) / sim.cellW);
+      const c = Math.floor((bolt.x - wallLeft(sim)) / sim.cellW);
       const r = Math.floor((bolt.y - top) / sim.cellH);
       if (c < 0 || r < 0 || c >= cols || r >= rows) continue;
       const t = tileAt(sim, c, r);
@@ -576,6 +591,10 @@ export function step(sim: Sim, dt: number, out: SimEvent[]): void {
   for (const t of sim.wave.tiles) {
     if (t.hit > 0) t.hit = Math.max(0, t.hit - dt * 3.2);
     if (t.warm > 0) t.warm = Math.max(0, t.warm - dt * 2.6);
+    if (t.kindle > 0) t.kindle = Math.max(0, t.kindle - dt * 1.4);
+    // A falling pane lands even while the ball is being re-served, so a life
+    // lost mid-drop never leaves a pane hanging in the air for ever.
+    if (t.drop > 0) t.drop = Math.max(0, t.drop - dt);
   }
 
   // Serving: sweep the aim so a launch is a choice, not a coin flip.
@@ -599,6 +618,7 @@ export function step(sim: Sim, dt: number, out: SimEvent[]): void {
       sim.aim = lo;
       sim.aimDir = 1;
     }
+    stepRemix(sim, dt, out, false);
     stepBolts(sim, dt, out);
     return;
   }
@@ -617,6 +637,9 @@ export function step(sim: Sim, dt: number, out: SimEvent[]): void {
     out.push({ t: "danger" });
   }
 
+  // The window is still being built while you are breaking it. See `remix.ts`.
+  stepRemix(sim, dt, out);
+
   for (const b of sim.balls) {
     if (!b.alive || b.held) continue;
     stepBall(sim, b, dt, out);
@@ -627,7 +650,7 @@ export function step(sim: Sim, dt: number, out: SimEvent[]): void {
   // only for a moment — it confirms, it never lets you plan without reading.
   for (const b of sim.balls) {
     if (!b.alive || b.held) continue;
-    const c = Math.round((b.x - sim.wallX) / sim.cellW);
+    const c = Math.round((b.x - wallLeft(sim)) / sim.cellW);
     const r = Math.round((b.y - sim.wallY - sim.descent) / sim.cellH);
     for (let dr = -1; dr <= 1; dr++) {
       for (let dc = -1; dc <= 1; dc++) {

--- a/dynawalla/games/mosaic/src/game/sim.ts
+++ b/dynawalla/games/mosaic/src/game/sim.ts
@@ -565,6 +565,16 @@ export function grantPower(sim: Sim, kind: PowerKind, out: SimEvent[]): void {
 // ---------------------------------------------------------------------------
 
 export function step(sim: Sim, dt: number, out: SimEvent[]): void {
+  // A held reveal STOPS THE WORLD. The forge already ran the game underneath
+  // itself at a twelfth speed while a beat was open, which was harmless when a
+  // beat lasted at most seven seconds; a reveal the child dismisses in their
+  // own time is unbounded, and the manual now tells them to take it. Without
+  // this the ball keeps travelling and the wall keeps creeping while their hand
+  // is off the glass — measured, a ten-second read cost a bead in 81 runs out
+  // of 120, and on the last bead it ended the run underneath the lesson.
+  // Nothing here is a clock, so nothing here may run while one is being read.
+  if (sim.forge?.held) return;
+
   sim.runTime += dt;
 
   if (sim.phase === "gameover") return;

--- a/dynawalla/games/mosaic/src/game/state.ts
+++ b/dynawalla/games/mosaic/src/game/state.ts
@@ -6,6 +6,7 @@
  * turns those into shake, shards, sound and buzz. That split is what lets the
  * physics be unit-tested headlessly and the juice be tuned without fear.
  */
+import type { Remix } from "./remix.ts";
 import type { Rule } from "./rules.ts";
 import type { Tile, Wave } from "./wall.ts";
 
@@ -63,6 +64,14 @@ export type Forge = {
   shards: ForgeShard[];
   /** >0 while the resolution animation plays before the beat closes. */
   resolving: number;
+  /**
+   * The reveal is up and waiting for a hand. Set only on a miss, and while it
+   * is set nothing — no timer, no next frame, no `FORGE_TIMEOUT` — may close
+   * the beat. See `chooseShard`.
+   */
+  held: boolean;
+  /** `age` before which even the child's own input may not dismiss the reveal. */
+  settleAt: number;
   outcome: "none" | "right" | "wrong";
 };
 
@@ -93,7 +102,13 @@ export type SimEvent =
   | { t: "power"; kind: PowerKind }
   | { t: "laser"; x: number; y: number }
   | { t: "gameover" }
-  | { t: "danger" };
+  | { t: "danger" }
+  /** A pane has been scheduled to fall back into an empty cell. */
+  | { t: "reglaze"; x: number; y: number; tile: Tile }
+  /** A stone tile has caught light and become a target. */
+  | { t: "kindle"; x: number; y: number; tile: Tile }
+  /** The window has taken a new swing. */
+  | { t: "turn" };
 
 export type Sim = {
   /** Virtual playfield height; width is always `VW`. */
@@ -119,6 +134,15 @@ export type Sim = {
   /** Wall origin (top-left of cell 0,0) and cell size, in virtual units. */
   wallX: number;
   wallY: number;
+  /**
+   * Horizontal drift of the whole window, in virtual units.
+   *
+   * The twin of `descent`, and like it a property of the wall rather than of
+   * any tile: one number added to every column's x. Bounded by
+   * `MAX_SWAY_CELLS`, which is chosen so the swung wall still fits inside the
+   * playfield with the tracery on.
+   */
+  sway: number;
   cellW: number;
   cellH: number;
   /** Grid lookup: row * cols + col -> tile index, or -1. */
@@ -138,6 +162,9 @@ export type Sim = {
   powers: Powers;
 
   forge: Forge | null;
+
+  /** The live-remix scheduler for the wave currently on screen. */
+  remix: Remix;
 
   phase: Phase;
   /** Counts down during the fever/clear celebration. */

--- a/dynawalla/games/mosaic/src/game/wall.test.ts
+++ b/dynawalla/games/mosaic/src/game/wall.test.ts
@@ -151,7 +151,6 @@ test("carving never takes a wall below the floor it promises", () => {
     for (const seed of SPREAD_SEEDS.slice(0, 60)) {
       const w = buildWave({ seed, index });
       assert.ok(w.tiles.length >= 20, `wave ${index} seed ${seed} carved down to ${w.tiles.length}`);
-      assert.ok(w.carved >= 0);
       assert.equal(w.guiltyShare, w.guiltyTotal / w.tiles.length);
     }
   }

--- a/dynawalla/games/mosaic/src/game/wall.test.ts
+++ b/dynawalla/games/mosaic/src/game/wall.test.ts
@@ -74,12 +74,87 @@ test("every wave is winnable and worth playing: enough targets, not all targets"
 
 test("wave 1 is the tutorial and has no tutorial", () => {
   const w = buildWave({ seed: 3, index: 0 });
-  // Even numbers, a full grid, no descent, no crystal or star to explain.
+  // Even numbers, no descent, no crystal or star to explain. The SHAPE is no
+  // longer part of the contract — see the opening-board tests below.
   assert.equal(w.rule.kind, "multiple");
   assert.equal(w.rule.target.n, 2);
   assert.equal(w.descentRate, 0);
-  assert.equal(w.layout, "solid");
   for (const t of w.tiles) assert.equal(t.kind, "glass");
+});
+
+// ---------------------------------------------------------------------------
+// The opening board
+//
+// "The first board is just a rectangle of the numbers and it's boring." It was:
+// measured over four hundred seeds, wave one produced exactly ONE shape — a
+// filled 9×4 block, fill fraction 1.000, every run the game has ever played.
+// These four tests are the ones that would go green again if the carve were
+// deleted, so they assert the property and not the implementation.
+// ---------------------------------------------------------------------------
+
+/** A shape key: which cells are occupied, independent of what is printed on them. */
+function shapeKey(w: ReturnType<typeof buildWave>): string {
+  return (
+    w.tiles
+      .map((t) => `${t.col},${t.row}`)
+      .sort()
+      .join("|") + `#${w.cols}x${w.rows}`
+  );
+}
+
+const SPREAD_SEEDS = Array.from({ length: 300 }, (_, i) => (i * 2654435761 + 12345) >>> 0);
+
+test("the opening board is not a filled rectangle", () => {
+  let full = 0;
+  for (const seed of SPREAD_SEEDS) {
+    const w = buildWave({ seed, index: 0 });
+    if (w.tiles.length === w.cols * w.rows) full++;
+  }
+  // A carve may legitimately roll back to nothing on the odd seed; a majority
+  // of full rectangles would mean the carve is not doing its job.
+  assert.ok(full / SPREAD_SEEDS.length < 0.05, `${full}/${SPREAD_SEEDS.length} openings were solid blocks`);
+});
+
+test("the opening board is a different shape nearly every run", () => {
+  const shapes = new Set(SPREAD_SEEDS.map((seed) => shapeKey(buildWave({ seed, index: 0 }))));
+  assert.ok(
+    shapes.size > SPREAD_SEEDS.length * 0.8,
+    `only ${shapes.size} distinct opening shapes across ${SPREAD_SEEDS.length} seeds`,
+  );
+});
+
+test("the opening board is not always the same KIND of window either", () => {
+  // The carve alone would satisfy the two tests above while wave one still
+  // drew from a single hard-coded mask for ever. It does not: the opening
+  // draws from a family of shapes that stay legible at four or five rows.
+  const families = new Set(SPREAD_SEEDS.map((seed) => buildWave({ seed, index: 0 }).layout));
+  assert.ok(families.size >= 3, `the opening only ever uses ${[...families].join(", ")}`);
+});
+
+test("two fresh sessions do not open on the same wall", () => {
+  // What `mount.ts` actually does: seed from the clock. Consecutive launches a
+  // few milliseconds apart must still differ.
+  const now = 1785000000000;
+  const a = buildWave({ seed: (now ^ 0x5eed1e) >>> 0, index: 0 });
+  const b = buildWave({ seed: ((now + 1) ^ 0x5eed1e) >>> 0, index: 0 });
+  const c = buildWave({ seed: ((now + 17) ^ 0x5eed1e) >>> 0, index: 0 });
+  assert.notEqual(shapeKey(a), shapeKey(b));
+  assert.notEqual(shapeKey(b), shapeKey(c));
+  assert.notDeepEqual(
+    a.tiles.map((t) => t.face.text),
+    b.tiles.map((t) => t.face.text),
+  );
+});
+
+test("carving never takes a wall below the floor it promises", () => {
+  for (let index = 0; index < WAVES; index++) {
+    for (const seed of SPREAD_SEEDS.slice(0, 60)) {
+      const w = buildWave({ seed, index });
+      assert.ok(w.tiles.length >= 20, `wave ${index} seed ${seed} carved down to ${w.tiles.length}`);
+      assert.ok(w.carved >= 0);
+      assert.equal(w.guiltyShare, w.guiltyTotal / w.tiles.length);
+    }
+  }
 });
 
 test("difficulty escalates monotonically where it should", () => {

--- a/dynawalla/games/mosaic/src/game/wall.ts
+++ b/dynawalla/games/mosaic/src/game/wall.ts
@@ -19,8 +19,20 @@ export type TileKind = "glass" | "crystal" | "star";
 /** Chips a masonry tile takes before it gives way. */
 export const MASONRY_HP = 3;
 
-/** A wall thinner than this does not read as a window. */
+/** A wall thinner than this does not read as a window before it is carved. */
 const MIN_TILES = 26;
+
+/**
+ * The floor a carve may not take the wall below.
+ *
+ * The layout masks are chosen against `MIN_TILES` so there is something solid
+ * to carve *from*; the carve is then allowed to open the window right down to
+ * here. Twenty panes still reads as a rose and leaves plenty to break.
+ */
+const CARVE_FLOOR = 20;
+
+/** How far the window may drift sideways, as a fraction of one cell. */
+export const MAX_SWAY_CELLS = 0.42;
 
 export type Tile = {
   col: number;
@@ -36,6 +48,17 @@ export type Tile = {
   hit: number;
   /** Cosmetic: 0..1, set when the ball passes close and the tile is guilty. */
   warm: number;
+  /**
+   * Seconds left of a pane's fall into its cell.
+   *
+   * A re-glazed pane is `alive` from the instant it is scheduled — so the wave
+   * cannot declare itself clear while one is still in the air — but it is not
+   * *there* yet, so `tileAt` refuses to return it and nothing can collide with
+   * it. Zero for every tile the wall was born with.
+   */
+  drop: number;
+  /** Cosmetic: 0..1, decays. The flash of masonry catching light. */
+  kindle: number;
 };
 
 export type Wave = {
@@ -49,6 +72,13 @@ export type Wave = {
   descentRate: number;
   ballSpeed: number;
   layout: string;
+  /** How many cells the carve took out of the layout mask. Reporting only. */
+  carved: number;
+  /** Share of this wall's panes that are targets — what re-glazing matches. */
+  guiltyShare: number;
+  /** Colour-band parameters, kept so a re-glazed pane joins the same design. */
+  palette: number;
+  bands: number;
 };
 
 const LAYOUTS = [
@@ -104,8 +134,75 @@ function occupies(layout: string, c: number, r: number, cols: number, rows: numb
   }
 }
 
+/**
+ * The carve — the difference between nine walls and an unbounded supply.
+ *
+ * The nine layout masks are hand-written shapes, and nine shapes played at two
+ * column counts is fourteen distinct openings in the entire game: measured over
+ * four hundred seeds, wave one was *one* shape — a filled 9×4 rectangle, every
+ * single run, for ever. The founder's word for it was "boring", and he was
+ * describing a fact rather than a feeling.
+ *
+ * So the mask now only says what *kind* of window this is. The carve says which
+ * one: one to three elliptical voids punched out of it, plus a scatter of single
+ * missing panes, all at seeded positions. Every cut is made at a cell **and at
+ * its mirror**, so the result is still a designed rose window — sparser, holed,
+ * asymmetric top-to-bottom, and different every run — rather than a chewed edge.
+ *
+ * A cut that would take the wall below `CARVE_FLOOR` is rolled back whole, so
+ * the floor is a guarantee and not a tendency.
+ */
+function carve(grid: boolean[][], cols: number, rows: number, rng: Rng): number {
+  const half = Math.floor((cols - 1) / 2);
+  const count = (): number => {
+    let n = 0;
+    for (const row of grid) for (const on of row) if (on) n++;
+    return n;
+  };
+  const before = count();
+
+  /** Apply `cut` to the half-grid and its mirror; roll back if it goes too far. */
+  const attempt = (cut: (c: number, r: number) => boolean): void => {
+    const snapshot = grid.map((row) => row.slice());
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c <= half; c++) {
+        if (!cut(c, r)) continue;
+        grid[r]![c] = false;
+        grid[r]![cols - 1 - c] = false;
+      }
+    }
+    if (count() >= CARVE_FLOOR) return;
+    for (let r = 0; r < rows; r++) grid[r] = snapshot[r]!;
+  };
+
+  const voids = rng.int(1, 3);
+  for (let v = 0; v < voids; v++) {
+    const cc = rng.int(0, half);
+    const cr = rng.int(0, rows - 1);
+    const rx = 0.55 + rng.f() * 1.7;
+    const ry = 0.45 + rng.f() * 1.25;
+    attempt((c, r) => {
+      const dx = (c - cc) / rx;
+      const dy = (r - cr) / ry;
+      return dx * dx + dy * dy <= 1;
+    });
+  }
+
+  // Panes that were simply never fitted. One at a time, so each is rolled back
+  // on its own and the scatter stops exactly at the floor.
+  const speckle = rng.int(0, 5);
+  for (let s = 0; s < speckle; s++) {
+    const sc = rng.int(0, half);
+    const sr = rng.int(0, rows - 1);
+    if (!grid[sr]![sc]) continue;
+    attempt((c, r) => c === sc && r === sr);
+  }
+
+  return before - count();
+}
+
 /** Colour index from a symmetric function so the wall reads as a design. */
-function colourAt(c: number, r: number, cols: number, palette: number, bands: number): number {
+export function colourAt(c: number, r: number, cols: number, palette: number, bands: number): number {
   const cx = (cols - 1) / 2;
   const dx = Math.abs(c - cx);
   const v = Math.round(dx * 0.9 + r * 0.6 + palette);
@@ -209,7 +306,7 @@ function exprFor(v: number, rng: Rng, hard: boolean): Face {
  * mal-rule outputs, so scanning it is the same cognitive act as choosing
  * between distractors, just with a ball involved.
  */
-function makeFace(rule: Rule, wantGuilty: boolean, rng: Rng, stage: number): Face {
+export function makeFace(rule: Rule, wantGuilty: boolean, rng: Rng, stage: number): Face {
   const hard = stage >= 2;
   switch (rule.kind) {
     case "multiple": {
@@ -276,9 +373,40 @@ function makeFace(rule: Rule, wantGuilty: boolean, rng: Rng, stage: number): Fac
 
 export type WaveOptions = { seed: number; index: number };
 
+/** The difficulty rung a wave sits on. Pure function of the wave index. */
+export function stageFor(index: number): number {
+  return Math.min(6, Math.floor(index / 3));
+}
+
+/**
+ * A face with the guilt the caller asked for, belt-and-braces checked.
+ *
+ * The generator is the only source of truth for guilt, so the answer is
+ * verified and a drifting family falls back to the stage-0 path. Shared with
+ * the remix, so a pane that drops in mid-wave is generated by exactly the same
+ * code as a pane the wall was born with — there is no second face generator to
+ * disagree with this one.
+ */
+export function faceFor(rule: Rule, wantGuilty: boolean, rng: Rng, stage: number): Face {
+  const face = makeFace(rule, wantGuilty, rng, stage);
+  if (guilty(rule, face.value) === wantGuilty) return face;
+  return makeFace(rule, wantGuilty, rng, 0);
+}
+
+/**
+ * The opening wall is deliberately gentle, but it is no longer a rectangle.
+ *
+ * Wave one used to be hard-coded to `solid`, which is why it was the same
+ * thirty-six-pane block in every run the game has ever played. It now draws
+ * from the shapes that stay legible at four or five rows — no `frame`, which is
+ * a maze, and no `chevron`, whose diagonal banding needs height to read — and
+ * then gets carved like every other wall.
+ */
+const OPENING_LAYOUTS = ["solid", "arch", "rose", "stair", "checker", "lattice"] as const;
+
 export function buildWave({ seed, index }: WaveOptions): Wave {
   const rng = new Rng(subSeed(seed, index, 0x51ed));
-  const stage = Math.min(6, Math.floor(index / 3));
+  const stage = stageFor(index);
 
   const rule = ruleForWave(index, rng);
   const cols = index === 0 ? 9 : 9 + rng.int(0, 1) * 2; // 9 or 11, always odd
@@ -290,8 +418,9 @@ export function buildWave({ seed, index }: WaveOptions): Wave {
   //    and the first one dense enough wins — deterministic, and never a
   //    fourteen-tile wave.
   // The opening wave is deliberately the smallest wall in the game.
-  const baseRows = index === 0 ? 4 : Math.min(7, 5 + Math.floor(index / 5));
-  const candidates = index === 0 ? ["solid"] : rng.shuffle([...LAYOUTS]);
+  const baseRows = index === 0 ? 4 + rng.int(0, 1) : Math.min(7, 5 + Math.floor(index / 5));
+  const candidates =
+    index === 0 ? rng.shuffle([...OPENING_LAYOUTS]) : rng.shuffle([...LAYOUTS]);
   let layout = "solid";
   let rows = baseRows;
   let occupied: boolean[][] = [];
@@ -326,6 +455,9 @@ export function buildWave({ seed, index }: WaveOptions): Wave {
     }
   }
 
+  // 1b. Carve. The mask picked the family; this picks the individual.
+  const carved = carve(occupied, cols, rows, rng);
+
   // 2. Guilt, mirrored. Aim for a share of the wall that keeps every wave
   //    winnable inside a couple of minutes without becoming a chore.
   const share = index === 0 ? 0.62 : 0.6 - Math.min(0.14, stage * 0.025);
@@ -351,12 +483,7 @@ export function buildWave({ seed, index }: WaveOptions): Wave {
     for (let c = 0; c < cols; c++) {
       if (!occupied[r]![c]) continue;
       const wantGuilty = guiltyMask[r]![c]!;
-      let face = makeFace(rule, wantGuilty, rng, stage);
-      // Belt and braces: the generator is the only source of truth for guilt,
-      // so assert it and fall back to a bare integer if a family ever drifts.
-      if (guilty(rule, face.value) !== wantGuilty) {
-        face = makeFace(rule, wantGuilty, rng, 0);
-      }
+      const face = faceFor(rule, wantGuilty, rng, stage);
       const isGuilty = guilty(rule, face.value);
       let kind: TileKind = "glass";
       // Masonry is not indestructible, only stubborn: three chips, and only
@@ -382,6 +509,8 @@ export function buildWave({ seed, index }: WaveOptions): Wave {
         alive: true,
         hit: 0,
         warm: 0,
+        drop: 0,
+        kindle: 0,
       });
     }
   }
@@ -396,5 +525,9 @@ export function buildWave({ seed, index }: WaveOptions): Wave {
     descentRate: index < 2 ? 0 : Math.min(9, 1.2 + (index - 2) * 0.5),
     ballSpeed: Math.min(1250, 820 + index * 28),
     layout,
+    carved,
+    guiltyShare: guiltyTotal / Math.max(1, tiles.length),
+    palette,
+    bands,
   };
 }

--- a/dynawalla/games/mosaic/src/game/wall.ts
+++ b/dynawalla/games/mosaic/src/game/wall.ts
@@ -31,8 +31,18 @@ const MIN_TILES = 26;
  */
 const CARVE_FLOOR = 20;
 
-/** How far the window may drift sideways, as a fraction of one cell. */
-export const MAX_SWAY_CELLS = 0.42;
+/**
+ * How far the window may drift sideways, as a fraction of one cell.
+ *
+ * Bounded by the stone frame rather than by the glass: `drawTracery` draws
+ * `TRACERY_BLEED` units outside the tile grid on every side, so the number that
+ * has to fit inside the wall margin is `MAX_SWAY_CELLS * cellW + TRACERY_BLEED`,
+ * not the sway alone. At 0.42 the tiles stayed on screen and the frame did not.
+ */
+export const MAX_SWAY_CELLS = 0.26;
+
+/** How far outside the tile grid the stone frame is drawn. See `drawTracery`. */
+export const TRACERY_BLEED = 24;
 
 export type Tile = {
   col: number;

--- a/dynawalla/games/mosaic/src/mount.ts
+++ b/dynawalla/games/mosaic/src/mount.ts
@@ -182,6 +182,15 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
   /** One tap, one meaning: use the best thing available right now. */
   const act = (vx: number, vy: number) => {
     audio.start();
+    // Before the game-over branch: a held reveal is the only thing on screen,
+    // and the tap that takes it down must never be spent restarting the run.
+    if (sim.forge?.held) {
+      if (dismissForge(sim)) {
+        cam.timeScaleTarget = 1;
+        audio.setSlowed(false);
+      }
+      return;
+    }
     if (sim.phase === "gameover") {
       restart(sim, (sim.seed * 1103515245 + 12345) >>> 0);
       particles.clearAll();
@@ -191,15 +200,6 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
       return;
     }
     if (sim.forge) {
-      // A held reveal is taken down by the child's own hand, anywhere on the
-      // screen, whenever they have finished with it — never by a timer.
-      if (sim.forge.held) {
-        if (dismissForge(sim)) {
-          cam.timeScaleTarget = 1;
-          audio.setSlowed(false);
-        }
-        return;
-      }
       const i = forgeShardAt(sim.forge, vx, vy);
       if (i >= 0) resolveForge(i);
       return;

--- a/dynawalla/games/mosaic/src/mount.ts
+++ b/dynawalla/games/mosaic/src/mount.ts
@@ -23,7 +23,7 @@ import { Camera, clamp01, lerp } from "./fx/camera.ts";
 import { Particles } from "./fx/particles.ts";
 import { Renderer } from "./fx/render.ts";
 import { JEWELS, DANGER, CHARGE_HOT, BALL_GLOW, POWER_LOOK } from "./fx/palette.ts";
-import { chooseShard, forgeShardAt, openForge, stepForge } from "./game/forge.ts";
+import { chooseShard, dismissForge, forgeShardAt, openForge, stepForge } from "./game/forge.ts";
 import {
   createSim,
   fireLaser,
@@ -107,6 +107,7 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
           "Tap once while it glows. Time slows down and four glass shapes float up with a question above them.",
           "Each shape holds an answer and a prize. Tap the one with the right answer to win its prize: a wider paddle, a laser, extra balls, or a slower ball.",
           "A wrong answer only costs the glow. You do not lose a ball.",
+          "When you get one wrong the right answer lights up under the question. Look at it for as long as you like, then tap once to carry on.",
         ],
       },
       {
@@ -114,6 +115,7 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
         lines: [
           "The dots at the bottom are the balls you have left. You lose one when the ball goes past the paddle.",
           "The wall slides down while you play, so keep breaking.",
+          "New panes drop into the empty spaces, stone tiles sometimes light up and turn into targets, and the whole window drifts from side to side. Keep looking at it — it is never the same wall twice.",
         ],
       },
     ],
@@ -189,6 +191,15 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
       return;
     }
     if (sim.forge) {
+      // A held reveal is taken down by the child's own hand, anywhere on the
+      // screen, whenever they have finished with it — never by a timer.
+      if (sim.forge.held) {
+        if (dismissForge(sim)) {
+          cam.timeScaleTarget = 1;
+          audio.setSlowed(false);
+        }
+        return;
+      }
       const i = forgeShardAt(sim.forge, vx, vy);
       if (i >= 0) resolveForge(i);
       return;
@@ -249,10 +260,15 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
     moved = false;
     if (v.y > vh * 0.18) pointerTargetX = v.x;
     if (sim.forge) {
-      const i = forgeShardAt(sim.forge, v.x, v.y);
-      if (i >= 0) {
+      if (sim.forge.held) {
         act(v.x, v.y);
         moved = true; // consumed
+      } else {
+        const i = forgeShardAt(sim.forge, v.x, v.y);
+        if (i >= 0) {
+          act(v.x, v.y);
+          moved = true; // consumed
+        }
       }
     }
     canvas.focus?.();
@@ -295,7 +311,7 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
     } else if (e.key === "m" || e.key === "M") {
       audio.setMuted(audio.enabled);
     } else if (e.key >= "1" && e.key <= "4") {
-      if (sim.forge) resolveForge(Number(e.key) - 1);
+      if (sim.forge && !sim.forge.held) resolveForge(Number(e.key) - 1);
     }
   };
   const onKeyUp = (e: KeyboardEvent) => {
@@ -473,6 +489,26 @@ export function mount(el: HTMLElement, host: Host): GameHandle {
         cam.timeScaleTarget = 0.3;
         slowUntil = performance.now() + 900;
         buzz("failure");
+        break;
+      }
+      case "reglaze": {
+        // A pane arriving is a small, bright, entirely good thing. It gets the
+        // charge pip rather than a cue of its own: nothing in MOSAIC names a
+        // pitch, and there is no reason for a new sound where one already fits.
+        audio.charge(0.35);
+        particles.cone(e.x, e.y - sim.cellH * 1.2, 6, JEWELS[e.tile.colour]!.glow, 0, 1, 0.7);
+        break;
+      }
+      case "kindle": {
+        audio.charge(0.85);
+        cam.addTrauma(0.05);
+        particles.ring(e.x, e.y, 6, 120, JEWELS[e.tile.colour]!.glow, 0.4, 4);
+        particles.burst(e.x, e.y, 8, "#ffe9b8", 200, 0.45, 8);
+        buzz("light");
+        break;
+      }
+      case "turn": {
+        cam.addTrauma(0.04);
         break;
       }
       case "danger": {

--- a/dynawalla/games/mosaic/tools/bench-sim.mts
+++ b/dynawalla/games/mosaic/tools/bench-sim.mts
@@ -13,7 +13,8 @@
  * Run: `npm run bench`
  */
 import { Rng } from "../src/rng.ts";
-import { createSim, launch, paddleHalf, step } from "../src/game/sim.ts";
+import { createSim, launch, paddleHalf, step, wallLeft } from "../src/game/sim.ts";
+import { createRemix } from "../src/game/remix.ts";
 import type { Sim, SimEvent } from "../src/game/state.ts";
 import { VW } from "../src/game/state.ts";
 import { buildWave } from "../src/game/wall.ts";
@@ -47,8 +48,8 @@ function aimingPaddle(sim: Sim, rng: Rng): void {
   let best: { x: number; y: number } | null = null;
   let bestD = Infinity;
   for (const t of sim.wave.tiles) {
-    if (!t.alive || !t.guilty) continue;
-    const tx = sim.wallX + (t.col + 0.5) * sim.cellW;
+    if (!t.alive || !t.guilty || t.drop > 0) continue;
+    const tx = wallLeft(sim) + (t.col + 0.5) * sim.cellW;
     const ty = sim.wallY + sim.descent + (t.row + 0.5) * sim.cellH;
     const d = Math.hypot(tx - landing, ty - sim.paddleY);
     if (d < bestD) {
@@ -71,6 +72,9 @@ function playWave(seed: number, index: number, limit = 400): { t: number; cleare
     const wave = buildWave({ seed, index });
     sim.wave = wave;
     sim.rule = wave.rule;
+    // Per-wave state, and the benchmark is the tool that measures the remix.
+    sim.remix = createRemix(seed, wave);
+    sim.sway = 0;
     const grid = new Int32Array(wave.cols * wave.rows).fill(-1);
     sim.cellW = (VW - 100) / wave.cols;
     sim.cellH = Math.min(sim.cellW / 1.62, 62);


### PR DESCRIPTION
> "mosaic is pretty nice but I think we need more juicy remixing of the targets while it's running.. The first board is just a rectangle of the numbers and it's boring. Maybe if it was more sparse or things dropped in or more random .. but it just calmly knocks out all of the even numbers and cracks all of the odd ones and just bounces around, not that fun."

He was describing a fact, not a feeling. Measured over 400 seeds before this PR:

| | before | after |
|---|---|---|
| opening board: distinct shapes / 400 seeds | **1** | **386** |
| opening board: fill fraction | **1.000** (always) | **0.600** avg, 0.44–0.92 |
| opening board: layout families | 1 (`solid`, hard-coded) | 4 |
| wave 5: distinct shapes / 400 seeds | 14 | 399 |
| wave 5: fill fraction | 0.794 | 0.554 |
| changes to a board mid-play | **0, ever** | **15.4 beats/wave, one every 6.2 s** |
| waves with zero mid-play change (of 240) | 240 | **0** |
| panes dropping in per wave | 0 | 11.1 |

## What I built

**THE CARVE** (`wall.ts`). The nine hand-written layout masks now only say what *kind* of window this is; a seeded carve says which one — one to three elliptical voids plus a scatter of single missing panes. Every cut is made at a cell **and at its mirror**, so the result is still a designed rose window rather than a chewed edge, and the two existing mirror-symmetry tests still pass unchanged. A cut that would take the wall below a floor of 20 panes is rolled back whole. The opening wave also draws from a family of shapes that stay legible at four or five rows instead of being hard-coded to `solid`.

**THE REMIX** (`remix.ts`, new). A seeded, jittered scheduler fires a beat every 4.5–7.5 s of wave time:

- **RE-GLAZE** — a mirrored pair of panes falls back into empty cells and sets there. The window fills in behind you, so a half-emptied board is a *different* board rather than a smaller one.
- **KINDLE** — a mirrored pair of *stone* catches light and becomes a target. The field of targets is redrawn under a wall you thought you had read.
- **TURN** — the whole rose takes a new amplitude and period of sideways drift. The maths does not change; the aim does.

A beat with nothing to do falls through to the next kind rather than being spent on nothing.

## Not breaking the maths

Three rules, each a property test over many seeds with **every invariant checked on every frame** of a played-to-completion run (`play()` in `remix.test.ts`), including a six-wave session so the late waves — descent, hardest drift, crystal and star — are covered too.

1. **Nothing a child is aiming at is ever taken away.** A live target never stops being a target, never stops being alive, and never changes its face or its cell. Kindling is strictly stone → glass; there is no path back. Re-glazing only ever writes into a cell that is *empty*. Every remix is additive from where the child is standing — the worst case is a gift, never a tile that vanished from under a shot. This is the ABYSSAL BLOOM / MATH NINJA class and it is the first thing the test asserts.
2. **The board provably converges.** Targets added over a wave are hard-capped at ~⅓ of the opening count, and none may be added once three or fewer are left standing. Total targets a wave can ever contain is `guiltyTotal + budget`, a finite number, and every break removes one permanently. A wave cannot be remixed into being unwinnable *or* endless. A falling pane counts as alive for the clear check but is not collidable, so a wave cannot declare itself clear while glass is still in the air.
3. **It is not a clock.** Every beat is wall-side. Nothing shortens the time a child has to think about anything; the forge is untimed apart from its own constant, generous, unpunished close. Drift is bounded *per wave* — a fifteenth of a cell on the tutorial, a third of a cell late — and the global bound is chosen so a full swing still fits inside the wall margin. Speed stays rewarded (the clear bonus) and nowhere enforced.

Stone re-glazing gets its own budget for pacing: uncapped it took the mean headless wave from 75 s to 104 s while adding no maths at all. Capped, it costs 20 s and the window still visibly fills back in eleven times a wave.

## Also: the miss now holds

The forge is the one place MOSAIC asks a question, and a wrong answer used to take the lit correct rune away after 1.15 s. It now uses `packs/shared/game-pacing`'s `revealPlan` contract: `holdMs: Infinity`, ended by the child's own hand anywhere on screen, with the shared 350 ms settle lockout so the second tap of an impatient double-tap cannot eat the lesson it just raised. The prompt and the correct rune stay up together — the sum completed in front of them, in the warm accent, never in red. A clean win still just plays its flourish and goes; there is nothing to marinate on in a sum you got right. Dimmed runes now fade *down and stay down* instead of quietly returning to full a second later.

## What I rejected

- **Changing the rule mid-board.** The loudest possible remix and the worst one: it re-classifies every tile at once, so a child mid-shot is aiming at something that is no longer a target. Rule 1 forbids it.
- **Guilty → stone (un-kindling).** The obvious symmetric partner of KINDLE, and exactly the bug that cost two rounds on ABYSSAL BLOOM. Kindling is one-directional by construction, and the mutation that widens its predicate to include live targets is killed by the test.
- **Moving individual tiles / sliding rows.** Genuinely juicy, but it makes a tile the child is tracking arrive somewhere else, and it wrecks the mirror symmetry that is the art direction. Drift of the *whole* window gets the "the field moves" feeling from one number, changes no tile's identity, and cannot desync the grid.
- **Tuning the target budget down to shorten waves.** Measured: 0.25 / 0.30 / 0.35 give 105 / 109 / 104 s. The added targets are free; the length came entirely from re-glazed *stone*, so that is what got a budget instead.
- **A new audio cue.** MOSAIC has a private synth predating the shared soundscape and migrating it is not this PR. The two new beats reuse the existing `charge(fraction)` pip — an existing cue, and one where the caller passes a fraction rather than naming a pitch.
- **Sway on the tutorial at full strength.** Wave one gets a fifteenth of a cell: visibly alive, negligible to aim at. A test asserts the tutorial swings less than a tenth of a cell and a late wave more than three times as far.

## Verification

- `npm run -s tsc` clean; `npm run -s test` **98 pass / 0 fail, five consecutive runs**.
- `node dynawalla/packs/build.mjs mosaic` builds and passes the SDK checker.
- Solvability property-tested: 24 seeds played headless to a clear with every invariant checked every frame, plus 4 seeds × 6 consecutive waves.
- **Every new assertion mutation-tested.** 27 mutations applied to production code; all killed but one, which is provably equivalent (`t.guilty = true` vs `t.guilty = !t.guilty` inside a loop whose selection predicate already guarantees `!t.guilty` — the mutation that *widens* that predicate is killed). Transcript in the task report.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb