### PR TITLE
fix(dynawalla/host): a pack can say what it cannot draw in BOTH directions, and TREBUCHET has a question again

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/bridge.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.test.ts
@@ -411,6 +411,36 @@ test("a difficulty request crosses the boundary, clamped rather than refused", a
   assert.deepEqual(calls[2]?.input, { packId: "p" })
 })
 
+test("a floor crosses the boundary too, and it is not silently dropped", async () => {
+  // The half of the capability window this boundary did not carry. A field the
+  // wire drops is the worst shape of this bug — the pack states it, every test
+  // on either side passes, and the child still gets the empty field, because
+  // nothing between them ever said the word. TREBUCHET spent three releases in
+  // exactly that state for want of the field itself.
+  const calls: Calls = []
+  const bridge = createBridge({ packId: "p", granted: ["items"], services: services(calls) })
+
+  await bridge.handle({
+    id: 1,
+    method: "items.next",
+    params: { difficulty: 0.28, minDifficulty: 0.28, maxDifficulty: 0.9 },
+  })
+  assert.deepEqual(calls[0]?.input, {
+    packId: "p",
+    difficulty: 0.28,
+    maxDifficulty: 0.9,
+    minDifficulty: 0.28,
+  })
+
+  // Clamped like every other number here, and absent when it is not a number:
+  // a floor of `NaN` must not become a floor of zero, which reads as "no floor"
+  // and is the failure this field exists to prevent.
+  await bridge.handle({ id: 2, method: "items.next", params: { minDifficulty: 7 } })
+  assert.deepEqual(calls[1]?.input, { packId: "p", minDifficulty: 1 })
+  await bridge.handle({ id: 3, method: "items.next", params: { minDifficulty: "high" } })
+  assert.deepEqual(calls[2]?.input, { packId: "p" })
+})
+
 /* ─── streams, and the native-backed capability behind them ────────────────── */
 //
 // A stream is the first thing on this seam that OUTLIVES the message that opened

