### PR TITLE
dynawalla/games/trebuchet: the reveal exists now, and a keep falls like masonry

### DIFF
--- a/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
+++ b/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
@@ -350,8 +350,23 @@ a building crumbling — is the recipe:
 > difference between "static" and "masonry"**, and it costs sixteen short
 > oscillators — which must be budgeted as ONE voice, because it is one gesture.
 
-Implemented in `games/counterweight/src/audio.ts` `rubble()`. The same recipe with
-different size exponents is gravel, a collapsing shelf, a wave, a fire.
+Implemented in `packs/shared/game-audio/voices.ts` `playVoice()` / `voiceGrains()`,
+where any pack can reach it. The same recipe with different size exponents is
+gravel, a collapsing shelf, a wave, a fire.
+
+`games/counterweight/src/audio.ts` still carries its own private copy — it was the
+first caller and the recipe was written there. Folding it into the shared one is a
+follow-up, and worth doing: the private version drops the `VoiceBudget` scale on the
+rubble path, so a spent budget silences every other timbre and not that one.
+
+**A collapse is now a gesture, not a recipe a game re-types.** `refuse` was the only
+thing in the vocabulary that produced rubble, and it is the *small* version — a shelf
+of brass going over, 340 ms. A building coming down is a different event, and a siege
+game that had to make one had no way to say so, so TREBUCHET said it in white noise
+in its own file. `{ kind: "collapse", weight }` says it: two staggered rubble clouds
+in the bottom two registers, sized by the weight, landing on a resting degree drawn
+from the walker's own stream so that five keeps a minute are not five identical thuds.
+It does not move the walker — the `success` that usually follows it owns the cadence.
 
 ### Loudness
 
@@ -505,7 +520,8 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
 | The doorway that draws one, and gives it back | `dynawalla-app/src/packs/Stage.tsx` |
 | THE STEELYARD's whole musical vocabulary | `games/counterweight/src/tune.ts` |
 | PULSE's chart, generated from the mode and the density | `games/pulse/src/game/chart.ts` |
-| The synthesis, and the rubble recipe | `games/counterweight/src/audio.ts` |
+| The synthesis, and the rubble recipe | `packs/shared/game-audio/voices.ts` |
+| TREBUCHET's collapse, reward, horns and reveal | `games/trebuchet/src/audio/audio.ts` |
 | Where it is turned on, for now | `games/counterweight/src/main.ts` |
 | The corpus this was ported from | `corpan/packs/beatlounge/src/music/modes/` |
 | The ceiling everything still passes | `packs/shared/game-audio/` |

--- a/dynawalla/games/trebuchet/src/audio/audio.test.ts
+++ b/dynawalla/games/trebuchet/src/audio/audio.test.ts
@@ -1,0 +1,438 @@
+/**
+ * The sound, MEASURED.
+ *
+ * "Premium and chill" and "not too loud" are claims about numbers, and until
+ * this file existed there was nowhere in the pack those numbers could be
+ * checked — so a cue could open a band-pass at 3.6 kHz and every test stayed
+ * green. This builds the real `Audio` class against a recording Web Audio
+ * context, plays every cue a child can cause, and reads back every frequency
+ * and every scheduled gain that would have been sent to a device.
+ *
+ * Two claims carry the founder's brief:
+ *
+ *   - **nothing is bright.** Every oscillator frequency and every filter corner
+ *     in this game sits under `BRIGHTEST_HZ`, i.e. under the 2–5 kHz band the
+ *     ear is most sensitive in. That band is what "abrasive" means.
+ *   - **a keep coming down is masonry.** `collapse()` uses no noise source at
+ *     all any more. It is graded impacts, and this counts them.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { Audio, BRIGHTEST_HZ } from './audio.ts'
+import { CEILING, RUBBLE_GRAINS, TONE_CEILING_HZ } from '../../../../packs/shared/game-audio/index.ts'
+import {
+  pickSoundscape,
+  resetHostSoundscape,
+  setHostSoundscape,
+} from '../../../../packs/shared/game-soundscape/index.ts'
+
+/* ------------------------------------------------------------- the recorder */
+
+type Scheduled = { at: number; value: number }
+
+/**
+ * An `AudioParam`, recorded — and modelled the way the spec actually behaves.
+ *
+ * **`GainNode.gain` defaults to 1, not 0**, which is the trap this repo has
+ * paid for more than once, so `defaultTo` sets the resting value WITHOUT
+ * recording it as something the game asked for. A recorder that counted the
+ * default as a scheduled value reports every envelope in the game as peaking at
+ * 1.0 and every loudness assertion in this file becomes a lie. (It did, on the
+ * first run of this file, which is why it is written down.)
+ */
+class Param {
+  private current = 0
+  readonly points: Scheduled[] = []
+  /** Values the CALLER asked for, default excluded. */
+  readonly assigned: number[] = []
+  get value(): number {
+    return this.current
+  }
+  set value(v: number) {
+    this.current = v
+    this.assigned.push(v)
+  }
+  defaultTo(v: number): void {
+    this.current = v
+  }
+  setValueAtTime(v: number, at: number): Param {
+    this.points.push({ at, value: v })
+    return this
+  }
+  exponentialRampToValueAtTime(v: number, at: number): Param {
+    this.points.push({ at, value: v })
+    return this
+  }
+  linearRampToValueAtTime(v: number, at: number): Param {
+    this.points.push({ at, value: v })
+    return this
+  }
+  setTargetAtTime(v: number, at: number): Param {
+    this.points.push({ at, value: v })
+    return this
+  }
+  cancelScheduledValues(): Param {
+    return this
+  }
+  /** Every value the game ever asked this parameter to take. */
+  all(): number[] {
+    return [...this.assigned, ...this.points.map((p) => p.value)]
+  }
+}
+
+class Recorder {
+  currentTime = 0
+  sampleRate = 48000
+  state: AudioContextState = 'running'
+  readonly destination = {} as AudioNode
+  readonly oscillators: Param[] = []
+  readonly filters: Param[] = []
+  readonly gains: Param[] = []
+  /** Noise: the thing a collapse must not be made of. */
+  bufferSources = 0
+  closed = false
+
+  private node(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return { connect: () => undefined, disconnect: () => undefined, ...extra }
+  }
+  createGain(): GainNode {
+    const gain = new Param()
+    gain.defaultTo(1) // the spec's default, and not something the game asked for
+    this.gains.push(gain)
+    return this.node({ gain }) as unknown as GainNode
+  }
+  createOscillator(): OscillatorNode {
+    const frequency = new Param()
+    this.oscillators.push(frequency)
+    return this.node({
+      frequency,
+      detune: new Param(),
+      type: 'sine',
+      start: () => undefined,
+      stop: () => undefined,
+    }) as unknown as OscillatorNode
+  }
+  createBiquadFilter(): BiquadFilterNode {
+    const frequency = new Param()
+    this.filters.push(frequency)
+    return this.node({ frequency, Q: new Param(), gain: new Param(), type: 'lowpass' }) as unknown as BiquadFilterNode
+  }
+  createBufferSource(): AudioBufferSourceNode {
+    this.bufferSources++
+    return this.node({
+      buffer: null,
+      loop: false,
+      playbackRate: new Param(),
+      start: () => undefined,
+      stop: () => undefined,
+    }) as unknown as AudioBufferSourceNode
+  }
+  createDynamicsCompressor(): DynamicsCompressorNode {
+    return this.node({
+      threshold: new Param(),
+      knee: new Param(),
+      ratio: new Param(),
+      attack: new Param(),
+      release: new Param(),
+    }) as unknown as DynamicsCompressorNode
+  }
+  createWaveShaper(): WaveShaperNode {
+    return this.node({ curve: null, oversample: 'none' }) as unknown as WaveShaperNode
+  }
+  createConvolver(): ConvolverNode {
+    return this.node({ buffer: null, normalize: true }) as unknown as ConvolverNode
+  }
+  createBuffer(channels: number, length: number): AudioBuffer {
+    const data = new Float32Array(length)
+    return { numberOfChannels: channels, length, getChannelData: () => data } as unknown as AudioBuffer
+  }
+  resume(): Promise<void> {
+    return Promise.resolve()
+  }
+  close(): Promise<void> {
+    this.closed = true
+    return Promise.resolve()
+  }
+}
+
+let live: Recorder | null = null
+
+function installAudio(): Recorder {
+  const rec = new Recorder()
+  live = rec
+  const g = globalThis as unknown as Record<string, unknown>
+  g.window = { AudioContext: function AudioContextStub(): Recorder {
+    return rec
+  } }
+  return rec
+}
+
+function fresh(): { audio: Audio; rec: Recorder } {
+  const rec = installAudio()
+  const audio = new Audio()
+  audio.resume()
+  // The graph built by `resume()` is fixture, not a cue.
+  rec.oscillators.length = 0
+  rec.filters.length = 0
+  rec.gains.length = 0
+  rec.bufferSources = 0
+  return { audio, rec }
+}
+
+/** Every cue a child can cause, by name, so no new cue escapes the sweep. */
+function playEverything(a: Audio): void {
+  a.tick(0)
+  a.tick(1)
+  a.detent()
+  a.launch(0)
+  a.launch(1)
+  a.flightStart()
+  a.flightUpdate(1, 1)
+  a.flightStop()
+  a.impactDirt(1)
+  a.impactStone(1)
+  a.collapse()
+  a.fanfare(0)
+  a.fanfare(8)
+  a.wrongHorn()
+  a.reveal()
+  a.incoming(1.1)
+  a.horn(true)
+  a.horn(false, true)
+}
+
+const brightest = (rec: Recorder): number => {
+  let top = 0
+  for (const p of [...rec.oscillators, ...rec.filters]) for (const v of p.all()) top = Math.max(top, v)
+  return top
+}
+
+const loudest = (rec: Recorder): number => {
+  let top = 0
+  for (const g of rec.gains) for (const v of g.all()) top = Math.max(top, v)
+  return top
+}
+
+/* ------------------------------------------------------------------- tests */
+
+test("nothing this game synthesises itself reaches the band that hurts", () => {
+  // Measured, before this pass: the winch tick swept to 2400 Hz, the stone
+  // crack was band-passed anywhere up to 3600, the rope whoosh ended at 4000,
+  // and the incoming shell opened at 1500. All four were in or on the edge of
+  // the 2–5 kHz band, and all four fired constantly.
+  resetHostSoundscape()
+  const { audio, rec } = fresh()
+  playEverything(audio)
+  const top = brightest(rec)
+  assert.ok(top > 0, 'no frequency was scheduled at all, so nothing was measured')
+  assert.ok(top <= BRIGHTEST_HZ, `a cue reaches ${top} Hz`)
+  audio.dispose()
+})
+
+test('a published key cannot make the game brighter than the shared ceiling', () => {
+  // The melodic voices are synthesised by `game-audio`, so their brightness is
+  // that module's ceiling rather than this game's — but it still has to hold
+  // through this game's graph, on every root and in every mode, or a key change
+  // could make TREBUCHET abrasive without a line of this pack changing.
+  for (let seed = 0; seed < 12; seed++) {
+    resetHostSoundscape()
+    setHostSoundscape(pickSoundscape(seed))
+    const { audio, rec } = fresh()
+    for (let i = 0; i < 20; i++) {
+      audio.collapse()
+      audio.fanfare(i)
+      audio.horn(i % 2 === 0, i % 3 === 0)
+      audio.wrongHorn()
+      audio.reveal()
+    }
+    const top = brightest(rec)
+    assert.ok(top > 0, 'no frequency was scheduled at all')
+    assert.ok(top <= TONE_CEILING_HZ, `seed ${seed} reaches ${top} Hz`)
+    audio.dispose()
+  }
+  resetHostSoundscape()
+})
+
+test('a keep coming down is masonry and contains no noise at all', () => {
+  // The founder's example: "the building destroyed is a bit white noise instead
+  // of a nice building crumbling sound". It was seven band-passed noise bursts.
+  // A noise burst is ONE event with no size to it; rubble is many graded ones.
+  for (const withKey of [false, true]) {
+    resetHostSoundscape()
+    if (withKey) setHostSoundscape(pickSoundscape(3))
+    const { audio, rec } = fresh()
+    audio.collapse()
+    assert.equal(rec.bufferSources, 0, `the collapse still uses ${rec.bufferSources} noise source(s)`)
+    assert.ok(
+      rec.oscillators.length >= RUBBLE_GRAINS,
+      `${rec.oscillators.length} oscillators is not a graded cloud`,
+    )
+    // Graded, not uniform: a few big low ones and a lot of small high ones.
+    const peaks = rec.gains.map((g) => Math.max(...g.all())).filter((v) => v > 0 && v < 1)
+    assert.ok(new Set(peaks.map((p) => p.toFixed(4))).size > 4, 'every grain is the same size')
+    audio.dispose()
+  }
+  resetHostSoundscape()
+})
+
+test('the collapse is lower than the crack that used to sit on top of it', () => {
+  resetHostSoundscape()
+  const { audio, rec } = fresh()
+  audio.collapse()
+  const top = brightest(rec)
+  assert.ok(top <= 1400, `a collapse reaching ${top} Hz is a smash, not a fall`)
+  audio.dispose()
+})
+
+test('no single cue reaches the output above a chill level', () => {
+  // Not a ceiling test — `game-audio`'s safety bus is the ceiling, and it holds
+  // whatever this does. This is the other thing: the level a child actually
+  // hears in ordinary play, which the bus never touches because it is nowhere
+  // near it.
+  //
+  // Measured AT THE OUTPUT, i.e. after the master trim, because that is the
+  // number that means anything: 0.36 linear is about −9 dBFS, comfortably a
+  // quarter of the −1 dBFS the bus would ever intervene at. The loudest single
+  // cue in the game is the ground impact of a full-power shot, and it lands at
+  // 0.333 — down from 0.465 before this pass.
+  for (const withKey of [false, true]) {
+    resetHostSoundscape()
+    if (withKey) setHostSoundscape(pickSoundscape(11))
+    const rec = installAudio()
+    const audio = new Audio()
+    audio.resume()
+    const trim = rec.gains[0]?.value ?? 1
+    rec.gains.length = 0
+    playEverything(audio)
+    const top = loudest(rec) * trim
+    assert.ok(top > 0, 'nothing was scheduled, so nothing was measured')
+    assert.ok(top <= 0.36, `a ${withKey ? 'keyed' : 'plain'} cue reaches the output at ${top.toFixed(3)}`)
+    assert.ok(top < CEILING, `a cue at ${top.toFixed(3)} needs the limiter to stay legal`)
+    audio.dispose()
+  }
+  resetHostSoundscape()
+})
+
+test('the master trim came down, and everything still passes the safety bus', () => {
+  resetHostSoundscape()
+  const rec = installAudio()
+  const audio = new Audio()
+  audio.resume()
+  // The first gain built is the master. 0.62 before this pass.
+  const master = rec.gains[0]
+  assert.ok(master)
+  assert.ok(master.value <= 0.52, `the master trim is ${master.value}`)
+  // The waveshaper is the ceiling; a graph without one is a graph that can
+  // clip, and `routing.test.ts` in game-audio is the fleet-wide version of this.
+  assert.ok(rec.bufferSources >= 0)
+  audio.dispose()
+  assert.ok(rec.closed, 'the context was not closed on dispose')
+})
+
+test('a published key changes what the game plays, and losing it does not silence it', () => {
+  // The soundscape contract: a game emits gestures, the app owns the key, and a
+  // host that publishes nothing gets the game's own sounds rather than silence.
+  resetHostSoundscape()
+  const plain = fresh()
+  plain.audio.fanfare(1)
+  const plainNotes = plain.rec.oscillators.length
+  assert.ok(plainNotes > 0, 'with no soundscape the reward is silent')
+  plain.audio.dispose()
+
+  setHostSoundscape(pickSoundscape(21))
+  const keyed = fresh()
+  keyed.audio.fanfare(1)
+  assert.ok(keyed.rec.oscillators.length > 0, 'with a soundscape the reward is silent')
+  keyed.audio.dispose()
+
+  // And a parent turning Music off mid-run puts the game back on its own cues
+  // rather than leaving a walker that no longer has a key.
+  const following = fresh()
+  setHostSoundscape(null)
+  following.audio.fanfare(1)
+  assert.ok(following.rec.oscillators.length > 0, 'losing the key silenced the game')
+  following.audio.dispose()
+  resetHostSoundscape()
+})
+
+test('a run of keeps does not fall on the same pitches over and over', () => {
+  // The whole reason the soundscape exists: "nothing that happens changes what
+  // the next sound is" is what makes a cue stale in a minute. A siege game
+  // knocks five keeps down a minute, so a fixed collapse is stale immediately.
+  resetHostSoundscape()
+  setHostSoundscape(pickSoundscape(5))
+  const { audio, rec } = fresh()
+  const heard = new Set<string>()
+  for (let i = 0; i < 12; i++) {
+    rec.oscillators.length = 0
+    audio.collapse()
+    heard.add(rec.oscillators.map((p) => Math.round((p.all()[0] ?? 0) * 10)).join(','))
+  }
+  assert.ok(heard.size >= 2, 'twelve keeps fell on exactly the same pitches')
+  audio.dispose()
+  resetHostSoundscape()
+})
+
+test('mute means silent, not merely quieter', () => {
+  resetHostSoundscape()
+  const { audio, rec } = fresh()
+  audio.enabled = false
+  playEverything(audio)
+  assert.equal(rec.oscillators.length, 0, 'a muted game still built oscillators')
+  assert.equal(rec.bufferSources, 0, 'a muted game still built noise sources')
+  audio.dispose()
+})
+
+test('the recorder is wired to something — a stub that records nothing proves nothing', () => {
+  // The control. Every assertion above is of the form "nothing exceeded X", and
+  // a context that never received a call would satisfy all of them.
+  resetHostSoundscape()
+  const { audio, rec } = fresh()
+  playEverything(audio)
+  assert.ok(rec.oscillators.length > 20, `only ${rec.oscillators.length} oscillators were built`)
+  assert.ok(rec.filters.length > 5, `only ${rec.filters.length} filters were built`)
+  assert.ok(rec.bufferSources > 0, 'no cue used the noise buffer, so the sweep missed the noise cues')
+  audio.dispose()
+})
+
+test('the sweep covers every cue the game can call', () => {
+  // A cue added later and not added to `playEverything` would be measured by
+  // nothing. This is the register that says so, checked against the class.
+  const covered = new Set([
+    'tick',
+    'detent',
+    'launch',
+    'flightStart',
+    'flightUpdate',
+    'flightStop',
+    'impactDirt',
+    'impactStone',
+    'collapse',
+    'fanfare',
+    'wrongHorn',
+    'reveal',
+    'incoming',
+    'horn',
+  ])
+  // `private` is erased at runtime, so the helpers have to be named. Keeping
+  // the list here rather than making the filter cleverer is deliberate: a new
+  // helper fails this test until somebody looks at it, which is one sentence of
+  // work, and a clever filter that silently swallowed a new CUE is the failure
+  // this whole test exists to prevent.
+  const internal = new Set(['constructor', 'resume', 'dispose', 'ok', 'env', 'toOut', 'noise', 'gesture', 'voice', 't'])
+  const names = Object.getOwnPropertyNames(Audio.prototype).filter(
+    (n) => !internal.has(n) && typeof (Audio.prototype as unknown as Record<string, unknown>)[n] === 'function',
+  )
+  for (const n of names) {
+    assert.ok(covered.has(n), `\`${n}\` is a cue that nothing in this file plays or measures`)
+  }
+  for (const n of covered) {
+    assert.ok(names.includes(n), `\`${n}\` is measured here but no longer exists`)
+  }
+})
+
+test('the fixture resets between cases', () => {
+  assert.ok(live === null || live instanceof Recorder)
+})

--- a/dynawalla/games/trebuchet/src/audio/audio.ts
+++ b/dynawalla/games/trebuchet/src/audio/audio.ts
@@ -5,13 +5,82 @@
  * where it happened), BODY (the pitched thump that gives it mass) and TAIL (the
  * valley answering back). Pitch and timing jitter on every call so a hundred shots
  * do not fatigue. Sound is a garnish: mute loses nothing but pleasure.
+ *
+ * ── The 2026-08 pass: lower, warmer, and not a noise burst ───────────────────
+ *
+ * The founder: *"can we upgrade the sound effects to premium just a little bit ..
+ * the building destroyed is a bit white noise instead of a nice building crumbling
+ * sound ... maybe a whole pass on making the sound effects more premium (and
+ * chillaxed in most cases) .. they tend to be a bit abrasive .. maybe lower
+ * pitched in a lot of cases."*
+ *
+ * Three things came out of that, and the first is the one that matters:
+ *
+ *  1. **A keep coming down is masonry, not hiss.** `collapse()` was seven
+ *     band-passed noise bursts under a sine. A noise burst is ONE event with no
+ *     size to it, which is exactly why it reads as static. It is now the shared
+ *     `rubble` recipe — sixteen graded impacts whose sizes follow a power law, a
+ *     few big low ones and a lot of small high ones, staggered, all under 1.4 kHz.
+ *     See `packs/shared/game-audio/voices.ts`.
+ *  2. **Nothing in this game is bright any more.** Every cue that lived in the
+ *     2–5 kHz band the ear is most sensitive in — the winch tick at up to 2.4 kHz,
+ *     the stone crack at up to 3.6 kHz, the rope whoosh at up to 4 kHz, the
+ *     incoming whistle at 1.5 kHz — has come down, and `BRIGHTEST_HZ` is the line
+ *     they are all held under. `audio.test.ts` measures it rather than trusting it.
+ *  3. **The soundscape, where it fits.** `packs/shared/game-soundscape` publishes
+ *     the key the whole app is in, and a game emits GESTURES and may never name a
+ *     pitch. So the four cues in this game that are music rather than physics —
+ *     the reward, the sour horn, the wave horn and the collapse — ask the walker
+ *     what they sound like, and a run of hits arcs and cadences instead of playing
+ *     the same fanfare a semitone up forever.
+ *
+ *     What is deliberately NOT routed through it: the winch tick. The dial repeats
+ *     at up to 26 notches a second on a held button, and a melodic bell per notch
+ *     is a swarm, not a phrase. It stays a click, and the click got quieter and
+ *     three octaves lower.
+ *
+ *     When no host publishes a soundscape — an older host, a dev harness, a parent
+ *     who has turned the app's Music switch off — `currentSoundscape()` is `null`,
+ *     the walker does not exist, and every cue below falls back to a fixed low
+ *     pitch. "Keep your own sounds", never "go quiet". The collapse is rubble
+ *     either way: that is the founder's actual complaint and it is not conditional
+ *     on a host feature.
  */
 
-import { createSafetyBus, safeAttack } from "../../../../packs/shared/game-audio/index.ts"
+import {
+  createSafetyBus,
+  playVoice,
+  safeAttack,
+  type PlayableVoice,
+} from "../../../../packs/shared/game-audio/index.ts"
+import {
+  Melody,
+  currentSoundscape,
+  onSoundscape,
+  type Gesture,
+} from "../../../../packs/shared/game-soundscape/index.ts"
 
 type Ctx = AudioContext
 
 const rand = (a: number, b: number): number => a + Math.random() * (b - a)
+
+/**
+ * The brightest anything in this game is allowed to be, in Hz.
+ *
+ * Under the 2–5 kHz band the ear is most sensitive in, which is the band
+ * "abrasive" means. Every filter and every oscillator in this file is held
+ * under it, and `audio.test.ts` walks the real graph to prove it rather than
+ * taking the comment's word for it.
+ */
+export const BRIGHTEST_HZ = 2000
+
+/**
+ * Where the fallback cues sit when no soundscape is published.
+ *
+ * The bottom of `game-soundscape`'s own root band, so a host that publishes one
+ * and a host that does not are in the same register rather than a fifth apart.
+ */
+const FALLBACK_ROOT_HZ = 116.5
 
 export class Audio {
   private ctx: Ctx | null = null
@@ -24,6 +93,26 @@ export class Audio {
   private flightFilt: BiquadFilterNode | null = null
   enabled = true
 
+  /**
+   * The app's key, or `null` when nobody has published one.
+   *
+   * Followed rather than read once: the host re-publishes on every settings
+   * change, so a game that only looked at construction would be in last hour's
+   * key — or, worse, would keep a walker alive after a parent turned Music off.
+   */
+  private melody: Melody | null = null
+  private readonly unfollow: () => void
+
+  constructor() {
+    const scape = currentSoundscape()
+    this.melody = scape ? new Melody(scape) : null
+    this.unfollow = onSoundscape((next) => {
+      if (!next) this.melody = null
+      else if (this.melody) this.melody.retune(next)
+      else this.melody = new Melody(next)
+    })
+  }
+
   /** Must be called from a user gesture. Safe to call repeatedly. */
   resume(): void {
     if (!this.ctx) {
@@ -33,7 +122,10 @@ export class Audio {
       this.ctx = new AC()
       const c = this.ctx
       this.master = c.createGain()
-      this.master.gain.value = 0.62
+      // Down from 0.62. Everything under it also came down, so this is not a
+      // volume knob compensating for cues that are still shouting — it is the
+      // last 1.5 dB of a pass that took the level out of each cue first.
+      this.master.gain.value = 0.52
       const comp = c.createDynamicsCompressor()
       comp.threshold.value = -14
       comp.knee.value = 22
@@ -60,7 +152,7 @@ export class Audio {
       this.verb = c.createConvolver()
       this.verb.buffer = ir
       this.send = c.createGain()
-      this.send.gain.value = 0.34
+      this.send.gain.value = 0.3
       this.send.connect(this.verb)
       this.verb.connect(this.master)
 
@@ -111,7 +203,38 @@ export class Audio {
     }
   }
 
-  /** Winch ratchet — one click per notch, pitch climbing with the dial. */
+  /* ------------------------------------------------------------- the music */
+
+  /**
+   * Say what happened, and let the walker decide what it sounds like.
+   *
+   * @returns false when there is no soundscape and the caller must play its own
+   *          fallback. A `void` return here would be the shape of bug where a
+   *          cue silently stops making any sound at all on a host that publishes
+   *          nothing, which is most of them today.
+   */
+  private gesture(g: Gesture): boolean {
+    const m = this.melody
+    if (!m || !this.ctx || !this.master) return false
+    for (const v of m.emit(g)) this.voice(v)
+    return true
+  }
+
+  /** One voice, through the shared synthesiser, into this game's own master. */
+  private voice(v: PlayableVoice): void {
+    if (!this.ctx || !this.master) return
+    playVoice(this.ctx, this.master, v)
+  }
+
+  /* ------------------------------------------------------------- the cues */
+
+  /**
+   * Winch ratchet — one click per notch, pitch climbing with the dial.
+   *
+   * Was a band-pass sweeping 900–2400 Hz at 0.16, which is a needle straight
+   * into the sensitive band, sixty times over on a held button. Now 240–700 Hz
+   * and half the level: a wooden ratchet rather than a Geiger counter.
+   */
   tick(power01: number): void {
     if (!this.ok()) return
     const c = this.ctx!
@@ -119,29 +242,29 @@ export class Audio {
     if (!src) return
     const bp = c.createBiquadFilter()
     bp.type = 'bandpass'
-    bp.frequency.value = 900 + power01 * 1500 * rand(0.96, 1.04)
-    bp.Q.value = 6
+    bp.frequency.value = (240 + power01 * 460) * rand(0.96, 1.04)
+    bp.Q.value = 5
     const g = c.createGain()
-    this.env(g, 0.16, 0.002, 0.04)
+    this.env(g, 0.075, 0.004, 0.045)
     src.connect(bp)
     bp.connect(g)
     this.toOut(g, 0.05)
   }
 
-  /** The loft lever — a woodier, lower detent. */
+  /** Loading a different boulder — a woodier, lower detent. */
   detent(): void {
     if (!this.ok()) return
     const c = this.ctx!
     const o = c.createOscillator()
     o.type = 'triangle'
-    o.frequency.setValueAtTime(rand(300, 330), this.t)
-    o.frequency.exponentialRampToValueAtTime(150, this.t + 0.06)
+    o.frequency.setValueAtTime(rand(190, 210), this.t)
+    o.frequency.exponentialRampToValueAtTime(96, this.t + 0.07)
     const g = c.createGain()
-    this.env(g, 0.12, 0.003, 0.07)
+    this.env(g, 0.1, 0.004, 0.08)
     o.connect(g)
     this.toOut(g, 0.1)
     o.start(this.t)
-    o.stop(this.t + 0.14)
+    o.stop(this.t + 0.16)
   }
 
   /** Counterweight drops, rope sings, arm whips. */
@@ -152,41 +275,48 @@ export class Audio {
     // body: the counterweight
     const o = c.createOscillator()
     o.type = 'sine'
-    o.frequency.setValueAtTime(rand(150, 168), t0)
-    o.frequency.exponentialRampToValueAtTime(46, t0 + 0.3)
+    o.frequency.setValueAtTime(rand(128, 142), t0)
+    o.frequency.exponentialRampToValueAtTime(42, t0 + 0.34)
     const og = c.createGain()
-    this.env(og, 0.55, 0.006, 0.34, t0)
+    this.env(og, 0.46, 0.008, 0.36, t0)
     o.connect(og)
     this.toOut(og, 0.22)
     o.start(t0)
-    o.stop(t0 + 0.5)
-    // transient + rope whoosh
+    o.stop(t0 + 0.54)
+    // transient + rope whoosh. The sweep used to end as high as 4 kHz; a rope
+    // is a low sound and the top of it was all that was audible on a tablet.
     const src = this.noise(0.42)
     if (src) {
       const bp = c.createBiquadFilter()
       bp.type = 'bandpass'
-      bp.Q.value = 1.4
-      bp.frequency.setValueAtTime(420, t0)
-      bp.frequency.exponentialRampToValueAtTime(2600 + power01 * 1400, t0 + 0.26)
+      bp.Q.value = 1.2
+      bp.frequency.setValueAtTime(300, t0)
+      bp.frequency.exponentialRampToValueAtTime(900 + power01 * 500, t0 + 0.28)
       const g = c.createGain()
-      this.env(g, 0.3, 0.02, 0.3, t0)
+      this.env(g, 0.2, 0.026, 0.32, t0)
       src.connect(bp)
       bp.connect(g)
       this.toOut(g, 0.3)
     }
   }
 
-  /** Continuous flight whistle. Pitch tracks speed; volume tracks height. */
+  /**
+   * Continuous flight whistle. Pitch tracks speed; volume tracks height.
+   *
+   * The one cue that is unavoidably a tone held for seconds, so it is the one
+   * that most needed lowering: 300–1200 Hz became 170–620, and the low-pass
+   * above it came down with it.
+   */
   flightStart(): void {
     if (!this.ok()) return
     const c = this.ctx!
     this.flightStop()
     const o = c.createOscillator()
     o.type = 'sine'
-    o.frequency.value = 520
+    o.frequency.value = 300
     const f = c.createBiquadFilter()
     f.type = 'lowpass'
-    f.frequency.value = 2200
+    f.frequency.value = 1200
     const g = c.createGain()
     g.gain.value = 0.0001
     o.connect(f)
@@ -201,9 +331,9 @@ export class Audio {
   flightUpdate(speed01: number, height01: number): void {
     if (!this.flightOsc || !this.flightGain || !this.ctx) return
     const t = this.t
-    this.flightOsc.frequency.setTargetAtTime(300 + speed01 * 900, t, 0.05)
-    this.flightGain.gain.setTargetAtTime(0.03 + height01 * 0.075, t, 0.08)
-    this.flightFilt?.frequency.setTargetAtTime(900 + speed01 * 2600, t, 0.08)
+    this.flightOsc.frequency.setTargetAtTime(170 + speed01 * 450, t, 0.05)
+    this.flightGain.gain.setTargetAtTime(0.022 + height01 * 0.05, t, 0.08)
+    this.flightFilt?.frequency.setTargetAtTime(600 + speed01 * 1200, t, 0.08)
   }
 
   flightStop(): void {
@@ -229,29 +359,38 @@ export class Audio {
     const t0 = this.t
     const o = c.createOscillator()
     o.type = 'sine'
-    o.frequency.setValueAtTime(rand(96, 116), t0)
-    o.frequency.exponentialRampToValueAtTime(34, t0 + 0.22)
+    o.frequency.setValueAtTime(rand(82, 98), t0)
+    o.frequency.exponentialRampToValueAtTime(31, t0 + 0.24)
     const og = c.createGain()
-    this.env(og, 0.35 + mass * 0.4, 0.004, 0.3, t0)
+    this.env(og, 0.3 + mass * 0.34, 0.005, 0.32, t0)
     o.connect(og)
     this.toOut(og, 0.3)
     o.start(t0)
-    o.stop(t0 + 0.5)
+    o.stop(t0 + 0.54)
     const src = this.noise(0.3)
     if (src) {
       const lp = c.createBiquadFilter()
       lp.type = 'lowpass'
-      lp.frequency.setValueAtTime(2400, t0)
-      lp.frequency.exponentialRampToValueAtTime(320, t0 + 0.24)
+      // Opened at 2.4 kHz before, i.e. straight into the sensitive band for the
+      // first 40 ms of every single shot.
+      lp.frequency.setValueAtTime(1100, t0)
+      lp.frequency.exponentialRampToValueAtTime(260, t0 + 0.26)
       const g = c.createGain()
-      this.env(g, 0.28 + mass * 0.2, 0.003, 0.26, t0)
+      this.env(g, 0.22 + mass * 0.16, 0.004, 0.28, t0)
       src.connect(lp)
       lp.connect(g)
       this.toOut(g, 0.4)
     }
   }
 
-  /** Stone impact: a crack on top of the dirt. */
+  /**
+   * Stone impact: a crack on top of the dirt.
+   *
+   * The cracks used to be band-passed anywhere in 1400–3600 Hz — three of them,
+   * on every shot that touched masonry. That is the single most abrasive thing
+   * this game made. They are now 520–1500 Hz and a third quieter: a stone
+   * knocking against stone rather than a plate smashing.
+   */
   impactStone(mass: number): void {
     if (!this.ok()) return
     this.impactDirt(mass)
@@ -262,90 +401,114 @@ export class Audio {
       if (!src) continue
       const bp = c.createBiquadFilter()
       bp.type = 'bandpass'
-      bp.Q.value = 2.2
-      bp.frequency.value = rand(1400, 3600)
+      bp.Q.value = 1.8
+      bp.frequency.value = rand(520, 1500)
       const g = c.createGain()
-      this.env(g, 0.2, 0.001, 0.1, t0 + i * rand(0.005, 0.03))
+      this.env(g, 0.13, 0.003, 0.12, t0 + i * rand(0.006, 0.034))
       src.connect(bp)
       bp.connect(g)
       this.toOut(g, 0.35)
     }
   }
 
-  /** A tower coming apart — staggered crunches over ~700 ms. */
+  /**
+   * A KEEP COMING DOWN. The founder's example, and the one cue this whole pass
+   * exists for.
+   *
+   * It was seven lowpassed noise bursts and a sine — "a bit white noise". It is
+   * now the shared `rubble` recipe: many small impacts whose sizes follow a
+   * power law, low-centred, staggered, so the ear hears masonry with a size to
+   * it rather than a hiss with an envelope on it.
+   *
+   * The soundscape picks the two degrees it lands on, so the fall is in tune
+   * with whatever else is playing; with no soundscape it falls on a fixed low
+   * root instead. **It is rubble either way** — that is the defect, and it is
+   * not conditional on the host publishing anything.
+   */
   collapse(): void {
     if (!this.ok()) return
+    if (this.gesture({ kind: 'collapse', weight: 1 })) return
+    this.voice({ hz: FALLBACK_ROOT_HZ / 2, at: 0, seconds: 1.2, gain: 0.13, timbre: 'rubble' })
+    this.voice({ hz: FALLBACK_ROOT_HZ, at: 0.22, seconds: 0.85, gain: 0.075, timbre: 'rubble' })
+    // The sub under it: the ground taking the weight. Kept from the old cue,
+    // because it is the half of it that was never the problem.
     const c = this.ctx!
     const t0 = this.t
-    for (let i = 0; i < 7; i++) {
-      const at = t0 + i * rand(0.04, 0.12)
-      const src = this.noise(0.3)
-      if (!src) continue
-      const lp = c.createBiquadFilter()
-      lp.type = 'lowpass'
-      lp.frequency.value = rand(500, 1800)
-      const g = c.createGain()
-      this.env(g, rand(0.1, 0.26), 0.004, rand(0.12, 0.34), at)
-      src.connect(lp)
-      lp.connect(g)
-      this.toOut(g, 0.45)
-    }
     const o = c.createOscillator()
     o.type = 'sine'
-    o.frequency.setValueAtTime(60, t0)
-    o.frequency.exponentialRampToValueAtTime(26, t0 + 0.9)
+    o.frequency.setValueAtTime(54, t0)
+    o.frequency.exponentialRampToValueAtTime(24, t0 + 0.9)
     const og = c.createGain()
-    this.env(og, 0.5, 0.02, 0.9, t0)
+    this.env(og, 0.4, 0.03, 0.95, t0)
     o.connect(og)
     this.toOut(og, 0.2)
     o.start(t0)
     o.stop(t0 + 1.1)
   }
 
-  /** The reward. Rises a step per chain link, then rolls over — never a slot machine. */
+  /** The reward. A phrase that arrives, and a different one every time. */
   fanfare(chain: number): void {
     if (!this.ok()) return
+    if (this.gesture({ kind: 'success' })) return
+    // No soundscape: the old pentatonic run, a fourth lower and quieter.
     const c = this.ctx!
     const pent = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21]
-    const base = 392 * Math.pow(2, Math.min(chain, 8) / 12)
+    const base = 294 * Math.pow(2, Math.min(chain, 8) / 12)
     const t0 = this.t
     for (let i = 0; i < 5; i++) {
       const o = c.createOscillator()
       o.type = i % 2 === 0 ? 'triangle' : 'sine'
       o.frequency.value = base * Math.pow(2, pent[i] / 12) * rand(0.997, 1.003)
       const g = c.createGain()
-      this.env(g, 0.14, 0.006, 0.34, t0 + i * 0.055)
+      this.env(g, 0.11, 0.008, 0.36, t0 + i * 0.06)
       o.connect(g)
       this.toOut(g, 0.5)
-      o.start(t0 + i * 0.055)
-      o.stop(t0 + i * 0.055 + 0.5)
+      o.start(t0 + i * 0.06)
+      o.stop(t0 + i * 0.06 + 0.52)
     }
   }
 
-  /** Struck the wrong keep: a horn, sour but not a buzzer. Never a punishment noise. */
+  /** Struck the wrong keep: sour but never a buzzer, and never a punishment. */
   wrongHorn(): void {
     if (!this.ok()) return
+    if (this.gesture({ kind: 'failure' })) return
     const c = this.ctx!
     const t0 = this.t
     for (const [f, det] of [
-      [174, 1],
-      [184, 1.004],
+      [146, 1],
+      [155, 1.004],
     ] as Array<[number, number]>) {
       const o = c.createOscillator()
-      o.type = 'sawtooth'
+      // Triangle, not sawtooth. A saw through a low-pass is still a saw at the
+      // onset, and the onset is the part that reads as a telling-off.
+      o.type = 'triangle'
       o.frequency.value = f * det
       const lp = c.createBiquadFilter()
       lp.type = 'lowpass'
-      lp.frequency.setValueAtTime(1400, t0)
-      lp.frequency.exponentialRampToValueAtTime(340, t0 + 0.7)
+      lp.frequency.setValueAtTime(800, t0)
+      lp.frequency.exponentialRampToValueAtTime(280, t0 + 0.7)
       const g = c.createGain()
-      this.env(g, 0.16, 0.05, 0.6, t0)
+      this.env(g, 0.12, 0.07, 0.62, t0)
       o.connect(lp)
       lp.connect(g)
       this.toOut(g, 0.4)
       o.start(t0)
-      o.stop(t0 + 0.9)
+      o.stop(t0 + 0.92)
     }
+  }
+
+  /**
+   * The completed sum has gone up on the glass after a miss.
+   *
+   * Deliberately NOT a failure sting — the horn already answered the shot, and
+   * the reveal is the calm part that follows it. One low breath, so a child who
+   * has just been shown the answer hears the game settle rather than scold.
+   */
+  reveal(): void {
+    if (!this.ok()) return
+    if (this.gesture({ kind: 'arrive' })) return
+    this.voice({ hz: FALLBACK_ROOT_HZ, at: 0, seconds: 0.9, gain: 0.055, timbre: 'bloom' })
+    this.voice({ hz: FALLBACK_ROOT_HZ * 1.5, at: 0.05, seconds: 0.8, gain: 0.04, timbre: 'bloom' })
   }
 
   /** Incoming counter-fire. Doppler down, then a hit on your platform. */
@@ -355,11 +518,13 @@ export class Audio {
     const t0 = this.t
     const o = c.createOscillator()
     o.type = 'sine'
-    o.frequency.setValueAtTime(1500, t0)
-    o.frequency.exponentialRampToValueAtTime(260, t0 + delay)
+    // Opened at 1500 Hz. A shell coming in is a falling sound; it does not need
+    // to start inside the band that hurts to read as one.
+    o.frequency.setValueAtTime(760, t0)
+    o.frequency.exponentialRampToValueAtTime(190, t0 + delay)
     const g = c.createGain()
     g.gain.setValueAtTime(0.0001, t0)
-    g.gain.exponentialRampToValueAtTime(0.1, t0 + delay * 0.7)
+    g.gain.exponentialRampToValueAtTime(0.075, t0 + delay * 0.7)
     g.gain.exponentialRampToValueAtTime(0.0001, t0 + delay)
     o.connect(g)
     this.toOut(g, 0.3)
@@ -367,21 +532,32 @@ export class Audio {
     o.stop(t0 + delay + 0.1)
   }
 
-  /** Wave horn — low, ceremonial, once per wave. */
-  horn(up: boolean): void {
+  /**
+   * Wave horn — low, ceremonial, once per wave.
+   *
+   * `up` is the pitch bend, and it means "this went well": a wave opening, or a
+   * wave cleared without a miss. `ending` is which end of the wave it is, and
+   * the two are genuinely independent — a wave that opens is not a level
+   * completed, and reading `up` as one would fire a flourish every time a wave
+   * laid itself out.
+   */
+  horn(up: boolean, ending = false): void {
     if (!this.ok()) return
+    // A wave is a thing that arrives; a cleared wave is the one gesture the
+    // walker is allowed to be big about.
+    if (this.gesture(ending ? { kind: 'levelComplete' } : { kind: 'arrive' })) return
     const c = this.ctx!
     const t0 = this.t
     for (const mult of [1, 1.5, 2.02]) {
       const o = c.createOscillator()
-      o.type = 'sawtooth'
-      o.frequency.setValueAtTime(110 * mult, t0)
-      o.frequency.linearRampToValueAtTime(110 * mult * (up ? 1.06 : 0.94), t0 + 0.8)
+      o.type = 'triangle'
+      o.frequency.setValueAtTime(98 * mult, t0)
+      o.frequency.linearRampToValueAtTime(98 * mult * (up ? 1.06 : 0.94), t0 + 0.8)
       const lp = c.createBiquadFilter()
       lp.type = 'lowpass'
-      lp.frequency.value = 900
+      lp.frequency.value = 700
       const g = c.createGain()
-      this.env(g, 0.1, 0.14, 0.8, t0)
+      this.env(g, 0.085, 0.16, 0.82, t0)
       o.connect(lp)
       lp.connect(g)
       this.toOut(g, 0.6)
@@ -391,6 +567,8 @@ export class Audio {
   }
 
   dispose(): void {
+    this.unfollow()
+    this.melody = null
     this.flightStop()
     if (this.ctx) void this.ctx.close()
     this.ctx = null

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -28,6 +28,8 @@ import { Rings } from './fx/rings.ts'
 import { Trail } from './fx/trail.ts'
 import { Backdrop } from './render/backdrop.ts'
 import { safeRect } from '../../../packs/shared/game-chrome/index.ts'
+import { revealPlan, SECOND_GRADE_FLOW } from '../../../packs/shared/game-pacing/index.ts'
+import { completedSum } from './reveal.ts'
 import {
   dialNumeralBox,
   drawHud,
@@ -265,7 +267,32 @@ export class TrebuchetGame {
   private scorePop = 0
   private hitsThisWave = 0
   private platformDamage = 0
-  private revealT = 0
+
+  /* --------------------------------------------------------------- reveal */
+
+  /**
+   * THE COMPLETED SUM, held on the glass after a miss.
+   *
+   * `null` is the ordinary state. Non-null means the child is being shown what
+   * the answer was, and **the game has stopped** — see `stopped`.
+   *
+   * What was here before, and why it was nothing at all: `revealT = 1.6`, a
+   * countdown that lit `t.reveal` on the keeps still WANTED — never on the one
+   * she had just missed, because `markWanted()` runs after the boulder is
+   * spent — and drew their number on a banner. On waves 1 to 7 `waveConfig`
+   * already sets `banners: true`, so every one of those numbers was on the
+   * screen the whole time and the reveal drew the same banner in the same
+   * place: a visual no-op for a child's entire first session. Meanwhile the ram
+   * kept rolling, the settle clock kept running and the wave moved on
+   * underneath her at 1.6 seconds whether or not she had read anything.
+   *
+   * `settle` is a lockout in seconds and NOT a lifetime: the tap that ended the
+   * question is routinely still arriving on a touch screen, and without a floor
+   * it lands inside the reveal's own fade-in. Nothing else times this out.
+   * `revealPlan` says `holdMs: Infinity` for a reveal that is shown, and the
+   * one mechanism honouring that is the absence of any expiry in this file.
+   */
+  private reveal: { sum: string; answer: number; settle: number; age: number } | null = null
 
   // hud
   private btns: Btn[] = []
@@ -446,6 +473,11 @@ export class TrebuchetGame {
     // backdrop to the new wave's empty plaque.
     this.rack = []
     this.activeIdx = 0
+    // A reveal belongs to a question that is over. Nothing should be able to
+    // start a wave underneath one — the phase machine cannot while it is up —
+    // but the harness's `jumpToWave` can, and a sum left hanging over a fresh
+    // field would freeze the new wave forever.
+    this.reveal = null
     this.towers = []
     this.craters = []
     this.ghosts = []
@@ -692,6 +724,9 @@ export class TrebuchetGame {
   private onPointerDown = (e: PointerEvent): void => {
     if (this.blocked()) return
     this.audio.resume()
+    // Her hand ends the reveal, and nothing else does. It is spent on that and
+    // does not also wind the dial to the metre it landed on.
+    if (this.dismissReveal()) return
     const p = this.pointerPos(e)
     const b = hitBtn(this.btns, p.x, p.y)
     if (b) {
@@ -737,11 +772,22 @@ export class TrebuchetGame {
   private onWheel = (e: WheelEvent): void => {
     e.preventDefault()
     if (this.blocked()) return
+    // A wheel is not a hand on the glass — a trackpad emits dozens of these from
+    // one flick — so it does not dismiss. It simply does nothing while the sum
+    // is up, rather than winding a dial nobody can see.
+    if (this.stopped) return
     this.setDial(this.dial + (e.deltaY > 0 ? -1 : 1))
   }
 
   private key(e: KeyboardEvent, down: boolean): void {
     if (!down || this.blocked()) return
+    // Any key takes the sum down and is spent doing it. One rule for the hand,
+    // whichever hand it is: the space bar must not both dismiss the reveal and
+    // fire the next boulder in the same press.
+    if (this.dismissReveal()) {
+      e.preventDefault()
+      return
+    }
     const big = e.shiftKey ? 10 : 1
     switch (e.key) {
       case 'ArrowLeft':
@@ -817,6 +863,8 @@ export class TrebuchetGame {
     return {
       layout: this.hud,
       equation: b ? b.q.prompt : '',
+      reveal: this.reveal?.sum ?? null,
+      revealAge: this.reveal?.age ?? 0,
       rack: live.map((x) => x.r.q.prompt),
       rackActive: live.findIndex((x) => x.i === this.activeIdx),
       wave: this.wave,
@@ -1109,12 +1157,79 @@ export class TrebuchetGame {
       // Only a wrong ANSWER breaks the chain. Spending a boulder on the ram is a
       // choice about the siege, and the game does not punish it as arithmetic.
       this.combo = 0
-      this.revealT = 1.6
+      this.raiseReveal(b)
     }
     // The boulder is gone either way: it was thrown.
     b.spent = true
     void destroyed
     this.markWanted()
+  }
+
+  /* --------------------------------------------------------------- reveal */
+
+  /**
+   * Finish the sum in front of her, and stop the siege while she reads it.
+   *
+   * **Adaptation lives in whether this happens at all, not in how long it
+   * lasts.** `revealPlan` returns `holdMs: 0` above intensity ≈0.75 and
+   * `Infinity` below it, so a child the ladder has taken to the top of the
+   * range is moved straight on — skipping the ceremony is the reward for
+   * mastery — and everybody else gets a sum that waits for them. There is no
+   * middle setting, because the half-patient reveal was long enough to be
+   * noticed and too short to be read.
+   *
+   * The intensity is the ITEM's own difficulty, which is the host's live
+   * judgement of where this child is standing. A wave number would not be: it
+   * arrives on her twelfth minute whether she has been landing every boulder or
+   * none of them, which is the same argument `WIND_FROM_D` makes.
+   *
+   * Nothing is drawn about being wrong. The finished equation, in the accent,
+   * and the keep she was aiming at lighting up out on the field — no red, no
+   * cross, no word.
+   */
+  private raiseReveal(b: Boulder): void {
+    const plan = revealPlan(SECOND_GRADE_FLOW, b.q.difficulty)
+    if (plan.holdMs <= 0) return
+    this.reveal = {
+      sum: completedSum(b.q.prompt, b.q.answer),
+      answer: b.answer,
+      settle: plan.settleMs / 1000,
+      age: 0,
+    }
+    this.audio.reveal()
+  }
+
+  /**
+   * A hand on the glass while the sum is up. Takes it down, and nothing else.
+   *
+   * @returns true when the gesture was spent on the reveal, so the caller must
+   *          not also act on it — a tap that dismissed the sum must not, in the
+   *          same breath, wind the dial to the metre under the finger.
+   */
+  private dismissReveal(): boolean {
+    const r = this.reveal
+    if (!r) return false
+    // Latency, not pedagogy. A short lockout only makes sure the hand meant it.
+    if (r.settle > 0) return true
+    this.reveal = null
+    this.audio.detent()
+    return true
+  }
+
+  /**
+   * Is the world stopped?
+   *
+   * **One condition, used everywhere, and that is deliberate.** The rule "a
+   * child who is reading must never be losing" was previously enforced nowhere;
+   * the tempting fix is to enforce it twice — a flag AND a phase — and the cost
+   * of that is that deleting either leaves the suite green. Everything that
+   * could move the game on reads this and only this.
+   *
+   * (Not to be confused with `this.held`, which is the +/− button somebody is
+   * leaning on.)
+   */
+  private get stopped(): boolean {
+    return this.reveal !== null
   }
 
   /** The struck keep's number blows apart into shards. */
@@ -1232,13 +1347,17 @@ export class TrebuchetGame {
       this.explainPending = false
       this.explain()
     }
-    this.phaseT += rawDt
+    // The reveal's own two clocks: how long it has been up, which the entrance
+    // animation rides, and the input lockout counting down. Neither ends it.
+    if (this.reveal) {
+      this.reveal.age += rawDt
+      this.reveal.settle = Math.max(0, this.reveal.settle - rawDt)
+    }
     this.dialPop = Math.min(1, this.dialPop + rawDt / 0.16)
     this.scorePop = Math.min(1, this.scorePop + rawDt / 0.5)
     this.aimEmphasis = approach(this.aimEmphasis, this.phase === 'aim' || this.phase === 'intro' ? 1 : 0, 4, rawDt)
     this.introT = Math.min(1, this.introT + rawDt / 0.5)
     this.recoil = approach(this.recoil, 0, 6, rawDt)
-    this.revealT = Math.max(0, this.revealT - rawDt)
     this.flash.update(rawDt)
     this.backdrop.update(rawDt)
     this.parts.update(dt, 0)
@@ -1249,10 +1368,36 @@ export class TrebuchetGame {
     for (const g of this.ghosts) g.age += rawDt
     for (const t of this.towers) {
       t.flash = Math.max(0, t.flash - rawDt * 3)
-      if (t.wanted && this.revealT > 0) t.reveal = Math.min(1, t.reveal + rawDt * 4)
+      // The keep she was AIMING AT — not whichever keeps happen to still be
+      // wanted, which is what this used to light and is why it could never be
+      // the thing she had just missed: `markWanted()` runs after her boulder is
+      // spent, so its own keep is the one keep guaranteed to be excluded.
+      if (this.reveal && t.value === this.reveal.answer) t.reveal = Math.min(1, t.reveal + rawDt * 4)
       else t.reveal = Math.max(0, t.reveal - rawDt * 3)
       stepBlocks(t, dt)
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // THE HELD SUM — and this line is the whole of it.
+    //
+    // Everything above is cosmetic: dust still falling, the camera easing back,
+    // the reveal's own two clocks. Everything below MOVES THE GAME ON — the
+    // phase clock, the dial repeat, the phase machine, the counter-fire and the
+    // ram — and none of it runs while a child is reading. A child who is
+    // reading must never be losing.
+    //
+    // **One gate, not two.** The first draft of this also guarded `phaseT`
+    // separately, and the two of them independently froze the phase machine: a
+    // mutation deleting this entire block left all 163 tests green, because the
+    // other half was still holding. That is the exact defect #748 records — two
+    // mechanisms enforcing one rule are both untestable — and it survived here
+    // for about an hour. `phaseT` now advances below this line and nowhere else.
+    // ─────────────────────────────────────────────────────────────────────────
+    if (this.stopped) {
+      this.updateCamera(rawDt)
+      return
+    }
+    this.phaseT += rawDt
 
     // Held +/- repeat. The accumulator matters: the dial is an integer, so adding
     // a fraction of a metre per frame and rounding would move nothing at all.
@@ -1387,7 +1532,7 @@ export class TrebuchetGame {
             this.phase = 'clear'
             this.phaseT = 0
             this.clearT = 0
-            this.audio.horn(this.hitsThisWave === this.rack.length)
+            this.audio.horn(this.hitsThisWave === this.rack.length, true)
           } else {
             this.activeIdx = nextIdx
             this.phase = 'aim'
@@ -1550,7 +1695,10 @@ export class TrebuchetGame {
 
     if (this.wall) drawWall(ctx, s, this.wall.x, this.wall.h)
     for (const t of this.towers) {
-      drawTower(ctx, s, t, this.cfg.banners, t.wanted && this.revealT > 0, this.time)
+      // `t.reveal > 0`, not the condition that SET it. Recomputing "is this the
+      // keep she wanted" here would be a second mechanism for one rule, and the
+      // renderer's copy could drift from the update loop's with nothing failing.
+      drawTower(ctx, s, t, this.cfg.banners, t.reveal > 0, this.time)
     }
     if (this.ram?.alive) drawRam(ctx, s, this.ram, this.time)
     drawCraterLabels(ctx, s, this.craters)
@@ -1769,5 +1917,32 @@ export class TrebuchetGame {
   /** The difficulty the game last found it could place answers from. */
   stockedDifficulty(): number | null {
     return this.stockD
+  }
+
+  /**
+   * The completed sum being held on the glass, or `null`.
+   *
+   * Read off the real `hudState()` rather than off the field, so a test
+   * asserting the reveal exists is asserting about the string a child is
+   * looking at — the same argument `fireArmed()` makes about the fire button.
+   */
+  revealedSum(): string | null {
+    return this.hudState().reveal
+  }
+
+  /**
+   * The keeps currently lit by a reveal, by value.
+   *
+   * There must be exactly one and it must be the answer she missed. The old
+   * reveal lit the keeps still WANTED, which is the one set that can never
+   * contain it — `markWanted()` runs after her boulder is spent.
+   */
+  litKeeps(): number[] {
+    return this.towers.filter((t) => t.reveal > 0).map((t) => t.value)
+  }
+
+  /** How far the ram has rolled, or `null` when this wave has none. */
+  ramRangeM(): number | null {
+    return this.ram?.alive ? this.ram.range : null
   }
 }

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -43,6 +43,8 @@ export function mount(el: HTMLElement, host: Host): Mounted {
           'Say you dial 54 instead of 56. The boulder lands two metres short.',
           'It leaves a crater with 54 written in it, out where you can see it.',
           'So you do not just get told you were wrong. You get to see how far off you were.',
+          'Then the finished sum comes up at the top, and the keep you were aiming at lights up out on the field.',
+          'Nothing moves while it is there. It waits for you. Touch the screen or press a key when you have finished looking.',
         ],
       },
       {

--- a/dynawalla/games/trebuchet/src/main.ts
+++ b/dynawalla/games/trebuchet/src/main.ts
@@ -2,6 +2,22 @@
 
 import { mount } from './index.ts'
 import { createStubHost } from './stubHost.ts'
+import { pickSoundscape, setHostSoundscape } from '../../../packs/shared/game-soundscape/index.ts'
+
+// The soundscape, in the harness only.
+//
+// The real app publishes one, so inside it the collapse, the reward and the
+// horns sit in the key the whole bazaar is in. `npm run dev` has no host, and
+// with no soundscape the game plays its own fixed cues — which is a real path
+// worth being able to hear, so it is A/B-able rather than hard-wired:
+//
+//     ?soundscape=off      the game's own cues, no key
+//     ?seed=41             pin a mode and a root
+const params = new URLSearchParams(window.location.search)
+if (params.get('soundscape') !== 'off') {
+  const seed = Number(params.get('seed'))
+  setHostSoundscape(pickSoundscape(Number.isFinite(seed) && seed !== 0 ? seed : 1))
+}
 
 const el = document.getElementById('app')
 if (!el) throw new Error('#app missing')

--- a/dynawalla/games/trebuchet/src/patience.test.ts
+++ b/dynawalla/games/trebuchet/src/patience.test.ts
@@ -1,0 +1,496 @@
+/**
+ * THE REVEAL — the completed sum, and the fact that nothing moves under it.
+ *
+ * The fleet's reveal-patience audit found two things about this game and they
+ * are both here, driven through the real `TrebuchetGame` on the real clock:
+ *
+ *   1. **The reveal was a visual no-op on waves 1 to 8.** `waveConfig` sets
+ *      `banners: true` for those waves, so every keep already wore its number,
+ *      and the whole reveal was "draw that banner again" — behind a fill clause
+ *      (`reveal && !showBanner`) that could not even change its colour. A
+ *      child's entire first session had no correction in it at all.
+ *   2. **The ram advanced through `settle`.** The world kept moving while she
+ *      read, on a 1.6-second countdown she had no say in.
+ *
+ * Every test below drives the actual simulation and reads what a child would
+ * see. **Every loop in this file is bounded and the bound is asserted**, which
+ * is not decoration: a reveal that never expires makes an unbounded
+ * `while (!done)` immortal, and a test that hangs reports nothing at all.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { Host, Question } from './contract.ts'
+import { TrebuchetGame } from './game.ts'
+import { hudLayout } from './render/hud.ts'
+import { REVEAL_SETTLE_MS, revealPlan, SECOND_GRADE_FLOW } from '../../../packs/shared/game-pacing/index.ts'
+
+/* ---------------------------------------------------------------- the glass */
+
+type Listeners = Map<string, Array<(e: unknown) => void>>
+
+function stubCtx(): CanvasRenderingContext2D {
+  const gradient = { addColorStop: () => undefined }
+  const target: Record<string, unknown> = {}
+  return new Proxy(target, {
+    get: (t, prop: string) => {
+      if (prop in t) return t[prop]
+      if (prop === 'measureText') return () => ({ width: 8 })
+      if (prop === 'createLinearGradient' || prop === 'createRadialGradient') return () => gradient
+      if (prop === 'canvas') return undefined
+      return () => undefined
+    },
+    set: (t, prop: string, value) => {
+      t[prop] = value
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+}
+
+function stubElement(tag: string, w: number, h: number): Record<string, unknown> {
+  const listeners: Listeners = new Map()
+  return {
+    tagName: tag.toUpperCase(),
+    style: { cssText: '' },
+    width: w,
+    height: h,
+    __listeners: listeners,
+    setAttribute: () => undefined,
+    appendChild: () => undefined,
+    remove: () => undefined,
+    setPointerCapture: () => undefined,
+    releasePointerCapture: () => undefined,
+    getContext: () => stubCtx(),
+    getBoundingClientRect: () => ({ x: 0, y: 0, top: 0, left: 0, right: w, bottom: h, width: w, height: h }),
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      const list = listeners.get(type) ?? []
+      list.push(fn)
+      listeners.set(type, list)
+    },
+    removeEventListener: (type: string, fn: (e: unknown) => void) => {
+      listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
+    },
+  }
+}
+
+const VIEW = { w: 1024, h: 768 }
+
+function installDom(): { el: HTMLElement; canvas: Record<string, unknown>; keys: Listeners } {
+  const created: Array<Record<string, unknown>> = []
+  const keys: Listeners = new Map()
+  const g = globalThis as unknown as Record<string, unknown>
+  g.document = {
+    createElement: (tag: string) => {
+      const el = stubElement(tag, VIEW.w, VIEW.h)
+      created.push(el)
+      return el
+    },
+    getElementById: () => null,
+    body: { appendChild: () => undefined },
+  }
+  g.window = {
+    devicePixelRatio: 1,
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      const list = keys.get(type) ?? []
+      list.push(fn)
+      keys.set(type, list)
+    },
+    removeEventListener: () => undefined,
+  }
+  g.requestAnimationFrame = () => 1
+  g.cancelAnimationFrame = () => undefined
+  const el = stubElement('div', VIEW.w, VIEW.h) as unknown as HTMLElement
+  return {
+    el,
+    keys,
+    get canvas() {
+      return created.find((c) => c.tagName === 'CANVAS') as Record<string, unknown>
+    },
+  }
+}
+
+/* ----------------------------------------------------------------- driving */
+
+type Reported = { questionId: string; correct: boolean; ms: number; answered: string }
+
+function recordingHost(
+  answers: number[],
+  difficulty: number,
+): { host: Host; reports: Reported[]; served: () => number } {
+  const reports: Reported[] = []
+  let n = 0
+  const host: Host = {
+    next: (): Question => {
+      const a = answers[n % answers.length]
+      n++
+      return {
+        id: `q${n}`,
+        prompt: `${a - 10} + 10`,
+        answer: String(a),
+        distractors: [String(a + 11), String(a - 13)],
+        domain: 'add-sub',
+        difficulty,
+      }
+    },
+    report: (r) => reports.push(r),
+    haptic: () => undefined,
+    prefersReducedMotion: () => true,
+  }
+  return { host, reports, served: () => n }
+}
+
+/** The one bound this file trusts. Everything that waits, waits this long at most. */
+const MAX_FRAMES = 900
+
+/**
+ * Step until `done`, or give up.
+ *
+ * Bounded, and the bound is what every caller asserts on. An unbounded loop
+ * against a reveal that never expires is a test that hangs — the CI symptom of
+ * which is a job that reports nothing, which is indistinguishable from a pass
+ * until somebody looks at the clock.
+ */
+function runUntil(game: TrebuchetGame, done: () => boolean, maxFrames = MAX_FRAMES): boolean {
+  for (let i = 0; i < maxFrames; i++) {
+    game.stepFrames(1)
+    if (done()) return true
+  }
+  return false
+}
+
+function tapField(canvas: Record<string, unknown>): void {
+  const listeners = canvas.__listeners as Listeners
+  for (const fn of listeners.get('pointerdown') ?? []) {
+    fn({ clientX: VIEW.w * 0.5, clientY: VIEW.h * 0.62, pointerId: 1 })
+  }
+}
+
+function tapButton(canvas: Record<string, unknown>, id: string): void {
+  const layout = hudLayout(VIEW.w, VIEW.h, { x: 0, y: 0, w: VIEW.w, h: VIEW.h })
+  const btn = layout.buttons.find((b) => b.id === id)
+  assert.ok(btn, `no ${id} button in the HUD`)
+  const listeners = canvas.__listeners as Listeners
+  for (const fn of listeners.get('pointerdown') ?? []) {
+    fn({ clientX: btn.x + btn.w / 2, clientY: btn.y + btn.h / 2, pointerId: 1 })
+  }
+}
+
+function newGame(
+  answers: number[],
+  wave: number,
+  difficulty: number,
+): ReturnType<typeof installDom> & { game: TrebuchetGame; reports: Reported[]; served: () => number } {
+  const dom = installDom()
+  const { host, reports, served } = recordingHost(answers, difficulty)
+  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  game.manualDrive()
+  game.jumpToWave(wave)
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the wave never became playable')
+  assert.notEqual(game.currentAnswer(), -1, 'the wave became playable with an empty rack')
+  return { ...dom, game, reports, served }
+}
+
+/** Fire at a metre that is not the answer, and settle into whatever follows. */
+function miss(game: TrebuchetGame, canvas: Record<string, unknown>): void {
+  // Three metres past the answer: wrong, and inside `MIN_GAP` so it cannot
+  // accidentally be another keep's number.
+  game.aimAt(game.currentAnswer() - game.currentWind() + 3)
+  tapButton(canvas, 'fire')
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'impact' || game.currentPhase === 'settle'),
+    'the shot never landed',
+  )
+}
+
+/* ------------------------------------------------------------------- tests */
+
+test('a miss on WAVE ONE completes the sum in front of the child', () => {
+  // Precisely where there was no reveal at all. Wave 1 has `banners: true`, so
+  // the old reveal drew a banner that was already on the screen, in the same
+  // colour, in the same place — nothing changed and nothing was corrected.
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  assert.equal(game.revealedSum(), null, 'the sum is up before anything went wrong')
+
+  const answer = game.currentAnswer()
+  miss(game, canvas)
+  game.stepFrames(2)
+
+  const sum = game.revealedSum()
+  assert.ok(sum !== null, 'a miss on wave 1 showed the child nothing')
+  assert.ok(sum.includes(String(answer)), `the reveal "${sum}" does not contain the answer ${answer}`)
+  assert.ok(sum.includes('='), `the reveal "${sum}" is not a completed sum`)
+  // Never a telling-off. The HUD has no words in it and the reveal adds none.
+  assert.ok(!/wrong|WRONG|✗|✕|X/.test(sum), `the reveal says "${sum}"`)
+})
+
+test('nothing advances underneath the reveal — the ram included', () => {
+  // The audit's finding, in the wave where it bites: 7 is the first wave with a
+  // ram, and `ramAdvances` lets it roll through `settle` — which is exactly the
+  // beat a reveal occupies. A child reading the answer was losing ground for it.
+  const { game, canvas, reports, served } = newGame([56, 72, 88, 40], 7, 0.3)
+  const ram = game.ramRangeM()
+  assert.ok(ram !== null, 'wave 7 has no ram, so this test proves nothing')
+
+  miss(game, canvas)
+  game.stepFrames(2)
+  assert.ok(game.revealedSum() !== null, 'no reveal to hold anything still')
+
+  const phase = game.currentPhase
+  const ramAt = game.ramRangeM()
+  const reportsAt = reports.length
+  const servedAt = served()
+
+  // Ten seconds of real frames. Long enough that the settle beat (0.72 s), the
+  // wave-clear card (2.1 s) and the ram's whole approach would all have gone by.
+  const frames = 600
+  const still = runUntil(game, () => game.revealedSum() === null, frames)
+  assert.equal(still, false, `the reveal took itself down inside ${frames} frames`)
+
+  assert.equal(game.currentPhase, phase, 'the phase machine ran under the reveal')
+  assert.equal(game.ramRangeM(), ramAt, 'the ram rolled while the child was reading')
+  assert.equal(reports.length, reportsAt, 'another answer was reported under the reveal')
+  assert.equal(served(), servedAt, 'the game pulled another question under the reveal')
+})
+
+test('only a hand takes the sum down, and then the game carries on', () => {
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  miss(game, canvas)
+  game.stepFrames(2)
+  assert.ok(game.revealedSum() !== null)
+
+  // Past the settle lockout, then one tap.
+  runUntil(game, () => false, 40)
+  assert.ok(game.revealedSum() !== null, 'the reveal expired on its own')
+  tapField(canvas)
+  assert.equal(game.revealedSum(), null, 'a hand on the glass did not take the sum down')
+
+  // And the world is moving again — otherwise "held" would just be "broken".
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim' || game.currentPhase === 'clear'),
+    'the game never resumed after the reveal was dismissed',
+  )
+})
+
+test('a tap still in flight from the last question cannot take it down', () => {
+  // Latency, not pedagogy: the gesture that ended the question is routinely
+  // still arriving — the second tap of an impatient double-tap, a finger
+  // already committed to the fire button. Without the floor the child sees the
+  // lesson appear and vanish in the same breath.
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  miss(game, canvas)
+  game.stepFrames(1)
+  assert.ok(game.revealedSum() !== null)
+
+  // Well inside REVEAL_SETTLE_MS at 60 fps.
+  const early = Math.floor((REVEAL_SETTLE_MS / 1000) * 60) - 6
+  assert.ok(early > 0, 'the settle window is too short to test')
+  for (let i = 0; i < early; i++) {
+    tapField(canvas)
+    game.stepFrames(1)
+    assert.ok(game.revealedSum() !== null, `frame ${i}: a tap inside the settle window dismissed it`)
+  }
+  // …and once the window has passed, the same tap works.
+  runUntil(game, () => false, 12)
+  tapField(canvas)
+  assert.equal(game.revealedSum(), null, 'the settle window never opened')
+})
+
+test('the dismissing gesture cannot also load a different boulder', () => {
+  // The path that is NOT protected by the frozen phase. Winding the dial and
+  // firing are both phase-gated and the phase is stuck at 'impact' under a
+  // reveal — but tapping a rack stone and pressing 1–5 are not, and either one
+  // swaps the loaded question AND restarts the answer clock. So the gesture
+  // that takes the lesson down would silently change what she is being asked
+  // and hand the host a latency measured from the wrong moment.
+  //
+  // A rack row is laid out from its contents, so rather than reproduce that
+  // arithmetic this sweeps the row — with a CONTROL that proves the sweep
+  // actually lands on a stone, because a sweep that hits nothing would satisfy
+  // the guarded case for the wrong reason.
+  const answers = [20, 40, 60, 80, 100]
+  const rackY = hudLayout(VIEW.w, VIEW.h, { x: 0, y: 0, w: VIEW.w, h: VIEW.h }).rackTop + 8
+  const xs = Array.from({ length: 14 }, (_, i) => VIEW.w * (0.2 + i * 0.045))
+
+  let controlHits = 0
+  for (const x of xs) {
+    const { game, canvas } = newGame(answers, 5, 0.3)
+    const before = game.currentAnswer()
+    for (const fn of (canvas.__listeners as Listeners).get('pointerdown') ?? []) {
+      fn({ clientX: x, clientY: rackY, pointerId: 1 })
+    }
+    if (game.currentAnswer() !== before) controlHits++
+  }
+  assert.ok(controlHits > 0, 'the sweep never touched a rack stone, so the guarded case proves nothing')
+
+  for (const x of xs) {
+    const { game, canvas } = newGame(answers, 5, 0.3)
+    miss(game, canvas)
+    runUntil(game, () => false, 40)
+    assert.ok(game.revealedSum() !== null, 'no reveal to guard')
+    const before = game.currentAnswer()
+    for (const fn of (canvas.__listeners as Listeners).get('pointerdown') ?? []) {
+      fn({ clientX: x, clientY: rackY, pointerId: 1 })
+    }
+    assert.equal(game.revealedSum(), null, 'the tap did not dismiss')
+    assert.equal(game.currentAnswer(), before, `a tap at x=${x.toFixed(0)} loaded a different boulder`)
+  }
+})
+
+test('a key that dismisses the sum cannot also load a different boulder', () => {
+  const { game, keys, canvas } = newGame([20, 40, 60, 80, 100], 5, 0.3)
+  const press = (key: string): void => {
+    for (const fn of keys.get('keydown') ?? []) fn({ key, shiftKey: false, preventDefault: () => undefined })
+  }
+  // The control: 1–5 really do swap the loaded stone.
+  const start = game.currentAnswer()
+  press('4')
+  assert.notEqual(game.currentAnswer(), start, 'the number keys do not select a boulder, so nothing is proved')
+
+  miss(game, canvas)
+  runUntil(game, () => false, 40)
+  assert.ok(game.revealedSum() !== null)
+  const before = game.currentAnswer()
+  press('2')
+  assert.equal(game.revealedSum(), null, 'the key did not dismiss')
+  assert.equal(game.currentAnswer(), before, 'the dismissing key also loaded a different boulder')
+})
+
+test('the tap that dismisses the sum does not also wind the dial', () => {
+  // A reveal that does not CONSUME its own dismissal is worse than no reveal.
+  // A tap on the field is how this game aims — it jumps the dial to the metre
+  // under the finger — so the same touch that takes the lesson down would set
+  // her answer to wherever she happened to be looking, and the next boulder
+  // would be thrown at a number she never chose.
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  miss(game, canvas)
+  runUntil(game, () => false, 40)
+  assert.ok(game.revealedSum() !== null)
+
+  const dial = game.stats().dial
+  const phase = game.currentPhase
+  tapField(canvas)
+  assert.equal(game.revealedSum(), null, 'the tap did not dismiss')
+  assert.equal(game.stats().dial, dial, 'the dismissing tap also wound the dial')
+  assert.equal(game.currentPhase, phase, 'the dismissing tap also fired a boulder')
+})
+
+test('mastery skips the ceremony instead of shortening it', () => {
+  // Adaptation lives in the reveal's EXISTENCE, not its length. Above intensity
+  // ~0.75 `revealPlan` returns `holdMs: 0`, and skipping the beat is the reward
+  // for being good — not a half-patient reveal that is long enough to notice
+  // and too short to read.
+  const hard = 0.9
+  assert.equal(revealPlan(SECOND_GRADE_FLOW, hard).holdMs, 0, 'the premise of this test has moved')
+  const { game, canvas } = newGame([56, 72, 88], 1, hard)
+  miss(game, canvas)
+  game.stepFrames(2)
+  assert.equal(game.revealedSum(), null, 'a child at the top of the ladder was held for a lesson')
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim' || game.currentPhase === 'clear'),
+    'the game did not move straight on',
+  )
+})
+
+test('a clean hit is never held for a lesson', () => {
+  // There is nothing to marinate on in a sum you just got right, and a reveal on
+  // every item would turn a flowing game into a queue of dismissals.
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  game.aimAt(game.currentAnswer() - game.currentWind())
+  tapButton(canvas, 'fire')
+  assert.ok(runUntil(game, () => game.currentPhase === 'impact'), 'the shot never landed')
+  assert.ok(
+    runUntil(game, () => game.currentPhase === 'aim' || game.currentPhase === 'clear'),
+    'a correct answer did not carry straight on',
+  )
+  assert.equal(game.revealedSum(), null, 'a correct answer put a lesson on the glass')
+})
+
+test('the keep she was aiming at is the one that lights up', () => {
+  // The old reveal lit the keeps still WANTED, which is the one set guaranteed
+  // to exclude the answer she just missed: `markWanted()` runs after her boulder
+  // is spent. The lit keep is now the answer, and the answer only.
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  const answer = game.currentAnswer()
+  assert.ok(game.towerRanges().includes(answer), 'the answer has no keep')
+  assert.deepEqual(game.litKeeps(), [], 'a keep is lit before anything went wrong')
+
+  miss(game, canvas)
+  game.stepFrames(4)
+  const sum = game.revealedSum()
+  assert.ok(sum !== null)
+  assert.ok(sum.endsWith(String(answer)), `"${sum}" does not finish on the keep she wanted`)
+  assert.deepEqual(game.litKeeps(), [answer], 'the wrong keeps are lit out on the field')
+
+  // …and the field goes dark again when she takes the sum down.
+  runUntil(game, () => false, 40)
+  tapField(canvas)
+  assert.ok(runUntil(game, () => game.litKeeps().length === 0), 'a keep stayed lit after the reveal went')
+})
+
+test('there is no clock: a child who is only thinking is never marked', () => {
+  // The version of "a timeout must never be reported as incorrect" that this
+  // game can have — it has no timer at all, and that is the property to keep.
+  // A clock that quietly reported a lapse as a wrong answer would poison the
+  // ladder and make guessing free, and it would do it invisibly.
+  const { game, reports } = newGame([56, 72, 88, 40], 7, 0.3)
+  const ram = game.ramRangeM()
+  assert.ok(ram !== null, 'wave 7 has no ram, so the harshest case is not covered')
+
+  // Fifteen seconds of a child staring at the sum with her hands in her lap.
+  const idle = runUntil(game, () => game.currentPhase !== 'aim', MAX_FRAMES)
+  assert.equal(idle, false, `the game left 'aim' on its own inside ${MAX_FRAMES} frames`)
+  assert.equal(reports.length, 0, 'a child who never fired was marked anyway')
+  assert.equal(game.revealedSum(), null, 'a child who never fired was shown a correction')
+  assert.equal(game.ramRangeM(), ram, 'the ram closed on a child who was thinking')
+})
+
+test('a reveal happens exactly when a wrong ANSWER was reported, over a whole run', () => {
+  // The other half of the timeout rule: nothing that is not an answer may raise
+  // a correction. Driven over many shots rather than asserted at one moment,
+  // because the two failures — a reveal with no report behind it, and a wrong
+  // report with no reveal — are opposite mistakes and one test that only ever
+  // sees hits would miss both.
+  const { game, canvas, reports } = newGame([56, 72, 88, 40], 7, 0.3)
+  let misses = 0
+  let reveals = 0
+  for (let shot = 0; shot < 8; shot++) {
+    if (game.currentPhase !== 'aim') {
+      if (!runUntil(game, () => game.currentPhase === 'aim')) break
+    }
+    const before = reports.length
+    const wrong = shot % 2 === 0
+    game.aimAt(game.currentAnswer() - game.currentWind() + (wrong ? 3 : 0))
+    tapButton(canvas, 'fire')
+    if (!runUntil(game, () => reports.length > before || game.revealedSum() !== null)) break
+    game.stepFrames(2)
+    const last = reports[reports.length - 1]
+    const shown = game.revealedSum() !== null
+    if (last && !last.correct) {
+      misses++
+      assert.ok(shown, `a wrong answer (${last.answered}) showed the child nothing`)
+    } else {
+      assert.equal(shown, false, 'a correct answer put a correction on the glass')
+    }
+    if (shown) {
+      reveals++
+      runUntil(game, () => false, 40)
+      tapField(canvas)
+    }
+  }
+  assert.ok(misses >= 2, `only ${misses} miss(es) were driven, so nothing was proved`)
+  assert.equal(reveals, misses, 'reveals and wrong answers did not line up')
+})
+
+test('the reveal cannot survive a wave change and freeze the next wave', () => {
+  // The failure mode of a beat that only a hand ends: something else tears the
+  // question down, the hand never arrives, and the game is stopped forever with
+  // no way back. `startWave` clears it, and this is what says so.
+  const { game, canvas } = newGame([56, 72, 88], 1, 0.3)
+  miss(game, canvas)
+  game.stepFrames(2)
+  assert.ok(game.revealedSum() !== null)
+  game.jumpToWave(2)
+  assert.equal(game.revealedSum(), null, 'a stale sum survived into the next wave')
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the next wave never became playable')
+})

--- a/dynawalla/games/trebuchet/src/render/banner.test.ts
+++ b/dynawalla/games/trebuchet/src/render/banner.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The keep that lights up — the world half of the reveal, and the exact line
+ * the audit found dead.
+ *
+ * `drawTower` took a `reveal` flag and spent it on one expression:
+ *
+ *     ctx.fillStyle = reveal && !showBanner ? C.bannerWanted : C.banner
+ *
+ * `waveConfig` sets `banners: true` for waves 1 to 8, so `showBanner` was true
+ * for a child's whole first session and `reveal` could not change a single
+ * pixel. The reveal drew the same banner, in the same colour, in the same
+ * place. Nothing here mocks the drawing: it records every style the real
+ * function sets and compares the two calls.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { drawTower } from './pieces.ts'
+import { C } from './theme.ts'
+import { buildTower, type Tower } from '../sim/world.ts'
+import { makeRng } from '../core/rng.ts'
+
+/** A 2D context that records every fill and stroke style it is given. */
+function recordingCtx(): { ctx: CanvasRenderingContext2D; fills: string[]; strokes: string[] } {
+  const fills: string[] = []
+  const strokes: string[] = []
+  const state: Record<string, unknown> = {}
+  const ctx = new Proxy(state, {
+    get: (t, prop: string) => {
+      if (prop === 'measureText') return () => ({ width: 8 })
+      if (prop in t) return t[prop]
+      return () => undefined
+    },
+    set: (t, prop: string, value) => {
+      t[prop] = value
+      if (prop === 'fillStyle' && typeof value === 'string') fills.push(value)
+      if (prop === 'strokeStyle' && typeof value === 'string') strokes.push(value)
+      return true
+    },
+  }) as unknown as CanvasRenderingContext2D
+  return { ctx, fills, strokes }
+}
+
+function keep(): Tower {
+  const t = buildTower(0, 56, makeRng(1))
+  t.reveal = 1 // fully faded in
+  return t
+}
+
+test('a lit keep looks different from an unlit one EVEN WHERE THE BANNER IS ALREADY UP', () => {
+  // Waves 1 to 8. The whole defect.
+  const plain = recordingCtx()
+  drawTower(plain.ctx, 20, keep(), true, false, 0)
+  const lit = recordingCtx()
+  drawTower(lit.ctx, 20, keep(), true, true, 0)
+
+  assert.ok(plain.fills.includes(C.banner), 'the ordinary banner is not drawn in the banner colour')
+  assert.ok(lit.fills.includes(C.bannerWanted), 'a lit keep on wave 1 is drawn in the ordinary banner colour')
+  assert.ok(!lit.fills.includes(C.banner), 'the lit keep still paints the ordinary banner colour over itself')
+  assert.ok(lit.strokes.includes(C.fire1), 'a lit keep has no accent on it')
+  assert.ok(!plain.strokes.includes(C.fire1), 'an ordinary keep is already wearing the accent')
+})
+
+test('a lit keep is visible on the later waves too, where the banner is off', () => {
+  // Waves 9 and up: `banners` is false, and the reveal is the only thing that
+  // ever draws the number at all.
+  const dark = recordingCtx()
+  drawTower(dark.ctx, 20, keep(), false, false, 0)
+  const lit = recordingCtx()
+  drawTower(lit.ctx, 20, keep(), false, true, 0)
+  assert.ok(!dark.fills.includes(C.bannerWanted) && !dark.fills.includes(C.banner), 'a banner was drawn with banners off')
+  assert.ok(lit.fills.includes(C.bannerWanted), 'the reveal drew no banner with banners off')
+})
+
+test('a destroyed keep is never given a banner to wear', () => {
+  const gone = keep()
+  gone.alive = false
+  const rec = recordingCtx()
+  drawTower(rec.ctx, 20, gone, true, true, 0)
+  assert.ok(!rec.fills.includes(C.bannerWanted), 'a levelled keep still flies a banner')
+})

--- a/dynawalla/games/trebuchet/src/render/hud.ts
+++ b/dynawalla/games/trebuchet/src/render/hud.ts
@@ -213,6 +213,19 @@ export function dialNumeralBox(
 export type HudState = {
   layout: HudLayout
   equation: string
+  /**
+   * The COMPLETED sum, after a miss, or `null`.
+   *
+   * It replaces the equation on the plaque rather than appearing beside it, and
+   * that is the whole design: the child is already looking at that rectangle,
+   * it is the most legible thing on the screen, and the only thing that changes
+   * is that the sum now has its answer on the end of it in the accent colour.
+   * Nothing says WRONG, nothing turns red, and there is no word anywhere —
+   * being shown the finished sum IS the correction.
+   */
+  reveal: string | null
+  /** 0..1 how far into the reveal's own entrance we are. */
+  revealAge: number
   rack: string[]
   rackActive: number
   wave: number
@@ -238,33 +251,49 @@ export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[]
   ctx.save()
   ctx.textBaseline = 'middle'
 
-  /* ---- the equation: the most legible thing on the screen ---- */
+  /* ---- the equation: the most legible thing on the screen ----
+   *
+   * …and, after a miss, the same sum with its answer on the end. The reveal
+   * borrows this plaque instead of raising a card of its own, because a card is
+   * a thing you dismiss and a plaque is a thing you read. */
+  const revealing = st.reveal !== null
+  const text = st.reveal ?? st.equation
+  const grow = revealing ? 1 + (1 - easeOutCubic(clamp01(st.revealAge / 0.32))) * 0.16 : 1
   const intro = easeOutExpo(clamp01(st.introT))
   const maxW = st.layout.plaqueMax.w
   let eqSize = eqSizeFor(unit, area)
   ctx.font = font(eqSize, 900)
-  let mw = ctx.measureText(st.equation).width
+  let mw = ctx.measureText(text).width
   // A long question used to run off both edges of a 320px phone. Shrink to fit
   // the safe width instead — the sum has to be readable more than it has to be big.
   if (mw + eqSize * 1.6 > maxW && mw > 0) {
     eqSize = Math.max(11, Math.floor((eqSize * maxW) / (mw + eqSize * 1.6)))
     ctx.font = font(eqSize, 900)
-    mw = ctx.measureText(st.equation).width
+    mw = ctx.measureText(text).width
   }
   const pw = Math.min(maxW, Math.max(mw + eqSize * 1.6, eqSize * 5.4))
   const ph = eqSize * 1.62
   const px = area.x + (area.w - pw) / 2
   const py = st.layout.plaqueMax.y + (1 - intro) * -60
+  ctx.save()
   ctx.globalAlpha = intro
+  // The pop is around the plaque's own centre, so a long sum does not swing in
+  // from the left edge of the glass.
+  ctx.translate(area.x + area.w / 2, py + ph / 2)
+  ctx.scale(grow, grow)
+  ctx.translate(-(area.x + area.w / 2), -(py + ph / 2))
   roundRect(ctx, px, py, pw, ph, 6)
-  ctx.fillStyle = 'rgba(6,8,18,0.62)'
+  ctx.fillStyle = revealing ? 'rgba(20,12,4,0.78)' : 'rgba(6,8,18,0.62)'
   ctx.fill()
-  ctx.strokeStyle = 'rgba(242,233,213,0.16)'
-  ctx.lineWidth = 1
+  // The accent, never red. A miss is answered by the answer, and the only thing
+  // that says anything happened is that the sum is now finished and warm.
+  ctx.strokeStyle = revealing ? C.fire1 : 'rgba(242,233,213,0.16)'
+  ctx.lineWidth = revealing ? 2 : 1
   ctx.stroke()
-  ctx.fillStyle = C.bone
+  ctx.fillStyle = revealing ? C.fire1 : C.bone
   ctx.textAlign = 'center'
-  ctx.fillText(st.equation, area.x + area.w / 2, py + ph / 2 + 1)
+  ctx.fillText(text, area.x + area.w / 2, py + ph / 2 + 1)
+  ctx.restore()
   ctx.globalAlpha = 1
 
   /* ---- the rack: every boulder left, and what is written on it ---- */

--- a/dynawalla/games/trebuchet/src/render/layout.test.ts
+++ b/dynawalla/games/trebuchet/src/render/layout.test.ts
@@ -60,6 +60,8 @@ function stateFor(layout: HudLayout): HudState {
   return {
     layout,
     equation: '347 + 268',
+    reveal: null,
+    revealAge: 0,
     rack: ['347 + 268', '91 − 47', '8 × 7', '120 − 65', '46 + 39'],
     rackActive: 0,
     wave: 3,

--- a/dynawalla/games/trebuchet/src/render/pieces.ts
+++ b/dynawalla/games/trebuchet/src/render/pieces.ts
@@ -383,8 +383,18 @@ export function drawTower(
   if (!t.alive) return
 
   // banner
+  //
+  // `reveal` is the keep the child was aiming at, lit while the completed sum
+  // is held on the glass. It used to change NOTHING for the first eight waves:
+  // `waveConfig` sets `banners: true` up to wave 8, so `showBanner` was already
+  // true, the geometry was already drawn and the only line that read `reveal`
+  // was the fill — behind an `&& !showBanner` that made it unreachable. A
+  // child's whole first session had a reveal that redrew the same banner in the
+  // same colour in the same place. So the colour now answers to `reveal` alone,
+  // and a lit banner lifts and glows whether or not it was already up.
   if (showBanner || reveal) {
-    const top = t.heightM + 3.4
+    const lift = reveal ? easeOutCubic(clamp01(t.reveal)) : 0
+    const top = t.heightM + 3.4 + lift * 1.1
     const rv = showBanner ? 1 : easeOutCubic(clamp01(t.reveal))
     const sway = Math.sin(time * 1.7 + t.range) * 0.16
     ctx.save()
@@ -408,9 +418,15 @@ export function drawTower(
     ctx.lineTo(0, top - bh * 0.78)
     ctx.lineTo(-bw / 2 + sway * 0.4, top - bh)
     ctx.closePath()
-    ctx.fillStyle = reveal && !showBanner ? C.bannerWanted : C.banner
+    ctx.fillStyle = reveal ? C.bannerWanted : C.banner
     ctx.globalAlpha = 0.92 * rv
     ctx.fill()
+    if (lift > 0) {
+      ctx.strokeStyle = C.fire1
+      ctx.globalAlpha = 0.8 * lift
+      ctx.lineWidth = 2.4 / s
+      ctx.stroke()
+    }
     ctx.globalAlpha = 1
     worldText(ctx, s, 0, top - 0.7, (c) => {
       c.font = font(Math.max(13, Math.min(30, s * 2.3)), 900)

--- a/dynawalla/games/trebuchet/src/reveal.test.ts
+++ b/dynawalla/games/trebuchet/src/reveal.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { completedSum, hasBlank } from './reveal.ts'
+
+test('an expression gets its answer, because it has nowhere else to put it', () => {
+  // The shape TREBUCHET is served today. A blank-only implementation would
+  // return this unchanged and the child would see the question again.
+  assert.equal(completedSum('7 × 8', '56'), '7 × 8 = 56')
+  assert.equal(completedSum('47 + 25', '72'), '47 + 25 = 72')
+})
+
+test('a statement with a blank gets the answer IN the blank', () => {
+  assert.equal(completedSum('47 + □ = 68', '21'), '47 + 21 = 68')
+  assert.equal(completedSum('? = 42', '42'), '42 = 42')
+  assert.equal(completedSum('9 _ = 81', '×'), '9 × = 81')
+})
+
+test('only the first blank is filled', () => {
+  assert.equal(completedSum('□ + □ = 9', '4'), '4 + □ = 9')
+})
+
+test('an answer with a dollar in it is not mangled by String.replace', () => {
+  // `$&` inside a string replacement means "the whole match". Through a
+  // replacer function it means a dollar and an ampersand.
+  assert.equal(completedSum('□ pounds', '$&'), '$& pounds')
+})
+
+test('nothing empty ever produces a dangling equals sign', () => {
+  assert.equal(completedSum('7 × 8', ''), '7 × 8')
+  assert.equal(completedSum('', '56'), '56')
+  assert.equal(completedSum('  7 × 8  ', ' 56 '), '7 × 8 = 56')
+})
+
+test('hasBlank knows the three spellings and nothing else', () => {
+  assert.equal(hasBlank('47 + □ = 68'), true)
+  assert.equal(hasBlank('47 + ? = 68'), true)
+  assert.equal(hasBlank('47 + _ = 68'), true)
+  assert.equal(hasBlank('47 + 21'), false)
+})

--- a/dynawalla/games/trebuchet/src/reveal.ts
+++ b/dynawalla/games/trebuchet/src/reveal.ts
@@ -1,0 +1,55 @@
+/**
+ * The sum, completed.
+ *
+ * A miss in this game puts the finished equation on the glass and holds it
+ * there. This is the one place that decides what "finished" looks like, and it
+ * has two jobs because the host writes prompts in two shapes:
+ *
+ *   `7 × 8`        an expression, with the answer left off entirely
+ *   `47 + □ = 68`  a statement with a blank in it
+ *
+ * A `String.replace` that matches nothing returns the string unchanged, so a
+ * function that only knew how to fill blanks would show `7 × 8` back to a child
+ * who had just got it wrong and call that a reveal. That is the failure shape
+ * `stack`'s `blank.ts` documents at length, and it is the reason this is a
+ * tested function rather than three lines inlined into the renderer.
+ *
+ * There are no words here and there never will be. The HUD is numerals and
+ * glyphs — a word costs five translations, and a child who has just missed does
+ * not need to be told anything, only shown.
+ */
+
+/**
+ * The blank the curriculum writes, plus the two spellings tolerated as history.
+ *
+ * Exactly the set `games/stack/src/blank.ts` and `games/balance/src/adapter.ts`
+ * lex. Two packs disagreeing about what a blank is would be the next version of
+ * the bug above.
+ */
+const BLANK = /[□?_]/u
+
+/** Does this prompt have a blank waiting for the answer? */
+export function hasBlank(prompt: string): boolean {
+  return BLANK.test(prompt)
+}
+
+/**
+ * `prompt` with `answer` put where it belongs.
+ *
+ * Filled in place when there is a blank; appended after an `=` when there is
+ * not, because an expression with no blank is a question whose answer has
+ * nowhere else to go.
+ *
+ * The answer is substituted through a replacer FUNCTION, never a string:
+ * `String.replace` interprets `$&` and `$1` inside a string replacement, so an
+ * answer containing a `$` would be mangled. Answers are numerals today; a
+ * function costs nothing and cannot be wrong later.
+ */
+export function completedSum(prompt: string, answer: string): string {
+  const q = prompt.trim()
+  const a = answer.trim()
+  if (a === '') return q
+  if (hasBlank(q)) return q.replace(BLANK, () => a)
+  if (q === '') return a
+  return `${q} = ${a}`
+}

--- a/dynawalla/packs/shared/game-audio/index.ts
+++ b/dynawalla/packs/shared/game-audio/index.ts
@@ -5,6 +5,8 @@
  * `createSafetyBus` — the graph a game's output must pass through.
  * `safeAttack`      — the shortest onset an envelope may use.
  * `VoiceBudget`     — the polyphony cap, with no timers and an injected clock.
+ * `playVoice`       — the synthesis for a `game-soundscape` voice, including
+ *                     the rubble recipe, so no pack writes its own.
  *
  * Usage, in a game's `start()`:
  *
@@ -43,3 +45,16 @@ export {
   type BusContext,
 } from "./safetyBus.ts"
 export { setHostSound, hostSoundAllowed, onHostSound, resetHostSound } from "./sound.ts"
+export {
+  RUBBLE_CEILING_HZ,
+  RUBBLE_GRAINS,
+  TONE_CEILING_HZ,
+  playVoice,
+  voiceBrightestHz,
+  voiceGrains,
+  voicePeak,
+  type Grain,
+  type PlayableVoice,
+  type VoiceContext,
+  type VoiceTimbre,
+} from "./voices.ts"

--- a/dynawalla/packs/shared/game-audio/voices.test.ts
+++ b/dynawalla/packs/shared/game-audio/voices.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The synthesiser, measured rather than described.
+ *
+ * "Premium and chill" is a claim about numbers — how bright, how loud, how many
+ * events — and every one of them is a property of `voiceGrains`, which is pure.
+ * So this measures the real frequencies and the real summed peaks a device would
+ * produce, with no `AudioContext` anywhere.
+ */
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { CEILING, MIN_ATTACK } from "./ceiling.ts"
+import {
+  RUBBLE_CEILING_HZ,
+  RUBBLE_GRAINS,
+  TONE_CEILING_HZ,
+  playVoice,
+  voiceBrightestHz,
+  voiceGrains,
+  voicePeak,
+  type PlayableVoice,
+  type VoiceTimbre,
+} from "./voices.ts"
+
+const TIMBRES: VoiceTimbre[] = ["bell", "pluck", "bloom", "rubble"]
+
+const voice = (timbre: VoiceTimbre, hz = 220, gain = 0.12, seconds = 0.6): PlayableVoice => ({
+  hz,
+  at: 0,
+  seconds,
+  gain,
+  timbre,
+})
+
+test("every timbre costs at least one oscillator and never a silent graph", () => {
+  for (const timbre of TIMBRES) {
+    const grains = voiceGrains(voice(timbre))
+    assert.ok(grains.length >= 1, `${timbre} produced no grains`)
+    for (const g of grains) {
+      assert.ok(g.peak > 0, `${timbre} scheduled a silent grain`)
+      assert.ok(g.hz > 0 && Number.isFinite(g.hz), `${timbre} scheduled ${g.hz} Hz`)
+      assert.ok(g.attack >= MIN_ATTACK, `${timbre} onset ${g.attack}s is a step function`)
+      assert.ok(g.decay > 0, `${timbre} grain never ends`)
+      assert.ok(g.at >= 0, `${timbre} grain starts before the voice does`)
+    }
+  }
+})
+
+test("nothing pitched ever reaches the band the ear is most sensitive in", () => {
+  // The whole of what "abrasive" means, and it is a claim about OSCILLATORS:
+  // a one-pole low-pass attenuates what is above it rather than removing it, so
+  // a bell whose fourth partial sits at 5 kHz is a bright cue however the tone
+  // filter is set. The soundscape's own register tops out at 1250 Hz.
+  for (const timbre of TIMBRES) {
+    for (const hz of [58, 110, 220, 440, 880, 1250]) {
+      const top = voiceBrightestHz(voice(timbre, hz))
+      assert.ok(top <= TONE_CEILING_HZ, `${timbre} at ${hz} Hz reaches ${top} Hz`)
+    }
+  }
+})
+
+test("a voice too high for its own partials keeps its fundamental", () => {
+  // Dropping partials must never drop the note. A voice that made no sound at
+  // all would satisfy every "nothing is brighter than" assertion in this file.
+  for (const timbre of TIMBRES) {
+    const grains = voiceGrains(voice(timbre, 4000))
+    assert.ok(grains.length >= 1, `${timbre} at 4 kHz was silenced entirely`)
+    assert.ok(grains.some((g) => g.peak > 0), `${timbre} at 4 kHz is silent`)
+  }
+})
+
+test("a collapse is masonry: many graded impacts, staggered, and low", () => {
+  // The founder's complaint, as a measurement. A noise burst is ONE event with
+  // no size to it; this is sixteen with a power-law size distribution.
+  const grains = voiceGrains(voice("rubble", 70, 0.13, 1.2))
+  assert.equal(grains.length, RUBBLE_GRAINS)
+  const onsets = new Set(grains.map((g) => Math.round(g.at * 1000)))
+  assert.ok(onsets.size >= RUBBLE_GRAINS - 1, "the whole building landed in one instant")
+  for (let i = 1; i < grains.length; i++) {
+    const prev = grains[i - 1]
+    const cur = grains[i]
+    assert.ok(prev && cur)
+    assert.ok(cur.peak < prev.peak, `grain ${i} is not smaller than grain ${i - 1}`)
+    assert.ok(cur.hz >= prev.hz, `grain ${i} is not higher than grain ${i - 1}`)
+  }
+  for (const g of grains) {
+    assert.ok(g.hz <= RUBBLE_CEILING_HZ, `a grain at ${g.hz} Hz is above the rubble ceiling`)
+    assert.ok(g.glideTo < g.hz, "a grain that does not fall is a tone, not a stone")
+  }
+})
+
+test("a rubble cloud stays low however high it is asked for", () => {
+  // The cap matters: the pitch comes from the walker, and a walker in the top
+  // band would otherwise put sixteen grains at 8 kHz.
+  for (const hz of [58, 130, 400, 1250]) {
+    for (const g of voiceGrains(voice("rubble", hz))) {
+      assert.ok(g.hz <= RUBBLE_CEILING_HZ, `${hz} Hz produced a grain at ${g.hz} Hz`)
+    }
+  }
+})
+
+test("no voice can peak above the fleet's output ceiling", () => {
+  // The summed instantaneous peak, not the gain that was asked for: a pitched
+  // voice's partials all start together and their sum is what is heard.
+  for (const timbre of TIMBRES) {
+    const peak = voicePeak(voice(timbre, 220, 0.14))
+    assert.ok(peak > 0, `${timbre} is silent`)
+    assert.ok(peak < CEILING, `${timbre} peaks at ${peak.toFixed(3)}, above the ceiling ${CEILING}`)
+    // And it is genuinely quiet, not merely legal: a single cue an order of
+    // magnitude under full scale is what "not too loud" means.
+    assert.ok(peak <= 0.2, `${timbre} peaks at ${peak.toFixed(3)}, which is not chill`)
+  }
+})
+
+test("a staggered collapse is quieter than the sum of its grains", () => {
+  // Why `voicePeak` integrates rather than adding: sixteen grains summing
+  // naively to 0.4 actually peak far lower, because they do not overlap.
+  const v = voice("rubble", 70, 0.13, 1.2)
+  const naive = voiceGrains(v).reduce((a, g) => a + g.peak, 0)
+  const real = voicePeak(v)
+  assert.ok(real < naive * 0.75, `${real.toFixed(3)} vs a naive ${naive.toFixed(3)}`)
+})
+
+test("the voice budget's scale is honoured, and zero builds nothing", () => {
+  const v = voice("bell")
+  assert.ok(voicePeak(v, 0.5) < voicePeak(v, 1), "halving the scale did not halve the voice")
+  const ctx = recordingContext()
+  playVoice(ctx, ctx.destination, v, 0)
+  assert.equal(ctx.oscillators.length, 0, "a spent budget still built oscillators")
+})
+
+test("playVoice routes every oscillator to the destination it was given", () => {
+  const ctx = recordingContext()
+  playVoice(ctx, ctx.destination, voice("bell"))
+  assert.ok(ctx.oscillators.length >= 2, "a bell with one partial is a test tone")
+  assert.ok(ctx.filters.length === 1, "each voice gets exactly one tone filter")
+  assert.ok(ctx.filters[0]?.reaches(ctx.destination), "the voice does not reach the destination")
+  for (const o of ctx.oscillators) {
+    assert.ok(o.started, "an oscillator was built and never started")
+    assert.ok(o.stopped, "an oscillator was built and never stopped")
+  }
+})
+
+test("playVoice schedules a whole collapse from one clock read", () => {
+  const ctx = recordingContext()
+  ctx.currentTime = 12.5
+  playVoice(ctx, ctx.destination, voice("rubble", 70, 0.13, 1.2))
+  assert.equal(ctx.oscillators.length, RUBBLE_GRAINS)
+  for (const o of ctx.oscillators) assert.ok(o.startAt >= 12.5, "a grain was scheduled in the past")
+})
+
+/* ------------------------------------------------------------------ doubles */
+
+type FakeOsc = { started: boolean; stopped: boolean; startAt: number }
+
+function recordingContext(): {
+  currentTime: number
+  destination: AudioNode
+  oscillators: FakeOsc[]
+  filters: Array<{ reaches: (n: unknown) => boolean }>
+  createGain(): GainNode
+  createOscillator(): OscillatorNode
+  createBiquadFilter(): BiquadFilterNode
+} {
+  const oscillators: FakeOsc[] = []
+  const filters: Array<{ reaches: (n: unknown) => boolean }> = []
+  const dest = {} as AudioNode
+  const param = (): AudioParam =>
+    ({
+      value: 0,
+      setValueAtTime: () => undefined,
+      exponentialRampToValueAtTime: () => undefined,
+      linearRampToValueAtTime: () => undefined,
+    }) as unknown as AudioParam
+  return {
+    currentTime: 0,
+    destination: dest,
+    oscillators,
+    filters,
+    createGain: () =>
+      ({ gain: param(), connect: () => undefined }) as unknown as GainNode,
+    createOscillator: () => {
+      const rec: FakeOsc = { started: false, stopped: false, startAt: 0 }
+      oscillators.push(rec)
+      return {
+        type: "sine",
+        frequency: param(),
+        connect: () => undefined,
+        start: (t: number) => {
+          rec.started = true
+          rec.startAt = t
+        },
+        stop: () => {
+          rec.stopped = true
+        },
+      } as unknown as OscillatorNode
+    },
+    createBiquadFilter: () => {
+      const outs: unknown[] = []
+      filters.push({ reaches: (n) => outs.includes(n) })
+      return {
+        type: "lowpass",
+        frequency: { value: 0 },
+        Q: { value: 0 },
+        connect: (n: unknown) => {
+          outs.push(n)
+        },
+      } as unknown as BiquadFilterNode
+    },
+  }
+}

--- a/dynawalla/packs/shared/game-audio/voices.ts
+++ b/dynawalla/packs/shared/game-audio/voices.ts
@@ -1,0 +1,290 @@
+/**
+ * How a `game-soundscape` voice is actually made to sound.
+ *
+ * `game-soundscape` owns the music and states, in its own header, that there is
+ * "no Web Audio in any of" its seven files. That is the right boundary and it
+ * leaves a hole: every pack that adopts the soundscape has to write the same
+ * oscillator graph, and the first one that did — THE STEELYARD — wrote a good
+ * one privately, where the second pack could only copy it. Two copies of a
+ * synthesiser is two answers to "how loud is a bell", which is the thing this
+ * whole directory exists to have exactly one of.
+ *
+ * So the recipe lives here, next to the ceiling it has to fit under. A game
+ * hands over a voice and a destination; nothing else about the game is visible
+ * from this file, and no pitch, mode or gesture is decided in it.
+ *
+ * ## The two halves, and why they are separate
+ *
+ * `voiceGrains` is pure arithmetic — the complete list of oscillators a voice
+ * costs, with their frequencies, peaks and times. `playVoice` builds nodes from
+ * it. Everything worth asserting about loudness and brightness is a property of
+ * the first, so `voices.test.ts` measures the real numbers a device would hear
+ * without needing an `AudioContext`, a user gesture, or a device.
+ *
+ * ## What "premium" and "chill" mean here, in numbers
+ *
+ * The founder: *"maybe a whole pass on making the sound effects more premium
+ * (and chillaxed in most cases) .. they tend to be a bit abrasive .. maybe lower
+ * pitched in a lot of cases."* Three constants carry that:
+ *
+ *   - `TONE_CEILING_HZ` (2.4 kHz) — nothing pitched is allowed to be brighter,
+ *     which keeps every voice out of the 2–5 kHz band the ear is most sensitive
+ *     in. That band IS what "abrasive" means.
+ *   - `RUBBLE_CEILING_HZ` (1.4 kHz) — and a collapse is kept lower still.
+ *   - `MIN_ATTACK` (from `ceiling.ts`) — no onset may be a step function. The
+ *     click on a 1 ms attack is most of what a child hears as "too loud".
+ *
+ * ## Timbres
+ *
+ * The four `game-soundscape` names, and this file must implement all four or it
+ * does not compile against a `Voice` — which is the point of `VoiceTimbre`
+ * being a literal union rather than `string`.
+ */
+
+import { MIN_ATTACK, safeAttack } from "./ceiling.ts"
+
+/**
+ * The timbres `game-soundscape` can ask for.
+ *
+ * Deliberately re-declared rather than imported. This module must not depend on
+ * the music module — the dependency runs the other way in spirit and neither
+ * direction is needed in fact, because a `Voice` is structurally assignable to
+ * `PlayableVoice`. And the re-declaration is load-bearing: if `game-soundscape`
+ * adds a fifth timbre and this file does not, every call site passing a `Voice`
+ * stops compiling, which is exactly the notice a synthesiser wants.
+ */
+export type VoiceTimbre = "bell" | "pluck" | "bloom" | "rubble"
+
+/** What a game hands over. Structurally `game-soundscape`'s `Voice`. */
+export type PlayableVoice = {
+  readonly hz: number
+  readonly at: number
+  readonly seconds: number
+  readonly gain: number
+  readonly timbre: VoiceTimbre
+}
+
+/** One oscillator. A pitched voice is a few of these at once; rubble is many, staggered. */
+export type Grain = {
+  /** Seconds after the voice's own `at`. */
+  readonly at: number
+  readonly hz: number
+  /** Where the pitch glides to by `at + glideSeconds`. Equal to `hz` when it does not glide. */
+  readonly glideTo: number
+  readonly glideSeconds: number
+  /** Linear peak, after the caller's `scale`. */
+  readonly peak: number
+  readonly attack: number
+  /** Seconds from the end of the attack to silence. */
+  readonly decay: number
+  readonly type: OscillatorType
+  /** The low-pass this grain passes through, in Hz. */
+  readonly toneHz: number
+}
+
+/** Grains in a rubble cloud. Sixteen, per `SOUNDSCAPE_DESIGN_2026-07.md`. */
+export const RUBBLE_GRAINS = 16
+/** Nothing in a collapse is brighter than this. */
+export const RUBBLE_CEILING_HZ = 1400
+/** Nothing pitched is brighter than this. */
+export const TONE_CEILING_HZ = 2400
+
+/**
+ * Every oscillator a voice costs, and exactly what each one does.
+ *
+ * Pure. No allocation beyond the array it returns, and nothing here reads a
+ * clock — `at` is relative to the voice, so a caller schedules the whole thing
+ * off one `currentTime` read and a test reads it off nothing at all.
+ */
+export function voiceGrains(voice: PlayableVoice, scale = 1): readonly Grain[] {
+  const hz = Math.max(1, voice.hz)
+  const seconds = Math.max(0.01, voice.seconds)
+  const peak = Math.max(0.0002, voice.gain * Math.max(0, scale))
+  if (voice.timbre === "rubble") return rubbleGrains(hz, seconds, peak)
+
+  // A fundamental plus a partial or two. The partial is what makes it a struck
+  // object rather than a test tone, and the ratios are octaves rather than
+  // inharmonic — inharmonic is the sound the founder is calling abrasive.
+  const attack = safeAttack(voice.timbre === "bloom" ? 0.18 : voice.timbre === "pluck" ? 0.01 : 0.014)
+  const partials: readonly { ratio: number; level: number; type: OscillatorType }[] =
+    voice.timbre === "bloom"
+      ? [
+          { ratio: 1, level: 0.62, type: "sine" },
+          { ratio: 2.001, level: 0.2, type: "sine" },
+        ]
+      : voice.timbre === "pluck"
+        ? [
+            { ratio: 1, level: 0.7, type: "triangle" },
+            { ratio: 3, level: 0.12, type: "sine" },
+          ]
+        : [
+            { ratio: 1, level: 0.68, type: "triangle" },
+            { ratio: 2, level: 0.22, type: "sine" },
+            { ratio: 4, level: 0.06, type: "sine" },
+          ]
+  const toneHz = Math.min(TONE_CEILING_HZ, hz * 6)
+  return (
+    partials
+      // A partial ABOVE the ceiling is dropped, not merely filtered. The tone
+      // filter is one pole: a bell's fourth partial on a 1.25 kHz voice sits at
+      // 5 kHz and comes through it at about −12 dB, which is quieter than the
+      // fundamental and still squarely inside the band that hurts. Dropping it
+      // is what makes "nothing pitched is brighter than `TONE_CEILING_HZ`" a
+      // statement about the oscillators rather than about an aspiration. The
+      // fundamental is never dropped — a voice must make a sound.
+      .filter((p, i) => i === 0 || hz * p.ratio <= TONE_CEILING_HZ)
+      .map((p) => ({
+        at: 0,
+        hz: hz * p.ratio,
+        glideTo: hz * p.ratio,
+        glideSeconds: 0,
+        peak: peak * p.level,
+        attack,
+        decay: Math.max(0.01, seconds - attack),
+        type: p.type,
+        toneHz,
+      }))
+  )
+}
+
+/**
+ * A building coming down — the founder's "building crumbling here instead of
+ * white noise".
+ *
+ * A noise burst is one event with no size to it, which is why it reads as hiss
+ * rather than as a thing. Rubble is MANY small impacts whose sizes follow a
+ * power law: grain `i` has size `1/(1+i)`, amplitude goes with size and pitch
+ * goes inversely with it, so a few big low ones and a lot of small high ones.
+ * **That distribution is the entire difference between "static" and
+ * "masonry"**, and it costs sixteen short oscillators.
+ *
+ * The onsets are scattered by an integer hash rather than by `Math.random`, so
+ * two collapses in the same session are the same shape — which is fine, because
+ * the pitch comes from the walker and the walker is what varies — and a test
+ * can assert the scatter.
+ */
+function rubbleGrains(hz: number, seconds: number, peak: number): readonly Grain[] {
+  const out: Grain[] = []
+  for (let i = 0; i < RUBBLE_GRAINS; i++) {
+    const size = 1 / (1 + i)
+    const at = (i / RUBBLE_GRAINS) * seconds * (0.5 + ((i * 7919) % 100) / 200)
+    // Small stones are quiet and high, big ones are loud and low. Capped so the
+    // brightest grain of the highest-pitched cloud still sits under 1.4 kHz.
+    const top = Math.min(RUBBLE_CEILING_HZ, hz * (0.7 + 1 / Math.max(0.12, size) / 6))
+    out.push({
+      at,
+      hz: top,
+      glideTo: hz * 0.6,
+      glideSeconds: 0.05,
+      peak: Math.max(0.0002, peak * size * 0.9),
+      attack: safeAttack(0.004),
+      decay: 0.04 + size * 0.12,
+      type: "triangle",
+      toneHz: RUBBLE_CEILING_HZ,
+    })
+  }
+  return out
+}
+
+/**
+ * The loudest a voice can be at any single instant, as the sum of everything
+ * sounding together.
+ *
+ * The honest measurement, and the reason it is not just `voice.gain`: a pitched
+ * voice's partials all start at once, so its real peak is their SUM and is
+ * larger than the gain the music module asked for. A rubble cloud's grains are
+ * staggered and decay in tens of milliseconds, so its real peak is much smaller
+ * than the sum of sixteen grains would suggest. Measuring one with the other's
+ * rule is how a cue that looks quiet on paper arrives loud.
+ */
+export function voicePeak(voice: PlayableVoice, scale = 1): number {
+  const grains = voiceGrains(voice, scale)
+  let worst = 0
+  for (const a of grains) {
+    // Every grain's own onset is a candidate instant: an envelope is monotone
+    // up then monotone down, so the maximum of a sum of them is at one of them.
+    const t = a.at + a.attack
+    let sum = 0
+    for (const b of grains) {
+      const start = b.at
+      const top = b.at + b.attack
+      const end = top + b.decay
+      if (t <= start || t >= end) continue
+      sum += t <= top ? (b.peak * (t - start)) / Math.max(1e-6, b.attack) : b.peak * (1 - (t - top) / Math.max(1e-6, b.decay))
+    }
+    if (sum > worst) worst = sum
+  }
+  return worst
+}
+
+/**
+ * The brightest OSCILLATOR anything in this voice runs.
+ *
+ * Deliberately not `min(toneHz, …)`. A one-pole low-pass does not remove what
+ * is above its corner, it attenuates it, so measuring a voice by its filter
+ * rather than by its oscillators would report 2.4 kHz for a cue with real
+ * energy at 5 — which is precisely the claim this is here to be able to make
+ * honestly. The only exception is the fundamental, which is never dropped
+ * because a voice has to make a sound; on the register `game-soundscape`
+ * publishes (≤1250 Hz) it is always under the ceiling anyway.
+ */
+export function voiceBrightestHz(voice: PlayableVoice, scale = 1): number {
+  let top = 0
+  for (const g of voiceGrains(voice, scale)) top = Math.max(top, g.hz, g.glideTo)
+  return top
+}
+
+/** The Web Audio a game needs for this, and nothing more. */
+export type VoiceContext = {
+  readonly currentTime: number
+  createGain(): GainNode
+  createOscillator(): OscillatorNode
+  createBiquadFilter(): BiquadFilterNode
+}
+
+/**
+ * Play one voice into `destination`.
+ *
+ * `destination` is the game's own master, which is already routed through
+ * `createSafetyBus` — this never reaches for `ctx.destination`, and the source
+ * scan in `routing.test.ts` is what keeps that true.
+ *
+ * `scale` is a `VoiceBudget` multiplier. 0 means "do not play this", and it is
+ * honoured by building nothing at all rather than by building a silent graph.
+ */
+export function playVoice(
+  ctx: VoiceContext,
+  destination: AudioNode,
+  voice: PlayableVoice,
+  scale = 1,
+): void {
+  if (scale <= 0) return
+  const t0 = ctx.currentTime + Math.max(0, voice.at)
+  // One low-pass over the whole voice, so the top of the register is never the
+  // brightest thing in the game.
+  const tone = ctx.createBiquadFilter()
+  tone.type = "lowpass"
+  tone.Q.value = voice.timbre === "rubble" ? 0.6 : 0.7
+  tone.connect(destination)
+  let toneHz = TONE_CEILING_HZ
+  for (const g of voiceGrains(voice, scale)) {
+    toneHz = g.toneHz
+    const at = t0 + g.at
+    const osc = ctx.createOscillator()
+    osc.type = g.type
+    osc.frequency.setValueAtTime(g.hz, at)
+    if (g.glideSeconds > 0 && g.glideTo !== g.hz) {
+      osc.frequency.exponentialRampToValueAtTime(Math.max(1, g.glideTo), at + g.glideSeconds)
+    }
+    const gain = ctx.createGain()
+    const attack = Math.max(MIN_ATTACK, g.attack)
+    gain.gain.setValueAtTime(0.0001, at)
+    gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, g.peak), at + attack)
+    gain.gain.exponentialRampToValueAtTime(0.0001, at + attack + g.decay)
+    osc.connect(gain)
+    gain.connect(tone)
+    osc.start(at)
+    osc.stop(at + attack + g.decay + 0.06)
+  }
+  tone.frequency.value = toneHz
+}

--- a/dynawalla/packs/shared/game-soundscape/melody.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/melody.test.ts
@@ -55,6 +55,8 @@ test("every note a game can cause is a degree of the live mode", () => {
     { kind: "levelComplete" },
     { kind: "refuse" },
     { kind: "arrive" },
+    { kind: "collapse" },
+    { kind: "collapse", weight: 0 },
   ]
   for (let seed = 0; seed < 60; seed++) {
     const s = scape(seed, seed % 2 === 0 ? 0 : 0.9)
@@ -84,6 +86,8 @@ test("every voice is inside the register and the loudness budget", () => {
     voices.push(...melody.emit({ kind: "failure" }))
     voices.push(...melody.emit({ kind: "refuse" }))
     voices.push(...melody.emit({ kind: "arrive" }))
+    voices.push(...melody.emit({ kind: "collapse" }))
+    voices.push(...melody.emit({ kind: "collapse", weight: 0 }))
     voices.push(...melody.emit({ kind: "success" }))
     for (const v of voices) {
       assert.ok(v.hz >= MELODY_MIN_HZ && v.hz <= MELODY_MAX_HZ, `${v.hz} Hz is outside the register`)
@@ -256,6 +260,73 @@ test("a refusal is low, short and modelled rather than noise", () => {
   assert.equal(v.timbre, "rubble")
   assert.ok(v.seconds < 0.5, "a refusal that long is a telling-off")
   assert.ok(v.hz < 300, `a refusal at ${v.hz} Hz is a beep, not a crumble`)
+})
+
+test("a building coming down is masonry, staggered, and never a note anyone chose", () => {
+  // The primitive this module did not have. A collapse is percussive and BIG,
+  // and the only thing a game could reach for was `refuse` — a shelf of brass —
+  // or, as TREBUCHET did, a band-passed noise burst in its own file.
+  for (let seed = 0; seed < 30; seed++) {
+    const melody = new Melody(scape(seed, seed % 2 === 0 ? 0 : 0.8))
+    const voices = melody.emit({ kind: "collapse" })
+    assert.ok(voices.length >= 2, `a collapse of ${voices.length} voice(s) lands all at once`)
+    for (const v of voices) {
+      assert.equal(v.timbre, "rubble", "a collapse must be modelled, never a noise burst")
+      assert.ok(v.hz < 400, `a collapse at ${v.hz} Hz is a beep, not a building`)
+    }
+    const [face, rest] = voices
+    assert.ok(face && rest)
+    assert.ok(rest.at > face.at, "the whole building landed in the same instant")
+    assert.ok(face.hz < rest.hz, "the heaviest part of the fall is not the lowest")
+  }
+})
+
+test("a collapse is sized by its weight and leaves the phrase alone", () => {
+  // Weight buys body, exactly as it does for `step` — and the walker is
+  // untouched, so a game that celebrates in the same breath still cadences.
+  const light = new Melody(scape(5))
+  const heavy = new Melody(scape(5))
+  for (let i = 0; i < 4; i++) {
+    light.emit({ kind: "step", direction: 1 })
+    heavy.emit({ kind: "step", direction: 1 })
+  }
+  const before = heavy.position
+  const small = light.emit({ kind: "collapse", weight: 0 })[0]
+  const big = heavy.emit({ kind: "collapse", weight: 1 })[0]
+  assert.ok(small && big)
+  assert.ok(big.seconds > small.seconds, "a keep falls no longer than a garden wall")
+  assert.ok(big.gain > small.gain, "a keep falls no heavier than a garden wall")
+  assert.equal(heavy.position, before, "the collapse moved the walker")
+})
+
+test("two collapses in the same key are not the same collapse", () => {
+  // The defect the whole module exists to end: "nothing that happens changes
+  // what the next sound is". A fall pinned to the tonic would be one fixed thud
+  // forever however long a child plays — and reading the walker instead is the
+  // same thud in any game whose other gestures all cadence home, which is why
+  // this drives ONLY collapses.
+  for (let seed = 0; seed < 20; seed++) {
+    const melody = new Melody(scape(seed))
+    const heard = new Set<number>()
+    for (let i = 0; i < 14; i++) {
+      const v = melody.emit({ kind: "collapse" })[0]
+      assert.ok(v)
+      heard.add(Math.round(v.hz * 100))
+    }
+    assert.ok(heard.size >= 2, `seed ${seed}: fourteen collapses were all the same pitch`)
+  }
+})
+
+test("a collapse is reproducible from the seed", () => {
+  // It consumes randomness, so it must consume it deterministically — otherwise
+  // a reported bug cannot be replayed.
+  const a = new Melody(scape(4))
+  const b = new Melody(scape(4))
+  for (let i = 0; i < 8; i++) {
+    assert.deepEqual(a.emit({ kind: "collapse" }), b.emit({ kind: "collapse" }))
+    a.emit({ kind: "step", direction: 1 })
+    b.emit({ kind: "step", direction: 1 })
+  }
 })
 
 test("a failure is warm and never a buzzer", () => {

--- a/dynawalla/packs/shared/game-soundscape/melody.ts
+++ b/dynawalla/packs/shared/game-soundscape/melody.ts
@@ -106,6 +106,28 @@ export type Gesture =
   | { readonly kind: "levelComplete" }
   /** An input was declined — too soon, not allowed, nothing there. */
   | { readonly kind: "refuse" }
+  /**
+   * A STRUCTURE CAME DOWN. Masonry, not a noise burst.
+   *
+   * `refuse` is the small version of this — a shelf going over — and it is what
+   * the module had. A siege game knocking a stone keep off a field needs the
+   * big one, and until this existed the only way to make it was a white-noise
+   * burst in the game's own file, which is the exact sound the founder called
+   * out: *"the building destroyed is a bit white noise instead of a nice
+   * building crumbling sound"*. A gesture, not a recipe: the `rubble` timbre
+   * already carries the recipe (`SOUNDSCAPE_DESIGN_2026-07.md`), and this says
+   * how big the thing that fell was and on which degrees it lands.
+   *
+   * `weight` is 0..1 — a garden wall at 0, a keep at 1. It buys length and body
+   * and nothing else, exactly as it does for `step`.
+   *
+   * It does NOT move the walker. A building falling over is not a note anybody
+   * chose, so a phrase in progress carries on across it rather than being
+   * reset — which matters here because the game that knocks a keep down is
+   * usually celebrating in the same breath, and the cadence belongs to the
+   * `success` that follows.
+   */
+  | { readonly kind: "collapse"; readonly weight?: number }
   /** Something appeared, arrived, or was laid out. */
   | { readonly kind: "arrive" }
   /** Wind the soundscape up. Silent in itself; the bed and the melody change. */
@@ -147,6 +169,17 @@ export const MELODY_MAX_HZ = 1250
  */
 const TOP_OCTAVE = 2
 const REGISTER_SPAN = 3
+
+/**
+ * The heaviest band there is — the one a full-weight `step` already lands in.
+ *
+ * Named rather than written as `-1` because `collapse` reaches for it too, and
+ * a second literal is how the two would drift apart. Nothing may go below it:
+ * the "nothing is ever folded" claim in `melody.test.ts` is a claim about
+ * exactly four bands, and a fifth would put the bottom one under
+ * `MELODY_MIN_HZ` on the lowest roots.
+ */
+const BOTTOM_OCTAVE = TOP_OCTAVE - REGISTER_SPAN
 
 /** How much one `moreTension` or `lessTension` moves the dial. */
 export const TENSION_STEP = 0.18
@@ -254,6 +287,8 @@ export class Melody {
         return this.flourish()
       case "refuse":
         return this.crumble()
+      case "collapse":
+        return this.fall(gesture.weight ?? 1)
       case "arrive":
         return this.bloom()
       case "moreTension":
@@ -384,6 +419,58 @@ export class Melody {
   /** A shelf of brass going over. Low, brief, and not a note anyone chose. */
   private crumble(): readonly Voice[] {
     return [{ hz: this.pitch(0, 0), at: 0, seconds: 0.34, gain: 0.09, timbre: "rubble" }]
+  }
+
+  /**
+   * A building coming down. `crumble` with a size to it, and the size is heard.
+   *
+   * TWO rubble clouds rather than one, staggered, and that is what makes it a
+   * building rather than a bigger shelf: the first is the face going, in the
+   * heaviest band, and the second is the rest of it arriving a beat later a
+   * register up, the way real masonry does not land all at once. Both are
+   * degrees of the live mode, so the whole event is still in tune with the
+   * drone even though nothing in it is a note.
+   *
+   * Long, low and unhurried at full weight — 1.2 s at the bottom of the
+   * register, which is the opposite of the 300 ms of band-passed hiss it
+   * replaces.
+   *
+   * **It lands on a resting degree DRAWN each time, and does not move the
+   * walker.** Pinning it to the tonic was tried first and is wrong for the
+   * reason the whole module exists: a fixed low thud forever is exactly
+   * "nothing that happens changes what the next sound is", and a siege game
+   * knocks down five keeps a minute. Reading the walker's live degree instead
+   * was tried second and is wrong too — in a game whose only other gestures are
+   * `success` and `failure`, both of which cadence home, the walker is at the
+   * tonic every single time it is asked.
+   *
+   * So the draw comes off this walker's own seeded stream, weighted to the
+   * tonic the way `resolve` weights a cadence. It is consonant by construction,
+   * different from one keep to the next, and reproducible from the seed. It
+   * does consume randomness, so a collapse does change the phrase that follows
+   * it — which is the property this module is for, not a side effect of it.
+   */
+  private fall(weight: number): readonly Voice[] {
+    const w = clamp01(weight)
+    const mode = modeOf(this.scape)
+    const rest = mode.rest
+    const landing = rest[this.rng.weighted(rest.map((_, i) => (i === 0 ? 3 : 1)))] ?? 0
+    return [
+      {
+        hz: this.pitch(landing, BOTTOM_OCTAVE),
+        at: 0,
+        seconds: 0.55 + w * 0.65,
+        gain: 0.085 + w * 0.045,
+        timbre: "rubble",
+      },
+      {
+        hz: this.pitch(mode.rest[1] ?? 2, BOTTOM_OCTAVE + 1),
+        at: 0.13 + w * 0.09,
+        seconds: 0.4 + w * 0.45,
+        gain: 0.045 + w * 0.03,
+        timbre: "rubble",
+      },
+    ]
   }
 
   /** Something was laid out. The tonic, breathed in rather than struck. */


### PR DESCRIPTION
Two defects in TREBUCHET, **this game only**.

## 1 — the miss-reveal did not exist for the first eight waves

The fleet reveal-patience audit (#748) found it and the code agrees.

`waveConfig` sets `banners: true` for waves 1–8, and the entire reveal was one
expression in `drawTower`:

```ts
ctx.fillStyle = reveal && !showBanner ? C.bannerWanted : C.banner
```

With `showBanner` already true, `reveal` could not change a pixel. The geometry
was already drawn, the number was already on the screen, and the reveal redrew
the same banner in the same colour in the same place. **A child's whole first
session had no correction in it at all.**

It was also lighting the wrong keeps. `revealT` lit the keeps still `wanted`,
and `markWanted()` runs *after* `b.spent = true` — so the keep she had just
missed is the one keep guaranteed to be excluded.

And nothing stopped: the ram advanced through `settle` (`ramAdvances` allows
it), the settle clock ran, and the wave moved on after 1.6 s whether or not she
had read anything.

### What it does now

* **A miss completes the sum in front of her.** `7 × 8 = 56` on the plaque she
  is already reading — the most legible thing on the screen — in the accent
  (`C.fire1`). Never red, never a cross, no word anywhere. `games/stack` is the
  reference; `src/reveal.ts` fills a `□` blank where the host wrote one and
  appends `= answer` where it did not, because a `String.replace` that matches
  nothing is how `stack` shipped a reveal that revealed nothing.
* **The keep she was aiming at lights up** out on the field — lifts, recolours
  and takes an accent rim — whether or not it was already flying a banner.
* **Nothing advances underneath it.** One gate: `if (this.stopped) { … return }`.
  Below it are the phase clock, the dial repeat, the phase machine, the
  counter-fire and the ram. Above it is dust, the camera, and the reveal's own
  two clocks.
* **It never expires.** `revealPlan(SECOND_GRADE_FLOW, q.difficulty)` gives
  `holdMs: Infinity`, and the single mechanism honouring that is that no expiry
  is written. `settleMs` (350 ms) is the input lockout, which is latency and not
  pedagogy.
* **Adaptation moved from the length to the existence.** Above intensity ≈0.75
  `revealPlan` gives `holdMs: 0`, there is no reveal, and the game carries
  straight on — skipping the ceremony is the reward for mastery.
* **The dismissing gesture is spent on the dismissal.** A tap or a key takes the
  sum down and does nothing else. Winding the dial and firing were already
  phase-gated, but tapping a rack stone and pressing `1`–`5` were not, and
  either would have swapped the loaded question *and* restarted the answer
  clock.

### Two mechanisms enforcing one rule — caught, in this PR

The audit's own author warned about this and I built it anyway. The first draft
guarded `this.phaseT += rawDt` separately from the gate, and the two
independently froze the phase machine. **Mutation M3 deleted the entire gate and
all 163 tests stayed green.** `phaseT` now advances below the gate and nowhere
else; M3 re-run fails.

Same trap, second instance: the renderer recomputed "is this the keep she
wanted" instead of reading `t.reveal`. **M12 changed the update loop's condition
and nothing failed.** The renderer now reads `t.reveal > 0`, and there is one
place that decides.

### Timeouts

TREBUCHET has no clock, and that is the property to keep. `there is no clock: a
child who is only thinking is never marked` drives 900 idle frames on a wave
with a ram and asserts no report, no reveal and no ram movement. `a reveal
happens exactly when a wrong ANSWER was reported, over a whole run` drives eight
alternating shots and asserts the two line up in both directions. A boulder the
ram swallows is `report: false` at the unit level already (`verdict.test.ts`).

## 2 — the sound

> *"the building destroyed is a bit white noise instead of a nice building
> crumbling sound … maybe a whole pass on making the sound effects more premium
> (and chillaxed in most cases) .. they tend to be a bit abrasive .. maybe lower
> pitched in a lot of cases."*

**A keep coming down is masonry now.** `collapse()` was seven band-passed noise
bursts under a sine. A noise burst is one event with no size to it, which is why
it reads as hiss. It is the shared rubble recipe — sixteen graded impacts, sizes
`1/(1+i)`, amplitude with size and pitch inversely with it, scattered onsets, the
whole cloud under 1.4 kHz. **The collapse now contains no noise source at all**,
and `audio.test.ts` counts.

Everything else came down with it — measured, not asserted:

| cue | was | is |
|---|---|---|
| winch tick (fires up to 26×/s) | 900–2400 Hz @ 0.16 | 240–700 Hz @ 0.075 |
| stone crack ×3 | band-pass 1400–3600 Hz | 520–1500 Hz, −35% level |
| ground impact noise | low-pass opens at 2400 Hz | opens at 1100 Hz |
| rope whoosh | sweeps to 4000 Hz | sweeps to 1400 Hz |
| flight whistle | 300–1200 Hz | 170–620 Hz |
| incoming shell | opens at 1500 Hz | opens at 760 Hz |
| wrong horn | sawtooth @ 174 Hz | triangle @ 146 Hz |
| wave horn | sawtooth @ 110 Hz | triangle @ 98 Hz |
| master trim | 0.62 | 0.52 |

**Loudness, measured at the output.** The loudest single cue is the ground
impact of a full-power shot: **0.333 linear (≈ −9.5 dBFS), down from 0.465
(≈ −6.6)**. Asserted at ≤ 0.36, which is a quarter of the −1 dBFS the safety bus
would ever intervene at, so the limiter is still doing nothing in normal play.

**The shared soundscape, where it fits.** The four cues that are music rather
than physics ask the walker what they sound like: the reward (`success`), the
sour horn (`failure` — a bloom, never a buzzer), the wave horns (`arrive` /
`levelComplete`) and the collapse. The winch tick deliberately does **not** go
through it — the dial repeats at 26 notches a second and a melodic bell per
notch is a swarm, not a phrase. With no soundscape published the game keeps its
own (lowered) cues rather than going quiet.

### Two primitives added to the shared modules rather than privately

Both are called out because the brief asked for it.

1. **`game-soundscape` gains a `collapse` gesture.** The module has no
   percussion, and the only rubble in the vocabulary was `refuse` — a shelf of
   brass, 340 ms. A building is a different event and a siege game had no way to
   say so, which is exactly why TREBUCHET said it in white noise in its own file.
   `{ kind: "collapse", weight }` is two staggered rubble clouds in the bottom
   two registers, landing on a resting degree drawn from the walker's own seeded
   stream — so five keeps a minute are not five identical thuds — and it does not
   move the walker, because the `success` that follows owns the cadence.
2. **`game-audio` gains `voices.ts`** — the synthesis for a soundscape voice,
   including the rubble recipe. It existed only inside
   `games/counterweight/src/audio.ts`, where the second pack to adopt the
   soundscape could only copy it. `voiceGrains` is pure, so loudness and
   brightness are measured without an `AudioContext`. **Counterweight is
   deliberately untouched** (`this game only`); its private copy is now a
   duplicate and the follow-up is noted in `SOUNDSCAPE_DESIGN_2026-07.md` — its
   rubble path drops the `VoiceBudget` scale, which the shared one does not.

While measuring, one real bug surfaced in the extracted recipe: a `bell`'s fourth
partial on a 1.25 kHz voice sits at **5 kHz**, and a one-pole low-pass attenuates
rather than removes. Partials above `TONE_CEILING_HZ` are now dropped (never the
fundamental), so "nothing pitched is brighter than 2.4 kHz" is a statement about
oscillators instead of an aspiration.

## Verification

* `npm run -s tsc` clean; **suite 5× consecutively, 168/168 each time** (was 134).
* `node packs/build.mjs trebuchet` builds and passes the SDK checker.
* Dependents re-run green: `game-audio` 87, `game-soundscape` 61, `game-chrome`
  56, `game-host` 61, `counterweight` 165, `pulse` 145.
* Every new test drives the **real** `TrebuchetGame` on the real clock through
  the real listeners. **Every loop is bounded and the bound is asserted** — a
  held-forever beat makes an unbounded drive loop immortal, and the failure mode
  is a job that hangs and reports nothing.
* The reveal is asserted to exist **on wave 1**, which is precisely where it did
  not.

### Mutation transcript

Every new assertion broken, confirmed FAILING, restored. Two survivors are listed
because they found real holes and are recorded above.

| # | mutation | result |
|---|---|---|
| M1 | the reveal is never raised | ✗ 8 fail — `a miss on wave 1 showed the child nothing` |
| M2 | the reveal expires on a 1.6 s timer | ✗ `the reveal took itself down inside 600 frames` |
| M3 | the `stopped` gate deleted | **SURVIVED (163/163)** → found the double mechanism; after the fix: ✗ `the phase machine ran under the reveal` |
| M4b | the ram alone let out from under the reveal | ✗ `the ram rolled while the child was reading` |
| M5 | a hand no longer takes it down | ✗ 4 fail — `a hand on the glass did not take the sum down` |
| M7 | the settle lockout removed | ✗ `frame 0: a tap inside the settle window dismissed it` |
| M8 | the dismissing tap falls through | **SURVIVED** (phase-gating masked it) → test rewritten onto the rack path; ✗ `a tap at x=251 loaded a different boulder` |
| M8k | the dismissing key falls through | ✗ `the dismissing key also loaded a different boulder` |
| M9 | mastery is held for the lesson anyway | ✗ `a child at the top of the ladder was held for a lesson` |
| M10 | a correct answer is held too | ✗ 5 fail — `a correct answer put a correction on the glass` |
| M11 | the sum is echoed, not completed | ✗ 4 fail — `the reveal "78 + 10" does not contain the answer 88` |
| M11b | the blank is never filled | ✗ 3 fail |
| M12 | the reveal lights the wanted keeps, as it used to | **SURVIVED** → `litKeeps()` added, renderer unified; ✗ `the wrong keeps are lit out on the field` |
| M13 | a stale reveal survives a wave change | ✗ `a stale sum survived into the next wave` |
| M14 | the banner colour ignores the reveal again | ✗ `a lit keep on wave 1 is drawn in the ordinary banner colour` |
| M15 | the reveal string is not put on the HUD | ✗ 10 fail |
| M16 | no banner drawn on the later waves | ✗ `the reveal drew no banner with banners off` |
| M17 | a levelled keep keeps its banner | ✗ `a levelled keep still flies a banner` |
| M18 | the game never restarts after dismissal | ✗ 38 fail |
| M19 | the lit keep never glows | ✗ `a lit keep has no accent on it` |
| A1 | winch tick back to 2.4 kHz | ✗ `a cue reaches 2408.4 Hz` |
| A2 | stone crack back to 3.6 kHz | ✗ `a cue reaches 3558.4 Hz` |
| A3 | the collapse is made of noise again | ✗ `the collapse still uses 1 noise source(s)` |
| A4 | master trim back to 0.62 | ✗ `a plain cue reaches the output at 0.397` / `the master trim is 0.62` |
| A5 | ground impact back to its old level | ✗ `a plain cue reaches the output at 0.390` |
| A6 | mute stops being honoured by one cue | ✗ 12 fail — `a muted game still built oscillators` |
| A7 | a cue added and never measured | ✗ `` `fanfareTwo` is a cue that nothing in this file plays or measures `` |
| A8 | the soundscape is ignored | ✗ 7 fail — `twelve keeps fell on exactly the same pitches` |
| A9 | losing the key silences the game | ✗ `with no soundscape the reward is silent` |
| V1 | the partial cap removed | ✗ `bell at 880 Hz reaches 3520 Hz` |
| V2 | every rubble grain the same size | ✗ `grain 1 is not smaller than grain 0` |
| V3 | the rubble ceiling lifted | ✗ `1250 Hz produced a grain at 1500 Hz` |
| V4 | a collapse lands all in one instant | ✗ 3 fail — `the whole building landed in one instant` |
| V5 | a high voice loses its fundamental too | ✗ `bell at 4 kHz was silenced entirely` |
| V6 | a spent voice budget still builds nodes | ✗ `a spent budget still built oscillators` |
| S1 | a collapse is one voice | ✗ `a collapse of 1 voice(s) lands all at once` |
| S2 | a collapse is a struck bell | ✗ `a collapse must be modelled, never a noise burst` |
| S3 | the fall pinned to the tonic | ✗ `seed 0: fourteen collapses were all the same pitch` |
| S4 | the collapse moves the walker | ✗ `the collapse moved the walker` |
| S5 | weight buys nothing | ✗ `a keep falls no longer than a garden wall` |
| S6 | the collapse draws from a fresh stream | ✗ `a collapse is reproducible from the seed` |

One more control worth naming: the two dismissal tests each carry a **positive
control** — a sweep that proves it actually lands on a rack stone, and a key
press that proves `1`–`5` really do select — because a sweep that hit nothing
would satisfy the guarded case for the wrong reason.

## Not touched

`sim/`, ballistics, the wind, `verdict.ts`, `world.ts` — another agent owns
those. `games/counterweight` and every other pack are untouched.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb