### PR TITLE
dynawalla/games/trebuchet: the wind was smaller than the blast, so it hit the right keep and marked you wrong

### DIFF
--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -1092,6 +1092,15 @@ test('a miss in a wind stops the siege, and hands the wind back when she is read
   assert.ok(runUntil(game, () => reports.length > 1), 'the next shot never resolved')
   assert.equal(reports[1].correct, true, 'the shot after a miss was scored wrong')
   assert.equal(cells.get('dw.trebuchet.felled'), String(FLUENT + 1), 'the keep she felled bought nothing')
+
+  // And across the wave boundary, which is the only place the loss would show.
+  // `windCap` is read once per wave, so a miss that quietly spent the count would
+  // leave this wave blowing exactly as before and take the wind away at the NEXT
+  // one — a mechanic disappearing a minute after the thing that cost her it.
+  assert.ok(dismissReveal(game, canvas), 'a reveal was left standing')
+  game.jumpToWave(4)
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), 'the next wave never stocked')
+  assert.equal(game.currentWindCap(), WIND_MAX, 'the wind was gone by the next wave')
 })
 
 test('the wind arrives because she FELLED KEEPS, and only then', () => {

--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -16,6 +16,43 @@ import test from 'node:test'
 import type { Host, Question } from './contract.ts'
 import { TrebuchetGame } from './game.ts'
 import { hudLayout } from './render/hud.ts'
+import { resetFelledForTest } from './sim/felled.ts'
+import { WIND_MAX, WIND_MIN, WIND_STEPS } from './sim/world.ts'
+
+/**
+ * The felled keeps this device remembers, set to whatever the test needs.
+ *
+ * The wind is bought with keeps felled and the count is persisted, so a test that
+ * wants the windy game has to say what this child has already done — and a test
+ * that wants the beginner's game has to say she has done nothing. Both go through
+ * the REAL storage the game reads, so the read side is exercised rather than
+ * reached round.
+ */
+function seedFelled(n: number): Map<string, string> {
+  const cells = new Map<string, string>()
+  const g = globalThis as unknown as Record<string, unknown>
+  g.localStorage = {
+    getItem: (k: string) => cells.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      cells.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      cells.delete(k)
+    },
+    clear: () => cells.clear(),
+    key: () => null,
+    get length() {
+      return cells.size
+    },
+  }
+  if (n > 0) cells.set('dw.trebuchet.felled', String(n))
+  resetFelledForTest()
+  return cells
+}
+
+/** The first step of the wind ramp, and the top of it, read off the ramp itself. */
+const FIRST_WIND = WIND_STEPS[1].felled
+const FLUENT = WIND_STEPS[WIND_STEPS.length - 1].felled
 
 /* ---------------------------------------------------------------- the glass */
 
@@ -69,8 +106,17 @@ function stubElement(tag: string, w: number, h: number): Record<string, unknown>
 
 const VIEW = { w: 1024, h: 768 }
 
-/** Installs a canvas-shaped world on `globalThis`. Returns the mount element. */
+/**
+ * Installs a canvas-shaped world on `globalThis`. Returns the mount element.
+ *
+ * It resets the felled-keep count too, and it has to: the count lives in module
+ * scope behind a `localStorage` slot, so a test that fells twelve keeps leaves
+ * every test after it in this file starting on the windy game. Eleven tests build
+ * a `TrebuchetGame` directly rather than through `newGame`, and none of them are
+ * about the wind — they would have been silently handed one.
+ */
 function installDom(): { el: HTMLElement; canvas: Record<string, unknown> } {
+  seedFelled(0)
   const created: Array<Record<string, unknown>> = []
   const g = globalThis as unknown as Record<string, unknown>
   g.document = {
@@ -108,10 +154,9 @@ type Reported = { questionId: string; correct: boolean; ms: number; answered: st
 /**
  * A host that serves the answers it is given, on the rung it is told to.
  *
- * The rung matters now: `windCapFor` reads the item's own difficulty to decide
- * whether the wind blows, so a test that wants the beginner's game asks for an easy
- * rung and a test that wants the wind asks for a harder one. Nothing here is a wave
- * number.
+ * The rung no longer decides whether the wind blows — `seedFelled` does, because
+ * the wind is bought with right answers rather than handed over when the curriculum
+ * ladder drifts. The difficulty here is what the questions are, and nothing else.
  */
 function recordingHost(answers: number[], difficulty = 0.4): { host: Host; reports: Reported[] } {
   const reports: Reported[] = []
@@ -163,11 +208,16 @@ function newGame(
   answers: number[],
   wave: number,
   difficulty = 0.4,
+  felled = 0,
 ): ReturnType<typeof installDom> & {
   game: TrebuchetGame
   reports: Reported[]
+  /** The storage the game's felled-keep count is written into. */
+  cells: Map<string, string>
 } {
+  // `installDom` clears the count; the seed goes on after it, not before.
   const dom = installDom()
+  const cells = seedFelled(felled)
   const { host, reports } = recordingHost(answers, difficulty)
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   game.manualDrive()
@@ -177,7 +227,7 @@ function newGame(
   // exists for: `phase` reached 'aim' happily with no boulder and no question,
   // and every assertion below it read -1 and passed anyway.
   assert.notEqual(game.currentAnswer(), -1, 'the wave became playable with an empty rack')
-  return { ...dom, game, reports }
+  return { ...dom, game, reports, cells }
 }
 
 /**
@@ -559,11 +609,12 @@ test('the arithmetic creeps up with the waves and never off the field', () => {
 })
 
 test('a bullseye stays a bullseye when the dial is nudged mid-flight', () => {
-  // Wave 8: wind up to ±5, and the +/- buttons are not phase-gated, so a child
-  // fidgeting with the dial while the boulder is in the air used to have her
-  // answer re-read at impact — a keep hit dead centre, scored wrong, and the
-  // nudged number sent to the curriculum as what she said.
-  const { game, canvas, reports } = newGame([42, 60, 78, 96], 8)
+  // A fluent child, so there IS a wind and the dial is a different number from her
+  // answer — the +/- buttons are not phase-gated, so a child fidgeting with the
+  // dial while the boulder is in the air used to have her answer re-read at impact:
+  // a keep hit dead centre, scored wrong, and the nudged number sent to the
+  // curriculum as what she said.
+  const { game, canvas, reports } = newGame([42, 60, 78, 96], 8, 0.4, FLUENT)
   const answer = game.currentAnswer()
   assert.ok(game.towerRanges().includes(answer), 'the answer must have a keep')
 
@@ -584,7 +635,7 @@ test('a bullseye stays a bullseye when the dial is nudged mid-flight', () => {
 test('a wrong dial stays wrong when it is corrected mid-flight', () => {
   // The mirror: turning the dial onto the answer after the boulder has gone must
   // not buy the answer, and must not blow up a keep the shot never went near.
-  const { game, reports } = newGame([42, 60, 78, 96], 8)
+  const { game, reports } = newGame([42, 60, 78, 96], 8, 0.4, FLUENT)
   const standing = game.towerRanges()
   // A metre with no keep on it and none within blast range.
   const wrong = standing.reduce((a, b) => Math.max(a, b), 0) + 4
@@ -662,16 +713,17 @@ test('the whole rack can be answered without a false verdict', () => {
 /* ------------------------------------------------------- the wind, at the mount */
 
 test('the beginner never meets a wind, and dialling the answer is enough', () => {
-  // The founder is not complaining about the low end and it must not move. A rung
-  // of two-digit tables and no-regroup column sums — d=0.28, which is where the
-  // game's own search opens — has no wind on it at all, on any wave, however long
-  // the child plays. And the whole promise still holds: work the sum, wind the dial
-  // to that number, the keep comes down.
-  const { game, canvas, reports } = newGame([42, 60, 78, 96], 3, 0.28)
+  // The founder is not complaining about the low end and it must not move. A child
+  // who has not yet put a boulder on the metre gets no wind at all, on any wave,
+  // however long she plays — and, now, however hard the arithmetic she is served.
+  // That last clause is the change: the wind used to arrive because the ladder had
+  // moved, so a child who had never felled a keep could be handed a second
+  // arithmetic step for reasons that were nothing to do with her.
+  const { game, canvas, reports } = newGame([42, 60, 78, 96], 3, 0.95, 0)
   for (const wave of [1, 3, 6, 9, 14, 20]) {
     game.jumpToWave(wave)
     assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${wave} never stocked`)
-    assert.equal(game.currentWindCap(), 0, `wave ${wave} put a wind on a beginner's rung`)
+    assert.equal(game.currentWindCap(), 0, `wave ${wave} put a wind on a child who has felled nothing`)
     assert.equal(game.currentWind(), 0, `wave ${wave} is blowing`)
   }
   const answer = game.currentAnswer()
@@ -682,7 +734,7 @@ test('the beginner never meets a wind, and dialling the answer is enough', () =>
   assert.equal(reports[0].correct, true, 'the beginner dialled her answer and was marked wrong')
 })
 
-test('on a harder rung the wind decides the shot: ignoring it misses, taking it off lands', () => {
+test('once she has bought it the wind decides the shot: ignoring it misses, taking it off lands', () => {
   // The founder's actual question — "are we supposed to shoot it longer, shorter,
   // ignore it?" — answered through the real fire button rather than in `sim/`.
   //
@@ -690,9 +742,9 @@ test('on a harder rung the wind decides the shot: ignoring it misses, taking it 
   // the wind is wrong, and is recorded as having answered the metre the boulder
   // reached. The one who takes the wind off her answer first is right. That is the
   // whole of "the wind does something".
-  const ignoring = newGame([42, 60, 78, 96], 6, 0.55)
+  const ignoring = newGame([42, 60, 78, 96], 6, 0.55, FLUENT)
   const cap = ignoring.game.currentWindCap()
-  assert.ok(cap >= 3, `a rung at d=0.55 must have a wind; cap is ${cap}`)
+  assert.ok(cap >= WIND_MIN, `a fluent child must meet a wind; cap is ${cap}`)
   const wind = ignoring.game.currentWind()
   assert.notEqual(wind, 0, 'a wind of zero is not a wind')
   const answer = ignoring.game.currentAnswer()
@@ -711,7 +763,7 @@ test('on a harder rung the wind decides the shot: ignoring it misses, taking it 
     'the keep she failed to allow for must still be standing',
   )
 
-  const thinking = newGame([42, 60, 78, 96], 6, 0.55)
+  const thinking = newGame([42, 60, 78, 96], 6, 0.55, FLUENT)
   const answer2 = thinking.game.currentAnswer()
   thinking.game.aimAt(correctDial(thinking.game))
   tap(thinking.canvas, 'fire')
@@ -725,8 +777,8 @@ test('the dial reaches every compensation the wind can ask for', () => {
   // A correct answer she cannot physically enter is the same defect as a correct
   // answer scored wrong. The dial's stops move with the wind (`dialRange`), so this
   // drives the REAL `setDial` through `aimAt` and checks the number stuck.
-  const { game } = newGame([14, 40, 72, 100, 118], 6, 1)
-  assert.equal(game.currentWindCap(), 9, 'the top of the ladder must blow its hardest')
+  const { game } = newGame([14, 40, 72, 100, 118], 6, 1, FLUENT)
+  assert.equal(game.currentWindCap(), WIND_MAX, 'the top of the ramp must blow its hardest')
   for (let shot = 0; shot < 40; shot++) {
     if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim')) break
     const answer = game.currentAnswer()
@@ -751,7 +803,7 @@ test('the wind does not move between the question appearing and the boulder land
   //
   // Sampled every frame from the moment the question is on the glass to the moment
   // the host is told, rather than at two moments — the two moments are the easy part.
-  const { game, reports } = newGame([42, 60, 78, 96], 6, 0.55)
+  const { game, reports } = newGame([42, 60, 78, 96], 6, 0.55, FLUENT)
   for (let shot = 0; shot < 6; shot++) {
     if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim')) break
     const answer = game.currentAnswer()
@@ -788,6 +840,7 @@ test('the manual is raised the first time the wind blows, and only then', () => 
   // `guide.open()`; here it is a counter, so the rule "exactly once a run" is a test
   // and not a comment.
   const dom = installDom()
+  seedFelled(FLUENT)
   const { host } = recordingHost([42, 60, 78, 96], 0.55)
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   let raised = 0
@@ -808,7 +861,7 @@ test('the manual is raised the first time the wind blows, and only then', () => 
 })
 
 test('the manual is never raised on a run that has no wind in it', () => {
-  // The mirror. A child on the beginner's rungs must not have a panel about wind
+  // The mirror. A child who has not bought the wind must not have a panel about it
   // thrown at her; there is no wind, so there is nothing to explain.
   const dom = installDom()
   const { host } = recordingHost([42, 60, 78, 96], 0.28)
@@ -830,8 +883,8 @@ test('a whole windy rack can be answered without one false verdict', () => {
   // Perfect play on a rung the wind is blowing on: every report correct, every
   // report the answer to the SUM and not the number on the dial, and every keep she
   // named on the ground.
-  const { game, reports } = newGame([42, 60, 78, 96, 30, 110], 6, 0.55)
-  assert.ok(game.currentWindCap() > 0, 'this rung must have a wind on it')
+  const { game, reports } = newGame([42, 60, 78, 96, 30, 110], 6, 0.55, FLUENT)
+  assert.ok(game.currentWindCap() > 0, 'a fluent child must meet a wind')
   const named: number[] = []
   const dials: number[] = []
   for (let shot = 0; shot < 12; shot++) {
@@ -882,33 +935,102 @@ test('the loft lever is gone, and nothing took its place in the corner', () => {
   assert.equal(game.stats().dial, before, 'the bottom-left corner moved the dial')
 })
 
-test('the wind arrives because the LADDER moved, not because waves went by', () => {
-  // Driven by `ladderHost`, which is the measured shape of the shipped ladder —
-  // quantised requests, non-monotonic answer magnitudes, a lagging pool. The game
-  // opens its search at 0.28, which serves two-digit tables and no-regroup column
-  // sums, and climbs a notch a wave.
+test('only a felled keep buys the wind — a miss buys nothing, and buys it back too', () => {
+  // The currency has to be the thing it claims to be, or the ramp is indexed on
+  // something else wearing its name. A keep on the ground is a sum worked out and a
+  // boulder put on the metre; a miss is not, and must move nothing.
   //
-  // Two things have to be true at once, and a wave counter can only ever manage one
-  // of them: the opening waves are windless, AND the wind does eventually arrive.
+  // And the second half is what makes the TOP step reachable. A first draft counted
+  // only still-air kills, and a child playing perfectly froze at fifteen: the
+  // currency stopped being earnable the moment she crossed the first threshold, so
+  // the wider wind could never arrive. A keep felled in a wind counts too.
+  {
+    const { game, canvas, reports, cells: still } = newGame([42, 60, 78, 96], 3, 0.4, 0)
+    assert.equal(game.currentWind(), 0, 'this half of the test needs still air')
+    // A miss first: two metres short, which is a wrong answer and buys nothing.
+    game.aimAt(game.currentAnswer() - 2)
+    tap(canvas, 'fire')
+    assert.ok(runUntil(game, () => reports.length > 0), 'nothing was reported')
+    assert.equal(reports[0].correct, false)
+    assert.equal(still.get('dw.trebuchet.felled'), undefined, 'a miss bought progress')
+    // Then a hit.
+    assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the next boulder never loaded')
+    game.aimAt(game.currentAnswer())
+    tap(canvas, 'fire')
+    assert.ok(runUntil(game, () => reports.length > 1), 'the second shot never resolved')
+    assert.equal(reports[1].correct, true)
+    assert.equal(still.get('dw.trebuchet.felled'), '1', 'a felled keep bought nothing')
+  }
+
+  // And the same perfect play in a wind, from a child on the first step of the ramp:
+  // it has to keep counting, or the second step is unreachable.
+  {
+    const { game, canvas, reports, cells: windy } = newGame([42, 60, 78, 96], 3, 0.4, FIRST_WIND)
+    assert.notEqual(game.currentWind(), 0, 'this half of the test needs a wind')
+    game.aimAt(correctDial(game))
+    tap(canvas, 'fire')
+    assert.ok(runUntil(game, () => reports.length > 0), 'nothing was reported')
+    assert.equal(reports[0].correct, true, 'the compensated shot was scored wrong')
+    assert.equal(
+      windy.get('dw.trebuchet.felled'),
+      String(FIRST_WIND + 1),
+      'a keep felled in a wind bought nothing, so the top step can never arrive',
+    )
+  }
+})
+
+test('the wind arrives because she FELLED KEEPS, and only then', () => {
+  // The founder's second complaint, end to end through the real fire button.
+  //
+  // It used to arrive because the LADDER had moved. That sounds like the same thing
+  // and it is not: `stock()` sweeps for a rung whose answers fit on 122 metres and
+  // wraps when it runs out, so the difficulty served oscillates. Measured on
+  // `origin/main` over five seeds through this same `ladderHost`, the cap by wave
+  // came out 0,0,0,3,3,4,4,0,0,0,0,0,0,3,3,4,4,0,0,0 — the wind switched on at
+  // wave 4, OFF at wave 8, back at 14 and off again at 18, for reasons entirely
+  // invisible from where the child is sitting and none of which were anything she
+  // did.
+  //
+  // So this plays the game properly, wave after wave, and watches for the moment
+  // the rule changes. Two things have to be true at once and a wave counter can
+  // only ever manage one of them: she is windless until she has demonstrated the
+  // one-step game, AND the wind does arrive once she has.
   const dom = installDom()
   const { host } = ladderHost()
   const game = new TrebuchetGame(dom.el, host, 0xb01de)
   game.manualDrive()
   assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'wave 1 never stocked')
-  const opened = game.stockedDifficulty()
-  assert.ok(opened !== null && opened < 0.34, `the search opened at ${opened}, above the threshold`)
   assert.equal(game.currentWindCap(), 0, 'a child on her first wave was handed a wind')
 
-  const caps: number[] = [game.currentWindCap()]
-  for (let wave = 2; wave <= 14; wave++) {
-    game.jumpToWave(wave)
-    assert.ok(runUntil(game, () => game.currentPhase === 'aim', 3000), `wave ${wave} never stocked`)
-    caps.push(game.currentWindCap())
+  let felled = 0
+  let firstWindyShot = -1
+  const caps: number[] = []
+  for (let shot = 0; shot < 60; shot++) {
+    if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim', 3000)) break
+    const answer = game.currentAnswer()
+    if (answer < 0) break
+    const cap = game.currentWindCap()
+    caps.push(cap)
+    // Before she has felled FIRST_WIND keeps, the chip may not be showing anything.
+    if (felled < FIRST_WIND) {
+      assert.equal(cap, 0, `the wind blew after only ${felled} keeps`)
+      assert.equal(game.currentWind(), 0, `the chip read ${game.currentWind()} after ${felled} keeps`)
+    } else if (firstWindyShot < 0 && cap > 0) firstWindyShot = shot
+    game.aimAt(correctDial(game))
+    game.fireNow()
+    if (!runUntil(game, () => game.currentPhase !== 'flight' && game.currentPhase !== 'windup', 600)) break
+    felled++
   }
-  assert.deepEqual(caps.slice(0, 2), [0, 0], `the wind blew on waves 1-2: ${caps.join(',')}`)
-  assert.ok(caps.some((c) => c > 0), `the wind never arrived across 14 waves: ${caps.join(',')}`)
-  // And when it does arrive it is a real adjustment, not a nudge.
-  for (const c of caps) assert.ok(c === 0 || c >= 3, `a cap of ${c} is not arithmetic`)
+  assert.ok(felled >= FIRST_WIND, `only ${felled} keeps fell across ${caps.length} shots`)
+  assert.ok(firstWindyShot >= 0, `the wind never arrived across ${caps.length} shots: ${caps.join(',')}`)
+  // ...and once it arrives it never goes away again. The old behaviour would fail
+  // here: a cap of 0 after a cap of 3 is the wave-8 hole in the measurement above.
+  const started = caps.findIndex((c) => c > 0)
+  for (let i = started; i < caps.length; i++) {
+    assert.ok(caps[i] > 0, `the wind stopped at shot ${i}: ${caps.join(',')}`)
+  }
+  // And when it does arrive it is a real subtraction, never a nudge the blast eats.
+  for (const c of caps) assert.ok(c === 0 || c >= WIND_MIN, `a cap of ${c} is not arithmetic`)
 })
 
 /* ------------------------------------------------------------------ *

--- a/dynawalla/games/trebuchet/src/game.test.ts
+++ b/dynawalla/games/trebuchet/src/game.test.ts
@@ -196,6 +196,43 @@ function tap(canvas: Record<string, unknown>, id: string): void {
   }
 }
 
+/**
+ * A hand on the open field — the gesture that takes a reveal down.
+ *
+ * Not a HUD button: `tap()` above goes through `hitBtn`, and the reveal is
+ * dismissed by a pointerdown anywhere the buttons are not.
+ */
+function tapField(canvas: Record<string, unknown>): void {
+  const listeners = canvas.__listeners as Listeners
+  for (const fn of listeners.get('pointerdown') ?? []) {
+    fn({ clientX: VIEW.w * 0.5, clientY: VIEW.h * 0.62, pointerId: 1 })
+  }
+}
+
+/**
+ * Take the reveal down, if one is up, and say whether the world is moving again.
+ *
+ * #774 made a miss stop the siege until the child dismisses the completed sum by
+ * hand: `revealPlan` supplies `holdMs: Infinity` and one gate (`stopped`) freezes
+ * the phase clock, the dial repeat, the phase machine, the counter-fire and the
+ * ram. So EVERY drive loop in this file that crosses a wrong answer has to take
+ * the sum down before it can expect another boulder — and it has to do it on a
+ * bound, because a loop waiting on a world that has stopped forever is a test that
+ * hangs, which reports nothing and is indistinguishable from a pass.
+ *
+ * There is a short settle lockout before the gesture is accepted, so this steps
+ * frames until it is honoured rather than tapping once and hoping.
+ */
+function dismissReveal(game: TrebuchetGame, canvas: Record<string, unknown>, maxFrames = 240): boolean {
+  if (game.revealedSum() === null) return true
+  for (let i = 0; i < maxFrames; i++) {
+    game.stepFrames(1)
+    tapField(canvas)
+    if (game.revealedSum() === null) return true
+  }
+  return false
+}
+
 function runUntil(game: TrebuchetGame, done: () => boolean, maxFrames = 1200): boolean {
   for (let i = 0; i < maxFrames; i++) {
     game.stepFrames(1)
@@ -779,6 +816,7 @@ test('the dial reaches every compensation the wind can ask for', () => {
   // drives the REAL `setDial` through `aimAt` and checks the number stuck.
   const { game } = newGame([14, 40, 72, 100, 118], 6, 1, FLUENT)
   assert.equal(game.currentWindCap(), WIND_MAX, 'the top of the ramp must blow its hardest')
+  let taken = 0
   for (let shot = 0; shot < 40; shot++) {
     if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim')) break
     const answer = game.currentAnswer()
@@ -791,8 +829,14 @@ test('the dial reaches every compensation the wind can ask for', () => {
       `wind ${game.currentWind()}, answer ${answer}: the dial would not go to ${want}`,
     )
     game.fireNow()
+    taken++
     if (!runUntil(game, () => game.currentPhase === 'aim' || game.currentPhase === 'clear')) break
+    // Every shot here is the correct compensation, so #774's reveal must never come
+    // up. If one ever did, the world would stop, the loop would break out on its
+    // bound, and this test would pass having swept two dials instead of forty.
+    assert.equal(game.revealedSum(), null, `shot ${taken}: a correct compensation raised the reveal`)
   }
+  assert.ok(taken >= 8, `only ${taken} compensations were entered`)
 })
 
 test('the wind does not move between the question appearing and the boulder landing', () => {
@@ -935,15 +979,20 @@ test('the loft lever is gone, and nothing took its place in the corner', () => {
   assert.equal(game.stats().dial, before, 'the bottom-left corner moved the dial')
 })
 
-test('only a felled keep buys the wind — a miss buys nothing, and buys it back too', () => {
+test('only a felled keep buys the wind — a miss buys nothing, and the reveal takes nothing', () => {
   // The currency has to be the thing it claims to be, or the ramp is indexed on
   // something else wearing its name. A keep on the ground is a sum worked out and a
   // boulder put on the metre; a miss is not, and must move nothing.
   //
-  // And the second half is what makes the TOP step reachable. A first draft counted
+  // The second half is what makes the TOP step reachable. A first draft counted
   // only still-air kills, and a child playing perfectly froze at fifteen: the
   // currency stopped being earnable the moment she crossed the first threshold, so
   // the wider wind could never arrive. A keep felled in a wind counts too.
+  //
+  // And the miss is now driven THROUGH #774's reveal, which is the interaction this
+  // test used to get wrong: a wrong answer stops the siege until the child takes
+  // the completed sum down, so "the next boulder loads" is something she causes and
+  // not something that happens.
   {
     const { game, canvas, reports, cells: still } = newGame([42, 60, 78, 96], 3, 0.4, 0)
     assert.equal(game.currentWind(), 0, 'this half of the test needs still air')
@@ -953,13 +1002,33 @@ test('only a felled keep buys the wind — a miss buys nothing, and buys it back
     assert.ok(runUntil(game, () => reports.length > 0), 'nothing was reported')
     assert.equal(reports[0].correct, false)
     assert.equal(still.get('dw.trebuchet.felled'), undefined, 'a miss bought progress')
-    // Then a hit.
+
+    // The world has stopped on the completed sum, and it stays stopped. Bounded,
+    // and the bound is asserted: an unbounded wait on a world that has been held
+    // forever is a test that hangs and reports nothing.
+    assert.notEqual(game.revealedSum(), null, 'a miss did not raise the reveal')
+    assert.equal(
+      runUntil(game, () => game.currentPhase === 'aim', 300),
+      false,
+      'the next boulder loaded underneath the sum she was reading',
+    )
+    assert.equal(still.get('dw.trebuchet.felled'), undefined, 'the held reveal bought progress')
+
+    // She takes it down, and only then does the siege carry on.
+    assert.ok(dismissReveal(game, canvas), 'the reveal would not come down')
     assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the next boulder never loaded')
     game.aimAt(game.currentAnswer())
     tap(canvas, 'fire')
     assert.ok(runUntil(game, () => reports.length > 1), 'the second shot never resolved')
     assert.equal(reports[1].correct, true)
     assert.equal(still.get('dw.trebuchet.felled'), '1', 'a felled keep bought nothing')
+
+    // A right answer raises no reveal at all, so there is no second beat in which a
+    // keep could be counted twice. Held for a long stretch of frames: `noteFelled`
+    // sits in `impact`, and a reveal that re-entered it would show up here.
+    assert.equal(game.revealedSum(), null, 'a felled keep raised a reveal')
+    runUntil(game, () => false, 300)
+    assert.equal(still.get('dw.trebuchet.felled'), '1', 'one felled keep was counted more than once')
   }
 
   // And the same perfect play in a wind, from a child on the first step of the ramp:
@@ -977,6 +1046,52 @@ test('only a felled keep buys the wind — a miss buys nothing, and buys it back
       'a keep felled in a wind bought nothing, so the top step can never arrive',
     )
   }
+})
+
+test('a miss in a wind stops the siege, and hands the wind back when she is ready', () => {
+  // The two changes that landed together, composed. #774 freezes the world on a
+  // wrong answer; the wind is bought with felled keeps and rolled fresh for each
+  // boulder. So a miss in a wind has to hold the sum AND the wind she got it wrong
+  // against — a chip that re-rolled underneath the reveal would be showing her the
+  // arithmetic for a shot she has not taken yet, next to the sum for one she has.
+  const { game, canvas, reports, cells } = newGame([42, 60, 78, 96], 3, 0.4, FLUENT)
+  const wind = game.currentWind()
+  assert.notEqual(wind, 0, 'this test is pointless without a wind')
+  const answer = game.currentAnswer()
+
+  // She does the sum right and forgets the wind — the exact error this mechanic
+  // invites, and the one the reveal exists to answer.
+  game.aimAt(answer)
+  tap(canvas, 'fire')
+  assert.ok(runUntil(game, () => reports.length > 0), 'nothing was reported')
+  assert.equal(reports[0].correct, false, 'ignoring the wind landed the shot')
+  assert.equal(reports[0].answered, String(answer + wind), 'she is recorded as naming the wrong metre')
+
+  const sum = game.revealedSum()
+  assert.notEqual(sum, null, 'a miss in a wind did not raise the reveal')
+  assert.ok(sum?.includes(String(answer)), `the reveal "${String(sum)}" does not finish the sum`)
+
+  // Nothing moves under it — the wind included.
+  for (let i = 0; i < 240; i++) {
+    game.stepFrames(1)
+    assert.equal(game.currentWind(), wind, `frame ${i}: the wind re-rolled under the reveal`)
+  }
+  assert.equal(cells.get('dw.trebuchet.felled'), String(FLUENT), 'the reveal moved the count')
+
+  // She takes it down. The siege resumes, the wind is still in play, and the ramp
+  // is exactly where she left it: a miss costs her nothing she had already bought.
+  assert.ok(dismissReveal(game, canvas), 'the reveal would not come down')
+  assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'the siege never resumed')
+  assert.equal(game.currentWindCap(), WIND_MAX, 'the wind was taken away by a wrong answer')
+  assert.notEqual(game.currentWind(), 0, 'the chip went blank after a miss')
+  assert.equal(cells.get('dw.trebuchet.felled'), String(FLUENT), 'a miss spent what she had bought')
+
+  // ...and she can still win the very next boulder.
+  game.aimAt(correctDial(game))
+  tap(canvas, 'fire')
+  assert.ok(runUntil(game, () => reports.length > 1), 'the next shot never resolved')
+  assert.equal(reports[1].correct, true, 'the shot after a miss was scored wrong')
+  assert.equal(cells.get('dw.trebuchet.felled'), String(FLUENT + 1), 'the keep she felled bought nothing')
 })
 
 test('the wind arrives because she FELLED KEEPS, and only then', () => {
@@ -997,7 +1112,12 @@ test('the wind arrives because she FELLED KEEPS, and only then', () => {
   // one-step game, AND the wind does arrive once she has.
   const dom = installDom()
   const { host } = ladderHost()
-  const game = new TrebuchetGame(dom.el, host, 0xb01de)
+  // `ladderHost` throws its reports away; this loop counts felled keeps off them,
+  // so they have to be kept. Wrapped rather than reached into, because `report` is
+  // the real channel the curriculum is judged on.
+  const reports: Reported[] = []
+  const watched: Host = { ...host, report: (r) => reports.push(r) }
+  const game = new TrebuchetGame(dom.el, watched, 0xb01de)
   game.manualDrive()
   assert.ok(runUntil(game, () => game.currentPhase === 'aim'), 'wave 1 never stocked')
   assert.equal(game.currentWindCap(), 0, 'a child on her first wave was handed a wind')
@@ -1007,6 +1127,10 @@ test('the wind arrives because she FELLED KEEPS, and only then', () => {
   const caps: number[] = []
   for (let shot = 0; shot < 60; shot++) {
     if (game.currentPhase !== 'aim' && !runUntil(game, () => game.currentPhase === 'aim', 3000)) break
+    // Every shot below is the correct compensation, so nothing here may ever be
+    // reading a completed sum. If one were, #774's reveal would hold the world and
+    // this loop would count keeps that never fell.
+    assert.equal(game.revealedSum(), null, `shot ${shot}: the siege is stopped on a reveal`)
     const answer = game.currentAnswer()
     if (answer < 0) break
     const cap = game.currentWindCap()
@@ -1017,8 +1141,12 @@ test('the wind arrives because she FELLED KEEPS, and only then', () => {
       assert.equal(game.currentWind(), 0, `the chip read ${game.currentWind()} after ${felled} keeps`)
     } else if (firstWindyShot < 0 && cap > 0) firstWindyShot = shot
     game.aimAt(correctDial(game))
+    const want = felled + 1
     game.fireNow()
-    if (!runUntil(game, () => game.currentPhase !== 'flight' && game.currentPhase !== 'windup', 600)) break
+    if (!runUntil(game, () => reports.length >= want, 600)) break
+    // Counted off the host's own record, not off "a shot went out": a wrong answer
+    // would report too, and it must not be mistaken for a keep on the ground.
+    assert.equal(reports[want - 1].correct, true, `shot ${shot} was scored wrong`)
     felled++
   }
   assert.ok(felled >= FIRST_WIND, `only ${felled} keeps fell across ${caps.length} shots`)

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -1191,7 +1191,10 @@ export class TrebuchetGame {
    * The intensity is the ITEM's own difficulty, which is the host's live
    * judgement of where this child is standing. A wave number would not be: it
    * arrives on her twelfth minute whether she has been landing every boulder or
-   * none of them, which is the same argument `WIND_FROM_D` makes.
+   * none of them. `WIND_STEPS` makes the same argument one step further along —
+   * the wind is indexed on keeps this child has actually felled, because the
+   * ladder's own position turned out to oscillate as `stock()` sweeps for a rung
+   * that fits on the field, and the wind oscillated with it.
    *
    * Nothing is drawn about being wrong. The finished equation, in the accent,
    * and the keep she was aiming at lighting up out on the field — no red, no

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -65,6 +65,7 @@ import {
   type Outcome,
   type Solved,
 } from './sim/ballistics.ts'
+import { felledEver, noteFelled } from './sim/felled.ts'
 import { rollWind, shotFor, verdictFor } from './sim/verdict.ts'
 import {
   buildTower,
@@ -82,6 +83,7 @@ import {
   dialRange,
   DIAL_MAX,
   DIAL_MIN,
+  MIN_GAP,
   PLACEABLE_HI,
   PLACEABLE_LO,
   worldX,
@@ -93,8 +95,6 @@ import {
   type Tower,
   type WaveConfig,
 } from './sim/world.ts'
-
-const MIN_GAP = 8
 
 /**
  * One step of the search for a placeable rung, as a fraction of the ladder.
@@ -191,8 +191,8 @@ export class TrebuchetGame {
    */
   private wind = 0
   /**
-   * The strongest wind this wave can produce, from the difficulty of the questions
-   * in the rack. 0 for a beginner's wave, which is most of them.
+   * The strongest wind this wave can produce, from the number of keeps this child
+   * has already brought down. 0 until she has bought it.
    */
   private windCap = 0
   /** Whether the wind has ever blown in this run, so it is explained exactly once. */
@@ -636,12 +636,17 @@ export class TrebuchetGame {
     this.towers = values.map((v, i) => buildTower(i, v, this.rng, cfg.volley && i % 2 === 0))
     this.markWanted()
 
-    // The wind, from the RUNG THE QUESTIONS CAME FROM and not from the wave
-    // number. The lowest difficulty in the rack decides it, so one stray hard item
-    // in a beginner's pool cannot start the wind blowing on a child the ladder has
-    // not moved yet — and it is fixed for the wave, so tapping a different rack
-    // stone can never change the wind she is looking at.
-    this.windCap = Math.min(...boulders.map((b) => windCapFor(b.q.difficulty)))
+    // The wind, from WHAT THIS CHILD HAS ALREADY DONE. Not the wave number, and no
+    // longer the rung the questions came from either: the search that finds a
+    // placeable rung sweeps and wraps, so the difficulty served oscillates and the
+    // wind oscillated with it — on at wave 4, off at 8, back at 14, gone at 18,
+    // for reasons invisible from where she is sitting. See `sim/felled.ts`.
+    //
+    // Read once, here, and held for the whole wave: the twelfth keep may fall
+    // mid-rack, and a wind that started between two boulders would change the rule
+    // about what a right answer looks like while she was in the middle of a wave.
+    // It starts at the next one, where the manual can meet it.
+    this.windCap = windCapFor(felledEver())
     this.rollWindForShot()
     this.wall = null
     if (cfg.wall) {
@@ -1093,6 +1098,11 @@ export class TrebuchetGame {
         void freed
         struck.alive = false
         destroyed = true
+        // The currency the wind is bought with, and the ONLY thing that spends
+        // into it: a keep on the ground. A wrong answer buys nothing and costs
+        // nothing — the count only ever goes up — and a boulder spent on the ram
+        // never reaches this branch at all.
+        noteFelled()
         this.audio.collapse()
         this.audio.fanfare(this.combo)
         this.host.haptic('success')

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -53,7 +53,7 @@ export function mount(el: HTMLElement, host: Host): Mounted {
         // panel opens by itself the first time the wind blows.
         heading: 'Wind',
         lines: [
-          'When the sums get harder, a wind starts blowing across the field.',
+          'The wind arrives after you have knocked down a dozen keeps.',
           'The wind readout sits under your row of boulders: an arrow, and a number.',
           'The arrow shows which way the wind will push your boulder, and the number is how many metres it will push it.',
           'So the wind moves the boulder AFTER it leaves. You have to aim into the wind, and let the wind carry the stone the rest of the way.',
@@ -63,6 +63,8 @@ export function mount(el: HTMLElement, host: Host): Mounted {
           'If the arrow points back towards you, the wind holds the boulder 5 metres short instead, so dial 5 more. 72 and 5 is 77.',
           'Work out the sum first. Then take the wind off your answer, or add it on.',
           'The wind does not change while you are thinking. The number you can see is the number you get.',
+          'If you forget the wind, the boulder sails four to six metres past the keep, or lands that far short of it, and the keep stays standing.',
+          'The crater tells you the metre you actually claimed, which is the dial plus the wind. Answer 72, arrow pointing away with a 5, and you dial 72 anyway: the crater reads 77.',
         ],
       },
       {

--- a/dynawalla/games/trebuchet/src/sim/ballistics.ts
+++ b/dynawalla/games/trebuchet/src/sim/ballistics.ts
@@ -117,8 +117,75 @@ export type Outcome<T extends TargetRef = TargetRef> = {
   errorM: number
 }
 
+/* ------------------------------------------------------------------ *
+ * The metre-scale of the field.
+ *
+ * Four numbers, and three of them are derived from the first two, because the
+ * relationship BETWEEN them is what decides whether the wind is an honest
+ * mechanic or a decoration. Measured on `origin/main` over 450 shots across five
+ * seeds and waves 1–20, driven through the real game against the faithful ladder
+ * harness, for a child who works the sum out correctly and dials her answer
+ * without accounting for the wind:
+ *
+ *     wind cap 3   n=95   displacement 1..3 m   graze 72%  solid 28%  MISS 0%
+ *     wind cap 4   n=95   displacement 1..4 m   graze 55%  solid 25%  miss 20%
+ *
+ * 165 of those 190 windy shots — 86.8% — came down INSIDE the blast radius of the
+ * keep she was aiming at. The boulder struck the tower, the tower cracked and
+ * leaned, masonry came off it, and the game recorded a wrong answer. That is the
+ * founder's report, exactly: "they are confusing and don't necessarily do
+ * anything". A variable whose whole range is smaller than the blast it moves is
+ * invisible in the world and audible only in the verdict, which is the worst of
+ * both — it looks ignorable and it is not.
+ *
+ * So the wind's magnitude is now pinned to this geometry at both ends:
+ *
+ *   - it must be STRICTLY BIGGER than the blast, or an ignored wind still knocks
+ *     dust off the right keep and the child is told she is wrong about a shot she
+ *     watched hit;
+ *   - it must be small enough that a shot at the answer cannot read as a shot at
+ *     the NEXT keep along. `game.ts` fires the garrison — the wrong-horn, the
+ *     failure haptic, the counter-volley — when a landing comes down within 1 m of
+ *     a keep that is not the one asked for, and that would tell her she had named
+ *     the wrong number when what she had actually done was ignore the wind. Keeps
+ *     stand at least `MIN_GAP` apart, so the wind may not reach `MIN_GAP − 1`.
+ *
+ * What is deliberately NOT claimed: that an ignored wind touches nothing at all. At
+ * the closest spacing the field allows, a six-metre wind puts the boulder two
+ * metres from the neighbouring keep and the blast shakes it. That is the truth
+ * about the shot — she was six metres long — and it is told in the right place, out
+ * on the ground, next to a keep that is not hers. Making it touch nothing would
+ * need `MIN_GAP` at 10, which narrows the 104-metre field to the point where a wave
+ * cannot always find six answers to stand apart on it; the mechanic does not get to
+ * shorten the waves.
+ *
+ * Every bound here is asserted through behaviour, not through its own arithmetic,
+ * in `sim/world.test.ts`.
+ * ------------------------------------------------------------------ */
+
 /** Blast reach in metres — a landing this close still shakes a tower's footings. */
 export const GRAZE_M = 3
+
+/**
+ * The closest two keeps may ever stand. Two keeps nearer than this would be one
+ * target: the blast reaches `GRAZE_M` either side, so at 6 m apart a landing
+ * between them shakes both.
+ */
+export const MIN_GAP = 8
+
+/**
+ * The weakest wind there is. One metre past the blast, so a shot that ignores it
+ * lands in open ground and leaves a crater with her number in it — which is the
+ * feedback the manual has always promised for a wrong answer and which the wind
+ * was, measurably, never able to trigger.
+ */
+export const WIND_MIN = GRAZE_M + 1
+
+/**
+ * The strongest wind there is. One metre inside the garrison's reach, so a shot
+ * that ignores the wind is never mistaken for a claim about the neighbouring keep.
+ */
+export const WIND_MAX = MIN_GAP - 2
 
 /**
  * Where did the shot land, and what did that mean? `landing` and every `range`

--- a/dynawalla/games/trebuchet/src/sim/felled.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/felled.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The count the wind is bought with.
+ *
+ * Small, and load-bearing: it is the only thing standing between a child who has
+ * never landed a boulder and a second arithmetic step arriving unannounced. So the
+ * read side, the write side and the "storage is not there" side are all driven,
+ * rather than the module being trusted because it is twenty lines long.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { felledEver, noteFelled, resetFelledForTest } from './felled.ts'
+
+const SLOT = 'dw.trebuchet.felled' // gitleaks:allow
+
+type Cells = Map<string, string>
+
+/** A real `Storage` shape over a Map, installed where the module looks for it. */
+function installStorage(cells: Cells = new Map()): Cells {
+  ;(globalThis as unknown as Record<string, unknown>).localStorage = {
+    getItem: (k: string) => cells.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      cells.set(k, String(v))
+    },
+    removeItem: (k: string) => {
+      cells.delete(k)
+    },
+    clear: () => cells.clear(),
+    key: () => null,
+    get length() {
+      return cells.size
+    },
+  }
+  resetFelledForTest()
+  return cells
+}
+
+function removeStorage(): void {
+  delete (globalThis as unknown as Record<string, unknown>).localStorage
+  resetFelledForTest()
+}
+
+test('a keep felled in one sitting is still felled in the next', () => {
+  // The whole reason this is persisted rather than counted in module memory: a
+  // child who has already learnt the one-step game does not get walked through it
+  // again on Tuesday, and — the other way round, which matters more — a child who
+  // put the tablet down after four keeps does not come back to a wind.
+  const cells = installStorage()
+  assert.equal(felledEver(), 0, 'a device with nothing on it remembered something')
+  for (let i = 1; i <= 7; i++) assert.equal(noteFelled(), i)
+  assert.equal(cells.get(SLOT), '7', 'the count never reached storage')
+
+  // A new sitting: same device, same storage, fresh module state.
+  resetFelledForTest()
+  assert.equal(felledEver(), 7, 'the count did not survive the sitting')
+  assert.equal(noteFelled(), 8, 'the next keep did not carry on from seven')
+})
+
+test('a storage that is not there costs a child nothing but practice', () => {
+  // `localStorage` throws inside a pack frame on an opaque origin. The failure mode
+  // has to be the safe one — she meets the still-air game again, which is extra
+  // practice at something she is good at — and never a crash and never a wind.
+  removeStorage()
+  assert.equal(felledEver(), 0)
+  assert.equal(noteFelled(), 1, 'the count is still kept in memory for this sitting')
+  assert.equal(noteFelled(), 2)
+  resetFelledForTest()
+  assert.equal(felledEver(), 0, 'without storage the next sitting starts again')
+
+  // And the real failure: on an opaque origin, READING `globalThis.localStorage`
+  // is itself what throws — before there is any object to call `getItem` on. A
+  // guard placed only around the `getItem` call would not catch that, and the pack
+  // would die on its first felled keep.
+  const quiet = console.warn
+  const warned: string[] = []
+  console.warn = (...args: unknown[]) => warned.push(args.map(String).join(' '))
+  try {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get(): never {
+        throw new Error('SecurityError: the document is sandboxed')
+      },
+    })
+    resetFelledForTest()
+    assert.equal(felledEver(), 0, 'an opaque origin handed back a count')
+    assert.equal(noteFelled(), 1, 'the sitting could not count its own keeps')
+    assert.equal(noteFelled(), 2)
+  } finally {
+    console.warn = quiet
+    delete (globalThis as unknown as Record<string, unknown>).localStorage
+  }
+  // Noisy, never silent: a pack that cannot remember anything has to say so.
+  assert.ok(warned.length > 0, 'an unreachable storage was swallowed in silence')
+  assert.match(warned[0], /localStorage is not reachable/)
+  removeStorage()
+})
+
+test('junk in the slot is not a number of keeps', () => {
+  // Anything can be in a storage slot: another pack, a half-written value, a hand
+  // in the dev tools. The failure that matters is UPWARD — a value that hands a
+  // child a second arithmetic step she has never bought — so every case is pinned
+  // to the count it must produce rather than to a predicate that most of them
+  // would satisfy at any value.
+  const cases: Array<[string, number]> = [
+    ['', 0],
+    ['lots', 0],
+    ['-4', 0], // a negative count is not fewer keeps, it is not a count
+    ['NaN', 0],
+    ['Infinity', 0], // the one that would otherwise reach the top of the ramp
+    ['1e400', 0], // ...and so would this, which parses to Infinity
+    ['3.7', 3], // a keep is felled or it is not; the fraction floors away
+    ['12', 12], // and a real count survives untouched
+  ]
+  for (const [junk, want] of cases) {
+    installStorage(new Map([[SLOT, junk]]))
+    assert.equal(felledEver(), want, `"${junk}" became ${String(felledEver())} keeps`)
+  }
+  removeStorage()
+})

--- a/dynawalla/games/trebuchet/src/sim/felled.ts
+++ b/dynawalla/games/trebuchet/src/sim/felled.ts
@@ -1,0 +1,98 @@
+/**
+ * How many keeps this child has ever brought down — the one thing that buys the
+ * wind, and then widens it.
+ *
+ * The wind used to arrive because the ladder had moved. That sounds like the same
+ * thing and it is not, and the difference is measurable. `game.ts` climbs the
+ * difficulty it asks for by a notch every wave and sweeps, wrapping, when a rung's
+ * answers will not fit on 122 metres — so the rung a child is served oscillates.
+ * Driven through the real game against the faithful ladder harness on
+ * `origin/main`, the wind cap by wave came out:
+ *
+ *     wave  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+ *     cap   0  0  0  3  3  4  4  0  0  0  0  0  0  3  3  4  4  0  0  0
+ *
+ * The wind switched on at wave 4, switched OFF at wave 8, came back at 14 and went
+ * again at 18 — for reasons that are entirely invisible from where the child is
+ * sitting, and none of which are anything she did. A mechanic that appears and
+ * disappears is not a difficulty step; it is weather in the pejorative sense.
+ *
+ * So it is bought instead, with right answers: a keep on the ground is a sum worked
+ * out and a boulder put on the metre, and nothing else fells one. That is the only
+ * signal that separates "has never played TREBUCHET" from "can already do this". It
+ * is not accuracy and it is not a score — a child who takes six goes at a keep and
+ * fells it has demonstrated the thing this counts, and nothing here holds the other
+ * five against her.
+ *
+ * One counter, not two, and that is what makes every step of the ramp reachable.
+ * The first twelve are NECESSARILY felled in still air, because there is no wind
+ * below twelve — so the first step is bought by fluency at the one-step game, for
+ * free, with no second bookkeeping. The twelve after that are felled in a wind, so
+ * the wider wind is bought by fluency at the two-step game. A version of this that
+ * counted only still-air kills was written first and measured: a child playing
+ * perfectly froze at fifteen and could never reach the top step at all, because the
+ * currency stopped being earnable the moment she crossed the first threshold.
+ *
+ * Once bought it is never taken back, in this sitting or any other, which is the
+ * whole point: the rule about what a right answer looks like changes exactly once.
+ *
+ * **`localStorage` throws inside a pack frame.** The document is on an opaque
+ * origin, so every access is guarded and the value is held in memory as well. When
+ * storage is unreachable the failure mode is that a child meets the still-air game
+ * again next sitting — extra practice at a thing she is already good at, which is
+ * the right way round. The other way round is a second arithmetic step arriving
+ * unannounced on a child who has never landed a boulder.
+ */
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const FELLED_SLOT = 'dw.trebuchet.felled' // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn('[trebuchet] localStorage is not reachable from this frame', error)
+    return null
+  }
+}
+
+/** Keeps felled, ever, across every sitting this device remembers. */
+export function felledEver(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(FELLED_SLOT) ?? '0')
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn('[trebuchet] the felled-keep count could not be read back', error)
+    }
+  }
+  return memory
+}
+
+/** One more. Returns the new total. */
+export function noteFelled(): number {
+  const next = felledEver() + 1
+  memory = next
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(FELLED_SLOT, String(next))
+    } catch (error) {
+      console.warn('[trebuchet] the felled-keep count could not be written', error)
+    }
+  }
+  return next
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetFelledForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/trebuchet/src/sim/verdict.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.test.ts
@@ -34,7 +34,9 @@ import {
   PLACEABLE_HI,
   PLACEABLE_LO,
   WIND_MAX,
+  WIND_MIN,
   windCapFor,
+  WIND_STEPS,
 } from './world.ts'
 import { makeRng } from '../core/rng.ts'
 
@@ -86,8 +88,13 @@ const dialFor = (answer: number, wind: number): number => answer - wind
  */
 const recordedCorrect = (answered: string, answer: number): boolean => answered === String(answer)
 
-/** Every wind cap the game can put on the field, weakest first. */
-const CAPS = [0, 3, 4, 5, 6, 7, 8, WIND_MAX]
+/**
+ * Every wind cap the game can put on the field, weakest first — read off the ramp
+ * itself rather than typed out beside it, so a step added to `WIND_STEPS` is a step
+ * the whole of this file sweeps. The old hand-written list ran to a cap of 9, and
+ * five of its eight entries are caps the game has never been able to produce.
+ */
+const CAPS = WIND_STEPS.map((step) => step.cap)
 const pct = (n: number, d: number): string => (d === 0 ? 'n/a' : `${((n / d) * 100).toFixed(1)}%`)
 
 /* ------------------------------------------------------------------ *
@@ -132,24 +139,26 @@ test('the correct child always lands it: every wind, every answer on the field',
     `${failures.length} of ${shots} correct shots were punished`,
   )
   // A guard on the sweep itself, so a loop that quietly stopped iterating cannot
-  // pass by testing nothing. 8,925 today: 85 winds across the caps, 105 answers.
-  assert.ok(shots > 8000, `only ${shots} shots were swept`)
+  // pass by testing nothing. 1,155 today: 11 winds across the three steps of the
+  // ramp (still air, ±4..5, ±4..6), times the 105 answers the field can hold.
+  assert.equal(shots, 1155, `${shots} shots — the ramp is not the shape this file sweeps`)
 })
 
-test('the correct child always lands it, at every difficulty the ladder has', () => {
+test('the correct child always lands it, however many keeps she has felled', () => {
   // The same sweep, driven the way the game drives it: the wind cap comes from the
-  // item's difficulty, so walk the whole ladder rather than a list of caps someone
-  // chose. A rung whose cap the dial cannot express is a rung that punishes her.
+  // number of keeps she has brought down in still air, so walk that rather than a
+  // list of caps someone chose. A cap the dial cannot express is a cap that
+  // punishes her.
   const failures: string[] = []
-  for (let d = 0; d <= 1.0001; d += 0.01) {
-    const cap = windCapFor(d)
+  for (let felled = 0; felled <= 60; felled++) {
+    const cap = windCapFor(felled)
     for (const wind of cap ? windValues(cap) : [0]) {
       for (const answer of [PLACEABLE_LO, 40, 72, 99, PLACEABLE_HI]) {
         const dial = dialFor(answer, wind)
         const stops = dialRange(wind)
         const r = takeShot(dial, answer, wind)
         if (dial < stops.lo || dial > stops.hi || r.landing !== answer || !r.correct) {
-          failures.push(`d=${d.toFixed(2)} cap ${cap} wind ${wind} answer ${answer}: dial ${dial}, landed ${r.landing}, correct ${String(r.correct)}`)
+          failures.push(`felled ${felled} cap ${cap} wind ${wind} answer ${answer}: dial ${dial}, landed ${r.landing}, correct ${String(r.correct)}`)
         }
       }
     }
@@ -196,12 +205,12 @@ test('the wind is not decoration: ignoring it misses, accounting for it lands', 
   )
 })
 
-test('below the threshold there is no wind, and the dial is the answer', () => {
+test('before she has bought it there is no wind, and the dial is the answer', () => {
   // The low end is untouched, and that is a promise: a child meeting this game gets
-  // one idea — read the sum, dial the answer, the keep falls. Every rung the shipped
-  // ladder has below `WIND_FROM_D` that this field can hold.
-  for (const d of [0, 0.169, 0.2, 0.246, 0.262, 0.277, 0.292, 0.308, 0.323, 0.339]) {
-    assert.equal(windCapFor(d), 0, `d=${String(d)} has a wind on it`)
+  // one idea — read the sum, dial the answer, the keep falls. It stays that way
+  // however hard the arithmetic gets, until she has demonstrated she can do it.
+  for (const felled of [0, 1, 2, 5, 8, 10, 11]) {
+    assert.equal(windCapFor(felled), 0, `${String(felled)} keeps put a wind on the field`)
   }
   for (const answer of FIELD) {
     const r = takeShot(answer, answer, 0)
@@ -230,7 +239,7 @@ test('the number reported is her answer to the SUM, not the dial', () => {
   // reported is the whole question. #654 established that the dial was reported,
   // because then the dial WAS her answer. It is not any more: she is asked for 72
   // and turns the dial to 67.
-  for (const wind of [-9, -5, -1, 1, 5, 9]) {
+  for (const wind of windValues(WIND_MAX)) {
     for (const answer of [20, 47, 72, 100]) {
       const dial = dialFor(answer, wind)
       const r = takeShot(dial, answer, wind)
@@ -246,7 +255,7 @@ test('her answer is computed from what she saw, never read off the ground', () =
   // original defect reported the metre the wind chose, and it did that by reading
   // the ground.
   for (const dial of [-4, 0, 8, 72, 127, 500]) {
-    for (const wind of [-9, 0, 9]) {
+    for (const wind of [-WIND_MAX, 0, WIND_MAX]) {
       assert.equal(claimOf(dial, wind), dial + wind, `dial ${dial}, wind ${wind}`)
     }
   }
@@ -388,7 +397,7 @@ test('a boulder spent on the ram is not an answer to the question', () => {
 })
 
 test('rollWind only ever produces a wind the tests enumerate', () => {
-  for (const cap of [3, 5, 9]) {
+  for (const cap of CAPS.filter((c) => c > 0)) {
     const allowed = new Set(windValues(cap))
     const rng = makeRng(0x51e6e)
     const seen = new Set<number>()
@@ -400,8 +409,15 @@ test('rollWind only ever produces a wind the tests enumerate', () => {
     assert.equal(seen.size, allowed.size, `cap ${cap} did not cover its range`)
   }
   assert.equal(rollWind(0, makeRng(1)), 0, 'no wind means no wind')
+  // A cap the ramp has not reached is not a weak wind, it is no wind: a chip
+  // reading 1, 2 or 3 would ask for an adjustment the blast swallows.
+  for (let cap = 0; cap < WIND_MIN; cap++) {
+    assert.equal(rollWind(cap, makeRng(1)), 0, `a cap of ${String(cap)} blew`)
+  }
   // Never zero when there IS a wind: a chip reading 0 tells a child to adjust by
   // nothing, which is a lie about a mechanic she has just been taught.
   const rng = makeRng(9)
-  for (let i = 0; i < 2000; i++) assert.notEqual(rollWind(3, rng), 0)
+  for (let i = 0; i < 2000; i++) {
+    assert.ok(Math.abs(rollWind(WIND_MAX, rng)) >= WIND_MIN, 'a wind the blast would swallow')
+  }
 })

--- a/dynawalla/games/trebuchet/src/sim/verdict.ts
+++ b/dynawalla/games/trebuchet/src/sim/verdict.ts
@@ -41,27 +41,53 @@
  *      answer. It is computed from her own two inputs by integer addition, never
  *      read back off the physics; the landing is checked against it and a
  *      disagreement is logged loudly, with her claim still winning.
- *   3. **Below `WIND_FROM_D` there is no wind at all**, the cap is 0, and every
- *      formula above collapses to `claim = dial`. The beginner's game is the game
- *      it always was.
+ *   3. **Until she has felled twelve keeps in still air there is no wind at all**,
+ *      the cap is 0, and every formula above collapses to `claim = dial`. The
+ *      beginner's game is the game it always was, and it is now bought with right
+ *      answers rather than handed over when the curriculum ladder drifts.
+ *
+ * ## The third way of getting it wrong, and the fix in this change
+ *
+ * **Being invisible.** The arithmetic above was honest and the wind was still, in
+ * the founder's words, "confusing and doesn't necessarily do anything" — because
+ * its whole range was smaller than the blast. Measured over 450 shots through the
+ * real game, a child who worked the sum out correctly and dialled her answer
+ * without adjusting for the wind came down INSIDE the target keep's blast radius
+ * 165 times out of 190: the boulder hit the tower she was aiming at, the tower
+ * cracked and leaned, and the game recorded a wrong answer. She had no way to read
+ * that as "the wind carried it three metres long" rather than as "the game is
+ * broken". So the wind now starts one metre past the blast (`WIND_MIN`), and an
+ * ignored wind lands in open ground and burns her own number into it.
  */
 
-import { solve, type Solved } from './ballistics.ts'
+import { solve, WIND_MIN, type Solved } from './ballistics.ts'
 import type { Rng } from '../core/rng.ts'
 
-/** Every wind `rollWind` can produce for a cap — the roll never yields 0. */
+/**
+ * Every wind `rollWind` can produce for a cap.
+ *
+ * The roll never yields 0, and it never yields anything weaker than `WIND_MIN`
+ * either — which is the correction this whole change turns on. A wind of 1, 2 or 3
+ * metres is smaller than the blast it moves the boulder by, so a child who ignored
+ * it watched her boulder strike the right keep and was told she was wrong; measured
+ * on `origin/main`, 86.8% of the shots of a child who ignored the wind came down
+ * inside the target keep's blast radius. A wind you cannot see is not a variable,
+ * it is a tax.
+ */
 export function windValues(cap: number): number[] {
   const out: number[] = []
-  for (let v = -cap; v <= cap; v++) if (v !== 0) out.push(v)
+  for (let v = -cap; v <= cap; v++) if (Math.abs(v) >= WIND_MIN) out.push(v)
   return out
 }
 
-/** A crosswind for the shot. Never 0: a wind chip reading 0 lies about the mechanic. */
+/**
+ * A crosswind for the shot. Never 0 and never below `WIND_MIN`: a wind chip
+ * reading 0 lies about the mechanic, and a wind the blast swallows lies harder.
+ */
 export function rollWind(cap: number, rng: Rng): number {
-  if (!cap) return 0
-  let v = 0
-  while (v === 0) v = rng.int(-cap, cap)
-  return v
+  if (!Number.isFinite(cap) || cap < WIND_MIN) return 0
+  const mag = rng.int(WIND_MIN, Math.floor(cap))
+  return rng.next() < 0.5 ? -mag : mag
 }
 
 /**

--- a/dynawalla/games/trebuchet/src/sim/world.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.test.ts
@@ -4,7 +4,7 @@ import { test } from 'node:test'
 import type { Question } from '../contract.ts'
 import { makeRng } from '../core/rng.ts'
 import { createStubHost } from '../stubHost.ts'
-import { heightAtX, LAUNCH_H } from './ballistics.ts'
+import { GRAZE_M, heightAtX, LAUNCH_H, resolve } from './ballistics.ts'
 import { shotFor, windValues } from './verdict.ts'
 import {
   buildTower,
@@ -16,13 +16,13 @@ import {
   stepBlocks,
   wallFor,
   waveConfig,
-  WIND_FROM_D,
+  MIN_GAP,
   WIND_MAX,
+  WIND_MIN,
   windCapFor,
+  WIND_STEPS,
   type Phase,
 } from './world.ts'
-
-const MIN_GAP = 8
 
 test('no two keeps can ever occupy the same ground', () => {
   const rng = makeRng(7)
@@ -113,61 +113,115 @@ test('escalation is monotonic where it should be and bounded everywhere', () => 
   assert.ok(waveConfig(7).ram, 'the ram arrives at wave 7')
 })
 
-test('the wave number cannot start the wind blowing — only the ladder can', () => {
+test('the wave number cannot start the wind blowing', () => {
   // The founder's complaint about the wind was that it was pointless; the fix for
   // that is a second arithmetic step, and a second arithmetic step handed out on a
-  // TIMER is worse than a pointless one. `waveConfig` no longer has a `wind` field
-  // to read, which is what makes this a compile-time fact and not a convention:
-  // there is nowhere left for a wave counter to say how hard the wind blows.
+  // TIMER is worse than a pointless one. `waveConfig` has no `wind` field to read,
+  // which is what makes this a compile-time fact and not a convention: there is
+  // nowhere left for a wave counter to say how hard the wind blows.
   const cfg = waveConfig(20) as Record<string, unknown>
   assert.equal('wind' in cfg, false, 'the wave still decides the wind')
   assert.equal('gusty' in cfg, false, 'the wave still decides whether the wind rerolls')
   assert.equal('loft' in cfg, false, 'the wave still unlocks a lever that no longer exists')
 })
 
-test('the wind arrives on the ladder, above the facts and the no-regroup columns', () => {
-  // Measured over the shipped 66-rung ladder: every rung whose answers a 122-metre
-  // field can stand a keep at, and what arithmetic it is. The threshold sits above
-  // the last of the easy ones on purpose — a child still on tables or on column sums
-  // with no regrouping is meeting this game for the first time and gets the game
-  // that has no wind in it at all.
-  const beginner = [
-    { d: 0.246, what: 'tables-to-twelve L0' },
-    { d: 0.277, what: 'add.column.add-no-regroup L0' },
-    { d: 0.292, what: 'add.column.subtract-no-regroup L0' },
-    { d: 0.323, what: 'tables-to-twelve L1' },
-  ]
-  for (const rung of beginner) {
-    assert.equal(windCapFor(rung.d), 0, `${rung.what} (d=${String(rung.d)}) must have no wind`)
+test('the wind is bought with felled keeps, and never taken back', () => {
+  // It used to arrive because the LADDER had moved, and the ladder moves for
+  // reasons that have nothing to do with this child: `game.ts` sweeps for a rung
+  // whose answers fit on 122 metres and wraps when it runs out, so on `origin/main`
+  // the wind came on at wave 4, went off at 8, came back at 14 and went again at 18.
+  // It is now a pure function of what she has demonstrated.
+  assert.equal(windCapFor(0), 0, 'a child who has never felled a keep was handed a wind')
+  assert.equal(windCapFor(11), 0, 'eleven keeps is not yet the second step')
+  assert.ok(windCapFor(12) > 0, 'twelve felled keeps did not buy the wind')
+
+  let prev = -1
+  for (let felled = 0; felled <= 400; felled++) {
+    const cap = windCapFor(felled)
+    assert.ok(cap >= prev || prev === -1, `the wind shrank at ${String(felled)} keeps`)
+    assert.ok(cap <= WIND_MAX, `${String(felled)} keeps gives a cap of ${String(cap)}`)
+    // Zero, or a real subtraction. Never a nudge of the dial she could learn by
+    // watching, and never one the blast would swallow.
+    assert.ok(cap === 0 || cap >= WIND_MIN, `${String(felled)} keeps gives a cap of ${String(cap)}`)
+    prev = cap
   }
-  const higher = [
-    { d: 0.369, what: 'add.column.subtract-no-regroup L1' },
-    { d: 0.415, what: 'tables-to-twelve L2' },
-    { d: 0.462, what: 'add.regroup.add-multidigit L0' },
-    { d: 0.492, what: 'add.regroup.subtract-multidigit L0' },
-  ]
-  for (const rung of higher) {
-    assert.ok(windCapFor(rung.d) >= 3, `${rung.what} (d=${String(rung.d)}) must have a wind`)
+  assert.equal(windCapFor(1e9), WIND_MAX, 'the top step is not the strongest wind')
+  // A count that is not a number must not become a wind.
+  assert.equal(windCapFor(Number.NaN), 0, 'NaN is not a number of keeps')
+})
+
+test('each step of the ramp is more arithmetic than the last, not just more metres', () => {
+  // A step that adds a metre to the cap but leaves the child with the same ONE
+  // magnitude to memorise is not a step. Counted as magnitudes she has to tell
+  // apart, which is what makes the adjustment a subtraction rather than a habit.
+  const magnitudes = WIND_STEPS.map(
+    (step) => new Set(windValues(step.cap).map((w) => Math.abs(w))).size,
+  )
+  assert.deepEqual(magnitudes, [0, 2, 3], `the ramp offers ${magnitudes.join(', ')} magnitudes`)
+  for (const step of WIND_STEPS) {
+    for (const w of windValues(step.cap)) {
+      assert.ok(Math.abs(w) > GRAZE_M, `a wind of ${String(w)} is inside the blast`)
+    }
   }
 })
 
-test('the wind is never 1, never past WIND_MAX, and never shrinks with difficulty', () => {
-  // A wind of 1 metre is not arithmetic: a child can nudge the dial one notch and
-  // watch. And the dial only carries WIND_MAX of slack past the field, so a cap
-  // above it would ask for a compensation she cannot enter.
-  let prev = 0
-  for (let d = 0; d <= 1.0001; d += 0.002) {
-    const cap = windCapFor(d)
-    assert.ok(cap === 0 || cap >= 3, `d=${d.toFixed(3)} gives a cap of ${String(cap)}`)
-    assert.ok(cap <= WIND_MAX, `d=${d.toFixed(3)} gives a cap of ${String(cap)}`)
-    assert.ok(cap >= prev, `the wind dropped at d=${d.toFixed(3)}`)
-    prev = cap
+test('an ignored wind always misses the keep, at every step of the ramp', () => {
+  // THE test this change exists for, and the one the founder's report is about.
+  //
+  // Measured on `origin/main` over 450 shots through the real game: a child who
+  // worked the sum out correctly and dialled her answer without adjusting for the
+  // wind came down inside the target keep's blast radius 165 times out of 190 —
+  // 86.8%. The boulder struck the tower she was aiming at, the tower cracked and
+  // leaned, and she was told she was wrong. There was nothing on the screen from
+  // which she could have worked out why, which is what "they are confusing and
+  // don't necessarily do anything" means when you take it literally.
+  //
+  // So: an ignored wind must leave THE KEEP SHE NAMED standing and unmarked, out of
+  // blast reach, with the crater in the open ground beside it carrying her own
+  // number — which is the feedback the manual has promised all along for a wrong
+  // answer ("you get to see how far off you were") and which the wind, measurably,
+  // was never once able to trigger.
+  //
+  // And it must not fire the garrison at a keep that is not hers, because the
+  // garrison means "you named the wrong number" and she did not: she named the
+  // right one and let the wind have it.
+  const failures: string[] = []
+  let cases = 0
+  for (const step of WIND_STEPS) {
+    for (const wind of windValues(step.cap)) {
+      // Keeps at the closest spacing the field ever allows, which is the hardest
+      // case: any wider and an ignored wind is further from everything.
+      for (const answer of [20, 60, 100]) {
+        const field = [answer - MIN_GAP * 2, answer - MIN_GAP, answer, answer + MIN_GAP, answer + MIN_GAP * 2]
+        const towers = field.map((range, id) => ({ id, range, value: range, alive: true }))
+        cases++
+        // She reads the sum, gets it right, and dials her answer.
+        const out = resolve(shotFor(answer, LOFT_DEG, wind, LAUNCH_H).landing, towers)
+        const where = `cap ${String(step.cap)}, wind ${String(wind)}, answer ${String(answer)}`
+        if (Math.abs(out.landing - answer) <= GRAZE_M) {
+          failures.push(`${where}: landed ${String(out.landing)}, inside the blast of her own keep`)
+        }
+        if (out.target?.range === answer) {
+          failures.push(`${where}: ${out.quality} on the keep she named`)
+        }
+        for (const t of towers) {
+          if (Math.abs(out.landing - t.range) <= 1) {
+            failures.push(`${where}: landed ${String(out.landing)}, the garrison at ${String(t.range)} fires`)
+          }
+        }
+      }
+    }
   }
-  assert.equal(windCapFor(WIND_FROM_D - 0.001), 0, 'just below the threshold, no wind')
-  assert.equal(windCapFor(WIND_FROM_D), 3, 'at the threshold, three metres')
-  assert.equal(windCapFor(1), WIND_MAX, 'at the top of the ladder, the strongest wind')
-  // A difficulty that is not a number must not become a wind.
-  assert.equal(windCapFor(Number.NaN), 0, 'NaN is not a difficulty')
+  assert.equal(failures.slice(0, 8).join('\n'), '', `${failures.length} of ${cases} ignored winds`)
+  // A guard on the sweep, so a `windValues` that quietly returned nothing could not
+  // pass this by testing nothing. 30 today: the still-air step contributes no winds
+  // at all, the two windy steps contribute 4 and 6, and each is fired at 3 answers.
+  assert.equal(cases, 30, `${cases} ignored winds — the ramp is not the shape this sweeps`)
+  assert.equal(
+    WIND_STEPS.filter((step) => windValues(step.cap).length > 0).length,
+    2,
+    'the sweep no longer covers two windy steps',
+  )
 })
 
 test('the ram does not roll while the child is working the sum out', () => {
@@ -197,7 +251,7 @@ test('the wall can never stand between a child and a keep she named correctly', 
   for (let w = 1; w <= 40; w++) {
     const cfg = waveConfig(w)
     if (!cfg.wall) continue
-    for (const cap of [0, 3, 5, 7, WIND_MAX]) {
+    for (const cap of WIND_STEPS.map((step) => step.cap)) {
       for (let nearest = 14; nearest <= 118; nearest += 3) {
         const wall = wallFor(nearest, cap)
         walls++

--- a/dynawalla/games/trebuchet/src/sim/world.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.ts
@@ -8,8 +8,13 @@
 
 import type { Question } from '../contract.ts'
 import { type Rng } from '../core/rng.ts'
-import { heightAtX, LAUNCH_H } from './ballistics.ts'
+import { heightAtX, LAUNCH_H, WIND_MAX, WIND_MIN } from './ballistics.ts'
 import { shotFor } from './verdict.ts'
+
+// The field geometry is declared next to the blast that gives it its meaning; it
+// is re-exported here because this is the module the rest of the game asks about
+// the field.
+export { MIN_GAP, WIND_MAX, WIND_MIN } from './ballistics.ts'
 
 /** World x of the launch point; ranges are measured from here. */
 export const LAUNCH_X = 6
@@ -65,72 +70,60 @@ export function waveConfig(i: number): WaveConfig {
 export const LOFT_DEG = 46
 
 /**
- * When the wind starts blowing, as a position on the host's ladder.
+ * When the wind starts blowing, and how hard: a ladder indexed by what the child
+ * has DEMONSTRATED, not by where the curriculum happens to be pointing.
  *
- * NOT a wave number. A wave counter is a ratchet the pack owns, and it says
- * nothing about whether this particular child is ready for a second arithmetic
- * step: it arrives on her twelfth minute whether she has been landing every
- * boulder or none of them. The item's own difficulty is the host's judgement of
- * where she is, and it is on every `Question`.
+ * It used to be a position on the host's ladder (`WIND_FROM_D = 0.34`), on the
+ * reasoning that the item's own difficulty is the host's judgement of where the
+ * child is. The reasoning is sound and the measurement killed it: `game.ts` climbs
+ * the difficulty it asks for by a notch a wave and SWEEPS, wrapping, whenever a
+ * rung's answers will not fit on 122 metres, so the rung served oscillates and the
+ * wind oscillated with it — on at wave 4, off at 8, back at 14, gone at 18. See
+ * `sim/felled.ts` for the run.
  *
- * Measured over the shipped 66-rung ladder, taking 60 questions off every rung
- * and keeping the ones whose answers a 122-metre field can stand a keep at:
+ * So it is bought instead, with keeps felled. Three steps, and the whole table is
+ * here so that "monotone non-decreasing in what she has demonstrated" is something
+ * you can read rather than something you have to trust:
  *
- *     0.246  PLACEABLE   4..49     dw.mul.facts.tables-to-twelve L0
- *     0.277  PLACEABLE  27..99     dw.add.column.add-no-regroup L0
- *     0.292  PLACEABLE   1..82     dw.add.column.subtract-no-regroup L0
- *     0.323  PLACEABLE   6..72     dw.mul.facts.tables-to-twelve L1
- *     ---- 0.34: the wind starts here ----
- *     0.369  PLACEABLE   6..765    dw.add.column.subtract-no-regroup L1
- *     0.415  PLACEABLE   6..144    dw.mul.facts.tables-to-twelve L2
- *     0.462  PLACEABLE  33..171    dw.add.regroup.add-multidigit L0
- *     0.492  PLACEABLE   3..78     dw.add.regroup.subtract-multidigit L0
+ *     felled  0..11   no wind        — the game the founder is not complaining about
+ *     felled 12..23   ±4 or ±5       — two magnitudes: not one nudge to memorise
+ *     felled 24+      ±4, ±5 or ±6   — the whole mechanic
  *
- * So everything below the line is a table fact or a column sum with no
- * regrouping. A child on those is meeting the game for the first time and gets
- * the game the founder is not complaining about: read the sum, dial the answer,
- * the keep falls. The wind arrives once the ladder has taken her past that —
- * `game.ts` opens its search at 0.28 and climbs a notch a wave.
+ * The first twelve are necessarily felled in still air, because there is no wind
+ * below twelve, so step 1 is bought by fluency at the ONE-step game; the twelve
+ * after it are felled in a wind, so step 2 is bought by fluency at the two-step
+ * game. Twelve keeps is roughly the first four or five waves' worth of boulders,
+ * which is where the old difficulty gate landed too — but now it lands there
+ * because she has been putting boulders on the metre, and a child who has not is
+ * simply still playing the one-step game. There is no clock in this and no wave
+ * counter: a child can take six goes at a keep and the twelfth felled keep still
+ * buys the wind.
  *
- * Driven against the real `ladder()` with the real generators and the app's own
- * rung quantisation, that lands as:
- *
- *     wave 1   rung 0.277  answers 98, 87        no wind
- *     wave 2   rung 0.292  answers 27, 71        no wind
- *     wave 3   rung 0.308  answers 25, 16        no wind
- *     wave 4   rung 0.323  answers 16, 30, 45    no wind
- *     wave 5   rung 0.369  answers 43,80,97,112  WIND, up to 3 metres
- *     ...      rung 0.369                        WIND, up to 3 metres
- *
- * So four waves of the game the founder is not complaining about, and then the
- * second step. It holds at three metres from there because the pack's arithmetic
- * escalation is itself pinned by the 122-metre field — the sweep cannot climb past
- * rung 24 without landing on four-digit column sums no keep can stand at, which is
- * the plateau #702 documented and is not this change's to move.
+ * The steps stop at three because the geometry stops there. `WIND_MIN` is one
+ * metre past the blast and `WIND_MAX` one metre inside the garrison's reach (see
+ * `ballistics.ts`), so 4..6 is the entire honest range and there is nothing left to
+ * stagger. A fourth step would have to invent headroom the field does not have.
  */
-export const WIND_FROM_D = 0.34
-/** The strongest wind there is. The dial carries this much slack at both ends. */
-export const WIND_MAX = 9
-/** One more metre of wind every this far up the ladder. */
-const WIND_RAMP = 0.06
+export const WIND_STEPS: ReadonlyArray<{ felled: number; cap: number }> = [
+  { felled: 0, cap: 0 },
+  { felled: 12, cap: WIND_MIN + 1 },
+  { felled: 24, cap: WIND_MAX },
+]
 
 /**
- * How hard the wind blows for an item of this difficulty — the size of the second
- * arithmetic step, in metres.
+ * How hard the wind may blow for a child who has felled this many keeps — the size
+ * of the second arithmetic step, in metres.
  *
- * Zero below the threshold, and it never OPENS below 3 — so from the first wind she
- * meets, `rollWind` has the whole of ±1..±3 to draw from and the adjustment is a
- * different number every shot. A cap of 1 would have made the mechanic a single
- * nudge of the dial, learnable without arithmetic and then boring.
- *
- * It grows a metre every `WIND_RAMP` up the ladder, to `WIND_MAX`. On today's ladder
- * the pack's own escalation plateaus before that headroom is used — see
- * `WIND_FROM_D` — so the ramp is what happens when the curriculum or the field
- * grows, not a promise about this month's content.
+ * A pure function of the count and nothing else. It never opens below `WIND_MIN`,
+ * so from the first wind she ever meets the adjustment is a real subtraction and
+ * not a nudge of the dial she could learn by watching; and it never shrinks, so the
+ * rule about what a right answer looks like changes exactly once.
  */
-export function windCapFor(difficulty: number): number {
-  if (!Number.isFinite(difficulty) || difficulty < WIND_FROM_D) return 0
-  return Math.min(WIND_MAX, 3 + Math.floor((difficulty - WIND_FROM_D) / WIND_RAMP))
+export function windCapFor(felled: number): number {
+  if (!Number.isFinite(felled)) return 0
+  let cap = 0
+  for (const step of WIND_STEPS) if (felled >= step.felled) cap = step.cap
+  return cap
 }
 
 /* ------------------------------------------------------------------ *
@@ -171,15 +164,15 @@ export const PLACEABLE_HI = FIELD_MAX - 4
  * How far the dial winds — and it is WIDER than the field, on purpose.
  *
  * The dial is the range in still air, and in a wind the child aims off it: to put
- * a boulder on metre 14 with the wind pushing 9 metres downrange she has to dial
- * 5, and to put one on 118 against a 9-metre headwind she has to dial 127. If the
- * dial stopped at the field the compensation would be inexpressible at both ends —
- * a correct answer she is physically unable to enter, which is the same defect as
- * a correct answer scored wrong. So the dial carries `WIND_MAX` of slack past
+ * a boulder on metre 14 with the wind pushing 6 metres downrange she has to dial 8,
+ * and to put one on 118 against a 6-metre headwind she has to dial 124. If the dial
+ * stopped at the field the compensation would be inexpressible at both ends — a
+ * correct answer she is physically unable to enter, which is the same defect as a
+ * correct answer scored wrong. So the dial carries `WIND_MAX` of slack past
  * `PLACEABLE_LO..PLACEABLE_HI` at both ends, and `windValues` can never ask for
  * more than that.
  *
- * Nothing lands out there: a shot dialled to 127 into a 9-metre headwind
+ * Nothing lands out there: a shot dialled to 124 into a 6-metre headwind
  * decelerates the whole way and comes down at 118, and the drawn ground already
  * runs 40 metres past the field.
  */
@@ -191,11 +184,16 @@ export const DIAL_MAX = PLACEABLE_HI + WIND_MAX
  * a metre that exists.
  *
  * The dial reaches past both ends of the field so that the compensation is always
- * expressible, and that slack has to be paid for at the other end: dialling 5 into
- * a nine-metre headwind claims metre −4, and a boulder aimed at metre −4 arcs
- * forward, turns round in mid-air and comes down behind the trebuchet. Found by
- * sweeping the dial rather than by reading the code, which is the only way this
- * kind of corner ever turns up.
+ * expressible, and that slack used to have to be paid for at the other end: when
+ * the wind reached 9, dialling 5 into a nine-metre headwind claimed metre −4, and a
+ * boulder aimed at metre −4 arced forward, turned round in mid-air and came down
+ * behind the trebuchet. Found by sweeping the dial rather than by reading the code,
+ * which is the only way that kind of corner ever turns up.
+ *
+ * At `WIND_MAX = 6` the floor is 8 and `1 − wind` never exceeds 7, so the `1 −
+ * wind` term can no longer bind and the corner is gone from the geometry rather
+ * than merely guarded. The guard stays because it is the thing that has to remain
+ * true if the field or the blast ever move, and it costs one `Math.max`.
  *
  * So the claim is held inside `1..DIAL_MAX` and the dial's own stops move with the
  * wind. **This can never bind on a child who is right**, and that is arithmetic and

--- a/dynawalla/games/trebuchet/src/stubHost.ts
+++ b/dynawalla/games/trebuchet/src/stubHost.ts
@@ -11,12 +11,16 @@
 
 import type { Host, Question } from './contract.ts'
 import { makeRng, shuffled, type Rng } from './core/rng.ts'
+// The one MIN_GAP. It used to be typed out here as well, and it now sets the
+// strongest wind the game can blow (`WIND_MAX = MIN_GAP - 2`), so a second copy is
+// a way for the stub's keeps and the real wind bounds to drift apart in silence.
+export { MIN_GAP } from './sim/ballistics.ts'
+
+import { MIN_GAP } from './sim/ballistics.ts'
 
 /** Towers stand at their own value in metres, so answers must fit the field. */
 export const ANSWER_MIN = 14
 export const ANSWER_MAX = 118
-/** Two towers closer than this would overlap on screen. */
-export const MIN_GAP = 8
 
 export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
 


### PR DESCRIPTION
> "for trebuchet, we can't figure out what the wind .. are we supposed to shoot it longer, shorter, ignore it? ... I think in the current implementation they are confusing and don't necessarily do anything."

**Option (a): the wind stays and becomes real maths.** The measurement below is why, and what it cost.

## First, what the wind actually did

Measured on `origin/main` before touching anything — 450 shots across five seeds and waves 1–20, driven through the real `TrebuchetGame` against the faithful ladder harness. The child modelled is a competent one: she reads the sum, works it out **correctly**, and dials her answer without adjusting for the wind.

| wind cap | n | displacement | graze | solid | **miss** |
|---|---|---|---|---|---|
| 3 | 95 | 1..3 m | 72% | 28% | **0%** |
| 4 | 95 | 1..4 m | 55% | 25% | **20%** |
| 0 | 260 | 0 m | — | — | (direct 100%) |

**165 of 190 windy shots — 86.8% — came down inside the blast radius of the keep she was aiming at.** The boulder struck the tower, the tower cracked and leaned, masonry came off it (`game.ts` `struck.damage += 0.34`, `struck.lean`), and the game recorded a wrong answer.

So: is the wind honest? The *arithmetic* was, and #654 fixed that — `claim = dial + wind`, rolled before she commits, never touched again, and this PR does not move any of it. I verified the pacing-audit defect (`landing = R + wind` with the caret on the dial) is genuinely gone.

But the wind's **entire range was smaller than the blast it moved the boulder by** — 1–3 m against `GRAZE_M = 3`, on a field where keeps are 8 m apart and 4.6 m wide. It was invisible in the world and audible only in the verdict. That is strictly worse than either honest option: it looks ignorable and it is not, and the child's only evidence is a tower she watched her boulder hit, still standing, marked wrong.

**Is it learnable?** The compensation is `answer − wind`, one integer subtraction — yes, computable. The reason a child could not learn it was not the arithmetic. It was that there was no observation from which to infer the rule.

### And a second thing nobody had measured

The wind cap by wave, same run:

```
wave  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
cap   0  0  0  3  3  4  4  0  0  0  0  0  0  3  3  4  4  0  0  0
```

On at wave 4, **off at 8**, back at 14, gone at 18. The wind was gated on the item's difficulty — defensible reasoning — but `stock()` sweeps and *wraps* looking for a rung whose answers fit on 122 metres, so the rung served oscillates and the wind oscillated with it. None of that is anything the child did. A mechanic that appears and disappears is not a difficulty step.

## What changed

**1. The magnitude is pinned to the geometry at both ends** (`sim/ballistics.ts`).

- `WIND_MIN = GRAZE_M + 1` = 4 — one metre past the blast, so an ignored wind lands **clear of her keep** and leaves a crater with her own number in it. That is the feedback the manual has promised for a wrong answer since day one ("you get to see how far off you were") and which the wind was measurably never able to trigger.
- `WIND_MAX = MIN_GAP − 2` = 6 — one metre inside the garrison's reach, so an ignored wind never fires the wrong-horn/counter-volley, which would say "you named the wrong number" when she had named the right one and let the wind have it.

Not claimed: that an ignored wind touches *nothing*. At the closest spacing the field allows, a 6 m wind lands 2 m from the neighbouring keep and the blast shakes it — the truth about the shot, told next to a keep that is not hers. Making it touch nothing needs `MIN_GAP = 10`, and the suite proves the cost directly: mutating `MIN_GAP` to 10 fails with **`wave 3 could not fill the rack`**. The mechanic does not get to shorten the waves.

**2. It is bought, not handed over** (`sim/felled.ts`, `WIND_STEPS` in `sim/world.ts`). A persisted count of felled keeps indexes a monotone three-step ramp — nothing below 12, ±4..5 to 24, ±4..6 above — with the top step being the full mechanic. The first twelve are *necessarily* felled in still air (there is no wind below twelve), so step 1 is bought by fluency at the one-step game and step 2 by fluency at the two-step game.

One counter, not two, and that came from measurement: a first draft counted only still-air kills, and a fresh child playing perfectly **froze at fifteen and could never reach the top step**, because the currency stopped being earnable the moment she crossed the first threshold.

## After

Same harness, a fresh child playing well:

```
waves 1-5   cap 0   still air — 15 keeps felled
waves 6-8   cap 5   ±4, ±5
wave 9+     cap 6   ±4, ±5, ±6      (monotone; never turns off again)

ignored winds that touched her own keep:  0 of 75
garrison misfires:                        0
displacement: 4..6 m, mean 4.9
```

### The compensation a child performs

The boulder says `47 + 25`. The chip shows an arrow pointing downrange with a **5** beside it.

1. `47 + 25 = 72` — the keep she wants.
2. The wind will carry the boulder 5 metres further than the dial says, so take it off: `72 − 5 = 67`.
3. Dial 67, fire. The boulder leaves at 67 and the wind puts it on **72**. The keep comes down.

Forget the 5 and it lands on **77** — five metres past a keep that stays standing, with `77` burnt into the open ground where she can read it. Wrong for a stated reason, not by an invisible margin.

## The angle

Not coming back, and I want to be plain about it rather than quietly ignore half the request. The loft lever was already removed for **exactly the defect being fixed here**: measured over 1,616 wall situations, three of its five settings were identical to the default and the two below it were blocked by the wall 42.9% and 21.9% of the time — every position was either the default or a way to lose. Making a launch angle *computable* by a child in grades 1–6 needs trigonometry that is not in the curriculum, and making it the wind's multiplier stacks a multiplication on top of the sum and the adjustment, three steps deep, on a child who is here to practise `47 + 25`. A second decorative dial is the complaint, not the answer.

## Verification

- `npm run -s tsc` clean; `npm run -s test` **139/139, five consecutive runs**, no flake.
- `node packs/build.mjs trebuchet` builds and passes the SDK checker.
- Adversarial self-review run before opening; all nine findings fixed (manual copy that was false ~10% of the time, stale `dialRange` docs, a `localStorage`/module-state leak across tests, a duplicated `MIN_GAP` in `stubHost.ts`, a junk-value sweep that only tested a weak predicate, a sweep guard sitting on its own boundary).

### Every new assertion mutation-tested

Each mutation applied, suite run, failure and exact message recorded, mutation reverted.

| # | mutation | fails with |
|---|---|---|
| 1 | `WIND_MIN = GRAZE_M` | `landed 17, inside the blast of her own keep` / `the ramp offers 0, 2, 4 magnitudes` |
| 2 | `WIND_MAX = MIN_GAP - 1` | `landed 13, the garrison at 12 fires` |
| 3 | ramp gate opens at 0 felled | `wave 1 put a wind on a child who has felled nothing` |
| 4 | top step goes backwards | `the wind shrank at 24 keeps` |
| 5 | `noteFelled()` never called | `the wind never arrived across 60 shots: 0,0,0,…` |
| 6 | every shot counts, not only kills | `a miss bought progress` / `the wind blew after only 7 keeps` |
| 7 | count never written to storage | `the count never reached storage` |
| 8 | count never read back | `a fluent child must meet a wind; cap is 0` |
| 9 | junk in the slot trusted | `"Infinity" became Infinity keeps` |
| 10 | `rollWind` may emit below `WIND_MIN` | `cap 5 rolled 3` |
| 11 | `windValues` drops the floor | `the ramp offers 0, 5, 6 magnitudes` |
| 12 | `localStorage` access unguarded | `Error: SecurityError: the document is sandboxed` |
| 13 | no `isFinite` guard on the count | `"Infinity" became Infinity keeps` |
| 14 | `installDom` stops resetting the count | `a child on her first wave was handed a wind` |
| 15 | `MIN_GAP` → 10 | `wave 3 could not fill the rack` |

No `assert.deepEqual(x, [])`, and no assertion compares a value to the tuning constant that produced it — the two bounds are asserted through behaviour (`resolve()` over real layouts), which is what mutations 1 and 2 demonstrate.

## Binding

- No clock added, none removed. Speed is not enforced anywhere in this game and this change does not introduce it.
- `windCapFor` is a **pure function of the felled count**, monotone non-decreasing, with the top step being the full mechanic — the ramp shape used in `games/lattice` (#762) and `games/skyledger` (#769).
- Stayed in lane: only the wind and the angle. `src/index.ts` instruction copy is touched only where this change made it false.

Scope is `dynawalla/games/trebuchet` only.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb