### PR TITLE
dynawalla/packs: a retired pack is uninstalled at the next launch, and a downloaded one is not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1252,6 +1252,25 @@ jobs:
             exit 1
           fi
 
+      # ── the pack runtime's own tests ─────────────────────────────────────
+      #
+      # No workflow in this repository ran `cargo test`, at all, until this
+      # step. That is not a theoretical gap: PR 749 added a regression test
+      # asserting the bundled-pack sync stays additive — the thing standing
+      # between a bad refactor and every downloaded pack being uninstalled from
+      # every device at launch — and it had never executed on a pull request.
+      # A test that never runs is a comment.
+      #
+      # Scoped to `packs::` and to the one crate whose pack runtime this is.
+      # `--all-targets` above already compiled these; this links and runs them,
+      # measured at a few seconds after that. Widening it to the whole test
+      # suite of both apps is a separate, larger decision about job time.
+      - name: cargo test (dynawalla pack runtime)
+        working-directory: dynawalla/dynawalla-app/src-tauri
+        # Quoted: a plain YAML scalar ending in a colon is a mapping key, and
+        # `packs::` unquoted is a parse error rather than a filter.
+        run: "cargo test --locked --lib packs::"
+
   # Single summary status that aggregates every job above. THIS is the context to
   # mark as a required check on `main` — it always runs (if: always()) and always
   # reports, so path-skipped sub-jobs never deadlock the branch protection / queue.

--- a/dynawalla/dynawalla-app/src-tauri/retired-packs.json
+++ b/dynawalla/dynawalla-app/src-tauri/retired-packs.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "note": "Pack ids this build removes from every device at launch. Dropping a game from games/ drops it from the next bundle and from the catalogue, and does nothing at all to the devices that already have it: the pack root outlives an app update and the sync is additive on purpose, because it is also where downloaded packs live. This file is the other half of a retirement. Read by src/packs/mod.rs (remove_retired) and by packs/build.mjs, which refuses to build an id listed here. An id in this list must NOT exist under dynawalla/games/ — see the tests in src/packs/tests.rs and src/packs/retired.test.ts.",
+  "retired": [
+    {
+      "id": "dynawalla.foundry",
+      "name": "THE GRAPPLE FOUNDRY",
+      "retiredIn": 749,
+      "why": "Retired from the shipping fleet."
+    },
+    {
+      "id": "dynawalla.gavel",
+      "name": "THE GAVEL",
+      "retiredIn": 749,
+      "why": "Retired from the shipping fleet."
+    },
+    {
+      "id": "dynawalla.street",
+      "name": "FOUNDRY STREET",
+      "retiredIn": 760,
+      "why": "Shelved: the concept survives, the execution does not."
+    }
+  ]
+}

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
@@ -20,7 +20,13 @@
 //!    before a single byte is extracted.
 //! 4. **A pack that is removed is gone.** `packs_remove` is registered — the
 //!    frontend invoking a command the backend never registered is how Corpán's
-//!    uninstalled packs came to live on disk forever.
+//!    uninstalled packs came to live on disk forever. And a pack the *company*
+//!    removed is gone too: `retired-packs.json` names the ids this build must
+//!    uninstall, and [`remove_retired`] runs down that list at every launch.
+//!    Dropping a game from `games/` only stops shipping it; without the ledger
+//!    it stays installed and playable on every device that ever had it, which
+//!    is how a retired game turned up in a catalogue a release after it was
+//!    scrapped.
 //!
 //! The scheme name `dynawalla-pack` is baked into the built JavaScript of every
 //! pack ever published. It is a public API from the first release and it can
@@ -1021,16 +1027,45 @@ pub fn sync_bundled<R: Runtime>(app: &AppHandle<R>) {
     let root = match pack_root(app) {
         Ok(root) => root,
         Err(problem) => {
-            eprintln!("[packs] no pack root ({problem}); bundled packs were NOT installed");
+            eprintln!(
+                "[packs] no pack root ({problem}); bundled packs were NOT installed and retired \
+                 packs were NOT removed"
+            );
             return;
         }
     };
 
-    match bundled_source(app) {
-        Some(Bundled::Directory(source)) => sync_from_directory(&source, &root),
+    sync_into(&root, || bundled_source(app));
+}
+
+/// The launch sequence, with only the platform-specific hunt for the bundle
+/// left to the caller.
+///
+/// A seam rather than an inlined body: locating the bundle needs an `AppHandle`
+/// and a real installation, and everything that matters happens after it. The
+/// tests drive *this* function, so what they exercise is the order the app
+/// runs in rather than an approximation of it.
+///
+/// **Retirement goes first, and outside the match.** Two reasons, both
+/// load-bearing:
+///
+/// * It does not depend on the bundle. `bundled_source` returns `None` on a
+///   build that cannot find its own packs, and a retirement that only happens
+///   when the bundle is readable is a retirement that does not happen.
+/// * Going first means an id that was somehow both retired and bundled would
+///   end the launch *installed*. That is the safe direction for a
+///   contradiction — a child keeps a playable game rather than losing one —
+///   and the contradiction cannot be shipped anyway, because
+///   `retired-packs.json` is checked against `games/` by both test suites and
+///   `packs/build.mjs` refuses to build a retired id.
+fn sync_into(root: &Path, locate: impl FnOnce() -> Option<Bundled>) {
+    remove_retired(root, &retired_ids());
+
+    match locate() {
+        Some(Bundled::Directory(source)) => sync_from_directory(&source, root),
         Some(Bundled::Apk(apk)) => match fs::File::open(&apk) {
             Ok(file) => match zip::ZipArchive::new(std::io::BufReader::new(file)) {
-                Ok(mut archive) => sync_from_zip(&mut archive, &root),
+                Ok(mut archive) => sync_from_zip(&mut archive, root),
                 Err(problem) => eprintln!(
                     "[packs] {} is not readable as an archive: {problem}",
                     apk.display()
@@ -1201,6 +1236,107 @@ fn unpack_into<S: Read + Seek>(
         fs::write(&target, &body).map_err(|e| format!("cannot write {target:?}: {e}"))?;
     }
     Ok(())
+}
+
+// ─── Packs this build has retired ────────────────────────────────────────────
+
+/// The ledger of pack ids this build must uninstall, verbatim.
+///
+/// **Compiled in, not read from the bundle.** It has to be true on a device
+/// whose bundle cannot be located at all — `bundled_source` returns `None` on a
+/// broken build and on a platform whose resource directory has moved, and a
+/// retirement conditional on finding the bundle is a retirement that does not
+/// happen on exactly the devices least able to recover.
+///
+/// The file sits beside `Cargo.toml` rather than in `packs/` so that editing it
+/// changes something under a `src-tauri/` path, which is what CI path-gates the
+/// native and app jobs on. A ledger whose edits ran no gate would be a ledger
+/// nothing checks.
+const RETIRED_LEDGER: &str = include_str!("../../retired-packs.json");
+
+#[derive(Debug, Deserialize)]
+struct RetiredLedger {
+    retired: Vec<RetiredEntry>,
+}
+
+/// One retirement. Only the id is read here; `name`, `retiredIn` and `why` are
+/// there for the human deciding whether a line may be deleted.
+#[derive(Debug, Deserialize)]
+struct RetiredEntry {
+    id: String,
+}
+
+/// The ids named by a ledger, or none and a loud complaint.
+///
+/// A ledger that will not parse retires nothing. That is the wrong answer and
+/// it is the least wrong one available: the alternative — guessing, or
+/// panicking at setup — either deletes a directory nobody named or stops the
+/// app from opening. Both test suites parse this file, so a malformed ledger
+/// fails a gate long before a device sees it.
+fn retired_ids_in(ledger: &str) -> Vec<String> {
+    match serde_json::from_str::<RetiredLedger>(ledger) {
+        Ok(ledger) => ledger.retired.into_iter().map(|entry| entry.id).collect(),
+        Err(problem) => {
+            eprintln!(
+                "[packs] retired-packs.json is unreadable ({problem}); NO retired pack was \
+                 removed, and every device keeps every game this build meant to pull"
+            );
+            Vec::new()
+        }
+    }
+}
+
+fn retired_ids() -> Vec<String> {
+    retired_ids_in(RETIRED_LEDGER)
+}
+
+/// Uninstall the packs this build has retired, wherever they came from.
+///
+/// **By name, one lookup per retired id — it never reads the directory.** A
+/// pack that is not on the list is not merely spared here, it is unreachable
+/// from here, and that is the whole design.
+///
+/// The obvious rule — "delete anything the bundle does not carry" — is wrong
+/// and destructive. The pack root is not a mirror of the bundle: it is also
+/// where `packs_install` puts everything downloaded from the catalogue, so that
+/// rule would uninstall every downloaded pack at every launch, silently, on
+/// every device. `sync_from_directory` stays additive for that reason and a
+/// test pins it there. A retirement is a decision about *named* packs, so it is
+/// expressed as a list of names.
+///
+/// Cheap and idempotent: three `is_dir` calls on a launch where nothing is
+/// retired, and nothing at all to do on the launch after the first.
+///
+/// Returns the ids actually removed, which is what the tests assert on and what
+/// keeps "it removed something" from being confused with "it looked".
+fn remove_retired(root: &Path, retired: &[String]) -> Vec<String> {
+    let mut removed = Vec::new();
+    for id in retired {
+        // The ledger is data, and this is the step that turns it into a path.
+        // `..`, an absolute path, and anything else that is not a pack id names
+        // no pack and is refused before `join` sees it.
+        if !valid_pack_id(id) {
+            eprintln!(
+                "[packs] the retirement ledger names {id:?}, which is not a pack id; ignored"
+            );
+            continue;
+        }
+        let directory = root.join(id);
+        if !directory.is_dir() {
+            continue;
+        }
+        match fs::remove_dir_all(&directory) {
+            Ok(()) => {
+                eprintln!("[packs] {id} has been retired; it is no longer installed");
+                removed.push(id.clone());
+            }
+            // Logged rather than propagated: a pack that will not delete is not
+            // a reason for the app not to open, and the next launch tries
+            // again.
+            Err(problem) => eprintln!("[packs] could not remove retired {id}: {problem}"),
+        }
+    }
+    removed
 }
 
 #[cfg(test)]

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
@@ -661,6 +661,18 @@ fn a_pack_that_is_no_longer_bundled_stays_installed_and_playable() {
     // `street` (FOUNDRY STREET) after them — so the fixture carries two at once:
     // a retirement is not a one-off migration to be special-cased, it is a thing
     // that keeps happening, and each one has to be as uneventful as the last.
+    //
+    // **What "uneventful" cost, and what changed.** Uneventful here meant that a
+    // retired game went on being installed and playable forever, which is how
+    // FOUNDRY STREET turned up in the founder's catalogue a release after it was
+    // scrapped. Uninstalling it is now the job of `remove_retired`, which works
+    // from the named list in `retired-packs.json` and never reads the pack root.
+    // That leaves this function's contract exactly where it was and exactly
+    // where it must stay — *this* is the one that would take a downloaded pack
+    // with it — so every assertion below is unchanged. The fixture ids here are
+    // deliberately bare (`gavel`, not `dynawalla.gavel`): they stand for "a pack
+    // this build does not carry", which is a larger set than "a pack this build
+    // retired", and it is the larger set that this function must not touch.
     let root = scratch("retired-root");
     let source = scratch("retired-source");
 
@@ -699,4 +711,275 @@ fn a_pack_that_is_no_longer_bundled_stays_installed_and_playable() {
 
     let _ = fs::remove_dir_all(&root);
     let _ = fs::remove_dir_all(&source);
+}
+
+// ─── Retirement ──────────────────────────────────────────────────────────────
+
+#[test]
+fn a_retired_pack_is_uninstalled_at_the_next_launch_and_a_downloaded_one_is_not() {
+    // **The bug this exists for.** FOUNDRY STREET was scrapped in PR 760 and
+    // was still in the founder's catalogue a release later, because dropping a
+    // game from `games/` drops it from the next bundle and reaches no device.
+    //
+    // And the trap next to it, in the same directory. `packs_install` writes
+    // downloaded packs into this same root, so a sync that deleted whatever the
+    // bundle lacked would uninstall every one of them at every launch. Both
+    // halves are asserted here against one root, because a fix that only
+    // satisfies the first half is worse than the bug.
+    let root = scratch("retire-launch-root");
+    let source = scratch("retire-launch-source");
+
+    // On the device: the game that was pulled, ...
+    let street = root.join("dynawalla.street");
+    pack_dir(&root, "dynawalla.street", "0.1.0", &"5".repeat(64));
+    // ... a game this build still ships, ...
+    pack_dir(&root, "dynawalla.arena", "0.1.0", &"a".repeat(64));
+    // ... and one that came off the catalogue and was never in any bundle.
+    let downloaded = pack_dir(&root, "someone.tower", "0.1.0", &"d".repeat(64));
+
+    // In the new build: only the survivor, upgraded.
+    pack_dir(&source, "dynawalla.arena", "0.2.0", &"b".repeat(64));
+
+    let bundle = source.clone();
+    sync_into(&root, move || Some(Bundled::Directory(bundle)));
+
+    assert!(
+        !street.exists(),
+        "FOUNDRY STREET is still installed, so it is still in the catalogue and still playable",
+    );
+
+    // The half that must never regress.
+    assert!(
+        downloaded.join("manifest.json").exists(),
+        "a downloaded pack was uninstalled by a sync that had no business knowing about it",
+    );
+    assert!(
+        downloaded.join("pack.html").exists(),
+        "a downloaded pack lost the document it launches",
+    );
+    assert_eq!(
+        fs::read_to_string(downloaded.join("manifest.json")).expect("manifest"),
+        manifest_json("someone.tower", "0.1.0", Some(&"d".repeat(64))),
+        "a downloaded pack's manifest was rewritten",
+    );
+
+    // And the survivor was still refreshed in the same pass, which is what
+    // proves the launch actually ran and the assertions above are not passing
+    // on a sync that did nothing at all.
+    assert_eq!(
+        fs::read_to_string(root.join("dynawalla.arena").join("manifest.json")).expect("manifest"),
+        manifest_json("dynawalla.arena", "0.2.0", Some(&"b".repeat(64))),
+        "the bundled pack was not refreshed, so this launch did nothing",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&source);
+}
+
+#[test]
+fn retirement_needs_no_bundle_and_is_the_same_on_every_launch() {
+    // A build that cannot find its own packs still has to honour a retirement:
+    // `bundled_source` returns `None` on a broken build, and those are the
+    // devices least able to recover by other means. And this runs at every
+    // launch forever, so the second and the hundredth must cost nothing and
+    // change nothing.
+    let root = scratch("retire-no-bundle");
+    pack_dir(&root, "dynawalla.gavel", "0.1.0", &"b".repeat(64));
+    let kept = pack_dir(&root, "someone.tower", "0.1.0", &"d".repeat(64));
+
+    sync_into(&root, || None);
+    assert!(
+        !root.join("dynawalla.gavel").exists(),
+        "a build with no locatable bundle skipped the retirement",
+    );
+
+    for _ in 0..3 {
+        sync_into(&root, || None);
+    }
+    assert!(
+        !root.join("dynawalla.gavel").exists(),
+        "a later launch put a retired pack back",
+    );
+    assert!(
+        kept.join("pack.html").exists(),
+        "a repeated launch eventually took a downloaded pack with it",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_retirement_ledger_names_every_pack_that_has_been_pulled() {
+    let ids = retired_ids();
+    // Named one by one rather than by count: a count goes green the day
+    // someone deletes a line, and a deleted line is a game coming back.
+    for id in ["dynawalla.foundry", "dynawalla.gavel", "dynawalla.street"] {
+        assert!(
+            ids.iter().any(|listed| listed == id),
+            "{id} is not in retired-packs.json, so every device that has it keeps it",
+        );
+    }
+    for id in &ids {
+        assert!(
+            valid_pack_id(id),
+            "{id} is not a pack id, so no directory can ever match it and the line does nothing",
+        );
+    }
+    let mut unique = ids.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        ids.len(),
+        "retired-packs.json lists a duplicate"
+    );
+}
+
+#[test]
+fn a_retired_pack_is_not_also_a_game_in_this_repository() {
+    // The one contradiction the ledger can express: an id that is both retired
+    // and built. Un-retiring a game means deleting its line here as well as
+    // restoring its directory, and this is what says so out loud.
+    let games = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("games");
+    let entries = fs::read_dir(&games)
+        .unwrap_or_else(|problem| panic!("cannot read {}: {problem}", games.display()));
+
+    let mut shipped = vec![];
+    for entry in entries.flatten() {
+        let meta = entry.path().join("pack.json");
+        let Ok(body) = fs::read_to_string(&meta) else {
+            continue;
+        };
+        let identity = manifest_identity(&body)
+            .unwrap_or_else(|| panic!("{} has no readable id", meta.display()));
+        shipped.push(identity.id);
+    }
+    // Proof this walked the games directory rather than an empty one. Without
+    // it the loop below asserts nothing at all, which is exactly how three
+    // vacuous sweeps got through this repository in a fortnight.
+    assert!(
+        shipped.len() >= 20,
+        "found only {} pack.json files under {} — this test is looking in the wrong place",
+        shipped.len(),
+        games.display(),
+    );
+
+    for id in retired_ids() {
+        assert!(
+            !shipped.contains(&id),
+            "{id} is retired AND built from games/ — every device would delete it at the launch \
+             after the one that installed it",
+        );
+    }
+}
+
+#[test]
+fn a_ledger_entry_that_is_not_a_pack_id_removes_nothing() {
+    // The ledger is data and `remove_retired` turns it into a path, so it is
+    // the place a traversal would land. Nothing here names a pack, and nothing
+    // here may delete one.
+    let root = scratch("retire-hostile");
+    let victim = pack_dir(&root, "someone.tower", "0.1.0", &"d".repeat(64));
+    let sibling = root
+        .parent()
+        .expect("temp dir")
+        .join("dynawalla-retire-bystander");
+    fs::create_dir_all(&sibling).expect("bystander");
+
+    let removed = remove_retired(
+        &root,
+        &[
+            "..".to_string(),
+            "../dynawalla-retire-bystander".to_string(),
+            "/etc".to_string(),
+            "someone.tower/../someone.tower".to_string(),
+            "SOMEONE.TOWER".to_string(),
+            String::new(),
+        ],
+    );
+
+    assert!(
+        removed.is_empty(),
+        "a ledger entry that is not a pack id removed {removed:?}"
+    );
+    assert!(
+        victim.join("pack.html").exists(),
+        "a hostile ledger entry reached a real pack"
+    );
+    assert!(
+        sibling.is_dir(),
+        "a hostile ledger entry escaped the pack root"
+    );
+    assert!(
+        root.is_dir(),
+        "a hostile ledger entry deleted the pack root itself"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&sibling);
+}
+
+#[test]
+fn an_unreadable_ledger_retires_nothing_rather_than_guessing() {
+    assert!(
+        retired_ids_in("{ not json").is_empty(),
+        "a malformed ledger produced ids from somewhere",
+    );
+    assert!(
+        retired_ids_in(r#"{"schema":1,"retired":[]}"#).is_empty(),
+        "an empty ledger produced ids from somewhere",
+    );
+    // And the shape that is read is the shape the file is written in, so the
+    // two assertions above are about parsing and not about a field name that
+    // never matches anything.
+    assert_eq!(
+        retired_ids_in(r#"{"schema":1,"retired":[{"id":"a.b","name":"A","retiredIn":1}]}"#),
+        vec!["a.b".to_string()],
+    );
+}
+
+#[test]
+fn a_retired_pack_that_is_not_installed_is_not_an_error() {
+    // The overwhelmingly common launch: nothing to do. It must not create the
+    // directory it is looking for, and it must not report having removed one.
+    let root = scratch("retire-absent");
+    let removed = remove_retired(&root, &["dynawalla.street".to_string()]);
+    assert!(
+        removed.is_empty(),
+        "reported removing a pack that was never there"
+    );
+    assert!(
+        !root.join("dynawalla.street").exists(),
+        "the lookup created the directory"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_retired_id_that_is_a_symlink_does_not_reach_what_it_points_at() {
+    // A pack directory cannot become a symlink by any route in this module —
+    // `copy_tree` skips links and both extractors write regular files only — so
+    // this is the belt for a device whose pack root someone else has been in.
+    // `fs::remove_dir_all` does not follow a symlink at the path it is given, and
+    // this pins that rather than trusting it: the consequence of being wrong is
+    // a delete outside the pack root.
+    let root = scratch("retire-symlink");
+    let elsewhere = root.parent().expect("temp").join("dynawalla-retire-target");
+    fs::create_dir_all(&elsewhere).expect("target");
+    fs::write(elsewhere.join("keep.txt"), b"keep").expect("keep");
+    std::os::unix::fs::symlink(&elsewhere, root.join("dynawalla.street")).expect("symlink");
+
+    remove_retired(&root, &["dynawalla.street".to_string()]);
+
+    assert!(
+        elsewhere.join("keep.txt").exists(),
+        "a symlinked pack id reached outside the pack root",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&elsewhere);
 }

--- a/dynawalla/dynawalla-app/src/packs/retired.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/retired.test.ts
@@ -1,0 +1,113 @@
+// The retirement ledger, checked from the app's own suite.
+//
+// `remove_retired` and its Rust tests are the mechanism. Until this change no
+// workflow in this repository ran `cargo test` at all — PR 749's additive-sync
+// regression test had never executed on a pull request — and the `native` job
+// now does, so those tests are gated too.
+//
+// This file is not a duplicate of them. It is the second reader of the same
+// two files, and it runs in a different job on a different filter: a change to
+// `retired-packs.json` alone would run the Rust tests, and a change to
+// `mod.rs`'s call sites would run both, but only this suite is gated on the
+// app's own path and only this one keeps a ledger edit from ever being a
+// one-gate change.
+//
+// This is the same shape as `native.test.ts`, which reads `lib.rs` for exactly
+// the same reason: the thing that goes wrong is two files disagreeing, and only
+// reading both catches it.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const srcTauri = path.resolve(here, "../../src-tauri")
+const games = path.resolve(here, "../../../games")
+
+const ledgerText = fs.readFileSync(path.join(srcTauri, "retired-packs.json"), "utf8")
+const modRs = fs.readFileSync(path.join(srcTauri, "src/packs/mod.rs"), "utf8")
+
+interface Ledger {
+  readonly schema: number
+  readonly retired: readonly { readonly id: string; readonly name?: string }[]
+}
+
+const ledger = JSON.parse(ledgerText) as Ledger
+
+/** The same rule `valid_pack_id` states in Rust, which is what turns an id into a directory name. */
+function validPackId(id: string): boolean {
+  return /^[a-z][a-z0-9]*([.-][a-z0-9]+)*$/.test(id) && id.length <= 64
+}
+
+test("the ledger names every pack that has been pulled from the fleet", () => {
+  const ids = ledger.retired.map((entry) => entry.id)
+  // Named one at a time rather than counted: a count goes green the day
+  // someone deletes a line, and a deleted line is a retired game coming back
+  // to life on every device that still has it.
+  for (const id of ["dynawalla.foundry", "dynawalla.gavel", "dynawalla.street"]) {
+    assert.ok(ids.includes(id), `${id} is not in retired-packs.json, so every device that has it keeps it`)
+  }
+  assert.equal(new Set(ids).size, ids.length, "retired-packs.json lists a duplicate id")
+  for (const id of ids) {
+    assert.ok(validPackId(id), `${id} is not a pack id, so no directory can ever match it`)
+  }
+})
+
+test("no retired id is also a game built from this repository", () => {
+  const shipped: string[] = []
+  for (const entry of fs.readdirSync(games, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const meta = path.join(games, entry.name, "pack.json")
+    if (!fs.existsSync(meta)) continue
+    shipped.push((JSON.parse(fs.readFileSync(meta, "utf8")) as { id: string }).id)
+  }
+  // Proof the walk found the games directory. Without it every assertion below
+  // passes over an empty list and this test asserts nothing at all.
+  assert.ok(shipped.length >= 20, `found only ${String(shipped.length)} packs under ${games}`)
+
+  for (const entry of ledger.retired) {
+    assert.ok(
+      !shipped.includes(entry.id),
+      `${entry.id} is retired AND built — every device deletes it at the launch after it installs`,
+    )
+  }
+})
+
+test("the launch sequence retires before it installs, and does it unconditionally", () => {
+  // The call site, not the function. `remove_retired` existing while nothing
+  // calls it is the exact failure this repository already has one instance of:
+  // `packs_remove` is written, registered, exported — and invoked by nothing.
+  const sequence = /fn sync_into\([^)]*\)[^{]*\{([\s\S]*?)\n\}/.exec(modRs)
+  assert.ok(sequence, "mod.rs has no sync_into")
+  const body = sequence[1] ?? ""
+  assert.match(body, /remove_retired\(root, &retired_ids\(\)\)/, "sync_into does not retire anything")
+  assert.ok(
+    body.indexOf("remove_retired") < body.indexOf("match locate()"),
+    "retirement must run before the bundle is even located, so a build that cannot find its packs still honours it",
+  )
+  assert.match(modRs, /sync_into\(&root, \|\| bundled_source\(app\)\)/, "sync_bundled does not run the launch sequence")
+})
+
+test("nothing in the launch path enumerates the pack root", () => {
+  // The destructive rule this whole design exists to avoid: "delete whatever
+  // the bundle does not carry". The pack root is not a mirror of the bundle —
+  // it is also where `packs_install` puts every download — so a rule shaped
+  // that way uninstalls a child's downloaded packs at every launch, silently.
+  //
+  // Its signature in source is a walk of the *root* inside a function whose job
+  // is the *bundle*. `sync_from_directory` reads `source`, `sync_from_zip`
+  // reads the archive, and `remove_retired` joins names it was handed; none of
+  // the three may ever read the destination directory.
+  for (const walker of ["sync_from_directory", "sync_from_zip", "remove_retired"]) {
+    const fn = new RegExp(`\\nfn ${walker}[\\s\\S]*?\\n\\}\\n`).exec(modRs)
+    assert.ok(fn, `mod.rs has no ${walker}`)
+    assert.ok(fn[0].length > 200, `the match for ${walker} is too short to be its body`)
+    assert.doesNotMatch(
+      fn[0],
+      /read_dir\(root\)|read_dir\(&root\)|read_dir\(destination\)|read_dir\(&destination\)/,
+      `${walker} enumerates the directory it writes into — that is the rule that deletes downloads`,
+    )
+  }
+})

--- a/dynawalla/packs/build.mjs
+++ b/dynawalla/packs/build.mjs
@@ -45,8 +45,24 @@ const GAMES = path.join(root, "games")
 const STAGE = path.join(root, "dynawalla-app", "src-tauri", "packs")
 const DIST = path.join(root, "dist-packs")
 const CHECK = path.join(here, "sdk", "bin", "dw-pack.mjs")
+const RETIRED = path.join(root, "dynawalla-app", "src-tauri", "retired-packs.json")
 
 const filters = process.argv.slice(2)
+
+/**
+ * The ids the app uninstalls from every device at launch.
+ *
+ * Discovery here is a glob and never a list — see the header — but a
+ * retirement is the one thing a glob cannot express, because nothing in
+ * `games/` remembers what used to be there. The ledger is that memory, and it
+ * is read here so the two can never disagree: an id in it is a directory the
+ * shipped app deletes, so building that pack would stage something every device
+ * removes at the launch after the one that installed it.
+ */
+function retiredIds() {
+  const ledger = JSON.parse(fs.readFileSync(RETIRED, "utf8"))
+  return new Set(ledger.retired.map((entry) => entry.id))
+}
 
 /** Every file under `dir`, relative and sorted. Sorted so a digest is stable. */
 function walk(dir, base = dir, out = []) {
@@ -163,6 +179,21 @@ fs.mkdirSync(STAGE, { recursive: true })
 const packs = discover()
 if (packs.length === 0) {
   console.error("no packs found — a pack is a directory under games/ with a pack.json")
+  process.exit(1)
+}
+
+// Refused before a single pack is built, so the answer is one message rather
+// than a build that succeeds and ships a game the app then deletes.
+const retired = retiredIds()
+const contradictions = packs.filter((pack) => retired.has(pack.source.id))
+if (contradictions.length > 0) {
+  for (const pack of contradictions) {
+    console.error(
+      `${pack.source.id} (games/${pack.name}) is listed in dynawalla-app/src-tauri/retired-packs.json.\n` +
+        "  Every device uninstalls it at launch, so building it stages a pack that cannot survive a\n" +
+        "  restart. To bring it back, delete its entry from that file in the same change.",
+    )
+  }
   process.exit(1)
 }
 


### PR DESCRIPTION
## What

Make a retirement reach the device. `retired-packs.json` names the pack ids this build must uninstall, and `remove_retired` runs down that list at every launch, before the bundle is even located.

## Why

Three packs have been retired and shipped as retired — `dynawalla.foundry` and `dynawalla.gavel` (#749), `dynawalla.street` / FOUNDRY STREET (#760). `main` carries 25 packs and none of the three. **All three are still installed and playable on every device that had them**, which is how the founder found FOUNDRY STREET in his catalogue a release after it was scrapped. That blocks cutting a game from a production release.

The mechanism: `sync_from_directory` / `sync_from_zip` iterate the **bundled** packs and install or refresh each one. Neither walks the pack root looking for strangers, so nothing is ever removed, and the pack root is `app_data_dir()/packs`, which survives an app update. `packs_catalog` has zero callers in the app's TypeScript and no workflow publishes to that origin, so every pack on every device arrived bundled.

### Why a named list and not a prune

The obvious rule — *delete anything the bundle does not carry* — is wrong and destructive. `packs_install` writes downloaded packs into that **same** directory, so that rule uninstalls every downloaded pack at every launch, silently, on every device. #749 added a Rust regression test pinning the sync additive for exactly that reason; **every assertion in it is unchanged here**, and only its prose grew, to say where retirement moved to.

A bundled-origin marker written at install was the other candidate and it cannot solve this problem. The three packs are *already* installed, by builds that wrote no marker, and nothing on disk records where they came from — a marker fixes the next retirement and leaves the founder's device exactly as it is. Only a list carried by the new build reaches a pack that is already there.

So the retirement is a list of **names**. `remove_retired` joins each id onto the pack root once and never enumerates anything, which means a pack that is not named is not merely spared, it is unreachable from that code. That is a structural property, not a check that could be got wrong.

Three consequences, stated:

- **A downloaded pack is untouched**, whether or not it was ever bundled. A pack that was bundled and is later downloaded is likewise untouched unless its id is in the ledger; a retired id is deleted whatever route it took to the device, which is the point of retiring it.
- **Saved state for a retired pack is dropped**, and that is correct — the game is gone. What survives: the learner's `answered`/`correct` totals, which are global and not per-pack; and the host's installed-pack record self-heals, because `libraryStore` already forgets any recorded id `readLibrary` no longer returns. What is *left behind* is the pack's own key/value store under `packs/storage.ts`, capped at 200 keys per pack per learner and cleared by the parent's "erase everything". I deliberately did **not** sweep it: the safe sweep needs the retired list on the JS side too, and the unsafe one (drop any pack storage whose pack is not in the library) would delete a child's save for a pack that is installed but temporarily unreadable.
- **Safe and idempotent on every launch.** Three `is_dir` calls when nothing is retired; nothing at all to do on the launch after the first. Failures are logged and swallowed, so a directory that will not delete is retried next launch and is never a reason the app does not open.

Retirement runs **first and outside** the bundle match: it must not depend on `bundled_source`, which returns `None` on a build that cannot find its own packs, and going first means an id that was somehow both retired and bundled ends the launch *installed* — the safe direction for a contradiction. That contradiction cannot ship anyway: `packs/build.mjs` refuses to build an id in the ledger, and both suites assert the ledger and `games/` stay disjoint.

The ledger lives at `dynawalla-app/src-tauri/retired-packs.json` rather than in `packs/` so that editing it changes a `src-tauri/` path, which is what the `native` and `dynawalla_app` filters gate on. A ledger whose edits ran no gate would be a ledger nothing checks.

### One thing found on the way

**No workflow in this repository ran `cargo test`, at all.** #749's additive-sync regression test — the one standing between a bad refactor and every downloaded pack being deleted from every device — has never executed on a pull request. The `native` job now runs `cargo test --locked --lib packs::`, and the invariants a future change could break quietly are *also* asserted from TypeScript in `src/packs/retired.test.ts`, which is gated on `dynawalla/dynawalla-app/` and runs on every PR that touches it.

### Not done, deliberately

`removePack` is exported, `packs_remove` is registered, and **nothing in the UI calls it**. That is a real gap and the founder has three unwanted games he cannot delete — but a catalogue card is a single button that plays, so a delete affordance means a new per-pack section on the parents surface, a confirmation modal (`window.confirm` no-ops in the WKWebView), new strings, and the refresh/forget wiring. That is a feature, not a line, and the retirement path is the blocking half. Left for its own PR.

## Blast radius

**Areas touched:** dynawalla (native + app tests), packs (build pipeline), CI

- [x] Every touched path is covered by a `ci.yml` area filter. `src-tauri/` → `native` (and `dynawalla_app`); `src/packs/retired.test.ts` → `dynawalla_app`; `packs/build.mjs` → `dynawalla_packs`; `ci.yml` → all three.
- [x] **Pack back-compat.** No published pack zip changed, no catalog entry dropped, no version bumped. The three ids named in the ledger are packs that were already removed from the fleet by #749 and #760; nothing that ships today is affected.
- [x] **Native integrity.** `cargo fmt --check` clean; clippy still **0** unique warnings for this crate (the budget is bidirectional and would fail either way). No `links =` change, no `[workspace]` added, no `[patch.crates-io]` moved.
- [x] **Strings.** No new user-visible string. `retired-packs.json` and every log line are developer-facing.
- [x] **Curriculum.** N/A — no skill id, grade or answer schema touched.
- [x] **Secrets.** None. `gitleaks detect --log-opts="origin/main..HEAD"` → `no leaks found`.

## Proof

### The test that fails on `origin/main`

A device with `dynawalla.street` installed, a bundle without it, one downloaded pack beside it. Written against `main`'s API — `sync_from_directory` is the whole of `main`'s launch behaviour for a directory bundle — in a detached worktree at `987ecf57a`:

```
running 1 test
test packs::tests::a_retired_pack_is_uninstalled_at_the_next_launch_and_a_downloaded_one_is_not ... FAILED

thread '...' panicked at src/packs/tests.rs:719:5:
FOUNDRY STREET is still installed, so it is still in the catalogue and still playable

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 30 filtered out
```

On this branch the same scenario, run through `sync_into` (the real launch sequence, with only the platform-specific hunt for the bundle faked), passes — and asserts in the same breath that the downloaded pack keeps its manifest, its bytes and its entry document, and that the surviving bundled pack was still upgraded, so the pass is not a no-op.

### Mutation transcript

Every new assertion was broken, watched fail, and restored. Thirteen mutations, thirteen kills, **no survivors**.

| # | Mutation | Killed by | Message |
|---|---|---|---|
| M1 | `remove_retired` never calls `remove_dir_all` | `a_retired_pack_is_uninstalled…`, `retirement_needs_no_bundle…` | *FOUNDRY STREET is still installed, so it is still in the catalogue and still playable* |
| M2 | retirement moved inside the `Directory` arm | Rust `retirement_needs_no_bundle…` + TS | *retirement must run before the bundle is even located, so a build that cannot find its packs still honours it* |
| M3 | `sync_from_directory` prunes what the bundle lacks | #749's test, the new downloaded-pack assertion, TS | *gavel was uninstalled from under a child* · *a downloaded pack was uninstalled by a sync that had no business knowing about it* · *sync_from_directory enumerates the directory it writes into* |
| M4 | `valid_pack_id` guard dropped in `remove_retired` | `a_ledger_entry_that_is_not_a_pack_id_removes_nothing` | *a ledger entry that is not a pack id removed ["someone.tower/../someone.tower", ""]* — and `..` took the shared temp directory with it, breaking an unrelated test, which is what the guard is for |
| M5 | `dynawalla.street` deleted from the ledger | Rust ledger test, Rust launch test, TS ledger test | *dynawalla.street is not in retired-packs.json, so every device that has it keeps it* |
| M6 | `dynawalla.arena` (shipping) added to the ledger | Rust + TS disjointness, `build.mjs` | *dynawalla.arena is retired AND built from games/ — every device would delete it at the launch after the one that installed it*; `build.mjs` exit=1 |
| M7 | an unreadable ledger returns an invented id | `an_unreadable_ledger_retires_nothing_rather_than_guessing` | *a malformed ledger produced ids from somewhere* |
| M8 | a lookup that finds nothing reports a removal | `a_retired_pack_that_is_not_installed_is_not_an_error` | *reported removing a pack that was never there* |
| M9 | the `games/` walk pointed at a real directory with no `pack.json` | the anti-vacuity guard, Rust **and** TS | *found only 0 pack.json files under …/dynawalla-app/src — this test is looking in the wrong place* |
| M10 | `remove_retired` starts enumerating the root | TS | *remove_retired enumerates the directory it writes into — that is the rule that deletes downloads* |
| M11 | `sync_bundled` stops calling the launch sequence | TS | *sync_bundled does not run the launch sequence* |
| M12 | `remove_retired` resolves a link before deleting (`canonicalize()`) | `a_retired_id_that_is_a_symlink_does_not_reach_what_it_points_at` | *a symlinked pack id reached outside the pack root* |

M9 is there because three vacuous sweeps got through this repository in a fortnight: both disjointness tests assert they found ≥ 20 `pack.json` files before asserting anything about them, and M9 proves that guard fires.

### Gates

```
$ cargo fmt --check                                    # FMT OK
$ cargo clippy --locked --all-targets                  # dynawalla: 0 unique clippy warning(s), 0 unique error(s)
$ for i in 1..5; cargo test --locked --lib packs::
  test result: ok. 38 passed; 0 failed   (×5)

$ npm run -s lint                                      # LINT OK
$ npm run -s tsc                                       # TSC OK
$ for i in 1..5; npm run -s test        (dynawalla-app)
  pass 420  fail 0                                     (×5)
$ npm run -s build                                     # exit 0

$ npm run -s tsc                        (packs/sdk)    # SDK TSC OK
$ for i in 1..5; npm run -s test        (packs/sdk)
  pass 121  fail 0                                     (×5)

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"   # ok
$ node --check dynawalla/packs/build.mjs                                       # ok
$ gitleaks detect --log-opts="origin/main..HEAD"                               # no leaks found
```

`packs::` was 30 tests before this change and is 38 after; the eight new ones are the launch sequence, the no-bundle/idempotence case, the ledger's contents, ledger-vs-`games/` disjointness, a hostile ledger entry, an unreadable ledger, the nothing-to-do launch, and a symlinked pack id.

### Self-review notes

The adversarial pass I ran by hand raised one question worth evidence rather than reasoning: a pack directory that is a **symlink**. `is_dir()` follows links, so `remove_retired` does reach `remove_dir_all` on one — and `fs::remove_dir_all` does not follow a link at the path it is handed, so the target is safe. That is now pinned by a test rather than trusted (M12 above). No route in this module can make a pack directory a symlink in the first place: `copy_tree` skips links and both extractors write regular files only.

The other paths I checked and found closed: a traversal or absolute path in the ledger dies at `valid_pack_id` before `join` (M4); `include_str!` registers a compiler file dependency, so editing the ledger rebuilds the crate, and the path is inside the repo on every build target; the `build.mjs` guard runs after `discover()` and before the first `buildOne`, so a contradiction costs one message and no build; and the new `cargo test` step sits after the compile step that creates the `dist/` tauri-codegen needs, in the same job.