--- a/dynawalla/dynawalla-app/src/packs/bridge.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.ts
@@ -86,6 +86,8 @@ export type HostServices = {
     difficulty?: number
     /** 0..1 ceiling. The stream never goes above it. */
     maxDifficulty?: number
+    /** 0..1 floor. The stream never goes below it. */
+    minDifficulty?: number
   }): Promise<Item | null>
   /** Records the attempt and judges it. One call, in that order. */
   judge(input: {
@@ -377,11 +379,13 @@ export function createBridge(options: BridgeOptions): Bridge {
         // an author can act on.
         const difficulty = unitParam(params, "difficulty")
         const maxDifficulty = unitParam(params, "maxDifficulty")
+        const minDifficulty = unitParam(params, "minDifficulty")
         const item = await services.nextItem({
           packId,
           ...(skillId === null ? {} : { skillId }),
           ...(difficulty === null ? {} : { difficulty }),
           ...(maxDifficulty === null ? {} : { maxDifficulty }),
+          ...(minDifficulty === null ? {} : { minDifficulty }),
         })
         return ok(id, { item })
       }

--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -3433,3 +3433,237 @@ test("the stream a child is served stays inside the spread of where the ladder s
   assert.ok(worstAbove >= SPREAD_ABOVE, "the spread never once reached its own ceiling")
   assert.ok(worstBelow >= SPREAD_BELOW, "the spread never once reached its own floor")
 })
+
+/* ------------------------------------------------------------------ *
+ * `minDifficulty`: the other half of the capability window.
+ * ------------------------------------------------------------------ */
+
+/**
+ * TREBUCHET's field, as the pack states it.
+ *
+ * A keep stands at its own answer in METRES on a 122-metre field, so the only
+ * questions the game can put on the screen at all are the ones whose answer is
+ * an integer in this window. Copied rather than imported because this file
+ * tests the HOST and must not gain a dependency on a pack; the numbers are
+ * `PLACEABLE_LO`/`PLACEABLE_HI` in `games/trebuchet/src/sim/world.ts` and the
+ * test below fails loudly if the pack moves them without moving these.
+ */
+const TREBUCHET_LO = 14
+const TREBUCHET_HI = 118
+
+/** Trebuchet's rung search, as `game.ts` runs it. */
+const PROBE_START = 0.28
+const PROBE_STEP = 0.012
+const PROBE_LIMIT = 100
+
+test("a pack whose renderable content sits above the child is served something it can render", () => {
+  // **The founder's bug, at the layer that caused it.** On 0.3.9 he opened
+  // TREBUCHET on an Android tablet and got an empty prompt frame over an empty
+  // field: no sum, no keeps, nothing to shoot at. Nothing in the pack had
+  // changed since he last played it.
+  //
+  // `HINT_BAND` is what changed, in 0.3.7. A `difficulty` is a hint clamped to
+  // one rung either side of `Math.floor(progress)`, `progress` opens at 0 every
+  // session, and rungs 0 and 1 are `dw.add.facts.add-within-ten` — answers 0..10,
+  // none of which is a distance this game has a field for. So the pack's rung
+  // search, which sweeps the whole ladder precisely because answer magnitude is
+  // NOT monotonic in it, was served rung 1 on all hundred of its probes and
+  // dropped every answer it was handed. Measured on the service as shipped:
+  // 0 placeable out of 1000.
+  //
+  // `maxDifficulty` could not have saved it. That channel is absolute — a pack
+  // saying what it can physically draw — but it only points downward, so a pack
+  // whose renderable content sits BELOW the child could say so and a pack whose
+  // renderable content sits ABOVE the child could not. `minDifficulty` is the
+  // missing half.
+  //
+  // Driven the way the pack drives it, and not with a hand-written request: the
+  // thing under test is whether the search terminates, and a search is the one
+  // shape a single call cannot stand in for.
+  const service = createItemService({ profileId: "p-trebuchet", record: noRecord })
+  assert.equal(service.position(), 0, "a fresh session no longer opens at the bottom of the ladder")
+
+  let probeD = PROBE_START
+  let direction = 0
+  let stocked: number[] | null = null
+  let drawn = 0
+  let placeableSeen = 0
+
+  for (let probe = 0; probe < PROBE_LIMIT && stocked === null; probe++) {
+    const answers: number[] = []
+    const keeps: number[] = []
+    for (let pull = 0; pull < 10; pull++) {
+      const item = service.next({
+        packId: "dynawalla.trebuchet",
+        difficulty: probeD,
+        minDifficulty: probeD,
+      })
+      assert.ok(item, "the service served nothing at all")
+      const answer = Number(service.reveal(item.id))
+      service.skip(item.id)
+      drawn += 1
+      answers.push(answer)
+      if (Number.isInteger(answer) && answer >= TREBUCHET_LO && answer <= TREBUCHET_HI) {
+        keeps.push(answer)
+        placeableSeen += 1
+      }
+    }
+    if (keeps.length > 0) {
+      stocked = keeps
+      break
+    }
+    if (direction === 0) {
+      const tooBig = answers.filter((a) => a > TREBUCHET_HI).length
+      const tooSmall = answers.filter((a) => a < TREBUCHET_LO).length
+      if (tooBig > tooSmall) direction = -1
+      else if (tooSmall > 0) direction = 1
+    }
+    probeD += (direction === 0 ? 1 : direction) * PROBE_STEP
+    if (probeD > 1) probeD -= 1
+    if (probeD < 0) probeD += 1
+  }
+
+  assert.ok(
+    stocked !== null,
+    `the search swept ${String(PROBE_LIMIT)} probes and ${String(drawn)} questions without one ` +
+      `answer it could stand a keep at — this is the founder's empty field, and it is what ` +
+      `0.3.7 through 0.3.9 shipped (0 of 1000 placeable)`,
+  )
+  assert.ok(placeableSeen > 0)
+
+  // And the pack did NOT get to promote the child by saying so. This is the
+  // asymmetry with `maxDifficulty` and it is the whole safety of the channel: a
+  // ceiling pulls `progress` down when it bites, a floor moves it not at all.
+  assert.equal(
+    service.position(),
+    0,
+    "a stated floor moved the host's ladder — a pack can now promote a child by declaring a " +
+      "capability, which is `HINT_BAND` inverted",
+  )
+})
+
+test("a floor is honoured above the host's band, where a difficulty is not", () => {
+  // The narrow statement of the same thing, so a failure says which half broke.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-floor", record: noRecord, rungs })
+  assert.ok(span > 4 * HINT_BAND, "the ladder is too short to tell a floor from the band")
+
+  const wanted = 4 * HINT_BAND
+  const hinted = service.next({ packId: "dynawalla.trebuchet", difficulty: wanted / span })
+  assert.ok(hinted)
+  assert.equal(
+    Math.round((hinted.difficulty ?? -1) * span),
+    HINT_BAND,
+    "a difficulty stopped being clamped to the band",
+  )
+
+  const floored = service.next({
+    packId: "dynawalla.trebuchet",
+    difficulty: wanted / span,
+    minDifficulty: wanted / span,
+  })
+  assert.ok(floored)
+  assert.equal(
+    Math.round((floored.difficulty ?? -1) * span),
+    wanted,
+    "a stated floor was clamped back into the band, which makes it not a floor",
+  )
+})
+
+test("a floor rounds up, because rounding one down serves under it", () => {
+  // The mirror of the rounding note on the ceiling, and the same bug: a cap that
+  // rounded up was served a rung over a pack's stated ceiling, silently, for as
+  // long as the arithmetic happened to work out. A floor that rounded down is
+  // that bug pointing the other way — and for TREBUCHET a rung under the floor
+  // is a rung whose answers do not fit on the field, which is a blank screen.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-round", record: noRecord, rungs })
+
+  // Deliberately between two rungs and NEARER THE LOWER ONE, so that rounding to
+  // nearest lands under the floor and only ceiling lands on or above it. 0.4 was
+  // written here first and proved nothing: `round(9.6)` and `ceil(9.6)` are both
+  // 10, so the assertion passed against either rule.
+  const target = 10
+  const between = (target - 0.8) / span
+  const item = service.next({
+    packId: "dynawalla.trebuchet",
+    difficulty: between,
+    minDifficulty: between,
+  })
+  assert.ok(item)
+  const served = Math.round((item.difficulty ?? -1) * span)
+  assert.equal(served, target, "a floor between two rungs was rounded down, under itself")
+  assert.ok((item.difficulty ?? -1) >= between, "the served rung is below the stated floor")
+})
+
+test("an empty window is resolved by the ceiling, and the host says so once", () => {
+  // Two capability claims that contradict each other is a pack bug, and of the
+  // two rules "never serve above what a pack can render" is the one whose
+  // failure is PR 694 — a question on the screen that the game cannot draw.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-empty", record: noRecord, rungs })
+
+  const warnings: string[] = []
+  const realWarn = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "))
+  }
+  try {
+    // BOTH paths through `next`. A pack that states a difficulty is served a
+    // point; one that does not is served the host's own spread around its rung,
+    // and the two resolve the window in different code. Asserting only the
+    // spread let a mutation that resolved the point upward pass.
+    for (const difficulty of [undefined, 20 / span]) {
+      for (let i = 0; i < 3; i++) {
+        const item = service.next({
+          packId: "dynawalla.impossible",
+          ...(difficulty === undefined ? {} : { difficulty }),
+          minDifficulty: 20 / span,
+          maxDifficulty: 5 / span,
+        })
+        assert.ok(item)
+        assert.equal(
+          Math.round((item.difficulty ?? -1) * span),
+          5,
+          "an empty capability window was resolved upward — a pack was handed a rung it declared " +
+            "it cannot render",
+        )
+      }
+    }
+  } finally {
+    console.warn = realWarn
+  }
+  const said = warnings.filter((line) => line.includes("empty window"))
+  assert.equal(said.length, 1, "the empty window was announced " + String(said.length) + " times, not once")
+})
+
+test("the spread the host draws around its own rung cannot reach under a stated floor", () => {
+  // A pack that states a floor and no difficulty gets the host's own kernel,
+  // which is deliberately several rungs wide. A spread that could reach under
+  // the floor is not a floor — the same argument the ceiling's own re-clamp is
+  // already written for.
+  const rungs = ladder()
+  const span = rungs.length - 1
+  const service = createItemService({ profileId: "p-spread", record: noRecord, rungs })
+  climbTo(service, 20)
+
+  const bottom = 18
+  let lowest = span
+  for (let i = 0; i < 200; i++) {
+    const item = service.next({ packId: "dynawalla.trebuchet", minDifficulty: bottom / span })
+    assert.ok(item)
+    const served = Math.round((item.difficulty ?? -1) * span)
+    assert.ok(
+      served >= bottom,
+      `the spread served rung ${String(served)}, under the stated floor of ${String(bottom)}`,
+    )
+    lowest = Math.min(lowest, served)
+    service.skip(item.id)
+  }
+  // And it really was the floor doing the work, not a spread that never reached
+  // down there anyway.
+  assert.equal(lowest, bottom, "the spread never once came down to the floor, so this proves nothing")
+})

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -706,6 +706,8 @@ export const PACE_FLOOR = 0.1
  * The ceiling is not this. `maxDifficulty` is a *capability* — "I cannot draw a
  * question harder than this" — and it still binds absolutely, below the band and
  * above it, because handing a pack a rung it cannot render is PR 694 again.
+ * `minDifficulty` is the same kind of statement pointing the other way, and it
+ * binds the same way; see it for why half a capability window was not enough.
  *
  * **Which leaves one way out, and it should be said rather than implied.** A
  * pack that pins its ceiling *to* its request has opted out of the band: it is
@@ -718,6 +720,22 @@ export const PACE_FLOOR = 0.1
  * That is pack work — widen what those games can render — and it cannot be done
  * from here without serving a game a question it cannot put on the screen.
  * `items.test.ts` pins the boundary so it is not mistaken for coverage.
+ *
+ * **What this constant cost, and why `minDifficulty` exists.** The escape above
+ * only opens downward. `index = min(clamp(asked, anchor ± 1), cap)`: a ceiling
+ * can pull a pack below the band and nothing could push one above it. That is
+ * fine for a pack whose renderable content sits under the child and fatal for
+ * one whose renderable content sits over them, and TREBUCHET is the second kind
+ * — a keep stands at its own answer in METRES on a 122-metre field, so the only
+ * questions it can put on the screen at all are the ones whose answer is an
+ * integer in 14..118, and nothing on the bottom rungs of this ladder
+ * (`dw.add.facts.*`, answers 0..10) is one of them. `progress` opens every
+ * session at 0, so from 0.3.7 to 0.3.9 the pack's whole rung search — which
+ * sweeps the ladder precisely because answer magnitude is not monotonic in it —
+ * was served rung 1 on all hundred probes, dropped all thousand answers, and
+ * left a child looking at an empty prompt frame on an empty field. Measured on
+ * the shipped service in `items.test.ts`: **0 of 1000 draws placeable**, against
+ * 0.3.6 which stocked on the first probe.
  */
 export const HINT_BAND = 1
 
@@ -1548,6 +1566,19 @@ export type ItemService = {
      * physically draw, and it binds below `HINT_BAND` as well as above it.
      */
     maxDifficulty?: number
+    /**
+     * A floor on the same scale. The stream never goes below it.
+     *
+     * The other half of `maxDifficulty`, and absolute for the same reason: a
+     * pack whose renderable content sits ABOVE the child is as real as one whose
+     * sits below, and until this field existed only the second could say so. See
+     * `HINT_BAND` for what the missing half cost TREBUCHET.
+     *
+     * It never moves the ladder. A ceiling pulls `progress` down when it bites,
+     * because standing above content a pack can never test is a fiction; the
+     * mirror write would let a pack push a child UP, so there is not one.
+     */
+    minDifficulty?: number
   }): Item | null
   judge(input: {
     packId: string
@@ -1724,7 +1755,7 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         actually came from. */
     position: () => Math.floor(progress),
 
-    next: ({ packId, skillId, difficulty, maxDifficulty }) => {
+    next: ({ packId, skillId, difficulty, minDifficulty, maxDifficulty }) => {
       // A pack may name a skill it covers. It is a request, not an instruction:
       // an unknown id falls back to the ladder rather than failing, because a
       // pack built against a later curriculum must still be playable.
@@ -1788,6 +1819,48 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         // fraction, which is what `progress − anchor` is.
         if (cap < anchor) progress = Math.max(0, cap) + (progress - anchor)
       }
+      if (minDifficulty !== undefined) {
+        // The **floor ceils** where the request rounds, for the mirror of the
+        // reason the cap floors: rounding a floor down puts the stream under the
+        // rung a pack has just said it cannot draw beneath.
+        //
+        // It binds after the band and after the ceiling, and it wins over the
+        // band for the same reason the ceiling does — it is not a pedagogy
+        // request, it is a pack saying what it can physically draw. A floor that
+        // yielded to `HINT_BAND` would be no floor at all: `progress` opens at 0
+        // every session, so the band is exactly where a pack whose content sits
+        // above the child gets starved, and starved is what TREBUCHET was.
+        //
+        // **It never moves `progress`, and that asymmetry with the ceiling is
+        // the whole safety of it.** A ceiling pulls the ladder DOWN when it
+        // bites, which is safe in the worst case — the child is handed work that
+        // is too easy. The mirror write would push a child UP the ladder on a
+        // pack's say-so, which is `HINT_BAND` inverted and would let one
+        // mis-declared manifest promote every child who opened it. So the host's
+        // model of where the child stands is left exactly as `judge` left it;
+        // what changes is only which of its rungs this pack is served from, and
+        // the answers come back as evidence at the rung they were drawn from
+        // (`Attempt.rung`) so the band still converges on its own.
+        //
+        // The ceiling wins a contradiction. A pack declaring `min > max` has
+        // declared an empty window, which is a pack bug, and of the two rules
+        // "never serve above what a pack can render" is the one whose failure is
+        // a blank screen in front of a child — PR 694 again.
+        const bottom = Math.ceil(minDifficulty * span)
+        index = Math.max(index, bottom)
+        if (maxDifficulty !== undefined) {
+          const cap = Math.floor(maxDifficulty * span)
+          if (bottom > cap) {
+            index = cap
+            sayOnce(
+              `window:${packId}`,
+              `[packs] ${packId} asked for a minDifficulty of ${minDifficulty.toFixed(2)} and a ` +
+                `maxDifficulty of ${maxDifficulty.toFixed(2)}, which is an empty window — the ` +
+                `ceiling wins, because serving above one is a question the pack cannot render`,
+            )
+          }
+        }
+      }
       index = Math.max(0, Math.min(span, index))
 
       sequence += 1
@@ -1820,6 +1893,17 @@ export function createItemService(deps: ItemServiceDeps): ItemService {
         if (maxDifficulty !== undefined) {
           drawn = Math.min(drawn, Math.max(0, Math.floor(maxDifficulty * span)))
         }
+        // And back inside the floor, for the reason the ceiling is re-applied
+        // here: a spread that can reach under a stated floor is not a floor. The
+        // ceiling is applied first so it still wins an empty window, exactly as
+        // above.
+        if (minDifficulty !== undefined) {
+          drawn = Math.max(drawn, Math.min(span, Math.ceil(minDifficulty * span)))
+          if (maxDifficulty !== undefined) {
+            drawn = Math.min(drawn, Math.max(0, Math.floor(maxDifficulty * span)))
+          }
+        }
+        drawn = Math.max(0, Math.min(span, drawn))
       }
 
       const rung = wanted ?? rungAt(drawn)

--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -910,3 +910,154 @@ test('the wind arrives because the LADDER moved, not because waves went by', () 
   // And when it does arrive it is a real adjustment, not a nudge.
   for (const c of caps) assert.ok(c === 0 || c >= 3, `a cap of ${c} is not arithmetic`)
 })
+
+/* ------------------------------------------------------------------ *
+ * The band, which the harness above does not have.
+ * ------------------------------------------------------------------ */
+
+/**
+ * A host that behaves like the shipped one *including its band*.
+ *
+ * `ladderHost` models a host that serves whatever rung it is asked for, and
+ * every search test in this file passed against it while the game was showing
+ * the founder an empty prompt frame over an empty field on a real tablet. What
+ * it was missing is `HINT_BAND`: since host 0.3.7 a `difficulty` is a HINT,
+ * clamped to one rung either side of where the host's own evidence stands, and
+ * that evidence opens at rung 0 every session. So the sweep asked for rung 18
+ * a hundred times and was served rung 1 a hundred times.
+ *
+ * `minDifficulty` is the host's capability channel and is honoured absolutely,
+ * because a question the game cannot put on the field is not a question. This
+ * host honours it the way `items.ts` does: after the band, ceil-rounded, and it
+ * never moves the ladder — a pack does not get to promote a child by declaring
+ * what it can draw.
+ */
+function bandedHost(opts: { standing?: number; rungs?: typeof RUNGS } = {}): {
+  host: Host
+  asks: number[]
+  floors: Array<number | null>
+  served: number[]
+} {
+  const table = opts.rungs ?? RUNGS
+  const span = 65
+  const standing = opts.standing ?? 0
+  const asks: number[] = []
+  const floors: Array<number | null> = []
+  const served: number[] = []
+  let want: number | null = null
+  let floor: number | null = null
+  let n = 0
+  const host: Host & {
+    setDifficulty?: (d: number) => void
+    setMinDifficulty?: (d: number | null) => void
+  } = {
+    next: (): Question => {
+      n++
+      const asked = want === null ? standing : Math.round(want * span)
+      let index = Math.max(standing - 1, Math.min(standing + 1, asked))
+      if (floor !== null) index = Math.max(index, Math.ceil(floor * span))
+      index = Math.max(0, Math.min(span, index))
+      const ordinate = index / span
+      const band = table.find((b) => ordinate < b.upto) ?? table[table.length - 1]
+      const spread = band.hi - band.lo + 1
+      const a = band.lo + ((n * 7) % spread)
+      served.push(ordinate)
+      return {
+        id: `q${n}`,
+        prompt: `? = ${a}`,
+        answer: String(a),
+        distractors: [String(a + 11), String(a + 23)],
+        domain: 'add-sub',
+        difficulty: ordinate,
+      }
+    },
+    report: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => true,
+    setDifficulty: (d: number) => {
+      asks.push(d)
+      want = d
+    },
+    setMinDifficulty: (d: number | null) => {
+      floors.push(d)
+      floor = d
+    },
+  }
+  return { host, asks, floors, served }
+}
+
+test('the opening wave stocks against a host that clamps a difficulty to its own band', () => {
+  // **The founder's screenshot, reproduced and then fixed.** 0.3.9, Android,
+  // portrait: the prompt box drew as an empty rounded rectangle and the range
+  // held no keeps at all. The trebuchet, the ground, the ruler and every control
+  // rendered normally, because the pack mounts and lays out fine — it had simply
+  // been handed a hundred probes' worth of `dw.add.facts` and could not stand a
+  // keep at an answer of 7.
+  //
+  // Nothing in this pack had changed. `HINT_BAND` landed in the host in 0.3.7
+  // and there was no channel through which a game could say "I cannot draw a
+  // question that easy", only one for "I cannot draw a question that hard".
+  const dom = installDom()
+  const { host, floors } = bandedHost({ standing: 0 })
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim'),
+    'the wave never became playable — the search was served the bottom of the ladder on every ' +
+      'probe and dropped every answer, which is an empty prompt frame over an empty field',
+  )
+  const answer = game.currentAnswer()
+  assert.notEqual(answer, -1, 'there is no question on the screen')
+  assert.ok(game.towerRanges().length > 0, 'the range has no keeps standing on it')
+  assert.ok(game.towerRanges().includes(answer), 'the answer has no keep to knock down')
+
+  // And it got there by SAYING what it cannot draw, not by luck.
+  assert.ok(floors.length > 0, 'the pack never stated a floor, so the band was never escaped')
+})
+
+test('every probe states the floor it is probing, so the sweep is a sweep', () => {
+  // The floor moves WITH the search. A pack that stated one floor and then swept
+  // its `difficulty` underneath it would be pinned at the opening guess forever,
+  // because the floor is the only channel the host honours — the `difficulty`
+  // under it is a hint the band eats. And the opening guess is documented as a
+  // guess: answer magnitude is not monotonic in the ladder, which is the whole
+  // reason `stock()` walks instead of bisecting.
+  //
+  // So the ladder here has NOTHING placeable at the opening probe. A floor
+  // stated once and held pins the served rung there and the wave never stocks;
+  // a floor that follows the sweep climbs out. A table whose opening probe is
+  // already placeable was written here first and proved neither.
+  const dom = installDom()
+  const { host, asks, floors } = bandedHost({
+    standing: 0,
+    rungs: [
+      { upto: 0.5, lo: 0, hi: 9 }, // where the search opens — unplaceable
+      { upto: 1.01, lo: 20, hi: 90 }, // placeable, and only reachable by sweeping
+    ],
+  })
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim'),
+    'the search never climbed out of the unplaceable rungs it opened on — a floor that does not ' +
+      'follow the sweep is a floor that pins it',
+  )
+  assert.notEqual(game.currentAnswer(), -1, 'there is no question on the screen')
+
+  assert.ok(asks.length > 1, 'the search stocked on its first probe, so it never had to move')
+  assert.equal(
+    floors.length,
+    asks.length,
+    `the pack made ${String(asks.length)} difficulty requests and stated ${String(floors.length)} ` +
+      `floors — a probe without a floor is a probe the band eats`,
+  )
+  for (let i = 0; i < asks.length; i++) {
+    assert.equal(
+      floors[i],
+      asks[i],
+      `probe ${String(i)} asked for ${String(asks[i])} and declared a floor of ${String(floors[i])}`,
+    )
+  }
+})

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -522,12 +522,31 @@ export class TrebuchetGame {
    */
   private stock(): boolean {
     const cfg = this.cfg
-    const anyHost = this.host as Host & { setDifficulty?: (d: number) => void }
+    const anyHost = this.host as Host & {
+      setDifficulty?: (d: number) => void
+      setMinDifficulty?: (d: number | null) => void
+    }
     // Only when it has actually moved. Re-stating a difficulty makes the host
     // flush and refill its pool, so asking again for what was already asked keeps
     // the pool permanently empty — the search would outrun the questions.
     if (this.askedD !== this.probeD) {
       this.askedD = this.probeD
+      // **The floor first, and it is what makes the sweep a sweep.** A
+      // `difficulty` is a hint the host clamps to one rung either side of where
+      // its own evidence has the child, and that evidence opens every session at
+      // the bottom of the ladder — so from host 0.3.7 this whole search was
+      // served rung 1 on every one of its hundred probes, dropped every answer
+      // for being under 14 metres, and left the child looking at an empty prompt
+      // frame on an empty field. `minDifficulty` is the host's capability
+      // channel and is honoured absolutely, because a question this game cannot
+      // put on the field is not a question.
+      //
+      // Stating the CURRENT probe as the floor is a true claim and not a way
+      // round the band: every rung under it has already been probed and found
+      // unplaceable, or has not been probed and will be if the sweep turns
+      // round, in which case the floor comes down with it. The sweep is the
+      // pack measuring what it can render, and this is where it reports it.
+      anyHost.setMinDifficulty?.(this.probeD)
       anyHost.setDifficulty?.(this.probeD)
     }
     this.probes++

--- a/dynawalla/packs/sdk/src/guest.test.ts
+++ b/dynawalla/packs/sdk/src/guest.test.ts
@@ -315,12 +315,21 @@ test("a difficulty request is on the wire, and only the fields that were named",
 
   // The whole point: a pack can say how hard it wants the next question, and
   // the ordinate it was actually served comes back on the item.
-  const served = await host.nextItem({ difficulty: 0.25, maxDifficulty: 0.6 })
+  // Both halves of the capability window travel, and the floor is asserted here
+  // rather than assumed: a field the guest never packs is a field the host never
+  // sees, every test on either side of the wire still passes, and the child gets
+  // the empty screen the pack declared it was avoiding. That is TREBUCHET's bug
+  // one layer further out.
+  const served = await host.nextItem({
+    difficulty: 0.25,
+    maxDifficulty: 0.6,
+    minDifficulty: 0.1,
+  })
   assert.equal(served?.difficulty, 0.25)
   assert.deepEqual(seen[0], {
     id: 1,
     method: "items.next",
-    params: { difficulty: 0.25, maxDifficulty: 0.6 },
+    params: { difficulty: 0.25, maxDifficulty: 0.6, minDifficulty: 0.1 },
   })
 
   // A field nobody named is absent rather than an explicit `undefined`: a

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -154,6 +154,25 @@ export type ItemRequest = {
    * deciding a child's level, which `difficulty` deliberately no longer does.
    */
   readonly maxDifficulty?: number
+  /**
+   * A floor on the same 0..1 scale. Never serve easier than this.
+   *
+   * The other half of `maxDifficulty` and absolute for the same reason: it is a
+   * pack saying what it can physically draw, so it is honoured above the host's
+   * band as well as below it. A game whose renderable content sits ABOVE where
+   * the host has the child — TREBUCHET, where the answer is a distance on a
+   * 122-metre field and nothing under 14 fits — is served nothing usable
+   * without it, because `difficulty` alone is clamped to the band and the band
+   * opens at the bottom of the ladder every session.
+   *
+   * Set it only to what the game genuinely cannot render. It does not move the
+   * child's ladder position in either direction, so a floor that is really a
+   * preference buys a pack nothing except a child stuck on work too hard: the
+   * host will keep serving inside the window and the band will never rescue
+   * them. If the window is empty (`minDifficulty` above `maxDifficulty`) the
+   * ceiling wins and the host says so once.
+   */
+  readonly minDifficulty?: number
 }
 
 export type HostClient = {
@@ -547,6 +566,7 @@ function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
       if (options.skillId !== undefined) params["skillId"] = options.skillId
       if (options.difficulty !== undefined) params["difficulty"] = options.difficulty
       if (options.maxDifficulty !== undefined) params["maxDifficulty"] = options.maxDifficulty
+      if (options.minDifficulty !== undefined) params["minDifficulty"] = options.minDifficulty
       const result = await call("items.next", params)
       return (result as { item: Item | null }).item
     },

--- a/dynawalla/packs/shared/game-host/index.test.ts
+++ b/dynawalla/packs/shared/game-host/index.test.ts
@@ -181,9 +181,15 @@ function fakeHost(
         const span = Math.max(1, rungs - 1)
         const cap = ask.maxDifficulty === undefined ? 1 : ask.maxDifficulty
         const wanted = ask.difficulty === undefined ? fake.standing / span : ask.difficulty
+        // The floor is honoured the way the shipped host honours it: absolutely,
+        // after the request and after the ceiling, and the ceiling wins an empty
+        // window because serving over one is a question the pack cannot render.
+        // A fake that ignored `minDifficulty` would let every assertion below
+        // pass against an adapter that never sent it.
+        const bottom = ask.minDifficulty === undefined ? 0 : ask.minDifficulty
         let index = Math.max(
           0,
-          Math.min(rungs - 1, Math.round(Math.min(wanted, cap) * span)),
+          Math.min(rungs - 1, Math.round(Math.min(Math.max(Math.min(wanted, cap), bottom), cap) * span)),
         )
         // A named skill wins outright and is served at the FIRST rung that
         // carries it, whatever the difficulty and whatever the ceiling. That is
@@ -1708,6 +1714,109 @@ test("a skills option a game passes wins over the manifest", async () => {
     fake.asks.filter((ask) => ask.skillId !== undefined).length,
     0,
     "a pack that opted out of the restriction had a skill named on its behalf",
+  )
+  mounted.dispose()
+})
+
+/* ------------------------------------------------------------------ *
+ * `setMinDifficulty`: the capability floor, on the wire.
+ * ------------------------------------------------------------------ */
+
+test("a floor a game states reaches the host, and it stands until it is withdrawn", async () => {
+  // TREBUCHET's bug, at this layer. `setDifficulty` alone is a hint the host
+  // clamps into its own band, and a game whose renderable content sits above
+  // the child is served the bottom of the ladder and drops every question. The
+  // floor is the channel that says "cannot", not "would like", and this asserts
+  // it actually crosses the wire — the whole defect was a request nobody heard.
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  const before = fake.asks.length
+
+  mounted.host.setMinDifficulty(0.6)
+  mounted.host.next()
+  await settle(6)
+
+  const sent = fake.asks.slice(before)
+  assert.ok(sent.length > 0, "no request was made at all")
+  assert.ok(
+    sent.every((ask) => ask.minDifficulty === 0.6),
+    `the floor reached the host on ${String(sent.filter((a) => a.minDifficulty === 0.6).length)} ` +
+      `of ${String(sent.length)} requests — it is a standing statement, not a per-question one`,
+  )
+
+  // And it comes back off when the game says so, because a game that has found
+  // its band and then re-opened its search must not be pinned by the old one.
+  const mark = fake.asks.length
+  mounted.host.setMinDifficulty(null)
+  mounted.host.next()
+  await settle(6)
+  const after = fake.asks.slice(mark)
+  assert.ok(
+    after.every((ask) => ask.minDifficulty === undefined),
+    "a withdrawn floor was still being sent",
+  )
+  mounted.dispose()
+})
+
+test("a floor that RISES flushes the pool it invalidated", async () => {
+  // The stall this whole change exists to remove, one layer down. A pack
+  // searching for a rung it can render states a floor, and the sixty-four
+  // questions already pooled under it are now unrenderable — TREBUCHET cannot
+  // stand a keep at an answer of 7 however near rung 1 is to the rung it asked
+  // for. `maybeFlush` cannot see this: it measures how far the AIM moved, and a
+  // game that states a floor without ever stating a difficulty moves it by
+  // nothing at all. So the floor has to flush on its own.
+  //
+  // Two floors, not one, and that is the whole point of the test: the FIRST
+  // request of any kind flushes anyway, so a test that states one floor proves
+  // nothing about this at all.
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+
+  mounted.host.setMinDifficulty(0.5)
+  await settle(12)
+  const settled = mounted.host.next()
+  assert.ok(settled.difficulty >= 0.5 - 1e-9, "the first floor was not honoured")
+  assert.ok(settled.difficulty < 0.9, "the pool is already above the second floor, so this proves nothing")
+  await settle(12)
+
+  const floor = 0.9
+  mounted.host.setMinDifficulty(floor)
+  await settle(12)
+
+  for (let i = 0; i < 12; i++) {
+    const question = mounted.host.next()
+    assert.ok(
+      question.difficulty >= floor - 1e-9,
+      `question ${String(i)} came back at ${String(question.difficulty)}, under the stated floor ` +
+        `of ${String(floor)} — a floor that rose did not flush the pool it invalidated`,
+    )
+    await settle(2)
+  }
+  mounted.dispose()
+})
+
+test("a floor is not `raiseFloor`, and the two do not collapse into one", async () => {
+  // `raiseFloor` is siege's preference — it moves this module's own target and
+  // the host is free to clamp it back. `setMinDifficulty` is a capability and
+  // goes on the wire. Merging them would silently promote every siege wave into
+  // a statement the host must honour absolutely.
+  const fake = fakeHost()
+  const mounted = attachGameHost(fake.client)
+  await mounted.warm()
+  const before = fake.asks.length
+
+  mounted.host.raiseFloor(0.5)
+  mounted.host.next()
+  await settle(6)
+
+  const sent = fake.asks.slice(before)
+  assert.ok(sent.length > 0)
+  assert.ok(
+    sent.every((ask) => ask.minDifficulty === undefined),
+    "`raiseFloor` now sends a capability claim the host must honour absolutely",
   )
   mounted.dispose()
 })

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -199,6 +199,16 @@ export type DifficultyRequest = {
    * until the game names a different one.
    */
   readonly maxDifficulty?: number
+  /**
+   * A floor on the same scale. The stream never goes below it, and it stands
+   * until the game names a different one.
+   *
+   * The other half of `maxDifficulty`. Absolute on the host's side — it is a
+   * pack saying what it can physically draw, so it is honoured above the host's
+   * own band as well as below it, which is exactly what `difficulty` is not.
+   * See `setMinDifficulty` for when a game is entitled to one.
+   */
+  readonly minDifficulty?: number
 }
 
 /**
@@ -350,6 +360,29 @@ export type GameHost = {
    * feature-detecting this since it shipped.
    */
   setDifficulty(difficulty: number): void
+  /**
+   * The easiest question this game can physically put on the screen, as a
+   * standing statement, or `null` to withdraw it.
+   *
+   * **Not a preference, and not `raiseFloor`.** `raiseFloor` is a game saying
+   * "a wave I have reached justifies a floor under the maths" — it moves this
+   * module's own `target`, which the host is free to clamp back into its band.
+   * This one goes on the wire as `minDifficulty` and the host honours it
+   * absolutely, because the alternative is handing a game a question it cannot
+   * render. That is the same promise `maxDifficulty` already makes, and it was
+   * only ever made in one direction: a pack whose renderable content sits BELOW
+   * the child could say so and a pack whose content sits ABOVE the child could
+   * not, so it was served the bottom of the ladder and dropped every question.
+   * TREBUCHET — whose answer is a distance on a 122-metre field, so nothing
+   * under 14 fits — showed a child an empty frame on an empty field for three
+   * releases because of it.
+   *
+   * A game with no such constraint must not call this. It does not move the
+   * child's ladder position, so a floor that is really a preference cannot be
+   * corrected by the host's own evidence: it just parks a child above their
+   * level for as long as the game keeps stating it.
+   */
+  setMinDifficulty(difficulty: number | null): void
   /**
    * Raise the floor under the stream and never lower it again. siege has been
    * feature-detecting this since it shipped: a wave that has been reached
@@ -914,6 +947,14 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   let target: number | null = null
   /** A standing ceiling, 0..1, or null for none. */
   let ceiling: number | null = null
+  /**
+   * A standing floor the host honours absolutely, 0..1, or null for none.
+   *
+   * Distinct from `floor` below, and the two must not be merged: that one is a
+   * game's own preference and this one is a statement about what the game can
+   * draw at all. See `setMinDifficulty`.
+   */
+  let renderFloor: number | null = null
   /** A floor that only ever rises. siege drives this. */
   let floor = 0
   /**
@@ -1047,9 +1088,15 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
    * rung it will not choose with them.
    */
   const askShape = (pin?: string): ItemRequest => {
-    const ask: { difficulty?: number; maxDifficulty?: number; skillId?: string } = {}
+    const ask: {
+      difficulty?: number
+      maxDifficulty?: number
+      minDifficulty?: number
+      skillId?: string
+    } = {}
     if (target !== null) ask.difficulty = target
     if (ceiling !== null) ask.maxDifficulty = ceiling
+    if (renderFloor !== null) ask.minDifficulty = renderFloor
     if (pin !== undefined) ask.skillId = pin
     return ask
   }
@@ -1283,14 +1330,25 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
   const distance = (entry: Pooled): number => {
     const want = aim() ?? ceiling ?? entry.question.difficulty
     const over = ceiling !== null && entry.question.difficulty > ceiling + EPS
-    // A question above a stated ceiling is never the answer while anything else
-    // exists, and is still an answer when nothing else does.
-    return Math.abs(entry.question.difficulty - want) + (over ? 1000 : 0)
+    // A question below a stated floor is unrenderable for the same reason one
+    // above the ceiling is, so it is ranked the same way: never while anything
+    // else exists, and still an answer when nothing else does. Without this the
+    // pool a game filled BEFORE it stated its floor keeps being served out of
+    // preferentially, and the floor takes sixty-four questions to bite.
+    const under = renderFloor !== null && entry.question.difficulty < renderFloor - EPS
+    return Math.abs(entry.question.difficulty - want) + (over || under ? 1000 : 0)
   }
 
   const flushNow = () => {
     lastFlush = now()
     filledFor = aim()
+    // The reserve below is chosen by `distance`, which already ranks a question
+    // under a stated floor a thousand short of anything else — so a reserve is
+    // made of renderable questions whenever any exist. Emptying the pool of the
+    // under-floor ones outright was tried and reverted: it hands the game the
+    // dry-pool sentinel, which is a question with no id whose answer cannot be
+    // reported, and a game searching for a rung it can render would meet one on
+    // every probe. Eight stale questions the game drops is the cheaper failure.
     if (aim() !== null && pool.length > FLUSH_KEEP) {
       // A focused value survives a flush whatever its difficulty. `focus`
       // outranks difficulty when a question is handed out — FUSE's chip has to
@@ -1334,11 +1392,21 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
       const unit = readScale(request.maxDifficulty, "maxDifficulty")
       if (unit !== null) ceiling = unit
     }
+    if (request.minDifficulty !== undefined) {
+      const unit = readScale(request.minDifficulty, "minDifficulty")
+      if (unit !== null) renderFloor = unit
+    }
     if (request.difficulty !== undefined) {
       const unit = readScale(request.difficulty, "difficulty")
       if (unit !== null) target = Math.max(unit, floor)
     }
     if (target !== null && ceiling !== null) target = Math.min(target, ceiling)
+    // The floor is a capability and the ceiling is a capability, so between the
+    // two of them there is nothing to choose here — the HOST resolves an empty
+    // window and says so once. What is resolved here is only where this module
+    // AIMS: a target under a stated floor would sort the pool toward questions
+    // the game has just said it cannot draw.
+    if (target !== null && renderFloor !== null) target = Math.max(target, renderFloor)
     maybeFlush()
   }
 
@@ -1522,6 +1590,26 @@ export function attachGameHost(client: HostClient, options: GameHostOptions = {}
 
     setDifficulty: (difficulty) => {
       applyRequest({ difficulty })
+    },
+
+    setMinDifficulty: (difficulty) => {
+      if (difficulty === null) {
+        if (renderFloor === null) return
+        renderFloor = null
+        return
+      }
+      // `readScale` once and here, not again inside `applyRequest`: it is
+      // idempotent on a value already in 0..1, but relying on that is how a
+      // second scale conversion goes unnoticed until a game speaks the other
+      // one. `applyRequest` is then handed the raw request, as everywhere else.
+      if (readScale(difficulty, "minDifficulty") === renderFloor) return
+      applyRequest({ minDifficulty: difficulty })
+      // Unconditionally, and not through `maybeFlush`. A floor that rose past
+      // the pool invalidates every question in it, and `maybeFlush` measures how
+      // far the AIM moved — which is zero for a game that states a floor without
+      // ever stating a difficulty. Sixty-four unrenderable questions is exactly
+      // the stall this whole change exists to remove.
+      flushNow()
     },
 
     raiseFloor: (difficulty) => {


### PR DESCRIPTION
The founder, on 0.3.9, Android, portrait:

> "trebuchet is completely broken. it doesn't show a problem and there are no buildings"

The prompt box drew as an empty rounded rectangle and the range held no keeps. The trebuchet, the ground line, the ruler, the `+`/`−` buttons and the fire control all rendered normally, because the pack mounts and lays out fine. It had simply been handed a hundred probes' worth of questions it cannot put on a field, and had refused every one of them.

## Nothing in this pack had changed

`git log dynawalla-v0.3.8..main -- dynawalla/games/trebuchet` is empty. The regression is the host's, and it did **not** ship in 0.3.9 — it shipped in **0.3.7**, in #735.

## What broke

`HINT_BAND` made a pack's `difficulty` a hint clamped to one rung either side of `Math.floor(progress)`, and `progress` opens at 0 every session. Rungs 0 and 1 are `dw.add.facts.add-within-ten`, answers 0..10. A keep in TREBUCHET stands at its own answer in **metres** on a 122-metre field, so the only questions it can draw at all are the ones whose answer is an integer in 14..118.

Driven against the real item service the way the pack drives it — the sweep in `stock()`, a hundred probes, ten pulls each:

| release | result |
|---|---|
| 0.3.6 | served rung 21 on the first probe, **STOCKED**, keeps at 96 72 66 81 42 24 35 96 14 |
| 0.3.7 | served rung 1 on every probe — **0 of 1000 placeable** |
| 0.3.8 | 0 of 1000 |
| 0.3.9 | 0 of 1000 |

`maxDifficulty` could not have saved it. That channel is absolute and documented as a *capability* — a pack saying what it can physically draw — and it binds below the band and above it. But it only points one way:

```
index = min(clamp(asked, anchor ± 1), cap)
```

A pack whose renderable content sits **below** the child could say so; a pack whose renderable content sits **above** the child could not. The note on `HINT_BAND` says a pack that pins its ceiling to its request "has opted out of the band" — that was only ever true when the window happened to sit under the child.

## The fix is the other half of the window

`minDifficulty`, on the SDK, across the bridge, into `next()`: absolute, honoured above the band as well as below it, **ceil**-rounded where the cap **floors** (rounding a floor down serves under it — the same rounding bug the cap already carries a note about), and the ceiling wins an empty window because serving above one is PR 694 again.

**It never moves `progress`, and that asymmetry is the whole safety of it.** A ceiling pulls the ladder DOWN when it bites, which is safe in the worst case. The mirror write would push a child UP on a pack's say-so — `HINT_BAND` inverted, and one mis-declared manifest promoting every child who opened it. So the host's model of the child is left exactly as `judge` left it; only which of its rungs this pack is served from changes, and the answers come back as evidence at the rung they came from, so the band converges on its own.

TREBUCHET states the floor it is probing on **every** probe, which is a true claim and not a way round the band: every rung under it has been probed and found unplaceable, and if the sweep turns round the floor comes down with it. The sweep is the pack measuring what it can render; this is where it reports it.

## Fleet

Three packs refuse an unrepresentable item: `trebuchet`, `balance`, `runner`. `balance` is bounded **above** (`MAX_COPIES = 12` — "too many crates"), which `maxDifficulty` already covers. **TREBUCHET is the only pack whose renderable content sits above the child, and the only one this clamp starved.** All 25 pack suites, the app, the SDK, game-host and the curriculum are green; `node packs/build.mjs trebuchet` builds and passes the checker.

## Verification

Suites 5× consecutively, `tsc` in all five packages. The headline test fails on `origin/main`:

```
✖ a pack whose renderable content sits above the child is served something it can render
  AssertionError: the search swept 100 probes and 1000 questions without one answer it
  could stand a keep at — this is the founder's empty field, and it is what 0.3.7
  through 0.3.9 shipped (0 of 1000 placeable)

✖ the opening wave stocks against a host that clamps a difficulty to its own band
  AssertionError: the wave never became playable — the search was served the bottom of
  the ladder on every probe and dropped every answer, which is an empty prompt frame
  over an empty field
```

`game.test.ts` gains `bandedHost`, which models `HINT_BAND`. The harness it sits next to does not — which is why 134 pack tests were green while a child looked at an empty field. `bridge.test.ts` and `guest.test.ts` pin the field onto the wire: a field the wire drops is the worst shape of this bug, because both sides pass and the child still gets the empty screen.

### Mutation transcript — 16 mutations, 16 failures

| # | mutation | assertion that caught it |
|---|---|---|
| M1 | `askShape` stops sending `minDifficulty` | `the floor reached the host on 0 of 32 requests — it is a standing statement, not a per-question one` |
| M2 | `setMinDifficulty(null)` stops withdrawing | `a withdrawn floor was still being sent` |
| M3 | `setMinDifficulty` stops flushing | `question 0 came back at 0.8, under the stated floor of 0.9 — a floor that rose did not flush the pool it invalidated` |
| M4 | `raiseFloor` also states a capability floor | `` `raiseFloor` now sends a capability claim the host must honour absolutely `` |
| M5 | `distance()` stops penalising under-floor entries | (same as M3) |
| M6 | the floor rounds to nearest instead of up | `a floor between two rungs was rounded down, under itself` |
| M7 | the floor yields to the band | `a stated floor was clamped back into the band, which makes it not a floor` |
| M8 | empty window resolved upward — point path | `an empty capability window was resolved upward — a pack was handed a rung it declared it cannot render` |
| M9 | the empty-window warning is said every time | `the empty window was announced 3 times, not once` |
| M10 | a floor pins the ladder UP, mirroring the ceiling | `` a stated floor moved the host's ladder — a pack can now promote a child by declaring a capability, which is `HINT_BAND` inverted `` |
| M11 | the spread can reach under the floor | `the spread served rung 17, under the stated floor of 18` |
| M12 | empty window resolved upward — spread path | (same as M8) |
| M13 | the pack stops stating a floor | `the wave never became playable — …an empty prompt frame over an empty field` |
| M14 | the floor is stated once and does not follow the sweep | `the search never climbed out of the unplaceable rungs it opened on — a floor that does not follow the sweep is a floor that pins it` |
| M15 | the bridge drops `minDifficulty` on the floor | `Expected values to be strictly deep-equal` |
| M16 | the SDK guest drops `minDifficulty` on the wire | `Expected values to be strictly deep-equal` |

M6 and M8 escaped on the first pass and both assertions were strengthened: M6 because `round(9.6)` and `ceil(9.6)` are both 10, so the original offset proved nothing; M8 because the test only exercised the spread path, and the point path is separate code. M14 escaped because the test's ladder made the opening probe placeable, so the sweep never had to move — it now opens on unplaceable rungs.

Two things were built and reverted, and the reasons are in the code: emptying the pool of under-floor questions at flush (it hands the game the dry-pool sentinel, a question with no id, on every probe), and a `progress` write-back mirroring the ceiling's.

### Known, out of scope

The miss-reveal in this pack is still a visual no-op on waves 1–8.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb