### PR TITLE
fix(dynawalla): the safe area, once, for the whole fleet — and a gate that makes the sixth time impossible

### DIFF
--- a/dynawalla/AGENTS.md
+++ b/dynawalla/AGENTS.md
@@ -23,6 +23,22 @@ first — it tells you what exists.
 - **Never a fourth required status check.** Dynawalla jobs join `ci-gate.needs`. A
   path-gated required context never reports on PRs that miss its paths and blocks the
   merge queue forever.
+- **A pack never reads `env(safe-area-inset-*)`.** It is the number ZERO inside a pack
+  frame — the frame is sandboxed `allow-scripts` with no `allow-same-origin`, and `env()`
+  belongs to the top-level browsing context. It looks perfect in a browser tab and ships a
+  HUD under the status bar; five packs have shipped that way, each found by the founder on
+  a device with a green suite behind it. Call `installSafeArea(root, onChange)` from
+  `packs/shared/game-chrome` — one call publishes `--dw-safe-*` for the stylesheet,
+  subscribes for rotation and Split View, and hands the same numbers to the canvas, so the
+  two halves of one game cannot disagree about where the screen is. The only permitted
+  spelling in CSS is `var(--dw-safe-<side>, env(safe-area-inset-<side>, 0px))`, and in
+  CSS-in-TS you interpolate `SAFE_VARS.<side>` rather than typing it.
+  `packs/sdk/src/safearea.test.ts` parses every pack's shipped stylesheet, runs the cascade
+  at ten real viewports and resolves each edge offset to a number; it fails the build for a
+  bare `env()`, for a `padding:` shorthand in a media query that throws a longhand away,
+  and for anything pinned within 64px of one edge that does not pay the inset. If a rule is
+  genuinely not anchored to the glass, say so in a `--dw-safe-exempt` declaration with a
+  reason you were willing to write down.
 - **No floats in `curriculum/` or `engine/`.** Exact integer/rational arithmetic only.
   `0.1 + 0.2 !== 0.3` marks correct decimal work wrong *deterministically*, so no flaky
   test ever fires. A lint suppression in those two directories is a review blocker.

--- a/dynawalla/games/arena/src/ui/hud.ts
+++ b/dynawalla/games/arena/src/ui/hud.ts
@@ -2,8 +2,11 @@ import {
   HOST_CONTROL,
   HOST_MARGIN,
   HOST_PROGRESS_H,
+  SAFE_VARS,
+  installSafeArea,
   type Insets,
   type Rect,
+  type SafeArea,
 } from "../../../../packs/shared/game-chrome/index.ts"
 import { RIVAL_NAMES, type World } from "../sim/world.ts"
 import { DEPTHS } from "../sim/depths.ts"
