### PR TITLE
dynawalla: ARENA teaches the times tables, and the fleet can no longer lose a curriculum row quietly

### DIFF
--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -53,6 +53,7 @@ import {
   windowFor,
 } from "./items.ts"
 import type { Attempt, Band, ItemService, Recent, Rung, Staircase } from "./items.ts"
+import type { Item } from "../../../packs/sdk/src/index.ts"
 import type { PromptBlank, PromptSlot } from "./curriculum.ts"
 import {
   activeNodes,
@@ -3666,4 +3667,123 @@ test("the spread the host draws around its own rung cannot reach under a stated 
   // And it really was the floor doing the work, not a spread that never reached
   // down there anyway.
   assert.equal(lowest, bottom, "the spread never once came down to the floor, so this proves nothing")
+})
+
+/* ── The rows THE GAVEL took with it, and the pack that has them now ───────── */
+
+/** ARENA's `MAX_DRAWABLE_LABEL` (`games/arena/src/sim/world.ts`), int32. */
+const ARENA_MAX_LABEL = 2147483647
+
+/** Everything a child would have to read off a sphere for one item. */
+function labelsOf(item: Item, service: ItemService): readonly string[] {
+  return [service.reveal(item.id) ?? "", ...(item.choices ?? []).map((choice) => choice.text)]
+}
+
+/** Whether ARENA could put this whole item on the screen. */
+function arenaCanDraw(labels: readonly string[]): boolean {
+  const distinct = new Set(labels)
+  if (distinct.size < 4) return false
+  for (const text of labels) {
+    const v = Number(text)
+    if (!Number.isSafeInteger(v) || Math.abs(v) > ARENA_MAX_LABEL) return false
+  }
+  return true
+}
+
+/**
+ * Every question the six rows can generate is one ARENA can actually build.
+ *
+ * These are the rows no shipping pack stated: the four THE GAVEL took with it
+ * when it was retired (PR 749) and the two — `dw.mul.scale.times-power-of-ten`,
+ * `dw.mul.multidigit.long-multiplication` — that were promoted to `active` and
+ * never claimed by anybody at all. ARENA declares them now, so this is the check
+ * that the declaration is a fact rather than a hope: the whole point of
+ * `covers.skills` is defeated by a pack that says it teaches a row and then meets
+ * a question from it that it cannot put on the screen. That has shipped four
+ * times in a fortnight — trebuchet 698, foundry 711, lattice 716, balance 724
+ * — and every one of them was a board built out of a prompt the pack had already
+ * decided to keep.
+ *
+ * "Build" is ARENA's own two conditions, and nothing else: **four distinct
+ * numerals**, because the beat is four spheres and it declines rather than draw a
+ * duplicate; and **every one of them inside int32**, because a label goes through
+ * `mval` and a value past that lands there as `0`. Every level, forty seeds each.
+ */
+test("every question ARENA's new rows can generate is one ARENA can build", () => {
+  const rungs = ladder()
+  const declared = new Set([
+    "dw.mul.facts.tables-within-five",
+    "dw.mul.facts.tables-to-twelve",
+    "dw.mul.scale.times-power-of-ten",
+    "dw.mul.multidigit.long-multiplication",
+    "dw.div.facts.division-facts",
+    "dw.div.whole.zero-in-the-quotient",
+  ])
+  const mine = rungs.filter((rung) => declared.has(String(rung.node.id)))
+  // Six rows, nineteen levels between them. Without this the filter can go stale
+  // against a renamed id and every assertion below passes on an empty sweep.
+  assert.equal(new Set(mine.map((rung) => String(rung.node.id))).size, 6, "a declared row is not on the ladder")
+  assert.ok(mine.length >= 15, `only ${String(mine.length)} levels swept — the ladder filter has gone stale`)
+
+  const unbuildable: string[] = []
+  for (const rung of mine) {
+    const service = createItemService({
+      profileId: `arena-${String(rung.node.id)}-${String(rung.level)}`,
+      record: noRecord,
+      rungs: [rung],
+    })
+    for (let seed = 0; seed < 40; seed++) {
+      const item = service.next({ packId: "dynawalla.arena", difficulty: 0.5 })
+      assert.ok(item, `${String(rung.node.id)} L${String(rung.level)} generated nothing`)
+      if (!arenaCanDraw(labelsOf(item, service))) {
+        unbuildable.push(`${String(rung.node.id)} L${String(rung.level)}: ${item.prompt}`)
+      }
+      service.skip(item.id)
+    }
+  }
+
+  // One level fails, it is the top of the whole ladder, and it is the level
+  // ARENA's ceiling exists to take out — see the test below. Everything else is
+  // clean, which is what the declaration is claiming.
+  const rows = new Set(unbuildable.map((line) => line.split(":")[0]))
+  assert.deepEqual(
+    [...rows].sort(),
+    ["dw.mul.multidigit.long-multiplication L2"],
+    `rows ARENA declares and cannot build: ${[...rows].sort().join(", ")}`,
+  )
+})
+
+/**
+ * …and the ceiling that covers the one level above it costs exactly one rung.
+ *
+ * A capability window is only honest if it is measured. ARENA's ceiling is
+ * derived at runtime from whatever it was actually refused, so the thing to pin
+ * here is the ladder-side fact that makes it cheap: `long-multiplication` L2 is
+ * the ONLY rung in the whole shipped curriculum that reaches past int32, and it
+ * is the TOP one. If that stopped being true — a new row landed above it, or a
+ * level widened underneath it — ARENA's ceiling would start costing a child
+ * content it can draw perfectly well, silently, and this is what says so.
+ */
+test("exactly one rung on the shipped ladder is out of ARENA's reach, and it is the last one", () => {
+  const rungs = ladder()
+  assert.ok(rungs.length > 40, `the ladder has ${String(rungs.length)} rungs — this sweep proves nothing`)
+  const over: number[] = []
+  for (let index = 0; index < rungs.length; index++) {
+    const rung = rungs[index] as Rung
+    const service = createItemService({ profileId: `reach-${String(index)}`, record: noRecord, rungs: [rung] })
+    for (let seed = 0; seed < 40; seed++) {
+      const item = service.next({ packId: "dynawalla.arena", difficulty: 0.5 })
+      assert.ok(item)
+      if (!arenaCanDraw(labelsOf(item, service))) {
+        over.push(index)
+        break
+      }
+      service.skip(item.id)
+    }
+  }
+  assert.deepEqual(
+    over,
+    [rungs.length - 1],
+    `rungs ARENA cannot draw: ${over.map((i) => `${String(i)} ${String((rungs[i] as Rung).node.id)}`).join(", ")}`,
+  )
 })

--- a/dynawalla/games/arena/pack.json
+++ b/dynawalla/games/arena/pack.json
@@ -2,13 +2,21 @@
   "id": "dynawalla.arena",
   "version": "0.1.0",
   "name": "ARENA",
-  "description": "A bioluminescent growth arena. You are a number in a black ocean where everything obeys one radius law, so \"smaller than me\" is something you see before you read it — and telling 3,418 from 3,481 at speed is the whole game.",
+  "description": "A bioluminescent growth arena. You are a number in a black ocean where everything obeys one radius law, so \"smaller than me\" is something you see before you read it. Then the water stills, four identical spheres rise, and only the times table tells them apart.",
   "sdk": "1.0.0",
   "host": { "min": "0.1.0", "max": "1.0.0" },
   "entry": "pack.html",
   "capabilities": ["items", "items.reveal", "haptics"],
   "covers": {
-    "skills": ["dw.ns.compare.whole-numbers"]
+    "skills": [
+      "dw.ns.compare.whole-numbers",
+      "dw.mul.facts.tables-within-five",
+      "dw.mul.facts.tables-to-twelve",
+      "dw.mul.scale.times-power-of-ten",
+      "dw.mul.multidigit.long-multiplication",
+      "dw.div.facts.division-facts",
+      "dw.div.whole.zero-in-the-quotient"
+    ]
   },
   "minAge": 8,
   "locales": ["en"],

