### PR TITLE
chore(dynawalla): 0.3.10

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dynawalla",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "identifier": "inc.corpora.dynawalla",
   "build": {
     "beforeDevCommand": "npm run packs && npm run dev",


### PR DESCRIPTION
Version bump only — `tauri.conf.json` 0.3.9 → 0.3.10. **25 packs.**

## TREBUCHET — all four complaints, each with a measured cause

- **#771 — it served no question at all.** `HINT_BAND` clamps a pack's request to ±1 rung of a `progress` that opens at 0 every session, so trebuchet was fed answers 0..10 — while its keeps stand at their own answer in metres and it can only draw **14..118**. Measured: **0 of 1000 placeable**, broken since 0.3.7. The fix is `minDifficulty`, the missing half of the capability window: a pack whose content sits *above* the child previously had no way to say so.
- **#775 — the wind was smaller than the blast it moved the boulder by.** Range 1–4 m against a 3 m blast radius, so a child who did the sum correctly and ignored the wind **still hit the keep 86.8% of the time** — and was marked wrong while watching the tower crack and lean. It also flickered on and off by wave for reasons unrelated to her. Now one metre past the blast (so an ignored wind lands clear, with her own number in the crater) and bought with felled keeps.
- **#774 — the reveal was unreachable while a banner was up**, which is exactly waves 1–8, so a first session showed no correction at all. It also lit every keep *except* the missed one, because `markWanted()` runs after `b.spent = true`.
- **#774 — a keep coming down was seven band-passed noise bursts.** It is masonry now, with no noise source at all, and the whole pack is lower and quieter (loudest cue −9.5 dBFS, down from 0.465).

## The curriculum could lose a row silently

- **#776 — ARENA teaches the times tables.** THE GAVEL was the only pack that ever covered them, and **two further rows had never been covered by anyone** — promoted to active when POLARITY's numeral budget was widened, with the manifest half never landing. A new fleet assertion fails loudly, naming the rows, when any active row is taught by no shipping pack. It fails on a clean `origin/main`.

## Safe area

- **#773 — MONUMENT and POLARITY read `env(safe-area-inset-*)`**, which is **zero in a sandboxed pack frame**. A 40px sound button sat entirely inside the navigation bar, and POLARITY's HUD has been describing padding it never had since its first commit. Verified against real headless Chromium: 266 probes, 7 viewports, 0 disagreements.

A main push does not release. The tag `dynawalla-v0.3.10` does.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb