### PR TITLE
dynawalla/soundscape: the groove EVOLVES — a tethered walk, steered by right and wrong, and a level turns the key over

### DIFF
--- a/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
+++ b/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
@@ -1,6 +1,6 @@
 # The Dynawalla soundscape
 
-**Status:** live. `packs/shared/game-soundscape/` exists and has 79 tests; the host
+**Status:** live. `packs/shared/game-soundscape/` exists and has 80 tests; the host
 now chooses a soundscape and publishes it, so THE STEELYARD plays through it in
 production. **Stage 2 is now partly built** — games talk back through
 `session.transition`, and correctness shapes the beat (see *The groove evolves*,
@@ -232,6 +232,30 @@ instant of the bar and an instant means the same thing in the new mode. So a
 shape a child earned in one key is still their shape in the next one, and a
 rotation lands as a modulation of the groove that was playing rather than as one
 groove stopping and a different one starting.
+
+### Two regressions caught in review, and what they teach
+
+Both were introduced by this change and both were found by *measuring* rather
+than by listening, which is the only reason they were found at all.
+
+**The arp started playing every bar line.** `grooveMatrix` forces beat 0 to a
+certainty — correct, it is not negotiable — so a backing layer that reads the
+matrix straight lands on the bar line in every bar. The hand-written arp landed
+there in one bar of three; the new one landed there in **300 of 300**, stacking a
+pluck onto the bass and onto the chart's own downbeat. A thicker transient and a
+stiffer bar line: the exact opposite of the point. `bandBeats` now takes
+`downbeat: "keep" | "leave"` — the bass keeps it because the bass *is* the
+pulse, the arp leaves it — and a layer that stands back has beat 0's share of
+the budget handed back to it so it does not silently lose a note a bar. The
+lesson: **a certainty in the matrix is a certainty for every layer that reads
+it**, and only one layer should own the bar line.
+
+**A burst of right answers landed on one instant.** `step()` snapshotted the
+field once and spent every queued gesture against it, so four right answers in
+one phrase all scored the same instant highest and piled four steps onto it —
+saturating one beat instead of opening four, against the plural in the brief and
+against this file's own prose. The field is now re-read between gestures, capped
+at `MAX_PENDING`. Measured: one right answer lifts 1.8 instants, four lift 3.0.
 
 ### Seams left for FORGE and TREBUCHET
 

--- a/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
+++ b/dynawalla/docs/SOUNDSCAPE_DESIGN_2026-07.md
@@ -1,10 +1,16 @@
 # The Dynawalla soundscape
 
-**Status:** live. `packs/shared/game-soundscape/` exists and has 57 tests; the host
+**Status:** live. `packs/shared/game-soundscape/` exists and has 79 tests; the host
 now chooses a soundscape and publishes it, so THE STEELYARD plays through it in
-production. Stage 2 (games talking back) and stage 3 (the host's ambient bed) are
-still proposed. The founder's answers to the open questions are recorded at the
-end.
+production. **Stage 2 is now partly built** — games talk back through
+`session.transition`, and correctness shapes the beat (see *The groove evolves*,
+below). Stage 3 (the host's ambient bed) is still proposed. The founder's answers
+to the open questions are recorded at the end.
+
+**The groove is no longer a fixed shape.** `evolve.ts` is an eighth file: a slow,
+tethered random walk over the bar that right and wrong answers steer in opposite
+directions, and a rotation policy that lets a LEVEL TRANSITION turn the app's key
+over. See *The groove evolves* below.
 
 **Second pack wired, and the module grew a seventh file.** PULSE reads the same
 soundscape as TIME rather than as pitch. The founder's brief for it — *"some
@@ -23,6 +29,221 @@ the whole app and `packSettings` puts it on the wire, where `game-host`'s
 `publish()` was already forwarding it. THE STEELYARD's own ship gate — "nothing
 in the shipped pack turns the soundscape on" — still passes unchanged, because
 turning it on was the host's job and never the pack's.
+
+---
+
+## The groove evolves
+
+> *"steelyard sounds is cool, pulse is somewhat improved but it needs to
+> gradually evolve more — the main rhythm is static. I think slowly things
+> should evolve and change stochastically. so there is sort of the seed but it
+> should be able to go almost anywhere. Maybe being 'right' or 'wrong' should
+> affect the beat in different ways. We don't have to just use random but random
+> is a good friend. Add and remove different beats with probability .. slowly
+> evolve."*
+
+### What was static, and where
+
+`grooveMatrix` is a pure function of the soundscape and the stage, so PULSE got
+the same probabilities back every phrase for as long as a run lasted. The *draw*
+differed; the bias never did.
+
+But that was **not** what the founder was hearing, and finding that out changed
+the shape of this work. PULSE's chart already varies a great deal per phrase —
+it draws a backbeat figure from a vocabulary and re-leans the matrix around it —
+so making the chart drift moved a measured strike-rate profile by **0.0005**,
+which nobody could hear. What was static was the layer *underneath* it:
+
+| | before |
+|---|---|
+| Bass | `BASS_PATTERNS[tier]`, a written array of beat offsets. **One** pattern, every bar, forever |
+| Shaker | every offbeat eighth, every bar, forever |
+| Arp | `(k + bar) % 3` — a three-bar loop |
+
+That is "the main rhythm", and it was a loop in the literal sense.
+
+### The mechanism
+
+One number per instant of the bar, `-1..1`, on top of what the mode said. Every
+`BARS_PER_MUTATION` bars — one phrase — a few of them move. `groove.ts` gained a
+`GrooveBias` seam and `leanAffinity`, which moves an instant *inside the range
+the mode already allowed it*, so `+1` is exactly `1` and `-1` is exactly
+`MIN_AFFINITY` and a drifted bar passes every invariant an undrifted one does
+with no clamp anywhere.
+
+Three constraints keep it a groove rather than noise, and each was tested by
+being removed:
+
+1. **The metre is not in the walk.** The drift moves the mode's affinity and
+   never the metric weight, so a downbeat outranks a halfway point outranks a
+   sixteenth however far the walk has got. The downbeat is not in the walk at
+   all.
+2. **The walk is tethered.** Every mutation decays every lean toward zero
+   (`SEED_HALF_LIFE_BARS = 144`). Mean-reverting, not Brownian: *"there is sort
+   of the seed but it should be able to go almost anywhere"* is exactly an
+   Ornstein–Uhlenbeck shape.
+3. **Nothing lands mid-phrase.** `matrix()` is frozen between `advance()` calls,
+   always. Gestures are queued; a bar a child is two beats into cannot become a
+   different bar.
+
+**The rate is measured in BARS**, not seconds — the module still has no tempo
+primitive and this did not add one. A caller with a bar clock passes bars; a
+caller without one does not need a groove.
+
+### Right and wrong, which are not a reward and a punishment
+
+The fleet's rule is that a miss is the teaching moment. So the asymmetry is the
+founder's own pair of verbs pointed in two **directions**, not at two volumes:
+
+* **Right → the groove ADDS.** `agree()` lights up an instant it had been
+  ignoring — the one with the most room the metre would most like to hear. The
+  bar keeps finding new places to sit. **It adds no notes**: the density budget
+  is renormalised, so the expected count is bit-identical to what the stage
+  asked for and what changed is *where*. Rewarding correctness with a busier bar
+  would be rewarding it with a harder game.
+* **Wrong → the groove REMOVES.** `makeRoom()` takes the busiest *decoration*
+  down — never a beat, never the downbeat — and leaves a little space for a few
+  phrases. A band backing off while somebody thinks. It expires on the clock
+  (`ROOM_HALF_LIFE_BARS = 8`) and not on merit, so nothing has to be earned
+  back, and it is capped at `MAX_OPENNESS` = a quarter of the budget so playing
+  badly on purpose never buys an easier game.
+
+Nothing here is red, nothing is a buzzer, and nothing anywhere changes the
+tempo.
+
+**Two designs were built, measured and rejected first**, both trying to make
+"right" mean *the groove commits to what it is already doing*:
+
+| attempt | result |
+|---|---|
+| push the instant with the highest `p` | beat an untouched groove **38 of 60** — a coin. `leanAffinity` is range-relative, so the strongest instant is by definition the one with the least room to get stronger |
+| draw the target in proportion to `p³` | **30 of 60**. Six pushes landed on five different instants and cancelled |
+
+Adding an instant has headroom by construction, and it is what the brief
+actually asked for.
+
+### The numbers
+
+Measured with the shipped code. `evolve.test.ts` holds each of these.
+
+**The drift, over time** (60 seeds, eighths grid, mean change in a slot's strike
+probability against the seed matrix):
+
+| | 1 phrase | 1 min | 2 min | 9 min | 35 min | 70 min |
+|---|---|---|---|---|---|---|
+| mean \|Δp\| | 0.012 | 0.036 | 0.050 | 0.068 | 0.073 | 0.065 |
+
+It goes somewhere over minutes and then stays inside its spread for an hour —
+the worst-affected instant in a bar moves its strike rate by **0.20 to 0.34**,
+which is an instant that fired in 40% of bars now firing in 10% or 70%.
+
+**The tether.** Twenty right answers push the groove's total lean to **+4.11**;
+two hundred bars later, with the child answering nothing at all, **15%** of it is
+left. With the decay deleted, 37% survives — which is how that assertion is
+known not to be vacuous.
+
+**Right against wrong** (200 seeds per grid, 8 answers, net instants opened
+minus closed):
+
+| grid | right | wrong | right > wrong |
+|---|---|---|---|
+| quarters `[1]` | +1.54 | −1.31 | 196/200 |
+| eighths `[1,2]` | +2.12 | −2.63 | 200/200 |
+| triplets `[1,3]` | +2.35 | −3.66 | 200/200 |
+| everything `[1,2,3,4]` | +1.61 | −3.93 | 200/200 |
+
+Right leaves the expected note count **bit-identical** in 60 of 60 seeds on
+every grid.
+
+**Reproducible.** The same seed replays a whole session exactly; 60 of 60 pairs
+of different seeds diverge.
+
+**In PULSE**, where the founder heard the problem:
+
+| | before | after |
+|---|---|---|
+| Distinct bass bars in 64 | **1** | **36.1** |
+| Strike-rate shift between two 200-bar windows, walk **off** | — | 0.031 |
+| Strike-rate shift between two 200-bar windows, walk **on** | — | **0.053** |
+
+The A/B is the same generator with `advance` stubbed out, so the only difference
+is the walk. The window has to be 200 bars: sampling noise in a strike rate falls
+as `1/√N` and the drift does not, so at 96 bars the two are the same size and the
+first version of that test asserted a ratio of 1.16 and failed honestly.
+
+### The rotation policy — when the mode changes
+
+> *"When does the musical mode get changed in general? Maybe it should switch
+> more often like when a level transitions on some games."*
+
+**Answer: a level transition rotates the key, and the gesture already existed.**
+
+The old rule — *never rotate while a pack owns it* — was protecting a reason, not
+a possession. Its reason, verbatim from the code, is that *"a key change
+underneath a child — mid-question, because a timer went off — is the jarring
+thing"*. A level transition is not that. It is the pack itself saying **the child
+finished something and nothing is in front of them**, which is precisely the
+condition a doorway satisfies and a moment the game already marks as "put that
+down". So the rule is restated rather than broken:
+
+> **The key never moves unbidden.** Doorways are the host's boundary;
+> transitions are the pack's.
+
+**The gesture is `session.transition`** — the SDK's existing, ungated session
+method, whose documented contract is already exactly the guarantee needed: *"a
+transition is a thing the child finished, never a thing that beat them."* No new
+wire field, no new capability, no new method, no `SDK_VERSION` bump. A pack that
+has no levels sends nothing and rotates at doorways alone, which is the policy
+that was already there — **nothing in the fleet is obliged to change.**
+
+The policy, in full:
+
+| | |
+|---|---|
+| A fresh key every launch | unchanged |
+| A new key every `ROTATION_MS` (8 min), landing at a doorway | unchanged — **kept as the backstop**, see below |
+| The key never moves under a playing child on a clock alone | unchanged, and still an invariant of the module rather than a caller's convention |
+| **A `transition` may turn the key over, after `TRANSITION_ROTATION_MS` (90 s)** | **new** |
+| Never the same mode twice running | unchanged, and now enforced on the transition path too |
+
+**Why the transition floor is shorter than the doorway floor, and not longer.** A
+doorway happens whenever a child browses, so it needs a long floor or the bazaar
+changes key at every threshold. A transition is a real boundary a game declared,
+which is a stronger signal, so it justifies a change on less accumulated time.
+Ninety seconds is long enough that a key gets to be a key even in a game whose
+levels are forty seconds long.
+
+**The eight-minute timer stays, and becomes the backstop rather than the driver.**
+Most of the fleet has no levels and sends no transitions; without it a
+forty-minute session at THE STEELYARD would sit in one key for forty minutes,
+which is the "stale and repetitive" the brief opened with.
+
+**Two guards, both tested.** A transition from a pack that is *not* on the stage
+is ignored — React renders the incoming pack before it runs the outgoing one's
+cleanup, so a message from a torn-down session is a real frame and honouring it
+would rotate the key under whoever is actually playing. And a clock that has gone
+backwards rotates once and settles, exactly as the doorway path does; refusing
+would disable level rotation until the wall clock caught up.
+
+**What a rotation sounds like in a pack.** `Groove.retune` queues the new key to
+the next phrase boundary and **keeps the drift across it**, exactly as
+`Melody.retune` keeps the walker's degree — a lean is a statement about an
+instant of the bar and an instant means the same thing in the new mode. So a
+shape a child earned in one key is still their shape in the next one, and a
+rotation lands as a modulation of the groove that was playing rather than as one
+groove stopping and a different one starting.
+
+### Seams left for FORGE and TREBUCHET
+
+* `Groove` is optional. A game with no bar clock does not need one; `Melody` is
+  unchanged and every existing gesture behaves exactly as before.
+* `grooveMatrix(scape, spec)` with no bias is byte-for-byte the pure function it
+  always was, so nothing that reads it today changes.
+* `bandBeats` in PULSE is the pattern for "a backing layer drawn from the groove
+  rather than written down", and it is thirteen lines.
+* The walk's universe is the **union** of every grid it is shown, so two layers
+  in one game may ask about different subdivisions in either order without
+  changing the music.
 
 ---
 
@@ -484,8 +705,10 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
      *nothing*, which is the path a host too old to know about soundscapes
      already takes, and it means "keep your own sounds".
 
-   Still open: `levelComplete` moving the key, which needs the stage 2 feedback
-   channel.
+   **`levelComplete` moving the key: ANSWERED and built.** See *The rotation
+   policy* above. It did not need a new feedback channel after all —
+   `session.transition` already carried exactly the right meaning, and the
+   host's `onTransition` handler was already wired for the day pass.
 3. **Chord progressions.** The brief asks for "many chord progressions to choose
    from" and beatlounge has ~994 generated ones. This design deliberately has
    **none** — a moving progression means the melody's home note moves, and a
@@ -512,6 +735,10 @@ Cost: about six oscillators and two filters, permanently. Cheaper than one of th
 | Mode + root + seed + tension, and the wire guard | `packs/shared/game-soundscape/soundscape.ts` |
 | The walker, the gestures, the voices | `packs/shared/game-soundscape/melody.ts` |
 | The bar as a probability matrix, by mode and density | `packs/shared/game-soundscape/groove.ts` |
+| The walk that makes it evolve, and right/wrong | `packs/shared/game-soundscape/evolve.ts` |
+| The level-transition rotation | `dynawalla-app/src/app/soundscape.ts` → `rotateOnTransition` |
+| Where a pack's level turnover is heard | `dynawalla-app/src/packs/Stage.tsx` → `onTransition` |
+| PULSE's band, drawn from the groove | `games/pulse/src/game/chart.ts` → `bandBeats` |
 | The soundscape the app is in | `packs/shared/game-soundscape/host.ts` |
 | The wire field | `packs/sdk/src/protocol.ts` → `Settings.soundscape` |
 | Where it is published to a pack | `packs/shared/game-host/index.ts` → `publish()` |

--- a/dynawalla/dynawalla-app/src/app/soundscape.test.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.test.ts
@@ -21,10 +21,12 @@ import assert from "node:assert/strict"
 
 import {
   ROTATION_MS,
+  TRANSITION_ROTATION_MS,
   claimSoundscape,
   epochSeed,
   releaseSoundscape,
   resetAppSoundscape,
+  rotateOnTransition,
   soundscapeForPack,
   type Soundscape,
 } from "./soundscape.ts"
@@ -306,4 +308,127 @@ test("sound off publishes no key at all", () => {
   const settings = packSettings(input({ sound: false }, chosen))
   assert.equal(settings.sound, false)
   assert.equal("soundscape" in settings, false, "a silent tablet was still told a key")
+})
+
+// ── A level turning over ─────────────────────────────────────────────────────
+//
+// The founder: *"When does the musical mode get changed in general? Maybe it
+// should switch more often like when a level transitions on some games."*
+//
+// The rule these tests hold is not "the pack owns the key" — it is "the key
+// never moves unbidden". A transition is a pack SAYING the child finished
+// something and nothing is in front of them, so it is bidden. Every assertion
+// below is about the difference between those two readings.
+
+/** A pack that mounted and is still on the stage. */
+function playing(at: number, packId: string): Soundscape {
+  const scape = soundscapeForPack(packId, at)
+  claimSoundscape(packId)
+  return scape
+}
+
+test("a level turning over changes the key, once the floor has passed", () => {
+  resetAppSoundscape(101)
+  const opening = playing(T0, "dw.pulse")
+
+  // Too soon: a game whose levels are twenty seconds long must not change the
+  // key of the whole bazaar three times a minute.
+  assert.deepEqual(rotateOnTransition("dw.pulse", T0 + 20_000), opening)
+  assert.deepEqual(rotateOnTransition("dw.pulse", T0 + TRANSITION_ROTATION_MS - 1), opening)
+
+  // And then it does, WITHOUT the child having left the game — which is the
+  // whole of what changed, and what rule 3 used to forbid.
+  const next = rotateOnTransition("dw.pulse", T0 + TRANSITION_ROTATION_MS)
+  assert.notDeepEqual(next, opening, "a level turned over and the key did not")
+
+  // The floor restarts from the change, not from the mount.
+  assert.deepEqual(rotateOnTransition("dw.pulse", T0 + TRANSITION_ROTATION_MS + 5_000), next)
+})
+
+test("a level never lands on the mode the app is already in", () => {
+  /**
+   * Launch seed 171 is the fixture and it is not arbitrary: it is the smallest
+   * launch seed whose epoch-0 and epoch-1 draws BOTH land on `maqam.hijazkar`.
+   * A uniform draw from 38 modes repeats about one time in 38, so an
+   * unremarkable seed asserts nothing here — the first version of this used one
+   * and passed with the re-draw deleted. On this seed the guard is the only
+   * thing standing between a child and the same mode twice running, and the
+   * re-draw takes it to `thaat.kalyan`.
+   */
+  resetAppSoundscape(171)
+  const opening = playing(T0, "dw.pulse")
+  assert.equal(opening.modeId, "maqam.hijazkar", "the fixture seed has drifted; re-derive it")
+  const next = rotateOnTransition("dw.pulse", T0 + TRANSITION_ROTATION_MS)
+  assert.notEqual(next.modeId, opening.modeId, "a level handed back the mode the app was in")
+  assert.equal(next.modeId, "thaat.kalyan")
+})
+
+test("a transition is the ONLY thing that moves a key under a playing child", () => {
+  // The invariant rule 3 was protecting, restated for the world where rule 4
+  // exists: everything that is not a transition still has no effect at all,
+  // however long the clock has run. `packSettings` re-runs on every settings
+  // change — a parent moving the text size slider — and that path leads here.
+  resetAppSoundscape(102)
+  const held = playing(T0, "dw.pulse")
+  for (const t of [T0 + 1, T0 + ROTATION_MS, T0 + 10 * ROTATION_MS, T0 + 400 * ROTATION_MS]) {
+    assert.deepEqual(soundscapeForPack("dw.pulse", t), held, `the key moved by itself at ${t - T0}ms`)
+  }
+})
+
+test("a transition from a pack that is not on the stage is ignored", () => {
+  // A message from a torn-down session. Honouring it would rotate the key under
+  // whoever IS playing — rule 3's exact failure, arriving through the door
+  // built to respect it. React renders the incoming pack before it runs the
+  // outgoing one's cleanup, so this overlap is a real frame and not a theory.
+  resetAppSoundscape(103)
+  playing(T0, "dw.pulse")
+  const live = playing(T0 + 5_000, "dw.lattice")
+  const after = rotateOnTransition("dw.pulse", T0 + 10 * TRANSITION_ROTATION_MS)
+  assert.deepEqual(after, live, "a dead session changed the key under a live one")
+  assert.deepEqual(soundscapeForPack("dw.lattice", T0 + 10 * TRANSITION_ROTATION_MS), live)
+})
+
+test("the eight-minute floor still holds for a pack with no levels", () => {
+  // Most of the fleet has no levels and sends no transitions. Without the
+  // doorway clock a forty-minute session at THE STEELYARD would sit in one key
+  // for forty minutes, which is the "stale and repetitive" the brief opened
+  // with. The two floors are a backstop and a driver, not a duplicate.
+  resetAppSoundscape(104)
+  const first = visit(T0, "dw.counterweight")
+  assert.deepEqual(visit(T0 + ROTATION_MS - 1, "dw.counterweight"), first)
+  assert.notDeepEqual(visit(T0 + ROTATION_MS, "dw.counterweight"), first)
+})
+
+test("a transition floor is shorter than a doorway floor, and that is the design", () => {
+  // A doorway happens whenever a child browses, so it needs a long floor. A
+  // transition is a boundary a game declared, which is a stronger signal, so it
+  // justifies a change on less accumulated time. If these ever invert, the
+  // reasoning in `soundscape.ts` has come apart.
+  assert.ok(
+    TRANSITION_ROTATION_MS < ROTATION_MS,
+    `a level (${TRANSITION_ROTATION_MS}ms) needs longer than a doorway (${ROTATION_MS}ms)`,
+  )
+  assert.ok(TRANSITION_ROTATION_MS >= 60_000, "a key that lasts under a minute is not a key")
+})
+
+test("a key rotated by a level reaches the pack, through the same wire", () => {
+  // The rotation is worth nothing if it stops at the host. This asserts on what
+  // a pack would actually receive, through the validator the pack side runs.
+  resetAppSoundscape(105)
+  playing(T0, "dw.pulse")
+  const rotated = rotateOnTransition("dw.pulse", T0 + TRANSITION_ROTATION_MS)
+  assert.deepEqual(parseSoundscape(packSettings(input({}, rotated)).soundscape), rotated)
+})
+
+test("a backwards clock rotates once on a level and then settles", () => {
+  // Same behaviour as the doorway path, and the same reasoning: refusing to
+  // rotate on a negative elapsed would look safer and would disable level
+  // rotation until the wall clock caught up — which, for a device corrected by
+  // ninety days, is the rest of the year.
+  resetAppSoundscape(106)
+  const held = playing(T0, "dw.pulse")
+  const back = T0 - 90 * 24 * 60 * 60 * 1000
+  const after = rotateOnTransition("dw.pulse", back)
+  assert.notDeepEqual(after, held, "a corrected clock pinned the key")
+  assert.deepEqual(rotateOnTransition("dw.pulse", back + 1000), after, "it kept rotating after settling")
 })

--- a/dynawalla/dynawalla-app/src/app/soundscape.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.ts
@@ -275,6 +275,30 @@ export function rotateOnTransition(packId: string, now: number): Soundscape {
 }
 
 /**
+ * `rotateOnTransition` at the wall clock.
+ *
+ * The clock read lives HERE and not at the call site, and that is a rule the
+ * React compiler enforces rather than a preference. `Stage`'s transition
+ * handler is defined inside the `useMemo` that builds the pack's services, and
+ * the compiler cannot see that `createServices` only stores the callback — so a
+ * `Date.now()` in it is a clock read the compiler must assume happens during
+ * render, and `react-hooks/purity` rejects it, correctly, because a render that
+ * reads a clock is a render that is not idempotent. `useEffectEvent` is the
+ * slot React provides for a function defined in render and called only outside
+ * it, but it may not be passed to anything, which is exactly what this callback
+ * has to be.
+ *
+ * So the component stops knowing about time at all, which is the better shape
+ * anyway: this module already owns every clock the music has — `ROTATION_MS`,
+ * `TRANSITION_ROTATION_MS`, and the `since` they are measured from. The pure
+ * function keeps taking `now`, so the whole policy stays assertable against a
+ * fixed instant; this is one line on top of it and has no logic to test.
+ */
+export function rotateOnTransitionNow(packId: string): Soundscape {
+  return rotateOnTransition(packId, Date.now())
+}
+
+/**
  * This pack is on the stage and the key is its until it leaves.
  *
  * Called from an effect rather than during render, so that React's development

--- a/dynawalla/dynawalla-app/src/app/soundscape.ts
+++ b/dynawalla/dynawalla-app/src/app/soundscape.ts
@@ -25,15 +25,11 @@
 //   2. **A new key every `ROTATION_MS` after that.** Eight minutes. Long enough
 //      that a whole run at one game sits inside one key; short enough that a
 //      long afternoon hears five or six of them.
-//   3. **The key cannot move while a pack owns it.** A key change *underneath* a
-//      child — mid-question, because a timer went off — is the jarring thing,
-//      and it is worse than repetition: the drone would slide and the plate a
-//      child is holding would answer in a different mode than it did a second
-//      ago. So the app changes key while a child is walking between games, and
-//      never while they are in one. A forty-minute session at a single pack
-//      therefore stays in one key on purpose; the walker is what keeps that
-//      from being the same ding twice, and stage 2's `levelComplete` feedback
-//      is the designed place for a mid-session change.
+//   3. **The key never moves unbidden.** A key change *underneath* a child —
+//      mid-question, because a timer went off — is the jarring thing, and it is
+//      worse than repetition: the drone would slide and the plate a child is
+//      holding would answer in a different mode than it did a second ago. So a
+//      clock alone may never move the key while a pack is on the stage.
 //
 //      This is an invariant of THIS module and not a convention the caller has
 //      to keep, which matters: `packSettings` re-runs on every settings change
@@ -42,9 +38,37 @@
 //      playing child, and nothing would fail. `soundscapeForPack` takes the id
 //      of the pack asking and hands the *same* key back to the pack that
 //      already has it, whatever the clock says and however often it is called.
-//      Rotation is what happens when a DIFFERENT pack asks, or when the one
-//      that owned it has left.
-//   4. **Never the same mode twice running.** A uniform draw from 38 modes
+//   4. **A pack MAY ask for the key to turn over, by finishing something.**
+//      The founder: *"When does the musical mode get changed in general? Maybe
+//      it should switch more often like when a level transitions on some
+//      games."*
+//
+//      Rule 3 forbade a key change nobody asked for. A level transition is not
+//      that: it is the pack itself saying *the child finished something and
+//      there is nothing in front of them right now*, which is the same
+//      condition a doorway satisfies and is the moment the game already marks
+//      as "put that down". So rotating there upholds rule 3's reasoning rather
+//      than contradicting it — the rule was never "the pack owns the key", it
+//      was "no unbidden change mid-question". Doorways are the host's boundary;
+//      transitions are the pack's.
+//
+//      The gesture already exists and no new one was invented: `session.
+//      transition`, the SDK's ungated session method, whose documented contract
+//      is already exactly the guarantee needed — *"a transition is a thing the
+//      child finished, never a thing that beat them"*. A pack that has no
+//      levels simply never sends one and rotates at doorways alone, which is
+//      the policy that was already there.
+//
+//      A transition carries its own floor, `TRANSITION_ROTATION_MS`, and it is
+//      SHORTER than the doorway floor rather than longer. That is deliberate
+//      and it is the whole reason there are two numbers: a doorway happens
+//      whenever a child browses, so it needs a long floor to stop the bazaar
+//      changing key at every threshold; a transition is a real boundary a game
+//      declared, which is a stronger signal, so it needs less accumulated time
+//      to justify a change. Ninety seconds — long enough that a key gets to be
+//      a key even in a game whose levels are forty seconds long, short enough
+//      that the founder's "switch more often" is honoured.
+//   5. **Never the same mode twice running.** A uniform draw from 38 modes
 //      repeats about one doorway in 38, and a repeat is exactly the "stale and
 //      repetitive" the brief names. Re-drawing costs one comparison.
 //
@@ -84,6 +108,24 @@ export type { Soundscape }
  * whenever the child next walks between games".
  */
 export const ROTATION_MS = 8 * 60 * 1000
+
+/**
+ * How long a key must have been held before a LEVEL TRANSITION may turn it over.
+ *
+ * Ninety seconds, and it stays a floor for the same reason `ROTATION_MS` is
+ * one: a game whose levels are twenty seconds long must not change the key of
+ * the whole bazaar three times a minute, which is the twenty-eight-ringtones
+ * failure with a faster rhythm.
+ *
+ * **`ROTATION_MS` stays and does NOT become redundant.** It is now the
+ * backstop rather than the main driver: most packs in the fleet have no levels
+ * and send no transitions, so without it a forty-minute session at THE
+ * STEELYARD would sit in one key for forty minutes — which is the "stale and
+ * repetitive" the brief opened with. With both, a game with levels rotates on
+ * its own boundaries and a game without one rotates on the clock at the next
+ * doorway, and neither ever rotates under a child mid-question.
+ */
+export const TRANSITION_ROTATION_MS = 90 * 1000
 
 /**
  * How many times a draw may be rejected for repeating the previous mode.
@@ -192,6 +234,43 @@ export function soundscapeForPack(packId: string, now: number): Soundscape {
   const scape = draw(epoch, previous?.scape.modeId ?? null)
   held = { scape, since: at, epoch }
   owner = packId
+  return scape
+}
+
+/**
+ * A pack has finished something — a level, a run, a boss — and the key may turn
+ * over on it.
+ *
+ * The founder's answer, made a function. The rules, and each is load-bearing:
+ *
+ *   * **Only the pack that owns the key may do this.** A transition arriving
+ *     from a pack that is not on the stage is a message from a torn-down
+ *     session, and honouring it would rotate the key under whoever IS on the
+ *     stage — which is the exact thing rule 3 exists to prevent, arriving
+ *     through the door built to respect it.
+ *   * **The floor still applies**, at `TRANSITION_ROTATION_MS` rather than at
+ *     `ROTATION_MS`. See the note on both.
+ *   * **Ownership does not change.** The pack keeps the key it just changed;
+ *     the next thing it asks gets the new one.
+ *
+ * Returns the key to play in either way, so a caller can push it and does not
+ * have to know whether anything moved.
+ */
+export function rotateOnTransition(packId: string, now: number): Soundscape {
+  const previous = held
+  if (previous === null || owner !== packId) return previous?.scape ?? soundscapeForPack(packId, now)
+  const at = Number.isFinite(now) ? now : previous.since
+  const elapsed = at - previous.since
+  // A clock that went backwards rotates ONCE and then settles, exactly as the
+  // doorway path does — and the alternative was tried and is worse. Treating a
+  // negative elapsed as "not yet" looks safer and would disable level rotation
+  // until the wall clock caught up, which for a device whose time was corrected
+  // by ninety days is the rest of the year. Rotating resets `since` to the
+  // corrected instant, so the very next level is inside the floor again.
+  if (elapsed >= 0 && elapsed < TRANSITION_ROTATION_MS) return previous.scape
+  const epoch = previous.epoch + 1
+  const scape = draw(epoch, previous.scape.modeId)
+  held = { scape, since: at, epoch }
   return scape
 }
 

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -28,7 +28,7 @@ import {
 import {
   claimSoundscape,
   releaseSoundscape,
-  rotateOnTransition,
+  rotateOnTransitionNow,
   soundscapeForPack,
 } from "../app/soundscape.ts"
 import { strings } from "../app/strings.ts"
@@ -179,18 +179,19 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
            * A transition is the game saying "the child finished something and
            * nothing is in front of them", which is the same condition a doorway
            * satisfies — see `app/soundscape.ts` for why that upholds the
-           * never-under-a-child rule rather than breaking it. `rotateOnTransition`
-           * owns the floor and the ownership check; this only has to push what
-           * comes back, and the `push` effect below carries it to the pack on the
-           * `settings` channel that already exists.
+           * never-under-a-child rule rather than breaking it. That module owns
+           * the floor, the ownership check AND the clock: this component reads
+           * no time, because a `Date.now()` here is a clock read the React
+           * compiler must assume happens during render. See
+           * `rotateOnTransitionNow`.
            *
-           * Unconditional `setSoundscape`: the rotation is refused far more often
-           * than it is granted (a level inside the floor gets the same key back),
-           * and React bails out of a re-render when the state is identical, so the
-           * common case costs nothing and there is no second condition to keep in
-           * step with the policy.
+           * Unconditional `setSoundscape`: the rotation is refused far more
+           * often than it is granted — a level inside the floor gets the same
+           * key back — and React bails out of a re-render when the state is
+           * identical, so the common case costs nothing and there is no second
+           * condition to keep in step with the policy.
            */
-          setSoundscape(rotateOnTransition(packId, Date.now()))
+          setSoundscape(rotateOnTransitionNow(packId))
           // The store decides and records in one call, so two transitions
           // arriving in the same frame cannot both be "the first one today".
           if (reachTransition(packId) === "rest") setOffering(true)

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -25,7 +25,12 @@ import {
   orientationPorts,
   primeOrientationPermission,
 } from "../app/platform.ts"
-import { claimSoundscape, releaseSoundscape, soundscapeForPack } from "../app/soundscape.ts"
+import {
+  claimSoundscape,
+  releaseSoundscape,
+  rotateOnTransition,
+  soundscapeForPack,
+} from "../app/soundscape.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { documentLock } from "../app/zoom.ts"
@@ -137,7 +142,7 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
   // a parent touches a setting cannot put the game into a new key mid-question
   // even if somebody later inlines this call into the memo below. The claim and
   // the release are what let the NEXT pack rotate.
-  const [soundscape] = useState(() => soundscapeForPack(packId, Date.now()))
+  const [soundscape, setSoundscape] = useState(() => soundscapeForPack(packId, Date.now()))
   useEffect(() => {
     claimSoundscape(packId)
     return () => releaseSoundscape(packId)
@@ -168,6 +173,24 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
         onMilestone: (name) => console.info(`[packs] ${packId} reached ${name}`),
         onTransition: (kind, label) => {
           console.info(`[packs] ${packId} reached a ${kind}${label ? ` (${label})` : ""}`)
+          /**
+           * The one moment a pack may turn the app's key over.
+           *
+           * A transition is the game saying "the child finished something and
+           * nothing is in front of them", which is the same condition a doorway
+           * satisfies — see `app/soundscape.ts` for why that upholds the
+           * never-under-a-child rule rather than breaking it. `rotateOnTransition`
+           * owns the floor and the ownership check; this only has to push what
+           * comes back, and the `push` effect below carries it to the pack on the
+           * `settings` channel that already exists.
+           *
+           * Unconditional `setSoundscape`: the rotation is refused far more often
+           * than it is granted (a level inside the floor gets the same key back),
+           * and React bails out of a re-render when the state is identical, so the
+           * common case costs nothing and there is no second condition to keep in
+           * step with the policy.
+           */
+          setSoundscape(rotateOnTransition(packId, Date.now()))
           // The store decides and records in one call, so two transitions
           // arriving in the same frame cannot both be "the first one today".
           if (reachTransition(packId) === "rest") setOffering(true)

--- a/dynawalla/games/pulse/src/contract.ts
+++ b/dynawalla/games/pulse/src/contract.ts
@@ -17,6 +17,19 @@ export type Host = {
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
   haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
   prefersReducedMotion(): boolean;
+  /**
+   * A natural stopping point the child REACHED — never one that beat them.
+   *
+   * PULSE sends `"level"` when a stage is climbed. The host counts these for
+   * the day pass, and — since `SOUNDSCAPE_DESIGN_2026-07.md`'s rotation policy
+   * — treats one as a licence to change the app's key, because it is the one
+   * moment a game itself marks as "put that down". Nothing else in this file
+   * may send it: stepping a stage BACK is a failure and a failure is never a
+   * transition.
+   *
+   * Optional so the dev harness, which has no host, is not obliged to have one.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void;
 };
 
 export type Mounted = { unmount(): void };

--- a/dynawalla/games/pulse/src/game/chart.test.ts
+++ b/dynawalla/games/pulse/src/game/chart.test.ts
@@ -479,6 +479,54 @@ test("the band's pattern is drawn from the groove, not written down", () => {
   }
 });
 
+test("only the layers that OWN the bar line play on it", () => {
+  /**
+   * A regression that shipped in the first draft of this work and was caught by
+   * measuring rather than by listening.
+   *
+   * `grooveMatrix` forces beat 0 to a certainty, so a layer that reads the
+   * matrix straight plays the bar line in every single bar. That is right for
+   * the bass, which IS the pulse. It is wrong for the arp, which used to land
+   * there in one bar of three and started landing there in 300 of 300 —
+   * stacking a pluck onto the bass and onto the chart's own always-present
+   * downbeat, which is a thicker transient and a stiffer bar line, the exact
+   * opposite of what this change is for.
+   *
+   * And the layer must not PAY for standing back: beat 0 was worth 1 of the
+   * budget, so it is shared out rather than lost.
+   */
+  let arpOnDownbeat = 0;
+  let arpNotes = 0;
+  let bassOnDownbeat = 0;
+  let bassNotes = 0;
+  let bars = 0;
+  for (let r = 0; r < 10; r++) {
+    _clearChartCache();
+    const c = ctx(`downbeat-${r}`);
+    for (let bar = 0; bar < 300; bar++) {
+      if (bar > 0 && bar % 4 === 0) c.groove.advance(4);
+      const arp = bandBeats(c, bar, "arp", 1 / 3, "leave");
+      const bass = bandBeats(c, bar, "bass", 3 / 8);
+      if (arp.includes(0)) arpOnDownbeat++;
+      if (bass.includes(0)) bassOnDownbeat++;
+      arpNotes += arp.length;
+      bassNotes += bass.length;
+      bars++;
+    }
+  }
+  assert.equal(arpOnDownbeat, 0, `the arp doubled the bar line in ${arpOnDownbeat} of ${bars} bars`);
+  assert.equal(bassOnDownbeat, bars, "the bass lost the bar line it is supposed to carry");
+  // The hand-written arp averaged 8/3 notes a bar and the hand-written bass 3.
+  assert.ok(
+    Math.abs(arpNotes / bars - 8 / 3) < 0.15,
+    `the arp plays ${(arpNotes / bars).toFixed(3)} notes a bar against the 2.667 it replaced`,
+  );
+  assert.ok(
+    Math.abs(bassNotes / bars - 3) < 0.15,
+    `the bass plays ${(bassNotes / bars).toFixed(3)} notes a bar against the 3 it replaced`,
+  );
+});
+
 test("the band changes its MIND over minutes, not merely its notes", () => {
   /**
    * The distinction that matters, and the one the first version of this work

--- a/dynawalla/games/pulse/src/game/chart.test.ts
+++ b/dynawalla/games/pulse/src/game/chart.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../packs/shared/game-soundscape/index.ts";
 import { hashSeed } from "../rng.ts";
 import {
+  bandBeats,
   barNotes,
   BEATS_PER_BAR,
   chartContext,
@@ -21,9 +22,17 @@ import { LANE_UP_ACCURACY, readyForMoreLanes, STAGES, stageAt } from "./stages.t
 
 const KINDS: readonly NoteKind[] = ["kick", "snare", "hat", "tom"];
 
-/** A run's context, as `Run` builds one: a seed plus whatever key the app is in. */
+/**
+ * A run's context, as `Run` builds one: a seed, whatever key the app is in, and
+ * the living groove that walks away from it.
+ *
+ * Built through `chartContext` rather than by hand so that a test cannot get a
+ * context the game could never produce — which is what happened to the version
+ * of this helper that spelled the object out and then had to be taught about a
+ * new field.
+ */
 function ctx(seed: string, scape?: Soundscape): ChartContext {
-  return { seed, scape: scape ?? pickSoundscape(hashSeed(seed)) };
+  return chartContext(seed, scape ?? pickSoundscape(hashSeed(seed)));
 }
 
 /** What a child would hear from one bar: the instants and the hands. */
@@ -430,4 +439,202 @@ test("escalation is monotone where it should be and bounded where it must be", (
     assert.ok(s.lanes <= 3 && s.bars > 0);
   }
   assert.ok(stageAt(40).bpm > STAGES[STAGES.length - 1]!.bpm, "endless mode must keep climbing");
+});
+
+// ── The band, which is what "the main rhythm" meant ──────────────────────────
+//
+// The founder: *"the main rhythm is static."* It was, literally — the bass was
+// a hand-written array of beat offsets, the arp a three-bar modulo. The chart a
+// child PLAYS was already varied; the thing underneath it never moved. These
+// assertions are about the layer he was hearing.
+
+/** One bar of a backing layer, as a string. */
+function bandSig(c: ChartContext, bar: number, density: number): string {
+  return bandBeats(c, bar, "bass", density).join(",");
+}
+
+/** How often each instant of the bar was struck, over a window. */
+function bandProfile(c: ChartContext, from: number, n: number, density: number): Map<number, number> {
+  const out = new Map<number, number>();
+  for (let bar = from; bar < from + n; bar++) {
+    if (bar > 0 && bar % 4 === 0) c.groove.advance(4);
+    for (const b of bandBeats(c, bar, "bass", density)) out.set(b, (out.get(b) ?? 0) + 1);
+  }
+  for (const [k, v] of out) out.set(k, v / n);
+  return out;
+}
+
+test("the band's pattern is drawn from the groove, not written down", () => {
+  // `BASS_PATTERNS[2]` was `[0, 1.5, 2]` in every bar of every run at that
+  // tier, forever. Three distinct patterns in 64 bars would already beat it;
+  // this is far past that, and the number that used to be right here is ONE.
+  const c = ctx("band-variety");
+  const seen = new Set<string>();
+  for (let bar = 0; bar < 64; bar++) seen.add(bandSig(c, bar, 3 / 8));
+  assert.ok(seen.size >= 12, `only ${seen.size} distinct bass bars in 64 — the band is still a loop`);
+  // The downbeat is not negotiable in the band either: it is the thing the rest
+  // of the bar is heard against.
+  for (let bar = 0; bar < 64; bar++) {
+    assert.ok(bandSig(c, bar, 3 / 8).startsWith("0"), `bar ${bar} lost its downbeat`);
+  }
+});
+
+test("the band changes its MIND over minutes, not merely its notes", () => {
+  /**
+   * The distinction that matters, and the one the first version of this work
+   * got wrong. A per-bar draw already gives different bars; what "static" meant
+   * is that the ODDS never changed, so the same instants won forever. So this
+   * measures the odds — how often each instant is actually struck — early in a
+   * session against later in it, with the walk on and with it off.
+   *
+   * **The window has to be 200 bars and the reason is arithmetic.** A strike
+   * rate measured over N bars carries sampling noise of about
+   * `sqrt(p(1-p)/N)`, which at 96 bars is 0.05 per instant — the same size as
+   * the drift, so the two are indistinguishable and the first version of this
+   * test asserted a ratio of 1.16 and failed. Noise falls as `1/sqrt(N)` and
+   * the drift does not, so a longer window separates them: measured, 0.029
+   * against 0.059 at 200 bars, a clean factor of two.
+   */
+  const WINDOW = 200;
+  const shift = (drift: boolean): number => {
+    let total = 0;
+    for (let r = 0; r < 24; r++) {
+      _clearChartCache();
+      const c = ctx(`band-drift-${r}`);
+      if (!drift) {
+        // The A/B: the same generator with the walk switched off. Everything
+        // else — the seed, the matrix, the per-bar draw — is identical.
+        (c.groove as unknown as { advance: (n: number) => void }).advance = () => {};
+      }
+      const early = bandProfile(c, 0, WINDOW, 3 / 8);
+      const late = bandProfile(c, WINDOW + 56, WINDOW, 3 / 8);
+      let d = 0;
+      for (const b of new Set([...early.keys(), ...late.keys()])) {
+        d += Math.abs((early.get(b) ?? 0) - (late.get(b) ?? 0));
+      }
+      total += d / 8;
+    }
+    return total / 24;
+  };
+  const frozen = shift(false);
+  const alive = shift(true);
+  assert.ok(
+    alive > frozen * 1.6,
+    `the band shifted ${alive.toFixed(4)} with the walk on and ${frozen.toFixed(4)} with it off`,
+  );
+});
+
+test("the band and the chart read ONE groove, in either order", () => {
+  /**
+   * Both layers call `matrix` with different grids in the same bar — the chart
+   * with the stage's subdivisions, the band with eighths — and `Groove` keeps
+   * the union of every grid it is shown precisely so that which of them happens
+   * to be called first cannot change the music. That is a real hazard and not a
+   * theory: `scheduleBacking` runs before the player notes are laid, and moving
+   * one line would swap them.
+   *
+   * The two orders run INTERLEAVED, bar by bar, with the phrase cache dropped
+   * between them — because `barNotes` memoises on the run's seed, so two
+   * contexts sharing a seed would otherwise hand each other bars and the test
+   * would compare a cache with itself.
+   */
+  const a = ctx("order");
+  const b = ctx("order");
+  const stage = STAGES[5]!;
+  for (let bar = 0; bar < 40; bar++) {
+    if (bar > 0 && bar % 4 === 0) {
+      a.groove.advance(4);
+      b.groove.advance(4);
+    }
+    _clearChartCache();
+    const chartFirst = [barSig(5, a, bar), bandSig(a, bar, 3 / 8)];
+    _clearChartCache();
+    const bandFirst = [bandSig(b, bar, 3 / 8), barSig(5, b, bar)];
+    assert.ok(chartFirst[0]!.length > 0, "an empty chart would make every order look alike");
+    assert.equal(chartFirst[0], bandFirst[1], `bar ${bar}: asking the band first changed the chart`);
+    assert.equal(chartFirst[1], bandFirst[0], `bar ${bar}: asking the chart first changed the band`);
+  }
+  void stage;
+});
+
+// ── The chart's own drift, and the cache that must not lie about it ──────────
+
+test("a phrase cannot change under a child, even when the cache is evicted", () => {
+  /**
+   * The guarantee: what a child is two beats into cannot become something else.
+   *
+   * `barNotes` memoises all four bars at the phrase's first bar and the cache is
+   * cleared wholesale at 64 entries, so an eviction mid-phrase is a real event
+   * and the rebuild has to agree with what was already played. What makes that
+   * true is that `agree()` and `makeRoom()` are QUEUED to the next `advance` —
+   * this test fails within a millisecond if either of them starts landing
+   * immediately, which is the mutation it was written against.
+   */
+  const c = ctx("evict");
+  const stage = STAGES[3]!;
+  for (let phrase = 0; phrase < 12; phrase++) {
+    const bars = [0, 1, 2, 3].map((k) => barNotes(stage, c, phrase * 4 + k));
+    // Everything a gate could do, mid-phrase, plus the cache falling over.
+    c.groove.agree();
+    c.groove.makeRoom();
+    _clearChartCache();
+    for (let k = 0; k < 4; k++) {
+      assert.deepEqual(
+        barNotes(stage, c, phrase * 4 + k),
+        bars[k],
+        `phrase ${phrase} bar ${k} changed under the child`,
+      );
+    }
+    c.groove.advance(4);
+  }
+});
+
+test("right and wrong shape the chart, and right never makes it busier", () => {
+  const stage = STAGES[2]!;
+  const notesIn = (c: ChartContext, from: number, n: number): number => {
+    let total = 0;
+    for (let bar = from; bar < from + n; bar++) total += barNotes(stage, c, bar).length;
+    return total;
+  };
+  let thinner = 0;
+  let rightTotal = 0;
+  let quietTotal = 0;
+  const runs = 40;
+  for (let r = 0; r < runs; r++) {
+    const right = ctx(`ab-${r}`);
+    const wrong = ctx(`ab-${r}`);
+    const quiet = ctx(`ab-${r}`);
+    for (let i = 0; i < 10; i++) {
+      right.groove.agree();
+      right.groove.advance(4);
+      wrong.groove.makeRoom();
+      wrong.groove.advance(4);
+      quiet.groove.advance(4);
+    }
+    _clearChartCache();
+    const withRight = notesIn(right, 100, 40);
+    _clearChartCache();
+    const withWrong = notesIn(wrong, 100, 40);
+    _clearChartCache();
+    const withNothing = notesIn(quiet, 100, 40);
+    if (withWrong < withRight) thinner++;
+    rightTotal += withRight;
+    quietTotal += withNothing;
+  }
+  assert.ok(thinner >= runs * 0.7, `a run of misses left more room in only ${thinner} of ${runs}`);
+  /**
+   * Being right must never hand a child MORE to hit.
+   *
+   * Against a run that answered NOTHING, not against the same run earlier: a
+   * per-bar draw over forty bars carries several notes of sampling noise, so a
+   * per-run bound with slack tight enough to mean anything fails six times in
+   * forty on noise alone — which is what the first version of this did. The
+   * aggregate over 1600 bars has the noise averaged out of it, and the exact
+   * claim — that the EXPECTED count is bit-identical — is asserted where it can
+   * be, on the matrix, in `game-soundscape/evolve.test.ts`.
+   */
+  assert.ok(
+    rightTotal <= quietTotal * 1.02,
+    `ten right answers bought ${rightTotal} notes against ${quietTotal} for answering nothing`,
+  );
 });

--- a/dynawalla/games/pulse/src/game/chart.ts
+++ b/dynawalla/games/pulse/src/game/chart.ts
@@ -32,9 +32,9 @@
  */
 
 import {
+  Groove,
   currentSoundscape,
   divOfBeat,
-  grooveMatrix,
   grooveSlotBeats,
   pickSoundscape,
   type GrooveSlot,
@@ -60,17 +60,27 @@ export const BEATS_PER_BAR = 4;
 /**
  * Everything a chart is generated from, other than the stage and the bar.
  *
- * The soundscape is resolved ONCE, when a run is constructed, and carried here.
- * Re-reading it per bar would let the app's key change under a child mid-phrase
- * — which `SOUNDSCAPE_DESIGN_2026-07.md` forbids for exactly the same reason
- * here as there: the groove they are two bars into is not allowed to become a
- * different groove because a rotation timer went off.
+ * **The groove is the thing that has changed here, and it is a live object
+ * rather than a soundscape.** It used to be four fixed numbers, and
+ * `grooveMatrix` is a pure function of them, so a run got the same twenty-four
+ * probabilities back every phrase for as long as it lasted. The draw differed;
+ * the bias never did; the founder heard that as *"the main rhythm is static"*
+ * and he was right. `Groove` is the same matrix with a slow tethered walk on
+ * top of it — see `packs/shared/game-soundscape/evolve.ts`.
+ *
+ * The rule the old comment stated is UNCHANGED and is now enforced by the
+ * shared module rather than by this file's restraint: nothing about the groove
+ * moves except inside `advance()`, which `Run` calls at a phrase boundary. A
+ * bar a child is two beats into cannot become a different bar, and a key that
+ * arrives on a settings push waits for the same boundary.
  */
 export type ChartContext = {
   /** The run's seed. Same seed, same chart, forever. */
   readonly seed: string;
-  /** The app's key, as a rhythm generator. Never used to make a sound. */
+  /** The app's key as it was at the doorway. `groove.soundscape` is the live one. */
   readonly scape: Soundscape;
+  /** The living probability matrix. Never used to make a sound. */
+  readonly groove: Groove;
 };
 
 /**
@@ -83,9 +93,17 @@ export type ChartContext = {
  * own seed. That is not a pack choosing a key: nothing here reaches an
  * oscillator. It is a pack needing a probability matrix and taking the only
  * honest source of one it has.
+ *
+ * The WALK is seeded from the run's own seed and not from the soundscape's,
+ * which matters for the thing the founder complained about: two runs opened a
+ * minute apart are in the same key — that is the whole point of a key — and if
+ * the drift were seeded from the key as well they would also drift along
+ * exactly the same path. Seeding it from the run makes every sitting its own
+ * piece of music in the same key, and still replays exactly from the seed.
  */
-export function chartContext(seed: string): ChartContext {
-  return { seed, scape: currentSoundscape() ?? pickSoundscape(hashSeed(seed)) };
+export function chartContext(seed: string, scape?: Soundscape): ChartContext {
+  const key = scape ?? currentSoundscape() ?? pickSoundscape(hashSeed(seed));
+  return { seed, scape: key, groove: new Groove(key, hashSeed(`${seed}|groove`)) };
 }
 
 /**
@@ -257,7 +275,7 @@ function buildPhrase(stage: StageSpec, ctx: ChartContext, phrase: number): Chart
   const downbeatLane = stage.lanes - 1;
   const polyLane = stage.poly ? Math.min(stage.poly.lane, stage.lanes - 1) : -1;
 
-  const matrix = grooveMatrix(ctx.scape, {
+  const matrix = ctx.groove.matrix({
     beatsPerBar: BEATS_PER_BAR,
     divs: stage.divs,
     density: stage.density,
@@ -429,9 +447,27 @@ function nearestSlot(want: number, matrix: readonly GrooveSlot[]): number | null
 type PhraseKey = string;
 const phraseCache = new Map<PhraseKey, ChartNote[][]>();
 
+/**
+ * The four bars of a phrase, memoised.
+ *
+ * **What keeps a bar from changing under a child is NOT this key**, and saying
+ * so plainly is worth a paragraph because the first version of this comment
+ * claimed it was and a mutation test proved otherwise. The guarantee is held at
+ * the other end: `Groove` banks bars and spends them only in whole phrases, and
+ * `Run` calls `advance` at a phrase boundary, so the groove simply cannot move
+ * between bar 0 and bar 3 of a phrase — an eviction in the middle rebuilds from
+ * an unchanged groove and gets the same four bars back. Delete `revision` from
+ * this key and nothing breaks today; queue-then-apply is what is load-bearing,
+ * and `chart.test.ts` fails the moment `agree()` starts landing immediately.
+ *
+ * `revision` stays anyway, for a cost of one string concatenation per phrase:
+ * it makes the cache correct for ANY caller rather than for the one PULSE
+ * happens to be, and a memo whose key does not mention every input it read is
+ * a trap laid for whoever writes the next rhythm game.
+ */
 export function barNotes(stage: StageSpec, ctx: ChartContext, bar: number): ChartNote[] {
   const phrase = Math.floor(bar / 4);
-  const key = `${ctx.seed}|${ctx.scape.modeId}|${stage.id}|${phrase}`;
+  const key = `${ctx.seed}|${ctx.groove.soundscape.modeId}|${ctx.groove.revision}|${stage.id}|${phrase}`;
   let bars = phraseCache.get(key);
   if (!bars) {
     bars = buildPhrase(stage, ctx, phrase);
@@ -439,6 +475,47 @@ export function barNotes(stage: StageSpec, ctx: ChartContext, bar: number): Char
     phraseCache.set(key, bars);
   }
   return bars[bar % 4] ?? [];
+}
+
+/**
+ * Where one BACKING layer plays this bar — the band, not the child.
+ *
+ * **This is the layer the founder was actually hearing.** *"The main rhythm is
+ * static"* — and it was, literally: the bass was `BASS_PATTERNS[tier]`, a
+ * hand-written array of beat offsets identical in every bar of every run at a
+ * tier, and the arp was `(k + bar) % 3`, a three-bar loop. The chart already
+ * varied a great deal per phrase, so making IT drift moved a strike-rate
+ * measurement by 0.0005 and could never have been audible; the variety was
+ * already there and the thing underneath it never moved at all.
+ *
+ * So the tier says HOW BUSY the bass is and the groove says WHERE it sits,
+ * exactly as a stage's `density` and the matrix already divide that work for
+ * the player's notes. Nothing here is judged and nothing here is struck by a
+ * child, so unlike the chart the band can be moved as far as the groove likes
+ * without ever making the game harder — which is why this is where the drift
+ * gets to be heard.
+ *
+ * The stream is seeded on the bar so two adjacent bars are not the same bar,
+ * and on `groove.revision` so a bar re-scheduled after a mutation cannot come
+ * back different from the one already heard — the same reason the revision is
+ * in the phrase cache key.
+ *
+ * Eighths and quarters only. A bass that could land on a triplet against a
+ * sixteenth chart would be a band fighting the child, and the subdivisions the
+ * game TEACHES belong to the chart.
+ */
+export function bandBeats(
+  ctx: ChartContext,
+  bar: number,
+  layer: string,
+  density: number,
+): number[] {
+  const rng = makeRng(hashSeed(`${ctx.seed}|band-${layer}|${bar}|${ctx.groove.revision}`));
+  const out: number[] = [];
+  for (const slot of ctx.groove.matrix({ beatsPerBar: BEATS_PER_BAR, divs: [1, 2], density })) {
+    if (rng.bool(slot.p)) out.push(slot.beat);
+  }
+  return out;
 }
 
 /** Test seam — drop memoised phrases so a determinism test starts clean. */

--- a/dynawalla/games/pulse/src/game/chart.ts
+++ b/dynawalla/games/pulse/src/game/chart.ts
@@ -503,16 +503,41 @@ export function barNotes(stage: StageSpec, ctx: ChartContext, bar: number): Char
  * Eighths and quarters only. A bass that could land on a triplet against a
  * sixteenth chart would be a band fighting the child, and the subdivisions the
  * game TEACHES belong to the chart.
+ *
+ * `downbeat` is which of the two kinds of layer this is, and getting it wrong
+ * was a real regression rather than a hypothetical. The matrix forces beat 0 to
+ * a certainty — it is not negotiable, which is right for a bass — so a layer
+ * that simply reads the matrix plays the bar line in EVERY bar. The arp used to
+ * land on it in one bar of three, and reading the matrix straight put it on all
+ * of them: measured, 300 of 300 bars against 100 of 300, stacking a pluck onto
+ * the bass and the chart's own downbeat and stiffening the exact bar line this
+ * work set out to loosen. `"leave"` hands the bar line to the layers that own
+ * it — and hands beat 0's share of the budget back to the rest of the bar, so
+ * the layer keeps the note count it was asked for instead of quietly losing one
+ * a bar.
  */
 export function bandBeats(
   ctx: ChartContext,
   bar: number,
   layer: string,
   density: number,
+  downbeat: "keep" | "leave" = "keep",
 ): number[] {
   const rng = makeRng(hashSeed(`${ctx.seed}|band-${layer}|${bar}|${ctx.groove.revision}`));
+  const slots = ctx.groove.matrix({ beatsPerBar: BEATS_PER_BAR, divs: [1, 2], density });
   const out: number[] = [];
-  for (const slot of ctx.groove.matrix({ beatsPerBar: BEATS_PER_BAR, divs: [1, 2], density })) {
+  if (downbeat === "leave") {
+    const rest = slots.slice(1);
+    let total = 0;
+    for (const s of rest) total += s.p;
+    // The downbeat was worth exactly 1 of the budget. Share it out in
+    // proportion, and keep the per-slot ceiling so no instant becomes a
+    // certainty — a decorative layer that is certain anywhere is a loop again.
+    const scale = total > 0 ? (total + 1) / total : 1;
+    for (const s of rest) if (rng.bool(Math.min(0.95, s.p * scale))) out.push(s.beat);
+    return out;
+  }
+  for (const slot of slots) {
     if (rng.bool(slot.p)) out.push(slot.beat);
   }
   return out;

--- a/dynawalla/games/pulse/src/game/run.test.ts
+++ b/dynawalla/games/pulse/src/game/run.test.ts
@@ -62,20 +62,31 @@ type Rig = {
   outcomes: string[];
   /** How many candidates each gate carried, in order, with its stage. */
   gateShapes: Array<{ stage: number; candidates: number; wrong: number }>;
+  /** Every `session.transition` the run sent the host, in order. */
+  transitions: Array<{ kind: string; label: string | undefined }>;
   play(seconds: number): void;
   dispose(): void;
 };
 
 /**
- * @param answer what the bot does at every gate: strike the right candidate,
- *               strike a wrong one, or nothing at all.
+ * @param answer what the bot does: strike the right candidate at every gate,
+ *               strike a wrong one, ignore gates but drum everything else, or —
+ *               `"silent"` — put its hands in its pockets and touch nothing.
+ *
+ * `"silent"` exists because the other three cannot reach the stumble. A bot
+ * that drums every ordinary note dead on earns back more health than a wrong
+ * gate costs, so `rig("wrong", 4)` played for five minutes and never once fell
+ * a stage — which made an assertion about what happens when a stage IS lost
+ * vacuous, and it passed with the guard it was testing deleted. Missing
+ * everything drains health at 0.05 a note and stumbles inside a stage.
  */
-function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
+function rig(answer: "right" | "wrong" | "never" | "silent", startStage = 0): Rig {
   const reports: Report[] = [];
   const stages: number[] = [];
   const readingWindows: number[] = [];
   const outcomes: string[] = [];
   const gateShapes: Array<{ stage: number; candidates: number; wrong: number }> = [];
+  const transitions: Array<{ kind: string; label: string | undefined }> = [];
   let n = 0;
 
   const host: Host = {
@@ -89,6 +100,9 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
     haptic() {},
     prefersReducedMotion() {
       return true;
+    },
+    transition(kind, label) {
+      transitions.push({ kind, label });
     },
   };
 
@@ -147,6 +161,7 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
    * prove nothing about the stages above it.
    */
   const botTick = (): void => {
+    if (answer === "silent") return;
     const heard = run.heard();
     for (const note of run.notes.all()) {
       if (note.judged !== null || planned.has(note.id)) continue;
@@ -172,6 +187,7 @@ function rig(answer: "right" | "wrong" | "never", startStage = 0): Rig {
 
   return {
     run,
+    transitions,
     reports,
     stages,
     readingWindows,
@@ -438,4 +454,123 @@ test("the viewport can hold the count down, but never below a real choice", () =
     "with room to spare the stage decides",
   );
   r.dispose();
+});
+
+// ── The groove, in a real run ────────────────────────────────────────────────
+//
+// The founder: *"pulse is somewhat improved but it needs to gradually evolve
+// more — the main rhythm is static … Maybe being 'right' or 'wrong' should
+// affect the beat in different ways."* These are the assertions that the
+// machinery in `packs/shared/game-soundscape/evolve.ts` is actually reached by
+// a thumb, rather than merely existing and being unit-tested next door.
+
+/**
+ * Play a rig and always tear it down, even when an assertion throws.
+ *
+ * A `Run` that is not disposed leaves its lookahead running, so a FAILING
+ * assertion held the whole test file open until Node's own timeout — sixty
+ * seconds of nothing where one line of red belonged. Found while
+ * mutation-testing these very tests, which is what mutation-testing is for.
+ */
+function played(answer: "right" | "wrong" | "never" | "silent", seconds: number, startStage = 0) {
+  const r = rig(answer, startStage);
+  try {
+    r.play(seconds);
+    return { r, done: () => r.dispose() };
+  } catch (error) {
+    r.dispose();
+    throw error;
+  }
+}
+
+test("a run ages its groove, one phrase at a time and never faster", () => {
+  const { r, done } = played("right", 180);
+  try {
+    const g = r.run.chart.groove;
+    // 180 s at 80-96 BPM is roughly 60 bars, so about 15 phrases. The exact
+    // count depends on how far the bot climbed; the claim is that it aged, in
+    // phrases, and that it neither stood still nor raced.
+    assert.ok(g.revision >= 8, `three minutes of play only aged the groove ${g.revision} times`);
+    assert.ok(g.revision <= 40, `the groove aged ${g.revision} times in three minutes — that is not "slowly"`);
+    assert.ok(g.bars >= g.revision * 4, "bars and mutations came apart");
+  } finally {
+    done();
+  }
+});
+
+test("right and wrong steer the same run's groove in opposite directions", () => {
+  // Two bots, one seed, one difference: what they do at a gate. Nothing else
+  // about the run differs, so a difference in the groove is caused by the
+  // arithmetic and by nothing else.
+  const spec = { beatsPerBar: 4, divs: [1, 2], density: 0.34 };
+  const net = (g: Rig["run"]["chart"]["groove"]): number => {
+    const now = g.matrix(spec);
+    const seed = g.seedMatrix(spec);
+    let out = 0;
+    for (let i = 1; i < now.length; i++) {
+      const d = (now[i]?.affinity ?? 0) - (seed[i]?.affinity ?? 0);
+      if (d >= 0.12) out++;
+      else if (d <= -0.12) out--;
+    }
+    return out;
+  };
+
+  const right = played("right", 240);
+  const wrong = played("wrong", 240);
+  try {
+    assert.ok(right.r.outcomes.includes("correct"), "the right bot never answered anything");
+    assert.ok(wrong.r.outcomes.includes("wrong"), "the wrong bot never answered anything");
+    assert.ok(
+      net(right.r.run.chart.groove) > net(wrong.r.run.chart.groove),
+      `right netted ${net(right.r.run.chart.groove)} and wrong netted ${net(wrong.r.run.chart.groove)} — the beat did not hear the difference`,
+    );
+    // And the miss left ROOM rather than a hole: the openness dial is up on the
+    // bot that got everything wrong and down on the one that got it right.
+    assert.ok(
+      wrong.r.run.chart.groove.openness > right.r.run.chart.groove.openness,
+      "a run of wrong answers left no more room than a run of right ones",
+    );
+  } finally {
+    right.done();
+    wrong.done();
+  }
+});
+
+test("a stage climbed is a transition; a stage LOST is not", () => {
+  // The host reads a transition as a licence to change the app's key, and the
+  // SDK's rule is absolute: *"a transition is a thing the child finished, never
+  // a thing that beat them"*. `checkStumble` steps a stage BACK through the
+  // same method, so the two paths have to be told apart.
+  const climbing = played("right", 300);
+  try {
+    assert.ok(climbing.r.run.stageIndex > 0, "the fixture never climbed, so this proves nothing");
+    assert.ok(climbing.r.transitions.length > 0, "a stage was climbed and the host was never told");
+    for (const t of climbing.r.transitions) assert.equal(t.kind, "level");
+    assert.equal(
+      climbing.r.transitions.length,
+      climbing.r.run.stageIndex,
+      "one transition per stage climbed, no more and no fewer",
+    );
+  } finally {
+    climbing.done();
+  }
+
+  // A bot that touches nothing misses every note, drains its health, stumbles
+  // and is stepped back down a stage. Not one of those is a transition. It has
+  // to be `"silent"`: a bot that drums perfectly and only fumbles the sums
+  // earns back more health than it loses and never falls at all — see `rig`.
+  const falling = played("silent", 300, 4);
+  try {
+    assert.ok(
+      falling.r.run.stageIndex < 4,
+      `the fixture never lost a stage (ended at ${falling.r.run.stageIndex}), so this proves nothing`,
+    );
+    assert.equal(
+      falling.r.transitions.length,
+      0,
+      "a failure was reported to the host as something the child finished",
+    );
+  } finally {
+    falling.done();
+  }
 });

--- a/dynawalla/games/pulse/src/game/run.ts
+++ b/dynawalla/games/pulse/src/game/run.ts
@@ -454,14 +454,16 @@ export class Run {
     }
     if (this.layers.has("arp")) {
       const seq = PENTATONIC;
-      for (const b of bandBeats(this.chart, bar, "arp", 1 / 3)) {
+      // `"leave"`: the bar line already has the bass and the chart's downbeat
+      // on it, and a third voice there is a thicker transient rather than a
+      // richer bar. See `bandBeats`.
+      for (const b of bandBeats(this.chart, bar, "arp", 1 / 3, "leave")) {
         const k = Math.round(b * 2);
         const semi = chord.root + seq[(k + bar) % seq.length]! + 36;
         this.voices.pluck(t + b * spb, hz(semi), 0.3, 1.4);
       }
     }
   }
-
 
   private scheduleGateBar(bar: number, t: number, spb: number): void {
     // The band takes over so the groove never thins while the player thinks.

--- a/dynawalla/games/pulse/src/game/run.ts
+++ b/dynawalla/games/pulse/src/game/run.ts
@@ -33,7 +33,9 @@ import {
   PENTATONIC,
   type LayerId,
 } from "../audio/music.ts";
+import { onSoundscape } from "../../../../packs/shared/game-soundscape/index.ts";
 import {
+  bandBeats,
   barNotes,
   BEATS_PER_BAR,
   chartContext,
@@ -197,6 +199,8 @@ export class Run {
   private readonly onCalibrationChange: ((ms: number) => void) | undefined;
   private strayTimes: number[] = [];
   private lastReapTime = 0;
+  /** Drops the app-key subscription. Set in `start`, spent in `dispose`. */
+  private unfollowKey: (() => void) | undefined;
 
   constructor(o: RunOptions) {
     this.host = o.host;
@@ -276,6 +280,27 @@ export class Run {
    * transport is still correctly anchored whenever the audio does come up.
    */
   start(): void {
+    /**
+     * Follow the app's key, which can now move mid-run.
+     *
+     * Before the rotation policy landed, a pack's key was fixed for as long as
+     * it was on stage and this subscription would have been dead code. It now
+     * changes when a LEVEL TURNS OVER — the host rotates on the `transition`
+     * this file sends from `setStage` — so the chart has to be able to hear
+     * about it. `Groove.retune` queues the new key to the next phrase boundary
+     * and keeps the drift across it, so a rotation lands as a modulation of the
+     * groove that was playing rather than as a different groove starting.
+     *
+     * Subscribed in `start` rather than in the constructor so a Run that is
+     * built and never started leaves nothing behind, and unsubscribed in
+     * `dispose` so a child who opens eight games does not leave eight charts
+     * listening.
+     */
+    this.unfollowKey?.();
+    this.unfollowKey = onSoundscape((scape) => {
+      if (scape === null) return;
+      this.chart.groove.retune(scape);
+    });
     void this.engine.resume();
     const t0 = this.engine.now() + 0.35;
     this.timeline.setTempoAtBeat(0, this.stage.bpm);
@@ -300,6 +325,8 @@ export class Run {
 
   dispose(): void {
     this.stop();
+    this.unfollowKey?.();
+    this.unfollowKey = undefined;
     this.engine.dispose();
   }
 
@@ -314,6 +341,21 @@ export class Run {
   private fillBar(bar: number, t: number): void {
     this.bar = bar;
     const beat0 = this.timeline.beatOfBar(bar);
+
+    /**
+     * The groove ages, one phrase at a time, and ONLY here.
+     *
+     * A phrase boundary is the only instant it is safe to move at: `barNotes`
+     * builds all four bars of a phrase at its first bar and memoises them, so a
+     * mutation landing anywhere else would either be invisible until the next
+     * phrase or — after a cache eviction — rewrite a bar the child is halfway
+     * through. `Groove` holds the other end of this by banking bars and only
+     * spending them in whole `BARS_PER_MUTATION` lots.
+     *
+     * Not at bar 0: the first phrase a child ever hears is the seed, which is
+     * the bar the key actually chose. Everything after it is where the key went.
+     */
+    if (bar > 0 && bar % 4 === 0) this.chart.groove.advance(4);
 
     // --- Stage advance lands on the bar line, tempo and all — but only once
     // the child has actually cleared the stage. Bars are how a stage is paced;
@@ -372,12 +414,35 @@ export class Run {
     }
   }
 
+  /**
+   * The band, drawn from the living groove instead of from a written loop.
+   *
+   * **This is the layer the founder was actually hearing** when he said *"the
+   * main rhythm is static"*, and `bandBeats` is where the argument for that is
+   * written down.
+   *
+   * So the tier now says HOW BUSY the bass is and the groove says WHERE it
+   * sits — see `bandBeats`. `BASS_PATTERNS` survives as the escalation ladder
+   * it always was, the same number of bass hits per tier, with the positions
+   * drawn rather than typed.
+   *
+   * **The shaker is deliberately left alone**, and that is the same argument
+   * this whole module rests on: something has to be the frame. A hat that is
+   * dead steady is what makes a bass that moves read as the bass moving rather
+   * than as the tempo wobbling. One layer holds the metre, the rest are free.
+   *
+   * Nothing here is judged, nothing here is struck by a child, and nothing here
+   * changes the tempo — so unlike the chart, the band can be moved as far as
+   * the groove wants to move it without ever making the game harder.
+   */
   private scheduleBacking(bar: number, t: number, spb: number, overdrive: boolean): void {
     const chord = chordAt(bar);
     const root = hz(chord.root + 24);
     const tier = Math.min(BASS_PATTERNS.length - 1, Math.floor(this.stageIndex / 2));
     if (this.layers.has("bass")) {
-      for (const b of BASS_PATTERNS[tier]!) {
+      // The tier's own hit count over the eighth-note grid, as a density.
+      const density = BASS_PATTERNS[tier]!.length / (BEATS_PER_BAR * 2);
+      for (const b of bandBeats(this.chart, bar, "bass", density)) {
         this.voices.bass(t + b * spb, root / 2, spb * 0.62, overdrive ? 1.15 : 1);
       }
     }
@@ -389,13 +454,14 @@ export class Run {
     }
     if (this.layers.has("arp")) {
       const seq = PENTATONIC;
-      for (let k = 0; k < BEATS_PER_BAR * 2; k++) {
-        if ((k + bar) % 3 !== 0) continue;
+      for (const b of bandBeats(this.chart, bar, "arp", 1 / 3)) {
+        const k = Math.round(b * 2);
         const semi = chord.root + seq[(k + bar) % seq.length]! + 36;
-        this.voices.pluck(t + (k / 2) * spb, hz(semi), 0.3, 1.4);
+        this.voices.pluck(t + b * spb, hz(semi), 0.3, 1.4);
       }
     }
   }
+
 
   private scheduleGateBar(bar: number, t: number, spb: number): void {
     // The band takes over so the groove never thins while the player thinks.
@@ -491,6 +557,7 @@ export class Run {
   }
 
   private setStage(index: number, atBeat: number): void {
+    const climbed = index > this.stageIndex;
     this.stageIndex = Math.max(0, index);
     this.stage = stageAt(this.stageIndex);
     this.stageStartBar = this.timeline.barOfBeat(atBeat);
@@ -499,6 +566,19 @@ export class Run {
     const anyHost = this.host as Host & { setFloor?: (d: number) => void };
     anyHost.setFloor?.(this.stage.gateFloor);
     this.fx.stageChanged(this.stage, this.stageIndex);
+    /**
+     * A stage turned over, and the host is told so it may change the app's key.
+     *
+     * **Only upward.** `checkStumble` also calls this method, to step a stage
+     * back when the mix has fallen apart, and the SDK's rule about this message
+     * is absolute: *"a transition is a thing the child finished, never a thing
+     * that beat them"* — it is what the day pass is counted in, and a purchase
+     * surface must never sit next to a failure (ADR-0013). Climbing a stage is
+     * a thing they finished; sliding back down one is not.
+     *
+     * Optional on the contract because the dev harness has no host to tell.
+     */
+    if (climbed) this.host.transition?.("level", this.stage.title);
   }
 
   // -------------------------------------------------------------------- input
@@ -617,6 +697,26 @@ export class Run {
       ms,
       answered: info.label,
     });
+
+    /**
+     * The arithmetic feeds the groove.
+     *
+     * A GATE and not a note, which is the whole judgement in this file about
+     * what "right" means here. A gate is the sum; a note is the rhythm. Thinning
+     * a groove because a child dropped a hat would be the music commenting on
+     * their hands, which is a running critique rather than a conversation — and
+     * the fleet's rule is that it must never read as one. The maths is what the
+     * music answers.
+     *
+     * Neither call makes a sound and neither changes the tempo. `agree` opens
+     * an instant the bar had been ignoring at exactly the same note count;
+     * `makeRoom` takes the busiest ornament down and leaves a little space for
+     * a few phrases, which expires on the clock whether or not the next answer
+     * is right. See `evolve.ts` for why it is those two and not a fanfare and a
+     * buzzer.
+     */
+    if (info.correct) this.chart.groove.agree();
+    else this.chart.groove.makeRoom();
 
     if (info.correct) {
       this.gatesCorrect++;

--- a/dynawalla/packs/shared/game-soundscape/evolve.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/evolve.test.ts
@@ -1,0 +1,529 @@
+/**
+ * The drift, in numbers.
+ *
+ * Every assertion in here was mutation-tested — broken on purpose, watched to
+ * fail, restored — because the last generator in this lineage shipped a test
+ * that passed with the feature switched off. The two that matter most are
+ * "`advance` actually moves the matrix" and "right and wrong move it in
+ * opposite directions"; both fail loudly if `Groove.step` is emptied.
+ */
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { BARS_PER_MUTATION, Groove } from "./evolve.ts"
+import { MAX_OPENNESS, MIN_AFFINITY, expectedNotes, leanAffinity, type GrooveSpec } from "./groove.ts"
+import { MODES } from "./modes.ts"
+import { pickSoundscape, type Soundscape } from "./soundscape.ts"
+
+/** The four grids PULSE actually plays, opening to endgame. */
+const GRIDS: readonly { name: string; spec: GrooveSpec }[] = [
+  { name: "quarters", spec: { beatsPerBar: 4, divs: [1], density: 0.65 } },
+  { name: "eighths", spec: { beatsPerBar: 4, divs: [1, 2], density: 0.34 } },
+  { name: "triplets", spec: { beatsPerBar: 4, divs: [1, 3], density: 0.28 } },
+  { name: "everything", spec: { beatsPerBar: 4, divs: [1, 2, 3, 4], density: 0.12 } },
+]
+
+const EIGHTHS = GRIDS[1]!.spec
+
+const scapes = (n: number): Soundscape[] =>
+  Array.from({ length: n }, (_, i) => pickSoundscape(i * 2654435761))
+
+/** A groove that has already been shown the grid it is going to be asked about. */
+const grooveOn = (scape: Soundscape, spec: GrooveSpec, seed?: number): Groove => {
+  const g = new Groove(scape, seed)
+  g.matrix(spec)
+  return g
+}
+
+const play = (g: Groove, bars: number): void => {
+  for (let b = 0; b < bars; b += BARS_PER_MUTATION) g.advance(BARS_PER_MUTATION)
+}
+
+/**
+ * Instants the groove now favours more than the seed did, minus the ones it
+ * favours less. The one number that says which way a groove has been steered.
+ *
+ * Measured on AFFINITY rather than on `p`, deliberately: `p` is renormalised
+ * against a fixed budget, so raising one instant lowers every other and the
+ * count would be near zero by construction whatever happened.
+ */
+const netOpened = (g: Groove, spec: GrooveSpec, threshold = 0.12): number => {
+  const now = g.matrix(spec)
+  const seed = g.seedMatrix(spec)
+  let net = 0
+  for (let i = 1; i < now.length; i++) {
+    const delta = (now[i]?.affinity ?? 0) - (seed[i]?.affinity ?? 0)
+    if (delta >= threshold) net++
+    else if (delta <= -threshold) net--
+  }
+  return net
+}
+
+// ── the seam in `groove.ts` ──────────────────────────────────────────────────
+
+test("a lean moves an instant inside the range the mode already allowed it", () => {
+  // The bounds hold by construction, not by clamping — which is why a drifted
+  // matrix passes the same invariants an undrifted one does.
+  assert.equal(leanAffinity(0.6, 0), 0.6)
+  assert.equal(leanAffinity(0.6, 1), 1)
+  assert.equal(leanAffinity(0.6, -1), MIN_AFFINITY)
+  assert.equal(leanAffinity(1, 1), 1, "a full lean on a full instant cannot overshoot")
+  assert.equal(leanAffinity(MIN_AFFINITY, -1), MIN_AFFINITY, "nor undershoot")
+  for (const a of [MIN_AFFINITY, 0.5, 0.8, 1]) {
+    for (const b of [-1, -0.4, 0, 0.4, 1, 5, -5, Number.NaN]) {
+      const out = leanAffinity(a, b)
+      assert.ok(out >= MIN_AFFINITY - 1e-12 && out <= 1 + 1e-12, `a=${a} b=${b} gave ${out}`)
+    }
+  }
+})
+
+test("no drift a groove can reach ever deletes an instant or forces one", () => {
+  for (const scape of scapes(24)) {
+    for (const { name, spec } of GRIDS) {
+      const g = grooveOn(scape, spec)
+      // Every kind of pressure at once, for a long time.
+      for (let i = 0; i < 120; i++) {
+        if (i % 3 === 0) g.agree()
+        if (i % 5 === 0) g.makeRoom()
+        g.advance(BARS_PER_MUTATION)
+        for (const s of g.matrix(spec)) {
+          assert.ok(
+            s.affinity >= MIN_AFFINITY - 1e-9 && s.affinity <= 1 + 1e-9,
+            `${scape.modeId} ${name}: affinity ${s.affinity} at beat ${s.beat}`,
+          )
+          assert.ok(Number.isFinite(s.p) && s.p >= 0 && s.p <= 1, `p=${s.p}`)
+        }
+        assert.equal(g.matrix(spec)[0]?.p, 1, "the downbeat is never negotiable")
+      }
+    }
+  }
+})
+
+// ── job 1: it drifts, slowly, and it comes home ──────────────────────────────
+
+test("the matrix is NOT the same bar forever — it moves, and only on `advance`", () => {
+  const g = grooveOn(pickSoundscape(7), EIGHTHS)
+  const first = g.matrix(EIGHTHS).map((s) => s.p)
+  play(g, 40)
+  const later = g.matrix(EIGHTHS).map((s) => s.p)
+  const moved = first.filter((p, i) => Math.abs(p - (later[i] ?? 0)) > 1e-6).length
+  assert.ok(moved >= 3, `only ${moved} of ${first.length} instants moved in 40 bars`)
+})
+
+test("a groove goes somewhere over minutes, and never off the edge", () => {
+  // The founder's rate: a child notices over minutes, not bars. So the walk has
+  // to be small at a phrase, real at a minute, and BOUNDED at an hour — a drift
+  // that keeps growing is a groove that eventually has nothing to do with the
+  // key the app is in.
+  //
+  // The bound here is held by the ±1 clamp in `nudge` and NOT by the tether:
+  // this test still passes with the decay deleted, which is why the tether has
+  // a test of its own that does not.
+  const at = (bars: number): number => {
+    let total = 0
+    for (const scape of scapes(40)) {
+      const g = grooveOn(scape, EIGHTHS)
+      play(g, bars)
+      total += g.distanceFromSeed(EIGHTHS)
+    }
+    return total / 40
+  }
+  const phrase = at(4)
+  const minute = at(24)
+  const nineMinutes = at(192)
+  const hour = at(1536)
+
+  assert.ok(phrase < 0.015, `one phrase already moved ${phrase.toFixed(4)} — that is not "slowly"`)
+  assert.ok(minute > phrase * 1.8, `a minute (${minute.toFixed(4)}) barely beat a phrase (${phrase.toFixed(4)})`)
+  assert.ok(nineMinutes > minute * 1.4, `nine minutes (${nineMinutes.toFixed(4)}) barely beat one (${minute.toFixed(4)})`)
+  assert.ok(hour < nineMinutes * 1.4, `an hour ran away to ${hour.toFixed(4)} from ${nineMinutes.toFixed(4)}`)
+  assert.ok(hour < 0.12, `an hour of drift reached ${hour.toFixed(4)}, which is a different game`)
+})
+
+test("the walk is TETHERED: a shape fades once nothing is holding it there", () => {
+  /**
+   * "There is sort of the seed but it should be able to go almost anywhere."
+   * Anywhere is the excursion; the seed is what it falls back to.
+   *
+   * **The obvious test of this is vacuous and it was written first.** Counting
+   * an instant's crossings back through its seed value, or bounding how far the
+   * matrix gets in an hour, both PASS with the decay deleted — because
+   * `nudge` clamps a lean to ±1, and a clamped zero-mean walk is already
+   * bounded and already crosses zero. Those assertions are true and they are
+   * not evidence.
+   *
+   * What only the tether can produce is a walk whose SIGNED total returns to
+   * zero. The wander is zero-mean, so it cannot undo a run of right answers; it
+   * can only scatter around it. Twenty right answers push the total to about
+   * +4, and after two hundred bars of nobody answering anything it is the decay
+   * and only the decay that brings it back. Measured with the decay removed:
+   * 37% of the shape survives. With it: 15%.
+   */
+  const total = (g: Groove): number =>
+    g.matrix(EIGHTHS).slice(1).reduce((sum, s) => sum + g.leanAt(s.beat), 0)
+
+  let earned = 0
+  let left = 0
+  const runs = 60
+  for (const scape of scapes(runs)) {
+    const g = grooveOn(scape, EIGHTHS)
+    for (let i = 0; i < 20; i++) {
+      g.agree()
+      g.advance(BARS_PER_MUTATION)
+    }
+    earned += total(g)
+    play(g, 200)
+    left += total(g)
+  }
+  assert.ok(earned / runs > 2, `twenty right answers only reached ${(earned / runs).toFixed(2)} of lean`)
+  assert.ok(
+    left / earned < 0.25,
+    `${((left / earned) * 100).toFixed(0)}% of an earned shape was still there 200 bars later — nothing is pulling it home`,
+  )
+
+  // And it really does travel while it is out there: the mode's affinity range
+  // is 0.65 wide, so an instant that has moved a third of it is audibly else.
+  let travelled = 0
+  for (const scape of scapes(20)) {
+    const g = grooveOn(scape, EIGHTHS)
+    for (let bar = 0; bar < 2000; bar += BARS_PER_MUTATION) {
+      g.advance(BARS_PER_MUTATION)
+      const now = g.matrix(EIGHTHS)
+      const seed = g.seedMatrix(EIGHTHS)
+      for (let i = 1; i < now.length; i++) {
+        travelled = Math.max(travelled, Math.abs((now[i]?.affinity ?? 0) - (seed[i]?.affinity ?? 0)))
+      }
+    }
+  }
+  assert.ok(travelled > 0.3, `the furthest any instant ever got was ${travelled.toFixed(3)}`)
+})
+
+test("the groove keeps finding new favourites, and does so about once a minute", () => {
+  // The audible number. Which three instants is the bar leaning on? At 88 BPM a
+  // phrase is 11 s, so 100 phrases is about eighteen minutes of play.
+  const favourites = (g: Groove): string =>
+    g
+      .matrix(EIGHTHS)
+      .map((s, i) => [i, s.p] as const)
+      .slice(1)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([i]) => i)
+      .sort((a, b) => a - b)
+      .join("/")
+
+  let distinct = 0
+  let changes = 0
+  const runs = 40
+  for (const scape of scapes(runs)) {
+    const g = grooveOn(scape, EIGHTHS)
+    const seen = new Set<string>()
+    let previous = ""
+    for (let i = 0; i < 100; i++) {
+      g.advance(BARS_PER_MUTATION)
+      const now = favourites(g)
+      seen.add(now)
+      if (previous !== "" && now !== previous) changes++
+      previous = now
+    }
+    distinct += seen.size
+  }
+  assert.ok(distinct / runs >= 5, `only ${(distinct / runs).toFixed(1)} distinct favoured sets in 18 minutes`)
+  assert.ok(changes / runs >= 8, `the bar changed its mind only ${(changes / runs).toFixed(1)} times in 18 minutes`)
+  assert.ok(changes / runs <= 60, `${(changes / runs).toFixed(1)} changes in 18 minutes is not "slowly"`)
+})
+
+test("nothing lands mid-phrase: the matrix is frozen between `advance` calls", () => {
+  // The guarantee PULSE's phrase cache is built on, and the guarantee that a
+  // bar a child is two beats into cannot become a different bar.
+  const g = grooveOn(pickSoundscape(21), EIGHTHS)
+  play(g, 60)
+  const before = JSON.stringify(g.matrix(EIGHTHS))
+  const revision = g.revision
+  g.agree()
+  g.agree()
+  g.makeRoom()
+  g.retune(pickSoundscape(999))
+  g.advance(1) // less than BARS_PER_MUTATION: banked, not spent
+  assert.equal(JSON.stringify(g.matrix(EIGHTHS)), before, "something moved without a mutation")
+  assert.equal(g.revision, revision, "the revision moved without the matrix")
+  g.advance(BARS_PER_MUTATION)
+  assert.notEqual(JSON.stringify(g.matrix(EIGHTHS)), before, "the boundary did not spend what was banked")
+  assert.equal(g.revision, revision + 1)
+})
+
+test("the same seed is the same session, and two seeds are two sessions", () => {
+  const fingerprint = (seed: number): string => {
+    const g = grooveOn(pickSoundscape(3), EIGHTHS, seed)
+    const out: string[] = []
+    for (let i = 0; i < 40; i++) {
+      if (i % 4 === 0) g.agree()
+      if (i % 7 === 0) g.makeRoom()
+      g.advance(BARS_PER_MUTATION)
+      out.push(g.matrix(EIGHTHS).map((s) => s.p.toFixed(6)).join(","))
+    }
+    return out.join("|")
+  }
+  assert.equal(fingerprint(1234), fingerprint(1234), "the same seed must replay exactly")
+  let diverged = 0
+  for (let s = 0; s < 60; s++) if (fingerprint(s) !== fingerprint(s + 1)) diverged++
+  assert.equal(diverged, 60, "two different seeds gave the same session")
+})
+
+test("the drift rate does not depend on how fine the grid is", () => {
+  // A stage with twenty-three movable instants must not evolve eight times more
+  // slowly than one with three, or the child who got good gets a static game.
+  const reach = (spec: GrooveSpec): number => {
+    let total = 0
+    for (const scape of scapes(30)) {
+      const g = grooveOn(scape, spec)
+      play(g, 200)
+      let moved = 0
+      const now = g.matrix(spec)
+      const seed = g.seedMatrix(spec)
+      for (let i = 1; i < now.length; i++) {
+        if (Math.abs((now[i]?.affinity ?? 0) - (seed[i]?.affinity ?? 0)) >= 0.1) moved++
+      }
+      total += moved / Math.max(1, now.length - 1)
+    }
+    return total / 30
+  }
+  const coarse = reach(GRIDS[0]!.spec)
+  for (const { name, spec } of GRIDS.slice(1)) {
+    const fine = reach(spec)
+    assert.ok(
+      fine > coarse * 0.8 && fine < coarse * 1.25,
+      `${name} moved ${(fine * 100).toFixed(1)}% of its instants and quarters moved ${(coarse * 100).toFixed(1)}%`,
+    )
+  }
+})
+
+test("the downbeat is never handed to the walk at all", () => {
+  // Belt AND braces, and both are needed for different reasons. `grooveMatrix`
+  // forces the downbeat's probability to 1, so a lean on it would be inert
+  // rather than dangerous — but every mutation event spent on an instant that
+  // cannot move is a mutation event the rest of the bar did not get, which is
+  // the drift quietly running an eighth slower than it says it does.
+  for (const scape of scapes(20)) {
+    for (const { name, spec } of GRIDS) {
+      const g = grooveOn(scape, spec)
+      for (let i = 0; i < 200; i++) {
+        if (i % 3 === 0) g.agree()
+        if (i % 4 === 0) g.makeRoom()
+        g.advance(BARS_PER_MUTATION)
+        assert.equal(g.leanAt(0), 0, `${scape.modeId} ${name}: something moved the downbeat`)
+      }
+    }
+  }
+})
+
+// ── job 2: right and wrong, in opposite directions ───────────────────────────
+
+test("right ADDS and wrong REMOVES — on every grid PULSE plays", () => {
+  for (const { name, spec } of GRIDS) {
+    let rightWins = 0
+    let rightNet = 0
+    let wrongNet = 0
+    const runs = 200
+    for (let s = 0; s < runs; s++) {
+      const scape = pickSoundscape(s * 2654435761)
+      const right = grooveOn(scape, spec)
+      const wrong = grooveOn(scape, spec)
+      for (let i = 0; i < 8; i++) {
+        right.agree()
+        right.advance(BARS_PER_MUTATION)
+        wrong.makeRoom()
+        wrong.advance(BARS_PER_MUTATION)
+      }
+      const r = netOpened(right, spec)
+      const w = netOpened(wrong, spec)
+      rightNet += r
+      wrongNet += w
+      if (r > w) rightWins++
+    }
+    assert.ok(rightNet / runs > 0.8, `${name}: eight right answers netted only ${(rightNet / runs).toFixed(2)} instants`)
+    assert.ok(wrongNet / runs < -0.8, `${name}: eight wrong answers netted ${(wrongNet / runs).toFixed(2)}`)
+    assert.ok(rightWins >= 190, `${name}: right beat wrong in only ${rightWins} of ${runs} runs`)
+  }
+})
+
+test("being right never hands a child a busier bar", () => {
+  // The whole reason right ADDS an instant rather than a note. If this ever
+  // fails, correctness has started buying difficulty, which is a punishment
+  // wearing a reward's clothes.
+  for (const { name, spec } of GRIDS) {
+    for (const scape of scapes(60)) {
+      const g = grooveOn(scape, spec)
+      const before = expectedNotes(g.seedMatrix(spec))
+      for (let i = 0; i < 12; i++) {
+        g.agree()
+        g.advance(BARS_PER_MUTATION)
+      }
+      assert.ok(
+        Math.abs(expectedNotes(g.matrix(spec)) - before) < 1e-9,
+        `${name} ${scape.modeId}: twelve right answers changed the bar from ${before.toFixed(3)} to ${expectedNotes(g.matrix(spec)).toFixed(3)} notes`,
+      )
+    }
+  }
+})
+
+test("being wrong leaves room — a little, briefly, and never more than a quarter", () => {
+  for (const { name, spec } of GRIDS) {
+    for (const scape of scapes(30)) {
+      const g = grooveOn(scape, spec)
+      const seed = expectedNotes(g.seedMatrix(spec))
+      // Everything wrong, over and over. The worst a child could ever do.
+      for (let i = 0; i < 30; i++) {
+        g.makeRoom()
+        g.advance(BARS_PER_MUTATION)
+      }
+      const worst = expectedNotes(g.matrix(spec))
+      assert.ok(worst < seed, `${name} ${scape.modeId}: a miss made no room at all`)
+      assert.ok(
+        worst >= seed * (1 - MAX_OPENNESS) - 1e-6,
+        `${name} ${scape.modeId}: the bar thinned to ${worst.toFixed(3)} from ${seed.toFixed(3)} — past the cap`,
+      )
+      assert.ok(g.openness <= 1 + 1e-9, "openness ran past its own ceiling")
+    }
+  }
+})
+
+test("the room a miss makes comes back WITHOUT the child earning it", () => {
+  // A miss is the teaching moment, so the recovery must be on the clock. A
+  // groove that only closed up again on a right answer would be a groove
+  // holding a mistake against a child.
+  for (const scape of scapes(30)) {
+    const g = grooveOn(scape, EIGHTHS)
+    g.makeRoom()
+    g.advance(BARS_PER_MUTATION)
+    const opened = g.openness
+    assert.ok(opened > 0.3, `a miss opened only ${opened.toFixed(3)}`)
+    // Six more phrases and nothing but silence from the child.
+    play(g, 24)
+    assert.ok(g.openness < opened * 0.25, `still ${g.openness.toFixed(3)} open six phrases later`)
+  }
+})
+
+test("wrong never touches the pulse — only decoration backs off", () => {
+  // "Space to think", not a hole in the beat. On a grid with subdivisions, what
+  // a miss takes down must be an offbeat.
+  const spec = GRIDS[3]!.spec
+  let onBeatHits = 0
+  let offBeatHits = 0
+  for (const scape of scapes(60)) {
+    const g = grooveOn(scape, spec)
+    const seed = g.seedMatrix(spec)
+    for (let i = 0; i < 6; i++) {
+      g.makeRoom()
+      g.advance(BARS_PER_MUTATION)
+    }
+    const now = g.matrix(spec)
+    for (let i = 1; i < now.length; i++) {
+      const dropped = (seed[i]?.affinity ?? 0) - (now[i]?.affinity ?? 0)
+      if (dropped < 0.2) continue
+      if (Math.abs((now[i]?.beat ?? 0) - Math.round(now[i]?.beat ?? 0)) < 1e-6) onBeatHits++
+      else offBeatHits++
+    }
+  }
+  assert.ok(offBeatHits > 0, "a miss took nothing down at all")
+  assert.ok(
+    offBeatHits > onBeatHits * 3,
+    `a miss hit ${onBeatHits} beats against ${offBeatHits} offbeats — that is the pulse, not decoration`,
+  )
+})
+
+// ── job 3's other half: a key change is a modulation, not a restart ──────────
+
+test("a new key keeps the drift, and lands at a phrase boundary", () => {
+  const g = grooveOn(pickSoundscape(5), EIGHTHS)
+  for (let i = 0; i < 10; i++) {
+    g.agree()
+    g.advance(BARS_PER_MUTATION)
+  }
+  /**
+   * The walk itself, and not its visible effect on the matrix.
+   *
+   * Reading the leans out of the matrix does not work here, and the failed
+   * attempt is worth recording: `leanAffinity` is bounded by whatever the mode
+   * already said about an instant, so a lean of +0.8 on an instant the NEW mode
+   * has already put at 1.0 shows up as a change of exactly zero. Two of seven
+   * instants did that on the first run of this test, which looked like lost
+   * state and was correct behaviour. The state is the leans.
+   */
+  const walk = (): string =>
+    g
+      .matrix(EIGHTHS)
+      .slice(1)
+      .map((s) => g.leanAt(s.beat).toFixed(6))
+      .join(",")
+
+  const before = walk()
+  assert.ok(
+    before.split(",").some((v) => Math.abs(Number(v)) > 0.05),
+    "the fixture did not drift, so this proves nothing",
+  )
+
+  const next = pickSoundscape(77)
+  assert.notEqual(next.modeId, g.soundscape.modeId, "pick a genuinely different key for the fixture")
+  const frozen = JSON.stringify(g.matrix(EIGHTHS))
+  g.retune(next)
+  assert.equal(JSON.stringify(g.matrix(EIGHTHS)), frozen, "a key change landed mid-phrase")
+
+  g.advance(BARS_PER_MUTATION)
+  assert.equal(g.soundscape.modeId, next.modeId)
+
+  // The step that landed the key also decays every lean once and wanders one
+  // instant, so the claim is that the SHAPE carried across: same signs, same
+  // ordering, nothing reset to zero.
+  const after = walk().split(",").map(Number)
+  const was = before.split(",").map(Number)
+  let reset = 0
+  let reversed = 0
+  for (let i = 0; i < was.length; i++) {
+    const w = was[i] ?? 0
+    const a = after[i] ?? 0
+    if (Math.abs(w) > 0.05 && Math.abs(a) < 0.01) reset++
+    if (Math.abs(w) > 0.05 && Math.abs(a) > 0.01 && Math.sign(a) !== Math.sign(w)) reversed++
+  }
+  assert.equal(reset, 0, `${reset} leans were wiped by the key change (${before} → ${after.join(",")})`)
+  assert.ok(reversed <= 1, `${reversed} leans reversed across the key change`)
+})
+
+test("every mode in the corpus survives an hour of drift", () => {
+  for (const mode of MODES) {
+    const scape: Soundscape = { modeId: mode.id, rootHz: 130.81, seed: 11, tension: 0.3 }
+    for (const { name, spec } of GRIDS) {
+      const g = grooveOn(scape, spec)
+      for (let i = 0; i < 300; i++) {
+        if (i % 2 === 0) g.agree()
+        if (i % 7 === 0) g.makeRoom()
+        g.advance(BARS_PER_MUTATION)
+      }
+      const m = g.matrix(spec)
+      assert.equal(m[0]?.p, 1, `${mode.id} ${name}: lost the downbeat`)
+      for (const s of m) assert.ok(Number.isFinite(s.p), `${mode.id} ${name}: p=${s.p}`)
+      // Every subdivision the stage teaches is still reachable, which is the
+      // property `chart.test.ts` holds the other end of.
+      for (const div of spec.divs) {
+        assert.ok(
+          m.some((s) => s.div === div && s.p > 0.02),
+          `${mode.id} ${name}: the drift made 1/${div} unreachable`,
+        )
+      }
+    }
+  }
+})
+
+test("a caller that says something absurd cannot break a groove", () => {
+  const g = grooveOn(pickSoundscape(2), EIGHTHS)
+  for (const bars of [0, -5, Number.NaN, Infinity, -Infinity]) {
+    const before = g.revision
+    g.advance(bars)
+    assert.equal(g.revision, before, `advance(${bars}) moved the shape`)
+  }
+  // An enormous jump is bounded work, not a hang, and still a legal matrix.
+  g.advance(1e9)
+  for (const s of g.matrix(EIGHTHS)) assert.ok(Number.isFinite(s.p) && s.p >= 0 && s.p <= 1)
+  assert.ok(g.bars > 0)
+})

--- a/dynawalla/packs/shared/game-soundscape/evolve.test.ts
+++ b/dynawalla/packs/shared/game-soundscape/evolve.test.ts
@@ -348,6 +348,42 @@ test("right ADDS and wrong REMOVES — on every grid PULSE plays", () => {
   }
 })
 
+test("a burst of right answers opens DIFFERENT instants, not one instant harder", () => {
+  /**
+   * The plural in the brief — *"add and remove different beats"* — and a real
+   * regression, caught in review rather than by a test.
+   *
+   * `step()` used to snapshot the field once and spend every pending gesture
+   * against it, so four right answers inside one phrase all scored the SAME
+   * instant highest and piled four steps onto one beat, saturating it instead
+   * of opening four. Re-reading between gestures fixes it, and this counts the
+   * result: a bigger burst lifts strictly more instants, up to the point where
+   * the tether and the ceiling take over.
+   */
+  const spec = GRIDS[3]!.spec
+  const lifted = (n: number): number => {
+    let total = 0
+    for (const scape of scapes(60)) {
+      const g = grooveOn(scape, spec)
+      const before = g.matrix(spec).slice(1).map((s) => g.leanAt(s.beat))
+      for (let i = 0; i < n; i++) g.agree()
+      g.advance(BARS_PER_MUTATION)
+      const after = g.matrix(spec).slice(1).map((s) => g.leanAt(s.beat))
+      for (let i = 0; i < before.length; i++) {
+        if ((after[i] ?? 0) - (before[i] ?? 0) > 0.2) total++
+      }
+    }
+    return total / 60
+  }
+  const one = lifted(1)
+  const four = lifted(4)
+  assert.ok(one >= 1, `one right answer lifted only ${one.toFixed(2)} instants`)
+  assert.ok(
+    four > one * 1.4,
+    `four right answers lifted ${four.toFixed(2)} instants against ${one.toFixed(2)} for one — a burst is landing on the same beat`,
+  )
+})
+
 test("being right never hands a child a busier bar", () => {
   // The whole reason right ADDS an instant rather than a note. If this ever
   // fails, correctness has started buying difficulty, which is a punishment

--- a/dynawalla/packs/shared/game-soundscape/evolve.ts
+++ b/dynawalla/packs/shared/game-soundscape/evolve.ts
@@ -189,6 +189,18 @@ const SLOTS_PER_MUTATION = 8
 const COMMIT_STEP = 0.28
 const OPEN_STEP = 0.28
 
+/**
+ * How many answers one phrase boundary will spend.
+ *
+ * `advance` already clamps a caller that hands over a nonsense number of bars;
+ * this is the same guard on the other input, because each pending gesture now
+ * re-reads the field and so costs a matrix build. Six is far above anything a
+ * game can produce in four bars — PULSE serves a gate every five or six bars —
+ * and it means a caller that reported a thousand answers between boundaries
+ * pays for six of them rather than for a thousand.
+ */
+const MAX_PENDING = 6
+
 /** A lean below this is not worth carrying, and dropping it keeps the map small. */
 const LEAN_EPSILON = 1e-4
 
@@ -400,25 +412,30 @@ export class Groove {
     }
     this.room *= Math.pow(0.5, BARS_PER_MUTATION / ROOM_HALF_LIFE_BARS)
 
-    const live = this.liveSlots()
-
-    // What the child did, spent first: correctness STEERS the walk and the
-    // random step EXPLORES from wherever the steering left it. That ordering is
-    // the design — the other way round, a run of right answers would be
-    // scribbled over by the noise that followed it in the same step.
-    for (let i = 0; i < this.pending.agree; i++) this.commit(live)
-    for (let i = 0; i < this.pending.room; i++) this.open(live)
-    if (this.pending.room > 0) {
-      this.room = Math.min(1, this.room + ROOM_PER_MISS * Math.min(3, this.pending.room))
-    }
-    if (this.pending.agree > 0) {
-      this.room *= Math.pow(ROOM_KEPT_ON_AGREE, Math.min(3, this.pending.agree))
-    }
+    /**
+     * What the child did, spent first: correctness STEERS the walk and the
+     * random step EXPLORES from wherever the steering left it. That ordering is
+     * the design — the other way round, a run of right answers would be
+     * scribbled over by the noise that followed it in the same step.
+     *
+     * **The field is re-read between gestures**, and it has to be. Four right
+     * answers inside one phrase read against a snapshot all scored the SAME
+     * instant highest and piled 4 x `COMMIT_STEP` onto it, saturating one beat
+     * instead of opening four — which contradicts both the plural in the brief
+     * ("add … different beats") and this file's own prose. Re-reading costs one
+     * matrix build per gesture, and `MAX_PENDING` is what bounds that.
+     */
+    const answered = Math.min(MAX_PENDING, this.pending.agree)
+    const missed = Math.min(MAX_PENDING, this.pending.room)
+    for (let i = 0; i < answered; i++) this.commit(this.liveSlots())
+    for (let i = 0; i < missed; i++) this.open(this.liveSlots())
+    if (missed > 0) this.room = Math.min(1, this.room + ROOM_PER_MISS * Math.min(3, missed))
+    if (answered > 0) this.room *= Math.pow(ROOM_KEPT_ON_AGREE, Math.min(3, answered))
     this.pending.agree = 0
     this.pending.room = 0
 
-    // And then the stochastic part: one instant, either way, every phrase.
-    this.wander(live)
+    // And then the stochastic part, over the field the steering just left.
+    this.wander(this.liveSlots())
 
     this.rev += 1
   }

--- a/dynawalla/packs/shared/game-soundscape/evolve.ts
+++ b/dynawalla/packs/shared/game-soundscape/evolve.ts
@@ -1,0 +1,587 @@
+/**
+ * The groove as something ALIVE: a bar that drifts away from its seed, slowly,
+ * and that right and wrong answers steer in opposite directions.
+ *
+ * The founder's brief, and the whole of what this file is for:
+ *
+ * > *"pulse is somewhat improved but it needs to gradually evolve more — the
+ * > main rhythm is static. I think slowly things should evolve and change
+ * > stochastically. so there is sort of the seed but it should be able to go
+ * > almost anywhere. Maybe being 'right' or 'wrong' should affect the beat in
+ * > different ways. We don't have to just use random but random is a good
+ * > friend. Add and remove different beats with probability .. slowly evolve."*
+ *
+ * ## What was static, exactly
+ *
+ * `grooveMatrix` is a pure function of the soundscape and the stage. PULSE
+ * calls it once per phrase with the same two arguments, so it gets the same
+ * twenty-four probabilities back every phrase of every minute of the run. The
+ * *draw* differed — a phrase is a fresh stream — but the BIAS never did, so the
+ * same two or three instants won every coin toss forever and the bar had a
+ * shape a child had heard all of within about forty seconds. That is what
+ * "static" means here: not that the notes repeat, but that the thing choosing
+ * them never changed its mind.
+ *
+ * ## The mechanism, and the three things that stop it becoming noise
+ *
+ * One number per instant of the bar, `-1..1`, on top of what the mode said.
+ * Every few bars, one of them moves. That is the whole of it, and everything
+ * else here is a constraint on it.
+ *
+ *   1. **The metre is not in the walk.** `grooveMatrix` drifts the mode's
+ *      affinity and never the metric weight, so a downbeat outranks a halfway
+ *      point outranks a sixteenth no matter where the walk has got to. A groove
+ *      that drifted its own skeleton would be a groove in name only after four
+ *      minutes. The downbeat itself is not in the walk at all — it is not
+ *      negotiable and never was.
+ *   2. **The walk is tethered, not free.** Every mutation decays every lean
+ *      toward zero (`SEED_HALF_LIFE_BARS`). That is a mean-reverting walk
+ *      rather than a Brownian one, and it is the exact shape of what was asked
+ *      for: *"there is sort of the seed but it should be able to go almost
+ *      anywhere"*. Anywhere — the stationary spread is wide and no instant is
+ *      pinned — but with a home it keeps falling back through rather than a
+ *      trajectory it leaves on. Individual leans cross back through zero
+ *      dozens of times in a long session; `evolve.test.ts` counts them.
+ *   3. **Nothing lands mid-phrase.** `matrix()` is stable between `advance()`
+ *      calls, always. A game advances at a phrase boundary and the shape
+ *      changes there or not at all, so a bar a child is two beats into can
+ *      never become a different bar. This is also what makes a phrase cache
+ *      safe, which PULSE needs.
+ *
+ * ## Right and wrong, which must not be a reward and a punishment
+ *
+ * The fleet's rule is that a miss is the teaching moment, so a wrong answer may
+ * never sound like a buzzer and may never make the next thing harder. The
+ * asymmetry here is the founder's own pair of verbs — *"add and remove
+ * different beats"* — pointed in two DIRECTIONS rather than at two volumes:
+ *
+ *   * **Right → the groove ADDS.** `agree()` lights up an instant it had been
+ *     ignoring: the one with the most room that the metre would most like to
+ *     hear. The bar keeps finding new places to sit while the child is holding
+ *     it together, which is what it sounds like when a band opens up around
+ *     somebody who is playing well. **It adds no notes.** The density budget is
+ *     renormalised, so the expected count is exactly what the stage asked for
+ *     and what changed is WHERE. Rewarding correctness with a busier bar would
+ *     be rewarding it with a harder game, which is the oldest way there is to
+ *     punish someone.
+ *   * **Wrong → the groove REMOVES.** `makeRoom()` takes the busiest
+ *     DECORATION down — never a beat, never the downbeat — and leaves a little
+ *     space in the bar for a few phrases. It is a band backing off while
+ *     somebody thinks, and it comes back by itself whether or not the next
+ *     answer is right, because it expires on the clock and not on merit
+ *     (`ROOM_HALF_LIFE_BARS`). Nothing is removed permanently, nothing goes
+ *     red, and the bar never speeds up or slows down: there is no tempo in this
+ *     module and this file does not add one.
+ *
+ * The space is capped at `MAX_OPENNESS` — a quarter of the budget — so playing
+ * badly on purpose buys a barely-thinner bar and never an easier game.
+ *
+ * Measured, 200 seeds per grid: a run of eight right answers leaves the groove
+ * with a net +1.5 to +2.4 instants opened, a run of eight wrong ones with a net
+ * −1.3 to −3.9, and right lands above wrong in 196 to 200 runs of 200 on every
+ * grid PULSE plays. Right leaves the expected note count bit-identical to the
+ * stage's in 60 of 60 seeds.
+ *
+ * ## The rate
+ *
+ * Measured in BARS, because bars are the only musical unit a caller can supply
+ * without this module growing a tempo primitive it has no business owning. One
+ * mutation event per `BARS_PER_MUTATION` bars; a lean's memory of its seed
+ * halves every `SEED_HALF_LIFE_BARS`. At PULSE's opening tempo that is one
+ * instant moving every twelve seconds and a shape whose favoured instants turn
+ * over about every sixty-five seconds — a child notices it the way they notice
+ * the light changing, which is what *"slowly evolve"* asks for and is why the
+ * numbers are in this file rather than in a game's.
+ *
+ * No Web Audio, no DOM, no timers, no frequency. Everything is arithmetic over
+ * a seeded stream, so a whole afternoon of drift is assertable in a
+ * millisecond.
+ */
+
+import {
+  grooveMatrix,
+  type GrooveBias,
+  type GrooveSlot,
+  type GrooveSpec,
+} from "./groove.ts"
+import { Rng } from "./rng.ts"
+import type { Soundscape } from "./soundscape.ts"
+
+/**
+ * How many bars pass between one instant moving and the next.
+ *
+ * Four, which is one phrase in every game that has asked so far, and the reason
+ * it is four rather than one is the whole of *"slowly"*. A mutation a bar would
+ * be a bar that is different every time it comes round, which is not evolution
+ * — it is a bar with no identity. A mutation a phrase means the shape a child
+ * has just learnt survives long enough to be learnt.
+ */
+export const BARS_PER_MUTATION = 4
+
+/**
+ * How long a lean remembers the seed, in bars.
+ *
+ * The tether, and with `MUTATION_STEP` it is the pair that decides how far
+ * "almost anywhere" reaches. A hundred and forty-four bars is about six and a
+ * half minutes at PULSE's tempi: a shape put in place by a run of right answers
+ * is still recognisably there three minutes later and mostly gone ten minutes
+ * later. Shorter and the drift is a shimmer that never gets anywhere; longer
+ * and an early accident becomes the rest of the session.
+ *
+ * The two together were fitted against a measurement rather than chosen: at
+ * these values a groove's favoured instants have moved 8% away from the seed
+ * after a minute, 15% after nine, and never further — the walk reaches its
+ * spread and stays inside it for an hour of play.
+ */
+export const SEED_HALF_LIFE_BARS = 144
+
+/** How long the room a miss makes lasts, in bars. Two phrases, then mostly gone. */
+export const ROOM_HALF_LIFE_BARS = 8
+
+/**
+ * How far one random mutation may move one instant.
+ *
+ * Signed and uniform, so *"add and remove different beats with probability"* is
+ * one draw and not two mechanisms. The stationary spread this produces against
+ * `SEED_HALF_LIFE_BARS` is measured rather than asserted by eye — see
+ * `evolve.test.ts`, which holds both ends of it: far enough to be a different
+ * groove, near enough that no instant ever pins.
+ */
+const MUTATION_STEP = 0.7
+
+/** How much room one wrong answer asks for, and how much one right answer takes back. */
+const ROOM_PER_MISS = 0.55
+const ROOM_KEPT_ON_AGREE = 0.5
+
+/**
+ * The bar shape a groove walks over before anybody has told it another.
+ *
+ * Quarters and a bar of four: the narrowest thing that is still a bar. The
+ * universe WIDENS to the union of every grid the groove is shown (see
+ * `remember`), so this is a floor and not an assumption — a groove nobody ever
+ * asks for a matrix still has somewhere to walk.
+ */
+const DEFAULT_BEATS_PER_BAR = 4
+const DEFAULT_DIVS: readonly number[] = [1]
+
+/** How strongly the walk prefers decoration to the pulse. */
+const ORNAMENT_LEAN = 0.55
+
+/**
+ * How many instants one mutation event moves: one per this many live slots.
+ *
+ * The drift rate has to be a property of TIME and not of how fine the grid
+ * happens to be. PULSE's opening stage has three movable instants and its last
+ * has twenty-three; one mutation per phrase in both would mean the groove
+ * evolved eight times more slowly for the child who got good, which is exactly
+ * backwards. Holding the per-instant rate constant instead means "the shape
+ * turns over in about this many minutes" is true at every stage.
+ */
+const SLOTS_PER_MUTATION = 8
+
+/**
+ * How much of a lean's range one right answer, or one wrong one, is worth.
+ *
+ * Four answers takes an instant the whole way, which is the right coarseness:
+ * one gate is a nudge a child would not name, and a stage's worth of them is a
+ * groove that has visibly made up its mind.
+ */
+const COMMIT_STEP = 0.28
+const OPEN_STEP = 0.28
+
+/** A lean below this is not worth carrying, and dropping it keeps the map small. */
+const LEAN_EPSILON = 1e-4
+
+type Pending = {
+  /** Right answers waiting for the next phrase boundary. */
+  agree: number
+  /** Wrong answers waiting for the next phrase boundary. */
+  room: number
+  /** A key the host published, waiting for the same boundary. */
+  scape: Soundscape | null
+}
+
+/**
+ * A living groove: the seed matrix, plus where it has wandered to.
+ *
+ * Stateful on purpose, in the way `Melody` is: the whole claim is that where
+ * the bar is now depends on what has already happened. The state is held in an
+ * object the game owns and the randomness comes from a seed, so two runs from
+ * one seed are the same session note for note and two different seeds are not.
+ */
+export class Groove {
+  private scape: Soundscape
+  private readonly rng: Rng
+  /** Beat offset → lean, `-1..1`. Absent means "the mode's own opinion". */
+  private readonly leans = new Map<number, number>()
+  private room = 0
+  private rev = 0
+  private barsBanked = 0
+  private barsTotal = 0
+  private beatsPerBar = DEFAULT_BEATS_PER_BAR
+  private divs: readonly number[] = [...DEFAULT_DIVS]
+  private readonly pending: Pending = { agree: 0, room: 0, scape: null }
+
+  /**
+   * @param scape the key the host published; the seed of the walk, not a cage.
+   * @param seed  the stream the walk is drawn from. Defaults to the
+   *   soundscape's own, which is right for a game with one groove; a game that
+   *   wants a different walk each run — PULSE does, its run seed is its
+   *   identity — passes its own and gets one that is still reproducible.
+   */
+  constructor(scape: Soundscape, seed?: number) {
+    this.scape = scape
+    this.rng = new Rng(typeof seed === "number" && Number.isFinite(seed) ? seed : scape.seed)
+  }
+
+  /** The key this groove is in. */
+  get soundscape(): Soundscape {
+    return this.scape
+  }
+
+  /**
+   * How many times the shape has changed.
+   *
+   * Exported because it is exactly the right cache key for a caller that
+   * memoises phrases: it changes when and only when `matrix()` would answer
+   * differently, so a phrase rebuilt after a cache eviction inside the same
+   * phrase is rebuilt identically. PULSE relies on that.
+   */
+  get revision(): number {
+    return this.rev
+  }
+
+  /** Bars of music this groove has lived through. */
+  get bars(): number {
+    return this.barsTotal
+  }
+
+  /**
+   * How much room the bar is currently leaving, `0..1`.
+   *
+   * `0` is the density the stage asked for. `1` is `MAX_OPENNESS` of it handed
+   * back. For a debug read-out and for tests; nothing about a game's behaviour
+   * should read it.
+   */
+  get openness(): number {
+    return this.room
+  }
+
+  /**
+   * Where one instant of the bar has been pushed to, `-1..1`. `0` is the
+   * mode's own untouched opinion.
+   *
+   * For a debug read-out and for tests, in the same spirit as
+   * `Melody.position` — the walk is the claim this module makes, and a claim
+   * that cannot be observed cannot be checked. Reading it back out of the
+   * matrix does NOT work: `leanAffinity` is bounded by what the mode already
+   * said, so an instant the mode has already put at 1 shows a lean of +0.8 as
+   * a change of exactly zero. That is correct behaviour and it is invisible.
+   *
+   * Nothing about a game's behaviour should read this.
+   */
+  leanAt(beat: number): number {
+    return this.leans.get(beat) ?? 0
+  }
+
+  /** The bar as it stands, at this stage's grid and density. */
+  matrix(spec: GrooveSpec): GrooveSlot[] {
+    this.remember(spec)
+    return grooveMatrix(this.scape, spec, this.bias())
+  }
+
+  /** The seed bar — where this groove started, and what it is drifting from. */
+  seedMatrix(spec: GrooveSpec): GrooveSlot[] {
+    return grooveMatrix(this.scape, spec)
+  }
+
+  /**
+   * How far the shape has travelled, `0..1`: the mean absolute change in a
+   * slot's probability against the seed matrix.
+   *
+   * The number the design is argued in. A drift that cannot be measured is a
+   * drift that can be switched off without anything failing, which is how the
+   * last generator in this lineage shipped with its matrix inert.
+   */
+  distanceFromSeed(spec: GrooveSpec): number {
+    const now = this.matrix(spec)
+    const seed = this.seedMatrix(spec)
+    if (now.length === 0) return 0
+    let total = 0
+    for (let i = 0; i < now.length; i++) total += Math.abs((now[i]?.p ?? 0) - (seed[i]?.p ?? 0))
+    return total / now.length
+  }
+
+  /**
+   * Music happened. Nothing moves until a whole `BARS_PER_MUTATION` has passed,
+   * and then everything that was waiting moves at once.
+   *
+   * A caller passes the bars it just played — a phrase, usually — and calls it
+   * at a phrase boundary. Calling it mid-phrase is not wrong, it is simply
+   * early: the shape still only turns over at the boundary the bar budget
+   * crosses, which is what the "nothing lands mid-phrase" guarantee is made of.
+   */
+  advance(bars: number): void {
+    if (!Number.isFinite(bars) || bars <= 0) return
+    this.barsBanked += bars
+    this.barsTotal += bars
+    // A guard and not a loop bound: a caller that slept for an hour and handed
+    // over four hundred bars gets four hundred bars of drift, but a caller that
+    // handed over a nonsense number cannot spin.
+    let steps = Math.floor(this.barsBanked / BARS_PER_MUTATION)
+    this.barsBanked -= steps * BARS_PER_MUTATION
+    if (steps <= 0) return
+    steps = Math.min(steps, 512)
+    for (let i = 0; i < steps; i++) this.step()
+  }
+
+  /**
+   * Something the child was trying to do WORKED.
+   *
+   * Not "make it louder" and not "add a note": the groove leans harder into the
+   * instant it already likes most, so the bar it plays next is a more decided
+   * version of the bar it was already playing. Music agreeing with you.
+   *
+   * Takes effect at the next `advance()`, like everything else here.
+   */
+  agree(): void {
+    this.pending.agree += 1
+  }
+
+  /**
+   * It did NOT — and this is the one method in the module that has to be read
+   * as a design document rather than as a setter.
+   *
+   * A wrong answer must never sound like punishment. So this does not thin the
+   * pulse, does not mute anything, does not slow anything down and does not
+   * make a noise at all: it takes the busiest piece of DECORATION down a step
+   * and leaves a little space in the bar. That is what a band does when the
+   * person out front needs a second, and a child reads it as room rather than
+   * as a verdict. It expires on the clock (`ROOM_HALF_LIFE_BARS`), so nothing
+   * has to be earned back.
+   */
+  makeRoom(): void {
+    this.pending.room += 1
+  }
+
+  /**
+   * The app changed key.
+   *
+   * The drift is KEPT, exactly as `Melody.retune` keeps the walker's degree and
+   * for the same reason: a lean is a statement about an instant of the bar, and
+   * an instant of the bar means the same thing in the new mode. Carrying it
+   * across makes a key change sound like a modulation of the groove that was
+   * playing rather than like one groove stopping and a different one starting.
+   *
+   * Queued to the next `advance()` so a key that arrives on a settings push
+   * cannot re-shape a bar a child is halfway through.
+   */
+  retune(scape: Soundscape): void {
+    this.pending.scape = scape
+  }
+
+  // ── the walk ───────────────────────────────────────────────────────────────
+
+  private step(): void {
+    const scape = this.pending.scape
+    if (scape !== null) {
+      this.scape = scape
+      this.pending.scape = null
+    }
+
+    // The tether, first: every lean forgets a little of wherever it got to, so
+    // the seed is a place the walk keeps falling back through rather than a
+    // point it leaves once.
+    const decay = Math.pow(0.5, BARS_PER_MUTATION / SEED_HALF_LIFE_BARS)
+    for (const [beat, lean] of [...this.leans]) {
+      const next = lean * decay
+      if (Math.abs(next) < LEAN_EPSILON) this.leans.delete(beat)
+      else this.leans.set(beat, next)
+    }
+    this.room *= Math.pow(0.5, BARS_PER_MUTATION / ROOM_HALF_LIFE_BARS)
+
+    const live = this.liveSlots()
+
+    // What the child did, spent first: correctness STEERS the walk and the
+    // random step EXPLORES from wherever the steering left it. That ordering is
+    // the design — the other way round, a run of right answers would be
+    // scribbled over by the noise that followed it in the same step.
+    for (let i = 0; i < this.pending.agree; i++) this.commit(live)
+    for (let i = 0; i < this.pending.room; i++) this.open(live)
+    if (this.pending.room > 0) {
+      this.room = Math.min(1, this.room + ROOM_PER_MISS * Math.min(3, this.pending.room))
+    }
+    if (this.pending.agree > 0) {
+      this.room *= Math.pow(ROOM_KEPT_ON_AGREE, Math.min(3, this.pending.agree))
+    }
+    this.pending.agree = 0
+    this.pending.room = 0
+
+    // And then the stochastic part: one instant, either way, every phrase.
+    this.wander(live)
+
+    this.rev += 1
+  }
+
+  /**
+   * One instant moves, up or down, drawn from this groove's own stream.
+   *
+   * Weighted toward decoration, because the finer subdivisions are where a
+   * groove is allowed to be surprising and the beats are where it has to be
+   * dependable. A beat can still move — `ORNAMENT_LEAN` is a lean and not a
+   * ban, and a groove whose beats never moved could not travel far — it simply
+   * moves about half as often as an offbeat does.
+   */
+  private wander(live: readonly LiveSlot[]): void {
+    if (live.length === 0) return
+    const weights = live.map((s) => Math.max(0.1, 1 - s.metre * ORNAMENT_LEAN))
+    const moves = Math.max(1, Math.round(live.length / SLOTS_PER_MUTATION))
+    for (let i = 0; i < moves; i++) {
+      const slot = live[this.rng.weighted(weights)]
+      if (!slot) return
+      this.nudge(slot.beat, (this.rng.next() * 2 - 1) * MUTATION_STEP)
+    }
+  }
+
+  /**
+   * Right: the groove ANSWERS — an instant it had been ignoring lights up.
+   *
+   * **Two designs were built and measured before this one, and both failed for
+   * the same reason**, which is worth writing down because it is the whole
+   * argument for the shape this ended up.
+   *
+   * The obvious reading of *"the music agreeing with you"* is that the groove
+   * leans harder into what it is already doing, so the first version pushed the
+   * instant with the highest `p`. It does almost nothing, and the arithmetic
+   * says why: `leanAffinity` moves an instant inside the range the mode allowed
+   * it, so an instant that is already at 0.9 has 0.1 of headroom upward and
+   * 0.55 downward. The strongest instant is by definition the one with the
+   * least room to get stronger. Measured over 60 seeds and eight right answers,
+   * it beat an untouched groove 38 times — a coin, on the metric it was built
+   * to move. (Drawing the target in proportion to `p` rather than taking the
+   * argmax was worse still: 30 of 60, because six pushes landed on five
+   * different instants and cancelled.)
+   *
+   * So right does what the founder actually asked for — *"add … different beats
+   * with probability"* — and adds one. The target is the instant with the most
+   * room that the METRE would most like to hear, `metre × (1 − affinity)`, so
+   * what lights up is a musically sensible place and not the most obscure
+   * corner of the grid. **It adds no notes**: the density budget is
+   * renormalised, so the bar keeps the exact expected note count the stage
+   * asked for and simply finds a new place to sit. A child who is getting
+   * everything right is rewarded with a groove that keeps opening up, never
+   * with a busier bar — rewarding correctness with more to hit is rewarding it
+   * with a harder game, which is the oldest way there is to punish someone.
+   */
+  private commit(live: readonly LiveSlot[]): void {
+    const slot = this.pickStrongest(
+      live,
+      (s) => s.metre * (1 - s.affinity),
+      (lean) => lean < 1,
+    )
+    if (!slot) return
+    this.nudge(slot.beat, COMMIT_STEP)
+  }
+
+  /**
+   * Wrong: take the busiest DECORATION down a step.
+   *
+   * Weighted by how loud an instant currently is AND by how little metric
+   * weight it carries, so what backs off is an ornament and never the pulse. On
+   * a grid that is nothing but beats — PULSE's opening stage is four quarter
+   * notes — `1 - metre` is small everywhere and the whole effect is carried by
+   * `openness` instead, which is the right answer there: there is no decoration
+   * to take away, so the bar simply leaves a little space.
+   */
+  private open(live: readonly LiveSlot[]): void {
+    const slot = this.pickStrongest(
+      live,
+      (s) => s.p * Math.max(0.05, 1 - s.metre),
+      (lean) => lean > -1,
+    )
+    if (!slot) return
+    this.nudge(slot.beat, -OPEN_STEP)
+  }
+
+  /** The instant that scores highest and still has room to move that way. */
+  private pickStrongest(
+    live: readonly LiveSlot[],
+    score: (slot: LiveSlot) => number,
+    room: (lean: number) => boolean,
+  ): LiveSlot | null {
+    let best: LiveSlot | null = null
+    let bestScore = -Infinity
+    for (const slot of live) {
+      if (!room(this.leans.get(slot.beat) ?? 0)) continue
+      const s = score(slot)
+      if (s > bestScore) {
+        bestScore = s
+        best = slot
+      }
+    }
+    return best
+  }
+
+  private nudge(beat: number, delta: number): void {
+    const next = Math.min(1, Math.max(-1, (this.leans.get(beat) ?? 0) + delta))
+    if (Math.abs(next) < LEAN_EPSILON) this.leans.delete(beat)
+    else this.leans.set(beat, next)
+  }
+
+  /**
+   * The instants currently in play, and how strong each one is right now.
+   *
+   * The downbeat is excluded from every one of the three movers, which is the
+   * cheapest possible way to state that it is not negotiable — nothing can
+   * nudge it because nothing is ever handed it.
+   */
+  private liveSlots(): LiveSlot[] {
+    const matrix = grooveMatrix(
+      this.scape,
+      { beatsPerBar: this.beatsPerBar, divs: this.divs, density: 0.5 },
+      this.bias(),
+    )
+    return matrix
+      .filter((s) => s.beat !== 0)
+      .map((s) => ({ beat: s.beat, metre: s.metre, affinity: s.affinity, p: s.p }))
+  }
+
+  /**
+   * Remember the grid the caller is actually playing, so the walk moves
+   * instants a child can hear.
+   *
+   * Without this the walk would spread itself over the finest grid the module
+   * can imagine and PULSE's opening stage — four quarter notes — would receive
+   * one audible mutation in every six. The leans of instants that are not in
+   * the current grid are KEPT and keep decaying, so a stage that goes back to
+   * triplets finds the shape it left rather than a blank one.
+   *
+   * **The UNION of every grid it has been shown, and not the last one.** One
+   * groove is asked about several grids in the same bar — PULSE reads it once
+   * for what the child plays and again for what the band plays underneath — and
+   * a last-one-wins universe would make the walk depend on the order those two
+   * calls happen to be made in, which is the kind of coupling that survives
+   * every test and breaks when somebody reorders two lines. `divs` only ever
+   * grows, and `SLOTS_PER_MUTATION` keeps the per-instant rate constant as it
+   * does, so a wider universe costs nothing.
+   */
+  private remember(spec: GrooveSpec): void {
+    this.beatsPerBar = Math.max(this.beatsPerBar, Math.max(1, Math.floor(spec.beatsPerBar)))
+    const divs = spec.divs.length > 0 ? spec.divs : [1]
+    let widened = false
+    for (const d of divs) {
+      const div = Math.max(1, Math.floor(d))
+      if (!this.divs.includes(div)) {
+        this.divs = [...this.divs, div]
+        widened = true
+      }
+    }
+    if (widened) this.divs = [...this.divs].sort((a, b) => a - b)
+  }
+
+  private bias(): GrooveBias {
+    return { at: this.leans, openness: this.room }
+  }
+}
+
+type LiveSlot = { beat: number; metre: number; affinity: number; p: number }

--- a/dynawalla/packs/shared/game-soundscape/groove.ts
+++ b/dynawalla/packs/shared/game-soundscape/groove.ts
@@ -68,6 +68,49 @@ export type GrooveSpec = {
   readonly density: number
 }
 
+/**
+ * A lean on the bar that is not the mode's and not the metre's.
+ *
+ * This is the seam `evolve.ts` drifts through, and it is a separate argument
+ * rather than a field of `GrooveSpec` because it is a different KIND of thing:
+ * a spec is what a stage wants and is written down in the game, while a bias is
+ * where a living groove has wandered to and is written down nowhere. Keeping
+ * them apart is also what keeps `grooveMatrix` honest — pass no bias and you
+ * get the seed matrix, byte for byte, forever, which is the property every test
+ * written before drift existed still rests on.
+ *
+ * **It cannot break either of the matrix's two invariants**, and that is by
+ * construction rather than by clamping afterwards. `at` moves an instant's
+ * affinity along the interval it was always allowed to occupy — `+1` takes it
+ * to exactly 1 and `-1` to exactly `MIN_AFFINITY` — so a drifted bar still
+ * colours every instant and still deletes none of them. `openness` may only
+ * ever REMOVE expected notes, never add them, so a groove that has wandered can
+ * never hand a child a fuller bar than the stage asked for.
+ */
+export type GrooveBias = {
+  /**
+   * Beat offset -> lean, `-1..1`. `0`, or a beat that is not in the map, is the
+   * mode's own opinion untouched.
+   *
+   * Keyed by BEAT and not by slot index on purpose. A game changes its
+   * subdivisions between stages — PULSE walks `[1]` to `[1,2,3,4]` — so an
+   * array indexed by slot would silently re-point every lean at a different
+   * instant the moment the grid grew. Beat 1.5 is beat 1.5 in every grid that
+   * contains it, and in the grids that do not it is simply not read.
+   */
+  readonly at: ReadonlyMap<number, number>
+  /**
+   * How much room to leave in the bar, `0..1`. `0` is the density asked for.
+   *
+   * Spends down to `MAX_OPENNESS` of the budget and no further, and never up:
+   * this exists so a groove can make SPACE, which is a thing music does when a
+   * player needs a moment. It is not a difficulty knob and it cannot become
+   * one, because the only direction it moves is toward the empty bar the
+   * downbeat still anchors.
+   */
+  readonly openness: number
+}
+
 /** One instant in the bar, and how likely this soundscape is to strike it. */
 export type GrooveSlot = {
   /** Offset from the bar line, in beats. `0` is the downbeat. */
@@ -97,6 +140,32 @@ export const MIN_AFFINITY = 0.35
 
 /** No single slot is ever a certainty except the downbeat. */
 const MAX_P = 0.95
+
+/**
+ * The most of the density budget a fully-open groove may hand back.
+ *
+ * A quarter. Enough that a child hears the bar breathe out; far too little for
+ * the emptier bar to be worth playing for. A game whose gates get easier the
+ * more you miss is a game that teaches missing, so the ceiling is the whole of
+ * why this is safe — see `evolve.ts`, which is the only thing that sets it.
+ */
+export const MAX_OPENNESS = 0.25
+
+/**
+ * A mode's opinion about an instant, leaned on by a drift.
+ *
+ * The mapping is chosen so the bounds hold with no clamp anywhere: at `b = +1`
+ * the instant is a full `1`, at `b = -1` it is exactly `MIN_AFFINITY`, and at
+ * `b = 0` it is whatever the mode said. That is why a drifted matrix passes the
+ * same "a mode colours the bar but can never delete a slot" assertion the
+ * undrifted one does, rather than passing it because something clipped.
+ */
+export function leanAffinity(affinity: number, bias: number): number {
+  if (!Number.isFinite(affinity)) return MIN_AFFINITY
+  const a = Math.min(1, Math.max(MIN_AFFINITY, affinity))
+  const b = Number.isFinite(bias) ? Math.min(1, Math.max(-1, bias)) : 0
+  return b >= 0 ? a + b * (1 - a) : a + b * (a - MIN_AFFINITY)
+}
 
 const CENTS_PER_OCTAVE = 1200
 
@@ -192,8 +261,17 @@ export function modeAffinity(scape: Soundscape, beat: number, beatsPerBar: numbe
  * The downbeat is forced to `1`. A bar with no downbeat is not a sparser bar,
  * it is a bar a child cannot find, and the whole point of starting sparse is
  * that what is left is unmistakable.
+ *
+ * `bias` is where a live groove has drifted to (`evolve.ts`). Omit it and this
+ * is the same pure function it has always been; pass it and the mode still
+ * chooses the colours and the metre still chooses the skeleton — the drift only
+ * moves an instant inside the range the mode already allowed it.
  */
-export function grooveMatrix(scape: Soundscape, spec: GrooveSpec): GrooveSlot[] {
+export function grooveMatrix(
+  scape: Soundscape,
+  spec: GrooveSpec,
+  bias?: GrooveBias,
+): GrooveSlot[] {
   const beatsPerBar = Math.max(1, Math.floor(spec.beatsPerBar))
   const divs = spec.divs.length > 0 ? spec.divs : [1]
   const density = clamp01(spec.density)
@@ -201,8 +279,19 @@ export function grooveMatrix(scape: Soundscape, spec: GrooveSpec): GrooveSlot[] 
 
   const raw = beats.map((beat) => {
     const div = divOfBeat(beat, divs)
+    // METRE IS NEVER DRIFTED, and that is the constraint that keeps a wandering
+    // groove a groove. A bar's skeleton — downbeat, then halfway, then the
+    // beats, then decoration — is a property of the bar and not of the music
+    // in it, so however far the drift travels the pulse a child is counting is
+    // still where it was. What moves is which instants the key currently
+    // FAVOURS, which is colour; what never moves is the frame that colour sits
+    // in. Take this constraint away and the walk becomes noise within a few
+    // minutes: every slot equal, every bar a coin toss.
     const metre = metreWeight(beat, beatsPerBar, div)
-    const affinity = modeAffinity(scape, beat, beatsPerBar)
+    const affinity = leanAffinity(
+      modeAffinity(scape, beat, beatsPerBar),
+      bias?.at.get(beat) ?? 0,
+    )
     return { beat, div, metre, affinity, want: metre * affinity }
   })
 
@@ -210,7 +299,7 @@ export function grooveMatrix(scape: Soundscape, spec: GrooveSpec): GrooveSlot[] 
   // `density × slots`. The downbeat is spent first and the rest of the budget
   // is shared out in proportion to `want`, re-spreading whatever the per-slot
   // ceiling refuses so the total is preserved rather than quietly lost.
-  const budget = density * raw.length
+  const budget = density * raw.length * (1 - MAX_OPENNESS * clamp01(bias?.openness ?? 0))
   const out = raw.map((s) => ({ ...s, p: s.beat === 0 ? 1 : 0 }))
   let remaining = Math.max(0, budget - 1)
   const open = out.filter((s) => s.beat !== 0)

--- a/dynawalla/packs/shared/game-soundscape/index.ts
+++ b/dynawalla/packs/shared/game-soundscape/index.ts
@@ -17,6 +17,9 @@
  *   `melody`     the walker: gestures in, in-tune voices out.
  *   `groove`     the same soundscape read as TIME: a probability matrix over
  *                the bar, whose two inputs are the mode and the density.
+ *   `evolve`     that matrix, alive: a slow tethered walk over the bar, steered
+ *                by whether the child was right, so the groove drifts somewhere
+ *                new over minutes instead of repeating a fixed shape.
  *   `host`       the soundscape the app is in, published by the host.
  *
  * Usage, in a game:
@@ -34,13 +37,22 @@
  */
 export { CENTS_PER_OCTAVE, centsBetween, centsToRatio, foldIntoRange, hz } from "./pitch.ts"
 export {
+  BARS_PER_MUTATION,
+  Groove,
+  ROOM_HALF_LIFE_BARS,
+  SEED_HALF_LIFE_BARS,
+} from "./evolve.ts"
+export {
+  MAX_OPENNESS,
   MIN_AFFINITY,
   divOfBeat,
   expectedNotes,
   grooveMatrix,
   grooveSlotBeats,
+  leanAffinity,
   metreWeight,
   modeAffinity,
+  type GrooveBias,
   type GrooveSlot,
   type GrooveSpec,
 } from "./groove.ts"


### PR DESCRIPTION
> *"steelyard sounds is cool, pulse is somewhat improved but it needs to gradually evolve more — the main rhythm is static. I think slowly things should evolve and change stochastically. so there is sort of the seed but it should be able to go almost anywhere. Maybe being 'right' or 'wrong' should affect the beat in different ways. We don't have to just use random but random is a good friend. Add and remove different beats with probability .. slowly evolve."*
>
> *"When does the musical mode get changed in general? Maybe it should switch more often like when a level transitions on some games."*

Closes the evolution half of #737.

---

## The thing I got wrong first, and it changed the design

`grooveMatrix` is a pure function, so PULSE got the same probabilities back
every phrase — that is the obvious reading of "static" and it is what I built
against first. Then I measured it, and **making the chart drift moved a
strike-rate profile by 0.0005.** Inaudible. PULSE's chart already varies a great
deal per phrase; the variety was already there.

The loop was the layer *underneath* it:

| | before |
|---|---|
| Bass | `BASS_PATTERNS[tier]` — a written array of beat offsets. **One** pattern, every bar, forever |
| Shaker | every offbeat eighth, every bar, forever |
| Arp | `(k + bar) % 3` — a three-bar loop |

That is "the main rhythm", and it was a loop in the literal sense. The tier now
says how BUSY the bass is and the groove says WHERE it sits — the same division
of labour `density` and the matrix already had for the player's notes. The
shaker is deliberately left steady: something has to be the frame, or a bass
that moves reads as the tempo wobbling.

## Job 1 — the walk (`evolve.ts`, new, 79 tests in the module)

One number per instant of the bar, `-1..1`, on top of what the mode said. Every
four bars a few of them move. Three constraints keep it a groove rather than
noise, **each verified by deleting it and watching a test fail**:

1. **The metre is never drifted.** The walk moves the mode's *affinity*, never
   the metric weight, so a downbeat outranks a halfway point outranks a
   sixteenth however far it travels. The downbeat is not in the walk at all.
2. **The walk is tethered** (`SEED_HALF_LIFE_BARS = 144`) — mean-reverting, not
   Brownian. *"There is sort of the seed but it should be able to go almost
   anywhere"* is exactly that shape: a wide stationary spread around a home it
   keeps falling back through.
3. **Nothing lands mid-phrase.** Gestures queue; `matrix()` is frozen between
   `advance()` calls. A bar a child is two beats into cannot become a different
   bar.

`groove.ts` gained a `GrooveBias` seam and `leanAffinity`, which moves an
instant *inside the range the mode already allowed it* — `+1` is exactly `1`,
`-1` is exactly `MIN_AFFINITY` — so a drifted matrix passes every invariant an
undrifted one does **with no clamp anywhere**. Pass no bias and `grooveMatrix`
is byte-for-byte the pure function it always was.

**The rate is in BARS.** No tempo primitive was added; the module still has
none.

## Job 2 — right and wrong, in two directions rather than at two volumes

* **Right ADDS.** `agree()` lights up an instant the bar had been ignoring — the
  one with the most room the metre would most like to hear. **It adds no
  notes**: the budget renormalises, so the expected count is *bit-identical* to
  what the stage asked for and only WHERE changed. Rewarding correctness with a
  busier bar would be rewarding it with a harder game.
* **Wrong REMOVES.** `makeRoom()` takes the busiest *decoration* down — never a
  beat, never the downbeat — and leaves a little space for a few phrases. A band
  backing off while somebody thinks. It expires on the clock and not on merit,
  so nothing has to be earned back, and it is capped at a quarter of the budget
  so playing badly on purpose never buys an easier game.

Nothing here is red, nothing is a buzzer, nothing changes the tempo. In PULSE it
is bound to **gates** (the arithmetic) and not to notes: thinning a groove
because a child dropped a hat would be the music running a critique of their
hands.

**Two designs were built and measured before this one**, both trying to make
"right" mean *the groove commits to what it is already doing*:

| attempt | result |
|---|---|
| push the instant with the highest `p` | beat an untouched groove **38 of 60** — a coin. `leanAffinity` is range-relative, so the strongest instant is by definition the one with the least room to get stronger |
| draw the target ∝ `p³` | **30 of 60**. Six pushes landed on five instants and cancelled |

Adding has headroom by construction, and it is what the brief literally asked
for.

## Job 3 — when the mode changes

**A level transition rotates the key, and the gesture already existed.**

The old rule — *never rotate while a pack owns it* — was protecting a **reason**,
not a possession. Its reason, verbatim from the code, is that *"a key change
underneath a child — mid-question, because a timer went off — is the jarring
thing"*. A transition is not that: it is the pack saying **the child finished
something and nothing is in front of them**, which is exactly the condition a
doorway satisfies. So the rule is restated rather than broken:

> **The key never moves unbidden.** Doorways are the host's boundary;
> transitions are the pack's.

The gesture is **`session.transition`** — the SDK's existing ungated session
method, whose documented contract is already the guarantee needed: *"a
transition is a thing the child finished, never a thing that beat them."* **No
wire field, no capability, no method, no `SDK_VERSION` bump.** A pack with no
levels sends nothing and rotates at doorways alone — the policy that was already
there. **Nothing in the fleet is obliged to change.**

| | |
|---|---|
| Fresh key every launch | unchanged |
| New key every `ROTATION_MS` (8 min) at a doorway | unchanged — **kept as the backstop** |
| Never moves under a playing child on a clock alone | unchanged, still a module invariant |
| **A `transition` may turn it over after `TRANSITION_ROTATION_MS` (90 s)** | **new** |
| Never the same mode twice running | unchanged, now enforced on the transition path too |

**Why the transition floor is shorter, not longer.** A doorway happens whenever
a child browses, so it needs a long floor. A transition is a real boundary a
game *declared* — a stronger signal — so it justifies a change on less
accumulated time. 90 s is long enough that a key gets to be a key even in a game
whose levels are forty seconds long.

**The 8-minute timer stays** and becomes the backstop rather than the driver:
most of the fleet has no levels, and without it a forty-minute session at THE
STEELYARD sits in one key for forty minutes.

**Guards, both tested.** A transition from a pack *not* on the stage is ignored
(React renders the incoming pack before the outgoing one's cleanup, so a message
from a dead session is a real frame). A backwards clock rotates once and settles,
as the doorway path does.

A rotation lands as a **modulation**: `Groove.retune` queues the new key to the
next phrase boundary and keeps the drift across it, exactly as `Melody.retune`
keeps the walker's degree.

## Numbers

**Drift over time** (60 seeds, eighths grid; mean change in a slot's strike
probability against the seed matrix):

| 1 phrase | 1 min | 2 min | 9 min | 35 min | 70 min |
|---|---|---|---|---|---|
| 0.012 | 0.036 | 0.050 | 0.068 | 0.073 | 0.065 |

It goes somewhere over minutes and then stays inside its spread for an hour. The
worst-affected instant moves its strike rate **0.20–0.34** — an instant that
fired in 40% of bars now firing in 10% or 70%.

**Tether.** 20 right answers reach **+4.11** of total lean; 200 bars later, with
the child answering nothing, **15%** is left. With the decay deleted, 37%
survives — which is how that assertion is known not to be vacuous.

**Right against wrong** (200 seeds per grid, 8 answers, net instants opened
minus closed):

| grid | right | wrong | right > wrong |
|---|---|---|---|
| quarters `[1]` | +1.54 | −1.31 | 196/200 |
| eighths `[1,2]` | +2.12 | −2.63 | 200/200 |
| triplets `[1,3]` | +2.35 | −3.66 | 200/200 |
| everything `[1,2,3,4]` | +1.61 | −3.93 | 200/200 |

Right leaves the expected note count **bit-identical** in 60/60 seeds, every
grid.

**Reproducible.** Same seed replays a session exactly; **60/60** different seed
pairs diverge.

**In PULSE**, where he heard it:

| | before | after |
|---|---|---|
| Distinct bass bars in 64 | **1** | **36.1** |
| Strike-rate shift, two 200-bar windows, walk **off** | — | 0.031 |
| Strike-rate shift, two 200-bar windows, walk **on** | — | **0.053** |

The A/B is the same generator with `advance` stubbed. The window has to be 200
bars: sampling noise in a strike rate falls as `1/√N` and the drift does not, so
at 96 bars the two are the same size — the first version of that test asserted a
ratio of 1.16 and failed honestly.

## Verification

`game-soundscape` 79 · `pulse` 153 · `counterweight` 165 · `dynawalla-app` 424 —
**five consecutive runs each**, plus `npm run -s tsc` on all four.
`node packs/build.mjs pulse counterweight` builds and passes the SDK checker.

**Every new assertion was mutation-tested** — broken, watched to fail, restored.
Sixteen mutations across the module, the host and PULSE. **Three did not bite
and were fixed rather than kept**, which is the part worth reading:

| mutation | what happened |
|---|---|
| delete the tether (`decay = 1`) | **PASSED.** Counting seed-crossings and bounding the hour-long excursion are both satisfied by the `±1` clamp alone. Replaced with a signed-total test that the wander (zero-mean) cannot fake: fails at 37% vs a 25% threshold |
| always one mutation per event, ignoring grid width | **PASSED.** The grid-rate bound was `0.5×–2×`; the real ratio is 0.96 and the mutation's is 0.68. Tightened to `0.8×–1.25×` |
| drop `groove.revision` from the phrase cache key | **PASSED — and the comment claiming it was load-bearing was wrong.** Queue-then-apply is what stops a bar changing under a child; the key is defence in depth for a future caller. Comment corrected, and the test now bites on the real guarantee (fails in 1 ms if `agree()` starts landing immediately) |

Also found by mutation testing: `rig("wrong", 4)` **never actually stumbles** — a
bot that drums perfectly earns back more health than a wrong gate costs — so "a
stage LOST is not a transition" was vacuous. The rig grew a `"silent"` bot that
genuinely falls. And a failing assertion left a `Run` undisposed, holding the
test file open for Node's full 60 s timeout instead of printing one line of red;
the new tests use `try/finally`.

## Seams left for FORGE and TREBUCHET

* `Groove` is optional — a game with no bar clock does not need one. `Melody` is
  untouched and every existing gesture behaves exactly as before.
* `grooveMatrix(scape, spec)` with no bias is the same pure function it was.
* `bandBeats` in PULSE is the pattern for "a backing layer drawn from the groove
  rather than written down", and it is thirteen lines.
* The walk's universe is the **union** of every grid it is shown, so two layers
  in one game may ask about different subdivisions **in either order** without
  changing the music — tested, because `scheduleBacking` runs before the player
  notes are laid and moving one line would swap them.

`SOUNDSCAPE_DESIGN_2026-07.md` carries the full policy and the rejected designs.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
