### PR TITLE
dynawalla/games/serpent: the board is the screen, the opening is five numbers, and turning around is a thud

### DIFF
--- a/dynawalla/games/serpent/src/game/arena.test.ts
+++ b/dynawalla/games/serpent/src/game/arena.test.ts
@@ -1,21 +1,25 @@
 /**
- * The shape of the vent, checked against something that is not itself.
+ * The shape of the board, checked against something that is not itself.
  *
- * The arena stopped being a circle: it is the ellipse inscribed in the safe
- * rectangle, so the board is the screen. That is a one-line change to a constant
- * and a real change to the *physics*, because on a circle "how far is the wall",
- * "which way does it face" and "where is the nearest legal spot inside it" are
- * `Math.hypot` and on an ellipse they are the root of a quartic. Those three
- * answers decide where a child dies, where they are paid for grazing, and where
- * an orb is allowed to appear, so every one of them is checked here against a
- * **brute-force sweep of the rim** rather than against a rearrangement of the
- * same algebra.
+ * The board is a rounded rectangle fitted to the real limit: the safe rectangle,
+ * minus the two 44px squares the host paints over every game, minus the rim's own
+ * ink measured in pixels. Nothing else is held back — there is no fill fraction
+ * any more.
  *
- * The other half is the promise the change was made for and the promise it must
- * not break at the same time: the rim reaches the ends of the screen, and no part
- * of it — through the worst shake and the peak of the camera's punch — leaves the
- * safe box. Both are asserted at the five viewports the rest of the pack is held
- * at, with and without a cutout.
+ * Two families of assertion, and both have to hold or the change is not the change:
+ *
+ *   · **It reaches the edge.** The fraction of the safe rectangle the playfield
+ *     covers is asserted with a floor, because that number is the founder's
+ *     question and a regression in it is the answer going backwards.
+ *   · **It stops at the edge.** The rim is a wall a child dies against, so no part
+ *     of it may sit under a rounded display corner or under the host's own
+ *     buttons, in ANY frame the game can draw — the camera's peak zoom and its
+ *     bounded shake included, both measured by running the real camera rather than
+ *     by believing a hand-derived number.
+ *
+ * The geometry underneath is checked against a 60,000-point brute-force sweep of
+ * the rim. A rounded rect's nearest point is closed form where the ellipse it
+ * replaces needed an iteration, and "the code is simpler now" is not evidence.
  */
 
 import assert from "node:assert/strict";
@@ -23,110 +27,133 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { NO_INSETS, safeRect, type Insets } from "../../../../packs/shared/game-chrome/index.ts";
 import {
-  ARENA_FILL,
-  MAX_ARENA_ASPECT,
-  arenaAspect,
-  arenaScale,
-  closestOnRim,
+  NO_INSETS,
+  chromeRects,
+  safeRect,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import {
+  CORNER_FRACTION,
+  SHAKE_HEADROOM,
+  ZOOM_PEAK,
+  arenaBoard,
+  arenaFrame,
   insideRim,
   pullInside,
   rimEdge,
+  rimPerimeter,
+  rimReach,
+  sampleRim,
+  topChromeBand,
+  type Board,
 } from "./arena.ts";
 import { addTrauma, createCamera, punch, updateCamera } from "./fx/camera.ts";
 import { TAU } from "./num.ts";
 import { TUNE } from "./tuning.ts";
 
+const label = (k: Board): string => `a=${k.a.toFixed(3)} b=${k.b.toFixed(3)} r=${k.r.toFixed(3)}`;
+
 /* -------------------------------------------------------------------------- */
 /* The geometry, against a sweep.                                             */
 /* -------------------------------------------------------------------------- */
 
+const SWEEP = 60000;
+const sweepX = new Float32Array(SWEEP);
+const sweepY = new Float32Array(SWEEP);
+const sweepNX = new Float32Array(SWEEP);
+const sweepNY = new Float32Array(SWEEP);
+
 /**
  * The nearest point on the rim, found by looking at 60,000 of them.
  *
- * Dumb on purpose. It can only ever be *worse* than the true minimum, so
- * "`closestOnRim` is no further than this" is a real bound and not a tolerance —
- * an implementation that lands on the wrong side of the ellipse, or stops
- * iterating, is further away and this catches it.
+ * Dumb on purpose. It can only ever be *worse* than the true minimum, so "the
+ * closed form is no further than this" is a bound and not a tolerance.
  */
-function sweepNearest(a: number, b: number, px: number, py: number): number {
+function sweepNearest(px: number, py: number): number {
   let best = Infinity;
-  const N = 60000;
-  for (let i = 0; i < N; i++) {
-    const t = (i / N) * TAU;
-    const d = Math.hypot(a * Math.cos(t) - px, b * Math.sin(t) - py);
+  for (let i = 0; i < SWEEP; i++) {
+    const d = Math.hypot((sweepX[i] as number) - px, (sweepY[i] as number) - py);
     if (d < best) best = d;
   }
   return best;
 }
 
-/** Every shape the game can be in, from a square to the cap, at both vent sizes. */
-const SHAPES: Array<[number, number]> = [];
+/** Every shape the game can be in, from a square to a corridor, at both vent sizes. */
+const SHAPES: Board[] = [];
 for (const r of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
-  for (const k of [1, 1.2, 1.777, 2.165, MAX_ARENA_ASPECT]) {
-    SHAPES.push([r, r * k]);
-    if (k !== 1) SHAPES.push([r * k, r]);
+  for (const k of [1, 1.2, 1.85, 2.4, 4]) {
+    SHAPES.push(arenaBoard(r, { x: k, y: 1 }));
+    if (k !== 1) SHAPES.push(arenaBoard(r, { x: 1, y: k }));
   }
 }
 
-/** Points worth asking about: the middle, the axes, off-axis, and well outside. */
-function probes(a: number, b: number): Array<[number, number]> {
+/** Points worth asking about: the middle, the sides, the corners, and well outside. */
+function probes(k: Board): Array<[number, number]> {
   const out: Array<[number, number]> = [[0, 0]];
-  for (const f of [0.01, 0.35, 0.9, 0.99, 1, 1.05, 1.6]) {
-    for (let i = 0; i < 12; i++) {
-      const t = (i / 12) * TAU + 0.11;
-      out.push([Math.cos(t) * a * f, Math.sin(t) * b * f]);
+  for (const f of [0.01, 0.4, 0.92, 0.999, 1.04, 1.7]) {
+    for (let i = 0; i < 16; i++) {
+      const t = (i / 16) * TAU + 0.13;
+      out.push([Math.cos(t) * k.a * f, Math.sin(t) * k.b * f]);
+    }
+  }
+  // And straight at the corner arcs, where the two branches meet.
+  for (const sx of [-1, 1]) {
+    for (const sy of [-1, 1]) {
+      out.push([sx * (k.a - k.r), sy * (k.b - k.r)]);
+      out.push([sx * (k.a - k.r * 0.3), sy * (k.b - k.r * 0.3)]);
+      out.push([sx * k.a, sy * k.b]);
     }
   }
   return out;
 }
 
 test("the nearest point on the rim is on the rim, and nothing on the rim is nearer", () => {
-  for (const [a, b] of SHAPES) {
-    for (const [px, py] of probes(a, b)) {
-      const c = closestOnRim(a, b, px, py);
-      const on = (c.x / a) ** 2 + (c.y / b) ** 2;
+  for (const k of SHAPES) {
+    sampleRim(k, SWEEP, sweepX, sweepY, sweepNX, sweepNY);
+    for (const [px, py] of probes(k)) {
+      const e = rimEdge(k, px, py);
+      // On the rim: the rounded rect's own distance function is zero there.
+      const qx = Math.max(0, Math.abs(e.x) - (k.a - k.r));
+      const qy = Math.max(0, Math.abs(e.y) - (k.b - k.r));
+      const on = Math.hypot(qx, qy) - k.r;
       assert.ok(
-        Math.abs(on - 1) < 1e-9,
-        `a=${a} b=${b} from (${px.toFixed(3)},${py.toFixed(3)}): the "nearest point on the rim" ` +
-          `is not on the rim — x²/a²+y²/b² = ${on}`,
+        Math.abs(on) < 1e-9,
+        `${label(k)} from (${px.toFixed(3)},${py.toFixed(3)}): the "nearest point on the rim" ` +
+          `is ${on} off the rim`,
       );
-      const mine = Math.hypot(px - c.x, py - c.y);
-      const swept = sweepNearest(a, b, px, py);
+      const mine = Math.hypot(px - e.x, py - e.y);
+      const swept = sweepNearest(px, py);
       assert.ok(
-        mine <= swept + 1e-9,
-        `a=${a} b=${b} from (${px.toFixed(3)},${py.toFixed(3)}): a sweep of the rim found a point ` +
-          `${swept.toFixed(9)} away and closestOnRim settled for ${mine.toFixed(9)}`,
+        mine <= swept + 1e-6,
+        `${label(k)} from (${px.toFixed(3)},${py.toFixed(3)}): a sweep of the rim found a point ` +
+          `${swept.toFixed(9)} away and rimEdge settled for ${mine.toFixed(9)}`,
       );
     }
   }
 });
 
 test("the rim's normal is the unit outward normal, and the query sits on it", () => {
-  for (const [a, b] of SHAPES) {
-    for (const [px, py] of probes(a, b)) {
-      const e = rimEdge(a, b, px, py);
+  for (const k of SHAPES) {
+    for (const [px, py] of probes(k)) {
+      const e = rimEdge(k, px, py);
       const len = Math.hypot(e.nx, e.ny);
-      assert.ok(Math.abs(len - 1) < 1e-9, `a=${a} b=${b}: the normal is ${len} long, not 1`);
-      // Outward: stepping along it leaves the ellipse, stepping back stays in.
+      assert.ok(Math.abs(len - 1) < 1e-9, `${label(k)}: the normal is ${len} long, not 1`);
       assert.ok(
-        !insideRim(a, b, e.x + e.nx * 1e-6, e.y + e.ny * 1e-6),
-        `a=${a} b=${b}: the normal points INTO the vent`,
+        !insideRim(k, e.x + e.nx * 1e-6, e.y + e.ny * 1e-6),
+        `${label(k)}: the normal points INTO the board`,
       );
-      assert.ok(insideRim(a, b, e.x - e.nx * 1e-6, e.y - e.ny * 1e-6));
-      // The foot of a perpendicular: the query lies on the normal line.
+      assert.ok(insideRim(k, e.x - e.nx * 1e-6, e.y - e.ny * 1e-6));
       const cross = e.nx * (py - e.y) - e.ny * (px - e.x);
       assert.ok(
-        Math.abs(cross) < 1e-7,
-        `a=${a} b=${b} from (${px.toFixed(3)},${py.toFixed(3)}): the query is ${cross} off the ` +
+        Math.abs(cross) < 1e-9,
+        `${label(k)} from (${px.toFixed(3)},${py.toFixed(3)}): the query is ${cross} off the ` +
           `normal line, so the "nearest" point is not a foot of a perpendicular`,
       );
-      // The sign of the gap is the side of the wall you are on. Asked only of
-      // points that are on a side: a probe placed exactly ON the rim has a gap of
-      // zero and rounds either way, which is not a fact about the shape.
+      // A probe exactly ON the rim has a gap of zero and rounds either way, which
+      // is not a fact about the shape.
       if (Math.abs(e.gap) > 1e-9) {
-        assert.equal(e.gap > 0, insideRim(a, b, px, py), `a=${a} b=${b}: the gap's sign is inside-out`);
+        assert.equal(e.gap > 0, insideRim(k, px, py), `${label(k)}: the gap's sign is inside-out`);
       }
       assert.ok(
         Math.abs(Math.abs(e.gap) - Math.hypot(px - e.x, py - e.y)) < 1e-12,
@@ -145,14 +172,14 @@ const MARGINS: Array<[string, number]> = [
 ];
 
 test("pullInside puts a body exactly its margin inside, whatever the shape", () => {
-  for (const [a, b] of SHAPES) {
+  for (const k of SHAPES) {
     for (const [what, m] of MARGINS) {
-      for (const [px, py] of probes(a, b)) {
-        const p = pullInside(a, b, px, py, m);
-        const gap = rimEdge(a, b, p.x, p.y).gap;
+      for (const [px, py] of probes(k)) {
+        const p = pullInside(k, px, py, m);
+        const gap = rimEdge(k, p.x, p.y).gap;
         assert.ok(
           gap >= m - 1e-9,
-          `a=${a} b=${b}, ${what} (${m}): (${px.toFixed(3)},${py.toFixed(3)}) was put at ` +
+          `${label(k)}, ${what} (${m}): (${px.toFixed(3)},${py.toFixed(3)}) was put at ` +
             `(${p.x.toFixed(3)},${p.y.toFixed(3)}), which is ${gap.toFixed(6)} from the wall`,
         );
       }
@@ -160,25 +187,58 @@ test("pullInside puts a body exactly its margin inside, whatever the shape", () 
   }
 });
 
-test("the aspect cap is what keeps pullInside exact", () => {
+test("the corner radius is what keeps pullInside exact", () => {
   // Walking `m` back along the normal lands exactly `m` inside only while `m` is
-  // under the smallest radius of curvature the ellipse has. That is the real
-  // reason MAX_ARENA_ASPECT exists, and it is worth the smallest vent and the
-  // largest margin the game can put together.
-  const short = TUNE.arenaFloor;
-  const long = TUNE.arenaFloor * MAX_ARENA_ASPECT;
-  const tightest = (short * short) / long;
+  // under the corner radius — past it the corner has run out and the offset curve
+  // is no longer a rounded rect. Worth the SMALLEST board the game can close to
+  // and the largest clearance it asks for. Note this does not depend on the aspect
+  // at all, which is why there is no cap on how long a board may be.
+  const tightest = TUNE.arenaFloor * CORNER_FRACTION;
   const worst = Math.max(...MARGINS.map(([, m]) => m));
   assert.ok(
     tightest > worst * 1.3,
-    `at the vent floor and the aspect cap the rim's tightest radius of curvature is ` +
-      `${tightest.toFixed(4)} and the game asks for ${worst.toFixed(4)} of clearance — ` +
-      `the offset stops being exact`,
+    `at the vent's floor the corner radius is ${tightest.toFixed(4)} and the game asks for ` +
+      `${worst.toFixed(4)} of clearance — the offset stops being exact`,
   );
 });
 
+test("the rim walk lands on the rim, evenly, facing outward", () => {
+  // `sampleRim` is a second description of the same curve — the renderer strokes
+  // it and the polyps ride it — so it has to agree with `rimEdge`, or the wall a
+  // child sees and the wall they hit are different objects.
+  const n = 400;
+  const x = new Float32Array(n);
+  const y = new Float32Array(n);
+  const nx = new Float32Array(n);
+  const ny = new Float32Array(n);
+  for (const k of SHAPES) {
+    sampleRim(k, n, x, y, nx, ny);
+    const step = rimPerimeter(k) / n;
+    for (let i = 0; i < n; i++) {
+      const e = rimEdge(k, x[i] as number, y[i] as number);
+      assert.ok(
+        Math.abs(e.gap) < 1e-6,
+        `${label(k)}: rim sample ${i} is ${e.gap.toFixed(9)} off the rim rimEdge describes`,
+      );
+      assert.ok(
+        Math.hypot((nx[i] as number) - e.nx, (ny[i] as number) - e.ny) < 1e-6,
+        `${label(k)}: rim sample ${i} faces a different way than rimEdge says the wall does`,
+      );
+      const j = (i + 1) % n;
+      const d = Math.hypot((x[j] as number) - (x[i] as number), (y[j] as number) - (y[i] as number));
+      // Chord, not arc, so a corner sample is a hair short — never long, and never
+      // by more than the sag of one step.
+      assert.ok(
+        d <= step + 1e-6 && d > step * 0.99,
+        `${label(k)}: samples ${i}→${j} are ${d.toFixed(6)} apart and the step is ${step.toFixed(6)} — ` +
+          `the walk is not even, so the graze glow will crawl at a corner`,
+      );
+    }
+  }
+});
+
 /* -------------------------------------------------------------------------- */
-/* The board is the screen — and stays inside it.                             */
+/* The board reaches the edge of the screen, and stops there.                 */
 /* -------------------------------------------------------------------------- */
 
 const PORTRAIT: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
@@ -200,130 +260,249 @@ function insetsFor(w: number, h: number): Array<[string, Insets]> {
   ];
 }
 
-/**
- * What the camera can actually do to the picture, measured by running it.
- *
- * Hand-derived numbers are how a margin goes stale. `prompt.ts` records that this
- * spring undershoots to 0.990 for exactly the same reason; this takes the other
- * end of it, and the shake, off the shipping code.
- */
-function cameraExtremes(): { zoom: number; shake: number } {
-  const cam = createCamera(false);
-  const biggest = Math.max(TUNE.punchEat, TUNE.punchWrong, TUNE.punchDepth, TUNE.punchDeath);
-  punch(cam, biggest);
-  addTrauma(cam, 1);
-  let zoom = 1;
-  let shake = 0;
-  for (let i = 0; i < 1200; i++) {
-    updateCamera(cam, 1 / 240);
-    zoom = Math.max(zoom, cam.zoom);
-    shake = Math.max(shake, Math.abs(cam.shakeX), Math.abs(cam.shakeY));
+type Fitted = {
+  where: string;
+  vw: number;
+  vh: number;
+  insets: Insets;
+  safe: { x: number; y: number; w: number; h: number };
+  band: number;
+  frame: ReturnType<typeof arenaFrame>;
+};
+
+function fits(): Fitted[] {
+  const out: Fitted[] = [];
+  for (const [name, vw, vh] of VIEWPORTS) {
+    for (const [tag, insets] of insetsFor(vw, vh)) {
+      const safe = safeRect(vw, vh, insets);
+      const band = topChromeBand(vw, safe.y, safe.h, insets);
+      out.push({
+        where: `${name} (${vw}x${vh}), ${tag}`,
+        vw,
+        vh,
+        insets,
+        safe,
+        band,
+        frame: arenaFrame(safe.w, safe.h, band),
+      });
+    }
   }
-  return { zoom, shake };
+  return out;
 }
 
 /**
- * The furthest ink `scene.ts: drawRim` puts from the centre, on one axis.
+ * What the camera can actually do to the picture, measured by running it.
  *
- * Mirrors the draw calls: the rim stroke straddles the semi-axis by half its
- * width, and the polyps ride at `1.012` of it with half a sprite beyond that.
- * The soft halo is deliberately not here — it is a radial gradient that has faded
- * out before it reaches its own edge, it is not a wall, and the 0.44 circle this
- * replaces let it past the safe box too.
+ * Hand-derived numbers are how a margin goes stale. The shake is reported RAW
+ * here, before `scene.ts` clamps it, so the assertion below is about the clamp
+ * doing work and not about the shake happening to be small.
  */
-function rimReach(semiAxisPx: number, S: number): number {
+function cameraExtremes(): { zoom: number; rawShake: number } {
+  const cam = createCamera(false);
+  punch(cam, Math.max(TUNE.punchEat, TUNE.punchWrong, TUNE.punchDepth, TUNE.punchDeath));
+  addTrauma(cam, 1);
+  let zoom = 1;
+  let rawShake = 0;
+  for (let i = 0; i < 1200; i++) {
+    updateCamera(cam, 1 / 240);
+    zoom = Math.max(zoom, cam.zoom);
+    rawShake = Math.max(rawShake, Math.abs(cam.shakeX), Math.abs(cam.shakeY));
+  }
+  return { zoom, rawShake };
+}
+
+test("the reserved zoom and shake are the ones the camera really produces", () => {
+  const cam = cameraExtremes();
+  assert.ok(
+    cam.zoom <= ZOOM_PEAK,
+    `the camera punches to ${cam.zoom.toFixed(5)} and the layout reserves ${ZOOM_PEAK}`,
+  );
+  assert.ok(cam.zoom > 1.001, `the punch measured ${cam.zoom} — the spring is not being driven`);
+  // The clamp has to be doing something, or reserving for it is theatre.
+  assert.ok(
+    cam.rawShake > SHAKE_HEADROOM,
+    `the raw shake peaks at ${cam.rawShake.toFixed(4)} and the clamp is ${SHAKE_HEADROOM} — ` +
+      `the clamp never bites, so it is not the reason the rim stays inside`,
+  );
+  // …and every shake a child is still steering through must be under it, or the
+  // clamp is trimming play and not just the death slam.
+  for (const [what, trauma] of [
+    ["a wall hit", TUNE.traumaWall],
+    ["a wrong answer", TUNE.traumaWrong],
+    ["a self-bump", TUNE.traumaBump],
+    ["a depth", TUNE.traumaDepth],
+    ["a bite", TUNE.traumaEat],
+  ] as const) {
+    assert.ok(
+      trauma * trauma * TUNE.shakeMax <= SHAKE_HEADROOM,
+      `${what} shakes to ${(trauma * trauma * TUNE.shakeMax).toFixed(4)}, past the ${SHAKE_HEADROOM} clamp`,
+    );
+  }
+});
+
+/** The rim line and its outward ink, in pixels from the board's centre. */
+function rimInk(semiAxisPx: number, S: number): number {
   const stroke = semiAxisPx + Math.max(2.5, S * (0.014 + 0.016)) / 2;
-  const polyps = semiAxisPx * 1.012 + (S * 0.016 * 1.4) / 2;
+  const polyps = semiAxisPx + S * (0.012 + 0.016 * 1.4 * 0.5);
   return Math.max(stroke, polyps);
 }
 
 test("no part of the rim ever leaves the safe box", () => {
   const cam = cameraExtremes();
-  for (const [name, vw, vh] of VIEWPORTS) {
-    for (const [label, insets] of insetsFor(vw, vh)) {
-      const safe = safeRect(vw, vh, insets);
-      const scale = arenaScale(safe.w, safe.h);
-      const aspect = arenaAspect(safe.w, safe.h);
-      const cx = safe.x + safe.w / 2;
-      const cy = safe.y + safe.h / 2;
-      for (const arenaR of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
-        const S = scale * cam.zoom;
-        const jitter = cam.shake * scale;
-        const rx = rimReach(arenaR * aspect.x * S, S) + jitter;
-        const ry = rimReach(arenaR * aspect.y * S, S) + jitter;
-        const where = `${name} (${vw}x${vh}), ${label}, vent ${arenaR}`;
-        assert.ok(cx - rx >= safe.x - 1e-9, `${where}: the rim crosses the left inset by ${(safe.x - (cx - rx)).toFixed(2)}px`);
-        assert.ok(cx + rx <= safe.x + safe.w + 1e-9, `${where}: the rim crosses the right inset by ${(cx + rx - safe.x - safe.w).toFixed(2)}px`);
-        assert.ok(cy - ry >= safe.y - 1e-9, `${where}: the rim crosses the top inset by ${(safe.y - (cy - ry)).toFixed(2)}px`);
-        assert.ok(cy + ry <= safe.y + safe.h + 1e-9, `${where}: the rim crosses the bottom inset by ${(cy + ry - safe.y - safe.h).toFixed(2)}px`);
+  for (const f of fits()) {
+    for (const arenaR of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
+      const S = f.frame.scale * cam.zoom;
+      const jitter = SHAKE_HEADROOM * f.frame.scale;
+      const cx = f.safe.x + f.frame.cx;
+      const cy = f.safe.y + f.frame.cy;
+      // The scene is drawn at S = scale x zoom, so the board's own half-extent is
+      // scaled too — measuring the ink off the UNZOOMED extent is how this passes
+      // while the punch quietly carries the rim off the screen.
+      const rx = rimInk(arenaR * f.frame.aspect.x * S, S) + jitter;
+      const ry = rimInk(arenaR * f.frame.aspect.y * S, S) + jitter;
+      const where = `${f.where}, vent ${arenaR}`;
+      assert.ok(cx - rx >= f.safe.x - 1e-9, `${where}: the rim crosses the left inset by ${(f.safe.x - (cx - rx)).toFixed(2)}px`);
+      assert.ok(cx + rx <= f.safe.x + f.safe.w + 1e-9, `${where}: the rim crosses the right inset by ${(cx + rx - f.safe.x - f.safe.w).toFixed(2)}px`);
+      assert.ok(cy - ry >= f.safe.y - 1e-9, `${where}: the rim crosses the top inset by ${(f.safe.y - (cy - ry)).toFixed(2)}px`);
+      assert.ok(cy + ry <= f.safe.y + f.safe.h + 1e-9, `${where}: the rim crosses the bottom inset by ${(cy + ry - f.safe.y - f.safe.h).toFixed(2)}px`);
+    }
+  }
+});
+
+test("no part of the rim ever passes under the host's own buttons", () => {
+  // The host paints `<` and `?` OVER the game. Water under them is water; a WALL
+  // under them is a thing that kills a child from behind a button. Sampled off the
+  // real rim walk rather than off the bounding box, because it is the corner arcs
+  // that come nearest.
+  const cam = cameraExtremes();
+  const n = 900;
+  const x = new Float32Array(n);
+  const y = new Float32Array(n);
+  const nx = new Float32Array(n);
+  const ny = new Float32Array(n);
+  for (const f of fits()) {
+    const squares = chromeRects(f.vw, f.insets);
+    assert.ok(squares.length >= 2, "the host stopped painting chrome — this test is now vacuous");
+    for (const arenaR of [TUNE.arenaStart, 0.8, TUNE.arenaFloor]) {
+      const board = arenaBoard(arenaR, f.frame.aspect);
+      sampleRim(board, n, x, y, nx, ny);
+      const S = f.frame.scale * cam.zoom;
+      const ink = S * (0.012 + 0.016 * 1.4 * 0.5);
+      const jitter = SHAKE_HEADROOM * f.frame.scale;
+      const cx = f.safe.x + f.frame.cx;
+      const cy = f.safe.y + f.frame.cy;
+      for (let i = 0; i < n; i++) {
+        // Push each sample as far out as the frame can carry it, in every direction.
+        const ox = (x[i] as number) * S + (nx[i] as number) * ink;
+        const oy = (y[i] as number) * S + (ny[i] as number) * ink;
+        for (const dx of [-jitter, jitter]) {
+          for (const dy of [-jitter, jitter]) {
+            const px = cx + ox + dx;
+            const py = cy + oy + dy;
+            for (const c of squares) {
+              // Touching the square's edge is clear: the board is fitted right up
+              // to the limit, and "up to" is where the limit is.
+              assert.ok(
+                px <= c.x + 1e-9 ||
+                  px >= c.x + c.w - 1e-9 ||
+                  py <= c.y + 1e-9 ||
+                  py >= c.y + c.h - 1e-9,
+                `${f.where}, vent ${arenaR}: the rim runs under a host control at ` +
+                  `(${px.toFixed(1)},${py.toFixed(1)}) — the square is ${c.x},${c.y} ${c.w}x${c.h}`,
+              );
+            }
+          }
+        }
       }
     }
   }
 });
 
-test("the board really is the screen, on every shape of screen", () => {
-  // The assertion the founder asked for, and the one a revert cannot pass: the
-  // vent spans ARENA_FILL of the safe box on BOTH axes, not on the short one with
-  // dead black bands on the other. A disc sized off the short side spans that
-  // fraction of the short side and a much smaller fraction of the long one.
-  for (const [name, vw, vh] of VIEWPORTS) {
-    for (const [label, insets] of insetsFor(vw, vh)) {
-      const safe = safeRect(vw, vh, insets);
-      const scale = arenaScale(safe.w, safe.h);
-      const aspect = arenaAspect(safe.w, safe.h);
-      const where = `${name} (${vw}x${vh}), ${label}`;
-      const spanX = TUNE.arenaStart * aspect.x * scale * 2;
-      const spanY = TUNE.arenaStart * aspect.y * scale * 2;
-      assert.ok(
-        Math.abs(spanX / safe.w - ARENA_FILL) < 1e-9,
-        `${where}: the vent is ${((spanX / safe.w) * 100).toFixed(1)}% of the safe width, not ${ARENA_FILL * 100}%`,
-      );
-      assert.ok(
-        Math.abs(spanY / safe.h - ARENA_FILL) < 1e-9,
-        `${where}: the vent is ${((spanY / safe.h) * 100).toFixed(1)}% of the safe height, not ${ARENA_FILL * 100}%`,
-      );
-      // And the fit the condition is measured against is still the disc inside
-      // the ellipse, so `arenaR × scale` has to stay the SHORT semi-axis.
-      assert.equal(Math.min(aspect.x, aspect.y), 1, `${where}: the short semi-axis is no longer arenaR`);
-    }
+test("the board really is the screen — the number that answers the question", () => {
+  // The founder asked three times why the board is not the whole screen. This is
+  // the answer as a number, with a floor under it so it cannot quietly go
+  // backwards. For reference, the shape this replaces — an ellipse at 0.9 of each
+  // axis — covered `0.81 × π/4 = 63.6%`, the same on every screen.
+  const rows: string[] = [];
+  for (const f of fits()) {
+    const board = arenaBoard(TUNE.arenaStart, f.frame.aspect);
+    const s = f.frame.scale;
+    const covered = (4 * board.a * board.b - (4 - Math.PI) * board.r * board.r) * s * s;
+    const share = covered / (f.safe.w * f.safe.h);
+    rows.push(`  ${f.where.padEnd(46)} ${(share * 100).toFixed(1)}%`);
+    // Measured range at the ten frames below: 77.0% to 84.4%. What is NOT board is
+    // the host's own two buttons (7.5 points on a tall phone, 11.7 on the shortest
+    // safe box the fleet tests) and the rim's ink, and nothing else.
+    assert.ok(
+      share > 0.76,
+      `${f.where}: the board covers only ${(share * 100).toFixed(1)}% of the safe rectangle`,
+    );
+    // And it is genuinely flush on the axis the host's band does not eat: the
+    // board's half-width plus the rim's ink IS the safe box's half-width.
+    const widest = board.a * s * ZOOM_PEAK + f.frame.reach;
+    assert.ok(
+      Math.abs(widest - f.safe.w / 2) < 1e-4,
+      `${f.where}: the board's widest frame is ${(f.safe.w / 2 - widest).toFixed(4)}px short of the safe box`,
+    );
+  }
+  console.log(`\n  playfield share of the safe rectangle (was 63.6% everywhere):\n${rows.join("\n")}\n`);
+});
+
+test("the fitted frame is a fixed point, not an approximation of one", () => {
+  for (const f of fits()) {
+    assert.ok(
+      Math.abs(rimReach(f.frame.scale) - f.frame.reach) < 1e-6,
+      `${f.where}: the frame reserved ${f.frame.reach} and its own scale needs ${rimReach(f.frame.scale)}`,
+    );
+    assert.equal(Math.min(f.frame.aspect.x, f.frame.aspect.y), 1, `${f.where}: neither axis is the short one`);
+    // The band really is the host's, not a number somebody picked.
+    const deepest = Math.max(...chromeRects(f.vw, f.insets).map((c) => c.y + c.h));
+    assert.ok(
+      Math.abs(f.band - (deepest - f.safe.y)) < 1e-9,
+      `${f.where}: the reserved band is ${f.band} and the host's chrome ends at ${deepest - f.safe.y}`,
+    );
   }
 });
 
 test("the shape reaches the renderer and the run, and by no other route", () => {
   // Source-level for the same reason `prompt.test.ts` is: `createRenderer` needs a
-  // canvas and there is none in Node. Two half-done states this guards, and both
-  // compile clean and look almost right:
-  //
-  //   · `mount.ts` never tells the world its shape, so the simulation stays a
-  //     circle, the renderer draws that circle, and the whole change ships as a
-  //     4% larger disc that nobody asked for;
-  //   · the simulation is an ellipse and the renderer still strokes a circle, so
-  //     the drawn wall and the wall a child dies against are different curves.
+  // canvas and there is none in Node. Four half-done states this guards, and all
+  // four compile clean and look almost right — the world never told its shape, the
+  // renderer fitting its own frame, the host's band unreserved, or the shake left
+  // unclamped so the board slides off a screen it is now flush against.
   const here = dirname(new URL(import.meta.url).pathname);
   const mount = readFileSync(join(here, "mount.ts"), "utf8");
   assert.ok(
-    /setArenaAspect\(\s*world,\s*renderer\.view\.safe\.w,\s*renderer\.view\.safe\.h\s*\)/.test(mount),
-    "mount.ts no longer fits the vent to the measured safe box — the arena is a circle again",
+    /setArenaAspect\(\s*world,\s*renderer\.view\.aspect\s*\)/.test(mount),
+    "mount.ts no longer hands the fitted shape to the world — the board is a square again",
   );
 
   const scene = readFileSync(join(here, "render", "scene.ts"), "utf8");
   assert.ok(
-    scene.includes("arenaScale(safe.w, safe.h)"),
-    "scene.ts sizes the arena itself again — that expression is `arenaScale` now, and a second " +
-      "copy of it is how the renderer and the shape part company",
+    scene.includes("arenaFrame(safe.w, safe.h, band)"),
+    "scene.ts fits the board itself again — that is `arenaFrame` now, and a second copy of it " +
+      "is how the renderer and the shape part company",
+  );
+  // The whole expression, not just the call: a band that is measured and then
+  // scaled, offset or ignored on its way into the frame reserves the wrong number
+  // and reads as if it reserves the right one.
+  assert.ok(
+    scene.includes("const band = topChromeBand(w, safe.y, safe.h, insets);"),
+    "scene.ts no longer reserves the host's chrome band as it is measured — the rim runs " +
+      "under the buttons",
   );
   assert.ok(
-    scene.includes("w.arenaR * w.aspectX * S") && scene.includes("w.arenaR * w.aspectY * S"),
-    "scene.ts draws the arena off one radius again, so it is a circle inside an elliptical vent",
+    scene.includes("clamp(cam.shakeX, -SHAKE_HEADROOM, SHAKE_HEADROOM)") &&
+      scene.includes("clamp(cam.shakeY, -SHAKE_HEADROOM, SHAKE_HEADROOM)"),
+    "scene.ts applies the camera shake unclamped — the board is flush to the safe box now, so " +
+      "an unclamped shake carries a lethal rim off it",
   );
   assert.ok(
-    scene.includes("g.ellipse(X(0), Y(0), aX, aY, 0, 0, TAU)"),
-    "the arena's clip is not the arena's shape",
+    scene.includes("sampleRim(board, segs, rimX, rimY, rimNX, rimNY)"),
+    "scene.ts no longer strokes the rim off the shared walk, so the drawn wall and the wall a " +
+      "child hits are two different curves",
   );
-  assert.ok(
-    scene.includes("g.ellipse(cx, cy, aX, aY, 0, a0, a1)"),
-    "the rim a child steers against is still stroked as a circle",
-  );
+  assert.ok(scene.includes("g.clip()"), "the board's clip is gone — see the header of prompt.ts");
 });
 
 test("an absurd surface produces a shape, not a NaN", () => {
@@ -335,13 +514,15 @@ test("an absurd surface produces a shape, not a NaN", () => {
     [4000, 320],
     [200, 60],
   ] as const) {
-    const s = arenaScale(w, h);
-    const k = arenaAspect(w, h);
-    assert.ok(Number.isFinite(s) && s > 0, `${w}x${h}: the scale is ${s}`);
-    assert.ok(Number.isFinite(k.x) && Number.isFinite(k.y), `${w}x${h}: the aspect is NaN`);
-    assert.equal(Math.min(k.x, k.y), 1, `${w}x${h}: neither axis is the short one`);
-    assert.ok(Math.max(k.x, k.y) <= MAX_ARENA_ASPECT + 1e-12, `${w}x${h}: the aspect cap was passed`);
-    const e = rimEdge(TUNE.arenaFloor * k.x, TUNE.arenaFloor * k.y, 0, 0);
+    const band = topChromeBand(w, 0, h, NO_INSETS);
+    const f = arenaFrame(w, h, band);
+    assert.ok(Number.isFinite(f.scale) && f.scale > 0, `${w}x${h}: the scale is ${f.scale}`);
+    assert.ok(Number.isFinite(f.aspect.x) && Number.isFinite(f.aspect.y), `${w}x${h}: the aspect is NaN`);
+    assert.equal(Math.min(f.aspect.x, f.aspect.y), 1, `${w}x${h}: neither axis is the short one`);
+    const board = arenaBoard(TUNE.arenaFloor, f.aspect);
+    const e = rimEdge(board, 0, 0);
     assert.ok(Number.isFinite(e.gap) && Number.isFinite(e.nx), `${w}x${h}: the rim went NaN at the centre`);
+    const p = pullInside(board, 99, 99, TUNE.orbRadius * 2.2);
+    assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y), `${w}x${h}: pullInside went NaN`);
   }
 });

--- a/dynawalla/games/serpent/src/game/arena.ts
+++ b/dynawalla/games/serpent/src/game/arena.ts
@@ -1,141 +1,214 @@
 /**
- * The vent, as a shape.
+ * The vent, as a shape — and the frame it is fitted into.
  *
- * The arena used to be a circle sized off the **short** side of the safe box, so
- * a phone held upright played inside a disc about 0.88 screens wide with two
- * dead black bands above and below it. The founder asked the obvious question —
- * why is the board not the screen — and the answer is that it now is: the vent
- * is an **ellipse inscribed in the safe rectangle**, so it reaches the top and
- * the bottom of a tall phone and the left and right of a wide one.
+ * ## Three times asked
+ *
+ * The board was a circle sized off the SHORT side of the safe box, which left two
+ * dead bands on a tall phone. It became an ellipse inscribed in the safe box at
+ * 0.9 of each axis, which removed the bands and left four dark corners and a
+ * tenth of every edge. The founder asked the same question all three times: why
+ * is the board not the screen.
+ *
+ * It is now a **rounded rectangle fitted to the real limit**, and the real limit
+ * is exactly two things:
+ *
+ *   1. **The safe rectangle.** Outside it is the cutout and the rounded display
+ *      corner. A lethal rim under a rounded corner is a wall a child dies against
+ *      and cannot see, which is what the original comment on the 0.44 circle was
+ *      protecting against and it was right.
+ *   2. **The host's chrome.** The host paints `<` at the top left and `?` at the
+ *      top right, 44px squares, OVER the game — `hostChrome.ts` owns those
+ *      numbers. In the founder's screenshot they sat on top of the board. The rim
+ *      is a wall, so it clears them; the water underneath them is still water.
+ *
+ * Nothing else is held back. There is no fill fraction any more: the rim's own
+ * ink — its stroke, its polyps, and a bounded camera shake — is measured in
+ * pixels and reserved in pixels, and the board takes every pixel that is left.
+ * `arena.test.ts` holds the whole rim inside the safe box and clear of both
+ * chrome squares, in every frame the game can draw.
  *
  * ## Why the shape is a module and not a constant
  *
- * The rim is a wall a child can die against, and grazing it is worth points, so
- * the boundary is not decoration: `world.ts` asks it three questions every
- * simulated step — how far am I from the wall, which way is the wall facing, and
- * where is the nearest legal spot inside it. On a circle all three were one line
- * of arithmetic on `Math.hypot`. On an ellipse none of them are, because the
- * nearest point on an ellipse is the root of a quartic, so the answers live here
- * and are checked in `arena.test.ts` against a brute-force sweep of the rim.
+ * The rim is a wall a child can die against and grazing it is worth points, so
+ * `world.ts` asks it three questions every simulated step: how far am I from the
+ * wall, which way is the wall facing, and where is the nearest legal spot inside
+ * it. All three go through `rimEdge` and `pullInside`, so the wall, the graze
+ * band, the spawner and the orb field cannot drift apart.
  *
- * Everything is in world units: the arena's SHORT semi-axis is exactly
- * `world.arenaR`, which is what makes this change feel like nothing on the axis
- * the game was tuned on. The long semi-axis is `arenaR × aspect`; the serpent,
- * the orbs and every radius in `TUNE` are untouched, and the pixels-per-world-unit
- * scale stays isotropic, so the snake is still round and turns the same way in
- * every direction. Only the room it swims in got bigger.
+ * A rounded rect answers all three in closed form — clamp to the straight run, or
+ * fall to the corner arc — where the ellipse it replaces needed an evolute
+ * iteration. It is less code AND it covers about 98% of its own bounding box
+ * instead of the ellipse's 78.5%. `arena.test.ts` still checks every answer
+ * against a 60,000-point brute-force sweep of the rim, because "less code" is not
+ * an argument.
+ *
+ * Everything is in world units: the board's SHORT half-extent is exactly
+ * `world.arenaR`, so the axis the game was tuned on is untouched, and the
+ * pixels-per-world-unit scale stays isotropic, so the serpent is round and turns
+ * the same way in every direction.
  */
 
-import { clamp } from "./num.ts";
+import { chromeRects, type Insets } from "../../../../packs/shared/game-chrome/index.ts";
 
 /**
- * How much of the safe box the arena's outer rim may use, per axis.
+ * The corner radius, as a fraction of the board's SHORT half-extent.
  *
- * The rim is not a hairline. Measured against what `scene.ts: drawRim` actually
- * puts on the glass, and what `camera.ts` can do to it, the furthest ink from the
- * centre on the short axis is
+ * Keyed to the short axis so the corners look the same on a phone and a tablet,
+ * and so an elongated board does not grow lozenge ends. At 0.30 the corners cost
+ * `(4 − π)r²` — about 1.3% of the board — and land near the display's own corner
+ * radius on a phone, which is why it reads as the screen rather than as a card
+ * lying on it.
  *
- *   · the polyps, drawn at `1.012 × semiAxis` with a sprite `0.016 × scale` wide
- *     at up to 1.4× its size, so a half-sprite of `0.0112 × scale` beyond that;
- *   · all of it multiplied by `cam.zoom`, whose spring peaks at about 1.007
- *     (`prompt.ts` records the matching 0.990 undershoot);
- *   · plus `cam.shakeX × view.scale`, and `shakeMax` is 0.055.
- *
- * That is `1.0 × 1.007 × 1.012 + 0.0112 × 1.007 + 0.055 ≈ 1.086` semi-axes, so a
- * fill of 0.9 puts the worst frame at `0.45 × 1.086 = 0.489` of the safe box's
- * short side against a budget of 0.5 — the same margin the old 0.44 bought, held
- * by `arena.test.ts` rather than by belief.
- *
- * The soft halo behind the rim is deliberately outside this: it is a radial
- * gradient that is already transparent where it meets the edge, it is not
- * something a child can steer into, and the shipped 0.44 arena let it out too.
+ * It is also the exactness bound for `pullInside`: walking a margin back along
+ * the normal is exact for any margin up to the corner radius, and only up to it.
+ * `arena.test.ts` holds that against the largest clearance the game asks for.
  */
-export const ARENA_FILL = 0.9;
+export const CORNER_FRACTION = 0.3;
 
 /**
- * The most elongated the vent is allowed to get.
+ * How far the rim's polyps ride outside the rim line, in world units.
  *
- * Not taste — curvature. `pullInside` puts a body `m` inside the rim by walking
- * `m` back along the surface normal, which is exact only while `m` stays under
- * the smallest radius of curvature the ellipse has, `min(a,b)² / max(a,b)`. At
- * the vent's floor (`TUNE.arenaFloor` = 0.62) that is `0.62 / aspect`, and the
- * largest margin anything asks for is an orb's spawn clearance, `0.062 × 2.2 =
- * 0.136`. So the shape stays exact up to an aspect of about 4.5, and this cap
- * keeps a 50% margin on it.
- *
- * Nothing a person holds is anywhere near it — the tallest phone is about 2.2:1
- * — but an iPad Slide Over is 3.7:1 and a pack frame can be resized to anything.
- * Past the cap the ellipse simply stops growing along the long axis and the game
- * is letterboxed, which is a smaller arena and never a wrong one.
+ * An absolute offset, not a multiple of the half-extent. The ellipse used
+ * `1.012 × semiAxis`, which on a long board cost twice as many pixels on the long
+ * axis as the short one for no reason anybody could see.
  */
-export const MAX_ARENA_ASPECT = 3;
+export const POLYP_OUT = 0.012;
 
-/** The arena's aspect: one axis is exactly 1, the other is the safe box's ratio. */
+/**
+ * The largest camera shake the board is allowed to be translated by, in world
+ * units — half of `TUNE.shakeMax`, and enforced in `scene.ts` where the offset is
+ * applied.
+ *
+ * Every shake the game produces while a child is still steering is already under
+ * it: a wall hit is `0.55² × 0.055 = 0.0166`, a wrong answer `0.0111`, a bite
+ * `0.0006`. The only thing this trims is the death slam, which keeps its hitstop,
+ * its slow-motion, its flash, its punch and its debris and loses a few pixels of
+ * translation on a frame where the run is already over.
+ *
+ * It is reserved in the layout, in pixels, which is the price of the rim being
+ * provably inside the safe box in EVERY frame rather than only at rest. Reserving
+ * the full `shakeMax` instead costs seven points of screen, all of it to protect
+ * a frame nobody is playing.
+ */
+export const SHAKE_HEADROOM = 0.028;
+
+/**
+ * The most `cam.zoom` can ever be.
+ *
+ * The punch is a spring (`stiffness 190, damping 19`) driven by an impulse, and
+ * the largest impulse in `TUNE` is 0.14. `prompt.ts` records the matching
+ * undershoot, 0.990, for the same spring. `arena.test.ts` runs the real camera
+ * and holds it against this, so the layout reserves a number that is checked
+ * rather than believed.
+ */
+export const ZOOM_PEAK = 1.008;
+
+/** The board's aspect: one axis is exactly 1, the other is the frame's ratio. */
 export type Aspect = { x: number; y: number };
 
 /**
- * Pixels per world unit, for a safe box.
+ * The board: half-extents and corner radius, in world units.
  *
- * Isotropic on purpose. The stretch that fills the screen is in the arena's
- * semi-axes, never in the transform — squeezing the canvas instead would make the
- * serpent fat one way and thin the other and turn its turning circle into an egg.
+ * Named `Board` and not `Rect` because `game-chrome` exports a `Rect` of its own
+ * (x/y/w/h, for the host's chrome squares) and a file that reads both must not
+ * have to guess which one it is holding.
  */
-export function arenaScale(safeW: number, safeH: number): number {
-  return (Math.max(1, Math.min(safeW, safeH)) * ARENA_FILL) / 2;
-}
+export type Board = { a: number; b: number; r: number };
 
-/** The aspect of the ellipse inscribed in a safe box, short axis normalised to 1. */
-export function arenaAspect(safeW: number, safeH: number): Aspect {
-  const short = Math.max(1, Math.min(safeW, safeH));
-  const long = Math.max(1, Math.max(safeW, safeH));
-  const k = clamp(long / short, 1, MAX_ARENA_ASPECT);
-  return safeW >= safeH ? { x: k, y: 1 } : { x: 1, y: k };
+/** The board at a given short half-extent (`world.arenaR`) and aspect. */
+export function arenaBoard(short: number, aspect: Aspect): Board {
+  return { a: short * aspect.x, b: short * aspect.y, r: short * CORNER_FRACTION };
 }
 
 /**
- * The point on the rim nearest `(px, py)`.
+ * How far the rim's outermost ink reaches beyond the rim line, in pixels.
  *
- * The evolute iteration: from a guess on the rim, step to the point whose normal
- * line passes through the query, using the centre of curvature as the pivot. It
- * is the standard construction and it converges quadratically. Six rounds, which
- * is two more than the point where the eccentricities this game can produce stop
- * moving; `arena.test.ts` checks the answer against an exhaustive sweep of the
- * rim, and the count against the residual it leaves behind.
- *
- * Solved in the first quadrant and mirrored back, because the ellipse is
- * symmetric in both axes and the iteration is only well behaved there.
+ * Mirrors `scene.ts: drawRim` exactly — the stroke straddles the line by half its
+ * width, the polyps ride `POLYP_OUT` outside it with half a sprite beyond that —
+ * plus the bounded shake, which translates all of it. The soft halo is
+ * deliberately not here: it is a radial gradient that has faded out before it
+ * reaches its own edge, and it is not something a child can steer into.
  */
-export function closestOnRim(a: number, b: number, px: number, py: number): { x: number; y: number } {
-  const sx = px < 0 ? -1 : 1;
-  const sy = py < 0 ? -1 : 1;
-  const qx0 = Math.abs(px);
-  const qy0 = Math.abs(py);
-  const aa = a * a;
-  const bb = b * b;
-  let tx = Math.SQRT1_2;
-  let ty = Math.SQRT1_2;
-  for (let i = 0; i < 6; i++) {
-    // The centre of curvature under the current guess — a point on the evolute.
-    const ex = ((aa - bb) * tx * tx * tx) / a;
-    const ey = ((bb - aa) * ty * ty * ty) / b;
-    const rx = a * tx - ex;
-    const ry = b * ty - ey;
-    const qx = qx0 - ex;
-    const qy = qy0 - ey;
-    const q = Math.hypot(qx, qy);
-    // The query sits exactly on the evolute: every direction is as good as any
-    // other and the next step would divide by zero. The guess in hand is already
-    // a nearest point.
-    if (q < 1e-12) break;
-    const r = Math.hypot(rx, ry);
-    tx = clamp((qx * (r / q) + ex) / a, 0, 1);
-    ty = clamp((qy * (r / q) + ey) / b, 0, 1);
-    const t = Math.hypot(tx, ty);
-    if (t < 1e-12) break;
-    tx /= t;
-    ty /= t;
+export function rimReach(scale: number): number {
+  const S = scale * ZOOM_PEAK;
+  const stroke = Math.max(2.5, S * (0.014 + 0.016)) / 2;
+  const polyps = S * (POLYP_OUT + 0.016 * 1.4 * 0.5);
+  return Math.max(stroke, polyps) + scale * SHAKE_HEADROOM;
+}
+
+/**
+ * The half-extent a board may have, given the room it has and what sits outside it.
+ *
+ * `ZOOM_PEAK` divides rather than multiplies because the camera's punch scales the
+ * whole scene about the board's own centre: a board laid out flush at rest slides
+ * its top edge `halfExtent × (zoom − 1)` upward on the frame the punch peaks, which
+ * on a phone is a pixel and a half of lethal rim under the host's back button. It
+ * costs eight tenths of one percent of the board to be right about it.
+ */
+function halfExtent(room: number, reach: number): number {
+  return Math.max(1, (room / 2 - reach) / ZOOM_PEAK);
+}
+
+/**
+ * The band across the top of the safe box that the host's chrome sits in.
+ *
+ * Read off `hostChrome.ts` rather than copied from it, so the day the host moves
+ * its controls this moves with them. Only chrome in the top third counts toward a
+ * TOP band; anything else would be reserved from the wrong edge, and
+ * `arena.test.ts` asserts the rim clears every chrome rect wherever they are, so
+ * a host that grows a bottom control fails loudly here instead of quietly on a
+ * device.
+ */
+export function topChromeBand(viewportW: number, safeY: number, safeH: number, insets: Insets): number {
+  let band = 0;
+  for (const c of chromeRects(viewportW, insets)) {
+    if (c.y - safeY > safeH / 3) continue;
+    band = Math.max(band, c.y + c.h - safeY);
   }
-  return { x: a * tx * sx, y: b * ty * sy };
+  return Math.max(0, Math.min(band, safeH * 0.5));
+}
+
+export type Frame = {
+  /** Pixels per world unit. Isotropic: the stretch is in the board, never the transform. */
+  scale: number;
+  aspect: Aspect;
+  /** The board's centre, relative to the safe box's origin. */
+  cx: number;
+  cy: number;
+  /** The reserve this frame was solved for, in pixels. */
+  reach: number;
+};
+
+/**
+ * Fit the board to a safe box with a chrome band across its top.
+ *
+ * The reserve depends on the scale and the scale depends on the reserve, so it is
+ * a fixed point rather than an expression. The map contracts by about 0.05 per
+ * round — the reserve is a twentieth of the scale — so six rounds are past
+ * machine precision, and `arena.test.ts` checks the answer by feeding it back in.
+ */
+export function arenaFrame(safeW: number, safeH: number, chromeBand: number): Frame {
+  const boxW = Math.max(2, safeW);
+  const boxH = Math.max(2, safeH - chromeBand);
+  let reach = 0;
+  let hw = boxW / 2;
+  let hh = boxH / 2;
+  for (let i = 0; i < 6; i++) {
+    hw = halfExtent(boxW, reach);
+    hh = halfExtent(boxH, reach);
+    reach = rimReach(Math.min(hw, hh));
+  }
+  const scale = Math.min(hw, hh);
+  return {
+    scale,
+    aspect: { x: hw / scale, y: hh / scale },
+    // The centre is placed so the board's WIDEST frame — punched to `ZOOM_PEAK`,
+    // shaken to the clamp, with the rim's ink on the outside of that — lands
+    // exactly on the safe box, and on the host's band at the top.
+    cx: reach + hw * ZOOM_PEAK,
+    cy: chromeBand + reach + hh * ZOOM_PEAK,
+    reach,
+  };
 }
 
 export type Edge = {
@@ -149,28 +222,49 @@ export type Edge = {
   gap: number;
 };
 
-/** Where the rim is from here, which way it faces, and how far away it is. */
-export function rimEdge(a: number, b: number, px: number, py: number): Edge {
-  const c = closestOnRim(a, b, px, py);
-  // The gradient of x²/a² + y²/b² points out of the ellipse.
-  let nx = c.x / (a * a);
-  let ny = c.y / (b * b);
-  const n = Math.hypot(nx, ny);
-  if (n > 1e-12) {
-    nx /= n;
-    ny /= n;
-  } else {
-    nx = 1;
-    ny = 0;
+/**
+ * Where the rim is from here, which way it faces, and how far away it is.
+ *
+ * Closed form, in three cases. Fold the query into the first quadrant; then it is
+ * either past both straight runs (the corner arc, so the answer is radial about
+ * that corner's centre) or past at most one of them (a straight side, so the
+ * answer is axis-aligned and the nearer side wins).
+ */
+export function rimEdge(k: Board, px: number, py: number): Edge {
+  const sx = px < 0 ? -1 : 1;
+  const sy = py < 0 ? -1 : 1;
+  const ax = Math.abs(px);
+  const ay = Math.abs(py);
+  const ix = k.a - k.r;
+  const iy = k.b - k.r;
+  const qx = ax - ix;
+  const qy = ay - iy;
+
+  if (qx > 0 && qy > 0) {
+    const d = Math.hypot(qx, qy);
+    // Dead on the corner's centre of curvature: every direction is equally near.
+    const nx = d > 1e-12 ? qx / d : 1;
+    const ny = d > 1e-12 ? qy / d : 0;
+    return {
+      x: sx * (ix + nx * k.r),
+      y: sy * (iy + ny * k.r),
+      nx: sx * nx,
+      ny: sy * ny,
+      gap: k.r - d,
+    };
   }
-  const d = Math.hypot(px - c.x, py - c.y);
-  const inside = (px / a) ** 2 + (py / b) ** 2 <= 1;
-  return { x: c.x, y: c.y, nx, ny, gap: inside ? d : -d };
+
+  const dx = k.a - ax;
+  const dy = k.b - ay;
+  if (dx <= dy) return { x: sx * k.a, y: py, nx: sx, ny: 0, gap: dx };
+  return { x: px, y: sy * k.b, nx: 0, ny: sy, gap: dy };
 }
 
 /** Is this point inside the vent at all? */
-export function insideRim(a: number, b: number, px: number, py: number): boolean {
-  return (px / a) ** 2 + (py / b) ** 2 <= 1;
+export function insideRim(k: Board, px: number, py: number): boolean {
+  const qx = Math.max(0, Math.abs(px) - (k.a - k.r));
+  const qy = Math.max(0, Math.abs(py) - (k.b - k.r));
+  return Math.hypot(qx, qy) <= k.r;
 }
 
 /**
@@ -179,17 +273,113 @@ export function insideRim(a: number, b: number, px: number, py: number): boolean
  * A point already deep enough is returned untouched; anything nearer (or outside)
  * is put on the inward normal at exactly `margin`. Every "keep this thing off the
  * wall" in the game goes through here, so a spawn, an orb bouncing off the edge
- * and a serpent thrown back by a wall hit all agree about where the wall is —
- * which is the whole failure mode a stretched arena invites.
+ * and a serpent thrown back by a wall hit all agree about where the wall is.
+ *
+ * Exact for any `margin` up to `k.r`: the rounded rect inset by `m` is the rounded
+ * rect with half-extents `(a−m, b−m)` and corner radius `r−m`, and that stops
+ * being true when the corners run out. `arena.test.ts` holds the corner radius at
+ * the vent's floor against the largest margin the game asks for.
  */
 export function pullInside(
-  a: number,
-  b: number,
+  k: Board,
   px: number,
   py: number,
   margin: number,
 ): { x: number; y: number } {
-  const e = rimEdge(a, b, px, py);
+  const e = rimEdge(k, px, py);
   if (e.gap >= margin) return { x: px, y: py };
   return { x: e.x - e.nx * margin, y: e.y - e.ny * margin };
+}
+
+/** The rim's length, in world units. */
+export function rimPerimeter(k: Board): number {
+  return 4 * (k.a - k.r) + 4 * (k.b - k.r) + 2 * Math.PI * k.r;
+}
+
+/**
+ * Walk `n` points evenly spaced BY ARC LENGTH around the rim, with their normals.
+ *
+ * Evenly by arc length and not by angle, because there is no angle: the rim is
+ * four straight runs and four quarter-circles, and a parameterisation that
+ * bunched samples into the corners would make the glow crawl as the serpent
+ * passed one. The walk starts at the middle of the right-hand side's lower half
+ * and goes counter-clockwise; nothing depends on where it starts, because the
+ * rim's heat is found by distance to the head's own point on the rim.
+ *
+ * Fills caller-owned arrays: this runs every frame and must not allocate.
+ */
+export function sampleRim(
+  k: Board,
+  n: number,
+  outX: Float32Array,
+  outY: Float32Array,
+  outNX: Float32Array,
+  outNY: Float32Array,
+): void {
+  const ix = k.a - k.r;
+  const iy = k.b - k.r;
+  const r = k.r;
+  const arc = (Math.PI / 2) * r;
+  const side = 2 * iy;
+  const top = 2 * ix;
+  const P = 2 * side + 2 * top + 4 * arc;
+  const c0 = side;
+  const c1 = c0 + arc;
+  const c2 = c1 + top;
+  const c3 = c2 + arc;
+  const c4 = c3 + side;
+  const c5 = c4 + arc;
+  const c6 = c5 + top;
+  for (let i = 0; i < n; i++) {
+    const s = (i / n) * P;
+    let x = 0;
+    let y = 0;
+    let nx = 0;
+    let ny = 0;
+    if (s < c0) {
+      x = k.a;
+      y = -iy + s;
+      nx = 1;
+    } else if (s < c1) {
+      const a = (s - c0) / r;
+      nx = Math.cos(a);
+      ny = Math.sin(a);
+      x = ix + nx * r;
+      y = iy + ny * r;
+    } else if (s < c2) {
+      x = ix - (s - c1);
+      y = k.b;
+      ny = 1;
+    } else if (s < c3) {
+      const a = Math.PI / 2 + (s - c2) / r;
+      nx = Math.cos(a);
+      ny = Math.sin(a);
+      x = -ix + nx * r;
+      y = iy + ny * r;
+    } else if (s < c4) {
+      x = -k.a;
+      y = iy - (s - c3);
+      nx = -1;
+    } else if (s < c5) {
+      const a = Math.PI + (s - c4) / r;
+      nx = Math.cos(a);
+      ny = Math.sin(a);
+      x = -ix + nx * r;
+      y = -iy + ny * r;
+    } else if (s < c6) {
+      x = -ix + (s - c5);
+      y = -k.b;
+      ny = -1;
+    } else {
+      const a = 1.5 * Math.PI + (s - c6) / r;
+      nx = Math.cos(a);
+      ny = Math.sin(a);
+      x = ix + nx * r;
+      y = -iy + ny * r;
+    }
+    outX[i] = x;
+    outY[i] = y;
+    outNX[i] = nx;
+    outNY[i] = ny;
+  }
 }

--- a/dynawalla/games/serpent/src/game/mount.ts
+++ b/dynawalla/games/serpent/src/game/mount.ts
@@ -69,10 +69,10 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
     // inset for two side ones, and iPadOS changes them when the pack is resized
     // in Split View. Read once and you are correct until the first rotation.
     renderer.resize(w, h, Math.min(window.devicePixelRatio || 1, 2.5), safeInsets());
-    // The board IS the screen: the vent is the ellipse inscribed in that same
-    // safe box. The renderer measures the box, the simulation takes the shape
-    // from it, and neither owns a second copy of the arithmetic.
-    setArenaAspect(world, renderer.view.safe.w, renderer.view.safe.h);
+    // The board IS the screen. The renderer solves the frame — safe box, minus the
+    // host's two buttons, minus the rim's own ink — and the simulation takes the
+    // shape straight off it, so neither owns a second copy of the arithmetic.
+    setArenaAspect(world, renderer.view.aspect);
   }
   layout();
   // A rotation does not always change the element's box — a square-ish split
@@ -236,6 +236,7 @@ export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
         heading: "Staying alive",
         lines: [
           "Do not swim into your own tail.",
+          "While you are still short, bumping your tail only knocks you off it. Once you have grown, it ends the dive.",
           "Do not push into the glowing edge of the water for long.",
           "The number in the top corner is your depth. It is how far down you have got, and it goes up one for every nine right numbers you eat.",
           "Deeper down, the water gets smaller and some numbers start chasing you.",

--- a/dynawalla/games/serpent/src/game/orbs.ts
+++ b/dynawalla/games/serpent/src/game/orbs.ts
@@ -14,10 +14,7 @@
 
 import { TAU, randRange } from "./num.ts";
 import { TUNE } from "./tuning.ts";
-import { pullInside, rimEdge } from "./arena.ts";
-
-/** The vent's semi-axes this frame. The short one is `world.arenaR`; see `arena.ts`. */
-export type Axes = { a: number; b: number };
+import { pullInside, rimEdge, type Board } from "./arena.ts";
 
 export type Orb = {
   x: number;
@@ -62,17 +59,17 @@ export function createOrb(): Orb {
  * and not on top of another orb. Falls back to the best of N tries rather than
  * looping forever.
  */
-export function placeOrb(orb: Orb, orbs: Orb[], axes: Axes, headX: number, headY: number): void {
+export function placeOrb(orb: Orb, orbs: Orb[], board: Board, headX: number, headY: number): void {
   let bestX = 0;
   let bestY = 0;
   let bestScore = -1;
   const clear = TUNE.orbRadius * 2.2;
-  // Candidates are drawn from the vent shrunk by the clearance, which is uniform
-  // over the ellipse rather than over a disc; the `pullInside` at the end is what
-  // actually guarantees the clearance, because a concentric ellipse is not the
-  // same curve as the rim offset inward and only one of those is the rule.
-  const sa = Math.max(TUNE.orbRadius, axes.a - clear);
-  const sb = Math.max(TUNE.orbRadius, axes.b - clear);
+  // Candidates are drawn from a board shrunk by the clearance, so they are spread
+  // over the shape rather than over a disc inside it. The `pullInside` at the end
+  // is what actually GUARANTEES the clearance: a concentric shrink is not the same
+  // curve as the rim offset inward, and only one of those is the rule.
+  const sa = Math.max(TUNE.orbRadius, board.a - clear);
+  const sb = Math.max(TUNE.orbRadius, board.b - clear);
   for (let attempt = 0; attempt < 14; attempt++) {
     const a = randRange(0, TAU);
     const r = Math.sqrt(Math.random());
@@ -92,7 +89,7 @@ export function placeOrb(orb: Orb, orbs: Orb[], axes: Axes, headX: number, headY
     }
     if (bestScore > TUNE.spawnClearance) break;
   }
-  const put = pullInside(axes.a, axes.b, bestX, bestY, clear);
+  const put = pullInside(board, bestX, bestY, clear);
   orb.x = put.x;
   orb.y = put.y;
   const a = randRange(0, TAU);
@@ -114,7 +111,7 @@ export function molt(orb: Orb, label: string, good: boolean, dur: number): void 
 
 export type OrbStepOptions = {
   dt: number;
-  axes: Axes;
+  board: Board;
   headX: number;
   headY: number;
   /** Rotating current, from depth 4. 0 disables it. */
@@ -166,7 +163,7 @@ export function stepOrbs(orbs: Orb[], o: OrbStepOptions): void {
 
     // The rim contains the field too, and by the same shape the serpent hits.
     const limit = TUNE.orbRadius * 1.1;
-    const e = rimEdge(o.axes.a, o.axes.b, orb.x, orb.y);
+    const e = rimEdge(o.board, orb.x, orb.y);
     if (e.gap < limit) {
       orb.x = e.x - e.nx * limit;
       orb.y = e.y - e.ny * limit;

--- a/dynawalla/games/serpent/src/game/render/prompt.test.ts
+++ b/dynawalla/games/serpent/src/game/render/prompt.test.ts
@@ -48,7 +48,7 @@ import { dirname, join } from "node:path";
 import test from "node:test";
 
 import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
-import { arenaScale } from "../arena.ts";
+import { arenaFrame, topChromeBand } from "../arena.ts";
 import { CAP_EM, type Ink } from "./glyphs.ts";
 import { TUNE } from "../tuning.ts";
 import {
@@ -179,11 +179,11 @@ function frames(): Frame[] {
   for (const [name, w, h] of VIEWPORTS) {
     for (const [label, insets] of insetsFor(w, h)) {
       const safe = safeRect(w, h, insets);
-      // `scene.ts: resize` — the arena is centred in the safe box and inscribed
-      // in it. `arenaScale` is the shipping expression, imported rather than
-      // copied; the condition is fitted to the disc INSIDE the ellipse, which is
-      // the short semi-axis, so `arenaR × scale` is still the radius that binds.
-      const scale = arenaScale(safe.w, safe.h);
+      // `scene.ts: resize` — the board is fitted to the safe box less the host's
+      // chrome band. `arenaFrame` is the shipping expression, imported rather than
+      // copied; the condition is fitted to the disc INSIDE the board, which is the
+      // short half-extent, so `arenaR × scale` is still the radius that binds.
+      const scale = arenaFrame(safe.w, safe.h, topChromeBand(w, safe.y, safe.h, insets)).scale;
       for (const arenaR of ARENA_RADII) {
         out.push({
           where: `${name} (${w}x${h}), ${label}, vent ${(arenaR * scale * 2).toFixed(0)}px across`,

--- a/dynawalla/games/serpent/src/game/render/scene.ts
+++ b/dynawalla/games/serpent/src/game/render/scene.ts
@@ -18,7 +18,18 @@ import { COLORS, TUNE } from "../tuning.ts";
 import { bolusTintAt } from "../serpent.ts";
 import { orbDrawRadius } from "../orbs.ts";
 import { NO_INSETS, safeRect, type Insets } from "../../../../../packs/shared/game-chrome/index.ts";
-import { arenaScale } from "../arena.ts";
+import {
+  POLYP_OUT,
+  SHAKE_HEADROOM,
+  arenaBoard,
+  arenaFrame,
+  rimEdge,
+  rimPerimeter,
+  sampleRim,
+  topChromeBand,
+  type Aspect,
+  type Board,
+} from "../arena.ts";
 import type { World } from "../world.ts";
 import { GLOW_PX, MOTE_PX, sprites } from "./sprites.ts";
 import { drawLabel, labelInk, labelWidth, type LabelStyle } from "./glyphs.ts";
@@ -45,6 +56,16 @@ export type View = {
   insets: Insets;
   /** The viewport minus those insets. */
   safe: { x: number; y: number; w: number; h: number };
+  /**
+   * The board's proportions, short half-extent normalised to 1.
+   *
+   * The renderer measures the frame; `mount.ts` hands this straight to the world,
+   * so the shape a child steers against and the shape that is drawn are one
+   * measurement and not two.
+   */
+  aspect: Aspect;
+  /** The band across the top of the safe box the host's own chrome sits in. */
+  chromeBand: number;
 };
 
 type Snow = { x: number; y: number; r: number; vy: number; vx: number; a: number; phase: number };
@@ -94,6 +115,8 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     dpr: 1,
     insets: NO_INSETS,
     safe: { x: 0, y: 0, w: 1, h: 1 },
+    aspect: { x: 1, y: 1 },
+    chromeBand: 0,
   };
   let bg: HTMLCanvasElement | null = null;
   const snowFar: Snow[] = [];
@@ -159,6 +182,17 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
       drawLabel(g, block.lines[i] as string, style, x, y + (block.offsets[i] as number) * scale, view.dpr, scale, alpha);
     }
   }
+
+  /**
+   * The most rim samples ever taken, and the buffers they land in.
+   *
+   * Allocated once: `drawRim` runs every frame and the walk must not allocate.
+   */
+  const RIM_SAMPLES = 200;
+  const rimX = new Float32Array(RIM_SAMPLES);
+  const rimY = new Float32Array(RIM_SAMPLES);
+  const rimNX = new Float32Array(RIM_SAMPLES);
+  const rimNY = new Float32Array(RIM_SAMPLES);
 
   // Scratch buffers for the body outline. Allocated once.
   const nx = new Float32Array(TUNE.maxSegments + 2);
@@ -235,14 +269,18 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     view.dpr = dpr;
     view.insets = insets;
     view.safe = safe;
-    // The arena is centred in the SAFE box and INSCRIBED in it: the ellipse
-    // reaches the top and bottom of a tall phone and the sides of a wide one,
-    // while every part of the rim — a wall a child can die against — stays clear
-    // of the cutout and the rounded corner. `arena.ts` owns both numbers; the
-    // shape itself is `world.aspectX/aspectY`, set from the same safe box.
-    view.cx = safe.x + safe.w / 2;
-    view.cy = safe.y + safe.h / 2;
-    view.scale = arenaScale(safe.w, safe.h);
+    // The board takes every pixel that is not the cutout and not the host's own
+    // two buttons. `arena.ts` solves the frame — the rim's ink is reserved in
+    // pixels and nothing else is held back — and the shape it returns is handed
+    // to the simulation by `mount.ts`, so the wall that is drawn and the wall a
+    // child dies against are one measurement.
+    const band = topChromeBand(w, safe.y, safe.h, insets);
+    const frame = arenaFrame(safe.w, safe.h, band);
+    view.chromeBand = band;
+    view.aspect = frame.aspect;
+    view.cx = safe.x + frame.cx;
+    view.cy = safe.y + frame.cy;
+    view.scale = frame.scale;
     canvas.width = Math.max(1, Math.floor(w * dpr));
     canvas.height = Math.max(1, Math.floor(h * dpr));
     canvas.style.width = `${w}px`;
@@ -283,8 +321,12 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
 
     const cam = w.cam;
     const S = view.scale * cam.zoom;
-    const ox = view.cx + cam.shakeX * view.scale;
-    const oy = view.cy + cam.shakeY * view.scale;
+    // The board is fitted flush to the safe box, so the shake that translates it
+    // is bounded rather than free — see SHAKE_HEADROOM. Everything survivable is
+    // already under the bound; only the death slam is trimmed, and it keeps its
+    // hitstop, its slow-motion, its flash and its debris.
+    const ox = view.cx + clamp(cam.shakeX, -SHAKE_HEADROOM, SHAKE_HEADROOM) * view.scale;
+    const oy = view.cy + clamp(cam.shakeY, -SHAKE_HEADROOM, SHAKE_HEADROOM) * view.scale;
     const X = (x: number): number => ox + x * S;
     const Y = (y: number): number => oy + y * S;
 
@@ -317,27 +359,28 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     drawSnow(snowFar, 0);
 
     // --- the arena floor --------------------------------------------------
-    const aX = w.arenaR * w.aspectX * S;
-    const aY = w.arenaR * w.aspectY * S;
+    const board = arenaBoard(w.arenaR, { x: w.aspectX, y: w.aspectY });
+    const aX = board.a * S;
+    const aY = board.b * S;
+    const aR = board.r * S;
     g.save();
-    g.beginPath();
-    g.ellipse(X(0), Y(0), aX, aY, 0, 0, TAU);
+    rimPath(X(0), Y(0), aX, aY, aR);
     g.clip();
 
-    // A radial gradient is a circle, so the floor is painted in a squashed frame
-    // and comes out as the same ellipse the clip already is — the alternative is
-    // a round pool of light sitting inside an oval board with dark ends.
-    g.save();
-    g.translate(X(0), Y(0));
-    g.scale(1, aY / aX);
-    const floor = g.createRadialGradient(0, 0, 0, 0, 0, aX);
-    floor.addColorStop(0, "rgba(34,124,150,0.7)");
-    floor.addColorStop(0.45, "rgba(14,72,104,0.56)");
-    floor.addColorStop(0.82, "rgba(6,36,62,0.4)");
-    floor.addColorStop(1, "rgba(2,14,28,0.16)");
+    // A flat wash first, so the board is lit floor all the way into its corners.
+    // A radial gradient alone is a round pool of light, and a rectangular board
+    // lit by one has four dark corners — which is most of what the founder was
+    // reading as "not the whole screen".
+    g.fillStyle = "rgba(9,46,72,0.42)";
+    g.fillRect(X(0) - aX, Y(0) - aY, aX * 2, aY * 2);
+
+    const lit = Math.min(aX, aY) * 1.25;
+    const floor = g.createRadialGradient(X(0), Y(0), 0, X(0), Y(0), lit);
+    floor.addColorStop(0, "rgba(34,124,150,0.52)");
+    floor.addColorStop(0.5, "rgba(14,72,104,0.3)");
+    floor.addColorStop(1, "rgba(6,36,62,0)");
     g.fillStyle = floor;
-    g.fillRect(-aX, -aX, aX * 2, aX * 2);
-    g.restore();
+    g.fillRect(X(0) - aX, Y(0) - aY, aX * 2, aY * 2);
 
     // The vent itself: a slow amber heart. Teal water against a warm centre is
     // the only complementary pair in the palette, and without it the whole
@@ -345,8 +388,8 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     const ventGlow = sp.glow[0];
     if (ventGlow) {
       const k = 1.15 + 0.05 * Math.sin(w.cam.t * 0.55);
-      const vw = aX * k;
-      const vh = aY * k;
+      const vw = Math.min(aX, aY) * k * 1.4;
+      const vh = vw;
       g.globalCompositeOperation = "lighter";
       g.globalAlpha = 0.13 + 0.03 * Math.sin(w.cam.t * 0.8) + w.depthPulse * 0.16;
       g.drawImage(ventGlow, X(0) - vw / 2, Y(0) - vh / 2, vw, vh);
@@ -462,7 +505,7 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     g.globalCompositeOperation = "source-over";
 
     // --- the vent rim -----------------------------------------------------
-    drawRim(w, X, Y, S, aX, aY);
+    drawRim(w, X, Y, S, aX, aY, aR);
 
     // --- floating score ---------------------------------------------------
     const floatStyle: LabelStyle = {
@@ -725,6 +768,33 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     return best;
   }
 
+  /**
+   * The rim, as a path: four straight runs and four quarter-circles.
+   *
+   * Built with `arcTo` rather than `roundRect` — the shipping surface is a
+   * WKWebView whose version is the OS's, not the app's, and a board that vanishes
+   * on an older iPad because a path method was missing is not a trade worth
+   * making for four fewer lines.
+   */
+  function rimPath(cx: number, cy: number, aX: number, aY: number, r: number): void {
+    const l = cx - aX;
+    const rt = cx + aX;
+    const t = cy - aY;
+    const b = cy + aY;
+    const k = Math.max(0, Math.min(r, Math.min(aX, aY)));
+    g.beginPath();
+    g.moveTo(l + k, t);
+    g.lineTo(rt - k, t);
+    g.arcTo(rt, t, rt, t + k, k);
+    g.lineTo(rt, b - k);
+    g.arcTo(rt, b, rt - k, b, k);
+    g.lineTo(l + k, b);
+    g.arcTo(l, b, l, b - k, k);
+    g.lineTo(l, t + k);
+    g.arcTo(l, t, l + k, t, k);
+    g.closePath();
+  }
+
   function drawRim(
     w: World,
     X: (x: number) => number,
@@ -732,59 +802,75 @@ export function createRenderer(canvas: HTMLCanvasElement): Renderer {
     S: number,
     aX: number,
     aY: number,
+    aR: number,
   ): void {
     const cx = X(0);
     const cy = Y(0);
-    // The head's ECCENTRIC angle, not its polar one: `ctx.ellipse` walks the
-    // parameter, so the arc a segment covers is `(aX cos t, aY sin t)` and the
-    // hot patch has to be found in the same parameter or the glow drifts away
-    // from the serpent everywhere except the four axis points.
-    const headA = Math.atan2(w.serpent.y / (w.arenaR * w.aspectY), w.serpent.x / (w.arenaR * w.aspectX));
-    const segs = 72;
+    const board: Board = arenaBoard(w.arenaR, { x: w.aspectX, y: w.aspectY });
 
     g.globalCompositeOperation = "lighter";
     const halo = sp.softRing[w.grazeGlow > 0.4 ? 5 : 2];
     if (halo) {
-      const hw = aX * 2 * 1.14;
-      const hh = aY * 2 * 1.14;
-      g.globalAlpha = 0.5 + w.grazeGlow * 0.4 + w.depthPulse * 0.35;
+      const hw = aX * 2 * 1.16;
+      const hh = aY * 2 * 1.16;
+      g.globalAlpha = 0.4 + w.grazeGlow * 0.4 + w.depthPulse * 0.3;
       g.drawImage(halo, cx - hw / 2, cy - hh / 2, hw, hh);
     }
 
+    // One sample every ~22 device-independent pixels of rim, so a corner is smooth
+    // on a tablet and the count does not run away on one. Sampled by ARC LENGTH:
+    // an angular walk would bunch the samples into the corners and make the graze
+    // glow crawl as the serpent rounded one.
+    const perimeterPx = rimPerimeter(board) * S;
+    const segs = Math.max(72, Math.min(RIM_SAMPLES, Math.round(perimeterPx / 22)));
+    sampleRim(board, segs, rimX, rimY, rimNX, rimNY);
+
+    // The hot patch follows the serpent along the WALL, by distance to the head's
+    // own point on the rim. There is no angle on a rounded rect to compare against,
+    // and this is the thing the angle was standing in for anyway.
+    const hot = rimEdge(board, w.serpent.x, w.serpent.y);
+    const span = w.arenaR * 0.55;
+
     g.lineCap = "butt";
     for (let i = 0; i < segs; i++) {
-      const a0 = (i / segs) * TAU;
-      const a1 = ((i + 1) / segs) * TAU;
-      let d = Math.abs(((a0 + a1) / 2 - headA + Math.PI * 3) % TAU) - Math.PI;
-      d = Math.abs(d);
-      const heat = w.grazeGlow * clamp(1 - d / 0.55, 0, 1);
+      const j = (i + 1) % segs;
+      const mx = ((rimX[i] as number) + (rimX[j] as number)) / 2;
+      const my = ((rimY[i] as number) + (rimY[j] as number)) / 2;
+      const heat = w.grazeGlow * clamp(1 - Math.hypot(mx - hot.x, my - hot.y) / span, 0, 1);
       const pulse = 0.72 + 0.16 * Math.sin(w.cam.t * 1.7 + i * 0.4) + w.depthPulse * 0.4;
       g.globalAlpha = clamp(pulse * (0.7 + heat), 0, 1);
       g.strokeStyle = heat > 0.05 ? COLORS.rimHot : COLORS.rim;
       g.lineWidth = Math.max(2.5, S * (0.014 + heat * 0.016));
       g.beginPath();
-      g.ellipse(cx, cy, aX, aY, 0, a0, a1);
-      g.stroke();
-      // A thin white-hot lip just inside, so the edge is a hard line the eye
-      // can trust rather than a soft glow you can misjudge at speed.
-      g.globalAlpha = clamp(pulse * (0.5 + heat * 0.8), 0, 1);
-      g.strokeStyle = heat > 0.05 ? "#ffd9c4" : "#d6fbff";
-      g.lineWidth = Math.max(1, S * 0.004);
-      g.beginPath();
-      g.ellipse(cx, cy, Math.max(1, aX - S * 0.009), Math.max(1, aY - S * 0.009), 0, a0, a1);
+      g.moveTo(X(rimX[i] as number), Y(rimY[i] as number));
+      g.lineTo(X(rimX[j] as number), Y(rimY[j] as number));
       g.stroke();
     }
 
-    // Polyps: a living edge rather than a drawn circle.
-    const polyps = 40;
+    // A thin white-hot lip just inside, so the edge is a hard line the eye can
+    // trust rather than a soft glow you can misjudge at speed. One path for the
+    // whole rim: a hairline has nowhere to put a shimmer, and this is the pass
+    // that has to read as a LINE against a screen edge.
+    const inset = S * 0.011;
+    g.globalAlpha = clamp(0.6 + w.depthPulse * 0.3, 0, 1);
+    g.strokeStyle = "#d6fbff";
+    g.lineWidth = Math.max(1, S * 0.005);
+    rimPath(cx, cy, Math.max(1, aX - inset), Math.max(1, aY - inset), Math.max(0, aR - inset));
+    g.stroke();
+
+    // Polyps: a living edge rather than a drawn line. They ride POLYP_OUT outside
+    // the rim, which is the outward ink `arena.ts` reserves room for.
+    const polyps = Math.min(56, Math.max(28, Math.round(segs / 3)));
     const dot = sp.mote[4];
     if (dot) {
       for (let i = 0; i < polyps; i++) {
-        const a = (i / polyps) * TAU + w.cam.t * 0.03;
-        const wob = 1 + Math.sin(w.cam.t * 1.3 + i) * 0.012;
+        const k = Math.floor((i / polyps) * segs);
+        const wob = POLYP_OUT * w.arenaR * (0.5 + 0.5 * Math.sin(w.cam.t * 1.3 + i));
         const size = S * 0.016 * (1 + 0.4 * Math.sin(w.cam.t * 2 + i * 1.7));
+        const px = X((rimX[k] as number) + (rimNX[k] as number) * wob);
+        const py = Y((rimY[k] as number) + (rimNY[k] as number) * wob);
         g.globalAlpha = 0.5;
-        g.drawImage(dot, cx + Math.cos(a) * aX * wob - size / 2, cy + Math.sin(a) * aY * wob - size / 2, size, size);
+        g.drawImage(dot, px - size / 2, py - size / 2, size, size);
       }
     }
     g.globalAlpha = 1;

--- a/dynawalla/games/serpent/src/game/serpent.ts
+++ b/dynawalla/games/serpent/src/game/serpent.ts
@@ -265,16 +265,27 @@ export function rebuildBody(s: Serpent): void {
   }
 }
 
-/** Distance from the head to the nearest body point that can kill it. */
-export function selfHit(s: Serpent): boolean {
+/**
+ * The body point the head is currently inside, or −1.
+ *
+ * The index and not just a yes/no, because the two things that can happen next
+ * both need to know WHERE: a death bursts there, and a bump before the serpent
+ * has grown turns the head straight off that point (`world.ts: bumpSelf`).
+ */
+export function selfHitIndex(s: Serpent): number {
   const lethal = TUNE.headRadius * TUNE.selfHitFactor;
   const r2 = lethal * lethal;
   for (let i = TUNE.neckSegments; i < s.bodyCount; i++) {
     const dx = (s.bodyX[i] as number) - s.x;
     const dy = (s.bodyY[i] as number) - s.y;
-    if (dx * dx + dy * dy < r2) return true;
+    if (dx * dx + dy * dy < r2) return i;
   }
-  return false;
+  return -1;
+}
+
+/** Is the head inside its own body? */
+export function selfHit(s: Serpent): boolean {
+  return selfHitIndex(s) >= 0;
 }
 
 export function bolusTintAt(s: Serpent, i: number): number {

--- a/dynawalla/games/serpent/src/game/tuning.ts
+++ b/dynawalla/games/serpent/src/game/tuning.ts
@@ -37,6 +37,22 @@ export const TUNE = {
   /** Body points nearer the head than this can never kill you. */
   neckSegments: 17,
   selfHitFactor: 0.55,
+  /**
+   * The length at which running into your own body starts to END a run.
+   *
+   * A child who has just picked the game up turns the way they turn in every
+   * other game they own, the head comes round into its own flank at 34 segments,
+   * and the run is over before they have read the condition once. That is being
+   * punished by a rule you have not been taught, and the founder filed it as
+   * "if I turn around he eats himself ... too hard".
+   *
+   * So until the serpent has grown — three correct answers, `startSegments +
+   * 3 × growPerCorrect` — a self-hit is a BUMP: the head is turned off its own
+   * flank with a thud and a moment of grace, and the dive carries on. The latch
+   * is one-way for the whole run (`world.selfHitArmed`), so coughing length back
+   * up cannot buy the grace a second time and a player cannot hover under it.
+   */
+  selfHitArmsAt: 49,
 
   // ---- arena -------------------------------------------------------------
   arenaStart: 1.0,
@@ -64,11 +80,31 @@ export const TUNE = {
    * forward turns a side-swipe into a near miss, which is what it looks like.
    */
   biteOffset: 0.78,
-  orbBaseCount: 10,
-  orbPerDepth: 1,
-  orbMaxCount: 20,
-  goodBase: 3,
-  goodMax: 5,
+  /**
+   * The opening field, and how it grows.
+   *
+   * `orbBaseCount` was 10 and the count was then multiplied by the board's AREA,
+   * so the first screen of a dive on a tall phone carried about twenty numbers.
+   * The founder: "why are there so many choices when I first start ... too hard
+   * and crowded and frustrating for the starting density."
+   *
+   * Five to open, and the field grows only with `depth` — which is nine CORRECT
+   * answers each, so it is demonstrated competence and never elapsed time and
+   * never the size of the screen. A child who is finding it hard is never handed
+   * a denser board for having been there a while.
+   */
+  orbBaseCount: 5,
+  orbPerDepth: 2,
+  orbMaxCount: 24,
+  /**
+   * How much of the field is edible, and the floor and ceiling on it.
+   *
+   * A share rather than a schedule, so the opening's five orbs and a deep dive's
+   * twenty-four read the same way: about a third of what you can see is food.
+   */
+  goodShare: 0.32,
+  goodBase: 2,
+  goodMax: 7,
   orbDrift: 0.022,
   hunterFromDepth: 5,
   hunterChance: 0.22,
@@ -82,6 +118,7 @@ export const TUNE = {
 
   // ---- juice (all measured; see README) -----------------------------------
   hitstopEatMs: 28,
+  hitstopBumpMs: 90,
   hitstopWrongMs: 110,
   hitstopWallMs: 95,
   hitstopShieldMs: 180,
@@ -90,6 +127,7 @@ export const TUNE = {
   traumaEat: 0.1,
   traumaWrong: 0.45,
   traumaWall: 0.55,
+  traumaBump: 0.34,
   traumaDepth: 0.25,
   traumaShield: 0.5,
   traumaDeath: 0.9,

--- a/dynawalla/games/serpent/src/game/world.test.ts
+++ b/dynawalla/games/serpent/src/game/world.test.ts
@@ -21,6 +21,8 @@ import {
   type World,
 } from "./world.ts";
 import { createOrb, placeOrb } from "./orbs.ts";
+import { arenaFrame, topChromeBand } from "./arena.ts";
+import { NO_INSETS, safeRect } from "../../../../packs/shared/game-chrome/index.ts";
 import { createStubHost } from "../stub/host.ts";
 import { TUNE } from "./tuning.ts";
 import { TAU, angleDelta } from "./num.ts";
@@ -77,11 +79,14 @@ type Instrumented = {
   host: Host;
   served: Question[];
   reports: Report[];
+  /** How many questions had been served when this run first answered one. */
+  servedBeforeFirstAnswer(): number;
 };
 
 function instrument(seed: string, startLevel?: number): Instrumented {
   const served: Question[] = [];
   const reports: Report[] = [];
+  let before = Infinity;
   const inner = createStubHost(startLevel === undefined ? { seed } : { seed, startLevel });
   const host: Host = {
     next() {
@@ -90,13 +95,14 @@ function instrument(seed: string, startLevel?: number): Instrumented {
       return q;
     },
     report(r) {
+      if (reports.length === 0) before = served.length;
       reports.push(r);
       inner.report(r);
     },
     haptic() {},
     prefersReducedMotion: () => false,
   };
-  return { host, served, reports };
+  return { host, served, reports, servedBeforeFirstAnswer: () => before };
 }
 
 /**
@@ -107,7 +113,11 @@ function instrument(seed: string, startLevel?: number): Instrumented {
  */
 function pilotHeading(w: World, skill: number): number | null {
   const s = w.serpent;
-  const rim = Math.hypot(s.x, s.y);
+  // Off the wall it actually has. `Math.hypot` was the distance from the middle,
+  // which on a circle was the same thing; on a board that is the whole screen it
+  // pins the bot to the centre of a tall phone and makes the game look unplayable
+  // when it is the measuring instrument that is broken.
+  const rim = arenaEdge(w, s.x, s.y);
 
   let best: { x: number; y: number } | null = null;
   let bestCost = Infinity;
@@ -128,9 +138,9 @@ function pilotHeading(w: World, skill: number): number | null {
 
   let ax = best ? best.x - s.x : -s.x;
   let ay = best ? best.y - s.y : -s.y;
-  if (rim > w.arenaR - 0.3) {
-    ax -= s.x * 5;
-    ay -= s.y * 5;
+  if (rim.gap < 0.3) {
+    ax -= rim.nx * 5;
+    ay -= rim.ny * 5;
   }
   // Look ahead: sample where the head will be and steer off anything there.
   for (const lead of [0.14, 0.26]) {
@@ -242,14 +252,24 @@ test("twenty minutes of play escalates and never leaves its budgets", () => {
     smallestArena = Math.min(smallestArena, w.arenaR);
   }
 
-  assert.ok(deepest >= 8, `only reached depth ${deepest} in twenty minutes`);
+  // Six and not the eight this asked for before the field was thinned. The
+  // opening went from ten orbs times the board's AREA to five, so the serpent
+  // swims further per bite and a depth costs more minutes. Escalation still
+  // arrives, and the number that actually matters — how many questions a child
+  // is asked — is asserted below and went UP, not down.
+  assert.ok(deepest >= 6, `only reached depth ${deepest} in twenty minutes`);
   assert.ok(smallestArena <= TUNE.arenaStart - TUNE.arenaShrinkPerDepth * 3, `arena barely closed: ${smallestArena}`);
   assert.ok(smallestArena >= TUNE.arenaFloor - 1e-6, `arena shrank past its floor: ${smallestArena}`);
   assert.ok(maxParticles <= w.particles.cap, `particle cap breached: ${maxParticles}`);
   assert.ok(maxOrbs <= TUNE.orbMaxCount, `orb cap breached: ${maxOrbs}`);
   assert.ok(maxBody <= TUNE.maxSegments, `segment cap breached: ${maxBody}`);
   assert.ok(w.rings.count <= w.rings.cap);
-  assert.ok(reports.length > 200, `twenty minutes produced only ${reports.length} answers`);
+  // The retrieval-volume floor, and the reason a sparser field is not a quieter
+  // game. Twenty simulated minutes of a competent pilot puts ~548 questions to the
+  // child — better than twenty a minute. If thinning the field ever starts
+  // starving the question stream, this is where it shows up, and it is the metric
+  // this product is actually judged on.
+  assert.ok(reports.length > 400, `twenty minutes produced only ${reports.length} answers`);
   assert.ok(Number.isFinite(w.score) && w.score >= 0);
   assert.ok(Number.isFinite(w.serpent.x) && Number.isFinite(w.serpent.y));
 });
@@ -280,7 +300,12 @@ test("eating wrong costs length; eating right pays it back", () => {
   assert.ok(w.wrongEats > 4, `expected the bad pilot to eat wrong things, got ${w.wrongEats}`);
   assert.ok(w.serpent.targetSegments < start || w.phase === "dead", "wrong answers must cost something");
   assert.ok(w.serpent.targetSegments >= TUNE.minSegments, "the serpent must never shrink below its floor");
-  assert.equal(w.combo, 0);
+  // A pilot eating wrong answers cannot build a run of right ones. Asserted as the
+  // BEST combo of the whole run rather than the combo on the last frame: the
+  // opening field is sparse and about a third of it is edible, so a pilot aiming
+  // for wrong orbs stumbles into a right one now and then, and which frame the run
+  // happens to end on is not a rule.
+  assert.ok(w.bestCombo <= 2, `a pilot eating wrong answers reached a combo of ${w.bestCombo}`);
 });
 
 test("the wall costs length and throws you back — it never ends the run", () => {
@@ -374,8 +399,14 @@ test("the same seed serves the same questions to the same run", () => {
   startRun(wb);
   play(wa, 60, 0.9);
   play(wb, 60, 0.4);
-  const n = Math.min(a.served.length, b.served.length, 30);
-  assert.ok(n >= 10);
+  // Up to the first ANSWER, and no further. The host is adaptive by design — it
+  // is handed every report and is entitled to serve a struggling child something
+  // else — so two runs with different accuracy are supposed to diverge, and a
+  // test that compares past that point is asserting the learner model does not
+  // work. What is seed-determined, and what this holds, is everything the host
+  // says before it has been told anything.
+  const n = Math.min(a.servedBeforeFirstAnswer(), b.servedBeforeFirstAnswer(), 30);
+  assert.ok(n >= 5, `only ${n} questions were served before either run answered one`);
   for (let i = 0; i < n; i++) {
     assert.equal((a.served[i] as Question).prompt, (b.served[i] as Question).prompt);
     assert.equal((a.served[i] as Question).answer, (b.served[i] as Question).answer);
@@ -415,10 +446,13 @@ const SCREENS: Array<[string, number, number]> = [
   ["square", 600, 600],
 ];
 
-function fresh(seed: string, safeW: number, safeH: number): World {
+/** A run on a given screen, shaped exactly the way `scene.ts` would shape it. */
+function fresh(seed: string, viewW: number, viewH: number): World {
   const { host } = instrument(seed);
   const w = createWorld(host, silentAudio(), false);
-  setArenaAspect(w, safeW, safeH);
+  const safe = safeRect(viewW, viewH, NO_INSETS);
+  const band = topChromeBand(viewW, safe.y, safe.h, NO_INSETS);
+  setArenaAspect(w, arenaFrame(safe.w, safe.h, band).aspect);
   startRun(w);
   return w;
 }
@@ -571,12 +605,16 @@ test("nothing is ever put outside the vent, whatever shape it is", () => {
       worst >= -1e-9,
       `${name}: an orb was ${(-worst).toFixed(4)} outside the rim at ${worstAt}`,
     );
-    // And it is a real ellipse being tested, not a circle wearing a new name.
-    const axes = arenaAxes(w);
-    const ratio = Math.max(axes.a, axes.b) / Math.min(axes.a, axes.b);
+    // And the screen's shape really did reach the game. A "square" viewport is not
+    // a square board — the host's chrome band comes off the top first — so it is
+    // only asserted to be near one.
+    const board = arenaAxes(w);
+    const ratio = Math.max(board.a, board.b) / Math.min(board.a, board.b);
+    const want = Math.max(sw, sh - 57) / Math.min(sw, sh - 57);
     assert.ok(
-      name === "square" ? ratio === 1 : ratio > 1.2,
-      `${name}: the vent came out ${ratio.toFixed(2)}:1 — the screen's shape did not reach the game`,
+      Math.abs(ratio - want) < 0.15,
+      `${name}: the board came out ${ratio.toFixed(2)}:1 on a ${want.toFixed(2)}:1 frame — ` +
+        `the screen's shape did not reach the game`,
     );
   }
 });
@@ -593,7 +631,8 @@ test("a rotation reshapes the board without stranding anything outside it", () =
     before.some((o) => Math.abs(o.y) > w.arenaR * 1.05),
     "no orb was out in the tall end of the vent, so the rotation proves nothing",
   );
-  setArenaAspect(w, 844, 390);
+  const wide = safeRect(844, 390, NO_INSETS);
+  setArenaAspect(w, arenaFrame(wide.w, wide.h, topChromeBand(844, wide.y, wide.h, NO_INSETS)).aspect);
   for (const o of w.orbs) {
     assert.ok(
       arenaEdge(w, o.x, o.y).gap >= TUNE.orbRadius * 1.1 - 1e-9,
@@ -606,22 +645,272 @@ test("a rotation reshapes the board without stranding anything outside it", () =
   assert.ok(Number.isFinite(w.serpent.x) && Number.isFinite(w.serpent.y));
 });
 
-test("a taller board carries a proportionally denser field, not a sparser one", () => {
-  // The field IS the maze — `orbs.ts` says so. A 2.2x board holding the same ten
-  // orbs is half the density and half the obstacle course, on the device most
-  // children hold.
-  const square = fresh("density-square", 600, 600);
-  const tall = fresh("density-tall", 390, 844);
-  const areaRatio = (tall.aspectX * tall.aspectY) / (square.aspectX * square.aspectY);
-  assert.ok(areaRatio > 2, `the tall board is only ${areaRatio.toFixed(2)}x the area`);
-  const ratio = tall.orbs.length / square.orbs.length;
+/* -------------------------------------------------------------------------- */
+/* The opening.                                                               */
+/* -------------------------------------------------------------------------- */
+
+test("the first screen of a dive is not crowded, on any screen", () => {
+  // The founder, on the shipped 0.3.8: "why are there so many choices when I
+  // first start ... it's too hard and crowded and frustrating for the starting
+  // density". His screenshot carried about twenty orbs at LV1, because the count
+  // was multiplied by the board's AREA and the board had just become the screen.
+  //
+  // The opening is now the same five numbers whatever a child is holding.
+  //
+  // The ceiling is absolute and comes first, because everything below compares
+  // the field to `TUNE.orbBaseCount` and would happily agree with itself at any
+  // value — an opening of twenty orbs matching a constant that says twenty is
+  // exactly the state that shipped.
   assert.ok(
-    Math.abs(ratio - areaRatio) < 0.25,
-    `the tall board is ${areaRatio.toFixed(2)}x the area but carries ${ratio.toFixed(2)}x the orbs`,
+    TUNE.orbBaseCount <= 6,
+    `a dive opens on ${TUNE.orbBaseCount} numbers; the founder filed 22 as "too hard and ` +
+      `crowded and frustrating for the starting density"`,
   );
-  const goodShare = (x: World): number => x.orbs.filter((o) => o.good).length / x.orbs.length;
+  for (const [name, sw, sh] of SCREENS) {
+    const w = fresh(`opening-${name}`, sw, sh);
+    assert.equal(
+      w.orbs.length,
+      TUNE.orbBaseCount,
+      `${name}: a dive opens on ${w.orbs.length} orbs and the opening is ${TUNE.orbBaseCount}`,
+    );
+    const good = w.orbs.filter((o) => o.good).length;
+    assert.ok(good >= 1, `${name}: nothing on the opening screen is edible`);
+    assert.ok(
+      good < w.orbs.length,
+      `${name}: everything on the opening screen is edible — there is no question to answer`,
+    );
+  }
+});
+
+/**
+ * The biggest field seen at each depth of a real dive.
+ *
+ * Measured off a played run and not by poking `w.depth`, because `ensureField` is
+ * called by the game at the moments the game calls it — a test that sets the depth
+ * and asks nicely is testing an expression, not the field a child sees.
+ */
+function fieldByDepth(w: World, maxDepth: number, minutes: number): Map<number, { count: number; good: number }> {
+  // The field the child mostly SEES, taken as the commonest (count, edible) pair
+  // over every frame at that depth. Not the peak: a bite is answered by a spawn
+  // and a molt on different frames, so the extremes catch the board mid-restock
+  // and make two identical boards look like two different ones.
+  const tally = new Map<number, Map<string, number>>();
+  const steps = Math.round((minutes * 60) / FIXED);
+  for (let i = 0; i < steps && w.depth <= maxDepth; i++) {
+    if (w.phase === "dead" && w.deathT > 0.6) confirmPressed(w);
+    // A measuring instrument, and it says so: it swims straight at the nearest
+    // edible orb and is held at the opening length so it never coils into itself.
+    // The question here is what the FIELD does with depth, and a bot that dies at
+    // depth three answers a different one — the real pilot's survival is measured
+    // by the twenty-minute test above.
+    w.serpent.targetSegments = Math.min(w.serpent.targetSegments, TUNE.startSegments);
+    w.serpent.segments = Math.min(w.serpent.segments, TUNE.startSegments);
+    let want = w.serpent.heading;
+    let near = Infinity;
+    for (const o of w.orbs) {
+      if (!o.good || o.scale < 0.7 || o.moltT > 0) continue;
+      const d = Math.hypot(o.x - w.serpent.x, o.y - w.serpent.y);
+      if (d < near) {
+        near = d;
+        want = Math.atan2(o.y - w.serpent.y, o.x - w.serpent.x);
+      }
+    }
+    stepWorld(w, FIXED, { heading: want, boost: false });
+    if (w.phase !== "play" || w.mutateT > 0) continue;
+    const key = `${w.orbs.length}/${w.orbs.filter((o) => o.good).length}`;
+    const at = tally.get(w.depth) ?? new Map<string, number>();
+    at.set(key, (at.get(key) ?? 0) + 1);
+    tally.set(w.depth, at);
+  }
+  const out = new Map<number, { count: number; good: number }>();
+  for (const [depth, at] of tally) {
+    let best = "";
+    let bestN = -1;
+    for (const [key, n] of at) {
+      if (n > bestN) {
+        bestN = n;
+        best = key;
+      }
+    }
+    const [count, good] = best.split("/").map(Number) as [number, number];
+    out.set(depth, { count, good });
+  }
+  return out;
+}
+
+test("the field grows with correct answers, and with nothing else", () => {
+  // Not elapsed time and not the size of the screen: a child who is finding it
+  // hard is never handed a denser board for having been there a while, and a
+  // bigger screen is not an achievement.
+  const shapes: Array<[string, number, number]> = [
+    ["phone portrait, small", 320, 568],
+    ["tablet landscape", 1024, 768],
+    ["phone portrait", 390, 844],
+  ];
+  const byShape = shapes.map(([name, sw, sh]) => [name, fieldByDepth(fresh(`grow-${name}`, sw, sh), 5, 8)] as const);
+
+  const rows: string[] = [];
+  for (let depth = 1; depth <= 5; depth++) {
+    const seen = new Set<string>();
+    for (const [name, m] of byShape) {
+      const f = m.get(depth);
+      assert.ok(f, `${name} never reached depth ${depth} in eight minutes of perfect play`);
+      seen.add(`${f.count}/${f.good}`);
+    }
+    assert.equal(
+      seen.size,
+      1,
+      `at depth ${depth} three different screens carry different fields: ${[...seen].join(", ")}`,
+    );
+    const f = (byShape[0] as (readonly [string, Map<number, { count: number; good: number }>]))[1].get(depth) as {
+      count: number;
+      good: number;
+    };
+    rows.push(
+      `  LV${String(depth).padEnd(3)} ${String(f.count).padStart(2)} orbs, ${f.good} edible ` +
+        `(${((f.good / f.count) * 100).toFixed(0)}%)`,
+    );
+    // About a third of what a child can see is edible, at every depth: a sparse
+    // board where everything is food teaches nothing, and a deep one where almost
+    // nothing is food is a needle hunt.
+    const share = f.good / f.count;
+    assert.ok(
+      share >= 0.2 && share <= 0.45,
+      `at depth ${depth} the field is ${f.count} orbs with ${f.good} edible (${(share * 100).toFixed(0)}%)`,
+    );
+  }
+  console.log(`\n  the field, by depth (nine correct answers each):\n${rows.join("\n")}\n`);
+
+  const counts = [1, 2, 3, 4, 5].map(
+    (d) => ((byShape[0] as (readonly [string, Map<number, { count: number; good: number }>]))[1].get(d) as { count: number }).count,
+  );
+  for (let i = 1; i < counts.length; i++) {
+    assert.ok(
+      (counts[i] as number) >= (counts[i - 1] as number),
+      `the field shrank between depth ${i} and ${i + 1}: ${counts[i - 1]} then ${counts[i]}`,
+    );
+  }
   assert.ok(
-    Math.abs(goodShare(tall) - goodShare(square)) < 0.12,
-    `the share of edible orbs changed with the screen: ${goodShare(square).toFixed(2)} to ${goodShare(tall).toFixed(2)}`,
+    (counts[4] as number) >= (counts[0] as number) * 2,
+    `five depths only took the field from ${counts[0]} to ${counts[4]} — there is nothing to earn`,
   );
+});
+
+test("a minute of a first dive stays sparse", () => {
+  // The measurement the founder's complaint is really about: not the opening
+  // frame, but what the first minute FEELS like. A competent pilot is used, so
+  // this is the crowding a child gets for playing WELL — a struggling child sees
+  // strictly less.
+  const w = fresh("minute", 390, 844);
+  let total = 0;
+  let peak = 0;
+  const steps = Math.round(60 / FIXED);
+  const marks: string[] = [];
+  for (let i = 0; i < steps; i++) {
+    if (w.phase === "dead" && w.deathT > 0.6) confirmPressed(w);
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 0.9), boost: false });
+    total += w.orbs.length;
+    peak = Math.max(peak, w.orbs.length);
+    if ((i + 1) % Math.round(10 / FIXED) === 0) {
+      marks.push(`${(i + 1) * FIXED}s: ${w.orbs.length} orbs, LV${w.depth}`);
+    }
+  }
+  const mean = total / steps;
+  console.log(`\n  first minute, competent pilot: mean ${mean.toFixed(1)} orbs, peak ${peak}\n    ${marks.join("\n    ")}\n`);
+  assert.ok(mean <= 9, `the first minute averaged ${mean.toFixed(1)} orbs on screen`);
+  assert.ok(peak <= 13, `the first minute peaked at ${peak} orbs on screen`);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Turning around.                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** Hold the tightest turn the serpent can make until something happens. */
+function coilUntil(w: World, stop: (w: World) => boolean, limit = 6000): boolean {
+  for (let i = 0; i < limit; i++) {
+    stepWorld(w, FIXED, { heading: w.serpent.heading + 1.4, boost: false });
+    if (stop(w)) return true;
+  }
+  return false;
+}
+
+test("turning around at the start of a dive is a thud, not an ending", () => {
+  // "he zooms around and grows and if I turn around he eats himself ... it's too
+  // hard". At `startSegments` the head closes a full loop on itself inside two
+  // seconds, so a child who turns the way they turn in every other game they own
+  // loses the run before they have read the condition once.
+  const w = fresh("bump", 390, 844);
+  w.orbs.length = 0; // nothing to eat, so nothing arms the latch
+  assert.equal(w.selfHitArmed, false, "a dive must open unarmed");
+
+  const before = w.serpent.targetSegments;
+  // Stop on EITHER outcome, so the assertion that fires names the one that
+  // happened: "it ended the run" and "it never touched its own body" are very
+  // different failures and a single stop condition reports them both as the second.
+  const touched = coilUntil(w, (x) => x.invulnT > 0.4 || x.phase === "dead");
+  assert.ok(touched, "a hard turn at the opening length never reached its own body");
+  assert.equal(w.phase, "play", "turning around at the opening length ended the run");
+  assert.ok(w.serpent.alive, "the serpent died on its own tail before it had grown");
+  assert.equal(
+    w.serpent.targetSegments,
+    before,
+    "the bump cost length — which would keep a child under the arming length for ever",
+  );
+  // And it is a real event, not a silent no-op: the child feels it.
+  assert.ok(w.cam.trauma > 0.1, "the bump was silent — a lesson nobody notices is not a lesson");
+
+  // It also keeps working: a child who has not yet earned length can bump again.
+  const second = coilUntil(w, (x) => x.invulnT > 0.4 || x.phase === "dead");
+  assert.ok(second, "the grace ran out after one bump without the serpent having grown");
+  assert.equal(w.phase, "play");
+});
+
+test("once the serpent has grown, its own body ends the dive again", () => {
+  const w = fresh("armed", 390, 844);
+  w.orbs.length = 0;
+  w.serpent.targetSegments = TUNE.selfHitArmsAt;
+  w.serpent.segments = TUNE.selfHitArmsAt;
+  const ended = coilUntil(w, (x) => x.phase === "dead");
+  assert.ok(w.selfHitArmed, "growing past the arming length did not arm the body");
+  assert.ok(ended, "a grown serpent coiled into itself and lived");
+});
+
+test("the grace is one-way: coughing length back up does not buy it again", () => {
+  // Otherwise a player could hover under the arming length and be immortal, and
+  // the one thing that can end a dive would be optional.
+  const w = fresh("latch", 390, 844);
+  w.orbs.length = 0;
+  w.serpent.targetSegments = TUNE.selfHitArmsAt;
+  w.serpent.segments = TUNE.selfHitArmsAt;
+  stepWorld(w, FIXED, { heading: 0, boost: false });
+  assert.ok(w.selfHitArmed, "the latch did not trip at the arming length");
+
+  w.serpent.targetSegments = TUNE.startSegments;
+  w.serpent.segments = TUNE.startSegments;
+  stepWorld(w, FIXED, { heading: 0, boost: false });
+  assert.ok(w.selfHitArmed, "shrinking back below the arming length disarmed the body");
+  const ended = coilUntil(w, (x) => x.phase === "dead");
+  assert.ok(ended, "a serpent that had grown and shrank back was immortal");
+});
+
+test("the arming length is reachable, and it is reached by answering correctly", () => {
+  // Three correct answers, by construction — and the constant has to actually BE
+  // three growths above the opening or the grace is either nothing or for ever.
+  assert.ok(
+    TUNE.selfHitArmsAt > TUNE.startSegments,
+    "the serpent is armed the moment a dive opens — there is no grace at all",
+  );
+  assert.ok(
+    TUNE.selfHitArmsAt <= TUNE.startSegments + TUNE.growPerCorrect * 3,
+    `the grace lasts ${(TUNE.selfHitArmsAt - TUNE.startSegments) / TUNE.growPerCorrect} correct ` +
+      `answers, which is long enough to be a mechanic rather than a lesson`,
+  );
+  const { host } = instrument("arming");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  for (let i = 0; i < Math.round(200 / FIXED) && !w.selfHitArmed; i++) {
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 1), boost: false });
+  }
+  assert.ok(w.selfHitArmed, "a pilot answering correctly never grew into the lethal length");
+  assert.ok(w.correctEats >= 3, `it armed after only ${w.correctEats} correct answers`);
 });

--- a/dynawalla/games/serpent/src/game/world.ts
+++ b/dynawalla/games/serpent/src/game/world.ts
@@ -51,12 +51,12 @@ import {
   createSerpent,
   grow,
   resetSerpent,
-  selfHit,
+  selfHitIndex,
   stepSerpent,
   type Serpent,
 } from "./serpent.ts";
-import { createOrb, molt, orbDrawRadius, placeOrb, stepOrbs, type Axes, type Orb } from "./orbs.ts";
-import { arenaAspect, pullInside, rimEdge, type Edge } from "./arena.ts";
+import { createOrb, molt, orbDrawRadius, placeOrb, stepOrbs, type Orb } from "./orbs.ts";
+import { arenaBoard, pullInside, rimEdge, type Aspect, type Board, type Edge } from "./arena.ts";
 import type { Audio } from "./audio.ts";
 
 const BEST_KEY = "serpent.best";
@@ -116,14 +116,22 @@ export type World = {
   arenaR: number;
   arenaTargetR: number;
   /**
-   * The vent's proportions, short axis normalised to exactly 1.
+   * The board's proportions, short half-extent normalised to exactly 1.
    *
-   * Set from the safe rectangle by `setArenaAspect` on every layout, so the board
-   * is the screen. Both are 1 until the first layout arrives, which is a circle —
-   * the shape the game shipped with, and one that every later aspect contains.
+   * Set from the fitted frame by `setArenaAspect` on every layout, so the board is
+   * the screen. Both are 1 until the first layout arrives, which is a square — and
+   * a square is contained by every later shape, so nothing is ever stranded.
    */
   aspectX: number;
   aspectY: number;
+
+  /**
+   * Has the serpent grown past `TUNE.selfHitArmsAt` at any point in this run?
+   *
+   * One-way for the whole run. Before it trips, swimming into your own body is a
+   * bump; after it, it is the only thing that can end a dive.
+   */
+  selfHitArmed: boolean;
 
   prompt: string;
   pending: Trial[];
@@ -195,6 +203,7 @@ export function createWorld(host: Host, audio: Audio, reduced: boolean): World {
     arenaTargetR: TUNE.arenaStart,
     aspectX: 1,
     aspectY: 1,
+    selfHitArmed: false,
 
     prompt: "",
     pending: [],
@@ -221,38 +230,37 @@ export function createWorld(host: Host, audio: Audio, reduced: boolean): World {
 
 // -------------------------------------------------------------------- shape
 
-/** The vent's semi-axes, this frame. */
-export function arenaAxes(w: World): Axes {
-  return { a: w.arenaR * w.aspectX, b: w.arenaR * w.aspectY };
+/** The board, this frame: half-extents and corner radius in world units. */
+export function arenaAxes(w: World): Board {
+  return arenaBoard(w.arenaR, { x: w.aspectX, y: w.aspectY });
 }
 
 /** Where the rim is from a point, which way it faces, how far away it is. */
 export function arenaEdge(w: World, x: number, y: number): Edge {
-  return rimEdge(w.arenaR * w.aspectX, w.arenaR * w.aspectY, x, y);
+  return rimEdge(arenaAxes(w), x, y);
 }
 
 /**
- * Fit the vent to the safe rectangle.
+ * Take the shape of the fitted frame.
  *
  * Called on every layout, so a rotation reshapes the board. That is the one
- * moment the arena can get *smaller* along an axis — portrait to landscape swaps
- * a tall ellipse for a wide one — so everything loose is walked back inside the
- * new rim rather than left stranded in the black with a wall between it and the
- * game. The serpent's recorded path is not: it is history, the head drags it back
- * within a body length, and rewriting it would put a kink in the animal.
+ * moment the board can get *smaller* along an axis — portrait to landscape swaps
+ * a tall rectangle for a wide one — so everything loose is walked back inside the
+ * new rim rather than left stranded outside with a wall between it and the game.
+ * The serpent's recorded path is not: it is history, the head drags it back within
+ * a body length, and rewriting it would put a kink in the animal.
  */
-export function setArenaAspect(w: World, safeW: number, safeH: number): void {
-  const next = arenaAspect(safeW, safeH);
-  if (next.x === w.aspectX && next.y === w.aspectY) return;
-  w.aspectX = next.x;
-  w.aspectY = next.y;
-  const { a, b } = arenaAxes(w);
+export function setArenaAspect(w: World, aspect: Aspect): void {
+  if (aspect.x === w.aspectX && aspect.y === w.aspectY) return;
+  w.aspectX = aspect.x;
+  w.aspectY = aspect.y;
+  const board = arenaAxes(w);
   for (const o of w.orbs) {
-    const put = pullInside(a, b, o.x, o.y, TUNE.orbRadius * 1.1);
+    const put = pullInside(board, o.x, o.y, TUNE.orbRadius * 1.1);
     o.x = put.x;
     o.y = put.y;
   }
-  const head = pullInside(a, b, w.serpent.x, w.serpent.y, TUNE.headRadius * 1.6);
+  const head = pullInside(board, w.serpent.x, w.serpent.y, TUNE.headRadius * 1.6);
   w.serpent.x = head.x;
   w.serpent.y = head.y;
 }
@@ -290,22 +298,20 @@ function pullQuestion(w: World): boolean {
 /**
  * How many orbs, and how many of them are edible.
  *
- * Both scale with the vent's AREA, which is the one gameplay consequence of the
- * board becoming the screen. `orbs.ts` says the field is the maze — "the arena is
- * dense with wrong answers you have to swim *through*, so reading the field is
- * the same act as steering through it" — and a tall phone is a 2.2× larger board,
- * so holding the counts fixed would have halved that density and quietly taken
- * the obstacle course out of the game on the device most children hold. The ratio
- * of edible to inedible is preserved exactly; only the scale changes.
+ * A function of `depth` and of NOTHING ELSE. Depth is nine correct answers each,
+ * so the field grows with demonstrated competence — never with elapsed time, and
+ * never with the size of the screen.
+ *
+ * It used to be multiplied by the board's area, which is how the first screen of
+ * a dive came to hold about twenty numbers once the board became the whole
+ * screen. Density is a thing you earn, and a bigger screen is not an achievement.
+ * `orbs.ts` is still right that the field IS the maze — it just has to be a maze
+ * the child walked into rather than one they were dropped in.
  */
 function fieldTargets(w: World): { count: number; good: number } {
-  const area = w.aspectX * w.aspectY;
-  return {
-    count: Math.round(
-      Math.min(TUNE.orbMaxCount, TUNE.orbBaseCount + (w.depth - 1) * TUNE.orbPerDepth) * area,
-    ),
-    good: Math.round(Math.min(TUNE.goodMax, TUNE.goodBase + Math.floor((w.depth - 1) / 3)) * area),
-  };
+  const count = Math.min(TUNE.orbMaxCount, TUNE.orbBaseCount + (w.depth - 1) * TUNE.orbPerDepth);
+  const good = clamp(Math.round(count * TUNE.goodShare), TUNE.goodBase, TUNE.goodMax);
+  return { count, good: Math.min(good, count - 1) };
 }
 
 function pickLabel(w: World, good: boolean): string {
@@ -373,7 +379,7 @@ function beginMutation(w: World, q: Question): void {
   slowmo(w.cam, TUNE.slowmoMutateTime, TUNE.slowmoMutateScale);
   addTrauma(w.cam, 0.18);
   flash(w.cam, "#4ff0d6", 0.1);
-  const reach = w.arenaR * Math.max(w.aspectX, w.aspectY);
+  const reach = Math.hypot(w.arenaR * w.aspectX, w.arenaR * w.aspectY);
   ring(w.rings, 0, 0, reach * 0.05, reach * 0.9, 0.7, 0.02, 2);
   w.audio.mutate();
   if (w.phase === "play") w.host.haptic("medium");
@@ -425,6 +431,7 @@ export function resetRun(w: World, phase: Phase): void {
   w.wrongEats = 0;
   w.arenaR = TUNE.arenaStart;
   w.arenaTargetR = TUNE.arenaStart;
+  w.selfHitArmed = false;
   w.orbs = [];
   w.pending = [];
   w.goodPool = [];
@@ -541,9 +548,9 @@ function descend(w: World): void {
   w.scorePulse = 1;
   addTrauma(w.cam, TUNE.traumaDepth);
   punch(w.cam, TUNE.punchDepth);
-  // Out to the LONG axis, so the "the water is closing in" beat sweeps the whole
-  // board rather than stopping halfway up a tall one.
-  const reach = w.arenaR * Math.max(w.aspectX, w.aspectY);
+  // Out to the CORNER, so the "the water is closing in" beat sweeps the whole
+  // board rather than stopping halfway up a tall one or short of its corners.
+  const reach = Math.hypot(w.arenaR * w.aspectX, w.arenaR * w.aspectY);
   ring(w.rings, 0, 0, reach * 1.02, reach * 0.55, 0.75, 0.02, 4);
   burstBubbles(w.particles, w.serpent.x, w.serpent.y, 12);
   w.audio.depth(w.depth);
@@ -595,6 +602,48 @@ function hitWall(w: World, e: Edge): void {
   w.grazeGlow = 1;
   w.audio.wall();
   if (w.phase === "play") w.host.haptic("heavy");
+}
+
+/**
+ * Swim into your own flank before you have grown: a thud, not an ending.
+ *
+ * The head is turned to face straight off the body point it touched and given
+ * half a second of grace, which is enough to be clear of it. It costs no length —
+ * a cost here would keep a child under `selfHitArmsAt` and hand them the grace
+ * for ever — and it does not break the combo, because this is a lesson and not a
+ * mistake. It is loud, though: hitstop, a shove of debris, a ring and the same
+ * thud the wall makes, so a child learns exactly what they must not do at the one
+ * moment it is free to learn it.
+ */
+function bumpSelf(w: World, index: number): void {
+  const s = w.serpent;
+  const bx = s.bodyX[index] as number;
+  const by = s.bodyY[index] as number;
+  let dx = s.x - bx;
+  let dy = s.y - by;
+  const d = Math.hypot(dx, dy);
+  if (d > 1e-6) {
+    dx /= d;
+    dy /= d;
+  } else {
+    // Dead centre on its own body: any way out will do, so take the one it is
+    // already pointing, reversed.
+    dx = -Math.cos(s.heading);
+    dy = -Math.sin(s.heading);
+  }
+  // The heading is snapped, never the position: the body follows the head's
+  // recorded path, and teleporting the head would draw a straight seam across the
+  // animal. Turning it is the nudge.
+  s.heading = Math.atan2(dy, dx);
+  s.targetHeading = s.heading;
+  w.invulnT = Math.max(w.invulnT, 0.5);
+  hitstop(w.cam, TUNE.hitstopBumpMs);
+  addTrauma(w.cam, TUNE.traumaBump);
+  punch(w.cam, TUNE.punchWrong);
+  burstDebris(w.particles, s.x, s.y, s.heading, 6);
+  ring(w.rings, s.x, s.y, TUNE.headRadius, TUNE.headRadius * 6, 0.42, 0.012, 3);
+  w.audio.wall();
+  if (w.phase === "play") w.host.haptic("medium");
 }
 
 function die(w: World, x: number, y: number): void {
@@ -712,7 +761,7 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
     w.deathT += dt;
     stepOrbs(w.orbs, {
       dt,
-      axes: arenaAxes(w),
+      board: arenaAxes(w),
       headX: s.x,
       headY: s.y,
       current: 0,
@@ -739,7 +788,7 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
 
   stepOrbs(w.orbs, {
     dt,
-    axes: arenaAxes(w),
+    board: arenaAxes(w),
     headX: s.x,
     headY: s.y,
     current: w.depth >= 4 ? 0.03 : 0,
@@ -793,18 +842,24 @@ export function stepWorld(w: World, dt: number, input: StepInput): void {
   // length and throws you back, and the only thing that can end a run is
   // outgrowing your own turning circle. That is also what makes the arena
   // closing in mean something: it squeezes you into yourself.
+  // The latch never falls back: length coughed up by a wrong answer or a wall does
+  // not buy the opening's grace a second time.
+  if (s.targetSegments >= TUNE.selfHitArmsAt) w.selfHitArmed = true;
+
   w.wallT = Math.max(0, w.wallT - dt);
   if (edge.gap < TUNE.headRadius * 0.75 && w.wallT <= 0) {
     hitWall(w, edge);
-  } else if (w.invulnT <= 0 && selfHit(s)) {
-    die(w, s.x, s.y);
+  } else if (w.invulnT <= 0) {
+    const hit = selfHitIndex(s);
+    if (hit >= 0) {
+      if (w.selfHitArmed) die(w, s.x, s.y);
+      else bumpSelf(w, hit);
+    }
   }
 
   if (Math.random() < dt * 2.4) {
-    const a = randRange(0, TAU);
-    const r = Math.sqrt(Math.random());
-    const { a: ax, b: ay } = arenaAxes(w);
-    burstBubbles(w.particles, Math.cos(a) * r * ax, Math.sin(a) * r * ay, 1);
+    const board = arenaAxes(w);
+    burstBubbles(w.particles, randRange(-board.a, board.a), randRange(-board.b, board.b), 1);
   }
 }
 


### PR DESCRIPTION
Three things from the founder's 0.3.8 session. One of them is my own call from #752 that I flagged and the coordinator approved.

---

## 1. "why not go all the way to the edge of the screen instead of oval?" — asked three times

An ellipse inscribed in a rectangle covers **π/4 = 78.5%** of it, and `ARENA_FILL = 0.9` sat on top of that, so the playfield was **63.6% of the safe rectangle** with four dark corners and a tenth of every edge.

**The board is now a rounded rectangle fitted to the real limit**, and the real limit is exactly two things:

| the limit | why it is real |
|---|---|
| the **safe rectangle** | outside it is the cutout and the rounded display corner. A lethal rim under a rounded corner is a wall a child dies against and cannot see — which is what the original comment on the 0.44 circle was protecting against, and it was right. |
| the **host's chrome** | `<` top-left, `?` top-right, 44px squares, painted OVER every game (`hostChrome.ts`). In the founder's screenshot they sat on the board. |

`ARENA_FILL` is gone. There is no fill fraction. The rim's own ink — stroke half-width, polyps, and a bounded camera shake — is measured in pixels and reserved in pixels by a fixed-point solve, and the board takes every pixel that is left.

### The number that answers the question

```
playfield share of the safe rectangle       was 63.6% everywhere
  phone portrait, small (320x568), no insets          80.7%
  phone portrait, small (320x568), cutout at the top  78.6%
  phone portrait (390x844), no insets                 84.4%
  phone portrait (390x844), cutout at the top         83.4%
  tablet portrait (768x1024), no insets               83.7%
  tablet portrait (768x1024), cutout at the top       82.9%
  tablet landscape (1024x768), no insets              82.7%
  tablet landscape (1024x768), cutout at the side     82.2%
  phone landscape (844x390), no insets                77.8%
  phone landscape (844x390), cutout at the side       77.0%
```

Printed by the suite, and floored at 76% so it cannot quietly go backwards.

### Why it is not 100%, honestly

**The host's own two buttons are the single biggest item: 7.5 points on a tall phone, 11.7 on the shortest safe box the fleet tests.** For a board flush to the safe rectangle to also clear a 44×44 square at `(10, 13)`, its top corner radius would have to be **≥ 189.5px** — larger than the half-width of a 320px phone. It is geometrically impossible. So the top edge sits below the buttons and every other edge is flush. That is the trade, stated as you asked.

The rest is the rim's own ink: the stroke, the polyps, and the shake.

### Keeping the rim readable against the screen edge

Solved in the rendering, not by shrinking the playfield: the white-hot inner lip is now **one continuous path** at a fixed inward inset instead of 72 shimmering arc segments — a hairline has nowhere to put a shimmer, and this is the pass that has to read as a *line* against a screen edge. The halo is stretched to the board's bounds and the floor gets a flat wash under the pool of light, so the corners are lit floor rather than the dark that was half of what "not the whole screen" meant.

### The camera shake

The board is flush now, so an unclamped shake carries a lethal rim off the safe box. The translation is clamped to `SHAKE_HEADROOM = 0.028` — half of `shakeMax`. **Every shake a child is still steering through is already under it** (a wall hit is 0.0166, a wrong answer 0.0111, a bite 0.0006 — all asserted). The only thing trimmed is the death slam, which keeps its hitstop, slow-motion, flash, punch and debris. Reserving the full `shakeMax` instead costs seven points of screen to protect a frame nobody is playing.

### The collision carried across, and got simpler

A rounded rect's nearest point is closed form — clamp to the straight run, or fall to the corner arc — where the ellipse needed a six-round evolute iteration. Everything still routes through one `rimEdge`/`pullInside` pair, so the wall, the graze band, the spawner and the orb field cannot drift apart. Still checked against a **60,000-point brute-force sweep of the rim**.

Kept: deflect-don't-reflect, the whole rim inside the safe rect, nothing spawning outside, the rotation walk-back. New: **the rim never passes under a host control** (sampled off the real rim walk at 900 points × every corner of the shake box), and **the drawn rim and the collided rim are one walk** (`sampleRim` is asserted to agree with `rimEdge` point for point).

`MAX_ARENA_ASPECT` is **gone**. It existed because the ellipse's offset curve stopped being exact past a curvature bound; a rounded rect's exactness depends only on `margin ≤ cornerRadius`, which is aspect-independent. Nothing caps how much screen the board takes any more.

---

## 2. The opening density — my error from #752

I wrote, in the #752 body: *"Orb count now scales with the vent's area. This is the one game-feel decision here rather than a consequence of the shape … three lines in `fieldTargets`, trivially revertible."* That is why his first screen had twenty-two numbers on it.

**The area term is gone.** The field is a function of `depth` and nothing else — and depth is nine *correct* answers each, so density is earned. Never elapsed time. Never the size of the screen.

### Before / after, same seed, same pilot, 390×844

| | shipped 0.3.8 | this branch |
|---|---|---|
| opening field | **22 orbs, 6 edible** | **5 orbs, 2 edible** |
| first minute, mean orbs on screen | **22.6** | **5.8** |
| first minute, peak | **24** | **7** |

The "before" numbers are measured by running the probe against `origin/main` in a scratch worktree, not reconstructed from the formula.

### The field, by depth (printed by the suite)

```
  LV1    5 orbs, 2 edible (40%)
  LV2    7 orbs, 2 edible (29%)
  LV3    9 orbs, 3 edible (33%)
  LV4   11 orbs, 4 edible (36%)
  LV5   13 orbs, 4 edible (31%)
```

Identical on a 320×568 phone, a 390×844 phone and a 1024×768 tablet — asserted. The edible share stays between 20% and 45% at every depth, so a sparse opening where everything is food and a deep board that is a needle hunt are both excluded.

### The thing this could have broken, and did not

A sparser field means longer swims, so a competent pilot now reaches **depth 6** in twenty simulated minutes instead of 8. I lowered that assertion and said why — and in exchange **raised the retrieval-volume floor from 200 to 400**, because that is the metric this product is actually judged on. Twenty minutes still puts **548 questions** to the child, better than twenty a minute. If thinning the field ever starts starving the question stream, that assertion is where it shows up.

---

## 3. "if I turn around he eats himself"

At `startSegments` the head closes a full loop on itself in under two seconds, so a child who turns the way they turn in every other game they own loses the run before they have read the condition once.

**What I chose: a grace by LENGTH, spent as a bump rather than a death.**

Until the serpent has grown `startSegments + 3 × growPerCorrect` — three correct answers — a self-hit turns the head off its own flank with a thud, a moment of invulnerability, and the dive carries on.

- **It costs no length.** A cost here would keep a child under the arming length for ever, and the grace would never end.
- **It does not break the combo.** This is a lesson, not a mistake.
- **It is loud.** Hitstop, debris, a ring, the wall's thud, a haptic. Asserted — a lesson nobody notices is not a lesson.
- **The heading is snapped, never the position.** The body follows the head's recorded path; teleporting the head would draw a straight seam across the animal.
- **The latch is one-way for the whole run.** Coughing length back up does not buy the grace again, so nobody can hover under the arming length and be immortal. Asserted.

Considered and rejected: *a fixed number of free bumps* (a child flailing in the first five seconds spends all three while still not knowing the rules), and *a permanent length rule* (farmable — stay short, graze the rim for 13 points a second, never die).

The manual gained one line, in the rules section where it belongs: "While you are still short, bumping your tail only knocks you off it. Once you have grown, it ends the dive."

---

## Verification

- `npm run -s tsc` clean; **83 tests, 5 consecutive green runs**.
- `node packs/build.mjs serpent` builds and passes the SDK checker.
- Boundary asserted at 320×568, 390×844, 768×1024, 1024×768, 844×390 and 600×600, with and without a cutout, at `arenaStart`, 0.8 and `arenaFloor`.
- The reserved zoom and shake are **measured by running the real camera**, not hand-derived.

### One fix to the measuring instrument itself

`world.test.ts`'s pilot steered off `Math.hypot(x, y)` — the distance from the *middle*, which on a circle was the same thing as the distance from the wall. On a board that is the whole screen it pinned the bot to the centre of a tall phone and made the game look unplayable when it was the instrument that was broken. It now steers off `arenaEdge`.

## Mutation transcript

Twenty-one removals, twenty-one distinct failures. Each applied alone to a clean tree and reverted.

### The frame

| # | mutation | the assertion that trips |
|---|---|---|
| M1 | the board is inset a tenth again (the shipped `ARENA_FILL`) | `the board covers only 65.9% of the safe rectangle` |
| M2 | the host's chrome band stops being reserved | `the rim runs under a host control at (10.1,39.9) — the square is 10,13 44x44` |
| M3 | the punch is left out of the layout | `the rim crosses the right inset by 1.87px` |
| M4 | the camera shake is applied unclamped | `scene.ts applies the camera shake unclamped — the board is flush to the safe box now, so an unclamped shake carries a lethal rim off it` |

### The shape

| # | mutation | the assertion that trips |
|---|---|---|
| M5 | `rimEdge` loses the corner arc | `the "nearest point on the rim" is 0.0348197750682272 off the rim` |
| M6 | the rim walk cuts the corners straight | `a sweep of the rim found a point 0.170857165 away and rimEdge settled for 0.175482467` |
| M7 | `pullInside` stops offsetting | `the graze band (0.075): (0.991,0.130) was put at (0.991,0.130), which is 0.009430 from the wall` |
| M8 | the corner radius drops below the clearances | `at the vent's floor the corner radius is 0.0620 and the game asks for 0.1364 of clearance — the offset stops being exact` |

### The field

| # | mutation | the assertion that trips |
|---|---|---|
| M9 | the field is multiplied by the board's area again | `a dive opens on 8 orbs and the opening is 5` · `at depth 1 three different screens carry different fields: 8/3, 7/2, 10/3` |
| M10 | the opening goes back to ten orbs | `a dive opens on 10 numbers; the founder filed 22 as "too hard and crowded and frustrating for the starting density"` |
| M11 | everything on the board becomes edible | `at depth 1 the field is 5 orbs with 4 edible (80%)` |
| M12 | the field stops growing with depth | `five depths only took the field from 5 to 5 — there is nothing to earn` |

### Turning around

| # | mutation | the assertion that trips |
|---|---|---|
| M13 | the grace is removed: a self-hit always ends the dive | `turning around at the opening length ended the run` |
| M14 | the latch is recomputed every frame instead of latching | `shrinking back below the arming length disarmed the body` |
| M15 | the bump costs length, the way the wall does | `the bump cost length — which would keep a child under the arming length for ever` |
| M16 | the bump is silent | `the bump was silent — a lesson nobody notices is not a lesson` |
| M17 | the arming length is put out of reach | `the grace lasts 21.2 correct answers, which is long enough to be a mechanic rather than a lesson` |
| M18 | there is no grace at all: armed from the first frame | `the serpent is armed the moment a dive opens — there is no grace at all` |

### The wiring

| # | mutation | the assertion that trips |
|---|---|---|
| M19 | `mount.ts` never hands the fitted shape to the world | `mount.ts no longer hands the fitted shape to the world — the board is a square again` |
| M20 | the renderer strokes its own rim instead of the shared walk | `scene.ts no longer strokes the rim off the shared walk, so the drawn wall and the wall a child hits are two different curves` |
| M21 | the measured band is scaled away on its way into the frame | `scene.ts no longer reserves the host's chrome band as it is measured — the rim runs under the buttons` |

### Two that were vacuous on the first attempt, and how they were caught

**M10** first passed. `assert.equal(w.orbs.length, TUNE.orbBaseCount)` compares the field to *its own constant* and agrees with itself at any value — an opening of twenty orbs matching a constant that says twenty is precisely the state that shipped. The test now leads with an absolute ceiling (`TUNE.orbBaseCount <= 6`) before anything self-referential, and the first-minute mean is an absolute number too.

**M21** first passed. The source guard only checked that `topChromeBand(` appeared in `scene.ts`, so a band that is measured and then multiplied by zero on its way into the frame read as if it reserved the right number. The guard now pins the whole assignment.

**M13** reported the wrong failure at first — its `coilUntil` stopped only on a bump, so a mutation that kills instead reported "never reached its own body" rather than "ended the run". Both outcomes now stop the loop, so the assertion that fires names the one that happened.

## Not done

- The condition's fit is still measured against the disc **inside** the board, which is conservative and unchanged. The rounded rect has more room in its corners than the ellipse did; widening the fit to use it is a separate call.
- Reclaiming the free middle of the top strip (the two buttons leave the centre clear) would need per-corner radii and a notched boundary. I costed it: the best case is worth about 1.6% of the screen and it makes the collision a materially harder shape. Not worth it on this budget — flagging it rather than doing it.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
