### PR TITLE
dynawalla/games: the safe area arrives from the host in STACK and POLARITY too

### DIFF
--- a/dynawalla/games/claim/src/game/index.ts
+++ b/dynawalla/games/claim/src/game/index.ts
@@ -10,6 +10,7 @@
 import {
   createInstructions,
   onInsetsChange,
+  publishSafeVars,
   safeInsets,
   type Instructions,
 } from "../../../../packs/shared/game-chrome/index.ts"
@@ -316,6 +317,12 @@ class Claim {
     // when a pack is resized in Split View, and a game that reads them once at
     // mount is correct until the first rotation and wrong after it.
     const insets = safeInsets()
+    // The cards centre their contents in the whole frame, so they need the raw
+    // insets rather than a derived box. Published here for the same reason
+    // everything else in this game is: `env()` resolves to zero inside a pack
+    // frame, because a pack is a cross-origin child and `env()` belongs to the
+    // top-level document.
+    publishSafeVars(this.root, "--cl-safe-", insets)
     this.r.resize(w, h, arenaRect(w, h, insets))
     const fw = this.root.clientWidth || w
     const fh = this.root.clientHeight || h

--- a/dynawalla/games/claim/src/style.css
+++ b/dynawalla/games/claim/src/style.css
@@ -366,7 +366,22 @@
   justify-content: center;
   gap: 10px;
   text-align: center;
-  padding: 20px;
+  /* The card is full-bleed and centres its children, so this padding is what
+     decides where a centred stack ends up. A flat 20px ignored the insets
+     entirely — on a 393x851 Android phone held sideways, with a 24px status
+     bar, the big goal fraction started at y=21 and the top of it was under the
+     clock. The insets are published by `Claim.layout` from the same
+     `safeInsets()` everything else here uses; the `env()`s are the dev-tab
+     fallback, where there is no host to publish anything.
+
+     Four longhands, not a shorthand: a shorthand resets all four sides, so a
+     breakpoint that only wanted a tighter card would take the safe area with
+     it. Change --cl-card-pad instead. */
+  --cl-card-pad: 20px;
+  padding-top: calc(var(--cl-card-pad) + var(--cl-safe-top, env(safe-area-inset-top, 0px)));
+  padding-right: calc(var(--cl-card-pad) + var(--cl-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: calc(var(--cl-card-pad) + var(--cl-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: calc(var(--cl-card-pad) + var(--cl-safe-left, env(safe-area-inset-left, 0px)));
   pointer-events: none;
 }
 .cl-card.cl-on {

--- a/dynawalla/games/claim/test/safearea.test.ts
+++ b/dynawalla/games/claim/test/safearea.test.ts
@@ -1,0 +1,350 @@
+// THE STYLESHEET, EVALUATED.
+//
+// `layout.test.ts` proves `hudFrame` and `muteRect` clear the notch and the
+// host's two corners. That is a proof about a MODEL. The screen is laid out by
+// `style.css`, and the question this file exists to answer is whether the two
+// are the same thing — because in three sibling packs they were not, and the
+// suite was green the whole time.
+//
+// A pack runs in an iframe sandboxed `allow-scripts` with no
+// `allow-same-origin`. `env(safe-area-inset-*)` belongs to the TOP-LEVEL
+// browsing context, so a cross-origin child resolves all four to ZERO. SIEGE,
+// STACK and POLARITY each read `env()` directly from their stylesheets and each
+// shipped a HUD under the Android status bar while their own tests passed.
+//
+// CLAIM was built the other way round from the start: `layout.ts` owns the
+// numbers, `Hud.layout` and `Claim.layout` publish them as custom properties,
+// and the `env()`s in `style.css` sit behind those properties as fallbacks for a
+// dev browser tab. This file is the evidence for that claim rather than a
+// description of it: it parses the shipped stylesheet, runs the cascade, and
+// evaluates every offset to a NUMBER with env() defined as zero.
+//
+// Nothing in this file changed the game. If it ever goes red, the game changed.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+import {
+  HOST_CONTROL,
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+} from "../../../packs/shared/game-chrome/index.ts"
+import {
+  SHAPES,
+  customPropsOf,
+  lengthOf,
+  paddingOf,
+  parseCss,
+  type Viewport,
+} from "../../../packs/shared/game-chrome/cssSafeArea.ts"
+import { hudFrame, muteRect } from "../src/game/layout.ts"
+
+const read = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8")
+
+const CSS = read("../src/style.css")
+const RULES = parseCss(CSS)
+
+/**
+ * Exactly what the running game publishes, in the same order it publishes it.
+ *
+ * `Hud.layout` writes the seven HUD properties from `hudFrame`; `Claim.layout`
+ * writes the three mute properties from `muteRect`. Both are called with the
+ * FRAME's size — `.cl-root` is 100%×100% — and with `safeInsets()`.
+ */
+function published(w: number, h: number, insets: Insets, vp: Viewport): Map<string, string> {
+  const vars = customPropsOf(RULES, ".cl-root", vp)
+  const f = hudFrame(w, h, insets)
+  vars.set("--cl-pt", `${f.padTop}px`)
+  vars.set("--cl-pl", `${f.padLeft}px`)
+  vars.set("--cl-pr", `${f.padRight}px`)
+  vars.set("--cl-gl", `${f.gutterLeft}px`)
+  vars.set("--cl-gr", `${f.gutterRight}px`)
+  vars.set("--cl-toph", `${f.topMinH}px`)
+  vars.set("--cl-cluster", `${f.clusterW}px`)
+  const m = muteRect(w, h, insets)
+  vars.set("--cl-mute-r", `${w - (m.x + m.w)}px`)
+  vars.set("--cl-mute-b", `${h - (m.y + m.h)}px`)
+  vars.set("--cl-mute-s", `${m.w}px`)
+  // …and the raw insets, for the cards, which centre in the whole frame.
+  for (const side of ["top", "right", "bottom", "left"] as const) {
+    vars.set(`--cl-safe-${side}`, `${insets[side]}px`)
+  }
+  return vars
+}
+
+const css = (selector: string, prop: string, s: (typeof SHAPES)[number], pct = 0): number =>
+  lengthOf(
+    RULES,
+    selector,
+    prop,
+    { w: s.w, h: s.h },
+    published(s.w, s.h, s.insets, { w: s.w, h: s.h }),
+    pct,
+  )
+
+const pad = (
+  selector: string,
+  s: (typeof SHAPES)[number],
+): Record<"top" | "right" | "bottom" | "left", number> =>
+  paddingOf(
+    RULES,
+    selector,
+    { w: s.w, h: s.h },
+    published(s.w, s.h, s.insets, { w: s.w, h: s.h }),
+  )
+
+const close = (got: number, want: number, msg: string): void => {
+  assert.ok(Math.abs(got - want) < 1e-9, `${msg}: the stylesheet says ${got}, layout.ts says ${want}`)
+}
+
+const inside = (r: Rect, safe: Rect, where: string, what: string): void => {
+  assert.ok(r.x >= safe.x - 1e-9, `${where}: ${what} crosses the LEFT inset (${r.x} < ${safe.x})`)
+  assert.ok(
+    r.x + r.w <= safe.x + safe.w + 1e-9,
+    `${where}: ${what} crosses the RIGHT inset (${r.x + r.w} > ${safe.x + safe.w})`,
+  )
+  assert.ok(r.y >= safe.y - 1e-9, `${where}: ${what} crosses the TOP inset (${r.y} < ${safe.y})`)
+  assert.ok(
+    r.y + r.h <= safe.y + safe.h + 1e-9,
+    `${where}: ${what} crosses the BOTTOM inset (${r.y + r.h} > ${safe.y + safe.h})`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// The two dialects say the same thing
+// ---------------------------------------------------------------------------
+
+test("the HUD's padding is the padding hudFrame was tested against", () => {
+  for (const s of SHAPES) {
+    const f = hudFrame(s.w, s.h, s.insets)
+    const p = pad(".cl-hud", s)
+    close(p.top, f.padTop, `${s.name}: the HUD's top padding`)
+    close(p.left, f.padLeft, `${s.name}: the HUD's left padding`)
+    close(p.right, f.padRight, `${s.name}: the HUD's right padding`)
+  }
+})
+
+test("the top row's gutters and height are the ones that walk the clusters past the host", () => {
+  for (const s of SHAPES) {
+    const f = hudFrame(s.w, s.h, s.insets)
+    close(css(".cl-top", "padding-left", s), f.gutterLeft, `${s.name}: the left gutter`)
+    close(css(".cl-top", "padding-right", s), f.gutterRight, `${s.name}: the right gutter`)
+    close(css(".cl-top", "min-height", s), f.topMinH, `${s.name}: the top row's height`)
+  }
+})
+
+test("the mute button is where muteRect puts it, at the size muteRect gives it", () => {
+  for (const s of SHAPES) {
+    const m = muteRect(s.w, s.h, s.insets)
+    close(s.w - css(".cl-mute", "right", s) - m.w, m.x, `${s.name}: the mute button's left edge`)
+    close(s.h - css(".cl-mute", "bottom", s) - m.h, m.y, `${s.name}: the mute button's top edge`)
+    close(css(".cl-mute", "width", s), m.w, `${s.name}: the mute button's width`)
+    close(css(".cl-mute", "height", s), m.h, `${s.name}: the mute button's height`)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// …and what the CSS produces is inside the safe rectangle
+// ---------------------------------------------------------------------------
+
+test("every HUD surface the stylesheet places is inside the safe area", () => {
+  for (const s of SHAPES) {
+    const safe = safeRect(s.w, s.h, s.insets)
+    const f = hudFrame(s.w, s.h, s.insets)
+    const p = pad(".cl-hud", s)
+    const gl = css(".cl-top", "padding-left", s)
+    const gr = css(".cl-top", "padding-right", s)
+    const toph = css(".cl-top", "min-height", s)
+
+    // The level counter and the score/lives cluster, at the two ends of the top
+    // row, built from the CSS numbers rather than from the model.
+    const rowX = p.left + gl
+    const rowW = s.w - p.left - p.right - gl - gr
+    const cluster = css(".cl-lvl", "max-width", s, rowW)
+    const left: Rect = { x: rowX, y: p.top, w: cluster, h: toph }
+    const right: Rect = { x: rowX + rowW - cluster, y: p.top, w: cluster, h: toph }
+    // The fraction bar spans the full inner width and is the pedagogy itself.
+    const meter: Rect = {
+      x: p.left,
+      y: p.top + toph + 7,
+      w: s.w - p.left - p.right,
+      h: css(".cl-meter", "height", s),
+    }
+    const mute: Rect = {
+      x: s.w - css(".cl-mute", "right", s) - HOST_CONTROL,
+      y: s.h - css(".cl-mute", "bottom", s) - HOST_CONTROL,
+      w: HOST_CONTROL,
+      h: HOST_CONTROL,
+    }
+
+    for (const [what, box] of [
+      ["the level counter", left],
+      ["the score and lives", right],
+      ["the fraction bar", meter],
+      ["the mute button", mute],
+    ] as const) {
+      inside(box, safe, s.name, what)
+      assert.equal(
+        hitsHostChrome(box, s.w, s.insets),
+        false,
+        `${s.name}: ${what} is under the host's exit or how-to-play control`,
+      )
+    }
+    // And the model agrees about the bar, which is the one that cannot dodge.
+    close(meter.y, f.meter.y, `${s.name}: the fraction bar's top edge`)
+  }
+})
+
+test("the safe area never clips the card that the frame was not already clipping", () => {
+  // The level card and the game-over card are full-bleed and CENTRED, so their
+  // flat 20px padding is not what keeps them off the notch — the centring is.
+  // The card's height is modelled here from the stylesheet's own type scale, at
+  // its tallest content: the big goal fraction over a percentage over a score.
+  //
+  // What this proves: wherever that stack fits inside the card's own padding
+  // box, it also fits inside the SAFE rectangle. The bottom inset on the
+  // founder's phone is 48px against a 20px padding, so if the card ever grew
+  // into it this would say so.
+  //
+  // What it does NOT prove, and is deliberately out of this change's scope: on a
+  // landscape phone the fraction's `clamp(64px, 21vw, 190px)` makes a 179px
+  // numeral and the stack overflows the 393px FRAME on its own, insets or no
+  // insets. That is a type-scale defect, it predates this file, and fixing it
+  // means changing how the game looks.
+  for (const s of SHAPES) {
+    const vp = { w: s.w, h: s.h }
+    const vars = published(s.w, s.h, s.insets, vp)
+    const px = (sel: string, prop: string): number => lengthOf(RULES, sel, prop, vp, vars)
+    const gap = px(".cl-card", "gap")
+    const frac = px(".cl-card .cl-bigfrac", "font-size")
+    const rule = px(".cl-card .cl-bigfrac i", "height") + 2 * 10
+    // Two stacks: the level card (fraction over prompt) and the game-over card
+    // (score over percentage over a line of type). The taller one is the test.
+    const level = 2 * frac * 0.82 + rule + gap + px(".cl-card p", "font-size") * 1.2
+    const over =
+      px(".cl-card h1", "font-size") * 0.86 +
+      gap +
+      px(".cl-card h2", "font-size") * 1.2 +
+      gap +
+      px(".cl-card p", "font-size") * 1.2
+    const contentH = Math.max(level, over)
+
+    // Vertical only, and on purpose. The card centres its children on BOTH
+    // axes, so a stack's horizontal extent is whatever its digits happen to
+    // measure and is symmetric about the frame's centre line — not something
+    // this stylesheet fixes and not something a parser can know. The things in
+    // this game that are pinned to a side edge, and can therefore be proven
+    // horizontally, are the level counter, the score, the fraction bar and the
+    // mute button, and every one of them is asserted above.
+    const p = pad(".cl-card", s)
+    const top = s.h / 2 - contentH / 2
+    const bottom = s.h / 2 + contentH / 2
+    if (top < p.top - 1e-9 || bottom > s.h - p.bottom + 1e-9) continue
+    const safe = safeRect(s.w, s.h, s.insets)
+    assert.ok(
+      top >= safe.y - 1e-9,
+      `${s.name}: the card's tallest content starts at ${top.toFixed(1)}, above a safe top of ${safe.y}`,
+    )
+    assert.ok(
+      bottom <= safe.y + safe.h + 1e-9,
+      `${s.name}: the card's tallest content ends at ${bottom.toFixed(1)}, below a safe bottom of ${
+        safe.y + safe.h
+      }`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// The seam
+// ---------------------------------------------------------------------------
+
+test("no rule takes its answer from env() — it is zero where this game runs", () => {
+  // The rule this pack already followed, now enforced: an `env(safe-area-inset-*)`
+  // may only appear as the FALLBACK of a `--cl-*` custom property. Read directly
+  // it is the number zero inside a pack frame, whatever the device.
+  const stripped = CSS.replace(/\/\*[\s\S]*?\*\//g, "")
+  const found = [...stripped.matchAll(/env\(safe-area-inset-(top|right|bottom|left)/g)]
+  assert.ok(found.length > 0, "the dev-harness fallbacks are gone entirely")
+  for (const m of found) {
+    const before = stripped.slice(0, m.index)
+    const open = before.lastIndexOf("var(--cl-")
+    const close = before.lastIndexOf(")")
+    assert.ok(
+      open > close,
+      `env(safe-area-inset-${m[1]}) at ${m.index} is read directly, not as the fallback of a ` +
+        `--cl-* property — inside a pack frame that is the number zero`,
+    )
+  }
+})
+
+test("no surface uses a `padding:` shorthand that a breakpoint could reset", () => {
+  // A shorthand resets all four longhands. `.cl-hud` may keep one because every
+  // one of its four sides is a published property; the card's is built from the
+  // raw insets and would lose three of them the first time a media query wanted
+  // a tighter gutter.
+  for (const rule of RULES) {
+    if (!rule.selectors.includes(".cl-card")) continue
+    assert.ok(
+      !rule.decls.some((d) => d.prop === "padding"),
+      "the card uses a `padding:` shorthand — a breakpoint can now erase its safe area",
+    )
+  }
+})
+
+test("every published property is written unconditionally, zeros included", () => {
+  // The other half of the seam. `var(--cl-pt, …)` falls back to its `env()` only
+  // when the property is ABSENT, so a publisher that skipped a zero would put
+  // the game straight back on the env() path — indistinguishable from correct
+  // until a child picks up a notched phone.
+  const none: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
+  const vars = published(393, 851, none, { w: 393, h: 851 })
+  for (const name of [
+    "--cl-pt",
+    "--cl-pl",
+    "--cl-pr",
+    "--cl-gl",
+    "--cl-gr",
+    "--cl-toph",
+    "--cl-cluster",
+    "--cl-mute-r",
+    "--cl-mute-b",
+    "--cl-mute-s",
+    "--cl-safe-top",
+    "--cl-safe-right",
+    "--cl-safe-bottom",
+    "--cl-safe-left",
+  ]) {
+    const v = vars.get(name)
+    assert.ok(v !== undefined, `${name} is not published at all on a device with no insets`)
+    assert.match(v as string, /^-?\d+(\.\d+)?px$/, `${name} was published as "${v ?? ""}"`)
+  }
+})
+
+test("the game publishes the frame at mount and again whenever the insets move", () => {
+  // A wiring check, and only that: none of the arithmetic above can see whether
+  // anything ever calls the publishers.
+  const hud = read("../src/game/hud.ts")
+  assert.ok(hud.includes('s.setProperty("--cl-pt"'), "the HUD never publishes its padding")
+  const index = read("../src/game/index.ts")
+  const at = index.indexOf("private layout()")
+  assert.ok(at > 0, "layout() is gone")
+  const body = index.slice(at, index.indexOf("\n  }", at))
+  assert.ok(body.includes("safeInsets()"), "layout() never reads the safe area")
+  assert.ok(body.includes("this.hud.layout("), "layout() never republishes the HUD's frame")
+  assert.ok(body.includes("muteRect("), "layout() never republishes the mute button")
+  assert.ok(
+    body.includes('publishSafeVars(this.root, "--cl-safe-", insets)'),
+    "layout() never publishes the raw insets — the cards fall back to an env() of zero",
+  )
+  assert.ok(index.includes("this.layout()"), "the frame is never published at all")
+  assert.ok(
+    index.includes("onInsetsChange(() => this.layout())"),
+    "nothing listens for the insets changing — the HUD keeps the shape the pack opened in",
+  )
+  assert.ok(index.includes("this.stopInsets()"), "the inset listener outlives the pack")
+})

--- a/dynawalla/games/polarity/src/mount.ts
+++ b/dynawalla/games/polarity/src/mount.ts
@@ -1,5 +1,9 @@
 import styles from "./ui/styles.css?inline";
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts";
+import {
+  createInstructions,
+  onInsetsChange,
+  safeInsets,
+} from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, Question } from "./contract.ts";
 import { TierMonitor, detectTier } from "./core/tier.ts";
 import { clamp01 } from "./core/util.ts";
@@ -352,6 +356,11 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
   let cssW = 1;
   let cssH = 1;
   function measure(): void {
+    // Read every time, never cached from construction: a rotation trades one top
+    // inset for two side ones, and iPadOS changes them when the pack is resized
+    // in Split View. Read once at mount and the register is correct until the
+    // first rotation and wrong after it.
+    hud.setInsets(safeInsets());
     const r = root.getBoundingClientRect();
     cssW = Math.max(1, Math.round(r.width));
     cssH = Math.max(1, Math.round(r.height));
@@ -360,6 +369,10 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
   }
   const ro = new ResizeObserver(() => measure());
   ro.observe(root);
+  // The insets can move without the frame moving: the host publishes its
+  // measurement over the `settings` channel, and a tablet's Split View changes
+  // them outright. Without this the register keeps the shape the pack opened in.
+  const stopInsets = onInsetsChange(() => measure());
   measure();
 
   // --- loop -----------------------------------------------------------------
@@ -422,6 +435,7 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       cancelAnimationFrame(raf);
       document.removeEventListener("visibilitychange", onVis);
       ro.disconnect();
+      stopInsets();
       saveSeen(world.cues);
       saveBest(world.stats.best);
       input.dispose();

--- a/dynawalla/games/polarity/src/ui/hud.ts
+++ b/dynawalla/games/polarity/src/ui/hud.ts
@@ -2,7 +2,8 @@ import { clamp01, fmtScore } from "../core/util.ts";
 import { fmtInt, fmtSigned, tryParseInt } from "../math/signed.ts";
 import { PLAYER } from "../game/constants.ts";
 import type { World } from "../game/world.ts";
-import { applyChromeVars } from "./layout.ts";
+import { applyChromeVars, applySafeVars } from "./layout.ts";
+import type { Insets } from "../../../../packs/shared/game-chrome/index.ts";
 
 /**
  * The HUD is DOM, not canvas: crisp numerals at every density, real safe-area
@@ -83,6 +84,7 @@ export class Hud {
   };
   private cueKey = "";
   private touch = false;
+  private insets: Insets | null = null;
 
   constructor(host: HTMLElement, private readonly hooks: HudHooks) {
     // The stylesheet is a static file and cannot be asserted about, so the
@@ -92,6 +94,13 @@ export class Hud {
     applyChromeVars(host);
 
     this.root = el("div", "pol-hud");
+
+    // The safe area cannot be read from the stylesheet at all: `env()` resolves
+    // to zero in a cross-origin child, which is what every pack frame is. It
+    // arrives from the host instead, written onto this element as four custom
+    // properties and inherited by everything under it — the mini controls, the
+    // key hint and the veil included. Republished on every resize.
+    applySafeVars(this.root);
 
     // --- top -------------------------------------------------------------
     const top = el("div", "pol-top");
@@ -184,6 +193,19 @@ export class Hud {
       },
       { capture: true },
     );
+  }
+
+  /**
+   * Republish the safe area onto the HUD root.
+   *
+   * Called on every resize rather than once at mount: a rotation trades one top
+   * inset for two side ones, and iPadOS changes them when the pack is resized in
+   * Split View. Idempotent — nothing is written when the numbers have not moved.
+   */
+  setInsets(insets: Insets): void {
+    if (applySafeVars(this.root, insets, this.insets)) {
+      this.insets = { ...insets };
+    }
   }
 
   dispose(): void {

--- a/dynawalla/games/polarity/src/ui/layout.ts
+++ b/dynawalla/games/polarity/src/ui/layout.ts
@@ -21,14 +21,32 @@
  * asserted about. These constants are written onto the root as custom
  * properties at mount, the stylesheet reads them through `var()`, and
  * `hudRects` reports the same geometry to the tests. One source.
+ *
+ * **And why the SAFE AREA is one of those numbers now.** `.pol-hud` padded all
+ * four edges with `env(safe-area-inset-*)` and had done since the first commit —
+ * and every one of those rules resolved to zero on a device. A pack runs in an
+ * iframe sandboxed `allow-scripts` with no `allow-same-origin`, and
+ * `env(safe-area-inset-*)` belongs to the TOP-LEVEL browsing context, so a
+ * cross-origin child reads all four as 0. `max(10px, env(...))` is 10px on every
+ * phone ever made, and `hudRects` below was reporting a padding the stylesheet
+ * never produced: the tests proved a HUD nobody shipped. SIEGE had exactly this
+ * and the founder found it, with the score painted under an Android clock.
+ *
+ * So `applySafeVars` publishes the host's measurement as four more custom
+ * properties and the stylesheet reads `var(--pol-safe-*, env(...))` — the
+ * `env()` kept only as the fallback for a dev browser tab, where there is no
+ * host and where it is right.
  */
 
 import {
   HOST_CONTROL,
   HOST_MARGIN,
   HOST_PROGRESS_H,
+  publishSafeVars,
+  safeInsets,
   type Insets,
   type Rect,
+  type StyleTarget,
 } from "../../../../packs/shared/game-chrome/index.ts";
 
 /**
@@ -100,4 +118,30 @@ export function hudRects(
 export function applyChromeVars(root: HTMLElement): void {
   root.style.setProperty("--pol-chrome-top", `${CHROME_TOP}px`);
   root.style.setProperty("--pol-mini-right", `${MINI_RIGHT}px`);
+}
+
+/** The namespace the four published safe-area lengths live under. */
+export const SAFE_PREFIX = "--pol-safe-";
+
+/** One safe edge, as a length `styles.css` can do arithmetic with. */
+export const cssSafe = (side: "top" | "right" | "bottom" | "left"): string =>
+  `var(${SAFE_PREFIX}${side}, env(safe-area-inset-${side}, 0px))`;
+
+/**
+ * Hand the stylesheet the safe area, from the host's own measurement.
+ *
+ * Separate from `applyChromeVars` because the two have different lifetimes: the
+ * host's control size is fixed for the life of the pack, the safe area changes
+ * on every rotation and again when a tablet is resized in Split View. This is
+ * called at mount and on every resize; it is idempotent, so nothing is written
+ * when the numbers have not moved.
+ *
+ * @returns whether anything changed.
+ */
+export function applySafeVars(
+  root: StyleTarget,
+  insets: Insets = safeInsets(),
+  previous?: Insets | null,
+): boolean {
+  return publishSafeVars(root, SAFE_PREFIX, insets, previous);
 }

--- a/dynawalla/games/polarity/src/ui/safearea.test.ts
+++ b/dynawalla/games/polarity/src/ui/safearea.test.ts
@@ -1,0 +1,271 @@
+/**
+ * The safe area, asserted against the SHIPPED stylesheet rather than against the
+ * model of it.
+ *
+ * **Why this file exists.** `layout.test.ts` next door proves `hudRects` clears
+ * a 47px notch, and it was passing on the day `.pol-hud` was padding 10px on
+ * every device in the world. The two had come apart: `hudRects` took the insets
+ * as an argument, and `styles.css` asked `env(safe-area-inset-*)` — which, in an
+ * iframe sandboxed `allow-scripts` with no `allow-same-origin`, is the number
+ * zero, because `env()` belongs to the top-level browsing context and a
+ * cross-origin child sees none of it. `max(10px, env(...))` is 10px, always.
+ *
+ * So this file parses `styles.css`, runs the cascade for a viewport, and
+ * evaluates every offset to a NUMBER with `env()` defined as ZERO — the
+ * environment the game runs in — then asserts the number the CSS produces is the
+ * number `hudRects` promised. Text being present in a file proves nothing about
+ * what it resolves to; that is how this shipped.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+  type StyleTarget,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import {
+  SHAPES,
+  customPropsOf,
+  envReadDirectly,
+  lengthOf,
+  paddingOf,
+  parseCss,
+  type Viewport,
+} from "../../../../packs/shared/game-chrome/cssSafeArea.ts";
+import { MINI, MINI_GAP, SAFE_PREFIX, applySafeVars, applyChromeVars, hudRects } from "./layout.ts";
+
+const read = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const CSS = read("./styles.css");
+const RULES = parseCss(CSS);
+
+/**
+ * Everything in scope on `.pol-root` — the gutters the stylesheet declares
+ * there, then the safe area and the chrome geometry the game writes over them
+ * as inline style. Custom properties inherit, so all of it reaches every rule
+ * below.
+ */
+function published(insets: Insets, vp: Viewport): Map<string, string> {
+  const vars = customPropsOf(RULES, ".pol-root", vp);
+  const stub: StyleTarget = {
+    style: { setProperty: (name: string, value: string): void => void vars.set(name, value) },
+  };
+  applySafeVars(stub, insets);
+  // `applyChromeVars` types its argument as an HTMLElement because that is what
+  // the game hands it; it touches nothing but `style.setProperty`.
+  applyChromeVars(stub as unknown as HTMLElement);
+  return vars;
+}
+
+const css = (
+  selector: string,
+  prop: string,
+  s: { w: number; h: number; insets: Insets },
+  pct = 0,
+): number =>
+  lengthOf(RULES, selector, prop, { w: s.w, h: s.h }, published(s.insets, { w: s.w, h: s.h }), pct);
+
+const pad = (selector: string, s: { w: number; h: number; insets: Insets }): Record<
+  "top" | "right" | "bottom" | "left",
+  number
+> => paddingOf(RULES, selector, { w: s.w, h: s.h }, published(s.insets, { w: s.w, h: s.h }));
+
+const close = (got: number, want: number, msg: string): void => {
+  assert.ok(Math.abs(got - want) < 1e-9, `${msg}: the stylesheet says ${got}, layout.ts says ${want}`);
+};
+
+const inside = (r: Rect, safe: Rect, where: string, what: string): void => {
+  assert.ok(r.x >= safe.x - 1e-9, `${where}: ${what} crosses the LEFT inset (${r.x} < ${safe.x})`);
+  assert.ok(
+    r.x + r.w <= safe.x + safe.w + 1e-9,
+    `${where}: ${what} crosses the RIGHT inset (${r.x + r.w} > ${safe.x + safe.w})`,
+  );
+  assert.ok(r.y >= safe.y - 1e-9, `${where}: ${what} crosses the TOP inset (${r.y} < ${safe.y})`);
+  assert.ok(
+    r.y + r.h <= safe.y + safe.h + 1e-9,
+    `${where}: ${what} crosses the BOTTOM inset (${r.y + r.h} > ${safe.y + safe.h})`,
+  );
+};
+
+/* ========================================================================== */
+/* The two dialects agree                                                     */
+/* ========================================================================== */
+
+test("the register's padding is exactly the padding hudRects was tested against", () => {
+  // The bug as one assertion. Everything `layout.test.ts` proves about the score
+  // and the shield pips is a claim about `.pol-hud`'s padding; until the
+  // stylesheet produced the same four numbers, it was a claim about nothing.
+  for (const s of SHAPES) {
+    const r = hudRects(s.w, s.h, s.insets);
+    const p = pad(".pol-hud", s);
+    close(p.top, r.top.y, `${s.name}: the register's top padding`);
+    close(p.left, r.top.x, `${s.name}: the register's left padding`);
+    close(p.right, s.w - (r.top.x + r.top.w), `${s.name}: the register's right padding`);
+    close(p.bottom, s.h - (r.padFlip.y + r.padFlip.h), `${s.name}: the register's bottom padding`);
+  }
+});
+
+test("the sound and pause buttons land where hudRects puts them", () => {
+  for (const s of SHAPES) {
+    const r = hudRects(s.w, s.h, s.insets);
+    close(css(".pol-mini", "top", s), r.mini.y, `${s.name}: the mini controls' top edge`);
+    close(
+      s.w - css(".pol-mini", "right", s) - (MINI * 2 + MINI_GAP),
+      r.mini.x,
+      `${s.name}: the mini controls' left edge`,
+    );
+  }
+});
+
+/* ========================================================================== */
+/* …and what the CSS produces is inside the safe area, and clear of the host   */
+/* ========================================================================== */
+
+test("the register's contents are inside the safe area at every shape", () => {
+  for (const s of SHAPES) {
+    const p = pad(".pol-hud", s);
+    const box: Rect = {
+      x: p.left,
+      y: p.top,
+      w: s.w - p.left - p.right,
+      h: Math.max(0, s.h - p.top - p.bottom),
+    };
+    inside(box, safeRect(s.w, s.h, s.insets), s.name, "the register");
+  }
+});
+
+test("the score, the pips and the touch pads never sit under the host's two controls", () => {
+  // The register's content box is the frame minus its padding, and the top row
+  // and the pads live at its two ends. Both are built from the CSS numbers here,
+  // not from the model.
+  for (const s of SHAPES) {
+    const p = pad(".pol-hud", s);
+    const r = hudRects(s.w, s.h, s.insets);
+    const top: Rect = { x: p.left, y: p.top, w: s.w - p.left - p.right, h: r.top.h };
+    assert.equal(
+      hitsHostChrome(top, s.w, s.insets),
+      false,
+      `${s.name}: the score and the shield pips run under the host's chrome`,
+    );
+    const mini: Rect = {
+      x: s.w - css(".pol-mini", "right", s) - (MINI * 2 + MINI_GAP),
+      y: css(".pol-mini", "top", s),
+      w: MINI * 2 + MINI_GAP,
+      h: MINI,
+    };
+    inside(mini, safeRect(s.w, s.h, s.insets), s.name, "the sound and pause buttons");
+    assert.equal(
+      hitsHostChrome(mini, s.w, s.insets),
+      false,
+      `${s.name}: the game's own buttons are under the host's how-to-play control`,
+    );
+  }
+});
+
+test("the key hint clears every inset", () => {
+  for (const s of SHAPES) {
+    for (const side of ["bottom", "left", "right"] as const) {
+      const v = css(".pol-keyhint", side, s);
+      assert.ok(
+        v >= s.insets[side] - 1e-9,
+        `${s.name}: the key hint sits ${v}px from the ${side} edge, inside a ${s.insets[side]}px inset`,
+      );
+    }
+  }
+});
+
+test("the veil keeps the REPOLARIZE orbs inside the safe area", () => {
+  // The veil carries the answer orbs, which a child taps. In landscape on a
+  // notched phone the outermost orb ran under the sensor housing.
+  for (const s of SHAPES) {
+    const p = pad(".pol-veil", s);
+    const box: Rect = {
+      x: p.left,
+      y: p.top,
+      w: s.w - p.left - p.right,
+      h: Math.max(0, s.h - p.top - p.bottom),
+    };
+    inside(box, safeRect(s.w, s.h, s.insets), s.name, "the veil's contents");
+  }
+});
+
+test("a breakpoint cannot quietly delete a safe-area padding", () => {
+  // SIEGE's second defect, guarded before it happens here: a `padding:`
+  // shorthand resets all four longhands, so a media query that only wanted a
+  // tighter gutter throws the safe area away with it. Both padded surfaces are
+  // driven by a custom property for exactly that reason.
+  for (const rule of RULES) {
+    for (const sel of [".pol-hud", ".pol-veil"]) {
+      if (!rule.selectors.includes(sel)) continue;
+      assert.ok(
+        !rule.decls.some((d) => d.prop === "padding"),
+        `${sel} uses a \`padding:\` shorthand — a breakpoint can now erase its safe area`,
+      );
+    }
+  }
+  // …and the numbers hold at the shapes a media query does apply to.
+  for (const s of SHAPES) {
+    for (const sel of [".pol-hud", ".pol-veil"]) {
+      const p = pad(sel, s);
+      for (const side of ["top", "right", "bottom", "left"] as const) {
+        assert.ok(
+          p[side] >= s.insets[side] - 1e-9,
+          `${s.name}: ${sel}'s ${side} padding is ${p[side]}px for a ${s.insets[side]}px inset`,
+        );
+      }
+    }
+  }
+});
+
+/* ========================================================================== */
+/* The seam itself                                                            */
+/* ========================================================================== */
+
+test("no rule takes its answer from env() — it is zero where this game runs", () => {
+  const offenders = envReadDirectly(CSS, SAFE_PREFIX);
+  assert.deepEqual(offenders, [], offenders.join("\n"));
+  assert.ok(
+    CSS.includes("env(safe-area-inset-top"),
+    "the dev-harness fallbacks are gone entirely — a browser tab with no host now gets nothing",
+  );
+});
+
+test("the safe area is published as four properties, zeros written out", () => {
+  const vars = published({ top: 24, right: 0, bottom: 48, left: 0 }, { w: 393, h: 851 });
+  for (const [name, want] of [
+    [`${SAFE_PREFIX}top`, "24px"],
+    [`${SAFE_PREFIX}right`, "0px"],
+    [`${SAFE_PREFIX}bottom`, "48px"],
+    [`${SAFE_PREFIX}left`, "0px"],
+  ] as const) {
+    assert.equal(vars.get(name), want, `${name} was not published`);
+  }
+  // A zero must be WRITTEN, not omitted: an absent custom property falls through
+  // to the `env()` beside it, which is the bug this file is about.
+  assert.equal(vars.get(`${SAFE_PREFIX}right`), "0px", "a zero inset was left for env() to answer");
+});
+
+test("the game publishes the safe area at mount and again on every resize", () => {
+  // A wiring check, and only that — the arithmetic above cannot see whether
+  // anything ever calls the publisher, and without these calls the stylesheet
+  // reads four unset properties and falls through to an `env()` of zero.
+  const hud = read("./hud.ts");
+  assert.ok(hud.includes("applySafeVars(this.root)"), "the HUD never publishes the safe area at mount");
+  const mount = read("../mount.ts");
+  const at = mount.indexOf("function measure()");
+  assert.ok(at > 0, "measure() is gone");
+  const body = mount.slice(at, mount.indexOf("\n  }", at));
+  assert.ok(body.includes("hud.setInsets(safeInsets())"), "measure() never republishes the safe area");
+  assert.ok(
+    mount.includes("onInsetsChange(() => measure())"),
+    "nothing listens for the insets changing — the register keeps the shape the pack opened in",
+  );
+  assert.ok(mount.includes("stopInsets()"), "the inset listener outlives the pack");
+});

--- a/dynawalla/games/polarity/src/ui/styles.css
+++ b/dynawalla/games/polarity/src/ui/styles.css
@@ -6,10 +6,28 @@
    this HUD out of those two squares and writes them onto the root at mount;
    the values here are the same numbers, as fallbacks. Nothing a child reads or
    touches may land in the corners — the field itself still bleeds to the
-   edges, which is what `viewport-fit=cover` is for. */
+   edges, which is what `viewport-fit=cover` is for.
+
+   THE SAFE AREA ARRIVES THE SAME WAY, and this is not a style choice. A pack
+   runs in an iframe sandboxed `allow-scripts` with no `allow-same-origin`, and
+   `env(safe-area-inset-*)` is a property of the TOP-LEVEL browsing context — so
+   a cross-origin child resolves all four to ZERO. Every rule below that once
+   read `env()` directly resolved to its 10px/20px fallback on every device, and
+   `layout.ts`'s numbers, which the tests assert, described a HUD that was never
+   drawn. `--pol-safe-*` is the host's real measurement, published by
+   `applySafeVars`; the `env()` behind each one is the dev-browser fallback,
+   where there is no host and where it happens to be right. Never read an
+   `env(safe-area-inset-*)` here except as the fallback of its `--pol-safe-*`. */
 .pol-root {
   --pol-chrome-top: 63px;
   --pol-mini-right: 64px;
+  /* The HUD's gap from every safe edge, and the veil's. Kept as custom
+     properties so a breakpoint can change a gutter WITHOUT restating a
+     `padding:` shorthand — a shorthand resets all four longhands and would take
+     the safe area with it, which is how SIEGE lost its bottom inset on every
+     landscape phone. */
+  --pol-hud-edge: 10px;
+  --pol-veil-pad: 20px;
   --pos: #ffcd52;
   --pos-dim: #7a5a1c;
   --neg: #38dcff;
@@ -45,14 +63,17 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  /* The four edges were already right. The top now also clears the host's two
-     44px corners: the score and the chain sat in the chevron's square and the
-     shield pips and STRATUM sat under the question mark, and no amount of
-     `env()` can help with that — the chrome floats INSIDE the safe area. Only
-     the top row moves; the middle row absorbs it and the pads stay put. */
-  padding: calc(env(safe-area-inset-top) + var(--pol-chrome-top))
-    max(10px, env(safe-area-inset-right))
-    max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+  /* The top clears the host's two 44px corners as well as the notch: the score
+     and the chain sat in the chevron's square and the shield pips and STRATUM
+     sat under the question mark, and no inset can help with that — the chrome
+     floats INSIDE the safe area. Only the top row moves; the middle row absorbs
+     it and the pads stay put.
+
+     Four longhands, deliberately not a shorthand. See --pol-hud-edge above. */
+  padding-top: calc(var(--pol-safe-top, env(safe-area-inset-top, 0px)) + var(--pol-chrome-top));
+  padding-right: max(var(--pol-hud-edge), var(--pol-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: max(var(--pol-hud-edge), var(--pol-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: max(var(--pol-hud-edge), var(--pol-safe-left, env(safe-area-inset-left, 0px)));
   display: grid;
   grid-template-rows: auto 1fr auto;
 }
@@ -197,9 +218,9 @@
 
 .pol-keyhint {
   position: absolute;
-  bottom: max(10px, env(safe-area-inset-bottom));
-  left: max(10px, env(safe-area-inset-left));
-  right: max(10px, env(safe-area-inset-right));
+  bottom: max(var(--pol-hud-edge), var(--pol-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  left: max(var(--pol-hud-edge), var(--pol-safe-left, env(safe-area-inset-left, 0px)));
+  right: max(var(--pol-hud-edge), var(--pol-safe-right, env(safe-area-inset-right, 0px)));
   text-align: center;
   font-size: clamp(9px, 1.9vw, 12px);
   letter-spacing: 0.2em;
@@ -220,8 +241,10 @@
      REPOLARIZE answer orbs, which a child taps, so in landscape on a notched
      phone the outermost orb ran under the sensor housing. Its contents are
      centred, so the corners are clear by construction. */
-  padding: max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right))
-    max(20px, env(safe-area-inset-bottom)) max(20px, env(safe-area-inset-left));
+  padding-top: max(var(--pol-veil-pad), var(--pol-safe-top, env(safe-area-inset-top, 0px)));
+  padding-right: max(var(--pol-veil-pad), var(--pol-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: max(var(--pol-veil-pad), var(--pol-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: max(var(--pol-veil-pad), var(--pol-safe-left, env(safe-area-inset-left, 0px)));
   text-align: center;
 }
 .pol-veil[hidden] { display: none; }
@@ -308,8 +331,11 @@
    game's chrome and the host's at every inset. */
 .pol-mini {
   position: absolute;
-  top: max(10px, env(safe-area-inset-top));
-  right: calc(max(10px, env(safe-area-inset-right)) + var(--pol-mini-right));
+  top: max(var(--pol-hud-edge), var(--pol-safe-top, env(safe-area-inset-top, 0px)));
+  right: calc(
+    max(var(--pol-hud-edge), var(--pol-safe-right, env(safe-area-inset-right, 0px))) +
+      var(--pol-mini-right)
+  );
   display: flex;
   gap: 8px;
   pointer-events: auto;

--- a/dynawalla/games/stack/src/game/mount.ts
+++ b/dynawalla/games/stack/src/game/mount.ts
@@ -26,7 +26,11 @@ import {
   SRGBColorSpace,
 } from "three";
 
-import { createInstructions } from "../../../../packs/shared/game-chrome/index.ts";
+import {
+  createInstructions,
+  onInsetsChange,
+  safeInsets,
+} from "../../../../packs/shared/game-chrome/index.ts";
 import type { Host } from "../contract.ts";
 import { Sim, type PlaceEvent, type SimEvent } from "./sim.ts";
 import { T } from "./tuning.ts";
@@ -825,6 +829,11 @@ export function mount(
   /* ── resize ─────────────────────────────────────────────────────────── */
 
   function resize(): void {
+    // Measured every resize, never cached from construction: a rotation trades
+    // one top inset for two side ones, and iPadOS changes them when the pack is
+    // resized in Split View. Read once at mount and the HUD is correct until the
+    // first rotation and wrong after it.
+    hud.setInsets(safeInsets());
     const w = holder.clientWidth || 320;
     const h = holder.clientHeight || 480;
     aspect = w / h;
@@ -839,6 +848,11 @@ export function mount(
 
   const ro = new ResizeObserver(() => resize());
   ro.observe(holder);
+  // The insets can move without the frame moving: the host publishes its
+  // measurement over the `settings` channel after the handshake, and Split View
+  // changes them on a tablet. Without this the HUD keeps the shape the pack
+  // opened in.
+  const stopInsets = onInsetsChange(() => resize());
   resize();
   applyStratum(stratumAt(0), 1);
   camY.set(camTargetY());
@@ -1266,6 +1280,7 @@ export function mount(
       running = false;
       cancelAnimationFrame(raf);
       ro.disconnect();
+      stopInsets();
       holder.removeEventListener("pointerdown", onPointerDown);
       window.removeEventListener("keydown", onKey);
       guide.destroy();

--- a/dynawalla/games/stack/src/ui/hud.ts
+++ b/dynawalla/games/stack/src/ui/hud.ts
@@ -16,6 +16,7 @@
  * asserting against the geometry that actually ships, not a copy of it.
  */
 
+import type { Insets } from "../../../../packs/shared/game-chrome/index.ts";
 import {
   BEST_NUM,
   CSS_CLEAR_LEFT,
@@ -31,11 +32,17 @@ import {
   LABEL,
   PROMPT,
   TOOL_SIZE,
+  applySafeVars,
+  cssSafe,
   cssScale,
 } from "./place.ts";
 import { BLANK } from "../blank.ts";
 
-const CSS = `
+/**
+ * The stylesheet, exported so `safearea.test.ts` can parse the string that
+ * actually ships rather than a copy of what it was meant to say.
+ */
+export const CSS = `
 .mn { position:absolute; inset:0; pointer-events:none; overflow:hidden;
   font-family: ui-sans-serif,-apple-system,"SF Pro Display","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
   color:var(--fg); -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
@@ -74,7 +81,7 @@ const CSS = `
   opacity:0; will-change:transform,opacity; text-shadow:0 0 60px color-mix(in srgb,var(--ac) 60%,transparent); }
 
 .mn-band { position:absolute; left:0; right:0; top:57%; text-align:center; opacity:0; will-change:transform,opacity;
-  padding-left:env(safe-area-inset-left); padding-right:env(safe-area-inset-right); box-sizing:border-box; }
+  padding-left:${cssSafe("left")}; padding-right:${cssSafe("right")}; box-sizing:border-box; }
 .mn-band u { text-decoration:none; display:block; font-size:clamp(9px,2.4vmin,13px); font-weight:800; letter-spacing:.42em;
   color:var(--dim); text-transform:uppercase; }
 .mn-band b { display:block; font-size:clamp(28px,8.5vmin,62px); font-weight:800; letter-spacing:.06em; }
@@ -87,8 +94,16 @@ const CSS = `
 .mn-over { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center;
   gap:clamp(12px,3vmin,24px); pointer-events:auto; opacity:0; visibility:hidden;
   background:radial-gradient(120% 90% at 50% 45%, transparent 18%, color-mix(in srgb,var(--bg) 99%,transparent) 62%);
-  padding:calc(env(safe-area-inset-top) + 20px) calc(env(safe-area-inset-right) + 20px)
-    calc(env(safe-area-inset-bottom) + 20px) calc(env(safe-area-inset-left) + 20px);
+  /* Four longhands, driven by a custom property, and deliberately NOT a
+     \`padding:\` shorthand. A shorthand resets all four sides, so a breakpoint
+     that wanted a tighter card on a short screen would silently delete the safe
+     area along with the gutter — which is exactly how SIEGE lost its bottom
+     inset on every landscape phone. Change --mn-card-pad; leave these alone. */
+  --mn-card-pad:20px;
+  padding-top:calc(${cssSafe("top")} + var(--mn-card-pad));
+  padding-right:calc(${cssSafe("right")} + var(--mn-card-pad));
+  padding-bottom:calc(${cssSafe("bottom")} + var(--mn-card-pad));
+  padding-left:calc(${cssSafe("left")} + var(--mn-card-pad));
   transition:opacity .28s ease; }
 .mn-over.on { opacity:1; visibility:visible; }
 .mn-over h1 { font-size:clamp(11px,2.8vmin,15px); font-weight:800; letter-spacing:.42em; color:var(--dim); text-transform:uppercase; }
@@ -157,6 +172,7 @@ export class Hud {
   private lastPrompt = "";
   private lastReveal: string | null = null;
   private lastFloor = -1;
+  private insets: Insets | null = null;
   private reduced: boolean;
   private anims: Animation[] = [];
 
@@ -189,6 +205,12 @@ export class Hud {
       <div class="mn-perf"></div>`;
     parent.appendChild(d);
     this.root = d;
+
+    // The stylesheet above cannot work the safe area out for itself: `env()`
+    // resolves to zero in a cross-origin child, which is what every pack is. It
+    // is written onto this root as four custom properties instead, from the
+    // host's own measurement, and republished on every resize.
+    applySafeVars(d);
 
     const q = <T extends Element>(s: string): T => d.querySelector<T>(s)!;
     this.floorEl = q(".mn-floor");
@@ -240,6 +262,20 @@ export class Hud {
       if (this.choicesEl.style.display !== "none" && this.choicesEl.children.length) return;
       cb.onRestart();
     });
+  }
+
+  /**
+   * Republish the safe area onto the HUD root.
+   *
+   * Called on every resize rather than once at mount: a rotation trades one top
+   * inset for two side ones, and the host re-sends its measurement whenever the
+   * app's own layout moves. Idempotent, so a `ResizeObserver` may call it
+   * freely — nothing is written when the numbers have not moved.
+   */
+  setInsets(insets: Insets): void {
+    if (applySafeVars(this.root, insets, this.insets)) {
+      this.insets = { ...insets };
+    }
   }
 
   /* ── palette ──────────────────────────────────────────────────────────── */

--- a/dynawalla/games/stack/src/ui/place.ts
+++ b/dynawalla/games/stack/src/ui/place.ts
@@ -19,11 +19,23 @@
  * Here that means the readouts step INWARD, past the corner squares, onto the
  * same row as the host's own controls.
  *
- * **`env()` cannot be read from JavaScript.** So this module owns the numbers
- * in both dialects at once: a `calc(env(...) + Npx)` string that `hud.ts`
- * interpolates into its stylesheet, and the same N as a number that
- * `place.test.ts` feeds to `hitsHostChrome`. One source, two readers — a test
- * that re-derived the geometry would prove only that it agreed with itself.
+ * **`env()` cannot be read from JavaScript, and inside a pack it cannot be read
+ * at all.** A pack runs in an iframe sandboxed `allow-scripts` with no
+ * `allow-same-origin`, and `env(safe-area-inset-*)` belongs to the TOP-LEVEL
+ * browsing context — so a cross-origin child resolves all four to ZERO. This
+ * module used to hand `hud.ts` a `calc(env(...) + Npx)` string, which meant the
+ * numeric dialect below was correct about a notch the stylesheet could not see:
+ * `place.test.ts` proved the floor count cleared a 59px status bar while the
+ * shipped rule put it at 13px. SIEGE shipped the identical split and the founder
+ * found it on an Android phone, with the currency painted under the OS clock.
+ *
+ * So the CSS dialect now reads `var(--mn-safe-*, env(...))`, and the four
+ * properties are published onto the HUD root from the host's own measurement by
+ * `publishSafeVars`. The `env()` stays as the fallback because it is right in a
+ * dev browser tab, where there is no host to publish anything.
+ *
+ * One source, two readers — a test that re-derived the geometry would prove only
+ * that it agreed with itself.
  */
 
 import {
@@ -31,8 +43,11 @@ import {
   HOST_MARGIN,
   HOST_PROGRESS_H,
   NO_INSETS,
+  publishSafeVars,
+  safeInsets,
   type Insets,
   type Rect,
+  type StyleTarget,
 } from "../../../../packs/shared/game-chrome/index.ts";
 
 /* ── the geometry ───────────────────────────────────────────────────────── */
@@ -116,8 +131,39 @@ export const FLOOR_DIGITS = 3;
 
 /* ── the CSS dialect ────────────────────────────────────────────────────── */
 
+/** The namespace the four published lengths live under. */
+export const SAFE_PREFIX = "--mn-safe-";
+
+/**
+ * One safe edge plus a gutter, as a length the stylesheet can use.
+ *
+ * The property first, the `env()` only as the fallback — see the module
+ * docblock. Inside the app the fallback is always the wrong answer; in a dev
+ * browser tab, where nothing publishes, it is the only one available.
+ */
 const safe = (side: "top" | "right" | "bottom" | "left", px: number): string =>
-  `calc(env(safe-area-inset-${side}) + ${px}px)`;
+  `calc(${cssSafe(side)} + ${px}px)`;
+
+/** Just the safe edge, with no gutter added. */
+export const cssSafe = (side: "top" | "right" | "bottom" | "left"): string =>
+  `var(${SAFE_PREFIX}${side}, env(safe-area-inset-${side}, 0px))`;
+
+/**
+ * Hand the stylesheet the safe area, from the host's measurement.
+ *
+ * Called at mount and again on every resize: a rotation trades one top inset for
+ * two side ones, and iPadOS changes them when a pack is resized in Split View.
+ * Idempotent — nothing is written when the numbers have not moved.
+ *
+ * @returns whether anything changed.
+ */
+export function applySafeVars(
+  root: StyleTarget,
+  insets: Insets = safeInsets(),
+  previous?: Insets | null,
+): boolean {
+  return publishSafeVars(root, SAFE_PREFIX, insets, previous);
+}
 
 /** The row the host's controls sit on. The readouts join it, beside them. */
 export const CSS_ROW_TOP = safe("top", CHROME_TOP);
@@ -126,7 +172,7 @@ export const CSS_CLEAR_RIGHT = safe("right", CHROME_CLEAR);
 export const CSS_EDGE_LEFT = safe("left", EDGE);
 export const CSS_TOOL_RIGHT = safe("right", TOOL_EDGE);
 export const CSS_TOOL_BOTTOM = safe("bottom", TOOL_EDGE);
-export const CSS_HINT_BOTTOM = `calc(env(safe-area-inset-bottom) + 12%)`;
+export const CSS_HINT_BOTTOM = `calc(${cssSafe("bottom")} + 12%)`;
 
 /**
  * The prompt's centre: 18% down, or below the floor readout, whichever is

--- a/dynawalla/games/stack/src/ui/safearea.test.ts
+++ b/dynawalla/games/stack/src/ui/safearea.test.ts
@@ -1,0 +1,307 @@
+/**
+ * The safe area, asserted against the SHIPPED stylesheet rather than against the
+ * model of it.
+ *
+ * **Why this file exists.** `place.test.ts` next door is a good test of the
+ * wrong thing. It feeds `hudRects(w, h, insets)` a 59px status bar and proves
+ * the floor count clears it — and it was passing on the day the shipped rule put
+ * that same floor count at 13px down the screen, under an Android clock. The two
+ * dialects `place.ts` owns had come apart: the numeric one knew about the notch
+ * and the CSS one asked `env(safe-area-inset-top)`, which inside a pack frame is
+ * the number zero. A pack is an iframe sandboxed `allow-scripts` with no
+ * `allow-same-origin`; `env()` belongs to the top-level browsing context and a
+ * cross-origin child reads all four as 0.
+ *
+ * So this file does not check text and does not re-derive geometry. It PARSES
+ * the stylesheet `hud.ts` actually injects, runs the cascade for a viewport, and
+ * evaluates every chrome offset to a NUMBER with `env()` defined as zero — the
+ * environment the game runs in. Then it asserts the number the CSS produces is
+ * the number `hudRects` promised. The two dialects cannot drift again without
+ * this failing.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  hitsHostChrome,
+  safeRect,
+  type Insets,
+  type Rect,
+  type StyleTarget,
+} from "../../../../packs/shared/game-chrome/index.ts";
+import {
+  SHAPES,
+  envReadDirectly,
+  lengthOf,
+  paddingOf,
+  parseCss,
+} from "../../../../packs/shared/game-chrome/cssSafeArea.ts";
+import { CSS } from "./hud.ts";
+import {
+  CHROME_TOP,
+  SAFE_PREFIX,
+  TOOL_EDGE,
+  TOOL_SIZE,
+  applySafeVars,
+  hudRects,
+  promptHalf,
+} from "./place.ts";
+
+const RULES = parseCss(CSS);
+
+/** The four properties the running game writes onto the HUD root. */
+function published(insets: Insets): Map<string, string> {
+  const vars = new Map<string, string>();
+  const stub: StyleTarget = {
+    style: { setProperty: (name: string, value: string): void => void vars.set(name, value) },
+  };
+  applySafeVars(stub, insets);
+  return vars;
+}
+
+/** A length from the stylesheet, at a viewport, as the browser would resolve it. */
+const css = (
+  selector: string,
+  prop: string,
+  s: { w: number; h: number; insets: Insets },
+  pct = 0,
+): number => lengthOf(RULES, selector, prop, { w: s.w, h: s.h }, published(s.insets), pct);
+
+/**
+ * Equal to within a float's worth of noise.
+ *
+ * `(min(w,h) * vmin) / 100` and `(vmin / 100) * min(w,h)` are the same number
+ * and not the same double. The tolerance is 1e-9 of a CSS pixel: it cannot hide
+ * a layout defect and it cannot fail on the order of two multiplications.
+ */
+const close = (got: number, want: number, msg: string): void => {
+  assert.ok(
+    Math.abs(got - want) < 1e-9,
+    `${msg}: the stylesheet says ${got}, hudRects says ${want}`,
+  );
+};
+
+const inside = (r: Rect, safe: Rect, where: string, what: string): void => {
+  assert.ok(r.x >= safe.x - 1e-9, `${where}: ${what} crosses the LEFT inset (${r.x} < ${safe.x})`);
+  assert.ok(
+    r.x + r.w <= safe.x + safe.w + 1e-9,
+    `${where}: ${what} crosses the RIGHT inset (${r.x + r.w} > ${safe.x + safe.w})`,
+  );
+  assert.ok(r.y >= safe.y - 1e-9, `${where}: ${what} crosses the TOP inset (${r.y} < ${safe.y})`);
+  assert.ok(
+    r.y + r.h <= safe.y + safe.h + 1e-9,
+    `${where}: ${what} crosses the BOTTOM inset (${r.y + r.h} > ${safe.y + safe.h})`,
+  );
+};
+
+/* ========================================================================== */
+/* The two dialects agree                                                     */
+/* ========================================================================== */
+
+test("the stylesheet puts the readouts exactly where hudRects says they are", () => {
+  // The bug, as one assertion. `place.test.ts` proves the RIGHT-hand side of
+  // each of these clears the notch; until the stylesheet produced the same
+  // number, that proof was about a layout nobody shipped.
+  for (const s of SHAPES) {
+    const r = hudRects(s.w, s.h, s.insets);
+    close(css(".mn-floor", "top", s), r.floor.y, `${s.name}: the floor count's top edge`);
+    close(css(".mn-floor", "left", s), r.floor.x, `${s.name}: the floor count's left edge`);
+    close(css(".mn-best", "top", s), r.best.y, `${s.name}: the best score's top edge`);
+    close(
+      s.w - css(".mn-best", "right", s),
+      r.best.x + r.best.w,
+      `${s.name}: the best score's right edge`,
+    );
+    close(
+      s.w - css(".mn-tools", "right", s),
+      r.tools.x + r.tools.w,
+      `${s.name}: the sound button's right edge`,
+    );
+    close(
+      s.h - css(".mn-tools", "bottom", s) - TOOL_SIZE,
+      r.tools.y,
+      `${s.name}: the sound button's top edge`,
+    );
+    // The plate is centred on its own `top`, so the CSS number is its centre.
+    close(
+      css(".mn-prompt", "top", s, s.h),
+      r.prompt.y + promptHalf(s.w, s.h),
+      `${s.name}: the equation plate's centre`,
+    );
+  }
+});
+
+/* ========================================================================== */
+/* …and what the CSS produces is inside the safe area                         */
+/* ========================================================================== */
+
+test("every readout the stylesheet places is inside the safe area", () => {
+  for (const s of SHAPES) {
+    const safe = safeRect(s.w, s.h, s.insets);
+    const r = hudRects(s.w, s.h, s.insets);
+    const floor: Rect = { x: css(".mn-floor", "left", s), y: css(".mn-floor", "top", s), w: r.floor.w, h: r.floor.h };
+    const best: Rect = {
+      x: s.w - css(".mn-best", "right", s) - r.best.w,
+      y: css(".mn-best", "top", s),
+      w: r.best.w,
+      h: r.best.h,
+    };
+    const tools: Rect = {
+      x: s.w - css(".mn-tools", "right", s) - TOOL_SIZE,
+      y: s.h - css(".mn-tools", "bottom", s) - TOOL_SIZE,
+      w: TOOL_SIZE,
+      h: TOOL_SIZE,
+    };
+    inside(floor, safe, s.name, "the floor count");
+    inside(best, safe, s.name, "the best score");
+    inside(tools, safe, s.name, "the sound button");
+    for (const [what, box] of [["the floor count", floor], ["the best score", best], ["the sound button", tools]] as const) {
+      assert.equal(
+        hitsHostChrome(box, s.w, s.insets),
+        false,
+        `${s.name}: ${what} is under the host's exit or how-to-play control`,
+      );
+    }
+  }
+});
+
+test("the tool row keeps a full 40px button clear of the bottom inset", () => {
+  // The home indicator is a system gesture area, not just an ugly place to draw:
+  // a button whose lower edge is inside it is a button a child presses and the
+  // OS answers.
+  for (const s of SHAPES) {
+    const bottom = css(".mn-tools", "bottom", s);
+    assert.ok(
+      bottom >= s.insets.bottom + TOOL_EDGE - 1e-9,
+      `${s.name}: the sound button sits ${bottom}px up, inside a ${s.insets.bottom}px inset`,
+    );
+  }
+});
+
+test("the tap hint clears the bottom inset", () => {
+  for (const s of SHAPES) {
+    const bottom = css(".mn-hint", "bottom", s, s.h);
+    assert.ok(
+      bottom >= s.insets.bottom - 1e-9,
+      `${s.name}: the hint sits ${bottom}px up, inside a ${s.insets.bottom}px inset`,
+    );
+  }
+});
+
+test("the stratum banner's text stays out of the side insets", () => {
+  // The banner spans the full width, so it cannot dodge a landscape cutout
+  // sideways — its padding is the only thing keeping the stratum name legible.
+  for (const s of SHAPES) {
+    const left = css(".mn-band", "padding-left", s);
+    const right = css(".mn-band", "padding-right", s);
+    assert.ok(
+      left >= s.insets.left - 1e-9,
+      `${s.name}: the banner's left padding is ${left}px for a ${s.insets.left}px inset`,
+    );
+    assert.ok(
+      right >= s.insets.right - 1e-9,
+      `${s.name}: the banner's right padding is ${right}px for a ${s.insets.right}px inset`,
+    );
+  }
+});
+
+test("the end-of-run card keeps its question and its buttons inside the safe area", () => {
+  // This card carries the revive question and the answer buttons — the most
+  // important thing to touch in the whole game, and it is full-bleed.
+  for (const s of SHAPES) {
+    const pad = paddingOf(RULES, ".mn-over", { w: s.w, h: s.h }, published(s.insets));
+    const box: Rect = {
+      x: pad.left,
+      y: pad.top,
+      w: s.w - pad.left - pad.right,
+      h: s.h - pad.top - pad.bottom,
+    };
+    inside(box, safeRect(s.w, s.h, s.insets), s.name, "the end-of-run card");
+  }
+});
+
+test("a breakpoint cannot quietly delete the card's safe-area padding", () => {
+  // SIEGE's second defect, guarded here before it happens: a `padding:`
+  // shorthand resets all four longhands, so a media query that only wanted a
+  // tighter gutter throws the safe area away with it. The card's gutter is a
+  // custom property for exactly that reason.
+  for (const rule of RULES) {
+    if (!rule.selectors.includes(".mn-over")) continue;
+    assert.ok(
+      !rule.decls.some((d) => d.prop === "padding"),
+      "the end-of-run card uses a `padding:` shorthand again — a breakpoint can now erase the safe area",
+    );
+  }
+  for (const s of SHAPES) {
+    const pad = paddingOf(RULES, ".mn-over", { w: s.w, h: s.h }, published(s.insets));
+    for (const side of ["top", "right", "bottom", "left"] as const) {
+      assert.ok(
+        pad[side] >= s.insets[side] - 1e-9,
+        `${s.name}: the card's ${side} padding is ${pad[side]}px for a ${s.insets[side]}px inset`,
+      );
+    }
+  }
+});
+
+/* ========================================================================== */
+/* The seam itself                                                            */
+/* ========================================================================== */
+
+test("no rule takes its answer from env() — it is zero where this game runs", () => {
+  const offenders = envReadDirectly(CSS, SAFE_PREFIX);
+  assert.deepEqual(offenders, [], offenders.join("\n"));
+  assert.ok(
+    CSS.includes("env(safe-area-inset-top"),
+    "the dev-harness fallbacks are gone entirely — a browser tab with no host now gets nothing",
+  );
+});
+
+test("the safe area is published as four properties, zeros written out", () => {
+  const vars = published({ top: 24, right: 0, bottom: 48, left: 0 });
+  assert.deepEqual(
+    [...vars.entries()].sort(),
+    [
+      [`${SAFE_PREFIX}bottom`, "48px"],
+      [`${SAFE_PREFIX}left`, "0px"],
+      [`${SAFE_PREFIX}right`, "0px"],
+      [`${SAFE_PREFIX}top`, "24px"],
+    ],
+  );
+  // A zero must be WRITTEN, not omitted: an absent custom property falls through
+  // to the `env()` beside it, which is the bug this file is about.
+  assert.equal(vars.get(`${SAFE_PREFIX}right`), "0px", "a zero inset was left for env() to answer");
+});
+
+test("the host's own geometry is where the top row's offset comes from", () => {
+  // Not typed in: if the host moves its chrome, this game follows on the next
+  // build rather than on the next bug report.
+  const s = SHAPES[0] as (typeof SHAPES)[number];
+  assert.equal(css(".mn-floor", "top", s), s.insets.top + CHROME_TOP);
+});
+
+test("the game publishes the safe area at mount and again on every resize", () => {
+  // A wiring check, and only that — everything above is arithmetic and none of
+  // it can see whether anything ever calls the publisher. Without these two
+  // calls the stylesheet reads four unset properties and falls through to an
+  // `env()` that answers zero, which is precisely the shipped bug.
+  const hud = readSrc("./hud.ts");
+  assert.ok(hud.includes("applySafeVars(d)"), "the HUD never publishes the safe area at mount");
+  const mount = readSrc("../game/mount.ts");
+  const at = mount.indexOf("function resize()");
+  assert.ok(at > 0, "resize() is gone");
+  const body = mount.slice(at, mount.indexOf("\n  }", at));
+  assert.ok(body.includes("hud.setInsets(safeInsets())"), "resize() never republishes the safe area");
+  assert.ok(
+    mount.includes("onInsetsChange(() => resize())"),
+    "nothing listens for the insets changing — the HUD keeps the shape the pack opened in",
+  );
+  assert.ok(mount.includes("stopInsets()"), "the inset listener outlives the pack");
+});
+
+function readSrc(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+}

--- a/dynawalla/packs/shared/game-chrome/cssSafeArea.test.ts
+++ b/dynawalla/packs/shared/game-chrome/cssSafeArea.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The CSS model, held to the behaviours three packs' safe-area tests rely on.
+ *
+ * This file matters more than it looks. If the evaluator is wrong, every
+ * assertion built on it is vacuous in the same quiet way the substring search it
+ * replaced was — the suite goes green and the currency is still under the clock.
+ * So the cascade, the shorthand expansion, the `var()` fallback and the one rule
+ * that gives the module its name are each pinned here.
+ */
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  envReadDirectly,
+  evalLength,
+  expandBox,
+  lengthOf,
+  paddingOf,
+  parseCss,
+  type EvalCtx,
+} from "./cssSafeArea.ts"
+
+const vars = (o: Record<string, string>): Map<string, string> => new Map(Object.entries(o))
+const ctx = (o: Record<string, string> = {}, w = 400, h = 800, pct = 0): EvalCtx => ({
+  vars: vars(o),
+  vp: { w, h },
+  pct,
+})
+
+test("env(safe-area-inset-*) is ZERO, fallback and all", () => {
+  // The reason the module exists. A rule that reaches for env() inside a pack
+  // frame gets nothing, not even the fallback the author wrote next to it.
+  assert.equal(evalLength("env(safe-area-inset-top)", ctx()), 0)
+  assert.equal(evalLength("env(safe-area-inset-bottom, 34px)", ctx()), 0)
+  assert.equal(evalLength("calc(env(safe-area-inset-top) + 20px)", ctx()), 20)
+  assert.equal(evalLength("max(10px, env(safe-area-inset-left))", ctx()), 10)
+})
+
+test("a published custom property beats the env() behind it", () => {
+  const raw = "calc(var(--x-safe-top, env(safe-area-inset-top, 0px)) + 8px)"
+  assert.equal(evalLength(raw, ctx()), 8, "unpublished: falls through to a zero env()")
+  assert.equal(evalLength(raw, ctx({ "--x-safe-top": "24px" })), 32)
+  // …including when the true inset IS zero, which is the case a missing write
+  // is indistinguishable from until a child picks up a notched phone.
+  assert.equal(evalLength(raw, ctx({ "--x-safe-top": "0px" })), 8)
+})
+
+test("calc, min, max, clamp and the viewport units", () => {
+  assert.equal(evalLength("calc(10px + 2 * 5px)", ctx()), 20)
+  assert.equal(evalLength("calc((10px + 6px) / 2)", ctx()), 8)
+  assert.equal(evalLength("min(30px, 12px)", ctx()), 12)
+  assert.equal(evalLength("clamp(10px, 4vmin, 20px)", ctx({}, 400, 800)), 16)
+  assert.equal(evalLength("clamp(10px, 1vmin, 20px)", ctx({}, 400, 800)), 10)
+  assert.equal(evalLength("10vw", ctx({}, 400, 800)), 40)
+  assert.equal(evalLength("10vh", ctx({}, 400, 800)), 80)
+  assert.equal(evalLength("5vmax", ctx({}, 400, 800)), 40)
+  assert.equal(evalLength("50%", ctx({}, 400, 800, 300)), 150)
+})
+
+test("an expression the evaluator does not understand throws rather than guessing", () => {
+  assert.throws(() => evalLength("anchor-size(10px)", ctx()), /does not know the function/)
+  assert.throws(() => evalLength("var(--nope)", ctx()), /neither published nor given a fallback/)
+})
+
+test("a padding shorthand overwrites all four longhands", () => {
+  // The second defect in SIEGE, as a unit: three safe-area longhands declared
+  // above, one `padding: 8px` below, and the safe area is gone on every
+  // landscape phone.
+  assert.deepEqual(expandBox("1px 2px 3px 4px"), {
+    top: "1px",
+    right: "2px",
+    bottom: "3px",
+    left: "4px",
+  })
+  assert.deepEqual(expandBox("1px 2px"), { top: "1px", right: "2px", bottom: "1px", left: "2px" })
+  assert.deepEqual(expandBox("calc(1px + 2px) 3px"), {
+    top: "calc(1px + 2px)",
+    right: "3px",
+    bottom: "calc(1px + 2px)",
+    left: "3px",
+  })
+
+  const rules = parseCss(`
+    .a { padding: 20px; padding-bottom: 48px; padding-left: 47px; }
+    @media (max-height: 619px) { .a { padding: 8px; } }
+  `)
+  const tall = paddingOf(rules, ".a", { w: 400, h: 800 }, new Map())
+  assert.equal(tall.bottom, 48)
+  const short = paddingOf(rules, ".a", { w: 800, h: 400 }, new Map())
+  assert.equal(short.bottom, 8, "the shorthand did not reset the longhand")
+  assert.equal(short.left, 8)
+})
+
+test("document order decides between equal selectors, and @keyframes never enters the cascade", () => {
+  const rules = parseCss(`
+    /* a comment { with braces } must not confuse the parser */
+    .a { top: 10px; }
+    .a { top: 20px; }
+    @keyframes spin { 0% { top: 999px; } 100% { top: 999px; } }
+  `)
+  assert.equal(lengthOf(rules, ".a", "top", { w: 400, h: 800 }, new Map()), 20)
+})
+
+test("a media query only applies at the viewports it matches", () => {
+  const rules = parseCss(`
+    .a { left: 10px; }
+    @media (max-width: 360px) { .a { left: 4px; } }
+    @media (min-width: 900px) and (min-height: 620px) { .a { left: 30px; } }
+    @media (prefers-reduced-motion: reduce) { .a { left: 999px; } }
+  `)
+  const at = (w: number, h: number): number => lengthOf(rules, ".a", "left", { w, h }, new Map())
+  assert.equal(at(320, 568), 4)
+  assert.equal(at(400, 800), 10)
+  assert.equal(at(1180, 820), 30)
+  assert.equal(at(1180, 400), 10, "an `and` query matched on one condition alone")
+})
+
+test("a custom property declared on the element wins for the viewport it was declared at", () => {
+  // How a breakpoint changes a pad without a shorthand going near the safe area.
+  const rules = parseCss(`
+    .a { --pad: 20px; padding: 0 0 calc(var(--x-safe-bottom, env(safe-area-inset-bottom, 0px)) + var(--pad)) 0; }
+    @media (max-height: 619px) { .a { --pad: 8px; } }
+  `)
+  const published = vars({ "--x-safe-bottom": "48px" })
+  assert.equal(paddingOf(rules, ".a", { w: 400, h: 800 }, published).bottom, 68)
+  assert.equal(paddingOf(rules, ".a", { w: 800, h: 400 }, published).bottom, 56)
+})
+
+test("a selector in a comma list is found", () => {
+  const rules = parseCss(`.a, .b { top: 7px; }`)
+  assert.equal(lengthOf(rules, ".b", "top", { w: 400, h: 800 }, new Map()), 7)
+})
+
+test("envReadDirectly names every env() that is not a var() fallback", () => {
+  assert.deepEqual(
+    envReadDirectly(
+      `.a { top: var(--mn-safe-top, env(safe-area-inset-top, 0px)); }`,
+      "--mn-safe-",
+    ),
+    [],
+  )
+  const bad = envReadDirectly(`.a { bottom: max(10px, env(safe-area-inset-bottom)); }`, "--mn-safe-")
+  assert.equal(bad.length, 1)
+  assert.match(bad[0] as string, /read directly/)
+  // A comment discussing env() is not a rule.
+  assert.deepEqual(envReadDirectly(`/* env(safe-area-inset-top) */ .a { top: 0 }`, "--mn-safe-"), [])
+})

--- a/dynawalla/packs/shared/game-chrome/cssSafeArea.ts
+++ b/dynawalla/packs/shared/game-chrome/cssSafeArea.ts
@@ -1,0 +1,570 @@
+/**
+ * A small CSS engine for TESTS: parse a pack's stylesheet, run the cascade, and
+ * evaluate a length to a NUMBER — with `env(safe-area-inset-*)` defined as zero.
+ *
+ * **Why this exists.** A pack runs in an iframe sandboxed `allow-scripts` with
+ * no `allow-same-origin`. `env(safe-area-inset-*)` is a property of the
+ * TOP-LEVEL browsing context, so a cross-origin child resolves all four to 0 and
+ * every rule that reaches for one silently collapses to its fallback. SIEGE
+ * shipped its currency under an Android clock that way, and the test that was
+ * supposed to catch it asserted `body.includes("env(safe-area-inset-top")` — a
+ * substring search, true on the day the pixels were wrong. Text being present
+ * says nothing about what it resolves to.
+ *
+ * So: no substring searches. Parse the shipped stylesheet, cascade it for a
+ * viewport, and evaluate the winning declaration to a number, with one rule
+ * baked into the evaluator:
+ *
+ *     env(safe-area-inset-*) evaluates to ZERO
+ *
+ * which is not a simplification — it is the environment the game runs in. Any
+ * rule still taking its answer from `env()` evaluates to its fallback here and
+ * the assertion above it fails, which is exactly what should happen. The only
+ * way to pass is for the number to arrive as a custom property, which is to say
+ * from the host.
+ *
+ * **It is deliberately not exported from `index.ts`.** Nothing that ships
+ * imports it; three packs' `safearea.test.ts` files do. It lives here rather
+ * than three times over because a fourth copy of a CSS parser is a fourth
+ * chance to get the cascade wrong, and `cssSafeArea.test.ts` next door holds
+ * this one to the behaviours the packs rely on.
+ *
+ * **The subset of CSS it knows**, which is all any of these stylesheets uses:
+ * comments, one level of `@media` with `min/max-width` and `min/max-height`,
+ * `@keyframes` skipped whole, `var()` with fallbacks, `calc()`, `min()`,
+ * `max()`, `clamp()`, `px`/`%`/`vw`/`vh`/`vmin`/`vmax`, and box shorthand
+ * expansion. Anything else throws rather than guessing — a parser that silently
+ * shrugs is how the first version of this shipped.
+ */
+
+import type { Insets } from "./insets.ts"
+
+/* ── the shapes every pack is held to ────────────────────────────────────── */
+
+export type Shape = { name: string; w: number; h: number; insets: Insets }
+
+/**
+ * The screens a pack's chrome must be proven on.
+ *
+ * Shared rather than retyped per pack for one reason: the founder's phone has to
+ * be in every list. It is a 1080x2340 panel at dpr 2.75, so 393x851 CSS px, with
+ * a 24dp status bar and a 48dp three-button navigation bar — 24 and 48 CSS px,
+ * because on Android a CSS pixel IS a dp. That is the device the safe-area bugs
+ * keep being found on, and a per-pack list is a list one pack can quietly omit
+ * it from.
+ *
+ * The rest: both landscape orientations of the same phone (the nav bar moves to
+ * a side and the status bar stays), the smallest phone anyone still holds, a
+ * notched phone upright and on its side, and two tablets.
+ */
+export const SHAPES: readonly Shape[] = [
+  {
+    name: "the founder's phone, portrait — status bar and three-button nav",
+    w: 393,
+    h: 851,
+    insets: { top: 24, right: 0, bottom: 48, left: 0 },
+  },
+  {
+    name: "the founder's phone, landscape — nav bar on the right",
+    w: 851,
+    h: 393,
+    insets: { top: 24, right: 48, bottom: 0, left: 0 },
+  },
+  {
+    name: "the founder's phone, landscape — nav bar on the left",
+    w: 851,
+    h: 393,
+    insets: { top: 24, right: 0, bottom: 0, left: 48 },
+  },
+  {
+    name: "the smallest phone, no insets",
+    w: 320,
+    h: 568,
+    insets: { top: 0, right: 0, bottom: 0, left: 0 },
+  },
+  {
+    name: "a notched phone, portrait",
+    w: 390,
+    h: 844,
+    insets: { top: 47, right: 0, bottom: 34, left: 0 },
+  },
+  {
+    name: "a notched phone, landscape — cutout at both sides",
+    w: 844,
+    h: 390,
+    insets: { top: 0, right: 47, bottom: 21, left: 47 },
+  },
+  {
+    name: "a notched phone, landscape — cutout at one side",
+    w: 844,
+    h: 390,
+    insets: { top: 0, right: 0, bottom: 21, left: 47 },
+  },
+  { name: "a tablet, portrait", w: 768, h: 1024, insets: { top: 24, right: 0, bottom: 20, left: 0 } },
+  { name: "a tablet, landscape", w: 1024, h: 768, insets: { top: 24, right: 0, bottom: 20, left: 0 } },
+  { name: "a large tablet, landscape", w: 1180, h: 820, insets: { top: 24, right: 0, bottom: 20, left: 0 } },
+]
+
+/* ── parsing ─────────────────────────────────────────────────────────────── */
+
+export type Decl = { prop: string; value: string }
+export type Rule = { media: string; selectors: string[]; decls: Decl[] }
+export type Viewport = { w: number; h: number }
+
+const fail = (message: string): never => {
+  throw new Error(message)
+}
+
+/** Split on `sep` at paren depth zero. `calc(a, b)` is not two things. */
+export function splitTop(s: string, sep: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let cur = ""
+  for (const ch of s) {
+    if (ch === "(") depth++
+    else if (ch === ")") depth--
+    if (ch === sep && depth === 0) {
+      out.push(cur)
+      cur = ""
+    } else cur += ch
+  }
+  out.push(cur)
+  return out
+}
+
+/** Split a declaration body into declarations. */
+export function parseDecls(body: string): Decl[] {
+  const out: Decl[] = []
+  for (const chunk of splitTop(body, ";")) {
+    const at = chunk.indexOf(":")
+    if (at < 0) continue
+    const prop = chunk.slice(0, at).trim()
+    const value = chunk.slice(at + 1).trim()
+    if (prop) out.push({ prop, value })
+  }
+  return out
+}
+
+/**
+ * Parse a stylesheet into a flat, ordered list of rules.
+ *
+ * Order is the whole point: every selector these tests ask about is a single
+ * class, so specificity is equal throughout and DOCUMENT ORDER decides — which
+ * is precisely the rule that let a `padding: 8px` inside a media query delete
+ * three safe-area longhands declared above it.
+ */
+export function parseCss(src: string): Rule[] {
+  const css = src.replace(/\/\*[\s\S]*?\*\//g, "")
+  const rules: Rule[] = []
+
+  const walk = (text: string, media: string): void => {
+    let i = 0
+    while (i < text.length) {
+      const open = text.indexOf("{", i)
+      if (open < 0) break
+      const prelude = text.slice(i, open).trim()
+      let depth = 0
+      let end = -1
+      for (let j = open; j < text.length; j++) {
+        if (text[j] === "{") depth++
+        else if (text[j] === "}") {
+          depth--
+          if (depth === 0) {
+            end = j
+            break
+          }
+        }
+      }
+      if (end < 0) fail("unbalanced braces in the stylesheet")
+      const body = text.slice(open + 1, end)
+      if (prelude.startsWith("@media")) {
+        if (media !== "") fail("nested @media is not supported by this parser")
+        walk(body, prelude.slice("@media".length).trim())
+      } else if (prelude.startsWith("@")) {
+        // @keyframes and friends: `0% { … }` blocks are not rules and must not
+        // enter the cascade.
+      } else {
+        rules.push({
+          media,
+          selectors: prelude
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+          decls: parseDecls(body),
+        })
+      }
+      i = end + 1
+    }
+  }
+
+  walk(css, "")
+  return rules
+}
+
+/**
+ * Evaluate a media prelude against a viewport.
+ *
+ * `prefers-reduced-motion` is always FALSE here: none of these assertions are
+ * about motion, and a reduced-motion block that changed geometry would be a
+ * defect of its own.
+ */
+export function mediaMatches(query: string, vp: Viewport): boolean {
+  if (query === "") return true
+  return query
+    .split(" and ")
+    .map((s) => s.trim())
+    .every((cond) => {
+      const m = /^\(([a-z-]+)\s*:\s*([^)]+)\)$/.exec(cond)
+      if (!m) return fail(`this parser does not understand the media condition "${cond}"`)
+      const feature = m[1] as string
+      const raw = m[2] as string
+      if (feature === "prefers-reduced-motion") return false
+      const n = Number.parseFloat(raw)
+      if (!Number.isFinite(n)) return fail(`non-length media value "${raw}"`)
+      if (feature === "max-width") return vp.w <= n
+      if (feature === "min-width") return vp.w >= n
+      if (feature === "max-height") return vp.h <= n
+      if (feature === "min-height") return vp.h >= n
+      return fail(`this parser does not understand the media feature "${feature}"`)
+    })
+}
+
+/* ── the cascade ─────────────────────────────────────────────────────────── */
+
+export const BOX_SIDES = ["top", "right", "bottom", "left"] as const
+export type Side = (typeof BOX_SIDES)[number]
+export type Box = Record<Side, number>
+
+/** Split on whitespace at paren depth zero — `calc(a + b)` is ONE component. */
+export function splitComponents(s: string): string[] {
+  const out: string[] = []
+  let depth = 0
+  let cur = ""
+  for (const ch of s) {
+    if (ch === "(") depth++
+    else if (ch === ")") depth--
+    if (depth === 0 && /\s/.test(ch)) {
+      if (cur.trim()) out.push(cur.trim())
+      cur = ""
+    } else cur += ch
+  }
+  if (cur.trim()) out.push(cur.trim())
+  return out
+}
+
+/** Expand `padding: a [b [c [d]]]` the way the box model does. */
+export function expandBox(value: string): Record<Side, string> {
+  const parts = splitComponents(value.trim())
+  const a = parts[0]
+  if (a === undefined) return fail("empty box shorthand")
+  const b = parts[1]
+  const c = parts[2]
+  const d = parts[3]
+  return { top: a, right: b ?? a, bottom: c ?? a, left: d ?? b ?? a }
+}
+
+/**
+ * The declarations that win for one selector at one viewport.
+ *
+ * A `padding`/`margin` SHORTHAND expands into its four longhands and overwrites
+ * all of them, because that is what it does in a browser and that is the second
+ * half of the bug this module exists for: `padding: 8px` in a landscape media
+ * query threw away three safe-area longhands and nothing failed.
+ */
+export function cascade(rules: Rule[], selector: string, vp: Viewport): Map<string, string> {
+  const won = new Map<string, string>()
+  for (const rule of rules) {
+    if (!rule.selectors.includes(selector)) continue
+    if (!mediaMatches(rule.media, vp)) continue
+    for (const d of rule.decls) {
+      if (d.prop === "padding" || d.prop === "margin") {
+        const box = expandBox(d.value)
+        for (const side of BOX_SIDES) won.set(`${d.prop}-${side}`, box[side])
+      } else {
+        won.set(d.prop, d.value)
+      }
+    }
+  }
+  return won
+}
+
+/* ── evaluation ──────────────────────────────────────────────────────────── */
+
+export type EvalCtx = {
+  /** Custom properties in scope, as the running game publishes them. */
+  vars: Map<string, string>
+  vp: Viewport
+  /** What a `%` is a percentage OF. Give 0 when the containing box is unknown. */
+  pct: number
+}
+
+/** Index of the `)` matching the `(` that starts at `open`. */
+function matchParen(s: string, open: number, what: string): number {
+  let depth = 0
+  for (let i = open; i < s.length; i++) {
+    if (s[i] === "(") depth++
+    else if (s[i] === ")") {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return fail(`unbalanced ${what}( in "${s}"`)
+}
+
+/**
+ * Substitute `var(--name, fallback)` and `env(…)` until none are left.
+ *
+ * `env()` is textual, not arithmetic: the whole call — name, fallback and all —
+ * becomes `0px`. That is the module's one deliberate rule and it has to happen
+ * here rather than in the expression grammar, because `env(safe-area-inset-top,
+ * 0px)` is not a function of a number and cannot be parsed as one.
+ */
+export function substituteVars(value: string, ctx: EvalCtx): string {
+  let s = value
+  for (let pass = 0; pass < 64; pass++) {
+    const v = s.indexOf("var(")
+    const e = s.indexOf("env(")
+    if (v < 0 && e < 0) return s
+    const useVar = v >= 0 && (e < 0 || v < e)
+    const at = useVar ? v : e
+    const close = matchParen(s, at + 3, useVar ? "var" : "env")
+    if (!useVar) {
+      s = `${s.slice(0, at)}0px${s.slice(close + 1)}`
+      continue
+    }
+    const comma = splitTop(s.slice(at + 4, close), ",")
+    const name = (comma[0] ?? "").trim()
+    const fallback = comma.slice(1).join(",").trim()
+    const got = ctx.vars.get(name)
+    if (got === undefined && fallback === "") {
+      fail(`${name} is neither published nor given a fallback in "${value}"`)
+    }
+    s = s.slice(0, at) + (got ?? fallback) + s.slice(close + 1)
+  }
+  return fail(`var()/env() substitution did not terminate for "${value}"`)
+}
+
+/** Tokenise a resolved length expression. */
+function tokenize(s: string): string[] {
+  const out: string[] = []
+  let i = 0
+  while (i < s.length) {
+    const ch = s[i] as string
+    if (/\s/.test(ch)) {
+      i++
+      continue
+    }
+    if ("()+-*/,".includes(ch)) {
+      out.push(ch)
+      i++
+      continue
+    }
+    const m = /^[a-zA-Z-]+|^[0-9.]+(px|%|vw|vh|vmin|vmax)?/.exec(s.slice(i))
+    if (!m) return fail(`cannot tokenise "${s}" at ${i}`)
+    out.push(m[0])
+    i += m[0].length
+  }
+  return out
+}
+
+/**
+ * Evaluate a length to a number.
+ *
+ * `env(safe-area-inset-*)` is ZERO, fallback and all — see the module docblock.
+ * That is what it is inside a pack frame, and modelling it any other way is how
+ * this bug shipped in the first place.
+ */
+export function evalLength(raw: string, ctx: EvalCtx): number {
+  const toks = tokenize(substituteVars(raw, ctx))
+  let p = 0
+  const peek = (): string | undefined => toks[p]
+  const take = (expected?: string): string => {
+    const got = toks[p++]
+    if (got === undefined) return fail(`ran off the end of "${raw}"`)
+    if (expected !== undefined && got !== expected) fail(`expected ${expected} in "${raw}"`)
+    return got
+  }
+
+  const args = (): number[] => {
+    take("(")
+    const out: number[] = []
+    if (peek() === ")") {
+      take(")")
+      return out
+    }
+    for (;;) {
+      out.push(expr())
+      if (peek() === ",") {
+        take(",")
+        continue
+      }
+      take(")")
+      return out
+    }
+  }
+
+  const factor = (): number => {
+    const t = take()
+    if (t === "(") {
+      const v = expr()
+      take(")")
+      return v
+    }
+    if (t === "-") return -factor()
+    if (t === "+") return factor()
+    if (/^[0-9.]/.test(t)) {
+      const n = Number.parseFloat(t)
+      if (!Number.isFinite(n)) fail(`bad number "${t}"`)
+      if (t.endsWith("%")) return (n / 100) * ctx.pct
+      if (t.endsWith("vw")) return (n / 100) * ctx.vp.w
+      if (t.endsWith("vh")) return (n / 100) * ctx.vp.h
+      if (t.endsWith("vmin")) return (n / 100) * Math.min(ctx.vp.w, ctx.vp.h)
+      if (t.endsWith("vmax")) return (n / 100) * Math.max(ctx.vp.w, ctx.vp.h)
+      return n
+    }
+    // `env()` never reaches here: `substituteVars` has already turned it into
+    // `0px`, which is what it is inside a pack frame.
+    const a = args()
+    if (t === "calc") {
+      if (a.length !== 1) fail(`calc() takes one expression, got ${a.length} in "${raw}"`)
+      return a[0] as number
+    }
+    if (t === "max") return Math.max(...a)
+    if (t === "min") return Math.min(...a)
+    if (t === "clamp") {
+      const lo = a[0] as number
+      const mid = a[1] as number
+      const hi = a[2] as number
+      return Math.min(Math.max(lo, mid), hi)
+    }
+    return fail(`this evaluator does not know the function ${t}() in "${raw}"`)
+  }
+
+  const term = (): number => {
+    let v = factor()
+    for (;;) {
+      const t = peek()
+      if (t === "*") {
+        take()
+        v *= factor()
+      } else if (t === "/") {
+        take()
+        v /= factor()
+      } else return v
+    }
+  }
+
+  function expr(): number {
+    let v = term()
+    for (;;) {
+      const t = peek()
+      if (t === "+") {
+        take()
+        v += term()
+      } else if (t === "-") {
+        take()
+        v -= term()
+      } else return v
+    }
+  }
+
+  const v = expr()
+  if (p !== toks.length) fail(`trailing tokens in "${raw}"`)
+  return v
+}
+
+/* ── the two questions a pack's test actually asks ───────────────────────── */
+
+/**
+ * Custom properties declared on the element itself join the map at the value
+ * that won for THIS viewport — which is how a `--pad` can change at a breakpoint
+ * without a shorthand going anywhere near the safe-area longhands.
+ */
+function scopeVars(won: Map<string, string>, published: Map<string, string>): Map<string, string> {
+  const vars = new Map(published)
+  for (const [prop, value] of won) if (prop.startsWith("--")) vars.set(prop, value)
+  return vars
+}
+
+/**
+ * The custom properties one selector declares, at one viewport.
+ *
+ * Custom properties INHERIT, so a `--pad` declared on a pack's root element is
+ * in scope for every rule under it. A test that only looks at the element's own
+ * declarations will report that property as unset and then quietly take the
+ * `env()` fallback of whatever it was guarding — which is the failure mode this
+ * whole module exists to make impossible. Merge this into `published` for every
+ * ancestor that declares one.
+ */
+export function customPropsOf(
+  rules: Rule[],
+  selector: string,
+  vp: Viewport,
+): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const [prop, value] of cascade(rules, selector, vp)) {
+    if (prop.startsWith("--")) out.set(prop, value)
+  }
+  return out
+}
+
+/** One selector's resolved `padding`, as four numbers. */
+export function paddingOf(
+  rules: Rule[],
+  selector: string,
+  vp: Viewport,
+  published: Map<string, string>,
+  pct = 0,
+): Box {
+  const won = cascade(rules, selector, vp)
+  const ctx: EvalCtx = { vars: scopeVars(won, published), vp, pct }
+  const out = {} as Box
+  for (const side of BOX_SIDES) {
+    const raw = won.get(`padding-${side}`)
+    if (raw === undefined) fail(`${selector} has no padding-${side} at ${vp.w}x${vp.h}`)
+    out[side] = evalLength(raw as string, ctx)
+  }
+  return out
+}
+
+/** One selector's resolved value for a single length property. */
+export function lengthOf(
+  rules: Rule[],
+  selector: string,
+  prop: string,
+  vp: Viewport,
+  published: Map<string, string>,
+  pct = 0,
+): number {
+  const won = cascade(rules, selector, vp)
+  const raw = won.get(prop)
+  if (raw === undefined) fail(`${selector} has no ${prop} at ${vp.w}x${vp.h}`)
+  return evalLength(raw as string, { vars: scopeVars(won, published), vp, pct })
+}
+
+/**
+ * Every `env(safe-area-inset-*)` in a stylesheet must be the FALLBACK of a
+ * named custom property, never the answer.
+ *
+ * Returns the offenders. A pack keeps the `env()` behind the `var()` because it
+ * is right in a dev browser tab, where there is no host to publish anything —
+ * but inside the app it is the number zero, so nothing may read it directly.
+ *
+ * @param prefix e.g. `--sg-safe-` for `var(--sg-safe-top, env(safe-area-inset-top, 0px))`
+ */
+export function envReadDirectly(css: string, prefix: string): string[] {
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "")
+  const bad: string[] = []
+  for (const m of stripped.matchAll(/env\(safe-area-inset-(top|right|bottom|left)/g)) {
+    const side = m[1] as string
+    const at = m.index
+    const before = stripped.slice(Math.max(0, at - (prefix.length + side.length + 8)), at)
+    if (!before.endsWith(`var(${prefix}${side}, `) && !before.endsWith(`var(${prefix}${side},`)) {
+      bad.push(
+        `env(safe-area-inset-${side}) at ${at} is read directly, not as the fallback of ` +
+          `${prefix}${side} — inside a pack frame that is the number zero`,
+      )
+    }
+  }
+  return bad
+}

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -8,7 +8,16 @@
  * `audioHold`   — the pack's sound, stopped while that surface is up. Mounting
  *                 the manual arms it; no game imports it or calls it.
  */
-export { safeInsets, setHostInsets, onInsetsChange, safeRect, NO_INSETS, type Insets } from "./insets.ts"
+export {
+  safeInsets,
+  setHostInsets,
+  onInsetsChange,
+  safeRect,
+  publishSafeVars,
+  NO_INSETS,
+  type Insets,
+  type StyleTarget,
+} from "./insets.ts"
 export {
   exitRect,
   helpRect,

--- a/dynawalla/packs/shared/game-chrome/insets.test.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 
-import { NO_INSETS, safeInsets, setHostInsets, safeRect } from "./insets.ts"
+import {
+  NO_INSETS,
+  publishSafeVars,
+  safeInsets,
+  setHostInsets,
+  safeRect,
+  type Insets,
+  type StyleTarget,
+} from "./insets.ts"
 import { HOST_CONTROL, chromeRects, exitRect, helpRect, hitsHostChrome } from "./hostChrome.ts"
 
 test("with no document to measure, the insets are zero rather than undefined", () => {
@@ -121,4 +129,62 @@ test("a malformed payload from the host is refused, not trusted", () => {
     }
   }
   setHostInsets(null)
+})
+
+// ---------------------------------------------------------------------------
+// Publishing the safe area to a stylesheet.
+//
+// A pack's DOM chrome cannot read `env()` at all — it is a cross-origin child —
+// so the four numbers have to be written onto the root as custom properties and
+// the stylesheet has to read them through `var()`. These are the two properties
+// every pack that does this depends on.
+// ---------------------------------------------------------------------------
+
+const spy = (): { seen: Map<string, string>; writes: number; el: StyleTarget } => {
+  const seen = new Map<string, string>()
+  const box = { writes: 0 }
+  const el: StyleTarget = {
+    style: {
+      setProperty(name: string, value: string): void {
+        box.writes++
+        seen.set(name, value)
+      },
+    },
+  }
+  return {
+    seen,
+    get writes(): number {
+      return box.writes
+    },
+    el,
+  }
+}
+
+test("all four properties are published, with zeros written out", () => {
+  const s = spy()
+  publishSafeVars(s.el, "--mn-safe-", { top: 24, right: 0, bottom: 48, left: 0 })
+  assert.deepEqual(
+    [...s.seen.entries()].sort(),
+    [
+      ["--mn-safe-bottom", "48px"],
+      ["--mn-safe-left", "0px"],
+      ["--mn-safe-right", "0px"],
+      ["--mn-safe-top", "24px"],
+    ],
+  )
+  // A zero must be WRITTEN, not left unset: an absent custom property falls
+  // through to the `env()` fallback beside it, and inside a pack frame that is
+  // the number zero whatever the real inset is. Leaving it out is the bug.
+  assert.equal(s.seen.get("--mn-safe-right"), "0px", "a zero inset was left for env() to answer")
+})
+
+test("republishing an unchanged safe area writes nothing; a rotation writes", () => {
+  const s = spy()
+  const i: Insets = { top: 24, right: 0, bottom: 48, left: 0 }
+  assert.equal(publishSafeVars(s.el, "--x-", i, null), true)
+  assert.equal(s.writes, 4)
+  assert.equal(publishSafeVars(s.el, "--x-", { ...i }, i), false, "an unchanged inset was rewritten")
+  assert.equal(s.writes, 4)
+  assert.equal(publishSafeVars(s.el, "--x-", { ...i, top: 47 }, i), true, "a rotation was not published")
+  assert.equal(s.writes, 8)
 })

--- a/dynawalla/packs/shared/game-chrome/insets.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.ts
@@ -155,3 +155,61 @@ export function safeRect(
     h: Math.max(0, h - y - Math.min(insets.bottom, h)),
   }
 }
+
+/** The narrow slice of an element `publishSafeVars` needs, so a test can stub it. */
+export type StyleTarget = { style: { setProperty(name: string, value: string): void } }
+
+/**
+ * Hand a STYLESHEET the safe area, as four custom properties it can do
+ * arithmetic with.
+ *
+ * **Why a stylesheet cannot just ask.** `env(safe-area-inset-*)` belongs to the
+ * top-level browsing context, and a pack is a cross-origin child, so all four
+ * resolve to 0 there — every `padding: env(safe-area-inset-top)` in a pack
+ * silently collapses to its fallback. That is not a rare edge: it is every
+ * device, every time, and SIEGE, STACK and POLARITY all shipped a DOM HUD under
+ * the Android status bar because of it. The numbers have to arrive as an
+ * argument from the host, which is what this does.
+ *
+ * The stylesheet then reads `var(--x-safe-top, env(safe-area-inset-top, 0px))`:
+ * the property inside the app, the `env()` only in a dev browser tab where there
+ * is no host and where it happens to be right.
+ *
+ * Zeros are written EXPLICITLY rather than left unset. `var()` falls back to its
+ * `env()` when the property is absent, and inside the app that is the wrong
+ * answer even when the true inset happens to be zero — it is the wrong answer
+ * *especially* then, because it is indistinguishable from the right one until
+ * the child picks up a phone with a notch.
+ *
+ * @param prefix the pack's own namespace, e.g. `"--mn-safe-"`.
+ * @param previous what was last published, so a resize path can skip a write.
+ * @returns whether anything changed.
+ */
+export function publishSafeVars(
+  root: StyleTarget,
+  prefix: string,
+  insets: Insets = safeInsets(),
+  previous?: Insets | null,
+): boolean {
+  const i = insets ?? NO_INSETS
+  const now: Insets = {
+    top: Math.max(0, i.top),
+    right: Math.max(0, i.right),
+    bottom: Math.max(0, i.bottom),
+    left: Math.max(0, i.left),
+  }
+  if (
+    previous &&
+    previous.top === now.top &&
+    previous.right === now.right &&
+    previous.bottom === now.bottom &&
+    previous.left === now.left
+  ) {
+    return false
+  }
+  root.style.setProperty(`${prefix}top`, `${now.top}px`)
+  root.style.setProperty(`${prefix}right`, `${now.right}px`)
+  root.style.setProperty(`${prefix}bottom`, `${now.bottom}px`)
+  root.style.setProperty(`${prefix}left`, `${now.left}px`)
+  return true
+}


### PR DESCRIPTION
The defect #767 diagnosed in SIEGE, in the two packs that PR named as still carrying it — plus one surface in the third, which the computed test found and which I would not have believed without it.

A pack runs in an iframe sandboxed `allow-scripts` with no `allow-same-origin`. `env(safe-area-inset-*)` is a property of the TOP-LEVEL browsing context, so a cross-origin child resolves all four to **zero**. Every rule that reaches for one collapses to its fallback — on every device, always, silently.

## What each pack's actual state was

### STACK — broken, and it had a passing test saying otherwise

`place.ts` deliberately owns its geometry in two dialects: a numeric one that `place.test.ts` feeds to `hitsHostChrome`, and a `calc(env(...) + Npx)` string that `hud.ts` interpolates into its stylesheet. The numeric one took the insets as an argument. The CSS one asked the browser, and got zero.

So `place.test.ts` was proving the floor count cleared a 59px status bar while the shipped rule put it 13px down the screen. Measured on the founder's 1080x2340 Android — 393x851 CSS px, 24px status bar, 48px three-button nav:

| | before | after |
|---|---|---|
| `.mn-floor` top (FLOOR — the number the game is about) | **13** | 37 |
| `.mn-tools` bottom (the sound button, 40px tall) | **12** | 60 |
| `.mn-over` padding-bottom (revive question + answer buttons) | **20** | 68 |

A button whose whole 40px sits 12px off the bottom edge is a button entirely inside the navigation bar. Held sideways, `.mn-best` right went 62 → 110 and the tool row 12 → 60.

### POLARITY — broken in the way that is hardest to see

`.pol-hud` padded all four edges with `env()` and had done since the first commit, which is why nobody looked at it again. `max(10px, env(safe-area-inset-bottom))` is 10px on every phone ever made. `layout.ts`'s `hudRects` — the thing `layout.test.ts` asserts — was describing a HUD that was never drawn.

| | before | after |
|---|---|---|
| `.pol-hud` padding-top | 63 | 87 |
| `.pol-hud` padding-bottom (the FLIP and VENT pads sit on it) | **10** | 48 |
| `.pol-mini` top (the game's own sound and pause) | **10** | 24 |
| `.pol-keyhint` bottom | **10** | 48 |
| `.pol-veil` padding-right, landscape (the REPOLARIZE orbs) | **20** | 48 |

### CLAIM — already clean on every published surface, defective on the one that was never published

CLAIM was built the right way round from the start and I want to say so plainly: `layout.ts` owns the numbers, `Hud.layout` and `Claim.layout` publish them as custom properties from `safeInsets()`, and the `env()`s in `style.css` are dead fallbacks that never win. The HUD padding, the two top-row gutters, the fraction bar and the mute button are **untouched by this PR** and its new test passes against them unmodified. That is the evidence, not a claim.

The exception is `.cl-card`, the full-bleed level/game-over card, which had a flat `padding: 20px` and was never given the insets at all. Its contents are centred, so the padding is what decides where a centred stack lands. Modelled from the stylesheet's own type scale, on the founder's phone held sideways the level card's big goal fraction starts at **y=21 against a safe top of 24** — the top of it under the status bar. Four longhands and four more published properties; nothing else in CLAIM moved.

## Host chrome

`exitRect`/`helpRect` are asserted against every readable or touchable box in all three packs, at all ten shapes, from the CSS numbers rather than the model: STACK's floor count, best score and sound button; POLARITY's top row and mini controls; CLAIM's level counter, score cluster, fraction bar and mute button. Nothing was reserved and no band was taken — the chrome overlays, and the playfields did not lose a pixel.

## Why it shipped, and the trap not repeated

SIEGE's old test asserted `body.includes("env(safe-area-inset-top")`. That was true on the day it shipped its currency under a clock. STACK's and POLARITY's tests were better — real numbers, real host-chrome collision checks — and just as blind, because they asserted a **model** the stylesheet did not consume.

So the new tests do not look for text and do not re-derive geometry. `packs/shared/game-chrome/cssSafeArea.ts` — lifted from #767's parser rather than copied a third and fourth time — parses the shipped stylesheet, runs the cascade, expands `padding`/`margin` shorthands, resolves custom properties including the inherited ones, and evaluates every offset to a **number**, with one rule baked in:

    env(safe-area-inset-*) evaluates to ZERO

Each pack then asserts that the number its CSS produces **is** the number its own model promised, and that both are inside `safeRect` and clear of the host's two corners, at ten shapes: the founder's phone in three orientations, 320x568, a notched phone portrait and landscape both ways, and three tablets. `cssSafeArea.test.ts` holds the parser itself to the cascade rules the packs rely on — a wrong parser makes all three suites vacuous in exactly the way the substring search was.

**Real headless Chromium too**, because a parser can still be wrong about the cascade: all three stylesheets loaded into a browser at seven viewports with the same properties the games publish, read back through `getComputedStyle`. **266 probes, 0 disagreements** with the parser.

## Mutation transcript

Every new assertion was broken on purpose and confirmed to fail. Each was restored and the suite returned to green.

| mutation | result |
|---|---|
| STACK — `applySafeVars` publishes zeros | **8 fail** |
| STACK — `.mn-over` back to a `padding:` shorthand | 1 fail |
| STACK — `hud.setInsets()` deleted from `resize()` | 1 fail |
| STACK — nothing subscribes `onInsetsChange` | 1 fail |
| POLARITY — `applySafeVars` publishes zeros | **8 fail** |
| POLARITY — `.pol-hud` back to a `padding:` shorthand | 1 fail |
| POLARITY — one rule reads a bare `env()` again | 5 fail |
| POLARITY — `hud.setInsets()` deleted from `measure()` | 1 fail |
| CLAIM — `hudFrame` ignores the insets | 4 fail |
| CLAIM — the card back to a flat `padding: 20px` | 2 fail |
| CLAIM — `publishSafeVars` deleted from `layout()` | 1 fail |
| shared — `publishSafeVars` skips a zero | 2 + 1 + 1 fail |

The headline ones, verbatim:

```
✖ the stylesheet puts the readouts exactly where hudRects says they are
  the founder's phone, portrait — status bar and three-button nav:
  the floor count's top edge: the stylesheet says 13, hudRects says 37

✖ the tool row keeps a full 40px button clear of the bottom inset
✖ every readout the stylesheet places is inside the safe area
✖ the end-of-run card keeps its question and its buttons inside the safe area

✖ the register's padding is exactly the padding hudRects was tested against
  the founder's phone, portrait: the register's top padding:
  the stylesheet says 63, layout.ts says 87

✖ the register's contents are inside the safe area at every shape
  the founder's phone, portrait: the register crosses the BOTTOM inset (841 > 803)

✖ the key hint clears every inset
  the founder's phone, portrait: the key hint sits 10px from the bottom edge,
  inside a 48px inset

✖ the score, the pips and the touch pads never sit under the host's two controls
  the founder's phone, portrait: the score and the shield pips run under the
  host's chrome

✖ the safe area never clips the card that the frame was not already clipping
  the founder's phone, landscape — nav bar on the right:
  the card's tallest content starts at 21.0, above a safe top of 24

✖ a breakpoint cannot quietly delete the card's safe-area padding
  the end-of-run card uses a `padding:` shorthand again — a breakpoint can now
  erase the safe area

✖ the game publishes the safe area at mount and again on every resize
  nothing listens for the insets changing — the HUD keeps the shape the pack
  opened in

✖ the safe area is published as four properties, zeros written out
  --pol-safe-right was not published
```

## Verification

- `stack` **76/76**, `polarity` **84/84**, `claim` **87/87**, `game-chrome` **68/68** — five consecutive runs each.
- `npm run -s tsc` clean in all four.
- `node packs/build.mjs stack|polarity|claim` — all three build and pass the SDK checker.

## Not in this PR

No gameplay, difficulty, type scale or colour was touched. One thing found and deliberately left alone: CLAIM's `.cl-bigfrac` is `clamp(64px, 21vw, 190px)`, which on an 851px-wide landscape phone is a 179px numeral, and the card's stack overflows the **frame** on its own, insets or no insets. That is a type-scale defect, it predates this change, and fixing it changes how the game looks. The card test says so in its docblock and asserts only what it can honestly prove.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb