### PR TITLE
dynawalla/games/siege: the safe area arrives from the host, not from env()

### DIFF
--- a/dynawalla/games/siege/src/mount.ts
+++ b/dynawalla/games/siege/src/mount.ts
@@ -316,16 +316,21 @@ export class Siege {
 
   private resize(): void {
     const b = this.hud.board;
+    // Measured every resize, never cached from construction: a rotation trades
+    // one top inset for two side ones, and iPadOS changes them when the pack is
+    // resized in Split View. Read once and you are correct until the first
+    // rotation and wrong after it.
+    const insets = safeInsets();
+    // Publish BEFORE measuring. The status bar's and the console's padding are
+    // derived from these, so they decide how much height is left for the board;
+    // a board measured first is a board measured against the previous insets.
+    this.hud.setInsets(insets);
     const w = Math.max(1, b.clientWidth);
     const h = Math.max(1, b.clientHeight);
     const dpr = Math.min(2, window.devicePixelRatio || 1);
     this.hud.canvas.width = Math.round(w * dpr);
     this.hud.canvas.height = Math.round(h * dpr);
-    // Measured every resize, never cached from construction: a rotation trades
-    // one top inset for two side ones, and iPadOS changes them when the pack is
-    // resized in Split View. Read once and you are correct until the first
-    // rotation and wrong after it.
-    this.view = computeView(w, h, dpr, boardSafe(w, h, safeInsets()));
+    this.view = computeView(w, h, dpr, boardSafe(w, h, insets));
   }
 
   restart(): void {

--- a/dynawalla/games/siege/src/ui/chrome.test.ts
+++ b/dynawalla/games/siege/src/ui/chrome.test.ts
@@ -10,9 +10,13 @@
  * SIEGE's status bar runs the full width of exactly that row.
  *
  * **Removing the fix fails this file.** Set `CORNER_CLEAR` to 0 and the corner
- * tests trip; drop the side `env()` rules out of `styles.css` and the stylesheet
- * test trips; hand `computeView` the whole element instead of the safe box and
- * the board test trips.
+ * tests trip; drop the side safe-area rules out of `styles.css` and the
+ * stylesheet test trips; hand `computeView` the whole element instead of the
+ * safe box and the board test trips.
+ *
+ * This file works in the pack's own vocabulary — rects and constants. The
+ * stylesheet's arithmetic is evaluated to pixels next door, in
+ * `safearea.test.ts`, which is where the defect that survived this file lived.
  */
 
 import { test } from "node:test";
@@ -133,9 +137,20 @@ test("the status bar stays inside the safe area on every edge", () => {
 test("the stylesheet honours all four edges, not only the two obvious ones", () => {
   // The original defect: `.sg-top` had `padding-top: env(...)` and `.sg-anvil`
   // had `padding-bottom: env(...)`, and that was the whole of it. Held sideways
-  // the cutout is a SIDE inset. This asserts the rules themselves, because they
-  // are the fix — there is no JavaScript to test.
-  const css = read("./styles.css");
+  // the cutout is a SIDE inset.
+  //
+  // What this test USED to assert was `body.includes("env(safe-area-inset-…")`,
+  // and that is a lesson worth leaving in the file. It passed on the day SIEGE
+  // shipped its ember count under an Android status bar, because the rule was in
+  // the stylesheet and resolved to zero: a pack frame is cross-origin and
+  // `env()` belongs to the top-level document. A substring search proves the
+  // text is present. It cannot tell you what the text evaluates to.
+  //
+  // So this now asserts the SHAPE of the fix — every edge is read from a
+  // `--sg-safe-*` property, which is the only channel the host's measurement can
+  // arrive on — and `safearea.test.ts` next door evaluates the stylesheet to
+  // pixels at ten viewports and asserts the geometry.
+  const css = read("./styles.css").replace(/\/\*[\s\S]*?\*\//g, "");
   const rule = (selector: string): string => {
     const at = css.indexOf(`${selector} {`);
     assert.ok(at >= 0, `${selector} is gone from the stylesheet`);
@@ -150,8 +165,8 @@ test("the stylesheet honours all four edges, not only the two obvious ones", () 
     const body = rule(selector);
     for (const edge of edges) {
       assert.ok(
-        body.includes(`env(safe-area-inset-${edge}`),
-        `${selector} does not honour safe-area-inset-${edge}`,
+        body.includes(`var(--sg-safe-${edge},`),
+        `${selector} does not read --sg-safe-${edge} — an inset it cannot get any other way`,
       );
     }
   }

--- a/dynawalla/games/siege/src/ui/chrome.ts
+++ b/dynawalla/games/siege/src/ui/chrome.ts
@@ -1,14 +1,31 @@
 /**
  * The room the host leaves SIEGE, and what the pack promises about it.
  *
- * SIEGE was one of the seven games that already read `env(safe-area-inset-*)`,
- * which turned out to be the half-fix it usually is: `.sg-top` honoured
- * `--top` and `.sg-anvil` honoured `--bottom`, and **neither side was touched
- * at all**. `viewport-fit=cover` opts a document into the rounded corners and
- * the display cutout on every edge, not just the one that is obvious in
- * portrait. Held sideways the ember count and the sound switch sat under the
- * cutout, which is a currency a child cannot read and a control they cannot
- * press.
+ * **The defect that survived the first pass.** SIEGE read
+ * `env(safe-area-inset-*)` from `styles.css` and believed that was the fix. It
+ * is not, and inside the shipped app it is not even close: a pack runs in an
+ * iframe sandboxed `allow-scripts` with no `allow-same-origin`, and
+ * `env(safe-area-inset-*)` is a property of the TOP-LEVEL browsing context. A
+ * cross-origin child resolves all four to **zero**. Every rule in the
+ * stylesheet therefore collapsed to its 8px/10px fallback, and on a 1080x2340
+ * Android phone the ember count was painted under the OS status bar and the
+ * overcharge lever under the three-button navigation bar. The canvas was fine
+ * the whole time, because `mount.ts` fitted the board against `safeInsets()` —
+ * the DOM half of the same game disagreed with the canvas half about where the
+ * screen was.
+ *
+ * So the numbers now arrive the only way they can: as an ARGUMENT from the
+ * host, through `game-chrome`'s `safeInsets()`, published onto the root as four
+ * custom properties by `applySafeVars` below. `styles.css` reads
+ * `var(--sg-safe-top, env(safe-area-inset-top, 0px))` — the property inside the
+ * app, the `env()` only in a dev browser tab where it happens to be right.
+ *
+ * **The half-fix before that.** `.sg-top` honoured `--top` and `.sg-anvil`
+ * honoured `--bottom`, and **neither side was touched at all**.
+ * `viewport-fit=cover` opts a document into the rounded corners and the display
+ * cutout on every edge, not just the one that is obvious in portrait. Held
+ * sideways the ember count and the sound switch sat under the cutout, which is
+ * a currency a child cannot read and a control they cannot press.
  *
  * The second encroachment is the host's own chrome: an exit control over the
  * top-LEFT 44px corner and a how-to-play control over the top-RIGHT one. SIEGE's
@@ -30,6 +47,9 @@
 import {
   HOST_CONTROL,
   HOST_MARGIN,
+  HOST_PROGRESS_H,
+  NO_INSETS,
+  safeInsets,
   safeRect,
   type Insets,
   type Rect,
@@ -47,6 +67,15 @@ export const CORNER_CLEAR = HOST_MARGIN + HOST_CONTROL;
 
 /** The status bar's own margin from whatever edge it ends up against. */
 export const BAR_PAD = 10;
+
+/**
+ * Down from the SAFE top edge to the bottom of the host's row of controls.
+ *
+ * Anything that must be read and is laid out across the full width — a banner,
+ * the defeat card — starts below this, because it cannot dodge the two corners
+ * sideways the way the status bar does.
+ */
+export const CHROME_BOTTOM = HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL;
 
 /**
  * The box the status bar's contents may use.
@@ -102,14 +131,59 @@ export function boardSafe(w: number, h: number, insets: Insets): Rect {
 /**
  * The CSS the stylesheet cannot express on its own.
  *
- * `styles.css` uses `env()` directly wherever it can — that is exact, it needs
- * no JavaScript, and it survives a rotation without a listener. The one thing it
- * cannot do is know how wide a host control is, so that number is written in
- * from here as a custom property and every rule that needs it reads
- * `var(--sg-corner)`.
+ * How wide a host control is, and how far in the bar's own margin sits. Written
+ * in from the shared constants so the pack follows if the host moves its chrome.
+ * These are fixed for the life of the pack, so they can live in a `<style>` tag;
+ * the safe area cannot, and goes through `applySafeVars` instead.
  */
 export function chromeVars(): string {
-  return `.sg{--sg-corner:${CORNER_CLEAR}px;--sg-bar-pad:${BAR_PAD}px}`;
+  return `.sg{--sg-corner:${CORNER_CLEAR}px;--sg-bar-pad:${BAR_PAD}px;--sg-chrome-bottom:${CHROME_BOTTOM}px}`;
+}
+
+/** The four custom properties `styles.css` does its safe-area arithmetic with. */
+export const SAFE_VARS = ["--sg-safe-top", "--sg-safe-right", "--sg-safe-bottom", "--sg-safe-left"] as const;
+
+/** The narrow slice of an element this needs — so a test can drive it with a stub. */
+export type StyleTarget = { style: { setProperty(name: string, value: string): void } };
+
+/**
+ * Hand the stylesheet the safe area, as four lengths it can do arithmetic with.
+ *
+ * Zeros are written EXPLICITLY rather than left unset. `var(--sg-safe-top, …)`
+ * falls back to its `env()` only when the property is absent, and inside the app
+ * `env()` is the wrong answer even when the true inset happens to be zero — it
+ * is the wrong answer *especially* then, because it is indistinguishable from
+ * the right one until the child picks up a phone with a notch.
+ *
+ * @returns whether anything actually changed, so a caller on a resize path can
+ *   avoid touching style it did not need to touch.
+ */
+export function applySafeVars(
+  root: StyleTarget,
+  insets: Insets = safeInsets(),
+  previous?: Insets | null,
+): boolean {
+  const i = insets ?? NO_INSETS;
+  const now: Insets = {
+    top: Math.max(0, i.top),
+    right: Math.max(0, i.right),
+    bottom: Math.max(0, i.bottom),
+    left: Math.max(0, i.left),
+  };
+  if (
+    previous &&
+    previous.top === now.top &&
+    previous.right === now.right &&
+    previous.bottom === now.bottom &&
+    previous.left === now.left
+  ) {
+    return false;
+  }
+  root.style.setProperty("--sg-safe-top", `${now.top}px`);
+  root.style.setProperty("--sg-safe-right", `${now.right}px`);
+  root.style.setProperty("--sg-safe-bottom", `${now.bottom}px`);
+  root.style.setProperty("--sg-safe-left", `${now.left}px`);
+  return true;
 }
 
 /** What `computeView` hands the renderer. Declared here so the fit can be tested. */

--- a/dynawalla/games/siege/src/ui/hud.ts
+++ b/dynawalla/games/siege/src/ui/hud.ts
@@ -6,7 +6,8 @@
  * crisp on every device.
  */
 import { TOWERS, type TowerKind } from "../game/constants.ts";
-import { chromeVars } from "./chrome.ts";
+import { applySafeVars, chromeVars } from "./chrome.ts";
+import type { Insets } from "../../../../packs/shared/game-chrome/index.ts";
 import type { Question } from "../contract.ts";
 
 export type HudCallbacks = {
@@ -122,6 +123,7 @@ export class Hud {
   private end: HTMLDivElement | null = null;
 
   private flyPool: HTMLDivElement[] = [];
+  private insets: Insets | null = null;
   private cb: HTMLCallbacksShim;
 
   constructor(host: HTMLElement, cb: HudCallbacks) {
@@ -129,13 +131,16 @@ export class Hud {
     const root = el("div", "sg");
     this.root = root;
 
-    // `styles.css` uses `env()` directly everywhere it can — exact, no
-    // JavaScript, and it survives a rotation with no listener. The one thing it
-    // cannot know is how wide the HOST's controls are, so that single number is
-    // written in from the shared constants here.
+    // Two things the stylesheet cannot work out for itself. How wide the HOST's
+    // controls are, which never changes and so can live in a `<style>` tag —
+    // and the safe area, which changes on every rotation and, more to the
+    // point, is not readable from inside a pack frame at all: `env()` resolves
+    // to zero in a cross-origin child. It is written onto the root as custom
+    // properties instead, from the host's own measurement.
     this.style = document.createElement("style");
     this.style.textContent = chromeVars();
     root.appendChild(this.style);
+    applySafeVars(root);
 
     // -- top bar -----------------------------------------------------------
     const top = el("div", "sg-top");
@@ -249,6 +254,21 @@ export class Hud {
 
     root.append(top, this.board, this.anvil);
     host.appendChild(root);
+  }
+
+  /**
+   * Republish the safe area onto the root.
+   *
+   * Called on every resize rather than once at mount: a rotation trades one top
+   * inset for two side ones, and the host re-sends its measurement whenever the
+   * app's own layout moves. Idempotent — nothing is written when the numbers
+   * have not moved, so this is safe to call from a `ResizeObserver` without
+   * writing style the browser then has to measure again.
+   */
+  setInsets(insets: Insets): void {
+    if (applySafeVars(this.root, insets, this.insets)) {
+      this.insets = { ...insets };
+    }
   }
 
   // -- stats ---------------------------------------------------------------

--- a/dynawalla/games/siege/src/ui/safearea.test.ts
+++ b/dynawalla/games/siege/src/ui/safearea.test.ts
@@ -1,0 +1,730 @@
+/**
+ * The safe area, asserted against the SHIPPED stylesheet rather than against a
+ * copy of what it was meant to say.
+ *
+ * **Why this file exists at all.** `chrome.test.ts` already claimed to prove
+ * this. It did it with `body.includes("env(safe-area-inset-top")` — a substring
+ * search on the stylesheet — and that assertion was true on the day SIEGE
+ * shipped a status bar underneath an Android status bar. The rule was there.
+ * The rule resolved to zero. A pack runs in an iframe sandboxed `allow-scripts`
+ * with no `allow-same-origin`; `env(safe-area-inset-*)` belongs to the
+ * top-level browsing context and a cross-origin child reads all four as 0. The
+ * text was in the file and the pixels were under the clock.
+ *
+ * So this file does not look for text. It PARSES `styles.css` — comments,
+ * media queries, the cascade, shorthand expansion, custom properties — and
+ * evaluates the padding of every chrome element to a NUMBER, at a list of real
+ * viewports with real insets, with one deliberate rule baked into the
+ * evaluator:
+ *
+ *     env(safe-area-inset-*) evaluates to ZERO.
+ *
+ * That is not a simplification, it is the environment the game actually runs
+ * in. Any rule that still reaches for `env()` for its answer resolves to its
+ * fallback here and the assertion below it fails, which is exactly what should
+ * happen. The only way to pass is for the number to come from `--sg-safe-*`,
+ * which is to say from the host.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  HOST_CONTROL,
+  HOST_MARGIN,
+  HOST_PROGRESS_H,
+  exitRect,
+  helpRect,
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import { CHROME_BOTTOM, TOP_BAR_MIN, applySafeVars, chromeVars } from "./chrome.ts";
+
+const read = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+/* ========================================================================== */
+/* A small CSS engine: parse, cascade, evaluate.                              */
+/* ========================================================================== */
+
+type Decl = { prop: string; value: string };
+type Rule = { media: string; selectors: string[]; decls: Decl[] };
+
+/** Split on `sep` at paren depth zero. */
+function splitTop(s: string, sep: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let cur = "";
+  for (const ch of s) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === sep && depth === 0) {
+      out.push(cur);
+      cur = "";
+    } else cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+function parseDecls(body: string): Decl[] {
+  const out: Decl[] = [];
+  for (const chunk of splitTop(body, ";")) {
+    const at = chunk.indexOf(":");
+    if (at < 0) continue;
+    const prop = chunk.slice(0, at).trim();
+    const value = chunk.slice(at + 1).trim();
+    if (prop) out.push({ prop, value });
+  }
+  return out;
+}
+
+/**
+ * Parse a stylesheet into a flat, ordered list of rules.
+ *
+ * Enough CSS for this stylesheet and no more: comments, one level of `@media`,
+ * `@keyframes` skipped whole (its `0% { … }` blocks are not rules and must not
+ * enter the cascade).
+ */
+function parseCss(src: string): Rule[] {
+  const css = src.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rules: Rule[] = [];
+
+  const block = (from: number): { body: string; end: number } => {
+    let depth = 0;
+    for (let i = from; i < css.length; i++) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") {
+        depth--;
+        if (depth === 0) return { body: css.slice(from + 1, i), end: i + 1 };
+      }
+    }
+    throw new Error("unbalanced braces in styles.css");
+  };
+
+  const walk = (text: string, media: string): void => {
+    let i = 0;
+    while (i < text.length) {
+      const open = text.indexOf("{", i);
+      if (open < 0) break;
+      const prelude = text.slice(i, open).trim();
+      // `block` needs absolute indices into whatever string it is scanning.
+      let depth = 0;
+      let end = -1;
+      for (let j = open; j < text.length; j++) {
+        if (text[j] === "{") depth++;
+        else if (text[j] === "}") {
+          depth--;
+          if (depth === 0) {
+            end = j;
+            break;
+          }
+        }
+      }
+      assert.ok(end > 0, "unbalanced braces in styles.css");
+      const body = text.slice(open + 1, end);
+      if (prelude.startsWith("@media")) {
+        assert.equal(media, "", "nested @media is not supported by this parser");
+        walk(body, prelude.slice("@media".length).trim());
+      } else if (prelude.startsWith("@")) {
+        // @keyframes and friends: not part of the cascade.
+      } else {
+        rules.push({
+          media,
+          selectors: prelude.split(",").map((s) => s.trim()).filter(Boolean),
+          decls: parseDecls(body),
+        });
+      }
+      i = end + 1;
+    }
+  };
+
+  walk(css, "");
+  void block;
+  return rules;
+}
+
+type Viewport = { w: number; h: number };
+
+/** Evaluate a media prelude. `prefers-reduced-motion` is never asserted here. */
+function mediaMatches(query: string, vp: Viewport): boolean {
+  if (query === "") return true;
+  return query
+    .split(" and ")
+    .map((s) => s.trim())
+    .every((cond) => {
+      const m = /^\(([a-z-]+)\s*:\s*([^)]+)\)$/.exec(cond);
+      assert.ok(m, `this parser does not understand the media condition "${cond}"`);
+      const [, feature, raw] = m as unknown as [string, string, string];
+      if (feature === "prefers-reduced-motion") return false;
+      const n = Number.parseFloat(raw);
+      assert.ok(Number.isFinite(n), `non-length media value "${raw}"`);
+      if (feature === "max-width") return vp.w <= n;
+      if (feature === "min-width") return vp.w >= n;
+      if (feature === "max-height") return vp.h <= n;
+      if (feature === "min-height") return vp.h >= n;
+      throw new Error(`this parser does not understand the media feature "${feature}"`);
+    });
+}
+
+const BOX_SIDES = ["top", "right", "bottom", "left"] as const;
+type Side = (typeof BOX_SIDES)[number];
+
+/** Split on whitespace at paren depth zero — `calc(a + b)` is ONE component. */
+function splitComponents(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let cur = "";
+  for (const ch of s) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (depth === 0 && /\s/.test(ch)) {
+      if (cur.trim()) out.push(cur.trim());
+      cur = "";
+    } else cur += ch;
+  }
+  if (cur.trim()) out.push(cur.trim());
+  return out;
+}
+
+/** Expand `padding: a [b [c [d]]]` the way the box model does. */
+function expandBox(value: string): Record<Side, string> {
+  const parts = splitComponents(value.trim());
+  const [a, b, c, d] = parts;
+  assert.ok(a, "empty shorthand");
+  const top = a;
+  const right = b ?? a;
+  const bottom = c ?? a;
+  const left = d ?? b ?? a;
+  return { top, right, bottom, left };
+}
+
+/**
+ * The declarations that win for one selector at one viewport.
+ *
+ * Every selector this file asks about is a single class, so specificity is
+ * equal throughout and document order decides — which is precisely the rule
+ * that made `padding: 8px` inside a media query quietly delete three
+ * safe-area longhands.
+ */
+function cascade(rules: Rule[], selector: string, vp: Viewport): Map<string, string> {
+  const won = new Map<string, string>();
+  for (const rule of rules) {
+    if (!rule.selectors.includes(selector)) continue;
+    if (!mediaMatches(rule.media, vp)) continue;
+    for (const d of rule.decls) {
+      if (d.prop === "padding") {
+        const box = expandBox(d.value);
+        for (const side of BOX_SIDES) won.set(`padding-${side}`, box[side]);
+      } else {
+        won.set(d.prop, d.value);
+      }
+    }
+  }
+  return won;
+}
+
+/* ---- value evaluation ---------------------------------------------------- */
+
+type EvalCtx = { vars: Map<string, string>; vp: Viewport; pct: number };
+
+/** Substitute `var(--name, fallback)` until none are left. */
+function substituteVars(value: string, ctx: EvalCtx): string {
+  let s = value;
+  for (let pass = 0; pass < 12; pass++) {
+    const at = s.indexOf("var(");
+    if (at < 0) return s;
+    let depth = 0;
+    let close = -1;
+    for (let i = at + 3; i < s.length; i++) {
+      if (s[i] === "(") depth++;
+      else if (s[i] === ")") {
+        depth--;
+        if (depth === 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    assert.ok(close > 0, `unbalanced var() in "${value}"`);
+    const inner = s.slice(at + 4, close);
+    const comma = splitTop(inner, ",");
+    const name = (comma[0] ?? "").trim();
+    const fallback = comma.slice(1).join(",").trim();
+    const got = ctx.vars.get(name);
+    assert.ok(
+      got !== undefined || fallback !== "",
+      `${name} is neither published nor given a fallback in "${value}"`,
+    );
+    s = s.slice(0, at) + (got ?? fallback) + s.slice(close + 1);
+  }
+  throw new Error(`var() substitution did not terminate for "${value}"`);
+}
+
+/** Tokenise a resolved length expression. */
+function tokenize(s: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < s.length) {
+    const ch = s[i] as string;
+    if (/\s/.test(ch)) {
+      i++;
+      continue;
+    }
+    if ("()+-*/,".includes(ch)) {
+      out.push(ch);
+      i++;
+      continue;
+    }
+    const m = /^[a-zA-Z-]+|^[0-9.]+(px|%|vw|vh|vmin|vmax)?/.exec(s.slice(i));
+    assert.ok(m, `cannot tokenise "${s}" at ${i}`);
+    out.push(m[0]);
+    i += m[0].length;
+  }
+  return out;
+}
+
+/**
+ * Evaluate a length. `env(safe-area-inset-*)` is ZERO — see the file docblock;
+ * that is what it is inside a pack frame, and modelling it any other way is how
+ * this bug shipped.
+ */
+function evalLength(raw: string, ctx: EvalCtx): number {
+  const toks = tokenize(substituteVars(raw, ctx));
+  let p = 0;
+  const peek = (): string | undefined => toks[p];
+  const take = (t?: string): string => {
+    const got = toks[p++];
+    if (t !== undefined) assert.equal(got, t, `expected ${t} in "${raw}"`);
+    assert.ok(got !== undefined, `ran off the end of "${raw}"`);
+    return got as string;
+  };
+
+  const args = (): number[] => {
+    take("(");
+    const out: number[] = [];
+    if (peek() === ")") {
+      take(")");
+      return out;
+    }
+    for (;;) {
+      out.push(expr());
+      if (peek() === ",") {
+        take(",");
+        continue;
+      }
+      take(")");
+      return out;
+    }
+  };
+
+  const factor = (): number => {
+    const t = take();
+    if (t === "(") {
+      const v = expr();
+      take(")");
+      return v;
+    }
+    if (t === "-") return -factor();
+    if (t === "+") return factor();
+    if (/^[0-9.]/.test(t)) {
+      const n = Number.parseFloat(t);
+      assert.ok(Number.isFinite(n), `bad number "${t}"`);
+      if (t.endsWith("%")) return (n / 100) * ctx.pct;
+      if (t.endsWith("vw")) return (n / 100) * ctx.vp.w;
+      if (t.endsWith("vh")) return (n / 100) * ctx.vp.h;
+      return n;
+    }
+    // a function
+    if (t === "env") {
+      const a = args();
+      // The whole point: inside a pack frame this is zero, fallback and all.
+      void a;
+      return 0;
+    }
+    const a = args();
+    if (t === "calc") {
+      assert.equal(a.length, 1, `calc() takes one expression, got ${a.length}`);
+      return a[0] as number;
+    }
+    if (t === "max") return Math.max(...a);
+    if (t === "min") return Math.min(...a);
+    if (t === "clamp") {
+      const [lo, mid, hi] = a as [number, number, number];
+      return Math.min(Math.max(lo, mid), hi);
+    }
+    throw new Error(`this evaluator does not know the function ${t}() in "${raw}"`);
+  };
+
+  const term = (): number => {
+    let v = factor();
+    for (;;) {
+      const t = peek();
+      if (t === "*") {
+        take();
+        v *= factor();
+      } else if (t === "/") {
+        take();
+        v /= factor();
+      } else return v;
+    }
+  };
+
+  function expr(): number {
+    let v = term();
+    for (;;) {
+      const t = peek();
+      if (t === "+") {
+        take();
+        v += term();
+      } else if (t === "-") {
+        take();
+        v -= term();
+      } else return v;
+    }
+  }
+
+  const v = expr();
+  assert.equal(p, toks.length, `trailing tokens in "${raw}"`);
+  return v;
+}
+
+/* ---- the game's own stylesheet, wired to the game's own publishers -------- */
+
+const RULES = parseCss(read("./styles.css"));
+
+/** The `<style>` tag `hud.ts` injects, read back the way the browser would. */
+function publishedVars(insets: Insets): Map<string, string> {
+  const vars = new Map<string, string>();
+  const body = chromeVars();
+  const at = body.indexOf("{");
+  for (const d of parseDecls(body.slice(at + 1, body.lastIndexOf("}")))) {
+    vars.set(d.prop, d.value);
+  }
+  // …and the four the game writes onto the root element itself.
+  const stub = {
+    style: {
+      setProperty(name: string, value: string): void {
+        vars.set(name, value);
+      },
+    },
+  };
+  applySafeVars(stub, insets);
+  return vars;
+}
+
+type Pad = Record<Side, number>;
+
+function padding(selector: string, vp: Viewport, insets: Insets, pct = 0): Pad {
+  const won = cascade(RULES, selector, vp);
+  const vars = publishedVars(insets);
+  // Custom properties declared on the element itself join the map, at the value
+  // that won for THIS viewport — which is how `--sg-pad` changes at a
+  // breakpoint without a shorthand being anywhere near the safe area.
+  for (const [prop, value] of won) if (prop.startsWith("--")) vars.set(prop, value);
+  const ctx: EvalCtx = { vars, vp, pct };
+  const out = {} as Pad;
+  for (const side of BOX_SIDES) {
+    const raw = won.get(`padding-${side}`);
+    assert.ok(raw !== undefined, `${selector} has no padding-${side} at ${vp.w}x${vp.h}`);
+    out[side] = evalLength(raw, ctx);
+  }
+  return out;
+}
+
+function lengthOf(selector: string, prop: string, vp: Viewport, insets: Insets, pct = 0): number {
+  const won = cascade(RULES, selector, vp);
+  const raw = won.get(prop);
+  assert.ok(raw !== undefined, `${selector} has no ${prop} at ${vp.w}x${vp.h}`);
+  const vars = publishedVars(insets);
+  for (const [p, v] of won) if (p.startsWith("--")) vars.set(p, v);
+  return evalLength(raw, { vars, vp, pct });
+}
+
+/* ========================================================================== */
+/* The shapes.                                                                */
+/* ========================================================================== */
+
+type Case = { name: string; w: number; h: number; insets: Insets };
+
+const CASES: Case[] = [
+  {
+    // The founder's device. 1080x2340 physical at dpr 2.75 is 393x851 CSS px;
+    // a 24dp status bar and a 48dp three-button navigation bar are 24 and 48
+    // CSS px, because on Android a CSS pixel IS a dp.
+    name: "the founder's phone, portrait — status bar and three-button nav",
+    w: 393,
+    h: 851,
+    insets: { top: 24, right: 0, bottom: 48, left: 0 },
+  },
+  {
+    // Rotated, the navigation bar moves to a side and the status bar stays.
+    name: "the founder's phone, landscape — nav bar on the right",
+    w: 851,
+    h: 393,
+    insets: { top: 24, right: 48, bottom: 0, left: 0 },
+  },
+  {
+    name: "the founder's phone, landscape — nav bar on the left",
+    w: 851,
+    h: 393,
+    insets: { top: 24, right: 0, bottom: 0, left: 48 },
+  },
+  { name: "the smallest phone, no insets", w: 320, h: 568, insets: { top: 0, right: 0, bottom: 0, left: 0 } },
+  {
+    name: "a notched phone, portrait",
+    w: 390,
+    h: 844,
+    insets: { top: 47, right: 0, bottom: 34, left: 0 },
+  },
+  {
+    name: "a notched phone, landscape — cutout at both sides",
+    w: 844,
+    h: 390,
+    insets: { top: 0, right: 47, bottom: 21, left: 47 },
+  },
+  {
+    name: "a notched phone, landscape — cutout at one side",
+    w: 844,
+    h: 390,
+    insets: { top: 0, right: 0, bottom: 21, left: 47 },
+  },
+  {
+    name: "a tablet, portrait",
+    w: 768,
+    h: 1024,
+    insets: { top: 24, right: 0, bottom: 20, left: 0 },
+  },
+  {
+    name: "a tablet, landscape",
+    w: 1024,
+    h: 768,
+    insets: { top: 24, right: 0, bottom: 20, left: 0 },
+  },
+  {
+    name: "a large tablet, landscape — the wide layout",
+    w: 1180,
+    h: 820,
+    insets: { top: 24, right: 0, bottom: 20, left: 0 },
+  },
+];
+
+const inside = (r: Rect, safe: Rect, where: string, what: string): void => {
+  assert.ok(r.x >= safe.x - 1e-9, `${where}: ${what} crosses the LEFT inset (${r.x} < ${safe.x})`);
+  assert.ok(
+    r.x + r.w <= safe.x + safe.w + 1e-9,
+    `${where}: ${what} crosses the RIGHT inset (${r.x + r.w} > ${safe.x + safe.w})`,
+  );
+  assert.ok(r.y >= safe.y - 1e-9, `${where}: ${what} crosses the TOP inset (${r.y} < ${safe.y})`);
+  assert.ok(
+    r.y + r.h <= safe.y + safe.h + 1e-9,
+    `${where}: ${what} crosses the BOTTOM inset (${r.y + r.h} > ${safe.y + safe.h})`,
+  );
+};
+
+/** The tallest a row of ~34px controls and its labels gets. Only its top edge matters. */
+const BAR_CONTENT_H = 34;
+
+/* ========================================================================== */
+/* The assertions.                                                            */
+/* ========================================================================== */
+
+test("the status bar's figures are inside the safe area at every shape", () => {
+  // This is the founder's top-edge defect, as a number. EMBERS / DPS / WAVE /
+  // HP IN start at the bar's padding-top; under the OS clock is where they were.
+  for (const { name, w, h, insets } of CASES) {
+    const pad = padding(".sg-top", { w, h }, insets);
+    const box: Rect = { x: pad.left, y: pad.top, w: w - pad.left - pad.right, h: BAR_CONTENT_H };
+    inside(box, safeRect(w, h, insets), name, "the status bar's figures");
+  }
+});
+
+test("the status bar's figures never sit under the host's two controls", () => {
+  for (const { name, w, h, insets } of CASES) {
+    const pad = padding(".sg-top", { w, h }, insets);
+    const box: Rect = { x: pad.left, y: pad.top, w: w - pad.left - pad.right, h: BAR_CONTENT_H };
+    const ex = exitRect(insets);
+    const help = helpRect(w, insets);
+    assert.equal(
+      hitsHostChrome(box, w, insets),
+      false,
+      `${name}: the bar's figures run under the host's chrome — bar x ${box.x}..${box.x + box.w}, ` +
+        `exit ${ex.x}..${ex.x + ex.w}, help ${help.x}..${help.x + help.w}`,
+    );
+  }
+});
+
+test("the status bar still has room for four figures after paying for both corners", () => {
+  for (const { name, w, h, insets } of CASES) {
+    const pad = padding(".sg-top", { w, h }, insets);
+    const inner = w - pad.left - pad.right;
+    assert.ok(inner >= TOP_BAR_MIN, `${name}: only ${inner.toFixed(0)}px left for the whole bar`);
+  }
+});
+
+test("the anvil — prompt, answers and overcharge — is inside the safe area at every shape", () => {
+  // This is the founder's bottom-edge defect. OVERCHARGE and its meter are the
+  // last thing in the console, so the console's padding-bottom IS the promise.
+  for (const { name, w, h, insets } of CASES) {
+    const pad = padding(".sg-anvil", { w, h }, insets);
+    const bottom: Rect = { x: pad.left, y: h - pad.bottom - 1, w: w - pad.left - pad.right, h: 1 };
+    const safe = safeRect(w, h, insets);
+    assert.ok(bottom.x >= safe.x - 1e-9, `${name}: the console crosses the LEFT inset`);
+    assert.ok(
+      bottom.x + bottom.w <= safe.x + safe.w + 1e-9,
+      `${name}: the console crosses the RIGHT inset`,
+    );
+    assert.ok(
+      bottom.y + bottom.h <= safe.y + safe.h + 1e-9,
+      `${name}: the overcharge meter is under the navigation bar ` +
+        `(bottom edge ${bottom.y + bottom.h}, safe ends at ${safe.y + safe.h})`,
+    );
+  }
+});
+
+test("a breakpoint cannot quietly delete the console's safe-area padding", () => {
+  // The specific way this stylesheet broke: `padding: 8px` in the short-viewport
+  // media query is a SHORTHAND, and a shorthand resets all four longhands. Both
+  // landscape phones below match that query.
+  for (const { name, w, h, insets } of CASES) {
+    if (h > 619) continue;
+    const pad = padding(".sg-anvil", { w, h }, insets);
+    for (const side of ["bottom", "left", "right"] as const) {
+      assert.ok(
+        pad[side] >= insets[side] - 1e-9,
+        `${name} (short viewport): the console's ${side} padding is ${pad[side]}px ` +
+          `for a ${insets[side]}px inset — a media query threw the safe area away`,
+      );
+    }
+  }
+  // …and the same for the wide layout, which also restated the shorthand.
+  for (const { name, w, h, insets } of CASES) {
+    if (!(w >= 900 && h >= 620)) continue;
+    const pad = padding(".sg-anvil", { w, h }, insets);
+    for (const side of ["bottom", "left", "right"] as const) {
+      assert.ok(pad[side] >= insets[side] - 1e-9, `${name} (wide layout): ${side} padding lost the inset`);
+    }
+  }
+});
+
+test("the wave banner clears the safe area and the host's controls", () => {
+  // The banner is a child of `.sg-board`, so its offsets are board-relative.
+  // The board begins at least `.sg-top`'s padding-top down the page — the bar
+  // cannot have negative height — so that is the honest lower bound to use.
+  for (const { name, w, h, insets } of CASES) {
+    const barTop = padding(".sg-top", { w, h }, insets).top;
+    // `top: max(16%, …)`: the percentage is of a board height this test does not
+    // model, so it is given as 0. Worst case, and the only case worth asserting.
+    const top = lengthOf(".sg-banner", "top", { w, h }, insets, 0);
+    const left = lengthOf(".sg-banner", "left", { w, h }, insets, w);
+    const right = lengthOf(".sg-banner", "right", { w, h }, insets, w);
+    const box: Rect = { x: left, y: barTop + top, w: w - left - right, h: 1 };
+    inside(box, safeRect(w, h, insets), name, "the wave banner");
+    assert.equal(
+      hitsHostChrome(box, w, insets),
+      false,
+      `${name}: the wave banner is under the host's exit or how-to-play control`,
+    );
+  }
+});
+
+test("the overcharge overlay keeps its question and answers inside the safe area", () => {
+  for (const { name, w, h, insets } of CASES) {
+    const pad = padding(".sg-oc", { w, h }, insets);
+    const box: Rect = { x: pad.left, y: pad.top, w: w - pad.left - pad.right, h: h - pad.top - pad.bottom };
+    inside(box, safeRect(w, h, insets), name, "the overcharge overlay");
+  }
+});
+
+test("the defeat card clears the safe area and the host's controls", () => {
+  for (const { name, w, h, insets } of CASES) {
+    const pad = padding(".sg-end", { w, h }, insets);
+    const box: Rect = { x: pad.left, y: pad.top, w: w - pad.left - pad.right, h: h - pad.top - pad.bottom };
+    inside(box, safeRect(w, h, insets), name, "the defeat card");
+    assert.equal(
+      hitsHostChrome(box, w, insets),
+      false,
+      `${name}: the defeat card runs under the host's chrome`,
+    );
+    assert.ok(
+      pad.top >= insets.top + CHROME_BOTTOM - 1e-9,
+      `${name}: the defeat card starts at ${pad.top}px, above the host's controls which end at ` +
+        `${insets.top + CHROME_BOTTOM}px`,
+    );
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* The seam itself.                                                           */
+/* -------------------------------------------------------------------------- */
+
+test("no rule takes its answer from env() — it is zero where this game runs", () => {
+  const css = read("./styles.css").replace(/\/\*[\s\S]*?\*\//g, "");
+  const found = [...css.matchAll(/env\(safe-area-inset-(top|right|bottom|left)/g)];
+  assert.ok(found.length > 0, "the dev-harness fallbacks are gone entirely");
+  for (const m of found) {
+    const before = css.slice(Math.max(0, m.index - 32), m.index);
+    assert.ok(
+      before.endsWith(`var(--sg-safe-${m[1]}, `),
+      `env(safe-area-inset-${m[1]}) at ${m.index} is read directly, not as the fallback of ` +
+        `--sg-safe-${m[1]} — inside a pack frame that is the number zero`,
+    );
+  }
+});
+
+test("the safe area is published as four properties, zeros written out", () => {
+  const seen = new Map<string, string>();
+  const stub = { style: { setProperty: (n: string, v: string): void => void seen.set(n, v) } };
+  applySafeVars(stub, { top: 24, right: 0, bottom: 48, left: 0 });
+  assert.deepEqual(
+    [...seen.entries()].sort(),
+    [
+      ["--sg-safe-bottom", "48px"],
+      ["--sg-safe-left", "0px"],
+      ["--sg-safe-right", "0px"],
+      ["--sg-safe-top", "24px"],
+    ],
+  );
+  // A zero must be WRITTEN, not left unset: an absent property falls through to
+  // the `env()` fallback, which is the bug this whole file is about.
+  assert.equal(seen.get("--sg-safe-right"), "0px", "a zero inset was left for env() to answer");
+});
+
+test("republishing an unchanged safe area writes nothing", () => {
+  let writes = 0;
+  const stub = { style: { setProperty: (): void => void writes++ } };
+  const i: Insets = { top: 24, right: 0, bottom: 48, left: 0 };
+  assert.equal(applySafeVars(stub, i, null), true);
+  assert.equal(writes, 4);
+  assert.equal(applySafeVars(stub, { ...i }, i), false, "an unchanged inset was written again");
+  assert.equal(writes, 4);
+  assert.equal(applySafeVars(stub, { ...i, top: 47 }, i), true, "a rotation was not published");
+  assert.equal(writes, 8);
+});
+
+test("the host's own geometry is where these numbers come from", () => {
+  assert.equal(CHROME_BOTTOM, HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL);
+  assert.ok(chromeVars().includes(`--sg-chrome-bottom:${CHROME_BOTTOM}px`), "the stylesheet cannot see it");
+});
+
+test("the game publishes the insets before it measures against them", () => {
+  // A wiring check, and it is only that: the geometry above is computed, but
+  // nothing above can see whether `resize()` ever calls the publisher. It must,
+  // and it must do so first — the console's padding decides how much height is
+  // left for the board, so a board measured before the insets are published is
+  // a board measured against the previous rotation.
+  const mount = read("../mount.ts");
+  const at = mount.indexOf("private resize()");
+  assert.ok(at > 0, "resize() is gone");
+  const body = mount.slice(at, mount.indexOf("\n  }", at));
+  const publish = body.indexOf("this.hud.setInsets(");
+  const measure = body.indexOf("clientWidth");
+  assert.ok(publish > 0, "resize() never publishes the safe area — the stylesheet will read zeros");
+  assert.ok(measure > 0, "resize() no longer measures the board");
+  assert.ok(publish < measure, "the board is measured before the insets are published");
+  assert.ok(read("./hud.ts").includes("applySafeVars("), "the HUD never publishes the safe area at mount");
+});

--- a/dynawalla/games/siege/src/ui/styles.css
+++ b/dynawalla/games/siege/src/ui/styles.css
@@ -59,7 +59,13 @@
 
    All four edges honour the safe area, not just the top. `viewport-fit=cover`
    opts this document into the rounded corners on every side, and in landscape
-   the cutout is a SIDE inset — which is where the ember count lives. */
+   the cutout is a SIDE inset — which is where the ember count lives.
+
+   The safe area arrives as `--sg-safe-*`, written onto `.sg` by `applySafeVars`
+   from the host's own measurement. The `env()` inside each `var()` is the DEV
+   fallback and nothing else: a pack frame is cross-origin, so `env()` resolves
+   to zero there, and reading it directly is how this bar came to be painted
+   under an Android status bar. */
 .sg-top {
   display: flex;
   align-items: center;
@@ -67,9 +73,9 @@
   min-width: 0;
   overflow: hidden;
   padding: 8px 10px calc(8px) 10px;
-  padding-top: max(8px, env(safe-area-inset-top, 0px));
-  padding-left: calc(env(safe-area-inset-left, 0px) + var(--sg-corner, 54px));
-  padding-right: calc(env(safe-area-inset-right, 0px) + var(--sg-corner, 54px));
+  padding-top: max(8px, var(--sg-safe-top, env(safe-area-inset-top, 0px)));
+  padding-left: calc(var(--sg-safe-left, env(safe-area-inset-left, 0px)) + var(--sg-corner, 54px));
+  padding-right: calc(var(--sg-safe-right, env(safe-area-inset-right, 0px)) + var(--sg-corner, 54px));
   background: linear-gradient(#170f12, #100a0d);
   border-bottom: 1px solid var(--seam);
 }
@@ -305,17 +311,25 @@
 /* Portrait is the default shape: a full-width console under a square board.
    A phone screen is tall, the board can only be as wide as the screen, so the
    space left over belongs to the maths. */
+/* `--sg-pad` exists so the two layout media queries can change the console's
+   padding WITHOUT re-stating it as a shorthand. They used to: `padding: 8px` in
+   the short-viewport block reset all four longhands, and the three safe-area
+   rules below it were silently thrown away on exactly the shapes — a landscape
+   phone, a small window — where the home indicator is closest to the answer
+   buttons. A breakpoint that has to remember to re-apply the safe area is a
+   breakpoint that will forget. */
 .sg-anvil {
+  --sg-pad: 10px;
   position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto auto;
   gap: 10px;
   align-items: center;
-  padding: 10px;
-  padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
-  padding-left: max(10px, env(safe-area-inset-left, 0px));
-  padding-right: max(10px, env(safe-area-inset-right, 0px));
+  padding: var(--sg-pad);
+  padding-bottom: max(var(--sg-pad), var(--sg-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: max(var(--sg-pad), var(--sg-safe-left, env(safe-area-inset-left, 0px)));
+  padding-right: max(var(--sg-pad), var(--sg-safe-right, env(safe-area-inset-right, 0px)));
   background: linear-gradient(#150e11, #0d0709);
   border-top: 1px solid var(--seam);
 }
@@ -582,11 +596,16 @@
 
 .sg-banner {
   position: absolute;
-  left: env(safe-area-inset-left, 0px);
-  right: env(safe-area-inset-right, 0px);
+  left: var(--sg-safe-left, env(safe-area-inset-left, 0px));
+  right: var(--sg-safe-right, env(safe-area-inset-right, 0px));
   /* Below the host's controls even on a short landscape phone, where 16% of the
-     height is less than a 44px button. */
-  top: max(16%, calc(env(safe-area-inset-top, 0px) + 68px));
+     height is less than a 44px button. `--sg-chrome-bottom` is the host's own
+     geometry — hairline, margin, control — not a number typed in here.
+     No top inset in this sum: the banner is a child of `.sg-board`, and the
+     board already begins below a status bar that has paid the top inset in
+     full. Adding it again here would push the wave call a second inset down
+     the screen for a notch it has already cleared. */
+  top: max(16%, calc(var(--sg-chrome-bottom, 57px) + 11px));
   z-index: 8;
   display: grid;
   justify-items: center;
@@ -631,8 +650,10 @@
   place-content: center;
   justify-items: center;
   gap: 16px;
-  padding: calc(20px + env(safe-area-inset-top, 0px)) calc(20px + env(safe-area-inset-right, 0px))
-    calc(20px + env(safe-area-inset-bottom, 0px)) calc(20px + env(safe-area-inset-left, 0px));
+  padding: calc(20px + var(--sg-safe-top, env(safe-area-inset-top, 0px)))
+    calc(20px + var(--sg-safe-right, env(safe-area-inset-right, 0px)))
+    calc(20px + var(--sg-safe-bottom, env(safe-area-inset-bottom, 0px)))
+    calc(20px + var(--sg-safe-left, env(safe-area-inset-left, 0px)));
   background: radial-gradient(circle at 50% 46%, rgba(60, 12, 4, 0.72), rgba(6, 3, 4, 0.94));
   backdrop-filter: blur(3px);
   animation: sg-oc-in 0.24s ease-out;
@@ -700,8 +721,13 @@
   place-content: center;
   justify-items: center;
   gap: 10px;
-  padding: calc(env(safe-area-inset-top, 0px) + 68px) calc(env(safe-area-inset-right, 0px) + 12px)
-    calc(env(safe-area-inset-bottom, 0px) + 12px) calc(env(safe-area-inset-left, 0px) + 12px);
+  /* The top is the host's chrome plus air, not a bare 68: the defeat card is a
+     child of `.sg` and its heading DOES have to clear the exit and how-to-play
+     controls, which the banner does not. */
+  padding: calc(var(--sg-safe-top, env(safe-area-inset-top, 0px)) + var(--sg-chrome-bottom, 57px) + 11px)
+    calc(var(--sg-safe-right, env(safe-area-inset-right, 0px)) + 12px)
+    calc(var(--sg-safe-bottom, env(safe-area-inset-bottom, 0px)) + 12px)
+    calc(var(--sg-safe-left, env(safe-area-inset-left, 0px)) + 12px);
   background: rgba(5, 3, 4, 0.9);
   animation: sg-oc-in 0.6s ease-out;
 }
@@ -746,10 +772,12 @@
    `orientation`, which does not answer the question being asked. */
 @media (max-height: 619px) {
   .sg-anvil {
+    /* `--sg-pad`, never `padding: 8px` — the shorthand would take the safe-area
+       longhands with it and put the answer buttons under a home indicator. */
+    --sg-pad: 8px;
     grid-template-columns: minmax(0, 1fr) 116px;
     grid-template-rows: auto;
     gap: 8px;
-    padding: 8px;
   }
   .sg-slugs { grid-template-columns: repeat(4, 1fr); gap: 7px; }
   .sg-slug { height: clamp(42px, 13vh, 68px); font-size: clamp(18px, 3.2vw, 26px); }
@@ -791,9 +819,7 @@
     border-top: 0;
     border-left: 1px solid var(--seam);
     gap: 14px;
-    padding: 14px;
-    padding-right: max(14px, env(safe-area-inset-right, 0px));
-    padding-bottom: max(14px, env(safe-area-inset-bottom, 0px));
+    --sg-pad: 14px;
   }
   .sg-pal { display: grid; }
   .sg-anvil::before {


### PR DESCRIPTION
Founder: *"siege is almost great but it doesn't respect the safe area on Android at least."*

1080x2340, portrait, three-button navigation. `EMBERS 113 / DPS 111 / WAVE 5 / HP IN 615` under the OS status bar, with the clock and the 5G indicator painted over them. `OVERCHARGE 27` and its meter behind the navigation bar. The board, the prompt and the four answer buttons in between: fine.

## What it actually was

That split *is* the diagnosis. SIEGE read the safe area twice, from two different places, and only one of them worked.

- `mount.ts` fitted the canvas against `game-chrome`'s `safeInsets()` — the host's own measurement, delivered over the `settings` channel. Correct. Hence the healthy middle.
- `styles.css` read `env(safe-area-inset-*)` **directly**. A pack runs in an iframe sandboxed `allow-scripts` with no `allow-same-origin`; `env(safe-area-inset-*)` is a property of the top-level browsing context, and a cross-origin child resolves all four to **zero**. Every DOM rule collapsed to its `8px`/`10px` fallback.

So: **siege applied insets to only part of its layout — the canvas half from the shared module, the DOM half from an `env()` that is always zero inside a pack frame.**

The stylesheet now reads `var(--sg-safe-*, env(...))`; `applySafeVars` writes those four properties onto the root from `safeInsets()`, with zeros written out explicitly (an absent property falls through to the `env()`, which is the bug). `resize()` republishes before it measures — the console's padding decides how much height is left for the board.

## A second defect, found on the way in

`@media (max-height: 619px)` set `padding: 8px` on `.sg-anvil`. A shorthand resets all four longhands, so the three safe-area rules above it were discarded on **every landscape phone** — the shape where the home indicator sits closest to the answer buttons. The console's padding is now a `--sg-pad` custom property a breakpoint can change without going near the safe area. The wide layout restated the same shorthand and had the same hole.

## Host chrome

Already handled and now asserted: the bar's contents start after `exitRect` and stop before `helpRect` (`CORNER_CLEAR`), the defeat card starts below `CHROME_BOTTOM` (derived from `HOST_PROGRESS_H + HOST_MARGIN + HOST_CONTROL`, not typed in), and the wave banner clears both. The banner's `top` **dropped** the top inset it used to add: it is a child of `.sg-board`, which already begins below a bar that has paid that inset in full, and adding it again pushed the wave call a second notch down the screen.

Nothing was reserved and no band was taken. The playfield did not lose a pixel.

## Why the old test did not catch this

`chrome.test.ts` asserted `body.includes("env(safe-area-inset-top")`. That was **true** on the day SIEGE shipped its currency under a clock. The rule was in the file; the rule evaluated to zero. A substring search proves text is present and says nothing about what it resolves to. That test is rewritten, with the lesson left in the file.

`safearea.test.ts` parses `styles.css` for real — comments, media queries, the cascade, shorthand expansion, custom properties — and evaluates every chrome element's padding to a **number**, with one rule baked into the evaluator:

    env(safe-area-inset-*) evaluates to ZERO

which is not a simplification but the environment the game runs in. Ten shapes: the founder's phone in three orientations, 320x568, a notched phone portrait and landscape (cutout one side and both), two tablets, and the wide layout.

## Verification

- `npm run -s tsc` clean; suite **48/48, five consecutive runs**.
- `node packs/build.mjs siege` builds and passes the SDK checker.
- Also driven through a **real headless Chromium** at seven viewports, because a parser can still be wrong about the cascade. Founder's portrait shape, measured from `getBoundingClientRect`: EMBERS top edge **y=8 → y=24** (the status bar), OVERCHARGE bottom edge **y=841 → y=803**, which is exactly `851 - 48`. Landscape with the nav bar on the right: console `padding-right` **8px → 48px** — the short-viewport shorthand bug, gone.
- All **30 build sockets** checked against `exitRect`/`helpRect` in the real browser at all seven shapes: **zero under host chrome**, topmost socket edge y=122.5 against a chrome bottom of y=81 on the founder's phone. The playfield needed no clearance, so it was given none.

## Mutation transcript

Every new assertion was broken on purpose and confirmed to fail.

| mutation | result |
|---|---|
| **Zero the insets** — `applySafeVars` publishes `0` for all four | **9 tests fail** |
| `.sg-anvil` reads bare `env()` for its bottom (the shipped bug) | 4 fail |
| `padding: 8px` shorthand restored in the short-viewport query | 2 fail |
| `this.hud.setInsets()` deleted from `resize()` | 1 fail |
| `CHROME_BOTTOM = 0` | 3 fail |
| `.sg-banner` `left`/`right` set to `0px` | 1 fail |

The headline one, zeroing the insets:

```
✖ the status bar's figures are inside the safe area at every shape
  the founder's phone, portrait — status bar and three-button nav:
  the status bar's figures crosses the TOP inset (8 < 24)

✖ the anvil — prompt, answers and overcharge — is inside the safe area at every shape
  the founder's phone, portrait — status bar and three-button nav:
  the overcharge meter is under the navigation bar (bottom edge 841, safe ends at 803)

✖ a breakpoint cannot quietly delete the console's safe-area padding
  the founder's phone, landscape — nav bar on the right (short viewport):
  the console's right padding is 8px for a 48px inset — a media query threw the safe area away

✖ the status bar's figures never sit under the host's two controls
  the founder's phone, landscape — nav bar on the right: the bar's figures run under
  the host's chrome — bar x 54..797, exit 10..54, help 749..793

✖ the wave banner clears the safe area and the host's controls
✖ the overcharge overlay keeps its question and answers inside the safe area
  ... crosses the TOP inset (20 < 24)
✖ the defeat card clears the safe area and the host's controls
  ... crosses the BOTTOM inset (839 > 803)
✖ the safe area is published as four properties, zeros written out
✖ republishing an unchanged safe area writes nothing
```

Restoring each mutation returns the suite to 48/48.

## Not in this PR

Gameplay, difficulty, board size and the answer buttons are untouched. `stack` and `polarity` and `claim` still read `env()` from their own stylesheets and have the same latent defect; that is a separate change.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb