### PR TITLE
dynawalla/games: GUILTY's numerals get a counter-ink, and COIL's hint learns to unfold

### DIFF
--- a/dynawalla/games/coil/src/game/hint.test.ts
+++ b/dynawalla/games/coil/src/game/hint.test.ts
@@ -1,0 +1,160 @@
+// THE HINT, AND THE THREE THINGS IT IS NOT ALLOWED TO BE.
+//
+// *"needs more hints, hints don't fit on mobile."*
+//
+// Three properties are gated here and each of them is a thing the founder has
+// already ruled out somewhere in this fleet:
+//
+//   1. **It cannot cost anything and it cannot read the child.** The quiet
+//      before the first picture is a pure function of the ITEM and monotone
+//      non-decreasing in it — a demand that needs more change buys more silence,
+//      never less. Nothing about how the child is doing goes in.
+//   2. **The clock never states the answer.** Time alone reaches `FREE_STAGES`
+//      and stops. The picture that pins the exact joint is something a child
+//      asks for with a thumb.
+//   3. **It has to be true.** `planFor` is the live marker, and a marker that
+//      points at the wrong link is worse than no marker: a child who follows it
+//      gets slag. So it is followed, exhaustively, on every demand the game can
+//      serve — crack where it says, cut where it says, and the piece that comes
+//      away must BE the demand.
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  FREE_STAGES,
+  HINT_DWELL_MS,
+  HINT_DWELL_PER_BREAK_MS,
+  HINT_STAGES,
+  firstHintMs,
+  planFor,
+  scheduledStage,
+} from "./hint.ts"
+import { breakAt, breaksNeeded, canBreak, coilOf, suffixValue, valueOf } from "./place.ts"
+
+test("the quiet is pure in the item and never shortens as the item hardens", () => {
+  // The law THE LATTICE holds its own hint to, asserted the same way: not by
+  // reading the implementation but by walking the whole range.
+  let previous = -1
+  for (let breaks = 0; breaks <= 24; breaks++) {
+    const ms = firstHintMs({ breaks })
+    assert.ok(
+      ms >= previous,
+      `a demand needing ${String(breaks)} breaks got ${String(ms)}ms of quiet, less than the one before it`,
+    )
+    assert.equal(ms, firstHintMs({ breaks }), "firstHintMs is not pure")
+    previous = ms
+  }
+  assert.equal(firstHintMs({ breaks: 0 }), HINT_DWELL_MS)
+  assert.equal(firstHintMs({ breaks: 2 }), HINT_DWELL_MS + HINT_DWELL_PER_BREAK_MS * 2)
+  // Nonsense in, silence out — never a hint that arrives instantly.
+  assert.ok(firstHintMs({ breaks: Number.NaN }) >= HINT_DWELL_MS)
+  assert.ok(firstHintMs({ breaks: -5 }) >= HINT_DWELL_MS)
+})
+
+test("a child who is getting on with it never sees a hint at all", () => {
+  const item = { breaks: 2 }
+  const first = firstHintMs(item)
+  for (const ms of [0, 100, 1_000, first - 1]) {
+    assert.equal(scheduledStage(ms, item), 0, `a hint appeared after ${String(ms)}ms of stillness`)
+  }
+  assert.equal(scheduledStage(first, item), 1)
+  assert.equal(scheduledStage(-1, item), 0)
+  assert.equal(scheduledStage(Number.NaN, item), 0)
+})
+
+test("the clock stops short of the picture that states the answer", () => {
+  // `mount.ts` caps the schedule at `FREE_STAGES`; what is asserted here is that
+  // the cap is in the right place. Stage 3 puts a ghost of the jaws on the joint
+  // to cut at, which IS the answer, so the free stages must end before it.
+  assert.ok(FREE_STAGES < HINT_STAGES, "every stage is free, so the clock states the answer")
+  assert.equal(FREE_STAGES, 2, "the free stages no longer end where THE PLACE begins")
+})
+
+test("the marker points at a link that can actually be opened", () => {
+  // A marker pointing at a bead — which cannot be cracked — would be an
+  // instruction a child cannot follow.
+  for (let coil = 1; coil <= 400; coil++) {
+    for (const demand of [1, 7, 9, 25, 48, 96, coil]) {
+      if (demand > coil) continue
+      const links = coilOf(coil)
+      const plan = planFor(links, demand)
+      if (plan.breakIndex < 0) continue
+      assert.ok(
+        canBreak(links, plan.breakIndex),
+        `coil ${String(coil)}, demand ${String(demand)}: the marker points at link ${String(plan.breakIndex)}, which cannot be opened`,
+      )
+      assert.equal(plan.aim, plan.breakIndex, "the jaws are sent somewhere other than the link to open")
+    }
+  }
+})
+
+test("following the marker takes exactly the demand — every reachable demand", () => {
+  // The one that matters. Crack where it says, as many times as it says, then
+  // cut where it says, and measure the piece that came away. If the marker is
+  // ever wrong the child following it drops slag, loses lane cells, and is
+  // punished for taking help — which is the thing this whole feature must not do.
+  let checked = 0
+  for (let coil = 1; coil <= 220; coil++) {
+    for (let demand = 0; demand <= coil; demand++) {
+      let links = coilOf(coil)
+      if (breaksNeeded(links, demand) < 0) continue
+      let guard = 0
+      let plan = planFor(links, demand)
+      while (plan.breaks > 0) {
+        assert.ok(plan.breakIndex >= 0, `coil ${String(coil)} demand ${String(demand)}: breaks needed, no link named`)
+        const before = suffixValue(links, plan.cut)
+        links = breakAt(links, plan.breakIndex)
+        // A break buys resolution, never a different amount. The plan must not
+        // be steering the child into changing what they are holding.
+        assert.equal(
+          valueOf(links),
+          coil,
+          `coil ${String(coil)} demand ${String(demand)}: opening a link changed the chain's value`,
+        )
+        assert.ok(before >= 0)
+        plan = planFor(links, demand)
+        guard++
+        assert.ok(guard <= 64, `coil ${String(coil)} demand ${String(demand)}: the marker never converges`)
+      }
+      assert.equal(
+        suffixValue(links, plan.cut),
+        demand,
+        `coil ${String(coil)} demand ${String(demand)}: the joint the marker names is worth ${String(suffixValue(links, plan.cut))}`,
+      )
+      checked++
+    }
+  }
+  // A guard on the guard: a loop that silently skipped everything would pass
+  // every assertion above it.
+  assert.ok(checked > 20_000, `only ${String(checked)} demands were actually followed`)
+})
+
+test("the marker agrees with the game's own count of the change needed", () => {
+  for (let coil = 1; coil <= 300; coil++) {
+    for (const demand of [3, 12, 25, 47, 99, 150]) {
+      if (demand > coil) continue
+      const links = coilOf(coil)
+      assert.equal(
+        planFor(links, demand).breaks,
+        breaksNeeded(links, demand),
+        `coil ${String(coil)}, demand ${String(demand)}: the marker and breaksNeeded disagree`,
+      )
+    }
+  }
+})
+
+test("a demand already sitting on the tail asks for no change at all", () => {
+  // `72 − 25` is the worked example in the manual and the founder's own sticking
+  // point: the tail is two beads, so the marker must name a drum to open.
+  const seventyTwo = coilOf(72)
+  const twentyFive = planFor(seventyTwo, 25)
+  assert.ok(twentyFive.breaks > 0, "25 came off a coil of 72 with no change, which is not possible")
+  assert.equal(seventyTwo[twentyFive.breakIndex], 1, "the marker named something other than a ten")
+
+  // And the counterpart: two ones ARE on the tail, so nothing needs opening.
+  const two = planFor(seventyTwo, 2)
+  assert.equal(two.breaks, 0)
+  assert.equal(two.breakIndex, -1)
+  assert.equal(suffixValue(seventyTwo, two.cut), 2)
+})

--- a/dynawalla/games/coil/src/game/hint.test.ts
+++ b/dynawalla/games/coil/src/game/hint.test.ts
@@ -23,6 +23,8 @@ import test from "node:test"
 
 import {
   FREE_STAGES,
+  STAGE_JOINT,
+  STAGE_SHAPE,
   HINT_DWELL_MS,
   HINT_DWELL_PER_BREAK_MS,
   HINT_STAGES,
@@ -42,7 +44,6 @@ test("the quiet is pure in the item and never shortens as the item hardens", () 
       ms >= previous,
       `a demand needing ${String(breaks)} breaks got ${String(ms)}ms of quiet, less than the one before it`,
     )
-    assert.equal(ms, firstHintMs({ breaks }), "firstHintMs is not pure")
     previous = ms
   }
   assert.equal(firstHintMs({ breaks: 0 }), HINT_DWELL_MS)
@@ -65,10 +66,19 @@ test("a child who is getting on with it never sees a hint at all", () => {
 
 test("the clock stops short of the picture that states the answer", () => {
   // `mount.ts` caps the schedule at `FREE_STAGES`; what is asserted here is that
-  // the cap is in the right place. Stage 3 puts a ghost of the jaws on the joint
-  // to cut at, which IS the answer, so the free stages must end before it.
-  assert.ok(FREE_STAGES < HINT_STAGES, "every stage is free, so the clock states the answer")
-  assert.equal(FREE_STAGES, 2, "the free stages no longer end where THE PLACE begins")
+  // the cap is in the right place.
+  //
+  // Against `STAGE_JOINT` — the constant `scene.ts` draws the ghost jaws from —
+  // and not against its own literal. The first version of this test compared
+  // `FREE_STAGES` to `HINT_STAGES` and then to the number 2, neither of which
+  // reaches the renderer; the doc and the renderer had drifted a whole stage
+  // apart and this test could not see it. Now moving either side fails here.
+  assert.ok(
+    FREE_STAGES < STAGE_JOINT,
+    `the clock reaches stage ${String(FREE_STAGES)} and the jaws are drawn from ${String(STAGE_JOINT)}, so stillness alone states the answer`,
+  )
+  assert.ok(FREE_STAGES >= STAGE_SHAPE, "the clock gives nothing at all, so there is no free hint")
+  assert.ok(STAGE_JOINT < HINT_STAGES + 1, "the jaws are drawn from a stage that does not exist")
 })
 
 test("the marker points at a link that can actually be opened", () => {
@@ -103,7 +113,6 @@ test("following the marker takes exactly the demand — every reachable demand",
       let plan = planFor(links, demand)
       while (plan.breaks > 0) {
         assert.ok(plan.breakIndex >= 0, `coil ${String(coil)} demand ${String(demand)}: breaks needed, no link named`)
-        const before = suffixValue(links, plan.cut)
         links = breakAt(links, plan.breakIndex)
         // A break buys resolution, never a different amount. The plan must not
         // be steering the child into changing what they are holding.
@@ -112,7 +121,6 @@ test("following the marker takes exactly the demand — every reachable demand",
           coil,
           `coil ${String(coil)} demand ${String(demand)}: opening a link changed the chain's value`,
         )
-        assert.ok(before >= 0)
         plan = planFor(links, demand)
         guard++
         assert.ok(guard <= 64, `coil ${String(coil)} demand ${String(demand)}: the marker never converges`)

--- a/dynawalla/games/coil/src/game/hint.ts
+++ b/dynawalla/games/coil/src/game/hint.ts
@@ -24,20 +24,18 @@
 // and for the same reason, that copy ships about fifty times translated and a
 // picture of the mechanic does not.
 //
-//   1. **THE SHAPE.** The demand, drawn as links, beside the piece the jaws are
-//      already holding. Two drums and five beads against two beads. It says the
-//      single most useful thing and says it in silhouettes: *this is what has to
-//      come off, and it is not what you have.*
-//   2. **THE CHANGE.** One crack mark per break the demand still needs. This is
-//      the borrow, as a count: *you cannot take this until you open that many
-//      links.* Zero marks is information too — *it is all there, go and find the
-//      joint.*
-//   3. **THE PLACE.** A ghost of the jaws, on the lane, at the link to put them
-//      on next — live, and it moves every time the child cracks something. When
-//      that link is one to open, the ten-for-one it yields is written beside it:
-//      a drum shows `10×1`, a ring shows `10×10`. Numerals and a multiplication
-//      sign, in a game whose whole subject is that ten of one place is one of
-//      the next.
+//   1. **THE SHAPE.** The demand, drawn as its own chain of links in the cells
+//      after the child's tail. Two drums and five beads next to two beads. It
+//      says the single most useful thing and says it in silhouettes: *this is
+//      what has to come off, and it is not what you have.*
+//   2. **THE PLACE.** The link that has to be opened, ringed on the lane, with
+//      the ten-for-one it yields written under it: a drum shows `10×1`, a ring
+//      shows `10×10`. Numerals and a multiplication sign, in a game whose whole
+//      subject is that ten of one place is one of the next. Live — it moves
+//      every time the child cracks something, and it is simply absent when
+//      nothing needs opening, which is information too.
+//   3. **THE JOINT.** A ghost of the jaws on the joint the cut has to finish at.
+//      **This is the answer**, which is why the clock never reaches it.
 //   4. **THE NUMBER.** What the jaws are holding, and what the wall wants, as
 //      two numerals. The gauge refuses to print these during normal play on
 //      purpose — *"if it printed 25 the child would nudge until the digits
@@ -54,11 +52,20 @@
 //
 // ## The clock stops before the answer
 //
-// Stages 1 and 2 arrive on their own after a long stillness. **Stage 3 pins the
-// exact joint, so the clock never reaches it.** Past `FREE_STAGES` a hint is
-// something a child asks for with a thumb, by tapping the gauge — the panel that
-// already answers "what am I holding". Nothing that happens to a child who is
-// merely sitting there ever puts the answer on the screen.
+// Stillness alone reaches THE SHAPE and THE PLACE — what has to come off, and
+// which link stands in the way of taking it. It never reaches **THE JOINT**,
+// which is where to cut and therefore the answer. Past `FREE_STAGES` a hint is
+// something a child asks for with a thumb, by pressing the gauge — the panel
+// that already answers "what am I holding". Nothing that happens to a child who
+// is merely sitting there ever puts the answer on the screen.
+//
+// That boundary is a pair of constants both this file and the renderer read, so
+// it cannot be moved on one side only: `scene.ts` draws the ghost jaws from
+// `STAGE_JOINT`, and `hint.test.ts` asserts `FREE_STAGES < STAGE_JOINT`. An
+// earlier version of this file described stage 2 as a count of crack marks that
+// nothing drew, and asserted the boundary by comparing `FREE_STAGES` to its own
+// literal — which is how a doc and a renderer came to disagree about what the
+// clock gives away.
 //
 // And the quiet is a **pure function of the item, monotone non-decreasing in the
 // item's difficulty** — the same law THE LATTICE holds its hint to. The item's
@@ -71,17 +78,23 @@
 
 import { breaksNeeded, canBreak, linkValue } from "./place.ts"
 
+/** The four pictures, by name. `scene.ts` draws from these, not from literals. */
+export const STAGE_SHAPE = 1
+export const STAGE_PLACE = 2
+export const STAGE_JOINT = 3
+export const STAGE_NUMBER = 4
+
 /** The four pictures. See the list above. */
-export const HINT_STAGES = 4
+export const HINT_STAGES = STAGE_NUMBER
 
 /**
- * The last stage the CLOCK may reach on its own.
+ * The last picture the CLOCK may reach on its own.
  *
- * Two, because stage 3 puts a ghost of the jaws on the joint to aim at, and that
- * is the answer. A child who is merely sitting there gets the shape of the
- * demand and the number of links to open, and then it stops.
+ * THE PLACE, because the one after it is THE JOINT and the joint is the answer.
+ * A child who is merely sitting there is shown what has to come off and which
+ * link is in the way of taking it, and then it stops.
  */
-export const FREE_STAGES = 2
+export const FREE_STAGES = STAGE_PLACE
 
 /**
  * The quiet before the first picture, and what it is allowed to depend on.

--- a/dynawalla/games/coil/src/game/hint.ts
+++ b/dynawalla/games/coil/src/game/hint.ts
@@ -1,0 +1,201 @@
+// THE HINT — the cut, stated a little at a time, in the machine's own vocabulary.
+//
+// The founder's first report on this game was: *"the coil of 96 the instructions
+// are confusing and I really have no idea what I'm doing."* The second, after the
+// manual landed, was: **"needs more hints, hints don't fit on mobile."**
+//
+// What shipped was one hint and it was a line of text — `2×10  5×1` — drawn into
+// the gauge with no measurement of any kind. On the founder's own handset it is
+// about 151px of type starting 21px into a 122px panel, so it ran out of the
+// gauge, across the SHEAR lever and off the glass. `hint.test.ts` measures that
+// at real viewports. It is also the wrong *kind* of hint: it restates the demand
+// the wall has already carved, once, and then has nothing further to say to a
+// child who is stuck on the part that is actually hard.
+//
+// ## The part that is actually hard
+//
+// It is never "what is 72 − 25". It is: *twenty-five is two tens and five ones,
+// this chain ends in two beads, so there is no joint on it worth twenty-five.*
+// A child who has not seen that is not stuck on arithmetic, they are stuck on
+// the machine — which is exactly the "I have no idea what I'm doing" report.
+//
+// So the escalation is four pictures of the SAME cut, and each one is a masking
+// of the next. Nothing here is a sentence; THE LATTICE's hint took the same line
+// and for the same reason, that copy ships about fifty times translated and a
+// picture of the mechanic does not.
+//
+//   1. **THE SHAPE.** The demand, drawn as links, beside the piece the jaws are
+//      already holding. Two drums and five beads against two beads. It says the
+//      single most useful thing and says it in silhouettes: *this is what has to
+//      come off, and it is not what you have.*
+//   2. **THE CHANGE.** One crack mark per break the demand still needs. This is
+//      the borrow, as a count: *you cannot take this until you open that many
+//      links.* Zero marks is information too — *it is all there, go and find the
+//      joint.*
+//   3. **THE PLACE.** A ghost of the jaws, on the lane, at the link to put them
+//      on next — live, and it moves every time the child cracks something. When
+//      that link is one to open, the ten-for-one it yields is written beside it:
+//      a drum shows `10×1`, a ring shows `10×10`. Numerals and a multiplication
+//      sign, in a game whose whole subject is that ten of one place is one of
+//      the next.
+//   4. **THE NUMBER.** What the jaws are holding, and what the wall wants, as
+//      two numerals. The gauge refuses to print these during normal play on
+//      purpose — *"if it printed 25 the child would nudge until the digits
+//      matched and the place value would be the machine's job instead of
+//      theirs"* — and that judgement is exactly right for the gauge and exactly
+//      wrong for a child who has been stuck for a minute and asked twice.
+//
+// ## What a hint costs: nothing
+//
+// Not a brick, not the wall, not the slag count, not the report. No counter says
+// how many hints were taken and no string mentions needing help. This game
+// already had the right instinct — *"punishing a child for thinking is the
+// failure mode this whole programme exists to avoid"* — and a hint is thinking.
+//
+// ## The clock stops before the answer
+//
+// Stages 1 and 2 arrive on their own after a long stillness. **Stage 3 pins the
+// exact joint, so the clock never reaches it.** Past `FREE_STAGES` a hint is
+// something a child asks for with a thumb, by tapping the gauge — the panel that
+// already answers "what am I holding". Nothing that happens to a child who is
+// merely sitting there ever puts the answer on the screen.
+//
+// And the quiet is a **pure function of the item, monotone non-decreasing in the
+// item's difficulty** — the same law THE LATTICE holds its hint to. The item's
+// difficulty here is `breaksNeeded`, this game's own measure of how much change
+// a demand costs. A demand that needs more change buys MORE silence, never less,
+// because a child mid-borrow is working, not stuck.
+//
+// There is no countdown, no ring filling, no banner and no "hint in 3". A
+// struggling child never sees a clock.
+
+import { breaksNeeded, canBreak, linkValue } from "./place.ts"
+
+/** The four pictures. See the list above. */
+export const HINT_STAGES = 4
+
+/**
+ * The last stage the CLOCK may reach on its own.
+ *
+ * Two, because stage 3 puts a ghost of the jaws on the joint to aim at, and that
+ * is the answer. A child who is merely sitting there gets the shape of the
+ * demand and the number of links to open, and then it stops.
+ */
+export const FREE_STAGES = 2
+
+/**
+ * The quiet before the first picture, and what it is allowed to depend on.
+ *
+ * `HINT_DWELL_MS` is what shipped and it is kept: nine seconds of stillness is
+ * already a long time in front of a child. `PER_BREAK` buys silence for a demand
+ * that costs change, because cracking links IS the work and a child in the
+ * middle of it has not stopped.
+ *
+ * Both coefficients are **non-negative**, which is the whole proof of the
+ * monotonicity law: `firstHintMs` is a sum of non-negative multiples of the
+ * item's own difficulty, so it cannot decrease when that difficulty rises.
+ * `hint.test.ts` asserts it exhaustively rather than taking the argument.
+ */
+export const HINT_DWELL_MS = 9_000
+export const HINT_DWELL_PER_BREAK_MS = 2_500
+
+/**
+ * The gap between one picture and the next, as a fraction of the first quiet.
+ *
+ * The clock has only two pictures to give and spending them slowly is what makes
+ * each one a separate thing that happened rather than a panel unfolding at a
+ * child who has looked away. A child who wants them faster taps the gauge.
+ */
+export const HINT_STEP_FRACTION = 0.85
+
+/** The item a hint is about. Everything `firstHintMs` is allowed to read. */
+export type HintItem = {
+  /** `breaksNeeded` for this demand on this coil. This game's own difficulty. */
+  readonly breaks: number
+}
+
+/**
+ * How long the game stays quiet before the first picture.
+ *
+ * **Pure in the item and monotone non-decreasing in it.** Not the clock, not how
+ * many cuts have missed, not how long the child took last time, not the slag
+ * count. Two calls with the same item return the same number forever.
+ */
+export function firstHintMs(item: HintItem): number {
+  const breaks = Number.isFinite(item.breaks) ? Math.max(0, item.breaks) : 0
+  return HINT_DWELL_MS + HINT_DWELL_PER_BREAK_MS * breaks
+}
+
+/**
+ * Which stage the clock alone has reached after `elapsedMs` on this item.
+ *
+ * `0` is "nothing at all", and it is where a child who is getting on with it
+ * spends the whole round. The result is capped at `FREE_STAGES` by the caller,
+ * not here, so that the schedule and the ceiling stay separately readable.
+ */
+export function scheduledStage(elapsedMs: number, item: HintItem): number {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return 0
+  const first = firstHintMs(item)
+  if (elapsedMs < first) return 0
+  const step = Math.max(1, first * HINT_STEP_FRACTION)
+  return 1 + Math.floor((elapsedMs - first) / step)
+}
+
+/**
+ * The next physical act, read off the chain the child is actually holding.
+ *
+ * This is the live field marker, and everything about it is recomputed from the
+ * chain rather than remembered — so it moves the instant a link is cracked, and
+ * it cannot go stale or disagree with the board.
+ *
+ * The walk is the strategy the interaction affords and the same one
+ * `breaksNeeded` counts with: come in from the tail taking whole links while
+ * they fit, and stop at the first link that overshoots. Where it stops is the
+ * whole answer to "what do I do now".
+ */
+export type Plan = {
+  /** Breaks still needed, or `-1` when the demand cannot be reached at all. */
+  readonly breaks: number
+  /** The joint the jaws must finish at, once nothing is left to open. */
+  readonly cut: number
+  /** The link to open next, or `-1` when none is needed. */
+  readonly breakIndex: number
+  /** Where to put the jaws NOW: the link to open, or the joint to cut at. */
+  readonly aim: number
+  /** What the walk has taken before it stalls. */
+  readonly taken: number
+}
+
+export function planFor(links: readonly number[], demand: number): Plan {
+  let taken = 0
+  let i = links.length - 1
+  while (i >= 0) {
+    const v = linkValue(links[i] as number)
+    if (taken + v > demand) break
+    taken += v
+    i--
+  }
+  const cut = i + 1
+  if (taken === demand) return { breaks: 0, cut, breakIndex: -1, aim: cut, taken }
+  // The walk stalled. `i` is the link that overshoots — the one to crack open,
+  // which is precisely where the jaws have to be parked, because the jaws are
+  // the only place in this game a link can be cracked.
+  if (i < 0 || !canBreak(links, i)) {
+    return { breaks: -1, cut, breakIndex: -1, aim: cut, taken }
+  }
+  return { breaks: breaksNeeded(links, demand), cut, breakIndex: i, aim: i, taken }
+}
+
+/** The hint as it stands, handed to the renderer whole. */
+export type HintState = {
+  /** 0 = nothing drawn. Up to `HINT_STAGES`. */
+  readonly stage: number
+  /** The live plan the marker is drawn from. */
+  readonly plan: Plan
+  /** The demand, so the renderer never has to reach for the round. */
+  readonly demand: number
+  /** What the jaws are holding right now. */
+  readonly holding: number
+  /** True when a deliberate tap would show something the clock will not. */
+  readonly more: boolean
+}

--- a/dynawalla/games/coil/src/mount.ts
+++ b/dynawalla/games/coil/src/mount.ts
@@ -470,8 +470,15 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
 
     // A new round: the schedule is re-read from the item, and the child's own
     // asking starts again from nothing.
-    if (round && round.questionId !== hintRound) {
-      hintRound = round.questionId
+    //
+    // Keyed on the coil and the demand as well as the id, because the id is the
+    // HOST's and nothing in the contract stops it serving one twice. Keyed on
+    // the id alone, a repeat would carry a stale `breaksNeeded` into a different
+    // coil — the quiet has to be a pure function of the item that is actually on
+    // the lane.
+    const key = `${round?.questionId ?? ""}|${String(round?.coil ?? 0)}|${String(round?.demand ?? 0)}`
+    if (round && key !== hintRound) {
+      hintRound = key
       hintItem = { breaks: Math.max(0, breaksNeeded(board.links, round.demand)) }
       asked = 0
     }

--- a/dynawalla/games/coil/src/mount.ts
+++ b/dynawalla/games/coil/src/mount.ts
@@ -499,9 +499,16 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
     const costly = hintItem.breaks > 0
     const clockStage = costly && !flight ? Math.min(FREE_STAGES, scheduledStage(idle, hintItem)) : 0
     const stage = Math.max(clockStage, asked)
-    hintShown = stage
+    // Only what is actually on the glass. Assigned unconditionally, a tap during
+    // the flight of a severed piece advanced `asked` past a picture the child
+    // never saw.
+    if (!flight) hintShown = stage
+    // Built whenever there is a round to build it about, INCLUDING at stage 0.
+    // `drawHint` returns immediately below `STAGE_SHAPE`, so nothing is drawn —
+    // but the gauge reads `more` off this to say that it can be pressed, and at
+    // stage 0 is exactly when a child has not yet found that out.
     const hintState: HintState | null =
-      round && stage > 0 && !flight
+      round && !flight
         ? {
             stage,
             plan: planFor(board.links, round.demand),

--- a/dynawalla/games/coil/src/mount.ts
+++ b/dynawalla/games/coil/src/mount.ts
@@ -29,14 +29,20 @@ import { createInstructions, onInsetsChange } from "../../../packs/shared/game-c
 import type { Host } from "./contract.ts"
 import { Audio } from "./audio/audio.ts"
 import { SLAG_CELLS, buried as buriedCount } from "./game/board.ts"
-import { breaksNeeded, coilOf } from "./game/place.ts"
+import {
+  FREE_STAGES,
+  HINT_STAGES,
+  type HintItem,
+  type HintState,
+  planFor,
+  scheduledStage,
+} from "./game/hint.ts"
+import { breaksNeeded, coilOf, suffixValue } from "./game/place.ts"
 import { REACTIONS, type Tier, tierFor } from "./game/reactions.ts"
 import { COURSE, createSession } from "./game/session.ts"
 import { cellAt, cellNear, inside } from "./render/layout.ts"
 import { type SceneState, Scene } from "./render/scene.ts"
 
-/** Hesitation before the hint offers itself. Long, and it never hurries. */
-const HINT_AFTER_MS = 9_000
 
 export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
   const container = document.createElement("div")
@@ -66,6 +72,7 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
           "Tap a link. The jaws are the big cutter, and they slide to that link. That is where the cut will happen.",
           "Pull the SHEAR lever. To shear is to cut, and everything after the jaws comes off.",
           "Take as long as you like. There is no timer and nothing is rushing you.",
+          "Stuck? Press the panel between the two levers. It shows you a little more each time, and it never costs you anything.",
           "Every cut that is exactly right lays one brick in the wall behind you. Eight bricks make a course, which is one whole row of the wall.",
         ],
       },
@@ -138,6 +145,19 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
   let flight: SceneState["flight"] = null
   let breaksThisRound = 0
   let lastInputAt = performance.now()
+  // How far the CHILD has asked the hint to unfold, this round. The clock's own
+  // stage is computed fresh every frame from `lastInputAt`; this one is not, so
+  // reaching for the jaws after asking for help does not take the help away.
+  let asked = 0
+  // The stage actually on the glass last frame. A tap advances from what the
+  // child can SEE, not from what they have asked for — so the first tap after
+  // the clock has already offered two pictures gives the third, not the first.
+  let hintShown = 0
+  // The item the quiet is a pure function of, captured when the round arrives
+  // rather than read live — cracking a link lowers `breaksNeeded`, and a hint
+  // schedule that moved while a child worked would be reading the child.
+  let hintItem: HintItem = { breaks: 0 }
+  let hintRound = ""
   let running = true
   let raf = 0
   let last = performance.now()
@@ -255,7 +275,6 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
     session.stoke()
     breaksThisRound = 0
     lastInputAt = performance.now()
-    fx.hint = 0
   }
 
   let pointer = -1
@@ -274,9 +293,17 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
     pointer = e.pointerId
     void audio.start()
     lastInputAt = performance.now()
-    fx.hint = 0
     const { x, y } = local(e)
 
+    // ASK FOR MORE. The gauge already answers "what am I holding"; a tap on it
+    // asks it to keep going. There is no hint button and no new word anywhere —
+    // copy in this fleet ships about fifty times translated, and a panel that
+    // unfolds when you press it needs none.
+    if (inside(scene.layout.gauge, x, y)) {
+      asked = Math.min(HINT_STAGES, Math.max(asked, hintShown) + 1)
+      host.haptic("light")
+      return
+    }
     if (inside(scene.layout.shear, x, y)) {
       onShear = true
       fx.shearPress = 1
@@ -347,7 +374,6 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
     if (guide.isOpen) return
     const board = session.board
     lastInputAt = performance.now()
-    fx.hint = 0
     switch (e.key) {
       case "ArrowLeft":
         session.aim(board.cut - 1)
@@ -439,18 +465,46 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
       }
     }
 
-    // The hint arrives on its own after a long stillness, and only when the
-    // demand actually costs a regrouping — telling a child the shape of a cut
-    // they could already reach is noise, not help.
-    const idle = now - lastInputAt
     const round = session.round
-    const costly = round ? breaksNeeded(session.board.links, round.demand) > 0 : false
-    fx.hint =
-      idle > HINT_AFTER_MS && costly && !flight
-        ? Math.min(1, fx.hint + dt * 1.4)
-        : decay(fx.hint, dt, 0.4)
-
     const board = session.board
+
+    // A new round: the schedule is re-read from the item, and the child's own
+    // asking starts again from nothing.
+    if (round && round.questionId !== hintRound) {
+      hintRound = round.questionId
+      hintItem = { breaks: Math.max(0, breaksNeeded(board.links, round.demand)) }
+      asked = 0
+    }
+
+    // The hint. Two clocks and no countdown.
+    //
+    // The first is stillness, and it only ever offers the two pictures that do
+    // not state the answer — and only when the demand actually costs a
+    // regrouping, because telling a child the shape of a cut they could already
+    // reach is noise rather than help. That gate is the one this game shipped
+    // with and it is kept.
+    //
+    // The second is the child's thumb, and it has no gate at all: a tap on the
+    // gauge always answers, on any round, however recently they moved. That is
+    // the whole of the founder's *"needs more hints"* — the game never
+    // volunteers noise, and it always answers when asked.
+    const idle = now - lastInputAt
+    const costly = hintItem.breaks > 0
+    const clockStage = costly && !flight ? Math.min(FREE_STAGES, scheduledStage(idle, hintItem)) : 0
+    const stage = Math.max(clockStage, asked)
+    hintShown = stage
+    const hintState: HintState | null =
+      round && stage > 0 && !flight
+        ? {
+            stage,
+            plan: planFor(board.links, round.demand),
+            demand: round.demand,
+            holding: suffixValue(board.links, board.cut),
+            more: stage < HINT_STAGES,
+          }
+        : null
+    fx.hint = hintState ? Math.min(1, fx.hint + dt * 1.4) : decay(fx.hint, dt, 0.4)
+
     const state: SceneState = {
       round,
       links: board.links,
@@ -470,6 +524,7 @@ export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
       shearPress: fx.shearPress,
       whip: reduced ? 0 : fx.whip,
       hint: fx.hint,
+      hintState,
       flight,
     }
     scene.draw(state)

--- a/dynawalla/games/coil/src/render/chrome.test.ts
+++ b/dynawalla/games/coil/src/render/chrome.test.ts
@@ -19,34 +19,12 @@ import assert from "node:assert/strict"
 import test from "node:test"
 
 import {
-  type Insets,
-  NO_INSETS,
   type Rect,
   hitsHostChrome,
   safeRect,
 } from "../../../../packs/shared/game-chrome/index.ts"
 import { cellAt, viewLayout } from "./layout.ts"
-
-const PORTRAIT_NOTCH: Insets = { top: 59, right: 0, bottom: 34, left: 0 }
-const LANDSCAPE_NOTCH: Insets = { top: 0, right: 59, bottom: 21, left: 59 }
-
-const VIEWPORTS: Array<[string, number, number]> = [
-  ["phone portrait, small", 320, 568],
-  ["phone portrait, tall", 390, 844],
-  ["tablet portrait", 768, 1024],
-  ["tablet landscape", 1024, 768],
-  ["phone landscape", 844, 390],
-]
-
-/** A flat profile always, and the notch the device of that shape actually has. */
-function profiles(w: number, h: number): Array<[string, Insets]> {
-  return [
-    ["no insets", NO_INSETS],
-    w >= h
-      ? ["landscape notch", LANDSCAPE_NOTCH]
-      : ["portrait notch", PORTRAIT_NOTCH],
-  ]
-}
+import { VIEWPORTS, profiles } from "./viewports.ts"
 
 const contains = (outer: Rect, inner: Rect): boolean =>
   inner.x >= outer.x - 0.5 &&
@@ -70,6 +48,7 @@ for (const [shape, w, h] of VIEWPORTS) {
         ["the lane", l.lane],
         ["the SHEAR lever", l.shear],
         ["the FURNACE lever", l.furnace],
+        ["the gauge", l.gauge],
       ]
 
       for (const [name, rect] of critical) {
@@ -101,6 +80,52 @@ for (const [shape, w, h] of VIEWPORTS) {
       const l = viewLayout(w, h, insets)
       assert.ok(l.recess.w >= 90, `the recess is ${l.recess.w.toFixed(1)}px at ${where}`)
       assert.ok(l.recess.h >= 55, `the recess is ${l.recess.h.toFixed(1)}px tall at ${where}`)
+    })
+  }
+}
+
+/* ────────────────────────────────────────────────────── the lever row shares */
+
+// The gauge is the panel that answers "what am I holding", and from this change
+// on it is also where a child taps to ask the hint to keep going. It used to be
+// whatever was left over after two independently-sized levers had taken what
+// they wanted — `shear.x − (furnace.x + furnace.w) − 24` — and the renderer gave
+// up on it below 60px without drawing anything at all. That is a panel that
+// silently disappears on the narrow screens where it is needed most.
+
+for (const [shape, w, h] of VIEWPORTS) {
+  for (const [profile, insets] of profiles(w, h)) {
+    const where = `${shape} ${String(w)}×${String(h)}, ${profile}`
+
+    test(`the lever row holds three panels without them touching — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      assert.ok(
+        l.furnace.x + l.furnace.w <= l.gauge.x + 0.5,
+        `the FURNACE overlaps the gauge at ${where}`,
+      )
+      assert.ok(
+        l.gauge.x + l.gauge.w <= l.shear.x + 0.5,
+        `the gauge overlaps the SHEAR lever at ${where} — gauge ends ${(l.gauge.x + l.gauge.w).toFixed(1)}, shear starts ${l.shear.x.toFixed(1)}`,
+      )
+      assert.ok(
+        l.furnace.x >= l.levers.x - 0.5 && l.shear.x + l.shear.w <= l.levers.x + l.levers.w + 0.5,
+        `the lever row runs off its own strip at ${where}`,
+      )
+    })
+
+    test(`the gauge is wide enough to read a piece in — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      assert.ok(
+        l.gauge.w >= 72,
+        `the gauge is ${l.gauge.w.toFixed(1)}px at ${where}; below 72 it clips to one link and stops answering`,
+      )
+    })
+
+    test(`both levers stay a hittable size — ${where}`, () => {
+      const l = viewLayout(w, h, insets)
+      assert.ok(l.shear.w >= 108, `the SHEAR lever is ${l.shear.w.toFixed(1)}px at ${where}`)
+      assert.ok(l.furnace.w >= 84, `the FURNACE lever is ${l.furnace.w.toFixed(1)}px at ${where}`)
+      assert.ok(l.shear.h >= 44 && l.furnace.h >= 44, `a lever is under 44px tall at ${where}`)
     })
   }
 }

--- a/dynawalla/games/coil/src/render/hintFit.test.ts
+++ b/dynawalla/games/coil/src/render/hintFit.test.ts
@@ -1,0 +1,123 @@
+// "HINTS DON'T FIT ON MOBILE."
+//
+// The shipped hint was one line of text — `2×10  5×1` — drawn into the gauge at
+// `x + unit × 1.4` with a font size taken from the panel's height and its width
+// never measured at all. This file measures it, at the founder's own handset and
+// at the smallest phone the pack supports, and then measures what replaced it.
+//
+// The metric is a model rather than a real canvas, and it is deliberately a
+// GENEROUS one — 0.55 em per character for a serif at a mixed run of digits and
+// multiplication signs, which is on the narrow side of real. A layout test that
+// models type as narrower than it is only ever passes for the wrong reason, and
+// the overflow below is large enough that the model cannot be what produces it.
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { coilOf, linkValue } from "../game/place.ts"
+import { PORTRAIT_ANDROID, VIEWPORTS, profiles } from "./viewports.ts"
+import { labelX, viewLayout } from "./layout.ts"
+
+/** Advance per character per pixel of type size. Narrow side of real. */
+const ADVANCE = 0.55
+const measure = (text: string, size: number): number => text.length * size * ADVANCE
+
+/** The founder's handset, and the Android chrome it reports. */
+const FOUNDER: [number, number] = [393, 851]
+const ANDROID = PORTRAIT_ANDROID
+
+/** The line the shipped hint drew, for a demand. `tally`, joined with two spaces. */
+function oldHintText(demand: number): string {
+  const counts = new Map<number, number>()
+  for (const place of coilOf(demand)) counts.set(place, (counts.get(place) ?? 0) + 1)
+  return [...counts.entries()]
+    .sort((a, b) => b[0] - a[0])
+    .map(([place, n]) => `${String(n)}×${String(linkValue(place))}`)
+    .join("  ")
+}
+
+test("the hint that shipped ran off the founder's phone, and off a 320px one", () => {
+  // The defect, reconstructed from the code that was there: the panel was
+  // `shear.x − (furnace.x + furnace.w) − 24` wide, the type was `h × 0.17`, and
+  // the line started `min(h × 0.26, 15) × 1.4` inside it.
+  for (const [name, w, h, insets] of [
+    ["the founder's phone", FOUNDER[0], FOUNDER[1], ANDROID],
+    ["a 320px phone", 320, 568, { top: 0, right: 0, bottom: 0, left: 0 }],
+  ] as Array<[string, number, number, typeof ANDROID]>) {
+    const l = viewLayout(w, h, insets)
+    // The gauge is the same strip it always was; only the hint inside it moved.
+    const panelW = l.gauge.w
+    const size = Math.max(10, l.levers.h * 0.17)
+    const start = Math.min(l.levers.h * 0.26, 15) * 1.4
+    const ink = measure(oldHintText(375), size)
+    assert.ok(
+      start + ink > panelW,
+      `${name}: the shipped hint was ${(start + ink).toFixed(0)}px of line in a ${panelW.toFixed(0)}px panel, which would have fitted`,
+    )
+  }
+})
+
+test("the ten-for-one label stays on the lane, wherever the link is", () => {
+  // The new hint writes `10×100` under the link that has to be opened, and that
+  // link can be the last one in a row. Centring it there would hang it off the
+  // very edge the shipped hint hung off, so `labelX` clamps — and this is where
+  // the clamp is measured rather than assumed.
+  for (const [shape, w, h] of VIEWPORTS) {
+    for (const [profile, insets] of profiles(w, h)) {
+      const where = `${shape} ${String(w)}×${String(h)}, ${profile}`
+      const l = viewLayout(w, h, insets)
+      const lane = l.lane
+      // The widest label the game can produce: the biggest place a coil of
+      // ninety-six times a power of ten reaches, opened.
+      const label = "10×1000"
+      const size = Math.max(9, lane.unit * 0.78)
+      const width = measure(label, size)
+      for (let cell = 0; cell < lane.capacity; cell++) {
+        const cx = lane.x + (lane.w * cell) / Math.max(1, lane.capacity - 1)
+        const x = labelX(lane, cx, width)
+        assert.ok(x >= lane.x - 0.5, `"${label}" starts left of the lane at ${where}`)
+        assert.ok(
+          x + width <= lane.x + lane.w + 0.5,
+          `"${label}" ends ${(x + width - lane.x - lane.w).toFixed(1)}px past the lane at ${where}`,
+        )
+      }
+    }
+  }
+})
+
+test("the lane is wide enough for the label it has to carry", () => {
+  // The counterpart, and the reason the clamp above is not the whole answer: a
+  // clamp on a lane narrower than the label would silently pin every label to
+  // the left edge and still overflow. This fails loudly instead.
+  const label = "10×1000"
+  for (const [shape, w, h] of VIEWPORTS) {
+    for (const [profile, insets] of profiles(w, h)) {
+      const l = viewLayout(w, h, insets)
+      const size = Math.max(9, l.lane.unit * 0.78)
+      assert.ok(
+        measure(label, size) + 4 <= l.lane.w,
+        `"${label}" is ${measure(label, size).toFixed(0)}px on a ${l.lane.w.toFixed(0)}px lane at ${shape} ${String(w)}×${String(h)}, ${profile}`,
+      )
+    }
+  }
+})
+
+test("the gauge's own numerals fit the panel they are printed in", () => {
+  // The last hint stage prints `holding / wanted` in the gauge. It is fitted at
+  // draw time against the real metrics, and what is checked here is that the
+  // panel is big enough for the fitting to leave something legible — a fit that
+  // shrinks to 9px is a fit that has failed.
+  for (const [shape, w, h] of VIEWPORTS) {
+    for (const [profile, insets] of profiles(w, h)) {
+      const l = viewLayout(w, h, insets)
+      const line = "9600 / 9599"
+      const nominal = Math.min(l.gauge.h * 0.3, 20)
+      const room = l.gauge.w - 12
+      const fitted = Math.min(nominal, (room / measure(line, nominal)) * nominal)
+      assert.ok(
+        fitted >= 11,
+        `the gauge would print the worst reading at ${fitted.toFixed(1)}px at ${shape} ${String(w)}×${String(h)}, ${profile}`,
+      )
+    }
+  }
+})

--- a/dynawalla/games/coil/src/render/layout.ts
+++ b/dynawalla/games/coil/src/render/layout.ts
@@ -62,6 +62,18 @@ export type Layout = {
   courses: Rect
   lane: Lane
   levers: Rect
+  /**
+   * The panel between the two levers: what the jaws are holding, and the hint.
+   *
+   * It is a rect in the layout rather than a sum the renderer works out for
+   * itself, and that is the fix for *"hints don't fit on mobile."* The scene
+   * used to derive this strip inline as `shear.x − (furnace.x + furnace.w) − 24`
+   * and give up silently when the answer came out under 60px — so on a narrow
+   * safe rectangle the one panel that says what you are holding, and the hint
+   * inside it, both disappeared with nothing to see. Here it is geometry, and
+   * `chrome.test.ts` asserts a floor on it at every viewport.
+   */
+  gauge: Rect
   shear: Rect
   furnace: Rect
 }
@@ -81,6 +93,21 @@ function clamp(v: number, lo: number, hi: number): number {
  * costs the alley no height at all.
  */
 const CORNER = HOST_MARGIN + HOST_CONTROL + 2
+
+/**
+ * The lever row, as three panels that must all survive a 320px phone.
+ *
+ * `SHEAR_MIN` and `FURNACE_MIN` are the widths that shipped and they are touch
+ * targets first — both are far wider than the 44px platform minimum even at the
+ * floor, because both carry a word. The gauge takes what is left, and 72px is
+ * the width below which the held piece clips to a single link and the panel
+ * stops answering the question it exists to answer; `chrome.test.ts` gates on it
+ * rather than this file clamping to it, so a change to either lever that
+ * squeezed the gauge out would fail a test instead of shipping.
+ */
+const LEVER_GAP = 12
+const SHEAR_MIN = 108
+const FURNACE_MIN = 84
 
 /**
  * Where everything is, inside `area`.
@@ -163,21 +190,41 @@ export function layout(w: number, h: number, area: Rect): Layout {
     capacity: Math.min(LANE_CELLS, rows * cols),
   }
 
-  const leverW = clamp(levers.w * 0.34, 108, 220)
+  // The lever row: FURNACE, the gauge, SHEAR, left to right, sharing the width.
+  //
+  // The two levers are sized exactly as they always were; what is new is that
+  // the strip between them is a rect in this file. It used to be worked out a
+  // second time inside `Scene.drawGauge`, as
+  // `shear.x − (furnace.x + furnace.w) − 24`, with a hardcoded 12px gap that
+  // this file knew nothing about and a silent `if (w < 60) return` at the end —
+  // so the panel that answers "what am I holding", and the hint inside it,
+  // could vanish with nothing on screen to say why. Two formulas for one strip,
+  // one of them able to give up. Now there is one, and it is asserted.
+  //
+  // No floor on what is left over, deliberately, for the reason the recess has
+  // none: a floor here would push the levers into each other to satisfy an
+  // arithmetic constraint and hide the real problem, which is a row too narrow
+  // to hold three panels. That it is wide enough is asserted at every viewport
+  // in `chrome.test.ts`, where it fails loudly.
+  const gap = LEVER_GAP
+  const shearW = clamp(levers.w * 0.34, SHEAR_MIN, 220)
+  const furnaceW = clamp(levers.w * 0.26, FURNACE_MIN, 168)
+  const furnace: Rect = { x: levers.x, y: levers.y, w: furnaceW, h: levers.h }
   const shear: Rect = {
-    x: levers.x + levers.w - leverW,
+    x: levers.x + levers.w - shearW,
     y: levers.y,
-    w: leverW,
+    w: shearW,
     h: levers.h,
   }
-  const furnace: Rect = {
-    x: levers.x,
+  const gaugeX = furnace.x + furnace.w + gap
+  const gauge: Rect = {
+    x: gaugeX,
     y: levers.y,
-    w: clamp(levers.w * 0.26, 84, 168),
+    w: Math.max(0, shear.x - gap - gaugeX),
     h: levers.h,
   }
 
-  return { w, h, compact, wall, recess, courses, lane, levers, shear, furnace }
+  return { w, h, compact, wall, recess, courses, lane, levers, gauge, shear, furnace }
 }
 
 /**
@@ -228,6 +275,21 @@ export function cellNear(lane: Lane, px: number, py: number, count: number): num
     }
   }
   return best
+}
+
+/**
+ * Where a label of `width` goes when it wants to be centred on `cx` but must
+ * stay on the lane.
+ *
+ * The hint writes `10×100` under the link a child has to open, and that link can
+ * be in the last column. Centring it there would hang it off the same edge the
+ * shipped hint hung off — which is the entire defect this pack was sent back
+ * for. It is a function rather than two `Math.min`s inside the renderer so that
+ * `hint.test.ts` can measure the worst label at every viewport.
+ */
+export function labelX(lane: Rect, cx: number, width: number): number {
+  const right = lane.x + lane.w - width - 2
+  return Math.min(Math.max(lane.x + 2, cx - width / 2), Math.max(lane.x + 2, right))
 }
 
 export function inside(r: Rect, px: number, py: number): boolean {

--- a/dynawalla/games/coil/src/render/legibility.test.ts
+++ b/dynawalla/games/coil/src/render/legibility.test.ts
@@ -1,0 +1,68 @@
+// CAN A CHILD READ WHAT THIS GAME WRITES DOWN?
+//
+// Everything below is computed from the composite. See `legibility.ts` for the
+// grounds and for the table of what these measured before anything moved.
+
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { MIN_TEXT, readables, shipped, worst } from "./legibility.ts"
+
+test("every readable thing in the alley clears 4.5:1 on the ground it is set on", () => {
+  const rows = readables()
+  assert.ok(rows.length >= 16, "the audit lost rows; every piece of type belongs in it")
+  for (const r of rows) {
+    assert.ok(
+      worst(r) >= MIN_TEXT,
+      `${r.name} measures ${worst(r).toFixed(2)}:1 against its own ground`,
+    )
+  }
+})
+
+test("the rule of the game was the least legible type on the screen", () => {
+  // The defect, pinned. `SHEAR OFF THE LIT NUMBER` is the whole instruction this
+  // pack has and it was set in `BONE_DIM` at 0.85 on the lit recess. If a change
+  // ever puts it back, this fails rather than the founder finding it again.
+  const before = shipped().find((r) => r.name === '"SHEAR OFF THE LIT NUMBER"')
+  assert.ok(before)
+  assert.ok(worst(before) < 2.6, `the rule already measured ${worst(before).toFixed(2)}:1`)
+  const after = readables().find((r) => r.name === '"SHEAR OFF THE LIT NUMBER"')
+  assert.ok(after)
+  assert.ok(
+    worst(after) > worst(before) * 2,
+    `the rule went from ${worst(before).toFixed(2)}:1 to ${worst(after).toFixed(2)}:1, which is not a fix`,
+  )
+})
+
+test("every ink that moved was failing before it moved", () => {
+  // The guard against a change that repainted something already fine — which is
+  // how a legibility pass turns into a restyle nobody asked for.
+  for (const before of shipped()) {
+    assert.ok(
+      worst(before) < MIN_TEXT,
+      `${before.name} already measured ${worst(before).toFixed(2)}:1, so changing its ink was not a legibility fix`,
+    )
+    const after = readables().find((r) => r.name === before.name)
+    assert.ok(after, `${before.name} left the audit`)
+    assert.ok(
+      worst(after) > worst(before),
+      `${before.name} did not get better: ${worst(before).toFixed(2)} → ${worst(after).toFixed(2)}`,
+    )
+  }
+})
+
+test("the furnace's own heat is not what was turned down", () => {
+  // The founder's rule is that legibility is won by sparsening the field, never
+  // by sanding the effects. Both furnace labels sit on the panel's ember
+  // gradient, and that gradient is unchanged — which is exactly why the two
+  // labels still measure differently at the two heights they are drawn at. If
+  // somebody "fixes" this by flattening the gradient, these stop differing.
+  const rows = readables()
+  const top = rows.find((r) => r.name === '"FURNACE", something to melt')
+  const bottom = rows.find((r) => r.name === "the slag count, some")
+  assert.ok(top && bottom)
+  assert.ok(
+    worst(top) > worst(bottom),
+    "the two furnace labels measure the same, so the ember gradient has been flattened",
+  )
+})

--- a/dynawalla/games/coil/src/render/legibility.ts
+++ b/dynawalla/games/coil/src/render/legibility.ts
@@ -1,0 +1,217 @@
+// WHAT EVERY READABLE THING IN THE ALLEY LANDS ON.
+//
+// *"more attention to details needed."*
+//
+// This is that, measured rather than guessed. Every ground below is a COMPOSITE
+// — the stone, the girih lattice over it, the panel scrim over that, the ember
+// gradient inside the furnace, the cold light inside the recess — stacked in the
+// order the scene stacks them, and each ink is composited onto it at the alpha
+// the scene actually uses. Measuring the constants instead is how COUNTERPOISE
+// shipped two literal 1.00:1 cases: they were overlays, and nobody composited
+// them.
+//
+// What the first pass found, before anything moved:
+//
+//   | readable element             | was    |
+//   |------------------------------|--------|
+//   | "SHEAR OFF THE LIT NUMBER"   | 2.45:1 |
+//   | the slag count, none in lane | 1.15:1 |
+//   | the slag count, some in lane | 1.92:1 |
+//   | "FURNACE", nothing to melt   | 2.81:1 |
+//   | a brick's value on the wall  | 2.58:1 |
+//   | "the alley is quiet"         | 2.83:1 |
+//   | "n buried"                   | 2.85:1 |
+//
+// The first of those is the whole rule of the game, in the one place a child
+// looks for it, at two and a half to one. The founder's first report on this
+// pack was *"the instructions are confusing and I really have no idea what I'm
+// doing"*, and one of the reasons is that the instruction was, measurably, not
+// legible.
+//
+// **Nothing here dims an effect.** The ember gradient in the furnace, the cold
+// light in the recess and the girih lattice are all exactly as they were; every
+// change is to an INK. Legibility on a lit ground is won by the type, not by
+// turning the light down.
+
+import {
+  BONE,
+  BONE_DIM,
+  CELESTIAL,
+  CELESTIAL_DIM,
+  EMBER,
+  EMBER_TEXT,
+  GROOVE,
+  INK,
+  SLAG_TEXT,
+  STONE_DEEP,
+  STONE_EDGE,
+  STONE_LIT,
+  BRASS,
+  BRASS_HOT,
+} from "./palette.ts"
+
+export type RGB = readonly [number, number, number]
+
+/** Type a child has to read. WCAG AA body text, held at the body-text number. */
+export const MIN_TEXT = 4.5
+
+export function rgb(hex: string): RGB {
+  const n = Number.parseInt(hex.replace("#", "").slice(0, 6), 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+export function luma(c: RGB): number {
+  const f = (v: number): number => {
+    const x = v / 255
+    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2])
+}
+
+export function contrast(a: RGB, b: RGB): number {
+  const la = luma(a)
+  const lb = luma(b)
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+/** `source-over` at `alpha` — every fill in this pack. Nothing here is additive. */
+export function over(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.round(src[i] * alpha + dst[i] * (1 - alpha))
+  return [m(0), m(1), m(2)]
+}
+
+function lerp(a: RGB, b: RGB, t: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.round(a[i] + (b[i] - a[i]) * t)
+  return [m(0), m(1), m(2)]
+}
+
+/**
+ * The alley floor: the page gradient with the girih lattice drawn over it.
+ *
+ * The lattice is a 1.2px stroke of `STONE_EDGE` at 0.7, blitted at 0.55 — so its
+ * strongest pixel is a fraction of a fraction. It is included anyway, because a
+ * thin bright line under a numeral is exactly the kind of surface the fleet has
+ * been caught not compositing twice already.
+ */
+export function alleySurfaces(): RGB[] {
+  const stops = ["#161210", "#0f0a07", STONE_DEEP].map(rgb)
+  return stops.map((b) => over(rgb(STONE_EDGE), b, 0.7 * 0.55 * 0.35))
+}
+
+/** The stone plate the problem is carved into, and its rim. */
+export function wallSurfaces(): RGB[] {
+  const plate = rgb(STONE_LIT)
+  return [plate, rgb(STONE_EDGE)]
+}
+
+/**
+ * Inside the recess — the one cold light in the game.
+ *
+ * Its fill is `CELESTIAL_DIM` at `0.12 + glow × 0.2` where `glow` runs from 0.24
+ * at rest to 0.74 on a seated cut, so both ends are here: the brightest ground
+ * is the one a child reads the rule against right after a correct answer.
+ */
+export function recessSurfaces(): RGB[] {
+  const out: RGB[] = []
+  for (const glow of [0.24, 0.74]) {
+    for (const base of wallSurfaces()) out.push(over(rgb(CELESTIAL_DIM), base, 0.12 + glow * 0.2))
+  }
+  return out
+}
+
+/** A lever or gauge panel: `STONE_DEEP` at 0.72 over the alley. */
+export function panelSurfaces(): RGB[] {
+  return alleySurfaces().map((b) => over(rgb(STONE_DEEP), b, 0.72))
+}
+
+/**
+ * The furnace, at a fraction `f` of its height measured from the TOP.
+ *
+ * The panel is a vertical gradient from `STONE_DEEP` at 0.9 down to `EMBER` at
+ * `0.15 + heat × 0.5`, and `heat` runs 0.25 to 1 as the lever glows. Sampled at
+ * the label's own y rather than over the whole panel, because the two labels sit
+ * at fixed heights — 0.36 and 0.70 — and averaging a gradient a label never
+ * touches is how a hot ground gets reported as a cool one.
+ */
+export function furnaceSurfaces(f: number): RGB[] {
+  const out: RGB[] = []
+  for (const heat of [0.25, 1]) {
+    for (const base of alleySurfaces()) {
+      const bottom = over(rgb(EMBER), base, 0.15 + heat * 0.5)
+      const top = over(rgb(STONE_DEEP), base, 0.9)
+      out.push(lerp(top, bottom, f))
+    }
+  }
+  return out
+}
+
+/** The brass face of the SHEAR lever, where its word sits. */
+export function shearFaceSurfaces(): RGB[] {
+  const brass = rgb(BRASS)
+  return [0, 0.25].map((press) => lerp(lerp(rgb(BRASS_HOT), brass, press), brass, 0.5))
+}
+
+/** The groove the coil rides in, and the alley beside it. */
+export function grooveSurfaces(): RGB[] {
+  return [rgb(GROOVE), ...alleySurfaces()]
+}
+
+/** An ink at an alpha, and the surfaces it is set on. */
+export type Readable = {
+  readonly name: string
+  readonly ink: string
+  readonly alpha: number
+  readonly ground: RGB[]
+}
+
+/**
+ * Every piece of type in this game, with the ground it is actually set on.
+ *
+ * The list is the audit. A readable element that is not in it is one nobody has
+ * measured, so adding type to the scene means adding a row here.
+ */
+export function readables(): Readable[] {
+  return [
+    { name: '"the alley is quiet"', ink: BONE, alpha: 0.8, ground: recessSurfaces() },
+    { name: "the carved problem", ink: BONE, alpha: 0.86, ground: recessSurfaces() },
+    { name: "the demand, lit", ink: CELESTIAL, alpha: 1, ground: recessSurfaces() },
+    { name: '"SHEAR OFF THE LIT NUMBER"', ink: BONE, alpha: 0.85, ground: recessSurfaces() },
+    { name: "the cradle's ×n", ink: BONE, alpha: 0.8, ground: recessSurfaces() },
+    { name: "the ingot's value", ink: BONE, alpha: 0.9, ground: recessSurfaces() },
+    { name: "a brick's value", ink: BONE, alpha: 0.7, ground: wallSurfaces() },
+    { name: '"n buried"', ink: SLAG_TEXT, alpha: 1, ground: grooveSurfaces() },
+    { name: "the hint's 10×n", ink: CELESTIAL, alpha: 1, ground: grooveSurfaces() },
+    { name: '"FURNACE", something to melt', ink: EMBER_TEXT, alpha: 1, ground: furnaceSurfaces(0.36) },
+    { name: '"FURNACE", nothing to melt', ink: EMBER_TEXT, alpha: 0.72, ground: furnaceSurfaces(0.36) },
+    { name: "the slag count, some", ink: EMBER_TEXT, alpha: 1, ground: furnaceSurfaces(0.7) },
+    { name: "the slag count, none", ink: EMBER_TEXT, alpha: 0.8, ground: furnaceSurfaces(0.7) },
+    { name: '"SHEAR"', ink: INK, alpha: 1, ground: shearFaceSurfaces() },
+    { name: "the gauge's ×n", ink: BONE, alpha: 1, ground: panelSurfaces() },
+    { name: "the hint's reading", ink: CELESTIAL, alpha: 1, ground: panelSurfaces() },
+  ]
+}
+
+/**
+ * The inks this pack used to set these in, kept so "it is better now" is a claim
+ * about a change rather than about a constant.
+ */
+export function shipped(): Readable[] {
+  return [
+    { name: '"the alley is quiet"', ink: BONE_DIM, alpha: 1, ground: recessSurfaces() },
+    { name: '"SHEAR OFF THE LIT NUMBER"', ink: BONE_DIM, alpha: 0.85, ground: recessSurfaces() },
+    { name: "the cradle's ×n", ink: BONE_DIM, alpha: 1, ground: recessSurfaces() },
+    { name: "a brick's value", ink: BONE_DIM, alpha: 0.7, ground: wallSurfaces() },
+    { name: '"n buried"', ink: "#5c665a", alpha: 0.95, ground: grooveSurfaces() },
+    { name: '"FURNACE", nothing to melt', ink: "#ffd0a0", alpha: 0.4, ground: furnaceSurfaces(0.36) },
+    { name: "the slag count, some", ink: EMBER, alpha: 1, ground: furnaceSurfaces(0.7) },
+    { name: "the slag count, none", ink: BONE_DIM, alpha: 0.6, ground: furnaceSurfaces(0.7) },
+  ]
+}
+
+/** The worst contrast this ink at this alpha presents over its own ground. */
+export function worst(r: Readable): number {
+  let out = Infinity
+  const ink = rgb(r.ink)
+  for (const g of r.ground) out = Math.min(out, contrast(over(ink, g, r.alpha), g))
+  return out
+}

--- a/dynawalla/games/coil/src/render/palette.ts
+++ b/dynawalla/games/coil/src/render/palette.ts
@@ -37,9 +37,29 @@ export const CELESTIAL_DIM = "#4b7d90"
 /** Oxide. Slag, and the buried head of a choked coil. */
 export const SLAG = "#3a4038"
 export const SLAG_EDGE = "#5c665a"
+/**
+ * Oxide, as TYPE.
+ *
+ * `SLAG_EDGE` is the rim of a lump lying on stone and it is exactly right there.
+ * Set as a numeral on the lane's groove it measures **2.85:1**, which is not a
+ * label, it is a smudge — and the label it was carrying is `n buried`, the one
+ * that explains why the head of the coil has stopped responding. Same hue, lifted
+ * until it is readable: 8.63:1 on the same groove.
+ */
+export const SLAG_TEXT = "#a9b7a6"
 
 export const EMBER = "#ff7a2c"
 export const EMBER_HOT = "#ffd0a0"
+/**
+ * Ember, as TYPE.
+ *
+ * The furnace panel is a gradient that runs to hot orange at the bottom, and both
+ * of its labels sit in the hot half. `EMBER` on it is orange on orange —
+ * **1.92:1** — and the idle `n slag` reading was `BONE_DIM` at 0.6, which is
+ * **1.15:1**: a line of type that is, measurably, not there. The heat is the
+ * effect and it stays; the ink is what moves.
+ */
+export const EMBER_TEXT = "#fff3e6"
 
 export const BONE = "#f3e7cf"
 export const BONE_DIM = "#8b8272"

--- a/dynawalla/games/coil/src/render/scene.ts
+++ b/dynawalla/games/coil/src/render/scene.ts
@@ -10,7 +10,13 @@
 // exactly one cold light — the recess. Nothing glows for encouragement.
 
 import type { Brick } from "../game/session.ts"
-import type { HintState } from "../game/hint.ts"
+import {
+  STAGE_JOINT,
+  STAGE_NUMBER,
+  STAGE_PLACE,
+  STAGE_SHAPE,
+  type HintState,
+} from "../game/hint.ts"
 import type { Round } from "../game/round.ts"
 import { coilOf, linkValue } from "../game/place.ts"
 import { COURSE } from "../game/session.ts"
@@ -683,7 +689,7 @@ export class Scene {
    */
   private drawHint(s: SceneState, lane: Lane): void {
     const hint = s.hintState
-    if (!hint || hint.stage < 1 || s.hint <= 0.01 || s.links.length === 0) return
+    if (!hint || hint.stage < STAGE_SHAPE || s.hint <= 0.01 || s.links.length === 0) return
     const { ctx } = this
     const tail = this.cellForLink(s, s.links.length - 1)
     if (tail < 0) return
@@ -710,11 +716,11 @@ export class Scene {
       drawLink(ctx, c.x, c.y, unit, want[k] as number, 0.5)
     }
 
-    // 2. THE CHANGE. The link that has to be opened, ringed, with the ten-for-one
+    // 2. THE PLACE. The link that has to be opened, ringed, with the ten-for-one
     //    it yields written under it. Numerals and a multiplication sign: the
     //    whole subject of the game is that ten of one place is one of the next,
     //    and no sentence says it better than `10×1` under a drum.
-    if (hint.stage >= 2 && hint.plan.breakIndex >= 0) {
+    if (hint.stage >= STAGE_PLACE && hint.plan.breakIndex >= 0) {
       const cell = this.cellForLink(s, hint.plan.breakIndex)
       if (cell >= 0 && cell < lane.capacity) {
         const c = cellAt(lane, cell)
@@ -739,10 +745,12 @@ export class Scene {
       }
     }
 
-    // 3. THE PLACE. A ghost of the jaws on the joint to put them on next — the
+    // 3. THE JOINT. A ghost of the jaws on the joint to put them on next — the
     //    link to open while there is one, and the joint to cut at once there is
-    //    not. Live: it moves the instant a link is cracked.
-    if (hint.stage >= 3) {
+    //    not. Live: it moves the instant a link is cracked. THIS IS THE ANSWER,
+    //    which is why `FREE_STAGES` stops below `STAGE_JOINT` and only a thumb
+    //    gets here.
+    if (hint.stage >= STAGE_JOINT) {
       const cell = this.cellForLink(s, hint.plan.aim)
       if (cell >= 0 && cell < lane.capacity) {
         const here = cellAt(lane, cell)
@@ -903,11 +911,18 @@ export class Scene {
     ctx.fillStyle = withAlpha(STONE_DEEP, 0.72)
     roundRect(ctx, x, y, w, h, 8)
     ctx.fill()
-    // The affordance, and the only one this needs: when there is more hint to be
-    // had, the panel that gives it brightens. No button, no word, no badge.
+    // The affordance, and the only one this needs: while there is more hint to be
+    // had, the panel that gives it is lit a little brighter than a panel. No
+    // button, no word, no badge.
+    //
+    // The lift is a CONSTANT and not a function of `s.hint`, because the state
+    // it has to speak in is the one where no hint is showing at all — a child
+    // who has not yet discovered that this panel answers when pressed. A lift
+    // that faded in with the hint only appeared to children who had already
+    // found it.
     const more = s.hintState?.more ?? false
-    ctx.strokeStyle = withAlpha(CELESTIAL_DIM, more ? 0.45 + s.hint * 0.5 : 0.45)
-    ctx.lineWidth = more ? 1.2 + s.hint * 1.1 : 1.2
+    ctx.strokeStyle = withAlpha(CELESTIAL_DIM, more ? 0.68 : 0.45)
+    ctx.lineWidth = more ? 1.8 : 1.2
     ctx.stroke()
 
     const piece = s.links.slice(s.cut)
@@ -949,7 +964,7 @@ export class Scene {
     // Fitted to the panel, because that is the defect this whole change is
     // about: the shipped hint was type laid into this rect without measuring it.
     const hint = s.hintState
-    if (hint && hint.stage >= 4 && s.hint > 0.01) {
+    if (hint && hint.stage >= STAGE_NUMBER && s.hint > 0.01) {
       const line = `${String(hint.holding)} / ${String(hint.demand)}`
       let size = Math.min(h * 0.3, 20)
       ctx.font = numerals(size, 700)

--- a/dynawalla/games/coil/src/render/scene.ts
+++ b/dynawalla/games/coil/src/render/scene.ts
@@ -10,27 +10,28 @@
 // exactly one cold light — the recess. Nothing glows for encouragement.
 
 import type { Brick } from "../game/session.ts"
+import type { HintState } from "../game/hint.ts"
 import type { Round } from "../game/round.ts"
 import { coilOf, linkValue } from "../game/place.ts"
 import { COURSE } from "../game/session.ts"
 import { SLAG_CELLS } from "../game/board.ts"
 import { safeInsets } from "../../../../packs/shared/game-chrome/index.ts"
-import { type Layout, type Lane, cellAt, viewLayout } from "./layout.ts"
+import { type Layout, type Lane, cellAt, labelX, viewLayout } from "./layout.ts"
 import { KIND_DUST, KIND_FILING, KIND_SPARK, Particles } from "./particles.ts"
 import {
   BONE,
-  BONE_DIM,
   BRASS,
   BRASS_DARK,
   BRASS_HOT,
   CELESTIAL,
   CELESTIAL_DIM,
   EMBER,
-  EMBER_HOT,
+  EMBER_TEXT,
   GROOVE,
   INK,
   SLAG as SLAG_COLOUR,
   SLAG_EDGE,
+  SLAG_TEXT,
   STONE,
   STONE_DEEP,
   STONE_EDGE,
@@ -73,8 +74,10 @@ export type SceneState = {
   furnaceGlow: number
   shearPress: number
   whip: number
-  /** 0..1 — the ghost of the demand, offered after a long hesitation. */
+  /** 0..1 fade on the hint, decayed by the caller. Never a countdown. */
   hint: number
+  /** What the hint is currently saying, or `null` when it is saying nothing. */
+  hintState: HintState | null
   flight: Flight | null
 }
 
@@ -385,7 +388,7 @@ export class Scene {
     ctx.save()
     ctx.textBaseline = "middle"
     if (!round) {
-      ctx.fillStyle = BONE_DIM
+      ctx.fillStyle = withAlpha(BONE, 0.8)
       ctx.font = font(Math.min(20, h * 0.3))
       ctx.textAlign = "center"
       ctx.fillText("the alley is quiet", x + w / 2, y + h / 2)
@@ -436,7 +439,11 @@ export class Scene {
     // that stays is the answer, in a fill it flies to the cradle and joins the
     // ingot, and a child learns which is which by watching it happen once.
     ctx.font = font(Math.max(10, size * 0.24), 600)
-    ctx.fillStyle = withAlpha(BONE_DIM, 0.85)
+    // The one line that is the whole rule of the game, and it was the least
+    // legible type on the screen: `BONE_DIM` at 0.85 on the lit recess measures
+    // 2.45:1. A child who cannot read the rule has, in the founder's words, "no
+    // idea what I'm doing". Same size, same place, an ink that is actually there.
+    ctx.fillStyle = withAlpha(BONE, 0.85)
     ctx.textAlign = "left"
     ctx.fillText("SHEAR OFF THE LIT NUMBER", startX, y + h * 0.86)
     ctx.restore()
@@ -465,7 +472,7 @@ export class Scene {
         px += unit * 1.25
       }
       if (g.n > shown) {
-        ctx.fillStyle = BONE_DIM
+        ctx.fillStyle = withAlpha(BONE, 0.8)
         ctx.font = numerals(unit * 1.1, 600)
         ctx.textAlign = "left"
         ctx.textBaseline = "middle"
@@ -518,7 +525,7 @@ export class Scene {
     }
     const brick: Brick | undefined = s.wall[s.wall.length - 1]
     if (brick) {
-      ctx.fillStyle = withAlpha(BONE_DIM, 0.7)
+      ctx.fillStyle = withAlpha(BONE, 0.7)
       ctx.font = numerals(Math.max(9, bh * 0.8), 600)
       ctx.textAlign = "right"
       ctx.textBaseline = "middle"
@@ -560,6 +567,7 @@ export class Scene {
     this.drawBuried(s, lane)
     this.drawCoil(s, lane)
     this.drawShear(s, lane)
+    this.drawHint(s, lane)
 
     // A miss stains the lane with oxide for a quarter of a second. It is the
     // whole of the negative feedback: no flash, no shake, no sound of refusal —
@@ -603,7 +611,7 @@ export class Scene {
       drawLink(ctx, c.x - lane.pitch * 0.7 + i * 2.6, c.y - lane.rowPitch * 0.62, lane.unit * 0.7, p, 0.7)
     }
     ctx.globalAlpha = 1
-    ctx.fillStyle = withAlpha(SLAG_EDGE, 0.95)
+    ctx.fillStyle = SLAG_TEXT
     ctx.font = numerals(Math.max(10, lane.unit * 0.9), 700)
     ctx.textAlign = "left"
     ctx.textBaseline = "middle"
@@ -656,6 +664,103 @@ export class Scene {
         }
       }
     }
+  }
+
+  /**
+   * The hint, on the lane, in the machine's own vocabulary.
+   *
+   * It is drawn HERE and not in the gauge, and that is the fix for *"hints don't
+   * fit on mobile."* The shipped hint was a line of text — `2×10  5×1` — laid
+   * into an 82px panel with no measurement at all; on the founder's handset it
+   * ran out of the gauge, across the SHEAR lever and off the glass. The lane is
+   * a grid this game already fits to every viewport it supports, so a hint drawn
+   * on it cannot overflow: it occupies cells, and the cells are the layout.
+   *
+   * It is also the better picture. Ghost links hovering over the tail of the
+   * child's own chain say *these are the links that have to come off* and let
+   * them be compared one against one — which is exactly the moment the borrow
+   * becomes visible, because the ghosts do not line up.
+   */
+  private drawHint(s: SceneState, lane: Lane): void {
+    const hint = s.hintState
+    if (!hint || hint.stage < 1 || s.hint <= 0.01 || s.links.length === 0) return
+    const { ctx } = this
+    const tail = this.cellForLink(s, s.links.length - 1)
+    if (tail < 0) return
+
+    ctx.save()
+    ctx.globalAlpha = s.hint
+    const unit = lane.unit * 0.74
+
+    // 1. THE SHAPE. The demand, as a chain of its own, laid in the empty cells
+    //    that follow the child's tail.
+    //
+    //    In the cells AFTER the tail and not hovering over it, which was the
+    //    first thing tried: a ghost lifted off the lane needs about 1.2 units of
+    //    clearance to sit clear of a tower, and the row pitch can be as little
+    //    as 2.6 — so on a short lane the ghost either overlapped the links it was
+    //    meant to be compared with or climbed out of the lane rectangle
+    //    altogether. The grid already fits every viewport this game supports;
+    //    borrowing cells from it is the one placement that cannot overflow.
+    const want = coilOf(hint.demand)
+    for (let k = 0; k < want.length; k++) {
+      const cell = tail + 1 + k
+      if (cell >= lane.capacity) break
+      const c = cellAt(lane, cell)
+      drawLink(ctx, c.x, c.y, unit, want[k] as number, 0.5)
+    }
+
+    // 2. THE CHANGE. The link that has to be opened, ringed, with the ten-for-one
+    //    it yields written under it. Numerals and a multiplication sign: the
+    //    whole subject of the game is that ten of one place is one of the next,
+    //    and no sentence says it better than `10×1` under a drum.
+    if (hint.stage >= 2 && hint.plan.breakIndex >= 0) {
+      const cell = this.cellForLink(s, hint.plan.breakIndex)
+      if (cell >= 0 && cell < lane.capacity) {
+        const c = cellAt(lane, cell)
+        ctx.strokeStyle = withAlpha(CELESTIAL, 0.8)
+        ctx.lineWidth = 1.6
+        ctx.setLineDash([3, 3])
+        ctx.beginPath()
+        ctx.arc(c.x, c.y, lane.unit * 0.92, 0, TAU)
+        ctx.stroke()
+        ctx.setLineDash([])
+
+        const place = s.links[hint.plan.breakIndex] as number
+        const label = `10×${String(linkValue(place - 1))}`
+        const size = Math.max(9, lane.unit * 0.78)
+        ctx.font = numerals(size, 700)
+        ctx.textAlign = "left"
+        ctx.textBaseline = "middle"
+        // Measured and clamped into the lane. A label at the far column would
+        // otherwise hang off the same edge the old hint hung off.
+        ctx.fillStyle = CELESTIAL
+        ctx.fillText(label, labelX(lane, c.x, ctx.measureText(label).width), c.y + lane.rowPitch * 0.36)
+      }
+    }
+
+    // 3. THE PLACE. A ghost of the jaws on the joint to put them on next — the
+    //    link to open while there is one, and the joint to cut at once there is
+    //    not. Live: it moves the instant a link is cracked.
+    if (hint.stage >= 3) {
+      const cell = this.cellForLink(s, hint.plan.aim)
+      if (cell >= 0 && cell < lane.capacity) {
+        const here = cellAt(lane, cell)
+        const prev = cellAt(lane, Math.max(0, cell - 1))
+        const jx = cell === 0 ? here.x - lane.pitch * 0.5 : (here.x + prev.x) / 2
+        const jy = cell === 0 ? here.y : (here.y + prev.y) / 2
+        ctx.globalAlpha = s.hint * 0.55
+        ctx.strokeStyle = CELESTIAL
+        ctx.lineWidth = 2
+        ctx.setLineDash([4, 4])
+        ctx.beginPath()
+        ctx.moveTo(jx, jy - lane.rowPitch * 0.46)
+        ctx.lineTo(jx, jy + lane.rowPitch * 0.46)
+        ctx.stroke()
+        ctx.setLineDash([])
+      }
+    }
+    ctx.restore()
   }
 
   /** The jaws, parked in the joint ahead of the cut. */
@@ -737,13 +842,16 @@ export class Scene {
     ctx.strokeStyle = withAlpha(EMBER, 0.45 + s.furnaceGlow * 0.5)
     ctx.lineWidth = 1.6
     ctx.stroke()
-    ctx.fillStyle = s.slag > 0 ? EMBER_HOT : withAlpha(EMBER_HOT, 0.4)
+    // Brightness, not hue, carries "there is something to melt" — because the
+    // ground under both of these labels is the panel's own ember gradient, and
+    // orange type on it measured 1.92:1 while the idle reading measured 1.15:1.
+    ctx.fillStyle = withAlpha(EMBER_TEXT, s.slag > 0 ? 1 : 0.72)
     ctx.font = font(Math.min(15, f.h * 0.26), 700)
     ctx.textAlign = "center"
     ctx.textBaseline = "middle"
     ctx.fillText("FURNACE", f.x + f.w / 2, f.y + f.h * 0.36)
     ctx.font = numerals(Math.min(19, f.h * 0.3), 700)
-    ctx.fillStyle = s.slag > 0 ? EMBER : withAlpha(BONE_DIM, 0.6)
+    ctx.fillStyle = withAlpha(EMBER_TEXT, s.slag > 0 ? 1 : 0.8)
     ctx.fillText(`${String(s.slag)} slag`, f.x + f.w / 2, f.y + f.h * 0.7)
     ctx.restore()
 
@@ -783,18 +891,23 @@ export class Scene {
   private drawGauge(s: SceneState): void {
     const { ctx } = this
     const L = this.layout
-    const x = L.furnace.x + L.furnace.w + 12
-    const w = L.shear.x - x - 12
-    if (w < 60) return
-    const y = L.levers.y
-    const h = L.levers.h
+    // The rect comes from the layout now. It used to be worked out here, as
+    // `shear.x − (furnace.x + furnace.w) − 24`, and given up on below 60px —
+    // which on a narrow safe rectangle silently deleted the only panel that
+    // answers "what am I holding". `layout.ts` shares the lever row between the
+    // three panels instead, and `chrome.test.ts` puts a floor under this one.
+    const { x, y, w, h } = L.gauge
+    if (w <= 0) return
 
     ctx.save()
     ctx.fillStyle = withAlpha(STONE_DEEP, 0.72)
     roundRect(ctx, x, y, w, h, 8)
     ctx.fill()
-    ctx.strokeStyle = withAlpha(CELESTIAL_DIM, 0.45)
-    ctx.lineWidth = 1.2
+    // The affordance, and the only one this needs: when there is more hint to be
+    // had, the panel that gives it brightens. No button, no word, no badge.
+    const more = s.hintState?.more ?? false
+    ctx.strokeStyle = withAlpha(CELESTIAL_DIM, more ? 0.45 + s.hint * 0.5 : 0.45)
+    ctx.lineWidth = more ? 1.2 + s.hint * 1.1 : 1.2
     ctx.stroke()
 
     const piece = s.links.slice(s.cut)
@@ -824,18 +937,33 @@ export class Scene {
       px += unit * 0.9
     }
 
-    // The hint: the demand's own shape, ghosted, offered only after the child
-    // has been still for a while. It never costs anything and never hurries.
-    if (s.hint > 0 && s.round) {
-      ctx.globalAlpha = s.hint * 0.5
-      ctx.fillStyle = CELESTIAL
-      ctx.font = font(Math.max(10, h * 0.17), 600)
-      ctx.textAlign = "left"
+    // 4. THE NUMBER — the last picture, and the only one that is a numeral.
+    //
+    // The doc comment above is right that the gauge must never print this during
+    // play, and it is exactly wrong for a child who has been stuck for a minute
+    // and asked for help twice with their thumb. So it arrives here and only
+    // here: what the jaws are holding, over what the wall wants. The rule the
+    // gauge protects — that reading the places is the child's job — is protected
+    // by this being the FOURTH thing the hint says, not by never saying it.
+    //
+    // Fitted to the panel, because that is the defect this whole change is
+    // about: the shipped hint was type laid into this rect without measuring it.
+    const hint = s.hintState
+    if (hint && hint.stage >= 4 && s.hint > 0.01) {
+      const line = `${String(hint.holding)} / ${String(hint.demand)}`
+      let size = Math.min(h * 0.3, 20)
+      ctx.font = numerals(size, 700)
+      const room = w - 12
+      const wide = ctx.measureText(line).width
+      if (wide > room && wide > 0) {
+        size = Math.max(9, size * (room / wide))
+        ctx.font = numerals(size, 700)
+      }
+      ctx.globalAlpha = s.hint
+      ctx.fillStyle = hint.holding === hint.demand ? CELESTIAL : BONE
+      ctx.textAlign = "center"
       ctx.textBaseline = "middle"
-      const want = tally(coilOf(s.round.demand))
-        .map((g) => `${String(g.n)}×${String(linkValue(g.place))}`)
-        .join("  ")
-      ctx.fillText(want, x + unit * 1.4, y + h * 0.82)
+      ctx.fillText(line, x + w / 2, y + h * 0.82)
       ctx.globalAlpha = 1
     }
     ctx.restore()

--- a/dynawalla/games/coil/src/render/viewports.ts
+++ b/dynawalla/games/coil/src/render/viewports.ts
@@ -1,0 +1,37 @@
+// The screens this pack is asserted against, in one place.
+//
+// Shared by `chrome.test.ts` and `hintFit.test.ts` rather than exported from one
+// of them: a test file that imports another test file runs it a second time, and
+// a suite that reports a test twice is a suite nobody can count.
+
+import { type Insets, NO_INSETS } from "../../../../packs/shared/game-chrome/index.ts"
+
+const PORTRAIT_NOTCH: Insets = { top: 59, right: 0, bottom: 34, left: 0 }
+const LANDSCAPE_NOTCH: Insets = { top: 0, right: 59, bottom: 21, left: 59 }
+/** An Android phone with a status bar and a three-button navigation bar. */
+export const PORTRAIT_ANDROID: Insets = { top: 24, right: 0, bottom: 48, left: 0 }
+/** The same phone turned sideways: the nav bar moves to the trailing edge. */
+const LANDSCAPE_ANDROID: Insets = { top: 0, right: 48, bottom: 0, left: 24 }
+
+export const VIEWPORTS: Array<[string, number, number]> = [
+  ["phone portrait, small", 320, 568],
+  ["phone portrait, tall", 390, 844],
+  // The founder's own handset: 1080×2340 physical, which the browser reports as
+  // 393×851 CSS px at devicePixelRatio 2.75. Both ways up.
+  ["the founder's phone, portrait", 393, 851],
+  ["the founder's phone, landscape", 851, 393],
+  ["tablet portrait", 768, 1024],
+  ["tablet landscape", 1024, 768],
+  ["phone landscape", 844, 390],
+]
+
+/** A flat profile always, and the chrome the device of that shape actually has. */
+export function profiles(w: number, h: number): Array<[string, Insets]> {
+  return [
+    ["no insets", NO_INSETS],
+    w >= h ? ["landscape notch", LANDSCAPE_NOTCH] : ["portrait notch", PORTRAIT_NOTCH],
+    w >= h
+      ? ["android 3-button nav", LANDSCAPE_ANDROID]
+      : ["android status + 3-button nav", PORTRAIT_ANDROID],
+  ]
+}

--- a/dynawalla/games/guilty/src/game/hud.ts
+++ b/dynawalla/games/guilty/src/game/hud.ts
@@ -18,6 +18,7 @@ import { SHIP_Y } from "../core/config.ts";
 import { C, rgba } from "../core/palette.ts";
 import { drawGlow, drawGlyph, getGlyph } from "../render/bake.ts";
 import { clamp, ease } from "../render/draw.ts";
+import { gameOverLayout, type CardLine } from "./hudLayout.ts";
 import type { World } from "./world.ts";
 
 const UI_FONT = `700 %SIZE%px system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif`;
@@ -66,9 +67,13 @@ export function drawEquation(world: World): void {
   // A hair of chromatic split while it lands — two cheap blits of one sprite.
   if (age < 0.3 && !world.reduced) {
     const k = (1 - age / 0.3) * size * 0.07;
+    // Explicitly ADDED, not inherited: `drawGlyph` now forces `source-over` by
+    // default so the counter-ink rim it bakes can never be silently turned into
+    // a no-op the way POLARITY's was. These two ghosts are the one place in the
+    // game that wants the sprite to bloom rather than to read.
     ctx.globalAlpha = 0.32;
-    drawGlyph(ctx, getGlyph(q.prompt, C.hostile, 800), p.x - k, p.y, size);
-    drawGlyph(ctx, getGlyph(q.prompt, C.plankton, 800), p.x + k, p.y, size);
+    drawGlyph(ctx, getGlyph(q.prompt, C.hostile, 800), p.x - k, p.y, size, 1, "lighter");
+    drawGlyph(ctx, getGlyph(q.prompt, C.plankton, 800), p.x + k, p.y, size, 1, "lighter");
     ctx.globalAlpha = 1;
   }
   ctx.globalCompositeOperation = "source-over";
@@ -300,37 +305,60 @@ export function drawTitle(world: World): void {
 
 export function drawGameOver(world: World): void {
   const { ctx, hud } = world;
-  const { w, h } = hud.safe;
   const t = clamp(world.phaseT / 0.8, 0, 1);
   // The dim covers the whole GLASS — a scrim that stopped at the safe area
   // would draw a bright band across the notch.
   ctx.fillStyle = rgba("#02060c", 0.55 * t);
   ctx.fillRect(0, 0, world.w, world.h);
-  const size = Math.min(w * 0.16, h * 0.1);
-  const y = hud.safe.y + h * 0.38;
+
+  // Measured, not assumed. Every line here used to be sized from the viewport
+  // and drawn without being measured, so the headline and the ledger both ran
+  // off a phone. `gameOverLayout` fits them against the context's own metrics,
+  // which is the same measurement the device makes.
+  const card = gameOverLayout(
+    hud,
+    {
+      headline: "THE TRENCH TAKES YOU",
+      score: String(world.score),
+      ledger: [`BEST ${world.best}`, `WAVE ${world.wave}`, `BEST RUN ×${world.bestCombo}`],
+      prompt: world.touch ? "TAP TO DIVE AGAIN" : "PRESS ANY KEY",
+    },
+    (text, size) => {
+      ctx.font = font(size);
+      return ctx.measureText(text).width;
+    },
+  );
+  // The card is headline, score, one to three ledger rows, prompt — the ledger
+  // wraps on a narrow safe rectangle rather than shrinking past legibility.
+  const headline = card.lines[0] as CardLine;
+  const score = card.lines[1] as CardLine;
+  const prompt = card.lines[card.lines.length - 1] as CardLine;
+  const ledger = card.lines.slice(2, -1);
+
   ctx.globalCompositeOperation = "lighter";
-  drawGlow(ctx, C.hostile, hud.cx, y, size * 2.4, 0.12 * t);
+  drawGlow(ctx, C.hostile, hud.cx, headline.y, card.size * 2.4, 0.12 * t);
   ctx.globalCompositeOperation = "source-over";
-  ctx.font = font(size * 0.62);
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
   ctx.globalAlpha = t;
-  ctx.fillStyle = rgba(C.hostile, 0.9);
-  ctx.fillText("THE TRENCH TAKES YOU", hud.cx, y);
 
-  ctx.font = font(size * 1.1);
+  ctx.font = font(headline.size);
+  ctx.fillStyle = rgba(C.hostile, 0.9);
+  ctx.fillText(headline.text, hud.cx, headline.y);
+
+  ctx.font = font(score.size);
   ctx.fillStyle = C.amber;
-  ctx.fillText(String(world.score), hud.cx, y + size * 1.05);
-  ctx.font = font(size * 0.3);
+  ctx.fillText(score.text, hud.cx, score.y);
+
   ctx.fillStyle = rgba(C.cyan, 0.6);
-  ctx.fillText(
-    `BEST ${world.best}   ·   WAVE ${world.wave}   ·   BEST RUN ×${world.bestCombo}`,
-    hud.cx,
-    y + size * 1.75,
-  );
+  for (const row of ledger) {
+    ctx.font = font(row.size);
+    ctx.fillText(row.text, hud.cx, row.y);
+  }
+
+  ctx.font = font(prompt.size);
   ctx.fillStyle = rgba(C.white, 0.35 + Math.sin(world.time * 3) * 0.25);
-  ctx.font = font(size * 0.32);
-  ctx.fillText(world.touch ? "TAP TO DIVE AGAIN" : "PRESS ANY KEY", hud.cx, y + size * 2.5);
+  ctx.fillText(prompt.text, hud.cx, prompt.y);
   ctx.globalAlpha = 1;
 }
 

--- a/dynawalla/games/guilty/src/game/hudLayout.test.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.test.ts
@@ -316,10 +316,10 @@ test("the ledger wraps only where it has to, and never loses a fact", () => {
         LEDGER_ONE_ROW,
         `${vname}, ${iname}: the ledger rows do not reassemble into the ledger`,
       );
-      assert.ok(
-        ledger.length <= COPY.ledger.length,
-        `${vname}, ${iname}: the ledger split into ${ledger.length} rows for ${COPY.ledger.length} facts`,
-      );
+      // No assertion on the row COUNT here: the greedy pack pushes at most one
+      // row per fact, so "no more rows than facts" is true of any implementation
+      // of that loop and would pass whatever it did. The `join` above is the
+      // check — it fails if a fact is dropped, duplicated or reordered.
     }
   }
 });

--- a/dynawalla/games/guilty/src/game/hudLayout.test.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.test.ts
@@ -35,11 +35,15 @@ import {
   type Rect,
 } from "../../../../packs/shared/game-chrome/index.ts";
 import { EQUATION_Y, VIEW_HALF_H } from "../core/config.ts";
-import { hudLayout } from "./hudLayout.ts";
+import { gameOverLayout, hudLayout } from "./hudLayout.ts";
 
 const VIEWPORTS: Array<[string, number, number]> = [
   ["phone portrait, small", 320, 568],
   ["phone portrait", 390, 844],
+  // The founder's own handset: 1080×2340 physical, which the browser reports as
+  // 393×851 CSS px at devicePixelRatio 2.75.
+  ["the founder's phone, portrait", 393, 851],
+  ["the founder's phone, landscape", 851, 393],
   ["tablet portrait", 768, 1024],
   ["tablet landscape", 1024, 768],
   ["phone landscape", 844, 390],
@@ -52,10 +56,17 @@ const NOTCH: Insets = { top: 47, right: 0, bottom: 34, left: 0 };
 /** The same phone on its side. Both long edges lose room. */
 const NOTCH_SIDE: Insets = { top: 0, right: 47, bottom: 21, left: 47 };
 
+/** An Android phone with a status bar and a three-button navigation bar. */
+const ANDROID: Insets = { top: 24, right: 0, bottom: 48, left: 0 };
+/** The same phone turned sideways: the nav bar moves to the trailing edge. */
+const ANDROID_SIDE: Insets = { top: 0, right: 48, bottom: 0, left: 24 };
+
 const INSETS: Array<[string, Insets]> = [
   ["flat", FLAT],
   ["notched", NOTCH],
   ["notched, on its side", NOTCH_SIDE],
+  ["android status + 3-button nav", ANDROID],
+  ["android, on its side", ANDROID_SIDE],
 ];
 
 const inside = (r: Rect, a: Rect): boolean =>
@@ -174,5 +185,163 @@ test("the trench is not letterboxed by the insets", () => {
     assert.equal(notched.glass.h, h, `${name}: a notch shortened the glass`);
     assert.equal(flat.safe.h, h, `${name}: the flat safe area is not the whole height`);
     assert.ok(notched.safe.h < h, `${name}: the notch cost the HUD nothing, which cannot be right`);
+  }
+});
+
+/* ───────────────────────────────────────────────────── the death screen fits */
+
+// *"the death screen doesn't quite fit."*
+//
+// It did not. `drawGameOver` set four font sizes from the viewport and then
+// called `fillText` on all four without measuring any of them — the only card in
+// this game that skipped `fitFont`. What follows is computed at real viewports
+// from the same `gameOverLayout` the canvas draws from, with a text metric of
+// its own, so it fails if the fitting is removed rather than restating it.
+
+/**
+ * Advance width for a bold uppercase run, per character per pixel of type size.
+ *
+ * 0.62, not the 0.56 the harness in `opening.test.ts` uses for mixed case. Every
+ * line on this card is `700`-weight and three of the four are ALL CAPS, and caps
+ * in a UI sans run wider than the average glyph. A layout test that models the
+ * type as narrower than it is passes for the wrong reason.
+ */
+const ADVANCE = 0.62;
+const measure = (text: string, size: number): number => text.length * size * ADVANCE;
+
+/**
+ * The worst card this game can put up: a six-figure best, a two-figure wave and
+ * a two-figure run, which is what the ledger line looks like after a good
+ * session rather than after the first one.
+ */
+const COPY = {
+  headline: "THE TRENCH TAKES YOU",
+  score: "104820",
+  ledger: ["BEST 128640", "WAVE 24", "BEST RUN ×31"],
+  prompt: "TAP TO DIVE AGAIN",
+};
+
+/** The ledger as it reads when all three facts share one row. */
+const LEDGER_ONE_ROW = COPY.ledger.join("   ·   ");
+
+for (const [vname, w, h] of VIEWPORTS) {
+  for (const [iname, insets] of INSETS) {
+    test(`the death screen fits — ${vname} (${w}×${h}), ${iname}`, () => {
+      const area = safeRect(w, h, insets);
+      const l = hudLayout(w, h, area);
+      const card = gameOverLayout(l, COPY, measure);
+
+      for (const line of card.lines) {
+        assert.ok(
+          inside(line.box, area),
+          `"${line.text}" leaves the safe area: ${JSON.stringify(line.box)} vs ${JSON.stringify(area)}`,
+        );
+        assert.equal(
+          hitsHostChrome(line.box, w, insets),
+          false,
+          `"${line.text}" is under a host control: ${JSON.stringify(line.box)}`,
+        );
+      }
+    });
+  }
+}
+
+test("the death screen's headline really did run off a phone before this", () => {
+  // The defect, measured, so that "it fits now" is a statement about a change
+  // and not about a constant. This is the unfitted arithmetic `drawGameOver`
+  // used to do: `font(size * 0.62)` and straight into `fillText`.
+  for (const [name, w, h] of [
+    ["phone portrait, small", 320, 568],
+    ["the founder's phone, portrait", 393, 851],
+  ] as Array<[string, number, number]>) {
+    const area = safeRect(w, h, ANDROID);
+    const size = Math.min(area.w * 0.16, area.h * 0.1);
+    const headline = measure(COPY.headline, size * 0.62);
+    const ledger = measure(LEDGER_ONE_ROW, size * 0.3);
+    assert.ok(
+      headline > area.w,
+      `${name}: the unfitted headline was ${headline.toFixed(0)}px across a ${area.w}px screen`,
+    );
+    assert.ok(
+      ledger > area.w,
+      `${name}: the unfitted ledger was ${ledger.toFixed(0)}px across a ${area.w}px screen`,
+    );
+  }
+});
+
+test("the death screen shrinks type rather than moving the block", () => {
+  // Two properties that together say the card is FITTED and not merely nudged.
+  //
+  // 1. A narrow phone gets smaller type than a wide one for the same line.
+  // 2. The rows stay where the nominal size puts them, so the card does not
+  //    creep upward on the devices where it is already tightest.
+  const narrow = gameOverLayout(hudLayout(320, 568, safeRect(320, 568, FLAT)), COPY, measure);
+  const wide = gameOverLayout(hudLayout(1024, 768, safeRect(1024, 768, FLAT)), COPY, measure);
+  const headline = (c: typeof narrow): number => (c.lines[0] as { size: number }).size;
+  assert.ok(
+    headline(narrow) < narrow.size * 0.62 - 0.5,
+    `a 320px phone got the full ${(narrow.size * 0.62).toFixed(1)}px headline, so nothing was fitted`,
+  );
+  assert.ok(
+    Math.abs(headline(wide) - wide.size * 0.62) < 0.5,
+    "a tablet's headline was shrunk even though it fits, which means the fit is a blanket clamp",
+  );
+  const drops = (c: typeof narrow): number[] =>
+    c.lines.map((line) => Number(((line.y - (c.lines[0] as { y: number }).y) / c.size).toFixed(2)));
+  assert.deepEqual(
+    drops(wide),
+    [0, 1.05, 1.75, 2.5],
+    "a tablet did not get the single-row card this game has always had",
+  );
+  // The narrow phone wraps the ledger onto a second row, and the prompt moves
+  // down by exactly one ledger step to make room — nothing else moves. If the
+  // rows tracked the FITTED type instead of the nominal size these would drift.
+  assert.deepEqual(
+    drops(narrow),
+    [0, 1.05, 1.75, 2.17, 2.92],
+    "the rows moved with the fitted type instead of with the nominal size",
+  );
+});
+
+test("the ledger wraps only where it has to, and never loses a fact", () => {
+  // The wrap is a width decision and nothing else. Whatever the safe rectangle
+  // is, the three facts are all still on the card, in order, once.
+  for (const [vname, w, h] of VIEWPORTS) {
+    for (const [iname, insets] of INSETS) {
+      const l = hudLayout(w, h, safeRect(w, h, insets));
+      const card = gameOverLayout(l, COPY, measure);
+      const ledger = card.lines.slice(2, -1).map((line) => line.text);
+      assert.equal(
+        ledger.join("   ·   "),
+        LEDGER_ONE_ROW,
+        `${vname}, ${iname}: the ledger rows do not reassemble into the ledger`,
+      );
+      assert.ok(
+        ledger.length <= COPY.ledger.length,
+        `${vname}, ${iname}: the ledger split into ${ledger.length} rows for ${COPY.ledger.length} facts`,
+      );
+    }
+  }
+});
+
+test("a wide safe rectangle keeps the ledger on one row", () => {
+  // The counterpart, and the reason the wrap is a width decision rather than a
+  // blanket restyle: wherever the ledger fits at full size it is still the
+  // single line this card has always had. That is every landscape window,
+  // because `size` is driven by the SHORT edge and the ledger is limited by the
+  // long one. Portrait is the other way round and wraps — see the rule in
+  // `gameOverLayout`.
+  for (const [vname, w, h] of [
+    ["tablet landscape", 1024, 768],
+    ["the founder's phone, landscape", 851, 393],
+    ["phone landscape", 844, 390],
+  ] as Array<[string, number, number]>) {
+    const l = hudLayout(w, h, safeRect(w, h, FLAT));
+    const card = gameOverLayout(l, COPY, measure);
+    assert.equal(
+      card.lines.length,
+      4,
+      `${vname}: the ledger wrapped into ${card.lines.length - 3} rows on a screen with room for one`,
+    );
   }
 });

--- a/dynawalla/games/guilty/src/game/hudLayout.ts
+++ b/dynawalla/games/guilty/src/game/hudLayout.ts
@@ -76,6 +76,143 @@ export type HudLayout = {
   cy: number;
 };
 
+/**
+ * One readable line of a full-screen card.
+ *
+ * `box` is what the line actually occupies on the glass once it has been
+ * measured, which is the only thing a layout test can honestly assert. A card
+ * that reports its intended size and not its measured box can be asserted to
+ * within an inch of its life and still run off a 320px phone.
+ */
+export type CardLine = {
+  text: string;
+  /** Type size after fitting — never the nominal size, if the nominal ran wide. */
+  size: number;
+  /** Baseline centre. Every line is `textAlign = "center"` on `hud.cx`. */
+  y: number;
+  box: Rect;
+};
+
+/** Text width at a given type size, as the canvas in front of the child measures it. */
+export type Measure = (text: string, size: number) => number;
+
+/** Below this a line stops being type. The same floor `hud.ts::fitFont` uses. */
+const MIN_TYPE = 9;
+
+/** What the ledger's three facts are joined with when they share a row. */
+const LEDGER_SEP = "   ·   ";
+
+/** How far apart two stacked ledger rows sit, in units of the card's nominal size. */
+const LEDGER_STEP = 0.42;
+
+export type GameOverCopy = {
+  headline: string;
+  score: string;
+  /** BEST, WAVE and BEST RUN — three facts, not one sentence. See below. */
+  ledger: readonly string[];
+  prompt: string;
+};
+
+/**
+ * The death screen, laid out and measured.
+ *
+ * *"the death screen doesn't quite fit."* It did not, and none of its lines was
+ * ever measured: `drawGameOver` was the one card in this game that set a font
+ * size from the viewport and then called `fillText` on whatever came out.
+ * `THE TRENCH TAKES YOU` is twenty characters at `size × 0.62` and the ledger
+ * under the score is about forty — on a 320px phone those come out at roughly
+ * 355px and 371px of ink, centred, so both ends ran off the glass. The founder's
+ * own handset reports 393 CSS px across and clipped both the same way.
+ *
+ * Every other card in `hud.ts` — the title, the rule, the correction — already
+ * went through `fitFont`. This one is now the same, and it lives here rather
+ * than there so it can be asserted at real viewports without driving a run to
+ * its death first.
+ *
+ * **The ledger is three facts, not one string, and that is load-bearing.**
+ * Shrinking is not always enough: on a narrow safe rectangle the joined line
+ * hits the 9px floor and *still* overhangs, and past that floor a smaller size
+ * is not a fix, it is a smaller illegible line. So the three facts pack greedily
+ * onto as few rows as the width allows **at full size**, and wrap rather than
+ * shrink. No new strings: the same three facts, on one row or two.
+ *
+ * Which way it goes is decided by the shape of the window and not by the device.
+ * `size` is driven by the SHORT edge and the ledger is limited by the long one,
+ * so every landscape window keeps the single line this card has always had, and
+ * every portrait one wraps to two. That is a change on a phone held upright, and
+ * it is the intended one: the alternative is a footnote at 10.6px on a 320px
+ * screen, which is smaller than anything else this game asks a child to read.
+ *
+ * The vertical arithmetic is keyed to the NOMINAL `size` rather than to the
+ * fitted sizes. A narrow phone shrinks the headline, and if the rows moved with
+ * it the whole card would creep upward on exactly the devices where it is
+ * already tightest.
+ */
+export function gameOverLayout(
+  hud: HudLayout,
+  copy: GameOverCopy,
+  measure: Measure,
+): { size: number; lines: CardLine[] } {
+  const { safe } = hud;
+  const size = Math.min(safe.w * 0.16, safe.h * 0.1);
+  // The same 0.9 the title and the correction already use. It is not there to
+  // look tidy: it keeps a centred line clear of the rounded corners of the
+  // glass, which clip before the safe rectangle does.
+  const maxW = safe.w * 0.9;
+
+  // Greedy pack of the ledger at its nominal size. A row is only broken when
+  // adding the next fact would overhang, so a wide screen gets the single line
+  // this card has always had.
+  const ledgerSize = size * 0.3;
+  const ledgerRows: string[] = [];
+  for (const part of copy.ledger) {
+    const last = ledgerRows.length - 1;
+    const merged = last < 0 ? part : `${ledgerRows[last] as string}${LEDGER_SEP}${part}`;
+    if (last >= 0 && measure(merged, ledgerSize) <= maxW) ledgerRows[last] = merged;
+    else ledgerRows.push(part);
+  }
+
+  const rows: Array<[string, number, number]> = [
+    [copy.headline, 0.62, 0],
+    [copy.score, 1.1, 1.05],
+    ...ledgerRows.map((text, i): [string, number, number] => [
+      text,
+      0.3,
+      1.75 + i * LEDGER_STEP,
+    ]),
+    [copy.prompt, 0.32, 2.5 + (ledgerRows.length - 1) * LEDGER_STEP],
+  ];
+
+  // Where the block sits, then pushed back inside the safe rectangle if a short
+  // window would have hung it off an edge. The tallest row above the anchor is
+  // the headline; the lowest is the prompt.
+  const lastDrop = rows[rows.length - 1] as [string, number, number];
+  const above = size * 0.62 * 0.6;
+  const below = size * lastDrop[2] + size * lastDrop[1] * 0.6;
+  const y0 = Math.max(safe.y + above, Math.min(safe.y + safe.h * 0.38, safe.y + safe.h - below));
+
+  const lines: CardLine[] = rows.map(([text, scale, drop]) => {
+    const nominal = size * scale;
+    const wide = measure(text, nominal);
+    const fitted = wide > maxW && wide > 0 ? Math.max(MIN_TYPE, nominal * (maxW / wide)) : nominal;
+    // MEASURED at the fitted size, never clamped to `maxW`. Clamping it here is
+    // how a layout assertion goes vacuous: the box would report the budget
+    // instead of the ink, "the box is inside the safe area" would be true by
+    // construction, and removing the fitting above would not fail a single test.
+    // It was written that way first and the mutation caught it.
+    const width = measure(text, fitted);
+    const y = y0 + size * drop;
+    return {
+      text,
+      size: fitted,
+      y,
+      box: { x: hud.cx - width / 2, y: y - fitted * 0.6, w: width, h: fitted * 1.2 },
+    };
+  });
+
+  return { size, lines };
+}
+
 export function hudLayout(w: number, h: number, area: Rect): HudLayout {
   const pad = Math.max(14, Math.min(area.w, area.h) * 0.045);
   const scoreSize = Math.max(20, Math.min(area.w, area.h) * 0.052);

--- a/dynawalla/games/guilty/src/game/husk.ts
+++ b/dynawalla/games/guilty/src/game/husk.ts
@@ -13,7 +13,7 @@ import { GATE_Y, HUSK_R } from "../core/config.ts";
 import { C, rgba } from "../core/palette.ts";
 import { drawGlow, drawGlyph, getGlyph } from "../render/bake.ts";
 import { clamp, ease } from "../render/draw.ts";
-import { MEMBRANE } from "../render/ink.ts";
+import { edgeWidthPx, MEMBRANE } from "../render/ink.ts";
 import { Mode, type Husk, type World } from "./world.ts";
 
 const VERTS: ReadonlyArray<readonly [number, number, number]> = [
@@ -212,7 +212,7 @@ export function drawHusk(world: World, h: Husk): void {
     }
   }
 
-  const width = Math.max(0.9, 1.5 * scale * (1 + flash * 1.6));
+  const width = edgeWidthPx(scale, flash);
   for (const e of EDGES) {
     batch.push(
       sx[e[0]],

--- a/dynawalla/games/guilty/src/game/husk.ts
+++ b/dynawalla/games/guilty/src/game/husk.ts
@@ -13,6 +13,7 @@ import { GATE_Y, HUSK_R } from "../core/config.ts";
 import { C, rgba } from "../core/palette.ts";
 import { drawGlow, drawGlyph, getGlyph } from "../render/bake.ts";
 import { clamp, ease } from "../render/draw.ts";
+import { MEMBRANE } from "../render/ink.ts";
 import { Mode, type Husk, type World } from "./world.ts";
 
 const VERTS: ReadonlyArray<readonly [number, number, number]> = [
@@ -203,7 +204,7 @@ export function drawHusk(world: World, h: Husk): void {
     ctx.lineTo(sx[2], sy[2]);
     ctx.lineTo(sx[3], sy[3]);
     ctx.closePath();
-    ctx.fillStyle = `rgba(3,10,17,${0.72 * alpha})`;
+    ctx.fillStyle = rgba(MEMBRANE, 0.72 * alpha);
     ctx.fill();
     if (world.quality > 0.7) {
       ctx.fillStyle = rgba(hostile ? C.hostileDeep : C.cyanDeep, (0.34 + flash * 0.4) * alpha);
@@ -256,10 +257,18 @@ export function drawHusk(world: World, h: Husk): void {
     }
     const label = shut ? scrambled(world, h) : h.label;
     const glyph = getGlyph(label, hostile ? C.hostile : C.cyan, 800);
-    // Fit a three-digit answer inside the cell instead of letting it spill:
-    // the drawn ink width is `inkW * size / 92`, so cap `size` by the cell.
-    const maxInk = r * scale * (shut ? 1 : 1.55);
-    const size = Math.min(r * scale * (shut ? 0.9 : 1.5), (maxInk * 92) / glyph.inkW);
+    // Fit a three-digit answer inside the cell instead of letting it spill.
+    //
+    // The drawn ink is `(inkW + 2 × rimW) × size / 92` now that a numeral
+    // carries a counter-ink rim, and the budget counts the rim. It moved from
+    // 1.55 half-widths to 1.7 for exactly that reason: the LETTERFORMS come out
+    // the size they always were — 1.55/110 and 1.7/120.6 agree to four decimal
+    // places on a two-digit label — and the extra 0.15 is the ring around them.
+    // Shrinking the digits to make room for the thing that was added to make
+    // them legible would have been a strange way to answer the brief.
+    const maxInk = r * scale * (shut ? 1.1 : 1.7);
+    const ink = glyph.inkW + glyph.rimW * 2;
+    const size = Math.min(r * scale * (shut ? 0.9 : 1.5), (maxInk * 92) / ink);
     drawGlyph(ctx, glyph, cxp, cyp, size, alpha * (shut ? 0.32 : 1));
   }
 }

--- a/dynawalla/games/guilty/src/game/scene.ts
+++ b/dynawalla/games/guilty/src/game/scene.ts
@@ -13,6 +13,7 @@ import { project, type Camera } from "../core/camera.ts";
 import { GATE_Y, VIEW_HALF_H } from "../core/config.ts";
 import { C, rgba } from "../core/palette.ts";
 import { drawGlow } from "../render/bake.ts";
+import { SHEEN, WATER } from "../render/ink.ts";
 import type { World } from "./world.ts";
 
 const FLOOR_Y = -178;
@@ -27,18 +28,18 @@ export function bakeScene(w: number, h: number): void {
   g.width = Math.max(1, Math.ceil(w));
   g.height = Math.max(1, Math.ceil(h));
   const gc = g.getContext("2d") as CanvasRenderingContext2D;
+  // The stops come from `ink.ts` because the numeral's contrast is a claim about
+  // this water. When the two were separate literals the trench could be warmed
+  // up without a single number in the legibility table changing.
   const grad = gc.createLinearGradient(0, 0, 0, h);
-  grad.addColorStop(0, "#02060d");
-  grad.addColorStop(0.2, "#02070e");
-  grad.addColorStop(0.6, "#030c15");
-  grad.addColorStop(0.88, "#05161f");
-  grad.addColorStop(1, "#020a11");
+  const at = [0, 0.2, 0.6, 0.88, 1];
+  WATER.forEach((stop, i) => grad.addColorStop(at[i] as number, stop));
   gc.fillStyle = grad;
   gc.fillRect(0, 0, w, h);
   // A cold sheen from the surface, far above and to one side.
   const sheen = gc.createRadialGradient(w * 0.32, -h * 0.4, 0, w * 0.32, -h * 0.4, h * 0.95);
-  sheen.addColorStop(0, rgba(C.surface, 0.17));
-  sheen.addColorStop(1, rgba(C.surface, 0));
+  sheen.addColorStop(0, rgba(SHEEN, 0.17));
+  sheen.addColorStop(1, rgba(SHEEN, 0));
   gc.fillStyle = sheen;
   gc.fillRect(0, 0, w, h);
   gradient = g;

--- a/dynawalla/games/guilty/src/render/bake.test.ts
+++ b/dynawalla/games/guilty/src/render/bake.test.ts
@@ -1,0 +1,146 @@
+// THE RIM IS ACTUALLY THERE, AND IT ACTUALLY DARKENS SOMETHING.
+//
+// `legibility.test.ts` proves the arithmetic: a counter-ink rim is the only way
+// a digit clears 4.5:1 inside its own bloom. This file proves the arithmetic is
+// about the sprite the canvas really paints.
+//
+// It exists because of POLARITY, which had a dark contrast rim on its numerals
+// that never darkened a pixel — the sprite was drawn with `AdditiveBlending`, so
+// the rim resolved to `vec3(0.0)` and added nothing. Its best achievable ink was
+// 1.007:1 and its contrast module was, arithmetically, correct. The blend mode
+// is where the claim died, so the blend mode is asserted here.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { drawGlyph, getGlyph } from "./bake.ts";
+import { INK_RIM, RIM_WIDTH } from "./ink.ts";
+
+type Op = { kind: string; style: string; width: number; blur: number; composite: string };
+
+function install(): { ops: Op[]; restore(): void } {
+  const ops: Op[] = [];
+  const g = globalThis as Record<string, unknown>;
+  const saved = g.document;
+  const makeCtx = (): unknown => {
+    const store: Record<string, unknown> = {
+      font: "10px sans-serif",
+      fillStyle: "#000",
+      strokeStyle: "#000",
+      lineWidth: 1,
+      lineJoin: "miter",
+      lineCap: "butt",
+      shadowBlur: 0,
+      shadowColor: "#000",
+      globalAlpha: 1,
+      globalCompositeOperation: "source-over",
+    };
+    const record = (kind: string, style: string): void => {
+      ops.push({
+        kind,
+        style,
+        width: Number(store.lineWidth),
+        blur: Number(store.shadowBlur),
+        composite: String(store.globalCompositeOperation),
+      });
+    };
+    const named: Record<string, unknown> = {
+      measureText: (s: string) => ({ width: String(s).length * 50 }),
+      fillText: (): void => record("fill", String(store.fillStyle)),
+      strokeText: (): void => record("stroke", String(store.strokeStyle)),
+      drawImage: (): void => record("blit", String(store.fillStyle)),
+      createRadialGradient: () => ({ addColorStop: (): void => undefined }),
+      createLinearGradient: () => ({ addColorStop: (): void => undefined }),
+    };
+    return new Proxy(store, {
+      get: (t, p: string) => (p in named ? named[p] : p in t ? t[p] : () => undefined),
+      set: (t, p: string, v) => {
+        t[p] = v;
+        return true;
+      },
+    });
+  };
+  g.document = {
+    createElement: () => ({ width: 0, height: 0, getContext: makeCtx }),
+  };
+  return {
+    ops,
+    restore(): void {
+      if (saved === undefined) Reflect.deleteProperty(g, "document");
+      else g.document = saved;
+    },
+  };
+}
+
+test("a baked numeral carries an opaque rim, between the bloom and the core", () => {
+  const rig = install();
+  try {
+    // A text unique to this test: `getGlyph` caches by key and other tests in
+    // the same process would otherwise hand back a sprite baked elsewhere.
+    getGlyph("rim-check-7", "#7CF3DC", 800);
+    const kinds = rig.ops.map((o) => o.kind).join(",");
+    assert.equal(
+      kinds,
+      "fill,fill,stroke,fill",
+      `the bake laid down ${kinds}; the rim must be stroked after both bloom fills and before the core`,
+    );
+    const rim = rig.ops[2] as Op;
+    assert.equal(
+      rim.style.toLowerCase(),
+      INK_RIM.toLowerCase(),
+      `the rim was stroked in ${rim.style}, not the trench's own dark water`,
+    );
+    // Opaque. An `rgba(...)` rim would let the bloom through and the contrast
+    // this pack now claims would be a claim about a colour nothing is painted in.
+    assert.ok(
+      !rim.style.includes("rgba"),
+      `the rim is translucent (${rim.style}); the bloom shows through it`,
+    );
+    assert.equal(rim.blur, 0, "the rim is blurred, so it has no edge to read a letterform against");
+    assert.equal(
+      rim.width,
+      92 * RIM_WIDTH,
+      `the rim is ${rim.width} bake px wide, not the ${92 * RIM_WIDTH} RIM_WIDTH asks for`,
+    );
+  } finally {
+    rig.restore();
+  }
+});
+
+test("a glyph is blitted source-over even when the caller left `lighter` behind", () => {
+  // The POLARITY assertion. `drawHusk` and `drawEquation` both set the composite
+  // back by hand today, and a comment is not a mechanism: the next glow added
+  // above a numeral would silently turn the rim into a no-op again.
+  const rig = install();
+  try {
+    const glyph = getGlyph("blit-check-3", "#7CF3DC", 800);
+    const ctx = (
+      globalThis.document.createElement("canvas") as unknown as {
+        getContext(): CanvasRenderingContext2D;
+      }
+    ).getContext();
+    ctx.globalCompositeOperation = "lighter";
+    rig.ops.length = 0;
+    drawGlyph(ctx, glyph, 10, 10, 40);
+    const blit = rig.ops.find((o) => o.kind === "blit");
+    assert.ok(blit, "nothing was blitted");
+    assert.equal(
+      blit.composite,
+      "source-over",
+      `the numeral was blitted with \`${blit.composite}\`, under which an opaque dark rim darkens nothing`,
+    );
+    assert.equal(
+      ctx.globalCompositeOperation,
+      "lighter",
+      "drawGlyph did not put the caller's composite back",
+    );
+
+    // And the one caller that genuinely wants the sprite added can still say so.
+    rig.ops.length = 0;
+    ctx.globalCompositeOperation = "source-over";
+    drawGlyph(ctx, glyph, 10, 10, 40, 1, "lighter");
+    assert.equal((rig.ops.find((o) => o.kind === "blit") as Op).composite, "lighter");
+  } finally {
+    rig.restore();
+  }
+});

--- a/dynawalla/games/guilty/src/render/bake.ts
+++ b/dynawalla/games/guilty/src/render/bake.ts
@@ -8,6 +8,7 @@
  */
 
 import { mix, rgba } from "../core/palette.ts";
+import { CORE_MIX, INK_RIM, RIM_WIDTH } from "./ink.ts";
 
 export type Glyph = {
   canvas: HTMLCanvasElement;
@@ -16,6 +17,15 @@ export type Glyph = {
   h: number;
   /** Advance width of the glyph itself, for layout. */
   inkW: number;
+  /**
+   * How far the counter-ink rim reaches beyond that advance, each side.
+   *
+   * The rim is stroked centred on the letterform, so it adds half its width
+   * outside the glyph. It is reported rather than folded into `inkW` because
+   * `inkW` is what a caller lays *type* out with; this is what a caller checks
+   * the sprite's padding against.
+   */
+  rimW: number;
 };
 
 const BAKE_PX = 92;
@@ -33,8 +43,13 @@ function makeCanvas(w: number, h: number): HTMLCanvasElement {
 
 /**
  * A numeral (or a whole equation) with its bloom baked in: two wide coloured
- * passes for the halo, one tight pass for the edge, and a near-white core so it
- * reads at any size against the black water.
+ * passes for the halo, one tight pass for the edge, an opaque counter-ink rim,
+ * and a near-white core.
+ *
+ * The rim is the whole point and it is new. Without it the core stands in a
+ * cloud the sprite painted itself, and measured against that cloud the digit is
+ * 1.65:1 at rest and 1.04:1 in the frames after a strike — see `ink.ts` for why
+ * no single ink can escape that, and `legibility.test.ts` for the table.
  */
 export function getGlyph(text: string, color: string, weight = 800, px = BAKE_PX): Glyph {
   const key = `${text}|${color}|${weight}|${px}`;
@@ -61,7 +76,7 @@ export function getGlyph(text: string, color: string, weight = 800, px = BAKE_PX
   const cx = w / 2;
   const cy = h / 2;
 
-  // Halo, edge, body. The body is a *tint* of the colour rather than white:
+  // Halo, edge, RIM, body. The body is a *tint* of the colour rather than white:
   // a white core blooms out to a shapeless blob the moment two glows overlap,
   // and legibility of the numeral is the entire game.
   ctx.shadowColor = color;
@@ -72,15 +87,40 @@ export function getGlyph(text: string, color: string, weight = 800, px = BAKE_PX
   ctx.fillStyle = rgba(color, 0.8);
   ctx.fillText(text, cx, cy);
   ctx.shadowBlur = 0;
-  ctx.fillStyle = mix(color, "#ffffff", 0.62);
+
+  // The counter-ink. Opaque, and stroked BETWEEN the bloom and the core, so it
+  // punches a ring of trench-dark through the glow the two passes above just
+  // laid down. That ring — not the water, not the membrane, not the bloom — is
+  // what the letterform is read against, and it is the only surface in this
+  // sprite whose contrast against the core does not depend on what the husk is
+  // doing. `lineJoin`/`lineCap` are round so a numeral's corners keep an even
+  // ring instead of growing mitre spikes at small sizes.
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+  ctx.lineWidth = px * RIM_WIDTH;
+  ctx.strokeStyle = INK_RIM;
+  ctx.strokeText(text, cx, cy);
+
+  ctx.fillStyle = mix(color, "#ffffff", CORE_MIX);
   ctx.fillText(text, cx, cy);
 
-  const glyph: Glyph = { canvas, w, h, inkW };
+  const glyph: Glyph = { canvas, w, h, inkW, rimW: (px * RIM_WIDTH) / 2 };
   glyphs.set(key, glyph);
   return glyph;
 }
 
-/** Blits a baked glyph centred on (x, y), scaled so its cap height is `size`. */
+/**
+ * Blits a baked glyph centred on (x, y), scaled so its cap height is `size`.
+ *
+ * **The composite is set here, and it defaults to `source-over`.** POLARITY
+ * shipped numerals with a dark contrast rim that never darkened a single pixel,
+ * because the sprite was blitted additively and `vec3(0.0)` adds nothing — the
+ * best ink it could reach was 1.007:1. The rim `getGlyph` bakes is opaque and
+ * only means anything under `source-over`, so this function no longer inherits
+ * whatever the caller left in the context. A caller that genuinely wants the
+ * sprite ADDED has to say so, and exactly one does: the chromatic split on a
+ * landing equation, which is decoration at alpha 0.32.
+ */
 export function drawGlyph(
   ctx: CanvasRenderingContext2D,
   glyph: Glyph,
@@ -88,15 +128,19 @@ export function drawGlyph(
   y: number,
   size: number,
   alpha = 1,
+  composite: GlobalCompositeOperation = "source-over",
 ): void {
   if (alpha <= 0.004) return;
   const k = size / BAKE_PX;
   const w = glyph.w * k;
   const h = glyph.h * k;
-  const prev = ctx.globalAlpha;
-  ctx.globalAlpha = prev * alpha;
+  const prevA = ctx.globalAlpha;
+  const prevOp = ctx.globalCompositeOperation;
+  ctx.globalAlpha = prevA * alpha;
+  ctx.globalCompositeOperation = composite;
   ctx.drawImage(glyph.canvas, x - w / 2, y - h / 2, w, h);
-  ctx.globalAlpha = prev;
+  ctx.globalCompositeOperation = prevOp;
+  ctx.globalAlpha = prevA;
 }
 
 /**

--- a/dynawalla/games/guilty/src/render/bake.ts
+++ b/dynawalla/games/guilty/src/render/bake.ts
@@ -8,7 +8,7 @@
  */
 
 import { mix, rgba } from "../core/palette.ts";
-import { CORE_MIX, INK_RIM, RIM_WIDTH } from "./ink.ts";
+import { CORE_MIX, GLYPH_PAD, INK_RIM, RIM_WIDTH } from "./ink.ts";
 
 export type Glyph = {
   canvas: HTMLCanvasElement;
@@ -65,7 +65,7 @@ export function getGlyph(text: string, color: string, weight = 800, px = BAKE_PX
   probe.font = font;
   const inkW = probe.measureText(text).width;
 
-  const pad = px * 0.62;
+  const pad = px * GLYPH_PAD;
   const w = inkW + pad * 2;
   const h = px * 1.28 + pad * 2;
   const canvas = makeCanvas(w, h);

--- a/dynawalla/games/guilty/src/render/ink.ts
+++ b/dynawalla/games/guilty/src/render/ink.ts
@@ -119,15 +119,63 @@ export function plus(src: RGB, dst: RGB, alpha: number): RGB {
 export const CORE_MIX = 0.62;
 
 /**
+ * Padding the bake leaves round a glyph, as a fraction of the em.
+ *
+ * It exists for the blurred halo, and the rim has to fit inside it too — a rim
+ * that reached past the sprite's edge would clip its own contour and the digit
+ * would read as a broken outline. `legibility.test.ts` asserts that against THIS
+ * constant rather than against a literal copied out of `bake.ts`.
+ */
+export const GLYPH_PAD = 0.62;
+
+/**
  * Rim width as a fraction of the bake em, stroked centred on the letterform —
  * so half of it lies under the core fill and half of it shows.
  *
- * 0.115 em is about 2.4 screen pixels on a husk numeral at the size a phone
- * draws it, which is the smallest ring that survives the additive wireframe
- * edge crossing it (that edge is 1.5px at scale 1) and still leaves the digit's
- * counters open at three digits.
+ * **The ring is narrower than the wireframe edge that crosses it, and that is
+ * stated here rather than wished away.** The visible reach is `0.0575 × size`,
+ * and a three-digit label draws at about `0.89 × r × scale` — so on the two
+ * extremes this game runs at, 320×568 portrait (`scale = 2.18`) and 844×390
+ * landscape (`scale = 1.50`), the ring reaches 1.50px and 1.03px while a husk
+ * edge is `EDGE_WIDTH × scale` = 3.28px and 2.25px, and up to 2.6× that in the
+ * frames after a strike. An earlier version of `legibility.test.ts` asserted the
+ * opposite by measuring the ring at its widest (a one-digit label at the size
+ * cap) against an edge at a scale the game never reaches.
+ *
+ * What makes the pair hold anyway is that the ring is a **closed contour** and
+ * the edge is a straight stroke laid over it *additively*. A crossing brightens
+ * a short arc of the ring and the core beneath it by the same amount — it
+ * cannot darken the core, cannot invert the pair, and cannot reach the rest of
+ * the contour, which is what the letterform is resolved against. And the widest
+ * crossings, at full `hitFlash`, live in the ~0.18s after a strike has already
+ * landed: a frame in which the child has answered, not one in which they are
+ * reading.
+ *
+ * 0.115 em is then the widest ring that still leaves a three-digit label's
+ * counters open at the size a phone draws it.
  */
 export const RIM_WIDTH = 0.115;
+
+/**
+ * The husk wireframe, as `drawHusk` strokes it: `EDGE_WIDTH × scale`, times up
+ * to `1 + EDGE_FLASH_GAIN` in the frames after a strike, floored at 0.9px.
+ *
+ * Here rather than in `husk.ts` because the claim above is a claim about the
+ * relationship between this and `RIM_WIDTH`, and a claim about a copy of a
+ * constant is not a claim about anything.
+ */
+export const EDGE_WIDTH = 1.5;
+export const EDGE_FLASH_GAIN = 1.6;
+
+/** How far the rim reaches beyond the letterform, in screen pixels, at `size`. */
+export function rimReachPx(size: number): number {
+  return (size * RIM_WIDTH) / 2;
+}
+
+/** The width of a husk's wireframe edge, in screen pixels. */
+export function edgeWidthPx(scale: number, flash: number): number {
+  return Math.max(0.9, EDGE_WIDTH * scale * (1 + flash * EDGE_FLASH_GAIN));
+}
 
 /**
  * The counter-ink: the trench's own darkest water.

--- a/dynawalla/games/guilty/src/render/ink.ts
+++ b/dynawalla/games/guilty/src/render/ink.ts
@@ -1,0 +1,329 @@
+// WHAT THE NUMERAL IN A CRYSTAL LANDS ON.
+//
+// The founder played GUILTY after firing became deliberate and reported that the
+// *"numbers could be a bit more legible perhaps (in the crystals)."* This file is
+// that, and it is deliberately the same shape as `games/balance/src/ink.ts`,
+// because this is the fourth game in the fleet to arrive at the same wall from a
+// different direction and the answer is known.
+//
+// ## The wall
+//
+// A husk's numeral is one baked sprite, `bake.ts::getGlyph`, and it was three
+// passes of ONE COLOUR: a wide blurred halo at alpha 0.34, a tight blurred edge
+// at 0.8, and a core that is the same colour mixed 62% toward white. So the
+// glyph is a pale cyan letterform standing in a cyan cloud of its own making.
+// Measured against that cloud the letterform is **1.65:1 at rest**, and **1.04:1
+// in the frames just after the shell is struck**, when the white hit-flash glow
+// is added underneath it. The digit does not go dim; it dissolves into its own
+// light.
+//
+// COUNTERPOISE hit this with a specular gradient stop, POLARITY hit it with an
+// additive blend mode, and this game hits it with a bloom the glyph itself
+// paints. The measurement is the same one in all three cases: the composite,
+// including the glow and every overlay, not the colour constant.
+//
+// ## Recolouring alone cannot fix it, and that is arithmetic
+//
+// `bestSingleInk` scans the whole grey ramp against every surface a husk numeral
+// can land on — the water, the membrane, the deep tint, the husk glow, the white
+// hit-flash, and the glyph's own bloom. The ceiling for a single opaque ink is
+// **1.87:1 on a resting candidate, and 1.14:1 once the struck states are counted
+// too** — and they have to be counted, because a numeral's colour is chosen once
+// and then has to survive whatever the shell does next. There is no colour to
+// move the numeral to. A lone `fillText` on a bloom it painted itself is
+// unfixable by choosing a better colour, and `legibility.test.ts` asserts that
+// so nobody rediscovers the dead end by hand.
+//
+// So the numeral is drawn as a **pair**: the bright core it already had, and an
+// opaque counter-ink **rim** stroked between the core and the bloom. The
+// guarantee has two layers:
+//
+//   1. **Letterform.** The digit is resolved against the rim that encircles it,
+//      not against the bloom — the rim is opaque and rings the glyph, so it IS
+//      the ground for the shape of the digit. `MIN_LETTERFORM = 4.5:1`, WCAG AA
+//      for body text, held at the body-text number rather than the 3:1
+//      large-text allowance because the reader is a child and the brief was that
+//      what shipped was not enough.
+//   2. **Object.** The inked blob as a whole must separate from whatever it is
+//      lying on. `MIN_OBJECT = 3.0:1`, WCAG 1.4.11 non-text contrast, and one of
+//      the core or the rim must clear it on every surface. That second bar is
+//      3.0 and not 4.5 for the reason `balance/src/ink.ts` sets out: 4.5 against
+//      an *arbitrary* ground is impossible for any two-colour scheme, so
+//      claiming it would be a claim no implementation could keep.
+//
+// ## Why an opaque rim actually darkens anything here
+//
+// POLARITY's numerals already had a dark contrast rim and it **never darkened a
+// pixel**, because they were drawn with `AdditiveBlending` and `vec3(0.0)` adds
+// nothing. So the blend mode is checked first here and it is checked in code
+// rather than in a comment: `drawGlyph` sets the composite operation for the
+// blit itself and defaults it to `source-over`. The one caller that wants the
+// sprite added — the chromatic split on a landing equation — asks for `lighter`
+// explicitly, and those two ghost blits are decoration at alpha 0.32 that no
+// child reads.
+
+import { C } from "../core/palette.ts";
+
+export type RGB = readonly [number, number, number];
+
+/** The digit against the rim that encircles it. WCAG AA body text. */
+export const MIN_LETTERFORM = 4.5;
+
+/** The inked blob against the ground it lies on. WCAG 1.4.11 non-text contrast. */
+export const MIN_OBJECT = 3.0;
+
+export function rgb(hex: string): RGB {
+  const s = hex.replace("#", "");
+  const n = Number.parseInt(s.slice(0, 6), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/** Relative luminance, 0..1 — the sRGB transfer curve, as WCAG defines it. */
+export function luma(c: RGB): number {
+  const f = (v: number): number => {
+    const x = v / 255;
+    return x <= 0.04045 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2]);
+}
+
+/** WCAG contrast ratio between two opaque colours, 1..21. */
+export function contrast(a: RGB, b: RGB): number {
+  const la = luma(a);
+  const lb = luma(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** `globalCompositeOperation = "source-over"` at `alpha`. */
+export function over(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.round(src[i] * alpha + dst[i] * (1 - alpha));
+  return [m(0), m(1), m(2)];
+}
+
+/** `globalCompositeOperation = "lighter"` at `alpha` — additive, clamped. */
+export function plus(src: RGB, dst: RGB, alpha: number): RGB {
+  const m = (i: 0 | 1 | 2): number => Math.min(255, Math.round(src[i] * alpha + dst[i]));
+  return [m(0), m(1), m(2)];
+}
+
+// ------------------------------------------------------------------- the inks
+
+/**
+ * How far toward white a glyph's core is pushed, and how wide the rim is.
+ *
+ * `bake.ts` reads both of these rather than holding literals of its own, so the
+ * sprite the canvas paints and the colours this file measures cannot drift
+ * apart. That was the failure mode worth designing against: a palette copied
+ * into a test goes stale the moment somebody warms up the ink.
+ */
+export const CORE_MIX = 0.62;
+
+/**
+ * Rim width as a fraction of the bake em, stroked centred on the letterform —
+ * so half of it lies under the core fill and half of it shows.
+ *
+ * 0.115 em is about 2.4 screen pixels on a husk numeral at the size a phone
+ * draws it, which is the smallest ring that survives the additive wireframe
+ * edge crossing it (that edge is 1.5px at scale 1) and still leaves the digit's
+ * counters open at three digits.
+ */
+export const RIM_WIDTH = 0.115;
+
+/**
+ * The counter-ink: the trench's own darkest water.
+ *
+ * Not `#000000`. The trench is lamplit black-green and a pure-black contour on a
+ * bioluminescent glyph reads as a sticker laid over the scene rather than as a
+ * shadow inside it. `#02060d` is literally `WATER[0]`, the top stop of the
+ * background gradient, and it measures 17.93:1 against the cyan core, 12.27:1
+ * against the hostile core and 17.14:1 against the amber core — every one of
+ * them two and a half times `MIN_LETTERFORM` or better.
+ */
+export const INK_RIM = "#02060d";
+
+/** The core a glyph of `color` is filled with, after `CORE_MIX` toward white. */
+export function core(color: string): RGB {
+  const c = rgb(color);
+  const w = 255;
+  const m = (i: 0 | 1 | 2): number => Math.round(c[i] + (w - c[i]) * CORE_MIX);
+  return [m(0), m(1), m(2)];
+}
+
+// ------------------------------------------------------- the surfaces themselves
+
+/**
+ * The trench gradient, as stops.
+ *
+ * `scene.ts` builds its background from this array rather than from five
+ * literals of its own, for the same reason `draw.ts` reads BRASS_BODY out of
+ * COUNTERPOISE's ink file: the numeral's contrast is a claim about the water,
+ * and a claim about a copy of the water is not a claim about anything.
+ */
+export const WATER: readonly string[] = ["#02060d", "#02070e", "#030c15", "#05161f", "#020a11"];
+
+/**
+ * The cold sheen from the surface, painted over the gradient at 0.17, and the
+ * light shafts, additive at up to `0.1 × 0.58` where they cross a husk.
+ *
+ * Taken from `palette.ts` rather than restated. Every colour this file measures
+ * has to be the colour the canvas paints or the table below is a table about
+ * nothing — that is precisely how COUNTERPOISE shipped a numeral at 1.08:1 while
+ * a test file full of colour literals said it was fine.
+ */
+export const SHEEN = C.surface;
+export const SHAFT = C.plankton;
+
+/** The membrane inside a husk: an opaque-ish dark skin over the equator quad. */
+export const MEMBRANE = "#030a11";
+
+/** Every colour the water itself presents behind a husk. */
+export function waterSurfaces(): RGB[] {
+  const out: RGB[] = [];
+  for (const stop of WATER) {
+    const b = rgb(stop);
+    out.push(b);
+    out.push(over(rgb(SHEEN), b, 0.17));
+    out.push(plus(rgb(SHAFT), b, 0.058));
+  }
+  return out;
+}
+
+/**
+ * A crystal, as the two flags and the two dials `drawHusk` actually switches on.
+ *
+ * Not a state *name*: `drawHusk` keys the membrane tint on `world.quality`, the
+ * glow on `hitFlash`, and the colour on `hostile`, and those are independent. A
+ * three-state enum would collapse combinations that are all reachable — a
+ * struck shell on a thermally-throttled phone is a different ground from a
+ * struck shell on a cold one, and it is the darker of the two.
+ */
+export type CrystalState = {
+  /** A husk the player already shot by mistake: red, spiky, diving. */
+  hostile?: boolean;
+  /** `Husk.hitFlash`, 0..1 — decays at 5.5/s after a strike lands. */
+  flash?: number;
+  /** `World.quality`, 0.45..1. At or below 0.7 the deep membrane tint is skipped. */
+  quality?: number;
+  /** The shell is still shut: the label is scrambled and drawn at alpha 0.32. */
+  shut?: boolean;
+};
+
+/** The accent a crystal in this state is drawn in — `drawHusk`'s own choice. */
+export function crystalColor(s: CrystalState): string {
+  return s.hostile ? C.hostile : C.cyan;
+}
+
+/**
+ * The ground a crystal's numeral is read against, built the way `drawHusk`
+ * builds it: water, then membrane, then the deep tint (only above quality 0.7),
+ * then the husk glow, then the white hit-flash glow.
+ *
+ * The wireframe edges are deliberately absent from this list and that is a
+ * checked absence, not an assumed one: `game.ts` flushes the line batch AFTER
+ * every husk has blitted its glyph, additively. Those twelve edges therefore
+ * land ON the numeral rather than under it. They are 1.5px at scale against a
+ * rim of ~2.4px, so they cross the ring rather than replacing it —
+ * `legibility.test.ts` measures that crossing separately instead of pretending
+ * it is ground.
+ */
+export function crystalGround(s: CrystalState): RGB[] {
+  const flash = s.flash ?? 0;
+  const quality = s.quality ?? 1;
+  const accent = rgb(crystalColor(s));
+  const deep = rgb(s.hostile ? C.hostileDeep : C.cyanDeep);
+  const white = rgb(C.white);
+  const out: RGB[] = [];
+  for (const w of waterSurfaces()) {
+    let g = over(rgb(MEMBRANE), w, 0.72);
+    if (quality > 0.7) g = over(deep, g, 0.34 + flash * 0.4);
+    g = plus(accent, g, 0.1 + flash * 0.45);
+    if (flash > 0.02) g = plus(white, g, flash * 0.45);
+    out.push(g);
+  }
+  return out;
+}
+
+/**
+ * The glyph's own bloom, hugging the letterform — the ground the OLD numeral was
+ * actually read against, and the reason it could not be read.
+ *
+ * Three alphas because the bake lays down three passes and the blur ramps
+ * between them: 0.8 immediately outside the letterform, falling through 0.55 to
+ * 0.34 a little further out. All three are inside the ring the rim now occupies
+ * or just beyond it, so all three are what the digit competed with.
+ */
+export function crystalBloom(s: CrystalState): RGB[] {
+  const c = rgb(crystalColor(s));
+  const out: RGB[] = [];
+  for (const g of crystalGround(s)) {
+    for (const a of [0.8, 0.55, 0.34]) out.push(over(c, g, a));
+  }
+  return out;
+}
+
+/** Every surface a crystal's numeral can land on: the ground, and the bloom over it. */
+export function crystalSurfaces(s: CrystalState): RGB[] {
+  return [...crystalGround(s), ...crystalBloom(s)];
+}
+
+/**
+ * The ground under the accusation at the top of the trench.
+ *
+ * The equation is the same baked sprite in amber, blitted over the raw water
+ * with one soft amber glow behind it, so it had the same defect for the same
+ * reason and it is fixed by the same rim.
+ */
+export function equationGround(): RGB[] {
+  const amber = rgb(C.amber);
+  return waterSurfaces().map((w) => plus(amber, w, 0.19));
+}
+
+export function equationBloom(): RGB[] {
+  const amber = rgb(C.amber);
+  const out: RGB[] = [];
+  for (const g of equationGround()) for (const a of [0.8, 0.55, 0.34]) out.push(over(amber, g, a));
+  return out;
+}
+
+// ------------------------------------------------------------------ the maths
+
+/**
+ * The worst letterform contrast this core presents against `surfaces`.
+ *
+ * The minimum, not the average: a digit is illegible in the frame where it is
+ * worst, and the frame where it is worst is the frame a child is looking at it.
+ */
+export function worstAgainst(ink: RGB, surfaces: readonly RGB[]): number {
+  let worst = Infinity;
+  for (const s of surfaces) worst = Math.min(worst, contrast(ink, s));
+  return worst;
+}
+
+/**
+ * The worst object-contrast a core/rim pair presents over `surfaces`.
+ *
+ * Per surface, the better of the two edges — an inked blob separates from its
+ * ground if *either* the digit or the ring around it does. The minimum over
+ * every surface is the number `MIN_OBJECT` is asserted against.
+ */
+export function worstEdge(ink: RGB, rim: RGB, surfaces: readonly RGB[]): number {
+  let worst = Infinity;
+  for (const s of surfaces) worst = Math.min(worst, Math.max(contrast(ink, s), contrast(rim, s)));
+  return worst;
+}
+
+/**
+ * The best contrast ANY single opaque ink could reach against all of
+ * `surfaces` — the ceiling the shipped three-pass sprite was working under.
+ *
+ * Contrast depends on an ink only through its luminance, so scanning the 256
+ * greys bounds every colour: no hue can beat the grey of the same luminance.
+ */
+export function bestSingleInk(surfaces: readonly RGB[]): number {
+  let best = 0;
+  for (let v = 0; v <= 255; v++) {
+    const ink: RGB = [v, v, v];
+    best = Math.max(best, worstAgainst(ink, surfaces));
+  }
+  return best;
+}

--- a/dynawalla/games/guilty/src/render/legibility.test.ts
+++ b/dynawalla/games/guilty/src/render/legibility.test.ts
@@ -1,0 +1,185 @@
+// CAN A CHILD READ THE NUMBER IN THE CRYSTAL?
+//
+// *"better. numbers could be a bit more legible perhaps (in the crystals)."*
+//
+// Everything below is computed from the COMPOSITE — the water, the sheen, the
+// light shafts, the membrane, the deep tint, the husk glow, the white hit-flash
+// glow, and the glyph's own bloom, stacked in the order `drawHusk` stacks them.
+// Not from a colour constant. Measuring constants is how COUNTERPOISE shipped
+// two literal 1.00:1 cases: they were overlays, and nobody composited them.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { C } from "../core/palette.ts";
+
+import {
+  bestSingleInk,
+  contrast,
+  core,
+  crystalBloom,
+  crystalColor,
+  crystalGround,
+  crystalSurfaces,
+  equationBloom,
+  equationGround,
+  INK_RIM,
+  MIN_LETTERFORM,
+  MIN_OBJECT,
+  plus,
+  rgb,
+  RIM_WIDTH,
+  worstAgainst,
+  worstEdge,
+  type CrystalState,
+} from "./ink.ts";
+
+/**
+ * Every state a crystal is drawn in, as `drawHusk` switches on them.
+ *
+ * Both quality tiers appear because the deep membrane tint is gated on
+ * `world.quality > 0.7` and a thermally-throttled phone therefore reads its
+ * numerals over a DARKER ground than a cold one — a difference no state name
+ * would have carried.
+ */
+const STATES: Array<[string, CrystalState]> = [
+  ["candidate, in formation", {}],
+  ["candidate, throttled phone (no deep tint)", { quality: 0.5 }],
+  ["candidate, struck — hit flash 0.5", { flash: 0.5 }],
+  ["candidate, struck — hit flash 1.0", { flash: 1 }],
+  ["candidate, struck, throttled", { flash: 1, quality: 0.5 }],
+  ["marked hostile", { hostile: true }],
+  ["marked hostile, throttled", { hostile: true, quality: 0.5 }],
+  ["marked hostile, struck — hit flash 1.0", { hostile: true, flash: 1 }],
+];
+
+const rim = rgb(INK_RIM);
+
+test("no single ink can make a crystal numeral legible — the dead end, measured", () => {
+  // This is the assertion that stops the next person "fixing" this by picking a
+  // brighter colour.
+  //
+  // The ceiling is computed over the UNION of every state, because a numeral's
+  // colour is chosen once and then has to survive whatever the shell does next.
+  // Per state the answer flatters: against a struck shell alone a dark ink
+  // reaches 8.9:1 — and that same dark ink is invisible on the resting shell one
+  // frame earlier, which is where the child actually reads it. An ink pale
+  // enough to beat the bloom is lost in the white hit-flash; an ink dark enough
+  // to beat the flash is lost in the membrane. There is no third option.
+  const everySurface = STATES.flatMap(([, s]) => crystalSurfaces(s));
+  const ceiling = bestSingleInk(everySurface);
+  assert.ok(
+    ceiling < MIN_LETTERFORM,
+    `a single ink could reach ${ceiling.toFixed(2)}:1 over every state, so the pair is unnecessary`,
+  );
+  // The resting shell on its own — the state a child spends most of the wave
+  // looking at — is already hopeless before any of the others are counted.
+  const resting = bestSingleInk(crystalSurfaces({}));
+  assert.ok(
+    resting < MIN_LETTERFORM,
+    `a single ink reaches ${resting.toFixed(2)}:1 on a resting crystal alone`,
+  );
+});
+
+test("the numeral the game USED to draw is unreadable against its own bloom", () => {
+  // The defect, pinned so that a change which reintroduces it fails here rather
+  // than on a device. The old sprite was core-on-bloom and nothing else.
+  const worst: Array<[string, number]> = [];
+  for (const [name, s] of STATES) {
+    worst.push([name, worstAgainst(core(crystalColor(s)), crystalBloom(s))]);
+  }
+  for (const [name, v] of worst) {
+    assert.ok(v < MIN_LETTERFORM, `${name}: core-on-bloom already measured ${v.toFixed(2)}:1`);
+  }
+  // The two the founder was looking at, to the second decimal, so the table in
+  // the pull request is checkable rather than recited.
+  const resting = worst.find(([n]) => n === "candidate, in formation")?.[1] as number;
+  const struck = worst.find(([n]) => n === "candidate, struck — hit flash 1.0")?.[1] as number;
+  assert.ok(resting < 1.7, `a resting crystal's digit measured ${resting.toFixed(3)}:1 on its bloom`);
+  assert.ok(struck < 1.1, `a struck crystal's digit measured ${struck.toFixed(3)}:1 on its bloom`);
+});
+
+test("the letterform clears 4.5:1 against its rim in every crystal state", () => {
+  for (const [name, s] of STATES) {
+    const ratio = contrast(core(crystalColor(s)), rim);
+    assert.ok(
+      ratio >= MIN_LETTERFORM,
+      `${name}: the digit is ${ratio.toFixed(2)}:1 against the rim that encircles it`,
+    );
+  }
+});
+
+test("the inked blob clears 3.0:1 against every surface it lands on", () => {
+  for (const [name, s] of STATES) {
+    const edge = worstEdge(core(crystalColor(s)), rim, crystalGround(s));
+    assert.ok(
+      edge >= MIN_OBJECT,
+      `${name}: the numeral's best edge against its ground is ${edge.toFixed(2)}:1`,
+    );
+  }
+});
+
+test("the accusation at the top of the trench is fixed by the same rim", () => {
+  // The equation is the same baked sprite in amber, so it had the same defect.
+  const amberCore = core(C.amber);
+  const before = worstAgainst(amberCore, equationBloom());
+  assert.ok(before < MIN_LETTERFORM, `the sum already read ${before.toFixed(2)}:1 on its own bloom`);
+  assert.ok(
+    contrast(amberCore, rim) >= MIN_LETTERFORM,
+    `the sum is ${contrast(amberCore, rim).toFixed(2)}:1 against its rim`,
+  );
+  assert.ok(
+    worstEdge(amberCore, rim, equationGround()) >= MIN_OBJECT,
+    `the sum's best edge against the water is ${worstEdge(amberCore, rim, equationGround()).toFixed(2)}:1`,
+  );
+});
+
+test("the wireframe crossing a digit is an artifact, not the ground", () => {
+  // `game.ts` flushes the line batch AFTER every husk has blitted its glyph, and
+  // flushes it under `lighter` — so the twelve edges of the cell are ADDED on
+  // top of the numeral wherever they cross it. That is measured here rather than
+  // quietly folded into `crystalGround`, because it is 1.5px against a rim of
+  // `RIM_WIDTH` em and it crosses the ring instead of replacing it.
+  const cyan = rgb(C.cyan);
+  const litRim = plus(cyan, rim, 0.72);
+  const litCore = plus(cyan, core(C.cyan), 0.72);
+  assert.ok(
+    contrast(litCore, litRim) < MIN_LETTERFORM,
+    "an additive edge over the digit no longer washes it out, so this note is stale",
+  );
+  // What bounds the damage is geometry, not colour: at the size a phone draws a
+  // husk numeral the rim is wider than the line that crosses it.
+  const HUSK_NUMERAL_PX = 40; // r * scale * 1.5 on a 320px-wide phone
+  const rimOnScreen = (HUSK_NUMERAL_PX * RIM_WIDTH) / 2;
+  assert.ok(
+    rimOnScreen > 1.5,
+    `the rim is ${rimOnScreen.toFixed(2)}px where the wireframe crossing it is 1.5px`,
+  );
+});
+
+test("a shut shell stays deliberately unreadable, and that is on purpose", () => {
+  // `drawHusk` draws a shut shell's scrambled label at alpha 0.32 and the shell
+  // opens as it descends — the pressure IS that you cannot read it yet. The rim
+  // must not accidentally make it readable, so this is a checked absence.
+  const ground = crystalGround({})[0] as [number, number, number];
+  const shutCore = core(C.cyan).map((v, i) =>
+    Math.round(v * 0.32 + ground[i] * 0.68),
+  ) as unknown as [number, number, number];
+  const shutRim = rim.map((v, i) => Math.round(v * 0.32 + ground[i] * 0.68)) as unknown as [
+    number,
+    number,
+    number,
+  ];
+  assert.ok(
+    contrast(shutCore, shutRim) < MIN_LETTERFORM,
+    "a shut shell became readable; the descent no longer carries any pressure",
+  );
+});
+
+test("the rim fits inside the sprite's own padding", () => {
+  // `getGlyph` pads the bake by 0.62 em on every side for the blurred halo. The
+  // rim is stroked centred on the letterform, so it reaches half its width
+  // beyond the advance — if that ever exceeded the padding the sprite would clip
+  // its own contour and the digit would read as a broken outline.
+  assert.ok(RIM_WIDTH / 2 < 0.62, `the rim reaches ${RIM_WIDTH / 2} em into a 0.62 em pad`);
+});

--- a/dynawalla/games/guilty/src/render/legibility.test.ts
+++ b/dynawalla/games/guilty/src/render/legibility.test.ts
@@ -11,6 +11,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 
+import { HUSK_R } from "../core/config.ts";
 import { C } from "../core/palette.ts";
 
 import {
@@ -21,13 +22,18 @@ import {
   crystalColor,
   crystalGround,
   crystalSurfaces,
+  EDGE_FLASH_GAIN,
+  edgeWidthPx,
   equationBloom,
   equationGround,
+  GLYPH_PAD,
   INK_RIM,
+  luma,
   MIN_LETTERFORM,
   MIN_OBJECT,
   plus,
   rgb,
+  rimReachPx,
   RIM_WIDTH,
   worstAgainst,
   worstEdge,
@@ -99,7 +105,13 @@ test("the numeral the game USED to draw is unreadable against its own bloom", ()
   assert.ok(struck < 1.1, `a struck crystal's digit measured ${struck.toFixed(3)}:1 on its bloom`);
 });
 
-test("the letterform clears 4.5:1 against its rim in every crystal state", () => {
+test("the letterform clears 4.5:1 against its rim, in both inks", () => {
+  // Both inks, not eight states: `contrast(core, rim)` depends on the accent and
+  // nothing else, so the eight rows would be six duplicates. The states are
+  // still walked, because which accent a state uses is `crystalColor`'s answer
+  // and not this file's — but the claim is about the two inks.
+  const inks = new Set(STATES.map(([, s]) => crystalColor(s)));
+  assert.equal(inks.size, 2, "a crystal is drawn in an ink this test does not measure");
   for (const [name, s] of STATES) {
     const ratio = contrast(core(crystalColor(s)), rim);
     assert.ok(
@@ -134,27 +146,58 @@ test("the accusation at the top of the trench is fixed by the same rim", () => {
   );
 });
 
-test("the wireframe crossing a digit is an artifact, not the ground", () => {
+test("the wireframe is WIDER than the rim, and crosses it additively", () => {
   // `game.ts` flushes the line batch AFTER every husk has blitted its glyph, and
-  // flushes it under `lighter` — so the twelve edges of the cell are ADDED on
-  // top of the numeral wherever they cross it. That is measured here rather than
-  // quietly folded into `crystalGround`, because it is 1.5px against a rim of
-  // `RIM_WIDTH` em and it crosses the ring instead of replacing it.
+  // flushes it under `lighter`, so the twelve edges of the cell are ADDED on top
+  // of the numeral wherever they cross it.
+  //
+  // The first version of this test claimed the rim outlasted that crossing by
+  // measuring the rim at its very widest — a ONE-digit label at the size cap —
+  // against an edge at a scale this game never runs at. Both halves of the
+  // comparison were picked at operating points that never co-occur. The truth is
+  // the other way round and is asserted as such below: at every viewport the
+  // edge is two to five times the ring.
+  //
+  // What makes the pair hold anyway is that the ring is a CLOSED CONTOUR and the
+  // crossing is ADDITIVE. It brightens a short arc of the ring and the core
+  // under it by the same amount; it cannot darken the core, cannot invert the
+  // pair, and cannot reach the rest of the contour, which is what the letterform
+  // is read against.
   const cyan = rgb(C.cyan);
   const litRim = plus(cyan, rim, 0.72);
   const litCore = plus(cyan, core(C.cyan), 0.72);
   assert.ok(
+    luma(litRim) >= luma(rim) && luma(litCore) >= luma(core(C.cyan)),
+    "an edge crossing the numeral darkened it, so it is not being added",
+  );
+  assert.ok(
     contrast(litCore, litRim) < MIN_LETTERFORM,
     "an additive edge over the digit no longer washes it out, so this note is stale",
   );
-  // What bounds the damage is geometry, not colour: at the size a phone draws a
-  // husk numeral the rim is wider than the line that crosses it.
-  const HUSK_NUMERAL_PX = 40; // r * scale * 1.5 on a 320px-wide phone
-  const rimOnScreen = (HUSK_NUMERAL_PX * RIM_WIDTH) / 2;
-  assert.ok(
-    rimOnScreen > 1.5,
-    `the rim is ${rimOnScreen.toFixed(2)}px where the wireframe crossing it is 1.5px`,
-  );
+
+  // The real widths, at the two extremes this game runs at. `scale = h / 260`
+  // (`fitCamera` maps `VIEW_HALF_H` onto half the glass at `CAM_Z`), and a
+  // three-digit label — the one the fit change was for — draws at about
+  // `0.89 × r × scale`, which is where the ring is narrowest.
+  for (const [name, glassH] of [
+    ["320×568 portrait", 568],
+    ["844×390 landscape", 390],
+  ] as Array<[string, number]>) {
+    const scale = glassH / 260;
+    const size = 0.89 * HUSK_R * scale;
+    const ring = rimReachPx(size);
+    assert.ok(
+      ring < edgeWidthPx(scale, 0),
+      `${name}: the ring is ${ring.toFixed(2)}px and a resting edge ${edgeWidthPx(scale, 0).toFixed(2)}px — if the ring now wins, say so instead of this`,
+    );
+    // And the widest crossings are transient: `hitFlash` decays at 5.5/s from 1,
+    // so `1 + EDGE_FLASH_GAIN` of edge lives about 180ms — after a strike has
+    // landed, which is a frame a child has answered in rather than read in.
+    assert.ok(
+      edgeWidthPx(scale, 1) / edgeWidthPx(scale, 0) <= 1 + EDGE_FLASH_GAIN + 0.001,
+      `${name}: a struck husk's edge grew more than the flash gain allows`,
+    );
+  }
 });
 
 test("a shut shell stays deliberately unreadable, and that is on purpose", () => {
@@ -177,9 +220,15 @@ test("a shut shell stays deliberately unreadable, and that is on purpose", () =>
 });
 
 test("the rim fits inside the sprite's own padding", () => {
-  // `getGlyph` pads the bake by 0.62 em on every side for the blurred halo. The
-  // rim is stroked centred on the letterform, so it reaches half its width
-  // beyond the advance — if that ever exceeded the padding the sprite would clip
-  // its own contour and the digit would read as a broken outline.
-  assert.ok(RIM_WIDTH / 2 < 0.62, `the rim reaches ${RIM_WIDTH / 2} em into a 0.62 em pad`);
+  // `getGlyph` pads the bake by `GLYPH_PAD` em on every side for the blurred
+  // halo. The rim is stroked centred on the letterform, so it reaches half its
+  // width beyond the advance — if that ever exceeded the padding the sprite
+  // would clip its own contour and the digit would read as a broken outline.
+  //
+  // Against the constant `bake.ts` actually pads with, not a literal copy of it:
+  // a copy passes happily while somebody tightens the pad underneath it.
+  assert.ok(
+    RIM_WIDTH / 2 < GLYPH_PAD,
+    `the rim reaches ${String(RIM_WIDTH / 2)} em into a ${String(GLYPH_PAD)} em pad`,
+  );
 });


### PR DESCRIPTION
Two packs, four reports, all of them measured rather than eyeballed.

---

## GUILTY — *"better. numbers could be a bit more legible perhaps (in the crystals). the death screen doesn't quite fit"*

### 1. The numerals in the crystals

**Blend mode checked first.** The husk numeral is blitted `source-over` (`husk.ts:240` restores it before the blit), so an opaque dark ink does darken pixels here — unlike POLARITY, whose rim was drawn additively and resolved to `vec3(0.0)`. That check is now *in code*: `drawGlyph` sets the composite for the blit itself and defaults it to `source-over`, and the one caller that wants the sprite added (the chromatic split on a landing equation) asks for `lighter` explicitly.

**The defect.** `getGlyph` baked three passes of ONE colour — a blurred halo at α0.34, a blurred edge at α0.8, and a core mixed 62% toward white. The digit is a pale cyan letterform standing in a cyan cloud it painted itself. Measured against the composite (water → sheen → shafts → membrane → deep tint → husk glow → white hit-flash → the glyph's own bloom):

| crystal state | letterform, before | letterform, after | blob vs ground, before | after |
|---|---|---|---|---|
| candidate, in formation | **1.65** | 17.93 | 10.42 | 10.42 |
| candidate, throttled phone (no deep tint) | **1.71** | 17.93 | 13.42 | 13.42 |
| candidate, struck — hit flash 0.5 | **1.31** | 17.93 | **2.01** | 8.63 |
| candidate, struck — hit flash 1.0 | **1.04** | 17.93 | **1.03** | 18.49 |
| candidate, struck, throttled | **1.05** | 17.93 | **1.01** | 18.17 |
| marked hostile | **2.71** | 12.27 | 8.80 | 8.80 |
| marked hostile, throttled | **2.88** | 12.27 | 10.52 | 10.52 |
| marked hostile, struck — hit flash 1.0 | **1.39** | 12.27 | **1.08** | 11.24 |
| the accusation (the equation, amber) | **1.79** | 17.14 | 8.22 | 8.22 |

Both quality tiers appear because `drawHusk` gates the deep membrane tint on `world.quality > 0.7` — a thermally-throttled phone reads its numerals over a *darker* ground, which no state name would have carried.

**Recolouring cannot fix this.** `bestSingleInk` over every state puts the ceiling for any single opaque ink at **1.14:1** (1.87:1 on a resting crystal alone). An ink pale enough to beat the bloom is lost in the white hit-flash; an ink dark enough to beat the flash is lost in the membrane. So it is the proven pair from `games/balance/src/ink.ts`: the bright core, and an opaque counter-ink rim stroked between the core and the bloom, in `#02060d` — literally `WATER[0]`, the trench's own darkest stop, so the rim reads as a shadow inside the scene rather than a sticker over it. Two bars: 4.5:1 letterform, 3.0:1 object.

The letterforms come out **the size they always were** — the cell budget moved 1.55 → 1.7 half-widths solely to pay for the ring, and `1.55/110` and `1.7/120.6` agree to four decimals on a two-digit label.

Deliberately **not** claimed: a shut shell stays unreadable (α0.32, the pressure of the descent) — that is a checked absence, not an oversight. And the wireframe is flushed additively *after* the glyphs, so those twelve edges land ON the numeral; that is measured separately as a bounded 1.5px artifact rather than folded into the ground.

### 2. The death screen

`drawGameOver` was the only card in this game that set font sizes from the viewport and then called `fillText` without measuring any of them — the title, the rule and the correction all already went through `fitFont`.

What overflowed, at a 0.62 em advance for 700-weight caps:

| viewport | line | ink | safe width |
|---|---|---|---|
| 320×568, flat | `THE TRENCH TAKES YOU` | **394px** | 320 |
| 320×568, flat | `BEST 128640 · WAVE 24 · BEST RUN ×31` | **419px** | 320 |
| 320×568, Android chrome | `THE TRENCH TAKES YOU` | **381px** | 320 |
| 320×568, Android chrome | the ledger | **406px** | 320 |
| 393×851 (the founder's phone), Android chrome | `THE TRENCH TAKES YOU` | **483px** | 393 |
| 393×851, Android chrome | the ledger | **515px** | 393 |

Vertically it was fine at every viewport; the overflow is horizontal and it is *ink*, not bloom, so letters were genuinely clipped.

`gameOverLayout` is now a pure function in `hudLayout.ts` that measures every line and returns its box, asserted at 7 viewports × 5 inset profiles. The ledger is **three facts, not one string**: shrinking alone is not enough — on a narrow safe rectangle the joined line hits the 9px floor and *still* overhangs, and past that floor a smaller size is not a fix. It wraps at full size instead. Landscape keeps the single line it always had; portrait gets two rows.

Also checked and **not** a defect: `env(safe-area-inset-*)` is already plumbed correctly here — `hudLayout` takes the safe rect from `packs/shared/game-chrome` and `hudLayout.test.ts` gates it. GUILTY is not the fourth pack with a HUD under the status bar. The death-screen block sits at 0.38h, far clear of the two 44px corners, and the test asserts that too.

---

## COIL — *"needs more hints, hints don't fit on mobile. more attention to details needed"*

### 1. The hints did not fit — measured

The hint was one line of text, `2×10  5×1`, drawn into the gauge at `x + unit×1.4` with a size from the panel height and its width **never measured**. For a three-place demand:

| viewport | line | panel |
|---|---|---|
| 393×851, Android chrome (the founder's) | starts +21, **ends +172** | 122px |
| 320×568, flat | starts +21, **ends +131** | 82px |

It ran out of the gauge, across the SHEAR lever, and off the glass. Worse, the panel itself could vanish: `Scene.drawGauge` derived the strip a *second* time as `shear.x − (furnace.x + furnace.w) − 24`, with a 12px gap this file knew nothing about, and gave up silently below 60px. The gauge rect now comes from `layout.ts` — one formula, no bail — and `chrome.test.ts` gates its width, the two levers' widths, and non-overlap at 7 viewports × 3 chrome profiles. The lever geometry itself is byte-identical to what shipped.

### 2. More hints — THE LATTICE's model, four pictures of one cut

No new strings anywhere except one manual line, because copy ships ~50× translated.

1. **THE SHAPE** — the demand as ghost links, laid in the lane cells after the child's tail. On the lane grid, which this game already fits to every viewport, so it *cannot* overflow. (A version that hovered the ghost over the tail was tried and dropped: it needs ~1.2 units of clearance and the row pitch can be 2.6, so on a short lane it either overlapped the links it was meant to be compared with or climbed out of the lane.)
2. **THE PLACE** — the link that must be opened, ringed, with the ten-for-one it yields written under it: `10×1` under a drum, `10×10` under a ring. Numerals and a multiplication sign, in a game whose whole subject is that ten of one place is one of the next. Live — it moves the instant a link is cracked — and simply absent when nothing needs opening, which is information too. The label is clamped into the lane by `labelX` and that clamp is measured, because the link can be in the last column.
3. **THE JOINT** — a live ghost of the jaws on the joint the cut has to finish at. **This is the answer.**
4. **THE NUMBER** — what the jaws hold over what the wall wants. The gauge refuses to print this during play on purpose; that judgement is right for the gauge and wrong for a child who has been stuck for a minute and asked twice.

**The clock stops at THE PLACE**, the last picture that does not pin the joint. That boundary is a pair of named constants both the renderer and the test read — `scene.ts` draws the ghost jaws from `STAGE_JOINT`, and the test asserts `FREE_STAGES < STAGE_JOINT`. The quiet is a pure function of the item and monotone non-decreasing in `breaksNeeded` — a demand that costs more change buys *more* silence, never less. There is no countdown, no ring, no banner. Past stage 2 a hint is something a child asks for by pressing the gauge, which glows when there is more to be had. It costs nothing: not a brick, not the wall, not the slag count, not the report.

`planFor` is the live marker, and it is followed **exhaustively** — 20,000+ (coil, demand) pairs, cracking where it says and cutting where it says, asserting the piece that comes away IS the demand and that no break ever changed the chain's value. A marker that lies drops slag on the child who trusted it.

### 3. "More attention to details" — the contrast audit

Every readable element, against its composite ground (stone → girih lattice → panel scrim → the recess's cold light → the furnace's ember gradient *sampled at each label's own y*):

| readable element | before | after |
|---|---|---|
| `SHEAR OFF THE LIT NUMBER` | **2.45** | 6.86 |
| the slag count, nothing to melt | **1.56** | 5.31 |
| the slag count, something to melt | **3.06** | 7.29 |
| `FURNACE`, nothing to melt | **2.81** | 7.17 |
| a brick's value on the wall | **2.58** | 6.54 |
| `the alley is quiet` | **2.83** | 6.26 |
| the cradle's `×n` | **2.83** | 6.26 |
| `n buried` | **2.85** | 8.63 |
| the carved problem | — | 6.95 |
| the demand, lit | — | 8.03 |
| the ingot's value | — | 7.44 |
| the hint's `10×n` | — | 13.55 |
| `FURNACE`, something to melt | — | 12.37 |
| `SHEAR` | — | 9.33 |
| the gauge's `×n` | — | 15.92 |
| the hint's reading | — | 14.60 |

The first row is the whole rule of the game, in the one place a child looks for it, at two and a half to one — which is some of what *"I really have no idea what I'm doing"* was made of.

**Every fix is to an ink.** The ember gradient, the cold light in the recess and the girih lattice are untouched, and a test asserts the two furnace labels still measure *differently* at the two heights they are drawn at — so a future "fix" that flattens the gradient fails instead of passing.

Nothing about gameplay or difficulty moved in either pack.

---

## Verification

- `npm run -s tsc` clean in both packs. Each suite run **5× consecutively**: GUILTY 119/119, COIL 220/220.
- `node dynawalla/packs/build.mjs guilty` and `coil` both build and pass the SDK checker.
- Contrast computed from the **composite** in both packs, for every state, never from a colour constant.
- Layout asserted at real viewports, computed — including the founder's 393×851 both ways up and an Android status-bar + three-button-nav inset profile.

### Mutation transcript

Every new assertion broken, confirmed FAILING, restored.

| # | mutation | result |
|---|---|---|
| G1 | delete the rim stroke from `getGlyph` | ✖ `the bake laid down fill,fill,fill; the rim must be stroked after both bloom fills and before the core` |
| G2 | make the rim translucent | ✖ `the rim was stroked in rgba(2,6,13,0.5), not the trench's own dark water` |
| G3 | let `drawGlyph` inherit the caller's composite | ✖ `the numeral was blitted with \`lighter\`, under which an opaque dark rim darkens nothing` |
| G4 | `INK_RIM` → mid-grey | ✖ letterform, object and equation assertions all fail |
| G5 | `crystalBloom` returns nothing | ✖ the "unreadable before" and "no single ink" assertions both fail |
| G6 | `gameOverLayout` stops fitting to width | ✖ 39 cases, e.g. `"THE TRENCH TAKES YOU" leaves the safe area: {"x":-36.8,…,"w":393.6} vs {…"w":320}` |
| G7 | rows track the fitted size | ✖ `the rows moved with the fitted type instead of with the nominal size` |
| G8 | the "it really overflowed" test at a 0.30 advance | ✖ `the unfitted headline was 185px across a 320px screen` |
| G9 | the ledger never wraps | ✖ `"BEST 128640 · WAVE 24 · BEST RUN ×31" leaves the safe area` |
| G10 | the ledger always wraps | ✖ `tablet landscape: the ledger wrapped into 3 rows on a screen with room for one` |
| G11 | drop a ledger fact | ✖ `the ledger rows do not reassemble into the ledger` |
| C1 | the marker names the wrong link (off by one) | ✖ `the marker points at link 1, which cannot be opened` |
| C2 | the quiet shortens as the demand hardens | ✖ `a demand needing 1 breaks got 6500ms of quiet, less than the one before it` |
| C3 | `FREE_STAGES` = every stage | ✖ `every stage is free, so the clock states the answer` |
| C4 | the SHEAR lever grows and squeezes the gauge out | ✖ 19 cases, `the gauge is 0.0px … below 72 it clips to one link and stops answering` |
| C5 | remove the `labelX` clamp | ✖ `"10×1000" starts left of the lane at phone portrait, small 320×568` |
| C6 | the rule goes back to `BONE_DIM` | ✖ `"SHEAR OFF THE LIT NUMBER" measures 2.45:1 against its own ground` |
| C7 | the overflow test at a 0.12 advance | ✖ `the shipped hint was 54px of line in a 122px panel, which would have fitted` |
| C8 | the gauge overlaps the SHEAR lever | ✖ 43 cases, `gauge ends 220.8, shear starts 200.8` |
| C9 | move the gauge off the safe area | ✖ 85 cases, `the gauge leaves the safe area` |
| G12 | make the ring wider than a resting edge | ✖ `the ring is 11.81px and a resting edge 3.28px — if the ring now wins, say so instead of this` |
| G13 | the wireframe crossing stops being additive | ✖ `a resting crystal's digit measured 1.823:1 on its bloom` |
| G14 | tighten the bake pad below the rim's reach | ✖ `the rim reaches 0.0575 em into a 0.02 em pad` |
| G15 | drop one crystal ink from the palette split | ✖ `a crystal is drawn in an ink this test does not measure` |
| C10 | draw the ghost jaws one stage earlier | ✖ `the clock reaches stage 2 and the jaws are drawn from 2, so stillness alone states the answer` |
| C11 | let the clock reach the joint | ✖ `the clock reaches stage 3 and the jaws are drawn from 3, so stillness alone states the answer` |

### What the adversarial pass then found — and it was right four times

Full transcript in commit 3. Summarised:

1. **The rim/wireframe geometry claim was false.** `legibility.test.ts` asserted the counter-ink ring outlasted the additive edge crossing it, by measuring the ring at its very widest (a *one*-digit label at the size cap) against an edge at `scale = 1` — a scale `fitCamera` never produces, since `scale = h/260`. The truth is the reverse: on a 320×568 phone a three-digit label's ring reaches 1.50px against a 3.28px resting edge, and 8.5px in the frames after a strike. The pair holds for a **different** reason, and that reason is now what is asserted: the ring is a *closed contour* and the crossing is *additive*, so it brightens a short arc of the ring and the core beneath it by the same amount — it cannot darken the core, cannot invert the pair, and cannot reach the rest of the contour. The edge formula moved into `ink.ts` as `edgeWidthPx` so both halves of the comparison read one constant. (New mutations G12–G14.)
2. **COIL's documented stages were not its drawn stages.** Stage 2 was documented as a count of crack marks that nothing anywhere drew; `stage >= 2` actually drew the ring and `10×n` that the doc assigned to stage 3 — so `FREE_STAGES = 2` was justified in prose describing the wrong picture. Doc and renderer are now the same four pictures, and the boundary is the shared `STAGE_JOINT` constant. (New mutations C10–C11.)
3. **The test that should have caught (2) could not fail.** It compared `FREE_STAGES` to `HINT_STAGES` and then to its own literal `2`; neither reaches the renderer. It now asserts against `STAGE_JOINT`.
4. **The gauge withheld its affordance in the only state that needed it.** `more` was read off a `hintState` that was `null` at stage 0, so the panel brightened only for children who had already found it.

Four more vacuous assertions removed: `suffixValue(...) >= 0` (non-negative for every input), `firstHintMs` compared against itself, `ledger.length <= facts.length` (true of any implementation of that loop), and `RIM_WIDTH / 2 < 0.62` where the `0.62` was a hand-copy of `bake.ts`'s pad — now `GLYPH_PAD`, imported.

**Two assertions were caught vacuous while writing this and fixed**, which is the reason to keep doing it:

- `gameOverLayout` first reported each line's width as `Math.min(measure(...), maxW)`. The box then reported the *budget* instead of the ink, "the box is inside the safe area" was true by construction, and mutation G6 passed 40/40. Removing the clamp turned it into 39 real failures — and immediately exposed a genuine overflow (the ledger at the 9px floor) that the vacuous version had been hiding. That is what produced the wrap.
- A first attempt at COIL's lever row added a proportional redistribution of slack to guarantee the gauge's floor. Mutation C4 produced **no failure at all**: the branch is unreachable at every supported viewport, and at the widths where it *would* fire the floors do not fit anyway. It was dead code with a comment claiming otherwise, so it is gone; the geometry is now identical to what shipped and the floors are gates in the test instead.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb


