### PR TITLE
chore(dynawalla): 0.3.9

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.8 → 0.3.9. **25 packs.**

Fifteen changes, every one from a founder playtest note.

**Openings that stopped overwhelming a new player**
- **#769 SKYLEDGER** — the second problem arrives at **34.6s, not 2.6s**, and only if the child is working; a watcher stays on one line for ten minutes. Eight seconds in, the shipped game had four column sums in the air.
- **#762 THE LATTICE** — one husk on the first screen, **3.0% of the diagonal/sec instead of 10.4%**, and the field marks which numbers divide what is left.
- **#766 / #752 SERPENT** — **5 orbs at the opening, not 22**; playfield **63.6% → 77–84%** of the safe rect; a self-hit is a bump until three answers' growth.
- **#764 PULSE** — the opening bar was **identical every launch**: density 0.9 x an on-beat weight of 1.25 = 1.125, so every slot fired with certainty. **1 distinct opening bar in 24 runs → 8.** Three lanes now need 88% accuracy.
- **#761 GUILTY** — firing is deliberate; nothing is lost before the first shot, and a wrong answer no longer makes the trench 14% faster.
- **#765 MOSAIC** — wave one was a filled rectangle in **every run the game has ever played**. **1 distinct opening shape in 400 seeds → 386**, and boards remix while you play.

**Screens a child could not read**
- **#763 POLARITY** — numerals drawn with additive blending, so the dark contrast rim **never darkened a pixel**. **1.00:1 → 18.40:1.**
- **#758 COUNTERPOISE** — two more literal **1.00:1** cases, both overlays rather than gradient stops; no single ink could have fixed it.
- **#767 SIEGE** — the HUD read `env(safe-area-inset-*)`, which is **zero in a sandboxed pack frame**, so the stats row sat under the status bar.
- **#757 DEEPSWARM** — level-up cards had **no content box at all** in portrait (`height: 20, scrollHeight: 95`), and a level-up during a live question killed the answer permanently.

**Maths that was wrong or unreachable**
- **#756 FORGE MARK** — the card said `HAMMER 16` while the arithmetic used 46, and the `×2` ingot never touched the row it promised.
- **#755 ARENA** — apparent speed fell from 1.03 to 0.23 screen-widths/s as you grew; the view widened 6.4× while speed rose 4.3×.
- **#754 / #735** — a pack's difficulty is a hint clamped to ±1 rung, and the promotion gate now reads the rung the child stands on rather than the whole mixture. `sit` had covered own-rung accuracy from **83% to 100%**.
- **#760** — FOUNDRY STREET retired, 26 → 25 packs.

A main push does not release. The tag `dynawalla-v0.3.9` does.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