@@ -129,11 +132,26 @@ export function soundRect(h: number, insets: Insets = { top: 0, right: 0, bottom
   return { x: Math.max(12, insets.left), y: h - bottom - 44, w: 44, h: 44 }
 }
 
-const CSS = `
+/**
+ * The stylesheet.
+ *
+ * **`SAFE_VARS` rather than `env()`.** Every edge offset below used to read
+ * `env(safe-area-inset-*)` directly, and inside a pack frame that is the number
+ * ZERO — the frame is sandboxed `allow-scripts` with no `allow-same-origin`
+ * and `env()` belongs to the top-level browsing context. So `.arena-depth`
+ * started 63px down instead of 87 on the founder's phone, and `.arena-btns`
+ * sat 12px from the bottom of the glass, 36px inside a three-button navigation
+ * bar. `hudRects()` above had the arithmetic right the whole time and
+ * `layout.test.ts` asserted it — of a HUD that was never drawn.
+ *
+ * The numbers now arrive as `--dw-safe-*`, published by `installSafeArea` in
+ * the constructor below from the same measurement `hudRects` is given.
+ */
+export const CSS = `
 .arena-hud{position:absolute;inset:0;pointer-events:none;font-family:ui-rounded,"SF Pro Rounded",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;color:#cfefff;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;overflow:hidden}
 .arena-hud *{box-sizing:border-box}
-.arena-depth{position:absolute;top:calc(env(safe-area-inset-top) + ${HUD_TOP}px);left:max(${HUD_EDGE}px,env(safe-area-inset-left));
+.arena-depth{position:absolute;top:calc(${SAFE_VARS.top} + ${HUD_TOP}px);left:max(${HUD_EDGE}px,${SAFE_VARS.left});
   max-width:${DEPTH_W}px;
   font-size:clamp(11px,2.4vw,15px);letter-spacing:.30em;font-weight:800;opacity:.82;
   text-shadow:0 0 18px rgba(80,220,255,.55),0 2px 6px rgba(0,0,0,.9)}
@@ -141,7 +159,7 @@ const CSS = `
 .arena-pips{display:flex;gap:3px;margin-top:6px}
 .arena-pip{width:9px;height:3px;border-radius:2px;background:rgba(160,225,255,.20);transition:background .5s,box-shadow .5s}
 .arena-pip.on{background:#ffd479;box-shadow:0 0 9px rgba(255,200,110,.85)}
-.arena-board{position:absolute;top:calc(env(safe-area-inset-top) + ${HUD_TOP}px);right:max(${HUD_EDGE}px,env(safe-area-inset-right));
+.arena-board{position:absolute;top:calc(${SAFE_VARS.top} + ${HUD_TOP}px);right:max(${HUD_EDGE}px,${SAFE_VARS.right});
   min-width:${BOARD_W}px;display:flex;flex-direction:column;gap:2px;align-items:stretch}
 .arena-row{display:flex;justify-content:space-between;gap:10px;font-size:clamp(10px,2.1vw,13px);
   letter-spacing:.12em;font-weight:700;opacity:.5;font-variant-numeric:tabular-nums;
@@ -155,8 +173,8 @@ const CSS = `
    legitimately be a white bloom-out and a maths product may not have the one
    line of arithmetic on screen be the thing that disappears. Tabular numerals,
    so a replacing line does not jitter its own digits sideways. */
-.arena-eq{position:absolute;left:max(${RIBBON_EDGE}px,env(safe-area-inset-left));right:max(${RIBBON_EDGE}px,env(safe-area-inset-right));
-  bottom:calc(max(${RIBBON_EDGE}px,env(safe-area-inset-bottom)) + ${RIBBON_LIFT}px);
+.arena-eq{position:absolute;left:max(${RIBBON_EDGE}px,${SAFE_VARS.left});right:max(${RIBBON_EDGE}px,${SAFE_VARS.right});
+  bottom:calc(max(${RIBBON_EDGE}px,${SAFE_VARS.bottom}) + ${RIBBON_LIFT}px);
   max-width:${RIBBON_MAX_W}px;margin-inline:auto;height:${RIBBON_H}px;
   display:grid;place-items:center;pointer-events:none}
 .arena-eq>span{display:inline-block;padding:6px 16px;border-radius:8px;
@@ -178,7 +196,7 @@ const CSS = `
 .arena-eq.reveal>span{background:rgba(4,18,32,.80);color:#eafcff;
   box-shadow:inset 0 0 0 1px rgba(150,220,255,.45),0 0 22px rgba(110,190,255,.28),0 2px 14px rgba(0,0,0,.6);
   font-size:clamp(17px,5vw,30px)}
-.arena-combo{position:absolute;left:50%;bottom:calc(max(16px,env(safe-area-inset-bottom)) + ${RIBBON_LIFT + RIBBON_H + 8}px);transform:translate(-50%,0);
+.arena-combo{position:absolute;left:50%;bottom:calc(max(16px,${SAFE_VARS.bottom}) + ${RIBBON_LIFT + RIBBON_H + 8}px);transform:translate(-50%,0);
   font-size:clamp(14px,4vw,26px);font-weight:900;letter-spacing:.10em;opacity:0;transition:opacity .18s;
   text-shadow:0 0 26px rgba(120,255,220,.7),0 2px 8px rgba(0,0,0,.9);font-variant-numeric:tabular-nums}
 .arena-combo.on{opacity:.95}
@@ -187,8 +205,8 @@ const CSS = `
    SAFE left and right edges and centred inside them — 94vw was centred on the
    glass, which in landscape put a sixty-pixel numeral half under the sensor
    housing on the notched side. */
-.arena-q{position:absolute;left:max(${Q_EDGE}px,env(safe-area-inset-left));right:max(${Q_EDGE}px,env(safe-area-inset-right));
-  top:calc(env(safe-area-inset-top) + ${HUD_TOP}px);max-width:760px;margin-inline:auto;transform:translateY(-14px);
+.arena-q{position:absolute;left:max(${Q_EDGE}px,${SAFE_VARS.left});right:max(${Q_EDGE}px,${SAFE_VARS.right});
+  top:calc(${SAFE_VARS.top} + ${HUD_TOP}px);max-width:760px;margin-inline:auto;transform:translateY(-14px);
   opacity:0;transition:opacity .22s cubic-bezier(.2,.9,.2,1),transform .34s cubic-bezier(.2,.9,.2,1);
   text-align:center;text-wrap:balance}
 .arena-q.on{opacity:1;transform:none}
@@ -203,7 +221,7 @@ const CSS = `
   font-size:clamp(22px,7vw,52px);font-weight:900;letter-spacing:.16em;
   transition:opacity .2s,transform .35s cubic-bezier(.16,1.2,.3,1);text-shadow:0 0 40px currentColor,0 2px 10px rgba(0,0,0,.9)}
 .arena-verdict.on{opacity:1;transform:translate(-50%,-50%) scale(1)}
-.arena-btns{position:absolute;left:max(12px,env(safe-area-inset-left));bottom:max(12px,env(safe-area-inset-bottom));
+.arena-btns{position:absolute;left:max(12px,${SAFE_VARS.left});bottom:max(12px,${SAFE_VARS.bottom});
   display:flex;gap:8px;pointer-events:auto}
 /* 44×44 of hit area around a 34×34 face. The only interactive control in the
    game may not be smaller than a child's fingertip; the plate stays small so
@@ -221,7 +239,7 @@ const CSS = `
    carried by nothing a child can name, and this product does not do that. */
 .arena-btn.off{opacity:.32}
 .arena-btn.off>i{text-decoration:line-through;text-decoration-thickness:2px}
-.arena-perf{position:absolute;right:max(12px,env(safe-area-inset-right));bottom:max(12px,env(safe-area-inset-bottom));
+.arena-perf{position:absolute;right:max(12px,${SAFE_VARS.right});bottom:max(12px,${SAFE_VARS.bottom});
   font-size:10px;letter-spacing:.14em;opacity:.28;font-variant-numeric:tabular-nums;font-weight:700}
 @media (max-width:360px){.arena-board{min-width:92px}}
 @media (prefers-reduced-motion:reduce){.arena-q,.arena-verdict,.arena-combo,.arena-btn,.arena-eq>span{transition-duration:.01ms}}
@@ -311,6 +329,16 @@ export class Hud {
    */
   private eqHold = 0
 
+  /**
+   * The safe area, published onto `this.root` so the stylesheet can read it.
+   *
+   * Held so `dispose` can drop the subscription — the insets change on every
+   * rotation, and iPadOS changes them again when a pack is resized in Split
+   * View, so a HUD that reads them once at mount is correct until the child
+   * turns the phone over.
+   */
+  private safeArea: SafeArea | null = null
+
   constructor(container: HTMLElement, onToggleSound: (on: boolean) => boolean) {
     const style = document.createElement("style")
     style.textContent = CSS
@@ -397,6 +425,11 @@ export class Hud {
 
     this.root.append(this.depthEl, board, this.comboEl, this.eqEl, this.qEl, this.verdictEl, btns, this.perfEl)
     container.appendChild(this.root)
+
+    // The four lengths every rule above reads. Published here, before the first
+    // frame, and again on every change — an unpublished property falls through
+    // to the `env()` behind it, which is zero inside this frame.
+    this.safeArea = installSafeArea(this.root)
   }
 
   private setRungs(band: number): void {
@@ -545,6 +578,8 @@ export class Hud {
   }
 
   dispose(): void {
+    this.safeArea?.dispose()
+    this.safeArea = null
     this.root.remove()
   }
 }

--- a/dynawalla/games/balance/src/game.ts
+++ b/dynawalla/games/balance/src/game.ts
@@ -25,6 +25,7 @@ import {
 } from "./puzzle.ts";
 import {
   createInstructions,
+  onInsetsChange,
   type Instructions,
 } from "../../../packs/shared/game-chrome/index.ts";
 import { widestNumeral } from "./adapter.ts";
@@ -257,6 +258,13 @@ export class Game {
 
     this.ro = new ResizeObserver(() => this.resize());
     this.ro.observe(el);
+    // A ResizeObserver is not enough on its own. The insets arrive from the HOST,
+    // over the settings channel, AFTER the first layout — and iPadOS changes them
+    // in Split View without the element's box moving at all, so the observer never
+    // fires. A game that reads the safe rectangle once at mount therefore lays
+    // itself out against the probe's zeros and stays there. MERGE shipped exactly
+    // that; every pack in this fleet now subscribes.
+    this.stopInsets = onInsetsChange(() => this.resize());
     window.addEventListener("resize", this.onWinResize);
 
     this.canvas.addEventListener("pointerdown", this.onDown);
@@ -1410,11 +1418,16 @@ export class Game {
     }),
   };
 
+  /** Drops the inset subscription. A listener that outlives the frame keeps the whole closure alive. */
+  private stopInsets: (() => void) | null = null;
+
   unmount(): void {
     this.running = false;
     this.guide.destroy();
     cancelAnimationFrame(this.raf);
     this.ro?.disconnect();
+    this.stopInsets?.();
+    this.stopInsets = null;
     window.removeEventListener("resize", this.onWinResize);
     window.removeEventListener("keydown", this.onKey);
     this.canvas.removeEventListener("pointerdown", this.onDown);

--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -22,7 +22,7 @@
 // you at the phase `(v mod b) / b`. At zero the two waveforms fuse. Division,
 // audible.
 
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import type { Host, Question } from "./contract.ts"
 import { Audio } from "./audio.ts"
 import { Feel } from "./core/feel.ts"
@@ -305,6 +305,14 @@ export function mountBeam(el: HTMLElement, host: Host): {
   const ro = new ResizeObserver(() => resize())
   ro.observe(root)
   resize()
+
+  // A ResizeObserver is not enough on its own. The insets arrive from the HOST,
+  // over the settings channel, AFTER the first layout — and iPadOS changes them
+  // in Split View without the element's box moving at all, so the observer never
+  // fires. A game that reads the safe rectangle once at mount therefore lays
+  // itself out against the probe's zeros and stays there. MERGE shipped exactly
+  // that; every pack in this fleet now subscribes.
+  const stopInsets = onInsetsChange(() => resize())
 
   // ── helpers ──────────────────────────────────────────────────────────────
   function pop(text: string, x: number, y: number, size: number, color: string): void {
@@ -1150,6 +1158,7 @@ export function mountBeam(el: HTMLElement, host: Host): {
       guide.destroy()
       cancelAnimationFrame(raf)
       ro.disconnect()
+      stopInsets()
       canvas.removeEventListener("pointerdown", onDown)
       canvas.removeEventListener("pointermove", onMove)
       canvas.removeEventListener("pointerup", onUp)

--- a/dynawalla/games/claim/src/game/index.ts
+++ b/dynawalla/games/claim/src/game/index.ts
@@ -10,6 +10,7 @@
 import {
   createInstructions,
   onInsetsChange,
+  SAFE_PREFIX,
   publishSafeVars,
   safeInsets,
   type Instructions,
@@ -322,7 +323,7 @@ class Claim {
     // everything else in this game is: `env()` resolves to zero inside a pack
     // frame, because a pack is a cross-origin child and `env()` belongs to the
     // top-level document.
-    publishSafeVars(this.root, "--cl-safe-", insets)
+    publishSafeVars(this.root, SAFE_PREFIX, insets)
     this.r.resize(w, h, arenaRect(w, h, insets))
     const fw = this.root.clientWidth || w
     const fh = this.root.clientHeight || h

--- a/dynawalla/games/claim/src/style.css
+++ b/dynawalla/games/claim/src/style.css
@@ -86,11 +86,14 @@
   z-index: 2;
   flex: 0 0 auto;
   /* Published by `Hud.layout` from `layout.ts`, which is the version under
-     test. The `env()` fallbacks are what a HUD that never gets laid out
-     falls back to — correct for the notch, blind to the host's controls. */
-  padding: var(--cl-pt, calc(8px + env(safe-area-inset-top)))
-    var(--cl-pr, calc(12px + env(safe-area-inset-right))) 0
-    var(--cl-pl, calc(12px + env(safe-area-inset-left)));
+     test. The fallbacks are what a HUD that never gets laid out falls back to:
+     the safe edge plus a gutter, blind to the host's controls but never blind
+     to the notch. They used to read `env(safe-area-inset-*)` directly, which
+     inside a pack frame is the number ZERO — so the fallback path put the
+     score 8px from the top of the glass, under an Android clock. */
+  padding: var(--cl-pt, calc(8px + var(--dw-safe-top, env(safe-area-inset-top, 0px))))
+    var(--cl-pr, calc(12px + var(--dw-safe-right, env(safe-area-inset-right, 0px)))) 0
+    var(--cl-pl, calc(12px + var(--dw-safe-left, env(safe-area-inset-left, 0px))));
   will-change: transform;
 }
 .cl-hud.cl-punch {
@@ -209,11 +212,19 @@
   border: 2px solid rgba(244, 241, 232, 0.16);
   overflow: hidden;
 }
+/* The five layers of the fraction bar. Every one of them is positioned inside
+   `.cl-meter`, which is `position: relative` twenty lines up — so `left: 0`
+   here is the left end of a 20px-tall bar in the middle of the HUD, not the
+   left edge of the glass, and the safe area is `.cl-hud`'s padding to pay.
+   Said in a declaration rather than in this comment because the fleet gate
+   parses CSS and throws comments away, and an exemption it cannot see is an
+   exemption that quietly becomes universal. */
 .cl-ticks,
 .cl-fill,
 .cl-band,
 .cl-danger,
 .cl-marker {
+  --dw-safe-exempt: "inside .cl-meter, which is position:relative — these offsets are bar-relative";
   position: absolute;
   top: 0;
   bottom: 0;
@@ -277,7 +288,7 @@
     margin: 2px 0;
   }
   .cl-hud {
-    padding-top: var(--cl-pt, calc(6px + env(safe-area-inset-top)));
+    padding-top: var(--cl-pt, calc(6px + var(--dw-safe-top, env(safe-area-inset-top, 0px))));
   }
 }
 
@@ -378,10 +389,10 @@
      breakpoint that only wanted a tighter card would take the safe area with
      it. Change --cl-card-pad instead. */
   --cl-card-pad: 20px;
-  padding-top: calc(var(--cl-card-pad) + var(--cl-safe-top, env(safe-area-inset-top, 0px)));
-  padding-right: calc(var(--cl-card-pad) + var(--cl-safe-right, env(safe-area-inset-right, 0px)));
-  padding-bottom: calc(var(--cl-card-pad) + var(--cl-safe-bottom, env(safe-area-inset-bottom, 0px)));
-  padding-left: calc(var(--cl-card-pad) + var(--cl-safe-left, env(safe-area-inset-left, 0px)));
+  padding-top: calc(var(--cl-card-pad) + var(--dw-safe-top, env(safe-area-inset-top, 0px)));
+  padding-right: calc(var(--cl-card-pad) + var(--dw-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: calc(var(--cl-card-pad) + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: calc(var(--cl-card-pad) + var(--dw-safe-left, env(safe-area-inset-left, 0px)));
   pointer-events: none;
 }
 .cl-card.cl-on {
@@ -470,8 +481,8 @@
      gesture. 44px is the platform touch floor, and the box was 34.
      Published by `Claim.layout` from `muteRect`, which is the version under
      test; the `env()` fallbacks cover a layout that never runs. */
-  right: var(--cl-mute-r, calc(10px + env(safe-area-inset-right)));
-  bottom: var(--cl-mute-b, calc(10px + env(safe-area-inset-bottom)));
+  right: var(--cl-mute-r, calc(10px + var(--dw-safe-right, env(safe-area-inset-right, 0px))));
+  bottom: var(--cl-mute-b, calc(10px + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px))));
   width: var(--cl-mute-s, 44px);
   height: var(--cl-mute-s, 44px);
   border: 2px solid rgba(244, 241, 232, 0.22);

--- a/dynawalla/games/claim/test/safearea.test.ts
+++ b/dynawalla/games/claim/test/safearea.test.ts
@@ -41,6 +41,7 @@ import {
   parseCss,
   type Viewport,
 } from "../../../packs/shared/game-chrome/cssSafeArea.ts"
+import { envReadDirectly } from "../../../packs/shared/game-chrome/cssSafeArea.ts"
 import { hudFrame, muteRect } from "../src/game/layout.ts"
 
 const read = (rel: string): string =>
@@ -72,7 +73,7 @@ function published(w: number, h: number, insets: Insets, vp: Viewport): Map<stri
   vars.set("--cl-mute-s", `${m.w}px`)
   // …and the raw insets, for the cards, which centre in the whole frame.
   for (const side of ["top", "right", "bottom", "left"] as const) {
-    vars.set(`--cl-safe-${side}`, `${insets[side]}px`)
+    vars.set(`--dw-safe-${side}`, `${insets[side]}px`)
   }
   return vars
 }
@@ -264,22 +265,17 @@ test("the safe area never clips the card that the frame was not already clipping
 // ---------------------------------------------------------------------------
 
 test("no rule takes its answer from env() — it is zero where this game runs", () => {
-  // The rule this pack already followed, now enforced: an `env(safe-area-inset-*)`
-  // may only appear as the FALLBACK of a `--cl-*` custom property. Read directly
-  // it is the number zero inside a pack frame, whatever the device.
-  const stripped = CSS.replace(/\/\*[\s\S]*?\*\//g, "")
-  const found = [...stripped.matchAll(/env\(safe-area-inset-(top|right|bottom|left)/g)]
-  assert.ok(found.length > 0, "the dev-harness fallbacks are gone entirely")
-  for (const m of found) {
-    const before = stripped.slice(0, m.index)
-    const open = before.lastIndexOf("var(--cl-")
-    const close = before.lastIndexOf(")")
-    assert.ok(
-      open > close,
-      `env(safe-area-inset-${m[1]}) at ${m.index} is read directly, not as the fallback of a ` +
-        `--cl-* property — inside a pack frame that is the number zero`,
-    )
-  }
+  // An `env(safe-area-inset-*)` may only ever appear as the FALLBACK of the
+  // shared `--dw-safe-<side>` property. Read directly it is the number zero
+  // inside a pack frame, whatever the device.
+  //
+  // The rule used to be spelled out here against this pack's own `--cl-*`
+  // namespace. It is the shared check now, from `packs/shared/game-chrome`,
+  // because five packs each carrying their own copy of one rule is five
+  // chances for one of them to drift — and it is the SAME function
+  // `packs/sdk/src/safearea.test.ts` runs over every pack in the fleet.
+  assert.ok(/env\(safe-area-inset/.test(CSS), "the dev-harness fallbacks are gone entirely")
+  assert.deepEqual(envReadDirectly(CSS), [])
 })
 
 test("no surface uses a `padding:` shorthand that a breakpoint could reset", () => {
@@ -314,10 +310,10 @@ test("every published property is written unconditionally, zeros included", () =
     "--cl-mute-r",
     "--cl-mute-b",
     "--cl-mute-s",
-    "--cl-safe-top",
-    "--cl-safe-right",
-    "--cl-safe-bottom",
-    "--cl-safe-left",
+    "--dw-safe-top",
+    "--dw-safe-right",
+    "--dw-safe-bottom",
+    "--dw-safe-left",
   ]) {
     const v = vars.get(name)
     assert.ok(v !== undefined, `${name} is not published at all on a device with no insets`)
@@ -338,7 +334,7 @@ test("the game publishes the frame at mount and again whenever the insets move",
   assert.ok(body.includes("this.hud.layout("), "layout() never republishes the HUD's frame")
   assert.ok(body.includes("muteRect("), "layout() never republishes the mute button")
   assert.ok(
-    body.includes('publishSafeVars(this.root, "--cl-safe-", insets)'),
+    body.includes("publishSafeVars(this.root, SAFE_PREFIX, insets)"),
     "layout() never publishes the raw insets — the cards fall back to an env() of zero",
   )
   assert.ok(index.includes("this.layout()"), "the frame is never published at all")

--- a/dynawalla/games/colossus/src/mount.ts
+++ b/dynawalla/games/colossus/src/mount.ts
@@ -24,7 +24,7 @@ import { bestStreak, recordStreak } from "./game/best.ts"
 import { Game, type GameEvent } from "./game/game.ts"
 import { Scene, type Banner } from "./render/scene.ts"
 import { STRIKE_ON } from "./render/palette.ts"
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 
 /**
  * The largest step the clock may take in one frame.
@@ -273,6 +273,13 @@ export function mountColossus(
       : null
   observer?.observe(el)
 
+  // A ResizeObserver is not enough on its own. The host's real insets arrive
+  // over the settings channel AFTER the first layout, and iPadOS changes them
+  // in Split View without the element's box moving at all — so the observer
+  // never fires and a game that read the safe rectangle once at mount stays
+  // laid out against the probe's zeros for ever. MERGE shipped exactly that.
+  const stopInsets = onInsetsChange(() => scene.resize())
+
   apply(game.begin(now()))
   frame = requestAnimationFrame(tick)
 
@@ -290,6 +297,7 @@ export function mountColossus(
       globalThis.removeEventListener("keydown", key)
       globalThis.removeEventListener("resize", resize)
       observer?.disconnect()
+      stopInsets()
       audio.dispose()
       guide.destroy()
       canvas.remove()

--- a/dynawalla/games/counterweight/src/mount.ts
+++ b/dynawalla/games/counterweight/src/mount.ts
@@ -7,7 +7,7 @@
 // guard, the strain bleed and the beam all run on it, and a rAF that keeps
 // ticking behind a sheet racks a lot the child never saw.
 
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import type { Handle, Host } from "./contract.ts"
 import { Audio } from "./audio.ts"
 import { Bout, type BoutEvent, TIMING, TIMING_REDUCED } from "./game/bout.ts"
@@ -405,6 +405,13 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
       : null
   observer?.observe(el)
 
+  // A ResizeObserver is not enough on its own. The host's real insets arrive
+  // over the settings channel AFTER the first layout, and iPadOS changes them
+  // in Split View without the element's box moving at all — so the observer
+  // never fires and a game that read the safe rectangle once at mount stays
+  // laid out against the probe's zeros for ever. MERGE shipped exactly that.
+  const stopInsets = onInsetsChange(() => scene.resize())
+
   // A hidden tab is the same situation as a sheet, and it arrives far more
   // often. `MAX_STEP_MS` alone would still spend 120 ms a frame on a throttled
   // timer; this stops the world outright.
@@ -467,6 +474,7 @@ export function mountCounterweight(el: HTMLElement, host: Host): Handle {
       globalThis.removeEventListener("resize", resize)
       globalThis.document?.removeEventListener("visibilitychange", visibility)
       observer?.disconnect()
+      stopInsets()
       guide.destroy()
       audio.dispose()
       canvas.remove()

--- a/dynawalla/games/horde/src/style.css
+++ b/dynawalla/games/horde/src/style.css
@@ -53,7 +53,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  padding: max(10px, var(--hz-safe-top, env(safe-area-inset-top))) max(10px, var(--hz-safe-right, env(safe-area-inset-right))) max(10px, var(--hz-safe-bottom, env(safe-area-inset-bottom))) max(10px, var(--hz-safe-left, env(safe-area-inset-left)));
+  padding: max(10px, var(--dw-safe-top, env(safe-area-inset-top, 0px))) max(10px, var(--dw-safe-right, env(safe-area-inset-right, 0px))) max(10px, var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px))) max(10px, var(--dw-safe-left, env(safe-area-inset-left, 0px)));
 }
 
 /* The XP bar had no `env()` at all: flush to y=0 and edge to edge, so on a
@@ -62,9 +62,9 @@
    now starts under the host's own 3px hairline rather than beneath it. */
 .hz-xpbar {
   position: absolute;
-  top: calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-xp-top));
-  left: var(--hz-safe-left, env(safe-area-inset-left));
-  right: var(--hz-safe-right, env(safe-area-inset-right));
+  top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--hz-xp-top));
+  left: var(--dw-safe-left, env(safe-area-inset-left, 0px));
+  right: var(--dw-safe-right, env(safe-area-inset-right, 0px));
   height: 7px;
   background: rgba(120, 190, 255, 0.10);
 }
@@ -83,8 +83,8 @@
    them. */
 .hz-top {
   position: absolute;
-  top: calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-chrome-top));
-  left: var(--hz-safe-left, env(safe-area-inset-left)); right: var(--hz-safe-right, env(safe-area-inset-right));
+  top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--hz-chrome-top));
+  left: var(--dw-safe-left, env(safe-area-inset-left, 0px)); right: var(--dw-safe-right, env(safe-area-inset-right, 0px));
   display: flex;
   justify-content: center;
   gap: clamp(10px, 3vw, 26px);
@@ -129,7 +129,7 @@
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: calc(var(--hz-life-bottom, 18px) + var(--hz-safe-bottom, env(safe-area-inset-bottom)));
+  bottom: calc(var(--hz-life-bottom, 18px) + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
   width: min(380px, 62vw);
   height: var(--hz-life-h, 22px);
   background: rgba(70, 12, 26, 0.62);
@@ -169,8 +169,8 @@
 
 .hz-weps {
   position: absolute;
-  left: calc(12px + var(--hz-safe-left, env(safe-area-inset-left)));
-  bottom: calc(40px + var(--hz-safe-bottom, env(safe-area-inset-bottom)));
+  left: calc(12px + var(--dw-safe-left, env(safe-area-inset-left, 0px)));
+  bottom: calc(40px + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -235,10 +235,10 @@
 
      */
   padding:
-    max(12px, var(--hz-safe-top, env(safe-area-inset-top)))
-    max(12px, var(--hz-safe-right, env(safe-area-inset-right)))
-    max(12px, var(--hz-safe-bottom, env(safe-area-inset-bottom)))
-    max(12px, var(--hz-safe-left, env(safe-area-inset-left)));
+    max(12px, var(--dw-safe-top, env(safe-area-inset-top, 0px)))
+    max(12px, var(--dw-safe-right, env(safe-area-inset-right, 0px)))
+    max(12px, var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)))
+    max(12px, var(--dw-safe-left, env(safe-area-inset-left, 0px)));
   background:
     radial-gradient(120% 90% at 50% 40%, rgba(8, 14, 34, 0.62), rgba(2, 4, 12, 0.93));
   backdrop-filter: blur(9px) saturate(0.85);
@@ -256,7 +256,7 @@
    top padding on a phone held sideways pushed DIVE AGAIN toward the bottom edge
    for nothing. */
 .hz-picks {
-  padding-top: max(12px, calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-chrome-top)));
+  padding-top: max(12px, calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--hz-chrome-top)));
 }
 
 .hz-modal.hz-open { display: flex; animation: hz-fade 170ms ease-out; }
@@ -356,7 +356,13 @@
 }
 .hz-card:active { transform: translateY(-2px) scale(0.99); }
 
+/* The corner flag on a draft card. `.hz-card` twenty lines up is
+   `position: relative`, so `top: 0; right: 0` is the top-right of a card inside
+   `.hz-picks`, which pays the safe area itself — not the corner of the glass.
+   Stated as a declaration because the fleet gate parses the CSS and throws
+   comments away. */
 .hz-card-rarity {
+  --dw-safe-exempt: "corner of .hz-card, which is position:relative — not the glass";
   position: absolute;
   top: 0; right: 0;
   padding: 3px 7px;
@@ -656,8 +662,8 @@
    and the host paints nothing down there. */
 .hz-corner {
   position: absolute;
-  bottom: calc(var(--hz-icon-bottom) + var(--hz-safe-bottom, env(safe-area-inset-bottom)));
-  right: calc(var(--hz-icon-edge) + var(--hz-safe-right, env(safe-area-inset-right)));
+  bottom: calc(var(--hz-icon-bottom) + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  right: calc(var(--hz-icon-edge) + var(--dw-safe-right, env(safe-area-inset-right, 0px)));
   display: flex;
   gap: var(--hz-icon-gap);
   pointer-events: auto;
@@ -681,8 +687,8 @@
 /* Behind `?debug`, but it sat under the back chevron too. */
 .hz-fps {
   position: absolute;
-  left: calc(var(--hz-fps-edge) + var(--hz-safe-left, env(safe-area-inset-left)));
-  top: calc(var(--hz-safe-top, env(safe-area-inset-top)) + var(--hz-chrome-top));
+  left: calc(var(--hz-fps-edge) + var(--dw-safe-left, env(safe-area-inset-left, 0px)));
+  top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--hz-chrome-top));
   font-size: 10px;
   letter-spacing: 0.1em;
   color: #4f7ea0;

--- a/dynawalla/games/horde/src/ui/layout.test.ts
+++ b/dynawalla/games/horde/src/ui/layout.test.ts
@@ -139,10 +139,10 @@ function fakeRoot(): { el: HTMLElement; vars: Map<string, string> } {
 test("the safe area reaches the stylesheet as numbers, not as env()", () => {
   const { el, vars } = fakeRoot()
   applySafeVars(el, NOTCH_PORTRAIT)
-  assert.equal(vars.get("--hz-safe-top"), "47px")
-  assert.equal(vars.get("--hz-safe-bottom"), "34px")
-  assert.equal(vars.get("--hz-safe-left"), "0px")
-  assert.equal(vars.get("--hz-safe-right"), "0px")
+  assert.equal(vars.get("--dw-safe-top"), "47px")
+  assert.equal(vars.get("--dw-safe-bottom"), "34px")
+  assert.equal(vars.get("--dw-safe-left"), "0px")
+  assert.equal(vars.get("--dw-safe-right"), "0px")
 })
 
 test("a zero inset is written explicitly, never left to the env() fallback", () => {
@@ -151,18 +151,18 @@ test("a zero inset is written explicitly, never left to the env() fallback", () 
   // zero has to be stated.
   const { el, vars } = fakeRoot()
   applySafeVars(el, NONE)
-  for (const k of ["--hz-safe-top", "--hz-safe-right", "--hz-safe-bottom", "--hz-safe-left"]) {
+  for (const k of ["--dw-safe-top", "--dw-safe-right", "--dw-safe-bottom", "--dw-safe-left"]) {
     assert.equal(vars.get(k), "0px", `${k} was left unset, so the CSS falls back to env()`)
   }
 })
 
 test("the offsets the CSS composes put the HUD where hudRects says it is", () => {
   // The composition the stylesheet performs, spelled out: every top offset is
-  // `var(--hz-safe-top) + var(--hz-chrome-top)`. This is the arithmetic that
+  // `var(--dw-safe-top) + var(--hz-chrome-top)`. This is the arithmetic that
   // silently produced 63 instead of 110.
   const { el, vars } = fakeRoot()
   applySafeVars(el, NOTCH_PORTRAIT)
-  const safeTop = Number.parseFloat(vars.get("--hz-safe-top") as string)
+  const safeTop = Number.parseFloat(vars.get("--dw-safe-top") as string)
   const composed = safeTop + CHROME_TOP
   assert.equal(composed, hudRects(390, 844, NOTCH_PORTRAIT).top.y)
   assert.ok(

--- a/dynawalla/games/horde/src/ui/layout.ts
+++ b/dynawalla/games/horde/src/ui/layout.ts
@@ -40,8 +40,8 @@
  *
  * The host measures the real values and publishes them; `safeInsets()` returns
  * those when they are there and falls back to the probe. `applyChromeVars`
- * writes them onto the root as `--hz-safe-*` and every rule in `style.css` reads
- * `var(--hz-safe-top, env(safe-area-inset-top))` — the `env()` staying on as the
+ * writes them onto the root as `--dw-safe-*` and every rule in `style.css` reads
+ * `var(--dw-safe-top, env(safe-area-inset-top))` — the `env()` staying on as the
  * fallback for `npm run dev`, where the game is top-level and `env()` is real.
  * `watchChromeVars` keeps them current across a rotation.
  */
@@ -50,8 +50,9 @@ import {
   HOST_CONTROL,
   HOST_MARGIN,
   HOST_PROGRESS_H,
-  NO_INSETS,
+  SAFE_PREFIX,
   onInsetsChange,
+  publishSafeVars,
   safeInsets,
   type Insets,
   type Rect,
@@ -169,16 +170,12 @@ export function applyChromeVars(root: HTMLElement, insets: Insets = safeInsets()
 /**
  * The safe area, as four custom properties `style.css` can do arithmetic with.
  *
- * Zeros are written explicitly rather than left unset: `var(--hz-safe-top, …)`
+ * Zeros are written explicitly rather than left unset: `var(--dw-safe-top, …)`
  * falls back to `env()` only when the property is ABSENT, and inside the app
  * `env()` is the wrong answer even when the real inset is 0.
  */
 export function applySafeVars(root: HTMLElement, insets: Insets = safeInsets()): void {
-  const i = insets ?? NO_INSETS
-  root.style.setProperty("--hz-safe-top", `${Math.max(0, i.top)}px`)
-  root.style.setProperty("--hz-safe-right", `${Math.max(0, i.right)}px`)
-  root.style.setProperty("--hz-safe-bottom", `${Math.max(0, i.bottom)}px`)
-  root.style.setProperty("--hz-safe-left", `${Math.max(0, i.left)}px`)
+  publishSafeVars(root, SAFE_PREFIX, insets)
 }
 
 /**

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -26,7 +26,7 @@
 // the mouse as an alternative aim and its button as the trigger. Tablet and
 // desktop are first-class targets here, not a phone game stretched.
 
-import { createInstructions } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts"
 import { Audio } from "./audio/audio.ts"
 import type { Host } from "./contract.ts"
 import { Rng } from "./core/rng.ts"
@@ -550,6 +550,13 @@ export function mountLattice(
     typeof ResizeObserver === "function" ? new ResizeObserver(() => resize()) : null
   observer?.observe(el)
 
+  // A ResizeObserver is not enough on its own. The host's real insets arrive
+  // over the settings channel AFTER the first layout, and iPadOS changes them
+  // in Split View without the element's box moving at all — so the observer
+  // never fires and a game that read the safe rectangle once at mount stays
+  // laid out against the probe's zeros for ever. MERGE shipped exactly that.
+  const stopInsets = onInsetsChange(() => resize())
+
   resize()
   scene.say("SHOOT WHAT SPLITS", CELESTIAL)
   apply(arena.begin(now()))
@@ -586,6 +593,7 @@ export function mountLattice(
       globalThis.removeEventListener("keyup", keyUp)
       globalThis.removeEventListener("resize", resize)
       observer?.disconnect()
+      stopInsets()
       audio.dispose()
       scene.dispose()
     },

--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -36,7 +36,7 @@
 
 import {
   createInstructions,
-  onInsetsChange,
+  installSafeArea,
   safeRect,
   type Instructions,
   type InstructionsSpec,
@@ -357,7 +357,13 @@ export class Game {
   private observeSize(): void {
     // Insets change more often than "never": a rotation swaps top and bottom with
     // left and right, and iPadOS changes them when a pack is resized in Split View.
-    this.detach.push(onInsetsChange(() => this.layout()))
+    // `installSafeArea` rather than a bare `onInsetsChange`: it also PUBLISHES
+    // the four insets onto the HUD root as `--dw-safe-*`, which `.ab-badge`
+    // reads. Subscribing without publishing is how the badge came to sit in the
+    // navigation bar — the canvas half knew where the safe rectangle was and
+    // the one DOM rule that needed it had no way to ask.
+    const safeArea = installSafeArea(this.hud.root, () => this.layout())
+    this.detach.push(() => safeArea.dispose())
     if (typeof ResizeObserver === 'undefined') {
       const onResize = (): void => this.layout()
       window.addEventListener('resize', onResize)

--- a/dynawalla/games/merge-idle/src/ui/hud.ts
+++ b/dynawalla/games/merge-idle/src/ui/hud.ts
@@ -24,9 +24,10 @@
  * because the bottom-left of a landscape stage is shelf.
  */
 
+import { SAFE_VARS } from '../../../../packs/shared/game-chrome/index.ts'
 import { faceSizeFor, METER_H, STAGE_BTN, type Chrome } from './chrome.ts'
 
-const CSS = `
+export const CSS = `
 .ab-root{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
   background:#04060f;color:#eef6ff;user-select:none;-webkit-user-select:none;touch-action:none;
   font-family:"SF Pro Rounded",ui-rounded,"Nunito","Avenir Next",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
@@ -57,7 +58,7 @@ const CSS = `
 @keyframes ab-grew{0%{filter:brightness(1)}30%{filter:brightness(2.4)}100%{filter:brightness(1)}}
 .ab-meter.grew{animation:ab-grew .7s ease-out}
 
-.ab-toasts{position:absolute;left:0;right:0;top:8%;z-index:5;display:flex;flex-direction:column;
+.ab-toasts{--dw-safe-exempt:"inside .ab-stage, which starts below the band that already pays the top inset";position:absolute;left:0;right:0;top:8%;z-index:5;display:flex;flex-direction:column;
   align-items:center;gap:6px;pointer-events:none}
 .ab-toast{font-weight:900;font-size:15px;letter-spacing:.06em;padding:7px 16px;border-radius:999px;
   background:rgba(4,7,18,.8);border:1px solid rgba(238,246,255,.22);text-shadow:0 2px 10px #000}
@@ -77,7 +78,17 @@ const CSS = `
   animation:ab-urge 1.1s ease-in-out infinite}
 @keyframes ab-urge{0%,100%{filter:brightness(1)}50%{filter:brightness(1.35)}}
 
-.ab-badge{position:absolute;left:50%;transform:translateX(-50%);bottom:6px;z-index:4;font-size:10px;
+/* THE FOUNDER'S DEFECT, and the reason this pack was reopened.
+   .ab-badge is a child of .ab-stage, which is the flex-grow row: its bottom
+   edge IS the bottom of the glass. bottom: 6px therefore put "12 blooms · 40
+   joins" six pixels off the panel — entirely inside a 48px three-button
+   navigation bar on the founder's phone, and inside the home indicator on every
+   notched iPhone.
+   Note what it is NOT: there was no env(safe-area-inset-bottom) here to be
+   zero. This rule never mentioned the safe area at all, so no search for the
+   text found it. That is why the fleet gate now evaluates edge offsets to
+   numbers rather than looking for a string. */
+.ab-badge{position:absolute;left:50%;transform:translateX(-50%);bottom:calc(6px + ${SAFE_VARS.bottom});z-index:4;font-size:10px;
   font-weight:800;opacity:.4;letter-spacing:.08em;pointer-events:none;font-variant-numeric:tabular-nums}
 
 @media (prefers-reduced-motion:reduce){
@@ -181,7 +192,7 @@ export class Hud {
    *
    * This is the only place the band's padding, its height and the two buttons'
    * corners are decided, and every number comes from `chromeLayout`. The
-   * stylesheet deliberately holds no safe-area rule of its own: two sources of
+   * stylesheet holds exactly ONE safe-area rule of its own — `.ab-badge`, which
    * truth for "where the notch is" is how a HUD ends up half-corrected — and
    * `env(safe-area-inset-*)` reads ZERO inside a pack frame anyway.
    */

--- a/dynawalla/games/merge/src/mount.ts
+++ b/dynawalla/games/merge/src/mount.ts
@@ -1,4 +1,4 @@
-import { createInstructions, safeRect } from "../../../packs/shared/game-chrome/index.ts";
+import { createInstructions, onInsetsChange, safeRect } from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, FocusableHost } from "./contract.ts";
 import { Game } from "./game.ts";
 import { Renderer } from "./render.ts";
@@ -157,6 +157,15 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
 
   const ro = typeof ResizeObserver === "function" ? new ResizeObserver(resize) : null;
   ro?.observe(el);
+
+  // A ResizeObserver is not enough on its own. The host's real insets arrive
+  // over the settings channel AFTER the first layout, and iPadOS changes them
+  // in Split View without the element's box moving at all — so the observer
+  // never fires and a game that read the safe rectangle once at mount stays
+  // laid out against the probe's zeros for ever. MERGE shipped exactly that.
+  // This pack is where the rule came from: MERGE was the one found never to
+  // subscribe at all.
+  const stopInsets = onInsetsChange(resize);
   window.addEventListener("resize", resize);
   window.addEventListener("orientationchange", resize);
 
@@ -230,6 +239,7 @@ export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { u
       cancelAnimationFrame(raf);
       input.dispose();
       ro?.disconnect();
+      stopInsets();
       window.removeEventListener("resize", resize);
       window.removeEventListener("orientationchange", resize);
       document.removeEventListener("visibilitychange", onVis);

--- a/dynawalla/games/polarity/src/ui/layout.ts
+++ b/dynawalla/games/polarity/src/ui/layout.ts
@@ -33,7 +33,7 @@
  * and the founder found it, with the score painted under an Android clock.
  *
  * So `applySafeVars` publishes the host's measurement as four more custom
- * properties and the stylesheet reads `var(--pol-safe-*, env(...))` — the
+ * properties and the stylesheet reads `var(--dw-safe-*, env(...))` — the
  * `env()` kept only as the fallback for a dev browser tab, where there is no
  * host and where it is right.
  */
@@ -42,6 +42,8 @@ import {
   HOST_CONTROL,
   HOST_MARGIN,
   HOST_PROGRESS_H,
+  SAFE_PREFIX,
+  safeVar,
   publishSafeVars,
   safeInsets,
   type Insets,
@@ -120,12 +122,24 @@ export function applyChromeVars(root: HTMLElement): void {
   root.style.setProperty("--pol-mini-right", `${MINI_RIGHT}px`);
 }
 
-/** The namespace the four published safe-area lengths live under. */
-export const SAFE_PREFIX = "--pol-safe-";
+/**
+ * The namespace the four published safe-area lengths live under.
+ *
+ * Re-exported from `packs/shared/game-chrome` rather than declared here. It
+ * used to be `--pol-safe-`, one of five per-pack spellings of the same four numbers
+ * — and five spellings is five chances to misspell one, and nothing a fleet
+ * gate can state as a rule. There is one name now and this pack does not own it.
+ */
+export { SAFE_PREFIX };
 
-/** One safe edge, as a length `styles.css` can do arithmetic with. */
-export const cssSafe = (side: "top" | "right" | "bottom" | "left"): string =>
-  `var(${SAFE_PREFIX}${side}, env(safe-area-inset-${side}, 0px))`;
+/**
+ * One safe edge, as a length `styles.css` can do arithmetic with.
+ *
+ * The shared builder, not a local copy of the same eight tokens. A hand-typed
+ * copy is a chance to leave the `var()` off, and leaving the `var()` off is
+ * the entire defect.
+ */
+export const cssSafe = safeVar;
 
 /**
  * Hand the stylesheet the safe area, from the host's own measurement.

--- a/dynawalla/games/polarity/src/ui/styles.css
+++ b/dynawalla/games/polarity/src/ui/styles.css
@@ -14,10 +14,10 @@
    a cross-origin child resolves all four to ZERO. Every rule below that once
    read `env()` directly resolved to its 10px/20px fallback on every device, and
    `layout.ts`'s numbers, which the tests assert, described a HUD that was never
-   drawn. `--pol-safe-*` is the host's real measurement, published by
+   drawn. `--dw-safe-*` is the host's real measurement, published by
    `applySafeVars`; the `env()` behind each one is the dev-browser fallback,
    where there is no host and where it happens to be right. Never read an
-   `env(safe-area-inset-*)` here except as the fallback of its `--pol-safe-*`. */
+   `env(safe-area-inset-*)` here except as the fallback of its `--dw-safe-*`. */
 .pol-root {
   --pol-chrome-top: 63px;
   --pol-mini-right: 64px;
@@ -70,10 +70,10 @@
      it and the pads stay put.
 
      Four longhands, deliberately not a shorthand. See --pol-hud-edge above. */
-  padding-top: calc(var(--pol-safe-top, env(safe-area-inset-top, 0px)) + var(--pol-chrome-top));
-  padding-right: max(var(--pol-hud-edge), var(--pol-safe-right, env(safe-area-inset-right, 0px)));
-  padding-bottom: max(var(--pol-hud-edge), var(--pol-safe-bottom, env(safe-area-inset-bottom, 0px)));
-  padding-left: max(var(--pol-hud-edge), var(--pol-safe-left, env(safe-area-inset-left, 0px)));
+  padding-top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--pol-chrome-top));
+  padding-right: max(var(--pol-hud-edge), var(--dw-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: max(var(--pol-hud-edge), var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: max(var(--pol-hud-edge), var(--dw-safe-left, env(safe-area-inset-left, 0px)));
   display: grid;
   grid-template-rows: auto 1fr auto;
 }
@@ -218,9 +218,9 @@
 
 .pol-keyhint {
   position: absolute;
-  bottom: max(var(--pol-hud-edge), var(--pol-safe-bottom, env(safe-area-inset-bottom, 0px)));
-  left: max(var(--pol-hud-edge), var(--pol-safe-left, env(safe-area-inset-left, 0px)));
-  right: max(var(--pol-hud-edge), var(--pol-safe-right, env(safe-area-inset-right, 0px)));
+  bottom: max(var(--pol-hud-edge), var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  left: max(var(--pol-hud-edge), var(--dw-safe-left, env(safe-area-inset-left, 0px)));
+  right: max(var(--pol-hud-edge), var(--dw-safe-right, env(safe-area-inset-right, 0px)));
   text-align: center;
   font-size: clamp(9px, 1.9vw, 12px);
   letter-spacing: 0.2em;
@@ -241,10 +241,10 @@
      REPOLARIZE answer orbs, which a child taps, so in landscape on a notched
      phone the outermost orb ran under the sensor housing. Its contents are
      centred, so the corners are clear by construction. */
-  padding-top: max(var(--pol-veil-pad), var(--pol-safe-top, env(safe-area-inset-top, 0px)));
-  padding-right: max(var(--pol-veil-pad), var(--pol-safe-right, env(safe-area-inset-right, 0px)));
-  padding-bottom: max(var(--pol-veil-pad), var(--pol-safe-bottom, env(safe-area-inset-bottom, 0px)));
-  padding-left: max(var(--pol-veil-pad), var(--pol-safe-left, env(safe-area-inset-left, 0px)));
+  padding-top: max(var(--pol-veil-pad), var(--dw-safe-top, env(safe-area-inset-top, 0px)));
+  padding-right: max(var(--pol-veil-pad), var(--dw-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: max(var(--pol-veil-pad), var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: max(var(--pol-veil-pad), var(--dw-safe-left, env(safe-area-inset-left, 0px)));
   text-align: center;
 }
 .pol-veil[hidden] { display: none; }
@@ -331,9 +331,9 @@
    game's chrome and the host's at every inset. */
 .pol-mini {
   position: absolute;
-  top: max(var(--pol-hud-edge), var(--pol-safe-top, env(safe-area-inset-top, 0px)));
+  top: max(var(--pol-hud-edge), var(--dw-safe-top, env(safe-area-inset-top, 0px)));
   right: calc(
-    max(var(--pol-hud-edge), var(--pol-safe-right, env(safe-area-inset-right, 0px))) +
+    max(var(--pol-hud-edge), var(--dw-safe-right, env(safe-area-inset-right, 0px))) +
       var(--pol-mini-right)
   );
   display: flex;

--- a/dynawalla/games/pulse/src/mount.ts
+++ b/dynawalla/games/pulse/src/mount.ts
@@ -19,7 +19,7 @@ import { gateFitFor } from "./render/layout.ts";
 import { Scene } from "./render/scene.ts";
 import { loadSettings, prefersReducedMotion, saveSettings } from "./settings.ts";
 
-const CSS = `
+export const CSS = `
 .pulse-root{position:relative;width:100%;height:100%;min-height:320px;background:#04050a;
 overflow:hidden;touch-action:none;user-select:none;-webkit-user-select:none;
 -webkit-tap-highlight-color:transparent;color-scheme:dark;contain:layout paint size;}

--- a/dynawalla/games/rhythm/src/index.ts
+++ b/dynawalla/games/rhythm/src/index.ts
@@ -9,65 +9,13 @@
  * jitter — 16ms, which is a third of the Perfect window.
  */
 
-import { createInstructions, onInsetsChange } from "../../../packs/shared/game-chrome/index.ts";
+import { createInstructions, installSafeArea } from "../../../packs/shared/game-chrome/index.ts";
 import type { Host, Mount } from "./contract.ts";
 import { Game, type Lane } from "./game/core.ts";
-import { GEAR_EDGE, GEAR_SIZE, GEAR_TOP, PANEL_TOP } from "./render/layout.ts";
+import { CSS } from "./ui/styles.ts";
 import { Renderer } from "./render/renderer.ts";
 import { autoTier, type Tier } from "./theme.ts";
 
-const CSS = `
-.sb-root{position:absolute;inset:0;overflow:hidden;background:#05060f;
-  font-family:"Inter","SF Pro Display","Segoe UI",system-ui,-apple-system,sans-serif;
-  color:#eaf2ff;-webkit-user-select:none;user-select:none;touch-action:none}
-.sb-canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
-.sb-overlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
-  flex-direction:column;gap:2.2vh;text-align:center;overflow:auto;
-  padding:max(4vmin,env(safe-area-inset-top)) max(4vmin,env(safe-area-inset-right))
-          max(4vmin,env(safe-area-inset-bottom)) max(4vmin,env(safe-area-inset-left));
-  background:radial-gradient(120% 90% at 50% 40%,rgba(10,16,48,.72),rgba(3,4,12,.94));
-  backdrop-filter:blur(3px)}
-.sb-title{font-size:clamp(38px,11vmin,120px);font-weight:900;letter-spacing:-.03em;margin:0;
-  background:linear-gradient(96deg,#7ee8ff 0%,#ff6fae 55%,#ffb45c 100%);
-  -webkit-background-clip:text;background-clip:text;color:transparent;line-height:.95}
-.sb-sub{font-size:clamp(12px,2.5vmin,19px);font-weight:600;letter-spacing:.16em;
-  color:rgba(190,215,255,.72);margin:0;text-transform:uppercase}
-.sb-btn{appearance:none;border:2px solid rgba(150,220,255,.85);background:rgba(10,18,44,.9);
-  color:#fff;font:800 clamp(15px,3.4vmin,24px)/1 inherit;letter-spacing:.14em;
-  padding:1.05em 2.4em;border-radius:999px;cursor:pointer;transition:transform .12s,box-shadow .12s;
-  box-shadow:0 0 0 0 rgba(120,220,255,.5)}
-.sb-btn:hover,.sb-btn:focus-visible{transform:translateY(-2px);box-shadow:0 0 34px 2px rgba(120,220,255,.4);outline:none}
-.sb-btn:active{transform:translateY(1px)}
-.sb-legend{display:flex;gap:1.4vmin;flex-wrap:wrap;justify-content:center;margin-top:1vh}
-.sb-chip{display:flex;align-items:center;gap:.6em;font-size:clamp(10px,1.9vmin,14px);font-weight:700;
-  letter-spacing:.1em;padding:.55em 1em;border-radius:10px;background:rgba(255,255,255,.05);
-  border:1px solid rgba(255,255,255,.1)}
-.sb-dot{width:1.05em;height:1.05em;flex:none}
-.sb-gear{position:absolute;
-  top:calc(max(${GEAR_EDGE}px,env(safe-area-inset-top)) + ${GEAR_TOP}px);
-  right:max(${GEAR_EDGE}px,env(safe-area-inset-right));
-  width:${GEAR_SIZE}px;height:${GEAR_SIZE}px;border-radius:12px;border:1px solid rgba(255,255,255,.16);
-  background:rgba(6,10,26,.72);color:#cfe4ff;font:800 17px/1 inherit;cursor:pointer;z-index:6}
-.sb-panel{position:absolute;
-  top:calc(max(${GEAR_EDGE}px,env(safe-area-inset-top)) + ${PANEL_TOP}px);
-  right:max(${GEAR_EDGE}px,env(safe-area-inset-right));width:min(290px,86vw);
-  max-height:calc(100% - max(${GEAR_EDGE}px,env(safe-area-inset-top)) - ${PANEL_TOP}px
-    - max(${GEAR_EDGE}px,env(safe-area-inset-bottom)));overflow-y:auto;overscroll-behavior:contain;
-  background:rgba(6,10,26,.96);border:1px solid rgba(255,255,255,.14);border-radius:16px;
-  padding:16px;display:grid;gap:14px;z-index:6;box-shadow:0 18px 60px rgba(0,0,0,.6)}
-.sb-row{display:grid;gap:7px}
-.sb-lab{font-size:11px;font-weight:800;letter-spacing:.14em;color:rgba(180,205,240,.72);text-transform:uppercase}
-.sb-seg{display:flex;gap:6px}
-.sb-seg button{flex:1;appearance:none;border:1px solid rgba(255,255,255,.16);background:rgba(255,255,255,.04);
-  color:#dceaff;font:700 12px/1 inherit;padding:9px 0;border-radius:9px;cursor:pointer;letter-spacing:.06em}
-.sb-seg button[aria-pressed=true]{background:rgba(120,220,255,.22);border-color:rgba(120,220,255,.75);color:#fff}
-.sb-panel input[type=range]{width:100%;accent-color:#7ee8ff}
-.sb-val{font:700 12px/1 inherit;color:rgba(190,215,255,.8)}
-.sb-perf{position:absolute;left:max(6px,env(safe-area-inset-left));bottom:max(6px,env(safe-area-inset-bottom));font:700 11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;
-  color:rgba(150,200,255,.75);z-index:5;pointer-events:none;white-space:pre}
-.sb-hide{display:none!important}
-@media (prefers-reduced-motion:reduce){.sb-btn{transition:none}}
-`;
 
 export const mount: Mount = (el: HTMLElement, host: Host) => {
   const root = document.createElement("div");
@@ -319,7 +267,14 @@ export const mount: Mount = (el: HTMLElement, host: Host) => {
   // Insets are not fixed: rotation swaps top/bottom with left/right, and iPadOS
   // changes them when the pack is resized in Split View. A layout read once at
   // mount is right until the first rotation and wrong after it.
-  const stopInsets = onInsetsChange(() => renderer.resize());
+  //
+  // `installSafeArea` also PUBLISHES the four insets onto `root` as
+  // `--dw-safe-*`, which is what every edge offset in `ui/styles.ts` reads. It
+  // used to read `env(safe-area-inset-*)`, which is zero in this frame, so the
+  // gear and the performance readout sat on the glass while the canvas half
+  // knew perfectly well where the safe rectangle was.
+  const safeArea = installSafeArea(root, () => renderer.resize());
+  const stopInsets = (): void => safeArea.dispose();
 
   /* ---------------- loop ---------------- */
   let raf = 0;

--- a/dynawalla/games/rhythm/src/ui/styles.ts
+++ b/dynawalla/games/rhythm/src/ui/styles.ts
@@ -1,0 +1,80 @@
+/**
+ * SPLITBEAT's stylesheet, in a module of its own.
+ *
+ * **Why it is not in `index.ts` any more.** `packs/sdk/src/safearea.test.ts`
+ * evaluates every pack's shipped CSS: it parses it, runs the cascade at ten
+ * real viewports and resolves each edge offset to a number, because a substring
+ * search on a stylesheet was true on the day SIEGE shipped its currency under
+ * an Android clock. To do that it has to IMPORT the module holding the CSS, so
+ * that `${GEAR_TOP}px` is a length rather than a template hole — and
+ * `index.ts` cannot be imported in node at all: it declares a TypeScript
+ * parameter property, which `--experimental-strip-types` refuses outright. The
+ * stylesheet was therefore the one part of this pack no test could see, which
+ * is exactly the part four packs shipped a HUD under the notch in.
+ *
+ * **`SAFE_VARS` rather than `env()`.** Every edge offset below used to read
+ * `env(safe-area-inset-*)` directly. Inside a pack frame that is the number
+ * ZERO — the frame is sandboxed `allow-scripts` with no `allow-same-origin`
+ * and `env()` belongs to the top-level browsing context — so the settings gear
+ * sat 8px from the top of the glass under an Android status bar, the panel
+ * measured its own maximum height against an inset of nothing, and the
+ * performance readout sat 6px inside a three-button navigation bar. The four
+ * numbers now arrive as `--dw-safe-*`, published by `installSafeArea` in
+ * `index.ts`.
+ */
+
+import { SAFE_VARS } from "../../../../packs/shared/game-chrome/index.ts";
+import { GEAR_EDGE, GEAR_SIZE, GEAR_TOP, PANEL_TOP } from "../render/layout.ts";
+
+export const CSS = `
+.sb-root{position:absolute;inset:0;overflow:hidden;background:#05060f;
+  font-family:"Inter","SF Pro Display","Segoe UI",system-ui,-apple-system,sans-serif;
+  color:#eaf2ff;-webkit-user-select:none;user-select:none;touch-action:none}
+.sb-canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
+.sb-overlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
+  flex-direction:column;gap:2.2vh;text-align:center;overflow:auto;
+  padding:max(4vmin,${SAFE_VARS.top}) max(4vmin,${SAFE_VARS.right})
+          max(4vmin,${SAFE_VARS.bottom}) max(4vmin,${SAFE_VARS.left});
+  background:radial-gradient(120% 90% at 50% 40%,rgba(10,16,48,.72),rgba(3,4,12,.94));
+  backdrop-filter:blur(3px)}
+.sb-title{font-size:clamp(38px,11vmin,120px);font-weight:900;letter-spacing:-.03em;margin:0;
+  background:linear-gradient(96deg,#7ee8ff 0%,#ff6fae 55%,#ffb45c 100%);
+  -webkit-background-clip:text;background-clip:text;color:transparent;line-height:.95}
+.sb-sub{font-size:clamp(12px,2.5vmin,19px);font-weight:600;letter-spacing:.16em;
+  color:rgba(190,215,255,.72);margin:0;text-transform:uppercase}
+.sb-btn{appearance:none;border:2px solid rgba(150,220,255,.85);background:rgba(10,18,44,.9);
+  color:#fff;font:800 clamp(15px,3.4vmin,24px)/1 inherit;letter-spacing:.14em;
+  padding:1.05em 2.4em;border-radius:999px;cursor:pointer;transition:transform .12s,box-shadow .12s;
+  box-shadow:0 0 0 0 rgba(120,220,255,.5)}
+.sb-btn:hover,.sb-btn:focus-visible{transform:translateY(-2px);box-shadow:0 0 34px 2px rgba(120,220,255,.4);outline:none}
+.sb-btn:active{transform:translateY(1px)}
+.sb-legend{display:flex;gap:1.4vmin;flex-wrap:wrap;justify-content:center;margin-top:1vh}
+.sb-chip{display:flex;align-items:center;gap:.6em;font-size:clamp(10px,1.9vmin,14px);font-weight:700;
+  letter-spacing:.1em;padding:.55em 1em;border-radius:10px;background:rgba(255,255,255,.05);
+  border:1px solid rgba(255,255,255,.1)}
+.sb-dot{width:1.05em;height:1.05em;flex:none}
+.sb-gear{position:absolute;
+  top:calc(max(${GEAR_EDGE}px,${SAFE_VARS.top}) + ${GEAR_TOP}px);
+  right:max(${GEAR_EDGE}px,${SAFE_VARS.right});
+  width:${GEAR_SIZE}px;height:${GEAR_SIZE}px;border-radius:12px;border:1px solid rgba(255,255,255,.16);
+  background:rgba(6,10,26,.72);color:#cfe4ff;font:800 17px/1 inherit;cursor:pointer;z-index:6}
+.sb-panel{position:absolute;
+  top:calc(max(${GEAR_EDGE}px,${SAFE_VARS.top}) + ${PANEL_TOP}px);
+  right:max(${GEAR_EDGE}px,${SAFE_VARS.right});width:min(290px,86vw);
+  max-height:calc(100% - max(${GEAR_EDGE}px,${SAFE_VARS.top}) - ${PANEL_TOP}px
+    - max(${GEAR_EDGE}px,${SAFE_VARS.bottom}));overflow-y:auto;overscroll-behavior:contain;
+  background:rgba(6,10,26,.96);border:1px solid rgba(255,255,255,.14);border-radius:16px;
+  padding:16px;display:grid;gap:14px;z-index:6;box-shadow:0 18px 60px rgba(0,0,0,.6)}
+.sb-row{display:grid;gap:7px}
+.sb-lab{font-size:11px;font-weight:800;letter-spacing:.14em;color:rgba(180,205,240,.72);text-transform:uppercase}
+.sb-seg{display:flex;gap:6px}
+.sb-seg button{flex:1;appearance:none;border:1px solid rgba(255,255,255,.16);background:rgba(255,255,255,.04);
+  color:#dceaff;font:700 12px/1 inherit;padding:9px 0;border-radius:9px;cursor:pointer;letter-spacing:.06em}
+.sb-seg button[aria-pressed=true]{background:rgba(120,220,255,.22);border-color:rgba(120,220,255,.75);color:#fff}
+.sb-panel input[type=range]{width:100%;accent-color:#7ee8ff}
+.sb-val{font:700 12px/1 inherit;color:rgba(190,215,255,.8)}
+.sb-perf{position:absolute;left:max(6px,${SAFE_VARS.left});bottom:max(6px,${SAFE_VARS.bottom});font:700 11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;
+  color:rgba(150,200,255,.75);z-index:5;pointer-events:none;white-space:pre}
+.sb-hide{display:none!important}
+@media (prefers-reduced-motion:reduce){.sb-btn{transition:none}}
+`;

--- a/dynawalla/games/runner/src/game/chrome.test.ts
+++ b/dynawalla/games/runner/src/game/chrome.test.ts
@@ -44,6 +44,7 @@ import {
   type StageEl,
 } from "./chrome.ts";
 import { HUD_CSS } from "./hud.ts";
+import { envReadDirectly } from "../../../../packs/shared/game-chrome/cssSafeArea.ts";
 import { inkVars } from "./contrast.ts";
 import { BAND, fullFrame, payoffEdge, popupEdge, readBand, type GateGeom } from "./readband.ts";
 import { INK, TRACK } from "./glyphs.ts";
@@ -287,14 +288,28 @@ test("the bottom readouts and the two buttons do not sit on each other", () => {
 /* ...and the stylesheet cannot disagree with any of it.                       */
 /* -------------------------------------------------------------------------- */
 
-test("the stylesheet never reaches for env(safe-area-inset-*)", () => {
+test("no rule takes its ANSWER from env(safe-area-inset-*)", () => {
   // The whole defect, in one assertion. `env()` belongs to the top-level
   // browsing context; a pack frame is sandboxed `allow-scripts` with no
   // `allow-same-origin`, so all four resolve to ZERO inside it, on every device,
   // for ever. The tests above were passing with insets the CSS never saw.
-  assert.ok(
-    !/env\(\s*safe-area-inset/.test(HUD_CSS),
-    "hud.ts reads env(safe-area-inset-*), which is 0 inside a pack — use the host's measured insets",
+  //
+  // This used to forbid the four characters `env(` outright. That was the right
+  // instinct and the wrong rule: the fleet now has ONE way to write a safe-area
+  // length — `var(--dw-safe-<side>, env(safe-area-inset-<side>, 0px))` — where
+  // the published property is the answer inside the app and the `env()` behind
+  // it only ever answers in a dev browser tab, which IS the top-level context
+  // and where it is right. Forbidding the string forbade the shared form too,
+  // and a pack that cannot use the shared form goes back to inventing its own.
+  //
+  // `envReadDirectly` is the shared check and it is not a substring search: it
+  // fails any occurrence that is not exactly the fallback of the published
+  // property. `packs/sdk/src/safearea.test.ts` runs the same rule over every
+  // pack in the fleet, on every pull request.
+  assert.deepEqual(
+    envReadDirectly(HUD_CSS),
+    [],
+    "hud.ts reads env(safe-area-inset-*) as an ANSWER, which is 0 inside a pack",
   );
 });
 

--- a/dynawalla/games/runner/src/game/hud.ts
+++ b/dynawalla/games/runner/src/game/hud.ts
@@ -22,7 +22,12 @@ import {
   gradientStops,
   laneFaceStops,
 } from "./contrast.ts";
-import type { Insets } from "../../../../packs/shared/game-chrome/index.ts";
+import {
+  SAFE_PREFIX,
+  SAFE_VARS,
+  publishSafeVars,
+  type Insets,
+} from "../../../../packs/shared/game-chrome/index.ts";
 
 /**
  * The safe-area insets, as CSS values.
@@ -97,8 +102,14 @@ export const HUD_CSS = `
    clear of both — the readouts move, the world behind them does not.
    Every offset comes from hudBoxes in chrome.ts. There is deliberately no
    arithmetic here to disagree with it. */
-.vt-tl { position:absolute; left:var(--vt-tl-x,10px); top:var(--vt-tl-y,63px); }
-.vt-tr { position:absolute; right:var(--vt-tr-x,10px); top:var(--vt-tr-y,63px); text-align:right; }
+/* The fallbacks measure from the SAFE edge, not from the glass.
+   hudBoxes in chrome.ts publishes the real offsets and they already pay the
+   insets — but a fallback is what stands before the first layout and after any
+   failure to run one, and 10px from the glass is 38px inside a three-button
+   navigation bar. A fallback that is only right on a phone with no notch is a
+   fallback that hides the bug it exists to survive. */
+.vt-tl { position:absolute; left:var(--vt-tl-x,calc(${SAFE_VARS.left} + 10px)); top:var(--vt-tl-y,calc(${SAFE_VARS.top} + 63px)); }
+.vt-tr { position:absolute; right:var(--vt-tr-x,calc(${SAFE_VARS.right} + 10px)); top:var(--vt-tr-y,calc(${SAFE_VARS.top} + 63px)); text-align:right; }
 /* Quiet, but never quiet enough to stop being readable. These carried an
    opacity, and an opacity composites the ink into the sky — halfway through the
    crossing from THE ABYSS to THE BLEACH the sky is a mid grey where no ink has
@@ -135,8 +146,8 @@ export const HUD_CSS = `
 /* ---- voltage ----
    The bottom offset clears Android's gesture strip as well as the reported inset: the
    strip eats the pixels and reports an inset of zero. See GESTURE_STRIP. */
-.vt-volt { position:absolute; left:var(--vt-volt-l,10px); right:var(--vt-volt-r,10px);
-  bottom:var(--vt-volt-b,36px); height:var(--vt-volt-h,9px);
+.vt-volt { position:absolute; left:var(--vt-volt-l,calc(${SAFE_VARS.left} + 10px)); right:var(--vt-volt-r,calc(${SAFE_VARS.right} + 10px));
+  bottom:var(--vt-volt-b,calc(${SAFE_VARS.bottom} + 36px)); height:var(--vt-volt-h,9px);
   border:2px solid rgba(255,255,255,0.30); display:flex; align-items:stretch; padding:2px;
   /* A bed, so the fill has a backdrop that is known rather than whatever stretch
      of deck or ocean happens to be under the bar. THE BLEACH's deck is #0b0b0d
@@ -155,7 +166,7 @@ export const HUD_CSS = `
    is only DECK_HALF metres wide), and in THE BLEACH the ocean is bone while the
    deck is near-black. One ink cannot clear both; a bed means it does not have
    to. */
-.vt-volt-label { position:absolute; left:0; bottom:calc(100% + 5px); font-size:clamp(8px,1.5vw,11px);
+.vt-volt-label { --dw-safe-exempt:"sits on .vt-volt, which is position:absolute and pays the insets itself"; position:absolute; left:0; bottom:calc(100% + 5px); font-size:clamp(8px,1.5vw,11px);
   letter-spacing:0.28em; color:var(--vt-ink-deck-dim,#eaf6ff); padding:1px 5px;
   background:rgba(${(VOLT_BED >> 16) & 255},${(VOLT_BED >> 8) & 255},${VOLT_BED & 255},${VOLT_BED_A}); }
 
@@ -240,10 +251,10 @@ export const HUD_CSS = `
   font-variant-numeric:tabular-nums; letter-spacing:0.01em;
   box-shadow:0 0 32px -6px var(--vt-accent, #6cf), inset 0 0 40px -14px var(--vt-accent, #6cf); }
 /* The lintel: the same overhead bar the gates on the causeway wear. */
-.vt-lane::before { content:""; position:absolute; left:calc(-1 * clamp(4px,0.9vw,7px));
+.vt-lane::before { --dw-safe-exempt:"the lintel of .vt-lane, which is position:relative inside .vt-lanes"; content:""; position:absolute; left:calc(-1 * clamp(4px,0.9vw,7px));
   right:calc(-1 * clamp(4px,0.9vw,7px)); top:0; height:clamp(7px,1.5vw,11px);
   background:var(--vt-accent, #6cf); box-shadow:0 0 24px var(--vt-accent, #6cf); }
-.vt-lane::after { content:""; position:absolute; left:0; right:0; bottom:0; height:2px;
+.vt-lane::after { --dw-safe-exempt:"the underline of .vt-lane, which is position:relative inside .vt-lanes"; content:""; position:absolute; left:0; right:0; bottom:0; height:2px;
   background:var(--vt-accent, #6cf); opacity:0.45; }
 .vt-lane span { position:relative; color:var(--vt-ink-lane,#eaf6ff);
   text-shadow:0 0 30px rgba(0,0,0,0.9), 0 3px 0 rgba(0,0,0,0.55); }
@@ -268,7 +279,7 @@ export const HUD_CSS = `
 /* ---- settings ----
    Stacked on the voltage readout rather than measured from the bottom edge, so
    the gap between the two cannot be closed by a change to either. */
-.vt-tools { position:absolute; right:var(--vt-tools-r,10px); bottom:var(--vt-tools-b,66px);
+.vt-tools { position:absolute; right:var(--vt-tools-r,calc(${SAFE_VARS.right} + 10px)); bottom:var(--vt-tools-b,calc(${SAFE_VARS.bottom} + 66px));
   display:flex; gap:6px; pointer-events:auto; }
 .vt-tool { width:var(--vt-tool-s,30px); height:var(--vt-tool-s,30px); border:2px solid rgba(255,255,255,0.28);
   background:rgba(2,5,14,0.55); color:inherit; font:inherit; font-size:clamp(11px,2.2vw,14px);
@@ -276,7 +287,7 @@ export const HUD_CSS = `
 .vt-tool[aria-pressed="true"] { background:currentColor; }
 .vt-tool[aria-pressed="true"] span { color:var(--vt-on-deck-ink,#04060f); }
 .vt-tool:focus-visible { outline:3px solid #fff; outline-offset:2px; }
-.vt-perf { position:absolute; left:var(--vt-perf-l,10px); bottom:var(--vt-perf-b,110px);
+.vt-perf { position:absolute; left:var(--vt-perf-l,calc(${SAFE_VARS.left} + 10px)); bottom:var(--vt-perf-b,calc(${SAFE_VARS.bottom} + 110px));
   padding:2px 5px; background:rgba(${(VOLT_BED >> 16) & 255},${(VOLT_BED >> 8) & 255},${VOLT_BED & 255},${VOLT_BED_A});
   font-size:11px; letter-spacing:0.1em; opacity:0.6; white-space:pre; display:none;
   font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-weight:400; text-transform:none; }
@@ -465,6 +476,11 @@ export function buildHud(host: HTMLElement): HudRefs {
  * those values.
  */
 export function layoutHud(refs: HudRefs, w: number, h: number, insets: Insets): void {
+  // The four shared lengths first. They are what every FALLBACK above reads,
+  // so they have to be on the element before a var() can miss and fall through
+  // to one — and they are published from the SAME insets that hudVars is about
+  // to place the boxes from, so the two can never describe different screens.
+  publishSafeVars(refs.root, SAFE_PREFIX, insets);
   const vars = hudVars(w, h, insets);
   for (const [name, value] of Object.entries(vars)) refs.root.style.setProperty(name, value);
 }

--- a/dynawalla/games/siege/src/ui/chrome.test.ts
+++ b/dynawalla/games/siege/src/ui/chrome.test.ts
@@ -147,7 +147,7 @@ test("the stylesheet honours all four edges, not only the two obvious ones", () 
   // text is present. It cannot tell you what the text evaluates to.
   //
   // So this now asserts the SHAPE of the fix — every edge is read from a
-  // `--sg-safe-*` property, which is the only channel the host's measurement can
+  // `--dw-safe-*` property, which is the only channel the host's measurement can
   // arrive on — and `safearea.test.ts` next door evaluates the stylesheet to
   // pixels at ten viewports and asserts the geometry.
   const css = read("./styles.css").replace(/\/\*[\s\S]*?\*\//g, "");
@@ -165,8 +165,8 @@ test("the stylesheet honours all four edges, not only the two obvious ones", () 
     const body = rule(selector);
     for (const edge of edges) {
       assert.ok(
-        body.includes(`var(--sg-safe-${edge},`),
-        `${selector} does not read --sg-safe-${edge} — an inset it cannot get any other way`,
+        body.includes(`var(--dw-safe-${edge},`),
+        `${selector} does not read --dw-safe-${edge} — an inset it cannot get any other way`,
       );
     }
   }

--- a/dynawalla/games/siege/src/ui/chrome.ts
+++ b/dynawalla/games/siege/src/ui/chrome.ts
@@ -17,7 +17,7 @@
  * So the numbers now arrive the only way they can: as an ARGUMENT from the
  * host, through `game-chrome`'s `safeInsets()`, published onto the root as four
  * custom properties by `applySafeVars` below. `styles.css` reads
- * `var(--sg-safe-top, env(safe-area-inset-top, 0px))` — the property inside the
+ * `var(--dw-safe-top, env(safe-area-inset-top, 0px))` — the property inside the
  * app, the `env()` only in a dev browser tab where it happens to be right.
  *
  * **The half-fix before that.** `.sg-top` honoured `--top` and `.sg-anvil`
@@ -48,11 +48,14 @@ import {
   HOST_CONTROL,
   HOST_MARGIN,
   HOST_PROGRESS_H,
-  NO_INSETS,
+  SAFE_PREFIX,
+  SIDES,
+  publishSafeVars,
   safeInsets,
   safeRect,
   type Insets,
   type Rect,
+  type StyleTarget,
 } from "../../../../packs/shared/game-chrome/index.ts";
 import { BOARD } from "../game/constants.ts";
 
@@ -140,16 +143,20 @@ export function chromeVars(): string {
   return `.sg{--sg-corner:${CORNER_CLEAR}px;--sg-bar-pad:${BAR_PAD}px;--sg-chrome-bottom:${CHROME_BOTTOM}px}`;
 }
 
-/** The four custom properties `styles.css` does its safe-area arithmetic with. */
-export const SAFE_VARS = ["--sg-safe-top", "--sg-safe-right", "--sg-safe-bottom", "--sg-safe-left"] as const;
-
-/** The narrow slice of an element this needs — so a test can drive it with a stub. */
-export type StyleTarget = { style: { setProperty(name: string, value: string): void } };
+/**
+ * The four custom properties `styles.css` does its safe-area arithmetic with.
+ *
+ * Derived from the shared prefix rather than typed out. They used to be
+ * `--sg-safe-*`, one of five per-pack spellings of the same four numbers, and
+ * five spellings is five chances to get one wrong and nothing a fleet gate can
+ * state as a rule. There is one name now and this pack does not own it.
+ */
+export const SAFE_VARS = SIDES.map((side) => `${SAFE_PREFIX}${side}`);
 
 /**
  * Hand the stylesheet the safe area, as four lengths it can do arithmetic with.
  *
- * Zeros are written EXPLICITLY rather than left unset. `var(--sg-safe-top, …)`
+ * Zeros are written EXPLICITLY rather than left unset. `var(--dw-safe-top, …)`
  * falls back to its `env()` only when the property is absent, and inside the app
  * `env()` is the wrong answer even when the true inset happens to be zero — it
  * is the wrong answer *especially* then, because it is indistinguishable from
@@ -163,27 +170,7 @@ export function applySafeVars(
   insets: Insets = safeInsets(),
   previous?: Insets | null,
 ): boolean {
-  const i = insets ?? NO_INSETS;
-  const now: Insets = {
-    top: Math.max(0, i.top),
-    right: Math.max(0, i.right),
-    bottom: Math.max(0, i.bottom),
-    left: Math.max(0, i.left),
-  };
-  if (
-    previous &&
-    previous.top === now.top &&
-    previous.right === now.right &&
-    previous.bottom === now.bottom &&
-    previous.left === now.left
-  ) {
-    return false;
-  }
-  root.style.setProperty("--sg-safe-top", `${now.top}px`);
-  root.style.setProperty("--sg-safe-right", `${now.right}px`);
-  root.style.setProperty("--sg-safe-bottom", `${now.bottom}px`);
-  root.style.setProperty("--sg-safe-left", `${now.left}px`);
-  return true;
+  return publishSafeVars(root, SAFE_PREFIX, insets, previous);
 }
 
 /** What `computeView` hands the renderer. Declared here so the fit can be tested. */

--- a/dynawalla/games/siege/src/ui/safearea.test.ts
+++ b/dynawalla/games/siege/src/ui/safearea.test.ts
@@ -22,7 +22,7 @@
  * That is not a simplification, it is the environment the game actually runs
  * in. Any rule that still reaches for `env()` for its answer resolves to its
  * fallback here and the assertion below it fails, which is exactly what should
- * happen. The only way to pass is for the number to come from `--sg-safe-*`,
+ * happen. The only way to pass is for the number to come from `--dw-safe-*`,
  * which is to say from the host.
  */
 
@@ -42,6 +42,7 @@ import {
   type Insets,
   type Rect,
 } from "../../../../packs/shared/game-chrome/index.ts";
+import { envReadDirectly } from "../../../../packs/shared/game-chrome/cssSafeArea.ts";
 import { CHROME_BOTTOM, TOP_BAR_MIN, applySafeVars, chromeVars } from "./chrome.ts";
 
 const read = (rel: string): string =>
@@ -663,17 +664,13 @@ test("the defeat card clears the safe area and the host's controls", () => {
 /* -------------------------------------------------------------------------- */
 
 test("no rule takes its answer from env() — it is zero where this game runs", () => {
-  const css = read("./styles.css").replace(/\/\*[\s\S]*?\*\//g, "");
-  const found = [...css.matchAll(/env\(safe-area-inset-(top|right|bottom|left)/g)];
-  assert.ok(found.length > 0, "the dev-harness fallbacks are gone entirely");
-  for (const m of found) {
-    const before = css.slice(Math.max(0, m.index - 32), m.index);
-    assert.ok(
-      before.endsWith(`var(--sg-safe-${m[1]}, `),
-      `env(safe-area-inset-${m[1]}) at ${m.index} is read directly, not as the fallback of ` +
-        `--sg-safe-${m[1]} — inside a pack frame that is the number zero`,
-    );
-  }
+  // The rule, from the one place that owns it. This file used to spell it out
+  // against SIEGE's own `--sg-safe-*` namespace; there is one namespace for
+  // the whole fleet now, and one implementation of the check —
+  // `packs/sdk/src/safearea.test.ts` runs this exact function over every pack.
+  const css = read("./styles.css");
+  assert.ok(/env\(safe-area-inset/.test(css), "the dev-harness fallbacks are gone entirely");
+  assert.deepEqual(envReadDirectly(css), []);
 });
 
 test("the safe area is published as four properties, zeros written out", () => {
@@ -683,15 +680,15 @@ test("the safe area is published as four properties, zeros written out", () => {
   assert.deepEqual(
     [...seen.entries()].sort(),
     [
-      ["--sg-safe-bottom", "48px"],
-      ["--sg-safe-left", "0px"],
-      ["--sg-safe-right", "0px"],
-      ["--sg-safe-top", "24px"],
+      ["--dw-safe-bottom", "48px"],
+      ["--dw-safe-left", "0px"],
+      ["--dw-safe-right", "0px"],
+      ["--dw-safe-top", "24px"],
     ],
   );
   // A zero must be WRITTEN, not left unset: an absent property falls through to
   // the `env()` fallback, which is the bug this whole file is about.
-  assert.equal(seen.get("--sg-safe-right"), "0px", "a zero inset was left for env() to answer");
+  assert.equal(seen.get("--dw-safe-right"), "0px", "a zero inset was left for env() to answer");
 });
 
 test("republishing an unchanged safe area writes nothing", () => {

--- a/dynawalla/games/siege/src/ui/styles.css
+++ b/dynawalla/games/siege/src/ui/styles.css
@@ -61,7 +61,7 @@
    opts this document into the rounded corners on every side, and in landscape
    the cutout is a SIDE inset — which is where the ember count lives.
 
-   The safe area arrives as `--sg-safe-*`, written onto `.sg` by `applySafeVars`
+   The safe area arrives as `--dw-safe-*`, written onto `.sg` by `applySafeVars`
    from the host's own measurement. The `env()` inside each `var()` is the DEV
    fallback and nothing else: a pack frame is cross-origin, so `env()` resolves
    to zero there, and reading it directly is how this bar came to be painted
@@ -73,9 +73,9 @@
   min-width: 0;
   overflow: hidden;
   padding: 8px 10px calc(8px) 10px;
-  padding-top: max(8px, var(--sg-safe-top, env(safe-area-inset-top, 0px)));
-  padding-left: calc(var(--sg-safe-left, env(safe-area-inset-left, 0px)) + var(--sg-corner, 54px));
-  padding-right: calc(var(--sg-safe-right, env(safe-area-inset-right, 0px)) + var(--sg-corner, 54px));
+  padding-top: max(8px, var(--dw-safe-top, env(safe-area-inset-top, 0px)));
+  padding-left: calc(var(--dw-safe-left, env(safe-area-inset-left, 0px)) + var(--sg-corner, 54px));
+  padding-right: calc(var(--dw-safe-right, env(safe-area-inset-right, 0px)) + var(--sg-corner, 54px));
   background: linear-gradient(#170f12, #100a0d);
   border-bottom: 1px solid var(--seam);
 }
@@ -327,9 +327,9 @@
   gap: 10px;
   align-items: center;
   padding: var(--sg-pad);
-  padding-bottom: max(var(--sg-pad), var(--sg-safe-bottom, env(safe-area-inset-bottom, 0px)));
-  padding-left: max(var(--sg-pad), var(--sg-safe-left, env(safe-area-inset-left, 0px)));
-  padding-right: max(var(--sg-pad), var(--sg-safe-right, env(safe-area-inset-right, 0px)));
+  padding-bottom: max(var(--sg-pad), var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  padding-left: max(var(--sg-pad), var(--dw-safe-left, env(safe-area-inset-left, 0px)));
+  padding-right: max(var(--sg-pad), var(--dw-safe-right, env(safe-area-inset-right, 0px)));
   background: linear-gradient(#150e11, #0d0709);
   border-top: 1px solid var(--seam);
 }
@@ -596,8 +596,8 @@
 
 .sg-banner {
   position: absolute;
-  left: var(--sg-safe-left, env(safe-area-inset-left, 0px));
-  right: var(--sg-safe-right, env(safe-area-inset-right, 0px));
+  left: var(--dw-safe-left, env(safe-area-inset-left, 0px));
+  right: var(--dw-safe-right, env(safe-area-inset-right, 0px));
   /* Below the host's controls even on a short landscape phone, where 16% of the
      height is less than a 44px button. `--sg-chrome-bottom` is the host's own
      geometry — hairline, margin, control — not a number typed in here.
@@ -650,10 +650,10 @@
   place-content: center;
   justify-items: center;
   gap: 16px;
-  padding: calc(20px + var(--sg-safe-top, env(safe-area-inset-top, 0px)))
-    calc(20px + var(--sg-safe-right, env(safe-area-inset-right, 0px)))
-    calc(20px + var(--sg-safe-bottom, env(safe-area-inset-bottom, 0px)))
-    calc(20px + var(--sg-safe-left, env(safe-area-inset-left, 0px)));
+  padding: calc(20px + var(--dw-safe-top, env(safe-area-inset-top, 0px)))
+    calc(20px + var(--dw-safe-right, env(safe-area-inset-right, 0px)))
+    calc(20px + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)))
+    calc(20px + var(--dw-safe-left, env(safe-area-inset-left, 0px)));
   background: radial-gradient(circle at 50% 46%, rgba(60, 12, 4, 0.72), rgba(6, 3, 4, 0.94));
   backdrop-filter: blur(3px);
   animation: sg-oc-in 0.24s ease-out;
@@ -724,10 +724,10 @@
   /* The top is the host's chrome plus air, not a bare 68: the defeat card is a
      child of `.sg` and its heading DOES have to clear the exit and how-to-play
      controls, which the banner does not. */
-  padding: calc(var(--sg-safe-top, env(safe-area-inset-top, 0px)) + var(--sg-chrome-bottom, 57px) + 11px)
-    calc(var(--sg-safe-right, env(safe-area-inset-right, 0px)) + 12px)
-    calc(var(--sg-safe-bottom, env(safe-area-inset-bottom, 0px)) + 12px)
-    calc(var(--sg-safe-left, env(safe-area-inset-left, 0px)) + 12px);
+  padding: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--sg-chrome-bottom, 57px) + 11px)
+    calc(var(--dw-safe-right, env(safe-area-inset-right, 0px)) + 12px)
+    calc(var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)) + 12px)
+    calc(var(--dw-safe-left, env(safe-area-inset-left, 0px)) + 12px);
   background: rgba(5, 3, 4, 0.9);
   animation: sg-oc-in 0.6s ease-out;
 }

--- a/dynawalla/games/slice/src/mount.ts
+++ b/dynawalla/games/slice/src/mount.ts
@@ -32,7 +32,7 @@
 //
 // Nothing here has a clock on it. Nothing ends. It escalates on evidence.
 
-import { createInstructions, safeRect } from "../../../packs/shared/game-chrome/index.ts"
+import { createInstructions, onInsetsChange, safeRect } from "../../../packs/shared/game-chrome/index.ts"
 import { SECOND_GRADE_FLOW, observe, seedSuccess, settle } from "../../../packs/shared/game-pacing/index.ts"
 import type { Host, Question } from "./contract.ts"
 import { Audio } from "./audio.ts"
@@ -514,6 +514,14 @@ export function mountSlice(
 
   const ro = new ResizeObserver(() => resize())
   ro.observe(root)
+
+  // A ResizeObserver is not enough on its own. The host's real insets arrive
+  // over the settings channel AFTER the first layout, and iPadOS changes them
+  // in Split View without the element's box moving at all — so the observer
+  // never fires and a game that read the safe rectangle once at mount stays
+  // laid out against the probe's zeros for ever. MERGE shipped exactly that.
+  const stopInsets = onInsetsChange(() => resize())
+
   resize()
 
   // ── colour ids for the particle field ────────────────────────────────────
@@ -2283,6 +2291,7 @@ export function mountSlice(
       guide.destroy()
       cancelAnimationFrame(raf)
       ro.disconnect()
+      stopInsets()
       canvas.removeEventListener("pointerdown", onDown)
       canvas.removeEventListener("pointermove", onMove)
       canvas.removeEventListener("pointerup", onUp)

--- a/dynawalla/games/stack/src/ui/place.ts
+++ b/dynawalla/games/stack/src/ui/place.ts
@@ -29,7 +29,7 @@
  * shipped rule put it at 13px. SIEGE shipped the identical split and the founder
  * found it on an Android phone, with the currency painted under the OS clock.
  *
- * So the CSS dialect now reads `var(--mn-safe-*, env(...))`, and the four
+ * So the CSS dialect now reads `var(--dw-safe-*, env(...))`, and the four
  * properties are published onto the HUD root from the host's own measurement by
  * `publishSafeVars`. The `env()` stays as the fallback because it is right in a
  * dev browser tab, where there is no host to publish anything.
@@ -43,6 +43,8 @@ import {
   HOST_MARGIN,
   HOST_PROGRESS_H,
   NO_INSETS,
+  SAFE_PREFIX,
+  safeVar,
   publishSafeVars,
   safeInsets,
   type Insets,
@@ -131,8 +133,15 @@ export const FLOOR_DIGITS = 3;
 
 /* ── the CSS dialect ────────────────────────────────────────────────────── */
 
-/** The namespace the four published lengths live under. */
-export const SAFE_PREFIX = "--mn-safe-";
+/**
+ * The namespace the four published safe-area lengths live under.
+ *
+ * Re-exported from `packs/shared/game-chrome` rather than declared here. It
+ * used to be `--mn-safe-`, one of five per-pack spellings of the same four numbers
+ * — and five spellings is five chances to misspell one, and nothing a fleet
+ * gate can state as a rule. There is one name now and this pack does not own it.
+ */
+export { SAFE_PREFIX };
 
 /**
  * One safe edge plus a gutter, as a length the stylesheet can use.
@@ -144,9 +153,14 @@ export const SAFE_PREFIX = "--mn-safe-";
 const safe = (side: "top" | "right" | "bottom" | "left", px: number): string =>
   `calc(${cssSafe(side)} + ${px}px)`;
 
-/** Just the safe edge, with no gutter added. */
-export const cssSafe = (side: "top" | "right" | "bottom" | "left"): string =>
-  `var(${SAFE_PREFIX}${side}, env(safe-area-inset-${side}, 0px))`;
+/**
+ * Just the safe edge, with no gutter added.
+ *
+ * The shared builder, not a local copy of the same eight tokens — a hand-typed
+ * copy is a chance to leave the `var()` off, and leaving the `var()` off is
+ * the whole defect.
+ */
+export const cssSafe = safeVar;
 
 /**
  * Hand the stylesheet the safe area, from the host's measurement.

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -27,7 +27,7 @@ import {
 import { Rings } from './fx/rings.ts'
 import { Trail } from './fx/trail.ts'
 import { Backdrop } from './render/backdrop.ts'
-import { safeRect } from '../../../packs/shared/game-chrome/index.ts'
+import { onInsetsChange, safeRect } from '../../../packs/shared/game-chrome/index.ts'
 import { revealPlan, SECOND_GRADE_FLOW } from '../../../packs/shared/game-pacing/index.ts'
 import { completedSum } from './reveal.ts'
 import {
@@ -389,6 +389,13 @@ export class TrebuchetGame {
       this.ro.observe(el)
     }
 
+    // A ResizeObserver is not enough on its own. The host's real insets arrive
+    // over the settings channel AFTER the first layout, and iPadOS changes them
+    // in Split View without the element's box moving at all — so the observer
+    // never fires and a game that read the safe rectangle once at mount stays
+    // laid out against the probe's zeros for ever. MERGE shipped exactly that.
+    this.stopInsets = onInsetsChange(() => this.resize())
+
     this.resize()
     this.startWave(1)
     this.cam.snap()
@@ -416,6 +423,9 @@ export class TrebuchetGame {
     this.questionShownAt = performance.now()
   }
 
+  /** Drops the inset subscription. A listener that outlives the frame keeps the closure alive. */
+  private stopInsets: (() => void) | null = null
+
   unmount(): void {
     this.running = false
     cancelAnimationFrame(this.raf)
@@ -427,6 +437,8 @@ export class TrebuchetGame {
     window.removeEventListener('keyup', this.onKeyUp)
     window.removeEventListener('resize', this.onResize)
     this.ro?.disconnect()
+    this.stopInsets?.()
+    this.stopInsets = null
     this.audio.dispose()
     this.canvas.remove()
   }

--- a/dynawalla/packs/README.md
+++ b/dynawalla/packs/README.md
@@ -106,6 +106,80 @@ one.
 
 ---
 
+## The safe area — one call, one name, one gate
+
+Every pack's `pack.html` declares `viewport-fit=cover`. That is not a neutral
+setting: it opts the document **into** the notch, the home indicator and the
+rounded corners. Something then has to claw those pixels back for anything a
+child must read or touch.
+
+The obvious way to do that is `env(safe-area-inset-*)`, and **it does not work
+here**. A pack runs in an iframe sandboxed `allow-scripts` with deliberately no
+`allow-same-origin`; `env()` belongs to the top-level browsing context, so a
+cross-origin child resolves all four to **zero**. Every rule that reaches for one
+silently collapses to its fallback. It is perfect in a browser tab and it ships a
+HUD under the status bar.
+
+That defect was found five times — SIEGE, MONUMENT, POLARITY, CLAIM and ABYSSAL
+BLOOM — each time by the founder, on a device, with a green suite behind it. So
+there is now exactly one mechanism and it is not optional.
+
+```ts
+import {
+  installSafeArea,
+  SAFE_VARS,
+  type SafeArea,
+} from "../../../packs/shared/game-chrome/index.ts"
+
+// At mount, once. Publishes --dw-safe-top/right/bottom/left onto `root` for the
+// stylesheet, subscribes for rotation and iPadOS Split View, and calls back with
+// the SAME numbers for the canvas — synchronously at mount and again on every
+// change.
+const safeArea = installSafeArea(root, (insets) => layout(insets))
+
+// In unmount:
+safeArea.dispose()
+```
+
+The stylesheet reads the published property, never the `env()` behind it:
+
+```css
+padding-top: max(12px, var(--dw-safe-top, env(safe-area-inset-top, 0px)));
+```
+
+In CSS-in-TS, interpolate `${SAFE_VARS.top}` rather than typing that string.
+The `env()` at the end is not a second answer — it is the answer in a dev browser
+tab opened straight at `index.html`, which **is** the top-level context and where
+`env()` is right.
+
+**Three rules, and `packs/sdk/src/safearea.test.ts` enforces all three on every
+pull request, over every pack:**
+
+1. `env(safe-area-inset-` may appear only as the fallback of `--dw-safe-<side>`.
+2. Every shipped stylesheet is parsed, cascaded at ten real viewports — including
+   the founder's 393×851 phone with its 24px status bar and 48px three-button
+   navigation bar — and every edge offset resolved to a **number**, with `env()`
+   defined as zero. It fails a value short of the inset, a `padding:` shorthand
+   in a media query that resets a longhand, and anything pinned within 64px of a
+   single edge that never pays for it. (`.ab-badge { bottom: 6px }` was that last
+   one, and it never mentioned the safe area at all, so no text search could have
+   found it.)
+3. A pack that holds CSS in a TypeScript template literal must **export** it, so
+   the gate can import the module and evaluate the same string the browser sees.
+
+The one escape hatch, for a rule that really is positioned inside a container
+that already paid:
+
+```css
+.cl-fill { --dw-safe-exempt: "inside .cl-meter, which is position:relative" }
+```
+
+A declaration rather than a comment, because a CSS parser throws comments away
+and an exemption a gate cannot see quietly becomes universal. The reason is the
+mechanism: nobody types "this sits inside the navigation bar".
+
+---
+
 ## Writing an arcade pack
 
 A game that wants questions mounts `shared/game-host`:

--- a/dynawalla/packs/sdk/src/safearea.test.ts
+++ b/dynawalla/packs/sdk/src/safearea.test.ts
@@ -1,0 +1,458 @@
+/**
+ * The safe area, for the WHOLE FLEET, on every pull request.
+ *
+ * ## Why this file exists
+ *
+ * `env(safe-area-inset-*)` resolves to ZERO inside a pack. A pack runs in an
+ * iframe sandboxed `allow-scripts` with deliberately no `allow-same-origin`;
+ * `env()` belongs to the top-level browsing context, and a cross-origin child
+ * gets nothing, so every rule that reaches for one silently collapses to its
+ * fallback. It looks perfect in a browser tab and ships a HUD under the status
+ * bar.
+ *
+ * That defect has now been found FIVE TIMES, each time by the founder, on a
+ * device, with a green test suite behind it:
+ *
+ *   * SIEGE — the stats row under the status bar and the overcharge meter 38px
+ *     into the navigation bar. Its canvas half was right, because `mount.ts`
+ *     used the host's `safeInsets()`; its CSS half asked the browser. The two
+ *     halves of one game disagreed about where the screen was.
+ *   * MONUMENT — `.mn-tools { bottom: 12 }` became 60 only after a device
+ *     report: a 40px sound button entirely inside the navigation bar. Its
+ *     geometry was owned in two dialects, numbers for the test and
+ *     `calc(env(...))` for the stylesheet, and only the tested one was right.
+ *   * POLARITY — `.pol-hud` padded all four edges with `env()` since its FIRST
+ *     COMMIT, so `hudRects` described a HUD that was never drawn.
+ *   * CLAIM — a flat `padding: 20px` on a full-screen card, and a mute button
+ *     pinned 10px from the bottom of the glass.
+ *   * ABYSSAL BLOOM — `.ab-badge { bottom: 6px }`. This one never mentioned the
+ *     safe area at all, so there was no text for anybody to search for.
+ *
+ * Each was fixed in its own pack. Nothing stopped the sixth. **That is what
+ * this file is: the thing that stops the sixth.**
+ *
+ * ## Why it is HERE
+ *
+ * `dynawalla_packs` is `^dynawalla/(games|packs)/`, and the SDK's `npm test` is
+ * the first thing that job runs. A guard that does not run on the change it
+ * guards against is not a guard. Discovery is a glob, exactly as in
+ * `fleet.test.ts` and `packs/build.mjs`: adding the thousandth pack is adding a
+ * directory, and a hand-written list here would be one more register to forget.
+ *
+ * ## What it does NOT do
+ *
+ * It does not search for text and call that proof. SIEGE's own test asserted
+ * `body.includes("env(safe-area-inset-top")` — a substring search that was TRUE
+ * on the day the currency shipped under an Android clock. The rule was in the
+ * file; the rule resolved to zero.
+ *
+ * So the stylesheet half of this file PARSES each pack's shipped CSS, runs the
+ * cascade at ten real viewports with real insets, expands `padding:` shorthands
+ * the way the box model does, and evaluates the winning declaration to a NUMBER
+ * with `env(safe-area-inset-*)` defined as zero — because that is the
+ * environment, not a simplification. See
+ * `packs/shared/game-chrome/cssSafeArea.ts`.
+ *
+ * Two of the checks below ARE text checks, and are labelled as such: whether a
+ * pack ever calls the publisher, and whether it ever subscribes. Neither can be
+ * evaluated without mounting the game, and both are the kind of omission that
+ * has no other symptom until a device shows one.
+ */
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import {
+  SAFE_PREFIX,
+  SIDES,
+  safeVar,
+} from "../../shared/game-chrome/insets.ts"
+import { auditStylesheet, SHAPES, type Violation } from "../../shared/game-chrome/cssSafeArea.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const gamesRoot = path.resolve(here, "../../../games")
+
+/* ── discovery ───────────────────────────────────────────────────────────── */
+
+type Pack = {
+  readonly name: string
+  readonly dir: string
+  /** Every file that reaches a device: sources, stylesheets, the entry document. */
+  readonly shipped: readonly string[]
+}
+
+const isTest = (file: string): boolean => /\.test\.[cm]?[jt]sx?$/.test(file)
+
+function walk(dir: string, out: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return out
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name < b.name ? -1 : 1,
+  )) {
+    if (entry.name === "node_modules" || entry.name === "dist-pack" || entry.name === "dist") {
+      continue
+    }
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walk(full, out)
+    else if (entry.isFile()) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Every pack, and every file in it that a child's device will actually load.
+ *
+ * `index.html` is the dev harness and never ships, but it is included anyway:
+ * it is where a `env()` gets written before being copied into `pack.html`, and
+ * a rule that is wrong in the harness is a rule somebody will paste.
+ *
+ * Test files are excluded, and must be — several of them contain
+ * `env(safe-area-inset-…)` inside the assertion that FORBIDS it, and a gate
+ * that fires on its own error message is a gate that gets deleted.
+ */
+function fleet(): readonly Pack[] {
+  const out: Pack[] = []
+  for (const entry of fs.readdirSync(gamesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const dir = path.join(gamesRoot, entry.name)
+    if (!fs.existsSync(path.join(dir, "pack.json"))) continue
+    const shipped = [
+      ...walk(path.join(dir, "src")).filter(
+        (f) => !isTest(f) && /\.(ts|tsx|js|mjs|css|html)$/.test(f),
+      ),
+      ...["pack.html", "index.html"].map((f) => path.join(dir, f)).filter((f) => fs.existsSync(f)),
+    ]
+    out.push({ name: entry.name, dir, shipped })
+  }
+  return out.sort((a, b) => (a.name < b.name ? -1 : 1))
+}
+
+const PACKS = fleet()
+const rel = (file: string): string => path.relative(path.resolve(gamesRoot, ".."), file)
+
+test("the glob still finds the fleet", () => {
+  // Without this, every assertion below passes on an empty list the day the
+  // games move, and this file reports green forever while the defect it exists
+  // to stop walks straight back in. `fleet.test.ts` next door carries the same
+  // guard for the same reason.
+  assert.ok(
+    PACKS.length >= 24,
+    `expected the fleet under ${gamesRoot}, found ${PACKS.length} pack.json directories`,
+  )
+  for (const pack of PACKS) {
+    assert.ok(
+      pack.shipped.length > 0,
+      `${pack.name} has pack.json but no shipped source — this walker has gone stale`,
+    )
+  }
+})
+
+/* ── 1. no rule may take its answer from env() ───────────────────────────── */
+
+/** The one form in which a pack may mention the safe area, per side. */
+const SANCTIONED = new Set(SIDES.map((side) => safeVar(side)))
+
+type Offence = { pack: string; file: string; line: number; text: string }
+
+/**
+ * Every `env(safe-area-inset-…)` in a file that is not, character for
+ * character, `var(--dw-safe-<side>, env(safe-area-inset-<side>, 0px))`.
+ *
+ * Comments are stripped first — both `/* … *\/` and `//` — because every one of
+ * these packs explains this defect in prose above the code that avoids it, and
+ * a gate that fires on the explanation teaches people to stop writing the
+ * explanation.
+ */
+function offences(pack: Pack, file: string): Offence[] {
+  const raw = fs.readFileSync(file, "utf8")
+  const stripped = raw
+    .split("\n")
+    .map((line) => line.replace(/\/\/.*$/, ""))
+    .join("\n")
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+  const out: Offence[] = []
+  for (const m of stripped.matchAll(/env\(\s*safe-area-inset-(top|right|bottom|left)[^)]*\)/g)) {
+    const side = m[1] as (typeof SIDES)[number]
+    const at = m.index
+    const whole = `var(${SAFE_PREFIX}${side}, ${m[0]})`
+    const before = stripped.slice(Math.max(0, at - `var(${SAFE_PREFIX}${side}, `.length), at)
+    const ok = before === `var(${SAFE_PREFIX}${side}, ` && SANCTIONED.has(whole)
+    if (ok) continue
+    out.push({
+      pack: pack.name,
+      file: rel(file),
+      line: stripped.slice(0, at).split("\n").length,
+      text: raw.split("\n")[stripped.slice(0, at).split("\n").length - 1]?.trim() ?? m[0],
+    })
+  }
+  return out
+}
+
+test("no pack takes its answer from env() — it is the number zero where packs run", () => {
+  const bad: Offence[] = []
+  for (const pack of PACKS) for (const file of pack.shipped) bad.push(...offences(pack, file))
+  assert.equal(
+    bad.length,
+    0,
+    `${bad.length} unsanctioned env(safe-area-inset-*) reference(s). Inside a pack frame ` +
+      `every one of them is the number ZERO.\n\n` +
+      bad.map((b) => `  ${b.pack}  ${b.file}:${b.line}\n    ${b.text}`).join("\n") +
+      `\n\nThe only permitted form is the shared one, which the host publishes into:\n` +
+      `    ${safeVar("top")}\n` +
+      `Interpolate safeVar("top") from packs/shared/game-chrome rather than typing it.`,
+  )
+})
+
+/* ── 2. the stylesheets, parsed and evaluated ────────────────────────────── */
+
+/**
+ * Pull every CSS-bearing template literal out of a TypeScript source.
+ *
+ * These packs hold their stylesheets three ways: a `.css` file (five of them),
+ * a `<style>` block in `pack.html` (all of them, for the document reset), and a
+ * tagged-nothing template literal in a `.ts` module (nearly all of them, and it
+ * is where ABYSSAL BLOOM's defect lived). The third kind is the only one a test
+ * cannot simply read off disk, because `${HUD_TOP}px` is not a length until
+ * something evaluates it.
+ *
+ * So the rule is: **CSS held in TypeScript must be EXPORTED.** One word,
+ * `export`, and the audit can import the module and see the same string the
+ * browser sees, interpolations and all. A stylesheet no gate can read is a
+ * stylesheet the gate is not checking, and four of the five defects above lived
+ * in exactly such a stylesheet.
+ */
+function cssLiterals(source: string): { name: string; exported: boolean }[] {
+  const out: { name: string; exported: boolean }[] = []
+  const decl = /(export\s+)?const\s+([A-Za-z_$][\w$]*)\s*(?::\s*[\w<>[\]| ]+\s*)?=\s*`/g
+  for (const m of source.matchAll(decl)) {
+    const open = (m.index ?? 0) + m[0].length
+    // Scan to the matching backtick, stepping over `${ … }` — which can itself
+    // contain a nested template literal, and does in several packs.
+    let i = open
+    let depth = 0
+    let end = -1
+    while (i < source.length) {
+      const ch = source[i]
+      if (ch === "\\") {
+        i += 2
+        continue
+      }
+      if (ch === "$" && source[i + 1] === "{") {
+        depth++
+        i += 2
+        continue
+      }
+      if (ch === "}" && depth > 0) {
+        depth--
+        i++
+        continue
+      }
+      if (ch === "`" && depth === 0) {
+        end = i
+        break
+      }
+      i++
+    }
+    if (end < 0) continue
+    const body = source.slice(open, end)
+    // A CSS rule: a selector at the start of a line, then a brace, then a
+    // declaration. Deliberately narrow — an SQL string or a shader also has
+    // braces, and neither is a stylesheet.
+    if (!/^[\t ]*[.#@:a-zA-Z][^\n{}]*\{[^}]*[a-z-]+\s*:/m.test(body)) continue
+    out.push({ name: m[2] as string, exported: Boolean(m[1]) })
+  }
+  return out
+}
+
+/** Every stylesheet of one pack, as text with every interpolation resolved. */
+async function stylesheetsOf(pack: Pack): Promise<{ where: string; css: string }[]> {
+  const sheets: { where: string; css: string }[] = []
+  for (const file of pack.shipped) {
+    // `index.html` is the dev harness: it is a browser tab, it is the TOP-LEVEL
+    // browsing context, and its own chrome never reaches a child. It stays in
+    // the `env()` scan above — a rule written there is a rule somebody pastes
+    // into `pack.html` — but its layout is not a promise to anybody.
+    if (path.basename(file) === "index.html") continue
+    if (file.endsWith(".css")) {
+      sheets.push({ where: rel(file), css: fs.readFileSync(file, "utf8") })
+      continue
+    }
+    if (file.endsWith(".html")) {
+      for (const m of fs.readFileSync(file, "utf8").matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)) {
+        sheets.push({ where: `${rel(file)} <style>`, css: m[1] as string })
+      }
+      continue
+    }
+    if (!/\.(ts|tsx|js|mjs)$/.test(file)) continue
+    const source = fs.readFileSync(file, "utf8")
+    const literals = cssLiterals(source)
+    if (literals.length === 0) continue
+    const hidden = literals.filter((l) => !l.exported).map((l) => l.name)
+    assert.deepEqual(
+      hidden,
+      [],
+      `${rel(file)} holds a stylesheet in ${hidden.join(", ")} without exporting it, so no ` +
+        `gate can read what it resolves to. Add \`export\` — ABYSSAL BLOOM's ` +
+        `\`.ab-badge { bottom: 6px }\` sat inside a 48px navigation bar in exactly such a ` +
+        `constant, and nothing could see it.`,
+    )
+    let module: Record<string, unknown>
+    try {
+      module = (await import(pathToFileURL(file).href)) as Record<string, unknown>
+    } catch (e) {
+      assert.fail(
+        `${rel(file)} holds a stylesheet but does not import in node: ${String(e).split("\n")[0]}\n` +
+          `Move the CSS into a module of its own that imports cleanly. A stylesheet the fleet ` +
+          `gate cannot evaluate is a stylesheet nothing is checking.`,
+      )
+    }
+    for (const { name } of literals) {
+      const value = module[name]
+      assert.equal(
+        typeof value,
+        "string",
+        `${rel(file)} exports ${name}, but it is not a string at run time`,
+      )
+      sheets.push({ where: `${rel(file)} ${name}`, css: value as string })
+    }
+  }
+  return sheets
+}
+
+const report = (where: string, violations: readonly Violation[]): string =>
+  violations.map((v) => `  ${where}\n    ${v.rule}: ${v.message}`).join("\n\n")
+
+for (const pack of PACKS) {
+  test(`${pack.name}: every shipped stylesheet clears the safe area at every shape`, async () => {
+    const sheets = await stylesheetsOf(pack)
+    assert.ok(
+      sheets.length > 0,
+      `${pack.name} ships no stylesheet this gate can read. Every pack has at least the ` +
+        `document reset in pack.html, so this means the walker has gone stale.`,
+    )
+    const found: string[] = []
+    for (const { where, css } of sheets) {
+      const violations = auditStylesheet(css, SHAPES)
+      if (violations.length > 0) found.push(report(where, violations))
+    }
+    assert.deepEqual(
+      found,
+      [],
+      `${pack.name} has ${found.length} stylesheet(s) that put chrome outside the safe ` +
+        `rectangle:\n\n${found.join("\n\n")}\n`,
+    )
+  })
+}
+
+/* ── 3. the wiring: published, and re-published ──────────────────────────── */
+
+/**
+ * Everything a pack ships, as one string, comments removed.
+ *
+ * The two assertions below are WIRING checks and nothing more: they ask whether
+ * a call appears at all. That is a weaker question than the stylesheet audit
+ * asks, and it is asked anyway because the omission it catches — never calling
+ * the publisher, or calling it once at mount and never again — has no symptom
+ * until a device shows one. MERGE never called `onInsetsChange`, so its HUD was
+ * laid out against the probe's zeros and stayed there: the host's real insets
+ * arrive AFTER the first layout, over the settings channel, and nothing asked
+ * again.
+ */
+function shippedText(pack: Pack): string {
+  return pack.shipped
+    .filter((f) => /\.(ts|tsx|js|mjs)$/.test(f))
+    .map((f) => fs.readFileSync(f, "utf8"))
+    .join("\n")
+    .split("\n")
+    .map((line) => line.replace(/\/\/.*$/, ""))
+    .join("\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+}
+
+test("every pack asks the shared module where the screen is (wiring)", () => {
+  // The failure this catches is the quietest one of all: a pack that never
+  // mentions the safe area anywhere. It has no wrong rule to find and no `env()`
+  // to flag — it simply lays out as though the glass were the screen. Every one
+  // of these games declares `viewport-fit=cover` in its `pack.html`, which opts
+  // the document INTO the notch, the home indicator and the rounded corners; a
+  // game that then never reads the insets back has taken the unsafe region on
+  // purpose and ignored it.
+  const bad: string[] = []
+  for (const pack of PACKS) {
+    const text = shippedText(pack)
+    const asks = ["installSafeArea(", "safeInsets(", "safeRect(", "SAFE_VARS"].some((call) =>
+      text.includes(call),
+    )
+    if (asks) continue
+    bad.push(
+      `${pack.name}: nothing in this pack asks where the safe rectangle is. It declares ` +
+        `viewport-fit=cover, so it has opted into the notch and the home indicator — call ` +
+        `installSafeArea(root, …) or safeRect(w, h) from packs/shared/game-chrome.`,
+    )
+  }
+  assert.deepEqual(bad, [], bad.join("\n"))
+})
+
+test("a pack whose CSS reads the safe area also publishes it (wiring)", () => {
+  const bad: string[] = []
+  for (const pack of PACKS) {
+    const text = shippedText(pack)
+    const usesVar = pack.shipped.some((f) => fs.readFileSync(f, "utf8").includes(SAFE_PREFIX))
+    if (!usesVar) continue
+    if (text.includes("installSafeArea(") || text.includes("publishSafeVars(")) continue
+    bad.push(
+      `${pack.name}: its stylesheet reads ${SAFE_PREFIX}* but nothing in the pack publishes ` +
+        `it. An unpublished custom property falls through to the env() behind it, which ` +
+        `inside a pack frame is the number zero — indistinguishable from a correct zero ` +
+        `right up until a child picks up a phone with a notch.`,
+    )
+  }
+  assert.deepEqual(bad, [], bad.join("\n"))
+})
+
+test("a pack that reads the insets also subscribes to them changing (wiring)", () => {
+  const bad: string[] = []
+  for (const pack of PACKS) {
+    const text = shippedText(pack)
+    const reads =
+      text.includes("safeInsets(") || text.includes("safeRect(") || text.includes(SAFE_PREFIX)
+    if (!reads) continue
+    if (text.includes("installSafeArea(") || text.includes("onInsetsChange(")) continue
+    bad.push(
+      `${pack.name}: it reads the safe area once and never asks again. The host's insets ` +
+        `arrive AFTER the first layout, and iPadOS changes them in Split View without ` +
+        `moving the canvas box. Call installSafeArea(root, …) — it publishes, subscribes ` +
+        `and hands the numbers to the canvas in one call — and dispose it on unmount.`,
+    )
+  }
+  assert.deepEqual(bad, [], bad.join("\n"))
+})
+
+test("the shapes include the device the defect keeps being found on", () => {
+  // A viewport matrix a pack could quietly shrink is a matrix that shrinks. The
+  // founder's phone is 1080x2340 at dpr 2.75 — 393x851 CSS px — with a 24dp
+  // status bar and a 48dp three-button navigation bar, and on Android a CSS
+  // pixel IS a dp.
+  const founder = SHAPES.find((s) => s.w === 393 && s.h === 851)
+  assert.ok(founder, "the founder's phone is no longer in SHAPES")
+  assert.deepEqual(founder?.insets, { top: 24, right: 0, bottom: 48, left: 0 })
+  assert.ok(
+    SHAPES.some((s) => s.w === 320 && s.h === 568),
+    "the smallest phone anyone still holds is no longer in SHAPES",
+  )
+  assert.ok(
+    SHAPES.some((s) => s.insets.top === 47 || s.insets.left === 47),
+    "no notched shape is left in SHAPES",
+  )
+  assert.ok(
+    SHAPES.some((s) => s.w >= 1024 && s.w > s.h) && SHAPES.some((s) => s.h > s.w && s.w >= 768),
+    "SHAPES has lost a tablet in one orientation",
+  )
+  assert.ok(
+    SHAPES.some((s) => s.w > s.h && s.insets.right > 0) &&
+      SHAPES.some((s) => s.w > s.h && s.insets.left > 0),
+    "SHAPES no longer covers a navigation bar on each side in landscape",
+  )
+})

--- a/dynawalla/packs/shared/game-chrome/cssSafeArea.test.ts
+++ b/dynawalla/packs/shared/game-chrome/cssSafeArea.test.ts
@@ -12,6 +12,9 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 
 import {
+  SHAPES,
+  auditStylesheet,
+  type Shape,
   envReadDirectly,
   evalLength,
   expandBox,
@@ -145,4 +148,165 @@ test("envReadDirectly names every env() that is not a var() fallback", () => {
   assert.match(bad[0] as string, /read directly/)
   // A comment discussing env() is not a rule.
   assert.deepEqual(envReadDirectly(`/* env(safe-area-inset-top) */ .a { top: 0 }`, "--mn-safe-"), [])
+})
+
+/* ── auditStylesheet: the fleet gate's engine ────────────────────────────── */
+
+/** One shape, so a failure names one screen and not ten. */
+const NAV: Shape = {
+  name: "the founder's phone, portrait",
+  w: 393,
+  h: 851,
+  insets: { top: 24, right: 0, bottom: 48, left: 0 },
+}
+
+const audit = (css: string): string[] =>
+  auditStylesheet(css, [NAV]).map((v) => `${v.rule}: ${v.message}`)
+
+test("a clean stylesheet audits clean", () => {
+  assert.deepEqual(
+    audit(`.hud {
+      position: absolute;
+      bottom: calc(6px + var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+      left: 50%;
+    }`),
+    [],
+  )
+})
+
+test("a bare env() is reported wherever it appears", () => {
+  const bad = audit(`.hud { position: absolute; bottom: max(6px, env(safe-area-inset-bottom)); }`)
+  // TWO reports, and both are wanted: the rule reaches for env() at all, AND the
+  // number it actually resolves to puts the element inside the navigation bar.
+  // The first says what to change; the second says what it costs a child.
+  assert.equal(bad.length, 2, bad.join(" | "))
+  assert.match(bad[0] as string, /read directly/)
+  assert.match(bad[1] as string, /resolves to 6px, inside the 48px bottom inset/)
+})
+
+test("an element hugging ONE edge without paying is reported — the ABYSSAL BLOOM defect", () => {
+  // This is the shape of the bug that had no `env()` in it to search for.
+  const bad = audit(`.badge { position: absolute; left: 50%; bottom: 6px; }`)
+  assert.equal(bad.length, 1, bad.join(" | "))
+  assert.match(bad[0] as string, /bottom: 6px resolves to 6px, inside the 48px bottom inset/)
+})
+
+test("an element pinned to BOTH ends of an axis is full-bleed and is left alone", () => {
+  // Full-bleed is the entire reason `viewport-fit=cover` is set. The water, the
+  // light shafts and the particles should run under the rounded corners.
+  assert.deepEqual(audit(`.layer { position: absolute; top: 0; bottom: 0; left: 0; right: 0; }`), [])
+})
+
+test("a centred element is not accused, because a percentage is declined not guessed", () => {
+  // `left: 50%` is centring. Calling it 0px would flag every centred element in
+  // the fleet, which is how the first version of this check produced 139 reports
+  // for one pack.
+  assert.deepEqual(audit(`.mid { position: absolute; left: 50%; top: 50%; }`), [])
+})
+
+test("a shorthand in a media query that throws the safe area away is caught", () => {
+  // MONUMENT's defect: `padding: 8px` is a SHORTHAND and resets all four
+  // longhands, including the three declared above it.
+  const css = `
+    .tools {
+      padding-bottom: max(12px, var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)));
+      padding-left: max(12px, var(--dw-safe-left, env(safe-area-inset-left, 0px)));
+    }
+    @media (max-width: 420px) { .tools { padding: 8px; } }`
+  const bad = audit(css)
+  assert.ok(bad.length >= 1, "the shorthand reset was not noticed")
+  assert.match(bad.join("\n"), /padding-bottom resolves to 8px .* the bottom inset there is 48px/)
+  // …and the same stylesheet WITHOUT the media query is clean, so the report is
+  // about the reset and not about the rule above it.
+  assert.deepEqual(audit(css.slice(0, css.indexOf("@media"))), [])
+})
+
+test("a full-bleed box whose padding starts the text inside the inset is caught", () => {
+  // CLAIM's `.cl-card`: `inset: 0` with a flat `padding: 20px`, so the words
+  // start 20px in — under a 24px status bar.
+  const bad = audit(`.card { position: fixed; top: 0; right: 0; bottom: 0; left: 0; padding: 20px; }`)
+  assert.match(bad.join("\n"), /contents start 20px in — inside the 24px top inset/)
+  assert.match(bad.join("\n"), /contents start 20px in — inside the 48px bottom inset/)
+})
+
+test("an exemption silences a rule, and an empty one does not", () => {
+  assert.deepEqual(
+    audit(`.badge { --dw-safe-exempt: "inside .card, which is position:relative"; position: absolute; bottom: 6px; }`),
+    [],
+  )
+  for (const excuse of ['""', '"ok"', '"fine"', '"n/a"', '"see above"']) {
+    // An empty reason and a two-letter one are the same evasion. The reason IS
+    // the mechanism — nobody types "this sits inside the navigation bar" — so a
+    // token that could not possibly be an argument does not buy the exemption.
+    const bad = audit(`.badge { --dw-safe-exempt: ${excuse}; position: absolute; bottom: 6px; }`)
+    assert.equal(bad.length, 1, `${excuse} bought an exemption: ${bad.join(" | ")}`)
+    assert.match(bad[0] as string, /reason is empty or too short/)
+  }
+})
+
+test("a custom property the GAME publishes is a lower bound, not an error", () => {
+  // HORDE publishes `--hz-chrome-top` from JavaScript. The audit cannot know it,
+  // and treating it as zero is the LOWER BOUND of a length: a rule that clears
+  // the inset with the term at zero clears it whatever the term turns out to be.
+  assert.deepEqual(
+    audit(`.top { position: absolute; left: 0; right: 0;
+      top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + var(--hz-chrome-top)); }`),
+    [],
+  )
+  // …and the lower bound still catches a rule that is short.
+  const bad = audit(`.top { position: absolute; left: 0; right: 0;
+    top: calc(4px + var(--hz-chrome-top) + 0 * var(--dw-safe-top, env(safe-area-inset-top, 0px))); }`)
+  assert.match(bad.join("\n"), /the top inset there is 24px/)
+})
+
+test("a font-relative length is a lower bound too, so a correct rule is not accused", () => {
+  // MONUMENT's `.mn-combo` is `calc(max(18%, …) + 2.9em)`, and the first version
+  // of the tokeniser read `2.9em` as `2.9` followed by an identifier and threw.
+  assert.deepEqual(
+    audit(`.combo { position: absolute; left: 0; right: 0;
+      top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + 2.9em); }`),
+    [],
+  )
+})
+
+test("a rule that SUBTRACTS the safe area is not read as a promise to exceed it", () => {
+  // SPLITBEAT caps its settings panel with
+  // `max-height: calc(100% - safe-top - 113px - safe-bottom)`. That is correct,
+  // and an earlier version of this check reported the resulting HEIGHT as an
+  // inset violation — a gate that cries wolf about a correct rule is a gate
+  // somebody switches off.
+  assert.deepEqual(
+    audit(`.panel { position: absolute; right: 8px;
+      top: calc(var(--dw-safe-top, env(safe-area-inset-top, 0px)) + 40px);
+      max-height: calc(100% - var(--dw-safe-top, env(safe-area-inset-top, 0px))
+        - 113px - var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px))); }`),
+    [],
+  )
+})
+
+test("one wrong declaration is reported ONCE, by the shape that proves it", () => {
+  const many = auditStylesheet(`.badge { position: absolute; left: 50%; bottom: 6px; }`, SHAPES)
+  assert.equal(
+    many.length,
+    1,
+    `ten shapes produced ${many.length} copies of one defect: ${many.map((v) => v.message).join(" | ")}`,
+  )
+  assert.match(many[0]?.message ?? "", /founder's phone/)
+})
+
+test("a static-only rule with no position is not the safe area's business", () => {
+  assert.deepEqual(audit(`.row { padding: 2px 7px; margin-top: 3px; }`), [])
+})
+
+test("the media parser understands the queries this fleet actually writes", () => {
+  // HORDE's tall-screen breakpoint is `(max-aspect-ratio: 4/5)`, and
+  // Number.parseFloat("4/5") is 4 — so a ratio has to be handled before the
+  // length path, not after it.
+  const css = `.a { top: 0px } @media (max-aspect-ratio: 4/5) { .a { top: 9px } }`
+  const rules = parseCss(css)
+  assert.equal(lengthOf(rules, ".a", "top", { w: 393, h: 851 }, new Map()), 9)
+  assert.equal(lengthOf(rules, ".a", "top", { w: 851, h: 393 }, new Map()), 0)
+  const orient = parseCss(`.b { left: 1px } @media (orientation: landscape) { .b { left: 2px } }`)
+  assert.equal(lengthOf(orient, ".b", "left", { w: 851, h: 393 }, new Map()), 2)
+  assert.equal(lengthOf(orient, ".b", "left", { w: 393, h: 851 }, new Map()), 1)
 })

--- a/dynawalla/packs/shared/game-chrome/cssSafeArea.ts
+++ b/dynawalla/packs/shared/game-chrome/cssSafeArea.ts
@@ -23,21 +23,39 @@
  * way to pass is for the number to arrive as a custom property, which is to say
  * from the host.
  *
- * **It is deliberately not exported from `index.ts`.** Nothing that ships
- * imports it; three packs' `safearea.test.ts` files do. It lives here rather
- * than three times over because a fourth copy of a CSS parser is a fourth
- * chance to get the cascade wrong, and `cssSafeArea.test.ts` next door holds
- * this one to the behaviours the packs rely on.
+ * **It is deliberately not exported from `index.ts`.** Nothing that SHIPS
+ * imports it. `packs/sdk/src/safearea.test.ts` — the fleet gate, which runs on
+ * every pull request that touches `dynawalla/games/` or `dynawalla/packs/` —
+ * imports `auditStylesheet` and runs it over every pack's stylesheets, and four
+ * packs' own `safearea.test.ts` files import the pieces. It lives here rather
+ * than five times over because a fifth copy of a CSS parser is a fifth chance
+ * to get the cascade wrong, and `cssSafeArea.test.ts` next door holds this one
+ * to the behaviours the packs rely on.
+ *
+ * `auditStylesheet` has been cross-checked against real headless Chromium:
+ * 2350 probes over every stylesheet in the fleet × ten viewports × eight
+ * geometric properties, compared against `getComputedStyle` in a document that
+ * publishes the four properties exactly as `installSafeArea` does. Zero
+ * disagreements. A deliberately wrong comparison in the same harness reports
+ * all 2350, so the agreement is a measurement and not an empty loop.
  *
  * **The subset of CSS it knows**, which is all any of these stylesheets uses:
- * comments, one level of `@media` with `min/max-width` and `min/max-height`,
- * `@keyframes` skipped whole, `var()` with fallbacks, `calc()`, `min()`,
- * `max()`, `clamp()`, `px`/`%`/`vw`/`vh`/`vmin`/`vmax`, and box shorthand
+ * comments, one level of `@media` with `min/max-width`, `min/max-height`,
+ * `min/max-aspect-ratio` and `orientation`, `@keyframes` skipped whole,
+ * `var()` with fallbacks, `calc()`, `min()`, `max()`, `clamp()`, and the
+ * units `px`/`%`/`vw`/`vh`/`vmin`/`vmax`/`em`/`rem`, plus box shorthand
  * expansion. Anything else throws rather than guessing — a parser that silently
  * shrugs is how the first version of this shipped.
+ *
+ * Two things it cannot resolve on its own: a percentage, which needs a
+ * containing block, and `em`/`rem`, which need a font. Neither is guessed.
+ * Percentages are declined outright; `em` and an unpublished custom property
+ * take the LOWER BOUND of zero, and only under `EvalCtx.unknown: "zero"`, where
+ * the question being asked is "is this at least the inset?" and a lower bound
+ * is a sound answer to it.
  */
 
-import type { Insets } from "./insets.ts"
+import { SAFE_PREFIX, SIDES, type Insets, type SideName } from "./insets.ts"
 
 /* ── the shapes every pack is held to ────────────────────────────────────── */
 
@@ -219,6 +237,24 @@ export function mediaMatches(query: string, vp: Viewport): boolean {
       const feature = m[1] as string
       const raw = m[2] as string
       if (feature === "prefers-reduced-motion") return false
+      if (feature === "orientation") {
+        if (raw.trim() === "landscape") return vp.w >= vp.h
+        if (raw.trim() === "portrait") return vp.w < vp.h
+        return fail(`this parser does not understand the orientation "${raw}"`)
+      }
+      // `(max-aspect-ratio: 4/5)` — HORDE's tall-screen breakpoint. A ratio is
+      // two integers, not a length, and Number.parseFloat("4/5") is 4, so this
+      // has to be handled before the length path below rather than after it.
+      if (feature === "max-aspect-ratio" || feature === "min-aspect-ratio") {
+        const parts = raw.split("/").map((s) => Number.parseFloat(s.trim()))
+        const num = parts[0]
+        const den = parts.length > 1 ? parts[1] : 1
+        if (!Number.isFinite(num) || !Number.isFinite(den as number) || den === 0) {
+          return fail(`this parser does not understand the aspect ratio "${raw}"`)
+        }
+        const ratio = (num as number) / (den as number)
+        return feature === "max-aspect-ratio" ? vp.w / vp.h <= ratio : vp.w / vp.h >= ratio
+      }
       const n = Number.parseFloat(raw)
       if (!Number.isFinite(n)) return fail(`non-length media value "${raw}"`)
       if (feature === "max-width") return vp.w <= n
@@ -271,7 +307,7 @@ export function expandBox(value: string): Record<Side, string> {
  * half of the bug this module exists for: `padding: 8px` in a landscape media
  * query threw away three safe-area longhands and nothing failed.
  */
-export function cascade(rules: Rule[], selector: string, vp: Viewport): Map<string, string> {
+export function cascade(rules: readonly Rule[], selector: string, vp: Viewport): Map<string, string> {
   const won = new Map<string, string>()
   for (const rule of rules) {
     if (!rule.selectors.includes(selector)) continue
@@ -296,6 +332,25 @@ export type EvalCtx = {
   vp: Viewport
   /** What a `%` is a percentage OF. Give 0 when the containing box is unknown. */
   pct: number
+  /**
+   * What to do with a custom property that is neither in `vars` nor given a
+   * `var()` fallback — HORDE's `--hz-chrome-top`, say, which the game publishes
+   * from JavaScript at mount with a number this module cannot know.
+   *
+   * `"throw"` (the default) is right for a test that names the properties it
+   * expects: an unset one is then a hole in the test rather than a silent zero.
+   *
+   * `"zero"` is right for the fleet audit's central question, which is *"is
+   * this at least the inset?"*. Zero is the LOWER BOUND of any non-negative
+   * length, so a declaration that clears the inset with every unknown at zero
+   * clears it whatever those unknowns really are. The audit can then hold
+   * `top: calc(var(--dw-safe-top) + var(--hz-chrome-top))` to the top inset
+   * without pretending to know what the second term is. The one place it must
+   * NOT be used is deciding whether a rule hugs an edge — there, zero is the
+   * answer that invents a defect rather than the answer that refuses to claim
+   * one, so that path keeps `"throw"` and skips what it cannot reduce.
+   */
+  unknown?: "throw" | "zero"
 }
 
 /** Index of the `)` matching the `(` that starts at `open`. */
@@ -335,9 +390,15 @@ export function substituteVars(value: string, ctx: EvalCtx): string {
     const comma = splitTop(s.slice(at + 4, close), ",")
     const name = (comma[0] ?? "").trim()
     const fallback = comma.slice(1).join(",").trim()
-    const got = ctx.vars.get(name)
+    let got = ctx.vars.get(name)
     if (got === undefined && fallback === "") {
-      fail(`${name} is neither published nor given a fallback in "${value}"`)
+      if (ctx.unknown !== "zero") {
+        fail(`${name} is neither published nor given a fallback in "${value}"`)
+      }
+      // The lower bound of a length the game publishes from JavaScript. See
+      // `EvalCtx.unknown` — a declaration that clears the inset with this term
+      // at zero clears it whatever the term turns out to be.
+      got = "0px"
     }
     s = s.slice(0, at) + (got ?? fallback) + s.slice(close + 1)
   }
@@ -359,7 +420,10 @@ function tokenize(s: string): string[] {
       i++
       continue
     }
-    const m = /^[a-zA-Z-]+|^[0-9.]+(px|%|vw|vh|vmin|vmax)?/.exec(s.slice(i))
+    // The NUMBER alternative comes first: `2.9em` must tokenise as one number
+    // with a unit, not as `2.9` followed by the identifier `em`, which is how
+    // MONUMENT's `.mn-combo` produced "expected ) in …" instead of an answer.
+    const m = /^[0-9.]+(px|%|vw|vh|vmin|vmax|rem|em)?|^[a-zA-Z-]+/.exec(s.slice(i))
     if (!m) return fail(`cannot tokenise "${s}" at ${i}`)
     out.push(m[0])
     i += m[0].length
@@ -420,6 +484,17 @@ export function evalLength(raw: string, ctx: EvalCtx): number {
       if (t.endsWith("vh")) return (n / 100) * ctx.vp.h
       if (t.endsWith("vmin")) return (n / 100) * Math.min(ctx.vp.w, ctx.vp.h)
       if (t.endsWith("vmax")) return (n / 100) * Math.max(ctx.vp.w, ctx.vp.h)
+      // `em` and `rem` are a font size this module cannot know, and measuring a
+      // font in node is the thing this whole approach exists to avoid. Under
+      // `unknown: "zero"` they take the same lower bound an unpublished custom
+      // property takes: a length is never negative, so a declaration that
+      // clears the inset with the em term at zero clears it at any font size.
+      // MONUMENT's `.mn-combo` is `calc(max(18%, …) + 2.9em)` and is safe on
+      // that reasoning alone.
+      if (t.endsWith("rem") || t.endsWith("em")) {
+        if (ctx.unknown === "zero") return 0
+        return fail(`this evaluator cannot resolve the font-relative length "${t}"`)
+      }
       return n
     }
     // `env()` never reaches here: `substituteVars` has already turned it into
@@ -497,7 +572,7 @@ function scopeVars(won: Map<string, string>, published: Map<string, string>): Ma
  * ancestor that declares one.
  */
 export function customPropsOf(
-  rules: Rule[],
+  rules: readonly Rule[],
   selector: string,
   vp: Viewport,
 ): Map<string, string> {
@@ -510,7 +585,7 @@ export function customPropsOf(
 
 /** One selector's resolved `padding`, as four numbers. */
 export function paddingOf(
-  rules: Rule[],
+  rules: readonly Rule[],
   selector: string,
   vp: Viewport,
   published: Map<string, string>,
@@ -529,7 +604,7 @@ export function paddingOf(
 
 /** One selector's resolved value for a single length property. */
 export function lengthOf(
-  rules: Rule[],
+  rules: readonly Rule[],
   selector: string,
   prop: string,
   vp: Viewport,
@@ -552,7 +627,7 @@ export function lengthOf(
  *
  * @param prefix e.g. `--sg-safe-` for `var(--sg-safe-top, env(safe-area-inset-top, 0px))`
  */
-export function envReadDirectly(css: string, prefix: string): string[] {
+export function envReadDirectly(css: string, prefix: string = SAFE_PREFIX): string[] {
   const stripped = css.replace(/\/\*[\s\S]*?\*\//g, "")
   const bad: string[] = []
   for (const m of stripped.matchAll(/env\(safe-area-inset-(top|right|bottom|left)/g)) {
@@ -567,4 +642,306 @@ export function envReadDirectly(css: string, prefix: string): string[] {
     }
   }
   return bad
+}
+
+/* ── the fleet audit ─────────────────────────────────────────────────────── */
+
+/**
+ * The declaration a rule uses to say "this edge offset is deliberate".
+ *
+ * A custom property rather than a comment, for one reason: comments are the
+ * first thing a CSS parser throws away, and an opt-out a gate cannot see is an
+ * opt-out that silently becomes universal. This one is a real declaration, it
+ * is inert at runtime (nothing reads it), and it CANNOT be written without
+ * typing a reason — which is the whole mechanism. `.ab-badge { bottom: 6px }`
+ * shipped ABYSSAL BLOOM's depth badge inside a 48px Android navigation bar; it
+ * would have had to be exempted with the sentence "this sits inside the
+ * navigation bar", and nobody types that.
+ *
+ * ```css
+ * .ab-toast { --dw-safe-exempt: "inside .ab-top, which pays the top inset" }
+ * ```
+ */
+export const EXEMPT_PROP = "--dw-safe-exempt"
+
+/**
+ * How close to an edge counts as "anchored to it".
+ *
+ * 64 CSS px. The largest inset in `SHAPES` is a 48px three-button navigation
+ * bar and the largest notch is 47, so anything nearer than 64 is inside, or
+ * within a finger's width of, the unsafe strip on some real device. Something
+ * pinned 200px from an edge is being centred or stacked, not hugging.
+ */
+export const EDGE_NEAR = 64
+
+/** One thing wrong with one pack's stylesheet, in a sentence a reader can act on. */
+export type Violation = {
+  /** The selector at fault, or `(stylesheet)` for something the parser saw whole. */
+  rule: string
+  /** What is wrong, in a sentence naming the declaration and the device it fails on. */
+  message: string
+  /**
+   * Identity of the DEFECT, not of this report of it.
+   *
+   * One wrong declaration is proved by nine of the ten shapes, and ten copies of
+   * one sentence is a gate nobody reads to the end. Reports sharing a key
+   * collapse to the first — which keeps the numbers of the shape that proved it,
+   * rather than flattening into a shapeless summary.
+   */
+  key: string
+}
+
+
+/** Does this value take its number from the shared custom property for `side`? */
+const paysSafeArea = (value: string, side: SideName): boolean =>
+  value.includes(`${SAFE_PREFIX}${side}`)
+
+/** Every distinct selector in a stylesheet, in first-seen order. */
+function selectorsOf(rules: readonly Rule[]): string[] {
+  const seen = new Set<string>()
+  for (const rule of rules) for (const sel of rule.selectors) seen.add(sel)
+  return [...seen]
+}
+
+/** Is this selector exempt at this viewport, and if so with what reason? */
+function exemptionFor(rules: readonly Rule[], selector: string, vp: Viewport): string | null {
+  const reason = cascade(rules, selector, vp).get(EXEMPT_PROP)
+  if (reason === undefined) return null
+  const text = reason.trim().replace(/^["']|["']$/g, "").trim()
+  return text.length >= 12 ? text : ""
+}
+
+/**
+ * Hold one stylesheet to the whole safe-area contract.
+ *
+ * Three questions, each of which has cost the fleet a device report:
+ *
+ *  1. **Does any rule take its answer from `env()`?** It is zero inside a pack
+ *     frame. SIEGE, MONUMENT and POLARITY all shipped a HUD under the status
+ *     bar this way, and POLARITY had done so since its first commit.
+ *
+ *  2. **Does a rule that pays the safe area somewhere still pay it
+ *     everywhere?** `padding: 8px` inside a landscape media query is a
+ *     SHORTHAND: it resets all four longhands and throws three safe-area
+ *     values away. That is how MONUMENT put a 40px sound button inside the
+ *     navigation bar, and it is invisible to any check that does not run the
+ *     cascade at the viewport where the media query matches.
+ *
+ *  3. **Is anything pinned to an edge without paying for it at all?** This is
+ *     the one that does not involve `env()` and so survived every previous
+ *     fix: ABYSSAL BLOOM's `.ab-badge { bottom: 6px }` never mentioned the safe
+ *     area, so there was nothing for a search to find. A rule that hugs an edge
+ *     must either read `--dw-safe-<side>` or carry `--dw-safe-exempt` with a
+ *     reason somebody was willing to write down.
+ *
+ * The evaluator resolves `env(safe-area-inset-*)` to ZERO throughout, because
+ * that is what it is where these packs run. A rule still relying on it fails
+ * here, which is the point.
+ *
+ * @param css the SHIPPED stylesheet text, interpolations already resolved.
+ * @param shapes the screens to hold it to. Defaults to the fleet's `SHAPES`.
+ */
+export function auditStylesheet(
+  css: string,
+  shapes: readonly Shape[] = SHAPES,
+): Violation[] {
+  const out: Violation[] = []
+  for (const message of envReadDirectly(css)) {
+    out.push({ rule: "(stylesheet)", message, key: message })
+  }
+
+  const rules = parseCss(css)
+  const selectors = selectorsOf(rules)
+
+  /** Published exactly as `installSafeArea` publishes it, zeros written out. */
+  const publish = (insets: Insets): Map<string, string> =>
+    new Map(SIDES.map((side) => [`${SAFE_PREFIX}${side}`, `${insets[side]}px`]))
+
+  for (const selector of selectors) {
+    // Which properties this selector pays the safe area on ANYWHERE in the
+    // stylesheet, and for which side. A side it never mentions is question 3's
+    // business; a side it mentions once is a PROMISE, and question 2 holds it to
+    // that promise at every viewport — including the ones where a media query
+    // fires and a shorthand throws three longhands away.
+    const promised = new Map<string, Set<SideName>>()
+    for (const rule of rules) {
+      if (!rule.selectors.includes(selector)) continue
+      for (const d of rule.decls) {
+        for (const side of SIDES) {
+          if (!paysSafeArea(d.value, side)) continue
+          const prop = d.prop === "padding" || d.prop === "margin" ? `${d.prop}-${side}` : d.prop
+          // Only where "at least the inset" is what the property MEANS: the four
+          // offsets and the two box longhands, and only for their own side.
+          //
+          // SPLITBEAT's settings panel is why the list is a list. It caps itself
+          // with `max-height: calc(100% - max(8px, var(--dw-safe-top)) - 113px -
+          // max(8px, var(--dw-safe-bottom)))` — a correct rule that SUBTRACTS the
+          // safe area, and the first version of this check read it as a promise
+          // and reported a HEIGHT of -185px as an inset violation. A gate that
+          // cries wolf about a correct rule is a gate somebody switches off.
+          if (prop !== side && prop !== `padding-${side}` && prop !== `margin-${side}`) continue
+          const at = promised.get(prop) ?? new Set<SideName>()
+          at.add(side)
+          promised.set(prop, at)
+        }
+      }
+    }
+
+    for (const shape of shapes) {
+      const vp: Viewport = { w: shape.w, h: shape.h }
+      const won = cascade(rules, selector, vp)
+      const vars = publish(shape.insets)
+      for (const [prop, value] of won) if (prop.startsWith("--")) vars.set(prop, value)
+      // `unknown: "zero"` — checks 2 and 3b ask "is this at least the inset?",
+      // and zero is the lower bound of any length a game publishes at run time.
+      // `pinAt` below builds its own context that THROWS instead, because there
+      // the same substitution would invent a defect rather than decline to
+      // claim one.
+      const ctx: EvalCtx = { vars, vp, pct: 0, unknown: "zero" }
+      const where = `${shape.name} (${vp.w}x${vp.h})`
+
+      const exempt = exemptionFor(rules, selector, vp)
+      if (exempt === "") {
+        out.push({
+          rule: selector,
+          key: `${selector} exempt-reason`,
+          message:
+            `${EXEMPT_PROP} is present but its reason is empty or too short to be one. ` +
+            "Write the sentence — a reason somebody was willing to write down is the whole " +
+            "mechanism.",
+        })
+      }
+
+      /* ── 2. a promise kept at every viewport ──────────────────────────── */
+      for (const [prop, sides] of promised) {
+        const raw = won.get(prop)
+        if (raw === undefined) {
+          out.push({
+            rule: selector,
+            key: `${selector} ${prop} vanished`,
+            message:
+              `${prop} pays the safe area somewhere in this stylesheet but has no value at ` +
+              `all on ${where} — a shorthand or a media query removed it.`,
+          })
+          continue
+        }
+        let got: number
+        try {
+          got = evalLength(raw, ctx)
+        } catch (e) {
+          out.push({
+            rule: selector,
+            key: `${selector} ${prop} unevaluable`,
+            message: `${prop}: "${raw}" could not be evaluated on ${where}: ${String(e)}`,
+          })
+          continue
+        }
+        for (const side of sides) {
+          const need = shape.insets[side]
+          if (got + 1e-9 >= need) continue
+          out.push({
+            rule: selector,
+            key: `${selector} ${prop} short of ${side}`,
+            message:
+              `${prop} resolves to ${got}px on ${where}, but the ${side} inset there is ` +
+              `${need}px. The winning declaration is "${raw}". A shorthand padding: or ` +
+              "margin: inside a media query resets all four longhands and is the usual " +
+              "cause — MONUMENT put a 40px sound button inside the navigation bar that way.",
+          })
+        }
+      }
+
+      /* ── 3. anything hugging an edge without paying for it ────────────── */
+      if (exempt !== null) continue
+      const position = won.get("position")
+      if (position !== "absolute" && position !== "fixed") continue
+
+      /**
+       * How far this rule pins `side`, or null if it does not pin it to a length.
+       *
+       * A percentage is null on purpose. `left: 50%` is centring, and this module
+       * does not model the containing block, so calling it 0px would flag every
+       * centred element in the fleet. Not asking beats guessing.
+       */
+      const pinAt = (side: SideName): number | null => {
+        const raw = won.get(side)
+        if (raw === undefined || raw === "auto" || raw === "unset" || raw === "initial") {
+          return null
+        }
+        if (raw.includes("%")) return null
+        try {
+          return evalLength(raw, { vars, vp, pct: 0, unknown: "throw" })
+        } catch {
+          return null
+        }
+      }
+
+      const flagged = new Set<SideName>()
+      for (const side of SIDES) {
+        if (shape.insets[side] === 0) continue
+        const raw = won.get(side)
+        const here = pinAt(side)
+        if (raw === undefined || here === null || here >= EDGE_NEAR) continue
+        if (paysSafeArea(raw, side)) continue
+        // A rule pinning BOTH ends of an axis is a full-bleed layer, and
+        // full-bleed is the entire reason `viewport-fit=cover` is set: the water,
+        // the light shafts and the particles SHOULD run under the rounded
+        // corners. Only a single-edge pin is hugging an edge.
+        const opposite = ({
+          top: "bottom",
+          bottom: "top",
+          left: "right",
+          right: "left",
+        } as const)[side]
+        if (pinAt(opposite) !== null) continue
+        flagged.add(side)
+        out.push({
+          rule: selector,
+          key: `${selector} ${side} unpaid`,
+          message:
+            `${side}: ${raw} resolves to ${here}px, inside the ${shape.insets[side]}px ` +
+            `${side} inset on ${where}. Read var(${SAFE_PREFIX}${side}, ` +
+            `env(safe-area-inset-${side}, 0px)) — or, if this element is not anchored to ` +
+            `the viewport edge, say why in ${EXEMPT_PROP}.`,
+        })
+      }
+
+      /* ── 3b. a box that REACHES an edge must pad past the inset ───────── */
+      // CLAIM's `.cl-card` is `inset: 0` with a flat `padding: 20px`: the box is
+      // the whole screen, so the words start 20px in — under a 24px status bar
+      // and well inside a 48px navigation bar. Pinning both ends is fine, and 3
+      // above lets it through on purpose; what is not fine is the padding that
+      // decides where the READING starts.
+      for (const side of SIDES) {
+        if (shape.insets[side] === 0 || flagged.has(side)) continue
+        const pin = pinAt(side)
+        if (pin === null || pin >= EDGE_NEAR) continue
+        const raw = won.get(`padding-${side}`)
+        if (raw === undefined || paysSafeArea(raw, side) || raw.includes("%")) continue
+        let pad: number
+        try {
+          pad = evalLength(raw, ctx)
+        } catch {
+          continue
+        }
+        if (pin + pad + 1e-9 >= shape.insets[side]) continue
+        out.push({
+          rule: selector,
+          key: `${selector} padding-${side} unpaid`,
+          message:
+            `this box reaches to ${pin}px of the ${side} edge and pads ${pad}px past it, so ` +
+            `its contents start ${pin + pad}px in — inside the ${shape.insets[side]}px ` +
+            `${side} inset on ${where}. padding-${side} is "${raw}"; it must read ` +
+            `var(${SAFE_PREFIX}${side}, env(safe-area-inset-${side}, 0px)).`,
+        })
+      }
+    }
+  }
+
+  const seen = new Set<string>()
+  return out.filter((v) => {
+    if (seen.has(v.key)) return false
+    seen.add(v.key)
+    return true
+  })
 }

--- a/dynawalla/packs/shared/game-chrome/index.ts
+++ b/dynawalla/packs/shared/game-chrome/index.ts
@@ -14,8 +14,15 @@ export {
   onInsetsChange,
   safeRect,
   publishSafeVars,
+  installSafeArea,
+  safeVar,
+  SAFE_PREFIX,
+  SAFE_VARS,
+  SIDES,
   NO_INSETS,
   type Insets,
+  type SafeArea,
+  type SideName,
   type StyleTarget,
 } from "./insets.ts"
 export {

--- a/dynawalla/packs/shared/game-chrome/insets.test.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.test.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict"
 import { test } from "node:test"
 
 import {
+  SAFE_PREFIX,
+  SIDES,
+  installSafeArea,
+  onInsetsChange,
+  safeVar,
   NO_INSETS,
   publishSafeVars,
   safeInsets,
@@ -187,4 +192,208 @@ test("republishing an unchanged safe area writes nothing; a rotation writes", ()
   assert.equal(s.writes, 4)
   assert.equal(publishSafeVars(s.el, "--x-", { ...i, top: 47 }, i), true, "a rotation was not published")
   assert.equal(s.writes, 8)
+})
+
+/* ── installSafeArea: the one call every pack makes ──────────────────────── */
+
+/**
+ * A stand-in for `globalThis` that records its listeners, so a test can fire a
+ * rotation without a browser. `onInsetsChange` attaches to `globalThis`, so
+ * this swaps it for the duration and puts it back.
+ */
+function withFakeWindow<T>(body: (fire: () => void) => T): T {
+  const listeners: (() => void)[] = []
+  const realAdd = globalThis.addEventListener
+  const realRemove = globalThis.removeEventListener
+  globalThis.addEventListener = ((_type: string, fn: () => void): void => {
+    listeners.push(fn)
+  }) as typeof globalThis.addEventListener
+  globalThis.removeEventListener = ((_type: string, fn: () => void): void => {
+    const at = listeners.indexOf(fn)
+    if (at >= 0) listeners.splice(at, 1)
+  }) as typeof globalThis.removeEventListener
+  try {
+    return body(() => {
+      for (const fn of [...listeners]) fn()
+    })
+  } finally {
+    globalThis.addEventListener = realAdd
+    globalThis.removeEventListener = realRemove
+    setHostInsets(null)
+  }
+}
+
+test("installSafeArea publishes all four immediately, zeros written out", () => {
+  const s = spy()
+  setHostInsets({ top: 24, right: 0, bottom: 48, left: 0 })
+  // Disposed BEFORE the reset. `setHostInsets` notifies now, so a live
+  // subscription would see the reset and rewrite all four back to zero — which
+  // is correct behaviour and would make this assertion measure the teardown.
+  try {
+    installSafeArea(s.el).dispose()
+  } finally {
+    setHostInsets(null)
+  }
+  assert.deepEqual(
+    [...s.seen.entries()].sort(),
+    [
+      ["--dw-safe-bottom", "48px"],
+      ["--dw-safe-left", "0px"],
+      ["--dw-safe-right", "0px"],
+      ["--dw-safe-top", "24px"],
+    ],
+    "the stylesheet was not handed the numbers the host measured",
+  )
+  // The two zeros are the whole point. Left unset, `var(--dw-safe-right, env(…))`
+  // falls through to an `env()` that is itself zero inside a pack frame — the
+  // right answer here and the wrong answer the moment the device rotates.
+  assert.equal(s.seen.get("--dw-safe-right"), "0px")
+  assert.equal(s.seen.get("--dw-safe-left"), "0px")
+})
+
+test("installSafeArea calls back synchronously, so nothing needs a second 'and lay out now'", () => {
+  const s = spy()
+  const seen: Insets[] = []
+  setHostInsets({ top: 47, right: 0, bottom: 34, left: 0 })
+  try {
+    const area = installSafeArea(s.el, (i) => seen.push(i))
+    assert.deepEqual(seen, [{ top: 47, right: 0, bottom: 34, left: 0 }])
+    assert.deepEqual(area.current(), { top: 47, right: 0, bottom: 34, left: 0 })
+    area.dispose()
+  } finally {
+    setHostInsets(null)
+  }
+})
+
+test("installSafeArea republishes when the insets change under it", () => {
+  withFakeWindow((fire) => {
+    const s = spy()
+    const seen: Insets[] = []
+    setHostInsets({ top: 24, right: 0, bottom: 48, left: 0 })
+    const area = installSafeArea(s.el, (i) => seen.push(i))
+    assert.equal(s.writes, 4)
+
+    // A rotation: the navigation bar leaves the bottom edge for the right one.
+    setHostInsets({ top: 24, right: 48, bottom: 0, left: 0 })
+    fire()
+    assert.equal(s.seen.get("--dw-safe-right"), "48px", "the rotation was never published")
+    assert.equal(s.seen.get("--dw-safe-bottom"), "0px", "the old bottom inset was left standing")
+    assert.deepEqual(area.current(), { top: 24, right: 48, bottom: 0, left: 0 })
+    assert.equal(seen.length, 2, "the canvas half was not told the screen had moved")
+
+    // Nothing moved: nothing is written, and nothing is laid out again.
+    const before = s.writes
+    fire()
+    assert.equal(s.writes, before, "an unchanged safe area was written again")
+    assert.equal(seen.length, 2, "an unchanged safe area triggered a relayout")
+
+    area.dispose()
+    setHostInsets({ top: 0, right: 0, bottom: 0, left: 0 })
+    fire()
+    assert.equal(seen.length, 2, "the subscription outlived dispose()")
+  })
+})
+
+test("the CSS and the canvas take the SAME measurement", () => {
+  // This is the defect in one assertion. SIEGE's canvas half was right because
+  // `mount.ts` used `safeInsets()`; its CSS half asked the browser and got
+  // zero, and the two halves of one game disagreed about where the screen was.
+  // There is now no way to ask twice: one call publishes and reports.
+  withFakeWindow(() => {
+    const s = spy()
+    setHostInsets({ top: 24, right: 0, bottom: 48, left: 0 })
+    let forTheCanvas: Insets = NO_INSETS
+    const area = installSafeArea(s.el, (i) => {
+      forTheCanvas = i
+    })
+    const forTheStylesheet: Insets = {
+      top: Number.parseFloat(s.seen.get("--dw-safe-top") ?? "-1"),
+      right: Number.parseFloat(s.seen.get("--dw-safe-right") ?? "-1"),
+      bottom: Number.parseFloat(s.seen.get("--dw-safe-bottom") ?? "-1"),
+      left: Number.parseFloat(s.seen.get("--dw-safe-left") ?? "-1"),
+    }
+    assert.deepEqual(forTheStylesheet, forTheCanvas)
+    assert.deepEqual(forTheCanvas, area.current())
+    area.dispose()
+  })
+})
+
+test("safeVar is the one string a stylesheet may use, and it names the property first", () => {
+  assert.equal(safeVar("top"), "var(--dw-safe-top, env(safe-area-inset-top, 0px))")
+  for (const side of SIDES) {
+    const v = safeVar(side)
+    assert.ok(
+      v.startsWith(`var(${SAFE_PREFIX}${side}, env(`),
+      `${side}: the published property must come FIRST — the env() behind it is zero inside a ` +
+        `pack frame, so a rule that reads it first reads zero`,
+    )
+    assert.ok(v.endsWith("0px))"), `${side}: the env() needs its own 0px fallback`)
+  }
+})
+
+test("the host telling us is itself a change — the path the real numbers arrive by", () => {
+  // The hole this closes. `onInsetsChange` used to listen for `resize` and
+  // `orientationchange` only, and `setHostInsets` was a plain assignment — so
+  // the ONE path by which the true insets reach a pack was the one path nothing
+  // was told about. On a device the sequence is: the pack mounts and lays out
+  // against the probe's zeros, the handshake completes, `game-host` writes the
+  // real numbers, and nothing asks again until the child happens to rotate the
+  // phone. On iPadOS a Split View resize pushes new insets without moving the
+  // pack's box at all, so a ResizeObserver never fires either.
+  //
+  // No DOM here on purpose: in node there are no window events, so if the host
+  // path did not notify, this test could not pass at all.
+  const seen: Insets[] = []
+  const stop = onInsetsChange((i) => seen.push(i))
+  try {
+    setHostInsets({ top: 24, right: 0, bottom: 48, left: 0 })
+    assert.deepEqual(seen, [{ top: 24, right: 0, bottom: 48, left: 0 }], "the handshake told nobody")
+
+    // A Split View resize: same box, different insets.
+    setHostInsets({ top: 24, right: 48, bottom: 0, left: 0 })
+    assert.equal(seen.length, 2, "a Split View change told nobody")
+
+    // The same numbers again are not a change.
+    setHostInsets({ top: 24, right: 48, bottom: 0, left: 0 })
+    assert.equal(seen.length, 2, "an unchanged push caused a relayout")
+  } finally {
+    stop()
+    setHostInsets(null)
+  }
+  // `stop()` runs before the reset in the same `finally`, so the reset is not
+  // seen — and nothing after it is either.
+  assert.equal(seen.length, 2)
+  setHostInsets({ top: 99, right: 0, bottom: 0, left: 0 })
+  assert.equal(seen.length, 2, "the subscription outlived its unsubscribe")
+  setHostInsets(null)
+})
+
+test("installSafeArea republishes when the HOST sends insets after mount", () => {
+  // The same hole, seen from the call every pack actually makes — and this is
+  // the sequence on a real device, in order.
+  const s = spy()
+  const forTheCanvas: Insets[] = []
+  const area = installSafeArea(s.el, (i) => forTheCanvas.push(i))
+  try {
+    // Mount: no host yet, and inside a pack frame the probe can only read zeros.
+    assert.deepEqual(area.current(), NO_INSETS)
+    assert.equal(s.seen.get("--dw-safe-bottom"), "0px")
+
+    // The handshake lands.
+    setHostInsets({ top: 24, right: 0, bottom: 48, left: 0 })
+    assert.equal(
+      s.seen.get("--dw-safe-bottom"),
+      "48px",
+      "the stylesheet never heard about the navigation bar",
+    )
+    assert.deepEqual(
+      forTheCanvas.at(-1),
+      { top: 24, right: 0, bottom: 48, left: 0 },
+      "the canvas never heard about the navigation bar",
+    )
+    assert.deepEqual(area.current(), { top: 24, right: 0, bottom: 48, left: 0 })
+  } finally {
+    area.dispose()
+    setHostInsets(null)
+  }
 })

--- a/dynawalla/packs/shared/game-chrome/insets.ts
+++ b/dynawalla/packs/shared/game-chrome/insets.ts
@@ -36,17 +36,43 @@ export type Insets = { top: number; right: number; bottom: number; left: number 
  * that trusted it drew its HUD under the notch believing it was safe.
  *
  * The host measures the real values and sends them on the `settings` channel;
- * `pack.ts` calls this once the host handshake completes. Until then, and in
- * the dev harness where there is no host, the probe is the best available
- * answer and costs nothing.
+ * `game-host` calls this on the handshake and again on every `settings` event.
+ * Until then, and in the dev harness where there is no host, the probe is the
+ * best available answer and costs nothing.
  */
 let hostInsets: Insets | null = null
+
+/**
+ * Everyone watching. Shared by `onInsetsChange` and `setHostInsets`.
+ *
+ * **Why `setHostInsets` has to notify.** It used to be a plain assignment, and
+ * `onInsetsChange` listened only for `resize` and `orientationchange` — so the
+ * one path the insets actually ARRIVE by was the one path nothing was told
+ * about. The sequence on a device is: the pack mounts and lays itself out
+ * against the probe's zeros, the host handshake completes, the real numbers are
+ * written here, and nothing asks again until the child happens to rotate the
+ * phone. The `settings` channel re-fires whenever the app's store changes,
+ * which on iPadOS includes a Split View resize that moves the insets without
+ * moving the pack's box at all — the exact case a ResizeObserver cannot see.
+ *
+ * A Set rather than an array: `onInsetsChange` returns an unsubscribe that has
+ * to be exact, and a game that mounts and unmounts a HUD repeatedly would
+ * otherwise leak one listener per cycle.
+ */
+const watchers = new Set<() => void>()
+
+const notify = (): void => {
+  // A copy, so a listener that unsubscribes during the walk cannot skip the
+  // one after it.
+  for (const fn of [...watchers]) fn()
+}
 
 export function setHostInsets(i: Insets | null | undefined): void {
   hostInsets =
     i && [i.top, i.right, i.bottom, i.left].every((n) => Number.isFinite(n) && n >= 0)
       ? { top: i.top, right: i.right, bottom: i.bottom, left: i.left }
       : null
+  notify()
 }
 
 export const NO_INSETS: Insets = { top: 0, right: 0, bottom: 0, left: 0 }
@@ -106,7 +132,6 @@ export function safeInsets(): Insets {
  * frame keeps the whole closure alive.
  */
 export function onInsetsChange(fn: (insets: Insets) => void): () => void {
-  if (typeof globalThis.addEventListener !== "function") return () => undefined
   let last = safeInsets()
   const check = (): void => {
     const now = safeInsets()
@@ -121,9 +146,20 @@ export function onInsetsChange(fn: (insets: Insets) => void): () => void {
     last = now
     fn(now)
   }
-  globalThis.addEventListener("resize", check)
-  globalThis.addEventListener("orientationchange", check)
+  // THREE triggers, not two. The window events cover a rotation and a window
+  // resize; `watchers` covers the host telling us, which is the only way the
+  // real numbers ever arrive inside the app and was the one this function used
+  // to miss. In node there is no `addEventListener` and the host path is the
+  // only one there is — which is also how a test drives this.
+  watchers.add(check)
+  const dom = typeof globalThis.addEventListener === "function"
+  if (dom) {
+    globalThis.addEventListener("resize", check)
+    globalThis.addEventListener("orientationchange", check)
+  }
   return () => {
+    watchers.delete(check)
+    if (!dom) return
     globalThis.removeEventListener("resize", check)
     globalThis.removeEventListener("orientationchange", check)
   }
@@ -158,6 +194,112 @@ export function safeRect(
 
 /** The narrow slice of an element `publishSafeVars` needs, so a test can stub it. */
 export type StyleTarget = { style: { setProperty(name: string, value: string): void } }
+
+/**
+ * The ONE name the safe area goes by, fleet-wide.
+ *
+ * It used to be five names. SIEGE published `--sg-safe-*`, MONUMENT
+ * `--mn-safe-*`, POLARITY `--pol-safe-*`, HORDE `--hz-safe-*`, CLAIM
+ * `--cl-safe-*` — and the four packs that had not been bitten yet published
+ * nothing at all and read `env()` directly. Five dialects meant five chances to
+ * spell one wrong, five things for a fleet gate to know about, and no way to
+ * write a rule that reads "this string, exactly, or the build fails".
+ *
+ * So there is one prefix and it is not per-pack. A pack's own namespace buys
+ * nothing here: these four properties are published on the pack's root element
+ * by shared code, read by that pack's stylesheet and by nothing else, and a
+ * collision is impossible because a pack is a whole document.
+ */
+export const SAFE_PREFIX = "--dw-safe-"
+
+export const SIDES = ["top", "right", "bottom", "left"] as const
+export type SideName = (typeof SIDES)[number]
+
+/**
+ * The only form in which a pack's CSS may mention the safe area.
+ *
+ * ```css
+ * padding-top: max(12px, var(--dw-safe-top, env(safe-area-inset-top, 0px)));
+ * ```
+ *
+ * The custom property is the answer inside the app. The `env()` behind it is
+ * the answer in a dev browser tab opened straight at `index.html`, where there
+ * is no host to publish anything and where `env()` happens to be right because
+ * the document IS the top-level browsing context. Inside the shipped app the
+ * `env()` is the number zero — a pack frame is sandboxed `allow-scripts` with
+ * no `allow-same-origin`, and `env(safe-area-inset-*)` belongs to the top-level
+ * context — so it must never be the thing a rule takes its answer from.
+ *
+ * `packs/sdk/src/safearea.test.ts` fails the build for any occurrence of
+ * `env(safe-area-inset-` in a pack that is not character-for-character this.
+ * Interpolate this function rather than typing the string: a hand-typed copy is
+ * a chance to leave the `var()` off, which is the entire defect.
+ */
+export function safeVar(side: SideName): string {
+  return `var(${SAFE_PREFIX}${side}, env(safe-area-inset-${side}, 0px))`
+}
+
+/** The four of them, for a stylesheet that wants all four sides. */
+export const SAFE_VARS: Readonly<Record<SideName, string>> = {
+  top: safeVar("top"),
+  right: safeVar("right"),
+  bottom: safeVar("bottom"),
+  left: safeVar("left"),
+}
+
+/** What `installSafeArea` hands back. */
+export type SafeArea = {
+  /** The insets as they stand right now. Never stale: the subscription updates it. */
+  current(): Insets
+  /** Drop the subscription. Call it from `unmount`. */
+  dispose(): void
+}
+
+/**
+ * The one call every pack makes, and the only one it needs.
+ *
+ * It does the three things that were being done separately, inconsistently, or
+ * not at all:
+ *
+ *   1. **Publishes** the four insets onto `root` as `--dw-safe-*`, immediately,
+ *      with zeros written out explicitly. An absent custom property falls
+ *      through to the `env()` in the `var()` fallback, and inside a pack frame
+ *      that is zero — indistinguishable from a correct zero right up until the
+ *      child picks up a phone with a notch.
+ *   2. **Subscribes**, so a rotation or an iPadOS Split View resize republishes.
+ *      Insets also arrive from the HOST after the first layout: `setHostInsets`
+ *      is called when the handshake completes, which is after mount, so a pack
+ *      that reads once at mount and never again has the probe's zeros forever.
+ *      MERGE shipped exactly that.
+ *   3. **Tells the canvas half**, through `onChange`. The defect that keeps
+ *      being found is not "the CSS is wrong" or "the canvas is wrong" — it is
+ *      the two halves of one game disagreeing about where the screen is,
+ *      because they asked different things. Here they cannot: one measurement,
+ *      published to the stylesheet and handed to the layout in the same call.
+ *
+ * `onChange` fires once synchronously with the insets at mount, so a caller
+ * never needs a separate "and also lay out now" line — forgetting that line is
+ * how a game ends up correct only after the first rotation.
+ */
+export function installSafeArea(
+  root: StyleTarget,
+  onChange?: (insets: Insets) => void,
+): SafeArea {
+  let insets = safeInsets()
+  let published: Insets | null = null
+  const apply = (next: Insets): void => {
+    insets = next
+    publishSafeVars(root, SAFE_PREFIX, next, published)
+    published = next
+    onChange?.(next)
+  }
+  apply(insets)
+  const unsubscribe = onInsetsChange(apply)
+  return {
+    current: () => ({ ...insets }),
+    dispose: unsubscribe,
+  }
+}
 
 /**
  * Hand a STYLESHEET the safe area, as four custom properties it can do


### PR DESCRIPTION
## The defect, and why it kept coming back

`env(safe-area-inset-*)` resolves to **ZERO** inside a pack. A pack runs in an iframe sandboxed `allow-scripts` with deliberately no `allow-same-origin`; `env()` belongs to the top-level browsing context, so a cross-origin child gets nothing and every rule that reaches for one silently collapses to its fallback. It looks perfect in a browser tab and it ships a HUD under the status bar.

It has been found **five times** — SIEGE (#767), MONUMENT, POLARITY and CLAIM (#773), and this week ABYSSAL BLOOM. Each time by the founder, on a device, with a green suite behind it. Each was fixed in its own pack.

Nothing stopped the next one. **That is the actual defect, and it is the half of this PR that matters.**

## One mechanism

`installSafeArea(root, onChange)` in `packs/shared/game-chrome` is now the only call a pack makes:

```ts
const safeArea = installSafeArea(root, (insets) => this.layout(insets))
// …and in unmount:
safeArea.dispose()
```

It publishes the four insets as `--dw-safe-*` for the stylesheet, subscribes so a rotation or an iPadOS Split View resize republishes, and hands the **same** numbers to the canvas. That last part is the point: every one of the five reports was two halves of one game disagreeing about where the screen was, because they asked separately. Now there is nothing to ask twice.

The five per-pack spellings — `--sg-safe-`, `--mn-safe-`, `--pol-safe-`, `--hz-safe-`, `--cl-safe-` — are gone. One name, `--dw-safe-*`, and no pack owns it. CSS interpolates `SAFE_VARS.<side>` rather than typing the string.

### A hole nobody had noticed

`setHostInsets` was a plain assignment, and `onInsetsChange` listened only for `resize` and `orientationchange` — so **the one path by which the true insets reach a pack was the one path nothing was told about**. The sequence on a device: the pack mounts and lays out against the probe's zeros, the host handshake completes, the real numbers are written, and nothing asks again until the child happens to rotate the phone. On iPadOS a Split View resize pushes new insets without moving the pack's box at all, so a `ResizeObserver` never fires either. `setHostInsets` now notifies, and `onInsetsChange` has three triggers instead of two.

## The gate

`dynawalla/packs/sdk/src/safearea.test.ts` — in the SDK, whose `npm test` is the first thing `dynawalla-packs` runs, gated on `^(dynawalla/(games|packs)/…)`. Discovery is a glob, matching `fleet.test.ts` and `packs/build.mjs`.

**It does not search for text.** SIEGE's own test asserted `body.includes("env(safe-area-inset-top")` — a substring search that was TRUE on the day the currency shipped under an Android clock. This one parses every pack's shipped stylesheet, runs the cascade at ten real viewports, expands `padding:` shorthands the way the box model does, and resolves every edge offset to a **number**, with `env()` defined as zero — because that is the environment, not a simplification.

It fails, naming the pack, the rule and the device:

1. any `env(safe-area-inset-` that is not character-for-character `var(--dw-safe-<side>, env(safe-area-inset-<side>, 0px))`;
2. a value that falls short of the inset at any shape;
3. a `padding:`/`margin:` shorthand in a media query that resets a safe-area longhand (MONUMENT's defect — invisible to anything that does not run the cascade at the viewport where the query matches);
4. anything `position: absolute|fixed` pinned within 64px of **one** edge that never pays for it — this is ABYSSAL BLOOM's defect, which contained no `env()` at all and so had no text for anyone to search for;
5. a full-bleed box whose padding starts its text inside the inset (CLAIM's `.cl-card`);
6. CSS held in a TypeScript template literal that is not `export`ed, because a stylesheet the gate cannot import is a stylesheet nothing is checking.

The one escape hatch is a declaration, not a comment — a CSS parser throws comments away, and an exemption a gate cannot see quietly becomes universal:

```css
.cl-fill { --dw-safe-exempt: "inside .cl-meter, which is position:relative" }
```

The reason must be at least twelve characters, and it is the whole mechanism: nobody types *"this sits inside the navigation bar"*.

## Every pack's actual state

I swept all 25. Reported honestly, including the ones that needed nothing.

**Broken, fixed here (10)**

| pack | what was wrong |
| --- | --- |
| **merge-idle** (ABYSSAL BLOOM) | `.ab-badge { bottom: 6px }` — the depth readout six pixels off the glass, entirely inside a 48px navigation bar. It is a child of `.ab-stage`, the flex-grow row whose bottom edge *is* the bottom of the screen. Never mentioned the safe area, so no search would have found it. |
| **arena** | Nine bare `env()`s in `hud.ts`'s stylesheet, while `hudRects()` in the same file had the arithmetic right — POLARITY's defect exactly: `layout.test.ts` asserted a HUD that was never drawn. `.arena-depth` started 63px down instead of 87; `.arena-btns` sat 12px from the bottom of the glass. |
| **rhythm** (SPLITBEAT) | Nine more bare `env()`s, in `src/index.ts` — a module that **cannot be imported under `--experimental-strip-types`** (a TS parameter property), so its stylesheet was the one part no test could see. CSS moved to `src/ui/styles.ts`. |
| **claim** | The mute button pinned `right/bottom: 10px` — a 44px control inside the navigation bar. Six `env()`s hidden inside `var(--cl-*, calc(…env()))` fallbacks that collapse to 8px/10px in the app. `.cl-fill` exempted (it is inside `position: relative` `.cl-meter`). |
| **runner** (VOLTA) | Every JS-published box had a bare-gutter CSS fallback (`10px`, `63px`) that is right only on a phone with no notch. Fallbacks now measure from the safe edge; three ancestor-relative rules exempted. |
| **siege**, **stack** (MONUMENT), **polarity**, **horde** | Already fixed for their own reports, but each carried its own prefix, its own copy of the publisher and its own copy of the "no bare env()" rule. Migrated to the shared prefix, the shared `publishSafeVars`, and the shared `envReadDirectly`. horde's `env()`s also lacked the `, 0px` fallback, so they were not the sanctioned form. |
| **pulse** | Small stylesheet; brought under the gate (`export`ed) and clean. |

**Read the insets once at mount and never again — subscription added (8):** balance, beam, colossus, counterweight, lattice, **merge** (the one the brief named), slice, trebuchet.

**Already clean, and left alone (7):** coil, forge, guilty, mosaic, serpent, skyledger, truedraw. These are canvas-only games that already take `safeRect(w, h)` and already subscribed. I changed nothing in them and am not claiming credit for them.

## Verification

**The evaluator is cross-checked against a real browser.** Headless Chromium, every stylesheet in the fleet × 10 viewports × 8 geometric properties, each compared against `getComputedStyle` in a document that publishes the four properties exactly as `installSafeArea` does:

```
11 stylesheet(s) from 11 packs
2350 probes across 10 viewports — 0 disagreement(s)
```

And the same harness with a deliberately wrong comparison (`mine + 1`) reports **2350 of 2350**, so the agreement is a measurement and not an empty loop.

**The gate is mutation-tested.** Twelve mutations, each reintroducing one real defect in a real file, then restored byte for byte:

| mutation | result |
| --- | --- |
| a bare `env()` reintroduced in a pack stylesheet | `✖ no pack takes its answer from env() — it is the number zero where packs run` |
| **the founder's ABYSSAL BLOOM defect put back verbatim** | `✖ merge-idle: every shipped stylesheet clears the safe area at every shape` |
| a `padding:` shorthand in a media query | `✖ siege: every shipped stylesheet clears the safe area at every shape` |
| a stylesheet in TypeScript that is not exported | `✖ arena: every shipped stylesheet clears the safe area at every shape` |
| a pack that stops subscribing | `✖ a pack that reads the insets also subscribes to them changing (wiring)` |
| a pack that stops publishing | `✖ a pack whose CSS reads the safe area also publishes it (wiring)` |
| an exemption with no reason | `✖ horde: every shipped stylesheet clears the safe area at every shape` |
| the founder's phone removed from the matrix | `✖ the shapes include the device the defect keeps being found on` |
| `installSafeArea` stops writing zeros | `✖ all four properties are published, with zeros written out` |
| `installSafeArea` stops subscribing | `✖ installSafeArea republishes when the insets change under it` |
| the canvas told different numbers from the CSS | `✖ installSafeArea calls back synchronously…` |
| `safeVar` puts the `env()` first | `✖ safeVar is the one string a stylesheet may use, and it names the property first` |

The ABYSSAL BLOOM one, in full:

```
merge-idle has 1 stylesheet(s) that put chrome outside the safe rectangle:

  games/merge-idle/src/ui/hud.ts CSS
    .ab-badge: bottom: 6px resolves to 6px, inside the 48px bottom inset on the
    founder's phone, portrait — status bar and three-button nav (393x851). Read
    var(--dw-safe-bottom, env(safe-area-inset-bottom, 0px)) — or, if this element
    is not anchored to the viewport edge, say why in --dw-safe-exempt.
```

**Every new assertion is mutation-tested too.** Ten more mutations against the audit engine — the full-bleed skip, the percentage decline, shorthand expansion, the exemption's reason, de-duplication, aspect-ratio media queries, the font-relative lower bound, the promise-property list, the padding check, and the unpublished-custom-property lower bound. **One of them came back "PASSED — ASSERTION IS DECORATION"**: my exemption test only covered an *empty* reason, so weakening the twelve-character floor changed nothing it could see. Fixed to cover `""`, `"ok"`, `"n/a"`, `"fine"`, `"see above"`; it now fails.

**Also run:**

- every touched pack's suite **5× consecutively** plus `tsc` — 18 packs, plus `packs/sdk`, `packs/shared/game-chrome` and `packs/shared/game-host`;
- `node packs/build.mjs` — **25 packs built, checked and staged**, SDK checker green;
- the fleet gate with **every pack's `node_modules` moved aside**, which is how CI runs it (the SDK step precedes any game's install): 31/31 pass.

## Two false positives I fixed rather than shipped

A gate that cries wolf about a correct rule is a gate somebody switches off.

- The first version reported **139 violations for CLAIM alone**, almost all of them decorative full-bleed layers and centred elements. A rule pinning *both* ends of an axis is full-bleed — which is the entire reason `viewport-fit=cover` is set — and `left: 50%` is centring, so a percentage is now declined rather than guessed at zero.
- SPLITBEAT caps its settings panel with `max-height: calc(100% - safe-top - 113px - safe-bottom)`, a correct rule that *subtracts* the safe area, and the check read it as a promise and reported a **height** of −185px as an inset violation. The promise now applies only to the four offsets and the two box longhands, and only for their own side.

Both are covered by named tests, and both tests fail if the fix is reverted.

## Docs

`dynawalla/AGENTS.md` gains the rule alongside the other "this is how you get it wrong here" entries; `dynawalla/packs/README.md` gains the full contract with the code the next pack author copies.

## Acceptance

No `ACCEPTANCE_CRITERIA.md` item covers this directly — it is a defect class and a gate, not a feature. It is worth landing because the same bug has cost five device reports and five fixes, and this is the first change that makes the sixth fail in CI instead of on a nine-year-old's phone.

**Not merging — flagging for your review.**

---
https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
