### PR TITLE
dynawalla: THE LATTICE gets its ring back, and LATTICE RUNNER becomes THE TUNING HALL

### DIFF
--- a/dynawalla/dynawalla-app/src/catalog/motifs.ts
+++ b/dynawalla/dynawalla-app/src/catalog/motifs.ts
@@ -164,7 +164,7 @@ const balance: Motif = (rng) => {
   ]
 }
 
-/** LATTICE RUNNER — ride a beam, fire, hear the remainder. */
+/** THE TUNING HALL (pack id `dynawalla.beam`) — ride a beam, fire, hear the remainder. */
 const beams: Motif = (rng) => {
   const out: Shape[] = []
   const rows = [24, 42, 60, 78]

--- a/dynawalla/games/beam/README.md
+++ b/dynawalla/games/beam/README.md
@@ -1,9 +1,36 @@
-# LATTICE RUNNER
+# THE TUNING HALL
 
-> after *Beam Rider* (1983). Rank 23, S tier, wave 2 of `docs/catalog/ARCADE_CANON.md`.
+> after *Beam Rider* (1983). Rank 23, S tier, wave 2 of `docs/catalog/ARCADE_CANON.md`,
+> where the design is catalogued as **Lattice Runner** — see the rename below.
 >
 > **Loop:** ride a divisor beam; only a beam that divides the automaton kills it.
 > **Juice:** resonance lock as two waveforms phasing — division made audible.
+
+## The name
+
+It shipped as **LATTICE RUNNER** and the catalogue also carries **THE LATTICE**
+(`games/lattice`), a twin-stick factor-tree arena that is a completely different
+game. Two names one word apart in one listing is a bad enough problem on its own;
+what it actually cost is on the record:
+
+> "Lattice runner is pretty cool but it's too hard and fast for a human .. maybe
+> one number at a time and a slower ramp up from an easier baseline .. the way it
+> starts for me now is chaotic and impossible."
+
+That report is quoted at the top of `games/lattice/src/game/opening.ts` and the
+calm opening it asks for was built **into the other pack**. LATTICE RUNNER did not
+get one, which is why the next report was "LATTICE RUNNER IS TOO FUCKING FAST FOR
+THE 100TH TIME." A pack that cannot be named unambiguously cannot be fixed
+reliably.
+
+So the display name is now THE TUNING HALL — a place in the bazaar where things
+are tuned until the wobble stops, which is this game's own verb — and the word
+"lattice" appears on no surface a child sees.
+
+**The pack id and the directory are still `beam`**, exactly as MATH NINJA and THE
+PEDDLER kept theirs: `dynawalla.beam` is what the catalogue, the build, the
+installed-pack record and the storage slots are keyed on, and renaming it would
+break every one of them for a cosmetic gain.
 
 ## The rule
 
@@ -158,6 +185,57 @@ resolving, and that exposure is worth something even when the answer is not. It 
 reason the miss is spent on the mathematics rather than on feedback about the miss:
 there is no red, no shake, no word for what happened, and no lamp goes out.
 
+**And it does not expire.** It used to run down `revealSeconds` — a second and a half to
+three — and then take the sum away whether or not anybody had finished reading it. That
+is the defect `packs/shared/game-pacing`'s `revealPlan` exists to name, and its answer is
+`holdMs: Infinity`: a child who has just missed is the slowest reader in the session, so
+a timer sized for a fluent one removes the evidence exactly when it becomes useful. The
+hall now stays held until the child's own hand ends it, with `REVEAL_SETTLE_MS` of
+lockout so the second tap of an impatient double-tap cannot dismiss a sum the first tap
+only just put up.
+
+## The opening
+
+> "LATTICE RUNNER IS TOO FUCKING FAST FOR THE 100TH TIME. NO ONE CAN THINK THAT FAST."
+
+The comprehension window was decoupled from the motion knob a while ago and stayed
+decoupled (see above), and the game was still too fast — because the window is only one
+of the two things that make a board fast. The other is **how much is happening while you
+use it**, and that had no floor at all: the director opened at `floorCount: 2` and the
+fracture threw out four candidates, so a child's very first screen was up to eight
+numbered hulls, six of them irrelevant to the sum on the seventh.
+
+Worse, the escalation was a **clock**. `Director.pressure` is
+`elapsed/90 × 0.65 + kills/60 × 0.45`, so two thirds of it was time served rather than
+anything demonstrated — and `drawWave` asks the host for `2 + round(level × 7)`, which
+means the clock was raising the *arithmetic*. A child who had answered nothing in ninety
+seconds was being handed item difficulty 7 and five hulls at a 1.3-second spawn gap.
+
+`sim/opening.ts` is the ramp, indexed by cores this child has **read** — `sim/learned.ts`
+persists it, `+1` for a core read and `−1` for a miss or a wave that reached the floor,
+floored at zero, never shown to anybody. Measured through the real shell, the real frame
+loop and the real keyboard handler, sixty seconds, five seeds, 768×1024, with a bot that
+slides, fires and dismisses the way a child's hands do:
+
+| | shipped | first sitting |
+|---|---|---|
+| numbered hulls, peak | 8 | **2** |
+| numbered hulls, mean | 3.92 | **1.62** |
+| the second problem arrives | 6.1s | **11.2s** |
+| problems asked in 60s | 10.8 | **5.8** |
+| item difficulty after 90s of sitting still | 7 | **2** |
+
+The first sitting is the CORE by itself until it fractures and then two candidates: one
+sum, two answers, nothing else moving. The board comes back up as the child reads cores —
+5.8 problems a minute at step 0, 8–9 by step 4 — and **the top step is the shipped game
+in every field**, asserted in `opening.test.ts` against the constants themselves. Nothing
+is lost at the ceiling; a child simply has to arrive there.
+
+Nothing in the ramp touches `sim/window.ts`. `descentScale` moves the ordinary stream and
+the core's approach — the motion, which is the excitement — and a candidate's fall is
+still computed from the item's own `windowSeconds` at fracture time. Speed is rewarded
+and never enforced.
+
 ## Stakes
 
 Three anchors. An ordinary automaton reaching the floor breaches one; at zero the lattice
@@ -167,7 +245,9 @@ cores read relights an anchor, cumulatively, and that progress is never taken aw
 
 Escalation is on the size of the run — elapsed time and total kills — and never on an
 unbroken streak. `src/test/director.test.ts` asserts that two runs reaching the same
-totals by different routes land on identical pressure.
+totals by different routes land on identical pressure. During the ramp that curve is
+**capped** at `opening.ceiling`; at the top step the cap is 1 and the curve is exactly
+what it always was. See "The opening".
 
 ## Running it
 

--- a/dynawalla/games/beam/index.html
+++ b/dynawalla/games/beam/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
-    <title>LATTICE RUNNER — dev harness</title>
+    <title>THE TUNING HALL — dev harness</title>
     <style>
       html,
       body {

--- a/dynawalla/games/beam/pack.html
+++ b/dynawalla/games/beam/pack.html
@@ -8,7 +8,7 @@
     />
     <meta name="color-scheme" content="dark" />
     <meta name="theme-color" content="#04060d" />
-    <title>LATTICE RUNNER</title>
+    <title>THE TUNING HALL</title>
     <style>
       html,
       body {

--- a/dynawalla/games/beam/pack.json
+++ b/dynawalla/games/beam/pack.json
@@ -1,8 +1,8 @@
 {
   "id": "dynawalla.beam",
   "version": "0.1.0",
-  "name": "LATTICE RUNNER",
-  "description": "A lattice of numbered beams. Ride one and fire, and a pulse destroys an automaton only when the beam divides the number it carries — while the beam sings the remainder against it, and goes pure when it hits zero.",
+  "name": "THE TUNING HALL",
+  "description": "Five numbered beams of light run down a hall. Ride one and fire, and a pulse destroys an automaton only when the beam divides the number it carries — while the beam sings the remainder against it, and goes pure when it hits zero.",
   "sdk": "1.0.0",
   "host": { "min": "0.1.0", "max": "1.0.0" },
   "entry": "pack.html",

--- a/dynawalla/games/beam/package.json
+++ b/dynawalla/games/beam/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "LATTICE RUNNER — ride a divisor beam. A pulse fired up beam b destroys an automaton carrying v if and only if b divides v, and the beam sings the remainder while you decide.",
+  "description": "THE TUNING HALL — ride a divisor beam. A pulse fired up beam b destroys an automaton carrying v if and only if b divides v, and the beam sings the remainder while you decide.",
   "engines": {
     "node": ">=24.0.0"
   },

--- a/dynawalla/games/beam/src/contract.ts
+++ b/dynawalla/games/beam/src/contract.ts
@@ -4,7 +4,7 @@
 // `mount` delegates to `./mount.ts`. That module imports `Host` from here
 // type-only, and a type-only import is erased, so there is no runtime cycle.
 
-import { mountBeam } from "./mount.ts"
+import { mountBeam, type Snapshot } from "./mount.ts"
 
 export type Question = {
   id: string
@@ -81,6 +81,14 @@ export type Handle = {
    * sheet's.
    */
   setPaused(paused: boolean): void
+  /**
+   * What is on the lattice right now. Observation only — see `mount.Snapshot`.
+   *
+   * On the handle rather than on a side channel because the thing being measured
+   * is what a child is looking at, and the only object that knows that is the
+   * mounted game. The host never calls it and no rule reads it.
+   */
+  snapshot(): Snapshot
 }
 
 export function mount(el: HTMLElement, host: Host): Handle {

--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -1,4 +1,4 @@
-// LATTICE RUNNER — the game.
+// THE TUNING HALL — the game. Directory and pack id are still `beam`.
 //
 // You ride the foot of a lattice of numbered beams. Automata walk down it
 // carrying numbers. A pulse fired up beam `b` destroys an automaton carrying
@@ -54,8 +54,10 @@ import {
   withAlpha,
 } from "./render/palette.ts"
 import { KIND_MOTE, KIND_SHARD, Particles } from "./render/particles.ts"
+import { REVEAL_SETTLE_MS } from "../../../packs/shared/game-pacing/index.ts"
 import { buildCore, type CoreWave } from "./sim/core.ts"
-import { revealSeconds } from "./sim/window.ts"
+import { coresRead as coresReadEver, noteMissed, noteRead } from "./sim/learned.ts"
+import { openingAt } from "./sim/opening.ts"
 import { Director, fieldValue, killScore, readingRelief } from "./sim/director.ts"
 import { A_CANDIDATE, A_CORE, A_ORDINARY, type Automaton, Field } from "./sim/field.ts"
 import { phaseOffset, resonates, tuneLattice, validBeamCount } from "./sim/lattice.ts"
@@ -77,9 +79,36 @@ type Pulse = { alive: boolean; col: number; t: number; prevT: number; hits: numb
 type Pop = { alive: boolean; x: number; y: number; life: number; max: number; text: string; size: number; color: string }
 type Banner = { text: string; sub: string; life: number; max: number; color: string }
 
+/**
+ * What is on the lattice right now, for the tests that measure the opening.
+ *
+ * An observation seam and nothing else: the shell never reads it, no rule
+ * branches on it, and removing it would change no behaviour. It exists because
+ * "how many numbered hulls is a child looking at" is the founder's whole report
+ * and it cannot be answered from the pure functions — the ramp only reaches the
+ * screen through the director, the field, the spawn cadence and the fracture,
+ * and every one of those is in this module. `opening.test.ts` drives the real
+ * loop and the real input handlers and reads this.
+ */
+export type Snapshot = {
+  /** Numbered hulls a child can see: ordinary automata, candidates, and a core. */
+  readonly onLattice: number
+  readonly ordinaries: number
+  readonly candidates: number
+  /** The problem currently on the wall, or `null` when there is none. */
+  readonly prompt: string | null
+  /** Items drawn from the host since this mount. */
+  readonly asked: number
+  /** The ramp step this child is on. See `sim/opening.ts`. */
+  readonly step: number
+  /** Whether the finished sum is up and the hall is held. */
+  readonly revealed: boolean
+}
+
 export function mountBeam(el: HTMLElement, host: Host): {
   unmount(): void
   setPaused(paused: boolean): void
+  snapshot(): Snapshot
 } {
   // ── surface ──────────────────────────────────────────────────────────────
   const root = document.createElement("div")
@@ -104,9 +133,9 @@ export function mountBeam(el: HTMLElement, host: Host): {
   // the game is broken when most shots bounce. The manual stays reachable during
   // play, because the moment a child needs the rule is never the title screen.
   const guide = createInstructions(root, {
-    title: "LATTICE RUNNER",
+    title: "THE TUNING HALL",
     summary: [
-      "Five beams of light run down the hall, and together they are the lattice. Each beam has a number at the bottom.",
+      "Five beams of light run down the hall. Each beam has a number at the bottom.",
       "Robots walk down carrying numbers. Ride a beam and shoot — but a shot only works if the beam's number divides the robot's number.",
     ],
     sections: [
@@ -156,7 +185,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
         lines: [
           "Three lights sit at the top of the screen. The game calls each one an anchor.",
           "A robot that reaches the floor puts one out.",
-          "When all three are out the run is over and the screen says THE LATTICE GOES DARK. Tap to start again.",
+          "When all three are out the run is over and the screen says THE HALL GOES DARK. Tap to start again.",
           "Read two cores right and one anchor lights up again.",
         ],
       },
@@ -187,6 +216,20 @@ export function mountBeam(el: HTMLElement, host: Host): {
   const parts = new Particles()
   const field = new Field()
   const director = new Director()
+
+  /**
+   * Put this child's step on the director, and keep it there.
+   *
+   * Called at mount and after every wave — a step is a fact about the child, not
+   * about the run, so it survives a game over and a remount and the next
+   * sitting. `sim/learned.ts` is what remembers it and `sim/opening.ts` is the
+   * table it indexes.
+   */
+  function fitOpening(): void {
+    director.opening = openingAt(coresReadEver())
+  }
+  fitOpening()
+
   // Two streams, deliberately separated.
   //
   // `rng` is the RUN: the numbers on the hulls, how the lattice tunes, which
@@ -240,15 +283,29 @@ export function mountBeam(el: HTMLElement, host: Host): {
   /**
    * THE FINISHED STATEMENT, after a miss or a wave that ran out.
    *
-   * `left` runs the text down; `hold` freezes the lattice for exactly as long,
-   * which is the part of STACK's reveal that makes it work — its sweep is HELD
-   * so the child never reads one thing while aiming at another. A frozen hall
-   * costs the child nothing: no wave is live, so no answering window is
-   * running, and every automaton that was descending is exactly where it was
-   * when the hold lifts.
+   * The lattice is HELD while it is up, which is the part of STACK's reveal that
+   * makes it work — its sweep is held so the child never reads one thing while
+   * aiming at another. A frozen hall costs the child nothing: no wave is live,
+   * so no answering window is running, and every automaton that was descending
+   * is exactly where it was when the hold lifts.
+   *
+   * **And it does not expire.** It used to run down `revealSeconds` — one and a
+   * half to three seconds — and then take the sum away whether or not anybody
+   * had finished reading it. `packs/shared/game-pacing`'s `revealPlan` is the
+   * fleet's answer to exactly that, and it is `holdMs: Infinity`:
+   *
+   * > "you should be able to study the answers and then go on, not just have the
+   * > answers flashed for a second and then go on"
+   *
+   * A child who has just missed is the slowest reader in the session, and a
+   * timer sized for a fluent one removes the evidence exactly when it was about
+   * to be useful. So the hall stays held until the child's own hand ends it, and
+   * `settleLeft` is the only thing that delays that: `REVEAL_SETTLE_MS` of
+   * lockout, so the second tap of an impatient double-tap does not dismiss a
+   * reveal the first tap only just put up.
    */
-  let reveal: { text: string; answer: string; left: number } | null = null
-  let hold = 0
+  let reveal: { text: string; answer: string; settleLeft: number } | null = null
+  let hold = false
 
   const pulses: Pulse[] = []
   for (let i = 0; i < 4; i++) pulses.push({ alive: false, col: 0, t: 0, prevT: 0, hits: 0 })
@@ -409,6 +466,10 @@ export function mountBeam(el: HTMLElement, host: Host): {
         { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors },
         N_BEAMS,
         () => rng.next(),
+        // Two answers to choose between on a child's first core, four once they
+        // have read a few. The window is unchanged either way — this is how much
+        // there is to READ, not how long there is to read it.
+        director.opening.candidates,
       )
       if (built) return built
     }
@@ -522,12 +583,32 @@ export function mountBeam(el: HTMLElement, host: Host): {
    * plate lighting up — and none of the parts a scolding is. There is no word
    * for what happened, no red, no shake and no lamp going out: a wrong
    * submission has never cost an anchor in this game and it does not start now.
+   *
+   * It stays up until the child ends it. See the note on `reveal`.
    */
   function completeSum(w: CoreWave): void {
-    const seconds = revealSeconds({ prompt: w.prompt, answer: w.answer })
-    reveal = { text: w.prompt, answer: String(w.answer), left: seconds }
-    hold = seconds
+    reveal = { text: w.prompt, answer: String(w.answer), settleLeft: REVEAL_SETTLE_MS / 1000 }
+    hold = true
     audio.riser()
+  }
+
+  /**
+   * The child's own hand, ending the reveal.
+   *
+   * Called from every input path — a key, a tap, a slide — and it is the ONLY
+   * thing that ends one. Refused for `REVEAL_SETTLE_MS`, which is latency and
+   * not patience: the gesture that ended the wave is routinely still arriving.
+   *
+   * @returns true when the input was spent on the reveal and must not also be
+   *   read as a move or a shot. A child dismissing a sum they were reading has
+   *   not aimed at anything.
+   */
+  function dismissReveal(): boolean {
+    if (!reveal) return false
+    if (reveal.settleLeft > 0) return true
+    reveal = null
+    hold = false
+    return true
   }
 
   function expireWave(): void {
@@ -548,6 +629,12 @@ export function mountBeam(el: HTMLElement, host: Host): {
     // nothing. It is feature-detected: a host without it hears silence, which
     // is what an unmeasured item should sound like.
     host.skip?.(w.questionId)
+    // The host hears nothing — the child demonstrated nothing about arithmetic —
+    // and the RAMP hears a step down, because a wave that reached the floor
+    // unanswered is this game's only direct evidence that the board was faster
+    // than the child. Two different questions; see `sim/learned.ts`.
+    noteMissed()
+    fitOpening()
     // Not a buzzer and not a life ticking down: the sum finishes on the wall,
     // in the same place it has been legible all along.
     completeSum(w)
@@ -660,6 +747,11 @@ export function mountBeam(el: HTMLElement, host: Host): {
     if (body.correct) {
       right++
       coresRead++
+      // The ramp's only input, and it is what the child demonstrated. Never
+      // shown, never scored, and it is the reason the board is allowed to get
+      // busier at all — see `sim/learned.ts`.
+      noteRead()
+      fitOpening()
       if (anchors < ANCHORS) credit = Math.min(READ_PER_ANCHOR, credit + 1)
       resonance = Math.min(RESONANCE_MAX, resonance + 1)
       resonanceLeft = RESONANCE_SECONDS
@@ -708,6 +800,12 @@ export function mountBeam(el: HTMLElement, host: Host): {
       // without scolding, and the sum completing on the wall. A wrong
       // submission still costs the multiplier, which is the whole economy and
       // is the reason a guess is not free; it has never cost an anchor.
+      // A step back down the ramp: the next board this child meets is calmer.
+      // Not a punishment and not a judgement — the number is never shown and the
+      // host is told nothing extra. It is the game noticing that this one was
+      // hard and getting out of the way. See `sim/learned.ts`.
+      noteMissed()
+      fitOpening()
       audio.settleWrong()
       feel.kick(0, 1, 3)
       host.haptic("light")
@@ -747,7 +845,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
     wave = null
     coreBody = null
     reveal = null
-    hold = 0
+    hold = false
     if (score > best) {
       best = score
       writeBest(best)
@@ -755,7 +853,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
     audio.collapse()
     feel.addTrauma(0.6)
     feel.slowmo(0.25, 900)
-    showBanner("THE LATTICE GOES DARK", "tap to tune it again", RESONANT, 3)
+    showBanner("THE HALL GOES DARK", "tap to tune it again", RESONANT, 3)
   }
 
   function restart(): void {
@@ -776,7 +874,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
     coreBody = null
     banner = null
     reveal = null
-    hold = 0
+    hold = false
     field.clear()
     parts.clear()
     feel.reset()
@@ -810,7 +908,11 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function onDown(e: PointerEvent): void {
-    if (paused || hold > 0) return
+    if (paused) return
+    // A tap on a held hall is the child saying they have finished reading. It is
+    // spent there and is not also a shot: the runner has not moved and nothing
+    // was aimed at.
+    if (dismissReveal()) return
     void audio.start()
     if (over) {
       if (performance.now() - overAt > 550) restart()
@@ -827,7 +929,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function onMove(e: PointerEvent): void {
-    if (paused || hold > 0 || !pointerDown) return
+    if (paused || hold || !pointerDown) return
     if (!dragged && Math.hypot(e.clientX - downX, e.clientY - downY) > 14) dragged = true
     if (!dragged) return
     // A drag is the *listening* verb: it rides the lattice without firing, so a
@@ -843,10 +945,14 @@ export function mountBeam(el: HTMLElement, host: Host): {
   }
 
   function onKey(e: KeyboardEvent): void {
-    // Refused, not queued. The runner cannot move while the hall is held, so a
-    // tap that set `fireOnArrive` would sit there looking like a dead control
-    // and then go off on its own two seconds later.
-    if (paused || hold > 0) return
+    // Spent on the reveal, not queued. The runner cannot move while the hall is
+    // held, so a key that set `fireOnArrive` would sit there looking like a dead
+    // control and then go off on its own once the hall let go.
+    if (paused) return
+    if (dismissReveal()) {
+      e.preventDefault()
+      return
+    }
     if (e.key === "ArrowLeft") rideTo(runnerCol - 1, false)
     else if (e.key === "ArrowRight") rideTo(runnerCol + 1, false)
     else if (e.key === " " || e.key === "Enter") {
@@ -868,17 +974,16 @@ export function mountBeam(el: HTMLElement, host: Host): {
   let raf = 0
 
   function step(dt: number): void {
-    if (reveal) {
-      reveal.left -= dt
-      if (reveal.left <= 0) reveal = null
-    }
-    if (hold > 0) {
+    if (reveal) reveal.settleLeft = Math.max(0, reveal.settleLeft - dt)
+    if (hold) {
       // THE HOLD. The lattice is still while the sum finishes: nothing
       // descends, nothing spawns, no pulse travels and the clock the director
-      // escalates on does not advance, and input is refused. Only the
-      // decoration keeps moving — the sparks and the resonance traces — so a
-      // held hall reads as held rather than as crashed.
-      hold -= dt
+      // escalates on does not advance, and input is spent on the reveal rather
+      // than on the lattice. Only the decoration keeps moving — the sparks and
+      // the resonance traces — so a held hall reads as held rather than as
+      // crashed.
+      //
+      // It ends when the child ends it. See `dismissReveal`.
       if (!reduced) traceScroll += dt * 0.42
       parts.update(dt)
       for (const q of pops) {
@@ -1144,6 +1249,21 @@ export function mountBeam(el: HTMLElement, host: Host): {
 
   return {
     setPaused,
+
+    snapshot(): Snapshot {
+      const ordinaries = field.liveCount(A_ORDINARY)
+      const candidates = field.liveCount(A_CANDIDATE)
+      const core = field.liveCount(A_CORE)
+      return {
+        onLattice: ordinaries + candidates + core,
+        ordinaries,
+        candidates,
+        prompt: wave ? wave.prompt : null,
+        asked,
+        step: director.opening.step,
+        revealed: reveal !== null,
+      }
+    },
 
     unmount(): void {
       running = false

--- a/dynawalla/games/beam/src/pack.ts
+++ b/dynawalla/games/beam/src/pack.ts
@@ -1,4 +1,4 @@
-// LATTICE RUNNER, as a Dynawalla pack.
+// THE TUNING HALL, as a Dynawalla pack.
 //
 // The seam and nothing else. `mount` is handed the real host in place of the
 // stub, because the adapter presents the same synchronous surface `Host` in
@@ -54,5 +54,5 @@ async function start(el: HTMLElement): Promise<void> {
 
 void start(root).catch((error: unknown) => {
   console.error("[beam] could not start", error)
-  renderNoHost(root, "LATTICE RUNNER")
+  renderNoHost(root, "THE TUNING HALL")
 })

--- a/dynawalla/games/beam/src/render/palette.ts
+++ b/dynawalla/games/beam/src/render/palette.ts
@@ -1,4 +1,4 @@
-// LATTICE RUNNER — a resonance hall, cut into stone, lit only by the lattice.
+// THE TUNING HALL — a resonance hall, cut into stone, lit only by its beams.
 //
 // The register is the house one: brass, lapis, carved stone, cold celestial
 // light. Not neon, not gradient soup. The beams are the only light source in

--- a/dynawalla/games/beam/src/sim/core.ts
+++ b/dynawalla/games/beam/src/sim/core.ts
@@ -69,8 +69,8 @@ function parseValue(s: string): number | null {
 }
 
 /** Fewer than this and the choice is not a choice. */
-const MIN_CANDIDATES = 2
-const MAX_CANDIDATES = 4
+export const MIN_CANDIDATES = 2
+export const MAX_CANDIDATES = 4
 
 export type CoreSource = {
   id: string
@@ -91,14 +91,23 @@ export function buildCore(
   source: CoreSource,
   beamCount: number,
   rand: () => number,
+  /**
+   * The most candidates this wave may carry, from `sim/opening.ts`.
+   *
+   * Clamped into `MIN_CANDIDATES..MAX_CANDIDATES` here rather than trusted: two
+   * is a choice and one is a formality, and a caller that asked for one would
+   * silently turn the question into "hit the only thing on the screen".
+   */
+  cap: number = MAX_CANDIDATES,
 ): CoreWave | null {
+  const most = Math.max(MIN_CANDIDATES, Math.min(MAX_CANDIDATES, Math.floor(cap)))
   const answer = parseValue(source.answer)
   if (answer === null || !usableCoreValue(answer)) return null
 
   const seen = new Set<number>([answer])
   const values: number[] = [answer]
   for (const raw of source.distractors) {
-    if (values.length >= MAX_CANDIDATES) break
+    if (values.length >= most) break
     const v = parseValue(raw)
     // A distractor is held to the same standard as the answer. A small prime —
     // 5, 7, 11 — can only be killed from its own beam, and a beam labelled 5
@@ -120,7 +129,7 @@ export function buildCore(
     // wave where the only thing on screen is the answer.
     const extra: number[] = []
     for (const v of columnMalRules(answer)) {
-      if (extra.length + kept.length >= MIN_CANDIDATES + 1) break
+      if (extra.length + kept.length >= Math.min(most, MIN_CANDIDATES + 1)) break
       if (seen.has(v) || !usableCoreValue(v)) continue
       if (!beamDivisors(v).some((d) => beams.includes(d))) continue
       seen.add(v)
@@ -136,6 +145,16 @@ export function buildCore(
   if (!beams.some((b) => resonates(b, answer))) return null
   kept = kept.filter((v) => v === answer || beams.some((b) => resonates(b, v)))
   if (kept.length < MIN_CANDIDATES) return null
+
+  // **Trimmed to the cap here and nowhere earlier.** The re-tune above can only
+  // remove values, so trimming before it would leave a wave the ramp asked to
+  // hold two of carrying three whenever the mal-rule top-up fired. The answer is
+  // never the one dropped — a wave without its own answer on it is not a
+  // question, it is four wrong numbers.
+  if (kept.length > most) {
+    const rest = kept.filter((v) => v !== answer).slice(0, most - 1)
+    kept = [answer, ...rest]
+  }
 
   // Shuffle by rejection so the answer is not always the leftmost candidate.
   const order = [...kept]

--- a/dynawalla/games/beam/src/sim/director.ts
+++ b/dynawalla/games/beam/src/sim/director.ts
@@ -12,6 +12,7 @@
 //     run rather than the ceiling alone.
 
 import { isFieldValue, MAX_BEAM, resonates, validBeamCount } from "./lattice.ts"
+import { type Opening, STEADY_OPENING } from "./opening.ts"
 
 export type Pressure = {
   /** 0..1 — the single scalar every other number below is derived from. */
@@ -37,6 +38,16 @@ export class Director {
   private sinceCore = 0
   private coresRun = 0
 
+  /**
+   * Where this child is on the ramp. See `sim/opening.ts`.
+   *
+   * The steady state by default, so every test written before the ramp existed
+   * keeps asking about the game a child who has played before actually gets, and
+   * so a `new Director()` anywhere is the shipped game and not a special case.
+   * `mount` sets it from `sim/learned.ts` at mount and after every wave.
+   */
+  opening: Opening = STEADY_OPENING
+
   /** Seconds of play, for the pressure curve. Advanced by the frame loop. */
   advance(dt: number): void {
     this.elapsed += dt
@@ -61,17 +72,33 @@ export class Director {
     // a child who is good at this gets there sooner than one who is grinding.
     const byTime = Math.min(1, this.elapsed / 90)
     const byKills = Math.min(1, this.kills / 60)
-    const level = Math.min(1, byTime * 0.65 + byKills * 0.45)
+    // **And then the ramp caps it.** The curve above is a clock — two thirds of
+    // it is `elapsed / 90` — and a clock decides how fast a board gets in front
+    // of a child who has demonstrated nothing. So what the curve computes is
+    // what a child at the top of the ramp is handed, unchanged, and every step
+    // below that is handed at most `opening.ceiling` of it. The cap is the whole
+    // of the change: nothing here is retuned and the ceiling is 1 at the top.
+    //
+    // It reaches the ARITHMETIC and not only the motion. `mount.drawWave` asks
+    // the host for `2 + round(level × 7)`, so an uncapped clock was raising the
+    // item difficulty from 2 to 7 against a child who had not answered one.
+    const level = Math.min(1, byTime * 0.65 + byKills * 0.45, this.opening.ceiling)
     return {
       level,
       // The floor was 13 and that was wrong. A run opens at pressure zero, and
       // at 13 seconds a crossing the first minute of play contained about two
       // curriculum problems — a child's first thirty seconds with this game is
       // exactly when it has to prove it is about arithmetic.
-      descentSeconds: lerp(10, 5.8, level),
+      // Scaled by the ramp, which is 1 at the top step. This is motion and not
+      // thinking time: a candidate's fall is computed from the ITEM's
+      // `windowSeconds` at fracture time and nothing here touches it.
+      descentSeconds: lerp(10, 5.8, level) * this.opening.descentScale,
       stepSeconds: lerp(1.15, 0.62, level),
       spawnGap: lerp(2.0, 0.95, level),
-      floorCount: Math.round(lerp(2, 5, level)),
+      // The ramp says how many hulls a child at this step may be asked to track
+      // BESIDE the sum. `0` is the founder's one number: the only thing on the
+      // lattice is the problem.
+      floorCount: Math.min(Math.round(lerp(2, 5, level)), this.opening.ordinaries),
       tightness: lerp(0.15, 0.8, level),
     }
   }
@@ -91,6 +118,12 @@ export class Director {
    *   test suite over it because the test only ever called the pure function.
    */
   wantsSpawn(live: number, p: Pressure = this.pressure()): boolean {
+    // **The ramp's cap is a ceiling and not a target**, and that is the whole
+    // difference between "one number calmly coming down the lattice" and one
+    // number plus whatever the spawn gap has produced since. `floorCount` alone
+    // could not express it: at zero it stops PULLING hulls onto the lattice and
+    // the `sinceSpawn` clause below still pushes one every two seconds.
+    if (live >= this.opening.ordinaries) return false
     if (live < p.floorCount) return true
     return this.sinceSpawn >= p.spawnGap
   }
@@ -123,7 +156,11 @@ export class Director {
    */
   wantsCore(coreLive: boolean): boolean {
     if (coreLive) return false
-    return this.sinceCore >= 2
+    // The ramp lengthens the quiet between problems for a child who has not
+    // read many, and it is two seconds — the constant this shipped with — at the
+    // top step. This is DEAD time, which may escalate; the answering window,
+    // which may not, is `sim/window.ts` and is not in this file.
+    return this.sinceCore >= this.opening.coreGapSeconds
   }
 
   noteCore(): void {

--- a/dynawalla/games/beam/src/sim/learned.ts
+++ b/dynawalla/games/beam/src/sim/learned.ts
@@ -1,0 +1,103 @@
+// How much of this game this child has actually demonstrated.
+//
+// One integer, never shown to anybody, and it is the only thing `sim/opening.ts`
+// reads. It is not a score, not an accuracy and not a claim about the child — it
+// counts **cores read**, net, which is the only signal that tells "has never
+// seen this" apart from "has played this before".
+//
+// ## Why it is not the clock
+//
+// `Director.pressure()` escalates on `elapsed / 90`. That is a clock, and a
+// clock is the one thing the house rules forbid here: a child who has answered
+// nothing in ninety seconds was being handed a board 65% of the way up the
+// pressure curve — faster hulls, a shorter spawn gap, five automata alive
+// instead of two, and a requested item difficulty of 7 instead of 2 — for
+// having stayed in the room. The pacing audit found seventeen games doing a
+// version of this. This is the channel that replaces it during the ramp: the
+// board gets busier when the child shows they can read it, and at no other time.
+//
+// ## Both directions
+//
+// `+1` for a core read, `−1` for a wrong hand-in or a wave that reached the
+// floor, floored at zero. It walks back DOWN, and that is the half that makes it
+// a fit rather than a ratchet — a child having a bad afternoon is met with a
+// calmer lattice inside two waves rather than being left on a board that is
+// already too fast for them. Nothing about it is shown, said or scored.
+//
+// A wave that expired counts as a step down even though the game reports it to
+// the host as nothing at all (`host.skip`). Those are two different questions:
+// "what did this child demonstrate about arithmetic" is the host's, and the
+// honest answer is silence; "was that board too fast for them" is this module's,
+// and a candidate that reached the floor unanswered is a yes.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, so every access is guarded and the value is held in memory too. When
+// storage is unreachable a child gets the calm opening again next sitting, which
+// is the right way round: an extra gentle first minute costs nothing and
+// dropping a first-time child onto the full lattice is the report this came from.
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const READ_SLOT = "dw.beam.read" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn("[beam] localStorage is not reachable from this frame", error)
+    return null
+  }
+}
+
+function write(next: number): number {
+  memory = next
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(READ_SLOT, String(next))
+    } catch (error) {
+      console.warn("[beam] the cores-read count could not be written", error)
+    }
+  }
+  return next
+}
+
+/** Cores read, net, across every sitting this device remembers. Never negative. */
+export function coresRead(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(READ_SLOT) ?? "0")
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn("[beam] the cores-read count could not be read back", error)
+    }
+  }
+  return memory
+}
+
+/** A core was read. Returns the new total. */
+export function noteRead(): number {
+  return write(coresRead() + 1)
+}
+
+/**
+ * A wrong hand-in, or a wave that reached the floor with nothing handed in.
+ *
+ * Floored at zero, so the calmest board is a floor and not a hole a child can
+ * fall through.
+ */
+export function noteMissed(): number {
+  return write(Math.max(0, coresRead() - 1))
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetReadForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/beam/src/sim/opening.ts
+++ b/dynawalla/games/beam/src/sim/opening.ts
@@ -1,0 +1,146 @@
+// THE OPENING — what a child who has never played this walks into.
+//
+// The founder's report is the specification, and it is the same report he has
+// made repeatedly:
+//
+// > "Lattice runner is pretty cool but it's too hard and fast for a human ..
+// > maybe one number at a time and a slower ramp up from an easier baseline ..
+// > first time you enter it could be just one number calmly coming down the
+// > lattice .. It needs to be a bit more hand-holdy on the first run. slower,
+// > easier, more hand-holdy. the way it starts for me now is chaotic and
+// > impossible."
+//
+// > "LATTICE RUNNER IS TOO FUCKING FAST FOR THE 100TH TIME. NO ONE CAN THINK
+// > THAT FAST."
+//
+// The first of those was answered — **in the wrong pack.** It is quoted at the
+// top of `games/lattice/src/game/opening.ts` and the ramp it describes was built
+// into THE LATTICE, a different game whose display name differs from this one's
+// by one word. This file is that ramp, in the game the report was about. See
+// `README.md` for why the pack is being renamed.
+//
+// ## What it opened with
+//
+// Driving the real shell, the real loop and the real input handlers on a fresh
+// profile, over five seeds, at 768×1024:
+//
+//   * the CORE arrives at **2.0s** and fractures into **four candidates**, and
+//     the director is already holding **two ordinary automata** alive beside
+//     them, so the first thing this game ever shows a child is seven numbered
+//     hulls, six of which are irrelevant to the sum on the seventh;
+//   * a hull crosses the lattice in **10s** and steps sideways every 1.15s;
+//   * the next problem is asked **2s** after the last one clears, all sitting;
+//   * and the pressure curve is on a **clock** — `elapsed / 90` is 65% of it —
+//     so a child who has answered nothing at all is at level 0.65 after ninety
+//     seconds: five automata alive, a 1.3s spawn gap, hulls crossing in 7.3s,
+//     and the requested item difficulty raised from 2 to 7.
+//
+// That last line is the defect the fleet has now found seventeen times: an
+// escalation knob indexed by elapsed time rather than by anything the child
+// demonstrated. Here it does not merely tighten the motion, it raises the
+// **arithmetic** — `mount.drawWave` asks for `2 + round(level × 7)`.
+//
+// ## The ramp
+//
+// Six positions, indexed by cores this child has read — `sim/learned.ts`
+// remembers it across sittings and moves it in **both** directions, so a child
+// coming back to their sixth core is not walked through the first one again and
+// a child having a hard afternoon is met with a calmer lattice inside two waves.
+//
+//   0. **One number.** No ordinary automata at all: the only thing on the
+//      lattice is the CORE with the problem on its face, crossing at five
+//      eighths of the ordinary pace, and it fractures into two candidates. One
+//      sum, two answers to choose between, and nothing else moving.
+//   1. The same, a little quicker, and the next problem comes a little sooner.
+//   2. One ordinary automaton joins, and a third candidate. Now there is
+//      something to do besides the sum.
+//   3. Two automata, and the pressure curve is allowed off its floor.
+//   4. Three automata, four candidates, nearly the full curve.
+//   5. and after: the game as it shipped, unchanged, in every particular.
+//
+// Every quantity is **monotone** in `step` — busier, faster and harder as it
+// rises, and never the other way — and `opening.test.ts` asserts it exhaustively
+// over the whole table rather than taking it on trust.
+//
+// ## What this is NOT
+//
+// It is not a comprehension window and it does not touch one. The answering
+// window is `sim/window.ts`, is a pure function of the item, and cannot see this
+// module, that module, the director or a clock. `descentScale` below moves the
+// ORDINARY stream and the CORE's approach — the motion, which is the excitement
+// — and a candidate's fall is computed from `windowSeconds` at fracture time and
+// is not scaled by anything in here. Speed is rewarded and never enforced.
+
+/** Cores read after which the game is simply the game. */
+export const CALM_CORES = 5
+
+export type Opening = {
+  readonly step: number
+  /**
+   * The most ordinary automata the director may hold alive.
+   *
+   * `0` is the founder's one number: nothing on the lattice but the problem.
+   * `Infinity` hands the job back to the pressure curve, which is what the game
+   * has always done.
+   */
+  readonly ordinaries: number
+  /** The most candidates a fracture may throw out. Never below two — a choice. */
+  readonly candidates: number
+  /**
+   * Multiplies `descentSeconds`, so a bigger number is a SLOWER crossing.
+   *
+   * Applied to the ordinary stream and to the core's approach. Never to a
+   * candidate's fall, which is the child's thinking time and belongs to the
+   * item.
+   */
+  readonly descentScale: number
+  /** Seconds of quiet lattice between one wave clearing and the next arriving. */
+  readonly coreGapSeconds: number
+  /**
+   * The most of the pressure curve this step may reach, 0..1.
+   *
+   * This is the cap on the clock. `Director.pressure()` still computes
+   * `elapsed/90 × 0.65 + kills/60 × 0.45` exactly as it shipped; the ramp only
+   * says how much of it a child at this step is allowed to be handed. At the top
+   * step the cap is 1 and the curve is untouched.
+   */
+  readonly ceiling: number
+}
+
+const CALM: readonly Omit<Opening, "step">[] = [
+  { ordinaries: 0, candidates: 2, descentScale: 1.6, coreGapSeconds: 3.5, ceiling: 0 },
+  { ordinaries: 0, candidates: 2, descentScale: 1.45, coreGapSeconds: 3.1, ceiling: 0 },
+  { ordinaries: 1, candidates: 3, descentScale: 1.3, coreGapSeconds: 2.8, ceiling: 0 },
+  { ordinaries: 2, candidates: 3, descentScale: 1.2, coreGapSeconds: 2.5, ceiling: 0.25 },
+  { ordinaries: 3, candidates: 4, descentScale: 1.1, coreGapSeconds: 2.2, ceiling: 0.6 },
+]
+
+/**
+ * The steady state, and it is the shipped game to the digit.
+ *
+ * `ordinaries: Infinity` gives the pressure curve's own `floorCount` back;
+ * `candidates: 4` is `core.MAX_CANDIDATES`; `descentScale: 1` is no scaling;
+ * `coreGapSeconds: 2` is the constant `Director.wantsCore` shipped with; and
+ * `ceiling: 1` is the whole curve. Nothing is lost at the top of the ramp, which
+ * is the property `opening.test.ts` pins against the constants themselves.
+ */
+const STEADY: Omit<Opening, "step"> = {
+  ordinaries: Number.POSITIVE_INFINITY,
+  candidates: 4,
+  descentScale: 1,
+  coreGapSeconds: 2,
+  ceiling: 1,
+}
+
+/**
+ * The opening a child who has read `step` cores gets. Pure, total, and defined
+ * for every number including the ones that are not numbers.
+ */
+export function openingAt(step: number): Opening {
+  const at = Number.isFinite(step) ? Math.max(0, Math.floor(step)) : 0
+  const row = at < CALM.length ? (CALM[at] as Omit<Opening, "step">) : STEADY
+  return { step: at, ...row }
+}
+
+/** The steady state, by name, for a test or a rig that wants "past all this". */
+export const STEADY_OPENING: Opening = { step: CALM_CORES, ...STEADY }

--- a/dynawalla/games/beam/src/sim/window.ts
+++ b/dynawalla/games/beam/src/sim/window.ts
@@ -126,18 +126,15 @@ export function comprehensionWindow(item: Item): number {
 /**
  * How long the finished statement is held on the wall after a miss.
  *
- * This is the other half of the same argument and it is not a punishment
- * interval. A child who cannot yet produce `473 + 168` can still absorb it if
- * the game shows the whole thing completing — learning by exposure, at the
- * bottom of the range, which is a stated goal of the product. The miss is the
- * teaching moment, so the game spends it on the mathematics rather than on
- * feedback about the failure.
+ * **There is no such function any more, and this note is why.** It returned 1.5
+ * to 3 seconds and the shell spent it as a countdown, taking the completed sum
+ * away whether or not anybody had finished reading it. That is the defect
+ * `packs/shared/game-pacing`'s `revealPlan` names, and its answer is
+ * `holdMs: Infinity` — a child who has just missed is the slowest reader in the
+ * session, and a timer sized for a fluent one removes the evidence exactly when
+ * it becomes useful. `mount.completeSum` now holds the hall until the child's
+ * own hand ends it, with `REVEAL_SETTLE_MS` of lockout and nothing else.
  *
- * Longer for a wider sum, because a wider sum takes longer to read. Bounded at
- * both ends: never so short that it flashes past, never so long that a child
- * who knows what happened is kept waiting.
+ * Do not bring it back. A duration here is a deadline on reading, and reading is
+ * the only thing a miss is for.
  */
-export function revealSeconds(item: Item): number {
-  const columns = Math.max(1, Math.min(BY_COLUMNS.length - 1, widestColumn(item)))
-  return Math.min(3, 1.5 + columns * 0.3)
-}

--- a/dynawalla/games/beam/src/test/comprehension.test.ts
+++ b/dynawalla/games/beam/src/test/comprehension.test.ts
@@ -24,6 +24,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
+import { REVEAL_SETTLE_MS } from "../../../../packs/shared/game-pacing/index.ts"
 import { mount } from "../contract.ts"
 import type { Host, Question } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
@@ -31,6 +32,8 @@ import { geomForViewport } from "../render/geom.ts"
 import { promptPlate, PROMPT_MIN_PX } from "../render/hall.ts"
 import { buildCore } from "../sim/core.ts"
 import { Director, readingRelief } from "../sim/director.ts"
+import { noteRead, resetReadForTest } from "../sim/learned.ts"
+import { CALM_CORES } from "../sim/opening.ts"
 import { A_CANDIDATE, A_ORDINARY } from "../sim/field.ts"
 import { shovedUrgency } from "../sim/pulse.ts"
 import {
@@ -48,7 +51,7 @@ type Painted = { text: string; px: number; x: number; y: number }
 
 type Recorder = {
   el: HTMLElement
-  install(): () => void
+  install(step?: number): () => void
   step(ms: number): void
   /** What `fillText` drew, frame by frame. Index is the frame number. */
   readonly frames: Painted[][]
@@ -170,7 +173,20 @@ function recorder(width: number, height: number, wallClock: number): Recorder {
   return {
     el: makeEl(),
     frames,
-    install: () => {
+    /**
+     * @param step where on the ramp this child is. **The steady state by
+     *   default**, exactly as `games/lattice`'s `rig()` defaults its
+     *   `experience` — every case in this file was written about the shipped
+     *   game and must keep asking about the shipped game. `opening.test.ts` is
+     *   the one that asks for a first sitting, and it says so out loud.
+     *
+     *   Reset either way: the ramp's memory is module state, node has no
+     *   `localStorage`, and it survives every mount in the process. A test that
+     *   did not clear it would play a different game than the one before it did.
+     */
+    install: (step: number = CALM_CORES) => {
+      resetReadForTest()
+      for (let i = 0; i < step; i++) noteRead()
       globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
         pending = cb
         return 1
@@ -816,6 +832,17 @@ test("after a wrong submission the sum is completed on screen too", () => {
   // The same beat, reached the other way: the child handed in a value and it
   // was not the one. Nothing about what follows says so — the statement simply
   // finishes, in the colour a correct answer is celebrated in.
+  //
+  // **The floor is the settle and not a duration.** The reveal no longer expires
+  // at all (see `mount.reveal` and `game-pacing`'s `revealPlan`), so the only
+  // thing that ends one is the child's own hand — and the bot below is leaning
+  // on the controls, so what is measured here is a child who dismissed it
+  // immediately. `REVEAL_SETTLE_MS` is the lockout that stops the second tap of
+  // a double-tap taking down a sum the first tap only just put up, and it is
+  // what a completed sum is worth even to a child who wants nothing to do with
+  // it. The test below this one is the other end: nobody touches anything, and
+  // the sum is still there three minutes later.
+  const settleFrames = Math.floor(REVEAL_SETTLE_MS / 16)
   let seen = 0
   for (const seed of [0x2b1, 0x2b2, 0x2b3, 0x2b4]) {
     const rec = recorder(360, 640, seed * 31)
@@ -851,6 +878,10 @@ test("after a wrong submission the sum is completed on screen too", () => {
       restore()
     }
     for (const miss of misses) {
+      // A miss in the last breath of the run has no room left to be held FOR;
+      // the recording simply stops. Counting one would be measuring the length
+      // of the test rather than the length of the reveal.
+      if (miss.frame + settleFrames >= rec.frames.length) continue
       let held = 0
       let smallest = Infinity
       for (let f = miss.frame; f < rec.frames.length; f++) {
@@ -859,12 +890,136 @@ test("after a wrong submission the sum is completed on screen too", () => {
         held++
         smallest = Math.min(smallest, Math.max(...hit.map((p) => p.px)))
       }
-      assert.ok(held >= 60, `"${miss.finished}" was completed for only ${String(held)} frames`)
+      assert.ok(
+        held >= settleFrames,
+        `"${miss.finished}" was completed for only ${String(held)} frames, under the ` +
+          `${String(settleFrames)}-frame settle`,
+      )
       assert.ok(smallest >= PROMPT_MIN_PX, `the completed sum was ${smallest.toFixed(1)}px`)
       seen++
     }
   }
   assert.ok(seen > 0, "random play never once missed, so nothing was proved")
+})
+
+test("THE FINISHED SUM DOES NOT EXPIRE — IT WAITS FOR THE CHILD'S OWN HAND", () => {
+  // > "you should be able to study the answers and then go on, not just have the
+  // > answers flashed for a second and then go on"
+  //
+  // `revealSeconds` used to answer that with one and a half to three seconds and
+  // then take the sum away whether or not anybody had finished reading it. The
+  // child who has just missed is the slowest reader in the session; a timer
+  // sized for a fluent one removes the evidence exactly when it becomes useful.
+  //
+  // Nobody touches anything here. Three minutes later the sum is still up, the
+  // hall is still held, and NOTHING has been drawn from the host in the
+  // meantime — a reveal that quietly let the next wave in behind it would pass
+  // the first assertion and fail the child.
+  const rec = recorder(768, 1024, 0x5e77)
+  const restore = rec.install()
+  let served = 0
+  const host: Host = {
+    next: () => {
+      served++
+      return {
+        id: `tiny-${String(served)}`,
+        prompt: "4 + 4",
+        answer: "8",
+        distractors: ["6", "9", "12"],
+        domain: "add",
+        difficulty: 1,
+      }
+    },
+    report: () => undefined,
+    skip: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(rec.el, host)
+  try {
+    // Long enough for the first wave to arrive and run out untouched.
+    for (let i = 0; i < 1400 && !handle.snapshot().revealed; i++) rec.step(16)
+    assert.equal(handle.snapshot().revealed, true, "no wave ever ran out, so nothing was proved")
+    const askedWhenRevealed = handle.snapshot().asked
+    // Three minutes of a child reading, and a child reading touches nothing.
+    for (let i = 0; i < 11_250; i++) rec.step(16)
+    assert.equal(
+      handle.snapshot().revealed,
+      true,
+      "the finished sum took itself away while the child was still reading it",
+    )
+    assert.equal(
+      handle.snapshot().asked,
+      askedWhenRevealed,
+      "the game drew the next question from behind the sum it was still showing",
+    )
+    assert.equal(handle.snapshot().prompt, null, "a wave was live behind the reveal")
+
+    // And now the child's own hand, which is the only thing that ends it. The
+    // first key is refused — that is `REVEAL_SETTLE_MS`, and by three minutes in
+    // it has long since run down, so this one lands.
+    rec.press(" ")
+    rec.step(16)
+    assert.equal(handle.snapshot().revealed, false, "the child could not put the sum away")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("a tap arriving in the same breath as the miss cannot take the sum away", () => {
+  // `REVEAL_SETTLE_MS` is latency and not patience. The gesture that ended the
+  // wave is routinely still arriving on a touch screen — the second tap of an
+  // impatient double-tap, a finger that had already committed — and without a
+  // lockout those land inside the reveal's own fade-in and the child watches the
+  // lesson appear and vanish in one breath.
+  const rec = recorder(768, 1024, 0x5e78)
+  const restore = rec.install()
+  let served = 0
+  const host: Host = {
+    next: () => {
+      served++
+      return {
+        id: `tiny-${String(served)}`,
+        prompt: "4 + 4",
+        answer: "8",
+        distractors: ["6", "9", "12"],
+        domain: "add",
+        difficulty: 1,
+      }
+    },
+    report: () => undefined,
+    skip: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(rec.el, host)
+  try {
+    for (let i = 0; i < 1400 && !handle.snapshot().revealed; i++) rec.step(16)
+    assert.equal(handle.snapshot().revealed, true, "no wave ever ran out")
+    // Every frame of the settle, hammered. None of them may land. `floor` and
+    // not `ceil`: the frame the settle actually runs out ON is the first one
+    // allowed to let go, and asserting it is still up would be asserting a
+    // rounding.
+    const settleFrames = Math.floor(REVEAL_SETTLE_MS / 16)
+    for (let i = 0; i < settleFrames; i++) {
+      rec.press(" ")
+      assert.equal(
+        handle.snapshot().revealed,
+        true,
+        `a key ${String(i)} frame(s) into the settle took the sum away`,
+      )
+      rec.step(16)
+    }
+    // And then it lets go, on the child's next key and not on its own.
+    rec.step(16)
+    assert.equal(handle.snapshot().revealed, true, "the sum expired rather than being dismissed")
+    rec.press(" ")
+    assert.equal(handle.snapshot().revealed, false, "the settle never let go")
+  } finally {
+    handle.unmount()
+    restore()
+  }
 })
 
 test("THE REVEAL HOLDS THE HALL, AND THE HOLD IS BILLED TO NOBODY", () => {

--- a/dynawalla/games/beam/src/test/loop.test.ts
+++ b/dynawalla/games/beam/src/test/loop.test.ts
@@ -16,6 +16,8 @@ import assert from "node:assert/strict"
 
 import { mount } from "../contract.ts"
 import { Rng } from "../core/rng.ts"
+import { noteRead, resetReadForTest } from "../sim/learned.ts"
+import { CALM_CORES } from "../sim/opening.ts"
 import { createStubHost } from "../stubHost.ts"
 
 type Handler = (e: unknown) => void
@@ -32,7 +34,7 @@ function stubSurface(
   cores: number,
 ): {
   el: HTMLElement
-  install(): () => void
+  install(step?: number): () => void
   pump(): (ms: number) => void
   keys: Map<string, Handler>
 } {
@@ -94,7 +96,17 @@ function stubSurface(
     nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
   }
 
-  const install = (): (() => void) => {
+  /**
+   * @param step where on the ramp this child is; the steady state by default,
+   *   because every case in this file was written about the shipped game. See
+   *   the same parameter in `comprehension.test.ts`, and `opening.test.ts` for
+   *   the file that asks for a first sitting.
+   */
+  const install = (step: number = CALM_CORES): (() => void) => {
+    // The ramp's memory is module state, node has no `localStorage`, and two
+    // `play()` calls in one process would otherwise be two different games.
+    resetReadForTest()
+    for (let i = 0; i < step; i++) noteRead()
     globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
       pending = cb
       return 1

--- a/dynawalla/games/beam/src/test/opening.test.ts
+++ b/dynawalla/games/beam/src/test/opening.test.ts
@@ -1,0 +1,432 @@
+// THE OPENING, MEASURED.
+//
+// > "LATTICE RUNNER IS TOO FUCKING FAST FOR THE 100TH TIME. NO ONE CAN THINK
+// > THAT FAST."
+//
+// > "Lattice runner is pretty cool but it's too hard and fast for a human ..
+// > maybe one number at a time and a slower ramp up from an easier baseline ..
+// > first time you enter it could be just one number calmly coming down the
+// > lattice .. slower, easier, more hand-holdy. the way it starts for me now is
+// > chaotic and impossible."
+//
+// The second of those was answered in `games/lattice` — a different pack, whose
+// display name differs from this one's by one word. This file is that ramp in
+// the game the report was about. See `sim/opening.ts` and `README.md`.
+//
+// ## What it opened with, and what it opens with
+//
+// Driving the real shell — the real mount, the real frame loop, the real
+// keyboard handler — for sixty seconds, five seeds, 768×1024, with a bot that
+// slides, fires and dismisses the way a child's hands do:
+//
+//                                    shipped      first sitting
+//     numbered hulls, peak                 8                  2
+//     numbered hulls, mean              3.92               1.62
+//     the second problem arrives        6.1s              11.2s
+//     problems asked in 60s             10.8                5.8
+//
+// The peak of eight is four ordinary automata and four candidates, all carrying
+// numbers, all at once, while the child does a column sum. The first sitting is
+// the CORE by itself until it fractures and then two candidates: one sum, two
+// answers, nothing else moving.
+//
+// **And the clock is off during the ramp.** `Director.pressure` is
+// `elapsed/90 × 0.65 + kills/60 × 0.45`, so two thirds of the escalation was
+// time served rather than anything demonstrated — and `mount.drawWave` asks the
+// host for `2 + round(level × 7)`, so it was raising the ARITHMETIC as well as
+// the motion. A child who had answered nothing in ninety seconds was at level
+// 0.65: five hulls alive, a 1.3s spawn gap, and item difficulty 7.
+//
+// Nothing is lost at the top: `openingAt(CALM_CORES)` is the shipped game in
+// every field, asserted below against the constants themselves.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Director } from "../sim/director.ts"
+import { coresRead, noteMissed, noteRead, resetReadForTest } from "../sim/learned.ts"
+import { MAX_CANDIDATES, MIN_CANDIDATES, buildCore } from "../sim/core.ts"
+import { CALM_CORES, openingAt, STEADY_OPENING } from "../sim/opening.ts"
+import { comprehensionWindow } from "../sim/window.ts"
+
+// ── the table itself ────────────────────────────────────────────────────────
+
+test("the ramp only ever gets busier, faster and harder — never the other way", () => {
+  let previous = openingAt(0)
+  for (let step = 1; step <= 40; step++) {
+    const at = openingAt(step)
+    assert.ok(at.ordinaries >= previous.ordinaries, `hulls fell at step ${step}`)
+    assert.ok(at.candidates >= previous.candidates, `candidates fell at step ${step}`)
+    assert.ok(at.ceiling >= previous.ceiling, `the pressure ceiling fell at step ${step}`)
+    // A bigger `descentScale` is a SLOWER crossing, so this one is the other
+    // way round and that is exactly the sort of thing a table gets wrong.
+    assert.ok(at.descentScale <= previous.descentScale, `the lattice slowed down at step ${step}`)
+    assert.ok(
+      at.coreGapSeconds <= previous.coreGapSeconds,
+      `the gap between problems grew at step ${step}`,
+    )
+    previous = at
+  }
+})
+
+test("the calmest step is still a question, and the top step is the shipped game", () => {
+  const first = openingAt(0)
+  // A choice, not a formality: two answers is the fewest that is a question at
+  // all, and the ramp may never take that away to make things easier.
+  assert.ok(first.candidates >= MIN_CANDIDATES, "the first core is not a choice")
+  assert.equal(first.ordinaries, 0, "the first screen has something else on it")
+  assert.equal(first.ceiling, 0, "the clock is running on a child's first sitting")
+
+  // Against the constants the rest of the game is written in, so a change to
+  // any of them fails here rather than quietly making the top step a lesser
+  // game than the one that shipped.
+  const top = openingAt(CALM_CORES)
+  assert.deepEqual(top, STEADY_OPENING)
+  assert.equal(top.candidates, MAX_CANDIDATES, "the ceiling lost a candidate")
+  assert.equal(top.ordinaries, Number.POSITIVE_INFINITY, "the ceiling caps the stream")
+  assert.equal(top.descentScale, 1, "the ceiling is not the shipped pace")
+  assert.equal(top.coreGapSeconds, 2, "the ceiling is not the shipped cadence")
+  assert.equal(top.ceiling, 1, "the ceiling cannot reach the whole pressure curve")
+  for (const step of [CALM_CORES, CALM_CORES + 1, 40, 4000]) {
+    assert.deepEqual({ ...openingAt(step), step: 0 }, { ...top, step: 0 })
+  }
+  // Nothing before it is already the full game.
+  for (let step = 0; step < CALM_CORES; step++) {
+    const at = openingAt(step)
+    assert.ok(
+      at.ordinaries < top.ordinaries ||
+        at.candidates < top.candidates ||
+        at.descentScale > top.descentScale ||
+        at.ceiling < top.ceiling,
+      `step ${step} is already the shipped game`,
+    )
+  }
+  // And nothing that is not a number is a step, and none of them throws.
+  for (const bad of [Number.NaN, -1, Number.POSITIVE_INFINITY, -Number.MAX_VALUE]) {
+    assert.equal(openingAt(bad).step, 0, `${String(bad)} was not read as the very beginning`)
+  }
+})
+
+test("the ramp caps the clock, and the clock is what it was at the top", () => {
+  const item = { prompt: "247 + 158", answer: 405 }
+  const window = comprehensionWindow(item)
+  for (const step of [0, 1, 2, 3, 4, CALM_CORES]) {
+    const director = new Director()
+    director.opening = openingAt(step)
+    // Three minutes of a child sitting there answering nothing at all.
+    for (let i = 0; i < 180; i++) director.advance(1)
+    const p = director.pressure()
+    assert.ok(
+      p.level <= openingAt(step).ceiling + 1e-9,
+      `step ${step}: three minutes of sitting still reached level ${p.level.toFixed(2)}`,
+    )
+    // The item difficulty `mount.drawWave` would ask for, which is the whole
+    // reason a capped clock matters: it is the ARITHMETIC and not the motion.
+    const asked = 2 + Math.round(p.level * 7)
+    assert.ok(asked <= 2 + Math.round(openingAt(step).ceiling * 7), `step ${step} asked for ${asked}`)
+    // And the window never moved for any of it.
+    assert.equal(comprehensionWindow(item), window, `step ${step} moved the comprehension window`)
+  }
+  // The top step reaches the whole curve, unchanged.
+  const top = new Director()
+  top.opening = openingAt(CALM_CORES)
+  for (let i = 0; i < 180; i++) {
+    top.advance(1)
+    top.recordKill()
+  }
+  const hot = top.pressure()
+  assert.ok(hot.level > 0.99, `the shipped curve no longer reaches the top (${hot.level.toFixed(2)})`)
+  assert.equal(hot.descentSeconds, 5.8, "the shipped pace changed at the top of the ramp")
+  assert.equal(hot.floorCount, 5, "the shipped stream changed at the top of the ramp")
+})
+
+test("nothing on the ramp can touch how long a question is answerable for", () => {
+  // The pacing audit's finding, stated for this pack: `window(d)` is a pure
+  // function of the item, so a wave built at the calmest step and the same wave
+  // built at the busiest carry the same window to the millisecond.
+  const source = { id: "q", prompt: "247 + 158", answer: "405", distractors: ["395", "415", "504"] }
+  const windows = new Set<number>()
+  for (const step of [0, 1, 2, 3, 4, CALM_CORES, 400]) {
+    const rng = new Rng(0xc0de)
+    const built = buildCore(source, 5, () => rng.next(), openingAt(step).candidates)
+    assert.ok(built, `step ${step} could not build the wave`)
+    windows.add(built.windowSeconds)
+    assert.ok(
+      built.candidates.length <= openingAt(step).candidates,
+      `step ${step} put ${built.candidates.length} candidates up against a cap of ` +
+        `${openingAt(step).candidates}`,
+    )
+    assert.ok(built.candidates.length >= MIN_CANDIDATES, `step ${step} was not a choice`)
+    assert.ok(
+      built.candidates.some((c) => c.correct),
+      `step ${step} trimmed the answer off its own wave`,
+    )
+  }
+  assert.deepEqual(
+    [...windows],
+    [comprehensionWindow({ prompt: source.prompt, answer: 405 })],
+    "the ramp moved the answering window",
+  )
+})
+
+// ── the counter ─────────────────────────────────────────────────────────────
+
+test("the step is what the child demonstrated, and it walks both ways", () => {
+  resetReadForTest()
+  assert.equal(coresRead(), 0)
+  for (let i = 1; i <= 4; i++) assert.equal(noteRead(), i)
+  assert.equal(noteMissed(), 3)
+  assert.equal(noteMissed(), 2)
+  // Floored, so the calmest board is a floor and not a hole.
+  for (let i = 0; i < 20; i++) noteMissed()
+  assert.equal(coresRead(), 0)
+  assert.deepEqual(openingAt(coresRead()), openingAt(0))
+})
+
+// ── the real shell ──────────────────────────────────────────────────────────
+
+type Snapshot = ReturnType<ReturnType<typeof mount>["snapshot"]>
+
+/**
+ * The real game, mounted on a surface with no pixels, driven a frame at a time.
+ *
+ * Not the sim and not the pure functions: the ramp only reaches a child through
+ * the director, the spawn cadence, the fracture and the frame loop, and every
+ * one of those lives in `mount.ts`. `hint.test.ts` in a sibling pack once passed
+ * with the machinery it was testing entirely unwired, because the wiring lived
+ * in the shell.
+ */
+function shell(step: number, seed: number, viewport: [number, number] = [768, 1024]) {
+  resetReadForTest()
+  for (let i = 0; i < step; i++) noteRead()
+  const [w, h] = viewport
+  const rect = { left: 0, top: 0, width: w, height: h, right: w, bottom: h, x: 0, y: 0 }
+  const keys = new Map<string, (e: unknown) => void>()
+  const noop = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, p) => (p === "then" ? undefined : noop),
+    set: () => true,
+    apply: () => noop,
+  }) as unknown as CanvasRenderingContext2D
+  const makeEl = (): HTMLElement =>
+    ({
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      id: "",
+      type: "",
+      className: "",
+      textContent: "",
+      tabIndex: 0,
+      hidden: false,
+      scrollTop: 0,
+      appendChild: () => undefined,
+      append: () => undefined,
+      remove: () => undefined,
+      focus: () => undefined,
+      setAttribute: () => undefined,
+      getAttribute: () => null,
+      removeAttribute: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => noop,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener: (k: string, fn: (e: unknown) => void) => keys.set(k, fn),
+      removeEventListener: (k: string) => keys.delete(k),
+    }) as unknown as HTMLElement
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    key: globalThis.addEventListener,
+    unkey: globalThis.removeEventListener,
+    doc: (globalThis as { document?: unknown }).document,
+    dateNow: Date.now,
+    nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
+  }
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+  globalThis.requestAnimationFrame = ((cb: (t: number) => void) => {
+    pending = cb
+    return 1
+  }) as typeof globalThis.requestAnimationFrame
+  globalThis.cancelAnimationFrame = (() => {
+    pending = null
+  }) as typeof globalThis.cancelAnimationFrame
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe(): void {}
+    disconnect(): void {}
+  }
+  performance.now = () => clock
+  Date.now = () => seed * 7919
+  Object.defineProperty(globalThis, "navigator", {
+    value: { hardwareConcurrency: 12 },
+    configurable: true,
+    writable: true,
+  })
+  globalThis.addEventListener = ((k: string, fn: (e: unknown) => void) => {
+    keys.set(k, fn)
+  }) as unknown as typeof globalThis.addEventListener
+  globalThis.removeEventListener = ((k: string) => {
+    keys.delete(k)
+  }) as unknown as typeof globalThis.removeEventListener
+  ;(globalThis as { document?: unknown }).document = {
+    createElement: () => makeEl(),
+    getElementById: () => null,
+    body: makeEl(),
+  }
+
+  let served = 0
+  const host: Host = {
+    // A fixed, small, honest item so the measurement is about the BOARD and not
+    // about which question the stub happened to draw.
+    next: (): Question => {
+      served++
+      return {
+        id: `q-${String(served)}`,
+        prompt: "24 + 12",
+        answer: "36",
+        distractors: ["26", "46", "63"],
+        domain: "add",
+        difficulty: 2,
+      }
+    },
+    report: () => undefined,
+    skip: () => undefined,
+    haptic: () => undefined,
+    prefersReducedMotion: () => false,
+  }
+  const handle = mount(makeEl(), host)
+  return {
+    handle,
+    press: (k: string) => keys.get("keydown")?.({ key: k, preventDefault: () => undefined }),
+    step: (ms = 16) => {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+    done: () => {
+      handle.unmount()
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      globalThis.addEventListener = saved.key
+      globalThis.removeEventListener = saved.unkey
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      Date.now = saved.dateNow
+      if (saved.nav) Object.defineProperty(globalThis, "navigator", saved.nav)
+    },
+  }
+}
+
+test("THE FIRST SCREEN IS ONE NUMBER, AND IT IS THE PROBLEM", () => {
+  // The founder's own words, as an assertion. Nobody touches anything, so the
+  // child cannot leave step 0 and the whole run is the calmest board there is.
+  for (const seed of [0x10be, 0x20be, 0x30be, 0x40be, 0x50be]) {
+    const rig = shell(0, seed)
+    try {
+      let sawPrompt = false
+      let peak = 0
+      let peakOrdinaries = 0
+      // Twenty seconds: the gap, the approach, the fall, and the reveal that
+      // follows it. More than enough for the busiest moment of a first sitting.
+      for (let f = 0; f < 1250; f++) {
+        rig.step()
+        const s: Snapshot = rig.handle.snapshot()
+        if (s.prompt !== null) sawPrompt = true
+        peak = Math.max(peak, s.onLattice)
+        peakOrdinaries = Math.max(peakOrdinaries, s.ordinaries)
+      }
+      assert.ok(sawPrompt, `seed ${seed.toString(16)}: no problem ever arrived`)
+      assert.equal(
+        peakOrdinaries,
+        0,
+        `seed ${seed.toString(16)}: ${peakOrdinaries} hull(s) with nothing to do with the sum ` +
+          `were on a first sitting's lattice`,
+      )
+      assert.ok(
+        peak <= MIN_CANDIDATES,
+        `seed ${seed.toString(16)}: ${peak} numbered hulls on a first sitting's lattice`,
+      )
+    } finally {
+      rig.done()
+    }
+  }
+})
+
+test("and the shipped game really does put a crowd on it, which is the point", () => {
+  // The other half, and without it the assertion above is a claim about a game
+  // nobody plays: the top of the ramp is the board the founder was reporting,
+  // unchanged, and it is four times as busy.
+  let peak = 0
+  for (const seed of [0x10be, 0x20be, 0x30be, 0x40be, 0x50be]) {
+    const rig = shell(CALM_CORES, seed)
+    try {
+      let t = 0
+      for (let f = 0; f < 3750; f++) {
+        rig.step()
+        t = (t + 1) % 23
+        if (t === 0) rig.press(" ")
+        if (t === 11) rig.press(f % 2 === 0 ? "ArrowLeft" : "ArrowRight")
+        peak = Math.max(peak, rig.handle.snapshot().onLattice)
+      }
+    } finally {
+      rig.done()
+    }
+  }
+  assert.ok(
+    peak > 2 * MIN_CANDIDATES,
+    `the shipped board peaked at ${peak} hulls, so the calm opening is not calmer than anything`,
+  )
+})
+
+test("reading cores is what moves the board, and a miss moves it back", () => {
+  // End to end through the shell: the step is persisted, it is read at mount,
+  // and it is the ONLY thing that changes the board. Nothing here advances a
+  // clock on purpose — the run is the same length in every case.
+  resetReadForTest()
+  const rig = shell(0, 0x10be)
+  try {
+    assert.equal(rig.handle.snapshot().step, 0, "a child with no history did not open at the floor")
+    // Four cores read, without playing them: this is the counter's contract and
+    // the shell's reading of it, not a claim about the bot's aim.
+    for (let i = 0; i < 4; i++) noteRead()
+    // The shell re-reads on the next outcome, so drive it far enough to have one.
+    for (let f = 0; f < 1400; f++) rig.step()
+    assert.ok(
+      rig.handle.snapshot().step >= 3,
+      `the shell is not reading the counter: it is on step ${rig.handle.snapshot().step} after ` +
+        `four cores`,
+    )
+  } finally {
+    rig.done()
+  }
+
+  // And a wave that reached the floor unanswered walks it back down. Nobody
+  // touches anything, so every wave expires.
+  resetReadForTest()
+  for (let i = 0; i < CALM_CORES; i++) noteRead()
+  const back = shell(CALM_CORES, 0x10be)
+  try {
+    assert.equal(back.handle.snapshot().step, CALM_CORES)
+    let guard = 0
+    while (coresRead() === CALM_CORES && guard++ < 4000) {
+      back.step()
+      // The reveal is held until a hand ends it, so the next wave needs one.
+      if (back.handle.snapshot().revealed) back.press(" ")
+    }
+    assert.ok(
+      coresRead() < CALM_CORES,
+      "a wave reached the floor unanswered and the board did not get out of the way",
+    )
+  } finally {
+    back.done()
+  }
+})

--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -140,7 +140,7 @@ the shipped difficulty wire:
 | rung reached (min / median / max) | 0 / 29 / 50 | 16 / 45 / 47 |
 | targets with a factor tree | 42% | 82% |
 | targets under 12 ("find a 2") | 21% | 0% |
-| time with no resonator at all | ~500s of every 600 | 8s in 3,000 |
+| time with no resonator at all | ~500s of every 600 | 2.5s in 3,000 |
 | first four targets | 5, 7, 10, 16 | 36, 40, 60, 98 |
 
 That "500s of every 600" is the half nobody had reported, because nobody had
@@ -149,12 +149,45 @@ failed, and the arena stalled — permanently, because there was no retry, leavi
 the previous resonator hanging with its id already spent. A child could fly into
 that ring forever and the host would never hear another word.
 
-There is one case where the arena still finds nothing, and it is the first session
-of a brand new profile: the host warms its pool at *its* position, which for a new
-profile is rung 0, and the first request flushes that down to a reserve of eight
-`2 + 0`s. So a stall is now a wait rather than a session — it stocks the field with
-husks and motes so the passive layer still works, says so on the HUD, and asks
-again 2.5 seconds later, by which time the pool has refilled where it was asked to.
+### The floor has to be *stated*, or there is no ring at all
+
+Everything above was true and none of it was enough, because from host 0.3.7 a
+`difficulty` stopped being a request:
+
+> **A hint, not an instruction.** It is honoured within `HINT_BAND` rungs of
+> where the host's own band has the child and clamped there otherwise.
+>
+> — `dynawalla-app/src/packs/items.ts`
+
+`HINT_BAND` is **one rung**, and the host's own position opens at rung 0 on every
+session of every fresh profile. So THE LATTICE asked for rung 16 and was served
+rung 1: answers of two to six, none of which can carry a factor tree. All six
+draws of the arming failed, the arena stalled, and the HUD drew
+`NO RESONATOR — SWEEP ON` — which is what the founder read out to us against a
+manual promising a ring in the middle with a sum on it.
+
+And it could not clear. The only thing that moves the host's position is a
+report, the only thing that produces a report is a resonator opening, and there
+was no resonator. Every rearm for the rest of the session drew from rung 1 again.
+
+The way out is the other channel, and it is a different kind of claim.
+`minDifficulty` is a **capability** — the pack stating what it can physically put
+on the screen — so the host honours it absolutely, above its own band as well as
+below it, and never moves the child's ladder for it. THE LATTICE's floor was
+always exactly that kind of claim: `MIN_TARGET` is 12 because a smaller answer
+has no factor tree in it. It is now on every single request. TREBUCHET had the
+identical defect for three releases and PR 771 built this channel for it.
+
+`stubHost.ts` models the band now, by default, because it not modelling the band
+is how two hundred and seven passing tests sat on top of a game with no ring in
+it. `band: false` is the opt-out, and only two cases want it.
+
+There is one case where the arena still finds nothing, and it is a rung being
+unlucky rather than a band it cannot reach. A stall is a wait and not a session —
+it stocks the field with husks and motes so the passive layer still works, says
+so on the HUD, and asks again 2.5 seconds later. Measured over five ten-minute
+sittings from a fresh profile, played perfectly, that now costs **2.5 seconds in
+3,000**, on one seed of five, and the longest single gap is one rearm.
 
 ---
 

--- a/dynawalla/games/lattice/src/contract.ts
+++ b/dynawalla/games/lattice/src/contract.ts
@@ -29,12 +29,25 @@ export type Host = {
   /**
    * The next question.
    *
-   * `difficulty` is a 0..1 position on the host's whole ladder and
-   * `maxDifficulty` a ceiling on the same scale. THE LATTICE names both on every
-   * single draw — see `game/ladder.ts` for why a game that names neither is a
-   * game that ends up asking a child to find a 2.
+   * `difficulty` is a 0..1 position on the host's whole ladder,
+   * `maxDifficulty` a ceiling on the same scale and `minDifficulty` a floor.
+   * THE LATTICE names all three on every single draw — see `game/ladder.ts` for
+   * why a game that names none is a game that ends up asking a child to find a
+   * 2, and why one that names only the first two is a game with no ring in it.
+   *
+   * **`difficulty` is a hint and the other two are capabilities**, and the
+   * difference is the whole of PR 771. A `difficulty` is honoured within one
+   * rung of where the host's own evidence stands (`HINT_BAND`); a ceiling and a
+   * floor are honoured absolutely, because they are the pack stating what it can
+   * physically put on the screen rather than what it thinks the child is ready
+   * for.
    */
-  next(opts?: { domain?: string; difficulty?: number; maxDifficulty?: number }): Question
+  next(opts?: {
+    domain?: string
+    difficulty?: number
+    maxDifficulty?: number
+    minDifficulty?: number
+  }): Question
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   /**
    * The child was never shown this one. Close it and record nothing.

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -73,7 +73,7 @@ const WALL_EVERY = 5
  * into a ring that reported nothing, forever, and the only sign was one line on
  * a console nobody was reading.
  */
-const REARM_MS = 2500
+export const REARM_MS = 2500
 
 /** Radii in arena units. The arena is nominally about 1000 units wide. */
 export const SHIP_R = 15

--- a/dynawalla/games/lattice/src/game/ladder.ts
+++ b/dynawalla/games/lattice/src/game/ladder.ts
@@ -164,6 +164,40 @@ export type Request = {
   readonly domain: string
   readonly difficulty: number
   readonly maxDifficulty: number
+  /**
+   * `FLOOR`, on every single request, forever.
+   *
+   * **This is the ring the founder could not find.** From host 0.3.7 a
+   * `difficulty` is a *hint*: it is honoured within `HINT_BAND` — one rung — of
+   * where the host's own evidence stands, and clamped there otherwise. That
+   * evidence is `progress`, and `progress` opens at rung 0 on every fresh
+   * profile. So THE LATTICE asked for rung 16 and was served rung 1: answers of
+   * two to six, none of them twelve or more, none of them carrying a factor
+   * tree. Every one of the six draws an arming makes missed, `arm` set
+   * `stalled`, and the screen read `NO RESONATOR — SWEEP ON`.
+   *
+   * And it could not clear. The only thing that moves the host's `progress` is a
+   * report, the only thing that produces a report is a resonator opening, and
+   * there was no resonator — so the rearm two and a half seconds later drew from
+   * rung 1 again, and so did the one after that, for as long as the child sat
+   * there. A whole game reduced to a grid with some twos drifting on it.
+   *
+   * `minDifficulty` is the other channel and it is a different kind of claim: a
+   * *capability*, honoured absolutely above the host's band as well as below it,
+   * because a question the pack cannot render is not a question. THE LATTICE's
+   * floor is exactly that kind of claim and it always was — `MIN_TARGET` is 12
+   * because a smaller answer has no factor tree in it, so a resonator cannot be
+   * a game about one. It is stated here rather than assumed, which is the whole
+   * difference between a floor and a wish.
+   *
+   * It is constant. It is what the pack can draw, not where the child is, so it
+   * never moves with `position` — and the host never moves the child's ladder
+   * for it, so stating it cannot promote anybody.
+   *
+   * TREBUCHET had the identical defect for three releases (0.3.7–0.3.9) and this
+   * is its fix, in the shape this pack's wire takes it.
+   */
+  readonly minDifficulty: number
 }
 
 export function clampToBand(position: number): number {
@@ -241,7 +275,7 @@ export class Ladder {
       const rung = rungOf(difficulty)
       if (seen.has(rung)) continue
       seen.add(rung)
-      const request = { domain, difficulty, maxDifficulty: CEILING }
+      const request = { domain, difficulty, maxDifficulty: CEILING, minDifficulty: FLOOR }
       if (this.yieldOf(rung) < BARREN) barren.push(request)
       else live.push(request)
     }

--- a/dynawalla/games/lattice/src/stubHost.ts
+++ b/dynawalla/games/lattice/src/stubHost.ts
@@ -11,11 +11,18 @@
 //   2. **`toUnit`**, character for character the reading in
 //      `packs/shared/game-host` — under 1 is a fraction, 1 or over is a ladder
 //      index — so a request written here means what it means there.
-//   3. **A named `difficulty` lands on exactly one rung.** `dynawalla-app`'s
-//      `items.next` spreads a rung *only* when the pack named none; a pack that
-//      drives its own difficulty is honoured as the point it asked for. So is
-//      `maxDifficulty`, which floors rather than rounds.
-//   4. **With nothing named, the rung is the host's own position**, and that
+//   3. **A named `difficulty` is a HINT, and it is clamped.** `dynawalla-app`'s
+//      `items.next` honours it within `HINT_BAND` — one rung — of where the
+//      host's own evidence stands, and clamps it there otherwise. See
+//      `HINT_BAND` below: this is the one the stub did not model, and not
+//      modelling it is how THE LATTICE shipped a screen with no ring on it.
+//   4. **A named `maxDifficulty` or `minDifficulty` is a CAPABILITY, and it is
+//      absolute.** The ceiling floors where the request rounds and the floor
+//      ceils, both bind after the band and both beat it, because they are the
+//      pack saying what it can physically draw rather than what it thinks the
+//      child is ready for. Only the ceiling moves the child's ladder, and only
+//      downward, and only when it bites.
+//   5. **With nothing named, the rung is the host's own position**, and that
 //      moves on `report` through the shipped staircase: an opening stride of four
 //      rungs decaying by 0.72 toward one, a correct answer worth
 //      `min(1, tail/latency)` of a stride, a wrong one worth a whole one down.
@@ -45,6 +52,24 @@ export const RUNGS = 66
 const SPAN = RUNGS - 1
 
 /**
+ * How far from its own evidence the host will follow a pack's `difficulty`.
+ *
+ * `dynawalla-app/src/packs/items.ts`, `HINT_BAND`, and it is **one rung**. This
+ * constant is the whole reason the founder saw `NO RESONATOR — SWEEP ON` on a
+ * fresh profile: THE LATTICE asks for rung 16 and up, the host's own `progress`
+ * opens every session at 0, so every draw of every arming came back from rung 1
+ * with an answer under seven — and nothing under twelve can carry a factor tree.
+ * All six draws missed, the arena stalled, and the stall could not clear because
+ * the only thing that moves `progress` is a report and the only thing that
+ * produces a report is a resonator.
+ *
+ * A `minDifficulty` is the way out and it is not a way round: it is the pack
+ * saying what it can physically draw, so the host honours it absolutely and
+ * never moves the child's ladder for it.
+ */
+export const HINT_BAND = 1
+
+/**
  * A difficulty on whichever of the two scales the caller speaks, as 0..1.
  *
  * The same rule as `packs/shared/game-host`, including its one ambiguous value:
@@ -58,10 +83,29 @@ export function toUnit(value: number): number | null {
   return Math.min(1, (value - 1) / 9)
 }
 
-/** The largest operand a rung draws. */
+/**
+ * The largest operand a rung draws.
+ *
+ * The base is set by the header's last calibration point — **"past 999 from
+ * about rung 47"** — and it is a statement about the *answer*, which is two
+ * operands. `3 · 1.115^47` is 500, so rung 47 is where a sum first reaches a
+ * thousand and rung 48 is where the game's `MAX_TARGET` stops being reachable.
+ *
+ * It was 1.125, and that put the sum past 999 from rung 44: at rung 47, 57% of
+ * answers were over the ceiling and only 16% were resonant. Nothing noticed for
+ * as long as nothing sat there. Modelling `HINT_BAND` put the game exactly
+ * there — a standing `maxDifficulty` pulls the host's own ladder down onto it,
+ * and the band then serves the two rungs either side of it and no others — and
+ * ten minutes of perfect play went from ten seconds without a question to
+ * eighty. That was the stub being wrong about the top of the ladder rather than
+ * the game being wrong about anything: `game/ladder.ts`'s table, measured
+ * against the shipped curriculum graph, has rung 46 at **57% usable**, and a
+ * model that says 26% would have this pack tuned against a rung that does not
+ * exist.
+ */
 export function operandCeilingAt(rung: number): number {
   const clamped = Math.max(0, Math.min(SPAN, Math.round(rung)))
-  return Math.max(2, Math.round(3 * Math.pow(1.125, clamped)))
+  return Math.max(2, Math.round(3 * Math.pow(1.115, clamped)))
 }
 
 /** The staircase's constants, from `dynawalla-app/src/packs/items.ts`. */
@@ -183,9 +227,31 @@ export type StubHostOptions = {
   /** Observe stopping points. The real host may sheet the frame on one. */
   onTransition?: (kind: string, label?: string) => void
   /** Observe every draw: what was asked for, and which rung answered. */
-  onDraw?: (draw: { asked: number | null; ceiling: number | null; rung: number; id: string }) => void
+  onDraw?: (draw: {
+    asked: number | null
+    ceiling: number | null
+    /** The render floor the pack stated, if any. See `band`. */
+    bottom: number | null
+    rung: number
+    id: string
+  }) => void
   /** Observe skips, so a test can hold the pack to closing what it discards. */
   onSkip?: (questionId: string) => void
+  /**
+   * Model `HINT_BAND` — the host's clamp on a pack's `difficulty`.
+   *
+   * **On by default, because the shipped host does it and this stub not doing it
+   * is how THE LATTICE shipped with no resonator on the screen.** From host
+   * 0.3.7 a `difficulty` is a *hint*, honoured only within one rung either side
+   * of where the host's own evidence stands, and that evidence opens every
+   * session at rung 0. A pack whose content sits above the child is therefore
+   * starved unless it also states a `minDifficulty`, which is a capability and
+   * is honoured absolutely. See `dynawalla-app/src/packs/items.ts`, `HINT_BAND`.
+   *
+   * Off only for the tests that are measuring the *pack's* own ladder in
+   * isolation and need the rung they asked for.
+   */
+  band?: boolean
 }
 
 /** What the stub is willing to say about itself, for the tests that measure it. */
@@ -203,6 +269,7 @@ export function createStubHost(opts: StubHostOptions = {}): StubHost {
   let n = 0
   const domains: Domain[] = ["add", "add", "sub"]
   const standing = opts.difficulty === undefined ? null : toUnit(opts.difficulty)
+  const band = opts.band !== false
 
   /** Where the host's own ladder is, carried as a real number like `items.ts`. */
   let progress = standing === null ? 0 : standing * SPAN
@@ -214,23 +281,43 @@ export function createStubHost(opts: StubHostOptions = {}): StubHost {
     next(o) {
       const asked = o?.difficulty === undefined ? standing : toUnit(o.difficulty)
       const ceiling = o?.maxDifficulty === undefined ? null : toUnit(o.maxDifficulty)
-      let rung = Math.floor(progress)
-      // Either field moves the rung, which is `items.next`'s own gate: a request
-      // that names only a ceiling still has to be honoured, or the ceiling half of
-      // the wire is modelled by nothing.
-      if (asked !== null || ceiling !== null) {
-        // The ceiling *floors* and the request *rounds*, exactly as `items.next`
-        // does it: rounding a cap can only round it up, and a cap that can be
-        // rounded over is not a cap.
-        const cap = ceiling === null ? SPAN : Math.floor(ceiling * SPAN)
-        // With no `difficulty` named, `items.next` reads the ladder's own position
-        // as the request and then applies the cap to it.
-        const want = asked === null ? Math.floor(progress) / Math.max(1, SPAN) : asked
-        rung = Math.max(0, Math.min(SPAN, cap, Math.round(want * SPAN)))
-        // The whole number the pack named, keeping the fraction already earned
-        // toward the next rung.
-        progress = rung + (progress - Math.floor(progress))
+      const bottom = o?.minDifficulty === undefined ? null : toUnit(o.minDifficulty)
+      // **The anchor: the rung the host's own evidence left the child on.** Read
+      // once, before anything the pack asked for is looked at, and never written
+      // back to from a request — which is what stops the band being a ratchet a
+      // pack climbs one rung a question. See `items.next`.
+      const anchor = Math.floor(progress)
+      let rung = anchor
+      if (asked !== null) {
+        // A request *rounds* to the nearest rung and is then pulled inside the
+        // band. With `band` off it is honoured as asked, which is the pre-0.3.7
+        // wire and is only for tests measuring the pack's own ladder.
+        const want = Math.round(asked * SPAN)
+        rung = band ? Math.max(anchor - HINT_BAND, Math.min(anchor + HINT_BAND, want)) : want
       }
+      if (ceiling !== null) {
+        // The ceiling *floors* where the request rounds, exactly as `items.next`
+        // does it: rounding a cap can only round it up, and a cap that can be
+        // rounded over is not a cap. It binds after the band and it wins.
+        const cap = Math.floor(ceiling * SPAN)
+        rung = Math.min(rung, cap)
+        // A standing ceiling pins the ladder itself, downward only and only when
+        // it bites — a position above content the pack cannot draw is a fiction.
+        if (cap < anchor) progress = Math.max(0, cap) + (progress - anchor)
+      }
+      if (bottom !== null) {
+        // The floor *ceils*, for the mirror of the reason the cap floors, and it
+        // wins over the band for the same reason the ceiling does: it is not a
+        // pedagogy request, it is the pack saying what it can physically draw.
+        // It never moves `progress` — the mirror write would let a pack promote
+        // a child by declaring a manifest.
+        const floor = Math.ceil(bottom * SPAN)
+        rung = Math.max(rung, floor)
+        // An empty window is a pack bug, and the ceiling wins it: serving above
+        // what a pack can render is a blank screen in front of a child.
+        if (ceiling !== null) rung = Math.min(rung, Math.floor(ceiling * SPAN))
+      }
+      rung = Math.max(0, Math.min(SPAN, rung))
 
       const domain = (o?.domain as Domain | undefined) ?? rng.pick(domains)
       const [a, b] = operandsFor(domain, rung, rng)
@@ -252,7 +339,7 @@ export function createStubHost(opts: StubHostOptions = {}): StubHost {
       const id = `stub-${n}`
       served.set(id, { rung, digits: Math.max(digitsOf(a), digitsOf(b)) })
       rungs.push(rung)
-      opts.onDraw?.({ asked, ceiling, rung, id })
+      opts.onDraw?.({ asked, ceiling, bottom, rung, id })
       return {
         id,
         prompt: `${a} ${GLYPH[domain]} ${b}`,

--- a/dynawalla/games/lattice/src/test/band.test.ts
+++ b/dynawalla/games/lattice/src/test/band.test.ts
@@ -1,0 +1,183 @@
+// **"'The lattice' is complete broken farce. 'The ring floats in the middle
+// with sum' — there is no fucking ring it says 'no resonator - sweep on'."**
+//
+// The founder, on a fresh profile, on the shipped 0.3.10 build. He is quoting
+// the manual against the screen, and both of them were telling the truth: the
+// manual describes a resonator hanging in the middle of the lattice with a
+// problem on its face, and the arena was drawing `NO RESONATOR — SWEEP ON`
+// because it had one.
+//
+// ## What it was
+//
+// Not the hint work. PR 739 (the six-stage factor tree) and PR 762 (one husk at
+// t=0, the gentler ramp, the live divisor marking) both landed on top of this
+// and neither caused it. It was the host, three days before either of them:
+//
+//     9de8cef16  fix(dynawalla/host): a pack's difficulty is a hint clamped
+//                to ±1 rung of the host's band  (#735)
+//
+// From that commit a pack's `difficulty` is a **hint**, honoured within
+// `HINT_BAND` — one rung — of where the host's own evidence stands, and clamped
+// there otherwise. The host's evidence is `progress`, and `progress` opens at
+// rung 0 on every session of every fresh profile.
+//
+// THE LATTICE's floor is rung 16. It asked for rung 16 and it was served rung 1:
+// answers of two to six. Nothing under twelve can carry a factor tree, so
+// `isResonant` refused all six draws of the arming, `arm` set `stalled`, and the
+// HUD drew the line the founder read out.
+//
+// **And it could not clear.** The only thing that moves the host's `progress` is
+// a report; the only thing that produces a report is a resonator opening; and
+// there was no resonator. The rearm two and a half seconds later drew from rung
+// 1 again, and so did every one after it, for as long as the child sat there.
+//
+// TREBUCHET had the identical defect for three releases and PR 771 built the way
+// out: `minDifficulty`, a **capability** rather than a hint — the pack stating
+// what it can physically put on the screen — honoured absolutely, above the
+// host's band as well as below it, and never moving the child's ladder. THE
+// LATTICE's floor is exactly that kind of claim and had simply never been
+// stated. See `game/ladder.ts`, `Request.minDifficulty`.
+//
+// ## Why the suite did not catch it
+//
+// Two hundred and seven tests passed throughout. `stubHost.ts` calls itself a
+// model of the wire and did not model the band: it served whatever rung it was
+// asked for, so the one thing that was wrong was the one thing nothing could
+// see. It models it now, by default, and `band: false` is the opt-out for the
+// two cases that are measuring the pack's own ladder in isolation.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena, REARM_MS } from "../game/arena.ts"
+import { CEILING, FLOOR, Ladder, rungOf } from "../game/ladder.ts"
+import { CALM_OPENINGS } from "../game/opening.ts"
+import { MIN_TARGET } from "../game/resonance.ts"
+import { HINT_BAND, createStubHost } from "../stubHost.ts"
+import { playCarefully } from "./harness.ts"
+
+const FRAME_MS = 16
+
+/** A fresh profile: the host's own ladder standing on rung 0, like every launch. */
+function freshProfile(seed: number, watch?: { asks: Array<number | null> }) {
+  return createStubHost({
+    seed,
+    reducedMotion: true,
+    onDraw: (d) => watch?.asks.push(d.bottom),
+  })
+}
+
+test("every request states the floor the pack cannot draw beneath", () => {
+  const ladder = new Ladder()
+  for (const at of [0, 5, 20, 60]) {
+    for (let i = 0; i < at; i++) ladder.opened()
+    for (const request of ladder.requests("add")) {
+      assert.equal(
+        request.minDifficulty,
+        FLOOR,
+        "a request went out without the pack's render floor on it",
+      )
+      // It is a capability and not a position: it does not move with the
+      // pack's own ladder, because what the pack can draw does not.
+      assert.ok(request.minDifficulty <= request.difficulty + 1e-9)
+      assert.ok(request.minDifficulty <= request.maxDifficulty)
+    }
+  }
+})
+
+test("the founder's screen: a fresh profile is served nothing this game can be about", () => {
+  // The defect, isolated at the wire, with no arena in it. This is what the pack
+  // was handed on every draw of every arming for as long as the child sat there.
+  const host = freshProfile(0x1a771ce)
+  assert.equal(host.position(), 0, "a fresh profile did not open at the bottom of the ladder")
+  let usable = 0
+  const n = 400
+  for (let i = 0; i < n; i++) {
+    // Exactly what the pack sent before PR 771's channel was used: a difficulty
+    // and a ceiling, and no statement of what it cannot draw beneath.
+    const q = host.next({ domain: "add", difficulty: FLOOR, maxDifficulty: CEILING })
+    if (Number(q.answer) >= MIN_TARGET) usable += 1
+  }
+  assert.equal(usable, 0, `${usable}/${n} draws were usable, so the band is not being modelled`)
+  assert.ok(
+    host.servedRungs().every((r) => r <= HINT_BAND),
+    "a request for rung 16 was served from above the host's own band",
+  )
+
+  // And with the floor stated, on the same host, on the same seed.
+  const fixed = freshProfile(0x1a771ce)
+  let big = 0
+  for (let i = 0; i < n; i++) {
+    const q = fixed.next({
+      domain: "add",
+      difficulty: FLOOR,
+      maxDifficulty: CEILING,
+      minDifficulty: FLOOR,
+    })
+    if (Number(q.answer) >= MIN_TARGET) big += 1
+  }
+  assert.ok(big / n > 0.75, `only ${big}/${n} draws reached ${MIN_TARGET} with the floor stated`)
+  assert.ok(
+    fixed.servedRungs().every((r) => r >= rungOf(FLOOR)),
+    "the floor was not honoured above the host's own band",
+  )
+  // The floor is a capability, so it must not have promoted anybody: the host's
+  // model of where this child stands is exactly where `judge` left it.
+  assert.equal(fixed.position(), 0, "stating a render floor moved the child's ladder")
+})
+
+test("a fresh profile gets a ring, and it is there before the child touches anything", () => {
+  // The whole report, through the real arena and the real rearm.
+  for (const seed of [0x1a771ce, 0x0c105, 0x5eed, 0xbea7, 0x9a11]) {
+    const host = freshProfile(seed)
+    const arena = new Arena(host, new Rng(seed ^ 0x51de), {
+      width: 900,
+      height: 700,
+      // A first sitting. Nobody who has never played has an `experience`.
+      experience: 0,
+    })
+    arena.begin(0)
+    const res = arena.resonator
+    assert.ok(res, `seed ${seed.toString(16)}: no ring on the first frame of a first sitting`)
+    assert.equal(arena.stalled, false, `seed ${seed.toString(16)}: the arena opened stalled`)
+    assert.ok(
+      res.target >= MIN_TARGET,
+      `seed ${seed.toString(16)}: the first ring asked for ${res.target}`,
+    )
+  }
+})
+
+test("and the ring keeps coming back, for a whole sitting, from rung nought", () => {
+  // The deadlock, which is the part that made it a farce rather than a bad
+  // opening: nothing could clear the stall, because clearing it needed a report
+  // and a report needed the thing that was missing.
+  //
+  // Five minutes, from a fresh profile, played properly.
+  const frames = Math.round((5 * 60 * 1000) / FRAME_MS)
+  for (const seed of [0x1a771ce, 0x5eed]) {
+    const host = freshProfile(seed)
+    const arena = new Arena(host, new Rng(seed ^ 0x51de), {
+      width: 900,
+      height: 700,
+      experience: CALM_OPENINGS,
+    })
+    arena.begin(0)
+    const played = playCarefully(arena, frames, FRAME_MS)
+    assert.ok(
+      played.targets.length > 20,
+      `seed ${seed.toString(16)}: only ${played.targets.length} rings in five minutes`,
+    )
+    assert.ok(
+      played.longestGapMs <= 3 * REARM_MS,
+      `seed ${seed.toString(16)}: ${(played.longestGapMs / 1000).toFixed(1)}s with no ring`,
+    )
+    // And the child climbed. A floor that pinned the stream at the floor forever
+    // would pass everything above this and still be the wrong game.
+    assert.ok(
+      host.position() > rungOf(FLOOR),
+      `seed ${seed.toString(16)}: five minutes of perfect play left the host on rung ` +
+        `${host.position()}`,
+    )
+  }
+})

--- a/dynawalla/games/lattice/src/test/harness.ts
+++ b/dynawalla/games/lattice/src/test/harness.ts
@@ -131,6 +131,17 @@ export type Sitting = {
   readonly targets: number[]
   /** Wall-clock milliseconds the arena had no question at all. */
   readonly withoutQuestionMs: number
+  /**
+   * The longest single run of them.
+   *
+   * The total is a budget and this is the promise: an arming that misses stalls
+   * for `REARM_MS` and tries again, so a gap of a few seconds is a rung being
+   * unlucky and a gap of a minute is a game with no ring in it. The founder's
+   * report is the second, and only this number can tell them apart — a snapshot
+   * of `arena.stalled` on the final frame cannot, because it is true for a
+   * two-and-a-half-second gap and false for one that has just closed.
+   */
+  readonly longestGapMs: number
   /** How long until the first target with a real factor tree in it. */
   readonly firstTreeMs: number | null
 }
@@ -147,12 +158,20 @@ export function playCarefully(arena: Arena, frames: number, frameMs = 16): Sitti
   const targets: number[] = []
   const seen = new Set<string>()
   let withoutQuestionMs = 0
+  let longestGapMs = 0
+  let gapMs = 0
   let firstTreeMs: number | null = null
   let t = 0
   for (let f = 0; f < frames; f++) {
     t += frameMs
     const res = arena.resonator
-    if (!res) withoutQuestionMs += frameMs
+    if (!res) {
+      withoutQuestionMs += frameMs
+      gapMs += frameMs
+      longestGapMs = Math.max(longestGapMs, gapMs)
+    } else {
+      gapMs = 0
+    }
     if (res && !seen.has(res.questionId)) {
       seen.add(res.questionId)
       targets.push(res.target)
@@ -208,5 +227,5 @@ export function playCarefully(arena: Arena, frames: number, frameMs = 16): Sitti
     // a permanent stall in a test and would not be one in the game.
     arena.rearm(t)
   }
-  return { targets, withoutQuestionMs, firstTreeMs }
+  return { targets, withoutQuestionMs, longestGapMs, firstTreeMs }
 }

--- a/dynawalla/games/lattice/src/test/ladder.test.ts
+++ b/dynawalla/games/lattice/src/test/ladder.test.ts
@@ -49,11 +49,20 @@ test("a session opens on the floor, and the floor is not the bottom of the ladde
 test("the floor is where the host's answers can first carry a factor tree", () => {
   // The request is only worth making if the other end honours it, and the point
   // of the floor is the *answers* it produces rather than the number itself.
+  //
+  // Every field the game actually sends, including `minDifficulty` — because on
+  // the shipped wire that is the only one of the three the host is obliged to
+  // honour. See `Request.minDifficulty`.
   const host = createStubHost({ seed: 0x51ee, reducedMotion: true })
   let big = 0
   const n = 300
   for (let i = 0; i < n; i++) {
-    const q = host.next({ domain: "add", difficulty: FLOOR, maxDifficulty: CEILING })
+    const q = host.next({
+      domain: "add",
+      difficulty: FLOOR,
+      maxDifficulty: CEILING,
+      minDifficulty: FLOOR,
+    })
     if (Number(q.answer) >= MIN_TARGET) big += 1
   }
   assert.ok(big / n > 0.75, `only ${big}/${n} floor answers reached ${MIN_TARGET}`)

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -248,6 +248,47 @@ for (const [w, h] of [
   }
 }
 
+test("a fresh profile never sees NO RESONATOR — SWEEP ON", () => {
+  // **The founder's screen, at the shell.** `band.test.ts` has the full account
+  // and the rules-level assertions; this one is here because the line he read
+  // out is drawn by `render/scene.ts` off `arena.stalled`, and neither the rules
+  // nor the renderer can be asked on its own whether a child saw it.
+  //
+  // So: the real mount, the real loop, the real HUD, a canvas that records every
+  // string it is asked to paint, and a host whose own ladder is standing on rung
+  // 0 the way it is on every launch of every fresh profile. Sixty seconds of it.
+  //
+  // Against the shipped 0.3.10 build this fails on the first frame and stays
+  // failed: the notice is the only thing on the screen that changes.
+  const realNow = Date.now
+  Date.now = () => 1_700_000_000_000
+  try {
+    const counter = { calls: 0, text: [] as string[] }
+    withBrowser({ w: 390, h: 740 }, counter, ({ host, frames }) => {
+      const stub = createStubHost({ seed: 0x1a771ce, reducedMotion: true })
+      assert.equal(stub.position(), 0, "the host did not open on a fresh profile")
+      const handle = mount(host as unknown as HTMLElement, stub)
+      pump(frames, 3600)
+      const stalls = counter.text.filter((s) => s.includes("NO RESONATOR"))
+      assert.deepEqual(
+        stalls.slice(0, 1),
+        [],
+        `a child on a fresh profile was told there is no resonator, on ${stalls.length} frames ` +
+          `of 3600`,
+      )
+      // And the ring was really drawn, rather than the notice merely being
+      // absent because nothing was drawn at all.
+      assert.ok(
+        counter.text.some((s) => /^\d+\s[+−]\s\d+$/.test(s)),
+        "no resonator ever put a problem on its face",
+      )
+      handle.unmount()
+    })
+  } finally {
+    Date.now = realNow
+  }
+})
+
 test("flying into the resonator actually asserts the hold", () => {
   // The rule for this lives in `Arena.enter`, it is asserted to death in
   // `arena.test.ts` and `resonance.test.ts` — and the shell never called it.

--- a/dynawalla/games/lattice/src/test/opening.test.ts
+++ b/dynawalla/games/lattice/src/test/opening.test.ts
@@ -8,7 +8,7 @@
 // sixty seeds, and what a child would be looking at is counted.
 //
 // The shipped opening, measured the same way (the `step: 5` row below is
-// literally it, unchanged): up to six numbers on the screen before the child
+// literally it, unchanged): up to seven numbers on the screen before the child
 // has touched anything, the fastest of them crossing the arena's diagonal in
 // nine and a half seconds, and up to nine on the screen once that field is
 // ground down to primes.
@@ -36,8 +36,7 @@ const VIEWPORTS: Array<[string, number, number]> = [
 const SEEDS = Array.from({ length: 60 }, (_, i) => i * 7919 + 1)
 
 /**
- * The bounds. Measured, then written down one notch loose so an unlucky seed
- * does not fail the suite and a regression of any size does.
+ * The bounds.
  *
  * `bodies` is what is on the screen at t=0. `ground` is what is on the screen
  * after every husk in that field has been shot all the way down to primes —
@@ -45,14 +44,28 @@ const SEEDS = Array.from({ length: 60 }, (_, i) => i * 7919 + 1)
  * fastest anything is moving, as a percentage of the arena's own diagonal per
  * second, which is the only frame-of-reference that means the same thing on a
  * phone and on a tablet (see `arena.REFERENCE_SPAN`).
+ *
+ * `bodies` and `ground` are measured over three hundred seeds at three
+ * viewports and written down at the maximum. `drift` is **not** measured: a
+ * body's velocity is drawn per axis from `±DRIFT_MAX_SPAN · plan.drift`, so its
+ * magnitude cannot exceed `√2 · 7.7% · plan.drift` however many bodies there
+ * are, and the row below is that number rounded up. An empirical maximum here
+ * is an order statistic over however many bodies the field happened to have,
+ * which is what the old row was — it was set from sixty seeds, sat a tenth of a
+ * point under the real ceiling, and a change to the *question stream* moved a
+ * body count and walked it over. The ceiling does not move for a seed.
+ *
+ * They are literals and not a derivation, deliberately: `√2 · DRIFT_MAX_SPAN ·
+ * openingAt(step).drift` would agree with itself at any value of either
+ * constant, and the point is that doubling the drift constant fails this file.
  */
 const BOUNDS: Array<{ step: number; bodies: number; ground: number; drift: number }> = [
-  { step: 0, bodies: 1, ground: 5, drift: 3.0 },
-  { step: 1, bodies: 1, ground: 5, drift: 4.5 },
-  { step: 2, bodies: 3, ground: 6, drift: 6.3 },
-  { step: 3, bodies: 5, ground: 7, drift: 7.5 },
-  { step: 4, bodies: 6, ground: 8, drift: 9.8 },
-  { step: 5, bodies: 6, ground: 9, drift: 10.5 },
+  { step: 0, bodies: 1, ground: 5, drift: 3.3 },
+  { step: 1, bodies: 1, ground: 5, drift: 4.9 },
+  { step: 2, bodies: 3, ground: 6, drift: 6.6 },
+  { step: 3, bodies: 5, ground: 8, drift: 8.2 },
+  { step: 4, bodies: 7, ground: 9, drift: 9.9 },
+  { step: 5, bodies: 7, ground: 9, drift: 10.9 },
 ]
 
 function armed(seed: number, w: number, h: number, experience: number): Arena {

--- a/dynawalla/games/lattice/src/test/pacing.test.ts
+++ b/dynawalla/games/lattice/src/test/pacing.test.ts
@@ -43,7 +43,7 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import { Rng } from "../core/rng.ts"
-import { Arena } from "../game/arena.ts"
+import { Arena, REARM_MS } from "../game/arena.ts"
 import { primeFactors } from "../game/factor.ts"
 import { CEILING, FLOOR, RUNGS, rungOf } from "../game/ladder.ts"
 import { CALM_OPENINGS } from "../game/opening.ts"
@@ -118,7 +118,17 @@ test("ten minutes of perfect play is spent on the real game, not below it", () =
     targets = targets.concat(played.targets)
     withoutQuestionMs += played.withoutQuestionMs
     rungs.push(...played.host.servedRungs())
-    assert.equal(played.arena.stalled, false, `seed ${seed.toString(16)} ended stalled`)
+    // **Not `arena.stalled` on the final frame.** That is what this line used to
+    // be, and it cannot tell the two failures apart: it is true of a
+    // two-and-a-half-second rearm that is about to close and false of an arena
+    // that was empty for nine minutes and happened to arm on the last one. The
+    // longest single gap is the number that means something, and a gap longer
+    // than a couple of rearms is a band the game cannot draw from.
+    assert.ok(
+      played.longestGapMs <= 3 * REARM_MS,
+      `seed ${seed.toString(16)} went ${(played.longestGapMs / 1000).toFixed(1)}s with no ring on ` +
+        `the screen, which is more than three rearms`,
+    )
     // The host's own ladder ends inside the band too, because every request the
     // game makes moves it — a pack that drove the stream out of its own reach and
     // left it there is the shape of the defect at the other end of this fix.
@@ -161,13 +171,13 @@ test("ten minutes of perfect play is spent on the real game, not below it", () =
     "a hold needed a mote larger than the game draws",
   )
 
-  // The arena is essentially never without something to answer. Measured at
-  // roughly 500 of every 600 seconds before and at 10 seconds in 3,000 after —
-  // the fallback tier refuses a hold with an unreadable mote in it, and a couple
-  // of `REARM_MS` waits a sitting is what that costs.
+  // The arena is essentially never without something to answer. Roughly 500 of
+  // every 600 seconds before the ladder existed; 2.5 seconds in 3,000 now, on
+  // one seed of five, against a host that models `HINT_BAND`. The budget is
+  // twelve, which is four rearms across five ten-minute sittings.
   assert.ok(
-    withoutQuestionMs < 45_000,
-    `the arena had no question for ${(withoutQuestionMs / 1000).toFixed(0)}s across five sittings`,
+    withoutQuestionMs < 12_000,
+    `the arena had no question for ${(withoutQuestionMs / 1000).toFixed(1)}s across five sittings`,
   )
 
   // And no rung below the floor was ever served — not even once, not even while
@@ -326,7 +336,12 @@ test("the game learns from the rung that answered, not the rung it asked for", (
   // the position onto a rung the child never saw, which breaks all three of the
   // mechanisms this fix is built on.
   const STALE = 21
-  const inner = createStubHost({ seed: 0x57a1e, reducedMotion: true })
+  // `band: false`, and it is the one thing this case needs off: it is a
+  // statement about the PACK's ladder — that `landed()` follows the rung that
+  // answered — and it works by forcing every answer to come from one rung. A
+  // host that then clamped that rung into its own band would be answering from a
+  // rung of its choosing, and there would be nothing left to measure.
+  const inner = createStubHost({ seed: 0x57a1e, reducedMotion: true, band: false })
   const asked: number[] = []
   const stale: StubHost = {
     ...inner,


### PR DESCRIPTION
Two games the founder says are not shippable.

## 1. THE LATTICE (`games/lattice`) — there was no ring, on every fresh profile, forever

> "'The lattice' is complete broken farce. 'The ring floats in the middle with sum' — there is no fucking ring it says 'no resonator - sweep on'"

The manual was right and the screen was right. `render/scene.ts` draws `NO RESONATOR — SWEEP ON` off `arena.stalled`, and the arena stalled on the first frame of every first sitting and could never clear.

**The hint work is innocent.** #739 (six-stage factor tree) and #762 (one husk at t=0, gentler ramp, live divisor marking) both landed on top of this; neither caused it. The cause is three days earlier:

```
9de8cef16  fix(dynawalla/host): a pack's difficulty is a hint clamped to ±1 rung of the host's band  (#735)
```

From that commit a pack's `difficulty` is a **hint**, honoured within `HINT_BAND` — one rung — of where the host's own evidence stands. That evidence (`progress`) opens at rung 0 on every fresh profile. THE LATTICE's floor is rung 16, so it was served rung 1: answers of two to six, and nothing under twelve carries a factor tree. All six draws of the arming missed, `arm` set `stalled`.

**And it was a deadlock.** The only thing that moves the host's `progress` is a report; the only thing that produces a report is a resonator opening; there was no resonator. Every rearm drew from rung 1 again, for as long as the child sat there.

TREBUCHET had the identical defect for three releases (0.3.7–0.3.9) and #771 built the way out. `minDifficulty` is a **capability** — the pack stating what it can physically render — honoured absolutely, above the host's band as well as below it, and it never moves the child's ladder. THE LATTICE's floor was always that kind of claim (`MIN_TARGET` is 12 because a smaller answer has no tree in it) and had never been stated. It now goes out on every request.

### Why 207 tests missed it

`stubHost.ts` calls itself a model of the wire and did not model the band — it served whatever rung it was asked for. It models it now, **by default**; `band: false` is the opt-out and exactly two cases want it (both measuring the pack's own ladder in isolation, and both say so).

Its rung→operand curve is also recalibrated to its own documented calibration point ("past 999 from about rung 47"): at 1.125 the sum passed 999 from rung **44**, making rung 47 16% usable against `ladder.ts`'s measured **57%** for the shipped graph. Base 1.115 makes the docstring true. This is not tuning to make the change pass — it is the stub being wrong about the top of the ladder, exposed because modelling the band puts the game there.

|  | before | after |
|---|---|---|
| fresh profile, 60s through the real shell | the stall notice on **3600 of 3600 frames** | never |
| no-question time, 5 × 10 min of perfect play | 81s | **2.5s** |
| longest single gap | — | one rearm (2.5s) |

New: `src/test/band.test.ts` and a shell-level case in `mount.test.ts`.

## 2. LATTICE RUNNER (`games/beam`) — too fast, for the hundredth time

> "LATTICE RUNNER IS TOO FUCKING FAST FOR THE 100TH TIME. NO ONE CAN THINK THAT FAST."

**The reason it never got fixed is the name.** His earlier report about this game — "maybe one number at a time and a slower ramp up from an easier baseline .. first time you enter it could be just one number calmly coming down the lattice" — is quoted verbatim at the top of `games/lattice/src/game/opening.ts`. The ramp it asks for was built into **the other pack**.

`window(d)` here is already a pure, monotone function of the item and stays that way (`sim/window.ts`, decoupled from `descentSeconds` in an earlier PR). The defect was everything around it:

* the director opened at `floorCount: 2` and a fracture threw out four candidates, so a child's first screen was up to **eight numbered hulls**, six irrelevant to the sum on the seventh;
* the escalation was a **clock** — `elapsed/90 × 0.65 + kills/60 × 0.45` — and `drawWave` asks the host for `2 + round(level × 7)`, so time served was raising the **arithmetic**. A child who had answered nothing in 90s was on item difficulty 7 with five hulls at a 1.3s spawn gap.

`sim/opening.ts` is the fleet's shape, copied rather than tuned: **one thing on screen at t=0**; a ramp **indexed by demonstrated competence and persisted** (`sim/learned.ts` — +1 a core read, −1 a miss or a wave that reached the floor, floored at zero, never shown to anybody); **the top step is the shipped game unchanged**, asserted against the constants themselves; monotone in both directions, asserted exhaustively.

Measured through the **real shell** — real mount, real frame loop, real key handler — 60s, 5 seeds, 768×1024, with a bot that slides, fires and dismisses:

| | shipped | first sitting |
|---|---|---|
| numbered hulls, peak | 8 | **2** |
| numbered hulls, mean | 3.92 | **1.62** |
| the second problem arrives | 6.1s | **11.2s** |
| problems asked in 60s | 10.8 | **5.8** |
| item difficulty after 90s of sitting still | 7 | **2** |

It comes back up as the child reads cores (5.8/min at step 0 → 8–9 by step 4) and the ceiling is the board he was reporting, untouched.

**And the miss now holds.** `revealSeconds` (1.5–3s, then the sum was taken away) is deleted, with a note at its grave, in favour of `packs/shared/game-pacing`'s `revealPlan` semantics: `holdMs: Infinity`, `REVEAL_SETTLE_MS` of lockout, ended only by the child's own hand.

## 3. The rename

THE LATTICE and LATTICE RUNNER are one word apart in one catalogue, and §2 is what that cost. Considered: THE DIVISOR GATE, THE SIEVE, BRASS CHOIR, THE RESONANCE HALL, THE TUNING HALL.

Chosen: **THE TUNING HALL** — a place in the bazaar where things are tuned until the wobble stops, which is already this game's own verb ("when the beam fits exactly, the wobble stops and you hear one clean note"). The word "lattice" now appears on no surface a child sees: the manual, the game-over banner ("THE HALL GOES DARK") and the catalogue description are all changed.

**The pack id and directory stay `beam`**, as MATH NINJA and THE PEDDLER kept theirs.

## Verification

* `npm run -s tsc` clean in both packs; both suites **5× consecutively** — beam 112/112, lattice 212/212.
* `node packs/build.mjs lattice beam` builds and passes the SDK checker; `dynawalla.beam@0.1.0 — THE TUNING HALL`, id unchanged.
* **Every new assertion mutation-tested.** Reverting `minDifficulty: FLOOR` fails 9 tests including `a child on a fresh profile was told there is no resonator, on 3600 frames of 3600`; flipping the stub's `band` default off fails `400/400 draws were usable, so the band is not being modelled`; flattening the beam ramp's step 0 fails `hulls fell at step 1` and `2 hull(s) with nothing to do with the sum were on a first sitting's lattice`; unwiring `fitOpening` from the shell fails `a child with no history did not open at the floor`; deleting the `wantsSpawn` cap fails at 6 hulls; deleting the clock cap fails `step 0: three minutes of sitting still reached level 0.65`; deleting the reveal settle and the reveal hold each fail their own cases. The shell-level cases drive the real pointer/key handlers and the real loop, not pure functions.

## Thresholds that moved, and why

* `opening.test.ts` (lattice) `BOUNDS.drift` is now the **analytic ceiling** (`√2 · DRIFT_MAX_SPAN · plan.drift`) written as literals instead of a 60-seed empirical maximum. The old row sat a tenth of a point under the real ceiling and a change to the *question stream* walked a body count over it. `bodies`/`ground` re-measured over 300 seeds. Step 0 — the founder-facing claim, one number at 3.0% of the diagonal — is unchanged to the digit.
* `pacing.test.ts` (lattice) no longer asserts `arena.stalled === false` on the final frame; that is true of a 2.5s rearm about to close and false of an arena that was empty for nine minutes. It asserts the **longest single gap** instead, and the total budget is **tightened** 45s → 12s.
* `comprehension.test.ts` (beam) the miss-reveal floor is `REVEAL_SETTLE_MS` rather than 60 frames, because the reveal no longer has a length — the bot dismisses it. Two new cases cover the other end: it survives three minutes untouched, and no key inside the settle can take it away.

## Noted, not fixed here

`games/beam` sends `difficulty` with no `minDifficulty`/`maxDifficulty`, so on a fresh profile it is banded to rung 1 too. Unlike THE LATTICE it is not deadlocked — it reports every answer, so the host's own staircase carries it out within a few cores — and the founder's report is that it is too fast, not too easy. Worth its own PR.

Do not merge — @skyl merges.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb