### PR TITLE
dynawalla/games/skyledger: the first screen is ONE ledger line, and the board opens on right answers

### DIFF
--- a/dynawalla/games/skyledger/src/game/game.ts
+++ b/dynawalla/games/skyledger/src/game/game.ts
@@ -41,6 +41,7 @@
 import type { Host, Question } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
 import { Escalation, type Channels, type Release } from "./escalation.ts"
+import { openingAt, revealFor, stepFor, type Opening } from "./opening.ts"
 import {
   RINGS,
   answerOf,
@@ -103,7 +104,14 @@ export type Star = {
   askedAt: number
   /** Set once the child has sighted it, so latency is thinking time. */
   taken: boolean
-  state: "falling" | "caught" | "landed"
+  /**
+   * `shown` is the calm opening's outcome: the mark went wide, the observatory
+   * completed the sum in front of the child, and the star came off the sky. It
+   * is not a bloom (nothing is logged, no link, no lamp relit) and it is not a
+   * landing (no lamp goes out). It was already reported, once, when the mark
+   * went wide, and it is never reported again.
+   */
+  state: "falling" | "caught" | "landed" | "shown"
 }
 
 export type GameEvent =
@@ -112,6 +120,7 @@ export type GameEvent =
   | { kind: "refused"; reason: "dry" | "nothing-sighted" }
   | { kind: "bloom"; star: Star; station: Station; channels: Channels; link: number }
   | { kind: "wide"; star: Star; station: Station; value: number; recognised: boolean }
+  | { kind: "shown"; star: Star; line: string }
   | { kind: "release"; release: Release }
   | { kind: "land"; star: Star; lamp: number }
   | { kind: "watch"; watch: number; logged: number; relit: boolean }
@@ -154,14 +163,38 @@ export class Game {
   private over = false
   private stalledFlag = false
 
+  /**
+   * Stars this child has ever logged. Seeded from `game/seen.ts` at the shell
+   * and only ever climbs, including across a `restart` — a run ending is not a
+   * reason to forget that the child can do this.
+   */
+  private competence: number
+  private opening: Opening
+
+  /**
+   * A sum the observatory completed in front of the child, held until they take
+   * it down. Nothing moves while it is up: the sky, the chain, the refill and
+   * the input are all stopped, because a lesson a child is reading must not
+   * cost them a lamp.
+   */
+  private held: { star: Star; line: string; at: number } | null = null
+
   readonly ledger: Ledger = { logged: 0, watches: 0, longest: 0, wide: 0 }
 
-  constructor(host: Host, rng: Rng, now: number, reduced: boolean) {
+  /**
+   * `experience` — stars logged in every previous sitting — is REQUIRED, not
+   * defaulted. Every construction site has to state it, so no shell can quietly
+   * hand a child who has played for a month the first-minute opening, or a child
+   * who has never seen the astrolabe four sums at once.
+   */
+  constructor(host: Host, rng: Rng, now: number, reduced: boolean, experience: number) {
     this.host = host
     this.rng = rng
     this.chain = new Escalation(reduced)
     this.clock = now
     this.refillAt = now + REFILL_MS
+    this.competence = Number.isFinite(experience) ? Math.max(0, Math.floor(experience)) : 0
+    this.opening = openingAt(stepFor(this.competence))
   }
 
   /** Open the first watch. Separate from the constructor so events can be seen. */
@@ -229,6 +262,37 @@ export class Game {
 
   get stalled(): boolean {
     return this.stalledFlag
+  }
+
+  /** Which position on the ramp this sitting currently stands at. */
+  get opened(): Opening {
+    return this.opening
+  }
+
+  /**
+   * The sum the observatory has completed and is holding, or `null`.
+   *
+   * A finished sentence — `247 + 225 = 472` — and nothing else: no verdict, no
+   * adjective, no colour named here. It is built in the rules because the render
+   * layer is not allowed to see an answer.
+   */
+  get shown(): string | null {
+    return this.held?.line ?? null
+  }
+
+  /**
+   * The line the sighted star's plate should read, or `null` when the opening is
+   * past needing it.
+   *
+   * The right-hand side is the child's OWN reading off the astrolabe, live, so
+   * this tells them nothing they did not produce — it only says where the number
+   * they are making is going to stand.
+   */
+  get guide(): string | null {
+    if (!this.opening.reading) return null
+    const star = this.sighted
+    const value = this.reading
+    return star && value !== null ? `${star.item.prompt} = ${value}` : null
   }
 
   // ── the verbs ─────────────────────────────────────────────────────────────
@@ -304,10 +368,51 @@ export class Game {
       // saying something untrue about the sky, and the light goes out on it.
       const release = this.chain.cut()
       if (release) events.push({ kind: "release", release })
+
+      // The calm opening finishes the sum rather than leaving the child to
+      // guess again. The star comes off the sky WITH the reveal — not because a
+      // second try would be unkind, but because a child who has just been shown
+      // `247 + 225 = 472` and then dials 472 would be reported as having worked
+      // it out, and the register would be lying about them. It was reported
+      // once, above, as the wrong answer it was. That is the honest entry.
+      if (truth !== null && revealFor(this.opening).holdMs > 0) {
+        star.state = "shown"
+        if (star.id === this.sightedId) this.sightedId = -1
+        const line = `${star.item.prompt} = ${truth}`
+        this.held = { star, line, at: now }
+        events.push({ kind: "shown", star, line })
+      }
       return events
     }
 
     return this.bloom(star, value, now)
+  }
+
+  /**
+   * The child takes a completed sum down.
+   *
+   * `settleMs` is the only thing between the reveal going up and the child being
+   * able to dismiss it, and it is short on purpose: a lockout is its own
+   * rudeness, and all this one does is make sure the tap that lands was meant —
+   * the second tap of an impatient double-tap arrives inside it. There is no
+   * ceiling. `revealPlan` gives `holdMs: Infinity` and nothing in this file
+   * counts it down; the reveal ends when a hand ends it.
+   */
+  dismiss(now: number): GameEvent[] {
+    const held = this.held
+    if (!held || this.paused || this.over) return []
+    if (now - held.at < revealFor(this.opening).settleMs) return []
+    this.held = null
+    // Put the next line under the sight, the way a bloom does. The sky is
+    // exactly where the child left it — nothing fell while they were reading.
+    const next = this.lowestFalling()
+    if (!next) return []
+    this.sightedId = next.id
+    if (!next.taken) {
+      next.taken = true
+      next.askedAt = now
+    }
+    return [{ kind: "sight", star: next }]
   }
 
   /**
@@ -319,7 +424,10 @@ export class Game {
    * descent while the blooms play.
    */
   tick(dt: number, now: number): GameEvent[] {
-    if (this.paused || this.over || this.stalledFlag) return []
+    // A held reveal stops the world exactly as a pause does. A child reading the
+    // sum they just got wrong must not be losing lamps behind it, and the chain
+    // they were in the middle of must not expire while they read.
+    if (this.paused || this.over || this.stalledFlag || this.held !== null) return []
     this.clock = now
     this.world += Math.max(0, dt)
     const events: GameEvent[] = []
@@ -334,9 +442,21 @@ export class Game {
       this.refillAt = now + REFILL_MS
     }
 
+    // How many ledger lines are already in the air and readable. This is the
+    // number the founder's report is about, and it is the number the opening
+    // caps: a star waits for its gap on the world clock AND for room on the
+    // board. At `onBoard: Infinity` the second test cannot fire and release is
+    // the shipped 2.6-second cadence, unchanged.
+    let onBoard = 0
+    for (const star of this.sky) if (star.state === "falling" && star.t > 0) onBoard += 1
+
     for (const star of this.sky) {
       if (star.state !== "falling") continue
-      if (this.world < star.releaseIn) continue
+      if (star.t === 0) {
+        if (this.world < star.releaseIn) continue
+        if (onBoard >= this.opening.onBoard) continue
+        onBoard += 1
+      }
       star.t += dt / star.fallMs
       if (star.t < 1) continue
       star.t = 1
@@ -401,12 +521,18 @@ export class Game {
     for (const star of this.sky) star.askedAt += by
     this.chain.shift(by)
     this.refillAt += by
+    // A reveal's settle is a wall-clock mark like any other. Without this a
+    // thirty-second sheet raised over a held sum would hand it back already
+    // dismissible, and the tap that took the sheet down would take the lesson
+    // with it.
+    if (this.held) this.held.at += by
   }
 
   /** Start the next run after the ledger page. */
   restart(now: number): GameEvent[] {
     if (!this.over) return []
     this.over = false
+    this.held = null
     this.lampsLit = LAMPS
     this.watchNo = 0
     this.ledger.logged = 0
@@ -421,7 +547,7 @@ export class Game {
   // ── internals ─────────────────────────────────────────────────────────────
 
   private active(): boolean {
-    return !this.paused && !this.over && !this.stalledFlag
+    return !this.paused && !this.over && !this.stalledFlag && this.held === null
   }
 
   /**
@@ -456,6 +582,11 @@ export class Game {
       star.state = "caught"
       this.ledger.logged += 1
       this.loggedThisWatch += 1
+      // The one thing the ramp is indexed by, and it is banked here — at the
+      // moment a true assertion is made — rather than at a watch boundary or on
+      // a clock. `mount.ts` writes the same event to storage so it survives the
+      // sitting.
+      this.competence += 1
       const channels = this.chain.link(now)
       this.ledger.longest = Math.max(this.ledger.longest, this.chain.links)
       events.push({
@@ -516,9 +647,17 @@ export class Game {
     this.world = 0
     this.sky = []
     this.sightedId = -1
+    this.held = null
+
+    // Where the child stands NOW. Read once per watch rather than per frame, so
+    // a watch has one shape from end to end — but read every watch, so a child
+    // who earns the second line does not have to close the game to be given it.
+    this.opening = openingAt(stepFor(this.competence))
 
     const count = Math.min(WATCH_MAX, WATCH_BASE + (this.watchNo - 1) * WATCH_STEP)
-    const fallMs = Math.max(FALL_FLOOR_MS, FALL_BASE_MS - (this.watchNo - 1) * FALL_STEP_MS)
+    const fallMs =
+      Math.max(FALL_FLOOR_MS, FALL_BASE_MS - (this.watchNo - 1) * FALL_STEP_MS) *
+      this.opening.fall
 
     for (let i = 0; i < count; i++) {
       const item = this.drawOne()

--- a/dynawalla/games/skyledger/src/game/opening.ts
+++ b/dynawalla/games/skyledger/src/game/opening.ts
@@ -1,0 +1,161 @@
+// THE OPENING — what a child who has never worked a ledger line walks into.
+//
+// The founder's report, verbatim, is the specification:
+//
+// > "sky ledger is pretty cool. but to start it needs to be Wayy slower. only
+// > one problem to look at and maybe even a tutorial. only once the user has
+// > proven they have the hang of it should we put more than one problem on the
+// > board"
+//
+// ## What it opened with before
+//
+// Measured by driving the real `Game` against the stub host over sixty seeds,
+// counting the ledger lines actually falling and readable — `state === "falling"
+// && t > 0`, which is exactly what `mount.view` hands the renderer:
+//
+//   * **one** on the first frame, and then
+//   * **two at 2.6 s, three at 5.2 s, four at 7.8 s**, every seed, because a
+//     watch releases its whole set on a fixed 2.6-second gap and does not care
+//     whether the child has finished the first one;
+//   * **five inside the first minute**, because a watch of four that nobody
+//     answered lands, and the next watch opens with five.
+//
+// A child who has never seen the astrolabe has, eight seconds in, four column
+// sums in the air and one dial. That is the report.
+//
+// ## The ramp
+//
+// Six positions, indexed by **stars this child has ever marked correctly** —
+// `game/seen.ts` remembers that across sittings, and `Game` keeps counting
+// within one, so the board opens up during the sitting the child earns it in.
+// It is a count of things they got RIGHT: not seconds elapsed, not watches
+// survived, not a difficulty scalar. `LOGGED_AT` is the whole index.
+//
+//   0. **One ledger line.** One sum in the air at a time, falling at not much
+//      over half the ordinary rate, with the child's own reading written into
+//      the sum on the plate. The next star waits for the first to be gone.
+//   1. Still one, a little quicker.
+//   2. Two. The first time there is a choice of what to work.
+//   3. Three.
+//   4. Four, at the shipped descent. The written reading comes off.
+//   5. and after: the game exactly as it shipped.
+//
+// Every quantity is **monotone in `step`** — `onBoard` non-decreasing, `fall`
+// non-increasing, `reading` and the reveal non-increasing — and
+// `opening.test.ts` asserts all four exhaustively rather than taking the table
+// on trust. A child is never overtaken by their own progress.
+//
+// ## What this is NOT
+//
+// It is not a comprehension window and it does not add one. `fall` scales the
+// descent SKY LEDGER has always had; nothing here reads a clock, a rate, a
+// streak or an accuracy, and `openingAt` is a pure function of one integer that
+// counts stars the child logged. The pacing audit's finding — seventeen games
+// deriving the time-to-answer from the same constant that escalates the game —
+// is why `fall` is a pure function of demonstrated competence and of nothing
+// else: it does not move with the watch number, the chain, or the wall clock.
+
+import { revealPlan, SECOND_GRADE_FLOW, type RevealPlan } from "../../../../packs/shared/game-pacing/index.ts"
+
+/**
+ * Steps that have a hand on them. `openingAt(5)` and everything above it is the
+ * shipped game, so a test or a rig can say "a child who is past all this"
+ * without knowing the table.
+ */
+export const CALM_STEPS = 5
+
+export type Opening = {
+  readonly step: number
+  /**
+   * The most ledger lines that may be in the air at once.
+   *
+   * `1` is the founder's one problem: a watch still holds four stars, but the
+   * second waits until the first has bloomed, been shown or landed.
+   * `Infinity` hands release back to the watch's own 2.6-second gap, which is
+   * what the game has always done.
+   */
+  readonly onBoard: number
+  /**
+   * A multiplier on how long a star takes to reach the horizon. `1` is the
+   * shipped descent.
+   */
+  readonly fall: number
+  /**
+   * Whether the sighted star's plate is written out as a whole sentence —
+   * `247 + 225 = 74` — with the right-hand side being the child's OWN reading
+   * off the astrolabe, live.
+   *
+   * This is the entire tutorial, and it is arithmetic rather than prose: it
+   * says *what the two rings are for* by showing the number they are producing
+   * standing where the answer goes. It reveals nothing — the value is the
+   * child's, not the star's — and it adds no string to translate.
+   */
+  readonly reading: boolean
+  /**
+   * What `revealPlan` is asked about at this step. Climbs across the calm steps
+   * and lands on 1 at the shipped game.
+   *
+   * The top calm value is 0.6 and that is not free choice: `revealShown` draws
+   * its own line at 250 ms, which on `SECOND_GRADE_FLOW`'s numbers and the
+   * `steep` curve `revealMs` reads them through falls at intensity ≈0.756. Every
+   * calm step therefore sits above the line with room, and the shipped game sits
+   * below it and shows nothing.
+   */
+  readonly intensity: number
+}
+
+const CALM: readonly Omit<Opening, "step">[] = [
+  { onBoard: 1, fall: 1.7, reading: true, intensity: 0 },
+  { onBoard: 1, fall: 1.5, reading: true, intensity: 0.15 },
+  { onBoard: 2, fall: 1.3, reading: true, intensity: 0.3 },
+  { onBoard: 3, fall: 1.15, reading: true, intensity: 0.45 },
+  { onBoard: 4, fall: 1, reading: false, intensity: 0.6 },
+]
+
+const STEADY: Omit<Opening, "step"> = {
+  onBoard: Number.POSITIVE_INFINITY,
+  fall: 1,
+  reading: false,
+  intensity: 1,
+}
+
+/**
+ * Stars logged at which each step begins.
+ *
+ * Achievement, not wall clock: a child who sits and watches four stars land
+ * stays at step 0 forever, and a child who marks three correctly is at step 2
+ * whether that took them thirty seconds or three sittings.
+ */
+export const LOGGED_AT: readonly number[] = [0, 1, 3, 6, 10, 15]
+
+/** How many stars a child has to have logged before the ramp is behind them. */
+export const LOGGED_PAST_CALM = LOGGED_AT[CALM_STEPS] as number
+
+/** The step a child who has logged `logged` stars, ever, stands at. */
+export function stepFor(logged: number): number {
+  const n = Number.isFinite(logged) ? Math.max(0, Math.floor(logged)) : 0
+  let step = 0
+  for (let i = 0; i < LOGGED_AT.length; i++) {
+    if (n >= (LOGGED_AT[i] as number)) step = i
+  }
+  return step
+}
+
+/** The opening at `step`. Pure, total, defined for every number. */
+export function openingAt(step: number): Opening {
+  const at = Number.isFinite(step) ? Math.max(0, Math.floor(step)) : 0
+  const row = at < CALM.length ? (CALM[at] as Omit<Opening, "step">) : STEADY
+  return { step: at, ...row }
+}
+
+/**
+ * What to do with a sum this opening has just completed for the child.
+ *
+ * `holdMs` is `Infinity` at every calm step — nothing but the child's own hand
+ * takes a reveal down — and `0` at the shipped game, where there is no reveal at
+ * all. The decision is `packs/shared/game-pacing`'s, not this module's; all this
+ * does is hand it the intensity.
+ */
+export function revealFor(opening: Opening): RevealPlan {
+  return revealPlan(SECOND_GRADE_FLOW, opening.intensity)
+}

--- a/dynawalla/games/skyledger/src/game/seen.ts
+++ b/dynawalla/games/skyledger/src/game/seen.ts
@@ -1,0 +1,71 @@
+// How many stars this child has ever logged — marked, correctly.
+//
+// The one thing the calm opening reads, and it is never shown to anybody. It is
+// not a score and it is not accuracy: it counts assertions the child made that
+// were true, which is the only signal that distinguishes "has never worked a
+// ledger line" from "has done a hundred of them". A child coming back to a
+// second sitting does not get walked through the first minute again.
+//
+// It is deliberately NOT `best.ts`'s longest chain. A chain is a rhythm, and a
+// child can be entirely fluent at column addition and never run one; what the
+// board opening up has to be paid for with is right answers.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, so every access is guarded and the value is held in memory as well,
+// exactly as `best.ts` does. When storage is unreachable the failure mode is
+// that a child gets the calm opening again next sitting, which is the right way
+// round: an extra gentle first minute costs nothing, and dropping a first-time
+// child into four sums at once is the report this work came from.
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const LOGGED_SLOT = "dw.skyledger.logged" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn("[skyledger] localStorage is not reachable from this frame", error)
+    return null
+  }
+}
+
+/** Stars logged, ever, across every sitting this device remembers. */
+export function loggedEver(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(LOGGED_SLOT) ?? "0")
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn("[skyledger] the logged count could not be read back", error)
+    }
+  }
+  return memory
+}
+
+/** One more. Returns the new total. */
+export function noteLogged(): number {
+  const next = loggedEver() + 1
+  memory = next
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(LOGGED_SLOT, String(next))
+    } catch (error) {
+      console.warn("[skyledger] the logged count could not be written", error)
+    }
+  }
+  return next
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetLoggedForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/skyledger/src/mount.ts
+++ b/dynawalla/games/skyledger/src/mount.ts
@@ -30,12 +30,13 @@
 // particles spawned by the impact are already on screen, so the freeze contains
 // the flash rather than preceding it.
 
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import { Audio } from "./audio/audio.ts"
 import type { Host } from "./contract.ts"
 import { unit } from "./core/feel.ts"
 import { Rng } from "./core/rng.ts"
 import { bestChain, recordChain } from "./game/best.ts"
+import { loggedEver, noteLogged } from "./game/seen.ts"
 import { CHAIN_CAP } from "./game/escalation.ts"
 import { Game, LAMPS, SIGHTINGS, type GameEvent } from "./game/game.ts"
 import { angleAt, ringAt, type Ring } from "./render/astrolabe.ts"
@@ -75,7 +76,9 @@ export function mountSkyLedger(
     return typeof performance === "object" ? performance.now() : Date.now()
   }
 
-  const game = new Game(host, new Rng(seed), now(), reduced)
+  // The calm opening's index: stars this child has logged in every previous
+  // sitting. Read ONCE, here — the rules keep counting within the sitting.
+  const game = new Game(host, new Rng(seed), now(), reduced, loggedEver())
   let best = bestChain()
 
   let running = true
@@ -119,6 +122,9 @@ export function mountSkyLedger(
         case "bloom": {
           scene.addBloom(event.star, event.station, unit(event.link / CHAIN_CAP), event.link)
           logged.add(event.station.y * 10 + event.station.x)
+          // The write side of the ramp. One true assertion, banked, so tomorrow
+          // starts where today finished.
+          noteLogged()
           audio.bloom(event.link)
           host.haptic(event.link >= 4 ? "heavy" : "success")
           hitstopLeft = Math.max(hitstopLeft, event.channels.hitstopMs)
@@ -134,6 +140,16 @@ export function mountSkyLedger(
           scene.addCold(event.station)
           audio.wide()
           host.haptic(event.recognised ? "light" : "medium")
+          break
+        }
+        case "shown": {
+          // The observatory finishes the sum and holds it. No shake, no red,
+          // no buzzer: the register is writing a line out. What is DRAWN comes
+          // from `game.shown` on every frame, because the reveal has no
+          // duration — it is up until a hand takes it down — so it cannot be a
+          // fading effect the scene owns.
+          audio.wide()
+          host.haptic("light")
           break
         }
         case "refused": {
@@ -184,6 +200,12 @@ export function mountSkyLedger(
 
   const view = (t: number): SceneState => {
     const sighted = game.sighted
+    // The whole tutorial, and it is one string the rules built out of the star's
+    // own prompt and the child's own reading: the sighted plate says
+    // `247 + 225 = 74` while the rings stand at 74. Nothing is revealed — the
+    // right-hand side is theirs — and no new copy is shipped, which matters at
+    // fifty locales. `null` once the opening is past needing it.
+    const plate = game.guide
     const stars: StarView[] = game.stars
       .filter((s) => s.state === "falling")
       .map((s) => ({
@@ -191,7 +213,7 @@ export function mountSkyLedger(
         lane: s.lane,
         t: s.t,
         order: s.order,
-        prompt: s.item.prompt,
+        prompt: plate !== null && sighted?.id === s.id ? plate : s.item.prompt,
         sighted: sighted?.id === s.id,
         visible: s.t > 0,
       }))
@@ -203,6 +225,7 @@ export function mountSkyLedger(
       bloom: bloomLevel,
       chromaRpx: chroma,
       stalled: game.stalled,
+      shown: game.shown,
       over: game.isOver
         ? { ...game.ledger, best: Math.max(best, game.ledger.longest) }
         : null,
@@ -264,6 +287,14 @@ export function mountSkyLedger(
     pointer = e.pointerId
     canvas.setPointerCapture?.(e.pointerId)
     const { px, py } = local(e)
+
+    // A held sum is taken down by the same hand that would have done anything
+    // else. Checked FIRST, and it consumes the gesture: a tap that lands on the
+    // dial while the lesson is up must not also turn a ring.
+    if (game.shown !== null) {
+      apply(game.dismiss(now()))
+      return
+    }
 
     if (game.isOver) {
       apply(game.restart(now()))
@@ -339,6 +370,12 @@ export function mountSkyLedger(
    */
   const onKey = (e: KeyboardEvent): void => {
     if (paused) return
+    if (game.shown !== null) {
+      // Any key, and only the dismissal. The rings must not move under a lesson.
+      e.preventDefault()
+      apply(game.dismiss(now()))
+      return
+    }
     switch (e.key) {
       case "ArrowRight":
         apply(game.dial("ones", 1))
@@ -379,6 +416,15 @@ export function mountSkyLedger(
   const observer =
     typeof ResizeObserver === "function" ? new ResizeObserver(() => scene.resize()) : null
   observer?.observe(canvas)
+  // The safe rect is not a constant and it does not always move with the canvas
+  // box. `env(safe-area-inset-*)` resolves to ZERO inside a pack frame — the
+  // document is opaque-origin, and `env()` is a property of the TOP-LEVEL
+  // browsing context — so the real numbers arrive from the host on the
+  // `settings` channel, AFTER this shell has already laid itself out once, and
+  // change again on a Split View resize that leaves the canvas the same shape.
+  // `Layout` is computed from `safeRect()` at `resize` and nowhere else, so
+  // without this the astrolabe and the lattice stay where the zeros put them.
+  const unwatchInsets = onInsetsChange(() => scene.resize())
 
   // ── the pause ────────────────────────────────────────────────────────────
   // One pair, reached from two places: the host, through the handle below, and
@@ -493,6 +539,7 @@ export function mountSkyLedger(
       canvas.removeEventListener("pointercancel", onUp)
       globalThis.removeEventListener("keydown", onKey)
       globalThis.removeEventListener("resize", onResize)
+      unwatchInsets()
       observer?.disconnect()
       audio.close()
       canvas.remove()

--- a/dynawalla/games/skyledger/src/render/scene.ts
+++ b/dynawalla/games/skyledger/src/render/scene.ts
@@ -24,6 +24,7 @@ import {
   FIGURE_FONT,
   LAPIS_LIT,
   OXIDE,
+  PLATE_FONT,
   sized,
   STARLIGHT,
   STONE,
@@ -66,6 +67,15 @@ export type SceneState = {
   chromaRpx: number
   over: { logged: number; watches: number; longest: number; wide: number; best: number } | null
   stalled: boolean
+  /**
+   * A sum the observatory completed for the child, already written out as a
+   * finished sentence by the rules — `247 + 225 = 472`.
+   *
+   * It is STATE, not an effect: there is no age, no life and no fade, because
+   * the reveal ends when a hand ends it and this layer is not allowed to have an
+   * opinion about when that is. `null` when nothing is held.
+   */
+  shown: string | null
 }
 
 export class Scene {
@@ -232,8 +242,56 @@ export class Scene {
 
     drawAstrolabe(g, l, state.dial, state.held, this.reduced)
 
+    if (state.shown !== null) this.drawShown(state.shown)
     if (state.stalled) this.drawStalled()
     if (state.over) this.drawLedgerPage(state.over)
+  }
+
+  /**
+   * The sum, finished, held.
+   *
+   * Drawn in BRASS_LIT — the accent this observatory writes its own record in,
+   * the same ink as a logged station and the ledger page. Never `OXIDE`, which
+   * is this palette's refusal colour, and never red: the child has already been
+   * told the mark went wide by the cold ring that is still on the plane behind
+   * this. What is on the glass now is the line completed, which is the lesson,
+   * and a lesson is not a scolding.
+   *
+   * No timer anywhere in here. `Scene` is not told how long this has been up and
+   * has no way to take it down.
+   */
+  private drawShown(line: string): void {
+    const g = this.g
+    const l = this.layout
+    const cx = l.sky.x + l.sky.w / 2
+    const cy = l.sky.y + l.sky.h / 2
+
+    // A scrim over the sky only. The astrolabe stays lit and legible underneath,
+    // because the next thing the child does is turn it.
+    g.fillStyle = "rgba(5, 8, 16, 0.82)"
+    g.fillRect(l.sky.x, l.sky.y, l.sky.w, l.sky.h)
+
+    let size = Math.max(16, Math.min(l.cell * 0.92, 44 * Math.max(1, l.rpx * 1.4)))
+    g.textAlign = "center"
+    g.textBaseline = "middle"
+    // The line is the whole event, so it is fitted to the room rather than
+    // clipped: a four-digit sum on a phone must still be readable end to end.
+    const room = l.sky.w * 0.86
+    for (let i = 0; i < 8; i++) {
+      g.font = sized(PLATE_FONT, size)
+      if (g.measureText(line).width <= room) break
+      size *= 0.88
+    }
+    g.font = sized(PLATE_FONT, size)
+
+    g.strokeStyle = alpha(BRASS, 0.8)
+    g.lineWidth = Math.max(1, l.rpx * 2.5)
+    const pw = Math.min(room + size, l.sky.w * 0.94)
+    const ph = size * 2.4
+    g.strokeRect(cx - pw / 2, cy - ph / 2, pw, ph)
+
+    g.fillStyle = BRASS_LIT
+    g.fillText(line, cx, cy)
   }
 
   private drawRelease(): void {

--- a/dynawalla/games/skyledger/src/test/harness.ts
+++ b/dynawalla/games/skyledger/src/test/harness.ts
@@ -8,6 +8,7 @@
 
 import { Rng } from "../core/rng.ts"
 import { Game } from "../game/game.ts"
+import { LOGGED_PAST_CALM } from "../game/opening.ts"
 import { answerOf, orderOf, stationOf, type Station } from "../game/station.ts"
 import type { Star } from "../game/game.ts"
 import { createStubHost } from "../stubHost.ts"
@@ -23,7 +24,13 @@ export type Rig = {
   host: Host
 }
 
-export function rig(seed: number, reduced = false, now = 0): Rig {
+/**
+ * `experience` defaults to a child who is PAST the calm opening, so every test
+ * written before `game/opening.ts` existed keeps asking about the game a
+ * practised child actually gets. `opening.test.ts` is the one file that names
+ * other values.
+ */
+export function rig(seed: number, reduced = false, now = 0, experience = LOGGED_PAST_CALM): Rig {
   const reports: Report[] = []
   const haptics: string[] = []
   const transitions: Array<{ kind: string; label?: string }> = []
@@ -34,7 +41,7 @@ export function rig(seed: number, reduced = false, now = 0): Rig {
     onHaptic: (k) => haptics.push(k),
     onTransition: (kind, label) => transitions.push({ kind, label }),
   })
-  const game = new Game(host, new Rng(seed ^ 0x5ec2), now, reduced)
+  const game = new Game(host, new Rng(seed ^ 0x5ec2), now, reduced, experience)
   game.begin(now)
   return { game, reports, haptics, transitions, host }
 }

--- a/dynawalla/games/skyledger/src/test/manual.test.ts
+++ b/dynawalla/games/skyledger/src/test/manual.test.ts
@@ -24,168 +24,11 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-// From `audioHold.ts` directly, not the barrel: `index.ts` deliberately does
-// NOT re-export this, because a game that reached for it would defeat the hold
-// for the whole pack. Node 24 enforces that; Node 22 does not, which is how the
-// wrong import passed locally and failed in CI.
-import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/audioHold.ts"
+import { LOGGED_PAST_CALM } from "../game/opening.ts"
+import { noteLogged, resetLoggedForTest } from "../game/seen.ts"
 import { mountSkyLedger } from "../mount.ts"
 import { createStubHost } from "../stubHost.ts"
-
-type Handler = (e: unknown) => void
-
-type FakeEl = {
-  className: string
-  tag?: string
-  fire(type: string, event?: unknown): void
-  [key: string]: unknown
-}
-
-function makeSurface(width = 768, height = 1024) {
-  const created: FakeEl[] = []
-  const rect = { left: 0, top: 0, right: width, bottom: height, width, height, x: 0, y: 0 }
-
-  const ctx: unknown = new Proxy(
-    {},
-    {
-      get(_t, prop) {
-        if (prop === "then") return undefined
-        if (typeof prop === "symbol") return undefined
-        return () => ctx
-      },
-      set: () => true,
-    },
-  )
-
-  const makeEl = (): FakeEl => {
-    const listeners = new Map<string, Handler[]>()
-    const el = {
-      style: {} as Record<string, unknown>,
-      width: 0,
-      height: 0,
-      id: "",
-      type: "",
-      className: "",
-      textContent: "",
-      tabIndex: 0,
-      hidden: false,
-      scrollTop: 0,
-      offsetHeight: 400,
-      appendChild: (c: unknown) => c,
-      append: () => undefined,
-      remove: () => undefined,
-      focus: () => undefined,
-      setAttribute: () => undefined,
-      getAttribute: () => null,
-      removeAttribute: () => undefined,
-      getBoundingClientRect: () => rect,
-      getContext: () => ctx,
-      setPointerCapture: () => undefined,
-      releasePointerCapture: () => undefined,
-      hasPointerCapture: () => false,
-      addEventListener(type: string, h: Handler) {
-        const list = listeners.get(type) ?? []
-        list.push(h)
-        listeners.set(type, list)
-      },
-      removeEventListener(type: string, h: Handler) {
-        const list = listeners.get(type) ?? []
-        const at = list.indexOf(h)
-        if (at >= 0) list.splice(at, 1)
-      },
-      fire(type: string, event: unknown = {}) {
-        for (const h of [...(listeners.get(type) ?? [])]) h(event)
-      },
-    } as unknown as FakeEl
-    created.push(el)
-    return el
-  }
-
-  const root = makeEl()
-  const globalKeys = new Map<string, Handler[]>()
-  let pending: ((t: number) => void) | null = null
-  let clock = 0
-
-  const saved = {
-    raf: globalThis.requestAnimationFrame,
-    caf: globalThis.cancelAnimationFrame,
-    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
-    now: performance.now,
-    dateNow: Date.now,
-    add: globalThis.addEventListener,
-    remove: globalThis.removeEventListener,
-    doc: (globalThis as { document?: unknown }).document,
-    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
-  }
-
-  const install = (): (() => void) => {
-    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
-      pending = cb
-      return 1
-    }) as typeof globalThis.requestAnimationFrame
-    globalThis.cancelAnimationFrame = ((): void => {
-      pending = null
-    }) as typeof globalThis.cancelAnimationFrame
-    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
-      observe(): void {}
-      disconnect(): void {}
-    }
-    performance.now = () => clock
-    // The scene seeds itself from the wall clock, which is right on a tablet and
-    // fatal in a test: a suite that is green four runs in five has proved
-    // nothing.
-    Date.now = () => 0x5eed
-    globalThis.addEventListener = ((type: string, h: Handler): void => {
-      const list = globalKeys.get(type) ?? []
-      list.push(h)
-      globalKeys.set(type, list)
-    }) as unknown as typeof globalThis.addEventListener
-    globalThis.removeEventListener = ((type: string, h: Handler): void => {
-      const list = globalKeys.get(type) ?? []
-      const at = list.indexOf(h)
-      if (at >= 0) list.splice(at, 1)
-    }) as unknown as typeof globalThis.removeEventListener
-    ;(globalThis as { document?: unknown }).document = {
-      createElement: (tag: string) => {
-        const el = makeEl()
-        el.tag = tag
-        return el
-      },
-      getElementById: () => null,
-      body: makeEl(),
-      activeElement: null,
-      addEventListener: () => undefined,
-      removeEventListener: () => undefined,
-    }
-    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
-    return () => {
-      globalThis.requestAnimationFrame = saved.raf
-      globalThis.cancelAnimationFrame = saved.caf
-      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
-      performance.now = saved.now
-      Date.now = saved.dateNow
-      globalThis.addEventListener = saved.add
-      globalThis.removeEventListener = saved.remove
-      ;(globalThis as { document?: unknown }).document = saved.doc
-      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
-      forgetAudioContexts()
-    }
-  }
-
-  return {
-    root,
-    install,
-    step(ms: number): void {
-      clock += ms
-      const cb = pending
-      pending = null
-      cb?.(clock)
-    },
-    /** The shared module's own controls, found the way a finger finds them. */
-    help: () => created.find((e) => e.className === "dwc-help"),
-    closeButton: () => created.find((e) => e.className === "dwc-close"),
-  }
-}
+import { makeSurface } from "./surface.ts"
 
 type Rig = {
   surface: ReturnType<typeof makeSurface>
@@ -200,6 +43,12 @@ type Rig = {
 function rig(seed = 0x5c7ed6): Rig {
   const surface = makeSurface()
   const restore = surface.install()
+  // A practised child. This file is about the MANUAL, not about the opening: it
+  // needs stars that land inside its twenty-four seconds, which is the shipped
+  // descent and not the calm one. Seeded AFTER `install`, so the count lands in
+  // this rig's own storage and not in the one the last rig took away with it.
+  resetLoggedForTest()
+  for (let i = 0; i < LOGGED_PAST_CALM; i++) noteLogged()
   const haptics: string[] = []
   const reports: Array<{ ms: number }> = []
   let served = 0

--- a/dynawalla/games/skyledger/src/test/opening.test.ts
+++ b/dynawalla/games/skyledger/src/test/opening.test.ts
@@ -1,0 +1,602 @@
+// THE CALM OPENING, measured.
+//
+// > "sky ledger is pretty cool. but to start it needs to be Wayy slower. only
+// > one problem to look at and maybe even a tutorial. only once the user has
+// > proven they have the hang of it should we put more than one problem on the
+// > board"
+//
+// Three claims, and each is asserted against the real `Game` rather than against
+// the table in `game/opening.ts`:
+//
+//   1. a first sitting has **one** ledger line in the air and keeps having one;
+//   2. a second one arrives when the child has **logged stars**, never when a
+//      clock has run out;
+//   3. the top of the ramp is the game as it shipped, byte for byte.
+//
+// The observable throughout is `state === "falling" && t > 0` — the exact filter
+// `mount.view` applies before handing the sky to the renderer, so what is counted
+// here is what is on the glass and not what is in an array.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Game, type Star } from "../game/game.ts"
+import {
+  CALM_STEPS,
+  LOGGED_AT,
+  LOGGED_PAST_CALM,
+  openingAt,
+  revealFor,
+  stepFor,
+} from "../game/opening.ts"
+import { loggedEver, noteLogged, resetLoggedForTest } from "../game/seen.ts"
+import { answerOf, stationOf } from "../game/station.ts"
+import { mountSkyLedger } from "../mount.ts"
+import { BRASS_LIT, OXIDE } from "../render/palette.ts"
+import { createStubHost } from "../stubHost.ts"
+import { setHostInsets } from "../../../../packs/shared/game-chrome/index.ts"
+import { makeSurface } from "./surface.ts"
+
+const SEEDS = Array.from({ length: 60 }, (_, i) => i * 7919 + 1)
+const STEP = 50
+
+function game(seed: number, experience: number): Game {
+  const host = createStubHost({ seed })
+  const g = new Game(host, new Rng(seed ^ 0x5ec2), 0, false, experience)
+  g.begin(0)
+  return g
+}
+
+/** What `mount.view` would hand the renderer: the readable ledger lines. */
+function onBoard(g: Game): number {
+  let n = 0
+  for (const s of g.stars) if (s.state === "falling" && s.t > 0) n += 1
+  return n
+}
+
+/** Work the sighted star correctly. Returns false when there was nothing to work. */
+function solve(g: Game, now: number): boolean {
+  const star: Star | null = g.sighted
+  if (!star) return false
+  const value = answerOf(star.item)
+  if (value === null) return false
+  const want = stationOf(value)
+  for (let i = 0; i < 12 && g.station.x !== want.x; i++) g.dial("ones", 1)
+  for (let i = 0; i < 12 && g.station.y !== want.y; i++) g.dial("tens", 1)
+  g.mark(now)
+  return true
+}
+
+/**
+ * A sitting.
+ *
+ * `thinkMs` is `null` for a child who never touches anything at all. Nothing in
+ * here reads a difficulty, a speed or a streak; it is a clock only so that the
+ * ASSERTIONS can be about how little the clock matters.
+ */
+function sit(
+  g: Game,
+  untilMs: number,
+  thinkMs: number | null,
+): { peak: number; board: number[]; logged: number } {
+  const board: number[] = []
+  let due = thinkMs ?? Number.POSITIVE_INFINITY
+  for (let t = STEP; t <= untilMs; t += STEP) {
+    g.tick(STEP, t)
+    if (g.shown !== null) g.dismiss(t + 1000)
+    if (t >= due) {
+      solve(g, t)
+      due = t + (thinkMs ?? Number.POSITIVE_INFINITY)
+    }
+    board.push(onBoard(g))
+  }
+  return { peak: Math.max(0, ...board), board, logged: g.ledger.logged }
+}
+
+// ── the table ───────────────────────────────────────────────────────────────
+
+test("the ramp is monotone in every direction, and never reverses on a child", () => {
+  let previous = openingAt(0)
+  assert.equal(previous.onBoard, 1, `a first sitting is ${previous.onBoard} ledger lines, not one`)
+  for (let step = 1; step <= CALM_STEPS + 6; step++) {
+    const at = openingAt(step)
+    assert.ok(
+      at.onBoard >= previous.onBoard,
+      `step ${step} puts ${at.onBoard} on the board where step ${step - 1} put ${previous.onBoard}`,
+    )
+    assert.ok(
+      at.fall <= previous.fall,
+      `step ${step} falls at ×${at.fall} where step ${step - 1} fell at ×${previous.fall}`,
+    )
+    assert.ok(
+      Number(at.reading) <= Number(previous.reading),
+      `the written reading came back at step ${step}`,
+    )
+    assert.ok(
+      at.intensity >= previous.intensity,
+      `step ${step} is calmer (${at.intensity}) than step ${step - 1} (${previous.intensity})`,
+    )
+    assert.ok(
+      revealFor(at).holdMs <= revealFor(previous).holdMs,
+      `the reveal came back at step ${step}`,
+    )
+    previous = at
+  }
+})
+
+test("the top of the ramp is the game as it shipped", () => {
+  for (const step of [CALM_STEPS, CALM_STEPS + 1, CALM_STEPS + 40]) {
+    const at = openingAt(step)
+    assert.equal(at.onBoard, Number.POSITIVE_INFINITY, `step ${step} still caps the board`)
+    assert.equal(at.fall, 1, `step ${step} still stretches the descent`)
+    assert.equal(at.reading, false, `step ${step} still writes the reading out`)
+    assert.equal(revealFor(at).holdMs, 0, `step ${step} still completes sums for the child`)
+  }
+  // …and every calm step holds its reveal until a hand takes it down. The
+  // decision is `game-pacing`'s; this is the claim that it comes out the way
+  // this game needs.
+  for (let step = 0; step < CALM_STEPS; step++) {
+    assert.equal(
+      revealFor(openingAt(step)).holdMs,
+      Number.POSITIVE_INFINITY,
+      `step ${step} puts a deadline on a completed sum`,
+    )
+    assert.ok(revealFor(openingAt(step)).settleMs > 0, `step ${step} can be dismissed by a stray tap`)
+  }
+})
+
+test("the step is a function of stars logged, and it is monotone in them", () => {
+  assert.equal(stepFor(0), 0, "a child who has logged nothing is not at the start of the ramp")
+  let previous = 0
+  for (let logged = 0; logged <= 400; logged++) {
+    const step = stepFor(logged)
+    assert.ok(step >= previous, `logging one more star moved a child from step ${previous} to ${step}`)
+    assert.ok(step <= CALM_STEPS, `${logged} logged put a child at step ${step}, past the table`)
+    previous = step
+  }
+  assert.equal(stepFor(LOGGED_PAST_CALM), CALM_STEPS, "the ramp never actually ends")
+  // The board opens up only after a real number of right answers, not after one.
+  assert.ok(
+    (LOGGED_AT[2] as number) >= 3,
+    `a second ledger line arrives after only ${LOGGED_AT[2]} logged stars`,
+  )
+  assert.equal(stepFor((LOGGED_AT[2] as number) - 1), 1, "the second line arrives a star early")
+  assert.equal(openingAt(stepFor((LOGGED_AT[2] as number) - 1)).onBoard, 1)
+  assert.equal(openingAt(stepFor(LOGGED_AT[2] as number)).onBoard, 2)
+})
+
+// ── what a first sitting actually walks into ────────────────────────────────
+
+test("a first sitting is ONE ledger line, on the first frame and for the whole minute", () => {
+  for (const seed of SEEDS) {
+    const g = game(seed, 0)
+    assert.equal(onBoard(g), 0, `seed ${seed}: a star was already falling before the first frame`)
+    g.tick(STEP, STEP)
+    assert.equal(onBoard(g), 1, `seed ${seed}: the first frame had ${onBoard(g)} ledger lines on it`)
+
+    // Ten minutes of a child who is only LOOKING at it. Not a second line, ever.
+    const idle = sit(g, 600_000, null)
+    assert.equal(
+      idle.peak,
+      1,
+      `seed ${seed}: a child who never touched anything was shown ${idle.peak} ledger lines`,
+    )
+  }
+})
+
+test("a practised child gets the board the game always gave them", () => {
+  // The counter-measurement, and the reason the one above is not vacuous: the
+  // same drive, the same seeds, the same observable — four lines inside eight
+  // seconds and five inside the minute, which is the report this work came from.
+  let mostAtEight = 0
+  let mostAtSixty = 0
+  for (const seed of SEEDS) {
+    const g = game(seed, LOGGED_PAST_CALM)
+    const eight = sit(g, 8000, null)
+    mostAtEight = Math.max(mostAtEight, eight.peak)
+    const minute = sit(g, 52_000, null)
+    mostAtSixty = Math.max(mostAtSixty, minute.peak)
+  }
+  assert.equal(mostAtEight, 4, `the shipped opening put ${mostAtEight} lines up in eight seconds`)
+  assert.equal(mostAtSixty, 5, `the shipped first minute peaked at ${mostAtSixty} lines`)
+})
+
+test("the second ledger line is bought with right answers, never with time", () => {
+  for (const seed of SEEDS.slice(0, 12)) {
+    // Two children, same seed, same opening. One works; one watches.
+    const worker = game(seed, 0)
+    const watcher = game(seed, 0)
+
+    const watched = sit(watcher, 600_000, null)
+    assert.equal(watched.peak, 1, `seed ${seed}: ten minutes alone opened the board up`)
+    assert.equal(watcher.opened.step, 0, `seed ${seed}: ten idle minutes moved the ramp`)
+
+    const worked = sit(worker, 600_000, 3000)
+    assert.ok(worked.logged > 0, `seed ${seed}: the worker never logged anything`)
+    assert.ok(
+      worker.opened.step > 0,
+      `seed ${seed}: ${worked.logged} logged stars did not move the ramp`,
+    )
+    assert.ok(
+      worked.peak >= 2,
+      `seed ${seed}: ${worked.logged} logged stars never bought a second ledger line`,
+    )
+
+    // And the second one does not arrive before the third right answer.
+    const secondAt = worked.board.findIndex((n) => n >= 2)
+    assert.ok(secondAt >= 0)
+    const g2 = game(seed, 0)
+    let loggedWhenSecondAppeared = 0
+    for (let i = 0, t = STEP; i <= secondAt; i++, t += STEP) {
+      g2.tick(STEP, t)
+      if (g2.shown !== null) g2.dismiss(t + 1000)
+      if (t % 3000 === 0) solve(g2, t)
+      if (onBoard(g2) >= 2) {
+        loggedWhenSecondAppeared = g2.ledger.logged
+        break
+      }
+    }
+    assert.ok(
+      loggedWhenSecondAppeared >= (LOGGED_AT[2] as number),
+      `seed ${seed}: the second line arrived on ${loggedWhenSecondAppeared} logged stars`,
+    )
+  }
+})
+
+test("the calm descent is slower, and it is a function of the step and of nothing else", () => {
+  for (const seed of SEEDS.slice(0, 20)) {
+    const calm = game(seed, 0)
+    const shipped = game(seed, LOGGED_PAST_CALM)
+    const a = calm.stars[0]
+    const b = shipped.stars[0]
+    assert.ok(a && b)
+    assert.ok(
+      a.fallMs > b.fallMs * 1.5,
+      `seed ${seed}: a first sitting falls in ${a.fallMs} ms against the shipped ${b.fallMs} ms`,
+    )
+    // Ten minutes of wall clock does not touch it. Only a right answer does.
+    const before = calm.opened
+    sit(calm, 600_000, null)
+    assert.deepEqual(calm.opened, before, `seed ${seed}: the opening moved on the clock`)
+  }
+})
+
+// ── the tutorial: the plate says what the rings are for ─────────────────────
+
+test("the sighted plate is the child's OWN reading, standing where the answer goes", () => {
+  const g = game(0x71a1, 0)
+  g.tick(STEP, STEP)
+  const star = g.sighted
+  assert.ok(star)
+  assert.equal(
+    g.guide,
+    `${star.item.prompt} = ${g.reading}`,
+    "the guided plate is not the prompt completed with the reading",
+  )
+  // It follows the rings, because it IS the rings.
+  const seen = new Set<string>()
+  for (let i = 0; i < 10; i++) {
+    g.dial("ones", 1)
+    const line = g.guide
+    assert.ok(line !== null)
+    assert.ok(line.endsWith(` = ${g.reading}`), `the plate said ${line} while the rings said ${g.reading}`)
+    seen.add(line)
+  }
+  assert.equal(seen.size, 10, "turning the ones ring ten times produced fewer than ten readings")
+})
+
+test("the guidance comes off, and a practised child is never shown it", () => {
+  const g = game(0x71a2, LOGGED_PAST_CALM)
+  g.tick(STEP, STEP)
+  assert.ok(g.sighted, "nothing was under the sight")
+  assert.equal(g.guide, null, "a practised child was handed the guided plate")
+})
+
+// ── a miss completes the sum, and holds it ──────────────────────────────────
+
+function missOn(g: Game, now: number): { star: Star; truth: number } {
+  const star = g.sighted
+  assert.ok(star, "nothing was under the sight")
+  const truth = answerOf(star.item)
+  assert.ok(truth !== null)
+  const want = stationOf(truth)
+  // One detent off the ones ring: wrong, and wrong in a way a child is wrong.
+  const wrong = { x: (want.x + 1) % 10, y: want.y }
+  for (let i = 0; i < 12 && g.station.x !== wrong.x; i++) g.dial("ones", 1)
+  for (let i = 0; i < 12 && g.station.y !== wrong.y; i++) g.dial("tens", 1)
+  g.mark(now)
+  return { star, truth }
+}
+
+test("a miss in the calm opening completes the sum, in full, and holds it", () => {
+  for (const seed of SEEDS.slice(0, 20)) {
+    const reports: Array<{ questionId: string; correct: boolean }> = []
+    const host = createStubHost({ seed, onReport: (r) => reports.push(r) })
+    const g = new Game(host, new Rng(seed ^ 0x5ec2), 0, false, 0)
+    g.begin(0)
+    g.tick(STEP, STEP)
+
+    const { star, truth } = missOn(g, 1000)
+    assert.equal(
+      g.shown,
+      `${star.item.prompt} = ${truth}`,
+      `seed ${seed}: a miss left ${g.shown} on the glass`,
+    )
+    assert.equal(star.state, "shown", `seed ${seed}: the shown star is still ${star.state}`)
+
+    // Reported exactly once, as the wrong answer it was. Being shown the sum is
+    // not being credited with it.
+    const mine = reports.filter((r) => r.questionId === star.item.id)
+    assert.equal(mine.length, 1, `seed ${seed}: ${mine.length} reports for one ledger line`)
+    assert.equal(mine[0]?.correct, false, `seed ${seed}: a shown sum was reported correct`)
+
+    // Ten minutes. Nothing takes it down but a hand — and nothing moves behind it.
+    const lamps = g.lamps
+    for (let t = 1050; t < 600_000; t += 500) g.tick(500, t)
+    assert.equal(g.shown, `${star.item.prompt} = ${truth}`, `seed ${seed}: the sum timed itself out`)
+    assert.equal(g.lamps, lamps, `seed ${seed}: a lamp went out behind a held sum`)
+    for (const s of g.stars) {
+      if (s.id !== star.id) {
+        assert.ok(s.t < 1, `seed ${seed}: a star landed behind a held sum`)
+      }
+    }
+  }
+})
+
+test("a completed sum outlasts a stray second tap, and then the child's own hand ends it", () => {
+  const g = game(0x5e77, 0)
+  g.tick(STEP, STEP)
+  missOn(g, 1000)
+  const line = g.shown
+  assert.ok(line)
+
+  const settle = revealFor(g.opened).settleMs
+  assert.ok(settle > 0)
+  // The second tap of a double-tap, arriving inside the fade-in.
+  assert.deepEqual(g.dismiss(1000 + settle - 1), [], "a stray tap took the lesson down")
+  assert.equal(g.shown, line, "a stray tap took the lesson down")
+
+  g.dismiss(1000 + settle)
+  assert.equal(g.shown, null, "the child's own hand did not end it")
+  // And the world starts again, with the next ledger line under the sight as
+  // soon as the watch's own release gap has passed — a star waits for its gap
+  // AND for room, and dismissing a lesson only ever grants the second.
+  let t = 1000 + settle
+  for (let i = 0; i < 200 && g.sighted === null; i++) {
+    t += STEP
+    g.tick(STEP, t)
+  }
+  assert.ok(g.sighted, "nothing was ever put under the sight after the lesson")
+  assert.equal(onBoard(g), 1, "the lesson ending put more than one line on the board")
+})
+
+test("a practised child's miss is the miss the game always gave them", () => {
+  const g = game(0x5e78, LOGGED_PAST_CALM)
+  g.tick(STEP, STEP)
+  const { star } = missOn(g, 1000)
+  assert.equal(g.shown, null, "the shipped game completed a sum for a practised child")
+  assert.equal(star.state, "falling", "the shipped game took the star away")
+  // And the world is still running.
+  g.tick(STEP, 1050)
+  assert.ok((g.stars.find((s) => s.id === star.id)?.t ?? 0) > 0)
+})
+
+test("a held sum takes no input but its own dismissal", () => {
+  const g = game(0x5e79, 0)
+  g.tick(STEP, STEP)
+  missOn(g, 1000)
+  const ring = { ...g.station }
+  assert.deepEqual(g.dial("ones", 1), [], "a ring turned under a held sum")
+  assert.deepEqual(g.station, ring, "a ring turned under a held sum")
+  assert.deepEqual(g.mark(2000), [], "a mark was taken under a held sum")
+  assert.deepEqual(g.sight(1), [], "a star was sighted under a held sum")
+})
+
+test("a sheet raised over a held sum does not hand it back already dismissible", () => {
+  const g = game(0x5e7a, 0)
+  g.tick(STEP, STEP)
+  missOn(g, 1000)
+  const settle = revealFor(g.opened).settleMs
+
+  g.pause(1100)
+  g.resume(1100 + 30_000)
+  // The tap that took the host's sheet down must not take the lesson with it.
+  assert.deepEqual(g.dismiss(1100 + 30_000), [], "thirty seconds of sheet spent the settle")
+  assert.equal(g.shown !== null, true)
+  g.dismiss(1000 + settle + 30_000 + 1)
+  assert.equal(g.shown, null, "the lesson could not be dismissed after the sheet came off")
+})
+
+// ── the wire ────────────────────────────────────────────────────────────────
+//
+// Everything above would pass in full with `mount.ts` never reading or writing
+// the count, so the shell is driven for itself.
+
+test("the shell reads the ramp back and writes to it, across sittings", () => {
+  const surface = makeSurface()
+  const restore = surface.install()
+  try {
+    resetLoggedForTest()
+    assert.equal(loggedEver(), 0, "the slot was not empty at the start of a first sitting")
+
+    const host = createStubHost({ seed: 0x91e1 })
+    const handle = mountSkyLedger(surface.root as unknown as HTMLElement, host)
+    // Four minutes of a child at the keyboard — the shell's own input path, so
+    // every turn and every mark goes through the same `apply` a finger does.
+    // The rings are walked over every station and MARK is pressed at each, which
+    // is a brute force and is exactly why it works here: whatever the answer is,
+    // this child will find it, and the count that comes back is real.
+    for (let i = 0; i < 15_000; i++) {
+      surface.step(16)
+      if (i % 7 === 0) key(surface, "ArrowRight")
+      if (i % 71 === 0) key(surface, "ArrowUp")
+      if (i % 11 === 0) key(surface, " ")
+    }
+    handle.unmount()
+
+    const banked = loggedEver()
+    assert.ok(banked > 0, "a whole sitting of marks banked nothing")
+    assert.equal(
+      Number(globalThis.localStorage.getItem("dw.skyledger.logged")),
+      banked,
+      "the logged count never reached storage",
+    )
+
+    // The read side: a fresh shell on the same device is past the first step.
+    resetLoggedForTest()
+    assert.equal(loggedEver(), banked, "the count did not survive a fresh module")
+  } finally {
+    restore()
+  }
+})
+
+function key(surface: ReturnType<typeof makeSurface>, k: string): void {
+  surface.fireGlobal("keydown", { key: k, preventDefault: () => undefined })
+}
+
+// ── the glass ───────────────────────────────────────────────────────────────
+
+test("the completed sum reaches the glass, in brass and never in the refusal colour", () => {
+  const surface = makeSurface()
+  const restore = surface.install()
+  try {
+    resetLoggedForTest()
+    assert.equal(loggedEver(), 0, "this has to be a first sitting or there is no reveal to draw")
+
+    const host = createStubHost({ seed: 0x9c1a })
+    const handle = mountSkyLedger(surface.root as unknown as HTMLElement, host)
+    for (let i = 0; i < 40; i++) surface.step(16)
+
+    // A wrong mark, through the shell: turn the ones ring once and press space.
+    // One of the ten readings is right; nine are not, and one turn from the
+    // origin is not the answer for any ledger line this stub draws at 0x9c1a.
+    key(surface, "ArrowRight")
+    key(surface, " ")
+    surface.clearPainted()
+    surface.step(16)
+
+    const painted = surface.painted()
+    const sum = painted.find((p) => /^\d+\s*[+−-]\s*\d+\s*=\s*\d+$/.test(p.text.trim()))
+    assert.ok(
+      sum,
+      `no completed sum was painted; the glass had ${painted.map((p) => p.text).join(" | ")}`,
+    )
+    // Brass, the ink this observatory writes its own record in. Never OXIDE,
+    // which is this palette's refusal colour, and never anything red.
+    assert.equal(sum.fill, BRASS_LIT, `the completed sum was painted ${sum.fill}`)
+    assert.notEqual(sum.fill, OXIDE, "the completed sum was painted in the refusal colour")
+    for (const p of painted) {
+      assert.notEqual(p.fill, OXIDE, `${p.text} was painted in the refusal colour`)
+    }
+    handle.unmount()
+  } finally {
+    restore()
+  }
+})
+
+// ── the safe rect ───────────────────────────────────────────────────────────
+
+test("the layout follows the safe rect when the host moves it, with no resize", () => {
+  // `env(safe-area-inset-*)` resolves to ZERO inside a pack frame, so the real
+  // numbers arrive from the host and can arrive LATE — and can change again on
+  // an iPadOS Split View without the canvas box moving at all. `Layout` is
+  // computed from `safeRect()` inside `Scene.resize` and nowhere else.
+  //
+  // The observable is a pixel: where MARK is engraved on the boss. And the
+  // event fired is `orientationchange`, which `mount` does NOT listen for on its
+  // own — only `onInsetsChange` does — so a shell that dropped the subscription
+  // and kept its own `resize` handler fails here.
+  const surface = makeSurface()
+  const restore = surface.install()
+  try {
+    resetLoggedForTest()
+    setHostInsets(null)
+    const handle = mountSkyLedger(
+      surface.root as unknown as HTMLElement,
+      createStubHost({ seed: 0x5afe }),
+    )
+    surface.step(16)
+    surface.clearPainted()
+    surface.step(16)
+    const before = surface.painted().find((p) => p.text === "MARK")
+    assert.ok(before, "MARK was never engraved on the boss")
+
+    setHostInsets({ top: 180, right: 0, bottom: 120, left: 0 })
+    surface.fireGlobal("orientationchange")
+    surface.clearPainted()
+    surface.step(16)
+    const after = surface.painted().find((p) => p.text === "MARK")
+    assert.ok(after)
+    assert.notEqual(
+      Math.round(after.y),
+      Math.round(before.y),
+      `the astrolabe stayed at y=${before.y} after the host moved the safe rect`,
+    )
+    handle.unmount()
+  } finally {
+    setHostInsets(null)
+    restore()
+  }
+})
+
+test("the guided plate reaches the glass, and a practised child's plate does not", () => {
+  // `game.guide` being right is a claim about the rules. THIS is the claim that
+  // anything ever draws it: the shell has to put it on the sighted star's plate,
+  // and a `view` that kept handing over `s.item.prompt` would pass every rules
+  // assertion in this file.
+  const sums = /^\s*\d+\s*[+−-]\s*\d+\s*=\s*\d+\s*$/
+
+  const first = makeSurface()
+  const restoreFirst = first.install()
+  let firstSitting: readonly string[] = []
+  try {
+    resetLoggedForTest()
+    const handle = mountSkyLedger(
+      first.root as unknown as HTMLElement,
+      createStubHost({ seed: 0x91a7 }),
+    )
+    for (let i = 0; i < 60; i++) first.step(16)
+    key(first, "ArrowRight")
+    key(first, "ArrowUp")
+    first.clearPainted()
+    first.step(16)
+    firstSitting = first.painted().map((p) => p.text)
+    handle.unmount()
+  } finally {
+    restoreFirst()
+  }
+  assert.ok(
+    firstSitting.some((t) => sums.test(t)),
+    `no plate on a first sitting was written out as a whole sum; the glass had ${firstSitting.join(" | ")}`,
+  )
+
+  const later = makeSurface()
+  const restoreLater = later.install()
+  let practised: readonly string[] = []
+  try {
+    resetLoggedForTest()
+    for (let i = 0; i < LOGGED_PAST_CALM; i++) noteLogged()
+    const handle = mountSkyLedger(
+      later.root as unknown as HTMLElement,
+      createStubHost({ seed: 0x91a7 }),
+    )
+    for (let i = 0; i < 60; i++) later.step(16)
+    key(later, "ArrowRight")
+    key(later, "ArrowUp")
+    later.clearPainted()
+    later.step(16)
+    practised = later.painted().map((p) => p.text)
+    handle.unmount()
+  } finally {
+    restoreLater()
+  }
+  assert.ok(
+    practised.length > 0,
+    "the practised sitting drew nothing at all, so this half proves nothing",
+  )
+  assert.ok(
+    !practised.some((t) => sums.test(t)),
+    `a practised child's plate was written out for them: ${practised.filter((t) => sums.test(t)).join(" | ")}`,
+  )
+})

--- a/dynawalla/games/skyledger/src/test/produce.test.ts
+++ b/dynawalla/games/skyledger/src/test/produce.test.ts
@@ -22,6 +22,7 @@ import { test } from "node:test"
 import type { Host, Question } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
 import { Game } from "../game/game.ts"
+import { LOGGED_PAST_CALM } from "../game/opening.ts"
 import { RINGS, detentsBetween, type Station } from "../game/station.ts"
 import { createStubHost } from "../stubHost.ts"
 import { raise, rig, truthOf } from "./harness.ts"
@@ -139,8 +140,8 @@ test("where a star is in the sky is not a function of what it is worth", () => {
   const plain = createStubHost({ seed: 0xa11e })
   const altered = shift(createStubHost({ seed: 0xa11e }))
 
-  const a = new Game(plain, new Rng(0xbeef), 0, false)
-  const b = new Game(altered, new Rng(0xbeef), 0, false)
+  const a = new Game(plain, new Rng(0xbeef), 0, false, LOGGED_PAST_CALM)
+  const b = new Game(altered, new Rng(0xbeef), 0, false, LOGGED_PAST_CALM)
   a.begin(0)
   b.begin(0)
 

--- a/dynawalla/games/skyledger/src/test/surface.ts
+++ b/dynawalla/games/skyledger/src/test/surface.ts
@@ -1,0 +1,235 @@
+// A headless browser surface, shared by every test that mounts the real shell.
+//
+// It was `manual.test.ts`'s private fixture; `opening.test.ts` needs the same
+// thing and a second copy of a hundred and fifty lines of fake DOM is how two
+// tests quietly stop agreeing about what a frame is.
+//
+// Two things were added when it moved out, and both exist so an assertion can be
+// made about pixels and about storage rather than about source text:
+//
+//   * the 2d context RECORDS `fillText` and the `fillStyle` in force when each
+//     call was made, so a test can ask what is actually on the glass;
+//   * `install()` puts a real, in-memory `localStorage` on `globalThis`, so the
+//     read and write sides of a persisted count can be driven end to end.
+//
+// The fake elements below carry a listener map EACH, which is not tidiness: the
+// help button and the PLAY button both register a `"click"`, so one shared map
+// keyed by type silently drops the first and nothing opens.
+
+// From `audioHold.ts` directly, not the barrel: `index.ts` deliberately does
+// NOT re-export this, because a game that reached for it would defeat the hold
+// for the whole pack. Node 24 enforces that; Node 22 does not, which is how the
+// wrong import passed locally and failed in CI.
+import { forgetAudioContexts } from "../../../../packs/shared/game-chrome/audioHold.ts"
+
+export type Handler = (e: unknown) => void
+
+export type Painted = { text: string; fill: string; x: number; y: number }
+
+export type FakeEl = {
+  className: string
+  tag?: string
+  fire(type: string, event?: unknown): void
+  [key: string]: unknown
+}
+
+export function makeSurface(width = 768, height = 1024) {
+  const created: FakeEl[] = []
+  const rect = { left: 0, top: 0, right: width, bottom: height, width, height, x: 0, y: 0 }
+
+  // Everything the canvas is asked to paint, in order. `fillText` is the only
+  // call whose ARGUMENTS a test has ever needed, so it is the only one recorded
+  // in full; the fill in force is captured with it, because "is this drawn in
+  // the accent and never in the refusal colour" is a question about the pair.
+  const painted: Painted[] = []
+  let fill = ""
+  const ctx: unknown = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "then") return undefined
+        if (typeof prop === "symbol") return undefined
+        if (prop === "fillStyle") return fill
+        if (prop === "measureText") {
+          // A monospace-ish estimate. Enough for the fitting loop in
+          // `Scene.drawShown` to terminate on something other than zero.
+          return (t: string) => ({ width: String(t).length * 10 })
+        }
+        if (prop === "fillText") {
+          return (text: unknown, x: unknown, y: unknown) => {
+            painted.push({ text: String(text), fill, x: Number(x), y: Number(y) })
+          }
+        }
+        return () => ctx
+      },
+      set(_t, prop, value) {
+        if (prop === "fillStyle") fill = String(value)
+        return true
+      },
+    },
+  )
+
+  const makeEl = (): FakeEl => {
+    const listeners = new Map<string, Handler[]>()
+    const el = {
+      style: {} as Record<string, unknown>,
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      offsetHeight: 400,
+      appendChild: (c: unknown) => c,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => ctx,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? []
+        list.push(h)
+        listeners.set(type, list)
+      },
+      removeEventListener(type: string, h: Handler) {
+        const list = listeners.get(type) ?? []
+        const at = list.indexOf(h)
+        if (at >= 0) list.splice(at, 1)
+      },
+      fire(type: string, event: unknown = {}) {
+        for (const h of [...(listeners.get(type) ?? [])]) h(event)
+      },
+    } as unknown as FakeEl
+    created.push(el)
+    return el
+  }
+
+  const root = makeEl()
+  const globalKeys = new Map<string, Handler[]>()
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    dateNow: Date.now,
+    add: globalThis.addEventListener,
+    remove: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    storage: (globalThis as { localStorage?: unknown }).localStorage,
+  }
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb
+      return 1
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    // The scene seeds itself from the wall clock, which is right on a tablet and
+    // fatal in a test: a suite that is green four runs in five has proved
+    // nothing.
+    Date.now = () => 0x5eed
+    globalThis.addEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? []
+      list.push(h)
+      globalKeys.set(type, list)
+    }) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = ((type: string, h: Handler): void => {
+      const list = globalKeys.get(type) ?? []
+      const at = list.indexOf(h)
+      if (at >= 0) list.splice(at, 1)
+    }) as unknown as typeof globalThis.removeEventListener
+    ;(globalThis as { document?: unknown }).document = {
+      createElement: (tag: string) => {
+        const el = makeEl()
+        el.tag = tag
+        return el
+      },
+      getElementById: () => null,
+      body: makeEl(),
+      activeElement: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+    // A real one, in memory. `game/best.ts` and `game/seen.ts` both guard every
+    // access because a pack frame throws; without a slot here they fall back to
+    // module memory and a persistence assertion proves nothing.
+    const slots = new Map<string, string>()
+    ;(globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: (k: string) => slots.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        slots.set(k, String(v))
+      },
+      removeItem: (k: string) => {
+        slots.delete(k)
+      },
+      clear: () => {
+        slots.clear()
+      },
+      key: () => null,
+      length: 0,
+    }
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      Date.now = saved.dateNow
+      globalThis.addEventListener = saved.add
+      globalThis.removeEventListener = saved.remove
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      ;(globalThis as { localStorage?: unknown }).localStorage = saved.storage
+      forgetAudioContexts()
+    }
+  }
+
+  return {
+    root,
+    install,
+    step(ms: number): void {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+    /** The shared module's own controls, found the way a finger finds them. */
+    help: () => created.find((e) => e.className === "dwc-help"),
+    closeButton: () => created.find((e) => e.className === "dwc-close"),
+    /** Every `fillText` since the last `clearPainted`, newest last. */
+    painted: (): readonly Painted[] => painted,
+    clearPainted: (): void => {
+      painted.length = 0
+    },
+    /** The game's own canvas, so a test can press a finger to it. */
+    canvas: () => created.find((e) => e.tag === "canvas"),
+    /**
+     * An event on `globalThis` — a keydown, a resize. The shell listens there
+     * for the keyboard, so this is the only way a test can type at it.
+     */
+    fireGlobal(type: string, event: unknown = {}): void {
+      for (const h of [...(globalKeys.get(type) ?? [])]) h(event)
+    },
+  }
+}
+


### PR DESCRIPTION
> "sky ledger is pretty cool. but to start it needs to be Wayy slower. only one problem to look at and maybe even a tutorial. only once the user has proven they have the hang of it should we put more than one problem on the board"

## What it opened with, measured

Driving the **real `Game`** against the stub host over sixty seeds. The observable is `state === "falling" && t > 0` — the exact filter `mount.view` applies before handing the sky to the renderer, so what is counted is what is on the glass and not what is in an array.

| a first sitting | ledger lines at t=0 | 2nd arrives | 3rd | 4th | most in the first minute |
|---|---|---|---|---|---|
| **as it shipped** | 1 | **2.6 s** | 5.2 s | 7.8 s | **5** |
| **now** (child working a sum every 8 s) | 1 | **34.6 s** | never | never | **2** |
| **now** (child working every 15 s) | 1 | **never** | never | never | **1** |
| **now** (child who is only looking) | 1 | **never**, for ten minutes | — | — | **1** |

Eight seconds into the first screen a child had ever seen, the shipped game had **four column sums in the air and one dial**. That was not a difficulty setting: a watch released its whole set on a fixed 2.6-second gap and did not care whether the first one had been finished. The fifth line arrived because a watch of four that nobody answered lands and the next watch opens with five.

A first sitting now shows **one**, and the second waits for the child.

## The ramp

Six positions, indexed by stars this child has **ever logged** — marked, correctly. `game/seen.ts` remembers that across sittings; `Game` keeps counting within one, so the board opens up during the sitting the child earns it in. The step is read once per watch, so a watch has one shape end to end.

| step | logged | on the board | descent | plate written out | a miss completes the sum |
|---|---|---|---|---|---|
| 0 | 0 | **1** | ×1.7 | yes | held |
| 1 | 1 | **1** | ×1.5 | yes | held |
| 2 | 3 | 2 | ×1.3 | yes | held |
| 3 | 6 | 3 | ×1.15 | yes | held |
| 4 | 10 | 4 | ×1 | no | held |
| 5+ | 15 | ∞ | ×1 | no | none |

**Step 5 is the shipped game.** `onBoard: Infinity` cannot fire the cap, so release is the 2.6-second cadence it always was; `fall: 1` leaves the descent alone; the plate is the prompt; a wide mark leaves the star falling and shows nothing. Measured at experience 15 the numbers come back identical to the "as it shipped" row above — 2nd at 2.6 s, 3rd at 5.2 s, five in the minute.

Every quantity is monotone — `onBoard` non-decreasing, `fall` non-increasing, the written plate and the reveal non-increasing — asserted exhaustively rather than taken on trust. A child is never overtaken by their own progress.

**Achievement, never wall clock.** `openingAt` is a pure function of one integer and that integer counts right answers. Two children on the same seed: one who works logs stars and reaches step 2; one who sits and watches is at **step 0 after ten minutes** and has still been shown exactly one ledger line. That pair is an assertion, not a claim.

**No window was added.** SKY LEDGER has never had a comprehension window and this does not give it one — `fall` scales the descent the game already had, and it is a function of demonstrated competence and of nothing else: not the watch number, not the chain, not the clock. There is no eighteenth game deriving a comprehension window from a motion constant here.

## The tutorial

He said "maybe even a tutorial", so it is optional — and this game already ships a four-section how-to-play sheet through `game-chrome`. A second wall of prose is the wrong answer, and copy ships ~50× translated. **No new string is added anywhere in this PR.**

What is added instead is arithmetic, which is LATTICE's `18÷3` move:

* **The sighted star's plate is written out as a whole sentence** — `247 + 225 = 74` — where the right-hand side is the child's **own live reading off the astrolabe**. It reveals nothing, because the number is theirs. What it says, without words, is *what the two rings are for*: the thing you are making with your thumb goes where the answer goes. It follows the rings detent by detent, and it comes off at step 4.
* **A miss completes the sum in front of them and holds it.** `packs/shared/game-pacing`'s `revealPlan` decides — `holdMs: Infinity` at every calm step, `0` at the shipped game — and nothing in this package counts a millisecond of it. It is drawn in `BRASS_LIT`, the ink this observatory writes its own record in; never `OXIDE`, which is this palette's refusal colour, and never red. The sky, the chain, the sighting refill and every input but the dismissal stop dead behind it, because a lesson a child is reading must not cost them a lamp.

The star comes off the sky **with** the reveal, and that is the load-bearing part: it was already reported once, as the wrong answer it was, and a child who is shown `247 + 225 = 472` and then dials 472 would otherwise be reported as having worked it out. The register would be lying about them. Asserted — exactly one report per shown ledger line, `correct: false`.

## The safe rect, while I was in here

`skyledger` was already clean on the reported defect: it has no `env(safe-area-inset-*)` in its own stylesheet at all, and `Scene` has laid out against `game-chrome`'s `safeRect()` since it was written. One real gap remained and it was cheap: `Layout` is computed inside `Scene.resize` and nowhere else, and the shell only re-laid out on `resize` and a `ResizeObserver`. The host publishes the real insets on the `settings` channel — possibly after the first layout, and again on an iPadOS Split View change that leaves the canvas the same shape. `mount` now subscribes `onInsetsChange` and unsubscribes in `unmount`.

The assertion for it drives the real shell and fires **`orientationchange`**, which `mount` does not listen for on its own — only `onInsetsChange` does — and asserts the pixel where `MARK` is engraved moves. A shell that dropped the subscription and kept its own `resize` handler fails it.

## Verification

* `npm run -s tsc` clean; `npm run -s test` **5× consecutively, 91/91** (was 73).
* `node packs/build.mjs skyledger` builds and passes the SDK checker — `dynawalla.skyledger@0.1.0`, 3 files, 76,651 bytes, capabilities `items, items.reveal, haptics`.

`src/test/surface.ts` is `manual.test.ts`'s private headless surface, moved out so a second copy of a hundred and fifty lines of fake DOM does not exist. Two things were added when it moved: the 2d context **records `fillText` with the fill and the point in force**, and `install()` puts a real in-memory `localStorage` on `globalThis` — both so the new assertions can be about pixels and about storage rather than about source text.

`ArenaOptions`-style: `Game`'s `experience` is **required, not defaulted**. Every construction site has to state it, so no shell can quietly hand a practised child the first-minute opening or a first-timer four sums at once. `test/harness.ts`'s `rig()` defaults to a child past the ramp, so all 73 tests written before this keep asking about the game a practised child actually gets.

## Mutation transcript

Twenty-two mutations, each applied to the source, the suite run, the source restored. **All twenty-two fail.**

| # | mutation | first failure |
|---|---|---|
| M1 | the calm descent is dropped; every step falls at the shipped rate | `seed 1: a first sitting falls in 21000 ms against the shipped 21000 ms` |
| M2 | the board cap is dropped; stars release on the clock alone | `seed 1: a child who never touched anything was shown 5 ledger lines` |
| M3 | a first sitting opens with two ledger lines instead of one | `a first sitting is 2 ledger lines, not one` |
| M4 | the ramp is never applied: every child starts at the top | `a child who has logged nothing is not at the start of the ramp` |
| M5 | the ramp is indexed by watches survived, not by stars logged | `the sky never filled` |
| M6 | a right answer never moves the ramp within a sitting | `seed 1: 200 logged stars did not move the ramp` |
| M7 | the shell hardcodes a first sitting and never reads the count back | `nothing ever landed, so there is nothing to freeze` |
| M8 | the shell never banks a logged star | `a whole sitting of marks banked nothing` |
| M9 | a miss never completes the sum | `seed 1: a miss left null on the glass` |
| M10 | the completed sum is the child's own wrong value | `seed 1: a miss left 11 − 10 = 2 on the glass` |
| M11 | the sky keeps falling behind a held lesson | `seed 1: the sum timed itself out` |
| M12 | a stray second tap takes the lesson down | `a stray tap took the lesson down` |
| M13 | a host sheet over a held lesson spends its settle | `thirty seconds of sheet spent the settle` |
| M14 | the completed sum is painted in the refusal colour | `the completed sum was painted #7d5a44` |
| M15 | the scene never draws the held sum | `no completed sum was painted; the glass had 0 \| 1 \| … \| MARK` |
| M16 | the guided plate is never built | `the guided plate is not the prompt completed with the reading` |
| M17 | the guided plate never comes off | `a practised child was handed the guided plate` |
| M18 | the shell never puts the guided plate on the star | `no plate on a first sitting was written out as a whole sum; the glass had … 94 + 50 \| 1▫▫ …` |
| M19 | a shown star is reported a second time, as correct | `seed 1: 2 reports for one ledger line` |
| M20 | the shell drops the safe-rect subscription | `the astrolabe stayed at y=800.63 after the host moved the safe rect` |
| M21 | the shell writes every star's plate out, at every step | `a practised child's plate was written out for them: 94 + 50 = 0` |
| M22 | the completed sum reaches nobody (scene ignores `state.shown`) | *= M15* |

**M18 survived the first pass** and that is worth writing down. `game.guide` was asserted at the rules level in three places, and every one of them passed with `mount.view` handing the renderer `s.item.prompt` and never the guide — the whole tutorial reached nothing. It took the mount-level test that reads the recorded `fillText` calls off the real canvas to kill it. M21 was added at the same time, because a test that only asks "is a sum written out somewhere" would pass with the guidance welded on for every child forever.

## What is deliberately unchanged

The rules of the game. The astrolabe still produces an ordered pair one detent at a time and there is still no way to hand it a number. A star's lane is still drawn from the generator and never from its value. The chain, its caps, its snap-back and its seven-second window are untouched. `produce.test.ts`'s gate — that no file under `render/` or `mount.ts` may so much as mention an answer — still holds: the completed sum is built in `game.ts` and crosses as a finished string.