--- a/dynawalla/games/arena/src/contract.ts
+++ b/dynawalla/games/arena/src/contract.ts
@@ -1,6 +1,14 @@
 export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
 export type Host = {
-  next(opts?: { domain?: string; difficulty?: number }): Question
+  /**
+   * `maxDifficulty` is a CAPABILITY, not a preference: "I cannot draw a question
+   * harder than this." `packs/shared/game-host` holds it as a standing ceiling
+   * once sent and puts it on the wire on every request after, and the host
+   * honours it absolutely — above the child's band as well as below it. ARENA
+   * sends it only after meeting a numeral it cannot print; see
+   * `lowerDrawCeiling` in `sim/world.ts`.
+   */
+  next(opts?: { domain?: string; difficulty?: number; maxDifficulty?: number }): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean

--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -413,6 +413,105 @@ test("a question ARENA cannot draw is never asked, and never costs a child anyth
 })
 
 /**
+ * Declining is half a capability. This is the other half.
+ *
+ * The test above proves ARENA never poses a numeral it cannot print. On its own
+ * that is a pack that stops asking questions while looking exactly like a pack
+ * that is working: the host has no reason to stop offering the rung, so the beat
+ * is refused, retried twenty seconds later, and refused again, for the rest of
+ * the session. That is the defect `next({ maxDifficulty })` exists for, and it is
+ * the one this pack was carrying — POLARITY and TREBUCHET each shipped a release
+ * of it before the window grew the half they needed.
+ *
+ * Two claims, and the second is the one that makes it a capability rather than a
+ * mood: the ceiling is DERIVED from the refused item's own ordinate, and it only
+ * ever goes down.
+ */
+test("meeting a numeral it cannot print makes ARENA state a ceiling, once and downward", () => {
+  const realWarn = console.warn
+  console.warn = () => {}
+  try {
+    const asks: ({ difficulty?: number; maxDifficulty?: number } | undefined)[] = []
+    // The LOW rung first, then the high one for the rest of the run. This
+    // ordering is the whole reason the fixture is shaped like this: a ceiling
+    // that simply tracked the latest refusal would be set to 0.70, then RAISED to
+    // 0.93 on the next question, and would re-admit the very rung it was set for.
+    // Written the other way round — high first, then low — every mutation of the
+    // monotone guard still passes, because the numbers happen to descend on their
+    // own. (It was written that way round first, and M4 below caught nothing.)
+    //
+    // This stub deliberately ignores `maxDifficulty`: what is under test is what
+    // ARENA says, not whether a host obeys it.
+    const ordinates = [0.71, 0.94]
+    let served = 0
+    const bigHost: Host = {
+      next: (opts) => {
+        asks.push(opts)
+        const at = ordinates[Math.min(served, ordinates.length - 1)] as number
+        served++
+        return {
+          id: `big-${String(served)}`,
+          prompt: "37388 × 85585",
+          answer: "3199851980",
+          distractors: ["3199851981", "3199851979", "3199851990"],
+          domain: "multiply",
+          difficulty: at,
+        }
+      },
+      report: () => {},
+      haptic: () => {},
+      prefersReducedMotion: () => false,
+    }
+    const bw = new World(bigHost, specFor("low"), 21)
+    for (let f = 0; f < 60 * 60 * 4; f++) bw.step(1 / 60)
+
+    assert.ok(asks.length >= 3, `the host was asked ${String(asks.length)} times — too few to see a ceiling`)
+    // Nothing is claimed before there is evidence for it. A pack that asserted a
+    // ceiling on its opening request would be guessing at a ladder it cannot see.
+    assert.equal(
+      asks[0]?.maxDifficulty,
+      undefined,
+      "ARENA stated a ceiling before it had ever been handed something it could not draw",
+    )
+    // …and every request after the first refusal carries one, under the rung
+    // that was refused rather than at it: `items.ts` caps with
+    // `floor(maxDifficulty * span)`, so a ceiling set AT the refused ordinate
+    // re-admits the rung it was set for.
+    const after = asks.slice(1)
+    for (const ask of after) {
+      assert.equal(typeof ask?.maxDifficulty, "number", `a request after a refusal carried no ceiling: ${JSON.stringify(ask)}`)
+    }
+    const first = after[0]?.maxDifficulty as number
+    assert.ok(
+      first < 0.71,
+      `the ceiling was ${String(first)}, which does not exclude the 0.71 rung that was refused — ` +
+        `\`items.ts\` caps with floor(maxDifficulty × span), so a ceiling set AT the refused ` +
+        `ordinate re-admits the rung it was set for`,
+    )
+    // Derived from the refusal, not typed: it tracks the ordinate that arrived.
+    // A margin of zero, or a hard-coded ceiling, or one read off the wrong
+    // question all miss this by more than a float's worth.
+    assert.ok(
+      Math.abs(first - 0.7) < 1e-9,
+      `the ceiling was ${String(first)} — not one margin under the 0.71 rung the host actually offered`,
+    )
+    // Monotone. Every question after the first is offered at 0.94, which is ABOVE
+    // the ceiling already set: a ceiling that tracked the latest refusal would
+    // climb to 0.93 here and hand a child back the rung it had just excluded.
+    for (const ask of after) {
+      const c = ask?.maxDifficulty as number
+      assert.ok(
+        Math.abs(c - 0.7) < 1e-9,
+        `the ceiling moved from 0.7 to ${String(c)} — a refusal at a HARDER rung raised it`,
+      )
+    }
+    assert.equal(bw.drawableCeiling, first, "the world reports a different ceiling from the one it sends")
+  } finally {
+    console.warn = realWarn
+  }
+})
+
+/**
  * The other exploit, and the one that decided the shape of `devourGain`.
  *
  * The twenty-minute test above flies a bot that eats motes. This one flies the

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -192,27 +192,39 @@ const LADDER_CLIMB_ANSWERS = 55
  * is fine, `37388 × 85585 = 3199851980` is not. ARENA's old integer request landed
  * on exactly that rung whenever the breath reached its ceiling.
  *
- * **That measurement was taken against an UNRESTRICTED host, and it is worth being
- * exact about why it still matters.** `pack.json` declares
- * `covers.skills: ["dw.ns.compare.whole-numbers"]`, and `game-host` honours that by
- * restricting the stream to the `dw.ns` domain — so in a normal session ARENA is not
- * served long multiplication at all and the bound is unreachable. But the
- * restriction is not a guarantee: `game-host` SURRENDERS it, loudly and for the rest
- * of the session, whenever it cannot serve the declared domain, and after a
- * surrender the whole ladder is in scope. The stub host reaches past it too, and
- * `covers.skills` is a line in a manifest that a future edit can widen without
- * touching this file.
+ * **That measurement was taken against an UNRESTRICTED host, and this is now the
+ * ordinary case rather than the exotic one.** This paragraph used to say the bound
+ * was unreachable in a normal session, because `pack.json` declared only
+ * `dw.ns.compare.whole-numbers` and `game-host` restricts the stream to the
+ * declared *domains*. Both halves of that were wrong. Every `dw.ns` row is `draft`,
+ * so the host cannot serve one at all and `game-host` SURRENDERS the restriction
+ * three questions in — after which the whole ladder was already in scope, exactly
+ * as it is here. And the manifest now declares the `dw.mul` and `dw.div` rows this
+ * pack actually teaches, which puts the top rung in scope by design.
  *
- * So this is a guard on the seam rather than a fix for a bug a child is hitting
- * today: it costs one comparison per option, and what it prevents is a child being
- * shown four spheres one of which silently reads `0`.
- *
- * `openResonance` refuses to pose an item it cannot draw, in the same way and for
- * the same reason it already refuses one it cannot supply four distinct options
- * for. It is a structural check on the item in hand rather than a ceiling on the
- * request, because the request is relative and the ladder grows.
+ * So the guard is load-bearing, and a guard on its own is not enough: refusing item
+ * after item from a rung the host has no reason to stop serving is a beat a child
+ * never gets, every twenty seconds, forever. `lowerDrawCeiling` turns the first
+ * refusal into a stated capability — `next({ maxDifficulty })` — so the second one
+ * never happens.
  */
 const MAX_DRAWABLE_LABEL = 2147483647
+
+/**
+ * How far below a refused item's own ordinate the ceiling is set.
+ *
+ * A hundredth of the host's ladder. The pack cannot count the host's rungs — the
+ * wire is a 0..1 ordinate precisely so it does not have to — so the margin is
+ * expressed in the same units the refusal arrived in: whatever rung that item was,
+ * the ceiling goes under it. On the 77-rung ladder this ships against a rung is
+ * 0.0132 wide, so this drops exactly the rung that was refused and nothing else;
+ * on a ladder long enough for a hundredth to span two rungs it drops two, which is
+ * the safe direction to be wrong in.
+ *
+ * It is not zero, because `items.ts` caps with `Math.floor(maxDifficulty * span)`
+ * and a ceiling set *at* the refused ordinate re-admits the rung that was refused.
+ */
+const DRAW_CEILING_MARGIN = 0.01
 const QUIET_TIDE_CEILING = 0.62
 
 /**
@@ -914,6 +926,13 @@ export class World {
   }
   private nextResonanceAt = 16
   private resonanceCount = 0
+  /**
+   * The highest ordinate ARENA will accept, once it has met one it cannot draw.
+   *
+   * `null` until the first refusal, and monotone non-increasing after it. See
+   * `MAX_DRAWABLE_LABEL` and `lowerDrawCeiling`.
+   */
+  private drawCeiling: number | null = null
 
   // -- events -------------------------------------------------------------
   private readonly eventPool: GameEvent[] = Array.from({ length: MAX_EVENTS }, blankEvent)
@@ -2562,6 +2581,44 @@ export class World {
     }
   }
 
+  /**
+   * Say, on the wire, that the rung just refused is above what ARENA can draw.
+   *
+   * The refusal above is a check on the item in hand; this is the half that was
+   * missing. Without it the host has no reason to stop offering that rung, so a
+   * child at the top of the ladder gets a refused beat every twenty seconds and
+   * the game simply stops asking questions while looking like it is working.
+   *
+   * **Derived, never typed.** The number is the ordinate of the item ARENA could
+   * not draw, less `DRAW_CEILING_MARGIN` — so it is measured off the actual
+   * refusal against the actual ladder, and a curriculum that grows a rung, moves
+   * one, or renumbers all of them needs no edit here. A constant here would be a
+   * rung index somebody counted by hand against a ladder that is 66 rungs in one
+   * comment in this file and 77 in the shipped graph.
+   *
+   * **Monotone non-increasing**, and never below zero. A ceiling that could rise
+   * again would re-admit the rung it was set for on the next breath, which is the
+   * decline loop with extra steps; and one that could go negative would ask the
+   * host for an empty window, which `items.ts` answers by saying so and serving
+   * anyway.
+   */
+  private lowerDrawCeiling(ordinate: number): void {
+    if (!Number.isFinite(ordinate)) return
+    const want = Math.max(0, ordinate - DRAW_CEILING_MARGIN)
+    if (this.drawCeiling !== null && want >= this.drawCeiling) return
+    this.drawCeiling = want
+    console.warn(
+      `[arena] capping the stream at ${want.toFixed(3)} — the rung at ` +
+        `${ordinate.toFixed(3)} carries numerals past ${String(MAX_DRAWABLE_LABEL)}, ` +
+        `which this pack cannot print`,
+    )
+  }
+
+  /** What ARENA has told the host it cannot draw above, or `null` if nothing. */
+  get drawableCeiling(): number | null {
+    return this.drawCeiling
+  }
+
   private openResonance(): void {
     const res = this.resonance
     // The difficulty comes from the BREATH, not from the depth.
@@ -2604,7 +2661,14 @@ export class World {
     const diff = 1 + this.ladderPosition * (DIFFICULTY_RUNGS - 1)
     let q: Question
     try {
-      q = this.host.next({ difficulty: diff })
+      // `maxDifficulty` is a CAPABILITY and not a preference, so it is sent only
+      // once ARENA has actually met something it cannot draw — see
+      // `lowerDrawCeiling`. A ceiling asserted before the evidence would be this
+      // pack guessing at the shape of a ladder it cannot see.
+      q =
+        this.drawCeiling === null
+          ? this.host.next({ difficulty: diff })
+          : this.host.next({ difficulty: diff, maxDifficulty: this.drawCeiling })
     } catch (err) {
       console.error("[arena] host.next failed", err)
       this.nextResonanceAt = this.time + 20
@@ -2643,6 +2707,7 @@ export class World {
       const v = Number(text)
       if (Number.isSafeInteger(v) && Math.abs(v) <= MAX_DRAWABLE_LABEL) continue
       console.warn(`[arena] declining a question ARENA cannot draw: "${q.prompt}" has the option "${text}"`)
+      this.lowerDrawCeiling(q.difficulty)
       this.nextResonanceAt = this.time + 20
       return
     }

--- a/dynawalla/packs/sdk/src/fleet.test.ts
+++ b/dynawalla/packs/sdk/src/fleet.test.ts
@@ -31,6 +31,7 @@ import { fileURLToPath } from "node:url"
 import { MIN_AGE_CEILING, MIN_AGE_FLOOR, parseManifest } from "./manifest.ts"
 // @ts-expect-error — a plain .mjs pipeline module with no type declarations.
 import { manifestFrom } from "../../authoring.mjs"
+import { activeNodes, allNodes } from "../../shared/curriculum/src/index.ts"
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const gamesRoot = path.resolve(here, "../../../games")
@@ -131,6 +132,75 @@ test("the fleet spreads across the ladder rather than labelling everything the s
   // is the guard against a future bulk edit that flattens the judgement.
   const ages = new Set(fleet().map(([, source]) => source.minAge))
   assert.ok(ages.size >= 3, `every game claims one of ${ages.size} ages — that is not guidance`)
+})
+
+/* ── What the fleet teaches ───────────────────────────────────────────────── */
+
+/**
+ * Every skill id any pack in this repository claims, as a set.
+ *
+ * A pack states its claims in `covers.skills` and nowhere else, so this is the
+ * whole of what the fleet says it teaches. Read off the same glob as everything
+ * above it, for the same reason: a game arrives as a directory.
+ */
+function claimedSkills(): ReadonlySet<string> {
+  const claimed = new Set<string>()
+  for (const [, source] of fleet()) {
+    const skills = source.covers?.["skills"]
+    if (!Array.isArray(skills)) continue
+    for (const skill of skills) if (typeof skill === "string") claimed.add(skill)
+  }
+  return claimed
+}
+
+test("every active curriculum row is taught by some shipping pack", () => {
+  // **This is the assertion whose absence made a retirement silent.** PR #749
+  // retired THE GAVEL, which was the only pack covering
+  // `dw.mul.facts.tables-within-five`, `dw.mul.facts.tables-to-twelve`,
+  // `dw.div.facts.division-facts` and `dw.div.whole.zero-in-the-quotient`. Its
+  // own commit message says so, and then says the part that matters: "Nothing
+  // asserts fleet-wide skill coverage, so this is silent." A maths product for a
+  // nine-year-old shipped for three days teaching no times tables, and no test
+  // in the repository could go red about it.
+  //
+  // The direction is one-way on purpose. `active ⊆ claimed` is the product
+  // claim — a row the curriculum says is shipped is a row a child can reach. The
+  // converse is NOT a defect: twelve of the ids the fleet names are `draft`
+  // rows, authored ahead of promotion, and a pack that is ready before the
+  // curriculum row is promoted is exactly the order these things should happen
+  // in. `no pack claims a skill the graph has never heard of` below is the guard
+  // that keeps that tolerance from swallowing a typo.
+  //
+  // It lives here rather than in the app for the reason at the top of this file:
+  // `dynawalla_packs` is `^dynawalla/(games|packs)/`, which is BOTH halves of
+  // this assertion — deleting `games/gavel/` runs it, and promoting a row under
+  // `packs/shared/curriculum/` runs it too. The app's filter would have missed
+  // the first and the curriculum's job would have missed the second.
+  const active = activeNodes().map((node) => String(node.id))
+  // Neither side may be empty, or the set difference below is vacuously empty
+  // and this test reports green on nothing at all.
+  assert.ok(active.length > 20, `expected the shipped graph, found ${String(active.length)} active rows`)
+  const claimed = claimedSkills()
+  assert.ok(claimed.size > 20, `expected the fleet's claims, found ${String(claimed.size)} skill ids`)
+
+  const orphans: string[] = active.filter((id) => !claimed.has(id))
+  assert.deepEqual(
+    orphans,
+    [] as string[],
+    `active curriculum rows no shipping pack states in covers.skills — a child cannot reach them: ${orphans.join(", ")}`,
+  )
+})
+
+test("no pack claims a skill the graph has never heard of", () => {
+  // The other half, and a weaker claim than coverage on purpose: a pack may
+  // name a `draft` row, but it may not name a row that does not exist. Without
+  // this, a mistyped id in `covers.skills` would satisfy nothing, teach nothing
+  // and fail nowhere — and the coverage test above would still be green because
+  // a phantom id is simply not in `active`.
+  const known = new Set(allNodes.map((node) => String(node.id)))
+  assert.ok(known.size > 40, `expected the whole graph, found ${String(known.size)} rows`)
+  const phantom: string[] = [...claimedSkills()].filter((id) => !known.has(id)).sort()
+  assert.deepEqual(phantom, [] as string[], `skill ids in pack.json that no curriculum row defines: ${phantom.join(", ")}`)
 })
 
 /* ── The builder's projection ─────────────────────────────────────────────── */


### PR DESCRIPTION
THE GAVEL was the only pack covering `dw.mul.facts.tables-within-five`,
`dw.mul.facts.tables-to-twelve`, `dw.div.facts.division-facts` and
`dw.div.whole.zero-in-the-quotient`. PR 749 retired it, named those four rows in
its own commit message, said they were still `active` — and then said the part
that made it a bug rather than a note: *"Nothing asserts fleet-wide skill
coverage, so this is silent."* A maths product for a nine-year-old has been
shipping with no times tables in it since 2026-07-31 and nothing in the
repository could go red about it.

## The assertion first, because it found more than four

`packs/sdk/src/fleet.test.ts` now asserts that every `active` curriculum row is
named by some `games/*/pack.json`. It lives in the SDK for the reason already at
the top of that file — `dynawalla_packs` is `^dynawalla/(games|packs)/`, which is
**both** halves of this claim: deleting `games/gavel/` runs it, and promoting a
row under `packs/shared/curriculum/` runs it too. The app's filter would have
missed the first; the curriculum's job would have missed the second.

**It fails on `origin/main` with SIX ids, not four:**

```
✖ every active curriculum row is taught by some shipping pack
  AssertionError [ERR_ASSERTION]: active curriculum rows no shipping pack states in
  covers.skills — a child cannot reach them: dw.mul.facts.tables-within-five,
  dw.mul.facts.tables-to-twelve, dw.mul.scale.times-power-of-ten,
  dw.mul.multidigit.long-multiplication, dw.div.facts.division-facts,
  dw.div.whole.zero-in-the-quotient
```

`dw.mul.scale.times-power-of-ten` and `dw.mul.multidigit.long-multiplication`
were **never** covered by anybody, and PR 749 did not know about them. They were
promoted to `active` when POLARITY's numeral budget was widened to ten characters
precisely so they could be; the promotion landed and the manifest half never did.

The direction is one-way on purpose. Twelve of the thirty ids the fleet names are
`draft` rows authored ahead of promotion, which is the right order for those to
happen in. A second test bans an id that no row defines at all, so that tolerance
cannot swallow a typo.

## Which pack — ARENA, and why not FORGE

The founder named FORGE and ARENA. The deciding question is representability, and
FORGE loses it on a fact that is the fleet's most repeated bug in a new costume:
**`game-host` coarsens `covers.skills` to DOMAINS.** A pack that states one
`dw.mul` row is served the whole of `dw.mul`, up to
`45335 × 37372 = 1694259620` — ten characters.

Measured through FORGE's own `computeLayout`, a cast ingot is a quarter of the
workbench panel: on a 320 px phone that is **six characters at 14 px, and ten
characters at the 8 px `fitSize` floor**, which is not a numeral, and nothing in
the pack refuses it — it silently shrinks. FORGE's local contract is
`next(): Question`; it has no request options at all. And answer width is not
monotone in difficulty — a 9-character `times-power-of-ten` sits at ordinate 0.57,
below 4-character add rungs at 0.99 — so `maxDifficulty` could not express the
limit even if the contract carried it. Teaching FORGE times tables means
reflowing its ingot rack: degrading a game the founder already likes, in order to
teach the fact *less* honestly than the pack that goes on to do it.

ARENA wins on merits it already has in code:

* **Its answer beat switches the size cue OFF.** Four spheres, one radius,
  `max(playerRTrue * 0.82, 54)` — independent of the label, and commented as
  deliberate. That is what lets a game whose entire premise is comparison pose
  `7 × 6` without the child reading the answer off the apparatus. It is the same
  standard `games/balance` meets from the opposite direction: balance refuses what
  it cannot picture; ARENA switches the picture off for the beat that must not
  have one.
* **It already refuses what it cannot draw, out loud**, with a test that drives
  `37388 × 85585` and asserts zero beats opened and zero spheres reading `0`.
* **`window(d)` is already there and already right.** `sim/window.ts` derives the
  silence allowance from the item alone, is asserted monotone over the full cross
  product, has zero imports (asserted by reading its own source), and already
  charges `mul`/`div` an extra row. `7 × 6` gets 60 s; `4092 ÷ 4` gets ~180 s.
  There is no clock on the child and never was.
* **Its manifest was FALSE.** Every `dw.ns` row is `draft`, so
  `dw.ns.compare.whole-numbers` cannot be served at all — `items.test.ts` already
  pins `service.next(...) === null` for it. `game-host` therefore SURRENDERS the
  restriction three questions in and hands ARENA the whole ladder. ARENA has been
  posing `12 × 3` and `721308 ÷ 84` to children from a manifest claiming it only
  compares whole numbers. It also had no floor; `tables-within-five` L0 at
  ordinate 0.16 is a rung a struggling child can now be walked *down* to, which
  did not exist for this pack before.

### What ARENA can and cannot represent

**Can.** Any item whose four options are distinct integers inside int32, drawn as
four identical spheres you swim into: `3 × 5`, `7 × 6`, `144 ÷ 12`, `4208 ÷ 4`,
`44776 × 10000`. All six declared rows, every level, verified below.

**Cannot.** A numeral past `MAX_DRAWABLE_LABEL` (2 147 483 647) — a sphere's label
goes through `mval`, an `Int32Array`, because the instanced numeral layer needs an
integer attribute, and anything past it lands there as `0`. Exactly one rung of
the 77 on the shipped ladder reaches past it: `long-multiplication` L2, the top
one. ARENA also cannot show *working* — there is no long-division bracket and no
partial-product column anywhere in the ocean, so `zero-in-the-quotient` is taught
as the answer rather than as the algorithm, which is what every pack in the fleet
does with that row's flat `4208 ÷ 4` prompt.

## The capability half

A refusal on its own is a beat a child never gets, every twenty seconds, forever
— POLARITY 716 and TREBUCHET 698 again. So the first refusal now **states** a
ceiling: `lowerDrawCeiling` sets `next({ maxDifficulty })` to the refused item's
own ordinate less a margin, monotone non-increasing, sent only once the evidence
exists (nothing is claimed on the opening request). It is derived rather than
typed — a curriculum that grows, moves or renumbers a rung needs no edit here —
and `items.test.ts` pins the ladder-side fact that makes it cheap.

## Verification

`npm run -s tsc` clean in `packs/sdk`, `games/arena`, `dynawalla-app` (three
projects) and `dynawalla/curriculum`; `npm run lint` clean in `dynawalla-app`.
All four suites run **five consecutive times**, green every time (121 / 99 / 416 /
221 tests). `node packs/build.mjs arena` builds and passes the SDK checker
(`covers 7 skills`).

### Mutation transcript — seven mutations, seven failures

| # | mutation | result |
|---|---|---|
| 1 | drop `dw.div.facts.division-facts` from `arena/pack.json` | `✖ every active curriculum row is taught by some shipping pack` — *"active curriculum rows no shipping pack states in covers.skills — a child cannot reach them: dw.div.facts.division-facts"* |
| 2 | add `dw.mul.facts.tables-to-thirteen` to `arena/pack.json` | `✖ no pack claims a skill the graph has never heard of` — *"skill ids in pack.json that no curriculum row defines: dw.mul.facts.tables-to-thirteen"* |
| 3 | delete the `this.lowerDrawCeiling(q.difficulty)` call | `✖ meeting a numeral it cannot print makes ARENA state a ceiling, once and downward` — *"a request after a refusal carried no ceiling: {"difficulty":1.3599999999999999}"* |
| 4 | delete the monotone guard in `lowerDrawCeiling` | same test — *"the ceiling moved from 0.7 to 0.9299999999999999 — a refusal at a HARDER rung raised it"* |
| 5 | `DRAW_CEILING_MARGIN = 0.01` → `0` | same test — *"the ceiling was 0.71, which does not exclude the 0.71 rung that was refused — `items.ts` caps with floor(maxDifficulty × span), so a ceiling set AT the refused ordinate re-admits the rung it was set for"* |
| 6 | widen `long-multiplication` L1 to `times(5, 5, true)` in the curriculum | `✖ every question ARENA's new rows can generate is one ARENA can build` — *"rows ARENA declares and cannot build: dw.mul.multidigit.long-multiplication L1, dw.mul.multidigit.long-multiplication L2"*, **and** `✖ exactly one rung on the shipped ladder is out of ARENA's reach, and it is the last one` — *"rungs ARENA cannot draw: 74 …long-multiplication, 76 …long-multiplication"* |
| 7 | `CHOICE_COUNT = 4` → `3` in the host | `✖ every question ARENA's new rows can generate is one ARENA can build` — all eighteen levels named |

**Mutation 4 caught the test, not the code, on its first attempt.** The fixture
originally offered the *hard* rung first and the easy one after, so the ceiling
descended on its own and removing the monotone guard changed nothing — a vacuous
assertion. The fixture now offers 0.71 first and 0.94 for the rest of the run,
which is the only ordering in which a rising ceiling is observable; the comment in
the test says so, so nobody reverses it back.

## Not done, deliberately

* **`game-host`'s domain coarsening is still the sharp edge.** Declaring one row
  of a domain buys the whole domain, and the module argues at length why skill
  granularity was rejected (21 packs would lose the bottom of the ladder). That
  argument is about the *floor*; it says nothing about a ceiling, and a pack
  cannot currently say "this domain, up to here, by skill". ARENA works around it
  with a derived `maxDifficulty` because that costs it exactly one rung. FORGE
  could not, and that is why FORGE is not this PR.
* **`dw.mul.multidigit.times-one-digit` / `times-two-digit` / `divide-exact`** are
  already claimed by five packs, so they were never in the gap.
* **Nothing in FORGE was touched.**
